### PR TITLE
feat: harden tick flow, add burst protection and liquidity preflight gating

### DIFF
--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -235,6 +235,13 @@ class MarketDataManager:
         self._tick_emit_min_interval = self._parse_float_env(
             "MDM_TICK_EMIT_MIN_INTERVAL_SEC", default=0.02, minimum=0.0
         )
+        self._tick_burst_window_sec = self._parse_float_env(
+            "MDM_TICK_BURST_WINDOW_SEC", default=1.0, minimum=0.1
+        )
+        self._tick_burst_limit = self._parse_int_env(
+            "MDM_TICK_BURST_LIMIT", default=200, minimum=1
+        )
+        self._tick_burst_tracker: dict[str, tuple[float, int]] = {}
         self._tick_bus: Any | None = None
         self._main_loop: asyncio.AbstractEventLoop | None = None
         self._async_dispatch_drops = 0
@@ -2471,6 +2478,9 @@ class MarketDataManager:
         if symbol not in self._tracked_symbols:
             self._tracked_symbols.add(symbol)
 
+        if not self._allow_tick_for_symbol(symbol):
+            return
+
         with self._lock:
             previous = self._latest_ticks.get(symbol)
 
@@ -2523,6 +2533,44 @@ class MarketDataManager:
             self._last_tick_stats_log = now
         tick_source = str(tick.get("source", "ws") or "ws").lower()
         self._emit_tick(symbol, normalized_tick, source=tick_source)
+
+    def _allow_tick_for_symbol(self, symbol: str) -> bool:
+        """Args: symbol; Returns: burst-gate decision; Raises: none."""
+
+        try:
+            now = time.monotonic()
+            with self._lock:
+                window_start, count = self._tick_burst_tracker.get(symbol, (now, 0))
+                if now - window_start >= self._tick_burst_window_sec:
+                    window_start = now
+                    count = 0
+                count += 1
+                self._tick_burst_tracker[symbol] = (window_start, count)
+            if count <= self._tick_burst_limit:
+                return True
+            log_throttled(
+                self._logger,
+                f"mdm_tick_burst_drop_{symbol}",
+                "Dropping burst tick flood for %s count=%d window=%.2fs"
+                % (symbol, count, self._tick_burst_window_sec),
+                interval_sec=5.0,
+                level=logging.WARNING,
+                extra={
+                    "event": "mdm_tick_burst_drop",
+                    "symbol": symbol,
+                    "count": count,
+                    "window_sec": self._tick_burst_window_sec,
+                },
+            )
+            return False
+        except Exception as exc:  # noqa: BLE001
+            self._logger.error(
+                "Failure in MarketDataManager._allow_tick_for_symbol: %s",
+                exc,
+                extra={"event": "mdm_tick_burst_error", "symbol": symbol},
+                exc_info=exc,
+            )
+            return True
 
     def _seed_mapping(self, symbol: str, token: int | None) -> None:
         if token is None:

--- a/src/nifty_scalper_bot/execution/preflight_validator.py
+++ b/src/nifty_scalper_bot/execution/preflight_validator.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
+from collections import deque
+from dataclasses import dataclass
 import logging
 import math
 import time
-from collections import deque
-from dataclasses import dataclass
 from typing import Any, Deque, Mapping
 
 from pydantic import AliasChoices, Field
@@ -33,6 +33,7 @@ class PreFlightValidatorSettings(BaseSettings):
 
     quote_max_age_ms: int = Field(default=2000, ge=0)
     spread_max_pct: float = Field(default=1.5, ge=0.0)
+    min_depth_qty: int = Field(default=300, ge=0)
     risk_max_drawdown_pct_day: float = Field(
         default=7.0,
         ge=0.0,
@@ -235,6 +236,7 @@ class PreFlightValidator:
             ("market_hours", self._check_market_hours, "HARD"),
             ("quote_staleness", self._check_quote_staleness, "HARD"),
             ("spread_check", self._check_spread, "HARD"),
+            ("liquidity_depth", self._check_liquidity_depth, "HARD"),
             ("daily_loss_limit", self._check_daily_loss_limit, "HARD"),
             ("consecutive_losses", self._check_consecutive_losses, "HARD"),
             ("position_limit", self._check_position_limit, "SOFT"),
@@ -635,6 +637,99 @@ class PreFlightValidator:
                 "limit": self._settings.spread_max_pct,
             }
 
+    def _check_liquidity_depth(
+        self,
+        symbol: str,
+        now: float,
+        context: Mapping[str, Any],
+    ) -> dict[str, Any] | None:
+        """Validate combined bid/ask top quantity. Args: symbol, now, context; Returns: reason or None; Raises: none."""
+
+        self._logger.debug(
+            "Entered PreFlightValidator._check_liquidity_depth",
+            extra={"event": "preflight_gate_liquidity_depth", "symbol": symbol},
+        )
+        try:
+            _ = now
+            if self._settings.min_depth_qty <= 0:
+                return None
+            tick = dict(context.get("tick") or {})
+            if not tick:
+                fetch = getattr(self._datahub, "getlatesttick", None)
+                if fetch is None:
+                    fetch = getattr(self._datahub, "get_latest_tick", None)
+                tick = (fetch(symbol) if callable(fetch) else None) or {}
+            if not tick:
+                return {
+                    "detail": "Missing quote for liquidity check",
+                    "current_value": None,
+                    "limit": self._settings.min_depth_qty,
+                }
+            bid_qty = _first_float(
+                tick,
+                "best_bid_qty",
+                "bid_qty",
+                "total_buy_qty",
+                "buy_quantity",
+            )
+            ask_qty = _first_float(
+                tick,
+                "best_ask_qty",
+                "ask_qty",
+                "total_sell_qty",
+                "sell_quantity",
+            )
+            depth_payload = tick.get("depth") if isinstance(tick, Mapping) else None
+            if isinstance(depth_payload, Mapping):
+                bid_qty = bid_qty or self._depth_qty(depth_payload.get("buy"))
+                ask_qty = ask_qty or self._depth_qty(depth_payload.get("sell"))
+            total_qty = float(bid_qty or 0.0) + float(ask_qty or 0.0)
+            if total_qty >= float(self._settings.min_depth_qty):
+                return None
+            return {
+                "detail": "Insufficient top-of-book liquidity",
+                "current_value": total_qty,
+                "limit": self._settings.min_depth_qty,
+            }
+        except Exception as exc:  # noqa: BLE001
+            self._logger.error(
+                "Failure in PreFlightValidator._check_liquidity_depth: %s",
+                exc,
+                extra={
+                    "event": "preflight_gate_liquidity_depth_error",
+                    "symbol": symbol,
+                },
+                exc_info=exc,
+            )
+            return {
+                "detail": "Liquidity depth validation error",
+                "current_value": None,
+                "limit": self._settings.min_depth_qty,
+            }
+
+    @staticmethod
+    def _depth_qty(payload: Any) -> float | None:
+        """Summarise top-level depth quantity. Args: payload; Returns: qty or None; Raises: none."""
+
+        if not isinstance(payload, list):
+            return None
+        total = 0.0
+        found = False
+        for row in payload:
+            if not isinstance(row, Mapping):
+                continue
+            value = row.get("quantity") or row.get("qty") or row.get("orders")
+            try:
+                qty = float(value)
+            except (TypeError, ValueError):
+                continue
+            if qty > 0:
+                total += qty
+                found = True
+        if not found:
+            return None
+        return total
+
     def _check_daily_loss_limit(
         self,
         symbol: str,
@@ -943,7 +1038,7 @@ class PreFlightValidator:
                     confidence = float(self._regime_manager.get_regime_confidence())
                 except (TypeError, ValueError):
                     confidence = 0.0
-            
+
             # Regime data unavailable (startup warmup or detector not yet run).
             # Do NOT block trading — regime is advisory, not a hard gate.
             if regime is None:
@@ -1096,3 +1191,17 @@ __all__ = [
     "PreFlightValidatorSettings",
     "ValidationResult",
 ]
+
+
+def _first_float(payload: Mapping[str, Any], *keys: str) -> float | None:
+    """Read first numeric field from payload. Args: payload, keys; Returns: value or None; Raises: none."""
+
+    for key in keys:
+        value = payload.get(key)
+        if value is None:
+            continue
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            continue
+    return None

--- a/src/nifty_scalper_bot/strategies/elite_strategies/vwap_pro.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/vwap_pro.py
@@ -28,7 +28,7 @@ class VWAPProStrategy(EliteStrategy):
     """
 
     MIN_BARS_REQUIRED = 10
-    COOLDOWN_SECONDS = 45    # ✅ FIX #5: Reduced from 60s → 45s; prevents overtrading while capturing fast NIFTY moves
+    COOLDOWN_SECONDS = 45  # ✅ FIX #5: Reduced from 60s → 45s; prevents overtrading while capturing fast NIFTY moves
     VWAP_ACCEPTANCE_BARS = 1  # ✅ FIX #5: Reduced from 2 → 1; index bias gate is already a strong 2-condition filter
     TELEMETRY_LOG_EVERY = 5
     VOLUME_GRACE_SECONDS = 900.0  # ✅ FIX C: Extended from 120s → 900s (15 min). NFO options tick ≈once/13min between batches; 120s grace expired before next tick arrived → volume_below_threshold on every call.
@@ -45,7 +45,7 @@ class VWAPProStrategy(EliteStrategy):
         "_last_valid_volume_ts",
         "_reject_reason_counts",
         "_index_bias_degraded_logged",
-        "_index_bias_missing_logged",   # ✅ FIX #5b: Was missing from __slots__ but set in __init__ and read in _evaluate_signal
+        "_index_bias_missing_logged",  # ✅ FIX #5b: Was missing from __slots__ but set in __init__ and read in _evaluate_signal
         "_last_valid_index_vwap",
         "_bias_failover_logged_bar",
     )
@@ -271,7 +271,7 @@ class VWAPProStrategy(EliteStrategy):
             extra={"event": "vwap_pro_signal_enter", "symbol": symbol},
         )
         try:
-            vwap = 0.0   # prevent closure error
+            vwap = 0.0  # prevent closure error
 
             def _emit_no_signal(reason_code: str) -> None:
                 """Args: reason_code. Returns: None. Raises: Exception."""
@@ -533,7 +533,9 @@ class VWAPProStrategy(EliteStrategy):
             # CE direction for minutes. 0.5% requires a deliberate directional move
             # (~125 pts on 25000 NIFTY) before blocking the opposite option type.
             # Configurable via VWAP_BIAS_TOLERANCE env var (e.g. "0.003" = 0.3%).
-            _bias_tolerance = index_vwap * float(os.getenv("VWAP_BIAS_TOLERANCE", "0.005"))
+            _bias_tolerance = index_vwap * float(
+                os.getenv("VWAP_BIAS_TOLERANCE", "0.005")
+            )
             if (is_ce and index_ltp < (index_vwap - _bias_tolerance)) or (
                 not is_ce and index_ltp > (index_vwap + _bias_tolerance)
             ):
@@ -591,10 +593,17 @@ class VWAPProStrategy(EliteStrategy):
             _min_premium = float(os.getenv("VWAP_MIN_PREMIUM", "10"))
             if current_price < _min_premium:
                 self._telemetry["skipped_data"] += 1
-                if self._telemetry["skipped_data"] <= 5 or self._telemetry["skipped_data"] % self.TELEMETRY_LOG_EVERY == 0:
+                if (
+                    self._telemetry["skipped_data"] <= 5
+                    or self._telemetry["skipped_data"] % self.TELEMETRY_LOG_EVERY == 0
+                ):
                     LOGGER.info(
                         f"💰 MIN PREMIUM: {symbol} | price={current_price:.2f} < min={_min_premium:.0f} — skipping illiquid option",
-                        extra={"event": "vwap_pro_min_premium_reject", "symbol": symbol, "price": current_price},
+                        extra={
+                            "event": "vwap_pro_min_premium_reject",
+                            "symbol": symbol,
+                            "price": current_price,
+                        },
                     )
                 self._log_no_signal_reason(
                     "premium_too_low",
@@ -616,14 +625,24 @@ class VWAPProStrategy(EliteStrategy):
             if _spread_pct > 0 and _max_spread > 0 and _spread_pct > _max_spread:
                 self._telemetry.setdefault("skipped_spread", 0)
                 self._telemetry["skipped_spread"] += 1
-                if self._telemetry["skipped_spread"] <= 3 or self._telemetry["skipped_spread"] % self.TELEMETRY_LOG_EVERY == 0:
+                if (
+                    self._telemetry["skipped_spread"] <= 3
+                    or self._telemetry["skipped_spread"] % self.TELEMETRY_LOG_EVERY == 0
+                ):
                     LOGGER.info(
                         f"💹 SPREAD REJECT: {symbol} | spread={_spread_pct:.1f}% > max={_max_spread:.0f}%",
-                        extra={"event": "vwap_pro_spread_reject", "symbol": symbol,
-                               "spread_pct": _spread_pct, "max_spread_pct": _max_spread},
+                        extra={
+                            "event": "vwap_pro_spread_reject",
+                            "symbol": symbol,
+                            "spread_pct": _spread_pct,
+                            "max_spread_pct": _max_spread,
+                        },
                     )
                 self._log_no_signal_reason(
-                    "spread_too_wide", symbol=symbol, ltp=current_price, vwap=vwap,
+                    "spread_too_wide",
+                    symbol=symbol,
+                    ltp=current_price,
+                    vwap=vwap,
                     context={"spread_pct": _spread_pct, "max_spread_pct": _max_spread},
                 )
                 _emit_no_signal("spread_too_wide")
@@ -662,6 +681,47 @@ class VWAPProStrategy(EliteStrategy):
                 _emit_no_signal("price_below_vwap")
                 return None
 
+            distance = 0.0
+            if _option_vwap > 0:
+                distance = abs(current_price - _option_vwap) / _option_vwap
+                if distance > 0.08:
+                    self._log_no_signal_reason(
+                        "vwap_distance_extension",
+                        symbol=symbol,
+                        ltp=current_price,
+                        vwap=_option_vwap,
+                        context={"distance": distance, "max_distance": 0.08},
+                    )
+                    self._reset_acceptance(
+                        acc_key,
+                        symbol=symbol,
+                        reason_code="vwap_distance_extension",
+                    )
+                    _emit_no_signal("vwap_distance_extension")
+                    return None
+
+            pullback_ok = True
+            if _option_vwap > 0:
+                pullback_ok = abs(current_price - _option_vwap) <= max(atr * 0.6, 1.0)
+            momentum_confirmation = bool(
+                indicators.get("momentum_confirmation")
+                or indicators.get("confirmation_candle")
+                or indicators.get("trend_momentum_confirm")
+            )
+            if not pullback_ok or not momentum_confirmation:
+                self._log_no_signal_reason(
+                    "vwap_pullback_not_confirmed",
+                    symbol=symbol,
+                    ltp=current_price,
+                    vwap=_option_vwap or vwap,
+                    context={
+                        "pullback_ok": pullback_ok,
+                        "momentum_confirmation": momentum_confirmation,
+                    },
+                )
+                _emit_no_signal("vwap_pullback_not_confirmed")
+                return None
+
             # 📏 Over-extension filter
             vwap_std = float(indicators.get("vwap_std") or 0.0)
             if vwap_std > 0:
@@ -692,7 +752,9 @@ class VWAPProStrategy(EliteStrategy):
 
             # 🔊 ISSUE 4 FIX: Reset acceptance on Volume rejection
             vol = float(indicators.get("volume") or 0.0)
-            avg_vol = float(indicators.get("avg_volume") or indicators.get("average_volume") or 0.0)
+            avg_vol = float(
+                indicators.get("avg_volume") or indicators.get("average_volume") or 0.0
+            )
             # ✅ FIX B: Seed last_valid_volume from hydration data on first call.
             # Options with sparse ticks (≈1 per 13 min) never complete a 60-second live
             # bar, so indicators["volume"] is always 0 for the current bar.  The grace-

--- a/tests/data/test_market_data_manager.py
+++ b/tests/data/test_market_data_manager.py
@@ -472,3 +472,23 @@ def test_out_of_order_tick_is_discarded(
     latest = manager.get_latest_tick("NIFTY23")
     assert latest is not None
     assert latest["ltp"] == 100.0
+
+
+def test_tick_burst_protection_drops_excess_ticks(
+    monkeypatch: pytest.MonkeyPatch, broker: DummyBroker, ws: DummyWebSocket
+) -> None:
+    monkeypatch.setenv("MDM_TICK_BURST_LIMIT", "2")
+    monkeypatch.setenv("MDM_TICK_BURST_WINDOW_SEC", "10")
+    manager = MarketDataManager(broker, ws)
+    events: list[dict[str, Any]] = []
+    manager.subscribe("NIFTY23", events.append)
+    assert ws.on_tick is not None
+
+    ws.on_tick({"instrument_token": 123, "last_price": 100.0, "timestamp": 1000.0})
+    ws.on_tick({"instrument_token": 123, "last_price": 101.0, "timestamp": 1001.0})
+    ws.on_tick({"instrument_token": 123, "last_price": 102.0, "timestamp": 1002.0})
+
+    assert len(events) == 2
+    latest = manager.get_latest_tick("NIFTY23")
+    assert latest is not None
+    assert latest["ltp"] == pytest.approx(101.0)

--- a/tests/strategies/test_market_regime_engine.py
+++ b/tests/strategies/test_market_regime_engine.py
@@ -1,15 +1,18 @@
-from nifty_scalper_bot.strategies.market_regime_engine import MarketRegime, MarketRegimeEngine
+from nifty_scalper_bot.strategies.market_regime_engine import (
+    MarketRegime,
+    MarketRegimeEngine,
+)
 
 
 def test_market_regime_trend_classification() -> None:
     engine = MarketRegimeEngine()
     snapshot = engine.classify(
         {
-            'adx': 28.0,
-            'atr': 10.0,
-            'atr_average': 8.0,
-            'vwap_slope': 0.2,
-            'volume_expansion': 1.2,
+            "adx": 28.0,
+            "atr": 10.0,
+            "atr_average": 8.0,
+            "vwap_slope": 0.2,
+            "volume_expansion": 1.2,
         }
     )
     assert snapshot.regime == MarketRegime.TREND
@@ -19,11 +22,39 @@ def test_market_regime_volatile_classification() -> None:
     engine = MarketRegimeEngine()
     snapshot = engine.classify(
         {
-            'adx': 18.0,
-            'atr': 20.0,
-            'atr_average': 10.0,
-            'vwap_slope': 0.0,
-            'volume_expansion': 1.0,
+            "adx": 18.0,
+            "atr": 20.0,
+            "atr_average": 10.0,
+            "vwap_slope": 0.0,
+            "volume_expansion": 1.0,
         }
     )
     assert snapshot.regime == MarketRegime.VOLATILE
+
+
+def test_market_regime_range_classification() -> None:
+    engine = MarketRegimeEngine()
+    snapshot = engine.classify(
+        {
+            "adx": 10.0,
+            "atr": 8.0,
+            "atr_average": 8.5,
+            "vwap_slope": 0.001,
+            "volume_expansion": 1.0,
+        }
+    )
+    assert snapshot.regime == MarketRegime.RANGE
+
+
+def test_market_regime_low_activity_classification() -> None:
+    engine = MarketRegimeEngine()
+    snapshot = engine.classify(
+        {
+            "adx": 20.0,
+            "atr": 7.0,
+            "atr_average": 7.5,
+            "vwap_slope": 0.001,
+            "volume_expansion": 0.4,
+        }
+    )
+    assert snapshot.regime == MarketRegime.LOW_ACTIVITY

--- a/tests/test_preflight_validator.py
+++ b/tests/test_preflight_validator.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-import time
 from dataclasses import dataclass
+import time
 from types import MethodType, SimpleNamespace
 from typing import Any
 
@@ -93,6 +93,8 @@ class DummyDataHub:
             "timestamp": FIXED_TIME,
             "best_bid": 100.0,
             "best_ask": 100.5,
+            "best_bid_qty": 250,
+            "best_ask_qty": 250,
         }
 
     def set_tick(self, payload: dict[str, Any] | None) -> None:
@@ -242,3 +244,25 @@ def test_preflight_rate_limit_blocks_after_threshold(
     gates = {reason["gate"] for reason in outcome.reasons}
     assert "rate_limit" in gates
     assert outcome.blocking_level == "HARD"
+
+
+def test_preflight_blocks_low_liquidity_depth(
+    validator_components: dict[str, Any],
+) -> None:
+    validator_components["datahub"].set_tick(
+        {
+            "timestamp": FIXED_TIME,
+            "best_bid": 100.0,
+            "best_ask": 100.3,
+            "best_bid_qty": 100,
+            "best_ask_qty": 120,
+        }
+    )
+    validator = _build_validator(validator_components)
+    outcome = validator.validate(
+        "NIFTY",
+        context={"order_cost": 100.0, "margin_available": 5_000.0},
+    )
+    assert outcome.allowed is False
+    gates = {reason["gate"] for reason in outcome.reasons}
+    assert "liquidity_depth" in gates


### PR DESCRIPTION
### Motivation
- Harden market-data ingestion to protect downstream engines from tick floods while preserving existing monotonicity and duplicate protections.
- Block execution on thin option books to avoid placing orders with poor fill/lack of liquidity.
- Improve VWAP strategy signal quality to prevent entries during extreme momentum extensions or without momentum confirmation.

### Description
- MarketDataManager: added per-symbol burst protection using `MDM_TICK_BURST_WINDOW_SEC` and `MDM_TICK_BURST_LIMIT` and integrated `_allow_tick_for_symbol()` into the live tick path; retains strict monotonic/out-of-order checks and duplicate suppression and uses existing locks for thread-safety.
- PreFlightValidator: added a hard `liquidity_depth` gate (config `min_depth_qty`) that evaluates top-of-book bid/ask quantities and falls back to `depth` payload parsing; wired into the main gate sequence so the liquidity check blocks early.
- VWAP strategy (`VWAPProStrategy`): added an over-extension distance guard (`distance > 0.08` rejects signal) and a pullback + momentum-confirmation requirement before entry to avoid chasing extreme moves.
- Tests: added/updated tests for tick-burst protection, liquidity-depth gating, and additional regime classification cases; refactored small test fixtures to support new checks.

### Testing
- Ran targeted pytest commands for modified areas: `pytest -q tests/test_preflight_validator.py::test_preflight_blocks_low_liquidity_depth tests/data/test_market_data_manager.py::test_tick_burst_protection_drops_excess_ticks tests/strategies/test_market_regime_engine.py tests/strategies/test_runner_gap_repair.py tests/strategies/test_runner_reliability_guards.py --disable-warnings` — all targeted tests passed.
- Ran broader test run `pytest -q tests --disable-warnings --ignore=tests/test_live_mode.py --ignore=tests/test_health_server.py` which surfaced an unrelated repository baseline import error (`ModuleNotFoundError: No module named 'market_data_manager'` in `tests/test_mdm_diagnostics.py`), so full-suite validation could not be completed here.
- Executed `./run_checks.sh` in this environment but the script was not directly executable (`Permission denied`); `bash ./run_checks.sh` bootstrapped dependencies and began checks but a full non-interactive run output could not be captured end-to-end in this session (partial dependency/install logs available in the rollout transcript).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b23fe614988324a7be83b8a8030fab)