### PR TITLE
Fix spot WS stale handling, balance visibility, and live order path

### DIFF
--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -203,7 +203,26 @@ class MarketDataManager:
         self._ltp_stale_seconds = self._parse_float_env(
             "MDM_LTP_STALE_SECONDS", default=5.0, minimum=1.0
         )
+        self._index_ltp_stale_seconds = self._parse_float_env(
+            "MDM_INDEX_LTP_STALE_SECONDS", default=120.0, minimum=1.0
+        )
+        self._offmarket_index_ltp_stale_seconds = self._parse_float_env(
+            "MDM_OFFMARKET_INDEX_LTP_STALE_SECONDS", default=3600.0, minimum=60.0
+        )
+        self._option_ltp_stale_seconds = self._parse_float_env(
+            "MDM_OPTION_LTP_STALE_SECONDS", default=30.0, minimum=1.0
+        )
+        self._future_ltp_stale_seconds = self._parse_float_env(
+            "MDM_FUTURE_LTP_STALE_SECONDS", default=30.0, minimum=1.0
+        )
+        self._generic_ltp_stale_seconds = self._parse_float_env(
+            "MDM_GENERIC_LTP_STALE_SECONDS", default=30.0, minimum=1.0
+        )
         self._ltp_stale_warn_last: dict[str, float] = {}
+        self._spot_ws_first_tick_seen = False
+        self._last_spot_resubscribe_attempt = 0.0
+        self._last_spot_stale_log = 0.0
+        self._pending_subscription_tokens: set[int] = set()
         self._tick_warn_last: dict[str, float] = (
             {}
         )  # ✅ FIX: rate-limit cache-miss warnings
@@ -843,7 +862,18 @@ class MarketDataManager:
 
         self._ws_connected = bool(connected)
         if self._ws_connected:
+            pending_tokens = sorted(self._pending_subscription_tokens)
+            if pending_tokens:
+                self._logger.info(
+                    "WS_PENDING_SUBSCRIPTION_FLUSH count=%s",
+                    len(pending_tokens),
+                    extra={
+                        "event": "WS_PENDING_SUBSCRIPTION_FLUSH",
+                        "count": len(pending_tokens),
+                    },
+                )
             self._reconcile_ws_subscriptions()
+            self._pending_subscription_tokens.clear()
 
     def register_heartbeat_callback(self, callback: Callable[[float], None]) -> None:
         """Register callback invoked whenever a heartbeat is recorded.
@@ -1171,6 +1201,9 @@ class MarketDataManager:
         if ws is None:
             return
         if not hasattr(ws, "set_tokens"):
+            return
+        if hasattr(ws, "is_connected") and not self._is_ws_connected():
+            self._pending_subscription_tokens.update(self._desired_tokens)
             return
         try:
             ws.set_tokens(sorted(self._desired_tokens))
@@ -1505,7 +1538,7 @@ class MarketDataManager:
             float | None: Latest price or None if unavailable from all sources.
         """
         canonical_symbol = self._canonical_symbol(symbol)
-        _STALE_SECONDS = float(self._ltp_stale_seconds)
+        stale_seconds = self._ltp_stale_threshold_for_symbol(canonical_symbol)
         now = time.time()
 
         # 1. Try tick cache with freshness check
@@ -1518,18 +1551,42 @@ class MarketDataManager:
             try:
                 ltp = float(tick["ltp"])
                 if ltp > 0:
-                    if tick_age is None or tick_age <= _STALE_SECONDS:
+                    if tick_age is None or tick_age <= stale_seconds:
                         return ltp
                     # Tick exists but is stale — log and fall through to broker
                     last_warn = self._ltp_stale_warn_last.get(canonical_symbol, 0.0)
-                    if now - last_warn >= 60.0:
+                    market_state = get_market_state()
+                    log_interval = 900.0 if market_state != MarketState.OPEN else 60.0
+                    if now - last_warn >= log_interval:
                         self._ltp_stale_warn_last[canonical_symbol] = now
-                        self._logger.warning(
-                            "STALE_DATA symbol=%s age=%.2fs — falling back to broker REST",
-                            canonical_symbol,
-                            tick_age,
-                            extra={"event": "STALE_DATA", "symbol": canonical_symbol, "age_s": round(float(tick_age), 3)},
-                        )
+                        if market_state == MarketState.OPEN:
+                            self._logger.warning(
+                                "STALE_DATA symbol=%s age=%.2fs threshold=%.2fs — falling back to broker REST",
+                                canonical_symbol,
+                                tick_age,
+                                stale_seconds,
+                                extra={
+                                    "event": "STALE_DATA",
+                                    "symbol": canonical_symbol,
+                                    "age_s": round(float(tick_age), 3),
+                                    "threshold_s": stale_seconds,
+                                },
+                            )
+                        else:
+                            self._logger.debug(
+                                "OFF_MARKET_LTP_STALE symbol=%s age=%.2fs threshold=%.2fs state=%s",
+                                canonical_symbol,
+                                tick_age,
+                                stale_seconds,
+                                market_state.value,
+                                extra={
+                                    "event": "OFF_MARKET_LTP_STALE",
+                                    "symbol": canonical_symbol,
+                                    "age_s": round(float(tick_age), 3),
+                                    "threshold_s": stale_seconds,
+                                    "state": market_state.value,
+                                },
+                            )
             except (KeyError, TypeError, ValueError):
                 pass
 
@@ -1544,7 +1601,7 @@ class MarketDataManager:
                     if price:
                         p = float(price)
                         if p > 0:
-                            self._logger.debug(
+                            self._logger.info(
                                 "MDM_REST_FALLBACK_USED symbol=%s reason=stale_ws_tick price=%.2f",
                                 canonical_symbol,
                                 p,
@@ -2729,12 +2786,25 @@ class MarketDataManager:
         market_state = get_market_state()
         if market_state != MarketState.OPEN:
             self._logger.info(
-                "Readiness bypassed outside live market session "
-                "(state=%s, historical data active)",
+                "MDM_READY_BYPASS_OFF_MARKET state=%s dashboard_ready=true trading_ready=false",
                 market_state.value,
+                extra={
+                    "event": "MDM_READY_BYPASS_OFF_MARKET",
+                    "state": market_state.value,
+                    "dashboard_ready": True,
+                    "trading_ready": False,
+                    "off_market_ready_bypass": True,
+                },
             )
             self.ready = True
             self.degraded = False
+            self._last_readiness_state.update(
+                {
+                    "off_market_ready_bypass": True,
+                    "dashboard_ready": True,
+                    "trading_ready": False,
+                }
+            )
             return
 
         if self.hydration_complete:
@@ -3520,10 +3590,14 @@ class MarketDataManager:
                 datahub.register_symbol(normalized_symbol, token_int)
             if normalized_symbol == "NSE:NIFTY":
                 self._logger.info(
-                    "SPOT_SUBSCRIPTION_READY symbol=%s token=%s",
+                    "SPOT_TOKEN_RESOLVED symbol=%s token=%s",
                     normalized_symbol,
                     token_int,
-                    extra={"event": "SPOT_SUBSCRIPTION_READY", "symbol": normalized_symbol, "token": token_int},
+                    extra={
+                        "event": "SPOT_TOKEN_RESOLVED",
+                        "symbol": normalized_symbol,
+                        "token": token_int,
+                    },
                 )
         except Exception as exc:  # noqa: BLE001
             self._logger.debug("Resolver/DataHub sync skipped: %s", exc, exc_info=exc)
@@ -3606,6 +3680,19 @@ class MarketDataManager:
                 },
             )
             if source == "ws" and symbol == "NSE:NIFTY":
+                if not self._spot_ws_first_tick_seen:
+                    self._spot_ws_first_tick_seen = True
+                    self._logger.info(
+                        "MDM_WS_FIRST_TICK symbol=NSE:NIFTY token=%s ltp=%s",
+                        _token_val,
+                        _price_val,
+                        extra={
+                            "event": "MDM_WS_FIRST_TICK",
+                            "symbol": "NSE:NIFTY",
+                            "token": _token_val,
+                            "ltp": _price_val,
+                        },
+                    )
                 tick_age = 0.0
                 try:
                     tick_age = max(time.time() - float(self._last_tick_time.get(symbol, 0.0) or 0.0), 0.0)
@@ -3934,6 +4021,7 @@ class MarketDataManager:
         if not is_market_open():
             self._zombie_stale_logged = False
             return
+        self._monitor_spot_ws_health()
         if not self._is_ws_healthy():
             self._zombie_stale_logged = False
             return
@@ -5101,6 +5189,86 @@ class MarketDataManager:
             self._emit_tick(symbol, normalized, source="rest")
         self._process_poll_quote(symbol, normalized)
 
+    def _ltp_stale_threshold_for_symbol(self, symbol: str) -> float:
+        """Return per-symbol stale threshold. Args: symbol. Returns: seconds. Raises: none."""
+        upper = (symbol or "").upper()
+        if upper in {"NSE:NIFTY", "NIFTY", "NSE:NIFTY 50", "NIFTY 50"}:
+            if get_market_state() != MarketState.OPEN:
+                return float(self._offmarket_index_ltp_stale_seconds)
+            return float(self._index_ltp_stale_seconds)
+        if upper.endswith(("CE", "PE")):
+            return float(self._option_ltp_stale_seconds)
+        if upper.endswith("FUT"):
+            return float(self._future_ltp_stale_seconds)
+        if self._generic_ltp_stale_seconds > 0:
+            return float(self._generic_ltp_stale_seconds)
+        return float(self._ltp_stale_seconds)
+
+    def _monitor_spot_ws_health(self) -> None:
+        """Monitor NSE spot tick freshness and trigger throttled resubscribe. Args: none. Returns: none. Raises: none."""
+        if get_market_state() != MarketState.OPEN:
+            return
+        symbol = "NSE:NIFTY"
+        age_ms = self.symbol_data_age_ms(symbol)
+        threshold_ms = self._ltp_stale_threshold_for_symbol(symbol) * 1000.0
+        if age_ms <= threshold_ms:
+            return
+        now = time.time()
+        if now - self._last_spot_stale_log >= 60.0:
+            self._last_spot_stale_log = now
+            self._logger.warning(
+                "MDM_WS_TICK_STALE symbol=%s age=%.2fs",
+                symbol,
+                age_ms / 1000.0,
+                extra={
+                    "event": "MDM_WS_TICK_STALE",
+                    "symbol": symbol,
+                    "age_s": round(age_ms / 1000.0, 3),
+                },
+            )
+        if now - self._last_spot_resubscribe_attempt < 120.0:
+            return
+        self._last_spot_resubscribe_attempt = now
+        try:
+            token = int(
+                self._symbol_to_token.get(symbol)
+                or self._token_by_symbol.get(symbol)
+                or 0
+            )
+            if token <= 0:
+                return
+            self._logger.info(
+                "WS_RESUBSCRIBE_REQUESTED symbol=%s reason=stale_index_tick",
+                symbol,
+                extra={
+                    "event": "WS_RESUBSCRIBE_REQUESTED",
+                    "symbol": symbol,
+                    "reason": "stale_index_tick",
+                },
+            )
+            self.request_token_subscription(token, symbol=symbol)
+            self._logger.info(
+                "WS_RESUBSCRIBE_SUCCESS symbol=%s token=%s",
+                symbol,
+                token,
+                extra={
+                    "event": "WS_RESUBSCRIBE_SUCCESS",
+                    "symbol": symbol,
+                    "token": token,
+                },
+            )
+        except Exception as exc:  # noqa: BLE001
+            self._logger.warning(
+                "WS_RESUBSCRIBE_FAILED symbol=%s error=%s",
+                symbol,
+                exc,
+                extra={
+                    "event": "WS_RESUBSCRIBE_FAILED",
+                    "symbol": symbol,
+                    "error": str(exc),
+                },
+            )
+
     def _has_recent_rest_ticks(self) -> bool:
         cutoff = time.time() - max(self._rest_poll_interval * 2.0, 5.0)
         with self._lock:
@@ -5138,7 +5306,27 @@ class MarketDataManager:
             if changed:
                 token = self._symbol_to_token.get(symbol)
                 if token:
-                    self._logger.info(f"WS SUBSCRIPTION REQUESTED: {symbol} ({token})")
+                    self._logger.info(
+                        "WS_SUBSCRIBE_REQUESTED symbol=%s token=%s",
+                        symbol,
+                        token,
+                        extra={
+                            "event": "WS_SUBSCRIBE_REQUESTED",
+                            "symbol": symbol,
+                            "token": token,
+                        },
+                    )
+                    if not hasattr(self._ws, "is_connected") or self._is_ws_connected():
+                        self._logger.info(
+                            "WS_SUBSCRIBE_CONFIRMED symbol=%s token=%s",
+                            symbol,
+                            token,
+                            extra={
+                                "event": "WS_SUBSCRIBE_CONFIRMED",
+                                "symbol": symbol,
+                                "token": token,
+                            },
+                        )
         except Exception as exc:  # noqa: BLE001
             # Log both message and details so it shows up even if the logger ignores
             # 'extra'.

--- a/src/nifty_scalper_bot/data/rest/zerodha_client.py
+++ b/src/nifty_scalper_bot/data/rest/zerodha_client.py
@@ -219,6 +219,8 @@ class ZerodhaKiteClient(BaseBrokerClient):
         self._last_log_ltp_bulk = 0.0
         self._last_log_margins = 0.0
         self._last_log_balance = 0.0
+        self._last_balance_snapshot: dict[str, float] | None = None
+        self._last_balance_snapshot_at: float = 0.0
         self._last_log_instrument_load = 0.0
         self._rest_cache_ttl = max(
             1.0, get_float("BROKER_REST_CACHE_TTL_SEC", default=15.0)
@@ -1423,6 +1425,7 @@ class ZerodhaKiteClient(BaseBrokerClient):
             },
         )
         summary: dict[str, float] | None = None
+        account_payload: Mapping[str, Any] | None = None
         account_error: Exception | None = None
         try:
             account_payload = self.get_account_margins(segment=normalized_segment)
@@ -1513,19 +1516,75 @@ class ZerodhaKiteClient(BaseBrokerClient):
             )
             return fallback_balance
 
-        # [CORRECTED] Aligned correctly and placed before return
+        available_cash = float(available)
+        live_balance = 0.0
+        opening_balance = 0.0
+        net = float(summary.get("net", available_cash) or available_cash)
+        if isinstance(account_payload, Mapping):
+            equity = account_payload.get("equity")
+            equity_map = equity if isinstance(equity, Mapping) else {}
+            available_map_raw = equity_map.get("available")
+            available_map = (
+                available_map_raw if isinstance(available_map_raw, Mapping) else {}
+            )
+            available_cash = float(
+                available_map.get("cash")
+                or available_map.get("live_balance")
+                or available_map.get("opening_balance")
+                or available_cash
+                or 0.0
+            )
+            live_balance = float(available_map.get("live_balance") or 0.0)
+            opening_balance = float(available_map.get("opening_balance") or 0.0)
+            net = float(equity_map.get("net") or summary.get("net") or available_cash or 0.0)
+        else:
+            live_balance = float(summary.get("live_balance", 0.0) or 0.0)
+            opening_balance = float(summary.get("opening_balance", 0.0) or 0.0)
+
+        snapshot = {
+            "available_cash": round(available_cash, 2),
+            "live_balance": round(live_balance, 2),
+            "opening_balance": round(opening_balance, 2),
+            "net": round(net, 2),
+        }
         now = time.time()
-        if now - self._last_log_balance >= self._log_throttle_interval:
-            # [FIX] Keep as INFO, throttled by _log_throttle_interval (default 60s)
+        should_info_log = self._last_balance_snapshot != snapshot
+        if not should_info_log:
+            should_info_log = (now - self._last_log_balance) >= 900.0
+        if should_info_log:
             LOGGER.info(
-                "zerodha_available_balance_success",
+                (
+                    "ZERODHA_BALANCE_REFRESH_SUCCESS available_cash=%.2f "
+                    "live_balance=%.2f opening_balance=%.2f net=%.2f"
+                ),
+                snapshot["available_cash"],
+                snapshot["live_balance"],
+                snapshot["opening_balance"],
+                snapshot["net"],
                 extra={
-                    "event": "zerodha_available_balance_success",
+                    "event": "ZERODHA_BALANCE_REFRESH_SUCCESS",
                     "segment": normalized_segment,
-                    "available": available,
+                    "available_cash": snapshot["available_cash"],
+                    "live_balance": snapshot["live_balance"],
+                    "opening_balance": snapshot["opening_balance"],
+                    "net": snapshot["net"],
                 },
             )
             self._last_log_balance = now
+            self._last_balance_snapshot = snapshot
+            self._last_balance_snapshot_at = now
+        else:
+            LOGGER.debug(
+                "ZERODHA_BALANCE_REFRESH_UNCHANGED available_cash=%0.2f net=%0.2f",
+                snapshot["available_cash"],
+                snapshot["net"],
+                extra={
+                    "event": "ZERODHA_BALANCE_REFRESH_UNCHANGED",
+                    "segment": normalized_segment,
+                    "available_cash": snapshot["available_cash"],
+                    "net": snapshot["net"],
+                },
+            )
         return available
 
     def _resolve_balance_fallback(self) -> float:

--- a/src/nifty_scalper_bot/execution/order_manager.py
+++ b/src/nifty_scalper_bot/execution/order_manager.py
@@ -63,6 +63,7 @@ from nifty_scalper_bot.utils.circuit_breaker import CircuitBreaker
 from nifty_scalper_bot.utils.errors import RateLimitError
 from nifty_scalper_bot.utils.logging import get_logger
 from nifty_scalper_bot.utils.metrics import Counter, Gauge
+from nifty_scalper_bot.utils.market_hours import get_time_status
 from nifty_scalper_bot.utils.pricing import canonical_price_source
 from nifty_scalper_bot.utils.rate_limiter import RateLimiter
 from nifty_scalper_bot.utils.reasons import canonical
@@ -78,11 +79,6 @@ SOFT_BLOCK_CODES: set[str] = {
     "AMO_ONLY",
     "MARKET_CLOSED",
 }
-SAFE_WINDOW_START = (9, 30)
-SAFE_WINDOW_END = (15, 15)
-MARKET_WINDOW_START = (9, 15)
-MARKET_WINDOW_END = (15, 30)
-
 _REFERENCE_LOGGER = get_logger(__name__)
 
 BrokerError = execution_exceptions.BrokerError
@@ -739,7 +735,7 @@ class OrderManager:
         self._consecutive_failures: int = 0
         self._max_failures: int = max(1, int(os.getenv("ORDER_KILL_SWITCH_MAX_FAILURES", "5") or 5))
         self._kill_switch_auto_reset_seconds: int = max(60, int(os.getenv("ORDER_KILL_SWITCH_AUTO_RESET_SECONDS", "900") or 900))
-        self._kill_switch_allow_auto_reset: bool = os.getenv("ORDER_KILL_SWITCH_ALLOW_AUTO_RESET", "true").strip().lower() in {"1", "true", "yes", "on"}
+        self._kill_switch_allow_auto_reset: bool = os.getenv("ORDER_KILL_SWITCH_ALLOW_AUTO_RESET", "false").strip().lower() in {"1", "true", "yes", "on"}
         self._kill_switch_engaged_at: datetime | None = None
         self._kill_switch_reason: str | None = None
         self._last_kill_switch_log_ts: float = 0.0
@@ -2026,33 +2022,31 @@ class OrderManager:
                     return None
 
         # ---------------------------------------------------------------------
-        # 2. TIME GUARD (Safe Window: 09:30 - 15:15 IST)
+        # 2. TIME GUARD (central market_hours source of truth)
         # ---------------------------------------------------------------------
         if variety == "regular" and not is_system_exit:
             try:
-                ist = ZoneInfo("Asia/Kolkata")
-                now = datetime.now(ist).time()
-                safe_start = dtime(*SAFE_WINDOW_START)
-                safe_end = dtime(*SAFE_WINDOW_END)
-                market_open = dtime(*MARKET_WINDOW_START)
-                market_close = dtime(*MARKET_WINDOW_END)
-
-                if not (safe_start <= now <= safe_end):
-                    reason = "Market Closed"
-                    if market_open <= now < safe_start:
-                        reason = f"Opening Volatility Buffer (Wait until {safe_start.strftime('%H:%M')})"
-                    elif safe_end < now <= market_close:
-                        reason = f"EOD Safety Cutoff (No trades after {safe_end.strftime('%H:%M')})"
-
-                    self._logger.warning(
-                        f"🛑 Order Blocked: {reason}. Current Time: {now.strftime('%H:%M:%S')}",
+                execution_mode = os.getenv("EXECUTION_MODE", "SHADOW").strip().upper()
+                enable_live = os.getenv("ENABLE_LIVE", "false").strip().lower() in {"1", "true", "yes", "on"}
+                is_live_mode = execution_mode == "LIVE" or enable_live
+                allowed, detail = get_time_status()
+                if is_live_mode and not allowed:
+                    self._logger.info(
+                        "ORDER_BLOCKED reason=time_guard detail=%s symbol=%s",
+                        detail,
+                        normalized_symbol,
                         extra={
+                            "event": "ORDER_BLOCKED",
+                            "reason": "time_guard",
+                            "detail": detail,
                             "symbol": normalized_symbol,
-                            "event": "time_guard_block",
                         },
                     )
-                    self._logger.info("ORDER_BLOCKED: time_guard reason=%s symbol=%s time=%s", reason, normalized_symbol, now.strftime("%H:%M:%S"))
-                    _log_order_decision(allowed=False, block_reason="time_guard_block")
+                    _log_order_decision(
+                        allowed=False,
+                        block_reason="time_guard",
+                        detail=detail,
+                    )
                     return None
             except Exception as e:
                 self._logger.error(

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -537,7 +537,7 @@ class StrategyRunner:
         )
         self._index_stale_tick_seconds = max(
             1.0,
-            float(os.getenv("RUNNER_INDEX_STALE_TICK_SECONDS", "30")),
+            float(os.getenv("RUNNER_INDEX_STALE_TICK_SECONDS", "120")),
         )
         self._future_stale_tick_seconds = max(
             1.0,
@@ -6356,13 +6356,18 @@ class StrategyRunner:
         try:
             action = signal.action
             base_symbol = self._normalize_symbol(signal.symbol)
-            _ = self._transition_execution_state(
-                base_symbol, ExecutionState.EXIT_PENDING
-            )
             trade_symbol = base_symbol
             trade_price = price
 
             if action in {"BUY", "SELL"}:
+                if not self._transition_execution_state(
+                    base_symbol, ExecutionState.SIGNAL_RECEIVED
+                ):
+                    return SignalExecutionResult(
+                        False,
+                        "signal_state_rejected",
+                        details={"trace_id": trace_id},
+                    )
                 return self._handle_entry_signal(
                     signal,
                     base_symbol,
@@ -6373,6 +6378,7 @@ class StrategyRunner:
                 )
 
             elif action in {"CLOSE_LONG", "CLOSE_SHORT"}:
+                self._transition_execution_state(base_symbol, ExecutionState.EXIT_PENDING)
                 self._handle_exit_signal(
                     signal, base_symbol, trade_symbol, trade_price, timestamp
                 )
@@ -6782,25 +6788,12 @@ class StrategyRunner:
                 extra={"event": "entry_signal_inner", "symbol": base_symbol},
             )
 
-            # ── PHASE 2: SIGNAL_RECEIVED log ────────────────────────────────
-            self._logger.info(
-                "SIGNAL_RECEIVED symbol=%s action=%s qty_lots=%s price=%s sl=%s tp=%s confidence=%.2f reason=%s trace_id=%s",
-                signal.symbol,
-                signal.action,
-                signal.quantity,
-                trade_price,
-                signal.stop_loss,
-                signal.take_profit,
-                signal.confidence,
-                signal.reason,
-                trace_id,
-            )
-
             if not self._order_manager:
                 self._logger.error(
                     "ORDER_BLOCKED: order_manager is None — cannot execute entry for %s",
                     base_symbol,
                 )
+                self._reset_execution_state(base_symbol)
                 return SignalExecutionResult(False, "order_manager_missing")
 
             qty = int(signal.quantity or 0)
@@ -6808,6 +6801,7 @@ class StrategyRunner:
                 self._logger.critical(
                     "ORDER_BLOCKED: invalid quantity=%s for %s", qty, base_symbol
                 )
+                self._reset_execution_state(base_symbol)
                 return SignalExecutionResult(False, "invalid_quantity")
 
             # Cooldown + burst guard
@@ -6826,6 +6820,7 @@ class StrategyRunner:
                         level=logging.DEBUG,
                         extra={"event": "PREMIUM_SQUEEZE_SKIPPED", "symbol": trade_symbol or base_symbol, "reason": "non_option_instrument"},
                     )
+                    self._reset_execution_state(base_symbol)
                     return SignalExecutionResult(False, "non_option_instrument")
                 last_premium_ts = float(self._premium_squeeze_last_signal_ts.get(underlying, 0.0))
                 if now_epoch - last_premium_ts < self._underlying_signal_cooldown_seconds:
@@ -6837,18 +6832,37 @@ class StrategyRunner:
                         level=logging.INFO,
                         extra={"event": "PREMIUM_SQUEEZE_SUPPRESSED", "underlying": underlying, "reason": "cooldown"},
                     )
+                    self._reset_execution_state(base_symbol)
                     return SignalExecutionResult(False, "premium_squeeze_cooldown")
             if now_epoch - float(self._underlying_last_signal_ts.get(underlying, 0.0)) < self._underlying_signal_cooldown_seconds:
                 log_throttled(self._logger, f"runner_underlying_cd_{underlying}", "RUNNER_SIGNAL_SUPPRESSED_EXECUTION_HALTED", interval_sec=self._cooldown_log_throttle_seconds, level=logging.INFO, extra={"event": "RUNNER_SIGNAL_SUPPRESSED_EXECUTION_HALTED", "symbol": base_symbol, "reason": "underlying_cooldown"})
+                self._reset_execution_state(base_symbol)
                 return SignalExecutionResult(False, "underlying_cooldown")
             if now_epoch - float(self._reason_last_signal_ts.get(underlying_reason_key, 0.0)) < self._reason_signal_cooldown_seconds:
                 log_throttled(self._logger, f"runner_reason_cd_{reason_key}", "RUNNER_SIGNAL_SUPPRESSED_EXECUTION_HALTED", interval_sec=self._cooldown_log_throttle_seconds, level=logging.INFO, extra={"event": "RUNNER_SIGNAL_SUPPRESSED_EXECUTION_HALTED", "symbol": base_symbol, "reason": "reason_cooldown"})
+                self._reset_execution_state(base_symbol)
                 return SignalExecutionResult(False, "reason_cooldown")
             while self._order_attempt_window and (now_epoch - self._order_attempt_window[0]) > 60.0:
                 self._order_attempt_window.popleft()
             if len(self._order_attempt_window) >= self._max_order_attempts_per_minute:
                 log_throttled(self._logger, "runner_order_attempt_rate", "RUNNER_SIGNAL_SUPPRESSED_EXECUTION_HALTED", interval_sec=300.0, level=logging.INFO, extra={"event": "RUNNER_SIGNAL_SUPPRESSED_EXECUTION_HALTED", "symbol": base_symbol, "reason": "max_order_attempts_per_minute"})
+                self._reset_execution_state(base_symbol)
                 return SignalExecutionResult(False, "max_order_attempts_per_minute")
+            if reason_key == "premium_momentum_squeeze":
+                self._premium_squeeze_last_signal_ts[underlying] = now_epoch
+
+            self._logger.info(
+                "SIGNAL_RECEIVED symbol=%s action=%s qty_lots=%s price=%s sl=%s tp=%s confidence=%.2f reason=%s trace_id=%s",
+                signal.symbol,
+                signal.action,
+                signal.quantity,
+                trade_price,
+                signal.stop_loss,
+                signal.take_profit,
+                signal.confidence,
+                signal.reason,
+                trace_id,
+            )
 
             lot_size = 1
             final_qty = qty
@@ -6858,19 +6872,22 @@ class StrategyRunner:
                     lot_size = int(self._order_manager.resolve_lot_size(trade_symbol or base_symbol))
                 final_qty = qty_lots * lot_size
                 self._logger.info(
-                    "ORDER_QTY_NORMALIZED symbol=%s input_qty_lots=%s lot_size=%s final_qty=%s",
+                    "ORDER_QTY_NORMALIZED symbol=%s input_qty_lots=%s lot_size=%s final_qty=%s trace_id=%s",
                     trade_symbol or base_symbol,
                     qty_lots,
                     lot_size,
                     final_qty,
+                    trace_id,
                     extra={"event": "ORDER_QTY_NORMALIZED", "symbol": trade_symbol or base_symbol, "input_qty_lots": qty_lots, "lot_size": lot_size, "final_qty": final_qty},
                 )
             except Exception as lot_exc:
                 self._logger.warning("ORDER_BLOCKED: invalid_lot_quantity symbol=%s error=%s", trade_symbol or base_symbol, lot_exc)
+                self._reset_execution_state(base_symbol)
                 return SignalExecutionResult(False, "invalid_lot_quantity")
             qty = final_qty
             if qty <= 0 or (lot_size > 0 and qty % lot_size != 0):
                 self._logger.warning("ORDER_BLOCKED: invalid_lot_quantity symbol=%s qty=%s lot_size=%s", trade_symbol or base_symbol, qty, lot_size)
+                self._reset_execution_state(base_symbol)
                 return SignalExecutionResult(False, "invalid_lot_quantity")
 
             # Resolve price: prefer signal metadata, fall back to live tick
@@ -6894,8 +6911,14 @@ class StrategyRunner:
                 or "runner"
             )
 
+            if not self._transition_execution_state(
+                base_symbol, ExecutionState.ORDER_PENDING
+            ):
+                self._reset_execution_state(base_symbol)
+                return SignalExecutionResult(False, "order_state_rejected", details={"trace_id": trace_id})
+
             self._logger.info(
-                "TRADE_ATTEMPT symbol=%s side=%s qty=%s price=%s sl=%s tp=%s strategy=%s",
+                "RUNNER_ORDER_REQUEST symbol=%s side=%s qty=%s price=%s sl=%s tp=%s strategy=%s trace_id=%s",
                 base_symbol,
                 signal.action,
                 qty,
@@ -6903,6 +6926,12 @@ class StrategyRunner:
                 stop_loss,
                 take_profit,
                 strategy_name,
+                trace_id,
+                extra={
+                    "event": "RUNNER_ORDER_REQUEST",
+                    "symbol": base_symbol,
+                    "trace_id": trace_id,
+                },
             )
 
             self._order_attempt_window.append(now_epoch)
@@ -6922,13 +6951,11 @@ class StrategyRunner:
 
             if order_id:
                 self._logger.info(
-                    "ORDER_SUBMITTED order_id=%s symbol=%s side=%s qty=%s",
-                    order_id, base_symbol, signal.action, qty,
+                    "ORDER_SUBMITTED order_id=%s symbol=%s side=%s qty=%s trace_id=%s",
+                    order_id, base_symbol, signal.action, qty, trace_id,
                 )
                 self._underlying_last_signal_ts[underlying] = now_epoch
                 self._reason_last_signal_ts[underlying_reason_key] = now_epoch
-                if reason_key == "premium_momentum_squeeze":
-                    self._premium_squeeze_last_signal_ts[underlying] = now_epoch
                 self._order_attempt_window.append(now_epoch)
                 try:
                     self._record_trade(
@@ -6940,10 +6967,12 @@ class StrategyRunner:
                 return SignalExecutionResult(True, "order_submitted", order_id=order_id, details={"trace_id": trace_id})
             else:
                 log_throttled(self._logger, f"runner_order_rejected_{base_symbol}", "ORDER_REJECTED by order_manager", interval_sec=300.0, level=logging.WARNING, extra={"event": "ORDER_REJECTED", "symbol": base_symbol})
+                self._reset_execution_state(base_symbol)
                 return SignalExecutionResult(False, "order_rejected", details={"trace_id": trace_id})
 
         except Exception as exc:
             self._logger.error("🔴 ENTRY LOGIC CRASH: %s", exc, exc_info=True)
+            self._reset_execution_state(base_symbol)
             return SignalExecutionResult(False, "entry_exception", details={"trace_id": trace_id, "error": str(exc)})
 
     def _get_atr_with_fallback(

--- a/src/nifty_scalper_bot/utils/market_hours.py
+++ b/src/nifty_scalper_bot/utils/market_hours.py
@@ -43,7 +43,22 @@ class MarketState(Enum):
 
 
 def _override_enabled() -> bool:
-    return os.getenv("SESSION_ALLOW_OUT_OF_HOURS", "").lower() == "true"
+    """Args: none; Returns: bool; Raises: none."""
+    execution_mode = os.getenv("EXECUTION_MODE", "SHADOW").strip().upper()
+    enable_live = os.getenv("ENABLE_LIVE", "false").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+    if execution_mode == "LIVE" or enable_live:
+        return False
+    return os.getenv("SESSION_ALLOW_OUT_OF_HOURS", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
 
 
 def _now_ist() -> datetime:

--- a/tests/data/test_market_data_manager_subscriptions.py
+++ b/tests/data/test_market_data_manager_subscriptions.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any
 
 from nifty_scalper_bot.data.market_data_manager import MarketDataManager
+from nifty_scalper_bot.utils.market_hours import MarketState
 
 
 class DummyBroker:
@@ -24,10 +25,14 @@ class DummyResolver:
 class DummyWebSocket:
     def __init__(self) -> None:
         self.calls: list[list[int]] = []
+        self.connected = True
 
     def set_tokens(self, tokens) -> bool:  # noqa: ANN001
         self.calls.append(list(tokens))
         return True
+
+    def is_connected(self) -> bool:
+        return self.connected
 
 
 def test_request_symbol_subscription_reconciles_once() -> None:
@@ -136,3 +141,34 @@ def test_ensure_subscription_uses_request_api() -> None:
     mdm._ensure_subscription('NSE:NIFTY')  # noqa: SLF001
 
     assert calls == ['NSE:NIFTY']
+
+
+def test_pending_subscriptions_flush_on_connect() -> None:
+    ws = DummyWebSocket()
+    ws.connected = False
+    mdm = MarketDataManager(DummyBroker(), ws, resolver=DummyResolver())
+
+    changed = mdm.request_symbol_subscription('NSE:NIFTY')
+    assert changed is True
+    assert ws.calls == []
+    assert 256265 in mdm._pending_subscription_tokens  # noqa: SLF001
+
+    ws.connected = True
+    mdm.set_ws_connected(True)
+    assert ws.calls == [[256265]]
+
+
+def test_ltp_stale_thresholds_are_symbol_specific(monkeypatch) -> None:
+    mdm = MarketDataManager(DummyBroker(), websocket=None, resolver=DummyResolver())
+    monkeypatch.setattr(
+        'nifty_scalper_bot.data.market_data_manager.get_market_state',
+        lambda: MarketState.OPEN,
+    )
+    assert mdm._ltp_stale_threshold_for_symbol('NSE:NIFTY') == 120.0  # noqa: SLF001
+    assert mdm._ltp_stale_threshold_for_symbol('NFO:NIFTY26APR23800PE') == 30.0  # noqa: SLF001
+
+    monkeypatch.setattr(
+        'nifty_scalper_bot.data.market_data_manager.get_market_state',
+        lambda: MarketState.CLOSED,
+    )
+    assert mdm._ltp_stale_threshold_for_symbol('NSE:NIFTY') == 3600.0  # noqa: SLF001

--- a/tests/data/test_zerodha_balance_logging.py
+++ b/tests/data/test_zerodha_balance_logging.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import logging
+
+from nifty_scalper_bot.data.rest.zerodha_client import ZerodhaKiteClient
+
+
+def test_balance_refresh_logs_amount_fields(caplog) -> None:
+    client = ZerodhaKiteClient(api_key='k', access_token='t')
+    client.get_account_margins = lambda segment='equity': {
+        'equity': {
+            'net': 125000.0,
+            'available': {
+                'cash': 100000.0,
+                'live_balance': 98000.0,
+                'opening_balance': 102000.0,
+            },
+        }
+    }
+    with caplog.at_level(logging.INFO):
+        out = client.get_available_balance('equity')
+
+    assert out == 100000.0
+    assert any('ZERODHA_BALANCE_REFRESH_SUCCESS' in r.getMessage() for r in caplog.records)
+    assert any(getattr(r, 'event', '') == 'ZERODHA_BALANCE_REFRESH_SUCCESS' for r in caplog.records)
+
+
+def test_balance_refresh_unchanged_is_debug(monkeypatch, caplog) -> None:
+    client = ZerodhaKiteClient(api_key='k', access_token='t')
+    payload = {
+        'equity': {
+            'net': 50000.0,
+            'available': {
+                'cash': 45000.0,
+                'live_balance': 44000.0,
+                'opening_balance': 46000.0,
+            },
+        }
+    }
+    client.get_account_margins = lambda segment='equity': payload
+
+    with caplog.at_level(logging.INFO):
+        client.get_available_balance('equity')
+    caplog.clear()
+
+    # Keep time inside 15m unchanged-info window.
+    monkeypatch.setattr(client, '_log_time_fn', lambda: 1.0)
+    with caplog.at_level(logging.DEBUG):
+        client.get_available_balance('equity')
+
+    assert any('ZERODHA_BALANCE_REFRESH_UNCHANGED' in r.getMessage() for r in caplog.records)

--- a/tests/strategies/test_runner_live_path_guards.py
+++ b/tests/strategies/test_runner_live_path_guards.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections import deque
 from datetime import datetime, timezone
+import threading
 
 from nifty_scalper_bot.strategies.runner import StrategyRunner
 from nifty_scalper_bot.strategies.signal_generator import Signal
@@ -52,6 +53,7 @@ def _build_runner() -> StrategyRunner:
     runner._order_attempt_window = deque()
     runner._max_order_attempts_per_minute = 100
     runner._record_trade = lambda *args, **kwargs: None
+    runner._entry_lock = threading.Lock()
     return runner
 
 
@@ -116,8 +118,41 @@ def test_stale_thresholds_are_instrument_specific() -> None:
     runner = _build_runner()
     runner._option_stale_tick_seconds = 900.0
     runner._future_stale_tick_seconds = 120.0
-    runner._index_stale_tick_seconds = 30.0
+    runner._index_stale_tick_seconds = 120.0
     runner._generic_stale_tick_seconds = 60.0
-    assert runner._stale_tick_threshold_for_symbol('NSE:NIFTY') == 30.0
+    assert runner._stale_tick_threshold_for_symbol('NSE:NIFTY') == 120.0
     assert runner._stale_tick_threshold_for_symbol('NFO:NIFTY26APR23800PE') == 900.0
     assert runner._stale_tick_threshold_for_symbol('NFO:NIFTY26APRFUT') == 120.0
+
+
+def test_handle_signal_entry_transitions_to_signal_and_order_pending(monkeypatch) -> None:
+    runner = _build_runner()
+    monkeypatch.setattr(
+        'nifty_scalper_bot.strategies.runner.is_market_hours_cached',
+        lambda: True,
+    )
+    transition_states: list[str] = []
+    runner._normalize_symbol = lambda value: value
+    runner._transition_execution_state = lambda _symbol, state: transition_states.append(state.value) or True
+    runner._reset_execution_state = lambda _symbol: None
+
+    signal = Signal(
+        action='BUY',
+        symbol='NFO:NIFTY26APR23800PE',
+        quantity=1,
+        confidence=0.9,
+        reason='test',
+        stop_loss=100.0,
+        take_profit=120.0,
+        metadata={},
+    )
+    result = runner._handle_signal(
+        signal,
+        price=110.0,
+        timestamp=datetime.now(timezone.utc),
+        trace_id='trace-entry-state',
+    )
+
+    assert result.accepted is True
+    assert transition_states[:2] == ['SIGNAL_RECEIVED', 'ORDER_PENDING']
+    assert 'EXIT_PENDING' not in transition_states

--- a/tests/utils/test_market_hours_cache.py
+++ b/tests/utils/test_market_hours_cache.py
@@ -39,3 +39,12 @@ def test_market_hours_blocks_weekend_even_inside_safe_clock(
 
     assert market_hours.is_market_hours() is False
     assert market_hours.is_market_hours_cached() is False
+
+
+def test_offhours_override_disabled_in_live_mode(monkeypatch) -> None:
+    """Args: monkeypatch. Returns: None. Raises: AssertionError."""
+    monkeypatch.setenv('SESSION_ALLOW_OUT_OF_HOURS', 'true')
+    monkeypatch.setenv('EXECUTION_MODE', 'LIVE')
+    monkeypatch.setenv('ENABLE_LIVE', 'true')
+
+    assert market_hours._override_enabled() is False  # noqa: SLF001


### PR DESCRIPTION
### Motivation
- Reduce noisy/off-market `STALE_DATA` logs for `NSE:NIFTY` and make WS subscription lifecycle observable and self-healing. 
- Make Zerodha balance logging actionable by exposing numeric amounts and throttling unchanged refresh messages. 
- Prevent `SESSION_ALLOW_OUT_OF_HOURS` from enabling LIVE execution and fix incorrect entry→exit execution state transitions that could block or mislabel orders. 
- Unify safe-window logic so `OrderManager` uses the single source of truth in `market_hours` and harden kill-switch defaults for safety.

### Description
- Market-hours: hardened override in `src/nifty_scalper_bot/utils/market_hours.py` so `SESSION_ALLOW_OUT_OF_HOURS` cannot open the market when `EXECUTION_MODE=LIVE` or `ENABLE_LIVE=true`.
- Balance logging: updated `src/nifty_scalper_bot/data/rest/zerodha_client.py` to extract safe fields and emit `ZERODHA_BALANCE_REFRESH_SUCCESS available_cash=... live_balance=... opening_balance=... net=...` with snapshot-change detection and debug fallback when unchanged.
- LTP stale policy & WS robustness: added per-instrument stale thresholds and off-market thresholds, quieter off-market logging, pending WS subscription queue, explicit `SPOT_TOKEN_RESOLVED` / `WS_SUBSCRIBE_REQUESTED` / `WS_SUBSCRIBE_CONFIRMED` / `MDM_WS_FIRST_TICK` / `MDM_WS_TICK_STALE` / `WS_RESUBSCRIBE_*` events, and a throttled resubscribe monitor in `src/nifty_scalper_bot/data/market_data_manager.py`.
- Runner & order path: corrected execution state transitions in `src/nifty_scalper_bot/strategies/runner.py` to use `SIGNAL_RECEIVED -> ORDER_PENDING` for entries, added resets to IDLE on blocks/exceptions, applied premium-squeeze generation cooldown earlier, and renamed runner-side log to `RUNNER_ORDER_REQUEST` (traceable via `trace_id`).
- Safe-window unification & kill-switch: `OrderManager` now uses `get_time_status()` from `market_hours` to block entries only in LIVE, and default `ORDER_KILL_SWITCH_ALLOW_AUTO_RESET` set to `false` in `src/nifty_scalper_bot/execution/order_manager.py`.
- Off-market readiness: MDM now reports `MDM_READY_BYPASS_OFF_MARKET` with `dashboard_ready=true` and `trading_ready=false` so dashboard health does not imply live trading readiness.
- Tests: added focused tests covering balance logging, pending WS subscription flush, stale thresholds, LIVE override safety, and runner state transitions (files in `tests/*`).

Files changed (key):
- `src/nifty_scalper_bot/utils/market_hours.py`
- `src/nifty_scalper_bot/data/market_data_manager.py`
- `src/nifty_scalper_bot/data/rest/zerodha_client.py`
- `src/nifty_scalper_bot/strategies/runner.py`
- `src/nifty_scalper_bot/execution/order_manager.py`
- `tests/data/test_zerodha_balance_logging.py`
- `tests/data/test_market_data_manager_subscriptions.py`
- `tests/utils/test_market_hours_cache.py`
- `tests/strategies/test_runner_live_path_guards.py`

### Testing
- Compiled code with `python -m compileall src` and compilation completed successfully.
- Ran focused unit tests: `pytest -q tests/utils/test_market_hours_cache.py tests/data/test_market_data_manager_subscriptions.py tests/data/test_zerodha_balance_logging.py tests/strategies/test_runner_live_path_guards.py` and they all passed.
- Full `pytest -q` run failed due to an unrelated repository import issue (`ImportError: cannot import name 'InstrumentResolver' from nifty_scalper_bot.data`) existing in the test matrix; targeted tests for the changes passed despite that.
- `./run_checks.sh` / `bash ./run_checks.sh` were executed; dependency installation proceeded but the script's final test step inside the virtualenv reported `pytest` not installed in that venv (environment setup nuance), so CI-style checks need `pytest` installed in the run-checks environment to produce the same green result.

Notes for reviewers / deployers:
- Expected runtime env variables to tune behavior: `MDM_INDEX_LTP_STALE_SECONDS=120`, `MDM_OFFMARKET_INDEX_LTP_STALE_SECONDS=3600`, `MDM_OPTION_LTP_STALE_SECONDS=30`, `RUNNER_INDEX_STALE_TICK_SECONDS=120`, and `ORDER_KILL_SWITCH_ALLOW_AUTO_RESET=false` (defaults added but can be set explicitly).
- Watch logs after deploy for `MDM_WS_FIRST_TICK`, `WS_RESUBSCRIBE_REQUESTED`/`SUCCESS`/`FAILED`, and `ZERODHA_BALANCE_REFRESH_SUCCESS` lines to validate runtime behavior.
- Rollback: revert the change if unexpected subscription/reconcile behavior occurs; this is low-to-medium risk and limited to freshness/logging/state-guards only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec9784eb988324b2e27f4bf23afda0)