### PR TITLE
fix: unblock runner history readiness from live bars

### DIFF
--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -1033,6 +1033,24 @@ class StrategyRunner:
                     is_provisional=False,
                 )
 
+            try:
+                history_size = len(self._indicator_engine.get_history(symbol))
+            except Exception:
+                history_size = 0
+
+            if history_size >= self._required_candles:
+                if not self._history_ready_by_symbol.get(symbol, False):
+                    self._logger.info(
+                        "Condition met: history_ready_from_live_bars",
+                        extra={
+                            "event": "history_ready_from_live_bars",
+                            "symbol": symbol,
+                            "bars": history_size,
+                            "required": self._required_candles,
+                        },
+                    )
+                self._history_ready_by_symbol[symbol] = True
+
             # 4. BRACKET MANAGER: Inject Dynamic ATR (Volatility)
             if self._bracket_manager:
                 # Compute ATR (Period 14 is standard)
@@ -2634,9 +2652,6 @@ class StrategyRunner:
                 )
                 skip_strategy = True
 
-            if skip_strategy:
-                return
-
             # Volume validity check (relaxed warnings for REST mode)
             if volume < 0:
                 log_throttled(
@@ -2715,6 +2730,9 @@ class StrategyRunner:
                     interval_sec=30.0,
                     level=logging.WARNING,
                 )
+                return
+
+            if skip_strategy:
                 return
 
             # =================================================================


### PR DESCRIPTION
### Motivation
- Live ticks were being dropped before bar construction when the market was closed or the tick was stale, causing `Historical data is not ready for symbol` to persist and preventing strategies from ever receiving indicators.
- The goal is to allow bar-building from incoming ticks even when strategy evaluation must be skipped so the indicator history can reach readiness without upstream manual backfill.

### Description
- In `StrategyRunner._on_tick` moved the `skip_strategy` early-return to after Phase 4/5/6 so bar building, position price updates and risk checks still run when `skip_strategy` is set.
- In `_ingest_bar` added a live-readiness promotion that checks `len(self._indicator_engine.get_history(symbol))` and sets `self._history_ready_by_symbol[symbol] = True` once the number of live bars meets `self._required_candles`. 
- Added a one-time structured info log `history_ready_from_live_bars` when a symbol transitions from not-ready to ready to aid observability.

### Testing
- Located the gating message with `rg -n "Historical data is not ready" src/` which pointed to `src/nifty_scalper_bot/strategies/runner.py`.
- Ran repository checks with `./run_checks.sh`, which exposed many pre-existing lint/mypy issues and an initial `pytest-cov` absence; the script therefore fails at the global repo level (pre-existing errors unrelated to this change).
- Installed `pytest-cov` and executed targeted unit tests: `./.venv/bin/pytest -q tests/strategies/test_runner_tick_volume.py tests/test_order_manager.py --disable-warnings`, and both test suites passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c26f10d488324b762afe0a3195e7e)