### PR TITLE
fix: harden spot and bulk LTP fallbacks

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -2140,7 +2140,7 @@ def _get_symbols(
             ltp = float(ltp_raw) if ltp_raw is not None else 0.0
         except (TypeError, ValueError):
             ltp = 0.0
-    elif market_data_manager is not None:
+    elif market_data_manager is not None and broker is None:
         LOGGER.warning(
             "spot_unavailable_after_wait",
             extra={"event": "spot_unavailable_after_wait", "symbol": spot_symbol},
@@ -2180,7 +2180,15 @@ def _get_symbols(
             if ltp == 0 and hasattr(inner, "get_ltp"):
                 for candidate in str_candidates:
                     try:
-                        price = parse_price(inner.get_ltp(candidate))
+                        get_ltp_response = inner.get_ltp([candidate])
+                        response_payload: Any = get_ltp_response
+                        if isinstance(get_ltp_response, dict):
+                            response_payload = (
+                                get_ltp_response.get(candidate)
+                                or get_ltp_response.get(spot_symbol)
+                                or next(iter(get_ltp_response.values()), 0.0)
+                            )
+                        price = parse_price(response_payload)
                         if price > 0:
                             ltp = price
                             break
@@ -2190,12 +2198,16 @@ def _get_symbols(
             if ltp == 0 and hasattr(inner, "ltp"):
                 try:
                     q = inner.ltp(str_candidates)
-                    if spot_symbol not in q:
-                        LOGGER.error("Strategy skipped — missing live tick")
-                        return []
-                    for candidate in str_candidates:
-                        if candidate in q:
-                            price = parse_price(q[candidate])
+                    for candidate in (spot_symbol, *str_candidates):
+                        payload = q.get(candidate) if isinstance(q, dict) else None
+                        price = parse_price(payload)
+                        if price > 0:
+                            ltp = price
+                            break
+
+                    if ltp == 0 and isinstance(q, dict):
+                        for payload in q.values():
+                            price = parse_price(payload)
                             if price > 0:
                                 ltp = price
                                 break
@@ -2203,6 +2215,12 @@ def _get_symbols(
                     pass
         except Exception as exc:
             LOGGER.error("Error fetching live price: %s", exc, exc_info=True)
+
+    if ltp <= 0 and market_data_manager is not None:
+        LOGGER.warning(
+            "spot_unavailable_after_wait",
+            extra={"event": "spot_unavailable_after_wait", "symbol": spot_symbol},
+        )
 
     if ltp <= 0:
         if _allow_offhours:

--- a/src/nifty_scalper_bot/data/rest/zerodha_client.py
+++ b/src/nifty_scalper_bot/data/rest/zerodha_client.py
@@ -667,19 +667,26 @@ class ZerodhaKiteClient(BaseBrokerClient):
                 # get_quote_bulk already honors rate limiting and symbol resolution.
                 quote_map = self.get_quote_bulk(tokens)
                 out: dict[int, float] = {}
-                for token, payload in quote_map.items():
+                for symbol, payload in quote_map.items():
                     if not isinstance(payload, Mapping):
+                        continue
+                    try:
+                        token = int(
+                            payload.get("instrument_token")
+                            or payload.get("instrument_token_id")
+                            or 0
+                        )
+                    except (TypeError, ValueError):
+                        token = 0
+                    if token <= 0:
                         continue
                     try:
                         last_price = float(payload.get("last_price", 0.0) or 0.0)
                     except (TypeError, ValueError):
                         continue
-
-                    # [CORRECTED] Indentation fixed to be inside the for loop
                     if last_price > 0:
                         out[token] = last_price
 
-                # [CORRECTED] Logic for returning data if found (inside try)
                 if out:
                     now = time.time()
                     if now - self._last_log_ltp_bulk >= self._log_throttle_interval:
@@ -693,11 +700,10 @@ class ZerodhaKiteClient(BaseBrokerClient):
                         self._last_log_ltp_bulk = now
                     return out
 
-                # depth fetch returned but no usable last_price values
-                LOGGER.warning(
-                    "zerodha_get_ltp_bulk_depth_no_ltp",
+                LOGGER.info(
+                    "zerodha_get_ltp_bulk_depth_empty_fallback",
                     extra={
-                        "event": "zerodha_get_ltp_bulk_depth_no_ltp",
+                        "event": "zerodha_get_ltp_bulk_depth_empty_fallback",
                         "tokens": tokens,
                     },
                 )

--- a/tests/data/test_zerodha_client_resilience.py
+++ b/tests/data/test_zerodha_client_resilience.py
@@ -100,3 +100,31 @@ def test_transient_errors_open_breaker(monkeypatch: pytest.MonkeyPatch) -> None:
         pytest.approx(client._breaker_cooldown_sec) == call for call in sleep_calls
     )
     client._client.close()
+
+
+def test_get_ltp_bulk_depth_maps_symbol_payload_to_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv('POLL_REQUIRE_DEPTH', 'true')
+    client = ZerodhaKiteClient(api_key='key', access_token='token')
+
+    class _Resolver:
+        @staticmethod
+        def format_token_as_symbol(token: int) -> str:
+            return {256265: 'NSE:NIFTY 50'}.get(token, '')
+
+    client.attach_resolver(_Resolver())
+
+    monkeypatch.setattr(
+        client,
+        'get_quote_bulk',
+        lambda _tokens: {
+            'NSE:NIFTY 50': {'instrument_token': 256265, 'last_price': 25382.4}
+        },
+    )
+
+    out = client.get_ltp_bulk([256265])
+
+    assert out == {256265: 25382.4}
+
+    client._client.close()

--- a/tests/test_app_symbol_resolution.py
+++ b/tests/test_app_symbol_resolution.py
@@ -24,14 +24,14 @@ class _BrokerWithSpot:
         return {'NSE:NIFTY 50': {'last_price': 25382.4}}
 
 
-def test_get_symbols_aborts_when_live_spot_symbol_missing() -> None:
+def test_get_symbols_accepts_alternate_spot_symbol_keys() -> None:
     cfg = SimpleNamespace(symbols=None)
     universe = _UniverseStub()
 
     symbols = app._get_symbols(cfg, broker=_BrokerNoSpot(), option_universe=universe)
 
-    assert symbols == []
-    assert universe.underlying is None
+    assert symbols == ['NFO:NIFTY26FEB25000CE']
+    assert universe.underlying == 25300.0
 
 
 def test_get_symbols_uses_nse_nifty_50_symbol() -> None:


### PR DESCRIPTION
### Motivation
- Resolve recurring runtime noise where spot price resolution reports `spot_unavailable_after_wait` despite valid broker payloads under alternate keys. 
- Stop cases where depth-mode `get_quote_bulk` returned symbol-keyed payloads that downstream `get_ltp_bulk` consumers could not map to instrument tokens, causing LTP fallbacks and degraded polling. 
- Improve resilience so the bot never aborts symbol resolution due to mismatched response shapes and keeps robust LTP access for polling mode. 

### Description
- Improved `_get_symbols()` to accept alternate broker keys (`NIFTY 50` vs `NSE:NIFTY 50`) and to robustly parse `get_ltp()` and `ltp()` payload shapes (handles dict responses keyed by symbol or payload, and falls back to scanning values). 
- Avoid emitting the same `spot_unavailable_after_wait` warning when a broker is present and move a final warning to run only when both market data and broker lookups fail. 
- Hardened `ZerodhaKiteClient.get_ltp_bulk()` depth-mode parsing to extract `instrument_token` from quote payloads and return a `dict[int, float]` mapped by token, preventing symbol-keyed results from breaking callers. 
- Reduced noisy log level for empty depth results from `warning` to `info` while preserving observability and added a small regression test suite (one updated test, one new test) to cover the fixes. 

### Testing
- Ran targeted unit tests with `pytest -q tests/test_app_symbol_resolution.py tests/data/test_zerodha_client_resilience.py --disable-warnings` which passed (tests covering alternate spot key and depth symbol->token mapping). 
- Attempted full test/check run with `source .venv/bin/activate && pytest -q tests --disable-warnings --ignore=tests/test_live_mode.py --ignore=tests/test_health_server.py` which errored due to an unrelated pre-existing `ImportError` in `tests/strategies/test_elite_strategies.py`. 
- Ran repository checks; `./run_checks.sh` initially failed to execute due to file permission in this environment then progressed to venv setup, but `ruff` reported many pre-existing lint issues outside this patch; the change set itself is restricted to `src/nifty_scalper_bot/core/app.py`, `src/nifty_scalper_bot/data/rest/zerodha_client.py`, and two tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995e86fa9608324a867568c8a368f3c)