### PR TITLE
fix: initialize RiskManager available balance for production startup

### DIFF
--- a/src/nifty_scalper_bot/risk/risk_manager.py
+++ b/src/nifty_scalper_bot/risk/risk_manager.py
@@ -119,6 +119,7 @@ class RiskManager:
     _broker_client: Any | None = field(init=False, repr=False, default=None)
     _data_hub: "DataHub | None" = field(init=False, repr=False, default=None)
     _cached_balance: float = field(init=False, repr=False, default=0.0)
+    _available_balance: float = field(init=False, repr=False, default=0.0)
     _last_balance_refresh: float = field(init=False, repr=False, default=0.0)
     _balance_cache_ttl: float = field(init=False, repr=False, default=60.0)
     _balance_force_refresh: float = field(init=False, repr=False, default=0.0)

--- a/tests/test_risk_manager_new.py
+++ b/tests/test_risk_manager_new.py
@@ -77,6 +77,15 @@ def test_risk_manager_cooldown_after_rejection() -> None:
     assert risk.cooldown_remaining() > 0.0
 
 
+def test_risk_manager_exposes_available_balance_on_init() -> None:
+    settings = RiskSettings(per_trade_risk_pct=1.0)
+    pm = DummyPositionManager(realized=0.0)
+
+    risk = _make_risk_manager(settings=settings, pm=pm, balance=12_345.0)
+
+    assert risk.available_balance == 12_345.0
+
+
 def test_suggest_position_size_returns_lot_multiple() -> None:
     settings = RiskSettings(per_trade_risk_pct=1.0)
     pm = DummyPositionManager(realized=0.0)


### PR DESCRIPTION
### Motivation
- Prevent a production startup crash where `RiskManager.__post_init__` assigns to `_available_balance` before the attribute exists under `@dataclass(slots=True)`, which raised `AttributeError` and put the bot into degraded mode.

### Description
- Declare `_available_balance: float` as an `init=False` dataclass field in `RiskManager` and add a regression test `test_risk_manager_exposes_available_balance_on_init` to ensure a fresh `RiskManager` exposes `available_balance` immediately.

### Testing
- Ran `PYTHONPATH=src pytest -q tests/test_risk_manager_new.py -k available_balance --disable-warnings`, and the new test passed.
- Performed a startup smoke `PYTHONPATH=src .venv/bin/python -c 'from nifty_scalper_bot.config.settings import RiskSettings; from nifty_scalper_bot.risk.risk_manager import RiskManager; ...'` which printed the expected `available_balance` and did not raise the prior `AttributeError`.
- Executed `bash ./run_checks.sh` and full `pytest` suite; both surfaced pre-existing repository-wide lint/type/import failures unrelated to this change (these failures pre-existed and were not introduced by this PR).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d75e7ee5c8324ba6aae04e11d3e12)