### PR TITLE
Fix readiness gating, candidate resolution, and consensus safety

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -7209,7 +7209,7 @@ async def startup_sequence(ctx: BotContext) -> None:
                             hard_ready = bool(readiness_state.get("hard_ready"))
                             spot_ready = bool(readiness_state.get("spot_ready"))
                             missing_hard = list(readiness_state.get("missing_hard") or [])
-                            indicators_ready_for_trading = _compute_indicator_readiness(ctx)
+                            indicators_ready_for_trading = hard_ready
                             if ctx.market_regime_manager is not None:
                                 ctx.market_regime_manager.indicators_ready = (
                                     indicators_ready_for_trading
@@ -7253,6 +7253,18 @@ async def startup_sequence(ctx: BotContext) -> None:
                                     },
                                 )
                             else:
+                                LOGGER.info(
+                                    "DATA_PIPELINE_NOT_READY hard_ready=%s spot_ready=%s missing=%s",
+                                    hard_ready,
+                                    spot_ready,
+                                    missing_hard,
+                                    extra={
+                                        "event": "DATA_PIPELINE_NOT_READY",
+                                        "hard_ready": hard_ready,
+                                        "spot_ready": spot_ready,
+                                        "missing": missing_hard,
+                                    },
+                                )
                                 LOGGER.error(
                                     "startup_pipeline_incomplete missing=%s",
                                     ",".join(missing_hard) if missing_hard else "unknown",
@@ -7263,6 +7275,46 @@ async def startup_sequence(ctx: BotContext) -> None:
                                         "timed_out": not readiness_ready,
                                         "missing": missing_hard,
                                         "ws_connected": ws_connected,
+                                    },
+                                )
+                            live_mode = (
+                                str(os.getenv("EXECUTION_MODE", "SHADOW"))
+                                .strip()
+                                .upper()
+                                == "LIVE"
+                                or str(os.getenv("ENABLE_LIVE", "false"))
+                                .strip()
+                                .lower()
+                                in {"1", "true", "yes", "on"}
+                            )
+                            if hard_ready:
+                                LOGGER.info(
+                                    "DATA_PIPELINE_READY hard_ready=%s spot_ready=%s symbols_ready=%s",
+                                    hard_ready,
+                                    spot_ready,
+                                    len(readiness_state.get("ready_symbols") or []),
+                                    extra={
+                                        "event": "DATA_PIPELINE_READY",
+                                        "hard_ready": hard_ready,
+                                        "spot_ready": spot_ready,
+                                        "symbols_ready": len(
+                                            readiness_state.get("ready_symbols") or []
+                                        ),
+                                    },
+                                )
+                            if live_mode and not hard_ready:
+                                ctx.live_orders_armed = False
+                                ctx.trading_ready = False
+                                ctx.readiness_mode = "DATA_WARMUP"
+                                LOGGER.error(
+                                    "LIVE_TRADING_BLOCKED reason=startup_pipeline_incomplete missing=%s",
+                                    missing_hard,
+                                    extra={
+                                        "event": "LIVE_TRADING_BLOCKED",
+                                        "reason": "startup_pipeline_incomplete",
+                                        "missing": missing_hard,
+                                        "hard_ready": hard_ready,
+                                        "spot_ready": spot_ready,
                                     },
                                 )
                         except Exception as ready_exc:

--- a/src/nifty_scalper_bot/core/strategy_manager.py
+++ b/src/nifty_scalper_bot/core/strategy_manager.py
@@ -1796,7 +1796,7 @@ class StrategyManager(_BaseStrategyManager):
         required_missing = sorted(
             name for name in self._required_indicators if indicators.get(name) is None
         )
-        log.info(
+        log.debug(
             "STRATEGY_MANAGER_ENTER",
             extra={
                 "event": "STRATEGY_MANAGER_ENTER",
@@ -1831,7 +1831,7 @@ class StrategyManager(_BaseStrategyManager):
 
         def _emit_strategy_exit() -> None:
             """Emit terminal strategy manager summary. Args: none. Returns: none. Raises: none."""
-            log.info(
+            log.debug(
                 "STRATEGY_MANAGER_EXIT",
                 extra={
                     "event": "STRATEGY_MANAGER_EXIT",

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -201,6 +201,7 @@ class MarketDataManager:
             "spot_ready": False,
             "missing_hard": [],
         }
+        self._spot_ready_logged = False
         self._spot_refresh_last_attempt_mono: float = 0.0
         # Bounded queue: drops oldest when full so a stall in the async
         # consumer never grows memory without bound. Size 10 000 is ~8 s
@@ -3017,7 +3018,40 @@ class MarketDataManager:
             readiness_state = self._readiness_state(bars, min_bars, requirements)
             self._last_readiness_state = dict(readiness_state)
             valid_symbols = [s for s, count in bars.items() if count >= min_bars]
+            spot_symbol = str(requirements.get("spot") or "NSE:NIFTY")
+            spot_age_ms = self.symbol_data_age_ms(spot_symbol) if spot_symbol else -1
+            if readiness_state["spot_ready"] and not self._spot_ready_logged:
+                spot_source = str(self._last_tick_source.get(spot_symbol, "unknown"))
+                source = "ws" if spot_source == "ws" else "rest_ltp"
+                token = self._token_by_symbol.get(spot_symbol)
+                self._spot_ready_logged = True
+                self._logger.info(
+                    "SPOT_READY symbol=%s source=%s age_ms=%s token=%s",
+                    spot_symbol,
+                    source,
+                    max(0, int(spot_age_ms)),
+                    token,
+                    extra={
+                        "event": "SPOT_READY",
+                        "symbol": spot_symbol,
+                        "source": source,
+                        "age_ms": max(0, int(spot_age_ms)),
+                        "token": token,
+                    },
+                )
             if readiness_state["hard_ready"]:
+                self._logger.info(
+                    "DATA_PIPELINE_READY hard_ready=%s spot_ready=%s symbols_ready=%s",
+                    True,
+                    readiness_state["spot_ready"],
+                    len(valid_symbols),
+                    extra={
+                        "event": "DATA_PIPELINE_READY",
+                        "hard_ready": True,
+                        "spot_ready": readiness_state["spot_ready"],
+                        "symbols_ready": len(valid_symbols),
+                    },
+                )
                 self.ready = True
                 self.degraded = False
                 self.hydration_complete = True
@@ -3031,6 +3065,18 @@ class MarketDataManager:
                     },
                 )
                 return
+            self._logger.info(
+                "DATA_PIPELINE_NOT_READY hard_ready=%s spot_ready=%s missing=%s",
+                False,
+                readiness_state["spot_ready"],
+                readiness_state.get("missing_hard") or [],
+                extra={
+                    "event": "DATA_PIPELINE_NOT_READY",
+                    "hard_ready": False,
+                    "spot_ready": readiness_state["spot_ready"],
+                    "missing": readiness_state.get("missing_hard") or [],
+                },
+            )
             await asyncio.sleep(0.1)
 
         market_state = get_market_state()
@@ -3148,6 +3194,18 @@ class MarketDataManager:
     def readiness_state_snapshot(self) -> dict[str, Any]:
         """Return latest readiness classification snapshot."""
         return dict(self._last_readiness_state)
+
+    def hard_ready(self) -> bool:
+        """Args: none; Returns: hard readiness flag; Raises: none."""
+        return bool(self._last_readiness_state.get("hard_ready"))
+
+    def spot_ready(self) -> bool:
+        """Args: none; Returns: spot readiness flag; Raises: none."""
+        return bool(self._last_readiness_state.get("spot_ready"))
+
+    def missing_hard(self) -> list[str]:
+        """Args: none; Returns: missing hard dependencies; Raises: none."""
+        return list(self._last_readiness_state.get("missing_hard") or [])
 
     def _is_symbol_fresh(self, symbol: str, max_age_ms: int) -> bool:
         """Return whether a symbol has a fresh enough tick age."""

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, time as dt_time, timedelta, timezone
 from enum import Enum
 import json
+import inspect
 import logging
 import os
 from pathlib import Path
@@ -1505,77 +1506,86 @@ class StrategyRunner:
     ) -> list[dict[str, Any]]:
         """Build option candidate snapshots around ATM for the chosen side."""
         try:
+            asyncio.get_running_loop()
+            self._logger.warning(
+                "CANDIDATE_SNAPSHOT_BUILD_FAILED reason=async_required",
+                extra={"event": "CANDIDATE_SNAPSHOT_BUILD_FAILED", "reason": "async_required"},
+            )
+            return []
+        except RuntimeError:
+            snapshots, _ = asyncio.run(
+                self.build_candidate_snapshots_async(
+                    underlying=underlying,
+                    direction_bias=direction_bias,
+                    atm_strike=atm_strike,
+                    window_each_side=window_each_side,
+                )
+            )
+            return snapshots
+
+    async def build_candidate_snapshots_async(
+        self,
+        underlying: str = "NIFTY",
+        direction_bias: Literal["CE", "PE"] = "CE",
+        atm_strike: int | None = None,
+        window_each_side: int = 2,
+    ) -> tuple[list[dict[str, Any]], bool]:
+        """Args: option context. Returns: snapshots and refresh_pending flag. Raises: none."""
+        try:
             if self._market_data is None or not hasattr(self._market_data, "get_symbol_snapshot"):
-                return []
+                return [], True
             spot_snapshot = self._market_data.get_symbol_snapshot(underlying)
             if spot_snapshot.ltp is None or spot_snapshot.canonical_symbol != "NSE:NIFTY":
                 self._logger.warning(
-                    "CANDIDATE_SNAPSHOT_BUILD_FAILED reason=spot_missing"
+                    "CANDIDATE_SNAPSHOT_BUILD_FAILED reason=spot_missing",
+                    extra={"event": "CANDIDATE_SNAPSHOT_BUILD_FAILED", "reason": "spot_missing"},
                 )
-                return []
+                return [], True
             atm = int(atm_strike or round(float(spot_snapshot.ltp) / 50.0) * 50)
             side = str(direction_bias).upper()
             if side not in {"CE", "PE"}:
                 side = "CE"
-            selected: list[tuple[str, int]] = []
             target_strikes = {
                 atm + 50 * offset
                 for offset in range(-max(1, int(window_each_side)), max(1, int(window_each_side)) + 1)
             }
-            resolver = getattr(self._market_data, "_resolver", None)
-            candidate_symbols: set[str] = set()
-            if resolver is not None:
-                for strike_value in sorted(target_strikes):
-                    for prefix in ("NFO:", ""):
-                        candidate_symbols.add(f"{prefix}NIFTY{strike_value}{side}")
-            for symbol_candidate in candidate_symbols:
-                lookup = None
-                if resolver is not None and hasattr(resolver, "lookup"):
-                    try:
-                        lookup = resolver.lookup(symbol_candidate)
-                    except Exception:
-                        lookup = None
-                if isinstance(lookup, Mapping):
-                    strike_val = int(float(lookup.get("strike") or 0))
-                    tsym = str(lookup.get("tradingsymbol") or symbol_candidate)
-                    exchange = str(lookup.get("exchange") or "NFO").upper()
-                    if strike_val in target_strikes and str(lookup.get("instrument_type") or side).upper() == side:
-                        selected.append((f"{exchange}:{tsym}", strike_val))
-            if not selected:
-                tracked = []
-                tracked_fn = getattr(self._market_data, "tracked_snapshot", None)
-                if callable(tracked_fn):
-                    tracked = [str(sym) for sym in tracked_fn()]
-                for sym in tracked:
-                    norm = enforce_canonical(normalize_symbol(sym))
-                    if not norm.startswith("NFO:NIFTY") or not norm.endswith(side):
-                        continue
-                    match = re.search(r"(\d{5})(CE|PE)$", norm)
-                    if match is None:
-                        continue
-                    strike = int(match.group(1))
-                    if strike in target_strikes:
-                        selected.append((norm, strike))
+            selected = self._resolve_candidate_contracts(side=side, target_strikes=target_strikes)
             selected = sorted(set(selected), key=lambda item: abs(item[1] - atm))
+            refresh_pending = False
             candidates: list[dict[str, Any]] = []
             for sym, strike in selected[: max(1, 2 * window_each_side + 1)]:
                 try:
                     self._market_data.request_symbol_subscription(sym)
                 except Exception:
                     pass
-                try:
-                    ensure_tick_fn = getattr(self._market_data, "ensure_fresh_tick", None)
-                    if callable(ensure_tick_fn):
-                        coro = ensure_tick_fn(sym)
-                        if asyncio.iscoroutine(coro):
-                            try:
-                                loop = asyncio.get_running_loop()
-                                loop.create_task(coro)
-                            except RuntimeError:
-                                asyncio.run(coro)
-                except Exception:
-                    pass
+                ensure_tick_fn = getattr(self._market_data, "ensure_fresh_tick", None)
+                if callable(ensure_tick_fn):
+                    self._logger.debug(
+                        "CANDIDATE_REFRESH_REQUESTED symbol=%s", sym, extra={"event": "CANDIDATE_REFRESH_REQUESTED", "symbol": sym}
+                    )
+                    refresh_result = ensure_tick_fn(sym)
+                    if inspect.isawaitable(refresh_result):
+                        try:
+                            await asyncio.wait_for(refresh_result, timeout=2.0)
+                            self._logger.debug(
+                                "CANDIDATE_REFRESH_COMPLETE symbol=%s",
+                                sym,
+                                extra={"event": "CANDIDATE_REFRESH_COMPLETE", "symbol": sym},
+                            )
+                        except asyncio.TimeoutError:
+                            refresh_pending = True
+                            self._logger.warning(
+                                "CANDIDATE_REFRESH_TIMEOUT symbol=%s",
+                                sym,
+                                extra={"event": "CANDIDATE_REFRESH_TIMEOUT", "symbol": sym},
+                            )
                 snap = self._market_data.get_symbol_snapshot(sym)
+                if refresh_pending and (snap.ltp is None or not snap.tradable_quote):
+                    self._logger.warning(
+                        "CANDIDATE_SNAPSHOT_PENDING_REFRESH symbol=%s",
+                        sym,
+                        extra={"event": "CANDIDATE_SNAPSHOT_PENDING_REFRESH", "symbol": sym},
+                    )
                 spread_pct = None
                 if snap.bid and snap.ask and snap.bid > 0 and snap.ask > 0:
                     mid = (snap.bid + snap.ask) / 2.0
@@ -1602,17 +1612,75 @@ class StrategyRunner:
                         "ask_missing": snap.ask_missing,
                         "bid_ask_source": snap.bid_ask_source,
                         "tradable_quote": snap.tradable_quote,
+                        "refresh_pending": refresh_pending,
                     }
                 )
-            self._logger.debug(
-                "CANDIDATE_SNAPSHOTS_READY count=%s direction_bias=%s",
-                len(candidates),
-                side,
-            )
-            return candidates
+            return candidates, refresh_pending
         except Exception as exc:
             self._logger.error("CANDIDATE_SNAPSHOT_BUILD_FAILED reason=%s", exc)
-            return []
+            return [], True
+
+    def _resolve_candidate_contracts(
+        self, *, side: str, target_strikes: set[int]
+    ) -> list[tuple[str, int]]:
+        """Args: side and strikes. Returns: symbol/strike list. Raises: none."""
+        sources = [
+            ("OptionsContractStore", getattr(self, "_options_contract_store", None) or getattr(self, "_contract_store", None)),
+            ("InstrumentManager", getattr(self, "_instrument_manager", None)),
+            ("ContractSelector", getattr(self, "_contract_selector", None)),
+        ]
+        methods = ("get_atm_window", "get_contracts", "select_atm_contracts", "get_nearest_weekly_options")
+        for source_name, source in sources:
+            if source is None:
+                continue
+            for method in methods:
+                fetch = getattr(source, method, None)
+                if not callable(fetch):
+                    continue
+                try:
+                    rows = list(fetch())
+                except Exception:
+                    continue
+                selected: list[tuple[str, int]] = []
+                for row in rows:
+                    if not isinstance(row, Mapping):
+                        continue
+                    option_type = str(row.get("option_type") or row.get("instrument_type") or "").upper()
+                    strike = int(float(row.get("strike") or 0))
+                    exchange = str(row.get("exchange") or "NFO").upper()
+                    tradingsymbol = str(row.get("tradingsymbol") or "").upper()
+                    if option_type != side or strike not in target_strikes or not tradingsymbol:
+                        continue
+                    selected.append((f"{exchange}:{tradingsymbol}", strike))
+                if selected:
+                    self._logger.info(
+                        "CANDIDATE_RESOLVER_USED source=%s count=%s",
+                        source_name,
+                        len(selected),
+                        extra={"event": "CANDIDATE_RESOLVER_USED", "source": source_name, "count": len(selected)},
+                    )
+                    return selected
+        selected = []
+        tracked = []
+        tracked_fn = getattr(self._market_data, "tracked_snapshot", None)
+        if callable(tracked_fn):
+            tracked = [str(sym) for sym in tracked_fn()]
+        for sym in tracked:
+            norm = enforce_canonical(normalize_symbol(sym))
+            if not norm.startswith("NFO:NIFTY") or not norm.endswith(side):
+                continue
+            match = re.search(r"(\d{5})(CE|PE)$", norm)
+            if match is None:
+                continue
+            strike = int(match.group(1))
+            if strike in target_strikes:
+                selected.append((norm, strike))
+        self._logger.info(
+            "CANDIDATE_RESOLVER_FALLBACK source=tracked_symbols reason=resolver_unavailable count=%s",
+            len(selected),
+            extra={"event": "CANDIDATE_RESOLVER_FALLBACK", "source": "tracked_symbols", "reason": "resolver_unavailable", "count": len(selected)},
+        )
+        return selected
 
     # ==================== STATE & PERSISTENCE ====================
 
@@ -2527,21 +2595,25 @@ class StrategyRunner:
             gap_count = int(self._session_gap_count.get(symbol, 0))
             if gap_count > 1:
                 self._logger.warning(
-                    "soft_data_issue",
+                    "SOFT_DATA_ISSUE symbol=%s reason=%s",
+                    symbol,
+                    "repeated_missing_candles",
                     extra={
-                        "event": "soft_data_issue",
+                        "event": "SOFT_DATA_ISSUE",
                         "symbol": symbol,
-                        "issue": "repeated_missing_candles",
+                        "reason": "repeated_missing_candles",
                         "gaps": gap_count,
                     },
                 )
                 return self._set_symbol_hydration_state(symbol, SymbolState.DEGRADED)
             self._logger.warning(
-                "soft_data_issue",
+                "SOFT_DATA_ISSUE symbol=%s reason=%s",
+                symbol,
+                "single_missing_candle",
                 extra={
-                    "event": "soft_data_issue",
+                    "event": "SOFT_DATA_ISSUE",
                     "symbol": symbol,
-                    "issue": "single_missing_candle",
+                    "reason": "single_missing_candle",
                 },
             )
             return self._set_symbol_hydration_state(symbol, SymbolState.DEGRADED)
@@ -5278,7 +5350,7 @@ class StrategyRunner:
                         self._bar_log_throttle_seconds,
                     )
                     if should_info_live_bar:
-                        self._logger.info(
+                        self._logger.debug(
                             "RUNNER_LIVE_BAR_INGESTED symbol=%s timestamp=%s open=%.4f high=%.4f low=%.4f close=%.4f volume=%s runner_history_count=%d candle_version=%d",
                             symbol,
                             completed_bar.timestamp.isoformat(),
@@ -5692,6 +5764,25 @@ class StrategyRunner:
                         "tick_price": price,
                     },
                 )
+            is_live_mode = (
+                str(os.getenv("EXECUTION_MODE", "SHADOW")).strip().upper() == "LIVE"
+                or str(os.getenv("ENABLE_LIVE", "false")).strip().lower()
+                in {"1", "true", "yes", "on"}
+            )
+            if is_live_mode and self._market_data is not None:
+                readiness = getattr(
+                    self._market_data, "readiness_state_snapshot", lambda: {}
+                )()
+                if not bool(readiness.get("hard_ready")):
+                    self._emit_runner_eval_decision(
+                        symbol=symbol,
+                        stage="phase9",
+                        reason="startup_pipeline_not_ready",
+                        allowed=False,
+                        trace_id=trace_id,
+                        readiness=readiness,
+                    )
+                    return
             upper_symbol = symbol.upper()
             is_index_symbol = (
                 upper_symbol.startswith("NSE:")
@@ -6053,7 +6144,7 @@ class StrategyRunner:
                                 signal_action=signal.action,
                                 signal_confidence=getattr(signal, "confidence", None),
                             )
-                        self._logger.info(
+                        self._logger.debug(
                             "STRATEGY_EVALUATED",
                             extra={
                                 "event": "strategy_evaluated",
@@ -7025,6 +7116,13 @@ class StrategyRunner:
                 str(os.getenv("ENABLE_LIVE", "false")).strip().lower()
                 in {"1", "true", "yes", "on"}
             )
+            if is_live_mode and self._market_data is not None:
+                readiness = getattr(
+                    self._market_data, "readiness_state_snapshot", lambda: {}
+                )()
+                if not bool(readiness.get("hard_ready")):
+                    self._reset_execution_state(base_symbol)
+                    return SignalExecutionResult(False, "startup_pipeline_not_ready")
             option_side = infer_option_side(signal.symbol, metadata)
             if is_live_mode and option_side == "UNKNOWN":
                 self._reset_execution_state(base_symbol)
@@ -7035,11 +7133,21 @@ class StrategyRunner:
                 candidate_snapshots_obj, list
             ):
                 atm_strike = int(metadata.get("atm_strike") or 0)
-                built = self.build_candidate_snapshots(
-                    direction_bias=cast(Literal["CE", "PE"], option_side),
-                    atm_strike=atm_strike,
-                    underlying=underlying,
-                )
+                try:
+                    asyncio.get_running_loop()
+                    self._reset_execution_state(base_symbol)
+                    return SignalExecutionResult(False, "candidate_refresh_pending")
+                except RuntimeError:
+                    built, refresh_pending = asyncio.run(
+                        self.build_candidate_snapshots_async(
+                            direction_bias=cast(Literal["CE", "PE"], option_side),
+                            atm_strike=atm_strike,
+                            underlying=underlying,
+                        )
+                    )
+                if refresh_pending:
+                    self._reset_execution_state(base_symbol)
+                    return SignalExecutionResult(False, "candidate_refresh_pending")
                 metadata["candidate_snapshots"] = built
                 candidate_snapshots_obj = built
             if is_live_mode and is_directional_option and not candidate_snapshots_obj:

--- a/src/nifty_scalper_bot/strategies/signal_generator.py
+++ b/src/nifty_scalper_bot/strategies/signal_generator.py
@@ -1516,7 +1516,31 @@ class StrategyManager:
                 return None
 
             if len(signals) == 1:
-                return signals[0]
+                signal = signals[0]
+                raw_conf = float(getattr(signal, "confidence", 0.0) or 0.0)
+                normalized_conf = raw_conf / 100.0 if raw_conf > 1.0 else raw_conf
+                preliminary_score = max(0.0, min(10.0, normalized_conf * 10.0))
+                if preliminary_score < 8.5:
+                    self._logger.info(
+                        "STRATEGY_CONSENSUS side=NO_TRADE score=%.2f votes=1 reason=single_vote_low_score",
+                        preliminary_score,
+                        extra={
+                            "event": "STRATEGY_CONSENSUS",
+                            "side": "NO_TRADE",
+                            "score": preliminary_score,
+                            "votes": 1,
+                            "reason": "single_vote_low_score",
+                        },
+                    )
+                    return None
+                return dataclasses.replace(
+                    signal,
+                    metadata={
+                        **(signal.metadata or {}),
+                        "single_vote_high_conviction": True,
+                        "preliminary_only": True,
+                    },
+                )
 
             def _normalize_confidence(value: float) -> float:
                 scaled = float(value)
@@ -1531,6 +1555,28 @@ class StrategyManager:
             buy_signals = [
                 (signal, conf) for signal, conf in normalized if signal.action == "BUY"
             ]
+            buy_ce_signals = [
+                (signal, conf)
+                for signal, conf in buy_signals
+                if str(signal.symbol).upper().endswith("CE")
+            ]
+            buy_pe_signals = [
+                (signal, conf)
+                for signal, conf in buy_signals
+                if str(signal.symbol).upper().endswith("PE")
+            ]
+            if buy_ce_signals and buy_pe_signals:
+                self._logger.info(
+                    "STRATEGY_CONSENSUS side=NO_TRADE votes=%s reason=ce_pe_conflict",
+                    len(buy_signals),
+                    extra={
+                        "event": "STRATEGY_CONSENSUS",
+                        "side": "NO_TRADE",
+                        "votes": len(buy_signals),
+                        "reason": "ce_pe_conflict",
+                    },
+                )
+                return None
             sell_signals = [
                 (signal, conf) for signal, conf in normalized if signal.action == "SELL"
             ]

--- a/tests/core/test_strategy_manager_scoring.py
+++ b/tests/core/test_strategy_manager_scoring.py
@@ -254,3 +254,23 @@ def test_strategy_manager_same_side_votes_increase_strategy_score() -> None:
     signal = manager.generate_signal('NFO:NIFTY26FEB22500CE', 100.0)
     assert signal is not None
     assert float(signal.metadata.get('strategy_score') or 0.0) > 8.0
+
+
+def test_strategy_manager_single_weak_vote_returns_none() -> None:
+    manager = StrategyManager(
+        [_FixedSymbolSignalStrategy('Alpha', 'NFO:NIFTY26FEB22500CE', 0.80)],
+        _DummyIndicatorEngine(),
+        _DummyPositionManager(),
+    )
+    assert manager.generate_signal('NFO:NIFTY26FEB22500CE', 100.0) is None
+
+
+def test_strategy_manager_single_strong_vote_is_preliminary_only() -> None:
+    manager = StrategyManager(
+        [_FixedSymbolSignalStrategy('Alpha', 'NFO:NIFTY26FEB22500CE', 0.90)],
+        _DummyIndicatorEngine(),
+        _DummyPositionManager(),
+    )
+    signal = manager.generate_signal('NFO:NIFTY26FEB22500CE', 100.0)
+    assert signal is not None
+    assert bool(signal.metadata.get('preliminary_only')) is True

--- a/tests/strategies/test_runner_live_path_guards.py
+++ b/tests/strategies/test_runner_live_path_guards.py
@@ -57,6 +57,7 @@ def _build_runner() -> StrategyRunner:
     runner._entry_lock = threading.Lock()
     runner._trade_candidate_selector = MagicMock()
     runner.build_candidate_snapshots = MagicMock(return_value=[])
+    runner._market_data = None
     return runner
 
 
@@ -244,6 +245,42 @@ def test_live_option_requires_candidate_snapshots(monkeypatch) -> None:
     )
     assert result.accepted is False
     assert result.reason == 'missing_candidate_snapshots'
+
+
+def test_live_mode_blocks_when_startup_pipeline_not_ready(monkeypatch) -> None:
+    class _Mdm:
+        def readiness_state_snapshot(self) -> dict[str, object]:
+            return {'hard_ready': False, 'spot_ready': False, 'missing_hard': ['futures']}
+
+    runner = _build_runner()
+    runner._market_data = _Mdm()
+    monkeypatch.setenv('EXECUTION_MODE', 'LIVE')
+    signal = Signal(
+        action='BUY',
+        symbol='NFO:NIFTY26APR23800PE',
+        quantity=1,
+        confidence=0.7,
+        reason='test',
+        stop_loss=100.0,
+        take_profit=120.0,
+        metadata={
+            'direction_score': 9.0,
+            'strategy_score': 9.0,
+            'option_score': 9.0,
+            'data_score': 9.0,
+            'rr_score': 9.0,
+        },
+    )
+    result = runner._handle_entry_signal_inner(
+        signal,
+        base_symbol='NFO:NIFTY26APR23800PE',
+        trade_symbol='NFO:NIFTY26APR23800PE',
+        trade_price=110.0,
+        timestamp=datetime.now(timezone.utc),
+        trace_id='startup-not-ready',
+    )
+    assert result.accepted is False
+    assert result.reason == 'startup_pipeline_not_ready'
 
 
 def test_final_confidence_is_derived_from_final_score(monkeypatch) -> None:


### PR DESCRIPTION
### Motivation
- Startup sometimes reached LIVE evaluation even when market data pipeline reported `hard_ready=False`, allowing unsafe live signals and orders. 
- The base signal ensemble returned a single strategy signal directly which allowed weak single-vote approvals. 
- Candidate generation synthesized expiry-less `NIFTY{strike}{side}` strings and scheduled async refreshes with `create_task(coro)` then immediately read snapshots causing stale/invalid snapshots to be used. 
- Soft data warnings were generic and INFO log noise obscured decision-critical events.

### Description
- Added `MarketDataManager.hard_ready()`, `spot_ready()`, and `missing_hard()` accessors and emitted structured `SPOT_READY`, `DATA_PIPELINE_READY`, and `DATA_PIPELINE_NOT_READY` events during readiness wait. 
- After startup readiness wait `core/app.py` now maps indicator readiness to `hard_ready` and enforces a LIVE startup gate that sets `live_orders_armed=False`, `trading_ready=False`, `readiness_mode="DATA_WARMUP"`, and logs `LIVE_TRADING_BLOCKED` when `hard_ready` is false. 
- `StrategyRunner` now checks the MDM readiness before PHASE-9 evaluation and in entry path and returns `startup_pipeline_not_ready` / `candidate_refresh_pending` `SignalExecutionResult` to block live execution when appropriate. 
- Rewrote candidate resolution and snapshot build in `StrategyRunner`: added `build_candidate_snapshots_async`, prefer contract metadata sources (`OptionsContractStore` / `InstrumentManager` / `ContractSelector`) via `_resolve_candidate_contracts`, only fall back to tracked symbols regex, await `ensure_fresh_tick(...)` when awaitable (with timeout), and mark `refresh_pending` to block live path; removed expiry-less primary symbol synthesis. 
- Replaced the single-signal fast-path in the ensemble with conservative single-vote logic that normalises confidence, blocks weak single votes (logs `STRATEGY_CONSENSUS reason=single_vote_low_score`), marks high-confidence single votes as `preliminary_only`, and vetoes conflicting CE/PE BUY votes. 
- Replaced generic `soft_data_issue` warnings with structured `SOFT_DATA_ISSUE` events with explicit `reason` codes and added refresh/resolver structured logs (`CANDIDATE_REFRESH_*`, `CANDIDATE_RESOLVER_USED`, `CANDIDATE_RESOLVER_FALLBACK`). 
- Reduced INFO-level log spam by demoting high-frequency lifecycle traces (`RUNNER_LIVE_BAR_INGESTED`, `STRATEGY_MANAGER_ENTER/EXIT`, `STRATEGY_EVALUATED`) to `DEBUG` while preserving decision and block events at INFO/ERROR. 
- Added unit tests for single-vote consensus behavior and for the startup readiness gate blocking live execution, and left existing behavior constraints intact (CE/PE sides preserved, orchestration prefilter naming preserved, tradable_quote checks and hydration caps unchanged).

### Testing
- Compiled the code with `python -m compileall src` and the compile passed. 
- Ran focused test suite `pytest -q tests/test_startup_readiness.py tests/core/test_strategy_manager_scoring.py tests/strategies/test_strategy_runner_datahub.py tests/strategies/test_runner_live_path_guards.py` and all tests in that set passed. 
- `pytest -q` across the whole repository failed early due to a pre-existing import issue in the repo (`ImportError: cannot import name 'InstrumentResolver' from 'nifty_scalper_bot.data'`) which is unrelated to these changes. 
- Executed `bash ./run_checks.sh` in this environment which installed dependencies but reported a venv/script environment mismatch (script flow reported `pytest not installed` inside the created venv); this is environmental and not caused by the code edits. 
- Performed grep/verifications to confirm removal of risky patterns and log presence: no expiry-less `NIFTY{strike}` templates produced as primary path, no `create_task(coro)` followed by immediate snapshot read in the candidate path, no remaining generic `soft_data_issue` logs, `DATA_PIPELINE_READY`/`DATA_PIPELINE_NOT_READY` and `LIVE_TRADING_BLOCKED` events are present, and updated ensemble single-vote behaviour is in place.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef273f4bc883248ff7228629a3d60d)