### PR TITLE
fix: harden startup WS spot readiness and logging

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -5935,6 +5935,66 @@ async def _wait_for_live_spot_or_raise(
     return _SYNTHETIC_FALLBACK_SPOT
 
 
+def _safe_startup_log(
+    logger: logging.Logger,
+    level: int,
+    event: str,
+    message: str,
+    *args: Any,
+    **extra_fields: Any,
+) -> None:
+    """Emit startup log safely. Args: logger/level/event/message/args/extra_fields. Returns: none. Raises: none."""
+    try:
+        logger.log(level, message, *args, extra={"event": event, **extra_fields})
+    except TypeError:
+        logger.exception(
+            "STARTUP_LOG_FORMAT_ERROR event=%s message=%s args_count=%s",
+            event,
+            message,
+            len(args),
+            extra={
+                "event": "STARTUP_LOG_FORMAT_ERROR",
+                "failed_event": event,
+                "message_template": message,
+                "args_count": len(args),
+            },
+        )
+
+
+async def _refresh_readiness_after_first_tick(ctx: BotContext, reason: str) -> None:
+    """Refresh readiness after startup tick proof. Args: ctx/reason. Returns: none. Raises: none."""
+    mdm = ctx.market_data_manager
+    runner = ctx.strategy_runner
+    spot_ready = False
+    if mdm is not None and hasattr(mdm, "get_fresh_spot_tick"):
+        spot_ready = mdm.get_fresh_spot_tick("NSE:NIFTY", require_ws=False) is not None
+    bus_running = bool(
+        getattr(ctx.message_bus, "running", False)
+        or getattr(ctx.message_bus, "_running", False)
+    )
+    runner_started = bool(
+        getattr(runner, "_started", False) or getattr(runner, "started", False)
+    )
+    if spot_ready and bus_running:
+        ctx.data_observation_ready = True
+        LOGGER.info(
+            "DATA_PIPELINE_READY_AFTER_TICK spot_ready=%s bus_running=%s runner_started=%s reason=%s",
+            spot_ready,
+            bus_running,
+            runner_started,
+            reason,
+            extra={"event": "DATA_PIPELINE_READY_AFTER_TICK", "spot_ready": spot_ready, "bus_running": bus_running, "runner_started": runner_started, "reason": reason},
+        )
+        return
+    LOGGER.info(
+        "DATA_PIPELINE_STILL_NOT_READY_AFTER_TICK spot_ready=%s bus_running=%s runner_started=%s reason=%s",
+        spot_ready,
+        bus_running,
+        runner_started,
+        reason,
+        extra={"event": "DATA_PIPELINE_STILL_NOT_READY_AFTER_TICK", "spot_ready": spot_ready, "bus_running": bus_running, "runner_started": runner_started, "reason": reason},
+    )
+
 
 
 def _runner_is_running(runner: Any) -> bool:
@@ -6450,23 +6510,21 @@ async def startup_sequence(ctx: BotContext) -> None:
             LOGGER.info(
                 "✅ MarketDataManager started — tick consumer active (WS deferred)"
             )
-            LOGGER.info(
+            _safe_startup_log(
+                LOGGER,
+                logging.INFO,
+                "STARTUP_WS_SPOT_FIRST_DECISION",
                 "STARTUP_WS_SPOT_FIRST_DECISION websocket_enabled=%s mdm_present=%s has_start_websocket=%s",
                 ctx.websocket_enabled,
                 ctx.market_data_manager is not None,
                 hasattr(ctx.market_data_manager, "start_websocket")
                 if ctx.market_data_manager
                 else False,
-                extra={
-                    "event": "STARTUP_WS_SPOT_FIRST_DECISION",
-                    "websocket_enabled": ctx.websocket_enabled,
-                    "mdm_present": ctx.market_data_manager is not None,
-                    "has_start_websocket": hasattr(
-                        ctx.market_data_manager, "start_websocket"
-                    )
-                    if ctx.market_data_manager
-                    else False,
-                },
+                websocket_enabled=ctx.websocket_enabled,
+                mdm_present=ctx.market_data_manager is not None,
+                has_start_websocket=hasattr(ctx.market_data_manager, "start_websocket")
+                if ctx.market_data_manager
+                else False,
             )
         except Exception as _mdm_start_exc:
             LOGGER.error("MarketDataManager.start() failed: %s", _mdm_start_exc)
@@ -6494,13 +6552,15 @@ async def startup_sequence(ctx: BotContext) -> None:
                 int(desired_token_count_fn()) if callable(desired_token_count_fn) else None
             )
             register_fn = getattr(ctx.market_data_manager, "register_symbol", None)
-            LOGGER.info(
+            _safe_startup_log(
+                LOGGER, logging.INFO, "STARTUP_SPOT_REGISTER_BEGIN",
                 "STARTUP_SPOT_REGISTER_BEGIN symbol=%s token=%d desired_token_count=%s ws_token_count=%s websocket_enabled=%s phase=spot_first",
                 policy.nifty_internal_symbol,
                 policy.nifty_spot_token,
                 desired_token_count,
                 ws_status.get("tokens"),
                 ctx.websocket_enabled,
+                symbol=policy.nifty_internal_symbol, token=policy.nifty_spot_token, desired_token_count=desired_token_count, ws_token_count=ws_status.get("tokens"), websocket_enabled=ctx.websocket_enabled, phase="spot_first",
             )
             if callable(register_fn):
                 try:
@@ -6510,24 +6570,28 @@ async def startup_sequence(ctx: BotContext) -> None:
                         "Spot symbol registration failed (will retry later)",
                         exc_info=True,
                     )
-            LOGGER.info(
+            _safe_startup_log(
+                LOGGER, logging.INFO, "STARTUP_SPOT_REGISTER_DONE",
                 "STARTUP_SPOT_REGISTER_DONE symbol=%s token=%d desired_token_count=%s ws_token_count=%s websocket_enabled=%s phase=spot_first",
                 policy.nifty_internal_symbol,
                 policy.nifty_spot_token,
                 desired_token_count,
                 ws_status.get("tokens"),
                 ctx.websocket_enabled,
+                symbol=policy.nifty_internal_symbol, token=policy.nifty_spot_token, desired_token_count=desired_token_count, ws_token_count=ws_status.get("tokens"), websocket_enabled=ctx.websocket_enabled, phase="spot_first",
             )
             subscribe_fn = getattr(
                 ctx.market_data_manager, "request_token_subscription", None
             )
-            LOGGER.info(
+            _safe_startup_log(
+                LOGGER, logging.INFO, "STARTUP_SPOT_TOKEN_REQUEST_BEGIN",
                 "STARTUP_SPOT_TOKEN_REQUEST_BEGIN symbol=%s token=%d desired_token_count=%s ws_token_count=%s websocket_enabled=%s phase=spot_first",
                 policy.nifty_internal_symbol,
                 policy.nifty_spot_token,
                 desired_token_count,
                 ws_status.get("tokens"),
                 ctx.websocket_enabled,
+                symbol=policy.nifty_internal_symbol, token=policy.nifty_spot_token, desired_token_count=desired_token_count, ws_token_count=ws_status.get("tokens"), websocket_enabled=ctx.websocket_enabled, phase="spot_first",
             )
             if callable(subscribe_fn):
                 subscribed = bool(
@@ -6549,40 +6613,64 @@ async def startup_sequence(ctx: BotContext) -> None:
             if callable(ws_token_count_fn):
                 ws_count = ws_token_count_fn()
                 ws_tokens = int(ws_count) if ws_count is not None else None
-            LOGGER.info(
+            _safe_startup_log(
+                LOGGER, logging.INFO, "STARTUP_SPOT_TOKEN_REQUEST_DONE",
                 "STARTUP_SPOT_TOKEN_REQUEST_DONE symbol=%s token=%d subscribed=%s desired_token_count=%s ws_token_count=%s websocket_enabled=%s phase=spot_first",
                 policy.nifty_internal_symbol,
                 policy.nifty_spot_token,
                 subscribed,
                 desired_tokens,
                 ws_tokens,
+                ctx.websocket_enabled,
+                symbol=policy.nifty_internal_symbol, token=policy.nifty_spot_token, subscribed=subscribed, desired_token_count=desired_tokens, ws_token_count=ws_tokens, websocket_enabled=ctx.websocket_enabled, phase="spot_first",
             )
-            LOGGER.info(
+            _safe_startup_log(
+                LOGGER, logging.INFO, "STARTUP_WS_START_BEGIN",
                 "STARTUP_WS_START_BEGIN symbol=%s token=%d desired_token_count=%s ws_token_count=%s websocket_enabled=%s phase=spot_first",
                 policy.nifty_internal_symbol,
                 policy.nifty_spot_token,
                 desired_tokens,
                 ws_tokens,
                 ctx.websocket_enabled,
+                symbol=policy.nifty_internal_symbol, token=policy.nifty_spot_token, desired_token_count=desired_tokens, ws_token_count=ws_tokens, websocket_enabled=ctx.websocket_enabled, phase="spot_first",
             )
             ctx.market_data_manager.start_websocket()
-            LOGGER.info(
+            _safe_startup_log(
+                LOGGER, logging.INFO, "STARTUP_WS_START_DONE",
                 "STARTUP_WS_START_DONE symbol=%s token=%d desired_token_count=%s ws_token_count=%s websocket_enabled=%s phase=spot_first",
                 policy.nifty_internal_symbol,
                 policy.nifty_spot_token,
                 desired_tokens,
                 ws_tokens,
                 ctx.websocket_enabled,
+                symbol=policy.nifty_internal_symbol, token=policy.nifty_spot_token, desired_token_count=desired_tokens, ws_token_count=ws_tokens, websocket_enabled=ctx.websocket_enabled, phase="spot_first",
             )
             ws_status = ws_status_fn() if callable(ws_status_fn) else {}
-            LOGGER.info(
+            _safe_startup_log(
+                LOGGER, logging.INFO, "STARTUP_WS_CONNECT_TASK_CREATED",
                 "STARTUP_WS_CONNECT_TASK_CREATED symbol=%s token=%d desired_token_count=%s ws_token_count=%s websocket_enabled=%s phase=spot_first",
                 policy.nifty_internal_symbol,
                 policy.nifty_spot_token,
                 desired_tokens,
                 ws_status.get("tokens"),
                 ctx.websocket_enabled,
+                symbol=policy.nifty_internal_symbol, token=policy.nifty_spot_token, desired_token_count=desired_tokens, ws_token_count=ws_status.get("tokens"), websocket_enabled=ctx.websocket_enabled, phase="spot_first",
             )
+            spot_wait_seconds = float(os.getenv("STARTUP_WAIT_FOR_WS_SPOT_SECONDS", "8"))
+            mode = str(getattr(ctx, "effective_mode", None) or os.getenv("EXECUTION_MODE", "PAPER")).upper()
+            live_mode = mode == "LIVE" or str(os.getenv("ENABLE_LIVE", "false")).lower() in {"1", "true", "yes", "on"}
+            try:
+                spot_price = await _wait_for_live_spot_or_raise(ctx, timeout=spot_wait_seconds, configured_mode=mode)
+                LOGGER.info("STARTUP_WS_SPOT_PROOF_READY symbol=%s price=%.2f mode=%s", policy.nifty_internal_symbol, spot_price, mode, extra={"event": "STARTUP_WS_SPOT_PROOF_READY", "symbol": policy.nifty_internal_symbol, "price": spot_price, "mode": mode})
+                await _refresh_readiness_after_first_tick(ctx, reason="ws_spot_proof_ready")
+            except RuntimeError as exc:
+                if live_mode:
+                    ctx.live_orders_armed = False
+                    ctx.trading_ready = False
+                    ctx.live_block_reason = "fresh_spot_tick_missing"
+                    LOGGER.error("STARTUP_WS_SPOT_PROOF_BLOCKED_LIVE symbol=%s reason=%s", policy.nifty_internal_symbol, exc, extra={"event": "STARTUP_WS_SPOT_PROOF_BLOCKED_LIVE", "symbol": policy.nifty_internal_symbol, "reason": str(exc)})
+                    raise
+                LOGGER.warning("STARTUP_WS_SPOT_PROOF_TIMEOUT_NONLIVE symbol=%s mode=%s reason=%s", policy.nifty_internal_symbol, mode, exc, extra={"event": "STARTUP_WS_SPOT_PROOF_TIMEOUT_NONLIVE", "symbol": policy.nifty_internal_symbol, "mode": mode, "reason": str(exc)})
         except Exception as _ws_spot_first_exc:  # noqa: BLE001
             LOGGER.warning(
                 "STARTUP_WS_SPOT_FIRST_FAILED symbol=%s token=%d websocket_enabled=%s err=%s",
@@ -7145,12 +7233,15 @@ async def startup_sequence(ctx: BotContext) -> None:
                 _wire_and_start_message_bus(ctx)
                 await _ensure_strategy_runner_started(ctx, reason="startup_mark_ready_complete")
                 await _replay_latest_mdm_ticks_to_bus(ctx, reason="post_runner_start")
+                await _refresh_readiness_after_first_tick(ctx, reason="post_runner_start")
                 ctx.data_observation_ready = True
                 if mode in {"PAPER", "SHADOW"}:
                     ctx.live_orders_armed = False
                     ctx.trading_ready = False
-                    ctx.live_block_reason = "paper_mode"
+                    ctx.live_block_reason = "paper_mode_or_startup_warmup"
                     LOGGER.info("PAPER_RUNNER_STARTED symbol_count=%d live_orders_armed=%s", len(readiness_symbols), False, extra={"event":"PAPER_RUNNER_STARTED","symbol_count":len(readiness_symbols),"live_orders_armed":False,"mode":mode})
+                    if not ready_symbols:
+                        LOGGER.info("PAPER_RUNNER_STARTED_OBSERVATION_ONLY reason=no_hydrated_symbols_yet", extra={"event": "PAPER_RUNNER_STARTED_OBSERVATION_ONLY", "reason": "no_hydrated_symbols_yet"})
                     LOGGER.info(
                         "RUNNER_READY_MARKED symbol_count=%d initial_ready_symbols=%s skipped_symbols=%s skipped_reasons=%s min_required_bars=%d",
                         len(readiness_symbols),
@@ -7436,14 +7527,16 @@ async def startup_sequence(ctx: BotContext) -> None:
                 deferred_flush_count = int(
                     ctx.data_hub.flush_pending_live_subscriptions()
                 )
-                LOGGER.info(
-                    "startup_deferred_listener_subscriptions_flushed count=%d",
-                    deferred_flush_count,
-                    extra={
-                        "event": "startup_deferred_listener_subscriptions_flushed",
-                        "count": deferred_flush_count,
-                    },
-                )
+                if deferred_flush_count:
+                    LOGGER.info(
+                        "DATAHUB_DEFERRED_SUBSCRIPTIONS_RECHECK count=%d phase=post_runner_start",
+                        deferred_flush_count,
+                        extra={
+                            "event": "DATAHUB_DEFERRED_SUBSCRIPTIONS_RECHECK",
+                            "count": deferred_flush_count,
+                            "phase": "post_runner_start",
+                        },
+                    )
             if ctx.market_data_manager is not None:
                 last_tick_map = getattr(ctx.market_data_manager, "_last_tick_time", {}) or {}
                 live_tick_seen_count = sum(
@@ -8199,6 +8292,7 @@ async def startup_sequence(ctx: BotContext) -> None:
                                     },
                                 )
                             else:
+                                non_live_mode = configured_mode in {"PAPER", "SHADOW"}
                                 LOGGER.info(
                                     "DATA_PIPELINE_NOT_READY hard_ready=%s spot_ready=%s missing=%s",
                                     hard_ready,
@@ -8211,18 +8305,29 @@ async def startup_sequence(ctx: BotContext) -> None:
                                         "missing": missing_hard,
                                     },
                                 )
-                                LOGGER.error(
-                                    "startup_pipeline_incomplete missing=%s",
-                                    ",".join(missing_hard) if missing_hard else "unknown",
-                                    extra={
-                                        "event": "startup_pipeline_incomplete",
-                                        "hard_ready": hard_ready,
-                                        "spot_ready": spot_ready,
-                                        "timed_out": not readiness_ready,
-                                        "missing": missing_hard,
-                                        "ws_connected": ws_connected,
-                                    },
-                                )
+                                if non_live_mode and _runner_is_running(ctx.strategy_runner):
+                                    ctx.data_observation_ready = True
+                                    ctx.live_orders_armed = False
+                                    ctx.trading_ready = False
+                                    ctx.live_block_reason = "paper_mode_or_startup_warmup"
+                                    LOGGER.warning(
+                                        "startup_pipeline_warmup_nonlive missing=%s",
+                                        ",".join(missing_hard) if missing_hard else "unknown",
+                                        extra={"event": "startup_pipeline_warmup_nonlive", "hard_ready": hard_ready, "spot_ready": spot_ready, "timed_out": not readiness_ready, "missing": missing_hard, "ws_connected": ws_connected},
+                                    )
+                                else:
+                                    LOGGER.error(
+                                        "startup_pipeline_incomplete missing=%s",
+                                        ",".join(missing_hard) if missing_hard else "unknown",
+                                        extra={
+                                            "event": "startup_pipeline_incomplete",
+                                            "hard_ready": hard_ready,
+                                            "spot_ready": spot_ready,
+                                            "timed_out": not readiness_ready,
+                                            "missing": missing_hard,
+                                            "ws_connected": ws_connected,
+                                        },
+                                    )
                             live_mode = configured_mode == "LIVE" or (
                                 str(os.getenv("ENABLE_LIVE", "false"))
                                 .strip()

--- a/src/nifty_scalper_bot/core/message_bus.py
+++ b/src/nifty_scalper_bot/core/message_bus.py
@@ -68,6 +68,7 @@ class MessageBus:
             msg_type: set() for msg_type in MessageType
         }
         self._dropped_counts: dict[MessageType, int] = defaultdict(int)
+        self._first_tick_delivered_symbols: set[str] = set()
         LOGGER.info(
             "MessageBus initialized with max_queue_size=%s", self._max_queue_size
         )
@@ -160,6 +161,18 @@ class MessageBus:
                             extra={"event": "message_bus_handler_dispatch_error"},
                             exc_info=exc,
                         )
+                    if message_type == MessageType.TICK:
+                        symbol = str((message.data or {}).get("symbol") or "")
+                        if symbol and symbol not in self._first_tick_delivered_symbols:
+                            self._first_tick_delivered_symbols.add(symbol)
+                            LOGGER.info(
+                                "MESSAGE_BUS_TICK_DELIVERED_TO_DATAHUB symbol=%s",
+                                symbol,
+                                extra={
+                                    "event": "MESSAGE_BUS_TICK_DELIVERED_TO_DATAHUB",
+                                    "symbol": symbol,
+                                },
+                            )
 
                 queue.task_done()
 

--- a/src/nifty_scalper_bot/data/data_hub.py
+++ b/src/nifty_scalper_bot/data/data_hub.py
@@ -808,7 +808,21 @@ class DataHub:
             tick = self._canonicalize_tick_payload(payload)
             if tick is None:
                 return
+            symbol = str(tick.get("symbol") or "")
+            first_seen_bus = False
+            if symbol:
+                if not hasattr(self, "_first_bus_ingested_symbols"):
+                    self._first_bus_ingested_symbols = set()
+                first_seen_bus = symbol not in self._first_bus_ingested_symbols
+                if first_seen_bus:
+                    self._first_bus_ingested_symbols.add(symbol)
             self._ingest_tick_impl(tick)
+            if first_seen_bus:
+                LOGGER.info(
+                    "DATAHUB_TICK_INGESTED_FROM_BUS symbol=%s",
+                    symbol,
+                    extra={"event": "DATAHUB_TICK_INGESTED_FROM_BUS", "symbol": symbol},
+                )
         except Exception as exc:
             LOGGER.exception("DATAHUB_TICK_INGEST_FAILED error=%r", exc, extra=to_json_safe({"event": "DATAHUB_TICK_INGEST_FAILED", "error": repr(exc)}))
 

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -973,6 +973,25 @@ class MarketDataManager:
                 },
             )
             self._ws.start()
+            post_status = self.ws_status_snapshot()
+            self._ws_connect_task_started = bool(post_status.get("connect_task_alive"))
+            self._ws_connected = bool(post_status.get("connected"))
+            if not self._ws_connected:
+                self._logger.info(
+                    "MDM_WS_START_PENDING_CONNECTION connect_task_alive=%s desired_token_count=%s ws_token_count=%s",
+                    self._ws_connect_task_started,
+                    len(self._desired_tokens),
+                    post_status.get("tokens"),
+                    extra={"event": "MDM_WS_START_PENDING_CONNECTION", "connect_task_alive": self._ws_connect_task_started, "desired_token_count": len(self._desired_tokens), "ws_token_count": post_status.get("tokens")},
+                )
+            if not self._ws_connect_task_started and not self._ws_connected:
+                self._ws_start_requested = False
+                self._logger.warning(
+                    "MDM_WS_START_NO_CONNECT_TASK desired_token_count=%s ws_token_count=%s",
+                    len(self._desired_tokens),
+                    post_status.get("tokens"),
+                    extra={"event": "MDM_WS_START_NO_CONNECT_TASK", "desired_token_count": len(self._desired_tokens), "ws_token_count": post_status.get("tokens")},
+                )
         except Exception:
             self._ws_start_requested = False
             self._logger.exception("Failure in ws.start")
@@ -1012,11 +1031,9 @@ class MarketDataManager:
         """Record WebSocket connectivity state for health reporting."""
 
         self._ws_connected = bool(connected)
-        self._ws_connected = bool(connected)
         self._ws_connect_task_started = bool(
             self.ws_status_snapshot().get("connect_task_alive")
         )
-        self._ws_connected = bool(connected)
         self._ws_started = bool(connected)
         if not connected and not self._ws_connect_task_started:
             self._ws_start_requested = False
@@ -6869,10 +6886,11 @@ class MarketDataManager:
             log_throttled(
                 self._logger,
                 key="spot_ws_first_tick_missing",
-                msg="MDM_WS_FIRST_TICK_MISSING symbol=NSE:NIFTY reason=no_tick_received",
+                msg="MDM_WS_FIRST_TICK_MISSING symbol=%s reason=no_tick_received connected=%s connect_task_alive=%s ws_tokens=%s",
+                args=(symbol, self.ws_status_snapshot().get("connected"), self.ws_status_snapshot().get("connect_task_alive"), self.ws_status_snapshot().get("tokens")),
                 interval_sec=60.0,
                 level=logging.WARNING,
-                extra={"event": "MDM_WS_FIRST_TICK_MISSING", "symbol": symbol, "reason": "no_tick_received"},
+                extra={"event": "MDM_WS_FIRST_TICK_MISSING", "symbol": symbol, "reason": "no_tick_received", "connected": self.ws_status_snapshot().get("connected"), "connect_task_alive": self.ws_status_snapshot().get("connect_task_alive"), "ws_tokens": self.ws_status_snapshot().get("tokens")},
             )
             self._request_spot_resubscribe_if_due(symbol, reason="first_tick_missing")
             return

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -4253,6 +4253,17 @@ class StrategyRunner:
             except Exception:  # pragma: no cover - defensive
                 pass
             self._last_tick_time_by_symbol[normalized_symbol] = time.time()
+            if not hasattr(self, "_first_tick_ingested_symbols"):
+                self._first_tick_ingested_symbols = set()
+            if normalized_symbol not in self._first_tick_ingested_symbols:
+                self._first_tick_ingested_symbols.add(normalized_symbol)
+                history_count = len(self._indicator_engine.get_history(normalized_symbol) or [])
+                self._logger.info(
+                    "RUNNER_TICK_INGESTED symbol=%s history_count=%d",
+                    normalized_symbol,
+                    history_count,
+                    extra={"event": "RUNNER_TICK_INGESTED", "symbol": normalized_symbol, "history_count": history_count},
+                )
             engine = self._candle_engines.setdefault(normalized_symbol, CandleEngine())
             with self._symbol_locks[normalized_symbol]:
                 engine.on_tick(tick)

--- a/tests/test_bus_to_runner_tick_path.py
+++ b/tests/test_bus_to_runner_tick_path.py
@@ -1,0 +1,22 @@
+import asyncio
+from datetime import datetime
+from nifty_scalper_bot.core.message_bus import MessageBus, Message, MessageType
+from nifty_scalper_bot.data.data_hub import DataHub
+
+
+async def _noop_runner_tick(_: dict):
+    return None
+
+
+def test_bus_to_datahub_tick_path_logs(caplog):
+    async def run():
+        bus = MessageBus()
+        hub = DataHub(market_data=None, bus=bus)
+        bus.subscribe_once(MessageType.TICK, hub.ingest_tick_from_bus, subscriber_id='data_hub.ingest_tick_from_bus')
+        bus.start()
+        await bus.publish(Message(type=MessageType.TICK, timestamp=datetime.utcnow(), data={"symbol":"NSE:NIFTY","last_price":24000.0}, source='test'))
+        await asyncio.sleep(0.05)
+        await bus.stop()
+    asyncio.run(run())
+    assert 'MESSAGE_BUS_TICK_DELIVERED_TO_DATAHUB' in caplog.text
+    assert 'DATAHUB_TICK_INGESTED_FROM_BUS' in caplog.text

--- a/tests/test_logging_format_safety.py
+++ b/tests/test_logging_format_safety.py
@@ -1,0 +1,21 @@
+import logging
+from nifty_scalper_bot.core.app import _safe_startup_log
+
+
+def test_safe_startup_log_handles_expected_args(caplog):
+    logger = logging.getLogger("test.startup.log")
+    with caplog.at_level(logging.INFO):
+        _safe_startup_log(
+            logger,
+            logging.INFO,
+            "STARTUP_SPOT_TOKEN_REQUEST_DONE",
+            "STARTUP_SPOT_TOKEN_REQUEST_DONE symbol=%s token=%d subscribed=%s desired_token_count=%s ws_token_count=%s websocket_enabled=%s phase=spot_first",
+            "NSE:NIFTY",
+            256265,
+            True,
+            5,
+            2,
+            True,
+        )
+    assert "STARTUP_SPOT_TOKEN_REQUEST_DONE" in caplog.text
+    assert "STARTUP_LOG_FORMAT_ERROR" not in caplog.text

--- a/tests/test_mdm_start_websocket_pending_connection.py
+++ b/tests/test_mdm_start_websocket_pending_connection.py
@@ -1,0 +1,19 @@
+from types import SimpleNamespace
+from nifty_scalper_bot.data.market_data_manager import MarketDataManager
+
+
+def test_start_websocket_pending_connection_logs(caplog):
+    mdm = MarketDataManager.__new__(MarketDataManager)
+    mdm._ws = SimpleNamespace(start=lambda: None)
+    mdm._desired_tokens = {1, 2}
+    mdm._ws_start_requested = False
+    mdm._ws_connect_task_started = False
+    mdm._ws_connected = False
+    mdm._logger = __import__('logging').getLogger('test.mdm')
+    mdm._reconcile_ws_subscriptions = lambda: None
+    mdm.ws_status_snapshot = lambda: {"connect_task_alive": True, "connected": False, "tokens": 1}
+    with caplog.at_level('INFO'):
+        MarketDataManager.start_websocket(mdm)
+    assert mdm._ws_start_requested is True
+    assert mdm._ws_connected is False
+    assert "MDM_WS_START_PENDING_CONNECTION" in caplog.text

--- a/tests/test_startup_ws_spot_first_logging.py
+++ b/tests/test_startup_ws_spot_first_logging.py
@@ -1,0 +1,16 @@
+import logging
+from nifty_scalper_bot.core.app import _safe_startup_log
+
+
+def test_startup_spot_first_cluster_logging(caplog):
+    logger = logging.getLogger('test.startup.cluster')
+    events = [
+        'STARTUP_WS_SPOT_FIRST_DECISION','STARTUP_SPOT_REGISTER_BEGIN','STARTUP_SPOT_REGISTER_DONE',
+        'STARTUP_SPOT_TOKEN_REQUEST_BEGIN','STARTUP_SPOT_TOKEN_REQUEST_DONE','STARTUP_WS_START_BEGIN',
+        'STARTUP_WS_START_DONE','STARTUP_WS_CONNECT_TASK_CREATED',
+    ]
+    with caplog.at_level(logging.INFO):
+        for ev in events:
+            _safe_startup_log(logger, logging.INFO, ev, f"{ev} symbol=%s", "NSE:NIFTY")
+    for ev in events:
+        assert ev in caplog.text


### PR DESCRIPTION
### Motivation

- Startup hit a `TypeError: not enough arguments for format string` from mismatched logger placeholders during WS spot-first startup logging, which interrupted observability.
- The bot treated delayed but healthy WebSocket first ticks as a permanent DATA_PIPELINE_NOT_READY failure, causing PAPER/SHADOW starts to be needlessly blocked from observation mode.
- `MarketDataManager.start_websocket()` implied connection proof too early and `set_ws_connected()` contained duplicate assignments, leading to misleading diagnostics.
- Need minimal, targeted fixes to make startup resilient while preserving LIVE safety (no synthetic spot in LIVE), without architectural changes or new dependencies.

### Description

- Added a safe startup logging helper `
_safe_startup_log(logger, level, event, message, *args, **extra_fields)`
` in `src/nifty_scalper_bot/core/app.py` and replaced the WS spot-first log cluster with calls to this helper to prevent future format-string crashes.  
- Fixed the `STARTUP_SPOT_TOKEN_REQUEST_DONE` call by supplying the missing `ctx.websocket_enabled` argument and emitting structured `extra` metadata.  
- After `ctx.market_data_manager.start_websocket()` the startup flow now waits a short, mode-aware proof (`_wait_for_live_spot_or_raise`) for a fresh WS NIFTY tick; in LIVE this blocks arming and raises on failure, and in PAPER/SHADOW it logs and continues in observation mode.  
- Added `_refresh_readiness_after_first_tick(ctx, reason)` and invoke it after `post_runner_start` replay and after successful WS spot-proof so delayed first ticks can flip readiness without a permanent failure.  
- Adjusted DATA_PIPELINE_NOT_READY semantics in `startup_sequence` so non-live modes treat missing readiness as a warm-up (set `ctx.data_observation_ready=True`, keep live orders disarmed) instead of a fatal state when the runner is active.  
- In `src/nifty_scalper_bot/data/market_data_manager.py`: updated `start_websocket()` to inspect `ws_status_snapshot()` after `ws.start()` and emit `MDM_WS_START_PENDING_CONNECTION` / `MDM_WS_START_NO_CONNECT_TASK` diagnostics rather than implying connection; deduplicated assignments in `set_ws_connected()`; enriched `_monitor_spot_ws_health()` logging with connection status fields.  
- Added lightweight first-hop observability (first-per-symbol only) in the tick path: `MESSAGE_BUS_TICK_DELIVERED_TO_DATAHUB` in `MessageBus`, `DATAHUB_TICK_INGESTED_FROM_BUS` in `DataHub.ingest_tick_from_bus`, and `RUNNER_TICK_INGESTED` in `StrategyRunner` to prove end-to-end tick flow without spamming.  
- Made the deferred DataHub flush recheck post-runner-start idempotent and only log `DATAHUB_DEFERRED_SUBSCRIPTIONS_RECHECK` when a non-zero count exists.  
- Added focused unit tests: logging-format safety, WS-start pending connection diagnostics, the WS spot-first logging cluster, and bus→datahub tick path diagnostics (new tests under `tests/`).

Files touched (key): `src/nifty_scalper_bot/core/app.py`, `src/nifty_scalper_bot/data/market_data_manager.py`, `src/nifty_scalper_bot/core/message_bus.py`, `src/nifty_scalper_bot/data/data_hub.py`, `src/nifty_scalper_bot/strategies/runner.py`, and new tests in `tests/`.

### Testing

- Built/compiled Python sources with `python -m compileall -q src tests` and ran focused pytest slices with: `pytest -q tests/test_logging_format_safety.py tests/test_startup_ws_spot_first_logging.py tests/test_mdm_start_websocket_pending_connection.py tests/test_bus_to_runner_tick_path.py tests/test_market_data_policy.py tests/test_mdm_ws_token_preservation.py tests/test_datahub_deferred_subscribe_no_pull.py`.  
- All invoked tests passed (dot output and pytest summary showed successful runs for the listed tests).  
- The fix specifically eliminates the startup `TypeError` and allows PAPER/SHADOW startup to continue to observation mode while preserving LIVE safety (live arming blocked when fresh WS spot proof is absent).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f86ba3b3cc8324bce559c80e2ffde9)