### PR TITLE
Fix market-data fallback ownership, quote quality, and live strategy gating

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -3629,6 +3629,7 @@ def initialize_components(settings: Settings | None = None) -> BotContext:
             warn_on_rate_limit=poll_warn_rate_limit,
         )
         market_data_manager.disable_rest_polling(reason="polling_streamer_fallback")
+        market_data_manager.set_polling_fallback_streamer(polling_fallback_streamer)
         polling_fallback_streamer.set_websocket_mode(True)
 
         def _activate_polling_fallback() -> None:
@@ -6546,7 +6547,16 @@ async def startup_sequence(ctx: BotContext) -> None:
                         recovered_since: float | None = None
                         activate_after = 3.0
                         recover_cooldown = 10.0
-                        quote_stale_ms = 5000
+                        fallback_stale_sec = max(
+                            1.0,
+                            float(
+                                os.getenv(
+                                    "POLLING_SUPERVISOR_INDEX_STALE_SECONDS", "120"
+                                )
+                                or 120.0
+                            ),
+                        )
+                        quote_stale_ms = int(fallback_stale_sec * 1000.0)
                         while True:
                             try:
                                 ws_ok = bool(ctx.websocket_manager.is_connected())
@@ -6574,12 +6584,23 @@ async def startup_sequence(ctx: BotContext) -> None:
                                         now_mono - degraded_since >= activate_after
                                         and not polling_fallback.is_running()
                                     ):
+                                        if (
+                                            spot_age_ms is not None
+                                            and float(spot_age_ms) <= float(quote_stale_ms)
+                                            and ws_ok
+                                        ):
+                                            LOGGER.info(
+                                                "POLLING_FALLBACK_SKIPPED reason=within_spot_stale_threshold age_ms=%s",
+                                                spot_age_ms,
+                                            )
+                                            await asyncio.sleep(1.0)
+                                            continue
                                         LOGGER.warning(
-                                            "Polling fallback activate (supervisor) ws_ok=%s stale=%s lagging=%s spot_quote_age_ms=%s",
-                                            ws_ok,
-                                            not bool(feed_health.get("trading_feed_healthy")),
-                                            lagging,
+                                            "POLLING_FALLBACK_ACTIVATE reason=spot_stale age_ms=%s threshold_ms=%s ws_ok=%s lagging=%s",
                                             spot_age_ms,
+                                            quote_stale_ms,
+                                            ws_ok,
+                                            lagging,
                                             extra={
                                                 "event": "poll_fallback_activate",
                                                 "reason": (

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -85,6 +85,21 @@ class MarketSnapshot:
     latest_candle_synthetic: bool
     ohlc_valid: bool
     depth_available: bool = False
+    bid_missing: bool = False
+    ask_missing: bool = False
+    bid_ask_source: str = "missing"
+    tradable_quote: bool = False
+
+
+@dataclass(slots=True)
+class ResolvedInstrument:
+    """Resolved instrument details. Args: symbol. Returns: normalized payload. Raises: none."""
+
+    canonical_symbol: str
+    broker_symbol: str
+    instrument_token: int | None
+    exchange: str
+    tradingsymbol: str
 
 
 def canonical_symbol(symbol: str) -> str:
@@ -335,6 +350,7 @@ class MarketDataManager:
         self._zombie_restart_consecutive = 0
         self._zombie_stale_logged = False
         self._rest_refresh_inflight: set[str] = set()
+        self._polling_fallback_streamer: Any | None = None
         self._tick_stale_threshold_ms = self._parse_int_env(
             "TICK_STALE_MS", default=2_000, minimum=0
         )
@@ -1245,6 +1261,53 @@ class MarketDataManager:
             )
         return value
 
+    def _resolve_instrument(self, symbol: str) -> ResolvedInstrument:
+        """Resolve canonical and broker symbols. Args: symbol; Returns: resolved instrument; Raises: none."""
+        canonical_value = self._canonical_symbol(symbol)
+        exchange, tradingsymbol = canonical_value.split(":", 1)
+        broker_symbol = canonical_value
+        token = self._symbol_to_token.get(canonical_value) or self._token_by_symbol.get(
+            canonical_value
+        )
+        resolver = getattr(self, "_resolver", None)
+        if resolver is not None and hasattr(resolver, "resolve_symbol"):
+            try:
+                resolved = resolver.resolve_symbol(canonical_value)
+                if resolved:
+                    broker_symbol = str(
+                        resolved.get("broker_symbol")
+                        or resolved.get("exchange_symbol")
+                        or f"{resolved.get('exchange', exchange)}:{resolved.get('tradingsymbol', tradingsymbol)}"
+                    )
+                    token = int(
+                        resolved.get("instrument_token")
+                        or resolved.get("token")
+                        or token
+                        or 0
+                    ) or None
+                    exchange = str(resolved.get("exchange") or exchange)
+                    tradingsymbol = str(resolved.get("tradingsymbol") or tradingsymbol)
+            except Exception as exc:  # noqa: BLE001
+                self._logger.error("Failure in _resolve_instrument: %s", exc)
+        if canonical_value == "NSE:NIFTY":
+            if token is None:
+                self._logger.error(
+                    "SPOT_TOKEN_RESOLUTION_FAILED symbol=NSE:NIFTY reason=token_not_found"
+                )
+            else:
+                self._logger.info(
+                    "SPOT_BROKER_SYMBOL_RESOLVED canonical=NSE:NIFTY broker_symbol=%s token=%s",
+                    broker_symbol,
+                    token,
+                )
+        return ResolvedInstrument(
+            canonical_symbol=canonical_value,
+            broker_symbol=broker_symbol,
+            instrument_token=token,
+            exchange=exchange,
+            tradingsymbol=tradingsymbol,
+        )
+
     def _reconcile_ws_subscriptions(self) -> None:
         """Apply desired token set to websocket transport. Args: none. Returns: none. Raises: none."""
 
@@ -1418,6 +1481,52 @@ class MarketDataManager:
                 extra={"event": "mdm_internal_rest_poller_disabled", "reason": reason},
             )
 
+    def set_polling_fallback_streamer(self, streamer: Any) -> None:
+        """Attach polling fallback owner. Args: streamer; Returns: none; Raises: none."""
+        self._polling_fallback_streamer = streamer
+
+    def request_fallback_refresh(self, symbol: str, *, reason: str) -> bool:
+        """Request a fallback refresh. Args: symbol/reason; Returns: dispatched flag; Raises: none."""
+        resolved = self._resolve_instrument(symbol)
+        streamer = self._polling_fallback_streamer
+        owner = "polling_streamer" if streamer is not None else "mdm_rest"
+        self._logger.info(
+            "MDM_FALLBACK_REFRESH_REQUESTED symbol=%s owner=%s reason=%s",
+            resolved.canonical_symbol,
+            owner,
+            reason,
+        )
+        if streamer is not None:
+            token = resolved.instrument_token
+            if token is None:
+                self._logger.info(
+                    "MDM_FALLBACK_REFRESH_SKIPPED symbol=%s reason=missing_token",
+                    resolved.canonical_symbol,
+                )
+                return False
+            try:
+                if hasattr(streamer, "subscribe"):
+                    streamer.subscribe([int(token)])
+                if hasattr(streamer, "start") and hasattr(streamer, "is_running"):
+                    if not bool(streamer.is_running()):
+                        streamer.start()
+                return True
+            except Exception as exc:  # noqa: BLE001
+                self._logger.error(
+                    "MDM_FALLBACK_REFRESH_SKIPPED symbol=%s reason=%s",
+                    resolved.canonical_symbol,
+                    exc,
+                )
+                return False
+        if not self._should_refresh_symbol(resolved.canonical_symbol):
+            self._logger.info(
+                "MDM_FALLBACK_REFRESH_SKIPPED symbol=%s reason=rate_limited",
+                resolved.canonical_symbol,
+            )
+            return False
+        self._schedule_rest_refresh(resolved.canonical_symbol)
+        return True
+
     def subscribe(self, symbol: str, callback: TickCallback) -> None:
         """Subscribe *callback* to receive normalized ticks for *symbol*."""
 
@@ -1523,8 +1632,8 @@ class MarketDataManager:
             and stale_threshold > 0.0
             and tick_age > stale_threshold
         )
-        if tick_stale and self._should_refresh_symbol(normalized_symbol):
-            self._schedule_rest_refresh(normalized_symbol)
+        if tick_stale:
+            self.request_fallback_refresh(normalized_symbol, reason="stale_tick")
         return tick
 
     def time_since_last_tick(self, symbol: str) -> float | None:
@@ -1544,7 +1653,9 @@ class MarketDataManager:
 
     async def _rest_refresh(self, symbol: str) -> None:
         """Args: symbol; Returns: none; Raises: none."""
-        canonical = self._canonical_symbol(symbol)
+        resolved = self._resolve_instrument(symbol)
+        canonical = resolved.canonical_symbol
+        broker_symbol = resolved.broker_symbol
         broker = self._broker or getattr(self, "_kite", None) or getattr(
             self, "_client", None
         )
@@ -1555,12 +1666,14 @@ class MarketDataManager:
             return None
         try:
             quote_payload: Any = None
-            if hasattr(broker, "ltp"):
-                quote_payload = broker.ltp([canonical])
+            if canonical.endswith(("CE", "PE")) and hasattr(broker, "get_quote"):
+                quote_payload = {broker_symbol: broker.get_quote(broker_symbol)}
+            elif hasattr(broker, "ltp"):
+                quote_payload = broker.ltp([broker_symbol])
             elif hasattr(broker, "get_ltp"):
-                quote_payload = {canonical: {"last_price": broker.get_ltp(canonical)}}
+                quote_payload = {broker_symbol: {"last_price": broker.get_ltp(broker_symbol)}}
             elif hasattr(broker, "get_quote"):
-                quote_payload = {canonical: broker.get_quote(canonical)}
+                quote_payload = {broker_symbol: broker.get_quote(broker_symbol)}
             else:
                 self._logger.debug(
                     "MDM_REST_REFRESH_SKIPPED symbol=%s reason=no_ltp_method",
@@ -1570,8 +1683,10 @@ class MarketDataManager:
 
             quote = quote_payload
             if isinstance(quote_payload, Mapping):
-                quote = quote_payload.get(canonical) or quote_payload.get(
-                    f"NSE:{canonical.split(':')[-1]}"
+                quote = (
+                    quote_payload.get(broker_symbol)
+                    or quote_payload.get(canonical)
+                    or quote_payload.get(f"NSE:{canonical.split(':')[-1]}")
                 )
             if not isinstance(quote, Mapping):
                 self._logger.debug(
@@ -1590,9 +1705,11 @@ class MarketDataManager:
                 "symbol": canonical,
                 "ltp": float(ltp),
                 "last_price": float(ltp),
+                "bid": _coerce_positive_float(quote.get("bid") or quote.get("buy_price")),
+                "ask": _coerce_positive_float(quote.get("ask") or quote.get("sell_price")),
                 "received_at": time.time(),
                 "timestamp": time.time(),
-                "source": "rest",
+                "source": "rest_quote" if canonical.endswith(("CE", "PE")) else "rest_ltp",
             }
             with self._lock:
                 previous = self._latest_ticks.get(canonical)
@@ -1600,16 +1717,19 @@ class MarketDataManager:
             if normalized is None:
                 return None
             self._emit_tick(canonical, normalized, source="rest")
-            self._logger.info(
-                "MDM_REST_FALLBACK_USED symbol=%s ltp=%s",
-                canonical,
-                float(ltp),
-                extra={
-                    "event": "MDM_REST_FALLBACK_USED",
-                    "symbol": canonical,
-                    "ltp": float(ltp),
-                },
-            )
+            if canonical.endswith(("CE", "PE")):
+                self._logger.info(
+                    "MDM_REST_QUOTE_FALLBACK_USED symbol=%s bid=%s ask=%s",
+                    canonical,
+                    tick.get("bid"),
+                    tick.get("ask"),
+                )
+            else:
+                self._logger.info(
+                    "MDM_REST_FALLBACK_USED symbol=%s ltp=%s",
+                    canonical,
+                    float(ltp),
+                )
         except Exception as exc:  # noqa: BLE001
             self._logger.error(
                 "MDM_REST_REFRESH_FAILED symbol=%s error=%s", canonical, exc
@@ -3124,7 +3244,7 @@ class MarketDataManager:
             return False
         self._spot_refresh_last_attempt_mono = now_mono
         self._logger.info("spot_rest_refresh_attempt symbol=%s", canonical_symbol)
-        self.request_refresh(canonical_symbol)
+        self.request_fallback_refresh(canonical_symbol, reason="spot_reference_stale")
         return False
 
     def get_hydration_status(self, symbol: str) -> str:
@@ -4851,6 +4971,12 @@ class MarketDataManager:
         latest_candle_synthetic = bool(latest.get("synthetic")) if isinstance(latest, Mapping) else False
         ohlc_valid = bool(bars)
         depth_available = isinstance(tick.get("depth"), Mapping) and bool(tick.get("depth"))
+        bid_missing = bool(tick.get("bid_missing")) or bid is None or bid <= 0
+        ask_missing = bool(tick.get("ask_missing")) or ask is None or ask <= 0
+        bid_ask_source = str(tick.get("bid_ask_source") or ("market_depth" if depth_available else "missing"))
+        tradable_quote = (not bid_missing and not ask_missing) and bool(
+            tick.get("tradable_quote", True)
+        )
         snapshot = MarketSnapshot(
             symbol=str(symbol),
             canonical_symbol=canonical,
@@ -4865,6 +4991,10 @@ class MarketDataManager:
             latest_candle_synthetic=latest_candle_synthetic,
             ohlc_valid=ohlc_valid,
             depth_available=depth_available,
+            bid_missing=bid_missing,
+            ask_missing=ask_missing,
+            bid_ask_source=bid_ask_source,
+            tradable_quote=tradable_quote,
         )
         age_value = snapshot.tick_age_s
         stale_threshold = self._ltp_stale_threshold_for_symbol(canonical)
@@ -5710,32 +5840,24 @@ class MarketDataManager:
         if ask is None:
             ask = self._coerce_from_depth(depth, "sell")
 
-        # 4. Handle Empty Depth Gracefully (Prevent Errors)
+        # 4. Preserve missing bid/ask (do not fabricate from LTP)
         if bid is None:
             buy_levels = depth.get("buy")
             if isinstance(buy_levels, list) and not buy_levels:
-                # Empty list = valid "no buyers" state
                 self._logger.debug(
                     "Depth present but buy side empty", extra={"symbol": symbol}
                 )
-            # Fallback: Previous > LTP
-            bid = previous.get("bid") if previous else ltp
 
         if ask is None:
             sell_levels = depth.get("sell")
             if isinstance(sell_levels, list) and not sell_levels:
-                # Empty list = valid "no sellers" state
                 self._logger.debug(
                     "Depth present but sell side empty", extra={"symbol": symbol}
                 )
-            # Fallback: Previous > LTP
-            ask = previous.get("ask") if previous else ltp
 
-        # Final Safety
-        if bid is None:
-            bid = ltp
-        if ask is None:
-            ask = ltp
+        bid_missing = bid is None or float(bid) <= 0
+        ask_missing = ask is None or float(ask) <= 0
+        tradable_quote = not bid_missing and not ask_missing
 
         timestamp = self._coerce_timestamp(tick)
 
@@ -5743,20 +5865,26 @@ class MarketDataManager:
             "symbol": symbol,
             "ltp": float(ltp),
             "last_price": float(ltp),
-            "bid": float(bid),
-            "ask": float(ask),
+            "bid": float(bid) if not bid_missing else None,
+            "ask": float(ask) if not ask_missing else None,
             "timestamp": timestamp,
             "received_at": self._parse_wallclock(
                 tick.get("received_at") or tick.get("wallclock")
             )
             or time.time(),
             "depth": depth,
+            "bid_missing": bid_missing,
+            "ask_missing": ask_missing,
+            "bid_ask_source": "market_depth" if depth else "missing",
+            "tradable_quote": tradable_quote,
             "ltq": tick.get("last_quantity"),
             "oi": self._coerce_float(tick, "oi", "open_interest"),
         }
         source = tick.get("source")
         if isinstance(source, str) and source:
             normalized["source"] = source
+            if tradable_quote and not depth:
+                normalized["bid_ask_source"] = source
         broker_timestamp = tick.get("broker_timestamp")
         if broker_timestamp is not None:
             normalized["broker_timestamp"] = broker_timestamp

--- a/src/nifty_scalper_bot/strategies/elite_strategies/builder.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/builder.py
@@ -5,6 +5,7 @@ Production-Grade: Explicit Registry Mapping for Stability and Fault-Tolerance.
 
 from __future__ import annotations
 
+import os
 from typing import Any, List, Dict, Type
 
 from nifty_scalper_bot.strategies.elite_strategies.base_elite import EliteStrategy
@@ -27,6 +28,11 @@ from nifty_scalper_bot.utils.logging import get_logger
 
 LOGGER = get_logger(__name__)
 
+_DIRECT_DIRECTIONAL = {'smc', 'vwap', 'cpr', 'order_flow', 'bb_squeeze', 'orb'}
+_CONTEXT_ONLY = {'oi_max_pain'}
+_EXPIRY_ONLY = {'gamma_scalping', 'tuesday_gamma_buyer'}
+_THETA_ONLY = {'straddle'}
+
 def build_elite_strategies(
     settings: EliteStrategiesSettings,
     indicator_engine: Any
@@ -42,6 +48,13 @@ def build_elite_strategies(
         A list of fully initialized strategy instances.
     """
     strategies: List[EliteStrategy] = []
+    strategy_mode = str(os.getenv('STRATEGY_MODE', 'directional_scalp')).strip().lower()
+    allow_expiry_gamma = str(
+        os.getenv('ALLOW_EXPIRY_GAMMA_STRATEGIES', 'false')
+    ).strip().lower() in {'1', 'true', 'yes', 'on'}
+    active_names: list[str] = []
+    context_names: list[str] = []
+    disabled_names: list[str] = []
 
     # ✅ PRODUCTION REGISTRY: Maps Config Field -> Strategy Class
     # This is the "Source of Truth" for loading.
@@ -74,6 +87,23 @@ def build_elite_strategies(
             # 3. Check if strategy is enabled in .env / config.yaml
             if not strat_config or not strat_config.enabled:
                 LOGGER.debug(f"ℹ️  Strategy '{field_name}' is disabled.")
+                disabled_names.append(strategy_cls.__name__.replace('Strategy', ''))
+                continue
+
+            if strategy_mode == 'directional_scalp':
+                if field_name in _EXPIRY_ONLY or field_name in _THETA_ONLY:
+                    disabled_names.append(strategy_cls.__name__.replace('Strategy', ''))
+                    continue
+                if field_name in _CONTEXT_ONLY:
+                    context_names.append(strategy_cls.__name__.replace('Strategy', ''))
+                    continue
+            if field_name in _EXPIRY_ONLY and not (
+                strategy_mode == 'expiry_gamma' and allow_expiry_gamma
+            ):
+                disabled_names.append(strategy_cls.__name__.replace('Strategy', ''))
+                continue
+            if field_name in _THETA_ONLY and strategy_mode != 'theta':
+                disabled_names.append(strategy_cls.__name__.replace('Strategy', ''))
                 continue
 
             # 4. Instantiate with Dependency Injection
@@ -85,6 +115,7 @@ def build_elite_strategies(
             
             strategies.append(strategy_instance)
             LOGGER.info(f"✅ Strategy Loaded: {strategy_instance.name}")
+            active_names.append(strategy_instance.name)
 
         except Exception as e:
             # Shielding: One strategy failing to load should not kill the bot
@@ -93,6 +124,13 @@ def build_elite_strategies(
     passed = len(strategies)
     total = len(registry)
     LOGGER.info(f"📊 Strategy Build Complete: {passed}/{total} active.")
+    LOGGER.info(
+        "STRATEGY_REGISTRY_LOADED active=%s context=%s disabled=%s mode=%s",
+        active_names,
+        context_names or ['OIMaxPain'],
+        sorted(set(disabled_names)),
+        strategy_mode,
+    )
 
     return strategies
 

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -13,6 +13,7 @@ import json
 import logging
 import os
 from pathlib import Path
+import re
 import threading
 import time
 import time as time_module
@@ -1525,10 +1526,10 @@ class StrategyRunner:
                 norm = enforce_canonical(normalize_symbol(sym))
                 if not norm.startswith("NFO:NIFTY") or not norm.endswith(side):
                     continue
-                digits = "".join(ch for ch in norm.split(":")[-1] if ch.isdigit())
-                if len(digits) < 4:
+                match = re.search(r"(\d{5})(CE|PE)$", norm)
+                if match is None:
                     continue
-                strike = int(digits[-5:]) if len(digits) >= 5 else int(digits[-4:])
+                strike = int(match.group(1))
                 if abs(strike - atm) <= max(1, int(window_each_side)) * 50:
                     selected.append((norm, strike))
             selected.sort(key=lambda item: abs(item[1] - atm))
@@ -1539,7 +1540,7 @@ class StrategyRunner:
                 if snap.bid and snap.ask and snap.bid > 0 and snap.ask > 0:
                     mid = (snap.bid + snap.ask) / 2.0
                     if mid > 0:
-                        spread_pct = ((snap.ask - snap.bid) / mid) * 100.0
+                        spread_pct = (snap.ask - snap.bid) / mid
                 candidates.append(
                     {
                         "symbol": snap.canonical_symbol,
@@ -1557,6 +1558,10 @@ class StrategyRunner:
                         "latest_candle_volume": None,
                         "ohlc_valid": snap.ohlc_valid,
                         "atm_distance": abs(strike - atm),
+                        "bid_missing": snap.bid_missing,
+                        "ask_missing": snap.ask_missing,
+                        "bid_ask_source": snap.bid_ask_source,
+                        "tradable_quote": snap.tradable_quote,
                     }
                 )
             self._logger.debug(

--- a/tests/data/test_market_data_manager_subscriptions.py
+++ b/tests/data/test_market_data_manager_subscriptions.py
@@ -172,3 +172,59 @@ def test_ltp_stale_thresholds_are_symbol_specific(monkeypatch) -> None:
         lambda: MarketState.CLOSED,
     )
     assert mdm._ltp_stale_threshold_for_symbol('NSE:NIFTY') == 3600.0  # noqa: SLF001
+
+
+class DummyPollingFallback:
+    def __init__(self) -> None:
+        self.subscribed: list[list[int]] = []
+        self.started = False
+
+    def subscribe(self, tokens: list[int]) -> None:
+        self.subscribed.append(tokens)
+
+    def is_running(self) -> bool:
+        return self.started
+
+    def start(self) -> None:
+        self.started = True
+
+
+def test_normalize_tick_does_not_fabricate_bid_ask() -> None:
+    mdm = MarketDataManager(DummyBroker(), websocket=None, resolver=DummyResolver())
+
+    tick = mdm._normalize_tick('NFO:NIFTY26APR23800CE', {'last_price': 123.0})  # noqa: SLF001
+
+    assert tick is not None
+    assert tick['bid'] is None
+    assert tick['ask'] is None
+    assert tick['tradable_quote'] is False
+    assert tick['bid_ask_source'] == 'missing'
+
+
+def test_snapshot_marks_ltp_only_quote_not_tradable() -> None:
+    mdm = MarketDataManager(DummyBroker(), websocket=None, resolver=DummyResolver())
+    mdm._emit_tick(  # noqa: SLF001
+        'NFO:NIFTY26APR23800CE',
+        {'symbol': 'NFO:NIFTY26APR23800CE', 'last_price': 123.0, 'ltp': 123.0, 'source': 'rest_ltp'},
+        source='rest_ltp',
+    )
+
+    snap = mdm.get_symbol_snapshot('NFO:NIFTY26APR23800CE')
+
+    assert snap.bid is None
+    assert snap.ask is None
+    assert snap.tradable_quote is False
+
+
+def test_ensure_fresh_tick_uses_polling_fallback_owner(monkeypatch) -> None:
+    mdm = MarketDataManager(DummyBroker(), websocket=None, resolver=DummyResolver())
+    fallback = DummyPollingFallback()
+    mdm.set_polling_fallback_streamer(fallback)
+    monkeypatch.setattr(mdm, 'get_latest_tick', lambda _symbol: None)
+    monkeypatch.setattr(mdm, 'time_since_last_tick', lambda _symbol: 999.0)
+
+    import asyncio
+
+    asyncio.run(mdm.ensure_fresh_tick('NSE:NIFTY'))
+
+    assert fallback.subscribed

--- a/tests/strategies/test_elite_builder_mode.py
+++ b/tests/strategies/test_elite_builder_mode.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from nifty_scalper_bot.strategies.elite_strategies.builder import build_elite_strategies
+from nifty_scalper_bot.strategies.elite_strategies.config_models import (
+    EliteStrategiesSettings,
+)
+
+
+def test_directional_mode_disables_gamma_theta_and_context(monkeypatch) -> None:
+    monkeypatch.setenv('STRATEGY_MODE', 'directional_scalp')
+    monkeypatch.setenv('ALLOW_EXPIRY_GAMMA_STRATEGIES', 'false')
+
+    strategies = build_elite_strategies(
+        settings=EliteStrategiesSettings(),
+        indicator_engine=None,
+    )
+    names = {strategy.name for strategy in strategies}
+
+    assert 'GammaScalping' not in names
+    assert 'EliteTuesdayGammaBuyer' not in names
+    assert 'StraddleTheta' not in names
+    assert 'OIMaxPain' not in names
+    assert {'SMC', 'VWAPPro', 'CPRBreakout', 'OrderFlow', 'BBSqueeze', 'ORBPro'}.issubset(
+        names
+    )

--- a/tests/strategies/test_strategy_runner_datahub.py
+++ b/tests/strategies/test_strategy_runner_datahub.py
@@ -58,6 +58,10 @@ class _StubMDM:
                 self.latest_candle_provisional = False
                 self.latest_candle_synthetic = False
                 self.ohlc_valid = True
+                self.bid_missing = True
+                self.ask_missing = True
+                self.bid_ask_source = "missing"
+                self.tradable_quote = False
 
         if symbol in {"NIFTY", "NSE:NIFTY", "NIFTY 50"}:
             return _Snapshot("NSE:NIFTY", 25025.0)


### PR DESCRIPTION
### Motivation
- Recent logs showed premature polling fallback activation, fabricated bid/ask from LTP, heavy hydration, and unsafe LIVE approvals that must be prevented for capital protection. 
- The intent is to unify fallback ownership, make WS first‑tick readiness and REST fallback explicit, and require real quote quality before permitting LIVE option entry. 
- Reduce startup hydration and keep directional LIVE mode limited to intended strategies to avoid unintended exposures. 

### Description
- Added `ResolvedInstrument` and canonical/broker resolution in `MarketDataManager` and emitted `SYMBOL_CANONICALIZED`, `SPOT_BROKER_SYMBOL_RESOLVED`, and `SPOT_TOKEN_RESOLUTION_FAILED` logs to separate internal canonical keys from broker symbols and tokens. 
- Unified fallback ownership by adding `set_polling_fallback_streamer(...)` and `request_fallback_refresh(symbol, reason)` to `MarketDataManager`, and wired `ensure_fresh_tick(...)` and `ensure_spot_reference_fresh(...)` to call the unified fallback API. 
- Wired the app startup to register the `PollingStreamer` as the MDM fallback owner, and updated the polling failover supervisor to use `POLLING_SUPERVISOR_INDEX_STALE_SECONDS` (default 120s) with explicit `POLLING_FALLBACK_SKIPPED` and `POLLING_FALLBACK_ACTIVATE` logs. 
- Hardened REST fallback (`_rest_refresh`) to call broker APIs using resolved `broker_symbol`, prefer quote-level `bid`/`ask` for options (`rest_quote`) and emit `MDM_REST_FALLBACK_USED` / `MDM_REST_QUOTE_FALLBACK_USED` logs. 
- Removed fabrication of `bid`/`ask` from `_normalize_tick` (no longer set `bid = ltp` / `ask = ltp`), added tick fields `bid_missing`, `ask_missing`, `bid_ask_source`, and `tradable_quote`, and exposed these in `MarketSnapshot` so LIVE selection requires real tradable quotes. 
- Tightened candidate snapshot builder in `StrategyRunner` to use a safe regex `r"(\d{5})(CE|PE)$"` for strike extraction, switched `spread_pct` to decimal convention `(ask - bid) / mid`, and included quote-quality fields in candidate dicts. 
- Restricted elite strategy loading via `build_elite_strategies` so `STRATEGY_MODE=directional_scalp` only activates direct-entry strategies (SMC, VWAPPro, CPRBreakout, OrderFlow, BBSqueeze, ORBPro) while marking `OIMaxPain` as context-only and disabling gamma/theta unless explicitly enabled by mode flags; emits `STRATEGY_REGISTRY_LOADED` summary. 
- Added lightweight unit tests and updated stubs to validate: no bid/ask fabrication, LTP-only snapshot non-tradable, `ensure_fresh_tick` delegates to polling fallback owner, and directional strategy-mode gating. 

### Testing
- Ran `python -m compileall src` and compilation completed successfully. 
- Ran targeted unit tests: `pytest -q tests/data/test_market_data_manager_subscriptions.py tests/strategies/test_strategy_runner_datahub.py tests/strategies/test_elite_builder_mode.py` and they passed. 
- Ran full test suite `pytest -q` which failed due to a pre-existing import issue in the repository (`InstrumentResolver` import from `nifty_scalper_bot.data`) that is unrelated to these tactical changes. 
- Attempted `./run_checks.sh`; dependency/install steps ran but the helper environment created by the script did not have `pytest` available in-place (environment/runtime provisioning), so CI wrapper was not completed in this session.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eef4acd6248324a2251bd1110f7e0e)