### PR TITLE
fix: harden orphan adoption and ATR compatibility

### DIFF
--- a/src/nifty_scalper_bot/execution/bracket_manager.py
+++ b/src/nifty_scalper_bot/execution/bracket_manager.py
@@ -256,6 +256,8 @@ class BracketManager:
         self._trailing_controllers: Dict[str, Any] = {}
         self._recent_ticks: Dict[str, deque] = {}
         self._max_tick_history = 20
+        self._orphan_retry_count: Dict[str, int] = {}
+        self._orphan_retry_last_attempt: Dict[str, float] = {}
     
         # Real-time Data Cache (Legacy Fallback)
         self._current_atr: Dict[str, float] = {}
@@ -2124,12 +2126,26 @@ class BracketManager:
         Called by Runner when 'ORPHAN GUARD' triggers.
         """
         oid = f"orphan_{int(time.time())}_{symbol}"
-        
+        now = time.time()
+        last_attempt = self._orphan_retry_last_attempt.get(symbol)
+        if last_attempt is not None and (now - last_attempt) < 10:
+            return oid
+        if self._orphan_retry_count.get(symbol, 0) >= 3:
+            LOGGER.error("Orphan adoption disabled after max retries: %s", symbol)
+            return oid
+
         # 1. Dynamic ATR Calculation (if provider available)
         atr = entry_price * 0.01  # Default 1%
-        if self._atr_provider:
-             calc_atr = self._atr_provider.get_current_atr(symbol)
-             if calc_atr and calc_atr > 0: atr = calc_atr
+        try:
+            if self._atr_provider:
+                calc_atr = self._atr_provider.get_current_atr(symbol)
+                if calc_atr and calc_atr > 0:
+                    atr = calc_atr
+        except Exception:
+            self._orphan_retry_count[symbol] = self._orphan_retry_count.get(symbol, 0) + 1
+            self._orphan_retry_last_attempt[symbol] = now
+            LOGGER.exception("Failed orphan adoption")
+            return oid
 
         # 2. Define Rescue Levels (1.5x Risk / 3.0x Reward)
         # Handle 'BUY'/'LONG' vs 'SELL'/'SHORT'
@@ -2156,6 +2172,8 @@ class BracketManager:
             activate_immediately=True  # 🟢 Critical: It's already live
         )
         
+        self._orphan_retry_count.pop(symbol, None)
+        self._orphan_retry_last_attempt.pop(symbol, None)
         LOGGER.warning(
             f"🧯 ORPHAN ATTACHED: {symbol} | Entry={entry_price:.2f} | "
             f"SL={sl:.2f} | TP={tp:.2f} | ID={oid}"

--- a/src/nifty_scalper_bot/execution/order_manager.py
+++ b/src/nifty_scalper_bot/execution/order_manager.py
@@ -10070,7 +10070,10 @@ class OrderManager:
             self._logger.warning(f"Subscription attempt warning: {e}")
 
         # --- STEP 1: Determine Valid Base Price ---
-        base_price = float(average_price)
+        try:
+            base_price = float(average_price)
+        except (TypeError, ValueError):
+            base_price = 0.0
         current_ltp = 0.0
 
         # Try to get fresh LTP from Cache (might be empty if cold start)
@@ -10080,17 +10083,16 @@ class OrderManager:
                 current_ltp = float(quote.get("last_price") or quote.get("ltp") or 0.0)
 
         # Use LTP if base_price is invalid (0.0)
-        if base_price <= 0:
+        if not base_price or base_price <= 0:
             if current_ltp > 0:
                 base_price = current_ltp
                 self._logger.warning(f"⚠️ Using LTP {base_price} for guard (Broker avg_price was 0)")
-            else:
-                # [FIX] Return False gracefully, but we are now SUBSCRIBED.
-                # The next reconciliation loop will succeed.
-                self._logger.warning(
-                    f"⏳ Cannot guard {symbol} yet: Waiting for Tick/LTP (tracking ensured)"
-                )
-                return False
+            if not base_price:
+                try:
+                    raise ValueError("Cannot determine entry price")
+                except ValueError as exc:
+                    self._logger.error("Failure in guard_orphan_position: %s", exc)
+                    return False
 
         # --- STEP 2: Fix Accounting ---
         if not consume_existing:

--- a/src/nifty_scalper_bot/indicators/atr_provider.py
+++ b/src/nifty_scalper_bot/indicators/atr_provider.py
@@ -114,15 +114,28 @@ class SafeATRProvider:
                         closes = hist.get_closes(1)
                         if closes and closes[0] > 0:
                             estimated = closes[0] * 0.015  # 1.5% of price
-                            return ATRSnapshot(
-                                value=estimated,
-                                timestamp=time(),
-                                source='estimated',
-                            )
+                            if estimated > 0 and math.isfinite(estimated):
+                                return ATRSnapshot(
+                                    value=estimated,
+                                    timestamp=time(),
+                                    source='estimated',
+                                )
                 except Exception:
                     pass
-                
-                return None
+
+                # 5. Final non-None fallback to keep risk guards operational
+                return ATRSnapshot(
+                    value=5.0,
+                    timestamp=time(),
+                    source='hardcoded_fallback',
+                )
+
+    def get_current_atr(self, symbol: str) -> float:
+        """Args: symbol. Returns: current ATR value. Raises: None."""
+        snapshot = self.get_atr(symbol)
+        if snapshot and snapshot.value > 0:
+            return float(snapshot.value)
+        return 5.0
 
     def _resolve_underlying_symbol(self, symbol: str) -> str:
         """Args: symbol. Returns: Underlying symbol. Raises: None."""

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -554,6 +554,8 @@ class StrategyRunner:
         self._session_gap_count: dict[str, int] = {}
         self._runner_state: RunnerState = RunnerState.STARTING
         self._active_orphan_guards: set[str] = set()
+        self._orphan_retry_count: dict[str, int] = {}
+        self._orphan_retry_last_attempt: dict[str, float] = {}
         self._signals_last_hour: Deque[float] = deque(maxlen=1000)
         self._last_signal_frequency_check_ts: float = 0.0
         self._last_eval_queue_log_ts: float = 0.0
@@ -594,7 +596,10 @@ class StrategyRunner:
             # mark_ready() → EXECUTION_ENABLED, then calls start() seconds later.
             # Without this guard start() resets the state to HISTORICAL_READY and the
             # bot never trades — "Execution blocked: HISTORICAL_READY" in every tick.
-            if self._runner_state != RunnerState.EXECUTION_ENABLED:
+            if self._runner_state in (
+                RunnerState.STARTING,
+                RunnerState.BOOTING,
+            ):
                 self._runner_state = RunnerState.HISTORICAL_READY
             self._history_ready_by_symbol = {symbol: False for symbol in symbols}
             for symbol in symbols:
@@ -4409,6 +4414,18 @@ class StrategyRunner:
                 if self._bracket_manager.is_symbol_managed(symbol):
                     continue  # Already protected, skip
 
+                now = time.time()
+                if symbol in self._orphan_retry_last_attempt:
+                    if now - self._orphan_retry_last_attempt[symbol] < 10:
+                        self._active_orphan_guards.discard(symbol)
+                        continue
+                if self._orphan_retry_count.get(symbol, 0) >= 3:
+                    self._logger.error(
+                        "Orphan adoption disabled after max retries: %s", symbol
+                    )
+                    self._active_orphan_guards.discard(symbol)
+                    continue
+
                 # 3. Log the adoption
                 self._logger.warning(
                     f"🔧 AUTO-ADOPTING ORPHAN: {symbol} ({side}) | "
@@ -4422,6 +4439,8 @@ class StrategyRunner:
                     bracket_id = self._bracket_manager.attach_orphan_position(
                         symbol=symbol, side=side, qty=qty, entry_price=entry
                     )
+                    self._orphan_retry_count.pop(symbol, None)
+                    self._orphan_retry_last_attempt.pop(symbol, None)
                     adopted_count += 1
                     self._logger.info(
                         f"✅ Orphan protected: {symbol} | Bracket={bracket_id}"
@@ -4433,8 +4452,10 @@ class StrategyRunner:
                     except (AttributeError, TypeError):
                         pass  # Position might be frozen/immutable
 
-                except Exception as e:
-                    self._logger.error(f"❌ Failed to adopt orphan {symbol}: {e}")
+                except Exception:
+                    self._orphan_retry_count[symbol] = self._orphan_retry_count.get(symbol, 0) + 1
+                    self._orphan_retry_last_attempt[symbol] = now
+                    self._logger.exception("Failed orphan adoption")
                 finally:
                     self._active_orphan_guards.discard(symbol)
 


### PR DESCRIPTION
### Motivation
- Prevent runtime AttributeError from `SafeATRProvider` because callers expect `get_current_atr` while only `get_atr` existed.  
- Stop tight infinite retry/log spam when auto-adopting orphaned broker positions by throttling retries and capping attempts.  
- Prevent StrategyRunner from regressing execution state back to `HISTORICAL_READY` after it has already been promoted to execution-ready.  
- Ensure orphan-guard logic never proceeds with an invalid entry price (broker `avg_price = 0`) and ensure ATR guard never returns `None` so protection logic is always supplied a numeric ATR.

### Description
- `src/nifty_scalper_bot/indicators/atr_provider.py`: strengthened `get_atr()` fallback behavior to always return a usable `ATRSnapshot` (final hard fallback `5.0`) and added a compatibility shim `get_current_atr(symbol)` returning a float to satisfy callers that expect the older API; preserved original logic and added safe checks for finiteness.  
- `src/nifty_scalper_bot/execution/bracket_manager.py`: added per-symbol orphan retry state (`_orphan_retry_count`, `_orphan_retry_last_attempt`), enforced a 10s cooldown and a max 3 retry cap before disabling adoption attempts for that symbol, wrapped ATR provider calls with exception handling to bump retry counters on errors, and reset counters on successful attach.  
- `src/nifty_scalper_bot/strategies/runner.py`: prevented state regression in `start()` by transitioning to `HISTORICAL_READY` only when current state is `STARTING` or `BOOTING`; added the same orphan adoption retry/cooldown checks to the runner's auto-adopt loop to avoid tight retry loops and updated logging/exception handling.  
- `src/nifty_scalper_bot/execution/order_manager.py`: hardened `guard_orphan_position()` base-price resolution by safely coercing `average_price`, falling back to cached LTP, and failing gracefully with an error log when no valid entry price can be determined to avoid creating unsafe virtual guards.  

### Testing
- Ran a repository sanity/CI flow: `bash ./run_checks.sh`; this showed pre-existing repository-wide `ruff`/`mypy` and `pytest-cov` configuration issues (these are unrelated to the localized fixes), so `run_checks.sh` did not fully pass.  
- Verified compilation: ran `.venv/bin/python -m compileall` against the four modified modules and compilation succeeded.  
- Executed targeted unit tests: `.venv/bin/pytest -q -o addopts='' tests/execution/test_bracket_manager.py tests/bot/test_strategy_runner.py` which passed (12 passed, 1 warning).  
- Ran linter on modified files as part of checks; `ruff` surfaced pre-existing style/line-length findings across the repo but did not indicate runtime regressions for the applied changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7ec3270f88324baaac45503cbd18b)