### PR TITLE
fix: stabilize symbol hydration, VWAP gating, and freeze intraday universe

### DIFF
--- a/src/nifty_scalper_bot/core/option_universe.py
+++ b/src/nifty_scalper_bot/core/option_universe.py
@@ -15,8 +15,8 @@ LOGGER = get_logger(__name__)
 class OptionUniverseConfig:
     """Configuration consumed by :class:`OptionUniverseManager`."""
 
-    underlying: str = 'NIFTY'
-    exchange: str = 'NFO'
+    underlying: str = "NIFTY"
+    exchange: str = "NFO"
     strike_step: int = 50
     strikes_around_atm: int = 2
     expiry_roll_hours: float = 12.0
@@ -47,15 +47,16 @@ class OptionUniverseManager:
         """
         self._config = self._coerce_config(config)
         if self._config.strike_step <= 0:
-            raise ValueError('strike_step must be positive')
+            raise ValueError("strike_step must be positive")
         if self._config.strikes_around_atm < 0:
-            raise ValueError('strikes_around_atm must be non-negative')
+            raise ValueError("strikes_around_atm must be non-negative")
 
         self._now_fn = now_fn or datetime.now
         self._latest_spot: float | None = None
         self._atm_strike: int | None = None
         self._current_expiry: date | None = None
         self._current_universe: list[str] = []
+        self._frozen_universe: set[str] = set()
         self._last_recalc_spot: float | None = None
 
     def update_underlying(self, spot_price: float) -> None:
@@ -71,11 +72,14 @@ class OptionUniverseManager:
             ValueError: When *spot_price* is not positive.
         """
         if spot_price <= 0:
-            raise ValueError('spot_price must be positive')
+            raise ValueError("spot_price must be positive")
 
         now = self._now_fn()
         self._latest_spot = float(spot_price)
-        new_atm = int(round(self._latest_spot / self._config.strike_step) * self._config.strike_step)
+        new_atm = int(
+            round(self._latest_spot / self._config.strike_step)
+            * self._config.strike_step
+        )
         new_expiry = self._resolve_active_expiry(now)
 
         atm_changed = new_atm != self._atm_strike
@@ -83,28 +87,35 @@ class OptionUniverseManager:
 
         if expiry_changed and self._current_expiry is not None:
             LOGGER.debug(
-                'OptionUniv: expiry rolled %s -> %s',
+                "OptionUniv: expiry rolled %s -> %s",
                 self._current_expiry,
                 new_expiry,
-                extra={'event': 'option_universe_expiry_roll'},
+                extra={"event": "option_universe_expiry_roll"},
             )
 
         if atm_changed:
             LOGGER.debug(
-                'OptionUniv: ATM updated -> ATM=%s expiry=%s',
+                "OptionUniv: ATM updated -> ATM=%s expiry=%s",
                 new_atm,
                 new_expiry,
-                extra={'event': 'option_universe_atm_update'},
+                extra={"event": "option_universe_atm_update"},
             )
 
-        if atm_changed or expiry_changed or not self._current_universe:
+        should_refresh = expiry_changed or not self._frozen_universe
+        if should_refresh:
             self._atm_strike = new_atm
             self._current_expiry = new_expiry
             self._current_universe = self._build_universe(new_atm, new_expiry)
+            self._frozen_universe = set(self._current_universe)
             LOGGER.debug(
-                'OptionUniv: Universe refreshed -> %s',
+                "OptionUniv: Universe refreshed -> %s",
                 self._current_universe,
-                extra={'event': 'option_universe_refreshed'},
+                extra={"event": "option_universe_refreshed"},
+            )
+        elif atm_changed:
+            LOGGER.debug(
+                "OptionUniv: Symbol ignored (not in frozen universe rebuild window)",
+                extra={"event": "option_universe_frozen_skip", "atm": new_atm},
             )
 
     def get_current_universe(self) -> list[str]:
@@ -136,24 +147,21 @@ class OptionUniverseManager:
         return self.get_current_universe()
 
     def get_filtered_universe(self, spot_ltp: float) -> list[str]:
-        """Return a throttled ATM-window universe for the nearest weekly expiry."""
+        """Return the frozen intraday universe while tracking spot diagnostics."""
         if spot_ltp <= 0:
             return list(self._current_universe)[:8]
         threshold = max(1.0, float(self._config.spot_recalc_threshold_points))
-        if self._last_recalc_spot is None or abs(spot_ltp - self._last_recalc_spot) >= threshold:
+        if self._last_recalc_spot is None:
             self.update_underlying(spot_ltp)
-            self._last_recalc_spot = float(spot_ltp)
-        atm = self._atm_strike
-        if atm is None:
-            return list(self._current_universe)[:8]
-        weekly, _ = self._resolve_weekly_monthly_expiries(self._now_fn())
-        if weekly is None:
-            return list(self._current_universe)[:8]
-        symbols = self._build_universe(atm, weekly)
-        # Hard cap to control quote fanout and broker rate-limit pressure.
-        return list(dict.fromkeys(symbols))[:8]
+        elif abs(spot_ltp - self._last_recalc_spot) >= threshold:
+            # Keep universe frozen intraday; only track diagnostic spot drift.
+            self._latest_spot = float(spot_ltp)
+        self._last_recalc_spot = float(spot_ltp)
+        return self.get_current_universe()
 
-    def _coerce_config(self, config: OptionUniverseConfig | dict[str, Any] | Any) -> OptionUniverseConfig:
+    def _coerce_config(
+        self, config: OptionUniverseConfig | dict[str, Any] | Any
+    ) -> OptionUniverseConfig:
         """Normalize external config objects into :class:`OptionUniverseConfig`."""
         if isinstance(config, OptionUniverseConfig):
             return config
@@ -161,27 +169,27 @@ class OptionUniverseManager:
             payload = dict(config)
         else:
             payload = {
-                'underlying': getattr(config, 'underlying', 'NIFTY'),
-                'exchange': getattr(config, 'exchange', 'NFO'),
-                'strike_step': getattr(config, 'strike_step', 50),
-                'strikes_around_atm': getattr(config, 'strikes_around_atm', 3),
-                'expiry_roll_hours': getattr(config, 'expiry_roll_hours', 12.0),
-                'market_close_hour': getattr(config, 'market_close_hour', 15),
-                'market_close_minute': getattr(config, 'market_close_minute', 30),
-                'spot_recalc_threshold_points': getattr(
-                    config, 'spot_recalc_threshold_points', 25.0
+                "underlying": getattr(config, "underlying", "NIFTY"),
+                "exchange": getattr(config, "exchange", "NFO"),
+                "strike_step": getattr(config, "strike_step", 50),
+                "strikes_around_atm": getattr(config, "strikes_around_atm", 3),
+                "expiry_roll_hours": getattr(config, "expiry_roll_hours", 12.0),
+                "market_close_hour": getattr(config, "market_close_hour", 15),
+                "market_close_minute": getattr(config, "market_close_minute", 30),
+                "spot_recalc_threshold_points": getattr(
+                    config, "spot_recalc_threshold_points", 25.0
                 ),
             }
         return OptionUniverseConfig(
-            underlying=str(payload.get('underlying', 'NIFTY')).upper(),
-            exchange=str(payload.get('exchange', 'NFO')).upper(),
-            strike_step=int(payload.get('strike_step', 50)),
-            strikes_around_atm=int(payload.get('strikes_around_atm', 3)),
-            expiry_roll_hours=float(payload.get('expiry_roll_hours', 12.0)),
-            market_close_hour=int(payload.get('market_close_hour', 15)),
-            market_close_minute=int(payload.get('market_close_minute', 30)),
+            underlying=str(payload.get("underlying", "NIFTY")).upper(),
+            exchange=str(payload.get("exchange", "NFO")).upper(),
+            strike_step=int(payload.get("strike_step", 50)),
+            strikes_around_atm=int(payload.get("strikes_around_atm", 3)),
+            expiry_roll_hours=float(payload.get("expiry_roll_hours", 12.0)),
+            market_close_hour=int(payload.get("market_close_hour", 15)),
+            market_close_minute=int(payload.get("market_close_minute", 30)),
             spot_recalc_threshold_points=float(
-                payload.get('spot_recalc_threshold_points', 25.0)
+                payload.get("spot_recalc_threshold_points", 25.0)
             ),
         )
 
@@ -191,9 +199,33 @@ class OptionUniverseManager:
         """Resolve nearest weekly then next monthly expiry candidates."""
         calendar = self._build_expiry_calendar(now.date())
         roll_delta = timedelta(hours=self._config.expiry_roll_hours)
-        weekly = next((item for item in calendar if (datetime.combine(item, time(self._config.market_close_hour, self._config.market_close_minute)) - now) > roll_delta), None)
-        monthly_candidates = [item for item in self._monthly_expiries(now.date(), months=8) if item >= now.date()]
-        monthly = next((item for item in monthly_candidates if weekly is None or item > weekly), None)
+        weekly = next(
+            (
+                item
+                for item in calendar
+                if (
+                    datetime.combine(
+                        item,
+                        time(
+                            self._config.market_close_hour,
+                            self._config.market_close_minute,
+                        ),
+                    )
+                    - now
+                )
+                > roll_delta
+            ),
+            None,
+        )
+        monthly_candidates = [
+            item
+            for item in self._monthly_expiries(now.date(), months=8)
+            if item >= now.date()
+        ]
+        monthly = next(
+            (item for item in monthly_candidates if weekly is None or item > weekly),
+            None,
+        )
         return weekly, monthly
 
     def _build_universe(self, atm_strike: int, expiry: date) -> list[str]:
@@ -201,15 +233,17 @@ class OptionUniverseManager:
         expiry_code = self._format_expiry_code(expiry)
         strikes = [
             atm_strike + (offset * self._config.strike_step)
-            for offset in range(-self._config.strikes_around_atm, self._config.strikes_around_atm + 1)
+            for offset in range(
+                -self._config.strikes_around_atm, self._config.strikes_around_atm + 1
+            )
         ]
         symbols: list[str] = []
         for strike in strikes:
             symbols.append(
-                f'{self._config.exchange}:{self._config.underlying}{expiry_code}{strike}CE'
+                f"{self._config.exchange}:{self._config.underlying}{expiry_code}{strike}CE"
             )
             symbols.append(
-                f'{self._config.exchange}:{self._config.underlying}{expiry_code}{strike}PE'
+                f"{self._config.exchange}:{self._config.underlying}{expiry_code}{strike}PE"
             )
         return symbols
 
@@ -217,7 +251,7 @@ class OptionUniverseManager:
         """Select nearest valid expiry, rolling early near expiry cutoff."""
         candidates = self._build_expiry_calendar(now.date())
         if not candidates:
-            raise ValueError('no expiry candidates generated')
+            raise ValueError("no expiry candidates generated")
 
         roll_delta = timedelta(hours=self._config.expiry_roll_hours)
         for candidate in candidates:
@@ -280,9 +314,11 @@ class OptionUniverseManager:
 
     def _format_expiry_code(self, expiry: date) -> str:
         """Format expiry into weekly or monthly Zerodha option code."""
-        monthly_expiry = expiry in set(self._monthly_expiries(expiry.replace(day=1), months=1))
+        monthly_expiry = expiry in set(
+            self._monthly_expiries(expiry.replace(day=1), months=1)
+        )
         if monthly_expiry:
-            return expiry.strftime('%y%b').upper()
-        month_map = {10: 'O', 11: 'N', 12: 'D'}
+            return expiry.strftime("%y%b").upper()
+        month_map = {10: "O", 11: "N", 12: "D"}
         month_token = month_map.get(expiry.month, str(expiry.month))
         return f"{expiry.strftime('%y')}{month_token}{expiry.strftime('%d')}"

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -6,7 +6,8 @@ import asyncio
 import calendar
 from collections import defaultdict, deque
 from dataclasses import dataclass, field
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
+from enum import Enum
 import logging
 import os
 import threading
@@ -213,9 +214,18 @@ class StrategyRunnerConfig:
             raise ValueError(msg)
 
 
+class SymbolState(Enum):
+    """Hydration lifecycle state maintained per symbol."""
+
+    INIT = 0
+    HYDRATING = 1
+    READY = 2
+    TRADING = 3
+
+
 @dataclass(slots=True)
-class SymbolState:
-    """Mutable state maintained per symbol."""
+class SymbolRuntimeState:
+    """Mutable runtime data maintained per symbol."""
 
     symbol: str
     history_limit: int
@@ -451,7 +461,7 @@ class StrategyRunner:
         self._running = False
         self._trading_paused = False
         self._active_symbols: set[str] = set()
-        self._symbol_state: Dict[str, SymbolState] = {}
+        self._symbol_state: Dict[str, SymbolRuntimeState] = {}
         self._callbacks: MutableMapping[str, Callable[[dict], None]] = {}
         self._bar_builders: Dict[str, OneMinuteBarBuilder] = {}
         self._last_bar_ts: dict[str, datetime] = {}
@@ -486,6 +496,9 @@ class StrategyRunner:
         )
         self._history_gate_failed: bool = False
         self._history_ready_by_symbol: dict[str, bool] = {}
+        self._symbol_states: dict[str, SymbolState] = {}
+        self._frozen_universe: set[str] = set()
+        self._vwap_state: dict[str, dict[str, Any]] = {}
         self._rate_limit_backoff_until_by_symbol: dict[str, float] = {}
         self._hydration_attempted_symbols: set[str] = set()
         self._strategy_slot_limit: int = max(
@@ -503,11 +516,14 @@ class StrategyRunner:
             self._running = True
             self._trading_paused = False
             symbols = list(self._active_symbols)
-            # Dynamic mode keeps runtime universe mutable instead of freezing at start.
+            self._frozen_universe = set(symbols)
             self._universe_controller.update(symbols)
             self._history_gate_failed = False
             self._history_ready_by_symbol = {symbol: False for symbol in symbols}
+            for symbol in symbols:
+                self._symbol_states.setdefault(symbol, SymbolState.INIT)
             self._rate_limit_backoff_until_by_symbol = {}
+            self._vwap_state = {}
 
         # Capture the loop if called from async context (optional safety)
         try:
@@ -591,7 +607,7 @@ class StrategyRunner:
         with self._lock:
             state = self._symbol_state.get(normalized)
             if state is None:
-                state = SymbolState(
+                state = SymbolRuntimeState(
                     symbol=normalized,
                     history_limit=self._config.max_trade_history,
                 )
@@ -600,6 +616,7 @@ class StrategyRunner:
                 state.active = True
 
             self._active_symbols.add(normalized)
+            self._symbol_states.setdefault(normalized, SymbolState.INIT)
             # Update tracked universe snapshot only when membership changes.
             self._universe_controller.update(self._active_symbols)
 
@@ -627,6 +644,9 @@ class StrategyRunner:
 
             state.active = False
             self._active_symbols.discard(normalized)
+            self._frozen_universe.discard(normalized)
+            self._symbol_states.pop(normalized, None)
+            self._vwap_state.pop(normalized, None)
             # Dynamic diffing avoids legacy frozen-universe drift conflicts.
             self._universe_controller.update(self._active_symbols)
             callback = self._callbacks.pop(normalized, None)
@@ -860,7 +880,7 @@ class StrategyRunner:
             with self._lock:
                 state = self._symbol_state.get(symbol)
                 if state is None:
-                    state = SymbolState(
+                    state = SymbolRuntimeState(
                         symbol=symbol,
                         history_limit=self._config.max_trade_history,
                     )
@@ -951,9 +971,10 @@ class StrategyRunner:
             with self._lock:
                 self._active_symbols.add(data["symbol"])
                 if data["symbol"] not in self._symbol_state:
-                    self._symbol_state[data["symbol"]] = SymbolState(
+                    self._symbol_state[data["symbol"]] = SymbolRuntimeState(
                         symbol=data["symbol"], history_limit=2000
                     )
+                self._symbol_states.setdefault(data["symbol"], SymbolState.INIT)
 
         except Exception as exc:
             self._logger.error(
@@ -972,9 +993,11 @@ class StrategyRunner:
 
                 # 2. Ensure SymbolState exists (Critical for Strategy Context)
                 if sym not in self._symbol_state:
-                    self._symbol_state[sym] = SymbolState(
+                    self._symbol_state[sym] = SymbolRuntimeState(
                         symbol=sym, history_limit=2000
                     )
+                self._symbol_states.setdefault(sym, SymbolState.INIT)
+                self._set_symbol_hydration_state(sym, SymbolState.READY)
 
                 # 3. Initialize BarBuilder (Prevent KeyErrors in internal checks)
                 if sym not in self._bar_builders:
@@ -988,6 +1011,51 @@ class StrategyRunner:
         self._startup_hydrated = True
 
         self._logger.info(f"✅ StrategyRunner marked READY with {len(symbols)} symbols")
+
+    def _set_symbol_hydration_state(
+        self,
+        symbol: str,
+        next_state: SymbolState,
+        *,
+        allow_downgrade: bool = False,
+    ) -> SymbolState:
+        """Update per-symbol hydration state with READY downgrade protection."""
+        current = self._symbol_states.get(symbol, SymbolState.INIT)
+        if (
+            current in {SymbolState.READY, SymbolState.TRADING}
+            and next_state == SymbolState.HYDRATING
+            and not allow_downgrade
+        ):
+            return current
+        self._symbol_states[symbol] = next_state
+        self._history_ready_by_symbol[symbol] = next_state in {
+            SymbolState.READY,
+            SymbolState.TRADING,
+        }
+        return next_state
+
+    def _refresh_symbol_hydration_state(self, symbol: str) -> SymbolState:
+        """Set INIT/HYDRATING/READY from available indicator history size."""
+        try:
+            history_size = len(self._indicator_engine.get_history(symbol))
+        except Exception:
+            history_size = 0
+        if history_size >= self._required_candles:
+            return self._set_symbol_hydration_state(symbol, SymbolState.READY)
+        return self._set_symbol_hydration_state(symbol, SymbolState.HYDRATING)
+
+    def _ensure_symbol_vwap_state(self, symbol: str, now: datetime) -> dict[str, Any]:
+        """Return session-scoped VWAP accumulator for symbol."""
+        session_date = now.date()
+        state = self._vwap_state.setdefault(
+            symbol,
+            {"cum_pv": 0.0, "cum_vol": 0.0, "last_reset_date": session_date},
+        )
+        if state.get("last_reset_date") != session_date:
+            state["cum_pv"] = 0.0
+            state["cum_vol"] = 0.0
+            state["last_reset_date"] = session_date
+        return state
 
     def _ingest_bar(
         self, symbol: str, bar: OneMinuteBar, is_backfill: bool = False
@@ -1049,7 +1117,7 @@ class StrategyRunner:
                             "required": self._required_candles,
                         },
                     )
-                self._history_ready_by_symbol[symbol] = True
+                self._set_symbol_hydration_state(symbol, SymbolState.READY)
 
             # 4. BRACKET MANAGER: Inject Dynamic ATR (Volatility)
             if self._bracket_manager:
@@ -1720,7 +1788,9 @@ class StrategyRunner:
             # Check if symbol or underlying has pending order
             if symbol in self._orders_in_flight:
                 elapsed = now - self._orders_in_flight[symbol]
-                self._logger.debug(f"🛡️ ORDER IN FLIGHT: {symbol} | Age: {elapsed:.1f}s")
+                self._logger.debug(
+                    f"🛡️ ORDER IN FLIGHT: {symbol} | Age: {elapsed:.1f}s"
+                )
                 return True
 
             if (
@@ -1963,17 +2033,17 @@ class StrategyRunner:
                         for bar_data in history:
                             self.ingest_historical_bar(bar_data)
                             total_bars += 1
-                        self._history_ready_by_symbol[symbol] = True
+                        self._set_symbol_hydration_state(symbol, SymbolState.READY)
                         self._logger.info(
                             f"✅ Fallback backfill: Ingested {len(history)} bars for {symbol}"
                         )
                     else:
-                        self._history_ready_by_symbol[symbol] = False
+                        self._set_symbol_hydration_state(symbol, SymbolState.HYDRATING)
 
                     await asyncio.sleep(0.5)
 
                 except Exception as e:
-                    self._history_ready_by_symbol[symbol] = False
+                    self._set_symbol_hydration_state(symbol, SymbolState.HYDRATING)
                     self._logger.error(f"❌ Fallback fetch failed for {symbol}: {e}")
 
         except Exception as exc:
@@ -2052,7 +2122,7 @@ class StrategyRunner:
                 continue
         normalized.sort(key=lambda row: cast(datetime, row["timestamp"]))
         if len(normalized) < self._required_candles:
-            self._history_ready_by_symbol[symbol] = False
+            self._set_symbol_hydration_state(symbol, SymbolState.HYDRATING)
             self._warn_symbol_gate(
                 "insufficient_history",
                 symbol,
@@ -2065,7 +2135,7 @@ class StrategyRunner:
         if self._data_hub and hasattr(self._data_hub, "history_freshness"):
             fresh, meta = self._data_hub.history_freshness(symbol, "minute")
             if not fresh:
-                self._history_ready_by_symbol[symbol] = False
+                self._set_symbol_hydration_state(symbol, SymbolState.HYDRATING)
                 self._warn_symbol_gate(
                     "insufficient_history",
                     symbol,
@@ -2074,7 +2144,7 @@ class StrategyRunner:
                     meta=meta,
                 )
                 return []
-        self._history_ready_by_symbol[symbol] = True
+        self._set_symbol_hydration_state(symbol, SymbolState.READY)
         return normalized
 
     def _log_once_per_symbol_per_bar(
@@ -2145,11 +2215,7 @@ class StrategyRunner:
             }
             if context:
                 sanitized_context = {
-                    (
-                        f"context_{key}"
-                        if key in reserved_extra_keys
-                        else key
-                    ): value
+                    (f"context_{key}" if key in reserved_extra_keys else key): value
                     for key, value in context.items()
                 }
                 payload.update(sanitized_context)
@@ -2178,7 +2244,7 @@ class StrategyRunner:
             extra={"event": "symbol_unready_mark_enter", "symbol": symbol},
         )
         try:
-            self._history_ready_by_symbol[symbol] = False
+            self._set_symbol_hydration_state(symbol, SymbolState.HYDRATING)
             state_transition = False
             with self._lock:
                 state = self._symbol_state.get(symbol)
@@ -2234,7 +2300,12 @@ class StrategyRunner:
                 )
                 self._mark_symbol_unready(symbol, "universe_violation")
                 return False
-            # Frozen-universe enforcement is intentionally removed in dynamic mode.
+            if self._frozen_universe and symbol not in self._frozen_universe:
+                self._logger.debug(
+                    "Symbol ignored (not in frozen universe)",
+                    extra={"event": "symbol_ignored_frozen_universe", "symbol": symbol},
+                )
+                return False
             if symbol not in active_set:
                 self._logger.debug(
                     "Symbol outside active universe",
@@ -2745,14 +2816,21 @@ class StrategyRunner:
                 return
             if not self._validate_symbol_for_cycle(symbol):
                 return
-            if not self._history_ready_by_symbol.get(symbol, False):
-                self._warn_symbol_gate(
-                    "insufficient_history",
-                    symbol,
+            hydration_state = self._refresh_symbol_hydration_state(symbol)
+            if hydration_state != SymbolState.READY:
+                log_throttled(
+                    self._logger,
+                    f"history_not_ready_{symbol}",
                     "Historical data is not ready for symbol",
-                    reason="history_not_ready",
+                    interval_sec=30.0,
+                    level=logging.WARNING,
+                    extra={
+                        "event": "insufficient_history",
+                        "symbol": symbol,
+                        "reason": "history_not_ready",
+                        "state": hydration_state.name,
+                    },
                 )
-                self._mark_symbol_unready(symbol, "insufficient_history")
                 return
 
             with self._lock:
@@ -2772,13 +2850,17 @@ class StrategyRunner:
                 if state is None or not state.active:
                     return
 
+                vwap_state = self._ensure_symbol_vwap_state(symbol, now)
                 if volume > 0:
-                    state.session_vwap_volume += int(volume)
-                    state.session_vwap_turnover += float(price) * float(volume)
-                    if state.session_vwap_volume > 0:
-                        state.vwap = (
-                            state.session_vwap_turnover / state.session_vwap_volume
-                        )
+                    vwap_state["cum_vol"] = float(
+                        vwap_state.get("cum_vol", 0.0)
+                    ) + float(volume)
+                    vwap_state["cum_pv"] = float(vwap_state.get("cum_pv", 0.0)) + (
+                        float(price) * float(volume)
+                    )
+                cum_vol = float(vwap_state.get("cum_vol", 0.0))
+                if cum_vol > 0:
+                    state.vwap = float(vwap_state.get("cum_pv", 0.0)) / cum_vol
 
                 # Heartbeat logging for derivatives (confirms data flow)
                 if "NIFTY" in symbol and any(x in symbol for x in ["FUT", "CE", "PE"]):
@@ -2902,16 +2984,17 @@ class StrategyRunner:
 
                 # 8C. FALLBACK STRATEGY: Momentum Breakout (When VWAP is Missing/0)
                 if generated_signal is None and (not state.vwap or state.vwap <= 0):
-                    self._warn_symbol_gate(
-                        "vwap_invalid",
-                        symbol,
-                        "VWAP unavailable or invalid; skipping symbol strategy evaluation",
-                        reason="vwap_missing_or_non_positive",
-                    )
-                    self._mark_symbol_unready(
-                        symbol,
-                        "vwap_invalid",
-                        low_confidence=True,
+                    log_throttled(
+                        self._logger,
+                        f"vwap_unavailable_{symbol}",
+                        "VWAP unavailable; skipping signal",
+                        interval_sec=30.0,
+                        level=logging.WARNING,
+                        extra={
+                            "event": "vwap_invalid",
+                            "symbol": symbol,
+                            "reason": "vwap_missing_or_non_positive",
+                        },
                     )
                     return
 
@@ -2986,6 +3069,8 @@ class StrategyRunner:
                 return
 
             # If no immediate signal, delegate to complex StrategyManager
+            if self._symbol_states.get(symbol, SymbolState.INIT) != SymbolState.READY:
+                return
             if signal is None and self._required_candles:
                 should_evaluate = False
                 with self._lock:
@@ -3185,7 +3270,10 @@ class StrategyRunner:
             # =================================================================
 
             if signal and signal.action != "HOLD":
-                if signal.action in {"BUY", "SELL"} and not self._strategy_slots_available():
+                if (
+                    signal.action in {"BUY", "SELL"}
+                    and not self._strategy_slots_available()
+                ):
                     self._warn_symbol_gate(
                         "strategy_slots_full",
                         symbol,
@@ -4734,6 +4822,7 @@ __all__ = [
     "StrategyRunner",
     "StrategyRunnerConfig",
     "SymbolState",
+    "SymbolRuntimeState",
     "TradeRecord",
     "OrderRouter",
 ]

--- a/tests/strategies/test_runner_conflicts.py
+++ b/tests/strategies/test_runner_conflicts.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-import logging
 from datetime import datetime, timezone
+import logging
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock
@@ -10,7 +10,7 @@ from nifty_scalper_bot.options.strike_selector import SelectedContract
 from nifty_scalper_bot.strategies.runner import (
     StrategyRunner,
     StrategyRunnerConfig,
-    SymbolState,
+    SymbolRuntimeState,
 )
 from nifty_scalper_bot.strategies.signal_generator import Signal
 
@@ -85,7 +85,7 @@ def _make_runner(
         data_hub=data_hub,
         strike_selector=selector,
     )
-    runner._symbol_state["NIFTY"] = SymbolState(symbol="NIFTY", history_limit=5)
+    runner._symbol_state["NIFTY"] = SymbolRuntimeState(symbol="NIFTY", history_limit=5)
     runner._symbol_state["NIFTY"].active = True
     runner._symbol_state["NIFTY"].strategy_data["last_signal"] = {}
     return runner, risk_manager, order_manager

--- a/tests/strategies/test_runner_selector_integration.py
+++ b/tests/strategies/test_runner_selector_integration.py
@@ -7,7 +7,7 @@ from nifty_scalper_bot.options.strike_selector import SelectedContract
 from nifty_scalper_bot.strategies.runner import (
     StrategyRunner,
     StrategyRunnerConfig,
-    SymbolState,
+    SymbolRuntimeState,
 )
 from nifty_scalper_bot.strategies.signal_generator import Signal
 
@@ -78,7 +78,7 @@ def _make_runner(selector: _StubSelector) -> StrategyRunner:
         data_hub=data_hub,
         strike_selector=selector,
     )
-    runner._symbol_state["NIFTY"] = SymbolState(symbol="NIFTY", history_limit=5)
+    runner._symbol_state["NIFTY"] = SymbolRuntimeState(symbol="NIFTY", history_limit=5)
     runner._symbol_state["NIFTY"].active = True
     runner._symbol_state["NIFTY"].strategy_data["last_signal"] = {}
     return runner


### PR DESCRIPTION
### Motivation
- Reduce hydration oscillation and noisy unready transitions caused by transient gates (VWAP invalid, stale history, and universe churn). 
- Ensure VWAP accumulation and indicator histories remain session‑stable so strategies see continuous, non‑resetting indicators. 
- Prevent automatic universe rebuilds every cycle to avoid transient membership churn and related state regressions. 

### Description
- Add an explicit per‑symbol lifecycle enum `SymbolState` (`INIT`, `HYDRATING`, `READY`, `TRADING`) and a `_symbol_states` map to `StrategyRunner`, separating lifecycle from transient gating. 
- Implement `_set_symbol_hydration_state` and `_refresh_symbol_hydration_state` to set READY only when history length >= required warmup and to prevent READY → HYDRATING downgrades except on explicit removal/reset. 
- Change VWAP gating to use a session‑scoped accumulator (`_vwap_state` with `cum_pv`, `cum_vol`, `last_reset_date`) and skip signal generation with a throttled warning when VWAP is missing/<=0 without mutating hydration state. 
- Freeze universe membership at runner start (`_frozen_universe`) and update `OptionUniverseManager` to avoid full rebuilds every cycle by keeping an intraday frozen universe and only refreshing on initial build or expiry roll; per‑cycle validation ignores symbols not in the frozen set. 
- Ensure history backfill and hydration helper paths set symbol lifecycle via the new helpers instead of directly toggling boolean flags. 
- Small test updates to accommodate the runtime dataclass rename (`SymbolRuntimeState`) where tests constructed per‑symbol runtime state. 

### Testing
- Ran `python -m py_compile` on the modified modules and related tests to ensure syntactic correctness, which succeeded. 
- Executed targeted unit test suites: `pytest -q tests/strategies/test_runner_execution_gates.py tests/test_option_universe.py tests/strategies/test_runner_selector_integration.py tests/strategies/test_runner_conflicts.py`, and these passed. 
- Executed `./run_checks.sh` as required by project workflow; it did not fully succeed in this environment due to existing repo‑wide baseline issues (Ruff/mypy findings and pytest invocation/coverage args), so full CI checks remain blocked by unrelated baseline errors. 
- Performed broader `pytest -q tests --disable-warnings --ignore=tests/test_live_mode.py --ignore=tests/test_health_server.py` which failed in this environment due to a pre‑existing import error in `tests/strategies/test_elite_strategies.py` (unrelated to this patch).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c4a3f84248324a3dab49be7116068)