### PR TITLE
fix: harden live runner hydration and readiness gates

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -234,6 +234,22 @@ def nearest_available_strike(spot: float, strikes: Sequence[float]) -> int:
     return min(valid, key=lambda strike: (abs(strike - float(spot)), strike))
 
 
+def _is_selected_trade_symbol(ctx: Any, symbol: str) -> bool:
+    """Check if symbol is one of the selected execution symbols. Args: ctx/symbol. Returns: bool. Raises: none."""
+    normalized_symbol = canonical(symbol)
+    selected_symbols = {
+        canonical(value)
+        for value in (
+            getattr(ctx, "selected_ce", None),
+            getattr(ctx, "selected_pe", None),
+            getattr(ctx, "atm_ce_symbol", None),
+            getattr(ctx, "atm_pe_symbol", None),
+        )
+        if value
+    }
+    return normalized_symbol in selected_symbols
+
+
 def prioritize_startup_hydration_symbols(
     symbols: Sequence[str],
     atm_ce: str | None,
@@ -283,7 +299,33 @@ def _gate_runner_symbol_add(
         quote_ready = bool(ctx.market_data_manager.get_symbol_snapshot(symbol))
     except Exception:
         quote_ready = False
-    history_ready = max(runner_bars, mdm_bars) >= required
+    if runner_bars < required and mdm_bars >= required:
+        hydrate_fn = getattr(ctx.strategy_runner, "_hydrate_from_mdm_cache", None)
+        if callable(hydrate_fn):
+            LOGGER.info(
+                "RUNNER_HYDRATION_SYNC_ATTEMPT symbol=%s mdm_bars=%d before_runner_bars=%d",
+                symbol,
+                mdm_bars,
+                runner_bars,
+            )
+            try:
+                hydrate_fn(symbol)
+            except Exception:
+                LOGGER.exception("RUNNER_HYDRATION_SYNC_EXCEPTION symbol=%s", symbol)
+            try:
+                runner_engine = getattr(ctx.strategy_runner, "_indicator_engine", None)
+                if runner_engine is not None:
+                    runner_bars = len(runner_engine.get_history(symbol) or [])
+            except Exception:
+                runner_bars = 0
+            LOGGER.info(
+                "RUNNER_HYDRATION_SYNC_RESULT symbol=%s after_runner_bars=%d required=%d history_ready=%s",
+                symbol,
+                runner_bars,
+                required,
+                runner_bars >= required,
+            )
+    history_ready = runner_bars >= required
     add_ready = bool(quote_ready or history_ready)
     if not add_ready:
         pending_runner_symbols.add(symbol)
@@ -292,27 +334,10 @@ def _gate_runner_symbol_add(
     ctx.strategy_runner.add_symbol(symbol)
     if ctx.data_hub is not None and ctx.strategy_runner is not None:
         canonical_symbol = ctx.data_hub._canonical_quote_symbol(symbol)
-        subscription_key = f"{canonical_symbol}|{token or ''}"
-        if subscription_key not in ctx.datahub_runner_subscriptions:
-            _subscribe_ticks_force_live_compat(
-                ctx.data_hub,
-                canonical_symbol,
-                ctx.strategy_runner.on_datahub_tick,
-                token=token,
-            )
-            ctx.datahub_runner_subscriptions.add(subscription_key)
+        if hasattr(ctx.strategy_runner, "has_datahub_subscription") and ctx.strategy_runner.has_datahub_subscription(symbol, token):
+            ctx.datahub_runner_subscriptions.add(f"{canonical_symbol}|{token or ''}")
             if token is not None:
                 ctx.datahub_runner_subscriptions.add(f"TOKEN:{int(token)}")
-            LOGGER.info(
-                "DATAHUB_RUNNER_CALLBACK_REGISTERED symbol=%s token=%s",
-                canonical_symbol,
-                token,
-                extra={
-                    "event": "DATAHUB_RUNNER_CALLBACK_REGISTERED",
-                    "symbol": canonical_symbol,
-                    "token": token,
-                },
-            )
     pending_runner_symbols.discard(symbol)
     LOGGER.info(
         "RUNNER_SYMBOL_STATUS symbol=%s token=%s added_to_runner=%s runner_bars=%d mdm_bars=%d required_bars=%d history_ready=%s source=%s reason=%s",
@@ -324,7 +349,7 @@ def _gate_runner_symbol_add(
         required,
         history_ready,
         source,
-        "history_ready" if history_ready else "history_pending_runner_added",
+        "history_ready" if history_ready else ("quote_ready_history_pending" if quote_ready else "hydration_failed"),
         extra={
             "event": "RUNNER_SYMBOL_STATUS",
             "symbol": symbol,
@@ -335,7 +360,7 @@ def _gate_runner_symbol_add(
             "required_bars": required,
             "history_ready": history_ready,
             "source": source,
-            "reason": "history_ready" if history_ready else "history_pending_runner_added",
+            "reason": "history_ready" if history_ready else ("quote_ready_history_pending" if quote_ready else "hydration_failed"),
         },
     )
     try:
@@ -343,7 +368,7 @@ def _gate_runner_symbol_add(
             ctx,
             symbol=symbol,
             token=token,
-            selected=True,
+            selected=_is_selected_trade_symbol(ctx, symbol),
             hydrated_bars=runner_bars,
             runner_added=True,
             source=source,
@@ -6749,16 +6774,38 @@ async def _recompute_and_push_runtime_readiness(ctx: BotContext, *, reason: str)
         except Exception:
             return False
     spot_ready = _quote(spot_symbol) or _bars(spot_symbol) >= 1
-    option_min_live_bars = int(os.getenv("OPTION_MIN_LIVE_BARS", "3") or 3)
-    ce_ready = bool(selected_ce) and (_quote(selected_ce) or _bars(selected_ce) >= option_min_live_bars)
-    pe_ready = bool(selected_pe) and (_quote(selected_pe) or _bars(selected_pe) >= option_min_live_bars)
+    option_eval_min_live_bars = int(os.getenv("OPTION_EVAL_MIN_LIVE_BARS", "1") or 1)
+    option_execution_min_bars = int(os.getenv("OPTION_EXECUTION_MIN_BARS", "5") or 5)
+    context_execution_min_bars = int(os.getenv("CONTEXT_EXECUTION_MIN_BARS", "50") or 50)
+    ce_bars = _bars(selected_ce)
+    pe_bars = _bars(selected_pe)
+    ce_quote_fresh = _quote(selected_ce)
+    pe_quote_fresh = _quote(selected_pe)
+    ce_eval_ready = bool(selected_ce) and (ce_quote_fresh or ce_bars >= option_eval_min_live_bars)
+    pe_eval_ready = bool(selected_pe) and (pe_quote_fresh or pe_bars >= option_eval_min_live_bars)
+    ce_exec_ready = bool(selected_ce) and ce_quote_fresh and ce_bars >= option_execution_min_bars
+    pe_exec_ready = bool(selected_pe) and pe_quote_fresh and pe_bars >= option_execution_min_bars
+    futures_symbol = str(basket.get("futures_symbol") or "")
+    fut_bars = _bars(futures_symbol)
+    spot_bars = _bars(spot_symbol)
+    spot_quote_fresh = _quote(spot_symbol)
+    context_exec_ready = spot_bars >= context_execution_min_bars or (
+        spot_quote_fresh and fut_bars >= context_execution_min_bars
+    )
     full_basket_ready = all((_quote(s) or _bars(s) >= 20) for s in option_symbols if s.endswith(("CE", "PE")))
-    data_hard_ready = bool(spot_ready and ce_ready and pe_ready)
+    data_hard_ready = bool(spot_ready and ce_eval_ready and pe_eval_ready)
     runner_running = _runner_is_running(getattr(ctx, "strategy_runner", None))
     evaluation_ready = bool(data_hard_ready and runner_running)
     live_mode = str(getattr(ctx.settings, "execution_mode", "PAPER")).upper() == "LIVE"
     broker_ready = bool(getattr(ctx, "broker_client", None) and getattr(ctx, "order_manager", None))
-    live_orders_armed = bool(live_mode and data_hard_ready and evaluation_ready and broker_ready)
+    live_orders_armed = bool(
+        live_mode
+        and evaluation_ready
+        and ce_exec_ready
+        and pe_exec_ready
+        and context_exec_ready
+        and broker_ready
+    )
     ctx.data_hard_ready = data_hard_ready
     ctx.evaluation_ready = evaluation_ready
     ctx.live_orders_armed = live_orders_armed
@@ -6767,15 +6814,17 @@ async def _recompute_and_push_runtime_readiness(ctx: BotContext, *, reason: str)
     ctx.effective_mode = ctx.readiness_mode
     ctx.live_block_reason = None if live_orders_armed else "startup_pipeline_incomplete"
     LOGGER.info(
-        "LIVE_READINESS_COMPUTED spot_ready=%s ce_ready=%s pe_ready=%s full_basket_ready=%s selected_ce=%s selected_pe=%s ce_bars=%s pe_bars=%s",
+        "LIVE_READINESS_COMPUTED spot_ready=%s ce_eval_ready=%s pe_eval_ready=%s ce_exec_ready=%s pe_exec_ready=%s full_basket_ready=%s selected_ce=%s selected_pe=%s ce_bars=%s pe_bars=%s",
         spot_ready,
-        ce_ready,
-        pe_ready,
+        ce_eval_ready,
+        pe_eval_ready,
+        ce_exec_ready,
+        pe_exec_ready,
         full_basket_ready,
         selected_ce,
         selected_pe,
-        _bars(selected_ce),
-        _bars(selected_pe),
+        ce_bars,
+        pe_bars,
     )
     if (not selected_ce) or (not selected_pe):
         LOGGER.warning("LIVE_BASKET_INVALID reason=atm_option_selection_failed")
@@ -6797,6 +6846,8 @@ async def _recompute_and_push_runtime_readiness(ctx: BotContext, *, reason: str)
     LOGGER.info("RUNTIME_READINESS_REARM_RESULT data_hard_ready=%s evaluation_ready=%s live_orders_armed=%s reason=%s", ctx.data_hard_ready, ctx.evaluation_ready, ctx.live_orders_armed, reason)
     if ctx.live_orders_armed:
         LOGGER.info("LIVE_TRADING_ARMED")
+    elif ce_bars < option_execution_min_bars or pe_bars < option_execution_min_bars:
+        LOGGER.info("LIVE_TRADING_NOT_ARMED reason=selected_option_history_insufficient")
 async def _deferred_basket_hydration_retry(
     ctx: BotContext,
     *,
@@ -9064,7 +9115,7 @@ async def startup_sequence(ctx: BotContext) -> None:
                                         ctx,
                                         symbol=_sym,
                                         token=_tok,
-                                        selected=True,
+                                        selected=_is_selected_trade_symbol(ctx, sym),
                                         hydrated_bars=(
                                             len(
                                                 ctx.market_data_manager.get_ohlc_bars(

--- a/src/nifty_scalper_bot/strategies/indicators.py
+++ b/src/nifty_scalper_bot/strategies/indicators.py
@@ -202,8 +202,8 @@ class IndicatorEngine:
         self._lock = threading.RLock()
         self._logger = get_logger(__name__)
 
-    def set_indicators(self, symbol: str, indicators: Mapping[str, Any]) -> None:
-        """Store runtime context keys only. Args: symbol, indicators. Returns: None. Raises: Exception."""
+    def set_runtime_context(self, symbol: str, context: Mapping[str, Any]) -> None:
+        """Store runtime context. Args: symbol, context. Returns: None. Raises: Exception."""
         try:
             if not symbol:
                 return
@@ -217,14 +217,18 @@ class IndicatorEngine:
                 "option_role",
             }
             with self._lock:
-                context = self._runtime_context.setdefault(symbol, {})
-                for key, value in dict(indicators).items():
+                symbol_context = self._runtime_context.setdefault(symbol, {})
+                for key, value in dict(context).items():
                     if key in allowed_context_keys:
-                        context[key] = value
+                        symbol_context[key] = value
                 self._cache.pop(symbol, None)
         except Exception as e:
-            self._logger.error("Failure in IndicatorEngine.set_indicators: %s", e)
+            self._logger.error("Failure in IndicatorEngine.set_runtime_context: %s", e)
             raise
+
+    def set_indicators(self, symbol: str, indicators: Mapping[str, Any]) -> None:
+        """Backward-compatible alias for runtime context setter. Args: symbol, indicators. Returns: None. Raises: Exception."""
+        self.set_runtime_context(symbol, indicators)
 
     def get_runtime_context(self, symbol: str) -> dict[str, Any]:
         """Fetch runtime context. Args: symbol. Returns: context copy. Raises: Exception."""
@@ -233,6 +237,18 @@ class IndicatorEngine:
                 return dict(self._runtime_context.get(symbol, {}))
         except Exception as e:
             self._logger.error("Failure in IndicatorEngine.get_runtime_context: %s", e)
+            raise
+
+    def clear_runtime_context(self, symbol: str | None = None) -> None:
+        """Clear runtime context for one/all symbols. Args: symbol. Returns: None. Raises: Exception."""
+        try:
+            with self._lock:
+                if symbol is None:
+                    self._runtime_context.clear()
+                else:
+                    self._runtime_context.pop(symbol, None)
+        except Exception as e:
+            self._logger.error("Failure in IndicatorEngine.clear_runtime_context: %s", e)
             raise
 
     def update_price(

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -522,6 +522,7 @@ class StrategyRunner:
             self._logger.error(f"❌ Failed to create 'data/' directory: {e}")
         self._data_hub = data_hub
         self.datahub = datahub or data_hub
+        self._datahub_registered_symbols: set[str] = set()
         self._strike_selector = strike_selector
         self._bracket_manager = bracket_manager
         self._symbol_source: MarketDataManager | None = None
@@ -2349,6 +2350,12 @@ class StrategyRunner:
 
     def _subscribe_symbol(self, symbol: str) -> None:
         """Subscribe to tick updates for a symbol."""
+        normalized_symbol = normalize_symbol(symbol)
+        if self._data_hub is not None:
+            if normalized_symbol not in self._datahub_registered_symbols:
+                self._data_hub.subscribe_ticks(symbol, self.on_datahub_tick)
+                self._datahub_registered_symbols.add(normalized_symbol)
+            return
         callback = self._callbacks.get(symbol)
         callback_already_registered = callback is not None
         if callback is None:
@@ -2451,6 +2458,11 @@ class StrategyRunner:
         self._safe_subscribe(
             symbol, callback, callback_already_registered=callback_already_registered
         )
+
+    def has_datahub_subscription(self, symbol: str, token: int | None = None) -> bool:
+        """Check whether DataHub callback is already registered. Args: symbol/token. Returns: bool. Raises: none."""
+        _ = token
+        return normalize_symbol(symbol) in self._datahub_registered_symbols
 
     def _safe_subscribe(
         self,
@@ -5337,15 +5349,26 @@ class StrategyRunner:
                         fut_bars = len(self._indicator_engine.get_history(fut_symbol) or []) if fut_symbol else 0
                         if (spot_bars < self._context_required_bars or fut_bars < self._context_required_bars) and self._should_log_throttled(f"opt_ctx_cold:{symbol}", 120.0):
                             self._logger.warning("OPTION_EVAL_BLOCKED_CONTEXT_COLD option=%s spot_bars=%d futures_bars=%d required=%d", symbol, spot_bars, fut_bars, self._context_required_bars)
-                    strict_for_all = _env_bool(
-                        "OPTION_STRICT_HISTORY_FOR_ALL_STRATEGIES", False
-                    )
+                    strict_for_all = _env_bool("OPTION_STRICT_HISTORY_FOR_ALL_STRATEGIES", False)
                     tick_is_fresh = self._is_option_symbol_tick_fresh(symbol)
+                    selected_symbols = {
+                        normalize_symbol(sym)
+                        for sym in (self._active_selected_ce, self._active_selected_pe)
+                        if sym
+                    }
+                    is_selected_option = normalize_symbol(symbol) in selected_symbols
+                    option_eval_min_live_bars = int(os.getenv("OPTION_EVAL_MIN_LIVE_BARS", "1") or "1")
+                    spot_bars = len(self._indicator_engine.get_history("NSE:NIFTY") or [])
+                    fut_symbol = next((sym for sym in self._active_symbols if self._is_context_symbol(sym) and sym != "NSE:NIFTY"), "")
+                    fut_bars = len(self._indicator_engine.get_history(fut_symbol) or []) if fut_symbol else 0
+                    context_ready = spot_bars >= self._context_required_bars and fut_bars >= self._context_required_bars
                     soft_pass = (
                         self._is_tradable_symbol(symbol)
                         and not strict_for_all
-                        and history_count >= 1
+                        and is_selected_option
+                        and history_count >= option_eval_min_live_bars
                         and tick_is_fresh
+                        and context_ready
                     )
                     if soft_pass:
                         if self._should_log_throttled(f"opt_soft_pass:{symbol}", 60.0):
@@ -6863,21 +6886,17 @@ class StrategyRunner:
                         atm_strike = getattr(self, "_active_atm_strike", None)
                         symbol_strike = self._extract_strike_from_symbol(symbol)
                         normalized_symbol = normalize_symbol(symbol)
-                        selected_set = {
-                            normalize_symbol(item)
-                            for item in [selected_ce, selected_pe]
-                            if item
+                        selected_set = {normalize_symbol(item) for item in [selected_ce, selected_pe] if item}
+                        runtime_ctx: dict[str, Any] = {
+                            "selected_ce": selected_ce,
+                            "selected_pe": selected_pe,
+                            "atm_strike": atm_strike,
+                            "is_selected_option": normalized_symbol in selected_set,
                         }
-                        indicators_ctx["selected_ce"] = selected_ce
-                        indicators_ctx["selected_pe"] = selected_pe
-                        indicators_ctx["atm_strike"] = atm_strike
-                        indicators_ctx["is_selected_option"] = (
-                            normalized_symbol in selected_set
-                        )
                         if symbol_strike is not None and atm_strike is not None:
-                            indicators_ctx["strike_distance_from_atm"] = abs(float(symbol_strike) - float(atm_strike))
-                        if hasattr(self._indicator_engine, "set_indicators"):
-                            self._indicator_engine.set_indicators(symbol, indicators_ctx)
+                            runtime_ctx["strike_distance_from_atm"] = abs(float(symbol_strike) - float(atm_strike))
+                        if hasattr(self._indicator_engine, "set_runtime_context"):
+                            self._indicator_engine.set_runtime_context(symbol, runtime_ctx)
                         elif self._should_log_throttled(
                             "indicator_ctx_missing_setter", 60.0
                         ):


### PR DESCRIPTION
### Motivation
- Prevent declaring a symbol `history_ready` when only MDM (not the runner) is hydrated, and stop premature live arming and duplicate tick callbacks that caused mis-evaluations and crashes.
- Ensure runtime metadata for selected options is available to strategies without calling a missing API on `IndicatorEngine` and avoid incorrect `selected=True` tagging for non-selected instruments.
- Tighten option-evaluation gates so selected options with minimal but fresh data may be observed while execution remains blocked until execution-grade history is present.

### Description
- In `src/nifty_scalper_bot/core/app.py` updated `_gate_runner_symbol_add` to attempt runner hydration from MDM via `ctx.strategy_runner._hydrate_from_mdm_cache(symbol)` when MDM has sufficient bars, and compute `history_ready` from the runner engine after hydration, emitting `RUNNER_HYDRATION_SYNC_ATTEMPT` and `RUNNER_HYDRATION_SYNC_RESULT` logs and clearer reasons (`history_ready`, `quote_ready_history_pending`, `hydration_failed`).
- Added helper `_is_selected_trade_symbol(ctx, symbol)` and replaced hardcoded `selected=True` calls so only actual selected CE/PE are marked selected in `_emit_option_symbol_pipeline_status` and dynamic-universe emissions.
- Split evaluation vs execution readiness in `_recompute_and_push_runtime_readiness` by introducing `OPTION_EVAL_MIN_LIVE_BARS`, `OPTION_EXECUTION_MIN_BARS`, and `CONTEXT_EXECUTION_MIN_BARS`, computing `*_eval_ready` and `*_exec_ready` separately, and only arming live orders when execution-grade readiness and broker readiness are satisfied, with explicit `LIVE_TRADING_NOT_ARMED reason=selected_option_history_insufficient` logging when bars are low.
- In `src/nifty_scalper_bot/strategies/runner.py` removed duplicate DataHub callback registration by having `StrategyRunner._subscribe_symbol` register `self.on_datahub_tick` idempotently via an internal `_datahub_registered_symbols` set and exposing `has_datahub_subscription(...)` for app-side guards.
- Strengthened phase-9 history gate so only selected CE/PE can soft-pass cold history (requires fresh tick, context readiness and minimum eval bars) while non-selected options remain strictly gated.
- Replaced runner calls to `set_indicators` with `set_runtime_context` semantics and normalized selected-option detection for runtime metadata population in the runner evaluation path.
- In `src/nifty_scalper_bot/strategies/indicators.py` added runtime-context APIs: `set_runtime_context`, `get_runtime_context`, and `clear_runtime_context`, and provided a backward-compatible `set_indicators` alias to avoid breaking callers.

### Testing
- Ran `python -m compileall src` which completed successfully (no compile errors).
- Ran focused test files which passed: `pytest tests/core/test_app_runner_symbol_gate.py -q` ✅, `pytest tests/core/test_option_pipeline_status_token_aware.py -q` ✅, and `pytest tests/bot/test_strategy_runner.py -q` ✅.
- Ran full test suite `pytest tests -q` which failed early due to an unrelated/pre-existing test import error: `ModuleNotFoundError: No module named 'market_data_manager'` in `tests/test_mdm_diagnostics.py`, which is outside the scope of these changes; targeted tests covering the modified behavior passed.
- Verified `grep -R "set_indicators" -n src/` shows only the backward-compatible alias in `IndicatorEngine` (no runner invocation remains), and local logging additions emit hydration/readiness decisions as intended.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd9ca085d88324aff9351a8a44409a)