### PR TITLE
feat: tighten strategy signal filters

### DIFF
--- a/src/nifty_scalper_bot/strategies/opening_range_breakout.py
+++ b/src/nifty_scalper_bot/strategies/opening_range_breakout.py
@@ -93,82 +93,118 @@ class OpeningRangeBreakoutStrategy(Strategy):
             "Entered OpeningRangeBreakoutStrategy.generate_signal",
             extra={"event": "opening_range_generate_enter", "symbol": symbol},
         )
-        orb_high_raw = indicators.get("opening_range_high")
-        orb_low_raw = indicators.get("opening_range_low")
-        if not isinstance(orb_high_raw, (int, float)) or not isinstance(
-            orb_low_raw, (int, float)
-        ):
-            return None
-        orb_high = float(orb_high_raw)
-        orb_low = float(orb_low_raw)
-        current_range = max(orb_high - orb_low, 0.0)
+        try:
+            orb_high_raw = indicators.get("opening_range_high")
+            orb_low_raw = indicators.get("opening_range_low")
+            if not isinstance(orb_high_raw, (int, float)) or not isinstance(
+                orb_low_raw, (int, float)
+            ):
+                return None
+            orb_high = float(orb_high_raw)
+            orb_low = float(orb_low_raw)
+            current_range = max(orb_high - orb_low, 0.0)
 
-        if not self._passes_nr7(symbol, current_range):
+            if not self._passes_nr7(symbol, current_range):
+                logger.info(
+                    "Condition met: nr7_filter_failed",
+                    extra={
+                        "event": "nr7_filter_failed",
+                        "symbol": symbol,
+                        "current_range": current_range,
+                    },
+                )
+                return None
+
             logger.info(
-                "Condition met: nr7_filter_failed",
+                "Condition met: nr7_filter_passed",
                 extra={
-                    "event": "nr7_filter_failed",
+                    "event": "nr7_filter_passed",
                     "symbol": symbol,
                     "current_range": current_range,
                 },
             )
-            return None
 
-        logger.info(
-            "Condition met: nr7_filter_passed",
-            extra={
-                "event": "nr7_filter_passed",
-                "symbol": symbol,
-                "current_range": current_range,
-            },
-        )
+            if position:
+                # Skip entries if position already open to avoid duplicates.
+                return None
 
-        if position:
-            # Skip entries if position already open to avoid duplicates.
-            return None
+            direction = indicators.get("orb_break_direction")
+            entry_raw = indicators.get("orb_entry_price")
+            if not isinstance(entry_raw, (int, float)):
+                entry_price = current_price
+            else:
+                entry_price = float(entry_raw)
+            breakout_buffer = max(current_range * 0.05, 0.5)
+            side: Literal["BUY", "SELL"]
+            stop_loss_price: float | None
+            take_profit_price: float | None
+            if direction == "UP":
+                if entry_price <= orb_high + breakout_buffer:
+                    logger.info(
+                        "Condition met: breakout_buffer_unmet",
+                        extra={
+                            "event": "opening_range_buffer_failed",
+                            "symbol": symbol,
+                            "direction": "UP",
+                            "entry_price": entry_price,
+                            "orb_high": orb_high,
+                            "buffer": breakout_buffer,
+                        },
+                    )
+                    return None
+                side = "BUY"
+                stop_loss_price, take_profit_price = self._ensure_rr(
+                    "BUY", entry_price, orb_low, desired_rr=2.0
+                )
+            elif direction == "DOWN":
+                if entry_price >= orb_low - breakout_buffer:
+                    logger.info(
+                        "Condition met: breakout_buffer_unmet",
+                        extra={
+                            "event": "opening_range_buffer_failed",
+                            "symbol": symbol,
+                            "direction": "DOWN",
+                            "entry_price": entry_price,
+                            "orb_low": orb_low,
+                            "buffer": breakout_buffer,
+                        },
+                    )
+                    return None
+                side = "SELL"
+                stop_loss_price, take_profit_price = self._ensure_rr(
+                    "SELL", entry_price, orb_high, desired_rr=2.0
+                )
+            else:
+                return None
 
-        direction = indicators.get("orb_break_direction")
-        entry_raw = indicators.get("orb_entry_price")
-        if not isinstance(entry_raw, (int, float)):
-            entry_price = current_price
-        else:
-            entry_price = float(entry_raw)
-        side: Literal["BUY", "SELL"]
-        stop_loss_price: float | None
-        take_profit_price: float | None
-        if direction == "UP":
-            side = "BUY"
-            stop_loss_price, take_profit_price = self._ensure_rr(
-                "BUY", entry_price, orb_low, desired_rr=2.0
+            if stop_loss_price is None or take_profit_price is None:
+                return None
+
+            reason = "Opening range breakout with NR7 confirmation"
+            metadata = {
+                "strategy": self.name,
+                "orb_high": orb_high,
+                "orb_low": orb_low,
+                "nr7": True,
+                "breakout_buffer": breakout_buffer,
+            }
+            return Signal(
+                action=side,
+                symbol=symbol,
+                quantity=1,
+                confidence=self._bounded_confidence(0.6),
+                reason=reason,
+                stop_loss=stop_loss_price,
+                take_profit=take_profit_price,
+                metadata=metadata,
             )
-        elif direction == "DOWN":
-            side = "SELL"
-            stop_loss_price, take_profit_price = self._ensure_rr(
-                "SELL", entry_price, orb_high, desired_rr=2.0
+        except Exception as exc:  # noqa: BLE001
+            logger.error(
+                "Failure in OpeningRangeBreakoutStrategy.generate_signal: %s",
+                exc,
+                extra={"event": "opening_range_generate_error", "symbol": symbol},
             )
-        else:
             return None
-
-        if stop_loss_price is None or take_profit_price is None:
-            return None
-
-        reason = "Opening range breakout with NR7 confirmation"
-        metadata = {
-            "strategy": self.name,
-            "orb_high": orb_high,
-            "orb_low": orb_low,
-            "nr7": True,
-        }
-        return Signal(
-            action=side,
-            symbol=symbol,
-            quantity=1,
-            confidence=self._bounded_confidence(0.6),
-            reason=reason,
-            stop_loss=stop_loss_price,
-            take_profit=take_profit_price,
-            metadata=metadata,
-        )
 
     def _passes_nr7(self, symbol: str, current_range: float) -> bool:
         """Return ``True`` when current range is narrowest of last seven.

--- a/src/nifty_scalper_bot/strategies/vwap_mean_reversion.py
+++ b/src/nifty_scalper_bot/strategies/vwap_mean_reversion.py
@@ -129,6 +129,23 @@ class VWAPMeanReversionStrategy:
             if vwap > 0:
                 deviation = (spot_price - vwap) / vwap
             threshold = self._threshold_pct
+            volatility_pct = 0.0
+            if len(closes) > 1 and vwap > 0:
+                mean_close = sum(closes) / len(closes)
+                variance = sum(
+                    (close - mean_close) ** 2 for close in closes
+                ) / len(closes)
+                volatility_pct = (variance**0.5) / vwap
+                threshold = max(threshold, volatility_pct * 0.5)
+            logger.debug(
+                "Computed VWAP volatility-adjusted threshold",
+                extra={
+                    "event": "vwap_mean_reversion_threshold",
+                    "base_threshold_pct": self._threshold_pct,
+                    "dynamic_threshold_pct": threshold,
+                    "volatility_pct": volatility_pct,
+                },
+            )
             if deviation <= -threshold:
                 action: Literal["BUY", "SELL", "HOLD"] = "BUY"
                 reason = "spot_below_vwap"
@@ -145,6 +162,7 @@ class VWAPMeanReversionStrategy:
                 "total_volume": total_volume,
                 "bars_used": len(closes),
                 "threshold_pct": threshold,
+                "volatility_pct": volatility_pct,
             }
             logger.info(
                 "Condition met: vwap_signal_computed",

--- a/tests/strategies/test_opening_range_breakout.py
+++ b/tests/strategies/test_opening_range_breakout.py
@@ -106,3 +106,19 @@ def test_generate_signal_handles_provider_errors() -> None:
     signal = strategy.generate_signal("NIFTY24JANFUT", indicators, 126.0, None)
 
     assert signal is None
+
+
+def test_generate_signal_blocks_on_breakout_buffer() -> None:
+    """Strategy should skip signals that do not clear the breakout buffer."""
+
+    strategy = OpeningRangeBreakoutStrategy()
+    indicators = {
+        "opening_range_high": 25.0,
+        "opening_range_low": 24.0,
+        "orb_break_direction": "UP",
+        "orb_entry_price": 25.1,
+    }
+
+    signal = strategy.generate_signal("NIFTY24JANFUT", indicators, 25.1, None)
+
+    assert signal is None

--- a/tests/strategies/test_vwap_mean_reversion.py
+++ b/tests/strategies/test_vwap_mean_reversion.py
@@ -27,6 +27,8 @@ def test_vwap_strategy_generates_sell_signal() -> None:
     assert signal.reason == "spot_above_vwap"
     assert signal.metadata["total_volume"] == pytest.approx(150.0)
     assert signal.metadata["vwap"] == pytest.approx(100.231, rel=1e-3)
+    assert signal.metadata["threshold_pct"] >= 0.001
+    assert signal.metadata["volatility_pct"] >= 0.0
 
 
 def test_vwap_strategy_generates_buy_signal() -> None:
@@ -42,6 +44,8 @@ def test_vwap_strategy_generates_buy_signal() -> None:
     assert signal.action == "BUY"
     assert signal.reason == "spot_below_vwap"
     assert signal.metadata["bars_used"] == 2
+    assert signal.metadata["threshold_pct"] >= 0.001
+    assert signal.metadata["volatility_pct"] >= 0.0
 
 
 def test_vwap_strategy_returns_hold_when_volume_missing() -> None:


### PR DESCRIPTION
### Motivation
- Reduce noise-driven false entries by tightening VWAP mean-reversion thresholds with a volatility-aware adjustment. 
- Prevent weak opening-range breakouts from entering positions by requiring a small breakout buffer and making the ORB path more defensive. 
- Improve observability by emitting additional metadata and debug logs to aid post-mortem and monitoring.

### Description
- Updated `VWAPMeanReversionStrategy.generate_signal` to compute `volatility_pct` from recent closes and use it to raise the effective threshold, and added debug logging plus `volatility_pct` to the returned `metadata` (file: `src/nifty_scalper_bot/strategies/vwap_mean_reversion.py`).
- Hardened `OpeningRangeBreakoutStrategy.generate_signal` by wrapping logic in a `try/except`, adding a `breakout_buffer` gate to require the entry to clear a buffer relative to the opening range, and returning enriched `metadata` including `breakout_buffer` (file: `src/nifty_scalper_bot/strategies/opening_range_breakout.py`).
- Extended tests: added assertions to `tests/strategies/test_vwap_mean_reversion.py` to verify `threshold_pct` and `volatility_pct` in metadata and added `test_generate_signal_blocks_on_breakout_buffer` to `tests/strategies/test_opening_range_breakout.py` to validate the buffer gating.

### Testing
- Ran `bash ./run_checks.sh`; it failed during lint/type checks and pytest setup with multiple repo-wide `ruff`/`mypy` issues and pytest argument errors, so the full checks did not complete (see run output excerpt indicating many lint/mypy findings and the pytest argument error). 
- Ran `.venv/bin/pytest -q tests --disable-warnings --ignore=tests/test_live_mode.py --ignore=tests/test_health_server.py`; this run failed early with an `ImportError: cannot import name '_format_chain_summary'` from `nifty_scalper_bot.notifications.telegram_commands`, preventing the strategy tests from running to completion. 
- Unit test changes were added to cover the new gates and metadata, but a failing import elsewhere in the project blocks end-to-end test validation and needs to be fixed before CI will greenlight this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69881b5a1c4c8324a86dbeebd7503523)