### PR TITLE
fix: switch market data flow to websocket-primary

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -2787,7 +2787,7 @@ def initialize_components(settings: Settings | None = None) -> BotContext:
     def _ws_token_issued_at() -> float | None:
         return None
 
-    use_polling = (not websocket_enabled) or streaming_mode in {"polling", "poll", ""}
+    use_polling = (not websocket_enabled) or streaming_mode in {"polling", "poll"}
     # [FIX] Container for direct wiring
     strategy_runner_ref: dict[str, Any] = {}
 
@@ -3126,16 +3126,8 @@ def initialize_components(settings: Settings | None = None) -> BotContext:
         )
         websocket_manager.set_client_factory(_build_ws)
 
-        # Initialize WebSocket Streamer
-        from nifty_scalper_bot.streaming.websocket_streamer import WebSocketStreamer
-
-        streamer = WebSocketStreamer(
-            api_key=config.broker.api_key,
-            access_token_provider=_resolve_ws_token,
-            on_tick=lambda tick: None,  # Handled via managers below
-            subscriptions=set(),
-            reconnect_interval=5.0,
-        )
+        # WebSocketManager is the primary streamer in WS mode.
+        streamer = websocket_manager
 
         # Wire up WebSocket handlers
         market_data_manager = MarketDataManager(
@@ -3152,14 +3144,8 @@ def initialize_components(settings: Settings | None = None) -> BotContext:
             message_bus=message_bus,
         )
 
-        # Register Callbacks
+        # Register callback to MarketDataManager; DataHub receives updates via MDM.
         websocket_manager.on_tick = market_data_manager._handle_tick
-        streamer.register_handler(
-            market_data_manager._handle_tick
-        )  # Redundant but safe
-        streamer.register_handler(
-            lambda tick: asyncio.create_task(data_hub.ingest_tick(tick))
-        )
 
     else:
         LOGGER.info("Initializing Polling Streamer...")

--- a/src/nifty_scalper_bot/data/data_hub.py
+++ b/src/nifty_scalper_bot/data/data_hub.py
@@ -281,11 +281,15 @@ class DataHub:
         if tick is not None:
             return tick
 
-        # FIX: Restore allow_pull logic to satisfy RuntimeSelfChecker
         if allow_pull and self._mdm and hasattr(self._mdm, "pull_quote"):
             try:
-                # pull_quote usually returns the dict and may trigger ingestion.
-                # We return it directly here to satisfy the caller immediately
+                transport_status = getattr(self._mdm, "transport_status", None)
+                if callable(transport_status):
+                    state = transport_status()
+                    poll_enabled = bool((state or {}).get("polling"))
+                    ws_connected = bool((state or {}).get("websocket"))
+                    if ws_connected and not poll_enabled:
+                        return None
                 return self._mdm.pull_quote(symbol)
             except Exception:
                 pass

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -1115,6 +1115,16 @@ class MarketDataManager:
             None.
         """
 
+        if not self._rest_poll_enabled:
+            self._logger.info(
+                "Condition met: mdm_pull_quote_skipped_ws_primary",
+                extra={
+                    "event": "mdm_pull_quote_skipped_ws_primary",
+                    "symbol": symbol,
+                },
+            )
+            return {"symbol": symbol}
+
         candidates: list[str | int] = self._candidate_quote_keys(symbol)
         if not candidates:
             candidates = [symbol]
@@ -2507,7 +2517,7 @@ class MarketDataManager:
                 "Condition met: mdm_tracking_added",
                 extra={"event": "mdm_tracking_added", "symbol": sym},
             )
-            if seed:
+            if seed and self._rest_poll_enabled:
                 seeded = self._seed_quote_from_broker(sym)
                 if seeded:
                     self._logger.info(


### PR DESCRIPTION
### Motivation
- Polling and per-symbol REST seeding were triggering Zerodha quote rate limits and producing noisy LTP-fallback behaviour, so websocket should be the primary live data path to reduce latency and eliminate REST quote bursts.

### Description
- Default streamer selection now treats WebSocket as the primary transport unless `STREAM__MODE` explicitly requests polling, preventing accidental polling-first startup in normal operation.
- In websocket mode the code uses the existing `WebSocketManager` as the active streamer and wires its ticks to `MarketDataManager._handle_tick` so the DataHub/MDM pipeline is the single source of truth for ticks.
- `MarketDataManager.pull_quote()` is guarded to no-op and return a sentinel when REST polling fallback is disabled to avoid per-symbol REST calls in WS-primary mode.
- `MarketDataManager.ensure_tracking(..., seed=True)` now only invokes REST seeding when REST polling fallback is enabled, and `DataHub.get_quote(..., allow_pull=True)` will avoid pulling from broker while WebSocket is connected, keeping REST reserved for orders/occasional snapshots.

### Testing
- Ran targeted unit tests: `pytest -q tests/data/test_market_data_manager.py tests/data/test_data_hub.py` and both tests passed (all green). 
- Ran `python -m py_compile` on modified modules which succeeded with no syntax errors. 
- Attempted repository checks via `./run_checks.sh` which bootstrapped dependencies but initially reported test tooling not installed in this environment; after installing test tooling I ran a broader test run `pytest -q tests --ignore=tests/test_live_mode.py --ignore=tests/test_health_server.py` which failed due to a pre-existing unrelated ImportError in `tests/strategies/test_elite_strategies.py` (missing `elite_strategy_tags`) and not due to this change.
- Commit includes only the streaming and MD/Hub guard changes and no structural or dependency changes; risk assessed as low.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990d67f57548324a7a4a62b0af1ef94)