### PR TITLE
fix: canonicalize Nifty spot market-data flow

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -42,6 +42,10 @@ from nifty_scalper_bot.data.market_regime import MarketRegimeDetector
 from nifty_scalper_bot.data.persistent_state import PersistentStateManager
 from nifty_scalper_bot.data.rest.zerodha_client import ZerodhaKiteClient
 from nifty_scalper_bot.data.rest.zerodha_ws_adapter import build_kite_ticker
+from nifty_scalper_bot.data.symbols import (
+    NIFTY_SPOT_CANONICAL_SYMBOL,
+    canonicalize_market_symbol,
+)
 from nifty_scalper_bot.data.websocket.manager import WebSocketManager
 from nifty_scalper_bot.execution.bracket_manager import (
     BracketManager,
@@ -1587,13 +1591,17 @@ def initialize_components(settings: Settings | None = None) -> BotContext:
         default=True,
     )
     # Normalize symbols (quotes tolerated) and default fallback
+    trade_symbol = canonicalize_market_symbol(
+        coalesce_str("INSTRUMENTS__TRADE_SYMBOL", default="NIFTY")
+    )
     raw_syms = get_csv("POLLING__SYMBOLS")
     if raw_syms:
-        poll_symbols = [s.strip().upper() for s in raw_syms if s.strip()]
+        poll_symbols = [
+            canonicalize_market_symbol(s) for s in raw_syms if str(s).strip()
+        ]
     else:
-        trade_symbol = coalesce_str("INSTRUMENTS__TRADE_SYMBOL", default="NIFTY")
         poll_symbols = (
-            [trade_symbol.strip().upper()] if trade_symbol.strip() else ["NIFTY"]
+            [trade_symbol] if trade_symbol.strip() else [NIFTY_SPOT_CANONICAL_SYMBOL]
         )
 
     instrument_resolver = InstrumentResolver(broker_client)
@@ -1736,7 +1744,7 @@ def initialize_components(settings: Settings | None = None) -> BotContext:
         stream_supervisor = StreamSupervisor(
             streamer=streamer,
             resolver=instrument_resolver,
-            default_symbols=list(poll_symbols or ["NIFTY"]),
+            default_symbols=list(poll_symbols or [NIFTY_SPOT_CANONICAL_SYMBOL]),
             autostart=True,
         )
         stream_supervisor.bootstrap()
@@ -1855,7 +1863,7 @@ def initialize_components(settings: Settings | None = None) -> BotContext:
     ):
         os.environ.setdefault(env_key, env_default)
 
-    regime_symbol = "NIFTY"
+    regime_symbol = NIFTY_SPOT_CANONICAL_SYMBOL
     if poll_symbols:
         regime_symbol = poll_symbols[0]
 
@@ -2192,7 +2200,7 @@ def initialize_components(settings: Settings | None = None) -> BotContext:
         risk_symbol = coalesce_str(
             "RISK_STATE_SYMBOL",
             "RISK_STATE__SYMBOL",
-            default=trade_symbol or "NIFTY",
+            default=trade_symbol or NIFTY_SPOT_CANONICAL_SYMBOL,
         )
         attach = getattr(risk_state, "attach_data_hub", None)
         if callable(attach):
@@ -2506,13 +2514,6 @@ def initialize_components(settings: Settings | None = None) -> BotContext:
     background_tasks: list[asyncio.Task[Any]] = []
     try:
         background_tasks = start_background_tasks(order_manager, LOGGER)
-        LOGGER.info(
-            "Background tasks started",
-            extra={
-                "event": "background_tasks.started",
-                "count": len(background_tasks),
-            },
-        )
     except Exception as exc:  # noqa: BLE001
         LOGGER.error(
             "Failed to start background tasks",
@@ -3324,6 +3325,7 @@ def initialize_components(settings: Settings | None = None) -> BotContext:
                 get_ws_token=_resolve_ws_token,
                 get_ws_token_issued_at=_ws_token_issued_at,
                 ws_host=ws_host,
+                spot_symbol=trade_symbol or NIFTY_SPOT_CANONICAL_SYMBOL,
                 set_shadow_mode=set_shadow,
                 get_shadow_mode=get_shadow,
                 paper_mode_getters=paper_mode_getters or None,
@@ -3353,10 +3355,6 @@ def initialize_components(settings: Settings | None = None) -> BotContext:
                 else:
                     ctx.telegram_application = application
                     controller.attach_application(application)
-                    LOGGER.info(
-                        "telegram_application_attached",
-                        extra={"event": "telegram_application_attached"},
-                    )
                     version_info = {
                         "build": str(getattr(config, "version", "unknown")),
                         "sha": str(getattr(settings, "git_sha", "unknown")),

--- a/src/nifty_scalper_bot/data/data_hub.py
+++ b/src/nifty_scalper_bot/data/data_hub.py
@@ -9,6 +9,10 @@ from threading import RLock
 import time
 from typing import Any, Callable, Iterable, Mapping, Optional, TypedDict, cast
 
+from nifty_scalper_bot.data.symbols import (
+    NIFTY_SPOT_CANONICAL_SYMBOL,
+    normalize_hub_symbol,
+)
 from nifty_scalper_bot.storage.hub_store import HubStore, WalEntry
 from nifty_scalper_bot.utils.logging import get_logger
 from nifty_scalper_bot.utils.options_math import (
@@ -114,7 +118,7 @@ class DataHub:
         self._last_snapshot_ts = 0.0
         self._option_chain_cache: dict[str, tuple[float, list[dict[str, Any]]]] = {}
         self._option_chain_ttl = 5.0
-        self._spot_symbol = "NIFTY"
+        self._spot_symbol = NIFTY_SPOT_CANONICAL_SYMBOL
         self._risk_free_rate = 0.06
 
         error_cooldown = self._parse_env_float("TICK_ERROR_LOG_COOLDOWN_SEC")
@@ -171,19 +175,18 @@ class DataHub:
     def normalize(sym: Any) -> str:
         """Normalise trading symbol with prefix trimming."""
 
-        if sym is None:
-            return ""
-        text = str(sym).strip().upper()
-        if ":" in text:
-            text = text.split(":", 1)[-1].strip()
-        return text
+        return normalize_hub_symbol(sym)
 
     def _allow(self, symbol: str) -> bool:
         if not symbol:
             return False
         if not self._options_only:
             return True
-        return symbol.endswith("CE") or symbol.endswith("PE") or symbol == "NIFTY"
+        return (
+            symbol.endswith("CE")
+            or symbol.endswith("PE")
+            or symbol == NIFTY_SPOT_CANONICAL_SYMBOL
+        )
 
     def reset_warmup(self) -> None:
         """Restart the warm-up grace period for stale tick evaluation."""

--- a/src/nifty_scalper_bot/data/instruments.py
+++ b/src/nifty_scalper_bot/data/instruments.py
@@ -7,6 +7,11 @@ from math import ceil, floor
 import os
 from typing import Any, Iterable
 
+from nifty_scalper_bot.data.symbols import (
+    NIFTY_SPOT_CANONICAL_SYMBOL,
+    NIFTY_SPOT_CANONICAL_TRADINGSYMBOL,
+    NIFTY_SPOT_TOKEN,
+)
 from nifty_scalper_bot.utils.errors import BrokerError
 from nifty_scalper_bot.utils.logging import get_logger
 from nifty_scalper_bot.utils.options_math import black_scholes_greeks
@@ -16,13 +21,13 @@ log = get_logger(__name__)
 # Common index tokens (Zerodha). Keep here as fallbacks.
 WELL_KNOWN = {
     # NSE Index tokens
-    "NIFTY": 256265,  # NIFTY 50 spot
+    "NIFTY": NIFTY_SPOT_TOKEN,  # NIFTY 50 spot
     # Robust aliases people often use
-    "NIFTY50": 256265,
-    "NIFTY-50": 256265,
-    "NSE:NIFTY": 256265,
-    "NSE:NIFTY 50": 256265,
-    "NIFTY 50": 256265,
+    "NIFTY50": NIFTY_SPOT_TOKEN,
+    "NIFTY-50": NIFTY_SPOT_TOKEN,
+    "NSE:NIFTY": NIFTY_SPOT_TOKEN,
+    NIFTY_SPOT_CANONICAL_SYMBOL: NIFTY_SPOT_TOKEN,
+    NIFTY_SPOT_CANONICAL_TRADINGSYMBOL: NIFTY_SPOT_TOKEN,
     "BANKNIFTY": 260105,  # NIFTY BANK spot
     "NIFTY BANK": 260105,
     "FINNIFTY": 257801,  # NIFTY FIN SERVICE spot
@@ -31,7 +36,7 @@ WELL_KNOWN = {
 
 # Canonical trading symbols used when formatting tokens for REST calls.
 CANONICAL_TOKENS: dict[int, str] = {
-    256265: "NIFTY 50",
+    NIFTY_SPOT_TOKEN: NIFTY_SPOT_CANONICAL_TRADINGSYMBOL,
     260105: "NIFTY BANK",
     257801: "NIFTY FIN SERVICE",
     288009: "NIFTY MIDCAP SELECT",

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -15,6 +15,7 @@ from typing import Any, Callable, Deque, Iterable, Mapping, Sequence, cast
 
 from nifty_scalper_bot.config.settings import get_settings
 from nifty_scalper_bot.data.resolver import InstrumentResolver
+from nifty_scalper_bot.data.symbols import canonicalize_market_symbol
 from nifty_scalper_bot.data.websocket.manager import ConnectionState, WebSocketManager
 from nifty_scalper_bot.infra.metrics import METRICS
 from nifty_scalper_bot.utils.env import get_str
@@ -796,6 +797,9 @@ class MarketDataManager:
     def subscribe(self, symbol: str, callback: TickCallback) -> None:
         """Subscribe *callback* to receive normalized ticks for *symbol*."""
 
+        symbol = canonicalize_market_symbol(symbol)
+        if not symbol:
+            return
         with self._lock:
             subscribers = self._subscribers[symbol]
             subscribers.add(callback)
@@ -849,6 +853,9 @@ class MarketDataManager:
     def unsubscribe(self, symbol: str, callback: TickCallback) -> None:
         """Remove *callback* from subscribers of *symbol*."""
 
+        symbol = canonicalize_market_symbol(symbol)
+        if not symbol:
+            return
         should_unsubscribe = False
         with self._lock:
             callbacks = self._subscribers.get(symbol)
@@ -863,11 +870,17 @@ class MarketDataManager:
             self._release_subscription(symbol)
 
     def get_latest_tick(self, symbol: str) -> dict[str, Any] | None:
+        symbol = canonicalize_market_symbol(symbol)
+        if not symbol:
+            return None
         with self._lock:
             tick = self._latest_ticks.get(symbol)
             return None if tick is None else dict(tick)
 
     def get_latest_price(self, symbol: str) -> float | None:
+        symbol = canonicalize_market_symbol(symbol)
+        if not symbol:
+            return None
         tick = self.get_latest_tick(symbol)
         if tick is None:
             return None
@@ -877,16 +890,13 @@ class MarketDataManager:
             return None
 
     def _resolve_underlying_price(self, symbol: str) -> float | None:
+        symbol = canonicalize_market_symbol(symbol)
+        if not symbol:
+            return None
         tick_price = self.get_latest_price(symbol)
         if tick_price is not None:
             return tick_price
-        broker = getattr(self, "_broker", None)
-        if broker is None or not hasattr(broker, "get_quote"):
-            return None
-        try:
-            quote = broker.get_quote(symbol)
-        except Exception:  # noqa: BLE001
-            return None
+        quote = self.pull_quote(symbol)
         if isinstance(quote, Mapping):
             price_value = _coerce_float(
                 quote.get("ltp")
@@ -945,6 +955,9 @@ class MarketDataManager:
         return results
 
     def get_tick_history(self, symbol: str) -> list[dict[str, Any]]:
+        symbol = canonicalize_market_symbol(symbol)
+        if not symbol:
+            return []
         with self._lock:
             history = self._history.get(symbol)
             if history is None:
@@ -977,6 +990,9 @@ class MarketDataManager:
             timeout elapsed, ``False`` otherwise.
         """
 
+        symbol = canonicalize_market_symbol(symbol)
+        if not symbol:
+            return False
         if self.get_latest_tick(symbol) is not None:
             return True
 
@@ -993,9 +1009,27 @@ class MarketDataManager:
 
         return False
 
-    def pull_quote(self, symbol: str) -> dict[str, Any]:
-        quote = self._broker.get_quote(symbol)
+    def pull_quote(
+        self, symbol: str, *, trace_id: str | None = None
+    ) -> dict[str, Any]:
+        symbol = canonicalize_market_symbol(symbol)
+        if not symbol:
+            return {"symbol": ""}
+        quote: dict[str, Any] | None = None
+        for key in self._candidate_quote_keys(symbol):
+            payload = self._broker_quote_any(key)
+            if payload:
+                quote = payload
+                break
         if not isinstance(quote, dict):
+            self._logger.error(
+                "pull_quote_failed",
+                extra={
+                    "event": "mdm_pull_quote_failed",
+                    "symbol": symbol,
+                    "trace_id": trace_id,
+                },
+            )
             return {"symbol": symbol}
         quote = self._prepare_rest_tick(quote, source="rest")
         with self._lock:
@@ -1003,6 +1037,13 @@ class MarketDataManager:
 
         normalized = self._normalize_tick(symbol, quote, previous)
         if normalized is not None:
+            now_ms = self._now_ms()
+            bid = _coerce_float(normalized.get("bid"))
+            ask = _coerce_float(normalized.get("ask"))
+            with self._lock:
+                self._last_quote_ts_ms[symbol] = now_ms
+                if bid is not None and ask is not None and bid > 0 and ask > 0:
+                    self._last_mid[symbol] = ((bid + ask) / 2.0, now_ms)
             if not self._is_duplicate(symbol, normalized):
                 self._emit_tick(symbol, normalized, source="rest")
             else:
@@ -1464,6 +1505,9 @@ class MarketDataManager:
     # ------------------------------------------------------------------
     # Internal plumbing
     def _seed_mapping(self, symbol: str, token: int | None) -> None:
+        symbol = canonicalize_market_symbol(symbol)
+        if not symbol:
+            return
         if token is None:
             return
         try:
@@ -1494,6 +1538,7 @@ class MarketDataManager:
         if not symbol:
             self._logger.debug("Dropping tick without symbol", extra={"raw": tick})
             return
+        symbol = canonicalize_market_symbol(symbol)
 
         raw_ltp = tick.get("last_price")
         if raw_ltp is None:
@@ -1695,6 +1740,11 @@ class MarketDataManager:
             candidates = list(self._subscribers.keys())
             if not candidates:
                 candidates = list(self._latest_ticks.keys())
+        candidates = [
+            symbol
+            for symbol in map(canonicalize_market_symbol, candidates)
+            if symbol
+        ]
         limit = self._rest_poll_max_symbols
         if limit > 0 and len(candidates) > limit:
             candidates = candidates[:limit]
@@ -1716,6 +1766,9 @@ class MarketDataManager:
             None.
         """
 
+        symbol = canonicalize_market_symbol(symbol)
+        if not symbol:
+            return None
         self._logger.debug(
             "Entered get_quote",
             extra={"event": "mdm_get_quote_enter", "symbol": symbol},
@@ -1756,7 +1809,7 @@ class MarketDataManager:
                 "levels": levels,
             },
         )
-        normalized = (symbol or "").strip().upper()
+        normalized = canonicalize_market_symbol(symbol)
         if not normalized:
             self._logger.info(
                 "Condition met: get_orderbook_missing_symbol",
@@ -1857,7 +1910,7 @@ class MarketDataManager:
         """
 
         symbols: list[str | int] = []
-        normalized = (symbol or "").strip().upper()
+        normalized = canonicalize_market_symbol(symbol)
         if not normalized:
             return symbols
         symbols.append(normalized)
@@ -1880,8 +1933,11 @@ class MarketDataManager:
                     exchange = str(meta.get("exchange") or "NFO").upper()
                     token = meta.get("instrument_token")
                     if tradingsymbol:
-                        symbols.append(tradingsymbol)
-                        symbols.append(f"{exchange}:{tradingsymbol}")
+                        exchange_symbol = canonicalize_market_symbol(
+                            f"{exchange}:{tradingsymbol}"
+                        )
+                        if exchange_symbol and exchange_symbol != normalized:
+                            symbols.append(exchange_symbol)
                     if token is not None:
                         try:
                             symbols.append(int(token))
@@ -1922,7 +1978,7 @@ class MarketDataManager:
                 else:
                     return None
             else:
-                quote = broker.get_quote(key)
+                quote = broker.get_quote(canonicalize_market_symbol(key))
         except Exception as exc:  # noqa: BLE001
             self._logger.debug(
                 "Failure in _broker_quote_any: %s",
@@ -1958,49 +2014,8 @@ class MarketDataManager:
                 "trace_id": trace_id,
             },
         )
-        candidates = self._candidate_quote_keys(symbol)
-        _logger.info(
-            "reference_price_refresh",
-            extra={
-                "symbol": symbol,
-                "age_ms": self.quote_age_ms(symbol) if symbol else None,
-                "trace_id": trace_id,
-            },
-        )
-        for key in candidates:
-            quote = self._broker_quote_any(key)
-            _logger.info(
-                "refresh_attempt",
-                extra={
-                    "symbol": symbol,
-                    "key": key,
-                    "ok": bool(quote),
-                    "trace_id": trace_id,
-                },
-            )
-            if not quote:
-                continue
-            now_ms = self._now_ms()
-            bid = _coerce_float(quote.get("bid"))
-            ask = _coerce_float(quote.get("ask"))
-            mid: float | None = None
-            if bid is not None and ask is not None:
-                mid = (bid + ask) / 2.0
-            with self._lock:
-                self._latest_ticks[symbol] = dict(quote)
-                self._last_quote_ts_ms[symbol] = now_ms
-                if mid is not None:
-                    self._last_mid[symbol] = (mid, now_ms)
-            return dict(quote)
-        self._logger.error(
-            "refresh_quote_failed_all_candidates",
-            extra={
-                "symbol": symbol,
-                "candidates": candidates,
-                "trace_id": trace_id,
-            },
-        )
-        return None
+        quote = self.pull_quote(symbol, trace_id=trace_id)
+        return quote if quote.get("ltp") is not None else None
 
     def has_quote(self, symbol: str) -> bool:
         """Return whether cached quote data appears usable.
@@ -2015,6 +2030,7 @@ class MarketDataManager:
             None.
         """
 
+        symbol = canonicalize_market_symbol(symbol)
         quote = self.get_quote(symbol)
         if not isinstance(quote, Mapping):
             return False
@@ -2036,6 +2052,9 @@ class MarketDataManager:
             None.
         """
 
+        symbol = canonicalize_market_symbol(symbol)
+        if not symbol:
+            return 1_000_000_000
         self._logger.debug(
             "Entered quote_age_ms",
             extra={"event": "mdm_quote_age_enter", "symbol": symbol},
@@ -2073,6 +2092,9 @@ class MarketDataManager:
             None.
         """
 
+        symbol = canonicalize_market_symbol(symbol)
+        if not symbol:
+            return None, None
         self._logger.debug(
             "Entered cached_mid",
             extra={"event": "mdm_cached_mid_enter", "symbol": symbol},
@@ -2120,18 +2142,7 @@ class MarketDataManager:
         return max(interval, 0.01)
 
     def _poll_symbol(self, symbol: str) -> None:
-        quote = self._broker.get_quote(symbol)
-        if not isinstance(quote, dict):
-            return
-        quote = self._prepare_rest_tick(quote, source="rest")
-        with self._lock:
-            previous = self._latest_ticks.get(symbol)
-        normalized = self._normalize_tick(symbol, quote, previous)
-        if normalized is None:
-            return
-        if self._is_duplicate(symbol, normalized):
-            return
-        self._emit_tick(symbol, normalized, source="rest")
+        self.pull_quote(symbol)
 
     def _has_recent_rest_ticks(self) -> bool:
         cutoff = time.time() - max(self._rest_poll_interval * 2.0, 5.0)
@@ -2163,6 +2174,9 @@ class MarketDataManager:
         return max(value, minimum)
 
     def _ensure_subscription(self, symbol: str) -> None:
+        symbol = canonicalize_market_symbol(symbol)
+        if not symbol:
+            return
         if self._ws is None:
             return
         try:
@@ -2191,6 +2205,9 @@ class MarketDataManager:
             )
 
     def _release_subscription(self, symbol: str) -> None:
+        symbol = canonicalize_market_symbol(symbol)
+        if not symbol:
+            return
         if self._ws is None:
             return
         token = self._token_by_symbol.get(symbol)
@@ -2205,6 +2222,9 @@ class MarketDataManager:
             )
 
     def _resolve_token(self, symbol: str) -> int | None:
+        symbol = canonicalize_market_symbol(symbol)
+        if not symbol:
+            return None
         try:
             if hasattr(self._broker, "get_instrument_token"):
                 instrument_token = self._broker.get_instrument_token(symbol)
@@ -2241,7 +2261,7 @@ class MarketDataManager:
         for key in ("symbol", "tradingsymbol", "instrument"):
             value = tick.get(key)
             if isinstance(value, str) and value:
-                return value
+                return canonicalize_market_symbol(value)
         return None
 
     def _normalize_tick(

--- a/src/nifty_scalper_bot/data/resolver.py
+++ b/src/nifty_scalper_bot/data/resolver.py
@@ -1,28 +1,7 @@
-"""Resolver façade for instrument metadata lookups."""
+"""Resolver facade for instrument metadata lookups."""
 
 from __future__ import annotations
 
 from nifty_scalper_bot.data.instruments import InstrumentResolver
-
-# --- injected: retry helper for network calls (idempotent insertion) ----------
-import random
-import threading
-
-def _with_retries(fn, *, retries: int = 3, backoff: float = 0.2, max_backoff: float = 5.0):
-    """
-    Call fn() with retries. fn may raise; retries uses exponential backoff with jitter.
-    Returns fn() result or raises last exception.
-    """
-    last_exc = None
-    for attempt in range(1, retries + 1):
-        try:
-            return fn()
-        except Exception as exc:  # pragma: no cover - network error paths
-            last_exc = exc
-            sleep = min(max_backoff, backoff * (2 ** (attempt - 1))) * (0.5 + random.random() * 0.5)
-            time.sleep(sleep)
-    # final raise
-    raise last_exc
-# --- end injected helper ---------------------------------------------------
 
 __all__ = ["InstrumentResolver"]

--- a/src/nifty_scalper_bot/data/symbols.py
+++ b/src/nifty_scalper_bot/data/symbols.py
@@ -1,0 +1,60 @@
+"""Shared symbol canonicalization helpers for market-data paths."""
+
+from __future__ import annotations
+
+from typing import Any
+
+NIFTY_SPOT_TOKEN = 256265
+NIFTY_SPOT_CANONICAL_SYMBOL = "NSE:NIFTY 50"
+NIFTY_SPOT_CANONICAL_TRADINGSYMBOL = "NIFTY 50"
+
+_NIFTY_SPOT_ALIASES = frozenset(
+    {
+        "NIFTY",
+        "NIFTY 50",
+        "NIFTY50",
+        "NIFTY-50",
+        "NSE:NIFTY",
+        "NSE:NIFTY 50",
+    }
+)
+
+
+def canonicalize_market_symbol(symbol: Any) -> str:
+    """Return the canonical broker-facing symbol for market data operations."""
+
+    if symbol is None:
+        return ""
+    normalized = str(symbol).strip().upper()
+    if not normalized:
+        return ""
+    if normalized in _NIFTY_SPOT_ALIASES:
+        return NIFTY_SPOT_CANONICAL_SYMBOL
+    return normalized
+
+
+def normalize_hub_symbol(symbol: Any) -> str:
+    """Return the canonical cache key used by :class:`DataHub`."""
+
+    normalized = canonicalize_market_symbol(symbol)
+    if normalized == NIFTY_SPOT_CANONICAL_SYMBOL:
+        return normalized
+    if ":" in normalized:
+        return normalized.split(":", 1)[-1].strip()
+    return normalized
+
+
+def is_nifty_spot_symbol(symbol: Any) -> bool:
+    """Return ``True`` when *symbol* refers to the Nifty spot index."""
+
+    return canonicalize_market_symbol(symbol) == NIFTY_SPOT_CANONICAL_SYMBOL
+
+
+__all__ = [
+    "NIFTY_SPOT_CANONICAL_SYMBOL",
+    "NIFTY_SPOT_CANONICAL_TRADINGSYMBOL",
+    "NIFTY_SPOT_TOKEN",
+    "canonicalize_market_symbol",
+    "is_nifty_spot_symbol",
+    "normalize_hub_symbol",
+]

--- a/src/nifty_scalper_bot/data/websocket/manager.py
+++ b/src/nifty_scalper_bot/data/websocket/manager.py
@@ -570,17 +570,29 @@ class WebSocketManager:
             if not new_tokens:
                 return
             self._subscription_tokens.update(new_tokens)
+            active_tokens = len(self._subscription_tokens)
 
             if state != ConnectionState.CONNECTED:
-                self._logger.debug(
-                    "Deferring WS subscribe until connected",
-                    extra={"tokens": new_tokens, "mode": mode, "state": state.value},
+                self._logger.info(
+                    "WebSocket subscription queued",
+                    extra={
+                        "event": "ws_subscription_queued",
+                        "queued_tokens": len(new_tokens),
+                        "active_tokens": active_tokens,
+                        "mode": mode,
+                        "state": state.value,
+                    },
                 )
                 return
 
-            self._logger.debug(
-                "Subscribing websocket tokens",
-                extra={"tokens": new_tokens, "mode": mode},
+            self._logger.info(
+                "WebSocket subscribed",
+                extra={
+                    "event": "ws_subscription_updated",
+                    "added_tokens": len(new_tokens),
+                    "active_tokens": active_tokens,
+                    "mode": mode,
+                },
             )
             if getattr(self._client, "subscribe", None) is not None:
                 self._client.subscribe(list(new_tokens))
@@ -602,11 +614,20 @@ class WebSocketManager:
             )
             for token in to_remove:
                 self._subscription_tokens.discard(token)
+            active_tokens = len(self._subscription_tokens)
             if (
                 self._client_is_connected()
                 and getattr(self._client, "unsubscribe", None) is not None
             ):
                 self._client.unsubscribe(list(to_remove))
+        self._logger.info(
+            "WebSocket unsubscribed",
+            extra={
+                "event": "ws_unsubscription_updated",
+                "removed_tokens": len(to_remove),
+                "active_tokens": active_tokens,
+            },
+        )
 
     def connection_state(self) -> ConnectionState:
         """Return the current websocket connection state."""
@@ -692,7 +713,8 @@ class WebSocketManager:
                     extra={
                         "event": "ws_subs_flushed",
                         "mode": mode,
-                        "count": total,
+                        "resubscribed_tokens": total,
+                        "active_tokens": len(self._subscription_tokens),
                     },
                 )
 

--- a/src/nifty_scalper_bot/infra/scheduled_tasks.py
+++ b/src/nifty_scalper_bot/infra/scheduled_tasks.py
@@ -148,8 +148,8 @@ def start_background_tasks(order_manager: Any, logger: Any) -> list[asyncio.Task
     )
 
     logger.info(
-        "Background tasks started",
-        extra={"event": "tasks.started", "count": len(tasks)},
+        "Scheduled maintenance tasks started",
+        extra={"event": "scheduled_tasks.started", "count": len(tasks)},
     )
 
     return tasks

--- a/src/nifty_scalper_bot/notifications/telegram_controller.py
+++ b/src/nifty_scalper_bot/notifications/telegram_controller.py
@@ -84,6 +84,7 @@ from nifty_scalper_bot.core.performance_metrics import build_performance_snapsho
 from nifty_scalper_bot.core.trading_switch import trading_switch
 from nifty_scalper_bot.data.assess_data import assess_datahub_fresh
 from nifty_scalper_bot.data.data_hub import DataHub
+from nifty_scalper_bot.data.symbols import NIFTY_SPOT_CANONICAL_SYMBOL
 from nifty_scalper_bot.diagnostics.assess import assess_suite
 from nifty_scalper_bot.infra.diagnostics import LOG_TAP
 from nifty_scalper_bot.infra.metrics import METRICS, MetricsCollector
@@ -409,6 +410,7 @@ class TelegramDeps:
     get_ws_token: t.Callable[[], str] | None = None
     get_ws_token_issued_at: t.Callable[[], float | None] | None = None
     ws_host: str | None = None
+    spot_symbol: str | None = None
     # Shadow mode toggler (optional): Callable[[bool], bool] | None
     set_shadow_mode: t.Callable[[bool], bool] | None = None
     get_shadow_mode: t.Callable[[], bool] | None = None
@@ -3492,7 +3494,7 @@ class TelegramBot:
             spot_symbol = getattr(self.deps, "spot_symbol", None)
             if spot_symbol:
                 return str(spot_symbol)
-        return "NIFTY"
+        return NIFTY_SPOT_CANONICAL_SYMBOL
 
     def _poll_interval_seconds(self) -> float:
         """Return the polling interval used for adaptive freshness bounds."""

--- a/src/nifty_scalper_bot/notifications/telegram_webhook_enhanced.py
+++ b/src/nifty_scalper_bot/notifications/telegram_webhook_enhanced.py
@@ -437,7 +437,7 @@ class TelegramWebhookController:
         self._application_ready.clear()
         self.logger.info(
             "telegram_application_attached",
-            extra={"event": "application_attached"},
+            extra={"event": "telegram_application_attached"},
         )
 
     def is_polling_active(self) -> bool:

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -24,6 +24,7 @@ from typing import (
 
 from nifty_scalper_bot.core.strategy_manager import StrategyManager
 from nifty_scalper_bot.data.market_data_manager import MarketDataManager
+from nifty_scalper_bot.data.symbols import canonicalize_market_symbol
 from nifty_scalper_bot.execution.order_manager import ExitIntent, OrderType
 from nifty_scalper_bot.execution.position_manager import OrderSide, PositionManager
 from nifty_scalper_bot.options.strike_selector import SelectedContract, StrikeSelector
@@ -1798,7 +1799,7 @@ class StrategyRunner:
 
     @staticmethod
     def _normalize_symbol(symbol: str) -> str:
-        normalized = symbol.strip().upper()
+        normalized = canonicalize_market_symbol(symbol)
         if not normalized:
             msg = "symbol must not be empty"
             raise ValueError(msg)

--- a/src/nifty_scalper_bot/streaming/stream_supervisor.py
+++ b/src/nifty_scalper_bot/streaming/stream_supervisor.py
@@ -8,6 +8,7 @@ import threading
 import time
 from typing import Any, Iterable, Sequence
 
+from nifty_scalper_bot.data.symbols import NIFTY_SPOT_CANONICAL_SYMBOL
 from nifty_scalper_bot.utils.logging import get_logger
 
 LOG = get_logger(__name__)
@@ -80,7 +81,7 @@ class StreamSupervisor:
     def bootstrap(self) -> None:
         """Subscribe default symbols and start the poller if configured."""
 
-        symbols = list(self._default_symbols) or ["NIFTY"]
+        symbols = list(self._default_symbols) or [NIFTY_SPOT_CANONICAL_SYMBOL]
         self.subscribe_symbols(symbols)
         if self._autostart:
             self.ensure_started()

--- a/tests/data/test_data_hub.py
+++ b/tests/data/test_data_hub.py
@@ -6,6 +6,7 @@ from typing import Any, Callable
 import pytest
 
 from nifty_scalper_bot.data.data_hub import DataHub
+from nifty_scalper_bot.data.symbols import NIFTY_SPOT_CANONICAL_SYMBOL
 from nifty_scalper_bot.storage import HubStore
 
 
@@ -94,8 +95,8 @@ def test_replace_positions_filters_and_normalises(hub: DataHub) -> None:
     assert positions["NIFTY25OCT25000CE"]["quantity"] == 50
     assert positions["NIFTY25OCT25000CE"]["average_price"] == pytest.approx(201.5)
     assert "BANKNIFTY25NOVFUT" not in positions
-    assert positions["NIFTY"]["quantity"] == 0
-    assert positions["NIFTY"]["side"] == "FLAT"
+    assert positions[NIFTY_SPOT_CANONICAL_SYMBOL]["quantity"] == 0
+    assert positions[NIFTY_SPOT_CANONICAL_SYMBOL]["side"] == "FLAT"
     assert positions["NIFTY25OCT25000PE"]["side"] == "SHORT"
     assert positions["NIFTY25OCT25000PE"]["quantity"] == 25
 
@@ -200,6 +201,11 @@ def test_is_fresh_reports_metrics_for_cached_tick(hub: DataHub) -> None:
     assert meta["effective_ms"] is not None
     assert meta["threshold_ms"] >= 0
     assert meta["reason"] in {None, "warmup_grace"}
+
+
+def test_normalize_canonicalizes_nifty_spot_aliases() -> None:
+    assert DataHub.normalize("NIFTY") == NIFTY_SPOT_CANONICAL_SYMBOL
+    assert DataHub.normalize("NSE:NIFTY") == NIFTY_SPOT_CANONICAL_SYMBOL
 
 
 def test_upsert_order_rejects_invalid_transition(hub: DataHub) -> None:

--- a/tests/data/test_market_data_manager.py
+++ b/tests/data/test_market_data_manager.py
@@ -7,6 +7,7 @@ from typing import Any, Iterable
 import pytest
 
 from nifty_scalper_bot.data.market_data_manager import MarketDataManager
+from nifty_scalper_bot.data.symbols import NIFTY_SPOT_CANONICAL_SYMBOL
 from nifty_scalper_bot.data.websocket.manager import ConnectionState
 
 
@@ -356,3 +357,25 @@ def test_heartbeat_callback_invoked(broker: DummyBroker, ws: DummyWebSocket) -> 
     manager.bump_heartbeat(2.5)
     assert captured[-1] == 2.5
     assert len(captured) == 2
+
+
+def test_nifty_spot_aliases_canonicalize_for_quote_and_subscription() -> None:
+    broker = DummyBroker()
+    ws = DummyWebSocket()
+    broker.set_token(NIFTY_SPOT_CANONICAL_SYMBOL, 256265)
+    broker.set_quote(
+        NIFTY_SPOT_CANONICAL_SYMBOL,
+        {"symbol": NIFTY_SPOT_CANONICAL_SYMBOL, "ltp": 22500.0, "timestamp": 1.0},
+    )
+    manager = MarketDataManager(broker, ws)
+
+    received: list[dict[str, Any]] = []
+    manager.subscribe("NSE:NIFTY", received.append)
+
+    assert ws.subscribed[-1] == ("ltp", [256265])
+    pulled = manager.pull_quote("NIFTY")
+    assert pulled["symbol"] == NIFTY_SPOT_CANONICAL_SYMBOL
+    assert broker.calls[-1] == ("get_quote", (NIFTY_SPOT_CANONICAL_SYMBOL,))
+    cached = manager.get_latest_tick("NSE:NIFTY")
+    assert cached is not None
+    assert cached["symbol"] == NIFTY_SPOT_CANONICAL_SYMBOL

--- a/tests/test_initialize_components_polling.py
+++ b/tests/test_initialize_components_polling.py
@@ -22,6 +22,7 @@ from nifty_scalper_bot.config.settings import (
     StreamerSettings,
 )
 from nifty_scalper_bot.core.app import initialize_components
+from nifty_scalper_bot.data.symbols import NIFTY_SPOT_CANONICAL_SYMBOL
 
 
 class DummyBroker:
@@ -39,7 +40,11 @@ class DummyResolver:
     def __init__(self, broker_client) -> None:  # noqa: ANN001
         self.broker_client = broker_client
         self.warmed = False
-        self._mapping = {"NIFTY": 111, "BANKNIFTY": 222}
+        self._mapping = {
+            NIFTY_SPOT_CANONICAL_SYMBOL: 111,
+            "NIFTY": 111,
+            "BANKNIFTY": 222,
+        }
 
     def warm(self) -> None:
         self.warmed = True
@@ -216,7 +221,7 @@ def test_poll_tick_normalization_backfills_price(
 ) -> None:
     ctx, _dummy_notifier = _initialize_polling_context(monkeypatch)
     mdm: DummyMarketDataManager = ctx.market_data_manager  # type: ignore[assignment]
-    mdm._symbol_by_token[256265] = "NIFTY"
+    mdm._symbol_by_token[256265] = NIFTY_SPOT_CANONICAL_SYMBOL
 
     caplog.set_level("WARNING")
 
@@ -226,7 +231,7 @@ def test_poll_tick_normalization_backfills_price(
     tick = mdm._handle_tick_calls[-1]
     assert tick["instrument_token"] == 256265
     assert tick["ltp"] == 195.5
-    assert tick["symbol"] == "NIFTY"
+    assert tick["symbol"] == NIFTY_SPOT_CANONICAL_SYMBOL
     assert tick["source"] == "polling"
     warnings = [record.message for record in caplog.records]
     assert "poll_tick_missing_price" not in warnings


### PR DESCRIPTION
## Summary
- standardize Nifty spot handling on the broker-safe canonical symbol `NSE:NIFTY 50`
- route quote hydration and recovery through a single `MarketDataManager.pull_quote()` REST fallback path while keeping WebSocket as primary live market data
- remove duplicate Telegram lifecycle logs and make WebSocket subscription telemetry report operational counts

## Details
- add a narrow symbol canonicalization layer for Nifty spot aliases and apply it across the critical market-data path
- stop storing duplicate first-class Nifty aliases in market-data state and token lookups
- normalize startup/default symbols to the canonical spot symbol and keep polling fallback limited to the MDM REST poll path
- clean up the `data.resolver` shim so the import path remains stable without extra behavior

## Verification
- `python -m pytest tests/data/test_market_data_manager.py tests/data/test_data_hub.py tests/data/test_instruments.py tests/test_initialize_components_polling.py tests/core/test_core_app_imports.py tests/test_startup_sequence.py tests/notifications/test_telegram_controller.py tests/infra/test_scheduled_tasks.py tests/streaming/test_stream_supervisor.py`
- `python -m compileall src\\nifty_scalper_bot`

## Notes
- I did not target `main` directly because the current local checkout is 212 commits ahead / 103 commits behind `origin/main`, and `origin/main` is missing modules required by this code path. Opening a PR to `main` from this checkout would not be a focused change.