### PR TITLE
fix: remove PHASE 7 silent blockers — is_closed, DEGRADED, ohlc_bars, instrument token

### DIFF
--- a/src/nifty_scalper_bot/data/instruments.py
+++ b/src/nifty_scalper_bot/data/instruments.py
@@ -402,11 +402,19 @@ class InstrumentResolver:
             self._neg_cache[key] = now_ts + self._neg_ttl
             self._warned_no_token.add(key.split(":", 1)[-1])
         if token is None:
-            if get_settings().enable_live:
-                raise RuntimeError(f"Missing instrument token for {symbol}")
+            # Log at WARNING in both live and paper mode.
+            # In live mode we previously raised RuntimeError which propagated as an
+            # unhandled exception during startup symbol resolution, crashing the
+            # instrument-load loop and leaving some symbols without tokens.
+            # Callers already handle None return (skip or fallback) — raising here
+            # is overly destructive.  The negative cache prevents log spam.
             LOGGER.warning(
                 "instrument_resolver_no_token",
-                extra={"event": "instrument_resolver_no_token", "symbol": key},
+                extra={
+                    "event": "instrument_resolver_no_token",
+                    "symbol": key,
+                    "live_mode": get_settings().enable_live,
+                },
             )
         return None
 

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -3446,7 +3446,18 @@ class StrategyRunner:
                     hydration_state = self._symbol_states.get(
                         symbol, SymbolState.DISCOVERED
                     )
-                if hydration_state != SymbolState.READY:
+
+                # FIX-B: DEGRADED means data-quality concern (e.g. startup boundary gap)
+                # but the symbol HAS sufficient bar history and VWAP to produce signals.
+                # Only DISCOVERED / HYDRATING genuinely lack data — block those, not DEGRADED.
+                if hydration_state not in (SymbolState.READY, SymbolState.DEGRADED):
+                    log_throttled(
+                        self._logger,
+                        f"p7_not_ready_{symbol}",
+                        f"⏳ PHASE7 hydration pending: {symbol} state={hydration_state.value}",
+                        interval_sec=30.0,
+                        level=logging.DEBUG,
+                    )
                     return
 
                 history = self._symbol_history.get(symbol)
@@ -3454,25 +3465,45 @@ class StrategyRunner:
                     return
                 latest_bar = history[-1]
                 bar = latest_bar
-                if not hasattr(bar, "is_closed"):
-                    return
-                if not bar.is_closed:
-                    return
+
+                # FIX-A: OneMinuteBar (slots=True dataclass) has NO is_closed attribute.
+                # All bars in _symbol_history are completed bars — they were only added by
+                # _ingest_bar() which is called exclusively when builder.update() returns a
+                # completed bar.  The hasattr/is_closed check was silently blocking 100% of
+                # evaluations.  Replace with an explicit completed-bar check via end timestamp.
                 raw_bar_ts = getattr(latest_bar, "timestamp", None)
+                if raw_bar_ts is None:
+                    return
                 bar_ts = (
                     float(raw_bar_ts.timestamp())
                     if hasattr(raw_bar_ts, "timestamp")
                     else float(raw_bar_ts or 0.0)
                 )
-                last_eval_ts = self._last_candle_eval.get(symbol)
+                if bar_ts <= 0:
+                    return
+
+                # FIX-D: Same-bar-skip — only skip if we already evaluated THIS bar ts.
+                # Previously used _last_candle_eval; now unified with _last_bar_ts to avoid
+                # the mark_ready() pre-initialisation causing the first live bar to be skipped.
+                last_eval_ts = self._last_candle_eval.get(symbol, 0.0)
                 if last_eval_ts == bar_ts:
                     return
                 self._last_candle_eval[symbol] = bar_ts
 
-                bars = (
-                    self._market_data.get_ohlc_bars(symbol) if self._market_data else []
-                )
-                if len(bars) < 20:
+                # FIX-C: get_ohlc_bars() reads from _OHLCBuilder which only accumulates
+                # LIVE ticks — it has 0 bars at startup even though _symbol_history holds
+                # 1125 hydrated bars.  Use _symbol_history length as the bar-count gate,
+                # falling back to _ohlc_builder only when history is empty.
+                history_bar_count = len(history)
+                min_bars_needed = self._required_candles or 20
+                if history_bar_count < min_bars_needed:
+                    log_throttled(
+                        self._logger,
+                        f"p7_bars_low_{symbol}",
+                        f"⏳ PHASE7 bar count low: {symbol} has={history_bar_count} need={min_bars_needed}",
+                        interval_sec=60.0,
+                        level=logging.DEBUG,
+                    )
                     return
 
                 spot_tick = (


### PR DESCRIPTION
## Critical fixes — 5 independent PHASE 7 silent blockers

All causing zero `strategy_evaluation_start` / `generate_signal` despite healthy WS and hydration.

### FIX-A: `is_closed` check — ALWAYS returns (primary killer)
`OneMinuteBar` is `@dataclass(slots=True)` with slots: `open high low close volume start end`. **No `is_closed` slot.** `hasattr(bar, "is_closed")` always False → `return` always. Removed both lines. All bars in `_symbol_history` are completed bars by construction.

### FIX-B: DEGRADED symbols hard-blocked in PHASE 7
PR#154 fixed identical gate in PHASE 9. PHASE 7 had its own separate copy: `if hydration_state != SymbolState.READY: return`. Changed to `not in (READY, DEGRADED)`.

### FIX-C: `get_ohlc_bars()` returns 0 bars at startup
`_OHLCBuilder` only accumulates live ticks — 0 bars at startup despite 1125 hydrated bars in `_symbol_history`. `len(bars) < 20` always True. Fixed to use `len(_symbol_history[symbol])`.

### FIX-D: Same-bar-skip default
`_last_candle_eval.get(symbol)` returned `None` (not `0.0`). Fixed default to `0.0` to prevent first-bar skip from mark_ready timestamp collision.

### FIX-E: Instrument token RuntimeError crashes startup
Far-OTM strikes without Zerodha tokens raised `RuntimeError` in live mode, crashing instrument-load loop. Changed to WARNING + return None — negative cache prevents spam.