### PR TITLE
fix: harden VWAP fallback and multiprocess Gauge initialization

### DIFF
--- a/src/nifty_scalper_bot/streaming/polling_streamer.py
+++ b/src/nifty_scalper_bot/streaming/polling_streamer.py
@@ -482,26 +482,53 @@ class PollingStreamer:
                     token_int = int(token)
 
                     # ✅ CRITICAL: Extract VWAP (average_price) and Volume
-                    avg_price = quote.get("average_price") or quote.get("vwap")
-                    volume = quote.get("volume")
-                    oi = quote.get("oi")
+                    avg_price = quote.get('average_price') or quote.get('vwap')
+                    volume = quote.get('volume')
+                    oi = quote.get('oi')
+                    ohlc = quote.get('ohlc') or {}
 
                     # Convert to proper types with safe defaults
                     avg_price_float = float(avg_price) if avg_price is not None else 0.0
                     volume_int = int(volume) if volume is not None else 0
                     oi_int = int(oi) if oi is not None else 0
 
-                    # ✅ DIAGNOSTIC: Log if VWAP is missing (but don't spam)
-                    if avg_price_float == 0:
+                    used_vwap_fallback = False
+                    if avg_price_float <= 0:
+                        ohlc_close = ohlc.get('close')
+                        if ohlc_close is not None:
+                            try:
+                                avg_price_float = float(ohlc_close)
+                                used_vwap_fallback = avg_price_float > 0
+                            except (TypeError, ValueError) as exc:
+                                LOGGER.debug(
+                                    '[POLL] VWAP fallback conversion failed: %s',
+                                    exc,
+                                )
+
+                    if used_vwap_fallback:
                         log_throttled(
                             LOGGER,
-                            f"vwap_zero_{key}",
-                            f"⚠️ VWAP=0 for {key} | This prevents VWAP strategy from triggering",
+                            f'vwap_fallback_{key}',
+                            (
+                                'Condition met: vwap_fallback_ohlc '
+                                f'for {key} (close={avg_price_float:.2f})'
+                            ),
+                            interval_sec=300.0,
+                        )
+                    elif avg_price_float == 0:
+                        # ✅ DIAGNOSTIC: Log if VWAP is missing (but don't spam)
+                        log_throttled(
+                            LOGGER,
+                            f'vwap_zero_{key}',
+                            (
+                                f'⚠️ VWAP=0 for {key} | This prevents VWAP '
+                                'strategy from triggering'
+                            ),
                             interval_sec=300.0,  # Only log every 5 minutes
                         )
 
                     # Handle timestamp
-                    q_ts = quote.get("timestamp")
+                    q_ts = quote.get('timestamp')
                     if q_ts and hasattr(q_ts, "timestamp"):
                         ts = int(q_ts.timestamp() * 1000)
                     elif q_ts and isinstance(q_ts, (int, float)):
@@ -511,19 +538,19 @@ class PollingStreamer:
 
                     # Build tick with ALL available data
                     tick = {
-                        "instrument_token": token_int,
-                        "last_price": lp,
-                        "timestamp": ts,
-                        "volume": volume_int,
-                        "average_price": avg_price_float,  # ✅ VWAP
-                        "oi": oi_int,
-                        "depth": quote.get("depth"),
-                        "symbol": (
+                        'instrument_token': token_int,
+                        'last_price': lp,
+                        'timestamp': ts,
+                        'volume': volume_int,
+                        'average_price': avg_price_float,  # ✅ VWAP
+                        'oi': oi_int,
+                        'depth': quote.get('depth'),
+                        'symbol': (
                             key
                             if ":" in str(key)
                             else self._resolve_instrument(token_int)
                         ),
-                        "source": "rest",
+                        'source': 'rest',
                     }
 
                     # ✅ LOG SUCCESS when we have VWAP (throttled)

--- a/src/nifty_scalper_bot/utils/metrics.py
+++ b/src/nifty_scalper_bot/utils/metrics.py
@@ -184,16 +184,32 @@ def Gauge(name: str, doc: str, labels: Iterable[str] | None = None) -> Any:
     if _PGauge is None:
         return _Noop()
     label_key = tuple(labels or ())
-    cache_key = ("gauge", name, label_key)
+    cache_key = ('gauge', name, label_key)
     metric = _METRIC_CACHE.get(cache_key)
     if metric is None:
         ensure_multiproc_dir()
         try:
-            metric = _PGauge(name, doc, list(label_key))
+            multiproc_mode = (
+                'livesum'
+                if os.environ.get('PROMETHEUS_MULTIPROC_DIR')
+                else None
+            )
+            if multiproc_mode:
+                try:
+                    metric = _PGauge(
+                        name,
+                        doc,
+                        list(label_key),
+                        multiprocess_mode=multiproc_mode,
+                    )
+                except TypeError:
+                    metric = _PGauge(name, doc, list(label_key))
+            else:
+                metric = _PGauge(name, doc, list(label_key))
         except Exception as exc:  # pragma: no cover - defensive fallback
             LOGGER.warning(
-                "Prometheus Gauge init failed; using no-op",
-                extra={"metric_name": name, "error": str(exc)},
+                'Prometheus Gauge init failed; using no-op',
+                extra={'metric_name': name, 'error': str(exc)},
             )
             metric = _Noop()
         _METRIC_CACHE[cache_key] = metric

--- a/tests/streaming/test_polling_streamer_vwap.py
+++ b/tests/streaming/test_polling_streamer_vwap.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from src.nifty_scalper_bot.streaming.polling_streamer import PollingStreamer
+
+
+class FakeResolver:
+    """Simple resolver for mapping tokens to symbols."""
+
+    def format_token_as_symbol(self, token: int) -> str:
+        """Return symbol. Args: token. Returns: symbol. Raises: None."""
+        return 'NSE:NIFTY 50'
+
+
+def test_fetch_ticks_falls_back_to_ohlc_close_for_vwap() -> None:
+    """Test VWAP fallback. Args: None. Returns: None. Raises: None."""
+
+    class QuoteBroker:
+        def quote(self, symbols: list[str]) -> dict[str, dict[str, Any]]:
+            """Return quote payload. Args: symbols. Returns: quote map. Raises: None."""
+            return {
+                symbols[0]: {
+                    'last_price': 123.45,
+                    'instrument_token': 101,
+                    'average_price': 0.0,
+                    'volume': 0,
+                    'ohlc': {'close': 122.0},
+                }
+            }
+
+    broker = QuoteBroker()
+    resolver = FakeResolver()
+    streamer = PollingStreamer(
+        broker_client=broker,
+        on_tick=lambda t: None,
+        instrument_resolver=resolver,
+    )
+    ticks = streamer._fetch_ticks([101])
+    assert len(ticks) == 1
+    assert ticks[0]['average_price'] == pytest.approx(122.0)

--- a/tests/utils/test_metrics.py
+++ b/tests/utils/test_metrics.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from typing import Any
+
+from src.nifty_scalper_bot.utils import metrics
+
+
+def test_gauge_uses_multiprocess_mode_when_env_set(
+    monkeypatch: Any, tmp_path: Any
+) -> None:
+    """Test multiprocess Gauge config. Args: None. Returns: None. Raises: None."""
+    calls: dict[str, Any] = {}
+
+    class DummyGauge:
+        def __init__(self, *_: Any, **kwargs: Any) -> None:
+            """Store call kwargs. Args: None. Returns: None. Raises: None."""
+            calls.update(kwargs)
+
+    monkeypatch.setenv('PROMETHEUS_MULTIPROC_DIR', str(tmp_path))
+    monkeypatch.setattr(metrics, '_PGauge', DummyGauge)
+    metrics._METRIC_CACHE.clear()
+
+    metrics.Gauge('test_gauge', 'desc', ['label'])
+
+    assert calls.get('multiprocess_mode') == 'livesum'


### PR DESCRIPTION
### Motivation
- Address frequent "VWAP=0" observations by ensuring the poller can recover VWAP from available OHLC close values when broker quotes omit average_price. 
- Reduce Prometheus Gauge initialization failures in multiprocess environments by attempting to create a multiprocess-aware Gauge before falling back to a no-op.

### Description
- Update `PollingStreamer._fetch_ticks` to use `ohlc['close']` as a safe VWAP fallback when `average_price`/`vwap` is zero and to emit a throttled `vwap_fallback` diagnostic when used (`src/nifty_scalper_bot/streaming/polling_streamer.py`).
- Harden `Gauge()` in `src/nifty_scalper_bot/utils/metrics.py` to attempt creating a multiprocess Gauge with `multiprocess_mode='livesum'` when `PROMETHEUS_MULTIPROC_DIR` is present, while preserving the existing defensive fallback to a `_Noop` metric on errors or unsupported signatures.
- Add unit tests exercising the changes: `tests/streaming/test_polling_streamer_vwap.py` verifies VWAP fallback to `ohlc.close`, and `tests/utils/test_metrics.py` verifies multiprocess-mode invocation when the env var is set.

### Testing
- Ran the project checklist `./run_checks.sh` (installs deps, runs Ruff, mypy, pytest); the run completed dependency installation but reported existing lint/mypy issues across the codebase and stopped during pytest with an import error in an unrelated test (`tests/data/test_resolver_lots_delta.py`), so the full test-suite did not finish green.
- Added targeted unit tests `tests/streaming/test_polling_streamer_vwap.py` and `tests/utils/test_metrics.py` covering the VWAP fallback and Gauge multiprocess behavior (these tests were added to the repo and are included in the PR).
- Risk: low — changes are narrow, defensive, and preserve existing fallbacks; however CI/lint/mypy failures in the repository (pre-existing) must be resolved before the full test-suite can pass.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984db16506c83248c459a5dc436a665)