### PR TITLE
fix(app,data_hub): restore telegram console + wire DataHub event loop

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -4767,11 +4767,10 @@ def initialize_components(settings: Settings | None = None) -> BotContext:
 
                 paper_mode_getters["stream"] = _stream_paper_getter
                 paper_mode_setters["stream"] = _stream_paper_setter
-            settings = get_settings(),
-            cache_settings = getattr(settings, "cache", None),
+            cache_settings = getattr(settings, "cache", None)
 
-            instrument_db_path = None,
-            instrument_csv_path = None,
+            instrument_db_path: str | None = None
+            instrument_csv_path: str | None = None
 
             if cache_settings:
                 db_path = getattr(cache_settings, "db_path", None)
@@ -4978,9 +4977,10 @@ async def startup_sequence(ctx: BotContext) -> None:
     )
 
     loop = asyncio.get_running_loop()
+    # DataHub forwards to MDM internally; keep MDM call as fallback when DH absent.
     if ctx.data_hub is not None:
         ctx.data_hub.set_event_loop(loop)
-    if ctx.market_data_manager is not None and hasattr(
+    elif ctx.market_data_manager is not None and hasattr(
         ctx.market_data_manager, "set_event_loop"
     ):
         ctx.market_data_manager.set_event_loop(loop)

--- a/src/nifty_scalper_bot/data/data_hub.py
+++ b/src/nifty_scalper_bot/data/data_hub.py
@@ -77,9 +77,31 @@ class DataHub:
         self._poll_block_ms = 800
 
         # ===========================
+        # EVENT LOOP (wired at startup)
+        # ===========================
+        self._main_loop: Optional[asyncio.AbstractEventLoop] = None
+
+        # ===========================
         # 🔗 BIND MDM → DATAHUB (CRITICAL FIX)
         # ===========================
         self._bind_to_mdm()
+
+    def set_event_loop(self, loop: asyncio.AbstractEventLoop) -> None:
+        """Wire the main asyncio loop and forward to MDM if supported.
+
+        Idempotent: first call wins; subsequent calls are ignored so
+        reconnects don't swap the loop out from under pending tasks.
+        """
+        if self._main_loop is not None:
+            LOGGER.warning("DataHub event loop already wired — ignoring rewire")
+            return
+        self._main_loop = loop
+        mdm_set = getattr(self._mdm, "set_event_loop", None)
+        if callable(mdm_set):
+            try:
+                mdm_set(loop)
+            except Exception as exc:
+                LOGGER.error("DataHub.set_event_loop → MDM failed: %s", exc)
 
 
     def replace_positions(self, positions: list[dict]) -> None:


### PR DESCRIPTION
## Summary

Two production regressions surfaced after the market-data SSOT refactor:

- `'DataHub' object has no attribute 'set_event_loop'` → bot entered degraded mode on startup.
- `Telegram console disabled: 'tuple' object has no attribute 'notifications'` → telegram commands never registered.

## Fixes

1. **`DataHub.set_event_loop(loop)`** (`src/nifty_scalper_bot/data/data_hub.py`)
   - Added an idempotent method that stores the loop and forwards to MDM when present.
   - Caller in `core/app.py` simplified — DataHub forwards, MDM is used only as fallback when DataHub is None.

2. **Trailing-comma tuple bug in telegram setup** (`src/nifty_scalper_bot/core/app.py`)
   - `settings = get_settings(),` (and three siblings) produced 1-tuples, breaking the later `settings.notifications.enabled` access.
   - Dropped the redundant reassignment (`settings` already in scope) and removed trailing commas on the other vars.

No API changes, no new dependencies, no behavior changes beyond these bug fixes.

## Test plan

- [x] `ast.parse` clean on app.py / data_hub.py.
- [x] Smoke: `DataHub(StubMDM).set_event_loop(loop)` sets `_main_loop`, forwards to MDM, idempotent on second call.
- [x] Verified all required facade methods on DataHub (`set_event_loop`, `get_available_balance`, `get_account_snapshot`, `is_ready`, `is_fresh`, `get_latest_price`, `pull_quote`, `ensure_tracking`, `subscribe_orders`, `unsubscribe_orders`, `ingest_tick_sync`, `get_quote`, `get_tick_by_token`, `replace_positions`, `get_positions`, `update_position`).
- [x] AST scan across `app.py / data_hub.py / market_data_manager.py / bot/components.py` for other single-element-tuple assignments → 0 found.

https://claude.ai/code/session_01YSb2CcK2zsHqu63vtisUf7