### PR TITLE
fix: websocket pre-connect token handoff and runner async preparation

### DIFF
--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -1325,19 +1325,32 @@ class MarketDataManager:
         """Apply desired token set to websocket transport. Args: none. Returns: none. Raises: none."""
 
         ws = self._ws
-        if ws is None:
+        if ws is None or not hasattr(ws, "set_tokens"):
             return
-        if not hasattr(ws, "set_tokens"):
-            return
+
+        try:
+            changed = ws.set_tokens(sorted(self._desired_tokens))
+            self._dispatched_subscriptions.update(self._desired_tokens)
+            connected = self._is_ws_connected()
+            self._logger.debug(
+                "ws_tokens_reconciled desired=%d changed=%s connected=%s",
+                len(self._desired_tokens),
+                changed,
+                connected,
+                extra={
+                    "event": "ws_tokens_reconciled",
+                    "desired_tokens": len(self._desired_tokens),
+                    "changed": changed,
+                    "connected": connected,
+                },
+            )
+        except Exception as exc:  # noqa: BLE001
+            self._logger.debug("ws token reconcile deferred: %s", exc)
+
         if hasattr(ws, "is_connected") and not self._is_ws_connected():
             self._pending_subscription_tokens.update(self._desired_tokens)
             self._pending_subscriptions.update(self._desired_tokens)
             return
-        try:
-            ws.set_tokens(sorted(self._desired_tokens))
-            self._dispatched_subscriptions.update(self._desired_tokens)
-        except Exception as exc:  # noqa: BLE001
-            self._logger.debug("ws token reconcile deferred: %s", exc)
 
     def request_token_subscription(
         self,
@@ -4088,7 +4101,30 @@ class MarketDataManager:
     def symbol_has_tick(self, symbol: str | int) -> bool:
         """Return whether at least one tick exists for symbol/token. Args: symbol/token. Returns: bool. Raises: none."""
 
-        return self.symbol_data_age_ms_or_none(symbol) is not None
+        resolved_symbol: str | None = None
+        try:
+            if isinstance(symbol, int):
+                with self._lock:
+                    resolved_symbol = self._symbol_by_token.get(int(symbol))
+            elif str(symbol).strip().isdigit():
+                with self._lock:
+                    resolved_symbol = self._symbol_by_token.get(int(str(symbol).strip()))
+            else:
+                resolved_symbol = self._canonical_symbol(str(symbol))
+        except Exception:
+            resolved_symbol = None
+
+        if not resolved_symbol:
+            return False
+
+        with self._lock:
+            if resolved_symbol in self._latest_ticks:
+                return True
+            if float(self._last_tick_wallclock.get(resolved_symbol, 0.0) or 0.0) > 0.0:
+                return True
+            if float(self._last_tick_time.get(resolved_symbol, 0.0) or 0.0) > 0.0:
+                return True
+        return False
 
 
     # ------------------------------------------------------------------

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -829,12 +829,10 @@ class StrategyRunner:
             if signal:
                 from datetime import datetime, timezone
                 now = datetime.now(timezone.utc)
-                prepared_signal, prepare_reason = asyncio.run(
-                    self._prepare_signal_for_handling(
-                        signal,
-                        price,
-                        trace_id,
-                    )
+                prepared_signal, prepare_reason = await self._prepare_signal_for_handling(
+                    signal,
+                    price,
+                    trace_id,
                 )
                 if prepared_signal is None:
                     self._emit_runner_eval_decision(
@@ -1649,6 +1647,21 @@ class StrategyRunner:
         except Exception as exc:
             self._logger.error("CANDIDATE_SNAPSHOT_BUILD_FAILED reason=%s", exc)
             return [], True
+
+    def _prepare_signal_for_handling_sync(
+        self,
+        signal: Signal,
+        price: float,
+        trace_id: str,
+    ) -> tuple[Signal | None, str | None]:
+        """Prepare a signal from sync paths. Args: signal/price/trace_id. Returns: prepared signal and reason. Raises: none."""
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return asyncio.run(
+                self._prepare_signal_for_handling(signal, price, trace_id)
+            )
+        return None, "candidate_refresh_pending"
 
     async def _prepare_signal_for_handling(
         self,
@@ -6572,12 +6585,10 @@ class StrategyRunner:
                     extra={"event": "signal_executing", "symbol": symbol,
                            "action": signal.action},
                 )
-                prepared_signal, prepare_reason = asyncio.run(
-                    self._prepare_signal_for_handling(
-                        signal,
-                        price,
-                        trace_id,
-                    )
+                prepared_signal, prepare_reason = self._prepare_signal_for_handling_sync(
+                    signal,
+                    price,
+                    trace_id,
                 )
                 if prepared_signal is None:
                     self._emit_runner_eval_decision(

--- a/tests/data/test_market_data_manager_subscriptions.py
+++ b/tests/data/test_market_data_manager_subscriptions.py
@@ -275,6 +275,27 @@ def test_ensure_fresh_tick_uses_polling_fallback_owner(monkeypatch) -> None:
     assert fallback.subscribed
 
 
+
+
+def test_request_token_subscription_sets_ws_tokens_before_connect() -> None:
+    ws = DummyWebSocket()
+    ws.connected = False
+    ws._tokens: set[int] = set()
+
+    def _set_tokens(tokens) -> bool:  # noqa: ANN001
+        ws.calls.append(list(tokens))
+        ws._tokens = set(tokens)
+        return True
+
+    ws.set_tokens = _set_tokens  # type: ignore[method-assign]
+    mdm = MarketDataManager(DummyBroker(), ws, resolver=DummyResolver())
+
+    changed = mdm.request_token_subscription(256265, symbol='NSE:NIFTY')
+
+    assert changed is True
+    assert ws.calls[-1] == [256265]
+    assert 256265 in ws._tokens
+
 def test_start_websocket_reconciles_tokens_before_connect() -> None:
     class WsWithStart(DummyWebSocket):
         def __init__(self) -> None:

--- a/tests/strategies/test_runner_live_path_guards.py
+++ b/tests/strategies/test_runner_live_path_guards.py
@@ -809,6 +809,51 @@ async def test_build_candidate_snapshots_all_pending_returns_refresh_pending() -
     assert refresh_pending is True
 
 
+
+
+def test_prepare_signal_for_handling_sync_uses_asyncio_run_without_loop(monkeypatch) -> None:
+    runner = _build_runner()
+
+    async def _fake_prepare(signal, price, trace_id):
+        return signal, None
+
+    runner._prepare_signal_for_handling = _fake_prepare
+    signal = Signal(
+        action='BUY',
+        symbol='NFO:NIFTY26APR23800CE',
+        quantity=1,
+        confidence=0.9,
+        reason='unit_test',
+        stop_loss=100.0,
+        take_profit=120.0,
+        metadata={},
+    )
+
+    prepared, reason = runner._prepare_signal_for_handling_sync(signal, 101.0, 'trace-sync')
+
+    assert prepared is signal
+    assert reason is None
+
+
+@pytest.mark.asyncio
+async def test_prepare_signal_for_handling_sync_returns_pending_when_loop_running() -> None:
+    runner = _build_runner()
+    signal = Signal(
+        action='BUY',
+        symbol='NFO:NIFTY26APR23800CE',
+        quantity=1,
+        confidence=0.9,
+        reason='unit_test',
+        stop_loss=100.0,
+        take_profit=120.0,
+        metadata={},
+    )
+
+    prepared, reason = runner._prepare_signal_for_handling_sync(signal, 101.0, 'trace-loop')
+
+    assert prepared is None
+    assert reason == 'candidate_refresh_pending'
+
 def test_runner_no_async_event_loop_fallback_in_runner_source() -> None:
     """Regression guard: async paths must not skip prep just because event loop exists."""
     from pathlib import Path


### PR DESCRIPTION
### Motivation
- Ensure websocket transport receives desired tokens before connection so the WS token state is populated at connect and logs show correct token counts.
- Avoid calling `asyncio.run()` from code paths that may execute inside an active event loop to prevent runtime errors during signal preparation.
- Make tick-presence checks more robust so symbol tick state is correctly reported even when timestamp maps are delayed.

### Description
- Modify `MarketDataManager._reconcile_ws_subscriptions()` to call `ws.set_tokens(sorted(self._desired_tokens))` unconditionally (when `set_tokens` exists) before performing connected-state early returns, and add a debug `ws_tokens_reconciled` log with `desired/changed/connected` fields; files changed: `src/nifty_scalper_bot/data/market_data_manager.py`.
- Strengthen `MarketDataManager.symbol_has_tick()` to resolve canonical symbol/token and explicitly check `_latest_ticks`, `_last_tick_wallclock`, and `_last_tick_time` instead of delegating solely to the age helper; file changed: `src/nifty_scalper_bot/data/market_data_manager.py`.
- Replace fragile `asyncio.run(self._prepare_signal_for_handling(...))` uses in async code paths with `await self._prepare_signal_for_handling(...)`, and add a sync helper `StrategyRunner._prepare_signal_for_handling_sync()` which uses `asyncio.run()` only when no running loop is detected and returns `(None, "candidate_refresh_pending")` when called from inside an active loop; file changed: `src/nifty_scalper_bot/strategies/runner.py`.
- Update sync execution path to use the new `_prepare_signal_for_handling_sync()` and update async `_process_token` to `await` preparation correctly; file changed: `src/nifty_scalper_bot/strategies/runner.py`.
- Add tests: pre-connect WS token handoff test to `tests/data/test_market_data_manager_subscriptions.py` and sync-helper tests to `tests/strategies/test_runner_live_path_guards.py` that validate both no-loop (`asyncio.run` taken) and running-loop (`candidate_refresh_pending`) behaviors.

### Testing
- Ran `python -m compileall src` which completed successfully.
- Ran a full `pytest -q` which failed early due to an unrelated import error in `tests/data/test_instrument_resolver.py` (`ImportError: cannot import name 'InstrumentResolver' from 'nifty_scalper_bot.data'`), so full test-suite is blocked by existing test/import expectations.
- Ran targeted tests `pytest -q tests/data/test_market_data_manager_subscriptions.py tests/strategies/test_runner_live_path_guards.py` which produced a failing test in the runner suite (`test_build_candidate_snapshots_per_symbol_refresh_pending` raised `TypeError: object tuple can't be used in 'await'`), indicating a test harness path that expects an awaitable from a mocked function; new tests for WS token handoff and sync-helper were executed as part of these runs.
- Verification commands executed include `grep` checks for `_reconcile_ws_subscriptions`, `ws.set_tokens`, and the `asyncio.run` pattern, and commits were created on branch `fix/zip59-ws-token-handoff-runner-async` with message `Fix websocket token handoff and runner async preparation`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f22e78250883249dd43f9c23d687e3)