### PR TITLE
fix: harden live startup readiness and telegram import safety

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -313,7 +313,7 @@ def _gate_runner_symbol_add(
     except Exception:
         runner_bars = 0
     mdm_bars = len(ctx.market_data_manager.get_ohlc_bars(symbol) or [])
-    required = int(os.getenv("READINESS_OPTION_EVAL_MIN_BARS", os.getenv("OPTION_EVAL_MIN_LIVE_BARS", "1")) or 1)
+    required = int(os.getenv("READINESS_OPTION_EVAL_MIN_BARS", os.getenv("OPTION_EVAL_MIN_LIVE_BARS", "20")) or 20)
     quote_ready = False
     try:
         quote_ready = bool(ctx.market_data_manager.get_symbol_snapshot(symbol))
@@ -6856,8 +6856,8 @@ async def _recompute_and_push_runtime_readiness(ctx: BotContext, *, reason: str)
         except Exception:
             return False
     spot_ready = _quote(spot_symbol) or _bars(spot_symbol) >= 1
-    option_eval_min_live_bars = int(os.getenv("READINESS_OPTION_EVAL_MIN_BARS", os.getenv("OPTION_EVAL_MIN_LIVE_BARS", "1")) or 1)
-    option_execution_min_bars = int(os.getenv("READINESS_OPTION_EXEC_MIN_BARS", os.getenv("OPTION_EXECUTION_MIN_BARS", "5")) or 5)
+    option_eval_min_live_bars = int(os.getenv("READINESS_OPTION_EVAL_MIN_BARS", os.getenv("OPTION_EVAL_MIN_LIVE_BARS", "20")) or 20)
+    option_execution_min_bars = int(os.getenv("READINESS_OPTION_EXEC_MIN_BARS", os.getenv("OPTION_EXECUTION_MIN_BARS", "30")) or 30)
     context_execution_min_bars = int(os.getenv("READINESS_CONTEXT_MIN_BARS", os.getenv("CONTEXT_EXECUTION_MIN_BARS", "20")) or 20)
     await _ensure_selected_options_hydrated(
         ctx, selected_ce, selected_pe, option_execution_min_bars, reason
@@ -7952,7 +7952,7 @@ async def startup_sequence(ctx: BotContext) -> None:
                 return None
 
             active_symbol_tokens: dict[str, int] = {}
-            symbols_to_hydrate_raw = [sym for sym in targets if sym]
+            symbols_to_hydrate_raw = build_active_trading_basket_symbols(ctx, basket)
             symbols_to_hydrate: list[str] = []
             for _sym in symbols_to_hydrate_raw:
                 _tok = _resolve_startup_token(_sym)
@@ -7964,10 +7964,20 @@ async def startup_sequence(ctx: BotContext) -> None:
                     )
                     continue
                 active_symbol_tokens[_sym] = int(_tok)
+                LOGGER.info("ACTIVE_BASKET_TOKEN_RESOLVED symbol=%s token=%s", _sym, int(_tok))
                 symbols_to_hydrate.append(_sym)
-            atm_ce = next((s for s in targets if s.endswith("CE")), None)
-            atm_pe = next((s for s in targets if s.endswith("PE")), None)
-            symbols_to_hydrate = build_active_trading_basket_symbols(ctx, basket)
+            atm_ce = str(basket.get("selected_ce") or basket.get("atm_ce") or "")
+            atm_pe = str(basket.get("selected_pe") or basket.get("atm_pe") or "")
+            if atm_ce and atm_ce not in active_symbol_tokens:
+                LOGGER.error("ACTIVE_BASKET_TOKEN_MISSING symbol=%s fatal_for_live=True", atm_ce)
+            if atm_pe and atm_pe not in active_symbol_tokens:
+                LOGGER.error("ACTIVE_BASKET_TOKEN_MISSING symbol=%s fatal_for_live=True", atm_pe)
+            LOGGER.info(
+                "ACTIVE_BASKET_TOKEN_MAP_READY count=%d selected_ce_token=%s selected_pe_token=%s",
+                len(active_symbol_tokens),
+                active_symbol_tokens.get(atm_ce) if atm_ce else None,
+                active_symbol_tokens.get(atm_pe) if atm_pe else None,
+            )
             LOGGER.info(
                 "HYDRATION_PLAN_STARTUP symbols=%d bars_target=%d lookback_days=%d",
                 len(symbols_to_hydrate),
@@ -9671,8 +9681,7 @@ async def startup_sequence(ctx: BotContext) -> None:
                                         "quote_available": False,
                                     },
                                 )
-                            if live_mode and armed:
-                                ctx.live_orders_armed = True
+                            if live_mode and armed and bool(getattr(ctx, "live_orders_armed", False)):
                                 ctx.trading_ready = bool(ctx.data_hard_ready)
                                 previous_mode = str(getattr(ctx, "readiness_mode", "DATA_WARMUP"))
                                 ctx.readiness_mode = "LIVE_READY"

--- a/src/nifty_scalper_bot/notifications/telegram_commands.py
+++ b/src/nifty_scalper_bot/notifications/telegram_commands.py
@@ -4,10 +4,18 @@ import math
 from bisect import bisect_right
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import Any, Callable, Mapping, Sequence, cast
+from typing import TYPE_CHECKING, Any, Callable, Mapping, Sequence, cast
 
-from telegram import Update
-from telegram.ext import Application, CommandHandler, ContextTypes
+if TYPE_CHECKING:
+    from telegram import Update
+    from telegram.ext import Application, ContextTypes
+else:
+    Update = Any
+    Application = Any
+    class _ContextTypesStub:
+        DEFAULT_TYPE = Any
+
+    ContextTypes = _ContextTypesStub
 
 # Correct imports (utils and logging only)
 from nifty_scalper_bot.notifications.telegram_utils import redact, reply_err, reply_ok
@@ -80,6 +88,17 @@ def _extract_argument(update: Update) -> str:
         return ""
     parts = message.text.split(maxsplit=1)
     return parts[1].strip() if len(parts) >= 2 else ""
+
+
+def _load_command_handler() -> Any | None:
+    """Load telegram CommandHandler lazily. Args: none. Returns: class or None. Raises: never."""
+    try:
+        from telegram.ext import CommandHandler
+
+        return CommandHandler
+    except Exception as exc:
+        LOG.warning("telegram_commands_unavailable: %s", exc)
+        return None
 
 
 def _parse_chain_argument(argument: str) -> tuple[str, str | None]:
@@ -615,17 +634,21 @@ def cmd_emergencystop(_u: Update, _c: ContextTypes.DEFAULT_TYPE, services: Servi
 
 def _command_exists(application: Application, command: str) -> bool:
     """Check if a command handler is already registered."""
+    command_handler_cls = _load_command_handler()
+    if command_handler_cls is None:
+        return False
     for handlers in application.handlers.values():
         for handler in handlers:
-            if isinstance(handler, CommandHandler) and command in handler.commands:
+            if isinstance(handler, command_handler_cls) and command in handler.commands:
                 return True
     return False
 
 
-def register_telegram_commands(
-    bot: Any, application: Application, services: Services
-) -> None:
+def register_telegram_commands(bot: Any, application: Application, services: Services) -> bool:
     """Register production commands with security wrapping."""
+    command_handler_cls = _load_command_handler()
+    if command_handler_cls is None:
+        return False
 
     # 1. Inject correct chat ID from the bot instance if not already set
     if hasattr(bot, "deps") and hasattr(bot.deps, "chat_id"):
@@ -642,7 +665,7 @@ def register_telegram_commands(
 
     for name, handler in aliases.items():
         if not _command_exists(application, name):
-            application.add_handler(CommandHandler(name, handler))
+            application.add_handler(command_handler_cls(name, handler))
 
     # 3. Register local commands with security wrapper
     new_commands: dict[str, CommandFunc] = {
@@ -687,5 +710,6 @@ def register_telegram_commands(
     for name, func in new_commands.items():
         if not _command_exists(application, name):
             application.add_handler(
-                CommandHandler(name, _wrap_command(services, func, name))
+                command_handler_cls(name, _wrap_command(services, func, name))
             )
+    return True

--- a/src/nifty_scalper_bot/strategies/elite_strategies/oi_max_pain.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/oi_max_pain.py
@@ -31,7 +31,7 @@ class OIMaxPainStrategy(EliteStrategy):
             atr = max(float(indicators.get('atr') or 0.0), current_price * 0.01, 1.0)
             direction = str(indicators.get('direction_bias') or '').upper()
             if max_pain <= 0:
-                LOGGER.debug('STRATEGY_NO_VOTE strategy=OIMaxPain reason=missing_oi')
+                self._no_vote('missing_oi_data')
                 return None
 
             context_bias = 'CE' if current_price < max_pain else 'PE'
@@ -47,6 +47,7 @@ class OIMaxPainStrategy(EliteStrategy):
                 reasons.append('near_oi_wall_against_trade')
             strategy_score = max(0.0, min(4.0, score))
             if strategy_score <= 0:
+                self._no_vote('no_max_pain_edge')
                 return None
 
             metadata = {


### PR DESCRIPTION
### Motivation
- Prevent import-time failures when `python-telegram-bot` is not installed so core modules (e.g., `nifty_scalper_bot.core.app`) can import in test and CI environments. 
- Ensure active option basket token resolution, hydration and runner wiring happen deterministically from the final active basket rather than from stale `targets`. 
- Prevent unsafe live-arm transitions by raising hydration/readiness defaults and removing a dual path that could erroneously arm live orders. 

### Description
- Made Telegram imports lazy and optional in `src/nifty_scalper_bot/notifications/telegram_commands.py` using `TYPE_CHECKING` type stubs, a `_ContextTypesStub`, and a runtime `_load_command_handler()` fallback so registration safely no-ops when the dependency is absent and import-time crashes are avoided. 
- Changed `register_telegram_commands()` to return a boolean and to use the lazily-loaded `CommandHandler` class so the rest of the app can import even without `python-telegram-bot`. 
- Reordered startup basket hydration in `src/nifty_scalper_bot/core/app.py` to call `build_active_trading_basket_symbols()` first, then resolve tokens only for that active basket, and emit explicit logs: `ACTIVE_BASKET_TOKEN_RESOLVED`, `ACTIVE_BASKET_TOKEN_MISSING`, and `ACTIVE_BASKET_TOKEN_MAP_READY`. 
- Removed reliance on `next(...endswith("CE"/"PE"))` over stale `targets` and now derive selected CE/PE from basket metadata so selected options are always token-resolved before hydration. 
- Increased default readiness thresholds from unsafe low defaults to production-safe values by setting `READINESS_OPTION_EVAL_MIN_BARS` default to `20` and `READINESS_OPTION_EXEC_MIN_BARS` default to `30`, and updated runner gating to use these values. 
- Prevented the legacy non-authoritative readiness branch from forcing `ctx.live_orders_armed=True` by requiring the authoritative arm state before the older path can transition the startup mode, reducing accidental arming. 
- Fixed OIMaxPain strategy in `src/nifty_scalper_bot/strategies/elite_strategies/oi_max_pain.py` to call `self._no_vote(...)` for missing OI and no-edge scenarios so the StrategyManager receives explicit no-vote reasons instead of silent `None` returns. 

### Testing
- Ran `python -m compileall -q src` and compilation succeeded. 
- Executed the focused test suite via `PYTHONPATH=src pytest -q` for the required tests (including `tests/test_core_app_import_without_telegram.py`, `tests/test_active_basket_hydration.py`, `tests/test_selected_option_runner_sync.py`, `tests/test_live_arm_blocks_low_history.py`, `tests/test_active_symbol_wiring.py`, `tests/test_live_tick_pipeline_to_runner.py`, `tests/test_indicator_readiness.py`, `tests/test_strategy_domain_routing.py`, `tests/test_quote_quality_orderflow.py`, `tests/test_direction_arbitration.py`, `tests/test_single_vote_score_decomposition.py`, `tests/test_ws_depth_preservation.py`, `tests/test_strategy_manager_consensus.py`, `tests/test_execution_path_contract.py`, and `tests/test_bus_to_runner_tick_path.py`). 
- Result: all automated tests in the above run passed (30 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02b29b942c83248a40195e5ae761d5)