### PR TITLE
fix: stabilize canonical quote handling and polling starvation gating

### DIFF
--- a/src/nifty_scalper_bot/data/rest/zerodha_client.py
+++ b/src/nifty_scalper_bot/data/rest/zerodha_client.py
@@ -789,7 +789,14 @@ class ZerodhaKiteClient(BaseBrokerClient):
                 )
 
         # Fallback to the LTP-only endpoint
-        symbols, symbol_map = self._tokens_to_symbols(tokens)
+        canonical_input = all(
+            isinstance(item, str) and ":" in str(item).strip() for item in tokens
+        )
+        if canonical_input:
+            symbols = [str(item).strip() for item in tokens]
+            symbol_map: dict[str, int] = {}
+        else:
+            symbols, symbol_map = self._tokens_to_symbols(tokens)
         if not symbols:
             return {}
         self._acquire_bucket(self._QUOTE_BUCKET)
@@ -2196,9 +2203,6 @@ class ZerodhaKiteClient(BaseBrokerClient):
         symbols: list[str] = []
         symbol_map: dict[str, int] = {}
 
-        if resolver is None:
-            return symbols, symbol_map
-
         for token in tokens:
             # ✅ CRITICAL FIX: Handle symbol strings directly
             if isinstance(token, str):
@@ -2207,23 +2211,35 @@ class ZerodhaKiteClient(BaseBrokerClient):
                 # Check if it's already a valid symbol (contains ":")
                 if ":" in token_str:
                     symbols.append(token_str)
-                    # Try to get the token from resolver for the reverse map
-                    try:
-                        if hasattr(resolver, "get_token_for_symbol"):
-                            resolved_token = resolver.get_token_for_symbol(token_str)
-                            if resolved_token:
-                                symbol_map[token_str] = int(resolved_token)
-                        elif hasattr(resolver, "lookup_by_symbol"):
-                            info = resolver.lookup_by_symbol(token_str)
-                            if info and "instrument_token" in info:
-                                symbol_map[token_str] = int(info["instrument_token"])
-                    except Exception as e:
-                        __import__("logging").getLogger(__name__).exception("[CRITICAL] unhandled exception", exc_info=True)
-                        raise  # Token lookup failed, but we can still use the symbol
+                    # Reverse token enrichment is best-effort only.
+                    if resolver is not None:
+                        try:
+                            if hasattr(resolver, "get_token_for_symbol"):
+                                resolved_token = resolver.get_token_for_symbol(
+                                    token_str
+                                )
+                                if resolved_token:
+                                    symbol_map[token_str] = int(resolved_token)
+                            elif hasattr(resolver, "lookup_by_symbol"):
+                                info = resolver.lookup_by_symbol(token_str)
+                                if info and "instrument_token" in info:
+                                    symbol_map[token_str] = int(
+                                        info["instrument_token"]
+                                    )
+                        except Exception as exc:  # noqa: BLE001
+                            LOGGER.debug(
+                                "Reverse token enrichment failed for %s: %s",
+                                token_str,
+                                exc,
+                            )
                     continue
 
                 # Check if it's a numeric string (token as string)
                 if token_str.isdigit():
+                    if resolver is None:
+                        symbols.append(token_str)
+                        symbol_map[token_str] = int(token_str)
+                        continue
                     try:
                         token_int = int(token_str)
                         formatted = resolver.format_token_as_symbol(token_int)
@@ -2245,6 +2261,14 @@ class ZerodhaKiteClient(BaseBrokerClient):
                 continue
 
             # Handle integer tokens (original behavior)
+            if resolver is None:
+                try:
+                    s = str(int(token))
+                    symbols.append(s)
+                    symbol_map[s] = int(token)
+                except (ValueError, TypeError):
+                    continue
+                continue
             try:
                 token_int = int(token)
                 formatted = resolver.format_token_as_symbol(token_int)

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -5851,13 +5851,13 @@ class StrategyRunner:
 
             if order_id:
                 self._logger.critical(
-                    "ORDER_FILLED order_id=%s symbol=%s side=%s qty=%s",
+                    "ORDER_SUBMITTED order_id=%s symbol=%s side=%s qty=%s",
                     order_id, base_symbol, signal.action, qty,
                 )
                 try:
                     self._record_trade(
                         base_symbol,
-                        TradeRecord(timestamp, signal.action, qty, price or 0.0, "filled", signal.reason, order_id),
+                        TradeRecord(timestamp, signal.action, qty, price or 0.0, "submitted", signal.reason, order_id),
                     )
                 except Exception as rec_exc:
                     self._logger.error("record_trade failed: %s", rec_exc)
@@ -6083,13 +6083,13 @@ class StrategyRunner:
 
             if order_id:
                 self._logger.critical(
-                    "ORDER_FILLED order_id=%s symbol=%s side=%s qty=%s (EXIT)",
+                    "ORDER_SUBMITTED order_id=%s symbol=%s side=%s qty=%s (EXIT)",
                     order_id, base_symbol, exit_side, qty,
                 )
                 try:
                     self._record_trade(
                         base_symbol,
-                        TradeRecord(timestamp, signal.action, qty, trade_price, "filled", signal.reason, order_id),
+                        TradeRecord(timestamp, signal.action, qty, trade_price, "submitted", signal.reason, order_id),
                     )
                 except Exception as rec_exc:
                     self._logger.error("record_trade failed: %s", rec_exc)

--- a/src/nifty_scalper_bot/streaming/polling_streamer.py
+++ b/src/nifty_scalper_bot/streaming/polling_streamer.py
@@ -53,6 +53,7 @@ class PollingStreamer:
         self._kite_streamer = None  # Optional KiteTicker reference for health checks
         self._websocket_mode_enabled = False
         self._last_poll_heartbeat = time.monotonic()
+        self._last_fetch_status = "idle"
 
         # Metrics
         self._m_poll_ok = Counter("polling_success_total", "Successful poll cycles")
@@ -70,7 +71,9 @@ class PollingStreamer:
     def start(self) -> None:
         """Start the background polling thread."""
         if self._interval_s <= 0:
-            LOGGER.info("Polling disabled (interval <= 0)", extra={"event": "polling_disabled"})
+            LOGGER.info(
+                "Polling disabled (interval <= 0)", extra={"event": "polling_disabled"}
+            )
             return
         with self._lock:
             if self._thread and self._thread.is_alive():
@@ -251,26 +254,28 @@ class PollingStreamer:
                         symbol = self._resolve_instrument(token)
                         if not symbol:
                             continue
-                        
+
                         # Get last arrival time to prioritize oldest data
                         last_arr = 0.0
                         if self._data_hub:
                             quote = self._data_hub.get_quote(symbol)
-                            last_arr = (quote.get("arrival_time") or 0.0) if quote else 0.0
-                        
+                            last_arr = (
+                                (quote.get("arrival_time") or 0.0) if quote else 0.0
+                            )
+
                         # Only poll if WS is not fresh (local arrival time)
                         if not (self._data_hub and self._data_hub.is_ws_fresh(symbol)):
                             candidates.append((token, last_arr))
 
                 # 2. Sort by last_arrival (oldest/missing first)
                 candidates.sort(key=lambda x: x[1])
-                
+
                 # 3. Batch Smoothing: Take only up to ONE batch per cycle
                 # This prevents API burst spikes by spreading the load across cycles
-                active_tokens = [c[0] for c in candidates[:self._batch_size]]
+                active_tokens = [c[0] for c in candidates[: self._batch_size]]
 
                 should_poll_quotes = bool(active_tokens)
-                
+
                 if should_poll_quotes:
                     # Single batch processing (self._chunks is now a safety measure)
                     for batch in self._chunks(active_tokens, self._batch_size):
@@ -282,7 +287,10 @@ class PollingStreamer:
                             log_throttled(
                                 LOGGER,
                                 "poll_empty_batch",
-                                f"[POLL-TRACE] Empty ticks returned for batch {batch[:5]}...",
+                                (
+                                    "[POLL-TRACE] Empty ticks returned for batch "
+                                    f"{batch[:5]} status={self._last_fetch_status}"
+                                ),
                                 level=10,
                                 interval_sec=60.0,
                             )
@@ -315,7 +323,9 @@ class PollingStreamer:
                                 continue
                             symbol = enforce_canonical(canonical(str(symbol)))
                             if symbol.count(":") != 1:
-                                raise RuntimeError(f"Malformed canonical symbol: {symbol}")
+                                raise RuntimeError(
+                                    f"Malformed canonical symbol: {symbol}"
+                                )
                             tick["symbol"] = symbol
 
                             # 4. Update Metrics
@@ -324,7 +334,7 @@ class PollingStreamer:
                             except Exception as metric_err:
                                 LOGGER.debug(f"Metric update error: {metric_err}")
 
-                             # 5. TickBus handoff (authoritative pipeline)
+                            # 5. TickBus handoff (authoritative pipeline)
                             try:
                                 self._on_tick(tick)
                                 self._m_ticks_ingested.inc()
@@ -374,11 +384,20 @@ class PollingStreamer:
                 # we do NOT kill the bot, even if 'last_healthy_ts' is old.
                 # This prevents "Quiet Market" suicide.
 
-                if tokens and not seen_any_tick_this_cycle and not ws_healthy:
+                if self._should_escalate_starvation(
+                    tokens_present=bool(tokens),
+                    seen_any_tick=seen_any_tick_this_cycle,
+                    ws_healthy=ws_healthy,
+                ):
                     if time.monotonic() - last_healthy_ts > 30.0:
                         LOGGER.critical(
                             "💀 FATAL POLLER ERROR: True market data starvation "
-                            "(REST + WS silent for >30s). Escalating to supervisor."
+                            "(REST + WS silent for >30s). Escalating to supervisor.",
+                            extra={
+                                "event": "polling_starvation",
+                                "poll_failure_reason": self._last_fetch_status,
+                                "ws_healthy": ws_healthy,
+                            },
                         )
                         self._stop.set()
                         return
@@ -410,6 +429,14 @@ class PollingStreamer:
             sleep_time = max(0.1, backoff - elapsed)
             time.sleep(sleep_time)
 
+    def _should_escalate_starvation(
+        self, *, tokens_present: bool, seen_any_tick: bool, ws_healthy: bool
+    ) -> bool:
+        """Args: status flags. Returns: starvation escalation decision. Raises: None."""
+        if not tokens_present or seen_any_tick or ws_healthy:
+            return False
+        return self._last_fetch_status in {"quote_request_failed"}
+
     # ----------------------------------------------------------------
     # ✅ FIX: Thread-Safe Fetch with Timeout (Prevents Zombie Hangs)
     # ----------------------------------------------------------------
@@ -435,6 +462,7 @@ class PollingStreamer:
         - ✅ depth
         """
         try:
+            self._last_fetch_status = "started"
             # Clean Batch: Ensure all items are integers
             tokens = []
             for t in batch:
@@ -444,6 +472,7 @@ class PollingStreamer:
                     continue
 
             if not tokens:
+                self._last_fetch_status = "invalid_batch"
                 return []
 
             # ✅ CRITICAL FIX: Convert tokens to "exchange:tradingsymbol" format
@@ -483,6 +512,7 @@ class PollingStreamer:
                 LOGGER.warning(
                     "[POLL] No symbols resolved from tokens - check instrument resolver"
                 )
+                self._last_fetch_status = "mapping_failure"
                 return []
 
             # Diagnostic Log - show what we're sending to API
@@ -495,12 +525,18 @@ class PollingStreamer:
 
             # ✅ API CALL: Pass symbols as "exchange:tradingsymbol" strings
             # This is the KEY FIX - passing symbols instead of integer tokens
-            quote_map = self._broker.quote(symbols_for_api)
+            try:
+                quote_map = self._broker.quote(symbols_for_api)
+            except Exception as exc:  # noqa: BLE001
+                self._last_fetch_status = "quote_request_failed"
+                LOGGER.warning("[POLL] Quote request failed: %s", exc, exc_info=True)
+                return []
 
             if not quote_map:
                 LOGGER.warning(
                     f"[POLL] Empty quote_map returned for symbols: {symbols_for_api[:3]}..."
                 )
+                self._last_fetch_status = "empty_quote_map"
                 return []
 
             # ✅ DIAGNOSTIC: Check if we got VWAP data
@@ -647,9 +683,11 @@ class PollingStreamer:
                     level=logging.DEBUG,
                 )
 
+            self._last_fetch_status = "ok" if ticks else "parse_failure"
             return ticks
 
         except Exception as e:
+            self._last_fetch_status = "quote_request_failed"
             LOGGER.warning(f"[POLL-QUOTE-FAIL] {e}", exc_info=True)
             return []
 

--- a/tests/data/test_zerodha_client_canonical.py
+++ b/tests/data/test_zerodha_client_canonical.py
@@ -1,0 +1,54 @@
+import pytest
+
+from nifty_scalper_bot.data.rest.zerodha_client import ZerodhaKiteClient
+
+
+def test_tokens_to_symbols_accepts_canonical_without_resolver() -> None:
+    client = ZerodhaKiteClient(api_key="k", access_token="t")
+    symbols, symbol_map = client._tokens_to_symbols(["NSE:NIFTY"])
+    assert symbols == ["NSE:NIFTY"]
+    assert symbol_map == {}
+    client.close()
+
+
+def test_tokens_to_symbols_canonical_reverse_enrichment_is_best_effort() -> None:
+    class BrokenResolver:
+        @staticmethod
+        def get_token_for_symbol(_symbol: str) -> int:
+            raise RuntimeError("boom")
+
+    client = ZerodhaKiteClient(api_key="k", access_token="t")
+    client.attach_resolver(BrokenResolver())
+
+    symbols, symbol_map = client._tokens_to_symbols(["NSE:NIFTY"])
+
+    assert symbols == ["NSE:NIFTY"]
+    assert symbol_map == {}
+    client.close()
+
+
+def test_get_quote_bulk_short_circuits_all_canonical(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = ZerodhaKiteClient(api_key="k", access_token="t")
+
+    called = {"acquire": 0}
+
+    monkeypatch.setattr(
+        client,
+        "_acquire_bucket",
+        lambda _bucket: called.__setitem__("acquire", called["acquire"] + 1),
+    )
+    monkeypatch.setattr(
+        client,
+        "_make_request",
+        lambda *_args, **_kwargs: {
+            "data": {"NSE:NIFTY": {"last_price": 25000.0, "instrument_token": 256265}}
+        },
+    )
+
+    out = client.get_quote_bulk(["NSE:NIFTY"])
+    assert called["acquire"] == 1
+    assert "NSE:NIFTY" in out
+    assert out["NSE:NIFTY"]["instrument_token"] == 256265
+    client.close()

--- a/tests/streaming/test_polling_streamer_starvation.py
+++ b/tests/streaming/test_polling_streamer_starvation.py
@@ -1,0 +1,61 @@
+from src.nifty_scalper_bot.streaming.polling_streamer import PollingStreamer
+
+
+class _Resolver:
+    @staticmethod
+    def format_token_as_symbol(_token: int) -> str:
+        return "NSE:NIFTY"
+
+
+class _QuoteBroker:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def quote(self, _symbols):
+        return self._payload
+
+
+def test_fetch_ticks_marks_empty_quote_map_not_transport_failure() -> None:
+    streamer = PollingStreamer(
+        broker_client=_QuoteBroker({}),
+        on_tick=lambda _tick: None,
+        instrument_resolver=_Resolver(),
+    )
+
+    ticks = streamer._fetch_ticks([256265])
+
+    assert ticks == []
+    assert streamer._last_fetch_status == "empty_quote_map"
+    assert (
+        streamer._should_escalate_starvation(
+            tokens_present=True,
+            seen_any_tick=False,
+            ws_healthy=False,
+        )
+        is False
+    )
+
+
+def test_fetch_ticks_marks_quote_failure_as_transport_starvation_candidate() -> None:
+    class _BrokenQuoteBroker:
+        def quote(self, _symbols):
+            raise RuntimeError("network down")
+
+    streamer = PollingStreamer(
+        broker_client=_BrokenQuoteBroker(),
+        on_tick=lambda _tick: None,
+        instrument_resolver=_Resolver(),
+    )
+
+    ticks = streamer._fetch_ticks([256265])
+
+    assert ticks == []
+    assert streamer._last_fetch_status == "quote_request_failed"
+    assert (
+        streamer._should_escalate_starvation(
+            tokens_present=True,
+            seen_any_tick=False,
+            ws_healthy=False,
+        )
+        is True
+    )

--- a/tests/test_app_canonical_basket.py
+++ b/tests/test_app_canonical_basket.py
@@ -1,0 +1,61 @@
+from nifty_scalper_bot.core.app import _build_canonical_active_basket
+
+
+class _FakeInstrumentManager:
+    def is_loaded(self) -> bool:
+        return True
+
+    def select_tokens_for_universe(
+        self,
+        *,
+        base: str,
+        spot_price: float,
+        strikes_around_atm: int,
+        strike_step: int,
+    ) -> list[int]:
+        assert base == "NIFTY"
+        assert strikes_around_atm == 3
+        assert strike_step == 50
+        assert spot_price > 0
+        return list(range(10, 24))
+
+    def get_symbol(self, token: int) -> str:
+        symbols = {
+            10: "NFO:NIFTY26APR25000CE",
+            11: "NFO:NIFTY26APR25050CE",
+            12: "NFO:NIFTY26APR25100CE",
+            13: "NFO:NIFTY26APR25150CE",
+            14: "NFO:NIFTY26APR25200CE",
+            15: "NFO:NIFTY26APR25250CE",
+            16: "NFO:NIFTY26APR25300CE",
+            17: "NFO:NIFTY26APR25000PE",
+            18: "NFO:NIFTY26APR25050PE",
+            19: "NFO:NIFTY26APR25100PE",
+            20: "NFO:NIFTY26APR25150PE",
+            21: "NFO:NIFTY26APR25200PE",
+            22: "NFO:NIFTY26APR25250PE",
+            23: "NFO:NIFTY26APR25300PE",
+        }
+        return symbols[token]
+
+    def get_token(self, symbol: str) -> int:
+        assert symbol == "NFO:NIFTY26APRFUT"
+        return 123456
+
+
+def test_build_canonical_active_basket_includes_spot_futures_and_options() -> None:
+    basket = _build_canonical_active_basket(
+        instrument_manager=_FakeInstrumentManager(),
+        spot_token_resolver=lambda _symbol: 256265,
+        spot_ltp=25125,
+        futures_symbol="NFO:NIFTY26APRFUT",
+        strike_step=50,
+        strikes_around_atm=3,
+    )
+
+    assert basket["spot_symbol"] == "NSE:NIFTY"
+    assert basket["futures_symbol"] == "NFO:NIFTY26APRFUT"
+    assert basket["spot_token"] == 256265
+    assert basket["futures_token"] == 123456
+    assert len(basket["ce_symbols"]) == 7
+    assert len(basket["pe_symbols"]) == 7


### PR DESCRIPTION
### Motivation
- Production failures showed canonical symbols (e.g., `NSE:NIFTY`) were being remapped or rejected and that polling fallback escalated into false market-data starvation, causing alert floods and degraded readiness.  The PR fixes the canonical symbol path and polling starvation decisions. 
- Order lifecycle semantics were inconsistent (broker ack logged as fill), reducing observability and correctness of downstream follow-up logic. 
- Add small targeted tests to lock these behaviors and prevent regressions.

### Description
- Zerodha client: accept canonical `EXCHANGE:SYMBOL` inputs end-to-end and make reverse token enrichment best-effort so resolver absence or lookup failures do not fail the flow; add a short-circuit in bulk quote/LTP fallback for all-canonical input to avoid unnecessary remapping. (file: `src/nifty_scalper_bot/data/rest/zerodha_client.py`)
- Polling streamer: add fetch-status tracking (`_last_fetch_status`) and a `_should_escalate_starvation` gating function, track distinct failure reasons (`mapping_failure`, `empty_quote_map`, `quote_request_failed`, etc.), and escalate starvation only on transport-level failures rather than local mapping/parse empties. Also add safer logs and throttled diagnostics. (file: `src/nifty_scalper_bot/streaming/polling_streamer.py`)
- Strategy runner: change pre-mature `ORDER_FILLED` logs/records to `ORDER_SUBMITTED` and mark recorded trades as `submitted` on broker acknowledgement so submit-vs-fill semantics are correct. (file: `src/nifty_scalper_bot/strategies/runner.py`)
- Tests: added focused tests for canonical symbol handling, polling starvation classification, and canonical active basket composition. (files: `tests/data/test_zerodha_client_canonical.py`, `tests/streaming/test_polling_streamer_starvation.py`, `tests/test_app_canonical_basket.py`)
- Misc: small defensive/logging improvements and throttled diagnostics to reduce alert flood potential.

### Testing
- Ran the project checks script: `bash ./run_checks.sh` (virtualenv created and dependencies installed) but full run failed in this environment at the pytest stage due to a pre-existing test import error unrelated to these changes: `ImportError: cannot import name 'InstrumentResolver' from 'nifty_scalper_bot.data'` in `tests/data/test_instrument_resolver.py` (this is an existing test/import issue; changes in this PR do not introduce this failure).
- Ran targeted pytest suites that exercise the modified behavior and features and they passed:
  - `./.venv/bin/pytest -q tests/data/test_zerodha_client_canonical.py tests/streaming/test_polling_streamer_starvation.py tests/test_app_canonical_basket.py tests/test_initialize_components_polling.py tests/streaming/test_polling_streamer.py` — PASS
  - `./.venv/bin/pytest -q tests/test_order_manager.py -k "ORDER_SUBMITTED or place_order"` — PASS
- Summary: focused unit tests covering canonical symbol flow, polling starvation gating, and canonical basket composition pass; the repository-wide test run in this environment is blocked by an unrelated pre-existing import error (documented above) and should be re-run in CI/main where that issue is resolved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e788c54d408324be844b51cb7c7131)