### PR TITLE
fix: stabilize VWAP fallback and hydration gating

### DIFF
--- a/src/nifty_scalper_bot/data/data_hub.py
+++ b/src/nifty_scalper_bot/data/data_hub.py
@@ -34,6 +34,58 @@ OrderListener = Callable[[dict[str, Any]], None]
 TickListener = Callable[[dict[str, Any]], None]
 
 
+@dataclass(slots=True)
+class CandleBuilder:
+    """Build minute OHLCV candles from ticks. Args: none; Returns: none; Raises: none."""
+
+    current_minute: datetime | None = None
+    candle: dict[str, Any] | None = None
+
+    def update(self, tick: Mapping[str, Any]) -> dict[str, Any] | None:
+        """Update builder state with a tick. Args: tick; Returns: closed candle|None; Raises: ValueError."""
+        timestamp_raw = tick.get("timestamp")
+        if not isinstance(timestamp_raw, datetime):
+            msg = "tick.timestamp must be datetime"
+            raise ValueError(msg)
+        timestamp = timestamp_raw
+        if timestamp.tzinfo is None:
+            timestamp = timestamp.replace(tzinfo=timezone.utc)
+        minute_ts = timestamp.replace(second=0, microsecond=0)
+
+        price = float(tick.get("price") or tick.get("ltp") or tick.get("last_price") or 0.0)
+        volume = float(tick.get("volume") or 0.0)
+
+        if self.current_minute != minute_ts:
+            closed = dict(self.candle) if self.candle else None
+            self.current_minute = minute_ts
+            self.candle = {
+                "timestamp": minute_ts,
+                "open": price,
+                "high": price,
+                "low": price,
+                "close": price,
+                "volume": volume,
+            }
+            return closed
+
+        if self.candle is None:
+            self.candle = {
+                "timestamp": minute_ts,
+                "open": price,
+                "high": price,
+                "low": price,
+                "close": price,
+                "volume": volume,
+            }
+            return None
+
+        self.candle["high"] = max(float(self.candle["high"]), price)
+        self.candle["low"] = min(float(self.candle["low"]), price)
+        self.candle["close"] = price
+        self.candle["volume"] = float(self.candle["volume"]) + volume
+        return None
+
+
 class EventBus:
     """Generic in-process event bus.
 
@@ -231,6 +283,8 @@ class DataHub:
             os.getenv("HISTORY_FRESHNESS_MAX_AGE_SECONDS", "120")
         )
         self._main_loop: asyncio.AbstractEventLoop | None = None
+        self._candle_builders: dict[str, CandleBuilder] = {}
+        self.symbol_candles: dict[str, list[dict[str, Any]]] = defaultdict(list)
 
     # ----------------------------------------------------------------
     # Ingestion (Write Path)
@@ -258,6 +312,23 @@ class DataHub:
             raise RuntimeError(
                 f"Malformed canonical symbol in ingest_tick: {canonical_tick['symbol']}"
             )
+
+        try:
+            tick_dt = canonical_tick.get("timestamp")
+            if isinstance(tick_dt, (int, float)):
+                canonical_tick["timestamp"] = datetime.fromtimestamp(float(tick_dt), tz=timezone.utc)
+            elif isinstance(tick_dt, str):
+                canonical_tick["timestamp"] = datetime.fromisoformat(tick_dt.replace("Z", "+00:00"))
+            elif tick_dt is None:
+                canonical_tick["timestamp"] = datetime.now(timezone.utc)
+            if "price" not in canonical_tick:
+                canonical_tick["price"] = float(canonical_tick.get("ltp") or canonical_tick.get("last_price") or 0.0)
+            builder = self._candle_builders.setdefault(normalized_symbol, CandleBuilder())
+            closed_candle = builder.update(canonical_tick)
+            if closed_candle is not None:
+                self.symbol_candles[normalized_symbol].append(closed_candle)
+        except Exception as exc:  # noqa: BLE001
+            LOGGER.error("Failure in DataHub.ingest_tick candle_build: %s", exc, exc_info=exc)
 
         with self._lock:
             # 1. Update Cache

--- a/src/nifty_scalper_bot/options/strike_selector.py
+++ b/src/nifty_scalper_bot/options/strike_selector.py
@@ -688,7 +688,7 @@ class StrikeSelector:
             )
         step = int(getattr(self._selector_settings, "strike_step", 50) or 50)
         atm = _nearest_strike(underlying_price, step)
-        window = float(max(step, 1) * 2)
+        window = float(max(step, 1))
         active_contracts = [
             contract
             for contract in contracts

--- a/src/nifty_scalper_bot/strategies/elite_strategies/cpr_breakout.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/cpr_breakout.py
@@ -63,7 +63,8 @@ class CPRBreakoutStrategy(EliteStrategy):
             "ltp",
             "volume",
             "average_volume",
-            "atr"
+            "atr",
+            "futures_vwap",
         }
 
     def _evaluate_signal(
@@ -96,9 +97,15 @@ class CPRBreakoutStrategy(EliteStrategy):
             vol = float(indicators.get("volume") or 0.0)
             avg_vol = float(indicators.get("average_volume") or 1.0)
             atr = float(indicators.get("atr") or 0.0)
+            futures_vwap = float(
+                indicators.get("futures_vwap")
+                or indicators.get("nifty_fut_vwap")
+                or indicators.get("nifty_index_vwap")
+                or 0.0
+            )
 
             # Sanity Check
-            if pivot == 0 or tc == 0 or bc == 0:
+            if pivot == 0 or tc == 0 or bc == 0 or futures_vwap <= 0:
                 return None
 
             # 2. Update Range History (For NR7)

--- a/src/nifty_scalper_bot/strategies/elite_strategies/gamma_scalping.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/gamma_scalping.py
@@ -61,6 +61,7 @@ class GammaScalpingStrategy(EliteStrategy):
             "macd",  # Momentum Trigger
             "macd_signal",  # Signal Line
             "atr",  # Volatility for stops
+            "futures_vwap",
         }
 
     def _evaluate_signal(
@@ -87,9 +88,15 @@ class GammaScalpingStrategy(EliteStrategy):
             atr = float(indicators.get("atr") or 0.0)
             vol = float(indicators.get("volume") or 0.0)
             avg_vol = float(indicators.get("avg_volume") or 1.0)
+            futures_vwap = float(
+                indicators.get("futures_vwap")
+                or indicators.get("nifty_fut_vwap")
+                or indicators.get("nifty_index_vwap")
+                or 0.0
+            )
 
             # Sanity Checks
-            if current_price <= 0:
+            if current_price <= 0 or futures_vwap <= 0:
                 return None
 
             # 2. Logic: Gamma Filter (Acceleration)

--- a/src/nifty_scalper_bot/strategies/elite_strategies/vwap_pro.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/vwap_pro.py
@@ -94,6 +94,7 @@ class VWAPProStrategy(EliteStrategy):
         """Declare ALL indicators VWAPPro needs."""
         return {
             "vwap",
+            "futures_vwap",
             "atr",
             "volume",
             "avg_volume",
@@ -402,13 +403,13 @@ class VWAPProStrategy(EliteStrategy):
                 _emit_no_signal("cooldown_active")
                 return None
 
-            # 📊 ISSUE 1 FIX: Hard-block on missing Futures VWAP (No spot fallback)
-            # ✅ BONUS: Prefer exchange VWAP (full-session, from broker) over rolling VWAP
-            _exch_vwap = indicators.get("exchange_vwap")
-            _rolling_vwap = indicators.get("vwap")
+            # Use underlying futures VWAP for option decisions.
             vwap = float(
-                _exch_vwap or _rolling_vwap or 0.0
-            )  # ✅ Exchange > Rolling > 0
+                indicators.get("futures_vwap")
+                or indicators.get("nifty_fut_vwap")
+                or indicators.get("nifty_index_vwap")
+                or 0.0
+            )
 
             # ✅ FIX 1: Enforce minimum ATR floor.
             # Option 1-min bars produce micro-ATR (e.g. 0.24 for 828₹ option).

--- a/src/nifty_scalper_bot/strategies/indicators.py
+++ b/src/nifty_scalper_bot/strategies/indicators.py
@@ -1220,17 +1220,17 @@ class IndicatorEngine:
         try:
             if not prices or not volumes or len(prices) != len(volumes):
                 return None
-            pv = 0.0
-            vol = 0.0
+            cum_pv = 0.0
+            cum_vol = 0.0
             for price, volume in zip(prices, volumes, strict=False):
                 v = float(volume)
                 if v <= 0:
-                    continue  # Skip zero/negative volume bars instead of crashing
-                pv += float(price) * v
-                vol += v
-            if vol <= 0:
-                return None  # All-zero volume window — return None, don't crash
-            result = pv / vol
+                    v = 1.0
+                cum_pv += float(price) * v
+                cum_vol += v
+            if cum_vol <= 0:
+                return None
+            result = cum_pv / cum_vol
             if not (result > 0):  # catches NaN and negative
                 return None
             return result

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -519,9 +519,11 @@ class StrategyRunner:
         # We intentionally keep this sticky so per-symbol loops cannot spam checks/logs.
         self._risk_halt_active = False
         self._risk_halt_logged = False
+        warmup_bars = 20
         self._required_candles = max(
+            warmup_bars,
             self._config.min_indicator_bars,
-            int(os.getenv("REQUIRED_CANDLES", str(self._config.min_indicator_bars))),
+            int(os.getenv("REQUIRED_CANDLES", str(warmup_bars))),
         )
         self._max_symbol_count: int = int(os.getenv("STRATEGY_MAX_SYMBOL_COUNT", "32"))
         self._universe_controller = UniverseController()

--- a/src/nifty_scalper_bot/strategies/signal_generator.py
+++ b/src/nifty_scalper_bot/strategies/signal_generator.py
@@ -1248,6 +1248,18 @@ class StrategyManager:
         bar_count = int(float(indicators.get("bar_count", 0)))
         vix = float(indicators.get("vix") or 15.0)
         regime_factor = self._get_regime_modifier(vix)
+        vwap = float(
+            indicators.get("futures_vwap")
+            or indicators.get("nifty_fut_vwap")
+            or indicators.get("vwap")
+            or 0.0
+        )
+        logger.info(
+            "INDICATOR_STATE symbol=%s bars=%s vwap=%s",
+            symbol,
+            bar_count,
+            vwap,
+        )
 
         for strategy in self._strategies:
             try:
@@ -1849,6 +1861,7 @@ class StrategyManager:
                 indicators["nifty_fut_ltp"] = indicators["nifty_index_ltp"]
             if indicators.get("nifty_index_vwap"):
                 indicators["nifty_fut_vwap"] = indicators["nifty_index_vwap"]
+                indicators["futures_vwap"] = indicators["nifty_index_vwap"]
 
             # Log for debugging
             if indicators.get("nifty_index_ltp") or indicators.get("nifty_index_vwap"):


### PR DESCRIPTION
### Motivation
- Strategies were rejecting valid signals due to incomplete minute candles and fragile VWAP logic which produced `indicator_integrity_missing_candle`, `vwap_zero_or_invalid`, and `data_invalid` outcomes. 
- The goal is to make candle aggregation deterministic, ensure VWAP never becomes zero/None, and base option decisions on the underlying futures VWAP while limiting the evaluated option universe. 
- Also introduce pragmatic warmup gating and indicator-health logging so strategies only enable after enough valid bars.

### Description
- Add a minute `CandleBuilder` and wire tick ingestion to close and store minute OHLCV candles in `symbol_candles[symbol]` so indicators use completed bars (file: `src/nifty_scalper_bot/data/data_hub.py`).
- Harden VWAP calculation to treat non-positive bar volumes as `1` and compute `cum_pv / cum_vol` to avoid zero/None VWAP (file: `src/nifty_scalper_bot/strategies/indicators.py`).
- Change elite strategies `VWAPPro`, `GammaScalping`, and `CPRBreakout` to use underlying `futures_vwap` (`nifty_fut_vwap`/`nifty_index_vwap`) instead of option-local VWAP, and publish a `futures_vwap` alias in the indicator augmentation (files under `strategies/elite_strategies` and `strategies/signal_generator.py`).
- Reduce strike selection universe to ATM±1 by shrinking the selector ranking window to one strike step (file: `src/nifty_scalper_bot/options/strike_selector.py`).
- Enforce warmup floor of `warmup_bars = 20` before strategies are allowed to evaluate (file: `src/nifty_scalper_bot/strategies/runner.py`).
- Add an indicator health log message: `INDICATOR_STATE symbol=%s bars=%s vwap=%s` at strategy-evaluation entry for easier diagnostics (file: `src/nifty_scalper_bot/strategies/signal_generator.py`).

### Testing
- Ran `./run_checks.sh` which created the venv and installed runtime dependencies but initially exited at the pytest phase because `pytest` was not present in the environment. 
- Installed tooling with `. .venv/bin/activate && pip install pytest ruff mypy` and ran `ruff check` which reported many pre-existing style/format issues in the repo (these are repository-wide and not introduced by this patch). 
- Ran full test-suite with `pytest`; the full suite failed due to an existing test import issue (`tests/test_mdm_diagnostics.py` raised `ModuleNotFoundError: market_data_manager`) which is unrelated to the implemented fixes. 
- Executed targeted strategy tests: `. .venv/bin/activate && pytest -q tests/strategies/test_elite_strategies.py` which passed (`4 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a94068733483249d07a848dca9b4a6)