### PR TITLE
fix: harden order processor bracket tracking

### DIFF
--- a/src/nifty_scalper_bot/execution/order_processor.py
+++ b/src/nifty_scalper_bot/execution/order_processor.py
@@ -4,21 +4,21 @@ Production-Grade: Handles Risk Checks, Thread Safety, Position Awareness, and Ex
 """
 
 import asyncio
-import logging
-import os
-from contextlib import suppress
 from datetime import datetime, timezone
-from typing import Any, Dict
+import os
+from typing import Any, Dict, Literal, cast
 
 from nifty_scalper_bot.core.message_bus import Message, MessageBus, MessageType
 from nifty_scalper_bot.execution.order_manager import OrderManager, OrderType
 from nifty_scalper_bot.execution.position_manager import PositionManager
-from nifty_scalper_bot.risk.risk_manager import RiskManager
+from nifty_scalper_bot.risk.risk_manager import OrderSignal, RiskManager
+from nifty_scalper_bot.utils.logging import get_logger
 
 # --- Order Execution States ---
-INTENT = "INTENT"   # Signal accepted, execution pending
+INTENT = "INTENT"  # Signal accepted, execution pending
 
-LOGGER = logging.getLogger(__name__)
+LOGGER = get_logger(__name__)
+
 
 class OrderProcessor:
     """
@@ -31,19 +31,20 @@ class OrderProcessor:
         message_bus: MessageBus,
         safe_order_manager: OrderManager,
         risk_manager: RiskManager,
-        position_manager: PositionManager, 
-        data_hub: Any, 
-    ):
+        position_manager: PositionManager,
+        data_hub: Any,
+    ) -> None:
+        """Initialize the order processor. Args: message_bus, safe_order_manager, risk_manager, position_manager, data_hub. Returns: None. Raises: None."""
         self.bus = message_bus
         self.executor = safe_order_manager
         self.risk_manager = risk_manager
         self.pos_manager = position_manager
         self.data_hub = data_hub
         self._running = False
-        
+
         # 1. Thread Safety Lock
         self._lock = asyncio.Lock()
-        
+
         # 2. State Tracking
         self._active_trades: Dict[str, str] = {}
         self._last_signal_time: Dict[str, float] = {}
@@ -53,59 +54,125 @@ class OrderProcessor:
 
         # 3. Validation: Ensure OrderManager supports brackets
         # This prevents silent naked trading if the underlying manager is outdated
-        if not hasattr(self.executor, "place_bracket_order"):
-            LOGGER.critical("FATAL: OrderManager does not support 'place_bracket_order'. Brackets will fail.")
-            # We don't raise here to allow startup, but this is a critical configuration error.
+        try:
+            if not hasattr(self.executor, "place_bracket_order"):
+                LOGGER.critical(
+                    "FATAL: OrderManager does not support 'place_bracket_order'. Brackets will fail."
+                )
+                # We don't raise here to allow startup, but this is a critical configuration error.
+        except Exception as exc:  # noqa: BLE001
+            LOGGER.error(
+                "Failure in OrderProcessor.__init__: %s",
+                exc,
+                extra={"event": "order_processor_init_error"},
+                exc_info=exc,
+            )
 
     async def start(self) -> None:
-        """Start the order processor message listener."""
+        """Start the order processor message listener. Args: None. Returns: None. Raises: None."""
         LOGGER.info("OrderProcessor: Starting...")
         self._running = True
-        await self.bus.subscribe(MessageType.STRATEGY_SIGNAL, self.on_strategy_signal)
+        try:
+            self.bus.subscribe(MessageType.SIGNAL, self.on_strategy_signal)
+        except Exception as exc:  # noqa: BLE001
+            LOGGER.error(
+                "Failure in OrderProcessor.start subscribe: %s",
+                exc,
+                extra={"event": "order_processor_subscribe_error"},
+                exc_info=exc,
+            )
         # Ensure executor monitoring is active
-        with suppress(Exception):
+        try:
             self.executor.start_monitoring()
+        except Exception as exc:  # noqa: BLE001
+            LOGGER.error(
+                "Failure in OrderProcessor.start: %s",
+                exc,
+                extra={"event": "order_processor_start_error"},
+                exc_info=exc,
+            )
 
     async def stop(self) -> None:
-        """Stop the order processor."""
+        """Stop the order processor. Args: None. Returns: None. Raises: None."""
         LOGGER.info("OrderProcessor: Stopping...")
         self._running = False
-        with suppress(Exception):
+        try:
             self.executor.stop_monitoring()
+        except Exception as exc:  # noqa: BLE001
+            LOGGER.error(
+                "Failure in OrderProcessor.stop: %s",
+                exc,
+                extra={"event": "order_processor_stop_error"},
+                exc_info=exc,
+            )
+
+    def _resolve_trade_price(self, symbol: str, price: float) -> float:
+        """Resolve a usable trade price. Args: symbol, price. Returns: float. Raises: None."""
+        if price > 0:
+            return price
+        if not self.data_hub or not hasattr(self.data_hub, "get_quote"):
+            return 0.0
+        try:
+            quote = self.data_hub.get_quote(symbol, allow_pull=True)
+            if not isinstance(quote, dict):
+                return 0.0
+            ltp = quote.get("ltp") or quote.get("last_price")
+            if isinstance(ltp, (int, float)) and ltp > 0:
+                return float(ltp)
+        except Exception as exc:  # noqa: BLE001
+            LOGGER.error(
+                "Failure in OrderProcessor._resolve_trade_price: %s",
+                exc,
+                extra={
+                    "event": "order_processor_price_resolve_error",
+                    "symbol": symbol,
+                },
+                exc_info=exc,
+            )
+        return 0.0
 
     async def on_strategy_signal(self, message: Message) -> None:
-        """
-        Handle incoming strategy signals with enforced Bracket Logic.
-        """
+        """Handle incoming strategy signals with enforced bracket logic. Args: message. Returns: None. Raises: None."""
         if not self._running:
             return
 
+        LOGGER.debug(
+            "Entered OrderProcessor.on_strategy_signal",
+            extra={"event": "order_processor_signal_enter"},
+        )
         signal: dict[str, Any] = message.data
         symbol = signal.get("symbol")
         side = signal.get("side")
         qty = signal.get("quantity")
-        price = signal.get("price", 0.0) or 0.0
-        
+        price = float(signal.get("price", 0.0) or 0.0)
+
         # ✅ FIX 1: Extract Protection Data & Strategy Name
         stop_loss = float(signal.get("stop_loss") or 0.0)
         take_profit = float(signal.get("target") or signal.get("take_profit") or 0.0)
         strategy_name = str(signal.get("strategy_name") or "strategy_auto")
+        metadata = signal.get("metadata") or {}
+        trailing_spec = signal.get("trailing_spec") or metadata.get("trailing_spec")
 
         if not symbol or not side or not qty:
-            LOGGER.error(f"Invalid Signal: {signal}")
+            LOGGER.error("Invalid Signal: %s", signal)
             return
+        if side not in ("BUY", "SELL"):
+            LOGGER.error(
+                "Condition met: invalid_signal_side",
+                extra={"event": "order_processor_invalid_side", "side": side},
+            )
+            return
+        price = self._resolve_trade_price(symbol, price)
 
         # ================= OPTION ENTRY LIMIT (ENV CONTROLLED) =================
-        if (
-            self._max_active_option_trades > 0
-            and symbol.startswith("NFO:")
-        ):
+        if self._max_active_option_trades > 0 and symbol.startswith("NFO:"):
             # exits must NEVER be blocked
             position = self.pos_manager.get_position(symbol)
             is_exit_check = False
             if position and position.quantity != 0:
-                if (position.side == "LONG" and side == "SELL") or \
-                   (position.side == "SHORT" and side == "BUY"):
+                if (position.side == "LONG" and side == "SELL") or (
+                    position.side == "SHORT" and side == "BUY"
+                ):
                     is_exit_check = True
 
             if not is_exit_check:
@@ -117,8 +184,7 @@ class OrderProcessor:
                 active_option_count = sum(
                     1
                     for pos in active_positions
-                    if pos.symbol.startswith("NFO:")
-                    and pos.quantity != 0
+                    if pos.symbol.startswith("NFO:") and pos.quantity != 0
                 )
 
                 if active_option_count >= self._max_active_option_trades:
@@ -135,11 +201,10 @@ class OrderProcessor:
                     return
         # ================= END OPTION ENTRY LIMIT =============================
 
-
         # 1. Concurrency Check (Debounce)
         key = f"{symbol}"
         if key in self._active_trades:
-            LOGGER.warning(f"⚠️ Skipping Signal {symbol}: Active Order in Process")
+            LOGGER.warning("⚠️ Skipping Signal %s: Active Order in Process", symbol)
             return
 
         self._active_trades[key] = INTENT
@@ -148,24 +213,40 @@ class OrderProcessor:
             # 2. Position Awareness (Exit vs Entry)
             position = self.pos_manager.get_position(symbol)
             is_exit = False
-            
+
             if position and position.quantity != 0:
                 # Simple logic: if side differs, it's an exit/reduction
-                if (position.side == "LONG" and side == "SELL") or \
-                   (position.side == "SHORT" and side == "BUY"):
+                if (position.side == "LONG" and side == "SELL") or (
+                    position.side == "SHORT" and side == "BUY"
+                ):
                     is_exit = True
-                    LOGGER.info(f"🔻 Signal Identified as EXIT for {symbol}")
+                    LOGGER.info("🔻 Signal Identified as EXIT for %s", symbol)
 
             # 3. Risk Check (Skip for exits to allow closing)
             if not is_exit:
-                risk_ok, risk_msg = self.risk_manager.check_trade_risk(
-                    symbol=symbol, 
-                    side=side, 
-                    quantity=qty, 
-                    price=price
+                if price <= 0:
+                    LOGGER.error(
+                        "Condition met: price_missing_for_risk_check",
+                        extra={
+                            "event": "order_processor_price_missing",
+                            "symbol": symbol,
+                        },
+                    )
+                    return
+                risk_signal = OrderSignal(
+                    symbol=str(symbol),
+                    side=cast(Literal["BUY", "SELL"], side),
+                    quantity=int(qty),
+                    price=float(price),
+                    stop_loss=float(stop_loss) if stop_loss > 0 else None,
+                    take_profit=float(take_profit) if take_profit > 0 else None,
+                )
+                risk_ok, risk_msg = self.risk_manager.check_order(
+                    risk_signal,
+                    live_enabled=True,
                 )
                 if not risk_ok:
-                    LOGGER.warning(f"⛔ Risk Reject {symbol}: {risk_msg}")
+                    LOGGER.warning("⛔ Risk Reject %s: %s", symbol, risk_msg)
                     # Release lock immediately on rejection
                     self._active_trades.pop(key, None)
                     return
@@ -175,7 +256,14 @@ class OrderProcessor:
             if price > 0:
                 order_type = OrderType.LIMIT
 
-            LOGGER.info(f"🚀 Executing: {side} {qty} {symbol} @ {price or 'MKT'} (Is Exit: {is_exit})")
+            LOGGER.info(
+                "🚀 Executing: %s %s %s @ %s (Is Exit: %s)",
+                side,
+                qty,
+                symbol,
+                price or "MKT",
+                is_exit,
+            )
 
             # 5. Execution Logic with FORCED BRACKETS
             broker_order_id = None
@@ -183,13 +271,16 @@ class OrderProcessor:
             # ✅ FIX 2: FORCE BRACKET EXECUTION FOR ENTRIES
             # If it's an ENTRY and we have valid Stop/Target, use place_bracket_order
             if not is_exit and stop_loss > 0 and take_profit > 0:
-                
+
                 # Double check capability to avoid crash
                 if hasattr(self.executor, "place_bracket_order"):
                     LOGGER.info(
-                        f"🛡️ BRACKET ORDER SUBMITTED | {symbol} | SL={stop_loss} | TP={take_profit}"
+                        "🛡️ BRACKET ORDER SUBMITTED | %s | SL=%s | TP=%s",
+                        symbol,
+                        stop_loss,
+                        take_profit,
                     )
-                    
+
                     broker_order_id = await asyncio.to_thread(
                         self.executor.place_bracket_order,
                         symbol=symbol,
@@ -200,10 +291,13 @@ class OrderProcessor:
                         take_profit=take_profit,
                         trailing_atr_mult=1.5,  # Conservative default for auto-trail
                         tag=strategy_name,
+                        trailing_spec=trailing_spec,
                     )
                 else:
                     # Critical fallback if OrderManager is outdated, but logs the orphan risk
-                    LOGGER.error("❌ OrderManager missing 'place_bracket_order'. Placing ORPHAN trade.")
+                    LOGGER.error(
+                        "❌ OrderManager missing 'place_bracket_order'. Placing ORPHAN trade."
+                    )
                     broker_order_id = await asyncio.to_thread(
                         self.executor.place_order,
                         symbol=symbol,
@@ -211,13 +305,16 @@ class OrderProcessor:
                         quantity=qty,
                         order_type=order_type,
                         price=price,
-                        tag=strategy_name
+                        tag=strategy_name,
                     )
             else:
                 # Standard Execution for Exits or Naked Entries (if missing SL/TP)
                 if not is_exit:
-                    LOGGER.warning(f"⚠️ Executing NAKED ENTRY for {symbol} (Missing SL/TP in signal)")
-                
+                    LOGGER.warning(
+                        "⚠️ Executing NAKED ENTRY for %s (Missing SL/TP in signal)",
+                        symbol,
+                    )
+
                 broker_order_id = await asyncio.to_thread(
                     self.executor.place_order,
                     symbol=symbol,
@@ -225,35 +322,43 @@ class OrderProcessor:
                     quantity=qty,
                     order_type=order_type,
                     price=price,
-                    tag=strategy_name
+                    tag=strategy_name,
                 )
-            
+
             # ✅ FIX 3: Update message with strategy source
+            entry_id = broker_order_id
+            stop_id = None
+            target_id = None
+            if isinstance(broker_order_id, tuple) and len(broker_order_id) == 3:
+                entry_id, stop_id, target_id = broker_order_id
             await self.bus.publish(
                 Message(
                     type=MessageType.ORDER_UPDATE,
                     timestamp=datetime.now(timezone.utc),
                     data={
-                        "order_id": broker_order_id,
+                        "order_id": entry_id,
                         "symbol": symbol,
                         "status": "SUBMITTED",
                         "price": price,
                         "side": side,
-                        "strategy": strategy_name
+                        "strategy": strategy_name,
+                        "stop_order_id": stop_id,
+                        "target_order_id": target_id,
+                        "trailing_spec": trailing_spec,
                     },
-                    source="order_processor"
+                    source="order_processor",
                 )
             )
 
-        except Exception as exc:
-            LOGGER.error(f"❌ Order Execution Failed: {exc}", exc_info=True)
-            
+        except Exception as exc:  # noqa: BLE001
+            LOGGER.error("❌ Order Execution Failed: %s", exc, exc_info=exc)
+
             await self.bus.publish(
                 Message(
                     type=MessageType.ORDER_UPDATE,
                     timestamp=datetime.now(timezone.utc),
                     data={"status": "REJECTED", "symbol": symbol, "error": str(exc)},
-                    source="order_processor"
+                    source="order_processor",
                 )
             )
         finally:

--- a/tests/test_order_processor.py
+++ b/tests/test_order_processor.py
@@ -1,0 +1,111 @@
+from datetime import datetime, timezone
+
+import pytest
+
+from nifty_scalper_bot.core.message_bus import Message, MessageType
+from nifty_scalper_bot.execution.order_processor import OrderProcessor
+
+
+class DummyBus:
+    def __init__(self) -> None:
+        self.published: list[Message] = []
+
+    async def publish(self, message: Message) -> None:
+        self.published.append(message)
+
+    async def subscribe(self, _message_type: MessageType, _handler) -> None:
+        return None
+
+
+class DummyOrderManager:
+    def __init__(self) -> None:
+        self.bracket_calls: list[dict] = []
+        self.order_calls: list[dict] = []
+
+    def start_monitoring(self) -> None:
+        return None
+
+    def stop_monitoring(self) -> None:
+        return None
+
+    def place_bracket_order(self, **kwargs):
+        self.bracket_calls.append(kwargs)
+        return ("entry-1", "stop-1", "target-1")
+
+    def place_order(self, **kwargs):
+        self.order_calls.append(kwargs)
+        return "order-1"
+
+
+class DummyRiskManager:
+    def __init__(self) -> None:
+        self.last_signal = None
+
+    def check_order(self, signal, live_enabled: bool):
+        self.last_signal = signal
+        return True, ""
+
+
+class DummyPositionManager:
+    def get_position(self, _symbol: str):
+        return None
+
+    def get_all_positions(self):
+        return []
+
+
+class DummyDataHub:
+    def __init__(self, price: float) -> None:
+        self.price = price
+
+    def get_quote(self, _symbol: str, allow_pull: bool = False):
+        return {"ltp": self.price}
+
+
+@pytest.mark.asyncio
+async def test_order_processor_bracket_update_tracks_ids_and_trailing():
+    bus = DummyBus()
+    order_manager = DummyOrderManager()
+    risk_manager = DummyRiskManager()
+    pos_manager = DummyPositionManager()
+    data_hub = DummyDataHub(price=100.0)
+
+    processor = OrderProcessor(
+        message_bus=bus,
+        safe_order_manager=order_manager,
+        risk_manager=risk_manager,
+        position_manager=pos_manager,
+        data_hub=data_hub,
+    )
+    processor._running = True
+
+    payload = {
+        "symbol": "NFO:TEST",
+        "side": "BUY",
+        "quantity": 1,
+        "price": 0.0,
+        "stop_loss": 95.0,
+        "take_profit": 110.0,
+        "strategy_name": "test_strategy",
+        "metadata": {"trailing_spec": {"kind": "atr", "mult": 1.0}},
+    }
+
+    message = Message(
+        type=MessageType.SIGNAL,
+        timestamp=datetime.now(timezone.utc),
+        data=payload,
+        source="test",
+    )
+
+    await processor.on_strategy_signal(message)
+
+    assert risk_manager.last_signal is not None
+    assert risk_manager.last_signal.price == 100.0
+    assert order_manager.bracket_calls
+    assert bus.published
+
+    update = bus.published[0].data
+    assert update["order_id"] == "entry-1"
+    assert update["stop_order_id"] == "stop-1"
+    assert update["target_order_id"] == "target-1"
+    assert update["trailing_spec"] == {"kind": "atr", "mult": 1.0}


### PR DESCRIPTION
### Motivation
- Ensure the order processor reliably registers and surfaces bracket/trailing metadata and does not accept ambiguous signals or missing prices before sending orders.
- Improve observability and safety by running risk gating at execution time and emitting consistent structured logs for order lifecycle events.

### Description
- Reworked `OrderProcessor` to use the unified logger via `get_logger` and added `_resolve_trade_price` to derive LTP when signal price is missing or zero.
- Validate signal `side` values, construct an `OrderSignal` and call `RiskManager.check_order` (instead of the old non-existent helper), and gate entries accordingly.
- Force bracket execution for entries when valid `stop_loss`/`take_profit` exist and propagate `trailing_spec` into `place_bracket_order` calls and the published `ORDER_UPDATE` payload, exposing `order_id`, `stop_order_id`, `target_order_id`, and `trailing_spec` for downstream tracking.
- Subscribe to the canonical bus event `MessageType.SIGNAL` and harden start/stop subscribe/monitoring calls with defensive exception logging, and added a focused integration test `tests/test_order_processor.py` that asserts bracket IDs and trailing spec are propagated.

### Testing
- Formatting and import ordering were applied with `black .` and `isort .`, and these succeeded locally.
- Lint/type checks: `ruff check .` reported issues (20 errors) and `mypy src` reported typing issues across the repository (362 errors); these failures are inherited from pre-existing repo-wide findings and not introduced by this change.
- Full CI-style run: executed `bash ./run_checks.sh` which installed deps but the check run surfaced the same `ruff`/`mypy` failures and a test import error (`ImportError: cannot import name '_format_chain_summary' from nifty_scalper_bot.notifications.telegram_commands`) that prevented the test suite from completing.
- Targeted test: added and exercised `tests/test_order_processor.py` locally via the processor entry point, but the repository-level `pytest` run aborts early due to the unrelated import error above, so the focused test could not be validated in the full test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986209f305483248e27760ed09827a1)