### PR TITLE
fix: align weekly expiry checks to Tuesday

### DIFF
--- a/src/nifty_scalper_bot/risk/time_based_sizer.py
+++ b/src/nifty_scalper_bot/risk/time_based_sizer.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from datetime import datetime
 
 from nifty_scalper_bot.utils.logging import get_logger
+from nifty_scalper_bot.utils.smart_symbol import WEEKLY_EXPIRY_WEEKDAY
 
 LOGGER = get_logger(__name__)
 
@@ -75,7 +76,7 @@ class TimeBasedSizer:
             None.
 
         Returns:
-            bool: ``True`` when the current day is a Thursday expiry.
+            bool: ``True`` when the current day is a Tuesday expiry.
 
         Raises:
             None.
@@ -86,7 +87,7 @@ class TimeBasedSizer:
             extra={"event": "time_sizer_expiry_check"},
         )
         try:
-            result = datetime.now().weekday() == 3
+            result = datetime.now().weekday() == WEEKLY_EXPIRY_WEEKDAY
             LOGGER.debug(
                 "Condition met: expiry_day_flag",
                 extra={"event": "expiry_day_flag", "value": result},

--- a/src/nifty_scalper_bot/strategies/elite_strategies/vwap_pro.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/vwap_pro.py
@@ -12,6 +12,7 @@ from nifty_scalper_bot.strategies.elite_strategies.config_models import (
     VWAPProStrategyConfig,
 )
 from nifty_scalper_bot.utils.logging import get_logger, log_throttled
+from nifty_scalper_bot.utils.smart_symbol import WEEKLY_EXPIRY_WEEKDAY
 
 LOGGER = get_logger(__name__)
 
@@ -62,17 +63,17 @@ class VWAPProStrategy(EliteStrategy):
         self._last_valid_volume_ts: Dict[str, float] = {}
 
         self._telemetry: Dict[str, int] = {
-            'evaluations': 0,
-            'signals': 0,
-            'skipped_cooldown': 0,
-            'skipped_strike_lock': 0,
-            'skipped_bias': 0,
-            'skipped_no_vwap': 0,
-            'skipped_vwap': 0,
-            'skipped_volume': 0,
-            'skipped_data': 0,
-            'skipped_overextended': 0,
-            'skipped_acceptance': 0,
+            "evaluations": 0,
+            "signals": 0,
+            "skipped_cooldown": 0,
+            "skipped_strike_lock": 0,
+            "skipped_bias": 0,
+            "skipped_no_vwap": 0,
+            "skipped_vwap": 0,
+            "skipped_volume": 0,
+            "skipped_data": 0,
+            "skipped_overextended": 0,
+            "skipped_acceptance": 0,
         }
         self._index_bias_missing_logged: bool = False
 
@@ -104,57 +105,58 @@ class VWAPProStrategy(EliteStrategy):
     def _is_expiry_day(self) -> bool:
         """Args: None. Returns: bool. Raises: Exception."""
         LOGGER.debug(
-            'Entered VWAPProStrategy._is_expiry_day',
-            extra={'event': 'vwap_pro_expiry_day_enter'},
+            "Entered VWAPProStrategy._is_expiry_day",
+            extra={"event": "vwap_pro_expiry_day_enter"},
         )
         try:
-            expiry_day_raw = os.getenv('NIFTY_EXPIRY_WEEKDAY', '2')
+            default_weekday = WEEKLY_EXPIRY_WEEKDAY
+            expiry_day_raw = os.getenv("NIFTY_EXPIRY_WEEKDAY", str(default_weekday))
             try:
                 expiry_day = int(expiry_day_raw)
             except ValueError as e:
                 log_throttled(
                     LOGGER,
-                    'vwap_pro_expiry_defaulted',
-                    'Condition met: expiry_day_defaulted',
+                    "vwap_pro_expiry_defaulted",
+                    "Condition met: expiry_day_defaulted",
                     interval_sec=3600.0,
                 )
                 LOGGER.error(
-                    'Failure in VWAPProStrategy._is_expiry_day: %s',
+                    "Failure in VWAPProStrategy._is_expiry_day: %s",
                     e,
-                    extra={'event': 'vwap_pro_expiry_day_parse_error'},
+                    extra={"event": "vwap_pro_expiry_day_parse_error"},
                     exc_info=e,
                 )
-                expiry_day = 2
+                expiry_day = default_weekday
             if expiry_day not in range(7):
                 log_throttled(
                     LOGGER,
-                    'vwap_pro_expiry_out_of_range',
-                    'Condition met: expiry_day_out_of_range',
+                    "vwap_pro_expiry_out_of_range",
+                    "Condition met: expiry_day_out_of_range",
                     interval_sec=3600.0,
                 )
-                expiry_day = 2
+                expiry_day = default_weekday
             if expiry_day == 3:
                 log_throttled(
                     LOGGER,
-                    'vwap_pro_expiry_corrected',
-                    'Condition met: expiry_day_corrected_to_wednesday',
+                    "vwap_pro_expiry_corrected",
+                    "Condition met: expiry_day_corrected_to_default",
                     interval_sec=3600.0,
                 )
-                expiry_day = 2
+                expiry_day = default_weekday
             is_expiry = time_module.localtime().tm_wday == expiry_day
             if is_expiry:
                 log_throttled(
                     LOGGER,
-                    'vwap_pro_expiry_active',
-                    'Condition met: expiry_day_active',
+                    "vwap_pro_expiry_active",
+                    "Condition met: expiry_day_active",
                     interval_sec=3600.0,
                 )
             return is_expiry
         except Exception as e:
             LOGGER.error(
-                'Failure in VWAPProStrategy._is_expiry_day: %s',
+                "Failure in VWAPProStrategy._is_expiry_day: %s",
                 e,
-                extra={'event': 'vwap_pro_expiry_day_error'},
+                extra={"event": "vwap_pro_expiry_day_error"},
                 exc_info=e,
             )
             return False
@@ -182,8 +184,8 @@ class VWAPProStrategy(EliteStrategy):
             direction = "CE" if is_ce else "PE"
 
             # ✅ FIX B6: Periodic telemetry dump
-            self._telemetry['evaluations'] += 1
-            _evals = self._telemetry['evaluations']
+            self._telemetry["evaluations"] += 1
+            _evals = self._telemetry["evaluations"]
             if _evals == 1 or _evals % self.TELEMETRY_LOG_EVERY == 0:
                 LOGGER.info(
                     f"📊 VWAPPro TELEMETRY [{symbol}]: evals={_evals} "
@@ -197,7 +199,7 @@ class VWAPProStrategy(EliteStrategy):
                     f"data={self._telemetry['skipped_data']} "
                     f"overext={self._telemetry['skipped_overextended']} "
                     f"accept={self._telemetry['skipped_acceptance']}",
-                    extra={'event': 'vwap_pro_telemetry', 'symbol': symbol},
+                    extra={"event": "vwap_pro_telemetry", "symbol": symbol},
                 )
 
             lock_key = f"NIFTY:{expiry}:{direction}"
@@ -328,8 +330,8 @@ class VWAPProStrategy(EliteStrategy):
                     return None
 
             # 🔊 ISSUE 4 FIX: Reset acceptance on Volume rejection
-            vol = float(indicators.get('volume') or 0.0)
-            avg_vol = float(indicators.get('avg_volume') or 0.0)
+            vol = float(indicators.get("volume") or 0.0)
+            avg_vol = float(indicators.get("avg_volume") or 0.0)
             if vol > 0 and avg_vol > 0:
                 self._last_valid_volume[symbol] = vol
                 self._last_valid_avg_volume[symbol] = avg_vol
@@ -344,29 +346,29 @@ class VWAPProStrategy(EliteStrategy):
                     and (now - last_ts) <= self.VOLUME_GRACE_SECONDS
                 ):
                     LOGGER.info(
-                        'Condition met: vwap_pro_volume_grace_fallback',
+                        "Condition met: vwap_pro_volume_grace_fallback",
                         extra={
-                            'event': 'vwap_pro_volume_grace_fallback',
-                            'symbol': symbol,
-                            'fallback_volume': last_vol,
-                            'fallback_avg_volume': last_avg,
+                            "event": "vwap_pro_volume_grace_fallback",
+                            "symbol": symbol,
+                            "fallback_volume": last_vol,
+                            "fallback_avg_volume": last_avg,
                         },
                     )
                     vol = last_vol
                     avg_vol = last_avg
                 else:
-                    self._telemetry['skipped_data'] += 1
+                    self._telemetry["skipped_data"] += 1
                     if (
-                        self._telemetry['skipped_data'] <= 5
-                        or self._telemetry['skipped_data'] % self.TELEMETRY_LOG_EVERY
+                        self._telemetry["skipped_data"] <= 5
+                        or self._telemetry["skipped_data"] % self.TELEMETRY_LOG_EVERY
                         == 0
                     ):
                         LOGGER.warning(
                             f"⚠️ DATA INVALID: {symbol} | "
                             f"vol={vol:.0f} avg_vol={avg_vol:.0f}",
                             extra={
-                                'event': 'vwap_pro_data_invalid',
-                                'symbol': symbol,
+                                "event": "vwap_pro_data_invalid",
+                                "symbol": symbol,
                             },
                         )
                     self._vwap_acceptance_tracker[acc_key] = 0

--- a/tests/risk/test_time_based_sizer_expiry_day.py
+++ b/tests/risk/test_time_based_sizer_expiry_day.py
@@ -1,0 +1,44 @@
+"""Tests for TimeBasedSizer expiry-day detection."""
+
+from __future__ import annotations
+
+import datetime as datetime_module
+
+import pytest
+
+from nifty_scalper_bot.risk import time_based_sizer as sizer_module
+from nifty_scalper_bot.risk.time_based_sizer import TimeBasedSizer
+from nifty_scalper_bot.utils.smart_symbol import WEEKLY_EXPIRY_WEEKDAY
+
+
+class _FixedDatetime(datetime_module.datetime):
+    """Datetime stub for deterministic weekday testing."""
+
+    _fixed_now: datetime_module.datetime = datetime_module.datetime(2025, 1, 7, 10, 0)
+
+    @classmethod
+    def now(cls, tz: datetime_module.tzinfo | None = None) -> datetime_module.datetime:
+        """Args: tz. Returns: datetime. Raises: None."""
+        if tz is None:
+            return cls._fixed_now
+        return cls._fixed_now.replace(tzinfo=tz)
+
+
+@pytest.mark.parametrize(
+    ("weekday", "expected"),
+    [
+        (WEEKLY_EXPIRY_WEEKDAY, True),
+        ((WEEKLY_EXPIRY_WEEKDAY + 1) % 7, False),
+    ],
+)
+def test_time_based_sizer_expiry_day_detection(
+    monkeypatch: pytest.MonkeyPatch,
+    weekday: int,
+    expected: bool,
+) -> None:
+    """Args: monkeypatch, weekday, expected. Returns: None. Raises: AssertionError."""
+    anchor = datetime_module.datetime(2025, 1, 6 + weekday, 10, 0)
+    _FixedDatetime._fixed_now = anchor
+    monkeypatch.setattr(sizer_module, "datetime", _FixedDatetime)
+
+    assert TimeBasedSizer()._is_expiry_day() is expected

--- a/tests/strategies/test_vwap_pro_expiry_day.py
+++ b/tests/strategies/test_vwap_pro_expiry_day.py
@@ -1,0 +1,55 @@
+"""Tests for VWAP Pro expiry-day detection."""
+
+from __future__ import annotations
+
+import time as time_module
+
+import pytest
+
+from nifty_scalper_bot.strategies.elite_strategies import vwap_pro as vwap_pro_module
+from nifty_scalper_bot.strategies.elite_strategies.config_models import (
+    VWAPProStrategyConfig,
+)
+from nifty_scalper_bot.strategies.elite_strategies.vwap_pro import VWAPProStrategy
+from nifty_scalper_bot.utils.smart_symbol import WEEKLY_EXPIRY_WEEKDAY
+
+
+class _DummyIndicatorEngine:
+    """Minimal indicator engine stub for VWAP Pro tests."""
+
+    def get_indicators(self, symbol: str, names: object) -> dict[str, object]:
+        """Args: symbol, names. Returns: dict[str, object]. Raises: None."""
+        return {name: None for name in names}
+
+
+def _make_struct_time(weekday: int) -> time_module.struct_time:
+    """Args: weekday. Returns: time.struct_time. Raises: None."""
+    return time_module.struct_time((2025, 1, 7, 10, 0, 0, weekday, 7, -1))
+
+
+def test_vwap_pro_expiry_day_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Args: monkeypatch. Returns: None. Raises: AssertionError."""
+    monkeypatch.delenv("NIFTY_EXPIRY_WEEKDAY", raising=False)
+    monkeypatch.setattr(
+        vwap_pro_module.time_module,
+        "localtime",
+        lambda: _make_struct_time(WEEKLY_EXPIRY_WEEKDAY),
+    )
+    strategy = VWAPProStrategy(VWAPProStrategyConfig(), _DummyIndicatorEngine())
+
+    assert strategy._is_expiry_day() is True
+
+
+def test_vwap_pro_expiry_day_out_of_range_defaults(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Args: monkeypatch. Returns: None. Raises: AssertionError."""
+    monkeypatch.setenv("NIFTY_EXPIRY_WEEKDAY", "9")
+    monkeypatch.setattr(
+        vwap_pro_module.time_module,
+        "localtime",
+        lambda: _make_struct_time(WEEKLY_EXPIRY_WEEKDAY),
+    )
+    strategy = VWAPProStrategy(VWAPProStrategyConfig(), _DummyIndicatorEngine())
+
+    assert strategy._is_expiry_day() is True


### PR DESCRIPTION
### Motivation
- NIFTY weekly expiry moved to Tuesday, so expiry-day gating used by sizing and strategy logic needed to match the current schedule to avoid incorrect position sizing or blocked signals.
- Ensure the VWAP Pro strategy respects repository-wide canonical weekday constant instead of hardcoded literals.

### Description
- Replace hardcoded Thursday checks with the canonical `WEEKLY_EXPIRY_WEEKDAY` in `TimeBasedSizer._is_expiry_day` and update the docstring to reflect Tuesday expiry.
- Update `VWAPProStrategy._is_expiry_day` to use `WEEKLY_EXPIRY_WEEKDAY` as the default, apply that default on parse errors/out-of-range values, and adjust logging messages accordingly.
- Add unit tests `tests/risk/test_time_based_sizer_expiry_day.py` and `tests/strategies/test_vwap_pro_expiry_day.py` covering default and fallback expiry-day behavior.
- Minor telemetry/logging string normalization in `vwap_pro.py` (consistent quote style) as part of formatting adjustments.

### Testing
- Ran `black .` and `isort .` successfully to reformat touched files; changes were committed.
- Ran `ruff check .` which surfaced pre-existing repository lint issues (existing lint errors remain unrelated to this change).
- Ran `mypy src` which showed existing type problems in the repository and did not fail due to the small scoped edits made here.
- Executed `pytest -q tests --disable-warnings --ignore=tests/test_live_mode.py --ignore=tests/test_health_server.py` which stopped early with an unrelated `ImportError` in `tests/notifications/test_telegram_commands.py`, so new expiry-day tests were added but the full test-suite run could not complete in this environment.
- Attempted `./run_checks.sh` (permission denied) and then `bash ./run_checks.sh` which installed dependencies but reported the environment lacks `pytest` for the top-level runner; `run_checks.sh` therefore did not produce a green test run in this workspace.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988c21465b083249fed9d67fa130e77)