### PR TITLE
fix: harden execution tick exits and schedule EOD flatten

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -6286,6 +6286,24 @@ async def startup_sequence(ctx: BotContext) -> None:
         except Exception as e:
             LOGGER.error(f"Failed to wire bracket ticks: {e}")
 
+    if ctx.bracket_manager:
+        try:
+            now_ist = datetime.now(ZoneInfo("Asia/Kolkata"))
+            eod_target_ist = now_ist.replace(hour=15, minute=24, second=0, microsecond=0)
+            if now_ist >= eod_target_ist:
+                eod_target_ist = eod_target_ist + timedelta(days=1)
+            seconds_to_15h24 = max(
+                0.0, (eod_target_ist - now_ist).total_seconds()
+            )
+            loop.call_later(seconds_to_15h24, ctx.bracket_manager.eod_flatten_all)
+            LOGGER.info(
+                "EOD bracket flatten scheduled for %s IST (in %.1fs)",
+                eod_target_ist.isoformat(),
+                seconds_to_15h24,
+            )
+        except Exception as e:
+            LOGGER.error("Failed to schedule EOD flatten: %s", e)
+
     LOGGER.info("✅ Startup sequence fully complete.")
 
 

--- a/src/nifty_scalper_bot/execution/bracket_manager.py
+++ b/src/nifty_scalper_bot/execution/bracket_manager.py
@@ -887,7 +887,12 @@ class BracketManager:
             for eid in relevant_ids:
                 b = self._brackets.get(eid)
                 # 🟢 FIX: Remove 'b.active' check so we can catch inactive ones
-                if b and b.remaining_quantity > 0 and not b.exit_executed and not b.exit_in_progress:
+                if (
+                    b
+                    and b.remaining_quantity > 0
+                    and not b.exit_executed
+                    and not b.exit_in_progress
+                ):
                     candidates.append(b)
         
         if not candidates:
@@ -910,43 +915,48 @@ class BracketManager:
         exits_to_fire = []
         
         for bracket in candidates:
-            # 🟢 FAILSAFE: Auto-activate on first tick if stuck inactive
-            if not bracket.active:
-                if ltp > 0:
-                    bracket.active = True
-                    # Fix missing entry price (Market Orders)
-                    if bracket.entry_price <= 0:
-                        bracket.entry_price = ltp
-                    
-                    # Initialize Watermarks for Trailing
-                    if bracket.side == "BUY": 
-                        bracket.highest_ltp = ltp
-                    else: 
-                        bracket.lowest_ltp = ltp
-                    
-                    # ✅ CORRECTED ATTRIBUTE: Use 'entry_order_id', not 'order_id'
-                    self._log_throttled('debug', f'failsafe_{bracket.entry_order_id}', 5.0, 'FAILSAFE_ACTIVATION entry_id=%s ltp=%s', bracket.entry_order_id, round(ltp, 2))
-                else:
-                    # If we can't activate (no price), skip this bracket
-                    continue
+            # Keep all bracket field mutations atomic against watchdog reads.
+            with self._lock:
+                # 🟢 FAILSAFE: Auto-activate on first tick if stuck inactive
+                if not bracket.active:
+                    if ltp > 0:
+                        bracket.active = True
+                        # Fix missing entry price (Market Orders)
+                        if bracket.entry_price <= 0:
+                            bracket.entry_price = ltp
 
-            # Track previous tick for jump/cross stop-loss detection.
-            bracket.previous_ltp = float(bracket.last_ltp or ltp)
-            bracket.last_ltp = ltp
-            
-            # Update high/low water marks (atomic operations)
-            if bracket.side == "BUY":
-                if ltp > bracket.highest_ltp:
-                    bracket.highest_ltp = ltp
-            else:
-                if ltp < bracket.lowest_ltp:
-                    bracket.lowest_ltp = ltp
-            
-            # Fast SL check with cross detection (jump-safe) before trailing updates.
-            pre_action = self._evaluate_exit_fast(bracket, ltp)
-            if pre_action and pre_action.get('type') == 'SL':
-                exits_to_fire.append((bracket, pre_action))
-                continue
+                        # Initialize Watermarks for Trailing
+                        if bracket.side == "BUY":
+                            bracket.highest_ltp = ltp
+                        else:
+                            bracket.lowest_ltp = ltp
+
+                        # ✅ CORRECTED ATTRIBUTE: Use 'entry_order_id', not 'order_id'
+                        self._log_throttled(
+                            "debug",
+                            f"failsafe_{bracket.entry_order_id}",
+                            5.0,
+                            "FAILSAFE_ACTIVATION entry_id=%s ltp=%s",
+                            bracket.entry_order_id,
+                            round(ltp, 2),
+                        )
+                    else:
+                        # If we can't activate (no price), skip this bracket
+                        continue
+
+                # Track previous tick for jump/cross stop-loss detection.
+                bracket.previous_ltp = float(
+                    bracket.last_ltp or bracket.entry_price or ltp
+                )
+                bracket.last_ltp = ltp
+
+                # Update high/low water marks (atomic operations)
+                if bracket.side == "BUY":
+                    if ltp > bracket.highest_ltp:
+                        bracket.highest_ltp = ltp
+                else:
+                    if ltp < bracket.lowest_ltp:
+                        bracket.lowest_ltp = ltp
             
             # Check trailing controller (if attached)
             # Wrapped in try/except so trailing failures cannot block SL/TP eval
@@ -1011,6 +1021,32 @@ class BracketManager:
             ]
         )
 
+    def eod_flatten_all(self) -> None:
+        """Force-exit all active brackets for EOD risk control. Args: none; Returns: none; Raises: none."""
+        exits_to_fire: list[tuple[BracketState, dict[str, object]]] = []
+        with self._lock:
+            for bracket in self._brackets.values():
+                if (
+                    bracket.remaining_quantity <= 0
+                    or bracket.exit_executed
+                    or bracket.exit_in_progress
+                ):
+                    continue
+                exits_to_fire.append(
+                    (
+                        bracket,
+                        {
+                            "type": "SL",
+                            "price": bracket.last_ltp or bracket.entry_price,
+                            "qty": bracket.remaining_quantity,
+                            "reason": "EOD_FLATTEN_1524",
+                        },
+                    )
+                )
+        if exits_to_fire:
+            LOGGER.info("EOD flatten triggered for %s active brackets", len(exits_to_fire))
+            self._fire_exits_batch(exits_to_fire)
+
     def _sl_crossed(self, bracket: BracketState, ltp: float) -> bool:
         """Return True when a tick crosses stop-loss. Args: bracket, ltp; Returns: bool; Raises: none."""
         prev_ltp = float(bracket.previous_ltp or bracket.last_ltp or ltp)
@@ -1063,12 +1099,16 @@ class BracketManager:
         
         # Check SL (CRITICAL - always check last) using jump-safe cross detection.
         if bracket.sl_trigger_price > 0:
-            prev_ltp = float(bracket.previous_ltp or ltp)
+            prev_ltp = float(bracket.previous_ltp or bracket.entry_price or ltp)
             triggered = False
             if bracket.side == "BUY":
-                triggered = prev_ltp > bracket.sl_trigger_price and ltp <= bracket.sl_trigger_price
+                crossed = prev_ltp > bracket.sl_trigger_price and ltp <= bracket.sl_trigger_price
+                breached = ltp <= bracket.sl_trigger_price
+                triggered = crossed or breached
             elif bracket.side == "SELL":
-                triggered = prev_ltp < bracket.sl_trigger_price and ltp >= bracket.sl_trigger_price
+                crossed = prev_ltp < bracket.sl_trigger_price and ltp >= bracket.sl_trigger_price
+                breached = ltp >= bracket.sl_trigger_price
+                triggered = crossed or breached
 
             if triggered:
                 return {
@@ -1233,22 +1273,6 @@ class BracketManager:
         with self._lock:
             return {b.symbol: b for b in self._brackets.values() if b.active}
 
-
-    def _check_and_fire(self, bracket: BracketState, ltp: float) -> None:
-        """Evaluate logic for a single bracket: Exits, Partials, and Trailing."""
-        
-        # 1. UPDATE TRAILING STATE (High/Low Water Marks)
-        self._process_trailing_logic(bracket, ltp)
-
-        # 2. STOP LOSS CHECK
-        if self._check_stop_loss(bracket, ltp):
-            return  # SL hit, stop processing
-
-        # 3. PARTIAL TARGETS (TP1)
-        self._check_partial_targets(bracket, ltp)
-
-        # 4. FINAL TARGET (TP2)
-        self._check_final_target(bracket, ltp)
 
     def _process_trailing_logic(self, bracket: BracketState, ltp: float) -> None:
         """Updates High/Low marks and adjusts SL if Trailing is enabled."""

--- a/src/nifty_scalper_bot/execution/order_manager.py
+++ b/src/nifty_scalper_bot/execution/order_manager.py
@@ -2041,13 +2041,24 @@ class OrderManager:
                 # We use the 'Thread' class already imported at top of file
                 t = Thread(target=target, name=f"ord_{unique_client_id}", daemon=True)
                 t.start()
-                t.join(timeout=3.0)  # Strict 3s timeout
+                t.join(timeout=8.0)
 
                 if t.is_alive():
-                    self._logger.critical(
-                        f"🚨 Broker API hung on attempt {attempt}! Timeout forced."
+                    self._logger.warning(
+                        "Broker call exceeded 8s for %s (attempt %s); waiting recovery window",
+                        normalized_symbol,
+                        attempt,
                     )
-                    raise TimeoutError("Broker API call timed out (3s)")
+                    t.join(timeout=2.0)
+                    if t.is_alive():
+                        self._logger.critical(
+                            f"🚨 Broker API hung on attempt {attempt}! Timeout forced."
+                        )
+                        raise TimeoutError("Broker API call timed out (10s)")
+                    self._logger.info(
+                        "Recovered late broker response inside grace window for %s",
+                        normalized_symbol,
+                    )
 
                 response = result_holder["resp"]
 


### PR DESCRIPTION
### Motivation
- Prevent TOCTOU races between the watchdog and tick path by making bracket field updates atomic. 
- Eliminate duplicate per-tick exit evaluations to avoid double-firing and reduce race windows. 
- Ensure positions are force-flattened before broker auto-squareoff (reduce worst-price drift at EOD). 
- Reduce ghost-position risk from strict broker-call timeouts by allowing a short recovery window for late ACKs. 

### Description
- Moved all mutable bracket field updates inside a single `with self._lock:` in `BracketManager.on_tick()` to make activation, `last_ltp`/`previous_ltp`, and watermark updates atomic. 
- Removed redundant/dangling `_check_and_fire` path and ensured a single call to `_evaluate_exit_fast()` after trailing updates so exits are evaluated once per tick. 
- Added `BracketManager.eod_flatten_all()` to create protective SL exits for all active brackets and wired it into `startup_sequence()` in `core/app.py` using `loop.call_later(...)` to schedule a call at 15:24 IST. 
- Hardened SL logic to handle gap-breaches by falling back to `entry_price` for previous LTP and checking direct breaches in `_evaluate_exit_fast()`. 
- Extended `OrderManager.place_order()` broker-thread join timeout from `3s` to `8s` and added a `2s` grace join before raising a `TimeoutError` so late broker ACKs can be recovered safely. 

Files touched: `src/nifty_scalper_bot/execution/bracket_manager.py`, `src/nifty_scalper_bot/execution/order_manager.py`, `src/nifty_scalper_bot/core/app.py`.

### Testing
- Ran compile checks: `python3 -m py_compile src/nifty_scalper_bot/execution/bracket_manager.py` and `python3 -m py_compile src/nifty_scalper_bot/execution/order_manager.py src/nifty_scalper_bot/core/app.py` — both succeeded. 
- Executed `./run_checks.sh` (full repo checks); it completed but reported pre-existing repo-wide `ruff`/`mypy`/pytest invocation issues unrelated to these changes. 
- Ran targeted execution tests: `. .venv/bin/activate && pytest -q tests/execution/test_bracket_manager_reliability.py tests/execution/test_exit_batch_cooldown.py` — all targeted tests passed (6 passed). 
- Attempted full test run: `. .venv/bin/activate && pytest -q tests --disable-warnings --ignore=tests/test_live_mode.py --ignore=tests/test_health_server.py` — failed due to a pre-existing import error in the test suite (`ModuleNotFoundError: market_data_manager`) and other repository-wide lint/type issues reported by `ruff`/`mypy` (these are pre-existing and not introduced by this PR).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c93264c5a883248b167363c0ac9e3d)