### PR TITLE
fix: lazy-load Telegram notifier import and preserve reseed history list type

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -921,18 +921,30 @@ from nifty_scalper_bot.utils.rate_limiter import RateLimiter
 from nifty_scalper_bot.utils.reasons import SOFT, canonical as canonical_reason
 from nifty_scalper_bot.utils.symbols import canonical, unique_normalized_symbols
 
-from nifty_scalper_bot.notifications.telegram_enhanced import TelegramEnhancedNotifier
-
 if TYPE_CHECKING:
+    from nifty_scalper_bot.notifications.telegram_enhanced import TelegramEnhancedNotifier
     from nifty_scalper_bot.notifications.telegram_controller import TelegramBot
     from nifty_scalper_bot.notifications.telegram_webhook_enhanced import (
         TelegramWebhookController,
     )
     from telegram.ext import Application
 else:
+    TelegramEnhancedNotifier = Any
     TelegramWebhookController = Any
 
 LOGGER = logging.getLogger("nifty_scalper_bot.core.app")
+
+
+def _load_telegram_enhanced_notifier() -> type[Any] | None:
+    """Load Telegram notifier lazily. Args: none. Returns: notifier class or None. Raises: none."""
+    try:
+        from nifty_scalper_bot.notifications.telegram_enhanced import TelegramEnhancedNotifier
+
+        return TelegramEnhancedNotifier
+    except Exception as exc:  # noqa: BLE001
+        LOGGER.warning("TELEGRAM_ENHANCED_IMPORT_UNAVAILABLE reason=%s", exc)
+        return None
+
 
 _ComponentT = TypeVar("_ComponentT")
 
@@ -5032,15 +5044,21 @@ def initialize_components(settings: Settings | None = None) -> BotContext:
     notifier: TelegramEnhancedNotifier | None = None
 
     if not ctx_ref.get("telegram_wired", False):
-        try:
-            notifier = TelegramEnhancedNotifier.from_settings(settings.notifications)
-            order_manager.set_notifier(notifier)
-            ctx_ref["telegram_wired"] = True
-            LOGGER.info("✅ Telegram Notifier wired to Order Manager")
-        except Exception:
+        TelegramEnhancedNotifierCls = _load_telegram_enhanced_notifier()
+        if TelegramEnhancedNotifierCls is None:
             notifier = None
             order_manager.set_notifier(None)
-            LOGGER.exception("Telegram notifier wiring failed")
+            LOGGER.warning("TELEGRAM_NOTIFIER_SKIPPED reason=dependency_unavailable")
+        else:
+            try:
+                notifier = TelegramEnhancedNotifierCls.from_settings(settings.notifications)
+                order_manager.set_notifier(notifier)
+                ctx_ref["telegram_wired"] = True
+                LOGGER.info("✅ Telegram Notifier wired to Order Manager")
+            except Exception:
+                notifier = None
+                order_manager.set_notifier(None)
+                LOGGER.exception("Telegram notifier wiring failed")
     else:
         LOGGER.info("ℹ️ Telegram Notifier already wired")
 

--- a/src/nifty_scalper_bot/strategies/indicators.py
+++ b/src/nifty_scalper_bot/strategies/indicators.py
@@ -408,6 +408,17 @@ class IndicatorEngine:
                 }
 
             selected_rows = sorted(normalized_rows.values(), key=lambda item: item["timestamp"])
+            if not selected_rows:
+                self._logger.warning(
+                    "INDICATOR_HISTORY_RESEED_EMPTY symbol=%s min_bars=%d source=%s",
+                    symbol,
+                    max(1, int(min_bars or 1)),
+                    source,
+                )
+                with self._lock:
+                    self._histories[symbol] = PriceHistory()
+                    self._cache.pop(symbol, None)
+                return 0
             new_history = PriceHistory()
             for bar in selected_rows:
                 new_history.add_tick(

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -2758,7 +2758,7 @@ class StrategyRunner:
                     )
                 )
             with self._lock:
-                self._symbol_history[normalized_symbol] = deque(one_minute_bars, maxlen=2000)
+                self._symbol_history[normalized_symbol] = list(one_minute_bars[-2000:])
                 if one_minute_bars:
                     self._last_bar_ts[normalized_symbol] = one_minute_bars[-1].start
                 self._active_symbols.add(normalized_symbol)


### PR DESCRIPTION
### Motivation
- Prevent import-time failures when Telegram dependencies are unavailable by avoiding runtime imports in `core.app` and making notifier loading resilient. 
- Maintain declared types and avoid type-drift by ensuring `_symbol_history` stores a `list` rather than a `deque`. 
- Make indicator reseed robust by explicitly handling empty reseed inputs with a clear log and safe reset.

### Description
- Replace the top-level runtime import of `TelegramEnhancedNotifier` in `src/nifty_scalper_bot/core/app.py` with a `TYPE_CHECKING` hint (`TelegramEnhancedNotifier = Any`) and add a lazy loader `_load_telegram_enhanced_notifier()` that logs and returns `None` when import fails. 
- Update the notifier wiring in app startup to use the lazy-loaded class and explicitly skip wiring with `TELEGRAM_NOTIFIER_SKIPPED reason=dependency_unavailable` when the Telegram dependency is not present, while preserving existing behavior when available. 
- Change `StrategyRunner.reseed_history_from_bars()` in `src/nifty_scalper_bot/strategies/runner.py` to assign `self._symbol_history[normalized_symbol] = list(one_minute_bars[-2000:])` (list slice) instead of a `deque` to match declared types. 
- Add an empty-reseed guard in `IndicatorEngine.replace_history()` in `src/nifty_scalper_bot/strategies/indicators.py` that logs `INDICATOR_HISTORY_RESEED_EMPTY`, resets the per-symbol `PriceHistory` and cache under lock, and returns `0` when no rows are available. 
- Did not modify `get_http_app()`; its local try-import remains unchanged.

### Testing
- Ran `python -m compileall -q src tests` which completed successfully. 
- Ran `pytest tests/strategies/test_runner_reseed_history.py -q` which passed. 
- Ran `pytest tests/core/test_readiness_live_tick_proof.py -q` which passed. 
- Ran `pytest tests/test_ws_depth_preservation.py -q` and `pytest tests/test_core_app_import_without_telegram.py -q` which both passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a040bcdc39883248703c164cbe1b96e)