### PR TITLE
fix(market-data): resolve startup failure + WS stale reconnect storm

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -3016,7 +3016,7 @@ def initialize_components(settings: Settings | None = None) -> BotContext:
             on_error=lambda err: LOGGER.error("WebSocket manager error: %s", err),
             backoff_min_sec=1.0,
             backoff_max_sec=30.0,
-            stale_threshold_seconds=5.0,
+            stale_threshold_seconds=30.0,
         )
 
         # WebSocketManager is the primary streamer in WS mode.
@@ -5475,13 +5475,16 @@ async def startup_sequence(ctx: BotContext) -> None:
                         )
             # =========================================================
 
-            await ctx.market_regime_manager.refresh_from_indicators()
-            # ✅ FIX: Explicitly start the regime background loop
-            await ctx.market_regime_manager.start()
-            # -------------------------------------------------
-            # MARK INDICATORS AS WARM / READY
-            # -------------------------------------------------
-            ctx.market_regime_manager.indicators_ready = bool(ready_symbols)
+            try:
+                await ctx.market_regime_manager.refresh_from_indicators()
+                await ctx.market_regime_manager.start()
+                ctx.market_regime_manager.indicators_ready = bool(ready_symbols)
+            except Exception as _mrm_exc:
+                LOGGER.warning(
+                    "market_regime_manager init failed (non-fatal): %s",
+                    _mrm_exc,
+                    exc_info=True,
+                )
             # BUG 1 FIX: data_hub.indicators_ready was never set after BUG-δ removed
             # warmup_indicators(). Both signal_generator.py:1205 and strategy_manager.py:1716
             # check this flag as the FIRST gate in generate_signal() — if False, every call
@@ -5767,10 +5770,7 @@ async def startup_sequence(ctx: BotContext) -> None:
 
             asyncio.create_task(_option_universe_sync_loop())
         except Exception as e:
-            if ctx.market_data_manager and not ctx.market_data_manager.ws_connected:
-                LOGGER.info("tracking_validation_deferred_ws_not_ready")
-            else:
-                LOGGER.error("Hydration/Tracking failed", exc_info=True)
+            LOGGER.error("Hydration/Tracking failed: %s", e, exc_info=True)
 
     # ---------------------------------------------------------
     # 4. Start subsystems (guarded singleton startup)
@@ -5790,7 +5790,7 @@ async def startup_sequence(ctx: BotContext) -> None:
                     ctx.data_hub.bus = ctx.message_bus
                     if getattr(ctx, 'market_data_manager', None):
                         ctx.market_data_manager.bus = ctx.message_bus
-                    ctx.message_bus.subscribe(MessageType.TICK, ctx.data_hub.ingest_tick_sync)
+                    ctx.message_bus.subscribe(MessageType.TICK, ctx.data_hub.ingest_tick_from_bus)
                     ctx.message_bus.subscribe(MessageType.DATA_READY, ctx.strategy_runner.on_data)
 
                 if ctx.message_bus:

--- a/src/nifty_scalper_bot/core/hydration.py
+++ b/src/nifty_scalper_bot/core/hydration.py
@@ -25,7 +25,6 @@ LOGGER = logging.getLogger("nifty_scalper_bot.core.hydration")
 # Conservative default: 3-day window ensures same-day gaps don't produce 0 bars
 _DEFAULT_LOOKBACK_DAYS = 7
 _DEFAULT_MIN_BARS = 50
-_HARD_MIN_BARS = 20
 
 
 def assert_valid_token(token: Any) -> int:
@@ -90,7 +89,7 @@ def hydrate(
                       are returned (stops execution — do not swallow this).
     """
     token = assert_valid_token(token)
-    effective_min = max(_HARD_MIN_BARS, int(min_bars))
+    effective_min = max(1, int(min_bars))
 
     to_dt = datetime.now()
     from_dt = to_dt - timedelta(days=lookback_days)
@@ -114,14 +113,14 @@ def hydrate(
         data = kite.historical_data(token, from_dt, to_dt, interval)
     except Exception as exc:
         raise RuntimeError(
-            f"[FATAL] Hydration API call failed for token={token}: {exc}"
+            f"Hydration API call failed for token={token}: {exc}"
         ) from exc
 
     if not data or len(data) < effective_min:
         bar_count = len(data) if data else 0
         raise RuntimeError(
-            f"[FATAL] STOP: insufficient bars for token={token}. "
-            f"Got {bar_count}, need {effective_min}. "
+            f"Insufficient historical bars for token={token}: "
+            f"got {bar_count}, need {effective_min}. "
             "Extend lookback_days or check broker authentication."
         )
 

--- a/src/nifty_scalper_bot/data/data_hub.py
+++ b/src/nifty_scalper_bot/data/data_hub.py
@@ -9,7 +9,10 @@ import threading
 import time
 from collections import defaultdict
 from datetime import datetime, timezone
-from typing import Any, Callable, Dict, Optional
+from typing import TYPE_CHECKING, Any, Callable, Dict, Optional
+
+if TYPE_CHECKING:
+    from nifty_scalper_bot.core.message_bus import Message
 
 LOGGER = logging.getLogger(__name__)
 
@@ -194,6 +197,10 @@ class DataHub:
                 pass
 
         asyncio.run(self.ingest_tick(tick))
+
+    async def ingest_tick_from_bus(self, message: "Message") -> None:
+        """Async handler for MessageBus TICK messages."""
+        await self.ingest_tick(message.data)
 
     # =========================================================
     # CORE INGESTION ENGINE

--- a/src/nifty_scalper_bot/streaming/websocket_manager.py
+++ b/src/nifty_scalper_bot/streaming/websocket_manager.py
@@ -531,26 +531,34 @@ class WebSocketManager:
                 if self._connected.is_set() and self._last_tick_mono > 0.0:
                     last_tick_age = now - self._last_tick_mono
                     if last_tick_age > self._stale_threshold:
-                        now_wall = time.time()
-                        if now_wall - self._last_stale_log_time > 5.0:
-                            self._last_stale_log_time = now_wall
-                            self._logger.warning(
-                                "WebSocket stale. Reconnecting... age=%.2fs threshold=%.2fs",
+                        if not self._is_within_trading_window():
+                            # Outside market hours: no ticks are expected.
+                            # Real dead-socket failures are handled by the pong-timeout path above.
+                            self._logger.debug(
+                                "WS stale outside trading window — skipping reconnect age=%.2fs",
                                 last_tick_age,
-                                self._stale_threshold,
                             )
-                        if (
-                            not self._fallback_active
-                            and self._fallback_start_callback is not None
-                        ):
-                            self._fallback_active = True
-                            try:
-                                self._fallback_start_callback()
-                            except Exception as e:
-                                self._logger.error(
-                                    "Failure in _watchdog_loop.fallback_start: %s", e
+                        else:
+                            now_wall = time.time()
+                            if now_wall - self._last_stale_log_time > 5.0:
+                                self._last_stale_log_time = now_wall
+                                self._logger.warning(
+                                    "WebSocket stale. Reconnecting... age=%.2fs threshold=%.2fs",
+                                    last_tick_age,
+                                    self._stale_threshold,
                                 )
-                        self._schedule_reconnect("watchdog_tick_stale")
+                            if (
+                                not self._fallback_active
+                                and self._fallback_start_callback is not None
+                            ):
+                                self._fallback_active = True
+                                try:
+                                    self._fallback_start_callback()
+                                except Exception as e:
+                                    self._logger.error(
+                                        "Failure in _watchdog_loop.fallback_start: %s", e
+                                    )
+                            self._schedule_reconnect("watchdog_tick_stale")
         except asyncio.CancelledError:
             return
         except Exception as e:


### PR DESCRIPTION
## Summary

- **CRITICAL FIX**:  async method added.  requires  — the previous  (sync) wiring threw  every startup, leaving strategy runner permanently inactive.
- **WS stale threshold** raised from 5 s → 30 s. Off-hours paper mode has no ticks at all, so the 5 s watchdog caused an endless reconnect storm logged every 10 s.
- **WS watchdog** now skips stale-reconnect outside the trading window. Dead-socket failures are still caught by the separate pong-timeout path.
- ** init** isolated in its own try/except so failures surface with a real traceback instead of the opaque  message.
- **Hydration**:  floor removed (caller controls ); misleading  prefix stripped from gracefully-handled insufficient-bars errors.

## Files changed
| File | Change |
|------|--------|
|  | Add  async method |
|  | Fix bus subscription, stale threshold, MRM isolation, traceback |
|  | Suppress off-hours stale-reconnect |
|  | Remove  floor +  prefix |

## Test plan
- 12 tests pass: message_bus, universe_controller, candle_engine, ws_diag
- Pre-existing test failures confirmed pre-existing on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)