### PR TITLE
fix: harden market data tick bus publish and timestamp normalization

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -907,10 +907,12 @@ def _sync_data_hub_positions(
         ]
         data_hub.replace_positions(rows)
     except Exception as exc:  # noqa: BLE001
-        logger.error(
+        log_throttled(
+            logger,
             "data_hub_position_sync_failed",
-            extra={"event": "data_hub_position_sync_failed", "error": str(exc)},
-            exc_info=exc,
+            "data_hub_position_sync_failed error=%r" % exc,
+            interval_sec=30.0,
+            level=logging.WARNING,
         )
 
 
@@ -8595,7 +8597,10 @@ async def startup_sequence(ctx: BotContext) -> None:
     elif live_ready:
         LOGGER.info("STARTUP_COMPLETE_LIVE_READY mode=%s runner_running=%s", mode, runner_running, extra={"event":"STARTUP_COMPLETE_LIVE_READY","mode":mode,"runner_running":runner_running})
     else:
-        LOGGER.warning("STARTUP_DEGRADED runner_running=%s data_observation_ready=%s trading_ready=%s live_orders_armed=%s", runner_running, bool(getattr(ctx, "data_observation_ready", False)), bool(getattr(ctx, "trading_ready", False)), bool(getattr(ctx, "live_orders_armed", False)), extra={"event":"STARTUP_DEGRADED","runner_running":runner_running,"data_observation_ready":bool(getattr(ctx, "data_observation_ready", False)),"trading_ready":bool(getattr(ctx, "trading_ready", False)),"live_orders_armed":bool(getattr(ctx, "live_orders_armed", False))})
+        if mode == "LIVE":
+            LOGGER.warning("STARTUP_DEGRADED runner_running=%s data_observation_ready=%s trading_ready=%s live_orders_armed=%s", runner_running, bool(getattr(ctx, "data_observation_ready", False)), bool(getattr(ctx, "trading_ready", False)), bool(getattr(ctx, "live_orders_armed", False)), extra={"event":"STARTUP_DEGRADED","runner_running":runner_running,"data_observation_ready":bool(getattr(ctx, "data_observation_ready", False)),"trading_ready":bool(getattr(ctx, "trading_ready", False)),"live_orders_armed":bool(getattr(ctx, "live_orders_armed", False))})
+        elif bool(getattr(ctx, "data_observation_ready", False)):
+            LOGGER.info("DATA_PIPELINE_OBSERVATION_READY mode=%s runner_running=%s", mode, runner_running, extra={"event":"DATA_PIPELINE_OBSERVATION_READY","mode":mode,"runner_running":runner_running})
 
 
 async def shutdown_sequence(ctx: BotContext, *, reason: str = "shutdown") -> None:

--- a/src/nifty_scalper_bot/data/data_hub.py
+++ b/src/nifty_scalper_bot/data/data_hub.py
@@ -662,7 +662,7 @@ class DataHub:
             )
 
             tick_ts = pd.to_datetime(raw_ts, utc=True, errors="coerce")
-            if pd.isna(tick_ts):
+            if pd.isna(tick_ts) or tick_ts.year < 2020:
                 tick_ts = pd.Timestamp.utcnow()
 
             now = pd.Timestamp.utcnow()

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -44,6 +44,7 @@ from nifty_scalper_bot.utils.market_hours import (
     stale_threshold_for_symbol,
 )
 from nifty_scalper_bot.utils.metrics import Counter
+from nifty_scalper_bot.utils.serialization import to_json_safe
 from nifty_scalper_bot.utils.symbols import enforce_canonical, normalize_symbol
 
 # NOTE: resolver is attached at runtime by app.py (ctx.market_data_manager._resolver).
@@ -638,7 +639,7 @@ class MarketDataManager:
                 "low": float(bar.get("low", 0.0) or 0.0),
                 "close": float(bar.get("close", 0.0) or 0.0),
                 "volume": int(float(bar.get("volume", 0) or 0)),
-                "timestamp": ts,
+                "timestamp": ts.isoformat(),
                 "source": "historical",
             }
             self._history[symbol].append(dict(payload))
@@ -4351,9 +4352,9 @@ class MarketDataManager:
         if price <= 0:
             return None
 
-        ts_raw = raw.get("timestamp") or raw.get("exchange_timestamp") or raw.get("received_at")
+        ts_raw = raw.get("exchange_timestamp") or raw.get("timestamp") or raw.get("received_at")
         ts = pd.to_datetime(ts_raw, utc=True, errors="coerce")
-        if pd.isna(ts):
+        if pd.isna(ts) or ts.year < 2020:
             ts = pd.Timestamp.utcnow()
 
         return {
@@ -4363,7 +4364,7 @@ class MarketDataManager:
             "token": token,
             "ltp": price,
             "last_price": price,
-            "timestamp": ts,
+            "timestamp": ts.isoformat(),
             "source": raw.get("source") or "ws",
             "received_at": raw.get("received_at") or time.time(),
         }
@@ -4587,6 +4588,77 @@ class MarketDataManager:
                     "event": "market_data_staleness_metric_error",
                     "symbol": symbol,
                 },
+            )
+
+    def _publish_tick_to_bus_safe(self, tick: dict[str, Any]) -> None:
+        """Publish a normalized tick to MessageBus without ever crashing MDM."""
+        bus = getattr(self, "bus", None) or getattr(self, "_tick_bus", None)
+        if bus is None:
+            log_throttled(
+                self._logger,
+                "mdm_bus_publish_skipped_no_bus",
+                "MDM_BUS_PUBLISH_SKIPPED reason=no_bus symbol=%s" % tick.get("symbol"),
+                interval_sec=30.0,
+                level=logging.DEBUG,
+            )
+            return
+        if not getattr(bus, "running", False):
+            log_throttled(
+                self._logger,
+                "mdm_bus_publish_skipped_bus_not_running",
+                "MDM_BUS_PUBLISH_SKIPPED reason=bus_not_running symbol=%s"
+                % tick.get("symbol"),
+                interval_sec=30.0,
+                level=logging.DEBUG,
+            )
+            return
+        loop = (
+            getattr(self, "_main_loop", None)
+            or getattr(self, "_event_loop", None)
+            or getattr(self, "event_loop", None)
+        )
+        if loop is None or loop.is_closed():
+            log_throttled(
+                self._logger,
+                "mdm_bus_publish_skipped_loop_unavailable",
+                "MDM_BUS_PUBLISH_SKIPPED reason=loop_unavailable symbol=%s"
+                % tick.get("symbol"),
+                interval_sec=30.0,
+                level=logging.WARNING,
+            )
+            return
+        payload = to_json_safe(dict(tick))
+        try:
+            msg = Message(
+                type=MessageType.TICK,
+                data=payload,
+                source="market_data_manager",
+                timestamp=time.time(),
+            )
+            future = asyncio.run_coroutine_threadsafe(bus.publish(msg), loop)
+
+            def _done(fut: Any) -> None:
+                try:
+                    fut.result()
+                except Exception as exc:
+                    log_throttled(
+                        self._logger,
+                        "mdm_bus_publish_failed",
+                        "MDM_BUS_PUBLISH_FAILED symbol=%s error=%r"
+                        % (tick.get("symbol"), exc),
+                        interval_sec=10.0,
+                        level=logging.ERROR,
+                    )
+
+            future.add_done_callback(_done)
+        except Exception as exc:
+            log_throttled(
+                self._logger,
+                "mdm_bus_publish_submit_failed",
+                "MDM_BUS_PUBLISH_SUBMIT_FAILED symbol=%s error=%r"
+                % (tick.get("symbol"), exc),
+                interval_sec=10.0,
+                level=logging.ERROR,
             )
 
     def _emit_tick(self, symbol: str, tick: dict[str, Any], *, source: str) -> None:
@@ -5582,14 +5654,21 @@ class MarketDataManager:
             bid = _coerce_positive_float(payload.get("bid"))
             ask = _coerce_positive_float(payload.get("ask"))
 
-            ts = float(time.time())
+            now_ts = pd.Timestamp.utcnow().isoformat()
             tick = {
                 "symbol": symbol,
                 "ltp": ltp,
+                "last_price": ltp,
                 "bid": bid,
                 "ask": ask,
-                "timestamp": ts,
+                "timestamp": now_ts,
+                "received_at": time.time(),
+                "source": "rest",
             }
+            token = payload.get("instrument_token") or payload.get("token")
+            if token is not None:
+                tick["instrument_token"] = int(token)
+                tick["token"] = int(token)
 
             if ltp is not None:
                 self._emit_tick(symbol, tick, source="rest")

--- a/tests/data/test_mdm_publish_tick_to_bus_safe.py
+++ b/tests/data/test_mdm_publish_tick_to_bus_safe.py
@@ -1,0 +1,97 @@
+import asyncio
+import concurrent.futures
+import logging
+
+import pandas as pd
+
+from nifty_scalper_bot.data.market_data_manager import MarketDataManager
+
+
+def _make_mdm() -> MarketDataManager:
+    mdm = MarketDataManager.__new__(MarketDataManager)
+    mdm._logger = logging.getLogger('test_mdm')
+    mdm.bus = None
+    mdm._tick_bus = None
+    mdm._main_loop = None
+    return mdm
+
+
+def test_publish_tick_no_bus_no_exception() -> None:
+    mdm = _make_mdm()
+    mdm._publish_tick_to_bus_safe({'symbol': 'NSE:NIFTY', 'ltp': 1.0})
+
+
+def test_publish_tick_bus_not_running_no_exception() -> None:
+    mdm = _make_mdm()
+
+    class Bus:
+        running = False
+
+    mdm.bus = Bus()
+    mdm._publish_tick_to_bus_safe({'symbol': 'NSE:NIFTY', 'ltp': 1.0})
+
+
+def test_publish_tick_missing_loop_no_exception() -> None:
+    mdm = _make_mdm()
+
+    class Bus:
+        running = True
+
+    mdm.bus = Bus()
+    mdm._publish_tick_to_bus_safe({'symbol': 'NSE:NIFTY', 'ltp': 1.0})
+
+
+def test_publish_tick_calls_bus_publish_once() -> None:
+    mdm = _make_mdm()
+    called = []
+
+    class Bus:
+        running = True
+
+        async def publish(self, msg):
+            called.append(msg)
+
+    class Loop:
+        def is_closed(self):
+            return False
+
+    fut = concurrent.futures.Future()
+    fut.set_result(None)
+    orig = asyncio.run_coroutine_threadsafe
+    asyncio.run_coroutine_threadsafe = lambda coro, loop: (asyncio.get_event_loop().run_until_complete(coro), fut)[1]
+    try:
+        mdm.bus = Bus()
+        mdm._main_loop = Loop()
+        mdm._publish_tick_to_bus_safe({'symbol': 'NSE:NIFTY', 'ltp': 1.0})
+    finally:
+        asyncio.run_coroutine_threadsafe = orig
+
+    assert len(called) == 1
+
+
+def test_publish_tick_payload_json_safe() -> None:
+    mdm = _make_mdm()
+    captured = {}
+
+    class Bus:
+        running = True
+
+        async def publish(self, msg):
+            captured['msg'] = msg
+
+    class Loop:
+        def is_closed(self):
+            return False
+
+    fut = concurrent.futures.Future()
+    fut.set_result(None)
+    orig = asyncio.run_coroutine_threadsafe
+    asyncio.run_coroutine_threadsafe = lambda coro, loop: (asyncio.get_event_loop().run_until_complete(coro), fut)[1]
+    try:
+        mdm.bus = Bus()
+        mdm._main_loop = Loop()
+        mdm._publish_tick_to_bus_safe({'symbol': 'NSE:NIFTY', 'ltp': 1.0, 'timestamp': pd.Timestamp.utcnow()})
+    finally:
+        asyncio.run_coroutine_threadsafe = orig
+
+    assert isinstance(captured['msg'].data['timestamp'], str)

--- a/tests/data/test_mdm_tick_timestamp_fallback.py
+++ b/tests/data/test_mdm_tick_timestamp_fallback.py
@@ -1,0 +1,34 @@
+import logging
+
+import pandas as pd
+
+from nifty_scalper_bot.data.market_data_manager import MarketDataManager
+
+
+def _make_mdm() -> MarketDataManager:
+    mdm = MarketDataManager.__new__(MarketDataManager)
+    mdm._logger = logging.getLogger('test_mdm')
+    mdm._lock = type('L', (), {'__enter__': lambda s: s, '__exit__': lambda s,a,b,c: None})()
+    mdm._symbol_by_token = {1: 'NSE:NIFTY'}
+    mdm._token_to_symbol = {1: 'NSE:NIFTY'}
+    return mdm
+
+
+def test_epoch_exchange_timestamp_fallbacks_to_current() -> None:
+    mdm = _make_mdm()
+    tick = mdm._normalize_ws_tick({'instrument_token': 1, 'last_price': 10, 'exchange_timestamp': '1970-01-01 00:00:00'})
+    ts = pd.to_datetime(tick['timestamp'], utc=True)
+    assert ts.year >= 2020
+
+
+def test_none_timestamp_fallbacks_to_current() -> None:
+    mdm = _make_mdm()
+    tick = mdm._normalize_ws_tick({'instrument_token': 1, 'last_price': 10, 'timestamp': None})
+    ts = pd.to_datetime(tick['timestamp'], utc=True)
+    assert ts.year >= 2020
+
+
+def test_valid_exchange_timestamp_kept() -> None:
+    mdm = _make_mdm()
+    tick = mdm._normalize_ws_tick({'instrument_token': 1, 'last_price': 10, 'exchange_timestamp': '2026-04-30T09:15:00Z'})
+    assert tick['timestamp'].startswith('2026-04-30T09:15:00')

--- a/tests/data/test_seed_quote_from_broker.py
+++ b/tests/data/test_seed_quote_from_broker.py
@@ -1,0 +1,35 @@
+import logging
+
+from nifty_scalper_bot.data.market_data_manager import MarketDataManager
+
+
+class Broker:
+    def get_quote(self, symbol: str):
+        return {'last_price': 100.0, 'bid': 99.5, 'ask': 100.5, 'instrument_token': 123}
+
+
+def test_seed_quote_emits_rest_tick() -> None:
+    mdm = MarketDataManager.__new__(MarketDataManager)
+    mdm._logger = logging.getLogger('test_mdm')
+    mdm._lock = type('L', (), {'__enter__': lambda s: s, '__exit__': lambda s,a,b,c: None})()
+    mdm._broker = Broker()
+    mdm._seeded_symbols = set()
+    mdm._seed_completed = False
+    mdm._latest_ticks = {}
+    mdm._last_tick_source = {}
+    mdm._is_ws_healthy = lambda: False
+    mdm._canonical_symbol = lambda s: s
+
+    emitted = {}
+
+    def emit(symbol, tick, source):
+        emitted.update({'symbol': symbol, 'tick': tick, 'source': source})
+
+    mdm._emit_tick = emit
+    ok = mdm._seed_quote_from_broker('NSE:NIFTY')
+    assert ok is True
+    assert emitted['source'] == 'rest'
+    assert emitted['tick']['ltp'] == 100.0
+    assert emitted['tick']['last_price'] == 100.0
+    assert isinstance(emitted['tick']['timestamp'], str)
+    assert 'received_at' in emitted['tick']


### PR DESCRIPTION
### Motivation
- Resolve production crashes where `_emit_tick()` called a missing `_publish_tick_to_bus_safe` method and caused AttributeError failures.
- Prevent invalid/stale `Timestamp`/`datetime` objects from leaking into the MessageBus/DataHub and breaking JSON serialization or readiness gating.
- Reduce noisy position-sync logs and avoid marking PAPER/SHADOW startups as degraded when observation data is available.

### Description
- Added `MarketDataManager._publish_tick_to_bus_safe` to publish ticks to the message bus without crashing MDM and wired `_emit_tick` to use it; publish failures are throttled and non-fatal and payloads are JSON-safe via `to_json_safe` and `Message/MessageType` wrapping in an async-safe future callback.
- Normalized WS tick timestamp handling in `MarketDataManager._normalize_ws_tick` to prefer `exchange_timestamp`, coerce with `pd.to_datetime(..., errors='coerce')`, reject epoch/invalid timestamps (`year < 2020`), and always serialize timestamps to ISO strings (`.isoformat()`);
- Fixed REST seeding in `MarketDataManager._seed_quote_from_broker` to emit a JSON-safe REST tick with `last_price`, ISO `timestamp`, `received_at`, `source: 'rest'`, and preserve/carry `instrument_token`/`token` when present.
- Hardened `DataHub.ingest_tick_from_bus` timestamp parsing to coerce and fallback the same way and store `normalized['timestamp']` as an ISO string only.
- Replaced noisy `data_hub_position_sync_failed` logging with `log_throttled(...)` including the exception repr and 30s throttle to avoid log spam.
- Adjusted startup logging logic so PAPER/SHADOW modes emit `DATA_PIPELINE_OBSERVATION_READY` when observation readiness is satisfied instead of unconditionally logging `STARTUP_DEGRADED` for non-LIVE modes.
- Added focused unit tests in `tests/data/` for `_publish_tick_to_bus_safe`, WS timestamp fallback behavior, and `_seed_quote_from_broker` REST seed emission.

### Testing
- Ran compilation with `python -m compileall src tests` which succeeded.
- Ran focused tests: `pytest -q tests/data/test_mdm_publish_tick_to_bus_safe.py`, `pytest -q tests/data/test_mdm_tick_timestamp_fallback.py`, and `pytest -q tests/data/test_seed_quote_from_broker.py`, and all three passed.
- Ran `pytest -q` for the full suite which fails due to an unrelated pre-existing test import error (`tests/data/test_resolver_lots_delta.py` cannot import `atm_strike_for_spot`), so full-suite regression is blocked by that unrelated test.
- Executed `./run_checks.sh` in this environment; the script performs dependency installs and reported the environment differences (pytest not present in that script run path); the targeted test files were validated after installing `pytest` in the local `.venv` and passing as reported above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f47c1a7dc083248f51715d03c68530)