### PR TITLE
fix: deterministic candle lifecycle with hydration & WS fallback guards

### DIFF
--- a/src/nifty_scalper_bot/data/candle_engine.py
+++ b/src/nifty_scalper_bot/data/candle_engine.py
@@ -1,0 +1,226 @@
+"""Deterministic candle lifecycle + data hydration helpers."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Callable, Mapping
+
+import pandas as pd
+
+FetchHistoricalFn = Callable[[str], pd.DataFrame | None]
+FetchRecentFn = Callable[[str], pd.DataFrame | None]
+
+
+@dataclass(slots=True)
+class CandleEngine:
+    """Build candles from ticks.
+
+    Args: interval/max_bars. Returns: engine. Raises: ValueError.
+    """
+
+    interval: str = "1min"
+    max_bars: int = 500
+    df: pd.DataFrame = field(default_factory=pd.DataFrame)
+    current_candle: dict[str, Any] | None = None
+    last_candle_close: datetime | None = None
+
+    def on_tick(self, tick: Mapping[str, Any]) -> None:
+        """Ingest tick. Args: tick. Returns: None. Raises: ValueError."""
+        ts = pd.to_datetime(tick["timestamp"], utc=True)
+        raw_price = tick.get("price") or tick.get("ltp") or tick.get("last_price")
+        if raw_price is None:
+            msg = "tick price is required"
+            raise ValueError(msg)
+        price = float(raw_price)
+        normalized_tick: dict[str, Any] = {
+            "timestamp": ts,
+            "price": price,
+            "volume": float(tick.get("volume") or 0.0),
+        }
+
+        if self.current_candle is None:
+            self.current_candle = self._init_candle(normalized_tick)
+            return
+
+        if ts >= self._candle_close_time(
+            pd.Timestamp(self.current_candle["timestamp"])
+        ):
+            self._finalize_candle()
+            self.current_candle = self._init_candle(normalized_tick)
+        else:
+            self._update_candle(normalized_tick)
+
+    def _init_candle(self, tick: Mapping[str, Any]) -> dict[str, Any]:
+        """Create candle. Args: tick. Returns: candle dict. Raises: None."""
+        price = float(tick["price"])
+        return {
+            "timestamp": pd.to_datetime(tick["timestamp"], utc=True),
+            "open": price,
+            "high": price,
+            "low": price,
+            "close": price,
+            "volume": float(tick.get("volume") or 0.0),
+        }
+
+    def _update_candle(self, tick: Mapping[str, Any]) -> None:
+        """Update candle. Args: tick. Returns: None. Raises: None."""
+        if self.current_candle is None:
+            return
+        price = float(tick["price"])
+        self.current_candle["high"] = max(float(self.current_candle["high"]), price)
+        self.current_candle["low"] = min(float(self.current_candle["low"]), price)
+        self.current_candle["close"] = price
+        self.current_candle["volume"] = float(
+            self.current_candle.get("volume") or 0.0
+        ) + float(tick.get("volume") or 0.0)
+
+    def _candle_close_time(self, ts: pd.Timestamp) -> pd.Timestamp:
+        """Return close time. Args: ts. Returns: timestamp. Raises: ValueError."""
+        if self.interval != "1min":
+            msg = f"Unsupported interval: {self.interval}"
+            raise ValueError(msg)
+        base = ts.floor("min")
+        return base + pd.Timedelta(minutes=1)
+
+    def _finalize_candle(self) -> None:
+        """Persist candle. Args: none. Returns: None. Raises: None."""
+        if self.current_candle is None:
+            return
+        df_new = pd.DataFrame([self.current_candle])
+        merged = pd.concat([self.df, df_new], ignore_index=True)
+        merged = merged.drop_duplicates(subset="timestamp", keep="last")
+        merged = (
+            merged.sort_values("timestamp").tail(self.max_bars).reset_index(drop=True)
+        )
+        self.df = merged
+        self.last_candle_close = pd.to_datetime(
+            self.current_candle["timestamp"], utc=True
+        )
+
+    def get_df(self) -> pd.DataFrame:
+        """Return candles. Args: none. Returns: DataFrame. Raises: None."""
+        return self.df.copy(deep=True)
+
+
+def detect_gap(df: pd.DataFrame) -> bool:
+    """Detect gaps. Args: df. Returns: bool. Raises: None."""
+    if df is None or len(df) < 3 or "timestamp" not in df.columns:
+        return False
+    ts = (
+        pd.to_datetime(df["timestamp"], utc=True, errors="coerce")
+        .dropna()
+        .sort_values()
+    )
+    if len(ts) < 3:
+        return False
+    diffs = ts.diff().dropna()
+    expected = diffs.mode().iloc[0]
+    return bool((diffs != expected).any())
+
+
+def repair_with_backfill(
+    symbol: str,
+    df: pd.DataFrame,
+    *,
+    fetch_recent_rest: FetchRecentFn,
+    max_bars: int = 500,
+) -> pd.DataFrame:
+    """Repair gaps.
+
+    Args: symbol/df/fetch_recent_rest/max_bars. Returns: DataFrame. Raises: Exception.
+    """
+    recent = fetch_recent_rest(symbol)
+    if recent is None or recent.empty:
+        return df.tail(max_bars).copy() if df is not None else pd.DataFrame()
+
+    merged = pd.concat([df, recent], ignore_index=True)
+    merged["timestamp"] = pd.to_datetime(merged["timestamp"], utc=True, errors="coerce")
+    merged = merged.dropna(subset=["timestamp"])
+    merged = merged.drop_duplicates(subset="timestamp", keep="last")
+    merged = merged.sort_values("timestamp")
+    return merged.tail(max_bars).reset_index(drop=True)
+
+
+def fetch_historical_safe(
+    symbol: str,
+    *,
+    fetch_historical: FetchHistoricalFn,
+    min_required: int = 50,
+    retries: int = 3,
+    sleep_seconds: float = 0.5,
+) -> pd.DataFrame | None:
+    """Fetch history safely.
+
+    Args: symbol/fetch_historical/min_required/retries/sleep_seconds.
+    Returns: DataFrame|None. Raises: None.
+    """
+    for _ in range(retries):
+        df = fetch_historical(symbol)
+        if df is not None and len(df) >= min_required:
+            return df
+        time.sleep(sleep_seconds)
+    return None
+
+
+def validate_dataframe(df: pd.DataFrame | None, min_required: int = 50) -> bool:
+    """Validate candles. Args: df/min_required. Returns: bool. Raises: None."""
+    if df is None:
+        return False
+    if len(df) < min_required:
+        return False
+    if df.isnull().any().any():
+        return False
+    if df.duplicated(subset="timestamp").any():
+        return False
+    if detect_gap(df):
+        return False
+    return True
+
+
+def normalize_ohlc_timezone(df: pd.DataFrame) -> pd.DataFrame:
+    """Normalize tz. Args: df. Returns: DataFrame. Raises: None."""
+    normalized = df.copy()
+    ts = pd.to_datetime(normalized["timestamp"], errors="coerce", utc=True)
+    normalized["timestamp"] = ts.dt.tz_convert("Asia/Kolkata")
+    normalized = normalized.dropna(subset=["timestamp"]).set_index("timestamp")
+    return normalized
+
+
+def ensure_valid_data(
+    symbol: str,
+    engine: CandleEngine,
+    *,
+    fetch_historical: FetchHistoricalFn,
+    fetch_recent_rest: FetchRecentFn,
+    min_required: int = 50,
+) -> pd.DataFrame | None:
+    """Ensure valid candles.
+
+    Args: symbol/engine/fetch_historical/fetch_recent_rest/min_required.
+    Returns: DataFrame|None. Raises: None.
+    """
+    df = engine.get_df()
+
+    if not validate_dataframe(df, min_required=min_required):
+        df_hist = fetch_historical_safe(
+            symbol,
+            fetch_historical=fetch_historical,
+            min_required=min_required,
+        )
+        if df_hist is not None:
+            engine.df = df_hist.copy(deep=True)
+            return engine.get_df()
+        return None
+
+    if detect_gap(df):
+        repaired = repair_with_backfill(
+            symbol,
+            df,
+            fetch_recent_rest=fetch_recent_rest,
+            max_bars=engine.max_bars,
+        )
+        engine.df = repaired.copy(deep=True)
+
+    return engine.get_df()

--- a/src/nifty_scalper_bot/strategies/indicators.py
+++ b/src/nifty_scalper_bot/strategies/indicators.py
@@ -7,10 +7,10 @@ that calculates common technical indicators from the stored price history.
 
 from __future__ import annotations
 
-import logging
-import threading
 from collections import deque
 from datetime import datetime, time, timedelta, timezone
+import logging
+import threading
 from typing import Any, Callable, Deque, Dict, Iterable, Mapping, Sequence
 from zoneinfo import ZoneInfo
 
@@ -279,7 +279,9 @@ class IndicatorEngine:
             try:
                 self._augment_session_metrics(symbol, indicators)
             except Exception as e:
-                __import__("logging").getLogger(__name__).exception("[CRITICAL] unhandled exception", exc_info=True)
+                __import__("logging").getLogger(__name__).exception(
+                    "[CRITICAL] unhandled exception", exc_info=True
+                )
                 raise  # Session metrics are non-critical — don't crash pipeline
             # ✅ FIX S1: Expose latest-bar OHLC for strategies that need it
             history = self._histories.get(symbol)
@@ -804,16 +806,16 @@ class IndicatorEngine:
                 log_throttled(
                     LOGGER,
                     f"indicator_gap_{symbol}",
-                    "Condition met: indicator_integrity_missing_candle",
+                    "skipped: invalid data",
                     interval_sec=300.0,
                     level=logging.WARNING,
                     extra={
-                        "event": "indicator_integrity_missing_candle",
+                        "event": "indicator_gap_detected",
                         "symbol": symbol,
                         "gap_seconds": gap_seconds,
                     },
                 )
-                continue
+                return False
         return True
 
     def ensure_min_bars(
@@ -1322,7 +1324,9 @@ class IndicatorEngine:
                             )
                             return estimated_atr
             except Exception as e:
-                __import__("logging").getLogger(__name__).exception("[CRITICAL] unhandled exception", exc_info=True)
+                __import__("logging").getLogger(__name__).exception(
+                    "[CRITICAL] unhandled exception", exc_info=True
+                )
                 raise
             return None
 
@@ -1373,7 +1377,9 @@ class IndicatorEngine:
                     if closes:
                         return float(closes[-1]) * 0.015
             except Exception as e:
-                __import__("logging").getLogger(__name__).exception("[CRITICAL] unhandled exception", exc_info=True)
+                __import__("logging").getLogger(__name__).exception(
+                    "[CRITICAL] unhandled exception", exc_info=True
+                )
                 raise
             return None
 

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -39,6 +39,12 @@ from nifty_scalper_bot.core.message_bus import Message, MessageBus, MessageType
 from nifty_scalper_bot.core.strategy_manager import StrategyManager
 from nifty_scalper_bot.core.trade_manager import TradeManager
 from nifty_scalper_bot.core.universe_controller import UniverseController
+from nifty_scalper_bot.data.candle_engine import (
+    CandleEngine,
+    ensure_valid_data,
+    normalize_ohlc_timezone,
+    validate_dataframe,
+)
 
 # Assumes you created the data/constants.py file as advised
 from nifty_scalper_bot.data.market_data_manager import MarketDataManager
@@ -618,7 +624,9 @@ class StrategyRunner:
         self._eval_gate_lock = threading.Lock()
         self._last_global_eval_ts: float = time.monotonic()
         self._last_tick_seen_ts: float = time.monotonic()
+        self._last_tick_time_by_symbol: dict[str, float] = {}
         self._last_stall_warn_ts: float = 0.0  # throttle stall warnings to 30s
+        self._candle_engines: dict[str, CandleEngine] = {}
         self._symbol_history: dict[str, list[OneMinuteBar]] = {}
         self._hydration_ready_streak: dict[str, int] = {}
         self._frozen_universe: set[str] = set()
@@ -837,6 +845,7 @@ class StrategyRunner:
         """Begin tracking a new symbol."""
         normalized = self._normalize_symbol(symbol)
         with self._lock:
+            self._candle_engines.setdefault(normalized, CandleEngine())
             state = self._symbol_state.get(normalized)
             if state is None:
                 state = SymbolRuntimeState(
@@ -910,7 +919,10 @@ class StrategyRunner:
             if "timestamp" not in df.columns:
                 return False
             df["timestamp"] = pd.to_datetime(df["timestamp"], utc=True, errors="coerce")
-            df = df.dropna(subset=["timestamp"]).set_index("timestamp")
+            df = df.dropna(subset=["timestamp"])
+            if not validate_dataframe(df, min_required=self._required_candles):
+                return False
+            df = normalize_ohlc_timezone(df)
             return is_symbol_valid(df, min_required_bars=self._required_candles)
         except Exception as exc:  # noqa: BLE001
             self._logger.error(
@@ -1334,13 +1346,7 @@ class StrategyRunner:
                 if self._symbol_has_valid_data(normalized):
                     valid_symbols.append(normalized)
                 else:
-                    self._logger.warning(
-                        "Condition met: symbol_excluded_invalid_data",
-                        extra={
-                            "event": "symbol_excluded_invalid_data",
-                            "symbol": normalized,
-                        },
-                    )
+                    self._logger.warning("skipped: invalid data")
 
         # 5. Keep _startup_hydrated=True so Phase 7 can promote HYDRATING→DEGRADED
         # while _symbol_history is still empty (no live bars yet, first minute after
@@ -1353,14 +1359,7 @@ class StrategyRunner:
             self._logger.info("🚀 StrategyRunner execution enabled")
         else:
             self._runner_state = RunnerState.HISTORICAL_READY
-            self._logger.warning(
-                "Condition met: runner_not_ready_invalid_symbol_data",
-                extra={
-                    "event": "runner_not_ready_invalid_symbol_data",
-                    "valid_symbols": len(valid_symbols),
-                    "required_symbols": self._required_symbol_count,
-                },
-            )
+            self._logger.warning("skipped: invalid data")
 
         # BUG W1 FIX: Removed deadlocking tick-wait that caused 21s startup delay.
         # mark_ready() is called from startup_sequence() (event-loop thread).
@@ -3057,6 +3056,9 @@ class StrategyRunner:
             normalized_symbol = enforce_canonical(normalize_symbol(str(symbol)))
             if normalized_symbol.count(":") != 1:
                 raise RuntimeError(f"Malformed canonical symbol: {normalized_symbol}")
+            self._last_tick_time_by_symbol[normalized_symbol] = time.time()
+            engine = self._candle_engines.setdefault(normalized_symbol, CandleEngine())
+            engine.on_tick(tick)
             now_mono = time.monotonic()
             self._last_tick_seen_ts = now_mono
             # ✅ FIX: Throttle stall warning to 30s — same-bar-skip causes expected
@@ -3092,6 +3094,20 @@ class StrategyRunner:
                 "STRATEGY_RECEIVED_TICK",
                 extra={"event": "strategy_received_tick", "symbol": normalized_symbol},
             )
+            safe_df = ensure_valid_data(
+                normalized_symbol,
+                engine,
+                fetch_historical=lambda sym: pd.DataFrame(
+                    self._hydrate_missing_bars(sym, max(self._required_candles, 50))
+                ),
+                fetch_recent_rest=lambda sym: pd.DataFrame(
+                    self._hydrate_missing_bars(sym, max(self._required_candles, 50))
+                ),
+                min_required=max(self._required_candles, 50),
+            )
+            if safe_df is None:
+                self._logger.warning("skipped: invalid data")
+                return
             with self._eval_gate_lock:
                 if normalized_symbol in self._eval_in_progress_symbols:
                     return
@@ -3163,6 +3179,22 @@ class StrategyRunner:
                     "stall_sec": round(now - self._last_global_eval_ts, 1),
                 },
             )
+        now_wall = time.time()
+        for symbol, engine in self._candle_engines.items():
+            if now_wall - self._last_tick_time_by_symbol.get(symbol, 0.0) > 2.0:
+                self._logger.info("%s: WS stale → backfill", symbol)
+                try:
+                    repaired = pd.DataFrame(
+                        self._hydrate_missing_bars(
+                            symbol, max(self._required_candles, 50)
+                        )
+                    )
+                    if not repaired.empty:
+                        engine.df = repaired
+                except Exception as exc:  # noqa: BLE001
+                    self._logger.error(
+                        "Failure in StrategyRunner._health_watchdog: %s", exc
+                    )
 
     # ✅ FIX: New Method to Prime Indicators
     async def _backfill_history(self) -> None:

--- a/tests/data/test_candle_engine.py
+++ b/tests/data/test_candle_engine.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pandas as pd
+
+from nifty_scalper_bot.data.candle_engine import (
+    CandleEngine,
+    detect_gap,
+    ensure_valid_data,
+    fetch_historical_safe,
+    validate_dataframe,
+)
+
+
+def _tick(ts: datetime, price: float) -> dict[str, float | datetime]:
+    return {"timestamp": ts, "price": price, "volume": 1.0}
+
+
+def test_candle_engine_finalizes_closed_candle() -> None:
+    engine = CandleEngine()
+    ts = datetime(2026, 1, 2, 9, 15, tzinfo=timezone.utc)
+    engine.on_tick(_tick(ts, 100.0))
+    engine.on_tick(_tick(ts + timedelta(seconds=10), 102.0))
+    engine.on_tick(_tick(ts + timedelta(minutes=1), 101.0))
+
+    df = engine.get_df()
+    assert len(df) == 1
+    row = df.iloc[0]
+    assert row["open"] == 100.0
+    assert row["high"] == 102.0
+    assert row["low"] == 100.0
+    assert row["close"] == 102.0
+
+
+def test_detect_gap_returns_true_for_missing_minute() -> None:
+    ts = datetime(2026, 1, 2, 9, 15, tzinfo=timezone.utc)
+    df = pd.DataFrame(
+        [
+            {"timestamp": ts, "open": 1, "high": 1, "low": 1, "close": 1},
+            {
+                "timestamp": ts + timedelta(minutes=1),
+                "open": 1,
+                "high": 1,
+                "low": 1,
+                "close": 1,
+            },
+            {
+                "timestamp": ts + timedelta(minutes=3),
+                "open": 1,
+                "high": 1,
+                "low": 1,
+                "close": 1,
+            },
+        ]
+    )
+
+    assert detect_gap(df) is True
+    assert validate_dataframe(df, min_required=3) is False
+
+
+def test_fetch_historical_safe_retries_until_minimum() -> None:
+    calls = {"count": 0}
+
+    def fetch(_symbol: str) -> pd.DataFrame:
+        calls["count"] += 1
+        if calls["count"] < 3:
+            return pd.DataFrame([{"timestamp": datetime.now(timezone.utc)}])
+        ts = datetime(2026, 1, 2, 9, 15, tzinfo=timezone.utc)
+        return pd.DataFrame(
+            [{"timestamp": ts + timedelta(minutes=i)} for i in range(50)]
+        )
+
+    result = fetch_historical_safe("NFO:NIFTY", fetch_historical=fetch, min_required=50)
+    assert result is not None
+    assert len(result) == 50
+    assert calls["count"] == 3
+
+
+def test_ensure_valid_data_hydrates_when_cache_invalid() -> None:
+    engine = CandleEngine()
+    engine.df = pd.DataFrame()
+    ts = datetime(2026, 1, 2, 9, 15, tzinfo=timezone.utc)
+    hist = pd.DataFrame(
+        [
+            {
+                "timestamp": ts + timedelta(minutes=i),
+                "open": 100.0,
+                "high": 101.0,
+                "low": 99.0,
+                "close": 100.5,
+                "volume": 10,
+            }
+            for i in range(50)
+        ]
+    )
+
+    out = ensure_valid_data(
+        "NFO:NIFTY",
+        engine,
+        fetch_historical=lambda _symbol: hist,
+        fetch_recent_rest=lambda _symbol: hist,
+        min_required=50,
+    )
+
+    assert out is not None
+    assert len(out) == 50

--- a/tests/strategies/test_indicator_integrity.py
+++ b/tests/strategies/test_indicator_integrity.py
@@ -15,24 +15,24 @@ def test_has_min_bars_rejects_non_monotonic_timestamps() -> None:
     assert engine.has_min_bars(symbol, 2) is False
 
 
-def test_has_min_bars_allows_missing_candle_gap_for_live_feed_jitter() -> None:
+def test_has_min_bars_rejects_missing_candle_gap_for_live_feed_jitter() -> None:
     engine = IndicatorEngine()
     symbol = "NIFTY25JAN25000PE"
     ts = datetime.now(timezone.utc).replace(second=0, microsecond=0)
     engine.update_price(symbol, 100.0, timestamp=ts)
     engine.update_price(symbol, 101.0, timestamp=ts + timedelta(minutes=3))
 
-    assert engine.has_min_bars(symbol, 2) is True
+    assert engine.has_min_bars(symbol, 2) is False
 
 
-def test_has_min_bars_allows_large_gap_after_integrity_warning() -> None:
+def test_has_min_bars_rejects_large_gap_after_integrity_warning() -> None:
     engine = IndicatorEngine()
     symbol = "NIFTY25JAN25050PE"
     ts = datetime.now(timezone.utc).replace(second=0, microsecond=0)
     engine.update_price(symbol, 100.0, timestamp=ts)
     engine.update_price(symbol, 101.0, timestamp=ts + timedelta(minutes=15))
 
-    assert engine.has_min_bars(symbol, 2) is True
+    assert engine.has_min_bars(symbol, 2) is False
 
 
 def test_has_min_bars_rejects_provisional_candles() -> None:


### PR DESCRIPTION
### Motivation
- Indicators and strategies were operating on inconsistent OHLC data (gaps, provisional/incomplete bars, non-monotonic timestamps) causing unstable signals and occasional global gating; closed candles must be the source of truth.
- Introduce deterministic candle lifecycle, gap detection/repair and a hydration path so indicators always see indicator-safe data without blocking trading globally.

### Description
- Added `src/nifty_scalper_bot/data/candle_engine.py` implementing `CandleEngine`, `detect_gap`, `repair_with_backfill`, `fetch_historical_safe`, `validate_dataframe`, `normalize_ohlc_timezone`, and `ensure_valid_data` for deterministic candle building and self-healing hydration.
- Integrated per-symbol `CandleEngine` into `StrategyRunner` and updated tick path to: update per-symbol engine on every tick, track last-tick times, and gate strategy evaluation by calling `ensure_valid_data` (uses historical fetch/backfill when needed) so strategies only evaluate on validated closed candles.
- Added a WS-stale watchdog in `StrategyRunner._health_watchdog` to trigger REST backfill repairs for stale symbols and populate engines with repaired history.
- Replaced noisy/locking legacy invalid-data events with a safe skip path (`log: "skipped: invalid data"`) so individual symbols can degrade without blocking global execution.
- Tightened indicator readiness in `IndicatorEngine` to fail on large gaps and emit `indicator_gap_detected` (prevents indicator truthiness from being falsely satisfied when gaps exist).
- Tests: added `tests/data/test_candle_engine.py` covering candle finalization, gap detection, historical retry and hydration; updated `tests/strategies/test_indicator_integrity.py` expectations to reflect stricter gap handling.

### Testing
- Ran full checks script `./run_checks.sh`; this run surfaced pre-existing repo-wide Ruff/mypy issues unrelated to this change so the global script did not exit green (baseline linter/type-check failures exist across the repository).
- Focused validation for the change: `pytest -q tests/data/test_candle_engine.py tests/strategies/test_indicator_integrity.py` completed and all tests passed.
- Formatting/linting for the new module and test exercised: `black`/`isort`/`ruff check` on the modified files ran successfully for the added/changed files.
- `mypy` run against the repository reported existing type issues outside the modified files; the new candle engine is typed but the project-level mypy baseline requires separate remediation and is out of scope for this patch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c032ca416c8324b4da018dc1870940)