### PR TITLE
Finalize subscription SSOT by routing supervisor and Telegram through MarketDataManager

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -3501,6 +3501,7 @@ def initialize_components(settings: Settings | None = None) -> BotContext:
         stream_supervisor = StreamSupervisor(
             streamer=streamer,
             resolver=instrument_manager,
+            market_data_manager=market_data_manager,
             default_symbols=list(poll_symbols or ["NSE:NIFTY"]),
             autostart=True,
             monitor_interval_s=1.0,

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -1212,6 +1212,26 @@ class MarketDataManager:
             self._reconcile_ws_subscriptions()
         return added_count
 
+    def request_token_unsubscriptions(self, tokens: Iterable[int]) -> int:
+        """Record token removal intents. Args: tokens. Returns: number of removed tokens. Raises: none."""
+
+        normalized = {int(token) for token in tokens if int(token) > 0}
+        if not normalized:
+            return 0
+        with self._lock:
+            before = len(self._desired_tokens)
+            self._desired_tokens.difference_update(normalized)
+            removed_count = before - len(self._desired_tokens)
+            for token in normalized:
+                mapped_symbol = self._token_to_symbol.pop(token, None)
+                if mapped_symbol is not None:
+                    current = self._symbol_to_token.get(mapped_symbol)
+                    if current == token:
+                        self._symbol_to_token.pop(mapped_symbol, None)
+        if removed_count > 0:
+            self._reconcile_ws_subscriptions()
+        return removed_count
+
     def request_token_unsubscription(
         self,
         token: int,
@@ -1231,13 +1251,32 @@ class MarketDataManager:
             if token_int in self._desired_tokens:
                 self._desired_tokens.discard(token_int)
                 changed = True
-            if normalized_symbol and self._symbol_to_token.pop(normalized_symbol, None) is not None:
-                changed = True
-            if self._token_to_symbol.pop(token_int, None) is not None:
+            if normalized_symbol:
+                current = self._symbol_to_token.get(normalized_symbol)
+                if current == token_int:
+                    self._symbol_to_token.pop(normalized_symbol, None)
+                    changed = True
+            mapped_symbol = self._token_to_symbol.pop(token_int, None)
+            if mapped_symbol is not None:
+                current = self._symbol_to_token.get(mapped_symbol)
+                if current == token_int:
+                    self._symbol_to_token.pop(mapped_symbol, None)
                 changed = True
         if changed:
             self._reconcile_ws_subscriptions()
         return changed
+
+    def desired_token_count(self) -> int:
+        """Return desired token count. Args: none. Returns: token count. Raises: none."""
+
+        with self._lock:
+            return len(self._desired_tokens)
+
+    def desired_tokens_snapshot(self) -> list[int]:
+        """Return sorted desired tokens. Args: none. Returns: tokens list. Raises: none."""
+
+        with self._lock:
+            return sorted(self._desired_tokens)
 
     def request_symbol_unsubscription(self, symbol: str) -> bool:
         """Record symbol removal intent. Args: symbol. Returns: changed flag. Raises: none."""

--- a/src/nifty_scalper_bot/notifications/telegram_controller.py
+++ b/src/nifty_scalper_bot/notifications/telegram_controller.py
@@ -4474,6 +4474,11 @@ class TelegramBot:
             return self._supervisor
         return getattr(self.deps, "stream_supervisor", None)
 
+    def _market_data_manager(self) -> t.Any | None:
+        """Return MarketDataManager dependency if available."""
+
+        return getattr(self.deps, "market_data_manager", None)
+
     def _fmt_age(self, seconds: float | None) -> str:
         """Return a compact age string for transport diagnostics.
 
@@ -4979,24 +4984,33 @@ class TelegramBot:
                 return 0
         return 0
 
-    def _streamer_subscribe(self, streamer: t.Any, tokens: t.Sequence[int]) -> None:
-        handler = getattr(streamer, "subscribe_tokens", None)
-        if callable(handler):
-            handler(tokens)
-            return
-        handler = getattr(streamer, "subscribe", None)
-        if callable(handler):
-            handler(tokens)
-            return
-        raise RuntimeError("Polling streamer does not support subscribe")
+    def _mdm_subscribe_tokens(self, tokens: t.Sequence[int]) -> tuple[int, int]:
+        """Route token additions through MarketDataManager."""
 
-    def _streamer_unsubscribe(self, streamer: t.Any, tokens: t.Sequence[int]) -> None:
-        for name in ("unsubscribe_tokens", "unsubscribe"):
-            handler = getattr(streamer, name, None)
-            if callable(handler):
-                handler(tokens)
-                return
-        raise RuntimeError("Polling streamer does not support unsubscribe")
+        normalized = sorted({int(token) for token in tokens if int(token) > 0})
+        if not normalized:
+            mdm = self._market_data_manager()
+            total = int(mdm.desired_token_count()) if mdm is not None else 0
+            return (0, total)
+        mdm = self._market_data_manager()
+        if mdm is None:
+            return (-1, 0)
+        changed = int(mdm.request_token_subscriptions(normalized))
+        return (changed, int(mdm.desired_token_count()))
+
+    def _mdm_unsubscribe_tokens(self, tokens: t.Sequence[int]) -> tuple[int, int]:
+        """Route token removals through MarketDataManager."""
+
+        normalized = sorted({int(token) for token in tokens if int(token) > 0})
+        if not normalized:
+            mdm = self._market_data_manager()
+            total = int(mdm.desired_token_count()) if mdm is not None else 0
+            return (0, total)
+        mdm = self._market_data_manager()
+        if mdm is None:
+            return (-1, 0)
+        changed = int(mdm.request_token_unsubscriptions(normalized))
+        return (changed, int(mdm.desired_token_count()))
 
     # ------------------------------------------------------------------
     # Consistent composer: render sections without multiplying <br> tags.
@@ -7811,88 +7825,41 @@ class TelegramBot:
         if not tokens and not symbols:
             await self._reply(chat, ctx, "Usage: /subscribe SYMBOL|TOKEN [MORE]")
             return
-        ws = self.deps.websocket_manager
-        if ws is None:
-            supervisor = self._stream_supervisor()
-            streamer = self._polling_streamer()
-            if supervisor is None and streamer is None:
-                await self._reply(chat, ctx, "Polling streamer not available")
-                return
-            try:
-                lines: list[str] = []
-                unresolved: list[str] = []
-                resolved_pairs: list[str] = []
-                added = 0
-                combined_tokens = list(tokens)
-                if supervisor is not None and symbols:
-                    resolver = getattr(supervisor, "resolve_symbols", None)
-                    if callable(resolver):
-                        resolved_tokens, unresolved, mapping = resolver(symbols)
-                        combined_tokens.extend(resolved_tokens)
-                        resolved_pairs = [
-                            f"{symbol}->{mapping[symbol]}" for symbol in mapping
-                        ]
-                    else:
-                        unresolved = list(symbols)
-                elif symbols:
-                    unresolved = list(symbols)
+        supervisor = self._stream_supervisor()
+        lines: list[str] = []
+        unresolved: list[str] = []
+        resolved_pairs: list[str] = []
+        combined_tokens = list(tokens)
+        if supervisor is not None and symbols:
+            resolver = getattr(supervisor, "resolve_symbols", None)
+            if callable(resolver):
+                resolved_tokens, unresolved, mapping = resolver(symbols)
+                combined_tokens.extend(resolved_tokens)
+                resolved_pairs = [f"{symbol}->{mapping[symbol]}" for symbol in mapping]
+            else:
+                unresolved = list(symbols)
+        elif symbols:
+            unresolved = list(symbols)
 
-                if supervisor is not None:
-                    token_count = getattr(supervisor, "token_count", None)
-                    if callable(token_count):
-                        before = int(token_count())
-                    else:
-                        before = len(
-                            getattr(supervisor, "tracked_tokens", lambda: [])()
-                        )
-                    unique_tokens = sorted({int(token) for token in combined_tokens})
-                    after = supervisor.subscribe_tokens(unique_tokens)
-                    added = max(0, int(after) - before)
-                    with suppress(Exception):
-                        supervisor.ensure_started()
-                    status_line = ""
-                    with suppress(Exception):
-                        status_line = str(supervisor.status_line())
-                    if added > 0:
-                        lines.append(f"Added {added} token(s).")
-                    elif unique_tokens:
-                        lines.append("No new tokens added (already tracking).")
-                    if resolved_pairs:
-                        lines.append(f"Resolved: {', '.join(resolved_pairs)}")
-                    if unresolved:
-                        lines.append(f"Unresolved: {', '.join(unresolved)}")
-                    if invalid:
-                        lines.append(f"Ignored: {', '.join(invalid)}")
-                    if not status_line:
-                        status_line = str(
-                            self._polling_snapshot().get("status") or "n/a"
-                        )
-                    lines.append(f"Poll: {status_line}")
-                    await self._reply(chat, ctx, "\n".join(lines))
-                    return
-                self._streamer_subscribe(streamer, tokens)
-                count = self._streamer_token_count(streamer)
-            except Exception as exc:  # noqa: BLE001
-                await self._reply(chat, ctx, f"Subscribe failed: {exc}")
-                return
-            message = f"Subscribed {len(tokens)} token(s). Now tracking {count}."
-            if invalid:
-                message += f" (ignored: {', '.join(invalid)})"
-            if symbols:
-                message += f" (symbols ignored: {', '.join(symbols)})"
-            await self._reply(chat, ctx, message)
+        changed, desired_total = self._mdm_subscribe_tokens(combined_tokens)
+        if changed < 0:
+            await self._reply(chat, ctx, "MarketDataManager unavailable for subscription.")
             return
-        try:
-            await asyncio.to_thread(ws.subscribe, tokens)
-        except Exception as exc:
-            await self._reply(chat, ctx, f"Subscribe failed: {exc}")
-            return
-        message = f"Queued subscribe for tokens: {', '.join(map(str, tokens))}"
+        if supervisor is not None:
+            with suppress(Exception):
+                supervisor.ensure_started()
+        if changed > 0:
+            lines.append(f"Tracked via MarketDataManager: added {changed} token(s).")
+        elif combined_tokens:
+            lines.append("Already tracked in MarketDataManager.")
+        if resolved_pairs:
+            lines.append(f"Resolved: {', '.join(resolved_pairs)}")
+        if unresolved:
+            lines.append(f"Unresolved: {', '.join(unresolved)}")
         if invalid:
-            message += f" (ignored: {', '.join(invalid)})"
-        if symbols:
-            message += f" (symbols ignored: {', '.join(symbols)})"
-        await self._reply(chat, ctx, message)
+            lines.append(f"Ignored: {', '.join(invalid)}")
+        lines.append(f"Current desired token count: {desired_total}")
+        await self._reply(chat, ctx, "\n".join(lines))
 
     async def cmd_unsubscribe(
         self, update: Update, ctx: ContextTypes.DEFAULT_TYPE
@@ -7904,51 +7871,23 @@ class TelegramBot:
         if not tokens:
             await self._reply(chat, ctx, "Usage: /unsubscribe TOKEN[,TOKEN]")
             return
-        ws = self.deps.websocket_manager
-        if ws is None:
-            supervisor = self._stream_supervisor()
-            streamer = self._polling_streamer()
-            if supervisor is None and streamer is None:
-                await self._reply(chat, ctx, "Polling streamer not available")
-                return
-            try:
-                if supervisor is not None:
-                    count = supervisor.unsubscribe_tokens(tokens)
-                    status_line = ""
-                    with suppress(Exception):
-                        status_line = str(supervisor.status_line())
-                    message_lines = [
-                        f"Unsubscribed {len(tokens)} token(s). Now tracking {count}.",
-                    ]
-                    if invalid:
-                        message_lines.append(f"Ignored: {', '.join(invalid)}")
-                    if not status_line:
-                        status_line = str(
-                            self._polling_snapshot().get("status") or "n/a"
-                        )
-                    message_lines.append(f"Poll: {status_line}")
-                    await self._reply(chat, ctx, "\n".join(message_lines))
-                    return
-                else:
-                    self._streamer_unsubscribe(streamer, tokens)
-                    count = self._streamer_token_count(streamer)
-            except Exception as exc:  # noqa: BLE001
-                await self._reply(chat, ctx, f"Unsubscribe failed: {exc}")
-                return
-            message = f"Unsubscribed {len(tokens)} token(s). Now tracking {count}."
-            if invalid:
-                message += f" (ignored: {', '.join(invalid)})"
-            await self._reply(chat, ctx, message)
+        changed, desired_total = self._mdm_unsubscribe_tokens(tokens)
+        if changed < 0:
+            await self._reply(
+                chat, ctx, "MarketDataManager unavailable for unsubscription."
+            )
             return
-        try:
-            await asyncio.to_thread(ws.unsubscribe, tokens)
-        except Exception as exc:
-            await self._reply(chat, ctx, f"Unsubscribe failed: {exc}")
-            return
-        message = f"Queued unsubscribe for tokens: {', '.join(map(str, tokens))}"
+        lines: list[str] = []
+        if changed > 0:
+            lines.append(
+                f"Removed from desired subscription set: {changed} token(s)."
+            )
+        else:
+            lines.append("No matching desired subscriptions found.")
         if invalid:
-            message += f" (ignored: {', '.join(invalid)})"
-        await self._reply(chat, ctx, message)
+            lines.append(f"Ignored: {', '.join(invalid)}")
+        lines.append(f"Current desired token count: {desired_total}")
+        await self._reply(chat, ctx, "\n".join(lines))
 
     @command_meta("/sub N[,N]", "Subscribe tokens (alias of /subscribe).")
     async def cmd_sub(self, update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:  # type: ignore[override]

--- a/src/nifty_scalper_bot/streaming/stream_supervisor.py
+++ b/src/nifty_scalper_bot/streaming/stream_supervisor.py
@@ -53,13 +53,14 @@ class StreamHealth:
 
 
 class StreamSupervisor:
-    """Single source of truth for polling lifecycle, health, and tokens."""
+    """Lifecycle supervisor for polling; subscription intent is owned by MarketDataManager."""
 
     def __init__(
         self,
         *,
         streamer: Any,
         resolver: Any,
+        market_data_manager: Any | None = None,
         default_symbols: Sequence[str] | None = None,
         autostart: bool = True,
         monitor_interval_s: float = 300.0,
@@ -67,12 +68,12 @@ class StreamSupervisor:
     ) -> None:
         self.streamer = streamer
         self.resolver = resolver
+        self.market_data_manager = market_data_manager
         self._default_symbols = unique_normalized_symbols(default_symbols or [])
         self._autostart = bool(autostart)
         self._monitor_interval = max(float(monitor_interval_s), 0.2)
         self._risk_halt_getter = risk_halt_getter
 
-        self._tokens: set[int] = set()
         self._lock = threading.RLock()
         self._monitor_stop = threading.Event()
         self._monitor_thread: threading.Thread | None = None
@@ -104,9 +105,8 @@ class StreamSupervisor:
     def ensure_started(self) -> bool:
         """Start the poller when tokens are present."""
 
-        with self._lock:
-            if not self._tokens:
-                return False
+        if self.token_count() <= 0:
+            return False
         return self.start()
 
     def start(self) -> bool:
@@ -280,30 +280,13 @@ class StreamSupervisor:
         additions = {int(token) for token in tokens or []}
         if not additions:
             return self.token_count()
-        with self._lock:
-            new_tokens = additions - self._tokens
-            if new_tokens:
-                self._tokens.update(new_tokens)
-        if new_tokens:
-            payload = sorted(new_tokens)
-            try:
-                subscribe = getattr(self.streamer, "subscribe_tokens", None)
-                if callable(subscribe):
-                    subscribe(payload)
-                else:
-                    self.streamer.subscribe(payload)
-            except Exception as exc:  # noqa: BLE001 - defensive guard
-                LOG.warning(
-                    "stream_supervisor_subscribe_failed",
-                    extra={
-                        "event": "stream_supervisor_subscribe_failed",
-                        "tokens": payload,
-                        "error": str(exc),
-                    },
-                )
+        mdm = self.market_data_manager
+        if mdm is None:
+            raise RuntimeError("MarketDataManager unavailable for subscription routing")
+        mdm.request_token_subscriptions(sorted(additions))
         if self._autostart:
             self.ensure_started()
-        return len(self._tokens)
+        return self.token_count()
 
     def unsubscribe_tokens(self, tokens: Iterable[int]) -> int:
         """Unsubscribe the provided tokens and return the remaining size."""
@@ -311,46 +294,38 @@ class StreamSupervisor:
         removals = {int(token) for token in tokens or []}
         if not removals:
             return self.token_count()
-        with self._lock:
-            has_overlap = bool(self._tokens & removals)
-            if has_overlap:
-                self._tokens -= removals
-        payload = sorted(removals)
-        try:
-            unsubscribe = getattr(self.streamer, "unsubscribe_tokens", None)
-            if callable(unsubscribe):
-                unsubscribe(payload)
-            else:
-                self.streamer.unsubscribe(payload)
-        except Exception as exc:  # noqa: BLE001 - defensive guard
-            LOG.warning(
-                "stream_supervisor_unsubscribe_failed",
-                extra={
-                    "event": "stream_supervisor_unsubscribe_failed",
-                    "tokens": payload,
-                    "error": str(exc),
-                },
-            )
-        if not self._tokens:
+        mdm = self.market_data_manager
+        if mdm is None:
+            raise RuntimeError("MarketDataManager unavailable for subscription routing")
+        mdm.request_token_unsubscriptions(sorted(removals))
+        if self.token_count() == 0:
             with suppress(Exception):
                 self.streamer.stop()
             with self._lock:
                 self._started_at_mono = None
-        return len(self._tokens)
+        return self.token_count()
 
     # ------------------------------------------------------------------
     # Telemetry helpers
     def token_count(self) -> int:
         """Return the number of tracked tokens."""
 
-        with self._lock:
-            return len(self._tokens)
+        mdm = self.market_data_manager
+        if mdm is not None:
+            desired_count = getattr(mdm, "desired_token_count", None)
+            if callable(desired_count):
+                return int(desired_count())
+        return 0
 
     def tracked_tokens(self) -> list[int]:
         """Return the tracked tokens in sorted order."""
 
-        with self._lock:
-            return sorted(self._tokens)
+        mdm = self.market_data_manager
+        if mdm is not None:
+            desired_snapshot = getattr(mdm, "desired_tokens_snapshot", None)
+            if callable(desired_snapshot):
+                return list(desired_snapshot())
+        return []
 
     def on_tick(self, _tick: dict[str, Any]) -> None:
         """Record the last tick timestamps for health accounting."""
@@ -367,8 +342,8 @@ class StreamSupervisor:
         """Return the current supervisor health snapshot."""
 
         running = self.is_running()
+        tokens = self.token_count()
         with self._lock:
-            tokens = len(self._tokens)
             started_at = self._started_at_mono
             last_tick_wall = self._last_tick_wall
             last_tick_mono = self._last_tick_mono
@@ -470,7 +445,7 @@ class StreamSupervisor:
             if not self._is_trading_window():
                 continue
             with self._lock:
-                active_tokens = bool(self._tokens)
+                active_tokens = self.token_count() > 0
             if not active_tokens:
                 continue
             running = self.is_running()

--- a/src/nifty_scalper_bot/streaming/websocket_manager.py
+++ b/src/nifty_scalper_bot/streaming/websocket_manager.py
@@ -39,7 +39,7 @@ class _CircuitState:
 
 
 class WebSocketManager:
-    """Manage one resilient KiteTicker session with guarded reconnect logic."""
+    """Transport-only KiteTicker session manager; business subscription intent lives upstream."""
 
     def __init__(
         self,
@@ -324,21 +324,12 @@ class WebSocketManager:
         self.add_tokens(tokens)
 
     def resubscribe(self, tokens: list[int]) -> None:
-        """Args: tokens; Returns: none; Raises: none."""
+        """Compatibility replay helper that delegates token-set reconciliation."""
 
         try:
             if not tokens:
                 return
-            unique_tokens = sorted({int(token) for token in tokens})
-            if not unique_tokens:
-                return
-            self._merge_tokens(unique_tokens)
-            ticker = self._ticker
-            if ticker is None or not self._connected.is_set():
-                return
-            ticker.subscribe(unique_tokens)
-            ticker.set_mode(ticker.MODE_FULL, unique_tokens)
-            self._logger.info("WebSocket resubscribed to %d tokens", len(unique_tokens))
+            self.set_tokens(tokens)
         except Exception as e:
             self._logger.error("WebSocket resubscribe failed: %s", e, exc_info=True)
 
@@ -348,7 +339,7 @@ class WebSocketManager:
         self.unsubscribe_tokens(tokens)
 
     def unsubscribe_tokens(self, tokens: Sequence[int]) -> None:
-        """Args: tokens; Returns: none; Raises: none."""
+        """Compatibility wrapper for transport token removals. Args: tokens; Returns: none; Raises: none."""
 
         try:
             self.remove_tokens(tokens)
@@ -854,12 +845,6 @@ class WebSocketManager:
             await asyncio.to_thread(ticker.subscribe, batch)
             await asyncio.to_thread(ticker.set_mode, ticker.MODE_FULL, batch)
             self._log_ws_subscriptions(batch)
-
-    def _merge_tokens(self, tokens: Sequence[int]) -> None:
-        """Args: tokens; Returns: none; Raises: none."""
-
-        for token in tokens:
-            self._tokens.add(int(token))
 
     def _log_ws_subscriptions(self, tokens: Sequence[int]) -> None:
         """Emit symbol/token subscription logs once per token. Args: tokens. Returns: none. Raises: none."""

--- a/tests/data/test_market_data_manager_subscriptions.py
+++ b/tests/data/test_market_data_manager_subscriptions.py
@@ -61,6 +61,18 @@ def test_request_token_subscriptions_batch_reconciles_once() -> None:
     assert ws.calls == [[101, 202]]
 
 
+def test_request_token_subscriptions_idempotent() -> None:
+    ws = DummyWebSocket()
+    mdm = MarketDataManager(DummyBroker(), ws, resolver=DummyResolver())
+
+    first = mdm.request_token_subscriptions([101, 202])
+    second = mdm.request_token_subscriptions([202, 101])
+
+    assert first == 2
+    assert second == 0
+    assert ws.calls == [[101, 202]]
+
+
 def test_request_subscription_without_ws_retains_desired_set() -> None:
     mdm = MarketDataManager(DummyBroker(), websocket=None, resolver=DummyResolver())
 
@@ -79,6 +91,37 @@ def test_request_token_unsubscription_reconciles_transport() -> None:
 
     assert changed is True
     assert ws.calls[-1] == [202]
+
+
+def test_request_token_unsubscriptions_batch_reconciles_once() -> None:
+    ws = DummyWebSocket()
+    mdm = MarketDataManager(DummyBroker(), ws, resolver=DummyResolver())
+    mdm.request_token_subscriptions([101, 202, 303])
+
+    removed = mdm.request_token_unsubscriptions([202, 303, 303])
+
+    assert removed == 2
+    assert ws.calls[-1] == [101]
+
+
+def test_request_token_unsubscriptions_missing_token_is_harmless() -> None:
+    ws = DummyWebSocket()
+    mdm = MarketDataManager(DummyBroker(), ws, resolver=DummyResolver())
+    mdm.request_token_subscriptions([101])
+    before_calls = list(ws.calls)
+
+    removed = mdm.request_token_unsubscriptions([999])
+
+    assert removed == 0
+    assert ws.calls == before_calls
+
+
+def test_desired_token_snapshot_and_count_are_stable() -> None:
+    mdm = MarketDataManager(DummyBroker(), websocket=None, resolver=DummyResolver())
+    mdm.request_token_subscriptions([303, 101, 202, 202])
+
+    assert mdm.desired_token_count() == 3
+    assert mdm.desired_tokens_snapshot() == [101, 202, 303]
 
 
 def test_ensure_subscription_uses_request_api() -> None:

--- a/tests/notifications/test_telegram_subscriptions.py
+++ b/tests/notifications/test_telegram_subscriptions.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from nifty_scalper_bot.notifications.telegram_controller import TelegramBot, TelegramDeps
+
+
+class _DummyMdm:
+    def __init__(self) -> None:
+        self.desired: set[int] = set()
+        self.sub_calls = 0
+        self.unsub_calls = 0
+
+    def request_token_subscriptions(self, tokens: list[int]) -> int:
+        self.sub_calls += 1
+        before = len(self.desired)
+        self.desired.update(int(token) for token in tokens)
+        return len(self.desired) - before
+
+    def request_token_unsubscriptions(self, tokens: list[int]) -> int:
+        self.unsub_calls += 1
+        before = len(self.desired)
+        self.desired.difference_update(int(token) for token in tokens)
+        return before - len(self.desired)
+
+    def desired_token_count(self) -> int:
+        return len(self.desired)
+
+
+class _DummySupervisor:
+    def __init__(self) -> None:
+        self.ensure_started_calls = 0
+
+    def resolve_symbols(self, symbols: list[str]) -> tuple[list[int], list[str], dict[str, int]]:
+        mapping = {'NIFTY': 256265}
+        resolved: list[int] = []
+        unresolved: list[str] = []
+        pairs: dict[str, int] = {}
+        for symbol in symbols:
+            token = mapping.get(symbol)
+            if token is None:
+                unresolved.append(symbol)
+            else:
+                resolved.append(token)
+                pairs[symbol] = token
+        return resolved, unresolved, pairs
+
+    def ensure_started(self) -> bool:
+        self.ensure_started_calls += 1
+        return True
+
+
+class _ForbiddenWs:
+    def __getattr__(self, name: str):
+        if name in {'subscribe', 'unsubscribe', 'subscribe_tokens', 'unsubscribe_tokens'}:
+            raise AssertionError(f'unexpected websocket call: {name}')
+        raise AttributeError(name)
+
+
+class _DummyChat:
+    def __init__(self, chat_id: int) -> None:
+        self.id = chat_id
+
+
+@pytest.mark.asyncio
+async def test_subscribe_routes_through_mdm(monkeypatch: pytest.MonkeyPatch) -> None:
+    deps = TelegramDeps(token='x', chat_id=1, app_version='test')
+    deps.market_data_manager = _DummyMdm()
+    deps.stream_supervisor = _DummySupervisor()
+    deps.websocket_manager = _ForbiddenWs()
+    bot = TelegramBot(deps)
+
+    sent: list[str] = []
+    async def _guard(_update):  # noqa: ANN001
+        return _DummyChat(1)
+
+    monkeypatch.setattr(bot, '_guard', _guard)
+
+    async def _reply(_chat, _ctx, text: str, parse_mode=None):  # noqa: ANN001
+        del parse_mode
+        sent.append(text)
+        return None
+
+    monkeypatch.setattr(bot, '_reply', _reply)
+
+    ctx = SimpleNamespace(args=['NIFTY', '123'])
+    await bot.cmd_subscribe(SimpleNamespace(), ctx)
+
+    mdm = deps.market_data_manager
+    assert mdm.sub_calls == 1
+    assert mdm.desired == {123, 256265}
+    assert deps.stream_supervisor.ensure_started_calls == 1
+    assert any('Tracked via MarketDataManager' in line for line in sent)
+
+
+@pytest.mark.asyncio
+async def test_unsubscribe_routes_through_mdm(monkeypatch: pytest.MonkeyPatch) -> None:
+    deps = TelegramDeps(token='x', chat_id=1, app_version='test')
+    mdm = _DummyMdm()
+    mdm.desired = {123, 256265}
+    deps.market_data_manager = mdm
+    deps.websocket_manager = _ForbiddenWs()
+    bot = TelegramBot(deps)
+
+    sent: list[str] = []
+    async def _guard(_update):  # noqa: ANN001
+        return _DummyChat(1)
+
+    monkeypatch.setattr(bot, '_guard', _guard)
+
+    async def _reply(_chat, _ctx, text: str, parse_mode=None):  # noqa: ANN001
+        del parse_mode
+        sent.append(text)
+        return None
+
+    monkeypatch.setattr(bot, '_reply', _reply)
+
+    ctx = SimpleNamespace(args=['123'])
+    await bot.cmd_unsubscribe(SimpleNamespace(), ctx)
+
+    assert mdm.unsub_calls == 1
+    assert mdm.desired == {256265}
+    assert any('Removed from desired subscription set' in line for line in sent)

--- a/tests/streaming/test_stream_supervisor.py
+++ b/tests/streaming/test_stream_supervisor.py
@@ -7,9 +7,10 @@ from nifty_scalper_bot.streaming.stream_supervisor import StreamSupervisor
 
 class _DummyStreamer:
     def __init__(self) -> None:
-        self.subscribed: set[int] = set()
         self.running = False
         self.start_calls = 0
+        self.subscribe_calls = 0
+        self.unsubscribe_calls = 0
 
     _interval_s = 0.7
     _batch_size = 200
@@ -25,11 +26,10 @@ class _DummyStreamer:
         return self.running
 
     def subscribe_tokens(self, tokens: list[int]) -> None:
-        self.subscribed.update(int(token) for token in tokens)
+        self.subscribe_calls += 1
 
     def unsubscribe_tokens(self, tokens: list[int]) -> None:
-        for token in tokens:
-            self.subscribed.discard(int(token))
+        self.unsubscribe_calls += 1
 
 
 class _DummyResolver:
@@ -43,12 +43,38 @@ class _DummyResolver:
         return self.mapping.get(symbol.upper())
 
 
+class _DummyMarketDataManager:
+    def __init__(self) -> None:
+        self.desired: set[int] = set()
+        self.subscribe_calls = 0
+        self.unsubscribe_calls = 0
+
+    def request_token_subscriptions(self, tokens: list[int]) -> int:
+        self.subscribe_calls += 1
+        before = len(self.desired)
+        self.desired.update(int(token) for token in tokens)
+        return len(self.desired) - before
+
+    def request_token_unsubscriptions(self, tokens: list[int]) -> int:
+        self.unsubscribe_calls += 1
+        before = len(self.desired)
+        self.desired.difference_update(int(token) for token in tokens)
+        return before - len(self.desired)
+
+    def desired_token_count(self) -> int:
+        return len(self.desired)
+
+    def desired_tokens_snapshot(self) -> list[int]:
+        return sorted(self.desired)
+
+
 def test_supervisor_bootstrap_and_status() -> None:
     streamer = _DummyStreamer()
     resolver = _DummyResolver({"NIFTY": 101})
     supervisor = StreamSupervisor(
         streamer=streamer,
         resolver=resolver,
+        market_data_manager=_DummyMarketDataManager(),
         default_symbols=["NIFTY"],
         autostart=True,
         monitor_interval_s=0.05,
@@ -75,6 +101,7 @@ def test_supervisor_auto_restart_on_stop() -> None:
     supervisor = StreamSupervisor(
         streamer=streamer,
         resolver=resolver,
+        market_data_manager=_DummyMarketDataManager(),
         autostart=True,
         monitor_interval_s=0.05,
     )
@@ -94,10 +121,37 @@ def test_supervisor_auto_restart_on_stop() -> None:
 def test_supervisor_resolve_symbols_mapping() -> None:
     streamer = _DummyStreamer()
     resolver = _DummyResolver({"NIFTY": 123})
-    supervisor = StreamSupervisor(streamer=streamer, resolver=resolver)
+    supervisor = StreamSupervisor(
+        streamer=streamer,
+        resolver=resolver,
+        market_data_manager=_DummyMarketDataManager(),
+    )
 
     tokens, unresolved, mapping = supervisor.resolve_symbols(["NIFTY", "UNKNOWN"])
 
     assert tokens == [123]
     assert unresolved == ["UNKNOWN"]
     assert mapping == {"NIFTY": 123}
+
+
+def test_supervisor_subscription_methods_route_via_mdm() -> None:
+    streamer = _DummyStreamer()
+    resolver = _DummyResolver({})
+    mdm = _DummyMarketDataManager()
+    supervisor = StreamSupervisor(
+        streamer=streamer,
+        resolver=resolver,
+        market_data_manager=mdm,
+        autostart=True,
+    )
+
+    total = supervisor.subscribe_tokens([101, 202, 101])
+    assert total == 2
+    assert mdm.subscribe_calls == 1
+    assert streamer.subscribe_calls == 0
+    assert streamer.start_calls == 1
+
+    remaining = supervisor.unsubscribe_tokens([202, 999])
+    assert remaining == 1
+    assert mdm.unsubscribe_calls == 1
+    assert streamer.unsubscribe_calls == 0

--- a/tests/streaming/test_websocket_manager.py
+++ b/tests/streaming/test_websocket_manager.py
@@ -272,3 +272,31 @@ def test_subscribe_tokens_wrapper_unions_and_delegates(
     manager.subscribe_tokens([20, 30])
 
     assert manager._tokens == {10, 20, 30}  # noqa: SLF001
+
+
+def test_unsubscribe_tokens_wrapper_subtracts_and_delegates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(ws_module, "KiteTicker", FakeKiteTicker)
+    manager = ws_module.WebSocketManager(
+        "k", "t", [10, 20, 30], trading_window_enabled=False
+    )
+
+    manager.unsubscribe_tokens([20, 99])
+
+    assert manager._tokens == {10, 30}  # noqa: SLF001
+
+
+def test_resubscribe_delegates_to_set_tokens(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(ws_module, "KiteTicker", FakeKiteTicker)
+    manager = ws_module.WebSocketManager("k", "t", [1], trading_window_enabled=False)
+    called: list[list[int]] = []
+
+    def _set_tokens(tokens: list[int]) -> bool:
+        called.append(list(tokens))
+        return True
+
+    manager.set_tokens = _set_tokens  # type: ignore[method-assign]
+    manager.resubscribe([1, 2, 2])
+
+    assert called == [[1, 2, 2]]

--- a/tests/test_initialize_components_polling.py
+++ b/tests/test_initialize_components_polling.py
@@ -74,6 +74,7 @@ class DummyMarketDataManager:
         self._enqueue_calls: list[dict[str, object]] = []
         self._symbol_by_token: dict[int, str] = {}
         self._heartbeat_callbacks: list[callable] = []  # type: ignore[var-annotated]
+        self._desired_tokens: set[int] = set()
 
     def _handle_tick(self, tick):  # noqa: ANN001
         self._handle_tick_calls.append(dict(tick))
@@ -100,6 +101,22 @@ class DummyMarketDataManager:
 
     def get_latest_price(self, _symbol: str) -> None:
         return None
+
+    def request_token_subscriptions(self, tokens):  # noqa: ANN001
+        before = len(self._desired_tokens)
+        self._desired_tokens.update(int(token) for token in tokens)
+        return len(self._desired_tokens) - before
+
+    def request_token_unsubscriptions(self, tokens):  # noqa: ANN001
+        before = len(self._desired_tokens)
+        self._desired_tokens.difference_update(int(token) for token in tokens)
+        return before - len(self._desired_tokens)
+
+    def desired_token_count(self) -> int:
+        return len(self._desired_tokens)
+
+    def desired_tokens_snapshot(self) -> list[int]:
+        return sorted(self._desired_tokens)
 
 
 class DummyPollingStreamer:


### PR DESCRIPTION
### Motivation

- Eliminate remaining bypass paths so MarketDataManager (MDM) is the single source of truth for desired websocket subscriptions.
- Prevent StreamSupervisor and TelegramController from mutating transport subscriptions directly and ensure WebSocketManager remains transport-only.

### Description

- MarketDataManager: added `request_token_unsubscriptions`, `desired_token_count`, and `desired_tokens_snapshot`, and made symbol/token cleanup guarded to avoid unsafe mapping removals; batch ops reconcile exactly once via `_reconcile_ws_subscriptions`. (file: `data/market_data_manager.py`)
- StreamSupervisor: removed local authoritative `_tokens` behavior and routing; `subscribe_tokens` / `unsubscribe_tokens` now forward intent to `market_data_manager.request_token_subscriptions` / `request_token_unsubscriptions`; telemetry (`token_count`, `tracked_tokens`, health) now reads from MDM; lifecycle/start logic preserved. (file: `streaming/stream_supervisor.py`) 
- TelegramController: added helpers `_market_data_manager`, `_mdm_subscribe_tokens`, and `_mdm_unsubscribe_tokens`; rewired `/subscribe` and `/unsubscribe` command handlers to always route intent through MDM and to use the supervisor only for lifecycle `ensure_started` when present; removed direct streamer/ws mutation from command paths. (file: `notifications/telegram_controller.py`)
- WebSocketManager: clarified docstring; collapsed mutation helpers into thin wrappers around `set_tokens()` (`resubscribe` now delegates to `set_tokens`, `subscribe_tokens`/`unsubscribe_tokens` remain compatibility shims), ensuring transport-only reconciliation. (file: `streaming/websocket_manager.py`)
- Core wiring: pass `market_data_manager` into `StreamSupervisor` at initialization so supervisor can call MDM APIs. (file: `core/app.py`)
- Tests: added/updated focused unit tests to cover MDM idempotency and batch reconciliation, supervisor routing through MDM, Telegram routing through MDM, websocket wrapper behavior, and polling initialization compatibility. (files: tests under `tests/...`)

### Testing

- Ran targeted unit tests: `pytest -q tests/data/test_market_data_manager_subscriptions.py tests/streaming/test_stream_supervisor.py tests/notifications/test_telegram_subscriptions.py tests/streaming/test_websocket_manager.py tests/test_initialize_components_polling.py` and they all passed in this environment.
- Ran grep checks for remaining subscribe/unsubscribe/set_tokens callers and verified Telegram and StreamSupervisor no longer directly mutate websocket transport for business intent; `set_tokens()` remains the transport reconciliation entrypoint.
- Executed `./run_checks.sh` in this environment; initial invocation required installing `pytest` and `pytest-cov` to satisfy the environment hooks and then progressed, but full CI-style run is environment-dependent (not all global tooling was preinstalled here). All focused tests above passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9a7a48a2483249936f65e641e00cb)