### PR TITLE
fix: harden queued tick processing and remove invalid tick token access

### DIFF
--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -3954,6 +3954,10 @@ class MarketDataManager:
 
     def _ensure_tick_worker(self) -> None:
         """Start the fallback drain thread once, on first need."""
+        # TODO: fallback worker currently uses asyncio.Queue from a worker thread.
+        # Runtime path normally uses run_coroutine_threadsafe() onto _main_loop.
+        # If fallback becomes production-critical, replace with queue.Queue for
+        # cross-thread safety.
         t = self._tick_worker_thread
         if t is not None and t.is_alive():
             return
@@ -4247,15 +4251,6 @@ class MarketDataManager:
                 return True
         return False
 
-        with self._lock:
-            if resolved_symbol in self._latest_ticks:
-                return True
-            if float(self._last_tick_wallclock.get(resolved_symbol, 0.0) or 0.0) > 0.0:
-                return True
-            if float(self._last_tick_time.get(resolved_symbol, 0.0) or 0.0) > 0.0:
-                return True
-        return False
-
 
     # ------------------------------------------------------------------
     # Internal plumbing
@@ -4358,16 +4353,19 @@ class MarketDataManager:
             tick_dict["oi"] = raw.get("oi")
 
         # Structured Logging for tick received (Objective 6)
-        self._logger.debug(
-            "TICK_RECEIVED",
-            extra={
-                "event": "tick_received",
-                "symbol": symbol,
-                "price": tick.ltp,
-                "source": "ws",
-                "token": tick.instrument_token,
-            },
-        )
+        try:
+            self._logger.debug(
+                "TICK_RECEIVED",
+                extra={
+                    "event": "tick_received",
+                    "symbol": symbol,
+                    "price": tick.ltp,
+                    "source": "ws",
+                    "token": token_value,
+                },
+            )
+        except Exception:
+            pass
 
         self._emit_tick(symbol, tick_dict, source="ws")
         if candle:

--- a/tests/test_no_invalid_tick_attribute.py
+++ b/tests/test_no_invalid_tick_attribute.py
@@ -1,0 +1,6 @@
+from pathlib import Path
+
+
+def test_market_data_manager_does_not_reference_missing_tick_instrument_token() -> None:
+    src = Path('src/nifty_scalper_bot/data/market_data_manager.py').read_text()
+    assert 'tick.instrument_token' not in src


### PR DESCRIPTION
### Motivation
- Prevent a runtime crash in the queued WS consumer where `_process_queued_tick()` referenced a non-existent `Tick` attribute (`tick.instrument_token`) which could abort before `_emit_tick()` and stop subscriber callbacks and candle building.
- Remove unreachable duplicate code in `symbol_has_tick()` to eliminate dead paths and preserve the NIFTY special-case handling.
- Add a small safety note about the fallback worker queue cross-thread usage to highlight a future hardening opportunity without changing architecture now.

### Description
- Replaced the invalid `tick.instrument_token` access with the already-extracted `token_value` in `MarketDataManager._process_queued_tick()` and preserved the raw token in the tick payload (`instrument_token`).
- Wrapped only the structured debug logging block in a narrow `try/except` so logging failures cannot prevent `_emit_tick()` from running, and kept `_emit_tick()` outside the logging guard.
- Removed the unreachable duplicate block at the end of `symbol_has_tick()` while keeping the NIFTY alias/token special-case logic intact.
- Added a `TODO` comment near the fallback worker startup noting that `asyncio.Queue` is used from a worker thread and suggesting `queue.Queue` if fallback becomes production-critical.
- Added a static regression test `tests/test_no_invalid_tick_attribute.py` to ensure `tick.instrument_token` is not referenced in the source and verified the existing `tests/test_mdm_ws_token_preservation.py` behavior.
- Files changed: `src/nifty_scalper_bot/data/market_data_manager.py` (fixes and TODO) and `tests/test_no_invalid_tick_attribute.py` (new test).

### Testing
- Ran compilation with `python -m compileall src` which completed successfully.
- Ran focused tests: `python -m pytest tests/test_mdm_ws_token_preservation.py -q`, `python -m pytest tests/test_mdm_event_loop_consumer.py -q`, `python -m pytest tests/test_runner_start_preserves_execution_state.py -q`, `python -m pytest tests/test_market_data_manager_spot_readiness.py -q`, `python -m pytest tests/test_health_check_paper_mode.py -q`, and `python -m pytest tests/test_no_invalid_tick_attribute.py -q`, and all commands passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3a0a3a3048324ac87e98c526a1eac)