### PR TITLE
fix: stabilize strategy signal scoring and live candidate gating

### DIFF
--- a/src/nifty_scalper_bot/core/strategy_manager.py
+++ b/src/nifty_scalper_bot/core/strategy_manager.py
@@ -21,6 +21,7 @@ from nifty_scalper_bot.core.market_regime import RegimeSnapshot
 from nifty_scalper_bot.core.market_regime_manager import MarketRegimeManager
 from nifty_scalper_bot.infra.metrics import METRICS
 from nifty_scalper_bot.strategies.elite_strategies.base_elite import EliteStrategy
+from nifty_scalper_bot.strategies.signal_quality import infer_option_side
 from nifty_scalper_bot.strategies.signal_generator import (
     Signal,
 )
@@ -269,6 +270,37 @@ class StrategyAdapter(StrategyInterface):
 
 
 StrategyFactory = t.Callable[..., StrategyInterface | t.Any]
+
+
+@dataclass(slots=True)
+class StrategyVote:
+    """Args: strategy vote fields. Returns: structured vote. Raises: none."""
+
+    strategy: str
+    side: str
+    score: float
+    confidence: float
+    reasons: list[str]
+    metadata: dict[str, t.Any]
+
+
+def signal_to_vote(signal: Signal, strategy_name: str) -> StrategyVote:
+    """Args: signal + strategy name. Returns: normalized vote. Raises: none."""
+    metadata = dict(signal.metadata or {})
+    side = infer_option_side(signal.symbol, metadata)
+    score_candidate = float(metadata.get('strategy_score') or 0.0)
+    score = float(signal.confidence or 0.0) * 10.0
+    if score <= 0.0:
+        score = score_candidate
+    reason = str(signal.reason or '').strip()
+    return StrategyVote(
+        strategy=strategy_name,
+        side=side if side in {'CE', 'PE'} else 'UNKNOWN',
+        score=max(0.0, min(10.0, score)),
+        confidence=max(0.0, min(1.0, float(signal.confidence or 0.0))),
+        reasons=[reason] if reason else [],
+        metadata=metadata,
+    )
 
 
 @dataclass(slots=True)
@@ -2105,6 +2137,7 @@ class StrategyManager(_BaseStrategyManager):
         position = self._position_manager.get_position(symbol)
 
         signals: list[Signal] = []
+        signal_votes: list[tuple[Signal, StrategyVote]] = []
         max_votes = max(1, int(getattr(app_settings, "MAX_STRATEGY_VOTES", 5)))
         disabled: list[str] = []
         empty: list[str] = []
@@ -2145,6 +2178,7 @@ class StrategyManager(_BaseStrategyManager):
                 base_signal, strategy.name, entry
             )
             signals.append(adjusted)
+            signal_votes.append((adjusted, signal_to_vote(adjusted, strategy.name)))
             if len(signals) >= max_votes:
                 break
 
@@ -2212,7 +2246,11 @@ class StrategyManager(_BaseStrategyManager):
             _emit_strategy_exit()
             return None
 
-        combined = self._combine_signals(signals)
+        combined = self._combine_strategy_votes(
+            symbol=symbol,
+            signals=signal_votes,
+            indicators=indicators,
+        )
         if combined and bool(getattr(combined, "metadata", {}).get("is_approved")):
             exit_result = "signal"
             signal_action = combined.action
@@ -2364,6 +2402,82 @@ class StrategyManager(_BaseStrategyManager):
                     ).sharpe_ratio()
                 ),
             },
+        )
+
+    def _combine_strategy_votes(
+        self,
+        *,
+        symbol: str,
+        signals: list[tuple[Signal, StrategyVote]],
+        indicators: t.Mapping[str, t.Any],
+    ) -> Signal | None:
+        """Args: symbol/signals/indicators. Returns: consensus signal or None. Raises: none."""
+        if not signals:
+            return None
+        if len(signals) == 1:
+            return signals[0][0]
+        by_side: dict[str, list[tuple[Signal, StrategyVote]]] = {
+            'CE': [],
+            'PE': [],
+            'UNKNOWN': [],
+        }
+        for signal, vote in signals:
+            if signal.action in {'CLOSE_LONG', 'CLOSE_SHORT'}:
+                return signal
+            by_side.setdefault(vote.side, []).append((signal, vote))
+        ce_votes = by_side.get('CE', [])
+        pe_votes = by_side.get('PE', [])
+        conflict = bool(ce_votes and pe_votes)
+        if conflict:
+            log.info(
+                'STRATEGY_CONSENSUS side=NO_TRADE score=0.00 votes=%s conflict=True',
+                len(ce_votes) + len(pe_votes),
+                extra={'event': 'STRATEGY_CONSENSUS', 'side': 'NO_TRADE', 'score': 0.0, 'votes': len(ce_votes) + len(pe_votes), 'conflict': True},
+            )
+            return None
+        winning_side = 'CE' if len(ce_votes) >= len(pe_votes) else 'PE'
+        winning = ce_votes if winning_side == 'CE' else pe_votes
+        if not winning:
+            return self._combine_signals([signal for signal, _ in signals])
+        direction_score = float(indicators.get('direction_score') or 0.0)
+        data_score = float(indicators.get('data_score') or 0.0)
+        option_score = float(indicators.get('option_score') or 0.0)
+        high_conviction = max(vote.score for _, vote in winning) >= 8.5
+        enough_confirmations = len(winning) >= 2 or (
+            high_conviction
+            and direction_score >= 7.5
+            and data_score >= 7.0
+            and option_score >= 7.0
+        )
+        if not enough_confirmations:
+            log.info(
+                'STRATEGY_CONSENSUS side=NO_TRADE score=0.00 votes=%s conflict=False',
+                len(winning),
+                extra={'event': 'STRATEGY_CONSENSUS', 'side': 'NO_TRADE', 'score': 0.0, 'votes': len(winning), 'conflict': False},
+            )
+            return None
+        best_signal, _ = max(winning, key=lambda pair: pair[1].score)
+        strategy_score = sum(vote.score for _, vote in winning) / max(len(winning), 1)
+        metadata = dict(best_signal.metadata or {})
+        metadata['strategy_score'] = round(max(float(metadata.get('strategy_score') or 0.0), strategy_score), 3)
+        metadata['confirming_votes'] = [vote.strategy for _, vote in winning]
+        metadata['direction_bias'] = winning_side
+        log.info(
+            'STRATEGY_CONSENSUS side=%s score=%.2f votes=%s conflict=False',
+            winning_side,
+            strategy_score,
+            len(winning),
+            extra={'event': 'STRATEGY_CONSENSUS', 'side': winning_side, 'score': strategy_score, 'votes': len(winning), 'conflict': False},
+        )
+        return Signal(
+            action='BUY',
+            symbol=best_signal.symbol,
+            quantity=best_signal.quantity,
+            confidence=best_signal.confidence,
+            reason=best_signal.reason,
+            stop_loss=best_signal.stop_loss,
+            take_profit=best_signal.take_profit,
+            metadata=metadata,
         )
 
     def increment_observability_counter(self, key: str) -> None:

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -83,6 +83,7 @@ from nifty_scalper_bot.strategies.market_regime_engine import (
 )
 from nifty_scalper_bot.strategies.signal_generator import Signal
 from nifty_scalper_bot.strategies.signal_quality import (
+    infer_option_side,
     missing_score_components,
     score_signal_quality,
 )
@@ -4535,6 +4536,45 @@ class StrategyRunner:
             except Exception:  # pragma: no cover - defensive
                 pass
 
+    def _strategy_evaluation_allowed(
+        self, symbol: str, trace_id: str | None = None
+    ) -> bool:
+        """Args: symbol + trace_id. Returns: bool gate verdict. Raises: none."""
+        try:
+            if symbol not in self._active_symbols:
+                self._emit_runner_eval_decision(
+                    symbol=symbol,
+                    stage='phase9',
+                    reason='symbol_not_active',
+                    allowed=False,
+                    trace_id=trace_id,
+                )
+                return False
+            if not self._indicator_engine.has_min_bars(symbol, self._required_candles):
+                self._emit_runner_eval_decision(
+                    symbol=symbol,
+                    stage='phase9',
+                    reason='insufficient_indicator_bars',
+                    allowed=False,
+                    trace_id=trace_id,
+                )
+                return False
+            return True
+        except Exception as exc:  # noqa: BLE001
+            self._logger.error(
+                'Failure in StrategyRunner._strategy_evaluation_allowed: %s',
+                exc,
+                exc_info=exc,
+            )
+            self._emit_runner_eval_decision(
+                symbol=symbol,
+                stage='phase9',
+                reason='strategy_eval_gate_exception',
+                allowed=False,
+                trace_id=trace_id,
+            )
+            return False
+
     def _mark_symbol_unready(
         self,
         symbol: str,
@@ -5329,8 +5369,6 @@ class StrategyRunner:
                         symbol, SymbolState.DISCOVERED
                     )
 
-                # ── Hydration-state gate ─────────────────────────────────────────────
-                # 🚨 ALL PHASE 7 GATES REMOVED: Bypassing Hydration, Bar-Count, and Pipeline checks.
                 min_bars_needed = self._required_candles or 20
                 
 
@@ -5820,6 +5858,8 @@ class StrategyRunner:
                         should_evaluate = True
 
                 if should_evaluate:
+                    if not self._strategy_evaluation_allowed(symbol, trace_id):
+                        return
                     log_throttled(
                         self._logger,
                         f"strategy_evaluation_triggered:{symbol}",
@@ -6935,13 +6975,36 @@ class StrategyRunner:
                 self._premium_squeeze_last_signal_ts[underlying] = now_epoch
 
             metadata = dict(signal.metadata or {})
+            mode = str(os.getenv("EXECUTION_MODE", "SHADOW")).strip().upper()
+            is_live_mode = mode == "LIVE" or (
+                str(os.getenv("ENABLE_LIVE", "false")).strip().lower()
+                in {"1", "true", "yes", "on"}
+            )
+            option_side = infer_option_side(signal.symbol, metadata)
+            if is_live_mode and option_side == "UNKNOWN":
+                self._reset_execution_state(base_symbol)
+                return SignalExecutionResult(False, "unknown_option_side")
             candidate_snapshots_obj = metadata.get("candidate_snapshots")
+            is_directional_option = option_side in {"CE", "PE"}
+            if is_live_mode and is_directional_option and not isinstance(
+                candidate_snapshots_obj, list
+            ):
+                atm_strike = int(metadata.get("atm_strike") or 0)
+                built = self.build_candidate_snapshots(
+                    direction_bias=cast(Literal["CE", "PE"], option_side),
+                    atm_strike=atm_strike,
+                    underlying=underlying,
+                )
+                metadata["candidate_snapshots"] = built
+                candidate_snapshots_obj = built
+            if is_live_mode and is_directional_option and not candidate_snapshots_obj:
+                self._reset_execution_state(base_symbol)
+                return SignalExecutionResult(False, "missing_candidate_snapshots")
             if isinstance(candidate_snapshots_obj, list):
-                direction_bias = "CE" if str(signal.action).upper() == "BUY" else "PE"
                 try:
                     candidate = self._trade_candidate_selector.select_best_candidate(
                         underlying=underlying,
-                        direction_bias=direction_bias,
+                        direction_bias=option_side,
                         atm_strike=int(metadata.get("atm_strike") or 0),
                         snapshots=[
                             snap
@@ -6987,11 +7050,6 @@ class StrategyRunner:
                 metadata["spread_pct"] = candidate.spread_pct
                 metadata["candidate_score"] = candidate.score
             missing_components = missing_score_components(metadata)
-            mode = str(os.getenv("EXECUTION_MODE", "SHADOW")).strip().upper()
-            is_live_mode = mode == "LIVE" or (
-                str(os.getenv("ENABLE_LIVE", "false")).strip().lower()
-                in {"1", "true", "yes", "on"}
-            )
             if missing_components and is_live_mode:
                 if reason_key == "premium_momentum_squeeze":
                     metadata["shadow_only"] = True

--- a/src/nifty_scalper_bot/strategies/signal_quality.py
+++ b/src/nifty_scalper_bot/strategies/signal_quality.py
@@ -14,6 +14,17 @@ REQUIRED_SCORE_COMPONENTS: tuple[str, ...] = (
 )
 
 
+def infer_option_side(symbol: str, metadata: dict[str, object] | None = None) -> str:
+    """Args: symbol + metadata. Returns: CE/PE/UNKNOWN side. Raises: none."""
+    upper = str(symbol or '').upper()
+    if upper.endswith('CE'):
+        return 'CE'
+    if upper.endswith('PE'):
+        return 'PE'
+    payload = dict(metadata or {})
+    return str(payload.get('direction_bias', 'UNKNOWN')).upper()
+
+
 @dataclass(slots=True)
 class SignalQualityScore:
     """Args: score components. Returns: normalized score object. Raises: none."""

--- a/src/nifty_scalper_bot/strategies/trade_selector.py
+++ b/src/nifty_scalper_bot/strategies/trade_selector.py
@@ -48,6 +48,7 @@ class TradeCandidateSelector:
         max_option_premium: float = 400.0,
         max_tick_age_s: float | None = None,
         min_real_ticks_last_60s: int = 1,
+        require_real_ticks_last_60s: bool | None = None,
     ) -> None:
         self.option_strike_window_each_side = max(1, int(option_strike_window_each_side))
         self.max_option_spread_pct = max(0.0, float(max_option_spread_pct))
@@ -60,6 +61,14 @@ class TradeCandidateSelector:
         )
         self.max_tick_age_s = max(0.0, configured_tick_age)
         self.min_real_ticks_last_60s = max(0, int(min_real_ticks_last_60s))
+        configured_require_real_ticks = (
+            os.getenv('REQUIRE_REAL_TICKS_LAST_60S', 'false').strip().lower()
+            in {'1', 'true', 'yes', 'on'}
+        )
+        if require_real_ticks_last_60s is None:
+            self.require_real_ticks_last_60s = configured_require_real_ticks
+        else:
+            self.require_real_ticks_last_60s = bool(require_real_ticks_last_60s)
 
     def evaluate_data_quality(self, snapshot: dict[str, Any]) -> DataQualityResult:
         """Args: snapshot dict. Returns: DataQualityResult. Raises: none."""
@@ -83,6 +92,10 @@ class TradeCandidateSelector:
         real_ticks_60s = int(snapshot.get('real_ticks_last_60s') or 0)
         if real_ticks_60s < self.min_real_ticks_last_60s:
             reasons.append('no_recent_real_tick')
+            if self.require_real_ticks_last_60s:
+                score -= 2.0
+            else:
+                score -= 0.75
 
         bid = self._to_float(snapshot.get('bid'))
         ask = self._to_float(snapshot.get('ask'))
@@ -105,10 +118,11 @@ class TradeCandidateSelector:
             'stale_tick',
             'invalid_ohlc',
             'absurd_ltp_jump',
-            'no_recent_real_tick',
             'invalid_bid_ask',
             'spread_too_wide',
         }
+        if self.require_real_ticks_last_60s:
+            hard_blocks.add('no_recent_real_tick')
         allowed = len(hard_blocks.intersection(reasons)) == 0
         score = max(0.0, min(10.0, score - 1.0 * len(hard_blocks.intersection(reasons))))
         LOGGER.debug(

--- a/tests/core/test_strategy_manager_scoring.py
+++ b/tests/core/test_strategy_manager_scoring.py
@@ -152,6 +152,38 @@ class _SignalStrategy(_DummyStrategy):
         )
 
 
+class _FixedSymbolSignalStrategy(_DummyStrategy):
+    """Strategy stub returning a BUY signal for a fixed option symbol side."""
+
+    def __init__(self, name: str, option_symbol: str, confidence: float = 0.8) -> None:
+        super().__init__(name)
+        self._option_symbol = option_symbol
+        self._confidence = confidence
+
+    def generate_signal(
+        self,
+        symbol: str,
+        indicators: t.Mapping[str, t.Any],
+        current_price: float,
+        position: t.Any,
+    ) -> Signal | None:
+        return Signal(
+            action='BUY',
+            symbol=self._option_symbol,
+            quantity=1,
+            confidence=self._confidence,
+            reason='vote',
+            stop_loss=current_price - 1,
+            take_profit=current_price + 2,
+            metadata={
+                'direction_score': 8.0,
+                'data_score': 8.0,
+                'option_score': 8.0,
+                'strategy_score': 8.0,
+            },
+        )
+
+
 class _BlockedRegimeManager:
     def can_trade(self, context: t.Mapping[str, t.Any] | None = None) -> bool:
         return False
@@ -193,3 +225,32 @@ def test_regime_block_can_still_block_when_adaptive_disabled(
     signal = manager.generate_signal('NFO:NIFTY26FEB22500CE', 100.0)
 
     assert signal is None
+
+
+def test_strategy_manager_conflicting_ce_pe_votes_return_no_trade() -> None:
+    manager = StrategyManager(
+        [
+            _FixedSymbolSignalStrategy('Alpha', 'NFO:NIFTY26FEB22500CE', 0.82),
+            _FixedSymbolSignalStrategy('Beta', 'NFO:NIFTY26FEB22500PE', 0.84),
+        ],
+        _DummyIndicatorEngine(),
+        _DummyPositionManager(),
+    )
+
+    signal = manager.generate_signal('NFO:NIFTY26FEB22500CE', 100.0)
+    assert signal is None
+
+
+def test_strategy_manager_same_side_votes_increase_strategy_score() -> None:
+    manager = StrategyManager(
+        [
+            _FixedSymbolSignalStrategy('Alpha', 'NFO:NIFTY26FEB22500CE', 0.82),
+            _FixedSymbolSignalStrategy('Beta', 'NFO:NIFTY26FEB22500CE', 0.86),
+        ],
+        _DummyIndicatorEngine(),
+        _DummyPositionManager(),
+    )
+
+    signal = manager.generate_signal('NFO:NIFTY26FEB22500CE', 100.0)
+    assert signal is not None
+    assert float(signal.metadata.get('strategy_score') or 0.0) > 8.0

--- a/tests/strategies/test_runner_live_path_guards.py
+++ b/tests/strategies/test_runner_live_path_guards.py
@@ -55,6 +55,8 @@ def _build_runner() -> StrategyRunner:
     runner._max_order_attempts_per_minute = 100
     runner._record_trade = lambda *args, **kwargs: None
     runner._entry_lock = threading.Lock()
+    runner._trade_candidate_selector = MagicMock()
+    runner.build_candidate_snapshots = MagicMock(return_value=[])
     return runner
 
 
@@ -182,6 +184,66 @@ def test_missing_score_components_block_live_mode(monkeypatch) -> None:
     )
     assert result.accepted is False
     assert result.reason == 'missing_signal_score_components'
+
+
+def test_live_unknown_option_side_is_blocked(monkeypatch) -> None:
+    runner = _build_runner()
+    monkeypatch.setenv('EXECUTION_MODE', 'LIVE')
+    signal = Signal(
+        action='BUY',
+        symbol='NSE:NIFTY',
+        quantity=1,
+        confidence=0.7,
+        reason='test',
+        stop_loss=100.0,
+        take_profit=120.0,
+        metadata={
+            'direction_score': 8.0,
+            'strategy_score': 8.0,
+            'option_score': 8.0,
+            'data_score': 8.0,
+            'rr_score': 8.0,
+        },
+    )
+    result = runner._handle_entry_signal_inner(
+        signal,
+        base_symbol='NSE:NIFTY',
+        trade_symbol='NSE:NIFTY',
+        trade_price=110.0,
+        timestamp=datetime.now(timezone.utc),
+        trace_id='unknown-side',
+    )
+    assert result.accepted is False
+    assert result.reason == 'unknown_option_side'
+
+
+def test_live_option_requires_candidate_snapshots(monkeypatch) -> None:
+    runner = _build_runner()
+    monkeypatch.setenv('EXECUTION_MODE', 'LIVE')
+    signal = Signal(
+        action='BUY',
+        symbol='NFO:NIFTY26APR23800PE',
+        quantity=1,
+        confidence=0.7,
+        reason='test',
+        stop_loss=100.0,
+        take_profit=120.0,
+        metadata={
+            'direction_score': 8.0,
+            'strategy_score': 8.0,
+            'rr_score': 8.0,
+        },
+    )
+    result = runner._handle_entry_signal_inner(
+        signal,
+        base_symbol='NFO:NIFTY26APR23800PE',
+        trade_symbol='NFO:NIFTY26APR23800PE',
+        trade_price=110.0,
+        timestamp=datetime.now(timezone.utc),
+        trace_id='missing-candidates',
+    )
+    assert result.accepted is False
+    assert result.reason == 'missing_candidate_snapshots'
 
 
 def test_final_confidence_is_derived_from_final_score(monkeypatch) -> None:

--- a/tests/strategies/test_signal_quality.py
+++ b/tests/strategies/test_signal_quality.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from nifty_scalper_bot.strategies.signal_quality import score_signal_quality
+from nifty_scalper_bot.strategies.signal_quality import infer_option_side, score_signal_quality
 
 
 def test_signal_quality_weighted_score_and_confidence_model(monkeypatch) -> None:
@@ -29,3 +29,12 @@ def test_signal_quality_live_threshold_blocks_low_score(monkeypatch) -> None:
     )
     assert result.allowed is False
     assert 'score_below_threshold' in result.reasons
+
+
+def test_infer_option_side_detects_ce_and_pe() -> None:
+    assert infer_option_side('NFO:NIFTY26APR23800PE', {}) == 'PE'
+    assert infer_option_side('NFO:NIFTY26APR23800CE', {}) == 'CE'
+
+
+def test_infer_option_side_unknown_uses_metadata() -> None:
+    assert infer_option_side('NSE:NIFTY', {'direction_bias': 'PE'}) == 'PE'

--- a/tests/strategies/test_trade_selector.py
+++ b/tests/strategies/test_trade_selector.py
@@ -73,3 +73,21 @@ def test_selector_default_tick_age_from_env(monkeypatch) -> None:
     monkeypatch.delenv('MAX_OPTION_TICK_AGE_SECONDS', raising=False)
     selector = TradeCandidateSelector()
     assert selector.max_tick_age_s == 10.0
+
+
+def test_no_recent_real_tick_is_penalty_when_soft_mode() -> None:
+    selector = TradeCandidateSelector(require_real_ticks_last_60s=False)
+    quality = selector.evaluate_data_quality(
+        _snapshot('NFO:NIFTY23500CE', 23500, real_ticks_last_60s=0)
+    )
+    assert quality.allowed is True
+    assert quality.score < 10.0
+
+
+def test_no_recent_real_tick_is_block_when_strict_mode() -> None:
+    selector = TradeCandidateSelector(require_real_ticks_last_60s=True)
+    quality = selector.evaluate_data_quality(
+        _snapshot('NFO:NIFTY23500CE', 23500, real_ticks_last_60s=0)
+    )
+    assert quality.allowed is False
+    assert 'no_recent_real_tick' in quality.reasons


### PR DESCRIPTION
### Motivation
- Prevent noisy or overconfident LIVE executions by enforcing complete score components and strict directional/candidate gating. 
- Avoid executing on stale/provisional/synthetic data or with mismatched option side inference. 
- Provide a simple, robust vote/consensus flow so multiple strategy signals combine deterministically for CE/PE option decisions.

### Description
- Add `infer_option_side(symbol, metadata)` to derive CE/PE/UNKNOWN from the symbol (fallback to metadata) and block UNKNOWN in LIVE flows. (src/nifty_scalper_bot/strategies/signal_quality.py, runner changes)
- Enforce mandatory score components and candidate gating in the runner: build candidate snapshots when missing, block LIVE when snapshots remain missing, run `TradeCandidateSelector` and reject non-selected symbols, and map candidate scores into signal metadata. Final signal confidence is set to `final_score / 10.0` (no hardcoded confidences). (src/nifty_scalper_bot/strategies/runner.py)
- Add `_strategy_evaluation_allowed(...)` gate and wire indicator/hydration readiness checks before strategy evaluation to prevent unsafe bypasses and same-bar evaluation issues. (src/nifty_scalper_bot/strategies/runner.py)
- Tune `TradeCandidateSelector` data-quality rules: default `MAX_OPTION_TICK_AGE_SECONDS=10`, `REQUIRE_REAL_TICKS_LAST_60S` defaults to false, treat missing recent real ticks as a soft penalty when false and as a hard block when true. (src/nifty_scalper_bot/strategies/trade_selector.py)
- Introduce simple strategy vote model and consensus in `StrategyManager`: `StrategyVote` dataclass, `signal_to_vote` adapter, gather up to configured votes, detect CE/PE conflicts (no-trade), and boost/propagate same-side confirmations into `strategy_score`. (src/nifty_scalper_bot/core/strategy_manager.py)
- Tests: add focused unit tests covering option-side inference, trade-selector recent-tick behavior, live-side/candidate snapshot blocking, and CE/PE vote conflicts/confirmations. (tests/…)

### Testing
- Ran `./run_checks.sh`; it bootstrapped the virtualenv and installed dependencies but required manual install of `pytest` in the created environment during the run (see logs); environment was prepared for test runs. 
- Verified byte-compilation with `python -m compileall src` which completed successfully. 
- Ran targeted pytest subset and they all passed: `tests/strategies/test_signal_quality.py`, `tests/strategies/test_trade_selector.py`, `tests/strategies/test_runner_live_path_guards.py`, `tests/core/test_strategy_manager_scoring.py` (all green). 
- Full `pytest -q` still stops early on a pre-existing import issue outside the changed areas (`ImportError: cannot import name 'InstrumentResolver' from 'nifty_scalper_bot.data'`) which is unrelated to these changes; grep scans confirmed removal of the previously unsafe defaults and hardcoded confidence patterns in the updated files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eeeb3e50948324b3f44dabc0714993)