### PR TITLE
fix: stabilize websocket hydration, token↔symbol mapping, and zombie detection

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -5823,7 +5823,9 @@ async def startup_sequence(ctx: BotContext) -> None:
             if ctx.data_hub is not None:
                 ctx.data_hub.indicators_ready = bool(ready_symbols)
             if ready_symbols:
-                LOGGER.info("🧠 Indicators fully hydrated and READY at startup")
+                LOGGER.info(
+                    "Indicators hydration pre-check complete; waiting for live readiness gate"
+                )
             else:
                 LOGGER.error(
                     "Indicators remain unready because no symbols passed hydration barrier"
@@ -6149,6 +6151,27 @@ async def startup_sequence(ctx: BotContext) -> None:
                         ctx.stream_supervisor_started = True
 
                 if ctx.strategy_runner:
+                    if ctx.market_data_manager is not None:
+                        try:
+                            await ctx.market_data_manager.wait_until_ready(timeout=30.0)
+                            LOGGER.info(
+                                "Condition met: startup_pipeline_ready",
+                                extra={
+                                    "event": "startup_pipeline_ready",
+                                    "ws_connected": bool(
+                                        ctx.websocket_manager.is_connected()
+                                        if ctx.websocket_manager is not None
+                                        else False
+                                    ),
+                                },
+                            )
+                        except Exception as ready_exc:
+                            LOGGER.critical(
+                                "Startup readiness gate failed: %s",
+                                ready_exc,
+                                exc_info=ready_exc,
+                            )
+                            raise
                     if not _data_ready(ctx.market_data_manager):
                         LOGGER.debug("startup_tick_gate: waiting_for_live_ticks (expected at boot)")
                     ctx.strategy_runner.start()

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -94,11 +94,6 @@ class MarketDataManager:
         self._settings = settings or {}
         self._resolver = resolver
         self._logger = get_logger(__name__)
-        # Initialise _zombie_symbol early so any partially-constructed object
-        # never raises AttributeError if the health monitor or a callback fires
-        # before __init__ completes.
-        self._zombie_symbol = "NSE:NIFTY"
-
         # FIX: Initialize cache_len before it is used
         self._cache_len = cache_len
 
@@ -128,9 +123,7 @@ class MarketDataManager:
         self._tick_cache: dict[str, dict[str, Any]] = {}
         self._tick_counter = 0
         self._last_tick_log_time = time.monotonic()
-        self._last_tick_time: dict[str, float] = {
-            "NSE:NIFTY": time.time()   # seed: prevent false zombie alarm at startup
-        }
+        self._last_tick_time: dict[str, float] = {}
         self._tick_bus: Any | None = None
         self._main_loop: asyncio.AbstractEventLoop | None = None
         self._async_dispatch_drops = 0
@@ -153,8 +146,13 @@ class MarketDataManager:
         self._account_snapshot: dict[str, float] = {}
         self._account_updated_at: float = 0.0
         self._tracked_symbols: set[str] = set()
+        self._active_subscribed_symbols: set[str] = set()
+        self._symbols_with_tick: set[str] = set()
+        self._ticks_received_per_symbol: dict[str, int] = defaultdict(int)
         self._tick_stats: dict[str, int] = defaultdict(int)
         self._last_tick_stats_log = time.monotonic()
+        self._last_tick_rate_snapshot_at = time.monotonic()
+        self._last_tick_rate_snapshot: dict[str, int] = {}
         self._account_cache_ttl = self._parse_float_env(
             "MDM_ACCOUNT_CACHE_TTL", default=60.0, minimum=1.0
         )
@@ -208,15 +206,11 @@ class MarketDataManager:
         self._rest_poll_thread: threading.Thread | None = None
         self._health_monitor_stop = threading.Event()
         self._health_monitor_thread: threading.Thread | None = None
-        # Pre-seed _last_tick_time for zombie symbol so the 60-second
-        # threshold is measured from MDM construction, not from epoch-0.
-        # Without this, any startup taking > 60s before first WS tick
-        # triggers spurious zombie restarts.
-        self._last_tick_time[self._zombie_symbol] = time.time()
         self._zombie_tick_threshold_sec = self._parse_float_env(
             "ZOMBIE_TICK_THRESHOLD_SEC", default=60.0, minimum=10.0
         )
         self._zombie_restart_failures = 0
+        self._zombie_restart_attempts: Deque[float] = deque()
         self._zombie_restart_window = self._parse_float_env(
             "ZOMBIE_RESTART_WINDOW_SEC", default=120.0, minimum=1.0
         )
@@ -233,8 +227,9 @@ class MarketDataManager:
         self._tick_stale_threshold_ms = self._parse_int_env(
             "TICK_STALE_MS", default=2_000, minimum=0
         )
-        if self._rest_poll_enabled:
-            self._tracked_symbols.add("NSE:NIFTY")
+        self._min_required_bars = self._parse_int_env(
+            "MIN_INDICATOR_BARS", default=20, minimum=1
+        )
 
         # Load optional settings overrides
         if settings is not None:
@@ -262,6 +257,22 @@ class MarketDataManager:
         self._m_ticks = Counter("mdm_ticks_total", "Normalized ticks processed")
         self._last_balance_log_time = 0.0
         self._started = False
+
+    def validate_token_symbol_mappings(self) -> None:
+        """Args: none; Returns: None; Raises: RuntimeError on mapping mismatch."""
+
+        with self._lock:
+            symbol_by_token = dict(self._symbol_by_token)
+            token_by_symbol = dict(self._token_by_symbol)
+        mismatches: list[str] = []
+        for token, symbol in symbol_by_token.items():
+            reverse = token_by_symbol.get(symbol)
+            if reverse != token:
+                mismatches.append(f"{symbol}:{token}->{reverse}")
+        if mismatches:
+            raise RuntimeError(
+                f"Token/symbol mapping mismatch detected ({len(mismatches)}): {mismatches[:5]}"
+            )
 
     def ingest_rest_quote(self, symbol: str, quote: Mapping[str, Any]) -> None:
         """Ingest a REST/polling quote for symbol.
@@ -803,6 +814,7 @@ class MarketDataManager:
             subscribers.add(callback)
             latest = self._latest_ticks.get(symbol)
             cached_token = self._token_by_symbol.get(symbol)
+            self._active_subscribed_symbols.add(symbol)
 
         if latest is not None:
             try:
@@ -844,6 +856,7 @@ class MarketDataManager:
             callbacks.discard(callback)
             if not callbacks:
                 self._subscribers.pop(symbol, None)
+                self._active_subscribed_symbols.discard(symbol)
                 should_unsubscribe = True
 
         if should_unsubscribe:
@@ -1930,9 +1943,10 @@ class MarketDataManager:
         try:
             normalized = normalize_symbol(str(symbol or ""))
             bar_count = len(list(bars))
-            if bar_count >= 20:
+            if bar_count >= self._min_required_bars:
                 self._hydration_status[normalized] = "READY"
             else:
+                self._hydration_status[normalized] = "HYDRATING"
                 self._logger.error(
                     "insufficient_bars_for_strategy",
                     extra={
@@ -1941,10 +1955,61 @@ class MarketDataManager:
                         "bars": bar_count,
                     },
                 )
+            self._logger.info(
+                "Condition met: mdm_hydration_progress",
+                extra={
+                    "event": "mdm_hydration_progress",
+                    "symbol": normalized,
+                    "bars": bar_count,
+                    "required": self._min_required_bars,
+                    "status": self._hydration_status.get(normalized, "HYDRATING"),
+                },
+            )
         except Exception as exc:
             self._logger.error(
                 "Failure in update_hydration_status: %s", exc, exc_info=exc
             )
+
+    def is_symbol_ready(self, symbol: str) -> bool:
+        """Args: symbol; Returns: bool; Raises: none."""
+        normalized = normalize_symbol(str(symbol or ""))
+        with self._lock:
+            return len(self._history.get(normalized, ())) >= self._min_required_bars
+
+    def is_ready(self) -> bool:
+        """Args: none; Returns: bool; Raises: none."""
+        with self._lock:
+            active = sorted(self._active_subscribed_symbols)
+            if not active:
+                return False
+            return all(
+                len(self._history.get(symbol, ())) >= self._min_required_bars
+                for symbol in active
+            )
+
+    async def wait_until_ready(self, timeout: float = 30.0) -> None:
+        """Args: timeout; Returns: None; Raises: TimeoutError."""
+
+        deadline = time.monotonic() + max(timeout, 0.0)
+        while time.monotonic() <= deadline:
+            if self.is_ready():
+                with self._lock:
+                    ready_symbols = sorted(self._active_subscribed_symbols)
+                self._logger.info(
+                    "Condition met: mdm_ready",
+                    extra={"event": "mdm_ready", "symbols": ready_symbols},
+                )
+                return
+            await asyncio.sleep(0.1)
+        with self._lock:
+            snapshot = {
+                symbol: len(self._history.get(symbol, ()))
+                for symbol in sorted(self._active_subscribed_symbols)
+            }
+        raise TimeoutError(
+            "MarketDataManager did not reach READY state within "
+            f"{timeout:.1f}s (min_bars={self._min_required_bars}, bars={snapshot})"
+        )
 
     def get_hydration_status(self, symbol: str) -> str:
         """Return hydration status. Args: symbol. Returns: status string. Raises: None."""
@@ -2278,8 +2343,12 @@ class MarketDataManager:
                 return
             symbol_from_map = self._symbol_by_token.get(int(token))
             if not symbol_from_map:
-                self._logger.debug(
-                    "Unmapped instrument_token=%s — dropped (subscribe pending?)", token
+                self._logger.error(
+                    "Condition met: mdm_unmapped_token_drop",
+                    extra={
+                        "event": "mdm_unmapped_token_drop",
+                        "token": int(token),
+                    },
                 )
                 return
             raw = {**raw, "symbol": symbol_from_map}
@@ -2393,7 +2462,15 @@ class MarketDataManager:
             self._latest_ticks[symbol] = cached_tick
             self._tick_cache[symbol] = cached_tick
             self._last_tick_time[symbol] = time.time()
+            if "ltp" not in cached_tick or cached_tick.get("timestamp") is None:
+                self._logger.debug(
+                    "Condition met: mdm_history_append_rejected",
+                    extra={"event": "mdm_history_append_rejected", "symbol": symbol},
+                )
+                return
             self._history[symbol].append(cached_tick)
+            self._ticks_received_per_symbol[symbol] += 1
+            self._symbols_with_tick.add(symbol)
             self._last_tick_wallclock[symbol] = float(wallclock)
         staleness_seconds = 0.0
         try:
@@ -2435,10 +2512,38 @@ class MarketDataManager:
                     cached_count = len(self._tick_cache)
                     tick_count = self._tick_counter
                     self._tick_counter = 0
+                    rate_interval = max(
+                        now_mono - self._last_tick_rate_snapshot_at,
+                        1e-6,
+                    )
+                    rates = {
+                        sym: (
+                            count - self._last_tick_rate_snapshot.get(sym, 0)
+                        )
+                        / rate_interval
+                        for sym, count in self._ticks_received_per_symbol.items()
+                        if sym in self._active_subscribed_symbols
+                    }
+                    history_lengths = {
+                        sym: len(self._history.get(sym, ()))
+                        for sym in sorted(self._active_subscribed_symbols)
+                    }
+                    self._last_tick_rate_snapshot = dict(
+                        self._ticks_received_per_symbol
+                    )
+                    self._last_tick_rate_snapshot_at = now_mono
             self._logger.debug(
                 "EVENT|tick_stats|cached=%d|ticks_last_5s=%d",
                 cached_count,
                 tick_count,
+            )
+            self._logger.info(
+                "Condition met: mdm_tick_health",
+                extra={
+                    "event": "mdm_tick_health",
+                    "ticks_per_second_by_symbol": rates,
+                    "history_length_by_symbol": history_lengths,
+                },
             )
         try:
             self._m_ticks.inc()
@@ -2564,9 +2669,11 @@ class MarketDataManager:
                         self._ohlc[self._bar_symbol_key(canonical_symbol)].append(
                             finalized
                         )
-                    self._last_historical_ts[canonical_symbol] = float(
-                        validated["timestamp"].timestamp()
-                    )
+                    validated_ts = getattr(validated, "timestamp", None)
+                    if validated_ts is not None:
+                        self._last_historical_ts[canonical_symbol] = float(
+                            validated_ts.timestamp()
+                        )
 
             self._logger.info("WARMUP_COMPLETE")
         except Exception as e:
@@ -2605,6 +2712,14 @@ class MarketDataManager:
         while not self._health_monitor_stop.wait(1.0):
             try:
                 self._check_zombie_ticks()
+            except RuntimeError as exc:
+                self._logger.critical(
+                    "Failure in _health_monitor_loop: %s",
+                    exc,
+                    extra={"event": "mdm_health_monitor_circuit_break"},
+                    exc_info=exc,
+                )
+                os._exit(1)
             except Exception as exc:  # noqa: BLE001
                 self._logger.error(
                     "Failure in _health_monitor_loop: %s",
@@ -2625,21 +2740,47 @@ class MarketDataManager:
             self._zombie_stale_logged = False
             return
 
-        tick_age = self.time_since_last_tick(self._zombie_symbol)
-        if tick_age is None or tick_age <= self._zombie_tick_threshold_sec:
+        now = time.time()
+        with self._lock:
+            candidate_symbols = sorted(
+                sym
+                for sym in self._active_subscribed_symbols
+                if sym in self._symbols_with_tick
+            )
+            stale_symbols = [
+                sym
+                for sym in candidate_symbols
+                if (now - self._last_tick_time.get(sym, now))
+                > self._zombie_tick_threshold_sec
+            ]
+        if not candidate_symbols:
             self._zombie_stale_logged = False
             return
 
-        if not self._zombie_stale_logged:
+        stale_ratio = len(stale_symbols) / max(len(candidate_symbols), 1)
+        self._logger.info(
+            "Condition met: mdm_zombie_summary",
+            extra={
+                "event": "mdm_zombie_summary",
+                "active_symbols": len(candidate_symbols),
+                "stale_symbols": len(stale_symbols),
+                "stale_ratio": round(stale_ratio, 3),
+                "threshold_seconds": self._zombie_tick_threshold_sec,
+            },
+        )
+        if stale_ratio < 0.70:
+            self._zombie_stale_logged = False
+            return
+
+        if not self._zombie_stale_logged and stale_symbols:
             self._logger.critical(
-                "CRITICAL zombie_tick_detected symbol=%s age=%.2fs threshold=%.2fs",
-                self._zombie_symbol,
-                tick_age,
+                "CRITICAL zombie_tick_detected symbols=%s threshold=%.2fs",
+                stale_symbols[:8],
                 self._zombie_tick_threshold_sec,
                 extra={
                     "event": "mdm_zombie_tick_detected",
-                    "symbol": self._zombie_symbol,
-                    "age_seconds": tick_age,
+                    "symbols": stale_symbols,
+                    "stale_ratio": stale_ratio,
                 },
             )
             self._zombie_stale_logged = True
@@ -2669,6 +2810,11 @@ class MarketDataManager:
             try:
                 reconnect()
                 self._zombie_restart_failures = 0
+                self._zombie_restart_attempts.append(now)
+                while self._zombie_restart_attempts and (
+                    now - self._zombie_restart_attempts[0]
+                ) > 120.0:
+                    self._zombie_restart_attempts.popleft()
                 self._logger.warning(
                     "Condition met: mdm_zombie_ws_restart",
                     extra={
@@ -2684,6 +2830,16 @@ class MarketDataManager:
                     extra={"event": "mdm_zombie_ws_restart_error"},
                     exc_info=exc,
                 )
+
+        if len(self._zombie_restart_attempts) > 5:
+            self._logger.critical(
+                "Failure in _trigger_zombie_ws_restart: restart circuit breaker tripped",
+                extra={
+                    "event": "mdm_zombie_restart_circuit_breaker",
+                    "attempts_in_2m": len(self._zombie_restart_attempts),
+                },
+            )
+            raise RuntimeError("WebSocket restart circuit breaker exceeded: >5 in 120s")
 
         if self._zombie_restart_failures > self._zombie_restart_limit:
             self._zombie_breaker_open_until = now + self._zombie_restart_window
@@ -3704,6 +3860,7 @@ class MarketDataManager:
                     "WS subscribe skipped (no token)", extra={"symbol": symbol}
                 )
                 return
+            self.validate_token_symbol_mappings()
             self._logger.debug(
                 "EVENT|subscribe|%s|token=%s|mode=full",
                 symbol,

--- a/src/nifty_scalper_bot/streaming/websocket_manager.py
+++ b/src/nifty_scalper_bot/streaming/websocket_manager.py
@@ -635,6 +635,10 @@ class WebSocketManager:
             )
             if self._tokens:
                 token_list = sorted(self._tokens)
+                mdm = getattr(self, "_market_data_manager", None)
+                validate_mapping = getattr(mdm, "validate_token_symbol_mappings", None)
+                if callable(validate_mapping):
+                    validate_mapping()
                 ws.subscribe(token_list)
                 ws.set_mode(ws.MODE_FULL, token_list)
                 self._logger.info(

--- a/tests/data/test_market_data_manager.py
+++ b/tests/data/test_market_data_manager.py
@@ -444,6 +444,42 @@ def test_zombie_restart_circuit_opens_after_failed_reconnects(
     assert manager._zombie_breaker_open_until == 162.0
 
 
+def test_zombie_detection_uses_active_symbols_with_ticks_only(
+    monkeypatch: pytest.MonkeyPatch, broker: DummyBroker, ws: DummyWebSocket
+) -> None:
+    monkeypatch.setattr(
+        "nifty_scalper_bot.utils.market_hours.is_market_open",
+        lambda: True,
+    )
+    manager = MarketDataManager(broker, ws)
+    manager._zombie_tick_threshold_sec = 1.0
+    manager._ws_connected = True
+    manager._active_subscribed_symbols = {"NSE:NIFTY23", "NSE:NIFTY24"}
+    manager._symbols_with_tick = {"NSE:NIFTY23"}
+    manager._last_tick_time["NSE:NIFTY23"] = time.time()
+
+    calls: list[int] = []
+    manager._trigger_zombie_ws_restart = lambda: calls.append(1)  # type: ignore[method-assign]
+    manager._check_zombie_ticks()
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_wait_until_ready_requires_min_bars(
+    broker: DummyBroker, ws: DummyWebSocket
+) -> None:
+    manager = MarketDataManager(broker, ws, cache_len=5)
+    manager._min_required_bars = 2
+    manager._active_subscribed_symbols = {"NSE:NIFTY23"}
+    manager._history["NSE:NIFTY23"].append({"ltp": 100.0, "timestamp": time.time()})
+
+    with pytest.raises(TimeoutError):
+        await manager.wait_until_ready(timeout=0.1)
+
+    manager._history["NSE:NIFTY23"].append({"ltp": 101.0, "timestamp": time.time()})
+    await manager.wait_until_ready(timeout=0.2)
+
+
 @pytest.mark.asyncio
 async def test_warmup_history_primes_cache_without_emitting_callbacks(
     broker: DummyBroker, ws: DummyWebSocket

--- a/tests/test_startup_sequence.py
+++ b/tests/test_startup_sequence.py
@@ -75,6 +75,10 @@ class DummyMarketDataManager:
     def get_latest_price(self, _symbol: str) -> None:  # pragma: no cover - defensive
         return None
 
+    async def wait_until_ready(self, timeout: float = 30.0) -> None:
+        del timeout
+        return None
+
 
 class DummyOrderManager:
     def __init__(self) -> None:


### PR DESCRIPTION
### Motivation

- Production saw false "zombie" detections, premature hydration READY logs, and strategies starting before market data was truly usable, caused by hardcoded symbols, silent token→symbol failures, and insufficient tick validation.
- The startup race allowed the StrategyRunner to start before the MarketDataManager had valid history, leading to immediate failures after an apparent READY state.

### Description

- Removed hardcoded `NSE:NIFTY` seeding and made zombie detection subscription-aware so only actively subscribed symbols that have received at least one tick are monitored. 
- Reworked zombie logic to compute per-run stale ratio and only trigger a websocket restart when ≥70% of active symbols are stale, plus a restart circuit-breaker that trips after >5 restarts in 120s. 
- Enforced strict bidirectional `token ↔ symbol` mappings with `validate_token_symbol_mappings()` and added unmapped-token drop logging to avoid silent mapping misses. 
- Hardened tick ingestion and history buffer: validated ticks before appending to `deque(maxlen=...)`, reject malformed ticks, update `last_tick_wallclock` and per-symbol `ticks_received_per_symbol`, add structured tick-health logging, and added `wait_until_ready(timeout)` / `is_ready()` gates (poll every 100ms). 
- Adjusted startup sequence so the order is: connect websocket, subscribe tokens, start tick ingestion, `await market_data_manager.wait_until_ready(timeout=30s)`, then start `StrategyRunner`, and removed premature "Indicators READY" info logs until readiness is confirmed.

Files changed: `src/nifty_scalper_bot/data/market_data_manager.py`, `src/nifty_scalper_bot/streaming/websocket_manager.py`, `src/nifty_scalper_bot/core/app.py`, and updated unit tests in `tests/data/test_market_data_manager.py` and `tests/test_startup_sequence.py`.

### Testing

- Ran `bash ./run_checks.sh`; the script executed but the full checks failed due to existing repository-wide lint/mypy/test issues unrelated to this change (these pre-existing failures are outside the scope of this PR). 
- Ran focused unit tests for the MDM and WS pieces with `pytest -q tests/data/test_market_data_manager.py tests/streaming/test_websocket_manager.py --disable-warnings`, which passed (focused suite: 26 tests passed). 
- Attempted full test run `pytest -q tests --disable-warnings --ignore=tests/test_live_mode.py --ignore=tests/test_health_server.py`, which failed on a pre-existing import error in `tests/execution/test_full_pipeline.py` (`OrderExecutionHub`), not introduced by this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3a07906dc832489410bad3ff27978)