### PR TITLE
fix: tighten scalping cooldowns and harden execution guards

### DIFF
--- a/src/nifty_scalper_bot/config/settings.py
+++ b/src/nifty_scalper_bot/config/settings.py
@@ -732,7 +732,7 @@ class RiskSettings:
     atr_stop_multiple: float = 1.0
     contract_lot_size: int = 65  # NIFTY options lot size = 65 (current)
     allow_pyramiding: bool = False
-    signal_debounce_seconds: float = 60.0
+    signal_debounce_seconds: float = 15.0
 
     def __post_init__(self) -> None:
         # Keep the historical ``daily_pnl_cap_pct`` alias in sync with the

--- a/src/nifty_scalper_bot/execution/bracket_manager.py
+++ b/src/nifty_scalper_bot/execution/bracket_manager.py
@@ -1021,8 +1021,13 @@ class BracketManager:
             ]
         )
 
-    def eod_flatten_all(self) -> None:
-        """Force-exit all active brackets for EOD risk control. Args: none; Returns: none; Raises: none."""
+    def eod_flatten_all(
+        self,
+        reason: str = 'EOD_FLATTEN_1524',
+        *_: object,
+        **__: object,
+    ) -> None:
+        """Force-exit all active brackets for EOD risk control. Args: reason. Returns: none. Raises: none."""
         exits_to_fire: list[tuple[BracketState, dict[str, object]]] = []
         with self._lock:
             for bracket in self._brackets.values():
@@ -1039,7 +1044,7 @@ class BracketManager:
                             "type": "SL",
                             "price": bracket.last_ltp or bracket.entry_price,
                             "qty": bracket.remaining_quantity,
-                            "reason": "EOD_FLATTEN_1524",
+                            "reason": reason,
                         },
                     )
                 )

--- a/src/nifty_scalper_bot/execution/order_manager.py
+++ b/src/nifty_scalper_bot/execution/order_manager.py
@@ -9452,12 +9452,12 @@ class OrderManager:
                 order_type = OrderType(
                     payload.get("order_type", OrderType.MARKET.value)
                 )
-            except:
+            except (TypeError, ValueError):
                 order_type = OrderType.MARKET
 
             try:
                 status = OrderStatus(payload.get("status", OrderStatus.SUBMITTED.value))
-            except:
+            except (TypeError, ValueError):
                 status = OrderStatus.SUBMITTED
 
             # Robust Timestamp

--- a/src/nifty_scalper_bot/strategies/elite_strategies/vwap_pro.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/vwap_pro.py
@@ -29,7 +29,7 @@ class VWAPProStrategy(EliteStrategy):
     """
 
     MIN_BARS_REQUIRED = 10
-    COOLDOWN_SECONDS = 45  # ✅ FIX #5: Reduced from 60s → 45s; prevents overtrading while capturing fast NIFTY moves
+    COOLDOWN_SECONDS = 20  # ✅ Scalping fix: shorter directional cooldown for rapid continuation legs
     VWAP_ACCEPTANCE_BARS = 1  # ✅ FIX #5: Reduced from 2 → 1; index bias gate is already a strong 2-condition filter
     TELEMETRY_LOG_EVERY = 5
     VOLUME_GRACE_SECONDS = 900.0  # ✅ FIX C: Extended from 120s → 900s (15 min). NFO options tick ≈once/13min between batches; 120s grace expired before next tick arrived → volume_below_threshold on every call.

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -605,7 +605,7 @@ class StrategyRunner:
         self._last_valid_price: dict[str, float] = {}
         self._last_valid_price_ts: dict[str, datetime] = {}
         self._post_exit_cooldown_seconds: float = float(
-            os.getenv("POST_EXIT_COOLDOWN_SECONDS", "60.0")
+            os.getenv("POST_EXIT_COOLDOWN_SECONDS", "20.0")
         )
         # Global risk-halt latch keeps control-plane work quiet once breaker trips.
         # We intentionally keep this sticky so per-symbol loops cannot spam checks/logs.
@@ -707,7 +707,26 @@ class StrategyRunner:
             os.getenv("MAX_TRADES_PER_SYMBOL_PER_CANDLE", "1")
         )
         self._min_trade_interval_seconds = float(
-            os.getenv("MIN_TRADE_INTERVAL_SECONDS", "180")
+            os.getenv("MIN_TRADE_INTERVAL_SECONDS", "60")
+        )
+        self._session_allow_out_of_hours = (
+            os.getenv("SESSION_ALLOW_OUT_OF_HOURS", "").lower() == "true"
+        )
+        self._force_signal_enabled = os.getenv("FORCE_SIGNAL", "").lower() == "true"
+        self._disable_early_forced_signals = (
+            os.getenv("FEATURE_DISABLE_EARLY_FORCED_SIGNALS", "").lower() == "true"
+        )
+        self._vwap_crossover_enabled = (
+            os.getenv("ENABLE_VWAP_CROSSOVER", "false").lower() == "true"
+        )
+        self._vwap_sl_pct = float(os.getenv("VWAP_SL_PCT", "1.5"))
+        self._vwap_tp_pct = float(os.getenv("VWAP_TP_PCT", "2.0"))
+        self._global_min_signal_confidence = float(
+            os.getenv("GLOBAL_MIN_SIGNAL_CONFIDENCE", "0.45")
+        )
+        self._max_nifty_positions = int(os.getenv("MAX_NIFTY_POSITIONS", "1"))
+        self._exit_reentry_cooldown_sec = float(
+            os.getenv("EXIT_REENTRY_COOLDOWN_SEC", "300")
         )
         self._trade_counter_by_symbol_candle: dict[tuple[str, datetime], int] = {}
         self._trade_counter_lock = threading.RLock()
@@ -4691,13 +4710,7 @@ class StrategyRunner:
                 generated_signal = None
 
                 # 8A. FORCED SIGNAL (Testing only)
-                force_signal_enabled = os.getenv("FORCE_SIGNAL", "").lower() == "true"
-                disable_early_forced = (
-                    os.getenv("FEATURE_DISABLE_EARLY_FORCED_SIGNALS", "").lower()
-                    == "true"
-                )
-
-                if force_signal_enabled and not disable_early_forced:
+                if self._force_signal_enabled and not self._disable_early_forced_signals:
                     generated_signal = Signal(
                         action="BUY",
                         symbol=symbol,
@@ -4711,12 +4724,8 @@ class StrategyRunner:
                     self._logger.warning(f"⚠️ FORCED SIGNAL EMITTED for {symbol}")
 
                 # 8B. PRIMARY STRATEGY: VWAP Crossover (Requires VWAP > 0)
-                vwap_crossover_enabled = (
-                    os.getenv("ENABLE_VWAP_CROSSOVER", "false").lower() == "true"
-                )
-
                 if (
-                    vwap_crossover_enabled
+                    self._vwap_crossover_enabled
                     and generated_signal is None
                     and state.vwap
                     and state.vwap > 0
@@ -4739,10 +4748,8 @@ class StrategyRunner:
                         )
 
                         # ✅ FIX: Calculate proper stop_loss and take_profit
-                        sl_pct = float(os.getenv("VWAP_SL_PCT", "1.5"))  # 1.5% SL
-                        tp_pct = float(
-                            os.getenv("VWAP_TP_PCT", "2.0")
-                        )  # 2.0% TP (1:1.33 RR)
+                        sl_pct = self._vwap_sl_pct  # 1.5% SL
+                        tp_pct = self._vwap_tp_pct  # 2.0% TP (1:1.33 RR)
 
                         if is_cross_up:
                             # BUY signal - SL below, TP above
@@ -5623,7 +5630,7 @@ class StrategyRunner:
         from zoneinfo import ZoneInfo
 
         # Check session override for testing
-        allow_off_hours = os.getenv("SESSION_ALLOW_OUT_OF_HOURS", "").lower() == "true"
+        allow_off_hours = self._session_allow_out_of_hours
         ist_now = datetime.now(ZoneInfo("Asia/Kolkata"))
         is_market_hours = 9 <= ist_now.hour < 16
 
@@ -5894,9 +5901,7 @@ class StrategyRunner:
             # -----------------------------------------------------------
             import time as _time_mod
 
-            _exit_cooldown_sec = float(
-                os.getenv("EXIT_REENTRY_COOLDOWN_SEC", "300")
-            )  # 5 min default
+            _exit_cooldown_sec = self._exit_reentry_cooldown_sec
             _last_exit_time = self._recently_closed.get(base_symbol, 0)
             if (
                 _last_exit_time
@@ -5988,7 +5993,7 @@ class StrategyRunner:
                     return
 
                 # ✅ FIX (6 Feb 2026): Cross-strike check — block if ANY NIFTY option is active
-                _max_nifty_positions = int(os.getenv("MAX_NIFTY_POSITIONS", "1"))
+                _max_nifty_positions = self._max_nifty_positions
                 _all_positions = (
                     list(self._position_manager.get_open_positions())
                     if hasattr(self._position_manager, "get_open_positions")
@@ -6069,7 +6074,7 @@ class StrategyRunner:
             confidence = self._calculate_signal_score(signal.symbol, side, trade_price)
 
             # Confidence Threshold
-            min_confidence = float(os.getenv("GLOBAL_MIN_SIGNAL_CONFIDENCE", "0.45"))
+            min_confidence = self._global_min_signal_confidence
 
             if confidence < min_confidence:
                 self._logger.info(


### PR DESCRIPTION
### Motivation
- Scalping cadence was overly constrained by long defaults (3min/minimum locks and long post-exit cooldowns) causing missed re-entry opportunities.  
- Hot-path code repeatedly called `os.getenv()` on every tick which is inefficient and brittle for high-frequency evaluation.  
- A couple of robustness issues allowed silent failure or call-shape crashes: bare `except:` in order deserialization can swallow important errors and `eod_flatten_all()` had a rigid signature that mismatched callers.

### Description
- Reduced scalping cooldowns and reentry timing by changing `POST_EXIT_COOLDOWN_SECONDS` default to `20.0` and `MIN_TRADE_INTERVAL_SECONDS` default to `60` in `StrategyRunner` (`src/nifty_scalper_bot/strategies/runner.py`).  
- Cached environment-driven toggles/parameters once during `StrategyRunner` initialization and replaced hot-path `os.getenv()` reads with cached attributes for `SESSION_ALLOW_OUT_OF_HOURS`, `FORCE_SIGNAL`, `FEATURE_DISABLE_EARLY_FORCED_SIGNALS`, `ENABLE_VWAP_CROSSOVER`, `VWAP_SL_PCT`, `VWAP_TP_PCT`, `GLOBAL_MIN_SIGNAL_CONFIDENCE`, `MAX_NIFTY_POSITIONS`, and `EXIT_REENTRY_COOLDOWN_SEC` (`src/nifty_scalper_bot/strategies/runner.py`).  
- Reduced `signal_debounce_seconds` default from `60.0` to `15.0` in `RiskSettings` to allow faster valid re-entries (`src/nifty_scalper_bot/config/settings.py`).  
- Shortened `VWAPProStrategy.COOLDOWN_SECONDS` from `45` to `20` seconds to better capture rapid continuation legs (`src/nifty_scalper_bot/strategies/elite_strategies/vwap_pro.py`).  
- Replaced bare `except:` blocks in order deserialization with explicit `except (TypeError, ValueError):` fallbacks to avoid swallowing unexpected exceptions (`src/nifty_scalper_bot/execution/order_manager.py`).  
- Hardened `BracketManager.eod_flatten_all` to accept a `reason` plus variadic `*_, **__` so scheduled callers with different call shapes will not crash, and the provided reason is propagated into the exit payload (`src/nifty_scalper_bot/execution/bracket_manager.py`).

### Testing
- Ran `bash ./run_checks.sh`; the script completed dependency install and exercised lint/type tooling but exited non-zero due to many pre-existing repository-wide Ruff/mypy issues unrelated to these targeted changes.  
- Ran `pytest` with the prescribed ignores via `source .venv/bin/activate && pytest -q tests --disable-warnings --ignore=tests/test_live_mode.py --ignore=tests/test_health_server.py`, which failed early with a pre-existing `ModuleNotFoundError: market_data_manager` in `tests/test_mdm_diagnostics.py` (repository test infra import path issue), so full test-suite pass is blocked by baseline repo config.  
- Verified syntactic correctness of modified modules with `python -m py_compile` for the changed files (`runner.py`, `settings.py`, `vwap_pro.py`, `order_manager.py`, `bracket_manager.py`) which completed successfully.  
- Ran `ruff` checks targeted to the modified files; lint warnings exist in the repo baseline but the applied edits avoid introducing new unsafe patterns (no bare `except`, no repeated hot-path `os.getenv()` calls).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c9508ffd8c8324804e33f28233bd75)