### PR TITLE
fix: avoid datetime shadowing in futures metrics

### DIFF
--- a/src/nifty_scalper_bot/strategies/signal_generator.py
+++ b/src/nifty_scalper_bot/strategies/signal_generator.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from collections import defaultdict, deque
 import dataclasses
+import datetime as dt
 from dataclasses import dataclass, field
 from datetime import datetime, time
 import hashlib
@@ -1709,7 +1710,7 @@ class StrategyManager:
                 if index_vwap and index_vwap > 0:
                     indicators['nifty_index_vwap'] = index_vwap
 
-            cache_now = datetime.now().timestamp()
+            cache_now = dt.datetime.now().timestamp()
             if indicators.get('nifty_index_ltp') or indicators.get('nifty_index_vwap'):
                 self._last_index_ltp = indicators.get('nifty_index_ltp')
                 self._last_index_vwap = indicators.get('nifty_index_vwap')
@@ -1742,7 +1743,7 @@ class StrategyManager:
             # ✅ FALLBACK: Use futures VWAP if index VWAP unavailable
             # ═══════════════════════════════════════════════════════
             if not indicators.get('nifty_index_vwap'):
-                now = datetime.now()
+                now = dt.datetime.now()
                 y_str = now.strftime('%y')
                 m_str = now.strftime('%b').upper()
 


### PR DESCRIPTION
### Motivation
- Fix an UnboundLocalError in `StrategyManager._augment_futures_metrics` where use of `datetime.now()` was impacted by local name shadowing and prevented index/VWAP augmentation.

### Description
- Import `datetime` as `dt` and replace `datetime.now()` calls with `dt.datetime.now()` in `src/nifty_scalper_bot/strategies/signal_generator.py` so index/futures cache timestamps use the module alias and avoid shadowing (3 insertions, 2 deletions). 

### Testing
- Ran `pytest -q tests --disable-warnings --ignore=tests/test_live_mode.py --ignore=tests/test_health_server.py`, which failed with `ImportError: cannot import name '_format_chain_summary' from nifty_scalper_bot.notifications.telegram_commands`, an unrelated test import issue; running `./run_checks.sh` was not possible due to permission denied.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69886f87a2588324b48c9452d91c3b8f)