### PR TITLE
fix: enforce premium-domain option execution and add optional tenacity fallback

### DIFF
--- a/src/nifty_scalper_bot/core/strategy_manager.py
+++ b/src/nifty_scalper_bot/core/strategy_manager.py
@@ -2503,7 +2503,6 @@ class StrategyManager(_BaseStrategyManager):
         best_signal, best_vote = max(trigger_votes, key=lambda pair: pair[1].score)
         threshold = float(os.getenv("STRATEGY_TRIGGER_MIN_SCORE", "4.5") or "4.5")
         single_high = float(os.getenv("STRATEGY_SINGLE_VOTE_HIGH_CONVICTION", "8.8") or "8.8")
-        single_scalp_min = float(os.getenv("STRATEGY_SINGLE_VOTE_SCALP_MIN", "6.6") or "6.6")
         allow_scalp_single = str(os.getenv("STRATEGY_ALLOW_SINGLE_VOTE_SCALP", "false")).lower() in {"1", "true", "yes", "on"}
         final_score = float(best_vote.score)
         vetoed = False
@@ -2516,9 +2515,23 @@ class StrategyManager(_BaseStrategyManager):
         if len(trigger_votes) == 1:
             selected_option = bool((best_signal.metadata or {}).get("is_selected_option"))
             near_atm = float((best_signal.metadata or {}).get("strike_distance_from_atm") or 999.0) <= 50.0
+            score_min, conf_min = self._single_vote_thresholds(best_vote.strategy)
+            score_ok = best_vote.score >= score_min
+            conf_ok = best_vote.confidence >= conf_min
+            selected_ok = selected_option or near_atm
+            log.info(
+                "SINGLE_VOTE_DECISION strategy=%s score=%.2f score_min=%.2f confidence=%.2f conf_min=%.2f selected_ok=%s vetoed=%s",
+                best_vote.strategy,
+                best_vote.score,
+                score_min,
+                best_vote.confidence,
+                conf_min,
+                selected_ok,
+                vetoed,
+            )
             if best_vote.score >= single_high:
                 metadata_stage = "preliminary_single_high_conviction"
-            elif allow_scalp_single and best_vote.score >= single_scalp_min and (selected_option or near_atm) and not vetoed:
+            elif allow_scalp_single and score_ok and conf_ok and selected_ok and not vetoed:
                 metadata_stage = "single_vote_scalp_controlled"
             else:
                 return None
@@ -2527,6 +2540,8 @@ class StrategyManager(_BaseStrategyManager):
         if vetoed or final_score < threshold:
             return None
         metadata = dict(best_signal.metadata or {})
+        metadata.setdefault("trigger_strategy_score", metadata.get("strategy_score"))
+        metadata["consensus_score"] = round(final_score, 3)
         metadata["strategy_score"] = round(final_score, 3)
         metadata["confirming_votes"] = [best_vote.strategy] + [v.strategy for v in same_side_context]
         metadata["direction_bias"] = best_vote.side
@@ -2566,6 +2581,19 @@ class StrategyManager(_BaseStrategyManager):
         except Exception as exc:  # noqa: BLE001
             log.error("Failure in StrategyManager._extract_regime_scale: %s", exc)
             return 1.0
+
+    def _single_vote_thresholds(self, strategy_name: str) -> tuple[float, float]:
+        """Args: strategy_name. Returns: score/conf thresholds. Raises: none."""
+        key = str(strategy_name or "").strip().lower().replace(" ", "_")
+        if key in {"vwappro", "vwap_pro"}:
+            return (
+                float(os.getenv("STRATEGY_SINGLE_VOTE_VWAP_MIN_SCORE", "5.8") or "5.8"),
+                float(os.getenv("STRATEGY_SINGLE_VOTE_VWAP_MIN_CONFIDENCE", "0.45") or "0.45"),
+            )
+        return (
+            float(os.getenv("STRATEGY_SINGLE_VOTE_SCALP_MIN", "6.6") or "6.6"),
+            float(os.getenv("STRATEGY_SINGLE_VOTE_MIN_CONFIDENCE", "0.60") or "0.60"),
+        )
 
     def _apply_regime_vote_weight(
         self, *, vote: StrategyVote, regime_name: str | None

--- a/src/nifty_scalper_bot/data/robust_provider.py
+++ b/src/nifty_scalper_bot/data/robust_provider.py
@@ -7,13 +7,93 @@ from enum import Enum
 from typing import Any, Callable, TypeVar
 from dataclasses import dataclass
 
-from tenacity import (
-    retry,
-    stop_after_attempt,
-    wait_exponential,
-    retry_if_exception_type,
-    before_sleep_log
-)
+try:
+    from tenacity import (
+        retry,
+        stop_after_attempt,
+        wait_exponential,
+        retry_if_exception_type,
+        before_sleep_log,
+    )
+except ImportError:  # dependency-free fallback for clean envs
+    import asyncio
+    import time
+
+    def stop_after_attempt(attempts: int) -> int:
+        return int(attempts)
+
+    def wait_exponential(*, multiplier: float = 1.0, min: float = 1.0, max: float = 10.0):
+        return (float(multiplier), float(min), float(max))
+
+    def retry_if_exception_type(exc_types):
+        return exc_types
+
+    def before_sleep_log(logger, level):
+        def _before_sleep(retry_state) -> None:
+            try:
+                logger.log(
+                    level,
+                    "ROBUST_PROVIDER_RETRY_FALLBACK attempt=%s",
+                    getattr(retry_state, "attempt_number", None),
+                )
+            except Exception:
+                pass
+
+        return _before_sleep
+
+    def retry(*, stop=3, wait=(1.0, 1.0, 10.0), retry=Exception, before_sleep=None):
+        attempts = int(stop if isinstance(stop, int) else 3)
+        exc_types = retry if isinstance(retry, tuple) else (retry,)
+
+        def decorator(fn):
+            if asyncio.iscoroutinefunction(fn):
+                async def _wrapped(*args, **kwargs):
+                    mult, min_wait, max_wait = wait
+                    for attempt in range(1, attempts + 1):
+                        try:
+                            return await fn(*args, **kwargs)
+                        except exc_types as exc:
+                            if attempt >= attempts:
+                                raise
+                            if before_sleep:
+                                try:
+                                    state = type(
+                                        "RetryState",
+                                        (),
+                                        {"attempt_number": attempt, "fn": fn, "exception": exc},
+                                    )()
+                                    before_sleep(state)
+                                except Exception:
+                                    pass
+                            delay = min(max_wait, max(min_wait, mult * (2 ** (attempt - 1))))
+                            await asyncio.sleep(delay)
+
+                return _wrapped
+
+            def _wrapped(*args, **kwargs):
+                mult, min_wait, max_wait = wait
+                for attempt in range(1, attempts + 1):
+                    try:
+                        return fn(*args, **kwargs)
+                    except exc_types as exc:
+                        if attempt >= attempts:
+                            raise
+                        if before_sleep:
+                            try:
+                                state = type(
+                                    "RetryState",
+                                    (),
+                                    {"attempt_number": attempt, "fn": fn, "exception": exc},
+                                )()
+                                before_sleep(state)
+                            except Exception:
+                                pass
+                        delay = min(max_wait, max(min_wait, mult * (2 ** (attempt - 1))))
+                        time.sleep(delay)
+
+            return _wrapped
+
+        return decorator
 
 LOGGER = logging.getLogger(__name__)
 T = TypeVar('T')

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -5279,6 +5279,64 @@ class StrategyRunner:
         value = str(symbol or "").upper()
         return value.startswith("NFO:NIFTY") and (value.endswith("CE") or value.endswith("PE"))
 
+    def _is_tradable_option_symbol(self, symbol: str) -> bool:
+        """Compatibility alias for option-tradability checks."""
+        return self._is_tradable_symbol(symbol)
+
+    def get_quote(self, symbol: str) -> dict[str, Any] | None:
+        """Return freshest normalized quote available from DataHub/MDM."""
+        normalized = normalize_symbol(symbol)
+        for source in (self._data_hub, self._market_data):
+            if source is None:
+                continue
+            for name in ("get_quote", "get_symbol_snapshot", "get_latest_tick"):
+                fn = getattr(source, name, None)
+                if not callable(fn):
+                    continue
+                try:
+                    raw = fn(normalized)
+                except Exception:
+                    continue
+                if raw is None:
+                    continue
+                if isinstance(raw, Mapping):
+                    payload = dict(raw)
+                else:
+                    payload = {
+                        "ltp": getattr(raw, "ltp", None) or getattr(raw, "last_price", None) or getattr(raw, "price", None),
+                        "bid": getattr(raw, "bid", None) or getattr(raw, "best_bid", None),
+                        "ask": getattr(raw, "ask", None) or getattr(raw, "best_ask", None),
+                        "tick_age_s": getattr(raw, "tick_age_s", None),
+                        "ts_ns": getattr(raw, "ts_ns", None),
+                    }
+                ltp = _extract_float(payload, "ltp", "last_price", "price", "close")
+                if ltp is not None and ltp > 0:
+                    return payload
+        return None
+
+    def _is_option_symbol_tick_fresh(self, symbol: str, *, max_age_s: float | None = None) -> bool:
+        """Freshness guard for selected option soft-pass and live execution readiness."""
+        if not self._is_tradable_symbol(symbol):
+            return False
+        limit = float(max_age_s or os.getenv("OPTION_TICK_FRESH_MAX_AGE_S", "60") or 60.0)
+        quote = self.get_quote(symbol)
+        if isinstance(quote, Mapping):
+            age = _extract_float(quote, "tick_age_s", "age_s")
+            if age is not None:
+                return age <= limit
+        for source in (self._market_data, self._data_hub):
+            if source is None:
+                continue
+            fn = getattr(source, "time_since_last_tick", None)
+            if callable(fn):
+                try:
+                    age = fn(symbol)
+                except Exception:
+                    continue
+                if age is not None:
+                    return float(age) <= limit
+        return False
+
     def _is_context_symbol(self, symbol: str) -> bool:
         """Return True when symbol is a context-only spot/futures instrument. Args: symbol. Returns: bool. Raises: none."""
         value = str(symbol or "").upper()
@@ -7560,11 +7618,19 @@ class StrategyRunner:
         option_score = max(0.0, min(10.0, option_score))
         data_score = max(0.0, min(10.0, data_score))
         rr_score = max(0.0, min(10.0, rr_score))
+        premium_rr = (float(calculated_tp) - float(price)) / max(float(price) - float(calculated_sl), 1e-9)
+        confidence = max(
+            0.55,
+            min(
+                0.85,
+                (direction_score + strategy_score + option_score + data_score + rr_score) / 50.0,
+            ),
+        )
         return Signal(
             action="BUY",
             symbol=symbol,
             quantity=1,
-            confidence=0.72,
+            confidence=confidence,
             reason="premium_momentum_squeeze",
             stop_loss=calculated_sl,
             take_profit=calculated_tp,
@@ -7575,15 +7641,85 @@ class StrategyRunner:
                 "tag": "premium_squeeze",
                 "feature": "premium_momentum_squeeze",
                 "strategy_name": "premium_momentum_squeeze",
+                "is_selected_option": bool(selected),
+                "strike_distance_from_atm": abs(strike - atm_strike_float) if strike > 0 and atm_strike_float > 0 else None,
+                "premium_stop_distance": max(float(price) - float(calculated_sl), 0.0),
+                "premium_target_rr": premium_rr,
                 "direction_score": direction_score,
                 "strategy_score": strategy_score,
                 "setup_quality": strategy_score,
-                "confidence": 0.72,
+                "confidence": confidence,
                 "option_score": option_score,
                 "data_score": data_score,
                 "rr_score": rr_score,
             },
         )
+
+    def _materialize_option_trade_plan(
+        self,
+        signal: Signal,
+        *,
+        execution_price: float,
+        atr: float,
+        entry_side: OrderSide,
+    ) -> Signal:
+        """Build final long-option SL/TP from metadata, then normalize geometry."""
+        metadata = dict(signal.metadata or {})
+        entry_price = float(execution_price or metadata.get("entry_price") or metadata.get("price") or 0.0)
+        if entry_price <= 0:
+            return signal
+
+        def _to_float(value: Any) -> float | None:
+            try:
+                return None if value is None else float(value)
+            except (TypeError, ValueError):
+                return None
+
+        stop_loss = _to_float(signal.stop_loss)
+        take_profit = _to_float(signal.take_profit)
+        rr = _to_float(metadata.get("premium_target_rr")) or 2.0
+        stop_distance = _to_float(metadata.get("premium_stop_distance"))
+        explicit_stop = _to_float(metadata.get("setup_invalidation_premium")) or _to_float(metadata.get("premium_stop_price"))
+        plan_source = "existing_signal_levels"
+        if stop_loss is None or stop_loss <= 0 or take_profit is None or take_profit <= 0:
+            if metadata.get("premium_stop_pct") is not None:
+                signal = self._apply_premium_targets(signal, premium=entry_price, entry_side=entry_side)
+                stop_loss = _to_float(signal.stop_loss)
+                take_profit = _to_float(signal.take_profit)
+                plan_source = "premium_stop_pct"
+            else:
+                distance = stop_distance if stop_distance is not None and stop_distance > 0 else max(atr * 1.2, entry_price * 0.02, 1.0)
+                if explicit_stop is not None and explicit_stop > 0 and str(entry_side).upper() == "BUY":
+                    stop_loss = explicit_stop
+                    plan_source = "explicit_premium_stop"
+                else:
+                    stop_loss = entry_price - distance
+                    plan_source = "premium_stop_distance"
+                risk = max(entry_price - float(stop_loss), max(atr * 0.8, 1.0))
+                take_profit = entry_price + risk * rr
+            signal = dataclasses.replace(
+                signal,
+                stop_loss=float(stop_loss) if stop_loss is not None else None,
+                take_profit=float(take_profit) if take_profit is not None else None,
+                metadata={**metadata, "entry_price": entry_price, "option_trade_plan_source": plan_source},
+            )
+        signal = self._validate_long_option_geometry(signal=signal, entry_price=entry_price, entry_side=entry_side, atr=atr)
+        signal = self._anchor_sl_tp_to_execution(signal=signal, signal_price=entry_price, execution_price=entry_price, entry_side=entry_side, atr=atr)
+        final_md = dict(signal.metadata or {})
+        final_md["entry_price"] = entry_price
+        final_md["stop_loss"] = signal.stop_loss
+        final_md["take_profit"] = signal.take_profit
+        final_md["materialized_trade_plan"] = True
+        final_md["option_trade_plan_source"] = final_md.get("option_trade_plan_source", plan_source)
+        self._logger.info(
+            "OPTION_TRADE_PLAN_MATERIALIZED symbol=%s entry=%.2f sl=%s tp=%s source=%s",
+            signal.symbol,
+            entry_price,
+            signal.stop_loss,
+            signal.take_profit,
+            final_md.get("option_trade_plan_source"),
+        )
+        return dataclasses.replace(signal, metadata=final_md)
 
     def _handle_signal(
         self,
@@ -8234,17 +8370,30 @@ class StrategyRunner:
                 signal_symbol = normalize_symbol(signal.symbol)
                 selected_ce = normalize_symbol(str(metadata.get("selected_ce") or self._selected_ce_symbol or ""))
                 selected_pe = normalize_symbol(str(metadata.get("selected_pe") or self._selected_pe_symbol or ""))
-                quote = self.get_quote(signal.symbol)
-                quote_fresh = bool(isinstance(quote, dict) and quote.get("ltp"))
-                selected_or_near = signal_symbol in {selected_ce, selected_pe} or bool(metadata.get("is_selected_option"))
-                sl_ok = signal.stop_loss is not None and signal.take_profit is not None
-                self._reset_execution_state(base_symbol)
-                _trace("missing_candidate_snapshots")
-                return self._reject_signal_execution(
-                    symbol=base_symbol,
-                    trace_id=trace_id,
-                    reason="missing_candidate_snapshots",
+                strike_distance = float(metadata.get("strike_distance_from_atm") or 999.0)
+                selected_or_near = (
+                    signal_symbol in {selected_ce, selected_pe}
+                    or bool(metadata.get("is_selected_option"))
+                    or strike_distance <= float(os.getenv("PREMIUM_FALLBACK_MAX_STRIKE_DISTANCE", "100") or 100)
                 )
+                quote_fresh = self._is_option_symbol_tick_fresh(
+                    signal.symbol,
+                    max_age_s=float(os.getenv("ORDER_MAX_QUOTE_AGE_MS", "60000") or "60000") / 1000.0,
+                )
+                sl_ok = signal.stop_loss is not None and signal.take_profit is not None
+                if selected_or_near and quote_fresh and sl_ok:
+                    metadata["candidate_selected"] = True
+                    metadata["candidate_symbol"] = signal.symbol
+                    metadata["quote_usable_for_order_plan"] = True
+                    signal = dataclasses.replace(signal, metadata=metadata)
+                else:
+                    self._reset_execution_state(base_symbol)
+                    _trace("missing_candidate_snapshots")
+                    return self._reject_signal_execution(
+                        symbol=base_symbol,
+                        trace_id=trace_id,
+                        reason="missing_candidate_snapshots",
+                    )
             if isinstance(candidate_snapshots_obj, list):
                 atm_strike = int(metadata.get("atm_strike") or 0)
                 if atm_strike <= 0:
@@ -8366,7 +8515,7 @@ class StrategyRunner:
             )
             metadata.setdefault(
                 "option_score",
-                float(metadata.get("option_quality", quality_hint) or quality_hint),
+                float(metadata.get("option_quality", 5.5) or 5.5),
             )
             metadata.setdefault(
                 "data_score",
@@ -8428,6 +8577,7 @@ class StrategyRunner:
                         },
                     )
                     self._reset_execution_state(base_symbol)
+                    _trace("final_score_required")
                     return SignalExecutionResult(False, "final_score_required")
             missing_components = missing_score_components(metadata)
             if missing_components and reason_key == "premium_momentum_squeeze":
@@ -8509,6 +8659,7 @@ class StrategyRunner:
                         },
                     )
                     self._reset_execution_state(base_symbol)
+                    _trace("final_score_required")
                     return SignalExecutionResult(False, "final_score_required")
             if not quality.allowed:
                 delta = quality.final_score - float(quality.components.get("threshold", 0.0) or 0.0)

--- a/src/nifty_scalper_bot/strategies/signal_quality.py
+++ b/src/nifty_scalper_bot/strategies/signal_quality.py
@@ -26,6 +26,16 @@ def infer_option_side(symbol: str, metadata: dict[str, object] | None = None) ->
     return str(payload.get('direction_bias', 'UNKNOWN')).upper()
 
 
+def resolve_signal_domain(symbol: str, metadata: dict[str, object] | None = None) -> tuple[str, bool, bool]:
+    """Return (contract_side, option_premium_domain, underlying_domain)."""
+    payload = dict(metadata or {})
+    contract_side = infer_option_side(symbol, payload)
+    source_symbol = str(payload.get("source_symbol") or "").strip().upper()
+    option_symbol = str(symbol or "").upper().endswith(("CE", "PE"))
+    option_premium_domain = bool(option_symbol and not source_symbol)
+    underlying_domain = bool(source_symbol)
+    return contract_side, option_premium_domain, underlying_domain
+
 @dataclass(slots=True)
 class SignalQualityScore:
     """Args: score components. Returns: normalized score object. Raises: none."""

--- a/src/nifty_scalper_bot/strategies/trade_selector.py
+++ b/src/nifty_scalper_bot/strategies/trade_selector.py
@@ -51,10 +51,10 @@ class TradeCandidateSelector:
 
     def _limits(self) -> tuple[float, float, int]:
         if self.quality_mode == 'strict':
-            return 0.03, 5.0, 2
+            return 3.0, 5.0, 2
         if self.quality_mode == 'loose':
-            return 0.07, 15.0, 1
-        return 0.05, 10.0, 1
+            return 7.0, 15.0, 1
+        return 5.0, 10.0, 1
 
     def select_ranked_candidates(self, *, direction_bias: str, atm_strike: int, snapshots: list[dict[str, Any]]) -> list[TradeCandidate]:
         max_spread, max_age, min_ticks = self._limits()
@@ -100,7 +100,7 @@ class TradeCandidateSelector:
             spread_pct: float | None = None
             if has_bid_ask:
                 mid = ((bid or 0.0) + (ask or 0.0)) / 2.0
-                spread_pct = ((ask or 0.0) - (bid or 0.0)) / mid if mid > 0 else 1.0
+                spread_pct = (((ask or 0.0) - (bid or 0.0)) / mid * 100.0) if mid > 0 else 100.0
                 if spread_pct > max_spread:
                     rejects['spread_too_wide'] += 1
                     continue
@@ -129,7 +129,9 @@ class TradeCandidateSelector:
             liquidity = 5.0 if spread_pct is None else max(0.0, 10.0 - spread_pct * 100.0)
             micro = min(10.0, real_ticks * 3.0)
             score = 6.0 + liquidity * 0.2 + micro * 0.2 - atm_distance * 0.5 - score_penalty
-            ranked.append(TradeCandidate(symbol=symbol, side=side, score=score, reasons=reasons, spread_pct=spread_pct, tick_age_s=tick_age_s, premium=premium, atm_distance=atm_distance, data_quality_score=10.0, entry_price=entry, stop_loss=sl, target=target, rr=rr, liquidity_score=liquidity, microstructure_score=micro, final_score=score))
+            dq = self.evaluate_data_quality(s)
+            final = max(0.0, min(10.0, 0.7 * score + 0.3 * dq.score))
+            ranked.append(TradeCandidate(symbol=symbol, side=side, score=final, reasons=reasons, spread_pct=spread_pct, tick_age_s=tick_age_s, premium=premium, atm_distance=atm_distance, data_quality_score=dq.score, entry_price=entry, stop_loss=sl, target=target, rr=rr, liquidity_score=liquidity, microstructure_score=micro, final_score=final))
         sorted_ranked = sorted(ranked, key=lambda c: c.final_score or 0.0, reverse=True)
         key = f'candidate_summary_empty:{direction_bias}:{atm_strike}'
         event_extra = {'event': 'CANDIDATE_SELECTION_SUMMARY', 'direction': direction_bias, 'atm': atm_strike, 'total': len(snapshots), 'ranked': len(sorted_ranked), 'rejects': rejects, 'ltp_only_used': ltp_only_used}
@@ -159,7 +161,7 @@ class TradeCandidateSelector:
             score -= 3.0
         else:
             mid = ((bid or 0.0) + (ask or 0.0)) / 2.0
-            spread_pct = ((ask or 0.0) - (bid or 0.0)) / mid if mid > 0 else 1.0
+            spread_pct = (((ask or 0.0) - (bid or 0.0)) / mid * 100.0) if mid > 0 else 100.0
             if spread_pct > max_spread:
                 reasons.append('spread_too_wide')
                 score -= 3.0


### PR DESCRIPTION
### Motivation
- Prevent runtime failures when optional dependency `tenacity` is not installed and ensure retry primitives remain available for data providers.
- Separate option-premium domain logic from underlying-direction logic to avoid CE/PE flips and ensure long-option SL/TP geometry is premium-based and safe.
- Allow selected-option live execution when candidate snapshots are missing but the selected option has a fresh quote and valid SL/TP so live paths are not rejected unnecessarily.
- Treat bid/ask spread as a percent execution cost and integrate data-quality into candidate scoring to avoid misleading candidate ranking.

### Description
- `src/nifty_scalper_bot/data/robust_provider.py`: replaced direct `tenacity` import with an optional fallback that exposes `retry`, `stop_after_attempt`, `wait_exponential`, `retry_if_exception_type`, and `before_sleep_log` shim implementations so imports do not fail in clean environments.
- `src/nifty_scalper_bot/strategies/signal_quality.py`: added `resolve_signal_domain()` to return `(contract_side, option_premium_domain, underlying_domain)` and decouple contract side inference from domain detection.
- `src/nifty_scalper_bot/strategies/runner.py`: added `get_quote`, `_is_tradable_option_symbol`, and `_is_option_symbol_tick_fresh` helpers; introduced `_materialize_option_trade_plan()` to build premium-domain SL/TP anchored to execution price and normalized geometry; changed missing `option_score` default to `5.5` to avoid inflation from trigger confidence; completed premium-squeeze metadata (bounded `confidence`, `premium_target_rr`, `premium_stop_distance`, etc.); updated live path to allow selected/near-ATM option execution when quote freshness and SL/TP are valid and inserted `_trace` before certain early returns required by trading-path trace coverage.
- `src/nifty_scalper_bot/core/strategy_manager.py`: added `_single_vote_thresholds()` and updated single-vote logic to allow VWAP-specific, lower-threshold preliminary acceptance while preserving `trigger_strategy_score` and introducing `consensus_score` metadata.
- `src/nifty_scalper_bot/strategies/trade_selector.py`: corrected `_limits()` to return spread thresholds in percent units, changed spread calculations to percent (`* 100.0`), used `evaluate_data_quality()` to blend candidate `final` score (70% original score, 30% data quality) and no longer hardcode `data_quality_score=10.0`.

### Testing
- Ran targeted compilation with `python -m compileall` against the modified modules (`robust_provider.py`, `signal_quality.py`, `runner.py`, `trade_selector.py`, `strategy_manager.py`) and the compilation succeeded for those files.
- There were no new unit tests executed in this patch; existing test suite was not modified in this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01372f8e208324bb3264146428ab44)