### PR TITLE
fix: harden market data hydration, indicator ingestion, and MDM account TTL

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -5685,7 +5685,7 @@ async def startup_sequence(ctx: BotContext) -> None:
 
             LOGGER.info(f"⏳ Hydrating {len(targets)} symbols: {targets}")
 
-            # ---------- HISTORICAL HYDRATION (PARALLEL FETCH + SERIAL COMMIT) ----------
+            # ---------- HISTORICAL HYDRATION (SEQUENTIAL FETCH + SERIAL COMMIT) ----------
             end_dt = datetime.now()
             start_dt = end_dt - timedelta(days=5)
             from_str = start_dt.strftime("%Y-%m-%d %H:%M:%S")
@@ -5713,9 +5713,13 @@ async def startup_sequence(ctx: BotContext) -> None:
                 )
                 return symbol, list(records or [])
 
-            fetch_results = await asyncio.gather(
-                *[_fetch_symbol(sym) for sym in targets], return_exceptions=True
-            )
+            fetch_results: list[tuple[str, list[Any]] | Exception] = []
+            for target_symbol in targets:
+                try:
+                    fetch_results.append(await _fetch_symbol(target_symbol))
+                except Exception as exc:  # noqa: BLE001
+                    fetch_results.append(exc)
+                await asyncio.sleep(0.35)
 
             LOGGER.info(
                 "hydration_commit_start",

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -150,7 +150,7 @@ class MarketDataManager:
         self._tick_stats: dict[str, int] = defaultdict(int)
         self._last_tick_stats_log = time.monotonic()
         self._account_cache_ttl = self._parse_float_env(
-            "MDM_ACCOUNT_CACHE_TTL", default=30.0, minimum=1.0
+            "MDM_ACCOUNT_CACHE_TTL", default=60.0, minimum=1.0
         )
         self._account_segment = _resolve_account_segment()
 

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -2096,8 +2096,7 @@ class StrategyRunner:
 
         try:
             # 3. INDICATORS: Feed the Engine
-            # [FIX] Use update_price() instead of update_bar()
-            # We convert the bar to a dict using .as_mapping() as expected by the engine.
+            # [FIX] Use update_price() instead of update_bar().
             if hasattr(self._indicator_engine, "update_bar"):
                 self._indicator_engine.update_bar(symbol, bar)
             else:
@@ -2105,7 +2104,7 @@ class StrategyRunner:
                 indicator_volume = 0 if getattr(bar, "synthetic", False) else bar.volume
                 self._indicator_engine.update_price(
                     symbol,
-                    bar.as_mapping(),
+                    float(bar.close),
                     volume=indicator_volume,
                     timestamp=bar.timestamp,
                     is_complete=True,


### PR DESCRIPTION
### Motivation
- Avoid startup hydration rate-limit failures by preventing concurrent historical-data bursts.
- Fix indicator ingestion bug that prevented `_histories` from being populated and blocked readiness gating.
- Align account-cache TTL with the margin refresh cadence to avoid stale-balance windows.

### Description
- Replace concurrent `asyncio.gather(...)` hydration with a sequential fetch loop and a `0.35s` throttle in `core/app.py` to reduce upstream rate-limit errors (`startup` hydration path).
- Fix fallback indicator ingestion in `strategies/runner.py` by passing `float(bar.close)` into `update_price()` instead of `bar.as_mapping()` so the engine receives a scalar price as expected.
- Change default `MDM_ACCOUNT_CACHE_TTL` from `30.0` to `60.0` in `data/market_data_manager.py` to match the intended refresh cadence.

### Testing
- Ran `python3 -m py_compile src/nifty_scalper_bot/core/app.py src/nifty_scalper_bot/strategies/runner.py src/nifty_scalper_bot/data/market_data_manager.py` and compilation succeeded for the modified files.
- Executed `bash ./run_checks.sh`; it installed dependencies but the overall check failed due to repository-wide `ruff`/`mypy` findings and a `pytest` config issue (`pytest` was invoked with coverage flags not present in this environment).
- Ran targeted `pytest` command per project guidelines which failed at collection with `ModuleNotFoundError: No module named 'market_data_manager'` in `tests/test_mdm_diagnostics.py`, indicating test import path assumptions in the test suite rather than changes introduced here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c749117c008324b5251e0802e19877)