### PR TITLE
Fix live trading readiness, option indicator quality, and runner diagnostics

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -2524,6 +2524,40 @@ def _data_ready(mdm: MarketDataManager | None) -> bool:
     return True
 
 
+def _compute_indicator_readiness(ctx: BotContext) -> bool:
+    """Compute indicator readiness from runner/indicator histories."""
+    runner = getattr(ctx, "strategy_runner", None)
+    indicator_engine = getattr(ctx, "indicator_engine", None)
+    if runner is None or indicator_engine is None:
+        return False
+    required = int(getattr(runner, "_required_candles", 20) or 20)
+    active_symbols = list(getattr(runner, "_active_symbols", set()) or [])
+    tradeable_symbols = [
+        symbol
+        for symbol in active_symbols
+        if str(symbol).upper().startswith("NFO:")
+        and str(symbol).upper().endswith(("CE", "PE"))
+    ]
+    if not tradeable_symbols:
+        return False
+    for symbol in tradeable_symbols:
+        try:
+            if hasattr(indicator_engine, "has_min_bars") and indicator_engine.has_min_bars(
+                symbol, required
+            ):
+                return True
+            history = (
+                indicator_engine.get_history(symbol)
+                if hasattr(indicator_engine, "get_history")
+                else []
+            )
+            if history is not None and len(history) >= required:
+                return True
+        except Exception:
+            continue
+    return False
+
+
 def _build_canonical_active_basket(
     *,
     instrument_manager: InstrumentManager | None,
@@ -7154,7 +7188,7 @@ async def startup_sequence(ctx: BotContext) -> None:
                             hard_ready = bool(readiness_state.get("hard_ready"))
                             spot_ready = bool(readiness_state.get("spot_ready"))
                             missing_hard = list(readiness_state.get("missing_hard") or [])
-                            indicators_ready_for_trading = hard_ready
+                            indicators_ready_for_trading = _compute_indicator_readiness(ctx)
                             if ctx.market_regime_manager is not None:
                                 ctx.market_regime_manager.indicators_ready = (
                                     indicators_ready_for_trading
@@ -7163,6 +7197,14 @@ async def startup_sequence(ctx: BotContext) -> None:
                                 ctx.data_hub.indicators_ready = (
                                     indicators_ready_for_trading
                                 )
+                            LOGGER.info(
+                                "INDICATOR_READINESS_SYNC ready=%s",
+                                indicators_ready_for_trading,
+                                extra={
+                                    "event": "INDICATOR_READINESS_SYNC",
+                                    "ready": indicators_ready_for_trading,
+                                },
+                            )
                             ws_connected = bool(
                                 ctx.websocket_manager.is_connected()
                                 if ctx.websocket_manager is not None
@@ -7223,6 +7265,16 @@ async def startup_sequence(ctx: BotContext) -> None:
                     atr_prov = ctx.indicator_engine.atr_provider
                     if hasattr(atr_prov, "mark_warmed_up"):
                         atr_prov.mark_warmed_up()
+                indicator_ready = _compute_indicator_readiness(ctx)
+                if ctx.data_hub is not None:
+                    ctx.data_hub.indicators_ready = indicator_ready
+                if ctx.market_regime_manager is not None:
+                    ctx.market_regime_manager.indicators_ready = indicator_ready
+                LOGGER.info(
+                    "INDICATOR_READINESS_SYNC ready=%s",
+                    indicator_ready,
+                    extra={"event": "INDICATOR_READINESS_SYNC", "ready": indicator_ready},
+                )
 
                 ctx.subsystems_started = True
                 LOGGER.info("✅ All subsystems started.")

--- a/src/nifty_scalper_bot/core/strategy_manager.py
+++ b/src/nifty_scalper_bot/core/strategy_manager.py
@@ -1734,9 +1734,12 @@ class StrategyManager(_BaseStrategyManager):
         signal_score: float | None = None
         signal_confidence: float | None = None
         exit_result = "no_signal"
-        indicators_ready = True
+        required_bars = int(getattr(self, "_required_candles", 20) or 20)
+        bars_available = len(self._indicator_engine.get_history(symbol) or [])
+        indicators_ready = bars_available >= required_bars
+        hub_ready = None
         if self._data_hub is not None:
-            indicators_ready = bool(getattr(self._data_hub, "indicators_ready", False))
+            hub_ready = bool(getattr(self._data_hub, "indicators_ready", False))
         indicators_raw = self._indicator_engine.get_indicators(
             symbol, self._required_indicators
         )
@@ -1753,6 +1756,9 @@ class StrategyManager(_BaseStrategyManager):
                 "symbol": symbol,
                 "trace_id": trace_id,
                 "indicators_ready": indicators_ready,
+                "bars_available": bars_available,
+                "required_bars": required_bars,
+                "hub_indicators_ready": hub_ready,
                 "vwap": vwap,
                 "avg_volume": avg_volume,
                 "required_indicators_missing": required_missing,
@@ -1763,13 +1769,16 @@ class StrategyManager(_BaseStrategyManager):
             no_signal_reasons.append("global_indicators_not_ready_diagnostic_only")
             log_throttled(
                 log,
-                key=f"signal_blocked_indicators_not_ready:{symbol}",
-                msg="signal_blocked_indicators_not_ready",
-                interval_sec=30.0,
+                key=f"indicators_not_ready_diagnostic:{symbol}",
+                msg="indicators_not_ready_diagnostic",
+                interval_sec=120.0,
+                level=10,
                 extra={
-                    "event": "signal_blocked_indicators_not_ready",
+                    "event": "indicators_not_ready_diagnostic",
                     "symbol": symbol,
                     "trace_id": trace_id,
+                    "bars": bars_available,
+                    "required": required_bars,
                 },
             )
 

--- a/src/nifty_scalper_bot/strategies/elite_strategies/vwap_pro.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/vwap_pro.py
@@ -31,7 +31,7 @@ class VWAPProStrategy(EliteStrategy):
     MIN_BARS_REQUIRED = 10
     COOLDOWN_SECONDS = 20  # ✅ Scalping fix: shorter directional cooldown for rapid continuation legs
     VWAP_ACCEPTANCE_BARS = 1  # ✅ FIX #5: Reduced from 2 → 1; index bias gate is already a strong 2-condition filter
-    TELEMETRY_LOG_EVERY = 5
+    TELEMETRY_LOG_EVERY = 50
     VOLUME_GRACE_SECONDS = 900.0  # ✅ FIX C: Extended from 120s → 900s (15 min). NFO options tick ≈once/13min between batches; 120s grace expired before next tick arrived → volume_below_threshold on every call.
 
     __slots__ = (
@@ -49,6 +49,10 @@ class VWAPProStrategy(EliteStrategy):
         "_index_bias_missing_logged",  # ✅ FIX #5b: Was missing from __slots__ but set in __init__ and read in _evaluate_signal
         "_last_valid_index_vwap",
         "_bias_failover_logged_bar",
+        "_cfg_allow_vwap_pullback",
+        "_cfg_vwap_slack_atr_mult",
+        "_cfg_max_vwap_distance_pct",
+        "_cfg_telemetry_log_every",
     )
 
     def __init__(
@@ -108,6 +112,18 @@ class VWAPProStrategy(EliteStrategy):
             )
         except ValueError:
             self._cfg_expiry_weekday = WEEKLY_EXPIRY_WEEKDAY
+        self._cfg_allow_vwap_pullback = str(
+            os.getenv("VWAP_ALLOW_PULLBACK_ENTRY", "1")
+        ).strip().lower() in {"1", "true", "yes", "on"}
+        self._cfg_vwap_slack_atr_mult = float(
+            os.getenv("VWAP_SLACK_ATR_MULT", "1.5")
+        )
+        self._cfg_max_vwap_distance_pct = float(
+            os.getenv("VWAP_MAX_OPTION_DISTANCE_PCT", "0.18")
+        )
+        self._cfg_telemetry_log_every = max(
+            1, int(os.getenv("VWAP_TELEMETRY_LOG_EVERY", "50") or 50)
+        )
 
     # ------------------------------------------------------------------ #
     # Helpers
@@ -318,14 +334,14 @@ class VWAPProStrategy(EliteStrategy):
             # ✅ FIX B6: Periodic telemetry dump
             self._telemetry["evaluations"] += 1
             _evals = self._telemetry["evaluations"]
-            if _evals == 1 or _evals % self.TELEMETRY_LOG_EVERY == 0:
+            if _evals == 1 or _evals % self._cfg_telemetry_log_every == 0:
                 dominant_reject_reason = None
                 if self._reject_reason_counts:
                     dominant_reject_reason = max(
                         self._reject_reason_counts.items(),
                         key=lambda item: item[1],
                     )[0]
-                LOGGER.info(
+                LOGGER.debug(
                     f"📊 VWAPPro TELEMETRY [{symbol}]: evals={_evals} "
                     f"signals={self._telemetry['signals']} "
                     f"cool={self._telemetry['skipped_cooldown']} "
@@ -539,7 +555,7 @@ class VWAPProStrategy(EliteStrategy):
                 self._telemetry["skipped_bias"] += 1
                 if (
                     self._telemetry["skipped_bias"] <= 3
-                    or self._telemetry["skipped_bias"] % self.TELEMETRY_LOG_EVERY == 0
+                    or self._telemetry["skipped_bias"] % self._cfg_telemetry_log_every == 0
                 ):
                     LOGGER.info(
                         f"🧭 BIAS GATE: {symbol} {direction} blocked | "
@@ -594,7 +610,7 @@ class VWAPProStrategy(EliteStrategy):
                     self._telemetry["skipped_data"] += 1
                     if (
                         self._telemetry["skipped_data"] <= 5
-                        or self._telemetry["skipped_data"] % self.TELEMETRY_LOG_EVERY
+                        or self._telemetry["skipped_data"] % self._cfg_telemetry_log_every
                         == 0
                     ):
                         LOGGER.info(
@@ -636,7 +652,7 @@ class VWAPProStrategy(EliteStrategy):
                 self._telemetry["skipped_spread"] += 1
                 if (
                     self._telemetry["skipped_spread"] <= 3
-                    or self._telemetry["skipped_spread"] % self.TELEMETRY_LOG_EVERY == 0
+                    or self._telemetry["skipped_spread"] % self._cfg_telemetry_log_every == 0
                 ):
                     LOGGER.info(
                         f"💹 SPREAD REJECT: {symbol} | spread={_spread_pct:.1f}% > max={_max_spread:.0f}%",
@@ -666,12 +682,13 @@ class VWAPProStrategy(EliteStrategy):
             _option_vwap = float(
                 indicators.get("vwap") or indicators.get("exchange_vwap") or 0.0
             )
-            _vwap_slack = atr * 1.0
-            if _option_vwap > 0 and current_price < (_option_vwap - _vwap_slack):
+            _vwap_slack = atr * self._cfg_vwap_slack_atr_mult
+            price_below_vwap = _option_vwap > 0 and current_price < (_option_vwap - _vwap_slack)
+            if price_below_vwap and not self._cfg_allow_vwap_pullback:
                 self._telemetry["skipped_vwap"] += 1
                 if (
                     self._telemetry["skipped_vwap"] <= 3
-                    or self._telemetry["skipped_vwap"] % self.TELEMETRY_LOG_EVERY == 0
+                    or self._telemetry["skipped_vwap"] % self._cfg_telemetry_log_every == 0
                 ):
                     LOGGER.info(
                         f"📏 OPT VWAP: {symbol} {direction} | "
@@ -693,13 +710,16 @@ class VWAPProStrategy(EliteStrategy):
             distance = 0.0
             if _option_vwap > 0:
                 distance = abs(current_price - _option_vwap) / _option_vwap
-                if distance > 0.12:
+                if distance > self._cfg_max_vwap_distance_pct:
                     self._log_no_signal_reason(
                         "vwap_distance_extension",
                         symbol=symbol,
                         ltp=current_price,
                         vwap=_option_vwap,
-                        context={"distance": distance, "max_distance": 0.12},
+                        context={
+                            "distance": distance,
+                            "max_distance": self._cfg_max_vwap_distance_pct,
+                        },
                     )
                     self._reset_acceptance(
                         acc_key,
@@ -723,7 +743,9 @@ class VWAPProStrategy(EliteStrategy):
                 or indicators.get("orb_breakout")
             )
             soft_flag = False
-            if not pullback_ok or not momentum_confirmation:
+            if not pullback_ok or not momentum_confirmation or (
+                price_below_vwap and self._cfg_allow_vwap_pullback
+            ):
                 soft_flag = True
                 self._log_no_signal_reason(
                     "vwap_pullback_soft_flag",
@@ -736,7 +758,7 @@ class VWAPProStrategy(EliteStrategy):
                         "breakout_detected": breakout_detected,
                     },
                 )
-                if not breakout_detected:
+                if not breakout_detected and (not self._cfg_allow_vwap_pullback or not price_below_vwap):
                     _emit_no_signal("vwap_pullback_not_confirmed")
                     return None
 
@@ -821,7 +843,7 @@ class VWAPProStrategy(EliteStrategy):
                     self._telemetry["skipped_data"] += 1
                     if (
                         self._telemetry["skipped_data"] <= 5
-                        or self._telemetry["skipped_data"] % self.TELEMETRY_LOG_EVERY
+                        or self._telemetry["skipped_data"] % self._cfg_telemetry_log_every
                         == 0
                     ):
                         LOGGER.warning(
@@ -858,7 +880,7 @@ class VWAPProStrategy(EliteStrategy):
                 self._telemetry["skipped_volume"] += 1
                 if (
                     self._telemetry["skipped_volume"] <= 5
-                    or self._telemetry["skipped_volume"] % self.TELEMETRY_LOG_EVERY == 0
+                    or self._telemetry["skipped_volume"] % self._cfg_telemetry_log_every == 0
                 ):
                     LOGGER.info(
                         f"🔊 VOL GATE: {symbol} | vol={vol:.0f} < avg={avg_vol:.0f}×{vol_thresh}={avg_vol*vol_thresh:.0f}",

--- a/src/nifty_scalper_bot/strategies/indicators.py
+++ b/src/nifty_scalper_bot/strategies/indicators.py
@@ -522,6 +522,18 @@ class IndicatorEngine:
                 return cached  # type: ignore[return-value]
             prices = history.get_closes(effective_period)
             volumes = history.get_volumes(effective_period)
+            provisional_flags = history.get_provisional_flags(effective_period)
+            if provisional_flags and len(provisional_flags) == len(volumes):
+                filtered_pairs = [
+                    (float(price), int(volume))
+                    for price, volume, provisional in zip(
+                        prices, volumes, provisional_flags, strict=False
+                    )
+                    if not bool(provisional)
+                ]
+                if filtered_pairs:
+                    prices = [pair[0] for pair in filtered_pairs]
+                    volumes = [pair[1] for pair in filtered_pairs]
 
             # Pre-check: skip calculation if all volumes are zero
             if not volumes or all(v == 0 for v in volumes):
@@ -966,16 +978,38 @@ class IndicatorEngine:
             return
 
         volumes = history.get_volumes()
+        provisional_flags = history.get_provisional_flags()
         if volumes:
-            last_volume = float(volumes[-1])
+            last_volume = (
+                float(volumes[-1]) if not provisional_flags or not provisional_flags[-1] else 0.0
+            )
             indicators["volume"] = last_volume
-            tail = volumes[-20:]
+            upper_symbol = str(symbol).upper()
+            is_option = upper_symbol.endswith("CE") or upper_symbol.endswith("PE")
+            zipped = list(zip(volumes, provisional_flags, strict=False)) if provisional_flags else [
+                (volume, False) for volume in volumes
+            ]
+            recent = zipped[-20:]
+            if is_option:
+                tail = [float(volume) for volume, provisional in recent if not provisional and float(volume) > 0.0]
+                if not tail:
+                    tail = [
+                        float(volume)
+                        for volume, provisional in zipped
+                        if not provisional and float(volume) > 0.0
+                    ][-20:]
+            else:
+                tail = [float(volume) for volume, provisional in recent if not provisional]
             if tail:
                 avg_volume = sum(float(v) for v in tail) / len(tail)
                 indicators["avg_volume"] = avg_volume
-                indicators["average_volume"] = avg_volume  # ✅ ADD ALIAS
+                indicators["average_volume"] = avg_volume
                 if avg_volume > 0:
                     indicators["volume_spike_ratio"] = last_volume / avg_volume
+                else:
+                    indicators["volume_spike_ratio"] = 0.0
+            else:
+                indicators["volume_spike_ratio"] = 0.0
 
         timestamps = history.get_timestamps()
         highs = history.get_highs()

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -525,6 +525,22 @@ class StrategyRunner:
             1.0,
             float(os.getenv("RUNNER_COOLDOWN_LOG_THROTTLE_SECONDS", "60")),
         )
+        self._index_stale_tick_seconds = max(
+            1.0,
+            float(os.getenv("RUNNER_INDEX_STALE_TICK_SECONDS", "30")),
+        )
+        self._future_stale_tick_seconds = max(
+            1.0,
+            float(os.getenv("RUNNER_FUTURE_STALE_TICK_SECONDS", "120")),
+        )
+        self._option_stale_tick_seconds = max(
+            1.0,
+            float(os.getenv("RUNNER_OPTION_STALE_TICK_SECONDS", "900")),
+        )
+        self._generic_stale_tick_seconds = max(
+            1.0,
+            float(os.getenv("RUNNER_GENERIC_STALE_TICK_SECONDS", "60")),
+        )
         self._no_signal_log_throttle_seconds = max(
             1.0,
             float(os.getenv("RUNNER_NO_SIGNAL_LOG_THROTTLE_SECONDS", "300")),
@@ -2092,6 +2108,7 @@ class StrategyRunner:
             ts_utc = row_ts.astimezone(timezone.utc).replace(second=0, microsecond=0)
             cache_by_minute[ts_utc] = row
 
+        is_option_symbol = upper_symbol.endswith("CE") or upper_symbol.endswith("PE")
         prev_close = float(previous_bar.close)
         while expected < incoming_bar.timestamp:
             row = cache_by_minute.get(expected)
@@ -2107,7 +2124,7 @@ class StrategyRunner:
                     end=expected + timedelta(seconds=59),
                     synthetic=False,
                 )
-            else:
+            elif not is_option_symbol:
                 repaired_bar = OneMinuteBar(
                     open=prev_close,
                     high=prev_close,
@@ -2118,19 +2135,23 @@ class StrategyRunner:
                     end=expected + timedelta(seconds=59),
                     synthetic=True,
                 )
+            else:
+                expected += timedelta(minutes=1)
+                continue
             repaired.append(repaired_bar)
             prev_close = repaired_bar.close
             expected += timedelta(minutes=1)
 
         if repaired:
-            self._logger.warning(
-                "candle_gap_repaired",
-                extra={
-                    "event": "candle_gap_repaired",
-                    "symbol": symbol,
-                    "count": len(repaired),
-                },
-            )
+            if self._should_log_throttled(f"candle_gap_repaired:{symbol}", 300.0):
+                self._logger.info(
+                    "candle_gap_repaired",
+                    extra={
+                        "event": "candle_gap_repaired",
+                        "symbol": symbol,
+                        "count": len(repaired),
+                    },
+                )
             if (
                 self._main_loop
                 and self._main_loop.is_running()
@@ -2507,7 +2528,7 @@ class StrategyRunner:
                     volume=indicator_volume,
                     timestamp=bar.timestamp,
                     is_complete=True,
-                    is_provisional=False,
+                    is_provisional=bool(getattr(bar, "synthetic", False)),
                 )
 
             self._update_symbol_readiness(symbol)
@@ -2631,8 +2652,11 @@ class StrategyRunner:
             if self._data_phase.get(symbol) != "LIVE":
                 self._data_phase[symbol] = "LIVE"
                 self._live_bar_seen.add(symbol)
-                LOGGER.info("LIVE MODE ENABLED: %s", symbol)
-                self._logger.info("LIVE MODE ENABLED: %s", symbol)
+                self._logger.info(
+                    "LIVE_MODE_ENABLED symbol=%s",
+                    symbol,
+                    extra={"event": "LIVE_MODE_ENABLED", "symbol": symbol},
+                )
         except Exception as e:
             self._logger.error("Failure in StrategyRunner._mark_live: %s", e)
 
@@ -5074,7 +5098,7 @@ class StrategyRunner:
                 log_throttled(
                     self._logger,
                     "warmup_period",
-                    f"⏳ WARMUP: {15 - time_since_startup:.0f}s remaining before trading enabled",
+                    f"RUNNER_BOOT_GRACE: {15 - time_since_startup:.0f}s remaining before live evaluation allowed",
                     interval_sec=5.0,
                     level=logging.INFO,
                 )
@@ -5171,12 +5195,17 @@ class StrategyRunner:
                     )
 
             # =================================================================
-            # PHASE 6: RISK CHECK (Moved to ExecutionEngine)
+            # PHASE 6: Global readiness gate
             # =================================================================
-            # 🚨 ALL GATES REMOVED: Runner is permanently EXECUTION_ENABLED
-            self._runner_state = RunnerState.EXECUTION_ENABLED
-            self.ready = True
-            self._hydration_complete = True
+            if self._runner_state != RunnerState.EXECUTION_ENABLED:
+                self._emit_runner_eval_decision(
+                    symbol=symbol,
+                    stage="phase6",
+                    reason="runner_not_execution_enabled",
+                    allowed=False,
+                    trace_id=trace_id,
+                )
+                return
 
             # =================================================================
             # PHASE 7: STRATEGY PREPARATION
@@ -5795,36 +5824,60 @@ class StrategyRunner:
                         mdm_last_tick = getattr(
                             self._market_data, "_last_tick_time", {}
                         ).get(symbol)
-                        # ✅ FIX H: MDM stale-tick threshold for NFO options/futures
-                        # is raised to 900s.  Options legitimately have 13-min gaps
-                        # between ticks; the previous 30s threshold caused the MDM
-                        # check to fire on every single option evaluation, returning
-                        # before _last_global_eval_ts was updated → stall watchdog spam.
-                        _is_option = any(x in symbol for x in ("CE", "PE", "FUT"))
-                        _stale_thresh = 900.0 if _is_option else 10.0
+                        _stale_thresh = self._stale_tick_threshold_for_symbol(symbol)
                         if (
                             isinstance(mdm_last_tick, (int, float))
                             and time.time() - float(mdm_last_tick) > _stale_thresh
                         ):
                             _mdm_age = time.time() - float(mdm_last_tick)
-                            log_throttled(
-                                self._logger,
-                                f"stale_mdm_tick_{symbol}",
-                                f"⏰ Stale MDM tick — skipping: {symbol} "
-                                f"age={_mdm_age:.1f}s",
-                                interval_sec=300.0,
-                                level=logging.WARNING,
-                            )
-                            self._emit_runner_eval_decision(
-                                symbol=symbol,
-                                stage="phase9",
-                                reason="stale_mdm_tick",
-                                allowed=False,
-                                trace_id=trace_id,
-                                mdm_tick_age_s=_mdm_age,
-                                stale_tick_threshold_s=_stale_thresh,
-                            )
-                            return
+                            upper_symbol = symbol.upper()
+                            if upper_symbol in {"NSE:NIFTY", "NIFTY", "NSE:NIFTY 50", "NIFTY 50"}:
+                                fallback_ltp = None
+                                if self._market_data is not None and hasattr(self._market_data, "get_ltp"):
+                                    try:
+                                        fallback_ltp = self._market_data.get_ltp(symbol)
+                                    except Exception:
+                                        fallback_ltp = None
+                                log_throttled(
+                                    self._logger,
+                                    f"stale_mdm_tick_{symbol}",
+                                    f"Stale MDM tick for {symbol} age={_mdm_age:.1f}s; using fallback and continuing",
+                                    interval_sec=60.0,
+                                    level=logging.WARNING,
+                                )
+                                if fallback_ltp and fallback_ltp > 0:
+                                    self._logger.info(
+                                        "MDM_REST_FALLBACK_USED symbol=%s reason=stale_ws_tick",
+                                        symbol,
+                                        extra={"event": "MDM_REST_FALLBACK_USED", "symbol": symbol, "reason": "stale_ws_tick"},
+                                    )
+                                self._emit_runner_eval_decision(
+                                    symbol=symbol,
+                                    stage="phase9",
+                                    reason="stale_mdm_tick_index_fallback",
+                                    allowed=True,
+                                    trace_id=trace_id,
+                                    mdm_tick_age_s=_mdm_age,
+                                    stale_tick_threshold_s=_stale_thresh,
+                                )
+                            else:
+                                log_throttled(
+                                    self._logger,
+                                    f"stale_mdm_tick_{symbol}",
+                                    f"Stale MDM tick — skipping: {symbol} age={_mdm_age:.1f}s",
+                                    interval_sec=60.0,
+                                    level=logging.WARNING,
+                                )
+                                self._emit_runner_eval_decision(
+                                    symbol=symbol,
+                                    stage="phase9",
+                                    reason="stale_mdm_tick",
+                                    allowed=False,
+                                    trace_id=trace_id,
+                                    mdm_tick_age_s=_mdm_age,
+                                    stale_tick_threshold_s=_stale_thresh,
+                                )
+                                return
                         self._last_global_eval_ts = time.monotonic()
                         self._logger.debug(
                             "strategy_evaluation_start",
@@ -6741,6 +6794,7 @@ class StrategyRunner:
             now_epoch = time.time()
             underlying = self._extract_underlying(base_symbol) or base_symbol
             reason_key = str(signal.reason or "unknown")
+            underlying_reason_key = f"{underlying}:{reason_key}"
             if reason_key == "premium_momentum_squeeze":
                 upper_symbol = (trade_symbol or base_symbol).upper()
                 if ("CE" not in upper_symbol and "PE" not in upper_symbol) or "FUT" in upper_symbol:
@@ -6749,7 +6803,7 @@ class StrategyRunner:
                         f"premium_squeeze_skipped_{upper_symbol}",
                         "PREMIUM_SQUEEZE_SKIPPED",
                         interval_sec=self._cooldown_log_throttle_seconds,
-                        level=logging.INFO,
+                        level=logging.DEBUG,
                         extra={"event": "PREMIUM_SQUEEZE_SKIPPED", "symbol": trade_symbol or base_symbol, "reason": "non_option_instrument"},
                     )
                     return
@@ -6767,7 +6821,7 @@ class StrategyRunner:
             if now_epoch - float(self._underlying_last_signal_ts.get(underlying, 0.0)) < self._underlying_signal_cooldown_seconds:
                 log_throttled(self._logger, f"runner_underlying_cd_{underlying}", "RUNNER_SIGNAL_SUPPRESSED_EXECUTION_HALTED", interval_sec=self._cooldown_log_throttle_seconds, level=logging.INFO, extra={"event": "RUNNER_SIGNAL_SUPPRESSED_EXECUTION_HALTED", "symbol": base_symbol, "reason": "underlying_cooldown"})
                 return
-            if now_epoch - float(self._reason_last_signal_ts.get(reason_key, 0.0)) < self._reason_signal_cooldown_seconds:
+            if now_epoch - float(self._reason_last_signal_ts.get(underlying_reason_key, 0.0)) < self._reason_signal_cooldown_seconds:
                 log_throttled(self._logger, f"runner_reason_cd_{reason_key}", "RUNNER_SIGNAL_SUPPRESSED_EXECUTION_HALTED", interval_sec=self._cooldown_log_throttle_seconds, level=logging.INFO, extra={"event": "RUNNER_SIGNAL_SUPPRESSED_EXECUTION_HALTED", "symbol": base_symbol, "reason": "reason_cooldown"})
                 return
             while self._order_attempt_window and (now_epoch - self._order_attempt_window[0]) > 60.0:
@@ -6776,21 +6830,20 @@ class StrategyRunner:
                 log_throttled(self._logger, "runner_order_attempt_rate", "RUNNER_SIGNAL_SUPPRESSED_EXECUTION_HALTED", interval_sec=300.0, level=logging.INFO, extra={"event": "RUNNER_SIGNAL_SUPPRESSED_EXECUTION_HALTED", "symbol": base_symbol, "reason": "max_order_attempts_per_minute"})
                 return
 
-            input_qty = qty
             lot_size = 1
             final_qty = qty
             try:
+                qty_lots = max(int(signal.quantity or 1), 1)
                 if hasattr(self._order_manager, "resolve_lot_size"):
                     lot_size = int(self._order_manager.resolve_lot_size(trade_symbol or base_symbol))
-                qty_lots = max(int(signal.quantity or 1), 1)
                 final_qty = qty_lots * lot_size
                 self._logger.info(
                     "ORDER_QTY_NORMALIZED symbol=%s input_qty_lots=%s lot_size=%s final_qty=%s",
                     trade_symbol or base_symbol,
-                    input_qty,
+                    qty_lots,
                     lot_size,
                     final_qty,
-                    extra={"event": "ORDER_QTY_NORMALIZED", "symbol": trade_symbol or base_symbol, "input_qty_lots": input_qty, "lot_size": lot_size, "final_qty": final_qty},
+                    extra={"event": "ORDER_QTY_NORMALIZED", "symbol": trade_symbol or base_symbol, "input_qty_lots": qty_lots, "lot_size": lot_size, "final_qty": final_qty},
                 )
             except Exception as lot_exc:
                 self._logger.warning("ORDER_BLOCKED: invalid_lot_quantity symbol=%s error=%s", trade_symbol or base_symbol, lot_exc)
@@ -6852,7 +6905,7 @@ class StrategyRunner:
                     order_id, base_symbol, signal.action, qty,
                 )
                 self._underlying_last_signal_ts[underlying] = now_epoch
-                self._reason_last_signal_ts[reason_key] = now_epoch
+                self._reason_last_signal_ts[underlying_reason_key] = now_epoch
                 if reason_key == "premium_momentum_squeeze":
                     self._premium_squeeze_last_signal_ts[underlying] = now_epoch
                 self._order_attempt_window.append(now_epoch)
@@ -7008,6 +7061,20 @@ class StrategyRunner:
 
         return symbol
 
+    def _stale_tick_threshold_for_symbol(self, symbol: str) -> float:
+        """Return configured stale threshold for symbol type."""
+        upper_symbol = (symbol or "").upper()
+        is_option = upper_symbol.endswith("CE") or upper_symbol.endswith("PE")
+        is_future = upper_symbol.endswith("FUT")
+        is_index = upper_symbol in {"NSE:NIFTY", "NIFTY", "NSE:NIFTY 50", "NIFTY 50"}
+        if is_option:
+            return self._option_stale_tick_seconds
+        if is_future:
+            return self._future_stale_tick_seconds
+        if is_index:
+            return self._index_stale_tick_seconds
+        return self._generic_stale_tick_seconds
+
     def _handle_exit_signal(
         self,
         signal: Signal,
@@ -7037,6 +7104,9 @@ class StrategyRunner:
                     base_symbol,
                 )
                 return
+            now_epoch = time.time()
+            underlying = self._extract_underlying(base_symbol) or base_symbol
+            reason_key = str(signal.reason or "unknown")
 
             # Determine exit side from action
             if signal.action == "CLOSE_LONG":
@@ -7086,7 +7156,7 @@ class StrategyRunner:
                     order_id, base_symbol, exit_side, qty,
                 )
                 self._underlying_last_signal_ts[underlying] = now_epoch
-                self._reason_last_signal_ts[reason_key] = now_epoch
+                self._reason_last_signal_ts[f"{underlying}:{reason_key}"] = now_epoch
                 self._order_attempt_window.append(now_epoch)
                 try:
                     self._record_trade(

--- a/tests/strategies/test_indicator_engine.py
+++ b/tests/strategies/test_indicator_engine.py
@@ -280,6 +280,36 @@ def test_ensure_min_bars_uses_hydrator(engine: IndicatorEngine) -> None:
     assert engine.has_min_bars('TEST', 2) is True
 
 
+def test_option_avg_volume_ignores_zero_volume_bars(engine: IndicatorEngine) -> None:
+    symbol = 'NFO:NIFTY26APR23850PE'
+    volumes = [0, 0, 10, 0, 20]
+    for idx, volume in enumerate(volumes):
+        engine.update_price(
+            symbol,
+            {'open': 100 + idx, 'high': 101 + idx, 'low': 99 + idx, 'close': 100 + idx},
+            volume=volume,
+            timestamp=datetime(2024, 1, 1, 0, idx, tzinfo=timezone.utc),
+        )
+    indicators = engine.get_indicators(symbol, {'avg_volume', 'average_volume'})
+    assert indicators['avg_volume'] is not None
+    assert float(indicators['avg_volume']) > 0.0
+    assert indicators['average_volume'] == indicators['avg_volume']
+
+
+def test_non_option_avg_volume_keeps_standard_average(engine: IndicatorEngine) -> None:
+    symbol = 'NSE:NIFTY'
+    volumes = [0, 0, 10, 0, 20]
+    for idx, volume in enumerate(volumes):
+        engine.update_price(
+            symbol,
+            {'open': 200 + idx, 'high': 201 + idx, 'low': 199 + idx, 'close': 200 + idx},
+            volume=volume,
+            timestamp=datetime(2024, 1, 1, 1, idx, tzinfo=timezone.utc),
+        )
+    indicators = engine.get_indicators(symbol, {'avg_volume'})
+    assert indicators['avg_volume'] == pytest.approx(sum(volumes) / len(volumes))
+
+
 def _atr_reference(
     highs: list[float], lows: list[float], closes: list[float], period: int
 ) -> float:

--- a/tests/strategies/test_runner_gap_repair.py
+++ b/tests/strategies/test_runner_gap_repair.py
@@ -40,3 +40,16 @@ def test_gap_repair_generates_for_large_gap() -> None:
     repaired = runner._repair_candle_gap('NSE:NIFTY', prev_bar, incoming)
     assert len(repaired) == 4
     assert all(bar.synthetic for bar in repaired)
+
+
+def test_gap_repair_does_not_create_synthetic_option_bars() -> None:
+    runner = StrategyRunner.__new__(StrategyRunner)
+    runner._main_loop = None
+    runner._gap_repair_inflight = set()
+    runner._load_history_cache = lambda _s: []
+    runner._logger = type('L', (), {'warning': lambda *a, **k: None, 'info': lambda *a, **k: None})()
+    runner._should_log_throttled = lambda *_a, **_k: False
+    prev_bar = _bar(datetime(2026, 1, 1, 9, 15, tzinfo=timezone.utc), 100.0)
+    incoming = _bar(datetime(2026, 1, 1, 9, 20, tzinfo=timezone.utc), 101.0)
+    repaired = runner._repair_candle_gap('NFO:NIFTY26JAN25000CE', prev_bar, incoming)
+    assert repaired == []

--- a/tests/strategies/test_runner_live_path_guards.py
+++ b/tests/strategies/test_runner_live_path_guards.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from collections import deque
+from datetime import datetime, timezone
+
+from nifty_scalper_bot.strategies.runner import StrategyRunner
+from nifty_scalper_bot.strategies.signal_generator import Signal
+
+
+class _SilentLogger:
+    def debug(self, *args, **kwargs) -> None:
+        return
+
+    def info(self, *args, **kwargs) -> None:
+        return
+
+    def warning(self, *args, **kwargs) -> None:
+        return
+
+    def error(self, *args, **kwargs) -> None:
+        return
+
+
+class _RecordingOrderManager:
+    def __init__(self) -> None:
+        self.last_quantity = 0
+        self.calls = 0
+
+    def resolve_lot_size(self, _symbol: str) -> int:
+        return 65
+
+    def place_order(self, **kwargs) -> str:
+        self.calls += 1
+        self.last_quantity = int(kwargs.get('quantity') or 0)
+        return f'order-{self.calls}'
+
+    def is_kill_switch_active(self) -> bool:
+        return False
+
+
+def _build_runner() -> StrategyRunner:
+    runner = StrategyRunner.__new__(StrategyRunner)
+    runner._logger = _SilentLogger()
+    runner._order_manager = _RecordingOrderManager()
+    runner._last_execution_halted_log_ts = 0.0
+    runner._underlying_last_signal_ts = {}
+    runner._reason_last_signal_ts = {}
+    runner._premium_squeeze_last_signal_ts = {}
+    runner._underlying_signal_cooldown_seconds = 30.0
+    runner._reason_signal_cooldown_seconds = 30.0
+    runner._cooldown_log_throttle_seconds = 1.0
+    runner._order_attempt_window = deque()
+    runner._max_order_attempts_per_minute = 100
+    runner._record_trade = lambda *args, **kwargs: None
+    return runner
+
+
+def test_runner_normalizes_one_lot_to_exchange_quantity() -> None:
+    runner = _build_runner()
+    signal = Signal(
+        action='BUY',
+        symbol='NFO:NIFTY26APR23800PE',
+        quantity=1,
+        confidence=0.9,
+        reason='test',
+        stop_loss=100.0,
+        take_profit=120.0,
+        metadata={},
+    )
+    runner._handle_entry_signal_inner(
+        signal,
+        base_symbol='NFO:NIFTY26APR23800PE',
+        trade_symbol='NFO:NIFTY26APR23800PE',
+        trade_price=110.0,
+        timestamp=datetime.now(timezone.utc),
+        trace_id='t1',
+    )
+    assert runner._order_manager.last_quantity == 65
+
+
+def test_premium_squeeze_suppresses_second_signal_within_cooldown() -> None:
+    runner = _build_runner()
+    ts = datetime.now(timezone.utc)
+    signal = Signal(
+        action='BUY',
+        symbol='NFO:NIFTY26APR23800CE',
+        quantity=1,
+        confidence=0.9,
+        reason='premium_momentum_squeeze',
+        stop_loss=100.0,
+        take_profit=120.0,
+        metadata={},
+    )
+    runner._handle_entry_signal_inner(
+        signal,
+        base_symbol='NFO:NIFTY26APR23800CE',
+        trade_symbol='NFO:NIFTY26APR23800CE',
+        trade_price=110.0,
+        timestamp=ts,
+        trace_id='t1',
+    )
+    first_calls = runner._order_manager.calls
+    runner._handle_entry_signal_inner(
+        signal,
+        base_symbol='NFO:NIFTY26APR23850CE',
+        trade_symbol='NFO:NIFTY26APR23850CE',
+        trade_price=112.0,
+        timestamp=ts,
+        trace_id='t2',
+    )
+    assert first_calls == 1
+    assert runner._order_manager.calls == 1
+
+
+def test_stale_thresholds_are_instrument_specific() -> None:
+    runner = _build_runner()
+    runner._option_stale_tick_seconds = 900.0
+    runner._future_stale_tick_seconds = 120.0
+    runner._index_stale_tick_seconds = 30.0
+    runner._generic_stale_tick_seconds = 60.0
+    assert runner._stale_tick_threshold_for_symbol('NSE:NIFTY') == 30.0
+    assert runner._stale_tick_threshold_for_symbol('NFO:NIFTY26APR23800PE') == 900.0
+    assert runner._stale_tick_threshold_for_symbol('NFO:NIFTY26APRFUT') == 120.0

--- a/tests/strategies/test_vwap_pro_data_health.py
+++ b/tests/strategies/test_vwap_pro_data_health.py
@@ -72,3 +72,13 @@ def test_vwap_pro_uses_volume_grace_fallback(monkeypatch: pytest.MonkeyPatch) ->
     assert signal is None
     assert strategy._telemetry['skipped_data'] == 0
     assert strategy._telemetry['skipped_volume'] == 2
+
+
+def test_vwap_pro_reads_configurable_thresholds(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv('VWAP_MAX_OPTION_DISTANCE_PCT', '0.18')
+    monkeypatch.setenv('VWAP_SLACK_ATR_MULT', '1.5')
+    monkeypatch.setenv('VWAP_ALLOW_PULLBACK_ENTRY', '1')
+    strategy = VWAPProStrategy(VWAPProStrategyConfig(), _DummyIndicatorEngine())
+    assert strategy._cfg_max_vwap_distance_pct == pytest.approx(0.18)
+    assert strategy._cfg_vwap_slack_atr_mult == pytest.approx(1.5)
+    assert strategy._cfg_allow_vwap_pullback is True

--- a/tests/test_order_manager.py
+++ b/tests/test_order_manager.py
@@ -261,6 +261,20 @@ def test_resolve_lot_size_supports_bare_symbol_normalization(
     assert order_manager.resolve_lot_size("NFO:NIFTY26APR23800PE") == 65
 
 
+def test_resolve_lot_size_supports_lot_size_for_symbol_interface(
+    order_manager: OrderManager,
+) -> None:
+    class _LotResolver:
+        def lot_size_for_symbol(self, symbol: str) -> int | None:
+            if symbol in {"NFO:NIFTY26APR23800PE", "NIFTY26APR23800PE"}:
+                return 65
+            return None
+
+    order_manager.set_instrument_resolver(_LotResolver())
+    assert order_manager.resolve_lot_size("NFO:NIFTY26APR23800PE") == 65
+    assert order_manager.resolve_lot_size("NIFTY26APR23800PE") == 65
+
+
 def test_place_order_rounding_to_zero_skips(
     order_manager: OrderManager, fake_broker: FakeBrokerClient
 ) -> None:


### PR DESCRIPTION
### Motivation
- Reduce false readiness blocks and noisy rejections caused by static/global readiness flags, zero-volume/synthetic option bars, rigid stale-tick gates, and over-aggressive VWAP rejections.
- Ensure 1-lot signals are normalized to broker lot sizes, keep WebSocket primary with REST fallback for stale index ticks, and preserve all safety/risk checks while reducing log spam.

### Description
- Compute indicator readiness from actual indicator / runner history via new helper `_compute_indicator_readiness(ctx)` and sync into `data_hub`/`market_regime_manager` with `INDICATOR_READINESS_SYNC` logs (startup and post-warmup). (file: `core/app.py`).
- StrategyManager now derives `indicators_ready` from per-symbol bars (required vs available), emits a throttled diagnostic (`indicators_not_ready_diagnostic`) instead of a hard blocking spammer, and logs bar counts. (file: `core/strategy_manager.py`).
- IndicatorEngine hardened: ignore provisional/synthetic candles for VWAP and compute option `avg_volume` from non-zero non-provisional tails while retaining normal averaging for non-options; set `volume_spike_ratio` safely (no divide-by-zero). (file: `strategies/indicators.py`).
- Candle gap repair adjusted to never inject synthetic flat zero-volume bars for option CE/PE symbols (it skips synthetic creation when no history row exists) and throttles `candle_gap_repaired` logs; synthetic bars are now marked provisional so the indicator engine can ignore them. (file: `strategies/runner.py`).
- Runner logging and warmup wording tidied: `LIVE MODE ENABLED` -> `LIVE_MODE_ENABLED symbol=...`; `WARMUP` wording changed to `RUNNER_BOOT_GRACE:`. (file: `strategies/runner.py`).
- Removed unsafe per-tick forced setting of `RunnerState.EXECUTION_ENABLED`; phase-6 now respects global runner state and emits an eval decision when not enabled. (file: `strategies/runner.py`).
- Stale tick handling made instrument-specific and configurable via env vars (`RUNNER_INDEX_STALE_TICK_SECONDS`, `RUNNER_FUTURE_STALE_TICK_SECONDS`, `RUNNER_OPTION_STALE_TICK_SECONDS`, `RUNNER_GENERIC_STALE_TICK_SECONDS`); `NSE:NIFTY` stale now attempts REST/LTP fallback and continues rather than hard-blocking option evaluation. (file: `strategies/runner.py`, env defaults added in runner init).
- VWAPPro strategy made configurable and less rigid: env-driven `VWAP_ALLOW_PULLBACK_ENTRY`, `VWAP_SLACK_ATR_MULT`, `VWAP_MAX_OPTION_DISTANCE_PCT`, `VWAP_TELEMETRY_LOG_EVERY`; telemetry cadence reduced and price-below-VWAP treated as soft/optional when configured. (file: `strategies/elite_strategies/vwap_pro.py`).
- Lot-size and order-qty handling clarified: runner treats signal.quantity as lots; uses `order_manager.resolve_lot_size()` to compute final exchange `final_qty = qty_lots * lot_size` and emits `ORDER_QTY_NORMALIZED` logs. (file: `strategies/runner.py`).
- Premium-squeeze burst suppression tightened: reason cooldown keyed by `underlying:reason` and non-option squeezes logged at DEBUG when skipped; underlying cooldown preserved. (file: `strategies/runner.py`).
- Fixed risk of undefined variables in exit path by ensuring `now_epoch`, `underlying`, and `reason_key` are assigned before use. (file: `strategies/runner.py`).
- Added targeted unit tests for lot-size resolver interfaces, option avg-volume logic, gap repair behavior, stale-threshold helper, VWAP config parsing, and runner live-path lot normalization/cooldown. (files under `tests/`).

### Testing
- Compiled all source files: `python -m compileall src` (SUCCESS).
- Ran targeted unit tests for changes: `pytest -q` invoked for selected tests and the following tests passed:
  - lot-size resolver compatibility tests in `tests/test_order_manager.py` (new/extended assertions) — PASS.
  - indicator avg-volume tests in `tests/strategies/test_indicator_engine.py` — PASS.
  - gap-repair tests including option-skip case in `tests/strategies/test_runner_gap_repair.py` — PASS.
  - runner live-path tests (lot normalization, premium-squeeze cooldown, stale-threshold helper) in `tests/strategies/test_runner_live_path_guards.py` — PASS.
  - VWAPPro config parsing test in `tests/strategies/test_vwap_pro_data_health.py` — PASS.
- Ran repository checks via `./run_checks.sh`; script ran but reported existing baseline Ruff/mypy issues and pytest plugin configuration considerations unrelated to this patch (these are pre-existing repo-wide check failures, not regressions from this change).

If you want, I can now:
- Open the final PR on GitHub with the provided title/body (push failed here because remote `origin` is not configured in this environment), or
- Tweak any of the env-defaults or logging throttle values before you merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb315d578c832486ba28063b261b54)