### PR TITLE
fix: unblock live readiness and runtime entry gating

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -6756,6 +6756,15 @@ async def _deferred_basket_hydration_retry(
                 ctx,
                 reason="deferred_basket_hydration_success",
             )
+            if ctx.strategy_runner is not None and hasattr(
+                ctx.strategy_runner, "set_runtime_readiness"
+            ):
+                ctx.strategy_runner.set_runtime_readiness(
+                    data_hard_ready=bool(getattr(ctx, "data_hard_ready", False)),
+                    evaluation_ready=bool(getattr(ctx, "evaluation_ready", False)),
+                    live_orders_armed=bool(getattr(ctx, "live_orders_armed", False)),
+                    reason=str(getattr(ctx, "live_block_reason", None) or "LIVE"),
+                )
             LOGGER.info(
                 "DEFERRED_BASKET_RETRY_SUCCESS attempt=%d spot_ltp=%.2f",
                 attempt,
@@ -6800,15 +6809,27 @@ async def _build_and_hydrate_live_basket_from_spot(
     del configured_mode
     if float(spot_ltp) <= 0:
         raise RuntimeError("spot_ltp must be positive for live basket hydration")
+    LOGGER.info(
+        "LIVE_BASKET_BUILD_STARTED spot_ltp=%.2f hydrate=%s",
+        float(spot_ltp),
+        bool(hydrate),
+        extra={"event": "LIVE_BASKET_BUILD_STARTED", "spot_ltp": float(spot_ltp), "hydrate": bool(hydrate)},
+    )
     if ctx.instrument_manager is None or not ctx.instrument_manager.is_loaded():
-        LOGGER.info(
-            "LIVE_BASKET_BUILD_DEFERRED reason=instrument_manager_not_ready",
+        instrument_manager = getattr(ctx, "instrument_manager", None)
+        is_loaded = bool(instrument_manager.is_loaded()) if instrument_manager is not None and hasattr(instrument_manager, "is_loaded") else False
+        LOGGER.error(
+            "LIVE_BASKET_BUILD_BLOCKED reason=instrument_manager_not_ready type=%s is_loaded=%s",
+            type(instrument_manager).__name__ if instrument_manager is not None else "NoneType",
+            is_loaded,
             extra={
-                "event": "LIVE_BASKET_BUILD_DEFERRED",
+                "event": "LIVE_BASKET_BUILD_BLOCKED",
                 "reason": "instrument_manager_not_ready",
+                "instrument_manager_type": type(instrument_manager).__name__ if instrument_manager is not None else "NoneType",
+                "is_loaded": is_loaded,
             },
         )
-        return {"deferred": True, "reason": "instrument_manager_not_ready"}
+        raise RuntimeError("instrument_manager_not_ready_for_live_basket")
     if ctx.market_data_manager is None:
         raise RuntimeError("market_data_manager_unavailable_for_live_basket")
     if ctx.broker_client is None:
@@ -6981,6 +7002,11 @@ async def _build_and_hydrate_live_basket_from_spot(
         flushed_result = flush_pending()
         if inspect.isawaitable(flushed_result):
             await flushed_result
+    LOGGER.info(
+        "LIVE_BASKET_BUILD_SUCCESS symbols=%s",
+        list(targets),
+        extra={"event": "LIVE_BASKET_BUILD_SUCCESS", "symbols": list(targets)},
+    )
     return basket
 
 
@@ -9328,15 +9354,6 @@ async def startup_sequence(ctx: BotContext) -> None:
                                 and configured_runtime_mode == "LIVE"
                                 and runner_running
                             )
-                            if ctx.strategy_runner is not None and hasattr(
-                                ctx.strategy_runner, "set_runtime_readiness"
-                            ):
-                                ctx.strategy_runner.set_runtime_readiness(
-                                    data_hard_ready=ctx.data_hard_ready,
-                                    evaluation_ready=ctx.evaluation_ready,
-                                    live_orders_armed=ctx.live_orders_armed,
-                                    reason=ctx.live_block_reason,
-                                )
                             if configured_runtime_mode in {"PAPER", "SHADOW"}:
                                 ctx.live_orders_armed = False
                                 if ctx.strategy_runner is not None:
@@ -9434,6 +9451,30 @@ async def startup_sequence(ctx: BotContext) -> None:
                                 ",".join(data_warmup_reasons) if data_warmup_reasons else None
                             )
                             ctx.live_block_reason = data_warmup_reason
+                            runtime_reason = "LIVE" if (live_mode and armed) else ctx.live_block_reason
+                            if ctx.strategy_runner is not None and hasattr(
+                                ctx.strategy_runner, "set_runtime_readiness"
+                            ):
+                                ctx.strategy_runner.set_runtime_readiness(
+                                    data_hard_ready=bool(ctx.data_hard_ready),
+                                    evaluation_ready=bool(ctx.evaluation_ready),
+                                    live_orders_armed=bool(ctx.live_orders_armed),
+                                    reason=runtime_reason,
+                                )
+                                LOGGER.info(
+                                    "RUNTIME_READINESS_PUSHED data_hard_ready=%s evaluation_ready=%s live_orders_armed=%s reason=%s",
+                                    bool(ctx.data_hard_ready),
+                                    bool(ctx.evaluation_ready),
+                                    bool(ctx.live_orders_armed),
+                                    runtime_reason,
+                                    extra={
+                                        "event": "RUNTIME_READINESS_PUSHED",
+                                        "data_hard_ready": bool(ctx.data_hard_ready),
+                                        "evaluation_ready": bool(ctx.evaluation_ready),
+                                        "live_orders_armed": bool(ctx.live_orders_armed),
+                                        "reason": runtime_reason,
+                                    },
+                                )
                             ctx.market_session_state = session_state_str
                             ctx.quote_api_available = quote_available
                             ctx.quote_api_error = quote_error

--- a/src/nifty_scalper_bot/execution/order_manager.py
+++ b/src/nifty_scalper_bot/execution/order_manager.py
@@ -2688,7 +2688,7 @@ class OrderManager:
             )
             return None
         if hasattr(self, "place_managed_order"):
-            return self.place_managed_order(symbol=symbol, side=plan.side, quantity=plan.quantity, entry_price=price, stop_loss=plan.stop_loss, take_profit=plan.take_profit, signal_id=plan.signal_id, strategy_name=plan.strategy_name, tag=plan.tag, product=plan.product, variety=plan.variety, trace_id=plan.trace_id, allow_market_entry=False)
+            return self.place_managed_order(symbol=symbol, side=plan.side, quantity=plan.quantity, entry_price=price, stop_loss=plan.stop_loss, take_profit=plan.take_profit, signal_id=plan.signal_id, strategy_name=plan.strategy_name, tag=plan.tag, product=plan.product, variety=plan.variety, trace_id=plan.trace_id, allow_market_entry=plan.allow_market_entry)
         return self.place_order(symbol=symbol, side=plan.side, quantity=plan.quantity, order_type=OrderType.LIMIT, price=price, stop_loss=plan.stop_loss, take_profit=plan.take_profit, tag=plan.tag, check_risk=True, product=plan.product)
 
     def place_managed_order(

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -7170,7 +7170,6 @@ class StrategyRunner:
         tp_pct = self._vwap_tp_pct
         calculated_sl = price * (1 - sl_pct / 100)
         calculated_tp = price * (1 + tp_pct / 100)
-        self._premium_squeeze_last_signal_ts[underlying] = now_epoch
         self._reason_last_signal_ts[f"{underlying}:premium_momentum_squeeze"] = now_epoch
         log_throttled(
             self._logger,
@@ -7240,26 +7239,28 @@ class StrategyRunner:
             str(os.getenv("ENABLE_LIVE", "false")).strip().lower()
             in {"1", "true", "yes", "on"}
         )
-        if is_live_mode and self._market_data is not None:
-            readiness = getattr(
-                self._market_data, "readiness_state_snapshot", lambda: {}
-            )()
-            hard_ready_fn = getattr(self._market_data, "hard_ready", None)
-            hard_ready = (
-                bool(hard_ready_fn())
-                if callable(hard_ready_fn)
-                else bool(readiness.get("hard_ready"))
+        if is_live_mode and not bool(self._runtime_data_hard_ready):
+            self._logger.info(
+                "RUNNER_BLOCKED_RUNTIME_READINESS",
+                extra={
+                    "event": "RUNNER_BLOCKED_RUNTIME_READINESS",
+                    "stage": "handle_signal",
+                    "runtime_data_hard_ready": bool(self._runtime_data_hard_ready),
+                    "runtime_evaluation_ready": bool(self._runtime_evaluation_ready),
+                    "runtime_live_orders_armed": bool(self._runtime_live_orders_armed),
+                    "runtime_readiness_reason": self._runtime_readiness_reason,
+                    "trace_id": trace_id,
+                },
             )
-            if not hard_ready:
-                self._emit_runner_eval_decision(
-                    symbol=self._normalize_symbol(signal.symbol),
-                    stage="handle_signal",
-                    reason="startup_pipeline_not_ready",
-                    allowed=False,
-                    trace_id=trace_id,
-                    readiness=readiness,
-                )
-                return SignalExecutionResult(False, "startup_pipeline_not_ready")
+            self._emit_runner_eval_decision(
+                symbol=self._normalize_symbol(signal.symbol),
+                stage="handle_signal",
+                reason=str(self._runtime_readiness_reason or "runtime_data_not_ready"),
+                allowed=False,
+                trace_id=trace_id,
+                readiness={},
+            )
+            return SignalExecutionResult(False, "runtime_data_not_ready")
         self._logger.info(
             "RUNNER_SIGNAL_DECISION",
             extra={
@@ -7779,19 +7780,21 @@ class StrategyRunner:
                 str(os.getenv("ENABLE_LIVE", "false")).strip().lower()
                 in {"1", "true", "yes", "on"}
             )
-            if is_live_mode and self._market_data is not None:
-                readiness = getattr(
-                    self._market_data, "readiness_state_snapshot", lambda: {}
-                )()
-                hard_ready_fn = getattr(self._market_data, "hard_ready", None)
-                hard_ready = (
-                    bool(hard_ready_fn())
-                    if callable(hard_ready_fn)
-                    else bool(readiness.get("hard_ready"))
+            if is_live_mode and not bool(self._runtime_live_orders_armed):
+                self._logger.info(
+                    "RUNNER_BLOCKED_RUNTIME_READINESS",
+                    extra={
+                        "event": "RUNNER_BLOCKED_RUNTIME_READINESS",
+                        "stage": "entry",
+                        "runtime_data_hard_ready": bool(self._runtime_data_hard_ready),
+                        "runtime_evaluation_ready": bool(self._runtime_evaluation_ready),
+                        "runtime_live_orders_armed": bool(self._runtime_live_orders_armed),
+                        "runtime_readiness_reason": self._runtime_readiness_reason,
+                        "trace_id": trace_id,
+                    },
                 )
-                if not hard_ready:
-                    self._reset_execution_state(base_symbol)
-                    return SignalExecutionResult(False, "startup_pipeline_not_ready")
+                self._reset_execution_state(base_symbol)
+                return SignalExecutionResult(False, "runtime_live_orders_not_armed")
             option_side = infer_option_side(signal.symbol, metadata)
             if is_live_mode and option_side == "UNKNOWN":
                 self._reset_execution_state(base_symbol)
@@ -8162,7 +8165,11 @@ class StrategyRunner:
             )
 
             self._order_attempt_window.append(now_epoch)
-            plan = TradePlan(symbol=base_symbol, side=signal.action, quantity=qty, entry_price=price, stop_loss=stop_loss, take_profit=take_profit, strategy_name=strategy_name, signal_id=signal.deterministic_id, trace_id=trace_id, tag=f"runner_{signal.action.lower()}", product="MIS", variety="regular", max_quote_age_ms=5000, max_spread_pct=5.0, min_depth_qty=150, allow_market_entry=False)
+            max_quote_age_ms = int(os.getenv("ORDER_MAX_QUOTE_AGE_MS", "60000") or "60000")
+            max_spread_pct = float(os.getenv("ORDER_MAX_SPREAD_PCT", os.getenv("SPREAD_MAX_PCT", "10.0")) or "10.0")
+            min_depth_qty = int(os.getenv("ORDER_MIN_DEPTH_QTY", os.getenv("MIN_DEPTH_QTY", "0")) or "0")
+            allow_market_entry = str(os.getenv("ALLOW_MARKET_ENTRY", "false")).strip().lower() in {"1", "true", "yes", "on"}
+            plan = TradePlan(symbol=base_symbol, side=signal.action, quantity=qty, entry_price=price, stop_loss=stop_loss, take_profit=take_profit, strategy_name=strategy_name, signal_id=signal.deterministic_id, trace_id=trace_id, tag=f"runner_{signal.action.lower()}", product="MIS", variety="regular", max_quote_age_ms=max_quote_age_ms, max_spread_pct=max_spread_pct, min_depth_qty=min_depth_qty, allow_market_entry=allow_market_entry)
             order_id = self._order_manager.submit_trade_plan(plan)
 
             if order_id:
@@ -8174,7 +8181,6 @@ class StrategyRunner:
                 self._reason_last_signal_ts[underlying_reason_key] = now_epoch
                 if reason_key == "premium_momentum_squeeze":
                     self._premium_squeeze_last_signal_ts[underlying] = now_epoch
-                self._order_attempt_window.append(now_epoch)
                 try:
                     self._record_trade(
                         base_symbol,
@@ -8219,7 +8225,16 @@ class StrategyRunner:
         _bars_source = self._data_hub or self._market_data
         bars = _bars_source.get_ohlc_bars(symbol) if _bars_source else []
         if len(bars) < self._required_candles:
-            raise RuntimeError("ATR unavailable due to insufficient data")
+            fallback_atr = max(float(current_price) * 0.015, 1.0)
+            self._logger.warning(
+                "ATR_FALLBACK_USED symbol=%s atr=%.4f reason=insufficient_bars bars=%d required=%d",
+                symbol,
+                fallback_atr,
+                len(bars),
+                int(self._required_candles),
+                extra={"event": "ATR_FALLBACK_USED", "symbol": symbol, "atr": fallback_atr, "bars": len(bars), "required": int(self._required_candles), "reason": "insufficient_bars"},
+            )
+            return fallback_atr
 
         atr_val = 0.0
         source = "unknown"
@@ -8277,7 +8292,14 @@ class StrategyRunner:
                             pass
 
         if atr_val <= 0:
-            raise RuntimeError("ATR unavailable due to insufficient data")
+            fallback_atr = max(float(current_price) * 0.015, 1.0)
+            self._logger.warning(
+                "ATR_FALLBACK_USED symbol=%s atr=%.4f reason=atr_unavailable",
+                symbol,
+                fallback_atr,
+                extra={"event": "ATR_FALLBACK_USED", "symbol": symbol, "atr": fallback_atr, "reason": "atr_unavailable"},
+            )
+            return fallback_atr
 
         spread = 0.0
         try:

--- a/tests/execution/test_order_manager_trade_plan.py
+++ b/tests/execution/test_order_manager_trade_plan.py
@@ -4,3 +4,18 @@ def test_trade_plan_dataclass_defaults():
     plan = TradePlan(symbol='NFO:NIFTY', side='BUY', quantity=75, entry_price=100.0, stop_loss=90.0, take_profit=110.0)
     assert plan.allow_market_entry is False
     assert isinstance(OrderPreflightResult(True), OrderPreflightResult)
+
+
+def test_submit_trade_plan_passes_allow_market_entry() -> None:
+    manager = type('M', (), {})()
+    captured = {}
+    def place_managed_order(**kwargs):
+        captured.update(kwargs)
+        return 'oid-1'
+    manager.place_managed_order = place_managed_order
+    manager._preflight_trade_plan = lambda _plan: OrderPreflightResult(True)
+    from nifty_scalper_bot.execution.order_manager import OrderManager
+    plan = TradePlan(symbol='NFO:NIFTY', side='BUY', quantity=75, entry_price=100.0, stop_loss=90.0, take_profit=110.0, allow_market_entry=True)
+    result = OrderManager.submit_trade_plan(manager, plan)  # type: ignore[arg-type]
+    assert result == 'oid-1'
+    assert captured['allow_market_entry'] is True

--- a/tests/strategies/test_runner_live_path_guards.py
+++ b/tests/strategies/test_runner_live_path_guards.py
@@ -170,6 +170,50 @@ def test_premium_squeeze_does_not_self_suppress_on_first_execution() -> None:
     assert result.reason == 'order_submitted'
     assert runner._premium_squeeze_last_signal_ts.get('NIFTY', 0.0) > 0.0
 
+
+def test_live_entry_uses_runtime_readiness_not_mdm_hard_ready(monkeypatch) -> None:
+    runner = _build_runner()
+    monkeypatch.setenv('EXECUTION_MODE', 'LIVE')
+    runner._runtime_data_hard_ready = True
+    runner._runtime_live_orders_armed = True
+    class _BadMarketData:
+        def hard_ready(self):
+            raise AssertionError('hard_ready should not be called')
+    runner._market_data = _BadMarketData()
+    runner._order_manager.submit_trade_plan = MagicMock(return_value='order-1')
+    signal = Signal(action='BUY', symbol='NFO:NIFTY26APR23800CE', quantity=1, confidence=0.9, reason='test', stop_loss=100.0, take_profit=120.0, metadata={'strategy_score': 7, 'option_score': 7, 'data_score': 7, 'rr_score': 7})
+    result = runner._handle_entry_signal_inner(signal, 'NFO:NIFTY26APR23800CE', 'NFO:NIFTY26APR23800CE', 110.0, datetime.now(timezone.utc), trace_id='runtime-ready')
+    assert result.accepted is True
+
+
+def test_trade_plan_uses_env_preflight_values(monkeypatch) -> None:
+    runner = _build_runner()
+    monkeypatch.setenv('ORDER_MAX_QUOTE_AGE_MS', '65000')
+    monkeypatch.setenv('SPREAD_MAX_PCT', '12.5')
+    monkeypatch.setenv('MIN_DEPTH_QTY', '25')
+    monkeypatch.setenv('ALLOW_MARKET_ENTRY', 'true')
+    captured = {}
+    def _submit(plan):
+        captured['plan'] = plan
+        return 'order-2'
+    runner._order_manager.submit_trade_plan = _submit
+    signal = Signal(action='BUY', symbol='NFO:NIFTY26APR23800CE', quantity=1, confidence=0.9, reason='test', stop_loss=100.0, take_profit=120.0, metadata={'strategy_score': 7, 'option_score': 7, 'data_score': 7, 'rr_score': 7})
+    runner._handle_entry_signal_inner(signal, 'NFO:NIFTY26APR23800CE', 'NFO:NIFTY26APR23800CE', 110.0, datetime.now(timezone.utc), trace_id='preflight')
+    plan = captured['plan']
+    assert plan.max_quote_age_ms == 65000
+    assert plan.max_spread_pct == 12.5
+    assert plan.min_depth_qty == 25
+    assert plan.allow_market_entry is True
+
+
+def test_atr_fallback_used_for_insufficient_bars() -> None:
+    runner = _build_runner()
+    runner._required_candles = 20
+    runner._data_hub = SimpleNamespace(get_ohlc_bars=lambda _symbol: [])
+    runner._market_data = None
+    atr = runner._get_atr_with_fallback('NFO:NIFTY26APR23800CE', {}, 100.0)
+    assert atr > 0
+
 def test_stale_thresholds_are_instrument_specific() -> None:
     runner = _build_runner()
     runner._option_stale_tick_seconds = 900.0


### PR DESCRIPTION
### Motivation
- Live startup could remain stuck in `DATA_WARMUP` because `_build_and_hydrate_live_basket_from_spot()` silently deferred when the instrument manager was not ready and the runner received stale `live_orders_armed` state.  The goal is to make failures explicit and ensure the runner receives the final readiness state so eligible signals are allowed once instruments and data are available.
- StrategyRunner gated live evaluation/entry on `market_data.hard_ready()` which prevented app-driven readiness transitions from unlocking live entry; this change moves gating to app-pushed runtime readiness to match centralized startup logic.
- Several execution edge-cases (premium squeeze cooldown stamping, duplicate order-attempt counting, hardcoded TradePlan preflight values, ATR fallback) risked blocking valid entries or raising avoidable errors in live conditions and needed deterministic, env-driven behavior and safer fallbacks.

### Description
- Changed `_build_and_hydrate_live_basket_from_spot()` to log `LIVE_BASKET_BUILD_STARTED`, `LIVE_BASKET_BUILD_BLOCKED` (with `instrument_manager` type and `is_loaded`), and `LIVE_BASKET_BUILD_SUCCESS`, and to raise `RuntimeError("instrument_manager_not_ready_for_live_basket")` instead of silently returning a deferred payload.
- Ensured deferred retry path calls `_ensure_strategy_runner_started()` after rebuild and pushes runtime readiness via `ctx.strategy_runner.set_runtime_readiness(...)` so the runner receives the updated `live_orders_armed` value after instruments/data load; added `RUNTIME_READINESS_PUSHED` log when pushed.
- Moved readiness push in the main startup readiness gate to occur after finalizing `ctx.live_orders_armed`, `ctx.trading_ready`, `ctx.readiness_mode`, and `ctx.effective_mode` so `StrategyRunner.set_runtime_readiness()` receives the final state and `reason="LIVE"` when armed.
- Replaced StrategyRunner direct `market_data.hard_ready()` blockers with app-driven runtime fields (`_runtime_data_hard_ready`, `_runtime_evaluation_ready`, `_runtime_live_orders_armed`, `_runtime_readiness_reason`) and emit `RUNNER_BLOCKED_RUNTIME_READINESS` with full runtime readiness diagnostics; in live mode only block evaluation when `_runtime_data_hard_ready` is false and only block entry when `_runtime_live_orders_armed` is false.
- Fixed premium squeeze cooldown by removing the early `self._premium_squeeze_last_signal_ts[underlying]` assignment during signal generation and stamping cooldown only after a successful `order_id` is returned; removed the duplicate append to `_order_attempt_window` after successful submit and retained the pre-submit append.
- Replaced hardcoded TradePlan preflight values with env-configurable defaults: `ORDER_MAX_QUOTE_AGE_MS` (default `60000`), `ORDER_MAX_SPREAD_PCT` or `SPREAD_MAX_PCT` (default `10.0`), `ORDER_MIN_DEPTH_QTY` or `MIN_DEPTH_QTY` (default `0`), and `ALLOW_MARKET_ENTRY` (default `false`); passed `plan.allow_market_entry` through in `OrderManager.submit_trade_plan()` to `place_managed_order()`.
- Improved ATR fallback in `StrategyRunner._get_atr_with_fallback()` to return a safe fallback ATR `max(current_price * 0.015, 1.0)` and log `ATR_FALLBACK_USED` instead of raising `RuntimeError` when bars or ATR sources are insufficient.

### Testing
- Ran `bash run_checks.sh`; the script executed dependency installation but reported the environment-managed run path lacked `pytest` and exited (`❌ pytest not installed but tests/ exists`).
- Activated the venv and ran targeted tests with `pytest -q tests/strategies/test_runner_live_path_guards.py tests/execution/test_order_manager_trade_plan.py`; these tests passed (all assertions green).
- Added/updated unit tests: `tests/strategies/test_runner_live_path_guards.py` (runtime-readiness gating, preflight env values, ATR fallback) and `tests/execution/test_order_manager_trade_plan.py` (pass-through of `allow_market_entry`), and executed them successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc14387c9c83248df6be8cd7892adf)