### PR TITLE
fix: resolver-driven NIFTY option contract selection in _get_symbols

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -2254,98 +2254,38 @@ def _get_symbols(
     universe.update_underlying(float(ltp))
     final_symbols = universe.get_filtered_universe(float(ltp))
 
-    def _coerce_expiry_date(expiry_raw: Any) -> date | None:
-        """Parse resolver expiry payload. Args: expiry_raw. Returns: expiry date or None. Raises: None."""
-        try:
-            if expiry_raw is None:
-                return None
-            if isinstance(expiry_raw, datetime):
-                return expiry_raw.date()
-            if isinstance(expiry_raw, date):
-                return expiry_raw
-            value = str(expiry_raw).strip()
-            if not value:
-                return None
-            if "T" in value:
-                value = value.split("T", 1)[0]
-            return date.fromisoformat(value)
-        except Exception as exc:
-            LOGGER.error("Failure in _coerce_expiry_date: %s", exc)
-            return None
+    if resolver is None:
+        LOGGER.error("Strategy skipped — instrument resolver unavailable")
+        return []
 
-    def _resolve_hydration_symbol(symbol: str) -> str:
-        """Resolve symbol to a hydrated token-backed contract. Args: symbol. Returns: tradable symbol. Raises: None."""
-        normalized_symbol = str(symbol or "").strip().upper()
-        if not normalized_symbol or resolver is None:
-            return normalized_symbol
-        try:
-            if resolver.resolve(normalized_symbol):
-                return normalized_symbol
-        except Exception as exc:
-            LOGGER.error("Failure in _resolve_hydration_symbol: %s", exc)
+    contracts = resolver.get_option_contracts(underlying="NIFTY")
+    today = datetime.now().date()
+    valid_contracts = [c for c in contracts if c.expiry >= today]
+    if not valid_contracts:
+        raise RuntimeError("No valid option contracts resolved. Check instrument dump.")
 
-        try:
-            base_symbol = normalized_symbol.split(":", 1)[-1]
-            if not base_symbol.startswith("NIFTY"):
-                return normalized_symbol
-            option_type = "CE" if base_symbol.endswith("CE") else "PE"
-            strike_text = base_symbol[:-2]
-            strike_digits = "".join(ch for ch in strike_text if ch.isdigit())
-            if not strike_digits:
-                return normalized_symbol
-            requested_strike = int(strike_digits[-5:])
-            contracts = resolver.option_contracts("NIFTY")
-            if not contracts:
-                return normalized_symbol
+    nearest_expiry = min(c.expiry for c in valid_contracts)
+    filtered = [c for c in valid_contracts if c.expiry == nearest_expiry]
+    unique_strikes = sorted({c.strike for c in filtered})
+    if len(unique_strikes) < 2:
+        raise RuntimeError("No valid option contracts resolved. Check instrument dump.")
+    strike_step = unique_strikes[1] - unique_strikes[0]
+    if strike_step <= 0:
+        raise RuntimeError("No valid option contracts resolved. Check instrument dump.")
 
-            today = datetime.now().date()
-            eligible: list[tuple[int, date, str]] = []
-            for contract in contracts:
-                contract_symbol = (
-                    str(contract.get("tradingsymbol") or "").strip().upper()
-                )
-                if not contract_symbol.endswith(option_type):
-                    continue
-                contract_strike_raw = contract.get("strike")
-                if contract_strike_raw in (None, ""):
-                    continue
-                try:
-                    contract_strike = int(round(float(contract_strike_raw)))
-                except (TypeError, ValueError):
-                    continue
-                expiry_date = _coerce_expiry_date(contract.get("expiry"))
-                if expiry_date is None or expiry_date < today:
-                    continue
-                eligible.append((contract_strike, expiry_date, contract_symbol))
-
-            if not eligible:
-                return normalized_symbol
-
-            eligible.sort(
-                key=lambda item: (
-                    abs(item[0] - requested_strike),
-                    abs((item[1] - today).days),
-                    item[2],
-                )
-            )
-            remapped = f"NFO:{eligible[0][2]}"
-            if resolver.resolve(remapped):
-                LOGGER.warning(
-                    "option_symbol_hydration_remapped",
-                    extra={
-                        "event": "option_symbol_hydration_remapped",
-                        "requested": normalized_symbol,
-                        "resolved": remapped,
-                    },
-                )
-                return remapped
-            return normalized_symbol
-        except Exception as exc:
-            LOGGER.error("Failure in _resolve_hydration_symbol: %s", exc)
-            return normalized_symbol
-
-    final_symbols = [_resolve_hydration_symbol(sym) for sym in final_symbols]
+    atm = round(ltp / strike_step) * strike_step
+    selected = [c for c in filtered if abs(c.strike - atm) <= 200]
+    final_symbols = [c.tradingsymbol for c in selected]
     final_symbols = list(dict.fromkeys(sym for sym in final_symbols if sym))
+
+    if not final_symbols:
+        raise RuntimeError("No valid option contracts resolved. Check instrument dump.")
+
+    LOGGER.info(
+        "RESOLVED_CONTRACTS count=%d expiry=%s",
+        len(final_symbols),
+        nearest_expiry,
+    )
     LOGGER.debug("OptionUniv: Universe refreshed -> %s", final_symbols)
 
     if _LATEST_CTX:

--- a/src/nifty_scalper_bot/data/instruments.py
+++ b/src/nifty_scalper_bot/data/instruments.py
@@ -90,6 +90,15 @@ class Instrument:
     raw: Optional[Mapping[str, Any]] = None
 
 
+@dataclass(frozen=True, slots=True)
+class OptionContract:
+    """Resolved option contract model. Args: tradingsymbol, expiry, strike. Returns: OptionContract. Raises: None."""
+
+    tradingsymbol: str
+    expiry: date
+    strike: float
+
+
 class BrokerError(Exception):
     """Generic broker/resolver error sentinel."""
 
@@ -820,6 +829,59 @@ class InstrumentResolver:
             lst = list(self._option_contracts.get(key) or [])
         # return shallow copy to avoid accidental external mutation
         return [dict(item) for item in lst]
+
+    def get_option_contracts(self, underlying: str) -> List[OptionContract]:
+        """Return normalized option contracts. Args: underlying. Returns: OptionContract list. Raises: None."""
+        try:
+            contracts = self.option_contracts(underlying)
+            normalized: list[OptionContract] = []
+            for contract in contracts:
+                tradingsymbol = str(contract.get("tradingsymbol") or "").strip().upper()
+                if not tradingsymbol:
+                    continue
+                expiry_raw = contract.get("expiry")
+                expiry_value: date | None = None
+                if isinstance(expiry_raw, datetime):
+                    expiry_value = expiry_raw.date()
+                elif isinstance(expiry_raw, date):
+                    expiry_value = expiry_raw
+                elif expiry_raw:
+                    text = str(expiry_raw).strip()
+                    if "T" in text:
+                        text = text.split("T", 1)[0]
+                    try:
+                        expiry_value = date.fromisoformat(text)
+                    except ValueError:
+                        expiry_value = None
+                strike_raw = contract.get("strike")
+                if expiry_value is None or strike_raw in (None, ""):
+                    continue
+                try:
+                    strike = float(strike_raw)
+                except (TypeError, ValueError):
+                    continue
+                normalized.append(
+                    OptionContract(
+                        tradingsymbol=tradingsymbol,
+                        expiry=expiry_value,
+                        strike=strike,
+                    )
+                )
+            return normalized
+        except Exception as exc:
+            LOGGER.error("Failure in get_option_contracts: %s", exc)
+            return []
+
+    def get_token(self, symbol: str | int | None) -> Optional[int]:
+        """Return token for symbol. Args: symbol. Returns: token or None. Raises: RuntimeError."""
+        token = self.resolve(symbol)
+        if not token:
+            if get_settings().enable_live:
+                raise RuntimeError(
+                    f"Resolver failed: {symbol} not found in instrument dump"
+                )
+            return None
+        return token
 
     def sync_nfo_from_broker(self, instruments: list) -> int:
         """


### PR DESCRIPTION
### Motivation
- Manual construction and fallback remapping of option tradingsymbols caused invalid symbols and intermittent "Missing instrument token" errors in production.
- The goal is to ensure all tradable option symbols come from the instrument dump (resolver) and to fail fast in LIVE when a token is missing.

### Description
- Replaced the manual expiry/strike string construction and hydration-remap path inside `_get_symbols()` with resolver-driven selection using `resolver.get_option_contracts(underlying="NIFTY")` and removed the `_resolve_hydration_symbol` fallback.
- Added a typed `OptionContract` dataclass and `InstrumentResolver.get_option_contracts()` to return normalized contracts (`tradingsymbol`, `expiry`, `strike`) derived from the loaded instrument dump.
- Implemented `InstrumentResolver.get_token()` to hard-fail in LIVE mode by raising `RuntimeError("Resolver failed: {symbol} not found in instrument dump")` when a token is missing, and otherwise return tokens as before.
- In `_get_symbols()` the code now: infers `nearest_expiry` from non-expired contracts, computes `strike_step` from unique strikes (no hardcoded 50), computes ATM via rounding, selects contracts within ±200 of ATM, builds final symbol list from `tradingsymbol`, logs `RESOLVED_CONTRACTS`, and raises `RuntimeError` if no symbols resolved.

### Testing
- Ran `./run_checks.sh` which created the `.venv` and installed dependencies but the script reported the environment/toolchain variations (Ruff/mypy skipped or not installed) and failed at the `pytest` step in this workspace (tool provisioning issue); the command output is included in the run logs.
- Executed `python -m py_compile src/nifty_scalper_bot/core/app.py src/nifty_scalper_bot/data/instruments.py` which succeeded for the modified files.
- Ran an ad-hoc verification that the manual-format patterns were removed from `_get_symbols()` (search for `strftime("%y%m%d")`, `strftime("%y%m")`, `NFO:NIFTY{expiry}{strike}{opt_type}`, and `option_symbol_hydration_remapped`) which returned not found in the modified `_get_symbols()` region.
- Ran `pytest` after installing `pytest` which failed during test collection due to a pre-existing unrelated test import error (`tests/strategies/test_elite_strategies.py`), not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e67e7d8b883249eca6cfc42656e07)