### PR TITLE
fix: repair thread-safe tick ingestion bridge

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -5281,6 +5281,14 @@ async def startup_sequence(ctx: BotContext) -> None:
         os.getenv("PORT"),
     )
 
+    loop = asyncio.get_running_loop()
+    if ctx.data_hub is not None:
+        ctx.data_hub.set_event_loop(loop)
+    if ctx.market_data_manager is not None and hasattr(
+        ctx.market_data_manager, "set_event_loop"
+    ):
+        ctx.market_data_manager.set_event_loop(loop)
+
     # =========================================================
     # Create Data Directory
     # =========================================================

--- a/src/nifty_scalper_bot/data/data_hub.py
+++ b/src/nifty_scalper_bot/data/data_hub.py
@@ -230,18 +230,21 @@ class DataHub:
         self._history_freshness_max_age_seconds = float(
             os.getenv("HISTORY_FRESHNESS_MAX_AGE_SECONDS", "120")
         )
+        self._main_loop: asyncio.AbstractEventLoop | None = None
 
     # ----------------------------------------------------------------
     # Ingestion (Write Path)
     # ----------------------------------------------------------------
 
+    def set_event_loop(self, loop: asyncio.AbstractEventLoop) -> None:
+        """Wire main asyncio loop for thread-safe tick ingestion."""
+        self._main_loop = loop
+
     def ingest_tick_sync(self, tick: dict) -> None:
-        """Synchronous bridge to schedule ingest_tick on the running loop."""
-        try:
-            loop = asyncio.get_running_loop()
-            loop.create_task(self.ingest_tick(tick))
-        except RuntimeError:
-            pass
+        """Called from KiteConnect OS thread; schedules tick ingest safely."""
+        loop = self._main_loop
+        if loop and loop.is_running():
+            loop.call_soon_threadsafe(loop.create_task, self.ingest_tick(tick))
 
     async def ingest_tick(self, tick: Tick) -> None:
         """Process an incoming market tick."""
@@ -266,37 +269,31 @@ class DataHub:
             except Exception:
                 pass  # Don't let math errors kill the tick
 
-            # 3. Publish to MessageBus (The Critical Fix)
-            if self._message_bus:
-                try:
-                    await self._message_bus.publish(
-                        Message(
-                            type=MessageType.TICK,
-                            timestamp=datetime.now(timezone.utc),
-                            data=dict(canonical_tick),
-                            source="data_hub",
-                        )
+        # 3. Publish to MessageBus (outside lock)
+        if self._message_bus:
+            try:
+                await self._message_bus.publish(
+                    Message(
+                        type=MessageType.TICK,
+                        timestamp=datetime.now(timezone.utc),
+                        data=dict(canonical_tick),
+                        source="data_hub",
                     )
-                except Exception as exc:
-                    LOGGER.error(
-                        "Failure in DataHub.ingest_tick: %s", exc, exc_info=exc
-                    )
-            else:
-                LOGGER.debug(
-                    "DataHub has no event_bus — tick cached without bus publish"
                 )
+            except Exception as exc:
+                LOGGER.error("Failure in DataHub.ingest_tick: %s", exc, exc_info=True)
+        else:
+            LOGGER.debug("DataHub has no event_bus — tick cached without bus publish")
 
-            # 4. Notify Legacy Subscribers (Backward Compatibility)
-            if normalized_symbol in self._tick_subscribers:
-                for callback in list(self._tick_subscribers[normalized_symbol]):
-                    try:
-                        callback(dict(canonical_tick))
-                    except Exception as exc:
-                        # This is likely where the "Tick callback failed" log comes from
-                        LOGGER.error(
-                            f"Tick subscriber failed for {symbol}: {exc}",
-                            exc_info=True,  # Prints full traceback to help debug
-                        )
+        # 4. Notify Legacy Subscribers (outside lock)
+        with self._lock:
+            callbacks = list(self._tick_subscribers.get(normalized_symbol, ()))
+
+        for callback in callbacks:
+            try:
+                callback(dict(canonical_tick))
+            except Exception as exc:
+                LOGGER.error("Tick subscriber failed: %s", exc, exc_info=True)
 
     def store_quote(
         self,


### PR DESCRIPTION
### Motivation
- Live ticks delivered from KiteConnect OS threads were calling `asyncio.get_running_loop()` and dropping ticks due to `RuntimeError`, starving StrategyRunner; awaiting the message bus while holding `DataHub`'s lock also created a deadlock risk.

### Description
- In `src/nifty_scalper_bot/data/data_hub.py` add `self._main_loop`, a `set_event_loop()` hook, and replace `ingest_tick_sync()` to schedule ingestion via `loop.call_soon_threadsafe(loop.create_task, ...)` to safely bridge OS threads to the main asyncio loop.
- Refactor `DataHub.ingest_tick()` to update the cache and metrics while holding the lock, then publish to the async `MessageBus` and invoke legacy tick subscribers outside the lock to avoid `await` inside a lock and eliminate deadlocks.
- In `src/nifty_scalper_bot/core/app.py` during async startup wire the running loop into `DataHub` with `data_hub.set_event_loop(asyncio.get_running_loop())` and conditionally call `market_data_manager.set_event_loop(loop)` when present so thread callbacks can schedule safely.

### Testing
- Ran the project checks with `./run_checks.sh`, which executed but surfaced pre-existing repository-wide Ruff/mypy findings and a pytest configuration argument issue that are unrelated to this fix. 
- Verified syntax/compile sanity with `python -m py_compile src/nifty_scalper_bot/data/data_hub.py src/nifty_scalper_bot/core/app.py` which succeeded. 
- Executed focused unit tests with `pytest -q tests/data/test_data_hub.py --disable-warnings` and observed all tests in that module pass (16 passed). 
- Performed local lint/type/test iterations to ensure no new runtime regressions were introduced in the modified paths.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a39db08fc832480f0815c70b83e64)