### PR TITLE
fix: harden tick payload JSON serialization and drop late/out-of-order ticks

### DIFF
--- a/src/nifty_scalper_bot/data/candle_engine.py
+++ b/src/nifty_scalper_bot/data/candle_engine.py
@@ -62,7 +62,15 @@ class CandleEngine:
         minute = timestamp.floor('1min')
 
         if self._last_tick_ts is not None and timestamp < self._last_tick_ts:
-            raise DataIntegrityError('timestamps must be monotonic')
+            LOGGER.debug(
+                'tick_out_of_order',
+                extra={
+                    'event': 'tick_out_of_order',
+                    'tick_ts': timestamp.isoformat(),
+                    'last_ts': self._last_tick_ts.isoformat(),
+                },
+            )
+            return None
 
         finalized: dict[str, Any] | None = None
         if self.current_candle is None:
@@ -71,7 +79,15 @@ class CandleEngine:
         else:
             current_minute = pd.Timestamp(self.current_candle['timestamp'])
             if minute < current_minute:
-                raise DataIntegrityError('out-of-order minute bucket')
+                LOGGER.debug(
+                    'tick_out_of_order',
+                    extra={
+                        'event': 'tick_out_of_order',
+                        'tick_minute': minute.isoformat(),
+                        'current_minute': current_minute.isoformat(),
+                    },
+                )
+                return None
             if minute > current_minute:
                 finalized = self._finalize_current_candle()
                 self.current_candle = self._start_candle(payload, minute)
@@ -110,7 +126,13 @@ class CandleEngine:
             return None
         candle = dict(self.current_candle)
         _validate_ohlc_row(candle)
-        frame = pd.concat([self.df, pd.DataFrame([candle])], ignore_index=True)
+        new_row = pd.DataFrame([candle]).dropna(how='all')
+        if new_row.empty:
+            return None
+        if self.df.empty:
+            frame = new_row
+        else:
+            frame = pd.concat([self.df, new_row], ignore_index=True)
         frame = sanitize(frame).tail(self.max_bars).reset_index(drop=True)
         if frame['timestamp'].duplicated().any():
             raise DataIntegrityError('duplicate candle timestamps')

--- a/src/nifty_scalper_bot/data/data_hub.py
+++ b/src/nifty_scalper_bot/data/data_hub.py
@@ -199,12 +199,15 @@ class DataHub:
         if self._store is None:
             return
         with self._lock:
-            quotes = {k: dict(v) for k, v in self._quotes.items()}
-            orders = {k: dict(v) for k, v in self._orders.items()}
-            positions = {str(k): dict(v) for k, v in self._positions.items()}
-        self._store.save_snapshot("quotes", quotes)
-        self._store.save_snapshot("orders", orders)
-        self._store.save_snapshot("positions", positions)
+            quotes = to_json_safe({k: dict(v) for k, v in self._quotes.items()})
+            orders = to_json_safe({k: dict(v) for k, v in self._orders.items()})
+            positions = to_json_safe({str(k): dict(v) for k, v in self._positions.items()})
+        try:
+            self._store.save_snapshot("quotes", quotes)
+            self._store.save_snapshot("orders", orders)
+            self._store.save_snapshot("positions", positions)
+        except Exception as exc:
+            LOGGER.warning("DATAHUB_CHECKPOINT_FAILED error=%r", exc)
 
     def reset_warmup(self) -> None:
         self._start_mono = self._monotonic()
@@ -383,7 +386,7 @@ class DataHub:
         if seed:
             payload["seed"] = True
         if "timestamp" not in payload:
-            payload["timestamp"] = self._now()
+            payload["timestamp"] = pd.Timestamp.utcnow().isoformat()
         self._ingest_tick_impl(payload)
 
     def _normalize_tick_symbol(self, tick: Tick) -> str:
@@ -393,12 +396,23 @@ class DataHub:
         return self._canonical_quote_symbol(raw_symbol)
 
     def _timestamp_ms(self, timestamp: Any) -> float:
-        if isinstance(timestamp, datetime):
-            return timestamp.timestamp() * 1000.0
-        if isinstance(timestamp, (int, float)):
-            value = float(timestamp)
-            return value * 1000.0 if value < 1e11 else value
-        return self._now() * 1000.0
+        if timestamp is None or timestamp == "":
+            return self._now() * 1000.0
+        try:
+            if isinstance(timestamp, datetime):
+                ts = pd.Timestamp(timestamp)
+            elif isinstance(timestamp, (int, float)):
+                value = float(timestamp)
+                if value <= 0:
+                    return self._now() * 1000.0
+                return value * 1000.0 if value < 1e11 else value
+            else:
+                ts = pd.to_datetime(timestamp, utc=True, errors="coerce")
+            if pd.isna(ts) or ts.year < 2020:
+                return self._now() * 1000.0
+            return float(pd.Timestamp(ts).timestamp() * 1000.0)
+        except Exception:
+            return self._now() * 1000.0
 
     def _tick_price(self, tick: dict[str, Any]) -> float | None:
         for key in ("ltp", "last_price", "price", "close"):
@@ -552,6 +566,7 @@ class DataHub:
         )
 
     def _ingest_tick_impl(self, tick: Tick) -> None:
+        tick = to_json_safe(dict(tick))
         if not tick:
             return
         symbol = self._normalize_tick_symbol(tick)
@@ -583,7 +598,7 @@ class DataHub:
             if source == "poll" and (now_ms - last_ws) < self._poll_block_ms:
                 return
 
-            canonical_tick = dict(tick)
+            canonical_tick = to_json_safe(dict(tick))
             canonical_tick["symbol"] = symbol
             canonical_tick["source"] = source
             canonical_tick["timestamp"] = ts_ms
@@ -639,6 +654,7 @@ class DataHub:
             if not isinstance(payload, dict):
                 LOGGER.warning("DATAHUB_TICK_DROPPED reason=payload_not_dict")
                 return
+            payload = to_json_safe(dict(payload))
 
             symbol = str(payload.get("symbol") or "").strip()
             token = payload.get("instrument_token") or payload.get("token")
@@ -668,7 +684,7 @@ class DataHub:
             now = pd.Timestamp.utcnow()
             age_s = max(0.0, (now - tick_ts).total_seconds())
 
-            normalized = dict(payload)
+            normalized = to_json_safe(dict(payload))
             normalized["symbol"] = symbol
             normalized["instrument_token"] = token
             normalized["token"] = token

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -4699,7 +4699,12 @@ class MarketDataManager:
             except Exception:
                 pass
         callbacks: list[TickCallback]
-        tick_payload = dict(tick)
+        tick_payload = to_json_safe(dict(tick))
+        ts_payload = pd.to_datetime(tick_payload.get("timestamp"), utc=True, errors="coerce")
+        if pd.isna(ts_payload) or ts_payload.year < 2020:
+            ts_payload = pd.Timestamp.utcnow()
+        tick_payload["timestamp"] = ts_payload.isoformat()
+        tick_payload["received_at"] = float(tick_payload.get("received_at") or time.time())
         with self._lock:
             self._last_tick_source[symbol] = source
             callbacks = list(self._subscribers.get(symbol, ()))
@@ -4850,8 +4855,13 @@ class MarketDataManager:
                 else:
                     callback(dict(tick_payload))
             except Exception as exc:
-                self._logger.error(
-                    "Tick callback failed", extra={"symbol": symbol, "error": str(exc)}
+                log_throttled(
+                    self._logger,
+                    f"tick_callback_failed_{symbol}",
+                    "Tick callback failed symbol=%s error=%r" % (symbol, exc),
+                    interval_sec=10.0,
+                    level=logging.ERROR,
+                    exc_info=True,
                 )
         try:
             delivered = subscriber_count > 0

--- a/src/nifty_scalper_bot/storage/hub_store.py
+++ b/src/nifty_scalper_bot/storage/hub_store.py
@@ -12,6 +12,7 @@ from typing import Any, Mapping
 
 from nifty_scalper_bot.config.paths import get_data_dir
 from nifty_scalper_bot.utils.logging import get_logger
+from nifty_scalper_bot.utils.serialization import to_json_safe
 
 log = get_logger(__name__)
 
@@ -71,7 +72,7 @@ class HubStore:
     def append_wal(self, kind: str, entry_key: str, payload: MappingPayload) -> None:
         """Append an entry to the write-ahead log."""
 
-        encoded = json.dumps(payload)
+        encoded = json.dumps(to_json_safe(payload), ensure_ascii=False, default=str)
         with self._lock:
             self._conn.execute(
                 "INSERT INTO wal(ts, kind, entry_key, payload) VALUES(?,?,?,?)",
@@ -107,7 +108,7 @@ class HubStore:
     def save_snapshot(self, kind: str, payload: MappingPayload) -> None:
         """Persist the latest snapshot for *kind*."""
 
-        encoded = json.dumps(payload)
+        encoded = json.dumps(to_json_safe(payload), ensure_ascii=False, default=str)
         with self._lock:
             self._conn.execute(
                 """


### PR DESCRIPTION
### Motivation
- Production errors showed datetimes/pandas timestamps leaking into persistence and message paths causing `TypeError: Object of type datetime is not JSON serializable`, noisy callback logs, fatal out-of-order tick exceptions, and pandas concat warnings.  
- The change enforces the existing global contract that all tick/event payloads are JSON-safe, `timestamp` is an ISO UTC string, and `received_at` is a float epoch second, while avoiding architecture changes.

### Description
- Hub persistence: updated `src/nifty_scalper_bot/storage/hub_store.py` to JSON-normalize payloads with `to_json_safe(...)` and `json.dumps(..., default=str)` for both WAL (`append_wal`) and snapshots (`save_snapshot`) to prevent serialization crashes.  
- DataHub: updated `src/nifty_scalper_bot/data/data_hub.py` to snapshot JSON-safe copies in `checkpoint()` with a guarded save and warning on failure, make `store_quote` seed timestamps ISO UTC strings, replace `_timestamp_ms()` with a robust parser that accepts datetimes, numeric and string forms and falls back safely, and normalize inbound ticks at ingestion boundaries by applying `to_json_safe(...)` in `_ingest_tick_impl()` and `ingest_tick_from_bus()` and when creating canonical/normalized tick dicts.  
- CandleEngine: modified `src/nifty_scalper_bot/data/candle_engine.py` to drop late/out-of-order ticks instead of raising `DataIntegrityError` (emitting a `tick_out_of_order` debug log), and avoid `pd.concat` on empty/all-NaN new rows by early-returning and branching to prevent pandas warnings.  
- MarketDataManager: updated `src/nifty_scalper_bot/data/market_data_manager.py` `_emit_tick()` to `to_json_safe(...)` the payload, normalize `timestamp` to ISO UTC and ensure `received_at` is a float epoch, and replace the noisy per-callback error log with a throttled `log_throttled(...)` call to reduce log spam.

### Testing
- Ran `python -m compileall src tests` which completed successfully.  
- Ran `pytest -q` which stopped on a pre-existing unrelated import error (`ImportError: cannot import name 'atm_strike_for_spot' from 'nifty_scalper_bot.data.instruments'`) and therefore tests did not fully complete; the failures are unrelated to the JSON-serialization and tick-contract fixes in this patch.  
- Manual static checks: code compiles and patched files are limited and reversible and enforce the JSON-safe tick contract at the documented boundaries.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4a92af440832480d9533db70bcbda)