### PR TITLE
[codex] fix canonical nifty market data bootstrap

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -1549,7 +1549,7 @@ class RuntimeSelfChecker:
             # Pick the most liquid / reliable symbol (Spot index preferred)
             symbol = None
             for s in symbols:
-                if ("NIFTY 50" in s and "NIFTY" in s) and "NSE" in s:
+                if canonical(s) == "NSE:NIFTY":
                     symbol = s
                     break
 
@@ -1969,7 +1969,7 @@ def _get_symbols(
         return None
 
     ltp: float = 0.0
-    spot_symbol = "NSE:NIFTY 50"
+    spot_symbol = "NSE:NIFTY"
 
     _allow_offhours = os.getenv("SESSION_ALLOW_OUT_OF_HOURS", "").lower() == "true"
     _wait_timeout = 0.5 if _allow_offhours else 15.0
@@ -1989,7 +1989,7 @@ def _get_symbols(
     if broker:
         try:
             token_candidates = [256265]
-            str_candidates = [spot_symbol, "NIFTY 50", "NIFTY 50 INDEX"]
+            str_candidates = [spot_symbol]
             inner = getattr(broker, "client", getattr(broker, "_broker", broker))
 
             def parse_price(data: Any) -> float:
@@ -2852,7 +2852,7 @@ def initialize_components(settings: Settings | None = None) -> BotContext:
     if raw_syms:
         poll_symbols = unique_normalized_symbols(raw_syms)
     else:
-        poll_symbols = ["NSE:NIFTY 50", "256265"]
+        poll_symbols = ["NSE:NIFTY"]
 
     # InstrumentManager is the single source of truth - no resolver needed
     # Broker client will use instrument_manager directly via unified_manager
@@ -3123,6 +3123,7 @@ def initialize_components(settings: Settings | None = None) -> BotContext:
             require_depth=poll_require_depth,
             warn_on_rate_limit=poll_warn_rate_limit,
         )
+        market_data_manager.disable_rest_polling(reason="polling_streamer_fallback")
         polling_fallback_streamer.set_websocket_mode(True)
         websocket_manager.set_fallback_callbacks(
             on_start=lambda: polling_fallback_streamer.set_websocket_mode(False),
@@ -5293,7 +5294,7 @@ async def startup_sequence(ctx: BotContext) -> None:
                 except RuntimeError:
                     LOGGER.warning(f"⚠️ Could not resolve Futures: {future_symbol}")
 
-            targets.append("NSE:NIFTY 50")
+            targets.append("NSE:NIFTY")
             targets = list(dict.fromkeys(targets))
 
             LOGGER.info(f"⏳ Hydrating {len(targets)} symbols: {targets}")
@@ -5713,7 +5714,7 @@ async def startup_sequence(ctx: BotContext) -> None:
                 # Only start MDM polling if there's no streamer
                 asyncio.create_task(asyncio.to_thread(mdm._rest_poll_loop))
             else:
-                LOGGER.info("📡 MDM polling disabled (PollingStreamer is active)")
+                LOGGER.info("📡 MDM REST polling disabled (PollingStreamer owns fallback)")
 
             dynamic_option_symbols = {
                 sym

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -109,7 +109,6 @@ class MarketDataManager:
         self._token_by_symbol: dict[str, int] = {}
         self._symbol_by_token: dict[int, str] = {}
         self._token_by_symbol["NSE:NIFTY"] = 256265       # canonical
-        self._token_by_symbol["NSE:NIFTY 50"] = 256265  # alias
         self._symbol_by_token[256265] = "NSE:NIFTY"
         self._token_by_symbol["NSE:BANKNIFTY"] = 260105
         self._symbol_by_token[260105] = "NSE:BANKNIFTY"
@@ -1026,12 +1025,28 @@ class MarketDataManager:
 
     # ------------------------------------------------------------------
     # Public API
+    def _canonical_symbol(self, symbol: str) -> str:
+        value = enforce_canonical(normalize_symbol(str(symbol or "")))
+        if value.count(":") != 1:
+            raise RuntimeError(f"Malformed canonical symbol: {value}")
+        return value
+
+    def disable_rest_polling(self, *, reason: str | None = None) -> None:
+        """Disable the background REST poller when another component owns fallback."""
+
+        self._rest_poll_enabled = False
+        self._fallback_enabled = False
+        self._rest_poll_max_symbols = 0
+        if reason:
+            self._logger.info(
+                "mdm_rest_polling_disabled",
+                extra={"event": "mdm_rest_polling_disabled", "reason": reason},
+            )
+
     def subscribe(self, symbol: str, callback: TickCallback) -> None:
         """Subscribe *callback* to receive normalized ticks for *symbol*."""
 
-        symbol = normalize_symbol(str(symbol))
-        if symbol.count(":") != 1:
-            raise RuntimeError(f"Malformed canonical symbol: {symbol}")
+        symbol = self._canonical_symbol(symbol)
         with self._lock:
             subscribers = self._subscribers[symbol]
             subscribers.add(callback)
@@ -1068,9 +1083,7 @@ class MarketDataManager:
     def unsubscribe(self, symbol: str, callback: TickCallback) -> None:
         """Remove *callback* from subscribers of *symbol*."""
 
-        symbol = enforce_canonical(normalize_symbol(str(symbol)))
-        if symbol.count(":") != 1:
-            raise RuntimeError(f"Malformed canonical symbol: {symbol}")
+        symbol = self._canonical_symbol(symbol)
         should_unsubscribe = False
         with self._lock:
             callbacks = self._subscribers.get(symbol)
@@ -1094,7 +1107,13 @@ class MarketDataManager:
             if not resolved_symbol:
                 return None
         else:
-            resolved_symbol = enforce_canonical(normalize_symbol(symbol)) or symbol
+            if str(symbol).strip().isdigit():
+                with self._lock:
+                    resolved_symbol = self._symbol_by_token.get(int(str(symbol).strip()))
+                if not resolved_symbol:
+                    return None
+            else:
+                resolved_symbol = self._canonical_symbol(symbol)
 
         with self._lock:
             tick = self._tick_cache.get(resolved_symbol)
@@ -1196,14 +1215,15 @@ class MarketDataManager:
         Returns:
             float | None: Latest price or None if unavailable from all sources.
         """
+        canonical_symbol = self._canonical_symbol(symbol)
         _STALE_SECONDS = 2.0
         now = time.time()
 
         # 1. Try tick cache with freshness check
-        tick = self.get_latest_tick(symbol)
+        tick = self.get_latest_tick(canonical_symbol)
         tick_age: float | None = None
         if tick is not None:
-            last_ts = self._last_tick_time.get(symbol)
+            last_ts = self._last_tick_time.get(canonical_symbol)
             if last_ts is not None:
                 tick_age = now - last_ts
             try:
@@ -1214,7 +1234,8 @@ class MarketDataManager:
                     # Tick exists but is stale — log and fall through to broker
                     self._logger.warning(
                         "STALE_DATA symbol=%s age=%.2fs — falling back to broker REST",
-                        symbol, tick_age,
+                        canonical_symbol,
+                        tick_age,
                     )
             except (KeyError, TypeError, ValueError):
                 pass
@@ -1223,7 +1244,7 @@ class MarketDataManager:
         broker = getattr(self, "_broker", None)
         if broker:
             try:
-                quote = broker.get_quote(symbol)
+                quote = broker.get_quote(canonical_symbol)
                 if isinstance(quote, dict):
                     price = quote.get("last_price") or quote.get("ltp")
                     if price:
@@ -1231,15 +1252,17 @@ class MarketDataManager:
                         if p > 0:
                             # Refresh cache with fresh REST price
                             self._logger.debug(
-                                "REST_FALLBACK_HIT symbol=%s price=%.2f", symbol, p
+                                "REST_FALLBACK_HIT symbol=%s price=%.2f",
+                                canonical_symbol,
+                                p,
                             )
                             return p
             except Exception as exc:
                 self._logger.warning(
-                    "broker.get_quote failed for %s: %s", symbol, exc
+                    "broker.get_quote failed for %s: %s", canonical_symbol, exc
                 )
 
-        self._logger.warning("get_ltp: no price available for %s", symbol)
+        self._logger.warning("get_ltp: no price available for %s", canonical_symbol)
         return None
 
     def get_latest_price(self, symbol: str) -> float | None:
@@ -1247,14 +1270,15 @@ class MarketDataManager:
         return self.get_ltp(symbol)
 
     def _resolve_underlying_price(self, symbol: str) -> float | None:
-        tick_price = self.get_latest_price(symbol)
+        canonical_symbol = self._canonical_symbol(symbol)
+        tick_price = self.get_latest_price(canonical_symbol)
         if tick_price is not None:
             return tick_price
         broker = getattr(self, "_broker", None)
         if broker is None or not hasattr(broker, "get_quote"):
             return None
         try:
-            quote = broker.get_quote(symbol)
+            quote = broker.get_quote(canonical_symbol)
         except Exception:  # noqa: BLE001
             return None
         if isinstance(quote, Mapping):
@@ -1372,9 +1396,10 @@ class MarketDataManager:
             None.
         """
 
-        candidates: list[str | int] = self._candidate_quote_keys(symbol)
+        canonical_symbol = self._canonical_symbol(symbol)
+        candidates: list[str | int] = self._candidate_quote_keys(canonical_symbol)
         if not candidates:
-            candidates = [symbol]
+            candidates = [canonical_symbol]
         quote: dict[str, Any] | None = None
         for key in candidates:
             broker_key: str | int
@@ -1388,14 +1413,14 @@ class MarketDataManager:
                 break
         if quote is None:
             try:
-                raw_quote = self._broker.get_quote(symbol)
+                raw_quote = self._broker.get_quote(canonical_symbol)
             except Exception as exc:  # noqa: BLE001
                 self._logger.error(
                     "Failure in pull_quote direct get_quote: %s",
                     exc,
                     extra={
                         "event": "mdm_pull_quote_direct_error",
-                        "symbol": symbol,
+                        "symbol": canonical_symbol,
                         "error": str(exc),
                     },
                     exc_info=exc,
@@ -1404,16 +1429,16 @@ class MarketDataManager:
             if isinstance(raw_quote, Mapping):
                 quote = dict(raw_quote)
         if quote is None:
-            return {"symbol": symbol}
+            return {"symbol": canonical_symbol}
         quote = self._prepare_rest_tick(quote, source="rest")
         with self._lock:
-            previous = self._latest_ticks.get(symbol)
+            previous = self._latest_ticks.get(canonical_symbol)
 
-        normalized = self._normalize_tick(symbol, quote, previous)
+        normalized = self._normalize_tick(canonical_symbol, quote, previous)
         if normalized is not None:
-            self._store_tick(symbol, normalized)
+            self._store_tick(canonical_symbol, normalized)
             return normalized
-        return {"symbol": symbol, **quote}
+        return {"symbol": canonical_symbol, **quote}
 
     def probe_quote(self, symbol: str) -> dict[str, Any]:
         """Run a deep quote diagnostic across resolver, broker, and cache.
@@ -2859,9 +2884,7 @@ class MarketDataManager:
     def register_symbol(self, symbol: str, token: int) -> None:
         """Args: symbol/token; Returns: none; Raises: RuntimeError on bad data."""
 
-        normalized_symbol = enforce_canonical(normalize_symbol(str(symbol or "")))
-        if normalized_symbol.count(":") != 1:
-            raise RuntimeError(f"Malformed canonical symbol: {normalized_symbol}")
+        normalized_symbol = self._canonical_symbol(symbol)
         token_int = int(token)
         with self._lock:
             if self._token_by_symbol.get(normalized_symbol) == token_int:
@@ -2883,7 +2906,7 @@ class MarketDataManager:
         wallclock = tick.get("timestamp", time.time())
 
         # 🔥 PRODUCTION FIX — enforce canonical key
-        symbol = normalize_symbol(symbol)
+        symbol = self._canonical_symbol(symbol)
 
         cached_tick = dict(tick)
         with self._lock:
@@ -3827,15 +3850,16 @@ class MarketDataManager:
             "Entered get_quote",
             extra={"event": "mdm_get_quote_enter", "symbol": symbol},
         )
+        canonical_symbol = self._canonical_symbol(symbol)
         try:
-            latest = self.get_latest_tick(symbol)
+            latest = self.get_latest_tick(canonical_symbol)
         except Exception as exc:  # noqa: BLE001
             self._logger.error(
                 "Failure in get_quote: %s",
                 exc,
                 extra={
                     "event": "mdm_get_quote_failed",
-                    "symbol": symbol,
+                    "symbol": canonical_symbol,
                     "error": str(exc),
                 },
             )
@@ -3848,8 +3872,8 @@ class MarketDataManager:
         ask = _coerce_float(quote.get("ask"))
         if bid is not None and ask is not None and bid > 0 and ask > 0:
             mid = (float(bid) + float(ask)) / 2.0
-            self._last_mid[symbol] = (mid, now_ms)
-        self._last_quote_ts_ms[symbol] = now_ms
+            self._last_mid[canonical_symbol] = (mid, now_ms)
+        self._last_quote_ts_ms[canonical_symbol] = now_ms
         return quote
 
     def get_orderbook(self, symbol: str, *, levels: int = 5) -> dict[str, Any] | None:
@@ -3863,7 +3887,7 @@ class MarketDataManager:
                 "levels": levels,
             },
         )
-        normalized = (symbol or "").strip().upper()
+        normalized = self._canonical_symbol(symbol)
         if not normalized:
             self._logger.info(
                 "Condition met: get_orderbook_missing_symbol",
@@ -3973,7 +3997,10 @@ class MarketDataManager:
             None.
         """
 
-        normalized = (symbol or "").strip().upper()
+        raw_symbol = str(symbol or "").strip()
+        if raw_symbol.isdigit():
+            return [int(raw_symbol)]
+        normalized = self._canonical_symbol(raw_symbol)
         if not normalized:
             return []
         base_symbol = normalized.split(":", 1)[-1]
@@ -4061,25 +4088,32 @@ class MarketDataManager:
         broker = getattr(self, "_broker", None)
         if broker is None:
             return None
+        normalized_key: str | int = key
+        if isinstance(key, str) and not key.strip().isdigit():
+            normalized_key = self._canonical_symbol(key)
         try:
             quote_any_fn = getattr(broker, "quote_any", None)
             if callable(quote_any_fn):
                 try:
-                    raw_any = quote_any_fn([key])  # type: ignore[arg-type]
+                    raw_any = quote_any_fn([normalized_key])  # type: ignore[arg-type]
                 except Exception as exc:  # noqa: BLE001
                     self._logger.error(
                         "Failure in _broker_quote_any quote_any: %s",
                         exc,
-                        extra={"event": "mdm_quote_any_error", "key": key},
+                        extra={"event": "mdm_quote_any_error", "key": normalized_key},
                         exc_info=exc,
                     )
                 else:
                     if isinstance(raw_any, Mapping) and raw_any:
                         key_candidates: list[str] = []
-                        if isinstance(key, int):
-                            key_candidates.append(str(int(key)))
-                        elif isinstance(key, str):
-                            symbol_aliases = [key, key.upper(), key.split(":", 1)[-1]]
+                        if isinstance(normalized_key, int):
+                            key_candidates.append(str(int(normalized_key)))
+                        elif isinstance(normalized_key, str):
+                            symbol_aliases = [
+                                normalized_key,
+                                normalized_key.upper(),
+                                normalized_key.split(":", 1)[-1],
+                            ]
                             for alias in symbol_aliases:
                                 if alias not in key_candidates:
                                     key_candidates.append(alias)
@@ -4090,18 +4124,18 @@ class MarketDataManager:
                         for value in raw_any.values():
                             if isinstance(value, Mapping):
                                 return dict(value)
-            if isinstance(key, int):
+            if isinstance(normalized_key, int):
                 if hasattr(broker, "get_quote_by_token"):
-                    quote = broker.get_quote_by_token(key)
+                    quote = broker.get_quote_by_token(normalized_key)
                 else:
                     return None
             else:
-                quote = broker.get_quote(key)
+                quote = broker.get_quote(normalized_key)
         except Exception as exc:  # noqa: BLE001
             self._logger.debug(
                 "Failure in _broker_quote_any: %s",
                 exc,
-                extra={"event": "mdm_quote_fetch_failed", "key": key},
+                extra={"event": "mdm_quote_fetch_failed", "key": normalized_key},
             )
             return None
         if isinstance(quote, Mapping) and quote:
@@ -4315,6 +4349,7 @@ class MarketDataManager:
         Raises:
             None.
         """
+        symbol = self._canonical_symbol(symbol)
         quote = self._broker.get_quote(symbol)
         if not isinstance(quote, dict):
             return
@@ -4364,6 +4399,7 @@ class MarketDataManager:
         if self._ws is None:
             return
         try:
+            symbol = self._canonical_symbol(symbol)
             token = self._token_by_symbol.get(symbol)
             if not token:
                 raise RuntimeError(f"Token missing for {symbol}")
@@ -4383,6 +4419,7 @@ class MarketDataManager:
     def _release_subscription(self, symbol: str) -> None:
         if self._ws is None:
             return
+        symbol = self._canonical_symbol(symbol)
         token = self._token_by_symbol.get(symbol)
         if token is None:
             return
@@ -4395,6 +4432,7 @@ class MarketDataManager:
             )
 
     def _resolve_token(self, symbol: str) -> int | None:
+        symbol = self._canonical_symbol(symbol)
         # 1. Check local cache
         token = self._token_by_symbol.get(symbol)
         if token:

--- a/src/nifty_scalper_bot/data/option_chain.py
+++ b/src/nifty_scalper_bot/data/option_chain.py
@@ -8,6 +8,8 @@ from datetime import date
 from statistics import median
 from typing import Literal
 
+from nifty_scalper_bot.utils.symbols import canonical
+
 _TICK_SIZE = 0.05
 
 
@@ -196,12 +198,12 @@ class OptionsChainManager:
         broker_client: Any,
         market_data_manager: Any,
         refresh_interval: float = 30.0,
-        underlying_symbol: str = "NSE:NIFTY 50",
+        underlying_symbol: str = "NSE:NIFTY",
     ) -> None:
         self._broker = broker_client
         self._mdm = market_data_manager
         self._refresh_interval = max(refresh_interval, 10.0)
-        self._underlying_symbol = underlying_symbol
+        self._underlying_symbol = canonical(underlying_symbol)
 
         self._lock = threading.Lock()
         self._snapshot: OptionChainSnapshot | None = None
@@ -428,16 +430,15 @@ class OptionsChainManager:
     def _get_spot(self) -> float:
         """Get NIFTY spot price from MDM, falling back to cached value."""
         if self._mdm:
-            for sym in (self._underlying_symbol, "NSE:NIFTY 50", "NSE:NIFTY50", "NIFTY"):
-                try:
-                    p = (
-                        self._mdm.get_ltp(sym)
-                        if hasattr(self._mdm, "get_ltp")
-                        else self._mdm.get_latest_price(sym)
-                    )
-                    if p and float(p) > 0:
-                        return float(p)
-                except Exception:
-                    continue
+            try:
+                p = (
+                    self._mdm.get_ltp(self._underlying_symbol)
+                    if hasattr(self._mdm, "get_ltp")
+                    else self._mdm.get_latest_price(self._underlying_symbol)
+                )
+                if p and float(p) > 0:
+                    return float(p)
+            except Exception:
+                pass
         with self._lock:
             return self._spot_price

--- a/src/nifty_scalper_bot/execution/order_manager.py
+++ b/src/nifty_scalper_bot/execution/order_manager.py
@@ -347,10 +347,6 @@ def resolve_reference_price(
         None.
     """
 
-    # NEW: Intercept and map invalid spot symbol before broker rejection
-    if symbol.upper() == "NSE:NIFTY":
-        symbol = "NSE:NIFTY 50"
-        
     _REFERENCE_LOGGER.debug(
         "Entered resolve_reference_price",
         extra={"event": "resolve_reference_price_enter", "symbol": symbol},

--- a/src/nifty_scalper_bot/infra/scheduled_tasks.py
+++ b/src/nifty_scalper_bot/infra/scheduled_tasks.py
@@ -149,8 +149,8 @@ def start_background_tasks(order_manager: Any, logger: Any) -> list[asyncio.Task
     )
 
     logger.info(
-        "Background tasks started",
-        extra={"event": "tasks.started", "count": len(tasks)},
+        "Scheduled maintenance tasks created",
+        extra={"event": "tasks.created", "count": len(tasks)},
     )
 
     return tasks

--- a/src/nifty_scalper_bot/notifications/telegram_controller.py
+++ b/src/nifty_scalper_bot/notifications/telegram_controller.py
@@ -106,6 +106,7 @@ from nifty_scalper_bot.utils.errors import OrderPlacementError
 from nifty_scalper_bot.utils.logging import get_logger
 from nifty_scalper_bot.utils.reasons import SOFT, canonical
 from nifty_scalper_bot.utils.response_builder import EMOJI, RB, ResponseBuilder
+from nifty_scalper_bot.utils.symbols import canonical as canonical_symbol
 from telegram import Bot, Chat, InputFile, Message, Update
 from telegram.constants import ParseMode
 from telegram.error import BadRequest, NetworkError, RetryAfter, TelegramError
@@ -525,7 +526,6 @@ class TelegramBot:
         self.mode = "polling"
         self.application = self.builder().build()
         self._app: Application | None = self.application
-        log.info("telegram_application_attached")
         self._shutdown_event: asyncio.Event | None = None
         self._fallback_lock: asyncio.Lock | None = None
         self._webhook_server: "TelegramWebhookServer" | None = None
@@ -611,7 +611,7 @@ class TelegramBot:
                     self._heartbeat_loop(), name="telegram-heartbeat-loop"
                 )
                 self._bg_task_started = True
-                log.info("Background tasks started")
+                log.info("telegram_heartbeat_task_started")
 
         except Exception as exc:  # noqa: BLE001
             self._started = False
@@ -1378,25 +1378,25 @@ class TelegramBot:
 
     def _get_nifty_spot_price(self) -> float | None:
         """Get NIFTY spot price with multi-tier fallback."""
-        
+        spot_symbol = canonical_symbol("NSE:NIFTY")
+
         # Tier 1: Market data manager
         mdm = getattr(self.deps, "market_data_manager", None)
         if mdm:
-            for symbol in ["NIFTY", "NSE:NIFTY", "NSE:NIFTY50"]:
-                try:
-                    tick = mdm.get_latest_tick(symbol)
-                    if tick and isinstance(tick, dict):
-                        ltp = tick.get("ltp") or tick.get("last_price")
-                        if ltp and ltp > 0:
-                            return float(ltp)
-                except Exception:
-                    continue
+            try:
+                tick = mdm.get_latest_tick(spot_symbol)
+                if tick and isinstance(tick, dict):
+                    ltp = tick.get("ltp") or tick.get("last_price")
+                    if ltp and ltp > 0:
+                        return float(ltp)
+            except Exception:
+                pass
                     
         # Tier 2: Data hub
         hub = getattr(self.deps, "data_hub", None)
         if hub:
             try:
-                snapshot = hub.snapshot("NIFTY")
+                snapshot = hub.snapshot(spot_symbol)
                 if snapshot and snapshot.get("ltp"):
                     return float(snapshot["ltp"])
             except Exception as e:

--- a/src/nifty_scalper_bot/notifications/telegram_webhook_enhanced.py
+++ b/src/nifty_scalper_bot/notifications/telegram_webhook_enhanced.py
@@ -511,10 +511,6 @@ class TelegramWebhookController:
         self._application = application
         self._application_active = False
         self._application_ready.clear()
-        self.logger.info(
-            "telegram_application_attached",
-            extra={"event": "application_attached"},
-        )
 
     def is_polling_active(self) -> bool:
         """Return ``True`` if the polling fallback task is running."""

--- a/src/nifty_scalper_bot/options/contracts.py
+++ b/src/nifty_scalper_bot/options/contracts.py
@@ -285,7 +285,7 @@ class OptionsContractStore:
         
         # Add spot
         if include_spot and self._spot_token:
-            symbols.append("NSE:NIFTY 50")
+            symbols.append("NSE:NIFTY")
         
         # Add futures
         if include_futures and active_expiry in self._futures:

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -2830,10 +2830,11 @@ class StrategyRunner:
 
     def _get_spot_tick(self) -> dict[str, Any] | None:
         """Resilient spot tick fetcher checking canonical variants."""
-        if not self._market_data: return None
-        for sym in ("NSE:NIFTY 50", "NSE:NIFTY", "256265"):
-            tick = self._market_data.get_latest_tick(sym)
-            if tick: return tick
+        if not self._market_data:
+            return None
+        tick = self._market_data.get_latest_tick("NSE:NIFTY")
+        if tick:
+            return tick
         return None
 
     def _get_spot_price(self) -> float:
@@ -2841,10 +2842,9 @@ class StrategyRunner:
         source = self._data_hub or self._market_data
         if not source:
             return 0.0
-        for sym in ("NSE:NIFTY 50", "NSE:NIFTY", "256265"):
-            p = source.get_latest_price(sym)
-            if p and p > 0:
-                return p
+        price = source.get_latest_price("NSE:NIFTY")
+        if price and price > 0:
+            return price
         return 0.0
 
     def _execute_order(self, *, symbol: str, base_symbol: str, side: Literal["BUY", "SELL"], quantity: int, price: float, stop_loss: float | None, take_profit: float | None, timestamp: datetime, reference_price: float | None = None, metadata: Mapping[str, Any] | None = None, ) -> tuple[str, int]:

--- a/src/nifty_scalper_bot/strategies/signal_generator.py
+++ b/src/nifty_scalper_bot/strategies/signal_generator.py
@@ -1741,10 +1741,7 @@ class StrategyManager:
         # ✅ 2. INDEX LTP AND VWAP DATA (NEW)
         # ═══════════════════════════════════════════════════════════
         try:
-            # Try NIFTY 50 spot index first
             index_quote = data_hub.get_quote('NSE:NIFTY', allow_pull=True)
-            if not index_quote:
-                index_quote = data_hub.get_quote('NIFTY 50', allow_pull=True)
             if index_quote:
                 index_ltp = self._extract_float(
                     index_quote, ('last_price', 'ltp', 'close')

--- a/src/nifty_scalper_bot/streaming/polling_streamer.py
+++ b/src/nifty_scalper_bot/streaming/polling_streamer.py
@@ -80,10 +80,16 @@ class PollingStreamer:
                 target=self._run, name="polling_streamer", daemon=True
             )
             self._thread.start()
+            mode = "fallback" if self._websocket_mode_enabled else "primary"
             LOGGER.info(
-                "🚀 Scout Polling Started. Target Interval: %.1fs",
+                "REST polling streamer started | mode=%s interval=%.1fs",
+                mode,
                 self._interval_s,
-                extra={"event": "polling_started", "interval": self._interval_s},
+                extra={
+                    "event": "polling_started",
+                    "interval": self._interval_s,
+                    "mode": mode,
+                },
             )
 
     def stop(self) -> None:

--- a/src/nifty_scalper_bot/streaming/websocket_manager.py
+++ b/src/nifty_scalper_bot/streaming/websocket_manager.py
@@ -655,15 +655,22 @@ class WebSocketManager:
                         )
                 ws.subscribe(token_list)
                 ws.set_mode(ws.MODE_FULL, token_list)
-                self._logger.info(
-                    "WebSocket subscribed to %d tokens", len(self._tokens)
-                )
                 symbol_map = getattr(mdm, "_symbol_by_token", {})
+                active_symbols = {
+                    symbol_map.get(token)
+                    for token in token_list
+                    if symbol_map.get(token)
+                }
                 self._logger.info(
-                    "WebSocket subscribed tokens=%d symbols=%d",
-                    len(self._tokens),
-                    len(symbol_map),
+                    "WebSocket subscribed | active_tokens=%d active_symbols=%d",
+                    len(token_list),
+                    len(active_symbols),
                 )
+                if symbol_map:
+                    self._logger.debug(
+                        "WebSocket symbol registry size=%d",
+                        len(symbol_map),
+                    )
                 if len(symbol_map) == 0:
                     self._logger.warning(
                         "Token map is EMPTY after subscribe — ticks will be dropped. "

--- a/src/nifty_scalper_bot/utils/symbols.py
+++ b/src/nifty_scalper_bot/utils/symbols.py
@@ -4,6 +4,24 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 
+_NIFTY_SPOT_ALIASES = {
+    "NIFTY",
+    "NIFTY50",
+    "NIFTY50INDEX",
+}
+
+
+def _collapse_nifty_spot_alias(
+    exchange: str,
+    tradingsymbol: str,
+) -> tuple[str, str]:
+    exchange_value = str(exchange or "").strip().upper()
+    trading_value = " ".join(str(tradingsymbol or "").replace("_", " ").split()).upper()
+    compact = "".join(trading_value.split())
+    if exchange_value in {"", "NSE"} and compact in _NIFTY_SPOT_ALIASES:
+        return "NSE", "NIFTY"
+    return exchange_value, trading_value
+
 
 def canonical(symbol: str) -> str:
     """Args: symbol; Returns: canonical EXCHANGE:SYMBOL; Raises: none."""
@@ -13,13 +31,16 @@ def canonical(symbol: str) -> str:
     normalized = raw.replace("_", " ")
     if ":" in normalized:
         exchange, tradingsymbol = normalized.split(":", 1)
-        tradingsymbol = " ".join(tradingsymbol.split())
+        exchange, tradingsymbol = _collapse_nifty_spot_alias(exchange, tradingsymbol)
         if not exchange:
-            exchange = "NFO" if tradingsymbol.endswith(("CE", "PE", "FUT")) else "NSE"
+            compact = "".join(tradingsymbol.split())
+            exchange = "NFO" if compact.endswith(("CE", "PE", "FUT")) else "NSE"
         return f"{exchange}:{tradingsymbol}"
     compact = "".join(normalized.split())
     if compact.isdigit():
         return compact
+    if compact in _NIFTY_SPOT_ALIASES:
+        return "NSE:NIFTY"
     exchange = "NFO" if compact.endswith(("CE", "PE", "FUT")) else "NSE"
     return f"{exchange}:{compact}"
 
@@ -37,13 +58,24 @@ def normalize_symbol(symbol: str) -> str:
     raw = str(symbol or "").strip().upper()
     if not raw:
         return ""
+    normalized = raw.replace("_", " ")
     if ":" in raw:
-        return raw
+        exchange, tradingsymbol = normalized.split(":", 1)
+        exchange, tradingsymbol = _collapse_nifty_spot_alias(exchange, tradingsymbol)
+        if not exchange:
+            compact = "".join(tradingsymbol.split())
+            exchange = "NFO" if compact.endswith(("CE", "PE", "FUT")) else "NSE"
+        return f"{exchange}:{tradingsymbol}"
+    compact = "".join(normalized.split())
+    if compact.isdigit():
+        return compact
+    if compact in _NIFTY_SPOT_ALIASES:
+        return "NSE:NIFTY"
     # Infer exchange the same way canonical() does: derivatives get NFO,
     # everything else (indices, equities) gets NSE.
-    if raw.endswith(("CE", "PE", "FUT")):
-        return f"NFO:{raw}"
-    return f"NSE:{raw}"
+    if compact.endswith(("CE", "PE", "FUT")):
+        return f"NFO:{normalized}"
+    return f"NSE:{normalized}"
 
 
 def unique_normalized_symbols(symbols: Iterable[str]) -> list[str]:

--- a/tests/data/test_market_data_manager.py
+++ b/tests/data/test_market_data_manager.py
@@ -162,6 +162,37 @@ def test_pull_quote_updates_cache(broker: DummyBroker, ws: DummyWebSocket) -> No
     assert cached["ltp"] == 100.0
 
 
+def test_nifty_alias_subscription_collapses_to_canonical(
+    broker: DummyBroker,
+    ws: DummyWebSocket,
+) -> None:
+    manager = MarketDataManager(broker, ws)
+
+    manager.subscribe("NSE:NIFTY 50", lambda _: None)
+
+    assert ws.subscribed[-1] == ("full", [256265])
+    assert manager._active_subscribed_symbols == {"NSE:NIFTY"}
+
+
+def test_pull_quote_canonicalizes_nifty_spot_alias(
+    broker: DummyBroker,
+    ws: DummyWebSocket,
+) -> None:
+    broker.set_quote(
+        "NSE:NIFTY",
+        {"symbol": "NSE:NIFTY", "ltp": 25100.0, "bid": 25099.5, "ask": 25100.5},
+    )
+    manager = MarketDataManager(broker, ws)
+
+    quote = manager.pull_quote("NSE:NIFTY 50")
+
+    assert broker.calls[-1] == ("get_quote", ("NSE:NIFTY",))
+    assert quote["symbol"] == "NSE:NIFTY"
+    cached = manager.get_latest_tick("NSE:NIFTY")
+    assert cached is not None
+    assert cached["ltp"] == pytest.approx(25100.0)
+
+
 def test_wait_for_symbol_hits_after_tick(
     monkeypatch: pytest.MonkeyPatch, broker: DummyBroker, ws: DummyWebSocket
 ) -> None:

--- a/tests/infra/test_scheduled_tasks.py
+++ b/tests/infra/test_scheduled_tasks.py
@@ -110,5 +110,5 @@ def test_start_background_tasks_creates_tasks(monkeypatch: pytest.MonkeyPatch) -
 
     assert len(tasks) == 2
     assert created == tasks
-    assert logger.messages[-1][0] == "Background tasks started"
+    assert logger.messages[-1][0] == "Scheduled maintenance tasks created"
     assert logger.messages[-1][1]["count"] == 2


### PR DESCRIPTION
## Summary
- standardize the internal Nifty spot symbol on `NSE:NIFTY` and collapse legacy aliases through shared symbol canonicalization
- remove duplicate first-class alias handling from the market-data/bootstrap path and keep websocket as primary with a single PollingStreamer fallback in websocket mode
- clean up duplicated Telegram/background-task lifecycle logs and make websocket subscription telemetry report active subscribed counts

## Root cause
- broker-facing quote and instrument paths were already centered on `NSE:NIFTY`, but shared normalization still emitted `NSE:NIFTY 50`, which forced local remaps, duplicate subscriptions, and avoidable quote miss paths
- websocket mode was also carrying both the PollingStreamer fallback and MDM REST polling thread, creating overlapping fallback behavior and muddy startup telemetry
- Telegram attach/start logging was emitted by both the bootstrap owner and child controllers, producing duplicated lifecycle signals

## Validation
- `python -m pytest tests/test_production_hardening_guards.py tests/data/test_market_data_manager.py tests/infra/test_scheduled_tasks.py tests/strategies/test_signal_generator_futures_volume.py`
- `python -m pytest tests/streaming/test_websocket_manager.py tests/data/test_data_hub.py tests/notifications/test_telegram_controller.py`
- `python -m pytest tests/test_startup_sequence.py tests/test_initialize_components_polling.py tests/core/test_core_app_imports.py`
- `python -m pytest tests/streaming/test_polling_streamer.py tests/streaming/test_polling_streamer_vwap.py tests/execution/test_entry_price.py tests/execution/test_entry_price_ladder.py tests/execution/test_execution_policy.py`

## Impact
- live spot lookup, quote hydration, and subscription state now converge on one canonical broker-safe symbol
- websocket mode keeps one explicit REST fallback owner instead of overlapping pollers
- operator logs now report one Telegram lifecycle owner and truthful websocket active subscription counts