### PR TITLE
fix: unblock live final score gate with quote revalidation

### DIFF
--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -2124,7 +2124,15 @@ class StrategyRunner:
                 "source": str(snapshot.source or "signal_snapshot"),
                 "atr_option": float(metadata.get("atr", 0.0) or 0.0),
                 "history_bars": int(metadata.get("history_bars", 0) or 0),
-                "data_quality_score": float(metadata.get("data_quality_score", 0.0) or 0.0),
+                "data_quality_score": float(
+                    metadata.get("data_quality_score")
+                    if metadata.get("data_quality_score") is not None
+                    else metadata.get("data_score", 0.0)
+                    or 0.0
+                ),
+                "candidate_selected": bool(metadata.get("candidate_selected") or metadata.get("is_selected_option")),
+                "quote_usable_for_order_plan": bool(snapshot.tradable_quote and has_bid_ask),
+                "tradable_quote": bool(snapshot.tradable_quote and has_bid_ask),
                 "effective_bars": int(metadata.get("effective_bars", metadata.get("history_bars", 0)) or 0),
             }
         except Exception as exc:  # noqa: BLE001
@@ -8817,17 +8825,67 @@ class StrategyRunner:
                     ),
                     {},
                 )
-                metadata["tradable_quote"] = bool(
-                    (selected_snapshot or {}).get("tradable_quote")
+                selected_snapshot = dict(selected_snapshot or {})
+                metadata["selected_snapshot_symbol"] = selected_snapshot.get("symbol")
+
+                snapshot_bid = selected_snapshot.get("bid")
+                snapshot_ask = selected_snapshot.get("ask")
+
+                try:
+                    snapshot_bid_f = float(snapshot_bid) if snapshot_bid is not None else 0.0
+                except (TypeError, ValueError):
+                    snapshot_bid_f = 0.0
+
+                try:
+                    snapshot_ask_f = float(snapshot_ask) if snapshot_ask is not None else 0.0
+                except (TypeError, ValueError):
+                    snapshot_ask_f = 0.0
+
+                snapshot_bid_ask_valid = bool(
+                    snapshot_bid_f > 0
+                    and snapshot_ask_f > snapshot_bid_f
                 )
-                allow_ltp_live_plan = _env_flag(
-                    "ALLOW_LTP_ONLY_LIVE_ORDER_PLAN", default=False
+
+                snapshot_tradable_quote = bool(
+                    selected_snapshot.get("tradable_quote")
+                    or snapshot_bid_ask_valid
                 )
+
+                mdm_tradable_quote = False
+                mdm_bid_ask_valid = False
+                if self._market_data is not None:
+                    try:
+                        latest_snapshot = self._market_data.get_symbol_snapshot(candidate.symbol)
+                        latest_bid = float(latest_snapshot.bid or 0.0)
+                        latest_ask = float(latest_snapshot.ask or 0.0)
+                        mdm_bid_ask_valid = bool(latest_bid > 0 and latest_ask > latest_bid)
+                        mdm_tradable_quote = bool(latest_snapshot.tradable_quote and mdm_bid_ask_valid)
+                        metadata["latest_quote_bid"] = latest_bid
+                        metadata["latest_quote_ask"] = latest_ask
+                        metadata["latest_quote_tradable"] = bool(latest_snapshot.tradable_quote)
+                    except Exception as quote_exc:  # noqa: BLE001
+                        self._logger.warning(
+                            "QUOTE_REVALIDATION_FAILED symbol=%s err=%s trace_id=%s",
+                            candidate.symbol,
+                            quote_exc,
+                            trace_id,
+                            extra={
+                                "event": "QUOTE_REVALIDATION_FAILED",
+                                "symbol": candidate.symbol,
+                                "trace_id": trace_id,
+                                "error": str(quote_exc),
+                            },
+                        )
+
+                allow_ltp_live_plan = _env_flag("ALLOW_LTP_ONLY_LIVE_ORDER_PLAN", default=False)
+
+                metadata["tradable_quote"] = bool(snapshot_tradable_quote or mdm_tradable_quote)
                 metadata["quote_usable_for_order_plan"] = bool(
-                    (selected_snapshot or {}).get("tradable_quote")
+                    snapshot_tradable_quote
+                    or mdm_tradable_quote
                     or (
                         allow_ltp_live_plan
-                        and (selected_snapshot or {}).get("ltp_only_fallback")
+                        and selected_snapshot.get("ltp_only_fallback")
                         and candidate.entry_price
                         and candidate.stop_loss
                         and candidate.target
@@ -8920,17 +8978,42 @@ class StrategyRunner:
                 )
                 has_candidate = bool(metadata.get("candidate_selected"))
                 has_quote_usable = bool(metadata.get("quote_usable_for_order_plan"))
+                missing_components = [
+                    component
+                    for component in required_components
+                    if metadata.get(component) is None
+                ]
+
                 if not (has_components and has_candidate and has_quote_usable):
                     self._logger.info(
-                        "SIGNAL_EXECUTION_RESULT accepted=False reason=final_score_required symbol=%s trace_id=%s",
+                        "SIGNAL_EXECUTION_RESULT accepted=False reason=final_score_required "
+                        "symbol=%s trace_id=%s has_components=%s missing_components=%s "
+                        "has_candidate=%s has_quote_usable=%s candidate_symbol=%s "
+                        "tradable_quote=%s quote_usable_for_order_plan=%s selected_snapshot_symbol=%s",
                         base_symbol,
                         trace_id,
+                        has_components,
+                        missing_components,
+                        has_candidate,
+                        has_quote_usable,
+                        metadata.get("candidate_symbol"),
+                        metadata.get("tradable_quote"),
+                        metadata.get("quote_usable_for_order_plan"),
+                        metadata.get("selected_snapshot_symbol"),
                         extra={
                             "event": "SIGNAL_EXECUTION_RESULT",
                             "accepted": False,
                             "reason": "final_score_required",
                             "symbol": base_symbol,
                             "trace_id": trace_id,
+                            "has_components": has_components,
+                            "missing_components": missing_components,
+                            "has_candidate": has_candidate,
+                            "has_quote_usable": has_quote_usable,
+                            "candidate_symbol": metadata.get("candidate_symbol"),
+                            "tradable_quote": metadata.get("tradable_quote"),
+                            "quote_usable_for_order_plan": metadata.get("quote_usable_for_order_plan"),
+                            "selected_snapshot_symbol": metadata.get("selected_snapshot_symbol"),
                         },
                     )
                     self._reset_execution_state(base_symbol)

--- a/tests/strategies/test_runner_final_score_gate.py
+++ b/tests/strategies/test_runner_final_score_gate.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from nifty_scalper_bot.strategies.runner import StrategyRunner
+from nifty_scalper_bot.strategies.signal_generator import Signal
+
+
+class _Snapshot:
+    def __init__(self, *, ltp: float = 431.05, bid: float = 0.0, ask: float = 0.0, tradable_quote: bool = False) -> None:
+        self.ltp = ltp
+        self.bid = bid
+        self.ask = ask
+        self.tradable_quote = tradable_quote
+        self.source = 'ws'
+        self.tick_age_s = 0.1
+        self.real_ticks_last_60s = 5
+
+
+def _build_runner() -> StrategyRunner:
+    runner = StrategyRunner.__new__(StrategyRunner)
+    runner._logger = MagicMock()
+    runner._runtime_data_hard_ready = True
+    runner._runtime_evaluation_ready = True
+    runner._runtime_live_orders_armed = True
+    runner._runtime_readiness_reason = None
+    runner._order_manager = MagicMock()
+    runner._order_manager.is_kill_switch_active = MagicMock(return_value=False)
+    runner._order_manager.submit_trade_plan = MagicMock(return_value='order-1')
+    runner._reset_execution_state = MagicMock()
+    runner._trade_candidate_selector = MagicMock()
+    runner._trade_candidate_selector.select_best_candidate = MagicMock(
+        return_value=SimpleNamespace(
+            symbol='NFO:NIFTY26MAY23350CE',
+            score=6.0,
+            data_quality_score=8.0,
+            rr=1.8,
+            side='CE',
+            spread_pct=0.35,
+            entry_price=431.05,
+            stop_loss=420.27,
+            target=452.60,
+        )
+    )
+    return runner
+
+
+def _build_signal(metadata: dict) -> Signal:
+    return Signal(
+        action='BUY',
+        symbol='NFO:NIFTY26MAY23350CE',
+        quantity=1,
+        confidence=0.65,
+        reason='SMC',
+        stop_loss=420.27,
+        take_profit=452.60,
+        metadata=metadata,
+    )
+
+
+def test_final_score_gate_passes_precheck_and_not_generic_rejection(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv('EXECUTION_MODE', 'LIVE')
+    runner = _build_runner()
+    runner._market_data = SimpleNamespace(get_symbol_snapshot=lambda _symbol: _Snapshot(bid=431.15, ask=432.65, tradable_quote=True))
+    metadata = {
+        'preliminary_only': True,
+        'requires_runner_final_score': True,
+        'direction_score': 6.0,
+        'strategy_score': 6.0,
+        'data_score': 8.0,
+        'candidate_selected': True,
+        'candidate_snapshots': [
+            {'symbol': 'NFO:NIFTY26MAY23350CE', 'bid': 431.15, 'ask': 432.65, 'tradable_quote': True, 'ltp': 431.05, 'atm_strike': 23350}
+        ],
+        'atm_strike': 23350,
+    }
+    result = runner._handle_entry_signal_inner(_build_signal(metadata), 'NFO:NIFTY26MAY23350CE', 'NFO:NIFTY26MAY23350CE', 431.05, datetime.now(timezone.utc), trace_id='t1')
+    assert result.reason != 'final_score_required'
+
+
+def test_quote_usable_from_mdm_revalidation(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv('EXECUTION_MODE', 'LIVE')
+    runner = _build_runner()
+    runner._market_data = SimpleNamespace(get_symbol_snapshot=lambda _symbol: _Snapshot(bid=431.15, ask=432.65, tradable_quote=True))
+    metadata = {
+        'preliminary_only': True,
+        'requires_runner_final_score': True,
+        'direction_score': 6.0,
+        'strategy_score': 6.0,
+        'data_score': 8.0,
+        'candidate_selected': True,
+        'candidate_snapshots': [{'symbol': 'NFO:NIFTY26MAY23350CE', 'bid': 0.0, 'ask': 0.0, 'tradable_quote': False, 'ltp': 431.05, 'atm_strike': 23350}],
+        'atm_strike': 23350,
+    }
+    result = runner._handle_entry_signal_inner(_build_signal(metadata), 'NFO:NIFTY26MAY23350CE', 'NFO:NIFTY26MAY23350CE', 431.05, datetime.now(timezone.utc), trace_id='t2')
+    assert result.reason != 'final_score_required'
+
+
+def test_final_score_required_when_snapshot_and_mdm_not_usable(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv('EXECUTION_MODE', 'LIVE')
+    runner = _build_runner()
+    runner._market_data = SimpleNamespace(get_symbol_snapshot=lambda _symbol: _Snapshot(bid=0.0, ask=0.0, tradable_quote=False))
+    metadata = {
+        'preliminary_only': True,
+        'requires_runner_final_score': True,
+        'direction_score': 6.0,
+        'strategy_score': 6.0,
+        'data_score': 8.0,
+        'candidate_selected': True,
+        'candidate_snapshots': [{'symbol': 'NFO:NIFTY26MAY23350CE', 'bid': 0.0, 'ask': 0.0, 'tradable_quote': False, 'ltp': 431.05, 'atm_strike': 23350}],
+        'atm_strike': 23350,
+    }
+    result = runner._handle_entry_signal_inner(_build_signal(metadata), 'NFO:NIFTY26MAY23350CE', 'NFO:NIFTY26MAY23350CE', 431.05, datetime.now(timezone.utc), trace_id='t3')
+    assert result.reason == 'final_score_required'
+
+
+def test_build_single_candidate_uses_data_score_fallback() -> None:
+    runner = _build_runner()
+    runner._market_data = SimpleNamespace(get_symbol_snapshot=lambda _symbol: _Snapshot(bid=431.15, ask=432.65, tradable_quote=True))
+    signal = _build_signal({'data_score': 8.0, 'atm_strike': 23350})
+    candidate = runner._build_single_candidate_from_signal(signal=signal, metadata=signal.metadata or {}, option_side='CE')
+    assert candidate is not None
+    assert candidate['data_quality_score'] == 8.0


### PR DESCRIPTION
### Motivation
- Live SMC signals were entering order path and materializing trade plans but getting blocked by an opaque `final_score_required` rejection with no diagnostic data. 
- Quote usability was determined only from the selected snapshot and could falsely reject live orders when the latest MDM snapshot had valid bid/ask. 
- Fallback candidate construction lost useful scoring metadata (`data_score` → `data_quality_score`) preventing correct final-score computation and tracing.

### Description
- Added detailed diagnostics to the early `final_score_required` rejection in `_handle_entry_signal_inner`, logging `has_components`, `missing_components`, `has_candidate`, `has_quote_usable`, `candidate_symbol`, `selected_snapshot_symbol`, and latest quote fields in both message and `extra` context. 
- Rewrote candidate quote-usability logic to normalize `selected_snapshot`, validate `bid`/`ask` shape locally, revalidate against the latest MDM snapshot via `self._market_data.get_symbol_snapshot(...)`, and set `latest_quote_bid`/`latest_quote_ask`/`latest_quote_tradable` metadata before deciding `quote_usable_for_order_plan`. 
- Preserved and surfaced candidate metadata after selection (`candidate_symbol`, `candidate_entry_price`, `candidate_stop_loss`, `candidate_target`, `candidate_rr`, `candidate_data_quality_score`, `candidate_spread_pct`) while keeping existing max()-based score semantics. 
- Updated `_build_single_candidate_from_signal` to fallback `data_quality_score` from `data_score` when `data_quality_score` is absent and to include `candidate_selected`, `quote_usable_for_order_plan`, and `tradable_quote` fields. 
- Kept regime gate behavior unchanged and ensured its logs still include `regime_inputs`, `strategy`, `confidence/score`, `symbol`, and `trace_id`. 
- Added focused tests at `tests/strategies/test_runner_final_score_gate.py` covering precheck pass, MDM revalidation path, hard rejection when neither source is usable, and candidate `data_score` fallback.

### Testing
- Ran `python -m compileall src` which completed successfully. 
- Ran `pytest -q tests/strategies/test_runner_final_score_gate.py` which passed. 
- Ran full `pytest -q` which failed due to a pre-existing unrelated test import error (`ModuleNotFoundError: No module named 'market_data_manager'` in `tests/test_mdm_diagnostics.py`). 
- Executed `bash run_checks.sh` in CI-like environment which created a venv and installed deps but reported missing test tooling in that ephemeral environment (Ruff/mypy skipped and the script flagged pytest availability), so the full `run_checks.sh` workflow did not complete cleanly in this runner.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0441dabc3c83249b8295567948760d)