### PR TITLE
fix: harden startup readiness and MDM timestamp parsing

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -1930,6 +1930,7 @@ class BotContext:
     data_observation_ready: bool = False
     data_pipeline_ready: bool = False
     data_hard_ready: bool = False
+    mdm_strict_hard_ready: bool = False
     spot_ready: bool = False
     evaluation_ready: bool = False
     runner_task: asyncio.Task[Any] | None = None
@@ -6626,8 +6627,12 @@ def _sync_mdm_bars_to_runner(ctx: BotContext, symbol: str, *, min_bars: int) -> 
                 bars = list(fn(symbol) or [])
             except Exception:
                 bars = []
+    existing = _runner_bar_count(ctx, symbol)
+    if existing >= min_bars:
+        return 0
+    missing = max(0, min_bars - existing)
     ingested = 0
-    for bar in bars:
+    for bar in bars[-missing:]:
         try:
             payload = dict(bar)
             payload["symbol"] = symbol
@@ -6636,7 +6641,11 @@ def _sync_mdm_bars_to_runner(ctx: BotContext, symbol: str, *, min_bars: int) -> 
         except Exception:
             continue
     if ingested:
-        LOGGER.info(
+        log_throttled(
+            LOGGER,
+            logging.INFO,
+            "RUNNER_MDM_BAR_SYNC",
+            60.0,
             "RUNNER_MDM_BAR_SYNC symbol=%s ingested=%d min_bars=%d",
             symbol,
             ingested,
@@ -6646,7 +6655,7 @@ def _sync_mdm_bars_to_runner(ctx: BotContext, symbol: str, *, min_bars: int) -> 
     return ingested
 
 
-def _best_ready_option(
+def _best_fresh_option(
     ctx: BotContext, symbols: list[str], *, side: str, min_bars: int, max_age_s: float = 60.0
 ) -> str | None:
     """Pick best ready CE/PE option from candidates. Args: ctx/symbols/side/min_bars/max_age_s. Returns: symbol|None. Raises: none."""
@@ -6681,6 +6690,39 @@ def _best_ready_option(
             best_score = score
             best_symbol = sym
     return best_symbol if best_score >= 3 else None
+
+
+def _best_hydrated_option(
+    ctx: BotContext, symbols: list[str], *, side: str, min_bars: int
+) -> str | None:
+    """Pick option candidate with hydrated bars. Args: ctx/symbols/side/min_bars. Returns: symbol|None. Raises: none."""
+    side = side.upper()
+    candidates = [s for s in symbols if str(s).upper().endswith(side)]
+    best_symbol: str | None = None
+    best_count = -1
+    for sym in candidates:
+        try:
+            bars_count = (
+                len(list(ctx.market_data_manager.get_ohlc_bars(sym, limit=min_bars) or []))
+                if ctx.market_data_manager is not None
+                else 0
+            )
+        except Exception:
+            bars_count = 0
+        if bars_count < min_bars:
+            _sync_mdm_bars_to_runner(ctx, sym, min_bars=min_bars)
+            try:
+                bars_count = (
+                    len(list(ctx.market_data_manager.get_ohlc_bars(sym, limit=min_bars) or []))
+                    if ctx.market_data_manager is not None
+                    else bars_count
+                )
+            except Exception:
+                pass
+        if bars_count >= min_bars and bars_count > best_count:
+            best_count = bars_count
+            best_symbol = sym
+    return best_symbol
 async def _deferred_basket_hydration_retry(
     ctx: BotContext,
     *,
@@ -9252,25 +9294,53 @@ async def startup_sequence(ctx: BotContext) -> None:
                                     "SOFT_READINESS_MISSING missing=futures action=continue_with_spot_option_context",
                                     extra={"event": "SOFT_READINESS_MISSING", "missing": "futures", "action": "continue_with_spot_option_context"},
                                 )
-                            ready_ce = _best_ready_option(ctx, list(readiness_state.get("requirements", {}).get("options", []) or []), side="CE", min_bars=20)
-                            ready_pe = _best_ready_option(ctx, list(readiness_state.get("requirements", {}).get("options", []) or []), side="PE", min_bars=20)
-                            option_ticks_ready = bool(ready_ce is not None and ready_pe is not None)
+                            option_symbols = list(readiness_state.get("requirements", {}).get("options", []) or [])
+                            quote_ce = _best_fresh_option(ctx, option_symbols, side="CE", min_bars=20)
+                            quote_pe = _best_fresh_option(ctx, option_symbols, side="PE", min_bars=20)
+                            hydrated_ce = _best_hydrated_option(ctx, option_symbols, side="CE", min_bars=20)
+                            hydrated_pe = _best_hydrated_option(ctx, option_symbols, side="PE", min_bars=20)
+                            option_ticks_ready = bool(quote_ce is not None and quote_pe is not None)
                             futures_ready = "futures" not in set(missing_soft)
-                            atm_ce_ready = ready_ce is not None
-                            atm_pe_ready = ready_pe is not None
+                            atm_ce_ready = quote_ce is not None
+                            atm_pe_ready = quote_pe is not None
                             req_atm_ce = readiness_state.get("requirements", {}).get("atm_ce")
                             req_atm_pe = readiness_state.get("requirements", {}).get("atm_pe")
-                            if ready_ce and req_atm_ce and ready_ce != req_atm_ce:
-                                LOGGER.info("ATM_CE_SUBSTITUTED_WITH_READY_OPTION atm_ce=%s ready_ce=%s", req_atm_ce, ready_ce)
-                            if ready_pe and req_atm_pe and ready_pe != req_atm_pe:
-                                LOGGER.info("ATM_PE_SUBSTITUTED_WITH_READY_OPTION atm_pe=%s ready_pe=%s", req_atm_pe, ready_pe)
+                            if quote_ce and req_atm_ce and quote_ce != req_atm_ce:
+                                LOGGER.info("ATM_CE_SUBSTITUTED_WITH_READY_OPTION atm_ce=%s ready_ce=%s", req_atm_ce, quote_ce)
+                            if quote_pe and req_atm_pe and quote_pe != req_atm_pe:
+                                LOGGER.info("ATM_PE_SUBSTITUTED_WITH_READY_OPTION atm_pe=%s ready_pe=%s", req_atm_pe, quote_pe)
                             runner_running = _runner_is_running(ctx.strategy_runner)
                             ctx.spot_ready = bool(spot_ready)
                             ctx.data_observation_ready = bool(spot_ready or ws_quote_proof or ws_ltp_proof)
-                            ctx.evaluation_ready = bool(runner_running and len(getattr(ctx.strategy_runner, "_active_symbols", set()) or []) > 0 if ctx.strategy_runner is not None else False)
+                            enough_runner_symbols = bool(
+                                len(getattr(ctx.strategy_runner, "_active_symbols", set()) or []) > 0
+                                if ctx.strategy_runner is not None
+                                else False
+                            )
+                            ctx.evaluation_ready = bool(
+                                runner_running
+                                and (bool(hydrated_ce) or bool(hydrated_pe) or enough_runner_symbols)
+                            )
                             ctx.data_hard_ready = bool(spot_ready and atm_ce_ready and atm_pe_ready)
-                            ctx.data_pipeline_ready = bool(hard_ready)
-                            ctx.trading_ready = bool(ctx.data_hard_ready and mode == "LIVE" and runner_running)
+                            LOGGER.info(
+                                "OPTION_QUOTE_READY selected_ce=%s selected_pe=%s",
+                                quote_ce,
+                                quote_pe,
+                                extra={"event": "OPTION_QUOTE_READY", "selected_ce": quote_ce, "selected_pe": quote_pe},
+                            )
+                            LOGGER.info(
+                                "OPTION_HISTORY_READY selected_ce=%s selected_pe=%s",
+                                hydrated_ce,
+                                hydrated_pe,
+                                extra={"event": "OPTION_HISTORY_READY", "selected_ce": hydrated_ce, "selected_pe": hydrated_pe},
+                            )
+                            ctx.mdm_strict_hard_ready = bool(hard_ready)
+                            ctx.data_pipeline_ready = bool(ctx.data_hard_ready)
+                            ctx.trading_ready = bool(
+                                ctx.data_hard_ready
+                                and configured_runtime_mode == "LIVE"
+                                and runner_running
+                            )
                             if configured_runtime_mode in {"PAPER", "SHADOW"}:
                                 ctx.live_orders_armed = False
                                 if ctx.strategy_runner is not None:
@@ -10623,5 +10693,3 @@ __all__ = [
     "get_telegram_notifier",
     "get_nifty_expiry",
 ]
-
-# Deployment Fix: Force Update 2026-01-11

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -3547,25 +3547,27 @@ class MarketDataManager:
         atm_pe = str(requirements.get("atm_pe") or "")
         options = [str(s) for s in requirements.get("options") or []]
 
-        missing_hard: list[str] = []
-        if futures and bars.get(futures, 0) < min_bars:
-            missing_hard.append("futures")
-        if atm_ce and bars.get(atm_ce, 0) < min_bars:
-            missing_hard.append("atm_ce")
-        if atm_pe and bars.get(atm_pe, 0) < min_bars:
-            missing_hard.append("atm_pe")
+        strict_atm_ce_ready = bool(atm_ce and bars.get(atm_ce, 0) >= min_bars)
+        strict_atm_pe_ready = bool(atm_pe and bars.get(atm_pe, 0) >= min_bars)
+        selected_ce = atm_ce if strict_atm_ce_ready else next(
+            (sym for sym in options if sym.endswith("CE") and bars.get(sym, 0) >= min_bars),
+            "",
+        )
+        selected_pe = atm_pe if strict_atm_pe_ready else next(
+            (sym for sym in options if sym.endswith("PE") and bars.get(sym, 0) >= min_bars),
+            "",
+        )
+        ce_ready = bool(selected_ce)
+        pe_ready = bool(selected_pe)
 
-        if not atm_ce or not atm_pe:
-            ce_ready = any(
-                sym.endswith("CE") and bars.get(sym, 0) >= min_bars for sym in options
-            )
-            pe_ready = any(
-                sym.endswith("PE") and bars.get(sym, 0) >= min_bars for sym in options
-            )
-            if not ce_ready:
-                missing_hard.append("options_ce")
-            if not pe_ready:
-                missing_hard.append("options_pe")
+        missing_hard: list[str] = []
+        if not ce_ready:
+            missing_hard.append("options_ce")
+        if not pe_ready:
+            missing_hard.append("options_pe")
+        missing_soft: list[str] = []
+        if futures and bars.get(futures, 0) < min_bars:
+            missing_soft.append("futures")
 
         spot_ready = True
         if spot:
@@ -3574,9 +3576,14 @@ class MarketDataManager:
             except Exception:
                 spot_ready = False
         return {
-            "hard_ready": len(missing_hard) == 0,
+            "hard_ready": bool(spot_ready and ce_ready and pe_ready),
             "spot_ready": spot_ready,
             "missing_hard": missing_hard,
+            "missing_soft": missing_soft,
+            "selected_ce": selected_ce or None,
+            "selected_pe": selected_pe or None,
+            "strict_atm_ce_ready": strict_atm_ce_ready,
+            "strict_atm_pe_ready": strict_atm_pe_ready,
         }
 
     def readiness_state_snapshot(self) -> dict[str, Any]:
@@ -7372,6 +7379,8 @@ class MarketDataManager:
         value = (
             tick.get("received_at")
             or tick.get("wallclock")
+            or tick.get("exchange_timestamp")
+            or tick.get("last_trade_time")
             or tick.get("timestamp")
             or tick.get("ts")
             or tick.get("ts_ms")

--- a/tests/core/test_startup_readiness_regressions.py
+++ b/tests/core/test_startup_readiness_regressions.py
@@ -19,17 +19,26 @@ def test_futures_is_soft_readiness_requirement() -> None:
 
 
 def test_best_ready_option_can_substitute_atm_symbol() -> None:
-    assert "def _best_ready_option(" in SOURCE
+    assert "def _best_fresh_option(" in SOURCE
+    assert "def _best_hydrated_option(" in SOURCE
     assert "ATM_CE_SUBSTITUTED_WITH_READY_OPTION" in SOURCE
     assert "ATM_PE_SUBSTITUTED_WITH_READY_OPTION" in SOURCE
+    assert "OPTION_QUOTE_READY" in SOURCE
+    assert "OPTION_HISTORY_READY" in SOURCE
 
 
 def test_readiness_sync_helper_exists_for_mdm_to_runner() -> None:
     assert "def _sync_mdm_bars_to_runner" in SOURCE
     assert "RUNNER_MDM_BAR_SYNC" in SOURCE
+    assert "existing >= min_bars" in SOURCE
 
 
 def test_hydration_timeout_path_continues_in_degraded_mode() -> None:
     assert "STARTUP_PIPELINE_INCOMPLETE_CONTINUING" in SOURCE
     assert "ctx.degraded_mode = True" in SOURCE
     assert "ctx.live_orders_armed = False" in SOURCE
+
+
+def test_data_pipeline_ready_uses_app_level_data_hard_ready() -> None:
+    assert "ctx.data_pipeline_ready = bool(ctx.data_hard_ready)" in SOURCE
+    assert "and configured_runtime_mode == \"LIVE\"" in SOURCE

--- a/tests/data/test_market_data_manager.py
+++ b/tests/data/test_market_data_manager.py
@@ -1199,3 +1199,44 @@ def test_mdm_datahub_register_no_recursion(broker: DummyBroker, ws: DummyWebSock
     # Second start() call with defer_ws=False is a no-op because ws already up
     manager.start()
     assert ws.start_calls == 1
+
+
+def test_readiness_state_marks_futures_soft_requirement() -> None:
+    manager = MarketDataManager.__new__(MarketDataManager)
+    manager._tick_stale_threshold_ms = 60_000  # noqa: SLF001
+    manager._is_symbol_fresh = lambda *_a, **_k: True  # type: ignore[method-assign]  # noqa: SLF001
+    state = manager._readiness_state(  # noqa: SLF001
+        {"NFO:NIFTYCE": 20, "NFO:NIFTYPE": 20, "NFO:FUT": 0},
+        20,
+        {"spot": "NSE:NIFTY", "futures": "NFO:FUT", "options": ["NFO:NIFTYCE", "NFO:NIFTYPE"]},
+    )
+    assert state["hard_ready"] is True
+    assert "futures" in state["missing_soft"]
+    assert "futures" not in state["missing_hard"]
+
+
+def test_readiness_state_accepts_nearby_options_when_exact_atm_missing() -> None:
+    manager = MarketDataManager.__new__(MarketDataManager)
+    manager._tick_stale_threshold_ms = 60_000  # noqa: SLF001
+    manager._is_symbol_fresh = lambda *_a, **_k: True  # type: ignore[method-assign]  # noqa: SLF001
+    state = manager._readiness_state(  # noqa: SLF001
+        {"NFO:NIFTY24CE": 20, "NFO:NIFTY24PE": 20, "NFO:ATMCE": 0, "NFO:ATMPE": 0},
+        20,
+        {
+            "spot": "NSE:NIFTY",
+            "atm_ce": "NFO:ATMCE",
+            "atm_pe": "NFO:ATMPE",
+            "options": ["NFO:NIFTY24CE", "NFO:NIFTY24PE"],
+        },
+    )
+    assert state["hard_ready"] is True
+    assert state["strict_atm_ce_ready"] is False
+    assert state["strict_atm_pe_ready"] is False
+    assert state["selected_ce"] == "NFO:NIFTY24CE"
+    assert state["selected_pe"] == "NFO:NIFTY24PE"
+
+
+def test_coerce_timestamp_prefers_exchange_timestamp() -> None:
+    tick = {"exchange_timestamp": "2026-05-06T10:00:00+00:00", "timestamp": 0}
+    coerced = MarketDataManager._coerce_timestamp(tick)  # noqa: SLF001
+    assert coerced > 1_700_000_000


### PR DESCRIPTION
### Motivation
- Eliminate a crash/NameError in the readiness gate caused by referencing an undefined `mode` and make the runtime-mode check explicit.  
- Avoid startup/live gating being blocked by overly-strict MDM requirements (futures and exact-ATM options) and reduce spurious readiness timeouts.  
- Prevent duplicate ingestion of historical bars into the runner and ensure fresh broker ticks with `exchange_timestamp` are not treated as stale.

### Description
- In `core/app.py` replaced the unsafe `mode` usage with `configured_runtime_mode` for the trading-ready gate, added `ctx.mdm_strict_hard_ready`, and changed `ctx.data_pipeline_ready` to follow `ctx.data_hard_ready`.  
- Split option selection into ` _best_fresh_option(...)` (quote freshness) and ` _best_hydrated_option(...)` (bar hydration), and surfaced separate structured logs `OPTION_QUOTE_READY` and `OPTION_HISTORY_READY`.  
- Deduplicated MDM→runner synchronization in ` _sync_mdm_bars_to_runner(...)` by checking existing runner bar count and ingesting only the missing tail bars, and throttled `RUNNER_MDM_BAR_SYNC` logging via `log_throttled`.  
- In `data/market_data_manager.py` softened readiness rules so `futures` is treated as `missing_soft`, made CE/PE readiness accept nearby hydrated options when strict ATM is missing, return `selected_ce`/`selected_pe` and strict-ATM flags from `_readiness_state`, and updated `_coerce_timestamp(...)` priority to prefer `exchange_timestamp` and `last_trade_time` before generic timestamp fields.  
- Updated/added targeted regressions in `tests/core/test_startup_readiness_regressions.py` and `tests/data/test_market_data_manager.py` to assert the new semantics and timestamp handling.

### Testing
- Ran `python -m compileall -q src` and the source compiled successfully.  
- Ran `pytest -q tests/core tests/data tests/strategies`; the test run was blocked by an existing, unrelated import failure (`ImportError: cannot import name 'atm_strike_for_spot' from nifty_scalper_bot.data.instruments`) reported by `tests/data/test_resolver_lots_delta.py`, so full test-suite verification is pending.  
- Added/updated unit tests in `tests/core/test_startup_readiness_regressions.py` and `tests/data/test_market_data_manager.py` to cover the readiness gating, soft futures semantics, nearby option substitution, `RUNNER_MDM_BAR_SYNC` presence, and `exchange_timestamp` coercion.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb122382f083249f8df02338f9fe6c)