### PR TITLE
fix: restore runner bar ingestion path and reduce MDM subscriber log flood

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -7539,6 +7539,21 @@ async def startup_sequence(ctx: BotContext) -> None:
                         },
                     )
             pending_runner_symbols: set[str] = set(skipped_symbols)
+            if runner is not None:
+                for sym in readiness_symbols:
+                    try:
+                        runner.add_symbol(sym)
+                    except Exception as e:
+                        LOGGER.error(
+                            "RUNNER_ADD_SYMBOL_FROM_READINESS_FAILED symbol=%s error=%s",
+                            sym,
+                            e,
+                            extra={
+                                "event": "RUNNER_ADD_SYMBOL_FROM_READINESS_FAILED",
+                                "symbol": sym,
+                                "error": str(e),
+                            },
+                        )
             if runner is not None and hasattr(runner, "mark_ready") and ready_symbols:
                 runner.mark_ready(ready_symbols)
                 LOGGER.info(
@@ -7566,6 +7581,20 @@ async def startup_sequence(ctx: BotContext) -> None:
                         "event": "RUNNER_READY_MARK_SKIPPED",
                         "reason": "no_ready_symbols_or_method_missing",
                         "skipped_reasons": skipped_reasons,
+                    },
+                )
+            if (
+                ctx.data_hub is not None
+                and hasattr(ctx.data_hub, "flush_pending_live_subscriptions")
+            ):
+                flushed = int(ctx.data_hub.flush_pending_live_subscriptions())
+                LOGGER.info(
+                    "DATAHUB_PENDING_SUBSCRIPTIONS_FLUSHED count=%d phase=startup_readiness",
+                    flushed,
+                    extra={
+                        "event": "DATAHUB_PENDING_SUBSCRIPTIONS_FLUSHED",
+                        "count": flushed,
+                        "phase": "startup_readiness",
                     },
                 )
             configured_runtime_mode = str(

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -735,11 +735,14 @@ class MarketDataManager:
             except Exception as exc:
                 symbol = str(bar.get("symbol") or "")
                 callback_name = getattr(cb, "__qualname__", repr(cb))
-                self._logger.exception(
-                    "BAR_SUBSCRIBER_FAILED symbol=%s callback=%s error=%s",
-                    symbol,
-                    callback_name,
-                    exc,
+                log_throttled(
+                    self._logger,
+                    f"bar_subscriber_failed:{symbol}:{callback_name}:{type(exc).__name__}",
+                    "BAR_SUBSCRIBER_FAILED symbol=%s callback=%s error=%s"
+                    % (symbol, callback_name, exc),
+                    interval_sec=60,
+                    level=logging.ERROR,
+                    exc_info=True,
                     extra={
                         "event": "BAR_SUBSCRIBER_FAILED",
                         "symbol": symbol,
@@ -5025,25 +5028,41 @@ class MarketDataManager:
             if first_seen_map is None:
                 first_seen_map = {}
                 self._first_seen_at_by_symbol = first_seen_map
-            first_seen_at = first_seen_map.get(symbol)
+                first_seen_at = first_seen_map.get(symbol)
             if first_seen_at is None:
                 first_seen_map[symbol] = time.monotonic()
             else:
                 age = time.monotonic() - first_seen_at
                 if selected_or_active and age > 30:
-                    log_throttled(
-                        self._logger,
-                        f"mdm_tick_no_direct_subscriber_{symbol}",
-                        "MDM_TICK_NO_DIRECT_SUBSCRIBER symbol=%s age_s=%.1f note=bus_path_may_still_be_active"
-                        % (symbol, age),
-                        interval_sec=60,
-                        level=logging.WARNING,
-                        extra={
-                            "event": "MDM_TICK_NO_DIRECT_SUBSCRIBER",
-                            "symbol": symbol,
-                            "age_s": age,
-                        },
-                    )
+                    bus_running = bool(getattr(self.bus, "is_running", lambda: False)())
+                    if bus_running:
+                        log_throttled(
+                            self._logger,
+                            f"mdm_tick_bus_only_delivery_{symbol}",
+                            "MDM_TICK_BUS_ONLY_DELIVERY symbol=%s age_s=%.1f"
+                            % (symbol, age),
+                            interval_sec=120,
+                            level=logging.DEBUG,
+                            extra={
+                                "event": "MDM_TICK_BUS_ONLY_DELIVERY",
+                                "symbol": symbol,
+                                "age_s": age,
+                            },
+                        )
+                    else:
+                        log_throttled(
+                            self._logger,
+                            f"mdm_tick_no_direct_subscriber_{symbol}",
+                            "MDM_TICK_NO_DIRECT_SUBSCRIBER symbol=%s age_s=%.1f note=bus_unavailable"
+                            % (symbol, age),
+                            interval_sec=60,
+                            level=logging.WARNING,
+                            extra={
+                                "event": "MDM_TICK_NO_DIRECT_SUBSCRIBER",
+                                "symbol": symbol,
+                                "age_s": age,
+                            },
+                        )
         _price_val = tick.get("ltp") or tick.get("last_price") or tick.get("price")
         _token_val = tick.get("instrument_token") or tick.get("token")
         try:

--- a/src/nifty_scalper_bot/strategies/indicators.py
+++ b/src/nifty_scalper_bot/strategies/indicators.py
@@ -210,6 +210,63 @@ class IndicatorEngine:
             )
             self._cache.pop(symbol, None)
 
+    def ingest_bar(self, symbol: str, bar: Any) -> None:
+        """Ingest normalized/live bar. Args: symbol, bar. Returns: None. Raises: Exception."""
+        try:
+            if isinstance(bar, Mapping):
+                ts_value = bar.get("timestamp") or bar.get("start")
+                open_price = float(bar["open"])
+                high_price = float(bar["high"])
+                low_price = float(bar["low"])
+                close_price = float(bar["close"])
+                volume = int(bar.get("volume", 0) or 0)
+            else:
+                ts_value = getattr(bar, "timestamp", None) or getattr(bar, "start", None)
+                open_price = float(getattr(bar, "open"))
+                high_price = float(getattr(bar, "high"))
+                low_price = float(getattr(bar, "low"))
+                close_price = float(getattr(bar, "close"))
+                volume = int(getattr(bar, "volume", 0) or 0)
+
+            if isinstance(ts_value, datetime):
+                ts = ts_value
+            elif isinstance(ts_value, (int, float)):
+                ts = datetime.fromtimestamp(float(ts_value), tz=timezone.utc)
+            elif isinstance(ts_value, str):
+                ts = datetime.fromisoformat(ts_value.replace("Z", "+00:00"))
+            else:
+                raise ValueError(f"Unsupported bar timestamp: {ts_value!r}")
+            if ts.tzinfo is None:
+                ts = ts.replace(tzinfo=timezone.utc)
+
+            payload_ohlc = {
+                "open": open_price,
+                "high": high_price,
+                "low": low_price,
+                "close": close_price,
+            }
+            self.update_price(
+                symbol,
+                payload_ohlc,
+                volume=volume,
+                timestamp=ts,
+                is_complete=True,
+                is_provisional=False,
+            )
+        except Exception as e:
+            self._logger.error(
+                "Failure in IndicatorEngine.ingest_bar: %s",
+                e,
+                extra={"event": "INDICATOR_INGEST_BAR_FAILED", "symbol": symbol},
+            )
+            raise
+
+    def history_count(self, symbol: str) -> int:
+        """Return symbol history length. Args: symbol. Returns: count. Raises: none."""
+        with self._lock:
+            history = self._histories.get(symbol)
+            return len(history) if history is not None else 0
+
     def get_history(self, symbol: str, count: int | None = None) -> list[float]:
         """Args: symbol, count. Returns: close-price history list. Raises: Exception."""
         LOGGER.debug(

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -2321,21 +2321,50 @@ class StrategyRunner:
     def ingest_historical_bar(self, data: dict) -> None:
         """Public API for startup hydration ingestion. Args: data. Returns: None. Raises: None."""
         self._startup_hydrated = True
-        symbol = self._normalize_symbol(data.get("symbol", "")) if isinstance(data, dict) else ""
-        normalized = normalize_history_row(symbol, data, source=(data.get("source", "historical") if isinstance(data, dict) else "historical")) if symbol else None
-        if normalized is not None and self._indicator_engine is not None:
-            self._indicator_engine.ingest_bar(symbol, normalized)
+        symbol = (
+            self._normalize_symbol(data.get("symbol", ""))
+            if isinstance(data, dict)
+            else ""
+        )
+        normalized = (
+            normalize_history_row(
+                symbol,
+                data,
+                source=(
+                    data.get("source", "historical")
+                    if isinstance(data, dict)
+                    else "historical"
+                ),
+            )
+            if symbol
+            else None
+        )
+        if normalized is None:
+            return
+        try:
+            self._ingest_historical_bar_unlocked(normalized)
             indicator_count = 0
             if hasattr(self._indicator_engine, "history_count"):
-                indicator_count = self._indicator_engine.history_count(symbol)
-            elif hasattr(self._indicator_engine, "get_history"):
-                indicator_count = len(self._indicator_engine.get_history(symbol) or [])
-            self._logger.info("RUNNER_BAR_INGESTED symbol=%s source=%s runner_bars=%d indicator_bars=%d", symbol, normalized.get("source"), len(self._symbol_history.get(symbol, [])), indicator_count)
-            if len(self._symbol_history.get(symbol, [])) > 0 and indicator_count == 0:
-                for row in self._symbol_history.get(symbol, [])[-100:]:
-                    self._indicator_engine.ingest_bar(symbol, row)
-                self._logger.info("INDICATOR_HISTORY_AUTO_SYNC symbol=%s", symbol)
-        self._ingest_historical_bar_unlocked(data)
+                indicator_count = int(self._indicator_engine.history_count(symbol))
+            self._logger.debug(
+                "RUNNER_BAR_INGESTED symbol=%s source=%s runner_bars=%d indicator_bars=%d",
+                symbol,
+                normalized.get("source"),
+                len(self._symbol_history.get(symbol, [])),
+                indicator_count,
+            )
+        except Exception as e:
+            self._logger.error(
+                "RUNNER_BAR_INGEST_FAILED symbol=%s error=%s",
+                symbol,
+                e,
+                extra={
+                    "event": "RUNNER_BAR_INGEST_FAILED",
+                    "symbol": symbol,
+                    "error": str(e),
+                },
+            )
+            raise
 
     async def safe_ingest(self, data: dict[str, Any]) -> None:
         """Synchronize hydration ingestion on event loop. Args: data. Returns: None. Raises: None."""


### PR DESCRIPTION
### Motivation
- Live runs were failing because `StrategyRunner` and MDM closed-bar fanout attempted to call a non-existent `IndicatorEngine.ingest_bar`, preventing indicator hydration and marking the runner ready.  
- Repeated subscriber exceptions were flooding logs and hitting platform rate limits; tick delivery via the MessageBus path should not warn when the bus is active.  
- Startup readiness should register symbols with the runner and flush deferred DataHub subscriptions to ensure live delivery after hydration.

### Description
- Added `IndicatorEngine.ingest_bar(symbol, bar)` to accept normalized dicts or OneMinuteBar-like objects, safely parse timestamps, preserve full OHLCV, and call `update_price(..., is_complete=True, is_provisional=False)`; also added `history_count(symbol)` returning stored bar count. (`src/nifty_scalper_bot/strategies/indicators.py`)
- Reworked `StrategyRunner.ingest_historical_bar` to normalize input with `normalize_history_row()`, return early on invalid rows, call `_ingest_historical_bar_unlocked(normalized)` for actual ingestion, emit `RUNNER_BAR_INGESTED` at DEBUG with `indicator_bars`, and log + re-raise `RUNNER_BAR_INGEST_FAILED` so upstream MDM can correctly surface subscriber failures. (`src/nifty_scalper_bot/strategies/runner.py`)
- Throttled `BAR_SUBSCRIBER_FAILED` logging in `MarketDataManager._publish_closed_bar` using `log_throttled` keyed by `bar_subscriber_failed:{symbol}:{callback}:{ExceptionType}` with 60s interval and `exc_info=True` to retain traces and prevent log floods. (`src/nifty_scalper_bot/data/market_data_manager.py`)
- Adjusted `MDM_TICK_NO_DIRECT_SUBSCRIBER` behavior to log a debug `MDM_TICK_BUS_ONLY_DELIVERY` every 120s when the message bus is running, and only emit WARNING when the bus is unavailable. (`src/nifty_scalper_bot/data/market_data_manager.py`)
- In startup readiness flow, call `runner.add_symbol(sym)` for each readiness symbol before `mark_ready`, log failures as `RUNNER_ADD_SYMBOL_FROM_READINESS_FAILED`, and flush pending DataHub live subscriptions (logging `DATAHUB_PENDING_SUBSCRIPTIONS_FLUSHED`) after basket wiring. (`src/nifty_scalper_bot/core/app.py`)

### Testing
- Ran `python -m compileall -q src tests` and compilation completed successfully.  
- Ran `pytest -q tests --disable-warnings --ignore=tests/test_live_mode.py --ignore=tests/test_health_server.py` which failed during collection due to a pre-existing import error unrelated to these changes: `cannot import name 'atm_strike_for_spot' from nifty_scalper_bot.data.instruments`; this blocked full test execution.  
- No new dependencies were added and edits are minimal and backwards-compatible with existing public signatures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f96cc3c7e0832492dcf79d1c9b27a5)