### PR TITLE
fix: avoid datetime shadowing in futures metrics

### DIFF
--- a/src/nifty_scalper_bot/strategies/signal_generator.py
+++ b/src/nifty_scalper_bot/strategies/signal_generator.py
@@ -1742,8 +1742,6 @@ class StrategyManager:
             # ✅ FALLBACK: Use futures VWAP if index VWAP unavailable
             # ═══════════════════════════════════════════════════════
             if not indicators.get('nifty_index_vwap'):
-                from datetime import datetime
-
                 now = datetime.now()
                 y_str = now.strftime('%y')
                 m_str = now.strftime('%b').upper()


### PR DESCRIPTION
### Motivation
- Production logs showed "cannot access local variable 'datetime' where it is not associated with a value" originating from `StrategyManager._augment_futures_metrics` caused by a local `from datetime import datetime` that shadowed the module import.

### Description
- Remove the inner `from datetime import datetime` from `src/nifty_scalper_bot/strategies/signal_generator.py` so the function uses the module-level `datetime` and avoids the unbound-local error.

### Testing
- Ran `bash ./run_checks.sh`, which installed project dependencies but reported missing developer tools (`ruff`, `mypy`, `pytest`) so the automated test suite could not be executed (pytest not installed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698855d737008324afcdbaca2776330c)