### PR TITLE
Fix health loop crash, bracket safety, and candidate gating

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -483,7 +483,7 @@ from nifty_scalper_bot.utils.env import (
     normalize_path,
 )
 from nifty_scalper_bot.utils.errors import ConfigurationError
-from nifty_scalper_bot.utils.logging import get_logger, setup_logging
+from nifty_scalper_bot.utils.logging import get_logger, log_throttled, setup_logging
 from nifty_scalper_bot.utils.market_hours import (
     MarketState,
     allow_offhours_testing_safe,
@@ -3447,38 +3447,10 @@ def initialize_components(settings: Settings | None = None) -> BotContext:
     # [FIX] Polling Tick Handler & Throttling Helper
     # ------------------------------------------------------------------
 
-    # 1. Define the throttling cache and helper locally to guarantee existence.
-    #    This fixes the "NameError: name 'log_throttled' is not defined".
-    _log_throttling_cache: dict[str, float] = {}
+    # ------------------------------------------------------------------
+    # Streamer Selection Logic (Polling vs WebSocket)
+    # ------------------------------------------------------------------
 
-    def log_throttled(
-        logger: Any,
-        key: str,
-        msg: str,
-        interval_sec: float = 60.0,
-        level: int = logging.INFO,
-    ) -> None:
-        """
-        Thread-safe helper to log messages only once per interval.
-        Prevents log file flooding during high-frequency tick updates.
-        """
-        try:
-            # Use the global time_module alias defined at top of file
-            now = time_module.time()
-            last_time = _log_throttling_cache.get(key, 0.0)
-
-            if now - last_time >= interval_sec:
-                logger.log(level, msg)
-                _log_throttling_cache[key] = now
-        except Exception:
-            # Failsafe: Never crash the trading bot just because logging failed
-            pass
-            
-        # ------------------------------------------------------------------
-        # Streamer Selection Logic (Polling vs WebSocket)
-        # ------------------------------------------------------------------
-
-    
     def _on_poll_tick(tick: dict[str, Any]) -> None:
         if not tick or type(tick) is not dict:
             return
@@ -8103,11 +8075,27 @@ class NiftyScalperApp:
                 await self._health_task
             except asyncio.CancelledError:
                 pass
+            except Exception as exc:  # noqa: BLE001
+                LOGGER.warning(
+                    "Health task failed during shutdown: %s",
+                    exc,
+                    extra={"event": "health_task_shutdown_error"},
+                    exc_info=True,
+                )
             self._health_task = None
         if self._self_test_task:
             self._self_test_task.cancel()
-            with suppress(asyncio.CancelledError):
+            try:
                 await self._self_test_task
+            except asyncio.CancelledError:
+                pass
+            except Exception as exc:  # noqa: BLE001
+                LOGGER.warning(
+                    "Self-test task failed during shutdown: %s",
+                    exc,
+                    extra={"event": "self_test_task_shutdown_error"},
+                    exc_info=True,
+                )
             self._self_test_task = None
         if (
             self._ctx.telegram_application is not None
@@ -8322,10 +8310,26 @@ class NiftyScalperApp:
         while not self._shutdown_event.is_set():
             try:
                 await asyncio.wait_for(self._shutdown_event.wait(), timeout=interval)
+                break
             except asyncio.TimeoutError:
                 now = time_module.monotonic()
                 if now - last_heavy >= heavy_interval:
-                    _health_check(self._ctx)
+                    try:
+                        _health_check(self._ctx)
+                    except asyncio.CancelledError:
+                        LOGGER.debug(
+                            "Health loop cancelled",
+                            extra={"event": "health_loop_cancelled"},
+                        )
+                        raise
+                    except Exception as exc:  # noqa: BLE001
+                        LOGGER.error(
+                            "Failure in health loop: %s",
+                            exc,
+                            extra={"event": "health_loop_error"},
+                            exc_info=True,
+                        )
+                        await asyncio.sleep(5.0)
                     try:
                         await _reconcile_state(self._ctx)
                     except Exception as exc:  # noqa: BLE001
@@ -8350,7 +8354,12 @@ class NiftyScalperApp:
                         )
                     last_heavy = now
                 continue
-            break
+            except asyncio.CancelledError:
+                LOGGER.debug(
+                    "Health loop cancelled",
+                    extra={"event": "health_loop_cancelled"},
+                )
+                raise
 
 
 # ----------------------------------------------------------------

--- a/src/nifty_scalper_bot/execution/bracket_manager.py
+++ b/src/nifty_scalper_bot/execution/bracket_manager.py
@@ -348,12 +348,23 @@ class BracketManager:
                     for bracket in self._brackets.values():
                         ltp = float(bracket.last_ltp or 0.0)
                         if (
+                            not bracket.active
+                            or not bracket.entry_confirmed
+                            or bracket.entry_status != "ACTIVE"
+                            or
                             bracket.exit_executed
                             or bracket.exit_in_progress
                             or bracket.remaining_quantity <= 0
                             or bracket.sl_trigger_price <= 0
                             or ltp <= 0
                         ):
+                            self._log_throttled(
+                                'debug',
+                                f'watchdog_skip_{bracket.entry_order_id}',
+                                60.0,
+                                'BRACKET_WATCHDOG_SKIP symbol=%s reason=pending_or_inactive',
+                                bracket.symbol,
+                            )
                             continue
                         if bracket.side == 'BUY' and self._sl_crossed(bracket, ltp):
                             pending.append((bracket, {
@@ -1138,9 +1149,21 @@ class BracketManager:
             for bracket, action in exits:
                 if bracket.exit_executed or bracket.exit_in_progress:
                     continue
-                action_type = str(action.get('type', '')).upper()
-                is_protective_exit = action_type in {'SL', 'FINAL_TP', 'PARTIAL_TP'}
-                if (not bracket.active and not is_protective_exit) or bracket.remaining_quantity <= 0:
+                if (
+                    not bracket.active
+                    or not bracket.entry_confirmed
+                    or bracket.entry_status != "ACTIVE"
+                    or bracket.remaining_quantity <= 0
+                    or bracket.exit_executed
+                    or bracket.exit_in_progress
+                ):
+                    self._log_throttled(
+                        'debug',
+                        f'bracket_exit_skipped_{bracket.entry_order_id}',
+                        60.0,
+                        'BRACKET_EXIT_SKIPPED symbol=%s reason=inactive_or_unconfirmed',
+                        bracket.symbol,
+                    )
                     continue
                 last_attempt = self._exit_cooldowns.get(bracket.entry_order_id, 0.0)
                 if now - last_attempt < 0.5:
@@ -1367,7 +1390,11 @@ class BracketManager:
         """
         if not bracket.trailing_enabled:
             return
-        if not bracket.active or not bracket.entry_confirmed:
+        if (
+            not bracket.active
+            or not bracket.entry_confirmed
+            or bracket.entry_status != "ACTIVE"
+        ):
             return
         
         ltp = bracket.last_ltp
@@ -1903,6 +1930,18 @@ class BracketManager:
             if not filled:
                 LOGGER.warning("EXIT_ORDER_NOT_FILLED order_id=%s fallback=market", order_id)
                 return self._market_fallback_exit(bracket, qty, exit_side, reason)
+            if not is_partial and not self._verify_position_closed(bracket.symbol):
+                LOGGER.warning(
+                    "EXIT_FILL_STATUS_BUT_POSITION_OPEN symbol=%s order_id=%s",
+                    bracket.symbol,
+                    order_id,
+                    extra={
+                        "event": "EXIT_FILL_STATUS_BUT_POSITION_OPEN",
+                        "symbol": bracket.symbol,
+                        "order_id": str(order_id),
+                    },
+                )
+                return self._market_fallback_exit(bracket, qty, exit_side, reason)
             
             # Metrics
             if METRICS_AVAILABLE and METRICS:
@@ -1912,7 +1951,14 @@ class BracketManager:
                     LOGGER.exception("Unhandled exception", exc_info=True)
                     raise
                 
-            return ExitExecutionResult(True, True, str(order_id), int(qty), reason, status="FILLED")
+            return ExitExecutionResult(
+                True,
+                True,
+                str(order_id),
+                int(qty),
+                reason,
+                status="FILLED",
+            )
 
         except Exception as e:
             LOGGER.critical(f"🛑 EXIT FAILED for {bracket.symbol}: {e}", exc_info=True)
@@ -2485,6 +2531,7 @@ class BracketManager:
         quantity: int,
         strategy: str = "auto",
         order_id: str | None = None,
+        confirmed_position: bool = False,
     ) -> str:
         """
         Create a virtual bracket with specified SL/TP levels.
@@ -2556,7 +2603,7 @@ class BracketManager:
             tp=take_profit,
             tag=strategy,
             trailing_atr_mult=1.5,  # Enable ATR-based trailing
-            activate_immediately=True,  # Start monitoring immediately
+            activate_immediately=confirmed_position,
         )
         
         LOGGER.info(

--- a/src/nifty_scalper_bot/execution/order_manager.py
+++ b/src/nifty_scalper_bot/execution/order_manager.py
@@ -11125,6 +11125,54 @@ class OrderManager:
                 f"Base: {base_price} | SL: {sl_price} | TP: {tp_price}",
                 extra={"event": "orphan_guarding", "symbol": symbol},
             )
+            broker_position_qty = 0
+            broker = getattr(self, "_broker", None)
+            get_positions = getattr(broker, "get_positions", None)
+            if callable(get_positions):
+                try:
+                    positions = get_positions() or []
+                    normalized_symbol = normalize_symbol(symbol)
+                    for position in positions:
+                        if not isinstance(position, Mapping):
+                            continue
+                        pos_symbol = normalize_symbol(
+                            str(
+                                position.get("symbol")
+                                or position.get("tradingsymbol")
+                                or ""
+                            )
+                        )
+                        if pos_symbol != normalized_symbol:
+                            continue
+                        broker_position_qty = int(
+                            float(
+                                position.get("quantity")
+                                or position.get("net_quantity")
+                                or 0
+                            )
+                        )
+                        break
+                except Exception as exc:  # noqa: BLE001
+                    self._logger.error(
+                        "Failure in orphan broker position verification: %s",
+                        exc,
+                        extra={
+                            "event": "orphan_broker_position_verify_error",
+                            "symbol": symbol,
+                        },
+                        exc_info=exc,
+                    )
+            if broker_position_qty <= 0:
+                self._logger.warning(
+                    "ORPHAN_BRACKET_SKIPPED symbol=%s reason=no_broker_position",
+                    symbol,
+                    extra={
+                        "event": "ORPHAN_BRACKET_SKIPPED",
+                        "symbol": symbol,
+                        "reason": "no_broker_position",
+                    },
+                )
+                return False
 
             # Register
             self._bracket_manager.register_virtual_bracket(
@@ -11137,6 +11185,18 @@ class OrderManager:
                 tp=tp_price,
                 tag=strategy_tag,
                 activate_immediately=True,
+            )
+            self._logger.info(
+                "ORPHAN_POSITION_BRACKET_ATTACHED symbol=%s qty=%s base_price=%s",
+                symbol,
+                abs_qty,
+                base_price,
+                extra={
+                    "event": "ORPHAN_POSITION_BRACKET_ATTACHED",
+                    "symbol": symbol,
+                    "qty": abs_qty,
+                    "base_price": base_price,
+                },
             )
 
             self._log_trade_event(

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -86,9 +86,10 @@ from nifty_scalper_bot.strategies.signal_quality import (
     missing_score_components,
     score_signal_quality,
 )
+from nifty_scalper_bot.strategies.trade_selector import TradeCandidateSelector
 from nifty_scalper_bot.utils import metrics
 from nifty_scalper_bot.utils.errors import OrderPlacementError
-from nifty_scalper_bot.utils.logging import LogThrottle, get_logger
+from nifty_scalper_bot.utils.logging import LogThrottle, get_logger, log_throttled
 from nifty_scalper_bot.utils.market_hours import (
     MarketState,
     allow_offhours_testing_safe,
@@ -114,40 +115,8 @@ LOGGER = get_logger(__name__)
 RELAX_REGIME_FILTER = (
     os.getenv("RELAX_REGIME_FILTER", "true").lower() != "false"
 )  # default True: regime starts with no snapshot
-_THROTTLE_CACHE: Dict[str, float] = {}
-_THROTTLE_LOCK = threading.Lock()
 MIN_EVAL_INTERVAL_SECONDS = 5.0
 _IST = ZoneInfo("Asia/Kolkata")
-
-
-def log_throttled(
-    logger: Any,
-    key: str,
-    msg: str,
-    interval_sec: float = 60.0,
-    level: int | str = logging.INFO,
-    extra: dict[str, Any] | None = None,
-) -> None:
-    """Log throttled message. Args: logger, key, msg. Returns: None. Raises: Exception."""
-    try:
-        with _THROTTLE_LOCK:
-            now = time.time()
-            last_time = _THROTTLE_CACHE.get(key, 0.0)
-            if now - last_time < interval_sec:
-                return
-            _THROTTLE_CACHE[key] = now
-
-        # Normalize log level (accept str or logging.* int)
-        if isinstance(level, int):
-            logger.log(level, msg, extra=extra or {})
-        else:
-            log_method = getattr(logger, str(level).lower(), logger.info)
-            if extra:
-                log_method(msg, extra=extra)
-            else:
-                log_method(msg)
-    except Exception as exc:  # noqa: BLE001
-        logger.error("Failure in log_throttled: %s", exc, exc_info=True)
 
 
 _STRATEGY_SKIP_COUNTER = Counter(
@@ -622,6 +591,7 @@ class StrategyRunner:
         self._execution_totals: Dict[str, Dict[str, int]] = defaultdict(
             lambda: {"success": 0, "error": 0}
         )
+        self._trade_candidate_selector = TradeCandidateSelector()
         self._trade_counter_by_symbol_candle: Dict[str, dict] = {}
         self._settings = get_settings()
         try:
@@ -6891,6 +6861,57 @@ class StrategyRunner:
                 self._premium_squeeze_last_signal_ts[underlying] = now_epoch
 
             metadata = dict(signal.metadata or {})
+            candidate_snapshots_obj = metadata.get("candidate_snapshots")
+            if isinstance(candidate_snapshots_obj, list):
+                direction_bias = "CE" if str(signal.action).upper() == "BUY" else "PE"
+                try:
+                    candidate = self._trade_candidate_selector.select_best_candidate(
+                        underlying=underlying,
+                        direction_bias=direction_bias,
+                        atm_strike=int(metadata.get("atm_strike") or 0),
+                        snapshots=[
+                            snap
+                            for snap in candidate_snapshots_obj
+                            if isinstance(snap, dict)
+                        ],
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    self._logger.error(
+                        "Failure in trade candidate selection: %s",
+                        exc,
+                        extra={
+                            "event": "candidate_selection_error",
+                            "symbol": base_symbol,
+                            "trace_id": trace_id,
+                        },
+                        exc_info=exc,
+                    )
+                    self._reset_execution_state(base_symbol)
+                    return SignalExecutionResult(False, "no_valid_candidate")
+                if candidate is None:
+                    self._reset_execution_state(base_symbol)
+                    return SignalExecutionResult(False, "no_valid_candidate")
+                if normalize_symbol(signal.symbol) != normalize_symbol(candidate.symbol):
+                    self._logger.info(
+                        "SIGNAL_EXECUTION_RESULT accepted=False reason=not_selected_candidate symbol=%s selected_symbol=%s trace_id=%s",
+                        signal.symbol,
+                        candidate.symbol,
+                        trace_id,
+                        extra={
+                            "event": "SIGNAL_EXECUTION_RESULT",
+                            "accepted": False,
+                            "reason": "not_selected_candidate",
+                            "symbol": signal.symbol,
+                            "selected_symbol": candidate.symbol,
+                            "trace_id": trace_id,
+                        },
+                    )
+                    self._reset_execution_state(base_symbol)
+                    return SignalExecutionResult(False, "not_selected_candidate")
+                metadata["option_score"] = candidate.score
+                metadata["data_score"] = candidate.data_quality_score
+                metadata["spread_pct"] = candidate.spread_pct
+                metadata["candidate_score"] = candidate.score
             missing_components = missing_score_components(metadata)
             mode = str(os.getenv("EXECUTION_MODE", "SHADOW")).strip().upper()
             is_live_mode = mode == "LIVE" or (
@@ -6898,6 +6919,11 @@ class StrategyRunner:
                 in {"1", "true", "yes", "on"}
             )
             if missing_components and is_live_mode:
+                if reason_key == "premium_momentum_squeeze":
+                    metadata["shadow_only"] = True
+                    metadata["missing_reason"] = (
+                        "premium_squeeze_score_components_not_implemented"
+                    )
                 self._logger.info(
                     "SIGNAL_SCORE_BLOCKED reason=missing_signal_score_components missing=%s trace_id=%s",
                     missing_components,

--- a/src/nifty_scalper_bot/strategies/trade_selector.py
+++ b/src/nifty_scalper_bot/strategies/trade_selector.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import os
+import logging
 from dataclasses import dataclass
 from typing import Any
 
-from nifty_scalper_bot.utils.logging import get_logger
+from nifty_scalper_bot.utils.logging import get_logger, log_throttled
 
 LOGGER = get_logger(__name__)
 
@@ -44,14 +46,19 @@ class TradeCandidateSelector:
         max_option_spread_pct: float = 0.05,
         min_option_premium: float = 20.0,
         max_option_premium: float = 400.0,
-        max_tick_age_s: float = 2.5,
+        max_tick_age_s: float | None = None,
         min_real_ticks_last_60s: int = 1,
     ) -> None:
         self.option_strike_window_each_side = max(1, int(option_strike_window_each_side))
         self.max_option_spread_pct = max(0.0, float(max_option_spread_pct))
         self.min_option_premium = max(0.0, float(min_option_premium))
         self.max_option_premium = max(self.min_option_premium, float(max_option_premium))
-        self.max_tick_age_s = max(0.0, float(max_tick_age_s))
+        configured_tick_age = (
+            float(os.getenv('MAX_OPTION_TICK_AGE_SECONDS', '10'))
+            if max_tick_age_s is None
+            else float(max_tick_age_s)
+        )
+        self.max_tick_age_s = max(0.0, configured_tick_age)
         self.min_real_ticks_last_60s = max(0, int(min_real_ticks_last_60s))
 
     def evaluate_data_quality(self, snapshot: dict[str, Any]) -> DataQualityResult:
@@ -104,7 +111,7 @@ class TradeCandidateSelector:
         }
         allowed = len(hard_blocks.intersection(reasons)) == 0
         score = max(0.0, min(10.0, score - 1.0 * len(hard_blocks.intersection(reasons))))
-        LOGGER.info(
+        LOGGER.debug(
             'DATA_QUALITY_CHECK symbol=%s allowed=%s score=%.2f reasons=%s',
             snapshot.get('symbol'),
             allowed,
@@ -113,10 +120,12 @@ class TradeCandidateSelector:
             extra={'event': 'DATA_QUALITY_CHECK', 'allowed': allowed, 'score': score, 'reasons': reasons},
         )
         if not allowed:
-            LOGGER.info(
-                'DATA_QUALITY_BLOCKED symbol=%s reasons=%s',
-                snapshot.get('symbol'),
-                reasons,
+            log_throttled(
+                LOGGER,
+                key=f"data_quality_blocked_{snapshot.get('symbol')}",
+                msg=f"DATA_QUALITY_BLOCKED symbol={snapshot.get('symbol')} reasons={reasons}",
+                level=logging.DEBUG,
+                interval_sec=60.0,
                 extra={'event': 'DATA_QUALITY_BLOCKED', 'reasons': reasons},
             )
         return DataQualityResult(allowed=allowed, score=score, reasons=reasons)
@@ -195,10 +204,12 @@ class TradeCandidateSelector:
 
     def _log_rejection(self, symbol: str, reason: str) -> None:
         """Args: symbol and reason. Returns: None. Raises: none."""
-        LOGGER.info(
-            'CANDIDATE_REJECTED symbol=%s reason=%s',
-            symbol,
-            reason,
+        log_throttled(
+            LOGGER,
+            key=f'candidate_rejected_{symbol}_{reason}',
+            msg=f'CANDIDATE_REJECTED symbol={symbol} reason={reason}',
+            interval_sec=60.0,
+            level=logging.DEBUG,
             extra={'event': 'CANDIDATE_REJECTED', 'symbol': symbol, 'reason': reason},
         )
 

--- a/src/nifty_scalper_bot/utils/logging.py
+++ b/src/nifty_scalper_bot/utils/logging.py
@@ -540,9 +540,10 @@ def log_throttled(
     key: str,
     msg: str,
     *,
+    interval_sec: float = 60.0,
     level: int = logging.INFO,
-    interval_sec: float | None = None,
     extra: Optional[dict[str, Any]] = None,
+    exc_info: bool | BaseException | None = None,
 ) -> None:
     """Emit a log record at most once during the specified interval."""
     logger.debug(
@@ -555,18 +556,14 @@ def log_throttled(
         },
     )
     try:
-        interval = (
-            _resolve_float("LOG_THROTTLE_DEFAULT_SEC", 5.0)
-            if interval_sec is None
-            else float(interval_sec)
-        )
+        interval = float(interval_sec)
         now = time.time()
         with _THROTTLE_LOCK:
             last_emit = _THROTTLE_STATE.get(key, 0.0)
             if now - last_emit < interval:
                 return
             _THROTTLE_STATE[key] = now
-        logger.log(level, msg, extra=extra or {})
+        logger.log(level, msg, extra=extra or {}, exc_info=exc_info)
     except Exception as exc:  # noqa: BLE001
         logger.error(
             "Failure in log_throttled: %s",

--- a/tests/core/test_app_health.py
+++ b/tests/core/test_app_health.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from nifty_scalper_bot.core import app as app_module
+
+
+class _Runner:
+    def get_status(self):
+        return {'running': False}
+
+
+def test_health_check_uses_shared_log_throttled(monkeypatch) -> None:
+    ctx = SimpleNamespace(
+        strategy_runner=_Runner(),
+        settings=SimpleNamespace(enable_live=False),
+        shadow_mode_enabled=False,
+    )
+    monkeypatch.setattr(app_module, 'get_market_state', lambda: app_module.MarketState.CLOSED)
+    app_module._health_check(ctx)
+
+
+@pytest.mark.asyncio
+async def test_stop_handles_failed_health_task() -> None:
+    app = object.__new__(app_module.NiftyScalperApp)
+    app._running = True
+    app._shutdown_event = asyncio.Event()
+    app._self_test_task = None
+    app._ctx = SimpleNamespace(telegram_application=None, telegram_bot=None)
+    app._telegram_application_started = False
+    app._telegram_task = None
+
+    async def _fail():
+        raise RuntimeError('health-fail')
+
+    app._health_task = asyncio.create_task(_fail())
+    await asyncio.sleep(0)
+
+    async def _shutdown(_ctx):
+        return None
+
+    original = app_module.shutdown_sequence
+    app_module.shutdown_sequence = _shutdown
+    try:
+        await app.stop()
+    finally:
+        app_module.shutdown_sequence = original
+
+    assert app._health_task is None

--- a/tests/execution/test_bracket_manager.py
+++ b/tests/execution/test_bracket_manager.py
@@ -69,6 +69,30 @@ class TestBracketManager:
         assert bracket.side == "BUY"
         assert bracket.sl_trigger_price == pytest.approx(95.0)
         assert bracket.tp_trigger_price == pytest.approx(110.0)
+        assert bracket.active is False
+        assert bracket.entry_confirmed is False
+        assert bracket.entry_status == "PENDING_ENTRY"
+
+    def test_create_bracket_confirmed_position_activates_immediately(self) -> None:
+        """create_bracket should activate only when confirmed_position is true."""
+        broker = Mock()
+        manager = BracketManager(broker_client=broker)
+
+        order_id = manager.create_bracket(
+            symbol="NIFTYTEST",
+            side="LONG",
+            entry_price=100.0,
+            stop_loss=95.0,
+            take_profit=110.0,
+            quantity=1,
+            strategy="unit_test",
+            confirmed_position=True,
+        )
+        bracket = manager.get_bracket(order_id)
+        assert bracket is not None
+        assert bracket.active is True
+        assert bracket.entry_confirmed is True
+        assert bracket.entry_status == "ACTIVE"
 
     @pytest.mark.flaky(reruns=1)
     def test_race_between_stop_and_target_is_serialised(self) -> None:

--- a/tests/strategies/test_trade_selector.py
+++ b/tests/strategies/test_trade_selector.py
@@ -67,3 +67,9 @@ def test_selector_rejects_wide_spread_invalid_bid_ask_and_stale() -> None:
         )
         is None
     )
+
+
+def test_selector_default_tick_age_from_env(monkeypatch) -> None:
+    monkeypatch.delenv('MAX_OPTION_TICK_AGE_SECONDS', raising=False)
+    selector = TradeCandidateSelector()
+    assert selector.max_tick_age_s == 10.0

--- a/tests/utils/test_logging_helpers.py
+++ b/tests/utils/test_logging_helpers.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import logging
+
+from nifty_scalper_bot.utils.logging import log_throttled
+
+
+def test_log_throttled_accepts_extra_and_exc_info(caplog) -> None:
+    logger = logging.getLogger('tests.log_throttled')
+    with caplog.at_level(logging.ERROR):
+        log_throttled(
+            logger,
+            key='test_log_throttle_exc',
+            msg='throttle message',
+            interval_sec=0.0,
+            level=logging.ERROR,
+            extra={'event': 'throttle_test', 'trace_id': 'abc'},
+            exc_info=False,
+        )
+    assert any('throttle message' in record.message for record in caplog.records)


### PR DESCRIPTION
### Motivation
- Resolve a production crash where `_health_check()` called a locally-defined `log_throttled` (NameError) causing the health task to fail and shutdown to re-raise the error.
- Prevent single health-check/logging faults from terminating the whole application and make shutdown resilient to previously-failed background tasks.
- Close execution-safety regressions that allowed SL/TP/trailing logic to fire for pending/unconfirmed virtual brackets and that activated brackets immediately without broker confirmation.
- Reduce candidate-selection brittleness by making tick-age configurable and reducing INFO log spam for routine candidate rejections.

### Description
- Imported and standardized the shared `log_throttled` helper at module scope and extended its signature in `src/nifty_scalper_bot/utils/logging.py` to accept `interval_sec`, `level`, `extra`, and `exc_info` so all callers (including `_health_check`) use the single, compatible implementation.
- Hardened lifecycle handling in `src/nifty_scalper_bot/core/app.py` by catching exceptions from `_health_check` inside `_health_loop`, logging `health_loop_error` and continuing, and by making `stop()` cancel/await background tasks with safe exception handling and warnings instead of re-raising.
- Tightened virtual-bracket safety in `src/nifty_scalper_bot/execution/bracket_manager.py` by requiring `bracket.active and bracket.entry_confirmed and bracket.entry_status == "ACTIVE"` before watchdog/_fire_exits_batch/ trailing updates; changed `create_bracket()` default to `confirmed_position=False`; added verification in `_execute_exit()` that a final fill truly closed the broker position and preserved single-point quantity mutation after confirmed fills.
- Added guard in `src/nifty_scalper_bot/execution/order_manager.py` orphan-attach path to verify broker position quantity before registering an active bracket and emit `ORPHAN_BRACKET_SKIPPED` when none is found.
- Integrated `TradeCandidateSelector` into `src/nifty_scalper_bot/strategies/runner.py` and applied gating when `signal.metadata["candidate_snapshots"]` is present, enriching metadata with candidate scores and returning clear `no_valid_candidate` / `not_selected_candidate` outcomes; updated `src/nifty_scalper_bot/strategies/trade_selector.py` to use environment `MAX_OPTION_TICK_AGE_SECONDS` (default 10s) and throttle/downgrade noisy rejection logs via `log_throttled`.
- Kept all changes surgical and safety-first: no removal of risk logic, no new dependencies, and public signatures preserved where possible.

### Testing
- `python -m compileall src` — passed successfully.
- Targeted pytest runs: `pytest -q tests/core/test_app_health.py tests/strategies/test_trade_selector.py tests/utils/test_logging_helpers.py` — all passed.
- Bracket create tests: `pytest -q tests/execution/test_bracket_manager.py -k "create_bracket"` — passed.
- Full test run `pytest -q` — failed due to a pre-existing, unrelated test import error (`ImportError: cannot import name 'InstrumentResolver' from 'nifty_scalper_bot.data'`) and not caused by these changes.
- Grep/verifications executed to ensure single shared `log_throttled` is used and to review occurrences of `activate_immediately`, quantity mutation, and other safety-relevant patterns; notable occurrences adjusted or justified in-code.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee4c988c10832497979ccc29dd6d06)