### PR TITLE
fix: harden health loop monotonic and BotContext readiness state

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -1701,6 +1701,8 @@ class BotContext:
     live_orders_armed: bool = False
     trading_ready: bool = False
     readiness_mode: str = "SHADOW"
+    effective_mode: str = "SHADOW"
+    started_mono: float = field(default_factory=time_module.monotonic)
     live_block_reason: str | None = None
     market_session_state: str | None = None
     quote_api_available: bool = True
@@ -2352,8 +2354,8 @@ def _get_symbols(
         if market_data_manager is None:
             return None
 
-        start = time.monotonic()
-        while time.monotonic() - start < timeout:
+        start = time_module.monotonic()
+        while time_module.monotonic() - start < timeout:
             tick = market_data_manager.get_latest_tick(symbol)
             if tick:
                 return tick
@@ -6047,6 +6049,7 @@ def _schedule_deferred_basket_retry(ctx: BotContext, *, configured_mode: str) ->
     ctx.live_orders_armed = False
     ctx.trading_ready = False
     ctx.readiness_mode = "DATA_WARMUP"
+    ctx.effective_mode = ctx.readiness_mode
     ctx.live_block_reason = "fresh_ws_spot_unavailable"
     if not getattr(ctx, "_deferred_basket_retry_started", False):
         ctx._deferred_basket_retry_started = True
@@ -6104,6 +6107,7 @@ async def startup_sequence(ctx: BotContext) -> None:
     ctx.live_orders_armed = False
     ctx.trading_ready = False
     ctx.readiness_mode = "DATA_WARMUP" if configured_mode == "LIVE" else configured_mode
+    ctx.effective_mode = ctx.readiness_mode
     LOGGER.info(
         "Startup | configured_mode=%s | effective_mode=%s | live_orders_armed=%s | trading_ready=%s | data_dir=%s | port=%s",
         configured_mode,
@@ -6395,6 +6399,7 @@ async def startup_sequence(ctx: BotContext) -> None:
                 ctx.live_orders_armed = False
                 ctx.trading_ready = False
                 ctx.readiness_mode = "DATA_WARMUP"
+                ctx.effective_mode = ctx.readiness_mode
                 ctx.live_block_reason = "fresh_spot_tick_unavailable"
                 # Skip the option pre-hydration in this iteration; the
                 # readiness gate will keep us in DATA_WARMUP and the
@@ -8123,6 +8128,7 @@ async def startup_sequence(ctx: BotContext) -> None:
                                 ctx.live_orders_armed = True
                                 ctx.trading_ready = True
                                 ctx.readiness_mode = "LIVE"
+                                ctx.effective_mode = ctx.readiness_mode
                                 LOGGER.info(
                                     "LIVE_TRADING_ARMED hard_ready=%s quote_available=%s ws_quote_proof=%s",
                                     hard_ready,
@@ -8139,6 +8145,7 @@ async def startup_sequence(ctx: BotContext) -> None:
                                 ctx.live_orders_armed = False
                                 ctx.trading_ready = False
                                 ctx.readiness_mode = "DATA_WARMUP"
+                                ctx.effective_mode = ctx.readiness_mode
                                 if "startup_pipeline_incomplete" in data_warmup_reasons:
                                     LOGGER.error(
                                         "LIVE_TRADING_BLOCKED reason=startup_pipeline_incomplete missing=%s",
@@ -8798,13 +8805,22 @@ def _health_check(ctx: BotContext) -> None:
     status: Mapping[str, Any] = strategy_runner.get_status()
     if not bool(status.get("running")):
         state = get_market_state()
-        startup_age_s = max(0.0, time.monotonic() - float(ctx.started_mono or 0.0))
+        now_mono = time_module.monotonic()
+        started_mono = float(getattr(ctx, "started_mono", now_mono) or now_mono)
+        startup_age_s = max(0.0, now_mono - started_mono)
+        effective_mode = str(
+            getattr(ctx, "effective_mode", "")
+            or getattr(ctx, "readiness_mode", "")
+            or ""
+        ).upper()
+        trading_ready = bool(getattr(ctx, "trading_ready", False))
+        live_orders_armed = bool(getattr(ctx, "live_orders_armed", False))
         expected_active = bool(
             ctx.settings.enable_live
             and state == MarketState.OPEN
-            and ctx.effective_mode == "LIVE"
-            and ctx.trading_ready
-            and ctx.live_orders_armed
+            and effective_mode == "LIVE"
+            and trading_ready
+            and live_orders_armed
             and not ctx.shadow_mode_enabled
         )
         inactive_reason = "runner_task_not_started"
@@ -8812,13 +8828,13 @@ def _health_check(ctx: BotContext) -> None:
             inactive_reason = "live_disabled"
         elif state != MarketState.OPEN:
             inactive_reason = "market_closed"
-        elif ctx.effective_mode == "DATA_WARMUP":
+        elif effective_mode == "DATA_WARMUP":
             inactive_reason = "data_warmup"
-        elif ctx.effective_mode != "LIVE":
+        elif effective_mode != "LIVE":
             inactive_reason = "live_blocked"
         elif startup_age_s < 120.0:
             inactive_reason = "startup_grace"
-        elif status.get("readiness_unmet") or not ctx.trading_ready or not ctx.live_orders_armed:
+        elif status.get("readiness_unmet") or not trading_ready or not live_orders_armed:
             inactive_reason = "readiness_unmet"
         elif status.get("startup_degraded"):
             inactive_reason = "degraded_startup"
@@ -8838,9 +8854,9 @@ def _health_check(ctx: BotContext) -> None:
                 "market_state": state.value if hasattr(state, "value") else str(state),
                 "reason": inactive_reason,
                 "startup_age_s": round(startup_age_s, 2),
-                "effective_mode": ctx.effective_mode,
-                "trading_ready": ctx.trading_ready,
-                "live_orders_armed": ctx.live_orders_armed,
+                "effective_mode": effective_mode,
+                "trading_ready": trading_ready,
+                "live_orders_armed": live_orders_armed,
             },
         )
 

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -1381,7 +1381,14 @@ class MarketDataManager:
     def request_token_subscriptions(self, tokens: Iterable[int]) -> int:
         """Record token subscription intents. Args: tokens. Returns: number of newly added tokens. Raises: none."""
 
-        normalized = {int(token) for token in tokens if int(token) > 0}
+        normalized: set[int] = set()
+        for token in tokens:
+            try:
+                token_int = int(token)
+            except Exception:
+                continue
+            if token_int > 0:
+                normalized.add(token_int)
         if not normalized:
             return 0
         with self._lock:
@@ -1394,7 +1401,14 @@ class MarketDataManager:
     def request_token_unsubscriptions(self, tokens: Iterable[int]) -> int:
         """Record token removal intents. Args: tokens. Returns: number of removed tokens. Raises: none."""
 
-        normalized = {int(token) for token in tokens if int(token) > 0}
+        normalized: set[int] = set()
+        for token in tokens:
+            try:
+                token_int = int(token)
+            except Exception:
+                continue
+            if token_int > 0:
+                normalized.add(token_int)
         if not normalized:
             return 0
         with self._lock:

--- a/tests/core/test_app_health.py
+++ b/tests/core/test_app_health.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -50,3 +51,56 @@ async def test_stop_handles_failed_health_task() -> None:
         app_module.shutdown_sequence = original
 
     assert app._health_task is None
+
+
+def test_bot_context_declares_effective_mode_and_started_mono() -> None:
+    source = Path('src/nifty_scalper_bot/core/app.py').read_text(encoding='utf-8')
+    assert 'effective_mode: str = "SHADOW"' in source
+    assert 'started_mono: float = field(default_factory=time_module.monotonic)' in source
+
+
+def test_health_check_uses_time_module_monotonic_not_datetime_time(monkeypatch, caplog) -> None:
+    calls: list[str] = []
+
+    def _mono() -> float:
+        calls.append('mono')
+        return 1000.0
+
+    ctx = SimpleNamespace(
+        strategy_runner=_Runner(),
+        settings=SimpleNamespace(enable_live=True),
+        shadow_mode_enabled=False,
+        readiness_mode='DATA_WARMUP',
+        effective_mode='DATA_WARMUP',
+        trading_ready=False,
+        live_orders_armed=False,
+        started_mono=999.0,
+    )
+    monkeypatch.setattr(app_module, 'get_market_state', lambda: app_module.MarketState.OPEN)
+    monkeypatch.setattr(app_module.time_module, 'monotonic', _mono)
+
+    caplog.set_level('INFO')
+    app_module._health_check(ctx)
+
+    assert calls == ['mono']
+    assert any('data_warmup' in rec.message for rec in caplog.records)
+
+
+def test_health_check_market_closed_reason(monkeypatch, caplog) -> None:
+    ctx = SimpleNamespace(
+        strategy_runner=_Runner(),
+        settings=SimpleNamespace(enable_live=True),
+        shadow_mode_enabled=False,
+        readiness_mode='LIVE',
+        effective_mode='LIVE',
+        trading_ready=True,
+        live_orders_armed=True,
+        started_mono=10.0,
+    )
+    monkeypatch.setattr(app_module, 'get_market_state', lambda: app_module.MarketState.CLOSED)
+    monkeypatch.setattr(app_module.time_module, 'monotonic', lambda: 200.0)
+
+    caplog.set_level('INFO')
+    app_module._health_check(ctx)
+
+    assert any('market_closed' in rec.message for rec in caplog.records)

--- a/tests/data/test_market_data_manager_subscriptions.py
+++ b/tests/data/test_market_data_manager_subscriptions.py
@@ -350,3 +350,13 @@ def test_spot_ws_health_logs_stale_only_after_first_tick(monkeypatch, caplog) ->
         mdm._monitor_spot_ws_health()  # noqa: SLF001
 
     assert 'MDM_WS_TICK_STALE' in caplog.text
+
+
+def test_request_token_subscriptions_ignores_invalid_tokens() -> None:
+    ws = DummyWebSocket()
+    mdm = MarketDataManager(DummyBroker(), ws, resolver=DummyResolver())
+
+    added = mdm.request_token_subscriptions([101, 'bad', None, -1, 0, 202])  # type: ignore[list-item]
+
+    assert added == 2
+    assert ws.calls == [[101, 202]]


### PR DESCRIPTION
### Motivation
- Resolve a production crash where `datetime.time` was shadowing the stdlib `time` module and `time.monotonic()` calls raised `type object 'datetime.time' has no attribute 'monotonic'`.
- Make Bot runtime state deterministic by declaring missing `BotContext` fields used by health/readiness logic to avoid attribute errors at runtime.
- Prevent token subscription crashes caused by invalid/non-integer token values in batch requests.

### Description
- Replaced health/startup monotonic timing calls in `core/app.py` to use the imported `time_module.monotonic()` and rewrote the startup-age calculation to use `now_mono` / a safe `started_mono` fallback via `getattr`.
- Added `effective_mode: str = "SHADOW"` and `started_mono: float = field(default_factory=time_module.monotonic)` to the `BotContext` dataclass and kept `readiness_mode` and `effective_mode` synchronized at startup and on readiness transitions.
- Hardened `_health_check()` to derive `effective_mode`, `trading_ready`, and `live_orders_armed` using `getattr(...)` and to compute inactive reasons (`data_warmup`, `market_closed`, `startup_grace`, etc.) without raising.
- Replaced the risky set comprehension in `data/market_data_manager.py` for `request_token_subscriptions` and `request_token_unsubscriptions` with a guarded parsing loop that ignores invalid tokens while preserving the reconciliation and `ws.set_tokens` behavior; tests for subscription idempotency and reconciliation remain intact.
- Added/updated unit tests validating: BotContext field presence, that `_health_check()` uses `time_module.monotonic()`, that `data_warmup` and `market_closed` reasons are logged, and that invalid tokens are ignored while valid tokens are reconciled.

### Testing
- Ran `python -m compileall src` and it completed successfully.
- Ran `pytest -q tests/core/test_app_health.py tests/data/test_market_data_manager_subscriptions.py` and both test files passed (dot output shows success).
- Ran full `pytest -q` which surfaced a pre-existing unrelated test import error: `ImportError: cannot import name 'InstrumentResolver' from 'nifty_scalper_bot.data'` in `tests/data/test_instrument_resolver.py`, which is outside the scope of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2b85120048324b6ecfd89db07e9af)