### PR TITLE
fix: prevent startup ctx crash and keep bot in degraded mode on init failures

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -2760,6 +2760,11 @@ def initialize_components(settings: Settings | None = None) -> BotContext:
     websocket_manager: WebSocketManager | None = None
     streamer: Any
     stream_supervisor: StreamSupervisor | None = None
+    risk_manager_ref: dict[str, RiskManager | None] = {"instance": None}
+    stream_supervisor_started = False
+    risk_manager_data_hub_attached = False
+    margin_engine_data_hub_attached = False
+    bracket_manager_attached = False
     data_hub: DataHub | None = None
     hub_store: HubStore | None = None
     try:
@@ -3195,6 +3200,37 @@ def initialize_components(settings: Settings | None = None) -> BotContext:
     LOGGER.info("DataHub initialized. Snapshot deferred to startup sequence.")
 
     # Initialize Supervisor
+    def _risk_halt_active() -> bool:
+        """Return whether the circuit breaker currently requests a stream halt.
+
+        Args:
+            None.
+
+        Returns:
+            bool: True when the circuit breaker is tripped, False otherwise.
+
+        Raises:
+            None.
+        """
+
+        manager = risk_manager_ref.get("instance")
+        if manager is None:
+            LOGGER.warning(
+                "Condition met: risk manager unavailable during stream halt check",
+                extra={"event": "stream_risk_halt_check_skipped"},
+            )
+            return False
+        try:
+            return bool(manager.is_circuit_breaker_tripped()[0])
+        except Exception as exc:  # noqa: BLE001 - defensive stream guard
+            LOGGER.error(
+                "Failure in _risk_halt_active: %s",
+                exc,
+                extra={"event": "stream_risk_halt_check_failed"},
+                exc_info=exc,
+            )
+            return False
+
     stream_supervisor = StreamSupervisor(
         streamer=streamer,
         resolver=instrument_resolver,
@@ -3202,13 +3238,11 @@ def initialize_components(settings: Settings | None = None) -> BotContext:
         autostart=True,
         monitor_interval_s=300.0,
         # Keep stream supervisor passive during breaker halts to avoid restart churn.
-        risk_halt_getter=lambda: bool(
-            _require_component(ctx.risk_manager, "risk_manager").is_circuit_breaker_tripped()[0]
-        ),
+        risk_halt_getter=_risk_halt_active,
     )
     stream_supervisor.bootstrap()
     stream_supervisor.ensure_started()
-    ctx.stream_supervisor_started = True
+    stream_supervisor_started = True
 
     # Initialize Indicators & Regime
     indicator_engine = IndicatorEngine()
@@ -3363,6 +3397,7 @@ def initialize_components(settings: Settings | None = None) -> BotContext:
         position_manager=position_manager,
         account_balance=initial_balance,
     )
+    risk_manager_ref["instance"] = risk_manager
 
     # 2. Attach Broker (Safe Try/Except)
     try:
@@ -3377,10 +3412,10 @@ def initialize_components(settings: Settings | None = None) -> BotContext:
         LOGGER.error("risk_manager_attach_mdm_failed: %s", exc)
 
     # 4. Attach Data Hub once to avoid duplicate listeners across warm restarts.
-    if not getattr(ctx, "risk_manager_data_hub_attached", False):
+    if not risk_manager_data_hub_attached:
         try:
             risk_manager.attach_data_hub(data_hub)
-            ctx.risk_manager_data_hub_attached = True
+            risk_manager_data_hub_attached = True
         except Exception as exc:  # noqa: BLE001
             LOGGER.error("risk_manager_attach_data_hub_failed: %s", exc)
 
@@ -3471,10 +3506,10 @@ def initialize_components(settings: Settings | None = None) -> BotContext:
         indicator_engine=indicator_engine,  # <--- THIS IS THE CRITICAL ADDITION
     )
     order_manager.set_market_data_manager(market_data_manager)
-    if not getattr(ctx, "margin_engine_data_hub_attached", False):
+    if not margin_engine_data_hub_attached:
         # OrderManager owns MarginEngine wiring; attach once to avoid duplicate callbacks.
         order_manager.attach_data_hub(data_hub)
-        ctx.margin_engine_data_hub_attached = True
+        margin_engine_data_hub_attached = True
     order_manager.set_instrument_resolver(instrument_resolver)
     order_manager.set_risk_manager(risk_manager)
     order_manager.attach_persistent_state(persistent_state)
@@ -3500,9 +3535,9 @@ def initialize_components(settings: Settings | None = None) -> BotContext:
             )
 
             # Attach once; duplicate attachment can duplicate bracket listeners.
-            if not getattr(ctx, "bracket_manager_attached", False):
+            if not bracket_manager_attached:
                 order_manager.set_bracket_manager(bracket_manager=bracket_manager)
-                ctx.bracket_manager_attached = True
+                bracket_manager_attached = True
                 LOGGER.info("✅ BracketManager initialized and attached.")
 
         except Exception as exc:
@@ -4354,6 +4389,10 @@ def initialize_components(settings: Settings | None = None) -> BotContext:
         health_app=health_app,
         session_guard=session_guard,
         option_universe=option_universe_manager,
+        stream_supervisor_started=stream_supervisor_started,
+        margin_engine_data_hub_attached=margin_engine_data_hub_attached,
+        risk_manager_data_hub_attached=risk_manager_data_hub_attached,
+        bracket_manager_attached=bracket_manager_attached,
     )
 
     resolver_candidate = ctx.instrument_resolver

--- a/src/nifty_scalper_bot/main.py
+++ b/src/nifty_scalper_bot/main.py
@@ -108,15 +108,6 @@ print(f"   🔧 DATA_DIR = {os.getenv('DATA_DIR', 'NOT_SET')}", flush=True)
 
 
 # -------------------------------------------------------
-# HARD EXIT (CRITICAL FOR TRADING SAFETY)
-# -------------------------------------------------------
-
-def _fatal_exit(reason: str, exc: Exception | None = None) -> None:
-    LOG.critical(f"❌ FATAL BOT EXIT: {reason}", exc_info=exc)
-    os._exit(1)
-
-
-# -------------------------------------------------------
 # FASTAPI LIFESPAN (SUPERVISOR ONLY)
 # -------------------------------------------------------
 
@@ -148,9 +139,11 @@ async def lifespan(app: FastAPI):
 
         except Exception as exc:
             app.state.bot_error = str(exc)
-            print(f"❌ FATAL BOT CRASH: {exc}", flush=True)
-            LOG.critical("Bot crash during startup", exc_info=True)
-            _fatal_exit("Core bot crashed during startup", exc)
+            print(f"⚠️ BOT STARTUP WARNING: {exc}", flush=True)
+            LOG.error("Failure in run_bot_background: %s", exc, exc_info=exc)
+            LOG.warning(
+                "Condition met: bot entered degraded mode after startup failure"
+            )
 
     task = asyncio.create_task(run_bot_background())
     yield
@@ -183,7 +176,7 @@ def root():
 def health():
     if app.state.bot_error:
         return {
-            "status": "crashed",
+            "status": "degraded",
             "error": app.state.bot_error,
         }
 
@@ -222,6 +215,6 @@ def trading_status():
         "enable_live": enable_live,
         "execution_mode": exec_mode,
         "will_trade": enable_live and exec_mode.upper() == "LIVE",
-        "bot_status": "running" if app.state.bot else ("crashed" if app.state.bot_error else "starting"),
+        "bot_status": "running" if app.state.bot else ("degraded" if app.state.bot_error else "starting"),
         "warning": None if enable_live else "⚠️ ENABLE_LIVE is not 'true' - bot will NOT execute real trades!",
     }

--- a/tests/test_main_degraded_mode.py
+++ b/tests/test_main_degraded_mode.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from nifty_scalper_bot import main
+
+
+def test_health_reports_degraded_when_startup_error_exists() -> None:
+    """Verify health endpoint reports degraded mode after startup failures."""
+    main.app.state.bot = None
+    main.app.state.bot_error = 'boom'
+
+    payload = main.health()
+
+    assert payload['status'] == 'degraded'
+    assert payload['error'] == 'boom'
+
+
+def test_trading_status_reports_degraded_when_startup_error_exists(monkeypatch) -> None:
+    """Verify trading status surfaces degraded bot state without crashing."""
+    monkeypatch.setenv('ENABLE_LIVE', 'true')
+    monkeypatch.setenv('EXECUTION_MODE', 'LIVE')
+    main.app.state.bot = None
+    main.app.state.bot_error = 'startup failed'
+
+    payload = main.trading_status()
+
+    assert payload['bot_status'] == 'degraded'
+    assert payload['will_trade'] is True


### PR DESCRIPTION
### Motivation
- A recent startup wiring change could raise an `UnboundLocalError` (pre-`BotContext` references to `ctx`) and kill the process, leaving the trading system unavailable. 
- The service must remain observable and recoverable after initialization errors instead of hard-exiting the process. 

### Description
- Reworked `initialize_components` to remove pre-`ctx` local references by introducing local attachment flags (`stream_supervisor_started`, `risk_manager_data_hub_attached`, `margin_engine_data_hub_attached`, `bracket_manager_attached`) and a `risk_manager_ref` container for safe late-binding. 
- Replaced the inline lambda risk-halt getter with a defensive `_risk_halt_active()` callback that logs when the `RiskManager` is unavailable and returns `False` on errors to avoid crash paths during stream supervisor checks. 
- Persisted the new startup flags into the `BotContext` so downstream lifecycle code observes correct initialized state. 
- Changed FastAPI startup handling in `main.py` to record `app.state.bot_error`, log an error/warning and keep the API alive (degraded mode) rather than invoking a hard process exit, and updated `/health` and `/trading/status` to report `degraded` when startup fails. 
- Added `tests/test_main_degraded_mode.py` to assert the health/trading endpoints report degraded state without crashing. 

### Testing
- Ran `pytest -q tests/test_initialize_components_polling.py tests/test_main_degraded_mode.py --disable-warnings` and both test modules passed. 
- Attempted the repo check script `./run_checks.sh`, which initially failed in this environment (Python 3.10 used by the runner and missing tooling), and after installing test tooling a full `pytest` run surfaced an existing unrelated import error in `tests/notifications/test_telegram_commands.py` (`_format_chain_summary` missing), preventing the entire test suite from completing. 
- Summary of CI-local results: targeted unit tests for this change passed, `./run_checks.sh` / full test run did not complete due to pre-existing test/import issues and environment Python mismatch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698bffe2ab248324bbc16cd02147450d)