### PR TITLE
fix: harden strategy data hydration and sync gating

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -46,6 +46,7 @@ from nifty_scalper_bot.data.robust_provider import (
 from nifty_scalper_bot.infra.watchdog import start_watchdog
 
 LOGGER = logging.getLogger("nifty_scalper_bot.core.app")
+SYNC_LOCK = threading.Lock()
 
 from urllib.parse import urlsplit
 from zoneinfo import ZoneInfo
@@ -2128,7 +2129,7 @@ def _get_symbols(
         universe = OptionUniverseManager(universe_config)
 
     universe.update_underlying(float(ltp))
-    final_symbols = universe.get_current_universe()
+    final_symbols = universe.get_filtered_universe(float(ltp))
     LOGGER.debug('OptionUniv: Universe refreshed -> %s', final_symbols)
 
     if _LATEST_CTX:
@@ -5534,9 +5535,11 @@ async def startup_sequence(ctx: BotContext) -> None:
 
                         spot = ctx.market_data_manager.get_latest_price('NSE:NIFTY 50') if ctx.market_data_manager else None
                         if spot and spot > 0:
-                            ctx.option_universe.update_underlying(float(spot))
-
-                        latest_symbols = set(ctx.option_universe.get_current_universe())
+                            latest_symbols = set(
+                                ctx.option_universe.get_filtered_universe(float(spot))
+                            )
+                        else:
+                            latest_symbols = set(ctx.option_universe.get_current_universe())
                         add_symbols = sorted(latest_symbols - dynamic_option_symbols)
                         drop_symbols = sorted(dynamic_option_symbols - latest_symbols)
 
@@ -5830,37 +5833,34 @@ async def _reconcile_state(ctx: BotContext) -> None:
     Syncs local state with Broker (Orders & Positions).
     Features: Non-Blocking Execution, Position Sync, and Auto-Guarding of Orphans.
     """
-    # 1. SYNC ORDERS (Non-Blocking Thread)
-    if ctx.order_manager:
+    def safe_sync_fetch() -> list[Mapping[str, Any]]:
+        """Synchronize broker orders/positions under a global non-blocking lock."""
+        if not SYNC_LOCK.acquire(False):
+            return []
         try:
-            await asyncio.to_thread(ctx.order_manager.reconcile_open_orders_with_broker)
-        except Exception as exc:
-            LOGGER.debug(f"Order Reconcile Warning: {exc}")
-
-    # 2. SYNC POSITIONS & AUTO-GUARD ORPHANS
-    if ctx.position_manager:
-        try:
-            # A. Fetch Broker Positions (REQUIRED STEP)
-            raw_data = await ctx.broker_client.get_positions()
-            broker_positions = []
-
-            # Robust Parsing of Broker Data
-            if isinstance(raw_data, list):
-                broker_positions = [p for p in raw_data if isinstance(p, Mapping)]
-            elif isinstance(raw_data, Mapping):
-                # Handle 'net' or 'day' keys common in broker APIs
-                src = raw_data.get("net", raw_data)
+            if ctx.order_manager:
+                ctx.order_manager.reconcile_open_orders_with_broker()
+            raw = ctx.broker_client.get_positions()
+            broker_positions: list[Mapping[str, Any]] = []
+            if isinstance(raw, list):
+                broker_positions = [p for p in raw if isinstance(p, Mapping)]
+            elif isinstance(raw, Mapping):
+                src = raw.get('net', raw)
                 if isinstance(src, list):
                     broker_positions = [p for p in src if isinstance(p, Mapping)]
-                else:
+                elif isinstance(src, Mapping):
                     broker_positions = [src]
+            if ctx.position_manager:
+                ctx.position_manager.synchronize_with_broker(broker_positions)
+            return broker_positions
+        finally:
+            SYNC_LOCK.release()
 
-            # B. Sync Broker Positions (Pass data to Manager)
-            # We run this in a thread to keep the bot responsive
-            await asyncio.to_thread(
-                ctx.position_manager.synchronize_with_broker, broker_positions
-            )
-
+    # 1/2. SYNC ORDERS + POSITIONS & AUTO-GUARD ORPHANS
+    if ctx.position_manager:
+        try:
+            broker_positions = await asyncio.to_thread(safe_sync_fetch)
+            # A. Fetch Broker Positions (REQUIRED STEP)
             # C. Auto-Guard Orphans (CRITICAL SAFETY LOGIC)
             if ctx.order_manager and ctx.order_manager._bracket_manager:
                 om = ctx.order_manager

--- a/src/nifty_scalper_bot/core/option_universe.py
+++ b/src/nifty_scalper_bot/core/option_universe.py
@@ -22,6 +22,7 @@ class OptionUniverseConfig:
     expiry_roll_hours: float = 12.0
     market_close_hour: int = 15
     market_close_minute: int = 30
+    spot_recalc_threshold_points: float = 25.0
 
 
 class OptionUniverseManager:
@@ -55,6 +56,7 @@ class OptionUniverseManager:
         self._atm_strike: int | None = None
         self._current_expiry: date | None = None
         self._current_universe: list[str] = []
+        self._last_recalc_spot: float | None = None
 
     def update_underlying(self, spot_price: float) -> None:
         """Refresh ATM, expiry and universe based on latest underlying spot.
@@ -133,6 +135,25 @@ class OptionUniverseManager:
         """
         return self.get_current_universe()
 
+    def get_filtered_universe(self, spot_ltp: float) -> list[str]:
+        """Return ATM-window symbols for nearest weekly and next monthly expiry."""
+        if spot_ltp <= 0:
+            return list(self._current_universe)
+        threshold = max(1.0, float(self._config.spot_recalc_threshold_points))
+        if self._last_recalc_spot is None or abs(spot_ltp - self._last_recalc_spot) >= threshold:
+            self.update_underlying(spot_ltp)
+            self._last_recalc_spot = float(spot_ltp)
+        atm = self._atm_strike
+        if atm is None:
+            return list(self._current_universe)
+        weekly, monthly = self._resolve_weekly_monthly_expiries(self._now_fn())
+        symbols: list[str] = []
+        for expiry in (weekly, monthly):
+            if expiry is None:
+                continue
+            symbols.extend(self._build_universe(atm, expiry))
+        return list(dict.fromkeys(symbols)) if symbols else list(self._current_universe)
+
     def _coerce_config(self, config: OptionUniverseConfig | dict[str, Any] | Any) -> OptionUniverseConfig:
         """Normalize external config objects into :class:`OptionUniverseConfig`."""
         if isinstance(config, OptionUniverseConfig):
@@ -148,6 +169,9 @@ class OptionUniverseManager:
                 'expiry_roll_hours': getattr(config, 'expiry_roll_hours', 12.0),
                 'market_close_hour': getattr(config, 'market_close_hour', 15),
                 'market_close_minute': getattr(config, 'market_close_minute', 30),
+                'spot_recalc_threshold_points': getattr(
+                    config, 'spot_recalc_threshold_points', 25.0
+                ),
             }
         return OptionUniverseConfig(
             underlying=str(payload.get('underlying', 'NIFTY')).upper(),
@@ -157,7 +181,21 @@ class OptionUniverseManager:
             expiry_roll_hours=float(payload.get('expiry_roll_hours', 12.0)),
             market_close_hour=int(payload.get('market_close_hour', 15)),
             market_close_minute=int(payload.get('market_close_minute', 30)),
+            spot_recalc_threshold_points=float(
+                payload.get('spot_recalc_threshold_points', 25.0)
+            ),
         )
+
+    def _resolve_weekly_monthly_expiries(
+        self, now: datetime
+    ) -> tuple[date | None, date | None]:
+        """Resolve nearest weekly then next monthly expiry candidates."""
+        calendar = self._build_expiry_calendar(now.date())
+        roll_delta = timedelta(hours=self._config.expiry_roll_hours)
+        weekly = next((item for item in calendar if (datetime.combine(item, time(self._config.market_close_hour, self._config.market_close_minute)) - now) > roll_delta), None)
+        monthly_candidates = [item for item in self._monthly_expiries(now.date(), months=8) if item >= now.date()]
+        monthly = next((item for item in monthly_candidates if weekly is None or item > weekly), None)
+        return weekly, monthly
 
     def _build_universe(self, atm_strike: int, expiry: date) -> list[str]:
         """Build CE/PE symbol list for configured strike range and expiry."""

--- a/src/nifty_scalper_bot/data/rest/client.py
+++ b/src/nifty_scalper_bot/data/rest/client.py
@@ -5,11 +5,26 @@ from __future__ import annotations
 import time
 from typing import Any, Dict, Mapping, Protocol, Sequence, cast, runtime_checkable
 
-from nifty_scalper_bot.utils.errors import BrokerError
+from nifty_scalper_bot.utils.errors import BrokerError, RateLimitError
 from nifty_scalper_bot.utils.logging import get_logger
 from nifty_scalper_bot.utils.rate_limiter import RateLimiter
 
 LOGGER = get_logger(__name__)
+
+
+class ExponentialBackoff:
+    """Deterministic exponential backoff helper."""
+
+    def __init__(self, initial: float = 0.5, maximum: float = 10.0) -> None:
+        self._initial = max(0.0, float(initial))
+        self._maximum = max(self._initial, float(maximum))
+        self._current = self._initial
+
+    def next(self) -> float:
+        """Return next delay in seconds."""
+        delay = self._current
+        self._current = min(self._maximum, max(self._initial, self._current * 2))
+        return delay
 
 
 @runtime_checkable
@@ -64,10 +79,25 @@ class ThrottledBrokerClient:
         **kwargs: Any,
     ) -> Any:
         last_error: Exception | None = None
+        backoff = ExponentialBackoff(initial=0.5, maximum=10.0)
         for attempt in range(1, tries + 1):
             self._limiter.acquire(bucket, timeout=timeout)
             try:
                 return fn(*args, **kwargs)
+            except RateLimitError as exc:
+                last_error = exc
+                if attempt >= tries:
+                    break
+                delay = backoff.next()
+                self._logger.warning(
+                    'Rate limit backoff',
+                    extra={
+                        'symbol': str(args[0]) if args else '',
+                        'service': bucket,
+                        'backoff_ms': int(delay * 1000),
+                    },
+                )
+                time.sleep(delay)
             except Exception as exc:  # noqa: BLE001
                 last_error = exc
                 self._logger.warning(

--- a/src/nifty_scalper_bot/strategies/indicators.py
+++ b/src/nifty_scalper_bot/strategies/indicators.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from collections import deque
 from datetime import datetime, time, timedelta, timezone
-from typing import Any, Deque, Dict, Iterable, Mapping, Sequence
+from typing import Any, Callable, Deque, Dict, Iterable, Mapping, Sequence
 from zoneinfo import ZoneInfo
 
 import numpy as np
@@ -629,8 +629,48 @@ class IndicatorEngine:
 
     def is_ready(self, symbol: str, min_bars: int = 50) -> bool:
         """Check if enough data exists for indicator calculation."""
+        return self.has_min_bars(symbol, min_bars)
+
+    def has_min_bars(self, symbol: str, min_bars: int) -> bool:
+        """Return whether the internal history satisfies *min_bars*."""
         history = self._histories.get(symbol)
         return history is not None and len(history) >= min_bars
+
+    def ensure_min_bars(
+        self,
+        symbol: str,
+        min_bars: int,
+        hydrate: Callable[[str, int], list[dict[str, Any]]] | None = None,
+    ) -> bool:
+        """Hydrate missing bars for *symbol* via callback before evaluation."""
+        if self.has_min_bars(symbol, min_bars):
+            return True
+        if hydrate is None:
+            return False
+        for bar in hydrate(symbol, min_bars):
+            try:
+                self.update_price(
+                    symbol,
+                    {
+                        'open': float(bar.get('open', 0.0) or 0.0),
+                        'high': float(bar.get('high', 0.0) or 0.0),
+                        'low': float(bar.get('low', 0.0) or 0.0),
+                        'close': float(bar.get('close', 0.0) or 0.0),
+                    },
+                    volume=int(bar.get('volume', 0) or 0),
+                    timestamp=bar.get('timestamp'),
+                )
+            except Exception as exc:  # noqa: BLE001
+                LOGGER.error(
+                    'Failure in IndicatorEngine.ensure_min_bars: %s',
+                    exc,
+                    extra={
+                        'event': 'indicator_engine_hydrate_bar_failed',
+                        'symbol': symbol,
+                    },
+                    exc_info=exc,
+                )
+        return self.has_min_bars(symbol, min_bars)
 
     def get_opening_range(
         self, symbol: str, minutes: int = 30

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -452,6 +452,8 @@ class StrategyRunner:
         self._callbacks: MutableMapping[str, Callable[[dict], None]] = {}
         self._bar_builders: Dict[str, OneMinuteBarBuilder] = {}
         self._last_bar_ts: dict[str, datetime] = {}
+        self._gating_log_bar_cache: dict[tuple[str, str], datetime] = {}
+        self._hydration_log_bar_cache: dict[str, datetime] = {}
         self._orchestrator = getattr(strategy_manager, "orchestrator", None)
         self._persistent_state: PersistentStateManager | None = None
         self._orders_in_flight: dict[str, float] = {}  # symbol -> timestamp
@@ -1922,6 +1924,78 @@ class StrategyRunner:
                 f"✅ Emergency Backfill complete. Ingested {total_bars} bars."
             )
 
+    def _hydrate_missing_bars(self, symbol: str, min_bars: int) -> list[dict[str, Any]]:
+        """Fetch missing candles for *symbol* and return normalized OHLC bars."""
+        needed_bars = max(0, min_bars - len(self._indicator_engine.get_history(symbol)))
+        last_bar_ts = self._last_bar_ts.get(symbol)
+        if needed_bars <= 0:
+            return []
+        if last_bar_ts and self._hydration_log_bar_cache.get(symbol) != last_bar_ts:
+            self._hydration_log_bar_cache[symbol] = last_bar_ts
+            self._logger.info(
+                'Hydrating historical data',
+                extra={
+                    'symbol': symbol,
+                    'needed_bars': needed_bars,
+                    'have_bars': len(self._indicator_engine.get_history(symbol)),
+                },
+            )
+        fetch_coro: Any | None = None
+        if self._data_hub and hasattr(self._data_hub, 'fetch_history'):
+            fetch_coro = self._data_hub.fetch_history(
+                symbol, interval='minute', days=5
+            )
+        elif self._orchestrator and hasattr(self._orchestrator, 'fetch_history'):
+            fetch_coro = self._orchestrator.fetch_history(
+                symbol, interval='minute', days=5
+            )
+        if fetch_coro is None or self._main_loop is None:
+            return []
+        try:
+            rows = asyncio.run_coroutine_threadsafe(
+                fetch_coro,
+                self._main_loop,
+            ).result(timeout=5.0)
+        except Exception as exc:  # noqa: BLE001
+            self._logger.warning(
+                'Historical hydration unavailable',
+                extra={'event': 'indicator_hydration_failed', 'symbol': symbol, 'error': str(exc)},
+            )
+            return []
+        normalized: list[dict[str, Any]] = []
+        for row in rows or []:
+            try:
+                ts = row.get('timestamp') or row.get('date')
+                if isinstance(ts, str):
+                    ts = datetime.fromisoformat(ts.replace('Z', '+00:00'))
+                normalized.append(
+                    {
+                        'open': float(row.get('open', 0.0) or 0.0),
+                        'high': float(row.get('high', 0.0) or 0.0),
+                        'low': float(row.get('low', 0.0) or 0.0),
+                        'close': float(row.get('close', 0.0) or 0.0),
+                        'volume': int(row.get('volume', 0) or 0),
+                        'timestamp': ts,
+                    }
+                )
+            except Exception:
+                continue
+        return normalized
+
+    def _log_once_per_symbol_per_bar(self, symbol: str, event: str, reason: str) -> None:
+        """Emit edge-triggered per-symbol per-bar logs for noisy gates."""
+        bar_ts = self._last_bar_ts.get(symbol)
+        if bar_ts is None:
+            return
+        cache_key = (symbol, event)
+        if self._gating_log_bar_cache.get(cache_key) == bar_ts:
+            return
+        self._gating_log_bar_cache[cache_key] = bar_ts
+        self._logger.info(
+            event,
+            extra={'event': event, 'symbol': symbol, 'reason': reason, 'bar_ts': bar_ts.isoformat()},
+        )
+
     def _on_tick(self, symbol: str, tick: Mapping[str, Any]) -> None:
         """Handle incoming tick. Args: symbol, tick. Returns: None. Raises: Exception."""
         self._logger.debug(
@@ -2697,11 +2771,27 @@ class StrategyRunner:
                         interval_sec=30.0,
                         level=logging.INFO,
                     )
-                    is_ready = self._indicator_engine.is_ready(
+                    self._indicator_engine.ensure_min_bars(
+                        symbol,
+                        self._config.min_indicator_bars,
+                        hydrate=self._hydrate_missing_bars,
+                    )
+                    index_indicators_ready = bool(
+                        getattr(self._orchestrator, 'index_indicators_ready', True)
+                    )
+                    is_ready = self._indicator_engine.has_min_bars(
                         symbol, self._config.min_indicator_bars
                     )
 
-                    if is_ready:
+                    if not (index_indicators_ready and is_ready):
+                        reason = (
+                            'index_indicators_not_ready'
+                            if not index_indicators_ready
+                            else 'min_bars_not_ready'
+                        )
+                        self._log_once_per_symbol_per_bar(symbol, 'strategy_gated', reason)
+                        signal = None
+                    else:
                         # ✅ DIAGNOSTIC LOG: Confirm indicators are ready
                         log_throttled(
                             self._logger,
@@ -2758,15 +2848,7 @@ class StrategyRunner:
                                 },
                             )
                             cycle_stats.pop(bar_key, None)
-                    else:
-                        # ✅ DIAGNOSTIC LOG: Explain why no evaluation happened
-                        log_throttled(
-                            self._logger,
-                            f"not_ready_{symbol}",
-                            f"⏳ INDICATORS NOT READY: {symbol} (Need {self._config.min_indicator_bars} bars)",
-                            interval_sec=30.0,
-                            level=logging.WARNING,
-                        )
+                    
 
             # =================================================================
             # PHASE 10: EXECUTE SIGNAL

--- a/tests/strategies/test_indicator_engine.py
+++ b/tests/strategies/test_indicator_engine.py
@@ -219,6 +219,32 @@ def test_atr_matches_reference(engine: IndicatorEngine) -> None:
     assert atr == pytest.approx(expected_atr, rel=1e-12)
 
 
+def test_ensure_min_bars_uses_hydrator(engine: IndicatorEngine) -> None:
+    payload = [
+        {
+            'open': 100.0,
+            'high': 101.0,
+            'low': 99.0,
+            'close': 100.5,
+            'volume': 1,
+            'timestamp': datetime(2024, 1, 1, tzinfo=timezone.utc),
+        },
+        {
+            'open': 100.5,
+            'high': 102.0,
+            'low': 100.0,
+            'close': 101.0,
+            'volume': 1,
+            'timestamp': datetime(2024, 1, 1, 0, 1, tzinfo=timezone.utc),
+        },
+    ]
+
+    ready = engine.ensure_min_bars('TEST', 2, hydrate=lambda _s, _m: payload)
+
+    assert ready is True
+    assert engine.has_min_bars('TEST', 2) is True
+
+
 def _atr_reference(
     highs: list[float], lows: list[float], closes: list[float], period: int
 ) -> float:

--- a/tests/test_option_universe.py
+++ b/tests/test_option_universe.py
@@ -53,3 +53,32 @@ def test_primary_symbols_matches_current_universe() -> None:
     manager.update_underlying(22540.0)
 
     assert manager.get_primary_symbols() == manager.get_current_universe()
+
+
+def test_filtered_universe_uses_weekly_and_monthly() -> None:
+    manager = OptionUniverseManager(
+        OptionUniverseConfig(strike_step=50, strikes_around_atm=1),
+        now_fn=lambda: datetime(2026, 2, 2, 10, 0, 0),
+    )
+
+    symbols = manager.get_filtered_universe(18630.0)
+
+    assert symbols
+    assert len(symbols) == 12
+    assert any(symbol.endswith('18650CE') for symbol in symbols)
+
+
+def test_filtered_universe_reuses_spot_within_threshold() -> None:
+    manager = OptionUniverseManager(
+        OptionUniverseConfig(
+            strike_step=50,
+            strikes_around_atm=1,
+            spot_recalc_threshold_points=1000.0,
+        ),
+        now_fn=lambda: datetime(2026, 2, 2, 10, 0, 0),
+    )
+
+    first = manager.get_filtered_universe(18600.0)
+    second = manager.get_filtered_universe(18640.0)
+
+    assert first == second


### PR DESCRIPTION
### Motivation
- Prevent strategy pipeline starvation and noisy gating by ensuring each subscribed symbol has a minimum OHLC history before evaluation. 
- Keep the option universe tightly focused around ATM + nearest expiries so the bot subscribes only to relevant contracts as spot moves.
- Avoid overlapping broker syncs that cause races between orders and positions, and make broker calls resilient to rate limits.
- Reduce noisy repeated logs by emitting edge-trigger (once-per-symbol-per-bar) diagnostics.

### Description
- Added indicator readiness and hydrator API to `IndicatorEngine`: `has_min_bars(symbol, min_bars)` and `ensure_min_bars(symbol, min_bars, hydrate=...)` to allow on-demand historical OHLC backfill without dropping symbols, and used these from the runner prior to signal generation.
- Implemented per-symbol historical hydrator in `StrategyRunner` (`_hydrate_missing_bars`) that fetches missing minute bars (via `DataHub`/orchestrator) and logs once per symbol per bar with `logger.info("Hydrating historical data", extra={...})`.
- Replaced broad symbol lists with a filtered universe via `OptionUniverseManager.get_filtered_universe(spot_ltp)` which restricts to ATM ± configured strikes across nearest weekly and next monthly expiry and only recomputes when spot moves beyond `spot_recalc_threshold_points`.
- Added a global non-blocking sync lock (`SYNC_LOCK`) and encapsulated order/position reconciliation in `safe_sync_fetch()` to prevent overlapping sync jobs; rewired reconcile loop to call the safe function.
- Introduced deterministic exponential backoff (`ExponentialBackoff`) and structured rate-limit backoff logs in `ThrottledBrokerClient._retry` to handle `RateLimitError` with retries and warning metrics.
- Reduced log noise by adding edge-trigger helpers in the runner to emit gate/log events once per symbol per bar (e.g., `strategy_gated`) instead of repeated messages.

### Testing
- Bootstrapped environment and dependencies with `bash ./run_checks.sh`; initial script run highlighted missing test tooling in the ephemeral environment (addressed below).
- Installed tooling and ran focused tests: `pytest -q tests/test_option_universe.py tests/strategies/test_indicator_engine.py tests/strategies/test_runner_skip_reasons.py --disable-warnings` — these targeted suites passed.
- Ran a broader test run `pytest -q tests --disable-warnings --ignore=tests/test_live_mode.py --ignore=tests/test_health_server.py` which stopped due to an unrelated import error in `tests/notifications/test_telegram_commands.py` (preexisting test import issue: `_format_chain_summary` missing), not caused by these changes.
- Verified runtime files compile with `python -m py_compile` for the modified modules (`strategies/indicators.py`, `strategies/runner.py`, `core/option_universe.py`, `core/app.py`, `data/rest/client.py`).
- All targeted unit tests added/updated for new behavior passed; broader suite requires fixing the unrelated test import before full green run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698af688e1408324b101b10a80ddd5a6)