### PR TITLE
fix: stabilize live basket hydration, WS tick health, and polling/tick validation

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -145,6 +145,10 @@ def _history_lookback_minutes(required_bars: int) -> int:
     return max(180, required + buffer_bars)
 
 
+def _history_lookback_days(required_bars: int) -> int:
+    """Convert required minute bars into safe historical lookback days."""
+    minutes = _history_lookback_minutes(required_bars)
+    return max(2, int(math.ceil(minutes / 375.0)) + 1)
 
 
 def select_active_option_symbols(
@@ -1926,6 +1930,8 @@ class BotContext:
     data_pipeline_ready: bool = False
     data_hard_ready: bool = False
     spot_ready: bool = False
+    evaluation_ready: bool = False
+    runner_task: asyncio.Task[Any] | None = None
     readiness_mode: str = "SHADOW"
     effective_mode: str = "SHADOW"
     started_mono: float = field(default_factory=time_module.monotonic)
@@ -6615,7 +6621,14 @@ async def _build_and_hydrate_live_basket_from_spot(
     if float(spot_ltp) <= 0:
         raise RuntimeError("spot_ltp must be positive for live basket hydration")
     if ctx.instrument_manager is None or not ctx.instrument_manager.is_loaded():
-        raise RuntimeError("instrument_manager_unavailable_for_live_basket")
+        LOGGER.info(
+            "LIVE_BASKET_BUILD_DEFERRED reason=instrument_manager_not_ready",
+            extra={
+                "event": "LIVE_BASKET_BUILD_DEFERRED",
+                "reason": "instrument_manager_not_ready",
+            },
+        )
+        return {"deferred": True, "reason": "instrument_manager_not_ready"}
     if ctx.market_data_manager is None:
         raise RuntimeError("market_data_manager_unavailable_for_live_basket")
     if ctx.broker_client is None:

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -6779,6 +6779,26 @@ class MarketDataManager:
             if normalized_live is None:
                 self._log_poll_error(symbol, "quote_normalization_failed")
                 return
+            ws_age = self._tick_age_seconds(symbol)
+            stale_threshold = (
+                self._polling_policy.context_stale_seconds
+                if self._is_context_symbol(symbol)
+                else self._polling_policy.option_stale_seconds
+            )
+            if ws_age is not None and ws_age <= stale_threshold and self._last_tick_source.get(symbol) == "ws":
+                self._logger.debug(
+                    "poll_tick_skipped_fresh_ws symbol=%s ws_age=%.3f threshold=%.3f",
+                    symbol,
+                    ws_age,
+                    stale_threshold,
+                    extra={
+                        "event": "poll_tick_skipped_fresh_ws",
+                        "symbol": symbol,
+                        "ws_age": float(ws_age),
+                        "threshold": float(stale_threshold),
+                    },
+                )
+                return
             self._poll_fallback_count = int(getattr(self, "_poll_fallback_count", 0)) + 1
             self._ingest_normalized_tick(normalized_live)
             self._process_poll_quote(symbol, normalized)

--- a/src/nifty_scalper_bot/data/pipeline.py
+++ b/src/nifty_scalper_bot/data/pipeline.py
@@ -28,6 +28,7 @@ from typing import Any, Dict, Mapping, Optional
 import pandas as pd
 
 from nifty_scalper_bot.data.source import DataIntegrityError
+from nifty_scalper_bot.utils.logging import log_throttled
 
 LOGGER = logging.getLogger(__name__)
 
@@ -113,7 +114,7 @@ class TickValidator:
             if not symbol_raw or str(symbol_raw).strip() == "":
                 raise DataIntegrityError("missing symbol")
 
-            ts_raw = raw.get("timestamp") or raw.get("ts") or raw.get("exchange_timestamp")
+            ts_raw = raw.get("exchange_timestamp") or raw.get("timestamp") or raw.get("ts")
             if ts_raw is None:
                 raise DataIntegrityError("missing timestamp")
             ts = pd.to_datetime(ts_raw, utc=True, errors="coerce")
@@ -179,8 +180,16 @@ class CandleBuilder:
         last = self._last_ts.get(sym)
         if last is not None and ts < last:
             _DROPPED_TICKS.increment()
-            LOGGER.warning(
-                "tick_out_of_order",
+            log_throttled(
+                LOGGER,
+                f"tick_out_of_order:{sym}",
+                (
+                    f"tick_out_of_order symbol={sym} "
+                    f"tick_ts={ts.isoformat()} last_ts={last.isoformat()} "
+                    f"total_dropped={_DROPPED_TICKS.value}"
+                ),
+                interval_sec=30.0,
+                level=logging.DEBUG,
                 extra={
                     "event": "tick_out_of_order",
                     "symbol": sym,

--- a/src/nifty_scalper_bot/streaming/websocket_manager.py
+++ b/src/nifty_scalper_bot/streaming/websocket_manager.py
@@ -747,6 +747,16 @@ class WebSocketManager:
         now = time.monotonic()
         self._last_tick_mono = now
         self._last_pong_mono = now
+        if not self._connected.is_set() or self._state != ConnectionState.CONNECTED:
+            self._connected.set()
+            self._state = ConnectionState.CONNECTED
+            self._stream_health = "healthy"
+            self._circuit.failures = 0
+            self._circuit.open_until_mono = 0.0
+            self._logger.info(
+                "WEBSOCKET_CONNECTION_RESTORED_BY_TICK",
+                extra={"event": "WEBSOCKET_CONNECTION_RESTORED_BY_TICK"},
+            )
         update_authoritative = getattr(
             market_data_manager, "update_authoritative_ticks", None
         )

--- a/tests/test_runtime_stability_fixes.py
+++ b/tests/test_runtime_stability_fixes.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from nifty_scalper_bot.core import app as app_module
+from nifty_scalper_bot.data.pipeline import TickValidator
+from nifty_scalper_bot.streaming.websocket_manager import ConnectionState, WebSocketManager
+
+
+def test_history_lookback_days_defined() -> None:
+    source = (app_module.Path(app_module.__file__)).read_text(encoding='utf-8')
+    assert 'def _history_lookback_days(required_bars: int) -> int:' in source
+    assert source.index('def _history_lookback_days') < source.index('_history_lookback_days(required_bars)')
+
+
+def test_botcontext_slots_include_evaluation_ready() -> None:
+    assert 'evaluation_ready' in app_module.BotContext.__slots__
+    assert 'runner_task' in app_module.BotContext.__slots__
+
+
+def test_tick_validator_prefers_exchange_timestamp() -> None:
+    validator = TickValidator()
+    tick = validator.validate(
+        {
+            'symbol': 'NSE:NIFTY',
+            'timestamp': '2026-01-01T12:00:10Z',
+            'exchange_timestamp': '2026-01-01T12:00:00Z',
+            'ltp': 100.0,
+        }
+    )
+    assert tick is not None
+    assert tick.timestamp.isoformat().startswith('2026-01-01T12:00:00')
+
+
+def test_ws_tick_restores_connected_state() -> None:
+    manager = WebSocketManager(api_key='k', access_token='t', tokens=[])
+    manager._state = ConnectionState.DISCONNECTED
+    manager._connected.clear()
+    manager._on_ticks(None, [{'instrument_token': 123, 'last_price': 1.0}])
+    assert manager._connected.is_set()
+    assert manager._state == ConnectionState.CONNECTED
+    assert manager._stream_health == 'healthy'
+
+
+async def test_instrument_manager_missing_defers_basket_not_failure() -> None:
+    ctx = SimpleNamespace(
+        instrument_manager=None,
+        market_data_manager=object(),
+        broker_client=object(),
+    )
+    result = await app_module._build_and_hydrate_live_basket_from_spot(
+        ctx,
+        spot_ltp=25000.0,
+        configured_mode='LIVE',
+    )
+    assert result.get('deferred') is True
+    assert result.get('reason') == 'instrument_manager_not_ready'


### PR DESCRIPTION
### Motivation
- Railway runtime showed multiple transient crashes and noisy logs during live startup and streaming: undefined `_history_lookback_days`, missing `BotContext.evaluation_ready`, early live-basket failure before instruments loaded, `tick_out_of_order` spam, and WS health false-negatives while live ticks were flowing.
- These issues caused degraded startup readiness, unnecessary polling fallback, and noisy observability which risked incorrect behavior during live option hydration.

### Description
- Added `_history_lookback_days(required_bars)` to `src/nifty_scalper_bot/core/app.py` and ensured `math` is imported so hydration can compute safe day lookbacks (used by dynamic option hydration).
- Extended `BotContext` slots in `src/nifty_scalper_bot/core/app.py` with `evaluation_ready: bool = False` and `runner_task: asyncio.Task[Any] | None = None` to prevent slot-assignment attribute errors during readiness gating and runner task assignment.
- Changed first-spot live basket build in `src/nifty_scalper_bot/core/app.py` to defer when `InstrumentManager` is missing/not loaded by logging `LIVE_BASKET_BUILD_DEFERRED` and returning a deferred status, instead of hard-failing startup.
- In `src/nifty_scalper_bot/data/pipeline.py` changed timestamp precedence to prefer `exchange_timestamp` (`exchange_timestamp` → `timestamp` → `ts`) and replaced noisy `tick_out_of_order` warnings with a throttled DEBUG-level message via `log_throttled`, preserving drop counters.
- In `src/nifty_scalper_bot/streaming/websocket_manager.py` updated `_on_ticks()` to restore WS connected state, reset stream health and circuit-breaker state when fresh ticks arrive, and emit `WEBSOCKET_CONNECTION_RESTORED_BY_TICK` to avoid false-negative health and unnecessary fallback activation.
- In `src/nifty_scalper_bot/data/market_data_manager.py` guarded the poll fallback to skip emitting poll ticks when a fresh WS tick exists for the symbol (compares WS tick age to context/option stale thresholds) and logs the skip at DEBUG only.
- Added focused regression tests at `tests/test_runtime_stability_fixes.py` covering `_history_lookback_days` presence, `BotContext` slots, tick timestamp precedence, WS tick restoring connected state, and instrument-manager missing deferral.

### Testing
- Ran `python -m compileall -q src` and compilation succeeded with no syntax errors.
- Ran targeted tests with `pytest -q tests/test_runtime_stability_fixes.py` and the suite passed (`5 passed`).
- Executed the repository `./run_checks.sh` workflow; dependencies were installed successfully but the script environment reported `pytest not installed but tests/ exists` at the final step (tooling mismatch), so this is a non-blocking environment note rather than a code failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f99d2432508324ad53b5c38ecd6c82)