### PR TITLE
fix: atomically commit dynamic option basket before readiness recompute

### DIFF
--- a/src/nifty_scalper_bot/core/active_basket.py
+++ b/src/nifty_scalper_bot/core/active_basket.py
@@ -38,6 +38,11 @@ def pick_atm_option_symbols_from_basket(
         atm_strike = int(float(atm_raw)) if atm_raw is not None else None
     except Exception:
         atm_strike = None
+    valid_symbols = set(option_symbols)
+    if selected_ce and (not selected_ce.endswith('CE') or selected_ce not in valid_symbols):
+        selected_ce = None
+    if selected_pe and (not selected_pe.endswith('PE') or selected_pe not in valid_symbols):
+        selected_pe = None
     if selected_ce and selected_pe:
         return selected_ce, selected_pe
 

--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -7074,6 +7074,49 @@ async def _recompute_and_push_runtime_readiness(ctx: BotContext, *, reason: str)
     LOGGER.info("LIVE_READINESS_COMPUTED selected_ce=%s selected_pe=%s ce_ltp_fresh=%s pe_ltp_fresh=%s ce_tick_age_s=%s pe_tick_age_s=%s ce_tradable_quote=%s pe_tradable_quote=%s ce_depth_available=%s pe_depth_available=%s ce_subscription_confirmed=%s pe_subscription_confirmed=%s ce_subscription_or_live_tick=%s pe_subscription_or_live_tick=%s ce_bars_effective=%s ce_mdm_bars=%s ce_runner_bars=%s pe_bars_effective=%s pe_mdm_bars=%s pe_runner_bars=%s data_hard_ready=%s evaluation_ready=%s live_orders_armed=%s live_block_reason=%s", selected_ce, selected_pe, ce_quote_fresh, pe_quote_fresh, getattr(_snapshot(selected_ce),'tick_age_s',None), getattr(_snapshot(selected_pe),'tick_age_s',None), _tradable_quote(selected_ce), _tradable_quote(selected_pe), bool(getattr(_snapshot(selected_ce),'depth_available',False)), bool(getattr(_snapshot(selected_pe),'depth_available',False)), _subscription_confirmed(selected_ce), _subscription_confirmed(selected_pe), _subscription_or_live_tick(selected_ce), _subscription_or_live_tick(selected_pe), ce_bars, ce_mdm_bars, ce_runner_bars, pe_bars, pe_mdm_bars, pe_runner_bars, data_hard_ready, evaluation_ready, live_orders_armed, block_reason)
     if ctx.strategy_runner is not None and hasattr(ctx.strategy_runner, 'set_runtime_readiness'):
         ctx.strategy_runner.set_runtime_readiness(data_hard_ready=bool(ctx.data_hard_ready), evaluation_ready=bool(ctx.evaluation_ready), live_orders_armed=bool(ctx.live_orders_armed), reason=str(ctx.live_block_reason or reason), selected_ce=selected_ce, selected_pe=selected_pe, atm_strike=basket.get('atm_strike'), option_symbols=option_symbols)
+
+
+def _commit_active_dynamic_basket(
+    ctx: BotContext,
+    *,
+    basket: Mapping[str, object],
+    option_symbols: Sequence[str],
+    symbols: Sequence[str],
+    atm_strike: int | float | str | None,
+) -> tuple[str | None, str | None]:
+    """Commit active dynamic basket atomically. Args: ctx/basket/option_symbols/symbols/atm_strike. Returns: selected CE/PE. Raises: none."""
+    current_options = [str(sym) for sym in option_symbols if str(sym).endswith(("CE", "PE"))]
+    current_symbols = [str(sym) for sym in symbols if sym]
+    picked_ce, picked_pe = pick_atm_option_symbols_from_basket(basket)
+    selected_ce = str(basket.get("selected_ce") or basket.get("atm_ce") or picked_ce or "") or None
+    selected_pe = str(basket.get("selected_pe") or basket.get("atm_pe") or picked_pe or "") or None
+    active_set = set(current_options) | set(current_symbols)
+    if not (selected_ce and selected_ce.endswith("CE") and selected_ce in active_set):
+        selected_ce = next((sym for sym in current_options if sym.endswith("CE")), None)
+    if not (selected_pe and selected_pe.endswith("PE") and selected_pe in active_set):
+        selected_pe = next((sym for sym in current_options if sym.endswith("PE")), None)
+    ctx.selected_ce = selected_ce
+    ctx.selected_pe = selected_pe
+    ctx.atm_ce_symbol = selected_ce
+    ctx.atm_pe_symbol = selected_pe
+    committed = cast(dict[str, object], getattr(ctx, "active_trading_universe", {}) or {})
+    committed.update(
+        {
+            "selected_ce": selected_ce,
+            "selected_pe": selected_pe,
+            "atm_ce": selected_ce,
+            "atm_pe": selected_pe,
+            "option_symbols": list(current_options),
+            "symbols": list(current_symbols),
+            "atm_strike": atm_strike,
+            "committed_at": datetime.now(timezone.utc).isoformat(),
+        }
+    )
+    ctx.active_trading_universe = committed
+    runner = getattr(ctx, "strategy_runner", None)
+    if runner is not None and hasattr(runner, "set_active_trading_universe"):
+        runner.set_active_trading_universe(committed)
+    return selected_ce, selected_pe
 async def _deferred_basket_hydration_retry(
     ctx: BotContext,
     *,
@@ -9219,13 +9262,32 @@ async def startup_sequence(ctx: BotContext) -> None:
                         # where each option sits in the live lifecycle.
                         if add_symbols or drop_symbols:
                             try:
+                                basket_symbols = [
+                                    str(sym)
+                                    for sym in dict.fromkeys(
+                                        ["NSE:NIFTY", *sorted(latest_symbols)]
+                                    )
+                                ]
+                                committed_ce, committed_pe = _commit_active_dynamic_basket(
+                                    ctx,
+                                    basket=cast(
+                                        Mapping[str, object],
+                                        getattr(ctx, "active_trading_universe", {}) or {},
+                                    ),
+                                    option_symbols=sorted(latest_symbols),
+                                    symbols=basket_symbols,
+                                    atm_strike=cast(
+                                        int | float | str | None,
+                                        (getattr(ctx, "active_trading_universe", {}) or {}).get("atm_strike"),
+                                    ),
+                                )
                                 for _sym in add_symbols:
                                     _tok = active_symbol_tokens.get(_sym)
                                     _emit_option_symbol_pipeline_status(
                                         ctx,
                                         symbol=_sym,
                                         token=_tok,
-                                        selected=_is_selected_trade_symbol(ctx, sym),
+                                        selected=_sym in {committed_ce, committed_pe},
                                         hydrated_bars=(
                                             len(
                                                 ctx.market_data_manager.get_ohlc_bars(
@@ -9239,6 +9301,36 @@ async def startup_sequence(ctx: BotContext) -> None:
                                         runner_added=bool(ctx.strategy_runner),
                                         source="dynamic_universe",
                                         reason="post_universe_sync",
+                                    )
+                                ce_bars = (
+                                    len(ctx.market_data_manager.get_ohlc_bars(committed_ce) or [])
+                                    if committed_ce and ctx.market_data_manager is not None
+                                    else 0
+                                )
+                                pe_bars = (
+                                    len(ctx.market_data_manager.get_ohlc_bars(committed_pe) or [])
+                                    if committed_pe and ctx.market_data_manager is not None
+                                    else 0
+                                )
+                                LOGGER.info(
+                                    "ACTIVE_DYNAMIC_BASKET_COMMITTED selected_ce=%s selected_pe=%s atm_strike=%s option_count=%d ce_ready=%s pe_ready=%s",
+                                    committed_ce,
+                                    committed_pe,
+                                    (getattr(ctx, "active_trading_universe", {}) or {}).get("atm_strike"),
+                                    len(latest_symbols),
+                                    ce_bars >= _symbol_history_requirement(ctx),
+                                    pe_bars >= _symbol_history_requirement(ctx),
+                                )
+                                if committed_ce and committed_pe:
+                                    await _recompute_and_push_runtime_readiness(
+                                        ctx,
+                                        reason="dynamic_basket_committed",
+                                    )
+                                else:
+                                    LOGGER.info(
+                                        "LIVE_READINESS_DEFERRED reason=dynamic_basket_not_committed_yet selected_ce=%s selected_pe=%s",
+                                        committed_ce,
+                                        committed_pe,
                                     )
                                 _emit_trading_universe_summary(
                                     ctx,

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -1925,6 +1925,22 @@ class StrategyRunner:
             extra={"event": "RUNNER_ACTIVE_OPTION_CONTEXT", "selected_ce": self._active_selected_ce, "selected_pe": self._active_selected_pe, "atm_strike": self._active_atm_strike, "option_count": len(self._active_option_symbols)},
         )
 
+    def set_active_trading_universe(self, basket: Mapping[str, Any]) -> None:
+        """Set active trading universe snapshot. Args: basket. Returns: none. Raises: none."""
+        option_symbols = basket.get("option_symbols") or basket.get("symbols") or []
+        self.set_active_option_context(
+            selected_ce=cast(str | None, basket.get("selected_ce") or basket.get("atm_ce")),
+            selected_pe=cast(str | None, basket.get("selected_pe") or basket.get("atm_pe")),
+            atm_strike=cast(int | float | str | None, basket.get("atm_strike")),
+            option_symbols=cast(list[str] | tuple[str, ...] | set[str], option_symbols),
+        )
+        self._logger.info(
+            "RUNNER_ACTIVE_BASKET_UPDATED selected_ce=%s selected_pe=%s option_count=%d",
+            self._active_selected_ce,
+            self._active_selected_pe,
+            len(self._active_option_symbols),
+        )
+
     def set_runtime_readiness(
         self,
         *,

--- a/tests/core/test_live_readiness_recompute.py
+++ b/tests/core/test_live_readiness_recompute.py
@@ -16,6 +16,9 @@ class _Runner:
     def set_runtime_readiness(self, **kwargs):
         self.calls.append(kwargs)
 
+    def set_active_trading_universe(self, basket):
+        self.basket = basket
+
 
 def _ctx(mdm):
     return SimpleNamespace(
@@ -99,3 +102,33 @@ def test_gate_runner_symbol_add_discards_pending_when_quote_ready() -> None:
     pending = {'NFO:NIFTY24600CE'}
     assert app._gate_runner_symbol_add(ctx, 'NFO:NIFTY24600CE', pending) is True
     assert 'NFO:NIFTY24600CE' not in pending
+
+
+@pytest.mark.asyncio
+async def test_dynamic_basket_commit_sets_selected_symbols_and_readiness() -> None:
+    class _Snap:
+        def __init__(self) -> None:
+            self.ltp = 1.0
+            self.tick_age_s = 1.0
+            self.tradable_quote = True
+            self.bid = 0.9
+            self.ask = 1.1
+
+    mdm = SimpleNamespace(
+        get_ohlc_bars=lambda s: list(range(60)),
+        get_symbol_snapshot=lambda s: _Snap(),
+    )
+    ctx = _ctx(mdm)
+    ctx.active_trading_universe = {'spot_symbol': 'NSE:NIFTY', 'atm_strike': 24600}
+    app._commit_active_dynamic_basket(
+        ctx,
+        basket=ctx.active_trading_universe,
+        option_symbols=['NFO:NIFTY24600CE', 'NFO:NIFTY24600PE'],
+        symbols=['NSE:NIFTY', 'NFO:NIFTY24600CE', 'NFO:NIFTY24600PE'],
+        atm_strike=24600,
+    )
+    await app._recompute_and_push_runtime_readiness(ctx, reason='dynamic_basket_committed')
+    assert ctx.selected_ce == 'NFO:NIFTY24600CE'
+    assert ctx.selected_pe == 'NFO:NIFTY24600PE'
+    assert ctx.data_hard_ready is True
+    assert ctx.evaluation_ready is True


### PR DESCRIPTION
### Motivation
- Recent startup logs showed fully-hydrated/wired dynamic option symbols but the runner blocked on missing selected CE/PE which prevented readiness progressing. 
- Root cause: the dynamic option universe builder wired symbols one-by-one but never atomically committed the final basket into `ctx.active_trading_universe` / `ctx.selected_ce` / `ctx.selected_pe` before readiness recomputation. 
- The change implements an explicit commit step so the selected CE/PE become visible to readiness logic and the StrategyRunner.

### Description
- Added `_commit_active_dynamic_basket(...)` in `src/nifty_scalper_bot/core/app.py` that picks/validates selected CE/PE, updates `ctx.selected_*` / `ctx.atm_*`, persists a committed snapshot into `ctx.active_trading_universe` (including `committed_at`), and pushes the basket to the runner. 
- Updated the dynamic-universe sync loop in `core/app.py` to call the commit helper after building the live option set, mark per-symbol `OPTION_SYMBOL_PIPELINE_STATUS selected=True` for the committed CE/PE, emit `ACTIVE_DYNAMIC_BASKET_COMMITTED` diagnostics, and only trigger final readiness recompute with reason `dynamic_basket_committed` when CE+PE are committed. 
- Added `StrategyRunner.set_active_trading_universe(...)` in `src/nifty_scalper_bot/strategies/runner.py` to accept the committed basket and emit `RUNNER_ACTIVE_BASKET_UPDATED` so runner internals are kept in sync. 
- Hardened basket selection in `src/nifty_scalper_bot/core/active_basket.py` to reject stale or non-CE/PE explicit selections that are not present in the current option set. 
- Added a regression unit test in `tests/core/test_live_readiness_recompute.py` that commits a dynamic basket and verifies `selected_ce`/`selected_pe` are set and readiness flags (`data_hard_ready` and `evaluation_ready`) become true when data/quotes are hydrated and fresh.

### Testing
- Ran `bash run_checks.sh` in this environment; it initially failed because the created virtualenv did not have the test/lint tools installed by the CI wrapper (reported missing `pytest`/dev-tools). 
- After installing development tools in the venv, ran the focused unit test suite with: `. .venv/bin/activate && pip install pytest ruff mypy && pytest -q tests/core/test_live_readiness_recompute.py`, and the added test passed. 
- Ran `ruff` / `mypy` checks which reported repository-wide style/type issues (line-length / unused-import diagnostics) unrelated to the functional commit logic; these are existing findings and were not introduced by the atomic-commit logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0384d14c748324bf7c4795fb545635)