### PR TITLE
fix: resolve async coroutine iteration error in PostFillMonitor

### DIFF
--- a/src/nifty_scalper_bot/execution/post_fill_monitor.py
+++ b/src/nifty_scalper_bot/execution/post_fill_monitor.py
@@ -127,7 +127,7 @@ class PostFillMonitor:
         try:
             broker_positions = await asyncio.to_thread(self._fetch_broker_positions)
             broker_map = self._normalise_positions(broker_positions)
-            local_snapshot = list(self._state_tracker.get_open_positions())
+            local_snapshot = list(await self._state_tracker.get_open_positions())
             local_positions = self._normalise_positions(local_snapshot)
             mismatches = self._diff_positions(broker_map, local_positions)
             self._mismatch_count = len(mismatches)


### PR DESCRIPTION
Added await keyword to get_open_positions() call in reconcile method (line 130). This fixes the TypeError: 'coroutine' object is not iterable that was causing polling round failures and preventing the strategy runner from activating.