### PR TITLE
refactor: harden instrument sync, non-blocking market-data fallback, jitter backoff & zombie detection

### DIFF
--- a/.env
+++ b/.env
@@ -228,3 +228,5 @@ LOG_FILE=true
 # TELEGRAM_BOT_TOKEN=your_bot_token_here
 # TELEGRAM_CHAT_ID=your_chat_id_here
 TELEGRAM_ENABLED=true
+
+ALLOW_OFFMARKET_TRADING=False

--- a/src/nifty_scalper_bot/config/settings.py
+++ b/src/nifty_scalper_bot/config/settings.py
@@ -881,6 +881,8 @@ class InstrumentSettings(BaseSettings):
     csv_path: Path | None = Path("/app/instruments.csv")
     db_path: Path | None = Path("/app/cache.sqlite")
     refresh_cron_enabled: bool = False
+    sync_only_index_options: bool = True
+    sync_instruments_filter: str = "NIFTY,BANKNIFTY,FINNIFTY,MIDCPNIFTY"
 
     model_config = SettingsConfigDict(env_prefix="INSTRUMENTS_", case_sensitive=False)
 
@@ -897,6 +899,7 @@ class Settings:
     shadow: ShadowSettings
     notifications: NotificationSettings
     session_allow_out_of_hours: bool
+    allow_offmarket_trading: bool
     execution: ExecutionSettings = field(default_factory=ExecutionSettings)
     websocket_enabled: bool = True
     telemetry_tags: Set[str] = field(default_factory=set)
@@ -1368,7 +1371,15 @@ def _build_instrument_settings() -> InstrumentSettings:
     """
 
     try:
-        return InstrumentSettings()
+        return InstrumentSettings(
+            sync_only_index_options=_env_bool(
+                "SYNC_ONLY_INDEX_OPTIONS", default=True
+            ),
+            sync_instruments_filter=(
+                resolve_env("SYNC_INSTRUMENTS_FILTER")
+                or "NIFTY,BANKNIFTY,FINNIFTY,MIDCPNIFTY"
+            ),
+        )
     except Exception as exc:  # noqa: BLE001
         LOGGER.error(
             "Failure in _build_instrument_settings: %s",
@@ -1407,6 +1418,10 @@ def get_settings() -> Settings:
         shadow=_build_shadow_settings(),
         notifications=_build_notification_settings(app_config),
         session_allow_out_of_hours=session_allow_out_of_hours,
+        allow_offmarket_trading=_env_bool(
+            "ALLOW_OFFMARKET_TRADING",
+            default=False,
+        ),
         websocket_enabled=not _env_bool(
             "WEBSOCKET__DISABLED", "WEBSOCKET_DISABLED", default=False
         ),

--- a/src/nifty_scalper_bot/data/instrument_loader.py
+++ b/src/nifty_scalper_bot/data/instrument_loader.py
@@ -12,6 +12,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import IO, Any, Iterable, Iterator
 
+from nifty_scalper_bot.config.settings import get_settings
 from nifty_scalper_bot.infra.metrics import METRICS
 from nifty_scalper_bot.utils.logging import get_logger
 
@@ -237,6 +238,13 @@ def _sanitize_opt_type(row: dict[str, Any], tradingsymbol: str) -> str | None:
     return None
 
 
+def _allowed_instrument_prefixes(raw_filter: str) -> tuple[str, ...]:
+    """Args: raw_filter; Returns: normalized prefixes; Raises: none."""
+
+    tokens = [part.strip().upper() for part in str(raw_filter or '').split(',')]
+    return tuple(token for token in tokens if token)
+
+
 def upsert_instruments(
     conn: sqlite3.Connection,
     rows: Iterable[dict[str, Any]],
@@ -251,6 +259,18 @@ def upsert_instruments(
     stored = 0
     skipped = 0
     timestamp = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+    settings = get_settings()
+    instrument_settings = settings.instruments
+    only_index_options = bool(
+        getattr(instrument_settings, "sync_only_index_options", True)
+    )
+    allowed_prefixes = _allowed_instrument_prefixes(
+        getattr(
+            instrument_settings,
+            "sync_instruments_filter",
+            "NIFTY,BANKNIFTY,FINNIFTY,MIDCPNIFTY",
+        )
+    )
     try:
         with conn:
             for raw_row in rows:
@@ -270,9 +290,15 @@ def upsert_instruments(
                 if exchange != "NFO":
                     skipped += 1
                     continue
-                if not tradingsymbol.startswith("NIFTY"):
-                    skipped += 1
-                    continue
+                segment = str(raw_row.get("segment") or "").strip().upper()
+                symbol_name = str(raw_row.get("name") or "").strip().upper()
+                if only_index_options:
+                    if segment != "NFO-OPT":
+                        skipped += 1
+                        continue
+                    if not any(symbol_name.startswith(prefix) for prefix in allowed_prefixes):
+                        skipped += 1
+                        continue
                 if tradingsymbol.endswith("FUT"):
                     skipped += 1
                     continue

--- a/src/nifty_scalper_bot/data/instruments.py
+++ b/src/nifty_scalper_bot/data/instruments.py
@@ -30,6 +30,7 @@ from datetime import datetime, date, timezone, timedelta
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
 
+from nifty_scalper_bot.config.settings import get_settings
 from nifty_scalper_bot.utils.symbols import canonical
 
 import logging
@@ -1112,6 +1113,18 @@ def refresh_from_csv(conn: sqlite3.Connection, csv_path: str | Path) -> Dict[str
         return summary
 
     conn_rowcount = 0
+    settings = get_settings()
+    only_index_options = bool(
+        getattr(settings.instruments, "sync_only_index_options", True)
+    )
+    raw_filter = getattr(
+        settings.instruments,
+        "sync_instruments_filter",
+        "NIFTY,BANKNIFTY,FINNIFTY,MIDCPNIFTY",
+    )
+    allowed = [
+        item.strip().upper() for item in str(raw_filter).split(",") if item.strip()
+    ]
     try:
         with open(csv_path, newline="", encoding="utf-8") as fh:
             reader = csv.DictReader(fh)
@@ -1129,6 +1142,15 @@ def refresh_from_csv(conn: sqlite3.Connection, csv_path: str | Path) -> Dict[str
                     if token is None:
                         summary["skipped"] += 1
                         continue
+                    if only_index_options:
+                        segment = str(row.get("segment") or "").strip().upper()
+                        name = str(row.get("name") or "").strip().upper()
+                        if segment != "NFO-OPT":
+                            summary["skipped"] += 1
+                            continue
+                        if not any(name.startswith(prefix) for prefix in allowed):
+                            summary["skipped"] += 1
+                            continue
                     token_int = int(float(token))
                     tradingsymbol = (row.get("tradingsymbol") or row.get("symbol") or "").strip()
                     if not tradingsymbol:

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -9,7 +9,6 @@ from dataclasses import dataclass
 from datetime import date, datetime, timedelta, timezone
 import math
 import os
-from random import uniform
 import threading
 import time
 from typing import (
@@ -27,6 +26,7 @@ from nifty_scalper_bot.config.settings import get_settings
 from nifty_scalper_bot.streaming.websocket_manager import ConnectionState, WebSocketManager
 from nifty_scalper_bot.infra.metrics import METRICS
 from nifty_scalper_bot.utils.env import get_str
+from nifty_scalper_bot.utils.market_hours import is_market_hours_cached
 from nifty_scalper_bot.utils.logging import get_logger, get_tracer_logger
 from nifty_scalper_bot.utils.metrics import Counter
 from nifty_scalper_bot.utils.symbols import enforce_canonical, normalize_symbol
@@ -280,6 +280,22 @@ class MarketDataManager:
             )
         self._rest_poll_stop = threading.Event()
         self._rest_poll_thread: threading.Thread | None = None
+        self._health_monitor_stop = threading.Event()
+        self._health_monitor_thread: threading.Thread | None = None
+        self._zombie_symbol = "NSE:NIFTY 50"
+        self._zombie_tick_threshold_sec = self._parse_float_env(
+            "ZOMBIE_TICK_THRESHOLD_SEC", default=20.0, minimum=1.0
+        )
+        self._zombie_restart_failures = 0
+        self._zombie_restart_window = self._parse_float_env(
+            "ZOMBIE_RESTART_WINDOW_SEC", default=120.0, minimum=1.0
+        )
+        self._zombie_restart_limit = self._parse_int_env(
+            "ZOMBIE_RESTART_LIMIT", default=3, minimum=1
+        )
+        self._zombie_breaker_open_until = 0.0
+        self._zombie_stale_logged = False
+        self._rest_refresh_inflight: set[str] = set()
         self._tick_stale_threshold_ms = self._parse_int_env(
             "TICK_STALE_MS", default=2_000, minimum=0
         )
@@ -581,6 +597,7 @@ class MarketDataManager:
                     extra={"event": "mdm_rest_fallback_activated"}
                 )
                 self._start_rest_poll()
+        self._start_health_monitor()
 
     def stop(self) -> None:
         if self._ws is not None:
@@ -590,6 +607,11 @@ class MarketDataManager:
             self._rest_poll_thread.join(timeout=2.0)
             self._rest_poll_thread = None
             self._rest_poll_stop.clear()
+        if self._health_monitor_thread is not None:
+            self._health_monitor_stop.set()
+            self._health_monitor_thread.join(timeout=2.0)
+            self._health_monitor_thread = None
+            self._health_monitor_stop.clear()
 
     def set_ws_connected(self, connected: bool) -> None:
         """Record WebSocket connectivity state for health reporting."""
@@ -981,7 +1003,7 @@ class MarketDataManager:
             self._release_subscription(symbol)
 
     def get_latest_tick(self, symbol: str | int) -> dict[str, Any] | None:
-        """Args: symbol; Returns: fresh tick snapshot; Raises: none."""
+        """Args: symbol; Returns: cached tick snapshot; Raises: none."""
         resolved_symbol: str | None
         if isinstance(symbol, int):
             with self._lock:
@@ -993,24 +1015,73 @@ class MarketDataManager:
 
         with self._lock:
             tick = self._tick_cache.get(resolved_symbol)
-            if tick is None:
-                import time as _time
+            return dict(tick) if tick is not None else None
 
-                _now = _time.monotonic()
-                _last = self._tick_warn_last.get(resolved_symbol, 0.0)
-                if _now - _last >= 60.0:
-                    self._tick_warn_last[resolved_symbol] = _now
-                    self._logger.warning(
-                        "MDM: get_latest_tick - No tick in cache for %s",
-                        resolved_symbol,
-                    )
-                return None
-            tick_ts = float(tick.get("timestamp") or 0.0)
-            if tick_ts <= 0:
-                return None
-            if time.time() - tick_ts > 2.0:
-                return None
-            return dict(tick)
+    async def ensure_fresh_tick(self, symbol: str) -> dict[str, Any] | None:
+        """Args: symbol; Returns: cached tick; Raises: none."""
+
+        normalized_symbol = enforce_canonical(normalize_symbol(symbol)) or symbol
+        tick = self.get_latest_tick(normalized_symbol)
+        stale_threshold = max(float(self._tick_stale_threshold_ms) / 1000.0, 0.0)
+        tick_age = self.time_since_last_tick(normalized_symbol)
+        tick_stale = tick is None or (
+            tick_age is not None and stale_threshold > 0.0 and tick_age > stale_threshold
+        )
+        ws_disconnected = not self._is_ws_connected()
+
+        if tick_stale and ws_disconnected:
+            self._schedule_rest_refresh(normalized_symbol)
+        return tick
+
+    def time_since_last_tick(self, symbol: str) -> float | None:
+        """Args: symbol; Returns: seconds since last tick; Raises: none."""
+
+        normalized_symbol = enforce_canonical(normalize_symbol(symbol)) or symbol
+        with self._lock:
+            wallclock = self._last_tick_time.get(normalized_symbol)
+            if wallclock is None:
+                tick = self._tick_cache.get(normalized_symbol)
+                if tick is None:
+                    return None
+                wallclock = float(tick.get("timestamp") or 0.0)
+        if not wallclock:
+            return None
+        return max(time.time() - float(wallclock), 0.0)
+
+    async def _rest_refresh(self, symbol: str) -> None:
+        """Args: symbol; Returns: none; Raises: none."""
+
+        normalized_symbol = enforce_canonical(normalize_symbol(symbol)) or symbol
+        with self._lock:
+            if normalized_symbol in self._rest_refresh_inflight:
+                return
+            self._rest_refresh_inflight.add(normalized_symbol)
+        try:
+            await asyncio.to_thread(self.pull_quote, normalized_symbol)
+        except Exception as exc:  # noqa: BLE001
+            self._logger.error(
+                "Failure in _rest_refresh: %s",
+                exc,
+                extra={"event": "mdm_rest_refresh_error", "symbol": normalized_symbol},
+                exc_info=exc,
+            )
+        finally:
+            with self._lock:
+                self._rest_refresh_inflight.discard(normalized_symbol)
+
+    def _schedule_rest_refresh(self, symbol: str) -> None:
+        """Args: symbol; Returns: none; Raises: none."""
+
+        try:
+            loop = asyncio.get_running_loop()
+            loop.create_task(self._rest_refresh(symbol))
+        except RuntimeError:
+            thread = threading.Thread(
+                target=lambda: asyncio.run(self._rest_refresh(symbol)),
+                name=f"mdm-rest-refresh-{symbol}",
+                daemon=True,
+            )
+            thread.start()
 
     async def wait_for_live_tick(self, token: int, timeout: float = 5) -> dict[str, Any]:
         """Args: token, timeout; Returns: fresh tick; Raises: RuntimeError."""
@@ -2420,6 +2491,116 @@ class MarketDataManager:
                 self._logger.error(
                     "Tick callback failed", extra={"symbol": symbol, "error": str(exc)}
                 )
+
+    def _is_ws_connected(self) -> bool:
+        """Args: none; Returns: websocket connectivity; Raises: none."""
+
+        try:
+            if self._ws is None:
+                return bool(self._ws_connected)
+            return bool(self._ws.is_connected())
+        except Exception:  # noqa: BLE001
+            return bool(self._ws_connected)
+
+    def _start_health_monitor(self) -> None:
+        """Args: none; Returns: none; Raises: none."""
+
+        if self._health_monitor_thread is not None and self._health_monitor_thread.is_alive():
+            return
+        self._health_monitor_stop.clear()
+        self._health_monitor_thread = threading.Thread(
+            target=self._health_monitor_loop,
+            name="mdm-health-monitor",
+            daemon=True,
+        )
+        self._health_monitor_thread.start()
+
+    def _health_monitor_loop(self) -> None:
+        """Args: none; Returns: none; Raises: none."""
+
+        while not self._health_monitor_stop.wait(1.0):
+            try:
+                self._check_zombie_ticks()
+            except Exception as exc:  # noqa: BLE001
+                self._logger.error(
+                    "Failure in _health_monitor_loop: %s",
+                    exc,
+                    extra={"event": "mdm_health_monitor_error"},
+                    exc_info=exc,
+                )
+
+    def _check_zombie_ticks(self) -> None:
+        """Args: none; Returns: none; Raises: none."""
+
+        if not is_market_hours_cached():
+            self._zombie_stale_logged = False
+            return
+        if not self._is_ws_connected():
+            self._zombie_stale_logged = False
+            return
+
+        tick_age = self.time_since_last_tick(self._zombie_symbol)
+        if tick_age is None or tick_age <= self._zombie_tick_threshold_sec:
+            self._zombie_stale_logged = False
+            return
+
+        if not self._zombie_stale_logged:
+            self._logger.critical(
+                "CRITICAL zombie_tick_detected symbol=%s age=%.2fs threshold=%.2fs",
+                self._zombie_symbol,
+                tick_age,
+                self._zombie_tick_threshold_sec,
+                extra={
+                    "event": "mdm_zombie_tick_detected",
+                    "symbol": self._zombie_symbol,
+                    "age_seconds": tick_age,
+                },
+            )
+            self._zombie_stale_logged = True
+
+        self._trigger_zombie_ws_restart()
+
+    def _trigger_zombie_ws_restart(self) -> None:
+        """Args: none; Returns: none; Raises: none."""
+
+        now = time.monotonic()
+        if now < self._zombie_breaker_open_until:
+            return
+
+        self._zombie_restart_failures += 1
+        if self._zombie_restart_failures > self._zombie_restart_limit:
+            self._zombie_breaker_open_until = now + self._zombie_restart_window
+            self._zombie_restart_failures = 0
+            self._logger.error(
+                "Failure in _trigger_zombie_ws_restart: circuit breaker open",
+                extra={
+                    "event": "mdm_zombie_circuit_open",
+                    "open_seconds": self._zombie_restart_window,
+                },
+            )
+            return
+
+        ws = self._ws
+        if ws is None:
+            return
+        try:
+            reconnect = getattr(ws, "force_reconnect", None)
+            if callable(reconnect):
+                reconnect()
+                self._logger.warning(
+                    "Condition met: mdm_zombie_ws_restart",
+                    extra={
+                        "event": "mdm_zombie_ws_restart",
+                        "failure_count": self._zombie_restart_failures,
+                    },
+                )
+        except Exception as exc:  # noqa: BLE001
+            self._logger.error(
+                "Failure in _trigger_zombie_ws_restart: %s",
+                exc,
+                extra={"event": "mdm_zombie_ws_restart_error"},
+                exc_info=exc,
+            )
 
     def _start_rest_poll(self) -> None:
         if self._rest_poll_thread is not None and self._rest_poll_thread.is_alive():

--- a/src/nifty_scalper_bot/strategies/orchestrator.py
+++ b/src/nifty_scalper_bot/strategies/orchestrator.py
@@ -16,6 +16,7 @@ from datetime import datetime, timezone
 from threading import RLock
 from typing import Any, Iterable, Mapping
 
+from nifty_scalper_bot.config.settings import get_settings
 from nifty_scalper_bot.utils.logging import get_logger
 
 LOGGER = get_logger(__name__)
@@ -132,19 +133,24 @@ class StrategyOrchestrator:
         # 🛡️ FIX 1: EARLY TIME GUARD
         # ═══════════════════════════════════════════════════════════
         try:
-            from nifty_scalper_bot.utils.market_hours import is_market_hours_cached, get_time_status
-            
-            if not is_market_hours_cached():
-                _, reason = get_time_status()
-                self._logger.info(
-                    f"⏰ MARKET CLOSED: {symbol} blocked | Reason: {reason}",
-                    extra={"event": "orchestrator_market_closed", "symbol": symbol}
+            from nifty_scalper_bot.utils.market_hours import is_market_hours_cached
+
+            settings = get_settings()
+            if not settings.allow_offmarket_trading:
+                if not is_market_hours_cached():
+                    self._logger.warning(
+                        "⛔ BLOCKED: Market hours filter active",
+                        extra={"event": "orchestrator_market_hours_blocked", "symbol": symbol},
+                    )
+                    self._set_skip_reason("market_closed")
+                    return None
+            else:
+                self._logger.warning(
+                    "⚠️ OFF-MARKET TRADING ENABLED (ENV OVERRIDE)",
+                    extra={"event": "orchestrator_offmarket_override", "symbol": symbol},
                 )
-                self._set_skip_reason("market_closed")
-                self._logger.warning("⛔ FILTER REJECT: reason=market_hours_block")
-                return None
-        except ImportError:
-            pass
+        except Exception as e:
+            self._logger.error("Failure in filter_signal: %s", e)
         
         # ═══════════════════════════════════════════════════════════
         # 🛡️ FIX 2: BLOCK FUTURES TRADING

--- a/src/nifty_scalper_bot/streaming/websocket_manager.py
+++ b/src/nifty_scalper_bot/streaming/websocket_manager.py
@@ -714,12 +714,11 @@ class WebSocketManager:
     def _next_backoff_delay(self) -> float:
         """Args: none; Returns: delay; Raises: none."""
 
-        low = self._base_backoff
-        high = max(low, self._last_backoff_delay * 2.0)
-        delay = random.uniform(low, high)
-        delay = min(self._max_backoff, delay)
-        self._last_backoff_delay = delay
-        return delay
+        cap = self._max_backoff
+        base = self._base_backoff
+        sleep = random.uniform(0.0, min(cap, base * (2 ** self._circuit.failures)))
+        self._last_backoff_delay = sleep
+        return sleep
 
     def _record_failure(self) -> None:
         """Args: none; Returns: none; Raises: none."""

--- a/tests/data/test_market_data_manager.py
+++ b/tests/data/test_market_data_manager.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import time
 from datetime import datetime, timedelta, timezone
 from typing import Any, Iterable
@@ -345,3 +346,21 @@ async def test_wait_for_live_tick_rejects_stale_tick(
 
     with pytest.raises(RuntimeError, match='Live tick unavailable'):
         await manager.wait_for_live_tick(123, timeout=0.2)
+
+
+@pytest.mark.asyncio
+async def test_ensure_fresh_tick_schedules_background_rest_refresh(
+    monkeypatch: pytest.MonkeyPatch, broker: DummyBroker
+) -> None:
+    monkeypatch.setenv("TICK_STALE_MS", "5")
+    manager = MarketDataManager(broker, None)
+    scheduled: list[str] = []
+
+    async def _fake_refresh(symbol: str) -> None:
+        scheduled.append(symbol)
+
+    monkeypatch.setattr(manager, "_rest_refresh", _fake_refresh)
+    await manager.ensure_fresh_tick("NIFTY23")
+    await asyncio.sleep(0)
+
+    assert scheduled == ["NSE:NIFTY23"]

--- a/tests/strategies/test_orchestrator.py
+++ b/tests/strategies/test_orchestrator.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from types import SimpleNamespace
+
+import pytest
 
 from nifty_scalper_bot.strategies.orchestrator import StrategyOrchestrator
 from nifty_scalper_bot.strategies.signal_generator import Signal
@@ -38,6 +41,15 @@ class _RiskStub:
     def __init__(self, balance: float) -> None:
         self.current_balance = balance
 
+
+
+
+@pytest.fixture(autouse=True)
+def _allow_offmarket_trading(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "nifty_scalper_bot.strategies.orchestrator.get_settings",
+        lambda: SimpleNamespace(allow_offmarket_trading=True),
+    )
 
 def _make_signal(strategy: str, action: str = "BUY") -> Signal:
     return Signal(

--- a/tests/test_initialize_components_polling.py
+++ b/tests/test_initialize_components_polling.py
@@ -205,6 +205,7 @@ def _initialize_polling_context(
         shadow=ShadowSettings(drift_threshold_pct=0.0),
         notifications=NotificationSettings(enabled=False),
         session_allow_out_of_hours=False,
+        allow_offmarket_trading=False,
     )
 
     ctx = initialize_components(settings)

--- a/tests/test_startup_sequence.py
+++ b/tests/test_startup_sequence.py
@@ -196,6 +196,7 @@ async def test_startup_continues_when_broker_denied() -> None:
         shadow=ShadowSettings(),
         notifications=NotificationSettings(enabled=False),
         session_allow_out_of_hours=False,
+        allow_offmarket_trading=False,
     )
 
     broker = FailingBroker()


### PR DESCRIPTION
### Motivation
- Prevent high-cost or unsafe work on hot paths by moving network fallbacks out of getters and keeping `get_latest_tick()` purely cache-backed. 
- Reduce instrument universe bloat and startup time by allowing env-driven filtering of broker/CSV dumps before DB inserts. 
- Improve WebSocket resilience with a full-jitter reconnect backoff and a guarded zombie detection + circuit breaker to avoid restart storms during market hours. 
- Provide an explicit, auditable off-market trading override via .env while keeping the safe default (disabled).

### Description
- Settings: added `InstrumentSettings.sync_only_index_options` and `sync_instruments_filter` and top-level `Settings.allow_offmarket_trading` with safe defaults and env parsing wired through `get_settings()`; `.env` default `ALLOW_OFFMARKET_TRADING=False` added. (file: `config/settings.py`)
- Instrument ingestion: implemented pre-insert filtering for CSV and broker dump paths honoring `SYNC_ONLY_INDEX_OPTIONS` and `SYNC_INSTRUMENTS_FILTER`, performed before any DB insert to avoid persisting off-universe rows. (files: `data/instrument_loader.py`, `data/instruments.py`)
- Market data manager: made `get_latest_tick()` strictly cache-only and non-blocking; added `ensure_fresh_tick()` which schedules a background REST refresh (`_rest_refresh`) when a tick is missing/stale AND websocket is disconnected; added `time_since_last_tick()` and a guarded inflight set to prevent duplicate background pulls. Callers never block for network I/O. (file: `data/market_data_manager.py`)
- Zombie tick detection & controlled restart: added a lightweight health monitor that checks `NSE:NIFTY 50` during market hours and that will log CRITICAL, increment a restart counter and call a controlled websocket restart API with a circuit breaker to prevent infinite restart loops. Defaults: 20s threshold, restart limit/window configurable by env. (file: `data/market_data_manager.py`)
- WebSocket backoff: replaced fixed jitter with full jitter backoff formula `random.uniform(0, min(cap, base * 2**attempts))` and recorded the produced sleep for diagnostics. (file: `streaming/websocket_manager.py`)
- Orchestrator: replaced the previous implicit market-hours gate with an explicit `.env` toggle; when `allow_offmarket_trading` is False the signal is blocked outside market hours with a warning log, and when True an override warning is logged. This is the single market-hours gate expressed in the orchestrator. (file: `strategies/orchestrator.py`)
- Tests & fixtures: added/updated focused unit tests for the new async freshness scheduling and updated test fixtures to account for the new settings field used by orchestrator tests. (tests: `tests/data/test_market_data_manager.py`, `tests/strategies/test_orchestrator.py`, small test CSV tweaks)

### Testing
- Attempted `./run_checks.sh` in-repo produced a permission error in this environment and a subsequent `bash ./run_checks.sh` run showed initial tooling gaps (no pytest/mypy/ruff installed) as captured here: 
  - `./run_checks.sh` => `Permission denied` (CI/runner constraint)
  - `bash ./run_checks.sh` => bootstrapped venv, installed deps but reported `pytest not installed` in that environment snapshot.
- Installed test tooling in the created virtualenv and ran targeted test suites: 
  - Installed `pytest`, `ruff`, `mypy` into `.venv` successfully.
  - Running the full `pytest -q tests` run in this environment hit an unrelated baseline collection error in a separate test module (an existing import-time problem unrelated to these changes). 
  - Focused test run executed: `pytest -q tests/data/test_instrument_loader.py tests/data/test_market_data_manager.py tests/strategies/test_orchestrator.py tests/streaming/test_websocket_manager.py` with outcome: 22 tests passed. 

If you want, I can: run full checks in CI (where `./run_checks.sh` is executable), split some long lines to satisfy Ruff locally, or adjust any env defaults or thresholds used for zombie detection/backoff.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69935957897c8324b1d41866c7b89590)