### PR TITLE
fix: centralize WS subscription intent in MDM and remove app transport calls

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -6349,12 +6349,6 @@ async def startup_sequence(ctx: BotContext) -> None:
                                     tok,
                                     symbol=sym,
                                 )
-                            elif (
-                                tok
-                                and ctx.streamer
-                                and hasattr(ctx.streamer, "subscribe")
-                            ):
-                                ctx.streamer.subscribe([tok])
                             # Fetch OHLC history into MDM BEFORE adding to
                             # strategy runner so the runner's internal
                             # _prehydrate_symbol_history finds bars already
@@ -6419,14 +6413,11 @@ async def startup_sequence(ctx: BotContext) -> None:
                                     tok = _im.get_token(sym)
                                 except RuntimeError:
                                     tok = None
-                            if (
-                                tok
-                                and ctx.streamer
-                                and hasattr(ctx.streamer, "unsubscribe")
-                            ):
-                                res = ctx.streamer.unsubscribe([tok])
-                                if asyncio.iscoroutine(res):
-                                    await res
+                            if tok and ctx.market_data_manager is not None:
+                                ctx.market_data_manager.request_token_unsubscription(
+                                    tok,
+                                    symbol=sym,
+                                )
                             if ctx.strategy_runner:
                                 ctx.strategy_runner.remove_symbol(sym)
 

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -1212,6 +1212,42 @@ class MarketDataManager:
             self._reconcile_ws_subscriptions()
         return added_count
 
+    def request_token_unsubscription(
+        self,
+        token: int,
+        symbol: str | None = None,
+    ) -> bool:
+        """Record token removal intent. Args: token/symbol. Returns: changed flag. Raises: none."""
+
+        token_int = int(token)
+        if token_int <= 0:
+            return False
+        normalized_symbol: str | None = None
+        if symbol:
+            normalized_symbol = self._canonical_symbol(symbol)
+
+        changed = False
+        with self._lock:
+            if token_int in self._desired_tokens:
+                self._desired_tokens.discard(token_int)
+                changed = True
+            if normalized_symbol and self._symbol_to_token.pop(normalized_symbol, None) is not None:
+                changed = True
+            if self._token_to_symbol.pop(token_int, None) is not None:
+                changed = True
+        if changed:
+            self._reconcile_ws_subscriptions()
+        return changed
+
+    def request_symbol_unsubscription(self, symbol: str) -> bool:
+        """Record symbol removal intent. Args: symbol. Returns: changed flag. Raises: none."""
+
+        normalized = self._canonical_symbol(symbol)
+        token = self._symbol_to_token.get(normalized) or self._token_by_symbol.get(normalized)
+        if token is None:
+            return False
+        return self.request_token_unsubscription(token, symbol=normalized)
+
     def request_symbol_subscription(self, symbol: str) -> bool:
         """Record symbol subscription intent. Args: symbol. Returns: changed flag. Raises: none."""
 
@@ -4819,18 +4855,8 @@ class MarketDataManager:
             )
 
     def _release_subscription(self, symbol: str) -> None:
-        symbol = self._canonical_symbol(symbol)
-        token = self._symbol_to_token.get(symbol) or self._token_by_symbol.get(symbol)
-        if token is None:
-            return
         try:
-            changed = False
-            with self._lock:
-                if token in self._desired_tokens:
-                    self._desired_tokens.discard(token)
-                    changed = True
-            if changed:
-                self._reconcile_ws_subscriptions()
+            self.request_symbol_unsubscription(symbol)
         except Exception as exc:  # noqa: BLE001
             self._logger.debug(
                 "Unsubscribe failed",

--- a/src/nifty_scalper_bot/streaming/websocket_manager.py
+++ b/src/nifty_scalper_bot/streaming/websocket_manager.py
@@ -875,11 +875,11 @@ class WebSocketManager:
                 continue
             self._subscription_log_tokens.add(token)
             self._logger.info(
-                "WS SUBSCRIBED: %s (%s)",
+                "ws_transport_subscribed symbol=%s token=%s",
                 symbol,
                 token,
                 extra={
-                    "event": "ws_subscribed_symbol",
+                    "event": "ws_transport_subscribed",
                     "symbol": symbol,
                     "token": token,
                 },

--- a/tests/data/test_market_data_manager_subscriptions.py
+++ b/tests/data/test_market_data_manager_subscriptions.py
@@ -68,3 +68,28 @@ def test_request_subscription_without_ws_retains_desired_set() -> None:
 
     assert changed is True
     assert mdm._desired_tokens == {256265}  # noqa: SLF001
+
+
+def test_request_token_unsubscription_reconciles_transport() -> None:
+    ws = DummyWebSocket()
+    mdm = MarketDataManager(DummyBroker(), ws, resolver=DummyResolver())
+    mdm.request_token_subscriptions([101, 202])
+
+    changed = mdm.request_token_unsubscription(101)
+
+    assert changed is True
+    assert ws.calls[-1] == [202]
+
+
+def test_ensure_subscription_uses_request_api() -> None:
+    mdm = MarketDataManager(DummyBroker(), websocket=None, resolver=DummyResolver())
+    calls: list[str] = []
+
+    def _request(symbol: str) -> bool:
+        calls.append(symbol)
+        return True
+
+    mdm.request_symbol_subscription = _request  # type: ignore[method-assign]
+    mdm._ensure_subscription('NSE:NIFTY')  # noqa: SLF001
+
+    assert calls == ['NSE:NIFTY']

--- a/tests/streaming/test_websocket_manager.py
+++ b/tests/streaming/test_websocket_manager.py
@@ -259,3 +259,16 @@ def test_on_connect_replays_current_tokens_only(monkeypatch: pytest.MonkeyPatch)
 
     assert set(ticker.subscribed) == {11, 22}
     assert set(manager._tokens) == {11, 22}  # noqa: SLF001
+
+
+def test_subscribe_tokens_wrapper_unions_and_delegates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(ws_module, "KiteTicker", FakeKiteTicker)
+    manager = ws_module.WebSocketManager("k", "t", [10], trading_window_enabled=False)
+
+    changed = manager.add_tokens([20])
+    assert changed is True
+    manager.subscribe_tokens([20, 30])
+
+    assert manager._tokens == {10, 20, 30}  # noqa: SLF001

--- a/tests/streaming/test_websocket_subscription_logs.py
+++ b/tests/streaming/test_websocket_subscription_logs.py
@@ -16,5 +16,11 @@ def test_logs_ws_subscriptions_for_futures_and_options(caplog) -> None:
         manager._log_ws_subscriptions([101, 202, 101])
 
     messages = [record.getMessage() for record in caplog.records]
-    assert any('WS SUBSCRIBED: NFO:NIFTY26MAYFUT (101)' in msg for msg in messages)
-    assert any('WS SUBSCRIBED: NFO:NIFTY26MAY24500CE (202)' in msg for msg in messages)
+    assert any(
+        'ws_transport_subscribed symbol=NFO:NIFTY26MAYFUT token=101' in msg
+        for msg in messages
+    )
+    assert any(
+        'ws_transport_subscribed symbol=NFO:NIFTY26MAY24500CE token=202' in msg
+        for msg in messages
+    )

--- a/tests/test_initialize_components_subscriptions.py
+++ b/tests/test_initialize_components_subscriptions.py
@@ -11,6 +11,8 @@ def test_app_has_no_direct_websocket_subscription_calls() -> None:
     assert 'ctx.websocket_manager.subscribe_tokens(' not in source
     assert 'ctx.websocket_manager.unsubscribe_tokens(' not in source
     assert 'ws.subscribe_tokens(' not in source
+    assert 'ctx.streamer.subscribe([tok])' not in source
+    assert 'ctx.streamer.unsubscribe([tok])' not in source
 
 
 def test_app_routes_startup_and_universe_subscriptions_via_mdm() -> None:
@@ -18,3 +20,4 @@ def test_app_routes_startup_and_universe_subscriptions_via_mdm() -> None:
 
     assert 'mdm.request_token_subscriptions(tokens_to_poll)' in source
     assert 'ctx.market_data_manager.request_token_subscription(' in source
+    assert 'ctx.market_data_manager.request_token_unsubscription(' in source


### PR DESCRIPTION
### Motivation

- Startup showed duplicated subscription ownership and an early transport-level `NSE:NIFTY` subscribe that bypassed the deferred-WS flow, producing inconsistent boot logs and missed universe subscriptions.  
- The app, MDM, and WebSocket manager shared subscription responsibilities which led to racing and duplicate transport calls.  
- The goal is a single-path design where `MarketDataManager` is the SSOT for subscription intent and the WebSocket transport is purely responsible for applying a token set.

### Description

- Route all startup and universe add/remove token intent through `MarketDataManager` only by replacing app-level `ctx.streamer.subscribe/unsubscribe([tok])` usages with `mdm.request_token_subscription(...)` and `mdm.request_token_unsubscription(...)` in the option-universe sync.  
- Add MDM public unsubscription APIs: `request_token_unsubscription(token, symbol=None)` and `request_symbol_unsubscription(symbol)` and ensure `_release_subscription` funnels to the new canonical request APIs; keep `_reconcile_ws_subscriptions()` calling the transport `set_tokens(...)`.  
- Keep `WebSocketManager` transport-only and adjust its subscription log wording to a transport-focused event (`ws_transport_subscribed ...`) so logs no longer imply business intent ownership; compatibility token wrappers (`add_tokens` / `subscribe_tokens`) remain thin and delegate to `set_tokens(...)`.  
- Add / update focused tests to assert SSOT behavior, idempotence, unsubscription reconciliation, transport wrapper compatibility, and the absence of direct transport subscription calls in the app bootstrap path.

### Testing

- Attempted `./run_checks.sh` in this environment produced permission / dependency issues so it could not be used end-to-end here.  
- Installed test tooling and ran the focused test suite with: `pytest -q tests/streaming/test_websocket_manager.py tests/streaming/test_websocket_subscription_logs.py tests/data/test_market_data_manager_subscriptions.py tests/test_initialize_components_subscriptions.py`, and the focused tests passed (all assertions in those files succeeded).  
- Ran `ruff check` on the modified files to verify local lint smoke checks for the edited modules and found no failures for the inspected files.  
- Grep/inspection verification confirms `core/app.py` no longer contains direct transport subscription/unsubscription calls and startup/universe subscription changes are routed via `MarketDataManager` (covered by the updated tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e90ca6ade08324bc3f7cc38c4fced8)