### PR TITLE
feat: add OptionUniverseManager and integrate dynamic option universe

### DIFF
--- a/src/nifty_scalper_bot/config/settings.py
+++ b/src/nifty_scalper_bot/config/settings.py
@@ -851,6 +851,28 @@ class LiquiditySettings:
             raise ConfigurationError("min_top3_depth must be non-negative")
 
 
+@dataclass(slots=True)
+class OptionUniverseSettings:
+    """Dynamic option universe construction parameters."""
+
+    underlying: str = "NIFTY"
+    exchange: str = "NFO"
+    strike_step: int = 50
+    strikes_around_atm: int = 3
+    expiry_roll_hours: float = 12.0
+    market_close_hour: int = 15
+    market_close_minute: int = 30
+
+    def __post_init__(self) -> None:
+        self.underlying = (self.underlying or "NIFTY").strip().upper()
+        self.exchange = (self.exchange or "NFO").strip().upper()
+        self.strike_step = max(1, int(self.strike_step))
+        self.strikes_around_atm = max(0, int(self.strikes_around_atm))
+        self.expiry_roll_hours = max(0.0, float(self.expiry_roll_hours))
+        self.market_close_hour = min(max(0, int(self.market_close_hour)), 23)
+        self.market_close_minute = min(max(0, int(self.market_close_minute)), 59)
+
+
 class InstrumentSettings(BaseSettings):
     """Settings governing instrument cache warm-up and refresh."""
 
@@ -880,6 +902,7 @@ class Settings:
     replay: ReplaySettings = field(default_factory=ReplaySettings)
     selector: SelectorSettings = field(default_factory=SelectorSettings)
     liquidity: LiquiditySettings = field(default_factory=LiquiditySettings)
+    option_universe: OptionUniverseSettings = field(default_factory=OptionUniverseSettings)
     instruments: InstrumentSettings = field(default_factory=InstrumentSettings)
     elite: EliteStrategiesSettings = field(default_factory=EliteStrategiesSettings)
     poll_batch_size: int = 50
@@ -1284,6 +1307,27 @@ def _build_liquidity_settings() -> LiquiditySettings:
     )
 
 
+def _build_option_universe_settings() -> OptionUniverseSettings:
+    return OptionUniverseSettings(
+        underlying=_env_str("OPTION_UNIVERSE__UNDERLYING", default="NIFTY")
+        or "NIFTY",
+        exchange=_env_str("OPTION_UNIVERSE__EXCHANGE", default="NFO") or "NFO",
+        strike_step=_env_int("OPTION_UNIVERSE__STRIKE_STEP", default=50, minimum=1),
+        strikes_around_atm=_env_int(
+            "OPTION_UNIVERSE__STRIKES_AROUND_ATM", default=3, minimum=0
+        ),
+        expiry_roll_hours=_env_float(
+            "OPTION_UNIVERSE__EXPIRY_ROLL_HOURS", default=12.0, minimum=0.0
+        ),
+        market_close_hour=_env_int(
+            "OPTION_UNIVERSE__MARKET_CLOSE_HOUR", default=15, minimum=0
+        ),
+        market_close_minute=_env_int(
+            "OPTION_UNIVERSE__MARKET_CLOSE_MINUTE", default=30, minimum=0
+        ),
+    )
+
+
 def _build_instrument_settings() -> InstrumentSettings:
     """Construct instrument cache configuration from environment.
 
@@ -1345,6 +1389,7 @@ def get_settings() -> Settings:
         replay=_build_replay_settings(),
         selector=_build_selector_settings(),
         liquidity=_build_liquidity_settings(),
+        option_universe=_build_option_universe_settings(),
         instruments=_build_instrument_settings(),
         elite=_build_elite_settings(),
         execution=ExecutionSettings(

--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -55,6 +55,7 @@ from fastapi.responses import JSONResponse, PlainTextResponse
 
 from nifty_scalper_bot.config.base import AppConfig
 from nifty_scalper_bot.config.settings import Settings, get_settings
+from nifty_scalper_bot.core.option_universe import OptionUniverseManager
 from nifty_scalper_bot.core.market_regime_manager import MarketRegimeManager
 from nifty_scalper_bot.core.message_bus import Message, MessageBus, MessageType
 from nifty_scalper_bot.core.strategy_manager import StrategyManager
@@ -1444,6 +1445,7 @@ class BotContext:
     underlying_spot_prices: OrderedDict[str, float] = field(
         default_factory=lambda: OrderedDict()
     )
+    option_universe: OptionUniverseManager | None = None
 
     def update_spot_price(
         self, underlying: str, price: float, max_size: int = 100
@@ -2040,46 +2042,30 @@ def _get_symbols(
     config: AppConfig,
     resolver: InstrumentResolver | None = None,
     broker: Any | None = None,
+    option_universe: OptionUniverseManager | None = None,
 ) -> list[str]:
-    """
-    Return validated option symbols for trading.
+    """Return validated option symbols for trading."""
+    LOGGER.info('=' * 60)
+    LOGGER.info('🔍 _get_symbols() STARTING - Symbol Resolution')
 
-    PRODUCTION FIX v2.0:
-    - Fixed 'contracts' undefined bug
-    - Guaranteed option symbol generation
-    - Robust price fetching with multiple fallbacks
-    """
-    import calendar
-    import datetime
-    from datetime import timedelta
-
-    LOGGER.info("=" * 60)
-    LOGGER.info("🔍 _get_symbols() STARTING - Symbol Resolution")
-
-    # 1. Check for explicit configuration (highest priority)
-    symbols = getattr(config, "symbols", None)
+    symbols = getattr(config, 'symbols', None)
     if symbols:
         if isinstance(symbols, Iterable) and not isinstance(symbols, (str, bytes)):
             result = [str(s).strip() for s in symbols if str(s).strip()]
-            LOGGER.info(f"✅ Using configured SYMBOLS env: {result}")
-            LOGGER.info("=" * 60)
+            LOGGER.info('✅ Using configured SYMBOLS env: %s', result)
+            LOGGER.info('=' * 60)
             return result
         result = [str(symbols)]
-        LOGGER.info(f"✅ Using configured SYMBOLS env: {result}")
-        LOGGER.info("=" * 60)
+        LOGGER.info('✅ Using configured SYMBOLS env: %s', result)
+        LOGGER.info('=' * 60)
         return result
 
-    final_symbols: list[str] = []
-    atm_price: int | None = None
     ltp: float = 0.0
-
-    # 2. Fetch Live Spot Price
     if broker:
         try:
             token_candidates = [256265]
-            str_candidates = ["NSE:NIFTY 50", "NIFTY 50", "NIFTY 50 INDEX"]
-
-            inner = getattr(broker, "client", getattr(broker, "_broker", broker))
+            str_candidates = ['NSE:NIFTY 50', 'NIFTY 50', 'NIFTY 50 INDEX']
+            inner = getattr(broker, 'client', getattr(broker, '_broker', broker))
 
             def parse_price(data: Any) -> float:
                 if not data:
@@ -2087,7 +2073,7 @@ def _get_symbols(
                 if isinstance(data, (int, float)):
                     return float(data)
                 if isinstance(data, dict):
-                    for key in ("last_price", "ltp", "close"):
+                    for key in ('last_price', 'ltp', 'close'):
                         val = data.get(key)
                         if val:
                             try:
@@ -2096,198 +2082,60 @@ def _get_symbols(
                                 continue
                 return 0.0
 
-            # Strategy A: get_ltp_bulk
-            if ltp == 0 and hasattr(inner, "get_ltp_bulk"):
-                try:
-                    response = inner.get_ltp_bulk(token_candidates)
-                    if response:
-                        for t in token_candidates:
-                            val = response.get(t) or response.get(str(t))
-                            price = parse_price(val)
-                            if price > 0:
-                                ltp = price
-                                LOGGER.info(f"✅ NIFTY price via get_ltp_bulk: {ltp}")
-                                break
-                except Exception as e:
-                    LOGGER.debug(f"get_ltp_bulk failed: {e}")
-
-            # Strategy B: get_ltp
-            if ltp == 0 and hasattr(inner, "get_ltp"):
-                for s in str_candidates:
-                    try:
-                        p = inner.get_ltp(s)
-                        price = parse_price(p)
+            if ltp == 0 and hasattr(inner, 'get_ltp_bulk'):
+                response = inner.get_ltp_bulk(token_candidates)
+                if response:
+                    for t in token_candidates:
+                        val = response.get(t) or response.get(str(t))
+                        price = parse_price(val)
                         if price > 0:
                             ltp = price
-                            LOGGER.info(f"✅ NIFTY price via get_ltp: {ltp}")
+                            break
+
+            if ltp == 0 and hasattr(inner, 'get_ltp'):
+                for candidate in str_candidates:
+                    try:
+                        price = parse_price(inner.get_ltp(candidate))
+                        if price > 0:
+                            ltp = price
                             break
                     except Exception:
-                        pass
+                        continue
 
-            # Strategy C: Standard Kite .ltp()
-            if ltp == 0 and hasattr(inner, "ltp"):
+            if ltp == 0 and hasattr(inner, 'ltp'):
                 try:
                     q = inner.ltp(str_candidates)
-                    for k in str_candidates:
-                        if k in q:
-                            price = parse_price(q[k])
+                    for candidate in str_candidates:
+                        if candidate in q:
+                            price = parse_price(q[candidate])
                             if price > 0:
                                 ltp = price
-                                LOGGER.info(f"✅ NIFTY price via .ltp(): {ltp}")
                                 break
-                except Exception as e:
-                    LOGGER.debug(f".ltp() failed: {e}")
-
-            # Strategy D: quote()
-            if ltp == 0 and hasattr(inner, "quote"):
-                try:
-                    q = inner.quote(str_candidates)
-                    for k in str_candidates:
-                        if k in q:
-                            price = parse_price(q[k])
-                            if price > 0:
-                                ltp = price
-                                LOGGER.info(f"✅ NIFTY price via .quote(): {ltp}")
-                                break
-                except Exception as e:
-                    LOGGER.debug(f".quote() failed: {e}")
-
-            if ltp > 0:
-                atm_price = round(ltp / 50) * 50
-                LOGGER.info(f"✅ Live NIFTY Spot: {ltp} -> ATM Strike: {atm_price}")
-                global _LATEST_CTX
-                if _LATEST_CTX:
-                    _LATEST_CTX.update_spot_price("NIFTY", ltp)
-            else:
-                LOGGER.warning("⚠️ Could not fetch live NIFTY price from broker")
-
+                except Exception:
+                    pass
         except Exception as exc:
-            LOGGER.error(f"Error fetching live price: {exc}", exc_info=True)
+            LOGGER.error('Error fetching live price: %s', exc, exc_info=True)
 
-    # 3. Fallback ATM price (Update based on current NIFTY ~25200)
-    if atm_price is None or atm_price < 15000:
-        fallback_base = 25200
-        LOGGER.warning(f"⚠️ Using fallback ATM: {fallback_base}")
-        atm_price = fallback_base
+    if ltp <= 0:
+        ltp = 25200.0
+        LOGGER.warning('⚠️ Using fallback ATM from default spot %.2f', ltp)
 
-    # 4. Generate strike range
-    strike_step = 50
-    strikes_to_fetch = [
-        atm_price - strike_step,
-        atm_price,
-        atm_price + strike_step,
-    ]
-    LOGGER.info(f"📊 Strikes to fetch: {strikes_to_fetch}")
+    global _LATEST_CTX
+    universe = option_universe
+    if universe is None:
+        settings = getattr(_LATEST_CTX, 'settings', None)
+        universe_config = getattr(settings, 'option_universe', {})
+        universe = OptionUniverseManager(universe_config)
 
-    # 5. Try Smart Resolution (FIXED: contracts initialization)
-    try:
-        from nifty_scalper_bot.utils.smart_symbol import get_next_valid_symbols
+    universe.update_underlying(float(ltp))
+    final_symbols = universe.get_current_universe()
+    LOGGER.debug('OptionUniv: Universe refreshed -> %s', final_symbols)
 
-        contract_map = {}
-        contracts: list = []  # FIX: Initialize contracts list
+    if _LATEST_CTX:
+        _LATEST_CTX.update_spot_price('NIFTY', float(ltp))
 
-        if resolver:
-            if hasattr(resolver, "option_contracts"):
-                try:
-                    contracts = resolver.option_contracts("NIFTY") or []
-                    LOGGER.info(
-                        f"📦 Got {len(contracts)} contracts from option_contracts()"
-                    )
-                except Exception as e:
-                    LOGGER.debug(f"option_contracts() failed: {e}")
-                    contracts = []
-
-            if not contracts and hasattr(resolver, "_option_contracts"):
-                try:
-                    raw = getattr(resolver, "_option_contracts", {})
-                    for c_list in raw.values():
-                        if isinstance(c_list, list):
-                            contracts.extend(c_list)
-                    LOGGER.info(
-                        f"📦 Got {len(contracts)} contracts from _option_contracts"
-                    )
-                except Exception as e:
-                    LOGGER.debug(f"_option_contracts access failed: {e}")
-
-            for c in contracts:
-                t = c.get("instrument_token")
-                if t:
-                    try:
-                        contract_map[int(t)] = c
-                    except (ValueError, TypeError):
-                        pass
-
-        if contract_map and get_next_valid_symbols:
-            LOGGER.info(
-                f"🔍 Trying smart resolution with {len(contract_map)} contracts"
-            )
-            results = get_next_valid_symbols(
-                strikes_to_fetch, opt_types=("CE", "PE"), instrument_map=contract_map
-            )
-            for inst in results:
-                ts = inst.get("tradingsymbol") or inst.get("symbol")
-                if ts:
-                    prefix = "NFO:" if not ts.startswith("NFO:") else ""
-                    final_symbols.append(f"{prefix}{ts}")
-
-            if final_symbols:
-                LOGGER.info(
-                    f"✅ Smart resolution found {len(final_symbols)} symbols: {final_symbols}"
-                )
-
-    except Exception as exc:
-        LOGGER.warning(f"Smart resolution skipped: {exc}")
-
-    # 6. GUARANTEED Fallback - Always generate options if none found
-    if not final_symbols:
-        LOGGER.warning("⚠️ Smart resolution failed. Using GUARANTEED fallback.")
-
-        now = datetime.datetime.now()
-        today = now.date()
-
-        # Find next Tuesday (weekly expiry)
-        target_weekday = 1  # Tuesday
-        days_ahead = target_weekday - today.weekday()
-        if days_ahead < 0:
-            days_ahead += 7
-        if days_ahead == 0 and now.hour >= 16:
-            days_ahead += 7
-
-        next_expiry = today + timedelta(days=days_ahead)
-
-        # Check if monthly expiry (last Tuesday of month)
-        last_day_of_month = calendar.monthrange(next_expiry.year, next_expiry.month)[1]
-        potential_monthly = datetime.date(
-            next_expiry.year, next_expiry.month, last_day_of_month
-        )
-        while potential_monthly.weekday() != target_weekday:
-            potential_monthly -= timedelta(days=1)
-
-        is_monthly = next_expiry == potential_monthly
-
-        # Format expiry code (Zerodha convention)
-        if is_monthly:
-            date_code = next_expiry.strftime("%y%b").upper()
-        else:
-            y = next_expiry.strftime("%y")
-            d = next_expiry.strftime("%d")
-            m_map = {10: "O", 11: "N", 12: "D"}
-            m = m_map.get(next_expiry.month, str(next_expiry.month))
-            date_code = f"{y}{m}{d}"
-
-        LOGGER.info(
-            f"📅 Expiry: {next_expiry} | Type: {'Monthly' if is_monthly else 'Weekly'} | Code: {date_code}"
-        )
-
-        for strike in strikes_to_fetch:
-            for kind in ("CE", "PE"):
-                sym = f"NFO:NIFTY{date_code}{strike}{kind}"
-                final_symbols.append(sym)
-
-        LOGGER.info(f"✅ Generated fallback symbols: {final_symbols}")
-
-    LOGGER.info(f"🎯 FINAL SYMBOLS TO TRADE: {final_symbols}")
-    LOGGER.info("=" * 60)
+    LOGGER.info('🎯 FINAL SYMBOLS TO TRADE: %s', final_symbols)
+    LOGGER.info('=' * 60)
     return final_symbols
 
 
@@ -4433,6 +4281,8 @@ def initialize_components(settings: Settings | None = None) -> BotContext:
     )
     health_app = create_health_app(health_state)
 
+    option_universe_manager = OptionUniverseManager(settings.option_universe)
+
     ctx = BotContext(
         settings=settings,
         config=config,
@@ -4479,6 +4329,7 @@ def initialize_components(settings: Settings | None = None) -> BotContext:
         telegram_notifier=notifier,
         health_app=health_app,
         session_guard=session_guard,
+        option_universe=option_universe_manager,
     )
 
     resolver_candidate = ctx.instrument_resolver
@@ -5477,6 +5328,7 @@ async def startup_sequence(ctx: BotContext) -> None:
                 ctx.config,
                 ctx.instrument_resolver,
                 ctx.broker_client,
+                option_universe=ctx.option_universe,
             )
 
             # ---------- Futures rollover logic (unchanged) ----------
@@ -5666,6 +5518,58 @@ async def startup_sequence(ctx: BotContext) -> None:
                 asyncio.create_task(asyncio.to_thread(mdm._rest_poll_loop))
             else:
                 LOGGER.info("📡 MDM polling disabled (PollingStreamer is active)")
+
+            dynamic_option_symbols = {
+                sym for sym in targets if sym.startswith('NFO:NIFTY') and (sym.endswith('CE') or sym.endswith('PE'))
+            }
+
+            async def _option_universe_sync_loop() -> None:
+                """Keep option subscriptions aligned with the dynamic option universe."""
+                nonlocal dynamic_option_symbols
+                while True:
+                    try:
+                        if not ctx.option_universe:
+                            await asyncio.sleep(30)
+                            continue
+
+                        spot = ctx.market_data_manager.get_latest_price('NSE:NIFTY 50') if ctx.market_data_manager else None
+                        if spot and spot > 0:
+                            ctx.option_universe.update_underlying(float(spot))
+
+                        latest_symbols = set(ctx.option_universe.get_current_universe())
+                        add_symbols = sorted(latest_symbols - dynamic_option_symbols)
+                        drop_symbols = sorted(dynamic_option_symbols - latest_symbols)
+
+                        if add_symbols or drop_symbols:
+                            LOGGER.debug(
+                                'OptionUniv: subscription update add=%s drop=%s',
+                                add_symbols,
+                                drop_symbols,
+                                extra={'event': 'option_universe_subscriptions_update'},
+                            )
+
+                        for sym in add_symbols:
+                            if ctx.market_data_manager:
+                                ctx.market_data_manager.ensure_tracking(sym)
+                            tok = ctx.instrument_resolver.resolve(sym) if ctx.instrument_resolver else None
+                            if tok and ctx.streamer and hasattr(ctx.streamer, 'subscribe'):
+                                ctx.streamer.subscribe([tok])
+                            if ctx.strategy_runner:
+                                ctx.strategy_runner.add_symbol(sym)
+
+                        for sym in drop_symbols:
+                            tok = ctx.instrument_resolver.resolve(sym) if ctx.instrument_resolver else None
+                            if tok and ctx.streamer and hasattr(ctx.streamer, 'unsubscribe'):
+                                ctx.streamer.unsubscribe([tok])
+                            if ctx.strategy_runner:
+                                ctx.strategy_runner.remove_symbol(sym)
+
+                        dynamic_option_symbols = latest_symbols
+                    except Exception as exc:
+                        LOGGER.error('Failure in option universe sync loop: %s', exc, exc_info=exc)
+                    await asyncio.sleep(30)
+
+            asyncio.create_task(_option_universe_sync_loop())
         except Exception as e:
             LOGGER.error("Hydration/Tracking failed", exc_info=True)
 

--- a/src/nifty_scalper_bot/core/option_universe.py
+++ b/src/nifty_scalper_bot/core/option_universe.py
@@ -1,0 +1,251 @@
+"""Dynamic option universe construction for NIFTY contracts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime, time, timedelta
+from typing import Any, Callable
+
+from nifty_scalper_bot.utils.logging import get_logger
+
+LOGGER = get_logger(__name__)
+
+
+@dataclass(slots=True)
+class OptionUniverseConfig:
+    """Configuration consumed by :class:`OptionUniverseManager`."""
+
+    underlying: str = 'NIFTY'
+    exchange: str = 'NFO'
+    strike_step: int = 50
+    strikes_around_atm: int = 3
+    expiry_roll_hours: float = 12.0
+    market_close_hour: int = 15
+    market_close_minute: int = 30
+
+
+class OptionUniverseManager:
+    """Build and maintain a rolling liquid option universe around ATM."""
+
+    def __init__(
+        self,
+        config: OptionUniverseConfig | dict[str, Any] | Any,
+        now_fn: Callable[[], datetime] | None = None,
+    ) -> None:
+        """Initialize manager state.
+
+        Args:
+            config: Option universe configuration object.
+            now_fn: Optional clock override used by tests.
+
+        Returns:
+            None.
+
+        Raises:
+            ValueError: When strike step or strike window configuration is invalid.
+        """
+        self._config = self._coerce_config(config)
+        if self._config.strike_step <= 0:
+            raise ValueError('strike_step must be positive')
+        if self._config.strikes_around_atm < 0:
+            raise ValueError('strikes_around_atm must be non-negative')
+
+        self._now_fn = now_fn or datetime.now
+        self._latest_spot: float | None = None
+        self._atm_strike: int | None = None
+        self._current_expiry: date | None = None
+        self._current_universe: list[str] = []
+
+    def update_underlying(self, spot_price: float) -> None:
+        """Refresh ATM, expiry and universe based on latest underlying spot.
+
+        Args:
+            spot_price: Latest NIFTY spot or index LTP.
+
+        Returns:
+            None.
+
+        Raises:
+            ValueError: When *spot_price* is not positive.
+        """
+        if spot_price <= 0:
+            raise ValueError('spot_price must be positive')
+
+        now = self._now_fn()
+        self._latest_spot = float(spot_price)
+        new_atm = int(round(self._latest_spot / self._config.strike_step) * self._config.strike_step)
+        new_expiry = self._resolve_active_expiry(now)
+
+        atm_changed = new_atm != self._atm_strike
+        expiry_changed = new_expiry != self._current_expiry
+
+        if expiry_changed and self._current_expiry is not None:
+            LOGGER.debug(
+                'OptionUniv: expiry rolled %s -> %s',
+                self._current_expiry,
+                new_expiry,
+                extra={'event': 'option_universe_expiry_roll'},
+            )
+
+        if atm_changed:
+            LOGGER.debug(
+                'OptionUniv: ATM updated -> ATM=%s expiry=%s',
+                new_atm,
+                new_expiry,
+                extra={'event': 'option_universe_atm_update'},
+            )
+
+        if atm_changed or expiry_changed or not self._current_universe:
+            self._atm_strike = new_atm
+            self._current_expiry = new_expiry
+            self._current_universe = self._build_universe(new_atm, new_expiry)
+            LOGGER.debug(
+                'OptionUniv: Universe refreshed -> %s',
+                self._current_universe,
+                extra={'event': 'option_universe_refreshed'},
+            )
+
+    def get_current_universe(self) -> list[str]:
+        """Return the latest full option universe.
+
+        Args:
+            None.
+
+        Returns:
+            list[str]: Current CE/PE symbol universe.
+
+        Raises:
+            None.
+        """
+        return list(self._current_universe)
+
+    def get_primary_symbols(self) -> list[str]:
+        """Return ATM-centered symbols used as primary scan targets.
+
+        Args:
+            None.
+
+        Returns:
+            list[str]: ATM ± configured strike range contracts.
+
+        Raises:
+            None.
+        """
+        return self.get_current_universe()
+
+    def _coerce_config(self, config: OptionUniverseConfig | dict[str, Any] | Any) -> OptionUniverseConfig:
+        """Normalize external config objects into :class:`OptionUniverseConfig`."""
+        if isinstance(config, OptionUniverseConfig):
+            return config
+        if isinstance(config, dict):
+            payload = dict(config)
+        else:
+            payload = {
+                'underlying': getattr(config, 'underlying', 'NIFTY'),
+                'exchange': getattr(config, 'exchange', 'NFO'),
+                'strike_step': getattr(config, 'strike_step', 50),
+                'strikes_around_atm': getattr(config, 'strikes_around_atm', 3),
+                'expiry_roll_hours': getattr(config, 'expiry_roll_hours', 12.0),
+                'market_close_hour': getattr(config, 'market_close_hour', 15),
+                'market_close_minute': getattr(config, 'market_close_minute', 30),
+            }
+        return OptionUniverseConfig(
+            underlying=str(payload.get('underlying', 'NIFTY')).upper(),
+            exchange=str(payload.get('exchange', 'NFO')).upper(),
+            strike_step=int(payload.get('strike_step', 50)),
+            strikes_around_atm=int(payload.get('strikes_around_atm', 3)),
+            expiry_roll_hours=float(payload.get('expiry_roll_hours', 12.0)),
+            market_close_hour=int(payload.get('market_close_hour', 15)),
+            market_close_minute=int(payload.get('market_close_minute', 30)),
+        )
+
+    def _build_universe(self, atm_strike: int, expiry: date) -> list[str]:
+        """Build CE/PE symbol list for configured strike range and expiry."""
+        expiry_code = self._format_expiry_code(expiry)
+        strikes = [
+            atm_strike + (offset * self._config.strike_step)
+            for offset in range(-self._config.strikes_around_atm, self._config.strikes_around_atm + 1)
+        ]
+        symbols: list[str] = []
+        for strike in strikes:
+            symbols.append(
+                f'{self._config.exchange}:{self._config.underlying}{expiry_code}{strike}CE'
+            )
+            symbols.append(
+                f'{self._config.exchange}:{self._config.underlying}{expiry_code}{strike}PE'
+            )
+        return symbols
+
+    def _resolve_active_expiry(self, now: datetime) -> date:
+        """Select nearest valid expiry, rolling early near expiry cutoff."""
+        candidates = self._build_expiry_calendar(now.date())
+        if not candidates:
+            raise ValueError('no expiry candidates generated')
+
+        roll_delta = timedelta(hours=self._config.expiry_roll_hours)
+        for candidate in candidates:
+            expiry_dt = datetime.combine(
+                candidate,
+                time(self._config.market_close_hour, self._config.market_close_minute),
+            )
+            if expiry_dt - now > roll_delta:
+                return candidate
+        return candidates[-1]
+
+    def _build_expiry_calendar(self, anchor: date) -> list[date]:
+        """Generate weekly, monthly and quarterly expiry candidates."""
+        weekly = self._weekly_expiries(anchor, weeks=16)
+        monthly = self._monthly_expiries(anchor, months=8)
+        quarterly = self._quarterly_expiries(anchor, quarters=6)
+        ordered = sorted({*weekly, *monthly, *quarterly})
+        return [item for item in ordered if item >= anchor]
+
+    def _weekly_expiries(self, anchor: date, weeks: int) -> list[date]:
+        """Build Tuesday weekly expiry schedule from *anchor*."""
+        days_ahead = (1 - anchor.weekday()) % 7
+        first = anchor + timedelta(days=days_ahead)
+        return [first + timedelta(days=7 * idx) for idx in range(weeks)]
+
+    def _monthly_expiries(self, anchor: date, months: int) -> list[date]:
+        """Build monthly expiries (last Tuesday) from *anchor*."""
+        expiries: list[date] = []
+        year = anchor.year
+        month = anchor.month
+        for _ in range(months):
+            first_next = date(year + (month // 12), ((month % 12) + 1), 1)
+            cursor = first_next - timedelta(days=1)
+            while cursor.weekday() != 1:
+                cursor -= timedelta(days=1)
+            expiries.append(cursor)
+            month += 1
+            if month > 12:
+                month = 1
+                year += 1
+        return expiries
+
+    def _quarterly_expiries(self, anchor: date, quarters: int) -> list[date]:
+        """Build quarterly expiries (last Tuesday of Mar/Jun/Sep/Dec)."""
+        expiries: list[date] = []
+        quarter_months = (3, 6, 9, 12)
+        year = anchor.year
+        while len(expiries) < quarters:
+            for month in quarter_months:
+                if len(expiries) >= quarters:
+                    break
+                first_next = date(year + (month // 12), ((month % 12) + 1), 1)
+                cursor = first_next - timedelta(days=1)
+                while cursor.weekday() != 1:
+                    cursor -= timedelta(days=1)
+                if cursor >= anchor:
+                    expiries.append(cursor)
+            year += 1
+        return expiries
+
+    def _format_expiry_code(self, expiry: date) -> str:
+        """Format expiry into weekly or monthly Zerodha option code."""
+        monthly_expiry = expiry in set(self._monthly_expiries(expiry.replace(day=1), months=1))
+        if monthly_expiry:
+            return expiry.strftime('%y%b').upper()
+        month_map = {10: 'O', 11: 'N', 12: 'D'}
+        month_token = month_map.get(expiry.month, str(expiry.month))
+        return f"{expiry.strftime('%y')}{month_token}{expiry.strftime('%d')}"

--- a/tests/test_option_universe.py
+++ b/tests/test_option_universe.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from nifty_scalper_bot.core.option_universe import (
+    OptionUniverseConfig,
+    OptionUniverseManager,
+)
+
+
+def test_option_universe_builds_atm_range() -> None:
+    manager = OptionUniverseManager(
+        OptionUniverseConfig(strike_step=50, strikes_around_atm=1),
+        now_fn=lambda: datetime(2026, 2, 1, 10, 0, 0),
+    )
+
+    manager.update_underlying(18638.0)
+    symbols = manager.get_current_universe()
+
+    assert len(symbols) == 6
+    assert any(symbol.endswith('18650CE') for symbol in symbols)
+    assert any(symbol.endswith('18600PE') for symbol in symbols)
+    assert any(symbol.endswith('18700PE') for symbol in symbols)
+
+
+def test_option_universe_rolls_expiry_near_threshold() -> None:
+    manager = OptionUniverseManager(
+        OptionUniverseConfig(expiry_roll_hours=2.0),
+        now_fn=lambda: datetime(2026, 2, 3, 11, 0, 0),
+    )
+
+    manager.update_underlying(18650.0)
+    first_universe = manager.get_current_universe()
+
+    manager_late = OptionUniverseManager(
+        OptionUniverseConfig(expiry_roll_hours=2.0),
+        now_fn=lambda: datetime(2026, 2, 3, 15, 10, 0),
+    )
+    manager_late.update_underlying(18650.0)
+    rolled_universe = manager_late.get_current_universe()
+
+    assert first_universe
+    assert rolled_universe
+    assert first_universe != rolled_universe
+
+
+def test_primary_symbols_matches_current_universe() -> None:
+    manager = OptionUniverseManager(
+        OptionUniverseConfig(strike_step=100, strikes_around_atm=2),
+        now_fn=lambda: datetime(2026, 3, 10, 11, 0, 0),
+    )
+
+    manager.update_underlying(22540.0)
+
+    assert manager.get_primary_symbols() == manager.get_current_universe()


### PR DESCRIPTION
### Motivation
- Replace brittle hard-coded option symbol lists with a dynamic universe derived from live spot, ATM strike, and nearest expiries to make subscriptions resilient to spot moves and expiry rollovers.
- Ensure strategies continue to receive the same symbol inputs while enabling automatic roll/refresh behaviour and reducing manual symbol maintenance.
- Provide observability when ATM/expiry/universe transitions occur to aid debugging and reduce missed lifecycle events.

### Description
- Add a new `OptionUniverseManager` implemented in `src/nifty_scalper_bot/core/option_universe.py` that computes ATM (rounded to configured `strike_step`), builds an ATM ± `strikes_around_atm` CE/PE universe, selects nearest weekly/monthly/quarterly expiry, and supports early expiry roll based on `expiry_roll_hours` (all methods documented with docstrings).
- Introduce `OptionUniverseSettings` in `src/nifty_scalper_bot/config/settings.py` and wire environment-driven construction via `_build_option_universe_settings`, exposing runtime knobs like `strike_step`, `strikes_around_atm`, and `expiry_roll_hours`.
- Integrate the manager into startup and symbol resolution in `src/nifty_scalper_bot/core/app.py` by creating a singleton `option_universe` in `BotContext`, updating `_get_symbols` to use `OptionUniverseManager.get_current_universe()`, and adding a background `_option_universe_sync_loop` that diffs and applies add/remove subscription changes to `MarketDataManager`/`streamer` and the `StrategyRunner`.
- Add debug/INFO logging hooks for ATM updates, expiry rolls, universe refreshes, and subscription changes (structured via existing `LOGGER` calls) and add focused unit tests in `tests/test_option_universe.py` validating ATM strike generation and expiry-rolling behaviour.

### Testing
- Ran `./run_checks.sh`; the script executed but repository-wide checks failed due to pre-existing broad mypy/pytest and environment differences in this workspace (these issues are in unrelated areas of the codebase and not introduced by this change).
- Verified syntax/compilation with `python -m py_compile src/nifty_scalper_bot/core/option_universe.py src/nifty_scalper_bot/core/app.py src/nifty_scalper_bot/config/settings.py` which succeeded.
- Executed the new unit tests with `pytest -q tests/test_option_universe.py` and they passed (tests exercise ATM range generation and expiry roll behaviour).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698aeaa4330883248beb9c7a889ec2a2)