### PR TITLE
fix: unblock live signal handoff with snapshot and ws reconnect guards

### DIFF
--- a/src/nifty_scalper_bot/core/strategy_manager.py
+++ b/src/nifty_scalper_bot/core/strategy_manager.py
@@ -2082,6 +2082,29 @@ class StrategyManager(_BaseStrategyManager):
             self._observability_counters["signals_blocked_by_risk"] += 1
             count = self._symbol_invalid_counts.get(symbol, 0) + 1
             self._symbol_invalid_counts[symbol] = count
+            is_nifty_context_symbol = symbol in {"NSE:NIFTY", "NIFTY"}
+            if invalid_reason == "vwap_zero_or_invalid" and is_nifty_context_symbol:
+                log.info(
+                    "CONTEXT_SYMBOL_INVALID_NOT_SUSPENDED symbol=%s reason=%s",
+                    symbol,
+                    invalid_reason,
+                    extra={
+                        "event": "CONTEXT_SYMBOL_INVALID_NOT_SUSPENDED",
+                        "symbol": symbol,
+                        "reason_code": invalid_reason,
+                        "invalid_streak": count,
+                    },
+                )
+                _log_reject(
+                    "data_invalid",
+                    {
+                        "reason_code": invalid_reason,
+                        "invalid_streak": count,
+                        "ltp": current_price,
+                        "vwap": vwap,
+                    },
+                )
+                return None
             if count > self._symbol_invalid_threshold:
                 if symbol not in self._symbol_temporarily_ineligible:
                     self._symbol_temporarily_ineligible[symbol] = invalid_reason

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -6184,6 +6184,23 @@ class MarketDataManager:
                 and (self._tick_wallclock(row) or 0.0) >= recent_cutoff
             )
             bars = list(self._ohlc.get(self._bar_symbol_key(canonical), ()))
+        if ltp is None:
+            latest_bar = bars[-1] if bars else {}
+            candle_close = _coerce_float(latest_bar.get("close")) if isinstance(latest_bar, Mapping) else None
+            if candle_close is not None and candle_close > 0:
+                ltp = candle_close
+                source = "ws_candle_fallback"
+                self._logger.info(
+                    "SPOT_SNAPSHOT_FROM_CANDLE_FALLBACK symbol=%s ltp=%s",
+                    canonical,
+                    round(candle_close, 4),
+                    extra={
+                        "event": "SPOT_SNAPSHOT_FROM_CANDLE_FALLBACK",
+                        "symbol": canonical,
+                        "ltp": candle_close,
+                        "source": source,
+                    },
+                )
         latest = bars[-1] if bars else {}
         latest_candle_provisional = bool(latest.get("provisional")) if isinstance(latest, Mapping) else False
         latest_candle_synthetic = bool(latest.get("synthetic")) if isinstance(latest, Mapping) else False

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -1848,6 +1848,20 @@ class StrategyRunner:
             return dataclasses.replace(signal, metadata=metadata), None
         candidate_snapshots_obj = metadata.get("candidate_snapshots")
         if not isinstance(candidate_snapshots_obj, list):
+            fallback_candidate = self._build_single_candidate_from_signal(
+                signal=signal,
+                metadata=metadata,
+                option_side=cast(Literal["CE", "PE"], option_side),
+            )
+            if fallback_candidate is not None:
+                metadata["candidate_snapshots"] = [fallback_candidate]
+                metadata.setdefault("atm_strike", int(fallback_candidate.get("atm_strike") or 0))
+                self._logger.info(
+                    "CANDIDATE_FALLBACK_FROM_SIGNAL_USED symbol=%s",
+                    signal.symbol,
+                    extra={"event": "CANDIDATE_FALLBACK_FROM_SIGNAL_USED", "symbol": signal.symbol},
+                )
+                return dataclasses.replace(signal, metadata=metadata), None
             underlying = self._extract_underlying(signal.symbol) or "NIFTY"
             if underlying in {"NFO", "NSE", ""}:
                 underlying = "NIFTY"
@@ -1870,6 +1884,45 @@ class StrategyRunner:
         if not metadata.get("candidate_snapshots"):
             return None, "missing_candidate_snapshots"
         return dataclasses.replace(signal, metadata=metadata), None
+
+    def _build_single_candidate_from_signal(
+        self,
+        *,
+        signal: Signal,
+        metadata: Mapping[str, Any],
+        option_side: Literal["CE", "PE"],
+    ) -> dict[str, Any] | None:
+        """Build a single candidate snapshot from signal and MDM data. Args: signal/metadata/option_side. Returns: candidate or none. Raises: none."""
+        try:
+            if self._market_data is None:
+                return None
+            get_snapshot = getattr(self._market_data, "get_symbol_snapshot", None)
+            if not callable(get_snapshot):
+                return None
+            snapshot = get_snapshot(signal.symbol)
+            ltp = float(snapshot.ltp) if snapshot.ltp is not None and float(snapshot.ltp) > 0 else None
+            if ltp is None:
+                return None
+            bid = float(snapshot.bid) if snapshot.bid is not None and float(snapshot.bid) > 0 else ltp
+            ask = float(snapshot.ask) if snapshot.ask is not None and float(snapshot.ask) > 0 else ltp
+            strike_match = re.search(r"(\d{5})(CE|PE)$", str(signal.symbol).upper())
+            parsed_strike = int(strike_match.group(1)) if strike_match is not None else 0
+            strike = int(metadata.get("strike") or parsed_strike or metadata.get("atm_strike") or 0)
+            atm_strike = int(metadata.get("atm_strike") or strike)
+            return {
+                "symbol": signal.symbol,
+                "side": option_side,
+                "strike": strike,
+                "atm_strike": atm_strike,
+                "ltp": ltp,
+                "bid": bid,
+                "ask": ask,
+                "tradable_quote": bool(snapshot.tradable_quote or ltp > 0),
+                "source": str(snapshot.source or "signal_snapshot"),
+            }
+        except Exception as exc:  # noqa: BLE001
+            self._logger.error("Failure in _build_single_candidate_from_signal: %s", exc, exc_info=exc)
+            return None
 
     @staticmethod
     def _call_contract_resolver(
@@ -5138,6 +5191,23 @@ class StrategyRunner:
                 )
                 return False
             required_bars = self._required_bars_for_symbol(symbol)
+            if self._is_tradable_symbol(symbol):
+                min_live_bars = int(os.getenv("OPTION_MIN_LIVE_BARS", "3"))
+                capped_required = max(1, min(required_bars, min_live_bars))
+                if capped_required != required_bars:
+                    self._logger.info(
+                        "OPTION_LIVE_BARS_REQUIREMENT_CAPPED symbol=%s required=%d capped_required=%d",
+                        symbol,
+                        required_bars,
+                        capped_required,
+                        extra={
+                            "event": "OPTION_LIVE_BARS_REQUIREMENT_CAPPED",
+                            "symbol": symbol,
+                            "required": required_bars,
+                            "capped_required": capped_required,
+                        },
+                    )
+                    required_bars = capped_required
             if not self._indicator_engine.has_min_bars(symbol, required_bars):
                 history_count = len(self._indicator_engine.get_history(symbol) or [])
                 if history_count < required_bars:

--- a/src/nifty_scalper_bot/streaming/websocket_manager.py
+++ b/src/nifty_scalper_bot/streaming/websocket_manager.py
@@ -445,6 +445,19 @@ class WebSocketManager:
             async with self._connect_lock:
                 if self._shutdown or self._manual_disconnect:
                     return
+                if self._connected.is_set() and self._ticker is not None and self._tokens:
+                    self._logger.info(
+                        "WS_CONNECT_SKIPPED already_connected reason=%s tokens=%d",
+                        reason,
+                        len(self._tokens),
+                        extra={
+                            "event": "WS_CONNECT_SKIPPED",
+                            "reason": reason,
+                            "state": "already_connected",
+                            "tokens": len(self._tokens),
+                        },
+                    )
+                    return
         
                 self._state = ConnectionState.CONNECTING
                 self._connected.clear()

--- a/tests/data/test_market_data_manager.py
+++ b/tests/data/test_market_data_manager.py
@@ -923,6 +923,27 @@ def test_market_snapshot_handles_missing_bid_ask(
     assert snapshot.tick_age_s is not None
 
 
+def test_market_snapshot_uses_candle_close_when_ltp_missing(
+    broker: DummyBroker, ws: DummyWebSocket
+) -> None:
+    manager = MarketDataManager(broker, ws)
+    manager._store_tick(  # noqa: SLF001
+        "NSE:NIFTY",
+        {
+            "symbol": "NSE:NIFTY",
+            "ltp": None,
+            "timestamp": time.time(),
+            "received_at": time.time(),
+            "source": "ws",
+        },
+    )
+    bar_key = manager._bar_symbol_key("NSE:NIFTY")  # noqa: SLF001
+    manager._ohlc[bar_key].append({"close": 25234.5, "provisional": False})  # noqa: SLF001
+    snapshot = manager.get_symbol_snapshot("NSE:NIFTY")
+    assert snapshot.ltp == 25234.5
+    assert snapshot.source == "ws_candle_fallback"
+
+
 def test_zombie_restart_respects_cooldown(
     monkeypatch: pytest.MonkeyPatch, broker: DummyBroker, ws: DummyWebSocket
 ) -> None:

--- a/tests/strategies/test_runner_live_path_guards.py
+++ b/tests/strategies/test_runner_live_path_guards.py
@@ -4,6 +4,7 @@ import asyncio
 from collections import deque
 from datetime import datetime, timezone
 import logging
+from types import SimpleNamespace
 import threading
 from unittest.mock import AsyncMock, MagicMock
 import pytest
@@ -438,6 +439,52 @@ async def test_live_async_path_blocks_on_refresh_pending(monkeypatch) -> None:
     )
     assert prepared is None
     assert reason == 'candidate_refresh_pending'
+
+
+@pytest.mark.asyncio
+async def test_live_async_path_uses_signal_candidate_fallback(monkeypatch) -> None:
+    runner = _build_runner()
+    monkeypatch.setenv('EXECUTION_MODE', 'LIVE')
+    snapshot = SimpleNamespace(
+        ltp=111.0,
+        bid=None,
+        ask=None,
+        source='ws',
+        tradable_quote=False,
+    )
+    runner._market_data = MagicMock()
+    runner._market_data.get_symbol_snapshot = MagicMock(return_value=snapshot)
+    runner.build_candidate_snapshots_async = AsyncMock(return_value=([], True))
+    signal = Signal(
+        action='BUY',
+        symbol='NFO:NIFTY26APR23800PE',
+        quantity=1,
+        confidence=0.8,
+        reason='test',
+        stop_loss=100.0,
+        take_profit=120.0,
+        metadata={},
+    )
+    prepared, reason = await runner._prepare_signal_for_handling(signal, price=110.0, trace_id='fallback')
+    assert reason is None
+    assert prepared is not None
+    candidate = prepared.metadata['candidate_snapshots'][0]
+    assert candidate['ltp'] == 111.0
+    assert candidate['bid'] == 111.0
+    assert candidate['ask'] == 111.0
+
+
+def test_strategy_evaluation_caps_required_option_bars(monkeypatch) -> None:
+    runner = _build_runner()
+    runner._active_symbols = {'NFO:NIFTY26APR23800PE'}
+    monkeypatch.setenv('OPTION_MIN_LIVE_BARS', '3')
+    runner._required_bars_for_symbol = lambda _s: 5
+    runner._is_tradable_symbol = lambda _s: True
+    runner._is_context_symbol = lambda _s: False
+    runner._indicator_engine.has_min_bars = MagicMock(return_value=True)
+    allowed = runner._strategy_evaluation_allowed('NFO:NIFTY26APR23800PE')
+    assert allowed is True
+    runner._indicator_engine.has_min_bars.assert_called_once_with('NFO:NIFTY26APR23800PE', 3)
 
 
 def test_contract_resolver_invoked_with_side_and_strikes() -> None:

--- a/tests/streaming/test_websocket_manager.py
+++ b/tests/streaming/test_websocket_manager.py
@@ -138,6 +138,21 @@ async def test_watchdog_schedules_reconnect_for_missing_pong(
 
 
 @pytest.mark.asyncio
+async def test_connect_once_skips_when_already_connected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(ws_module, "KiteTicker", FakeKiteTicker)
+    manager = ws_module.WebSocketManager("k", "t", [111], trading_window_enabled=False)
+    await manager.connect()
+    ticker = manager.ticker
+    assert isinstance(ticker, FakeKiteTicker)
+    calls_before = ticker.connect_calls
+    await manager._connect_once("token_update")
+    assert ticker.connect_calls == calls_before
+    await manager.disconnect()
+
+
+@pytest.mark.asyncio
 async def test_watchdog_suppresses_pong_reconnect_outside_trading_window(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
### Motivation
- Live option signals were getting blocked before order placement due to missing tick LTP (`spot_missing`), candidate refresh blocks (`candidate_refresh_pending`), and option bar gating (`OPTION_HISTORY_COLD`), and websocket reconnect churn caused noisy reconnects/handshake timeouts.
- The goal is a surgical set of fixes so generated signals can progress to the `RUNNER_ORDER_REQUEST` path while preserving existing `OrderManager` safety gates and overall runtime safety.

### Description
- Market data snapshot fallback: in `MarketDataManager.get_symbol_snapshot()` use the latest OHLC candle `close` as LTP when the latest tick LTP is missing and mark the snapshot `source` as `ws_candle_fallback`, emitting `SPOT_SNAPSHOT_FROM_CANDLE_FALLBACK` log. (`src/nifty_scalper_bot/data/market_data_manager.py`)
- Signal candidate fast-path: in `StrategyRunner._prepare_signal_for_handling()` add `_build_single_candidate_from_signal()` to build one candidate from the original signal symbol + MDM snapshot and use it to avoid immediate `candidate_refresh_pending` when a fresh snapshot exists; bid/ask fallback to LTP is applied only at candidate-prep level and `OrderManager` gates remain unchanged. (`src/nifty_scalper_bot/strategies/runner.py`)
- Option live-bars gating: in `StrategyRunner._strategy_evaluation_allowed()` cap required live bars for tradable NFO option symbols via `OPTION_MIN_LIVE_BARS` (default `3`) and log `OPTION_LIVE_BARS_REQUIREMENT_CAPPED` when capping happens. (`src/nifty_scalper_bot/strategies/runner.py`)
- Context symbol safety: in `StrategyManager` avoid suspending `NSE:NIFTY` / `NIFTY` for `vwap_zero_or_invalid`, log `CONTEXT_SYMBOL_INVALID_NOT_SUSPENDED` instead of adding to `_symbol_temporarily_ineligible`. (`src/nifty_scalper_bot/core/strategy_manager.py`)
- WebSocket reconnect guard: in `WebSocketManager._connect_once()` skip reconnect when already connected with existing tokens (token updates should subscribe rather than force reconnect) and emit `WS_CONNECT_SKIPPED` log. (`src/nifty_scalper_bot/streaming/websocket_manager.py`)
- Added observability logs: `SPOT_SNAPSHOT_FROM_CANDLE_FALLBACK`, `CANDIDATE_FALLBACK_FROM_SIGNAL_USED`, `OPTION_LIVE_BARS_REQUIREMENT_CAPPED`, `CONTEXT_SYMBOL_INVALID_NOT_SUSPENDED`, and `WS_CONNECT_SKIPPED`.
- Tests: added targeted unit tests to cover candle LTP fallback, signal candidate fallback, option bar cap behavior, and websocket reconnect skip. (tests updated under `tests/data/` and `tests/strategies/` and `tests/streaming/`)

### Testing
- Ran targeted pytest invocations: `pytest -q tests/data/test_market_data_manager.py::test_market_snapshot_uses_candle_close_when_ltp_missing tests/strategies/test_runner_live_path_guards.py::test_live_async_path_uses_signal_candidate_fallback tests/strategies/test_runner_live_path_guards.py::test_strategy_evaluation_caps_required_option_bars tests/streaming/test_websocket_manager.py::test_connect_once_skips_when_already_connected` and the suite passed: `.... [100%]`.
- No changes were made to `OrderManager` semantics or final safety gates; broader `./run_checks.sh` (lint/mypy/full pytest/backtest) was not executed in this pass and should be run prior to deploy.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9b4569eb08324a53d85dc309ea9e0)