### PR TITLE
fix: harden VWAP fallback and websocket reconnect resilience

### DIFF
--- a/src/nifty_scalper_bot/strategies/indicators.py
+++ b/src/nifty_scalper_bot/strategies/indicators.py
@@ -270,7 +270,10 @@ class IndicatorEngine:
             indicators["atr_trend"] = self.get_atr_trend(symbol)
             indicators["volatility_index"] = self.get_volatility_index(symbol)
             indicators["vwap"] = self.get_vwap(symbol)
-            self._augment_session_metrics(symbol, indicators)
+            try:
+                self._augment_session_metrics(symbol, indicators)
+            except Exception:
+                pass  # Session metrics are non-critical — don't crash pipeline
             # ✅ FIX S1: Expose latest-bar OHLC for strategies that need it
             history = self._histories.get(symbol)
             if history and len(history) > 0:
@@ -479,27 +482,38 @@ class IndicatorEngine:
         return value
 
     def get_vwap(self, symbol: str, period: int = 20) -> float | None:
-        """Calculate VWAP. Returns None if insufficient data."""
-        history = self._histories.get(symbol)
-        if history is None or len(history) == 0:
-            return None
-        effective_period = min(period, len(history))
-        if effective_period < 3:
-            return None
+        """Calculate VWAP. Returns None if insufficient data. NEVER raises."""
+        try:
+            history = self._histories.get(symbol)
+            if history is None or len(history) == 0:
+                return None
+            effective_period = min(period, len(history))
+            if effective_period < 3:
+                return None
 
-        last_timestamp = history.last_timestamp
-        if last_timestamp is None:
-            return None
-        cache_key = f"vwap_{effective_period}"
-        cached = self._get_cached(symbol, cache_key, last_timestamp)
-        if cached is not None:
-            return cached  # type: ignore[return-value]
-        prices = history.get_closes(effective_period)
-        volumes = history.get_volumes(effective_period)
-        value = self._calculate_vwap(prices, volumes)
-        self._last_valid_vwap[symbol] = float(value)
-        self._set_cache(symbol, cache_key, value, last_timestamp)
-        return value
+            last_timestamp = history.last_timestamp
+            if last_timestamp is None:
+                return None
+            cache_key = f"vwap_{effective_period}"
+            cached = self._get_cached(symbol, cache_key, last_timestamp)
+            if cached is not None:
+                return cached  # type: ignore[return-value]
+            prices = history.get_closes(effective_period)
+            volumes = history.get_volumes(effective_period)
+
+            # Pre-check: skip calculation if all volumes are zero
+            if not volumes or all(v == 0 for v in volumes):
+                return self._last_valid_vwap.get(symbol)
+
+            value = self._calculate_vwap(prices, volumes)
+            if value is None:
+                # Return last known good VWAP to avoid signal dropout
+                return self._last_valid_vwap.get(symbol)
+            self._last_valid_vwap[symbol] = float(value)
+            self._set_cache(symbol, cache_key, value, last_timestamp)
+            return value
+        except Exception:
+            return self._last_valid_vwap.get(symbol)
 
     def get_atr_trend(self, symbol: str, period: int = 14) -> float | None:
         """Return ATR trend ratio for *symbol*.
@@ -1184,18 +1198,30 @@ class IndicatorEngine:
         atr_values = np.asarray(true_ranges[-period:], dtype=float)
         return float(atr_values.mean())
 
-    def _calculate_vwap(self, prices: list[float], volumes: list[int]) -> float:
-        """Internal VWAP calculation. Args: prices, volumes. Returns: VWAP. Raises: ValueError."""
-        pv = 0.0
-        vol = 0.0
-        for price, volume in zip(prices, volumes, strict=False):
-            if int(volume) <= 0:
-                raise ValueError("Invalid volume for VWAP")
-            pv += float(price) * float(volume)
-            vol += float(volume)
-        if vol <= 0:
-            raise ValueError("Zero cumulative volume")
-        return pv / vol
+    def _calculate_vwap(self, prices: list[float], volumes: list[int]) -> float | None:
+        """Internal VWAP calculation.
+
+        Returns None when data is invalid and never raises.
+        """
+        try:
+            if not prices or not volumes or len(prices) != len(volumes):
+                return None
+            pv = 0.0
+            vol = 0.0
+            for price, volume in zip(prices, volumes, strict=False):
+                v = float(volume)
+                if v <= 0:
+                    continue  # Skip zero/negative volume bars instead of crashing
+                pv += float(price) * v
+                vol += v
+            if vol <= 0:
+                return None  # All-zero volume window — return None, don't crash
+            result = pv / vol
+            if not (result > 0):  # catches NaN and negative
+                return None
+            return result
+        except Exception:
+            return None  # NEVER crash the indicator pipeline
 
     def _ema_series(self, values: Iterable[float], period: int) -> np.ndarray:
         """Return the EMA series for the supplied values.

--- a/src/nifty_scalper_bot/streaming/websocket_manager.py
+++ b/src/nifty_scalper_bot/streaming/websocket_manager.py
@@ -53,9 +53,9 @@ class WebSocketManager:
         max_backoff_seconds: float = 60.0,
         base_backoff_seconds: float = 1.0,
         heartbeat_interval_seconds: float = 10.0,
-        stale_threshold_seconds: float = 5.0,
+        stale_threshold_seconds: float = 30.0,
         heartbeat_timeout_seconds: float = 25.0,
-        handshake_timeout_seconds: float = 20.0,
+        handshake_timeout_seconds: float = 30.0,
         circuit_breaker_threshold: int = 5,
         circuit_breaker_cooldown_seconds: float = 60.0,
         reconnect_min_seconds: float | None = None,
@@ -95,8 +95,8 @@ class WebSocketManager:
             raise ValueError(
                 "heartbeat_timeout_seconds must be > heartbeat_interval_seconds"
             )
-        if handshake_timeout_seconds < 15.0 or handshake_timeout_seconds > 25.0:
-            raise ValueError("handshake_timeout_seconds must be within 15-25 seconds")
+        if handshake_timeout_seconds < 15.0 or handshake_timeout_seconds > 45.0:
+            raise ValueError("handshake_timeout_seconds must be within 15-45 seconds")
         if circuit_breaker_threshold <= 0:
             raise ValueError("circuit_breaker_threshold must be > 0")
         if circuit_breaker_cooldown_seconds <= 0:
@@ -355,6 +355,15 @@ class WebSocketManager:
         except Exception as e:
             self._record_failure()
             self._logger.error("Failure in _connect_once: %s", e)
+            # Close the ticker that failed to connect — prevents orphaned
+            # KiteTicker threads from producing late 1006 close events.
+            ticker = self._ticker
+            if ticker is not None:
+                try:
+                    await asyncio.to_thread(ticker.close)
+                except Exception:
+                    pass  # Best effort cleanup
+            self._ticker = None
             self._schedule_reconnect("connect_failure")
 
     def _schedule_reconnect(self, reason: str) -> None:
@@ -386,6 +395,9 @@ class WebSocketManager:
                     continue
 
                 delay = self._next_backoff_delay()
+                # Enforce minimum floor — sub-second reconnects overwhelm
+                # Zerodha and cause cascading 1006 errors.
+                delay = max(delay, 5.0)
                 self._logger.info(
                     "Condition met: reconnect_scheduled reason=%s delay=%.2fs",
                     reason,
@@ -430,12 +442,20 @@ class WebSocketManager:
                     continue
 
                 if self._connected.is_set() and self._last_pong_mono > 0.0:
-                    pong_age = now - self._last_pong_mono
-                    if pong_age > self._heartbeat_timeout:
+                    # Use max(pong, tick) as activity indicator.
+                    # KiteTicker pong callbacks are unreliable through
+                    # cloud proxies (Railway); flowing ticks prove the
+                    # connection is alive even when pong frames are delayed.
+                    last_activity = max(
+                        self._last_pong_mono,
+                        self._last_tick_mono if self._last_tick_mono > 0.0 else 0.0,
+                    )
+                    activity_age = now - last_activity
+                    if activity_age > self._heartbeat_timeout:
                         self._logger.warning(
                             "Condition met: websocket_pong_timeout "
                             "age=%.2fs threshold=%.2fs",
-                            pong_age,
+                            activity_age,
                             self._heartbeat_timeout,
                         )
                         self._connected.clear()
@@ -513,6 +533,10 @@ class WebSocketManager:
         try:
             now = time.monotonic()
             self._last_tick_mono = now
+            # Ticks prove the connection is alive — bump pong tracker
+            # to prevent false pong-timeout reconnects when pong frames
+            # are delayed/lost through Railway cloud proxy.
+            self._last_pong_mono = now
             callback = self._on_tick_callback
             if callback is None:
                 return
@@ -545,8 +569,16 @@ class WebSocketManager:
             self._record_failure()
             if self._on_error_callback is not None:
                 self._on_error_callback(RuntimeError(f"code={code} reason={reason}"))
+            # Don't schedule another reconnect if one is already running —
+            # this prevents the storm where error + close + watchdog each
+            # fire their own reconnect path simultaneously.
             if not self._manual_disconnect:
-                self._schedule_reconnect(f"error:{code}")
+                if self._reconnect_task is not None and not self._reconnect_task.done():
+                    self._logger.debug(
+                        "Suppressed error reconnect — reconnect already in progress"
+                    )
+                else:
+                    self._schedule_reconnect(f"error:{code}")
         except Exception as e:
             self._logger.error("Failure in _on_error: %s", e)
 
@@ -559,7 +591,16 @@ class WebSocketManager:
             )
             self._connected.clear()
             self._state = ConnectionState.DISCONNECTED
-            if code != 1000:
+            # 1006 = old connection handshake timeout during normal teardown.
+            # Don't count as failure and don't trigger redundant reconnect
+            # if one is already in progress — this breaks the 1006 cascade.
+            if code == 1006:
+                if self._reconnect_task is not None and not self._reconnect_task.done():
+                    self._logger.debug(
+                        "Suppressed 1006 reconnect — reconnect already in progress"
+                    )
+                    return
+            elif code != 1000:
                 self._record_failure()
             if self._on_disconnect_callback is not None:
                 self._on_disconnect_callback()
@@ -631,7 +672,7 @@ class WebSocketManager:
         """Args: none; Returns: delay; Raises: none."""
 
         low = self._base_backoff
-        high = max(low, self._last_backoff_delay * 3.0)
+        high = max(low, self._last_backoff_delay * 2.0)
         delay = random.uniform(low, high)
         delay = min(self._max_backoff, delay)
         self._last_backoff_delay = delay

--- a/tests/streaming/test_websocket_manager.py
+++ b/tests/streaming/test_websocket_manager.py
@@ -97,7 +97,7 @@ async def test_reconnect_scheduled_on_error(monkeypatch: pytest.MonkeyPatch) -> 
     assert isinstance(fake_ticker, FakeKiteTicker)
     fake_ticker.on_error(fake_ticker, 1006, "drop")
     fake_ticker.on_close(fake_ticker, 1006, "drop")
-    await asyncio.sleep(0.08)
+    await asyncio.sleep(5.2)
 
     assert manager.ticker is not fake_ticker
     assert manager.ticker.connect_calls >= 1
@@ -129,7 +129,7 @@ async def test_watchdog_schedules_reconnect_for_missing_pong(
 
     fake_ticker = manager.ticker
     assert isinstance(fake_ticker, FakeKiteTicker)
-    await asyncio.sleep(0.06)
+    await asyncio.sleep(5.2)
 
     assert manager.ticker is not fake_ticker
     await manager.disconnect()


### PR DESCRIPTION
### Motivation
- Prevent transient data faults or zero-volume windows from crashing the indicator pipeline and causing strategy signal dropouts.
- Reduce cascading websocket reconnect storms and false heartbeat timeouts observed when streaming through cloud proxies.
- Keep the bot resilient so strategy evaluation and order safety are not impacted by non‑critical telemetry failures.

### Description
- Wrap `IndicatorEngine._augment_session_metrics` in a safety guard so session-metric failures do not abort indicator assembly.
- Make `get_vwap` non-throwing and fallback to `self._last_valid_vwap` when volumes are invalid or the calculation fails, and have `_calculate_vwap` return `None` for invalid inputs instead of raising.
- Increase websocket tolerances and robustness by raising `stale_threshold_seconds` and `handshake_timeout_seconds`, closing failed ticker instances on connect failure, and reducing backoff aggressiveness.
- Enforce a reconnect delay floor (`max(delay, 5.0s)`), treat incoming ticks as heartbeat activity by bumping the pong tracker on ticks, and suppress duplicate reconnect scheduling on concurrent error/close/watchdog paths; adjust tests to match the reconnect floor timing.

### Testing
- Ran `bash ./run_checks.sh` in this environment but it reported pre-existing repository-wide Ruff/mypy findings outside the touched files (run failed for unrelated issues).
- Ran `ruff` against the modified files and the updated websocket test and it passed for those targets.
- Executed a focused pytest run of `tests/strategies/test_indicator_engine.py`, `tests/streaming/test_websocket_manager.py`, `tests/websocket/test_ws_resilience.py`, `tests/websocket/test_ws_tick_routing.py`, and `tests/test_production_hardening_guards.py` and the selected tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992ddee8d148324bc623834930bf2ac)