### PR TITLE
fix: harden tick price fallbacks

### DIFF
--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -448,6 +448,8 @@ class StrategyRunner:
         self._recently_closed: dict[str, float] = {}  # ✅ FIX: Track recently exited symbols
         self._entry_lock = threading.Lock()  # Atomic entry lock
         self._last_cumulative_volume: dict[str, int] = {}
+        self._last_valid_price: dict[str, float] = {}
+        self._last_valid_price_ts: dict[str, datetime] = {}
         self._post_exit_cooldown_seconds: float = float(
             os.getenv("POST_EXIT_COOLDOWN_SECONDS", "60.0")
         )
@@ -2049,6 +2051,70 @@ class StrategyRunner:
                     level=logging.WARNING,
                 )
                 return
+
+            price_source = 'ltp'
+            price_from_cache = False
+
+            if price <= 0:
+                best_bid = _extract_float(
+                    tick, 'best_bid', 'bid', 'best_bid_price', 'buy_price'
+                )
+                best_ask = _extract_float(
+                    tick, 'best_ask', 'ask', 'best_ask_price', 'sell_price'
+                )
+                if best_bid > 0 and best_ask > 0:
+                    price = (best_bid + best_ask) / 2.0
+                    price_source = 'book_mid'
+                elif best_bid > 0:
+                    price = best_bid
+                    price_source = 'book_bid'
+                elif best_ask > 0:
+                    price = best_ask
+                    price_source = 'book_ask'
+
+                if price > 0:
+                    log_throttled(
+                        self._logger,
+                        f'price_from_book_{symbol}',
+                        f'Condition met: tick_price_from_book ({price_source})',
+                        interval_sec=60.0,
+                        level=logging.INFO,
+                    )
+                else:
+                    last_price = self._last_valid_price.get(symbol)
+                    last_ts = self._last_valid_price_ts.get(symbol)
+                    if last_price and last_ts:
+                        max_age = 30.0 if source in ('rest', 'polling') else 5.0
+                        cache_age = (now - last_ts).total_seconds()
+                        if cache_age <= max_age:
+                            price = last_price
+                            price_source = 'cache'
+                            price_from_cache = True
+                            log_throttled(
+                                self._logger,
+                                f'price_from_cache_{symbol}',
+                                (
+                                    'Condition met: tick_price_cache_used '
+                                    f'age={cache_age:.1f}s'
+                                ),
+                                interval_sec=60.0,
+                                level=logging.INFO,
+                            )
+                        else:
+                            log_throttled(
+                                self._logger,
+                                f'price_cache_stale_{symbol}',
+                                (
+                                    'Condition met: tick_price_cache_stale '
+                                    f'age={cache_age:.1f}s'
+                                ),
+                                interval_sec=60.0,
+                                level=logging.WARNING,
+                            )
+
+            if price > 0 and not price_from_cache:
+                self._last_valid_price[symbol] = price
+                self._last_valid_price_ts[symbol] = now
 
             # Price validity check
             if price <= 0:

--- a/tests/strategies/test_runner_tick_volume.py
+++ b/tests/strategies/test_runner_tick_volume.py
@@ -58,3 +58,54 @@ def test_on_tick_uses_last_quantity_volume(
     except Exception as e:
         logger.error('Failure in test_on_tick_uses_last_quantity_volume: %s', e)
         raise
+
+
+def test_on_tick_uses_order_book_price(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify book fallback. Args: monkeypatch. Returns: None. Raises: Exception."""
+    logger = logging.getLogger(__name__)
+    try:
+        market_data = MagicMock()
+        indicator = MagicMock()
+        strategy_manager = MagicMock()
+        risk_manager = MagicMock()
+        order_manager = MagicMock()
+        position_manager = MagicMock()
+
+        risk_manager.can_trade.return_value = True
+
+        runner = StrategyRunner(
+            market_data_manager=market_data,
+            indicator_engine=indicator,
+            strategy_manager=strategy_manager,
+            risk_manager=risk_manager,
+            order_manager=order_manager,
+            position_manager=position_manager,
+            config=StrategyRunnerConfig(max_trade_history=4, min_indicator_bars=0),
+            data_hub=None,
+            strike_selector=None,
+        )
+
+        symbol = 'NFO:NIFTY2621025700PE'
+        runner._startup_timestamp = time.time()
+        monkeypatch.setattr(runner, '_is_market_open', lambda _now: True)
+
+        builder = MagicMock()
+        builder.update.return_value = None
+        runner._bar_builders[symbol] = builder
+
+        tick = {
+            'ltp': 0.0,
+            'best_bid': 100.0,
+            'best_ask': 102.0,
+            'timestamp': datetime.now(timezone.utc),
+        }
+
+        runner._on_tick(symbol, tick)
+
+        builder.update.assert_called()
+        assert builder.update.call_args[0][0] == pytest.approx(101.0)
+    except Exception as e:
+        logger.error('Failure in test_on_tick_uses_order_book_price: %s', e)
+        raise


### PR DESCRIPTION
### Motivation

- Production observed many "Invalid price (0.0)" tick skips during startup and REST/polling cycles, which caused missed bar updates and blocked downstream SL/TP monitoring. 
- Provide safe, deterministic fallbacks that do not loosen stale-tick guards and that preserve downstream invariants (bar building, position price updates).

### Description

- Added per-symbol caches `self._last_valid_price` and `self._last_valid_price_ts` to `StrategyRunner` to remember the most recent valid price and timestamp.  
- Implemented robust price fallback inside `_on_tick`: if LTP is non-positive, use order-book mid (best_bid+best_ask)/2 or best_bid/best_ask when available, otherwise fall back to cached last valid price bounded by age (different max age for `rest/polling` vs streaming).  
- Emit throttled diagnostic logs for each fallback path (`price_from_book_*`, `price_from_cache_*`, `price_cache_stale_*`) and only update the cache for non-cache fallbacks.  
- Kept existing stale-tick and volume validation rules intact and preserved warmup behavior and bar-building flow.  
- Added unit test `test_on_tick_uses_order_book_price` in `tests/strategies/test_runner_tick_volume.py` to verify the order-book mid-price fallback when `ltp` is zero.  
- Ran automatic formatting (`black`, `isort`) on affected files for style consistency.

Files changed: `src/nifty_scalper_bot/strategies/runner.py`, `tests/strategies/test_runner_tick_volume.py`.

### Testing

- Ran formatting: `black .` succeeded and `isort .` succeeded.  
- Ran lint: `ruff check .` failed due to numerous pre-existing repository lint issues unrelated to this change.  
- Ran static types: `mypy src` was not completed in the environment (pre-existing typing issues across the repo).  
- Ran tests: `pytest -q tests --disable-warnings --ignore=tests/test_live_mode.py --ignore=tests/test_health_server.py` failed during collection with an ImportError in unrelated `tests/notifications/test_telegram_commands.py` (`cannot import name '_format_chain_summary'`), so the new unit test could not be validated in the full suite.  

run_checks.sh excerpt (observed in CI run):
```
--- Running pytest ---
❌ pytest not installed but tests/ exists. Install pytest or remove tests/
```

- Summary of automated results: formatting OK; lint/type/test pipelines blocked by existing repository issues and test-import errors, not by the changes in this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698708afebc083248e83678974bd27bf)