### PR TITLE
fix: improve strategy observability and gating

### DIFF
--- a/src/nifty_scalper_bot/bot/components.py
+++ b/src/nifty_scalper_bot/bot/components.py
@@ -523,6 +523,22 @@ class StrategyRunner:
 
     def _on_tick(self, symbol: str, price: float) -> None:
         """Process a new market data tick for *symbol*."""
+        upper_symbol = symbol.upper()
+        if (
+            upper_symbol.startswith("NSE:")
+            and "NIFTY" in upper_symbol
+            and "CE" not in upper_symbol
+            and "PE" not in upper_symbol
+            and "FUT" not in upper_symbol
+        ):
+            LOGGER.debug(
+                "Condition met: strategy_eval_skipped_index_symbol",
+                extra={
+                    "event": "strategy_eval_skipped_index_symbol",
+                    "symbol": symbol,
+                },
+            )
+            return
 
         open_positions = {
             pos.symbol: pos for pos in self._positions.get_all_positions()

--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -1708,9 +1708,33 @@ class RuntimeSelfChecker:
                         extra={
                             "event": "runtime_self_check_data_freshness",
                             "symbol": symbol,
+                            "symbol_checked": symbol,
+                            "adaptive_ms": adaptive_ms,
                             "detail": detail,
+                            "detail_code": detail,
                         },
                     )
+                    if not ok:
+                        backoff_seconds = max(0.0, float(adaptive_ms) * 2.0 / 1000.0)
+                        runner = getattr(self._context, "strategy_runner", None)
+                        if runner is not None:
+                            try:
+                                runner.set_data_freshness_backoff(
+                                    backoff_seconds,
+                                    detail_code=detail,
+                                    symbol=symbol,
+                                )
+                            except Exception as exc:
+                                self._logger.error(
+                                    "Failure in RuntimeSelfChecker data freshness backoff: %s",
+                                    exc,
+                                    extra={
+                                        "event": "runtime_self_check_backoff_error",
+                                        "check": "data_freshness",
+                                        "symbol": symbol,
+                                    },
+                                    exc_info=exc,
+                                )
                     return ok, detail, payload
 
             ok, detail, meta = assess_datahub_fresh(
@@ -1728,9 +1752,33 @@ class RuntimeSelfChecker:
                 extra={
                     "event": "runtime_self_check_data_freshness",
                     "symbol": symbol,
+                    "symbol_checked": symbol,
+                    "adaptive_ms": adaptive_ms,
                     "detail": detail,
+                    "detail_code": detail,
                 },
             )
+            if not ok:
+                backoff_seconds = max(0.0, float(adaptive_ms) * 2.0 / 1000.0)
+                runner = getattr(self._context, "strategy_runner", None)
+                if runner is not None:
+                    try:
+                        runner.set_data_freshness_backoff(
+                            backoff_seconds,
+                            detail_code=detail,
+                            symbol=symbol,
+                        )
+                    except Exception as exc:
+                        self._logger.error(
+                            "Failure in RuntimeSelfChecker data freshness backoff: %s",
+                            exc,
+                            extra={
+                                "event": "runtime_self_check_backoff_error",
+                                "check": "data_freshness",
+                                "symbol": symbol,
+                            },
+                            exc_info=exc,
+                        )
 
             return ok, detail, payload
         except Exception as exc:

--- a/src/nifty_scalper_bot/core/strategy_manager.py
+++ b/src/nifty_scalper_bot/core/strategy_manager.py
@@ -962,7 +962,7 @@ class StrategyManager(_BaseStrategyManager):
         self._dynamic_enable_threshold = 0.35
         self._dynamic_trade_threshold = 5
         self._dynamic_confidence_floor = 0.45
-        self._last_regime_gate: tuple[bool, tuple[str, ...]] | None = None
+        self._last_regime_gate: tuple[bool, tuple[str, ...], str | None] | None = None
         self._last_regime_gate_at: float = 0.0
         self._regime_gate_cooldown = 10.0
         self._no_signal_summary: dict[str, int] = {
@@ -1913,16 +1913,6 @@ class StrategyManager(_BaseStrategyManager):
         )
 
         now = time.time()
-        gate_key = (allowed, reasons)
-
-        if (
-            self._last_regime_gate == gate_key
-            and (now - self._last_regime_gate_at) < self._regime_gate_cooldown
-        ):
-            return
-
-        self._last_regime_gate = gate_key
-        self._last_regime_gate_at = now
 
         # ---------- SAFE NORMALIZATION (NO ASSUMPTIONS) ----------
         regime_val: str | None = None
@@ -1940,6 +1930,8 @@ class StrategyManager(_BaseStrategyManager):
         # snapshot may also be None -> leave as None
         # ---------------------------------------------------------
 
+        gate_key = (allowed, reasons, regime_val)
+
         extras = {
             "event": (
                 "strategy_regime_gate_allow"
@@ -1952,6 +1944,15 @@ class StrategyManager(_BaseStrategyManager):
             "reasons": list(reasons),
         }
 
+        if self._last_regime_gate == gate_key:
+            if (now - self._last_regime_gate_at) < self._regime_gate_cooldown:
+                return
+            self._last_regime_gate_at = now
+            log.debug("Condition met: strategy_regime_gate_unchanged", extra=extras)
+            return
+
+        self._last_regime_gate = gate_key
+        self._last_regime_gate_at = now
         if allowed:
             log.info("Condition met: strategy_regime_gate_allow", extra=extras)
         else:

--- a/src/nifty_scalper_bot/strategies/elite_strategies/vwap_pro.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/vwap_pro.py
@@ -43,6 +43,7 @@ class VWAPProStrategy(EliteStrategy):
         "_last_valid_volume",
         "_last_valid_avg_volume",
         "_last_valid_volume_ts",
+        "_reject_reason_counts",
     )
 
     def __init__(
@@ -75,6 +76,7 @@ class VWAPProStrategy(EliteStrategy):
             "skipped_overextended": 0,
             "skipped_acceptance": 0,
         }
+        self._reject_reason_counts: Dict[str, int] = {}
         self._index_bias_missing_logged: bool = False
 
     # ------------------------------------------------------------------ #
@@ -161,6 +163,49 @@ class VWAPProStrategy(EliteStrategy):
             )
             return False
 
+    def _log_no_signal_reason(
+        self,
+        reason_code: str,
+        *,
+        symbol: str,
+        ltp: float | None = None,
+        vwap: float | None = None,
+        vol: float | None = None,
+        avg_vol: float | None = None,
+        context: Dict[str, Any] | None = None,
+    ) -> None:
+        """Args: reason_code, symbol, ltp, vwap, vol, avg_vol, context. Returns: None. Raises: Exception."""
+        try:
+            self._reject_reason_counts[reason_code] = (
+                self._reject_reason_counts.get(reason_code, 0) + 1
+            )
+            payload: Dict[str, Any] = {
+                "event": "vwap_pro_no_signal_reason",
+                "reason_code": reason_code,
+                "symbol": symbol,
+            }
+            if ltp is not None:
+                payload["ltp"] = ltp
+            if vwap is not None:
+                payload["vwap"] = vwap
+            if vol is not None:
+                payload["vol"] = vol
+            if avg_vol is not None:
+                payload["avg_vol"] = avg_vol
+            if context:
+                payload.update(context)
+            LOGGER.debug("NO SIGNAL: %s", reason_code, extra=payload)
+        except Exception as exc:
+            LOGGER.error(
+                "Failure in VWAPProStrategy._log_no_signal_reason: %s",
+                exc,
+                extra={
+                    "event": "vwap_pro_no_signal_reason_error",
+                    "symbol": symbol,
+                },
+                exc_info=exc,
+            )
+
     # ------------------------------------------------------------------ #
     # Core Signal Logic
     # ------------------------------------------------------------------ #
@@ -187,6 +232,12 @@ class VWAPProStrategy(EliteStrategy):
             self._telemetry["evaluations"] += 1
             _evals = self._telemetry["evaluations"]
             if _evals == 1 or _evals % self.TELEMETRY_LOG_EVERY == 0:
+                dominant_reject_reason = None
+                if self._reject_reason_counts:
+                    dominant_reject_reason = max(
+                        self._reject_reason_counts.items(),
+                        key=lambda item: item[1],
+                    )[0]
                 LOGGER.info(
                     f"📊 VWAPPro TELEMETRY [{symbol}]: evals={_evals} "
                     f"signals={self._telemetry['signals']} "
@@ -199,7 +250,12 @@ class VWAPProStrategy(EliteStrategy):
                     f"data={self._telemetry['skipped_data']} "
                     f"overext={self._telemetry['skipped_overextended']} "
                     f"accept={self._telemetry['skipped_acceptance']}",
-                    extra={"event": "vwap_pro_telemetry", "symbol": symbol},
+                    extra={
+                        "event": "vwap_pro_telemetry",
+                        "symbol": symbol,
+                        "dominant_reject_reason": dominant_reject_reason,
+                        "reject_counts_by_reason": dict(self._reject_reason_counts),
+                    },
                 )
 
             lock_key = f"NIFTY:{expiry}:{direction}"
@@ -222,6 +278,13 @@ class VWAPProStrategy(EliteStrategy):
                         f"🔐 STRIKE LOCK: {symbol} blocked | Active={self._strike_lock[lock_key]}",
                         extra={"event": "vwap_pro_strike_lock", "symbol": symbol},
                     )
+                self._log_no_signal_reason(
+                    "strike_lock_active",
+                    symbol=symbol,
+                    ltp=current_price,
+                    vwap=indicators.get("vwap"),
+                    context={"active_symbol": self._strike_lock.get(lock_key)},
+                )
                 self._vwap_acceptance_tracker[acc_key] = 0
                 return None
 
@@ -234,6 +297,17 @@ class VWAPProStrategy(EliteStrategy):
                         f"Remaining={self.COOLDOWN_SECONDS - (now - last_fire):.0f}s",
                         extra={"event": "vwap_pro_cooldown", "symbol": symbol},
                     )
+                self._log_no_signal_reason(
+                    "cooldown_active",
+                    symbol=symbol,
+                    ltp=current_price,
+                    vwap=indicators.get("vwap"),
+                    context={
+                        "cooldown_remaining_s": max(
+                            0.0, self.COOLDOWN_SECONDS - (now - last_fire)
+                        )
+                    },
+                )
                 self._vwap_acceptance_tracker[acc_key] = 0
                 return None
 
@@ -265,6 +339,13 @@ class VWAPProStrategy(EliteStrategy):
                         "INVALID INDEX DATA — blocking signal", extra={"symbol": symbol}
                     )
                     self._index_bias_missing_logged = True
+                self._log_no_signal_reason(
+                    "index_bias_invalid",
+                    symbol=symbol,
+                    ltp=current_price,
+                    vwap=vwap,
+                    context={"index_ltp": index_ltp, "index_vwap": index_vwap},
+                )
                 self._vwap_acceptance_tracker[acc_key] = 0
                 return None
 
@@ -284,6 +365,17 @@ class VWAPProStrategy(EliteStrategy):
                         f"Need={'BULL' if is_ce else 'BEAR'}",
                         extra={"event": "vwap_pro_bias_reject", "symbol": symbol},
                     )
+                self._log_no_signal_reason(
+                    "index_bias_invalid",
+                    symbol=symbol,
+                    ltp=current_price,
+                    vwap=vwap,
+                    context={
+                        "index_ltp": index_ltp,
+                        "index_vwap": index_vwap,
+                        "direction": direction,
+                    },
+                )
                 self._vwap_acceptance_tracker[acc_key] = 0
                 return None
 
@@ -294,6 +386,12 @@ class VWAPProStrategy(EliteStrategy):
                         f"⚠️ VWAP ZERO: {symbol} | price={current_price:.2f} vwap={vwap:.2f}",
                         extra={"event": "vwap_pro_zero_block", "symbol": symbol},
                     )
+                self._log_no_signal_reason(
+                    "vwap_zero_or_invalid",
+                    symbol=symbol,
+                    ltp=current_price,
+                    vwap=vwap,
+                )
                 self._vwap_acceptance_tracker[acc_key] = 0
                 return None
 
@@ -308,6 +406,12 @@ class VWAPProStrategy(EliteStrategy):
                         f"Price={current_price:.2f} VWAP={vwap:.2f}",
                         extra={"event": "vwap_pro_opt_vwap_reject", "symbol": symbol},
                     )
+                self._log_no_signal_reason(
+                    "price_below_vwap",
+                    symbol=symbol,
+                    ltp=current_price,
+                    vwap=vwap,
+                )
                 self._vwap_acceptance_tracker[acc_key] = 0
                 return None
 
@@ -326,6 +430,13 @@ class VWAPProStrategy(EliteStrategy):
                                 "symbol": symbol,
                             },
                         )
+                    self._log_no_signal_reason(
+                        "overextension_filter",
+                        symbol=symbol,
+                        ltp=current_price,
+                        vwap=vwap,
+                        context={"vwap_std": vwap_std, "z_score": z},
+                    )
                     self._vwap_acceptance_tracker[acc_key] = 0
                     return None
 
@@ -371,6 +482,24 @@ class VWAPProStrategy(EliteStrategy):
                                 "symbol": symbol,
                             },
                         )
+                        LOGGER.debug(
+                            "volume_below_threshold",
+                            extra={
+                                "event": "volume_below_threshold",
+                                "symbol": symbol,
+                                "vol": vol,
+                                "avg_vol": avg_vol,
+                                "required_volume": None,
+                            },
+                        )
+                    self._log_no_signal_reason(
+                        "volume_below_threshold",
+                        symbol=symbol,
+                        ltp=current_price,
+                        vwap=vwap,
+                        vol=vol,
+                        avg_vol=avg_vol,
+                    )
                     self._vwap_acceptance_tracker[acc_key] = 0
                     return None
             vol_thresh = self._dynamic_volume_threshold()
@@ -384,6 +513,29 @@ class VWAPProStrategy(EliteStrategy):
                         f"🔊 VOL GATE: {symbol} | vol={vol:.0f} < avg={avg_vol:.0f}×{vol_thresh}={avg_vol*vol_thresh:.0f}",
                         extra={"event": "vwap_pro_vol_reject", "symbol": symbol},
                     )
+                    LOGGER.debug(
+                        "volume_below_threshold",
+                        extra={
+                            "event": "volume_below_threshold",
+                            "symbol": symbol,
+                            "vol": vol,
+                            "avg_vol": avg_vol,
+                            "volume_threshold": vol_thresh,
+                            "required_volume": avg_vol * vol_thresh,
+                        },
+                    )
+                self._log_no_signal_reason(
+                    "volume_below_threshold",
+                    symbol=symbol,
+                    ltp=current_price,
+                    vwap=vwap,
+                    vol=vol,
+                    avg_vol=avg_vol,
+                    context={
+                        "volume_threshold": vol_thresh,
+                        "required_volume": avg_vol * vol_thresh,
+                    },
+                )
                 self._vwap_acceptance_tracker[acc_key] = 0
                 return None
 
@@ -394,6 +546,16 @@ class VWAPProStrategy(EliteStrategy):
                     f"⏳ ACCEPTANCE: {symbol} {direction} | "
                     f"Bar {self._vwap_acceptance_tracker[acc_key]}/{self.VWAP_ACCEPTANCE_BARS}",
                     extra={"event": "vwap_pro_acceptance", "symbol": symbol},
+                )
+                self._log_no_signal_reason(
+                    "acceptance_bars_insufficient",
+                    symbol=symbol,
+                    ltp=current_price,
+                    vwap=vwap,
+                    context={
+                        "acceptance_bars": self._vwap_acceptance_tracker[acc_key],
+                        "required_bars": self.VWAP_ACCEPTANCE_BARS,
+                    },
                 )
                 return None
 
@@ -425,6 +587,13 @@ class VWAPProStrategy(EliteStrategy):
                         "tp": tp2,
                         "atr": atr,
                     },
+                )
+                self._log_no_signal_reason(
+                    "overextension_filter",
+                    symbol=symbol,
+                    ltp=current_price,
+                    vwap=vwap,
+                    context={"sl": sl, "tp": tp2, "atr": atr},
                 )
                 self._vwap_acceptance_tracker[acc_key] = 0
                 return None

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -2503,6 +2503,43 @@ class StrategyRunner:
             # =================================================================
 
             signal = generated_signal
+            upper_symbol = symbol.upper()
+            is_index_symbol = (
+                upper_symbol.startswith("NSE:")
+                and "NIFTY" in upper_symbol
+                and "CE" not in upper_symbol
+                and "PE" not in upper_symbol
+                and "FUT" not in upper_symbol
+            )
+            if is_index_symbol:
+                self._logger.debug(
+                    "Condition met: strategy_eval_skipped_index_symbol",
+                    extra={
+                        "event": "strategy_eval_skipped_index_symbol",
+                        "symbol": symbol,
+                    },
+                )
+                return
+
+            backoff_until = float(getattr(self, "_data_freshness_backoff_until", 0.0))
+            if backoff_until and time_module.time() < backoff_until:
+                remaining = max(0.0, backoff_until - time_module.time())
+                self._logger.debug(
+                    "strategy_eval_skipped_stale_data",
+                    extra={
+                        "event": "strategy_eval_skipped_stale_data",
+                        "symbol": symbol,
+                        "backoff_until": backoff_until,
+                        "remaining_s": remaining,
+                        "detail_code": getattr(
+                            self, "_data_freshness_backoff_detail", None
+                        ),
+                        "symbol_checked": getattr(
+                            self, "_data_freshness_backoff_symbol", None
+                        ),
+                    },
+                )
+                return
 
             # If no immediate signal, delegate to complex StrategyManager
             if signal is None and self._config.min_indicator_bars:
@@ -2514,18 +2551,28 @@ class StrategyRunner:
                         last_bar_ts = self._last_bar_ts.get(symbol)
                         if last_bar_ts and state._last_eval_bar_ts:
                             if last_bar_ts <= state._last_eval_bar_ts:
-                                log_throttled(
-                                    self._logger,
-                                    f"strategy_eval_skip_bar_{symbol}",
-                                    "Condition met: strategy_eval_skipped_same_bar",
-                                    interval_sec=30.0,
-                                    level=logging.INFO,
-                                    extra={
-                                        "event": "strategy_eval_skipped_same_bar",
-                                        "symbol": symbol,
-                                        "bar_ts": last_bar_ts.isoformat(),
-                                    },
+                                logged_map = getattr(
+                                    self, "_same_bar_skip_logged", None
                                 )
+                                if logged_map is None:
+                                    logged_map = {}
+                                    self._same_bar_skip_logged = logged_map
+                                extra_payload = {
+                                    "event": "strategy_eval_skipped_same_bar",
+                                    "symbol": symbol,
+                                    "bar_ts": last_bar_ts.isoformat(),
+                                }
+                                if logged_map.get(symbol) == last_bar_ts:
+                                    self._logger.debug(
+                                        "Condition met: strategy_eval_skipped_same_bar",
+                                        extra=extra_payload,
+                                    )
+                                else:
+                                    logged_map[symbol] = last_bar_ts
+                                    self._logger.info(
+                                        "Condition met: strategy_eval_skipped_same_bar",
+                                        extra=extra_payload,
+                                    )
                                 return
                         if last_bar_ts:
                             bar_age = (now - last_bar_ts).total_seconds()
@@ -2547,6 +2594,31 @@ class StrategyRunner:
                         # Limit evaluation frequency (max 2 per second)
                         if last_eval and (now - last_eval).total_seconds() < 0.5:
                             return
+                        cooldown_map = getattr(self, "_pyramid_reject_cooldown", {})
+                        if cooldown_map:
+                            now_ts = time_module.time()
+                            cooldown_symbol = self._normalize_symbol(symbol)
+                            directions = (
+                                ["BUY"] if self._options_long_only else ["BUY", "SELL"]
+                            )
+                            for direction in directions:
+                                cooldown_key = (cooldown_symbol, direction)
+                                cooldown_until = cooldown_map.get(cooldown_key)
+                                if cooldown_until and now_ts < cooldown_until:
+                                    self._logger.debug(
+                                        "pyramid_cooldown_active",
+                                        extra={
+                                            "event": "pyramid_cooldown_active",
+                                            "symbol": cooldown_symbol,
+                                            "direction": direction,
+                                            "cooldown_remaining_s": max(
+                                                0.0, cooldown_until - now_ts
+                                            ),
+                                        },
+                                    )
+                                    return
+                                if cooldown_until and now_ts >= cooldown_until:
+                                    cooldown_map.pop(cooldown_key, None)
                         state._last_strategy_eval = now
                         if last_bar_ts:
                             state._last_eval_bar_ts = last_bar_ts
@@ -2576,14 +2648,52 @@ class StrategyRunner:
                         )
 
                         signal = self._strategy_manager.generate_signal(symbol, price)
+                        cycle_stats = getattr(self, "_strategy_cycle_stats", None)
+                        if cycle_stats is None:
+                            cycle_stats = {}
+                            self._strategy_cycle_stats = cycle_stats
+                        bar_key = (
+                            last_bar_ts.isoformat() if last_bar_ts else now.isoformat()
+                        )
+                        cycle = cycle_stats.setdefault(
+                            bar_key,
+                            {
+                                "symbols": set(),
+                                "total_signals": 0,
+                                "reject_reason_counts": defaultdict(int),
+                            },
+                        )
+                        cycle["symbols"].add(symbol)
                         if signal is None:
-                            log_throttled(
-                                self._logger,
-                                f"no_signal_manager_{symbol}",
-                                f"📉 Strategy Manager evaluated {symbol}: NO SIGNAL",
-                                interval_sec=30.0,
-                                level=logging.INFO,
+                            cycle["reject_reason_counts"]["no_signal"] += 1
+                        else:
+                            cycle["total_signals"] += 1
+                        expected_symbols = [
+                            sym
+                            for sym in self._active_symbols
+                            if not (
+                                sym.upper().startswith("NSE:")
+                                and "NIFTY" in sym.upper()
+                                and "CE" not in sym.upper()
+                                and "PE" not in sym.upper()
+                                and "FUT" not in sym.upper()
                             )
+                        ]
+                        if expected_symbols and len(cycle["symbols"]) >= len(
+                            expected_symbols
+                        ):
+                            self._logger.info(
+                                "strategy_cycle_summary",
+                                extra={
+                                    "event": "strategy_cycle_summary",
+                                    "total_symbols": len(cycle["symbols"]),
+                                    "total_signals": cycle["total_signals"],
+                                    "reject_reason_counts": dict(
+                                        cycle["reject_reason_counts"]
+                                    ),
+                                },
+                            )
+                            cycle_stats.pop(bar_key, None)
                     else:
                         # ✅ DIAGNOSTIC LOG: Explain why no evaluation happened
                         log_throttled(
@@ -2620,6 +2730,43 @@ class StrategyRunner:
         except Exception as e:
             self._logger.error("Failure in _on_tick: %s", e, exc_info=True)
             return
+
+    def set_data_freshness_backoff(
+        self,
+        backoff_seconds: float,
+        *,
+        detail_code: str | None = None,
+        symbol: str | None = None,
+    ) -> None:
+        """Args: backoff_seconds, detail_code, symbol. Returns: None. Raises: Exception."""
+        try:
+            seconds = max(float(backoff_seconds), 0.0)
+            now_ts = time_module.time()
+            until = now_ts + seconds
+            current_until = float(
+                getattr(self, "_data_freshness_backoff_until", 0.0)
+            )
+            if until > current_until:
+                self._data_freshness_backoff_until = until
+            self._data_freshness_backoff_detail = detail_code
+            self._data_freshness_backoff_symbol = symbol
+            self._logger.debug(
+                "Condition met: strategy_eval_backoff_set",
+                extra={
+                    "event": "strategy_eval_backoff_set",
+                    "backoff_seconds": seconds,
+                    "backoff_until": self._data_freshness_backoff_until,
+                    "detail_code": detail_code,
+                    "symbol_checked": symbol,
+                },
+            )
+        except Exception as exc:
+            self._logger.error(
+                "Failure in StrategyRunner.set_data_freshness_backoff: %s",
+                exc,
+                extra={"event": "strategy_eval_backoff_error"},
+                exc_info=exc,
+            )
 
     def _handle_signal(self, signal: Signal, price: float, timestamp: datetime) -> None:
         """
@@ -3036,6 +3183,24 @@ class StrategyRunner:
                         f"Already active on {active_contract.symbol} | "
                         "Pyramiding Disabled",
                         extra={"event": "signal_pyramid_reject", "symbol": base_symbol},
+                    )
+                    cooldown_seconds = 15.0
+                    cooldown_map = getattr(self, "_pyramid_reject_cooldown", None)
+                    if cooldown_map is None:
+                        cooldown_map = {}
+                        self._pyramid_reject_cooldown = cooldown_map
+                    cooldown_key = (base_symbol, signal.action)
+                    cooldown_map[cooldown_key] = (
+                        time_module.time() + cooldown_seconds
+                    )
+                    self._logger.debug(
+                        "Condition met: pyramid_reject_cooldown_set",
+                        extra={
+                            "event": "pyramid_reject_cooldown_set",
+                            "symbol": base_symbol,
+                            "direction": signal.action,
+                            "cooldown_seconds": cooldown_seconds,
+                        },
                     )
                     with self._lock:
                         if state:


### PR DESCRIPTION
### Motivation

- Improve production observability to surface why strategies return NO SIGNAL and remove silent failure modes without changing trading logic or thresholds.
- Prevent repeated noisy logs and avoid strategy evaluation when data is stale, when pyramid entries are rejected, or when index-only symbols are encountered.

### Description

- Add structured per-reject diagnostics in `VWAPProStrategy` using a fixed set of reason codes and `LOGGER.debug` payloads, and maintain a reject histogram exposed in telemetry (`dominant_reject_reason` and `reject_counts_by_reason`). (changes in `src/nifty_scalper_bot/strategies/elite_strategies/vwap_pro.py`)
- Emit a single structured cycle summary per evaluation cycle with counts (`total_symbols`, `total_signals`, `reject_reason_counts`) in `StrategyRunner`, and reduce per-symbol repeated summaries. (changes in `src/nifty_scalper_bot/strategies/runner.py`)
- Gate strategy evaluation on data freshness by wiring `RuntimeSelfChecker._check_data_freshness()` to set a backoff on `StrategyRunner` via `set_data_freshness_backoff()` and skip evaluations during backoff with a debug log `strategy_eval_skipped_stale_data`. (changes in `src/nifty_scalper_bot/core/app.py` and `src/nifty_scalper_bot/strategies/runner.py`)
- Add a short-lived “pyramid rejection cooldown” map: when an entry is rejected due to pyramiding disabled, store `(symbol, direction)` with expiry and skip subsequent evaluations for that pair while the cooldown is active with a debug `pyramid_cooldown_active` log. (changes in `src/nifty_scalper_bot/strategies/runner.py`)
- Reduce same-bar skip spam by logging `strategy_eval_skipped_same_bar` at INFO at most once per symbol per bar and DEBUG for subsequent skips. (changes in `src/nifty_scalper_bot/strategies/runner.py`)
- Exclude pure NSE index symbols (e.g., `NSE:NIFTY 50`) from strategy evaluation loops while still allowing indicator collection. (changes in `src/nifty_scalper_bot/strategies/runner.py` and `src/nifty_scalper_bot/bot/components.py`)
- Improve `RuntimeSelfChecker` freshness logging with structured INFO `runtime_self_check_data_freshness` including `symbol_checked`, `adaptive_ms`, and `detail_code`, and ensure exceptions inside the check are logged at ERROR without crashing. (changes in `src/nifty_scalper_bot/core/app.py`)
- Reduce repeated regime/condition logs by only logging regime state at INFO when it actually changes, otherwise log DEBUG. (changes in `src/nifty_scalper_bot/core/strategy_manager.py`)
- Make volume/data-invalid conditions consistently logged with DEBUG/INFO and emit structured `volume_below_threshold` diagnostics, and surface related reject reasons such as `volume_below_threshold`, `vwap_zero_or_invalid`, `price_below_vwap`, `index_bias_invalid`, `acceptance_bars_insufficient`, `overextension_filter`, `cooldown_active`, and `strike_lock_active`. (changes in `src/nifty_scalper_bot/strategies/elite_strategies/vwap_pro.py`)

### Testing

- Ran `bash ./run_checks.sh` to validate the change set and environment; dependency installation completed but `pytest` was not installed in the ephemeral environment so unit tests were not executed: `❌ pytest not installed but tests/ exists. Install pytest or remove tests/`.
- Sanity-checked the codebase by running the project's check script; no runtime exceptions occurred during static edits and commits were created successfully.

Run output (excerpt):
```
=== run_checks.sh: starting in /workspace/nifty_scalper_bot ===
PYTHONPATH=/workspace/nifty_scalper_bot/src:/workspace/nifty_scalper_bot:
--- Creating virtualenv (.venv) ---
--- Python version ---
Python 3.10.19
--- Installing requirements ---
ℹ Ruff not installed; skipping lint.
ℹ mypy not installed; skipping type check.
--- Running pytest ---
❌ pytest not installed but tests/ exists. Install pytest or remove tests/
```

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698964e8386c8324a140c262da55ad37)