### PR TITLE
fix: default websocket streaming mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ pytest
 | `BROKER_ACCESS_TOKEN` | Optional session token | `None` |
 | `BROKER_BASE_URL` | REST endpoint base | `https://api.example.com` |
 | `BROKER_WS_URL` | WebSocket endpoint | `wss://ws.example.com/stream` |
+| `STREAM__MODE` | Market data streaming mode (`websocket` or `poll`) | `websocket` |
+| `WEBSOCKET__DISABLED` | Disable websocket transport when `true` | `false` |
 | `BROKER_REST_CACHE_TTL_SEC` | Broker REST cache TTL for positions/margins fallback | `15.0` |
 | `BROKER_MARGIN_SEGMENT` | Zerodha margin segment to inspect (`equity` or `commodity`) | `equity` |
 | `LOG_LEVEL` | Logging level | `INFO` |

--- a/src/nifty_scalper_bot/config/settings.py
+++ b/src/nifty_scalper_bot/config/settings.py
@@ -1320,7 +1320,7 @@ def get_settings() -> Settings:
     """
 
     app_config = load_from_env()
-    # Streaming defaults: poll by default, WS opt-in via WEBSOCKET__DISABLED=false
+    # Streaming defaults: websocket by default, poll via STREAM__MODE=poll
     session_allow_out_of_hours = _env_bool(
         "SESSION_ALLOW_OUT_OF_HOURS",
         "SESSION__ALLOW_OUT_OF_HOURS",
@@ -1338,7 +1338,7 @@ def get_settings() -> Settings:
         notifications=_build_notification_settings(app_config),
         session_allow_out_of_hours=session_allow_out_of_hours,
         websocket_enabled=not _env_bool(
-            "WEBSOCKET__DISABLED", "WEBSOCKET_DISABLED", default=True
+            "WEBSOCKET__DISABLED", "WEBSOCKET_DISABLED", default=False
         ),
         telemetry_tags=_env_csv_strs("TELEMETRY_TAGS", "TELEMETRY__TAGS"),
         regime=_build_regime_config(),

--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -2733,8 +2733,12 @@ def initialize_components(settings: Settings | None = None) -> BotContext:
     websocket_enabled = bool(getattr(settings, "websocket_enabled", True))
     if websocket_disabled_env:
         websocket_enabled = False
-    stream_mode_raw = coalesce_str("STREAM__MODE", "STREAMING_MODE", default="poll")
-    streaming_mode = stream_mode_raw.strip().lower() or "poll"
+    stream_mode_raw = coalesce_str(
+        "STREAM__MODE",
+        "STREAMING_MODE",
+        default="websocket",
+    )
+    streaming_mode = stream_mode_raw.strip().lower() or "websocket"
     poll_enabled = coalesce_bool("POLLING__ENABLED", default=True)
     poll_interval_sec = coalesce_float("POLLING__INTERVAL_SEC", default=0.0)
     if poll_interval_sec > 10.0:
@@ -3073,7 +3077,7 @@ def initialize_components(settings: Settings | None = None) -> BotContext:
     # ------------------------------------------------------------------
     # Streamer Selection Logic (Polling vs WebSocket)
     # ------------------------------------------------------------------
-    use_websockets = os.getenv("USE_WEBSOCKETS", "false").lower() == "true"
+    use_websockets = not use_polling
     if use_websockets:
         LOGGER.info("Initializing WebSocket Streamer...")
 


### PR DESCRIPTION
### Motivation
- Reduce redundant polling by making the websocket transport the default now that WS ticks are working reliably. 
- Simplify environment-driven selection so deployments (e.g., Railway) use the more efficient transport unless polling is explicitly requested.

### Description
- Change default streaming mode to websocket by default in `initialize_components` in `src/nifty_scalper_bot/core/app.py` (use `STREAM__MODE=websocket` as default and derive usage from `use_polling`).
- Replace the `USE_WEBSOCKETS` env-var check with `use_websockets = not use_polling` so websocket activation is driven by the unified polling decision.
- Update runtime settings in `src/nifty_scalper_bot/config/settings.py` to make `WEBSOCKET__DISABLED` default to `false` (so websockets are enabled by default) and update the related comment.
- Document the new streaming environment variables (`STREAM__MODE`, `WEBSOCKET__DISABLED`) in `README.md`.

### Testing
- Ran `bash ./run_checks.sh` which installed dependencies and attempted lint/type/test steps, and the run completed until tests but reported repository-wide static issues; the script output included many lint/mypy failures and a failing pytest import: `ImportError: cannot import name '_format_chain_summary' from 'nifty_scalper_bot.notifications.telegram_commands'` causing pytest to stop; this failure is unrelated to the streaming-default change and represents pre-existing test/lint debt.
- `ruff` reported (~991) style/line-length/import ordering issues and `mypy` reported (~362) type errors across multiple files; these are present in the repository and did not originate from this change.
- No unit tests were added or modified by this change and there were no new runtime codepaths introduced beyond flipping the default transport selection.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69870583bcc48324a83d7865e6e2068a)