### PR TITLE
fix: restore indicator history accessor for strategy runner

### DIFF
--- a/src/nifty_scalper_bot/strategies/indicators.py
+++ b/src/nifty_scalper_bot/strategies/indicators.py
@@ -86,6 +86,10 @@ class PriceHistory:
         """Get high prices."""
         return self._get_tail(self._highs, count)
 
+    def get_opens(self, count: int | None = None) -> list[float]:
+        """Get open prices."""
+        return self._get_tail(self._opens, count)
+
     def get_lows(self, count: int | None = None) -> list[float]:
         """Get low prices."""
         return self._get_tail(self._lows, count)
@@ -164,6 +168,37 @@ class IndicatorEngine:
         timestamp = timestamp or datetime.now(timezone.utc)
         history.add_tick(price, volume, timestamp)
         self._cache.pop(symbol, None)
+
+    def get_history(self, symbol: str, count: int | None = None) -> list[float]:
+        """Args: symbol, count. Returns: close-price history list. Raises: Exception."""
+        LOGGER.debug(
+            'Entered IndicatorEngine.get_history',
+            extra={'event': 'indicator_engine_get_history_enter', 'symbol': symbol},
+        )
+        try:
+            history = self._histories.get(symbol)
+            if history is None:
+                LOGGER.info(
+                    'Condition met: indicator_history_missing',
+                    extra={
+                        'event': 'indicator_engine_history_missing',
+                        'symbol': symbol,
+                    },
+                )
+                return []
+            closes = history.get_closes(count)
+            LOGGER.info(
+                'Condition met: indicator_history_resolved',
+                extra={
+                    'event': 'indicator_engine_history_resolved',
+                    'symbol': symbol,
+                    'bars': len(closes),
+                },
+            )
+            return closes
+        except Exception as e:  # noqa: BLE001
+            LOGGER.error('Failure in IndicatorEngine.get_history: %s', e, exc_info=True)
+            return []
 
     def get_indicators(
         self, symbol: str, names: Iterable[str] | None = None

--- a/tests/strategies/test_indicator_engine.py
+++ b/tests/strategies/test_indicator_engine.py
@@ -30,6 +30,41 @@ def test_price_history_capacity() -> None:
     assert history.get_closes() == [5.0, 6.0, 7.0, 8.0, 9.0]
 
 
+def test_get_history_returns_closes(engine: IndicatorEngine) -> None:
+    """Verify history retrieval. Args: engine. Returns: None. Raises: Exception."""
+    engine.update_price(
+        'HISTORY',
+        101.5,
+        volume=5,
+        timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc),
+    )
+    engine.update_price(
+        'HISTORY',
+        102.5,
+        volume=6,
+        timestamp=datetime(2024, 1, 1, 0, 1, tzinfo=timezone.utc),
+    )
+    assert engine.get_history('HISTORY') == [101.5, 102.5]
+    assert engine.get_history('HISTORY', count=1) == [102.5]
+    assert engine.get_history('MISSING') == []
+
+
+def test_price_history_get_opens() -> None:
+    """Verify open price retrieval. Args: None. Returns: None. Raises: Exception."""
+    history = PriceHistory(max_length=3)
+    history.add_tick(
+        {'open': 100.0, 'high': 101.0, 'low': 99.0, 'close': 100.5},
+        volume=1,
+        timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc),
+    )
+    history.add_tick(
+        {'open': 101.0, 'high': 102.0, 'low': 100.0, 'close': 101.5},
+        volume=1,
+        timestamp=datetime(2024, 1, 1, 0, 1, tzinfo=timezone.utc),
+    )
+    assert history.get_opens() == [100.0, 101.0]
+    assert history.get_opens(1) == [101.0]
+
 def test_rsi_matches_reference(engine: IndicatorEngine) -> None:
     closes = [
         44.34,


### PR DESCRIPTION
### Motivation
- Production tick processing was crashing with `Failure in _on_tick: 'IndicatorEngine' object has no attribute 'get_history'`, because `StrategyRunner._hydrate_missing_bars` calls `self._indicator_engine.get_history(symbol)`.
- The codebase also referenced open prices via a missing helper, so an explicit `get_opens` on the history container simplifies callers and avoids ad-hoc `hasattr` checks.

### Description
- Added `IndicatorEngine.get_history(symbol, count=None)` which returns the close-price history list, logs resolution/missing-history events, and returns an empty list on error or missing history. 
- Added `PriceHistory.get_opens(count=None)` to expose open prices consistently with other OHLC getters. 
- Added unit tests `test_get_history_returns_closes` and `test_price_history_get_opens` to cover normal, tail and missing-symbol paths in `tests/strategies/test_indicator_engine.py`.

### Testing
- Ran targeted unit tests with `pytest -q tests/strategies/test_indicator_engine.py` which passed (`.............. [100%]`).
- Ran combined targeted suite with `pytest -q tests/bot/test_strategy_runner.py tests/strategies/test_indicator_engine.py` which passed (`..................... [100%]`).
- Ran the broader repository checks via `bash ./run_checks.sh`; the script executed and installed dependencies, but lint/mypy/pytest reported multiple pre-existing repository-wide issues unrelated to this patch (several `mypy`/`ruff` errors and a test collection error in `tests/notifications/test_telegram_commands.py`).
- Attempted full test collection with `pytest -q tests --disable-warnings --ignore=tests/test_live_mode.py --ignore=tests/test_health_server.py` which failed during collection due to an existing import error in `tests/notifications/test_telegram_commands.py` and is unrelated to the changes in this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b5ace29548324aae6ed39953ac3f0)