### PR TITLE
fix: unblock live candidate selection and freshness gating

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -19,6 +19,7 @@ from importlib import metadata as importlib_metadata
 import inspect
 import hashlib
 import logging
+import math
 import os
 from pathlib import Path
 import random
@@ -2184,22 +2185,44 @@ class RuntimeSelfChecker:
                 return True, "no_symbols_yet", {}
 
             interval = getattr(self._context.streamer, "_interval_s", 0.7) or 0.7
-            # Adaptive threshold: 2.5x poll interval, clamped 2s-5s
             adaptive_ms = max(2000, min(5000, int(float(interval) * 1000.0 * 2.5)))
+            hard_ready_fn = getattr(self._context.market_data_manager, "hard_ready", None)
+            hard_ready = bool(hard_ready_fn()) if callable(hard_ready_fn) else False
 
-            symbol = None
+            def _threshold_for_symbol(symbol_name: str) -> float:
+                upper = str(symbol_name or "").upper()
+                if upper.startswith("NFO:"):
+                    return 60000.0
+                if upper == "NSE:NIFTY":
+                    return 30000.0
+                return float(adaptive_ms)
+
+            per_symbol: list[tuple[str, bool, dict[str, object], float]] = []
             for s in symbols:
-                ok, _ = hub.is_fresh(s, threshold_ms=float(adaptive_ms))
-                if ok:
-                    symbol = s
-                    break
+                threshold_ms = _threshold_for_symbol(s)
+                ok_s, meta_s = hub.is_fresh(s, threshold_ms=threshold_ms)
+                per_symbol.append((s, bool(ok_s), dict(meta_s or {}), threshold_ms))
 
-            if symbol is None:
-                symbol = symbols[0]
+            fresh = [item for item in per_symbol if item[1]]
+            stale = [item for item in per_symbol if not item[1]]
+            critical = [
+                item
+                for item in per_symbol
+                if str(item[0]).upper().startswith("NFO:") or str(item[0]).upper() == "NSE:NIFTY"
+            ] or per_symbol
+            all_critical_stale = not any(item[1] for item in critical)
+            if hard_ready and symbols and stale and not all_critical_stale:
+                return True, "partial_stale_ignored", {
+                    "fresh_symbols": len(fresh),
+                    "stale_symbols": len(stale),
+                    "live_symbols": len(symbols),
+                }
+
+            symbol, ok, meta, symbol_threshold_ms = fresh[0] if fresh else per_symbol[0]
 
             if hasattr(hub, "is_fresh"):
                 try:
-                    ok, meta = hub.is_fresh(symbol, threshold_ms=float(adaptive_ms))
+                    ok, meta = hub.is_fresh(symbol, threshold_ms=float(symbol_threshold_ms))
                 except Exception as exc:
                     self._logger.error(
                         "Failure in RuntimeSelfChecker._check_data_freshness: %s",
@@ -2215,20 +2238,20 @@ class RuntimeSelfChecker:
                     detail = cast(str, meta.get("reason") or "ok")
                     payload = cast(dict[str, object], dict(meta or {}))
                     payload["symbol_checked"] = canonical(symbol)
-                    payload["adaptive_ms"] = adaptive_ms
+                    payload["adaptive_ms"] = symbol_threshold_ms
                     self._logger.info(
                         "Condition met: runtime_self_check_data_freshness",
                         extra={
                             "event": "runtime_self_check_data_freshness",
                             "symbol": symbol,
                             "symbol_checked": symbol,
-                            "adaptive_ms": adaptive_ms,
+                            "adaptive_ms": symbol_threshold_ms,
                             "detail": detail,
                             "detail_code": detail,
                         },
                     )
                     if not ok:
-                        backoff_seconds = max(0.0, float(adaptive_ms) * 2.0 / 1000.0)
+                        backoff_seconds = max(0.0, float(symbol_threshold_ms) * 2.0 / 1000.0)
                         runner = getattr(self._context, "strategy_runner", None)
                         if runner is not None:
                             try:

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -417,7 +417,8 @@ def _extract_int(payload: Mapping[str, Any], *keys: str) -> int:
 def _extract_timestamp(payload: Mapping[str, Any], fallback: datetime) -> datetime:
     """Extract a timestamp from *payload* or return *fallback*."""
     candidate = (
-        payload.get("timestamp")
+        payload.get("exchange_timestamp")
+        or payload.get("timestamp")
         or payload.get("ts")
         or payload.get("ts_ms")
         or payload.get("last_trade_time")
@@ -1721,6 +1722,10 @@ class StrategyRunner:
                 candidates.append(
                     {
                         "symbol": snap.canonical_symbol,
+                        "side": side,
+                        "option_type": side,
+                        "direction_bias": side,
+                        "atm_strike": atm,
                         "strike": strike,
                         "ltp": snap.ltp,
                         "bid": snap.bid,
@@ -1844,6 +1849,8 @@ class StrategyRunner:
         candidate_snapshots_obj = metadata.get("candidate_snapshots")
         if not isinstance(candidate_snapshots_obj, list):
             underlying = self._extract_underlying(signal.symbol) or "NIFTY"
+            if underlying in {"NFO", "NSE", ""}:
+                underlying = "NIFTY"
             atm_strike = int(metadata.get("atm_strike") or 0)
             built, refresh_pending = await self.build_candidate_snapshots_async(
                 direction_bias=cast(Literal["CE", "PE"], option_side),
@@ -1855,6 +1862,11 @@ class StrategyRunner:
             if not built:
                 return None, "missing_candidate_snapshots"
             metadata["candidate_snapshots"] = built
+            if not metadata.get("atm_strike"):
+                for snap in built:
+                    if isinstance(snap, dict) and snap.get("atm_strike"):
+                        metadata["atm_strike"] = int(snap["atm_strike"])
+                        break
         if not metadata.get("candidate_snapshots"):
             return None, "missing_candidate_snapshots"
         return dataclasses.replace(signal, metadata=metadata), None
@@ -7684,11 +7696,21 @@ class StrategyRunner:
                 self._reset_execution_state(base_symbol)
                 return SignalExecutionResult(False, "missing_candidate_snapshots")
             if isinstance(candidate_snapshots_obj, list):
+                atm_strike = int(metadata.get("atm_strike") or 0)
+                if atm_strike <= 0:
+                    for snap in candidate_snapshots_obj:
+                        if isinstance(snap, dict) and snap.get("atm_strike"):
+                            atm_strike = int(snap["atm_strike"])
+                            metadata["atm_strike"] = atm_strike
+                            break
+                if atm_strike <= 0:
+                    self._reset_execution_state(base_symbol)
+                    return SignalExecutionResult(False, "missing_atm_strike")
                 try:
                     candidate = self._trade_candidate_selector.select_best_candidate(
                         underlying=underlying,
                         direction_bias=option_side,
-                        atm_strike=int(metadata.get("atm_strike") or 0),
+                        atm_strike=atm_strike,
                         snapshots=[
                             snap
                             for snap in candidate_snapshots_obj
@@ -7711,23 +7733,30 @@ class StrategyRunner:
                 if candidate is None:
                     self._reset_execution_state(base_symbol)
                     return SignalExecutionResult(False, "no_valid_candidate")
-                if normalize_symbol(signal.symbol) != normalize_symbol(candidate.symbol):
+                selected_symbol = normalize_symbol(candidate.symbol)
+                original_symbol = normalize_symbol(signal.symbol)
+                if selected_symbol != original_symbol:
                     self._logger.info(
-                        "SIGNAL_EXECUTION_RESULT accepted=False reason=not_selected_candidate symbol=%s selected_symbol=%s trace_id=%s",
+                        "SIGNAL_SYMBOL_REPLACED_BY_CANDIDATE original=%s selected=%s trace_id=%s",
                         signal.symbol,
                         candidate.symbol,
                         trace_id,
                         extra={
-                            "event": "SIGNAL_EXECUTION_RESULT",
-                            "accepted": False,
-                            "reason": "not_selected_candidate",
-                            "symbol": signal.symbol,
+                            "event": "SIGNAL_SYMBOL_REPLACED_BY_CANDIDATE",
+                            "original_symbol": signal.symbol,
                             "selected_symbol": candidate.symbol,
                             "trace_id": trace_id,
                         },
                     )
-                    self._reset_execution_state(base_symbol)
-                    return SignalExecutionResult(False, "not_selected_candidate")
+                    trade_symbol = selected_symbol
+                    base_symbol = selected_symbol
+                    signal = dataclasses.replace(
+                        signal,
+                        symbol=selected_symbol,
+                        stop_loss=candidate.stop_loss or signal.stop_loss,
+                        take_profit=candidate.target or signal.take_profit,
+                        metadata=metadata,
+                    )
                 metadata["option_score"] = candidate.score
                 metadata["data_score"] = candidate.data_quality_score
                 metadata["spread_pct"] = candidate.spread_pct
@@ -8134,26 +8163,27 @@ class StrategyRunner:
         return atr_val
 
     def _extract_underlying(self, symbol: str) -> str:
-        """Extract underlying from option symbol (e.g., NIFTY from NIFTY2620325200CE)."""
-        if not symbol:
+        """Extract underlying symbol. Args: symbol. Returns: underlying. Raises: none."""
+        raw = str(symbol or "").strip().upper()
+        if not raw:
             return ""
-
-        # Common patterns
-        if symbol.startswith("NIFTY") and not symbol.startswith("NIFTYFUT"):
-            return "NIFTY"
-        if symbol.startswith("BANKNIFTY"):
+        if ":" in raw:
+            _, raw = raw.split(":", 1)
+        compact = "".join(raw.replace("_", " ").split())
+        if compact.startswith("BANKNIFTY"):
             return "BANKNIFTY"
-        if symbol.startswith("FINNIFTY"):
+        if compact.startswith("FINNIFTY"):
             return "FINNIFTY"
-
-        # Generic extraction: take alphabetic prefix
+        if compact.startswith("NIFTY"):
+            return "NIFTY"
         import re
-
-        match = re.match(r"^([A-Z]+)", symbol)
+        match = re.match(r"^([A-Z]+)", compact)
         if match:
-            return match.group(1)
-
-        return symbol
+            prefix = match.group(1)
+            if prefix in {"NFO", "NSE"}:
+                return "NIFTY"
+            return prefix
+        return compact
 
     def _stale_tick_threshold_for_symbol(self, symbol: str) -> float:
         """Return configured stale threshold for symbol type."""

--- a/tests/strategies/test_runner_live_path_guards.py
+++ b/tests/strategies/test_runner_live_path_guards.py
@@ -151,6 +151,13 @@ def test_stale_thresholds_are_instrument_specific() -> None:
     assert runner._stale_tick_threshold_for_symbol('NFO:NIFTY26APRFUT') == 120.0
 
 
+def test_extract_underlying_handles_canonical_derivatives() -> None:
+    runner = _build_runner()
+    assert runner._extract_underlying('NFO:NIFTY26MAY23850CE') == 'NIFTY'
+    assert runner._extract_underlying('NFO:NIFTY26MAYFUT') == 'NIFTY'
+    assert runner._extract_underlying('NSE:NIFTY') == 'NIFTY'
+
+
 def test_handle_signal_entry_transitions_to_signal_and_order_pending(monkeypatch) -> None:
     runner = _build_runner()
     monkeypatch.setattr(
@@ -340,6 +347,7 @@ async def test_live_async_path_builds_candidates_before_sync_handler(monkeypatch
                 {
                     'symbol': 'NFO:NIFTY26APR23800PE',
                     'strike': 23800,
+                    'atm_strike': 23800,
                     'tradable_quote': True,
                 }
             ],
@@ -370,7 +378,36 @@ async def test_live_async_path_builds_candidates_before_sync_handler(monkeypatch
     assert reason is None
     assert prepared is not None
     assert isinstance(prepared.metadata.get('candidate_snapshots'), list)
+    assert prepared.metadata.get('atm_strike') == 23800
     runner.build_candidate_snapshots_async.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_prepare_signal_sanitizes_underlying_to_nifty(monkeypatch) -> None:
+    runner = _build_runner()
+    monkeypatch.setenv('EXECUTION_MODE', 'LIVE')
+    captured: dict[str, object] = {}
+
+    async def _fake_builder(**kwargs):
+        captured.update(kwargs)
+        return ([{'symbol': 'NFO:NIFTY26APR23800PE', 'atm_strike': 23800}], False)
+
+    runner._extract_underlying = lambda _symbol: 'NFO'
+    runner.build_candidate_snapshots_async = _fake_builder
+    signal = Signal(
+        action='BUY',
+        symbol='NFO:NIFTY26APR23800PE',
+        quantity=1,
+        confidence=0.8,
+        reason='test',
+        stop_loss=100.0,
+        take_profit=120.0,
+        metadata={},
+    )
+    prepared, reason = await runner._prepare_signal_for_handling(signal, price=110.0, trace_id='u1')
+    assert reason is None
+    assert prepared is not None
+    assert captured.get('underlying') == 'NIFTY'
 
 
 @pytest.mark.asyncio
@@ -661,6 +698,7 @@ async def test_process_token_awaits_prepare_signal_for_handling(monkeypatch) -> 
 @pytest.mark.asyncio
 async def test_build_candidate_snapshots_per_symbol_refresh_pending() -> None:
     runner = _build_runner()
+    runner.build_candidate_snapshots_async = StrategyRunner.build_candidate_snapshots_async.__get__(runner, StrategyRunner)
     spot = MagicMock()
     spot.ltp = 23800.0
     spot.canonical_symbol = 'NSE:NIFTY'
@@ -747,11 +785,39 @@ async def test_build_candidate_snapshots_per_symbol_refresh_pending() -> None:
         for cand in candidates
     )
     assert refresh_pending is False  # at least one valid candidate keeps overall flag clear
+    assert all('side' in cand and 'option_type' in cand and 'atm_strike' in cand for cand in candidates)
+
+
+def test_live_entry_uses_selected_candidate_symbol(monkeypatch) -> None:
+    runner = _build_runner()
+    monkeypatch.setenv('EXECUTION_MODE', 'LIVE')
+    runner._trade_candidate_selector.select_best_candidate.return_value = MagicMock(
+        symbol='NFO:NIFTY26APR23950CE', score=8.5, data_quality_score=8.5, spread_pct=0.01, stop_loss=95.0, target=130.0
+    )
+    signal = Signal(
+        action='BUY',
+        symbol='NFO:NIFTY26APR24000CE',
+        quantity=1,
+        confidence=0.9,
+        reason='test',
+        stop_loss=100.0,
+        take_profit=120.0,
+        metadata={
+            'atm_strike': 23950,
+            'candidate_snapshots': [{'symbol': 'NFO:NIFTY26APR23950CE', 'atm_strike': 23950, 'side': 'CE', 'tradable_quote': True}],
+            'direction_score': 9.0, 'strategy_score': 9.0, 'option_score': 9.0, 'data_score': 9.0, 'rr_score': 9.0,
+        },
+    )
+    result = runner._handle_entry_signal_inner(
+        signal, 'NFO:NIFTY26APR24000CE', 'NFO:NIFTY26APR24000CE', 110.0, datetime.now(timezone.utc), trace_id='sel-1'
+    )
+    assert result.reason != 'not_selected_candidate'
 
 
 @pytest.mark.asyncio
 async def test_build_candidate_snapshots_all_pending_returns_refresh_pending() -> None:
     runner = _build_runner()
+    runner.build_candidate_snapshots_async = StrategyRunner.build_candidate_snapshots_async.__get__(runner, StrategyRunner)
     spot = MagicMock()
     spot.ltp = 23800.0
     spot.canonical_symbol = 'NSE:NIFTY'

--- a/tests/test_runtime_stability_fixes.py
+++ b/tests/test_runtime_stability_fixes.py
@@ -13,6 +13,10 @@ def test_history_lookback_days_defined() -> None:
     assert source.index('def _history_lookback_days') < source.index('_history_lookback_days(required_bars)')
 
 
+def test_history_lookback_days_executes() -> None:
+    assert app_module._history_lookback_days(100) >= 2
+
+
 def test_botcontext_slots_include_evaluation_ready() -> None:
     assert 'evaluation_ready' in app_module.BotContext.__slots__
     assert 'runner_task' in app_module.BotContext.__slots__


### PR DESCRIPTION
### Motivation

- Signals for NIFTY options were being blocked because `_extract_underlying()` returned exchange prefixes like `NFO`/`NSE`, causing candidate building to request spot snapshots for `NFO` and fail `spot_missing` canonicalization. 
- Candidate snapshots lacked selector-required context (`side`/`atm_strike`), causing `TradeCandidateSelector` to reject valid candidates. 
- `_history_lookback_days()` could raise a `NameError` at runtime because `math` was only imported locally elsewhere. 
- Runtime freshness checks and timestamp extraction were too strict or ignored `exchange_timestamp`, producing spurious stale/backoff behavior during normal option candle close activity.

### Description

- Added module-level `import math` in `src/nifty_scalper_bot/core/app.py` so `_history_lookback_days()` can call `math.ceil()` safely. 
- Rewrote `StrategyRunner._extract_underlying()` in `src/nifty_scalper_bot/strategies/runner.py` to strip exchange prefixes (`NFO:`, `NSE:`), normalize derivatives to `NIFTY` (and handle `BANKNIFTY`/`FINNIFTY`), and never return `NFO`/`NSE` as the underlying. 
- Hardened `_prepare_signal_for_handling()` to sanitize extracted underlyings (`if underlying in {"NFO","NSE",""}: underlying = "NIFTY"`) and to propagate `atm_strike` from built candidate snapshots into the signal `metadata`. 
- Enriched `build_candidate_snapshots_async()` candidate dicts with `side`, `option_type`, `direction_bias`, and `atm_strike` so the selector has required context. 
- In `_handle_entry_signal_inner()`: require a non-zero `atm_strike` (fallback to snapshot `atm_strike`), pass resolved `atm_strike` into `select_best_candidate()`, and replace the prior hard-reject on symbol mismatch with a symbol-rewrite flow that logs `SIGNAL_SYMBOL_REPLACED_BY_CANDIDATE`, updates the `signal` (symbol/SL/TP/metadata), and continues execution. 
- Updated runner timestamp extraction order to prefer `exchange_timestamp` before other fields in `src/nifty_scalper_bot/strategies/runner.py`. 
- Relaxed `RuntimeSelfChecker._check_data_freshness()` in `src/nifty_scalper_bot/core/app.py` by applying per-symbol thresholds (`NFO:*` -> 60s, `NSE:NIFTY` -> 30s), and skip backoff when the system is `hard_ready` and only a subset of critical symbols are stale. 
- Added regression tests to cover underlying parsing, snapshot metadata presence, underlying sanitization in preparation, candidate-symbol replacement behavior, and `_history_lookback_days()` execution, plus small test harness bindings to run async methods within tests.

### Testing

- Ran `python -m compileall -q src` which completed successfully. 
- Ran targeted unit tests: `pytest -q tests/strategies/test_runner_live_path_guards.py tests/test_runtime_stability_fixes.py tests/strategies/test_trade_selector.py` which passed. 
- Attempted broader test collection `pytest -q tests/strategies tests/core tests/data` and observed an unrelated collection failure in `tests/data/test_resolver_lots_delta.py` due to a pre-existing missing export `atm_strike_for_spot` (this failure is external to the changes in this PR). 
- All added/changed tests for the execution path (underlying extraction, candidate metadata, ATM propagation, symbol-replacement path, and history lookback) run and pass in the targeted test runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9abd83ec88324ac8132c5f9044977)