### PR TITLE
fix: replace frozen session universe with dynamic UniverseController

### DIFF
--- a/src/nifty_scalper_bot/config/settings.py
+++ b/src/nifty_scalper_bot/config/settings.py
@@ -16,10 +16,10 @@ clear error messages to ease troubleshooting in Railway deployments.
 
 from __future__ import annotations
 
-import os
 from dataclasses import dataclass, field
 from datetime import time
 from functools import lru_cache
+import os
 from pathlib import Path
 from typing import Set
 
@@ -60,24 +60,24 @@ LOGGER = get_logger(__name__)
 
 def _ensure_env_loaded_before_settings() -> None:
     """Load .env file before any settings are built.
-    
+
     ✅ CRITICAL FIX: This MUST run at import time!
-    
+
     Problem: Python imports settings.py which calls _build_order_settings()
     at module level. If load_dotenv() hasn't run yet, os.getenv("ENABLE_LIVE")
     returns None, and the bot starts in SHADOW mode.
-    
+
     Solution: Load .env here, before any settings classes are built.
     """
     from dotenv import load_dotenv
-    
+
     search_paths = [
         Path.cwd() / ".env",
         Path("/app/.env"),
         Path(__file__).resolve().parent.parent.parent / ".env",  # src/../.env
         Path(__file__).resolve().parent.parent / ".env",
     ]
-    
+
     for env_path in search_paths:
         try:
             if env_path.exists() and env_path.is_file():
@@ -89,13 +89,15 @@ def _ensure_env_loaded_before_settings() -> None:
         except Exception as e:
             print(f"⚠️ [SETTINGS] Error loading {env_path}: {e}", flush=True)
             continue
-    
+
     # Fallback
     load_dotenv(override=True)
     print("⚠️ [SETTINGS] No .env found, using system environment", flush=True)
 
+
 # ✅ EXECUTE IMMEDIATELY when settings.py is imported
 _ensure_env_loaded_before_settings()
+
 
 def _sanitize_token(raw: str) -> str:
     token = raw.strip().strip('"').strip("'")
@@ -902,13 +904,16 @@ class Settings:
     replay: ReplaySettings = field(default_factory=ReplaySettings)
     selector: SelectorSettings = field(default_factory=SelectorSettings)
     liquidity: LiquiditySettings = field(default_factory=LiquiditySettings)
-    option_universe: OptionUniverseSettings = field(default_factory=OptionUniverseSettings)
+    option_universe: OptionUniverseSettings = field(
+        default_factory=OptionUniverseSettings
+    )
     instruments: InstrumentSettings = field(default_factory=InstrumentSettings)
     elite: EliteStrategiesSettings = field(default_factory=EliteStrategiesSettings)
     poll_batch_size: int = 50
     poll_interval_ms_jitter_pct: float = 0.15
     feature_order_without_token: bool = True
     feature_resolver_learn_from_quotes: bool = True
+    universe_dynamic_mode: bool = True
 
 
 def _build_elite_settings() -> EliteStrategiesSettings:
@@ -923,7 +928,7 @@ def _build_elite_settings() -> EliteStrategiesSettings:
             min_confidence=_env_float("SMC_MIN_CONFIDENCE", default=45.0),
             cooldown_seconds=_env_float("SMC_COOLDOWN", default=60.0),
             sweep_distance_points=_env_float("SMC_SWEEP_DISTANCE", default=15.0),
-            volume_spike_mult=_env_float("SMC_VOLUME_SPIKE", default=2.0)
+            volume_spike_mult=_env_float("SMC_VOLUME_SPIKE", default=2.0),
         )
 
         # 2. VWAP Pro
@@ -931,25 +936,29 @@ def _build_elite_settings() -> EliteStrategiesSettings:
         vwap_cfg = VWAPProStrategyConfig(
             enabled=_env_bool("VWAP_PRO_ENABLED", "VWAP_ENABLED", default=True),
             min_confidence=_env_float("VWAP_MIN_CONFIDENCE", default=40.0),
-            ema_period=int(_env_float("VWAP_EMA_PERIOD", default=50.0)), 
-            proximity_pct=_env_float("VWAP_PROXIMITY_PCT", default=0.15)
+            ema_period=int(_env_float("VWAP_EMA_PERIOD", default=50.0)),
+            proximity_pct=_env_float("VWAP_PROXIMITY_PCT", default=0.15),
         )
 
         # 3. RSI Divergence
         # ✅ FIX: Use int(_env_float(...)) for period and lookback
         rsi_cfg = RSIDivergenceStrategyConfig(
             enabled=_env_bool("RSI_DIV_ENABLED", default=True),
-            min_confidence=_env_float("RSI_MIN_CONFIDENCE", "RSI_DIV_MIN_CONFIDENCE", default=48.0),
+            min_confidence=_env_float(
+                "RSI_MIN_CONFIDENCE", "RSI_DIV_MIN_CONFIDENCE", default=48.0
+            ),
             rsi_period=int(_env_float("RSI_PERIOD", default=14.0)),
         )
 
         # 4. ORB Pro
-        # ✅ CRITICAL FIX: The specific line causing your crash. 
+        # ✅ CRITICAL FIX: The specific line causing your crash.
         # We parse "15.0" as float first, then cast to int.
         orb_cfg = ORBProStrategyConfig(
             enabled=_env_bool("ORB_ENABLED", default=True),
             min_confidence=_env_float("ORB_MIN_CONFIDENCE", default=55.0),
-            orb_minutes=int(_env_float("ORB_DURATION_MIN", "ORB_MINUTES", default=15.0))
+            orb_minutes=int(
+                _env_float("ORB_DURATION_MIN", "ORB_MINUTES", default=15.0)
+            ),
         )
 
         # 5. Straddle / Theta
@@ -957,49 +966,61 @@ def _build_elite_settings() -> EliteStrategiesSettings:
             enabled=_env_bool("STRADDLE_ENABLED", default=False),
             min_confidence=_env_float("STRADDLE_MIN_CONFIDENCE", default=73.0),
             adx_threshold=_env_float("STRADDLE_ADX_LIMIT", default=25.0),
-            min_iv=_env_float("STRADDLE_MIN_IV", default=12.0)
+            min_iv=_env_float("STRADDLE_MIN_IV", default=12.0),
         )
 
         # 6. Gamma Scalping
         gamma_cfg = GammaScalpingStrategyConfig(
             enabled=_env_bool("GAMMA_ENABLED", default=False),
             min_confidence=_env_float("GAMMA_MIN_CONFIDENCE", default=65.0),
-            min_gamma=_env_float("GAMMA_THRESHOLD", default=0.0005)
+            min_gamma=_env_float("GAMMA_THRESHOLD", default=0.0005),
         )
 
         # 7. OI Max Pain (Unlocked)
         oi_cfg = OIMaxPainStrategyConfig(
             enabled=_env_bool("OI_MAX_PAIN_ENABLED", default=True),
             min_confidence=_env_float("OI_MIN_CONFIDENCE", default=40.0),
-            min_deviation_pct=_env_float("OI_MIN_DISTANCE_POINTS", default=50.0)
+            min_deviation_pct=_env_float("OI_MIN_DISTANCE_POINTS", default=50.0),
         )
 
         # 8. CPR Breakout (Unlocked)
         cpr_cfg = CPRBreakoutStrategyConfig(
             enabled=_env_bool("CPR_ENABLED", default=True),
             min_confidence=_env_float("CPR_MIN_CONFIDENCE", default=55.0),
-            narrow_cpr_threshold=_env_float("CPR_NARROW_THRESHOLD_PCT", default=0.25)
+            narrow_cpr_threshold=_env_float("CPR_NARROW_THRESHOLD_PCT", default=0.25),
         )
 
         # 9. Order Flow (Unlocked)
         of_cfg = OrderFlowStrategyConfig(
             enabled=_env_bool("ORDER_FLOW_ENABLED", default=True),
             min_confidence=_env_float("ORDER_FLOW_MIN_CONFIDENCE", default=60.0),
-            imbalance_ratio_min=_env_float("ORDER_FLOW_IMBALANCE_RATIO_BUY", default=2.8),
-            large_order_threshold_pct=_env_float("ORDER_FLOW_LARGE_ORDER_PCT", default=15.0)
+            imbalance_ratio_min=_env_float(
+                "ORDER_FLOW_IMBALANCE_RATIO_BUY", default=2.8
+            ),
+            large_order_threshold_pct=_env_float(
+                "ORDER_FLOW_LARGE_ORDER_PCT", default=15.0
+            ),
         )
 
         # 10. BB Squeeze (Unlocked)
         bb_cfg = BBSqueezeStrategyConfig(
             enabled=_env_bool("BB_SQUEEZE_ENABLED", default=True),
             min_confidence=_env_float("BB_MIN_CONFIDENCE", default=55.0),
-            squeeze_threshold_pct=_env_float("BB_SQUEEZE_BANDWIDTH", default=0.4)
+            squeeze_threshold_pct=_env_float("BB_SQUEEZE_BANDWIDTH", default=0.4),
         )
 
         # 11. Aggregate into Settings
         return EliteStrategiesSettings(
-            max_concurrent_strategies=int(_env_float("ELITE_MAX_CONCURRENT_STRATEGIES", "MAX_CONCURRENT_STRATS", default=10.0)),
-            position_size_pct=_env_float("ELITE_POSITION_SIZE_PCT", "STRAT_POS_SIZE_PCT", default=1.5),
+            max_concurrent_strategies=int(
+                _env_float(
+                    "ELITE_MAX_CONCURRENT_STRATEGIES",
+                    "MAX_CONCURRENT_STRATS",
+                    default=10.0,
+                )
+            ),
+            position_size_pct=_env_float(
+                "ELITE_POSITION_SIZE_PCT", "STRAT_POS_SIZE_PCT", default=1.5
+            ),
             smc=smc_cfg,
             vwap=vwap_cfg,
             rsi_div=rsi_cfg,
@@ -1009,12 +1030,15 @@ def _build_elite_settings() -> EliteStrategiesSettings:
             oi_max_pain=oi_cfg,
             cpr=cpr_cfg,
             order_flow=of_cfg,
-            bb_squeeze=bb_cfg
+            bb_squeeze=bb_cfg,
         )
 
     except Exception as exc:
         from nifty_scalper_bot.utils.logging import get_logger
-        get_logger(__name__).error(f"❌ Critical Error in _build_elite_settings: {exc}", exc_info=True)
+
+        get_logger(__name__).error(
+            f"❌ Critical Error in _build_elite_settings: {exc}", exc_info=True
+        )
         return EliteStrategiesSettings()
 
 
@@ -1134,7 +1158,9 @@ def _build_risk_settings() -> RiskSettings:
         atr_stop_multiple=atr_multiple,
         contract_lot_size=contract_lot_size,
         allow_pyramiding=_env_bool("RISK_ALLOW_PYRAMIDING", default=False),
-        signal_debounce_seconds=_env_float("RISK_SIGNAL_DEBOUNCE_SECONDS", default=60.0),
+        signal_debounce_seconds=_env_float(
+            "RISK_SIGNAL_DEBOUNCE_SECONDS", default=60.0
+        ),
     )
 
 
@@ -1309,8 +1335,7 @@ def _build_liquidity_settings() -> LiquiditySettings:
 
 def _build_option_universe_settings() -> OptionUniverseSettings:
     return OptionUniverseSettings(
-        underlying=_env_str("OPTION_UNIVERSE__UNDERLYING", default="NIFTY")
-        or "NIFTY",
+        underlying=_env_str("OPTION_UNIVERSE__UNDERLYING", default="NIFTY") or "NIFTY",
         exchange=_env_str("OPTION_UNIVERSE__EXCHANGE", default="NFO") or "NFO",
         strike_step=_env_int("OPTION_UNIVERSE__STRIKE_STEP", default=50, minimum=1),
         strikes_around_atm=_env_int(
@@ -1418,6 +1443,7 @@ def get_settings() -> Settings:
         feature_resolver_learn_from_quotes=_env_bool(
             "FEATURE_RESOLVER_LEARN_FROM_QUOTES", default=True
         ),
+        universe_dynamic_mode=_env_bool("UNIVERSE_DYNAMIC_MODE", default=True),
     )
 
     try:

--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -62,11 +62,12 @@ from fastapi.responses import JSONResponse, PlainTextResponse
 
 from nifty_scalper_bot.config.base import AppConfig
 from nifty_scalper_bot.config.settings import Settings, get_settings
-from nifty_scalper_bot.core.option_universe import OptionUniverseManager
 from nifty_scalper_bot.core.market_regime_manager import MarketRegimeManager
 from nifty_scalper_bot.core.message_bus import Message, MessageBus, MessageType
+from nifty_scalper_bot.core.option_universe import OptionUniverseManager
 from nifty_scalper_bot.core.strategy_manager import StrategyManager
 from nifty_scalper_bot.core.unified_manager import UnifiedManager
+from nifty_scalper_bot.core.universe_controller import UniverseController
 from nifty_scalper_bot.data import (
     InstrumentResolver,
     InstrumentUniverseStatus,
@@ -5585,6 +5586,8 @@ async def startup_sequence(ctx: BotContext) -> None:
             dynamic_option_symbols = {
                 sym for sym in targets if sym.startswith('NFO:NIFTY') and (sym.endswith('CE') or sym.endswith('PE'))
             }
+            option_universe_controller = UniverseController()
+            option_universe_controller.update(dynamic_option_symbols)
 
             async def _option_universe_sync_loop() -> None:
                 """Keep option subscriptions aligned with the dynamic option universe."""
@@ -5602,16 +5605,9 @@ async def startup_sequence(ctx: BotContext) -> None:
                             )
                         else:
                             latest_symbols = set(ctx.option_universe.get_current_universe())
-                        add_symbols = sorted(latest_symbols - dynamic_option_symbols)
-                        drop_symbols = sorted(dynamic_option_symbols - latest_symbols)
-
-                        if add_symbols or drop_symbols:
-                            LOGGER.debug(
-                                'OptionUniv: subscription update add=%s drop=%s',
-                                add_symbols,
-                                drop_symbols,
-                                extra={'event': 'option_universe_subscriptions_update'},
-                            )
+                        added, removed = option_universe_controller.update(latest_symbols)
+                        add_symbols = sorted(added)
+                        drop_symbols = sorted(removed)
 
                         for sym in add_symbols:
                             if ctx.market_data_manager:

--- a/src/nifty_scalper_bot/core/universe_controller.py
+++ b/src/nifty_scalper_bot/core/universe_controller.py
@@ -1,0 +1,41 @@
+"""Runtime controller for dynamic symbol universe membership."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from nifty_scalper_bot.utils.logging import get_logger
+
+LOGGER = get_logger(__name__)
+
+
+class UniverseController:
+    """Track active universe snapshots and emit diffs only on membership changes."""
+
+    def __init__(self) -> None:
+        """Initialize empty universe snapshots. Args: none. Returns: None. Raises: None."""
+        self.current_universe: set[str] = set()
+        self.previous_universe: set[str] = set()
+
+    def update(self, new_universe: Iterable[str]) -> tuple[set[str], set[str]]:
+        """Apply new universe and return added/removed symbols. Args: new_universe. Returns: tuple[set[str], set[str]]. Raises: None."""
+        next_universe = {
+            str(symbol) for symbol in new_universe if str(symbol or "").strip()
+        }
+        added = next_universe - self.current_universe
+        removed = self.current_universe - next_universe
+
+        if added or removed:
+            # Log only on transitions to avoid legacy per-tick warning spam.
+            LOGGER.info(
+                "Universe membership changed",
+                extra={
+                    "event": "universe_membership_changed",
+                    "added": sorted(added),
+                    "removed": sorted(removed),
+                },
+            )
+
+        self.previous_universe = set(self.current_universe)
+        self.current_universe = next_universe
+        return added, removed

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -30,6 +30,7 @@ from typing import (
 from nifty_scalper_bot.config.settings import get_settings
 from nifty_scalper_bot.core.message_bus import Message, MessageBus, MessageType
 from nifty_scalper_bot.core.strategy_manager import StrategyManager
+from nifty_scalper_bot.core.universe_controller import UniverseController
 
 # Assumes you created the data/constants.py file as advised
 from nifty_scalper_bot.data.constants import OPTION_ALIAS_SUFFIX
@@ -478,9 +479,11 @@ class StrategyRunner:
             self._config.min_indicator_bars,
             int(os.getenv("REQUIRED_CANDLES", str(self._config.min_indicator_bars))),
         )
-        self._frozen_symbol_universe: set[str] = set()
-        self._expected_symbol_count: int = 0
         self._max_symbol_count: int = int(os.getenv("STRATEGY_MAX_SYMBOL_COUNT", "32"))
+        self._universe_controller = UniverseController()
+        self._universe_dynamic_mode = bool(
+            getattr(get_settings(), "universe_dynamic_mode", True)
+        )
         self._history_gate_failed: bool = False
         self._history_ready_by_symbol: dict[str, bool] = {}
         self._rate_limit_backoff_until_by_symbol: dict[str, float] = {}
@@ -500,8 +503,8 @@ class StrategyRunner:
             self._running = True
             self._trading_paused = False
             symbols = list(self._active_symbols)
-            self._frozen_symbol_universe = set(symbols)
-            self._expected_symbol_count = len(symbols)
+            # Dynamic mode keeps runtime universe mutable instead of freezing at start.
+            self._universe_controller.update(symbols)
             self._history_gate_failed = False
             self._history_ready_by_symbol = {symbol: False for symbol in symbols}
             self._rate_limit_backoff_until_by_symbol = {}
@@ -597,6 +600,8 @@ class StrategyRunner:
                 state.active = True
 
             self._active_symbols.add(normalized)
+            # Update tracked universe snapshot only when membership changes.
+            self._universe_controller.update(self._active_symbols)
 
         running = False
         with self._lock:
@@ -622,6 +627,8 @@ class StrategyRunner:
 
             state.active = False
             self._active_symbols.discard(normalized)
+            # Dynamic diffing avoids legacy frozen-universe drift conflicts.
+            self._universe_controller.update(self._active_symbols)
             callback = self._callbacks.pop(normalized, None)
 
         try:
@@ -2185,7 +2192,7 @@ class StrategyRunner:
             )
 
     def _validate_symbol_for_cycle(self, symbol: str) -> bool:
-        """Validate symbol against frozen universe without aborting global loop.
+        """Validate symbol against active dynamic universe without aborting loop.
 
         Args: symbol. Returns: bool. Raises: None.
         """
@@ -2196,8 +2203,7 @@ class StrategyRunner:
         try:
             with self._lock:
                 symbols = sorted(self._active_symbols)
-                frozen = set(self._frozen_symbol_universe)
-                expected_count = self._expected_symbol_count
+                active_set = set(symbols)
 
             if self._max_symbol_count > 0 and len(symbols) > self._max_symbol_count:
                 self._warn_symbol_gate(
@@ -2210,32 +2216,14 @@ class StrategyRunner:
                 )
                 self._mark_symbol_unready(symbol, "universe_violation")
                 return False
-            if expected_count and len(symbols) != expected_count:
-                self._warn_symbol_gate(
-                    "universe_violation",
-                    symbol,
-                    "Session universe count deviated from frozen expectation",
-                    reason="expected_count_mismatch",
-                    actual_count=len(symbols),
-                    expected_count=expected_count,
-                )
-                self._mark_symbol_unready(symbol, "universe_violation")
-                return False
-            if frozen and symbol not in frozen:
-                self._warn_symbol_gate(
-                    "universe_violation",
-                    symbol,
-                    "Symbol not present in frozen session universe",
-                    reason="symbol_not_in_frozen_universe",
-                )
-                self._mark_symbol_unready(symbol, "universe_violation")
-                return False
-            if frozen and set(symbols) != frozen:
-                self._warn_symbol_gate(
-                    "universe_violation",
-                    symbol,
-                    "Active symbols deviate from frozen universe",
-                    reason="frozen_universe_deviation",
+            # Frozen-universe enforcement is intentionally removed in dynamic mode.
+            if symbol not in active_set:
+                self._logger.debug(
+                    "Symbol outside active universe",
+                    extra={
+                        "event": "symbol_outside_active_universe",
+                        "symbol": symbol,
+                    },
                 )
                 self._mark_symbol_unready(symbol, "universe_violation")
                 return False
@@ -2262,11 +2250,9 @@ class StrategyRunner:
         return "other"
 
     def _validate_symbol_universe(self) -> bool:
-        """Validate frozen index and option symbol universe before strategy eval."""
+        """Validate index/option composition with non-blocking dynamic diagnostics."""
         with self._lock:
             symbols = sorted(self._active_symbols)
-            frozen = set(self._frozen_symbol_universe)
-            expected_count = self._expected_symbol_count
         if self._max_symbol_count > 0 and len(symbols) > self._max_symbol_count:
             self._logger.error(
                 "Condition met: symbol_universe_mismatch",
@@ -2278,30 +2264,15 @@ class StrategyRunner:
                 },
             )
             return False
-        if expected_count and len(symbols) != expected_count:
-            self._logger.error(
-                "Condition met: symbol_universe_mismatch",
+        if self._universe_dynamic_mode:
+            # Keep diagnostics informative, but avoid frozen snapshot gating.
+            self._logger.debug(
+                "Condition met: symbol_universe_dynamic_validation",
                 extra={
-                    "event": "symbol_universe_mismatch",
-                    "reason": "expected_count_mismatch",
-                    "actual_count": len(symbols),
-                    "expected_count": expected_count,
-                    "frozen_symbols": sorted(frozen),
+                    "event": "symbol_universe_dynamic_validation",
                     "all_symbols": symbols,
                 },
             )
-            return False
-        if frozen and set(symbols) != frozen:
-            self._logger.error(
-                "Condition met: symbol_universe_mismatch",
-                extra={
-                    "event": "symbol_universe_mismatch",
-                    "reason": "frozen_universe_deviation",
-                    "frozen_symbols": sorted(frozen),
-                    "all_symbols": symbols,
-                },
-            )
-            return False
         index_symbols = [
             sym for sym in symbols if self._classify_symbol(sym) == "index"
         ]
@@ -2309,7 +2280,7 @@ class StrategyRunner:
             sym for sym in symbols if self._classify_symbol(sym) == "option"
         ]
         if not option_symbols:
-            self._logger.error(
+            self._logger.info(
                 "Condition met: symbol_universe_mismatch",
                 extra={
                     "event": "symbol_universe_mismatch",
@@ -2321,7 +2292,7 @@ class StrategyRunner:
             )
             return False
         if len(index_symbols) != 1:
-            self._logger.error(
+            self._logger.info(
                 "Condition met: symbol_universe_mismatch",
                 extra={
                     "event": "symbol_universe_mismatch",
@@ -2768,11 +2739,13 @@ class StrategyRunner:
 
             with self._lock:
                 if symbol not in self._active_symbols:
-                    self._warn_symbol_gate(
-                        "universe_violation",
-                        symbol,
-                        "Feed symbol is not tracked in active universe",
-                        reason="symbol_not_tracked",
+                    self._logger.debug(
+                        "Symbol outside active universe",
+                        extra={
+                            "event": "symbol_outside_active_universe",
+                            "symbol": symbol,
+                            "reason": "symbol_not_tracked",
+                        },
                     )
                     self._mark_symbol_unready(symbol, "universe_violation")
                     return

--- a/tests/core/test_universe_controller.py
+++ b/tests/core/test_universe_controller.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from nifty_scalper_bot.core.universe_controller import UniverseController
+
+
+def test_update_tracks_added_and_removed_members() -> None:
+    controller = UniverseController()
+
+    added, removed = controller.update(["A", "B"])
+    assert added == {"A", "B"}
+    assert removed == set()
+
+    added, removed = controller.update(["B", "C"])
+    assert added == {"C"}
+    assert removed == {"A"}
+
+
+def test_update_without_changes_keeps_empty_diff() -> None:
+    controller = UniverseController()
+    controller.update(["A", "B"])
+
+    added, removed = controller.update(["A", "B"])
+    assert added == set()
+    assert removed == set()

--- a/tests/strategies/test_runner_execution_gates.py
+++ b/tests/strategies/test_runner_execution_gates.py
@@ -49,36 +49,6 @@ def test_validate_symbol_universe_accepts_index_and_options() -> None:
     assert runner._validate_symbol_universe() is True
 
 
-def test_validate_symbol_universe_rejects_expected_count_deviation() -> None:
-    runner = _runner()
-    runner._active_symbols = {
-        "NSE:NIFTY 50",
-        "NIFTY25JAN25000CE",
-        "NIFTY25JAN25000PE",
-    }
-    runner._frozen_symbol_universe = set(runner._active_symbols)
-    runner._expected_symbol_count = 2
-
-    assert runner._validate_symbol_universe() is False
-
-
-def test_validate_symbol_universe_rejects_frozen_universe_deviation() -> None:
-    runner = _runner()
-    runner._active_symbols = {
-        "NSE:NIFTY 50",
-        "NIFTY25JAN25000CE",
-        "NIFTY25JAN25000PE",
-    }
-    runner._frozen_symbol_universe = {
-        "NSE:NIFTY 50",
-        "NIFTY25JAN25000CE",
-        "NIFTY25JAN25100PE",
-    }
-    runner._expected_symbol_count = 3
-
-    assert runner._validate_symbol_universe() is False
-
-
 def test_mark_symbol_unready_sets_state_flags() -> None:
     runner = _runner()
     symbol = "NIFTY25JAN25000CE"
@@ -92,21 +62,19 @@ def test_mark_symbol_unready_sets_state_flags() -> None:
     assert state.strategy_data["low_confidence"] is True
 
 
-def test_validate_symbol_for_cycle_warns_and_skips_on_universe_violation(
+def test_validate_symbol_for_cycle_debugs_and_skips_when_symbol_not_active(
     caplog,
 ) -> None:
     runner = _runner()
     symbol = "NIFTY25JAN25000CE"
-    runner._active_symbols = {symbol}
-    runner._frozen_symbol_universe = {"NIFTY25JAN25000PE"}
-    runner._expected_symbol_count = 1
+    runner._active_symbols = {"NIFTY25JAN25000PE"}
 
-    with caplog.at_level("WARNING", logger=runner._logger.name):
+    with caplog.at_level("DEBUG", logger=runner._logger.name):
         ok = runner._validate_symbol_for_cycle(symbol)
 
     assert ok is False
     assert any(
-        getattr(record, "event", "") == "universe_violation"
+        getattr(record, "event", "") == "symbol_outside_active_universe"
         for record in caplog.records
     )
 
@@ -154,8 +122,6 @@ def test_warn_symbol_gate_emits_structured_warning(caplog) -> None:
     assert getattr(record, "symbol", "") == "NIFTY25JAN25000CE"
 
 
-
-
 def test_warn_symbol_gate_sanitizes_reserved_logrecord_context_keys(caplog) -> None:
     runner = _runner()
 
@@ -178,6 +144,7 @@ def test_warn_symbol_gate_sanitizes_reserved_logrecord_context_keys(caplog) -> N
     assert getattr(record, "gate_message", "") == "Indicators are invalid"
     assert getattr(record, "context_message", "") == "reserved_message"
 
+
 def test_on_tick_insufficient_history_warns_and_skips_symbol(
     caplog, monkeypatch
 ) -> None:
@@ -185,9 +152,7 @@ def test_on_tick_insufficient_history_warns_and_skips_symbol(
     symbol = "NIFTY25JAN25000CE"
     runner.add_symbol(symbol)
     runner._startup_timestamp = 0.0
-    runner._frozen_symbol_universe = {symbol, "NSE:NIFTY 50"}
     runner._active_symbols = {symbol, "NSE:NIFTY 50"}
-    runner._expected_symbol_count = 2
     runner._history_ready_by_symbol[symbol] = False
     monkeypatch.setattr(runner, "_is_market_open", lambda _now: True)
 
@@ -208,9 +173,7 @@ def test_on_tick_missing_finalized_bar_warns_and_skips_symbol(
     symbol = "NIFTY25JAN25000CE"
     runner.add_symbol(symbol)
     runner._startup_timestamp = 0.0
-    runner._frozen_symbol_universe = {symbol, "NSE:NIFTY 50"}
     runner._active_symbols = {symbol, "NSE:NIFTY 50"}
-    runner._expected_symbol_count = 2
     runner._history_ready_by_symbol[symbol] = True
     runner._required_candles = 1
     runner._symbol_state[symbol].vwap = 100.0
@@ -232,9 +195,7 @@ def test_on_tick_invalid_vwap_warns_and_skips_symbol(caplog, monkeypatch) -> Non
     symbol = "NIFTY25JAN25000CE"
     runner.add_symbol(symbol)
     runner._startup_timestamp = 0.0
-    runner._frozen_symbol_universe = {symbol, "NSE:NIFTY 50"}
     runner._active_symbols = {symbol, "NSE:NIFTY 50"}
-    runner._expected_symbol_count = 2
     runner._history_ready_by_symbol[symbol] = True
     runner._required_candles = 1
     monkeypatch.setattr(runner, "_is_market_open", lambda _now: True)
@@ -255,9 +216,7 @@ def test_rate_limit_backoff_skips_only_target_symbol(caplog, monkeypatch) -> Non
     runner.add_symbol(blocked_symbol)
     runner.add_symbol(ready_symbol)
     runner._startup_timestamp = 0.0
-    runner._frozen_symbol_universe = {blocked_symbol, ready_symbol, "NSE:NIFTY 50"}
     runner._active_symbols = {blocked_symbol, ready_symbol, "NSE:NIFTY 50"}
-    runner._expected_symbol_count = 3
     runner._required_candles = 1
     runner._history_ready_by_symbol[blocked_symbol] = True
     runner._history_ready_by_symbol[ready_symbol] = True


### PR DESCRIPTION
### Motivation
- The legacy "frozen session" universe snapshot produced repeated warnings (`Symbol not present in frozen session universe`, `Active symbols deviate from frozen universe`) that conflict with dynamic ATM-driven option universe expansion.
- The intent is to remove blocking/warning frozen-universe enforcement while preserving robust universe tracking and informative diagnostics.

### Description
- Add `UniverseController` (`src/nifty_scalper_bot/core/universe_controller.py`) that maintains `current_universe`, `previous_universe`, computes `added`/`removed` diffs and emits a single structured info log only when membership actually changes to avoid per-tick spam.
- Replace frozen snapshot usage in `StrategyRunner` by wiring `UniverseController.update()` at lifecycle points (`start`, `add_symbol`, `remove_symbol`) and remove the strict frozen-universe gating, converting legacy warnings into debug logs (`symbol_outside_active_universe`) so execution paths remain unchanged.
- Add `universe_dynamic_mode` setting (exposed as `UNIVERSE_DYNAMIC_MODE` via `get_settings`) and use it to keep the validation non-blocking and informational by default.
- Integrate `UniverseController` into the app option-universe sync loop so subscription add/remove decisions are driven by diffs returned from the controller and logged once per transition.
- Update tests to reflect dynamic behavior: remove tests that asserted frozen-snapshot gating, add `tests/core/test_universe_controller.py` for diff semantics, and adjust `tests/strategies/test_runner_execution_gates.py` expectations.

### Testing
- Ran the repository checks script with `bash ./run_checks.sh`; this completed dependency install but the full-suite checks reported failures due to pre-existing repository-wide lint/mypy issues and an environment pytest plugin argument mismatch (these failures are upstream baseline issues, not caused by this patch).
- Focused unit tests for the patch were executed with `pytest -q tests/core/test_universe_controller.py tests/strategies/test_runner_execution_gates.py` and passed (`.............. [100%]`).
- A broader `pytest` run (`pytest -q tests --disable-warnings --ignore=tests/test_live_mode.py --ignore=tests/test_health_server.py`) failed on unrelated pre-existing test import errors (`tests/notifications/test_telegram_commands.py`), confirming that remaining failures are outside the scope of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c109c70508324a24d65afb848b3fe)