### PR TITLE
fix: stabilize execution engine, trailing stops, and virtual bracket system

### DIFF
--- a/src/nifty_scalper_bot/execution/bracket_manager.py
+++ b/src/nifty_scalper_bot/execution/bracket_manager.py
@@ -62,6 +62,13 @@ METRICS = None
 
 LOGGER = get_logger(__name__)
 
+
+def _round_to_tick(price: float, tick_size: float = 0.05) -> float:
+    """Round *price* to broker-compatible tick precision."""
+    if tick_size <= 0:
+        return round(price, 2)
+    return round(round(float(price) / tick_size) * tick_size, 2)
+
 def _normalize_bracket_side(side: str) -> str:
     """Normalize side to 'BUY'/'SELL' for consistent bracket comparisons.
 
@@ -329,8 +336,7 @@ class BracketManager:
                     for bracket in self._brackets.values():
                         ltp = float(bracket.last_ltp or 0.0)
                         if (
-                            not bracket.active
-                            or bracket.exit_executed
+                            bracket.exit_executed
                             or bracket.exit_in_progress
                             or bracket.remaining_quantity <= 0
                             or bracket.sl_trigger_price <= 0
@@ -965,23 +971,10 @@ class BracketManager:
 
 
     def process_exit_checks(self, symbol: str, ltp: float) -> None:
-        """Process immediate SL checks on tick ingestion. Args: symbol, ltp; Returns: None; Raises: None."""
+        """Route tick to the single on-tick exit authority. Args: symbol, ltp; Returns: None; Raises: None."""
         LOGGER.debug('Entered process_exit_checks')
         try:
-            brackets = self._symbol_map.get(symbol, [])
-
-            for entry_id in brackets:
-
-                bracket = self._brackets.get(entry_id)
-
-                if not bracket or not bracket.active:
-                    continue
-
-                bracket.previous_ltp = float(bracket.last_ltp or ltp)
-                bracket.last_ltp = ltp
-                if self._sl_crossed(bracket, ltp):
-                    LOGGER.warning('SL_TRIGGERED symbol=%s', bracket.symbol)
-                    self._force_exit(bracket)
+            self.on_tick(symbol, ltp)
         except Exception as e:
             LOGGER.error('Failure in process_exit_checks: %s', e)
 
@@ -1083,7 +1076,9 @@ class BracketManager:
             for bracket, action in exits:
                 if bracket.exit_executed or bracket.exit_in_progress:
                     continue
-                if not bracket.active or bracket.remaining_quantity <= 0:
+                action_type = str(action.get('type', '')).upper()
+                is_protective_exit = action_type in {'SL', 'FINAL_TP', 'PARTIAL_TP'}
+                if (not bracket.active and not is_protective_exit) or bracket.remaining_quantity <= 0:
                     continue
                 last_attempt = self._exit_cooldowns.get(bracket.entry_order_id, 0.0)
                 if now - last_attempt < 0.5:
@@ -1340,7 +1335,7 @@ class BracketManager:
                 current_sl = bracket.sl_trigger_price  # authoritative read under lock
                 if new_sl > current_sl:
                     old_sl = bracket.sl_trigger_price
-                    bracket.sl_trigger_price = round(new_sl, 2)
+                    bracket.sl_trigger_price = _round_to_tick(new_sl)
                     bracket.updated_at = time.time()
                     
                     LOGGER.debug(
@@ -1366,7 +1361,7 @@ class BracketManager:
                 current_sl = bracket.sl_trigger_price  # authoritative read under lock
                 if new_sl < current_sl:
                     old_sl = bracket.sl_trigger_price
-                    bracket.sl_trigger_price = round(new_sl, 2)
+                    bracket.sl_trigger_price = _round_to_tick(new_sl)
                     bracket.updated_at = time.time()
                     
                     LOGGER.debug(
@@ -1954,6 +1949,7 @@ class BracketManager:
 
     def update_trailing_sl(self, symbol: str, new_sl: float) -> None:
         """Update SL monotonically for all active brackets on a symbol. Args: symbol,new_sl; Returns: None; Raises: None."""
+        rounded_sl = _round_to_tick(new_sl)
         with self._lock:
             relevant_ids = self._symbol_map.get(symbol, [])
             if not relevant_ids:
@@ -1966,9 +1962,9 @@ class BracketManager:
 
                 old_sl = bracket.sl_trigger_price
                 if bracket.side == 'BUY':
-                    bracket.sl_trigger_price = max(old_sl, new_sl)
+                    bracket.sl_trigger_price = max(old_sl, rounded_sl)
                 else:
-                    bracket.sl_trigger_price = min(old_sl, new_sl)
+                    bracket.sl_trigger_price = min(old_sl, rounded_sl)
 
                 if bracket.sl_trigger_price != old_sl:
                     bracket.updated_at = time.time()

--- a/src/nifty_scalper_bot/execution/dynamic_tp.py
+++ b/src/nifty_scalper_bot/execution/dynamic_tp.py
@@ -32,7 +32,7 @@ class DynamicTPController:
         self._check_interval = 2.0  # Check every 2 seconds
         self._min_expansion = 5.0   # Minimum points to move TP
         
-        LOGGER.info(
+        LOGGER.debug(
             f"🚀 Dynamic TP Controller started for {symbol} (Order: {tp_order_id})",
             extra={"symbol": symbol, "initial_tp": initial_price}
         )
@@ -79,7 +79,7 @@ class DynamicTPController:
             new_price = self._calculate_new_price(self.current_tp_price, expansion_amount)
             
             # Log the intent
-            LOGGER.info(
+            LOGGER.debug(
                 f"🔥 Momentum Detected (RSI={rsi:.1f}). Expanding TP.",
                 extra={
                     "symbol": self.symbol,

--- a/src/nifty_scalper_bot/execution/order_queue.py
+++ b/src/nifty_scalper_bot/execution/order_queue.py
@@ -17,12 +17,14 @@ LOGGER = get_logger(__name__)
 OrderIntent = Literal["ENTRY", "EXIT_SL", "EXIT_TP1", "EXIT_TP2", "ADJUST_TRAIL"]
 
 _PRIORITY_MAP: dict[OrderIntent, int] = {
-    "EXIT_SL": 10,
+    "EXIT_SL": 20,
     "EXIT_TP1": 8,
     "EXIT_TP2": 8,
     "ADJUST_TRAIL": 5,
     "ENTRY": 3,
 }
+
+_EMERGENCY_EXIT_INTENTS: set[OrderIntent] = {"EXIT_SL"}
 
 _COUNTER = itertools.count()
 
@@ -130,7 +132,7 @@ class OrderQueue:
                     request.side.upper(),
                     request.intent,
                 )
-                if dedup_key in self._dedup:
+                if dedup_key in self._dedup and request.intent not in _EMERGENCY_EXIT_INTENTS:
                     LOGGER.warning(
                         "order_queue_duplicate_rejected",
                         extra={

--- a/src/nifty_scalper_bot/execution/post_fill_monitor.py
+++ b/src/nifty_scalper_bot/execution/post_fill_monitor.py
@@ -73,6 +73,7 @@ class PostFillMonitor:
         if self._task is not None and not self._task.done():
             return
         self._stop_event.clear()
+        await self.reconcile()
         try:
             loop = asyncio.get_running_loop()
         except RuntimeError as exc:  # noqa: BLE001
@@ -127,9 +128,6 @@ class PostFillMonitor:
         Raises:
             None. Exceptions are logged for diagnostics.
         """
-        if time.time() - self._startup_time < 30.0:
-            return
-
         self._logger.debug(
             "Entered PostFillMonitor.reconcile",
             extra={"event": "post_fill_monitor_reconcile"},

--- a/tests/execution/test_order_queue_reliability.py
+++ b/tests/execution/test_order_queue_reliability.py
@@ -1,0 +1,53 @@
+"""Reliability coverage for queue priority and exit dedup behaviour."""
+
+from __future__ import annotations
+
+from nifty_scalper_bot.execution.order_queue import OrderQueue, OrderRequest
+
+
+def test_exit_sl_is_dequeued_before_entry() -> None:
+    """Ensure STOP exits bypass entry queue backlog."""
+    queue = OrderQueue()
+    queue.submit_order_request(
+        OrderRequest(symbol='NFO:NIFTY1', side='BUY', quantity=1, intent='ENTRY')
+    )
+    queue.submit_order_request(
+        OrderRequest(symbol='NFO:NIFTY1', side='SELL', quantity=1, intent='EXIT_SL')
+    )
+
+    first = queue.get_next_request(timeout=0.1)
+    second = queue.get_next_request(timeout=0.1)
+
+    assert first is not None
+    assert second is not None
+    assert first.intent == 'EXIT_SL'
+    assert second.intent == 'ENTRY'
+
+
+def test_duplicate_emergency_exit_is_allowed() -> None:
+    """Ensure emergency EXIT_SL requests remain idempotent and unblocked."""
+    queue = OrderQueue()
+    request = OrderRequest(
+        symbol='NFO:NIFTY2',
+        side='SELL',
+        quantity=1,
+        intent='EXIT_SL',
+    )
+
+    queue.submit_order_request(request)
+    queue.submit_order_request(
+        OrderRequest(
+            symbol='NFO:NIFTY2',
+            side='SELL',
+            quantity=1,
+            intent='EXIT_SL',
+        )
+    )
+
+    first = queue.get_next_request(timeout=0.1)
+    second = queue.get_next_request(timeout=0.1)
+
+    assert first is not None
+    assert second is not None
+    assert first.intent == 'EXIT_SL'
+    assert second.intent == 'EXIT_SL'

--- a/tests/execution/test_post_fill_monitor_reconcile.py
+++ b/tests/execution/test_post_fill_monitor_reconcile.py
@@ -1,0 +1,36 @@
+"""Post-fill monitor reconciliation startup behaviour tests."""
+
+from __future__ import annotations
+
+import asyncio
+
+from nifty_scalper_bot.execution.post_fill_monitor import PostFillMonitor
+
+
+class _Broker:
+    async def get_positions(self) -> list[dict[str, object]]:
+        return []
+
+
+class _Tracker:
+    def get_open_positions(self) -> list[dict[str, object]]:
+        return []
+
+
+def test_start_runs_immediate_reconciliation() -> None:
+    """Ensure startup executes one reconciliation cycle before background loop."""
+
+    async def _run() -> None:
+        monitor = PostFillMonitor(
+            broker_client=_Broker(),
+            state_tracker=_Tracker(),
+            interval_sec=30,
+        )
+        await monitor.start()
+        await asyncio.sleep(0.01)
+        stats = monitor.get_stats()
+        await monitor.stop()
+        assert stats['interval_sec'] == 30
+        assert stats['total_mismatches'] == 0
+
+    asyncio.run(_run())


### PR DESCRIPTION
### Motivation

- Improve stop-loss reliability by removing state-guards and race paths that could block protective exits.  
- Centralize exit authority so a single tick-driven path evaluates SL/TP and trailing decisions.  
- Ensure trailing updates are broker-compatible and monotonic by enforcing tick-size normalization.  
- Reduce noisy informational telemetry while preserving execution-critical logs and add deterministic reconciliation on startup.

### Description

- Consolidated exit checks into the single tick-driven authority by routing `process_exit_checks` to `BracketManager.on_tick` and ensuring the watchdog no longer skips protective SL checks due to transient `active` state.  
- Made `_fire_exits_batch` allow protective exits (`SL`, `FINAL_TP`, `PARTIAL_TP`) to pass even when a bracket is temporarily `inactive`, and preserved existing cooldown/idempotency guards.  
- Added `_round_to_tick()` and applied tick-size rounding to trailing SL updates (both adaptive and manual) so SL values are always aligned to broker tick precision and never widen.  
- Increased `EXIT_SL` priority in the `OrderQueue` and added an emergency dedup bypass so emergency stop requests bypass normal duplicate suppression, ensuring exit orders are not blocked by entry backlog.  
- Triggered an immediate reconciliation run on `PostFillMonitor.start()` and removed the initial 30s skip so broker/local state alignment happens deterministically at startup.  
- Reduced log noise by downgrading dynamic TP initialization and momentum logs from `INFO` to `DEBUG`.  
- Added focused unit tests: `tests/execution/test_bracket_manager_reliability.py` (existing), `tests/execution/test_order_queue_reliability.py`, and `tests/execution/test_post_fill_monitor_reconcile.py` to cover exit priority/dedup and startup reconciliation behavior.

### Testing

- Executed `bash ./run_checks.sh` in the environment and captured the installer/runtime summary which shows dependencies installed but initially missing dev tools; key run output excerpts: dependency installation completed; `Ruff`/`mypy` were initially not installed; pytest was missing when tests/ appeared.  
- After installing dev tools (`pytest`, `ruff`, `mypy`, `black`, `isort`) I ran the focused test suite with `pytest -q tests/execution/test_bracket_manager_reliability.py tests/execution/test_order_queue_reliability.py tests/execution/test_post_fill_monitor_reconcile.py` and all targeted tests passed (`........  [100%]`).  
- Running the full repository test run (`pytest -q tests --disable-warnings --ignore=tests/test_live_mode.py --ignore=tests/test_health_server.py`) failed at collection due to a pre-existing unrelated import issue (`ModuleNotFoundError: No module named 'market_data_manager'` in `tests/test_mdm_diagnostics.py`), which is outside the scope of these changes.  
- `ruff check` was executed on the modified files and reported many existing/legacy style issues in `bracket_manager.py` (mostly line-length/import ordering and pre-existing problems), none of which were regressions introduced by these safety-focused changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2d503f7488324ac2617b118139bcb)