### PR TITLE
fix: centralize historical OHLCV normalization and slow startup hydration

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -137,6 +137,26 @@ def _history_lookback_minutes(required_bars: int) -> int:
     return max(180, required + buffer_bars)
 
 
+def _prioritize_startup_hydration_symbols(symbols: Sequence[str], max_symbols: int = 4) -> list[str]:
+    """Prioritize startup hydration symbols. Args: symbols/max_symbols. Returns: ordered symbols. Raises: none."""
+    spot = [s for s in symbols if s == "NSE:NIFTY" or s.endswith(":NIFTY")]
+    futures = [s for s in symbols if s.startswith("NFO:NIFTY") and s.endswith("FUT")]
+    options = [
+        s
+        for s in symbols
+        if s.startswith("NFO:NIFTY") and (s.endswith("CE") or s.endswith("PE"))
+    ]
+
+    selected: list[str] = []
+    for bucket in (spot, futures, options):
+        for sym in bucket:
+            if sym not in selected:
+                selected.append(sym)
+            if len(selected) >= max_symbols:
+                return selected
+    return selected
+
+
 def _gate_runner_symbol_add(
     ctx: Any,
     symbol: str,
@@ -6903,7 +6923,10 @@ async def startup_sequence(ctx: BotContext) -> None:
                     )
                     continue
                 symbols_to_hydrate.append(_sym)
-            symbols_to_hydrate = symbols_to_hydrate[:hydration_max_contracts]
+            symbols_to_hydrate = _prioritize_startup_hydration_symbols(
+                symbols_to_hydrate,
+                max_symbols=min(4, hydration_max_contracts),
+            )
             LOGGER.info(
                 "HYDRATION_PLAN symbols=%d bars_target=%d lookback_days=%d",
                 len(symbols_to_hydrate),
@@ -6926,11 +6949,10 @@ async def startup_sequence(ctx: BotContext) -> None:
             async def _fetch_symbol(symbol: str) -> tuple[str, list[Any]]:
                 """Fetch historical records for one symbol. Args: symbol. Returns: symbol and raw records. Raises: Exception."""
                 records = await asyncio.to_thread(
-                    ctx.broker_client.get_ohlc,
+                    ctx.market_data_manager.fetch_history,
                     symbol,
                     "minute",
-                    from_str,
-                    to_str,
+                    2,
                 )
                 if records and len(records) > hydration_max_bars:
                     records = list(records)[-hydration_max_bars:]
@@ -6972,7 +6994,7 @@ async def startup_sequence(ctx: BotContext) -> None:
                     fetch_results.append(await _fetch_symbol(target_symbol))
                 except Exception as exc:  # noqa: BLE001
                     fetch_results.append(exc)
-                await asyncio.sleep(0.35)
+                await asyncio.sleep(1.15)
 
             LOGGER.info(
                 "hydration_commit_start",
@@ -6995,10 +7017,9 @@ async def startup_sequence(ctx: BotContext) -> None:
                 runner_ingested = 0
                 for row in records:
                     try:
-                        coerced = _coerce_ohlc_row(row)
-                        if coerced is None:
+                        bar_data = row if isinstance(row, dict) else None
+                        if bar_data is None:
                             continue
-                        bar_data = {"symbol": sym, **coerced}
                         if ctx.market_data_manager is not None:
                             ctx.market_data_manager.ingest_historical_bar(bar_data)
                         if (

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -6979,6 +6979,63 @@ class MarketDataManager:
         self._last_signature[symbol] = (signature, current)
         return False
 
+
+    @staticmethod
+    def normalize_history_row(symbol: str, row: Any, source: str = "historical") -> dict[str, Any] | None:
+        """Normalize broker/DataHub OHLC row. Args: symbol/row/source. Returns: canonical bar or None. Raises: None."""
+        try:
+            if isinstance(row, Mapping):
+                ts = row.get("timestamp") or row.get("date") or row.get("time")
+                open_ = row.get("open")
+                high = row.get("high")
+                low = row.get("low")
+                close = row.get("close")
+                volume = row.get("volume", 0)
+            elif isinstance(row, (list, tuple)) and len(row) >= 5:
+                ts = row[0]
+                open_ = row[1]
+                high = row[2]
+                low = row[3]
+                close = row[4]
+                volume = row[5] if len(row) > 5 else 0
+            else:
+                return None
+
+            if ts is None:
+                return None
+
+            if isinstance(ts, str):
+                ts = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+            elif not isinstance(ts, datetime):
+                ts = datetime.fromtimestamp(float(ts), tz=timezone.utc)
+
+            if ts.tzinfo is None:
+                ts = ts.replace(tzinfo=timezone.utc)
+            else:
+                ts = ts.astimezone(timezone.utc)
+
+            o = float(open_)
+            h = float(high)
+            l = float(low)
+            c = float(close)
+            v = int(float(volume or 0))
+
+            if min(o, h, l, c) <= 0:
+                return None
+
+            return {
+                "symbol": str(symbol),
+                "timestamp": ts,
+                "open": o,
+                "high": h,
+                "low": l,
+                "close": c,
+                "volume": v,
+                "source": source,
+            }
+        except Exception:
+            return None
+
     # -------------------------------------------------------------------------
     # ✅ "HUNTER-KILLER" FIX: Robust History Fetching
     # -------------------------------------------------------------------------
@@ -7081,13 +7138,42 @@ class MarketDataManager:
                 data = await asyncio.to_thread(
                     fetcher, token, from_date, to_date, interval
                 )
-                if data:
-                    self._logger.info(f"✅ Received {len(data)} candles for {symbol}")
+                raw_rows = data or []
+                normalized = [
+                    bar
+                    for bar in (
+                        self.normalize_history_row(symbol, row, source="historical")
+                        for row in raw_rows
+                    )
+                    if bar is not None
+                ]
+
+                if normalized:
+                    self._logger.info(
+                        "HISTORY_FETCH_NORMALIZED symbol=%s raw=%d normalized=%d",
+                        symbol,
+                        len(raw_rows),
+                        len(normalized),
+                        extra={
+                            "event": "HISTORY_FETCH_NORMALIZED",
+                            "symbol": symbol,
+                            "raw": len(raw_rows),
+                            "normalized": len(normalized),
+                        },
+                    )
                 else:
                     self._logger.warning(
-                        f"⚠️ History fetch returned 0 candles for {symbol} (Token: {token})"
+                        "HISTORY_FETCH_ZERO_NORMALIZED symbol=%s raw=%d",
+                        symbol,
+                        len(raw_rows),
+                        extra={
+                            "event": "HISTORY_FETCH_ZERO_NORMALIZED",
+                            "symbol": symbol,
+                            "raw": len(raw_rows),
+                        },
                     )
-                return data
+
+                return normalized
 
             # Debugging Dump if failure persists
             self._logger.error(

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -4980,6 +4980,23 @@ class StrategyRunner:
                 )
                 return False
             if not self._indicator_engine.has_min_bars(symbol, self._required_candles):
+                history_count = len(self._indicator_engine.get_history(symbol) or [])
+                if history_count < self._required_candles:
+                    if self._should_log_throttled(
+                        f"eval_block_cold_history:{symbol}", 120.0
+                    ):
+                        self._logger.warning(
+                            "EVALUATION_BLOCKED_COLD_HISTORY symbol=%s bars=%d required=%d",
+                            symbol,
+                            history_count,
+                            self._required_candles,
+                            extra={
+                                "event": "EVALUATION_BLOCKED_COLD_HISTORY",
+                                "symbol": symbol,
+                                "bars": history_count,
+                                "required": self._required_candles,
+                            },
+                        )
                 self._emit_runner_eval_decision(
                     symbol=symbol,
                     stage='phase9',

--- a/tests/test_market_data_normalization.py
+++ b/tests/test_market_data_normalization.py
@@ -1,0 +1,51 @@
+from datetime import datetime, timezone
+
+import pytest
+
+from nifty_scalper_bot.data.market_data_manager import MarketDataManager
+
+
+class DummyBroker:
+    def historical_data(self, token, from_date, to_date, interval):
+        return [[datetime(2026, 1, 1, tzinfo=timezone.utc), 1, 2, 0.5, 1.5, 100]]
+
+
+@pytest.mark.asyncio
+async def test_normalize_history_row_list() -> None:
+    row = [datetime(2026, 1, 1), 1, 2, 0.5, 1.5, 100]
+    bar = MarketDataManager.normalize_history_row('NSE:NIFTY', row)
+    assert bar is not None
+    assert bar['symbol'] == 'NSE:NIFTY'
+    assert bar['open'] == 1.0
+    assert bar['volume'] == 100
+    assert bar['timestamp'].tzinfo is not None
+
+
+def test_normalize_history_row_dict() -> None:
+    row = {
+        'date': datetime(2026, 1, 1),
+        'open': 1,
+        'high': 2,
+        'low': 0.5,
+        'close': 1.5,
+        'volume': 100,
+    }
+    bar = MarketDataManager.normalize_history_row('NSE:NIFTY', row)
+    assert bar is not None
+    assert bar['close'] == 1.5
+    assert bar['source'] == 'historical'
+
+
+def test_normalize_history_row_invalid() -> None:
+    assert MarketDataManager.normalize_history_row('NSE:NIFTY', {'open': 1}) is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_history_returns_normalized_dicts_only() -> None:
+    manager = MarketDataManager(broker=DummyBroker())
+    manager._token_by_symbol['NSE:NIFTY'] = 256265
+    bars = await manager.fetch_history('NSE:NIFTY', 'minute', 2)
+    assert bars
+    assert isinstance(bars[0], dict)
+    assert 'open' in bars[0]
+    assert not isinstance(bars[0], (list, tuple))


### PR DESCRIPTION
### Motivation
- Improve market-data reliability by centralizing raw-history normalization so downstream systems only see canonical OHLCV bars.
- Prevent raw broker rows from leaking into hydration/indicator pipelines which caused unreliable indicator state and occasional execution gating failures.
- Reduce Zerodha historical API rate-limit failures by slowing and prioritizing startup hydration to secure direction/futures before options.

### Description
- Added `MarketDataManager.normalize_history_row(symbol, row, source="historical")` static method to produce canonical UTC-aware OHLCV dicts and reject invalid rows, and added required imports (`datetime`, `timezone`, `Any`, `Mapping`).
- Updated `MarketDataManager.fetch_history(...)` to normalize all fetched rows and return only canonical dict bars with diagnostic logs `HISTORY_FETCH_NORMALIZED` / `HISTORY_FETCH_ZERO_NORMALIZED` instead of returning raw broker lists/tuples.
- Rewrote startup hydration in `core/app.py` to call `ctx.market_data_manager.fetch_history(...)` (MDM-only path), ingest only normalized dict bars into `MarketDataManager`/`StrategyRunner`, added `_prioritize_startup_hydration_symbols(...)` to prefer spot → futures → ATM options (max 4), and increased inter-fetch sleep from `0.35` to `1.15` seconds.
- Added throttled diagnostic warning in `StrategyRunner._strategy_evaluation_allowed` when evaluation is blocked due to cold history, without bypassing the required-bars safety gate.
- Added unit tests `tests/test_market_data_normalization.py` covering list-row normalization, dict-row normalization, invalid-row rejection, and that `fetch_history` returns normalized dicts only.

### Testing
- Compiled the package with `python -m compileall src` with no compile errors across `src/`.
- Ran `pytest tests/test_market_data_normalization.py -q` which passed (`4 passed`).
- Ran `pytest tests/test_execution_path_contract.py -q` which passed (`8 passed`).
- Files changed: `src/nifty_scalper_bot/data/market_data_manager.py`, `src/nifty_scalper_bot/core/app.py`, `src/nifty_scalper_bot/strategies/runner.py`, and `tests/test_market_data_normalization.py`.
- Confirmation: raw broker history is now normalized centrally in `MarketDataManager.normalize_history_row(...)` and `fetch_history(...)` is the only modified startup path used for historical hydration so raw broker rows do not escape MDM.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f785d3ea4c832491996b78376ffcb4)