### PR TITLE
Add Railway health server and marketable pricing updates

### DIFF
--- a/README-DEPLOY.md
+++ b/README-DEPLOY.md
@@ -18,9 +18,47 @@ worker: bash manage_bot.sh run
 ```
 
 ## Health
-A lightweight Flask server, backed by Waitress by default (falling back to Flask
-only if Waitress is missing), exposes `GET /health` on port 8000 to help Railway
-detect unhealthy states and restart.
+A background `http.server` listener exposes `GET /health` on
+`0.0.0.0:$PORT` (defaults to `8080`).  Railway's health check path should be set
+to `/health` so probes continue to work without bundling Flask/Waitress.
+
+## Railway Variables
+Set these in *Railway → Variables* (raw values without quotes):
+
+- `ENABLE_LIVE_TRADING=false`
+- `KITE_API_KEY=…`
+- `KITE_API_SECRET=…`
+- `KITE_ACCESS_TOKEN=…`
+- `TELEGRAM__ENABLED=true`
+- `TELEGRAM__BOT_TOKEN=…`
+- `TELEGRAM__CHAT_ID=…`
+- `DATA__TIME_FILTER_START=09:20`
+- `DATA__TIME_FILTER_END=15:25`
+- `HISTORICAL_TIMEFRAME=minute`
+- `RISK__MAX_DAILY_DRAWDOWN_PCT=0.10`
+- `EXPOSURE_CAP_PCT=2.0`
+- `INSTRUMENTS__MIN_LOTS=1`
+- `INSTRUMENTS__MAX_LOTS=5`
+- `MAX_DATA_STALENESS_MS=30000`
+- `WATCHDOG_STALE_MS=6000`
+- `RECONNECT_DEBOUNCE_MS=20000`
+- `STALE_X_N=3`
+- `STALE_WINDOW_MS=60000`
+- `MICRO__STALE_MS=1500`
+- `ORDER_MAX_QUOTE_AGE_MS=6000`
+- `QUOTES__MODE=FULL`
+
+## Post-deploy verification
+
+After Railway deploys a build:
+
+1. Check Railway logs for `ws_resubscribe tokens=…` shortly after any reconnect
+   and confirm there are no stack traces.
+2. During market hours the decision loop should log `EVALUATE`/`decision` events;
+   outside market hours the runner should remain in the `IDLE` phase.
+3. In Telegram, run `/diag` to ensure `ws_connected=1` and the reported
+   `last_tick_age_ms` looks reasonable, then run `/subs` to confirm FULL quotes
+   are subscribed.
 
 ## Start/Stop jobs
 Use the included scripts from a Railway Cron or separate services:

--- a/src/utils/helpers.py
+++ b/src/utils/helpers.py
@@ -3,20 +3,30 @@
 from __future__ import annotations
 
 from datetime import datetime, time, timedelta
+from zoneinfo import ZoneInfo
+
+
+IST = ZoneInfo("Asia/Kolkata")
 
 
 def get_weekly_expiry(
-    now: datetime | None = None, *, use_same_day_before: str = "15:20"
+    now: datetime | None = None,
+    *,
+    cutoff: time = time(15, 20),
 ) -> str:
     """Return the upcoming weekly expiry (Thursday) formatted as ``YYMMDD``.
 
-    When today is Thursday the helper returns the same-day expiry until the
-    cut-off specified by ``use_same_day_before``.  After the cut-off the expiry
-    rolls forward to the following week to avoid stale contracts.
+    The calculation is anchored to Indian Standard Time.  When today is
+    Thursday the helper returns the same-day expiry until ``cutoff``; after the
+    cut-off it rolls to the following week's contract.
     """
 
-    current = now or datetime.now()
-    cutoff = time.fromisoformat(use_same_day_before)
+    current = now or datetime.now(tz=IST)
+    if current.tzinfo is None:
+        current = current.replace(tzinfo=IST)
+    else:
+        current = current.astimezone(IST)
+
     days_ahead = (3 - current.weekday()) % 7
     if days_ahead == 0 and current.time() > cutoff:
         days_ahead = 7
@@ -30,5 +40,5 @@ def get_next_thursday(now: datetime | None = None) -> str:
     return get_weekly_expiry(now=now)
 
 
-__all__ = ["get_weekly_expiry", "get_next_thursday"]
+__all__ = ["IST", "get_weekly_expiry", "get_next_thursday"]
 


### PR DESCRIPTION
## Summary
- replace the Flask-based Railway health probe with a lightweight http.server thread that respects the PORT variable
- document the Railway environment variables and verification steps required after deploy
- tighten fill pricing by snapping to the tick grid, adjusting sell orders, and updating weekly expiry handling/tests for IST

## Testing
- ./run_checks.sh

------
https://chatgpt.com/codex/tasks/task_e_68d64ac82d408324967013ecb52b45c5