### PR TITLE
[codex] Fix websocket fallback and startup hydration

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -545,6 +545,74 @@ def _fetch_positions_with_retry(
     return []
 
 
+def _sync_data_hub_positions(
+    data_hub: Any | None,
+    position_manager: Any | None,
+    *,
+    logger: Any = LOGGER,
+) -> None:
+    if data_hub is None or position_manager is None:
+        return
+    try:
+        rows = [
+            {
+                "symbol": pos.symbol,
+                "quantity": pos.quantity if pos.side == "LONG" else -pos.quantity,
+                "average_price": pos.entry_price,
+            }
+            for pos in position_manager.get_open_positions()
+        ]
+        data_hub.replace_positions(rows)
+    except Exception as exc:  # noqa: BLE001
+        logger.error(
+            "data_hub_position_sync_failed",
+            extra={"event": "data_hub_position_sync_failed", "error": str(exc)},
+            exc_info=exc,
+        )
+
+
+def _hydrate_positions(
+    *,
+    position_manager: Any,
+    persistent_state: Any,
+    broker_client: Any,
+    data_hub: Any | None,
+    logger: Any = LOGGER,
+    max_attempts: int,
+    backoff_min: float,
+    backoff_max: float,
+    backoff_multiplier: float,
+    jitter_fraction: float,
+    total_timeout_sec: float,
+) -> list[Mapping[str, object]] | None:
+    persisted_positions = persistent_state.load_positions()
+    broker_positions: list[Mapping[str, object]] | None
+    try:
+        broker_positions = _fetch_positions_with_retry(
+            broker_client,
+            max_attempts=max_attempts,
+            backoff_min=backoff_min,
+            backoff_max=backoff_max,
+            backoff_multiplier=backoff_multiplier,
+            jitter_fraction=jitter_fraction,
+            total_timeout_sec=total_timeout_sec,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.error(
+            "broker_position_sync_failed",
+            extra={"event": "broker_position_sync_failed", "error": str(exc)},
+        )
+        broker_positions = None
+
+    if broker_positions is None:
+        position_manager.restore_positions(persisted_positions)
+    else:
+        position_manager.synchronize_with_broker(broker_positions)
+
+    _sync_data_hub_positions(data_hub, position_manager, logger=logger)
+    return broker_positions
+
+
 def get_latest_bot_context() -> "BotContext | None":
     """Return the most recently initialized bot context, if any."""
 
@@ -3230,15 +3298,6 @@ def initialize_components(settings: Settings | None = None) -> BotContext:
     position_state_path = Path(data_dir) / "positions.json"
     position_manager = PositionManager(state_file=str(position_state_path))
     position_manager.attach_persistent_state(persistent_state)
-    position_manager.restore_positions(persistent_state.load_positions())
-    data_hub.replace_positions(
-        {
-            "symbol": pos.symbol,
-            "quantity": pos.quantity if pos.side == "LONG" else -pos.quantity,
-            "average_price": pos.entry_price,
-        }
-        for pos in position_manager.get_open_positions()
-    )
 
     broker_sync_attempts = max(
         1,
@@ -3280,25 +3339,19 @@ def initialize_components(settings: Settings | None = None) -> BotContext:
         ),
     )
 
-    try:
-        # [FIX] Indented correctly inside try
-        broker_positions = _fetch_positions_with_retry(
-            broker_client,
-            max_attempts=broker_sync_attempts,
-            backoff_min=broker_sync_backoff_min,
-            backoff_max=broker_sync_backoff_max,
-            backoff_multiplier=broker_sync_backoff_multiplier,
-            jitter_fraction=broker_sync_jitter,
-            total_timeout_sec=60.0,
-        )
-    except Exception as exc:  # noqa: BLE001
-        LOGGER.error(
-            "broker_position_sync_failed",
-            extra={"event": "broker_position_sync_failed", "error": str(exc)},
-        )
-        broker_positions = []
-    if broker_positions:
-        position_manager.synchronize_with_broker(broker_positions)
+    _hydrate_positions(
+        position_manager=position_manager,
+        persistent_state=persistent_state,
+        broker_client=broker_client,
+        data_hub=data_hub,
+        logger=LOGGER,
+        max_attempts=broker_sync_attempts,
+        backoff_min=broker_sync_backoff_min,
+        backoff_max=broker_sync_backoff_max,
+        backoff_multiplier=broker_sync_backoff_multiplier,
+        jitter_fraction=broker_sync_jitter,
+        total_timeout_sec=60.0,
+    )
 
     initial_balance = float(
         getattr(config, "initial_balance", 1_000_000.0) or 1_000_000.0
@@ -6321,6 +6374,8 @@ async def _reconcile_state(ctx: BotContext) -> None:
 
         except Exception as exc:
             LOGGER.error(f"Position Sync/Adoption Failed: {exc}", exc_info=True)
+
+    _sync_data_hub_positions(getattr(ctx, "data_hub", None), ctx.position_manager)
 
     # 3. SITUATION REPORT
     if ctx.order_manager:

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -221,7 +221,13 @@ class MarketDataManager:
 
         ws_disabled = os.getenv("WEBSOCKET__DISABLED", "false").lower() == "true"
         poll_src = os.getenv("DATA_READINESS_SOURCE", "").upper() == "POLL"
-        self._rest_poll_enabled = ws_disabled or poll_src
+        poll_fallback_env = os.getenv("MDM_POLL_FALLBACK", "").strip().lower() in {
+            "1",
+            "true",
+            "yes",
+            "on",
+        }
+        self._rest_poll_enabled = ws_disabled or poll_src or poll_fallback_env
         self._rest_poll_interval = self._parse_float_env(
             "MDM_POLL_INTERVAL_SECONDS", default=1.5, minimum=0.5
         )
@@ -409,21 +415,23 @@ class MarketDataManager:
             return
         try:
             symbol = normalize_symbol(str(symbol))
+            source = str(quote.get("source") or "poll").lower()
+            prepared = self._prepare_rest_tick(quote, source=source)
             with self._lock:
                 previous = self._latest_ticks.get(symbol)
-            normalized = self._normalize_tick(symbol, dict(quote), previous)
+            normalized = self._normalize_tick(symbol, prepared, previous)
             if normalized is None:
                 return
-            # Ensure timestamp present for downstream validator
-            if "timestamp" not in normalized:
-                normalized["timestamp"] = time.time()
             poll_ts = normalized.get("timestamp")
             if isinstance(poll_ts, (int, float)):
                 poll_bucket = int(float(poll_ts) // 60)
                 current_live_bucket = int(time.time() // 60)
                 if poll_bucket > current_live_bucket:
                     return
-            normalized.setdefault("source", "poll")
+            if self._is_duplicate(symbol, normalized):
+                self._store_tick(symbol, normalized)
+            else:
+                self._emit_tick(symbol, normalized, source=source)
             self._process_poll_quote(symbol, normalized)
         except Exception as exc:  # noqa: BLE001
             self._logger.debug(
@@ -1397,6 +1405,7 @@ class MarketDataManager:
                 quote = dict(raw_quote)
         if quote is None:
             return {"symbol": symbol}
+        quote = self._prepare_rest_tick(quote, source="rest")
         with self._lock:
             previous = self._latest_ticks.get(symbol)
 
@@ -4300,11 +4309,28 @@ class MarketDataManager:
         Raises:
             None.
         """
-
-        del symbol
-        return
+        quote = self._broker.get_quote(symbol)
+        if not isinstance(quote, dict):
+            return
+        quote = self._prepare_rest_tick(quote, source="rest")
+        with self._lock:
+            previous = self._latest_ticks.get(symbol)
+        normalized = self._normalize_tick(symbol, quote, previous)
+        if normalized is None:
+            return
+        if self._is_duplicate(symbol, normalized):
+            self._store_tick(symbol, normalized)
+        else:
+            self._emit_tick(symbol, normalized, source="rest")
+        self._process_poll_quote(symbol, normalized)
 
     def _has_recent_rest_ticks(self) -> bool:
+        cutoff = time.time() - max(self._rest_poll_interval * 2.0, 5.0)
+        with self._lock:
+            for symbol, ts in self._last_tick_wallclock.items():
+                source = self._last_tick_source.get(symbol)
+                if source in {"rest", "poll"} and ts >= cutoff:
+                    return True
         return False
 
     @staticmethod
@@ -4509,6 +4535,12 @@ class MarketDataManager:
             "ltq": tick.get("last_quantity"),
             "oi": self._coerce_float(tick, "oi", "open_interest"),
         }
+        source = tick.get("source")
+        if isinstance(source, str) and source:
+            normalized["source"] = source
+        broker_timestamp = tick.get("broker_timestamp")
+        if broker_timestamp is not None:
+            normalized["broker_timestamp"] = broker_timestamp
 
         # 5. Volume Handling
         volume = self._coerce_float(
@@ -4572,6 +4604,24 @@ class MarketDataManager:
                 val /= 1000.0
             return val
         return time.time()
+
+    @staticmethod
+    def _prepare_rest_tick(tick: Mapping[str, Any], *, source: str) -> dict[str, Any]:
+        payload = dict(tick)
+        broker_timestamp = payload.get("broker_timestamp")
+        if broker_timestamp is None:
+            broker_timestamp = (
+                payload.get("timestamp") or payload.get("ts") or payload.get("ts_ms")
+            )
+        if broker_timestamp is not None:
+            payload["broker_timestamp"] = broker_timestamp
+        observed_at = payload.pop("_local_timestamp", None)
+        payload["source"] = source
+        if isinstance(observed_at, (int, float)):
+            payload["timestamp"] = float(observed_at)
+        else:
+            payload["timestamp"] = time.time()
+        return payload
 
     def _is_duplicate(
         self,

--- a/tests/core/test_position_hydration.py
+++ b/tests/core/test_position_hydration.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+from nifty_scalper_bot.core.app import _hydrate_positions
+
+
+class _PersistentState:
+    def __init__(self, positions: list[Any]) -> None:
+        self._positions = list(positions)
+
+    def load_positions(self) -> list[Any]:
+        return list(self._positions)
+
+
+class _PositionManager:
+    def __init__(self) -> None:
+        self.restored: list[Any] | None = None
+        self.synced: list[dict[str, Any]] | None = None
+        self._positions: list[Any] = []
+
+    def restore_positions(self, positions: list[Any]) -> None:
+        self.restored = list(positions)
+        self._positions = list(positions)
+
+    def synchronize_with_broker(self, positions: list[dict[str, Any]]) -> None:
+        self.synced = list(positions)
+        self._positions = [
+            SimpleNamespace(
+                symbol=str(entry["tradingsymbol"]).upper(),
+                side="LONG" if int(entry["quantity"]) > 0 else "SHORT",
+                quantity=abs(int(entry["quantity"])),
+                entry_price=float(entry["average_price"]),
+            )
+            for entry in positions
+            if int(entry["quantity"]) != 0
+        ]
+
+    def get_open_positions(self) -> list[Any]:
+        return list(self._positions)
+
+
+class _DataHub:
+    def __init__(self) -> None:
+        self.rows: list[dict[str, Any]] = []
+
+    def replace_positions(self, rows: list[dict[str, Any]]) -> None:
+        self.rows = list(rows)
+
+
+def test_hydrate_positions_prefers_broker_snapshot(
+    monkeypatch,
+) -> None:
+    persisted = [
+        SimpleNamespace(
+            symbol="PERSISTED",
+            side="LONG",
+            quantity=2,
+            entry_price=99.0,
+        )
+    ]
+    broker_positions = [
+        {
+            "tradingsymbol": "NIFTY25O2025450CE",
+            "quantity": 1,
+            "average_price": 125.0,
+        }
+    ]
+    manager = _PositionManager()
+    data_hub = _DataHub()
+    monkeypatch.setattr(
+        "nifty_scalper_bot.core.app._fetch_positions_with_retry",
+        lambda *args, **kwargs: broker_positions,
+    )
+
+    result = _hydrate_positions(
+        position_manager=manager,
+        persistent_state=_PersistentState(persisted),
+        broker_client=object(),
+        data_hub=data_hub,
+        max_attempts=1,
+        backoff_min=0.1,
+        backoff_max=0.1,
+        backoff_multiplier=1.0,
+        jitter_fraction=0.0,
+        total_timeout_sec=1.0,
+    )
+
+    assert result == broker_positions
+    assert manager.restored is None
+    assert manager.synced == broker_positions
+    assert data_hub.rows == [
+        {
+            "symbol": "NIFTY25O2025450CE",
+            "quantity": 1,
+            "average_price": 125.0,
+        }
+    ]
+
+
+def test_hydrate_positions_falls_back_to_persisted_state(
+    monkeypatch,
+) -> None:
+    persisted = [
+        SimpleNamespace(
+            symbol="NIFTY25O2025450PE",
+            side="SHORT",
+            quantity=1,
+            entry_price=88.5,
+        )
+    ]
+    manager = _PositionManager()
+    data_hub = _DataHub()
+
+    def _raise_fetch(*args, **kwargs) -> list[dict[str, Any]]:
+        raise RuntimeError("broker unavailable")
+
+    monkeypatch.setattr(
+        "nifty_scalper_bot.core.app._fetch_positions_with_retry",
+        _raise_fetch,
+    )
+
+    result = _hydrate_positions(
+        position_manager=manager,
+        persistent_state=_PersistentState(persisted),
+        broker_client=object(),
+        data_hub=data_hub,
+        max_attempts=1,
+        backoff_min=0.1,
+        backoff_max=0.1,
+        backoff_multiplier=1.0,
+        jitter_fraction=0.0,
+        total_timeout_sec=1.0,
+    )
+
+    assert result is None
+    assert manager.synced is None
+    assert manager.restored == persisted
+    assert data_hub.rows == [
+        {
+            "symbol": "NIFTY25O2025450PE",
+            "quantity": -1,
+            "average_price": 88.5,
+        }
+    ]

--- a/tests/data/test_market_data_manager.py
+++ b/tests/data/test_market_data_manager.py
@@ -203,6 +203,35 @@ def test_rest_poll_fallback_dispatches_ticks(
         manager.stop()
 
 
+def test_rest_poll_uses_observed_time_for_freshness(
+    monkeypatch: pytest.MonkeyPatch, broker: DummyBroker, ws: DummyWebSocket
+) -> None:
+    observed_at = 10_000.0
+    broker.set_quote(
+        "NIFTY23",
+        {
+            "ltp": 100.0,
+            "bid": 99.5,
+            "ask": 100.5,
+            "timestamp": 1_000.0,
+        },
+    )
+    monkeypatch.setattr(
+        "nifty_scalper_bot.data.market_data_manager.time.time",
+        lambda: observed_at,
+    )
+    manager = MarketDataManager(broker, ws)
+
+    manager._poll_symbol("NIFTY23")
+
+    latest = manager.get_latest_tick("NIFTY23")
+    assert latest is not None
+    assert latest["timestamp"] == pytest.approx(observed_at)
+    assert latest["broker_timestamp"] == pytest.approx(1_000.0)
+    assert latest["source"] == "rest"
+    assert manager._has_recent_rest_ticks()
+
+
 def test_ohlc_builder_generates_minute_bars(
     monkeypatch: pytest.MonkeyPatch, broker: DummyBroker, ws: DummyWebSocket
 ) -> None:


### PR DESCRIPTION
## What changed
- restored live REST polling fallback in `MarketDataManager` by honoring `MDM_POLL_FALLBACK`, implementing `_poll_symbol`, and marking recent REST/poll ticks correctly
- stamp REST/poll quotes with the observed wall-clock time while preserving the original broker timestamp separately
- preserve tick `source` and `broker_timestamp` through normalization so freshness logic can distinguish websocket vs fallback data
- simplify startup position hydration so broker positions are canonical when fetch succeeds, persistent state is only the fallback when broker sync fails, and DataHub position sync happens through one helper
- sync DataHub positions after runtime reconciliation as well
- add regression coverage for fallback tick freshness and startup hydration selection

## Root causes
- the current production branch had `_poll_symbol()` stubbed out and `_has_recent_rest_ticks()` hardcoded to `False`, so polling fallback health never became true
- poll quotes were still normalized with broker-provided timestamps, which makes off-hours fallback data look stale immediately
- `initialize_components()` restored persisted positions into memory and DataHub first, then fetched broker positions and synchronized again, which duplicated hydration and made the startup path harder to reason about

## Impact
- websocket outages now have a working REST/poll fallback path again
- off-hours fallback quotes stay fresh enough for health checks and downstream consumers while still retaining the broker timestamp for diagnostics
- startup hydration now has one source-of-truth decision: broker snapshot when available, persisted state only on broker-sync failure
- DataHub position state stays aligned after both startup hydration and later reconciliation

## Validation
- `python -m pytest tests/data/test_market_data_manager.py tests/core/test_position_hydration.py tests/test_initialize_components_polling.py`
- `python -m pytest tests/test_startup_sequence.py tests/core/test_core_app_imports.py`
