### PR TITLE
fix: sanitize symbol gate log extras to avoid LogRecord key collisions

### DIFF
--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -2109,16 +2109,25 @@ class StrategyRunner:
             extra={"event": "symbol_gate_warn_enter", "symbol": symbol},
         )
         try:
+            reserved_extra_keys = set(logging.makeLogRecord({}).__dict__)
             payload = {
                 "level": "WARNING",
                 "symbol": symbol,
                 "event": event_code,
-                "message": message,
+                "gate_message": message,
                 "reason": reason,
                 "time": datetime.now(timezone.utc).isoformat(),
             }
             if context:
-                payload.update(context)
+                sanitized_context = {
+                    (
+                        f"context_{key}"
+                        if key in reserved_extra_keys
+                        else key
+                    ): value
+                    for key, value in context.items()
+                }
+                payload.update(sanitized_context)
             self._logger.warning(message, extra=payload)
         except Exception as exc:  # noqa: BLE001
             self._logger.error(

--- a/tests/strategies/test_runner_execution_gates.py
+++ b/tests/strategies/test_runner_execution_gates.py
@@ -154,6 +154,30 @@ def test_warn_symbol_gate_emits_structured_warning(caplog) -> None:
     assert getattr(record, "symbol", "") == "NIFTY25JAN25000CE"
 
 
+
+
+def test_warn_symbol_gate_sanitizes_reserved_logrecord_context_keys(caplog) -> None:
+    runner = _runner()
+
+    with caplog.at_level("WARNING", logger=runner._logger.name):
+        runner._warn_symbol_gate(
+            "indicator_invalid",
+            "NIFTY25JAN25000CE",
+            "Indicators are invalid",
+            reason="min_bars_not_ready",
+            message="reserved_message",
+        )
+
+    match = [
+        record
+        for record in caplog.records
+        if getattr(record, "event", "") == "indicator_invalid"
+    ]
+    assert match
+    record = match[0]
+    assert getattr(record, "gate_message", "") == "Indicators are invalid"
+    assert getattr(record, "context_message", "") == "reserved_message"
+
 def test_on_tick_insufficient_history_warns_and_skips_symbol(
     caplog, monkeypatch
 ) -> None:


### PR DESCRIPTION
### Motivation
- Prevent repeated runtime failures where `StrategyRunner._warn_symbol_gate` attempted to inject reserved `logging.LogRecord` attributes (notably `message`) into `extra`, causing "Attempt to overwrite 'message' in LogRecord" and noisy error logs.

### Description
- Replace the conflicting payload key `message` with `gate_message` in `_warn_symbol_gate` to avoid colliding with `LogRecord` attributes.
- Compute the set of reserved `LogRecord` keys and sanitize all caller-provided `context` keys by prefixing any collision with `context_` before passing them to `logger.extra`.
- Add a regression test `test_warn_symbol_gate_sanitizes_reserved_logrecord_context_keys` that passes a reserved `message` key in context and asserts the values are preserved under `gate_message` and `context_message` respectively.

### Testing
- Ran the focused unit tests for the change with `pytest -q tests/strategies/test_runner_execution_gates.py -k warn_symbol_gate` and received `2 passed` for the warn-gate tests.
- Executed `./run_checks.sh` in this environment which installed runtime deps but reported missing dev tools initially, so I installed dev tooling with `.venv/bin/pip install pytest ruff mypy black isort`; `ruff` later reported many pre-existing lint issues in `runner.py` unrelated to this patch and the full test run aborted due to an unrelated import error in `tests/notifications/test_telegram_commands.py` (cannot import `_format_chain_summary`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c0958dd08832484432b5fac6b51b2)