### PR TITLE
Fix WebSocket-first market data readiness and Zerodha quote fallback

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -430,6 +430,7 @@ from nifty_scalper_bot.execution.paper_fill_engine import PaperFillEngine
 from nifty_scalper_bot.execution.position_manager import ActiveContract, PositionManager
 from nifty_scalper_bot.execution.post_fill_monitor import PostFillMonitor
 from nifty_scalper_bot.execution.preflight_validator import PreFlightValidator
+from nifty_scalper_bot.execution.readiness import compute_live_readiness
 from nifty_scalper_bot.execution.safe_order_manager import SafeOrderManager
 from nifty_scalper_bot.execution.state_tracker import StateTracker
 from nifty_scalper_bot.infra.cron_refresh import schedule_instrument_refresh
@@ -1703,6 +1704,11 @@ class BotContext:
     market_session_state: str | None = None
     quote_api_available: bool = True
     quote_api_error: str | None = None
+    # Authoritative live trading universe selected by the WS-spot-first
+    # startup pipeline.  When populated, downstream legacy hydration paths
+    # must reuse this rather than rebuild with their own (potentially
+    # synthetic) spot price.
+    active_trading_universe: dict[str, Any] | None = None
 
     def update_spot_price(
         self, underlying: str, price: float, max_size: int = 100
@@ -5564,6 +5570,163 @@ def force_enable_trading_override() -> str:
     return "\n".join(logs)
 
 
+_SYNTHETIC_FALLBACK_SPOT = 25600.0
+
+
+def _is_live_execution_mode(configured_mode: str | None = None) -> bool:
+    """Return True when the bot is configured to place live broker orders.
+
+    The check honours both the explicit ``EXECUTION_MODE`` value and the
+    legacy ``ENABLE_LIVE`` flag.  Synthetic fallbacks (such as the 25600.0
+    NIFTY proxy used during off-hours simulation) MUST be gated on the
+    inverse of this so live order arming can never select strikes from a
+    fake spot price.
+
+    Args:
+        configured_mode: Optional pre-resolved ``EXECUTION_MODE`` value.
+
+    Returns:
+        True if execution mode is LIVE *or* ENABLE_LIVE is truthy.
+    """
+
+    mode = str(
+        configured_mode
+        if configured_mode is not None
+        else os.getenv("EXECUTION_MODE", "")
+    ).strip().upper()
+    if mode == "LIVE":
+        return True
+    flag = str(os.getenv("ENABLE_LIVE", "false")).strip().lower()
+    return flag in {"1", "true", "yes", "on"}
+
+
+def _allow_synthetic_market_data() -> bool:
+    """Return True when explicit synthetic fallback is permitted.
+
+    Used so unit/integration tests can opt-in to the deterministic 25600.0
+    NIFTY fallback even while ``EXECUTION_MODE`` claims LIVE.
+    """
+
+    flag = str(os.getenv("ALLOW_SYNTHETIC_MARKET_DATA", "false")).strip().lower()
+    return flag in {"1", "true", "yes", "on"}
+
+
+def _coerce_spot_price(tick: Mapping[str, Any] | None) -> float | None:
+    """Pull a positive spot price out of an MDM tick payload."""
+
+    if not isinstance(tick, Mapping):
+        return None
+    for key in ("last_price", "ltp", "price", "close"):
+        raw = tick.get(key)
+        if raw is None:
+            continue
+        try:
+            value = float(raw)
+        except (TypeError, ValueError):
+            continue
+        if value > 0:
+            return value
+    return None
+
+
+async def _wait_for_live_spot_or_raise(
+    ctx: BotContext,
+    *,
+    timeout: float = 15.0,
+    configured_mode: str | None = None,
+) -> float:
+    """Resolve the NIFTY spot price to use for live option universe selection.
+
+    In LIVE mode this requires fresh WebSocket tick proof for ``NSE:NIFTY``
+    so the ATM basket cannot be built from a stale REST quote or synthetic
+    fallback.  In PAPER/SHADOW mode it allows REST/cached values and finally
+    a synthetic 25600.0 reference (with a clear log) so off-hours
+    simulations keep working.
+
+    Args:
+        ctx: Bot context with an attached MarketDataManager.
+        timeout: Maximum seconds to wait for a fresh WebSocket tick.
+        configured_mode: Optional pre-resolved ``EXECUTION_MODE`` value.
+
+    Returns:
+        Positive NIFTY spot price.
+
+    Raises:
+        RuntimeError: When LIVE mode is active but no fresh WebSocket
+            spot tick is available within ``timeout``.
+    """
+
+    mdm = ctx.market_data_manager
+    if mdm is None:
+        raise RuntimeError("MarketDataManager unavailable")
+
+    live_mode = _is_live_execution_mode(configured_mode)
+    wait_fn = getattr(mdm, "wait_for_fresh_spot_tick", None)
+    tick: Mapping[str, Any] | None = None
+    if callable(wait_fn):
+        try:
+            tick = await wait_fn(
+                "NSE:NIFTY",
+                timeout=float(timeout),
+                max_age_seconds=120.0,
+                require_ws=live_mode,
+            )
+        except Exception as exc:  # noqa: BLE001
+            LOGGER.warning(
+                "wait_for_fresh_spot_tick failed: %s",
+                exc,
+                extra={"event": "wait_for_fresh_spot_tick_failed"},
+            )
+            tick = None
+
+    price = _coerce_spot_price(tick)
+    if price is not None:
+        LOGGER.info(
+            "LIVE_SPOT_READY symbol=NSE:NIFTY price=%.2f source=ws",
+            price,
+            extra={
+                "event": "LIVE_SPOT_READY",
+                "symbol": "NSE:NIFTY",
+                "price": price,
+                "source": "ws",
+            },
+        )
+        return float(price)
+
+    if live_mode and not _allow_synthetic_market_data():
+        raise RuntimeError(
+            "fresh NIFTY WebSocket spot tick unavailable; "
+            "cannot build live option universe"
+        )
+
+    # Paper / off-hours fallback path: try cached REST/poll value first.
+    cached = float(mdm.get_latest_price("NSE:NIFTY") or 0.0)
+    if cached > 0:
+        LOGGER.info(
+            "LIVE_SPOT_READY symbol=NSE:NIFTY price=%.2f source=cache",
+            cached,
+            extra={
+                "event": "LIVE_SPOT_READY",
+                "symbol": "NSE:NIFTY",
+                "price": cached,
+                "source": "cache",
+            },
+        )
+        return float(cached)
+
+    LOGGER.warning(
+        "SYNTHETIC_SPOT_USED mode=%s price=%.2f reason=no_live_tick",
+        "LIVE" if live_mode else "NON_LIVE",
+        _SYNTHETIC_FALLBACK_SPOT,
+        extra={
+            "event": "SYNTHETIC_SPOT_USED",
+            "mode": "LIVE" if live_mode else "NON_LIVE",
+            "price": _SYNTHETIC_FALLBACK_SPOT,
+        },
+    )
+    return _SYNTHETIC_FALLBACK_SPOT
+
+
 def _resolve_quote_capability(ctx: BotContext) -> dict[str, Any]:
     """Combine MDM and broker quote capability snapshots. Args: ctx. Returns: combined snapshot. Raises: none."""
     available = True
@@ -5637,6 +5800,50 @@ async def startup_sequence(ctx: BotContext) -> None:
             )
         except Exception as _mdm_start_exc:
             LOGGER.error("MarketDataManager.start() failed: %s", _mdm_start_exc)
+
+    # ── Bring the WebSocket online with the NIFTY spot token FIRST ──
+    # The bot must observe a real exchange tick before selecting ATM
+    # options.  Starting the WS now (with the canonical NIFTY spot token
+    # already registered in MarketDataManager.__init__) lets us prove a
+    # fresh spot price before any option-universe selection runs and
+    # guarantees the readiness gate has a tick to evaluate.  Option
+    # tokens are added later via request_token_subscription once the
+    # ATM basket is known.
+    if (
+        ctx.market_data_manager is not None
+        and getattr(ctx, "websocket_enabled", True)
+        and hasattr(ctx.market_data_manager, "start_websocket")
+    ):
+        try:
+            register_fn = getattr(ctx.market_data_manager, "register_symbol", None)
+            if callable(register_fn):
+                try:
+                    register_fn("NSE:NIFTY", 256265)
+                except Exception:  # noqa: BLE001
+                    LOGGER.debug(
+                        "Spot symbol registration failed (will retry later)",
+                        exc_info=True,
+                    )
+            LOGGER.info(
+                "STARTUP_WS_SPOT_SUBSCRIBE_REQUESTED symbol=NSE:NIFTY token=%d",
+                256265,
+                extra={
+                    "event": "STARTUP_WS_SPOT_SUBSCRIBE_REQUESTED",
+                    "symbol": "NSE:NIFTY",
+                    "token": 256265,
+                },
+            )
+            ctx.market_data_manager.start_websocket()
+            LOGGER.info(
+                "STARTUP_WS_STARTED phase=spot_first",
+                extra={"event": "STARTUP_WS_STARTED", "phase": "spot_first"},
+            )
+        except Exception as _ws_spot_first_exc:  # noqa: BLE001
+            LOGGER.warning(
+                "WS spot-first start failed (will retry after token universe): %s",
+                _ws_spot_first_exc,
+                extra={"event": "STARTUP_WS_SPOT_FIRST_FAILED"},
+            )
 
     # =========================================================
     # Create Data Directory
@@ -5779,12 +5986,35 @@ async def startup_sequence(ctx: BotContext) -> None:
                 getattr(ctx.broker_client, "broker", ctx.broker_client),
             )
 
-            # Get approximate spot price (best-effort; fallback to a safe default)
-            _spot_for_hydration = 25600.0
-            if ctx.market_data_manager:
-                _last_nifty = ctx.market_data_manager.get_last_tick("NSE:NIFTY")
-                if _last_nifty:
-                    _spot_for_hydration = float(_last_nifty.get("ltp", _spot_for_hydration))
+            # Resolve NIFTY spot — in LIVE mode this requires fresh WS tick
+            # proof; in PAPER/SHADOW it gracefully falls back to cached/REST
+            # values or a logged synthetic reference for off-hours testing.
+            try:
+                _spot_for_hydration = await _wait_for_live_spot_or_raise(
+                    ctx,
+                    timeout=15.0,
+                    configured_mode=configured_mode,
+                )
+            except RuntimeError as _spot_exc:
+                LOGGER.error(
+                    "LIVE_STARTUP_SPOT_UNAVAILABLE reason=%s",
+                    _spot_exc,
+                    extra={
+                        "event": "LIVE_STARTUP_SPOT_UNAVAILABLE",
+                        "reason": str(_spot_exc),
+                        "phase": "pre_hydration",
+                    },
+                )
+                ctx.live_orders_armed = False
+                ctx.trading_ready = False
+                ctx.readiness_mode = "DATA_WARMUP"
+                ctx.live_block_reason = "fresh_spot_tick_unavailable"
+                # Skip the option pre-hydration in this iteration; the
+                # readiness gate will keep us in DATA_WARMUP and the
+                # supervisor will retry on the next loop.
+                _spot_for_hydration = None
+            if _spot_for_hydration is None:
+                raise RuntimeError("skip_pre_hydration_no_live_spot")
 
             # Select ATM option contracts purely by token — no string building
             _preloaded = (
@@ -5901,13 +6131,41 @@ async def startup_sequence(ctx: BotContext) -> None:
             targets = list(dict.fromkeys(targets))
 
             # Canonical live basket for trading path: spot + futures + ATM±3 CE/PE.
-            spot_ltp = 0.0
-            if ctx.market_data_manager is not None:
-                spot_ltp = float(
-                    ctx.market_data_manager.get_latest_price("NSE:NIFTY") or 0.0
+            # Resolve spot via the WS-first helper.  In LIVE mode this raises
+            # when no fresh WebSocket tick proof exists so we never select an
+            # ATM basket from a synthetic/stale price.
+            try:
+                spot_ltp = await _wait_for_live_spot_or_raise(
+                    ctx,
+                    timeout=15.0,
+                    configured_mode=configured_mode,
                 )
-            if spot_ltp <= 0:
-                spot_ltp = 25600.0
+            except RuntimeError as _basket_spot_exc:
+                LOGGER.error(
+                    "LIVE_STARTUP_SPOT_UNAVAILABLE reason=%s phase=basket",
+                    _basket_spot_exc,
+                    extra={
+                        "event": "LIVE_STARTUP_SPOT_UNAVAILABLE",
+                        "reason": str(_basket_spot_exc),
+                        "phase": "basket",
+                    },
+                )
+                LOGGER.error(
+                    "STARTUP_NO_FAKE_SPOT_LIVE_MODE reason=%s",
+                    "fresh_spot_tick_unavailable",
+                    extra={
+                        "event": "STARTUP_NO_FAKE_SPOT_LIVE_MODE",
+                        "reason": "fresh_spot_tick_unavailable",
+                    },
+                )
+                ctx.live_orders_armed = False
+                ctx.trading_ready = False
+                ctx.readiness_mode = "DATA_WARMUP"
+                ctx.live_block_reason = "fresh_spot_tick_unavailable"
+                # Bail out of basket selection entirely.  We re-raise so the
+                # outer handler logs and the supervisor can retry.  No fake
+                # ATM strikes are subscribed and no live arming happens.
+                raise
             try:
                 basket = _build_canonical_active_basket(
                     instrument_manager=ctx.instrument_manager,
@@ -5921,18 +6179,47 @@ async def startup_sequence(ctx: BotContext) -> None:
                 )
                 targets = list(dict.fromkeys(basket["symbols"]))
                 LOGGER.info(
-                    "ACTIVE_BASKET summary size=%d spot=%s fut=%s ce=%d pe=%d",
+                    "ACTIVE_BASKET_BUILT spot_ltp=%.2f size=%d spot=%s fut=%s ce=%d pe=%d",
+                    spot_ltp,
                     len(targets),
                     basket["spot_symbol"],
                     basket["futures_symbol"],
                     len(basket["ce_symbols"]),
                     len(basket["pe_symbols"]),
                     extra={
-                        "event": "active_basket_built",
+                        "event": "ACTIVE_BASKET_BUILT",
+                        "spot_ltp": spot_ltp,
                         "size": len(targets),
                         "atm": basket["atm_strike"],
+                        "symbols": list(targets),
                     },
                 )
+                # Record the authoritative live universe for downstream
+                # consumers so they reuse this rather than rebuild against a
+                # different (potentially fake) spot reference.
+                try:
+                    spot_token_int: int | None = None
+                    try:
+                        spot_token_int = int(
+                            ctx.broker_client.get_instrument_token("NSE:NIFTY")
+                        )
+                    except Exception:  # noqa: BLE001
+                        spot_token_int = 256265
+                    ctx.active_trading_universe = {
+                        "spot_symbol": basket["spot_symbol"],
+                        "spot_token": spot_token_int,
+                        "spot_ltp": float(spot_ltp),
+                        "symbols": list(targets),
+                        "futures_symbol": basket["futures_symbol"],
+                        "atm_strike": basket["atm_strike"],
+                        "selected_at": datetime.now(timezone.utc).isoformat(),
+                        "source": "ws_spot_first_instrument_manager",
+                    }
+                except Exception:  # noqa: BLE001
+                    LOGGER.debug(
+                        "active_trading_universe record failed",
+                        exc_info=True,
+                    )
             except Exception as basket_exc:  # noqa: BLE001
                 LOGGER.error(
                     "Failed building canonical active basket: %s",
@@ -6358,24 +6645,50 @@ async def startup_sequence(ctx: BotContext) -> None:
                     if tok and tok not in tokens_to_poll:
                         tokens_to_poll.append(tok)
 
-                # Add ATM Options and Futures
+                # Add ATM Options and Futures.  Reuse the spot LTP that the
+                # WS-first basket selection already proved fresh; never let a
+                # synthetic 25600.0 leak into LIVE option universe selection.
+                _active_universe = getattr(ctx, "active_trading_universe", None)
                 spot_price = 0.0
-                if mdm:
-                    last_tick = mdm.get_last_tick("NSE:NIFTY")
-                    if last_tick:
-                        spot_price = last_tick.get("ltp", 0.0)
+                if isinstance(_active_universe, Mapping):
+                    try:
+                        spot_price = float(_active_universe.get("spot_ltp") or 0.0)
+                    except (TypeError, ValueError):
+                        spot_price = 0.0
                 if spot_price <= 0:
-                    spot_price = 25600.0
+                    try:
+                        spot_price = await _wait_for_live_spot_or_raise(
+                            ctx,
+                            timeout=5.0,
+                            configured_mode=configured_mode,
+                        )
+                    except RuntimeError as _spot_token_exc:
+                        LOGGER.error(
+                            "STARTUP_NO_FAKE_SPOT_LIVE_MODE reason=%s phase=token_select",
+                            _spot_token_exc,
+                            extra={
+                                "event": "STARTUP_NO_FAKE_SPOT_LIVE_MODE",
+                                "reason": str(_spot_token_exc),
+                                "phase": "token_select",
+                            },
+                        )
+                        spot_price = 0.0
 
-                extra_tokens = im.select_tokens_for_universe(
-                    base="NIFTY",
-                    spot_price=spot_price,
-                    strikes_around_atm=3,
-                    strike_step=ctx.settings.option_universe.strike_step
-                )
-                for t in extra_tokens:
-                    if t and t not in tokens_to_poll:
-                        tokens_to_poll.append(t)
+                if spot_price > 0:
+                    extra_tokens = im.select_tokens_for_universe(
+                        base="NIFTY",
+                        spot_price=spot_price,
+                        strikes_around_atm=3,
+                        strike_step=ctx.settings.option_universe.strike_step
+                    )
+                    for t in extra_tokens:
+                        if t and t not in tokens_to_poll:
+                            tokens_to_poll.append(t)
+                else:
+                    LOGGER.warning(
+                        "Skipping ATM token expansion — no trustworthy spot price",
+                        extra={"event": "atm_token_expansion_skipped"},
+                    )
 
                 # Ensure NIFTY spot is also covered by polling fallback.
                 try:
@@ -6764,9 +7077,11 @@ async def startup_sequence(ctx: BotContext) -> None:
                     asyncio.create_task(_polling_failover_supervisor())
 
             # ── Bring the WebSocket online now that tokens are registered ──
-            # MDM.start() earlier ran with defer_ws=True so the initial
-            # handshake observes a populated _tokens set.  When WS mode is
-            # enabled this is where we actually open the socket.
+            # The WS was opened earlier with the spot token only so we could
+            # prove a fresh tick before selecting strikes.  Now that the
+            # full token universe is known, ensure WS is up (idempotent) and
+            # log the option subscription request so we can correlate which
+            # tokens just joined the live subscription.
             if (
                 ctx.market_data_manager is not None
                 and hasattr(ctx.market_data_manager, "start_websocket")
@@ -6775,9 +7090,14 @@ async def startup_sequence(ctx: BotContext) -> None:
                 try:
                     ctx.market_data_manager.start_websocket()
                     LOGGER.info(
-                        "✅ MarketDataManager websocket brought online "
-                        "with %d pre-registered tokens",
+                        "OPTION_WS_SUBSCRIBE_REQUESTED count=%d total_tokens=%d",
+                        max(0, len(tokens_to_poll) - 1),
                         len(tokens_to_poll),
+                        extra={
+                            "event": "OPTION_WS_SUBSCRIBE_REQUESTED",
+                            "count": max(0, len(tokens_to_poll) - 1),
+                            "total_tokens": len(tokens_to_poll),
+                        },
                     )
                 except Exception as _ws_start_exc:  # noqa: BLE001
                     LOGGER.error(
@@ -6791,8 +7111,23 @@ async def startup_sequence(ctx: BotContext) -> None:
             if mdm and not ctx.streamer and not ctx.websocket_enabled:
                 # Only start MDM polling if there's no streamer
                 asyncio.create_task(asyncio.to_thread(mdm._rest_poll_loop))
+                LOGGER.info(
+                    "POLLING_FALLBACK_STANDBY owner=mdm_internal_rest_poller reason=no_streamer",
+                    extra={
+                        "event": "POLLING_FALLBACK_STANDBY",
+                        "owner": "mdm_internal_rest_poller",
+                        "reason": "no_streamer",
+                    },
+                )
             else:
-                LOGGER.info("📡 MDM REST polling disabled (PollingStreamer owns fallback)")
+                LOGGER.info(
+                    "POLLING_FALLBACK_STANDBY owner=PollingStreamer mdm_internal_rest_poller=false",
+                    extra={
+                        "event": "POLLING_FALLBACK_STANDBY",
+                        "owner": "PollingStreamer",
+                        "mdm_internal_rest_poller": False,
+                    },
+                )
 
             dynamic_option_symbols = {
                 sym
@@ -7413,49 +7748,74 @@ async def startup_sequence(ctx: BotContext) -> None:
                                         ),
                                     },
                                 )
-                            data_warmup_reasons: list[str] = []
-                            if live_mode and hard_ready and quote_available and market_state == MarketState.OPEN:
+                            market_open_now = market_state == MarketState.OPEN
+                            armed, blocking_reasons = compute_live_readiness(
+                                live_mode=bool(live_mode),
+                                hard_ready=bool(hard_ready),
+                                quote_available=bool(quote_available),
+                                ws_quote_proof=bool(ws_quote_proof),
+                                market_open=bool(market_open_now),
+                            )
+                            data_warmup_reasons: list[str] = list(blocking_reasons)
+                            if live_mode and not quote_available and ws_quote_proof:
+                                LOGGER.info(
+                                    "BROKER_QUOTE_DEGRADED_CONTINUING_WITH_WS",
+                                    extra={
+                                        "event": "BROKER_QUOTE_DEGRADED_CONTINUING_WITH_WS",
+                                        "ws_quote_proof": True,
+                                        "quote_available": False,
+                                    },
+                                )
+                            if live_mode and armed:
                                 ctx.live_orders_armed = True
                                 ctx.trading_ready = True
                                 ctx.readiness_mode = "LIVE"
-                            if live_mode and not hard_ready:
-                                ctx.live_orders_armed = False
-                                ctx.trading_ready = False
-                                ctx.readiness_mode = "DATA_WARMUP"
-                                data_warmup_reasons.append("startup_pipeline_incomplete")
-                                LOGGER.error(
-                                    "LIVE_TRADING_BLOCKED reason=startup_pipeline_incomplete missing=%s",
-                                    missing_hard,
+                                LOGGER.info(
+                                    "LIVE_TRADING_ARMED hard_ready=%s quote_available=%s ws_quote_proof=%s",
+                                    hard_ready,
+                                    quote_available,
+                                    ws_quote_proof,
                                     extra={
-                                        "event": "LIVE_TRADING_BLOCKED",
-                                        "reason": "startup_pipeline_incomplete",
-                                        "missing": missing_hard,
-                                        "hard_ready": hard_ready,
-                                        "spot_ready": spot_ready,
+                                        "event": "LIVE_TRADING_ARMED",
+                                        "hard_ready": bool(hard_ready),
+                                        "quote_available": bool(quote_available),
+                                        "ws_quote_proof": bool(ws_quote_proof),
                                     },
                                 )
-                            if (
-                                live_mode
-                                and not quote_available
-                                and not ws_quote_proof
-                            ):
+                            elif live_mode:
                                 ctx.live_orders_armed = False
                                 ctx.trading_ready = False
                                 ctx.readiness_mode = "DATA_WARMUP"
-                                data_warmup_reasons.append("broker_quote_access_denied")
-                                LOGGER.error(
-                                    "LIVE_TRADING_BLOCKED reason=broker_quote_access_denied",
-                                    extra={
-                                        "event": "LIVE_TRADING_BLOCKED",
-                                        "reason": "broker_quote_access_denied",
-                                    },
-                                )
-                            if live_mode and market_state != MarketState.OPEN:
-                                ctx.live_orders_armed = False
-                                ctx.trading_ready = False
-                                ctx.readiness_mode = "DATA_WARMUP"
-                                if "market_closed" not in data_warmup_reasons:
-                                    data_warmup_reasons.append("market_closed")
+                                if "startup_pipeline_incomplete" in data_warmup_reasons:
+                                    LOGGER.error(
+                                        "LIVE_TRADING_BLOCKED reason=startup_pipeline_incomplete missing=%s",
+                                        missing_hard,
+                                        extra={
+                                            "event": "LIVE_TRADING_BLOCKED",
+                                            "reason": "startup_pipeline_incomplete",
+                                            "missing": missing_hard,
+                                            "hard_ready": hard_ready,
+                                            "spot_ready": spot_ready,
+                                        },
+                                    )
+                                if "market_data_proof_unavailable" in data_warmup_reasons:
+                                    LOGGER.error(
+                                        "LIVE_TRADING_BLOCKED reason=market_data_proof_unavailable",
+                                        extra={
+                                            "event": "LIVE_TRADING_BLOCKED",
+                                            "reason": "market_data_proof_unavailable",
+                                            "quote_available": bool(quote_available),
+                                            "ws_quote_proof": bool(ws_quote_proof),
+                                        },
+                                    )
+                                if "market_closed" in data_warmup_reasons:
+                                    LOGGER.info(
+                                        "LIVE_TRADING_BLOCKED reason=market_closed",
+                                        extra={
+                                            "event": "LIVE_TRADING_BLOCKED",
+                                            "reason": "market_closed",
+                                        },
+                                    )
                             data_warmup_reason: str | None = (
                                 ",".join(data_warmup_reasons) if data_warmup_reasons else None
                             )

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -1928,6 +1928,99 @@ class MarketDataManager:
         """Alias for get_ltp — preserves backward compatibility."""
         return self.get_ltp(symbol)
 
+    def get_fresh_spot_tick(
+        self,
+        symbol: str = "NSE:NIFTY",
+        *,
+        max_age_seconds: float | None = None,
+        require_ws: bool = True,
+    ) -> dict[str, Any] | None:
+        """Return the cached spot tick if it satisfies freshness/source guards.
+
+        In live startup we must avoid building the option universe from a stale
+        REST quote.  This helper enforces a tick age window and (optionally) a
+        WebSocket-source requirement so callers can prove fresh exchange data
+        before arming live trading.
+
+        Args:
+            symbol: Spot symbol to inspect (default ``NSE:NIFTY``).
+            max_age_seconds: Maximum acceptable tick age in seconds.  When
+                ``None`` the per-symbol stale threshold is used.
+            require_ws: When ``True``, only WebSocket-sourced ticks are
+                accepted; REST/polling ticks are rejected.
+
+        Returns:
+            A copy of the latest tick dict that passes all guards, or ``None``
+            when no fresh proof is available.
+        """
+
+        canonical = self._canonical_symbol(symbol)
+        tick = self.get_latest_tick(canonical)
+        if not isinstance(tick, Mapping):
+            return None
+
+        age = self.time_since_last_tick(canonical)
+        threshold = (
+            float(max_age_seconds)
+            if max_age_seconds is not None
+            else float(self._ltp_stale_threshold_for_symbol(canonical) or 120.0)
+        )
+        if age is None or threshold <= 0 or age > threshold:
+            return None
+
+        source = str(
+            tick.get("source") or self._last_tick_source.get(canonical) or ""
+        ).lower()
+        if require_ws and source not in {"ws", "ws_full", "full", "quote"}:
+            return None
+
+        price = _coerce_positive_float(
+            tick.get("last_price")
+            or tick.get("ltp")
+            or tick.get("price")
+            or tick.get("close")
+        )
+        if price is None or price <= 0:
+            return None
+
+        return dict(tick)
+
+    async def wait_for_fresh_spot_tick(
+        self,
+        symbol: str = "NSE:NIFTY",
+        *,
+        timeout: float = 15.0,
+        max_age_seconds: float | None = None,
+        require_ws: bool = True,
+        poll_interval: float = 0.25,
+    ) -> dict[str, Any] | None:
+        """Block until ``symbol`` has a fresh spot tick or ``timeout`` elapses.
+
+        Args:
+            symbol: Spot symbol to wait on.
+            timeout: Maximum wait in seconds.
+            max_age_seconds: Override per-symbol stale threshold.
+            require_ws: Require a WebSocket-sourced tick when ``True``.
+            poll_interval: Seconds between checks while waiting.
+
+        Returns:
+            The fresh tick dict, or ``None`` if no fresh tick arrived in time.
+        """
+
+        deadline = time.monotonic() + max(0.0, float(timeout))
+        interval = max(0.05, float(poll_interval))
+        while True:
+            tick = self.get_fresh_spot_tick(
+                symbol,
+                max_age_seconds=max_age_seconds,
+                require_ws=require_ws,
+            )
+            if tick is not None:
+                return tick
+            if time.monotonic() >= deadline:
+                return None
+            await asyncio.sleep(interval)
+
     def _resolve_underlying_price(self, symbol: str) -> float | None:
         canonical_symbol = self._canonical_symbol(symbol)
         tick_price = self.get_latest_price(canonical_symbol)

--- a/src/nifty_scalper_bot/data/rest/zerodha_client.py
+++ b/src/nifty_scalper_bot/data/rest/zerodha_client.py
@@ -57,6 +57,7 @@ from nifty_scalper_bot.utils.retry import (
     RetryErrorContext,
     retry_with_backoff,
 )
+from nifty_scalper_bot.utils.symbols import zerodha_quote_aliases
 
 T = TypeVar("T")
 
@@ -910,8 +911,24 @@ class ZerodhaKiteClient(BaseBrokerClient):
         canonical_input = all(
             isinstance(item, str) and ":" in str(item).strip() for item in tokens
         )
+        # alias_to_original maps every alias variant we send to Kite back to
+        # the caller's requested symbol so the response can be re-keyed in the
+        # caller's preferred form (e.g. "NSE:NIFTY" instead of "NSE:NIFTY 50").
+        alias_to_original: dict[str, str] = {}
+        original_symbols: list[str] = []
         if canonical_input:
-            symbols = [str(item).strip() for item in tokens]
+            original_symbols = [str(item).strip() for item in tokens]
+            symbols = []
+            for original in original_symbols:
+                aliases = zerodha_quote_aliases(original)
+                # Always include the original even when not in the alias list.
+                if original and original not in aliases:
+                    aliases.insert(0, original)
+                for alias in aliases:
+                    if alias and alias not in symbols:
+                        symbols.append(alias)
+                    alias_upper = alias.strip().upper()
+                    alias_to_original.setdefault(alias_upper, original)
             symbol_map: dict[str, int] = {}
             LOGGER.debug(
                 "quote_bulk canonical fast-path",
@@ -919,6 +936,7 @@ class ZerodhaKiteClient(BaseBrokerClient):
                     "event": "quote_bulk_canonical_fast_path",
                     "symbols": symbols[:8],
                     "count": len(symbols),
+                    "originals": original_symbols[:8],
                 },
             )
         else:
@@ -939,29 +957,52 @@ class ZerodhaKiteClient(BaseBrokerClient):
                 self._make_request("GET", "/quote", params={"i": symbols})
             )
         except Exception as exc:
-            LOGGER.error(
-                "Quote bulk request failed: %s",
-                exc,
-                extra={
-                    "event": "quote_bulk_request_error",
-                    "symbols_count": len(symbols),
-                },
-            )
+            if self._is_quote_access_denied(exc):
+                self._mark_quote_api_status(available=False, error="access_denied")
+                # 403s repeat every poll interval; demote to debug after the
+                # first marker so logs do not flood.
+                LOGGER.debug(
+                    "Quote bulk denied (access_denied): %s",
+                    exc,
+                    extra={
+                        "event": "quote_bulk_access_denied",
+                        "symbols_count": len(symbols),
+                    },
+                )
+            else:
+                LOGGER.error(
+                    "Quote bulk request failed: %s",
+                    exc,
+                    extra={
+                        "event": "quote_bulk_request_error",
+                        "symbols_count": len(symbols),
+                    },
+                )
             return {}
 
         data = cast(dict[str, Any], response.get("data", {}))
+        self._mark_quote_api_status(available=True)
 
-        # ✅ FIX: Return keyed by symbol (not token) for consistency
+        # ✅ FIX: Return keyed by the caller's requested symbol when possible
+        # (so callers asking for "NSE:NIFTY" find the payload there even though
+        # Kite returned it under "NSE:NIFTY 50").
         out: dict[str, dict[str, Any]] = {}
-        for symbol, payload in data.items():
+        for returned_symbol, payload in data.items():
             if not payload:
                 continue
-            # Ensure instrument_token is present
-            if "instrument_token" not in payload:
-                token_from_map = symbol_map.get(symbol)
+            payload_dict = dict(payload)
+            if "instrument_token" not in payload_dict:
+                token_from_map = symbol_map.get(returned_symbol)
                 if token_from_map:
-                    payload["instrument_token"] = token_from_map
-            out[symbol] = payload
+                    payload_dict["instrument_token"] = token_from_map
+            original_key = alias_to_original.get(
+                str(returned_symbol).strip().upper(), returned_symbol
+            )
+            out.setdefault(original_key, payload_dict)
+            # Keep Kite's exact response key as a fallback so callers that
+            # pre-translate to "NSE:NIFTY 50" themselves still find it.
+            if returned_symbol not in out:
+                out[returned_symbol] = dict(payload_dict)
 
         return out
 

--- a/src/nifty_scalper_bot/execution/readiness.py
+++ b/src/nifty_scalper_bot/execution/readiness.py
@@ -1,0 +1,52 @@
+"""Pure readiness helpers used by the live arming gate.
+
+Keeping the readiness decision in a side-effect-free helper makes the live
+trading arming logic easy to unit-test and ensures the same rules are applied
+consistently from app startup, health endpoints, and supervisor checks.
+"""
+
+from __future__ import annotations
+
+
+def compute_live_readiness(
+    *,
+    live_mode: bool,
+    hard_ready: bool,
+    quote_available: bool,
+    ws_quote_proof: bool,
+    market_open: bool,
+) -> tuple[bool, list[str]]:
+    """Decide whether live trading should be armed.
+
+    The bot may arm live trading when:
+      * the configured execution mode is LIVE,
+      * the data pipeline reports ``hard_ready``,
+      * the market session is open, and
+      * either REST quote capability OR a fresh WebSocket tradable-quote
+        proof is available — the two are interchangeable here so a transient
+        Zerodha 403 cannot block trading while WS is healthy.
+
+    Args:
+        live_mode: True when EXECUTION_MODE is LIVE / ENABLE_LIVE is set.
+        hard_ready: MarketDataManager hard readiness flag.
+        quote_available: Broker REST quote capability snapshot.
+        ws_quote_proof: WebSocket tradable-quote proof flag.
+        market_open: True when the exchange session is currently open.
+
+    Returns:
+        Tuple ``(armed, reasons)`` where ``armed`` indicates whether live
+        trading should be enabled and ``reasons`` lists every blocking
+        condition (empty when armed).
+    """
+
+    if not live_mode:
+        return False, ["not_live_mode"]
+    market_data_proof = bool(quote_available or ws_quote_proof)
+    reasons: list[str] = []
+    if not hard_ready:
+        reasons.append("startup_pipeline_incomplete")
+    if not market_data_proof:
+        reasons.append("market_data_proof_unavailable")
+    if not market_open:
+        reasons.append("market_closed")
+    return (len(reasons) == 0), reasons

--- a/src/nifty_scalper_bot/utils/symbols.py
+++ b/src/nifty_scalper_bot/utils/symbols.py
@@ -104,3 +104,84 @@ def is_strategy_instrument(symbol: str) -> bool:
     """Args: symbol; Returns: True for strategy instruments; Raises: none."""
     normalized = canonical(symbol)
     return normalized.startswith("NFO:NIFTY")
+
+
+# ---------------------------------------------------------------------------
+# Zerodha REST quote alias helpers
+#
+# Zerodha's /quote endpoint keys the response by the exact instrument name it
+# recognises (e.g. "NSE:NIFTY 50" for the NIFTY index).  Our internal canonical
+# representation is "NSE:NIFTY".  These helpers translate canonical or shorthand
+# index names into the Kite REST quote-compatible variants without changing the
+# bot's internal symbol storage.  WebSocket token mapping is unaffected.
+# ---------------------------------------------------------------------------
+
+_ZERODHA_QUOTE_ALIAS_MAP: dict[str, str] = {
+    "NSE:NIFTY": "NSE:NIFTY 50",
+    "NIFTY": "NSE:NIFTY 50",
+    "NIFTY50": "NSE:NIFTY 50",
+    "NSE:NIFTY50": "NSE:NIFTY 50",
+    "NSE:NIFTY 50": "NSE:NIFTY 50",
+    "NSE:BANKNIFTY": "NSE:NIFTY BANK",
+    "BANKNIFTY": "NSE:NIFTY BANK",
+    "NSE:BANKNIFTY 1": "NSE:NIFTY BANK",
+    "NSE:NIFTY BANK": "NSE:NIFTY BANK",
+    "NIFTYBANK": "NSE:NIFTY BANK",
+    "NSE:FINNIFTY": "NSE:NIFTY FIN SERVICE",
+    "FINNIFTY": "NSE:NIFTY FIN SERVICE",
+    "NSE:NIFTY FIN SERVICE": "NSE:NIFTY FIN SERVICE",
+}
+
+
+def to_zerodha_quote_symbol(symbol: str) -> str:
+    """Translate a canonical/shorthand symbol to the Zerodha quote symbol.
+
+    Args:
+        symbol: Canonical or shorthand internal symbol (e.g. ``"NSE:NIFTY"``).
+
+    Returns:
+        Kite REST quote-compatible symbol (e.g. ``"NSE:NIFTY 50"``).  Symbols
+        that are not known indices are returned unchanged so option strikes and
+        equities continue to round-trip without modification.
+    """
+
+    raw = str(symbol or "").strip()
+    if not raw:
+        return ""
+    # Normalize whitespace before mapping: "NSE:NIFTY  50" → "NSE:NIFTY 50".
+    collapsed = " ".join(raw.split())
+    upper = collapsed.upper()
+    return _ZERODHA_QUOTE_ALIAS_MAP.get(upper, raw)
+
+
+def zerodha_quote_aliases(symbol: str) -> list[str]:
+    """Return all Kite quote-compatible aliases for ``symbol``.
+
+    The canonical Kite name is preferred, but the original symbol and the
+    bare tradingsymbol are kept as fallbacks so the response can be matched
+    even when Kite returns the payload under a slightly different key.  Order
+    is preserved and duplicates are removed.
+
+    Args:
+        symbol: Canonical or shorthand symbol to expand.
+
+    Returns:
+        List of alias strings, with the Kite-preferred form first.
+    """
+
+    raw = str(symbol or "").strip()
+    if not raw:
+        return []
+    primary = to_zerodha_quote_symbol(raw)
+    candidates = [
+        primary,
+        raw,
+        primary.split(":", 1)[-1] if ":" in primary else primary,
+        raw.split(":", 1)[-1] if ":" in raw else raw,
+    ]
+    out: list[str] = []
+    for item in candidates:
+        cleaned = str(item or "").strip()
+        if cleaned and cleaned not in out:
+            out.append(cleaned)
+    return out

--- a/tests/test_live_readiness_gate.py
+++ b/tests/test_live_readiness_gate.py
@@ -1,0 +1,88 @@
+"""Tests for the pure live-trading readiness gate."""
+
+from __future__ import annotations
+
+import pytest
+
+from nifty_scalper_bot.execution.readiness import compute_live_readiness
+
+
+class TestComputeLiveReadiness:
+    def test_arms_when_ws_proof_substitutes_for_rest_quote(self) -> None:
+        armed, reasons = compute_live_readiness(
+            live_mode=True,
+            hard_ready=True,
+            quote_available=False,
+            ws_quote_proof=True,
+            market_open=True,
+        )
+        assert armed is True
+        assert reasons == []
+
+    def test_blocks_when_neither_quote_nor_ws_proof(self) -> None:
+        armed, reasons = compute_live_readiness(
+            live_mode=True,
+            hard_ready=True,
+            quote_available=False,
+            ws_quote_proof=False,
+            market_open=True,
+        )
+        assert armed is False
+        assert reasons == ["market_data_proof_unavailable"]
+
+    def test_blocks_when_pipeline_not_ready(self) -> None:
+        armed, reasons = compute_live_readiness(
+            live_mode=True,
+            hard_ready=False,
+            quote_available=True,
+            ws_quote_proof=False,
+            market_open=True,
+        )
+        assert armed is False
+        assert "startup_pipeline_incomplete" in reasons
+
+    def test_blocks_when_market_closed(self) -> None:
+        armed, reasons = compute_live_readiness(
+            live_mode=True,
+            hard_ready=True,
+            quote_available=True,
+            ws_quote_proof=True,
+            market_open=False,
+        )
+        assert armed is False
+        assert reasons == ["market_closed"]
+
+    def test_returns_not_live_mode_when_disabled(self) -> None:
+        armed, reasons = compute_live_readiness(
+            live_mode=False,
+            hard_ready=True,
+            quote_available=True,
+            ws_quote_proof=True,
+            market_open=True,
+        )
+        assert armed is False
+        assert reasons == ["not_live_mode"]
+
+    def test_collects_multiple_blocking_reasons(self) -> None:
+        armed, reasons = compute_live_readiness(
+            live_mode=True,
+            hard_ready=False,
+            quote_available=False,
+            ws_quote_proof=False,
+            market_open=False,
+        )
+        assert armed is False
+        assert "startup_pipeline_incomplete" in reasons
+        assert "market_data_proof_unavailable" in reasons
+        assert "market_closed" in reasons
+
+    def test_arms_with_quote_only(self) -> None:
+        armed, reasons = compute_live_readiness(
+            live_mode=True,
+            hard_ready=True,
+            quote_available=True,
+            ws_quote_proof=False,
+            market_open=True,
+        )
+        assert armed is True
+        assert reasons == []

--- a/tests/test_market_data_manager_spot_readiness.py
+++ b/tests/test_market_data_manager_spot_readiness.py
@@ -1,0 +1,120 @@
+"""Tests for MarketDataManager fresh spot tick helpers."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+
+from nifty_scalper_bot.data.market_data_manager import MarketDataManager
+
+
+def _build_mdm() -> MarketDataManager:
+    """Build a bare MarketDataManager without broker/WS for direct cache access."""
+    return MarketDataManager(broker=None, websocket=None, settings={})
+
+
+def _seed_tick(
+    mdm: MarketDataManager,
+    *,
+    symbol: str = "NSE:NIFTY",
+    price: float = 24500.0,
+    source: str = "ws",
+    age_s: float = 0.0,
+) -> None:
+    """Seed the MDM tick caches with a freshly-timestamped tick."""
+    now = time.time() - max(0.0, age_s)
+    tick = {
+        "symbol": symbol,
+        "ltp": price,
+        "last_price": price,
+        "source": source,
+        "received_at": now,
+        "timestamp": now,
+    }
+    with mdm._lock:
+        mdm._latest_ticks[symbol] = tick
+        mdm._tick_cache[symbol] = tick
+        mdm._last_tick_time[symbol] = now
+        mdm._last_tick_wallclock[symbol] = now
+        mdm._last_tick_source[symbol] = source
+
+
+class TestGetFreshSpotTick:
+    def test_fresh_ws_tick_is_accepted(self) -> None:
+        mdm = _build_mdm()
+        _seed_tick(mdm, source="ws", price=24500.0)
+        tick = mdm.get_fresh_spot_tick("NSE:NIFTY")
+        assert tick is not None
+        assert tick["last_price"] == pytest.approx(24500.0)
+
+    def test_stale_ws_tick_is_rejected(self) -> None:
+        mdm = _build_mdm()
+        _seed_tick(mdm, source="ws", age_s=600.0)
+        tick = mdm.get_fresh_spot_tick("NSE:NIFTY", max_age_seconds=60.0)
+        assert tick is None
+
+    def test_rest_tick_rejected_when_require_ws(self) -> None:
+        mdm = _build_mdm()
+        _seed_tick(mdm, source="rest", price=24500.0)
+        tick = mdm.get_fresh_spot_tick(
+            "NSE:NIFTY", max_age_seconds=300.0, require_ws=True
+        )
+        assert tick is None
+
+    def test_rest_tick_accepted_when_require_ws_false(self) -> None:
+        mdm = _build_mdm()
+        _seed_tick(mdm, source="rest", price=24500.0)
+        tick = mdm.get_fresh_spot_tick(
+            "NSE:NIFTY", max_age_seconds=300.0, require_ws=False
+        )
+        assert tick is not None
+        assert tick["last_price"] == pytest.approx(24500.0)
+
+    def test_zero_price_rejected(self) -> None:
+        mdm = _build_mdm()
+        _seed_tick(mdm, source="ws", price=0.0)
+        tick = mdm.get_fresh_spot_tick("NSE:NIFTY", max_age_seconds=120.0)
+        assert tick is None
+
+    def test_no_tick_returns_none(self) -> None:
+        mdm = _build_mdm()
+        tick = mdm.get_fresh_spot_tick("NSE:NIFTY", max_age_seconds=60.0)
+        assert tick is None
+
+
+class TestWaitForFreshSpotTick:
+    def test_waits_until_tick_arrives(self) -> None:
+        mdm = _build_mdm()
+
+        async def runner() -> dict | None:
+            async def deliver_tick() -> None:
+                await asyncio.sleep(0.1)
+                _seed_tick(mdm, source="ws", price=24700.0)
+
+            asyncio.create_task(deliver_tick())
+            return await mdm.wait_for_fresh_spot_tick(
+                "NSE:NIFTY",
+                timeout=2.0,
+                max_age_seconds=60.0,
+                poll_interval=0.05,
+            )
+
+        tick = asyncio.run(runner())
+        assert tick is not None
+        assert tick["last_price"] == pytest.approx(24700.0)
+
+    def test_times_out_when_no_tick(self) -> None:
+        mdm = _build_mdm()
+
+        async def runner() -> dict | None:
+            return await mdm.wait_for_fresh_spot_tick(
+                "NSE:NIFTY",
+                timeout=0.2,
+                max_age_seconds=60.0,
+                poll_interval=0.05,
+            )
+
+        tick = asyncio.run(runner())
+        assert tick is None

--- a/tests/test_no_fake_spot_live.py
+++ b/tests/test_no_fake_spot_live.py
@@ -1,0 +1,137 @@
+"""Tests guarding against fake spot prices in LIVE mode."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from nifty_scalper_bot.core.app import (
+    _SYNTHETIC_FALLBACK_SPOT,
+    _is_live_execution_mode,
+    _wait_for_live_spot_or_raise,
+)
+
+
+class _StubMDM:
+    """Stand-in MarketDataManager exposing the helpers used in startup."""
+
+    def __init__(
+        self,
+        *,
+        ws_tick: dict[str, Any] | None = None,
+        cached_price: float = 0.0,
+    ) -> None:
+        self._ws_tick = ws_tick
+        self._cached_price = cached_price
+
+    async def wait_for_fresh_spot_tick(
+        self,
+        symbol: str,
+        *,
+        timeout: float,
+        max_age_seconds: float | None,
+        require_ws: bool,
+    ) -> dict[str, Any] | None:
+        return dict(self._ws_tick) if self._ws_tick else None
+
+    def get_latest_price(self, _symbol: str) -> float:
+        return float(self._cached_price)
+
+
+def _ctx(mdm: _StubMDM) -> SimpleNamespace:
+    return SimpleNamespace(market_data_manager=mdm)
+
+
+def test_live_mode_with_fresh_ws_tick_returns_real_price(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("EXECUTION_MODE", "LIVE")
+    monkeypatch.delenv("ALLOW_SYNTHETIC_MARKET_DATA", raising=False)
+    mdm = _StubMDM(ws_tick={"last_price": 24875.5, "source": "ws"})
+    price = asyncio.run(
+        _wait_for_live_spot_or_raise(_ctx(mdm), timeout=0.2, configured_mode="LIVE")
+    )
+    assert price == pytest.approx(24875.5)
+    assert price != _SYNTHETIC_FALLBACK_SPOT
+
+
+def test_live_mode_without_fresh_tick_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("EXECUTION_MODE", "LIVE")
+    monkeypatch.delenv("ALLOW_SYNTHETIC_MARKET_DATA", raising=False)
+    mdm = _StubMDM(ws_tick=None, cached_price=0.0)
+    with pytest.raises(RuntimeError) as excinfo:
+        asyncio.run(
+            _wait_for_live_spot_or_raise(
+                _ctx(mdm), timeout=0.1, configured_mode="LIVE"
+            )
+        )
+    assert "fresh NIFTY WebSocket spot tick unavailable" in str(excinfo.value)
+
+
+def test_paper_mode_falls_back_to_synthetic_with_log(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    monkeypatch.setenv("EXECUTION_MODE", "PAPER")
+    monkeypatch.delenv("ENABLE_LIVE", raising=False)
+    monkeypatch.delenv("ALLOW_SYNTHETIC_MARKET_DATA", raising=False)
+    mdm = _StubMDM(ws_tick=None, cached_price=0.0)
+    with caplog.at_level("WARNING"):
+        price = asyncio.run(
+            _wait_for_live_spot_or_raise(
+                _ctx(mdm), timeout=0.1, configured_mode="PAPER"
+            )
+        )
+    assert price == pytest.approx(_SYNTHETIC_FALLBACK_SPOT)
+    assert any("SYNTHETIC_SPOT_USED" in record.message for record in caplog.records)
+
+
+def test_paper_mode_uses_cached_price_when_available(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("EXECUTION_MODE", "PAPER")
+    monkeypatch.delenv("ENABLE_LIVE", raising=False)
+    mdm = _StubMDM(ws_tick=None, cached_price=24123.45)
+    price = asyncio.run(
+        _wait_for_live_spot_or_raise(
+            _ctx(mdm), timeout=0.1, configured_mode="PAPER"
+        )
+    )
+    assert price == pytest.approx(24123.45)
+
+
+def test_allow_synthetic_market_data_overrides_live_block(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("EXECUTION_MODE", "LIVE")
+    monkeypatch.setenv("ALLOW_SYNTHETIC_MARKET_DATA", "true")
+    mdm = _StubMDM(ws_tick=None, cached_price=0.0)
+    price = asyncio.run(
+        _wait_for_live_spot_or_raise(
+            _ctx(mdm), timeout=0.1, configured_mode="LIVE"
+        )
+    )
+    assert price == pytest.approx(_SYNTHETIC_FALLBACK_SPOT)
+
+
+class TestIsLiveExecutionMode:
+    def test_live_via_execution_mode(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("EXECUTION_MODE", "LIVE")
+        monkeypatch.delenv("ENABLE_LIVE", raising=False)
+        assert _is_live_execution_mode() is True
+
+    def test_live_via_enable_live_flag(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("EXECUTION_MODE", "PAPER")
+        monkeypatch.setenv("ENABLE_LIVE", "true")
+        assert _is_live_execution_mode() is True
+
+    def test_paper_mode_is_not_live(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("EXECUTION_MODE", "PAPER")
+        monkeypatch.setenv("ENABLE_LIVE", "false")
+        assert _is_live_execution_mode() is False

--- a/tests/test_symbols_zerodha_aliases.py
+++ b/tests/test_symbols_zerodha_aliases.py
@@ -1,0 +1,79 @@
+"""Tests for Zerodha REST quote alias helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from nifty_scalper_bot.utils.symbols import (
+    to_zerodha_quote_symbol,
+    zerodha_quote_aliases,
+)
+
+
+class TestToZerodhaQuoteSymbol:
+    def test_canonical_nifty_maps_to_kite_index_name(self) -> None:
+        assert to_zerodha_quote_symbol("NSE:NIFTY") == "NSE:NIFTY 50"
+
+    def test_bare_nifty_maps_to_kite_index_name(self) -> None:
+        assert to_zerodha_quote_symbol("NIFTY") == "NSE:NIFTY 50"
+
+    def test_nifty50_alias_maps_to_kite_index_name(self) -> None:
+        assert to_zerodha_quote_symbol("NIFTY50") == "NSE:NIFTY 50"
+
+    def test_already_kite_form_passes_through(self) -> None:
+        assert to_zerodha_quote_symbol("NSE:NIFTY 50") == "NSE:NIFTY 50"
+
+    def test_banknifty_maps_to_kite_index_name(self) -> None:
+        assert to_zerodha_quote_symbol("NSE:BANKNIFTY") == "NSE:NIFTY BANK"
+        assert to_zerodha_quote_symbol("BANKNIFTY") == "NSE:NIFTY BANK"
+
+    def test_finnifty_maps_to_kite_index_name(self) -> None:
+        assert to_zerodha_quote_symbol("NSE:FINNIFTY") == "NSE:NIFTY FIN SERVICE"
+        assert to_zerodha_quote_symbol("FINNIFTY") == "NSE:NIFTY FIN SERVICE"
+
+    def test_option_symbol_passes_through_unchanged(self) -> None:
+        assert (
+            to_zerodha_quote_symbol("NFO:NIFTY2612025700CE")
+            == "NFO:NIFTY2612025700CE"
+        )
+
+    def test_equity_symbol_passes_through_unchanged(self) -> None:
+        assert to_zerodha_quote_symbol("NSE:RELIANCE") == "NSE:RELIANCE"
+
+    def test_empty_input_returns_empty(self) -> None:
+        assert to_zerodha_quote_symbol("") == ""
+        assert to_zerodha_quote_symbol(None) == ""  # type: ignore[arg-type]
+
+    def test_double_space_collapses(self) -> None:
+        assert to_zerodha_quote_symbol("NSE:NIFTY  50") == "NSE:NIFTY 50"
+
+
+class TestZerodhaQuoteAliases:
+    def test_nifty_aliases_include_kite_form_and_bare_name(self) -> None:
+        aliases = zerodha_quote_aliases("NSE:NIFTY")
+        assert "NSE:NIFTY 50" in aliases
+        assert "NIFTY 50" in aliases
+        # Kite-preferred form must come first.
+        assert aliases[0] == "NSE:NIFTY 50"
+
+    def test_aliases_preserve_original_for_round_trip(self) -> None:
+        aliases = zerodha_quote_aliases("NSE:NIFTY")
+        assert "NSE:NIFTY" in aliases
+
+    def test_aliases_dedupe(self) -> None:
+        aliases = zerodha_quote_aliases("NSE:NIFTY 50")
+        assert aliases.count("NSE:NIFTY 50") == 1
+
+    def test_option_symbol_aliases_unchanged(self) -> None:
+        aliases = zerodha_quote_aliases("NFO:NIFTY2612025700CE")
+        assert aliases[0] == "NFO:NIFTY2612025700CE"
+        assert "NIFTY2612025700CE" in aliases
+
+    def test_empty_input_returns_empty(self) -> None:
+        assert zerodha_quote_aliases("") == []
+        assert zerodha_quote_aliases(None) == []  # type: ignore[arg-type]
+
+    def test_banknifty_aliases(self) -> None:
+        aliases = zerodha_quote_aliases("NSE:BANKNIFTY")
+        assert "NSE:NIFTY BANK" in aliases
+        assert "NIFTY BANK" in aliases

--- a/tests/test_zerodha_quote_aliases.py
+++ b/tests/test_zerodha_quote_aliases.py
@@ -1,0 +1,118 @@
+"""Tests for Zerodha quote_bulk index alias handling."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import pytest
+
+# Set credential env BEFORE importing the client so __init__ does not raise.
+os.environ.setdefault("ZERODHA_API_KEY", "test_api_key")
+os.environ.setdefault("ZERODHA_ACCESS_TOKEN", "test_access_token")
+
+from nifty_scalper_bot.data.rest.zerodha_client import ZerodhaKiteClient
+
+
+class _FakeRateLimiter:
+    """Minimal rate limiter that bypasses real bucket acquisition."""
+
+    def __init__(self) -> None:
+        self.acquire_calls: list[tuple[str, int]] = []
+
+    def add_bucket(self, *_args: Any, **_kwargs: Any) -> None:
+        pass
+
+    def acquire(self, bucket: str, weight: int = 1) -> None:
+        self.acquire_calls.append((bucket, weight))
+
+
+@pytest.fixture
+def client(monkeypatch: pytest.MonkeyPatch) -> ZerodhaKiteClient:
+    monkeypatch.setenv("ZERODHA_API_KEY", "test_api_key")
+    monkeypatch.setenv("ZERODHA_ACCESS_TOKEN", "test_access_token")
+    return ZerodhaKiteClient(limiter=_FakeRateLimiter())
+
+
+def _capture(client: ZerodhaKiteClient, response_data: dict[str, Any]) -> list[dict]:
+    captured: list[dict] = []
+
+    def fake_request(
+        method: str,
+        endpoint: str,
+        params: dict | None = None,
+        data: dict | None = None,
+        **_kwargs: Any,
+    ) -> dict:
+        captured.append({"method": method, "endpoint": endpoint, "params": params})
+        return {"data": response_data}
+
+    client._make_request = fake_request  # type: ignore[assignment]
+    client._acquire_bucket = lambda *_a, **_k: None  # type: ignore[assignment]
+    return captured
+
+
+def test_get_quote_bulk_translates_nifty_alias_and_returns_under_original_key(
+    client: ZerodhaKiteClient,
+) -> None:
+    captured = _capture(
+        client,
+        {"NSE:NIFTY 50": {"last_price": 24027.3, "instrument_token": 256265}},
+    )
+
+    result = client.get_quote_bulk(["NSE:NIFTY"])
+
+    # Caller-facing key remains "NSE:NIFTY".
+    assert "NSE:NIFTY" in result
+    assert result["NSE:NIFTY"]["last_price"] == pytest.approx(24027.3)
+    # The Kite alias must have been sent to /quote.
+    assert captured, "No HTTP call captured"
+    sent = captured[0]["params"]["i"]
+    assert "NSE:NIFTY 50" in sent
+
+
+def test_quote_alias_for_nifty_returns_payload_under_original_key(
+    client: ZerodhaKiteClient,
+) -> None:
+    _capture(
+        client,
+        {"NSE:NIFTY 50": {"last_price": 24500.0, "instrument_token": 256265}},
+    )
+
+    result = client.quote(["NSE:NIFTY"])
+    assert "NSE:NIFTY" in result
+    assert result["NSE:NIFTY"]["last_price"] == pytest.approx(24500.0)
+
+
+def test_quote_bulk_passes_through_non_index_symbol(
+    client: ZerodhaKiteClient,
+) -> None:
+    captured = _capture(
+        client,
+        {"NFO:NIFTY2612025700CE": {"last_price": 102.0, "instrument_token": 999}},
+    )
+
+    result = client.get_quote_bulk(["NFO:NIFTY2612025700CE"])
+
+    assert "NFO:NIFTY2612025700CE" in result
+    assert result["NFO:NIFTY2612025700CE"]["last_price"] == pytest.approx(102.0)
+    sent = captured[0]["params"]["i"]
+    assert "NFO:NIFTY2612025700CE" in sent
+    # No index alias rewriting should leak.
+    assert "NSE:NIFTY 50" not in sent
+
+
+def test_get_quote_bulk_marks_quote_api_unavailable_on_403(
+    client: ZerodhaKiteClient,
+) -> None:
+    def fake_request(*_args: Any, **_kwargs: Any) -> dict:
+        raise RuntimeError("Zerodha API error (403): HTTP 403 access denied")
+
+    client._make_request = fake_request  # type: ignore[assignment]
+    client._acquire_bucket = lambda *_a, **_k: None  # type: ignore[assignment]
+
+    result = client.get_quote_bulk(["NSE:NIFTY"])
+    assert result == {}
+    snap = client.quote_api_status_snapshot()
+    assert snap["available"] is False
+    assert snap["error"] == "access_denied"


### PR DESCRIPTION
## Summary

Live startup risked arming with a synthetic NIFTY spot (`25600.0`) because:
1. `get_latest_price("NSE:NIFTY")` was called before WebSocket bring-up, hitting REST.
2. The Zerodha REST quote path bypassed Kite's required index alias (`NSE:NIFTY 50`), returning empty data and a noisy 403 stream.
3. The readiness gate hard-blocked LIVE on REST quote capability even when WebSocket tradable-quote proof was healthy.

## Root cause and fixes

| Layer | Bug | Fix |
| --- | --- | --- |
| `utils/symbols.py` | No translation between `NSE:NIFTY` and Kite's `NSE:NIFTY 50`. | Added `to_zerodha_quote_symbol()` and `zerodha_quote_aliases()`. |
| `data/rest/zerodha_client.py` | `get_quote_bulk()` sent canonical `NSE:NIFTY` directly and never re-keyed the response. | Expand aliases, re-key under the caller's requested symbol, mark `quote_api_available=False` on 403, demote repeated 403 logs to debug. |
| `data/market_data_manager.py` | No way to prove a fresh WS tick before basket selection. | Added `get_fresh_spot_tick()` and `wait_for_fresh_spot_tick()` (require_ws gate, age threshold, positive price). |
| `core/app.py` startup | Opened WS only after option universe was known; used `25600.0` fallback when REST returned 0. | Spot-token-first WS bring-up, `_wait_for_live_spot_or_raise()`, no synthetic fallback in LIVE mode unless `ALLOW_SYNTHETIC_MARKET_DATA=true`. Records `ctx.active_trading_universe` for downstream reuse. |
| `core/app.py` readiness gate | `LIVE_TRADING_BLOCKED reason=broker_quote_access_denied` even when WS was healthy. | New `execution/readiness.compute_live_readiness()`: arms LIVE on `hard_ready ∧ market_open ∧ (quote_available ∨ ws_quote_proof)`. Emits `BROKER_QUOTE_DEGRADED_CONTINUING_WITH_WS` and `LIVE_TRADING_ARMED`. |

## Behavior matrix

| Mode | REST quote | WS proof | Result |
| --- | --- | --- | --- |
| LIVE | 403 | healthy | **Arms LIVE**, logs degraded REST |
| LIVE | 403 | missing | DATA_WARMUP, `market_data_proof_unavailable` |
| LIVE | OK | any | Arms LIVE |
| LIVE | n/a | no fresh spot tick | Skips basket, logs `STARTUP_NO_FAKE_SPOT_LIVE_MODE`, no live arming |
| PAPER/SHADOW | n/a | n/a | Falls back to cached or `25600.0` with `SYNTHETIC_SPOT_USED` log |

## Test plan

- [x] `python -m compileall -q src tests` — clean.
- [x] New tests (43 new, all passing):
  - `tests/test_symbols_zerodha_aliases.py` — index alias mapping
  - `tests/test_zerodha_quote_aliases.py` — `get_quote_bulk` / `quote` translate `NSE:NIFTY` → `NSE:NIFTY 50` and re-key, 403 propagates to capability flag
  - `tests/test_market_data_manager_spot_readiness.py` — fresh/stale/REST-only tick gating
  - `tests/test_live_readiness_gate.py` — readiness gate truth table
  - `tests/test_no_fake_spot_live.py` — LIVE mode raises without fresh tick; PAPER falls back; `ALLOW_SYNTHETIC_MARKET_DATA` overrides
- [x] Broader pytest sweep on app/health/freshness/canonical-basket/symbol-resolution suites (~477 passed; remaining failures are pre-existing import errors in unrelated modules).

## Limitations

- The pre-existing `tests/data/test_instrument_resolver.py` and `tests/test_mdm_diagnostics.py` import errors are unchanged by this PR (they fail before any code touched here is loaded).
- `_wait_for_live_spot_or_raise()` raises into the basket-build try/except; the supervisor will retry on its next tick — no infinite loop, but the first iteration after WS connection still has to wait for the first tick.

https://claude.ai/code/session_01S9UHx5KRJ9MLrgtP4ZiQ4w

---
_Generated by [Claude Code](https://claude.ai/code/session_01S9UHx5KRJ9MLrgtP4ZiQ4w)_