### PR TITLE
fix: downgrade stale spot to soft signal and gate fallback/readiness on futures+options

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -93,21 +93,19 @@ def _build_startup_fingerprint() -> dict[str, str]:
 def _polling_fallback_degraded(
     *,
     ws_ok: bool,
-    stale: bool,
     lagging: bool,
-    quote_age_degraded: bool,
+    futures_fresh: bool,
+    options_fresh: bool,
 ) -> bool:
-    """Evaluate fallback degrade state. Treat stale spot quote age as sufficient degradation on its own.
-    Otherwise NSE:NIFTY can remain symbol-stale forever while other symbols
-    keep the global feed appearing healthy."""
+    """Evaluate fallback degrade state using trading-critical feed health."""
 
     if not ws_ok:
         return True
-    if stale:
-        return True
     if lagging:
         return True
-    if quote_age_degraded:
+    if not futures_fresh:
+        return True
+    if not options_fresh:
         return True
     return False
 
@@ -6090,60 +6088,29 @@ async def startup_sequence(ctx: BotContext) -> None:
                 if ctx.websocket_manager is not None and ctx.market_data_manager is not None:
                     async def _polling_failover_supervisor() -> None:
                         """Supervise WS health and toggle polling fallback with hysteresis."""
-                        def _sanitize_quote_age(raw_age: Any) -> tuple[str, int | None]:
-                            """Classify quote freshness age. Args: raw age. Returns: state/age. Raises: none."""
-                            try:
-                                if raw_age is None:
-                                    return ("unknown", None)
-                                age = int(raw_age)
-                            except (TypeError, ValueError):
-                                return ("invalid_sentinel", None)
-                            if age < 0 or age > 60_000_000:
-                                return ("invalid_sentinel", None)
-                            if age <= quote_stale_ms:
-                                return ("fresh", age)
-                            return ("stale", age)
-
                         degraded_since: float | None = None
                         recovered_since: float | None = None
                         activate_after = 3.0
                         recover_cooldown = 10.0
                         quote_stale_ms = 5000
-                        core_symbol = "NSE:NIFTY"
                         while True:
                             try:
                                 ws_ok = bool(ctx.websocket_manager.is_connected())
-                                stale = bool(ctx.market_data_manager.is_data_stale())
-                                spot_age = ctx.market_data_manager.quote_age_ms(core_symbol)
-                                spot_state, sanitized_spot_age = _sanitize_quote_age(spot_age)
-                                quote_age_degraded = spot_state == "stale"
-
-                                if quote_age_degraded:
-                                    LOGGER.warning(
-                                        "spot_quote_stale_triggering_poll_fallback symbol=%s age_ms=%s threshold_ms=%s",
-                                        core_symbol,
-                                        sanitized_spot_age,
-                                        quote_stale_ms,
-                                        extra={
-                                            "event": "spot_quote_stale_triggering_poll_fallback",
-                                            "symbol": core_symbol,
-                                            "age_ms": sanitized_spot_age,
-                                            "threshold_ms": quote_stale_ms,
-                                        },
-                                    )
-                                core_tick_age_ms = ctx.market_data_manager.symbol_data_age_ms(
-                                    core_symbol
+                                feed_health = ctx.market_data_manager.trading_feed_health(
+                                    max_age_ms=quote_stale_ms
                                 )
+                                futures_fresh = bool(feed_health.get("futures_fresh"))
+                                options_fresh = bool(feed_health.get("options_fresh"))
+                                spot_fresh = bool(feed_health.get("spot_fresh"))
+                                spot_symbol = str(feed_health.get("spot_symbol") or "NSE:NIFTY")
+                                spot_age_ms = feed_health.get("spot_age_ms")
                                 auth_tick_age_ms = ctx.market_data_manager.data_age_ms()
-                                lagging = (
-                                    core_tick_age_ms > quote_stale_ms
-                                    and auth_tick_age_ms > quote_stale_ms
-                                )
+                                lagging = auth_tick_age_ms > quote_stale_ms
                                 degraded = _polling_fallback_degraded(
                                     ws_ok=ws_ok,
-                                    stale=stale,
                                     lagging=lagging,
-                                    quote_age_degraded=quote_age_degraded,
+                                    futures_fresh=futures_fresh,
+                                    options_fresh=options_fresh,
                                 )
                                 now_mono = time_module.monotonic()
                                 if degraded:
@@ -6156,38 +6123,39 @@ async def startup_sequence(ctx: BotContext) -> None:
                                         LOGGER.warning(
                                             "Polling fallback activate (supervisor) ws_ok=%s stale=%s lagging=%s spot_quote_age_ms=%s",
                                             ws_ok,
-                                            stale,
+                                            not bool(feed_health.get("trading_feed_healthy")),
                                             lagging,
-                                            sanitized_spot_age,
+                                            spot_age_ms,
                                             extra={
-                                                "event": "polling_fallback_activated",
+                                                "event": "poll_fallback_activate",
                                                 "reason": (
                                                     "ws_disconnected"
                                                     if not ws_ok
-                                                    else "stale_full_basket"
-                                                    if stale
                                                     else "tick_lag"
                                                     if lagging
-                                                    else "stale_spot_quote"
+                                                    else "futures_stale"
+                                                    if not futures_fresh
+                                                    else "options_stale"
                                                 ),
-                                                "spot_state": spot_state,
                                                 "lagging": lagging,
-                                                "core_tick_age_ms": core_tick_age_ms,
+                                                "futures_fresh": futures_fresh,
+                                                "options_fresh": options_fresh,
                                                 "authoritative_age_ms": auth_tick_age_ms,
                                             },
                                         )
                                         polling_fallback.set_websocket_mode(False)
                                         polling_fallback.start()
-                                elif spot_state in {"unknown", "invalid_sentinel"}:
-                                    LOGGER.info(
-                                        "Polling fallback not activated due to non-actionable spot quote age state=%s",
-                                        spot_state,
-                                        extra={
-                                            "event": "polling_fallback_age_ignored",
-                                            "spot_state": spot_state,
-                                        },
-                                    )
                                 else:
+                                    if not spot_fresh:
+                                        ctx.market_data_manager.ensure_spot_reference_fresh(
+                                            symbol=spot_symbol,
+                                            stale_after_ms=quote_stale_ms,
+                                        )
+                                        LOGGER.info(
+                                            "poll_fallback_skipped_spot_only_stale symbol=%s age_ms=%s",
+                                            spot_symbol,
+                                            spot_age_ms,
+                                        )
                                     degraded_since = None
                                     recovered_since = recovered_since or now_mono
                                     if (
@@ -6498,22 +6466,55 @@ async def startup_sequence(ctx: BotContext) -> None:
                         try:
                             await ctx.market_data_manager.wait_until_ready(timeout=30.0)
                             readiness_ready = bool(ctx.market_data_manager.ready)
+                            readiness_state = (
+                                ctx.market_data_manager.readiness_state_snapshot()
+                            )
+                            hard_ready = bool(readiness_state.get("hard_ready"))
+                            spot_ready = bool(readiness_state.get("spot_ready"))
+                            missing_hard = list(readiness_state.get("missing_hard") or [])
                             if ctx.market_regime_manager is not None:
                                 ctx.market_regime_manager.indicators_ready = readiness_ready
                             if ctx.data_hub is not None:
                                 ctx.data_hub.indicators_ready = readiness_ready
-                            LOGGER.info(
-                                "Condition met: startup_pipeline_ready",
-                                extra={
-                                    "event": "startup_pipeline_ready",
-                                    "readiness_ready": readiness_ready,
-                                    "ws_connected": bool(
-                                        ctx.websocket_manager.is_connected()
-                                        if ctx.websocket_manager is not None
-                                        else False
-                                    ),
-                                },
+                            ws_connected = bool(
+                                ctx.websocket_manager.is_connected()
+                                if ctx.websocket_manager is not None
+                                else False
                             )
+                            if readiness_ready and spot_ready:
+                                LOGGER.info(
+                                    "Condition met: startup_pipeline_ready",
+                                    extra={
+                                        "event": "startup_pipeline_ready",
+                                        "readiness_ready": readiness_ready,
+                                        "ws_connected": ws_connected,
+                                    },
+                                )
+                            elif hard_ready:
+                                LOGGER.warning(
+                                    "startup_pipeline_ready_degraded spot_ready=%s",
+                                    spot_ready,
+                                    extra={
+                                        "event": "startup_pipeline_ready_degraded",
+                                        "hard_ready": hard_ready,
+                                        "spot_ready": spot_ready,
+                                        "timed_out": not readiness_ready,
+                                        "ws_connected": ws_connected,
+                                    },
+                                )
+                            else:
+                                LOGGER.error(
+                                    "startup_pipeline_incomplete missing=%s",
+                                    ",".join(missing_hard) if missing_hard else "unknown",
+                                    extra={
+                                        "event": "startup_pipeline_incomplete",
+                                        "hard_ready": hard_ready,
+                                        "spot_ready": spot_ready,
+                                        "timed_out": not readiness_ready,
+                                        "missing": missing_hard,
+                                        "ws_connected": ws_connected,
+                                    },
+                                )
                         except Exception as ready_exc:
                             LOGGER.critical(
                                 "Startup readiness gate failed: %s",

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -154,6 +154,12 @@ class MarketDataManager:
         self._last_historical_ts: dict[str, float] = {}
         self._last_tick_ts: dict[str, float] = {}
         self._readiness_requirements: dict[str, Any] = {}
+        self._last_readiness_state: dict[str, Any] = {
+            "hard_ready": False,
+            "spot_ready": False,
+            "missing_hard": [],
+        }
+        self._spot_refresh_last_attempt_mono: float = 0.0
         # Bounded queue: drops oldest when full so a stall in the async
         # consumer never grows memory without bound. Size 10 000 is ~8 s
         # of headroom at 1 000 tps.
@@ -2692,8 +2698,10 @@ class MarketDataManager:
                     for symbol in subscribed_symbols
                 }
             requirements = dict(self._readiness_requirements)
+            readiness_state = self._readiness_state(bars, min_bars, requirements)
+            self._last_readiness_state = dict(readiness_state)
             valid_symbols = [s for s, count in bars.items() if count >= min_bars]
-            if self._readiness_passes(bars, min_bars, requirements):
+            if readiness_state["hard_ready"]:
                 self.ready = True
                 self.degraded = False
                 self.hydration_complete = True
@@ -2703,6 +2711,7 @@ class MarketDataManager:
                         "event": "mdm_ready",
                         "symbols": valid_symbols,
                         "requirements": requirements,
+                        "spot_ready": readiness_state["spot_ready"],
                     },
                 )
                 return
@@ -2731,13 +2740,21 @@ class MarketDataManager:
             self.ready = False
             self.degraded = True
         else:
+            timed_out_state = self._readiness_state(
+                bars, min_bars, self._readiness_requirements
+            )
+            self._last_readiness_state = dict(timed_out_state)
             self._logger.warning(
                 "Readiness timeout before hydration completed "
-                "(timeout=%.1fs, min_bars=%d, bars=%s, requirements=%s)",
+                "(timeout=%.1fs, min_bars=%d, bars=%s, requirements=%s, "
+                "hard_ready=%s, spot_ready=%s, missing_hard=%s)",
                 timeout,
                 min_bars,
                 bars,
                 self._readiness_requirements,
+                timed_out_state["hard_ready"],
+                timed_out_state["spot_ready"],
+                timed_out_state["missing_hard"],
             )
             self.ready = False
             self.degraded = False
@@ -2750,28 +2767,151 @@ class MarketDataManager:
         requirements: Mapping[str, Any],
     ) -> bool:
         """Evaluate strict readiness rules for startup/live gating."""
+        return bool(self._readiness_state(bars, min_bars, requirements)["hard_ready"])
+
+    def _readiness_state(
+        self,
+        bars: Mapping[str, int],
+        min_bars: int,
+        requirements: Mapping[str, Any],
+    ) -> dict[str, Any]:
+        """Classify readiness into hard-trading and soft-spot states."""
         if not requirements:
-            return any(count >= min_bars for count in bars.values())
+            any_ready = any(count >= min_bars for count in bars.values())
+            return {
+                "hard_ready": any_ready,
+                "spot_ready": True,
+                "missing_hard": [],
+            }
         spot = str(requirements.get("spot") or "")
         futures = str(requirements.get("futures") or "")
-        atm_ce = requirements.get("atm_ce")
-        atm_pe = requirements.get("atm_pe")
+        atm_ce = str(requirements.get("atm_ce") or "")
+        atm_pe = str(requirements.get("atm_pe") or "")
         options = [str(s) for s in requirements.get("options") or []]
-        if bars.get(spot, 0) < min_bars or bars.get(futures, 0) < min_bars:
+
+        missing_hard: list[str] = []
+        if futures and bars.get(futures, 0) < min_bars:
+            missing_hard.append("futures")
+        if atm_ce and bars.get(atm_ce, 0) < min_bars:
+            missing_hard.append("atm_ce")
+        if atm_pe and bars.get(atm_pe, 0) < min_bars:
+            missing_hard.append("atm_pe")
+
+        if not atm_ce or not atm_pe:
+            ce_ready = any(
+                sym.endswith("CE") and bars.get(sym, 0) >= min_bars for sym in options
+            )
+            pe_ready = any(
+                sym.endswith("PE") and bars.get(sym, 0) >= min_bars for sym in options
+            )
+            if not ce_ready:
+                missing_hard.append("options_ce")
+            if not pe_ready:
+                missing_hard.append("options_pe")
+
+        spot_ready = True if not spot else bars.get(spot, 0) >= min_bars
+        return {
+            "hard_ready": len(missing_hard) == 0,
+            "spot_ready": spot_ready,
+            "missing_hard": missing_hard,
+        }
+
+    def readiness_state_snapshot(self) -> dict[str, Any]:
+        """Return latest readiness classification snapshot."""
+        return dict(self._last_readiness_state)
+
+    def _is_symbol_fresh(self, symbol: str, max_age_ms: int) -> bool:
+        """Return whether a symbol has a fresh enough tick age."""
+        return self.symbol_data_age_ms(symbol) <= int(max(max_age_ms, 1))
+
+    def _active_option_symbols(self) -> list[str]:
+        """Return currently active option symbols used for hard feed checks."""
+        requirements = dict(self._readiness_requirements)
+        symbols = [str(s) for s in requirements.get("options") or [] if s]
+        if not symbols:
+            with self._lock:
+                symbols = [
+                    symbol
+                    for symbol in self._active_subscribed_symbols
+                    if symbol.endswith("CE") or symbol.endswith("PE")
+                ]
+        return sorted(set(symbols))
+
+    def _is_spot_fresh(self, max_age_ms: int | None = None) -> bool:
+        """Return whether spot is fresh enough for advisory reference."""
+        threshold = int(max_age_ms or self._tick_stale_threshold_ms)
+        spot_symbol = str(self._readiness_requirements.get("spot") or "NSE:NIFTY")
+        return self._is_symbol_fresh(spot_symbol, threshold)
+
+    def _is_futures_fresh(self, max_age_ms: int | None = None) -> bool:
+        """Return whether futures feed is fresh enough for trading safety."""
+        threshold = int(max_age_ms or self._tick_stale_threshold_ms)
+        futures_symbol = str(self._readiness_requirements.get("futures") or "")
+        if not futures_symbol:
             return False
-        if atm_ce and bars.get(str(atm_ce), 0) < min_bars:
+        return self._is_symbol_fresh(futures_symbol, threshold)
+
+    def _are_active_options_fresh(self, max_age_ms: int | None = None) -> bool:
+        """Return whether active options feed is fresh enough for trading safety."""
+        threshold = int(max_age_ms or self._tick_stale_threshold_ms)
+        option_symbols = self._active_option_symbols()
+        if not option_symbols:
             return False
-        if atm_pe and bars.get(str(atm_pe), 0) < min_bars:
-            return False
-        if atm_ce and atm_pe:
+        return all(self._is_symbol_fresh(symbol, threshold) for symbol in option_symbols)
+
+    def trading_feed_health(self, max_age_ms: int | None = None) -> dict[str, Any]:
+        """Return trading-critical feed health where spot is advisory only."""
+        threshold = int(max_age_ms or self._tick_stale_threshold_ms)
+        requirements = dict(self._readiness_requirements)
+        spot_symbol = str(requirements.get("spot") or "NSE:NIFTY")
+        futures_symbol = str(requirements.get("futures") or "")
+        option_symbols = self._active_option_symbols()
+        futures_fresh = self._is_futures_fresh(threshold)
+        options_fresh = self._are_active_options_fresh(threshold)
+        spot_fresh = self._is_spot_fresh(threshold)
+        return {
+            "trading_feed_healthy": futures_fresh and options_fresh,
+            "futures_fresh": futures_fresh,
+            "options_fresh": options_fresh,
+            "spot_fresh": spot_fresh,
+            "spot_symbol": spot_symbol,
+            "spot_age_ms": self.symbol_data_age_ms(spot_symbol),
+            "futures_symbol": futures_symbol,
+            "futures_age_ms": self.symbol_data_age_ms(futures_symbol)
+            if futures_symbol
+            else 1_000_000_000,
+            "option_symbols": option_symbols,
+            "threshold_ms": threshold,
+        }
+
+    def ensure_spot_reference_fresh(
+        self,
+        *,
+        symbol: str = "NSE:NIFTY",
+        stale_after_ms: int | None = None,
+        min_refresh_interval_s: float = 3.0,
+    ) -> bool:
+        """Soft-check spot and trigger REST refresh without global fallback."""
+        canonical_symbol = self._canonical_symbol(symbol)
+        threshold = int(stale_after_ms or self._tick_stale_threshold_ms)
+        age_ms = self.symbol_data_age_ms(canonical_symbol)
+        if age_ms <= threshold:
             return True
-        ce_ready = any(
-            sym.endswith("CE") and bars.get(sym, 0) >= min_bars for sym in options
+        self._logger.warning(
+            "spot_quote_stale_soft_warning symbol=%s age_ms=%s threshold_ms=%s",
+            canonical_symbol,
+            age_ms,
+            threshold,
         )
-        pe_ready = any(
-            sym.endswith("PE") and bars.get(sym, 0) >= min_bars for sym in options
-        )
-        return ce_ready and pe_ready
+        now_mono = time.monotonic()
+        if now_mono - self._spot_refresh_last_attempt_mono < max(
+            min_refresh_interval_s, 0.0
+        ):
+            return False
+        self._spot_refresh_last_attempt_mono = now_mono
+        self._logger.info("spot_rest_refresh_attempt symbol=%s", canonical_symbol)
+        self.request_refresh(canonical_symbol)
+        return False
 
     def get_hydration_status(self, symbol: str) -> str:
         """Return hydration status. Args: symbol. Returns: status string. Raises: None."""

--- a/src/nifty_scalper_bot/notifications/telegram_controller.py
+++ b/src/nifty_scalper_bot/notifications/telegram_controller.py
@@ -6402,6 +6402,35 @@ class TelegramBot:
             poll_line += f" {heart}"
             if not ws_ok and not ws_disabled and poll_tokens == 0:
                 hints.append("Enable polling or subscribe tokens.")
+            mdm_health_line = ""
+            market_data_manager = self.deps.market_data_manager
+            if market_data_manager is not None and hasattr(
+                market_data_manager, "trading_feed_health"
+            ):
+                try:
+                    feed_health = market_data_manager.trading_feed_health()
+                except Exception as exc:  # noqa: BLE001
+                    log.error(
+                        "Failure in cmd_status.trading_feed_health: %s",
+                        exc,
+                        extra={"event": "telegram_cmd_status_feed_health_error"},
+                    )
+                else:
+                    futures_fresh = bool(feed_health.get("futures_fresh"))
+                    options_fresh = bool(feed_health.get("options_fresh"))
+                    spot_fresh = bool(feed_health.get("spot_fresh"))
+                    mdm_health_line = (
+                        f"{EMOJI['data']} Feed: "
+                        f"futures=<b>{'OK' if futures_fresh else 'STALE'}</b> "
+                        f"options=<b>{'OK' if options_fresh else 'STALE'}</b> "
+                        f"spot=<b>{'OK' if spot_fresh else 'STALE (soft)'}</b>"
+                    )
+                    if not futures_fresh or not options_fresh:
+                        hints.append(
+                            "Trading feed degraded (futures/options stale)."
+                        )
+                    elif not spot_fresh:
+                        hints.append("Spot stale (soft); futures/options healthy.")
 
             risk_line = f"{EMOJI['risk']} Risk: <b>n/a</b>"
             risk_snapshot = self._coerce_risk_snapshot()
@@ -6531,6 +6560,8 @@ class TelegramBot:
                     positions_line,
                 ]
             )
+            if mdm_health_line:
+                section_main.insert(4, mdm_health_line)
             reconcile_line, reconcile_hint = self._reconcile_status_line()
             if reconcile_line:
                 section_main.append(reconcile_line)

--- a/tests/data/test_market_data_health.py
+++ b/tests/data/test_market_data_health.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import time
+
+from nifty_scalper_bot.data.market_data_manager import MarketDataManager
+
+
+class DummyBroker:
+    def get_quote(self, _symbol: str) -> dict[str, float]:
+        return {"ltp": 0.0}
+
+
+class DummyWebSocket:
+    on_tick = None
+
+    def subscribe_tokens(self, _tokens, mode: str = 'ltp') -> None:
+        return None
+
+    def set_tokens(self, _tokens) -> bool:
+        return True
+
+    def unsubscribe_tokens(self, _tokens) -> None:
+        return None
+
+    def connection_state(self):
+        return None
+
+    def is_connected(self) -> bool:
+        return True
+
+
+def _seed_tick(manager: MarketDataManager, symbol: str, age_seconds: float) -> None:
+    now = time.time()
+    manager._store_tick(
+        symbol,
+        {
+            'symbol': symbol,
+            'ltp': 100.0,
+            'last_price': 100.0,
+            'timestamp': now - age_seconds,
+        },
+    )
+    manager._last_tick_time[symbol] = now - age_seconds
+    manager._last_tick_wallclock[symbol] = now - age_seconds
+
+
+def _build_manager() -> MarketDataManager:
+    manager = MarketDataManager(DummyBroker(), DummyWebSocket())
+    manager._tick_stale_threshold_ms = 5_000
+    manager.set_readiness_requirements(
+        spot_symbol='NSE:NIFTY',
+        futures_symbol='NFO:NIFTYFUT',
+        atm_ce_symbol='NFO:NIFTYATMCE',
+        atm_pe_symbol='NFO:NIFTYATMPE',
+        option_symbols=['NFO:NIFTYATMCE', 'NFO:NIFTYATMPE'],
+    )
+    return manager
+
+
+def test_spot_stale_but_trading_feed_healthy() -> None:
+    manager = _build_manager()
+    _seed_tick(manager, 'NSE:NIFTY', age_seconds=9.0)
+    _seed_tick(manager, 'NFO:NIFTYFUT', age_seconds=0.5)
+    _seed_tick(manager, 'NFO:NIFTYATMCE', age_seconds=0.5)
+    _seed_tick(manager, 'NFO:NIFTYATMPE', age_seconds=0.5)
+
+    health = manager.trading_feed_health(max_age_ms=5_000)
+
+    assert health['spot_fresh'] is False
+    assert health['futures_fresh'] is True
+    assert health['options_fresh'] is True
+    assert health['trading_feed_healthy'] is True
+
+
+def test_futures_stale_marks_trading_feed_unhealthy() -> None:
+    manager = _build_manager()
+    _seed_tick(manager, 'NSE:NIFTY', age_seconds=0.5)
+    _seed_tick(manager, 'NFO:NIFTYFUT', age_seconds=9.0)
+    _seed_tick(manager, 'NFO:NIFTYATMCE', age_seconds=0.5)
+    _seed_tick(manager, 'NFO:NIFTYATMPE', age_seconds=0.5)
+
+    health = manager.trading_feed_health(max_age_ms=5_000)
+
+    assert health['futures_fresh'] is False
+    assert health['trading_feed_healthy'] is False
+
+
+def test_options_stale_marks_trading_feed_unhealthy() -> None:
+    manager = _build_manager()
+    _seed_tick(manager, 'NSE:NIFTY', age_seconds=0.5)
+    _seed_tick(manager, 'NFO:NIFTYFUT', age_seconds=0.5)
+    _seed_tick(manager, 'NFO:NIFTYATMCE', age_seconds=9.0)
+    _seed_tick(manager, 'NFO:NIFTYATMPE', age_seconds=0.5)
+
+    health = manager.trading_feed_health(max_age_ms=5_000)
+
+    assert health['options_fresh'] is False
+    assert health['trading_feed_healthy'] is False
+
+
+def test_spot_stale_only_does_not_flip_trading_feed_health() -> None:
+    manager = _build_manager()
+    _seed_tick(manager, 'NSE:NIFTY', age_seconds=7.0)
+    _seed_tick(manager, 'NFO:NIFTYFUT', age_seconds=0.2)
+    _seed_tick(manager, 'NFO:NIFTYATMCE', age_seconds=0.2)
+    _seed_tick(manager, 'NFO:NIFTYATMPE', age_seconds=0.2)
+
+    assert manager.trading_feed_health(max_age_ms=5_000)['trading_feed_healthy'] is True

--- a/tests/streaming/test_stream_supervisor_fallback.py
+++ b/tests/streaming/test_stream_supervisor_fallback.py
@@ -1,0 +1,61 @@
+from nifty_scalper_bot.core.app import _polling_fallback_degraded
+
+
+def test_spot_stale_only_does_not_activate_poll_fallback() -> None:
+    assert (
+        _polling_fallback_degraded(
+            ws_ok=True,
+            lagging=False,
+            futures_fresh=True,
+            options_fresh=True,
+        )
+        is False
+    )
+
+
+def test_futures_stale_activates_poll_fallback() -> None:
+    assert (
+        _polling_fallback_degraded(
+            ws_ok=True,
+            lagging=False,
+            futures_fresh=False,
+            options_fresh=True,
+        )
+        is True
+    )
+
+
+def test_options_stale_activates_poll_fallback() -> None:
+    assert (
+        _polling_fallback_degraded(
+            ws_ok=True,
+            lagging=False,
+            futures_fresh=True,
+            options_fresh=False,
+        )
+        is True
+    )
+
+
+def test_ws_disconnected_activates_poll_fallback() -> None:
+    assert (
+        _polling_fallback_degraded(
+            ws_ok=False,
+            lagging=False,
+            futures_fresh=True,
+            options_fresh=True,
+        )
+        is True
+    )
+
+
+def test_lagging_event_loop_activates_poll_fallback() -> None:
+    assert (
+        _polling_fallback_degraded(
+            ws_ok=True,
+            lagging=True,
+            futures_fresh=True,
+            options_fresh=True,
+        )
+        is True
+    )

--- a/tests/streaming/test_websocket_spot_symbol_freshness.py
+++ b/tests/streaming/test_websocket_spot_symbol_freshness.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import time
+
+from nifty_scalper_bot.data.market_data_manager import MarketDataManager
+
+
+class DummyBroker:
+    def get_quote(self, _symbol: str) -> dict[str, float]:
+        return {'ltp': 0.0}
+
+
+class DummyWebSocket:
+    on_tick = None
+
+
+def test_spot_token_updates_canonical_nse_nifty_freshness() -> None:
+    manager = MarketDataManager(DummyBroker(), DummyWebSocket())
+    before = manager.symbol_data_age_ms('NSE:NIFTY')
+
+    manager._process_queued_tick(
+        {
+            'instrument_token': 256265,
+            'last_price': 22500.0,
+            'timestamp': time.time(),
+        }
+    )
+
+    after = manager.symbol_data_age_ms('NSE:NIFTY')
+    assert after < before
+    assert manager.get_latest_tick('NSE:NIFTY') is not None
+
+
+def test_spot_alias_resolves_to_same_canonical_symbol_age() -> None:
+    manager = MarketDataManager(DummyBroker(), DummyWebSocket())
+    manager._process_queued_tick(
+        {
+            'instrument_token': 256265,
+            'last_price': 22510.0,
+            'timestamp': time.time(),
+        }
+    )
+
+    canonical_age = manager.symbol_data_age_ms('NSE:NIFTY')
+    alias_age = manager.symbol_data_age_ms('nifty')
+
+    assert alias_age >= 0
+    assert abs(canonical_age - alias_age) < 100

--- a/tests/test_startup_readiness.py
+++ b/tests/test_startup_readiness.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from nifty_scalper_bot.data.market_data_manager import MarketDataManager
+
+
+class DummyBroker:
+    def get_quote(self, _symbol: str) -> dict[str, float]:
+        return {'ltp': 0.0}
+
+
+class DummyWebSocket:
+    on_tick = None
+
+
+def _manager() -> MarketDataManager:
+    manager = MarketDataManager(DummyBroker(), DummyWebSocket())
+    manager.set_readiness_requirements(
+        spot_symbol='NSE:NIFTY',
+        futures_symbol='NFO:NIFTYFUT',
+        atm_ce_symbol='NFO:NIFTYATMCE',
+        atm_pe_symbol='NFO:NIFTYATMPE',
+        option_symbols=['NFO:NIFTYATMCE', 'NFO:NIFTYATMPE'],
+    )
+    return manager
+
+
+def test_hard_ready_with_missing_spot_is_allowed_as_degraded_spot() -> None:
+    manager = _manager()
+    bars = {
+        'NFO:NIFTYFUT': 120,
+        'NFO:NIFTYATMCE': 120,
+        'NFO:NIFTYATMPE': 120,
+        'NSE:NIFTY': 0,
+    }
+
+    readiness = manager._readiness_state(
+        bars, min_bars=50, requirements=manager._readiness_requirements
+    )
+
+    assert readiness['hard_ready'] is True
+    assert readiness['spot_ready'] is False
+    assert readiness['missing_hard'] == []
+
+
+def test_timeout_with_hard_requirements_met_reports_degraded_readiness() -> None:
+    manager = _manager()
+    manager._last_readiness_state = {
+        'hard_ready': True,
+        'spot_ready': False,
+        'missing_hard': [],
+    }
+
+    snapshot = manager.readiness_state_snapshot()
+
+    assert snapshot['hard_ready'] is True
+    assert snapshot['spot_ready'] is False
+
+
+def test_timeout_without_hard_requirements_reports_incomplete() -> None:
+    manager = _manager()
+    bars = {
+        'NFO:NIFTYFUT': 10,
+        'NFO:NIFTYATMCE': 120,
+        'NFO:NIFTYATMPE': 5,
+        'NSE:NIFTY': 120,
+    }
+
+    readiness = manager._readiness_state(
+        bars, min_bars=50, requirements=manager._readiness_requirements
+    )
+
+    assert readiness['hard_ready'] is False
+    assert 'futures' in readiness['missing_hard']
+    assert 'atm_pe' in readiness['missing_hard']


### PR DESCRIPTION
### Motivation
- Stale `NSE:NIFTY` spot was over-weighted in health/readiness/fallback logic and repeatedly triggered a global polling fallback despite healthy futures/options feeds. 
- Align market-data control with trading design where futures + active options are the hard trading gate and spot is advisory only. 

### Description
- MarketDataManager: added a compact hard-vs-soft readiness model with `_readiness_state(...)`, `readiness_state_snapshot()`, `trading_feed_health(...)`, and `ensure_spot_reference_fresh(...)`, and adjusted `wait_until_ready()` to treat spot as advisory and futures/options as hard requirements (`src/nifty_scalper_bot/data/market_data_manager.py`).
- Polling supervisor: replaced spot-only fallback triggers with a trading-critical decision that activates polling fallback only when WS is down, event-loop lag is high, futures are stale, or active options are stale, and logs/skips fallback for spot-only staleness while attempting a spot REST refresh (`src/nifty_scalper_bot/core/app.py`).
- Startup pipeline: improved readiness logging and semantics to emit `startup_pipeline_ready`, `startup_pipeline_ready_degraded`, or `startup_pipeline_incomplete` based on hard vs soft readiness (`src/nifty_scalper_bot/core/app.py`).
- Operator UI: added a concise feed-health line to Telegram `/status` that distinguishes `futures/options` (hard) vs `spot` (soft) freshness (`src/nifty_scalper_bot/notifications/telegram_controller.py`).
- Tests: added focused unit tests validating health semantics, fallback decision rules, readiness classification, and canonical spot freshness propagation (new tests under `tests/`).

### Testing
- Ran the targeted test suite with `pytest -q tests/data/test_market_data_health.py tests/streaming/test_stream_supervisor_fallback.py tests/test_startup_readiness.py tests/streaming/test_websocket_spot_symbol_freshness.py` and all tests passed (14 dots / 100% in the run). 
- Executed `bash ./run_checks.sh`; it installs deps and runs lint/mypy/pytest; this run surfaced pre-existing repository-wide `ruff`/`mypy`/coverage argument issues unrelated to this patch and therefore `run_checks.sh` did not fully succeed in this environment. 
- Verified relevant grep checks for new events/helpers: `spot_quote_stale_soft_warning`, `spot_rest_refresh_attempt`, `poll_fallback_skipped_spot_only_stale`, `_polling_fallback_degraded`, `startup_pipeline_ready_degraded`, and `trading_feed_health` are present in the modified files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9ad8e89bc8324a09ba81509aa9618)