### PR TITLE
refactor: unify trigger scoring, readiness gating, and data-quality contracts

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -293,7 +293,7 @@ def _gate_runner_symbol_add(
     except Exception:
         runner_bars = 0
     mdm_bars = len(ctx.market_data_manager.get_ohlc_bars(symbol) or [])
-    required = _symbol_history_requirement(ctx)
+    required = int(os.getenv("READINESS_OPTION_EVAL_MIN_BARS", os.getenv("OPTION_EVAL_MIN_LIVE_BARS", "1")) or 1)
     quote_ready = False
     try:
         quote_ready = bool(ctx.market_data_manager.get_symbol_snapshot(symbol))
@@ -325,8 +325,10 @@ def _gate_runner_symbol_add(
                 required,
                 runner_bars >= required,
             )
-    history_ready = runner_bars >= required
-    add_ready = bool(quote_ready or history_ready)
+    effective_bars = min(mdm_bars, runner_bars)
+    is_option = symbol.endswith(("CE", "PE"))
+    history_ready = effective_bars >= required
+    add_ready = bool(history_ready if is_option else (quote_ready or mdm_bars >= 1))
     if not add_ready:
         pending_runner_symbols.add(symbol)
         LOGGER.info("RUNNER_SYMBOL_DEFERRED_UNTIL_READY symbol=%s token=%s runner_bars=%d mdm_bars=%d required_bars=%d source=%s", symbol, token, runner_bars, mdm_bars, required, source)
@@ -6825,9 +6827,9 @@ async def _recompute_and_push_runtime_readiness(ctx: BotContext, *, reason: str)
         except Exception:
             return False
     spot_ready = _quote(spot_symbol) or _bars(spot_symbol) >= 1
-    option_eval_min_live_bars = int(os.getenv("OPTION_EVAL_MIN_LIVE_BARS", "1") or 1)
-    option_execution_min_bars = int(os.getenv("OPTION_EXECUTION_MIN_BARS", "5") or 5)
-    context_execution_min_bars = int(os.getenv("CONTEXT_EXECUTION_MIN_BARS", "50") or 50)
+    option_eval_min_live_bars = int(os.getenv("READINESS_OPTION_EVAL_MIN_BARS", os.getenv("OPTION_EVAL_MIN_LIVE_BARS", "1")) or 1)
+    option_execution_min_bars = int(os.getenv("READINESS_OPTION_EXEC_MIN_BARS", os.getenv("OPTION_EXECUTION_MIN_BARS", "5")) or 5)
+    context_execution_min_bars = int(os.getenv("READINESS_CONTEXT_MIN_BARS", os.getenv("CONTEXT_EXECUTION_MIN_BARS", "20")) or 20)
     await _ensure_selected_options_hydrated(
         ctx, selected_ce, selected_pe, option_execution_min_bars, reason
     )
@@ -6835,8 +6837,8 @@ async def _recompute_and_push_runtime_readiness(ctx: BotContext, *, reason: str)
     pe_bars, pe_mdm_bars, pe_runner_bars = _readiness_bars(selected_pe)
     ce_quote_fresh = _quote(selected_ce)
     pe_quote_fresh = _quote(selected_pe)
-    ce_eval_ready = bool(selected_ce) and (ce_quote_fresh or ce_bars >= option_eval_min_live_bars)
-    pe_eval_ready = bool(selected_pe) and (pe_quote_fresh or pe_bars >= option_eval_min_live_bars)
+    ce_eval_ready = bool(selected_ce) and ce_quote_fresh and ce_bars >= option_eval_min_live_bars
+    pe_eval_ready = bool(selected_pe) and pe_quote_fresh and pe_bars >= option_eval_min_live_bars
     ce_exec_ready = bool(selected_ce) and ce_quote_fresh and ce_bars >= option_execution_min_bars
     pe_exec_ready = bool(selected_pe) and pe_quote_fresh and pe_bars >= option_execution_min_bars
     futures_symbol = str(basket.get("futures_symbol") or "")

--- a/src/nifty_scalper_bot/strategies/indicators.py
+++ b/src/nifty_scalper_bot/strategies/indicators.py
@@ -12,7 +12,7 @@ from datetime import datetime, time, timedelta, timezone
 import logging
 import os
 import threading
-from typing import Any, Callable, Deque, Dict, Iterable, Mapping, Sequence
+from typing import Any, Callable, Deque, Dict, Iterable, Literal, Mapping, Sequence
 from zoneinfo import ZoneInfo
 
 import numpy as np
@@ -202,12 +202,15 @@ class IndicatorEngine:
         self._lock = threading.RLock()
         self._logger = get_logger(__name__)
 
-    def set_runtime_context(self, symbol: str, context: Mapping[str, Any]) -> None:
+    def set_runtime_context(self, symbol: str, context: Mapping[str, Any], *, merge: bool = True) -> None:
         """Store runtime context. Args: symbol, context. Returns: None. Raises: Exception."""
         try:
             if not symbol:
                 return
             allowed_context_keys = {
+                "contract_side", "underlying", "spot_symbol", "spot_price",
+                "futures_symbol", "futures_price", "quote_age_s", "spread_pct",
+                "bid", "ask",
                 "selected_ce",
                 "selected_pe",
                 "atm_strike",
@@ -217,10 +220,11 @@ class IndicatorEngine:
                 "option_role",
             }
             with self._lock:
-                symbol_context = self._runtime_context.setdefault(symbol, {})
+                symbol_context = self._runtime_context.setdefault(symbol, {}) if merge else {}
                 for key, value in dict(context).items():
                     if key in allowed_context_keys:
                         symbol_context[key] = value
+                self._runtime_context[symbol] = symbol_context
                 self._cache.pop(symbol, None)
         except Exception as e:
             self._logger.error("Failure in IndicatorEngine.set_runtime_context: %s", e)
@@ -230,11 +234,11 @@ class IndicatorEngine:
         """Backward-compatible alias for runtime context setter. Args: symbol, indicators. Returns: None. Raises: Exception."""
         self.set_runtime_context(symbol, indicators)
 
-    def get_runtime_context(self, symbol: str) -> dict[str, Any]:
+    def get_runtime_context(self, symbol: str, default: Mapping[str, Any] | None = None) -> dict[str, Any]:
         """Fetch runtime context. Args: symbol. Returns: context copy. Raises: Exception."""
         try:
             with self._lock:
-                return dict(self._runtime_context.get(symbol, {}))
+                return dict(self._runtime_context.get(symbol, dict(default or {})))
         except Exception as e:
             self._logger.error("Failure in IndicatorEngine.get_runtime_context: %s", e)
             raise
@@ -325,13 +329,23 @@ class IndicatorEngine:
             )
             raise
 
+
+    def ingest_historical_bar(self, symbol: str, bar: Mapping[str, Any]) -> int:
+        """Args: symbol/bar mapping. Returns: new history count. Raises: Exception."""
+        try:
+            self.ingest_bar(symbol, bar)
+            return self.history_count(symbol)
+        except Exception as e:
+            self._logger.error("Failure in IndicatorEngine.ingest_historical_bar: %s", e)
+            raise
+
     def history_count(self, symbol: str) -> int:
         """Return symbol history length. Args: symbol. Returns: count. Raises: none."""
         with self._lock:
             history = self._histories.get(symbol)
             return len(history) if history is not None else 0
 
-    def get_history(self, symbol: str, count: int | None = None) -> list[float]:
+    def get_history(self, symbol: str, count: int | None = None, *, field: Literal["close", "bars"] = "close") -> list[Any]:
         """Args: symbol, count. Returns: close-price history list. Raises: Exception."""
         LOGGER.debug(
             "Entered IndicatorEngine.get_history",
@@ -375,16 +389,30 @@ class IndicatorEngine:
                             },
                         )
                     return []
-                closes = history.get_closes(count)
+                if field == "bars":
+                    opens = history.get_opens(count)
+                    highs = history.get_highs(count)
+                    lows = history.get_lows(count)
+                    closes = history.get_closes(count)
+                    volumes = history.get_volumes(count)
+                    timestamps = history.get_timestamps(count)
+                    complete = history.get_completeness(count)
+                    provisional = history.get_provisional_flags(count)
+                    bars = [
+                        {"open": o, "high": h, "low": l, "close": c, "volume": v, "timestamp": ts, "is_complete": ic, "is_provisional": ip}
+                        for o, h, l, c, v, ts, ic, ip in zip(opens, highs, lows, closes, volumes, timestamps, complete, provisional)
+                    ]
+                else:
+                    bars = history.get_closes(count)
             LOGGER.debug(
                 "Condition met: indicator_history_resolved",
                 extra={
                     "event": "indicator_engine_history_resolved",
                     "symbol": symbol,
-                    "bars": len(closes),
+                    "bars": len(bars),
                 },
             )
-            return closes
+            return bars
         except Exception as e:  # noqa: BLE001
             LOGGER.error("Failure in IndicatorEngine.get_history: %s", e, exc_info=True)
             return []

--- a/src/nifty_scalper_bot/strategies/signal_quality.py
+++ b/src/nifty_scalper_bot/strategies/signal_quality.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass, field
+from typing import Literal
 
 REQUIRED_SCORE_COMPONENTS: tuple[str, ...] = (
     'direction_score',
@@ -62,6 +63,54 @@ def normalize_strategy_name(strategy_name: str | None) -> str:
     }
     return aliases.get(raw, raw)
 
+
+def trigger_threshold(strategy_name: str | None, mode: str | None = None) -> float:
+    """Args: strategy_name/mode. Returns: trigger threshold. Raises: none."""
+    effective_mode = str(mode or os.getenv('EXECUTION_MODE', 'SHADOW')).strip().upper()
+    strategy_key = normalize_strategy_name(strategy_name)
+    is_live = effective_mode == 'LIVE'
+    defaults = {
+        'vwap_pro': (7.2, 6.2, 'TRIGGER_VWAP_PRO_LIVE_MIN', 'SIGNAL_MIN_SCORE_LIVE_VWAP_PRO'),
+        'premium_squeeze': (7.4, 6.4, 'TRIGGER_PREMIUM_SQUEEZE_LIVE_MIN', 'SIGNAL_MIN_SCORE_LIVE_PREMIUM_SQUEEZE'),
+        'smc_liquidity_sweep_lite': (7.0, 6.0, 'TRIGGER_SMC_LIVE_MIN', None),
+        'smc_lite': (7.0, 6.0, 'TRIGGER_SMC_LIVE_MIN', None),
+    }
+    live_default, paper_default, primary_env, legacy_env = defaults.get(strategy_key, (7.2, 6.2, 'SIGNAL_MIN_SCORE_LIVE', None))
+    default_value = live_default if is_live else paper_default
+    value = os.getenv(primary_env)
+    if value is None and legacy_env:
+        value = os.getenv(legacy_env)
+    return float(value or default_value)
+
+
+def context_boost_cap(strategy_name: str | None = None) -> float:
+    """Args: strategy_name. Returns: absolute context boost cap. Raises: none."""
+    _ = strategy_name
+    return float(os.getenv('CONTEXT_BOOST_CAP', '1.25') or 1.25)
+
+
+def rejection_cooldown(reason_family: str) -> int:
+    """Args: reason_family. Returns: cooldown seconds. Raises: none."""
+    family = str(reason_family or 'score').strip().lower()
+    default_map = {'score': 60, 'candidate': 20, 'spread': 15, 'stale': 10, 'risk': 120, 'infra': 5}
+    return int(float(os.getenv(f'SIGNAL_REJECT_COOLDOWN_{family.upper()}_SECONDS', str(default_map.get(family, 60))) or default_map.get(family, 60)))
+
+
+def compute_context_boost(context_scores: list[float], *, strategy_name: str | None = None) -> float:
+    """Args: context scores list. Returns: bounded context boost. Raises: none."""
+    if not context_scores:
+        return 0.0
+    mean_centered = sum(float(s) - 5.0 for s in context_scores) / float(len(context_scores))
+    boost = mean_centered / 2.5
+    cap = context_boost_cap(strategy_name)
+    return max(-cap, min(cap, boost))
+
+
+def compute_final_execution_score(*, trigger_score: float, context_score_effective: float, candidate_score: float, data_score: float, rr_score: float) -> float:
+    """Args: score parts. Returns: final execution score 0..10. Raises: none."""
+    score = 0.45 * float(trigger_score) + 0.15 * float(context_score_effective) + 0.20 * float(candidate_score) + 0.10 * float(data_score) + 0.10 * float(rr_score)
+    return max(0.0, min(10.0, round(score, 3)))
+
 def _mode_threshold(strategy_name: str | None = None) -> float:
     mode = (os.getenv('EXECUTION_MODE', 'SHADOW') or 'SHADOW').strip().upper()
     strategy_key = normalize_strategy_name(strategy_name)
@@ -102,7 +151,7 @@ def score_signal_quality(
         + 0.10 * rr
     )
     normalized_strategy_name = normalize_strategy_name(strategy_name)
-    threshold = _mode_threshold(strategy_name=normalized_strategy_name)
+    threshold = trigger_threshold(strategy_name=normalized_strategy_name)
     reasons: list[str] = []
     if final < threshold:
         reasons.append('score_below_threshold')

--- a/src/nifty_scalper_bot/strategies/trade_selector.py
+++ b/src/nifty_scalper_bot/strategies/trade_selector.py
@@ -40,11 +40,14 @@ class TradeCandidate:
 
 
 class TradeCandidateSelector:
-    def __init__(self, *, quality_mode: str = 'normal', option_strike_window_each_side: int = 2, min_option_premium: float = 80.0, max_option_premium: float = float(os.getenv('MAX_OPTION_PREMIUM', '650'))) -> None:
+    def __init__(self, *, quality_mode: str = 'normal', option_strike_window_each_side: int = 2, min_option_premium: float = 80.0, max_option_premium: float = float(os.getenv('MAX_OPTION_PREMIUM', '650')), max_tick_age_s: float | None = None, max_option_spread_pct: float | None = None, require_real_ticks_last_60s: int | None = None) -> None:
         self.quality_mode = quality_mode
         self.option_strike_window_each_side = option_strike_window_each_side
         self.min_option_premium = min_option_premium
         self.max_option_premium = max_option_premium
+        self.max_tick_age_s = max_tick_age_s
+        self.max_option_spread_pct = max_option_spread_pct
+        self.require_real_ticks_last_60s = require_real_ticks_last_60s
 
     def _limits(self) -> tuple[float, float, int]:
         if self.quality_mode == 'strict':
@@ -55,6 +58,12 @@ class TradeCandidateSelector:
 
     def select_ranked_candidates(self, *, direction_bias: str, atm_strike: int, snapshots: list[dict[str, Any]]) -> list[TradeCandidate]:
         max_spread, max_age, min_ticks = self._limits()
+        if self.max_option_spread_pct is not None:
+            max_spread = float(self.max_option_spread_pct)
+        if self.max_tick_age_s is not None:
+            max_age = float(self.max_tick_age_s)
+        if self.require_real_ticks_last_60s is not None:
+            min_ticks = int(self.require_real_ticks_last_60s)
         allow_ltp_only = os.getenv('ALLOW_LTP_ONLY_CANDIDATE', 'true').lower() in {'1', 'true', 'yes', 'on'}
         ranked: list[TradeCandidate] = []
         rejects = {'side_mismatch': 0, 'atm_distance': 0, 'missing_bid_ask': 0, 'premium_out_of_range': 0, 'spread_too_wide': 0, 'tick_stale': 0, 'insufficient_ticks': 0, 'invalid_rr': 0}
@@ -133,6 +142,32 @@ class TradeCandidateSelector:
     def select_best_candidate(self, *, underlying: str, direction_bias: str, atm_strike: int, snapshots: list[dict[str, Any]]) -> TradeCandidate | None:
         ranked = self.select_ranked_candidates(direction_bias=direction_bias, atm_strike=atm_strike, snapshots=snapshots)
         return ranked[0] if ranked else None
+
+
+    def evaluate_data_quality(self, snapshot: dict[str, Any]) -> DataQualityResult:
+        """Args: snapshot. Returns: data quality result. Raises: none."""
+        max_spread, max_age, min_ticks = self._limits()
+        reasons: list[str] = []
+        score = 10.0
+        tick_age = self._f(snapshot.get('tick_age_s'))
+        if tick_age is None or tick_age > max_age:
+            reasons.append('tick_stale')
+            score -= 4.0
+        bid, ask = self._f(snapshot.get('bid')), self._f(snapshot.get('ask'))
+        if (bid or 0) <= 0 or (ask or 0) <= 0:
+            reasons.append('missing_bid_ask')
+            score -= 3.0
+        else:
+            mid = ((bid or 0.0) + (ask or 0.0)) / 2.0
+            spread_pct = ((ask or 0.0) - (bid or 0.0)) / mid if mid > 0 else 1.0
+            if spread_pct > max_spread:
+                reasons.append('spread_too_wide')
+                score -= 3.0
+        real_ticks = int(snapshot.get('real_ticks_last_60s') or 0)
+        if real_ticks < min_ticks:
+            reasons.append('insufficient_ticks')
+            score -= 2.0
+        return DataQualityResult(allowed=not reasons, score=max(0.0, score), reasons=reasons or ['data_quality_ok'])
 
     @staticmethod
     def _f(v: Any) -> float | None:


### PR DESCRIPTION
### Motivation
- Consolidate scattered scoring/readiness thresholds and make the runner the authoritative source for trigger/context policy to remove inconsistent behavior across modules. 
- Expand the indicator engine contract and candidate selection data-quality checks so strategies can evaluate richer runtime context and bar-level history deterministically. 
- Harden option readiness and hydration logic so the runner only evaluates/executed options when both market-data-manager (MDM) and runner histories meet the same effective-bar requirement. 

### Description
- Centralized scoring APIs in `src/nifty_scalper_bot/strategies/signal_quality.py` by adding `trigger_threshold(strategy_name, mode)`, `context_boost_cap(strategy_name)`, `rejection_cooldown(reason_family)`, `compute_context_boost(...)` and `compute_final_execution_score(...)`, and wired `score_signal_quality` to use `trigger_threshold`. 
- Expanded `IndicatorEngine` contract in `src/nifty_scalper_bot/strategies/indicators.py` by adding `ingest_historical_bar(symbol, bar)`, making `set_runtime_context(..., merge=True)` writable with an extended allowed key set, exposing `get_runtime_context(..., default=...)`, and extending `get_history(..., field='close'|'bars')` to optionally return bar dicts. 
- Tightened readiness/hydration in `src/nifty_scalper_bot/core/app.py` by using `effective_bars = min(mdm_bars, runner_bars)` in `_gate_runner_symbol_add`, using `READINESS_*` env names with legacy fallbacks, and making evaluation readiness for selected options require quote freshness plus effective bars. 
- Restored explicit trade-selector tunables in `src/nifty_scalper_bot/strategies/trade_selector.py` (`max_tick_age_s`, `max_option_spread_pct`, `require_real_ticks_last_60s`) and added `evaluate_data_quality(snapshot) -> DataQualityResult` to expose deterministic data-quality scoring. 
- Small supporting adjustments to thresholds and env var lookup sites to make the new contracts backward-compatible where possible. 

### Testing
- Ran startup checks with `bash ./run_checks.sh`, which exercised the environment setup but reported that `pytest` was not initially present in the run pipeline check. 
- Installed `pytest` into the created virtualenv and executed targeted tests with `.venv/bin/pytest -q tests/strategies/test_signal_quality.py tests/strategies/test_trade_selector.py tests/core/test_app_runner_symbol_gate.py`, which completed successfully with the suite passing (log shows the invoked tests passed). 
- Verified the modified files pass the repository's unit tests run above and observed no new test failures for the focused test set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a007348f0d88324afe084c5f698c68e)