### PR TITLE
Add live trading readiness gates and preflight diagnostics

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -1697,6 +1697,10 @@ class BotContext:
     live_orders_armed: bool = False
     trading_ready: bool = False
     readiness_mode: str = "SHADOW"
+    live_block_reason: str | None = None
+    market_session_state: str | None = None
+    quote_api_available: bool = True
+    quote_api_error: str | None = None
 
     def update_spot_price(
         self, underlying: str, price: float, max_size: int = 100
@@ -3201,6 +3205,7 @@ def _setup_telegram(ctx: BotContext) -> None:
             data_hub=ctx.data_hub,
             instrument_resolver=getattr(ctx, "instrument_manager", None),
             enable_polling_fallback=True,
+            bot_context=ctx,
         )
 
         ctx.telegram_bot = TelegramBot(deps)
@@ -5412,6 +5417,7 @@ def initialize_components(settings: Settings | None = None) -> BotContext:
                 reload_hook=None,
                 telegram_plain=telegram_plain_flag,
                 selfchecker=ctx.selfchecker,
+                bot_context=ctx,
             )
             telegram_bot_instance = TelegramBot(deps)
             telegram_chat_id = int(telegram_cfg.chat_id)
@@ -5554,6 +5560,36 @@ def force_enable_trading_override() -> str:
 
     LOGGER.critical(f"🚨 MANUAL OVERRIDE ACTIVATED: {', '.join(logs)}")
     return "\n".join(logs)
+
+
+def _resolve_quote_capability(ctx: BotContext) -> dict[str, Any]:
+    """Combine MDM and broker quote capability snapshots. Args: ctx. Returns: combined snapshot. Raises: none."""
+    available = True
+    error: str | None = None
+    sources: list[dict[str, Any]] = []
+    for holder in (
+        ctx.market_data_manager,
+        ctx.broker_client,
+        getattr(ctx.broker_client, "_broker", None),
+        getattr(ctx.broker_client, "broker", None),
+    ):
+        if holder is None:
+            continue
+        snap_fn = getattr(holder, "quote_api_status_snapshot", None)
+        if not callable(snap_fn):
+            continue
+        try:
+            snap = snap_fn() or {}
+        except Exception:  # noqa: BLE001
+            continue
+        snap_available = bool(snap.get("available", True))
+        snap_error = snap.get("error")
+        sources.append({"available": snap_available, "error": snap_error})
+        if not snap_available:
+            available = False
+            if snap_error and not error:
+                error = str(snap_error)
+    return {"available": available, "error": error, "sources": sources}
 
 
 async def startup_sequence(ctx: BotContext) -> None:
@@ -7293,22 +7329,31 @@ async def startup_sequence(ctx: BotContext) -> None:
                                 .lower()
                                 in {"1", "true", "yes", "on"}
                             )
-                            quote_available = True
-                            quote_error = None
+                            quote_capability = _resolve_quote_capability(ctx)
+                            quote_available = bool(quote_capability["available"])
+                            quote_error = quote_capability["error"]
                             ws_quote_proof = False
-                            quote_status_fn = getattr(
-                                ctx.market_data_manager, "quote_api_status_snapshot", None
-                            )
-                            if callable(quote_status_fn):
-                                quote_status = quote_status_fn() or {}
-                                quote_available = bool(quote_status.get("available", True))
-                                quote_error = quote_status.get("error")
                             ws_quote_proof_fn = getattr(
                                 ctx.market_data_manager, "has_ws_tradable_quote", None
                             )
                             if callable(ws_quote_proof_fn):
                                 ws_quote_proof = bool(ws_quote_proof_fn())
-                            if live_mode and not quote_available:
+                            try:
+                                market_state = get_market_state()
+                            except Exception:  # noqa: BLE001
+                                market_state = None
+                            session_state_str = (
+                                "open" if market_state == MarketState.OPEN else "closed"
+                            )
+                            LOGGER.info(
+                                "MARKET_SESSION_STATE state=%s",
+                                session_state_str,
+                                extra={
+                                    "event": "MARKET_SESSION_STATE",
+                                    "state": session_state_str,
+                                },
+                            )
+                            if not quote_available:
                                 LOGGER.info(
                                     "BROKER_QUOTE_CAPABILITY status=unavailable reason=%s",
                                     quote_error or "unknown",
@@ -7333,6 +7378,7 @@ async def startup_sequence(ctx: BotContext) -> None:
                                         ),
                                     },
                                 )
+                            data_warmup_reason: str | None = None
                             if live_mode and hard_ready and quote_available:
                                 ctx.live_orders_armed = True
                                 ctx.trading_ready = True
@@ -7341,6 +7387,7 @@ async def startup_sequence(ctx: BotContext) -> None:
                                 ctx.live_orders_armed = False
                                 ctx.trading_ready = False
                                 ctx.readiness_mode = "DATA_WARMUP"
+                                data_warmup_reason = "startup_pipeline_incomplete"
                                 LOGGER.error(
                                     "LIVE_TRADING_BLOCKED reason=startup_pipeline_incomplete missing=%s",
                                     missing_hard,
@@ -7360,11 +7407,35 @@ async def startup_sequence(ctx: BotContext) -> None:
                                 ctx.live_orders_armed = False
                                 ctx.trading_ready = False
                                 ctx.readiness_mode = "DATA_WARMUP"
+                                data_warmup_reason = "broker_quote_access_denied"
                                 LOGGER.error(
                                     "LIVE_TRADING_BLOCKED reason=broker_quote_access_denied",
                                     extra={
                                         "event": "LIVE_TRADING_BLOCKED",
                                         "reason": "broker_quote_access_denied",
+                                    },
+                                )
+                            if (
+                                live_mode
+                                and ctx.readiness_mode == "DATA_WARMUP"
+                                and data_warmup_reason is None
+                            ):
+                                data_warmup_reason = (
+                                    "market_closed"
+                                    if market_state != MarketState.OPEN
+                                    else "startup_pipeline_incomplete"
+                                )
+                            ctx.live_block_reason = data_warmup_reason
+                            ctx.market_session_state = session_state_str
+                            ctx.quote_api_available = quote_available
+                            ctx.quote_api_error = quote_error
+                            if data_warmup_reason:
+                                LOGGER.info(
+                                    "DATA_WARMUP reason=%s",
+                                    data_warmup_reason,
+                                    extra={
+                                        "event": "DATA_WARMUP",
+                                        "reason": data_warmup_reason,
                                     },
                                 )
                             LOGGER.info(

--- a/src/nifty_scalper_bot/notifications/telegram_controller.py
+++ b/src/nifty_scalper_bot/notifications/telegram_controller.py
@@ -451,6 +451,8 @@ class TelegramDeps:
     # Optional hot-reload hook
     reload_hook: t.Callable[[], str] | None = None
     selfchecker: t.Any | None = None
+    # Bot-wide runtime context exposing readiness/live gates
+    bot_context: t.Any | None = None
 
     # NOTE: the attributes above are intentionally soft-typed; the handlers below
     # probe methods with getattr/with suppress() to avoid hard coupling with
@@ -4433,6 +4435,7 @@ class TelegramBot:
                     ("check_execution", self.cmd_check_execution, ()),
                     ("check_connectivity", self.cmd_check_connectivity, ()),
                     ("why", self.cmd_why, ()),
+                    ("preflight", self.cmd_preflight, ()),
                     ("flow", self.cmd_flow, ()),
                     ("profile", self.cmd_profile, ()),
                     ("metrics", self.cmd_metrics, ()),
@@ -15022,9 +15025,104 @@ class TelegramBot:
             )
         await self._reply(chat, ctx, text, parse_mode=ParseMode.HTML)
 
+    def _gather_preflight_state(self) -> dict[str, t.Any]:
+        """Args: none. Returns: preflight summary dict. Raises: none."""
+        bot_ctx = getattr(self.deps, "bot_context", None)
+        mdm = getattr(self.deps, "market_data_manager", None)
+        broker = getattr(self.deps, "broker_client", None)
+        quote_available = True
+        quote_error: str | None = None
+        for holder in (
+            mdm,
+            broker,
+            getattr(broker, "_broker", None),
+            getattr(broker, "broker", None),
+        ):
+            if holder is None:
+                continue
+            snap_fn = getattr(holder, "quote_api_status_snapshot", None)
+            if not callable(snap_fn):
+                continue
+            with suppress(Exception):
+                snap = snap_fn() or {}
+                if not bool(snap.get("available", True)):
+                    quote_available = False
+                    if not quote_error and snap.get("error"):
+                        quote_error = str(snap.get("error"))
+        readiness: dict[str, t.Any] = {}
+        if mdm is not None:
+            readiness_fn = getattr(mdm, "readiness_state_snapshot", None)
+            if callable(readiness_fn):
+                with suppress(Exception):
+                    readiness = dict(readiness_fn() or {})
+        hard_ready = bool(readiness.get("hard_ready"))
+        spot_ready = bool(readiness.get("spot_ready"))
+        missing_hard = list(readiness.get("missing_hard") or [])
+        market_session_state = getattr(bot_ctx, "market_session_state", None)
+        if not market_session_state:
+            with suppress(Exception):
+                from nifty_scalper_bot.utils.market_hours import (
+                    MarketState as _MS,
+                    get_market_state as _gms,
+                )
+
+                market_session_state = (
+                    "open" if _gms() == _MS.OPEN else "closed"
+                )
+        return {
+            "quote_api_available": bool(
+                quote_available
+                and bool(getattr(bot_ctx, "quote_api_available", True))
+            ),
+            "quote_api_error": quote_error
+            or getattr(bot_ctx, "quote_api_error", None),
+            "market_session_state": market_session_state or "unknown",
+            "effective_mode": getattr(bot_ctx, "readiness_mode", "unknown"),
+            "live_orders_armed": bool(
+                getattr(bot_ctx, "live_orders_armed", False)
+            ),
+            "trading_ready": bool(getattr(bot_ctx, "trading_ready", False)),
+            "hard_ready": hard_ready,
+            "spot_ready": spot_ready,
+            "missing_hard": missing_hard,
+            "live_block_reason": getattr(bot_ctx, "live_block_reason", None),
+        }
+
+    @command_meta(
+        "/preflight",
+        "Show data/quote/live readiness summary.",
+    )
+    async def cmd_preflight(
+        self, update: Update, ctx: ContextTypes.DEFAULT_TYPE
+    ) -> None:
+        chat = await self._guard(update)
+        if chat is None:
+            return
+        rb = self._response_builder
+        info = self._gather_preflight_state()
+        rows = [
+            ("quote_api_available", str(info["quote_api_available"])),
+            ("quote_api_error", str(info["quote_api_error"] or "—")),
+            ("market_session_state", str(info["market_session_state"])),
+            ("effective_mode", str(info["effective_mode"])),
+            ("live_orders_armed", str(info["live_orders_armed"])),
+            ("trading_ready", str(info["trading_ready"])),
+            ("hard_ready", str(info["hard_ready"])),
+            ("spot_ready", str(info["spot_ready"])),
+            (
+                "missing_hard",
+                ",".join(info["missing_hard"]) if info["missing_hard"] else "—",
+            ),
+            ("live_block_reason", str(info["live_block_reason"] or "—")),
+        ]
+        body = f"{rb.section('Preflight')}<br>{rb.grid(rows)}"
+        text = self._compose([[body]])
+        await self._reply(chat, ctx, text, parse_mode=ParseMode.HTML)
+        return
+
     @command_meta(
         "/why",
-        "Explain risk breaker state and the last recorded error.",
+        "Explain risk breaker state, live block reason, and the last recorded error.",
     )
     async def cmd_why(self, update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
         chat = await self._guard(update)
@@ -15033,6 +15131,7 @@ class TelegramBot:
         rb = self._response_builder
         snap = self._coerce_risk_snapshot()
         info = self._last_error()
+        preflight = self._gather_preflight_state()
         if info is not None:
             category, message, when = info
             hint = self._hint_for(category, message)
@@ -15047,6 +15146,28 @@ class TelegramBot:
             )
         else:
             last_error_html = f"{rb.section('Last Error')}<br><i>No recent errors.</i>"
+
+        live_rows = [
+            ("effective_mode", str(preflight["effective_mode"])),
+            ("live_orders_armed", str(preflight["live_orders_armed"])),
+            ("trading_ready", str(preflight["trading_ready"])),
+            (
+                "live_block_reason",
+                str(preflight["live_block_reason"] or "—"),
+            ),
+            ("quote_api_available", str(preflight["quote_api_available"])),
+            ("quote_api_error", str(preflight["quote_api_error"] or "—")),
+            ("market_session_state", str(preflight["market_session_state"])),
+            ("hard_ready", str(preflight["hard_ready"])),
+            ("spot_ready", str(preflight["spot_ready"])),
+            (
+                "missing_hard",
+                ",".join(preflight["missing_hard"])
+                if preflight["missing_hard"]
+                else "—",
+            ),
+        ]
+        live_html = f"{rb.section('Live Gate')}<br>{rb.grid(live_rows)}"
 
         risk_html = ""
         if snap:
@@ -15077,7 +15198,10 @@ class TelegramBot:
                 f"{EMOJI['risk']} {rb.section('Risk Snapshot')}<br>{rb.grid(risk_rows)}"
             )
 
-        text = self._compose([[last_error_html]] + ([[risk_html]] if risk_html else []))
+        sections = [[last_error_html], [live_html]]
+        if risk_html:
+            sections.append([risk_html])
+        text = self._compose(sections)
 
         await self._reply(chat, ctx, text, parse_mode=ParseMode.HTML)
         return

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -826,19 +826,11 @@ class StrategyRunner:
             if signal:
                 from datetime import datetime, timezone
                 now = datetime.now(timezone.utc)
-                prepared_signal: Signal | None = None
-                prepare_reason: str | None = None
-                try:
-                    asyncio.get_running_loop()
-                    prepare_reason = "candidate_refresh_pending"
-                except RuntimeError:
-                    prepared_signal, prepare_reason = asyncio.run(
-                        self._prepare_signal_for_handling(
-                            signal,
-                            price,
-                            trace_id,
-                        )
-                    )
+                prepared_signal, prepare_reason = await self._prepare_signal_for_handling(
+                    signal,
+                    price,
+                    trace_id,
+                )
                 if prepared_signal is None:
                     self._emit_runner_eval_decision(
                         symbol=symbol,
@@ -1576,9 +1568,10 @@ class StrategyRunner:
             }
             selected = self._resolve_candidate_contracts(side=side, target_strikes=target_strikes)
             selected = sorted(set(selected), key=lambda item: abs(item[1] - atm))
-            refresh_pending = False
+            any_refresh_pending = False
             candidates: list[dict[str, Any]] = []
             for sym, strike in selected[: max(1, 2 * window_each_side + 1)]:
+                symbol_refresh_pending = False
                 try:
                     self._market_data.request_symbol_subscription(sym)
                 except Exception:
@@ -1598,14 +1591,15 @@ class StrategyRunner:
                                 extra={"event": "CANDIDATE_REFRESH_COMPLETE", "symbol": sym},
                             )
                         except asyncio.TimeoutError:
-                            refresh_pending = True
+                            symbol_refresh_pending = True
+                            any_refresh_pending = True
                             self._logger.warning(
                                 "CANDIDATE_REFRESH_TIMEOUT symbol=%s",
                                 sym,
                                 extra={"event": "CANDIDATE_REFRESH_TIMEOUT", "symbol": sym},
                             )
                 snap = self._market_data.get_symbol_snapshot(sym)
-                if refresh_pending and (snap.ltp is None or not snap.tradable_quote):
+                if symbol_refresh_pending and (snap.ltp is None or not snap.tradable_quote):
                     self._logger.warning(
                         "CANDIDATE_SNAPSHOT_PENDING_REFRESH symbol=%s",
                         sym,
@@ -1637,10 +1631,16 @@ class StrategyRunner:
                         "ask_missing": snap.ask_missing,
                         "bid_ask_source": snap.bid_ask_source,
                         "tradable_quote": snap.tradable_quote,
-                        "refresh_pending": refresh_pending,
+                        "refresh_pending": symbol_refresh_pending,
                     }
                 )
-            return candidates, refresh_pending
+            no_valid_candidates = not any(
+                bool(cand.get("tradable_quote"))
+                and not bool(cand.get("refresh_pending"))
+                and cand.get("ltp") is not None
+                for cand in candidates
+            )
+            return candidates, bool(any_refresh_pending and no_valid_candidates)
         except Exception as exc:
             self._logger.error("CANDIDATE_SNAPSHOT_BUILD_FAILED reason=%s", exc)
             return [], True
@@ -6487,19 +6487,15 @@ class StrategyRunner:
                     extra={"event": "signal_executing", "symbol": symbol,
                            "action": signal.action},
                 )
-                prepared_signal: Signal | None = None
+                prepared_signal: Signal | None = signal
                 prepare_reason: str | None = None
-                try:
-                    asyncio.get_running_loop()
+                if isinstance(signal.metadata, dict) and isinstance(
+                    signal.metadata.get("candidate_snapshots"), list
+                ):
+                    pass
+                else:
+                    prepared_signal = None
                     prepare_reason = "candidate_refresh_pending"
-                except RuntimeError:
-                    prepared_signal, prepare_reason = asyncio.run(
-                        self._prepare_signal_for_handling(
-                            signal,
-                            price,
-                            trace_id,
-                        )
-                    )
                 if prepared_signal is None:
                     self._emit_runner_eval_decision(
                         symbol=symbol,
@@ -7346,24 +7342,8 @@ class StrategyRunner:
             if is_live_mode and is_directional_option and not isinstance(
                 candidate_snapshots_obj, list
             ):
-                atm_strike = int(metadata.get("atm_strike") or 0)
-                try:
-                    asyncio.get_running_loop()
-                    self._reset_execution_state(base_symbol)
-                    return SignalExecutionResult(False, "candidate_refresh_pending")
-                except RuntimeError:
-                    built, refresh_pending = asyncio.run(
-                        self.build_candidate_snapshots_async(
-                            direction_bias=cast(Literal["CE", "PE"], option_side),
-                            atm_strike=atm_strike,
-                            underlying=underlying,
-                        )
-                    )
-                if refresh_pending:
-                    self._reset_execution_state(base_symbol)
-                    return SignalExecutionResult(False, "candidate_refresh_pending")
-                metadata["candidate_snapshots"] = built
-                candidate_snapshots_obj = built
+                self._reset_execution_state(base_symbol)
+                return SignalExecutionResult(False, "candidate_refresh_pending")
             if is_live_mode and is_directional_option and not candidate_snapshots_obj:
                 self._reset_execution_state(base_symbol)
                 return SignalExecutionResult(False, "missing_candidate_snapshots")

--- a/tests/strategies/test_runner_live_path_guards.py
+++ b/tests/strategies/test_runner_live_path_guards.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from collections import deque
 from datetime import datetime, timezone
 import logging
@@ -604,3 +605,217 @@ def test_premium_helper_skips_future_symbols() -> None:
     )
     assert generated is None
     runner._indicator_engine.get_indicators.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_process_token_awaits_prepare_signal_for_handling(monkeypatch) -> None:
+    runner = _build_runner()
+    captured: dict[str, object] = {}
+
+    class _StrategyManager:
+        def generate_signal(self, _symbol: str, _price: float):
+            return Signal(
+                action='BUY',
+                symbol='NFO:NIFTY26APR23800CE',
+                quantity=1,
+                confidence=0.9,
+                reason='unit_test',
+                stop_loss=100.0,
+                take_profit=120.0,
+                metadata={},
+            )
+
+    runner._strategy_manager = _StrategyManager()
+    runner._data_hub = None
+    runner._market_data = MagicMock()
+    runner._market_data._symbol_by_token = {1: 'NSE:NIFTY'}
+
+    async def _fake_prepare(signal, price, trace_id):
+        captured['called'] = True
+        captured['trace_id'] = trace_id
+        new_signal = signal
+        return new_signal, None
+
+    runner._prepare_signal_for_handling = _fake_prepare
+    runner._handle_signal = MagicMock(return_value=None)
+    runner._emit_runner_eval_decision = lambda **_kw: None
+
+    import pandas as pd
+
+    candles = pd.DataFrame(
+        [
+            {
+                'open': 100.0,
+                'high': 102.0,
+                'low': 99.0,
+                'close': 101.0,
+                'volume': 100.0,
+            }
+        ]
+    )
+    await runner._process_token(1, candles, indicators=None)
+    assert captured.get('called') is True
+    runner._handle_signal.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_build_candidate_snapshots_per_symbol_refresh_pending() -> None:
+    runner = _build_runner()
+    spot = MagicMock()
+    spot.ltp = 23800.0
+    spot.canonical_symbol = 'NSE:NIFTY'
+
+    fresh_snap = MagicMock()
+    fresh_snap.canonical_symbol = 'NFO:NIFTY26APR23800CE'
+    fresh_snap.ltp = 100.0
+    fresh_snap.bid = 99.0
+    fresh_snap.ask = 101.0
+    fresh_snap.mid = 100.0
+    fresh_snap.tick_age_s = 1.0
+    fresh_snap.source = 'ws'
+    fresh_snap.real_ticks_last_60s = 30
+    fresh_snap.latest_candle_provisional = False
+    fresh_snap.latest_candle_synthetic = False
+    fresh_snap.latest_candle_volume = 1.0
+    fresh_snap.ohlc_valid = True
+    fresh_snap.bid_missing = False
+    fresh_snap.ask_missing = False
+    fresh_snap.bid_ask_source = 'market_depth'
+    fresh_snap.tradable_quote = True
+
+    stale_snap = MagicMock()
+    stale_snap.canonical_symbol = 'NFO:NIFTY26APR23850CE'
+    stale_snap.ltp = None
+    stale_snap.bid = 0
+    stale_snap.ask = 0
+    stale_snap.mid = None
+    stale_snap.tick_age_s = 100.0
+    stale_snap.source = ''
+    stale_snap.real_ticks_last_60s = 0
+    stale_snap.latest_candle_provisional = True
+    stale_snap.latest_candle_synthetic = False
+    stale_snap.latest_candle_volume = 0.0
+    stale_snap.ohlc_valid = False
+    stale_snap.bid_missing = True
+    stale_snap.ask_missing = True
+    stale_snap.bid_ask_source = ''
+    stale_snap.tradable_quote = False
+
+    snapshots = {
+        'NIFTY': spot,
+        'NSE:NIFTY': spot,
+        'NFO:NIFTY26APR23800CE': fresh_snap,
+        'NFO:NIFTY26APR23850CE': stale_snap,
+    }
+
+    market_data = MagicMock()
+
+    def _get(symbol):
+        return snapshots.get(symbol, spot)
+
+    market_data.get_symbol_snapshot.side_effect = _get
+    market_data.request_symbol_subscription = MagicMock()
+
+    async def _ensure_fresh_tick(symbol):
+        if symbol == 'NFO:NIFTY26APR23850CE':
+            raise asyncio.TimeoutError
+        return None
+
+    market_data.ensure_fresh_tick = _ensure_fresh_tick
+    runner._market_data = market_data
+    runner._resolve_candidate_contracts = MagicMock(
+        return_value=[
+            ('NFO:NIFTY26APR23800CE', 23800),
+            ('NFO:NIFTY26APR23850CE', 23850),
+        ]
+    )
+
+    candidates, refresh_pending = await runner.build_candidate_snapshots_async(
+        underlying='NIFTY',
+        direction_bias='CE',
+        atm_strike=23800,
+        window_each_side=1,
+    )
+    assert any(
+        cand['symbol'] == 'NFO:NIFTY26APR23800CE'
+        and cand['refresh_pending'] is False
+        for cand in candidates
+    )
+    assert any(
+        cand['symbol'] == 'NFO:NIFTY26APR23850CE'
+        and cand['refresh_pending'] is True
+        for cand in candidates
+    )
+    assert refresh_pending is False  # at least one valid candidate keeps overall flag clear
+
+
+@pytest.mark.asyncio
+async def test_build_candidate_snapshots_all_pending_returns_refresh_pending() -> None:
+    runner = _build_runner()
+    spot = MagicMock()
+    spot.ltp = 23800.0
+    spot.canonical_symbol = 'NSE:NIFTY'
+
+    def _stale(name: str):
+        snap = MagicMock()
+        snap.canonical_symbol = name
+        snap.ltp = None
+        snap.bid = 0
+        snap.ask = 0
+        snap.mid = None
+        snap.tick_age_s = 100.0
+        snap.source = ''
+        snap.real_ticks_last_60s = 0
+        snap.latest_candle_provisional = True
+        snap.latest_candle_synthetic = False
+        snap.latest_candle_volume = 0.0
+        snap.ohlc_valid = False
+        snap.bid_missing = True
+        snap.ask_missing = True
+        snap.bid_ask_source = ''
+        snap.tradable_quote = False
+        return snap
+
+    snapshots = {
+        'NIFTY': spot,
+        'NSE:NIFTY': spot,
+        'NFO:NIFTY26APR23800CE': _stale('NFO:NIFTY26APR23800CE'),
+        'NFO:NIFTY26APR23850CE': _stale('NFO:NIFTY26APR23850CE'),
+    }
+
+    market_data = MagicMock()
+    market_data.get_symbol_snapshot.side_effect = lambda s: snapshots.get(s, spot)
+    market_data.request_symbol_subscription = MagicMock()
+
+    async def _ensure_fresh_tick(_symbol):
+        raise asyncio.TimeoutError
+
+    market_data.ensure_fresh_tick = _ensure_fresh_tick
+    runner._market_data = market_data
+    runner._resolve_candidate_contracts = MagicMock(
+        return_value=[
+            ('NFO:NIFTY26APR23800CE', 23800),
+            ('NFO:NIFTY26APR23850CE', 23850),
+        ]
+    )
+
+    candidates, refresh_pending = await runner.build_candidate_snapshots_async(
+        underlying='NIFTY',
+        direction_bias='CE',
+        atm_strike=23800,
+        window_each_side=1,
+    )
+    assert all(cand['refresh_pending'] is True for cand in candidates)
+    assert refresh_pending is True
+
+
+def test_runner_no_async_event_loop_fallback_in_runner_source() -> None:
+    """Regression guard: async paths must not skip prep just because event loop exists."""
+    from pathlib import Path
+    source = Path('src/nifty_scalper_bot/strategies/runner.py').read_text(encoding='utf-8')
+    # _process_token must call await self._prepare_signal_for_handling
+    assert 'await self._prepare_signal_for_handling' in source
+    # Sync candidate-builder fallback in _on_tick was removed
+    assert 'asyncio.run(\n                        self._prepare_signal_for_handling' not in source
+    # _handle_entry_signal_inner must not build snapshots in sync path
+    assert 'asyncio.run(\n                        self.build_candidate_snapshots_async' not in source

--- a/tests/test_startup_sequence.py
+++ b/tests/test_startup_sequence.py
@@ -443,3 +443,71 @@ def test_startup_blocks_live_on_quote_access_denied() -> None:
     source = Path('src/nifty_scalper_bot/core/app.py').read_text(encoding='utf-8')
     assert 'LIVE_TRADING_BLOCKED reason=broker_quote_access_denied' in source
     assert 'BROKER_QUOTE_CAPABILITY status=unavailable reason=%s' in source
+
+
+def test_startup_emits_market_session_and_data_warmup_logs() -> None:
+    source = Path('src/nifty_scalper_bot/core/app.py').read_text(encoding='utf-8')
+    assert 'MARKET_SESSION_STATE state=%s' in source
+    assert 'DATA_WARMUP reason=%s' in source
+
+
+def test_resolve_quote_capability_combines_mdm_and_broker() -> None:
+    from nifty_scalper_bot.core.app import _resolve_quote_capability
+
+    class _MDMOk:
+        def quote_api_status_snapshot(self) -> dict[str, Any]:
+            return {"available": True, "error": None}
+
+    class _BrokerForbidden:
+        def quote_api_status_snapshot(self) -> dict[str, Any]:
+            return {"available": False, "error": "access_denied"}
+
+    class _Ctx:
+        market_data_manager = _MDMOk()
+        broker_client = _BrokerForbidden()
+
+    snap = _resolve_quote_capability(_Ctx())
+    assert snap["available"] is False
+    assert snap["error"] == "access_denied"
+
+
+def test_resolve_quote_capability_unwraps_robust_provider() -> None:
+    from nifty_scalper_bot.core.app import _resolve_quote_capability
+
+    class _Inner:
+        def quote_api_status_snapshot(self) -> dict[str, Any]:
+            return {"available": False, "error": "access_denied"}
+
+    class _RobustProvider:
+        _broker = _Inner()
+
+    class _MDMOk:
+        def quote_api_status_snapshot(self) -> dict[str, Any]:
+            return {"available": True, "error": None}
+
+    class _Ctx:
+        market_data_manager = _MDMOk()
+        broker_client = _RobustProvider()
+
+    snap = _resolve_quote_capability(_Ctx())
+    assert snap["available"] is False
+    assert snap["error"] == "access_denied"
+
+
+def test_resolve_quote_capability_margin_success_does_not_override_quote_failure() -> None:
+    from nifty_scalper_bot.core.app import _resolve_quote_capability
+
+    class _BrokerWithDeniedQuote:
+        def quote_api_status_snapshot(self) -> dict[str, Any]:
+            return {"available": False, "error": "access_denied"}
+
+        def get_margins(self, *_args, **_kwargs) -> dict[str, Any]:
+            return {"equity": {"available": {"cash": 1000.0}}}
+
+    class _Ctx:
+        market_data_manager = None
+        broker_client = _BrokerWithDeniedQuote()
+
+    snap = _resolve_quote_capability(_Ctx())
+    assert snap["available"] is False
+    assert snap["error"] == "access_denied"


### PR DESCRIPTION
## Summary
This PR introduces comprehensive live trading readiness monitoring and diagnostic capabilities. It adds a new `/preflight` command to expose data/quote/live gate status, enhances the `/why` command with live gate information, and refactors async signal preparation to properly await async operations instead of falling back to sync execution.

## Key Changes

### Live Trading Readiness Gates
- Added `live_block_reason`, `market_session_state`, `quote_api_available`, and `quote_api_error` fields to `BotContext` to track live trading blockers
- Introduced `_resolve_quote_capability()` helper to combine quote API status from both market data manager and broker client
- Enhanced startup sequence to detect and log market session state and data warmup reasons
- Properly distinguish between different blocking reasons: startup pipeline incomplete, broker quote access denied, and market closed

### Telegram Diagnostics
- Added new `/preflight` command that displays:
  - Quote API availability and errors
  - Market session state (open/closed)
  - Effective readiness mode
  - Live orders armed status
  - Trading readiness state
  - Hard/spot readiness flags
  - Missing hard requirements
  - Live block reason
- Enhanced `/why` command to include live gate section alongside risk snapshot and error information
- Added `bot_context` field to `TelegramDeps` to expose runtime readiness state

### Async Signal Preparation Refactoring
- Fixed `_process_token()` to properly `await` `_prepare_signal_for_handling()` instead of attempting `asyncio.run()` fallback when event loop exists
- Removed sync fallback pattern that would skip preparation when event loop was already running
- Updated `build_candidate_snapshots_async()` to track per-symbol refresh pending status and only return overall refresh_pending=True when all candidates are pending
- Simplified `_handle_entry_signal_inner()` to skip candidate snapshot building in sync context (returns refresh_pending reason)

### Test Coverage
- Added async tests for signal preparation awaiting behavior
- Added tests for candidate snapshot refresh pending logic (mixed fresh/stale, all pending scenarios)
- Added regression guard test ensuring async paths don't skip preparation
- Added tests for `_resolve_quote_capability()` combining MDM and broker snapshots
- Added tests for market session state and data warmup logging

https://claude.ai/code/session_01D1j735neTZBMsqejm2zg7q