### PR TITLE
fix: harden market data layer — crash bugs, silent drops, thread safety

### DIFF
--- a/src/nifty_scalper_bot/data/data_hub.py
+++ b/src/nifty_scalper_bot/data/data_hub.py
@@ -80,17 +80,32 @@ class TickBus:
     def publish(self, tick: dict[str, Any]) -> None:
         """Args: tick; Returns: none; Raises: none."""
         self._event_bus.publish("tick", tick)
-        if getattr(self, "bus", None) is not None:
+        bus = getattr(self, "bus", None)
+        if bus is not None:
             try:
-                import asyncio
-                from nifty_scalper_bot.core.message_bus import Message, MessageType
                 msg = Message(
                     type=MessageType.DATA_READY,
                     timestamp=datetime.now(timezone.utc),
                     data=tick,
-                    source="data_hub"
+                    source="data_hub",
                 )
-                asyncio.create_task(self.bus.publish(msg))
+                loop: asyncio.AbstractEventLoop | None = None
+                try:
+                    loop = asyncio.get_running_loop()
+                except RuntimeError:
+                    pass
+                if loop is not None and loop.is_running():
+                    asyncio.ensure_future(bus.publish(msg))
+                else:
+                    # Called from sync (WS) thread — schedule safely
+                    try:
+                        loop = asyncio.get_event_loop()
+                        if loop.is_running():
+                            loop.call_soon_threadsafe(
+                                asyncio.ensure_future, bus.publish(msg)
+                            )
+                    except RuntimeError:
+                        pass  # No loop available — skip bus publish
             except Exception as e:
                 LOGGER.error("Failed to publish DATA_READY: %s", e)
 
@@ -282,13 +297,17 @@ class DataHub:
     def ingest_tick_sync(self, tick: dict) -> None:
         """Called from KiteConnect OS thread; schedules tick ingest safely."""
         loop = self._main_loop
-        
+
         # 1. Fallback if the main loop was not explicitly injected
         if loop is None or not loop.is_running():
             try:
                 loop = asyncio.get_running_loop()
             except RuntimeError:
-                return  # Drop tick gracefully if no loop exists yet
+                LOGGER.debug(
+                    "ingest_tick_sync: no event loop — tick dropped for %s",
+                    tick.get("symbol", tick.get("instrument_token", "?")),
+                )
+                return
 
         # 2. Correct thread-safe async scheduling across OS threads
         if loop and loop.is_running():
@@ -449,9 +468,8 @@ class DataHub:
                     if ws_connected and not poll_enabled:
                         return None
                 return self._mdm.pull_quote(symbol)
-            except Exception as e:
-                __import__("logging").getLogger(__name__).exception("[CRITICAL] unhandled exception", exc_info=True)
-                raise
+            except Exception:
+                LOGGER.error("pull_quote failed for %s", symbol, exc_info=True)
 
         return None
 
@@ -565,42 +583,45 @@ class DataHub:
         }
 
     async def warmup_indicators(self, symbol: str, interval: str = "minute", bars: int = 100) -> None:
-        self._logger.info(f"Starting true history warmup for {symbol}")
-        
+        LOGGER.info("Starting true history warmup for %s", symbol)
+
+        source = getattr(self, "_source", None)
+        if source is None or not hasattr(source, "get_historical_data"):
+            LOGGER.warning("warmup_indicators: no _source available for %s", symbol)
+            return
+
         try:
-            # FIX: Ensure this is explicitly awaited. If this is a blocking HTTP request,
-            # it must be wrapped in asyncio.to_thread() or use an async client (aiohttp).
-            # If your client is synchronous (e.g., standard requests):
             candles = await asyncio.to_thread(
-                self._source.get_historical_data, 
-                symbol, 
-                interval, 
-                bars + 20
+                source.get_historical_data,
+                symbol,
+                interval,
+                bars + 20,
             )
-            
+
             if not candles:
-                self._logger.warning(f"No history returned for {symbol}. Warmup aborted.")
+                LOGGER.warning("No history returned for %s. Warmup aborted.", symbol)
                 return
 
-            # FIX: Prime the Live Quote Cache so the bot doesn't think data is "Stale"
+            # Prime the Live Quote Cache so the bot doesn't think data is "Stale"
             last_candle = candles[-1]
             last_close = float(last_candle.get("close", 0.0))
-            
-            # Prime the quote cache
+
             self.store_quote(
                 symbol=symbol,
                 quote_data={"ltp": last_close, "timestamp": time.time(), "source": "warmup"},
-                seed=True
+                seed=True,
             )
 
-            # Feed to CandleEngine
-            for candle in candles:
-                self._candle_engine.update(symbol, candle)
-                
-            self._logger.info(f"✅ True warmup complete for {symbol}. {len(candles)} bars loaded.")
-            
+            # Feed to CandleEngine if available
+            candle_engine = getattr(self, "_candle_engine", None)
+            if candle_engine is not None:
+                for candle in candles:
+                    candle_engine.update(symbol, candle)
+
+            LOGGER.info("True warmup complete for %s. %d bars loaded.", symbol, len(candles))
+
         except Exception as e:
-            self._logger.error(f"Warmup critically failed for {symbol}: {e}")
+            LOGGER.error("Warmup critically failed for %s: %s", symbol, e)
 
     # ----------------------------------------------------------------
     # Subscription Management
@@ -698,9 +719,8 @@ class DataHub:
 
             self._last_greeks_update[symbol] = now
 
-        except Exception as e:
-            __import__("logging").getLogger(__name__).exception("[CRITICAL] unhandled exception", exc_info=True)
-            raise
+        except Exception:
+            LOGGER.error("Greeks/IV computation failed for %s", symbol, exc_info=True)
 
     def _get_underlying_price(self, base: str) -> float | None:
         candidates = [canonical(base)]
@@ -736,9 +756,8 @@ class DataHub:
                     )
                     base = "NIFTY" if "NIFTY" in clean_sym else "BANKNIFTY"
                     return base, ts, strike, is_call
-            except Exception as e:
-                __import__("logging").getLogger(__name__).exception("[CRITICAL] unhandled exception", exc_info=True)
-                raise
+            except Exception:
+                LOGGER.error("Option symbol parse failed for %s", symbol, exc_info=True)
         return None
 
     def _clock(self) -> float:
@@ -770,17 +789,8 @@ class DataHub:
     def get_option_chain(
         self, symbol: str, option_type: str | None = None
     ) -> list[dict]:
-        """Retrieves option chain with Traceability Logs."""
-
-        # LOG 1: Entry
-        if hasattr(self, "_logger"):
-            self._logger.info(f"🔍 DataHub: Fetching chain for {symbol}...")
-
-        mdm = (
-            getattr(self, "_market_data", None)
-            or getattr(self, "_mdm", None)
-            or getattr(self, "_market_data_manager", None)
-        )
+        """Retrieves option chain via MDM or provider fallback."""
+        mdm = self._mdm
 
         result = []
         source = "None"
@@ -794,15 +804,11 @@ class DataHub:
                 result = provider.get_option_chain(symbol)
                 source = "Provider"
 
-        # LOG 2: Result
         count = len(result) if result else 0
-        if hasattr(self, "_logger"):
-            if count > 0:
-                self._logger.info(f"✅ DataHub: Found {count} strikes via {source}.")
-            else:
-                self._logger.warning(
-                    f"⚠️ DataHub: Chain is EMPTY! Source: {source}. (Symbol: {symbol})"
-                )
+        if count > 0:
+            LOGGER.debug("DataHub: option chain for %s — %d strikes via %s", symbol, count, source)
+        else:
+            LOGGER.warning("DataHub: option chain EMPTY for %s (source=%s)", symbol, source)
 
         return result
 

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -2648,27 +2648,6 @@ class MarketDataManager:
         self._enqueue_tick_threadsafe(tick)
 
     def process_ticks(self, ticks: list[dict[str, Any]]) -> None:
-        if getattr(self, "bus", None) is not None:
-            try:
-                import asyncio
-                import time
-                now = time.time()
-                for t in ticks:
-                    token = t.get("instrument_token")
-                    price = float(t.get("last_price", t.get("ltp", 0.0)))
-                    msg = Message(
-                        type=MessageType.TICK,
-                        timestamp=now,
-                        data={
-                            "token": token,
-                            "ltp": price,
-                            "ts": t.get("exchange_timestamp", now)
-                        },
-                        source="market_data_manager"
-                    )
-                    asyncio.create_task(self.bus.publish(msg))
-            except Exception as e:
-                pass
         """Batch-enqueue WS ticks from KiteTicker callback.
 
         Called by WebSocketManager._on_ticks() for every tick batch —
@@ -2683,6 +2662,31 @@ class MarketDataManager:
         """
         if not ticks:
             return
+
+        # Publish to MessageBus (thread-safe: schedule onto the async loop)
+        bus = getattr(self, "bus", None)
+        if bus is not None:
+            loop = self._main_loop
+            if loop is not None and loop.is_running():
+                try:
+                    now = time.time()
+                    for t in ticks:
+                        token = t.get("instrument_token")
+                        price = float(t.get("last_price", t.get("ltp", 0.0)))
+                        msg = Message(
+                            type=MessageType.TICK,
+                            timestamp=now,
+                            data={
+                                "token": token,
+                                "ltp": price,
+                                "ts": t.get("exchange_timestamp", now),
+                            },
+                            source="market_data_manager",
+                        )
+                        asyncio.run_coroutine_threadsafe(bus.publish(msg), loop)
+                except Exception:  # noqa: BLE001 — WS thread must not raise
+                    pass
+
         try:
             iterator = iter(ticks)
         except TypeError:
@@ -2737,13 +2741,21 @@ class MarketDataManager:
             self._event_loop_lag_seconds = max(0.0, time.monotonic() - float(enqueued_mono))
         if not raw.get("symbol"):
             token = raw.get("instrument_token")
-            if token is None: return
-            
+            if token is None:
+                return
+
             token_int = int(token)
-            symbol_from_map = self._symbol_by_token.get(token_int)
-            
+            with self._lock:
+                symbol_from_map = self._symbol_by_token.get(token_int)
+
             if not symbol_from_map:
-                self._logger.warning("Unmapped token %s", token_int)
+                log_throttled(
+                    self._logger,
+                    f"unmapped_token_{token_int}",
+                    "Unmapped token %s — tick dropped" % token_int,
+                    interval_sec=30.0,
+                    level=logging.WARNING,
+                )
                 return
             raw = {**raw, "symbol": symbol_from_map}
 

--- a/src/nifty_scalper_bot/market_data_streamer.py
+++ b/src/nifty_scalper_bot/market_data_streamer.py
@@ -1,13 +1,11 @@
 import asyncio
 from collections.abc import Sequence
-from datetime import datetime
+from datetime import datetime, timezone
 import time
-import asyncio
 from typing import Any
 
 from nifty_scalper_bot.core.message_bus import Message, MessageType
 from nifty_scalper_bot.data.market_state import MarketState
-from nifty_scalper_bot.core.message_bus import Message, MessageType
 from nifty_scalper_bot.utils.logging import get_logger
 
 LOGGER = get_logger(__name__)
@@ -24,7 +22,6 @@ class MarketDataStreamer:
         self.bus = bus
         self._subscribed_tokens: set[int] = set()
         self._last_heartbeat: float | None = None
-        self.bus = None
 
     @property
     def last_heartbeat(self) -> float | None:
@@ -35,10 +32,12 @@ class MarketDataStreamer:
     def on_ticks(self, ws: Any, ticks: Sequence[dict[str, Any]]) -> None:
         """Update market state from websocket ticks. Args: ws, ticks. Returns: none. Raises: none."""
 
+        now = datetime.now(timezone.utc)
+        now_epoch = time.time()
         for t in ticks:
             try:
-                token = int(tick.get("instrument_token"))
-                price = float(tick.get("last_price") or tick.get("ltp"))
+                token = int(t.get("instrument_token"))
+                price = float(t.get("last_price") or t.get("ltp"))
                 if token == 256265:
                     self._market_state.set_spot_ltp(price, source="ws")
                 self._market_state.update_tick(token, price, source="ws")
@@ -50,11 +49,15 @@ class MarketDataStreamer:
                         data={
                             "token": token,
                             "ltp": price,
-                            "ts": tick.get("exchange_timestamp", now)
+                            "ts": t.get("exchange_timestamp", now_epoch),
                         },
-                        source="market_data_streamer"
+                        source="market_data_streamer",
                     )
-                    asyncio.create_task(self.bus.publish(msg))
+                    loop = asyncio.get_event_loop()
+                    if loop.is_running():
+                        loop.call_soon_threadsafe(
+                            asyncio.ensure_future, self.bus.publish(msg)
+                        )
             except Exception as e:
                 LOGGER.exception("Failure in MarketDataStreamer.on_ticks: %s", e)
 

--- a/src/nifty_scalper_bot/streaming/websocket_manager.py
+++ b/src/nifty_scalper_bot/streaming/websocket_manager.py
@@ -641,17 +641,19 @@ class WebSocketManager:
                 mdm = getattr(self, "_market_data_manager", None)
                 validate_mapping = getattr(mdm, "validate_token_symbol_mappings", None)
                 if callable(validate_mapping):
-                    validate_mapping()
+                    try:
+                        validate_mapping()
+                    except RuntimeError as map_err:
+                        self._logger.warning(
+                            "Token/symbol mapping mismatch on connect (non-fatal): %s",
+                            map_err,
+                        )
                 ws.subscribe(token_list)
                 ws.set_mode(ws.MODE_FULL, token_list)
                 self._logger.info(
                     "WebSocket subscribed to %d tokens", len(self._tokens)
                 )
-                symbol_map = getattr(
-                    getattr(self, "_market_data_manager", None),
-                    "_symbol_by_token",
-                    {},
-                )
+                symbol_map = getattr(mdm, "_symbol_by_token", {})
                 self._logger.info(
                     "WebSocket subscribed tokens=%d symbols=%d",
                     len(self._tokens),

--- a/src/nifty_scalper_bot/utils/symbols.py
+++ b/src/nifty_scalper_bot/utils/symbols.py
@@ -37,9 +37,13 @@ def normalize_symbol(symbol: str) -> str:
     raw = str(symbol or "").strip().upper()
     if not raw:
         return ""
-    if ":" not in raw:
+    if ":" in raw:
+        return raw
+    # Infer exchange the same way canonical() does: derivatives get NFO,
+    # everything else (indices, equities) gets NSE.
+    if raw.endswith(("CE", "PE", "FUT")):
         return f"NFO:{raw}"
-    return raw
+    return f"NSE:{raw}"
 
 
 def unique_normalized_symbols(symbols: Iterable[str]) -> list[str]:


### PR DESCRIPTION
## Summary

- **market_data_streamer.py**: Fix NameError crash (`tick` vs `t` loop var), define `now` timestamp, remove duplicate imports, stop `bus=None` overwrite, use thread-safe bus publish
- **data_hub.py**: Log dropped ticks instead of silent return, fix TickBus `asyncio.create_task` from sync context, remove bare `raise` in Greeks/IV/quote handlers that crashed tick pipeline, fix `self._logger` references
- **market_data_manager.py**: Fix `process_ticks` calling `asyncio.create_task` from WS thread (use `run_coroutine_threadsafe`), fix misplaced docstring, add lock on `_symbol_by_token` read, throttle unmapped-token warnings
- **websocket_manager.py**: Catch `RuntimeError` from `validate_mapping` non-fatally so subscription proceeds
- **symbols.py**: Fix `normalize_symbol` blindly prefixing `NFO:` for all symbols — now infers `NSE:` for non-derivatives (matches `canonical()`)

## Test plan

- [x] All 5 modified files compile cleanly (`py_compile`)
- [x] `normalize_symbol` / `canonical` produce consistent results for NIFTY, BANKNIFTY, options, futures
- [ ] Verify live tick flow from WS → MDM → DataHub → strategies with no silent drops
- [ ] Confirm no NameError crash on first WS tick batch

https://claude.ai/code/session_01UUr5kwBCVW8YDYoV5Yd9oy