### PR TITLE
fix: align runner runtime readiness with app gating and enforce deterministic limit-order submission

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -6656,25 +6656,14 @@ def _sync_mdm_bars_to_runner(ctx: BotContext, symbol: str, *, min_bars: int) -> 
 
 
 def _best_fresh_option(
-    ctx: BotContext, symbols: list[str], *, side: str, min_bars: int, max_age_s: float = 60.0
+    ctx: BotContext, symbols: list[str], *, side: str, max_age_s: float = 60.0
 ) -> str | None:
-    """Pick best ready CE/PE option from candidates. Args: ctx/symbols/side/min_bars/max_age_s. Returns: symbol|None. Raises: none."""
+    """Pick best fresh quote CE/PE option. Args: ctx/symbols/side/max_age_s. Returns: symbol|None. Raises: none."""
     side = side.upper()
     candidates = [s for s in symbols if str(s).upper().endswith(side)]
     best_symbol: str | None = None
     best_score = -1
     for sym in candidates:
-        bars_count = 0
-        try:
-            bars_count = len(list(ctx.market_data_manager.get_ohlc_bars(sym, limit=min_bars) or [])) if ctx.market_data_manager is not None else 0
-        except Exception:
-            bars_count = 0
-        if bars_count < min_bars:
-            _sync_mdm_bars_to_runner(ctx, sym, min_bars=min_bars)
-            try:
-                bars_count = len(list(ctx.market_data_manager.get_ohlc_bars(sym, limit=min_bars) or [])) if ctx.market_data_manager is not None else bars_count
-            except Exception:
-                pass
         quote_fresh = False
         try:
             snap = ctx.market_data_manager.get_symbol_snapshot(sym) if ctx.market_data_manager is not None else None
@@ -6683,9 +6672,7 @@ def _best_fresh_option(
             quote_fresh = ltp > 0 and age <= max_age_s
         except Exception:
             quote_fresh = False
-        score = 2 if bars_count >= min_bars else (1 if bars_count > 0 else 0)
-        if quote_fresh:
-            score += 3
+        score = 3 if quote_fresh else 0
         if score > best_score:
             best_score = score
             best_symbol = sym
@@ -9295,8 +9282,8 @@ async def startup_sequence(ctx: BotContext) -> None:
                                     extra={"event": "SOFT_READINESS_MISSING", "missing": "futures", "action": "continue_with_spot_option_context"},
                                 )
                             option_symbols = list(readiness_state.get("requirements", {}).get("options", []) or [])
-                            quote_ce = _best_fresh_option(ctx, option_symbols, side="CE", min_bars=20)
-                            quote_pe = _best_fresh_option(ctx, option_symbols, side="PE", min_bars=20)
+                            quote_ce = _best_fresh_option(ctx, option_symbols, side="CE")
+                            quote_pe = _best_fresh_option(ctx, option_symbols, side="PE")
                             hydrated_ce = _best_hydrated_option(ctx, option_symbols, side="CE", min_bars=20)
                             hydrated_pe = _best_hydrated_option(ctx, option_symbols, side="PE", min_bars=20)
                             option_ticks_ready = bool(quote_ce is not None and quote_pe is not None)
@@ -9341,6 +9328,15 @@ async def startup_sequence(ctx: BotContext) -> None:
                                 and configured_runtime_mode == "LIVE"
                                 and runner_running
                             )
+                            if ctx.strategy_runner is not None and hasattr(
+                                ctx.strategy_runner, "set_runtime_readiness"
+                            ):
+                                ctx.strategy_runner.set_runtime_readiness(
+                                    data_hard_ready=ctx.data_hard_ready,
+                                    evaluation_ready=ctx.evaluation_ready,
+                                    live_orders_armed=ctx.live_orders_armed,
+                                    reason=ctx.live_block_reason,
+                                )
                             if configured_runtime_mode in {"PAPER", "SHADOW"}:
                                 ctx.live_orders_armed = False
                                 if ctx.strategy_runner is not None:

--- a/src/nifty_scalper_bot/execution/order_manager.py
+++ b/src/nifty_scalper_bot/execution/order_manager.py
@@ -2670,11 +2670,26 @@ class OrderManager:
         symbol = normalize_symbol(plan.symbol)
         validation = self._validate_trade_plan(plan)
         if not validation.allowed:
+            self._logger.warning(
+                "ORDER_REJECTED symbol=%s reason=%s details=%s trace_id=%s",
+                symbol,
+                validation.reason,
+                validation.details,
+                plan.trace_id,
+            )
             return None
         price = self._protected_limit_price(plan)
+        if price is None:
+            self._logger.warning(
+                "ORDER_REJECTED symbol=%s reason=protected_limit_unavailable details=%s trace_id=%s",
+                symbol,
+                {"entry_price": plan.entry_price},
+                plan.trace_id,
+            )
+            return None
         if hasattr(self, "place_managed_order"):
-            return self.place_managed_order(symbol=symbol, side=plan.side, quantity=plan.quantity, entry_price=price, stop_loss=plan.stop_loss, take_profit=plan.take_profit, signal_id=plan.signal_id, strategy_name=plan.strategy_name, tag=plan.tag, product=plan.product, variety=plan.variety, trace_id=plan.trace_id, allow_market_entry=plan.allow_market_entry)
-        return self.place_order(symbol=symbol, side=plan.side, quantity=plan.quantity, order_type=OrderType.LIMIT if price else OrderType.MARKET, price=price, stop_loss=plan.stop_loss, take_profit=plan.take_profit, tag=plan.tag, check_risk=True, product=plan.product)
+            return self.place_managed_order(symbol=symbol, side=plan.side, quantity=plan.quantity, entry_price=price, stop_loss=plan.stop_loss, take_profit=plan.take_profit, signal_id=plan.signal_id, strategy_name=plan.strategy_name, tag=plan.tag, product=plan.product, variety=plan.variety, trace_id=plan.trace_id, allow_market_entry=False)
+        return self.place_order(symbol=symbol, side=plan.side, quantity=plan.quantity, order_type=OrderType.LIMIT, price=price, stop_loss=plan.stop_loss, take_profit=plan.take_profit, tag=plan.tag, check_risk=True, product=plan.product)
 
     def place_managed_order(
         self,

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -582,6 +582,10 @@ class StrategyRunner:
         self._reason_signal_cooldown_seconds = max(1.0, float(os.getenv("RUNNER_REASON_SIGNAL_COOLDOWN_SECONDS", "120") or 120))
         self._max_order_attempts_per_minute = max(1, int(os.getenv("RUNNER_MAX_ORDER_ATTEMPTS_PER_MINUTE", "3") or 3))
         self._last_execution_halted_log_ts: float = 0.0
+        self._runtime_data_hard_ready = False
+        self._runtime_evaluation_ready = False
+        self._runtime_live_orders_armed = False
+        self._runtime_readiness_reason: str | None = None
 
         if self._message_bus is None:
             raise RuntimeError("MessageBus not injected into StrategyRunner")
@@ -1836,6 +1840,20 @@ class StrategyRunner:
         task.add_done_callback(_on_done)
         return True, "signal_preparation_scheduled"
 
+    def set_runtime_readiness(
+        self,
+        *,
+        data_hard_ready: bool,
+        evaluation_ready: bool,
+        live_orders_armed: bool,
+        reason: str | None = None,
+    ) -> None:
+        """Set app-level runtime readiness flags. Args: flags/reason. Returns: none. Raises: none."""
+        self._runtime_data_hard_ready = bool(data_hard_ready)
+        self._runtime_evaluation_ready = bool(evaluation_ready)
+        self._runtime_live_orders_armed = bool(live_orders_armed)
+        self._runtime_readiness_reason = reason
+
     async def _prepare_signal_for_handling(
         self,
         signal: Signal,
@@ -1851,18 +1869,12 @@ class StrategyRunner:
         )
         if not is_live_mode:
             return signal, None
-        if self._market_data is not None:
-            readiness = getattr(
-                self._market_data, "readiness_state_snapshot", lambda: {}
-            )()
-            hard_ready_fn = getattr(self._market_data, "hard_ready", None)
-            hard_ready = (
-                bool(hard_ready_fn())
-                if callable(hard_ready_fn)
-                else bool(readiness.get("hard_ready"))
+        runtime_ready = bool(getattr(self, "_runtime_data_hard_ready", False))
+        if is_live_mode and not runtime_ready:
+            return None, str(
+                getattr(self, "_runtime_readiness_reason", None)
+                or "startup_pipeline_not_ready"
             )
-            if not hard_ready:
-                return None, "startup_pipeline_not_ready"
         metadata = dict(signal.metadata or {})
         option_side = infer_option_side(signal.symbol, metadata)
         is_directional_option = option_side in {"CE", "PE"}
@@ -7890,6 +7902,15 @@ class StrategyRunner:
                 metadata["tradable_quote"] = bool(
                     (selected_snapshot or {}).get("tradable_quote")
                 )
+                metadata["quote_usable_for_order_plan"] = bool(
+                    (selected_snapshot or {}).get("tradable_quote")
+                    or (
+                        (selected_snapshot or {}).get("ltp_only_fallback")
+                        and candidate.entry_price
+                        and candidate.stop_loss
+                        and candidate.target
+                    )
+                )
             requires_final_score = bool(metadata.get("preliminary_only")) or bool(
                 metadata.get("requires_runner_final_score")
             )
@@ -7943,8 +7964,8 @@ class StrategyRunner:
                     for component in required_components
                 )
                 has_candidate = bool(metadata.get("candidate_selected"))
-                has_tradable_quote = bool(metadata.get("tradable_quote"))
-                if not (has_components and has_candidate and has_tradable_quote):
+                has_quote_usable = bool(metadata.get("quote_usable_for_order_plan"))
+                if not (has_components and has_candidate and has_quote_usable):
                     self._logger.info(
                         "SIGNAL_EXECUTION_RESULT accepted=False reason=final_score_required symbol=%s trace_id=%s",
                         base_symbol,

--- a/tests/strategies/test_runner_live_path_guards.py
+++ b/tests/strategies/test_runner_live_path_guards.py
@@ -64,6 +64,10 @@ def _build_runner() -> StrategyRunner:
     runner.build_candidate_snapshots = MagicMock(return_value=[])
     runner.build_candidate_snapshots_async = MagicMock(return_value=([], False))
     runner._market_data = None
+    runner._runtime_data_hard_ready = True
+    runner._runtime_evaluation_ready = True
+    runner._runtime_live_orders_armed = True
+    runner._runtime_readiness_reason = None
     return runner
 
 
@@ -495,8 +499,9 @@ async def test_live_async_path_uses_signal_candidate_fallback(monkeypatch) -> No
     assert prepared is not None
     candidate = prepared.metadata['candidate_snapshots'][0]
     assert candidate['ltp'] == 111.0
-    assert candidate['bid'] == 111.0
-    assert candidate['ask'] == 111.0
+    assert candidate['bid'] == 0.0
+    assert candidate['ask'] == 0.0
+    assert candidate['ltp_only_fallback'] is True
 
 
 def test_strategy_evaluation_caps_required_option_bars(monkeypatch) -> None:


### PR DESCRIPTION
### Motivation
- Prevent live signals being blocked by stale MDM strict hard_ready when the app has already declared readiness.  
- Separate quote freshness (LTP/bid/ask) from historical hydration to make readiness semantics deterministic.  
- Make order submission deterministic and safe by surfacing rejection reason and avoiding silent MARKET fallbacks when protected limits are unavailable.  

### Description
- Added app-injectable runtime readiness to `StrategyRunner` with `set_runtime_readiness(...)` and initialized runtime readiness fields in `__init__`.  
- Replaced the MDM strict `hard_ready` gate in `StrategyRunner._prepare_signal_for_handling` with the injected app-level runtime readiness check and propagated the readiness reason on rejection.  
- Introduced `quote_usable_for_order_plan` metadata so an LTP-only candidate can pass the final-score gate only when it contains `entry_price`, `stop_loss`, and `target`, while preserving `tradable_quote` semantics.  
- Split readiness selection into `_best_fresh_option` (quote freshness-only) and `_best_hydrated_option` (bar hydration), updated app readiness computation to use both, and pushed computed readiness into the runner via `set_runtime_readiness(...)`.  
- Hardened `OrderManager.submit_trade_plan` to log deterministic `ORDER_REJECTED` messages on validation failure, reject when the protected limit price is unavailable, and never fall back to `MARKET` in this submission path (use `LIMIT` only).  
- Updated live-path runner tests to seed the new runtime readiness fields and adjusted expectations for LTP-only fallback candidates.  

### Testing
- `python -m compileall -q src` succeeded.  
- Full test run `pytest -q tests/core tests/data tests/strategies tests/execution` failed during collection with an existing repository import issue: `ImportError` in `tests/data/test_resolver_lots_delta.py` due to `atm_strike_for_spot` missing from `nifty_scalper_bot.data.instruments`.  
- Targeted test run including startup/readiness and runner live-paths (`tests/strategies/test_runner_live_path_guards.py tests/data/test_market_data_manager.py tests/core/test_startup_readiness_regressions.py`) produced a failing data test: `tests/data/test_market_data_manager.py::test_readiness_passes_with_required_quorum` (the manager reported `ready` as False because `spot_ready` remained false in the timeout snapshot).  
- Runner live-path unit tests were adjusted (seeded runtime readiness and LTP-only expectations); the runner-related regressions observed earlier were addressed, but the overall suite still shows a failing MDM readiness test that needs follow-up.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb137af2ec832497ec29350f54ebb8)