### PR TITLE
fix: correct telegram transport ownership in polling mode

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -1112,6 +1112,34 @@ def _resolve_session_reason(
     return reason if reason else "OK", soft_override
 
 
+def _telegram_webhook_env_requested() -> bool:
+    """Return whether webhook transport was explicitly enabled via environment variables."""
+
+    raw_value = os.getenv("TELEGRAM__WEBHOOK_ENABLED")
+    if raw_value is None:
+        raw_value = os.getenv("TELEGRAM_WEBHOOK_ENABLED")
+    return str(raw_value or "").strip().lower() == "true"
+
+
+def _telegram_transport_mode(settings: Settings) -> str:
+    """Return the configured transport mode for Telegram notifications."""
+
+    notifications = settings.notifications
+    if (
+        notifications.enabled
+        and notifications.webhook_enabled
+        and bool((notifications.public_base_url or "").strip())
+    ):
+        return "webhook"
+    return "polling"
+
+
+def _telegram_requires_http_controller(settings: Settings) -> bool:
+    """Return whether Telegram delivery for this process needs HTTP controller wiring."""
+
+    return _telegram_transport_mode(settings) == "webhook"
+
+
 def get_http_app() -> FastAPI:
     """Return the FastAPI application exposing inbound Telegram webhook."""
     global _HTTP_APP, _HTTP_NOTIFIER, _HTTP_CONTROLLER
@@ -1124,10 +1152,7 @@ def get_http_app() -> FastAPI:
 
     telemetry_logger = get_logger("telegram.bootstrap")
 
-    raw_webhook_env = os.getenv("TELEGRAM__WEBHOOK_ENABLED")
-    if raw_webhook_env is None:
-        raw_webhook_env = os.getenv("TELEGRAM_WEBHOOK_ENABLED")
-    webhook_env_requested = str(raw_webhook_env or "false").strip().lower() == "true"
+    webhook_env_requested = _telegram_webhook_env_requested()
 
     if not webhook_env_requested and settings.notifications.webhook_enabled:
         settings.notifications.webhook_enabled = False
@@ -1139,6 +1164,7 @@ def get_http_app() -> FastAPI:
     notifier = TelegramEnhancedNotifier.from_settings(settings.notifications)
     _HTTP_NOTIFIER = notifier
 
+    _HTTP_CONTROLLER = None
     controller: TelegramWebhookController | None = None
     if settings.notifications.enabled:
         if notifier is None:
@@ -1146,13 +1172,21 @@ def get_http_app() -> FastAPI:
                 "telegram_controller_skipped",
                 extra={"event": "controller_skipped", "reason": "no_notifier"},
             )
-        else:
+        elif _telegram_requires_http_controller(settings):
             controller = TelegramWebhookController(
                 bot=notifier.bot,
                 settings=settings.notifications,
             )
             app.include_router(controller.router)
             _HTTP_CONTROLLER = controller
+        else:
+            telemetry_logger.info(
+                "telegram_http_controller_not_required",
+                extra={
+                    "event": "telegram_http_controller_not_required",
+                    "mode": "polling",
+                },
+            )
     else:
         telemetry_logger.info(
             "telegram_disabled",
@@ -1280,11 +1314,13 @@ def get_http_app() -> FastAPI:
     async def _startup_webhook() -> None:
         telegram_logger = get_logger("telegram")
         notif_settings = settings.notifications
-        if (
-            controller
-            and notif_settings.webhook_enabled
-            and notif_settings.public_base_url
-        ):
+        if controller is None:
+            telegram_logger.info(
+                "telegram_webhook_startup_skipped",
+                extra={"event": "telegram_webhook_startup_skipped", "mode": "polling"},
+            )
+            return
+        if notif_settings.webhook_enabled and notif_settings.public_base_url:
             registered = await register_webhook(
                 controller.bot,
                 notif_settings.public_base_url,
@@ -1308,7 +1344,7 @@ def get_http_app() -> FastAPI:
                         },
                     )
         else:
-            if controller and notif_settings.allow_poll_fallback:
+            if notif_settings.allow_poll_fallback:
                 await controller.activate_polling_fallback("webhook url missing")
                 telegram_logger.info(
                     "telegram_polling_started_no_webhook",
@@ -1357,6 +1393,7 @@ def get_http_app() -> FastAPI:
     # ----------------------------------------------------------------
 
     app.include_router(selftest_router)
+    return app
 
 
 def get_telegram_notifier() -> TelegramEnhancedNotifier | None:
@@ -4962,28 +4999,8 @@ def initialize_components(settings: Settings | None = None) -> BotContext:
 
     telegram_cfg = getattr(config, "telegram", None)
     ctx.telegram_bot = None
-    # Ensure controller exists for telegram setup
-    controller = _HTTP_CONTROLLER
-    if (
-        controller is None
-        and settings.notifications.enabled
-        and settings.notifications.webhook_enabled
-    ):
-        # Create a minimal webhook controller only when webhook transport is active.
-        try:
-            from nifty_scalper_bot.notifications.telegram_webhook_enhanced import (
-                TelegramWebhookController,
-            )
-
-            notifier = ctx.telegram_notifier
-            if notifier and hasattr(notifier, "bot"):
-                controller = TelegramWebhookController(
-                    bot=notifier.bot,
-                    settings=settings.notifications,
-                )
-                LOGGER.info("✅ Created TelegramWebhookController (webhook mode)")
-        except Exception as e:
-            LOGGER.warning(f"Could not create fallback controller: {e}")
+    telegram_transport_mode = _telegram_transport_mode(settings)
+    controller = _HTTP_CONTROLLER if _telegram_requires_http_controller(settings) else None
     telegram_bot_instance: TelegramBot | None = None
     telegram_chat_id: int | None = None
 
@@ -5165,74 +5182,83 @@ def initialize_components(settings: Settings | None = None) -> BotContext:
             telegram_chat_id = int(telegram_cfg.chat_id)
             LOGGER.info("Telegram configured for chat_id=%s", telegram_chat_id)
 
-            if controller is not None and settings.notifications.enabled:
-                try:
-                    application = telegram_bot_instance.build_application(
-                        bot=controller.bot
-                    )
-                except Exception as exc:  # noqa: BLE001 - defensive wiring
-                    LOGGER.exception(
-                        "telegram_application_build_failed",
+            if settings.notifications.enabled and telegram_transport_mode == "webhook":
+                if controller is None:
+                    LOGGER.warning(
+                        "telegram_application_controller_missing",
                         extra={
-                            "event": "telegram_application_build_failed",
-                            "err": str(exc),
+                            "event": "telegram_application_controller_missing",
+                            "mode": "webhook",
                         },
                     )
                 else:
-                    ctx.telegram_application = application
-                    controller.attach_application(application)
-                    LOGGER.info(
-                        "telegram_application_attached",
-                        extra={"event": "telegram_application_attached"},
-                    )
-                    version_info = {
-                        "build": str(getattr(config, "version", "unknown")),
-                        "sha": str(getattr(settings, "git_sha", "unknown")),
-                    }
-                    services_bundle = TelegramCommandServices(
-                        order_manager=ctx.order_manager,
-                        risk_manager=ctx.risk_manager,
-                        market_data=ctx.market_data_manager,
-                        strategy_runner=ctx.strategy_runner,
-                        config=config,
-                        broker=ctx.broker_client,
-                        journal=None,
-                        metrics=None,
-                        market_regime=ctx.market_regime,
-                        state_tracker=ctx.state_tracker,
-                        preflight_validator=ctx.preflight_validator,
-                        version_info=version_info,
-                        allowed_chat_id=telegram_chat_id,
-                    )
                     try:
-                        register_telegram_commands(
-                            telegram_bot_instance, application, services_bundle
+                        application = telegram_bot_instance.build_application(
+                            bot=controller.bot
                         )
                     except Exception as exc:  # noqa: BLE001 - defensive wiring
-                        LOGGER.warning(
-                            "telegram_command_registration_failed",
+                        LOGGER.exception(
+                            "telegram_application_build_failed",
                             extra={
-                                "event": "telegram_command_registration_failed",
+                                "event": "telegram_application_build_failed",
                                 "err": str(exc),
                             },
                         )
-                    hook = getattr(
-                        telegram_bot_instance, "after_application_built", None
-                    )
-                    if callable(hook):
-                        result = hook()
-                        if inspect.isawaitable(result):
-                            awaitable = cast(Coroutine[Any, Any, object], result)
-                            try:
-                                loop = asyncio.get_running_loop()
-                            except RuntimeError:
-                                asyncio.run(awaitable)
-                            else:
-                                loop.create_task(awaitable)
-            elif settings.notifications.enabled and controller is None:
-                LOGGER.warning(
-                    "telegram_application_controller_missing",
-                    extra={"event": "telegram_application_controller_missing"},
+                    else:
+                        ctx.telegram_application = application
+                        controller.attach_application(application)
+                        LOGGER.info(
+                            "telegram_application_attached",
+                            extra={"event": "telegram_application_attached"},
+                        )
+                        version_info = {
+                            "build": str(getattr(config, "version", "unknown")),
+                            "sha": str(getattr(settings, "git_sha", "unknown")),
+                        }
+                        services_bundle = TelegramCommandServices(
+                            order_manager=ctx.order_manager,
+                            risk_manager=ctx.risk_manager,
+                            market_data=ctx.market_data_manager,
+                            strategy_runner=ctx.strategy_runner,
+                            config=config,
+                            broker=ctx.broker_client,
+                            journal=None,
+                            metrics=None,
+                            market_regime=ctx.market_regime,
+                            state_tracker=ctx.state_tracker,
+                            preflight_validator=ctx.preflight_validator,
+                            version_info=version_info,
+                            allowed_chat_id=telegram_chat_id,
+                        )
+                        try:
+                            register_telegram_commands(
+                                telegram_bot_instance, application, services_bundle
+                            )
+                        except Exception as exc:  # noqa: BLE001 - defensive wiring
+                            LOGGER.warning(
+                                "telegram_command_registration_failed",
+                                extra={
+                                    "event": "telegram_command_registration_failed",
+                                    "err": str(exc),
+                                },
+                            )
+                        hook = getattr(
+                            telegram_bot_instance, "after_application_built", None
+                        )
+                        if callable(hook):
+                            result = hook()
+                            if inspect.isawaitable(result):
+                                awaitable = cast(Coroutine[Any, Any, object], result)
+                                try:
+                                    loop = asyncio.get_running_loop()
+                                except RuntimeError:
+                                    asyncio.run(awaitable)
+                                else:
+                                    loop.create_task(awaitable)
+            elif settings.notifications.enabled and telegram_transport_mode == "polling":
+                LOGGER.info(
+                    "telegram_application_attach_skipped",
+                    extra={"event": "telegram_application_attach_skipped", "mode": "polling"},
                 )
         else:
             LOGGER.info("Telegram disabled (no token/chat_id provided).")

--- a/tests/notifications/test_telegram_http_app.py
+++ b/tests/notifications/test_telegram_http_app.py
@@ -89,7 +89,7 @@ def test_http_app_registers_webhook(monkeypatch) -> None:
     core_app._HTTP_NOTIFIER = None
 
 
-def test_http_app_starts_polling_when_webhook_missing(monkeypatch) -> None:
+def test_http_app_skips_webhook_controller_when_webhook_missing(monkeypatch) -> None:
     monkeypatch.setenv("BROKER_API_KEY", "demo")
     monkeypatch.setenv("BROKER_API_SECRET", "demo-secret")
     monkeypatch.setenv("BROKER_ACCESS_TOKEN", "demo-token")
@@ -103,44 +103,28 @@ def test_http_app_starts_polling_when_webhook_missing(monkeypatch) -> None:
     core_app = importlib.import_module("nifty_scalper_bot.core.app")
     importlib.reload(core_app)
 
-    events: list[tuple[str, dict[str, object] | None]] = []
-
-    async def fake_send_event(
-        self, event: str, payload: dict[str, object] | None = None
-    ) -> None:
-        events.append((event, payload))
-
-    monkeypatch.setattr(
-        core_app.TelegramEnhancedNotifier,
-        "send_event",
-        fake_send_event,
-        raising=False,
-    )
-
-    started: dict[str, object] = {}
-
-    async def record_activate(
+    async def fail_activate(
         self, reason: str, *, interval: float | None = None
     ) -> None:  # type: ignore[no-untyped-def]
-        started["controller"] = self
-        started["reason"] = reason
+        raise AssertionError(f"polling fallback should not start (reason={reason})")
 
+    def fail_register(*_args, **_kwargs) -> None:  # type: ignore[no-untyped-def]
+        raise AssertionError("webhook registration should not be attempted")
+
+    monkeypatch.setattr(core_app, "register_webhook", fail_register)
     monkeypatch.setattr(
         core_app.TelegramWebhookController,
         "activate_polling_fallback",
-        record_activate,
+        fail_activate,
     )
 
     app = core_app.get_http_app()
 
-    assert "/telegram/webhook" in _ensure_routes(app)
+    assert "/telegram/webhook" not in _ensure_routes(app)
+    assert core_app._HTTP_CONTROLLER is None
 
     with TestClient(app):
         pass
-
-    assert started
-    assert started["reason"] == "webhook url missing"
-    assert events == []
 
     settings_module.get_settings.cache_clear()
     core_app._HTTP_APP = None
@@ -148,7 +132,7 @@ def test_http_app_starts_polling_when_webhook_missing(monkeypatch) -> None:
     core_app._HTTP_NOTIFIER = None
 
 
-def test_http_app_polling_when_webhook_disabled(monkeypatch) -> None:
+def test_http_app_skips_webhook_controller_when_webhook_disabled(monkeypatch) -> None:
     monkeypatch.setenv("BROKER_API_KEY", "demo")
     monkeypatch.setenv("BROKER_API_SECRET", "demo-secret")
     monkeypatch.setenv("BROKER_ACCESS_TOKEN", "demo-token")
@@ -163,13 +147,10 @@ def test_http_app_polling_when_webhook_disabled(monkeypatch) -> None:
     core_app = importlib.import_module("nifty_scalper_bot.core.app")
     importlib.reload(core_app)
 
-    started: dict[str, object] = {}
-
-    async def record_activate(
+    async def fail_activate(
         self, reason: str, *, interval: float | None = None
     ) -> None:  # type: ignore[no-untyped-def]
-        started["controller"] = self
-        started["reason"] = reason
+        raise AssertionError(f"polling fallback should not start (reason={reason})")
 
     def fail_register(*_args, **_kwargs) -> None:  # type: ignore[no-untyped-def]
         raise AssertionError("webhook registration should be skipped when disabled")
@@ -177,19 +158,17 @@ def test_http_app_polling_when_webhook_disabled(monkeypatch) -> None:
     monkeypatch.setattr(
         core_app.TelegramWebhookController,
         "activate_polling_fallback",
-        record_activate,
+        fail_activate,
     )
     monkeypatch.setattr(core_app, "register_webhook", fail_register)
 
     app = core_app.get_http_app()
 
-    assert "/telegram/webhook" in _ensure_routes(app)
+    assert "/telegram/webhook" not in _ensure_routes(app)
+    assert core_app._HTTP_CONTROLLER is None
 
     with TestClient(app):
         pass
-
-    assert started
-    assert started["reason"] == "webhook url missing"
 
     settings_module.get_settings.cache_clear()
     core_app._HTTP_APP = None

--- a/tests/test_initialize_components_polling.py
+++ b/tests/test_initialize_components_polling.py
@@ -24,6 +24,15 @@ from nifty_scalper_bot.config.settings import (
 from nifty_scalper_bot.core.app import initialize_components
 
 
+class DummyTelegramBot:
+    def __init__(self, _deps) -> None:  # noqa: ANN001
+        self.application_build_calls = 0
+
+    def build_application(self, *, bot) -> object:  # noqa: ANN001
+        self.application_build_calls += 1
+        return object()
+
+
 class DummyBroker:
     def __init__(self, api_key: str, api_secret: str, access_token: str) -> None:
         self.api_key = api_key
@@ -387,3 +396,65 @@ def test_poll_tick_invalid_token_is_dropped(
     assert "instrument_token" not in tick
     warnings = [record.message for record in caplog.records]
     assert "invalid_token_value" in warnings
+
+
+def test_initialize_components_polling_telegram_does_not_require_controller(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    monkeypatch.setattr("nifty_scalper_bot.core.app.ZerodhaKiteClient", DummyBroker)
+    monkeypatch.setattr("nifty_scalper_bot.core.app.InstrumentResolver", DummyResolver)
+    monkeypatch.setattr(
+        "nifty_scalper_bot.core.app.MarketDataManager", DummyMarketDataManager
+    )
+    monkeypatch.setattr(
+        "nifty_scalper_bot.core.app.PollingStreamer", DummyPollingStreamer
+    )
+    monkeypatch.setattr(
+        "nifty_scalper_bot.notifications.telegram_controller.TelegramBot",
+        DummyTelegramBot,
+    )
+    monkeypatch.setattr("nifty_scalper_bot.core.app._HTTP_CONTROLLER", None)
+
+    app_config = AppConfig(
+        broker=BrokerConfig(
+            api_key="demo",
+            api_secret="secret",
+            access_token="token",
+            base_url="https://example.com",
+            websocket_url="wss://example.com/ws",
+        ),
+        risk=RiskConfig(),
+        logging=LoggingConfig(level="INFO"),
+        ratelimit=RateLimitConfig(
+            orders=RateLimitBucketConfig(capacity=10, refill_rate_per_sec=10.0),
+            rest=RateLimitBucketConfig(capacity=10, refill_rate_per_sec=10.0),
+            hist=RateLimitBucketConfig(capacity=10, refill_rate_per_sec=10.0),
+        ),
+        quote_stale_threshold_ms=1_000,
+    )
+    settings = Settings(
+        app=app_config,
+        enable_live=False,
+        orders=OrderSettings(),
+        risk=RiskSettings(),
+        streamer=StreamerSettings(),
+        shadow=ShadowSettings(drift_threshold_pct=0.0),
+        notifications=NotificationSettings(
+            enabled=True,
+            token="fake-token",
+            chat_id=12345,
+            webhook_enabled=False,
+            public_base_url=None,
+        ),
+        session_allow_out_of_hours=False,
+        allow_offmarket_trading=False,
+    )
+    settings.app.telegram.bot_token = "fake-token"
+    settings.app.telegram.chat_id = 12345
+
+    caplog.set_level("INFO")
+    ctx = initialize_components(settings)
+
+    assert ctx.telegram_bot is not None
+    warnings = [record.message for record in caplog.records]
+    assert "telegram_application_controller_missing" not in warnings


### PR DESCRIPTION
### Motivation
- Polling mode produced a false `telegram_application_controller_missing` warning because controller ownership and creation were split between HTTP app setup and runtime initialization.
- The HTTP app eagerly created a webhook controller and attempted polling fallback even when webhook transport was not requested, causing duplicated creation paths and contradictory logs.

### Description
- Added three small, pure helpers to centralise transport decisions: `_telegram_webhook_env_requested()`, `_telegram_transport_mode(settings)` and `_telegram_requires_http_controller(settings)` in `src/nifty_scalper_bot/core/app.py`.
- Changed `get_http_app()` to create `_HTTP_CONTROLLER` and include the webhook router only when webhook transport is explicitly required, and to make the startup webhook hook a webhook-only path that does not bootstrap polling for polling-mode processes.
- Removed the duplicate fallback `TelegramWebhookController` creation from the runtime initialization path and made `_build_runtime_context` (runtime init) consult the transport helpers so polling mode proceeds without requiring an HTTP controller.
- Updated attach logic so `telegram_application_controller_missing` is only logged when webhook mode is selected and the controller is unexpectedly absent; polling mode now skips attachment without warning while still creating `TelegramBot` for polling delivery.
- Tests updated/added: `tests/notifications/test_telegram_http_app.py` now asserts no webhook route/controller/fallback in polling mode, and `tests/test_initialize_components_polling.py` adds a focused runtime test to verify polling-mode Telegram initialisation does not require a controller.

### Testing
- Ran targeted unit tests: `pytest -q tests/notifications/test_telegram_http_app.py` — all tests passed (3 passed).
- Ran targeted unit tests: `pytest -q tests/test_initialize_components_polling.py` — all tests passed (6 passed).
- Verified grep checks: `telegram_application_controller_missing` is now only emitted from the webhook-required runtime branch in `src/nifty_scalper_bot/core/app.py`, and `TelegramWebhookController(` only appears in the HTTP app webhook creation path.
- Attempted repository check script: `./run_checks.sh` failed due to executable bit (`Permission denied`), and `bash ./run_checks.sh` completed dependency install but the script environment did not run tests to completion (noted that `pytest` was not installed in that script-managed environment); targeted tests above were run independently and green.

Files changed: `src/nifty_scalper_bot/core/app.py`, `tests/notifications/test_telegram_http_app.py`, `tests/test_initialize_components_polling.py`.

Risk: low — changes are surgical to Telegram transport wiring and tests only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8fbe28bb88324a48fe05b1d97c0f5)