### PR TITLE
fix: stabilize control-plane behavior during global risk halt

### DIFF
--- a/src/nifty_scalper_bot/notifications/telegram_webhook_enhanced.py
+++ b/src/nifty_scalper_bot/notifications/telegram_webhook_enhanced.py
@@ -277,7 +277,7 @@ class TelegramEnhancedNotifier:
             if elapsed >= retry_window_s:
                 # Latch degraded state so callers stop retrying until cooldown expires.
                 self._telegram_degraded = True
-                self._telegram_degraded_until = _current_loop_time() + 60.0
+                self._telegram_degraded_until = _current_loop_time() + retry_window_s
                 if not self._telegram_degraded_logged:
                     self._telegram_degraded_logged = True
                     self._logger.error(
@@ -285,7 +285,7 @@ class TelegramEnhancedNotifier:
                         extra={
                             "event": "telegram_notifier_degraded",
                             "chat_id": chat_id,
-                            "cooldown_s": 60.0,
+                            "cooldown_s": retry_window_s,
                         },
                     )
                 return
@@ -328,6 +328,20 @@ class TelegramEnhancedNotifier:
                             "err": str(exc),
                         },
                     )
+                    # Repeated hard failures indicate transport degradation; latch
+                    # to avoid retry spam from every caller until cooldown expires.
+                    self._telegram_degraded = True
+                    self._telegram_degraded_until = _current_loop_time() + retry_window_s
+                    if not self._telegram_degraded_logged:
+                        self._telegram_degraded_logged = True
+                        self._logger.error(
+                            "telegram_notifier_degraded",
+                            extra={
+                                "event": "telegram_notifier_degraded",
+                                "chat_id": chat_id,
+                                "cooldown_s": retry_window_s,
+                            },
+                        )
                     return
                 delay = min(2.0**attempt, 30.0)
                 self._logger.warning(
@@ -364,6 +378,20 @@ class TelegramEnhancedNotifier:
                             "err": str(exc),
                         },
                     )
+                    # Generic Telegram transport failures are latched as degraded so
+                    # recovery waits for cooldown instead of immediate retry storms.
+                    self._telegram_degraded = True
+                    self._telegram_degraded_until = _current_loop_time() + retry_window_s
+                    if not self._telegram_degraded_logged:
+                        self._telegram_degraded_logged = True
+                        self._logger.error(
+                            "telegram_notifier_degraded",
+                            extra={
+                                "event": "telegram_notifier_degraded",
+                                "chat_id": chat_id,
+                                "cooldown_s": retry_window_s,
+                            },
+                        )
                     return
                 delay = min(2.0**attempt, 30.0)
                 self._logger.warning(

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -2168,8 +2168,9 @@ class StrategyRunner:
                 )
                 return
 
-            if self._bracket_manager and price > 0:
-                self._bracket_manager.on_tick(symbol, price)
+            # Bracket tick forwarding already happened at function entry.
+            # Keep a single forward per tick so protective handlers do not churn
+            # duplicate state transitions during stressed periods.
 
             # Global breaker latch: once tripped, keep running only protective paths
             # (brackets + position reconciliation) and skip strategy/indicator work.

--- a/tests/notifications/test_telegram_webhook_enhanced.py
+++ b/tests/notifications/test_telegram_webhook_enhanced.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from telegram.error import TimedOut
+
+from nifty_scalper_bot.notifications.telegram_webhook_enhanced import (
+    TelegramEnhancedNotifier,
+)
+
+
+@pytest.mark.asyncio
+async def test_send_single_latches_degraded_after_retry_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify notifier enters degraded mode after repeated transport failures.
+
+    Args:
+        monkeypatch: Fixture used to freeze loop time and async sleeps.
+
+    Returns:
+        None.
+
+    Raises:
+        Exception: If notifier execution fails unexpectedly.
+    """
+
+    fake_time = 100.0
+    monkeypatch.setattr(
+        'nifty_scalper_bot.notifications.telegram_webhook_enhanced._current_loop_time',
+        lambda: fake_time,
+    )
+
+    async def _noop_sleep(_seconds: float) -> None:
+        return None
+
+    monkeypatch.setattr(
+        'nifty_scalper_bot.notifications.telegram_webhook_enhanced.asyncio.sleep',
+        _noop_sleep,
+    )
+
+    bot = MagicMock()
+    bot.send_message = AsyncMock(side_effect=TimedOut('timeout'))
+    settings = SimpleNamespace(
+        rate_per_second=20.0,
+        burst_capacity=20.0,
+        whitelist_chat_ids=None,
+        whitelist_user_ids=None,
+    )
+    notifier = TelegramEnhancedNotifier(bot=bot, settings=settings)
+
+    await notifier._send_single(chat_id=1, text='x')
+
+    assert notifier._telegram_degraded is True
+    assert notifier._telegram_degraded_until == pytest.approx(400.0)
+    assert bot.send_message.await_count == 5
+
+    bot.send_message.reset_mock()
+    await notifier._send_single(chat_id=1, text='x')
+    assert bot.send_message.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_send_single_recovers_after_degraded_cooldown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify degraded latch is cleared once cooldown expires.
+
+    Args:
+        monkeypatch: Fixture used to set deterministic loop time.
+
+    Returns:
+        None.
+
+    Raises:
+        Exception: If notifier execution fails unexpectedly.
+    """
+
+    fake_time = 500.0
+    monkeypatch.setattr(
+        'nifty_scalper_bot.notifications.telegram_webhook_enhanced._current_loop_time',
+        lambda: fake_time,
+    )
+
+    bot = MagicMock()
+    bot.send_message = AsyncMock(return_value=None)
+    settings = SimpleNamespace(
+        rate_per_second=20.0,
+        burst_capacity=20.0,
+        whitelist_chat_ids=None,
+        whitelist_user_ids=None,
+    )
+    notifier = TelegramEnhancedNotifier(bot=bot, settings=settings)
+    notifier._telegram_degraded = True
+    notifier._telegram_degraded_logged = True
+    notifier._telegram_degraded_until = 450.0
+
+    await notifier._send_single(chat_id=1, text='ok')
+
+    assert bot.send_message.await_count == 1
+    assert notifier._telegram_degraded is False
+    assert notifier._telegram_degraded_until == pytest.approx(0.0)

--- a/tests/strategies/test_runner_risk_halt_latch.py
+++ b/tests/strategies/test_runner_risk_halt_latch.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+
+def test_risk_halt_latch_short_circuits_strategy_work(
+    monkeypatch,
+) -> None:
+    """Verify risk-halt latch blocks redundant strategy processing.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture.
+
+    Returns:
+        None.
+
+    Raises:
+        Exception: If setup stubs fail unexpectedly.
+    """
+
+    from nifty_scalper_bot.strategies.runner import StrategyRunner, StrategyRunnerConfig
+
+    market_data = MagicMock()
+    indicator = MagicMock()
+    strategy_manager = MagicMock()
+    risk_manager = MagicMock()
+    order_manager = MagicMock()
+    position_manager = MagicMock()
+    bracket_manager = MagicMock()
+
+    risk_manager.is_circuit_breaker_tripped.return_value = (True, 'dd_limit')
+
+    runner = StrategyRunner(
+        market_data_manager=market_data,
+        indicator_engine=indicator,
+        strategy_manager=strategy_manager,
+        risk_manager=risk_manager,
+        order_manager=order_manager,
+        position_manager=position_manager,
+        bracket_manager=bracket_manager,
+        config=StrategyRunnerConfig(max_trade_history=4, min_indicator_bars=0),
+        data_hub=None,
+        strike_selector=None,
+    )
+    monkeypatch.setattr(runner, '_is_market_open', lambda _now: True)
+
+    symbol = 'NFO:NIFTY2621025700PE'
+    tick = {
+        'ltp': 101.0,
+        'timestamp': datetime.now(timezone.utc),
+        'volume': 10,
+        'source': 'ws',
+    }
+
+    runner._on_tick(symbol, tick)
+    runner._on_tick(symbol, tick)
+
+    assert runner._risk_halt_active is True
+    assert risk_manager.is_circuit_breaker_tripped.call_count == 1
+    assert bracket_manager.on_tick.call_count == 2
+    assert strategy_manager.generate_signals.call_count == 0
+    assert indicator.update_price.call_count == 0
+    assert position_manager.update_position_price.call_count == 2


### PR DESCRIPTION
### Motivation
- Prevent log floods and redundant processing when the global risk breaker trips by making control-plane behavior idempotent and state-aware.
- Stop notifier retry storms by adding a circuit-breaker/latch so Telegram failures do not produce unbounded retry spam.
- Add small, focused tests to guard the halt and notifier behavior without touching strategy, SL/TP, or risk math.

### Description
- Remove duplicate per-tick bracket forwarding in `StrategyRunner._on_tick` so bracket handling runs once per tick and protective handlers do not churn state during stress; keep the existing global latch (`_risk_halt_active` / `_risk_halt_logged`) to short-circuit strategy work.
- Harden `TelegramEnhancedNotifier._send_single` by making the degraded cooldown equal the retry window (`retry_window_s`), and latch degraded state on repeated transport failures (network/timeouts/generic Telegram errors) while keeping degradation logging edge-triggered.
- Add two focused unit tests: `tests/strategies/test_runner_risk_halt_latch.py` to verify the risk-halt short-circuits strategy/indicator work while still forwarding bracket ticks, and `tests/notifications/test_telegram_webhook_enhanced.py` to verify degraded latch/cooldown and recovery.
- Add explanatory comments near changes describing intent and why the guards are necessary (no changes to trading math or public APIs).

### Testing
- Ran `./run_checks.sh` as required; it executed but returned repository-wide lint/type/test failures that are pre-existing and unrelated to this patch (Ruff/mypy findings and an unrelated test import error), so `run_checks.sh` did not complete green for the whole repo.
- Executed focused test run `pytest -q tests/strategies/test_runner_risk_halt_latch.py tests/notifications/test_telegram_webhook_enhanced.py` and both tests passed.
- Executed the broader `pytest -q tests --disable-warnings --ignore=tests/test_live_mode.py --ignore=tests/test_health_server.py` and it failed due to pre-existing test import issues unrelated to the changes in this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698acdc0fb8c832487d4a3dcce4ce0a4)