### PR TITLE
fix: reduce indicator log spam and unblock VWAP signal path

### DIFF
--- a/src/nifty_scalper_bot/strategies/indicators.py
+++ b/src/nifty_scalper_bot/strategies/indicators.py
@@ -7,6 +7,7 @@ that calculates common technical indicators from the stored price history.
 
 from __future__ import annotations
 
+import logging
 from collections import deque
 from datetime import datetime, time, timedelta, timezone
 from typing import Any, Callable, Deque, Dict, Iterable, Mapping, Sequence
@@ -216,7 +217,7 @@ class IndicatorEngine:
                 )
                 return []
             closes = history.get_closes(count)
-            LOGGER.info(
+            LOGGER.debug(
                 "Condition met: indicator_history_resolved",
                 extra={
                     "event": "indicator_engine_history_resolved",
@@ -765,15 +766,19 @@ class IndicatorEngine:
                 return False
             gap_seconds = (curr - prev).total_seconds()
             if gap_seconds > 120:
-                LOGGER.error(
+                log_throttled(
+                    LOGGER,
+                    f"indicator_gap_{symbol}",
                     "Condition met: indicator_integrity_missing_candle",
+                    interval_sec=60.0,
+                    level=logging.WARNING,
                     extra={
                         "event": "indicator_integrity_missing_candle",
                         "symbol": symbol,
                         "gap_seconds": gap_seconds,
                     },
                 )
-                return False
+                continue
         return True
 
     def ensure_min_bars(
@@ -1192,7 +1197,17 @@ class IndicatorEngine:
         price_arr = np.asarray(prices, dtype=float)
         total_volume = volume_arr.sum()
         if np.isclose(total_volume, 0.0):
-            return None
+            if price_arr.size == 0:
+                return None
+            log_throttled(
+                LOGGER,
+                "indicator_vwap_zero_volume",
+                "Condition met: indicator_vwap_zero_volume_fallback",
+                interval_sec=60.0,
+                level=logging.WARNING,
+                extra={"event": "indicator_vwap_zero_volume_fallback"},
+            )
+            return float(price_arr.mean())
         vwap = float(np.dot(price_arr, volume_arr) / total_volume)
         return vwap
 
@@ -1243,7 +1258,6 @@ class IndicatorEngine:
         - Added fallback ATR calculation (1.5% of price)
         """
         # Lazy import to avoid circular dependency
-        from nifty_scalper_bot.indicators.atr_provider import ATRSnapshot
 
         hist = self._histories.get(symbol)
 

--- a/tests/strategies/test_indicator_integrity.py
+++ b/tests/strategies/test_indicator_integrity.py
@@ -15,14 +15,24 @@ def test_has_min_bars_rejects_non_monotonic_timestamps() -> None:
     assert engine.has_min_bars(symbol, 2) is False
 
 
-def test_has_min_bars_rejects_missing_candle_gap() -> None:
+def test_has_min_bars_allows_missing_candle_gap_for_live_feed_jitter() -> None:
     engine = IndicatorEngine()
     symbol = "NIFTY25JAN25000PE"
     ts = datetime.now(timezone.utc).replace(second=0, microsecond=0)
     engine.update_price(symbol, 100.0, timestamp=ts)
     engine.update_price(symbol, 101.0, timestamp=ts + timedelta(minutes=3))
 
-    assert engine.has_min_bars(symbol, 2) is False
+    assert engine.has_min_bars(symbol, 2) is True
+
+
+def test_has_min_bars_allows_large_gap_after_integrity_warning() -> None:
+    engine = IndicatorEngine()
+    symbol = "NIFTY25JAN25050PE"
+    ts = datetime.now(timezone.utc).replace(second=0, microsecond=0)
+    engine.update_price(symbol, 100.0, timestamp=ts)
+    engine.update_price(symbol, 101.0, timestamp=ts + timedelta(minutes=15))
+
+    assert engine.has_min_bars(symbol, 2) is True
 
 
 def test_has_min_bars_rejects_provisional_candles() -> None:


### PR DESCRIPTION
### Motivation
- Production runs showed repeated indicator history and missing-candle logs flooding logs and preventing strategy evaluation readiness. 
- Signals were being skipped when VWAP returned `None` due to zero-volume snapshots, blocking live trading in degraded-but-recoverable conditions.

### Description
- Downgraded `indicator_history_resolved` logging from `INFO` to `DEBUG` in `IndicatorEngine.get_history` to stop routine history reads from spamming logs.
- Converted missing-candle integrity hard-fail to a throttled warning by using `log_throttled` for `indicator_integrity_missing_candle` and continuing the integrity loop instead of returning `False`.
- Added a VWAP fallback in `_calculate_vwap` that returns the mean close price when cumulative volume is zero (with a throttled warning) to avoid `VWAP unavailable` signal suppression.
- Updated indicator integrity tests to reflect relaxed gap handling and added a test covering larger timestamp gaps.
- Files changed: `src/nifty_scalper_bot/strategies/indicators.py` and `tests/strategies/test_indicator_integrity.py`.

### Testing
- Ran `bash ./run_checks.sh`; installation completed but full checks failed on unrelated repository baseline issues (test import error in `tests/strategies/test_elite_strategies.py`), so full script did not exit cleanly.
- Linted changed files with `ruff` on the venv and fixed import ordering; `ruff` checks for modified files passed (no findings).
- Ran `mypy` on the whole repo which failed due to many pre-existing typing errors unrelated to this patch (337 errors reported), so typecheck regression not introduced by this change.
- Executed targeted pytest: `pytest -q tests/strategies/test_indicator_integrity.py tests/strategies/test_indicator_engine.py` and both test modules passed.
- Attempted repository-wide `pytest -q tests --disable-warnings --ignore=tests/test_live_mode.py --ignore=tests/test_health_server.py` which failed early due to an unrelated import error (`elite_strategy_tags` missing from `elite_strategies.builder`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cbf55c0188324a48040edc8a44344)