### PR TITLE
fix: throttle futures vwap proxy log

### DIFF
--- a/src/nifty_scalper_bot/strategies/signal_generator.py
+++ b/src/nifty_scalper_bot/strategies/signal_generator.py
@@ -1692,14 +1692,22 @@ class StrategyManager:
 
                     if (not fut_vwap or fut_vwap <= 0) and fut_ltp and fut_ltp > 0:
                         fut_vwap = fut_ltp
-                        self._logger.info(
-                            "Condition met: futures_vwap_proxy_used",
-                            extra={
-                                "event": "futures_vwap_proxy_used",
-                                "symbol": working_symbol,
-                                "ltp": fut_ltp,
-                            },
+                        proxy_logged = getattr(
+                            self, "_vwap_proxy_logged_symbols", None
                         )
+                        if proxy_logged is None:
+                            proxy_logged = set()
+                            self._vwap_proxy_logged_symbols = proxy_logged
+                        if working_symbol not in proxy_logged:
+                            self._logger.info(
+                                'Condition met: futures_vwap_proxy_used',
+                                extra={
+                                    'event': 'futures_vwap_proxy_used',
+                                    'symbol': working_symbol,
+                                    'ltp': fut_ltp,
+                                },
+                            )
+                            proxy_logged.add(working_symbol)
 
                     if fut_vwap and fut_vwap > 0:
                         # Adjust for basis (futures typically trades at ~0.2% premium)


### PR DESCRIPTION
### Motivation
- Reduce noisy log spam from repeated `futures_vwap_proxy_used` INFO messages that were emitted on every tick and obscuring other signals.

### Description
- Update `src/nifty_scalper_bot/strategies/signal_generator.py` to cache symbols that already emitted the `futures_vwap_proxy_used` INFO log in a session using the `_vwap_proxy_logged_symbols` set and only log once per symbol.

### Testing
- Ran `black .` which completed successfully and reformatted files.
- Ran `isort .` which completed successfully and re-sorted imports.
- Ran `ruff check .` which reported existing repo lint issues (failed, unrelated to this change).
- Ran `mypy src` which reported existing type errors in the repository (failed, unrelated to this change).
- Ran `pytest -q tests --disable-warnings --ignore=tests/test_live_mode.py --ignore=tests/test_health_server.py` which failed with an `ImportError` in `tests/notifications/test_telegram_commands.py` (unrelated to this change).
- Ran `./run_checks.sh` (via `bash ./run_checks.sh`) which exercised the full checks and reproduced the above `ruff`/`mypy`/`pytest` findings (failed overall).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698548324ad4832488af09270af6736b)