### PR TITLE
feat: harden elite strategy signal gating

### DIFF
--- a/src/nifty_scalper_bot/strategies/elite_strategies/base_elite.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/base_elite.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import inspect
 from dataclasses import dataclass, field, asdict
 from datetime import datetime, timezone
-from typing import Any, Dict, Set, Optional, Mapping
+from typing import Any, Dict, Mapping
 
 from nifty_scalper_bot.strategies.elite_strategies.config_models import (
     EliteStrategyConfig,
@@ -95,8 +95,18 @@ class EliteStrategy(Strategy):
         else:
             LOGGER.debug(f"🚀 {self.name}: Running in Modern Mode (Push-Based)")
 
-    def get_required_indicators(self) -> Set[str]:
-        return set()
+    def get_required_indicators(self) -> list[str]:
+        """Args: none. Returns: list[str]. Raises: Exception."""
+        LOGGER.debug('Entered EliteStrategy.get_required_indicators')
+        try:
+            LOGGER.info(
+                'Condition met: using base indicator set',
+                extra={'event': 'elite_strategy_required_indicators', 'strategy': self.name},
+            )
+            return []
+        except Exception as exc:
+            LOGGER.error('Failure in get_required_indicators: %s', exc, exc_info=exc)
+            return []
 
     def generate_signal(
         self, 
@@ -105,58 +115,131 @@ class EliteStrategy(Strategy):
         current_price: float, 
         position: Any | None = None
     ) -> Signal | None:
-        """
-        ✅ THE BRIDGE: Satisfies abstract requirement of parent class.
-        """
-        if not self._config.enabled:
-            return None
-
-        # ✅ Early exit if capital is exhausted (prevents wasted computation)
-        if hasattr(self, '_orchestrator') and self._orchestrator:
-            if not self._orchestrator._has_capital_headroom_quick():
+        """Args: symbol, indicators, price, pos. Returns: Signal|None. Raises: Err."""
+        LOGGER.debug('Entered EliteStrategy.generate_signal')
+        try:
+            if not self._config.enabled:
+                LOGGER.info(
+                    'Condition met: strategy disabled',
+                    extra={'event': 'elite_strategy_disabled', 'strategy': self.name},
+                )
                 return None
 
-        elite_signal = self._evaluate_signal(
-            symbol=symbol, 
-            indicators=indicators, 
-            current_price=current_price, 
-            position=position
-        )
+            if not symbol:
+                LOGGER.info(
+                    'Condition met: missing symbol',
+                    extra={'event': 'elite_strategy_missing_symbol', 'strategy': self.name},
+                )
+                return None
 
-        if elite_signal:
-            return self._process_signal(elite_signal)
-            
+            if current_price <= 0:
+                LOGGER.info(
+                    'Condition met: invalid current price',
+                    extra={
+                        'event': 'elite_strategy_invalid_price',
+                        'strategy': self.name,
+                        'price': current_price,
+                    },
+                )
+                return None
+
+            if indicators is None:
+                LOGGER.info(
+                    'Condition met: missing indicators payload',
+                    extra={'event': 'elite_strategy_missing_indicators', 'strategy': self.name},
+                )
+                return None
+
+            # ✅ Early exit if capital is exhausted (prevents wasted computation)
+            if hasattr(self, '_orchestrator') and self._orchestrator:
+                if not self._orchestrator._has_capital_headroom_quick():
+                    LOGGER.info(
+                        'Condition met: capital headroom exhausted',
+                        extra={'event': 'elite_strategy_no_capital', 'strategy': self.name},
+                    )
+                    return None
+
+            indicators_payload: dict[str, Any] = dict(indicators)
+            elite_signal = self._evaluate_signal(
+                symbol=symbol,
+                indicators=indicators_payload,
+                current_price=current_price,
+                position=position,
+            )
+
+            if elite_signal:
+                LOGGER.info(
+                    'Condition met: elite signal generated',
+                    extra={'event': 'elite_strategy_signal', 'strategy': self.name},
+                )
+                return self._process_signal(elite_signal)
+
+            LOGGER.debug(
+                'No signal generated',
+                extra={'event': 'elite_strategy_no_signal', 'strategy': self.name},
+            )
+        except Exception as exc:
+            LOGGER.error('Failure in generate_signal: %s', exc, exc_info=exc)
+
         return None
 
     def evaluate(self) -> Signal | None:
-        """Fallback for polling execution."""
-        if not self._config.enabled:
-            return None
-
-        if self._last_signal_at:
-            elapsed = (datetime.now(timezone.utc) - self._last_signal_at).total_seconds()
-            if elapsed < self._config.cooldown_seconds:
+        """Args: none. Returns: Signal|None. Raises: Exception."""
+        LOGGER.debug('Entered EliteStrategy.evaluate')
+        try:
+            if not self._config.enabled:
+                LOGGER.info(
+                    'Condition met: strategy disabled',
+                    extra={'event': 'elite_strategy_disabled_poll', 'strategy': self.name},
+                )
                 return None
 
-        try:
-            if self._is_legacy_signature:
-                elite_signal = self._evaluate_signal() # type: ignore
-                if elite_signal:
-                    return self._process_signal(elite_signal)
-            else:
-                symbol = getattr(self._config, "symbol", None)
-                if not symbol:
+            if self._last_signal_at:
+                elapsed = (datetime.now(timezone.utc) - self._last_signal_at).total_seconds()
+                if elapsed < self._config.cooldown_seconds:
+                    LOGGER.info(
+                        'Condition met: cooldown active',
+                        extra={
+                            'event': 'elite_strategy_cooldown',
+                            'strategy': self.name,
+                            'elapsed': elapsed,
+                        },
+                    )
                     return None
-                
-                req_inds = self.get_required_indicators()
-                indicators = self._indicator_engine.get_indicators(symbol, list(req_inds))
-                ltp = float(indicators.get("ltp") or 0.0)
-                
-                return self.generate_signal(symbol, indicators, ltp)
 
-        except Exception as e:
-            LOGGER.error(f"Error evaluating {self.name}: {e}", exc_info=True)
-        
+            if self._is_legacy_signature:
+                elite_signal = self._evaluate_signal()  # type: ignore
+                if elite_signal:
+                    LOGGER.info(
+                        'Condition met: legacy signal generated',
+                        extra={
+                            'event': 'elite_strategy_legacy_signal',
+                            'strategy': self.name,
+                        },
+                    )
+                    return self._process_signal(elite_signal)
+                LOGGER.debug(
+                    'No legacy signal generated',
+                    extra={'event': 'elite_strategy_legacy_no_signal', 'strategy': self.name},
+                )
+                return None
+
+            symbol = getattr(self._config, 'symbol', None)
+            if not symbol:
+                LOGGER.info(
+                    'Condition met: missing symbol',
+                    extra={'event': 'elite_strategy_missing_symbol', 'strategy': self.name},
+                )
+                return None
+
+            req_inds = self.get_required_indicators()
+            indicators = self._indicator_engine.get_indicators(symbol, list(req_inds))
+            ltp = float(indicators.get('ltp') or 0.0)
+
+            return self.generate_signal(symbol, indicators, ltp)
+        except Exception as exc:
+            LOGGER.error('Failure in evaluate: %s', exc, exc_info=exc)
+
         return None
 
     def _evaluate_signal(


### PR DESCRIPTION
### Motivation
- Improve safety and observability of the elite strategy base class to reduce spurious or unsafe trade signals. 
- Ensure strategies exit early on invalid inputs (missing symbol/indicators/price) and avoid wasted computation when capital headroom is exhausted.

### Description
- Added defensive validation and structured logging in `EliteStrategy.generate_signal` including early exits for disabled strategies, missing symbol, invalid price, missing indicators, and exhausted capital headroom, and a debug entry log.
- Made `get_required_indicators` return a `list[str]` (matching the registry expectations) and added a guarded default implementation with logging.
- Copied the incoming `indicators` mapping to a local `dict` (`indicators_payload`) before passing to `_evaluate_signal` to avoid accidental mutation of externals.
- Strengthened `EliteStrategy.evaluate` with entry logging, cooldown logging, legacy vs push-mode decision logs, safer symbol retrieval, indicator fetching, and unified exception logging.

### Testing
- Ran the repository checks via `./run_checks.sh` as the project policy requires, which triggers linting, type checking and pytest; the script executed but returned issues from pre-existing checks rather than new failures introduced by this change.
- Ruff/linters: reported existing import/formatting and line-length issues across the repo (many files); these are preexisting and not introduced by this PR.
- Mypy: produced numerous preexisting type errors across the codebase; none of the errors appear to be caused by this targeted change to the elite strategy base class.
- Pytest: the test run aborted on importing `tests/notifications/test_telegram_commands.py` with an existing ImportError: "cannot import name '_format_chain_summary'"; this failure is unrelated to the hardened gating in this file.
- Result summary: `./run_checks.sh` completed but reported existing Ruff/mypy issues and a pytest import error; the modified file is type hinted and includes logging as required by project guidelines.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69854f1a202c83248e92124744ac9de0)