### PR TITLE
fix: unblock live hydration, indicator readiness, and volume normalization

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -8095,11 +8095,28 @@ async def startup_sequence(ctx: BotContext) -> None:
 
             def _resolve_startup_token(symbol: str) -> int | None:
                 """Resolve startup token by symbol class. Args: symbol. Returns: token or None. Raises: None."""
+                canonical = str(symbol or "").strip().upper()
+                well_known_spot_tokens = {
+                    "NSE:NIFTY": 256265,
+                    "NIFTY": 256265,
+                    "NSE:NIFTY50": 256265,
+                    "NIFTY50": 256265,
+                }
+                if canonical in well_known_spot_tokens:
+                    return int(well_known_spot_tokens[canonical])
                 if _is_nfo_symbol(symbol):
                     if ctx.instrument_manager and ctx.instrument_manager.is_loaded():
                         try:
                             return int(ctx.instrument_manager.get_token(symbol))
                         except RuntimeError:
+                            return None
+                        except Exception as exc:
+                            LOGGER.warning(
+                                "startup_nfo_token_unresolved symbol=%s err=%s",
+                                symbol,
+                                exc,
+                                extra={"event": "startup_nfo_token_unresolved", "symbol": symbol},
+                            )
                             return None
                     return None
                 if ctx.broker_client and hasattr(ctx.broker_client, "get_instrument_token"):
@@ -8144,6 +8161,18 @@ async def startup_sequence(ctx: BotContext) -> None:
                 len(active_symbol_tokens),
                 active_symbol_tokens.get(atm_ce) if atm_ce else None,
                 active_symbol_tokens.get(atm_pe) if atm_pe else None,
+            )
+            LOGGER.info(
+                "HYDRATION_SYMBOLS_FINAL symbols=%s has_spot=%s has_futures=%s",
+                symbols_to_hydrate,
+                "NSE:NIFTY" in symbols_to_hydrate,
+                any(str(s).startswith("NFO:NIFTY") and str(s).endswith("FUT") for s in symbols_to_hydrate),
+                extra={
+                    "event": "HYDRATION_SYMBOLS_FINAL",
+                    "symbols": symbols_to_hydrate,
+                    "has_spot": "NSE:NIFTY" in symbols_to_hydrate,
+                    "has_futures": any(str(s).startswith("NFO:NIFTY") and str(s).endswith("FUT") for s in symbols_to_hydrate),
+                },
             )
             LOGGER.info(
                 "HYDRATION_PLAN_STARTUP symbols=%d bars_target=%d lookback_days=%d",

--- a/src/nifty_scalper_bot/core/strategy_manager.py
+++ b/src/nifty_scalper_bot/core/strategy_manager.py
@@ -2532,7 +2532,23 @@ class StrategyManager(_BaseStrategyManager):
         indicators: t.Mapping[str, t.Any],
     ) -> Signal | None:
         """Args: symbol/signals/indicators. Returns: consensus signal or None. Raises: none."""
-        del symbol, indicators
+        symbol_norm = str(symbol or "").strip().upper()
+        indicator_map = dict(indicators or {})
+        selected_symbols = {
+            str(indicator_map.get("selected_ce") or "").strip().upper(),
+            str(indicator_map.get("selected_pe") or "").strip().upper(),
+        }
+        selected_symbols.discard("")
+        indicator_selected_option = bool(
+            indicator_map.get("is_selected_option")
+            or symbol_norm in selected_symbols
+        )
+        indicator_near_atm = False
+        try:
+            if indicator_map.get("strike_distance_from_atm") is not None:
+                indicator_near_atm = float(indicator_map.get("strike_distance_from_atm")) <= 50.0
+        except (TypeError, ValueError):
+            indicator_near_atm = False
         if not signals:
             return None
         trigger_votes: list[tuple[Signal, StrategyVote]] = []
@@ -2546,6 +2562,20 @@ class StrategyManager(_BaseStrategyManager):
             else:
                 trigger_votes.append((signal, vote))
         if not trigger_votes:
+            log_throttled(
+                log,
+                f"strategy_no_trigger_vote:{symbol_norm}",
+                "STRATEGY_NO_TRIGGER_VOTE symbol=%s context_votes=%s",
+                symbol_norm,
+                [v.strategy for _, v in context_votes],
+                interval_sec=30.0,
+                level=logging.INFO,
+                extra={
+                    "event": "STRATEGY_NO_TRIGGER_VOTE",
+                    "symbol": symbol_norm,
+                    "context_votes": [v.strategy for _, v in context_votes],
+                },
+            )
             return None
         best_signal, best_vote = max(trigger_votes, key=lambda pair: pair[1].score)
         threshold = float(os.getenv("STRATEGY_TRIGGER_MIN_SCORE", "4.5") or "4.5")
@@ -2564,8 +2594,12 @@ class StrategyManager(_BaseStrategyManager):
         if opposite_context and max(v.score for v in opposite_context) >= 8.0:
             vetoed = True
         if len(trigger_votes) == 1:
-            selected_option = bool((best_signal.metadata or {}).get("is_selected_option"))
-            near_atm = float((best_signal.metadata or {}).get("strike_distance_from_atm") or 999.0) <= 50.0
+            metadata = dict(best_signal.metadata or {})
+            selected_option = bool(metadata.get("is_selected_option") or indicator_selected_option)
+            try:
+                near_atm = float(metadata.get("strike_distance_from_atm")) <= 50.0
+            except (TypeError, ValueError):
+                near_atm = indicator_near_atm
             score_min, conf_min = self._single_vote_thresholds(best_vote.strategy)
             score_ok = best_vote.score >= score_min
             conf_ok = best_vote.confidence >= conf_min
@@ -2591,6 +2625,8 @@ class StrategyManager(_BaseStrategyManager):
         if vetoed or final_score < threshold:
             return None
         metadata = dict(best_signal.metadata or {})
+        metadata["is_selected_option"] = bool(metadata.get("is_selected_option") or indicator_selected_option)
+        metadata["indicator_near_atm"] = bool(indicator_near_atm)
         metadata.setdefault("trigger_strategy_score", metadata.get("strategy_score"))
         metadata["consensus_score"] = round(final_score, 3)
         metadata["strategy_score"] = round(final_score, 3)

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -231,6 +231,7 @@ class MarketDataManager:
         self._engines: dict[str, CandleEngine] = {}
         self._last_historical_ts: dict[str, float] = {}
         self._last_tick_ts: dict[str, float] = {}
+        self._last_cumulative_volume_by_symbol: dict[str, float] = {}
         self._last_tick_snapshot: dict[str, dict[str, Any]] = {}
         self._readiness_requirements: dict[str, Any] = {}
         self._last_readiness_state: dict[str, Any] = {
@@ -4577,6 +4578,38 @@ class MarketDataManager:
         mid = ((bid + ask) / 2.0) if (bid is not None and ask is not None and bid > 0 and ask > 0) else None
         return {"bid": bid, "ask": ask, "best_bid": bid, "best_ask": ask, "bid_qty": bid_qty, "ask_qty": ask_qty, "mid": mid, "spread": spread, "depth": depth, "depth_available": depth_available, "tradable_quote": bool(bid is not None and ask is not None and bid > 0 and ask > bid), "bid_missing": not bool(bid and bid > 0), "ask_missing": not bool(ask and ask > 0), "bid_ask_source": "ws_full" if depth_available else ("quote" if bid is not None or ask is not None else "missing")}
 
+    def _normalise_tick_volume_delta(self, symbol: str, raw: dict[str, Any]) -> dict[str, Any]:
+        """Convert cumulative broker volume into per-tick delta volume. Args: symbol/raw. Returns: normalized payload. Raises: none."""
+        payload = dict(raw)
+        cumulative_raw = (
+            payload.get("volume_traded_today")
+            or payload.get("volume_traded")
+            or payload.get("total_traded_volume")
+        )
+        if cumulative_raw is None:
+            return payload
+        try:
+            cumulative = float(cumulative_raw)
+        except (TypeError, ValueError):
+            return payload
+        key = self._canonical_symbol(symbol)
+        previous = self._last_cumulative_volume_by_symbol.get(key)
+        if previous is None:
+            ltq_raw = payload.get("last_traded_quantity") or payload.get("last_quantity") or payload.get("ltq")
+            try:
+                delta = max(float(ltq_raw), 0.0) if ltq_raw is not None else 0.0
+            except (TypeError, ValueError):
+                delta = 0.0
+        elif cumulative >= previous:
+            delta = cumulative - previous
+        else:
+            delta = 0.0
+        self._last_cumulative_volume_by_symbol[key] = cumulative
+        payload["volume_cumulative"] = cumulative
+        payload["volume_delta"] = delta
+        payload["volume"] = delta
+        return payload
+
     def _process_queued_tick(self, raw: dict[str, Any]) -> None:
         raw = self._normalize_ws_tick(raw)
         if raw is None:
@@ -4603,6 +4636,11 @@ class MarketDataManager:
                 )
                 return
             raw = {**raw, "symbol": symbol_from_map}
+            raw = self._normalise_tick_volume_delta(symbol_from_map or raw.get("symbol", ""), raw)
+
+        symbol = str(raw.get("symbol") or "")
+        if symbol:
+            raw = self._normalise_tick_volume_delta(symbol, raw)
 
         try:
             tick = validate_tick(raw)
@@ -7083,7 +7121,8 @@ class MarketDataManager:
                 "spread": spread,
                 "last_price": ltp,
                 "instrument_token": token,
-                "volume": _coerce_int(raw.get("volume") or raw.get("volume_traded") or raw.get("volume_traded_today")),
+                "volume": _coerce_int(raw.get("volume") or raw.get("volume_delta") or 0),
+                "volume_cumulative": _coerce_int(raw.get("volume_cumulative") or raw.get("volume_traded_today") or raw.get("volume_traded")),
                 "oi": _coerce_int(raw.get("oi")),
                 "depth": depth_obj,
                 "depth_available": bool(depth_obj),

--- a/src/nifty_scalper_bot/strategies/elite_strategies/order_flow.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/order_flow.py
@@ -38,6 +38,9 @@ class OrderFlowStrategy(EliteStrategy):
             contract_side, option_premium_domain, _ = resolve_signal_domain(symbol, indicators)
             atr = max(float(indicators.get('atr') or 0.0), current_price * 0.01, 1.0)
 
+            allow_orderflow_trigger = str(
+                os.getenv('ORDERFLOW_ALLOW_TRIGGER_ROLE', 'false')
+            ).strip().lower() in {'1', 'true', 'yes', 'on'}
             if bid <= 0 or ask <= 0 or ask <= bid:
                 self._no_vote('ltp_only_no_depth' if not depth else 'missing_bid_ask')
                 LOGGER.debug('STRATEGY_NO_VOTE strategy=OrderFlow reason=missing_bid_ask')
@@ -87,7 +90,7 @@ class OrderFlowStrategy(EliteStrategy):
                     self._no_vote('weak_tick_confirmation')
                     return None
                 metadata = {'orderflow_depth_source': 'ltp_tick_fallback', 'risk_label': 'ltp_only_orderflow_reduced_confidence'}
-                metadata.update({'strategy': 'OrderFlow', 'strategy_name': 'OrderFlow', 'role': 'context', 'source_domain': 'market_microstructure', 'context_score': strategy_score, 'side': side, 'direction_bias': side, 'strategy_score': strategy_score, 'spread_pct': round(spread_pct, 3), 'depth_imbalance': 0.0, 'tick_direction': tick_direction, 'premium_stop_distance': max(0.8 * atr, current_price * 0.02, 1.0), 'premium_target_rr': 1.8})
+                metadata.update({'strategy': 'OrderFlow', 'strategy_name': 'OrderFlow', 'role': 'trigger' if allow_orderflow_trigger and strategy_score >= 7.0 and spread_pct <= 8.0 else 'context', 'source_domain': 'market_microstructure', 'context_score': strategy_score, 'side': side, 'direction_bias': side, 'strategy_score': strategy_score, 'spread_pct': round(spread_pct, 3), 'depth_imbalance': 0.0, 'tick_direction': tick_direction, 'premium_stop_distance': max(0.8 * atr, current_price * 0.02, 1.0), 'premium_target_rr': 1.8})
                 return EliteSignal(symbol=symbol, signal='BUY', confidence=max(0.1, min(0.55, strategy_score / 10.0)), entry_price=current_price, stop_loss=None, target=None, quantity=self._cfg.quantity or 1, strategy_name='OrderFlow', metadata=metadata)
             depth_imbalance = (total_bid - total_ask) / max(total_bid + total_ask, 1.0)
             side = contract_side if option_premium_domain else ('CE' if depth_imbalance > 0 else 'PE')
@@ -124,7 +127,7 @@ class OrderFlowStrategy(EliteStrategy):
             metadata = {
                 'strategy': 'OrderFlow',
                 'strategy_name': 'OrderFlow',
-                'role': 'context',
+                'role': 'trigger' if allow_orderflow_trigger and strategy_score >= 7.0 and spread_pct <= 8.0 else 'context',
                 'source_domain': 'market_microstructure',
                 'context_score': strategy_score,
                 'side': side,

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -3450,14 +3450,15 @@ class StrategyRunner:
                 # FIX S12-3: was float(bar.close) — scalar input causes _normalize_price
                 # to use close for ALL of open/high/low/close, destroying ATR/EMA accuracy.
                 # Pass bar.as_mapping() so the full OHLC is stored correctly.
-                indicator_volume = 0 if getattr(bar, "synthetic", False) else bar.volume
+                synthetic_gap_fill = bool(getattr(bar, "synthetic", False))
+                indicator_volume = 0 if synthetic_gap_fill else bar.volume
                 self._indicator_engine.update_price(
                     symbol,
                     bar.as_mapping(),
                     volume=indicator_volume,
                     timestamp=bar.timestamp,
                     is_complete=True,
-                    is_provisional=bool(getattr(bar, "synthetic", False)),
+                    is_provisional=False,
                 )
 
             self._update_symbol_readiness(symbol)

--- a/tests/core/test_startup_spot_hydration_token.py
+++ b/tests/core/test_startup_spot_hydration_token.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+
+
+def test_startup_spot_hydration_has_well_known_nifty_token_fallback() -> None:
+    source = Path('src/nifty_scalper_bot/core/app.py').read_text(encoding='utf-8')
+    assert 'well_known_spot_tokens' in source
+    assert '"NSE:NIFTY": 256265' in source
+    assert '"NIFTY": 256265' in source
+    assert 'HYDRATION_SYMBOLS_FINAL' in source

--- a/tests/core/test_strategy_manager_consensus.py
+++ b/tests/core/test_strategy_manager_consensus.py
@@ -94,3 +94,25 @@ def test_single_vote_scalp_disabled_rejects_single_vote(monkeypatch) -> None:
         indicators={'selected_ce': 'NFO:NIFTY25000CE', 'selected_pe': 'NFO:NIFTY25000PE', 'atm_strike': 25000},
     )
     assert combined is None
+
+
+
+def test_context_only_vote_returns_none_and_logs(caplog) -> None:
+    manager = _manager_stub()
+    signal = _make_signal()
+    vote = StrategyVote(
+        strategy='OrderFlow',
+        side='CE',
+        score=6.0,
+        confidence=0.7,
+        reasons=[],
+        metadata={'role': 'context'},
+    )
+    caplog.set_level('INFO')
+    combined = manager._combine_strategy_votes(
+        symbol='NFO:NIFTY25000CE',
+        signals=[(signal, vote)],
+        indicators={},
+    )
+    assert combined is None
+    assert any('STRATEGY_NO_TRIGGER_VOTE' in rec.message for rec in caplog.records)

--- a/tests/data/test_mdm_volume_delta.py
+++ b/tests/data/test_mdm_volume_delta.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from nifty_scalper_bot.data.market_data_manager import MarketDataManager
+
+
+def test_normalise_tick_volume_delta_from_cumulative_sequence() -> None:
+    manager = MarketDataManager(broker=None, websocket=None)
+    symbol = 'NFO:NIFTY26MAYFUT'
+
+    tick1 = manager._normalise_tick_volume_delta(symbol, {'symbol': symbol, 'volume_traded_today': 1000})
+    tick2 = manager._normalise_tick_volume_delta(symbol, {'symbol': symbol, 'volume_traded_today': 1040})
+    tick3 = manager._normalise_tick_volume_delta(symbol, {'symbol': symbol, 'volume_traded_today': 1090})
+
+    assert tick1['volume'] == 0.0
+    assert tick2['volume'] == 40.0
+    assert tick3['volume'] == 50.0
+    assert tick3['volume_cumulative'] == 1090.0
+
+
+def test_normalise_tick_volume_delta_uses_ltq_on_first_tick() -> None:
+    manager = MarketDataManager(broker=None, websocket=None)
+    symbol = 'NFO:NIFTY26MAYFUT'
+
+    first = manager._normalise_tick_volume_delta(
+        symbol,
+        {'symbol': symbol, 'volume_traded_today': 1000, 'last_traded_quantity': 12},
+    )
+    second = manager._normalise_tick_volume_delta(symbol, {'symbol': symbol, 'volume_traded_today': 1040})
+
+    assert first['volume'] == 12.0
+    assert second['volume'] == 40.0

--- a/tests/strategies/test_runner_synthetic_gap_fill_integrity.py
+++ b/tests/strategies/test_runner_synthetic_gap_fill_integrity.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from nifty_scalper_bot.strategies.bar_builder import OneMinuteBar
+from nifty_scalper_bot.strategies.runner import StrategyRunner
+
+
+class _EngineProbe:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+
+    def update_price(self, symbol: str, _bar: dict[str, object], **kwargs: object) -> None:
+        self.calls.append({'symbol': symbol, **kwargs})
+
+
+class _Logger:
+    def warning(self, *_a, **_k) -> None:
+        return None
+
+
+def test_runner_ingests_synthetic_gap_fill_as_non_provisional() -> None:
+    runner = StrategyRunner.__new__(StrategyRunner)
+    runner._last_bar_ts = {}
+    runner._symbol_history = {}
+    runner._candle_versions = {'NFO:NIFTY26MAYFUT': 0}
+    runner._indicator_engine = _EngineProbe()
+    runner._update_symbol_readiness = lambda _s: None
+    runner._bracket_manager = None
+    runner._strategy_manager = None
+    runner._main_loop = None
+    runner._logger = _Logger()
+
+    ts = datetime(2026, 5, 1, 9, 15, tzinfo=timezone.utc)
+    bar = OneMinuteBar(
+        open=100.0,
+        high=101.0,
+        low=99.0,
+        close=100.5,
+        volume=100,
+        start=ts,
+        end=ts + timedelta(seconds=59),
+        synthetic=True,
+    )
+
+    runner._ingest_bar('NFO:NIFTY26MAYFUT', bar, is_backfill=True)
+
+    assert runner._indicator_engine.calls
+    call = runner._indicator_engine.calls[-1]
+    assert call['is_complete'] is True
+    assert call['is_provisional'] is False
+    assert call['volume'] == 0


### PR DESCRIPTION
### Motivation
- Hydration skipped NSE:NIFTY when broker token lookup failed, leaving the runner with only a few live bars and blocking execution.
- Synthetic gap-repair bars were being flagged provisional, causing indicator history integrity failures for futures despite full closed bars.
- Zerodha WS provides cumulative day volume which leaked into candle builders and VWAP calculations, producing absurd average volumes and misleading signals.

### Description
- Startup hydration: added a small internal `well_known_spot_tokens` fallback for NIFTY aliases and a `HYDRATION_SYMBOLS_FINAL` observability log to ensure NSE:NIFTY is included in startup hydration when broker lookup fails (file: `core/app.py`).
- Runner ingestion: treat synthetic gap-repair bars as completed, non-provisional candles when feeding the indicator engine while preserving zero-volume semantics (file: `strategies/runner.py`).
- MDM volume normalization: add per-symbol state to convert cumulative WS `volume_traded`/`volume_traded_today` into a single per-tick delta (`volume_delta` / `volume`), preserve `volume_cumulative` for diagnostics, and wire normalization into `_process_queued_tick` and `normalize_live_tick` outputs (file: `data/market_data_manager.py`).
- Consensus & observability: make single-vote gating use runner-provided indicator context (`selected_ce/pe`, `strike_distance_from_atm`) and enrich final signal metadata accordingly, and emit explicit throttled `STRATEGY_NO_TRIGGER_VOTE` logs when only context votes (e.g., OrderFlow) exist (file: `core/strategy_manager.py`).
- OrderFlow opt-in trigger: add an env-gated `ORDERFLOW_ALLOW_TRIGGER_ROLE` flag so OrderFlow can be promoted to a `trigger` role only when explicitly enabled and meeting strict quality thresholds (file: `strategies/elite_strategies/order_flow.py`).
- Tests: added focused regression tests for cumulative→delta normalization, synthetic gap-fill ingestion semantics, startup NIFTY token fallback presence, and context-only vote logging (files under `tests/data`, `tests/strategies`, `tests/core`).

### Testing
- `python -m compileall src` ran successfully and compiled the modified modules without syntax errors.
- Focused pytest runs passed: `pytest -q tests/data/test_mdm_volume_delta.py`, `pytest -q tests/strategies/test_runner_synthetic_gap_fill_integrity.py`, `pytest -q tests/core/test_strategy_manager_consensus.py`, and `pytest -q tests/core/test_startup_spot_hydration_token.py` all succeeded (targeted regressions green).
- `bash run_checks.sh` was executed in this environment (dependency bootstrap completed), however the script run reported a tooling mismatch in this session (notably a transient `pytest` detection message in the run environment); core targeted tests above were run separately and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a041fe7fafc8324b297bd5dd4aa65eb)