### PR TITLE
fix: harden telegram notifier startup wiring

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -920,15 +920,15 @@ from nifty_scalper_bot.utils.rate_limiter import RateLimiter
 from nifty_scalper_bot.utils.reasons import SOFT, canonical as canonical_reason
 from nifty_scalper_bot.utils.symbols import canonical, unique_normalized_symbols
 
+from nifty_scalper_bot.notifications.telegram_enhanced import TelegramEnhancedNotifier
+
 if TYPE_CHECKING:
-    from nifty_scalper_bot.notifications.telegram_enhanced import TelegramEnhancedNotifier
     from nifty_scalper_bot.notifications.telegram_controller import TelegramBot
     from nifty_scalper_bot.notifications.telegram_webhook_enhanced import (
         TelegramWebhookController,
     )
     from telegram.ext import Application
 else:
-    TelegramEnhancedNotifier = Any
     TelegramWebhookController = Any
 
 LOGGER = logging.getLogger("nifty_scalper_bot.core.app")
@@ -5004,6 +5004,7 @@ def initialize_components(settings: Settings | None = None) -> BotContext:
 
     _apply_paper_mode(paper_state["enabled"])
     shadow_enabled = paper_state["enabled"]
+    notifier: TelegramEnhancedNotifier | None = None
 
     if not ctx_ref.get("telegram_wired", False):
         try:
@@ -5011,8 +5012,10 @@ def initialize_components(settings: Settings | None = None) -> BotContext:
             order_manager.set_notifier(notifier)
             ctx_ref["telegram_wired"] = True
             LOGGER.info("✅ Telegram Notifier wired to Order Manager")
-        except Exception as e:
-            LOGGER.error(f"Telegram notifier wiring failed: {e}")
+        except Exception:
+            notifier = None
+            order_manager.set_notifier(None)
+            LOGGER.exception("Telegram notifier wiring failed")
     else:
         LOGGER.info("ℹ️ Telegram Notifier already wired")
 


### PR DESCRIPTION
### Motivation
- Prevent bot startup crashes caused by `TelegramEnhancedNotifier` being `typing.Any` at runtime which led to `type object 'Any' has no attribute 'from_settings'` and subsequent `UnboundLocalError` for `notifier`.
- Ensure a failing Telegram notifier does not abort overall bot initialization and that failures are logged with tracebacks for easier debugging.

### Description
- Import `TelegramEnhancedNotifier` at runtime in `src/nifty_scalper_bot/core/app.py` and keep only controller/application types under `TYPE_CHECKING` so `TelegramEnhancedNotifier` is usable at runtime.
- Remove the runtime assignment `TelegramEnhancedNotifier = Any` to eliminate invalid runtime references.
- Initialize `notifier: TelegramEnhancedNotifier | None = None` before the wiring block to ensure `notifier` is always defined.
- Replace the Telegram wiring with exception-safe logic that calls `TelegramEnhancedNotifier.from_settings(settings.notifications)`, attaches the notifier via `order_manager.set_notifier(notifier)`, and on any exception sets `notifier = None`, clears `order_manager` notifier with `order_manager.set_notifier(None)`, and logs the full traceback using `LOGGER.exception(...)` so startup continues.

### Testing
- Ran `python -m compileall src` which completed and showed the project compiled successfully.
- Ran `pytest -q` which failed during test collection with `ModuleNotFoundError: No module named 'market_data_manager'` in `tests/test_mdm_diagnostics.py`, indicating a test-environment import issue unrelated to the Telegram wiring changes.
- No additional automated failures attributable to the changes were observed during compilation; runtime behavior should now avoid the previous `Any.from_settings` and `UnboundLocalError` failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02f2ec3a388324aafd373b9a3dd7a8)