### PR TITLE
fix: enforce option-premium domain and anchor CE/PE side for VWAPPro and OrderFlow

### DIFF
--- a/src/nifty_scalper_bot/strategies/elite_strategies/order_flow.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/order_flow.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from nifty_scalper_bot.strategies.elite_strategies.base_elite import EliteSignal, EliteStrategy
 from nifty_scalper_bot.strategies.elite_strategies.config_models import OrderFlowStrategyConfig
+from nifty_scalper_bot.strategies.signal_quality import resolve_signal_domain
 from nifty_scalper_bot.utils.logging import get_logger
 
 LOGGER = get_logger(__name__)
@@ -34,6 +35,7 @@ class OrderFlowStrategy(EliteStrategy):
             depth = indicators.get('depth') or {}
             tick_direction = str(indicators.get('tick_direction') or '').upper()
             direction = str(indicators.get('direction_bias') or '').upper()
+            contract_side, option_premium_domain, _ = resolve_signal_domain(symbol, indicators)
             atr = max(float(indicators.get('atr') or 0.0), current_price * 0.01, 1.0)
 
             if bid <= 0 or ask <= 0 or ask <= bid:
@@ -66,7 +68,7 @@ class OrderFlowStrategy(EliteStrategy):
                     self._no_vote('spread_unavailable_for_ltp_fallback')
                     return None
                 tick_direction = str(indicators.get('tick_direction') or '').upper()
-                side = 'CE' if tick_direction in {'UP', 'BUY'} else 'PE'
+                side = contract_side if option_premium_domain else ('CE' if tick_direction in {'UP', 'BUY'} else 'PE')
                 depth_imbalance = 0.0
                 fallback_score = 2.0 + (2.0 if spread_pct <= 12.0 else 0.0)
                 if direction in {'CE', 'PE'} and direction == side:
@@ -81,7 +83,10 @@ class OrderFlowStrategy(EliteStrategy):
                 metadata.update({'strategy': 'OrderFlow', 'strategy_name': 'OrderFlow', 'role': 'context', 'source_domain': 'market_microstructure', 'context_score': strategy_score, 'side': side, 'direction_bias': side, 'strategy_score': strategy_score, 'spread_pct': round(spread_pct, 3), 'depth_imbalance': 0.0, 'tick_direction': tick_direction, 'invalidation_level': bid - 0.5 * atr if side == 'CE' else ask + 0.5 * atr})
                 return EliteSignal(symbol=symbol, signal='BUY', confidence=max(0.1, min(0.85, strategy_score / 10.0)), entry_price=current_price, stop_loss=float(metadata['invalidation_level']), target=current_price + (1.8 * atr), quantity=self._cfg.quantity or 1, strategy_name='OrderFlow', metadata=metadata)
             depth_imbalance = (total_bid - total_ask) / max(total_bid + total_ask, 1.0)
-            side = 'CE' if depth_imbalance > 0 else 'PE'
+            side = contract_side if option_premium_domain else ('CE' if depth_imbalance > 0 else 'PE')
+            if option_premium_domain and depth_imbalance <= 0 and tick_direction not in {'UP', 'BUY'}:
+                self._no_vote('negative_premium_flow')
+                return None
 
             score = 0.0
             reasons: list[str] = []

--- a/src/nifty_scalper_bot/strategies/elite_strategies/vwap_pro.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/vwap_pro.py
@@ -5,7 +5,7 @@ from typing import Any
 
 from nifty_scalper_bot.strategies.elite_strategies.base_elite import EliteSignal, EliteStrategy
 from nifty_scalper_bot.strategies.elite_strategies.config_models import VWAPProStrategyConfig
-from nifty_scalper_bot.strategies.signal_quality import infer_option_side
+from nifty_scalper_bot.strategies.signal_quality import resolve_signal_domain
 from nifty_scalper_bot.utils.logging import get_logger
 
 LOGGER = get_logger(__name__)
@@ -74,7 +74,7 @@ class VWAPProStrategy(EliteStrategy):
 
             score = 0.0
             reasons: list[str] = []
-            contract_side = infer_option_side(symbol, indicators)
+            contract_side, option_premium_domain, _ = resolve_signal_domain(symbol, indicators)
             trend_alignment = False
             pullback_flag = False
             continuation_confirmed = False
@@ -87,6 +87,9 @@ class VWAPProStrategy(EliteStrategy):
                     self._no_vote('unknown_contract_side')
                     LOGGER.debug('STRATEGY_NO_VOTE strategy=VWAPPro reason=unknown_contract_side')
                     return None
+            if not option_premium_domain:
+                self._no_vote('invalid_price_domain')
+                return None
             premium_above_vwap = current_price >= vwap
             if premium_above_vwap:
                 score += 2.0
@@ -96,17 +99,17 @@ class VWAPProStrategy(EliteStrategy):
             atr_safe = max(atr, current_price * 0.01, 1.0)
             continuation_confirmed = candle_body >= (0.35 * atr_safe)
             if continuation_confirmed:
-                score += 2.0
-                reasons.append('continuation_confirmed')
+                score += 1.5
+                reasons.append('premium_continuation')
 
             reclaim_from_below = low <= (vwap - (atr_safe * self._slack_atr_mult * 0.2)) and close >= vwap
             if self._allow_pullback and reclaim_from_below:
                 pullback_flag = True
-                score += 1.0
-                reasons.append('premium_reclaim')
+                score += 1.5
+                reasons.append('premium_reclaim_vwap')
 
             if distance_pct <= self._max_distance_pct * 0.7:
-                score += 2.0
+                score += 1.0
                 reasons.append('not_overextended')
 
             if avg_vol > 0 and vol >= 0.6 * avg_vol:
@@ -121,13 +124,13 @@ class VWAPProStrategy(EliteStrategy):
                     score -= 2.0
                     reasons.append('direction_conflict')
 
-            if score < 3.0:
+            if score < 5.5:
                 self._no_vote('weak_score')
                 LOGGER.debug('STRATEGY_NO_VOTE strategy=VWAPPro reason=low_score')
                 return None
 
             strategy_score = max(0.0, min(10.0, score))
-            confidence = max(0.1, min(0.85, strategy_score / 10.0))
+            confidence = max(0.45, min(0.85, strategy_score / 10.0))
             metadata = {
                 'strategy': 'VWAPPro',
                 'strategy_name': 'VWAPPro',


### PR DESCRIPTION
### Motivation
- Ensure option-premium strategies evaluate the contract premium domain (not underlying) and never invert CE/PE side based on premium action or microstructure signals.
- Tighten VWAP trigger quality so weak premium-domain votes (score 3–4) do not enter consensus and keep confidence bounds deterministic.
- Preserve OrderFlow as a context-only signal while allowing safe LTP fallback and preventing it from flipping contract side in premium-domain cases.

### Description
- Replaced symbol-side inference in the VWAP trigger with `resolve_signal_domain(symbol, indicators)` and added an explicit guard that rejects non-option-premium domains in `VWAPProStrategy._evaluate_signal`.
- Reworked VWAP scoring to use premium-domain reasons (`premium_above_vwap`, `premium_reclaim_vwap`, `premium_continuation`, `not_overextended`), raised the minimum emission gate to `>= 5.5`, and bounded confidence to `0.45–0.85`.
- Updated `OrderFlowStrategy` to import `resolve_signal_domain`, anchor `side` to `contract_side` when `option_premium_domain` is true, and return `None` on clearly negative premium-flow instead of flipping CE↔PE.
- Kept OrderFlow behavior as a context vote with the existing LTP fallback guarded by `ORDERFLOW_ALLOW_LTP_TICK_FALLBACK` and preserved reduced-confidence metadata when fallback is used.

### Testing
- Ran targeted unit tests: `pytest -q tests/strategies/test_vwap_pro_premium_domain.py tests/strategies/test_vwap_pro_side_domain.py tests/strategies/test_trade_selector.py`, and they all passed.
- Ran `python -m compileall src`, which completed successfully (noting an existing `SyntaxWarning` in `order_manager.py` unrelated to these changes).
- Ran full test suite `pytest -q tests`, which failed early due to an unrelated environment/import issue: `ModuleNotFoundError: No module named 'market_data_manager'` in existing tests, not caused by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01458203f88324b41f4aa3dd8d8094)