### PR TITLE
fix: harden mdm→datahub runner tick routing

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -162,10 +162,26 @@ def _gate_runner_symbol_add(
     ctx.strategy_runner.add_symbol(symbol)
     if ctx.data_hub is not None and ctx.strategy_runner is not None:
         canonical_symbol = ctx.data_hub._canonical_quote_symbol(symbol)
-        if canonical_symbol not in ctx.datahub_runner_subscriptions:
-            ctx.data_hub.subscribe_ticks(canonical_symbol, ctx.strategy_runner.on_datahub_tick)
-            ctx.datahub_runner_subscriptions.add(canonical_symbol)
-            LOGGER.info("DATAHUB_RUNNER_CALLBACK_REGISTERED symbol=%s", canonical_symbol, extra={"event":"DATAHUB_RUNNER_CALLBACK_REGISTERED","symbol":canonical_symbol})
+        subscription_key = f"{canonical_symbol}|{token or ''}"
+        if subscription_key not in ctx.datahub_runner_subscriptions:
+            ctx.data_hub.subscribe_ticks(
+                canonical_symbol,
+                ctx.strategy_runner.on_datahub_tick,
+                token=token,
+            )
+            ctx.datahub_runner_subscriptions.add(subscription_key)
+            if token is not None:
+                ctx.datahub_runner_subscriptions.add(f"TOKEN:{int(token)}")
+            LOGGER.info(
+                "DATAHUB_RUNNER_CALLBACK_REGISTERED symbol=%s token=%s",
+                canonical_symbol,
+                token,
+                extra={
+                    "event": "DATAHUB_RUNNER_CALLBACK_REGISTERED",
+                    "symbol": canonical_symbol,
+                    "token": token,
+                },
+            )
     if history_ready:
         pending_runner_symbols.discard(symbol)
     else:
@@ -236,6 +252,8 @@ def _emit_option_symbol_pipeline_status(
     datahub_callback_registered = False
     datahub_quote_present = False
     datahub_runner_subscription_registered = False
+    datahub_token_callback_registered = False
+    datahub_token_quote_present = False
     datahub_mdm_delegate_subscribed = False
     mdm_tracked = False
     mdm_has_subscriber = False
@@ -257,14 +275,40 @@ def _emit_option_symbol_pipeline_status(
     if dh is not None:
         try:
             canonical = dh._canonical_quote_symbol(symbol)
-            datahub_callback_registered = bool(
-                getattr(dh, "_tick_subscribers", {}).get(canonical)
+            token_key = int(token) if token is not None else None
+            symbol_callbacks = bool(getattr(dh, "_tick_subscribers", {}).get(canonical))
+            token_callbacks = (
+                token_key is not None
+                and bool(getattr(dh, "_tick_subscribers_by_token", {}).get(token_key))
             )
+            datahub_callback_registered = symbol_callbacks or token_callbacks
             datahub_mdm_delegate_subscribed = canonical in getattr(
                 dh, "_mdm_subscribed_symbols", set()
             )
-            datahub_quote_present = dh.get_quote(symbol, allow_pull=False) is not None
-            datahub_runner_subscription_registered = canonical in getattr(ctx, "datahub_runner_subscriptions", set())
+            datahub_runner_subscription_registered = (
+                canonical in getattr(ctx, "datahub_runner_subscriptions", set())
+                or f"{canonical}|{token or ''}"
+                in getattr(ctx, "datahub_runner_subscriptions", set())
+                or (
+                    token is not None
+                    and f"TOKEN:{int(token)}"
+                    in getattr(ctx, "datahub_runner_subscriptions", set())
+                )
+            )
+            datahub_quote_present = (
+                dh.get_quote(symbol, allow_pull=False) is not None
+                or (
+                    token_key is not None
+                    and getattr(dh, "get_tick_by_token", lambda _t: None)(token_key)
+                    is not None
+                )
+            )
+            datahub_token_callback_registered = token_callbacks
+            datahub_token_quote_present = (
+                token_key is not None
+                and getattr(dh, "get_tick_by_token", lambda _t: None)(token_key)
+                is not None
+            )
         except Exception:
             pass
     if mdm is not None:
@@ -297,7 +341,7 @@ def _emit_option_symbol_pipeline_status(
         except Exception:
             pass
     LOGGER.info(
-        "OPTION_SYMBOL_PIPELINE_STATUS symbol=%s token=%s selected=%s hydrated_bars=%s runner_added=%s runner_history_count=%s datahub_callback_registered=%s datahub_mdm_delegate_subscribed=%s datahub_quote_present=%s datahub_runner_subscription_registered=%s mdm_tracked=%s mdm_has_subscriber=%s mdm_active_subscribed=%s broker_ws_token_requested=%s broker_ws_token_active=%s live_tick_seen=%s last_tick_age_s=%s",
+        "OPTION_SYMBOL_PIPELINE_STATUS symbol=%s token=%s selected=%s hydrated_bars=%s runner_added=%s runner_history_count=%s datahub_callback_registered=%s datahub_mdm_delegate_subscribed=%s datahub_quote_present=%s datahub_runner_subscription_registered=%s datahub_token_callback_registered=%s datahub_token_quote_present=%s mdm_tracked=%s mdm_has_subscriber=%s mdm_active_subscribed=%s broker_ws_token_requested=%s broker_ws_token_active=%s live_tick_seen=%s last_tick_age_s=%s",
         symbol,
         token,
         selected,
@@ -308,6 +352,8 @@ def _emit_option_symbol_pipeline_status(
         datahub_mdm_delegate_subscribed,
         datahub_quote_present,
         datahub_runner_subscription_registered,
+        datahub_token_callback_registered,
+        datahub_token_quote_present,
         mdm_tracked,
         mdm_has_subscriber,
         mdm_active_subscribed,
@@ -328,6 +374,8 @@ def _emit_option_symbol_pipeline_status(
             "datahub_mdm_delegate_subscribed": datahub_mdm_delegate_subscribed,
             "datahub_quote_present": datahub_quote_present,
             "datahub_runner_subscription_registered": datahub_runner_subscription_registered,
+            "datahub_token_callback_registered": datahub_token_callback_registered,
+            "datahub_token_quote_present": datahub_token_quote_present,
             "message_bus_tick_owner": getattr(ctx, "message_bus_tick_owner", "data_hub"),
             "mdm_tracked": mdm_tracked,
             "mdm_has_subscriber": mdm_has_subscriber,

--- a/src/nifty_scalper_bot/data/data_hub.py
+++ b/src/nifty_scalper_bot/data/data_hub.py
@@ -30,15 +30,6 @@ TickListener = Callable[[Tick], None]
 OrderListener = Callable[[dict[str, Any]], None]
 
 
-class _CompletedAwaitable:
-    """Provide await-compatibility for sync-first ingestion APIs."""
-
-    def __await__(self):
-        if False:
-            yield None
-        return None
-
-
 class _EventBus:
     def __init__(self) -> None:
         self._handlers: dict[str, list[Callable[[dict[str, Any]], None]]] = defaultdict(list)
@@ -131,6 +122,8 @@ class DataHub:
         self._token_by_symbol: Dict[str, int] = {}
         self._symbol_by_token: Dict[int, str] = {}
         self._tick_subscribers: Dict[str, set[TickListener]] = defaultdict(set)
+        self._tick_subscribers_by_token: dict[int, set[TickListener]] = defaultdict(set)
+        self._symbol_aliases: dict[str, set[str]] = defaultdict(set)
         self._order_subscribers: list[OrderListener] = []
         self._mdm_subscribed_symbols: set[str] = set()
         self._defer_live_symbol_subscriptions = bool(
@@ -239,6 +232,72 @@ class DataHub:
                 except Exception:
                     continue
         return canonical(s)
+
+
+    def _token_from_symbol(self, symbol: str) -> int | None:
+        """Resolve instrument token from symbol aliases. Args: symbol. Returns: token. Raises: none."""
+        normalized = self._canonical_quote_symbol(symbol)
+        token = self._token_by_symbol.get(normalized)
+        if token is not None:
+            try:
+                return int(token)
+            except Exception:
+                return None
+
+        mdm = getattr(self, "_mdm", None)
+        for attr in ("_token_by_symbol", "_symbol_to_token"):
+            mapping = getattr(mdm, attr, None)
+            if isinstance(mapping, dict):
+                token = mapping.get(normalized) or mapping.get(symbol)
+                if token is not None:
+                    try:
+                        return int(token)
+                    except Exception:
+                        return None
+
+        resolver = getattr(self, "_resolver", None)
+        for method_name in ("token_for_symbol", "resolve_token", "get_token", "instrument_token"):
+            method = getattr(resolver, method_name, None)
+            if callable(method):
+                try:
+                    token = method(normalized)
+                    if token is not None:
+                        return int(token)
+                except Exception:
+                    pass
+
+        return None
+
+    def _register_symbol_alias(self, symbol: str, token: int | None = None) -> str:
+        """Register symbol aliases and optional token mapping. Args: symbol/token. Returns: canonical symbol. Raises: none."""
+        normalized = self._canonical_quote_symbol(symbol)
+        if not normalized:
+            return ""
+
+        aliases = {normalized, str(symbol).strip().upper().replace(" ", "")}
+        token_int: int | None = None
+        if token is not None:
+            try:
+                token_int = int(token)
+                self._token_by_symbol[normalized] = token_int
+                self._symbol_by_token[token_int] = normalized
+                aliases.add(str(token_int))
+            except Exception:
+                token_int = None
+        else:
+            token_int = self._token_from_symbol(normalized)
+
+        if token_int is not None:
+            broker_symbol = self._symbol_by_token.get(token_int)
+            if broker_symbol:
+                aliases.add(self._canonical_quote_symbol(broker_symbol))
+
+        for alias in aliases:
+            if alias:
+                self._symbol_aliases[normalized].add(alias)
+                self._symbol_aliases[alias].add(normalized)
+
+        return normalized
 
     def _position_symbol(self, symbol: str) -> str:
         raw = str(symbol or "").strip().upper()
@@ -678,7 +737,21 @@ class DataHub:
             elif source in {"poll", "rest"}:
                 self._last_poll_arrival[symbol] = now_ms
             self._stale_candidates[symbol] = 0
-            subscribers = list(self._tick_subscribers.get(symbol, ()))
+            token_value = canonical_tick.get("instrument_token") or canonical_tick.get("token")
+            token_int = None
+            try:
+                token_int = int(token_value) if token_value is not None else None
+            except Exception:
+                token_int = None
+            if token_int is not None:
+                self._register_symbol_alias(symbol, token_int)
+            callbacks: set[TickListener] = set()
+            callbacks.update(self._tick_subscribers.get(symbol, set()))
+            for alias in self._symbol_aliases.get(symbol, set()):
+                callbacks.update(self._tick_subscribers.get(alias, set()))
+            if token_int is not None:
+                callbacks.update(self._tick_subscribers_by_token.get(token_int, set()))
+            subscribers = list(callbacks)
         trace_id = str(tick.get("trace_id") or self._make_trace_id(symbol))
         canonical_tick["trace_id"] = trace_id
         LOGGER.debug(
@@ -704,9 +777,9 @@ class DataHub:
                 self._log_listener_failure(exc)
         self.checkpoint()
 
-    def ingest_tick_sync(self, tick: Tick):
+    def ingest_tick_sync(self, tick: Tick) -> None:
         self._ingest_tick_impl(tick)
-        return _CompletedAwaitable()
+        return None
 
     async def ingest_tick_from_bus(self, message: "Message") -> None:
         try:
@@ -722,9 +795,9 @@ class DataHub:
             LOGGER.exception("DATAHUB_TICK_INGEST_FAILED error=%r", exc, extra=to_json_safe({"event": "DATAHUB_TICK_INGEST_FAILED", "error": repr(exc)}))
 
 
-    def ingest_tick(self, tick: Tick):
+    def ingest_tick(self, tick: Tick) -> None:
         self._ingest_tick_impl(tick)
-        return _CompletedAwaitable()
+        return None
 
     def get_quote(self, symbol: str, allow_pull: bool = True) -> Optional[Tick]:
         lookup = self._canonical_quote_symbol(symbol)
@@ -899,8 +972,14 @@ class DataHub:
         self._pending_live_symbols.clear()
         return len(pending_symbols)
 
-    def subscribe_ticks(self, symbol: str, callback: Optional[TickListener] = None):
-        normalized = self._canonical_quote_symbol(symbol)
+    def subscribe_ticks(
+        self,
+        symbol: str,
+        callback: Optional[TickListener] = None,
+        *,
+        token: int | None = None,
+    ):
+        normalized = self._register_symbol_alias(symbol, token)
         if not normalized or normalized.isdigit():
             LOGGER.info(
                 "DATAHUB_SYMBOL_STATUS symbol=%s state=rejected_invalid",
@@ -921,6 +1000,11 @@ class DataHub:
         trace_id = self._make_trace_id(normalized)
         if callback is not None:
             self._tick_subscribers[normalized].add(callback)
+            for alias in self._symbol_aliases.get(normalized, set()):
+                self._tick_subscribers[alias].add(callback)
+            token_int = int(token) if token is not None else self._token_from_symbol(normalized)
+            if token_int is not None:
+                self._tick_subscribers_by_token[int(token_int)].add(callback)
         if self._defer_live_symbol_subscriptions:
             self._pending_live_symbols.add(normalized)
             LOGGER.info(
@@ -1419,9 +1503,9 @@ class DataHub:
         return self._mdm_call("ingest_rest_quote", *args, **kwargs)
 
     def register_symbol(self, symbol: str, token: Optional[int] = None) -> Any:
+        normalized = self._register_symbol_alias(symbol, token)
         if token is not None:
             try:
-                normalized = self._canonical_quote_symbol(symbol)
                 token_int = int(token)
                 self._token_by_symbol[normalized] = token_int
                 self._symbol_by_token[token_int] = normalized

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -4669,6 +4669,59 @@ class MarketDataManager:
                 level=logging.ERROR,
             )
 
+
+    def _dispatch_awaitable_callback_result(
+        self,
+        result: Any,
+        *,
+        symbol: str,
+        callback: Any,
+    ) -> None:
+        """Schedule awaitable callback results. Args: result/symbol/callback. Returns: none. Raises: none."""
+        if result is None or not inspect.isawaitable(result):
+            return
+
+        async def _await_result(awaitable: Any) -> None:
+            try:
+                await awaitable
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                log_throttled(
+                    self._logger,
+                    f"tick_async_callback_failed_{symbol}",
+                    "Async tick callback failed symbol=%s callback=%s error=%r"
+                    % (symbol, getattr(callback, "__qualname__", repr(callback)), exc),
+                    interval_sec=10.0,
+                    level=logging.ERROR,
+                    exc_info=True,
+                )
+
+        loop = getattr(self, "_main_loop", None) or getattr(self, "_event_loop", None)
+        if loop is not None and loop.is_running():
+            try:
+                if loop is asyncio.get_running_loop():
+                    loop.create_task(_await_result(result))
+                else:
+                    asyncio.run_coroutine_threadsafe(_await_result(result), loop)
+                return
+            except RuntimeError:
+                pass
+
+        try:
+            running_loop = asyncio.get_running_loop()
+            running_loop.create_task(_await_result(result))
+            return
+        except RuntimeError:
+            log_throttled(
+                self._logger,
+                f"tick_async_callback_dropped_{symbol}",
+                "Async tick callback dropped symbol=%s reason=no_running_loop callback=%s"
+                % (symbol, getattr(callback, "__qualname__", repr(callback))),
+                interval_sec=10.0,
+                level=logging.WARNING,
+            )
+
     def _emit_tick(self, symbol: str, tick: dict[str, Any], *, source: str) -> None:
         source = str(source or "unknown").lower()
         if source == "ws":
@@ -4863,9 +4916,11 @@ class MarketDataManager:
                         )
                 else:
                     result = callback(dict(tick_payload))
-                    if inspect.isawaitable(result):
-                        task = asyncio.create_task(result)
-                        task.add_done_callback(lambda t: t.exception())
+                    self._dispatch_awaitable_callback_result(
+                        result,
+                        symbol=symbol,
+                        callback=callback,
+                    )
             except Exception as exc:
                 log_throttled(
                     self._logger,

--- a/tests/core/test_option_pipeline_status_token_aware.py
+++ b/tests/core/test_option_pipeline_status_token_aware.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+
+from nifty_scalper_bot.core.app import _emit_option_symbol_pipeline_status
+
+
+class StubDataHub:
+    def __init__(self) -> None:
+        self._tick_subscribers: dict[str, set[object]] = {}
+        self._tick_subscribers_by_token: dict[int, set[object]] = {123: {object()}}
+        self._mdm_subscribed_symbols: set[str] = set()
+
+    def _canonical_quote_symbol(self, symbol: str) -> str:
+        return symbol
+
+    def get_quote(self, symbol: str, allow_pull: bool = False):
+        return None
+
+    def get_tick_by_token(self, token: int):
+        return {'instrument_token': token}
+
+
+class StubMdm:
+    _tracked_symbols: set[str] = set()
+    _subscribers: dict[str, set[object]] = {}
+    _active_subscribed_symbols: set[str] = set()
+    _last_tick_time: dict[str, float] = {}
+    _subscribed_tokens: set[int] = set()
+    _requested_tokens: set[int] = set()
+    _active_tokens: set[int] = set()
+    _desired_tokens: set[int] = {123}
+
+
+def test_pipeline_status_uses_token_callbacks(caplog) -> None:
+    ctx = SimpleNamespace(
+        data_hub=StubDataHub(),
+        market_data_manager=StubMdm(),
+        strategy_runner=None,
+        datahub_runner_subscriptions={'TOKEN:123'},
+        message_bus_tick_owner='data_hub',
+    )
+    caplog.set_level(logging.INFO)
+
+    _emit_option_symbol_pipeline_status(
+        ctx,
+        symbol='NFO:NIFTY26MAY23950CE',
+        token=123,
+        selected=True,
+        hydrated_bars=0,
+        runner_added=False,
+        source='test',
+        reason='test',
+    )
+
+    rec = next(r for r in caplog.records if r.message.startswith('OPTION_SYMBOL_PIPELINE_STATUS'))
+    assert rec.datahub_callback_registered is True
+    assert rec.datahub_quote_present is True
+    assert rec.datahub_runner_subscription_registered is True

--- a/tests/data/test_datahub_token_subscription_bridge.py
+++ b/tests/data/test_datahub_token_subscription_bridge.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from typing import Any
+
+from nifty_scalper_bot.data.data_hub import DataHub
+
+
+class StubMdm:
+    def __init__(self) -> None:
+        self._token_by_symbol: dict[str, int] = {}
+        self._symbol_to_token: dict[str, int] = {}
+
+
+
+def test_token_subscription_bridges_symbol_alias_without_duplication() -> None:
+    hub = DataHub(StubMdm())
+    received: list[dict[str, Any]] = []
+    hub.subscribe_ticks('NFO:NIFTY26MAY23950CE', lambda t: received.append(t), token=123)
+
+    hub.ingest_tick_sync({'symbol': 'NFO:NIFTY2650523950CE', 'instrument_token': 123, 'ltp': 100.0})
+
+    assert len(received) == 1
+    assert hub.get_quote('NFO:NIFTY26MAY23950CE', allow_pull=False) is not None
+    assert hub.get_tick_by_token(123) is not None

--- a/tests/data/test_mdm_callback_dispatch.py
+++ b/tests/data/test_mdm_callback_dispatch.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from nifty_scalper_bot.data.data_hub import DataHub
+from nifty_scalper_bot.data.market_data_manager import MarketDataManager
+
+
+class DummyBroker:
+    pass
+
+
+def test_sync_callback_none_no_error() -> None:
+    mdm = MarketDataManager(DummyBroker(), websocket=None)
+    seen: list[dict[str, Any]] = []
+
+    def callback(tick: dict[str, Any]) -> None:
+        seen.append(tick)
+        return None
+
+    mdm.subscribe('NSE:NIFTY', callback)
+    mdm._emit_tick('NSE:NIFTY', {'symbol': 'NSE:NIFTY', 'ltp': 10.0}, source='ws')  # noqa: SLF001
+    assert len(seen) == 1
+
+
+def test_sync_callback_custom_awaitable_no_type_error() -> None:
+    mdm = MarketDataManager(DummyBroker(), websocket=None)
+
+    class CustomAwaitable:
+        def __await__(self):
+            if False:
+                yield None
+            return None
+
+    def callback(_tick: dict[str, Any]) -> CustomAwaitable:
+        return CustomAwaitable()
+
+    mdm.subscribe('NSE:NIFTY', callback)
+    mdm._emit_tick('NSE:NIFTY', {'symbol': 'NSE:NIFTY', 'ltp': 10.0}, source='ws')  # noqa: SLF001
+
+
+def test_async_callback_scheduled_on_main_loop() -> None:
+    mdm = MarketDataManager(DummyBroker(), websocket=None)
+    ran = {'ok': False}
+
+    async def callback(_tick: dict[str, Any]) -> None:
+        ran['ok'] = True
+
+    async def runner() -> None:
+        mdm.set_event_loop(asyncio.get_running_loop())
+        mdm.subscribe('NSE:NIFTY', callback)
+        mdm._emit_tick('NSE:NIFTY', {'symbol': 'NSE:NIFTY', 'ltp': 11.0}, source='ws')  # noqa: SLF001
+        await asyncio.sleep(0.01)
+
+    asyncio.run(runner())
+    assert ran['ok'] is True
+
+
+def test_datahub_ingest_tick_sync_returns_none() -> None:
+    mdm = MarketDataManager(DummyBroker(), websocket=None)
+    hub = DataHub(mdm)
+    result = hub.ingest_tick_sync({'symbol': 'NSE:NIFTY', 'ltp': 1.0})
+    assert result is None


### PR DESCRIPTION
### Motivation
- Production logs showed `TypeError('a coroutine was expected, got <..._CompletedAwaitable object ...>')` when MDM dispatched DataHub callbacks.  
- Broker tick symbol formats sometimes differ from selection symbols (e.g. `NFO:NIFTY26MAY23950CE` vs `NFO:NIFTY2650523950CE`) causing selected option ticks to not reach the DataHub/StrategyRunner.  
- `OPTION_SYMBOL_PIPELINE_STATUS` sometimes reported `datahub_callback_registered=False` despite token-based subscriptions existing, producing misleading observability.

### Description
- Fixed DataHub sync ingest APIs to return `None` and removed `_CompletedAwaitable` usage so synchronous ingestion does not produce non-coroutine awaitables.  
- Added token-aware routing in `DataHub` including `_tick_subscribers_by_token`, `_symbol_aliases`, `_token_from_symbol`, and `_register_symbol_alias`, and updated `subscribe_ticks`, `register_symbol`, and `_ingest_tick_impl` to dispatch ticks by canonical symbol, aliases, and instrument token while deduplicating callbacks.  
- Hardened MDM callback scheduling by adding `MarketDataManager._dispatch_awaitable_callback_result` and replacing unsafe `asyncio.create_task(...)` on arbitrary awaitables with a defensive scheduler that respects available loops and throttles failure logging.  
- Updated app registration so `StrategyRunner` callbacks are registered with a `symbol|token` subscription key and the `DATAHUB_RUNNER_CALLBACK_REGISTERED symbol=... token=...` log is emitted.  
- Made `OPTION_SYMBOL_PIPELINE_STATUS` token-aware to detect token-based callbacks and quotes and added `datahub_token_callback_registered` and `datahub_token_quote_present` to observability output.  
- Added focused tests covering MDM callback dispatch, DataHub token subscription bridge, and token-aware pipeline status behavior.

### Testing
- Compiled modified modules with `python -S -m py_compile src/nifty_scalper_bot/data/data_hub.py src/nifty_scalper_bot/data/market_data_manager.py src/nifty_scalper_bot/core/app.py src/nifty_scalper_bot/strategies/runner.py` with no syntax errors.  
- Ran targeted tests: `pytest -q tests/data/test_mdm_callback_dispatch.py` (passed), `pytest -q tests/data/test_datahub_token_subscription_bridge.py` (passed), and `pytest -q tests/core/test_option_pipeline_status_token_aware.py` (passed).  
- Full test run `pytest -q` was blocked by an unrelated pre-existing import error in `tests/data/test_resolver_lots_delta.py` (`ImportError: cannot import name 'atm_strike_for_spot' from nifty_scalper_bot.data.instruments`) which is not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4e93011008324a41468fc2a3932bb)