### PR TITLE
fix: unblock premium squeeze execution and readiness logging

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -6802,15 +6802,16 @@ async def _build_and_hydrate_live_basket_from_spot(
                 LOGGER.debug("RUNNER_ADD_SYMBOL_SKIPPED symbol=%s", symbol)
         mark_ready = getattr(runner, "mark_ready", None)
         if callable(mark_ready):
-            mark_ready(ready_symbols)
-            LOGGER.info(
-                "RUNNER_READY_MARKED_FROM_LIVE_BASKET symbols=%d",
-                len(ready_symbols),
-                extra={
-                    "event": "RUNNER_READY_MARKED_FROM_LIVE_BASKET",
-                    "symbols": ready_symbols,
-                },
-            )
+            runner_ready = bool(mark_ready(ready_symbols))
+            if runner_ready:
+                LOGGER.info(
+                    "RUNNER_READY_MARKED_FROM_LIVE_BASKET symbols=%d",
+                    len(ready_symbols),
+                    extra={
+                        "event": "RUNNER_READY_MARKED_FROM_LIVE_BASKET",
+                        "symbols": ready_symbols,
+                    },
+                )
     data_hub = getattr(ctx, "data_hub", None)
     flush_pending = (
         getattr(data_hub, "flush_pending_live_subscriptions", None)

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -1799,7 +1799,23 @@ class StrategyRunner:
                     extra={"event": "SIGNAL_EXECUTION_RESULT", "symbol": signal.symbol, "accepted": False, "reason": prepare_reason, "order_id": None, "trace_id": trace_id},
                 )
                 return
-            self._handle_signal(prepared_signal, price, now, trace_id=trace_id)
+            result = self._handle_signal(prepared_signal, price, now, trace_id=trace_id)
+            self._logger.info(
+                "SIGNAL_EXECUTION_RESULT symbol=%s accepted=%s reason=%s order_id=%s trace_id=%s",
+                signal.symbol,
+                result.accepted,
+                result.reason,
+                result.order_id,
+                trace_id,
+                extra={
+                    "event": "SIGNAL_EXECUTION_RESULT",
+                    "symbol": signal.symbol,
+                    "accepted": result.accepted,
+                    "reason": result.reason,
+                    "order_id": result.order_id,
+                    "trace_id": trace_id,
+                },
+            )
 
         try:
             loop = asyncio.get_running_loop()
@@ -1809,7 +1825,23 @@ class StrategyRunner:
             )
             if prepared_signal is None:
                 return False, prepare_reason
-            self._handle_signal(prepared_signal, price, now, trace_id=trace_id)
+            result = self._handle_signal(prepared_signal, price, now, trace_id=trace_id)
+            self._logger.info(
+                "SIGNAL_EXECUTION_RESULT symbol=%s accepted=%s reason=%s order_id=%s trace_id=%s",
+                signal.symbol,
+                result.accepted,
+                result.reason,
+                result.order_id,
+                trace_id,
+                extra={
+                    "event": "SIGNAL_EXECUTION_RESULT",
+                    "symbol": signal.symbol,
+                    "accepted": result.accepted,
+                    "reason": result.reason,
+                    "order_id": result.order_id,
+                    "trace_id": trace_id,
+                },
+            )
             return True, None
         loop.create_task(_job())
         return True, "signal_preparation_scheduled"
@@ -2477,7 +2509,7 @@ class StrategyRunner:
         async with self._ingest_lock:
             self._ingest_historical_bar_unlocked(data)
 
-    def mark_ready(self, symbols: list[str]) -> None:
+    def mark_ready(self, symbols: list[str]) -> bool:
         """
         Public API to finalize startup hydration.
         Explicitly registers symbols and sets readiness flags.
@@ -2552,7 +2584,11 @@ class StrategyRunner:
                 f"✅ StrategyRunner marked READY with {len(valid_symbols)} active symbols"
             )
         else:
-            self._runner_state = RunnerState.HISTORICAL_READY
+            self._runner_state = (
+                RunnerState.WARMING_UP
+                if len(valid_symbols) == 0
+                else RunnerState.HISTORICAL_READY
+            )
             self._logger.info(
                 "mark_ready: HISTORICAL_READY "
                 f"(valid={len(valid_symbols)}/{len(symbols)}, "
@@ -2600,6 +2636,7 @@ class StrategyRunner:
                     "ready": _ok,
                 },
             )
+        return self.ready
 
     def _set_symbol_hydration_state(
         self,
@@ -6758,8 +6795,9 @@ class StrategyRunner:
                         ).inc()
 
                         self._logger.info(
-                            "SIGNAL_GENERATED",
+                            "SIGNAL_CANDIDATE_GENERATED",
                             extra={
+                                "event": "SIGNAL_CANDIDATE_GENERATED",
                                 "strategy": str(
                                     signal.metadata.get("strategy")
                                     if signal.metadata
@@ -6920,6 +6958,20 @@ class StrategyRunner:
                     symbol, signal.action, signal.reason, price,
                     extra={"event": "signal_executing", "symbol": symbol,
                            "action": signal.action},
+                )
+                self._logger.info(
+                    "SIGNAL_GENERATED symbol=%s action=%s reason=%s trace_id=%s",
+                    symbol,
+                    signal.action,
+                    signal.reason,
+                    trace_id,
+                    extra={
+                        "event": "SIGNAL_GENERATED",
+                        "symbol": symbol,
+                        "action": signal.action,
+                        "reason": signal.reason,
+                        "trace_id": trace_id,
+                    },
                 )
                 scheduled, prepare_reason = self._schedule_signal_preparation(
                     signal, price, now, trace_id
@@ -7136,7 +7188,6 @@ class StrategyRunner:
         tp_pct = self._vwap_tp_pct
         calculated_sl = price * (1 - sl_pct / 100)
         calculated_tp = price * (1 + tp_pct / 100)
-        self._premium_squeeze_last_signal_ts[underlying] = now_epoch
         self._logger.info(
             "PREMIUM_SQUEEZE_SIGNAL_EMITTED symbol=%s rsi=%.2f trace_id=%s",
             symbol,
@@ -7729,9 +7780,6 @@ class StrategyRunner:
                 log_throttled(self._logger, "runner_order_attempt_rate", "RUNNER_SIGNAL_SUPPRESSED_EXECUTION_HALTED", interval_sec=300.0, level=logging.INFO, extra={"event": "RUNNER_SIGNAL_SUPPRESSED_EXECUTION_HALTED", "symbol": base_symbol, "reason": "max_order_attempts_per_minute"})
                 self._reset_execution_state(base_symbol)
                 return SignalExecutionResult(False, "max_order_attempts_per_minute")
-            if reason_key == "premium_momentum_squeeze":
-                self._premium_squeeze_last_signal_ts[underlying] = now_epoch
-
             metadata = dict(signal.metadata or {})
             mode = str(os.getenv("EXECUTION_MODE", "SHADOW")).strip().upper()
             is_live_mode = mode == "LIVE" or (
@@ -8096,6 +8144,8 @@ class StrategyRunner:
                 )
                 self._underlying_last_signal_ts[underlying] = now_epoch
                 self._reason_last_signal_ts[underlying_reason_key] = now_epoch
+                if reason_key == "premium_momentum_squeeze":
+                    self._premium_squeeze_last_signal_ts[underlying] = now_epoch
                 self._order_attempt_window.append(now_epoch)
                 try:
                     self._record_trade(

--- a/tests/strategies/test_runner_execution_gates.py
+++ b/tests/strategies/test_runner_execution_gates.py
@@ -85,6 +85,20 @@ def test_mark_ready_controls_readiness_not_start() -> None:
     assert symbol in runner._active_symbols
 
 
+def test_mark_ready_stays_unready_when_no_valid_hydrated_symbols() -> None:
+    runner = _runner()
+    symbol = 'NIFTY25JAN25000CE'
+    runner._indicator_engine.has_min_bars.return_value = False
+    runner._indicator_engine.get_history.return_value = []
+    runner._active_symbols = set()
+
+    marked_ready = runner.mark_ready([symbol])
+
+    assert marked_ready is False
+    assert runner.ready is False
+    assert runner._runner_state == RunnerState.WARMING_UP
+
+
 def test_mark_symbol_unready_sets_state_flags() -> None:
     runner = _runner()
     symbol = "NIFTY25JAN25000CE"

--- a/tests/strategies/test_runner_live_path_guards.py
+++ b/tests/strategies/test_runner_live_path_guards.py
@@ -141,6 +141,31 @@ def test_premium_squeeze_suppresses_second_signal_within_cooldown() -> None:
     assert runner._order_manager.calls == 1
 
 
+def test_premium_squeeze_does_not_self_suppress_on_first_execution() -> None:
+    runner = _build_runner()
+    runner._order_manager.submit_trade_plan = MagicMock(return_value='order-1')
+    signal = Signal(
+        action='BUY',
+        symbol='NFO:NIFTY26APR23800CE',
+        quantity=1,
+        confidence=0.9,
+        reason='premium_momentum_squeeze',
+        stop_loss=100.0,
+        take_profit=120.0,
+        metadata={},
+    )
+    result = runner._handle_entry_signal_inner(
+        signal,
+        base_symbol='NFO:NIFTY26APR23800CE',
+        trade_symbol='NFO:NIFTY26APR23800CE',
+        trade_price=110.0,
+        timestamp=datetime.now(timezone.utc),
+        trace_id='t-premium-first',
+    )
+    assert result.accepted is True
+    assert result.reason == 'order_submitted'
+    assert runner._premium_squeeze_last_signal_ts.get('NIFTY', 0.0) > 0.0
+
 def test_stale_thresholds_are_instrument_specific() -> None:
     runner = _build_runner()
     runner._option_stale_tick_seconds = 900.0
@@ -951,6 +976,37 @@ def test_schedule_signal_preparation_uses_asyncio_run_without_loop() -> None:
     runner._handle_signal.assert_called_once()
 
 
+def test_schedule_signal_preparation_logs_result_when_handle_signal_rejects(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = _build_runner()
+    logs: list[tuple[tuple[object, ...], dict[str, object]]] = []
+    runner._logger.info = lambda *args, **kwargs: logs.append((args, kwargs))  # type: ignore[method-assign]
+
+    async def _fake_prepare(signal, price, trace_id):
+        return signal, None
+
+    runner._prepare_signal_for_handling = _fake_prepare
+    signal = Signal(
+        action='BUY',
+        symbol='NFO:NIFTY26APR23800CE',
+        quantity=1,
+        confidence=0.9,
+        reason='unit_test',
+        stop_loss=100.0,
+        take_profit=120.0,
+        metadata={},
+    )
+    runner._handle_signal = MagicMock(return_value=SignalExecutionResult(False, 'blocked'))  # type: ignore[method-assign]
+    runner._schedule_signal_preparation(
+        signal, 101.0, datetime.now(timezone.utc), 'trace-reject'
+    )
+    assert any(
+        kwargs.get('extra', {}).get('event') == 'SIGNAL_EXECUTION_RESULT'
+        and kwargs.get('extra', {}).get('accepted') is False
+        for _, kwargs in logs
+    )
+
 @pytest.mark.asyncio
 async def test_schedule_signal_preparation_schedules_when_loop_running() -> None:
     runner = _build_runner()
@@ -988,3 +1044,12 @@ def test_runner_no_async_event_loop_fallback_in_runner_source() -> None:
     assert 'asyncio.run(\n                        self._prepare_signal_for_handling' not in source
     # _handle_entry_signal_inner must not build snapshots in sync path
     assert 'asyncio.run(\n                        self.build_candidate_snapshots_async' not in source
+
+
+def test_signal_generated_log_occurs_after_regime_skip_guard_in_source() -> None:
+    from pathlib import Path
+
+    source = Path('src/nifty_scalper_bot/strategies/runner.py').read_text(encoding='utf-8')
+    assert source.index('Strategy skipped due to detected market regime') < source.index(
+        'SIGNAL_GENERATED symbol=%s action=%s reason=%s trace_id=%s'
+    )


### PR DESCRIPTION
### Motivation
- Premium-squeeze candidate signals were mutating cooldown timestamps at generation time and suppressing their own execution before orders were submitted, while scheduled signal handling did not consistently log execution results and signal lifecycle logs appeared before regime/cooldown filters.
- mark_ready() could mark the runner as ready even when no hydrated symbols existed, causing misleading READY logs and premature execution enabling.

### Description
- Stop mutating `_premium_squeeze_last_signal_ts` inside `_maybe_generate_premium_squeeze_signal()` so candidate generation does not set cooldowns. 
- Move setting of `self._premium_squeeze_last_signal_ts[underlying]` into `_handle_entry_signal_inner()` and only set it after `submit_trade_plan()` returns a success `order_id`.
- Capture the return value of `_handle_signal()` inside `_schedule_signal_preparation()` for both the async `_job` and the synchronous fallback, and always emit a structured `SIGNAL_EXECUTION_RESULT` log with `accepted`, `reason`, `order_id`, `symbol`, and `trace_id`.
- Rename the early pre-filter log `SIGNAL_GENERATED` to `SIGNAL_CANDIDATE_GENERATED`, and emit `SIGNAL_GENERATED` only after regime filters, cooldowns, scoring and candidate selection and immediately before the `RUNNER_ORDER_REQUEST` path.
- Change `mark_ready()` to return a boolean readiness value and keep the runner in `WARMING_UP` (not `HISTORICAL_READY`/EXECUTION_ENABLED) when valid hydrated symbols are zero; update startup (`core/app.py`) to log `RUNNER_READY_MARKED_FROM_LIVE_BASKET` only when `mark_ready()` returns true.
- Add focused unit tests covering premium-squeeze non-self-suppression on first execution, `_schedule_signal_preparation` logging of `SignalExecutionResult` when `_handle_signal` rejects, that `SIGNAL_GENERATED` appears after regime-skip in source order, and that `mark_ready()` does not mark ready when valid hydrated symbols are zero.

### Testing
- Ran `bash ./run_checks.sh` in CI-like environment which bootstrapped the venv and attempted the checks; the full suite failed due to unrelated environment/test issues (initial `pytest` missing, then a pre-existing `ImportError` from `tests/data/test_resolver_lots_delta.py`) and not due to these changes.
- Executed targeted unit tests with pytest: `. .venv/bin/activate && pytest -q tests/strategies/test_runner_live_path_guards.py tests/strategies/test_runner_execution_gates.py` and they passed (all added/modified strategy tests green).
- Verified the new tests added: `test_premium_squeeze_does_not_self_suppress_on_first_execution`, `test_schedule_signal_preparation_logs_result_when_handle_signal_rejects`, `test_signal_generated_log_occurs_after_regime_skip_guard_in_source`, and `test_mark_ready_stays_unready_when_no_valid_hydrated_symbols` which exercise the reported failure modes and pass locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9b8217f3c8324b3a0cae5ecf80d94)