### PR TITLE
fix: start strategy runner after first tick readiness

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -6000,10 +6000,50 @@ async def _refresh_readiness_after_first_tick(ctx: BotContext, reason: str) -> N
         or getattr(ctx.message_bus, "_running", False)
     )
     runner_started = bool(
-        getattr(runner, "_started", False) or getattr(runner, "started", False)
+        getattr(runner, "_started", False)
+        or getattr(runner, "started", False)
+        or getattr(ctx, "strategy_runner_task", None)
     )
     if spot_ready and bus_running:
         ctx.data_observation_ready = True
+        if runner is not None and not runner_started:
+            ensure_runner_started = globals().get("_ensure_strategy_runner_started")
+            if ensure_runner_started is None:
+                LOGGER.warning(
+                    "STRATEGY_RUNNER_START_HELPER_MISSING reason=%s",
+                    reason,
+                    extra={
+                        "event": "STRATEGY_RUNNER_START_HELPER_MISSING",
+                        "reason": reason,
+                    },
+                )
+            else:
+                LOGGER.info(
+                    "STRATEGY_RUNNER_START_REQUESTED_AFTER_TICK reason=%s",
+                    reason,
+                    extra={
+                        "event": "STRATEGY_RUNNER_START_REQUESTED_AFTER_TICK",
+                        "reason": reason,
+                    },
+                )
+                try:
+                    await ensure_runner_started(
+                        ctx, reason=f"{reason}:data_pipeline_ready_after_tick"
+                    )
+                except Exception:
+                    LOGGER.exception(
+                        "STRATEGY_RUNNER_START_AFTER_TICK_FAILED reason=%s",
+                        reason,
+                        extra={
+                            "event": "STRATEGY_RUNNER_START_AFTER_TICK_FAILED",
+                            "reason": reason,
+                        },
+                    )
+                runner_started = bool(
+                    getattr(runner, "_started", False)
+                    or getattr(runner, "started", False)
+                    or getattr(ctx, "strategy_runner_task", None)
+                )
         LOGGER.info(
             "DATA_PIPELINE_READY_AFTER_TICK spot_ready=%s bus_running=%s runner_started=%s reason=%s",
             spot_ready,

--- a/tests/test_runner_start_after_first_spot_tick.py
+++ b/tests/test_runner_start_after_first_spot_tick.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from nifty_scalper_bot.core import app
+
+
+class _MdmStub:
+    def get_fresh_spot_tick(self, symbol: str, require_ws: bool = False) -> dict[str, Any] | None:
+        return {'symbol': symbol, 'last_price': 25000.0}
+
+
+@pytest.mark.asyncio
+async def test_refresh_readiness_starts_runner_after_first_tick(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    started_reasons: list[str] = []
+
+    async def _fake_ensure_strategy_runner_started(ctx: Any, *, reason: str) -> None:
+        started_reasons.append(reason)
+        ctx.strategy_runner.started = True
+
+    monkeypatch.setattr(app, '_ensure_strategy_runner_started', _fake_ensure_strategy_runner_started)
+
+    ctx = SimpleNamespace(
+        market_data_manager=_MdmStub(),
+        strategy_runner=SimpleNamespace(_started=False, started=False),
+        message_bus=SimpleNamespace(running=True),
+        strategy_runner_task=None,
+        data_observation_ready=False,
+        live_orders_armed=False,
+    )
+
+    caplog.set_level('INFO', logger='nifty_scalper_bot.core.app')
+    await app._refresh_readiness_after_first_tick(ctx, reason='first_spot_tick_listener')
+
+    assert started_reasons == ['first_spot_tick_listener:data_pipeline_ready_after_tick']
+    assert 'STRATEGY_RUNNER_START_REQUESTED_AFTER_TICK' in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_refresh_readiness_does_not_arm_live_orders() -> None:
+    ctx = SimpleNamespace(
+        market_data_manager=_MdmStub(),
+        strategy_runner=SimpleNamespace(_started=True, started=True),
+        message_bus=SimpleNamespace(running=True),
+        strategy_runner_task=None,
+        data_observation_ready=False,
+        live_orders_armed=False,
+    )
+
+    await app._refresh_readiness_after_first_tick(ctx, reason='first_spot_tick_listener')
+
+    assert ctx.live_orders_armed is False
+
+
+@pytest.mark.asyncio
+async def test_refresh_readiness_logs_helper_missing(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    monkeypatch.delattr(app, '_ensure_strategy_runner_started')
+
+    ctx = SimpleNamespace(
+        market_data_manager=_MdmStub(),
+        strategy_runner=SimpleNamespace(_started=False, started=False),
+        message_bus=SimpleNamespace(running=True),
+        strategy_runner_task=None,
+        data_observation_ready=False,
+        live_orders_armed=False,
+    )
+
+    caplog.set_level('INFO', logger='nifty_scalper_bot.core.app')
+    await app._refresh_readiness_after_first_tick(ctx, reason='first_spot_tick_listener')
+
+    assert 'STRATEGY_RUNNER_START_HELPER_MISSING' in caplog.text


### PR DESCRIPTION
### Motivation

- Observed pipeline readiness after the first NIFTY spot tick (`spot_ready=True`, `bus_running=True`) while the `StrategyRunner` remained stopped, preventing the strategy from entering observation/start flows. 
- The fix must start the runner when safe without arming live orders, bypassing market-hours gates, or placing any orders.

### Description

- Updated `_refresh_readiness_after_first_tick` to include `ctx.strategy_runner_task` in the `runner_started` detection and to request runner startup when `spot_ready` and `bus_running` are true but the runner is not started. 
- Startup is invoked via the existing helper `_ensure_strategy_runner_started` looked up from `globals()`, and the code logs `STRATEGY_RUNNER_START_REQUESTED_AFTER_TICK` before attempting startup. 
- If the helper is missing we log `STRATEGY_RUNNER_START_HELPER_MISSING`, and if the attempt raises we log `STRATEGY_RUNNER_START_AFTER_TICK_FAILED` with exception info; `runner_started` is recomputed after the attempt and `DATA_PIPELINE_READY_AFTER_TICK` is emitted with the updated state. 
- Added tests `tests/test_runner_start_after_first_spot_tick.py` covering: `test_refresh_readiness_starts_runner_after_first_tick`, `test_refresh_readiness_does_not_arm_live_orders`, and `test_refresh_readiness_logs_helper_missing`.

### Testing

- Ran byte-compile step with `python -m compileall -q src tests` which succeeded. 
- Executed `pytest -q tests/test_runner_start_after_first_spot_tick.py` which passed. 
- Executed `pytest -q tests/test_env_normalisation.py` and `pytest -q tests/test_env_precedence.py` which both passed. 
- Note: `./run_checks.sh` was invoked via `bash ./run_checks.sh` in CI-like environment which installed dependencies but reported tooling notices that `ruff` and `mypy` were not installed and initially flagged `pytest not installed but tests/ exists`; `pytest` was then installed in the virtualenv and the test runs above were executed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8c1ef0d4c83249b35b9340b960aa6)