### PR TITLE
Fix spot websocket subscription, first-tick handling, and runner health

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -6181,14 +6181,36 @@ async def startup_sequence(ctx: BotContext) -> None:
                         "Spot symbol registration failed (will retry later)",
                         exc_info=True,
                     )
+            subscribe_fn = getattr(
+                ctx.market_data_manager, "request_token_subscription", None
+            )
+            if callable(subscribe_fn):
+                subscribed = bool(
+                    subscribe_fn(
+                        policy.nifty_spot_token,
+                        symbol=policy.nifty_internal_symbol,
+                    )
+                )
+            else:
+                subscribed = False
+            desired_count_fn = getattr(
+                ctx.market_data_manager, "desired_token_count", None
+            )
+            desired_tokens = (
+                int(desired_count_fn()) if callable(desired_count_fn) else None
+            )
             LOGGER.info(
-                "STARTUP_WS_SPOT_SUBSCRIBE_REQUESTED symbol=%s token=%d",
+                "STARTUP_WS_SPOT_SUBSCRIBE_REQUESTED symbol=%s token=%d subscribed=%s desired_tokens=%s",
                 policy.nifty_internal_symbol,
                 policy.nifty_spot_token,
+                subscribed,
+                desired_tokens,
                 extra={
                     "event": "STARTUP_WS_SPOT_SUBSCRIBE_REQUESTED",
                     "symbol": policy.nifty_internal_symbol,
                     "token": policy.nifty_spot_token,
+                    "subscribed": subscribed,
+                    "desired_tokens": desired_tokens,
                 },
             )
             ctx.market_data_manager.start_websocket()
@@ -8769,18 +8791,30 @@ def _health_check(ctx: BotContext) -> None:
     status: Mapping[str, Any] = strategy_runner.get_status()
     if not bool(status.get("running")):
         state = get_market_state()
+        startup_age_s = max(0.0, time.monotonic() - float(ctx.started_mono or 0.0))
         expected_active = bool(
-            ctx.settings.enable_live and state == MarketState.OPEN and not ctx.shadow_mode_enabled
+            ctx.settings.enable_live
+            and state == MarketState.OPEN
+            and ctx.effective_mode == "LIVE"
+            and ctx.trading_ready
+            and ctx.live_orders_armed
+            and not ctx.shadow_mode_enabled
         )
         inactive_reason = "runner_task_not_started"
         if not ctx.settings.enable_live:
             inactive_reason = "live_disabled"
         elif state != MarketState.OPEN:
             inactive_reason = "market_closed"
+        elif ctx.effective_mode == "DATA_WARMUP":
+            inactive_reason = "data_warmup"
+        elif ctx.effective_mode != "LIVE":
+            inactive_reason = "live_blocked"
+        elif startup_age_s < 120.0:
+            inactive_reason = "startup_grace"
+        elif status.get("readiness_unmet") or not ctx.trading_ready or not ctx.live_orders_armed:
+            inactive_reason = "readiness_unmet"
         elif status.get("startup_degraded"):
             inactive_reason = "degraded_startup"
-        elif status.get("readiness_unmet"):
-            inactive_reason = "readiness_unmet"
         elif status.get("basket_build_failed"):
             inactive_reason = "basket_build_failure"
         elif status.get("loop_error"):
@@ -8796,6 +8830,10 @@ def _health_check(ctx: BotContext) -> None:
                 "expected_active": expected_active,
                 "market_state": state.value if hasattr(state, "value") else str(state),
                 "reason": inactive_reason,
+                "startup_age_s": round(startup_age_s, 2),
+                "effective_mode": ctx.effective_mode,
+                "trading_ready": ctx.trading_ready,
+                "live_orders_armed": ctx.live_orders_armed,
             },
         )
 

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -885,6 +885,7 @@ class MarketDataManager:
             return
         self._ws_started = True
         try:
+            self._reconcile_ws_subscriptions()
             self._ws.start()
         except Exception:
             self._ws_started = False
@@ -4058,6 +4059,38 @@ class MarketDataManager:
             return 1_000_000_000
         return int(max(0.0, (now - freshest) * 1000.0))
 
+    def symbol_data_age_ms_or_none(self, symbol: str | int) -> int | None:
+        """Return age in milliseconds or None when no tick exists. Args: symbol/token. Returns: age ms or none. Raises: none."""
+
+        resolved_symbol: str | None = None
+        try:
+            if isinstance(symbol, int):
+                with self._lock:
+                    resolved_symbol = self._symbol_by_token.get(int(symbol))
+            elif str(symbol).strip().isdigit():
+                with self._lock:
+                    resolved_symbol = self._symbol_by_token.get(int(str(symbol).strip()))
+            else:
+                resolved_symbol = self._canonical_symbol(str(symbol))
+        except Exception:
+            resolved_symbol = None
+        if not resolved_symbol:
+            return None
+        now = time.time()
+        with self._lock:
+            wallclock = float(self._last_tick_wallclock.get(resolved_symbol, 0.0) or 0.0)
+            arrival = float(self._last_tick_time.get(resolved_symbol, 0.0) or 0.0)
+        freshest = max(wallclock, arrival)
+        if freshest <= 0.0:
+            return None
+        return int(max(0.0, (now - freshest) * 1000.0))
+
+    def symbol_has_tick(self, symbol: str | int) -> bool:
+        """Return whether at least one tick exists for symbol/token. Args: symbol/token. Returns: bool. Raises: none."""
+
+        return self.symbol_data_age_ms_or_none(symbol) is not None
+
+
     # ------------------------------------------------------------------
     # Internal plumbing
 
@@ -5951,24 +5984,55 @@ class MarketDataManager:
         market_open = get_market_state() == MarketState.OPEN
         return float(stale_threshold_for_symbol(symbol, market_open))
 
+    def _request_spot_resubscribe_if_due(self, symbol: str, reason: str) -> None:
+        """Request throttled spot resubscription when a token is available. Args: symbol/reason. Returns: none. Raises: none."""
+
+        now = time.time()
+        if now - self._last_spot_resubscribe_attempt < 120.0:
+            return
+        self._last_spot_resubscribe_attempt = now
+        token = int(self._symbol_to_token.get(symbol) or self._token_by_symbol.get(symbol) or 0)
+        if token <= 0:
+            self._logger.info(
+                "SPOT_RESUBSCRIBE_SKIPPED symbol=%s reason=token_missing",
+                symbol,
+                extra={"event": "SPOT_RESUBSCRIBE_SKIPPED", "symbol": symbol, "reason": "token_missing"},
+            )
+            return
+        self._logger.info(
+            "WS_RESUBSCRIBE_REQUESTED symbol=%s reason=%s",
+            symbol,
+            reason,
+            extra={"event": "WS_RESUBSCRIBE_REQUESTED", "symbol": symbol, "reason": reason},
+        )
+        self.request_token_subscription(token, symbol=symbol)
+
     def _monitor_spot_ws_health(self) -> None:
         """Monitor NSE spot tick freshness and trigger throttled resubscribe. Args: none. Returns: none. Raises: none."""
         if get_market_state() != MarketState.OPEN:
             return
         symbol = "NSE:NIFTY"
-        age_ms = self.symbol_data_age_ms(symbol)
+        if not self.symbol_has_tick(symbol):
+            log_throttled(
+                self._logger,
+                key="spot_ws_first_tick_missing",
+                msg="MDM_WS_FIRST_TICK_MISSING symbol=NSE:NIFTY reason=no_tick_received",
+                interval_sec=60.0,
+                level=logging.WARNING,
+                extra={"event": "MDM_WS_FIRST_TICK_MISSING", "symbol": symbol, "reason": "no_tick_received"},
+            )
+            self._request_spot_resubscribe_if_due(symbol, reason="first_tick_missing")
+            return
+        age_ms = self.symbol_data_age_ms_or_none(symbol)
+        if age_ms is None:
+            return
         threshold_ms = self._ltp_stale_threshold_for_symbol(symbol) * 1000.0
         self._logger.debug(
             "SPOT_WS_HEALTH_CHECK symbol=%s age=%.2fs threshold=%.2fs",
             symbol,
             age_ms / 1000.0,
             threshold_ms / 1000.0,
-            extra={
-                "event": "SPOT_WS_HEALTH_CHECK",
-                "symbol": symbol,
-                "age_s": round(age_ms / 1000.0, 3),
-                "threshold_s": round(threshold_ms / 1000.0, 3),
-            },
+            extra={"event": "SPOT_WS_HEALTH_CHECK", "symbol": symbol, "age_s": round(age_ms / 1000.0, 3), "threshold_s": round(threshold_ms / 1000.0, 3)},
         )
         if age_ms <= threshold_ms:
             return
@@ -5979,54 +6043,10 @@ class MarketDataManager:
                 "MDM_WS_TICK_STALE symbol=%s age=%.2fs",
                 symbol,
                 age_ms / 1000.0,
-                extra={
-                    "event": "MDM_WS_TICK_STALE",
-                    "symbol": symbol,
-                    "age_s": round(age_ms / 1000.0, 3),
-                },
+                extra={"event": "MDM_WS_TICK_STALE", "symbol": symbol, "age_s": round(age_ms / 1000.0, 3)},
             )
-        if now - self._last_spot_resubscribe_attempt < 120.0:
-            return
-        self._last_spot_resubscribe_attempt = now
-        try:
-            token = int(
-                self._symbol_to_token.get(symbol)
-                or self._token_by_symbol.get(symbol)
-                or 0
-            )
-            if token <= 0:
-                return
-            self._logger.info(
-                "WS_RESUBSCRIBE_REQUESTED symbol=%s reason=stale_index_tick",
-                symbol,
-                extra={
-                    "event": "WS_RESUBSCRIBE_REQUESTED",
-                    "symbol": symbol,
-                    "reason": "stale_index_tick",
-                },
-            )
-            self.request_token_subscription(token, symbol=symbol)
-            self._logger.info(
-                "WS_RESUBSCRIBE_SUCCESS symbol=%s token=%s",
-                symbol,
-                token,
-                extra={
-                    "event": "WS_RESUBSCRIBE_SUCCESS",
-                    "symbol": symbol,
-                    "token": token,
-                },
-            )
-        except Exception as exc:  # noqa: BLE001
-            self._logger.warning(
-                "WS_RESUBSCRIBE_FAILED symbol=%s error=%s",
-                symbol,
-                exc,
-                extra={
-                    "event": "WS_RESUBSCRIBE_FAILED",
-                    "symbol": symbol,
-                    "error": str(exc),
-                },
-            )
+        self._request_spot_resubscribe_if_due(symbol, reason="stale_index_tick")
+
 
     def _has_recent_rest_ticks(self) -> bool:
         cutoff = time.time() - max(self._rest_poll_interval * 2.0, 5.0)

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -829,10 +829,12 @@ class StrategyRunner:
             if signal:
                 from datetime import datetime, timezone
                 now = datetime.now(timezone.utc)
-                prepared_signal, prepare_reason = await self._prepare_signal_for_handling(
-                    signal,
-                    price,
-                    trace_id,
+                prepared_signal, prepare_reason = asyncio.run(
+                    self._prepare_signal_for_handling(
+                        signal,
+                        price,
+                        trace_id,
+                    )
                 )
                 if prepared_signal is None:
                     self._emit_runner_eval_decision(
@@ -6570,15 +6572,13 @@ class StrategyRunner:
                     extra={"event": "signal_executing", "symbol": symbol,
                            "action": signal.action},
                 )
-                prepared_signal: Signal | None = signal
-                prepare_reason: str | None = None
-                if isinstance(signal.metadata, dict) and isinstance(
-                    signal.metadata.get("candidate_snapshots"), list
-                ):
-                    pass
-                else:
-                    prepared_signal = None
-                    prepare_reason = "candidate_refresh_pending"
+                prepared_signal, prepare_reason = asyncio.run(
+                    self._prepare_signal_for_handling(
+                        signal,
+                        price,
+                        trace_id,
+                    )
+                )
                 if prepared_signal is None:
                     self._emit_runner_eval_decision(
                         symbol=symbol,

--- a/tests/data/test_market_data_manager_subscriptions.py
+++ b/tests/data/test_market_data_manager_subscriptions.py
@@ -273,3 +273,58 @@ def test_ensure_fresh_tick_uses_polling_fallback_owner(monkeypatch) -> None:
     asyncio.run(mdm.ensure_fresh_tick('NSE:NIFTY'))
 
     assert fallback.subscribed
+
+
+def test_start_websocket_reconciles_tokens_before_connect() -> None:
+    class WsWithStart(DummyWebSocket):
+        def __init__(self) -> None:
+            super().__init__()
+            self.start_calls = 0
+
+        def start(self) -> None:
+            self.start_calls += 1
+
+    ws = WsWithStart()
+    mdm = MarketDataManager(DummyBroker(), ws, resolver=DummyResolver())
+    mdm.request_token_subscription(256265, symbol='NSE:NIFTY')
+    ws.calls.clear()
+
+    mdm.start_websocket()
+
+    assert ws.start_calls == 1
+    assert ws.calls == [[256265]]
+
+
+def test_spot_ws_health_logs_first_tick_missing_not_stale(monkeypatch, caplog) -> None:
+    mdm = MarketDataManager(DummyBroker(), websocket=None, resolver=DummyResolver())
+    mdm.register_symbol('NSE:NIFTY', 256265)
+    monkeypatch.setattr(
+        'nifty_scalper_bot.data.market_data_manager.get_market_state',
+        lambda: MarketState.OPEN,
+    )
+
+    with caplog.at_level('WARNING'):
+        mdm._monitor_spot_ws_health()  # noqa: SLF001
+
+    assert 'MDM_WS_FIRST_TICK_MISSING' in caplog.text
+    assert 'MDM_WS_TICK_STALE' not in caplog.text
+
+
+def test_spot_ws_health_logs_stale_only_after_first_tick(monkeypatch, caplog) -> None:
+    mdm = MarketDataManager(DummyBroker(), websocket=None, resolver=DummyResolver())
+    mdm.register_symbol('NSE:NIFTY', 256265)
+    mdm._last_tick_wallclock['NSE:NIFTY'] = 1.0  # noqa: SLF001
+    mdm._last_tick_time['NSE:NIFTY'] = 1.0  # noqa: SLF001
+    monkeypatch.setattr(
+        'nifty_scalper_bot.data.market_data_manager.get_market_state',
+        lambda: MarketState.OPEN,
+    )
+    monkeypatch.setattr(
+        'nifty_scalper_bot.data.market_data_manager.time.time',
+        lambda: 1000.0,
+    )
+
+    with caplog.at_level('WARNING'):
+        mdm._monitor_spot_ws_health()  # noqa: SLF001
+
+    assert 'MDM_WS_TICK_STALE' in caplog.text


### PR DESCRIPTION
### Motivation
- Ensure the startup spot subscription is a real WS subscription intent so the WebSocket connects with the spot token and the first tick can arrive. 
- Avoid mis-reporting a missing first tick as a stale tick (the 1_000_000_000 sentinel) and provide a clear recovery path. 
- Reduce false alarms from the strategy runner health check during normal startup/warmup. 
- Make phase10 candidate preparation actually attempt preparation instead of unconditionally rejecting with `candidate_refresh_pending`.

### Description
- Wire startup flow to call `request_token_subscription(...)` for the canonical NIFTY spot immediately after `register_symbol(...)` and log `subscribed` and `desired_tokens` before `start_websocket()` is invoked. 
- Make `MarketDataManager.start_websocket()` call `_reconcile_ws_subscriptions()` prior to starting the transport so desired tokens are applied before connect. 
- Add `symbol_data_age_ms_or_none()` and `symbol_has_tick()` to distinguish "no first tick" from stale ticks, and change `_monitor_spot_ws_health()` to emit `MDM_WS_FIRST_TICK_MISSING` when no tick exists and only emit `MDM_WS_TICK_STALE` after a real tick exists. 
- Add `_request_spot_resubscribe_if_due(symbol, reason)` with a 120s throttle, explicit skip log when token is missing, and use it for both first-tick-missing and stale-index-tick paths. 
- Improve `_health_check()` to compute `expected_active` with `effective_mode`, `trading_ready` and `live_orders_armed`, and prioritize non‑abnormal reasons (`live_disabled`, `market_closed`, `data_warmup`/`live_blocked`, `startup_grace`, etc.) before reporting `runner_task_not_started`. 
- Replace the unconditional snapshot-check in phase10 with an actual preparation call to `_prepare_signal_for_handling(...)` and preserve existing rejection/logging when preparation fails. 
- Add focused unit tests that assert token reconciliation happens before WS `start()` and that first-tick-missing is logged separately from stale tick logging.

### Testing
- `python -m compileall src` succeeded. 
- Targeted unit tests `pytest -q tests/data/test_market_data_manager_subscriptions.py` passed. 
- Full test run `pytest -q` failed due to an unrelated repository import/export issue (`ImportError` in `tests/data/test_instrument_resolver.py` for `InstrumentResolver`) and is not caused by these changes. 
- `run_checks.sh` could not be used end-to-end in this environment (initial permission and environment differences prevented a complete checks run here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2243cadd4832496c3c2a52c98f78a)