### PR TITLE
fix: unify live tick ingestion with ws-first polling fallback

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -628,6 +628,24 @@ LOGGER = logging.getLogger("nifty_scalper_bot.core.app")
 _ComponentT = TypeVar("_ComponentT")
 
 
+def _safe_ws_token_count(ctx: BotContext) -> int | str:
+    """Resolve WS token diagnostics safely. Args: ctx. Returns: count or unknown. Raises: none."""
+    for obj_name, attr_name in [
+        ("market_data_manager", "_subscribed_tokens"),
+        ("market_data_manager", "subscribed_tokens"),
+        ("market_data_manager", "_token_to_symbol"),
+        ("broker_client", "ws_tokens"),
+    ]:
+        obj = getattr(ctx, obj_name, None)
+        value = getattr(obj, attr_name, None) if obj is not None else None
+        if value is not None:
+            try:
+                return len(value)
+            except Exception:
+                continue
+    return "unknown"
+
+
 def _get_current_nifty_futures_symbol() -> str:
     """
     Compute the current month's NIFTY futures symbol.
@@ -7487,7 +7505,7 @@ async def startup_sequence(ctx: BotContext) -> None:
                     and float(last_tick_map.get(_sym, 0.0)) > 0
                 )
                 LOGGER.info(
-                    "LIVE_WIRING_FINAL_STATUS symbols_count=%d tokens_count=%d mdm_tracked_count=%d mdm_subscriber_count=%d datahub_callback_symbols_count=%d broker_ws_token_count=%d live_tick_seen_count=%d",
+                    "LIVE_WIRING_FINAL_STATUS symbols_count=%d tokens_count=%d mdm_tracked_count=%d mdm_subscriber_count=%d datahub_callback_symbols_count=%d broker_ws_token_count=%s live_tick_seen_count=%d",
                     len(targets),
                     len(active_symbol_tokens),
                     len(getattr(ctx.market_data_manager, "_tracked_symbols", set())),
@@ -7499,10 +7517,7 @@ async def startup_sequence(ctx: BotContext) -> None:
                     )
                     if ctx.data_hub is not None
                     else 0,
-                    len(
-                        getattr(ctx.market_data_manager, "_requested_tokens", set())
-                        or getattr(ctx.market_data_manager, "_subscribed_tokens", set())
-                    ),
+                    _safe_ws_token_count(ctx),
                     live_tick_seen_count,
                     extra={
                         "event": "LIVE_WIRING_FINAL_STATUS",
@@ -7523,10 +7538,7 @@ async def startup_sequence(ctx: BotContext) -> None:
                             if ctx.data_hub is not None
                             else 0
                         ),
-                        "broker_ws_token_count": len(
-                            getattr(ctx.market_data_manager, "_requested_tokens", set())
-                            or getattr(ctx.market_data_manager, "_subscribed_tokens", set())
-                        ),
+                        "broker_ws_token_count": _safe_ws_token_count(ctx),
                         "live_tick_seen_count": live_tick_seen_count,
                     },
                 )
@@ -8113,10 +8125,7 @@ async def startup_sequence(ctx: BotContext) -> None:
                                     mdm_subscriber_count = len(
                                         getattr(ctx.market_data_manager, "_subscribers", {})
                                     )
-                                    broker_ws_token_count = len(
-                                        getattr(ctx.market_data_manager, "_requested_tokens", set())
-                                        or getattr(ctx.market_data_manager, "_subscribed_tokens", set())
-                                    )
+                                    broker_ws_token_count = _safe_ws_token_count(ctx)
                                     last_tick_map = getattr(ctx.market_data_manager, "_last_tick_time", {}) or {}
                                     live_tick_seen_count = sum(
                                         1
@@ -8131,7 +8140,7 @@ async def startup_sequence(ctx: BotContext) -> None:
                                         if bool(getattr(ctx.data_hub, "_tick_subscribers", {}).get(_s))
                                     )
                                 LOGGER.info(
-                                    "LIVE_WIRING_FINAL_STATUS symbols_count=%d tokens_count=%d mdm_tracked_count=%d mdm_subscriber_count=%d datahub_callback_symbols_count=%d broker_ws_token_count=%d live_tick_seen_count=%d",
+                                    "LIVE_WIRING_FINAL_STATUS symbols_count=%d tokens_count=%d mdm_tracked_count=%d mdm_subscriber_count=%d datahub_callback_symbols_count=%d broker_ws_token_count=%s live_tick_seen_count=%d",
                                     len(latest_symbols),
                                     len(active_symbol_tokens),
                                     mdm_tracked_count,

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -258,6 +258,13 @@ class MarketDataManager:
         self._stale_threshold_seconds = self._parse_float_env(
             "MDM_STALE_THRESHOLD_SECONDS", default=10.0, minimum=1.0
         )
+        self._critical_symbol_stale_seconds = self._parse_float_env(
+            "MDM_CRITICAL_SYMBOL_STALE_SECONDS", default=30.0, minimum=1.0
+        )
+        self._option_stale_seconds = self._parse_float_env(
+            "MDM_OPTION_STALE_SECONDS", default=60.0, minimum=1.0
+        )
+        self._poll_fallback_count = 0
         self._ltp_stale_seconds = self._parse_float_env(
             "MDM_LTP_STALE_SECONDS", default=5.0, minimum=1.0
         )
@@ -4485,7 +4492,10 @@ class MarketDataManager:
         except Exception:
             pass
 
-        self._emit_tick(symbol, tick_dict, source="ws")
+        normalized_live = self.normalize_live_tick(tick_dict, source="ws")
+        if normalized_live is None:
+            return
+        self._ingest_normalized_tick(normalized_live)
         if candle:
             self._ohlc[symbol].append(candle)
 
@@ -4741,6 +4751,13 @@ class MarketDataManager:
                 level=logging.WARNING,
             )
 
+    def _ingest_normalized_tick(self, tick: Mapping[str, Any]) -> None:
+        """Ingest one canonical live tick. Args: tick; Returns: none; Raises: none."""
+        symbol = str(tick["symbol"])
+        source = str(tick.get("source") or "unknown").lower()
+        tick_payload = dict(tick)
+        self._emit_tick(symbol, tick_payload, source=source)
+
     def _emit_tick(self, symbol: str, tick: dict[str, Any], *, source: str) -> None:
         source = str(source or "unknown").lower()
         if source == "ws":
@@ -4754,13 +4771,13 @@ class MarketDataManager:
                 last_logged = float(self._ws_stored_tick_log_at.get(symbol, 0.0))
                 if last_logged <= 0.0 or (now - last_logged) >= 60.0:
                     self._ws_stored_tick_log_at[symbol] = now
-                    self._logger.info(
+                    self._logger.debug(
                         "MDM_TICK_CACHE_UPDATED symbol=%s token=%s source=ws",
                         symbol,
                         token_int,
                         extra={"event": "MDM_TICK_CACHE_UPDATED", "symbol": symbol, "token": token_int, "source": "ws"},
                     )
-                    self._logger.info(
+                    self._logger.debug(
                         "WS_TICK_STORED symbol=%s token=%s ltp=%s source=ws age_ms=0",
                         symbol,
                         token_int,
@@ -4920,13 +4937,33 @@ class MarketDataManager:
                 cached_count,
                 tick_count,
             )
-            self._logger.info(
+            self._logger.debug(
                 "Condition met: mdm_tick_health",
                 extra={
                     "event": "mdm_tick_health",
                     "ticks_per_second_by_symbol": rates,
                     "history_length_by_symbol": history_lengths,
                 },
+            )
+        if now_mono - self._last_tick_stats_log >= 120.0:
+            self._last_tick_stats_log = now_mono
+            with self._lock:
+                live_symbols = len(self._symbols_with_tick)
+                subscribed = len(self._active_subscribed_symbols)
+                stale_symbols = sum(
+                    1
+                    for sym in self._active_subscribed_symbols
+                    if (time.time() - float(self._last_tick_time.get(sym, 0.0) or 0.0))
+                    >= self._option_stale_seconds
+                )
+            self._logger.info(
+                "MARKET_DATA_HEALTH_SUMMARY ws_connected=%s subscribed=%d live_symbols=%d stale_symbols=%d poll_fallbacks=%d bus_running=%s",
+                self._is_ws_connected(),
+                subscribed,
+                live_symbols,
+                stale_symbols,
+                int(getattr(self, "_poll_fallback_count", 0)),
+                bool(getattr(getattr(self, "bus", None), "running", False)),
             )
         try:
             self._m_ticks.inc()
@@ -5516,6 +5553,8 @@ class MarketDataManager:
                     candidates.update(self._latest_ticks.keys())
                 candidates.update(self._tracked_symbols)
             ordered = sorted(symbol for symbol in candidates if symbol)
+            now_dt = datetime.now(timezone.utc)
+            ordered = [sym for sym in ordered if self._should_poll_symbol(sym, now_dt)]
             limit = self._rest_poll_max_symbols
             if limit > 0 and len(ordered) > limit:
                 self._logger.debug(
@@ -6491,11 +6530,76 @@ class MarketDataManager:
         normalized = self._normalize_tick(symbol, quote, previous)
         if normalized is None:
             return
-        if self._is_duplicate(symbol, normalized):
-            self._store_tick(symbol, normalized)
-        else:
-            self._emit_tick(symbol, normalized, source="rest")
+        normalized_live = self.normalize_live_tick(normalized, source="poll")
+        if normalized_live is None:
+            return
+        self._poll_fallback_count = int(getattr(self, "_poll_fallback_count", 0)) + 1
+        self._ingest_normalized_tick(normalized_live)
         self._process_poll_quote(symbol, normalized)
+
+    def _is_context_symbol(self, symbol: str) -> bool:
+        """Return whether symbol is context feed. Args: symbol; Returns: bool; Raises: none."""
+        sym = self._canonical_symbol(symbol)
+        return sym == "NSE:NIFTY" or "FUT" in sym
+
+    def _should_poll_symbol(self, symbol: str, now: datetime) -> bool:
+        """Decide REST poll fallback need. Args: symbol, now; Returns: bool; Raises: none."""
+        sym = self._canonical_symbol(symbol)
+        with self._lock:
+            active = set(self._active_subscribed_symbols) or set(self._tracked_symbols)
+            if active and sym not in active:
+                return False
+            if not self._is_ws_connected():
+                return True
+            last_ts_raw = self._last_tick_time.get(sym)
+        if last_ts_raw is None:
+            return True
+        last_ts = datetime.fromtimestamp(float(last_ts_raw), tz=timezone.utc)
+        age = (now - last_ts).total_seconds()
+        threshold = (
+            self._critical_symbol_stale_seconds
+            if self._is_context_symbol(sym)
+            else self._option_stale_seconds
+        )
+        return age >= threshold
+
+    def normalize_live_tick(
+        self, raw: Mapping[str, Any], source: str = "ws"
+    ) -> dict[str, Any] | None:
+        """Normalize live tick. Args: raw/source. Returns: canonical tick or none. Raises: none."""
+        token_raw = raw.get("token") or raw.get("instrument_token")
+        token: int | None = None
+        if token_raw is not None:
+            with suppress(Exception):
+                token = int(token_raw)
+        symbol_raw = raw.get("symbol")
+        symbol = str(symbol_raw) if symbol_raw else ""
+        if not symbol and token is not None:
+            with self._lock:
+                symbol = str(self._symbol_by_token.get(token) or self._token_to_symbol.get(token) or "")
+        if not symbol:
+            return None
+        ltp_raw = raw.get("ltp") or raw.get("last_price") or raw.get("price")
+        with suppress(Exception):
+            ltp = float(ltp_raw)
+            if ltp <= 0:
+                return None
+            ts = pd.to_datetime(raw.get("timestamp") or raw.get("exchange_timestamp") or datetime.now(timezone.utc), utc=True, errors="coerce")
+            if pd.isna(ts):
+                ts = pd.Timestamp.utcnow()
+            ts_py = ts.to_pydatetime().astimezone(timezone.utc)
+            return {
+                "symbol": self._canonical_symbol(symbol),
+                "token": token,
+                "ltp": ltp,
+                "bid": _coerce_float(raw.get("bid")),
+                "ask": _coerce_float(raw.get("ask")),
+                "volume": _coerce_int(raw.get("volume") or raw.get("volume_traded") or raw.get("volume_traded_today")),
+                "oi": _coerce_int(raw.get("oi")),
+                "timestamp": ts_py,
+                "source": "poll" if str(source).lower() == "poll" else "ws",
+            }
+        return None
 
     def _ltp_stale_threshold_for_symbol(self, symbol: str) -> float:
         """Return per-symbol stale threshold. Args: symbol. Returns: seconds. Raises: none."""

--- a/tests/test_live_tick_normalization.py
+++ b/tests/test_live_tick_normalization.py
@@ -1,0 +1,37 @@
+from datetime import datetime, timezone
+
+from nifty_scalper_bot.data.market_data_manager import MarketDataManager
+
+
+def test_ws_raw_tick_normalizes_to_canonical_tick() -> None:
+    mdm = MarketDataManager()
+    mdm.register_symbol('NSE:NIFTY', 256265)
+    tick = mdm.normalize_live_tick({'instrument_token': 256265, 'last_price': 22450.5}, source='ws')
+    assert tick is not None
+    assert tick['symbol'] == 'NSE:NIFTY'
+    assert tick['token'] == 256265
+    assert tick['ltp'] == 22450.5
+    assert tick['source'] == 'ws'
+
+
+def test_missing_bid_ask_stays_none() -> None:
+    mdm = MarketDataManager()
+    tick = mdm.normalize_live_tick({'symbol': 'NSE:NIFTY', 'ltp': 22450.0}, source='ws')
+    assert tick is not None
+    assert tick['bid'] is None
+    assert tick['ask'] is None
+
+
+def test_ltp_non_positive_returns_none() -> None:
+    mdm = MarketDataManager()
+    assert mdm.normalize_live_tick({'symbol': 'NSE:NIFTY', 'ltp': 0}, source='ws') is None
+
+
+def test_timestamp_is_timezone_aware_utc() -> None:
+    mdm = MarketDataManager()
+    tick = mdm.normalize_live_tick({'symbol': 'NSE:NIFTY', 'ltp': 1.0, 'timestamp': '2026-01-01T10:00:00'}, source='poll')
+    assert tick is not None
+    ts = tick['timestamp']
+    assert isinstance(ts, datetime)
+    assert ts.tzinfo is not None
+    assert ts.tzinfo == timezone.utc

--- a/tests/test_no_history_fetch_in_tick_path.py
+++ b/tests/test_no_history_fetch_in_tick_path.py
@@ -1,0 +1,27 @@
+import ast
+from pathlib import Path
+
+
+FORBIDDEN = {'historical_data', 'get_ohlc', 'fetch_history'}
+TARGETS = {'on_tick', 'process_tick', '_process_queued_tick', '_emit_tick', 'on_datahub_tick', '_on_tick'}
+
+
+def _assert_no_forbidden_calls(path: Path) -> None:
+    tree = ast.parse(path.read_text())
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name in TARGETS:
+            for sub in ast.walk(node):
+                if isinstance(sub, ast.Call):
+                    fn = sub.func
+                    if isinstance(fn, ast.Attribute):
+                        name = fn.attr
+                    elif isinstance(fn, ast.Name):
+                        name = fn.id
+                    else:
+                        continue
+                    assert name not in FORBIDDEN, f'{path}:{node.name} calls {name}'
+
+
+def test_no_history_fetch_calls_in_tick_path() -> None:
+    _assert_no_forbidden_calls(Path('src/nifty_scalper_bot/data/market_data_manager.py'))
+    _assert_no_forbidden_calls(Path('src/nifty_scalper_bot/strategies/runner.py'))

--- a/tests/test_polling_fallback_policy.py
+++ b/tests/test_polling_fallback_policy.py
@@ -1,0 +1,37 @@
+from datetime import datetime, timedelta, timezone
+
+from nifty_scalper_bot.data.market_data_manager import MarketDataManager
+
+
+def test_fresh_ws_tick_should_not_poll() -> None:
+    mdm = MarketDataManager()
+    mdm._ws_connected = True
+    mdm._active_subscribed_symbols = {'NSE:NIFTY'}
+    mdm._last_tick_time['NSE:NIFTY'] = datetime.now(timezone.utc).timestamp()
+    assert mdm._should_poll_symbol('NSE:NIFTY', datetime.now(timezone.utc)) is False
+
+
+def test_stale_context_symbol_should_poll() -> None:
+    mdm = MarketDataManager()
+    mdm._ws_connected = True
+    mdm._active_subscribed_symbols = {'NSE:NIFTY'}
+    stale = datetime.now(timezone.utc) - timedelta(seconds=mdm._critical_symbol_stale_seconds + 1)
+    mdm._last_tick_time['NSE:NIFTY'] = stale.timestamp()
+    assert mdm._should_poll_symbol('NSE:NIFTY', datetime.now(timezone.utc)) is True
+
+
+def test_stale_option_symbol_should_poll() -> None:
+    mdm = MarketDataManager()
+    mdm._ws_connected = True
+    sym = 'NFO:NIFTY26MAY22500CE'
+    mdm._active_subscribed_symbols = {sym}
+    stale = datetime.now(timezone.utc) - timedelta(seconds=mdm._option_stale_seconds + 1)
+    mdm._last_tick_time[sym] = stale.timestamp()
+    assert mdm._should_poll_symbol(sym, datetime.now(timezone.utc)) is True
+
+
+def test_inactive_symbol_should_not_poll() -> None:
+    mdm = MarketDataManager()
+    mdm._ws_connected = True
+    mdm._active_subscribed_symbols = {'NSE:NIFTY'}
+    assert mdm._should_poll_symbol('NFO:NIFTY26MAY22500CE', datetime.now(timezone.utc)) is False


### PR DESCRIPTION
### Motivation
- Live tick handling used separate WS and REST paths, causing duplicated publish logic, noisy diagnostics, and polling acting like a parallel primary source.
- Polling was fetching broadly and could fetch historical data from tick paths; polling should be strictly a fallback when WS data is stale.
- WS token diagnostics were misleading (could show zero while ticks flow) and per-tick logs were too noisy for production monitoring.

### Description
- Added a canonical normalizer `normalize_live_tick(self, raw, source='ws')` that returns the single canonical tick contract (symbol, token, ltp, bid, ask, volume, oi, timezone-aware UTC timestamp, source) and returns `None` for invalid ticks.
- Introduced `_ingest_normalized_tick(self, tick)` so both WS queued processing (`_process_queued_tick`) and REST poll handler (`_poll_symbol`) route through the same cache/publish path instead of duplicating logic.
- Implemented fallback polling gating with `_should_poll_symbol(self, symbol, now)` and `_is_context_symbol`, using default thresholds of 30s for context symbols and 60s for options, and limited `_symbols_for_poll` to only candidates that actually need polling.
- Demoted repetitive per-tick INFO logs to `debug`, preserved first-tick INFO events, and added a throttled 120s `MARKET_DATA_HEALTH_SUMMARY` to surface periodic health metrics.
- Prevented historical API calls from being invoked in tick-processing functions via behavior changes and a static test guard (no `historical_data`, `get_ohlc`, `fetch_history` in tick-path functions).
- Fixed WS token diagnostic in `core/app.py` by adding `_safe_ws_token_count(ctx)` which prefers MDM subscription sets before falling back to broker attributes, and updated formatting to safely display unknown values.
- Files changed: `src/nifty_scalper_bot/data/market_data_manager.py`, `src/nifty_scalper_bot/core/app.py`, plus added tests under `tests/` for normalization, polling policy, and tick-path static checks.

### Testing
- Compiled the package with `python -m compileall src` and the compilation succeeded.
- Ran focused unit tests: `pytest tests/test_live_tick_normalization.py -q` (passed), `pytest tests/test_polling_fallback_policy.py -q` (passed), and `pytest tests/test_no_history_fetch_in_tick_path.py -q` (passed), and also `pytest tests/test_execution_path_contract.py -q` (passed). 
- Test coverage added: `tests/test_live_tick_normalization.py`, `tests/test_polling_fallback_policy.py`, and `tests/test_no_history_fetch_in_tick_path.py`, all of which passed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f788bc51948324a252d689b0b09613)