### PR TITLE
Improve Railway quoting fallbacks and expiry timezone

### DIFF
--- a/src/utils/helpers.py
+++ b/src/utils/helpers.py
@@ -3,6 +3,10 @@
 from __future__ import annotations
 
 from datetime import datetime, time, timedelta
+from zoneinfo import ZoneInfo
+
+
+IST = ZoneInfo("Asia/Kolkata")
 
 
 def get_weekly_expiry(
@@ -12,10 +16,16 @@ def get_weekly_expiry(
 
     When today is Thursday the helper returns the same-day expiry until the
     cut-off specified by ``use_same_day_before``.  After the cut-off the expiry
-    rolls forward to the following week to avoid stale contracts.
+    rolls forward to the following week to avoid stale contracts.  Datetimes are
+    normalised to IST to match the NSE trading calendar.
     """
 
-    current = now or datetime.now()
+    current = now or datetime.now(IST)
+    if current.tzinfo is None:
+        current = current.replace(tzinfo=IST)
+    else:
+        current = current.astimezone(IST)
+
     cutoff = time.fromisoformat(use_same_day_before)
     days_ahead = (3 - current.weekday()) % 7
     if days_ahead == 0 and current.time() > cutoff:

--- a/tests/test_scalper_safety_fixes.py
+++ b/tests/test_scalper_safety_fixes.py
@@ -4,6 +4,8 @@ import datetime as dt
 from types import SimpleNamespace
 from typing import Any, Dict, Iterable, Iterator, List, Mapping, MutableMapping
 
+from zoneinfo import ZoneInfo
+
 import pytest
 import pandas as pd
 
@@ -28,6 +30,9 @@ from src.strategies.scalper import ScalperStrategy, StaleMarketDataError
 from src.utils.helpers import get_next_thursday, get_weekly_expiry
 
 
+IST = ZoneInfo("Asia/Kolkata")
+
+
 @pytest.fixture(autouse=True)
 def _allow_offhours(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(settings, "allow_offhours_testing", True)
@@ -37,12 +42,12 @@ def _allow_offhours(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_get_weekly_expiry_same_day_before_cutoff() -> None:
-    now = dt.datetime(2024, 6, 6, 10, 0)
+    now = dt.datetime(2024, 6, 6, 10, 0, tzinfo=IST)
     assert get_weekly_expiry(now=now) == "240606"
 
 
 def test_get_weekly_expiry_rolls_forward_after_cutoff() -> None:
-    now = dt.datetime(2024, 6, 6, 16, 0)
+    now = dt.datetime(2024, 6, 6, 16, 0, tzinfo=IST)
     assert get_weekly_expiry(now=now) == "240613"
 
 


### PR DESCRIPTION
## Summary
- add a marketable limit price helper for thin Railway depth and tighten tick rounding
- switch the Railway health check to a stdlib HTTP server and normalize weekly expiry to IST
- extend tests for the new pricing fallback and timezone-aware expiry logic

## Testing
- ./run_checks.sh

------
https://chatgpt.com/codex/tasks/task_e_68d64e3c58f08324a4ffbf20c09ae2dc