### PR TITLE
fix: harden trailing and risk sizing

### DIFF
--- a/src/nifty_scalper_bot/execution/bracket_manager.py
+++ b/src/nifty_scalper_bot/execution/bracket_manager.py
@@ -1215,132 +1215,142 @@ class BracketManager:
         - Tier 3 (4-6%): Protect 50% of profit + ATR trail
         - Tier 4 (> 6%): Protect 60% of profit + tight ATR trail
         """
+        import math
         import os
 
-        entry = bracket.entry_price
-        current_sl = bracket.sl_trigger_price
+        LOGGER.debug("Entered _calculate_tiered_trailing_sl")
 
-        if bracket.side == "SELL" and (high_water == float("inf") or high_water <= 0):
+        try:
+            entry = bracket.entry_price
+            current_sl = bracket.sl_trigger_price
+
+            if not math.isfinite(high_water) or high_water <= 0:
+                LOGGER.info(
+                    "Condition met: trailing_high_water_invalid",
+                    extra={"symbol": bracket.symbol, "side": bracket.side},
+                )
+                return None
+
+            # Configuration from environment
+            tier1_threshold = float(os.getenv("TRAIL_TIER1_PCT", "1.0"))
+            tier2_threshold = float(os.getenv("TRAIL_TIER2_PCT", "2.0"))
+            tier3_threshold = float(os.getenv("TRAIL_TIER3_PCT", "4.0"))
+            tier4_threshold = float(os.getenv("TRAIL_TIER4_PCT", "6.0"))
+
+            # ═══════════════════════════════════════════════════════════
+            # TIER 0: NO PROFIT (< 1%) - Use original SL
+            # ═══════════════════════════════════════════════════════════
+            if profit_pct < tier1_threshold:
+                return None  # No change
+
+            # ═══════════════════════════════════════════════════════════
+            # TIER 1: SMALL PROFIT (1-2%) - BREAKEVEN LOCK
+            # ═══════════════════════════════════════════════════════════
+            if tier1_threshold <= profit_pct < tier2_threshold:
+                # Lock at breakeven (entry price)
+                if bracket.side == "BUY":
+                    if entry > current_sl:
+                        LOGGER.debug(f"🔒 Tier 1: Breakeven lock at {entry:.2f}")
+                        return entry
+                else:
+                    if entry < current_sl:
+                        LOGGER.debug(f"🔒 Tier 1: Breakeven lock at {entry:.2f}")
+                        return entry
+
+            # ═══════════════════════════════════════════════════════════
+            # TIER 2: MODERATE PROFIT (2-4%) - PROTECT 40%
+            # ═══════════════════════════════════════════════════════════
+            if tier2_threshold <= profit_pct < tier3_threshold:
+                protection_pct = 0.40
+
+                if bracket.side == "BUY":
+                    profit_amount = high_water - entry
+                    protected_sl = entry + (profit_amount * protection_pct)
+                    LOGGER.debug(f"🛡️ Tier 2: 40% protection at {protected_sl:.2f}")
+                    return protected_sl
+                else:
+                    profit_amount = entry - high_water
+                    protected_sl = entry - (profit_amount * protection_pct)
+                    LOGGER.debug(f"🛡️ Tier 2: 40% protection at {protected_sl:.2f}")
+                    return protected_sl
+
+            # ═══════════════════════════════════════════════════════════
+            # TIER 3: GOOD PROFIT (4-6%) - PROTECT 50% + ATR TRAIL
+            # ═══════════════════════════════════════════════════════════
+            if tier3_threshold <= profit_pct < tier4_threshold:
+                protection_pct = 0.50
+
+                # Calculate momentum-adjusted ATR multiplier
+                momentum = self._calculate_momentum(bracket.symbol)
+                atr_mult = self._get_momentum_adjusted_atr_mult(momentum, base_mult=1.5)
+
+                if bracket.side == "BUY":
+                    # Minimum: 50% profit protection
+                    profit_amount = high_water - entry
+                    min_sl = entry + (profit_amount * protection_pct)
+
+                    # ATR trail from high water
+                    if atr > 0:
+                        atr_sl = high_water - (atr * atr_mult)
+                        # Use whichever is HIGHER (more protective)
+                        protected_sl = max(min_sl, atr_sl)
+                    else:
+                        protected_sl = min_sl
+
+                    LOGGER.debug(f"📊 Tier 3: 50% + ATR trail at {protected_sl:.2f}")
+                    return protected_sl
+                else:
+                    profit_amount = entry - high_water
+                    min_sl = entry - (profit_amount * protection_pct)
+
+                    if atr > 0:
+                        atr_sl = high_water + (atr * atr_mult)
+                        protected_sl = min(min_sl, atr_sl)
+                    else:
+                        protected_sl = min_sl
+
+                    LOGGER.debug(f"📊 Tier 3: 50% + ATR trail at {protected_sl:.2f}")
+                    return protected_sl
+
+            # ═══════════════════════════════════════════════════════════
+            # TIER 4: EXCELLENT PROFIT (> 6%) - PROTECT 60% + TIGHT TRAIL
+            # ═══════════════════════════════════════════════════════════
+            if profit_pct >= tier4_threshold:
+                protection_pct = 0.60
+
+                # Tighter ATR multiplier for big winners
+                momentum = self._calculate_momentum(bracket.symbol)
+                atr_mult = self._get_momentum_adjusted_atr_mult(momentum, base_mult=1.0)
+
+                if bracket.side == "BUY":
+                    profit_amount = high_water - entry
+                    min_sl = entry + (profit_amount * protection_pct)
+
+                    if atr > 0:
+                        atr_sl = high_water - (atr * atr_mult)
+                        protected_sl = max(min_sl, atr_sl)
+                    else:
+                        protected_sl = min_sl
+
+                    LOGGER.info(f"🏆 Tier 4: 60% + tight trail at {protected_sl:.2f}")
+                    return protected_sl
+                else:
+                    profit_amount = entry - high_water
+                    min_sl = entry - (profit_amount * protection_pct)
+
+                    if atr > 0:
+                        atr_sl = high_water + (atr * atr_mult)
+                        protected_sl = min(min_sl, atr_sl)
+                    else:
+                        protected_sl = min_sl
+
+                    LOGGER.info(f"🏆 Tier 4: 60% + tight trail at {protected_sl:.2f}")
+                    return protected_sl
+
             return None
-
-        # Configuration from environment
-        tier1_threshold = float(os.getenv("TRAIL_TIER1_PCT", "1.0"))
-        tier2_threshold = float(os.getenv("TRAIL_TIER2_PCT", "2.0"))
-        tier3_threshold = float(os.getenv("TRAIL_TIER3_PCT", "4.0"))
-        tier4_threshold = float(os.getenv("TRAIL_TIER4_PCT", "6.0"))
-
-        # ═══════════════════════════════════════════════════════════
-        # TIER 0: NO PROFIT (< 1%) - Use original SL
-        # ═══════════════════════════════════════════════════════════
-        if profit_pct < tier1_threshold:
-            return None  # No change
-
-        # ═══════════════════════════════════════════════════════════
-        # TIER 1: SMALL PROFIT (1-2%) - BREAKEVEN LOCK
-        # ═══════════════════════════════════════════════════════════
-        if tier1_threshold <= profit_pct < tier2_threshold:
-            # Lock at breakeven (entry price)
-            if bracket.side == "BUY":
-                if entry > current_sl:
-                    LOGGER.debug(f"🔒 Tier 1: Breakeven lock at {entry:.2f}")
-                    return entry
-            else:
-                if entry < current_sl:
-                    LOGGER.debug(f"🔒 Tier 1: Breakeven lock at {entry:.2f}")
-                    return entry
+        except Exception as exc:
+            LOGGER.error("Failure in _calculate_tiered_trailing_sl: %s", exc)
             return None
-
-        # ═══════════════════════════════════════════════════════════
-        # TIER 2: MODERATE PROFIT (2-4%) - PROTECT 40%
-        # ═══════════════════════════════════════════════════════════
-        if tier2_threshold <= profit_pct < tier3_threshold:
-            protection_pct = 0.40
-
-            if bracket.side == "BUY":
-                profit_amount = high_water - entry
-                protected_sl = entry + (profit_amount * protection_pct)
-                LOGGER.debug(f"🛡️ Tier 2: 40% protection at {protected_sl:.2f}")
-                return protected_sl
-            else:
-                profit_amount = entry - high_water
-                protected_sl = entry - (profit_amount * protection_pct)
-                LOGGER.debug(f"🛡️ Tier 2: 40% protection at {protected_sl:.2f}")
-                return protected_sl
-
-        # ═══════════════════════════════════════════════════════════
-        # TIER 3: GOOD PROFIT (4-6%) - PROTECT 50% + ATR TRAIL
-        # ═══════════════════════════════════════════════════════════
-        if tier3_threshold <= profit_pct < tier4_threshold:
-            protection_pct = 0.50
-
-            # Calculate momentum-adjusted ATR multiplier
-            momentum = self._calculate_momentum(bracket.symbol)
-            atr_mult = self._get_momentum_adjusted_atr_mult(momentum, base_mult=1.5)
-
-            if bracket.side == "BUY":
-                # Minimum: 50% profit protection
-                profit_amount = high_water - entry
-                min_sl = entry + (profit_amount * protection_pct)
-
-                # ATR trail from high water
-                if atr > 0:
-                    atr_sl = high_water - (atr * atr_mult)
-                    # Use whichever is HIGHER (more protective)
-                    protected_sl = max(min_sl, atr_sl)
-                else:
-                    protected_sl = min_sl
-
-                LOGGER.debug(f"📊 Tier 3: 50% + ATR trail at {protected_sl:.2f}")
-                return protected_sl
-            else:
-                profit_amount = entry - high_water
-                min_sl = entry - (profit_amount * protection_pct)
-
-                if atr > 0:
-                    atr_sl = high_water + (atr * atr_mult)
-                    protected_sl = min(min_sl, atr_sl)
-                else:
-                    protected_sl = min_sl
-
-                LOGGER.debug(f"📊 Tier 3: 50% + ATR trail at {protected_sl:.2f}")
-                return protected_sl
-
-        # ═══════════════════════════════════════════════════════════
-        # TIER 4: EXCELLENT PROFIT (> 6%) - PROTECT 60% + TIGHT TRAIL
-        # ═══════════════════════════════════════════════════════════
-        if profit_pct >= tier4_threshold:
-            protection_pct = 0.60
-
-            # Tighter ATR multiplier for big winners
-            momentum = self._calculate_momentum(bracket.symbol)
-            atr_mult = self._get_momentum_adjusted_atr_mult(momentum, base_mult=1.0)
-
-            if bracket.side == "BUY":
-                profit_amount = high_water - entry
-                min_sl = entry + (profit_amount * protection_pct)
-
-                if atr > 0:
-                    atr_sl = high_water - (atr * atr_mult)
-                    protected_sl = max(min_sl, atr_sl)
-                else:
-                    protected_sl = min_sl
-
-                LOGGER.info(f"🏆 Tier 4: 60% + tight trail at {protected_sl:.2f}")
-                return protected_sl
-            else:
-                profit_amount = entry - high_water
-                min_sl = entry - (profit_amount * protection_pct)
-
-                if atr > 0:
-                    atr_sl = high_water + (atr * atr_mult)
-                    protected_sl = min(min_sl, atr_sl)
-                else:
-                    protected_sl = min_sl
-
-                LOGGER.info(f"🏆 Tier 4: 60% + tight trail at {protected_sl:.2f}")
-                return protected_sl
-
-        return None
 
     def _get_current_atr(self, symbol: str) -> float:
         """Get current ATR from provider or cache."""

--- a/src/nifty_scalper_bot/risk/risk_manager.py
+++ b/src/nifty_scalper_bot/risk/risk_manager.py
@@ -3,14 +3,14 @@
 from __future__ import annotations
 
 import asyncio
-import os
-import threading
-import time
 from collections import deque
 from contextlib import suppress
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
+import os
 from statistics import median
+import threading
+import time
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, Literal, Mapping, Protocol
 
 from nifty_scalper_bot.execution.position_manager import Position
@@ -133,11 +133,13 @@ class RiskManager:
 
     def __post_init__(self) -> None:
         self._logger = get_logger(__name__)
-        
+
         # [ROBUSTNESS] Do not crash on 0 balance; allow API to fetch it later
         if self.account_balance <= 0:
-            self._logger.warning("Initial account_balance is 0 or negative. Waiting for DataHub refresh.")
-            if self.account_balance < 0: 
+            self._logger.warning(
+                "Initial account_balance is 0 or negative. Waiting for DataHub refresh."
+            )
+            if self.account_balance < 0:
                 self.account_balance = 0.0
 
         self._cooldown_until = None
@@ -186,13 +188,15 @@ class RiskManager:
             float(get_float("RISK__BALANCE_JIT_REFRESH", default=1.0)),
         )
         self._last_log_time = 0.0
-        
+
         # [FIX] Just ensure day starts clean, but let _refresh_realized_pnl handle the sync
         import os
+
         if os.getenv("RISK__SOFT_OVERRIDE", "false").lower() == "true":
             self._switches.reset_day()
             self._breaker_tripped = False
             self._logger.info("⚠️ Risk Override Enabled: Waiting for PnL sync...")
+
     @property
     def risk_config(self) -> RiskSettings:
         """Expose the bound risk settings for telemetry consumers."""
@@ -361,7 +365,7 @@ class RiskManager:
                 extra={"event": "balance_fetch_error"},
                 exc_info=exc,
             )
-            
+
             fallback_value = cached_balance_value
             if fallback_value is None or fallback_value <= 0:
                 for candidate in (self._cached_balance, self.account_balance):
@@ -370,7 +374,7 @@ class RiskManager:
                         break
             if fallback_value is None:
                 fallback_value = self._resolve_env_balance_fallback()
-            
+
             self.account_balance = float(fallback_value)
             self._cached_balance = self.account_balance
             self._last_balance_refresh = now
@@ -517,12 +521,12 @@ class RiskManager:
             if force_refresh:
                 self.refresh_account_balance(force=True)
         except Exception as exc:  # noqa: BLE001
-            # [ROBUSTNESS] Non-blocking error handling. 
+            # [ROBUSTNESS] Non-blocking error handling.
             self._logger.warning(
                 "RiskManager balance refresh failed during check_order (using cache)",
-                extra={"error": str(exc)}
+                extra={"error": str(exc)},
             )
-        
+
         self._reset_daily_if_needed()
         self._refresh_realized_pnl()
 
@@ -607,14 +611,14 @@ class RiskManager:
             self._last_rejection = None
         return allowed, ordered
 
-
     # [FIX] Enhanced can_trade with Override Support
     def can_trade(self, symbol: str) -> bool:
         # 0. Check Override (The "God Mode" check)
         import os
+
         if os.getenv("RISK__SOFT_OVERRIDE", "false").lower() == "true":
             # If override is ON, we force trade (unless data is stale)
-            # We still check risk_gate_should_trade() because trading on 
+            # We still check risk_gate_should_trade() because trading on
             # stale data is technically impossible/dangerous, not just risky.
             stale_check, _ = self.risk_gate_should_trade()
             return stale_check
@@ -678,121 +682,131 @@ class RiskManager:
         symbol: str | None = None,
     ) -> int:
         """Return quantity respecting per-trade risk sizing with diagnostics.
-        
+
         ✅ PRODUCTION FIX: Added fallback stop_loss when None is provided.
         """
         import os
-        
-        # ✅ FIX 1: Enhanced diagnostic logging
-        self._logger.info(
-            f"📊 SIZING: {symbol} | Price={price:.2f} | SL={stop_loss} | "
-            f"ATR={atr} | ReqQty={requested_quantity} | Conf={confidence}"
-        )
 
-        # ✅ FIX 2: Generate fallback stop_loss if None (using 2% default)
-        if stop_loss is None:
-            default_sl_pct = float(os.getenv("DEFAULT_SL_PCT", "2.0"))
-            if side == "BUY":
-                stop_loss = price * (1 - default_sl_pct / 100)
-            else:
-                stop_loss = price * (1 + default_sl_pct / 100)
-            self._logger.warning(
-                f"⚠️ No SL provided, using {default_sl_pct}% fallback: {stop_loss:.2f}"
-            )
+        self._logger.debug("Entered suggest_position_size")
 
-        # Validate basic inputs (but not stop_loss anymore - we generated it above)
-        if requested_quantity <= 0 or price <= 0:
-            self._logger.warning(
-                f"❌ Risk sizing skipped: qty={requested_quantity}, price={price}"
-            )
-            return 0
-
-        sl_distance = abs(price - stop_loss)
-        if atr is not None:
-            try:
-                atr_value = float(atr)
-            except (TypeError, ValueError):
-                atr_value = 0.0
-            sl_distance = max(sl_distance, abs(atr_value))
-        
-        # ✅ FIX 3: Minimum SL distance to prevent division issues
-        min_sl_distance = price * 0.005  # 0.5% minimum
-        if sl_distance < min_sl_distance:
-            sl_distance = min_sl_distance
-            self._logger.warning(f"⚠️ SL distance too small, using minimum: {sl_distance:.2f}")
-
-        # ✅ FIX 4: Fallback account balance when 0 or negative
-        balance = self.account_balance
-        if balance <= 0:
-            balance = getattr(self, '_cached_balance', 0.0)
-        if balance <= 0:
-            balance = float(os.getenv("FALLBACK_MARGIN", "100000"))
-            self._logger.warning(f"⚠️ Using FALLBACK_MARGIN: ₹{balance:,.2f}")
-        
-        allowed_risk = balance * (self.settings.per_trade_risk_pct / 100.0)
-        
-        # ✅ FIX 5: Minimum risk allowance
-        min_risk = float(os.getenv("MIN_RISK_PER_TRADE", "500"))
-        allowed_risk = max(allowed_risk, min_risk)
-        
-        self._logger.info(
-            f"💰 Balance={balance:,.2f} | AllowedRisk={allowed_risk:.2f} | SL_Dist={sl_distance:.2f}"
-        )
-
-        confidence_value = 1.0
-        if confidence is not None:
-            try:
-                confidence_value = float(confidence)
-            except (TypeError, ValueError):
-                confidence_value = 0.0
-        confidence_value = max(0.0, min(1.0, confidence_value))
-
-        # Lot size resolution with fallback
         try:
-            lot_size = self._resolve_lot_size(symbol)
-        except (RuntimeError, ValueError) as exc:
-            self._logger.warning(f"Cannot resolve lot size for {symbol}: {exc}")
-            lot_size = int(os.getenv("DEFAULT_LOT_SIZE", "25"))
+            # ✅ FIX 1: Enhanced diagnostic logging
+            self._logger.info(
+                f"📊 SIZING: {symbol} | Price={price:.2f} | SL={stop_loss} | "
+                f"ATR={atr} | ReqQty={requested_quantity} | Conf={confidence}"
+            )
 
-        max_units_by_risk = int(allowed_risk // sl_distance)
-        
-        self._logger.info(f"📈 MaxUnits={max_units_by_risk} | LotSize={lot_size}")
-        
-        # ✅ FIX 6: Force minimum 1 lot when capital exists
-        if max_units_by_risk < lot_size:
-            if balance > 0:
-                one_lot_risk = lot_size * sl_distance
-                if one_lot_risk > (allowed_risk * 2.0):
-                    self._logger.warning(
-                        "⚠️ Skipping trade: 1 lot risk exceeds 2x allowed risk"
-                    )
-                    return 0
+            # ✅ FIX 2: Generate fallback stop_loss if None (using 2% default)
+            if stop_loss is None:
+                default_sl_pct = float(os.getenv("DEFAULT_SL_PCT", "2.0"))
+                if side == "BUY":
+                    stop_loss = price * (1 - default_sl_pct / 100)
+                else:
+                    stop_loss = price * (1 + default_sl_pct / 100)
                 self._logger.warning(
-                    "⚠️ Forcing minimum 1 lot (capital insufficient for standard sizing)"
+                    f"⚠️ No SL provided, using {default_sl_pct}% fallback: {stop_loss:.2f}"
                 )
-                return lot_size
+
+            # Validate basic inputs (but not stop_loss anymore - we generated it above)
+            if requested_quantity <= 0 or price <= 0:
+                self._logger.warning(
+                    f"❌ Risk sizing skipped: qty={requested_quantity}, price={price}"
+                )
+                return 0
+
+            sl_distance = abs(price - stop_loss)
+            if atr is not None:
+                try:
+                    atr_value = float(atr)
+                except (TypeError, ValueError):
+                    atr_value = 0.0
+                sl_distance = max(sl_distance, abs(atr_value))
+
+            # ✅ FIX 3: Minimum SL distance to prevent division issues
+            min_sl_distance = price * 0.005  # 0.5% minimum
+            if sl_distance < min_sl_distance:
+                sl_distance = min_sl_distance
+                self._logger.warning(
+                    f"⚠️ SL distance too small, using minimum: {sl_distance:.2f}"
+                )
+
+            # ✅ FIX 4: Fallback account balance when 0 or negative
+            balance = self.account_balance
+            if balance <= 0:
+                balance = getattr(self, "_cached_balance", 0.0)
+            if balance <= 0:
+                balance = float(os.getenv("FALLBACK_MARGIN", "100000"))
+                self._logger.warning(f"⚠️ Using FALLBACK_MARGIN: ₹{balance:,.2f}")
+
+            allowed_risk = balance * (self.settings.per_trade_risk_pct / 100.0)
+
+            # ✅ FIX 5: Minimum risk allowance
+            min_risk = float(os.getenv("MIN_RISK_PER_TRADE", "500"))
+            allowed_risk = max(allowed_risk, min_risk)
+
+            self._logger.info(
+                f"💰 Balance={balance:,.2f} | AllowedRisk={allowed_risk:.2f} | "
+                f"SL_Dist={sl_distance:.2f}"
+            )
+
+            confidence_value = 1.0
+            if confidence is not None:
+                try:
+                    confidence_value = float(confidence)
+                except (TypeError, ValueError):
+                    confidence_value = 0.0
+            confidence_value = max(0.0, min(1.0, confidence_value))
+
+            # Lot size resolution with fallback
+            try:
+                lot_size = self._resolve_lot_size(symbol)
+            except (RuntimeError, ValueError) as exc:
+                self._logger.warning(f"Cannot resolve lot size for {symbol}: {exc}")
+                lot_size = int(os.getenv("DEFAULT_LOT_SIZE", "25"))
+
+            max_units_by_risk = int(allowed_risk // sl_distance)
+
+            self._logger.info(f"📈 MaxUnits={max_units_by_risk} | LotSize={lot_size}")
+
+            # ✅ FIX 6: Force minimum 1 lot when capital exists
+            if max_units_by_risk < lot_size:
+                if balance > 0:
+                    one_lot_risk = lot_size * sl_distance
+                    if one_lot_risk > allowed_risk:
+                        self._logger.warning(
+                            "⚠️ Skipping trade: 1 lot risk exceeds allowed risk"
+                        )
+                        return 0
+                    self._logger.warning(
+                        "⚠️ Forcing minimum 1 lot (capital insufficient for standard sizing)"
+                    )
+                    return lot_size
+                return 0
+
+            max_lots_by_risk = max_units_by_risk // lot_size
+            scaled_lots = int(max_lots_by_risk * confidence_value)
+            if scaled_lots == 0 and confidence_value > 0.0 and max_lots_by_risk > 0:
+                scaled_lots = 1
+
+            requested_lots = requested_quantity // lot_size
+            if requested_lots == 0 and requested_quantity > 0:
+                requested_lots = 1
+
+            final_lots = min(requested_lots, scaled_lots)
+
+            # ✅ FIX 7: Ensure minimum 1 lot output when we have capital
+            if final_lots <= 0 and balance > 0:
+                final_lots = 1
+
+            final_qty = final_lots * lot_size
+            self._logger.info(
+                f"✅ FINAL QTY: {final_qty} ({final_lots} lots × {lot_size})"
+            )
+
+            return final_qty
+        except Exception as exc:
+            self._logger.error("Failure in suggest_position_size: %s", exc)
             return 0
-
-        max_lots_by_risk = max_units_by_risk // lot_size
-        scaled_lots = int(max_lots_by_risk * confidence_value)
-        if scaled_lots == 0 and confidence_value > 0.0 and max_lots_by_risk > 0:
-            scaled_lots = 1
-
-        requested_lots = requested_quantity // lot_size
-        if requested_lots == 0 and requested_quantity > 0:
-            requested_lots = 1
-
-        final_lots = min(requested_lots, scaled_lots)
-        
-        # ✅ FIX 7: Ensure minimum 1 lot output when we have capital
-        if final_lots <= 0 and balance > 0:
-            final_lots = 1
-
-        final_qty = final_lots * lot_size
-        self._logger.info(f"✅ FINAL QTY: {final_qty} ({final_lots} lots × {lot_size})")
-        
-        return final_qty
-        
 
     def set_lot_size_provider(
         self, lookup: Callable[[str], int] | None, *, symbol: str | None = None
@@ -807,7 +821,7 @@ class RiskManager:
         # 1. Try the wired lookup function (Primary)
         lookup = self._lot_size_lookup
         target_symbol = symbol or self._lot_size_symbol
-        
+
         if lookup is not None and callable(lookup) and target_symbol:
             try:
                 resolved = lookup(target_symbol)
@@ -815,14 +829,14 @@ class RiskManager:
                 if lot_size > 0:
                     return lot_size
             except Exception:
-                pass # Fallthrough to settings
-        
+                pass  # Fallthrough to settings
+
         # 2. Fallback to Settings (Safety Net)
         # Your settings.py already defaults contract_lot_size to 75. Use it!
         if hasattr(self.settings, "contract_lot_size"):
-             default_size = int(self.settings.contract_lot_size)
-             if default_size > 0:
-                 return default_size
+            default_size = int(self.settings.contract_lot_size)
+            if default_size > 0:
+                return default_size
 
         # 3. Last Resort Hardcoded Fallback
         return 75
@@ -985,16 +999,17 @@ class RiskManager:
         """
         current = float(self.position_manager.get_realized_pnl())
         delta = current - self._last_pnl_snapshot
-        
+
         if abs(delta) < 1e-6:
             return
 
         # [FIX] Zombie Data Protection
-        # If we see a massive drop AND we have the override enabled, 
+        # If we see a massive drop AND we have the override enabled,
         # assume this is history loading and ignore the loss.
         import os
+
         is_override = os.getenv("RISK__SOFT_OVERRIDE", "false").lower() == "true"
-        
+
         # Threshold: If delta is negative and > 50% of daily limit (or just huge)
         # This catches the -11L restore event.
         if is_override and delta < 0 and abs(delta) > 5000:
@@ -1004,7 +1019,7 @@ class RiskManager:
             )
             # Sync the snapshot BUT DO NOT record the loss to switches
             self._last_pnl_snapshot = current
-            
+
             # Ensure breaker is clear
             if self._breaker_tripped:
                 self._breaker_tripped = False
@@ -1014,7 +1029,7 @@ class RiskManager:
         # Normal operation
         self._switches.record_pnl(delta)
         self._last_pnl_snapshot = current
-        
+
         try:
             METRICS.set_live_pnl(book="primary", value=current)
         except Exception:
@@ -1023,7 +1038,7 @@ class RiskManager:
             METRICS.set_pnl_breakdown(book="primary", realized=current)
         except Exception:
             pass
-            
+
         reason = self._switches.breach_reason()
         if reason:
             formatted = self._format_switch_reason(reason)
@@ -1032,9 +1047,12 @@ class RiskManager:
     def _trip_breaker(self, reason: str) -> None:  # pragma: no cover
         # [FIX] Nuclear Override: Physically prevent breaker activation
         import os
+
         if os.getenv("RISK__SOFT_OVERRIDE", "false").lower() == "true":
             if not getattr(self, "_override_log_sent", False):
-                self._logger.warning(f"🛡️ BREAKER TRIED TO TRIP BUT WAS BLOCKED BY OVERRIDE. Reason: {reason}")
+                self._logger.warning(
+                    f"🛡️ BREAKER TRIED TO TRIP BUT WAS BLOCKED BY OVERRIDE. Reason: {reason}"
+                )
                 self._override_log_sent = True
             return
 
@@ -1168,7 +1186,6 @@ class RiskManager:
             },
         )
 
-
     def _set_cooldown_metric(self, value: float) -> None:  # pragma: no cover
         try:
             self._m_cooldown.set(value)
@@ -1301,7 +1318,6 @@ class RiskState:
         """
         self._last_tick_ns = -1
         self._reasons.discard("STALE")
- 
 
     def _evaluate_spread(self, spread: float) -> None:
         if self._median_spread <= 0:

--- a/src/nifty_scalper_bot/strategies/orchestrator.py
+++ b/src/nifty_scalper_bot/strategies/orchestrator.py
@@ -10,9 +10,9 @@ Strategy orchestration utilities for capital and correlation controls.
 
 from __future__ import annotations
 
-import os
 from dataclasses import dataclass
 from datetime import datetime, timezone
+import os
 from threading import RLock
 from typing import Any, Iterable, Mapping
 
@@ -34,7 +34,7 @@ class ActiveAllocation:
     """Track strategies actively controlling an underlying."""
 
     strategy: str
-    tags: tuple[str, ...] 
+    tags: tuple[str, ...]
     timestamp: datetime
 
 
@@ -102,7 +102,7 @@ class StrategyOrchestrator:
     ) -> Any | None:
         """
         Return signal when allowed else ``None`` if blocked.
-        
+
         ✅ PRODUCTION FIX v2:
         - All filter rejections now log at INFO level for visibility
         - Reduced default rate limits for better signal throughput
@@ -112,13 +112,13 @@ class StrategyOrchestrator:
         - Added single-underlying constraint
         """
         import time
-        
+
         symbol = getattr(signal, "symbol", "")
         action = getattr(signal, "action", "")
         confidence = getattr(signal, "confidence", 0.0)
-        
+
         self._skip_reason = ""  # Reset skip reason
-        
+
         self._logger.debug(
             f"🔍 Orchestrator evaluating: {symbol} | {action} | conf={confidence:.2f}",
             extra={
@@ -127,31 +127,34 @@ class StrategyOrchestrator:
                 "action": action,
             },
         )
-        
+
         # ═══════════════════════════════════════════════════════════
         # 🛡️ FIX 1: EARLY TIME GUARD
         # ═══════════════════════════════════════════════════════════
         try:
-            from nifty_scalper_bot.utils.market_hours import is_market_hours_cached, get_time_status
-            
+            from nifty_scalper_bot.utils.market_hours import (
+                get_time_status,
+                is_market_hours_cached,
+            )
+
             if not is_market_hours_cached():
                 _, reason = get_time_status()
                 self._logger.info(
                     f"⏰ MARKET CLOSED: {symbol} blocked | Reason: {reason}",
-                    extra={"event": "orchestrator_market_closed", "symbol": symbol}
+                    extra={"event": "orchestrator_market_closed", "symbol": symbol},
                 )
                 self._set_skip_reason("market_closed")
                 return None
         except ImportError:
             pass
-        
+
         # ═══════════════════════════════════════════════════════════
         # 🛡️ FIX 2: BLOCK FUTURES TRADING
         # ═══════════════════════════════════════════════════════════
         if self._is_futures(symbol):
             self._logger.info(
                 f"🚫 FUTURES BLOCKED: {symbol} (Options Only Mode)",
-                extra={"event": "orchestrator_futures_blocked", "symbol": symbol}
+                extra={"event": "orchestrator_futures_blocked", "symbol": symbol},
             )
             self._set_skip_reason("futures_blocked")
             return None
@@ -160,10 +163,10 @@ class StrategyOrchestrator:
         # 🛡️ FIX 3: BLOCK SELL SIGNALS FOR OPTIONS BUYING STRATEGY
         # ═══════════════════════════════════════════════════════════
         options_long_only = os.getenv("OPTIONS_LONG_ONLY", "true").lower() == "true"
-        
+
         if options_long_only and action == "SELL":
             is_position_close = False
-            
+
             if position_manager:
                 try:
                     pos = position_manager.get_position(symbol)
@@ -171,31 +174,127 @@ class StrategyOrchestrator:
                         is_position_close = True
                 except Exception:
                     pass
-            
+
             if not is_position_close:
                 self._logger.info(
                     f"🛡️ SELL BLOCKED: {symbol} (Options Long Only mode, no position to close)",
-                    extra={"event": "orchestrator_sell_blocked", "symbol": symbol}
+                    extra={"event": "orchestrator_sell_blocked", "symbol": symbol},
                 )
                 self._set_skip_reason("sell_blocked_long_only")
                 return None
-        
+
         # ═══════════════════════════════════════════════════════════
         # 🛡️ FIX 6: DIRECTION CONFLICT GUARD (No simultaneous CE+PE)
         # ✅ Added 6 Feb 2026: Prevents bot from taking both CE and PE trades
         # ═══════════════════════════════════════════════════════════
         _direction = None
+        _dir_cooldown = 0.0
         if action == "BUY":
-            import time as _t
             _sym_upper = symbol.upper()
             _direction = (
-                "CE" if _sym_upper.endswith("CE")
+                "CE"
+                if _sym_upper.endswith("CE")
                 else ("PE" if _sym_upper.endswith("PE") else None)
             )
             _dir_cooldown = float(os.getenv("DIRECTION_LOCK_SECONDS", "600"))  # 10 min
 
+        # ═══════════════════════════════════════════════════════════
+        # 🛡️ FIX 4: SIGNAL FLOOD PREVENTION (Rate Limiting)
+        # ✅ CHANGED: Default reduced from 5.0 to 2.0 seconds
+        # ✅ CHANGED: Log level from DEBUG to INFO
+        # ═══════════════════════════════════════════════════════════
+        signal_cooldown = float(
+            os.getenv("ORCHESTRATOR_SIGNAL_COOLDOWN", "2.0")
+        )  # ✅ Reduced
+        now = time.time()
+
+        if (
+            action in {"BUY", "SELL"}
+            and (now - self._last_signal_time) < signal_cooldown
+        ):
+            elapsed = now - self._last_signal_time
+            self._logger.info(  # ✅ CHANGED: DEBUG → INFO
+                f"⏳ RATE LIMIT: {symbol} | Wait {signal_cooldown - elapsed:.1f}s (global {signal_cooldown}s cooldown)",
+                extra={
+                    "event": "orchestrator_rate_limit",
+                    "symbol": symbol,
+                    "cooldown": signal_cooldown,
+                },
+            )
+            self._set_skip_reason("global_rate_limit")
+            return None
+
+        # ═══════════════════════════════════════════════════════════
+        # 🛡️ FIX 5: SINGLE UNDERLYING CONSTRAINT
+        # ✅ CHANGED: Default reduced from 30.0 to 10.0 seconds
+        # ✅ CHANGED: Log level from DEBUG to INFO
+        # ═══════════════════════════════════════════════════════════
+        underlying = self._normalize_underlying(symbol)
+
+        pending_cooldown = float(
+            os.getenv("UNDERLYING_SIGNAL_COOLDOWN", "10.0")
+        )  # ✅ Reduced
+        last_underlying_signal = self._pending_underlyings.get(underlying, 0.0)
+
+        if action in {"BUY"} and (now - last_underlying_signal) < pending_cooldown:
+            elapsed = now - last_underlying_signal
+            self._logger.info(  # ✅ CHANGED: DEBUG → INFO
+                f"🛡️ UNDERLYING LIMIT: {symbol} | {underlying} | Wait {pending_cooldown - elapsed:.1f}s",
+                extra={
+                    "event": "orchestrator_underlying_limit",
+                    "symbol": symbol,
+                    "underlying": underlying,
+                },
+            )
+            self._set_skip_reason("underlying_rate_limit")
+            return None
+
+        # ═══════════════════════════════════════════════════════════
+        # STRATEGY ALLOCATION CHECKS
+        # ═══════════════════════════════════════════════════════════
+        strategy_name = self._resolve_strategy_name(signal)
+        if not strategy_name:
+            if action in {"BUY"}:
+                self._last_signal_time = now
+                self._pending_underlyings[underlying] = now
+            self._logger.info(
+                f"✅ SIGNAL PASSED (no strategy allocation): {symbol} | {action}",
+                extra={"event": "orchestrator_pass_no_allocation", "symbol": symbol},
+            )
+            return signal
+
+        allocation = self._allocations.get(strategy_name)
+        if allocation is None:
+            if action in {"BUY"}:
+                self._last_signal_time = now
+                self._pending_underlyings[underlying] = now
+            self._logger.info(
+                f"✅ SIGNAL PASSED (strategy not registered): {symbol} | {action} | {strategy_name}",
+                extra={"event": "orchestrator_pass_unregistered", "symbol": symbol},
+            )
+            return signal
+
+        if action not in {"BUY", "SELL"}:
+            return signal
+
+        if not underlying:
+            return signal
+
+        if not self._has_capital_headroom(allocation, position_manager):
+            self._logger.info(
+                f"💰 CAPITAL BLOCK: {symbol} | Strategy: {strategy_name}",
+                extra={
+                    "event": "orchestrator_capital_block",
+                    "strategy": strategy_name,
+                    "symbol": symbol,
+                },
+            )
+            self._set_skip_reason("orchestrator_capital")
+            return None
+
+        try:
             if _direction and self._active_direction:
-                _time_since_lock = _t.time() - self._direction_lock_time
+                _time_since_lock = time.time() - self._direction_lock_time
                 if (
                     self._active_direction != _direction
                     and _time_since_lock < _dir_cooldown
@@ -212,86 +311,15 @@ class StrategyOrchestrator:
                     )
                     self._set_skip_reason("direction_conflict")
                     return None
+        except Exception as exc:
+            self._logger.error(
+                "Failure in filter_signal direction lock: %s",
+                exc,
+                extra={"event": "orchestrator_direction_error", "symbol": symbol},
+            )
+            self._set_skip_reason("direction_conflict_error")
+            return None
 
-        # ═══════════════════════════════════════════════════════════
-        # 🛡️ FIX 4: SIGNAL FLOOD PREVENTION (Rate Limiting)
-        # ✅ CHANGED: Default reduced from 5.0 to 2.0 seconds
-        # ✅ CHANGED: Log level from DEBUG to INFO
-        # ═══════════════════════════════════════════════════════════
-        signal_cooldown = float(os.getenv("ORCHESTRATOR_SIGNAL_COOLDOWN", "2.0"))  # ✅ Reduced
-        now = time.time()
-        
-        if action in {"BUY", "SELL"} and (now - self._last_signal_time) < signal_cooldown:
-            elapsed = now - self._last_signal_time
-            self._logger.info(  # ✅ CHANGED: DEBUG → INFO
-                f"⏳ RATE LIMIT: {symbol} | Wait {signal_cooldown - elapsed:.1f}s (global {signal_cooldown}s cooldown)",
-                extra={"event": "orchestrator_rate_limit", "symbol": symbol, "cooldown": signal_cooldown}
-            )
-            self._set_skip_reason("global_rate_limit")
-            return None
-        
-        # ═══════════════════════════════════════════════════════════
-        # 🛡️ FIX 5: SINGLE UNDERLYING CONSTRAINT
-        # ✅ CHANGED: Default reduced from 30.0 to 10.0 seconds
-        # ✅ CHANGED: Log level from DEBUG to INFO
-        # ═══════════════════════════════════════════════════════════
-        underlying = self._normalize_underlying(symbol)
-        
-        pending_cooldown = float(os.getenv("UNDERLYING_SIGNAL_COOLDOWN", "10.0"))  # ✅ Reduced
-        last_underlying_signal = self._pending_underlyings.get(underlying, 0.0)
-        
-        if action in {"BUY"} and (now - last_underlying_signal) < pending_cooldown:
-            elapsed = now - last_underlying_signal
-            self._logger.info(  # ✅ CHANGED: DEBUG → INFO
-                f"🛡️ UNDERLYING LIMIT: {symbol} | {underlying} | Wait {pending_cooldown - elapsed:.1f}s",
-                extra={"event": "orchestrator_underlying_limit", "symbol": symbol, "underlying": underlying}
-            )
-            self._set_skip_reason("underlying_rate_limit")
-            return None
-        
-        # ═══════════════════════════════════════════════════════════
-        # STRATEGY ALLOCATION CHECKS
-        # ═══════════════════════════════════════════════════════════
-        strategy_name = self._resolve_strategy_name(signal)
-        if not strategy_name:
-            if action in {"BUY"}:
-                self._last_signal_time = now
-                self._pending_underlyings[underlying] = now
-            self._logger.info(
-                f"✅ SIGNAL PASSED (no strategy allocation): {symbol} | {action}",
-                extra={"event": "orchestrator_pass_no_allocation", "symbol": symbol}
-            )
-            return signal
-            
-        allocation = self._allocations.get(strategy_name)
-        if allocation is None:
-            if action in {"BUY"}:
-                self._last_signal_time = now
-                self._pending_underlyings[underlying] = now
-            self._logger.info(
-                f"✅ SIGNAL PASSED (strategy not registered): {symbol} | {action} | {strategy_name}",
-                extra={"event": "orchestrator_pass_unregistered", "symbol": symbol}
-            )
-            return signal
-            
-        if action not in {"BUY", "SELL"}:
-            return signal
-            
-        if not underlying:
-            return signal
-
-        if not self._has_capital_headroom(allocation, position_manager):
-            self._logger.info(
-                f"💰 CAPITAL BLOCK: {symbol} | Strategy: {strategy_name}",
-                extra={
-                    "event": "orchestrator_capital_block",
-                    "strategy": strategy_name,
-                    "symbol": symbol,
-                },
-            )
-            self._set_skip_reason("orchestrator_capital")
-            return None
-            
         if self._is_correlated(underlying, position_manager):
             self._logger.info(
                 f"🔗 CORRELATION BLOCK: {symbol} | {underlying} already active",
@@ -303,11 +331,14 @@ class StrategyOrchestrator:
             )
             self._set_skip_reason("orchestrator_correlation")
             return None
-            
+
         if not self._futures_context_ready(indicators):
             self._logger.debug(
                 "Futures context missing, but allowing Option trade.",
-                extra={"event": "orchestrator_futures_context_missing", "symbol": symbol}
+                extra={
+                    "event": "orchestrator_futures_context_missing",
+                    "symbol": symbol,
+                },
             )
 
         # Update rate limit timestamps on successful pass
@@ -318,12 +349,16 @@ class StrategyOrchestrator:
                 self._active_direction = _direction
                 self._active_direction_symbol = symbol
                 self._direction_lock_time = time.time()
-        
+
         self._logger.info(
             f"✅ SIGNAL APPROVED: {symbol} | {action} | conf={confidence:.2f} | Strategy: {strategy_name}",
-            extra={"event": "orchestrator_approved", "symbol": symbol, "action": action}
+            extra={
+                "event": "orchestrator_approved",
+                "symbol": symbol,
+                "action": action,
+            },
         )
-        
+
         return signal
 
     def notify_submission(self, signal: Any, underlying: str) -> None:
@@ -376,10 +411,10 @@ class StrategyOrchestrator:
     def _is_futures(self, symbol: str) -> bool:
         """Check if symbol is a futures contract."""
         normalized = symbol.strip().upper()
-        
+
         if normalized.endswith("CE") or normalized.endswith("PE"):
             return False
-            
+
         return "FUT" in normalized
 
     def _resolve_strategy_name(self, signal: Any) -> str:
@@ -396,13 +431,13 @@ class StrategyOrchestrator:
     ) -> bool:
         """
         Check if there is remaining capital for this strategy allocation.
-        
+
         ✅ PRODUCTION FIX: Excludes orphan/manual positions from exposure calculation.
         This prevents orphan trades from blocking ALL new signals.
         """
         balance = float(getattr(self._risk_manager, "current_balance", 0.0) or 0.0)
         max_allocation = balance * allocation.capital_fraction
-        
+
         # ✅ FIX: Calculate exposure excluding orphan positions
         exposure = 0.0
         tracked_exposure = 0.0
@@ -413,44 +448,49 @@ class StrategyOrchestrator:
         get_all = getattr(position_manager, "get_all_positions", None)
         if callable(get_all):
             positions = get_all()
-            
+
             for pos in positions or []:
                 try:
                     qty = abs(float(getattr(pos, "quantity", 0) or 0))
                     price = float(
-                        getattr(pos, "entry_price", 0) or 
-                        getattr(pos, "avg_price", 0) or 0
+                        getattr(pos, "entry_price", 0)
+                        or getattr(pos, "avg_price", 0)
+                        or 0
                     )
                     pos_exposure = qty * price
-                    
+
                     if pos_exposure <= 0:
                         continue
-                    
+
                     # Check if this is an orphan position
                     strategy = (
-                        getattr(pos, "strategy", "") or 
-                        getattr(pos, "strategy_name", "") or ""
+                        getattr(pos, "strategy", "")
+                        or getattr(pos, "strategy_name", "")
+                        or ""
                     )
-                    
+
                     # Identify orphan positions
-                    is_orphan = (
-                        not strategy or 
-                        strategy.lower().strip() in ("manual", "unknown", "manual/unknown", "none", "")
+                    is_orphan = not strategy or strategy.lower().strip() in (
+                        "manual",
+                        "unknown",
+                        "manual/unknown",
+                        "none",
+                        "",
                     )
-                    
+
                     if is_orphan:
                         orphan_exposure += pos_exposure
                         orphan_count += 1
                     else:
                         tracked_exposure += pos_exposure
                         tracked_count += 1
-                        
+
                 except (TypeError, ValueError, AttributeError):
                     continue
-        
+
         total_exposure = tracked_exposure + orphan_exposure
         result = tracked_exposure < max_allocation
-        
+
         self._logger.info(
             f"💰 Capital Check: tracked={tracked_exposure:.2f} | orphan={orphan_exposure:.2f} | "
             f"max={max_allocation:.2f} | balance={balance:.2f} | "
@@ -462,15 +502,15 @@ class StrategyOrchestrator:
                 "orphan_exposure": orphan_exposure,
                 "max_allocation": max_allocation,
                 "result": result,
-            }
+            },
         )
-        
+
         # ✅ Only check tracked exposure, not orphan exposure
         return result
 
     def _has_capital_headroom_quick(self) -> bool:
         """
-        Quick check used by base_elite.py. 
+        Quick check used by base_elite.py.
         ✅ FIX: Was missing, causing AttributeError.
         """
         balance = float(getattr(self._risk_manager, "current_balance", 0.0) or 0.0)
@@ -479,15 +519,15 @@ class StrategyOrchestrator:
     def _is_correlated(self, underlying: str, position_manager: Any) -> bool:
         """
         Check if taking position in *underlying* would violate correlation rules.
-        
+
         ✅ PRODUCTION FIX: Excludes orphan positions from correlation blocking.
         """
         with self._lock:
             active = self._active.get(underlying)
-        
+
         if active is None:
             return False
-            
+
         # Check if the active position is an orphan
         get_all = getattr(position_manager, "get_all_positions", None)
         if callable(get_all):
@@ -496,31 +536,38 @@ class StrategyOrchestrator:
                 try:
                     pos_symbol = getattr(pos, "symbol", "")
                     pos_underlying = self._normalize_underlying(pos_symbol)
-                    
+
                     if pos_underlying != underlying:
                         continue
-                        
+
                     strategy = (
-                        getattr(pos, "strategy", "") or 
-                        getattr(pos, "strategy_name", "") or ""
+                        getattr(pos, "strategy", "")
+                        or getattr(pos, "strategy_name", "")
+                        or ""
                     )
-                    
-                    is_orphan = (
-                        not strategy or 
-                        strategy.lower().strip() in ("manual", "unknown", "manual/unknown", "none", "")
+
+                    is_orphan = not strategy or strategy.lower().strip() in (
+                        "manual",
+                        "unknown",
+                        "manual/unknown",
+                        "none",
+                        "",
                     )
-                    
+
                     if is_orphan:
                         # Don't block correlation for orphan positions
                         self._logger.debug(
                             f"Ignoring orphan position in correlation check: {pos_symbol}",
-                            extra={"event": "correlation_orphan_skip", "symbol": pos_symbol}
+                            extra={
+                                "event": "correlation_orphan_skip",
+                                "symbol": pos_symbol,
+                            },
                         )
                         return False
-                        
+
                 except (TypeError, ValueError, AttributeError):
                     continue
-        
+
         return True
 
     def _futures_context_ready(self, indicators: Mapping[str, Any]) -> bool:
@@ -538,18 +585,18 @@ class StrategyOrchestrator:
         if not symbol:
             return ""
         normalized = symbol.strip().upper()
-        
+
         # Remove exchange prefix
         for prefix in ("NFO:", "NSE:", "BSE:"):
             if normalized.startswith(prefix):
-                normalized = normalized[len(prefix):]
+                normalized = normalized[len(prefix) :]
                 break
-        
+
         # Extract underlying (e.g., "NIFTY" from "NIFTY2620324650CE")
         for underlying in ("NIFTY", "BANKNIFTY", "FINNIFTY"):
             if normalized.startswith(underlying):
                 return underlying
-        
+
         return normalized.split()[0] if normalized else ""
 
 

--- a/tests/execution/test_bracket_manager.py
+++ b/tests/execution/test_bracket_manager.py
@@ -8,7 +8,7 @@ from unittest.mock import Mock
 
 import pytest
 
-from nifty_scalper_bot.execution.bracket_manager import BracketManager
+from nifty_scalper_bot.execution.bracket_manager import BracketManager, BracketState
 
 
 class TestBracketManager:
@@ -47,6 +47,32 @@ class TestBracketManager:
         )
 
         broker.cancel_order.assert_called_once_with("tp-2")
+
+    def test_tiered_trailing_skips_invalid_high_water(self) -> None:
+        """Trailing calc should skip when high-water is invalid."""
+
+        broker = Mock()
+        manager = BracketManager(broker_client=broker)
+        bracket = BracketState(
+            entry_order_id="entry-4",
+            symbol="NIFTYTEST",
+            side="SELL",
+            quantity=1,
+            entry_price=100.0,
+            sl_trigger_price=105.0,
+            tp_trigger_price=90.0,
+        )
+
+        assert (
+            manager._calculate_tiered_trailing_sl(
+                bracket=bracket,
+                ltp=95.0,
+                profit_pct=5.0,
+                high_water=float("inf"),
+                atr=0.0,
+            )
+            is None
+        )
 
     @pytest.mark.flaky(reruns=1)
     def test_race_between_stop_and_target_is_serialised(self) -> None:


### PR DESCRIPTION
### Motivation

- Prevent premature direction locks by ensuring capital gating runs before the direction lock check and make the lock logic resilient to errors.
- Avoid forcing a minimum lot that violates the actual allowed per-trade risk by adding a stricter allowed-risk ceiling and clearer diagnostics.
- Prevent SELL trailing computation from using non-finite high-water values which produced invalid trailing SL calculations.

### Description

- Moved direction conflict evaluation to after the capital headroom check and wrapped it in guarded error handling to avoid locking on signals that would be blocked (`src/nifty_scalper_bot/strategies/orchestrator.py`).
- Tightened `suggest_position_size` so the one-lot-forcing path verifies `one_lot_risk` against the actual `allowed_risk` (no implicit 2x multiplier), added robust logging and exception handling, and ensured deterministic fallbacks for lot resolution (`src/nifty_scalper_bot/risk/risk_manager.py`).
- Hardened trailing SL computation by validating `high_water` with `math.isfinite()` and short-circuiting on invalid values, added debug/info logging and exception capture around the tiered trailing logic (`src/nifty_scalper_bot/execution/bracket_manager.py`).
- Added a unit test that asserts trailing logic skips invalid high-water values: `tests/execution/test_bracket_manager.py::TestBracketManager::test_tiered_trailing_skips_invalid_high_water`.

### Testing

- Ran `black .` which reformatted files successfully.
- Ran `isort .` and `ruff`/`mypy` checks; `isort`/`black` completed, while `ruff check .` and `mypy src` surfaced existing repo-wide issues unrelated to these targeted fixes and did not pass.
- Attempted `pytest -q tests --disable-warnings --ignore=tests/test_live_mode.py --ignore=tests/test_health_server.py` but it failed during collection with an `ImportError` in existing tests; the new unit test was added but full test-suite could not be executed.
- Executed `./run_checks.sh` (venv install + lint/test flow) which progressed to dependency installation but terminated with `pytest not installed but tests/ exists` (test runner environment issue), so the full CI-style checks did not finish.

Note: changes are surgical and localized to the orchestrator, risk sizing, and bracket trailing codepaths and include logging for easier telemetry; broader lint/type failures are pre-existing and were observed when running repo checks but are outside the scope of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988aa1a6ef0832499e81bf006eb55c2)