### PR TITLE
fix: harden startup readiness gating for option activation

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -7029,6 +7029,20 @@ async def _recompute_and_push_runtime_readiness(ctx: BotContext, *, reason: str)
             return bool(mdm.get_symbol_snapshot(sym))
         except Exception:
             return False
+    def _subscription_confirmed(sym: str | None) -> bool:
+        if not sym or mdm is None:
+            return False
+        try:
+            token = None
+            resolve_token = getattr(mdm, "_resolve_token_for_symbol", None)
+            if callable(resolve_token):
+                token = resolve_token(sym)
+            if token is None:
+                token = getattr(mdm, "_symbol_to_token", {}).get(sym)
+            confirmed = getattr(mdm, "_confirmed_subscriptions", set()) or set()
+            return bool(token is not None and int(token) in confirmed)
+        except Exception:
+            return False
     spot_ready = _quote(spot_symbol) or _bars(spot_symbol) >= 1
     option_eval_min_live_bars = int(os.getenv("READINESS_OPTION_EVAL_MIN_BARS", os.getenv("OPTION_EVAL_MIN_LIVE_BARS", "20")) or 20)
     option_execution_min_bars = int(os.getenv("READINESS_OPTION_EXEC_MIN_BARS", os.getenv("OPTION_EXECUTION_MIN_BARS", "30")) or 30)
@@ -7040,6 +7054,8 @@ async def _recompute_and_push_runtime_readiness(ctx: BotContext, *, reason: str)
     pe_bars, pe_mdm_bars, pe_runner_bars = _readiness_bars(selected_pe)
     ce_quote_fresh = _quote(selected_ce)
     pe_quote_fresh = _quote(selected_pe)
+    ce_subscribed = _subscription_confirmed(selected_ce)
+    pe_subscribed = _subscription_confirmed(selected_pe)
     ce_eval_ready = bool(selected_ce) and ce_quote_fresh and ce_bars >= option_eval_min_live_bars
     pe_eval_ready = bool(selected_pe) and pe_quote_fresh and pe_bars >= option_eval_min_live_bars
     ce_exec_ready = bool(selected_ce) and ce_quote_fresh and ce_bars >= option_execution_min_bars
@@ -7052,7 +7068,13 @@ async def _recompute_and_push_runtime_readiness(ctx: BotContext, *, reason: str)
         spot_quote_fresh and fut_bars >= context_execution_min_bars
     )
     full_basket_ready = all((_quote(s) or _bars(s) >= 20) for s in option_symbols if s.endswith(("CE", "PE")))
-    data_hard_ready = bool(spot_ready and ce_eval_ready and pe_eval_ready)
+    data_hard_ready = bool(
+        spot_ready
+        and ce_eval_ready
+        and pe_eval_ready
+        and ce_subscribed
+        and pe_subscribed
+    )
     runner_running = _runner_is_running(getattr(ctx, "strategy_runner", None))
     evaluation_ready = bool(data_hard_ready and runner_running)
     live_mode = str(getattr(ctx.settings, "execution_mode", "PAPER")).upper() == "LIVE"
@@ -7073,10 +7095,12 @@ async def _recompute_and_push_runtime_readiness(ctx: BotContext, *, reason: str)
     ctx.effective_mode = ctx.readiness_mode
     ctx.live_block_reason = None if live_orders_armed else "startup_pipeline_incomplete"
     LOGGER.info(
-        "LIVE_READINESS_COMPUTED spot_ready=%s ce_eval_ready=%s pe_eval_ready=%s ce_exec_ready=%s pe_exec_ready=%s full_basket_ready=%s selected_ce=%s selected_pe=%s ce_bars_effective=%s ce_mdm_bars=%s ce_runner_bars=%s pe_bars_effective=%s pe_mdm_bars=%s pe_runner_bars=%s",
+        "LIVE_READINESS_COMPUTED spot_ready=%s ce_eval_ready=%s pe_eval_ready=%s ce_subscribed=%s pe_subscribed=%s ce_exec_ready=%s pe_exec_ready=%s full_basket_ready=%s selected_ce=%s selected_pe=%s ce_bars_effective=%s ce_mdm_bars=%s ce_runner_bars=%s pe_bars_effective=%s pe_mdm_bars=%s pe_runner_bars=%s",
         spot_ready,
         ce_eval_ready,
         pe_eval_ready,
+        ce_subscribed,
+        pe_subscribed,
         ce_exec_ready,
         pe_exec_ready,
         full_basket_ready,

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -598,6 +598,8 @@ class StrategyRunner:
         self._runtime_evaluation_ready = False
         self._runtime_live_orders_armed = False
         self._runtime_readiness_reason: str | None = None
+        self._runtime_startup_ready = False
+        self._startup_gate_last_log_ts = 0.0
         self._active_selected_ce: str | None = None
         self._active_selected_pe: str | None = None
         self._active_atm_strike: int | None = None
@@ -1908,8 +1910,10 @@ class StrategyRunner:
                 atm_value = int(float(atm_strike))
             except (TypeError, ValueError):
                 atm_value = None
-        self._active_selected_ce = selected_ce_norm
-        self._active_selected_pe = selected_pe_norm
+        if selected_ce_norm:
+            self._active_selected_ce = selected_ce_norm
+        if selected_pe_norm:
+            self._active_selected_pe = selected_pe_norm
         self._active_atm_strike = atm_value
         self._active_option_symbols = {normalize_symbol(str(sym)) for sym in (option_symbols or []) if sym}
         self._logger.info(
@@ -1938,8 +1942,21 @@ class StrategyRunner:
         self._runtime_evaluation_ready = bool(evaluation_ready)
         self._runtime_live_orders_armed = bool(live_orders_armed)
         self._runtime_readiness_reason = reason
+        self._runtime_startup_ready = bool(
+            self._runtime_data_hard_ready and self._runtime_evaluation_ready
+        )
         if any(value is not None for value in (selected_ce, selected_pe, atm_strike, option_symbols)):
             self.set_active_option_context(selected_ce=selected_ce, selected_pe=selected_pe, atm_strike=atm_strike, option_symbols=option_symbols)
+        self._logger.info(
+            "RUNNER_STARTUP_READINESS_UPDATE startup_ready=%s data_hard_ready=%s evaluation_ready=%s live_orders_armed=%s reason=%s selected_ce=%s selected_pe=%s",
+            self._runtime_startup_ready,
+            self._runtime_data_hard_ready,
+            self._runtime_evaluation_ready,
+            self._runtime_live_orders_armed,
+            self._runtime_readiness_reason,
+            self._active_selected_ce,
+            self._active_selected_pe,
+        )
 
     async def _prepare_signal_for_handling(
         self,
@@ -6266,6 +6283,21 @@ class StrategyRunner:
                     trace_id=trace_id,
                 )
                 return
+            if not bool(self._runtime_startup_ready):
+                now_mono = time_module.monotonic()
+                if now_mono - float(self._startup_gate_last_log_ts) >= 5.0:
+                    self._startup_gate_last_log_ts = now_mono
+                    self._emit_runner_eval_decision(
+                        symbol=symbol,
+                        stage="phase6",
+                        reason=str(
+                            self._runtime_readiness_reason
+                            or "startup_pipeline_incomplete"
+                        ),
+                        allowed=False,
+                        trace_id=trace_id,
+                    )
+                return
 
             # =================================================================
             # PHASE 7: STRATEGY PREPARATION
@@ -6567,6 +6599,14 @@ class StrategyRunner:
 
             self._last_global_eval_ts = time.monotonic()
             signal = generated_signal
+            upstream_version = int(
+                tick.get("candle_version")
+                or tick.get("version")
+                or tick.get("data_version")
+                or 0
+            )
+            if upstream_version > int(self._candle_versions.get(symbol, 0)):
+                self._candle_versions[symbol] = upstream_version
             current_version = int(self._candle_versions.get(symbol, 0))
             last_version = int(self._last_strategy_versions.get(symbol, 0))
             candle_count = len(self._indicator_engine.get_history(symbol) or [])


### PR DESCRIPTION
### Motivation

- Prevent the startup race where strategies evaluate before option subscriptions, quote hydration, and bar history converge, which produced `startup_pipeline_incomplete` and missing CE/PE context.  
- Avoid transient hydration/quote gaps from zeroing the active selected CE/PE pair and causing repeated evaluation/version desync loops.  
- Reduce noisy evaluation spam during startup and add structured diagnostics so readiness transitions and subscription events are observable.  

### Description

- Add a strict startup readiness flag and throttled gate in the runner (`_runtime_startup_ready`, `_startup_gate_last_log_ts`) so ticks do not drive full PHASE-9 evaluations until both data hard-ready and evaluation-ready are true. (`src/nifty_scalper_bot/strategies/runner.py`).  
- Preserve previously valid option context by changing `set_active_option_context` to not overwrite `self._active_selected_ce`/`self._active_selected_pe` when new values are `None`. (`src/nifty_scalper_bot/strategies/runner.py`).  
- Propagate upstream candle/data version from incoming tick metadata (`candle_version`, `version`, `data_version`) into the runner `_candle_versions` to avoid stale `current_version`/`last_version` desync loops. (`src/nifty_scalper_bot/strategies/runner.py`).  
- Require confirmed WS token subscription for selected CE/PE before declaring `data_hard_ready` in runtime readiness recomputation and log subscription readiness (`_subscription_confirmed`, `ce_subscribed`, `pe_subscribed`) so option tokens are proven live before enabling execution. (`src/nifty_scalper_bot/core/app.py`).  
- Add structured runner readiness logging on `set_runtime_readiness` and additional readiness diagnostics emitted from the runner and app to help triage startup state transitions. (`src/nifty_scalper_bot/strategies/runner.py`, `src/nifty_scalper_bot/core/app.py`).  

### Testing

- Ran `python -m compileall src` and compilation completed successfully.  
- Ran `pytest -q`; test run failed in the repository due to an existing test import error (`ModuleNotFoundError: No module named 'market_data_manager'` in `tests/test_mdm_diagnostics.py`) that is unrelated to these changes.  
- Verified logging and gating behavior by code inspection and added throttled decision logs to avoid startup spam; no runtime exceptions were introduced by the edits during static checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02f5d7970883248150cc828f0301d6)