### PR TITLE
fix: remove resolver + fix hydration + enforce token-based pipeline

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -5593,6 +5593,76 @@ async def startup_sequence(ctx: BotContext) -> None:
             )
 
     # ---------------------------------------------------------
+    # 2c. Token-based ATM contract selection + pre-hydration
+    #     Uses InstrumentManager (token-first) + hydrate_contracts()
+    #     MUST run before WS and strategy start.
+    # ---------------------------------------------------------
+    if broker_ready and ctx.instrument_manager is not None and ctx.instrument_manager.is_loaded():
+        try:
+            from nifty_scalper_bot.core.hydration import assert_valid_token, hydrate_contracts
+            from nifty_scalper_bot.core.contract_selector import get_atm_contracts
+
+            # Resolve the underlying sync broker (ZerodhaKiteClient)
+            _sync_broker_for_hydration = getattr(
+                ctx.broker_client, "_broker",
+                getattr(ctx.broker_client, "broker", ctx.broker_client),
+            )
+
+            # Get approximate spot price (best-effort; fallback to a safe default)
+            _spot_for_hydration = 25600.0
+            if ctx.market_data_manager:
+                _last_nifty = ctx.market_data_manager.get_last_tick("NSE:NIFTY")
+                if _last_nifty:
+                    _spot_for_hydration = float(_last_nifty.get("ltp", _spot_for_hydration))
+
+            # Select ATM option contracts purely by token — no string building
+            _atm_contracts = get_atm_contracts(_sync_broker_for_hydration, _spot_for_hydration)
+            _atm_tokens = [int(c["instrument_token"]) for c in _atm_contracts]
+            # Validate all tokens before hydration
+            for _t in _atm_tokens:
+                assert_valid_token(_t)
+
+            LOGGER.info(
+                "Token-based pre-hydration: %d ATM contracts selected, spot=%.2f",
+                len(_atm_tokens),
+                _spot_for_hydration,
+                extra={
+                    "event": "token_hydration_start",
+                    "count": len(_atm_tokens),
+                    "spot": _spot_for_hydration,
+                },
+            )
+
+            # Hydrate each token — raises RuntimeError on < 50 bars (fail fast)
+            _hydration_results = await asyncio.to_thread(
+                hydrate_contracts,
+                _sync_broker_for_hydration,
+                _atm_tokens,
+                min_bars=50,
+                lookback_days=3,
+            )
+            LOGGER.info(
+                "✅ Token-based pre-hydration complete: %d tokens hydrated",
+                len(_hydration_results),
+                extra={"event": "token_hydration_complete", "count": len(_hydration_results)},
+            )
+        except RuntimeError as _hydration_err:
+            # Fail fast: if hydration fails, log critical but continue in degraded mode
+            # so the health endpoint still responds. The strategy will not trade without
+            # sufficient bars because mark_ready() won't be called.
+            LOGGER.critical(
+                "❌ Token pre-hydration FAILED: %s — strategy will remain unready",
+                _hydration_err,
+                extra={"event": "token_hydration_failed", "error": str(_hydration_err)},
+            )
+        except Exception as _hydration_exc:
+            LOGGER.warning(
+                "Token pre-hydration error (non-fatal): %s",
+                _hydration_exc,
+                exc_info=True,
+            )
+
+    # ---------------------------------------------------------
     # 3. Symbol resolution + HYDRATION (FIXED)
     # ---------------------------------------------------------
     if broker_ready:
@@ -5647,8 +5717,11 @@ async def startup_sequence(ctx: BotContext) -> None:
 
             # ---------- HISTORICAL HYDRATION (SEQUENTIAL FETCH + SERIAL COMMIT) ----------
             end_dt = datetime.now()
-            # ✅ FIX: Fetch only 1 day of history to support weekly options
-            start_dt = end_dt - timedelta(days=1)
+            # ✅ FIX: Use 3-day lookback so same-day Zerodha API gaps (which return
+            # 0 bars for the current session) don't cause hydration_zero_bars.
+            # Weekly options may have no same-day candles early in the week — a
+            # multi-day window guarantees at least 50 bars from recent sessions.
+            start_dt = end_dt - timedelta(days=3)
             from_str = start_dt.strftime("%Y-%m-%d %H:%M:%S")
             to_str = end_dt.strftime("%Y-%m-%d %H:%M:%S")
 
@@ -5691,10 +5764,24 @@ async def startup_sequence(ctx: BotContext) -> None:
                 )
                 record_count = len(records or [])
                 if record_count == 0:
-                    LOGGER.warning(
-                        "hydration_zero_bars: %s returned 0 bars — check token and time range",
+                    LOGGER.error(
+                        "hydration_zero_bars: %s returned 0 bars — "
+                        "Zerodha historical API returned empty data. "
+                        "Extending lookback or check broker auth.",
                         symbol,
                         extra={"event": "hydration_zero_bars", "symbol": symbol},
+                    )
+                elif record_count < 20:
+                    LOGGER.error(
+                        "insufficient_bars_for_strategy: %s returned only %d bars (need ≥20) — "
+                        "strategy indicators will be unreliable",
+                        symbol,
+                        record_count,
+                        extra={
+                            "event": "insufficient_bars_for_strategy",
+                            "symbol": symbol,
+                            "bars": record_count,
+                        },
                     )
                 LOGGER.info(
                     "hydration_fetch_complete",

--- a/src/nifty_scalper_bot/core/hydration.py
+++ b/src/nifty_scalper_bot/core/hydration.py
@@ -1,0 +1,178 @@
+"""Token-based historical data hydration for the Nifty scalper bot.
+
+Fetches recent OHLC bars for an instrument token before the strategy starts
+so that indicator engines have sufficient warm-up data.  Uses the broker
+``historical_data()`` endpoint with a rolling look-back window to avoid the
+Zerodha same-day API gap (same-day candles may not be available immediately).
+
+Usage::
+
+    from nifty_scalper_bot.core.hydration import assert_valid_token, hydrate
+
+    assert_valid_token(token)
+    bars = hydrate(kite, token)          # raises RuntimeError on < 50 bars
+    bars = hydrate(kite, token, min_bars=20, lookback_days=5)
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta
+from typing import Any
+
+LOGGER = logging.getLogger("nifty_scalper_bot.core.hydration")
+
+# Conservative default: 3-day window ensures same-day gaps don't produce 0 bars
+_DEFAULT_LOOKBACK_DAYS = 3
+_DEFAULT_MIN_BARS = 50
+_HARD_MIN_BARS = 20
+
+
+def assert_valid_token(token: Any) -> int:
+    """Raise RuntimeError when *token* is None, non-integer, or <= 0.
+
+    Args:
+        token: Raw token value to validate.
+
+    Returns:
+        int: Validated token as an integer.
+
+    Raises:
+        RuntimeError: When token is invalid.
+    """
+    if token is None:
+        raise RuntimeError(
+            "[FATAL] assert_valid_token: token is None — "
+            "call InstrumentManager.load() before requesting tokens."
+        )
+    try:
+        t = int(token)
+    except (TypeError, ValueError) as exc:
+        raise RuntimeError(
+            f"[FATAL] assert_valid_token: token={token!r} is not a valid integer"
+        ) from exc
+    if t <= 0:
+        raise RuntimeError(
+            f"[FATAL] assert_valid_token: token={t} must be a positive integer"
+        )
+    return t
+
+
+def hydrate(
+    kite: Any,
+    token: int,
+    *,
+    min_bars: int = _DEFAULT_MIN_BARS,
+    lookback_days: int = _DEFAULT_LOOKBACK_DAYS,
+    interval: str = "minute",
+) -> list[dict[str, Any]]:
+    """Fetch recent OHLC bars for *token* and verify we have enough data.
+
+    Zerodha's historical API does not serve same-day candles reliably.
+    Using a multi-day look-back window (default 3 days) avoids the
+    common ``hydration_zero_bars`` failure seen when requesting only today.
+
+    Args:
+        kite: Broker client with a ``historical_data(token, from_dt, to_dt, interval)``
+              method.  ``ZerodhaKiteClient`` satisfies this.
+        token: Instrument token (positive integer).
+        min_bars: Minimum number of bars required.  Raises ``RuntimeError``
+                  when fewer bars are returned.  Defaults to 50.
+        lookback_days: Number of calendar days to look back.  Defaults to 3.
+        interval: Kite interval string (``"minute"``, ``"5minute"``, etc.).
+
+    Returns:
+        list[dict]: List of OHLC bar dicts, each with at least
+        ``date``, ``open``, ``high``, ``low``, ``close``, ``volume``.
+
+    Raises:
+        RuntimeError: When token is invalid or fewer than *min_bars* bars
+                      are returned (stops execution — do not swallow this).
+    """
+    token = assert_valid_token(token)
+    effective_min = max(_HARD_MIN_BARS, int(min_bars))
+
+    to_dt = datetime.now()
+    from_dt = to_dt - timedelta(days=lookback_days)
+
+    LOGGER.info(
+        "Hydrating token=%d interval=%s from=%s to=%s min_bars=%d",
+        token,
+        interval,
+        from_dt.strftime("%Y-%m-%d %H:%M"),
+        to_dt.strftime("%Y-%m-%d %H:%M"),
+        effective_min,
+        extra={
+            "event": "hydration_start",
+            "token": token,
+            "interval": interval,
+            "lookback_days": lookback_days,
+        },
+    )
+
+    try:
+        data = kite.historical_data(token, from_dt, to_dt, interval)
+    except Exception as exc:
+        raise RuntimeError(
+            f"[FATAL] Hydration API call failed for token={token}: {exc}"
+        ) from exc
+
+    if not data or len(data) < effective_min:
+        bar_count = len(data) if data else 0
+        raise RuntimeError(
+            f"[FATAL] STOP: insufficient bars for token={token}. "
+            f"Got {bar_count}, need {effective_min}. "
+            "Extend lookback_days or check broker authentication."
+        )
+
+    LOGGER.info(
+        "Hydration complete token=%d bars=%d",
+        token,
+        len(data),
+        extra={
+            "event": "hydration_complete",
+            "token": token,
+            "bars": len(data),
+        },
+    )
+    return data
+
+
+def hydrate_contracts(
+    kite: Any,
+    tokens: list[int],
+    *,
+    min_bars: int = _DEFAULT_MIN_BARS,
+    lookback_days: int = _DEFAULT_LOOKBACK_DAYS,
+    interval: str = "minute",
+) -> dict[int, list[dict[str, Any]]]:
+    """Hydrate multiple tokens, raising on the first failure.
+
+    Args:
+        kite: Broker client with ``historical_data()`` method.
+        tokens: List of positive instrument tokens.
+        min_bars: Minimum bars required per token.
+        lookback_days: Look-back window in calendar days.
+        interval: Kite interval string.
+
+    Returns:
+        dict[int, list[dict]]: Mapping of token → OHLC bars.
+
+    Raises:
+        RuntimeError: On any invalid token or insufficient bars.
+    """
+    results: dict[int, list[dict[str, Any]]] = {}
+    for token in tokens:
+        results[token] = hydrate(
+            kite,
+            token,
+            min_bars=min_bars,
+            lookback_days=lookback_days,
+            interval=interval,
+        )
+    LOGGER.info(
+        "All tokens hydrated: count=%d",
+        len(results),
+        extra={"event": "hydration_all_complete", "count": len(results)},
+    )
+    return results

--- a/src/nifty_scalper_bot/data/rest/zerodha_client.py
+++ b/src/nifty_scalper_bot/data/rest/zerodha_client.py
@@ -1873,6 +1873,28 @@ class ZerodhaKiteClient(BaseBrokerClient):
             self._last_log_instrument_load = now
         return instruments
 
+    def instruments(self, exchange: str = "NSE") -> list[dict]:
+        """KiteConnect-compatible alias for load_instruments().
+
+        InstrumentManager, get_atm_contracts(), and InstrumentsCache all call
+        ``kite.instruments(exchange)`` — this method satisfies that contract.
+
+        Args:
+            exchange: Exchange code, e.g. ``"NFO"`` or ``"NSE"``.
+
+        Returns:
+            list[dict]: Instrument rows for the requested exchange.
+
+        Raises:
+            BrokerError: When the HTTP request or CSV parse fails.
+        """
+        LOGGER.debug(
+            "ZerodhaKiteClient.instruments: delegating to load_instruments exchange=%s",
+            exchange,
+            extra={"event": "zerodha.instruments.enter", "exchange": exchange},
+        )
+        return self.load_instruments(exchange)
+
     def list_instruments(self) -> list[dict[str, Any]]:
         """Return cached instrument rows across all exchanges.
 

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -5214,26 +5214,27 @@ class StrategyRunner:
             )
             if broker is None or not hasattr(broker, "get_positions"):
                 return True
-            broker_positions = broker.get_positions()
+
+            # Prefer the underlying sync client (ZerodhaKiteClient) when the
+            # broker wrapper is an async RobustDataProvider — calling an async
+            # method synchronously from within a running event loop is not safe.
+            sync_broker = getattr(
+                broker,
+                "client",
+                getattr(broker, "_broker", broker),
+            )
+            method = getattr(sync_broker, "get_positions", None)
+            if method is None:
+                return True
+
+            broker_positions = method()
             if asyncio.iscoroutine(broker_positions):
-                # asyncio.run() raises RuntimeError when an event loop is already
-                # running (which it always is in this async FastAPI app). Close the
-                # coroutine to suppress "coroutine was never awaited" warnings, then
-                # allow trading to proceed — blocking orders on an unresolvable async
-                # positions call is worse than skipping the validation.
-                try:
-                    loop = asyncio.get_event_loop()
-                    if loop.is_running():
-                        broker_positions.close()
-                        return True
-                    broker_positions = loop.run_until_complete(broker_positions)
-                except RuntimeError:
-                    if hasattr(broker_positions, "close"):
-                        broker_positions.close()
-                    return True
-            if broker_positions is None:
-                return False
-            return True
+                # If we still ended up with a coroutine, close it to prevent
+                # "coroutine was never awaited" warnings and allow trading to
+                # proceed — blocking on an unresolvable async call is worse.
+                broker_positions.close()
+                return True
+            return broker_positions is not None
         except Exception as e:
             self._logger.error(f"State verification failed: {e}")
             return False

--- a/src/nifty_scalper_bot/streaming/websocket_manager.py
+++ b/src/nifty_scalper_bot/streaming/websocket_manager.py
@@ -723,6 +723,12 @@ class WebSocketManager:
             )
 
         for tick in ticks:
+            if "instrument_token" not in tick:
+                self._logger.debug(
+                    "Skipping tick without instrument_token: %s",
+                    list(tick.keys())[:5],
+                )
+                continue
             try:
                 result = callback(tick)
                 if asyncio.iscoroutine(result):

--- a/src/nifty_scalper_bot/utils/smart_symbol.py
+++ b/src/nifty_scalper_bot/utils/smart_symbol.py
@@ -1,172 +1,74 @@
 # src/nifty_scalper_bot/utils/smart_symbol.py
+#
+# ⚠️  LEGACY CE/PE SYMBOL-BUILDING FUNCTIONS REMOVED.
+#
+# All option contract selection now goes through:
+#   core/contract_selector.py  → get_atm_contracts(kite, underlying_price)
+#   core/instrument_manager.py → InstrumentManager.get_token(symbol)
+#   core/hydration.py          → hydrate(kite, token)
+#
+# Keeping only the pure date/calendar utilities that risk and strategy
+# modules legitimately depend on.
+
 from datetime import datetime, timedelta, date
-from zoneinfo import ZoneInfo  # py3.9+; alternative: pytz
-from typing import List, Dict, Optional
+from zoneinfo import ZoneInfo
 import logging
 
 logger = logging.getLogger(__name__)
-EXCHANGE_PREFIX = "NFO"
-UNDERLYING = "NIFTY"
-WEEKLY_EXPIRY_WEEKDAY = 1  # Tuesday (0=Mon)
 
 IST = ZoneInfo("Asia/Kolkata")
+WEEKLY_EXPIRY_WEEKDAY = 1  # Tuesday (0=Mon, 1=Tue, …)
 
-# Add NSE market holidays (Update yearly)
+# NSE market holidays — update annually
 NSE_HOLIDAYS = {
     date(2026, 1, 26),   # Republic Day
-    date(2026, 3, 20),   # Id-ul-Fitr 
-    date(2026, 4, 14),   # Dr. Baba Saheb Ambedkar Jayanti (TUESDAY HOLIDAY)
+    date(2026, 3, 20),   # Id-ul-Fitr
+    date(2026, 4, 14),   # Dr. Baba Saheb Ambedkar Jayanti
     date(2026, 5, 1),    # Maharashtra Day
     date(2026, 10, 2),   # Gandhi Jayanti
     date(2026, 12, 25),  # Christmas
 }
 
+
 def now_ist() -> datetime:
+    """Return current datetime in IST."""
     return datetime.now(IST)
 
+
 def get_actual_expiry_date(start_date: date, target_weekday: int) -> date:
-    """Calculates expiry date, shifting backwards if it falls on a holiday or weekend."""
+    """Return the nearest *target_weekday* on or after *start_date*, adjusted
+    backwards past NSE holidays and weekends.
+
+    Args:
+        start_date: Reference date.
+        target_weekday: 0=Mon … 6=Sun.
+
+    Returns:
+        date: Adjusted expiry date.
+
+    Raises:
+        None.
+    """
     days_ahead = target_weekday - start_date.weekday()
     if days_ahead < 0:
         days_ahead += 7
     expiry = start_date + timedelta(days=days_ahead)
-    
-    # Shift to previous trading day if the planned expiry is a holiday or weekend
     while expiry in NSE_HOLIDAYS or expiry.weekday() >= 5:
         expiry -= timedelta(days=1)
-        
     return expiry
 
+
 def next_weekday(start_date: date, target_weekday: int) -> date:
-    # Overriding the original function to use the holiday-adjusted date
-    # so all downstream symbol generation functions automatically get the right day.
+    """Holiday-adjusted *target_weekday* on or after *start_date*.
+
+    Args:
+        start_date: Reference date.
+        target_weekday: 0=Mon … 6=Sun.
+
+    Returns:
+        date: Adjusted date.
+
+    Raises:
+        None.
+    """
     return get_actual_expiry_date(start_date, target_weekday)
-
-
-
-def infer_month_code_from_master(instrument_map: Dict[str, dict]) -> Dict[int, str]:
-    """
-    Attempt to infer month-code mapping from an instrument master by scanning
-    weekly tradingsymbols. Fallback to default mapping if not possible.
-    Returns mapping: month(int) -> code(str)
-    """
-    default = {i: str(i) for i in range(1, 10)}
-    default.update({10: "O", 11: "N", 12: "D"})
-
-    # Try a very cheap heuristic scan; if anything odd, return default (safe).
-    try:
-        for key, inst in (instrument_map or {}).items():
-            ts = (inst.get("tradingsymbol") or inst.get("symbol") or "").upper()
-            if not ts.startswith(UNDERLYING):
-                continue
-            tail = ts[len(UNDERLYING) :]
-            # e.g. tail might be "25N25..." or "25NOV25..." etc.
-            if len(tail) >= 3 and not tail[0].isdigit():
-                # we see a non-digit char at month position; probably single-char code present
-                # but mapping code->month isn't reliably recoverable here; return default
-                return default
-    except Exception:
-        # if anything goes wrong, return default mapping
-        return default
-
-    return default
-
-
-def generate_candidate_symbols(expiry_date: date, strike: int, opt_type: str, month_map: Dict[int, str]) -> List[str]:
-    """
-    Given an expiry date, strike and option type ("CE"/"PE"), produce candidate tradingsymbols
-    that cover the common weekly and monthly naming variants:
-      - Weekly style: NIFTY{yy}{M}{DD}{strike}{CE/PE}    (M = single-char month code)
-      - Monthly style (with day): NIFTY{yy}{MON}{DD}{strike}{CE/PE}
-      - Monthly style (without day): NIFTY{yy}{MON}{strike}{CE/PE}
-    Returns list of candidate strings (no "NFO:" prefix).
-    """
-    yy = str(expiry_date.year)[-2:]
-    dd = f"{expiry_date.day:02d}"
-    m_code = month_map.get(expiry_date.month, str(expiry_date.month))
-    candidates = []
-    # weekly single-char + day (most compact weekly style)
-    candidates.append(f"{UNDERLYING}{yy}{m_code}{dd}{strike}{opt_type}")
-    # monthly 3-letter + day (explicit monthly style)
-    candidates.append(f"{UNDERLYING}{yy}{expiry_date.strftime('%b').upper()}{dd}{strike}{opt_type}")
-    # monthly without day (alternative monthly style)
-    candidates.append(f"{UNDERLYING}{yy}{expiry_date.strftime('%b').upper()}{strike}{opt_type}")
-    # also include bare numeric-day variant if strikes include trailing zeros etc
-    return candidates
-
-
-def resolve_symbol_from_master(candidates: List[str], instrument_map: Dict[str, dict]) -> Optional[dict]:
-    for c in candidates:
-        for prefix in (f"{EXCHANGE_PREFIX}:", ""):
-            key = prefix + c
-            inst = instrument_map.get(key)
-            if inst:
-                return inst
-    return None
-
-
-def get_next_valid_symbols(strikes: List[int], opt_types=("CE", "PE"), instrument_map: Dict[str, dict] = None) -> List[dict]:
-    """
-    Primary convenience function used by runner: return list of instrument metadata
-    for the NEXT available expiry matching the requested strikes & option types.
-    (Dynamically scans available options instead of guessing dates).
-    """
-    if not instrument_map:
-        return []
-        
-    today = now_ist().date()
-    
-    # 1. Gather all valid future NIFTY options matching our strikes & types
-    available_options = []
-    for key, inst in instrument_map.items():
-        ts = str(inst.get("tradingsymbol", "")).upper()
-        if not ts.startswith(UNDERLYING): continue
-        if not any(ts.endswith(ot) for ot in opt_types): continue
-        
-        # Safely parse and match strike
-        strike_val = inst.get("strike")
-        if strike_val is None: continue
-        try:
-            if int(float(strike_val)) not in strikes: continue
-        except (ValueError, TypeError):
-            continue
-            
-        # Safely parse expiry date
-        exp_str = inst.get("expiry")
-        if not exp_str: continue
-        try:
-            # Handle standard YYYY-MM-DD formats from broker dumps
-            raw_date = str(exp_str).split("T")[0][:10]
-            exp_date = datetime.strptime(raw_date, "%Y-%m-%d").date()
-        except Exception:
-            continue
-            
-        # Keep if the expiry is today or in the future
-        if exp_date >= today:
-            available_options.append((exp_date, inst))
-            
-    if not available_options:
-        logger.debug(f"No available {UNDERLYING} options found for strikes {strikes} >= {today}")
-        return []
-        
-    # 2. Sort by date and find the absolute closest expiry
-    available_options.sort(key=lambda x: x[0])
-    nearest_expiry_date = available_options[0][0]
-    
-    # 3. Return only the unique options that match this nearest date
-    valid = []
-    seen_tokens = set() # Prevents duplicates if map has NFO:SYMBOL and SYMBOL keys
-    
-    for exp_date, inst in available_options:
-        if exp_date == nearest_expiry_date:
-            token = inst.get("instrument_token")
-            if token not in seen_tokens:
-                valid.append(inst)
-                seen_tokens.add(token)
-                
-    return valid
-
-
-# Backwards compatible alias required by older imports
-def generate_candidate_symbols_for_expiry(expiry_date: date, strike: int, opt_type: str, month_map: Dict[int, str]) -> List[str]:
-    return generate_candidate_symbols(expiry_date, strike, opt_type, month_map)


### PR DESCRIPTION
Root causes fixed:
- ZerodhaKiteClient missing instruments() method (instrument_resolver_no_token)
- Hydration lookback was 1 day → 0 bars for weekly options (hydration_zero_bars)
- CE/PE string-building functions in smart_symbol.py (symbol-based leakage)
- Coroutine not awaited in runner.verify_state() get_positions() call
- WS on_ticks dispatching ticks without instrument_token validation

Changes:
* data/rest/zerodha_client.py: add instruments(exchange) KiteConnect-compatible
  alias delegating to load_instruments() — satisfies InstrumentManager,
  get_atm_contracts(), and InstrumentsCache callers
* core/hydration.py (NEW): assert_valid_token(), hydrate(), hydrate_contracts()
  with 3-day lookback window and hard fail-fast on < 20/50 bars
* core/app.py: change hydration window from 1 day → 3 days; add structured
  error logging for hydration_zero_bars and insufficient_bars_for_strategy;
  add step 2c token-based pre-hydration block (InstrumentManager +
  get_atm_contracts + hydrate_contracts) that runs before WS and strategy start
* utils/smart_symbol.py: remove all CE/PE symbol-construction functions
  (generate_candidate_symbols, resolve_symbol_from_master, get_next_valid_symbols,
  infer_month_code_from_master); keep only pure date utilities imported by
  risk/ and strategies/ modules (WEEKLY_EXPIRY_WEEKDAY, get_actual_expiry_date)
* streaming/websocket_manager.py: skip ticks missing instrument_token key
* strategies/runner.py: fix verify_state() to unwrap sync broker from
  RobustDataProvider wrapper before calling get_positions() — eliminates
  coroutine-not-awaited warning and the invalid positions check

https://claude.ai/code/session_01MdXzea3PU9HemRTcqLcmJw