### PR TITLE
fix: harden startup gating and order arbitration

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -5978,11 +5978,13 @@ async def startup_sequence(ctx: BotContext) -> None:
 
                 if ctx.order_manager:
                     ctx.order_manager.start_monitoring()
-                if ctx.strategy_runner:
-                    instrument_cache_ready.wait()
-                    if not _data_ready(ctx.market_data_manager):
-                        LOGGER.info("waiting_for_live_ticks")
-                    ctx.strategy_runner.start()
+
+                instrument_cache_ready.wait()
+                warmup_targets = list(locals().get("targets", []) or [])
+                if ctx.data_hub and warmup_targets:
+                    for sym in warmup_targets:
+                        await ctx.data_hub.warmup_indicators(sym)
+
                 if not ctx.websocket_enabled and ctx.market_data_manager is not None:
                     ctx.market_data_manager._seed_completed = True
                 if ctx.websocket_enabled:
@@ -5997,6 +5999,11 @@ async def startup_sequence(ctx: BotContext) -> None:
                         if inspect.isawaitable(res):
                             await res
                         ctx.stream_supervisor_started = True
+
+                if ctx.strategy_runner:
+                    if not _data_ready(ctx.market_data_manager):
+                        LOGGER.info("waiting_for_live_ticks")
+                    ctx.strategy_runner.start()
 
                 if ctx.telegram_bot:
                     LOGGER.info("🚀 Starting Telegram Bot (Polling Mode)...")

--- a/src/nifty_scalper_bot/core/strategy_manager.py
+++ b/src/nifty_scalper_bot/core/strategy_manager.py
@@ -1758,6 +1758,7 @@ class StrategyManager(_BaseStrategyManager):
                     log,
                     throttle_key,
                     f"📉 NO SIGNAL | symbol={symbol} reason={reason_code}",
+                    level=10,
                     interval_sec=60.0,
                     extra=payload,
                 )

--- a/src/nifty_scalper_bot/data/data_hub.py
+++ b/src/nifty_scalper_bot/data/data_hub.py
@@ -285,6 +285,9 @@ class DataHub:
         self._main_loop: asyncio.AbstractEventLoop | None = None
         self._candle_builders: dict[str, CandleBuilder] = {}
         self.symbol_candles: dict[str, list[dict[str, Any]]] = defaultdict(list)
+        self.broker = getattr(self._mdm, "broker", None) or getattr(self._mdm, "_broker", None)
+        self.bar_aggregator = getattr(self._mdm, "bar_aggregator", None)
+        self.indicators_ready = False
 
     # ----------------------------------------------------------------
     # Ingestion (Write Path)
@@ -571,6 +574,42 @@ class DataHub:
             "source": source,
             "reason": None if is_fresh else "stale",
         }
+
+    async def warmup_indicators(
+        self, symbol: str, interval: str = "minute", bars: int = 50
+    ) -> None:
+        """Warm indicator state from broker candles. Args: symbol/interval/bars. Returns: None. Raises: None."""
+        try:
+            broker = self.broker
+            if broker is None:
+                LOGGER.warning("indicator_warmup_skipped_no_broker", extra={"symbol": symbol})
+                return
+            getter = getattr(broker, "get_historical_candles", None)
+            if not callable(getter):
+                LOGGER.warning(
+                    "indicator_warmup_skipped_no_historical_api",
+                    extra={"symbol": symbol},
+                )
+                return
+            candles = await asyncio.to_thread(
+                getter,
+                symbol=symbol,
+                interval=interval,
+                count=bars,
+            )
+            candle_rows = list(candles or [])
+            for candle in candle_rows:
+                if self.bar_aggregator and hasattr(self.bar_aggregator, "process_bar"):
+                    self.bar_aggregator.process_bar(candle)
+                try:
+                    normalized_symbol = enforce_canonical(normalize_symbol(str(symbol)))
+                    self.symbol_candles[normalized_symbol].append(dict(candle))
+                except Exception as exc:  # noqa: BLE001
+                    LOGGER.error("Failure in DataHub.warmup_indicators candle ingest: %s", exc)
+            self.indicators_ready = True
+            LOGGER.info("indicator_warmup_complete", extra={"bars": len(candle_rows)})
+        except Exception as exc:  # noqa: BLE001
+            LOGGER.error("Failure in DataHub.warmup_indicators: %s", exc, exc_info=exc)
 
     # ----------------------------------------------------------------
     # Subscription Management

--- a/src/nifty_scalper_bot/data/instruments.py
+++ b/src/nifty_scalper_bot/data/instruments.py
@@ -203,6 +203,7 @@ class InstrumentResolver:
 
         # threading guard for caches
         self._lock = threading.RLock()
+        self._warmed = False
 
         # seed well-known tokens
         # self._seed_well_known()
@@ -278,6 +279,8 @@ class InstrumentResolver:
 
         # Finalize
         self._seed_well_known()
+        self._warmed = True
+        LOGGER.info("resolver_warm_loaded", extra={"event": "resolver_warm_loaded", "symbols": len(self._by_symbol)})
         LOGGER.info("InstrumentResolver ready with %d symbols", len(self._by_symbol), extra={"event": "instrument_resolver_ready"})
 
     # --- Helper Methods (Add these to the class) ---
@@ -328,6 +331,8 @@ class InstrumentResolver:
                 except Exception:
                     LOGGER.exception("instrument_resolver_ingest_error for row")
             self._seed_well_known()
+            self._warmed = True
+        LOGGER.info("resolver_warm_loaded", extra={"event": "resolver_warm_loaded", "symbols": len(self._by_symbol)})
         LOGGER.info("InstrumentResolver warmed from dump: symbols=%d", len(self._by_symbol), extra={"event": "instrument_resolver_warm_dump_complete"})
 
     def upsert(self, symbol: str, token: int, *, exchange: Optional[str] = None) -> None:
@@ -887,6 +892,8 @@ class InstrumentResolver:
 
     def get_token(self, symbol: str | int | None) -> Optional[int]:
         """Return token for symbol. Args: symbol. Returns: token or None. Raises: RuntimeError."""
+        if not self._warmed:
+            return None
         token = self.resolve(symbol)
         if not token:
             if get_settings().enable_live:

--- a/src/nifty_scalper_bot/execution/order_manager.py
+++ b/src/nifty_scalper_bot/execution/order_manager.py
@@ -29,6 +29,7 @@ from zoneinfo import ZoneInfo
 
 import nifty_scalper_bot.config.settings as app_settings
 from nifty_scalper_bot.core.trading_switch import TradingSwitchState, trading_switch
+from nifty_scalper_bot.core.signal_arbitrator import SignalArbitrator
 from nifty_scalper_bot.data.data_hub import DataHub
 from nifty_scalper_bot.data.trade_store import TradeStore, TradeIntent
 from nifty_scalper_bot.data.bracket_store import BracketStore
@@ -656,6 +657,7 @@ class OrderManager:
         self._execution_policy: ExecutionPolicy | None = None
         self._options_policy = OptionsExecutionPolicy()
         self._risk_manager: RiskManager | None = None
+        self._signal_arbitrator = SignalArbitrator()
         self._client_order_index: dict[str, str] = {}
         self._last_skip_reason: str | None = None
         self._margin_block_events: deque[float] = deque()
@@ -1633,6 +1635,22 @@ class OrderManager:
         current_product = (product or "MIS").upper()
         is_intraday = (current_product == "MIS")
 
+        if not is_system_exit:
+            if self._positions.has_open_position(symbol):
+                self._logger.info("duplicate_entry_prevented")
+                return None
+            arbitration_payload = type(
+                "ArbitrationPayload",
+                (),
+                {"symbol": symbol, "action": side},
+            )()
+            if not self._signal_arbitrator.allow(arbitration_payload):
+                self._logger.info(
+                    "signal_arbitrator_blocked",
+                    extra={"symbol": symbol, "side": side},
+                )
+                return None
+
         # 3. THE INVARIANT CHECK
         if is_entry and is_intraday:
             # If SL is missing, None, or Zero -> REJECT
@@ -2045,6 +2063,8 @@ class OrderManager:
                                 # Don't fail the order just because pre-activation had issues
                                 self._logger.debug(f"Pre-activation note (non-critical): {exc}")
 
+                    if not is_system_exit:
+                        self._signal_arbitrator.register(normalized_symbol, side)
                     return order_id
                     
             except Exception as e:
@@ -4536,6 +4556,7 @@ class OrderManager:
         except Exception as e:
             self._logger.error(f"⚠️ Safety Net Cleanup Failed (Non-Critical): {e}")
 
+        self._signal_arbitrator.release(symbol)
         return exit_id
 
     def modify_order(self, order_id: str, price: float = 0.0, trigger_price: float = 0.0, quantity: int = 0) -> bool:

--- a/src/nifty_scalper_bot/execution/position_manager.py
+++ b/src/nifty_scalper_bot/execution/position_manager.py
@@ -1345,6 +1345,10 @@ class PositionManager:
 
         return symbol.upper() in self._positions
 
+    def has_open_position(self, symbol: str) -> bool:
+        """Return whether an open position exists. Args: symbol. Returns: bool. Raises: None."""
+        return self.has_position(symbol)
+
     def get_total_exposure(self) -> float:
         """Return the total notional exposure across open positions."""
 

--- a/src/nifty_scalper_bot/strategies/elite_strategies/vwap_pro.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/vwap_pro.py
@@ -279,7 +279,7 @@ class VWAPProStrategy(EliteStrategy):
                         self._vwap_acceptance_tracker.get(acc_key, 0) or 0
                     )
                     vwap_diff = float(current_price - (vwap or 0.0))
-                    LOGGER.info(
+                    LOGGER.debug(
                         "📉 NO SIGNAL | %s reason=%s",
                         symbol,
                         reason_code,

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -3809,7 +3809,7 @@ class StrategyRunner:
                 f"🔍 PHASE9 ENTERED: {symbol} | price={price:.2f} | "
                 f"skip={skip_strategy} | runner={self._runner_state}",
                 interval_sec=60.0,
-                level=logging.INFO,
+                level=logging.DEBUG,
             )
 
             signal = generated_signal
@@ -3970,7 +3970,7 @@ class StrategyRunner:
                         f"strategy_eval_{symbol}",
                         f"🎯 EVALUATING STRATEGIES: {symbol} | min_bars={self._required_candles}",
                         interval_sec=30.0,
-                        level=logging.INFO,
+                        level=logging.DEBUG,
                     )
                     if not self._indicator_engine.has_min_bars(
                         symbol, self._required_candles
@@ -4035,7 +4035,7 @@ class StrategyRunner:
                             f"indicators_ready_{symbol}",
                             f"✅ INDICATORS READY: {symbol} | Calling StrategyManager...",
                             interval_sec=60.0,
-                            level=logging.INFO,
+                            level=logging.DEBUG,
                         )
 
                         mdm_last_tick = getattr(

--- a/src/nifty_scalper_bot/strategies/signal_generator.py
+++ b/src/nifty_scalper_bot/strategies/signal_generator.py
@@ -1202,6 +1202,11 @@ class StrategyManager:
             extra={"event": "strategy_manager_generate", "symbol": symbol},
         )
 
+        if self._data_hub is not None and not bool(
+            getattr(self._data_hub, "indicators_ready", False)
+        ):
+            return None
+
         # 1. Fetch Position State
         position = self._position_manager.get_position(symbol)
 
@@ -1256,7 +1261,7 @@ class StrategyManager:
             or indicators.get("vwap")
             or 0.0
         )
-        logger.info(
+        logger.debug(
             "INDICATOR_STATE symbol=%s bars=%s vwap=%s",
             symbol,
             bar_count,


### PR DESCRIPTION
### Motivation

- Improve runtime reliability by preventing duplicate or conflicting entries during volatility spikes and when signals bypass higher orchestration layers.  
- Ensure indicators are warmed from broker historical candles at startup to remove missing-history warnings and avoid evaluating incomplete data.  
- Eliminate startup race between instrument resolution and strategy startup and reduce repetitive INFO log noise that hides important events.

### Description

- Enforce hard arbitration in the execution layer by wiring `SignalArbitrator` into `OrderManager`, adding a mandatory pre-order arbitration gate, registering arbitration on successful entry, and releasing the lock on position close; also add a safety gate that prevents duplicate entries when a position already exists (uses `PositionManager.has_open_position`).
- Add historical warmup support to `DataHub` via `async def warmup_indicators(self, symbol, interval="minute", bars=50)` and `indicators_ready` state so indicators can be hydrated from broker candle history before live streaming starts.
- Prevent instrument lookup race by adding an `_warmed` flag to the resolver and returning `None` from `get_token()` until the resolver completes warmup; wire deterministic startup ordering so indicator warmup runs before websocket and strategy runner start.
- Reduce log noise by downgrading repetitive strategy-loop messages (PHASE9 / INDICATORS READY / EVALUATING STRATEGIES / NO SIGNAL) to DEBUG and keep only significant trading events at INFO.

### Testing

- Run the project checks script: `./run_checks.sh` — environment setup and dependency install started but the initial run reported missing `pytest` (Ruff/mypy were skipped in that environment). (Observed: `❌ pytest not installed but tests/ exists.`)
- Installed test runner and executed a targeted test subset: `source .venv/bin/activate && PYTHONPATH=src pytest -q tests/test_order_manager.py tests/data/test_data_hub.py tests/test_initialize_components_polling.py --disable-warnings` which passed (`44 passed`).
- Attempted full test run `PYTHONPATH=src pytest -q tests --disable-warnings --ignore=tests/test_live_mode.py --ignore=tests/test_health_server.py` encountered an import error in a diagnostics test (`ModuleNotFoundError: No module named 'market_data_manager'`) likely due to test environment module path expectations; this was not a regression in changes.
- Performed bytecode/compile sanity check: `python -m compileall <modified files>` and it completed without syntax errors.

All changes are surgical, preserve existing public interfaces and strategy logic, and introduce no new dependencies. Please run full CI in your environment (with appropriate PYTHONPATH) to validate the broader test-suite and integration scenarios.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a98c7441d48324b79fa43e1caa2407)