### PR TITLE
fix: normalize strategy votes and side-domain handling

### DIFF
--- a/src/nifty_scalper_bot/core/strategy_manager.py
+++ b/src/nifty_scalper_bot/core/strategy_manager.py
@@ -298,12 +298,20 @@ class StrategyVote:
 def signal_to_vote(signal: Signal, strategy_name: str) -> StrategyVote:
     """Args: signal + strategy name. Returns: normalized vote. Raises: none."""
     metadata = dict(signal.metadata or {})
-    side = str(metadata.get("trade_side") or metadata.get("side") or infer_option_side(signal.symbol, metadata)).upper()
+    symbol_side = infer_option_side(signal.symbol, metadata)
+    metadata_side = str(metadata.get("trade_side") or metadata.get("side") or "").upper()
+    if symbol_side in {"CE", "PE"}:
+        if metadata_side in {"CE", "PE"} and metadata_side != symbol_side:
+            metadata["side_conflict"] = True
+            metadata["side_from_metadata"] = metadata_side
+        side = symbol_side
+    else:
+        side = metadata_side or symbol_side
     if signal.action == "HOLD" and side not in {"CE", "PE"}:
         side = "NO_TRADE"
     score_candidate = float(metadata.get("strategy_score") or metadata.get("setup_quality") or 0.0)
     confidence_score = float(signal.confidence or 0.0) * 10.0
-    score = score_candidate
+    score = max(score_candidate, confidence_score)
     reason = str(signal.reason or '').strip()
     reason_list = list(metadata.get("score_reasons") or [])
     if reason and reason not in reason_list:
@@ -313,7 +321,7 @@ def signal_to_vote(signal: Signal, strategy_name: str) -> StrategyVote:
     metadata.setdefault("setup_quality", score_candidate)
     metadata["vote_score_raw_strategy"] = score_candidate
     metadata["vote_score_from_confidence"] = confidence_score
-    metadata["vote_score"] = score
+    metadata["vote_score"] = max(0.0, min(10.0, score))
     metadata["score_reasons"] = reason_list
     return StrategyVote(
         strategy=strategy_name,
@@ -2582,7 +2590,7 @@ class StrategyManager(_BaseStrategyManager):
             )
             metadata = dict(vote.metadata or {})
             metadata["regime_weight"] = weight
-            metadata["strategy_score"] = weighted_score
+            metadata["regime_weighted_vote_score"] = weighted_score
             return StrategyVote(
                 strategy=vote.strategy,
                 side=vote.side,

--- a/src/nifty_scalper_bot/strategies/elite_strategies/vwap_pro.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/vwap_pro.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from nifty_scalper_bot.strategies.elite_strategies.base_elite import EliteSignal, EliteStrategy
 from nifty_scalper_bot.strategies.elite_strategies.config_models import VWAPProStrategyConfig
+from nifty_scalper_bot.strategies.signal_quality import infer_option_side
 from nifty_scalper_bot.utils.logging import get_logger
 
 LOGGER = get_logger(__name__)
@@ -73,19 +74,26 @@ class VWAPProStrategy(EliteStrategy):
 
             score = 0.0
             reasons: list[str] = []
-            contract_side = 'UNKNOWN'
+            contract_side = infer_option_side(symbol, indicators)
             trend_alignment = False
             pullback_flag = False
             continuation_confirmed = False
 
-            if current_price >= vwap:
-                contract_side = 'CE'
+            if contract_side not in {'CE', 'PE'}:
+                fallback_side = str(indicators.get('direction_bias') or '').upper()
+                if fallback_side in {'CE', 'PE'}:
+                    contract_side = fallback_side
+                else:
+                    self._no_vote('unknown_contract_side')
+                    LOGGER.debug('STRATEGY_NO_VOTE strategy=VWAPPro reason=unknown_contract_side')
+                    return None
+            premium_above_vwap = current_price >= vwap
+            if contract_side == 'CE' and premium_above_vwap:
                 score += 2.0
-                reasons.append('above_or_below_vwap:above')
-            else:
-                contract_side = 'PE'
+                reasons.append('ce_premium_above_vwap')
+            if contract_side == 'PE' and not premium_above_vwap:
                 score += 2.0
-                reasons.append('above_or_below_vwap:below')
+                reasons.append('pe_premium_below_vwap')
 
             candle_body = abs(close - open_price)
             atr_safe = max(atr, current_price * 0.01, 1.0)
@@ -131,6 +139,8 @@ class VWAPProStrategy(EliteStrategy):
                 'signal_family': 'directional_trigger',
                 'trade_side': contract_side,
                 'side': contract_side,
+                'contract_side': contract_side,
+                'premium_above_vwap': premium_above_vwap,
                 'direction_bias': contract_side,
                 'preliminary_only': True,
                 'requires_runner_final_score': True,

--- a/src/nifty_scalper_bot/strategies/signal_quality.py
+++ b/src/nifty_scalper_bot/strategies/signal_quality.py
@@ -53,11 +53,23 @@ def normalize_strategy_name(strategy_name: str | None) -> str:
     """Args: strategy_name. Returns: canonical strategy key. Raises: none."""
     raw = str(strategy_name or "").strip().lower().replace(" ", "_").replace("-", "_")
     aliases = {
+        "smc": "smc_lite",
+        "smc_liquidity": "smc_lite",
+        "smc_lite": "smc_lite",
+        "smc_liquidity_sweep_lite": "smc_lite",
         "premium_momentum": "premium_squeeze",
         "premium_momentum_squeeze": "premium_squeeze",
         "premium_squeeze": "premium_squeeze",
         "rsidivergence": "rsi_divergence",
         "rsi_divergence": "rsi_divergence",
+        "cprbreakout": "cpr_breakout",
+        "cpr_breakout": "cpr_breakout",
+        "bbsqueeze": "bb_squeeze",
+        "bb_squeeze": "bb_squeeze",
+        "orderflow": "order_flow",
+        "order_flow": "order_flow",
+        "orbpro": "orb_pro",
+        "orb_pro": "orb_pro",
         "vwappro": "vwap_pro",
         "vwap_pro": "vwap_pro",
     }
@@ -73,8 +85,11 @@ def trigger_threshold(strategy_name: str | None, mode: str | None = None) -> flo
         'vwap_pro': (7.5, 6.5, 'TRIGGER_VWAP_PRO_LIVE_MIN', 'SIGNAL_MIN_SCORE_LIVE_VWAP_PRO'),
         'premium_squeeze': (7.4, 6.4, 'TRIGGER_PREMIUM_SQUEEZE_LIVE_MIN', 'SIGNAL_MIN_SCORE_LIVE_PREMIUM_SQUEEZE'),
         'rsi_divergence': (7.6, 6.6, 'TRIGGER_RSI_DIVERGENCE_LIVE_MIN', 'SIGNAL_MIN_SCORE_LIVE_RSI_DIVERGENCE'),
-        'smc_liquidity_sweep_lite': (7.0, 6.0, 'TRIGGER_SMC_LIVE_MIN', None),
         'smc_lite': (7.0, 6.0, 'TRIGGER_SMC_LIVE_MIN', None),
+        'cpr_breakout': (7.2, 6.2, 'TRIGGER_CPR_BREAKOUT_LIVE_MIN', None),
+        'bb_squeeze': (7.3, 6.3, 'TRIGGER_BB_SQUEEZE_LIVE_MIN', None),
+        'order_flow': (7.1, 6.1, 'TRIGGER_ORDER_FLOW_LIVE_MIN', None),
+        'orb_pro': (7.4, 6.4, 'TRIGGER_ORB_PRO_LIVE_MIN', None),
     }
     live_default, paper_default, primary_env, legacy_env = defaults.get(strategy_key, (8.0, 6.5, 'SIGNAL_MIN_SCORE_LIVE', None))
     default_value = live_default if is_live else paper_default

--- a/tests/core/test_strategy_manager_vote_normalization.py
+++ b/tests/core/test_strategy_manager_vote_normalization.py
@@ -1,0 +1,59 @@
+from nifty_scalper_bot.core.strategy_manager import StrategyVote, signal_to_vote, StrategyManager
+from nifty_scalper_bot.strategies.signal_generator import Signal
+
+
+class _NoopStrategy:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    def get_required_indicators(self) -> list[str]:
+        return []
+
+    def generate_signal(self, symbol: str, indicators: dict, current_price: float, position=None):
+        return None
+
+
+class _DummyIndicatorEngine:
+    def get_indicators(self, symbol: str, names):
+        return {str(n): 0.0 for n in names}
+
+
+class _DummyPositionManager:
+    def get_position(self, symbol: str):
+        return None
+
+
+def test_signal_to_vote_uses_confidence_when_strategy_score_missing() -> None:
+    signal = Signal(action='BUY', symbol='NFO:NIFTY26FEB22500CE', quantity=1, confidence=0.72, metadata={})
+    vote = signal_to_vote(signal, 'VWAPPro')
+    assert vote.score == 7.2
+    assert vote.metadata['vote_score_from_confidence'] == 7.2
+
+
+def test_signal_to_vote_overrides_conflicting_metadata_side_with_symbol_side() -> None:
+    signal = Signal(
+        action='BUY',
+        symbol='NFO:NIFTY26FEB22500CE',
+        quantity=1,
+        confidence=0.8,
+        metadata={'trade_side': 'PE', 'strategy_score': 8.0},
+    )
+    vote = signal_to_vote(signal, 'VWAPPro')
+    assert vote.side == 'CE'
+    assert vote.metadata['side_conflict'] is True
+    assert vote.metadata['side_from_metadata'] == 'PE'
+
+
+def test_apply_regime_vote_weight_preserves_raw_strategy_score() -> None:
+    manager = StrategyManager([_NoopStrategy('VWAPPro')], _DummyIndicatorEngine(), _DummyPositionManager())
+    vote = StrategyVote(
+        strategy='VWAPPro',
+        side='CE',
+        score=8.0,
+        confidence=0.8,
+        reasons=[],
+        metadata={'strategy_score': 8.0},
+    )
+    weighted = manager._apply_regime_vote_weight(vote=vote, regime_name='BULL')
+    assert weighted.metadata['strategy_score'] == 8.0
+    assert 'regime_weighted_vote_score' in weighted.metadata

--- a/tests/strategies/test_signal_quality_strategy_thresholds.py
+++ b/tests/strategies/test_signal_quality_strategy_thresholds.py
@@ -12,3 +12,14 @@ def test_strategy_threshold_aliases_live(monkeypatch):
     ps = score_signal_quality(direction_score=7.5, strategy_score=7.5, option_score=7.5, data_score=7.5, rr_score=7.0, strategy_name='premium_momentum_squeeze')
     assert ps.components['threshold'] == 7.4
     assert ps.allowed
+    smc = score_signal_quality(direction_score=7.2, strategy_score=7.2, option_score=7.2, data_score=7.2, rr_score=7.2, strategy_name='smc')
+    assert smc.components['threshold'] == 7.0
+    assert smc.allowed
+    cpr = score_signal_quality(direction_score=7.3, strategy_score=7.3, option_score=7.3, data_score=7.3, rr_score=7.3, strategy_name='CPRBreakout')
+    assert cpr.components['threshold'] == 7.2
+    bb = score_signal_quality(direction_score=7.4, strategy_score=7.4, option_score=7.4, data_score=7.4, rr_score=7.4, strategy_name='BBSqueeze')
+    assert bb.components['threshold'] == 7.3
+    of = score_signal_quality(direction_score=7.2, strategy_score=7.2, option_score=7.2, data_score=7.2, rr_score=7.2, strategy_name='OrderFlow')
+    assert of.components['threshold'] == 7.1
+    orb = score_signal_quality(direction_score=7.5, strategy_score=7.5, option_score=7.5, data_score=7.5, rr_score=7.5, strategy_name='ORBPro')
+    assert orb.components['threshold'] == 7.4

--- a/tests/strategies/test_vwap_pro_side_domain.py
+++ b/tests/strategies/test_vwap_pro_side_domain.py
@@ -1,0 +1,35 @@
+from nifty_scalper_bot.strategies.elite_strategies.config_models import VWAPProStrategyConfig
+from nifty_scalper_bot.strategies.elite_strategies.vwap_pro import VWAPProStrategy
+
+
+class _DummyEngine:
+    pass
+
+
+def _base_indicators(direction_bias: str = 'CE') -> dict[str, float | str]:
+    return {
+        'vwap': 100.0,
+        'atr': 5.0,
+        'close': 103.0,
+        'open': 100.0,
+        'high': 104.0,
+        'low': 99.0,
+        'volume': 1000.0,
+        'avg_volume': 900.0,
+        'spread_pct': 2.0,
+        'direction_bias': direction_bias,
+    }
+
+
+def test_vwap_pro_never_emits_pe_for_ce_symbol() -> None:
+    strategy = VWAPProStrategy(config=VWAPProStrategyConfig(), indicator_engine=_DummyEngine())
+    signal = strategy._evaluate_signal('NFO:NIFTY26FEB22500CE', _base_indicators('CE'), 101.0)
+    assert signal is not None
+    assert signal.metadata['side'] == 'CE'
+
+
+def test_vwap_pro_never_emits_ce_for_pe_symbol() -> None:
+    strategy = VWAPProStrategy(config=VWAPProStrategyConfig(), indicator_engine=_DummyEngine())
+    signal = strategy._evaluate_signal('NFO:NIFTY26FEB22500PE', _base_indicators('PE'), 99.0)
+    assert signal is not None
+    assert signal.metadata['side'] == 'PE'


### PR DESCRIPTION
### Motivation
- Prevent valid strategy votes from being silently zeroed when `strategy_score` metadata is missing by restoring a confidence-derived fallback.
- Eliminate CE/PE contradictions where a strategy could emit the wrong execution side for an option contract, which blocked single-vote entries.
- Ensure active strategies are judged against their intended live thresholds by adding missing aliases so they do not fall back to the generic `8.0` live threshold.

### Description
- In `src/nifty_scalper_bot/core/strategy_manager.py` `signal_to_vote()` now computes `symbol_side = infer_option_side(...)`, forces `side` to the contract side when present, records `side_conflict`/`side_from_metadata` when metadata conflicts, and sets the vote score to `max(strategy_score, confidence*10)` while capping `vote_score` into 0..10.
- In the same file `_apply_regime_vote_weight()` no longer overwrites the raw `metadata['strategy_score']` and instead records `metadata['regime_weight']` and `metadata['regime_weighted_vote_score']` while still returning a weighted `StrategyVote`.
- In `src/nifty_scalper_bot/strategies/signal_quality.py` `normalize_strategy_name()` and `trigger_threshold()` were extended with aliases and defaults for `smc`, `cpr_breakout`, `bb_squeeze`, `order_flow`, and `orb_pro` so these strategies use explicit thresholds.
- In `src/nifty_scalper_bot/strategies/elite_strategies/vwap_pro.py` the contract execution side is now derived from the symbol via `infer_option_side()` (with a controlled fallback to `direction_bias`), premium-vs-VWAP becomes setup evidence (not the side selector), and new metadata fields `contract_side` and `premium_above_vwap` are added.
- Added targeted unit tests: `tests/core/test_strategy_manager_vote_normalization.py`, extended `tests/strategies/test_signal_quality_strategy_thresholds.py`, and `tests/strategies/test_vwap_pro_side_domain.py` to validate vote normalization, alias thresholds, and VWAP side invariants.

### Testing
- `PYTHONPATH=src python -m compileall src` ran successfully and the package compiled without syntax errors. ✅
- Targeted pytest run `PYTHONPATH=src pytest -q tests/core/test_strategy_manager_vote_normalization.py tests/core/test_strategy_manager_scoring.py tests/strategies/test_signal_quality_strategy_thresholds.py tests/strategies/test_vwap_pro_side_domain.py` passed for the modified and related tests. ✅
- `./run_checks.sh` was executed via `bash run_checks.sh`; it created the virtualenv and installed dependencies but the script could not complete the full check sequence because the created environment reported the test runner/tools missing (e.g., `pytest`/`ruff`/`mypy` not available in that invocation), so full `run_checks.sh` end-to-end was not green in this environment (requires CI/host dev tooling). ⚠️

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00b3de41b483248dcd512c07260997)