### PR TITLE
fix: unblock runner path and add structured decision tracing

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -141,6 +141,9 @@ def _gate_runner_symbol_add(
     ctx: Any,
     symbol: str,
     pending_runner_symbols: set[str],
+    *,
+    token: int | None = None,
+    source: str = "startup",
 ) -> bool:
     """Gate StrategyRunner add by bar readiness. Args: ctx/symbol/pending. Returns: added flag. Raises: none."""
 
@@ -148,24 +151,35 @@ def _gate_runner_symbol_add(
         return False
     bars = len(ctx.market_data_manager.get_ohlc_bars(symbol) or [])
     required = _symbol_history_requirement(ctx)
-    if bars >= required:
-        ctx.strategy_runner.add_symbol(symbol)
+    history_ready = bars >= required
+    ctx.strategy_runner.add_symbol(symbol)
+    if history_ready:
         pending_runner_symbols.discard(symbol)
-        return True
-    pending_runner_symbols.add(symbol)
+    else:
+        pending_runner_symbols.add(symbol)
     LOGGER.info(
-        "symbol_add_deferred_waiting_for_history symbol=%s bars=%d required=%d",
+        "RUNNER_SYMBOL_STATUS symbol=%s token=%s added_to_runner=%s bars=%d required_bars=%d history_ready=%s source=%s reason=%s",
         symbol,
+        token,
+        True,
         bars,
         required,
+        history_ready,
+        source,
+        "history_ready" if history_ready else "history_pending_runner_added",
         extra={
-            "event": "symbol_add_deferred_waiting_for_history",
+            "event": "RUNNER_SYMBOL_STATUS",
             "symbol": symbol,
+            "token": token,
+            "added_to_runner": True,
             "bars": bars,
-            "required": required,
+            "required_bars": required,
+            "history_ready": history_ready,
+            "source": source,
+            "reason": "history_ready" if history_ready else "history_pending_runner_added",
         },
     )
-    return False
+    return True
 
 
 from urllib.parse import urlsplit
@@ -6033,7 +6047,13 @@ async def startup_sequence(ctx: BotContext) -> None:
                     active_symbol_tokens[sym] = int(tok)
                     resolved_count += 1
                     LOGGER.info(f"✅ Resolved: {sym} -> token {tok}")
-                    _gate_runner_symbol_add(ctx, sym, pending_runner_symbols)
+                    _gate_runner_symbol_add(
+                        ctx,
+                        sym,
+                        pending_runner_symbols,
+                        token=int(tok),
+                        source="startup",
+                    )
                 else:
                     unresolved_symbols.append(sym)
                     LOGGER.warning(
@@ -6250,15 +6270,26 @@ async def startup_sequence(ctx: BotContext) -> None:
                             for _psym in list(pending_runner_symbols):
                                 _bars = len(ctx.market_data_manager.get_ohlc_bars(_psym) or [])
                                 if _bars >= _symbol_history_requirement(ctx):
-                                    ctx.strategy_runner.add_symbol(_psym)
                                     LOGGER.info(
-                                        "symbol_add_deferred_ready symbol=%s bars=%d",
+                                        "RUNNER_SYMBOL_STATUS symbol=%s token=%s added_to_runner=%s bars=%d required_bars=%d history_ready=%s source=%s reason=%s",
                                         _psym,
+                                        active_symbol_tokens.get(_psym),
+                                        True,
                                         _bars,
+                                        _symbol_history_requirement(ctx),
+                                        True,
+                                        "dynamic_universe",
+                                        "history_now_ready",
                                         extra={
-                                            "event": "symbol_add_deferred_ready",
+                                            "event": "RUNNER_SYMBOL_STATUS",
                                             "symbol": _psym,
                                             "bars": _bars,
+                                            "token": active_symbol_tokens.get(_psym),
+                                            "added_to_runner": True,
+                                            "required_bars": _symbol_history_requirement(ctx),
+                                            "history_ready": True,
+                                            "source": "dynamic_universe",
+                                            "reason": "history_now_ready",
                                         },
                                     )
                                 else:
@@ -6333,6 +6364,8 @@ async def startup_sequence(ctx: BotContext) -> None:
                                 continue
                             if tok and ctx.market_data_manager:
                                 ctx.market_data_manager.register_symbol(sym, tok)
+                            if tok:
+                                active_symbol_tokens[sym] = int(tok)
                             if tok and ctx.market_data_manager is not None:
                                 ctx.market_data_manager.request_token_subscription(
                                     tok,
@@ -6393,7 +6426,13 @@ async def startup_sequence(ctx: BotContext) -> None:
                                     )
                             # Add to runner only after MDM holds enough bars.
                             # Defer if still under-hydrated; the loop retries.
-                            _gate_runner_symbol_add(ctx, sym, pending_runner_symbols)
+                            _gate_runner_symbol_add(
+                                ctx,
+                                sym,
+                                pending_runner_symbols,
+                                token=int(tok),
+                                source="dynamic_universe",
+                            )
 
                         for sym in drop_symbols:
                             tok = None

--- a/src/nifty_scalper_bot/core/strategy_manager.py
+++ b/src/nifty_scalper_bot/core/strategy_manager.py
@@ -1698,7 +1698,13 @@ class StrategyManager(_BaseStrategyManager):
                 extra={"event": "strategy_no_signal_summary_error", "symbol": symbol},
             )
 
-    def generate_signal(self, symbol: str, current_price: float) -> Signal | None:
+    def generate_signal(
+        self,
+        symbol: str,
+        current_price: float,
+        *,
+        trace_id: str | None = None,
+    ) -> Signal | None:
         """Generate signal with confidence adjusted by strategy scores.
 
         Args:
@@ -1721,9 +1727,40 @@ class StrategyManager(_BaseStrategyManager):
             "strategy_evaluation_start",
             extra={"event": "strategy_evaluation_start", "symbol": symbol},
         )
-        if self._data_hub is not None and not bool(
-            getattr(self._data_hub, "indicators_ready", False)
-        ):
+        no_signal_reasons: list[str] = []
+        error_strategies: list[str] = []
+        disabled_strategies_snapshot: list[str] = []
+        signal_action: str | None = None
+        signal_score: float | None = None
+        signal_confidence: float | None = None
+        exit_result = "no_signal"
+        indicators_ready = True
+        if self._data_hub is not None:
+            indicators_ready = bool(getattr(self._data_hub, "indicators_ready", False))
+        indicators_raw = self._indicator_engine.get_indicators(
+            symbol, self._required_indicators
+        )
+        indicators: dict[str, t.Any] = dict(indicators_raw)
+        vwap = indicators.get("vwap")
+        avg_volume = indicators.get("avg_volume")
+        required_missing = sorted(
+            name for name in self._required_indicators if indicators.get(name) is None
+        )
+        log.info(
+            "STRATEGY_MANAGER_ENTER",
+            extra={
+                "event": "STRATEGY_MANAGER_ENTER",
+                "symbol": symbol,
+                "trace_id": trace_id,
+                "indicators_ready": indicators_ready,
+                "vwap": vwap,
+                "avg_volume": avg_volume,
+                "required_indicators_missing": required_missing,
+                "active_strategies_count": len(self._strategies),
+            },
+        )
+        if not indicators_ready:
+            no_signal_reasons.append("global_indicators_not_ready_diagnostic_only")
             log_throttled(
                 log,
                 key=f"signal_blocked_indicators_not_ready:{symbol}",
@@ -1732,9 +1769,27 @@ class StrategyManager(_BaseStrategyManager):
                 extra={
                     "event": "signal_blocked_indicators_not_ready",
                     "symbol": symbol,
+                    "trace_id": trace_id,
                 },
             )
-            return None
+
+        def _emit_strategy_exit() -> None:
+            """Emit terminal strategy manager summary. Args: none. Returns: none. Raises: none."""
+            log.info(
+                "STRATEGY_MANAGER_EXIT",
+                extra={
+                    "event": "STRATEGY_MANAGER_EXIT",
+                    "symbol": symbol,
+                    "trace_id": trace_id,
+                    "result": exit_result,
+                    "signal_action": signal_action,
+                    "signal_score": signal_score,
+                    "signal_confidence": signal_confidence,
+                    "no_signal_reasons": no_signal_reasons,
+                    "disabled_strategies": disabled_strategies_snapshot,
+                    "error_strategies": error_strategies,
+                },
+            )
 
         def _log_reject(
             reason_code: str, context: dict[str, t.Any] | None = None
@@ -1834,6 +1889,8 @@ class StrategyManager(_BaseStrategyManager):
                         {"gate_reasons": reasons, "gate": "regime_manager"},
                     )
                     _emit_no_signal("regime_gate_block", {"gate_reasons": reasons})
+                    no_signal_reasons.append("regime_gate_block")
+                    _emit_strategy_exit()
                     return None
             except Exception as exc:  # noqa: BLE001
                 log.error(
@@ -1883,10 +1940,7 @@ class StrategyManager(_BaseStrategyManager):
             },
         )
         score_map = self._recompute_scores()
-        indicators_raw = self._indicator_engine.get_indicators(
-            symbol, self._required_indicators
-        )
-        indicators: dict[str, t.Any] = dict(indicators_raw)
+        indicators = dict(indicators)
         indicators["_regime_adjustments"] = adjustments
         self._augment_futures_metrics(indicators)
         # ✅ FIX S3: Inject exchange VWAP for options
@@ -1998,6 +2052,8 @@ class StrategyManager(_BaseStrategyManager):
                     },
                 )
                 _emit_no_signal("data_invalid", {"reason_code": invalid_reason})
+                no_signal_reasons.append("data_invalid")
+                _emit_strategy_exit()
                 return None
             log_throttled(
                 log,
@@ -2034,6 +2090,8 @@ class StrategyManager(_BaseStrategyManager):
                     "reason_code": self._symbol_temporarily_ineligible.get(symbol),
                 },
             )
+            no_signal_reasons.append("data_invalid")
+            _emit_strategy_exit()
             return None
         position = self._position_manager.get_position(symbol)
 
@@ -2041,6 +2099,7 @@ class StrategyManager(_BaseStrategyManager):
         disabled: list[str] = []
         empty: list[str] = []
         errors: list[str] = []
+        disabled_strategies_snapshot = disabled
         evaluation_start = time.monotonic()
         for strategy in self._strategies:
             if strategy.name in self._disabled_strategies:
@@ -2060,6 +2119,7 @@ class StrategyManager(_BaseStrategyManager):
                 )
             except Exception as exc:  # noqa: BLE001
                 errors.append(strategy.name)
+                error_strategies.append(strategy.name)
                 log.error(
                     "Failure in strategy generate for %s: %s",
                     strategy.name,
@@ -2137,10 +2197,17 @@ class StrategyManager(_BaseStrategyManager):
                     "no_signal_strategies": empty[:8],
                 },
             )
+            no_signal_reasons.append("no_strategy_signal")
+            _emit_strategy_exit()
             return None
 
         combined = self._combine_signals(signals)
         if combined and bool(getattr(combined, "metadata", {}).get("is_approved")):
+            exit_result = "signal"
+            signal_action = combined.action
+            signal_score = float(combined.quantity)
+            signal_confidence = float(combined.confidence)
+            _emit_strategy_exit()
             return combined
         if combined and self._filter_signal(combined):
             orchestrator = self._orchestrator
@@ -2188,6 +2255,11 @@ class StrategyManager(_BaseStrategyManager):
                     float(dict(combined.metadata).get("kelly_fraction", 0.0))
                 )
                 self._emit_metrics_snapshot()
+                exit_result = "signal"
+                signal_action = combined.action
+                signal_score = float(combined.quantity)
+                signal_confidence = float(combined.confidence)
+                _emit_strategy_exit()
                 return combined
         elif combined is None:
             log_throttled(
@@ -2211,6 +2283,7 @@ class StrategyManager(_BaseStrategyManager):
                 },
             )
             _emit_no_signal("data_invalid", {"stage": "combine"})
+            no_signal_reasons.append("combine_none")
         else:
             log_throttled(
                 log,
@@ -2244,6 +2317,8 @@ class StrategyManager(_BaseStrategyManager):
                     "confidence": combined.confidence,
                 },
             )
+            no_signal_reasons.append("filtered_signal")
+        _emit_strategy_exit()
         return None
 
     def _emit_metrics_snapshot(self) -> None:

--- a/src/nifty_scalper_bot/execution/order_manager.py
+++ b/src/nifty_scalper_bot/execution/order_manager.py
@@ -1680,6 +1680,7 @@ class OrderManager:
         take_profit: float | None = None,
         signal_id: str | None = None,
         strategy_name: str = "manual",
+        trace_id: str | None = None,
     ) -> str | None:
         """
         Execute order with Idempotency, Safe Trading Window, Risk Gating, and Auto-Recovery.
@@ -1689,6 +1690,33 @@ class OrderManager:
             "TRADE_ATTEMPT symbol=%s side=%s qty=%s price=%s sl=%s tp=%s strategy=%s signal_id=%s",
             symbol, side, quantity, price, stop_loss, take_profit, strategy_name, signal_id,
         )
+        if trace_id:
+            self._last_trace_id = trace_id
+
+        def _log_order_decision(
+            *,
+            allowed: bool,
+            block_reason: str | None = None,
+            order_id: str | None = None,
+        ) -> None:
+            """Emit unified decision logs for order placement. Args: fields. Returns: None. Raises: None."""
+            self._logger.info(
+                "ORDER_MANAGER_DECISION",
+                extra={
+                    "event": "ORDER_MANAGER_DECISION",
+                    "symbol": symbol,
+                    "side": side,
+                    "allowed": allowed,
+                    "block_reason": block_reason,
+                    "signal_id": signal_id,
+                    "strategy_name": strategy_name,
+                    "price": price,
+                    "stop_loss": stop_loss,
+                    "take_profit": take_profit,
+                    "order_id": order_id,
+                    "trace_id": trace_id,
+                },
+            )
         # ✅ FIX: Round Price/Trigger to 0.05 tick size BEFORE processing
         # ═══════════════════════════════════════════════════════════════════════
         if price is not None and price > 0:
@@ -1711,6 +1739,7 @@ class OrderManager:
         ):
             if not self._validate_live_execution_safety():
                 self._logger.critical("ORDER_BLOCKED: live_execution_safety_check_failed symbol=%s", symbol)
+                _log_order_decision(allowed=False, block_reason="live_execution_safety_check_failed")
                 return None
 
         # 🛡️ CIRCUIT BREAKER CHECK — skipped for system exits
@@ -1726,6 +1755,7 @@ class OrderManager:
                     "Trading Halted to prevent API ban / account blowup."
                 )
                 self._logger.critical("ORDER_BLOCKED: kill_switch_engaged consecutive_failures=%s symbol=%s", self._consecutive_failures, symbol)
+                _log_order_decision(allowed=False, block_reason="kill_switch_engaged")
                 return None
         # 🛡️ SAFETY GUARD: ENFORCE VIRTUAL BRACKETS
         is_entry = (side == "BUY") and not is_system_exit
@@ -1744,12 +1774,14 @@ class OrderManager:
             )
             if has_open_local and has_pending_entry:
                 self._logger.critical("ORDER_BLOCKED: duplicate_entry_prevented symbol=%s side=%s", symbol, side)
+                _log_order_decision(allowed=False, block_reason="duplicate_entry_prevented")
                 return None
             if not self._signal_arbitrator.allow(symbol, side):
                 self._logger.critical(
                     "ORDER_BLOCKED: signal_arbitrator_blocked symbol=%s side=%s",
                     symbol, side,
                 )
+                _log_order_decision(allowed=False, block_reason="signal_arbitrator_blocked")
                 return None
 
         # 3. THE INVARIANT CHECK
@@ -1762,6 +1794,7 @@ class OrderManager:
                     f"\nData: Qty={quantity}, SL={stop_loss}, Tag={tag}"
                 )
                 self._logger.critical("ORDER_BLOCKED: naked_entry_no_stop_loss symbol=%s qty=%s", symbol, quantity)
+                _log_order_decision(allowed=False, block_reason="naked_entry_no_stop_loss")
                 return None  # ❌ STOP HERE. DO NOT CALL BROKER.
 
         # =========================================================
@@ -1822,6 +1855,7 @@ class OrderManager:
                     extra={"event": "duplicate_block", "symbol": normalized_symbol},
                 )
                 self._logger.critical("ORDER_BLOCKED: fresh_pending_order_exists symbol=%s", normalized_symbol)
+                _log_order_decision(allowed=False, block_reason="fresh_pending_order_exists")
                 return None
             elif pending_orders and is_system_exit:
                 self._logger.warning(
@@ -1848,6 +1882,7 @@ class OrderManager:
                 meta={"signal_id": signal_id},
             )
             self._logger.critical("ORDER_BLOCKED: duplicate_signal signal_id=%s symbol=%s", signal_id, normalized_symbol)
+            _log_order_decision(allowed=False, block_reason="duplicate_signal")
             return None
 
         # --- SEMANTIC VALIDATION GATEKEEPER ---
@@ -1859,12 +1894,14 @@ class OrderManager:
                         f"🛑 REJECTED: BUY TP ({take_profit}) is below entry ({price})"
                     )
                     self._logger.critical("ORDER_BLOCKED: buy_tp_below_entry symbol=%s tp=%s entry=%s", normalized_symbol, take_profit, price)
+                    _log_order_decision(allowed=False, block_reason="buy_tp_below_entry")
                     return None
                 if stop_loss and stop_loss >= price:
                     self._logger.error(
                         f"🛑 REJECTED: BUY SL ({stop_loss}) is above entry ({price})"
                     )
                     self._logger.critical("ORDER_BLOCKED: buy_sl_above_entry symbol=%s sl=%s entry=%s", normalized_symbol, stop_loss, price)
+                    _log_order_decision(allowed=False, block_reason="buy_sl_above_entry")
                     return None
             elif side == "SELL":
                 # For a Short/Exit, TP must be below Entry, SL must be above Entry
@@ -1873,12 +1910,14 @@ class OrderManager:
                         f"🛑 REJECTED: SELL TP ({take_profit}) is above entry ({price})"
                     )
                     self._logger.critical("ORDER_BLOCKED: sell_tp_above_entry symbol=%s tp=%s entry=%s", normalized_symbol, take_profit, price)
+                    _log_order_decision(allowed=False, block_reason="sell_tp_above_entry")
                     return None
                 if stop_loss and stop_loss <= price:
                     self._logger.error(
                         f"🛑 REJECTED: SELL SL ({stop_loss}) is below entry ({price})"
                     )
                     self._logger.critical("ORDER_BLOCKED: sell_sl_below_entry symbol=%s sl=%s entry=%s", normalized_symbol, stop_loss, price)
+                    _log_order_decision(allowed=False, block_reason="sell_sl_below_entry")
                     return None
 
         # ---------------------------------------------------------------------
@@ -1908,6 +1947,7 @@ class OrderManager:
                         },
                     )
                     self._logger.critical("ORDER_BLOCKED: time_guard reason=%s symbol=%s time=%s", reason, normalized_symbol, now.strftime("%H:%M:%S"))
+                    _log_order_decision(allowed=False, block_reason="time_guard_block")
                     return None
             except Exception as e:
                 self._logger.error(
@@ -1933,6 +1973,7 @@ class OrderManager:
                     extra={"symbol": normalized_symbol},
                 )
                 self._logger.critical("ORDER_BLOCKED: trading_switch_off symbol=%s", normalized_symbol)
+                _log_order_decision(allowed=False, block_reason="trading_switch_off")
                 return None
 
         # ---------------------------------------------------------------------
@@ -1962,6 +2003,7 @@ class OrderManager:
                     extra={"symbol": normalized_symbol, "event": "risk_block"},
                 )
                 self._logger.critical("ORDER_BLOCKED: risk_manager_blocked reason=%s symbol=%s", reason, normalized_symbol)
+                _log_order_decision(allowed=False, block_reason="risk_manager_blocked")
                 return None
 
         # ---------------------------------------------------------------------
@@ -2323,6 +2365,10 @@ class OrderManager:
 
                     if not is_system_exit:
                         self._signal_arbitrator.register(normalized_symbol, side)
+                    _log_order_decision(
+                        allowed=True,
+                        order_id=order_id,
+                    )
                     return order_id
 
             except Exception as e:
@@ -2353,12 +2399,14 @@ class OrderManager:
                         price=float(price or 0.0),
                         meta={"trade_id": trade_id, "error": str(e)},
                     )
+                    _log_order_decision(allowed=False, block_reason="fatal_order_error")
                     return None
 
                 self._logger.warning(f"⚠️ Retry {attempt}/3 failed: {e}")
                 time.sleep(0.5 * attempt)
 
         self._logger.error("❌ Order placement failed after retries.")
+        _log_order_decision(allowed=False, block_reason="order_placement_failed_after_retries")
         return None
 
     def place_managed_order(

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -246,6 +246,7 @@ class OrderRouter(Protocol):
         price: float | None = None,
         stop_loss: float | None = None,
         take_profit: float | None = None,
+        trace_id: str | None = None,
     ) -> str: ...
 
     def place_reduce_only_exit(self, intent: ExitIntent) -> str | None: ...
@@ -499,6 +500,15 @@ class StrategyRunner:
         ).strip().lower() in {"1", "true", "yes", "on"}
         # Time block logging throttle
         self._time_block_logged: Dict[str, float] = {}
+        self._allow_eval_without_new_bar = (
+            os.getenv("RUNNER_ALLOW_EVAL_WITHOUT_NEW_BAR", "false").strip().lower()
+            in {"1", "true", "yes", "on"}
+        )
+        self._same_bar_eval_interval_seconds = max(
+            1.0,
+            float(os.getenv("RUNNER_EVAL_WITHOUT_NEW_BAR_SECONDS", "15")),
+        )
+        self._last_same_bar_eval_ts: dict[str, float] = {}
 
         if self._message_bus is None:
             raise RuntimeError("MessageBus not injected into StrategyRunner")
@@ -774,7 +784,7 @@ class StrategyRunner:
             if signal:
                 from datetime import datetime, timezone
                 now = datetime.now(timezone.utc)
-                self._handle_signal(signal, price, now)
+                self._handle_signal(signal, price, now, trace_id=trace_id)
 
             print(f"STRATEGY TRIGGERED: {token}")
         except Exception as e:
@@ -3339,6 +3349,7 @@ class StrategyRunner:
             normalized_symbol = enforce_canonical(normalize_symbol(str(symbol)))
             if normalized_symbol.count(":") != 1:
                 raise RuntimeError(f"Malformed canonical symbol: {normalized_symbol}")
+            trace_id = f"{normalized_symbol}-{time_module.monotonic_ns()}"
             self._last_tick_time_by_symbol[normalized_symbol] = time.time()
             engine = self._candle_engines.setdefault(normalized_symbol, CandleEngine())
             with self._symbol_locks[normalized_symbol]:
@@ -3401,6 +3412,18 @@ class StrategyRunner:
                 "STRATEGY_RECEIVED_TICK",
                 extra={"event": "strategy_received_tick", "symbol": normalized_symbol},
             )
+            self._logger.info(
+                "RUNNER_TICK_ACCEPTED symbol=%s trace_id=%s tick_price=%s",
+                normalized_symbol,
+                trace_id,
+                tick.get("last_price") or tick.get("ltp"),
+                extra={
+                    "event": "RUNNER_TICK_ACCEPTED",
+                    "symbol": normalized_symbol,
+                    "trace_id": trace_id,
+                    "tick_price": tick.get("last_price") or tick.get("ltp"),
+                },
+            )
             
             # 🚨 FIX: Legacy ensure_valid_data() block completely removed.
             # We no longer pause live tick processing to attempt blocking historical 
@@ -3429,7 +3452,7 @@ class StrategyRunner:
                 )
                 self._last_eval_queue_log_ts = now_queue_log
             try:
-                self._on_tick(normalized_symbol, tick)
+                self._on_tick(normalized_symbol, {**dict(tick), "trace_id": trace_id})
             finally:
                 with self._eval_queue_lock:
                     self._eval_queue_depth = max(0, self._eval_queue_depth - 1)
@@ -4196,6 +4219,7 @@ class StrategyRunner:
             # =================================================================
 
             now = datetime.now(timezone.utc)
+            trace_id = str(tick.get("trace_id") or f"{symbol}-{time_module.monotonic_ns()}")
 
             # Helper: Extract timestamp for freshness check
             def _extract_timestamp(t, fallback):
@@ -4419,11 +4443,16 @@ class StrategyRunner:
                 log_throttled(
                     self._logger,
                     "market_closed_global",
-                    "Condition met: market_closed",
+                    "Condition met: market_closed_diagnostic_only",
                     interval_sec=300.0,
                     level=logging.INFO,
+                    extra={
+                        "event": "RUNNER_MARKET_HOURS_DIAGNOSTIC",
+                        "symbol": symbol,
+                        "trace_id": trace_id,
+                        "reason": "market_closed_no_runner_block",
+                    },
                 )
-                skip_strategy = True
 
             # 🚨 RELAXED LATENCY GUARD: Polling APIs have natural latency.
             # We allow ticks up to 5 seconds old to ensure strategies evaluate.
@@ -4470,12 +4499,21 @@ class StrategyRunner:
             # =================================================================
 
             # Log successful tick acceptance (throttled)
-            log_throttled(
-                self._logger,
-                f"tick_accepted_{symbol}",
-                f"✅ TICK ACCEPTED: {symbol} | LTP={price:.2f} | Age={tick_age:.1f}s | Vol={volume}",
-                interval_sec=60.0,
-                level=logging.DEBUG,
+            self._logger.info(
+                "RUNNER_TICK_ACCEPTED symbol=%s trace_id=%s tick_price=%.2f tick_age_s=%.3f volume=%s",
+                symbol,
+                trace_id,
+                price,
+                tick_age,
+                volume,
+                extra={
+                    "event": "RUNNER_TICK_ACCEPTED",
+                    "symbol": symbol,
+                    "trace_id": trace_id,
+                    "tick_price": price,
+                    "tick_age_s": tick_age,
+                    "volume": volume,
+                },
             )
 
             # Grace period warmup logging
@@ -4505,6 +4543,23 @@ class StrategyRunner:
                 completed_bar = builder.update(float(price), volume, timestamp)
                 if completed_bar is not None:
                     self._ingest_bar(symbol, completed_bar)
+                candle_count = len(self._indicator_engine.get_history(symbol) or [])
+                self._logger.info(
+                    "RUNNER_BAR_STATE symbol=%s trace_id=%s candle_count=%d required_candles=%d completed_bar=%s",
+                    symbol,
+                    trace_id,
+                    candle_count,
+                    self._required_candles,
+                    completed_bar is not None,
+                    extra={
+                        "event": "RUNNER_BAR_STATE",
+                        "symbol": symbol,
+                        "trace_id": trace_id,
+                        "candle_count": candle_count,
+                        "required_candles": self._required_candles,
+                        "completed_bar": completed_bar is not None,
+                    },
+                )
                 # NOTE: Do NOT return here when completed_bar is None.
                 # The position manager (PHASE 5) must receive every tick to
                 # track unrealised P&L and update stop-loss levels in real time.
@@ -4820,9 +4875,64 @@ class StrategyRunner:
             signal = generated_signal
             current_version = int(self._candle_versions.get(symbol, 0))
             last_version = int(self._last_strategy_versions.get(symbol, 0))
-            
+            candle_count = len(self._indicator_engine.get_history(symbol) or [])
             if current_version <= last_version:
-                return
+                now_eval_ts = time_module.time()
+                last_same_bar_eval = float(self._last_same_bar_eval_ts.get(symbol, 0.0))
+                if (
+                    self._allow_eval_without_new_bar
+                    and now_eval_ts - last_same_bar_eval
+                    >= self._same_bar_eval_interval_seconds
+                ):
+                    self._last_same_bar_eval_ts[symbol] = now_eval_ts
+                    self._logger.info(
+                        "RUNNER_PHASE9_DECISION",
+                        extra={
+                            "event": "RUNNER_PHASE9_DECISION",
+                            "symbol": symbol,
+                            "trace_id": trace_id,
+                            "allowed": True,
+                            "reason": "same_bar_periodic_eval",
+                            "current_version": current_version,
+                            "last_version": last_version,
+                            "candle_count": candle_count,
+                            "required_candles": self._required_candles,
+                            "tick_price": price,
+                        },
+                    )
+                else:
+                    self._logger.info(
+                        "RUNNER_PHASE9_DECISION",
+                        extra={
+                            "event": "RUNNER_PHASE9_DECISION",
+                            "symbol": symbol,
+                            "trace_id": trace_id,
+                            "allowed": False,
+                            "reason": "same_bar_version",
+                            "current_version": current_version,
+                            "last_version": last_version,
+                            "candle_count": candle_count,
+                            "required_candles": self._required_candles,
+                            "tick_price": price,
+                        },
+                    )
+                    return
+            else:
+                self._logger.info(
+                    "RUNNER_PHASE9_DECISION",
+                    extra={
+                        "event": "RUNNER_PHASE9_DECISION",
+                        "symbol": symbol,
+                        "trace_id": trace_id,
+                        "allowed": True,
+                        "reason": "new_bar_version",
+                        "current_version": current_version,
+                        "last_version": last_version,
+                        "candle_count": candle_count,
+                        "required_candles": self._required_candles,
+                        "tick_price": price,
+                    },
+                )
             upper_symbol = symbol.upper()
             is_index_symbol = (
                 upper_symbol.startswith("NSE:")
@@ -5042,7 +5152,9 @@ class StrategyRunner:
                                 return
 
                             signal = self._strategy_manager.generate_signal(
-                                symbol, price
+                                symbol,
+                                price,
+                                trace_id=trace_id,
                             )
                             self._logger.info(
                                 "STRATEGY_EVALUATED",
@@ -5362,7 +5474,14 @@ class StrategyRunner:
                 exc_info=exc,
             )
 
-    def _handle_signal(self, signal: Signal, price: float, timestamp: datetime) -> None:
+    def _handle_signal(
+        self,
+        signal: Signal,
+        price: float,
+        timestamp: datetime,
+        *,
+        trace_id: str | None = None,
+    ) -> None:
         """
         Handle signal execution with comprehensive error handling.
 
@@ -5373,24 +5492,30 @@ class StrategyRunner:
         # ═══════════════════════════════════════════════════════════
 
         exchange_open = is_market_hours_cached()
-        allow_signal_generation = True
-        allow_execution = bool(exchange_open)
-        if allow_signal_generation and not allow_execution:
-            cache_key = f"time_block_{signal.symbol}"
-            if not hasattr(self, "_time_block_logged"):
-                self._time_block_logged = {}
-            now = timestamp.timestamp()
-            last_logged = self._time_block_logged.get(cache_key, 0)
-            if now - last_logged > 60:
-                self._logger.info(
-                    "Condition met: after_market_signal_allowed_execution_blocked",
-                    extra={
-                        "event": "after_market_signal_allowed_execution_blocked",
-                        "symbol": signal.symbol,
-                    },
-                )
-                self._time_block_logged[cache_key] = now
-            return
+        if not bool(exchange_open):
+            self._logger.info(
+                "RUNNER_SIGNAL_DECISION",
+                extra={
+                    "event": "RUNNER_SIGNAL_DECISION",
+                    "symbol": signal.symbol,
+                    "action": signal.action,
+                    "proceed_to_order": True,
+                    "reason": "outside_market_hours_runner_forwarding",
+                    "trace_id": trace_id,
+                },
+            )
+        else:
+            self._logger.info(
+                "RUNNER_SIGNAL_DECISION",
+                extra={
+                    "event": "RUNNER_SIGNAL_DECISION",
+                    "symbol": signal.symbol,
+                    "action": signal.action,
+                    "proceed_to_order": True,
+                    "reason": "market_hours_open",
+                    "trace_id": trace_id,
+                },
+            )
         # ═══════════════════════════════════════════════════════════
 
         self._logger.info(
@@ -5409,7 +5534,12 @@ class StrategyRunner:
 
             if action in {"BUY", "SELL"}:
                 self._handle_entry_signal(
-                    signal, base_symbol, trade_symbol, trade_price, timestamp
+                    signal,
+                    base_symbol,
+                    trade_symbol,
+                    trade_price,
+                    timestamp,
+                    trace_id=trace_id,
                 )
 
             elif action in {"CLOSE_LONG", "CLOSE_SHORT"}:
@@ -5628,6 +5758,16 @@ class StrategyRunner:
         """
         # 1. GUARD: Check if Strike Selector component exists
         if self._strike_selector is None:
+            self._logger.info(
+                "RUNNER_SIGNAL_DECISION",
+                extra={
+                    "event": "RUNNER_SIGNAL_DECISION",
+                    "symbol": base_symbol,
+                    "action": action,
+                    "proceed_to_order": False,
+                    "reason": "strike_selector_none",
+                },
+            )
             log_throttled(
                 self._logger,
                 "strike_selector_none",
@@ -5643,6 +5783,16 @@ class StrategyRunner:
             if hasattr(
                 self._data_hub, "has_chain_data"
             ) and not self._data_hub.has_chain_data(base_symbol):
+                self._logger.info(
+                    "RUNNER_SIGNAL_DECISION",
+                    extra={
+                        "event": "RUNNER_SIGNAL_DECISION",
+                        "symbol": base_symbol,
+                        "action": action,
+                        "proceed_to_order": False,
+                        "reason": "missing_chain_data",
+                    },
+                )
                 log_throttled(
                     self._logger,
                     f"missing_chain_{base_symbol}",
@@ -5670,6 +5820,16 @@ class StrategyRunner:
             )
 
             if not selection:
+                self._logger.info(
+                    "RUNNER_SIGNAL_DECISION",
+                    extra={
+                        "event": "RUNNER_SIGNAL_DECISION",
+                        "symbol": base_symbol,
+                        "action": action,
+                        "proceed_to_order": False,
+                        "reason": "strike_selection_none",
+                    },
+                )
                 self._logger.warning(
                     f"⚠️ Strike Selector returned None for {base_symbol} {action} @ {price}"
                 )
@@ -5678,6 +5838,16 @@ class StrategyRunner:
             return selection
 
         except Exception as e:
+            self._logger.info(
+                "RUNNER_SIGNAL_DECISION",
+                extra={
+                    "event": "RUNNER_SIGNAL_DECISION",
+                    "symbol": base_symbol,
+                    "action": action,
+                    "proceed_to_order": False,
+                    "reason": "strike_selection_exception",
+                },
+            )
             self._logger.error(
                 f"💥 EXCEPTION in strike selection for {base_symbol}: {e}",
                 exc_info=True,
@@ -5714,6 +5884,8 @@ class StrategyRunner:
         trade_symbol: str,
         trade_price: float,
         timestamp: datetime,
+        *,
+        trace_id: str | None = None,
     ) -> None:
         """
         Handle entry signal execution with comprehensive safeguards.
@@ -5741,7 +5913,12 @@ class StrategyRunner:
 
         try:
             self._handle_entry_signal_inner(
-                signal, base_symbol, trade_symbol, trade_price, timestamp
+                signal,
+                base_symbol,
+                trade_symbol,
+                trade_price,
+                timestamp,
+                trace_id=trace_id,
             )
         finally:
             self._entry_lock.release()
@@ -5753,6 +5930,8 @@ class StrategyRunner:
         trade_symbol: str,
         trade_price: float,
         timestamp: datetime,
+        *,
+        trace_id: str | None = None,
     ) -> None:
         """Direct order_manager entry path — no ExecutionEngine middleman.
 
@@ -5833,6 +6012,7 @@ class StrategyRunner:
                 signal_id=signal.deterministic_id,
                 strategy_name=strategy_name,
                 tag=f"runner_{signal.action.lower()}",
+                trace_id=trace_id,
             )
 
             if order_id:


### PR DESCRIPTION
### Motivation
- Remove upstream hard blockers so ticks flow: runner membership, market-hours, and global indicator blackouts prevented upstream evaluation and visibility.  The only hard stop must remain the order layer. 
- Make every path decision observable from logs with a lightweight `trace_id` so operators can determine exactly why a symbol did or did not reach order placement.

### Description
- `core/app.py`: Always add token-resolved symbols to the `StrategyRunner` immediately; preserve hydration state only as metadata and emit structured `RUNNER_SYMBOL_STATUS` logs with `symbol`, `token`, `added_to_runner`, `bars`, `required_bars`, `history_ready`, `source`, and `reason` (startup/dynamic flows).
- `strategies/runner.py`: Propagate a simple `trace_id` per evaluation; add structured INFO checkpoints `RUNNER_TICK_ACCEPTED`, `RUNNER_BAR_STATE`, and `RUNNER_PHASE9_DECISION`; replace silent same-bar `current_version <= last_version` behavior with explicit `RUNNER_PHASE9_DECISION` logging and a conservative env switch `RUNNER_ALLOW_EVAL_WITHOUT_NEW_BAR` plus `RUNNER_EVAL_WITHOUT_NEW_BAR_SECONDS` to allow periodic same-bar evals when enabled; remove market-hours checks as hard blockers and emit `RUNNER_MARKET_HOURS_DIAGNOSTIC` and `RUNNER_SIGNAL_DECISION` instead; keep strike-selection guards but emit explicit reasons `strike_selector_none`, `missing_chain_data`, `strike_selection_none`, and `strike_selection_exception`.
- `core/strategy_manager.py`: Treat global `indicators_ready` as a soft diagnostic gate rather than an immediate `return`; add `STRATEGY_MANAGER_ENTER` (with `indicators_ready`, `vwap`, `avg_volume`, `required_indicators_missing`, `active_strategies_count`) and a terminal `STRATEGY_MANAGER_EXIT` summary (with `result`, `signal_action`, `signal_score`, `signal_confidence`, `no_signal_reasons`, `disabled_strategies`, `error_strategies`); accept and propagate `trace_id` through evaluation calls.
- `execution/order_manager.py`: Keep the order manager as the only hard blocker and preserve all safety checks (time guard, trading switch, risk manager, duplicate/pending, naked-entry SL requirement, semantic SL/TP validation); add `trace_id` parameter propagation and a unified structured `ORDER_MANAGER_DECISION` log emitted before each hard return (blocked=false with `block_reason`) and on successful submission (`allowed=true` and `order_id`).
- End-to-end: `trace_id` flows from runner tick → phase9 decision → `StrategyManager.generate_signal` → `_handle_signal` → `OrderManager.place_order` and appears in diagnostic logs at each stage; no new dependencies introduced and strategy logic otherwise preserved.

### Testing
- Compiled edited modules with `python -m py_compile` for `core/app.py`, `strategies/runner.py`, `core/strategy_manager.py`, and `execution/order_manager.py` — compilation succeeded. ✅
- Ran `ruff check` target files; the repo has an existing lint baseline and the run surfaced pre-existing findings (many long lines / unused imports) unrelated to the intent of this change; targeted edits focused on behavior and logging (Ruff reported baseline issues). ⚠️
- Executed `./run_checks.sh` (via `bash ./run_checks.sh`) in this environment; the script began (installed venv and packages) but reported toolchain/tool availability limits in this session (`Ruff/mypy/pytest` not available in the run as executed here), so full CI-style checks and `pytest` were not completed in this environment. ⚠️
- Per verification, grepped for prior blocker strings and confirmed behavior changes: `symbol_add_deferred_waiting_for_history` no longer blocks runner admission, `signal_blocked_indicators_not_ready` remains diagnostic-only, `current_version <= last_version` now emits `RUNNER_PHASE9_DECISION`, `after_market_signal_allowed_execution_blocked` is no longer a hard stop, and `ORDER_BLOCKED:` checks remain in `OrderManager` with new `ORDER_MANAGER_DECISION` logs. ✅

If you want, I can (a) run a tighter local `ruff --fix` / `mypy` pass for just the edited files, (b) add small unit tests for `StrategyManager` enter/exit logging or `OrderManager` decision logging, or (c) produce a short example log trace demonstrating the new `trace_id`-propagated events.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea3043476c8324a1983e2b03fe9b8e)