### PR TITLE
fix: add deterministic startup warmup for restart continuity

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -5825,6 +5825,7 @@ async def startup_sequence(ctx: BotContext) -> None:
             resolved_count = 0
             unresolved_symbols = []
             live_mode_enabled = bool(ctx.settings.enable_live)
+            active_symbols: list[str] = []
 
             for sym in targets:
                 if mdm:
@@ -5839,6 +5840,7 @@ async def startup_sequence(ctx: BotContext) -> None:
                         if mdm:
                             mdm.register_symbol(sym, tok)
                         tokens_to_poll.append(tok)
+                        active_symbols.append(sym)
                         resolved_count += 1
                         LOGGER.info(f"✅ Resolved: {sym} -> token {tok}")
                     else:
@@ -5846,6 +5848,24 @@ async def startup_sequence(ctx: BotContext) -> None:
                         LOGGER.warning(f"⚠️ UNRESOLVED (no token): {sym}")
 
                 ctx.strategy_runner.add_symbol(sym)
+
+            if mdm and active_symbols:
+                required_candles = int(
+                    getattr(ctx.strategy_runner, "_required_candles", 0)
+                )
+                lookback_minutes = 30
+                if (
+                    live_mode_enabled
+                    and required_candles > 0
+                    and lookback_minutes < required_candles
+                ):
+                    raise RuntimeError("Warmup lookback insufficient for indicators")
+                await mdm.warmup_history(
+                    symbols=active_symbols,
+                    lookback_minutes=lookback_minutes,
+                )
+                if ctx.strategy_runner and hasattr(ctx.strategy_runner, "mark_ready"):
+                    ctx.strategy_runner.mark_ready(active_symbols)
 
             LOGGER.info(
                 f"📊 Resolution summary: {resolved_count}/{len(targets)} resolved"

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -177,6 +177,7 @@ class MarketDataManager:
         MarketDataManager constructor.
         """
         self._broker = broker
+        self._rest_client = broker
         self._websocket = websocket
         # FIX: Explicitly assign self._ws for internal use
         self._ws = websocket
@@ -2485,7 +2486,8 @@ class MarketDataManager:
             self._logger.debug(f"TICK_RATE_15S {summary}")
             self._tick_stats.clear()
             self._last_tick_stats_log = now
-        self._emit_tick(symbol, normalized_tick, source="ws")
+        tick_source = str(tick.get("source", "ws") or "ws").lower()
+        self._emit_tick(symbol, normalized_tick, source=tick_source)
 
     def _seed_mapping(self, symbol: str, token: int | None) -> None:
         if token is None:
@@ -2553,6 +2555,8 @@ class MarketDataManager:
     def _emit_tick(self, symbol: str, tick: dict[str, Any], *, source: str) -> None:
         source = str(source or "unknown").lower()
         self._store_tick(symbol, tick)
+        if source == "warmup":
+            return
         callbacks: list[TickCallback]
         tick_payload = dict(tick)
         with self._lock:
@@ -2608,6 +2612,83 @@ class MarketDataManager:
                 self._logger.error(
                     "Tick callback failed", extra={"symbol": symbol, "error": str(exc)}
                 )
+
+    async def warmup_history(
+        self,
+        symbols: list[str],
+        lookback_minutes: int = 30,
+    ) -> None:
+        """Warm caches from minute candles; Args: symbols/lookback; Returns: None; Raises: RuntimeError."""
+
+        try:
+            end_time = datetime.now(timezone.utc)
+            start_time = end_time - timedelta(minutes=lookback_minutes)
+
+            self._logger.info(
+                "WARMUP_START symbols=%d lookback=%dmin",
+                len(symbols),
+                lookback_minutes,
+            )
+
+            rest_client = self._rest_client
+            fetcher = getattr(rest_client, "get_historical_data", None)
+            if not callable(fetcher):
+                fetcher = getattr(rest_client, "historical_data", None)
+            if not callable(fetcher):
+                raise RuntimeError("WARMUP failed: historical data client unavailable")
+
+            for symbol in symbols:
+                canonical_symbol = enforce_canonical(normalize_symbol(str(symbol)))
+                token = self._token_by_symbol.get(canonical_symbol)
+                if not token:
+                    raise RuntimeError(
+                        f"WARMUP failed: missing token for {canonical_symbol}"
+                    )
+
+                if asyncio.iscoroutinefunction(fetcher):
+                    candles = await fetcher(
+                        instrument_token=token,
+                        from_date=start_time,
+                        to_date=end_time,
+                        interval="minute",
+                    )
+                else:
+                    candles = await asyncio.to_thread(
+                        fetcher,
+                        token,
+                        start_time,
+                        end_time,
+                        "minute",
+                    )
+
+                for candle in candles or ():
+                    candle_dt = candle.get("date")
+                    if isinstance(candle_dt, str):
+                        try:
+                            candle_dt = datetime.fromisoformat(
+                                candle_dt.replace("Z", "+00:00")
+                            )
+                        except ValueError:
+                            continue
+                    if not isinstance(candle_dt, datetime):
+                        continue
+                    if candle_dt.tzinfo is None:
+                        candle_dt = candle_dt.replace(tzinfo=timezone.utc)
+
+                    synthetic_tick = {
+                        "instrument_token": token,
+                        "symbol": symbol,
+                        "last_price": float(candle.get("close", 0.0)),
+                        "volume": candle.get("volume", 0),
+                        "timestamp": float(candle_dt.timestamp()),
+                        "source": "warmup",
+                    }
+                    self._handle_tick(synthetic_tick)
+
+            self._logger.info("WARMUP_COMPLETE")
+        except Exception as e:
+            self._logger.error("Failure in warmup_history: %s", e)
+            raise
 
     def _is_ws_connected(self) -> bool:
         """Args: none; Returns: websocket connectivity; Raises: none."""

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -3328,6 +3328,8 @@ class StrategyRunner:
                 completed_bar = builder.update(float(price), volume, timestamp)
                 if completed_bar is not None:
                     self._ingest_bar(symbol, completed_bar)
+                else:
+                    return
             except ValueError as exc:
                 if getattr(builder, "_last_error_ts", 0) < now.timestamp() - 60:
                     self._logger.warning(f"Bar update issue for {symbol}: {exc}")

--- a/tests/data/test_market_data_manager.py
+++ b/tests/data/test_market_data_manager.py
@@ -417,3 +417,40 @@ def test_zombie_restart_circuit_opens_after_failed_reconnects(
     manager._trigger_zombie_ws_restart()
 
     assert manager._zombie_breaker_open_until == 162.0
+
+
+@pytest.mark.asyncio
+async def test_warmup_history_primes_cache_without_emitting_callbacks(
+    broker: DummyBroker, ws: DummyWebSocket
+) -> None:
+    manager = MarketDataManager(broker, ws)
+    manager.register_symbol('NSE:NIFTY23', 123)
+
+    events: list[dict[str, Any]] = []
+    manager.subscribe('NSE:NIFTY23', events.append)
+
+    class RestStub:
+        async def get_historical_data(self, **kwargs: Any) -> list[dict[str, Any]]:
+            return [
+                {
+                    'date': datetime(2024, 1, 1, 10, 0, tzinfo=timezone.utc),
+                    'close': 101.0,
+                    'volume': 50,
+                },
+                {
+                    'date': datetime(2024, 1, 1, 10, 1, tzinfo=timezone.utc),
+                    'close': 102.0,
+                    'volume': 80,
+                },
+            ]
+
+    manager._rest_client = RestStub()
+
+    await manager.warmup_history(['NSE:NIFTY23'], lookback_minutes=30)
+
+    assert events == []
+    latest = manager.get_latest_tick('NSE:NIFTY23')
+    assert latest is not None
+    assert latest['ltp'] == pytest.approx(102.0)
+    bars = manager.get_ohlc_bars('NSE:NIFTY23')
+    assert bars


### PR DESCRIPTION
### Motivation
- Ensure deterministic startup by hydrating indicator and OHLC state from historical minute candles before live websocket processing begins.
- Prevent strategy evaluation on partial bars or synthetic hydration ticks and avoid side-effects from warmup replay to subscriber callbacks.
- Improve restart continuity so strategies mark symbols ready only after required warmup is complete.

### Description
- Wire startup warmup in `startup_sequence` to collect resolved `active_symbols`, validate `lookback_minutes` against `ctx.strategy_runner._required_candles` in live mode, call `await mdm.warmup_history(...)`, and then invoke `ctx.strategy_runner.mark_ready(...)` for those symbols.
- Add `MarketDataManager._rest_client` and implement `async def warmup_history(self, symbols: list[str], lookback_minutes: int = 30) -> None` to fetch minute candles from a REST client, synthesize ticks and replay them through the existing normalization/store/ohlc pipeline, and log `WARMUP_START`/`WARMUP_COMPLETE` lifecycle events.
- Propagate tick `source` from `_handle_tick` into `_emit_tick` and make `_emit_tick` persist/store warmup-seeded ticks while suppressing callback fan-out when `source == "warmup"` to avoid subscriber side-effects during hydration.
- Add a closed-bar guard in strategy tick handling (`StrategyRunner`) to return early unless a one-minute bar completes, preventing evaluation on partial candles.
- Add regression test `test_warmup_history_primes_cache_without_emitting_callbacks` to verify warmup primes internal latest tick and OHLC state without invoking subscriber callbacks.

### Testing
- Ran `bash ./run_checks.sh` (environment note: executing `./run_checks.sh` initially produced `Permission denied`; running with `bash` performed dependency installs then reported baseline gate about `pytest` availability). 
- Installed test deps and ran `pytest -q tests/data/test_market_data_manager.py tests/bot/test_strategy_runner.py`, which passed (test suite for modified areas succeeded).
- Verified syntax by running `python -m py_compile` on modified modules which succeeded.
- Ran lint/type checks: `ruff` and `mypy` report pre-existing baseline issues in the repository unrelated to these changes, so they remain in repository baseline and were not introduced by this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e626230948324b7a1221ed9d78f17)