### PR TITLE
Fix startup hydration failures and illiquid option token selection

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -5374,10 +5374,9 @@ async def startup_sequence(ctx: BotContext) -> None:
             symbols_to_hydrate: list[str] = []
             for _sym in symbols_to_hydrate_raw:
                 _tok = _resolve_startup_token(_sym)
-                # Skip unknown NFO options with no token
-                if _tok is None and _is_nfo_symbol(_sym):
+                if _tok is None:
                     LOGGER.warning(
-                        "hydration_skip_no_token: skipping %s (no instrument token found)",
+                        "Skipping hydration for %s (no token)",
                         _sym,
                         extra={"event": "hydration_skip_no_token", "symbol": _sym},
                     )
@@ -5659,7 +5658,7 @@ async def startup_sequence(ctx: BotContext) -> None:
 
             for sym in targets:
                 if mdm:
-                    mdm.ensure_tracking(sym, seed=not websocket_enabled)
+                    mdm.ensure_tracking(sym, seed=not ctx.websocket_enabled)
 
                 tok = None
                 # BUG-α FIX: Never raise here — a missing token for one symbol

--- a/src/nifty_scalper_bot/core/contract_selector.py
+++ b/src/nifty_scalper_bot/core/contract_selector.py
@@ -21,7 +21,7 @@ Usage::
 
 from __future__ import annotations
 
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 import logging
 from typing import Any
 
@@ -177,6 +177,30 @@ def get_atm_contracts(
                 "exchange": str(inst.get("exchange") or "NFO").upper(),
             }
         )
+
+    interval = 'minute'
+    to_dt = datetime.now()
+    from_dt = to_dt - timedelta(days=3)
+    valid_tokens: list[dict[str, Any]] = []
+    for contract in selected:
+        token = contract['instrument_token']
+        try:
+            data = kite.historical_data(token, from_dt, to_dt, interval)
+            if data and len(data) >= 10:
+                valid_tokens.append(contract)
+            else:
+                LOGGER.warning(
+                    'Skipping illiquid token=%s (no usable history)',
+                    token,
+                )
+        except Exception as exc:  # noqa: BLE001 - best effort liquidity check
+            LOGGER.warning(
+                'Skipping token=%s (history fetch failed): %s',
+                token,
+                exc,
+            )
+
+    selected = valid_tokens
 
     if not selected:
         raise RuntimeError(

--- a/src/nifty_scalper_bot/data/rest/zerodha_client.py
+++ b/src/nifty_scalper_bot/data/rest/zerodha_client.py
@@ -2094,6 +2094,12 @@ class ZerodhaKiteClient(BaseBrokerClient):
                 ordered.append(c)
                 seen.add(c)
 
+        if raw.upper() in {"NSE:NIFTY", "NIFTY"}:
+            for alias in ("NSE:NIFTY 50", "NIFTY 50", "NIFTY50"):
+                if alias not in seen:
+                    ordered.append(alias)
+                    seen.add(alias)
+
         # Ensure instrument cache for exchange is loaded
         if exchange not in self._instrument_cache:
             try:


### PR DESCRIPTION
### Motivation

- Correct a `NameError` during startup tracking where `websocket_enabled` was referenced out of scope preventing proper market-data wiring. 
- Prevent spot symbols (e.g. `NSE:NIFTY`) from being forced through token-based hydration when a token cannot be resolved at startup, which caused hydration failures. 
- Avoid selecting illiquid option contracts that return zero historical bars and later break hydration/readiness. 

### Description

- In `src/nifty_scalper_bot/core/app.py` change the `ensure_tracking` call to use the context flag (`mdm.ensure_tracking(sym, seed=not ctx.websocket_enabled)`) to fix the scope bug. 
- In `src/nifty_scalper_bot/core/app.py` update the startup hydration gating so any symbol with no resolvable token is skipped with a warning (`Skipping hydration for %s (no token)`), avoiding forcing spot into token-based hydration. 
- In `src/nifty_scalper_bot/data/rest/zerodha_client.py` add common NIFTY spot alias candidates (`NSE:NIFTY 50`, `NIFTY 50`, `NIFTY50`) to the ordered lookup list in `get_instrument_token()` to improve token resolution alignment with quote logic. 
- In `src/nifty_scalper_bot/core/contract_selector.py` add a post-selection liquidity/history filter that requests minute historical data for the last 3 days and keeps only contracts with at least 10 bars, logging and skipping illiquid tokens. 

### Testing

- Ran the repository checks via `bash ./run_checks.sh`, which completed dependency installation but reported that `pytest` was not available to the script in the container (the script execution initially required `bash` due to permissions). 
- Installed tooling in the venv (`pip install pytest ruff mypy`) and ran `python -m py_compile` on the modified modules, which succeeded. 
- Ran `ruff` checks on the modified files which surfaced existing lint debt in the repository (pre-existing issues), so linting did not fully pass. 
- Ran `pytest` suites selectively: `tests/core/test_core_app_imports.py` passed while broader test runs failed on pre-existing test/import issues (an `ImportError` in `tests/data/test_instrument_resolver.py` and a `BotContext` signature mismatch in `tests/test_startup_sequence.py`) that are outside the scope of these surgical fixes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5f32407dc832482ca48fa0153b309)