### PR TITLE
fix: stabilize startup data fallback, telegram ownership, and quote key handling

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -213,9 +213,7 @@ def _get_current_nifty_futures_symbol() -> str:
     ]
     m_str = months[month - 1]
 
-    symbol = f"NFO:NIFTY{y_str}{m_str}FUT"
-    LOGGER.info(f"📅 Using futures symbol: {symbol}")
-    return symbol
+    return f"NFO:NIFTY{y_str}{m_str}FUT"
 
 
 def _require_component(component: _ComponentT | None, name: str) -> _ComponentT:
@@ -3125,11 +3123,33 @@ def initialize_components(settings: Settings | None = None) -> BotContext:
         )
         market_data_manager.disable_rest_polling(reason="polling_streamer_fallback")
         polling_fallback_streamer.set_websocket_mode(True)
+
+        def _activate_polling_fallback() -> None:
+            polling_fallback_streamer.set_websocket_mode(False)
+            if not polling_fallback_streamer.is_running():
+                LOGGER.warning(
+                    "PollingStreamer fallback activated due to websocket degradation",
+                    extra={"event": "polling_fallback_activated"},
+                )
+                polling_fallback_streamer.start()
+
+        def _deactivate_polling_fallback() -> None:
+            polling_fallback_streamer.set_websocket_mode(True)
+            if polling_fallback_streamer.is_running():
+                LOGGER.info(
+                    "PollingStreamer fallback deactivated after websocket recovery",
+                    extra={"event": "polling_fallback_deactivated"},
+                )
+                polling_fallback_streamer.stop()
+
         websocket_manager.set_fallback_callbacks(
-            on_start=lambda: polling_fallback_streamer.set_websocket_mode(False),
-            on_stop=lambda: polling_fallback_streamer.set_websocket_mode(True),
+            on_start=_activate_polling_fallback,
+            on_stop=_deactivate_polling_fallback,
         )
-        polling_fallback_streamer.start()
+        LOGGER.info(
+            "PollingStreamer standby fallback armed (inactive until websocket degrades)",
+            extra={"event": "polling_fallback_standby"},
+        )
 
     else:
         LOGGER.info("Initializing Polling Streamer...")
@@ -3710,11 +3730,13 @@ def initialize_components(settings: Settings | None = None) -> BotContext:
                     LOGGER.warning(
                         f"Failed to inject DataHub into {strategy.name}: {exc}"
                     )
+    futures_symbol = _get_current_nifty_futures_symbol()
+    LOGGER.info("📅 Using futures symbol: %s", futures_symbol)
     orchestrator = StrategyOrchestrator(
         risk_manager=risk_manager,
         order_manager=safe_order_manager,
         data_hub=data_hub,
-        futures_symbol=_get_current_nifty_futures_symbol(),
+        futures_symbol=futures_symbol,
     )
     regime_bias_map: dict[str, dict[str, float]] = {}
     if elite_strategies:
@@ -3812,7 +3834,7 @@ def initialize_components(settings: Settings | None = None) -> BotContext:
         min_confidence=_global_min_conf,
         data_hub=data_hub,
         orchestrator=orchestrator,
-        futures_symbol=_get_current_nifty_futures_symbol(),
+        futures_symbol=futures_symbol,
         score_weights=None,
         regime_signal_getter=_regime_signal_snapshot,
         regime_bias_map=regime_bias_map,
@@ -4692,8 +4714,12 @@ def initialize_components(settings: Settings | None = None) -> BotContext:
     ctx.telegram_bot = None
     # Ensure controller exists for telegram setup
     controller = _HTTP_CONTROLLER
-    if controller is None and settings.notifications.enabled:
-        # Create a minimal controller if the HTTP app wasn't started
+    if (
+        controller is None
+        and settings.notifications.enabled
+        and settings.notifications.webhook_enabled
+    ):
+        # Create a minimal webhook controller only when webhook transport is active.
         try:
             from nifty_scalper_bot.notifications.telegram_webhook_enhanced import (
                 TelegramWebhookController,
@@ -4705,7 +4731,7 @@ def initialize_components(settings: Settings | None = None) -> BotContext:
                     bot=notifier.bot,
                     settings=settings.notifications,
                 )
-                LOGGER.info("✅ Created fallback TelegramWebhookController")
+                LOGGER.info("✅ Created TelegramWebhookController (webhook mode)")
         except Exception as e:
             LOGGER.warning(f"Could not create fallback controller: {e}")
     telegram_bot_instance: TelegramBot | None = None

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -1039,8 +1039,8 @@ class MarketDataManager:
         self._rest_poll_max_symbols = 0
         if reason:
             self._logger.info(
-                "mdm_rest_polling_disabled",
-                extra={"event": "mdm_rest_polling_disabled", "reason": reason},
+                "mdm_internal_rest_poller_disabled",
+                extra={"event": "mdm_internal_rest_poller_disabled", "reason": reason},
             )
 
     def subscribe(self, symbol: str, callback: TickCallback) -> None:
@@ -1415,20 +1415,33 @@ class MarketDataManager:
             try:
                 raw_quote = self._broker.get_quote(canonical_symbol)
             except Exception as exc:  # noqa: BLE001
-                self._logger.error(
+                error_text = str(exc)
+                is_recoverable_miss = "Quote data missing" in error_text
+                log_fn = self._logger.warning if is_recoverable_miss else self._logger.error
+                log_fn(
                     "Failure in pull_quote direct get_quote: %s",
                     exc,
                     extra={
-                        "event": "mdm_pull_quote_direct_error",
+                        "event": (
+                            "mdm_pull_quote_direct_miss"
+                            if is_recoverable_miss
+                            else "mdm_pull_quote_direct_error"
+                        ),
                         "symbol": canonical_symbol,
-                        "error": str(exc),
+                        "error": error_text,
                     },
-                    exc_info=exc,
+                    exc_info=None if is_recoverable_miss else exc,
                 )
                 raw_quote = None
             if isinstance(raw_quote, Mapping):
                 quote = dict(raw_quote)
         if quote is None:
+            with self._lock:
+                cached_tick = self._latest_ticks.get(canonical_symbol)
+            if isinstance(cached_tick, Mapping) and cached_tick:
+                cached_quote = dict(cached_tick)
+                cached_quote.setdefault("source", "cache")
+                return cached_quote
             return {"symbol": canonical_symbol}
         quote = self._prepare_rest_tick(quote, source="rest")
         with self._lock:

--- a/src/nifty_scalper_bot/data/rest/zerodha_client.py
+++ b/src/nifty_scalper_bot/data/rest/zerodha_client.py
@@ -391,10 +391,48 @@ class ZerodhaKiteClient(BaseBrokerClient):
         response = self._ensure_json(
             self._make_request("GET", "/quote", params={"i": [kite_symbol]})
         )
-        try:
-            quote_data = response["data"][kite_symbol]
-        except KeyError as exc:  # pragma: no cover - API invariant
-            raise BrokerError(f"Quote data missing for {symbol}") from exc
+        data = response.get("data", {})
+        quote_data: Mapping[str, Any] | None = None
+        if isinstance(data, Mapping):
+            direct = data.get(kite_symbol)
+            if isinstance(direct, Mapping):
+                quote_data = direct
+            else:
+                variants: list[str] = []
+                raw_symbol = str(symbol or "").strip().upper()
+                formatted_symbol = str(kite_symbol or "").strip().upper()
+                for candidate in (
+                    formatted_symbol,
+                    raw_symbol,
+                    formatted_symbol.split(":", 1)[-1],
+                    raw_symbol.split(":", 1)[-1],
+                ):
+                    if candidate and candidate not in variants:
+                        variants.append(candidate)
+                if "NSE:NIFTY" in variants:
+                    variants.extend(["NSE:NIFTY 50", "NIFTY 50", "NIFTY50"])
+                if "NIFTY" in variants:
+                    variants.extend(["NIFTY 50", "NIFTY50"])
+                for key, payload in data.items():
+                    if not isinstance(payload, Mapping):
+                        continue
+                    key_text = str(key).strip().upper()
+                    normalized_key = key_text.replace(" ", "")
+                    normalized_key = normalized_key.replace("NIFTY50", "NIFTY")
+                    if key_text in variants:
+                        quote_data = payload
+                        break
+                    for variant in variants:
+                        normalized_variant = variant.replace(" ", "").replace(
+                            "NIFTY50", "NIFTY"
+                        )
+                        if key_text == variant or normalized_key == normalized_variant:
+                            quote_data = payload
+                            break
+                    if quote_data is not None:
+                        break
+        if quote_data is None:  # pragma: no cover - API invariant
+            raise BrokerError(f"Quote data missing for {symbol}")
 
         depth = quote_data.get("depth", {})
         buy_depth = depth.get("buy", [])

--- a/src/nifty_scalper_bot/streaming/polling_streamer.py
+++ b/src/nifty_scalper_bot/streaming/polling_streamer.py
@@ -80,15 +80,15 @@ class PollingStreamer:
                 target=self._run, name="polling_streamer", daemon=True
             )
             self._thread.start()
-            mode = "fallback" if self._websocket_mode_enabled else "primary"
+            mode = "fallback_standby" if self._websocket_mode_enabled else "primary"
             LOGGER.info(
-                "REST polling streamer started | mode=%s interval=%.1fs",
+                "PollingStreamer activated | role=%s interval=%.1fs",
                 mode,
                 self._interval_s,
                 extra={
                     "event": "polling_started",
                     "interval": self._interval_s,
-                    "mode": mode,
+                    "role": mode,
                 },
             )
 
@@ -112,6 +112,12 @@ class PollingStreamer:
     def set_websocket_mode(self, enabled: bool) -> None:
         """Args: enabled; Returns: none; Raises: none."""
         self._websocket_mode_enabled = bool(enabled)
+
+    def is_running(self) -> bool:
+        """Args: none; Returns: running state; Raises: none."""
+
+        with self._lock:
+            return bool(self._thread and self._thread.is_alive())
 
     def last_poll_heartbeat(self) -> float:
         """Return polling loop heartbeat monotonic timestamp."""

--- a/src/nifty_scalper_bot/streaming/websocket_manager.py
+++ b/src/nifty_scalper_bot/streaming/websocket_manager.py
@@ -406,7 +406,7 @@ class WebSocketManager:
                 )
                 if not self._is_within_trading_window():
                     self._logger.warning(
-                        "WebSocket connected outside trading hours (paper-mode only)"
+                        "WebSocket connected outside trading hours; running in data-observation mode while execution remains runtime-gated"
                     )
         except Exception as e:
             self._record_failure()

--- a/tests/data/test_market_data_manager.py
+++ b/tests/data/test_market_data_manager.py
@@ -193,6 +193,32 @@ def test_pull_quote_canonicalizes_nifty_spot_alias(
     assert cached["ltp"] == pytest.approx(25100.0)
 
 
+def test_pull_quote_uses_cached_tick_on_recoverable_direct_miss(
+    broker: DummyBroker,
+    ws: DummyWebSocket,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    class MissingQuoteBroker(DummyBroker):
+        def get_quote(self, symbol: str) -> dict[str, Any]:
+            self.calls.append(("get_quote", (symbol,)))
+            raise RuntimeError("Quote data missing for NSE:NIFTY")
+
+    miss_broker = MissingQuoteBroker()
+    miss_broker.set_token("NSE:NIFTY", 256265)
+    manager = MarketDataManager(miss_broker, ws)
+    manager._store_tick(  # noqa: SLF001 - explicit cache priming for fallback test
+        "NSE:NIFTY",
+        {"symbol": "NSE:NIFTY", "ltp": 25000.0, "source": "ws"},
+    )
+    caplog.set_level("WARNING")
+
+    quote = manager.pull_quote("NSE:NIFTY")
+
+    assert quote["ltp"] == pytest.approx(25000.0)
+    assert quote["source"] == "ws"
+    assert any("direct get_quote" in rec.message for rec in caplog.records)
+
+
 def test_wait_for_symbol_hits_after_tick(
     monkeypatch: pytest.MonkeyPatch, broker: DummyBroker, ws: DummyWebSocket
 ) -> None:

--- a/tests/data/test_zerodha_client_guards.py
+++ b/tests/data/test_zerodha_client_guards.py
@@ -81,3 +81,28 @@ def test_build_kite_params_accepts_option(monkeypatch: pytest.MonkeyPatch) -> No
     assert params["exchange"] == "NFO"
 
     client._client.close()
+
+
+def test_get_quote_accepts_alternate_nifty_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _make_client()
+
+    def fake_request(*_args, **_kwargs):  # noqa: ANN001
+        return {
+            "data": {
+                "NSE:NIFTY 50": {
+                    "last_price": 25234.5,
+                    "depth": {"buy": [], "sell": []},
+                }
+            }
+        }
+
+    monkeypatch.setattr(client, "_make_request", fake_request)
+    monkeypatch.setattr(client, "_ensure_json", lambda payload: payload)
+
+    quote = client.get_quote("NSE:NIFTY")
+
+    assert quote["symbol"] == "NSE:NIFTY"
+    assert quote["ltp"] == pytest.approx(25234.5)
+    client._client.close()

--- a/tests/streaming/test_polling_streamer.py
+++ b/tests/streaming/test_polling_streamer.py
@@ -188,3 +188,23 @@ def test_maybe_warn_rate_limits_sets_flag_and_metric():
     # Simulate large token count -> warn
     s._maybe_warn_rate_limits(5000)
     assert s._rate_limit_warned is True
+
+
+def test_start_logs_fallback_standby_role(caplog: pytest.LogCaptureFixture):
+    broker = FakeLtpBroker()
+    streamer = PollingStreamer(
+        broker_client=broker,
+        on_tick=lambda t: None,
+        instrument_resolver=None,
+        poll_interval_ms=500,
+    )
+    streamer.set_websocket_mode(True)
+    caplog.set_level("INFO")
+
+    streamer.start()
+    time.sleep(0.01)
+    streamer.stop()
+
+    assert any(
+        "role=fallback_standby" in record.message for record in caplog.records
+    )

--- a/tests/streaming/test_websocket_manager.py
+++ b/tests/streaming/test_websocket_manager.py
@@ -160,6 +160,24 @@ async def test_watchdog_suppresses_pong_reconnect_outside_trading_window(
 
 
 @pytest.mark.asyncio
+async def test_outside_trading_hours_log_is_mode_agnostic(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.setattr(ws_module, "KiteTicker", FakeKiteTicker)
+    caplog.set_level("WARNING")
+
+    manager = ws_module.WebSocketManager("k", "t")
+    manager._is_within_trading_window = lambda: False  # type: ignore[method-assign]
+    await manager.connect()
+    await manager.disconnect()
+
+    messages = [record.message for record in caplog.records]
+    assert any("outside trading hours" in message for message in messages)
+    assert all("paper-mode only" not in message for message in messages)
+
+
+@pytest.mark.asyncio
 async def test_circuit_breaker_opens_after_repeated_failures(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_app_symbol_resolution.py
+++ b/tests/test_app_symbol_resolution.py
@@ -76,3 +76,15 @@ def test_get_symbols_remaps_unresolved_option_to_available_contract() -> None:
     )
 
     assert symbols == ["NFO:NIFTY26FEB25050CE"]
+
+
+def test_get_current_nifty_futures_symbol_has_no_logging_side_effect(
+    caplog,
+) -> None:
+    caplog.set_level("INFO")
+
+    symbol = app._get_current_nifty_futures_symbol()
+
+    assert symbol.startswith("NFO:NIFTY")
+    assert symbol.endswith("FUT")
+    assert all("Using futures symbol" not in rec.message for rec in caplog.records)

--- a/tests/test_initialize_components_polling.py
+++ b/tests/test_initialize_components_polling.py
@@ -103,6 +103,7 @@ class DummyPollingStreamer:
         self._tokens: set[int] = set()
         self._interval_s = float(poll_interval_ms) / 1000.0
         self._batch_size = batch_size
+        self.websocket_mode = False
 
     def start(self) -> None:
         self.started = True
@@ -124,8 +125,22 @@ class DummyPollingStreamer:
     def is_running(self) -> bool:
         return self.running
 
+    def set_websocket_mode(self, enabled: bool) -> None:
+        self.websocket_mode = bool(enabled)
+
     def tracked_tokens(self) -> list[int]:
         return sorted(self._tokens)
+
+
+class DummyWebSocketManager:
+    def __init__(self, *_args, **_kwargs) -> None:  # noqa: ANN002, ANN003
+        self._fallback_on_start = None
+        self._fallback_on_stop = None
+        self._market_data_manager = None
+
+    def set_fallback_callbacks(self, *, on_start=None, on_stop=None) -> None:  # noqa: ANN001
+        self._fallback_on_start = on_start
+        self._fallback_on_stop = on_stop
 
 
 @pytest.fixture(autouse=True)
@@ -154,6 +169,60 @@ def test_initialize_components_uses_polling_by_default(monkeypatch):
     assert ctx.stream_supervisor.is_running() is True
     assert ctx.stream_supervisor.status_line().startswith("tokens=1")
     assert dummy_notifier.events == []
+
+
+def test_initialize_components_ws_arms_polling_fallback_without_starting(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("STREAM__MODE", "websocket")
+    monkeypatch.setenv("WEBSOCKET__DISABLED", "false")
+    monkeypatch.setenv("POLLING__ENABLED", "true")
+    monkeypatch.setattr("nifty_scalper_bot.core.app.ZerodhaKiteClient", DummyBroker)
+    monkeypatch.setattr("nifty_scalper_bot.core.app.InstrumentResolver", DummyResolver)
+    monkeypatch.setattr(
+        "nifty_scalper_bot.core.app.MarketDataManager", DummyMarketDataManager
+    )
+    monkeypatch.setattr(
+        "nifty_scalper_bot.core.app.PollingStreamer", DummyPollingStreamer
+    )
+    monkeypatch.setattr(
+        "nifty_scalper_bot.core.app.WebSocketManager", DummyWebSocketManager
+    )
+
+    app_config = AppConfig(
+        broker=BrokerConfig(
+            api_key="demo",
+            api_secret="secret",
+            access_token="token",
+            base_url="https://example.com",
+            websocket_url="wss://example.com/ws",
+        ),
+        risk=RiskConfig(),
+        logging=LoggingConfig(level="INFO"),
+        ratelimit=RateLimitConfig(
+            orders=RateLimitBucketConfig(capacity=10, refill_rate_per_sec=10.0),
+            rest=RateLimitBucketConfig(capacity=10, refill_rate_per_sec=10.0),
+            hist=RateLimitBucketConfig(capacity=10, refill_rate_per_sec=10.0),
+        ),
+        quote_stale_threshold_ms=1_000,
+    )
+    settings = Settings(
+        app=app_config,
+        enable_live=False,
+        orders=OrderSettings(),
+        risk=RiskSettings(),
+        streamer=StreamerSettings(),
+        shadow=ShadowSettings(drift_threshold_pct=0.0),
+        notifications=NotificationSettings(enabled=False),
+        session_allow_out_of_hours=False,
+        allow_offmarket_trading=False,
+    )
+
+    ctx = initialize_components(settings)
+
+    assert isinstance(ctx.websocket_manager, DummyWebSocketManager)
+    assert isinstance(ctx.polling_fallback_streamer, DummyPollingStreamer)
+    assert ctx.polling_fallback_streamer.start_calls == 0
 
 
 def _initialize_polling_context(


### PR DESCRIPTION
### Motivation
- Broker quote lookup was brittle for index/spot aliases (e.g., `NSE:NIFTY` vs `NSE:NIFTY 50`) and caused hard failures during startup.
- Startup logging and ownership for REST polling vs websocket fallback was contradictory and made the REST fallback appear as a second primary.
- Telegram could instantiate multiple controllers (polling + webhook) leading to duplicated control paths.
- A helper emitted the futures symbol log as a side effect causing duplicate startup lines and the websocket outside-hours message was mode‑inaccurate.

### Description
- Hardened Zerodha REST quote resolution in `ZerodhaKiteClient.get_quote()` to match alternate/equivalent keys and tolerate variants (e.g., `NSE:NIFTY 50`, `NIFTY50`) before failing. (`src/nifty_scalper_bot/data/rest/zerodha_client.py`).
- Made `MarketDataManager.pull_quote()` more robust: it tries `_broker_quote_any()` first, on direct `get_quote()` errors it downgrades recoverable missing-quote cases to warnings, and falls back to the cached tick (if present) before returning a minimal payload. Also renamed internal poll-disable log to clarify ownership. (`src/nifty_scalper_bot/data/market_data_manager.py`).
- Clarified PollingStreamer semantics and logging: startup log now reports `role=primary|fallback_standby`, and added `is_running()` helper used by the app to control activation. (`src/nifty_scalper_bot/streaming/polling_streamer.py`).
- Changed app startup fallback wiring so the PollingStreamer is armed as a cold standby in websocket-primary mode and is only started when the websocket fallback callback activates (and stopped on recovery). Also changed the fallback callback wiring and made MDM's internal poller-disable message explicit. (`src/nifty_scalper_bot/core/app.py`).
- Avoided unnecessary Telegram webhook controller creation when webhook transport is not enabled; the controller is only created when webhook transport is configured to be active. (`src/nifty_scalper_bot/core/app.py`).
- Removed the futures-symbol side-effecting log from the helper and centralized a single informational log at startup where the symbol is computed and used. (`src/nifty_scalper_bot/core/app.py`).
- Made the websocket outside-hours message truthful and mode-agnostic (no hardcoded “paper-mode only”). (`src/nifty_scalper_bot/streaming/websocket_manager.py`).
- Added/updated focused unit tests that exercise the fixed behaviors (quote fallback, alternate NIFTY keys, standby polling wiring, futures-symbol side-effect, polling role log, and outside-hours message). (files in `tests/` under `data/`, `streaming/`, etc.).

### Testing
- Ran a targeted subset of tests validating the changed behaviors: `tests/data/test_market_data_manager.py::test_pull_quote_uses_cached_tick_on_recoverable_direct_miss`, `tests/data/test_zerodha_client_guards.py::test_get_quote_accepts_alternate_nifty_key`, `tests/test_initialize_components_polling.py::test_initialize_components_ws_arms_polling_fallback_without_starting`, `tests/test_app_symbol_resolution.py::test_get_current_nifty_futures_symbol_has_no_logging_side_effect`, `tests/streaming/test_websocket_manager.py::test_outside_trading_hours_log_is_mode_agnostic`, `tests/streaming/test_polling_streamer.py::test_start_logs_fallback_standby_role` and they passed (6/6).
- Ran a broader related suite covering the touched modules; observed one failing pre-existing test in that broader run (`tests/data/test_market_data_manager.py::test_wait_for_live_tick_rejects_stale_tick`) which surfaced a token-mapping/setup mismatch unrelated to these fixes (failure reproduced when running the larger group but not in the targeted tests above).
- Executed the repository checks script `./run_checks.sh` in this environment; the script attempted to create a `.venv` and install deps but reported toolchain/venv issues (the ephemeral venv did not have `pytest` installed under this runner), so the full checks could not be completed here.

If you'd like, I can (a) push these changes as a focused PR branch (already created locally as `codex/startup-marketdata-telegram-2026-04-19`) and include the exact test logs, or (b) iterate on addressing the broader-suite failing test if you want that regression fixed in the same patch set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5191adabc8324b0d91f81af6c0dbb)