### PR TITLE
Fix NameError and add coroutine guard in _reconcile_state

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -6177,15 +6177,18 @@ async def _reconcile_state(ctx: BotContext) -> None:
             )
             try:
                 raw = _sync_broker.get_positions()
-                # Guard: if the resolved broker method is async it returns a coroutine
-                # object instead of positions (e.g. RobustDataProvider leaked through).
-                # Close the coroutine to suppress ResourceWarning and fall back safely.
-                if asyncio.iscoroutine(raw):
+                # Guard: if the resolved broker method is async it returns an awaitable
+                # (coroutine, Task, or Future) instead of positions.  Clean up the
+                # awaitable correctly and fall back to an empty result.
+                if inspect.isawaitable(raw):
                     LOGGER.error(
-                        "get_positions() returned a coroutine in sync context – "
+                        "get_positions() returned an awaitable in sync context – "
                         "broker client wrapping is incorrect. Falling back to empty list."
                     )
-                    raw.close()
+                    if asyncio.iscoroutine(raw):
+                        raw.close()          # suppress ResourceWarning on coroutines
+                    elif hasattr(raw, "cancel"):
+                        raw.cancel()         # cancel Tasks / Futures
                     raw = {}
             except Exception as _pos_err:
                 LOGGER.warning("Position fetch failed in reconcile: %s", _pos_err)

--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -6177,6 +6177,16 @@ async def _reconcile_state(ctx: BotContext) -> None:
             )
             try:
                 raw = _sync_broker.get_positions()
+                # Guard: if the resolved broker method is async it returns a coroutine
+                # object instead of positions (e.g. RobustDataProvider leaked through).
+                # Close the coroutine to suppress ResourceWarning and fall back safely.
+                if asyncio.iscoroutine(raw):
+                    LOGGER.error(
+                        "get_positions() returned a coroutine in sync context – "
+                        "broker client wrapping is incorrect. Falling back to empty list."
+                    )
+                    raw.close()
+                    raw = {}
             except Exception as _pos_err:
                 LOGGER.warning("Position fetch failed in reconcile: %s", _pos_err)
                 raw = {}
@@ -6200,6 +6210,9 @@ async def _reconcile_state(ctx: BotContext) -> None:
         try:
             broker_positions = await asyncio.to_thread(safe_sync_fetch)
             # A. Fetch Broker Positions (REQUIRED STEP)
+            # Initialise bm here so the ghost-bracket cleanup below never hits NameError
+            # even when ctx.order_manager or _bracket_manager is absent.
+            bm = None
             # C. Auto-Guard Orphans (CRITICAL SAFETY LOGIC)
             if ctx.order_manager and ctx.order_manager._bracket_manager:
                 om = ctx.order_manager


### PR DESCRIPTION
## Summary

- **Bug 1 (NameError – critical)**: `bm` was assigned only inside `if ctx.order_manager and ctx.order_manager._bracket_manager:` but referenced unconditionally in the ghost-bracket cleanup block below it. When either guard was `None`, the entire position-sync threw `NameError: name 'bm' is not defined`, which was swallowed by the outer `except` and logged as *"Position Sync/Adoption Failed"*. Fix: initialise `bm = None` immediately after the positions fetch.

- **Bug 2 (coroutine leak – defensive)**: The `_sync_broker` resolution via `.client` / `._broker` correctly reaches the synchronous `ZerodhaKiteClient.get_positions()` today, so no coroutine is returned in practice. However there was no guard for the scenario where a future broker-client refactor or incorrect wrapping causes an async method to slip through. Without the guard the coroutine object would be silently treated as an empty position list (no log, `ResourceWarning` at GC time). Fix: explicit `asyncio.iscoroutine()` check that closes the coroutine, logs an actionable `ERROR`, and falls back to `{}`.

## Root cause of the reported symptom

The provided analysis ("get_positions returns a coroutine") correctly identified the *class* of problem but pointed at the wrong line. The `_sync_broker` resolution already works correctly. The real runtime failure was the `NameError` on `bm` which caused every reconciliation cycle to exit early via the catch-all `except`.

## Files changed

- `src/nifty_scalper_bot/core/app.py` – `_reconcile_state` function only; no other logic altered.

## Test plan

- [ ] Start bot normally; confirm reconcile loop logs "broker_position_sync_success" without "Position Sync/Adoption Failed"
- [ ] Test with `ctx.order_manager = None` (e.g., paper mode without order manager); confirm ghost-bracket block is skipped cleanly with no NameError
- [ ] Test with `ctx.order_manager._bracket_manager = None`; same as above
- [ ] Test full path with open positions and brackets; confirm orphan detection and ghost cleanup still work

https://claude.ai/code/session_011knW53mBkNC76SdqzJx8QL