### PR TITLE
fix: stabilize hydration gating and strict market data validation

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -1408,7 +1408,9 @@ def get_http_app() -> FastAPI:
                 LOGGER.info("🛑 Shutting down Telegram Bot...")
                 await ctx.telegram_bot.stop()
         except Exception as e:
-            __import__("logging").getLogger(__name__).exception("[CRITICAL] unhandled exception", exc_info=True)
+            __import__("logging").getLogger(__name__).exception(
+                "[CRITICAL] unhandled exception", exc_info=True
+            )
             raise
 
     # ----------------------------------------------------------------
@@ -2141,7 +2143,9 @@ def _find_existing_nifty_option_symbol(
                         s_up if not s_up.startswith("NFO:") else s_up.split(":", 1)[-1]
                     )
     except Exception as e:
-        __import__("logging").getLogger(__name__).exception("[CRITICAL] unhandled exception", exc_info=True)
+        __import__("logging").getLogger(__name__).exception(
+            "[CRITICAL] unhandled exception", exc_info=True
+        )
         raise
 
     return None
@@ -2271,7 +2275,9 @@ def _get_symbols(
                                 ltp = price
                                 break
                 except Exception as e:
-                    __import__("logging").getLogger(__name__).exception("[CRITICAL] unhandled exception", exc_info=True)
+                    __import__("logging").getLogger(__name__).exception(
+                        "[CRITICAL] unhandled exception", exc_info=True
+                    )
                     raise
         except Exception as exc:
             LOGGER.error("Error fetching live price: %s", exc, exc_info=True)
@@ -3192,7 +3198,9 @@ def initialize_components(settings: Settings | None = None) -> BotContext:
                     if not mapped:
                         mapped = instrument_resolver.format_token_as_symbol(token_int)
                 except Exception as e:
-                    __import__("logging").getLogger(__name__).exception("[CRITICAL] unhandled exception", exc_info=True)
+                    __import__("logging").getLogger(__name__).exception(
+                        "[CRITICAL] unhandled exception", exc_info=True
+                    )
                     raise
 
             # Try MDM
@@ -4292,7 +4300,9 @@ def initialize_components(settings: Settings | None = None) -> BotContext:
                         )
                     )
             except Exception as e:
-                __import__("logging").getLogger(__name__).exception("[CRITICAL] unhandled exception", exc_info=True)
+                __import__("logging").getLogger(__name__).exception(
+                    "[CRITICAL] unhandled exception", exc_info=True
+                )
                 raise
 
     background_tasks: list[asyncio.Task[Any]] = []
@@ -5684,112 +5694,80 @@ async def startup_sequence(ctx: BotContext) -> None:
             engine = ctx.market_regime_manager.indicators
             HYDRATION_DELAY_SEC = 1.3  # Zerodha-safe pacing
             hydrated_counts: dict[str, int] = {}
+            runner = ctx.strategy_runner
 
-            for idx, sym in enumerate(targets, start=1):
-                try:
-                    LOGGER.debug(f"📥 Hydration {idx}/{len(targets)}: {sym}")
-
-                    records = await asyncio.to_thread(
-                        ctx.broker_client.get_ohlc,
-                        sym,
-                        "minute",
-                        from_str,
-                        to_str,
-                    )
-
-                    if records:
-                        count = 0
-                        # 1. Get Reference to Runner
-                        runner = ctx.strategy_runner
-
-                        for c in records:
-                            # Per-candle guard: one bad candle must not abort
-                            # the remaining bars for this symbol.
-                            try:
-                                # --- Parse OHLCV --------------------------------
-                                if isinstance(c, dict):
-                                    # kiteconnect SDK format: dict with "date" key
-                                    ts = c.get("date") or c.get("timestamp")
-                                    o = c.get("open")
-                                    h = c.get("high")
-                                    l = c.get("low")
-                                    c_p = c.get("close")
-                                    v = c.get("volume", 0)
-                                elif isinstance(c, (list, tuple)) and len(c) >= 6:
-                                    # Raw REST format: [ts, O, H, L, C, V] or
-                                    # [ts, O, H, L, C, V, OI] — index-safe slice
-                                    ts, o, h, l, c_p, v = (
-                                        c[0],
-                                        c[1],
-                                        c[2],
-                                        c[3],
-                                        c[4],
-                                        c[5],
-                                    )
-                                else:
-                                    continue  # unknown or incomplete row
-
-                                # --- Timestamp normalisation -------------------
-                                # Zerodha REST: string "2026-03-06 09:15:00+05:30"
-                                # KiteConnect SDK: datetime object
-                                if isinstance(ts, str):
-                                    ts = datetime.fromisoformat(
-                                        ts.replace("Z", "+00:00")
-                                    )
-                                elif not isinstance(ts, datetime):
-                                    # e.g. unix epoch float/int
-                                    try:
-                                        ts = datetime.fromtimestamp(
-                                            float(ts), tz=timezone.utc
-                                        )
-                                    except Exception:
-                                        continue  # unparseable timestamp
-
-                                if ts.tzinfo is None:
-                                    ts = ts.replace(tzinfo=timezone.utc)
-
-                                # --- Skip None/zero OHLC (bad rows) -----------
-                                if not all(x is not None for x in (o, h, l, c_p)):
-                                    continue
-
-                                # --- Feed runner indicator_engine --------------
-                                if runner and hasattr(runner, "ingest_historical_bar"):
-                                    bar_data = {
-                                        "symbol": sym,
-                                        "open": float(o),
-                                        "high": float(h),
-                                        "low": float(l),
-                                        "close": float(c_p),
-                                        "volume": int(v or 0),
-                                        "timestamp": ts,
-                                    }
-                                    runner.ingest_historical_bar(bar_data)
-
-                                count += 1
-                            except Exception as _candle_err:
-                                LOGGER.debug(
-                                    f"Skipping bad candle for {sym}: {_candle_err}"
-                                )
-
-                        LOGGER.info(f"✅ Hydrated {sym}: {count} bars")
-                        hydrated_counts[sym] = count
-                        if ctx.market_data_manager:
-                            bars_snapshot = ctx.market_data_manager.get_ohlc_bars(sym)
-                            ctx.market_data_manager.update_hydration_status(
-                                sym, bars_snapshot or records
+            async def _hydrate_symbol(idx: int, sym: str) -> tuple[str, int]:
+                await asyncio.sleep((idx - 1) * HYDRATION_DELAY_SEC)
+                LOGGER.debug(f"📥 Hydration {idx}/{len(targets)}: {sym}")
+                records = await asyncio.to_thread(
+                    ctx.broker_client.get_ohlc,
+                    sym,
+                    "minute",
+                    from_str,
+                    to_str,
+                )
+                if not records:
+                    return sym, 0
+                count = 0
+                for c in records:
+                    try:
+                        if isinstance(c, dict):
+                            ts = c.get("date") or c.get("timestamp")
+                            o = c.get("open")
+                            h = c.get("high")
+                            l = c.get("low")
+                            c_p = c.get("close")
+                            v = c.get("volume", 0)
+                        elif isinstance(c, (list, tuple)) and len(c) >= 6:
+                            ts, o, h, l, c_p, v = c[0], c[1], c[2], c[3], c[4], c[5]
+                        else:
+                            continue
+                        if isinstance(ts, str):
+                            ts = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+                        elif not isinstance(ts, datetime):
+                            ts = datetime.fromtimestamp(float(ts), tz=timezone.utc)
+                        if ts.tzinfo is None:
+                            ts = ts.replace(tzinfo=timezone.utc)
+                        if not all(x is not None for x in (o, h, l, c_p)):
+                            continue
+                        if runner and hasattr(runner, "ingest_historical_bar"):
+                            runner.ingest_historical_bar(
+                                {
+                                    "symbol": sym,
+                                    "open": float(o),
+                                    "high": float(h),
+                                    "low": float(l),
+                                    "close": float(c_p),
+                                    "volume": int(v or 0),
+                                    "timestamp": ts,
+                                }
                             )
+                        count += 1
+                    except Exception as candle_err:
+                        LOGGER.debug("Skipping bad candle for %s: %s", sym, candle_err)
+                if ctx.market_data_manager:
+                    bars_snapshot = ctx.market_data_manager.get_ohlc_bars(sym)
+                    ctx.market_data_manager.update_hydration_status(
+                        sym, bars_snapshot or records
+                    )
+                return sym, count
 
-                    await asyncio.sleep(HYDRATION_DELAY_SEC)
-
-                except Exception as e:
-                    if "rate limit" in str(e).lower():
-                        LOGGER.warning(
-                            f"⚠️ Rate limit hit for {sym}, skipping hydration"
-                        )
+            hydration_tasks = [
+                _hydrate_symbol(idx, sym) for idx, sym in enumerate(targets, start=1)
+            ]
+            hydration_results = await asyncio.gather(
+                *hydration_tasks, return_exceptions=True
+            )
+            for item in hydration_results:
+                if isinstance(item, Exception):
+                    if "rate limit" in str(item).lower():
+                        LOGGER.warning("⚠️ Rate limit hit during hydration: %s", item)
                     else:
-                        LOGGER.warning(f"❌ Failed to hydrate {sym}: {e}")
-
-                    await asyncio.sleep(HYDRATION_DELAY_SEC)
+                        LOGGER.warning("❌ Failed to hydrate symbol: %s", item)
+                    continue
+                sym, count = item
+                hydrated_counts[sym] = int(count)
+                LOGGER.info("✅ Hydrated %s: %s bars", sym, count)
 
             if get_settings().enable_live and ctx.market_data_manager is not None:
                 failed = [
@@ -6136,7 +6114,9 @@ async def startup_sequence(ctx: BotContext) -> None:
                             if callable(reset_fn):
                                 reset_fn()
                     except Exception as e:
-                        __import__("logging").getLogger(__name__).exception("[CRITICAL] unhandled exception", exc_info=True)
+                        __import__("logging").getLogger(__name__).exception(
+                            "[CRITICAL] unhandled exception", exc_info=True
+                        )
                         raise
                     from nifty_scalper_bot.utils.market_hours import (
                         is_market_open as _imo,

--- a/src/nifty_scalper_bot/data/candle_engine.py
+++ b/src/nifty_scalper_bot/data/candle_engine.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-import time
 from dataclasses import dataclass, field
 from datetime import datetime
+import time
 from typing import Any, Callable, Mapping
 
 import pandas as pd
@@ -27,7 +27,8 @@ def sanitize(df: pd.DataFrame | None) -> pd.DataFrame:
         cleaned = cleaned.sort_values("timestamp")
     else:
         cleaned = cleaned.drop_duplicates()
-    cleaned = cleaned.ffill().bfill()
+    cleaned = cleaned.ffill()
+    cleaned = cleaned.dropna()
     if "close" in cleaned.columns:
         cleaned = cleaned[~cleaned["close"].isna()]
     return cleaned.reset_index(drop=True)

--- a/src/nifty_scalper_bot/data/source.py
+++ b/src/nifty_scalper_bot/data/source.py
@@ -13,6 +13,56 @@ class DataIntegrityError(ValueError):
 
 
 @dataclass(slots=True)
+class MarketDataValidator:
+    """Central OHLC validator. Args: min_candles. Returns: MarketDataValidator. Raises: None."""
+
+    min_candles: int = 1
+
+    def validate_ohlc(self, df: pd.DataFrame, symbol: str) -> pd.DataFrame:
+        """Validate OHLCV frame. Args: df/symbol. Returns: validated frame. Raises: DataIntegrityError."""
+        if df is None or df.empty:
+            raise DataIntegrityError(f"{symbol}: empty dataframe")
+
+        required = ["open", "high", "low", "close", "volume"]
+        missing = [col for col in required if col not in df.columns]
+        if missing:
+            raise DataIntegrityError(f"{symbol}: missing columns {missing}")
+
+        if len(df) < int(self.min_candles):
+            raise DataIntegrityError(
+                f"{symbol}: insufficient candles {len(df)}<{int(self.min_candles)}"
+            )
+
+        validated = df
+        if validated[required].isnull().any().any():
+            validated = validated.ffill()
+            validated = validated.dropna(subset=required)
+
+        if validated.empty:
+            raise DataIntegrityError(f"{symbol}: no rows after null cleanup")
+
+        if "timestamp" in validated.columns:
+            ts = pd.to_datetime(validated["timestamp"], utc=True, errors="coerce")
+            if ts.isna().any():
+                raise DataIntegrityError(f"{symbol}: invalid timestamps")
+            if not ts.is_monotonic_increasing:
+                raise DataIntegrityError(f"{symbol}: non-monotonic timestamps")
+        elif isinstance(validated.index, pd.DatetimeIndex):
+            if not validated.index.is_monotonic_increasing:
+                raise DataIntegrityError(f"{symbol}: non-monotonic datetime index")
+
+        highs_ok = validated["high"] >= validated[["open", "close"]].max(axis=1)
+        if not bool(highs_ok.all()):
+            raise DataIntegrityError(f"{symbol}: invalid high values")
+
+        lows_ok = validated["low"] <= validated[["open", "close"]].min(axis=1)
+        if not bool(lows_ok.all()):
+            raise DataIntegrityError(f"{symbol}: invalid low values")
+
+        return validated
+
+
+@dataclass(slots=True)
 class CandleFrame:
     """OHLCV wrapper with integrity checks. Args: df. Returns: CandleFrame. Raises: DataIntegrityError."""
 

--- a/src/nifty_scalper_bot/notifications/telegram_webhook_enhanced.py
+++ b/src/nifty_scalper_bot/notifications/telegram_webhook_enhanced.py
@@ -5,15 +5,19 @@ and robust command replies (/ping, /status, /start).
 from __future__ import annotations
 
 import asyncio
-import json
-import random
 from contextlib import suppress
 from dataclasses import dataclass, field
+import json
 from logging import Logger
+import random
 from time import monotonic
 from typing import Any, Callable, Iterable, Mapping, Sequence, cast
 
 from fastapi import APIRouter, Request, Response, status
+
+from nifty_scalper_bot.config.settings import NotificationSettings
+from nifty_scalper_bot.utils.async_helpers import safe_task
+from nifty_scalper_bot.utils.logging import get_logger
 from telegram import Bot, Message, Update
 from telegram.error import (
     Forbidden,
@@ -23,10 +27,6 @@ from telegram.error import (
     TimedOut,
 )
 from telegram.ext import Application
-
-from nifty_scalper_bot.config.settings import NotificationSettings
-from nifty_scalper_bot.utils.async_helpers import safe_task
-from nifty_scalper_bot.utils.logging import get_logger
 
 
 def _ensure_set(values: Iterable[int] | None) -> set[int]:
@@ -343,7 +343,9 @@ class TelegramEnhancedNotifier:
                     # Repeated hard failures indicate transport degradation; latch
                     # to avoid retry spam from every caller until cooldown expires.
                     self._telegram_degraded = True
-                    self._telegram_degraded_until = _current_loop_time() + retry_window_s
+                    self._telegram_degraded_until = (
+                        _current_loop_time() + retry_window_s
+                    )
                     if not self._telegram_degraded_logged:
                         self._telegram_degraded_logged = True
                         self._logger.error(
@@ -395,7 +397,9 @@ class TelegramEnhancedNotifier:
                     # Generic Telegram transport failures are latched as degraded so
                     # recovery waits for cooldown instead of immediate retry storms.
                     self._telegram_degraded = True
-                    self._telegram_degraded_until = _current_loop_time() + retry_window_s
+                    self._telegram_degraded_until = (
+                        _current_loop_time() + retry_window_s
+                    )
                     if not self._telegram_degraded_logged:
                         self._telegram_degraded_logged = True
                         self._logger.error(
@@ -446,6 +450,14 @@ class TelegramWebhookController:
     commands work out of the box without pulling in the legacy console.
     """
 
+    _instance: TelegramWebhookController | None = None
+
+    def __new__(cls, *args: object, **kwargs: object) -> TelegramWebhookController:
+        if cls._instance is None:
+            cls._instance = cast(TelegramWebhookController, super().__new__(cls))
+            setattr(cls._instance, "_initialized", False)
+        return cls._instance
+
     def __init__(
         self,
         bot: Bot,
@@ -454,6 +466,8 @@ class TelegramWebhookController:
         status_provider: Callable[[], Mapping[str, object]] | None = None,
         application: Application | None = None,
     ) -> None:
+        if getattr(self, "_initialized", False):
+            return
         self.bot = bot
         self.settings = settings
         self.logger = get_logger(__name__)
@@ -482,6 +496,7 @@ class TelegramWebhookController:
         self._user_whitelist = _ensure_set(
             getattr(settings, "whitelist_user_ids", None)
         )
+        self._initialized = True
 
     async def _handle_webhook(self, request: Request) -> Response:
         try:

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -52,6 +52,7 @@ from nifty_scalper_bot.data.candle_engine import (
 from nifty_scalper_bot.data.market_data_manager import MarketDataManager
 from nifty_scalper_bot.data.source import (
     DataIntegrityError,
+    MarketDataValidator,
     ensure_ltp,
     is_symbol_valid,
 )
@@ -322,6 +323,21 @@ class SymbolState(Enum):
     SUSPENDED = "suspended"
 
 
+class HydrationState:
+    """Track startup hydration completion. Args: none. Returns: HydrationState. Raises: None."""
+
+    def __init__(self) -> None:
+        self._complete = False
+
+    def mark_complete(self) -> None:
+        """Mark hydration complete. Args: none. Returns: None. Raises: None."""
+        self._complete = True
+
+    def is_ready(self) -> bool:
+        """Return hydration readiness. Args: none. Returns: bool. Raises: None."""
+        return self._complete
+
+
 @dataclass(slots=True)
 class SymbolRuntimeState:
     """Mutable runtime data maintained per symbol."""
@@ -488,6 +504,10 @@ class StrategyRunner:
         self._strike_selector = strike_selector
         self._bracket_manager = bracket_manager
         self._symbol_source: MarketDataManager | None = None
+        self._hydration_state = HydrationState()
+        self._execution_enabled = True
+        self._data_integrity_broken = False
+        self._quarantined_symbols: set[str] = set()
         self._main_loop: asyncio.AbstractEventLoop | None = None
         self._legacy_tick_subscription_mode = os.getenv(
             "STRATEGY_RUNNER_LEGACY_SUBSCRIBE", "false"
@@ -612,6 +632,9 @@ class StrategyRunner:
             self._config.min_indicator_bars,
             int(os.getenv("REQUIRED_CANDLES", str(warmup_bars))),
         )
+        self._validator = MarketDataValidator(
+            min_candles=max(self._required_candles, 1)
+        )
         self._max_symbol_count: int = int(os.getenv("STRATEGY_MAX_SYMBOL_COUNT", "32"))
         self._universe_controller = UniverseController()
         self._universe_dynamic_mode = bool(
@@ -715,6 +738,9 @@ class StrategyRunner:
 
     def start(self) -> None:
         """Start processing market data events."""
+        if not self._hydration_state.is_ready():
+            self._logger.warning("Execution blocked: hydration incomplete")
+            return
         with self._lock:
             if self._running:
                 return
@@ -917,16 +943,11 @@ class StrategyRunner:
     def _symbol_has_valid_data(self, symbol: str) -> bool:
         """Validate symbol candle data integrity from the indicator engine."""
         try:
-            # 1. Primary check: Has the indicator engine processed enough bars?
-            if self._indicator_engine and self._indicator_engine.has_min_bars(symbol, self._required_candles):
-                return True
-            
-            # 2. Fallback check: Does our raw history deque have enough bars?
             history = self._symbol_history.get(symbol, [])
-            if len(history) >= self._required_candles:
-                return True
-                
-            return False
+            if not history:
+                return False
+            frame = pd.DataFrame(history)
+            return is_symbol_valid(frame, min_required_bars=self._required_candles)
         except Exception as exc:  # noqa: BLE001
             self._logger.error(
                 "Failure in StrategyRunner._symbol_has_valid_data: %s",
@@ -935,6 +956,12 @@ class StrategyRunner:
                 exc_info=exc,
             )
             return False
+
+    def _validate_execution_data(self, symbol: str) -> None:
+        """Validate runtime data before execution. Args: symbol. Returns: None. Raises: DataIntegrityError."""
+        bars = self._market_data.get_ohlc_bars(symbol)
+        frame = pd.DataFrame(bars or [])
+        self._validator.validate_ohlc(frame, symbol)
 
     def remove_symbol(self, symbol: str) -> None:
         """Stop tracking a symbol."""
@@ -1236,18 +1263,19 @@ class StrategyRunner:
                     # 1. Guard against empty or malformed ticks (prevents dict() TypeError)
                     if not tick:
                         return
-                        
+
                     # 2. Defensive copy to a mutable dictionary
                     payload = dict(tick)
                     payload["symbol"] = sym
-                    
+
                     # 3. Publish to the event bus
                     self._event_bus.publish(payload)
                 except Exception:
                     # Capture full stack trace AND the raw tick data for senior-level debugging
                     self._logger.exception(
-                        "CRITICAL: Failure in StrategyRunner._subscribe_symbol callback for %s. Raw tick: %s", 
-                        sym, tick
+                        "CRITICAL: Failure in StrategyRunner._subscribe_symbol callback for %s. Raw tick: %s",
+                        sym,
+                        tick,
                     )
 
             callback = _callback
@@ -1339,41 +1367,50 @@ class StrategyRunner:
         valid_symbols: list[str] = []
         with self._lock:
             for sym in symbols:
-                normalized = enforce_canonical(normalize_symbol(sym))
-                # 1. Register Active (Critical for main loop)
-                self._active_symbols.add(normalized)
-                self._tracked_symbols.add(normalized)
-
-                # 2. Ensure SymbolState exists (Critical for Strategy Context)
-                if normalized not in self._symbol_state:
-                    self._symbol_state[normalized] = SymbolRuntimeState(
-                        symbol=normalized, history_limit=2000
+                try:
+                    normalized = enforce_canonical(normalize_symbol(sym))
+                    self._active_symbols.add(normalized)
+                    self._tracked_symbols.add(normalized)
+                    if normalized not in self._symbol_state:
+                        self._symbol_state[normalized] = SymbolRuntimeState(
+                            symbol=normalized, history_limit=2000
+                        )
+                    self._symbol_states.setdefault(normalized, SymbolState.DISCOVERED)
+                    self._set_symbol_hydration_state(normalized, SymbolState.READY)
+                    if normalized not in self._bar_builders:
+                        self._bar_builders[normalized] = OneMinuteBarBuilder()
+                    if normalized not in self._last_bar_ts:
+                        self._last_bar_ts[normalized] = datetime.now(timezone.utc)
+                    if self._symbol_has_valid_data(normalized):
+                        valid_symbols.append(normalized)
+                    else:
+                        raise DataIntegrityError(f"{normalized}: invalid hydrated data")
+                except DataIntegrityError as exc:
+                    self._quarantined_symbols.add(str(sym))
+                    self._set_symbol_hydration_state(
+                        enforce_canonical(normalize_symbol(str(sym))),
+                        SymbolState.SUSPENDED,
+                        allow_downgrade=True,
                     )
-                self._symbol_states.setdefault(normalized, SymbolState.DISCOVERED)
-                self._set_symbol_hydration_state(normalized, SymbolState.READY)
-
-                # 3. Initialize BarBuilder (Prevent KeyErrors in internal checks)
-                if normalized not in self._bar_builders:
-                    self._bar_builders[normalized] = OneMinuteBarBuilder()
-
-                # 4. Set High-Water Mark (Prevent dropping first live tick)
-                if normalized not in self._last_bar_ts:
-                    self._last_bar_ts[normalized] = datetime.now(timezone.utc)
-                if self._symbol_has_valid_data(normalized):
-                    valid_symbols.append(normalized)
-                else:
-                    self._logger.warning("skipped: invalid data")
+                    self._logger.critical(
+                        "Hydration quarantine triggered: %s",
+                        exc,
+                        extra={"event": "hydration_symbol_quarantine", "symbol": sym},
+                    )
 
         # 5. Keep _startup_hydrated=True so Phase 7 can promote HYDRATING→DEGRADED
         # while _symbol_history is still empty (no live bars yet, first minute after
         # startup). _backfill_history() checks indicator bar counts, NOT this flag,
         # so setting it True here does not re-trigger backfill.
         self._startup_hydrated = True
+        self._hydration_state.mark_complete()
         self.ready = len(valid_symbols) >= self._required_symbol_count
         if self.ready:
             self._runner_state = RunnerState.EXECUTION_ENABLED
             self._logger.info("🚀 StrategyRunner execution enabled")
-            self._logger.info(f"✅ StrategyRunner marked READY with {len(valid_symbols)} active symbols")
+            self._logger.info(
+                f"✅ StrategyRunner marked READY with {len(valid_symbols)} active symbols"
+            )
         else:
             self._runner_state = RunnerState.HISTORICAL_READY
             self._logger.warning(
@@ -1400,7 +1437,9 @@ class StrategyRunner:
             norm_sym = enforce_canonical(normalize_symbol(_sym))
             try:
                 _bc = len(self._indicator_engine.get_history(norm_sym) or [])
-                _ok = self._indicator_engine.has_min_bars(norm_sym, self._required_candles)
+                _ok = self._indicator_engine.has_min_bars(
+                    norm_sym, self._required_candles
+                )
             except Exception:
                 _bc, _ok = 0, False
             self._logger.info(
@@ -1831,15 +1870,20 @@ class StrategyRunner:
             )
             return self._set_symbol_hydration_state(symbol, SymbolState.DEGRADED)
 
-        if valid_vwap and valid_volume:
-            streak = int(self._hydration_ready_streak.get(symbol, 0)) + 1
-            self._hydration_ready_streak[symbol] = streak
-            if prev_state == SymbolState.READY or streak >= 2:
-                return self._set_symbol_hydration_state(symbol, SymbolState.READY)
-
-        self._hydration_ready_streak[symbol] = 0
-        # Soft degrade on transient VWAP/volume issues; avoid repeated hard resets.
-        return self._set_symbol_hydration_state(symbol, SymbolState.DEGRADED)
+        if not (valid_vwap and valid_volume):
+            self._logger.warning(
+                "warmup_indicators_unready",
+                extra={
+                    "event": "warmup_indicators_unready",
+                    "symbol": symbol,
+                    "vwap_valid": valid_vwap,
+                    "volume_valid": valid_volume,
+                },
+            )
+        self._hydration_ready_streak[symbol] = (
+            int(self._hydration_ready_streak.get(symbol, 0)) + 1
+        )
+        return self._set_symbol_hydration_state(symbol, SymbolState.READY)
 
     def _ensure_symbol_vwap_state(self, symbol: str, now: datetime) -> dict[str, Any]:
         """Return session-scoped VWAP accumulator for symbol."""
@@ -3000,6 +3044,12 @@ class StrategyRunner:
                 extra={"event": "execution_blocked_state"},
             )
             return
+        if not self._hydration_state.is_ready():
+            self._logger.warning("Execution blocked: hydration incomplete")
+            return
+        if not self._execution_enabled or self._data_integrity_broken:
+            self._logger.critical("TRADING HALTED: DATA INTEGRITY FAILURE")
+            return
         try:
             # Offload heavy synchronous processing (and blocking broker calls) to a thread
             await asyncio.to_thread(self._on_tick_safe, tick)
@@ -3191,7 +3241,7 @@ class StrategyRunner:
         now = time.monotonic()
         tick_flowing = (now - self._last_tick_seen_ts) <= 5.0
         eval_stalled = (now - self._last_global_eval_ts) > 5.0
-        
+
         # ✅ FIX: Throttle — same-bar-skip keeps eval_stalled=True for the whole bar.
         # Only warn if stall > 90s (longer than one full bar cycle) to avoid spam.
         genuine_stall = (now - self._last_global_eval_ts) > 90.0
@@ -3210,24 +3260,30 @@ class StrategyRunner:
         for symbol, engine in self._candle_engines.items():
             # 1. Use .get() to prevent KeyError on newly subscribed symbols
             stale_for = now_wall - self._last_tick_time_by_symbol.get(symbol, now_wall)
-            
+
             # 2. Relax threshold to 15.0s (3.0s is too tight for OTM options)
             if stale_for > 15.0:
                 stale_count += 1
                 last_log_ts = self._last_ws_stale_log_ts_by_symbol.get(symbol, 0.0)
-                
+
                 # 3. GATE THE ENTIRE BACKFILL PROCESS, not just the logger
                 if now_wall - last_log_ts >= 60.0:
-                    self._logger.warning("⚠️ %s: WS stale (%.1fs) → triggering backfill", symbol, stale_for)
+                    self._logger.warning(
+                        "⚠️ %s: WS stale (%.1fs) → triggering backfill",
+                        symbol,
+                        stale_for,
+                    )
                     self._last_ws_stale_log_ts_by_symbol[symbol] = now_wall
-                    
+
                     try:
                         repair_input = pd.DataFrame(
-                            self._hydrate_missing_bars(symbol, max(self._required_candles, 50))
+                            self._hydrate_missing_bars(
+                                symbol, max(self._required_candles, 50)
+                            )
                         )
                         if repair_input.empty:
                             continue
-                            
+
                         with self._symbol_locks[symbol]:
                             repaired = repair_with_backfill(
                                 symbol,
@@ -3240,10 +3296,11 @@ class StrategyRunner:
                     except Exception:
                         # 4. Use .exception to capture traceback and stop silent failures
                         self._logger.exception(
-                            "CRITICAL: Failure in StrategyRunner._health_watchdog backfill for %s", symbol
+                            "CRITICAL: Failure in StrategyRunner._health_watchdog backfill for %s",
+                            symbol,
                         )
 
-        # 5. Move WS Reconnect OUTSIDE the symbol loop. 
+        # 5. Move WS Reconnect OUTSIDE the symbol loop.
         # We only want to evaluate a WS restart once per cycle, not once per symbol.
         if stale_count > 0:
             last_reconnect_ts = getattr(self, "_last_ws_reconnect_attempt_ts", 0.0)
@@ -3251,12 +3308,19 @@ class StrategyRunner:
             if now_wall - last_reconnect_ts >= 30.0:
                 self._last_ws_reconnect_attempt_ts = now_wall
                 try:
-                    reconnect = getattr(self._market_data, "_trigger_zombie_ws_restart", None)
+                    reconnect = getattr(
+                        self._market_data, "_trigger_zombie_ws_restart", None
+                    )
                     if callable(reconnect):
-                        self._logger.warning("🔄 Watchdog triggering zombie WS restart (%d symbols stale)", stale_count)
+                        self._logger.warning(
+                            "🔄 Watchdog triggering zombie WS restart (%d symbols stale)",
+                            stale_count,
+                        )
                         reconnect()
                 except Exception:
-                    self._logger.exception("CRITICAL: Failure in StrategyRunner._health_watchdog.reconnect")
+                    self._logger.exception(
+                        "CRITICAL: Failure in StrategyRunner._health_watchdog.reconnect"
+                    )
 
     # ✅ FIX: New Method to Prime Indicators
     async def _backfill_history(self) -> None:
@@ -5625,6 +5689,26 @@ class StrategyRunner:
                 base_symbol,
                 ExecutionState.SIGNAL_RECEIVED,
             )
+            try:
+                self._validate_execution_data(base_symbol)
+            except DataIntegrityError as exc:
+                self._quarantined_symbols.add(base_symbol)
+                self._set_symbol_hydration_state(
+                    base_symbol,
+                    SymbolState.SUSPENDED,
+                    allow_downgrade=True,
+                )
+                self._data_integrity_broken = True
+                self._execution_enabled = False
+                self._logger.critical(
+                    "TRADING HALTED: DATA INTEGRITY FAILURE (%s)",
+                    exc,
+                    extra={
+                        "event": "runtime_data_integrity_failure",
+                        "symbol": base_symbol,
+                    },
+                )
+                return
 
             # ═══════════════════════════════════════════════════════════════
             # 🛡️ GUARD 0.5: ORDER IN-FLIGHT CHECK

--- a/tests/data/test_source.py
+++ b/tests/data/test_source.py
@@ -3,8 +3,14 @@ from __future__ import annotations
 from datetime import datetime, timezone
 
 import pandas as pd
+import pytest
 
-from nifty_scalper_bot.data.source import HistoricalLiveOHLCProvider, is_symbol_valid
+from nifty_scalper_bot.data.source import (
+    DataIntegrityError,
+    HistoricalLiveOHLCProvider,
+    MarketDataValidator,
+    is_symbol_valid,
+)
 
 
 def test_get_clean_ohlc_overwrites_last_row_without_appending() -> None:
@@ -58,3 +64,45 @@ def test_is_symbol_valid_rejects_duplicates_and_nans() -> None:
     frame = pd.DataFrame({"close": [100.0, float("nan")]}, index=idx)
 
     assert is_symbol_valid(frame, min_required_bars=2) is False
+
+
+def test_market_data_validator_rejects_invalid_high() -> None:
+    validator = MarketDataValidator(min_candles=2)
+    frame = pd.DataFrame(
+        {
+            "timestamp": pd.to_datetime(
+                ["2026-01-01T09:15:00Z", "2026-01-01T09:16:00Z"], utc=True
+            ),
+            "open": [100.0, 102.0],
+            "high": [99.0, 103.0],
+            "low": [98.0, 101.0],
+            "close": [100.5, 102.5],
+            "volume": [10, 11],
+        }
+    )
+    with pytest.raises(DataIntegrityError):
+        validator.validate_ohlc(frame, "NSE:NIFTY")
+
+
+def test_market_data_validator_ffill_without_bfill() -> None:
+    validator = MarketDataValidator(min_candles=2)
+    frame = pd.DataFrame(
+        {
+            "timestamp": pd.to_datetime(
+                [
+                    "2026-01-01T09:15:00Z",
+                    "2026-01-01T09:16:00Z",
+                    "2026-01-01T09:17:00Z",
+                ],
+                utc=True,
+            ),
+            "open": [100.0, None, 102.0],
+            "high": [101.0, None, 103.0],
+            "low": [99.0, None, 101.0],
+            "close": [100.5, None, 102.5],
+            "volume": [10, None, 12],
+        }
+    )
+    validated = validator.validate_ohlc(frame, "NSE:NIFTY")
+    assert len(validated) == 3
+    assert validated.iloc[1]["open"] == 100.0


### PR DESCRIPTION
### Motivation
- Prevent silent data drops and future-data leakage by enforcing strict OHLCV validation and removing backward-fill in the candle sanitation path.
- Ensure execution never starts on partial/invalid hydration by adding an explicit hydration completion gate and runtime data guards.
- Quarantine symbol-level failures instead of silently skipping them so single-symbol corruption cannot crash or corrupt global execution.
- Make Telegram controller singleton to avoid duplicate controllers and unexpected command duplication.

### Description
- Added `MarketDataValidator` in `src/nifty_scalper_bot/data/source.py` with schema checks for `open/high/low/close/volume`, NaN handling via `ffill` then `dropna`, monotonic timestamp validation, candle consistency (high/low vs open/close), and minimum candle count enforcement that raises `DataIntegrityError` on failure.
- Replaced `ffill().bfill()` in `src/nifty_scalper_bot/data/candle_engine.py` with `ffill()` then `dropna()` to remove backward-fill and eliminate future-data leakage.
- Hardened `StrategyRunner` (`src/nifty_scalper_bot/strategies/runner.py`) by adding `HydrationState`, gating `start()` and tick processing until hydration is complete, introducing symbol-level quarantine on hydration failures, adding `_validate_execution_data()` to validate runtime OHLC before any execution, and a global fail-safe (`_execution_enabled` / `_data_integrity_broken`) that halts trading and logs CRITICAL on integrity breach.
- Updated warmup logic to be deterministic by bar-count while logging indicator readiness issues rather than silently blocking readiness.
- Rewrote startup hydration in `src/nifty_scalper_bot/core/app.py` to fan out per-symbol hydration using `asyncio.gather(...)`, pacing requests safely, and finalize readiness only after hydration tasks complete.
- Made `TelegramWebhookController` a singleton in `src/nifty_scalper_bot/notifications/telegram_webhook_enhanced.py` to avoid duplicate controllers.
- Added unit tests for validator behavior in `tests/data/test_source.py` covering invalid high detection and forward-fill/no-backfill behavior.

### Testing
- Ran targeted pytest for modified and related modules: `. .venv/bin/activate && pytest -q tests/data/test_source.py tests/data/test_candle_engine.py tests/strategies/test_runner_execution_gates.py` which completed and passed for those suites.
- Executed full test command used by CI: `. .venv/bin/activate && pytest -q tests --disable-warnings --ignore=tests/test_live_mode.py --ignore=tests/test_health_server.py` which failed due to a pre-existing unrelated import error in `tests/test_mdm_diagnostics.py` and is outside the scope of these changes.
- Ran repository sanity checks: `bash run_checks.sh` (environment-run produced dependency install and noted pytest/mypy/ruff steps; script cannot fully run in this execution environment and initially reported missing pytest), `mypy src` and `ruff` were executed but reported pre-existing repository-wide typing and lint issues unrelated to this change-set.
- The validator unit tests added specifically for this PR passed locally; CI should run full linters/type checks and the complete test suite where remaining pre-existing repo issues may need addressing independently.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c36d9c697c83249dbd1e13331c4ac6)