### PR TITLE
fix: restore websocket tick propagation pipeline

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -3542,19 +3542,19 @@ def initialize_components(settings: Settings | None = None) -> BotContext:
             # B. Fallback Defaults
             sym_upper = symbol.upper()
             if "NIFTY" in sym_upper:
-                return 75  # Force 75 for NIFTY
+                return 65  # Updated NIFTY lot size fallback
             if "BANKNIFTY" in sym_upper:
                 return 15
             return 1
         except Exception:
             # C. Safety Net
             if "NIFTY" in symbol.upper():
-                return 75
+                return 65
             return 1
 
     # Always attach the provider
     risk_manager.set_lot_size_provider(_lot_size_lookup)
-    LOGGER.info("✅ Wired Lot Size Provider to Risk Manager (NIFTY=75)")
+    LOGGER.info("✅ Wired Lot Size Provider to Risk Manager (NIFTY=65)")
 
     risk_state: RiskState | None = None
     try:

--- a/src/nifty_scalper_bot/data/data_hub.py
+++ b/src/nifty_scalper_bot/data/data_hub.py
@@ -329,10 +329,27 @@ class DataHub:
 
             payload["timestamp"] = int(time.time() * 1000)
 
-        # 3. 🔥 CRITICAL REDIRECT 🔥
-        # Send to the async pipeline to trigger MessageBus, Strategies, and Greeks.
-        # This makes Polling/Rest/Scout sources "Alive".
-        self.ingest_tick_sync(payload)
+        with self._lock:
+            self._quotes[canonical_symbol] = dict(payload)
+
+        if self._message_bus is not None:
+            message = Message(
+                type=MessageType.TICK,
+                timestamp=datetime.now(timezone.utc),
+                data=payload,
+                source="data_hub",
+            )
+            try:
+                publish_result = self._message_bus.publish(message)
+                if asyncio.iscoroutine(publish_result):
+                    try:
+                        loop = asyncio.get_running_loop()
+                    except RuntimeError:
+                        asyncio.run(publish_result)
+                    else:
+                        loop.create_task(publish_result)
+            except Exception as exc:  # noqa: BLE001
+                LOGGER.error("Failure in DataHub.store_quote: %s", exc, exc_info=exc)
 
     def replace_positions(self, positions: Iterable[dict[str, Any]]) -> None:
         """Atomically replace the entire position snapshot."""

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -2272,6 +2272,7 @@ class StrategyRunner:
             if symbol_value
             else "UNKNOWN"
         )
+        self._logger.debug("RUNNER_RECEIVED_TICK %s", symbol)
         if not self.ready:
             log_throttled(
                 self._logger,

--- a/src/nifty_scalper_bot/streaming/websocket_manager.py
+++ b/src/nifty_scalper_bot/streaming/websocket_manager.py
@@ -3,13 +3,12 @@
 from __future__ import annotations
 
 import asyncio
-import random
-import time
 from collections.abc import Awaitable, Callable, Coroutine, Sequence
 from dataclasses import dataclass
-from datetime import datetime
 from datetime import time as dtime
 from enum import Enum
+import random
+import time
 from typing import Any
 from zoneinfo import ZoneInfo
 
@@ -171,7 +170,6 @@ class WebSocketManager:
         if self._on_tick_callback is not None and not suppress_warning:
             self._logger.warning("WS|Replacing existing tick callback")
         self._on_tick_callback = callback
-
 
     def set_fallback_callbacks(
         self,
@@ -580,14 +578,18 @@ class WebSocketManager:
         else:
             self._logger.debug(
                 "Condition met: websocket_handlers_bound callback=%s",
-                getattr(self._on_tick_callback, "__name__", type(self._on_tick_callback).__name__),
+                getattr(
+                    self._on_tick_callback,
+                    "__name__",
+                    type(self._on_tick_callback).__name__,
+                ),
             )
 
     def _on_connect(self, ws: KiteTicker, response: dict[str, Any]) -> None:
         """Args: ws/response; Returns: none; Raises: none."""
 
         try:
-            del ws, response
+            del response
             self._last_pong_mono = time.monotonic()
             self._connected.set()
             self._state = ConnectionState.CONNECTED
@@ -595,6 +597,13 @@ class WebSocketManager:
                 "WebSocket CONNECTED successfully | tokens=%d",
                 len(self._tokens),
             )
+            if self._tokens:
+                token_list = sorted(self._tokens)
+                ws.subscribe(token_list)
+                ws.set_mode(ws.MODE_FULL, token_list)
+                self._logger.info(
+                    "WebSocket subscribed to %d tokens", len(self._tokens)
+                )
             if self._on_connect_callback is not None:
                 self._on_connect_callback()
             self._schedule_async(self._resubscribe_if_connected())
@@ -607,6 +616,14 @@ class WebSocketManager:
         del ws
         if not ticks:
             return
+
+        market_data_manager = getattr(self, "_market_data_manager", None)
+        process_ticks = getattr(market_data_manager, "process_ticks", None)
+        if callable(process_ticks):
+            try:
+                process_ticks(ticks)
+            except Exception as e:
+                self._logger.error("Failure in _on_ticks.process_ticks: %s", e)
 
         if not isinstance(ticks, list):
             self._logger.error("Invalid ticks payload type: %s", type(ticks))
@@ -635,7 +652,7 @@ class WebSocketManager:
                     self._schedule_coroutine(loop, result)
             except Exception as exc:
                 self._logger.error("Failure dispatching tick: %s", exc, exc_info=True)
-        
+
     def _on_pong(self, _ws: KiteTicker, _payload: Any | None = None) -> None:
         """Args: ws/payload; Returns: none; Raises: none."""
 


### PR DESCRIPTION
### Motivation
- Live strategies were starving because normalized quotes from polling/REST/WS were not consistently reaching the async MessageBus and StrategyRunner, preventing evaluations and signal generation.
- The change restores a single, non-blocking publish path from quote ingestion through the MessageBus into the strategy pipeline and ensures the WS client actually subscribes tokens on connect.

### Description
- DataHub: `store_quote()` now stores the normalized payload in `_quotes` and publishes a `Message(type=MessageType.TICK, data=payload)` to the `MessageBus`, scheduling async publishes when required and logging publish failures; duplicates of publish paths were avoided. (file: `src/nifty_scalper_bot/data/data_hub.py`)
- WebSocketManager: `_on_connect()` now calls `ws.subscribe(token_list)` and `ws.set_mode(ws.MODE_FULL, token_list)` and logs `WebSocket subscribed to {len(self._tokens)} tokens`, while `_on_ticks()` short-circuits on empty payloads and forwards incoming batches to `market_data_manager.process_ticks(ticks)` when available. (file: `src/nifty_scalper_bot/streaming/websocket_manager.py`)
- StrategyRunner: added a short debug trace at the start of `_handle_tick_message()` (`RUNNER_RECEIVED_TICK %s`) to verify tick delivery into the runner. (file: `src/nifty_scalper_bot/strategies/runner.py`)
- Lot size provider: updated the fallback NIFTY lot size from `75` to `65` (file: `src/nifty_scalper_bot/core/app.py`).

### Testing
- Attempted `./run_checks.sh` initially failed due to permission issues, then executed `bash ./run_checks.sh` which bootstrapped dependencies but initially reported `pytest` missing (environment/tooling state), so tooling installation was completed manually.  
- Installed dev tooling in the venv (`pip install pytest ruff mypy black isort`) and ran targeted tests: `pytest -q tests/streaming/test_websocket_manager.py tests/test_production_hardening_guards.py tests/strategies/test_strategy_runner_datahub.py` which passed.  
- Ran the broader test suite with ignores: `pytest -q tests --disable-warnings --ignore=tests/test_live_mode.py --ignore=tests/test_health_server.py`, which surfaced an unrelated pre-existing import failure in `tests/strategies/test_elite_strategies.py` (test run aborted for unrelated repo issues).  
- Static checks: `mypy` reported repository-wide typing errors that are unrelated to these focused fixes (no new mypy regressions introduced by this patch were observed during selective checking).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997f06f17d48324a363bfeddfb6a5d6)