### PR TITLE
fix: derive live env defaults from minimal railway vars

### DIFF
--- a/src/nifty_scalper_bot/config/env_utils.py
+++ b/src/nifty_scalper_bot/config/env_utils.py
@@ -1,0 +1,49 @@
+"""Environment normalization helpers for live/paper defaults."""
+
+from __future__ import annotations
+
+import os
+
+
+def truthy(value: str | None) -> bool:
+    """Parse truthy env flags. Args: value. Returns: bool. Raises: none."""
+    if value is None:
+        return False
+    return value.strip().lower() in {'1', 'true', 'yes', 'on'}
+
+
+def setdefault_env(key: str, value: str) -> None:
+    """Set env key only when missing. Args: key, value. Returns: None. Raises: none."""
+    if os.getenv(key) is None:
+        os.environ[key] = value
+
+
+def normalise_live_env_defaults() -> None:
+    """Derive live/paper env defaults. Args: none. Returns: None. Raises: none."""
+    enable_live = truthy(os.getenv('ENABLE_LIVE'))
+    execution_mode = (os.getenv('EXECUTION_MODE') or '').strip().upper()
+    live_requested = enable_live or execution_mode == 'LIVE'
+
+    if live_requested:
+        defaults = {
+            'ENABLE_LIVE': 'true',
+            'ENABLE_LIVE_TRADING': 'true',
+            'EXECUTION_MODE': 'LIVE',
+            'ORDERS__ENABLE_LIVE': 'true',
+            'PAPER__ENABLED': 'false',
+            'PAPER_MODE': 'false',
+            'SHADOW_MODE': 'false',
+        }
+    else:
+        defaults = {
+            'ENABLE_LIVE': 'false',
+            'ENABLE_LIVE_TRADING': 'false',
+            'EXECUTION_MODE': 'PAPER',
+            'ORDERS__ENABLE_LIVE': 'false',
+            'PAPER__ENABLED': 'true',
+            'PAPER_MODE': 'true',
+            'SHADOW_MODE': 'true',
+        }
+
+    for key, value in defaults.items():
+        setdefault_env(key, value)

--- a/src/nifty_scalper_bot/config/settings.py
+++ b/src/nifty_scalper_bot/config/settings.py
@@ -30,6 +30,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 from nifty_scalper_bot.analytics.regime_gate import RegimeGateConfig
 from nifty_scalper_bot.config.base import AppConfig
 from nifty_scalper_bot.config.env import load_from_env
+from nifty_scalper_bot.config.env_utils import normalise_live_env_defaults
 from nifty_scalper_bot.config.env_aliases import resolve_env
 from nifty_scalper_bot.execution.lifecycle_validator import (
     LifecycleConfigError,
@@ -84,6 +85,7 @@ def _ensure_env_loaded_before_settings() -> None:
         try:
             if env_path.exists() and env_path.is_file():
                 load_dotenv(dotenv_path=str(env_path), override=False)
+                normalise_live_env_defaults()
                 enable_live = os.getenv("ENABLE_LIVE", "NOT_SET")
                 print(f"✅ [SETTINGS] Loaded .env from {env_path}", flush=True)
                 print(f"   ENABLE_LIVE={enable_live}", flush=True)
@@ -95,6 +97,8 @@ def _ensure_env_loaded_before_settings() -> None:
     # Fallback
     load_dotenv(override=False)
     print("⚠️ [SETTINGS] No .env found, using system environment", flush=True)
+
+    normalise_live_env_defaults()
 
 
 # ✅ EXECUTE IMMEDIATELY when settings.py is imported

--- a/src/nifty_scalper_bot/main.py
+++ b/src/nifty_scalper_bot/main.py
@@ -19,6 +19,7 @@ from dotenv import load_dotenv
 from fastapi import FastAPI, HTTPException
 from fastapi.responses import PlainTextResponse
 
+from nifty_scalper_bot.config.env_utils import normalise_live_env_defaults
 from nifty_scalper_bot.config.paths import get_data_dir
 from nifty_scalper_bot.utils.async_helpers import safe_task
 from nifty_scalper_bot.utils.metrics import ensure_multiproc_dir
@@ -45,6 +46,8 @@ def _load_env_file() -> None:
             load_dotenv(dotenv_path=str(env_path), override=False)
             loaded_from = env_path
             break
+
+    normalise_live_env_defaults()
 
     if loaded_from is not None:
         print(f"✅ ENV FILE FOUND (defaults only): {loaded_from}", flush=True)

--- a/tests/test_env_normalisation.py
+++ b/tests/test_env_normalisation.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import os
+
+from nifty_scalper_bot.config.env_utils import normalise_live_env_defaults
+
+
+DERIVED_KEYS = (
+    'ENABLE_LIVE',
+    'ENABLE_LIVE_TRADING',
+    'EXECUTION_MODE',
+    'ORDERS__ENABLE_LIVE',
+    'PAPER__ENABLED',
+    'PAPER_MODE',
+    'SHADOW_MODE',
+)
+
+
+def _clear_derived(monkeypatch) -> None:
+    for key in DERIVED_KEYS:
+        monkeypatch.delenv(key, raising=False)
+
+
+def test_minimal_railway_live_env_derives_flags(monkeypatch) -> None:
+    _clear_derived(monkeypatch)
+    monkeypatch.setenv('ENABLE_LIVE', 'true')
+    monkeypatch.setenv('EXECUTION_MODE', 'LIVE')
+
+    normalise_live_env_defaults()
+
+    assert os.getenv('ENABLE_LIVE_TRADING') == 'true'
+    assert os.getenv('ORDERS__ENABLE_LIVE') == 'true'
+    assert os.getenv('PAPER__ENABLED') == 'false'
+    assert os.getenv('PAPER_MODE') == 'false'
+    assert os.getenv('SHADOW_MODE') == 'false'
+
+
+def test_execution_mode_live_alone_derives_enable_live(monkeypatch) -> None:
+    _clear_derived(monkeypatch)
+    monkeypatch.setenv('EXECUTION_MODE', 'LIVE')
+
+    normalise_live_env_defaults()
+
+    assert os.getenv('ENABLE_LIVE') == 'true'
+    assert os.getenv('ENABLE_LIVE_TRADING') == 'true'
+    assert os.getenv('ORDERS__ENABLE_LIVE') == 'true'
+    assert os.getenv('PAPER__ENABLED') == 'false'
+    assert os.getenv('PAPER_MODE') == 'false'
+    assert os.getenv('SHADOW_MODE') == 'false'
+
+
+def test_paper_defaults_when_no_live_requested(monkeypatch) -> None:
+    _clear_derived(monkeypatch)
+
+    normalise_live_env_defaults()
+
+    assert os.getenv('ENABLE_LIVE') == 'false'
+    assert os.getenv('ENABLE_LIVE_TRADING') == 'false'
+    assert os.getenv('EXECUTION_MODE') == 'PAPER'
+    assert os.getenv('ORDERS__ENABLE_LIVE') == 'false'
+    assert os.getenv('PAPER__ENABLED') == 'true'
+    assert os.getenv('PAPER_MODE') == 'true'
+    assert os.getenv('SHADOW_MODE') == 'true'
+
+
+def test_explicit_railway_override_preserved(monkeypatch) -> None:
+    _clear_derived(monkeypatch)
+    monkeypatch.setenv('ENABLE_LIVE', 'true')
+    monkeypatch.setenv('EXECUTION_MODE', 'LIVE')
+    monkeypatch.setenv('PAPER_MODE', 'true')
+
+    normalise_live_env_defaults()
+
+    assert os.getenv('PAPER_MODE') == 'true'


### PR DESCRIPTION
### Motivation
- Railway deployments should require only a minimal set of variables while all secondary live/paper flags are deterministically derived from them.
- .env files must provide defaults only and must never override system/Railway envs.
- Preserve any explicit Railway-provided flag values and avoid changing behavior unless missing.

### Description
- Added `src/nifty_scalper_bot/config/env_utils.py` with `truthy(value)`, `setdefault_env(key, value)` and `normalise_live_env_defaults()` which sets secondary live/paper flags using setdefault semantics so explicit envs are preserved.
- Wired `normalise_live_env_defaults()` to run immediately after `.env` defaults are loaded (`load_dotenv(..., override=False)`) in both `src/nifty_scalper_bot/main.py` and `src/nifty_scalper_bot/config/settings.py` so derived flags are available at startup and import time.
- Ensured startup prints the effective env keys requested (`ENABLE_LIVE`, `ENABLE_LIVE_TRADING`, `EXECUTION_MODE`, `ORDERS__ENABLE_LIVE`, `PAPER__ENABLED`, `PAPER_MODE`, `SHADOW_MODE`, `DATA_DIR`, `PORT`).
- Added `tests/test_env_normalisation.py` with targeted tests verifying live derivation, EXECUTION_MODE-only derivation, paper defaults, and that explicit Railway overrides are preserved.

### Testing
- Ran `python -m compileall -q src tests` and compilation succeeded.
- Ran `pytest -q tests/test_env_normalisation.py` and the new normalization tests passed (all green).
- Ran `pytest -q tests/test_env_precedence.py` to verify dotenv precedence behavior and it passed (green).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8baec55a483248a073db46ee16584)