### PR TITLE
fix: add feature capability helper and baseline failure record

### DIFF
--- a/docs/refactor_baseline_test_failures.md
+++ b/docs/refactor_baseline_test_failures.md
@@ -1,0 +1,9 @@
+# Baseline test failures (pre-refactor)
+
+## Commands run
+- `python -m compileall src`
+- `pytest -q tests`
+
+## Failures observed
+1. `tests/test_mdm_diagnostics.py` import error:
+   - `ModuleNotFoundError: No module named 'market_data_manager'`

--- a/src/nifty_scalper_bot/strategies/indicators.py
+++ b/src/nifty_scalper_bot/strategies/indicators.py
@@ -28,6 +28,20 @@ _MARKET_CLOSE = time(hour=15, minute=30)
 
 LOGGER = get_logger(__name__)
 
+_FEATURE_CAPABILITIES: dict[str, bool] = {
+    'vwap': True,
+    'bollinger': True,
+    'orb_levels': True,
+    'cpr_levels': False,
+    'structure_flags': False,
+    'order_book_depth': True,
+}
+
+
+def supports_feature(name: str) -> bool:
+    """Args: name. Returns: feature support status. Raises: none."""
+    return bool(_FEATURE_CAPABILITIES.get(str(name).strip().lower(), False))
+
 
 class PriceHistory:
     """Store OHLCV data efficiently.
@@ -1733,12 +1747,4 @@ class IndicatorEngine:
 
     def supports_feature(self, feature_name: str) -> bool:
         """Args: feature_name. Returns: support flag. Raises: none."""
-        capability_map = {
-            "cpr_levels": False,
-            "structure_flags": False,
-            "orb_levels": True,
-            "bollinger": True,
-            "order_book_depth": True,
-            "vwap": True,
-        }
-        return bool(capability_map.get(str(feature_name).strip().lower(), False))
+        return supports_feature(feature_name)

--- a/tests/strategies/test_indicator_capabilities.py
+++ b/tests/strategies/test_indicator_capabilities.py
@@ -1,0 +1,10 @@
+from nifty_scalper_bot.strategies.indicators import supports_feature
+
+
+def test_indicator_capabilities_matrix() -> None:
+    assert supports_feature('vwap') is True
+    assert supports_feature('bollinger') is True
+    assert supports_feature('orb_levels') is True
+    assert supports_feature('cpr_levels') is False
+    assert supports_feature('structure_flags') is False
+    assert supports_feature('order_book_depth') is True


### PR DESCRIPTION
### Motivation
- Make indicator capability gating explicit and reusable so strategy/builder code can safely query supported features and to record the pre-refactor baseline test failure discovered during initial checks.

### Description
- Added a module-level `_FEATURE_CAPABILITIES` map and a `supports_feature(name)` helper in `src/nifty_scalper_bot/strategies/indicators.py`, and updated `IndicatorEngine.supports_feature` to delegate to it; added `tests/strategies/test_indicator_capabilities.py` to validate capability flags and captured the baseline failure in `docs/refactor_baseline_test_failures.md`.

### Testing
- Ran `python -m compileall src` (success) and executed `pytest -q tests/strategies/test_indicator_capabilities.py tests/strategies/test_elite_no_vote_reasons.py tests/core/test_strategy_manager_consensus.py` (all passed), and documented a pre-existing failing test `tests/test_mdm_diagnostics.py` with `ModuleNotFoundError: No module named 'market_data_manager'` in `docs/refactor_baseline_test_failures.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01498f77588324b6cc0b0753524492)