### PR TITLE
fix: restore live quote preservation and candidate scoring path

### DIFF
--- a/src/nifty_scalper_bot/core/strategy_manager.py
+++ b/src/nifty_scalper_bot/core/strategy_manager.py
@@ -2206,6 +2206,10 @@ class StrategyManager(_BaseStrategyManager):
         errors: list[str] = []
         disabled_strategies_snapshot = disabled
         evaluation_start = time.monotonic()
+        symbol_upper = symbol.upper()
+        symbol_is_option = bool(re.search(r"(CE|PE)$", symbol_upper))
+        symbol_is_future = symbol_upper.endswith("FUT")
+        direction_bias = str(indicators.get("direction_bias") or "").upper()
         for strategy in self._strategies:
             if strategy.name in self._disabled_strategies:
                 disabled.append(strategy.name)
@@ -2216,6 +2220,37 @@ class StrategyManager(_BaseStrategyManager):
                         "strategy": strategy.name,
                         "symbol": symbol,
                     },
+                )
+                continue
+            strategy_name = str(getattr(strategy, "name", "") or "")
+            if strategy_name in {"VWAPPro", "OrderFlow"} and (
+                (symbol_is_future or not symbol_is_option)
+                and direction_bias not in {"CE", "PE"}
+            ):
+                no_vote_reason_counts["context_symbol_skipped_for_option_strategy"] = (
+                    no_vote_reason_counts.get(
+                        "context_symbol_skipped_for_option_strategy", 0
+                    )
+                    + 1
+                )
+                log_throttled(
+                    log,
+                    key=f"strategy_domain_skip:{symbol}:{strategy_name}",
+                    msg=(
+                        "STRATEGY_NO_VOTE strategy=%s symbol=%s "
+                        "reason=context_symbol_skipped_for_option_strategy"
+                    ),
+                    args=(strategy_name, symbol),
+                    interval_sec=30.0,
+                    level=logging.INFO,
+                )
+                continue
+            if strategy_name == "BBSqueeze" and symbol_is_option:
+                no_vote_reason_counts["context_symbol_skipped_for_underlying_strategy"] = (
+                    no_vote_reason_counts.get(
+                        "context_symbol_skipped_for_underlying_strategy", 0
+                    )
+                    + 1
                 )
                 continue
             try:

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -4625,7 +4625,8 @@ class MarketDataManager:
         # StrategyRunner's per-symbol callbacks) were registered in _subscribers
         # but NEVER called from the WS path — _store_tick only cached the tick.
         # _emit_tick is the correct call; it was defined but never invoked.
-        tick_dict = tick.to_dict()
+        tick_dict = {**to_json_safe(dict(raw)), **tick.to_dict()}
+        tick_dict["symbol"] = symbol
         tick_dict["timestamp"] = pd.to_datetime(
             tick_dict["timestamp"], utc=True, errors="coerce"
         ).isoformat()
@@ -4639,12 +4640,8 @@ class MarketDataManager:
         tick_dict["received_at"] = raw.get("received_at", time.time())
         if raw.get("exchange_timestamp") is not None:
             tick_dict["exchange_timestamp"] = raw.get("exchange_timestamp")
-        if raw.get("volume_traded") is not None:
-            tick_dict["volume_traded"] = raw.get("volume_traded")
-        if raw.get("volume_traded_today") is not None:
-            tick_dict["volume_traded_today"] = raw.get("volume_traded_today")
-        if raw.get("oi") is not None:
-            tick_dict["oi"] = raw.get("oi")
+        if raw.get("depth") is not None:
+            tick_dict["depth"] = raw.get("depth")
 
         # Structured Logging for tick received (Objective 6)
         try:
@@ -6973,14 +6970,45 @@ class MarketDataManager:
             if pd.isna(ts):
                 ts = pd.Timestamp.utcnow()
             ts_py = ts.to_pydatetime().astimezone(timezone.utc)
+            bid = _coerce_float(
+                raw.get("bid")
+                or raw.get("best_bid")
+                or raw.get("buy_price")
+                or raw.get("best_bid_price")
+            )
+            ask = _coerce_float(
+                raw.get("ask")
+                or raw.get("best_ask")
+                or raw.get("sell_price")
+                or raw.get("best_ask_price")
+            )
+            depth_obj = raw.get("depth") if isinstance(raw.get("depth"), Mapping) else None
+            bid_ask_source = "missing"
+            if bid is not None and ask is not None:
+                bid_ask_source = "ws_full"
+            elif depth_obj:
+                buy_levels = depth_obj.get("buy") if isinstance(depth_obj, Mapping) else None
+                sell_levels = depth_obj.get("sell") if isinstance(depth_obj, Mapping) else None
+                if isinstance(buy_levels, list) and buy_levels:
+                    bid = _coerce_float((buy_levels[0] or {}).get("price"))
+                if isinstance(sell_levels, list) and sell_levels:
+                    ask = _coerce_float((sell_levels[0] or {}).get("price"))
+                bid_ask_source = "market_depth"
+            tradable_quote = bool(
+                bid is not None and ask is not None and bid > 0 and ask > bid
+            )
             return {
                 "symbol": self._canonical_symbol(symbol),
                 "token": token,
                 "ltp": ltp,
-                "bid": _coerce_float(raw.get("bid")),
-                "ask": _coerce_float(raw.get("ask")),
+                "bid": bid,
+                "ask": ask,
                 "volume": _coerce_int(raw.get("volume") or raw.get("volume_traded") or raw.get("volume_traded_today")),
                 "oi": _coerce_int(raw.get("oi")),
+                "depth": depth_obj,
+                "depth_available": bool(depth_obj),
+                "bid_ask_source": bid_ask_source,
+                "tradable_quote": tradable_quote,
                 "timestamp": ts_py,
                 "source": "poll" if str(source).lower() == "poll" else "ws",
             }

--- a/src/nifty_scalper_bot/strategies/elite_strategies/vwap_pro.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/vwap_pro.py
@@ -83,6 +83,14 @@ class VWAPProStrategy(EliteStrategy):
                 fallback_side = str(indicators.get('direction_bias') or '').upper()
                 if fallback_side in {'CE', 'PE'}:
                     contract_side = fallback_side
+                elif symbol.upper().endswith('CE'):
+                    contract_side = 'CE'
+                    score -= 1.0
+                    reasons.append('symbol_side_fallback')
+                elif symbol.upper().endswith('PE'):
+                    contract_side = 'PE'
+                    score -= 1.0
+                    reasons.append('symbol_side_fallback')
                 else:
                     self._no_vote('unknown_contract_side')
                     LOGGER.debug('STRATEGY_NO_VOTE strategy=VWAPPro reason=unknown_contract_side')
@@ -126,7 +134,20 @@ class VWAPProStrategy(EliteStrategy):
 
             if score < 5.5:
                 self._no_vote('weak_score')
-                LOGGER.debug('STRATEGY_NO_VOTE strategy=VWAPPro reason=low_score')
+                LOGGER.info(
+                    'STRATEGY_NO_VOTE strategy=VWAPPro reason=weak_score score=%.2f direction=%s contract_side=%s current_price=%.2f vwap=%.2f distance_pct=%.4f atr=%.2f volume=%.2f avg_volume=%.2f trend_alignment=%s pullback_flag=%s',
+                    score,
+                    direction,
+                    contract_side,
+                    current_price,
+                    vwap,
+                    distance_pct,
+                    atr_safe,
+                    vol,
+                    avg_vol,
+                    trend_alignment,
+                    pullback_flag,
+                )
                 return None
 
             strategy_score = max(0.0, min(10.0, score))

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -1769,6 +1769,12 @@ class StrategyRunner:
                         "history_bars": int(getattr(snap, "history_bars", 0) or 0),
                         "data_quality_score": float(getattr(snap, "data_quality_score", 0.0) or 0.0),
                         "quote_quality": "bid_ask" if bool(snap.tradable_quote) else "ltp_only",
+                        "ltp_only_fallback": bool(
+                            snap.ltp is not None
+                            and float(snap.ltp) > 0
+                            and not bool(snap.tradable_quote)
+                            and not symbol_refresh_pending
+                        ),
                         "effective_bars": int(getattr(snap, "effective_bars", 0) or 0),
                     }
                 )
@@ -8487,10 +8493,14 @@ class StrategyRunner:
                 metadata["tradable_quote"] = bool(
                     (selected_snapshot or {}).get("tradable_quote")
                 )
+                allow_ltp_live_plan = _env_flag(
+                    "ALLOW_LTP_ONLY_LIVE_ORDER_PLAN", default=False
+                )
                 metadata["quote_usable_for_order_plan"] = bool(
                     (selected_snapshot or {}).get("tradable_quote")
                     or (
-                        (selected_snapshot or {}).get("ltp_only_fallback")
+                        allow_ltp_live_plan
+                        and (selected_snapshot or {}).get("ltp_only_fallback")
                         and candidate.entry_price
                         and candidate.stop_loss
                         and candidate.target

--- a/src/nifty_scalper_bot/strategies/trade_selector.py
+++ b/src/nifty_scalper_bot/strategies/trade_selector.py
@@ -64,7 +64,7 @@ class TradeCandidateSelector:
             max_age = float(self.max_tick_age_s)
         if self.require_real_ticks_last_60s is not None:
             min_ticks = int(self.require_real_ticks_last_60s)
-        allow_ltp_only = os.getenv('ALLOW_LTP_ONLY_CANDIDATE', 'true').lower() in {'1', 'true', 'yes', 'on'}
+        allow_ltp_only = os.getenv('ALLOW_LTP_ONLY_CANDIDATE', 'false').lower() in {'1', 'true', 'yes', 'on'}
         ranked: list[TradeCandidate] = []
         rejects = {'side_mismatch': 0, 'atm_distance': 0, 'missing_bid_ask': 0, 'premium_out_of_range': 0, 'spread_too_wide': 0, 'tick_stale': 0, 'insufficient_ticks': 0, 'invalid_rr': 0}
         ltp_only_used = 0
@@ -107,7 +107,9 @@ class TradeCandidateSelector:
                 entry = ask if (ask or 0.0) > 0 else ltp
                 score_penalty = 0.0
             else:
-                ltp_only_flag = bool(s.get('ltp_only_fallback'))
+                ltp_only_flag = bool(s.get('ltp_only_fallback')) or (
+                    str(s.get('quote_quality') or '').lower() == 'ltp_only'
+                )
                 if not (allow_ltp_only and ltp_only_flag):
                     rejects['missing_bid_ask'] += 1
                     continue

--- a/tests/test_ws_depth_preservation.py
+++ b/tests/test_ws_depth_preservation.py
@@ -1,0 +1,31 @@
+from nifty_scalper_bot.data.market_data_manager import MarketDataManager
+
+
+def test_normalize_live_tick_uses_market_depth_bid_ask() -> None:
+    mdm = MarketDataManager()
+    tick = mdm.normalize_live_tick(
+        {
+            'symbol': 'NFO:NIFTY26MAY24000CE',
+            'ltp': 120.0,
+            'depth': {
+                'buy': [{'price': 119.5, 'quantity': 100}],
+                'sell': [{'price': 120.5, 'quantity': 120}],
+            },
+        },
+        source='ws',
+    )
+    assert tick is not None
+    assert tick['bid'] == 119.5
+    assert tick['ask'] == 120.5
+    assert tick['depth_available'] is True
+    assert tick['bid_ask_source'] == 'market_depth'
+    assert tick['tradable_quote'] is True
+
+
+def test_normalize_live_tick_ltp_only_not_tradable() -> None:
+    mdm = MarketDataManager()
+    tick = mdm.normalize_live_tick({'symbol': 'NFO:NIFTY26MAY24000CE', 'ltp': 120.0}, source='ws')
+    assert tick is not None
+    assert tick['bid'] is None
+    assert tick['ask'] is None
+    assert tick['tradable_quote'] is False


### PR DESCRIPTION
### Motivation

- The live system was dropping raw WS FULL-mode fields (depth/bid/ask), causing strategies like `OrderFlow`, `VWAPPro`, and `BBSqueeze` to repeatedly `no_vote` and preventing the candidate-selection/signal-scoring path from running.
- Candidate selection incorrectly assumed an `ltp_only_fallback` flag was present which prevented safe LTP-only evaluation from being used for shadow/paper evaluation while keeping live order safety.
- Option/futures domain mismatches caused option-side strategies to evaluate on inappropriate instruments and spam `invalid_price_domain` / `unknown_contract_side` no-votes.

### Description

- Preserve WS FULL raw fields by merging the raw payload with the validated tick in `MarketDataManager._process_queued_tick` so `depth`, `volume_traded*`, `oi`, and other raw fields survive into normalization.  (`MarketDataManager._process_queued_tick`)
- Enhance `normalize_live_tick()` to derive `bid`/`ask` from direct keys or from `depth.buy[0].price` / `depth.sell[0].price`, preserve `depth` in output, and emit `depth_available`, `bid_ask_source`, and `tradable_quote` without fabricating quotes from LTP.  (`MarketDataManager.normalize_live_tick`)
- In the runner candidate builder (`StrategyRunner.build_candidate_snapshots_async`) populate `ltp_only_fallback` per-snapshot when LTP exists but no tradable bid/ask and refresh is not pending, and expose `quote_quality` consistently.  (`StrategyRunner.build_candidate_snapshots_async`)
- Tighten live-order safety so LTP-only candidates are not considered `quote_usable_for_order_plan` unless explicitly allowed via `ALLOW_LTP_ONLY_LIVE_ORDER_PLAN=true`.  (`StrategyRunner` execution path)
- Align `TradeCandidateSelector` behavior to require explicit opt-in for LTP-only acceptance by default and to accept either an explicit `ltp_only_fallback` or `quote_quality='ltp_only'` when allowed, preserving the score penalty and reasons.  (`TradeCandidateSelector.select_ranked_candidates`)
- Add domain gating in `StrategyManager.generate_signal` to skip option-premium strategies (`VWAPPro`, `OrderFlow`) when evaluating non-option/future context symbols without a direction bias and to skip `BBSqueeze` on option symbols, preventing spurious `invalid_price_domain` / `unknown_contract_side` spam.
- Improve `VWAPPro` resiliency and observability by falling back to symbol-suffix inference for CE/PE (with a score penalty) and richer weak-score diagnostic logging.  (`VWAPProStrategy`)
- Add unit tests to verify WS depth preservation and LTP-only behavior (`tests/test_ws_depth_preservation.py`) and keep/adjust existing candidate LTP fallback tests.

### Testing

- Ran static/compile check with `python -m compileall -q src`; it completed (note: an unrelated existing `SyntaxWarning` in `order_manager.py` was observed). ✅
- Ran targeted pytest suites: `pytest -q tests/test_live_tick_normalization.py tests/test_ws_depth_preservation.py tests/strategies/test_trade_selector_ltp_fallback.py` and all tests passed. ✅
- Changes committed to branch with descriptive message; tests above were used to validate the critical data->candidate path and ensure no regressions in the touched areas. ✅

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a016ece80a883249d675951f5676e04)