### PR TITLE
fix: restore Settings.execution_mode and data_dir compatibility accessors

### DIFF
--- a/src/nifty_scalper_bot/config/settings.py
+++ b/src/nifty_scalper_bot/config/settings.py
@@ -944,6 +944,20 @@ class Settings:
     universe_dynamic_mode: bool = True
     backtest_mode: bool = False
 
+    @property
+    def execution_mode(self) -> str:
+        """Args: None; Returns: Runtime execution mode string; Raises: Never."""
+        if self.paper_mode:
+            return "PAPER"
+        if self.enable_live:
+            return "LIVE"
+        return "SHADOW"
+
+    @property
+    def data_dir(self) -> Path:
+        """Args: None; Returns: Replay data directory path; Raises: Never."""
+        return self.replay.data_dir
+
 
 def _build_elite_settings() -> EliteStrategiesSettings:
     """

--- a/tests/test_startup_sequence.py
+++ b/tests/test_startup_sequence.py
@@ -275,3 +275,45 @@ async def test_startup_continues_when_broker_denied() -> None:
     payload = client.get("/health").json()
     assert payload.get("guard") == "blocked"
     assert "Broker session not validated" in payload.get("reasons", [])
+
+
+def test_settings_execution_mode_and_data_dir_compat() -> None:
+    app_config = AppConfig(
+        broker=BrokerConfig(
+            api_key='demo',
+            api_secret='secret',
+            access_token='token',
+            base_url='https://example.com',
+            websocket_url='wss://example.com/ws',
+        ),
+        risk=RiskConfig(),
+        logging=LoggingConfig(level='INFO'),
+        ratelimit=RateLimitConfig(
+            orders=RateLimitBucketConfig(capacity=10, refill_rate_per_sec=10.0),
+            rest=RateLimitBucketConfig(capacity=10, refill_rate_per_sec=10.0),
+            hist=RateLimitBucketConfig(capacity=10, refill_rate_per_sec=10.0),
+        ),
+        quote_stale_threshold_ms=1_000,
+    )
+
+    settings = Settings(
+        app=app_config,
+        enable_live=False,
+        orders=OrderSettings(),
+        risk=RiskSettings(),
+        streamer=StreamerSettings(),
+        shadow=ShadowSettings(),
+        notifications=NotificationSettings(enabled=False),
+        session_allow_out_of_hours=False,
+        allow_offmarket_trading=False,
+    )
+
+    assert settings.execution_mode == 'SHADOW'
+    assert settings.data_dir == settings.replay.data_dir
+
+    settings.paper_mode = True
+    assert settings.execution_mode == 'PAPER'
+
+    settings.paper_mode = False
+    settings.enable_live = True
+    assert settings.execution_mode == 'LIVE'


### PR DESCRIPTION
### Motivation

- Startup and other runtime paths expect `ctx.settings.execution_mode` and `ctx.settings.data_dir`, and startup was failing with `'Settings' object has no attribute 'execution_mode'`.
- Provide a backward-compatible, read-only view on the `Settings` dataclass so existing callers do not need to be changed and runtime behavior remains deterministic.

### Description

- Added `Settings.execution_mode` property that deterministically returns `"PAPER"`, `"LIVE"`, or `"SHADOW"` based on existing `paper_mode` and `enable_live` flags.
- Added `Settings.data_dir` property that proxies to `replay.data_dir` to preserve existing callers that read `settings.data_dir`.
- Added a small unit test `test_settings_execution_mode_and_data_dir_compat` validating default `SHADOW` behavior and precedence of `PAPER` then `LIVE`.

### Testing

- Executed the repository checks via `bash ./run_checks.sh`, which ran the dependency installer and reported test tooling status (Ruff/mypy skipped due to environment and `pytest` initially missing).
- Installed `pytest` and ran the full test suite using `pytest -q tests --disable-warnings --ignore=tests/test_live_mode.py --ignore=tests/test_health_server.py`, which failed during collection due to an unrelated baseline `ImportError` in `tests/strategies/test_elite_strategies.py` (unrelated to this change).
- Ran the targeted test `pytest -q tests/test_startup_sequence.py -k execution_mode_and_data_dir_compat`, and it passed (`1 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996078704bc8324a0bb8afe218f5af6)