### PR TITLE
fix: Harden market data, deterministic option resolution, and WS integration

### DIFF
--- a/src/nifty_scalper_bot/data/market_state.py
+++ b/src/nifty_scalper_bot/data/market_state.py
@@ -1,0 +1,111 @@
+"""Thread-safe in-memory market state for WS and polling integration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from threading import RLock
+import time
+from typing import Any
+
+
+@dataclass(frozen=True, slots=True)
+class MarketStateSnapshot:
+    """Immutable market state snapshot. Args: none. Returns: snapshot. Raises: none."""
+
+    spot_ltp: float | None
+    option_ltps: dict[int, float]
+    last_ws_update: float | None
+    last_poll_update: float | None
+    ohlc_cache: dict[tuple[int, str], tuple[float, list[dict[str, Any]]]]
+
+
+class MarketState:
+    """Central thread-safe state for market prices and OHLC cache."""
+
+    def __init__(self) -> None:
+        """Initialize empty market state. Args: none. Returns: none. Raises: none."""
+
+        self._lock = RLock()
+        self._spot_ltp: float | None = None
+        self._option_ltps: dict[int, float] = {}
+        self._last_ws_update: float | None = None
+        self._last_poll_update: float | None = None
+        self._ohlc_cache: dict[tuple[int, str], tuple[float, list[dict[str, Any]]]] = {}
+
+    def update_tick(self, token: int, price: float, *, source: str = "ws") -> None:
+        """Update token LTP. Args: token/price/source. Returns: none. Raises: ValueError."""
+
+        normalized_token = int(token)
+        normalized_price = float(price)
+        if normalized_price <= 0:
+            raise ValueError("price must be positive")
+        now = time.time()
+        with self._lock:
+            self._option_ltps[normalized_token] = normalized_price
+            if self._spot_ltp is None and normalized_token == 256265:
+                self._spot_ltp = normalized_price
+            if source == "poll":
+                self._last_poll_update = now
+            else:
+                self._last_ws_update = now
+
+    def set_spot_ltp(self, price: float, *, source: str = "ws") -> None:
+        """Set spot LTP directly. Args: price/source. Returns: none. Raises: ValueError."""
+
+        normalized_price = float(price)
+        if normalized_price <= 0:
+            raise ValueError("price must be positive")
+        now = time.time()
+        with self._lock:
+            self._spot_ltp = normalized_price
+            if source == "poll":
+                self._last_poll_update = now
+            else:
+                self._last_ws_update = now
+
+    def mark_poll_update(self) -> None:
+        """Mark poll update timestamp. Args: none. Returns: none. Raises: none."""
+
+        with self._lock:
+            self._last_poll_update = time.time()
+
+    def set_ohlc_cache(
+        self, token: int, interval: str, rows: list[dict[str, Any]]
+    ) -> None:
+        """Store OHLC cache entry. Args: token/interval/rows. Returns: none. Raises: none."""
+
+        with self._lock:
+            self._ohlc_cache[(int(token), str(interval))] = (time.time(), list(rows))
+
+    def get_ohlc_cache(
+        self,
+        token: int,
+        interval: str,
+        *,
+        ttl: int,
+    ) -> list[dict[str, Any]] | None:
+        """Read OHLC cache by token+interval. Args: token/interval/ttl. Returns: rows|None. Raises: none."""
+
+        with self._lock:
+            cache = self._ohlc_cache.get((int(token), str(interval)))
+            if cache is None:
+                return None
+            updated_at, rows = cache
+            if (time.time() - updated_at) > max(0, int(ttl)):
+                return None
+            return list(rows)
+
+    def get_snapshot(self) -> MarketStateSnapshot:
+        """Return immutable market snapshot. Args: none. Returns: snapshot. Raises: none."""
+
+        with self._lock:
+            return MarketStateSnapshot(
+                spot_ltp=self._spot_ltp,
+                option_ltps=dict(self._option_ltps),
+                last_ws_update=self._last_ws_update,
+                last_poll_update=self._last_poll_update,
+                ohlc_cache={
+                    key: (value[0], list(value[1]))
+                    for key, value in self._ohlc_cache.items()
+                },
+            )

--- a/src/nifty_scalper_bot/data/source.py
+++ b/src/nifty_scalper_bot/data/source.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Callable, Mapping
+from datetime import datetime, timezone
+from typing import Any, Callable, Mapping, Sequence
+
+import time
 
 import pandas as pd
 
@@ -108,3 +111,72 @@ class HistoricalLiveOHLCProvider:
                 raise DataIntegrityError("Invalid timestamps after live candle merge")
 
         return cleaned
+
+
+class MarketDataSource:
+    """Read LTP/OHLC with WS-first, polling fallback hierarchy."""
+
+    def __init__(self, kite: Any, market_state: Any) -> None:
+        """Initialize source with kite + market state. Args: kite/market_state. Returns: none. Raises: none."""
+
+        self._kite = kite
+        self._state = market_state
+
+    def get_ltp_poll(self, tokens: Sequence[int]) -> dict[int, float]:
+        """Fetch LTP by polling API. Args: tokens. Returns: token->price. Raises: none."""
+
+        if not tokens:
+            return {}
+        query = [f'NFO:{int(token)}' for token in tokens]
+        try:
+            payload = self._kite.ltp(query)
+        except Exception as e:
+            raise DataIntegrityError(f'Polling LTP failed: {e}') from e
+        parsed: dict[int, float] = {}
+        for token in tokens:
+            key = f'NFO:{int(token)}'
+            entry = payload.get(key) if isinstance(payload, Mapping) else None
+            if not isinstance(entry, Mapping):
+                continue
+            ltp = entry.get('last_price')
+            if ltp is None:
+                continue
+            parsed[int(token)] = float(ltp)
+        return parsed
+
+    def get_ltp(self, tokens: Sequence[int], *, stale_after_seconds: int = 5) -> dict[int, float]:
+        """Get token LTPs using WS first and polling fallback. Args: tokens/stale_after_seconds. Returns: token->price. Raises: none."""
+
+        snapshot = self._state.get_snapshot()
+        now = time.time()
+        ws_fresh = snapshot.last_ws_update is not None and (now - snapshot.last_ws_update) <= float(stale_after_seconds)
+        resolved = {int(token): float(snapshot.option_ltps[int(token)]) for token in tokens if int(token) in snapshot.option_ltps}
+        if ws_fresh and len(resolved) == len(tokens):
+            return resolved
+        polled = self.get_ltp_poll(tokens)
+        for token, price in polled.items():
+            self._state.update_tick(token, price, source='poll')
+        merged = dict(resolved)
+        merged.update(polled)
+        return merged
+
+    def get_ohlc(self, token: int, interval: str, ttl: int = 60) -> list[dict[str, Any]]:
+        """Get token OHLC with TTL cache. Args: token/interval/ttl. Returns: rows. Raises: DataIntegrityError."""
+
+        cached = self._state.get_ohlc_cache(token, interval, ttl=ttl)
+        if cached is not None:
+            return cached
+        try:
+            rows = self._kite.historical_data(
+                int(token),
+                datetime.now(timezone.utc).replace(hour=3, minute=45, second=0, microsecond=0),
+                datetime.now(timezone.utc),
+                interval,
+            )
+        except Exception as e:
+            raise DataIntegrityError(f'OHLC fetch failed for token {token}: {e}') from e
+        if len(rows) < 30:
+            raise DataIntegrityError(f'Insufficient OHLC candles for token {token}: {len(rows)}')
+        normalized = [dict(row) for row in rows]
+        self._state.set_ohlc_cache(int(token), interval, normalized)
+        return normalized

--- a/src/nifty_scalper_bot/execution/order_executor.py
+++ b/src/nifty_scalper_bot/execution/order_executor.py
@@ -10,13 +10,11 @@ from nifty_scalper_bot.config.base import RiskConfig
 from nifty_scalper_bot.execution.entry_price import EntryPriceModel, Side
 from nifty_scalper_bot.execution.options_policy import OptionsExecutionPolicy
 from nifty_scalper_bot.utils.errors import BrokerError, OrderPlacementError
+from nifty_scalper_bot.utils.logging import get_logger
 
 
 class ExecutionError(OrderPlacementError):
     """Raised when broker execution fails hard."""
-
-
-from nifty_scalper_bot.utils.logging import get_logger
 
 
 class OrderExecutor:
@@ -186,6 +184,33 @@ class OrderExecutor:
         if ts_val is not None:
             ts_ns = int(ts_val)
         return bid, ask, ts_ns
+
+
+
+    def is_execution_ready(self, symbol: str | None = None) -> tuple[bool, str]:
+        """Validate broker, margin, and instrument readiness. Args: symbol. Returns: (ready, reason). Raises: none."""
+
+        try:
+            if self._broker is None:
+                return (False, 'broker_unavailable')
+            health_fn = getattr(self._broker, 'is_connected', None)
+            if callable(health_fn) and not bool(health_fn()):
+                return (False, 'broker_disconnected')
+            margin_fn = getattr(self._broker, 'available_margin', None)
+            if callable(margin_fn):
+                margin = float(margin_fn())
+                if margin <= 0:
+                    return (False, 'insufficient_margin')
+            if symbol:
+                resolver = getattr(self._mdm, 'resolver', None) if self._mdm is not None else None
+                if resolver is not None:
+                    lookup = getattr(resolver, 'lookup', None)
+                    if callable(lookup) and lookup(symbol) is None:
+                        return (False, 'invalid_instrument')
+            return (True, 'ready')
+        except Exception as e:
+            self._logger.exception('Failure in is_execution_ready: %s', e)
+            return (False, 'execution_readiness_error')
 
     def reconcile_open_orders(self) -> dict[str, Dict[str, object]]:
         """Refresh cached open-order metadata using client order identifiers.

--- a/src/nifty_scalper_bot/market_data_streamer.py
+++ b/src/nifty_scalper_bot/market_data_streamer.py
@@ -1,0 +1,88 @@
+"""WebSocket streamer adapter with MarketState synchronization."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+import time
+from typing import Any
+
+from nifty_scalper_bot.data.market_state import MarketState
+from nifty_scalper_bot.utils.logging import get_logger
+
+LOGGER = get_logger(__name__)
+
+
+class MarketDataStreamer:
+    """Manage WS callbacks and token subscriptions with deterministic state sync."""
+
+    def __init__(self, websocket: Any, market_state: MarketState) -> None:
+        """Initialize streamer. Args: websocket/market_state. Returns: none. Raises: none."""
+
+        self._ws = websocket
+        self._market_state = market_state
+        self._subscribed_tokens: set[int] = set()
+        self._last_heartbeat: float | None = None
+
+    @property
+    def last_heartbeat(self) -> float | None:
+        """Return last heartbeat timestamp. Args: none. Returns: ts|None. Raises: none."""
+
+        return self._last_heartbeat
+
+    def on_ticks(self, ticks: Sequence[dict[str, Any]]) -> None:
+        """Update market state from websocket ticks. Args: ticks. Returns: none. Raises: none."""
+
+        now = time.time()
+        self._last_heartbeat = now
+        for tick in ticks:
+            try:
+                token = int(tick.get("instrument_token"))
+                price = float(tick.get("last_price") or tick.get("ltp"))
+                if token == 256265:
+                    self._market_state.set_spot_ltp(price, source="ws")
+                self._market_state.update_tick(token, price, source="ws")
+            except Exception as e:
+                LOGGER.exception("Failure in MarketDataStreamer.on_ticks: %s", e)
+
+    def on_error(self, error: Exception) -> None:
+        """Handle websocket error. Args: error. Returns: none. Raises: none."""
+
+        LOGGER.exception("WebSocket error, reconnecting: %s", error)
+        self._attempt_reconnect()
+
+    def on_close(self) -> None:
+        """Handle websocket close. Args: none. Returns: none. Raises: none."""
+
+        LOGGER.warning("WebSocket closed, reconnecting")
+        self._attempt_reconnect()
+
+    def update_subscription(self, tokens: Sequence[int]) -> None:
+        """Synchronize websocket subscription set. Args: tokens. Returns: none. Raises: none."""
+
+        new_tokens = {int(token) for token in tokens}
+        old_tokens = set(self._subscribed_tokens)
+        if not new_tokens and not old_tokens:
+            return
+        remove_tokens = sorted(old_tokens - new_tokens)
+        add_tokens = sorted(new_tokens - old_tokens)
+        try:
+            if remove_tokens:
+                self._ws.unsubscribe(remove_tokens)
+            if add_tokens:
+                self._ws.subscribe(add_tokens)
+                mode_ltp = getattr(self._ws, "MODE_LTP", None)
+                if mode_ltp is not None:
+                    self._ws.set_mode(mode_ltp, add_tokens)
+            self._subscribed_tokens = new_tokens
+        except Exception as e:
+            LOGGER.exception("Failure in MarketDataStreamer.update_subscription: %s", e)
+
+    def _attempt_reconnect(self) -> None:
+        """Attempt websocket reconnect safely. Args: none. Returns: none. Raises: none."""
+
+        try:
+            reconnect = getattr(self._ws, "connect", None)
+            if callable(reconnect):
+                reconnect()
+        except Exception as e:
+            LOGGER.exception("Failure in MarketDataStreamer._attempt_reconnect: %s", e)

--- a/src/nifty_scalper_bot/options/instruments_cache.py
+++ b/src/nifty_scalper_bot/options/instruments_cache.py
@@ -1,0 +1,94 @@
+"""NFO instrument dump cache for deterministic option resolution."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from threading import RLock
+import time
+from typing import Any, Mapping
+
+from nifty_scalper_bot.utils.logging import get_logger
+
+LOGGER = get_logger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class OptionInstrument:
+    """Option instrument row. Args: broker row. Returns: option instrument. Raises: none."""
+
+    instrument_token: int
+    tradingsymbol: str
+    name: str
+    expiry: date
+    strike: float
+    option_type: str
+
+
+class InstrumentsCache:
+    """Daily-refresh in-memory cache for broker instruments."""
+
+    def __init__(self, kite: Any) -> None:
+        """Create cache for broker instruments. Args: kite. Returns: none. Raises: none."""
+
+        self._kite = kite
+        self._lock = RLock()
+        self._last_loaded_day: date | None = None
+        self._last_loaded_ts: float | None = None
+        self._nifty_options: list[OptionInstrument] = []
+
+    def get_nifty_options(self) -> list[OptionInstrument]:
+        """Return cached NIFTY options, refreshing daily. Args: none. Returns: list. Raises: Exception."""
+
+        today = date.today()
+        with self._lock:
+            if self._last_loaded_day == today and self._nifty_options:
+                return list(self._nifty_options)
+        rows = self._load_from_broker()
+        with self._lock:
+            self._nifty_options = rows
+            self._last_loaded_day = today
+            self._last_loaded_ts = time.time()
+            return list(self._nifty_options)
+
+    def _load_from_broker(self) -> list[OptionInstrument]:
+        """Load NFO instruments from broker. Args: none. Returns: list. Raises: Exception."""
+
+        try:
+            raw_rows = self._kite.instruments("NFO")
+        except Exception as e:
+            LOGGER.exception("Failure in InstrumentsCache._load_from_broker: %s", e)
+            raise
+        results: list[OptionInstrument] = []
+        for row in raw_rows:
+            if not isinstance(row, Mapping):
+                continue
+            name = str(row.get("name") or "").strip().upper()
+            if name != "NIFTY":
+                continue
+            instrument_type = str(row.get("instrument_type") or "").strip().upper()
+            if instrument_type not in {"CE", "PE"}:
+                continue
+            expiry_value = row.get("expiry")
+            if expiry_value is None:
+                continue
+            expiry = expiry_value if isinstance(expiry_value, date) else None
+            if expiry is None:
+                continue
+            try:
+                token = int(row.get("instrument_token"))
+                strike = float(row.get("strike"))
+            except (TypeError, ValueError):
+                continue
+            results.append(
+                OptionInstrument(
+                    instrument_token=token,
+                    tradingsymbol=str(row.get("tradingsymbol") or "").strip().upper(),
+                    name=name,
+                    expiry=expiry,
+                    strike=strike,
+                    option_type=instrument_type,
+                )
+            )
+        LOGGER.info("Loaded %d NIFTY option instruments", len(results))
+        return results

--- a/src/nifty_scalper_bot/options/resolver.py
+++ b/src/nifty_scalper_bot/options/resolver.py
@@ -1,0 +1,61 @@
+"""Deterministic token-based resolver for ATM NIFTY options."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from typing import Any
+
+from nifty_scalper_bot.options.instruments_cache import (
+    InstrumentsCache,
+    OptionInstrument,
+)
+from nifty_scalper_bot.utils.logging import get_logger
+
+LOGGER = get_logger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class AtmOptionPair:
+    """ATM call/put pair. Args: CE/PE. Returns: pair. Raises: none."""
+
+    ce: OptionInstrument
+    pe: OptionInstrument
+    expiry: date
+    strike: float
+
+
+class OptionResolver:
+    """Resolve ATM CE/PE options from cached broker dump."""
+
+    def __init__(self, kite: Any) -> None:
+        """Create resolver from kite client. Args: kite. Returns: none. Raises: none."""
+
+        self._cache = InstrumentsCache(kite)
+
+    def resolve_atm_pair(
+        self, spot: float, *, today: date | None = None
+    ) -> AtmOptionPair:
+        """Resolve ATM pair. Args: spot/today. Returns: pair. Raises: ValueError."""
+
+        if spot <= 0:
+            raise ValueError("spot must be positive")
+        options = self._cache.get_nifty_options()
+        if not options:
+            raise ValueError("No NIFTY options available from broker dump")
+        trade_day = today or date.today()
+        expiries = sorted({row.expiry for row in options if row.expiry >= trade_day})
+        if not expiries:
+            raise ValueError("No valid upcoming expiries for NIFTY options")
+        expiry = expiries[0]
+        atm = float(round(spot / 50.0) * 50)
+        filtered = [
+            row for row in options if row.expiry == expiry and row.strike == atm
+        ]
+        ce = next((row for row in filtered if row.option_type == "CE"), None)
+        pe = next((row for row in filtered if row.option_type == "PE"), None)
+        if ce is None or pe is None:
+            raise ValueError(
+                f"Missing exact ATM CE/PE for expiry={expiry.isoformat()} strike={atm:.0f}"
+            )
+        return AtmOptionPair(ce=ce, pe=pe, expiry=expiry, strike=atm)

--- a/src/nifty_scalper_bot/options/strike_selector.py
+++ b/src/nifty_scalper_bot/options/strike_selector.py
@@ -18,6 +18,7 @@ from typing import (
     cast,
 )
 
+from nifty_scalper_bot.options.resolver import OptionResolver
 from nifty_scalper_bot.utils.logging import get_logger
 
 if TYPE_CHECKING:  # pragma: no cover - import for type checking only
@@ -354,6 +355,7 @@ class StrikeSelector:
         self._active: MutableMapping[str, SelectedContract] = {}
         self._contract_cache = {}  # {symbol: (timestamp, contract_details)}
         self._cache_ttl_seconds = 1
+        self._deterministic_resolver: OptionResolver | None = None
 
     @property
     def settings(self) -> "SelectorSettings":
@@ -371,6 +373,46 @@ class StrikeSelector:
         )
         # Removed the cast() calls that triggered the NameError
         return mdm, resolver
+
+    def _get_broker_client(self) -> Any | None:
+        """Resolve broker client from data hub context. Args: none. Returns: broker|None. Raises: none."""
+
+        broker = getattr(self._data_hub, "broker", None)
+        if broker is not None:
+            return broker
+        mdm = getattr(self._data_hub, "market_data_manager", None) or getattr(
+            self._data_hub, "_mdm", None
+        )
+        return getattr(mdm, "broker", None) if mdm is not None else None
+
+    def _resolve_deterministic_contract(
+        self,
+        *,
+        option_type: str,
+        underlying_price: float,
+    ) -> SelectedContract | None:
+        """Resolve ATM contract from broker instrument dump. Args: option_type/underlying_price. Returns: contract|None. Raises: none."""
+
+        broker = self._get_broker_client()
+        if broker is None:
+            return None
+        if self._deterministic_resolver is None:
+            self._deterministic_resolver = OptionResolver(broker)
+        try:
+            pair = self._deterministic_resolver.resolve_atm_pair(underlying_price)
+        except Exception as e:
+            LOGGER.exception("Failure in deterministic option resolver: %s", e)
+            return None
+        instrument = pair.ce if option_type == "CE" else pair.pe
+        return SelectedContract(
+            symbol=f"NFO:{instrument.tradingsymbol}",
+            option_type=instrument.option_type,
+            strike=float(instrument.strike),
+            expiry=datetime.combine(instrument.expiry, datetime.min.time(), tzinfo=timezone.utc),
+            ltp=0.0,
+            delta=None,
+            metadata={"instrument_token": int(instrument.instrument_token)},
+        )
 
     def select_contract(
         self,
@@ -432,6 +474,13 @@ class StrikeSelector:
         if requested_option_type is None:
             LOGGER.info("Condition met: selector_missing_option_type")
             return None
+
+        deterministic = self._resolve_deterministic_contract(
+            option_type=requested_option_type,
+            underlying_price=underlying_price,
+        )
+        if deterministic is not None:
+            return deterministic
 
         # --- TRACE 1: FETCH CHAIN ---
         LOGGER.info(f"🟡 Fetching option chain for {normalized}...")

--- a/tests/data/test_market_state_source.py
+++ b/tests/data/test_market_state_source.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from nifty_scalper_bot.data.market_state import MarketState
+from nifty_scalper_bot.data.source import DataIntegrityError, MarketDataSource
+
+
+class _StubKite:
+    def __init__(self) -> None:
+        self.ltp_payload = {"NFO:101": {"last_price": 100.5}}
+        self.rows = [
+            {
+                "date": datetime.now(timezone.utc).isoformat(),
+                "open": 1,
+                "high": 2,
+                "low": 1,
+                "close": 2,
+            }
+            for _ in range(35)
+        ]
+
+    def ltp(self, symbols: list[str]) -> dict[str, dict[str, float]]:
+        return {key: self.ltp_payload.get(key, {}) for key in symbols}
+
+    def historical_data(
+        self,
+        token: int,
+        start: datetime,
+        end: datetime,
+        interval: str,
+    ) -> list[dict[str, object]]:
+        return list(self.rows)
+
+
+def test_market_state_snapshot() -> None:
+    state = MarketState()
+    state.set_spot_ltp(24001.0)
+    state.update_tick(101, 123.4)
+    snap = state.get_snapshot()
+    assert snap.spot_ltp == 24001.0
+    assert snap.option_ltps[101] == 123.4
+
+
+def test_source_falls_back_to_poll_when_ws_stale() -> None:
+    state = MarketState()
+    kite = _StubKite()
+    source = MarketDataSource(kite, state)
+    prices = source.get_ltp([101], stale_after_seconds=0)
+    assert prices[101] == pytest.approx(100.5)
+    assert state.get_snapshot().option_ltps[101] == pytest.approx(100.5)
+
+
+def test_get_ohlc_validates_minimum_rows() -> None:
+    state = MarketState()
+    kite = _StubKite()
+    kite.rows = kite.rows[:5]
+    source = MarketDataSource(kite, state)
+    with pytest.raises(DataIntegrityError):
+        source.get_ohlc(101, "minute")

--- a/tests/execution/test_order_executor_readiness.py
+++ b/tests/execution/test_order_executor_readiness.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from nifty_scalper_bot.config.base import RiskConfig
+from nifty_scalper_bot.execution.order_executor import OrderExecutor
+
+
+class _Broker:
+    def __init__(self, *, connected: bool = True, margin: float = 10_000.0) -> None:
+        self._connected = connected
+        self._margin = margin
+
+    def is_connected(self) -> bool:
+        return self._connected
+
+    def available_margin(self) -> float:
+        return self._margin
+
+
+def test_is_execution_ready_reports_disconnected_broker() -> None:
+    executor = OrderExecutor(_Broker(connected=False), RiskConfig(), SimpleNamespace())
+    ready, reason = executor.is_execution_ready("NFO:NIFTY24APR25000CE")
+    assert ready is False
+    assert reason == "broker_disconnected"
+
+
+def test_is_execution_ready_reports_invalid_symbol() -> None:
+    resolver = SimpleNamespace(lookup=lambda _: None)
+    mdm = SimpleNamespace(resolver=resolver)
+    executor = OrderExecutor(_Broker(), RiskConfig(), mdm)
+    ready, reason = executor.is_execution_ready("NFO:NIFTY24APR25000CE")
+    assert ready is False
+    assert reason == "invalid_instrument"


### PR DESCRIPTION
### Motivation
- Fix WebSocket/polling integration, stale or missing LTPs, and option token/symbol mismatch by centralizing market prices and OHLC into a single in-memory authority. 
- Remove fragile multi-layer symbol inference and expiry guesswork so ATM option selection is deterministic and token‑accurate. 
- Improve observability and fault tolerance in the streamer and execution readiness checks to prevent silent failures and pipeline crashes.

### Description
- Introduced a thread-safe single source of truth `MarketState` with `update_tick(token, price)` and `get_snapshot()` to store `spot_ltp`, `option_ltps`, WS/poll timestamps and a token+interval OHLC TTL cache (`src/.../data/market_state.py`).
- Added `MarketDataStreamer` that updates `MarketState` on WS ticks, tracks heartbeat, handles reconnects and exposes `update_subscription(tokens)` to safely sync subscriptions and avoid duplicates (`src/.../market_data_streamer.py`).
- Implemented `MarketDataSource` (WS-first / polling fallback) with `get_ltp_poll(tokens)`, `get_ltp(tokens, stale_after_seconds=5)` and token-based `get_ohlc(token, interval, ttl=60)` with TTL cache and minimum-candle validation (`src/.../data/source.py`).
- Added deterministic NIFTY option instrument cache and resolver using broker dump (`kite.instruments('NFO')`): `InstrumentsCache` and `OptionResolver.resolve_atm_pair()` select nearest expiry ≥ today and exact ATM strike (50pt rounding) and return instrument tokens only (`src/.../options/instruments_cache.py`, `src/.../options/resolver.py`).
- Integrated deterministic resolver into existing `StrikeSelector` as the primary fast-path while preserving existing chain-based fallback and public signatures (`src/.../options/strike_selector.py`).
- Added `OrderExecutor.is_execution_ready()` returning `(bool, reason)` that validates broker connectivity, margin availability and instrument validity for safer execution gating (`src/.../execution/order_executor.py`).
- Added unit tests covering MarketState/polling fallback and execution readiness checks (`tests/data/test_market_state_source.py`, `tests/execution/test_order_executor_readiness.py`).

### Testing
- Ran targeted unit tests: `pytest -q tests/data/test_market_state_source.py tests/execution/test_order_executor_readiness.py tests/options/test_strike_selector.py --disable-warnings` — all passed. ✅
- Ran `./run_checks.sh` (attempted via `bash ./run_checks.sh` after permission issue); the script executed but reported repository‑wide `ruff`/`mypy` findings and a `pytest` argv mismatch related to coverage args in the environment; these are pre-existing, not introduced by this change. ⚠️
- Performed local formatting/linting on touched files (`black`, `ruff --check`) and ran `mypy` against the modified files; style fixes were applied where safe, and type checks surfaced broader, unrelated repo issues (not regressions from this PR). ⚠️

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d71c4ca51883248e54cf7c82a08fa6)