### PR TITLE
Fix spot freshness and deferred basket startup

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -1712,6 +1712,8 @@ class BotContext:
     # must reuse this rather than rebuild with their own (potentially
     # synthetic) spot price.
     active_trading_universe: dict[str, Any] | None = None
+    deferred_basket_retry_started: bool = False
+    deferred_basket_retry_task: asyncio.Task[Any] | None = None
 
     def update_spot_price(
         self, underlying: str, price: float, max_size: int = 100
@@ -6051,19 +6053,19 @@ def _schedule_deferred_basket_retry(ctx: BotContext, *, configured_mode: str) ->
     ctx.readiness_mode = "DATA_WARMUP"
     ctx.effective_mode = ctx.readiness_mode
     ctx.live_block_reason = "fresh_ws_spot_unavailable"
-    if not getattr(ctx, "_deferred_basket_retry_started", False):
-        ctx._deferred_basket_retry_started = True
-        ctx._deferred_basket_retry_task = asyncio.create_task(
+    if not getattr(ctx, "deferred_basket_retry_started", False):
+        ctx.deferred_basket_retry_started = True
+        ctx.deferred_basket_retry_task = asyncio.create_task(
             _deferred_basket_hydration_retry(
                 ctx,
                 configured_mode=configured_mode,
             )
         )
     LOGGER.info(
-        "STARTUP_BASKET_DEFERRED reason=fresh_ws_spot_unavailable",
+        "BASKET_BUILD_DEFERRED reason=market_closed_or_spot_not_ready",
         extra={
-            "event": "STARTUP_BASKET_DEFERRED",
-            "reason": "fresh_ws_spot_unavailable",
+            "event": "BASKET_BUILD_DEFERRED",
+            "reason": "market_closed_or_spot_not_ready",
         },
     )
 
@@ -6533,23 +6535,34 @@ async def startup_sequence(ctx: BotContext) -> None:
                     configured_mode=configured_mode,
                 )
             except RuntimeError as _basket_spot_exc:
-                LOGGER.error(
-                    "LIVE_STARTUP_SPOT_UNAVAILABLE reason=%s phase=basket",
-                    _basket_spot_exc,
-                    extra={
-                        "event": "LIVE_STARTUP_SPOT_UNAVAILABLE",
-                        "reason": str(_basket_spot_exc),
-                        "phase": "basket",
-                    },
-                )
-                LOGGER.error(
-                    "STARTUP_NO_FAKE_SPOT_LIVE_MODE reason=%s",
-                    "fresh_spot_tick_unavailable",
-                    extra={
-                        "event": "STARTUP_NO_FAKE_SPOT_LIVE_MODE",
-                        "reason": "fresh_spot_tick_unavailable",
-                    },
-                )
+                market_state = get_market_state()
+                if market_state == MarketState.OPEN:
+                    LOGGER.error(
+                        "LIVE_STARTUP_SPOT_UNAVAILABLE reason=%s phase=basket",
+                        _basket_spot_exc,
+                        extra={
+                            "event": "LIVE_STARTUP_SPOT_UNAVAILABLE",
+                            "reason": str(_basket_spot_exc),
+                            "phase": "basket",
+                        },
+                    )
+                    LOGGER.error(
+                        "STARTUP_NO_FAKE_SPOT_LIVE_MODE reason=%s",
+                        "fresh_spot_tick_unavailable",
+                        extra={
+                            "event": "STARTUP_NO_FAKE_SPOT_LIVE_MODE",
+                            "reason": "fresh_spot_tick_unavailable",
+                        },
+                    )
+                else:
+                    LOGGER.info(
+                        "BASKET_BUILD_DEFERRED reason=market_closed_or_spot_not_ready",
+                        extra={
+                            "event": "BASKET_BUILD_DEFERRED",
+                            "reason": "market_closed_or_spot_not_ready",
+                            "market_state": market_state.value,
+                        },
+                    )
                 _schedule_deferred_basket_retry(
                     ctx,
                     configured_mode=configured_mode,

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -3241,8 +3241,8 @@ class MarketDataManager:
             self._last_readiness_state = dict(readiness_state)
             valid_symbols = [s for s, count in bars.items() if count >= min_bars]
             spot_symbol = str(requirements.get("spot") or "NSE:NIFTY")
-            spot_age_ms = self.symbol_data_age_ms(spot_symbol) if spot_symbol else -1
-            threshold_ms = int(getattr(self, "_tick_stale_threshold_ms", 120000))
+            spot_age_ms = self.symbol_data_age_ms_or_none(spot_symbol)
+            threshold_ms = 120000
             spot_fresh = spot_age_ms is not None and 0 <= int(spot_age_ms) <= threshold_ms
             if readiness_state["spot_ready"] and spot_fresh and not self._spot_ready_logged:
                 spot_source = str(self._last_tick_source.get(spot_symbol, "unknown"))
@@ -3264,17 +3264,18 @@ class MarketDataManager:
                     },
                 )
             elif not (readiness_state["spot_ready"] and spot_fresh):
+                reason = "no_tick_received" if spot_age_ms is None else "stale_tick"
                 log_throttled(
                     self._logger,
                     "spot_not_ready_state",
-                    "SPOT_NOT_READY symbol=%s reason=stale_or_missing_tick age_ms=%s threshold_ms=%s"
-                    % (spot_symbol, spot_age_ms, threshold_ms),
+                    "SPOT_NOT_READY symbol=%s reason=%s age_ms=%s threshold_ms=%s"
+                    % (spot_symbol, reason, spot_age_ms, threshold_ms),
                     interval_sec=30.0,
                     level=logging.INFO,
                     extra={
                         "event": "SPOT_NOT_READY",
                         "symbol": spot_symbol,
-                        "reason": "stale_or_missing_tick",
+                        "reason": reason,
                         "age_ms": spot_age_ms,
                         "threshold_ms": threshold_ms,
                     },
@@ -4067,21 +4068,30 @@ class MarketDataManager:
         freshest = max(candidates)
         return int(max(0.0, (now - freshest) * 1000.0))
 
-    def symbol_data_age_ms(self, symbol: str | int) -> int:
-        """Return age in milliseconds for one symbol/token. Args: symbol/token. Returns: age ms. Raises: none."""
 
-        resolved_symbol: str | None = None
+    def _resolve_symbol_key_safe(self, symbol: str | int) -> str | None:
+        """Resolve symbol/token aliases to canonical symbol. Args: symbol. Returns: canonical or None. Raises: none."""
+
         try:
             if isinstance(symbol, int):
                 with self._lock:
-                    resolved_symbol = self._symbol_by_token.get(int(symbol))
-            elif str(symbol).strip().isdigit():
+                    resolved = self._symbol_by_token.get(int(symbol))
+                return self._canonical_symbol(resolved) if resolved else None
+            raw = str(symbol).strip()
+            if not raw:
+                return None
+            if raw.isdigit():
                 with self._lock:
-                    resolved_symbol = self._symbol_by_token.get(int(str(symbol).strip()))
-            else:
-                resolved_symbol = self._canonical_symbol(str(symbol))
+                    resolved = self._symbol_by_token.get(int(raw))
+                return self._canonical_symbol(resolved) if resolved else None
+            return self._canonical_symbol(raw)
         except Exception:
-            resolved_symbol = None
+            return None
+
+    def symbol_data_age_ms(self, symbol: str | int) -> int:
+        """Return age in milliseconds for one symbol/token. Args: symbol/token. Returns: age ms. Raises: none."""
+
+        resolved_symbol = self._resolve_symbol_key_safe(symbol)
         if not resolved_symbol:
             return 1_000_000_000
         now = time.time()
@@ -4096,18 +4106,7 @@ class MarketDataManager:
     def symbol_data_age_ms_or_none(self, symbol: str | int) -> int | None:
         """Return age in milliseconds or None when no tick exists. Args: symbol/token. Returns: age ms or none. Raises: none."""
 
-        resolved_symbol: str | None = None
-        try:
-            if isinstance(symbol, int):
-                with self._lock:
-                    resolved_symbol = self._symbol_by_token.get(int(symbol))
-            elif str(symbol).strip().isdigit():
-                with self._lock:
-                    resolved_symbol = self._symbol_by_token.get(int(str(symbol).strip()))
-            else:
-                resolved_symbol = self._canonical_symbol(str(symbol))
-        except Exception:
-            resolved_symbol = None
+        resolved_symbol = self._resolve_symbol_key_safe(symbol)
         if not resolved_symbol:
             return None
         now = time.time()
@@ -4122,18 +4121,7 @@ class MarketDataManager:
     def symbol_has_tick(self, symbol: str | int) -> bool:
         """Return whether at least one tick exists for symbol/token. Args: symbol/token. Returns: bool. Raises: none."""
 
-        resolved_symbol: str | None = None
-        try:
-            if isinstance(symbol, int):
-                with self._lock:
-                    resolved_symbol = self._symbol_by_token.get(int(symbol))
-            elif str(symbol).strip().isdigit():
-                with self._lock:
-                    resolved_symbol = self._symbol_by_token.get(int(str(symbol).strip()))
-            else:
-                resolved_symbol = self._canonical_symbol(str(symbol))
-        except Exception:
-            resolved_symbol = None
+        resolved_symbol = self._resolve_symbol_key_safe(symbol)
 
         if not resolved_symbol:
             return False
@@ -4317,10 +4305,19 @@ class MarketDataManager:
         symbol = self._canonical_symbol(symbol)
 
         cached_tick = dict(tick)
+        token_value = cached_tick.get("instrument_token") or cached_tick.get("token")
+        token_int = int(token_value) if token_value is not None else None
+        now_wall = time.time()
+        exchange_ts = self._tick_wallclock(cached_tick) or now_wall
         with self._lock:
+            if token_int is not None:
+                self._symbol_by_token[token_int] = symbol
+                self._token_to_symbol[token_int] = symbol
+                self._symbol_to_token[symbol] = token_int
+                self._token_by_symbol[symbol] = token_int
             self._latest_ticks[symbol] = cached_tick
             self._tick_cache[symbol] = cached_tick
-            self._last_tick_time[symbol] = float(wallclock)
+            self._last_tick_time[symbol] = float(exchange_ts)
             if "ltp" not in cached_tick or cached_tick.get("timestamp") is None:
                 self._logger.debug(
                     "Condition met: mdm_history_append_rejected",
@@ -4330,7 +4327,7 @@ class MarketDataManager:
             self._history[symbol].append(cached_tick)
             self._ticks_received_per_symbol[symbol] += 1
             self._symbols_with_tick.add(symbol)
-            self._last_tick_wallclock[symbol] = float(wallclock)
+            self._last_tick_wallclock[symbol] = float(now_wall)
             self._last_quote_ts_ms[symbol] = self._now_ms()
         staleness_seconds = 0.0
         try:
@@ -4366,6 +4363,12 @@ class MarketDataManager:
                 last_logged = float(self._ws_stored_tick_log_at.get(symbol, 0.0))
                 if last_logged <= 0.0 or (now - last_logged) >= 60.0:
                     self._ws_stored_tick_log_at[symbol] = now
+                    self._logger.info(
+                        "MDM_TICK_CACHE_UPDATED symbol=%s token=%s source=ws",
+                        symbol,
+                        token_int,
+                        extra={"event": "MDM_TICK_CACHE_UPDATED", "symbol": symbol, "token": token_int, "source": "ws"},
+                    )
                     self._logger.info(
                         "WS_TICK_STORED symbol=%s token=%s ltp=%s source=ws age_ms=0",
                         symbol,

--- a/tests/core/test_app_deferred_retry.py
+++ b/tests/core/test_app_deferred_retry.py
@@ -32,9 +32,9 @@ async def test_deferred_basket_retry_scheduled_on_spot_unavailable(
     assert ctx.trading_ready is False
     assert ctx.readiness_mode == "DATA_WARMUP"
     assert ctx.live_block_reason == "fresh_ws_spot_unavailable"
-    assert ctx._deferred_basket_retry_started is True  # noqa: SLF001
-    assert isinstance(ctx._deferred_basket_retry_task, asyncio.Task)  # noqa: SLF001
-    await ctx._deferred_basket_retry_task  # noqa: SLF001
+    assert ctx.deferred_basket_retry_started is True  # noqa: SLF001
+    assert isinstance(ctx.deferred_basket_retry_task, asyncio.Task)  # noqa: SLF001
+    await ctx.deferred_basket_retry_task  # noqa: SLF001
 
 
 @pytest.mark.asyncio

--- a/tests/streaming/test_websocket_spot_symbol_freshness.py
+++ b/tests/streaming/test_websocket_spot_symbol_freshness.py
@@ -46,3 +46,24 @@ def test_spot_alias_resolves_to_same_canonical_symbol_age() -> None:
 
     assert alias_age >= 0
     assert abs(canonical_age - alias_age) < 100
+
+
+def test_spot_aliases_and_snapshot_for_token_lookup() -> None:
+    manager = MarketDataManager(DummyBroker(), DummyWebSocket())
+    ltp = 24177.65
+    manager._process_queued_tick(
+        {
+            'instrument_token': 256265,
+            'last_price': ltp,
+            'timestamp': time.time(),
+        }
+    )
+
+    assert manager.symbol_has_tick('NSE:NIFTY') is True
+    assert manager.symbol_has_tick(256265) is True
+    assert manager.symbol_has_tick('NIFTY') is True
+    assert manager.symbol_data_age_ms_or_none('NSE:NIFTY') is not None
+    assert manager.symbol_data_age_ms_or_none(256265) is not None
+    snap = manager.get_symbol_snapshot('NSE:NIFTY')
+    assert snap.ltp == ltp
+


### PR DESCRIPTION
### Motivation
- Startup logs showed WS NIFTY ticks being received but readiness/basket code still reported missing/stale spot and threw a missing BotContext field error.  This broke safe basket hydration and produced noisy hard-errors during off-market startup. 
- Root causes: missing declared deferred-retry state on `BotContext`, non-canonical symbol/token resolution in `MarketDataManager` freshness paths, and WS tick storage not consistently updating canonical token↔symbol mappings.
- Change intent: ensure WS ticks update the canonical MDM caches, make freshness/alias lookups canonical and robust, and defer basket building gracefully when market is closed without touching order/execution logic.

### Description
- Added declared fields to `BotContext` for deferred retry state: `deferred_basket_retry_started: bool = False` and `deferred_basket_retry_task: asyncio.Task[Any] | None = None`, and switched scheduler to use these non-private names to avoid AttributeError. (`src/nifty_scalper_bot/core/app.py`)
- Made startup basket handling market-session aware so hard `LIVE_STARTUP_SPOT_UNAVAILABLE` / `STARTUP_NO_FAKE_SPOT_LIVE_MODE` errors are only emitted when the market is open; off-market cases log `BASKET_BUILD_DEFERRED reason=market_closed_or_spot_not_ready`. (`src/nifty_scalper_bot/core/app.py`)
- Introduced `_resolve_symbol_key_safe` and routed `symbol_data_age_ms`, `symbol_data_age_ms_or_none`, and `symbol_has_tick` through it so integers, numeric-strings, and alias names resolve to the same canonical symbol. (`src/nifty_scalper_bot/data/market_data_manager.py`)
- Ensured `_store_tick` enforces canonical key and updates token↔symbol mappings and freshness maps atomically, and added a `MDM_TICK_CACHE_UPDATED` WS log when a cached WS tick updates canonical state. (`src/nifty_scalper_bot/data/market_data_manager.py`)
- Split `SPOT_NOT_READY` reasoning into explicit `no_tick_received` vs `stale_tick` and moved the spot freshness threshold to 120000 ms in the readiness loop. (`src/nifty_scalper_bot/data/market_data_manager.py`)
- Tests updated/extended to cover deferred-retry field usage and canonical spot-token aliasing and snapshot freshness. (`tests/core/test_app_deferred_retry.py`, `tests/streaming/test_websocket_spot_symbol_freshness.py`)

### Testing
- Ran `python -m compileall src` and it completed successfully. (pass)
- Ran targeted unit tests: `pytest -q tests/core/test_app_deferred_retry.py tests/streaming/test_websocket_spot_symbol_freshness.py` and they passed. (pass)
- Ran full test suite with `pytest -q`; this run failed due to an unrelated pre-existing test import error in `tests/data/test_instrument_resolver.py` (`ImportError: cannot import name 'InstrumentResolver' from 'nifty_scalper_bot.data'`), so full-suite validation is blocked by that separate issue. (partial)
- Performed quick grep/verification to ensure old private attribute usage was removed and new readiness/freshness paths are present (checked presence of `deferred_basket_retry_started`, `symbol_data_age_ms_or_none` and `SPOT_NOT_READY` reason changes). (pass)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2bfc8c2d48324b7b903fb22d815b0)