### PR TITLE
fix: stabilize WS failover supervision and core readiness gating

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -15,7 +15,9 @@ from contextlib import suppress
 from dataclasses import asdict, dataclass, field, replace
 from datetime import date, datetime, time, timedelta, timezone
 from importlib import import_module
+from importlib import metadata as importlib_metadata
 import inspect
+import hashlib
 import logging
 import os
 from pathlib import Path
@@ -50,6 +52,62 @@ from nifty_scalper_bot.infra.watchdog import start_watchdog
 LOGGER = logging.getLogger("nifty_scalper_bot.core.app")
 SYNC_LOCK = threading.Lock()
 instrument_cache_ready = threading.Event()
+
+
+def _build_startup_fingerprint() -> dict[str, str]:
+    """Build startup fingerprint metadata. Args: none. Returns: metadata map. Raises: none."""
+
+    version = "unknown"
+    try:
+        version = importlib_metadata.version("nifty_scalper_bot")
+    except Exception:
+        version = str(os.getenv("APP_VERSION", "unknown")).strip() or "unknown"
+
+    release_id = str(
+        os.getenv("RAILWAY_GIT_COMMIT_SHA")
+        or os.getenv("GIT_SHA")
+        or os.getenv("RELEASE_ID")
+        or ""
+    ).strip()
+    if not release_id:
+        git_head = Path(".git/HEAD")
+        if git_head.exists():
+            try:
+                head_value = git_head.read_text(encoding="utf-8").strip()
+                if head_value.startswith("ref:"):
+                    ref_name = head_value.split(" ", 1)[1].strip()
+                    ref_path = Path(".git") / ref_name
+                    if ref_path.exists():
+                        release_id = ref_path.read_text(encoding="utf-8").strip()[:12]
+                elif head_value:
+                    release_id = head_value[:12]
+            except Exception:
+                release_id = ""
+    if not release_id:
+        digest = hashlib.sha1(version.encode("utf-8"), usedforsecurity=False).hexdigest()
+        release_id = f"cfg-{digest[:12]}"
+
+    return {"version": version, "release": release_id}
+
+
+def _polling_fallback_degraded(
+    *,
+    ws_ok: bool,
+    stale: bool,
+    lagging: bool,
+    quote_age_degraded: bool,
+) -> bool:
+    """Evaluate fallback degrade state. Args: health flags. Returns: bool. Raises: none."""
+
+    if not ws_ok:
+        return True
+    if stale:
+        return True
+    if lagging:
+        return True
+    # Quote-age is secondary: only confirm degradation when another explicit
+    # data-path signal is already unhealthy.
+    return quote_age_degraded and (stale or lagging or (not ws_ok))
 
 
 def _run_sync_locked(operation: Callable[[], Any]) -> Any:
@@ -2802,6 +2860,13 @@ def initialize_components(settings: Settings | None = None) -> BotContext:
 
     ensure_multiproc_dir(clear_stale=True)
     settings = settings or get_settings()
+    fingerprint = _build_startup_fingerprint()
+    LOGGER.info(
+        "startup_fingerprint version=%s release=%s",
+        fingerprint["version"],
+        fingerprint["release"],
+        extra={"event": "startup_fingerprint", **fingerprint},
+    )
     config = settings.app
     raw_ws_disabled = os.getenv("WEBSOCKET__DISABLED")
     if raw_ws_disabled is None:
@@ -5538,7 +5603,7 @@ async def startup_sequence(ctx: BotContext) -> None:
                         extra={"event": "hydration_zero_bars", "symbol": symbol},
                     )
                 elif record_count < 20:
-                    LOGGER.error(
+                    LOGGER.info(
                         "insufficient_bars_for_strategy: %s returned only %d bars (need ≥20) — "
                         "strategy indicators will be unreliable",
                         symbol,
@@ -5660,15 +5725,34 @@ async def startup_sequence(ctx: BotContext) -> None:
                         },
                     )
 
+            readiness_symbols = list(
+                dict.fromkeys(
+                    [
+                        basket.get("spot_symbol"),
+                        basket.get("futures_symbol"),
+                        basket.get("ce_symbols", [None])[
+                            len(basket.get("ce_symbols", [])) // 2
+                        ]
+                        if basket.get("ce_symbols")
+                        else None,
+                        basket.get("pe_symbols", [None])[
+                            len(basket.get("pe_symbols", [])) // 2
+                        ]
+                        if basket.get("pe_symbols")
+                        else None,
+                    ]
+                )
+            )
+            readiness_symbols = [str(sym) for sym in readiness_symbols if sym]
             ready_symbols: list[str] = []
             min_required_bars = int(
                 getattr(runner, "_required_candles", 20) if runner else 20
             )
-            for sym in targets:
+            for sym in readiness_symbols:
                 if hydrated_counts.get(sym, 0) >= min_required_bars:
                     ready_symbols.append(sym)
                 else:
-                    LOGGER.warning(
+                    LOGGER.info(
                         "Condition met: startup_hydration_incomplete",
                         extra={
                             "event": "startup_hydration_incomplete",
@@ -5704,7 +5788,7 @@ async def startup_sequence(ctx: BotContext) -> None:
                     "Indicators hydration pre-check complete; waiting for live readiness gate"
                 )
             else:
-                LOGGER.error(
+                LOGGER.warning(
                     "Indicators remain unready because no symbols passed hydration barrier"
                 )
 
@@ -5882,7 +5966,14 @@ async def startup_sequence(ctx: BotContext) -> None:
                                 spot_age = ctx.market_data_manager.quote_age_ms("NSE:NIFTY")
                                 spot_state, sanitized_spot_age = _sanitize_quote_age(spot_age)
                                 quote_age_degraded = spot_state == "stale"
-                                degraded = (not ws_ok) or stale or quote_age_degraded
+                                tick_age_ms = ctx.market_data_manager.data_age_ms()
+                                lagging = tick_age_ms > quote_stale_ms
+                                degraded = _polling_fallback_degraded(
+                                    ws_ok=ws_ok,
+                                    stale=stale,
+                                    lagging=lagging,
+                                    quote_age_degraded=quote_age_degraded,
+                                )
                                 now_mono = time_module.monotonic()
                                 if degraded:
                                     recovered_since = None
@@ -5892,9 +5983,10 @@ async def startup_sequence(ctx: BotContext) -> None:
                                         and not polling_fallback.is_running()
                                     ):
                                         LOGGER.warning(
-                                            "Polling fallback activate (supervisor) ws_ok=%s stale=%s spot_quote_age_ms=%s",
+                                            "Polling fallback activate (supervisor) ws_ok=%s stale=%s lagging=%s spot_quote_age_ms=%s",
                                             ws_ok,
                                             stale,
+                                            lagging,
                                             sanitized_spot_age,
                                             extra={
                                                 "event": "polling_fallback_activated",
@@ -5903,9 +5995,12 @@ async def startup_sequence(ctx: BotContext) -> None:
                                                     if not ws_ok
                                                     else "stale_full_basket"
                                                     if stale
+                                                    else "tick_lag"
+                                                    if lagging
                                                     else "stale_spot_quote"
                                                 ),
                                                 "spot_state": spot_state,
+                                                "lagging": lagging,
                                             },
                                         )
                                         polling_fallback.set_websocket_mode(False)
@@ -6320,7 +6415,6 @@ async def startup_sequence(ctx: BotContext) -> None:
         ctx.strategy_runner, "calculate_portfolio_greeks"
     ):
         import threading
-        import time as time_module
 
         runner = ctx.strategy_runner
 

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -1152,6 +1152,11 @@ class MarketDataManager:
         self._rest_poll_enabled = False
         self._fallback_enabled = False
         self._rest_poll_max_symbols = 0
+        if self._rest_poll_thread is not None:
+            self._rest_poll_stop.set()
+            self._rest_poll_thread.join(timeout=2.0)
+            self._rest_poll_thread = None
+            self._rest_poll_stop.clear()
         if reason:
             self._logger.info(
                 "mdm_internal_rest_poller_disabled",
@@ -2389,7 +2394,7 @@ class MarketDataManager:
                 self._hydration_status[normalized] = "READY"
             else:
                 self._hydration_status[normalized] = "HYDRATING"
-                self._logger.error(
+                self._logger.info(
                     "insufficient_bars_for_strategy",
                     extra={
                         "event": "insufficient_bars_for_strategy",
@@ -2520,13 +2525,15 @@ class MarketDataManager:
             return False
         if atm_pe and bars.get(str(atm_pe), 0) < min_bars:
             return False
-        ce_ready = [
-            sym for sym in options if sym.endswith("CE") and bars.get(sym, 0) >= min_bars
-        ]
-        pe_ready = [
-            sym for sym in options if sym.endswith("PE") and bars.get(sym, 0) >= min_bars
-        ]
-        return len(ce_ready) >= 2 and len(pe_ready) >= 2
+        if atm_ce and atm_pe:
+            return True
+        ce_ready = any(
+            sym.endswith("CE") and bars.get(sym, 0) >= min_bars for sym in options
+        )
+        pe_ready = any(
+            sym.endswith("PE") and bars.get(sym, 0) >= min_bars for sym in options
+        )
+        return ce_ready and pe_ready
 
     def get_hydration_status(self, symbol: str) -> str:
         """Return hydration status. Args: symbol. Returns: status string. Raises: None."""
@@ -3094,6 +3101,7 @@ class MarketDataManager:
             self._ticks_received_per_symbol[symbol] += 1
             self._symbols_with_tick.add(symbol)
             self._last_tick_wallclock[symbol] = float(wallclock)
+            self._last_quote_ts_ms[symbol] = self._now_ms()
         staleness_seconds = 0.0
         try:
             staleness_seconds = max(time.time() - float(wallclock), 0.0)
@@ -4379,7 +4387,7 @@ class MarketDataManager:
                 "candidates": candidates,
                 "trace_id": trace_id,
             },
-            exec_info=True,
+            exc_info=True,
         )
         return None
 

--- a/tests/data/test_market_data_manager.py
+++ b/tests/data/test_market_data_manager.py
@@ -74,6 +74,7 @@ class DummyWebSocket:
 def broker() -> DummyBroker:
     broker = DummyBroker()
     broker.set_token("NIFTY23", 123)
+    broker.set_token("NSE:NIFTY23", 123)
     broker.set_quote(
         "NIFTY23", {"ltp": 100.0, "bid": 99.5, "ask": 100.5, "ts": 1_000.0}
     )
@@ -362,6 +363,100 @@ async def test_readiness_passes_with_required_quorum(
         )
     await manager.wait_until_ready(timeout=0.5)
     assert manager.ready is True
+
+
+@pytest.mark.asyncio
+async def test_readiness_allows_outer_option_basket_to_lag(
+    monkeypatch: pytest.MonkeyPatch, broker: DummyBroker, ws: DummyWebSocket
+) -> None:
+    monkeypatch.setattr(
+        "nifty_scalper_bot.data.market_data_manager.get_market_state",
+        lambda: MarketState.OPEN,
+    )
+    manager = MarketDataManager(broker, ws)
+    manager._min_required_bars = 1  # noqa: SLF001
+    symbols = [
+        "NSE:NIFTY",
+        "NFO:NIFTY26MAYFUT",
+        "NFO:NIFTY26MAY25000CE",
+        "NFO:NIFTY26MAY25000PE",
+        "NFO:NIFTY26MAY24950CE",
+        "NFO:NIFTY26MAY24950PE",
+    ]
+    manager._active_subscribed_symbols = set(symbols)  # noqa: SLF001
+    manager.set_readiness_requirements(
+        spot_symbol="NSE:NIFTY",
+        futures_symbol="NFO:NIFTY26MAYFUT",
+        atm_ce_symbol="NFO:NIFTY26MAY25000CE",
+        atm_pe_symbol="NFO:NIFTY26MAY25000PE",
+        option_symbols=symbols[2:],
+    )
+    for symbol in symbols[:4]:
+        manager.ingest_historical_bar(
+            {
+                "symbol": symbol,
+                "open": 1,
+                "high": 2,
+                "low": 1,
+                "close": 1.5,
+                "volume": 1,
+                "timestamp": datetime.now(timezone.utc),
+            }
+        )
+    await manager.wait_until_ready(timeout=0.5)
+    assert manager.ready is True
+
+
+def test_store_tick_refreshes_quote_age_for_live_ticks(
+    broker: DummyBroker, ws: DummyWebSocket
+) -> None:
+    manager = MarketDataManager(broker, ws)
+    symbol = "NSE:NIFTY"
+    assert manager.quote_age_ms(symbol) >= 1_000_000_000
+
+    manager._store_tick(  # noqa: SLF001 - verify core cache write path
+        symbol,
+        {"symbol": symbol, "ltp": 25100.0, "timestamp": time.time(), "source": "ws"},
+    )
+
+    assert manager.quote_age_ms(symbol) < 1_000_000_000
+
+
+def test_quote_age_recovers_after_fresh_tick(
+    broker: DummyBroker, ws: DummyWebSocket
+) -> None:
+    manager = MarketDataManager(broker, ws)
+    symbol = "NSE:NIFTY"
+    manager._last_quote_ts_ms[symbol] = 0  # noqa: SLF001 - stale sentinel setup
+    assert manager.quote_age_ms(symbol) > 1_000
+
+    manager._store_tick(  # noqa: SLF001 - verify live tick freshness overwrite
+        symbol,
+        {"symbol": symbol, "ltp": 25200.0, "timestamp": time.time(), "source": "ws"},
+    )
+
+    assert manager.quote_age_ms(symbol) < 1_000
+
+
+def test_disable_rest_polling_stops_internal_thread(
+    broker: DummyBroker, ws: DummyWebSocket
+) -> None:
+    class _ThreadProbe:
+        def __init__(self) -> None:
+            self.join_calls = 0
+
+        def join(self, timeout: float | None = None) -> None:
+            self.join_calls += 1
+
+    manager = MarketDataManager(broker, ws)
+    probe = _ThreadProbe()
+    manager._rest_poll_thread = probe  # type: ignore[assignment]  # noqa: SLF001
+
+    manager.disable_rest_polling(reason="test")
+
+    assert manager._rest_poll_enabled is False  # noqa: SLF001
+    assert manager._rest_poll_thread is None  # noqa: SLF001
+    assert probe.join_calls == 1
 
 
 def test_nifty_pull_quote_logs_structured_warning_on_total_failure(

--- a/tests/streaming/test_websocket_manager.py
+++ b/tests/streaming/test_websocket_manager.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
 from collections.abc import Callable
 from typing import Any
 
 import pytest
 
+from nifty_scalper_bot.core import app as core_app
 from nifty_scalper_bot.streaming import websocket_manager as ws_module
 
 
@@ -196,3 +198,30 @@ async def test_circuit_breaker_opens_after_repeated_failures(
 
     snapshot = manager.health_snapshot()
     assert snapshot["circuit_open"] is True
+
+
+def test_app_uses_module_level_time_module_only() -> None:
+    source = inspect.getsource(core_app)
+    assert "import time as time_module" in source
+    assert "        import time as time_module" not in source
+
+
+def test_polling_degrade_ignores_quote_age_when_ws_is_healthy() -> None:
+    assert (
+        core_app._polling_fallback_degraded(  # noqa: SLF001 - behavior contract test
+            ws_ok=True,
+            stale=False,
+            lagging=False,
+            quote_age_degraded=True,
+        )
+        is False
+    )
+    assert (
+        core_app._polling_fallback_degraded(  # noqa: SLF001 - behavior contract test
+            ws_ok=False,
+            stale=False,
+            lagging=False,
+            quote_age_degraded=False,
+        )
+        is True
+    )


### PR DESCRIPTION
### Motivation
- Prevent a runtime crash in the polling failover supervisor caused by a shadowed `time_module` import and stop false REST failover triggers driven by stale-quote bookkeeping.
- Ensure WebSocket remains primary and `PollingStreamer` is the single REST fallback owner to avoid competing poll loops.
- Reduce noisy startup hydration logs and make the readiness gate depend only on core instruments so the bot can become trading-ready earlier.
- Add a lightweight startup fingerprint for deployment verification and fix a logger typo that suppressed proper tracebacks.

### Description
- Core failover and fingerprinting (src/nifty_scalper_bot/core/app.py): removed inner/local `import time as time_module` use and added `_polling_fallback_degraded()` to prioritize WS disconnect / MDM staleness / tick-lag over quote-age alone; added `_build_startup_fingerprint()` and a startup `LOGGER.info` of version/release. Reduced hydration pre-check log level and limited the startup hydration readiness check to core instruments (spot, futures, ATM CE, ATM PE).
- Market data manager fixes (src/nifty_scalper_bot/data/market_data_manager.py): update `_last_quote_ts_ms[symbol]` from the main live tick path (`_store_tick`) so quote-age stays fresh for live ticks; stop MDM internal REST thread immediately when `disable_rest_polling()` is called to avoid duplicate polling loops; change `insufficient_bars_for_strategy` from `error` to `info`; correct `exec_info=True` → `exc_info=True` in logging.
- Tests (tests/*): added/updated targeted tests to cover: MDM quote-age refresh on live tick, stale-age recovery after fresh tick, internal-rest-thread stop on `disable_rest_polling`, readiness gating limited to core instruments, and a module-level guard ensuring no inner `time_module` import remains plus fallback degrade policy behavior.
- Minor: removed the inner `import time as time_module` in the Greeks monitor block to prevent closure free-variable errors and preserved function signatures and component wiring so `WebSocketManager` stays primary and `PollingStreamer` remains the single fallback owner.

Files changed (key edits):
- src/nifty_scalper_bot/core/app.py — polling failover logic, startup fingerprint, hydration gating, removed inner time import, logging adjustments.
- src/nifty_scalper_bot/data/market_data_manager.py — `_store_tick` updates `_last_quote_ts_ms`, `disable_rest_polling` stops thread, readiness logic & logging severity, `exc_info` fix.
- tests/data/test_market_data_manager.py — added tests for quote-age refresh, stale→fresh recovery, disable-rest-poller behaviour, and readiness scope.
- tests/streaming/test_websocket_manager.py — added checks for module-level `time_module` usage and degrade logic contract.

### Testing
- Ran the targeted test suites and focused test groups:
  - `pytest -q tests/data/test_market_data_manager.py -k "readiness_allows_outer_option_basket_to_lag or store_tick_refreshes_quote_age_for_live_ticks or quote_age_recovers_after_fresh_tick or disable_rest_polling_stops_internal_thread"` → all tests passed (100%).
  - `pytest -q tests/streaming/test_polling_streamer.py tests/streaming/test_websocket_manager.py` → all tests passed (100%).
- Result: targeted tests green for the modified behaviors and no closure/free-variable crashes in the supervisor test.  
- Remaining / follow-up: only targeted tests were executed as requested; recommend running `./run_checks.sh` (lint, mypy, full pytest, lightweight backtest) in CI before release to confirm full-suite compatibility.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e835189f688324946f5b3fd0de14a1)