### PR TITLE
fix: unify tick routing and remove duplicate runner evaluations

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -2863,10 +2863,7 @@ def initialize_components(settings: Settings | None = None) -> BotContext:
     if websocket_enabled and ws_mode_requested:
         use_polling = False
         poll_enabled = False
-    # [FIX] Container for direct wiring
-    strategy_runner_ref: dict[str, Any] = {}
-
-    # [FIX 1/2] Container to hold strategy runner reference for direct tick injection
+    # Container to hold strategy runner reference for direct tick injection.
     strategy_runner_ref: dict[str, Any] = {}
 
     if not poll_enabled and not websocket_enabled:

--- a/src/nifty_scalper_bot/data/data_hub.py
+++ b/src/nifty_scalper_bot/data/data_hub.py
@@ -191,6 +191,7 @@ class DataHub:
         self._store = store
         self._lock = RLock()
         self.tick_bus = TickBus()
+        self.tick_bus.subscribe(self.ingest_tick_sync)
         attach_tick_bus = getattr(self._mdm, "attach_tick_bus", None)
         if callable(attach_tick_bus):
             try:

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -400,37 +400,31 @@ class StrategyRunner:
         except Exception as e:
             self._logger.error(f"❌ Failed to create 'data/' directory: {e}")
         self._data_hub = data_hub
+        self._strike_selector = strike_selector
+        self._bracket_manager = bracket_manager
         if self._data_hub is not None and hasattr(self._data_hub, "tick_bus"):
             try:
                 subscribe_event = getattr(
                     self._data_hub.tick_bus, "subscribe_event", None
                 )
                 if callable(subscribe_event):
-                    subscribe_event("tick_updated", self._on_tick_from_bus)
-                else:
-                    self._data_hub.tick_bus.subscribe(self._on_tick_from_bus)
+                    if self._bracket_manager is not None and hasattr(
+                        self._bracket_manager, "on_tick_event"
+                    ):
+                        subscribe_event("tick_updated", self._bracket_manager.on_tick_event)
+                    if self._order_manager is not None and hasattr(
+                        self._order_manager, "on_tick_event"
+                    ):
+                        subscribe_event("tick_updated", self._order_manager.on_tick_event)
             except Exception as e:
                 self._logger.error("Failure in StrategyRunner.__init__: %s", e)
-        self._strike_selector = strike_selector
-        self._bracket_manager = bracket_manager
-        if self._data_hub is not None and hasattr(self._data_hub, "tick_bus"):
-            subscribe_event = getattr(self._data_hub.tick_bus, "subscribe_event", None)
-            if callable(subscribe_event):
-                if self._bracket_manager is not None and hasattr(
-                    self._bracket_manager, "on_tick_event"
-                ):
-                    subscribe_event("tick_updated", self._bracket_manager.on_tick_event)
-                if self._order_manager is not None and hasattr(
-                    self._order_manager, "on_tick_event"
-                ):
-                    subscribe_event("tick_updated", self._order_manager.on_tick_event)
         self._symbol_source: MarketDataManager | None = None
         self._main_loop: asyncio.AbstractEventLoop | None = None
         # Time block logging throttle
         self._time_block_logged: Dict[str, float] = {}
 
-        # Subscribe to MessageBus if available
-        if self._message_bus is not None:
+        # Subscribe to MessageBus when DataHub is unavailable (avoids duplicate tick eval).
+        if self._message_bus is not None and self._data_hub is None:
             self._message_bus.subscribe(MessageType.TICK, self._handle_tick_message)
 
         hedge_env = os.getenv("NSB__ALLOW_HEDGE_ENTRIES", "false").strip().lower()

--- a/tests/data/test_event_bus_tick_pipeline.py
+++ b/tests/data/test_event_bus_tick_pipeline.py
@@ -19,3 +19,22 @@ def test_tick_bus_legacy_subscribe_routes_tick_event() -> None:
     bus.publish({"symbol": "NSE:NIFTY 50", "last_price": 2.0})
 
     assert seen == [{"symbol": "NSE:NIFTY 50", "last_price": 2.0}]
+
+
+def test_tick_bus_publish_routes_into_data_hub_quotes() -> None:
+    class _StubMDM:
+        def attach_tick_bus(self, _tick_bus):
+            return None
+
+    class _StubResolver:
+        pass
+
+    from nifty_scalper_bot.data.data_hub import DataHub
+
+    hub = DataHub(_StubMDM(), _StubResolver())
+    payload = {"symbol": "NSE:NIFTY 50", "last_price": 123.4}
+    hub.tick_bus.publish(payload)
+
+    quote = hub.get_quote("NSE:NIFTY 50")
+    assert quote is not None
+    assert quote.get("last_price") == 123.4

--- a/tests/strategies/test_strategy_runner_datahub.py
+++ b/tests/strategies/test_strategy_runner_datahub.py
@@ -88,3 +88,42 @@ def test_runner_falls_back_to_mdm_when_hub_missing() -> None:
 
     runner.stop()
     assert mdm.unsubscribed == ["NIFTY25SEP25000CE"]
+
+
+def test_runner_avoids_message_bus_tick_subscription_when_hub_present() -> None:
+    hub = _StubHub()
+    mdm = _StubMDM()
+    message_bus = MagicMock()
+    runner = StrategyRunner(
+        market_data_manager=mdm,
+        indicator_engine=MagicMock(),
+        strategy_manager=MagicMock(),
+        risk_manager=MagicMock(),
+        order_manager=MagicMock(),
+        position_manager=MagicMock(),
+        config=StrategyRunnerConfig(max_trade_history=10),
+        data_hub=hub,
+        message_bus=message_bus,
+    )
+
+    assert runner is not None
+    message_bus.subscribe.assert_not_called()
+
+
+def test_runner_subscribes_message_bus_tick_when_hub_missing() -> None:
+    mdm = _StubMDM()
+    message_bus = MagicMock()
+    runner = StrategyRunner(
+        market_data_manager=mdm,
+        indicator_engine=MagicMock(),
+        strategy_manager=MagicMock(),
+        risk_manager=MagicMock(),
+        order_manager=MagicMock(),
+        position_manager=MagicMock(),
+        config=StrategyRunnerConfig(max_trade_history=10),
+        data_hub=None,
+        message_bus=message_bus,
+    )
+
+    assert runner is not None
+    message_bus.subscribe.assert_called_once()


### PR DESCRIPTION
### Motivation
- Prevent duplicate strategy evaluations caused by overlapping tick delivery paths and ensure a single canonical ingestion path for tick data. 
- Guarantee that ticks published on the in-process TickBus are reliably cached in DataHub so downstream components (runner, order manager, bracket manager, signal generators) read the same authoritative quote. 
- Make startup wiring explicit to avoid ambiguous runner references and reduce risk of missed subscriptions during cold start.

### Description
- Wired `DataHub.tick_bus` to the DataHub ingestion pipeline by subscribing `tick_bus` to `DataHub.ingest_tick_sync` so bus-published ticks are persisted and fanned out from a single canonical source (`src/nifty_scalper_bot/data/data_hub.py`).
- Updated `StrategyRunner` subscription logic to avoid duplicate evaluation by: keeping `tick_updated` event wiring for execution listeners (`BracketManager` and `OrderManager`) and subscribing to `MessageBus` ticks only when `DataHub` is not present (`src/nifty_scalper_bot/strategies/runner.py`).
- Removed a duplicated `strategy_runner_ref` declaration in the app bootstrap to make tick wiring unambiguous (`src/nifty_scalper_bot/core/app.py`).
- Added small regression tests: one to assert TickBus publishes become DataHub quotes and another to verify the runner uses DataHub (and only subscribes to MessageBus when DataHub is absent) (`tests/data/test_event_bus_tick_pipeline.py`, `tests/strategies/test_strategy_runner_datahub.py`).

### Testing
- Ran `pytest -q tests/data/test_event_bus_tick_pipeline.py tests/strategies/test_strategy_runner_datahub.py` and both tests passed.
- Executed `bash run_checks.sh` to boot the environment and install dependencies; the script started successfully in this environment (dependency install and checks initiated). 
- Ran the wider pytest command used by CI and observed an unrelated existing baseline failure outside this change: `ImportError` from `elite_strategies.builder` when running the full test set, which is not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699424bca3a483249a7d74b10f7f08e4)