### PR TITLE
fix: resolver async bugs — get_last_tick, hydration_complete gate, NFO instrument loading

### DIFF
--- a/src/nifty_scalper_bot/data/__init__.py
+++ b/src/nifty_scalper_bot/data/__init__.py
@@ -13,6 +13,9 @@ from nifty_scalper_bot.data.instrument_loader import (
     write_instrument_rows_to_csv,
 )
 from nifty_scalper_bot.data.instruments import (
+    # NOTE: InstrumentResolver is kept for backward-compatibility with the
+    # CSV/SQLite warm-up path in app.py and cron_refresh.py.
+    # New code should use core.instrument_manager.InstrumentManager.get_token().
     InstrumentResolver,
     ResolvedSymbol,
     SymbolResolver,

--- a/src/nifty_scalper_bot/data/instruments.py
+++ b/src/nifty_scalper_bot/data/instruments.py
@@ -3,7 +3,9 @@
 Instrument resolver and CSV/SQLite instrument loader.
 
 Provides:
-- InstrumentResolver: broker/CSV/DB-backed instrument token resolver.
+- Token-based instrument loader (resolver removed from public API).
+- InstrumentResolver: legacy broker/CSV/DB-backed resolver (deprecated — use
+  InstrumentManager.get_token() for new code).
 - ensure_sqlite: create/open a sqlite db for cached instruments.
 - refresh_from_csv: read instruments CSV and persist into sqlite.
 - load_rows_for_resolver: return rows (mapping) usable by resolver.warm_from_broker_dump.
@@ -14,6 +16,10 @@ Optimized / hardened version:
 - Dynamic lot_size resolution via get_lot_size(symbol_or_base).
 - Expiry parsing / weekly-monthly helpers (includes O/N/D month codes).
 - Negative cache TTL configurable via env.
+
+NOTE: Prefer core.instrument_manager.InstrumentManager.get_token(symbol) over
+InstrumentResolver.resolve() in new code.  InstrumentResolver is kept for
+backward-compatibility with the CSV/SQLite warm-up path.
 """
 from __future__ import annotations
 

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -180,6 +180,11 @@ class MarketDataManager:
         self._seeded_symbols: set[str] = set()
         self.ready: bool = False
         self.degraded: bool = False
+        # True once at least one symbol has successfully passed the readiness
+        # gate.  The DEGRADED mode transition in wait_until_ready() is only
+        # armed after hydration has completed at least once so that a cold
+        # startup that never receives data does not immediately enter DEGRADED.
+        self.hydration_complete: bool = False
         self._margin_cache_ttl = self._parse_float_env(
             "MDM_MARGIN_TTL_SEC", default=15.0, minimum=1.0
         )
@@ -275,21 +280,31 @@ class MarketDataManager:
         try:
             if self._broker is None or not hasattr(self._broker, "instruments"):
                 return
-            instruments = self._broker.instruments()
             loaded = 0
-            with self._lock:
-                for ins in instruments:
-                    try:
-                        token = int(ins["instrument_token"])
-                        symbol = str(ins["tradingsymbol"]).strip()
-                    except (KeyError, TypeError, ValueError):
-                        continue
-                    if not symbol:
-                        continue
-                    canonical_symbol = normalize_symbol(symbol)
-                    self.register_symbol(canonical_symbol, token)
-                    loaded += 1
-            self._logger.info(f"Loaded {loaded} instruments")
+            # Load NFO (derivatives) first, then NSE (index tokens like NIFTY 50).
+            # Previously the call had no exchange argument which defaulted to NSE,
+            # leaving all NFO futures/options tokens missing from the mapping.
+            for exchange in ("NFO", "NSE"):
+                try:
+                    exchange_instruments = self._broker.instruments(exchange)
+                except Exception as exc:
+                    self._logger.warning(
+                        "Could not load instruments for %s: %s", exchange, exc
+                    )
+                    continue
+                with self._lock:
+                    for ins in exchange_instruments:
+                        try:
+                            token = int(ins["instrument_token"])
+                            symbol = str(ins["tradingsymbol"]).strip()
+                        except (KeyError, TypeError, ValueError):
+                            continue
+                        if not symbol:
+                            continue
+                        canonical_symbol = normalize_symbol(symbol)
+                        self.register_symbol(canonical_symbol, token)
+                        loaded += 1
+            self._logger.info(f"Loaded {loaded} instruments (NFO + NSE)")
         except Exception as e:
             self._logger.error(f"Instrument load failed: {e}")
             raise
@@ -458,7 +473,7 @@ class MarketDataManager:
             # CRITICAL FALLBACK: If resolver returns nothing, query broker for active NFO instruments
             if not option_contracts and hasattr(self._broker, "instruments"):
                 self._logger.info(f"Resolver failed. Fetching NIFTY chain directly from broker for {expiry}")
-                all_nfo = self._broker.instruments()
+                all_nfo = self._broker.instruments("NFO")
                 option_contracts = [
                     ins for ins in all_nfo 
                     if ins["name"] == normalized_underlying 
@@ -994,6 +1009,23 @@ class MarketDataManager:
         with self._lock:
             tick = self._tick_cache.get(resolved_symbol)
             return dict(tick) if tick is not None else None
+
+    def get_last_tick(self, symbol: str | int) -> dict[str, Any] | None:
+        """Return the most recent cached tick for *symbol*.
+
+        Alias for :meth:`get_latest_tick` — provided so callers that use the
+        ``get_last_tick`` convention work without modification.
+
+        Args:
+            symbol: Instrument identifier (symbol string or integer token).
+
+        Returns:
+            dict snapshot of the latest tick, or ``None`` if not yet received.
+
+        Raises:
+            None.
+        """
+        return self.get_latest_tick(symbol)
 
     async def ensure_fresh_tick(self, symbol: str) -> dict[str, Any] | None:
         """Args: symbol; Returns: cached tick; Raises: none."""
@@ -2167,6 +2199,7 @@ class MarketDataManager:
             if valid_symbols:
                 self.ready = True
                 self.degraded = False
+                self.hydration_complete = True
                 self._logger.info(
                     "Condition met: mdm_ready",
                     extra={"event": "mdm_ready", "symbols": valid_symbols},
@@ -2185,13 +2218,21 @@ class MarketDataManager:
 
         self._logger.warning(
             "Entering DEGRADED mode due to insufficient live data "
-            "(timeout=%.1fs, min_bars=%d, bars=%s)",
+            "(timeout=%.1fs, min_bars=%d, bars=%s, hydration_complete=%s)",
             timeout,
             min_bars,
             bars,
+            self.hydration_complete,
         )
-        self.ready = False
-        self.degraded = True
+        # Only arm DEGRADED once hydration has completed at least once.
+        # On a cold start that never received ticks we stay not-ready without
+        # falsely declaring the system degraded.
+        if self.hydration_complete:
+            self.ready = False
+            self.degraded = True
+        else:
+            self.ready = False
+            self.degraded = False
         return
 
     def get_hydration_status(self, symbol: str) -> str:
@@ -4120,7 +4161,12 @@ class MarketDataManager:
         try:
             # We strip exchange prefixes if present for the search
             clean_symbol = symbol.split(":")[-1]
-            instruments = self._broker.instruments()
+            # Route to the correct exchange: derivatives end in FUT/CE/PE → NFO,
+            # everything else → NSE.  Previously the call had no exchange argument
+            # which defaulted to NSE, so all NFO instruments silently returned None.
+            _suffix = clean_symbol.upper()
+            _exchange = "NFO" if any(_suffix.endswith(s) for s in ("FUT", "CE", "PE")) else "NSE"
+            instruments = self._broker.instruments(_exchange)
             for ins in instruments:
                 if ins["tradingsymbol"] == clean_symbol:
                     t = int(ins["instrument_token"])

--- a/src/nifty_scalper_bot/data/rest/zerodha_client.py
+++ b/src/nifty_scalper_bot/data/rest/zerodha_client.py
@@ -175,6 +175,10 @@ class ZerodhaKiteClient(BaseBrokerClient):
 
         # instrument cache: exchange -> mapping of many normalized keys -> row
         self._instrument_cache: dict[str, dict[str, dict[str, Any]]] = {}
+        # token_map: instrument_token (int) -> instrument row dict, populated from
+        # NFO (and NSE) on each load_instruments("NFO") / load_instruments("NSE") call.
+        # Provides O(1) reverse lookup: token -> full instrument metadata.
+        self.token_map: dict[int, dict[str, Any]] = {}
         self._resolver: InstrumentResolver | None = None
         self._log_time_fn: Callable[[], float] = time.time
         self._resilience_lock = threading.RLock()
@@ -1858,6 +1862,16 @@ class ZerodhaKiteClient(BaseBrokerClient):
             cache[base] = row
 
         self._instrument_cache[normalized_exchange] = cache
+
+        # Rebuild token_map from all loaded exchanges so callers can do
+        # fast O(1) instrument_token -> row lookups without iterating lists.
+        for row in instruments:
+            try:
+                tok = int(row.get("instrument_token") or 0)
+            except (TypeError, ValueError):
+                continue
+            if tok:
+                self.token_map[tok] = row
 
         # [CORRECTED] Aligned correctly
         now = time.time()


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **FIX 7 — `get_last_tick()` missing from `MarketDataManager`**: `app.py` calls `ctx.market_data_manager.get_last_tick("NSE:NIFTY")` in two places; the method did not exist, causing `AttributeError` at runtime. Added as a thin alias for the existing `get_latest_tick()`.

- **FIX 9 — Premature DEGRADED on cold startup**: `wait_until_ready()` would set `degraded=True` on the very first boot if no ticks arrived within the timeout, even when hydration had never run. Added `self.hydration_complete` (default `False`) that flips to `True` the first time `ready=True, degraded=False` is reached. The DEGRADED transition is now guarded: a clean cold start that never receives data stays `ready=False, degraded=False` instead of falsely declaring DEGRADED.

- **FIX 10 — `broker.instruments()` missing exchange → NSE-only token map**:
  - `_initialize_instruments()` called `broker.instruments()` with no argument, defaulting to NSE and leaving all NFO futures/options tokens absent from the symbol→token mapping. Fixed to loop `NFO` then `NSE`.
  - Option-chain fallback `all_nfo = broker.instruments()` corrected to `broker.instruments("NFO")`.
  - `_resolve_token()` fallback now routes `FUT`/`CE`/`PE` symbols to NFO and everything else to NSE.
  - `ZerodhaKiteClient`: added `self.token_map` (`int token → instrument row dict`) populated in `load_instruments()` for O(1) reverse token lookups.

- **Docs — mark `InstrumentResolver` as deprecated**: Updated `instruments.py` module docstring and `data/__init__.py` to steer new code toward `InstrumentManager.get_token()`; the class is kept for the existing CSV/SQLite warm-up path.

## Files changed

| File | Change |
|------|--------|
| `data/market_data_manager.py` | `get_last_tick()`, `hydration_complete` flag + gate, NFO instrument loading, `_resolve_token` exchange routing |
| `data/rest/zerodha_client.py` | `self.token_map` added to `__init__` + populated in `load_instruments()` |
| `data/instruments.py` | Module docstring updated (deprecation note) |
| `data/__init__.py` | Deprecation comment on `InstrumentResolver` export |

## Test plan

- [ ] Verify `MarketDataManager().get_last_tick("NSE:NIFTY")` no longer raises `AttributeError`
- [ ] Verify first-boot with no ticks: system stays `ready=False, degraded=False` (not DEGRADED)
- [ ] Verify second boot after data was received: timeout → `ready=False, degraded=True` as expected
- [ ] Verify NFO option/futures tokens appear in `_token_by_symbol` after `_initialize_instruments()`
- [ ] Verify `broker.instruments("NFO")` is called when fetching option chain fallback
- [ ] Verify `zerodha_client.token_map[<token>]` returns correct instrument row after `load_instruments("NFO")`

https://claude.ai/code/session_01HD7dLdQXiUxz9j4K67sBe8
EOF
)