### PR TITLE
fix: harden startup throttled logging and runner readiness

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -6052,13 +6052,49 @@ def _safe_startup_log(
         )
 
 
+def _create_named_task(coro: Any, *, name: str) -> asyncio.Task[Any]:
+    """Create startup task with exception logging. Args: coro/name. Returns: task. Raises: None."""
+    task = asyncio.create_task(coro, name=name)
+
+    def _done(done_task: asyncio.Task[Any]) -> None:
+        try:
+            exc = done_task.exception()
+        except asyncio.CancelledError:
+            return
+        except Exception as err:  # noqa: BLE001
+            LOGGER.warning(
+                "TASK_EXCEPTION_CHECK_FAILED task=%s error=%s",
+                name,
+                err,
+                extra={
+                    "event": "TASK_EXCEPTION_CHECK_FAILED",
+                    "task": name,
+                    "error": str(err),
+                },
+            )
+            return
+        if exc is not None:
+            LOGGER.exception(
+                "BACKGROUND_TASK_FAILED task=%s error=%s",
+                name,
+                exc,
+                exc_info=exc,
+                extra={"event": "BACKGROUND_TASK_FAILED", "task": name},
+            )
+
+    task.add_done_callback(_done)
+    return task
+
+
 async def _refresh_readiness_after_first_tick(ctx: BotContext, reason: str) -> None:
     """Refresh readiness after startup tick proof. Args: ctx/reason. Returns: none. Raises: none."""
+    configured_mode = str(os.getenv("EXECUTION_MODE", "SHADOW")).strip().upper()
     mdm = ctx.market_data_manager
     runner = ctx.strategy_runner
-    spot_ready = False
+    spot_tick: Mapping[str, Any] | None = None
     if mdm is not None and hasattr(mdm, "get_fresh_spot_tick"):
-        spot_ready = mdm.get_fresh_spot_tick("NSE:NIFTY", require_ws=False) is not None
+        spot_tick = mdm.get_fresh_spot_tick("NSE:NIFTY", require_ws=False)
+    spot_ready = spot_tick is not None
     bus_running = bool(
         getattr(ctx.message_bus, "running", False)
         or getattr(ctx.message_bus, "_running", False)
@@ -6070,19 +6106,45 @@ async def _refresh_readiness_after_first_tick(ctx: BotContext, reason: str) -> N
             active_count = len(getattr(runner, "_active_symbols", set()) or [])
             ensure_runner_started = globals().get("_ensure_strategy_runner_started")
             if active_count <= 0:
-                log_throttled(
-                    LOGGER,
-                    "runner_start_deferred_after_spot_no_symbols",
-                    "STRATEGY_RUNNER_START_DEFERRED_AFTER_SPOT reason=no_active_symbols_yet active_symbols=%d",
-                    active_count,
-                    interval_sec=60.0,
-                    level=logging.INFO,
-                    extra={
-                        "event": "STRATEGY_RUNNER_START_DEFERRED_AFTER_SPOT",
-                        "reason": "no_active_symbols_yet",
-                        "active_symbols": active_count,
-                    },
-                )
+                spot_ltp = _coerce_spot_price(spot_tick)
+                if (
+                    configured_mode in {"LIVE", "PAPER", "SHADOW"}
+                    and spot_ltp > 0.0
+                    and "_build_and_hydrate_live_basket_from_spot" in globals()
+                ):
+                    try:
+                        await _build_and_hydrate_live_basket_from_spot(
+                            ctx,
+                            spot_ltp=spot_ltp,
+                            configured_mode=configured_mode,
+                            hydrate=True,
+                        )
+                    except Exception as exc:  # noqa: BLE001
+                        LOGGER.warning(
+                            "LIVE_BASKET_BUILD_FAILED reason=%s",
+                            exc,
+                            extra={
+                                "event": "LIVE_BASKET_BUILD_FAILED",
+                                "reason": str(exc),
+                            },
+                        )
+                else:
+                    log_throttled(
+                        LOGGER,
+                        "runner_start_deferred_after_spot_no_symbols",
+                        "STRATEGY_RUNNER_START_DEFERRED_AFTER_SPOT reason=no_active_symbols_yet active_symbols=%d",
+                        active_count,
+                        interval_sec=60.0,
+                        level=logging.INFO,
+                        extra={
+                            "event": "STRATEGY_RUNNER_START_DEFERRED_AFTER_SPOT",
+                            "reason": "no_active_symbols_yet",
+                            "active_symbols": active_count,
+                        },
+                    )
+            active_count = len(getattr(runner, "_active_symbols", set()) or [])
+            if active_count <= 0:
+                pass
             elif ensure_runner_started is None:
                 LOGGER.warning(
                     "STRATEGY_RUNNER_START_HELPER_MISSING reason=%s",
@@ -6103,7 +6165,7 @@ async def _refresh_readiness_after_first_tick(ctx: BotContext, reason: str) -> N
                 )
                 try:
                     await ensure_runner_started(
-                        ctx, reason=f"{reason}:data_pipeline_ready_after_tick"
+                        ctx, reason=f"{reason}:symbols_ready_after_spot"
                     )
                 except Exception:
                     LOGGER.exception(
@@ -6650,7 +6712,10 @@ async def _build_and_hydrate_live_basket_from_spot(
             except Exception:  # noqa: BLE001
                 continue
             for row in list(records or [])[-hydration_max_bars:]:
+                if not isinstance(row, Mapping):
+                    continue
                 bar_data = dict(row)
+                bar_data["symbol"] = symbol
                 ctx.market_data_manager.ingest_historical_bar(bar_data)
                 runner = getattr(ctx, "strategy_runner", None)
                 if runner is not None and hasattr(runner, "ingest_historical_bar"):
@@ -6728,11 +6793,12 @@ def _schedule_deferred_basket_retry(ctx: BotContext, *, configured_mode: str) ->
 
     ctx.deferred_basket_retry_started = True
     ctx.last_deferred_basket_retry_ts = time_module.time()
-    ctx.deferred_basket_retry_task = asyncio.create_task(
+    ctx.deferred_basket_retry_task = _create_named_task(
         _deferred_basket_hydration_retry(
             ctx,
             configured_mode=configured_mode,
-        )
+        ),
+        name="deferred_basket_hydration_retry",
     )
     LOGGER.info(
         "BASKET_BUILD_DEFERRED reason=market_closed_or_spot_not_ready",
@@ -6893,11 +6959,12 @@ async def startup_sequence(ctx: BotContext) -> None:
                         ctx.startup_spot_refresh_done = True
 
                         loop.call_soon_threadsafe(
-                            lambda: asyncio.create_task(
+                            lambda: _create_named_task(
                                 _refresh_readiness_after_first_tick(
                                     ctx,
                                     reason="first_spot_tick_listener",
-                                )
+                                ),
+                                name="startup_spot_tick_listener",
                             )
                         )
                     except Exception as exc:
@@ -7526,7 +7593,7 @@ async def startup_sequence(ctx: BotContext) -> None:
                 runner_ingested = 0
                 for row in records:
                     try:
-                        if not isinstance(row, dict):
+                        if not isinstance(row, Mapping):
                             continue
                         bar_data = dict(row)
                         bar_data["symbol"] = sym

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -887,8 +887,7 @@ class StrategyRunner:
                 log_throttled(
                     self._logger,
                     "runner_start_deferred_no_active_symbols",
-                    "STRATEGY_RUNNER_START_DEFERRED reason=no_active_symbols state=%s",
-                    self._runner_state,
+                    f"STRATEGY_RUNNER_START_DEFERRED reason=no_active_symbols state={self._runner_state}",
                     interval_sec=60.0,
                     level=logging.INFO,
                     extra={

--- a/src/nifty_scalper_bot/utils/logging.py
+++ b/src/nifty_scalper_bot/utils/logging.py
@@ -539,7 +539,7 @@ def log_throttled(
     logger: logging.Logger,
     key: str,
     msg: str,
-    *,
+    *fmt_args: Any,
     interval_sec: float = 60.0,
     level: int = logging.INFO,
     extra: Optional[dict[str, Any]] = None,
@@ -563,6 +563,11 @@ def log_throttled(
             if now - last_emit < interval:
                 return
             _THROTTLE_STATE[key] = now
+        if fmt_args:
+            try:
+                msg = msg % fmt_args
+            except Exception:
+                msg = f"{msg} | fmt_args={fmt_args!r}"
         logger.log(level, msg, extra=extra or {}, exc_info=exc_info)
     except Exception as exc:  # noqa: BLE001
         logger.error(

--- a/tests/test_log_throttled_safety.py
+++ b/tests/test_log_throttled_safety.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import ast
+import logging
+from pathlib import Path
+
+from nifty_scalper_bot.utils.logging import log_throttled
+
+
+def test_log_throttled_accepts_format_args(caplog) -> None:
+    logger = logging.getLogger('nifty_scalper_bot.tests.log_throttled')
+    caplog.set_level(logging.INFO, logger=logger.name)
+    log_throttled(logger, 'k', 'value=%s', 1, interval_sec=0.0)
+    assert 'value=1' in caplog.text
+
+
+def test_no_invalid_log_throttled_calls() -> None:
+    root = Path('src/nifty_scalper_bot')
+    violations: list[str] = []
+    for path in root.rglob('*.py'):
+        tree = ast.parse(path.read_text(encoding='utf-8'))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            is_target = isinstance(func, ast.Name) and func.id == 'log_throttled'
+            is_target = is_target or (
+                isinstance(func, ast.Attribute) and func.attr == 'log_throttled'
+            )
+            if is_target and len(node.args) > 4:
+                violations.append(f'{path}:{node.lineno}')
+    assert not violations, f'Invalid log_throttled calls: {violations}'

--- a/tests/test_runner_start_after_first_spot_tick.py
+++ b/tests/test_runner_start_after_first_spot_tick.py
@@ -37,7 +37,7 @@ async def test_refresh_readiness_starts_runner_after_first_tick(
     caplog.set_level('INFO', logger='nifty_scalper_bot.core.app')
     await app._refresh_readiness_after_first_tick(ctx, reason='first_spot_tick_listener')
 
-    assert started_reasons == ['first_spot_tick_listener:data_pipeline_ready_after_tick']
+    assert started_reasons == ['first_spot_tick_listener:symbols_ready_after_spot']
     assert 'STRATEGY_RUNNER_START_REQUESTED_AFTER_TICK' in caplog.text
 
 
@@ -63,7 +63,34 @@ async def test_refresh_readiness_does_not_start_runner_without_active_symbols(
     await app._refresh_readiness_after_first_tick(ctx, reason='first_spot_tick_listener')
     assert ctx.data_observation_ready is True
     assert started_reasons == []
-    assert 'STRATEGY_RUNNER_START_DEFERRED_AFTER_SPOT' in caplog.text
+    assert 'LIVE_BASKET_BUILD_FAILED' in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_first_spot_builds_basket_when_runner_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    started_reasons: list[str] = []
+
+    async def _fake_ensure_strategy_runner_started(_ctx: Any, *, reason: str) -> None:
+        started_reasons.append(reason)
+
+    async def _fake_build(_ctx: Any, *, spot_ltp: float, configured_mode: str, hydrate: bool) -> dict[str, Any]:
+        assert spot_ltp > 0
+        assert configured_mode == 'LIVE'
+        assert hydrate is True
+        _ctx.strategy_runner._active_symbols = {'NSE:NIFTY', 'NFO:NIFTY24MAYFUT'}
+        return {}
+
+    monkeypatch.setattr(app, '_ensure_strategy_runner_started', _fake_ensure_strategy_runner_started)
+    monkeypatch.setattr(app, '_build_and_hydrate_live_basket_from_spot', _fake_build)
+    ctx = SimpleNamespace(
+        market_data_manager=_MdmStub(),
+        strategy_runner=SimpleNamespace(_started=False, started=False, _active_symbols=set()),
+        message_bus=SimpleNamespace(running=True),
+        strategy_runner_task=None,
+        data_observation_ready=False,
+    )
+    await app._refresh_readiness_after_first_tick(ctx, reason='first_spot_tick_listener')
+    assert started_reasons == ['first_spot_tick_listener:symbols_ready_after_spot']
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Motivation

- A startup crash occurred (`TypeError` from `log_throttled` misuse) which caused the bot to enter degraded mode and blocked option-basket construction and runner progression.  
- Background async startup tasks produced unobserved exceptions (`Task exception was never retrieved`) making failures noisy and hard to diagnose.  
- The first-spot readiness path could attempt to start the `StrategyRunner` with zero active symbols, leading to false-positive starts and confusing logs.  

### Description

- Hardened `log_throttled` in `src/nifty_scalper_bot/utils/logging.py` to accept optional printf-style args (`*fmt_args`) and safely format them (fallback on formatting error) so misuses no longer raise `TypeError`.  
- Fixed callsites that previously passed extra positional format args by formatting the message before calling `log_throttled` (notably in `src/nifty_scalper_bot/strategies/runner.py`).  
- Added `_create_named_task` helper to `src/nifty_scalper_bot/core/app.py` and used it for startup tasks (startup spot tick listener and deferred basket retry) so background task exceptions are observed and logged as `BACKGROUND_TASK_FAILED`.  
- Reworked `_refresh_readiness_after_first_tick` in `src/nifty_scalper_bot/core/app.py` to: mark observation ready on first spot tick, attempt live-basket build/hydration when the runner has zero active symbols and a valid spot LTP is available, re-check active symbols, and only call the runner-start helper when symbols exist (new reason suffix `:symbols_ready_after_spot`).  
- Hardened hydration ingestion loops to skip non-mapping rows and inject `symbol` into `bar_data` before calling `ingest_historical_bar` on MDM/runner to avoid silent failures during hydration.  
- Added regression/unit tests: `tests/test_log_throttled_safety.py` (format-args compatibility and AST check for invalid `log_throttled` calls) and extended `tests/test_runner_start_after_first_spot_tick.py` to cover the new readiness behavior and basket-build trigger.  

### Testing

- Ran `python -m compileall -q src`, which passed after the fixes.  
- Ran targeted tests: `python -m pytest -q tests/test_log_throttled_safety.py tests/test_runner_start_after_first_spot_tick.py`, and these passed locally.  
- Ran a broader subset `python -m pytest -q tests/core tests/data tests/strategies tests/test_runner_start_after_first_spot_tick.py`; this run failed early due to an existing, unrelated test/import issue (`cannot import name 'atm_strike_for_spot'` in `tests/data/test_resolver_lots_delta.py`) and is not caused by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f98306a85483249534dfdb6439e2c7)