### PR TITLE
fix: enforce symbol readiness gating and WS subscription proofs

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -116,6 +116,58 @@ def _run_sync_locked(operation: Callable[[], Any]) -> Any:
         return operation()
 
 
+def _symbol_history_requirement(ctx: Any) -> int:
+    """Compute per-symbol history requirement. Args: ctx. Returns: bars. Raises: none."""
+
+    reqs = [20, 50]
+    strategy_runner = getattr(ctx, "strategy_runner", None)
+    market_data_manager = getattr(ctx, "market_data_manager", None)
+    if strategy_runner is not None:
+        reqs.append(int(getattr(strategy_runner, "_required_candles", 0) or 0))
+    if market_data_manager is not None:
+        reqs.append(int(getattr(market_data_manager, "_min_required_bars", 0) or 0))
+    return max(r for r in reqs if r > 0)
+
+
+def _history_lookback_minutes(required_bars: int) -> int:
+    """Derive hydration lookback window. Args: required bars. Returns: minutes. Raises: none."""
+
+    required = max(1, int(required_bars))
+    buffer_bars = max(20, required // 2)
+    return max(180, required + buffer_bars)
+
+
+def _gate_runner_symbol_add(
+    ctx: Any,
+    symbol: str,
+    pending_runner_symbols: set[str],
+) -> bool:
+    """Gate StrategyRunner add by bar readiness. Args: ctx/symbol/pending. Returns: added flag. Raises: none."""
+
+    if not ctx.strategy_runner or not ctx.market_data_manager:
+        return False
+    bars = len(ctx.market_data_manager.get_ohlc_bars(symbol) or [])
+    required = _symbol_history_requirement(ctx)
+    if bars >= required:
+        ctx.strategy_runner.add_symbol(symbol)
+        pending_runner_symbols.discard(symbol)
+        return True
+    pending_runner_symbols.add(symbol)
+    LOGGER.info(
+        "symbol_add_deferred_waiting_for_history symbol=%s bars=%d required=%d",
+        symbol,
+        bars,
+        required,
+        extra={
+            "event": "symbol_add_deferred_waiting_for_history",
+            "symbol": symbol,
+            "bars": bars,
+            "required": required,
+        },
+    )
+    return False
+
+
 from urllib.parse import urlsplit
 from zoneinfo import ZoneInfo
 
@@ -5424,7 +5476,16 @@ async def startup_sequence(ctx: BotContext) -> None:
                     _spot_for_hydration = float(_last_nifty.get("ltp", _spot_for_hydration))
 
             # Select ATM option contracts purely by token — no string building
-            _atm_contracts = get_atm_contracts(_sync_broker_for_hydration, _spot_for_hydration)
+            _preloaded = (
+                ctx.instrument_manager.get_nifty_instruments_snapshot()
+                if hasattr(ctx.instrument_manager, "get_nifty_instruments_snapshot")
+                else None
+            )
+            _atm_contracts = get_atm_contracts(
+                _sync_broker_for_hydration,
+                _spot_for_hydration,
+                preloaded_instruments=_preloaded or None,
+            )
             _atm_tokens = [int(c["instrument_token"]) for c in _atm_contracts]
             # Validate all tokens before hydration
             for _t in _atm_tokens:
@@ -5900,6 +5961,8 @@ async def startup_sequence(ctx: BotContext) -> None:
             unresolved_symbols = []
             live_mode_enabled = bool(ctx.settings.enable_live)
             active_symbols: list[str] = []
+            active_symbol_tokens: dict[str, int] = {}
+            pending_runner_symbols: set[str] = set()
 
             for sym in targets:
                 if mdm:
@@ -5915,10 +5978,10 @@ async def startup_sequence(ctx: BotContext) -> None:
                     if tok not in tokens_to_poll:
                         tokens_to_poll.append(tok)
                     active_symbols.append(sym)
+                    active_symbol_tokens[sym] = int(tok)
                     resolved_count += 1
                     LOGGER.info(f"✅ Resolved: {sym} -> token {tok}")
-                    if ctx.strategy_runner:
-                        ctx.strategy_runner.add_symbol(sym)
+                    _gate_runner_symbol_add(ctx, sym, pending_runner_symbols)
                 else:
                     unresolved_symbols.append(sym)
                     LOGGER.warning(
@@ -5976,6 +6039,17 @@ async def startup_sequence(ctx: BotContext) -> None:
                     LOGGER.info(
                         "✅ Wired %d tokens to WebSocket", len(tokens_to_poll)
                     )
+                    for _sym, _tok in sorted(active_symbol_tokens.items()):
+                        LOGGER.info(
+                            "WS SUBSCRIBED: %s (%s)",
+                            _sym,
+                            _tok,
+                            extra={
+                                "event": "ws_subscribed_symbol",
+                                "symbol": _sym,
+                                "token": int(_tok),
+                            },
+                        )
                 elif streamer and hasattr(streamer, "subscribe"):
                     streamer.subscribe(tokens_to_poll)
                     LOGGER.info(
@@ -6133,15 +6207,6 @@ async def startup_sequence(ctx: BotContext) -> None:
             option_universe_controller = UniverseController()
             option_universe_controller.update(dynamic_option_symbols)
             # Symbols waiting for enough MDM bars before being added to runner.
-            pending_runner_symbols: set[str] = set()
-
-            def _symbol_history_requirement() -> int:
-                reqs = [20, 50]
-                if ctx.strategy_runner is not None:
-                    reqs.append(int(getattr(ctx.strategy_runner, "_required_candles", 0) or 0))
-                if ctx.market_data_manager is not None:
-                    reqs.append(int(getattr(ctx.market_data_manager, "_min_required_bars", 0) or 0))
-                return max(r for r in reqs if r > 0)
 
             async def _option_universe_sync_loop() -> None:
                 """Keep option subscriptions aligned with the dynamic option universe."""
@@ -6153,7 +6218,7 @@ async def startup_sequence(ctx: BotContext) -> None:
                             still_pending: set[str] = set()
                             for _psym in list(pending_runner_symbols):
                                 _bars = len(ctx.market_data_manager.get_ohlc_bars(_psym) or [])
-                                if _bars >= _symbol_history_requirement():
+                                if _bars >= _symbol_history_requirement(ctx):
                                     ctx.strategy_runner.add_symbol(_psym)
                                     LOGGER.info(
                                         "symbol_add_deferred_ready symbol=%s bars=%d",
@@ -6239,6 +6304,16 @@ async def startup_sequence(ctx: BotContext) -> None:
                                 ctx.market_data_manager.register_symbol(sym, tok)
                             if tok and ctx.websocket_manager is not None:
                                 ctx.websocket_manager.subscribe_tokens([tok])
+                                LOGGER.info(
+                                    "WS SUBSCRIBED: %s (%s)",
+                                    sym,
+                                    tok,
+                                    extra={
+                                        "event": "ws_subscribed_symbol",
+                                        "symbol": sym,
+                                        "token": int(tok),
+                                    },
+                                )
                             elif (
                                 tok
                                 and ctx.streamer
@@ -6252,8 +6327,10 @@ async def startup_sequence(ctx: BotContext) -> None:
                             # immediately evaluating with no history.
                             if ctx.broker_client and ctx.market_data_manager:
                                 try:
+                                    required_bars = _symbol_history_requirement(ctx)
+                                    lookback_minutes = _history_lookback_minutes(required_bars)
                                     end_dt = datetime.now()
-                                    start_dt = end_dt - timedelta(hours=2)
+                                    start_dt = end_dt - timedelta(minutes=lookback_minutes)
                                     records = await asyncio.to_thread(
                                         ctx.broker_client.get_ohlc,
                                         sym,
@@ -6298,28 +6375,7 @@ async def startup_sequence(ctx: BotContext) -> None:
                                     )
                             # Add to runner only after MDM holds enough bars.
                             # Defer if still under-hydrated; the loop retries.
-                            if ctx.strategy_runner and ctx.market_data_manager:
-                                _bars = len(ctx.market_data_manager.get_ohlc_bars(sym) or [])
-                                _required = _symbol_history_requirement()
-                                if _bars >= _required:
-                                    ctx.strategy_runner.add_symbol(sym)
-                                else:
-                                    LOGGER.info(
-                                        "symbol_add_deferred_waiting_for_history"
-                                        " symbol=%s bars=%d required=%d",
-                                        sym,
-                                        _bars,
-                                        _required,
-                                        extra={
-                                            "event": "symbol_add_deferred_waiting_for_history",
-                                            "symbol": sym,
-                                            "bars": _bars,
-                                            "required": _required,
-                                        },
-                                    )
-                                    pending_runner_symbols.add(sym)
-                            elif ctx.strategy_runner:
-                                ctx.strategy_runner.add_symbol(sym)
+                            _gate_runner_symbol_add(ctx, sym, pending_runner_symbols)
 
                         for sym in drop_symbols:
                             tok = None

--- a/src/nifty_scalper_bot/core/contract_selector.py
+++ b/src/nifty_scalper_bot/core/contract_selector.py
@@ -73,6 +73,7 @@ def get_atm_contracts(
     *,
     strike_band: int = _STRIKE_BAND,
     strike_step: int | None = None,
+    preloaded_instruments: list[dict[str, Any]] | None = None,
 ) -> list[dict[str, Any]]:
     """Return NIFTY option contracts for the nearest expiry around the ATM strike.
 
@@ -102,11 +103,22 @@ def get_atm_contracts(
             f"underlying_price must be positive, got {underlying_price}"
         )
 
-    LOGGER.info(
-        "ContractSelector: fetching NFO instruments for ATM=%.2f …",
-        underlying_price,
-    )
-    all_instruments: list[dict] = list(kite.instruments("NFO"))
+    if preloaded_instruments:
+        LOGGER.info(
+            "ContractSelector: using preloaded NFO instruments for ATM=%.2f",
+            underlying_price,
+            extra={
+                "event": "contract_selector_cache_hit",
+                "instruments": len(preloaded_instruments),
+            },
+        )
+        all_instruments: list[dict] = list(preloaded_instruments)
+    else:
+        LOGGER.info(
+            "ContractSelector: fetching NFO instruments for ATM=%.2f …",
+            underlying_price,
+        )
+        all_instruments = list(kite.instruments("NFO"))
 
     # ── filter to NIFTY options only ─────────────────────────────────────────
     nifty_opts = [

--- a/src/nifty_scalper_bot/core/instrument_manager.py
+++ b/src/nifty_scalper_bot/core/instrument_manager.py
@@ -200,6 +200,12 @@ class InstrumentManager:
         with self._lock:
             return len(self._symbol_map)
 
+    def get_nifty_instruments_snapshot(self) -> List[Dict[str, Any]]:
+        """Return cached NIFTY instrument rows. Args: none. Returns: rows. Raises: none."""
+
+        with self._lock:
+            return [dict(row) for row in self._instrument_data.values()]
+
     def get_lot_size(self, token_or_symbol: int | str) -> Optional[int]:
         """Get lot size for a token or symbol.
         

--- a/src/nifty_scalper_bot/data/data_hub.py
+++ b/src/nifty_scalper_bot/data/data_hub.py
@@ -134,6 +134,7 @@ class DataHub:
         self._last_ts: Dict[str, float] = {}
         self._last_arrival: Dict[str, float] = {}
         self._last_ws_arrival: Dict[str, float] = {}
+        self._last_poll_arrival: Dict[str, float] = {}
         self._last_global_ws_arrival = 0.0
         self._last_arrival_mono: Dict[str, float] = {}
         self._stale_candidates: Dict[str, int] = defaultdict(int)
@@ -589,9 +590,11 @@ class DataHub:
             self._last_ts[symbol] = ts_ms
             self._last_arrival[symbol] = now_ms
             self._last_arrival_mono[symbol] = mono_now
-            if source == "ws":
+            if source in {"ws", "websocket", "stream"}:
                 self._last_ws_arrival[symbol] = now_ms
                 self._last_global_ws_arrival = now_ms
+            elif source in {"poll", "rest"}:
+                self._last_poll_arrival[symbol] = now_ms
             self._stale_candidates[symbol] = 0
             subscribers = list(self._tick_subscribers.get(symbol, ()))
 

--- a/src/nifty_scalper_bot/streaming/websocket_manager.py
+++ b/src/nifty_scalper_bot/streaming/websocket_manager.py
@@ -149,6 +149,7 @@ class WebSocketManager:
         self._fallback_stop_callback: Callable[[], None] | None = None
         self._fallback_active = False
         self._first_tick_logged = False
+        self._subscription_log_tokens: set[int] = set()
 
     @property
     def on_tick(self) -> TickCallback | None:
@@ -655,6 +656,7 @@ class WebSocketManager:
                         )
                 ws.subscribe(token_list)
                 ws.set_mode(ws.MODE_FULL, token_list)
+                self._log_ws_subscriptions(token_list)
                 symbol_map = getattr(mdm, "_symbol_by_token", {})
                 active_symbols = {
                     symbol_map.get(token)
@@ -842,12 +844,37 @@ class WebSocketManager:
             batch = payload[idx : idx + 200]
             await asyncio.to_thread(ticker.subscribe, batch)
             await asyncio.to_thread(ticker.set_mode, ticker.MODE_FULL, batch)
+            self._log_ws_subscriptions(batch)
 
     def _merge_tokens(self, tokens: Sequence[int]) -> None:
         """Args: tokens; Returns: none; Raises: none."""
 
         for token in tokens:
             self._tokens.add(int(token))
+
+    def _log_ws_subscriptions(self, tokens: Sequence[int]) -> None:
+        """Emit symbol/token subscription logs once per token. Args: tokens. Returns: none. Raises: none."""
+
+        mdm = getattr(self, "_market_data_manager", None)
+        symbol_map = getattr(mdm, "_symbol_by_token", {}) if mdm is not None else {}
+        for raw_token in tokens:
+            token = int(raw_token)
+            if token in self._subscription_log_tokens:
+                continue
+            symbol = symbol_map.get(token)
+            if not symbol:
+                continue
+            self._subscription_log_tokens.add(token)
+            self._logger.info(
+                "WS SUBSCRIBED: %s (%s)",
+                symbol,
+                token,
+                extra={
+                    "event": "ws_subscribed_symbol",
+                    "symbol": symbol,
+                    "token": token,
+                },
+            )
 
     def _resolve_loop(self) -> asyncio.AbstractEventLoop:
         """Args: none; Returns: event loop; Raises: RuntimeError."""

--- a/tests/core/test_app_runner_symbol_gate.py
+++ b/tests/core/test_app_runner_symbol_gate.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from nifty_scalper_bot.core.app import (
+    _gate_runner_symbol_add,
+    _history_lookback_minutes,
+    _symbol_history_requirement,
+)
+
+
+class _Runner:
+    def __init__(self, required: int = 50) -> None:
+        self._required_candles = required
+        self.added: list[str] = []
+
+    def add_symbol(self, sym: str) -> None:
+        self.added.append(sym)
+
+
+class _Mdm:
+    def __init__(self, bars_by_symbol: dict[str, int], required: int = 50) -> None:
+        self._min_required_bars = required
+        self._bars_by_symbol = bars_by_symbol
+
+    def get_ohlc_bars(self, sym: str):
+        return [object()] * int(self._bars_by_symbol.get(sym, 0))
+
+
+def test_startup_runner_add_gate_resolved_and_unresolved() -> None:
+    runner = _Runner(required=55)
+    mdm = _Mdm({"NSE:NIFTY": 80, "NFO:NIFTY24500CE": 20}, required=60)
+    ctx = SimpleNamespace(strategy_runner=runner, market_data_manager=mdm)
+    pending: set[str] = set()
+
+    token_map = {"NSE:NIFTY": 256265, "NFO:NIFTY24500CE": 1234}
+    unresolved: list[str] = []
+    for sym in ["NSE:NIFTY", "NFO:NIFTY24500CE", "NFO:NIFTY24500PE"]:
+        tok = token_map.get(sym)
+        if not tok:
+            unresolved.append(sym)
+            continue
+        _gate_runner_symbol_add(ctx, sym, pending)
+
+    assert runner.added == ["NSE:NIFTY"]
+    assert "NFO:NIFTY24500CE" in pending
+    assert unresolved == ["NFO:NIFTY24500PE"]
+
+
+def test_active_basket_deferred_add_then_single_promotion() -> None:
+    runner = _Runner(required=50)
+    mdm = _Mdm({"NFO:NIFTY24600CE": 30}, required=50)
+    ctx = SimpleNamespace(strategy_runner=runner, market_data_manager=mdm)
+    pending: set[str] = set()
+
+    assert _gate_runner_symbol_add(ctx, "NFO:NIFTY24600CE", pending) is False
+    assert runner.added == []
+    assert "NFO:NIFTY24600CE" in pending
+
+    mdm._bars_by_symbol["NFO:NIFTY24600CE"] = 75
+    assert _gate_runner_symbol_add(ctx, "NFO:NIFTY24600CE", pending) is True
+    assert runner.added == ["NFO:NIFTY24600CE"]
+    assert "NFO:NIFTY24600CE" not in pending
+
+
+def test_symbol_history_requirement_uses_max_threshold() -> None:
+    runner = _Runner(required=75)
+    mdm = _Mdm({}, required=60)
+    ctx = SimpleNamespace(strategy_runner=runner, market_data_manager=mdm)
+    assert _symbol_history_requirement(ctx) == 75
+
+
+def test_history_fetch_lookback_grows_with_requirement() -> None:
+    assert _history_lookback_minutes(50) == 180
+    assert _history_lookback_minutes(240) > 240
+    assert _history_lookback_minutes(500) > _history_lookback_minutes(240)

--- a/tests/core/test_contract_selector_cache_preference.py
+++ b/tests/core/test_contract_selector_cache_preference.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from datetime import date
+
+from nifty_scalper_bot.core.contract_selector import get_atm_contracts
+
+
+class _Kite:
+    def __init__(self) -> None:
+        self.instruments_calls = 0
+
+    def instruments(self, exchange: str):
+        self.instruments_calls += 1
+        if exchange != "NFO":
+            return []
+        return []
+
+
+def _rows() -> list[dict]:
+    exp = date.today()
+    return [
+        {
+            "name": "NIFTY",
+            "instrument_type": "CE",
+            "expiry": exp,
+            "strike": 24500.0,
+            "instrument_token": 111,
+            "tradingsymbol": "NIFTYXX24500CE",
+            "exchange": "NFO",
+        },
+        {
+            "name": "NIFTY",
+            "instrument_type": "PE",
+            "expiry": exp,
+            "strike": 24500.0,
+            "instrument_token": 222,
+            "tradingsymbol": "NIFTYXX24500PE",
+            "exchange": "NFO",
+        },
+    ]
+
+
+def test_contract_selector_prefers_preloaded_cache() -> None:
+    kite = _Kite()
+    contracts = get_atm_contracts(
+        kite,
+        underlying_price=24510.0,
+        strike_band=100,
+        strike_step=50,
+        preloaded_instruments=_rows(),
+    )
+    assert len(contracts) == 2
+    assert kite.instruments_calls == 0

--- a/tests/data/test_data_hub_freshness_sources.py
+++ b/tests/data/test_data_hub_freshness_sources.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from nifty_scalper_bot.data.data_hub import DataHub
+
+
+class _Mdm:
+    def attach_tick_bus(self, _tick_bus) -> None:
+        return None
+
+
+def test_poll_source_does_not_update_ws_arrival_but_stream_does() -> None:
+    hub = DataHub(market_data_manager=_Mdm())
+    poll_tick = {
+        'symbol': 'NSE:NIFTY',
+        'instrument_token': 256265,
+        'ltp': 24000.0,
+        'timestamp': 1_000_000,
+        'source': 'poll',
+    }
+    hub.ingest_tick_sync(poll_tick)
+    assert hub._last_ws_arrival.get('NSE:NIFTY', 0.0) == 0.0
+
+    stream_tick = dict(poll_tick)
+    stream_tick['timestamp'] = 1_100_000
+    stream_tick['source'] = 'stream'
+    hub.ingest_tick_sync(stream_tick)
+    assert hub._last_ws_arrival.get('NSE:NIFTY', 0.0) > 0.0

--- a/tests/streaming/test_websocket_subscription_logs.py
+++ b/tests/streaming/test_websocket_subscription_logs.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+
+from nifty_scalper_bot.streaming.websocket_manager import WebSocketManager
+
+
+def test_logs_ws_subscriptions_for_futures_and_options(caplog) -> None:
+    manager = WebSocketManager(api_key='k', access_token='t')
+    manager._market_data_manager = SimpleNamespace(
+        _symbol_by_token={101: 'NFO:NIFTY26MAYFUT', 202: 'NFO:NIFTY26MAY24500CE'}
+    )
+
+    with caplog.at_level(logging.INFO):
+        manager._log_ws_subscriptions([101, 202, 101])
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert any('WS SUBSCRIBED: NFO:NIFTY26MAYFUT (101)' in msg for msg in messages)
+    assert any('WS SUBSCRIBED: NFO:NIFTY26MAY24500CE (202)' in msg for msg in messages)


### PR DESCRIPTION
### Motivation
- Ensure StrategyRunner never receives symbols until MarketDataManager holds sufficient history by centralizing the readiness gate. 
- Make startup and active-basket add paths use the same admission rule and avoid ad-hoc short lookbacks that led to repeated under-hydrated retries. 
- Reduce startup latency by preferring already-loaded instrument caches for ATM contract selection. 
- Provide unmistakable, structured logs proving futures and ATM CE/PE websocket subscriptions. 
- Keep poll vs websocket freshness semantics distinct so poll ticks cannot masquerade as websocket arrivals. 

### Description
- Introduced shared helpers in `core/app.py`: `_symbol_history_requirement(ctx)`, `_history_lookback_minutes(required_bars)`, and `_gate_runner_symbol_add(ctx, symbol, pending_runner_symbols)` and routed all `StrategyRunner.add_symbol(...)` calls through the gate so symbols are only admitted when MDM history >= requirement. (file: `src/nifty_scalper_bot/core/app.py`)
- Replaced fixed 2-hour history fetch for newly-added option symbols with a requirement-aware lookback calculated by `_history_lookback_minutes(...)`. (file: `src/nifty_scalper_bot/core/app.py`)
- Startup ATM contract selection now prefers already-loaded NFO instrument rows from `InstrumentManager.get_nifty_instruments_snapshot()` and passes them to the selector via `preloaded_instruments` to avoid redundant `instruments("NFO")` calls; selector still falls back to broker fetch when cache absent. (files: `src/nifty_scalper_bot/core/app.py`, `src/nifty_scalper_bot/core/contract_selector.py`, `src/nifty_scalper_bot/core/instrument_manager.py`)
- Added explicit structured logs `WS SUBSCRIBED: <symbol> (<token>)` for startup subscriptions and active-basket subscriptions, and added deduplicated subscription proof logs inside `WebSocketManager` when subscribe/resubscribe calls are issued. (files: `src/nifty_scalper_bot/core/app.py`, `src/nifty_scalper_bot/streaming/websocket_manager.py`)
- Ensured DataHub separates freshness markers: only websocket-like sources (`ws`, `websocket`, `stream`) update `_last_ws_arrival`/`_last_global_ws_arrival`, while poll/rest updates `_last_poll_arrival`. (file: `src/nifty_scalper_bot/data/data_hub.py`)
- Added focused unit tests that exercise the gating helper, lookback sizing, contract-selector cache preference, websocket subscription logs, and poll-vs-ws freshness behavior. (tests added under `tests/core`, `tests/streaming`, `tests/data`)

Changed files (one-line each):
- `src/nifty_scalper_bot/core/app.py` — central gating helpers, requirement-aware lookback, route all runner-adds through gate, startup WS-subscription proofs, and use instrument snapshot for ATM selection.
- `src/nifty_scalper_bot/core/contract_selector.py` — accept optional `preloaded_instruments` to avoid redundant broker calls.
- `src/nifty_scalper_bot/core/instrument_manager.py` — added `get_nifty_instruments_snapshot()` accessor.
- `src/nifty_scalper_bot/data/data_hub.py` — split ws vs poll freshness updates (`_last_ws_arrival` vs `_last_poll_arrival`).
- `src/nifty_scalper_bot/streaming/websocket_manager.py` — deduplicated per-token subscription proof logs emitted on subscribe/resubscribe.
- `tests/core/test_app_runner_symbol_gate.py` — gating, requirement and lookback tests.
- `tests/core/test_contract_selector_cache_preference.py` — cache-preference test for contract selector.
- `tests/streaming/test_websocket_subscription_logs.py` — subscription log test.
- `tests/data/test_data_hub_freshness_sources.py` — poll vs ws freshness test.

### Testing
- Attempted `./run_checks.sh`; initial run reported environment bootstrap issues (missing `pytest`) in this sandbox run environment and did not fully complete. (run output: dependency install run; `pytest` initially reported missing during the script run). 
- Installed test tooling and ran focused unit tests: `pytest -q tests/core/test_app_runner_symbol_gate.py tests/core/test_contract_selector_cache_preference.py tests/streaming/test_websocket_subscription_logs.py tests/data/test_data_hub_freshness_sources.py` — all tests passed. 
- Ran two targeted DataHub stale-data tests from the suite verifying poll does not update ws freshness: `pytest -q tests/data/test_stale_data_repair.py::TestDataHubPollTickDoesNotUpdateWS::test_poll_tick_does_not_set_last_ws_arrival tests/data/test_stale_data_repair.py::TestDataHubPollTickDoesNotUpdateWS::test_ws_tick_does_set_last_ws_arrival` — both passed. 
- Ran broader test collection with common ignores: `pytest -q tests --disable-warnings --ignore=tests/test_live_mode.py --ignore=tests/test_health_server.py` — collection failed on an unrelated pre-existing test importing `InstrumentResolver` (test-suite housekeeping issue), not caused by these changes. 

Remaining known risk: low — changes are surgical and preserve fallbacks; the only outstanding test-suite noise is an unrelated test import issue in the repo that prevents a full run in this sandbox (external to the fixes introduced).  

If you want, I can now: (a) tidy the minor ruff/mypy nits shown by the check run, or (b) walk through enabling a full `./run_checks.sh` execution in CI where environment tooling is preinstalled.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e88bf6649c832499fe9946e9722741)