### PR TITLE
fix: stabilize websocket subscriptions and add self‑healing candle backfill/sanitize

### DIFF
--- a/src/nifty_scalper_bot/data/candle_engine.py
+++ b/src/nifty_scalper_bot/data/candle_engine.py
@@ -13,6 +13,26 @@ FetchHistoricalFn = Callable[[str], pd.DataFrame | None]
 FetchRecentFn = Callable[[str], pd.DataFrame | None]
 
 
+def sanitize(df: pd.DataFrame | None) -> pd.DataFrame:
+    """Sanitize OHLCV frame. Args: df. Returns: cleaned DataFrame. Raises: None."""
+    if df is None or df.empty:
+        return pd.DataFrame()
+    cleaned = df.copy()
+    if "timestamp" in cleaned.columns:
+        cleaned["timestamp"] = pd.to_datetime(
+            cleaned["timestamp"], utc=True, errors="coerce"
+        )
+        cleaned = cleaned.dropna(subset=["timestamp"])
+        cleaned = cleaned.drop_duplicates(subset="timestamp", keep="last")
+        cleaned = cleaned.sort_values("timestamp")
+    else:
+        cleaned = cleaned.drop_duplicates()
+    cleaned = cleaned.ffill().bfill()
+    if "close" in cleaned.columns:
+        cleaned = cleaned[~cleaned["close"].isna()]
+    return cleaned.reset_index(drop=True)
+
+
 @dataclass(slots=True)
 class CandleEngine:
     """Build candles from ticks.
@@ -131,15 +151,13 @@ def repair_with_backfill(
 
     Args: symbol/df/fetch_recent_rest/max_bars. Returns: DataFrame. Raises: Exception.
     """
-    recent = fetch_recent_rest(symbol)
-    if recent is None or recent.empty:
-        return df.tail(max_bars).copy() if df is not None else pd.DataFrame()
+    old_df = sanitize(df)
+    recent = sanitize(fetch_recent_rest(symbol))
+    if recent.empty:
+        return old_df.tail(max_bars).copy()
 
-    merged = pd.concat([df, recent], ignore_index=True)
-    merged["timestamp"] = pd.to_datetime(merged["timestamp"], utc=True, errors="coerce")
-    merged = merged.dropna(subset=["timestamp"])
-    merged = merged.drop_duplicates(subset="timestamp", keep="last")
-    merged = merged.sort_values("timestamp")
+    merged = pd.concat([old_df, recent], ignore_index=True)
+    merged = sanitize(merged)
     return merged.tail(max_bars).reset_index(drop=True)
 
 
@@ -169,6 +187,8 @@ def validate_dataframe(df: pd.DataFrame | None, min_required: int = 50) -> bool:
     if df is None:
         return False
     if len(df) < min_required:
+        return False
+    if "timestamp" not in df.columns:
         return False
     if df.isnull().any().any():
         return False
@@ -201,7 +221,9 @@ def ensure_valid_data(
     Args: symbol/engine/fetch_historical/fetch_recent_rest/min_required.
     Returns: DataFrame|None. Raises: None.
     """
-    df = engine.get_df()
+    df = sanitize(engine.get_df())
+    if not df.equals(engine.df):
+        engine.df = df.copy(deep=True)
 
     if not validate_dataframe(df, min_required=min_required):
         df_hist = fetch_historical_safe(
@@ -210,9 +232,24 @@ def ensure_valid_data(
             min_required=min_required,
         )
         if df_hist is not None:
-            engine.df = df_hist.copy(deep=True)
-            return engine.get_df()
-        return None
+            repaired = sanitize(df_hist)
+            engine.df = repaired.copy(deep=True)
+            df = engine.get_df()
+        else:
+            return None
+
+    if not validate_dataframe(df, min_required=min_required):
+        repaired = repair_with_backfill(
+            symbol,
+            df,
+            fetch_recent_rest=fetch_recent_rest,
+            max_bars=engine.max_bars,
+        )
+        if validate_dataframe(repaired, min_required=min_required):
+            engine.df = repaired.copy(deep=True)
+            df = engine.get_df()
+        else:
+            return None
 
     if detect_gap(df):
         repaired = repair_with_backfill(

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -43,6 +43,8 @@ from nifty_scalper_bot.data.candle_engine import (
     CandleEngine,
     ensure_valid_data,
     normalize_ohlc_timezone,
+    repair_with_backfill,
+    sanitize,
     validate_dataframe,
 )
 
@@ -624,7 +626,12 @@ class StrategyRunner:
         self._eval_gate_lock = threading.Lock()
         self._last_global_eval_ts: float = time.monotonic()
         self._last_tick_seen_ts: float = time.monotonic()
-        self._last_tick_time_by_symbol: dict[str, float] = {}
+        self._last_tick_time_by_symbol: dict[str, float] = defaultdict(float)
+        self._symbol_locks: defaultdict[str, threading.Lock] = defaultdict(
+            threading.Lock
+        )
+        self._last_ws_stale_log_ts_by_symbol: dict[str, float] = defaultdict(float)
+        self._last_ws_reconnect_attempt_ts: float = 0.0
         self._last_stall_warn_ts: float = 0.0  # throttle stall warnings to 30s
         self._candle_engines: dict[str, CandleEngine] = {}
         self._symbol_history: dict[str, list[OneMinuteBar]] = {}
@@ -1239,20 +1246,22 @@ class StrategyRunner:
             callback = _callback
             self._callbacks[symbol] = callback
 
-        if self._data_hub is not None:
-            # Primary deterministic path: DataHub subscription only.
-            try:
+        self._safe_subscribe(symbol, callback)
+
+    def _safe_subscribe(
+        self, symbol: str, callback: Callable[[Mapping[str, Any]], None]
+    ) -> None:
+        """Subscribe symbol safely. Args: symbol/callback. Returns: None. Raises: None."""
+        try:
+            if self._data_hub is not None:
                 self._data_hub.subscribe_ticks(symbol, callback)
-            except Exception as exc:  # noqa: BLE001
-                self._logger.error(
-                    "Failure in StrategyRunner._subscribe_symbol: %s", exc
-                )
-        elif self._legacy_tick_subscription_mode:
-            self._market_data.subscribe(symbol, callback)
-        else:
-            self._logger.error(
-                "DataHub unavailable and legacy subscription mode disabled"
-            )
+                return
+            if self._legacy_tick_subscription_mode:
+                self._market_data.subscribe(symbol, callback)
+                return
+            raise RuntimeError("DataHub unavailable and legacy subscription disabled")
+        except Exception as exc:
+            self._logger.error("SUBSCRIBE_FAIL %s: %s", symbol, exc)
 
     def ingest_historical_bar(self, data: dict) -> None:
         """
@@ -3058,7 +3067,8 @@ class StrategyRunner:
                 raise RuntimeError(f"Malformed canonical symbol: {normalized_symbol}")
             self._last_tick_time_by_symbol[normalized_symbol] = time.time()
             engine = self._candle_engines.setdefault(normalized_symbol, CandleEngine())
-            engine.on_tick(tick)
+            with self._symbol_locks[normalized_symbol]:
+                engine.on_tick(tick)
             now_mono = time.monotonic()
             self._last_tick_seen_ts = now_mono
             # ✅ FIX: Throttle stall warning to 30s — same-bar-skip causes expected
@@ -3181,20 +3191,41 @@ class StrategyRunner:
             )
         now_wall = time.time()
         for symbol, engine in self._candle_engines.items():
-            if now_wall - self._last_tick_time_by_symbol.get(symbol, 0.0) > 2.0:
-                self._logger.info("%s: WS stale → backfill", symbol)
+            stale_for = now_wall - self._last_tick_time_by_symbol[symbol]
+            if stale_for > 3.0:
+                if now_wall - self._last_ws_stale_log_ts_by_symbol[symbol] >= 15.0:
+                    self._logger.info("%s: WS stale → backfill", symbol)
+                    self._last_ws_stale_log_ts_by_symbol[symbol] = now_wall
                 try:
-                    repaired = pd.DataFrame(
-                        self._hydrate_missing_bars(
-                            symbol, max(self._required_candles, 50)
-                        )
+                    repair_input = pd.DataFrame(
+                        self._hydrate_missing_bars(symbol, max(self._required_candles, 50))
                     )
-                    if not repaired.empty:
-                        engine.df = repaired
+                    if repair_input.empty:
+                        continue
+                    with self._symbol_locks[symbol]:
+                        repaired = repair_with_backfill(
+                            symbol,
+                            sanitize(engine.get_df()),
+                            fetch_recent_rest=lambda _sym: repair_input,
+                            max_bars=engine.max_bars,
+                        )
+                        if not repaired.empty:
+                            engine.df = repaired
                 except Exception as exc:  # noqa: BLE001
                     self._logger.error(
                         "Failure in StrategyRunner._health_watchdog: %s", exc
                     )
+                if now_wall - self._last_ws_reconnect_attempt_ts >= 5.0:
+                    self._last_ws_reconnect_attempt_ts = now_wall
+                    try:
+                        reconnect = getattr(self._market_data, "_trigger_zombie_ws_restart", None)
+                        if callable(reconnect):
+                            reconnect()
+                    except Exception as exc:  # noqa: BLE001
+                        self._logger.error(
+                            "Failure in StrategyRunner._health_watchdog.reconnect: %s",
+                            exc,
+                        )
 
     # ✅ FIX: New Method to Prime Indicators
     async def _backfill_history(self) -> None:

--- a/tests/data/test_candle_engine.py
+++ b/tests/data/test_candle_engine.py
@@ -9,6 +9,8 @@ from nifty_scalper_bot.data.candle_engine import (
     detect_gap,
     ensure_valid_data,
     fetch_historical_safe,
+    repair_with_backfill,
+    sanitize,
     validate_dataframe,
 )
 
@@ -105,3 +107,72 @@ def test_ensure_valid_data_hydrates_when_cache_invalid() -> None:
 
     assert out is not None
     assert len(out) == 50
+
+
+def test_sanitize_deduplicates_and_fills_missing_close() -> None:
+    ts = datetime(2026, 1, 2, 9, 15, tzinfo=timezone.utc)
+    dirty = pd.DataFrame(
+        [
+            {"timestamp": ts, "open": 100.0, "high": 101.0, "low": 99.0, "close": None},
+            {
+                "timestamp": ts + timedelta(minutes=1),
+                "open": 101.0,
+                "high": 102.0,
+                "low": 100.0,
+                "close": 101.5,
+            },
+            {
+                "timestamp": ts + timedelta(minutes=1),
+                "open": 100.5,
+                "high": 102.0,
+                "low": 100.0,
+                "close": 101.6,
+            },
+        ]
+    )
+
+    cleaned = sanitize(dirty)
+    assert len(cleaned) == 2
+    assert cleaned["close"].isna().sum() == 0
+
+
+def test_repair_with_backfill_merges_existing_and_recent() -> None:
+    ts = datetime(2026, 1, 2, 9, 15, tzinfo=timezone.utc)
+    old = pd.DataFrame(
+        [
+            {
+                "timestamp": ts + timedelta(minutes=i),
+                "open": 100 + i,
+                "high": 101 + i,
+                "low": 99 + i,
+                "close": 100.5 + i,
+            }
+            for i in range(2)
+        ]
+    )
+    recent = pd.DataFrame(
+        [
+            {
+                "timestamp": ts + timedelta(minutes=1),
+                "open": 200.0,
+                "high": 201.0,
+                "low": 199.0,
+                "close": 200.5,
+            },
+            {
+                "timestamp": ts + timedelta(minutes=2),
+                "open": 202.0,
+                "high": 203.0,
+                "low": 201.0,
+                "close": 202.5,
+            },
+        ]
+    )
+
+    merged = repair_with_backfill(
+        "NFO:NIFTY",
+        old,
+        fetch_recent_rest=lambda _symbol: recent,
+    )
+    assert len(merged) == 3
+    assert float(merged.iloc[-1]["close"]) == 202.5


### PR DESCRIPTION
### Motivation

- The system was entering a non‑recoverable data loop where subscription crashes → no WS ticks → REST fallback overwrote in‑memory OHLC with invalid frames → validators rejected data repeatedly.  A self‑healing merge + sanitize path is required to break the chain. 
- Subscription callback failures are a primary root cause and must be hardened without changing execution/strategy logic.
- Repairs must be thread‑safe and non‑blocking per symbol to avoid global trading pauses or new races.

### Description

- Added `sanitize(df)` to normalize timestamps, drop duplicates by `timestamp`, forward/backfill recoverable holes and drop rows with missing `close`, and reset the index (file: `src/nifty_scalper_bot/data/candle_engine.py`).
- Reworked backfill/repair to merge existing engine DF with REST/historical recent frames via `repair_with_backfill` (safe merge + sanitize) instead of overwriting engine state, and tightened `validate_dataframe` checks to require a `timestamp` column.
- Hardened `ensure_valid_data()` to follow a staged self‑heal flow: sanitize → historical hydrate (if needed) → merged backfill repair → final validation, and only return `None` after repair attempts fail.
- Hardened subscription/WS health path in `StrategyRunner` (file: `src/nifty_scalper_bot/strategies/runner.py`) by introducing `_safe_subscribe()` with `SUBSCRIBE_FAIL` logging, adding per‑symbol locks around candle mutation, throttling stale WS logs, doing merge‑style repair under lock, and triggering a bounded reconnect on zombie/stale conditions.
- Added unit tests to lock in the new behavior (`tests/data/test_candle_engine.py`) covering `sanitize()` and the merge backfill semantics.

### Testing

- Ran focused static/lint checks: `ruff check src/nifty_scalper_bot/data/candle_engine.py tests/data/test_candle_engine.py` (passed).
- Ran unit tests for modified components: `pytest -q tests/data/test_candle_engine.py` (passed) and `pytest -q tests/strategies/test_runner_gap_repair.py tests/strategies/test_runner_execution_gates.py` (passed).
- Attempted full project checks via `bash ./run_checks.sh`; script executed but repository contains unrelated, pre‑existing global lint/mypy failures and a test collection error in an unrelated test (`tests/test_mdm_diagnostics.py`) that imports `market_data_manager` with an unexpected module path; this prevented a clean full `pytest` sweep in this environment (fail during collection, unrelated to the changes in this PR).
- Summary of focused verification: added tests and modified modules exercising the new sanitize + merge backfill flow all passed; global repo checks surfaced unrelated pre‑existing issues that remain to be resolved separately.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0c2bbec9483248d2767bf211d91d9)