### PR TITLE
fix: normalize futures volume ratio

### DIFF
--- a/src/nifty_scalper_bot/strategies/signal_generator.py
+++ b/src/nifty_scalper_bot/strategies/signal_generator.py
@@ -1566,16 +1566,16 @@ class StrategyManager:
         return (sl, tp)
 
     def _augment_futures_metrics(self, indicators: MutableMapping[str, Any]) -> None:
-        """
-        Augment indicators with futures and index data.
-
-        ✅ PRODUCTION FIX: Now includes nifty_index_ltp and nifty_index_vwap
-        """
-        indicators.setdefault("futures_volume", None)
-        indicators.setdefault("futures_volume_avg", None)
-        indicators.setdefault("futures_volume_ratio", None)
-        indicators.setdefault("nifty_index_ltp", None)  # ✅ NEW
-        indicators.setdefault("nifty_index_vwap", None)  # ✅ NEW
+        '''Augment metrics. Args: indicators. Returns: None. Raises: NA.'''
+        self._logger.debug(
+            'Entered StrategyManager._augment_futures_metrics',
+            extra={'event': 'augment_futures_metrics'},
+        )
+        indicators.setdefault('futures_volume', None)
+        indicators.setdefault('futures_volume_avg', None)
+        indicators.setdefault('futures_volume_ratio', None)
+        indicators.setdefault('nifty_index_ltp', None)  # ✅ NEW
+        indicators.setdefault('nifty_index_vwap', None)  # ✅ NEW
 
         data_hub = self._data_hub
         if data_hub is None:
@@ -1586,23 +1586,59 @@ class StrategyManager:
         # ═══════════════════════════════════════════════════════════
         try:
             quote = data_hub.get_quote(self._futures_symbol)
-        except Exception:
+        except Exception as exc:
+            self._logger.error(
+                'Failure in StrategyManager._augment_futures_metrics futures quote: %s',
+                exc,
+                extra={'event': 'futures_quote_error', 'symbol': self._futures_symbol},
+            )
             quote = None
 
         if quote:
             volume = self._extract_float(
-                quote, ("volume_traded_today", "volume", "last_quantity")
+                quote,
+                ('volume_traded_today', 'volume_traded', 'volume', 'last_quantity'),
             )
             if volume is not None:
-                self._futures_volume_history.append(volume)
-                indicators["futures_volume"] = volume
+                last_volume = getattr(self, '_last_futures_volume', None)
+                if last_volume is None:
+                    volume_delta = volume
+                elif volume < last_volume:
+                    volume_delta = volume
+                    self._logger.info(
+                        'Condition met: futures_volume_reset',
+                        extra={
+                            'event': 'futures_volume_reset',
+                            'symbol': self._futures_symbol,
+                            'last_volume': last_volume,
+                            'current_volume': volume,
+                        },
+                    )
+                else:
+                    volume_delta = volume - last_volume
+
+                self._last_futures_volume = volume
+                if volume_delta >= 0:
+                    self._futures_volume_history.append(volume_delta)
+
+                indicators['futures_volume'] = volume
                 if self._futures_volume_history:
                     avg = sum(self._futures_volume_history) / len(
                         self._futures_volume_history
                     )
-                    indicators["futures_volume_avg"] = avg
+                    indicators['futures_volume_avg'] = avg
                     if avg > 0:
-                        indicators["futures_volume_ratio"] = volume / avg
+                        indicators['futures_volume_ratio'] = volume_delta / avg
+                        self._logger.info(
+                            'Condition met: futures_volume_ratio_updated',
+                            extra={
+                                'event': 'futures_volume_ratio_updated',
+                                'symbol': self._futures_symbol,
+                                'volume_delta': volume_delta,
+                                'volume_avg': avg,
+                                'volume_ratio': indicators['futures_volume_ratio'],
+                            },
+                        )
 
         # ═══════════════════════════════════════════════════════════
         # ✅ 2. INDEX LTP AND VWAP DATA (NEW)
@@ -1692,19 +1728,17 @@ class StrategyManager:
 
                     if (not fut_vwap or fut_vwap <= 0) and fut_ltp and fut_ltp > 0:
                         fut_vwap = fut_ltp
-                        proxy_logged = getattr(
-                            self, "_vwap_proxy_logged_symbols", None
-                        )
+                        proxy_logged = getattr(self, "_vwap_proxy_logged_symbols", None)
                         if proxy_logged is None:
                             proxy_logged = set()
                             self._vwap_proxy_logged_symbols = proxy_logged
                         if working_symbol not in proxy_logged:
                             self._logger.info(
-                                'Condition met: futures_vwap_proxy_used',
+                                "Condition met: futures_vwap_proxy_used",
                                 extra={
-                                    'event': 'futures_vwap_proxy_used',
-                                    'symbol': working_symbol,
-                                    'ltp': fut_ltp,
+                                    "event": "futures_vwap_proxy_used",
+                                    "symbol": working_symbol,
+                                    "ltp": fut_ltp,
                                 },
                             )
                             proxy_logged.add(working_symbol)
@@ -1739,7 +1773,11 @@ class StrategyManager:
                 )
 
         except Exception as e:
-            self._logger.debug(f"Index data augment failed: {e}")
+            self._logger.error(
+                'Failure in StrategyManager._augment_futures_metrics index augment: %s',
+                e,
+                extra={'event': 'index_data_augment_failed'},
+            )
 
     @staticmethod
     def _extract_float(

--- a/tests/strategies/test_signal_generator_futures_volume.py
+++ b/tests/strategies/test_signal_generator_futures_volume.py
@@ -1,0 +1,103 @@
+'''Tests for futures volume delta handling in signal generation.'''
+
+from __future__ import annotations
+
+from collections import deque
+from typing import Any, Iterable, Mapping
+
+from nifty_scalper_bot.strategies.signal_generator import StrategyManager
+from nifty_scalper_bot.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+class StubIndicatorEngine:
+    '''Stub indicator engine. Args: None. Returns: None. Raises: None.'''
+
+    def update_price(
+        self,
+        symbol: str,
+        price: Any,
+        *,
+        volume: int = 0,
+        timestamp: Any | None = None,
+    ) -> None:
+        '''No-op update. Args: symbol, price, volume. Returns: None. Raises: None.'''
+        try:
+            return None
+        except Exception as exc:
+            logger.error('Failure in StubIndicatorEngine.update_price: %s', exc)
+            raise
+
+    def get_indicators(
+        self, symbol: str, names: Iterable[str]
+    ) -> Mapping[str, float | tuple[float, float, float] | None]:
+        '''Return empty indicators. Args: symbol, names. Returns: map. Raises: None.'''
+        try:
+            return {}
+        except Exception as exc:
+            logger.error('Failure in StubIndicatorEngine.get_indicators: %s', exc)
+            raise
+
+
+class StubPositionManager:
+    '''Stub position manager. Args: None. Returns: None. Raises: None.'''
+
+    def get_position(self, symbol: str) -> None:
+        '''Return no position. Args: symbol. Returns: None. Raises: None.'''
+        try:
+            return None
+        except Exception as exc:
+            logger.error('Failure in StubPositionManager.get_position: %s', exc)
+            raise
+
+
+class StubDataHub:
+    '''Stub data hub for futures quotes. Args: volumes. Returns: None. Raises: None.'''
+
+    def __init__(self, volumes: list[float]) -> None:
+        '''Store futures volume samples. Args: volumes. Returns: None. Raises: None.'''
+        try:
+            self._volumes = deque(volumes)
+            self._last_volume = volumes[-1] if volumes else 0.0
+        except Exception as exc:
+            logger.error('Failure in StubDataHub.__init__: %s', exc)
+            raise
+
+    def get_quote(self, symbol: str) -> Mapping[str, Any] | None:
+        '''Return a stub quote. Args: symbol. Returns: mapping or None. Raises: None.'''
+        try:
+            if symbol == 'NSE:NIFTY 50':
+                return {'last_price': 20000.0, 'vwap': 19950.0}
+            if symbol == 'NIFTY':
+                if self._volumes:
+                    self._last_volume = self._volumes.popleft()
+                return {'volume_traded_today': self._last_volume}
+            return None
+        except Exception as exc:
+            logger.error('Failure in StubDataHub.get_quote: %s', exc)
+            raise
+
+
+def test_futures_volume_ratio_uses_delta() -> None:
+    '''Validate futures ratio uses deltas. Args: None. Returns: None. Raises: None.'''
+    try:
+        data_hub = StubDataHub([100.0, 150.0])
+        manager = StrategyManager(
+            strategies=[],
+            indicator_engine=StubIndicatorEngine(),
+            position_manager=StubPositionManager(),
+            data_hub=data_hub,
+            futures_symbol='NIFTY',
+        )
+        indicators: dict[str, Any] = {}
+
+        manager._augment_futures_metrics(indicators)
+        manager._augment_futures_metrics(indicators)
+
+        volume_ratio = indicators.get('futures_volume_ratio')
+        assert volume_ratio is not None
+        assert 0.6 < float(volume_ratio) < 0.8
+    except Exception as exc:
+        logger.error('Failure in test_futures_volume_ratio_uses_delta: %s', exc)
+        raise


### PR DESCRIPTION
### Motivation
- Futures cumulative volume was being used directly to compute `futures_volume_ratio`, which kept the ratio near 1.0 and prevented volume‑gated strategies from triggering.
- Minimal, production‑grade fix required to compute per‑interval deltas while preserving existing gating behavior and keeping architecture/flow unchanged.

### Description
- Compute per-interval futures volume deltas in `StrategyManager._augment_futures_metrics` and use the delta when deriving `futures_volume_ratio`, with safe handling for rollovers and resets, and persistent `_last_futures_volume` tracking. (file: `src/nifty_scalper_bot/strategies/signal_generator.py`)
- Add robust logging and error handling around futures/index quote retrieval and ratio updates to aid observability and prevent silent failures. (same file)
- Add a unit test that stubs `DataHub` and validates that successive calls produce a non-trivial `futures_volume_ratio` based on deltas. (file: `tests/strategies/test_signal_generator_futures_volume.py`)

### Testing
- Ran formatting and import tooling: `black .` and `isort .` completed successfully. `ruff check .` produced repository-wide lint findings (pre-existing) and did not pass. 
- Ran static types: `mypy src` produced repository-wide type errors (pre-existing) and did not pass. 
- Ran unit tests: `pytest -q tests --disable-warnings --ignore=tests/test_live_mode.py --ignore=tests/test_health_server.py`; test run failed early with an import error in Telegram command tests unrelated to this change (`ImportError: cannot import name '_format_chain_summary' from nifty_scalper_bot.notifications.telegram_commands`).
- Executed `bash run_checks.sh`; the script attempted full install and checks and reported the same `ruff`/`mypy`/`pytest` failures (summary: ~1024 ruff issues, ~368 mypy errors, pytest import error as above). The new test file was created and included in the commit.

Notes: The patch is intentionally surgical and keeps public signatures and flow unchanged; remaining lint/type/test failures appear to be pre-existing repository issues and not caused by this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985520ea3d4832496b0da53127e4857)