### PR TITLE
fix: defer DataHub startup subscriptions until post-universe activation

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -6073,6 +6073,22 @@ async def startup_sequence(ctx: BotContext) -> None:
             if not subscribed_symbols:
                 LOGGER.critical("⛔ STRATEGY SUBSCRIPTION LIST IS EMPTY")
 
+            deferred_flush_count = 0
+            if ctx.data_hub is not None and hasattr(
+                ctx.data_hub, "flush_pending_live_subscriptions"
+            ):
+                deferred_flush_count = int(
+                    ctx.data_hub.flush_pending_live_subscriptions()
+                )
+                LOGGER.info(
+                    "startup_deferred_listener_subscriptions_flushed count=%d",
+                    deferred_flush_count,
+                    extra={
+                        "event": "startup_deferred_listener_subscriptions_flushed",
+                        "count": deferred_flush_count,
+                    },
+                )
+
             if tokens_to_poll:
                 if mdm is not None:
                     seeded = mdm.request_token_subscriptions(tokens_to_poll)

--- a/src/nifty_scalper_bot/data/data_hub.py
+++ b/src/nifty_scalper_bot/data/data_hub.py
@@ -130,6 +130,10 @@ class DataHub:
         self._tick_subscribers: Dict[str, set[TickListener]] = defaultdict(set)
         self._order_subscribers: list[OrderListener] = []
         self._mdm_subscribed_symbols: set[str] = set()
+        self._defer_live_symbol_subscriptions = bool(
+            kwargs.get("defer_live_symbol_subscriptions", True)
+        )
+        self._pending_live_symbols: set[str] = set()
 
         self._last_ts: Dict[str, float] = {}
         self._last_arrival: Dict[str, float] = {}
@@ -650,6 +654,32 @@ class DataHub:
         if callable(mdm_sub):
             mdm_sub(symbol, self.ingest_tick_sync)
             self._mdm_subscribed_symbols.add(symbol)
+            LOGGER.info(
+                "datahub_live_symbol_subscribed symbol=%s",
+                symbol,
+                extra={"event": "datahub_live_symbol_subscribed", "symbol": symbol},
+            )
+
+    def flush_pending_live_subscriptions(self) -> int:
+        """Activate deferred live subscriptions. Args: none. Returns: flush count. Raises: none."""
+        pending_symbols = sorted(self._pending_live_symbols)
+        self._defer_live_symbol_subscriptions = False
+        if not pending_symbols:
+            LOGGER.info(
+                "datahub_live_symbol_flush count=0",
+                extra={"event": "datahub_live_symbol_flush", "count": 0},
+            )
+            return 0
+
+        LOGGER.info(
+            "datahub_live_symbol_flush count=%d",
+            len(pending_symbols),
+            extra={"event": "datahub_live_symbol_flush", "count": len(pending_symbols)},
+        )
+        for symbol in pending_symbols:
+            self._subscribe_symbol(symbol)
+        self._pending_live_symbols.clear()
+        return len(pending_symbols)
 
     def subscribe_ticks(self, symbol: str, callback: Optional[TickListener] = None):
         normalized = self._canonical_quote_symbol(symbol)
@@ -657,7 +687,18 @@ class DataHub:
             return
         if callback is not None:
             self._tick_subscribers[normalized].add(callback)
-        self._subscribe_symbol(normalized)
+        if self._defer_live_symbol_subscriptions:
+            self._pending_live_symbols.add(normalized)
+            LOGGER.info(
+                "datahub_symbol_registered_deferred symbol=%s",
+                normalized,
+                extra={
+                    "event": "datahub_symbol_registered_deferred",
+                    "symbol": normalized,
+                },
+            )
+        else:
+            self._subscribe_symbol(normalized)
         if callback is not None:
             quote = self.get_quote(normalized, allow_pull=True)
             if quote is not None:
@@ -676,6 +717,7 @@ class DataHub:
         if callback is not None and callback in self._tick_subscribers.get(normalized, set()):
             self._tick_subscribers[normalized].remove(callback)
         if not self._tick_subscribers.get(normalized):
+            self._pending_live_symbols.discard(normalized)
             self._mdm_subscribed_symbols.discard(normalized)
             mdm_unsub = getattr(self._mdm, "unsubscribe", None)
             if callable(mdm_unsub):

--- a/tests/core/test_app_startup_subscription_order.py
+++ b/tests/core/test_app_startup_subscription_order.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import inspect
+
+from nifty_scalper_bot.core import app as core_app
+
+
+def test_no_early_live_subscription_for_regime_and_risk_listeners() -> None:
+    source = inspect.getsource(core_app)
+
+    regime_idx = source.index('data_hub.subscribe_ticks(regime_symbol, callback)')
+    risk_idx = source.index(
+        'data_hub.subscribe_ticks(risk_symbol, _risk_state_tick_listener)'
+    )
+    flush_idx = source.index('ctx.data_hub.flush_pending_live_subscriptions()')
+    request_idx = source.index('mdm.request_token_subscriptions(tokens_to_poll)')
+
+    assert regime_idx < flush_idx
+    assert risk_idx < flush_idx
+    assert flush_idx < request_idx
+
+
+def test_flush_happens_after_universe_building_milestones() -> None:
+    source = inspect.getsource(core_app)
+
+    options_store_idx = source.index(
+        'ctx.options_store = OptionsContractStore(ctx.instrument_manager)'
+    )
+    basket_idx = source.index('_build_canonical_active_basket(')
+    flush_idx = source.index('ctx.data_hub.flush_pending_live_subscriptions()')
+
+    assert options_store_idx < flush_idx
+    assert basket_idx < flush_idx

--- a/tests/data/test_data_hub_deferred_subscriptions.py
+++ b/tests/data/test_data_hub_deferred_subscriptions.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from nifty_scalper_bot.data.data_hub import DataHub
+
+
+class _StubMdm:
+    def __init__(self) -> None:
+        self.subscribed: list[str] = []
+        self.callbacks: dict[str, list[Callable[[dict[str, Any]], None]]] = {}
+
+    def subscribe(
+        self, symbol: str, callback: Callable[[dict[str, Any]], None]
+    ) -> None:
+        self.subscribed.append(symbol)
+        self.callbacks.setdefault(symbol, []).append(callback)
+
+
+def test_subscribe_ticks_deferred_registers_without_live_subscribe() -> None:
+    mdm = _StubMdm()
+    hub = DataHub(market_data_manager=mdm)
+
+    def callback(_tick: dict[str, Any]) -> None:
+        return None
+
+    hub.subscribe_ticks('NSE:NIFTY', callback)
+
+    assert mdm.subscribed == []
+    assert 'NSE:NIFTY' in hub._pending_live_symbols  # noqa: SLF001
+    assert callback in hub._tick_subscribers['NSE:NIFTY']  # noqa: SLF001
+
+
+def test_flush_pending_live_subscriptions_subscribes_unique_symbols_once() -> None:
+    mdm = _StubMdm()
+    hub = DataHub(market_data_manager=mdm)
+
+    hub.subscribe_ticks('NSE:NIFTY', lambda _tick: None)
+    hub.subscribe_ticks('NSE:NIFTY', lambda _tick: None)
+    hub.subscribe_ticks('NFO:NIFTY26APR25500CE', lambda _tick: None)
+
+    flushed = hub.flush_pending_live_subscriptions()
+
+    assert flushed == 2
+    assert mdm.subscribed == ['NFO:NIFTY26APR25500CE', 'NSE:NIFTY']
+    assert hub._pending_live_symbols == set()  # noqa: SLF001
+
+
+def test_duplicate_listeners_same_symbol_keep_fanout_with_single_live_subscribe(
+) -> None:
+    mdm = _StubMdm()
+    hub = DataHub(market_data_manager=mdm)
+    received_one: list[dict[str, Any]] = []
+    received_two: list[dict[str, Any]] = []
+
+    hub.subscribe_ticks('NSE:NIFTY', lambda tick: received_one.append(tick))
+    hub.subscribe_ticks('NSE:NIFTY', lambda tick: received_two.append(tick))
+    hub.flush_pending_live_subscriptions()
+    live_callback = mdm.callbacks['NSE:NIFTY'][0]
+    live_callback({'symbol': 'NSE:NIFTY', 'ltp': 123.0, 'timestamp': 1})
+
+    assert mdm.subscribed == ['NSE:NIFTY']
+    assert len(received_one) == 1
+    assert len(received_two) == 1

--- a/tests/test_initialize_components_subscriptions.py
+++ b/tests/test_initialize_components_subscriptions.py
@@ -31,6 +31,18 @@ def test_startup_tracking_is_deferred_without_immediate_subscription() -> None:
     assert 'mdm.ensure_tracking(' in source
 
 
+def test_startup_listener_subscriptions_flush_after_universe_prep() -> None:
+    source = inspect.getsource(core_app)
+
+    assert 'data_hub.subscribe_ticks(regime_symbol, callback)' in source
+    assert 'data_hub.subscribe_ticks(risk_symbol, _risk_state_tick_listener)' in source
+    assert 'ctx.data_hub.flush_pending_live_subscriptions()' in source
+
+    flush_idx = source.index('ctx.data_hub.flush_pending_live_subscriptions()')
+    token_idx = source.index('mdm.request_token_subscriptions(tokens_to_poll)')
+    assert flush_idx < token_idx
+
+
 def test_market_data_manager_supports_optional_subscription_during_tracking() -> None:
     source = Path(
         'src/nifty_scalper_bot/data/market_data_manager.py'

--- a/tests/test_production_hardening_guards.py
+++ b/tests/test_production_hardening_guards.py
@@ -32,6 +32,7 @@ def test_data_hub_subscribe_deduplicates() -> None:
     hub.subscribe_ticks("NSE:NIFTY", lambda _: None)
     hub.subscribe_ticks("NSE:NIFTY", lambda _: None)
     hub.subscribe_ticks("256265", lambda _: None)
+    hub.flush_pending_live_subscriptions()
 
     assert mdm.calls == ["NSE:NIFTY"]
 


### PR DESCRIPTION
### Motivation
- Early listener registration (regime/risk) caused `DataHub.subscribe_ticks()` to trigger immediate MDM live subscriptions (notably `NSE:NIFTY`) before the universe/hydration completed.  
- The intent is to keep listener fanout active during startup while preventing transport-level subscriptions until the app explicitly activates the full live basket.  
- This change is surgical: preserve `MarketDataManager` ownership while making `DataHub` queue live subscription intent until an explicit flush point in startup.

### Description
- Added a deferred-subscription gate in `DataHub` with fields `self._defer_live_symbol_subscriptions` and `self._pending_live_symbols`, and changed `subscribe_ticks()` to register callbacks immediately but queue symbols when defer is active.  
- Implemented `DataHub.flush_pending_live_subscriptions()` that clears the defer flag, subscribes each pending symbol once via the existing `_subscribe_symbol()` (which continues to call MDM), and logs flush/subscription events.  
- Flushed pending `DataHub` subscriptions from `startup_sequence` in `core/app.py` at the universe-ready milestone immediately before `mdm.request_token_subscriptions(tokens_to_poll)` to ensure live subscriptions occur only after instrument resolution and hydration.  
- Added and updated tests to validate deferred registration, deduplication, single live subscribe on flush, and startup ordering (`tests/data/test_data_hub_deferred_subscriptions.py`, `tests/core/test_app_startup_subscription_order.py`, and related updates to existing tests).

### Testing
- Ran targeted pytest suites: `pytest -q tests/data/test_data_hub_deferred_subscriptions.py tests/test_initialize_components_subscriptions.py tests/core/test_app_startup_subscription_order.py tests/test_production_hardening_guards.py` and `pytest -q tests/data/test_data_hub.py tests/test_production_hardening_guards.py tests/data/test_data_hub_deferred_subscriptions.py tests/test_initialize_components_subscriptions.py tests/core/test_app_startup_subscription_order.py`; both runs completed successfully (all tests passed).  
- Verified unit test assertions that regime/risk `subscribe_ticks()` calls occur before `ctx.data_hub.flush_pending_live_subscriptions()` and that flush happens before `mdm.request_token_subscriptions(tokens_to_poll)`.  
- Ran `./run_checks.sh`, which created the virtualenv and installed dependencies but terminated early because `pytest` was not found in the created venv (dependency environment bootstrap succeeded up to package installation); tests were still executed directly and passed as noted above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9ff1344dc83249ad3681d9793a852)