### PR TITLE
fix: harden execution gates and option history hydration

### DIFF
--- a/src/nifty_scalper_bot/data/data_hub.py
+++ b/src/nifty_scalper_bot/data/data_hub.py
@@ -6,6 +6,7 @@ import os
 import re
 import time
 import asyncio
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from threading import RLock
 from typing import Any, Callable, Iterable, Mapping, Optional, TypedDict, cast
@@ -75,6 +76,27 @@ _ORDER_STATE_MACHINE: dict[str, set[str]] = {
 }
 
 
+@dataclass(frozen=True, slots=True)
+class _HistoryCacheKey:
+    """Key for option-chain-aware historical cache entries."""
+
+    symbol_root: str
+    expiry: str
+    interval: str
+
+
+@dataclass(slots=True)
+class _HistoryCacheEntry:
+    """Cached history rows and fetch timestamp."""
+
+    rows: list[dict[str, Any]]
+    fetched_at: float
+
+    def is_fresh(self, max_age_seconds: float, now: float) -> bool:
+        """Return True when this cache entry is still fresh."""
+        return (now - self.fetched_at) <= max_age_seconds
+
+
 class DataHub:
     """Central in-memory state cache for the trading bot."""
 
@@ -113,6 +135,14 @@ class DataHub:
         # Subscribers
         self._tick_subscribers: dict[str, set[TickListener]] = {}
         self._order_subscribers: list[OrderListener] = []
+        self._history_cache_lock = RLock()
+        self._history_cache: dict[_HistoryCacheKey, _HistoryCacheEntry] = {}
+        self._history_cache_ttl_seconds = float(
+            os.getenv('HISTORY_CACHE_TTL_SECONDS', '120')
+        )
+        self._history_freshness_max_age_seconds = float(
+            os.getenv('HISTORY_FRESHNESS_MAX_AGE_SECONDS', '120')
+        )
 
     # ----------------------------------------------------------------
     # Ingestion (Write Path)
@@ -541,23 +571,109 @@ class DataHub:
     # ----------------------------------------------------------------
     
     async def fetch_history(self, symbol: str, interval: str, days: int = 3) -> list[dict]:
-        """
-        Proxies historical data requests to the MarketDataManager.
-        Essential for 'Cold Start' indicator priming.
-        """
-        # 1. Resolve the underlying manager
-        mdm = getattr(self, "_mdm", None) or getattr(self, "_market_data", None)
-        
-        # 2. Check capability
-        if mdm and hasattr(mdm, "fetch_history"):
-            try:
-                # 3. Await the result (MDM.fetch_history is async)
-                return await mdm.fetch_history(symbol, interval, days)
-            except Exception as e:
-                LOGGER.error(f"DataHub Proxy Error: fetch_history failed for {symbol}: {e}")
-                return []
-        
-        LOGGER.warning(f"DataHub: Underlying MDM missing 'fetch_history' for {symbol}")
-        return []
+        """Fetch cached historical candles with option-chain aware pooling."""
+        root, expiry = self._extract_history_group(symbol)
+        cache_key = _HistoryCacheKey(symbol_root=root, expiry=expiry, interval=interval)
+        now = time.time()
+
+        with self._history_cache_lock:
+            entry = self._history_cache.get(cache_key)
+            if entry and entry.is_fresh(self._history_cache_ttl_seconds, now):
+                LOGGER.debug(
+                    'Condition met: history_cache_hit',
+                    extra={
+                        'event': 'history_cache_hit',
+                        'symbol': symbol,
+                        'root': root,
+                        'expiry': expiry,
+                        'interval': interval,
+                        'age_seconds': round(now - entry.fetched_at, 3),
+                    },
+                )
+                return [dict(row) for row in entry.rows]
+
+        mdm = getattr(self, '_mdm', None) or getattr(self, '_market_data', None)
+        if not (mdm and hasattr(mdm, 'fetch_history')):
+            LOGGER.warning(
+                'DataHub: Underlying MDM missing fetch_history',
+                extra={'event': 'history_fetcher_missing', 'symbol': symbol},
+            )
+            return []
+
+        try:
+            rows = await mdm.fetch_history(symbol, interval, days)
+        except Exception as e:  # noqa: BLE001
+            LOGGER.error(
+                'DataHub Proxy Error: fetch_history failed for %s: %s',
+                symbol,
+                e,
+                extra={'event': 'history_fetch_failed', 'symbol': symbol},
+                exc_info=True,
+            )
+            return []
+
+        normalized_rows = [dict(row) for row in (rows or []) if isinstance(row, Mapping)]
+        with self._history_cache_lock:
+            self._history_cache[cache_key] = _HistoryCacheEntry(
+                rows=normalized_rows,
+                fetched_at=now,
+            )
+
+        return [dict(row) for row in normalized_rows]
+
+    def history_freshness(
+        self,
+        symbol: str,
+        interval: str,
+        *,
+        max_age_seconds: float | None = None,
+    ) -> tuple[bool, dict[str, Any]]:
+        """Return freshness diagnostics for historical cache groups."""
+        root, expiry = self._extract_history_group(symbol)
+        cache_key = _HistoryCacheKey(symbol_root=root, expiry=expiry, interval=interval)
+        now = time.time()
+        age_limit = (
+            float(max_age_seconds)
+            if max_age_seconds is not None
+            else self._history_freshness_max_age_seconds
+        )
+        with self._history_cache_lock:
+            entry = self._history_cache.get(cache_key)
+
+        if entry is None:
+            return False, {
+                'ok': False,
+                'reason': 'missing',
+                'symbol_root': root,
+                'expiry': expiry,
+                'interval': interval,
+                'max_age_seconds': age_limit,
+            }
+
+        age_seconds = max(0.0, now - entry.fetched_at)
+        is_fresh = age_seconds <= age_limit
+        return is_fresh, {
+            'ok': is_fresh,
+            'reason': None if is_fresh else 'stale',
+            'symbol_root': root,
+            'expiry': expiry,
+            'interval': interval,
+            'age_seconds': round(age_seconds, 3),
+            'max_age_seconds': age_limit,
+            'candles': len(entry.rows),
+        }
+
+    @staticmethod
+    def _extract_history_group(symbol: str) -> tuple[str, str]:
+        """Return ``(symbol_root, expiry)`` grouping keys for history caching."""
+        normalized = (symbol or '').strip().upper()
+        clean = normalized.split(':')[-1]
+        match = re.match(
+            r'^(?P<root>[A-Z]+)(?P<expiry>(?:\d{2}[A-Z]\d{2}|\d{2}[A-Z]{3}|\d{2}[A-Z]{3}\d{2}))\d+(?:CE|PE)$',
+            clean,
+        )
+        if match:
+            return match.group('root'), match.group('expiry')
+        return clean, 'SPOT'
 
 __all__ = ["DataHub", "Tick", "OrderListener", "TickListener"]

--- a/src/nifty_scalper_bot/strategies/indicators.py
+++ b/src/nifty_scalper_bot/strategies/indicators.py
@@ -669,7 +669,60 @@ class IndicatorEngine:
     def has_min_bars(self, symbol: str, min_bars: int) -> bool:
         """Return whether the internal history satisfies *min_bars*."""
         history = self._histories.get(symbol)
-        return history is not None and len(history) >= min_bars
+        if history is None or len(history) < min_bars:
+            return False
+        return self._validate_history_integrity(symbol, history, min_bars=min_bars)
+
+    def _validate_history_integrity(
+        self,
+        symbol: str,
+        history: PriceHistory,
+        *,
+        min_bars: int,
+    ) -> bool:
+        """Validate indicator inputs before strategy evaluation."""
+        timestamps = history.get_timestamps()
+        if len(timestamps) < min_bars:
+            LOGGER.error(
+                'Condition met: indicator_integrity_short_history',
+                extra={
+                    'event': 'indicator_integrity_short_history',
+                    'symbol': symbol,
+                    'have': len(timestamps),
+                    'need': min_bars,
+                },
+            )
+            return False
+        if any(ts is None for ts in timestamps):
+            LOGGER.error(
+                'Condition met: indicator_integrity_missing_timestamp',
+                extra={'event': 'indicator_integrity_missing_timestamp', 'symbol': symbol},
+            )
+            return False
+        for prev, curr in zip(timestamps, timestamps[1:]):
+            if curr <= prev:
+                LOGGER.error(
+                    'Condition met: indicator_integrity_non_monotonic',
+                    extra={
+                        'event': 'indicator_integrity_non_monotonic',
+                        'symbol': symbol,
+                        'prev': prev.isoformat(),
+                        'curr': curr.isoformat(),
+                    },
+                )
+                return False
+            gap_seconds = (curr - prev).total_seconds()
+            if gap_seconds > 120:
+                LOGGER.error(
+                    'Condition met: indicator_integrity_missing_candle',
+                    extra={
+                        'event': 'indicator_integrity_missing_candle',
+                        'symbol': symbol,
+                        'gap_seconds': gap_seconds,
+                    },
+                )
+                return False
+        return True
 
     def ensure_min_bars(
         self,

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -472,6 +472,10 @@ class StrategyRunner:
         # We intentionally keep this sticky so per-symbol loops cannot spam checks/logs.
         self._risk_halt_active = False
         self._risk_halt_logged = False
+        self._required_candles = max(
+            self._config.min_indicator_bars,
+            int(os.getenv('REQUIRED_CANDLES', str(self._config.min_indicator_bars))),
+        )
 
     # ==================== LIFECYCLE MANAGEMENT ====================
 
@@ -1870,6 +1874,12 @@ class StrategyRunner:
                 return
 
             # 2. FALLBACK: Only runs if App.py failed
+            if not self._risk_allows_trading(None):
+                self._logger.warning(
+                    'Condition met: backfill_short_circuited_by_risk',
+                    extra={'event': 'backfill_short_circuited_by_risk'},
+                )
+                return
             self._logger.warning(
                 "⚠️ StrategyRunner memory is empty! Triggering fallback backfill..."
             )
@@ -1963,11 +1973,19 @@ class StrategyRunner:
             )
             return []
         normalized: list[dict[str, Any]] = []
+        seen_ts: set[datetime] = set()
         for row in rows or []:
             try:
                 ts = row.get('timestamp') or row.get('date')
                 if isinstance(ts, str):
                     ts = datetime.fromisoformat(ts.replace('Z', '+00:00'))
+                if not isinstance(ts, datetime):
+                    continue
+                if ts.tzinfo is None:
+                    ts = ts.replace(tzinfo=timezone.utc)
+                if ts in seen_ts:
+                    continue
+                seen_ts.add(ts)
                 normalized.append(
                     {
                         'open': float(row.get('open', 0.0) or 0.0),
@@ -1980,6 +1998,26 @@ class StrategyRunner:
                 )
             except Exception:
                 continue
+        normalized.sort(key=lambda row: cast(datetime, row['timestamp']))
+        if len(normalized) < self._required_candles:
+            self._logger.info(
+                'Condition met: hydrate_excluded_insufficient_candles',
+                extra={
+                    'event': 'hydrate_excluded_insufficient_candles',
+                    'symbol': symbol,
+                    'candles': len(normalized),
+                    'required_candles': self._required_candles,
+                },
+            )
+            return []
+        if self._data_hub and hasattr(self._data_hub, 'history_freshness'):
+            fresh, meta = self._data_hub.history_freshness(symbol, 'minute')
+            if not fresh:
+                self._logger.warning(
+                    'Condition met: hydrate_history_stale',
+                    extra={'event': 'hydrate_history_stale', 'symbol': symbol, 'meta': meta},
+                )
+                return []
         return normalized
 
     def _log_once_per_symbol_per_bar(self, symbol: str, event: str, reason: str) -> None:
@@ -1995,6 +2033,70 @@ class StrategyRunner:
             event,
             extra={'event': event, 'symbol': symbol, 'reason': reason, 'bar_ts': bar_ts.isoformat()},
         )
+
+    def _classify_symbol(self, symbol: str) -> str:
+        """Classify symbol into index, option or other buckets."""
+        upper = symbol.upper()
+        if upper.startswith('NSE:') and all(tok not in upper for tok in ('CE', 'PE', 'FUT')):
+            return 'index'
+        if upper.endswith('CE') or upper.endswith('PE'):
+            return 'option'
+        return 'other'
+
+    def _validate_symbol_universe(self) -> bool:
+        """Validate index and option symbol separation before strategy eval."""
+        with self._lock:
+            symbols = sorted(self._active_symbols)
+        index_symbols = [sym for sym in symbols if self._classify_symbol(sym) == 'index']
+        option_symbols = [sym for sym in symbols if self._classify_symbol(sym) == 'option']
+        if not option_symbols:
+            self._logger.error(
+                'Condition met: symbol_universe_mismatch',
+                extra={
+                    'event': 'symbol_universe_mismatch',
+                    'reason': 'missing_option_symbols',
+                    'all_symbols': symbols,
+                    'index_symbols': index_symbols,
+                    'option_symbols': option_symbols,
+                },
+            )
+            return False
+        if len(index_symbols) != 1:
+            self._logger.error(
+                'Condition met: symbol_universe_mismatch',
+                extra={
+                    'event': 'symbol_universe_mismatch',
+                    'reason': 'index_count_mismatch',
+                    'all_symbols': symbols,
+                    'index_symbols': index_symbols,
+                    'option_symbols': option_symbols,
+                },
+            )
+            return False
+        return True
+
+    def _risk_allows_trading(self, symbol: str | None) -> bool:
+        """Return whether risk engine allows entering strategy flow."""
+        try:
+            rm = self._risk_manager
+            if rm is None:
+                return True
+            if hasattr(rm, 'is_circuit_breaker_tripped'):
+                tripped, _ = rm.is_circuit_breaker_tripped()
+                if tripped:
+                    return False
+            if hasattr(rm, 'can_trade'):
+                return bool(rm.can_trade(symbol or 'GLOBAL'))
+            if hasattr(rm, 'risk_gate_should_trade'):
+                result = rm.risk_gate_should_trade()
+                return bool(result[0] if isinstance(result, tuple) else result)
+            if hasattr(rm, 'can_trade_now'):
+                result = rm.can_trade_now()
+                return bool(result[0] if isinstance(result, tuple) else result)
+        except Exception as exc:  # noqa: BLE001
+            self._logger.error('Failure in _risk_allows_trading: %s', exc, exc_info=True)
+            return False
+        return False
 
     def _on_tick(self, symbol: str, tick: Mapping[str, Any]) -> None:
         """Handle incoming tick. Args: symbol, tick. Returns: None. Raises: Exception."""
@@ -2387,48 +2489,25 @@ class StrategyRunner:
             # PHASE 6: RISK CHECK (Block trading if risk conditions not met)
             # =================================================================
 
-            # Only check risk if not in warmup
-            if not in_warmup:
-                try:
-                    is_allowed = False
-                    rm = self._risk_manager
-
-                    if rm:
-                        if hasattr(rm, "can_trade"):
-                            is_allowed = rm.can_trade(symbol)
-                        elif hasattr(rm, "risk_gate_should_trade"):
-                            res = rm.risk_gate_should_trade()
-                            is_allowed = res[0] if isinstance(res, tuple) else bool(res)
-                        elif hasattr(rm, "can_trade_now"):
-                            res = rm.can_trade_now()
-                            is_allowed = res[0] if isinstance(res, tuple) else bool(res)
-                        else:
-                            is_allowed = False
-                    else:
-                        # No risk manager = allow trading
-                        is_allowed = True
-
-                    if not is_allowed:
-                        log_throttled(
-                            self._logger,
-                            f"risk_block_{symbol}",
-                            f"⛔ Risk Block Active: {symbol}. Trading Halted.",
-                            interval_sec=30.0,
-                            level=logging.WARNING,
-                        )
-                        return
-
-                except Exception as e:
-                    self._logger.error(
-                        f"Critical error in risk check for {symbol}: {e}"
-                    )
-                    return
+            if not self._risk_allows_trading(symbol):
+                log_throttled(
+                    self._logger,
+                    f"risk_block_{symbol}",
+                    f"⛔ Risk Block Active: {symbol}. Trading Halted.",
+                    interval_sec=30.0,
+                    level=logging.WARNING,
+                )
+                return
 
             # =================================================================
             # PHASE 7: STRATEGY PREPARATION (Skip during warmup)
             # =================================================================
 
             if in_warmup:
+                return
+            if not self._is_market_open(now):
+                return
+            if not self._validate_symbol_universe():
                 return
 
             with self._lock:
@@ -2685,7 +2764,7 @@ class StrategyRunner:
                 return
 
             # If no immediate signal, delegate to complex StrategyManager
-            if signal is None and self._config.min_indicator_bars:
+            if signal is None and self._required_candles:
                 should_evaluate = False
                 with self._lock:
                     state = self._symbol_state.get(symbol)
@@ -2767,20 +2846,20 @@ class StrategyRunner:
                     log_throttled(
                         self._logger,
                         f"strategy_eval_{symbol}",
-                        f"🎯 EVALUATING STRATEGIES: {symbol} | min_bars={self._config.min_indicator_bars}",
+                        f"🎯 EVALUATING STRATEGIES: {symbol} | min_bars={self._required_candles}",
                         interval_sec=30.0,
                         level=logging.DEBUG,
                     )
                     self._indicator_engine.ensure_min_bars(
                         symbol,
-                        self._config.min_indicator_bars,
+                        self._required_candles,
                         hydrate=self._hydrate_missing_bars,
                     )
                     index_indicators_ready = bool(
                         getattr(self._orchestrator, 'index_indicators_ready', True)
                     )
                     is_ready = self._indicator_engine.has_min_bars(
-                        symbol, self._config.min_indicator_bars
+                        symbol, self._required_candles
                     )
 
                     if not (index_indicators_ready and is_ready):
@@ -4337,14 +4416,14 @@ class StrategyRunner:
         """Normalize symbol to uppercase trimmed string."""
         normalized = symbol.strip().upper()
         if not normalized:
-            msg = "symbol must not be empty"
+            msg = 'symbol must not be empty'
             raise ValueError(msg)
 
-        # ✅ FIX: Strip 'NFO:' or 'NSE:' prefix if present
-        if ":" in normalized:
-            normalized = normalized.split(":", 1)[1]
+        if ':' in normalized:
+            normalized = normalized.split(':', 1)[1]
 
         return normalized
+
 
     def _update_last_signal_selection(
         self, symbol: str, selection: SelectedContract

--- a/tests/strategies/test_indicator_integrity.py
+++ b/tests/strategies/test_indicator_integrity.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from nifty_scalper_bot.strategies.indicators import IndicatorEngine
+
+
+def test_has_min_bars_rejects_non_monotonic_timestamps() -> None:
+    engine = IndicatorEngine()
+    symbol = 'NIFTY25JAN25000CE'
+    ts = datetime.now(timezone.utc).replace(second=0, microsecond=0)
+    engine.update_price(symbol, 100.0, timestamp=ts)
+    engine.update_price(symbol, 101.0, timestamp=ts)
+
+    assert engine.has_min_bars(symbol, 2) is False
+
+
+def test_has_min_bars_rejects_missing_candle_gap() -> None:
+    engine = IndicatorEngine()
+    symbol = 'NIFTY25JAN25000PE'
+    ts = datetime.now(timezone.utc).replace(second=0, microsecond=0)
+    engine.update_price(symbol, 100.0, timestamp=ts)
+    engine.update_price(symbol, 101.0, timestamp=ts + timedelta(minutes=3))
+
+    assert engine.has_min_bars(symbol, 2) is False

--- a/tests/strategies/test_runner_execution_gates.py
+++ b/tests/strategies/test_runner_execution_gates.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from nifty_scalper_bot.strategies.runner import StrategyRunner, StrategyRunnerConfig
+
+
+def _runner() -> StrategyRunner:
+    return StrategyRunner(
+        market_data_manager=MagicMock(),
+        indicator_engine=MagicMock(),
+        strategy_manager=MagicMock(),
+        risk_manager=MagicMock(),
+        order_manager=MagicMock(),
+        position_manager=MagicMock(),
+        config=StrategyRunnerConfig(max_trade_history=5),
+        data_hub=MagicMock(),
+    )
+
+
+def test_validate_symbol_universe_rejects_missing_option_symbols() -> None:
+    runner = _runner()
+    runner._active_symbols = {'NSE:NIFTY 50'}
+
+    assert runner._validate_symbol_universe() is False
+
+
+def test_validate_symbol_universe_rejects_index_count_mismatch() -> None:
+    runner = _runner()
+    runner._active_symbols = {
+        'NSE:NIFTY 50',
+        'NSE:NIFTY BANK',
+        'NIFTY25JAN25000CE',
+        'NIFTY25JAN25000PE',
+    }
+
+    assert runner._validate_symbol_universe() is False
+
+
+def test_validate_symbol_universe_accepts_index_and_options() -> None:
+    runner = _runner()
+    runner._active_symbols = {
+        'NSE:NIFTY 50',
+        'NIFTY25JAN25000CE',
+        'NIFTY25JAN25000PE',
+    }
+
+    assert runner._validate_symbol_universe() is True


### PR DESCRIPTION
### Motivation
- Ensure option-chain historical data is cached and validated at the (symbol_root, expiry, interval) level to eliminate redundant fetches and ensure CE/PE for an expiry share a single source.
- Make the risk engine a blocking authority in the runner so any risk trigger short‑circuits hydration and execution paths.
- Prevent strategy evaluation on under‑hydrated or corrupt indicator inputs by enforcing strict candle-count and timestamp invariants.
- Add explicit symbol-universe validation to avoid mixing index and option namespaces and to fail fast with full symbol dumps on mismatch.

### Description
- DataHub: added `_HistoryCacheKey` and `_HistoryCacheEntry` dataclasses, an option‑chain aware `fetch_history` cache, `history_freshness` diagnostics, and `_extract_history_group` to group CE/PE by (symbol_root, expiry, interval) and avoid redundant broker history calls.
- IndicatorEngine: replaced `has_min_bars` simple length check with `_validate_history_integrity` that verifies input length, monotonic timestamps, no missing candles (gap check), and logs explicit errors on invalid inputs.
- StrategyRunner: introduced `_required_candles` initialization (from `min_indicator_bars` or `REQUIRED_CANDLES` env), pre‑hydration risk short‑circuit in `_backfill_history`, hardened `_hydrate_missing_bars` to dedupe/sort/normalize candles and enforce the required‑candles invariant and history freshness, added `_risk_allows_trading` central risk gate and `_validate_symbol_universe` plus `_classify_symbol` for index/option separation, and applied the risk/universe gates before any strategy evaluation.
- Tests: added focused unit tests exercising the new symbol‑universe gate and indicator integrity checks to catch non‑monotonic timestamps and missing‑candle gaps.

### Testing
- Ran compilation: `python -m compileall src/nifty_scalper_bot/data/data_hub.py src/nifty_scalper_bot/strategies/runner.py src/nifty_scalper_bot/strategies/indicators.py` which succeeded.
- Ran focused unit tests: `pytest -q tests/strategies/test_runner_execution_gates.py tests/strategies/test_indicator_integrity.py` and both test files passed ✅.
- Executed full checks via `./run_checks.sh`; installation completed but the run surfaced pre‑existing repository‑wide lint/mypy/type errors outside the touched files and a pytest collection failure caused by an unrelated import error in `tests/notifications/test_telegram_commands.py` (these are pre‑existing and not introduced by this change).
- Also ran `pytest -q tests --disable-warnings --ignore=tests/test_live_mode.py --ignore=tests/test_health_server.py` which failed at collection due to the unrelated test import error described above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b73fe81e4832488969289a4b7d8b8)