### PR TITLE
Add central market data policy for WebSocket-first startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,29 @@ pytest
 | `RECONCILIATION_BROKER_IS_TRUTH` | Treat broker snapshot as the source of truth | `true` |
 | `SESSION_ALLOW_OUT_OF_HOURS` | Allow strategy startup and checks outside market hours for testing | `false` |
 | `NIFTY_FALLBACK_LTP` | Fallback NIFTY spot used when live ticks are unavailable off-hours | `24000` |
+| `MARKETDATA_PRIMARY_SOURCE` | Primary market-data source | `websocket` |
+| `MARKETDATA_REST_FALLBACK_ENABLED` | Allow REST quote fallback | `true` |
+| `MARKETDATA_REST_FALLBACK_MODE` | REST fallback activation policy | `after_ws_degraded` |
+| `MARKETDATA_SUPPRESS_REST_BEFORE_WS` | Suppress REST quote before WS start in LIVE | `true` |
+| `MARKETDATA_REQUIRE_WS_SPOT_FOR_LIVE` | Require WS spot proof for LIVE startup | `true` |
+| `MARKETDATA_ALLOW_SYNTHETIC_SPOT_IN_LIVE` | Allow synthetic spot in LIVE | `false` |
+| `NIFTY_INTERNAL_SYMBOL` | Internal bot NIFTY symbol | `NSE:NIFTY` |
+| `NIFTY_ZERODHA_QUOTE_SYMBOL` | Zerodha REST quote symbol for NIFTY index | `NSE:NIFTY 50` |
+| `NIFTY_SPOT_TOKEN` | NIFTY spot token | `256265` |
+| `NIFTY_EXCHANGE` | Spot exchange code | `NSE` |
+| `STARTUP_WAIT_FOR_WS_SPOT_SECONDS` | Max wait for fresh startup WS spot tick | `15` |
+| `STARTUP_SPOT_MAX_AGE_SECONDS` | Max accepted age for startup spot tick | `120` |
+| `STARTUP_BLOCK_LIVE_IF_NO_WS_SPOT` | Block LIVE arming when no fresh WS spot | `true` |
+| `QUOTE_CANONICALIZE_INDEX_SYMBOLS` | Canonicalize index symbols for quote calls | `true` |
+| `QUOTE_MARK_403_AS_REST_DEGRADED_ONLY` | Treat quote 403 as quote-path degradation only | `true` |
+| `QUOTE_DO_NOT_BLOCK_IF_WS_HEALTHY` | Allow readiness with WS proof when REST quote degraded | `true` |
+| `LOG_THROTTLE_QUOTE_ERRORS_SECONDS` | Quote error log throttle interval | `120` |
+| `LOG_MARKETDATA_DECISIONS` | Emit market-data policy decision logs | `true` |
+
+> Note:
+> - Internal bot symbol remains `NSE:NIFTY`.
+> - Zerodha REST quote symbol for the NIFTY index is `NSE:NIFTY 50`.
+> - REST quote fallback is intentionally suppressed before WebSocket startup in LIVE mode.
 
 ### Live trading toggles
 

--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -416,6 +416,7 @@ from nifty_scalper_bot.data import (
 from nifty_scalper_bot.data.assess_data import assess_datahub_fresh
 from nifty_scalper_bot.data.data_hub import DataHub
 from nifty_scalper_bot.data.market_data_manager import MarketDataManager
+from nifty_scalper_bot.data.market_data_policy import MarketDataPolicy
 from nifty_scalper_bot.data.market_regime import MarketRegimeDetector
 from nifty_scalper_bot.data.persistent_state import PersistentStateManager
 from nifty_scalper_bot.data.rest.zerodha_client import ZerodhaKiteClient
@@ -5656,6 +5657,7 @@ async def _wait_for_live_spot_or_raise(
             spot tick is available within ``timeout``.
     """
 
+    policy = MarketDataPolicy.from_env()
     mdm = ctx.market_data_manager
     if mdm is None:
         raise RuntimeError("MarketDataManager unavailable")
@@ -5666,10 +5668,10 @@ async def _wait_for_live_spot_or_raise(
     if callable(wait_fn):
         try:
             tick = await wait_fn(
-                "NSE:NIFTY",
+                policy.nifty_internal_symbol,
                 timeout=float(timeout),
-                max_age_seconds=120.0,
-                require_ws=live_mode,
+                max_age_seconds=policy.startup_spot_max_age_seconds,
+                require_ws=policy.require_ws_spot_for_live and live_mode,
             )
         except Exception as exc:  # noqa: BLE001
             LOGGER.warning(
@@ -5682,32 +5684,50 @@ async def _wait_for_live_spot_or_raise(
     price = _coerce_spot_price(tick)
     if price is not None:
         LOGGER.info(
-            "LIVE_SPOT_READY symbol=NSE:NIFTY price=%.2f source=ws",
+            "LIVE_SPOT_READY symbol=%s price=%.2f source=ws",
+            policy.nifty_internal_symbol,
             price,
             extra={
                 "event": "LIVE_SPOT_READY",
-                "symbol": "NSE:NIFTY",
+                "symbol": policy.nifty_internal_symbol,
                 "price": price,
                 "source": "ws",
             },
         )
         return float(price)
 
-    if live_mode and not _allow_synthetic_market_data():
+    if (
+        live_mode
+        and policy.block_live_if_no_ws_spot
+        and not policy.allow_synthetic_spot_in_live
+    ):
         raise RuntimeError(
             "fresh NIFTY WebSocket spot tick unavailable; "
             "cannot build live option universe"
         )
 
     # Paper / off-hours fallback path: try cached REST/poll value first.
-    cached = float(mdm.get_latest_price("NSE:NIFTY") or 0.0)
+    cached_ltp_fn = getattr(mdm, "get_cached_ltp", None)
+    cached = (
+        float(
+            cached_ltp_fn(
+                policy.nifty_internal_symbol,
+                max_age_seconds=policy.startup_spot_max_age_seconds,
+                require_ws=False,
+            )
+            or 0.0
+        )
+        if callable(cached_ltp_fn)
+        else 0.0
+    )
     if cached > 0:
         LOGGER.info(
-            "LIVE_SPOT_READY symbol=NSE:NIFTY price=%.2f source=cache",
+            "LIVE_SPOT_READY symbol=%s price=%.2f source=cache",
+            policy.nifty_internal_symbol,
             cached,
             extra={
                 "event": "LIVE_SPOT_READY",
-                "symbol": "NSE:NIFTY",
+                "symbol": policy.nifty_internal_symbol,
                 "price": cached,
                 "source": "cache",
             },
@@ -5716,11 +5736,11 @@ async def _wait_for_live_spot_or_raise(
 
     LOGGER.warning(
         "SYNTHETIC_SPOT_USED mode=%s price=%.2f reason=no_live_tick",
-        "LIVE" if live_mode else "NON_LIVE",
+        configured_mode or ("LIVE" if live_mode else "NON_LIVE"),
         _SYNTHETIC_FALLBACK_SPOT,
         extra={
             "event": "SYNTHETIC_SPOT_USED",
-            "mode": "LIVE" if live_mode else "NON_LIVE",
+            "mode": configured_mode or ("LIVE" if live_mode else "NON_LIVE"),
             "price": _SYNTHETIC_FALLBACK_SPOT,
         },
     )
@@ -5759,6 +5779,7 @@ def _resolve_quote_capability(ctx: BotContext) -> dict[str, Any]:
 
 async def startup_sequence(ctx: BotContext) -> None:
     """Execute startup sequence with Smart Hydration and Option-Only Trading."""
+    policy = MarketDataPolicy.from_env()
     configured_mode = str(os.getenv("EXECUTION_MODE", "SHADOW")).strip().upper()
     if configured_mode not in {"LIVE", "PAPER", "SHADOW"}:
         configured_mode = "SHADOW"
@@ -5798,6 +5819,24 @@ async def startup_sequence(ctx: BotContext) -> None:
             LOGGER.info(
                 "✅ MarketDataManager started — tick consumer active (WS deferred)"
             )
+            LOGGER.info(
+                "STARTUP_WS_SPOT_FIRST_DECISION websocket_enabled=%s mdm_present=%s has_start_websocket=%s",
+                ctx.websocket_enabled,
+                ctx.market_data_manager is not None,
+                hasattr(ctx.market_data_manager, "start_websocket")
+                if ctx.market_data_manager
+                else False,
+                extra={
+                    "event": "STARTUP_WS_SPOT_FIRST_DECISION",
+                    "websocket_enabled": ctx.websocket_enabled,
+                    "mdm_present": ctx.market_data_manager is not None,
+                    "has_start_websocket": hasattr(
+                        ctx.market_data_manager, "start_websocket"
+                    )
+                    if ctx.market_data_manager
+                    else False,
+                },
+            )
         except Exception as _mdm_start_exc:
             LOGGER.error("MarketDataManager.start() failed: %s", _mdm_start_exc)
 
@@ -5818,19 +5857,20 @@ async def startup_sequence(ctx: BotContext) -> None:
             register_fn = getattr(ctx.market_data_manager, "register_symbol", None)
             if callable(register_fn):
                 try:
-                    register_fn("NSE:NIFTY", 256265)
+                    register_fn(policy.nifty_internal_symbol, policy.nifty_spot_token)
                 except Exception:  # noqa: BLE001
                     LOGGER.debug(
                         "Spot symbol registration failed (will retry later)",
                         exc_info=True,
                     )
             LOGGER.info(
-                "STARTUP_WS_SPOT_SUBSCRIBE_REQUESTED symbol=NSE:NIFTY token=%d",
-                256265,
+                "STARTUP_WS_SPOT_SUBSCRIBE_REQUESTED symbol=%s token=%d",
+                policy.nifty_internal_symbol,
+                policy.nifty_spot_token,
                 extra={
                     "event": "STARTUP_WS_SPOT_SUBSCRIBE_REQUESTED",
-                    "symbol": "NSE:NIFTY",
-                    "token": 256265,
+                    "symbol": policy.nifty_internal_symbol,
+                    "token": policy.nifty_spot_token,
                 },
             )
             ctx.market_data_manager.start_websocket()
@@ -6201,19 +6241,22 @@ async def startup_sequence(ctx: BotContext) -> None:
                     spot_token_int: int | None = None
                     try:
                         spot_token_int = int(
-                            ctx.broker_client.get_instrument_token("NSE:NIFTY")
+                            ctx.broker_client.get_instrument_token(
+                                policy.nifty_internal_symbol
+                            )
                         )
                     except Exception:  # noqa: BLE001
-                        spot_token_int = 256265
+                        spot_token_int = int(policy.nifty_spot_token)
                     ctx.active_trading_universe = {
-                        "spot_symbol": basket["spot_symbol"],
+                        "spot_symbol": policy.nifty_internal_symbol,
                         "spot_token": spot_token_int,
                         "spot_ltp": float(spot_ltp),
                         "symbols": list(targets),
+                        "tokens": [],
                         "futures_symbol": basket["futures_symbol"],
                         "atm_strike": basket["atm_strike"],
                         "selected_at": datetime.now(timezone.utc).isoformat(),
-                        "source": "ws_spot_first_instrument_manager",
+                        "source": "ws_spot_first_marketdata_policy",
                     }
                 except Exception:  # noqa: BLE001
                     LOGGER.debug(
@@ -6649,6 +6692,14 @@ async def startup_sequence(ctx: BotContext) -> None:
                 # WS-first basket selection already proved fresh; never let a
                 # synthetic 25600.0 leak into LIVE option universe selection.
                 _active_universe = getattr(ctx, "active_trading_universe", None)
+                if isinstance(_active_universe, Mapping):
+                    LOGGER.info(
+                        "ACTIVE_UNIVERSE_REUSED",
+                        extra={
+                            "event": "ACTIVE_UNIVERSE_REUSED",
+                            "source": _active_universe.get("source"),
+                        },
+                    )
                 spot_price = 0.0
                 if isinstance(_active_universe, Mapping):
                     try:
@@ -7191,8 +7242,13 @@ async def startup_sequence(ctx: BotContext) -> None:
                             continue
 
                         spot = (
-                            ctx.market_data_manager.get_latest_price("NSE:NIFTY")
+                            ctx.market_data_manager.get_cached_ltp(
+                                policy.nifty_internal_symbol,
+                                max_age_seconds=policy.startup_spot_max_age_seconds,
+                                require_ws=False,
+                            )
                             if ctx.market_data_manager
+                            and hasattr(ctx.market_data_manager, "get_cached_ltp")
                             else None
                         )
                         
@@ -7708,6 +7764,13 @@ async def startup_sequence(ctx: BotContext) -> None:
                             )
                             if callable(ws_quote_proof_fn):
                                 ws_quote_proof = bool(ws_quote_proof_fn())
+                            ws_quote_for_gate = bool(ws_quote_proof)
+                            if (
+                                ws_quote_for_gate
+                                and not quote_available
+                                and not policy.quote_do_not_block_if_ws_healthy
+                            ):
+                                ws_quote_for_gate = False
                             try:
                                 market_state = get_market_state()
                             except Exception:  # noqa: BLE001
@@ -7753,7 +7816,7 @@ async def startup_sequence(ctx: BotContext) -> None:
                                 live_mode=bool(live_mode),
                                 hard_ready=bool(hard_ready),
                                 quote_available=bool(quote_available),
-                                ws_quote_proof=bool(ws_quote_proof),
+                                ws_quote_proof=bool(ws_quote_for_gate),
                                 market_open=bool(market_open_now),
                             )
                             data_warmup_reasons: list[str] = list(blocking_reasons)

--- a/src/nifty_scalper_bot/data/data_hub.py
+++ b/src/nifty_scalper_bot/data/data_hub.py
@@ -879,7 +879,7 @@ class DataHub:
             )
             self._subscribe_symbol(normalized)
         if callback is not None:
-            quote = self.get_quote(normalized, allow_pull=True)
+            quote = self.get_quote(normalized, allow_pull=False)
             if quote is not None:
                 try:
                     callback(dict(quote))
@@ -926,17 +926,62 @@ class DataHub:
             except Exception as exc:  # noqa: BLE001
                 LOGGER.debug("unsubscribe_orders delegate failed: %s", exc)
 
-    def get_latest_price(self, symbol: str) -> Optional[float]:
-        tick = self.get_quote(symbol)
+    def get_latest_price(
+        self,
+        symbol: str,
+        *,
+        allow_pull: bool = False,
+        allow_rest_fallback: bool | None = None,
+    ) -> Optional[float]:
+        tick = self.get_quote(symbol, allow_pull=False)
         if tick:
             return self._tick_price(tick)
+        mdm_cached = getattr(self._mdm, "get_cached_ltp", None)
+        if callable(mdm_cached):
+            try:
+                cached = mdm_cached(symbol, max_age_seconds=None, require_ws=False)
+                if cached is not None:
+                    return float(cached)
+            except Exception as exc:  # noqa: BLE001
+                LOGGER.debug("get_cached_ltp delegate failed for %s: %s", symbol, exc)
+        if not allow_pull and allow_rest_fallback is not True:
+            return None
         mdm_fn = getattr(self._mdm, "get_latest_price", None)
         if callable(mdm_fn):
             try:
-                return mdm_fn(symbol)
+                return mdm_fn(symbol, allow_rest_fallback=allow_rest_fallback)
+            except TypeError:
+                if allow_rest_fallback is True:
+                    try:
+                        return mdm_fn(symbol)
+                    except Exception as exc:  # noqa: BLE001
+                        LOGGER.debug(
+                            "get_latest_price legacy delegate failed for %s: %s",
+                            symbol,
+                            exc,
+                        )
+                return None
             except Exception as exc:  # noqa: BLE001
                 LOGGER.debug("get_latest_price delegate failed for %s: %s", symbol, exc)
         return None
+
+    def get_cached_ltp(
+        self,
+        symbol: str,
+        *,
+        max_age_seconds: float | None = None,
+        require_ws: bool = False,
+    ) -> Optional[float]:
+        """Get cached LTP only. Args: symbol/guards. Returns: price. Raises: none."""
+        mdm_cached = getattr(self._mdm, "get_cached_ltp", None)
+        if callable(mdm_cached):
+            return mdm_cached(
+                symbol, max_age_seconds=max_age_seconds, require_ws=require_ws
+            )
+        quote = self.get_quote(symbol, allow_pull=False)
+        if not quote:
+            return None
+        return self._tick_price(quote)
 
     def pull_quote(self, symbol: str) -> Dict[str, Any]:
         mdm_fn = getattr(self._mdm, "pull_quote", None)
@@ -1133,9 +1178,10 @@ class DataHub:
         return dict(greeks) if greeks else None
 
     def expected_move(self, days: float) -> Optional[float]:
-        spot = self.get_latest_price("NIFTY")
-        if spot is None:
-            spot = self.get_latest_price("NSE:NIFTY")
+        spot = None
+        cached_fn = getattr(self, "get_cached_ltp", None)
+        if callable(cached_fn):
+            spot = cached_fn("NSE:NIFTY", max_age_seconds=300.0, require_ws=False)
         if spot is None:
             return None
         iv = next(iter(self._iv_cache.values()), None)
@@ -1254,14 +1300,20 @@ class DataHub:
         return self._mdm_call("heartbeat_age")
 
     def get_latest_tick(self, symbol: str) -> Optional[Tick]:
-        return self._mdm_call("get_latest_tick", symbol) or self.get_quote(symbol)
+        return self._mdm_call("get_latest_tick", symbol) or self.get_quote(
+            symbol, allow_pull=False
+        )
 
     def get_last_tick(self, symbol: str) -> Optional[Tick]:
-        return self._mdm_call("get_last_tick", symbol) or self.get_quote(symbol)
+        return self._mdm_call("get_last_tick", symbol) or self.get_quote(
+            symbol, allow_pull=False
+        )
 
     def get_ltp(self, symbol: str) -> Optional[float]:
-        value = self._mdm_call("get_ltp", symbol)
-        return value if value is not None else self.get_latest_price(symbol)
+        cached = self.get_cached_ltp(symbol, max_age_seconds=None, require_ws=False)
+        if cached is not None:
+            return float(cached)
+        return self.get_latest_price(symbol, allow_pull=False)
 
     def has_quote(self, symbol: str) -> bool:
         value = self._mdm_call("has_quote", symbol)

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -27,6 +27,7 @@ import pandas as pd
 
 from nifty_scalper_bot.config.settings import get_settings
 from nifty_scalper_bot.data.candle_engine import CandleEngine
+from nifty_scalper_bot.data.market_data_policy import MarketDataPolicy
 from nifty_scalper_bot.data.validator import validate_tick
 from nifty_scalper_bot.data.source import DataIntegrityError
 from nifty_scalper_bot.infra.metrics import METRICS
@@ -133,6 +134,7 @@ class MarketDataManager:
         # FIX: Explicitly assign self._ws for internal use
         self._ws = websocket
         self._settings = settings or {}
+        self._md_policy = MarketDataPolicy.from_env()
         self._resolver = resolver
         self._logger = get_logger(__name__)
         # FIX: Initialize cache_len before it is used
@@ -1779,7 +1781,41 @@ class MarketDataManager:
             await asyncio.sleep(0.1)
         raise RuntimeError("Live tick unavailable")
 
-    def get_ltp(self, symbol: str) -> float | None:
+    def get_cached_ltp(
+        self,
+        symbol: str,
+        *,
+        max_age_seconds: float | None = None,
+        require_ws: bool = False,
+    ) -> float | None:
+        """Cached-only LTP accessor. Args: symbol/guards. Returns: ltp. Raises: none."""
+        canonical_symbol = self._canonical_symbol(symbol)
+        tick = self.get_latest_tick(canonical_symbol)
+        if not isinstance(tick, Mapping):
+            return None
+        if max_age_seconds is not None:
+            age = self.time_since_last_tick(canonical_symbol)
+            if age is None or age > float(max_age_seconds):
+                return None
+        source = str(
+            tick.get("source") or self._last_tick_source.get(canonical_symbol) or ""
+        ).lower()
+        if require_ws and source not in {"ws", "ws_full", "full"}:
+            return None
+        price = _coerce_positive_float(
+            tick.get("last_price")
+            or tick.get("ltp")
+            or tick.get("price")
+            or tick.get("close")
+        )
+        return float(price) if price and price > 0 else None
+
+    def get_ltp(
+        self,
+        symbol: str,
+        *,
+        allow_rest_fallback: bool | None = None,
+    ) -> float | None:
         """Return latest traded price for symbol with 2-second stale guard.
 
         If the cached tick is older than 2 seconds, falls back to broker REST
@@ -1794,6 +1830,13 @@ class MarketDataManager:
         canonical_symbol = self._canonical_symbol(symbol)
         stale_seconds = self._ltp_stale_threshold_for_symbol(canonical_symbol)
         now = time.time()
+        cached = self.get_cached_ltp(
+            canonical_symbol,
+            max_age_seconds=stale_seconds,
+            require_ws=False,
+        )
+        if cached is not None:
+            return cached
 
         # 1. Try tick cache with freshness check
         tick = self.get_latest_tick(canonical_symbol)
@@ -1845,11 +1888,45 @@ class MarketDataManager:
                 pass
 
         # 2. Broker REST fallback
+        policy = getattr(self, "_md_policy", MarketDataPolicy.from_env())
+        ws_started = bool(
+            getattr(self, "_ws_started", False)
+            or getattr(self, "_websocket_started", False)
+            or getattr(self, "ws_connected", False)
+        )
+        fallback_active = bool(
+            getattr(self, "_polling_fallback_active", False)
+            or getattr(self, "_rest_fallback_active", False)
+            or getattr(self, "_fallback_active", False)
+        )
+        if policy.should_suppress_rest_quote(
+            symbol=canonical_symbol,
+            ws_started=ws_started,
+            fallback_active=fallback_active,
+            explicit_allow_rest=allow_rest_fallback,
+        ):
+            self._logger.debug(
+                "MDM_REST_QUOTE_SUPPRESSED symbol=%s ws_started=%s fallback_active=%s allow_rest_fallback=%s",
+                canonical_symbol,
+                ws_started,
+                fallback_active,
+                allow_rest_fallback,
+                extra={
+                    "event": "MDM_REST_QUOTE_SUPPRESSED",
+                    "symbol": canonical_symbol,
+                    "ws_started": ws_started,
+                    "fallback_active": fallback_active,
+                    "allow_rest_fallback": allow_rest_fallback,
+                },
+            )
+            return None
+
         broker = getattr(self, "_broker", None)
         if broker:
             try:
                 t_before_rest = time.time()
-                quote = broker.get_quote(canonical_symbol)
+                broker_symbol = policy.to_broker_quote_symbol(canonical_symbol)
+                quote = broker.get_quote(broker_symbol)
                 if isinstance(quote, dict):
                     price = quote.get("last_price") or quote.get("ltp")
                     if price:
@@ -1924,9 +2001,14 @@ class MarketDataManager:
         self._logger.warning("get_ltp: no price available for %s", canonical_symbol)
         return None
 
-    def get_latest_price(self, symbol: str) -> float | None:
+    def get_latest_price(
+        self,
+        symbol: str,
+        *,
+        allow_rest_fallback: bool | None = None,
+    ) -> float | None:
         """Alias for get_ltp — preserves backward compatibility."""
-        return self.get_ltp(symbol)
+        return self.get_ltp(symbol, allow_rest_fallback=allow_rest_fallback)
 
     def get_fresh_spot_tick(
         self,
@@ -1971,7 +2053,7 @@ class MarketDataManager:
         source = str(
             tick.get("source") or self._last_tick_source.get(canonical) or ""
         ).lower()
-        if require_ws and source not in {"ws", "ws_full", "full", "quote"}:
+        if require_ws and source not in {"ws", "ws_full", "full"}:
             return None
 
         price = _coerce_positive_float(
@@ -3345,8 +3427,8 @@ class MarketDataManager:
                 ).lower()
                 bid_ask_source = str(tick.get("bid_ask_source") or "").lower()
                 if bool(tick.get("tradable_quote")) and (
-                    source in {"ws", "ws_full", "quote", "full"}
-                    or bid_ask_source in {"market_depth", "ws_full", "quote"}
+                    source in {"ws", "ws_full", "full"}
+                    or bid_ask_source in {"market_depth", "ws_full"}
                 ):
                     return True
         return False

--- a/src/nifty_scalper_bot/data/market_data_policy.py
+++ b/src/nifty_scalper_bot/data/market_data_policy.py
@@ -1,0 +1,186 @@
+"""Central policy for websocket-first market-data behavior."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+
+def _env_bool(name: str, default: bool = False) -> bool:
+    """Parse bool env var. Args: name/default. Returns: bool. Raises: none."""
+    raw = str(os.getenv(name, str(default))).strip().lower()
+    return raw in {'1', 'true', 'yes', 'y', 'on'}
+
+
+def _env_float(name: str, default: float) -> float:
+    """Parse float env var. Args: name/default. Returns: float. Raises: none."""
+    try:
+        return float(os.getenv(name, default))
+    except Exception:
+        return default
+
+
+def _env_int(name: str, default: int) -> int:
+    """Parse int env var. Args: name/default. Returns: int. Raises: none."""
+    try:
+        return int(os.getenv(name, default))
+    except Exception:
+        return default
+
+
+@dataclass(frozen=True)
+class MarketDataPolicy:
+    primary_source: str
+    rest_fallback_enabled: bool
+    rest_fallback_mode: str
+    suppress_rest_before_ws: bool
+    require_ws_spot_for_live: bool
+    allow_synthetic_spot_in_live: bool
+    nifty_internal_symbol: str
+    nifty_zerodha_quote_symbol: str
+    nifty_spot_token: int
+    nifty_exchange: str
+    startup_wait_for_ws_spot_seconds: float
+    startup_spot_max_age_seconds: float
+    block_live_if_no_ws_spot: bool
+    quote_canonicalize_index_symbols: bool
+    quote_mark_403_as_rest_degraded_only: bool
+    quote_do_not_block_if_ws_healthy: bool
+    log_throttle_quote_errors_seconds: float
+    log_marketdata_decisions: bool
+
+    @property
+    def live_mode(self) -> bool:
+        """Resolve LIVE mode. Args: none. Returns: bool. Raises: none."""
+        return (
+            str(os.getenv('EXECUTION_MODE', '')).strip().upper() == 'LIVE'
+            or _env_bool('ENABLE_LIVE', False)
+        )
+
+    @classmethod
+    def from_env(cls) -> 'MarketDataPolicy':
+        """Build policy from env. Args: none. Returns: policy. Raises: none."""
+        return cls(
+            primary_source=os.getenv(
+                'MARKETDATA_PRIMARY_SOURCE', 'websocket'
+            ).strip().lower(),
+            rest_fallback_enabled=_env_bool(
+                'MARKETDATA_REST_FALLBACK_ENABLED', True
+            ),
+            rest_fallback_mode=os.getenv(
+                'MARKETDATA_REST_FALLBACK_MODE', 'after_ws_degraded'
+            ).strip().lower(),
+            suppress_rest_before_ws=_env_bool(
+                'MARKETDATA_SUPPRESS_REST_BEFORE_WS', True
+            ),
+            require_ws_spot_for_live=_env_bool(
+                'MARKETDATA_REQUIRE_WS_SPOT_FOR_LIVE', True
+            ),
+            allow_synthetic_spot_in_live=_env_bool(
+                'MARKETDATA_ALLOW_SYNTHETIC_SPOT_IN_LIVE', False
+            ),
+            nifty_internal_symbol=os.getenv(
+                'NIFTY_INTERNAL_SYMBOL', 'NSE:NIFTY'
+            ).strip(),
+            nifty_zerodha_quote_symbol=os.getenv(
+                'NIFTY_ZERODHA_QUOTE_SYMBOL', 'NSE:NIFTY 50'
+            ).strip(),
+            nifty_spot_token=_env_int('NIFTY_SPOT_TOKEN', 256265),
+            nifty_exchange=os.getenv('NIFTY_EXCHANGE', 'NSE').strip(),
+            startup_wait_for_ws_spot_seconds=_env_float(
+                'STARTUP_WAIT_FOR_WS_SPOT_SECONDS', 15.0
+            ),
+            startup_spot_max_age_seconds=_env_float(
+                'STARTUP_SPOT_MAX_AGE_SECONDS', 120.0
+            ),
+            block_live_if_no_ws_spot=_env_bool(
+                'STARTUP_BLOCK_LIVE_IF_NO_WS_SPOT', True
+            ),
+            quote_canonicalize_index_symbols=_env_bool(
+                'QUOTE_CANONICALIZE_INDEX_SYMBOLS', True
+            ),
+            quote_mark_403_as_rest_degraded_only=_env_bool(
+                'QUOTE_MARK_403_AS_REST_DEGRADED_ONLY', True
+            ),
+            quote_do_not_block_if_ws_healthy=_env_bool(
+                'QUOTE_DO_NOT_BLOCK_IF_WS_HEALTHY', True
+            ),
+            log_throttle_quote_errors_seconds=_env_float(
+                'LOG_THROTTLE_QUOTE_ERRORS_SECONDS', 120.0
+            ),
+            log_marketdata_decisions=_env_bool('LOG_MARKETDATA_DECISIONS', True),
+        )
+
+    def is_internal_nifty(self, symbol: str) -> bool:
+        """Check NIFTY aliases. Args: symbol. Returns: bool. Raises: none."""
+        s = str(symbol or '').strip().upper()
+        internal = self.nifty_internal_symbol.upper()
+        return s in {
+            'NIFTY',
+            'NIFTY50',
+            'NSE:NIFTY',
+            'NSE:NIFTY50',
+            'NSE:NIFTY 50',
+            internal,
+        }
+
+    def to_broker_quote_symbol(self, symbol: str) -> str:
+        """Map symbol for broker quote APIs. Args: symbol. Returns: str. Raises: none."""
+        raw = str(symbol or '').strip()
+        if not self.quote_canonicalize_index_symbols:
+            return raw
+        if self.is_internal_nifty(raw):
+            return self.nifty_zerodha_quote_symbol
+        s = raw.upper()
+        if s in {'BANKNIFTY', 'NSE:BANKNIFTY', 'NSE:NIFTY BANK'}:
+            return 'NSE:NIFTY BANK'
+        if s in {'FINNIFTY', 'NSE:FINNIFTY', 'NSE:NIFTY FIN SERVICE'}:
+            return 'NSE:NIFTY FIN SERVICE'
+        return raw
+
+    def quote_aliases(self, symbol: str) -> list[str]:
+        """Return quote aliases. Args: symbol. Returns: list[str]. Raises: none."""
+        raw = str(symbol or '').strip()
+        if not raw:
+            return []
+        primary = self.to_broker_quote_symbol(raw)
+        candidates = [
+            primary,
+            raw,
+            primary.split(':', 1)[-1],
+            raw.split(':', 1)[-1],
+        ]
+        out: list[str] = []
+        for item in candidates:
+            cleaned = str(item or '').strip()
+            if cleaned and cleaned not in out:
+                out.append(cleaned)
+        return out
+
+    def should_suppress_rest_quote(
+        self,
+        *,
+        symbol: str,
+        ws_started: bool,
+        fallback_active: bool,
+        explicit_allow_rest: bool | None = None,
+    ) -> bool:
+        """Decide REST quote suppression. Args: fields. Returns: bool. Raises: none."""
+        if explicit_allow_rest is True:
+            return False
+        if explicit_allow_rest is False:
+            return True
+        if not self.live_mode:
+            return False
+        if not self.rest_fallback_enabled:
+            return True
+        if (
+            self.is_internal_nifty(symbol)
+            and self.suppress_rest_before_ws
+            and not ws_started
+            and not fallback_active
+        ):
+            return True
+        if self.rest_fallback_mode == 'after_ws_degraded' and not fallback_active:
+            return True
+        return False

--- a/src/nifty_scalper_bot/data/rest/zerodha_client.py
+++ b/src/nifty_scalper_bot/data/rest/zerodha_client.py
@@ -43,6 +43,7 @@ else:  # pragma: no cover - fallback type when kiteconnect missing
 InstrumentResolver = Any  # type: ignore[misc]
 
 from nifty_scalper_bot.data.rest.client import BaseBrokerClient
+from nifty_scalper_bot.data.market_data_policy import MarketDataPolicy
 from nifty_scalper_bot.utils.env import get_float, get_int, get_str
 from nifty_scalper_bot.utils.errors import (
     BrokerError,
@@ -57,7 +58,6 @@ from nifty_scalper_bot.utils.retry import (
     RetryErrorContext,
     retry_with_backoff,
 )
-from nifty_scalper_bot.utils.symbols import zerodha_quote_aliases
 
 T = TypeVar("T")
 
@@ -232,6 +232,8 @@ class ZerodhaKiteClient(BaseBrokerClient):
         self._quote_api_available = True
         self._quote_api_error: str | None = None
         self._quote_api_last_checked_at: float | None = None
+        self._md_policy = MarketDataPolicy.from_env()
+        self._last_quote_error_log_at: dict[str, float] = {}
 
     def quote_api_available(self) -> bool:
         """Return quote API capability flag."""
@@ -434,34 +436,9 @@ class ZerodhaKiteClient(BaseBrokerClient):
         """
 
         self._acquire_bucket(self._QUOTE_BUCKET)
+        policy = getattr(self, "_md_policy", MarketDataPolicy.from_env())
         kite_symbol = self._format_symbol(symbol)
-        raw_symbol = str(symbol or "").strip().upper()
-        formatted_symbol = str(kite_symbol or "").strip().upper()
-
-        variants: list[str] = []
-        for candidate in (
-            formatted_symbol,
-            raw_symbol,
-            formatted_symbol.split(":", 1)[-1],
-            raw_symbol.split(":", 1)[-1],
-        ):
-            if candidate and candidate not in variants:
-                variants.append(candidate)
-
-        # Known index aliases Kite accepts under different keys.
-        _INDEX_ALIASES = {
-            "NSE:NIFTY": ("NSE:NIFTY 50", "NIFTY 50"),
-            "NIFTY": ("NSE:NIFTY 50", "NIFTY 50"),
-            "NIFTY50": ("NSE:NIFTY 50", "NIFTY 50"),
-            "NSE:BANKNIFTY": ("NSE:NIFTY BANK", "NIFTY BANK"),
-            "BANKNIFTY": ("NSE:NIFTY BANK", "NIFTY BANK"),
-            "NSE:FINNIFTY": ("NSE:NIFTY FIN SERVICE", "NIFTY FIN SERVICE"),
-            "FINNIFTY": ("NSE:NIFTY FIN SERVICE", "NIFTY FIN SERVICE"),
-        }
-        for alias_key in (formatted_symbol, raw_symbol):
-            for extra in _INDEX_ALIASES.get(alias_key, ()):
-                if extra not in variants:
-                    variants.append(extra)
+        variants = policy.quote_aliases(kite_symbol)
 
         # Send every alias to Kite so a single round-trip covers any naming
         # mismatch.  Kite silently drops unknown keys from the response.
@@ -472,6 +449,34 @@ class ZerodhaKiteClient(BaseBrokerClient):
         except Exception as exc:
             if self._is_quote_access_denied(exc):
                 self._mark_quote_api_status(available=False, error="access_denied")
+                throttle_window = max(
+                    1.0, float(policy.log_throttle_quote_errors_seconds)
+                )
+                now = time.monotonic()
+                key = f"quote:{str(symbol).upper()}"
+                last = self._last_quote_error_log_at.get(key, 0.0)
+                if now - last >= throttle_window:
+                    self._last_quote_error_log_at[key] = now
+                    LOGGER.error(
+                        "quote_request_access_denied label=quote symbol=%s error=%s",
+                        symbol,
+                        exc,
+                        extra={
+                            "event": "quote_request_access_denied",
+                            "label": "quote",
+                            "symbol": str(symbol),
+                        },
+                    )
+                else:
+                    LOGGER.debug(
+                        "quote_request_access_denied_suppressed label=quote symbol=%s",
+                        symbol,
+                        extra={
+                            "event": "quote_request_access_denied_suppressed",
+                            "label": "quote",
+                            "symbol": str(symbol),
+                        },
+                    )
             raise
         data = response.get("data", {})
         self._mark_quote_api_status(available=True)
@@ -772,6 +777,7 @@ class ZerodhaKiteClient(BaseBrokerClient):
 
         if not tokens:
             return {}
+        policy = getattr(self, "_md_policy", MarketDataPolicy.from_env())
 
         # When POLL_REQUIRE_DEPTH is enabled we prefer the /quote endpoint (depth)
         # so that polling mode retrieves full quote payloads (bid/ask/depth) rather
@@ -920,7 +926,7 @@ class ZerodhaKiteClient(BaseBrokerClient):
             original_symbols = [str(item).strip() for item in tokens]
             symbols = []
             for original in original_symbols:
-                aliases = zerodha_quote_aliases(original)
+                aliases = policy.quote_aliases(original)
                 # Always include the original even when not in the alias list.
                 if original and original not in aliases:
                     aliases.insert(0, original)

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -3503,13 +3503,30 @@ class StrategyRunner:
         return None
 
     def _get_spot_price(self) -> float:
-        """Resilient spot price fetcher checking canonical variants."""
-        source = self._data_hub or self._market_data
-        if not source:
-            return 0.0
-        price = source.get_latest_price("NSE:NIFTY")
-        if price and price > 0:
-            return price
+        """Get cached-only spot. Args: none. Returns: price. Raises: none."""
+        for source in (self._data_hub, self._market_data):
+            if source is None:
+                continue
+            cached_fn = getattr(source, "get_cached_ltp", None)
+            if callable(cached_fn):
+                try:
+                    price = cached_fn(
+                        "NSE:NIFTY", max_age_seconds=300.0, require_ws=False
+                    )
+                    if price and price > 0:
+                        return float(price)
+                except Exception:
+                    pass
+            get_latest_price = getattr(source, "get_latest_price", None)
+            if callable(get_latest_price):
+                try:
+                    price = get_latest_price("NSE:NIFTY", allow_pull=False)
+                    if price and price > 0:
+                        return float(price)
+                except TypeError:
+                    pass
+                except Exception:
+                    pass
         return 0.0
 
     def _execute_order(self, *, symbol: str, base_symbol: str, side: Literal["BUY", "SELL"], quantity: int, price: float, stop_loss: float | None, take_profit: float | None, timestamp: datetime, reference_price: float | None = None, metadata: Mapping[str, Any] | None = None, ) -> tuple[str, int]:

--- a/tests/test_datahub_deferred_subscribe_no_pull.py
+++ b/tests/test_datahub_deferred_subscribe_no_pull.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from nifty_scalper_bot.data.data_hub import DataHub
+
+
+class _StubMdm:
+    def subscribe(self, _symbol: str, _callback):  # noqa: ANN001, ANN201
+        return None
+
+
+def test_datahub_deferred_subscribe_replay_is_cached_only() -> None:
+    hub = DataHub(_StubMdm(), defer_live_symbol_subscriptions=True)
+
+    def _get_quote(symbol: str, allow_pull: bool = True):  # noqa: ANN001, ANN201
+        if allow_pull:
+            raise AssertionError('allow_pull=True is forbidden for deferred replay')
+        return None
+
+    hub.get_quote = _get_quote  # type: ignore[method-assign]
+    hub.subscribe_ticks('NSE:NIFTY', callback=lambda _tick: None)

--- a/tests/test_datahub_expected_move_cached_only.py
+++ b/tests/test_datahub_expected_move_cached_only.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from nifty_scalper_bot.data.data_hub import DataHub
+
+
+class _MdmNoop:
+    def get_cached_ltp(
+        self,
+        _symbol: str,
+        *,
+        max_age_seconds: float | None = None,
+        require_ws: bool = False,
+    ) -> None:
+        return None
+
+
+def test_expected_move_uses_cached_ltp_only() -> None:
+    hub = DataHub(_MdmNoop())
+
+    def _raise(*_args, **_kwargs):  # noqa: ANN002, ANN003, ANN201
+        raise AssertionError('get_latest_price must not be called')
+
+    hub.get_latest_price = _raise  # type: ignore[method-assign]
+    assert hub.expected_move(1) is None

--- a/tests/test_market_data_policy.py
+++ b/tests/test_market_data_policy.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from nifty_scalper_bot.data.market_data_policy import MarketDataPolicy
+
+
+def test_market_data_policy_defaults(monkeypatch) -> None:
+    monkeypatch.delenv('MARKETDATA_PRIMARY_SOURCE', raising=False)
+    monkeypatch.delenv('NIFTY_INTERNAL_SYMBOL', raising=False)
+    monkeypatch.delenv('NIFTY_ZERODHA_QUOTE_SYMBOL', raising=False)
+    monkeypatch.delenv('MARKETDATA_REST_FALLBACK_MODE', raising=False)
+    policy = MarketDataPolicy.from_env()
+    assert policy.primary_source == 'websocket'
+    assert policy.nifty_internal_symbol == 'NSE:NIFTY'
+    assert policy.nifty_zerodha_quote_symbol == 'NSE:NIFTY 50'
+    assert policy.rest_fallback_mode == 'after_ws_degraded'
+
+
+def test_policy_quote_alias_and_suppression(monkeypatch) -> None:
+    monkeypatch.setenv('EXECUTION_MODE', 'LIVE')
+    monkeypatch.setenv('ENABLE_LIVE', 'true')
+    policy = MarketDataPolicy.from_env()
+    assert policy.to_broker_quote_symbol('NSE:NIFTY') == 'NSE:NIFTY 50'
+    assert policy.to_broker_quote_symbol('NIFTY') == 'NSE:NIFTY 50'
+    assert 'NSE:NIFTY 50' in policy.quote_aliases('NSE:NIFTY')
+    assert (
+        policy.should_suppress_rest_quote(
+            symbol='NSE:NIFTY', ws_started=False, fallback_active=False
+        )
+        is True
+    )
+    assert (
+        policy.should_suppress_rest_quote(
+            symbol='NSE:NIFTY', ws_started=True, fallback_active=True
+        )
+        is False
+    )

--- a/tests/test_no_early_nifty_rest_quote.py
+++ b/tests/test_no_early_nifty_rest_quote.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from nifty_scalper_bot.data.market_data_manager import MarketDataManager
+
+
+class FakeBroker:
+    def __init__(self) -> None:
+        self.called = False
+
+    def get_quote(self, symbol: str):  # noqa: ANN201
+        self.called = True
+        raise AssertionError('REST quote should not be called before WS')
+
+
+def test_no_early_nifty_rest_quote(monkeypatch) -> None:
+    monkeypatch.setenv('EXECUTION_MODE', 'LIVE')
+    monkeypatch.setenv('ENABLE_LIVE', 'true')
+    monkeypatch.setenv('MARKETDATA_SUPPRESS_REST_BEFORE_WS', 'true')
+    monkeypatch.setenv('MARKETDATA_REST_FALLBACK_MODE', 'after_ws_degraded')
+    broker = FakeBroker()
+    mdm = MarketDataManager(broker=broker, websocket=None)
+    mdm._ws_started = False  # noqa: SLF001 - test state setup
+    assert mdm.get_latest_price('NSE:NIFTY') is None
+    assert broker.called is False

--- a/tests/test_readiness_ws_overrides_quote_403.py
+++ b/tests/test_readiness_ws_overrides_quote_403.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from nifty_scalper_bot.execution.readiness import compute_live_readiness
+
+
+def test_readiness_allows_ws_when_quote_unavailable() -> None:
+    armed, reasons = compute_live_readiness(
+        live_mode=True,
+        hard_ready=True,
+        quote_available=False,
+        ws_quote_proof=True,
+        market_open=True,
+    )
+    assert armed is True
+    assert reasons == []
+
+
+def test_readiness_blocks_when_no_market_data_proof() -> None:
+    armed, reasons = compute_live_readiness(
+        live_mode=True,
+        hard_ready=True,
+        quote_available=False,
+        ws_quote_proof=False,
+        market_open=True,
+    )
+    assert armed is False
+    assert 'market_data_proof_unavailable' in reasons

--- a/tests/test_ws_proof_does_not_accept_quote.py
+++ b/tests/test_ws_proof_does_not_accept_quote.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import time
+
+from nifty_scalper_bot.data.market_data_manager import MarketDataManager
+
+
+def test_ws_proof_rejects_quote_source() -> None:
+    mdm = MarketDataManager(broker=None, websocket=None)
+    symbol = 'NSE:NIFTY'
+    tick = {
+        'last_price': 24011.6,
+        'source': 'quote',
+        'tradable_quote': True,
+        'bid': 24011.0,
+        'ask': 24012.0,
+    }
+    mdm._latest_ticks[symbol] = tick  # noqa: SLF001
+    mdm._last_tick_source[symbol] = 'quote'  # noqa: SLF001
+    now = time.time()
+    mdm._last_tick_time[symbol] = now  # noqa: SLF001
+    assert mdm.get_fresh_spot_tick(symbol, require_ws=True) is None
+    assert mdm.has_ws_tradable_quote([symbol]) is False
+
+    tick['source'] = 'ws_full'
+    mdm._last_tick_source[symbol] = 'ws_full'  # noqa: SLF001
+    assert mdm.get_fresh_spot_tick(symbol, require_ws=True) is not None
+    assert mdm.has_ws_tradable_quote([symbol]) is True

--- a/tests/test_zerodha_quote_symbol_mapping.py
+++ b/tests/test_zerodha_quote_symbol_mapping.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from typing import Any
+
+from nifty_scalper_bot.data.market_data_policy import MarketDataPolicy
+from nifty_scalper_bot.data.rest.zerodha_client import ZerodhaKiteClient
+
+
+def test_zerodha_quote_bulk_maps_nifty_alias() -> None:
+    client = ZerodhaKiteClient.__new__(ZerodhaKiteClient)
+    client._md_policy = MarketDataPolicy.from_env()  # noqa: SLF001
+    client._quote_api_available = True  # noqa: SLF001
+    client._quote_api_error = None  # noqa: SLF001
+    client._quote_api_last_checked_at = None  # noqa: SLF001
+    client._last_quote_error_log_at = {}  # noqa: SLF001
+    client._acquire_bucket = lambda _bucket: None  # noqa: SLF001
+    client._ensure_json = lambda payload: payload  # noqa: SLF001
+    client._mark_quote_api_status = lambda **_kwargs: None  # noqa: SLF001
+    client._is_quote_access_denied = lambda _exc: False  # noqa: SLF001
+    calls: list[dict[str, Any]] = []
+
+    def _make_request(_method: str, _path: str, params: dict[str, Any]):  # noqa: ANN001
+        calls.append(params)
+        return {
+            'data': {
+                'NSE:NIFTY 50': {
+                    'last_price': 24011.60,
+                    'instrument_token': 256265,
+                }
+            }
+        }
+
+    client._make_request = _make_request  # type: ignore[attr-defined]  # noqa: SLF001
+    out = client.get_quote_bulk(['NSE:NIFTY'])
+    assert 'NSE:NIFTY' in out
+    assert out['NSE:NIFTY']['last_price'] == 24011.60
+    requested = calls[0]['i']
+    assert 'NSE:NIFTY 50' in requested


### PR DESCRIPTION
### Motivation
- Startup was triggering Zerodha REST quote for NIFTY before WebSocket spot proof, causing repeated 403s and DATA_WARMUP instability. 
- A centralized, env-driven policy is required to enforce websocket-first behavior, canonicalize NIFTY for broker REST, and avoid ad-hoc REST fallbacks during startup.

### Description
- Add `MarketDataPolicy` (`src/nifty_scalper_bot/data/market_data_policy.py`) with `from_env()`, symbol canonicalization/aliases, and `should_suppress_rest_quote(...)` rules driven by environment variables. 
- Integrate policy into `MarketDataManager`: init policy, add cached-only `get_cached_ltp(...)`, gate REST fallback in `get_ltp(...)` (emits `MDM_REST_QUOTE_SUPPRESSED`), map canonical → broker quote symbol (NSE:NIFTY → NSE:NIFTY 50), and tighten WS-proof checks so `quote/rest/polling` are not counted as WS proof. 
- Integrate policy into `ZerodhaKiteClient`: init policy, use `policy.quote_aliases(...)` in `get_quote`/`get_quote_bulk`, map responses back to original requested keys, and add throttled logging for quote 403/access-denied errors so repeated 403s are demoted after a throttle window. 
- Fix `DataHub` deferred subscription leak and cached-first APIs: avoid broker pulls during deferred replay (`allow_pull=False`), make `get_latest_price` cached-first with opt-in pull, add `get_cached_ltp(...)`, and update `expected_move(...)` to use cached LTP only. 
- Update `StrategyRunner._get_spot_price()` to use cached-only lookups and avoid implicit REST pulls, and update app startup (`core/app.py`) to use policy values for WS spot-first subscription, wait-for-fresh-WS-tick behavior, reuse an active universe, and respect policy flags when deciding to arm LIVE. 
- Documentation: add policy-related env vars and notes to `README.md`. 
- Tests: add focused unit tests covering policy defaults, suppression logic, no-early-REST behavior, Zerodha alias mapping, deferred-replay no-pull, WS-proof semantics, expected-move cached-only, and readiness behavior. 

### Testing
- Static compile: ran `python -m compileall src tests` which succeeded. 
- Targeted unit tests: ran `python -m pytest` for the new/changed test set (`tests/test_market_data_policy.py`, `tests/test_no_early_nifty_rest_quote.py`, `tests/test_zerodha_quote_symbol_mapping.py`, `tests/test_datahub_deferred_subscribe_no_pull.py`, `tests/test_ws_proof_does_not_accept_quote.py`, `tests/test_datahub_expected_move_cached_only.py`, `tests/test_readiness_ws_overrides_quote_403.py`) and they all passed. 
- Full test run: `python -m pytest -q` aborted early during collection due to a pre-existing import issue in the baseline test suite (`ImportError: cannot import name 'InstrumentResolver' from nifty_scalper_bot.data`) that is outside the scope of this change. 
- CI script: attempted `./run_checks.sh` which executed dependency installation; the script environment reported `pytest` missing inside its created venv in this run context, so its full toolchain / lint / type checks did not complete here. 

If helpful I can split follow-ups to (1) export `InstrumentResolver` glide-fix to unblock full-suite runs and (2) adjust the `run_checks.sh` venv invocation so the script runs end-to-end in CI; both are orthogonal to the websocket-first market-data policy changes above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f073a84804832497ec5b3aa9f37ada)