### PR TITLE
feat: add capital-aware EliteTuesdayGammaBuyer elite strategy

### DIFF
--- a/src/nifty_scalper_bot/config/settings.py
+++ b/src/nifty_scalper_bot/config/settings.py
@@ -45,6 +45,7 @@ from nifty_scalper_bot.strategies.elite_strategies.config_models import (
     RSIDivergenceStrategyConfig,
     SMCStrategyConfig,
     StraddleThetaStrategyConfig,
+    TuesdayGammaBuyerStrategyConfig,
     VWAPProStrategyConfig,
 )
 from nifty_scalper_bot.strategies.elite_validator import (
@@ -1019,6 +1020,14 @@ def _build_elite_settings() -> EliteStrategiesSettings:
             min_gamma=_env_float("GAMMA_THRESHOLD", default=0.0005),
         )
 
+        # 6b. Tuesday Gamma Buyer
+        tuesday_gamma_cfg = TuesdayGammaBuyerStrategyConfig(
+            enabled=_env_bool("ENABLE_TUESDAY_GAMMA_BUYER", default=False),
+            min_confidence=_env_float("TUESDAY_GAMMA_MIN_CONFIDENCE", default=65.0),
+            atr_multiplier=_env_float("TUESDAY_GAMMA_ATR_MULTIPLIER", default=1.2),
+            target_multiplier=_env_float("TUESDAY_GAMMA_TARGET_MULTIPLIER", default=1.8),
+        )
+
         # 7. OI Max Pain (Unlocked)
         oi_cfg = OIMaxPainStrategyConfig(
             enabled=_env_bool("OI_MAX_PAIN_ENABLED", default=True),
@@ -1070,6 +1079,7 @@ def _build_elite_settings() -> EliteStrategiesSettings:
             orb=orb_cfg,
             straddle=straddle_cfg,
             gamma_scalping=gamma_cfg,
+            tuesday_gamma_buyer=tuesday_gamma_cfg,
             oi_max_pain=oi_cfg,
             cpr=cpr_cfg,
             order_flow=of_cfg,

--- a/src/nifty_scalper_bot/config/strategies.yaml
+++ b/src/nifty_scalper_bot/config/strategies.yaml
@@ -9,3 +9,4 @@ enabled_strategies:
   - rsi_divergence
   - orb_pro
   - straddle_theta
+  - elite_tuesday_gamma_buyer

--- a/src/nifty_scalper_bot/strategies/elite_strategies/__init__.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from .bb_squeeze import BBSqueezeStrategy
 from .cpr_breakout import CPRBreakoutStrategy
 from .gamma_scalping import GammaScalpingStrategy
+from ..elite_tuesday_gamma_buyer import EliteTuesdayGammaBuyer
 from .oi_max_pain import OIMaxPainStrategy
 from .orb_pro import ORBProStrategy
 from .order_flow import OrderFlowStrategy
@@ -17,6 +18,7 @@ __all__ = [
     "BBSqueezeStrategy",
     "CPRBreakoutStrategy",
     "GammaScalpingStrategy",
+    "EliteTuesdayGammaBuyer",
     "OIMaxPainStrategy",
     "ORBProStrategy",
     "OrderFlowStrategy",

--- a/src/nifty_scalper_bot/strategies/elite_strategies/builder.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/builder.py
@@ -14,6 +14,7 @@ from nifty_scalper_bot.strategies.elite_strategies.config_models import EliteStr
 from nifty_scalper_bot.strategies.elite_strategies.bb_squeeze import BBSqueezeStrategy
 from nifty_scalper_bot.strategies.elite_strategies.cpr_breakout import CPRBreakoutStrategy
 from nifty_scalper_bot.strategies.elite_strategies.gamma_scalping import GammaScalpingStrategy
+from nifty_scalper_bot.strategies.elite_tuesday_gamma_buyer import EliteTuesdayGammaBuyer
 from nifty_scalper_bot.strategies.elite_strategies.oi_max_pain import OIMaxPainStrategy
 from nifty_scalper_bot.strategies.elite_strategies.orb_pro import ORBProStrategy
 from nifty_scalper_bot.strategies.elite_strategies.order_flow import OrderFlowStrategy
@@ -49,6 +50,7 @@ def build_elite_strategies(
         "vwap": VWAPProStrategy,
         "oi_max_pain": OIMaxPainStrategy,
         "gamma_scalping": GammaScalpingStrategy,
+        "tuesday_gamma_buyer": EliteTuesdayGammaBuyer,
         "cpr": CPRBreakoutStrategy,
         "order_flow": OrderFlowStrategy,
         "bb_squeeze": BBSqueezeStrategy,
@@ -107,6 +109,7 @@ def get_strategy_tags(settings: EliteStrategiesSettings) -> Dict[str, List[str]]
         "vwap": "VWAP Pro Pullback",
         "oi_max_pain": "OI Mean Reversion",
         "gamma_scalping": "Gamma Acceleration",
+        "tuesday_gamma_buyer": "Tuesday Gamma Buyer",
         "cpr": "CPR Trend Breakout",
         "order_flow": "Order Flow Imbalance",
         "bb_squeeze": "BB Volatility Squeeze",

--- a/src/nifty_scalper_bot/strategies/elite_strategies/config.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/config.py
@@ -17,6 +17,7 @@ from .config_models import (
     RSIDivergenceStrategyConfig,
     SMCStrategyConfig,
     StraddleThetaStrategyConfig,
+    TuesdayGammaBuyerStrategyConfig,
     VWAPProStrategyConfig,
 )
 
@@ -28,6 +29,7 @@ ELITE_STRATEGY_MODULES = [
     "vwap_pro",
     "oi_max_pain",
     "gamma_scalping",
+    "elite_tuesday_gamma_buyer",
     "cpr_breakout",
     "order_flow",
     "bb_squeeze",
@@ -49,5 +51,6 @@ __all__ = [
     "RSIDivergenceStrategyConfig",
     "SMCStrategyConfig",
     "StraddleThetaStrategyConfig",
+    "TuesdayGammaBuyerStrategyConfig",
     "VWAPProStrategyConfig",
 ]

--- a/src/nifty_scalper_bot/strategies/elite_strategies/config_models.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/config_models.py
@@ -66,6 +66,13 @@ class GammaScalpingStrategyConfig(EliteStrategyConfig):
 
 
 @dataclass(slots=True)
+class TuesdayGammaBuyerStrategyConfig(EliteStrategyConfig):
+    """Tuesday Gamma Buyer: expiry day and ATR-risk controls."""
+    atr_multiplier: float = 1.2
+    target_multiplier: float = 1.8
+
+
+@dataclass(slots=True)
 class CPRBreakoutStrategyConfig(EliteStrategyConfig):
     """CPR Breakout: Pivot width thresholds."""
     narrow_cpr_threshold: float = 0.25
@@ -118,6 +125,9 @@ class EliteStrategiesSettings:
     vwap: VWAPProStrategyConfig = field(default_factory=VWAPProStrategyConfig)
     oi_max_pain: OIMaxPainStrategyConfig = field(default_factory=OIMaxPainStrategyConfig)
     gamma_scalping: GammaScalpingStrategyConfig = field(default_factory=GammaScalpingStrategyConfig)
+    tuesday_gamma_buyer: TuesdayGammaBuyerStrategyConfig = field(
+        default_factory=lambda: TuesdayGammaBuyerStrategyConfig(enabled=False)
+    )
     cpr: CPRBreakoutStrategyConfig = field(default_factory=CPRBreakoutStrategyConfig)
     order_flow: OrderFlowStrategyConfig = field(default_factory=OrderFlowStrategyConfig)
     bb_squeeze: BBSqueezeStrategyConfig = field(default_factory=BBSqueezeStrategyConfig)
@@ -139,6 +149,7 @@ __all__ = [
     "VWAPProStrategyConfig",
     "OIMaxPainStrategyConfig",
     "GammaScalpingStrategyConfig",
+    "TuesdayGammaBuyerStrategyConfig",
     "CPRBreakoutStrategyConfig",
     "OrderFlowStrategyConfig",
     "BBSqueezeStrategyConfig",

--- a/src/nifty_scalper_bot/strategies/elite_strategies/elite_tuesday_gamma_buyer.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/elite_tuesday_gamma_buyer.py
@@ -1,0 +1,7 @@
+"""Compatibility wrapper for Tuesday gamma buyer strategy."""
+
+from __future__ import annotations
+
+from nifty_scalper_bot.strategies.elite_tuesday_gamma_buyer import EliteTuesdayGammaBuyer
+
+__all__ = ['EliteTuesdayGammaBuyer']

--- a/src/nifty_scalper_bot/strategies/elite_strategy_registry.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategy_registry.py
@@ -1,0 +1,11 @@
+"""Explicit elite strategy class registry."""
+
+from __future__ import annotations
+
+from nifty_scalper_bot.strategies.elite_tuesday_gamma_buyer import EliteTuesdayGammaBuyer
+
+ELITE_STRATEGY_REGISTRY = {
+    'tuesday_gamma_buyer': EliteTuesdayGammaBuyer,
+}
+
+__all__ = ['ELITE_STRATEGY_REGISTRY', 'EliteTuesdayGammaBuyer']

--- a/src/nifty_scalper_bot/strategies/elite_tuesday_gamma_buyer.py
+++ b/src/nifty_scalper_bot/strategies/elite_tuesday_gamma_buyer.py
@@ -1,0 +1,252 @@
+"""Capital-aware Tuesday expiry gamma buyer elite strategy."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from typing import Any, Mapping
+
+from nifty_scalper_bot.strategies.elite_strategies.base_elite import (
+    EliteSignal,
+    EliteStrategy,
+)
+from nifty_scalper_bot.strategies.elite_strategies.config_models import (
+    TuesdayGammaBuyerStrategyConfig,
+)
+from nifty_scalper_bot.utils.logging import get_logger
+
+LOGGER = get_logger(__name__)
+
+BaseEliteStrategy = EliteStrategy
+NIFTY_LOT_SIZE = 65
+MAX_RISK_PER_TRADE = 0.006
+MAX_DAILY_RISK = 0.02
+MAX_CAPITAL_DEPLOYMENT = 0.15
+
+
+@dataclass(slots=True)
+class _AccountState:
+    """Args: none. Returns: account state container. Raises: never."""
+
+    available_equity: float = 0.0
+
+
+class EliteTuesdayGammaBuyer(BaseEliteStrategy):
+    """Args: config, indicator_engine. Returns: initialized strategy. Raises: Exception."""
+
+    def __init__(
+        self,
+        config: TuesdayGammaBuyerStrategyConfig,
+        indicator_engine: Any,
+    ) -> None:
+        """Args: config, indicator_engine. Returns: None. Raises: Exception."""
+        super().__init__(config=config, indicator_engine=indicator_engine)
+        self._config = config
+        self.account_state = _AccountState()
+        self.daily_realized_pnl = 0.0
+        self._trading_disabled_day: date | None = None
+
+    def get_required_indicators(self) -> set[str]:
+        """Args: none. Returns: required indicators. Raises: Exception."""
+        return {
+            'spot',
+            'ltp',
+            'vwap',
+            'ema_fast',
+            'ema_slow',
+            'recent_high',
+            'recent_low',
+            'volume',
+            'avg_volume',
+            'atr',
+            'atr_ma',
+            'spot_return_3min',
+        }
+
+    def disable_trading_for_day(self) -> None:
+        """Args: none. Returns: None. Raises: Exception."""
+        try:
+            self._trading_disabled_day = self._today_local()
+            hook = getattr(self, '_on_daily_trading_disabled', None)
+            if callable(hook):
+                hook(self.name)
+            LOGGER.info(
+                'Condition met: tuesday_gamma_daily_halt',
+                extra={'event': 'tuesday_gamma_daily_halt', 'strategy': self.name},
+            )
+        except Exception as e:
+            LOGGER.error('Failure in disable_trading_for_day: %s', e, exc_info=e)
+
+    def compute_position_size(self, entry: float, stop: float) -> int:
+        """Args: entry, stop. Returns: lot-aligned quantity. Raises: Exception."""
+        try:
+            capital = float(self.account_state.available_equity)
+            if capital <= 0:
+                return 0
+
+            risk_amount = capital * MAX_RISK_PER_TRADE
+            risk_per_unit = abs(entry - stop)
+            if risk_per_unit <= 0:
+                return 0
+
+            contracts = int(risk_amount / (risk_per_unit * NIFTY_LOT_SIZE))
+            contracts = max(0, contracts)
+
+            max_deploy = capital * MAX_CAPITAL_DEPLOYMENT
+            while contracts > 0 and (entry * contracts * NIFTY_LOT_SIZE) > max_deploy:
+                contracts -= 1
+
+            quantity = contracts * NIFTY_LOT_SIZE
+            if quantity < NIFTY_LOT_SIZE:
+                return 0
+            return quantity
+        except Exception as e:
+            LOGGER.error('Failure in compute_position_size: %s', e, exc_info=e)
+            return 0
+
+    def _today_local(self) -> date:
+        """Args: none. Returns: local trading date. Raises: Exception."""
+        clock = getattr(self, 'clock', None)
+        if clock and callable(getattr(clock, 'now_local', None)):
+            return clock.now_local().date()
+        from datetime import datetime
+
+        return datetime.now().date()
+
+    def _evaluate_signal(
+        self,
+        symbol: str,
+        indicators: Mapping[str, Any],
+        current_price: float,
+        position: Any | None = None,
+    ) -> EliteSignal | None:
+        """Args: symbol, indicators, current_price, position. Returns: EliteSignal|None. Raises: Exception."""
+        del position
+        try:
+            now_local = None
+            clock = getattr(self, 'clock', None)
+            if clock and callable(getattr(clock, 'now_local', None)):
+                now_local = clock.now_local()
+
+            if now_local is not None:
+                if now_local.weekday() != 1:
+                    return None
+                if now_local.hour < 9 or now_local.hour > 14:
+                    return None
+                if now_local.hour == 9 and now_local.minute < 20:
+                    return None
+                if now_local.hour == 14 and now_local.minute >= 45:
+                    return None
+
+            if self._trading_disabled_day == self._today_local():
+                return None
+
+            spot = float(indicators.get('spot') or current_price or 0.0)
+            vwap = float(indicators.get('vwap') or 0.0)
+            ema_fast = float(indicators.get('ema_fast') or 0.0)
+            ema_slow = float(indicators.get('ema_slow') or 0.0)
+            recent_high = float(indicators.get('recent_high') or 0.0)
+            recent_low = float(indicators.get('recent_low') or 0.0)
+            volume = float(indicators.get('volume') or 0.0)
+            avg_volume = float(indicators.get('avg_volume') or 0.0)
+            atr = float(indicators.get('atr') or 0.0)
+            atr_ma = float(indicators.get('atr_ma') or 0.0)
+            spot_return_3min = float(indicators.get('spot_return_3min') or 0.0)
+
+            if abs(spot_return_3min) > 0.006:
+                return None
+
+            if spot <= 0:
+                return None
+
+            score = 0
+            if spot > vwap:
+                score += 2
+            else:
+                score -= 2
+
+            if ema_fast > ema_slow:
+                score += 2
+            else:
+                score -= 2
+
+            if current_price > recent_high:
+                score += 2
+            elif recent_low > 0 and current_price < recent_low:
+                score -= 2
+
+            if avg_volume > 0 and volume > 1.5 * avg_volume:
+                score += 1
+            elif avg_volume > 0 and volume < 0.8 * avg_volume:
+                score -= 1
+
+            if atr > atr_ma and atr_ma > 0:
+                score += 1
+            elif atr_ma > 0:
+                score -= 1
+
+            if score >= 5:
+                option_type = 'CE'
+            elif score <= -5:
+                option_type = 'PE'
+            else:
+                return None
+
+            position_manager = getattr(self, 'position_manager', None)
+            if position_manager and callable(getattr(position_manager, 'has_open_position', None)):
+                if bool(position_manager.has_open_position()):
+                    return None
+
+            capital = float(getattr(self.account_state, 'available_equity', 0.0) or 0.0)
+            if capital <= 0:
+                return None
+
+            self.daily_realized_pnl = float(getattr(self, 'daily_realized_pnl', 0.0) or 0.0)
+            if self.daily_realized_pnl <= -(capital * MAX_DAILY_RISK):
+                self.disable_trading_for_day()
+                return None
+
+            stop_loss = current_price - (max(atr, current_price * 0.005) * 1.2)
+            quantity = self.compute_position_size(entry=current_price, stop=stop_loss)
+            if quantity < NIFTY_LOT_SIZE:
+                return None
+
+            collision_reduce = False
+            orchestrator = getattr(self, '_orchestrator', None)
+            if orchestrator and callable(getattr(orchestrator, 'active_strategies_for_symbol', None)):
+                active = orchestrator.active_strategies_for_symbol(symbol)
+                if active:
+                    collision_reduce = True
+            if collision_reduce:
+                quantity = ((quantity // NIFTY_LOT_SIZE) // 2) * NIFTY_LOT_SIZE
+                if quantity < NIFTY_LOT_SIZE:
+                    return None
+
+            if quantity % NIFTY_LOT_SIZE != 0:
+                raise RuntimeError('Invalid lot size for NIFTY')
+
+            return EliteSignal(
+                symbol=symbol,
+                signal='BUY',
+                confidence=min(0.99, max(0.5, score / 10.0)),
+                entry_price=current_price,
+                stop_loss=stop_loss,
+                target=current_price + (max(atr, current_price * 0.005) * 1.8),
+                quantity=quantity,
+                strategy_name='EliteTuesdayGammaBuyer',
+                metadata={
+                    'option_type': option_type,
+                    'bracket_type': 'VIRTUAL',
+                    'sl_mode': 'ATR_TRAIL',
+                    'enable_trailing': True,
+                    'sl_atr_mult': 1.2,
+                    'trailing_atr_mult': 1.2,
+                    'tp2_atr_mult': 1.8,
+                    'atr_multiplier': self._config.atr_multiplier,
+                    'target_multiplier': self._config.target_multiplier,
+                    'score': score,
+                },
+            )
+        except Exception as e:
+            LOGGER.error('Failure in EliteTuesdayGammaBuyer._evaluate_signal: %s', e, exc_info=e)
+            return None

--- a/src/nifty_scalper_bot/strategies/registry.py
+++ b/src/nifty_scalper_bot/strategies/registry.py
@@ -12,6 +12,7 @@ ELITE_MODULES = [
     "vwap_pro",
     "oi_max_pain",
     "gamma_scalping",
+    "elite_tuesday_gamma_buyer",
     "cpr_breakout",
     "order_flow",
     "bb_squeeze",
@@ -40,6 +41,11 @@ CLASS_MAP: dict[str, tuple[str, str, Callable[[], Any] | None]] = {
         "gamma_scalping",
         "GammaScalpingStrategy",
         config_models.GammaScalpingStrategyConfig,
+    ),
+    "Tuesday Gamma Buyer": (
+        "elite_tuesday_gamma_buyer",
+        "EliteTuesdayGammaBuyer",
+        config_models.TuesdayGammaBuyerStrategyConfig,
     ),
     "CPR Breakout": (
         "cpr_breakout",


### PR DESCRIPTION
### Motivation

- Add a capital-aware, Tuesday-expiry focused elite options buying strategy that integrates with existing ATR trailing and virtual bracket systems while protecting capital. 
- Ensure sizing uses NIFTY lot multiples (65) and enforces per-trade and daily risk caps so the strategy cannot over-deploy capital. 
- Integrate the new strategy cleanly into the existing elite strategy loading/registry and config system without changing other elite strategies' behavior.

### Description

- Added `src/nifty_scalper_bot/strategies/elite_tuesday_gamma_buyer.py` implementing `class EliteTuesdayGammaBuyer(BaseEliteStrategy)` which returns `EliteSignal` and uses the existing signal lifecycle and indicator engine. 
- Implemented capital-aware sizing with `NIFTY_LOT_SIZE = 65`, `MAX_RISK_PER_TRADE = 0.006`, `MAX_DAILY_RISK = 0.02`, and `MAX_CAPITAL_DEPLOYMENT = 0.15` and exposed `compute_position_size(self, entry, stop)` that always rounds to 65-lot multiples and skips trades < 65. 
- Strategy gating: Tuesday-only execution, time windows (skip early minutes and after 14:45), 3-minute spot-return volatility shock guard, score-based gamma expansion model for CE/PE direction, collision reduction (reduce size by 50% if other elite strategy active), and daily realized-PnL halt via `disable_trading_for_day()`. 
- Integration: added `TuesdayGammaBuyerStrategyConfig` to elite config models, wired config loading in `src/nifty_scalper_bot/config/settings.py` with env toggle `ENABLE_TUESDAY_GAMMA_BUYER` (default false), registered the strategy in the elite builder (`tuesday_gamma_buyer`), added a compatibility wrapper under `elite_strategies`, and an explicit `elite_strategy_registry` mapping. 
- Execution safety: the strategy emits metadata for the runner to use virtual brackets/ATR-based stops and enables trailing via existing mechanisms and does not place broker orders directly.

### Testing

- Ran `./run_checks.sh` as part of validation; the script executed but overall run failed due to pre-existing repository-wide type/lint/test baseline issues not introduced by this change (global `mypy` failures and `pytest` config/tooling gaps). 
- Ran compilation checks for the modified/added modules with `python -m py_compile` which succeeded for the new/changed files. 
- Ran unit tests with `pytest -q tests --disable-warnings --ignore=tests/test_live_mode.py --ignore=tests/test_health_server.py` which failed during collection due to an existing test expecting `elite_strategy_tags` in the builder surface (test collection error unrelated to strategy runtime logic).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997ed59f57883248839c311eb6e3aa9)