### PR TITLE
fix: harden tick consumer startup and preserve runner execution state

### DIFF
--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -274,6 +274,7 @@ class MarketDataManager:
         )
         self._ltp_stale_warn_last: dict[str, float] = {}
         self._spot_ws_first_tick_seen = False
+        self._spot_ws_first_tick_seen_logged = False
         self._last_spot_resubscribe_attempt = 0.0
         self._last_spot_stale_log = 0.0
         self._pending_subscription_tokens: set[int] = set()
@@ -865,8 +866,7 @@ class MarketDataManager:
         self._initialize_instruments()
         if not defer_ws:
             self.start_websocket()
-        if self._main_loop is not None and self._tick_consumer_task is None:
-            self._tick_consumer_task = self._main_loop.create_task(self._consume_ticks())
+        self._ensure_tick_consumer(reason="mdm_start")
         self._start_health_monitor()
         if self._rest_poll_enabled:
             self._start_rest_poll()
@@ -3858,27 +3858,45 @@ class MarketDataManager:
                 return
 
             self._main_loop = loop
-
-            def _ensure_consumer() -> None:
-                task = getattr(self, "_tick_consumer_task", None)
-                if task is None or task.done():
-                    self._tick_consumer_task = loop.create_task(self._consume_ticks())
-                    self._logger.info(
-                        "MDM_TICK_CONSUMER_STARTED reason=event_loop_wired",
-                        extra={"event": "MDM_TICK_CONSUMER_STARTED", "reason": "event_loop_wired"},
-                    )
-
-            if loop.is_running():
-                if threading.current_thread() is threading.main_thread():
-                    _ensure_consumer()
-                else:
-                    loop.call_soon_threadsafe(_ensure_consumer)
+            self._ensure_tick_consumer(reason="event_loop_wired")
         except Exception as e:
             self._logger.error(
                 "Failure in MarketDataManager.set_event_loop: %s",
                 e,
                 exc_info=True,
             )
+
+    def _ensure_tick_consumer(self, reason: str) -> None:
+        """Start the async tick consumer exactly once on the owning loop thread."""
+        loop = self._main_loop
+        if loop is None:
+            return
+
+        def _start() -> None:
+            task = getattr(self, "_tick_consumer_task", None)
+            if task is None or task.done():
+                self._tick_consumer_task = loop.create_task(self._consume_ticks())
+                self._logger.info(
+                    "MDM_TICK_CONSUMER_STARTED reason=%s",
+                    reason,
+                    extra={
+                        "event": "MDM_TICK_CONSUMER_STARTED",
+                        "reason": reason,
+                    },
+                )
+
+        if not loop.is_running():
+            return
+
+        try:
+            running_loop = asyncio.get_running_loop()
+        except RuntimeError:
+            running_loop = None
+
+        if running_loop is loop:
+            _start()
+        else:
+            loop.call_soon_threadsafe(_start)
 
     async def push_tick(self, raw_tick: dict[str, Any]) -> None:
         """Queue one raw websocket tick for deterministic consumption."""
@@ -4024,6 +4042,20 @@ class MarketDataManager:
                     self._last_tick_wallclock["NSE:NIFTY"] = now
                     self._last_tick_source["NSE:NIFTY"] = "ws"
                     self._symbols_with_tick.add("NSE:NIFTY")
+                    if not getattr(self, "_spot_ws_first_tick_seen_logged", False):
+                        self._spot_ws_first_tick_seen_logged = True
+                        self._logger.info(
+                            "MDM_WS_FIRST_TICK symbol=NSE:NIFTY token=%s ltp=%s",
+                            token,
+                            price,
+                            extra={
+                                "event": "MDM_WS_FIRST_TICK",
+                                "symbol": "NSE:NIFTY",
+                                "token": token,
+                                "ltp": price,
+                                "source": "ws_fast_cache",
+                            },
+                        )
         except Exception as e:
             self._logger.error("Failure in MarketDataManager._record_ws_arrival_fast: %s", e)
 
@@ -4308,9 +4340,22 @@ class MarketDataManager:
         # but NEVER called from the WS path — _store_tick only cached the tick.
         # _emit_tick is the correct call; it was defined but never invoked.
         tick_dict = tick.to_dict()
-        # ensure ltp field is present so downstream DataHub/Runner can read price
-        if "ltp" not in tick_dict:
-            tick_dict["ltp"] = tick.ltp
+        token_value = raw.get("instrument_token") or raw.get("token")
+        if token_value is not None:
+            tick_dict["instrument_token"] = token_value
+        price_value = raw.get("last_price") or raw.get("ltp") or tick.ltp
+        tick_dict["last_price"] = price_value
+        tick_dict["ltp"] = tick.ltp
+        tick_dict["source"] = "ws"
+        tick_dict["received_at"] = raw.get("received_at", time.time())
+        if raw.get("exchange_timestamp") is not None:
+            tick_dict["exchange_timestamp"] = raw.get("exchange_timestamp")
+        if raw.get("volume_traded") is not None:
+            tick_dict["volume_traded"] = raw.get("volume_traded")
+        if raw.get("volume_traded_today") is not None:
+            tick_dict["volume_traded_today"] = raw.get("volume_traded_today")
+        if raw.get("oi") is not None:
+            tick_dict["oi"] = raw.get("oi")
 
         # Structured Logging for tick received (Objective 6)
         self._logger.debug(

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -871,7 +871,18 @@ class StrategyRunner:
                 self._runner_state = RunnerState.STARTING
                 self._running = False
                 return
-            self._runner_state = RunnerState.HISTORICAL_READY
+            if self._runner_state != RunnerState.EXECUTION_ENABLED:
+                self._runner_state = RunnerState.HISTORICAL_READY
+            else:
+                self._logger.info(
+                    "STRATEGY_RUNNER_STATE_PRESERVED state=%s reason=start_after_mark_ready",
+                    self._runner_state,
+                    extra={
+                        "event": "STRATEGY_RUNNER_STATE_PRESERVED",
+                        "state": str(self._runner_state),
+                        "reason": "start_after_mark_ready",
+                    },
+                )
             if self._order_manager and hasattr(self._order_manager, "get_kill_switch_status"):
                 try:
                     ks = self._order_manager.get_kill_switch_status()
@@ -896,11 +907,21 @@ class StrategyRunner:
             # _set_symbol_hydration_state() saves symbol states from regressing,
             # but _history_ready_by_symbol is wiped here explicitly and only
             # recovered on the first tick — making the debug log misleading.
-            if self._runner_state != RunnerState.EXECUTION_ENABLED:
+            preserve_execution_state = self._runner_state == RunnerState.EXECUTION_ENABLED
+            if not preserve_execution_state:
                 self._vwap_state = {}
                 self._symbol_bar_count = {}
                 self._hydration_ready_streak = {}
                 self._history_ready_by_symbol = {symbol: False for symbol in symbols}
+            else:
+                self._logger.info(
+                    "STRATEGY_WARMUP_STATE_PRESERVED symbols=%d",
+                    len(symbols),
+                    extra={
+                        "event": "STRATEGY_WARMUP_STATE_PRESERVED",
+                        "symbol_count": len(symbols),
+                    },
+                )
             # Always reset per-session rate limits (independent of warmup state).
 
         # Capture the loop if called from async context (optional safety)

--- a/tests/test_mdm_event_loop_consumer.py
+++ b/tests/test_mdm_event_loop_consumer.py
@@ -7,9 +7,9 @@ import time
 from nifty_scalper_bot.data.market_data_manager import MarketDataManager
 
 
-def test_set_event_loop_starts_consumer_after_start() -> None:
+def test_set_event_loop_starts_consumer_after_started_flag() -> None:
     mdm = MarketDataManager(broker=None, websocket=None, settings={})
-    mdm.start()
+    mdm._started = True
 
     loop = asyncio.new_event_loop()
 
@@ -22,10 +22,14 @@ def test_set_event_loop_starts_consumer_after_start() -> None:
     try:
         time.sleep(0.05)
         mdm.set_event_loop(loop)
-        time.sleep(0.1)
+        time.sleep(0.2)
         task = getattr(mdm, '_tick_consumer_task', None)
         assert task is not None
         assert not task.done()
     finally:
+        task = getattr(mdm, '_tick_consumer_task', None)
+        if task is not None:
+            loop.call_soon_threadsafe(task.cancel)
         loop.call_soon_threadsafe(loop.stop)
         thread.join(timeout=1.0)
+        loop.close()

--- a/tests/test_mdm_ws_token_preservation.py
+++ b/tests/test_mdm_ws_token_preservation.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from nifty_scalper_bot.data.market_data_manager import MarketDataManager
+
+
+def test_ws_tick_preserves_token_after_queue_processing() -> None:
+    mdm = MarketDataManager(broker=None, websocket=None, settings={})
+    mdm.register_symbol('NSE:NIFTY', 256265)
+
+    mdm._process_queued_tick(
+        {
+            'instrument_token': 256265,
+            'symbol': 'NSE:NIFTY',
+            'last_price': 24078.45,
+        }
+    )
+
+    tick = mdm.get_latest_tick('NSE:NIFTY')
+    assert tick is not None
+    assert tick.get('instrument_token') == 256265
+    assert tick.get('source') == 'ws'
+    assert tick.get('last_price') == 24078.45
+    assert mdm.get_cached_ltp('NSE:NIFTY', require_ws=True) == 24078.45
+    assert 256265 in mdm._confirmed_subscriptions or mdm._spot_ws_first_tick_seen

--- a/tests/test_runner_start_preserves_execution_state.py
+++ b/tests/test_runner_start_preserves_execution_state.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from nifty_scalper_bot.strategies.runner import RunnerState, StrategyRunner
+
+
+class StubRiskManager:
+    def suggest_position_size(self, **kwargs) -> int:
+        return int(kwargs.get('requested_quantity', 0))
+
+    def validate_new_position(self, **kwargs):
+        return True, None
+
+    def validate_close_position(self, **kwargs):
+        return True, None
+
+
+class StubStrategyManager:
+    pass
+
+
+class StubIndicatorEngine:
+    pass
+
+
+class StubMarketDataManager:
+    pass
+
+
+def _build_runner() -> StrategyRunner:
+    return StrategyRunner(
+        market_data_manager=StubMarketDataManager(),
+        indicator_engine=StubIndicatorEngine(),
+        strategy_manager=StubStrategyManager(),
+        risk_manager=StubRiskManager(),
+        order_manager=None,
+        position_manager=None,
+    )
+
+
+def test_runner_start_preserves_execution_enabled_state_and_warmup() -> None:
+    runner = _build_runner()
+    runner._active_symbols = {'NSE:NIFTY'}
+    runner._runner_state = RunnerState.EXECUTION_ENABLED
+    runner.ready = True
+    runner._vwap_state = {'NSE:NIFTY': {'vwap': 123.45}}
+    runner._symbol_bar_count = {'NSE:NIFTY': 42}
+    runner._hydration_ready_streak = {'NSE:NIFTY': 5}
+    runner._history_ready_by_symbol = {'NSE:NIFTY': True}
+
+    runner.start()
+
+    assert runner._runner_state == RunnerState.EXECUTION_ENABLED
+    assert runner._vwap_state == {'NSE:NIFTY': {'vwap': 123.45}}
+    assert runner._symbol_bar_count == {'NSE:NIFTY': 42}
+    assert runner._hydration_ready_streak == {'NSE:NIFTY': 5}
+    assert runner._history_ready_by_symbol == {'NSE:NIFTY': True}


### PR DESCRIPTION
### Motivation
- Prevent unsafe cross-thread asyncio task creation that started the MDM tick consumer from the wrong thread and caused races during startup.
- Ensure websocket raw tick metadata (instrument token / source / last_price / timestamps) is preserved so first-tick confirmation and pending-subscription cleanup work correctly.
- Stop unconditional downgrade of `StrategyRunner` from `EXECUTION_ENABLED` to `HISTORICAL_READY` which wiped warmup state and blocked Phase 6 evaluation.
- Make unit tests deterministic and avoid full `mdm.start()` in tests that do not mock broker/instrument loading.

### Description
- Added `MarketDataManager._ensure_tick_consumer(reason: str)` which idempotently starts `_consume_ticks()` only on the owning asyncio loop thread, using `asyncio.get_running_loop()` to determine safe creation context. (file: `src/nifty_scalper_bot/data/market_data_manager.py`)
- Rewired `MarketDataManager.set_event_loop()` and `MarketDataManager.start()` to call `_ensure_tick_consumer(...)` and removed direct cross-thread `loop.create_task(...)` calls. (file: `src/nifty_scalper_bot/data/market_data_manager.py`)
- Preserved raw WS metadata after `validate_tick()` in `_process_queued_tick()` by injecting `instrument_token`, `last_price`, `ltp`, `source`, `received_at`, and optional exchange/volume/oi fields into the emitted tick dict prior to `_emit_tick()`. (file: `src/nifty_scalper_bot/data/market_data_manager.py`)
- Added throttled canonical NIFTY first-tick confirmation logging in `_record_ws_arrival_fast()` and initialized `_spot_ws_first_tick_seen_logged` in `__init__` so first WS arrival is visible even before the async queue drains. (file: `src/nifty_scalper_bot/data/market_data_manager.py`)
- Fixed `StrategyRunner.start()` to avoid downgrading `RunnerState.EXECUTION_ENABLED` to `HISTORICAL_READY` and to preserve warmup/hydration dictionaries when execution is already enabled, emitting preservation logs when appropriate. (file: `src/nifty_scalper_bot/strategies/runner.py`)
- Updated tests to be safer and focused: replaced the event-loop consumer test so it does not call `mdm.start()`, and added two regression tests: one for WS token preservation and one for runner start state/warmup preservation. (files: `tests/test_mdm_event_loop_consumer.py`, `tests/test_mdm_ws_token_preservation.py`, `tests/test_runner_start_preserves_execution_state.py`)

### Testing
- Ran `python -m compileall src` and compilation completed successfully.
- Ran focused pytest suite and all targeted tests passed: `tests/test_market_data_manager_spot_readiness.py`, `tests/test_mdm_event_loop_consumer.py`, `tests/test_mdm_ws_token_preservation.py`, `tests/test_runner_start_preserves_execution_state.py`, and `tests/test_health_check_paper_mode.py` (all succeeded).
- No unrelated tests were modified and changes are low-risk and surgical to address the documented race/state bugs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f34cb7b1fc832484b32772b61f3790)