### PR TITLE
fix: forward ticks to bracket manager & set NIFTY weekly expiry to Wednesday

### DIFF
--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -1925,11 +1925,6 @@ class StrategyRunner:
             extra={"event": "tick_enter", "symbol": symbol},
         )
         try:
-            now = datetime.now(timezone.utc)
-
-            if "FUT" in symbol.upper():
-                return
-
             # =================================================================
             # PHASE -1: BRACKET MANAGER TICK FORWARDING (MUST be before ANY return)
             # =================================================================
@@ -1953,6 +1948,9 @@ class StrategyRunner:
                         f"Bracket tick forward failed: {_bm_err}",
                         extra={"event": "bracket_tick_error", "symbol": symbol},
                     )
+
+            if "FUT" in symbol.upper():
+                return
 
             # =================================================================
             # PHASE 0: EARLY EXIT CHECKS (Fast path for non-trading scenarios)

--- a/src/nifty_scalper_bot/utils/smart_symbol.py
+++ b/src/nifty_scalper_bot/utils/smart_symbol.py
@@ -7,7 +7,7 @@ import logging
 logger = logging.getLogger(__name__)
 EXCHANGE_PREFIX = "NFO"
 UNDERLYING = "NIFTY"
-WEEKLY_EXPIRY_WEEKDAY = 1  # Tuesday (0=Mon)
+WEEKLY_EXPIRY_WEEKDAY = 2  # Wednesday (0=Mon)
 
 IST = ZoneInfo("Asia/Kolkata")
 


### PR DESCRIPTION
### Motivation
- Ensure the bracket manager receives every incoming tick so SL/TP/trailing logic can fire reliably even if other early-return guards run.  
- Align weekly expiry logic with current NIFTY weekly expiry day to avoid stale symbol resolution.

### Description
- Forward ticks into the bracket manager at the top of `StrategyRunner._on_tick` (before any early `return` such as futures short-circuit), extracting a safe `ltp` and calling `self._bracket_manager.on_tick(symbol, ltp)` inside a guarded try/except; file changed: `src/nifty_scalper_bot/strategies/runner.py`.  
- Update the NIFTY weekly expiry weekday constant to Wednesday by changing `WEEKLY_EXPIRY_WEEKDAY` to `2` (0=Mon); file changed: `src/nifty_scalper_bot/utils/smart_symbol.py`.

### Testing
- Ran `./run_checks.sh` (initial permission denied), then `bash ./run_checks.sh` to run checks and dependency setup.  
- Results: `ruff` reported many style issues (`Found 924 errors`), `mypy` reported type issues (`Found 343 errors`), and `pytest` invocation failed due to unsupported coverage flags in the CI `pytest.ini` (`pytest: error: unrecognized arguments: --cov ...`), indicating repository-wide lint/type/test configuration that is unrelated to this small behavioral fix but must be resolved separately before a clean green CI run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989f7891c888324b39d5e43b4818863)