### PR TITLE
fix: harden runner hydration and logging fallbacks

### DIFF
--- a/src/nifty_scalper_bot/execution/paper_fill_engine.py
+++ b/src/nifty_scalper_bot/execution/paper_fill_engine.py
@@ -309,8 +309,8 @@ class PaperFillEngine:
                 lot = int(self.resolver.lot_size_for_symbol(symbol))
                 return max(lot, 1)
             except Exception:
-                return 75
-        return 75
+                return 65
+        return 65
 
     def _consume_queue(self, quantity: int) -> int:
         depth = max(self._queue_depth, 0)

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -309,7 +309,7 @@ class StrategyRunnerConfig:
     # Existing
     min_indicator_bars: int = 20
     max_trade_history: int = 100
-    fetch_history_on_startup: bool = True
+    fetch_history_on_startup: bool = False
 
     # ✅ REQUIRED FIX (missing fields)
     signal_cooldown_seconds: float = 3.0
@@ -1007,8 +1007,12 @@ class StrategyRunner:
         # BUG W4 FIX: _backfill_history() was scheduled immediately in runner.start(),
         # which races with core/app.py EngineWarmupTask. We only need the backfill task
         # as an emergency fallback if EngineWarmupTask fails.
+        emergency_backfill_enabled = self._coerce_bool(
+            os.getenv("RUNNER_ENABLE_EMERGENCY_BACKFILL"), default=False
+        )
         if (
             self._config.fetch_history_on_startup
+            and emergency_backfill_enabled
             and self._main_loop
             and not self._backfill_task_started
         ):
@@ -2830,18 +2834,21 @@ class StrategyRunner:
                 and symbol not in self._gap_repair_inflight
             ):
                 self._gap_repair_inflight.add(symbol)
-                asyncio.run_coroutine_threadsafe(
-                    self._refresh_gap_history_async(symbol),
-                    self._main_loop,
-                )
+                self._request_mdm_hydration(symbol, self._required_bars_for_symbol(symbol))
         return repaired
 
     async def _refresh_gap_history_async(self, symbol: str) -> None:
-        """Attempt async broker history refresh for repaired symbols. Args: symbol; Returns: none; Raises: none."""
+        """Refresh repaired symbol history from MDM cache only. Args: symbol. Returns: None. Raises: None."""
+        target = self._required_bars_for_symbol(symbol)
         try:
-            bars = await self._fetch_symbol_history(symbol, limit=32)
-            if bars:
-                self._write_history_cache(symbol, bars)
+            rows = self._get_mdm_bars(symbol, target)
+            if rows:
+                self._write_history_cache(symbol, rows)
+                for row in rows:
+                    with contextlib.suppress(Exception):
+                        self.ingest_historical_bar(row)
+            else:
+                self._request_mdm_hydration(symbol, target)
         except Exception as exc:  # noqa: BLE001
             self._logger.debug("gap_history_refresh_failed for %s: %s", symbol, exc)
         finally:
@@ -2860,10 +2867,7 @@ class StrategyRunner:
             "Condition met: historical_refresh_triggered",
             extra={"event": "historical_refresh_triggered", "symbol": symbol},
         )
-        asyncio.run_coroutine_threadsafe(
-            self._refresh_gap_history_async(symbol),
-            self._main_loop,
-        )
+        self._request_mdm_hydration(symbol, self._required_bars_for_symbol(symbol))
 
     def _emit_composite_reports(self) -> None:
         """Emit periodic system/strategy aggregate logs. Args: none; Returns: none; Raises: none."""
@@ -3090,7 +3094,7 @@ class StrategyRunner:
                 reason = "repeated_missing_candles" if recent_tick else "no_recent_tick_for_gap_assessment"
                 log_level = logging.INFO if is_option and recent_tick else logging.WARNING
                 log_throttled(
-                    log_level,
+                    self._logger,
                     f"soft_data_issue:{symbol}",
                     f"SOFT_DATA_ISSUE symbol={symbol} reason={reason} source=candle_gap_detector age_s={tick_age_s}",
                     interval_sec=60.0,
@@ -3849,8 +3853,23 @@ class StrategyRunner:
                     return tick
         if self._market_data and hasattr(self._market_data, "get_symbol_snapshot"):
             snap = self._market_data.get_symbol_snapshot("NSE:NIFTY")
-            if snap:
-                return {"symbol": "NSE:NIFTY", "ltp": snap.get("ltp") or snap.get("close"), "received_at": snap.get("received_at") or snap.get("timestamp"), "source": "market_data_snapshot"}
+            if snap and getattr(snap, "ltp", None):
+                tick_age = float(getattr(snap, "tick_age_s", 0.0) or 0.0)
+                return {
+                    "symbol": "NSE:NIFTY",
+                    "ltp": float(getattr(snap, "ltp")),
+                    "received_at": time.time() - tick_age,
+                    "source": getattr(snap, "source", "market_data_snapshot"),
+                }
+            if isinstance(snap, Mapping):
+                ltp = snap.get("ltp") or snap.get("close")
+                if ltp:
+                    return {
+                        "symbol": "NSE:NIFTY",
+                        "ltp": float(ltp),
+                        "received_at": snap.get("received_at") or snap.get("timestamp") or time.time(),
+                        "source": snap.get("source", "market_data_snapshot"),
+                    }
         if self._market_data and hasattr(self._market_data, "get_cached_ltp"):
             ltp = self._market_data.get_cached_ltp("NSE:NIFTY", max_age_seconds=300, require_ws=False)
             if ltp:

--- a/src/nifty_scalper_bot/utils/logging.py
+++ b/src/nifty_scalper_bot/utils/logging.py
@@ -546,6 +546,8 @@ def log_throttled(
     exc_info: bool | BaseException | None = None,
 ) -> None:
     """Emit a log record at most once during the specified interval."""
+    if not isinstance(logger, logging.Logger):
+        logger = LOGGER
     logger.debug(
         "Entered log_throttled",
         extra={

--- a/tests/execution/test_order_executor_readiness.py
+++ b/tests/execution/test_order_executor_readiness.py
@@ -32,3 +32,12 @@ def test_is_execution_ready_reports_invalid_symbol() -> None:
     ready, reason = executor.is_execution_ready("NFO:NIFTY24APR25000CE")
     assert ready is False
     assert reason == "invalid_instrument"
+
+
+from nifty_scalper_bot.execution.paper_fill_engine import PaperFillEngine
+
+
+def test_paper_fill_engine_nifty_lot_fallback_is_65() -> None:
+    engine = PaperFillEngine.__new__(PaperFillEngine)
+    engine.resolver = SimpleNamespace(lot_size_for_symbol=lambda _s: (_ for _ in ()).throw(RuntimeError("boom")))
+    assert engine._resolve_lot("NFO:NIFTY26MAY24050CE") == 65

--- a/tests/strategies/test_runner_mdm_hydration_paths.py
+++ b/tests/strategies/test_runner_mdm_hydration_paths.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+import asyncio
+import logging
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -105,3 +107,77 @@ def test_get_spot_tick_alias_and_snapshot_fallback() -> None:
     )
     tick = r._get_spot_tick()
     assert tick and tick["symbol"] == "NSE:NIFTY" and tick["received_at"] == 20.0
+
+
+def test_update_symbol_hydration_soft_data_uses_runner_logger(monkeypatch) -> None:
+    r = _runner()
+    r._has_session_candle_gaps = lambda _s: True
+    r._session_gap_count = {'NSE:NIFTY': 2}
+    r._last_tick_time_by_symbol = {'NSE:NIFTY': 0.0}
+    captured = {}
+
+    def _capture(logger, *_args, **_kwargs):
+        captured['logger'] = logger
+
+    monkeypatch.setattr('nifty_scalper_bot.strategies.runner.log_throttled', _capture)
+    r.update_symbol_hydration('NSE:NIFTY', [1.0, 2.0, 3.0], {'NSE:NIFTY': {'vwap': 1.0, 'cum_volume': 1.0}})
+    assert captured['logger'] is r._logger
+
+
+def test_get_spot_tick_snapshot_object_fallback() -> None:
+    r = _runner()
+    snap = SimpleNamespace(ltp=25010.0, tick_age_s=1.5, source='snapshot_obj')
+    r._market_data = SimpleNamespace(get_latest_tick=lambda *_: None, get_symbol_snapshot=lambda _s: snap, get_cached_ltp=lambda *_a, **_k: None)
+    r._data_hub = SimpleNamespace(get_latest_tick=lambda *_: None, get_quote=lambda *_: None)
+    tick = r._get_spot_tick()
+    assert tick is not None
+    assert tick['symbol'] == 'NSE:NIFTY'
+    assert tick['ltp'] == 25010.0
+    assert tick['source'] == 'snapshot_obj'
+
+
+def test_repair_candle_gaps_requests_mdm_hydration() -> None:
+    r = _runner()
+    r._main_loop = None
+    r._gap_repair_inflight = set()
+    r._required_bars_for_symbol = lambda _s: 33
+    called = []
+    r._request_mdm_hydration = lambda symbol, target: called.append((symbol, target))
+    prev = SimpleNamespace(start=datetime(2026,1,1,9,15,tzinfo=timezone.utc), end=datetime(2026,1,1,9,15,59,tzinfo=timezone.utc), close=100.0)
+    curr = SimpleNamespace(start=datetime(2026,1,1,9,20,tzinfo=timezone.utc), end=datetime(2026,1,1,9,20,59,tzinfo=timezone.utc), close=101.0)
+    r._repair_candle_gap('NSE:NIFTY', prev, curr)
+    assert called == [('NSE:NIFTY', 33)]
+
+
+def test_refresh_history_if_due_requests_mdm_hydration() -> None:
+    r = _runner()
+    loop = asyncio.new_event_loop()
+    try:
+        r._main_loop = loop
+        r._last_history_refresh_by_symbol = {}
+        r._history_refresh_interval_seconds = 0.0
+        r._required_bars_for_symbol = lambda _s: 21
+        called = []
+        r._request_mdm_hydration = lambda symbol, target: called.append((symbol, target))
+        r._refresh_history_if_due('NSE:NIFTY')
+        assert called == [('NSE:NIFTY', 21)]
+    finally:
+        loop.close()
+
+
+def test_runner_emergency_backfill_disabled_by_default(monkeypatch) -> None:
+    r = _runner()
+    r._config = SimpleNamespace(fetch_history_on_startup=True)
+    r._backfill_task_started = False
+    r._main_loop = asyncio.new_event_loop()
+    r._subscribe_symbol = lambda *_: None
+    r._symbols = []
+    r._callbacks = {}
+    r._market_data = SimpleNamespace(start=lambda: None)
+    r._lock = type('L', (), {'__enter__': lambda s: None, '__exit__': lambda s,a,b,c: None})()
+    monkeypatch.delenv('RUNNER_ENABLE_EMERGENCY_BACKFILL', raising=False)
+    try:
+        r.start([])
+        assert r._backfill_task_started is False
+    finally:
+        r._main_loop.close()

--- a/tests/test_log_throttled_safety.py
+++ b/tests/test_log_throttled_safety.py
@@ -30,3 +30,9 @@ def test_no_invalid_log_throttled_calls() -> None:
             if is_target and len(node.args) > 4:
                 violations.append(f'{path}:{node.lineno}')
     assert not violations, f'Invalid log_throttled calls: {violations}'
+
+
+def test_log_throttled_invalid_logger_is_safe(caplog) -> None:
+    caplog.set_level(logging.INFO)
+    log_throttled(123, "bad_logger", "safe message", interval_sec=0.0)
+    assert "safe message" in caplog.text


### PR DESCRIPTION
### Motivation
- Prevent runtime crashes and recursive logging failures when `log_throttled()` receives invalid input and ensure throttled logging calls use the runner logger, not an int log level. 
- Move hydration responsibility back to the MarketDataManager (MDM) and remove runner-owned broker history refresh to avoid competing async refresh paths and unintended automatic backfills. 
- Ensure spot snapshot fallback works with both object `MarketSnapshot` instances and dict-like snapshots and align the paper-engine NIFTY lot fallback with live value. 

### Description
- Hardened `log_throttled()` (`src/nifty_scalper_bot/utils/logging.py`) to fall back to the module `LOGGER` when the supplied `logger` is not a `logging.Logger` before any logging calls. 
- Fixed `update_symbol_hydration()` in `src/nifty_scalper_bot/strategies/runner.py` to call `log_throttled(self._logger, ...)` (instead of passing an int log level as the first arg) in the `SOFT_DATA_ISSUE` path. 
- Reworked `_get_spot_tick()` to safely handle attribute-style snapshots (via `getattr`) and dict-like snapshots (`Mapping`) so both `MarketSnapshot` objects and dicts are supported. 
- Removed `asyncio.run_coroutine_threadsafe(... _refresh_gap_history_async...)` calls from gap-repair and periodic refresh paths and replaced them with `self._request_mdm_hydration(symbol, target)` to request hydration from MDM instead of runner-owned broker fetches. 
- Rewrote `_refresh_gap_history_async()` to be cache-only: read rows via `_get_mdm_bars()`, write to cache and ingest if present, otherwise request MDM hydration; no direct `_fetch_symbol_history()` broker fetch. 
- Disabled the runner’s automatic emergency backfill by default by setting `fetch_history_on_startup: bool = False` and gating the deferred backfill in `start()` with the environment flag `RUNNER_ENABLE_EMERGENCY_BACKFILL`. 
- Corrected paper fill engine NIFTY lot fallback from `75` to `65` in `src/nifty_scalper_bot/execution/paper_fill_engine.py`. 
- Added/updated unit tests to cover: `log_throttled()` safety with invalid logger, `update_symbol_hydration()` logger argument correctness, `_get_spot_tick()` object/dict fallback, gap-repair and refresh routing to MDM hydration, emergency backfill default-disabled behavior, and the paper engine NIFTY lot fallback. 

### Testing
- Compiled sources with `python -m compileall -q src` which completed without syntax errors. 
- Ran focused pytest subsets: `pytest -q tests/test_log_throttled_safety.py tests/strategies/test_runner_mdm_hydration_paths.py tests/execution/test_order_executor_readiness.py` and these targeted tests passed. 
- Ran a broader test set `pytest -q tests/strategies tests/utils tests/execution` which surfaced an existing failing test `test_live_async_path_uses_signal_candidate_fallback` (assert expected `candidate['bid'] == 111.0` but received `0.0`); this failure appears to be orthogonal to the changes and is reported for follow-up. 
- `./run_checks.sh` was executed in the environment but the script failed at the pytest stage because the script environment did not have pytest available; dependency bootstrapping in this environment completed but CI/run environment should run `./run_checks.sh` for full verification. 

All changes are confined to the runner, logging helper, and paper fill engine, with accompanying unit tests; risk is low and the edits aim to remove fragile async hydration/backfill behavior and harden logging/error paths.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb0d2f84f08324bdcf1cf4425426c9)