### PR TITLE
Unify strategy no-vote reporting, add single-vote selected-option checks, and fallback orderflow logic

### DIFF
--- a/src/nifty_scalper_bot/core/strategy_manager.py
+++ b/src/nifty_scalper_bot/core/strategy_manager.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 import time
 import typing as t
 from abc import ABC, abstractmethod
@@ -2504,6 +2505,7 @@ class StrategyManager(_BaseStrategyManager):
             single_min_score = float(os.getenv("STRATEGY_SINGLE_VOTE_MIN_SCORE", "6.5") or "6.5")
             single_min_confidence = float(os.getenv("STRATEGY_SINGLE_VOTE_MIN_CONFIDENCE", "0.60") or "0.60")
             require_selected_option = str(os.getenv("STRATEGY_SINGLE_VOTE_REQUIRE_SELECTED_OPTION", "true")).strip().lower() in {"1", "true", "yes", "on"}
+            single_max_strike_distance = float(os.getenv("STRATEGY_SINGLE_VOTE_MAX_STRIKE_DISTANCE", "100") or "100")
             single_max_spread = float(os.getenv("STRATEGY_SINGLE_VOTE_MAX_SPREAD_PCT", "10.0") or "10.0")
             require_direction_score = str(os.getenv("STRATEGY_SINGLE_VOTE_REQUIRE_DIRECTION_SCORE", "false")).strip().lower() in {"1", "true", "yes", "on"}
             min_direction_score = float(os.getenv("STRATEGY_SINGLE_VOTE_MIN_DIRECTION_SCORE", "6.0") or "6.0")
@@ -2516,7 +2518,26 @@ class StrategyManager(_BaseStrategyManager):
                 spread_ok = spread_pct is None or spread_pct <= single_max_spread
                 selected_ok = True
                 if require_selected_option:
-                    selected_ok = bool(metadata.get("candidate_selected") or metadata.get("is_selected_option"))
+                    selected_marker = metadata.get("candidate_selected")
+                    if selected_marker is None:
+                        selected_marker = metadata.get("is_selected_option")
+                    if selected_marker is None:
+                        selected_ce = indicators.get("selected_ce")
+                        selected_pe = indicators.get("selected_pe")
+                        atm_strike = indicators.get("atm_strike")
+                        signal_strike = self._extract_strike_from_symbol(single_signal.symbol)
+                        if selected_ce or selected_pe or atm_strike:
+                            selected_ok = bool(single_signal.symbol in {selected_ce, selected_pe})
+                            if not selected_ok and signal_strike is not None and atm_strike is not None:
+                                try:
+                                    selected_ok = abs(float(signal_strike) - float(atm_strike)) <= single_max_strike_distance
+                                except (TypeError, ValueError):
+                                    selected_ok = False
+                        else:
+                            log.info("SINGLE_VOTE_SELECTED_CHECK_UNAVAILABLE")
+                            selected_ok = False
+                    else:
+                        selected_ok = bool(selected_marker)
                 direction_score = float(metadata.get("direction_score") or 0.0)
                 direction_ok = (not require_direction_score) or direction_score >= min_direction_score
                 if allow_single_vote_scalp and score_ok and confidence_ok and spread_ok and selected_ok and direction_ok:
@@ -2531,6 +2552,18 @@ class StrategyManager(_BaseStrategyManager):
                         extra={'event': 'STRATEGY_CONSENSUS', 'side': winning_side, 'score': single_vote.score, 'votes': 1, 'reason': 'single_vote_scalp_controlled'},
                     )
                     return Signal(action='BUY', symbol=single_signal.symbol, quantity=single_signal.quantity, confidence=single_signal.confidence, reason=single_signal.reason, stop_loss=single_signal.stop_loss, take_profit=single_signal.take_profit, metadata=metadata)
+                log.info(
+                    "SINGLE_VOTE_REJECTED strategy=%s score=%.2f score_ok=%s confidence=%.2f confidence_ok=%s selected_ok=%s spread_ok=%s direction_ok=%s allow_single_vote_scalp=%s",
+                    single_vote.strategy,
+                    single_vote.score,
+                    score_ok,
+                    float(single_signal.confidence or 0.0),
+                    confidence_ok,
+                    selected_ok,
+                    spread_ok,
+                    direction_ok,
+                    allow_single_vote_scalp,
+                )
                 log.info(
                     'STRATEGY_CONSENSUS side=NO_TRADE score=%.2f votes=1 reason=single_vote_low_score threshold=%.2f allow_single_vote_scalp=%s',
                     single_vote.score,
@@ -3248,6 +3281,21 @@ class StrategyManager(_BaseStrategyManager):
                 extra={"event": "strategy_metric_normalise_error"},
             )
             return {}
+
+
+    @staticmethod
+    def _extract_strike_from_symbol(symbol: str) -> int | None:
+        """Extract option strike from symbol. Args: symbol. Returns: strike/None. Raises: none."""
+        raw = str(symbol or "").strip().upper()
+        if ":" in raw:
+            raw = raw.split(":", 1)[1]
+        match = re.search(r"(\d{4,6})(CE|PE)$", raw.replace("-", "").replace("_", ""))
+        if not match:
+            return None
+        try:
+            return int(match.group(1))
+        except ValueError:
+            return None
 
 
 __all__ = [

--- a/src/nifty_scalper_bot/strategies/elite_strategies/base_elite.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/base_elite.py
@@ -242,6 +242,11 @@ class EliteStrategy(Strategy):
 
         return None
 
+
+    def _no_vote(self, reason: str) -> None:
+        """Record a single no-vote reason. Args: reason. Returns: None. Raises: none."""
+        self.last_no_vote_reason = reason
+
     def _evaluate_signal(
         self, 
         symbol: str = "", 

--- a/src/nifty_scalper_bot/strategies/elite_strategies/bb_squeeze.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/bb_squeeze.py
@@ -27,7 +27,7 @@ class BBSqueezeStrategy(EliteStrategy):
         """Args: symbol, indicators, current_price, position. Returns: EliteSignal|None. Raises: Exception."""
         del position
         try:
-            self.last_no_vote_reason = "none"
+            self._no_vote("stale_or_invalid_data")
             upper = float(indicators.get('bollinger_upper') or 0.0)
             lower = float(indicators.get('bollinger_lower') or 0.0)
             mid = float(indicators.get('bollinger_middle') or 0.0)
@@ -48,14 +48,12 @@ class BBSqueezeStrategy(EliteStrategy):
 
             breakout_side = 'CE' if close > upper else 'PE' if close < lower else 'UNKNOWN'
             if breakout_side == 'UNKNOWN':
-                self.last_no_vote_reason = 'no_breakout'
-                self.last_no_vote_reason = 'weak_expansion'
+                self._no_vote('no_breakout')
                 LOGGER.debug('STRATEGY_NO_VOTE strategy=BBSqueeze reason=no_breakout')
                 return None
             expansion_confirmed = abs(close - open_price) >= 0.35 * atr
             if not expansion_confirmed:
-                self.last_no_vote_reason = 'no_breakout'
-                self.last_no_vote_reason = 'weak_expansion'
+                self._no_vote('weak_expansion')
                 LOGGER.debug('STRATEGY_NO_VOTE strategy=BBSqueeze reason=no_expansion')
                 return None
 

--- a/src/nifty_scalper_bot/strategies/elite_strategies/cpr_breakout.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/cpr_breakout.py
@@ -27,7 +27,7 @@ class CPRBreakoutStrategy(EliteStrategy):
         """Args: symbol, indicators, current_price, position. Returns: EliteSignal|None. Raises: Exception."""
         del position
         try:
-            self.last_no_vote_reason = "none"
+            self._no_vote("stale_or_invalid_data")
             cpr_bottom = float(indicators.get('bc') or 0.0)
             cpr_top = float(indicators.get('tc') or 0.0)
             pivot = float(indicators.get('pivot') or 0.0)
@@ -39,16 +39,14 @@ class CPRBreakoutStrategy(EliteStrategy):
             if min(cpr_bottom, cpr_top, pivot) <= 0 or cpr_top <= cpr_bottom:
                 return None
             if cpr_bottom <= current_price <= cpr_top:
-                self.last_no_vote_reason = 'inside_cpr'
-                self.last_no_vote_reason = 'nearest_level_too_close'
+                self._no_vote('inside_cpr')
                 LOGGER.debug('STRATEGY_NO_VOTE strategy=CPRBreakout reason=inside_cpr')
                 return None
 
             side = 'CE' if current_price > cpr_top else 'PE'
             nearest_level_distance = (r1 - current_price) if side == 'CE' and r1 > 0 else (current_price - s1) if side == 'PE' and s1 > 0 else atr
             if nearest_level_distance < 0.5 * atr:
-                self.last_no_vote_reason = 'inside_cpr'
-                self.last_no_vote_reason = 'nearest_level_too_close'
+                self._no_vote('nearby_level')
                 LOGGER.debug('STRATEGY_NO_VOTE strategy=CPRBreakout reason=nearby_level')
                 return None
 

--- a/src/nifty_scalper_bot/strategies/elite_strategies/orb_pro.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/orb_pro.py
@@ -27,7 +27,7 @@ class ORBProStrategy(EliteStrategy):
         """Args: symbol, indicators, current_price, position. Returns: EliteSignal|None. Raises: Exception."""
         del position
         try:
-            self.last_no_vote_reason = "none"
+            self._no_vote("stale_or_invalid_data")
             or_complete = bool(indicators.get('orb_ready'))
             orb_high = float(indicators.get('orb_high') or 0.0)
             orb_low = float(indicators.get('orb_low') or 0.0)
@@ -40,17 +40,13 @@ class ORBProStrategy(EliteStrategy):
             regime = str(indicators.get('regime') or '').upper()
 
             if not or_complete:
-                self.last_no_vote_reason = 'orb_not_ready'
-                self.last_no_vote_reason = 'no_breakout'
-                self.last_no_vote_reason = 'wick_only_breakout'
+                self._no_vote('orb_not_ready')
                 LOGGER.debug('STRATEGY_NO_VOTE strategy=ORBPro reason=opening_range_incomplete')
                 return None
             if orb_high <= orb_low:
                 return None
             if regime in {'CHOPPY'}:
-                self.last_no_vote_reason = 'orb_not_ready'
-                self.last_no_vote_reason = 'no_breakout'
-                self.last_no_vote_reason = 'wick_only_breakout'
+                self._no_vote('invalid_orb_levels')
                 LOGGER.debug('STRATEGY_NO_VOTE strategy=ORBPro reason=choppy_regime')
                 return None
 
@@ -61,9 +57,7 @@ class ORBProStrategy(EliteStrategy):
             candle_range = max(abs(float(indicators.get('high') or close) - float(indicators.get('low') or close)), 1e-9)
             breakout_body_pct = abs(close - open_price) / candle_range
             if breakout_body_pct < 0.35:
-                self.last_no_vote_reason = 'orb_not_ready'
-                self.last_no_vote_reason = 'no_breakout'
-                self.last_no_vote_reason = 'wick_only_breakout'
+                self._no_vote('wick_only_breakout')
                 LOGGER.debug('STRATEGY_NO_VOTE strategy=ORBPro reason=wick_only_breakout')
                 return None
 

--- a/src/nifty_scalper_bot/strategies/elite_strategies/order_flow.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/order_flow.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from typing import Any
 
 from nifty_scalper_bot.strategies.elite_strategies.base_elite import EliteSignal, EliteStrategy
@@ -27,7 +28,7 @@ class OrderFlowStrategy(EliteStrategy):
         """Args: symbol, indicators, current_price, position. Returns: EliteSignal|None. Raises: Exception."""
         del position
         try:
-            self.last_no_vote_reason = "none"
+            self._no_vote("stale_or_invalid_data")
             bid = float(indicators.get('bid') or 0.0)
             ask = float(indicators.get('ask') or 0.0)
             depth = indicators.get('depth') or {}
@@ -36,16 +37,12 @@ class OrderFlowStrategy(EliteStrategy):
             atr = max(float(indicators.get('atr') or 0.0), current_price * 0.01, 1.0)
 
             if bid <= 0 or ask <= 0 or ask <= bid:
-                self.last_no_vote_reason = 'missing_depth'
-                self.last_no_vote_reason = 'weak_imbalance'
-                self.last_no_vote_reason = 'missing_depth'
+                self._no_vote('missing_bid_ask')
                 LOGGER.debug('STRATEGY_NO_VOTE strategy=OrderFlow reason=missing_bid_ask')
                 return None
             spread_pct = float(indicators.get('spread_pct') or (((ask - bid) / ((ask + bid) / 2.0)) * 100.0))
             if spread_pct > 28.0:
-                self.last_no_vote_reason = 'missing_depth'
-                self.last_no_vote_reason = 'weak_imbalance'
-                self.last_no_vote_reason = 'missing_depth'
+                self._no_vote('wide_spread')
                 LOGGER.debug('STRATEGY_NO_VOTE strategy=OrderFlow reason=wide_spread')
                 return None
 
@@ -55,11 +52,26 @@ class OrderFlowStrategy(EliteStrategy):
             total_bid = sum(float(level.get('quantity', 0.0)) for level in bids[:5]) if depth_available else 0.0
             total_ask = sum(float(level.get('quantity', 0.0)) for level in asks[:5]) if depth_available else 0.0
             if total_bid + total_ask <= 0:
-                self.last_no_vote_reason = 'missing_depth'
-                self.last_no_vote_reason = 'weak_imbalance'
-                self.last_no_vote_reason = 'missing_depth'
-                LOGGER.debug('STRATEGY_NO_VOTE strategy=OrderFlow reason=depth_missing')
-                return None
+                allow_fallback = str(os.getenv('ORDERFLOW_ALLOW_LTP_TICK_FALLBACK', 'false')).strip().lower() in {'1', 'true', 'yes', 'on'}
+                if not allow_fallback:
+                    self._no_vote('missing_depth')
+                    LOGGER.debug('STRATEGY_NO_VOTE strategy=OrderFlow reason=depth_missing')
+                    return None
+                tick_direction = str(indicators.get('tick_direction') or '').upper()
+                side = 'CE' if tick_direction in {'UP', 'BUY'} else 'PE'
+                depth_imbalance = 0.0
+                fallback_score = 2.0 + (2.0 if spread_pct <= 12.0 else 0.0)
+                if direction in {'CE', 'PE'} and direction == side:
+                    fallback_score += 1.5
+                if tick_direction in {'UP', 'DOWN', 'BUY', 'SELL'}:
+                    fallback_score += 1.0
+                strategy_score = min(5.5, max(0.0, fallback_score))
+                if strategy_score < 4.0:
+                    self._no_vote('weak_tick_confirmation')
+                    return None
+                metadata = {'orderflow_depth_source': 'ltp_tick_fallback', 'risk_label': 'reduced_microstructure_confidence'}
+                metadata.update({'strategy': 'OrderFlow', 'side': side, 'direction_bias': side, 'strategy_score': strategy_score, 'spread_pct': round(spread_pct, 3), 'depth_imbalance': 0.0, 'tick_direction': tick_direction, 'invalidation_level': bid - 0.5 * atr if side == 'CE' else ask + 0.5 * atr})
+                return EliteSignal(symbol=symbol, signal='BUY', confidence=max(0.1, min(0.85, strategy_score / 10.0)), entry_price=current_price, stop_loss=float(metadata['invalidation_level']), target=current_price + (1.8 * atr), quantity=self._cfg.quantity or 1, strategy_name='OrderFlow', metadata=metadata)
             depth_imbalance = (total_bid - total_ask) / max(total_bid + total_ask, 1.0)
             side = 'CE' if depth_imbalance > 0 else 'PE'
 
@@ -83,7 +95,7 @@ class OrderFlowStrategy(EliteStrategy):
 
             strategy_score = max(0.0, min(10.0, score))
             if strategy_score < 4.0:
-                self.last_no_vote_reason = "low_score"
+                self._no_vote('low_score')
                 return None
             metadata = {
                 'strategy': 'OrderFlow',

--- a/src/nifty_scalper_bot/strategies/elite_strategies/rsi_divergence.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/rsi_divergence.py
@@ -29,7 +29,7 @@ class RSIDivergenceStrategy(EliteStrategy):
         """Args: symbol, indicators, current_price, position. Returns: EliteSignal|None. Raises: Exception."""
         del position
         try:
-            self.last_no_vote_reason = "none"
+            self._no_vote("stale_or_invalid_data")
             rsi = float(indicators.get('rsi') or 50.0)
             close = float(indicators.get('close') or current_price)
             atr = max(float(indicators.get('atr') or 0.0), current_price * 0.01, 1.0)
@@ -52,7 +52,7 @@ class RSIDivergenceStrategy(EliteStrategy):
             if not confirmation:
                 confirmation = (bullish_div and close > hist[-2][0]) or (bearish_div and close < hist[-2][0])
             if not confirmation:
-                self.last_no_vote_reason = 'no_confirmation'
+                self._no_vote('no_confirmation')
                 LOGGER.debug('STRATEGY_NO_VOTE strategy=RSIDivergence reason=no_structure_confirmation')
                 return None
 
@@ -72,7 +72,7 @@ class RSIDivergenceStrategy(EliteStrategy):
 
             strategy_score = max(0.0, min(10.0, score))
             if strategy_score < 3.5:
-                self.last_no_vote_reason = "low_score"
+                self._no_vote('low_score')
                 return None
             metadata = {
                 'strategy': 'RSIDivergence',

--- a/src/nifty_scalper_bot/strategies/elite_strategies/smc_liquidity.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/smc_liquidity.py
@@ -27,7 +27,7 @@ class SMCStrategy(EliteStrategy):
         """Args: symbol, indicators, current_price, position. Returns: EliteSignal|None. Raises: Exception."""
         del position
         try:
-            self.last_no_vote_reason = "none"
+            self._no_vote("stale_or_invalid_data")
             high = float(indicators.get('high') or current_price)
             low = float(indicators.get('low') or current_price)
             close = float(indicators.get('close') or current_price)
@@ -37,9 +37,7 @@ class SMCStrategy(EliteStrategy):
             stale_data = bool(indicators.get('stale_data_used')) or float(indicators.get('data_age_seconds') or 0.0) > 120.0
 
             if stale_data or current_price <= 0:
-                self.last_no_vote_reason = 'no_liquidity_sweep'
-                self.last_no_vote_reason = 'no_liquidity_sweep'
-                self.last_no_vote_reason = 'low_score'
+                self._no_vote('no_liquidity_sweep')
                 LOGGER.debug('STRATEGY_NO_VOTE strategy=SMC reason=stale_or_invalid_data')
                 return None
 

--- a/src/nifty_scalper_bot/strategies/elite_strategies/vwap_pro.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/vwap_pro.py
@@ -31,7 +31,7 @@ class VWAPProStrategy(EliteStrategy):
         """Args: symbol, indicators, current_price, position. Returns: EliteSignal|None. Raises: Exception."""
         del position
         try:
-            self.last_no_vote_reason = "none"
+            self._no_vote("stale_or_invalid_data")
             vwap = float(indicators.get('vwap') or indicators.get('exchange_vwap') or 0.0)
             atr = float(indicators.get('atr') or 0.0)
             close = float(indicators.get('close') or current_price)
@@ -45,11 +45,7 @@ class VWAPProStrategy(EliteStrategy):
             stale_data = bool(indicators.get('stale_data_used')) or float(indicators.get('data_age_seconds') or 0.0) > 120.0
 
             if current_price <= 0 or vwap <= 0:
-                self.last_no_vote_reason = 'missing_vwap'
-                self.last_no_vote_reason = 'distance_outside_band'
-                self.last_no_vote_reason = 'no_direction_alignment'
-                self.last_no_vote_reason = 'distance_outside_band'
-                self.last_no_vote_reason = 'weak_score'
+                self._no_vote('missing_vwap')
                 LOGGER.debug('STRATEGY_NO_VOTE strategy=VWAPPro reason=missing_vwap')
                 return None
 
@@ -57,27 +53,15 @@ class VWAPProStrategy(EliteStrategy):
             distance_pct = abs(current_price - vwap) / max(vwap, 1e-9)
             overextended = distance_pct > self._max_distance_pct
             if overextended:
-                self.last_no_vote_reason = 'missing_vwap'
-                self.last_no_vote_reason = 'distance_outside_band'
-                self.last_no_vote_reason = 'no_direction_alignment'
-                self.last_no_vote_reason = 'distance_outside_band'
-                self.last_no_vote_reason = 'weak_score'
+                self._no_vote('distance_outside_band')
                 LOGGER.debug('STRATEGY_NO_VOTE strategy=VWAPPro reason=overextended')
                 return None
             if stale_data:
-                self.last_no_vote_reason = 'missing_vwap'
-                self.last_no_vote_reason = 'distance_outside_band'
-                self.last_no_vote_reason = 'no_direction_alignment'
-                self.last_no_vote_reason = 'distance_outside_band'
-                self.last_no_vote_reason = 'weak_score'
+                self._no_vote('stale_data')
                 LOGGER.debug('STRATEGY_NO_VOTE strategy=VWAPPro reason=stale_data')
                 return None
             if spread_pct > 28.0:
-                self.last_no_vote_reason = 'missing_vwap'
-                self.last_no_vote_reason = 'distance_outside_band'
-                self.last_no_vote_reason = 'no_direction_alignment'
-                self.last_no_vote_reason = 'distance_outside_band'
-                self.last_no_vote_reason = 'weak_score'
+                self._no_vote('wide_spread')
                 LOGGER.debug('STRATEGY_NO_VOTE strategy=VWAPPro reason=wide_spread')
                 return None
 
@@ -128,11 +112,7 @@ class VWAPProStrategy(EliteStrategy):
                     reasons.append('direction_conflict')
 
             if score < 3.0:
-                self.last_no_vote_reason = 'missing_vwap'
-                self.last_no_vote_reason = 'distance_outside_band'
-                self.last_no_vote_reason = 'no_direction_alignment'
-                self.last_no_vote_reason = 'distance_outside_band'
-                self.last_no_vote_reason = 'weak_score'
+                self._no_vote('weak_score')
                 LOGGER.debug('STRATEGY_NO_VOTE strategy=VWAPPro reason=low_score')
                 return None
 

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -6776,6 +6776,18 @@ class StrategyRunner:
                         price=price,
                     )
                     try:
+                        indicators_ctx = self._indicator_engine.get_indicators(symbol)
+                        selected_ce = getattr(self, "_active_selected_ce", None)
+                        selected_pe = getattr(self, "_active_selected_pe", None)
+                        atm_strike = getattr(self, "_active_atm_strike", None)
+                        symbol_strike = self._extract_strike_from_symbol(symbol)
+                        indicators_ctx["selected_ce"] = selected_ce
+                        indicators_ctx["selected_pe"] = selected_pe
+                        indicators_ctx["atm_strike"] = atm_strike
+                        indicators_ctx["is_selected_option"] = symbol in {selected_ce, selected_pe}
+                        if symbol_strike is not None and atm_strike is not None:
+                            indicators_ctx["strike_distance_from_atm"] = abs(float(symbol_strike) - float(atm_strike))
+                        self._indicator_engine.set_indicators(symbol, indicators_ctx)
                         # --- Objective 2: Block signals if market depth insufficient ---
                         if not self.validate_market_depth():
                             self._emit_runner_eval_decision(

--- a/tests/strategies/test_elite_no_vote_reasons.py
+++ b/tests/strategies/test_elite_no_vote_reasons.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from typing import Any
+
+from nifty_scalper_bot.strategies.elite_strategies.bb_squeeze import BBSqueezeStrategy
+from nifty_scalper_bot.strategies.elite_strategies.config_models import (
+    BBSqueezeStrategyConfig,
+    CPRBreakoutStrategyConfig,
+    ORBProStrategyConfig,
+    OrderFlowStrategyConfig,
+    RSIDivergenceStrategyConfig,
+    SMCStrategyConfig,
+    VWAPProStrategyConfig,
+)
+from nifty_scalper_bot.strategies.elite_strategies.cpr_breakout import CPRBreakoutStrategy
+from nifty_scalper_bot.strategies.elite_strategies.orb_pro import ORBProStrategy
+from nifty_scalper_bot.strategies.elite_strategies.order_flow import OrderFlowStrategy
+from nifty_scalper_bot.strategies.elite_strategies.rsi_divergence import RSIDivergenceStrategy
+from nifty_scalper_bot.strategies.elite_strategies.smc_liquidity import SMCStrategy
+from nifty_scalper_bot.strategies.elite_strategies.vwap_pro import VWAPProStrategy
+
+
+class _DummyIndicatorEngine:
+    def get_indicators(self, symbol: str, names: list[str] | None = None) -> dict[str, Any]:
+        del symbol, names
+        return {}
+
+
+def test_no_vote_reasons_not_none_for_all_strategy_return_none_paths() -> None:
+    indicator_engine = _DummyIndicatorEngine()
+    strategies = [
+        SMCStrategy(SMCStrategyConfig()),
+        VWAPProStrategy(VWAPProStrategyConfig(), indicator_engine),
+        CPRBreakoutStrategy(CPRBreakoutStrategyConfig(), indicator_engine),
+        OrderFlowStrategy(OrderFlowStrategyConfig(), indicator_engine),
+        BBSqueezeStrategy(BBSqueezeStrategyConfig(), indicator_engine),
+        RSIDivergenceStrategy(RSIDivergenceStrategyConfig(), indicator_engine),
+        ORBProStrategy(ORBProStrategyConfig(), indicator_engine),
+    ]
+
+    for strategy in strategies:
+        signal = strategy.generate_signal(
+            symbol='NFO:NIFTY26MAY24350CE',
+            indicators={},
+            current_price=0.0,
+            position=None,
+        )
+        assert signal is None
+        reason = getattr(strategy, 'last_no_vote_reason', None)
+        assert reason not in (None, '', 'none')


### PR DESCRIPTION
### Motivation

- Make strategies report a single, consistent no-vote reason via a helper to avoid scattered direct writes to `last_no_vote_reason` and improve observability. 
- Improve single-vote consensus handling by validating whether the signalled option is a selected candidate (including ATM proximity) and make the selection threshold configurable via env. 
- Provide a resilience path for `OrderFlow` when market depth is missing by optionally falling back to LTP/tick-based inference.

### Description

- Added `EliteStrategy._no_vote` helper and replaced scattered `last_no_vote_reason` assignments in multiple elite strategies to call `self._no_vote(...)` instead. 
- Introduced option-selection checks in `StrategyManager.generate_signal` and consensus logic, including a new env var `STRATEGY_SINGLE_VOTE_MAX_STRIKE_DISTANCE` and additional logging for rejected single-vote candidates. 
- Implemented `_extract_strike_from_symbol` static helper in `StrategyManager` to parse strikes from option symbols and used it for strike distance calculations. 
- Enhanced `OrderFlowStrategy` to optionally allow an LTP/tick fallback when depth is missing controlled by the env var `ORDERFLOW_ALLOW_LTP_TICK_FALLBACK`, returning a reduced-confidence `EliteSignal` when appropriate. 
- Updated the strategy runner to enrich the indicator context (`selected_ce`, `selected_pe`, `atm_strike`, `is_selected_option`, and `strike_distance_from_atm`) before evaluation by calling `get_indicators` and `set_indicators`. 
- Added `tests/strategies/test_elite_no_vote_reasons.py` to assert that strategies that return `None` expose a non-empty `last_no_vote_reason`.

### Testing

- Ran the new unit test `pytest -q tests/strategies/test_elite_no_vote_reasons.py`, which passed. 
- Ran the strategies unit checks locally to verify no regressions in vote/no-vote code paths, and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc6013c1f4832481aebf2c71431015)