### PR TITLE
fix: register symbols before websocket connect and add safe resubscribe

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -5717,6 +5717,7 @@ async def startup_sequence(ctx: BotContext) -> None:
             LOGGER.info(f"🔧 Processing {len(targets)} symbols for wiring...")
             resolved_count = 0
             unresolved_symbols = []
+            live_mode_enabled = bool(ctx.settings.enable_live)
 
             for sym in targets:
                 if mdm:
@@ -5725,7 +5726,11 @@ async def startup_sequence(ctx: BotContext) -> None:
                 tok = None
                 if ctx.instrument_resolver:
                     tok = ctx.instrument_resolver.resolve(sym)
+                    if tok is None and live_mode_enabled:
+                        raise RuntimeError(f"Live mode: Missing token for {sym}")
                     if tok:
+                        if mdm:
+                            mdm.register_symbol(sym, tok)
                         tokens_to_poll.append(tok)
                         resolved_count += 1
                         LOGGER.info(f"✅ Resolved: {sym} -> token {tok}")
@@ -5813,12 +5818,22 @@ async def startup_sequence(ctx: BotContext) -> None:
                                 if ctx.instrument_resolver
                                 else None
                             )
+                            if tok is None and live_mode_enabled:
+                                raise RuntimeError(f"Live mode: Missing token for {sym}")
+                            if tok and ctx.market_data_manager:
+                                ctx.market_data_manager.register_symbol(sym, tok)
                             if (
                                 tok
                                 and ctx.streamer
                                 and hasattr(ctx.streamer, "subscribe")
                             ):
                                 ctx.streamer.subscribe([tok])
+                            if (
+                                tok
+                                and ctx.websocket_manager is not None
+                                and ctx.websocket_manager.is_connected()
+                            ):
+                                ctx.websocket_manager.resubscribe([tok])
                             if ctx.strategy_runner:
                                 ctx.strategy_runner.add_symbol(sym)
 

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -2498,6 +2498,19 @@ class MarketDataManager:
             self._token_by_symbol[symbol] = token_int
             self._symbol_by_token[token_int] = symbol
 
+    def register_symbol(self, symbol: str, token: int) -> None:
+        """Args: symbol/token; Returns: none; Raises: RuntimeError on bad data."""
+
+        normalized_symbol = enforce_canonical(normalize_symbol(str(symbol or "")))
+        if normalized_symbol.count(":") != 1:
+            raise RuntimeError(f"Malformed canonical symbol: {normalized_symbol}")
+        token_int = int(token)
+        with self._lock:
+            if self._token_by_symbol.get(normalized_symbol) == token_int:
+                return
+            self._token_by_symbol[normalized_symbol] = token_int
+            self._symbol_by_token[token_int] = normalized_symbol
+
     def _store_tick(self, symbol: str, tick: dict[str, Any]) -> None:
         """Persist normalized *tick* for *symbol* and refresh derived series."""
 

--- a/src/nifty_scalper_bot/streaming/websocket_manager.py
+++ b/src/nifty_scalper_bot/streaming/websocket_manager.py
@@ -3,12 +3,12 @@
 from __future__ import annotations
 
 import asyncio
+import random
+import time
 from collections.abc import Awaitable, Callable, Coroutine, Sequence
 from dataclasses import dataclass
 from datetime import time as dtime
 from enum import Enum
-import random
-import time
 from typing import Any
 from zoneinfo import ZoneInfo
 
@@ -270,6 +270,25 @@ class WebSocketManager:
 
         self._merge_tokens(tokens)
         self._schedule_async(self._resubscribe_if_connected())
+
+    def resubscribe(self, tokens: list[int]) -> None:
+        """Args: tokens; Returns: none; Raises: none."""
+
+        try:
+            if not tokens:
+                return
+            unique_tokens = sorted({int(token) for token in tokens})
+            if not unique_tokens:
+                return
+            self._merge_tokens(unique_tokens)
+            ticker = self._ticker
+            if ticker is None or not self._connected.is_set():
+                return
+            ticker.subscribe(unique_tokens)
+            ticker.set_mode(ticker.MODE_FULL, unique_tokens)
+            self._logger.info("WebSocket resubscribed to %d tokens", len(unique_tokens))
+        except Exception as e:
+            self._logger.error("WebSocket resubscribe failed: %s", e, exc_info=True)
 
     def unsubscribe_tokens(self, tokens: Sequence[int]) -> None:
         """Args: tokens; Returns: none; Raises: none."""
@@ -603,6 +622,16 @@ class WebSocketManager:
                 ws.set_mode(ws.MODE_FULL, token_list)
                 self._logger.info(
                     "WebSocket subscribed to %d tokens", len(self._tokens)
+                )
+                symbol_map = getattr(
+                    getattr(self, "_market_data_manager", None),
+                    "_symbol_by_token",
+                    {},
+                )
+                self._logger.info(
+                    "WebSocket subscribed tokens=%d symbols=%d",
+                    len(self._tokens),
+                    len(symbol_map),
                 )
             if self._on_connect_callback is not None:
                 self._on_connect_callback()

--- a/tests/websocket/test_ws_resilience.py
+++ b/tests/websocket/test_ws_resilience.py
@@ -66,3 +66,30 @@ async def test_single_reconnect_task_is_scheduled(
         assert manager._ticker is not None
     finally:
         await manager.disconnect()
+
+
+def test_resubscribe_adds_and_subscribes_unique_tokens(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(ws_module, "KiteTicker", FakeKiteTicker)
+
+    subscribed: list[list[int]] = []
+    modes: list[tuple[str, list[int]]] = []
+
+    class RecordingTicker(FakeKiteTicker):
+        def subscribe(self, tokens: list[int]) -> None:
+            subscribed.append(tokens)
+
+        def set_mode(self, mode: str, tokens: list[int]) -> None:
+            modes.append((mode, tokens))
+
+    manager = ws_module.WebSocketManager("k", "t", trading_window_enabled=False)
+    ticker = RecordingTicker("k", "t", reconnect=False)
+    manager._ticker = ticker
+    manager._connected.set()
+
+    manager.resubscribe([12, 13, 12])
+
+    assert manager._tokens == {12, 13}
+    assert subscribed == [[12, 13]]
+    assert modes == [(ticker.MODE_FULL, [12, 13])]


### PR DESCRIPTION
### Motivation

- Dynamic option symbols were sometimes resolved after the WebSocket connected, causing missing token registrations and options not receiving ticks.
- The WebSocket needed a safe, non-blocking way to add subscriptions when new tokens are registered at runtime.
- In LIVE mode, missing instrument tokens must be treated as fatal to avoid trading on incomplete data.

### Description

- Ensure tokens are registered into the market data manager before the streamer subscribes by registering resolved tokens during startup wiring in `src/nifty_scalper_bot/core/app.py` and failing fast in LIVE mode when a token is missing.
- Add `MarketDataManager.register_symbol(symbol, token)` to atomically populate `_token_by_symbol` and `_symbol_by_token` under the existing lock in `src/nifty_scalper_bot/data/market_data_manager.py`.
- Add `WebSocketManager.resubscribe(tokens: list[int]) -> None` in `src/nifty_scalper_bot/streaming/websocket_manager.py` to safely merge, deduplicate and subscribe new tokens when the WS is already connected, without restarting the connection.
- On WS connect, log deterministic subscription verification with both token and symbol counts for observability in `websocket_manager._on_connect()`.
- Wire dynamic option-universe additions so that newly added symbols are registered with `MarketDataManager.register_symbol(...)`, the streamer is subscribed, and `WebSocketManager.resubscribe(...)` is invoked only when already connected, avoiding duplicate subscriptions or restart.
- Add a unit test that verifies `resubscribe()` deduplicates tokens and calls `subscribe`/`set_mode` as expected (tests updated in `tests/websocket/test_ws_resilience.py`).

### Testing

- Ran `./run_checks.sh` (attempted); it did not complete green in this environment because the repository baseline contains widespread mypy/type issues unrelated to this patch, so full `run_checks.sh` returned non‑zero due to existing baseline failures. (This is a baseline repo problem and not caused by these specific changes.)
- Executed the targeted WebSocket unit file: `pytest -q tests/websocket/test_ws_resilience.py` — passed (all tests in that file green).
- Ran `ruff` auto-fix for the edited `websocket_manager.py` and then `ruff check` on the changed files — fixed/clean for the modified websocket file and test file.

Files changed: `src/nifty_scalper_bot/core/app.py`, `src/nifty_scalper_bot/data/market_data_manager.py`, `src/nifty_scalper_bot/streaming/websocket_manager.py`, `tests/websocket/test_ws_resilience.py`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d291f09dc8324bdb51f92b888361d)