### PR TITLE
fix: stabilize execution engine, stop-loss reliability, and trailing stop logic

### DIFF
--- a/src/nifty_scalper_bot/execution/lifecycle_manager.py
+++ b/src/nifty_scalper_bot/execution/lifecycle_manager.py
@@ -11,6 +11,8 @@ from datetime import time as dtime
 from pathlib import Path
 from typing import Any, Callable, Iterable, Mapping, Protocol, cast
 
+from nifty_scalper_bot.data.option_chain import _round_to_tick
+
 import yaml  # type: ignore[import]
 
 from nifty_scalper_bot.execution.metrics import LIFECYCLE_EXITS
@@ -61,6 +63,7 @@ class LifecyclePosition:
     highest_price: float = 0.0
     entry_iv: float | None = None
     expiry: datetime | None = None
+    tick_size: float = 0.05
 
 
 class StateTrackerProtocol(Protocol):
@@ -460,18 +463,26 @@ class LifecycleManager:
             extra={"event": "lifecycle_on_fill", "symbol": symbol},
         )
         try:
-            stop_loss = entry_price - atr * self._config.trail_atr_mult
-            tp1 = entry_price + atr * self._config.tp1_r
+            tick_size = self._resolve_tick_size(symbol)
+            normalised_entry = self._normalise_price(entry_price, tick_size)
+            stop_loss = self._normalise_price(
+                normalised_entry - atr * self._config.trail_atr_mult,
+                tick_size,
+            )
+            tp1 = self._normalise_price(
+                normalised_entry + atr * self._config.tp1_r,
+                tick_size,
+            )
             tp2_r = (
                 self._config.tp2_r_trend
                 if regime.upper() == "TREND"
                 else self._config.tp2_r_range
             )
-            tp2 = entry_price + atr * tp2_r
+            tp2 = self._normalise_price(normalised_entry + atr * tp2_r, tick_size)
             expiry = self._infer_expiry(symbol)
             position = LifecyclePosition(
                 symbol=symbol,
-                entry_price=entry_price,
+                entry_price=normalised_entry,
                 quantity=quantity,
                 atr=atr,
                 regime=regime.upper(),
@@ -484,6 +495,7 @@ class LifecycleManager:
                 highest_price=entry_price,
                 entry_iv=iv,
                 expiry=expiry,
+                tick_size=tick_size,
             )
             if self._should_apply_gamma_mode(position):
                 LOGGER.warning(
@@ -494,12 +506,18 @@ class LifecycleManager:
                         "symbol": symbol,
                     },
                 )
-                position.tp2 = min(
-                    position.tp2,
-                    position.entry_price + position.atr * self._config.gamma_tp2_r_cap,
+                position.tp2 = self._normalise_price(
+                    min(
+                        position.tp2,
+                        position.entry_price
+                        + position.atr * self._config.gamma_tp2_r_cap,
+                    ),
+                    position.tick_size,
                 )
-                position.sl = position.entry_price - (
-                    position.atr * self._config.gamma_trail_atr_mult
+                position.sl = self._normalise_price(
+                    position.entry_price
+                    - (position.atr * self._config.gamma_trail_atr_mult),
+                    position.tick_size,
                 )
                 self._record_event(
                     symbol,
@@ -559,7 +577,7 @@ class LifecycleManager:
                 trail_mult = self._config.trail_atr_mult
                 if self._is_gamma_active(current_time):
                     trail_mult = self._config.gamma_trail_atr_mult
-                trail_candidate = highest - atr * trail_mult
+                trail_candidate = self._normalise_price(highest - atr * trail_mult, position.tick_size)
                 if position.trail_stop is None:
                     position.trail_stop = trail_candidate
                 else:
@@ -571,7 +589,7 @@ class LifecycleManager:
                     and greeks_iv < position.entry_iv * 0.8
                 ):
                     adjustment = position.tp2 - position.entry_price
-                    position.tp2 = position.entry_price + adjustment * 0.9
+                    position.tp2 = self._normalise_price(position.entry_price + adjustment * 0.9, position.tick_size)
                     self._record_event(
                         symbol,
                         "TP2_ADJUSTED_IV",
@@ -580,7 +598,7 @@ class LifecycleManager:
                 if position.expiry is not None:
                     if position.expiry - current_time <= timedelta(days=1):
                         cap = self._config.gamma_tp2_r_cap
-                        position.tp2 = position.entry_price + position.atr * cap
+                        position.tp2 = self._normalise_price(position.entry_price + position.atr * cap, position.tick_size)
                         self._record_event(
                             symbol,
                             "TP2_ADJUSTED_EXPIRY",
@@ -589,12 +607,14 @@ class LifecycleManager:
                                 "new_tp2": position.tp2,
                             },
                         )
+                if position.trail_stop is not None:
+                    position.sl = max(position.sl, position.trail_stop)
                 self._record_event(
                     symbol,
                     "TRAIL_UPDATED",
                     {
                         "event_type": "TRAIL_UPDATED",
-                        "new_sl": position.trail_stop,
+                        "new_sl": position.sl,
                         "atr": position.atr,
                     },
                 )
@@ -732,16 +752,18 @@ class LifecycleManager:
         price = self._extract_price(tick)
         if price is None:
             return
-        position.highest_price = max(position.highest_price, price)
-        if price <= position.sl:
+        normalised_price = self._normalise_price(price, position.tick_size)
+        epsilon = position.tick_size / 2.0
+        position.highest_price = max(position.highest_price, normalised_price)
+        if normalised_price <= position.sl + epsilon:
             self.exit_at_market(symbol, "STOP_LOSS")
             return
-        if price >= position.tp2:
+        if normalised_price >= position.tp2 - epsilon:
             self.exit_at_market(symbol, "TAKE_PROFIT_2")
             return
-        if price >= position.tp1 and not position.tp1_taken:
+        if normalised_price >= position.tp1 - epsilon and not position.tp1_taken:
             self.partial_exit(symbol, position)
-        if position.trail_stop is not None and price <= position.trail_stop:
+        if position.trail_stop is not None and normalised_price <= position.trail_stop + epsilon:
             self.exit_at_market(symbol, "TRAIL_STOP")
 
     def partial_exit(self, symbol: str, position: LifecyclePosition) -> None:
@@ -774,6 +796,7 @@ class LifecycleManager:
             )
             self._order_queue.submit_order_request(request)
             position.tp1_taken = True
+            position.quantity = max(position.quantity - partial_qty, 0)
             position.sl = position.entry_price
             position.lifecycle_stage = "TP1_TAKEN_RUNNING_TO_TP2"
             self._record_event(
@@ -881,6 +904,32 @@ class LifecycleManager:
                 extra={"event": "lifecycle_state_record_error", "symbol": symbol},
                 exc_info=exc,
             )
+
+    def _normalise_price(self, price: float, tick_size: float) -> float:
+        """Return price rounded to instrument tick-size. Args: price, tick_size. Returns: float. Raises: None."""
+
+        return float(_round_to_tick(price, tick_size=tick_size))
+
+    def _resolve_tick_size(self, symbol: str) -> float:
+        """Resolve symbol tick-size from data hub metadata. Args: symbol. Returns: float. Raises: None."""
+
+        try:
+            if self._data_hub is not None:
+                resolver = getattr(self._data_hub, "resolve_symbol", None)
+                if callable(resolver):
+                    payload = resolver(symbol)
+                    if isinstance(payload, Mapping):
+                        tick = _safe_float(payload.get("tick_size"), 0.05)
+                        if tick > 0:
+                            return tick
+        except Exception as exc:  # noqa: BLE001
+            LOGGER.error(
+                "Failure in LifecycleManager._resolve_tick_size: %s",
+                exc,
+                extra={"event": "lifecycle_tick_size_error", "symbol": symbol},
+                exc_info=exc,
+            )
+        return 0.05
 
     def _fetch_recent_candles(self, symbol: str) -> Iterable[Mapping[str, Any]] | None:
         """Return last 15 candles when the data hub exposes the API.

--- a/src/nifty_scalper_bot/execution/order_queue.py
+++ b/src/nifty_scalper_bot/execution/order_queue.py
@@ -24,7 +24,7 @@ _PRIORITY_MAP: dict[OrderIntent, int] = {
     "ENTRY": 3,
 }
 
-_EMERGENCY_EXIT_INTENTS: set[OrderIntent] = {"EXIT_SL"}
+_EMERGENCY_EXIT_INTENTS: set[OrderIntent] = {"EXIT_SL", "EXIT_TP1", "EXIT_TP2"}
 
 _COUNTER = itertools.count()
 
@@ -153,7 +153,7 @@ class OrderQueue:
                     intent=request.intent, symbol=request.symbol
                 ).inc()
                 QUEUE_DEPTH.set(self._queue.qsize())
-            LOGGER.info(
+            LOGGER.debug(
                 "order_queue_submitted",
                 extra={
                     "event": "order_queue_submitted",
@@ -214,7 +214,7 @@ class OrderQueue:
         dedup_key = (request.symbol.upper(), request.side.upper(), request.intent)
         with self._lock:
             self._dedup.discard(dedup_key)
-        LOGGER.info(
+        LOGGER.debug(
             "order_queue_dequeued",
             extra={
                 "event": "order_queue_dequeued",

--- a/src/nifty_scalper_bot/execution/post_fill_monitor.py
+++ b/src/nifty_scalper_bot/execution/post_fill_monitor.py
@@ -4,8 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import time
-from typing import Any, Awaitable, cast, Iterable
-# 💡 FIX 1: Import json for safe serialization of complex objects in logging
+from typing import Any, Awaitable, Iterable, Mapping, cast
 import json
 
 from nifty_scalper_bot.utils.logging import get_logger
@@ -86,7 +85,9 @@ class PostFillMonitor:
             )
             return
         # BEST PRACTICE: Name the task for debugging
-        self._task = loop.create_task(self._reconciliation_loop(), name="reconciliation-monitor")
+        self._task = loop.create_task(
+            self._reconciliation_loop(), name="reconciliation-monitor"
+        )
 
     async def stop(self) -> None:
         """Stop the background reconciliation loop.
@@ -254,7 +255,7 @@ class PostFillMonitor:
                         exc_info=exc,
                     )
         except asyncio.CancelledError:
-            self._logger.info(
+            self._logger.debug(
                 "Reconciliation loop cancelled",
                 extra={"event": "post_fill_monitor_loop_cancelled"},
             )
@@ -302,7 +303,11 @@ class PostFillMonitor:
         try:
             payload: Any
             if hasattr(self._broker, "get_positions"):
-                payload = await self._broker.get_positions()
+                response = self._broker.get_positions()
+                if asyncio.iscoroutine(response):
+                    payload = await response
+                else:
+                    payload = response
             else:
                 self._logger.error(
                     "CRITICAL: Broker client missing 'get_positions'. Cannot reconcile.",
@@ -312,11 +317,12 @@ class PostFillMonitor:
                 
             # 💡 FIX: Safely log the fetched payload as a JSON string
             if payload:
-                payload_str = json.dumps(payload, indent=2, default=str)
                 self._logger.debug(
-                    "Broker positions fetched: %s",
-                    payload_str,
-                    extra={"event": "broker_positions_fetched", "payload_sample": payload},
+                    "Condition met: broker positions fetched",
+                    extra={
+                        "event": "broker_positions_fetched",
+                        "count": len(payload),
+                    },
                 )
             
         except Exception as exc:  # noqa: BLE001

--- a/tests/execution/test_lifecycle_manager_reliability.py
+++ b/tests/execution/test_lifecycle_manager_reliability.py
@@ -1,0 +1,82 @@
+"""Reliability tests for LifecycleManager exit and trailing behaviour."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from nifty_scalper_bot.execution.lifecycle_manager import LifecycleManager
+from nifty_scalper_bot.execution.order_queue import OrderQueue
+
+
+class _DataHub:
+    def __init__(self) -> None:
+        self.handlers: dict[str, object] = {}
+
+    def subscribe_ticks(self, symbol: str, handler: object) -> None:
+        self.handlers[symbol] = handler
+
+    def unsubscribe_ticks(self, symbol: str, _handler: object) -> None:
+        self.handlers.pop(symbol, None)
+
+
+def test_partial_exit_reduces_remaining_qty() -> None:
+    """Ensure TP1 partial exit updates in-memory remaining quantity."""
+    queue = OrderQueue()
+    manager = LifecycleManager(data_hub=_DataHub(), order_queue=queue)
+
+    manager.on_fill(
+        symbol='NFO:NIFTYTEST',
+        entry_price=100.0,
+        quantity=10,
+        atr=5.0,
+        regime='RANGE',
+    )
+    position = manager._positions['NFO:NIFTYTEST']
+    manager.partial_exit('NFO:NIFTYTEST', position)
+
+    assert position.tp1_taken is True
+    assert position.quantity == 4
+
+
+def test_tick_is_normalized_to_tick_size_for_stop_loss() -> None:
+    """Ensure stop-loss trigger compares normalized prices to avoid missed exits."""
+    queue = OrderQueue()
+    manager = LifecycleManager(data_hub=_DataHub(), order_queue=queue)
+
+    manager.on_fill(
+        symbol='NFO:NIFTYTEST2',
+        entry_price=100.0,
+        quantity=1,
+        atr=5.0,
+        regime='TREND',
+    )
+    position = manager._positions['NFO:NIFTYTEST2']
+    position.tick_size = 0.05
+    position.sl = 99.95
+
+    manager._handle_tick('NFO:NIFTYTEST2', {'ltp': 99.949})
+
+    request = queue.get_next_request(timeout=0.1)
+    assert request is not None
+    assert request.intent == 'EXIT_SL'
+
+
+def test_trailing_updates_authoritative_stop() -> None:
+    """Ensure computed trail stop also advances authoritative stop-loss."""
+    queue = OrderQueue()
+    manager = LifecycleManager(data_hub=_DataHub(), order_queue=queue)
+
+    manager.on_fill(
+        symbol='NFO:NIFTYTEST3',
+        entry_price=100.0,
+        quantity=1,
+        atr=5.0,
+        regime='TREND',
+    )
+    position = manager._positions['NFO:NIFTYTEST3']
+    position.highest_price = 120.0
+
+    manager.update_all_positions(datetime.now(timezone.utc))
+
+    assert position.trail_stop is not None
+    assert position.sl >= position.trail_stop

--- a/tests/execution/test_post_fill_monitor_sync_positions.py
+++ b/tests/execution/test_post_fill_monitor_sync_positions.py
@@ -1,0 +1,39 @@
+"""Compatibility tests for PostFillMonitor broker position fetch modes."""
+
+from __future__ import annotations
+
+import asyncio
+
+from nifty_scalper_bot.execution.post_fill_monitor import PostFillMonitor
+
+
+class _SyncBroker:
+    def get_positions(self) -> list[dict[str, object]]:
+        return [{'symbol': 'NFO:NIFTY', 'quantity': 1, 'avg_price': 100.0}]
+
+
+class _Tracker:
+    def __init__(self) -> None:
+        self.updated: list[tuple[str, dict[str, object]]] = []
+
+    def get_open_positions(self) -> list[dict[str, object]]:
+        return []
+
+    def update_position(self, symbol: str, payload: dict[str, object]) -> None:
+        self.updated.append((symbol, payload))
+
+
+def test_reconcile_supports_sync_get_positions() -> None:
+    """Ensure monitor accepts synchronous broker clients."""
+
+    async def _run() -> None:
+        tracker = _Tracker()
+        monitor = PostFillMonitor(
+            broker_client=_SyncBroker(),
+            state_tracker=tracker,
+            interval_sec=15,
+        )
+        await monitor.reconcile()
+        assert tracker.updated
+
+    asyncio.run(_run())


### PR DESCRIPTION
### Motivation
- Stop-loss and trailing exits were occasionally missed due to mixed price precision and non‑authoritative trail state, reducing execution determinism.
- Multiple modules could independently decide exits and duplicate protection sometimes blocked valid immediate exits during volatile conditions.
- Broker reconciliation and high-frequency telemetry were brittle for different broker client implementations and produced noisy logs.

### Description
- Normalize all lifecycle entry, stop, and target prices to instrument tick-size by adding `_normalise_price` and `_resolve_tick_size` and using them in `LifecycleManager.on_fill`, `update_all_positions`, and `_handle_tick` so comparisons are deterministic and tick-aligned.
- Promote trailing updates into the authoritative stop source by applying `trail_stop` back into `position.sl`, ensuring a single source-of-truth for exit decisions.
- Fix partial exit accounting to reduce the in-memory `position.quantity` on `TP1` so later TP2/SL dispatches use the remaining quantity only.
- Change `OrderQueue` dedupe rules to allow all exit intents (`EXIT_SL`, `EXIT_TP1`, `EXIT_TP2`) to bypass duplicate rejection and demote hot-path enqueue/dequeue logging from `INFO` to `DEBUG` to cut logging noise.
- Harden `PostFillMonitor` reconciliation to accept both synchronous and asynchronous `get_positions()` broker implementations and reduce excessive payload logging; make cancellation/monitor logs DEBUG to reduce noise.
- Add focused unit tests for lifecycle reliability (`tests/execution/test_lifecycle_manager_reliability.py`) and sync broker reconciliation (`tests/execution/test_post_fill_monitor_sync_positions.py`).

### Testing
- Ran targeted pytest command: `pytest -q tests/execution/test_order_queue_reliability.py tests/execution/test_lifecycle_manager_reliability.py tests/execution/test_post_fill_monitor_reconcile.py tests/execution/test_post_fill_monitor_sync_positions.py` and all tests passed.
- Executed `./run_checks.sh` in this environment; the script started but the created venv did not have Ruff/mypy/pytest installed and reported: `❌ pytest not installed but tests/ exists` (environment provisioning issues), so full repo checks could not complete here; excerpt included in commit description.
- Attempted broader test run `pytest -q tests --disable-warnings --ignore=tests/test_live_mode.py --ignore=tests/test_health_server.py` which surfaced an unrelated repo test import failure (`ModuleNotFoundError: market_data_manager`) present prior to these changes and outside the scope of this patch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2d9d7f1dc8324a99f6b44a485760d)