### PR TITLE
fix: reseed runner and indicator history from hydrated bars

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -6927,18 +6927,39 @@ async def _ensure_selected_options_hydrated(
             bars = mdm.get_ohlc_bars(sym, limit=required_bars) or []
         except TypeError:
             bars = mdm.get_ohlc_bars(sym) or []
+        normalized_bars: list[dict[str, Any]] = []
         for row in bars:
             if not isinstance(row, Mapping):
                 continue
             bar_data = dict(row)
             bar_data["symbol"] = sym
-            if runner is not None and hasattr(runner, "ingest_historical_bar"):
+            normalized_bars.append(bar_data)
+        used_reseed = False
+        if runner is not None and hasattr(runner, "reseed_history_from_bars"):
+            runner.reseed_history_from_bars(
+                sym,
+                normalized_bars,
+                source=f"{reason}_selected_option_reseed",
+                min_bars=required_bars,
+            )
+            used_reseed = True
+        elif runner is not None and hasattr(runner, "ingest_historical_bar"):
+            for bar_data in normalized_bars:
                 runner.ingest_historical_bar(bar_data)
         update_fn = getattr(mdm, "update_hydration_status", None)
         if callable(update_fn):
             update_fn(sym, mdm.get_ohlc_bars(sym))
         after_mdm_bars = len(mdm.get_ohlc_bars(sym) or [])
         after_runner_bars = len(runner._indicator_engine.get_history(sym) or []) if runner is not None and hasattr(runner, "_indicator_engine") else 0
+        if used_reseed and after_mdm_bars >= required_bars and after_runner_bars < required_bars:
+            LOGGER.warning(
+                "SELECTED_OPTION_RESEED_FAILED symbol=%s after_mdm_bars=%d after_runner_bars=%d required_bars=%d reason=%s",
+                sym,
+                after_mdm_bars,
+                after_runner_bars,
+                required_bars,
+                reason,
+            )
         LOGGER.info(
             "SELECTED_OPTION_FORCE_HYDRATION_RESULT symbol=%s before_mdm_bars=%d after_mdm_bars=%d before_runner_bars=%d after_runner_bars=%d required_bars=%d",
             sym, before_mdm_bars, after_mdm_bars, before_runner_bars, after_runner_bars, required_bars,

--- a/src/nifty_scalper_bot/strategies/indicators.py
+++ b/src/nifty_scalper_bot/strategies/indicators.py
@@ -353,6 +353,79 @@ class IndicatorEngine:
             self._logger.error("Failure in IndicatorEngine.ingest_historical_bar: %s", e)
             raise
 
+    def replace_history(
+        self,
+        symbol: str,
+        bars: Iterable[Mapping[str, Any]],
+        source: str = "historical_reseed",
+        min_bars: int = 1,
+    ) -> int:
+        """Args: symbol/bars/source/min_bars. Returns: final history count. Raises: Exception."""
+        try:
+            normalized_rows: dict[datetime, dict[str, Any]] = {}
+            for row in bars or ():
+                if not isinstance(row, Mapping):
+                    continue
+                ts_value = row.get("timestamp") or row.get("start")
+                if ts_value is None:
+                    continue
+                if isinstance(ts_value, datetime):
+                    ts = ts_value
+                elif isinstance(ts_value, (int, float)):
+                    ts = datetime.fromtimestamp(float(ts_value), tz=timezone.utc)
+                elif isinstance(ts_value, str):
+                    ts = datetime.fromisoformat(ts_value.replace("Z", "+00:00"))
+                else:
+                    continue
+                if ts.tzinfo is None:
+                    ts = ts.replace(tzinfo=timezone.utc)
+                ts = ts.astimezone(timezone.utc).replace(microsecond=0)
+                normalized_rows[ts] = {
+                    "timestamp": ts,
+                    "open": float(row.get("open", row.get("close", 0.0)) or 0.0),
+                    "high": float(row.get("high", row.get("close", 0.0)) or 0.0),
+                    "low": float(row.get("low", row.get("close", 0.0)) or 0.0),
+                    "close": float(row.get("close", row.get("open", 0.0)) or 0.0),
+                    "volume": int(row.get("volume", 0) or 0),
+                }
+
+            selected_rows = sorted(normalized_rows.values(), key=lambda item: item["timestamp"])
+            new_history = PriceHistory()
+            for bar in selected_rows:
+                new_history.add_tick(
+                    {
+                        "open": bar["open"],
+                        "high": bar["high"],
+                        "low": bar["low"],
+                        "close": bar["close"],
+                    },
+                    volume=int(bar["volume"]),
+                    timestamp=cast(datetime, bar["timestamp"]),
+                    is_complete=True,
+                    is_provisional=False,
+                )
+            with self._lock:
+                self._histories[symbol] = new_history
+                self._cache.pop(symbol, None)
+                final_count = len(new_history)
+            event_name = (
+                "INDICATOR_HISTORY_RESEEDED"
+                if final_count >= max(1, int(min_bars or 1))
+                else "INDICATOR_HISTORY_RESEED_SHORT"
+            )
+            self._logger.info(
+                "%s symbol=%s bars=%d min_bars=%d source=%s",
+                event_name,
+                symbol,
+                final_count,
+                max(1, int(min_bars or 1)),
+                source,
+            )
+            return final_count
+        except Exception as e:
+            self._logger.error("Failure in IndicatorEngine.replace_history: %s", e)
+            raise
+
     def history_count(self, symbol: str) -> int:
         """Return symbol history length. Args: symbol. Returns: count. Raises: none."""
         with self._lock:

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -2712,6 +2712,84 @@ class StrategyRunner:
             )
             raise
 
+    def reseed_history_from_bars(
+        self,
+        symbol: str,
+        bars: Iterable[Mapping[str, Any]],
+        source: str = "mdm_reseed",
+        min_bars: int = 1,
+    ) -> int:
+        """Args: symbol/bars/source/min_bars. Returns: runner history count. Raises: Exception."""
+        try:
+            normalized_symbol = self._normalize_symbol(symbol)
+            if not normalized_symbol:
+                return 0
+            normalized_rows: dict[datetime, dict[str, Any]] = {}
+            for row in bars or ():
+                normalized = normalize_history_row(normalized_symbol, dict(row), source=source)
+                if normalized is None:
+                    continue
+                ts_value = normalized.get("timestamp")
+                if not isinstance(ts_value, datetime):
+                    continue
+                timestamp = ts_value.astimezone(timezone.utc).replace(microsecond=0)
+                normalized_rows[timestamp] = {
+                    "timestamp": timestamp,
+                    "open": float(normalized["open"]),
+                    "high": float(normalized["high"]),
+                    "low": float(normalized["low"]),
+                    "close": float(normalized["close"]),
+                    "volume": int(normalized.get("volume", 0) or 0),
+                }
+            selected_rows = sorted(normalized_rows.values(), key=lambda item: item["timestamp"])
+            one_minute_bars: list[OneMinuteBar] = []
+            for row in selected_rows:
+                start_ts = cast(datetime, row["timestamp"])
+                one_minute_bars.append(
+                    OneMinuteBar(
+                        open=float(row["open"]),
+                        high=float(row["high"]),
+                        low=float(row["low"]),
+                        close=float(row["close"]),
+                        volume=int(row["volume"]),
+                        start=start_ts,
+                        end=start_ts + timedelta(minutes=1),
+                    )
+                )
+            with self._lock:
+                self._symbol_history[normalized_symbol] = deque(one_minute_bars, maxlen=2000)
+                if one_minute_bars:
+                    self._last_bar_ts[normalized_symbol] = one_minute_bars[-1].start
+                self._active_symbols.add(normalized_symbol)
+                self._tracked_symbols.add(normalized_symbol)
+                self._data_phase.setdefault(normalized_symbol, "HYDRATION")
+            indicator_count = self._indicator_engine.replace_history(
+                normalized_symbol,
+                selected_rows,
+                source=source,
+                min_bars=min_bars,
+            )
+            target_min_bars = max(1, int(min_bars or 1))
+            if indicator_count >= target_min_bars:
+                self._set_symbol_hydration_state(normalized_symbol, SymbolState.READY)
+                self._seed_pipeline_store(normalized_symbol)
+                self._seed_candle_engine_from_history(normalized_symbol)
+            else:
+                self._set_symbol_hydration_state(normalized_symbol, SymbolState.DEGRADED)
+            runner_count = len(self._symbol_history.get(normalized_symbol, []))
+            self._logger.info(
+                "RUNNER_HISTORY_RESEEDED symbol=%s runner_bars=%d indicator_bars=%d min_bars=%d source=%s",
+                normalized_symbol,
+                runner_count,
+                indicator_count,
+                target_min_bars,
+                source,
+            )
+            return runner_count
+        except Exception as e:
+            self._logger.error("Failure in StrategyRunner.reseed_history_from_bars: %s", e)
+            raise
+
     async def safe_ingest(self, data: dict[str, Any]) -> None:
         """Synchronize hydration ingestion on event loop. Args: data. Returns: None. Raises: None."""
         self._startup_hydrated = True

--- a/tests/strategies/test_runner_reseed_history.py
+++ b/tests/strategies/test_runner_reseed_history.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from nifty_scalper_bot.core import app
+from nifty_scalper_bot.strategies.indicators import IndicatorEngine
+from nifty_scalper_bot.strategies.runner import StrategyRunner
+
+
+def _make_bars(symbol: str, count: int, start: datetime) -> list[dict[str, object]]:
+    bars: list[dict[str, object]] = []
+    for idx in range(count):
+        ts = start + timedelta(minutes=idx)
+        price = 100.0 + idx
+        bars.append(
+            {
+                'symbol': symbol,
+                'timestamp': ts,
+                'open': price,
+                'high': price + 0.5,
+                'low': price - 0.5,
+                'close': price + 0.2,
+                'volume': 100 + idx,
+            }
+        )
+    return bars
+
+
+def test_indicator_replace_history_overrides_short_live_history() -> None:
+    engine = IndicatorEngine()
+    symbol = 'NFO:NIFTY26MAY23300CE'
+    base = datetime(2026, 5, 1, 3, 45, tzinfo=timezone.utc)
+    for bar in _make_bars(symbol, 5, base + timedelta(minutes=60)):
+        engine.ingest_historical_bar(symbol, bar)
+    assert engine.history_count(symbol) == 5
+
+    reseed_bars = _make_bars(symbol, 30, base)
+    final_count = engine.replace_history(symbol, reseed_bars, min_bars=30)
+    assert final_count >= 30
+    assert engine.history_count(symbol) >= 30
+
+
+def test_runner_reseed_history_from_bars_sets_indicator_ready() -> None:
+    runner = StrategyRunner()
+    symbol = 'NFO:NIFTY26MAY23300PE'
+    base = datetime(2026, 5, 1, 3, 45, tzinfo=timezone.utc)
+    bars = _make_bars(symbol, 30, base)
+
+    runner_count = runner.reseed_history_from_bars(symbol, bars, min_bars=30)
+    assert runner_count >= 30
+    assert runner._indicator_engine.history_count(symbol) >= 30
+
+
+@pytest.mark.asyncio
+async def test_ensure_selected_options_hydrated_prefers_reseed_path() -> None:
+    symbol = 'NFO:NIFTY26MAY23300CE'
+    base = datetime(2026, 5, 1, 3, 45, tzinfo=timezone.utc)
+    mdm_bars = _make_bars(symbol, 30, base)
+
+    class RunnerStub:
+        def __init__(self) -> None:
+            self._indicator_engine = SimpleNamespace(get_history=lambda _s: list(range(5)))
+            self.reseed_calls: list[tuple[str, int, int]] = []
+            self._current = 5
+
+        def reseed_history_from_bars(self, sym: str, bars: list[dict[str, object]], source: str, min_bars: int) -> int:
+            self.reseed_calls.append((sym, len(bars), min_bars))
+            self._current = len(bars)
+            self._indicator_engine = SimpleNamespace(get_history=lambda _s: list(range(self._current)))
+            return self._current
+
+    class MdmStub:
+        def __init__(self) -> None:
+            self.hydrate_calls = 0
+
+        async def hydrate_symbol_history(self, *args, **kwargs) -> None:
+            self.hydrate_calls += 1
+
+        def get_ohlc_bars(self, _sym: str, limit: int | None = None):
+            return list(mdm_bars[: limit or len(mdm_bars)])
+
+    runner = RunnerStub()
+    mdm = MdmStub()
+    ctx = SimpleNamespace(market_data_manager=mdm, strategy_runner=runner)
+    await app._ensure_selected_options_hydrated(ctx, symbol, None, 30, 'test')
+
+    assert runner.reseed_calls
+    assert runner.reseed_calls[0][0] == symbol
+    assert runner.reseed_calls[0][1] >= 30
+    assert runner.reseed_calls[0][2] == 30


### PR DESCRIPTION
### Motivation
- Startup hydration could leave the runner/indicator with only a few live bars because older MDM bars were ignored by monotonic timestamp checks, preventing readiness despite MDM having many bars.  
- The fix must transfer MDM history deterministically into the runner/indicator histories rather than relaxing readiness checks.

### Description
- Added `IndicatorEngine.replace_history(symbol, bars, source="historical_reseed", min_bars=1)` to normalize OHLCV and timestamps, deduplicate by timestamp, sort oldest→newest, rebuild a new `PriceHistory`, clear the indicator cache, log `INDICATOR_HISTORY_RESEEDED` / `INDICATOR_HISTORY_RESEED_SHORT`, and return the final history count.  
- Added `StrategyRunner.reseed_history_from_bars(symbol, bars, source="mdm_reseed", min_bars=1)` to normalize/dedupe/sort rows into `OneMinuteBar`s, replace the runner `_symbol_history` and `_last_bar_ts`, ensure symbol registration (`_active_symbols`, `_tracked_symbols`, `_data_phase`), call `IndicatorEngine.replace_history(...)`, set hydration state to `READY` or `DEGRADED`, seed the pipeline store and `CandleEngine` from indicator history when ready, and log `RUNNER_HISTORY_RESEEDED`.  
- Updated `_ensure_selected_options_hydrated(...)` to prefer `runner.reseed_history_from_bars(...)` (with legacy `ingest_historical_bar` as fallback), and to emit a `SELECTED_OPTION_RESEED_FAILED` warning if MDM had sufficient bars but runner still lacks them after reseed.  
- Added focused tests (`tests/strategies/test_runner_reseed_history.py`) that validate `IndicatorEngine.replace_history`, `StrategyRunner.reseed_history_from_bars`, and that the app hydration path prefers the reseed API, exercising the before/after short→>=min_bars regression scenario.

### Testing
- Ran `python -m compileall -q src tests` which succeeded (byte-compile OK).  
- Ran `pytest tests/strategies/test_runner_reseed_history.py -q` and the tests passed.  
- Ran `pytest tests/core/test_readiness_live_tick_proof.py -q` and `pytest tests/test_ws_depth_preservation.py -q` and both suites passed.  
- Attempted repository `./run_checks.sh` in this environment: initial execution showed `Permission denied`, and invoking via `bash run_checks.sh` completed dependency install but the script reported the environment-managed venv did not have `pytest` installed (script message: `❌ pytest not installed but tests/ exists`), so `run_checks.sh` did not finish green here; the targeted unit tests listed above were executed directly and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03fbf738848324903a5fbfdbeb6cc0)