### PR TITLE
fix: restore DataHub→MessageBus→StrategyRunner tick wiring

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -2883,9 +2883,6 @@ def initialize_components(settings: Settings | None = None) -> BotContext:
     if websocket_enabled and ws_mode_requested:
         use_polling = False
         poll_enabled = False
-    # Container to hold strategy runner reference for direct tick injection.
-    strategy_runner_ref: dict[str, Any] = {}
-
     if not poll_enabled and not websocket_enabled:
         raise ConfigurationError(
             "Polling disabled while websocket transport is disabled; "
@@ -2950,7 +2947,7 @@ def initialize_components(settings: Settings | None = None) -> BotContext:
             instrument_resolver,
             options_only=True,
             store=hub_store,
-            message_bus=message_bus,
+            event_bus=message_bus,
         )
         # Explicitly mark WS disconnected in polling mode so health reflects polling
         market_data_manager.set_ws_connected(False)
@@ -3210,7 +3207,7 @@ def initialize_components(settings: Settings | None = None) -> BotContext:
             instrument_resolver,
             options_only=True,
             store=hub_store,
-            message_bus=message_bus,
+            event_bus=message_bus,
         )
 
         polling_fallback_streamer = PollingStreamer(
@@ -3248,7 +3245,7 @@ def initialize_components(settings: Settings | None = None) -> BotContext:
             instrument_resolver,
             options_only=True,
             store=hub_store,
-            message_bus=message_bus,
+            event_bus=message_bus,
         )
         LOGGER.info(f"✅ DataHub created: {data_hub is not None}")
 
@@ -4042,10 +4039,6 @@ def initialize_components(settings: Settings | None = None) -> BotContext:
     )
     strategy_runner.attach_persistent_state(persistent_state)
     strategy_runner.restore_trades(persistent_state.load_trades())
-    # [FIX 2/2] Populate the reference for Polling Mode to enable the hot-wire
-    strategy_runner_ref["instance"] = strategy_runner
-    LOGGER.info("✅ Polling Streamer -> StrategyRunner direct wiring established.")
-
     settings.enable_live = bool(live_toggle_env)
     mandatory_paper = not live_possible
     paper_state: dict[str, bool] = {"enabled": bool(paper_initial or mandatory_paper)}

--- a/src/nifty_scalper_bot/data/data_hub.py
+++ b/src/nifty_scalper_bot/data/data_hub.py
@@ -183,6 +183,7 @@ class DataHub:
         options_only: bool = True,
         store: HubStore | None = None,
         message_bus: MessageBus | None = None,
+        event_bus: MessageBus | None = None,
     ) -> None:
 
         self._mdm = market_data_manager
@@ -203,7 +204,8 @@ class DataHub:
         self._quotes: dict[str, Tick] = {}
         self._orders: dict[str, dict[str, Any]] = {}
         self._positions: dict[str, dict[str, Any]] = {}
-        self._message_bus = message_bus
+        self._message_bus = message_bus or event_bus
+        LOGGER.debug("DataHub using MessageBus id=%s", id(self._message_bus))
 
         # Derived Metrics Caches
         self._iv_cache: dict[str, float] = {}
@@ -246,6 +248,10 @@ class DataHub:
             return
         normalized_symbol = enforce_canonical(canonical(str(symbol)))
 
+        if self._message_bus is None:
+            LOGGER.error("DataHub has no event_bus — cannot emit tick")
+            return
+
         with self._lock:
             # 1. Update Cache
             self._quotes[normalized_symbol] = tick
@@ -259,7 +265,6 @@ class DataHub:
             # 3. Publish to MessageBus (The Critical Fix)
             if self._message_bus:
                 try:
-                    # FIX: Direct await for immediate data flow
                     await self._message_bus.publish(
                         Message(
                             type=MessageType.TICK,
@@ -269,7 +274,7 @@ class DataHub:
                         )
                     )
                 except Exception as exc:
-                    LOGGER.debug(f"MessageBus publish failed: {exc}")
+                    LOGGER.error("Failure in DataHub.ingest_tick: %s", exc, exc_info=exc)
 
             # 4. Notify Legacy Subscribers (Backward Compatibility)
             if normalized_symbol in self._tick_subscribers:

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -393,6 +393,7 @@ class StrategyRunner:
         self._message_bus = message_bus
         self._config = config or StrategyRunnerConfig()
         self._logger = get_logger(__name__)
+        self._logger.debug("StrategyRunner using MessageBus id=%s", id(self._message_bus))
         # ✅ FIX 1: Ensure 'data' directory exists to prevent Persistence Crash
         try:
             os.makedirs("data", exist_ok=True)
@@ -402,30 +403,12 @@ class StrategyRunner:
         self._data_hub = data_hub
         self._strike_selector = strike_selector
         self._bracket_manager = bracket_manager
-        if self._data_hub is not None and hasattr(self._data_hub, "tick_bus"):
-            try:
-                subscribe_event = getattr(
-                    self._data_hub.tick_bus, "subscribe_event", None
-                )
-                if callable(subscribe_event):
-                    subscribe_event("tick_updated", self.on_tick_event)
-                    if self._bracket_manager is not None and hasattr(
-                        self._bracket_manager, "on_tick_event"
-                    ):
-                        subscribe_event("tick_updated", self._bracket_manager.on_tick_event)
-                    if self._order_manager is not None and hasattr(
-                        self._order_manager, "on_tick_event"
-                    ):
-                        subscribe_event("tick_updated", self._order_manager.on_tick_event)
-            except Exception as e:
-                self._logger.error("Failure in StrategyRunner.__init__: %s", e)
         self._symbol_source: MarketDataManager | None = None
         self._main_loop: asyncio.AbstractEventLoop | None = None
         # Time block logging throttle
         self._time_block_logged: Dict[str, float] = {}
 
-        # Subscribe to MessageBus when DataHub is unavailable (avoids duplicate tick eval).
-        if self._message_bus is not None and self._data_hub is None:
+        if self._message_bus is not None:
             self._message_bus.subscribe(MessageType.TICK, self._handle_tick_message)
 
         hedge_env = os.getenv("NSB__ALLOW_HEDGE_ENTRIES", "false").strip().lower()


### PR DESCRIPTION
### Motivation

- Strategies were not receiving ticks because tick events were routed via legacy/local paths instead of the shared async bus, breaking the intended `Streamer -> DataHub -> MessageBus -> StrategyRunner` flow.
- The goal is to fix wiring using dependency injection only and avoid global singletons or direct `_on_tick` hot-wires.

### Description

- Updated `DataHub` to accept an injected bus argument (`event_bus`) and to use the provided `MessageBus` instance to publish ticks as `MessageType.TICK` only, and added a guard to log and drop ticks when no bus is injected (`src/nifty_scalper_bot/data/data_hub.py`).
- Ensured `app.py` passes the shared `message_bus` into all `DataHub` construction sites via `event_bus=message_bus` so there is exactly one shared bus instance used by components (`src/nifty_scalper_bot/core/app.py`).
- Normalised `StrategyRunner` to always subscribe to the shared bus using the `MessageType.TICK` enum and removed legacy `tick_updated`/`tick_bus` subscription hot-spots; added debug logging of the bus identity to verify wiring at runtime (`src/nifty_scalper_bot/strategies/runner.py`).
- Removed the stale direct-hotwire scaffolding that attempted to populate `strategy_runner_ref` for direct tick injection in favor of the DI-based bus routing.

### Testing

- Ran `bash ./run_checks.sh`; first attempt using `./run_checks.sh` failed due to execute permissions in this environment, then re-ran with `bash ./run_checks.sh` which completed dependency installation but surfaced existing repo baseline issues unrelated to these wiring changes (pre-existing mypy/type and pytest tooling problems), so full script did not complete green.
- Verified modified modules compile with `python -m py_compile src/nifty_scalper_bot/data/data_hub.py src/nifty_scalper_bot/strategies/runner.py src/nifty_scalper_bot/core/app.py` (succeeded).
- Ran targeted pytest invocation used by CI: `pytest -q tests --disable-warnings --ignore=tests/test_live_mode.py --ignore=tests/test_health_server.py` which failed early due to an existing test import error (`tests/strategies/test_elite_strategies.py`), indicating pre-existing test/export discrepancies not caused by this wiring fix.
- Performed lint/ruff check on modified files during `run_checks.sh` run; repo-wide lint/mypy findings remain in baseline and are unrelated to the wiring changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699540449d3c83248a5c4972ba5e46a7)