### PR TITLE
fix: reduce strategy evaluation log noise

### DIFF
--- a/src/nifty_scalper_bot/core/strategy_manager.py
+++ b/src/nifty_scalper_bot/core/strategy_manager.py
@@ -1729,10 +1729,12 @@ class StrategyManager(_BaseStrategyManager):
                 }
                 if context:
                     payload.update(context)
-                log.info(
-                    "📉 NO SIGNAL | symbol=%s reason=%s",
-                    symbol,
-                    reason_code,
+                throttle_key = f"strategy_no_signal_{symbol}_{reason_code}"
+                log_throttled(
+                    log,
+                    throttle_key,
+                    f"📉 NO SIGNAL | symbol={symbol} reason={reason_code}",
+                    interval_sec=60.0,
                     extra=payload,
                 )
             except Exception as exc:  # noqa: BLE001

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -2707,7 +2707,7 @@ class StrategyRunner:
                                 }
                                 if logged_map.get(symbol) != last_bar_ts:
                                     logged_map[symbol] = last_bar_ts
-                                    self._logger.info(
+                                    self._logger.debug(
                                         "Condition met: strategy_eval_skipped_same_bar",
                                         extra=extra_payload,
                                     )
@@ -2769,7 +2769,7 @@ class StrategyRunner:
                         f"strategy_eval_{symbol}",
                         f"🎯 EVALUATING STRATEGIES: {symbol} | min_bars={self._config.min_indicator_bars}",
                         interval_sec=30.0,
-                        level=logging.INFO,
+                        level=logging.DEBUG,
                     )
                     self._indicator_engine.ensure_min_bars(
                         symbol,
@@ -2798,7 +2798,7 @@ class StrategyRunner:
                             f"indicators_ready_{symbol}",
                             f"✅ INDICATORS READY: {symbol} | Calling StrategyManager...",
                             interval_sec=60.0,
-                            level=logging.INFO,
+                            level=logging.DEBUG,
                         )
 
                         signal = self._strategy_manager.generate_signal(symbol, price)


### PR DESCRIPTION
### Motivation
- Production logs were being flooded by repeated per-symbol strategy evaluation diagnostics and frequent "NO SIGNAL" messages, making operational alerts hard to find. 
- Reduce verbosity for high-frequency, non-actionable logs while preserving observability for real issues.

### Description
- Downgraded the per-symbol same-bar skip log in `StrategyRunner` from `INFO` to `DEBUG` to avoid repeated non-actionable messages in `src/nifty_scalper_bot/strategies/runner.py`.
- Changed throttled diagnostic logs for strategy evaluation and indicator-ready notifications in `StrategyRunner` from `INFO` to `DEBUG` to limit noise while retaining the throttled instrumentation.
- Replaced the direct `info` emission for repeated no-signal events in `StrategyManager` with `log_throttled(...)` keyed by `symbol+reason` to emit at most once per 60 seconds in `src/nifty_scalper_bot/core/strategy_manager.py`.

### Testing
- Ran the project checks via `./run_checks.sh` (invoked as `bash ./run_checks.sh`), which installed dependencies successfully but reported pre-existing repository lint/type issues and a pytest configuration mismatch, so the full script validation did not complete cleanly.
- Ran targeted pytest invocation `pytest -q tests --disable-warnings --ignore=tests/test_live_mode.py --ignore=tests/test_health_server.py`, which failed during test collection due to a pre-existing import error in the tests (not introduced by this change).
- Ran `ruff` on the modified files and observed many pre-existing style/import findings in the repository; the changes in this PR do not add new linting errors beyond the existing baseline.
- All changes are logging-only (no trading logic altered) and are low risk; additional CI/lint/mypy cleanup is recommended for separate follow-up work.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b6514f26c8324ac51cc1352bfee73)