### PR TITLE
fix: preserve Railway env vars when loading dotenv

### DIFF
--- a/src/nifty_scalper_bot/main.py
+++ b/src/nifty_scalper_bot/main.py
@@ -54,7 +54,12 @@ def _load_env_file() -> None:
     for env_path in search_paths:
         if env_path.exists() and env_path.is_file():
             print(f"✅ ENV FILE FOUND: {env_path}", flush=True)
-            load_dotenv(dotenv_path=str(env_path), override=True)
+            is_railway = bool(
+                os.getenv("RAILWAY_ENVIRONMENT")
+                or os.getenv("RAILWAY_PROJECT_ID")
+                or os.getenv("RAILWAY_SERVICE_ID")
+            )
+            load_dotenv(dotenv_path=str(env_path), override=not is_railway)
             env_loaded = True
 
             enable_live = os.getenv("ENABLE_LIVE", "NOT_SET")


### PR DESCRIPTION
### Motivation
- Prevent a checked-in or mounted `.env` from clobbering platform-provided environment variables when running on Railway so runtime secrets and mode flags remain authoritative.

### Description
- Update `_load_env_file()` in `src/nifty_scalper_bot/main.py` to detect Railway via `RAILWAY_ENVIRONMENT`, `RAILWAY_PROJECT_ID`, or `RAILWAY_SERVICE_ID` and call `load_dotenv(..., override=not is_railway)` so `.env` is not used to override Railway envs while keeping the previous `override=True` behavior for local development.

### Testing
- Executed `./run_checks.sh` (permission denied in this environment) and then `bash ./run_checks.sh`, which installed dependencies but the checks exited non‑zero because `ruff`, `mypy`, and `pytest` were reported missing and `pytest` was not run successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f872070d048324af8476c560d391b5)