### PR TITLE
fix: normalize signal confidence weighting

### DIFF
--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -1234,7 +1234,7 @@ class StrategyRunner:
         self,
         signals: list[Signal],
     ) -> dict[str, Signal]:
-        """Aggregate strategy signals by symbol to limit duplicated risk."""
+        """Aggregate by symbol with confidence weights. Args: signals. Returns: Aggregated signals. Raises: None."""
         self._logger.debug(
             "Entered StrategyRunner.aggregate_signals_by_symbol",
             extra={"event": "aggregate_signals_enter", "count": len(signals)},
@@ -1280,8 +1280,15 @@ class StrategyRunner:
                     )
                     continue
 
-                avg_confidence = sum(sig.confidence for sig in symbol_signals) / len(
-                    symbol_signals
+                normalized_confidences = [
+                    self._normalize_confidence(sig.confidence)
+                    for sig in symbol_signals
+                ]
+                weight_sum = sum(conf**2 for conf in normalized_confidences)
+                avg_confidence = (
+                    sum(conf * (conf**2) for conf in normalized_confidences) / weight_sum
+                    if weight_sum > 0
+                    else 0.0
                 )
 
                 stop_candidates = [
@@ -1296,13 +1303,19 @@ class StrategyRunner:
                     if isinstance(sig.take_profit, (int, float))
                 ]
 
-                best_signal = max(symbol_signals, key=lambda sig: sig.confidence)
+                best_signal = max(
+                    symbol_signals,
+                    key=lambda sig: self._normalize_confidence(sig.confidence),
+                )
                 metadata = dict(best_signal.metadata)
                 metadata["aggregated_count"] = len(symbol_signals)
                 metadata["aggregated_sources"] = [
                     {
                         "strategy": sig.metadata.get("strategy"),
                         "confidence": sig.confidence,
+                        "normalized_confidence": self._normalize_confidence(
+                            sig.confidence
+                        ),
                         "reason": sig.reason,
                     }
                     for sig in symbol_signals
@@ -1349,6 +1362,26 @@ class StrategyRunner:
             return {}
 
         return aggregated
+
+    def _normalize_confidence(self, value: float) -> float:
+        """Normalize confidence to 0-1. Args: value. Returns: Normalized confidence. Raises: None."""
+        self._logger.debug(
+            "Entered StrategyRunner._normalize_confidence",
+            extra={"event": "normalize_confidence"},
+        )
+        try:
+            scaled = float(value)
+            if scaled > 1.0:
+                scaled /= 100.0
+            return min(1.0, max(0.0, scaled))
+        except Exception as exc:
+            self._logger.error(
+                "Failure in StrategyRunner._normalize_confidence: %s",
+                exc,
+                extra={"event": "normalize_confidence_error"},
+                exc_info=exc,
+            )
+            return 0.0
 
     def _select_best_option(
         self,

--- a/src/nifty_scalper_bot/strategies/signal_generator.py
+++ b/src/nifty_scalper_bot/strategies/signal_generator.py
@@ -1452,57 +1452,105 @@ class StrategyManager:
         return None
 
     def _combine_signals_ensemble(self, signals: list[Signal]) -> Signal | None:
-        """
-        ✅ NEW: Combine multiple strategy signals using weighted voting.
-
-        Ensures all strategies get fair consideration instead of VWAP dominance.
-        """
-        if not signals:
-            return None
-
-        if len(signals) == 1:
-            return signals[0]
-
-        # Separate by action
-        buy_signals = [s for s in signals if s.action == "BUY"]
-        sell_signals = [s for s in signals if s.action == "SELL"]
-
-        # Calculate weighted votes
-        buy_weight = sum(s.confidence for s in buy_signals)
-        sell_weight = sum(s.confidence for s in sell_signals)
-
-        logger.info(
-            f"📊 Ensemble: BUY={len(buy_signals)} ({buy_weight:.1f}), "
-            f"SELL={len(sell_signals)} ({sell_weight:.1f})"
+        """Combine signals using confidence weights. Args: signals. Returns: Signal|None. Raises: None."""
+        self._logger.debug(
+            "Entered StrategyManager._combine_signals_ensemble",
+            extra={"event": "ensemble_enter", "count": len(signals)},
         )
+        try:
+            if not signals:
+                return None
 
-        # Determine winner
-        if buy_weight > sell_weight and buy_signals:
-            # Use the highest confidence BUY signal as base
-            best = max(buy_signals, key=lambda s: s.confidence)
-            # Average confidence across all BUY signals
-            avg_conf = buy_weight / len(buy_signals)
-            return dataclasses.replace(
-                best,
-                confidence=min(avg_conf, 99.0),
-                metadata={
-                    **(best.metadata or {}),
-                    "ensemble_count": len(buy_signals),
-                    "ensemble_weight": round(buy_weight, 2),
+            if len(signals) == 1:
+                return signals[0]
+
+            def _normalize_confidence(value: float) -> float:
+                scaled = float(value)
+                if scaled > 1.0:
+                    scaled /= 100.0
+                return max(0.0, min(1.0, scaled))
+
+            normalized: list[tuple[Signal, float]] = [
+                (signal, _normalize_confidence(signal.confidence))
+                for signal in signals
+            ]
+
+            buy_signals = [
+                (signal, conf)
+                for signal, conf in normalized
+                if signal.action == "BUY"
+            ]
+            sell_signals = [
+                (signal, conf)
+                for signal, conf in normalized
+                if signal.action == "SELL"
+            ]
+
+            buy_weight = sum(conf**2 for _, conf in buy_signals)
+            sell_weight = sum(conf**2 for _, conf in sell_signals)
+
+            suppressed = [
+                signal
+                for signal, conf in normalized
+                if conf < float(self._min_confidence)
+            ]
+
+            self._logger.info(
+                "Condition met: ensemble_weighted_vote",
+                extra={
+                    "event": "ensemble_weighted_vote",
+                    "buy_count": len(buy_signals),
+                    "sell_count": len(sell_signals),
+                    "buy_weight": round(buy_weight, 4),
+                    "sell_weight": round(sell_weight, 4),
+                    "suppressed": len(suppressed),
                 },
             )
-        elif sell_signals:
-            best = max(sell_signals, key=lambda s: s.confidence)
-            avg_conf = sell_weight / len(sell_signals)
-            return dataclasses.replace(
-                best,
-                confidence=min(avg_conf, 99.0),
-                metadata={
-                    **(best.metadata or {}),
-                    "ensemble_count": len(sell_signals),
-                    "ensemble_weight": round(sell_weight, 2),
-                },
+
+            if buy_weight > sell_weight and buy_signals:
+                best_signal, _ = max(buy_signals, key=lambda item: item[1])
+                weight_sum = sum(conf**2 for _, conf in buy_signals)
+                avg_conf = (
+                    sum(conf * (conf**2) for _, conf in buy_signals) / weight_sum
+                    if weight_sum > 0
+                    else 0.0
+                )
+                return dataclasses.replace(
+                    best_signal,
+                    confidence=min(avg_conf, 1.0),
+                    metadata={
+                        **(best_signal.metadata or {}),
+                        "ensemble_count": len(buy_signals),
+                        "ensemble_weight": round(buy_weight, 4),
+                        "ensemble_suppressed": len(suppressed),
+                    },
+                )
+            if sell_signals:
+                best_signal, _ = max(sell_signals, key=lambda item: item[1])
+                weight_sum = sum(conf**2 for _, conf in sell_signals)
+                avg_conf = (
+                    sum(conf * (conf**2) for _, conf in sell_signals) / weight_sum
+                    if weight_sum > 0
+                    else 0.0
+                )
+                return dataclasses.replace(
+                    best_signal,
+                    confidence=min(avg_conf, 1.0),
+                    metadata={
+                        **(best_signal.metadata or {}),
+                        "ensemble_count": len(sell_signals),
+                        "ensemble_weight": round(sell_weight, 4),
+                        "ensemble_suppressed": len(suppressed),
+                    },
+                )
+        except Exception as exc:
+            self._logger.error(
+                "Failure in StrategyManager._combine_signals_ensemble: %s",
+                exc,
+                extra={"event": "ensemble_error"},
+                exc_info=exc,
             )
+            return None
 
         return None
 


### PR DESCRIPTION
### Motivation
- Strategy signals arrived with inconsistent confidence scales and the ensemble voting was biased by raw values, causing suboptimal selection and potential misexecution.
- The goal was to make confidence handling deterministic and robust by normalizing inputs, biasing aggregation toward higher-confidence contributors, and surfacing diagnostics for suppressed low-confidence signals.

### Description
- Normalize strategy confidence values to the 0.0–1.0 range before any aggregation or ensemble voting and guard against common formats (e.g., 80 vs 0.80) in `StrategyManager._combine_signals_ensemble` (`src/nifty_scalper_bot/strategies/signal_generator.py`).
- Use squared-confidence weighting to favor higher-confidence signals when computing buy/sell ensemble weights and compute a weighted average confidence for the chosen action, with suppressed-count metadata and structured logging when votes are computed.
- Replace simple averaging with confidence-weighted aggregation per-symbol in `StrategyRunner.aggregate_signals_by_symbol` (`src/nifty_scalper_bot/strategies/runner.py`) and select the best signal using normalized confidence while annotating `metadata` with `normalized_confidence` for traceability.
- Add `_normalize_confidence` helper to `StrategyRunner` with debug/error logs and keep all public function signatures unchanged while adding defensive error handling and logging around ensemble combination.

### Testing
- Ran `bash ./run_checks.sh` after changes to exercise installation, lint, mypy and tests; the script executed but did not fully pass due to repository-wide static typing issues and a failing test import; see output below for summary.
- `run_checks.sh` produced many `mypy`/lint findings across the repo and `pytest` stopped with an import error: `cannot import name '_format_chain_summary'` in `tests/notifications/test_telegram_commands.py`, so automated test suite did not fully pass.

Command output excerpt (full output is attached in run logs):
```
=== run_checks.sh: starting in /workspace/nifty_scalper_bot ===
...Found 362 errors in 46 files (checked 190 source files)
--- Running pytest ---
ERROR collecting tests/notifications/test_telegram_commands.py
ImportError: cannot import name '_format_chain_summary' from 'nifty_scalper_bot.notifications.telegram_commands'
```

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987041ad52c8324a7dcd6d766968770)