### PR TITLE
fix: run telegram polling via async manual update loop (FastAPI/uvicorn compatible)

### DIFF
--- a/src/nifty_scalper_bot/notifications/telegram_controller.py
+++ b/src/nifty_scalper_bot/notifications/telegram_controller.py
@@ -117,7 +117,6 @@ from telegram.ext import (
     MessageHandler,
     filters,
 )
-from telegram.request import HTTPXRequest  # ✅ NEW IMPORT
 
 F = t.TypeVar("F", bound=t.Callable[..., t.Any])
 
@@ -601,27 +600,17 @@ class TelegramBot:
                 ("logs", self.cmd_tail),
                 ("test_trade", self.cmd_test_trade),
                 ("engine_test", self.cmd_engine_test),
+                ("ping", self.cmd_ping),
             )
             for cmd, handler in command_handlers:
                 if not self._command_registered(self._app, cmd):
                     self._app.add_handler(CommandHandler(cmd, handler))
 
             await self._app.initialize()
-            if not self._app.running:
-                await self._app.start()
-
+            await self._app.start()
             await self._app.bot.delete_webhook(drop_pending_updates=True)
-            try:
-                self._polling_task = asyncio.create_task(
-                    self._app.run_polling(
-                        allowed_updates=Update.ALL_TYPES,
-                        drop_pending_updates=True,
-                    )
-                )
-            except Exception as exc:  # noqa: BLE001
-                log.error("Telegram polling failed: %s", exc, exc_info=True)
-                raise
-            log.info("Telegram polling started successfully")
+            self._start_manual_polling_loop()
+            log.info("Telegram polling loop starting")
             self._ensure_alert_worker()
 
         except Exception as exc:  # noqa: BLE001
@@ -631,49 +620,24 @@ class TelegramBot:
         """
         Starts polling with explicit initialization to fix RuntimeError.
         """
-        if not self.deps.enable_polling_fallback:
+        if not self.deps.enable_polling_fallback or self._app is None:
             return
-        if self._app is None or self._app.updater is None:
-            return
-        
-        # GUARD: Stop if already running
-        if self._app.updater.running:
-            return
-
         try:
-            self._mark_polling_started()
-            
-            # ✅ FIX 1: Explicit Cool-down
-            await asyncio.sleep(2.0)
-            
-            log.info("📡 Starting Telegram Polling (Background)...")
+            await self._app.bot.delete_webhook(drop_pending_updates=True)
+        except Exception as exc:  # noqa: BLE001
+            log.error("Failure in _start_polling_if_needed: %s", exc)
+        self._start_manual_polling_loop()
 
-            # ✅ FIX 2: Clear Webhook safely
-            try:
-                await self._app.bot.delete_webhook(drop_pending_updates=True)
-            except Exception:
-                pass
+    def _start_manual_polling_loop(self) -> None:
+        """Start async update polling loop. Args: none. Returns: None. Raises: None."""
 
-            # ✅ FIX 3: Initialize the Updater explicitly
-            # This fixes 'RuntimeError: This Updater was not initialized via Updater.initialize!'
-            if not self._app.updater._initialized:
-                 await self._app.updater.initialize()
-
-            # ✅ FIX 4: Start Polling
-            await self._app.updater.start_polling(
-                drop_pending_updates=True,
-                allowed_updates=Update.ALL_TYPES,
-                poll_interval=2.0
-            )
-            
-            log.info("✅ Telegram Polling Active.")
-
-        except Exception as exc:
-            import traceback
-            log.error(f"❌ Polling CRASH: {exc}")
-            log.error(traceback.format_exc())
-            self._metrics.polling_errors += 1
-            self._mark_polling_stopped()
+        if self._polling_task is not None and not self._polling_task.done():
+            return
+        self._mark_polling_started()
+        self._polling_task = asyncio.create_task(
+            self._polling_loop(),
+            name="telegram-manual-polling",
+        )
 
   
     def _command_registered(self, app: Application, command: str) -> bool:
@@ -886,7 +850,13 @@ class TelegramBot:
         chat_id = int(chat.id)
         user_id = int(user.id) if user else "Unknown"
         username = user.username if user else "Unknown"
-        
+        log.info(
+            "Telegram message from chat_id=%s user=%s text=%s",
+            chat_id,
+            username,
+            text,
+        )
+
         # 1. Resolve Allowed ID (Primary Owner)
         allowed_primary = int(self.deps.chat_id)
         
@@ -3858,12 +3828,6 @@ class TelegramBot:
                 return
             if self._app is None:
                 return
-            updater = self._app.updater
-            if updater is None:
-                log.error(
-                    "PTB updater is not available; cannot start polling fallback."
-                )
-                return
             if self._webhook_server is not None:
                 await self._webhook_server.stop()
                 self._webhook_server = None
@@ -3873,32 +3837,33 @@ class TelegramBot:
             self._mark_polling_started()
             log.error("Telegram switching to polling fallback (%s)", reason)
             try:
-                self._polling_task = asyncio.create_task(
-                    self._polling_loop(updater),
-                    name="telegram-polling-fallback",
-                )
+                self._start_manual_polling_loop()
             except Exception as exc:  # pragma: no cover - defensive
                 self._mark_polling_stopped()
                 log.exception("Failed to spawn polling fallback task: %s", exc)
 
-    async def _polling_loop(self, updater: t.Any) -> None:
+    async def _polling_loop(self) -> None:
         """Run polling loop with backoff handling."""
 
         task = asyncio.current_task()
         try:
             log.warning("Telegram polling fallback active.")
+            offset: int | None = None
             while True:
                 if self._shutdown_event is not None and self._shutdown_event.is_set():
                     break
                 try:
-                    await updater.start_polling(
+                    if self._app is None:
+                        break
+                    updates = await self._app.bot.get_updates(
+                        offset=offset,
                         allowed_updates=Update.ALL_TYPES,
                         timeout=30,
-                        drop_pending_updates=False,
                     )
-                    if self._shutdown_event is not None:
-                        await self._shutdown_event.wait()
-                    break
+                    for update in updates:
+                        log.info("Telegram update received: %s", update)
+                        offset = update.update_id + 1
+                        await self._app.process_update(update)
                 except RetryAfter as exc:
                     self._metrics.polling_errors += 1
                     delay = float(
@@ -3913,11 +3878,8 @@ class TelegramBot:
                     await asyncio.sleep(self.deps.polling_interval_seconds)
                 except Exception as exc:  # pragma: no cover - defensive logging
                     self._metrics.polling_errors += 1
-                    log.exception("Telegram polling error: %s", exc)
-                    await asyncio.sleep(self.deps.polling_interval_seconds)
-                finally:
-                    with suppress(Exception):
-                        await updater.stop()
+                    log.error("Telegram polling error: %s", exc)
+                    await asyncio.sleep(2)
         except asyncio.CancelledError:
             raise
         finally:
@@ -4008,10 +3970,6 @@ class TelegramBot:
                 extra={"telegram_metrics": self._metrics.snapshot()},
             )
             return
-        updater = self._app.updater
-        if updater is not None:
-            with suppress(Exception):
-                await updater.stop()
         with suppress(Exception):
             await self._app.bot.delete_webhook(drop_pending_updates=True)
         with suppress(Exception):
@@ -15655,31 +15613,23 @@ class TelegramWebhookServer:
         return self._app
 
     async def start(self) -> None:
-        """Start the bot polling loop properly."""
-        if self._running:
+        """Start webhook HTTP server."""
+
+        if self._task is not None and not self._task.done():
             return
-
-        LOGGER.info("Starting Telegram Controller...")
         try:
-            # 1. Initialize & Start App
-            if not self.application.running:
-                await self.application.initialize()
-                await self.application.start()
-
-            # 2. FORCE START POLLING (Critical Fix)
-            # This ensures the bot actually listens to /commands
-            if self.application.updater:
-                await self.application.updater.start_polling(allowed_updates=Update.ALL_TYPES)
-                LOGGER.info("✅ Telegram Polling Started Successfully")
-            else:
-                LOGGER.error("❌ Telegram Updater missing! Commands will not work.")
-
-            # 3. Register Menu
-            await self._set_commands()
-            self._running = True
-            
-        except Exception as e:
-            LOGGER.error(f"Failed to start Telegram Controller: {e}", exc_info=True)
+            config = uvicorn.Config(
+                self._app,
+                host=self._host,
+                port=self._port,
+                log_level="warning",
+                access_log=False,
+            )
+            self._server = uvicorn.Server(config)
+            self._task = asyncio.create_task(self._server.serve())
+        except Exception as exc:
+            log.error("Failure in TelegramWebhookServer.start: %s", exc)
+            raise RuntimeError("Failed to start Telegram webhook server") from exc
 
     async def stop(self) -> None:
         if self._server is None:


### PR DESCRIPTION
### Motivation
- The Telegram controller mixed `initialize()`/`start()` with `run_polling()` which prevents the dispatcher from receiving updates under python-telegram-bot v20 when hosted inside an async framework such as FastAPI + uvicorn.
- The app must use a non-blocking polling approach compatible with the existing async runtime rather than the deprecated Updater-based polling APIs.

### Description
- Replaced blocking/updater-based polling paths with a manual async polling loop that calls `bot.get_updates(...)` and dispatches each update via `Application.process_update(...)`, launched as a background task (`_start_manual_polling_loop` / `_polling_loop`).
- Removed references to `self._app.updater`, `updater.start_polling` and `updater.stop`, and replaced the webhook server startup to run via `uvicorn.Server(config).serve()` rather than attempting updater-based polling.
- Added per-update debug logging (`log.info("Telegram update received: %s", update)`) and enhanced guard logging to emit `chat_id`, `user`, and `text` to help diagnose blocked commands.
- Ensured `/ping` handler is explicitly registered at startup so the minimal health command is available and will reply `pong` when allowed by the guard.

### Testing
- Attempted `./run_checks.sh` (executed as `bash ./run_checks.sh` in this environment) which ran dependency installation and checks but did not complete cleanly due to repository baseline/tooling/environment mismatches (environment Python 3.10.19 vs expected 3.11+, and pre-existing mypy/type errors across unrelated files); the script output shows these failures and is included in CI logs.
- Ran `ruff` against the modified file to surface style problems and fixed an unused import; remaining E501 long-line findings are pre-existing style issues in the file and were not introduced by this change.
- Verified the modified module compiles with `python -m py_compile src/nifty_scalper_bot/notifications/telegram_controller.py` (succeeded).
- Ran targeted test attempts with `pytest -k telegram` which failed collection due to unrelated test environment/import issues (`ModuleNotFoundError: No module named 'market_data_manager'`), and `mypy` run against the file showed two attribute name warnings that reflect existing naming expectations; these failures are unrelated to the new polling loop.

Notes: The change is limited to the Telegram controller and webhook server code paths only and does not alter any trading logic or core execution components; existing repository-wide type/lint/test issues remain and should be addressed separately to get a fully green `./run_checks.sh` run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8a07d8b6c832487a4bc2b983b2b23)