### PR TITLE
fix: remap unresolved NIFTY option symbols during hydration

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -13,7 +13,7 @@ import asyncio  # Required for startup reconciliation and background tasks
 from collections import OrderedDict
 from contextlib import suppress
 from dataclasses import asdict, dataclass, field, replace
-from datetime import datetime, time, timedelta, timezone
+from datetime import date, datetime, time, timedelta, timezone
 from importlib import import_module
 import inspect
 import logging
@@ -2253,6 +2253,99 @@ def _get_symbols(
 
     universe.update_underlying(float(ltp))
     final_symbols = universe.get_filtered_universe(float(ltp))
+
+    def _coerce_expiry_date(expiry_raw: Any) -> date | None:
+        """Parse resolver expiry payload. Args: expiry_raw. Returns: expiry date or None. Raises: None."""
+        try:
+            if expiry_raw is None:
+                return None
+            if isinstance(expiry_raw, datetime):
+                return expiry_raw.date()
+            if isinstance(expiry_raw, date):
+                return expiry_raw
+            value = str(expiry_raw).strip()
+            if not value:
+                return None
+            if "T" in value:
+                value = value.split("T", 1)[0]
+            return date.fromisoformat(value)
+        except Exception as exc:
+            LOGGER.error("Failure in _coerce_expiry_date: %s", exc)
+            return None
+
+    def _resolve_hydration_symbol(symbol: str) -> str:
+        """Resolve symbol to a hydrated token-backed contract. Args: symbol. Returns: tradable symbol. Raises: None."""
+        normalized_symbol = str(symbol or "").strip().upper()
+        if not normalized_symbol or resolver is None:
+            return normalized_symbol
+        try:
+            if resolver.resolve(normalized_symbol):
+                return normalized_symbol
+        except Exception as exc:
+            LOGGER.error("Failure in _resolve_hydration_symbol: %s", exc)
+
+        try:
+            base_symbol = normalized_symbol.split(":", 1)[-1]
+            if not base_symbol.startswith("NIFTY"):
+                return normalized_symbol
+            option_type = "CE" if base_symbol.endswith("CE") else "PE"
+            strike_text = base_symbol[:-2]
+            strike_digits = "".join(ch for ch in strike_text if ch.isdigit())
+            if not strike_digits:
+                return normalized_symbol
+            requested_strike = int(strike_digits[-5:])
+            contracts = resolver.option_contracts("NIFTY")
+            if not contracts:
+                return normalized_symbol
+
+            today = datetime.now().date()
+            eligible: list[tuple[int, date, str]] = []
+            for contract in contracts:
+                contract_symbol = (
+                    str(contract.get("tradingsymbol") or "").strip().upper()
+                )
+                if not contract_symbol.endswith(option_type):
+                    continue
+                contract_strike_raw = contract.get("strike")
+                if contract_strike_raw in (None, ""):
+                    continue
+                try:
+                    contract_strike = int(round(float(contract_strike_raw)))
+                except (TypeError, ValueError):
+                    continue
+                expiry_date = _coerce_expiry_date(contract.get("expiry"))
+                if expiry_date is None or expiry_date < today:
+                    continue
+                eligible.append((contract_strike, expiry_date, contract_symbol))
+
+            if not eligible:
+                return normalized_symbol
+
+            eligible.sort(
+                key=lambda item: (
+                    abs(item[0] - requested_strike),
+                    abs((item[1] - today).days),
+                    item[2],
+                )
+            )
+            remapped = f"NFO:{eligible[0][2]}"
+            if resolver.resolve(remapped):
+                LOGGER.warning(
+                    "option_symbol_hydration_remapped",
+                    extra={
+                        "event": "option_symbol_hydration_remapped",
+                        "requested": normalized_symbol,
+                        "resolved": remapped,
+                    },
+                )
+                return remapped
+            return normalized_symbol
+        except Exception as exc:
+            LOGGER.error("Failure in _resolve_hydration_symbol: %s", exc)
+            return normalized_symbol
+
+    final_symbols = [_resolve_hydration_symbol(sym) for sym in final_symbols]
+    final_symbols = list(dict.fromkeys(sym for sym in final_symbols if sym))
     LOGGER.debug("OptionUniv: Universe refreshed -> %s", final_symbols)
 
     if _LATEST_CTX:

--- a/tests/test_app_symbol_resolution.py
+++ b/tests/test_app_symbol_resolution.py
@@ -11,17 +11,37 @@ class _UniverseStub:
         self.underlying = ltp
 
     def get_filtered_universe(self, _ltp: float) -> list[str]:
-        return ['NFO:NIFTY26FEB25000CE']
+        return ["NFO:NIFTY26FEB25000CE"]
 
 
 class _BrokerNoSpot:
     def ltp(self, _symbols: list[str]) -> dict[str, dict[str, float]]:
-        return {'NIFTY 50': {'last_price': 25300.0}}
+        return {"NIFTY 50": {"last_price": 25300.0}}
 
 
 class _BrokerWithSpot:
     def ltp(self, _symbols: list[str]) -> dict[str, dict[str, float]]:
-        return {'NSE:NIFTY 50': {'last_price': 25382.4}}
+        return {"NSE:NIFTY 50": {"last_price": 25382.4}}
+
+
+class _ResolverStub:
+    def resolve(self, symbol: str) -> int | None:
+        if symbol == "NFO:NIFTY26FEB25000CE":
+            return None
+        if symbol == "NFO:NIFTY26FEB25050CE":
+            return 123456
+        return None
+
+    def option_contracts(self, base: str) -> list[dict[str, object]]:
+        if base != "NIFTY":
+            return []
+        return [
+            {
+                "tradingsymbol": "NIFTY26FEB25050CE",
+                "strike": 25050.0,
+                "expiry": "2026-02-26",
+            }
+        ]
 
 
 def test_get_symbols_accepts_alternate_spot_symbol_keys() -> None:
@@ -30,7 +50,7 @@ def test_get_symbols_accepts_alternate_spot_symbol_keys() -> None:
 
     symbols = app._get_symbols(cfg, broker=_BrokerNoSpot(), option_universe=universe)
 
-    assert symbols == ['NFO:NIFTY26FEB25000CE']
+    assert symbols == ["NFO:NIFTY26FEB25000CE"]
     assert universe.underlying == 25300.0
 
 
@@ -40,5 +60,19 @@ def test_get_symbols_uses_nse_nifty_50_symbol() -> None:
 
     symbols = app._get_symbols(cfg, broker=_BrokerWithSpot(), option_universe=universe)
 
-    assert symbols == ['NFO:NIFTY26FEB25000CE']
+    assert symbols == ["NFO:NIFTY26FEB25000CE"]
     assert universe.underlying == 25382.4
+
+
+def test_get_symbols_remaps_unresolved_option_to_available_contract() -> None:
+    cfg = SimpleNamespace(symbols=None)
+    universe = _UniverseStub()
+
+    symbols = app._get_symbols(
+        cfg,
+        broker=_BrokerWithSpot(),
+        option_universe=universe,
+        resolver=_ResolverStub(),
+    )
+
+    assert symbols == ["NFO:NIFTY26FEB25050CE"]


### PR DESCRIPTION
### Motivation
- Startup hydration sometimes failed because generated NFO option symbols had no resolver token, leaving the runner unhydrated and causing repeated resolver errors.
- The bot must not skip or crash on transient/expired option symbols and should pick a deterministically available contract instead.

### Description
- Add a guarded expiry parser `_coerce_expiry_date` and a hydration remap helper `_resolve_hydration_symbol` inside `_get_symbols` to detect unresolved NIFTY option symbols and remap them to the nearest valid, non-expired contract from the resolver cache while preserving CE/PE side and closest strike/expiry.
- Re-validate remapped symbol via `resolver.resolve(...)` and log a diagnostic `option_symbol_hydration_remapped` event when remapping occurs.
- De-duplicate and filter empty entries from the final symbol list before returning to the caller.
- Add `tests/test_app_symbol_resolution.py` coverage to assert the remap behavior for unresolved option symbols.

### Testing
- Ran the focused regression test: `pytest -q tests/test_app_symbol_resolution.py` — tests passed.
- Verified syntax/compilation: `python -m py_compile src/nifty_scalper_bot/core/app.py tests/test_app_symbol_resolution.py` — OK.
- Executed repository checks: `./run_checks.sh` — this run fails due to pre-existing, repository-wide lint/type/test-tooling issues unrelated to this change (reported by Ruff/mypy/pytest in CI); these baseline failures were not introduced by this PR.
- Ran broader test command used in CI: `. .venv/bin/activate && pytest -q tests --disable-warnings --ignore=tests/test_live_mode.py --ignore=tests/test_health_server.py` — currently fails on a pre-existing import error in `tests/strategies/test_elite_strategies.py` (unrelated to the hydration remap change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699da00bfc748324a286d0189fc00c87)