### PR TITLE
fix: unify off-market readiness and websocket idle handling

### DIFF
--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -37,7 +37,7 @@ from nifty_scalper_bot.streaming.websocket_manager import (
 from nifty_scalper_bot.utils.env import get_str
 from nifty_scalper_bot.utils.async_helpers import safe_task
 from nifty_scalper_bot.utils.logging import get_logger, get_tracer_logger, log_throttled
-from nifty_scalper_bot.utils.market_hours import is_market_hours_cached
+from nifty_scalper_bot.utils.market_hours import MarketState, get_market_state
 from nifty_scalper_bot.utils.metrics import Counter
 from nifty_scalper_bot.utils.symbols import enforce_canonical, normalize_symbol
 
@@ -2298,30 +2298,36 @@ class MarketDataManager:
                 return
             await asyncio.sleep(0.1)
 
-        is_market_hours = is_market_hours_cached()
-        if not is_market_hours:
-            self._logger.warning(
-                "Off-market -> bypassing readiness gate (historical data active)"
+        market_state = get_market_state()
+        if market_state != MarketState.OPEN:
+            self._logger.info(
+                "Readiness bypassed outside live market session "
+                "(state=%s, historical data active)",
+                market_state.value,
             )
             self.ready = True
-            self.degraded = True
+            self.degraded = False
             return
 
-        self._logger.warning(
-            "Entering DEGRADED mode due to insufficient live data "
-            "(timeout=%.1fs, min_bars=%d, bars=%s, hydration_complete=%s)",
-            timeout,
-            min_bars,
-            bars,
-            self.hydration_complete,
-        )
-        # Only arm DEGRADED once hydration has completed at least once.
-        # On a cold start that never received ticks we stay not-ready without
-        # falsely declaring the system degraded.
         if self.hydration_complete:
+            self._logger.warning(
+                "Entering DEGRADED mode due to insufficient live data "
+                "(timeout=%.1fs, min_bars=%d, bars=%s, hydration_complete=%s)",
+                timeout,
+                min_bars,
+                bars,
+                self.hydration_complete,
+            )
             self.ready = False
             self.degraded = True
         else:
+            self._logger.warning(
+                "Readiness timeout before hydration completed "
+                "(timeout=%.1fs, min_bars=%d, bars=%s)",
+                timeout,
+                min_bars,
+                bars,
+            )
             self.ready = False
             self.degraded = False
         return

--- a/src/nifty_scalper_bot/streaming/websocket_manager.py
+++ b/src/nifty_scalper_bot/streaming/websocket_manager.py
@@ -518,6 +518,14 @@ class WebSocketManager:
                     )
                     activity_age = now - last_activity
                     if activity_age > self._heartbeat_timeout:
+                        if not self._is_within_trading_window():
+                            self._logger.debug(
+                                "WS heartbeat idle outside trading window - suppressing reconnect "
+                                "age=%.2fs threshold=%.2fs",
+                                activity_age,
+                                self._heartbeat_timeout,
+                            )
+                            continue
                         self._logger.warning(
                             "Condition met: websocket_pong_timeout "
                             "age=%.2fs threshold=%.2fs",

--- a/src/nifty_scalper_bot/utils/market_hours.py
+++ b/src/nifty_scalper_bot/utils/market_hours.py
@@ -42,13 +42,20 @@ class MarketState(Enum):
     POSTMARKET = 'postmarket'
 
 
+def _override_enabled() -> bool:
+    return os.getenv("SESSION_ALLOW_OUT_OF_HOURS", "").lower() == "true"
+
+
+def _now_ist() -> datetime:
+    return datetime.now(IST)
+
+
 def get_market_state() -> MarketState:
     """Args: none; Returns: current market state; Raises: none."""
-    override = os.getenv('SESSION_ALLOW_OUT_OF_HOURS', '').lower()
-    if override == 'true':
+    if _override_enabled():
         return MarketState.OPEN
 
-    now = datetime.now(IST)
+    now = _now_ist()
     if now.weekday() >= 5:
         return MarketState.CLOSED
 
@@ -74,23 +81,20 @@ def is_market_hours(allow_override: bool = True) -> bool:
         True if trading is allowed, False otherwise
     """
     # Check environment override for testing
-    if allow_override:
-        override = os.getenv("SESSION_ALLOW_OUT_OF_HOURS", "").lower()
-        if override == "true":
-            return True
-    
-    now = datetime.now(IST).time()
+    if allow_override and _override_enabled():
+        return True
+
+    now_dt = _now_ist()
+    if now_dt.weekday() >= 5:
+        return False
+
+    now = now_dt.time()
     return SAFE_START <= now <= SAFE_END
 
 
 def is_market_open() -> bool:
     """Args: none; Returns: bool; Raises: none."""
-    now = datetime.now(IST)
-    if now.weekday() >= 5:
-        return False
-
-    current = now.time()
-    return MARKET_OPEN <= current <= MARKET_CLOSE
+    return get_market_state() == MarketState.OPEN
 
 
 def get_time_status() -> Tuple[bool, str]:
@@ -100,13 +104,15 @@ def get_time_status() -> Tuple[bool, str]:
     Returns:
         Tuple of (is_allowed, reason_string)
     """
-    # Check override first
-    override = os.getenv("SESSION_ALLOW_OUT_OF_HOURS", "").lower()
-    if override == "true":
+    if _override_enabled():
         return True, "Override enabled (SESSION_ALLOW_OUT_OF_HOURS=true)"
-    
-    now = datetime.now(IST).time()
-    
+
+    now_dt = _now_ist()
+    if now_dt.weekday() >= 5:
+        return False, f"Weekend closure ({now_dt.strftime('%A')})"
+
+    now = now_dt.time()
+
     if now < MARKET_OPEN:
         return False, f"Pre-market ({now.strftime('%H:%M')} < {MARKET_OPEN.strftime('%H:%M')})"
     
@@ -124,12 +130,12 @@ def get_time_status() -> Tuple[bool, str]:
 
 def get_current_ist_time() -> datetime:
     """Get current time in IST."""
-    return datetime.now(IST)
+    return _now_ist()
 
 
 def format_time_for_log() -> str:
     """Get formatted time string for logging."""
-    return datetime.now(IST).strftime("%H:%M:%S IST")
+    return _now_ist().strftime("%H:%M:%S IST")
 
 
 # Cached version for high-frequency calls (1 second cache)

--- a/tests/data/test_market_data_manager.py
+++ b/tests/data/test_market_data_manager.py
@@ -10,6 +10,7 @@ import pytest
 
 from nifty_scalper_bot.data.market_data_manager import MarketDataManager
 from nifty_scalper_bot.streaming.websocket_manager import ConnectionState
+from nifty_scalper_bot.utils.market_hours import MarketState
 
 
 class DummyBroker:
@@ -501,10 +502,11 @@ async def test_wait_until_ready_enters_degraded_during_market_hours(
     manager = MarketDataManager(broker, ws, cache_len=5)
     manager._min_required_bars = 2
     manager._active_subscribed_symbols = {"NSE:NIFTY23"}
+    manager.hydration_complete = True
 
     with patch(
-        "nifty_scalper_bot.data.market_data_manager.is_market_hours_cached",
-        return_value=True,
+        "nifty_scalper_bot.data.market_data_manager.get_market_state",
+        return_value=MarketState.OPEN,
     ):
         await manager.wait_until_ready(timeout=0.1)
 
@@ -522,17 +524,35 @@ async def test_wait_until_ready_bypasses_off_market(
     manager._history["NSE:NIFTY23"].append({"ltp": 100.0, "timestamp": time.time()})
 
     with patch(
-        "nifty_scalper_bot.data.market_data_manager.is_market_hours_cached",
-        return_value=False,
+        "nifty_scalper_bot.data.market_data_manager.get_market_state",
+        return_value=MarketState.CLOSED,
     ):
         await manager.wait_until_ready(timeout=0.1)
 
     assert manager.ready is True
-    assert manager.degraded is True
+    assert manager.degraded is False
 
     manager._history["NSE:NIFTY23"].append({"ltp": 101.0, "timestamp": time.time()})
     await manager.wait_until_ready(timeout=0.2)
     assert manager.ready is True
+    assert manager.degraded is False
+
+
+@pytest.mark.asyncio
+async def test_wait_until_ready_stays_not_degraded_before_first_hydration(
+    broker: DummyBroker, ws: DummyWebSocket
+) -> None:
+    manager = MarketDataManager(broker, ws, cache_len=5)
+    manager._min_required_bars = 2
+    manager._active_subscribed_symbols = {"NSE:NIFTY23"}
+
+    with patch(
+        "nifty_scalper_bot.data.market_data_manager.get_market_state",
+        return_value=MarketState.OPEN,
+    ):
+        await manager.wait_until_ready(timeout=0.1)
+
+    assert manager.ready is False
     assert manager.degraded is False
 
 

--- a/tests/streaming/test_websocket_manager.py
+++ b/tests/streaming/test_websocket_manager.py
@@ -136,6 +136,30 @@ async def test_watchdog_schedules_reconnect_for_missing_pong(
 
 
 @pytest.mark.asyncio
+async def test_watchdog_suppresses_pong_reconnect_outside_trading_window(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(ws_module, "KiteTicker", FakeKiteTicker)
+
+    manager = ws_module.WebSocketManager(
+        "k",
+        "t",
+        heartbeat_interval_seconds=0.01,
+        heartbeat_timeout_seconds=0.03,
+    )
+    manager._is_within_trading_window = lambda: False  # type: ignore[method-assign]
+    await manager.connect()
+
+    fake_ticker = manager.ticker
+    assert isinstance(fake_ticker, FakeKiteTicker)
+    await asyncio.sleep(0.12)
+
+    assert manager.ticker is fake_ticker
+    assert fake_ticker.connect_calls == 1
+    await manager.disconnect()
+
+
+@pytest.mark.asyncio
 async def test_circuit_breaker_opens_after_repeated_failures(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/utils/test_market_hours_cache.py
+++ b/tests/utils/test_market_hours_cache.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+from datetime import datetime
 
 from nifty_scalper_bot.utils import market_hours
 
@@ -23,3 +24,18 @@ def test_market_hours_cached_respects_runtime_override(monkeypatch) -> None:
     assert market_hours.is_market_hours_cached() is True
 
     market_hours._cached_market_hours_check.cache_clear()
+
+
+def test_market_hours_blocks_weekend_even_inside_safe_clock(
+    monkeypatch,
+) -> None:
+    class _SundayClock(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return cls(2026, 4, 19, 11, 53, tzinfo=tz)
+
+    monkeypatch.setattr(market_hours, "datetime", _SundayClock)
+    market_hours._cached_market_hours_check.cache_clear()
+
+    assert market_hours.is_market_hours() is False
+    assert market_hours.is_market_hours_cached() is False


### PR DESCRIPTION
## Summary
- unify off-market session detection so readiness, startup hydration, and websocket transport stop disagreeing about whether live data is required
- suppress websocket pong-timeout reconnect churn outside the trading window
- fix weekend handling in market-hours helpers and add regression coverage for weekend/off-market startup paths

## Root causes fixed
- `is_market_hours()` only checked the clock and ignored weekends, so a Sunday 11:53 IST startup was treated as a live session
- `MarketDataManager.wait_until_ready()` used that helper and logged `Entering DEGRADED mode...` even when `hydration_complete=False`, producing a false degraded diagnosis on cold start
- `WebSocketManager` treated off-hours idle sockets like in-session dead sockets and scheduled reconnects on pong timeout even when no live feed was expected

## Functional impact
- off-market startup now bypasses live-readiness cleanly without marking the bot degraded
- in-market timeouts still degrade only after hydration has completed at least once
- off-hours websocket sessions no longer churn or spam timeout logs while the market is closed

## Validation
- `python -m pytest tests/utils/test_market_hours_cache.py tests/streaming/test_websocket_manager.py tests/data/test_market_data_manager.py`
- `python -m pytest tests/test_startup_sequence.py tests/test_main_degraded_mode.py tests/test_initialize_components_polling.py tests/data/test_market_data_manager.py tests/data/test_data_hub.py tests/data/test_event_bus_tick_pipeline.py tests/execution/test_full_pipeline.py tests/streaming/test_stream_supervisor.py tests/streaming/test_polling_streamer.py tests/strategies/test_strategy_runner_datahub.py tests/test_unified_manager_features.py`
- `python -m pytest tests/core/test_position_hydration.py tests/execution/test_order_execution_hub.py tests/execution/test_order_executor_readiness.py tests/execution/test_post_fill_monitor_sync_positions.py tests/risk/test_risk_rejection_codes.py`