### PR TITLE
fix: harden startup hydration and balance gating

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -5464,7 +5464,9 @@ async def startup_sequence(ctx: BotContext) -> None:
 
                 # Format expiry code (Zerodha convention)
                 if _is_monthly:
-                    _date_code = _next_expiry.strftime("%y%b").upper()  # "26FEB"
+                    expiry_code = _next_expiry.strftime("%y%b").upper()
+                    assert len(expiry_code) == 5, "Invalid expiry format"
+                    _date_code = expiry_code  # "26FEB"
                 else:
                     _y = _next_expiry.strftime("%y")  # "26"
                     _d = _next_expiry.strftime("%d")  # "11"
@@ -5473,12 +5475,13 @@ async def startup_sequence(ctx: BotContext) -> None:
                         _next_expiry.month, str(_next_expiry.month)
                     )  # "2" for Feb
                     _date_code = f"{_y}{_m}{_d}"  # "26211" for Feb 11, 2026
+                    expiry_code = _date_code
 
                 # Use current ATM strike (approximate)
                 _atm_strike = 25600  # Default; ideally get from live NIFTY price
 
                 # Generate dynamic test symbol
-                test_sym = f"NFO:NIFTY{_date_code}{_atm_strike}CE"
+                test_sym = f"NFO:NIFTY{expiry_code}{_atm_strike}CE"
                 LOGGER.info(
                     f"📝 Testing dynamic NFO symbol: {test_sym} (Expiry: {_next_expiry})"
                 )
@@ -5654,6 +5657,17 @@ async def startup_sequence(ctx: BotContext) -> None:
 
                     await asyncio.sleep(HYDRATION_DELAY_SEC)
 
+            if get_settings().enable_live and ctx.market_data_manager is not None:
+                failed = [
+                    s
+                    for s, status in ctx.market_data_manager._hydration_status.items()
+                    if str(status).strip().lower() not in {"hydrated", "ready"}
+                ]
+                if failed:
+                    raise RuntimeError(
+                        f"Startup hydration incomplete for symbols: {failed}"
+                    )
+
             # =========================================================
             # ✅ WORLD CLASS FIX: FINALIZE RUNNER STATE
             # =========================================================
@@ -5751,6 +5765,11 @@ async def startup_sequence(ctx: BotContext) -> None:
                         f"🔴 UNRESOLVED SYMBOLS (will NOT be polled): {unresolved_symbols}"
                     )
             LOGGER.info(f"✅ tokens_to_poll has {len(tokens_to_poll)} tokens")
+            LOGGER.info(
+                "WS_SUBSCRIPTION_SUMMARY tokens=%d symbols=%d",
+                len(tokens_to_poll),
+                len(getattr(mdm, "_symbol_by_token", {})) if mdm is not None else 0,
+            )
             subscribed_symbols = sorted({sym for sym in targets})
             LOGGER.critical(
                 "📊 STRATEGY SUBSCRIBED SYMBOLS: %s",

--- a/src/nifty_scalper_bot/data/instruments.py
+++ b/src/nifty_scalper_bot/data/instruments.py
@@ -392,10 +392,12 @@ class InstrumentResolver:
         with self._lock:
             self._neg_cache[key] = now_ts + self._neg_ttl
             self._warned_no_token.add(key.split(":", 1)[-1])
-        LOGGER.warning("instrument_resolver_no_token", extra={"event": "instrument_resolver_no_token", "symbol": key})
-        if os.getenv("ENABLE_LIVE", "false").strip().lower() == "true":
-            raise RuntimeError(
-                f"InstrumentResolver: No token found for symbol {symbol}"
+        if token is None:
+            if get_settings().enable_live:
+                raise RuntimeError(f"Missing instrument token for {symbol}")
+            LOGGER.warning(
+                "instrument_resolver_no_token",
+                extra={"event": "instrument_resolver_no_token", "symbol": key},
             )
         return None
 

--- a/src/nifty_scalper_bot/risk/risk_manager.py
+++ b/src/nifty_scalper_bot/risk/risk_manager.py
@@ -176,6 +176,7 @@ class RiskManager:
         self._lot_size_lookup = None
         self._lot_size_symbol = None
         self._cached_balance = float(self.account_balance)
+        self._available_balance = float(self._cached_balance)
         self._last_balance_refresh = 0.0
         refresh_interval = max(
             5.0,
@@ -219,6 +220,14 @@ class RiskManager:
     def balance_source_label(self) -> str:
         """Return label describing the origin of the cached balance."""
         return self._balance_source
+
+    @property
+    def available_balance(self) -> float:
+        """Args: none. Returns: available balance snapshot. Raises: None."""
+        try:
+            return float(getattr(self, "_available_balance", 0.0) or 0.0)
+        except Exception:
+            return 0.0
 
     def set_broker_client(self, broker_client: Any | None) -> None:
         """Attach the broker client used for ancillary integrations."""
@@ -307,6 +316,7 @@ class RiskManager:
                 fallback_balance = self._resolve_env_balance_fallback()
             self.account_balance = float(fallback_balance)
             self._cached_balance = self.account_balance
+            self._available_balance = float(self._cached_balance)
             self._last_balance_refresh = now
             self._balance_source = "cache" if fallback_balance > 0 else "env"
             self._notify_unified_manager(
@@ -324,6 +334,7 @@ class RiskManager:
             if balance is not None and balance > 0:
                 self.account_balance = float(balance)
                 self._cached_balance = self.account_balance
+                self._available_balance = float(self._cached_balance)
                 self._last_balance_refresh = now
                 self._balance_source = "live"
                 # [FIX] Log only once every 60s
@@ -347,6 +358,7 @@ class RiskManager:
             if cached_balance_value is not None and cached_balance_value > 0:
                 self.account_balance = cached_balance_value
                 self._cached_balance = cached_balance_value
+                self._available_balance = float(self._cached_balance)
                 self._last_balance_refresh = now
                 self._balance_source = "cache"
                 self._notify_unified_manager(
@@ -377,6 +389,7 @@ class RiskManager:
 
             self.account_balance = float(fallback_value)
             self._cached_balance = self.account_balance
+            self._available_balance = float(self._cached_balance)
             self._last_balance_refresh = now
             self._balance_source = "env"
             self._notify_unified_manager(self.account_balance, source="env")
@@ -386,6 +399,7 @@ class RiskManager:
         if fallback_balance <= 0:
             fallback_balance = self._resolve_env_balance_fallback()
             self._cached_balance = float(fallback_balance)
+            self._available_balance = float(self._cached_balance)
             self.account_balance = float(fallback_balance)
             self._balance_source = "env"
         else:

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -3092,7 +3092,7 @@ class StrategyRunner:
                     if cooldown_until and now_ts < cooldown_until:
                         cooldown_ok = False
                         break
-            capital_ok = bool(self._risk_manager.available_balance() > 0.0)
+            capital_ok = bool(self._risk_manager.available_balance > 0.0)
             self._logger.debug(
                 "EVAL_GATE_STATUS",
                 extra={
@@ -3874,7 +3874,11 @@ class StrategyRunner:
                             self._logger.warning("Stale tick — skipping execution")
                             return
                         self._last_global_eval_ts = time.monotonic()
-                        signal = self._strategy_manager.generate_signal(symbol, price)
+                        try:
+                            signal = self._strategy_manager.generate_signal(symbol, price)
+                        except Exception:
+                            self._logger.exception("Signal evaluation failure")
+                            signal = None
                         if signal is not None:
                             self._signal_counter += 1
                             self._logger.info(
@@ -4894,7 +4898,7 @@ class StrategyRunner:
                         extra={
                             "event": "qty_zero",
                             "symbol": trade_symbol,
-                            "available_balance": self._risk_manager.available_balance(),
+                            "available_balance": self._risk_manager.available_balance,
                         },
                     )
                     self._qty_zero_log_ts[trade_symbol] = now_mono


### PR DESCRIPTION
### Motivation
- Prevent startup from proceeding in live mode with incomplete market-data hydration and guard dynamic symbol construction against malformed monthly expiry encodings.
- Ensure missing instrument tokens escalate in live mode but remain non-fatal in non-live/testing runs.
- Stabilize risk/runner interactions by providing a consistent `available_balance` surface and avoid tick-path crashes when signal evaluation fails.

### Description
- In `core/app.py` introduced `expiry_code` validation for monthly expiries and used it for dynamic NFO test symbol generation, added a live-mode hydration gate that raises if any symbol's hydration status is not `hydrated`/`ready`, and added a `WS_SUBSCRIPTION_SUMMARY` log for tokens vs tracked symbols.
- In `data/instruments.py` changed the negative-resolution path to raise `RuntimeError` when a token is missing and `get_settings().enable_live` is true, and otherwise log a warning in non-live mode.
- In `risk/risk_manager.py` added `_available_balance` sync points and an `@property available_balance` to expose a stable snapshot, and updated all refresh/fallback code paths to update `_available_balance` consistently.
- In `strategies/runner.py` switched usages to the new `available_balance` property (non-callable) and wrapped `generate_signal` calls in a guarded `try/except` to log exceptions and avoid crashing tick handling.

### Testing
- Ran `bash ./run_checks.sh` (project-level checks); result: failed due to pre-existing repository-wide lint/type/test configuration issues (many Ruff/mypy findings and pytest config/import errors) that are unrelated to this PR change.
- Verified syntax/compilation with `python -m py_compile` for the modified modules: `src/nifty_scalper_bot/core/app.py`, `src/nifty_scalper_bot/data/instruments.py`, `src/nifty_scalper_bot/risk/risk_manager.py`, and `src/nifty_scalper_bot/strategies/runner.py` (succeeded).
- Ran targeted `pytest` invocations: full test run initially failed on baseline import issues (`tests/strategies/test_elite_strategies.py`), and a focused subset (`tests/test_startup_sequence.py`, `tests/data/test_instrument_resolver.py`, `tests/strategies/test_runner_execution_gates.py`) exposed an existing `BotContext` fixture mismatch; these are baseline test-suite issues rather than regressions from this change.
- Notes: CI-style checks (`ruff`, `mypy`, and full `pytest`) report many existing issues across the repository; this PR confines changes to startup hydration, instrument resolution, risk balance exposure, and runner signal guarding and does not introduce new external dependencies or alter public APIs beyond adding a read-only `available_balance` property.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d7033c0e48324a148ba81629806bc)