### PR TITLE
fix: unblock phase9 evaluation on quote context failures

### DIFF
--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import calendar
 from collections import defaultdict, deque
+from contextlib import suppress
 import dataclasses
 from dataclasses import dataclass, field
 from datetime import datetime, time as dt_time, timedelta, timezone
@@ -3092,7 +3093,7 @@ class StrategyRunner:
             if rows:
                 self._write_history_cache(symbol, rows)
                 for row in rows:
-                    with contextlib.suppress(Exception):
+                    with suppress(Exception):
                         self.ingest_historical_bar(row)
             else:
                 self._request_mdm_hydration(symbol, target)
@@ -5612,10 +5613,11 @@ class StrategyRunner:
                                 "required": required_bars,
                             },
                         )
+                reason = 'insufficient_indicator_bar_count' if history_count < required_bars else 'indicator_history_integrity_failed'
                 self._emit_runner_eval_decision(
                     symbol=symbol,
                     stage='phase9',
-                    reason='insufficient_indicator_bars',
+                    reason=reason,
                     allowed=False,
                     trace_id=trace_id,
                 )
@@ -7014,10 +7016,7 @@ class StrategyRunner:
                                 return
                         # Frequency limit moved to ExecutionEngine
                         state._last_strategy_eval = now
-                        # ✅ FIX K (continued): store the effective bar_ts so the
-                        # same-bar-skip correctly advances each minute for options.
-                        if _effective_last_bar_ts:
-                            state._last_eval_bar_ts = _effective_last_bar_ts
+                        pending_eval_bar_ts = _effective_last_bar_ts
                         should_evaluate = True
 
                 if should_evaluate:
@@ -7165,20 +7164,25 @@ class StrategyRunner:
                         depth_payload = quote_map.get("depth") or tick_map.get("depth")
                         bid = quote_map.get("bid") or quote_map.get("best_bid") or tick_map.get("bid") or tick_map.get("best_bid")
                         ask = quote_map.get("ask") or quote_map.get("best_ask") or tick_map.get("ask") or tick_map.get("best_ask")
+                        bid_f = _extract_float({"value": bid}, "value")
+                        ask_f = _extract_float({"value": ask}, "value")
                         bid_qty = quote_map.get("bid_qty") or tick_map.get("bid_qty") or quote_map.get("buy_qty") or tick_map.get("buy_qty")
                         ask_qty = quote_map.get("ask_qty") or tick_map.get("ask_qty") or quote_map.get("sell_qty") or tick_map.get("sell_qty")
                         spread = quote_map.get("spread")
                         mid = quote_map.get("mid")
-                        if spread in (None, "") and bid and ask:
-                            with suppress(Exception):
-                                spread = float(ask) - float(bid)
-                        if mid in (None, "") and bid and ask:
-                            with suppress(Exception):
-                                mid = (float(ask) + float(bid)) / 2.0
+                        if spread in (None, "") and bid_f is not None and ask_f is not None:
+                            spread = ask_f - bid_f
+                        if mid in (None, "") and bid_f is not None and ask_f is not None:
+                            mid = (ask_f + bid_f) / 2.0
                         spread_pct = quote_map.get("spread_pct")
                         if spread_pct in (None, "") and spread not in (None, "") and mid not in (None, "", 0):
-                            with suppress(Exception):
-                                spread_pct = (float(spread) / float(mid)) * 100.0
+                            spread_f = _extract_float({"value": spread}, "value")
+                            mid_f = _extract_float({"value": mid}, "value")
+                            if spread_f is not None and mid_f not in (None, 0.0):
+                                spread_pct = (spread_f / mid_f) * 100.0
+                        tradable_quote = bool(quote_map.get("tradable_quote"))
+                        if not tradable_quote and bid_f is not None and ask_f is not None:
+                            tradable_quote = ask_f > bid_f
                         runtime_ctx.update({
                             "bid": bid,
                             "ask": ask,
@@ -7190,7 +7194,7 @@ class StrategyRunner:
                             "sell_qty": quote_map.get("sell_qty") or tick_map.get("sell_qty") or ask_qty,
                             "depth": depth_payload,
                             "depth_available": bool(quote_map.get("depth_available") or depth_payload),
-                            "tradable_quote": bool(quote_map.get("tradable_quote") or (bid and ask and float(ask) > float(bid))),
+                            "tradable_quote": tradable_quote,
                             "spread": spread,
                             "mid": mid,
                             "spread_pct": spread_pct,
@@ -7238,6 +7242,11 @@ class StrategyRunner:
                             price,
                             trace_id=trace_id,
                         )
+                        if pending_eval_bar_ts is not None:
+                            with self._lock:
+                                state_after = self._symbol_state.get(symbol)
+                                if state_after is not None:
+                                    state_after._last_eval_bar_ts = pending_eval_bar_ts
                         if signal is None:
                             self._emit_runner_eval_decision(
                                 symbol=symbol,

--- a/tests/strategies/test_runner_phase9_quote_context.py
+++ b/tests/strategies/test_runner_phase9_quote_context.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from nifty_scalper_bot.strategies.runner import StrategyRunner, StrategyRunnerConfig
+
+
+def _runner() -> StrategyRunner:
+    return StrategyRunner(
+        market_data_manager=MagicMock(),
+        indicator_engine=MagicMock(),
+        strategy_manager=MagicMock(),
+        risk_manager=MagicMock(),
+        order_manager=MagicMock(),
+        position_manager=MagicMock(),
+        config=StrategyRunnerConfig(max_trade_history=5),
+        data_hub=MagicMock(),
+    )
+
+
+def test_runner_imports_suppress_for_phase9_quote_context() -> None:
+    source = Path('src/nifty_scalper_bot/strategies/runner.py').read_text(encoding='utf-8')
+
+    assert 'from contextlib import suppress' in source
+    assert 'with suppress(Exception):' in source
+
+
+def test_strategy_eval_allowed_reports_integrity_failure_reason() -> None:
+    runner = _runner()
+    symbol = 'NFO:NIFTY26MAY25000FUT'
+    runner._active_symbols = {symbol}
+    runner._required_bars_for_symbol = MagicMock(return_value=5)
+    runner._indicator_engine.get_history.return_value = [1] * 50
+    runner._indicator_engine.has_min_bars.return_value = False
+    emitted: list[str] = []
+    runner._emit_runner_eval_decision = lambda **kwargs: emitted.append(kwargs.get('reason'))
+
+    allowed = runner._strategy_evaluation_allowed(symbol, trace_id='t1')
+
+    assert allowed is False
+    assert emitted[-1] == 'indicator_history_integrity_failed'
+
+
+def test_strategy_eval_allowed_reports_insufficient_bar_count_reason() -> None:
+    runner = _runner()
+    symbol = 'NFO:NIFTY26MAY25000CE'
+    runner._active_symbols = {symbol}
+    runner._required_bars_for_symbol = MagicMock(return_value=20)
+    runner._indicator_engine.get_history.return_value = [1, 2]
+    runner._indicator_engine.has_min_bars.return_value = False
+    emitted: list[str] = []
+    runner._emit_runner_eval_decision = lambda **kwargs: emitted.append(kwargs.get('reason'))
+
+    allowed = runner._strategy_evaluation_allowed(symbol, trace_id='t2')
+
+    assert allowed is False
+    assert emitted[-1] == 'insufficient_indicator_bar_count'


### PR DESCRIPTION
### Motivation
- Phase9 evaluation was erroring in live trading due to a missing `suppress` import causing `NameError`, malformed bid/ask payloads causing crashes, and a premature commit of the same-bar timestamp that caused subsequent same-bar skips after a failed evaluation.
- Gate diagnostics were conflating insufficient bar counts with indicator-history integrity failures, making troubleshooting harder.

### Description
- Added `from contextlib import suppress` to `src/nifty_scalper_bot/strategies/runner.py` and aligned usages to remove the `NameError` blocker.
- Prevented false same-bar skips by storing `pending_eval_bar_ts` and only committing `state._last_eval_bar_ts` after `StrategyManager.generate_signal(...)` returns normally, so failed evaluations do not mark the candle as evaluated. (keeps `_last_eval_bar_ts` unchanged on exceptions)
- Hardened the phase9 quote context by using `_extract_float` for bid/ask-derived numeric values and precomputing `bid_f`, `ask_f`, `spread`, `mid`, `spread_pct`, and `tradable_quote` safely to ensure malformed quote payloads cannot crash evaluation.
- Split the strategy evaluation gate diagnostic into two clearer reasons: `insufficient_indicator_bar_count` and `indicator_history_integrity_failed`.
- Added regression tests in `tests/strategies/test_runner_phase9_quote_context.py` covering the `suppress` import presence and the gate-reason split behavior.

### Testing
- Ran `python -m compileall src` which compiled `runner.py` successfully (no syntax errors) and returned success for the modified module.
- Ran the targeted tests via `pytest -q tests/strategies/test_runner_phase9_quote_context.py` and they passed.
- Ran full `pytest -q` which failed due to an unrelated existing test environment issue (`ModuleNotFoundError: No module named 'market_data_manager'` in `tests/test_mdm_diagnostics.py`), not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04161a5080832481ce94852472b37f)