### PR TITLE
Fix four production runtime errors from startup logs

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -2220,7 +2220,12 @@ async def reconcile_with_broker(
 
     # ── 2. Fetch live positions and attach safety brackets for orphans ────────
     try:
-        raw_positions = await asyncio.to_thread(_run_sync_locked, broker_client.get_positions)
+        if inspect.iscoroutinefunction(getattr(broker_client, "get_positions", None)):
+            raw_positions = await broker_client.get_positions()
+        else:
+            raw_positions = await asyncio.to_thread(_run_sync_locked, broker_client.get_positions)
+            if asyncio.iscoroutine(raw_positions):
+                raw_positions = await raw_positions
         positions = [p for p in (raw_positions or []) if isinstance(p, dict)]
         logger.info("RECONCILE_POSITIONS: found %d positions from broker", len(positions))
 
@@ -5199,7 +5204,6 @@ async def startup_sequence(ctx: BotContext) -> None:
 
             # ---------- Futures rollover logic (unchanged) ----------
             import calendar
-            from datetime import datetime, timedelta
 
             now = datetime.now()
             year, month = now.year, now.month

--- a/src/nifty_scalper_bot/data/__init__.py
+++ b/src/nifty_scalper_bot/data/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from nifty_scalper_bot.data.instrument_loader import (
     InstrumentUniverseStatus,
     ensure_sqlite,
+    load_rows_for_resolver,
     parse_kite_csv,
     refresh_from_csv,
     sync_instrument_csv_from_broker,
@@ -15,6 +16,7 @@ from nifty_scalper_bot.data.instrument_loader import (
 __all__ = [
     "InstrumentUniverseStatus",
     "ensure_sqlite",
+    "load_rows_for_resolver",
     "parse_kite_csv",
     "refresh_from_csv",
     "sync_instrument_csv_from_broker",

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -106,8 +106,9 @@ class MarketDataManager:
         )
         self._token_by_symbol: dict[str, int] = {}
         self._symbol_by_token: dict[int, str] = {}
-        self._token_by_symbol["NSE:NIFTY 50"] = 256265
-        self._symbol_by_token[256265] = "NSE:NIFTY 50"
+        self._token_by_symbol["NSE:NIFTY"] = 256265       # canonical
+        self._token_by_symbol["NSE:NIFTY 50"] = 256265  # alias
+        self._symbol_by_token[256265] = "NSE:NIFTY"
         self._token_by_symbol["NSE:BANKNIFTY"] = 260105
         self._symbol_by_token[260105] = "NSE:BANKNIFTY"
         self._last_signature: dict[


### PR DESCRIPTION
## Summary

Four distinct runtime errors observed in production startup logs, all fixed:

### 1. `ImportError: cannot import name 'load_rows_for_resolver'`
- **File:** `src/nifty_scalper_bot/data/__init__.py`
- `telegram_controller.py` imports `load_rows_for_resolver` from `nifty_scalper_bot.data` but it was never exported from `__init__.py` (defined in `instrument_loader.py`). Added the export — fixes legacy console being silently disabled on every startup.

### 2. `Failed to subscribe symbol NSE:NIFTY: Token missing for NSE:NIFTY`
- **File:** `src/nifty_scalper_bot/data/market_data_manager.py`
- `instrument_manager.py` and all strategy code use `"NSE:NIFTY"` but `MarketDataManager.__init__` only seeded `"NSE:NIFTY 50" → 256265`. Added `"NSE:NIFTY" → 256265` as canonical (`_symbol_by_token[256265] = "NSE:NIFTY"`) and kept `"NSE:NIFTY 50"` as an alias. This unblocks live data flow and prevents DEGRADED mode / StrategyRunner startup failure.

### 3. `RECONCILE_POSITIONS: 'coroutine' object is not iterable` + `RuntimeWarning: coroutine 'RobustDataProvider.get_positions' was never awaited`
- **File:** `src/nifty_scalper_bot/core/app.py` — `reconcile_with_broker()`
- `RobustDataProvider.get_positions` is `async`. Calling it via `asyncio.to_thread(_run_sync_locked, broker_client.get_positions)` invoked the coroutine function synchronously, returning a coroutine object instead of results. Applied the same `inspect.iscoroutinefunction` guard already used for `get_orders` on the line above.

### 4. `Failed to schedule EOD flatten: cannot access local variable 'datetime' where it is not associated with a value`
- **File:** `src/nifty_scalper_bot/core/app.py` — `startup_sequence()`
- A `from datetime import datetime, timedelta` inside the function body (inside a conditional block) made `datetime` a function-local variable for the entire function scope. When the EOD flatten scheduler (later in the same function) referenced `datetime.now(...)`, Python raised `UnboundLocalError` on code paths that didn't execute the inner import. Removed the redundant local import — `datetime` and `timedelta` are already imported at module level (line 16).

## Test plan
- [ ] Bot starts without `ImportError` for `load_rows_for_resolver`
- [ ] `NSE:NIFTY` subscribes successfully at startup; no DEGRADED mode
- [ ] No `'coroutine' object is not iterable` warning in RECONCILE_POSITIONS
- [ ] EOD flatten schedules cleanly at 15:24 IST without `UnboundLocalError`

https://claude.ai/code/session_017vu2FpzxXYvxr1z7USXpBh