### PR TITLE
fix: restore startup option selection and tick first-seen scope

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -145,6 +145,69 @@ def _history_lookback_minutes(required_bars: int) -> int:
     return max(180, required + buffer_bars)
 
 
+
+
+def select_active_option_symbols(
+    option_symbols: Sequence[str],
+    atm: int | float | str | None = None,
+    max_active: int = 6,
+) -> list[str]:
+    """Select balanced CE/PE symbols near ATM. Args: option_symbols/atm/max_active. Returns: selected symbols. Raises: none."""
+
+    safe_limit = max(1, int(max_active or 1))
+    unique_symbols = [str(sym) for sym in dict.fromkeys(option_symbols or ()) if sym]
+    if not unique_symbols:
+        return []
+
+    try:
+        atm_value = int(float(atm)) if atm is not None else None
+    except Exception:
+        atm_value = None
+
+    parsed: list[tuple[int, int, str, str]] = []
+    fallback: list[str] = []
+    for rank, symbol in enumerate(unique_symbols):
+        try:
+            head, tail = symbol.rsplit(":", 1)
+            _ = head
+            side = "CE" if tail.endswith("CE") else "PE" if tail.endswith("PE") else ""
+            if not side:
+                fallback.append(symbol)
+                continue
+            strike_digits = ""
+            for char in reversed(tail[:-2]):
+                if char.isdigit():
+                    strike_digits = char + strike_digits
+                elif strike_digits:
+                    break
+            if not strike_digits:
+                fallback.append(symbol)
+                continue
+            strike = int(strike_digits)
+            distance = abs(strike - atm_value) if atm_value is not None else 0
+            parsed.append((distance, rank, side, symbol))
+        except Exception:
+            fallback.append(symbol)
+
+    if not parsed:
+        return unique_symbols[:safe_limit]
+
+    ce_sorted = [item for item in sorted(parsed) if item[2] == "CE"]
+    pe_sorted = [item for item in sorted(parsed) if item[2] == "PE"]
+    selected: list[str] = []
+    while (ce_sorted or pe_sorted) and len(selected) < safe_limit:
+        if ce_sorted and len(selected) < safe_limit:
+            selected.append(ce_sorted.pop(0)[3])
+        if pe_sorted and len(selected) < safe_limit:
+            selected.append(pe_sorted.pop(0)[3])
+
+    for symbol in fallback + unique_symbols:
+        if len(selected) >= safe_limit:
+            break
+        if symbol not in selected:
+            selected.append(symbol)
+    return selected[:safe_limit]
+
 def nearest_available_strike(spot: float, strikes: Sequence[float]) -> int:
     """Pick nearest strike from available list. Args: spot, strikes. Returns: strike. Raises: ValueError."""
     valid = sorted({int(float(s)) for s in strikes if float(s) > 0})

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -5028,13 +5028,14 @@ class MarketDataManager:
             if first_seen_map is None:
                 first_seen_map = {}
                 self._first_seen_at_by_symbol = first_seen_map
-                first_seen_at = first_seen_map.get(symbol)
+            first_seen_at = first_seen_map.get(symbol)
             if first_seen_at is None:
                 first_seen_map[symbol] = time.monotonic()
             else:
                 age = time.monotonic() - first_seen_at
                 if selected_or_active and age > 30:
-                    bus_running = bool(getattr(self.bus, "is_running", lambda: False)())
+                    bus_obj = getattr(self, "bus", None)
+                    bus_running = bool(getattr(bus_obj, "is_running", lambda: False)())
                     if bus_running:
                         log_throttled(
                             self._logger,


### PR DESCRIPTION
### Motivation

- Prevent startup abort where readiness code called an undefined `select_active_option_symbols` which forced the bot into degraded mode before `StrategyRunner` could start.
- Eliminate `UnboundLocalError` in the market data tick consumer caused by `first_seen_at` variable scope and make bus checks defensive to avoid attribute errors during warning paths.

### Description

- Added a local helper `select_active_option_symbols(option_symbols, atm=None, max_active=6)` in `src/nifty_scalper_bot/core/app.py` that parses CE/PE and strike digits, ranks options by distance to ATM, selects a balanced CE/PE set up to `max_active`, and falls back safely to first-N on malformed symbols without raising. 
- Fixed `first_seen_at` scope in `src/nifty_scalper_bot/data/market_data_manager.py` by always reading `first_seen_at = first_seen_map.get(symbol)` after map initialization to avoid `UnboundLocalError`. 
- Hardened bus access in the same block by resolving `bus_obj = getattr(self, "bus", None)` and computing `bus_running = bool(getattr(bus_obj, "is_running", lambda: False)())` so logging paths do not assume a present bus object or method. 

### Testing

- Ran `python -m compileall -q src tests` which completed successfully. 
- Ran `bash ./run_checks.sh` which executed but did not complete full checks because the created environment lacked lint/type/test tooling; the script reported missing tools: "ℹ Ruff not installed; skipping lint.", "ℹ mypy not installed; skipping type check.", and "❌ pytest not installed but tests/ exists. Install pytest or remove tests/". 
- Confirmed code edits are minimal, add no new dependencies, and were committed as `fix: restore startup option selection and tick first-seen scope`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f970733cac83248aa1132eb37956f2)