### PR TITLE
fix: harden market-data delivery diagnostics and websocket degradation handling

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -361,8 +361,17 @@ def _emit_option_symbol_pipeline_status(
                 )
         except Exception:
             pass
+    effective_datahub_delivery = (
+        datahub_callback_registered
+        or datahub_token_callback_registered
+        or datahub_runner_subscription_registered
+    )
+    effective_quote_present = (
+        datahub_quote_present
+        or datahub_token_quote_present
+    )
     LOGGER.info(
-        "OPTION_SYMBOL_PIPELINE_STATUS symbol=%s token=%s selected=%s hydrated_bars=%s runner_added=%s runner_history_count=%s datahub_callback_registered=%s datahub_mdm_delegate_subscribed=%s datahub_quote_present=%s datahub_runner_subscription_registered=%s datahub_token_callback_registered=%s datahub_token_quote_present=%s mdm_tracked=%s mdm_has_subscriber=%s mdm_active_subscribed=%s broker_ws_token_requested=%s broker_ws_token_active=%s live_tick_seen=%s last_tick_age_s=%s",
+        "OPTION_SYMBOL_PIPELINE_STATUS symbol=%s token=%s selected=%s hydrated_bars=%s runner_added=%s runner_history_count=%s datahub_callback_registered=%s datahub_mdm_delegate_subscribed=%s datahub_quote_present=%s datahub_runner_subscription_registered=%s datahub_token_callback_registered=%s datahub_token_quote_present=%s mdm_tracked=%s mdm_has_subscriber=%s mdm_active_subscribed=%s broker_ws_token_requested=%s broker_ws_token_active=%s live_tick_seen=%s last_tick_age_s=%s effective_datahub_delivery=%s effective_quote_present=%s",
         symbol,
         token,
         selected,
@@ -382,6 +391,8 @@ def _emit_option_symbol_pipeline_status(
         broker_ws_token_active,
         live_tick_seen,
         last_tick_age_s,
+        effective_datahub_delivery,
+        effective_quote_present,
         extra={
             "event": "OPTION_SYMBOL_PIPELINE_STATUS",
             "symbol": symbol,
@@ -397,6 +408,8 @@ def _emit_option_symbol_pipeline_status(
             "datahub_runner_subscription_registered": datahub_runner_subscription_registered,
             "datahub_token_callback_registered": datahub_token_callback_registered,
             "datahub_token_quote_present": datahub_token_quote_present,
+            "effective_datahub_delivery": effective_datahub_delivery,
+            "effective_quote_present": effective_quote_present,
             "datahub_debug_status": debug_status if "debug_status" in locals() else None,
             "message_bus_tick_owner": getattr(ctx, "message_bus_tick_owner", "data_hub"),
             "mdm_tracked": mdm_tracked,

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -205,6 +205,7 @@ class MarketDataManager:
         self._engines: dict[str, CandleEngine] = {}
         self._last_historical_ts: dict[str, float] = {}
         self._last_tick_ts: dict[str, float] = {}
+        self._last_tick_snapshot: dict[str, dict[str, Any]] = {}
         self._readiness_requirements: dict[str, Any] = {}
         self._last_readiness_state: dict[str, Any] = {
             "hard_ready": False,
@@ -4412,15 +4413,32 @@ class MarketDataManager:
         last_ts = self._last_tick_ts.get(symbol)
         if last_ts is not None:
             last_ts = pd.to_datetime(last_ts, utc=True, errors="coerce")
-            if not pd.isna(last_ts) and tick_ts <= last_ts:
+            if not pd.isna(last_ts) and tick_ts < last_ts:
                 self._logger.debug(
-                    "MDM_TICK_DROPPED reason=non_monotonic symbol=%s ts=%s last=%s",
+                    "MDM_TICK_DROPPED reason=older_timestamp symbol=%s ts=%s last=%s",
                     symbol,
                     tick_ts,
                     last_ts,
                 )
                 return
 
+            if not pd.isna(last_ts) and tick_ts == last_ts:
+                last_snapshot = self._last_tick_snapshot.get(symbol, {})
+                same_price = float(last_snapshot.get("ltp", -1)) == float(tick.ltp)
+                same_volume = last_snapshot.get("volume") == raw.get("volume_traded_today")
+
+                if same_price and same_volume:
+                    self._logger.debug(
+                        "MDM_TICK_DROPPED reason=duplicate_tick symbol=%s ts=%s",
+                        symbol,
+                        tick_ts,
+                    )
+                    return
+
+        self._last_tick_snapshot[symbol] = {
+            "ltp": tick.ltp,
+            "volume": raw.get("volume_traded_today") or raw.get("volume_traded"),
+        }
         self._last_tick_ts[symbol] = tick_ts
         engine = self._get_engine(symbol)
         candle = engine.on_tick(tick)
@@ -4960,6 +4978,9 @@ class MarketDataManager:
                 )
         try:
             delivered = subscriber_count > 0
+            direct_subscribers = subscriber_count
+            bus_publish_attempted = bool(getattr(self, "bus", None))
+            bus_running = bool(getattr(getattr(self, "bus", None), "running", False))
             self._logger.debug(
                 "MDM_TICK_EMITTED symbol=%s delivered=%s subscribers=%d source=%s",
                 symbol,
@@ -4989,17 +5010,20 @@ class MarketDataManager:
             if emit_key not in first_emit_log_tracker:
                 first_emit_log_tracker.add(emit_key)
                 self._logger.info(
-                    "MDM_TICK_EMITTED_FIRST symbol=%s delivered=%s subscribers=%d source=%s",
+                    "MDM_TICK_EMITTED_FIRST symbol=%s direct_delivered=%s direct_subscribers=%d bus_running=%s source=%s",
                     symbol,
                     delivered,
-                    subscriber_count,
+                    direct_subscribers,
+                    bus_running,
                     source,
                     extra={
                         "event": "MDM_TICK_EMITTED",
                         "symbol": symbol,
                         "token": _token_val,
-                        "delivered_to_subscribers": delivered,
-                        "subscriber_count": subscriber_count,
+                        "direct_delivered_to_subscribers": delivered,
+                        "direct_subscriber_count": direct_subscribers,
+                        "bus_publish_attempted": bus_publish_attempted,
+                        "bus_running": bus_running,
                         "source": source,
                         "first_emit": True,
                     },

--- a/src/nifty_scalper_bot/streaming/websocket_manager.py
+++ b/src/nifty_scalper_bot/streaming/websocket_manager.py
@@ -495,11 +495,10 @@ class WebSocketManager:
                     continue
 
                 delay = self._next_backoff_delay()
-                # Enforce minimum floor — sub-second reconnects overwhelm
-                # Zerodha and cause cascading 1006 errors.
-                delay = max(delay, 5.0)
+                # Production reconnect ladder baseline for transient closes.
+                delay = min(max(delay, 2.0), 30.0)
                 self._logger.info(
-                    "Condition met: reconnect_scheduled reason=%s delay=%.2fs",
+                    "RECONNECT_SCHEDULED reason=%s delay=%.2fs",
                     reason,
                     delay,
                 )
@@ -680,7 +679,7 @@ class WebSocketManager:
             self._last_pong_mono = time.monotonic()
             self._state = ConnectionState.CONNECTING
             self._logger.info(
-                "WebSocket CONNECTED successfully | tokens=%d",
+                "WEBSOCKET_RECONNECTED tokens=%d",
                 len(self._tokens),
             )
             if self._tokens:
@@ -689,7 +688,7 @@ class WebSocketManager:
                 ws.set_mode(ws.MODE_FULL, token_list)
                 self._log_ws_subscriptions(token_list)
                 self._logger.info(
-                    "ws_replay_subscriptions total=%d",
+                    "WS_REPLAY_SUBSCRIPTIONS total=%d",
                     len(token_list),
                 )
             self._connected.set()
@@ -786,7 +785,10 @@ class WebSocketManager:
             self._logger.error("Failure in websocket: code=%s reason=%s", code, reason)
             self._connected.clear()
             self._state = ConnectionState.DISCONNECTED
-            self._record_failure()
+            self._stream_health = "degraded"
+            self._last_disconnect_at = time.time()
+            if code != 1006:
+                self._record_failure()
             if self._on_error_callback is not None:
                 self._on_error_callback(RuntimeError(f"code={code} reason={reason}"))
             # Don't schedule another reconnect if one is already running —
@@ -813,11 +815,11 @@ class WebSocketManager:
             self._state = ConnectionState.DISCONNECTED
             self._last_disconnect_at = time.time()
             self._stream_health = "degraded"
-            # 1006 = old connection handshake timeout during normal teardown.
-            # Don't count as failure and don't trigger redundant reconnect
-            # if one is already in progress — this breaks the 1006 cascade.
+            # 1006 is stream degradation, not fatal startup failure.
             if code == 1006:
-                self._logger.warning("Connection closed: 1006")
+                self._logger.warning(
+                    "WEBSOCKET_DEGRADED code=1006 reason=closing_handshake_timeout"
+                )
                 if self._reconnect_task is not None and not self._reconnect_task.done():
                     self._logger.debug(
                         "Suppressed 1006 reconnect — reconnect already in progress"

--- a/tests/core/test_pipeline_effective_delivery.py
+++ b/tests/core/test_pipeline_effective_delivery.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+
+from nifty_scalper_bot.core.app import _emit_option_symbol_pipeline_status
+
+
+class StubHub:
+    _mdm_subscribed_symbols: set[str] = set()
+
+    def __init__(self) -> None:
+        self._tick_subscribers = {}
+        self._tick_subscribers_by_token = {123: {object()}}
+
+    def _canonical_quote_symbol(self, symbol: str) -> str:
+        return symbol
+
+    def debug_subscription_status(self, symbol: str, token: int | None = None):
+        return {
+            'symbol': symbol,
+            'canonical': symbol,
+            'token': token,
+            'symbol_callbacks': 0,
+            'token_callbacks': 1,
+            'aliases': [],
+            'quote_present': False,
+            'token_quote_present': True,
+        }
+
+
+def test_effective_delivery_uses_token_flags(caplog) -> None:
+    ctx = SimpleNamespace(
+        data_hub=StubHub(),
+        market_data_manager=SimpleNamespace(
+            _tracked_symbols=set(), _subscribers={}, _active_subscribed_symbols=set(),
+            _last_tick_time={}, _subscribed_tokens=set(), _requested_tokens=set(), _active_tokens=set(), _desired_tokens={123}
+        ),
+        strategy_runner=None,
+        datahub_runner_subscriptions={'TOKEN:123'},
+        message_bus_tick_owner='data_hub',
+    )
+    caplog.set_level(logging.INFO)
+    _emit_option_symbol_pipeline_status(ctx, symbol='NFO:X', token=123, selected=True, hydrated_bars=0, runner_added=False, source='test', reason='test')
+    rec = next(r for r in caplog.records if r.message.startswith('OPTION_SYMBOL_PIPELINE_STATUS'))
+    assert rec.effective_datahub_delivery is True
+    assert rec.effective_quote_present is True

--- a/tests/data/test_mdm_delivery_diagnostics.py
+++ b/tests/data/test_mdm_delivery_diagnostics.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import logging
+
+from nifty_scalper_bot.data.market_data_manager import MarketDataManager
+
+
+class DummyBroker: ...
+
+
+class DummyWs: ...
+
+
+class Bus:
+    running = True
+
+
+def test_mdm_delivery_diagnostic_reflects_bus(caplog) -> None:
+    mdm = MarketDataManager(DummyBroker(), DummyWs())
+    mdm.bus = Bus()
+    caplog.set_level(logging.INFO)
+
+    mdm._emit_tick('NSE:NIFTY', {'symbol': 'NSE:NIFTY', 'ltp': 100.0}, source='ws')  # noqa: SLF001
+
+    rec = next(r for r in caplog.records if 'MDM_TICK_EMITTED_FIRST' in r.message)
+    assert 'direct_delivered=False' in rec.message
+    assert 'bus_running=True' in rec.message
+    assert ' delivered=' not in rec.message

--- a/tests/data/test_mdm_equal_timestamp_ticks.py
+++ b/tests/data/test_mdm_equal_timestamp_ticks.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from typing import Any
+
+from nifty_scalper_bot.data.market_data_manager import MarketDataManager
+
+
+class DummyBroker:
+    def get_instrument_token(self, _symbol: str) -> int:
+        return 123
+
+
+class DummyWebSocket:
+    on_tick = None
+
+
+def _base_tick(ts: str, price: float, volume: int) -> dict[str, Any]:
+    return {
+        'symbol': 'NSE:NIFTY23',
+        'timestamp': ts,
+        'ltp': price,
+        'last_price': price,
+        'instrument_token': 123,
+        'volume_traded_today': volume,
+    }
+
+
+def test_older_timestamp_dropped() -> None:
+    mdm = MarketDataManager(DummyBroker(), DummyWebSocket())
+    mdm._process_queued_tick(_base_tick('2026-01-01T10:00:01Z', 100.0, 10))  # noqa: SLF001
+    mdm._process_queued_tick(_base_tick('2026-01-01T10:00:00Z', 101.0, 11))  # noqa: SLF001
+    assert mdm.get_latest_tick('NSE:NIFTY23')['ltp'] == 100.0
+
+
+def test_equal_timestamp_same_price_volume_dropped() -> None:
+    mdm = MarketDataManager(DummyBroker(), DummyWebSocket())
+    mdm._process_queued_tick(_base_tick('2026-01-01T10:00:01Z', 100.0, 10))  # noqa: SLF001
+    mdm._process_queued_tick(_base_tick('2026-01-01T10:00:01Z', 100.0, 10))  # noqa: SLF001
+    assert mdm.get_latest_tick('NSE:NIFTY23')['ltp'] == 100.0
+
+
+def test_equal_timestamp_changed_price_accepted() -> None:
+    mdm = MarketDataManager(DummyBroker(), DummyWebSocket())
+    mdm._process_queued_tick(_base_tick('2026-01-01T10:00:01Z', 100.0, 10))  # noqa: SLF001
+    mdm._process_queued_tick(_base_tick('2026-01-01T10:00:01Z', 101.0, 10))  # noqa: SLF001
+    assert mdm.get_latest_tick('NSE:NIFTY23')['ltp'] == 101.0
+
+
+def test_equal_timestamp_changed_volume_accepted() -> None:
+    mdm = MarketDataManager(DummyBroker(), DummyWebSocket())
+    mdm._process_queued_tick(_base_tick('2026-01-01T10:00:01Z', 100.0, 10))  # noqa: SLF001
+    mdm._process_queued_tick(_base_tick('2026-01-01T10:00:01Z', 100.0, 11))  # noqa: SLF001
+    assert mdm.get_latest_tick('NSE:NIFTY23')['volume'] == 11

--- a/tests/streaming/test_websocket_1006_handling.py
+++ b/tests/streaming/test_websocket_1006_handling.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from nifty_scalper_bot.core.app import _polling_fallback_degraded
+from nifty_scalper_bot.streaming.websocket_manager import WebSocketManager
+
+
+def test_1006_marks_degraded_not_failed(monkeypatch) -> None:
+    ws = WebSocketManager('k', 't', tokens=[1])
+    called: list[str] = []
+    monkeypatch.setattr(ws, '_schedule_reconnect', lambda reason: called.append(reason))
+    ws._on_close(None, 1006, 'abnormal')
+    assert ws._stream_health == 'degraded'
+    assert ws._last_disconnect_at > 0
+    assert called == ['close:1006']
+
+
+def test_reconnect_replays_subscriptions() -> None:
+    ws = WebSocketManager('k', 't', tokens=[1, 2])
+
+    class Ticker:
+        MODE_FULL = 'full'
+
+        def __init__(self) -> None:
+            self.subscribed = []
+            self.mode_set = []
+
+        def subscribe(self, payload):
+            self.subscribed.extend(payload)
+
+        def set_mode(self, mode, payload):
+            self.mode_set.append((mode, list(payload)))
+
+    ticker = Ticker()
+    ws._ticker = ticker
+    ws._connected.set()
+    import asyncio
+    asyncio.run(ws._resubscribe_if_connected())
+    assert ticker.subscribed == [1, 2]
+
+
+def test_live_execution_blocked_when_stream_stale_or_degraded() -> None:
+    assert _polling_fallback_degraded(ws_ok=False, lagging=False, futures_fresh=True, options_fresh=True) is True


### PR DESCRIPTION
### Motivation
- Prevent legitimate ticks from being dropped when timestamps are equal but price/volume changed and remove misleading MDM diagnostics that implied fatal delivery failures.  
- Treat WebSocket close code `1006` as transient stream degradation with controlled recovery instead of a startup-fatal error.  
- Improve pipeline diagnostics so token-based DataHub routing is recognized in status logs.  

### Description
- MarketDataManager: change timestamp gating to drop only strictly older ticks (`<`) and add per-symbol `_last_tick_snapshot` to detect/allow equal-timestamp ticks when price or volume changed while dropping exact duplicates. (adds `_last_tick_snapshot` and updates `_process_queued_tick`).
- MarketDataManager: revise first-emit logging to report `direct_delivered`, `direct_subscribers`, `bus_publish_attempted`, and `bus_running` instead of a single ambiguous `delivered=False` field so MessageBus/DataHub routing is visible. (logging changes in `_emit_tick`).
- Core app: extend `OPTION_SYMBOL_PIPELINE_STATUS` with `effective_datahub_delivery` and `effective_quote_present` computed flags so pipeline status reflects token-path delivery and token-quote presence. (updates `_emit_option_symbol_pipeline_status`).
- WebSocketManager: harden error/close handling for code `1006` by marking `_stream_health = "degraded"`, stamping `_last_disconnect_at`, emitting `WEBSOCKET_DEGRADED` logs, and keeping reconnect logic with a bounded exponential ladder (2s → 5s → 10s capped to 30s) and standardized reconnect/replay logs (`RECONNECT_SCHEDULED`, `WEBSOCKET_RECONNECTED`, `WS_REPLAY_SUBSCRIPTIONS`). Also mark stream degraded on errors and avoid counting 1006 toward circuit failures. (updates `_on_error`, `_on_close`, `_reconnect_loop`, `_on_connect` and logging).
- Tests: add focused unit tests covering equal-timestamp tick behavior, MDM delivery diagnostics, effective pipeline delivery computation, and 1006 websocket handling and replay. (new tests under `tests/data/` and `tests/streaming/` and `tests/core/`).

### Testing
- Ran compilation: `python -m compileall src tests` — success.  
- Ran targeted pytest suites: `pytest -q tests/data/test_mdm_equal_timestamp_ticks.py`, `pytest -q tests/data/test_mdm_delivery_diagnostics.py`, `pytest -q tests/core/test_pipeline_effective_delivery.py`, and `pytest -q tests/streaming/test_websocket_1006_handling.py` — all succeeded.  
- Ran full `pytest -q` which failed due to a pre-existing, unrelated import error in `tests/data/test_resolver_lots_delta.py` (missing export `atm_strike_for_spot`), so overall test run is blocked by that unrelated failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f53d17d6b083249392fcd1b6dd4a9a)