### PR TITLE
fix: bootstrap and periodically sync instrument csv cache

### DIFF
--- a/src/nifty_scalper_bot/config/settings.py
+++ b/src/nifty_scalper_bot/config/settings.py
@@ -881,6 +881,7 @@ class InstrumentSettings(BaseSettings):
     csv_path: Path | None = Path("/app/instruments.csv")
     db_path: Path | None = Path("/app/cache.sqlite")
     refresh_cron_enabled: bool = False
+    refresh_interval_hours: float = 24.0
     sync_only_index_options: bool = True
     sync_instruments_filter: str = "NIFTY,BANKNIFTY,FINNIFTY,MIDCPNIFTY"
 
@@ -1372,9 +1373,7 @@ def _build_instrument_settings() -> InstrumentSettings:
 
     try:
         return InstrumentSettings(
-            sync_only_index_options=_env_bool(
-                "SYNC_ONLY_INDEX_OPTIONS", default=True
-            ),
+            sync_only_index_options=_env_bool("SYNC_ONLY_INDEX_OPTIONS", default=True),
             sync_instruments_filter=(
                 resolve_env("SYNC_INSTRUMENTS_FILTER")
                 or "NIFTY,BANKNIFTY,FINNIFTY,MIDCPNIFTY"

--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -75,6 +75,7 @@ from nifty_scalper_bot.data import (
     ensure_sqlite,
     load_rows_for_resolver,
     refresh_from_csv,
+    sync_instrument_csv_from_broker,
 )
 from nifty_scalper_bot.data.assess_data import assess_datahub_fresh
 from nifty_scalper_bot.data.data_hub import DataHub
@@ -321,21 +322,35 @@ def _try_warm_instruments(
                     "Instrument CSV path not configured; skipping CSV warm-up.",
                     extra={"event": "instrument_warm_csv_missing"},
                 )
-            elif not Path(csv_path).exists():
-                logger.warning(
-                    "Instrument CSV not found at %s; skipping warm-up.",
-                    csv_path,
-                    extra={
-                        "event": "instrument_warm_csv_not_found",
-                        "csv_path": str(csv_path),
-                    },
-                )
             elif conn is None:
                 logger.warning(
                     "Instrument database path not configured; skipping cache refresh.",
                     extra={"event": "instrument_warm_db_missing"},
                 )
             else:
+                csv_file = Path(csv_path)
+                if not csv_file.exists():
+                    logger.warning(
+                        "Instrument CSV not found at %s; creating from broker.",
+                        csv_path,
+                        extra={
+                            "event": "instrument_warm_csv_not_found",
+                            "csv_path": str(csv_path),
+                        },
+                    )
+                    sync_summary = sync_instrument_csv_from_broker(
+                        resolver._broker,
+                        str(csv_path),
+                        exchange="NFO",
+                    )
+                    logger.info(
+                        "Condition met: instrument_csv_bootstrap_complete",
+                        extra={
+                            "event": "instrument_csv_bootstrap_complete",
+                            "csv_path": str(csv_path),
+                            "written": int(sync_summary.get("written") or 0),
+                        },
+                    )
                 summary = refresh_from_csv(conn, str(csv_path))
                 instrument_options = int(summary.get("stored") or instrument_options)
                 instrument_source = "csv"
@@ -5859,21 +5874,26 @@ async def startup_sequence(ctx: BotContext) -> None:
 
             async def _sync_loop():
                 from nifty_scalper_bot.utils.market_hours import is_market_open
+
                 while True:
                     try:
                         if is_market_open():
                             await _reconcile_state(ctx)
                         else:
                             _inner = getattr(
-                                ctx.broker_client, "_broker",
-                                getattr(ctx.broker_client, "client", ctx.broker_client)
+                                ctx.broker_client,
+                                "_broker",
+                                getattr(ctx.broker_client, "client", ctx.broker_client),
                             )
                             reset_fn = getattr(_inner, "_reset_transient_state", None)
                             if callable(reset_fn):
                                 reset_fn()
                     except Exception:
                         pass
-                    from nifty_scalper_bot.utils.market_hours import is_market_open as _imo
+                    from nifty_scalper_bot.utils.market_hours import (
+                        is_market_open as _imo,
+                    )
+
                     await asyncio.sleep(15 if _imo() else 120)
 
             asyncio.create_task(_sync_loop())

--- a/src/nifty_scalper_bot/data/__init__.py
+++ b/src/nifty_scalper_bot/data/__init__.py
@@ -8,7 +8,9 @@ from nifty_scalper_bot.data.instrument_loader import (
     load_rows_for_resolver,
     parse_kite_csv,
     refresh_from_csv,
+    sync_instrument_csv_from_broker,
     upsert_instruments,
+    write_instrument_rows_to_csv,
 )
 from nifty_scalper_bot.data.instruments import InstrumentResolver
 
@@ -20,4 +22,6 @@ __all__ = [
     "upsert_instruments",
     "load_rows_for_resolver",
     "refresh_from_csv",
+    "sync_instrument_csv_from_broker",
+    "write_instrument_rows_to_csv",
 ]

--- a/src/nifty_scalper_bot/data/instrument_loader.py
+++ b/src/nifty_scalper_bot/data/instrument_loader.py
@@ -241,7 +241,7 @@ def _sanitize_opt_type(row: dict[str, Any], tradingsymbol: str) -> str | None:
 def _allowed_instrument_prefixes(raw_filter: str) -> tuple[str, ...]:
     """Args: raw_filter; Returns: normalized prefixes; Raises: none."""
 
-    tokens = [part.strip().upper() for part in str(raw_filter or '').split(',')]
+    tokens = [part.strip().upper() for part in str(raw_filter or "").split(",")]
     return tuple(token for token in tokens if token)
 
 
@@ -296,7 +296,9 @@ def upsert_instruments(
                     if segment != "NFO-OPT":
                         skipped += 1
                         continue
-                    if not any(symbol_name.startswith(prefix) for prefix in allowed_prefixes):
+                    if not any(
+                        symbol_name.startswith(prefix) for prefix in allowed_prefixes
+                    ):
                         skipped += 1
                         continue
                 if tradingsymbol.endswith("FUT"):
@@ -411,8 +413,7 @@ def load_rows_for_resolver(conn: sqlite3.Connection) -> list[dict[str, Any]]:
         extra={"event": "instrument_cache_load_enter"},
     )
     try:
-        cursor = conn.execute(
-            """
+        cursor = conn.execute("""
             SELECT
                 token,
                 tradingsymbol,
@@ -423,8 +424,7 @@ def load_rows_for_resolver(conn: sqlite3.Connection) -> list[dict[str, Any]]:
                 opt_type
             FROM instruments
             ORDER BY token ASC
-            """
-        )
+            """)
         rows: list[dict[str, Any]] = []
         for entry in cursor.fetchall():
             token_int = int(entry["token"])
@@ -495,6 +495,151 @@ def refresh_from_csv(
         raise
 
 
+def write_instrument_rows_to_csv(
+    rows: Iterable[dict[str, Any]],
+    csv_path: str,
+) -> int:
+    """Write broker rows to CSV.
+
+    Args: rows,csv_path.
+    Returns: Number of rows written.
+    Raises: Exception on I/O failure.
+    """
+
+    LOGGER.debug(
+        "Entered write_instrument_rows_to_csv",
+        extra={"event": "instrument_csv_write_enter", "path": csv_path},
+    )
+    serializable_rows = [dict(row) for row in rows if isinstance(row, dict)]
+    if not serializable_rows:
+        LOGGER.info(
+            "Condition met: instrument_csv_write_skipped",
+            extra={"event": "instrument_csv_write_skipped", "path": csv_path},
+        )
+        return 0
+    try:
+        field_names: list[str] = []
+        seen: set[str] = set()
+        for row in serializable_rows:
+            for key in row:
+                clean_key = str(key).strip()
+                if not clean_key or clean_key in seen:
+                    continue
+                seen.add(clean_key)
+                field_names.append(clean_key)
+        if "instrument_token" not in seen and "instrumenttoken" in seen:
+            field_names = [
+                "instrument_token" if name == "instrumenttoken" else name
+                for name in field_names
+            ]
+        if "instrument_token" not in field_names:
+            field_names.insert(0, "instrument_token")
+        target_path = Path(csv_path)
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        with target_path.open("w", encoding="utf-8", newline="") as handle:
+            writer = csv.DictWriter(
+                handle, fieldnames=field_names, extrasaction="ignore"
+            )
+            writer.writeheader()
+            for raw_row in serializable_rows:
+                row = dict(raw_row)
+                if row.get("instrument_token") in {None, ""} and row.get(
+                    "instrumenttoken"
+                ) not in {None, ""}:
+                    row["instrument_token"] = row.get("instrumenttoken")
+                writer.writerow(row)
+        LOGGER.info(
+            "Condition met: instrument_csv_write_success",
+            extra={
+                "event": "instrument_csv_write_success",
+                "path": str(target_path),
+                "written": len(serializable_rows),
+            },
+        )
+        return len(serializable_rows)
+    except Exception as exc:  # noqa: BLE001
+        LOGGER.error(
+            "Failure in write_instrument_rows_to_csv: %s",
+            exc,
+            extra={"event": "instrument_csv_write_error", "path": csv_path},
+            exc_info=exc,
+        )
+        raise
+
+
+def sync_instrument_csv_from_broker(
+    broker_client: Any,
+    csv_path: str,
+    *,
+    exchange: str = "NFO",
+) -> dict[str, Any]:
+    """Sync broker instruments into CSV.
+
+    Args: broker_client,csv_path,exchange.
+    Returns: Sync metrics.
+    Raises: Exception when broker retrieval fails.
+    """
+
+    LOGGER.debug(
+        "Entered sync_instrument_csv_from_broker",
+        extra={
+            "event": "instrument_csv_sync_enter",
+            "path": csv_path,
+            "exchange": exchange,
+        },
+    )
+    normalized_exchange = str(exchange or "NFO").strip().upper()
+    try:
+        rows: list[dict[str, Any]] = []
+        load_fn = getattr(broker_client, "load_instruments", None)
+        if callable(load_fn):
+            payload = load_fn(normalized_exchange)
+            if isinstance(payload, list):
+                rows = [row for row in payload if isinstance(row, dict)]
+        if not rows:
+            list_fn = getattr(broker_client, "list_instruments", None)
+            if callable(list_fn):
+                payload = list_fn()
+                if isinstance(payload, list):
+                    rows = [
+                        row
+                        for row in payload
+                        if isinstance(row, dict)
+                        and str(row.get("exchange") or "").strip().upper()
+                        == normalized_exchange
+                    ]
+        written = write_instrument_rows_to_csv(rows, csv_path)
+        LOGGER.info(
+            "Condition met: instrument_csv_sync_success",
+            extra={
+                "event": "instrument_csv_sync_success",
+                "exchange": normalized_exchange,
+                "path": csv_path,
+                "fetched": len(rows),
+                "written": written,
+            },
+        )
+        return {
+            "exchange": normalized_exchange,
+            "fetched": len(rows),
+            "written": written,
+            "path": csv_path,
+            "source": "broker",
+        }
+    except Exception as exc:  # noqa: BLE001
+        LOGGER.error(
+            "Failure in sync_instrument_csv_from_broker: %s",
+            exc,
+            extra={
+                "event": "instrument_csv_sync_error",
+                "path": csv_path,
+                "exchange": normalized_exchange,
+            },
+            exc_info=exc,
+        )
+        raise
+
+
 __all__ = [
     "InstrumentUniverseStatus",
     "ensure_sqlite",
@@ -502,4 +647,6 @@ __all__ = [
     "upsert_instruments",
     "load_rows_for_resolver",
     "refresh_from_csv",
+    "sync_instrument_csv_from_broker",
+    "write_instrument_rows_to_csv",
 ]

--- a/src/nifty_scalper_bot/infra/cron_refresh.py
+++ b/src/nifty_scalper_bot/infra/cron_refresh.py
@@ -15,6 +15,7 @@ from nifty_scalper_bot.data import (
     ensure_sqlite,
     load_rows_for_resolver,
     refresh_from_csv,
+    sync_instrument_csv_from_broker,
 )
 from nifty_scalper_bot.infra.metrics import METRICS
 from nifty_scalper_bot.utils.logging import get_logger
@@ -22,6 +23,39 @@ from nifty_scalper_bot.utils.logging import get_logger
 LOGGER = get_logger(__name__)
 _IST = ZoneInfo("Asia/Kolkata")
 _TARGET_TIME = time(hour=6, minute=30)
+
+
+def _csv_refresh_interval_seconds(settings: Any) -> float:
+    """Compute CSV refresh cadence.
+
+    Args: settings.
+    Returns: Refresh seconds.
+    Raises: None.
+    """
+
+    instrument_cfg = getattr(settings, "instruments", None)
+    raw_hours = getattr(instrument_cfg, "refresh_interval_hours", 24.0)
+    try:
+        hours = max(float(raw_hours), 0.25)
+    except (TypeError, ValueError):
+        hours = 24.0
+    return hours * 3600.0
+
+
+def _sync_csv_from_broker(
+    resolver: InstrumentResolver, csv_path: Path
+) -> dict[str, Any]:
+    """Sync instrument CSV from resolver broker.
+
+    Args: resolver,csv_path.
+    Returns: Sync summary.
+    Raises: Exception.
+    """
+
+    broker = getattr(resolver, "_broker", None)
+    if broker is None:
+        return {"written": 0, "path": str(csv_path), "source": "none"}
+    return sync_instrument_csv_from_broker(broker, str(csv_path), exchange="NFO")
 
 
 def _seconds_until_run(target_time: time, tz: ZoneInfo) -> float:
@@ -56,7 +90,7 @@ def schedule_instrument_refresh(
     *,
     state: InstrumentUniverseStatus | None = None,
 ) -> asyncio.Task[Any] | None:
-    """Schedule daily resolver refresh at 06:30 Asia/Kolkata.
+    """Schedule resolver refresh with initial 06:30 IST trigger and periodic updates.
 
     Args:
         settings: Settings object exposing ``instruments`` configuration.
@@ -96,16 +130,17 @@ def schedule_instrument_refresh(
         return None
 
     async def _refresh_loop() -> None:
-        """Execute the daily refresh loop until cancelled."""
+        """Execute the instrument refresh loop until cancelled."""
 
         LOGGER.debug(
             "Entered instrument refresh loop",
             extra={"event": "instrument_refresh_loop_enter"},
         )
+        delay = _seconds_until_run(_TARGET_TIME, _IST)
         while True:
             try:
-                delay = _seconds_until_run(_TARGET_TIME, _IST)
                 await asyncio.sleep(delay)
+                csv_sync_summary = _sync_csv_from_broker(resolver, csv_path)
                 conn = ensure_sqlite(str(instrument_cfg.db_path))
                 try:
                     summary = refresh_from_csv(conn, str(csv_path))
@@ -132,11 +167,13 @@ def schedule_instrument_refresh(
                             "tokens": tokens,
                             "options": options,
                             "path": str(csv_path),
+                            "csv_written": int(csv_sync_summary.get("written") or 0),
                         },
                     )
                 finally:
                     with suppress(Exception):
                         conn.close()
+                delay = _csv_refresh_interval_seconds(settings)
             except asyncio.CancelledError:
                 LOGGER.info(
                     "instrument_refresh_task_cancelled",

--- a/tests/data/test_instrument_loader.py
+++ b/tests/data/test_instrument_loader.py
@@ -8,6 +8,8 @@ from nifty_scalper_bot.data import (
     ensure_sqlite,
     load_rows_for_resolver,
     refresh_from_csv,
+    sync_instrument_csv_from_broker,
+    write_instrument_rows_to_csv,
 )
 
 
@@ -38,3 +40,55 @@ def test_refresh_and_load_from_csv(tmp_path: Path) -> None:
         assert "lot_size" in first
     finally:
         conn.close()
+
+
+def test_write_instrument_rows_to_csv_creates_file(tmp_path: Path) -> None:
+    """Broker rows should be persisted into a CSV consumable by refresh logic."""
+
+    csv_path = tmp_path / "instruments.csv"
+    written = write_instrument_rows_to_csv(
+        [
+            {
+                "instrument_token": 1001,
+                "exchange": "NFO",
+                "tradingsymbol": "NIFTY25OCT26000CE",
+                "lot_size": 50,
+                "expiry": "2025-10-30",
+                "strike": 26000,
+                "instrument_type": "CE",
+                "segment": "NFO-OPT",
+                "name": "NIFTY",
+            }
+        ],
+        str(csv_path),
+    )
+    assert written == 1
+    assert csv_path.exists()
+    header = csv_path.read_text(encoding="utf-8").splitlines()[0]
+    assert "instrument_token" in header
+
+
+def test_sync_instrument_csv_from_broker_uses_loader(tmp_path: Path) -> None:
+    """Broker loader should bootstrap a missing warm-up CSV file."""
+
+    class _Broker:
+        def load_instruments(self, exchange: str) -> list[dict[str, object]]:
+            assert exchange == "NFO"
+            return [
+                {
+                    "instrument_token": 2001,
+                    "exchange": "NFO",
+                    "tradingsymbol": "NIFTY25OCT26100PE",
+                    "lot_size": 50,
+                    "expiry": "2025-10-30",
+                    "strike": 26100,
+                    "instrument_type": "PE",
+                    "segment": "NFO-OPT",
+                    "name": "NIFTY",
+                }
+            ]
+
+    csv_path = tmp_path / "bootstrap.csv"
+    summary = sync_instrument_csv_from_broker(_Broker(), str(csv_path), exchange="NFO")
+    assert summary["written"] == 1
+    assert csv_path.exists()


### PR DESCRIPTION
### Motivation
- Startup sometimes skipped CSV warm-up because `/app/instruments.csv` was missing, causing resolver warm-up to fall back to broker and producing inconsistent cached state.
- The instrument CSV should be created and periodically refreshed so resolver warm-up from CSV→SQLite is reliable and deterministic.

### Description
- Added CSV persistence helpers in `nifty_scalper_bot.data.instrument_loader`: `write_instrument_rows_to_csv(rows, csv_path)` and `sync_instrument_csv_from_broker(broker_client, csv_path, *, exchange="NFO")`, and exported them from `nifty_scalper_bot.data`.
- Updated startup warm-up in `_try_warm_instruments` (in `core/app.py`) to bootstrap a missing configured CSV by calling `sync_instrument_csv_from_broker` and then run the existing `refresh_from_csv` → `load_rows_for_resolver` warm sequence.
- Extended scheduled refresh in `infra/cron_refresh.py` to sync the CSV from the broker before refreshing SQLite/resolver and to continue periodic refreshes using a new `refresh_interval_hours` setting.
- Added `refresh_interval_hours: float = 24.0` to `InstrumentSettings` so CSV refresh cadence is configurable via env/settings.
- Added unit tests `test_write_instrument_rows_to_csv_creates_file` and `test_sync_instrument_csv_from_broker_uses_loader` in `tests/data/test_instrument_loader.py` to validate CSV writing and broker bootstrap behavior.

### Testing
- `ruff check` on the modified files passed for the updated modules (`instrument_loader.py`, `cron_refresh.py`, tests). (Passed)
- Byte-compile validation via `python -m py_compile` for the touched modules passed. (Passed)
- Focused unit tests `pytest -q tests/data/test_instrument_loader.py` passed. (Passed)
- Wider test run `pytest -q tests --disable-warnings --ignore=tests/test_live_mode.py --ignore=tests/test_health_server.py` failed due to an unrelated pre-existing import error in `tests/strategies/test_elite_strategies.py` (cannot import `elite_strategy_tags`), not caused by these changes. (Unrelated failure)
- `./run_checks.sh` could not be completed end-to-end in this environment (initial permission/collection issues), but the modified modules were linted/compiled and the new tests were executed successfully as above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995d7088f7883248042c73ef4f58f86)