### PR TITLE
fix: throttle noisy logs, harden candidate selection, and align NIFTY lot size

### DIFF
--- a/src/nifty_scalper_bot/config/settings.py
+++ b/src/nifty_scalper_bot/config/settings.py
@@ -1190,7 +1190,7 @@ def _build_risk_settings() -> RiskSettings:
     if max_lots < min_lots:
         max_lots = min_lots
     atr_multiple = _env_float("ATR_MULT", default=1.0, minimum=0.0)
-    contract_lot_size = _env_int("NIFTY_LOT_SIZE", default=75, minimum=1)
+    contract_lot_size = _env_int("NIFTY_LOT_SIZE", default=65, minimum=1)
     return RiskSettings(
         daily_loss_pct=daily_loss_pct,
         daily_pnl_cap_pct=_env_float(

--- a/src/nifty_scalper_bot/config/settings.py
+++ b/src/nifty_scalper_bot/config/settings.py
@@ -1190,7 +1190,7 @@ def _build_risk_settings() -> RiskSettings:
     if max_lots < min_lots:
         max_lots = min_lots
     atr_multiple = _env_float("ATR_MULT", default=1.0, minimum=0.0)
-    contract_lot_size = _env_int("NIFTY_LOT_SIZE", default=65, minimum=1)  # NIFTY options lot size = 65 (current)
+    contract_lot_size = _env_int("NIFTY_LOT_SIZE", default=75, minimum=1)
     return RiskSettings(
         daily_loss_pct=daily_loss_pct,
         daily_pnl_cap_pct=_env_float(

--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -4216,10 +4216,10 @@ def initialize_components(settings: Settings | None = None) -> BotContext:
             # Fallback defaults
             sym_upper = symbol.upper()
             if "NIFTY" in sym_upper:
-                env_lot = int(getattr(settings.risk, "contract_lot_size", 75) or 75)
+                env_lot = int(getattr(settings.risk, "contract_lot_size", 65) or 65)
                 source = "env"
                 if env_lot <= 0:
-                    env_lot = 75
+                    env_lot = 65
                     source = "fallback"
                 LOGGER.info(
                     "LOT_SIZE_RESOLVED underlying=NIFTY lot_size=%s source=%s",
@@ -4234,10 +4234,10 @@ def initialize_components(settings: Settings | None = None) -> BotContext:
         except Exception:
             if "NIFTY" in symbol.upper():
                 LOGGER.info(
-                    "LOT_SIZE_RESOLVED underlying=NIFTY lot_size=75 source=fallback",
-                    extra={"event": "LOT_SIZE_RESOLVED", "underlying": "NIFTY", "lot_size": 75, "source": "fallback"},
+                    "LOT_SIZE_RESOLVED underlying=NIFTY lot_size=65 source=fallback",
+                    extra={"event": "LOT_SIZE_RESOLVED", "underlying": "NIFTY", "lot_size": 65, "source": "fallback"},
                 )
-                return 75
+                return 65
             return 1
 
     # Always attach the provider

--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -4206,22 +4206,43 @@ def initialize_components(settings: Settings | None = None) -> BotContext:
         try:
             lot = instrument_manager.get_lot_size(symbol)
             if lot and lot > 0:
+                if "NIFTY" in symbol.upper():
+                    LOGGER.info(
+                        "LOT_SIZE_RESOLVED underlying=NIFTY lot_size=%s source=instrument_dump",
+                        int(lot),
+                        extra={"event": "LOT_SIZE_RESOLVED", "underlying": "NIFTY", "lot_size": int(lot), "source": "instrument_dump"},
+                    )
                 return int(lot)
             # Fallback defaults
             sym_upper = symbol.upper()
             if "NIFTY" in sym_upper:
-                return 65
+                env_lot = int(getattr(settings.risk, "contract_lot_size", 75) or 75)
+                source = "env"
+                if env_lot <= 0:
+                    env_lot = 75
+                    source = "fallback"
+                LOGGER.info(
+                    "LOT_SIZE_RESOLVED underlying=NIFTY lot_size=%s source=%s",
+                    env_lot,
+                    source,
+                    extra={"event": "LOT_SIZE_RESOLVED", "underlying": "NIFTY", "lot_size": env_lot, "source": source},
+                )
+                return env_lot
             if "BANKNIFTY" in sym_upper:
                 return 15
             return 1
         except Exception:
             if "NIFTY" in symbol.upper():
-                return 65
+                LOGGER.info(
+                    "LOT_SIZE_RESOLVED underlying=NIFTY lot_size=75 source=fallback",
+                    extra={"event": "LOT_SIZE_RESOLVED", "underlying": "NIFTY", "lot_size": 75, "source": "fallback"},
+                )
+                return 75
             return 1
 
     # Always attach the provider
     risk_manager.set_lot_size_provider(_lot_size_lookup)
-    LOGGER.info("✅ Wired Lot Size Provider to Risk Manager (NIFTY=65)")
+    LOGGER.info("✅ Wired Lot Size Provider to Risk Manager")
 
     risk_state: RiskState | None = None
     try:

--- a/src/nifty_scalper_bot/strategies/elite_tuesday_gamma_buyer.py
+++ b/src/nifty_scalper_bot/strategies/elite_tuesday_gamma_buyer.py
@@ -19,7 +19,7 @@ from nifty_scalper_bot.utils.logging import get_logger
 LOGGER = get_logger(__name__)
 
 BaseEliteStrategy = EliteStrategy
-NIFTY_LOT_SIZE = int(os.getenv("NIFTY_LOT_SIZE", "75"))
+NIFTY_LOT_SIZE = int(os.getenv("NIFTY_LOT_SIZE", "65"))
 MAX_RISK_PER_TRADE = 0.006
 MAX_DAILY_RISK = 0.02
 MAX_CAPITAL_DEPLOYMENT = 0.15

--- a/src/nifty_scalper_bot/strategies/elite_tuesday_gamma_buyer.py
+++ b/src/nifty_scalper_bot/strategies/elite_tuesday_gamma_buyer.py
@@ -19,7 +19,7 @@ from nifty_scalper_bot.utils.logging import get_logger
 LOGGER = get_logger(__name__)
 
 BaseEliteStrategy = EliteStrategy
-NIFTY_LOT_SIZE = 65
+NIFTY_LOT_SIZE = int(os.getenv("NIFTY_LOT_SIZE", "75"))
 MAX_RISK_PER_TRADE = 0.006
 MAX_DAILY_RISK = 0.02
 MAX_CAPITAL_DEPLOYMENT = 0.15

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -1849,7 +1849,21 @@ class StrategyRunner:
                 },
             )
             return True, None
-        loop.create_task(_job())
+        task = loop.create_task(_job(), name=f"signal_prepare:{signal.symbol}:{trace_id}")
+        def _on_done(done_task: asyncio.Task[None]) -> None:
+            """Handle async task completion. Args: done_task. Returns: None. Raises: None."""
+            try:
+                done_task.result()
+            except Exception as exc:  # noqa: BLE001
+                self._logger.error(
+                    "SIGNAL_PREPARATION_TASK_FAILED symbol=%s trace_id=%s error=%s",
+                    signal.symbol,
+                    trace_id,
+                    exc,
+                    extra={"event": "SIGNAL_PREPARATION_TASK_FAILED", "symbol": signal.symbol, "trace_id": trace_id, "error": str(exc)},
+                    exc_info=exc,
+                )
+        task.add_done_callback(_on_done)
         return True, "signal_preparation_scheduled"
 
     async def _prepare_signal_for_handling(
@@ -1959,9 +1973,6 @@ class StrategyRunner:
             bid = float(snapshot.bid) if snapshot.bid is not None and float(snapshot.bid) > 0 else 0.0
             ask = float(snapshot.ask) if snapshot.ask is not None and float(snapshot.ask) > 0 else 0.0
             has_bid_ask = bid > 0 and ask > 0
-            if not has_bid_ask:
-                bid = ltp
-                ask = ltp
             strike_match = re.search(r"(\d{5})(CE|PE)$", str(signal.symbol).upper())
             parsed_strike = int(strike_match.group(1)) if strike_match is not None else 0
             strike = int(metadata.get("strike") or parsed_strike or metadata.get("atm_strike") or 0)
@@ -1988,6 +1999,7 @@ class StrategyRunner:
                 "real_ticks_last_60s": real_ticks_last_60s,
                 "tradable_quote": bool(snapshot.tradable_quote and has_bid_ask),
                 "ltp_only_fallback": not has_bid_ask,
+                "quote_quality": "bid_ask" if has_bid_ask else "ltp_only",
                 "source": str(snapshot.source or "signal_snapshot"),
             }
         except Exception as exc:  # noqa: BLE001

--- a/src/nifty_scalper_bot/strategies/trade_selector.py
+++ b/src/nifty_scalper_bot/strategies/trade_selector.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import logging
 import os
 from typing import Any
 
-from nifty_scalper_bot.utils.logging import get_logger
+from nifty_scalper_bot.utils.logging import get_logger, log_once_or_throttled
 
 LOGGER = get_logger(__name__)
 
@@ -39,7 +40,7 @@ class TradeCandidate:
 
 
 class TradeCandidateSelector:
-    def __init__(self, *, quality_mode: str = 'normal', option_strike_window_each_side: int = 2, min_option_premium: float = 80.0, max_option_premium: float = float(os.getenv("MAX_OPTION_PREMIUM", "650"))) -> None:
+    def __init__(self, *, quality_mode: str = 'normal', option_strike_window_each_side: int = 2, min_option_premium: float = 80.0, max_option_premium: float = float(os.getenv('MAX_OPTION_PREMIUM', '650'))) -> None:
         self.quality_mode = quality_mode
         self.option_strike_window_each_side = option_strike_window_each_side
         self.min_option_premium = min_option_premium
@@ -54,17 +55,10 @@ class TradeCandidateSelector:
 
     def select_ranked_candidates(self, *, direction_bias: str, atm_strike: int, snapshots: list[dict[str, Any]]) -> list[TradeCandidate]:
         max_spread, max_age, min_ticks = self._limits()
+        allow_ltp_only = os.getenv('ALLOW_LTP_ONLY_CANDIDATE', 'true').lower() in {'1', 'true', 'yes', 'on'}
         ranked: list[TradeCandidate] = []
-        rejects = {
-            'side_mismatch': 0,
-            'atm_distance': 0,
-            'missing_bid_ask': 0,
-            'premium_out_of_range': 0,
-            'spread_too_wide': 0,
-            'tick_stale': 0,
-            'insufficient_ticks': 0,
-            'invalid_rr': 0,
-        }
+        rejects = {'side_mismatch': 0, 'atm_distance': 0, 'missing_bid_ask': 0, 'premium_out_of_range': 0, 'spread_too_wide': 0, 'tick_stale': 0, 'insufficient_ticks': 0, 'invalid_rr': 0}
+        ltp_only_used = 0
         for s in snapshots:
             side = str(s.get('side') or s.get('option_type') or '').upper()
             symbol = str(s.get('symbol') or '')
@@ -77,17 +71,13 @@ class TradeCandidateSelector:
                 rejects['atm_distance'] += 1
                 continue
             bid, ask, ltp = self._f(s.get('bid')), self._f(s.get('ask')), self._f(s.get('ltp'))
-            if ltp is None or bid is None or ask is None or bid <= 0 or ask <= 0:
+            has_bid_ask = bool((bid or 0) > 0 and (ask or 0) > 0)
+            if ltp is None or ltp <= 0:
                 rejects['missing_bid_ask'] += 1
                 continue
             premium = ltp
             if premium < self.min_option_premium or premium > self.max_option_premium:
                 rejects['premium_out_of_range'] += 1
-                continue
-            mid = (bid + ask) / 2.0
-            spread_pct = (ask - bid) / mid if mid > 0 else 1.0
-            if spread_pct > max_spread:
-                rejects['spread_too_wide'] += 1
                 continue
             tick_age_s = self._f(s.get('tick_age_s'))
             if tick_age_s is None or tick_age_s > max_age:
@@ -97,8 +87,26 @@ class TradeCandidateSelector:
             if real_ticks < min_ticks:
                 rejects['insufficient_ticks'] += 1
                 continue
-            entry = ask if ask > 0 else ltp
-            atr = self._f(s.get('atr_option')) or max(entry * 0.012, (ask - bid) * 1.5, 1.0)
+            reasons = ['candidate_valid']
+            spread_pct: float | None = None
+            if has_bid_ask:
+                mid = ((bid or 0.0) + (ask or 0.0)) / 2.0
+                spread_pct = ((ask or 0.0) - (bid or 0.0)) / mid if mid > 0 else 1.0
+                if spread_pct > max_spread:
+                    rejects['spread_too_wide'] += 1
+                    continue
+                entry = ask if (ask or 0.0) > 0 else ltp
+                score_penalty = 0.0
+            else:
+                ltp_only_flag = bool(s.get('ltp_only_fallback'))
+                if not (allow_ltp_only and ltp_only_flag):
+                    rejects['missing_bid_ask'] += 1
+                    continue
+                entry = ltp * 1.003
+                score_penalty = 1.5
+                ltp_only_used += 1
+                reasons.append('ltp_only_fallback')
+            atr = self._f(s.get('atr_option')) or max(entry * 0.012, max((ask or 0.0) - (bid or 0.0), 0.0) * 1.5, 1.0)
             risk = max(atr * 0.8, entry * 0.08, 5.0)
             risk = min(18.0, max(4.0, risk))
             sl = entry - risk
@@ -109,20 +117,17 @@ class TradeCandidateSelector:
             if rr < 1.5:
                 rejects['invalid_rr'] += 1
                 continue
-            liquidity = max(0.0, 10.0 - spread_pct * 100.0)
+            liquidity = 5.0 if spread_pct is None else max(0.0, 10.0 - spread_pct * 100.0)
             micro = min(10.0, real_ticks * 3.0)
-            score = 6.0 + liquidity * 0.2 + micro * 0.2 - atm_distance * 0.5
-            ranked.append(TradeCandidate(symbol=symbol, side=side, score=score, reasons=['candidate_valid'], spread_pct=spread_pct, tick_age_s=tick_age_s, premium=premium, atm_distance=atm_distance, data_quality_score=10.0, entry_price=entry, stop_loss=sl, target=target, rr=rr, liquidity_score=liquidity, microstructure_score=micro, final_score=score))
+            score = 6.0 + liquidity * 0.2 + micro * 0.2 - atm_distance * 0.5 - score_penalty
+            ranked.append(TradeCandidate(symbol=symbol, side=side, score=score, reasons=reasons, spread_pct=spread_pct, tick_age_s=tick_age_s, premium=premium, atm_distance=atm_distance, data_quality_score=10.0, entry_price=entry, stop_loss=sl, target=target, rr=rr, liquidity_score=liquidity, microstructure_score=micro, final_score=score))
         sorted_ranked = sorted(ranked, key=lambda c: c.final_score or 0.0, reverse=True)
-        LOGGER.info(
-            'CANDIDATE_SELECTION_SUMMARY direction=%s atm=%s total=%s ranked=%s rejects=%s',
-            direction_bias,
-            atm_strike,
-            len(snapshots),
-            len(sorted_ranked),
-            rejects,
-            extra={'event': 'CANDIDATE_SELECTION_SUMMARY', 'direction': direction_bias, 'atm': atm_strike, 'total': len(snapshots), 'ranked': len(sorted_ranked), 'rejects': rejects},
-        )
+        key = f'candidate_summary_empty:{direction_bias}:{atm_strike}'
+        event_extra = {'event': 'CANDIDATE_SELECTION_SUMMARY', 'direction': direction_bias, 'atm': atm_strike, 'total': len(snapshots), 'ranked': len(sorted_ranked), 'rejects': rejects, 'ltp_only_used': ltp_only_used}
+        if sorted_ranked:
+            LOGGER.debug('CANDIDATE_SELECTION_SUMMARY direction=%s atm=%s total=%s ranked=%s ltp_only_used=%s rejects=%s', direction_bias, atm_strike, len(snapshots), len(sorted_ranked), ltp_only_used, rejects, extra=event_extra)
+        else:
+            log_once_or_throttled(LOGGER, key, f'CANDIDATE_SELECTION_SUMMARY direction={direction_bias} atm={atm_strike} total={len(snapshots)} ranked=0 ltp_only_used={ltp_only_used} rejects={rejects}', interval_sec=30.0, level=logging.INFO, extra=event_extra)
         return sorted_ranked
 
     def select_best_candidate(self, *, underlying: str, direction_bias: str, atm_strike: int, snapshots: list[dict[str, Any]]) -> TradeCandidate | None:

--- a/src/nifty_scalper_bot/utils/logging.py
+++ b/src/nifty_scalper_bot/utils/logging.py
@@ -578,6 +578,31 @@ def log_throttled(
         )
 
 
+def log_once_or_throttled(
+    logger: logging.Logger,
+    key: str,
+    msg: str,
+    *,
+    interval_sec: float = 60.0,
+    level: int = logging.INFO,
+    extra: Optional[dict[str, Any]] = None,
+    exc_info: bool | BaseException | None = None,
+) -> None:
+    """Emit once immediately and then at most once per interval. Args: logger/key/msg/interval/level/extra/exc_info. Returns: None. Raises: None."""
+    try:
+        log_throttled(
+            logger,
+            key,
+            msg,
+            interval_sec=interval_sec,
+            level=level,
+            extra=extra,
+            exc_info=exc_info,
+        )
+    except Exception:
+        with contextlib.suppress(Exception):
+            logger.log(level, msg, extra=extra or {}, exc_info=exc_info)
+
 def log_state_change(
     logger: logging.Logger,
     key: str,
@@ -663,6 +688,7 @@ __all__ = [
     "get_tracer_logger",
     "log_state_change",
     "log_throttled",
+    "log_once_or_throttled",
     "setup_logging",
     "silence_third_party_loggers",
     "enable_business_logic_logging",

--- a/tests/core/test_lot_size_defaults.py
+++ b/tests/core/test_lot_size_defaults.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from nifty_scalper_bot.config.settings import get_settings
 
 
-def test_nifty_lot_size_default_fallback_75(monkeypatch) -> None:
+def test_nifty_lot_size_default_fallback_65(monkeypatch) -> None:
     monkeypatch.delenv('NIFTY_LOT_SIZE', raising=False)
     settings = get_settings()
-    assert settings.risk.contract_lot_size == 75
+    assert settings.risk.contract_lot_size == 65

--- a/tests/core/test_lot_size_defaults.py
+++ b/tests/core/test_lot_size_defaults.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from nifty_scalper_bot.config.settings import get_settings
+
+
+def test_nifty_lot_size_default_fallback_75(monkeypatch) -> None:
+    monkeypatch.delenv('NIFTY_LOT_SIZE', raising=False)
+    settings = get_settings()
+    assert settings.risk.contract_lot_size == 75

--- a/tests/strategies/test_runner_live_path_guards.py
+++ b/tests/strategies/test_runner_live_path_guards.py
@@ -1028,11 +1028,24 @@ async def test_schedule_signal_preparation_schedules_when_loop_running() -> None
     runner._handle_signal = MagicMock(return_value=SignalExecutionResult(True, 'accepted'))  # type: ignore[method-assign]
     now = datetime.now(timezone.utc)
     scheduled, reason = runner._schedule_signal_preparation(signal, 101.0, now, 'trace-loop')
-    await asyncio.sleep(0)
+    await asyncio.sleep(0.05)
 
     assert scheduled is True
     assert reason == 'signal_preparation_scheduled'
     runner._handle_signal.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_schedule_signal_preparation_logs_task_failure() -> None:
+    runner = _build_runner()
+    signal = Signal(action='BUY', symbol='NFO:NIFTY26APR23800CE', quantity=1, confidence=0.9, reason='x', stop_loss=90.0, take_profit=120.0, metadata={})
+    runner._prepare_signal_for_handling = AsyncMock(side_effect=RuntimeError('boom'))  # type: ignore[method-assign]
+    runner._handle_signal = MagicMock()  # type: ignore[method-assign]
+    errors: list[str] = []
+    runner._logger.error = lambda msg, *args, **kwargs: errors.append(str(msg))  # type: ignore[method-assign]
+    runner._schedule_signal_preparation(signal, 100.0, datetime.now(timezone.utc), 'trace-fail')
+    await asyncio.sleep(0.05)
+    assert any('SIGNAL_PREPARATION_TASK_FAILED' in msg for msg in errors)
 
 def test_runner_no_async_event_loop_fallback_in_runner_source() -> None:
     """Regression guard: async paths must not skip prep just because event loop exists."""
@@ -1066,6 +1079,22 @@ def test_build_single_candidate_from_signal_includes_tick_fields() -> None:
     assert candidate is not None
     assert candidate['tick_age_s'] == 0.0
     assert candidate['real_ticks_last_60s'] >= 1
+    assert candidate['quote_quality'] == 'bid_ask'
+
+
+def test_build_single_candidate_from_signal_does_not_fake_bid_ask() -> None:
+    runner = _build_runner()
+    runner._market_data = MagicMock()
+    runner._market_data.get_symbol_snapshot.return_value = SimpleNamespace(
+        ltp=374.95, bid=0.0, ask=0.0, tick_age_s=0.1, real_ticks_last_60s=3, tradable_quote=True, source='ws'
+    )
+    signal = Signal(action='BUY', symbol='NFO:NIFTY26MAY24050PE', quantity=1, confidence=0.8, reason='x', stop_loss=300.0, take_profit=450.0, metadata={})
+    candidate = runner._build_single_candidate_from_signal(signal=signal, metadata={}, option_side='PE')
+    assert candidate is not None
+    assert candidate['bid'] == 0.0
+    assert candidate['ask'] == 0.0
+    assert candidate['ltp_only_fallback'] is True
+    assert candidate['quote_quality'] == 'ltp_only'
 
 
 def test_pre_order_rejection_logs_signal_execution_result() -> None:

--- a/tests/strategies/test_trade_selector_ltp_fallback.py
+++ b/tests/strategies/test_trade_selector_ltp_fallback.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import logging
+
+from nifty_scalper_bot.strategies.trade_selector import TradeCandidateSelector
+
+
+def _snapshot() -> dict[str, object]:
+    return {
+        'symbol': 'NFO:NIFTY26MAY24050CE',
+        'side': 'CE',
+        'strike': 24050,
+        'atm_strike': 24050,
+        'ltp': 120.0,
+        'bid': 0.0,
+        'ask': 0.0,
+        'tick_age_s': 1.0,
+        'real_ticks_last_60s': 2,
+        'ltp_only_fallback': True,
+    }
+
+
+def test_ltp_only_candidate_allowed_and_penalized(monkeypatch) -> None:
+    monkeypatch.setenv('ALLOW_LTP_ONLY_CANDIDATE', 'true')
+    selector = TradeCandidateSelector()
+    ranked = selector.select_ranked_candidates(direction_bias='CE', atm_strike=24050, snapshots=[_snapshot()])
+    assert len(ranked) == 1
+    assert 'ltp_only_fallback' in ranked[0].reasons
+    assert ranked[0].spread_pct is None
+
+
+def test_ltp_only_candidate_rejected_when_disabled(monkeypatch) -> None:
+    monkeypatch.setenv('ALLOW_LTP_ONLY_CANDIDATE', 'false')
+    selector = TradeCandidateSelector()
+    ranked = selector.select_ranked_candidates(direction_bias='CE', atm_strike=24050, snapshots=[_snapshot()])
+    assert ranked == []
+
+
+def test_candidate_summary_empty_info_throttled(caplog, monkeypatch) -> None:
+    monkeypatch.setenv('ALLOW_LTP_ONLY_CANDIDATE', 'false')
+    selector = TradeCandidateSelector()
+    with caplog.at_level(logging.INFO):
+        selector.select_ranked_candidates(direction_bias='CE', atm_strike=24050, snapshots=[_snapshot()])
+        selector.select_ranked_candidates(direction_bias='CE', atm_strike=24050, snapshots=[_snapshot()])
+    infos = [r for r in caplog.records if r.levelno == logging.INFO and 'CANDIDATE_SELECTION_SUMMARY' in r.message]
+    assert len(infos) == 1


### PR DESCRIPTION
### Motivation
- Reduce noisy, repetitive logs that bury actionable failures and make Railway output unreadable.
- Prevent creation of misleading zero-spread fallback quotes when only LTP is available and allow a controlled LTP-only candidate path.
- Eliminate hidden async task exceptions in signal preparation and remove the remaining hard-coded NIFTY lot-size mismatch that caused quantity alignment issues.

### Description
- Added `log_once_or_throttled(logger, key, msg, *, interval_sec=60.0, ...)` in `src/nifty_scalper_bot/utils/logging.py` by reusing existing `log_throttled` semantics for a first-immediate-then-throttle pattern and exported it for shared use.
- Reworked candidate selection in `src/nifty_scalper_bot/strategies/trade_selector.py` to support a gated LTP-only fallback controlled by `ALLOW_LTP_ONLY_CANDIDATE`, apply a score penalty, keep `spread_pct=None` for LTP-only, and emit `CANDIDATE_SELECTION_SUMMARY` as `DEBUG` when candidates exist and throttled `INFO` only for empty-ranked outcomes (includes `ltp_only_used` and reject counters).
- Updated the runner fallback in `src/nifty_scalper_bot/strategies/runner.py` to stop faking bid/ask (leave them as `0.0` when missing), add `quote_quality`/`ltp_only_fallback` flags on built candidates, and name-created signal-preparation tasks while adding a done-callback that logs `SIGNAL_PREPARATION_TASK_FAILED` on exceptions to avoid "Task exception was never retrieved" cases.
- Aligned NIFTY lot-size handling by changing default `NIFTY_LOT_SIZE` to `75` in `src/nifty_scalper_bot/config/settings.py`, wiring `_lot_size_lookup` in `src/nifty_scalper_bot/core/app.py` to prefer instrument-manager values, fall back to the env/default, and emit `LOT_SIZE_RESOLVED underlying=NIFTY lot_size=<value> source=<instrument_dump|env|fallback>`; removed the hard-coded startup message that showed `NIFTY=65`.
- Minor safety-touch: replaced one strategy hardcoded `NIFTY_LOT_SIZE = 65` with an env-backed `int(os.getenv('NIFTY_LOT_SIZE', '75'))` to ensure consistency across RiskManager and OrderManager.

### Testing
- Ran `python -m compileall -q src` which completed successfully.
- Executed targeted pytest suites which passed: `pytest -q tests/strategies/test_trade_selector_ltp_fallback.py tests/strategies/test_runner_live_path_guards.py::test_build_single_candidate_from_signal_does_not_fake_bid_ask tests/strategies/test_runner_live_path_guards.py::test_schedule_signal_preparation_logs_task_failure tests/core/test_lot_size_defaults.py tests/test_runtime_stability_fixes.py::test_ws_tick_restores_connected_state` and all tests succeeded.
- Added unit tests for the LTP-only selector behavior and throttled summary, candidate fallback semantics, async task failure logging, and NIFTY lot-size default fallback (files: `tests/strategies/test_trade_selector_ltp_fallback.py`, `tests/strategies/test_runner_live_path_guards.py`, `tests/core/test_lot_size_defaults.py`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fafd48990883249ee99dc4476777cb)