### PR TITLE
fix: centralize websocket subscription ownership in market data manager

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -6070,35 +6070,14 @@ async def startup_sequence(ctx: BotContext) -> None:
             if not subscribed_symbols:
                 LOGGER.critical("⛔ STRATEGY SUBSCRIPTION LIST IS EMPTY")
 
-            # FIX: Use subscribe_tokens() for WebSocket mode instead of the
-            # async subscribe() (which was called without await, silently
-            # dropping the coroutine). subscribe_tokens() merges tokens into
-            # the tracked set and schedules _resubscribe_if_connected() via
-            # asyncio.to_thread() — non-blocking and safe in async context.
-            # resubscribe() was avoided: it calls ticker.subscribe() directly
-            # (blocking) which can stall the event loop when connected.
             if tokens_to_poll:
-                ws = ctx.websocket_manager
-                if ws is not None:
-                    # Pre-populate the WebSocket token set so the deferred
-                    # WS.start() below connects with the full universe already
-                    # registered — this is the fix for the boot-time
-                    # "WebSocket CONNECTED | tokens=1" under-subscription.
-                    ws.subscribe_tokens(list(tokens_to_poll))
+                if mdm is not None:
+                    seeded = mdm.request_token_subscriptions(tokens_to_poll)
                     LOGGER.info(
-                        "✅ Wired %d tokens to WebSocket", len(tokens_to_poll)
+                        "✅ Routed %d/%d startup tokens via MarketDataManager",
+                        seeded,
+                        len(tokens_to_poll),
                     )
-                    for _sym, _tok in sorted(active_symbol_tokens.items()):
-                        LOGGER.info(
-                            "WS SUBSCRIBED: %s (%s)",
-                            _sym,
-                            _tok,
-                            extra={
-                                "event": "ws_subscribed_symbol",
-                                "symbol": _sym,
-                                "token": int(_tok),
-                            },
-                        )
                 elif streamer and hasattr(streamer, "subscribe"):
                     streamer.subscribe(tokens_to_poll)
                     LOGGER.info(
@@ -6365,17 +6344,10 @@ async def startup_sequence(ctx: BotContext) -> None:
                                 continue
                             if tok and ctx.market_data_manager:
                                 ctx.market_data_manager.register_symbol(sym, tok)
-                            if tok and ctx.websocket_manager is not None:
-                                ctx.websocket_manager.subscribe_tokens([tok])
-                                LOGGER.info(
-                                    "WS SUBSCRIBED: %s (%s)",
-                                    sym,
+                            if tok and ctx.market_data_manager is not None:
+                                ctx.market_data_manager.request_token_subscription(
                                     tok,
-                                    extra={
-                                        "event": "ws_subscribed_symbol",
-                                        "symbol": sym,
-                                        "token": int(tok),
-                                    },
+                                    symbol=sym,
                                 )
                             elif (
                                 tok
@@ -6455,8 +6427,6 @@ async def startup_sequence(ctx: BotContext) -> None:
                                 res = ctx.streamer.unsubscribe([tok])
                                 if asyncio.iscoroutine(res):
                                     await res
-                            if tok and ctx.websocket_manager is not None:
-                                ctx.websocket_manager.unsubscribe_tokens([tok])
                             if ctx.strategy_runner:
                                 ctx.strategy_runner.remove_symbol(sym)
 

--- a/src/nifty_scalper_bot/core/unified_manager.py
+++ b/src/nifty_scalper_bot/core/unified_manager.py
@@ -532,9 +532,12 @@ class UnifiedManager:
             instrument = self.resolve(symbol)
             subscribed = False
             polled = False
-            if instrument.token and self.ws is not None:
+            if instrument.token and self.mdm is not None:
                 with suppress(Exception):
-                    self.ws.subscribe_tokens({int(instrument.token)})
+                    self.mdm.request_token_subscription(
+                        int(instrument.token),
+                        symbol=instrument.symbol,
+                    )
                     subscribed = True
             with suppress(Exception):
                 poll = getattr(self.mdm, "enable_poll_tracking", None)

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -108,10 +108,15 @@ class MarketDataManager:
         )
         self._token_by_symbol: dict[str, int] = {}
         self._symbol_by_token: dict[int, str] = {}
+        self._desired_tokens: set[int] = set()
+        self._symbol_to_token: dict[str, int] = {}
+        self._token_to_symbol: dict[int, str] = {}
         self._token_by_symbol["NSE:NIFTY"] = 256265       # canonical
         self._symbol_by_token[256265] = "NSE:NIFTY"
         self._token_by_symbol["NSE:BANKNIFTY"] = 260105
         self._symbol_by_token[260105] = "NSE:BANKNIFTY"
+        self._symbol_to_token.update(self._token_by_symbol)
+        self._token_to_symbol.update(self._symbol_by_token)
         self._last_signature: dict[
             str, tuple[tuple[float | None, float | None, float | None], float]
         ] = {}
@@ -827,6 +832,8 @@ class MarketDataManager:
         """Record WebSocket connectivity state for health reporting."""
 
         self._ws_connected = bool(connected)
+        if self._ws_connected:
+            self._reconcile_ws_subscriptions()
 
     def register_heartbeat_callback(self, callback: Callable[[float], None]) -> None:
         """Register callback invoked whenever a heartbeat is recorded.
@@ -1146,6 +1153,82 @@ class MarketDataManager:
         if value.count(":") != 1:
             raise RuntimeError(f"Malformed canonical symbol: {value}")
         return value
+
+    def _reconcile_ws_subscriptions(self) -> None:
+        """Apply desired token set to websocket transport. Args: none. Returns: none. Raises: none."""
+
+        ws = self._ws
+        if ws is None:
+            return
+        if not hasattr(ws, "set_tokens"):
+            return
+        try:
+            ws.set_tokens(sorted(self._desired_tokens))
+        except Exception as exc:  # noqa: BLE001
+            self._logger.debug("ws token reconcile deferred: %s", exc)
+
+    def request_token_subscription(
+        self,
+        token: int,
+        symbol: str | None = None,
+    ) -> bool:
+        """Record token subscription intent. Args: token/symbol. Returns: changed flag. Raises: none."""
+
+        token_int = int(token)
+        if token_int <= 0:
+            return False
+        normalized_symbol: str | None = None
+        if symbol:
+            normalized_symbol = self._canonical_symbol(symbol)
+            self.register_symbol(normalized_symbol, token_int)
+
+        changed = False
+        with self._lock:
+            if token_int not in self._desired_tokens:
+                self._desired_tokens.add(token_int)
+                changed = True
+            if normalized_symbol:
+                if self._symbol_to_token.get(normalized_symbol) != token_int:
+                    self._symbol_to_token[normalized_symbol] = token_int
+                    changed = True
+                if self._token_to_symbol.get(token_int) != normalized_symbol:
+                    self._token_to_symbol[token_int] = normalized_symbol
+                    changed = True
+        if changed:
+            self._reconcile_ws_subscriptions()
+        return changed
+
+    def request_token_subscriptions(self, tokens: Iterable[int]) -> int:
+        """Record token subscription intents. Args: tokens. Returns: number of newly added tokens. Raises: none."""
+
+        normalized = {int(token) for token in tokens if int(token) > 0}
+        if not normalized:
+            return 0
+        with self._lock:
+            before = len(self._desired_tokens)
+            self._desired_tokens.update(normalized)
+            added_count = len(self._desired_tokens) - before
+        if added_count > 0:
+            self._reconcile_ws_subscriptions()
+        return added_count
+
+    def request_symbol_subscription(self, symbol: str) -> bool:
+        """Record symbol subscription intent. Args: symbol. Returns: changed flag. Raises: none."""
+
+        normalized = self._canonical_symbol(symbol)
+        token = self._resolve_token(normalized)
+        if token is None:
+            return False
+        return self.request_token_subscription(token, symbol=normalized)
+
+    def request_symbol_subscriptions(self, symbols: Iterable[str]) -> int:
+        """Record symbol subscription intents. Args: symbols. Returns: newly added token count. Raises: none."""
+
+        changed = 0
+        for symbol in symbols:
+            if self.request_symbol_subscription(symbol):
+                changed += 1
+        return changed
 
     def disable_rest_polling(self, *, reason: str | None = None) -> None:
         """Disable the background REST poller when another component owns fallback."""
@@ -3193,6 +3276,8 @@ class MarketDataManager:
                 return
             self._token_by_symbol[normalized_symbol] = token_int
             self._symbol_by_token[token_int] = normalized_symbol
+            self._symbol_to_token[normalized_symbol] = token_int
+            self._token_to_symbol[token_int] = normalized_symbol
         try:
             if self._resolver is not None and hasattr(self._resolver, "register"):
                 self._resolver.register(normalized_symbol, token_int)
@@ -4716,16 +4801,13 @@ class MarketDataManager:
         return max(value, minimum)
 
     def _ensure_subscription(self, symbol: str) -> None:
-        if self._ws is None:
-            return
         try:
             symbol = self._canonical_symbol(symbol)
-            token = self._token_by_symbol.get(symbol)
-            if not token:
-                raise RuntimeError(f"Token missing for {symbol}")
-            self.validate_token_symbol_mappings()
-            self._logger.info(f"WS SUBSCRIBED: {symbol} ({token})")
-            self._ws.subscribe_tokens([token], mode="full")
+            changed = self.request_symbol_subscription(symbol)
+            if changed:
+                token = self._symbol_to_token.get(symbol)
+                if token:
+                    self._logger.info(f"WS SUBSCRIPTION REQUESTED: {symbol} ({token})")
         except Exception as exc:  # noqa: BLE001
             # Log both message and details so it shows up even if the logger ignores
             # 'extra'.
@@ -4737,14 +4819,18 @@ class MarketDataManager:
             )
 
     def _release_subscription(self, symbol: str) -> None:
-        if self._ws is None:
-            return
         symbol = self._canonical_symbol(symbol)
-        token = self._token_by_symbol.get(symbol)
+        token = self._symbol_to_token.get(symbol) or self._token_by_symbol.get(symbol)
         if token is None:
             return
         try:
-            self._ws.unsubscribe_tokens([token])
+            changed = False
+            with self._lock:
+                if token in self._desired_tokens:
+                    self._desired_tokens.discard(token)
+                    changed = True
+            if changed:
+                self._reconcile_ws_subscriptions()
         except Exception as exc:  # noqa: BLE001
             self._logger.debug(
                 "Unsubscribe failed",

--- a/src/nifty_scalper_bot/streaming/websocket_manager.py
+++ b/src/nifty_scalper_bot/streaming/websocket_manager.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from contextlib import suppress
 import random
 import time
 from collections.abc import Awaitable, Callable, Coroutine, Sequence
@@ -239,8 +240,7 @@ class WebSocketManager:
 
         try:
             self._logger.debug("Entered subscribe")
-            self._merge_tokens(tokens)
-            await self._resubscribe_if_connected()
+            self.add_tokens(tokens)
         except Exception as e:
             self._logger.error("Failure in subscribe: %s", e)
             raise
@@ -269,11 +269,59 @@ class WebSocketManager:
             self._logger.error("Failure in stop: %s", e)
             raise
 
-    def subscribe_tokens(self, tokens: Sequence[int], mode: str = "full") -> None:
-        """Args: tokens/mode; Returns: none; Raises: none."""
+    def set_tokens(self, tokens: Sequence[int]) -> bool:
+        """Reconcile websocket transport token state. Args: tokens. Returns: changed flag. Raises: none."""
 
-        self._merge_tokens(tokens)
-        self._schedule_async(self._resubscribe_if_connected())
+        try:
+            new_tokens = {int(token) for token in tokens if int(token) > 0}
+        except Exception as e:
+            self._logger.error("Failure in set_tokens normalization: %s", e)
+            return False
+
+        if new_tokens == self._tokens:
+            return False
+
+        old_tokens = set(self._tokens)
+        to_add = sorted(new_tokens - old_tokens)
+        to_remove = sorted(old_tokens - new_tokens)
+
+        ticker = self._ticker
+        connected = ticker is not None and self._connected.is_set()
+        if connected and to_remove:
+            with suppress(Exception):
+                self._schedule_blocking(lambda: ticker.unsubscribe(to_remove))
+        if connected and to_add:
+            with suppress(Exception):
+                self._schedule_blocking(lambda: ticker.subscribe(to_add))
+                self._schedule_blocking(lambda: ticker.set_mode(ticker.MODE_FULL, to_add))
+                self._log_ws_subscriptions(to_add)
+
+        self._tokens = new_tokens
+        self._logger.info(
+            "ws_tokens_reconciled total=%d added=%d removed=%d",
+            len(self._tokens),
+            len(to_add),
+            len(to_remove),
+        )
+        return True
+
+    def add_tokens(self, tokens: Sequence[int]) -> bool:
+        """Add transport tokens. Args: tokens. Returns: changed flag. Raises: none."""
+
+        incoming = {int(token) for token in tokens if int(token) > 0}
+        return self.set_tokens(sorted(self._tokens | incoming))
+
+    def remove_tokens(self, tokens: Sequence[int]) -> bool:
+        """Remove transport tokens. Args: tokens. Returns: changed flag. Raises: none."""
+
+        outgoing = {int(token) for token in tokens if int(token) > 0}
+        return self.set_tokens(sorted(self._tokens - outgoing))
+
+    def subscribe_tokens(self, tokens: Sequence[int], mode: str = "full") -> None:
+        """Compatibility wrapper for transport token additions. Args: tokens/mode. Returns: none. Raises: none."""
+
+        del mode
+        self.add_tokens(tokens)
 
     def resubscribe(self, tokens: list[int]) -> None:
         """Args: tokens; Returns: none; Raises: none."""
@@ -303,12 +351,7 @@ class WebSocketManager:
         """Args: tokens; Returns: none; Raises: none."""
 
         try:
-            remove_set = {int(token) for token in tokens}
-            self._tokens -= remove_set
-            ticker = self._ticker
-            if ticker is not None and self._connected.is_set() and remove_set:
-                payload = sorted(remove_set)
-                self._schedule_blocking(lambda: ticker.unsubscribe(payload))
+            self.remove_tokens(tokens)
         except Exception as e:
             self._logger.error("Failure in unsubscribe_tokens: %s", e)
 
@@ -644,49 +687,15 @@ class WebSocketManager:
             )
             if self._tokens:
                 token_list = sorted(self._tokens)
-                mdm = getattr(self, "_market_data_manager", None)
-                validate_mapping = getattr(mdm, "validate_token_symbol_mappings", None)
-                if callable(validate_mapping):
-                    try:
-                        validate_mapping()
-                    except RuntimeError as map_err:
-                        self._logger.warning(
-                            "Token/symbol mapping mismatch on connect (non-fatal): %s",
-                            map_err,
-                        )
                 ws.subscribe(token_list)
                 ws.set_mode(ws.MODE_FULL, token_list)
                 self._log_ws_subscriptions(token_list)
-                symbol_map = getattr(mdm, "_symbol_by_token", {})
-                active_symbols = {
-                    symbol_map.get(token)
-                    for token in token_list
-                    if symbol_map.get(token)
-                }
                 self._logger.info(
-                    "WebSocket subscribed | active_tokens=%d active_symbols=%d",
+                    "ws_replay_subscriptions total=%d",
                     len(token_list),
-                    len(active_symbols),
                 )
-                if symbol_map:
-                    self._logger.debug(
-                        "WebSocket symbol registry size=%d",
-                        len(symbol_map),
-                    )
-                if len(symbol_map) == 0:
-                    self._logger.warning(
-                        "Token map is EMPTY after subscribe — ticks will be dropped. "
-                        "Ensure register_symbol() is called before WebSocket connect.",
-                    )
-                elif len(symbol_map) < 5:
-                    self._logger.warning(
-                        "Token map has only %d entries — expected >=5. "
-                        "Some ticks may be unmapped.",
-                        len(symbol_map),
-                    )
             if self._on_connect_callback is not None:
                 self._on_connect_callback()
-            self._schedule_async(self._resubscribe_if_connected())
         except Exception as e:
             self._logger.error("Failure in _on_connect: %s", e)
 

--- a/tests/data/test_market_data_manager.py
+++ b/tests/data/test_market_data_manager.py
@@ -60,6 +60,10 @@ class DummyWebSocket:
     def subscribe_tokens(self, tokens: Iterable[Any], mode: str = "ltp") -> None:
         self.subscribed.append((mode, list(tokens)))
 
+    def set_tokens(self, tokens: Iterable[Any]) -> bool:
+        self.subscribed.append(("full", sorted(int(token) for token in tokens)))
+        return True
+
     def unsubscribe_tokens(self, tokens: Iterable[Any]) -> None:
         self.unsubscribed.append(list(tokens))
 

--- a/tests/data/test_market_data_manager_subscriptions.py
+++ b/tests/data/test_market_data_manager_subscriptions.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from typing import Any
+
+from nifty_scalper_bot.data.market_data_manager import MarketDataManager
+
+
+class DummyBroker:
+    def get_quote(self, symbol: str) -> dict[str, Any]:
+        return {'symbol': symbol, 'ltp': 0.0}
+
+    def instruments(self, _exchange: str) -> list[dict[str, Any]]:
+        return []
+
+
+class DummyResolver:
+    def __init__(self) -> None:
+        self._map = {'NSE:NIFTY': 256265}
+
+    def resolve(self, symbol: str) -> int | None:
+        return self._map.get(symbol)
+
+
+class DummyWebSocket:
+    def __init__(self) -> None:
+        self.calls: list[list[int]] = []
+
+    def set_tokens(self, tokens) -> bool:  # noqa: ANN001
+        self.calls.append(list(tokens))
+        return True
+
+
+def test_request_symbol_subscription_reconciles_once() -> None:
+    ws = DummyWebSocket()
+    mdm = MarketDataManager(DummyBroker(), ws, resolver=DummyResolver())
+
+    changed = mdm.request_symbol_subscription('NSE:NIFTY')
+
+    assert changed is True
+    assert ws.calls == [[256265]]
+
+
+def test_request_symbol_subscription_no_duplicate_transport_call() -> None:
+    ws = DummyWebSocket()
+    mdm = MarketDataManager(DummyBroker(), ws, resolver=DummyResolver())
+
+    mdm.request_symbol_subscription('NSE:NIFTY')
+    changed = mdm.request_symbol_subscription('NSE:NIFTY')
+
+    assert changed is False
+    assert ws.calls == [[256265]]
+
+
+def test_request_token_subscriptions_batch_reconciles_once() -> None:
+    ws = DummyWebSocket()
+    mdm = MarketDataManager(DummyBroker(), ws, resolver=DummyResolver())
+
+    added = mdm.request_token_subscriptions([101, 202, 101])
+
+    assert added == 2
+    assert ws.calls == [[101, 202]]
+
+
+def test_request_subscription_without_ws_retains_desired_set() -> None:
+    mdm = MarketDataManager(DummyBroker(), websocket=None, resolver=DummyResolver())
+
+    changed = mdm.request_symbol_subscription('NSE:NIFTY')
+
+    assert changed is True
+    assert mdm._desired_tokens == {256265}  # noqa: SLF001

--- a/tests/streaming/test_websocket_manager.py
+++ b/tests/streaming/test_websocket_manager.py
@@ -225,3 +225,37 @@ def test_polling_degrade_ignores_quote_age_when_ws_is_healthy() -> None:
         )
         is True
     )
+
+
+def test_set_tokens_reconciles_added_tokens(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(ws_module, "KiteTicker", FakeKiteTicker)
+    manager = ws_module.WebSocketManager("k", "t", [101], trading_window_enabled=False)
+    manager._ticker = FakeKiteTicker("k", "t")
+    manager._connected.set()
+
+    changed = manager.set_tokens([101, 202, 303])
+
+    assert changed is True
+    assert manager._tokens == {101, 202, 303}  # noqa: SLF001
+    assert set(manager._ticker.subscribed) == {202, 303}
+
+
+def test_set_tokens_noop_for_same_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(ws_module, "KiteTicker", FakeKiteTicker)
+    manager = ws_module.WebSocketManager("k", "t", [101, 202], trading_window_enabled=False)
+
+    changed = manager.set_tokens([202, 101])
+
+    assert changed is False
+    assert manager._tokens == {101, 202}  # noqa: SLF001
+
+
+def test_on_connect_replays_current_tokens_only(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(ws_module, "KiteTicker", FakeKiteTicker)
+    manager = ws_module.WebSocketManager("k", "t", [11, 22], trading_window_enabled=False)
+    ticker = FakeKiteTicker("k", "t")
+
+    manager._on_connect(ticker, {"status": "ok"})  # noqa: SLF001
+
+    assert set(ticker.subscribed) == {11, 22}
+    assert set(manager._tokens) == {11, 22}  # noqa: SLF001

--- a/tests/test_initialize_components_subscriptions.py
+++ b/tests/test_initialize_components_subscriptions.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import inspect
+
+from nifty_scalper_bot.core import app as core_app
+
+
+def test_app_has_no_direct_websocket_subscription_calls() -> None:
+    source = inspect.getsource(core_app)
+
+    assert 'ctx.websocket_manager.subscribe_tokens(' not in source
+    assert 'ctx.websocket_manager.unsubscribe_tokens(' not in source
+    assert 'ws.subscribe_tokens(' not in source
+
+
+def test_app_routes_startup_and_universe_subscriptions_via_mdm() -> None:
+    source = inspect.getsource(core_app)
+
+    assert 'mdm.request_token_subscriptions(tokens_to_poll)' in source
+    assert 'ctx.market_data_manager.request_token_subscription(' in source


### PR DESCRIPTION
### Motivation

- Runtime showed duplicated subscription ownership: early websocket subscriptions from bootstrap, then deferred MDM, then a second subscription wave during universe sync, causing inconsistent startup state and log noise.  
- The goal is a single owner of subscription intent (MarketDataManager) with WebSocketManager reduced to a transport-only reconciler so startup ordering and intent are deterministic and minimal.

### Description

- MarketDataManager now owns subscription intent with a canonical desired-token set (`self._desired_tokens`) and simple public APIs: `request_symbol_subscription`, `request_token_subscription`, `request_symbol_subscriptions`, and `request_token_subscriptions`.  It exposes `_reconcile_ws_subscriptions()` to push desired state to the transport.  (file: `src/nifty_scalper_bot/data/market_data_manager.py`)  
- MarketDataManager internals updated so `_ensure_subscription()` and `_release_subscription()` mutate desired intent and call the single reconciliation path instead of calling WS directly.  Symbol/token maps are kept in sync when registering symbols.  (file: `src/nifty_scalper_bot/data/market_data_manager.py`)  
- WebSocketManager was simplified to be transport-only: introduced `set_tokens(tokens: Iterable[int]) -> bool` plus `add_tokens` and `remove_tokens` helpers; `subscribe_tokens` / `unsubscribe_tokens` are kept as thin compatibility wrappers that call transport primitives; `_on_connect()` only replays the manager-held `_tokens` set.  (file: `src/nifty_scalper_bot/streaming/websocket_manager.py`)  
- `core/app.py` startup and option-universe sync paths no longer call WebSocket transport directly; they route all subscription requests through MDM (`mdm.request_token_subscriptions` / `mdm.request_token_subscription`).  Dead/duplicative WS-subscribe comments and direct calls were removed.  (file: `src/nifty_scalper_bot/core/app.py`)  
- `UnifiedManager.ensure_tracking()` was updated to call MDM intent API instead of calling WS directly.  (file: `src/nifty_scalper_bot/core/unified_manager.py`)  
- Tests added/updated to verify transport reconciliation, MDM single-owner behavior, and that `core/app.py` no longer contains direct WS subscribe/unsubscribe calls: `tests/streaming/test_websocket_manager.py`, `tests/data/test_market_data_manager_subscriptions.py`, and `tests/test_initialize_components_subscriptions.py`.

### Testing

- Ran targeted pytest suites: `pytest -q tests/streaming/test_websocket_manager.py tests/data/test_market_data_manager_subscriptions.py tests/test_initialize_components_subscriptions.py` and the tests passed (all tests in these files succeeded).  
- Additional local invocation under the created venv: `. .venv/bin/activate && pytest -q tests/streaming/test_websocket_manager.py tests/data/test_market_data_manager_subscriptions.py tests/test_initialize_components_subscriptions.py` also passed.  
- Grep validation to ensure app no longer does direct WS subscribe/unsubscribe: ran `grep -Rni "subscribe_tokens(" src`, `grep -Rni "unsubscribe_tokens(" src`, and `grep -Rni "set_tokens(" src`; results show direct `subscribe_tokens` / `unsubscribe_tokens` remaining only in WS/stream supervisor compatibility surfaces and the only authoritative `set_tokens` usage is the MDM→WS reconciliation call.  
- Note on `./run_checks.sh`: the fuller project check was attempted (`bash ./run_checks.sh`) but in this environment the script’s dependency/install path flagged `❌ pytest not installed but tests/ exists` during its own flow; this did not affect the focused pytest runs above which were executed successfully in the project venv.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8fe496ce483248ff434dc93691e09)