### PR TITLE
refactor: deterministic websocket-only market data pipeline (CandleEngine-only)

### DIFF
--- a/src/nifty_scalper_bot/config/strategies.yaml
+++ b/src/nifty_scalper_bot/config/strategies.yaml
@@ -1,12 +1,2 @@
 enabled_strategies:
   - smc_liquidity
-  - vwap_pro
-  - oi_max_pain
-  - gamma_scalping
-  - cpr_breakout
-  - order_flow
-  - bb_squeeze
-  - rsi_divergence
-  - orb_pro
-  - straddle_theta
-  - elite_tuesday_gamma_buyer

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -22,8 +22,11 @@ from typing import (
     Sequence,
     cast,
 )
+import pandas as pd
 
 from nifty_scalper_bot.config.settings import get_settings
+from nifty_scalper_bot.data.candle_engine import CandleEngine, validate_tick
+from nifty_scalper_bot.data.source import DataIntegrityError
 from nifty_scalper_bot.infra.metrics import METRICS
 from nifty_scalper_bot.streaming.websocket_manager import (
     ConnectionState,
@@ -63,102 +66,6 @@ _EXPIRY_FORMATS: tuple[str, ...] = (
 _COMPACT_EXPIRY_FORMATS: tuple[str, ...] = ("%d%b%Y", "%d%b%y")
 
 _logger = get_tracer_logger(__name__)
-
-
-@dataclass(slots=True)
-class _OHLCBar:
-    """Normalized one-minute OHLCV bar."""
-
-    timestamp: datetime
-    open: float
-    high: float
-    low: float
-    close: float
-    volume: float
-
-
-class _OHLCBuilder:
-    """Aggregate ticks into fixed one-minute OHLC bars."""
-
-    def __init__(self, *, maxlen: int = 500) -> None:
-        self._bars: dict[str, Deque[_OHLCBar]] = defaultdict(
-            lambda: deque(maxlen=maxlen)
-        )
-        self._last_cumulative_volume: dict[str, float] = {}
-        self._lock = threading.RLock()
-
-    def add_tick(self, symbol: str, tick: Mapping[str, Any]) -> None:
-        """Update the latest bar for *symbol* with the provided tick."""
-
-        if not symbol:
-            return
-        ts_value = tick.get("timestamp")
-        price_value = tick.get("ltp")
-        if not isinstance(ts_value, (int, float)) or not isinstance(
-            price_value, (int, float)
-        ):
-            return
-        timestamp = datetime.fromtimestamp(float(ts_value), timezone.utc).replace(
-            second=0, microsecond=0
-        )
-        price = float(price_value)
-        volume_delta = 0.0
-        raw_volume = tick.get("volume")
-        if isinstance(raw_volume, (int, float)):
-            cumulative = float(raw_volume)
-            last_cumulative = self._last_cumulative_volume.get(symbol)
-            if last_cumulative is not None:
-                diff = cumulative - last_cumulative
-                if diff >= 0:
-                    volume_delta = diff
-            self._last_cumulative_volume[symbol] = cumulative
-        with self._lock:
-            bucket = self._bars[symbol]
-            if bucket and bucket[-1].timestamp == timestamp:
-                bar = bucket[-1]
-                bar.high = max(bar.high, price)
-                bar.low = min(bar.low, price)
-                bar.close = price
-                bar.volume += volume_delta
-            else:
-                bucket.append(
-                    _OHLCBar(
-                        timestamp=timestamp,
-                        open=price,
-                        high=price,
-                        low=price,
-                        close=price,
-                        volume=volume_delta,
-                    )
-                )
-
-    def get_bars(
-        self, symbol: str, *, limit: int | None = None
-    ) -> list[dict[str, Any]]:
-        """Return a snapshot of recent bars for *symbol*."""
-
-        with self._lock:
-            bars = list(self._bars.get(symbol, ()))
-        if limit is not None and limit >= 0:
-            bars = bars[-limit:]
-        return [
-            {
-                "timestamp": bar.timestamp,
-                "open": bar.open,
-                "high": bar.high,
-                "low": bar.low,
-                "close": bar.close,
-                "volume": bar.volume,
-            }
-            for bar in bars
-        ]
-
-    def snapshot(self) -> dict[str, list[dict[str, Any]]]:
-        """Return complete bar snapshot for all tracked symbols."""
-
-        with self._lock:
-            symbols = list(self._bars.keys())
-        return {symbol: self.get_bars(symbol) for symbol in symbols}
 
 
 class MarketDataManager:
@@ -217,9 +124,6 @@ class MarketDataManager:
         self._last_tick_log_time = time.monotonic()
         self._last_tick_time: dict[str, float] = {}
         self._last_emit_mono: dict[str, float] = {}
-        self._tick_emit_min_interval = self._parse_float_env(
-            "MDM_TICK_EMIT_MIN_INTERVAL_SEC", default=0.02, minimum=0.0
-        )
         self._tick_burst_window_sec = self._parse_float_env(
             "MDM_TICK_BURST_WINDOW_SEC", default=1.0, minimum=0.1
         )
@@ -238,10 +142,13 @@ class MarketDataManager:
         self._fallback_enabled = False
         self._poll_jitter_pct = 0.0
         self._poll_batch_ceiling = 0
-        self._ohlc_builder = _OHLCBuilder(maxlen=self._cache_len)
         self._ohlc: dict[str, Deque[dict[str, Any]]] = defaultdict(
             lambda: deque(maxlen=self._cache_len)
         )
+        self._engines: dict[str, CandleEngine] = {}
+        self._last_historical_ts: dict[str, float] = {}
+        self._tick_queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
+        self._tick_consumer_task: asyncio.Task[None] | None = None
         self._account_snapshot: dict[str, float] = {}
         self._account_updated_at: float = 0.0
         self._tracked_symbols: set[str] = set()
@@ -284,9 +191,7 @@ class MarketDataManager:
             margin_segment = "equity"
         self._margin_segment = margin_segment
 
-        poll_env = os.getenv("MDM_POLL_FALLBACK", "").strip().lower()
-        poll_flag_provided = bool(poll_env)
-        self._rest_poll_enabled = poll_env in {"1", "true", "yes", "on"}
+        self._rest_poll_enabled = False
         self._rest_poll_interval = self._parse_float_env(
             "MDM_POLL_INTERVAL_SECONDS", default=3.0, minimum=0.5
         )
@@ -297,19 +202,7 @@ class MarketDataManager:
             configured_poll_max if self._rest_poll_enabled else 0
         )
         self._fallback_enabled = self._rest_poll_enabled
-        if not poll_flag_provided and not self._rest_poll_enabled and self._ws is None:
-            self._rest_poll_enabled = True
-            self._rest_poll_interval = max(self._rest_poll_interval, 2.0)
-            self._rest_poll_max_symbols = max(configured_poll_max, 5)
-            self._fallback_enabled = True
-            self._logger.info(
-                "Condition met: mdm_rest_poll_auto_enabled",
-                extra={
-                    "event": "mdm_rest_poll_auto_enabled",
-                    "interval": float(self._rest_poll_interval),
-                    "max_symbols": int(self._rest_poll_max_symbols),
-                },
-            )
+        self._fallback_enabled = False
         self._rest_poll_stop = threading.Event()
         self._rest_poll_thread: threading.Thread | None = None
         self._health_monitor_stop = threading.Event()
@@ -369,59 +262,8 @@ class MarketDataManager:
         self._last_balance_log_time = 0.0
 
     def ingest_rest_quote(self, symbol: str, quote: Mapping[str, Any]) -> None:
-        """Commit REST quote payload for ``symbol`` into cache AND emit to subscribers."""
-        if not symbol or not isinstance(quote, Mapping):
-            return
-
-        try:
-            normalized_symbol = symbol.strip().upper()
-            if not normalized_symbol:
-                return
-
-            # Normalize fields
-            ltp = _coerce_float(quote.get("ltp") or quote.get("last_price"))
-            bid = _coerce_float(quote.get("bid"))
-            ask = _coerce_float(quote.get("ask"))
-            timestamp = _coerce_float(
-                quote.get("timestamp") or quote.get("server_ts_s")
-            )
-            volume = _coerce_float(quote.get("volume") or quote.get("volume_traded"))
-
-            payload = {
-                "symbol": normalized_symbol,
-                "ltp": ltp,
-                "bid": bid,
-                "ask": ask,
-                "volume": volume,
-                "timestamp": timestamp or time.time(),
-                "_source": "rest",
-                "depth": quote.get("depth"),
-            }
-
-            with self._lock:
-                previous = self._latest_ticks.get(normalized_symbol)
-                self._latest_ticks[normalized_symbol] = payload
-
-            # [FIX] CRITICAL: Emit to Strategy Runner!
-            # [FIX] CRITICAL: Emit to Strategy Runner!
-            normalized_tick = self._normalize_tick(normalized_symbol, payload, previous)
-
-            # Fallback: If normalization is too strict but we successfully extracted an LTP
-            # in the payload above, use the payload directly.
-            tick_to_emit = normalized_tick
-            if tick_to_emit is None and payload.get("ltp") is not None:
-                tick_to_emit = payload
-
-            if tick_to_emit:
-                self._emit_tick(normalized_symbol, tick_to_emit, source="rest")
-
-        except Exception as exc:
-            self._logger.error(
-                "Failure in MarketDataManager.ingest_rest_quote: %s",
-                exc,
-                extra={"event": "mdm_ingest_rest_quote_error", "symbol": symbol},
-                exc_info=exc,
-            )
+        """Reject non-websocket feed ingestion for deterministic tick path."""
+        raise DataIntegrityError("REST quote ingestion disabled; websocket only")
 
     def set_unified_manager(self, manager: Any | None) -> None:
         """Attach unified manager callbacks for cache updates.
@@ -627,20 +469,16 @@ class MarketDataManager:
                 self._ws.start()
             except Exception:
                 self._logger.exception("Failure in ws.start")
-
-        # 🔥 Force REST fallback if WS not connected
-        if self._rest_poll_enabled:
-            if not self._ws or not self._ws.is_connected():
-                self._logger.info(
-                    "mdm_rest_fallback_activated",
-                    extra={"event": "mdm_rest_fallback_activated"},
-                )
-                self._start_rest_poll()
+        if self._main_loop is not None and self._tick_consumer_task is None:
+            self._tick_consumer_task = self._main_loop.create_task(self._consume_ticks())
         self._start_health_monitor()
 
     def stop(self) -> None:
         if self._ws is not None:
             self._ws.stop()
+        if self._tick_consumer_task is not None:
+            self._tick_consumer_task.cancel()
+            self._tick_consumer_task = None
         if self._rest_poll_thread is not None:
             self._rest_poll_stop.set()
             self._rest_poll_thread.join(timeout=2.0)
@@ -1098,24 +936,8 @@ class MarketDataManager:
 
     async def _rest_refresh(self, symbol: str) -> None:
         """Args: symbol; Returns: none; Raises: none."""
-
-        normalized_symbol = enforce_canonical(normalize_symbol(symbol)) or symbol
-        with self._lock:
-            if normalized_symbol in self._rest_refresh_inflight:
-                return
-            self._rest_refresh_inflight.add(normalized_symbol)
-        try:
-            await asyncio.to_thread(self.pull_quote, normalized_symbol)
-        except Exception as exc:  # noqa: BLE001
-            self._logger.error(
-                "Failure in _rest_refresh: %s",
-                exc,
-                extra={"event": "mdm_rest_refresh_error", "symbol": normalized_symbol},
-                exc_info=exc,
-            )
-        finally:
-            with self._lock:
-                self._rest_refresh_inflight.discard(normalized_symbol)
+        del symbol
+        return None
 
     def _schedule_rest_refresh(self, symbol: str) -> None:
         """Args: symbol; Returns: none; Raises: none."""
@@ -1330,10 +1152,7 @@ class MarketDataManager:
 
         normalized = self._normalize_tick(symbol, quote, previous)
         if normalized is not None:
-            if not self._is_duplicate(symbol, normalized):
-                self._emit_tick(symbol, normalized, source="rest")
-            else:
-                self._store_tick(symbol, normalized)
+            self._store_tick(symbol, normalized)
             return normalized
         return {"symbol": symbol, **quote}
 
@@ -2378,9 +2197,9 @@ class MarketDataManager:
             return True
         state = self._ws.connection_state()
         if state != ConnectionState.CONNECTED:
-            return self._rest_poll_enabled and self._has_recent_rest_ticks()
+            return False
         if not self._ws.is_connected():
-            return self._rest_poll_enabled and self._has_recent_rest_ticks()
+            return False
         return True
 
     def attach_tick_bus(self, tick_bus: Any) -> None:
@@ -2405,27 +2224,7 @@ class MarketDataManager:
     def _on_tick(self, tick: dict[str, Any]) -> None:
         """Args: tick; Returns: none; Raises: none."""
         try:
-            symbol_value = tick.get("symbol")
-            if not symbol_value:
-                return
-            symbol = enforce_canonical(normalize_symbol(str(symbol_value)))
-            incoming = dict(tick)
-            incoming_ts = float(incoming.get("timestamp") or time.time())
-            previous = self._tick_cache.get(symbol)
-            if previous is not None:
-                previous_ts = float(previous.get("timestamp") or 0.0)
-                previous_source = str(previous.get("source", "")).lower()
-                incoming_source = str(incoming.get("source", "")).lower()
-                if (
-                    previous_source == "ws"
-                    and incoming_source in {"rest", "polling"}
-                    and incoming_ts <= previous_ts
-                ):
-                    return
-            self._tick_cache[symbol] = incoming
-            self._last_tick_time[symbol] = time.time()
-            self.last_tick_time = time.time()
-            self._handle_tick(incoming)
+            self._handle_tick(tick)
         except Exception as e:
             self._logger.error("Failure in MarketDataManager._on_tick: %s", e)
 
@@ -2447,7 +2246,7 @@ class MarketDataManager:
     # Internal plumbing
 
     def _handle_tick(self, tick: dict[str, Any]) -> None:
-        """Process an incoming raw tick from WebSocket or Polling."""
+        """Process an incoming raw tick from websocket only."""
 
         if not isinstance(tick, dict):
             self._logger.error("Invalid tick format: %s", type(tick))
@@ -2491,39 +2290,27 @@ class MarketDataManager:
         if symbol not in self._tracked_symbols:
             self._tracked_symbols.add(symbol)
 
-        if not self._allow_tick_for_symbol(symbol):
-            return
+        tick_source = str(tick.get("source", "ws") or "ws").lower()
+        if tick_source != "ws":
+            raise DataIntegrityError(f"non-websocket source rejected: {tick_source}")
 
-        with self._lock:
-            previous = self._latest_ticks.get(symbol)
-
-        try:
-            normalized_tick = self._normalize_tick(symbol, tick, previous)
-        except Exception as exc:
-            self._logger.error(
-                f"mdm_normalize_crash: {exc}", extra={"symbol": symbol}, exc_info=True
-            )
-            return
-
+        previous = self._latest_ticks.get(symbol)
+        normalized_tick = self._normalize_tick(symbol, tick, previous)
         if not normalized_tick:
-            return
+            raise DataIntegrityError(f"invalid tick payload for {symbol}")
+        normalized_tick["source"] = "ws"
+        raw_for_validation = dict(normalized_tick)
+        raw_for_validation["timestamp"] = datetime.fromtimestamp(
+            float(normalized_tick["timestamp"]),
+            tz=timezone.utc,
+        )
+        raw_validated = validate_tick(raw_for_validation)
+        raw_validated["source"] = "ws"
+        raw_validated["instrument_token"] = token
 
-        with self._lock:
-            last_seen = self._latest_ticks.get(symbol)
-        if isinstance(last_seen, Mapping):
-            last_ts = float(last_seen.get("timestamp") or 0.0)
-            current_ts = float(normalized_tick.get("timestamp") or 0.0)
-            if current_ts <= last_ts:
-                self._logger.debug(
-                    "Dropping out-of-order tick for %s ts=%.3f last=%.3f",
-                    symbol,
-                    current_ts,
-                    last_ts,
-                )
-                return
-
-        if self._is_duplicate(symbol, normalized_tick):
-            return
+        last_hist = float(self._last_historical_ts.get(symbol, 0.0))
+        if float(pd.Timestamp(raw_validated["timestamp"]).timestamp()) <= last_hist:
+            raise DataIntegrityError("live tick timestamp must be after historical")
 
         if self._ws:
             self.set_ws_connected(True)
@@ -2544,8 +2331,45 @@ class MarketDataManager:
             self._logger.debug(f"TICK_RATE_15S {summary}")
             self._tick_stats.clear()
             self._last_tick_stats_log = now
-        tick_source = str(tick.get("source", "ws") or "ws").lower()
-        self._emit_tick(symbol, normalized_tick, source=tick_source)
+        loop = self._main_loop
+        if loop is None or not loop.is_running():
+            self._tick_queue.put_nowait(raw_validated)
+            self._drain_tick_queue_sync()
+            return
+        asyncio.run_coroutine_threadsafe(self._tick_queue.put(raw_validated), loop)
+
+    async def _consume_ticks(self) -> None:
+        """Consume websocket ticks serially and build candles deterministically."""
+        while True:
+            raw = await self._tick_queue.get()
+            self._process_queued_tick(raw)
+
+    def _drain_tick_queue_sync(self) -> None:
+        """Drain queued ticks serially when async loop is unavailable."""
+        while True:
+            try:
+                raw = self._tick_queue.get_nowait()
+            except asyncio.QueueEmpty:
+                break
+            self._process_queued_tick(raw)
+
+    def _process_queued_tick(self, raw: dict[str, Any]) -> None:
+        """Process one queued tick deterministically."""
+        tick = validate_tick(raw)
+        symbol = enforce_canonical(normalize_symbol(str(tick["symbol"])))
+        engine = self._get_engine(symbol)
+        candle = engine.on_tick(tick)
+        tick_payload = dict(tick)
+        tick_payload["timestamp"] = pd.Timestamp(tick["timestamp"]).timestamp()
+        self._emit_tick(symbol, tick_payload, source="ws")
+        if candle:
+            self._ohlc[self._bar_symbol_key(symbol)].append(candle)
+
+    def _get_engine(self, symbol: str) -> CandleEngine:
+        """Return or create candle engine for symbol."""
+        if symbol not in self._engines:
+            self._engines[symbol] = CandleEngine()
+        return self._engines[symbol]
 
     def _allow_tick_for_symbol(self, symbol: str) -> bool:
         """Args: symbol; Returns: burst-gate decision; Raises: none."""
@@ -2618,20 +2442,12 @@ class MarketDataManager:
         symbol = enforce_canonical(normalize_symbol(symbol))
 
         cached_tick = dict(tick)
-        with self._lock:
-            self._latest_ticks[symbol] = cached_tick
-            self._tick_cache[symbol] = cached_tick
-            self._last_tick_time[symbol] = time.time()
-            self._history[symbol].append(cached_tick)
-            self._last_tick_wallclock[symbol] = float(wallclock)
+        self._latest_ticks[symbol] = cached_tick
+        self._tick_cache[symbol] = cached_tick
+        self._last_tick_time[symbol] = time.time()
+        self._history[symbol].append(cached_tick)
+        self._last_tick_wallclock[symbol] = float(wallclock)
         self._notify_unified_manager(symbol, cached_tick)
-        bar_symbol = self._bar_symbol_key(symbol)
-        self._ohlc_builder.add_tick(bar_symbol, cached_tick)
-        with self._lock:
-            self._ohlc[bar_symbol] = deque(
-                self._ohlc_builder.get_bars(bar_symbol),
-                maxlen=self._cache_len,
-            )
         staleness_seconds = 0.0
         try:
             staleness_seconds = max(time.time() - float(wallclock), 0.0)
@@ -2655,29 +2471,13 @@ class MarketDataManager:
 
     def _emit_tick(self, symbol: str, tick: dict[str, Any], *, source: str) -> None:
         source = str(source or "unknown").lower()
-        now_emit = time.monotonic()
-        with self._lock:
-            last_emit = float(self._last_emit_mono.get(symbol, 0.0))
-            if (
-                source != "warmup"
-                and source != "historical"
-                and
-                self._tick_emit_min_interval > 0
-                and (now_emit - last_emit) < self._tick_emit_min_interval
-            ):
-                return
-            self._last_emit_mono[symbol] = now_emit
         self._store_tick(symbol, tick)
-        if source == "warmup":
-            return
         callbacks: list[TickCallback]
         tick_payload = dict(tick)
-        with self._lock:
-            self._last_tick_source[symbol] = source
-            callbacks = list(self._subscribers.get(symbol, ()))
-            self._tick_counter += 1
-        if source != "ws":
-            self.bump_heartbeat()
+        self._last_tick_source[symbol] = source
+        callbacks = list(self._subscribers.get(symbol, ()))
+        self._tick_counter += 1
+        self.bump_heartbeat()
         now_mono = time.monotonic()
         tick_stats_interval = float(os.getenv("TICK_STATS_INTERVAL", "5.0"))
         if now_mono - self._last_tick_log_time >= tick_stats_interval:
@@ -2701,9 +2501,8 @@ class MarketDataManager:
                             lambda: safe_task(callback(dict(tick_payload)))
                         )
                     else:
-                        with self._lock:
-                            self._async_dispatch_drops += 1
-                            async_dispatch_drops = self._async_dispatch_drops
+                        self._async_dispatch_drops += 1
+                        async_dispatch_drops = self._async_dispatch_drops
                         now = time.monotonic()
                         if now - self._last_async_drop_log > 5.0:
                             self._logger.warning(
@@ -2796,15 +2595,29 @@ class MarketDataManager:
                     if candle_dt.tzinfo is None:
                         candle_dt = candle_dt.replace(tzinfo=timezone.utc)
 
-                    synthetic_tick = {
-                        "instrument_token": token,
-                        "symbol": symbol,
-                        "last_price": float(candle.get("close", 0.0)),
-                        "volume": candle.get("volume", 0),
-                        "timestamp": float(candle_dt.timestamp()),
-                        "source": "warmup",
+                    historical_tick = {
+                        "symbol": canonical_symbol,
+                        "ltp": float(candle.get("close", 0.0)),
+                        "volume": float(candle.get("volume", 0.0)),
+                        "timestamp": candle_dt,
+                        "source": "historical",
                     }
-                    self._handle_tick(synthetic_tick)
+                    validated = validate_tick(historical_tick)
+                    validated_payload = dict(validated)
+                    validated_payload["timestamp"] = float(
+                        validated["timestamp"].timestamp()
+                    )
+                    validated_payload["source"] = "historical"
+                    self._store_tick(canonical_symbol, validated_payload)
+                    engine = self._get_engine(canonical_symbol)
+                    finalized = engine.on_tick(validated)
+                    if finalized:
+                        self._ohlc[self._bar_symbol_key(canonical_symbol)].append(
+                            finalized
+                        )
+                    self._last_historical_ts[canonical_symbol] = float(
+                        validated["timestamp"].timestamp()
+                    )
 
             self._logger.info("WARMUP_COMPLETE")
         except Exception as e:
@@ -3910,39 +3723,10 @@ class MarketDataManager:
             None.
         """
 
-        candidates: list[str | int] = self._candidate_quote_keys(symbol)
-        if not candidates:
-            candidates = [symbol]
-        quote: dict[str, Any] | None = None
-        for key in candidates:
-            broker_key: str | int
-            if isinstance(key, int):
-                broker_key = int(key)
-            else:
-                broker_key = key
-            fetched = self._broker_quote_any(broker_key)
-            if fetched:
-                quote = fetched
-                break
-        if quote is None:
-            return
-        if not isinstance(quote, dict):
-            quote = dict(quote)
-        with self._lock:
-            previous = self._latest_ticks.get(symbol)
-        normalized = self._normalize_tick(symbol, quote, previous)
-        if normalized is None:
-            return
-        if self._is_duplicate(symbol, normalized):
-            return
-        self._emit_tick(symbol, normalized, source="rest")
+        del symbol
+        return
 
     def _has_recent_rest_ticks(self) -> bool:
-        cutoff = time.time() - max(self._rest_poll_interval * 2.0, 5.0)
-        with self._lock:
-            for symbol, ts in self._last_tick_wallclock.items():
-                if self._last_tick_source.get(symbol) == "rest" and ts >= cutoff:
-                    return True
         return False
 
     @staticmethod

--- a/src/nifty_scalper_bot/strategies/signal.py
+++ b/src/nifty_scalper_bot/strategies/signal.py
@@ -15,6 +15,7 @@ from nifty_scalper_bot.utils.logging import get_logger
 from .signal_generator import Signal, Strategy
 
 LOGGER = get_logger(__name__)
+ACTIVE_STRATEGIES = ['SMC']
 
 
 def _load_enabled_strategy_modules() -> list[str]:
@@ -69,8 +70,8 @@ def _load_enabled_strategy_modules() -> list[str]:
             "No elite modules enabled; using defaults",
             extra={"event": "strategy_config_empty"},
         )
-        return list(ELITE_STRATEGY_MODULES)
-    return normalized
+        return ['smc_liquidity']
+    return ['smc_liquidity']
 
 
 def basic_signal(


### PR DESCRIPTION
### Motivation

- Eliminate multiple ingestion paths, race conditions and duplicate candle pipelines by centralising candle construction in a single deterministic engine.  
- Ensure every live tick follows one serialised path (WebSocket → validate_tick → queue → single consumer → CandleEngine → storage) to remove out-of-order and duplicate candle issues.  
- Remove legacy OHLC builder, throttle/fallback behaviour and locks from the hot data path to guarantee deterministic, single-threaded processing.

### Description

- Removed the legacy in-manager OHLC builder and all uses of `_OHLCBuilder`, `.add_tick()`, `.get_bars()` and `.snapshot()` and replaced them with `CandleEngine` only.  
- Introduced an engine registry `self._engines: dict[str, CandleEngine]` and `_get_engine(symbol)` to lazily create per-symbol `CandleEngine` instances.  
- Added a single-path queue: `self._tick_queue = asyncio.Queue()` and a single consumer task (`_consume_ticks` / `_process_queued_tick`) which validates ticks with `validate_tick` and feeds them to the symbol's `CandleEngine`; finalized candles are appended to `_ohlc`.  
- Rejected non-websocket sources at the first entry point and disabled REST/polling ingestion and polling helpers so only `source == "ws"` is allowed for live ticks.  
- Removed tick-throttling and removed lock usage from the live data pipeline (locks retained only for non-hot-path operations).  
- Hydration (historical) now runs at startup only and is fed through `CandleEngine` (historical rows converted to validated ticks and passed to engines), and the last historical timestamp per symbol is recorded so live ticks are rejected until after hydration.  
- Temporarily isolated strategy loading to SMC-only for debugging by pinning enabled strategies to `smc_liquidity` and adding `ACTIVE_STRATEGIES = ['SMC']` to reduce surface during validation.

### Testing

- Ran `pytest -q tests/data/test_market_data_manager.py` and the suite passed.  
- Verified Python byte-compile with `python -m py_compile src/nifty_scalper_bot/data/market_data_manager.py src/nifty_scalper_bot/strategies/signal.py` succeeded.  
- Executed `./run_checks.sh` (via `bash run_checks.sh`) which installed project dependencies successfully but reported missing developer tooling inside the created venv (ruff/mypy/pytest) so the full checks were not completed in that environment.  
- Ran full `pytest` (all tests) which stopped during collection due to an existing test import expectation (`ModuleNotFoundError: No module named 'market_data_manager'`) unrelated to the deterministic pipeline changes, so end-to-end test run could not complete in this session.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c43d16fa5083249bfff0d934008e23)