### PR TITLE
refactor: separate setup/regime/context/execution decision gates

### DIFF
--- a/src/nifty_scalper_bot/core/strategy_manager.py
+++ b/src/nifty_scalper_bot/core/strategy_manager.py
@@ -322,6 +322,9 @@ def signal_to_vote(signal: Signal, strategy_name: str) -> StrategyVote:
     metadata["vote_score_raw_strategy"] = score_candidate
     metadata["vote_score_from_confidence"] = confidence_score
     metadata["vote_score"] = max(0.0, min(10.0, score))
+    metadata["raw_setup_score"] = max(0.0, min(10.0, score))
+    metadata["setup_score"] = max(0.0, min(10.0, score))
+    metadata["raw_confidence"] = max(0.0, min(1.0, float(signal.confidence or 0.0)))
     metadata["score_reasons"] = reason_list
     return StrategyVote(
         strategy=strategy_name,
@@ -2551,6 +2554,30 @@ class StrategyManager(_BaseStrategyManager):
             indicator_near_atm = False
         if not signals:
             return None
+        def _raw_score(vote: StrategyVote) -> float:
+            payload = dict(vote.metadata or {})
+            try:
+                return float(
+                    payload.get("raw_vote_score")
+                    if payload.get("raw_vote_score") is not None
+                    else payload.get("raw_setup_score")
+                    if payload.get("raw_setup_score") is not None
+                    else payload.get("vote_score")
+                    if payload.get("vote_score") is not None
+                    else vote.score
+                )
+            except (TypeError, ValueError):
+                return float(vote.score or 0.0)
+        def _weighted_score(vote: StrategyVote) -> float:
+            try:
+                return float(vote.score or 0.0)
+            except (TypeError, ValueError):
+                return 0.0
+        def _regime_weight(vote: StrategyVote) -> float:
+            try:
+                return float((vote.metadata or {}).get("regime_weight", 1.0) or 1.0)
+            except (TypeError, ValueError):
+                return 1.0
         trigger_votes: list[tuple[Signal, StrategyVote]] = []
         context_votes: list[tuple[Signal, StrategyVote]] = []
         for signal, vote in signals:
@@ -2576,20 +2603,40 @@ class StrategyManager(_BaseStrategyManager):
                     "context_votes": [v.strategy for _, v in context_votes],
                 },
             )
+            log.info(
+                "TRADE_DECISION_TRACE symbol=%s strategy=%s side=%s allowed=%s blocked_at=%s blocked_reason=%s context_votes=%s",
+                symbol_norm,
+                "context_only",
+                "UNKNOWN",
+                False,
+                "strategy_manager_trigger_gate",
+                "no_trigger_vote",
+                [v.strategy for _, v in context_votes],
+                extra={
+                    "event": "TRADE_DECISION_TRACE",
+                    "symbol": symbol_norm,
+                    "strategy": "context_only",
+                    "allowed": False,
+                    "blocked_at": "strategy_manager_trigger_gate",
+                    "blocked_reason": "no_trigger_vote",
+                    "context_votes": [v.strategy for _, v in context_votes],
+                },
+            )
             return None
-        best_signal, best_vote = max(trigger_votes, key=lambda pair: pair[1].score)
+        best_signal, best_vote = max(trigger_votes, key=lambda pair: _raw_score(pair[1]))
         threshold = float(os.getenv("STRATEGY_TRIGGER_MIN_SCORE", "4.5") or "4.5")
         single_high = float(os.getenv("STRATEGY_SINGLE_VOTE_HIGH_CONVICTION", "8.8") or "8.8")
         allow_scalp_single = str(os.getenv("STRATEGY_ALLOW_SINGLE_VOTE_SCALP", "false")).lower() in {"1", "true", "yes", "on"}
-        final_score = float(best_vote.score)
+        raw_trigger_score = _raw_score(best_vote)
+        weighted_trigger_score = _weighted_score(best_vote)
         vetoed = False
         same_side_context = [v for _, v in context_votes if v.side == best_vote.side]
         opposite_context = [v for _, v in context_votes if v.side in {"CE", "PE"} and v.side != best_vote.side]
         positive_context = sum(float(v.score) for v in same_side_context)
         negative_context = sum(float(v.score) for v in opposite_context)
-        final_score = float(best_vote.score)
-        final_score += min(1.5, 0.45 * positive_context)
-        final_score -= min(1.5, 0.60 * negative_context)
+        context_bonus = min(1.5, 0.45 * positive_context)
+        context_penalty = min(1.5, 0.60 * negative_context)
+        final_score = raw_trigger_score + context_bonus - context_penalty
         final_score = max(0.0, min(10.0, final_score))
         if opposite_context and max(v.score for v in opposite_context) >= 8.0:
             vetoed = True
@@ -2601,28 +2648,71 @@ class StrategyManager(_BaseStrategyManager):
             except (TypeError, ValueError):
                 near_atm = indicator_near_atm
             score_min, conf_min = self._single_vote_thresholds(best_vote.strategy)
-            score_ok = best_vote.score >= score_min
+            regime_weight = _regime_weight(best_vote)
+            score_ok = raw_trigger_score >= score_min
             conf_ok = best_vote.confidence >= conf_min
             selected_ok = selected_option or near_atm
             log.info(
-                "SINGLE_VOTE_DECISION strategy=%s score=%.2f score_min=%.2f confidence=%.2f conf_min=%.2f selected_ok=%s vetoed=%s",
+                "SINGLE_VOTE_DECISION strategy=%s raw_score=%.2f weighted_score=%.2f regime_weight=%.2f score_min=%.2f confidence=%.2f conf_min=%.2f selected_ok=%s vetoed=%s",
                 best_vote.strategy,
-                best_vote.score,
+                raw_trigger_score,
+                weighted_trigger_score,
+                regime_weight,
                 score_min,
                 best_vote.confidence,
                 conf_min,
                 selected_ok,
                 vetoed,
+                extra={
+                    "event": "SINGLE_VOTE_DECISION",
+                    "symbol": symbol_norm,
+                    "strategy": best_vote.strategy,
+                    "raw_score": raw_trigger_score,
+                    "weighted_score": weighted_trigger_score,
+                    "regime_weight": regime_weight,
+                    "score_min": score_min,
+                    "confidence": best_vote.confidence,
+                    "conf_min": conf_min,
+                    "selected_ok": selected_ok,
+                    "vetoed": vetoed,
+                },
             )
-            if best_vote.score >= single_high and selected_ok and not vetoed:
+            if raw_trigger_score >= single_high and selected_ok and not vetoed:
                 metadata_stage = "preliminary_single_high_conviction"
             elif allow_scalp_single and score_ok and conf_ok and selected_ok and not vetoed:
                 metadata_stage = "single_vote_scalp_controlled"
             else:
+                blocked_reason = (
+                    "raw_score_below_min" if not score_ok else "confidence_below_min"
+                    if not conf_ok else "not_selected_or_near_atm" if not selected_ok
+                    else "context_veto"
+                )
+                log.info(
+                    "TRADE_DECISION_TRACE symbol=%s strategy=%s side=%s allowed=%s blocked_at=%s blocked_reason=%s",
+                    symbol_norm,
+                    best_vote.strategy,
+                    best_vote.side,
+                    False,
+                    "single_vote_gate",
+                    blocked_reason,
+                    extra={"event": "TRADE_DECISION_TRACE", "symbol": symbol_norm, "strategy": best_vote.strategy, "side": best_vote.side, "allowed": False, "blocked_at": "single_vote_gate", "blocked_reason": blocked_reason},
+                )
                 return None
         else:
             metadata_stage = "multi_vote_confirmed"
+        metadata["raw_setup_score"] = round(raw_trigger_score, 3)
+        metadata["regime_weighted_score"] = round(weighted_trigger_score, 3)
+        metadata["regime_weight"] = round(_regime_weight(best_vote), 3)
+        metadata["context_bonus"] = round(context_bonus, 3)
+        metadata["context_penalty"] = round(context_penalty, 3)
+        metadata["final_trade_score"] = round(final_score, 3)
         if vetoed or final_score < threshold:
+            blocked_reason = "context_veto" if vetoed else "final_trade_score_below_threshold"
+            log.info(
+                "TRADE_DECISION_TRACE symbol=%s strategy=%s side=%s data_gate=%s setup_score=%.2f setup_min=%.2f weighted_score=%.2f regime_weight=%.2f context_bonus=%.2f context_penalty=%.2f final_score=%.2f final_min=%.2f allowed=%s blocked_at=%s blocked_reason=%s",
+                symbol_norm, best_vote.strategy, best_vote.side, True, raw_trigger_score, threshold, weighted_trigger_score, _regime_weight(best_vote), context_bonus, context_penalty, final_score, threshold, False, "strategy_manager_combine", blocked_reason,
+                extra={"event": "TRADE_DECISION_TRACE", "symbol": symbol_norm, "strategy": best_vote.strategy, "side": best_vote.side, "data_gate": True, "setup_score": raw_trigger_score, "setup_min": threshold, "weighted_score": weighted_trigger_score, "regime_weight": _regime_weight(best_vote), "context_bonus": context_bonus, "context_penalty": context_penalty, "final_score": final_score, "final_min": threshold, "allowed": False, "blocked_at": "strategy_manager_combine", "blocked_reason": blocked_reason},
+            )
             return None
         metadata = dict(best_signal.metadata or {})
         metadata["is_selected_option"] = bool(metadata.get("is_selected_option") or indicator_selected_option)
@@ -2704,8 +2794,12 @@ class StrategyManager(_BaseStrategyManager):
                 },
             )
             metadata = dict(vote.metadata or {})
+            raw_score = float((vote.metadata or {}).get("raw_setup_score", vote.score))
+            metadata["raw_vote_score"] = raw_score
+            metadata["raw_setup_score"] = raw_score
             metadata["regime_weight"] = weight
             metadata["regime_weighted_vote_score"] = weighted_score
+            metadata["regime_name"] = regime_key or "UNKNOWN"
             return StrategyVote(
                 strategy=vote.strategy,
                 side=vote.side,

--- a/src/nifty_scalper_bot/strategies/elite_strategies/order_flow.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/order_flow.py
@@ -91,6 +91,8 @@ class OrderFlowStrategy(EliteStrategy):
                     return None
                 metadata = {'orderflow_depth_source': 'ltp_tick_fallback', 'risk_label': 'ltp_only_orderflow_reduced_confidence'}
                 metadata.update({'strategy': 'OrderFlow', 'strategy_name': 'OrderFlow', 'role': 'trigger' if allow_orderflow_trigger and strategy_score >= 7.0 and spread_pct <= 8.0 else 'context', 'source_domain': 'market_microstructure', 'context_score': strategy_score, 'side': side, 'direction_bias': side, 'strategy_score': strategy_score, 'spread_pct': round(spread_pct, 3), 'depth_imbalance': 0.0, 'tick_direction': tick_direction, 'premium_stop_distance': max(0.8 * atr, current_price * 0.02, 1.0), 'premium_target_rr': 1.8})
+                side_aligns = direction in {'CE', 'PE'} and direction == side
+                metadata.update({'context_role': 'confirmation', 'context_bonus_score': strategy_score if side_aligns else 0.0, 'context_veto_score': strategy_score if (direction in {'CE', 'PE'} and direction != side) else 0.0, 'can_trigger': bool(metadata['role'] == 'trigger')})
                 return EliteSignal(symbol=symbol, signal='BUY', confidence=max(0.1, min(0.55, strategy_score / 10.0)), entry_price=current_price, stop_loss=None, target=None, quantity=self._cfg.quantity or 1, strategy_name='OrderFlow', metadata=metadata)
             depth_imbalance = (total_bid - total_ask) / max(total_bid + total_ask, 1.0)
             side = contract_side if option_premium_domain else ('CE' if depth_imbalance > 0 else 'PE')
@@ -149,6 +151,8 @@ class OrderFlowStrategy(EliteStrategy):
                 'premium_stop_distance': max(0.8 * atr, current_price * 0.02, 1.0),
                 'premium_target_rr': 1.8,
             }
+            side_aligns = direction in {'CE', 'PE'} and direction == side
+            metadata.update({'context_role': 'confirmation', 'context_bonus_score': strategy_score if side_aligns else 0.0, 'context_veto_score': strategy_score if (direction in {'CE', 'PE'} and direction != side) else 0.0, 'can_trigger': bool(metadata['role'] == 'trigger')})
             LOGGER.info('STRATEGY_VOTE strategy=OrderFlow side=%s score=%.2f', side, strategy_score)
             if metadata["role"] == "trigger":
                 LOGGER.info(

--- a/src/nifty_scalper_bot/strategies/elite_strategies/vwap_pro.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/vwap_pro.py
@@ -147,6 +147,7 @@ class VWAPProStrategy(EliteStrategy):
                     avg_vol,
                     trend_alignment,
                     pullback_flag,
+                    extra={'score_reasons': reasons},
                 )
                 return None
 
@@ -162,9 +163,17 @@ class VWAPProStrategy(EliteStrategy):
                 'side': contract_side,
                 'contract_side': contract_side,
                 'premium_above_vwap': premium_above_vwap,
-                'direction_bias': contract_side,
+                'direction_bias': direction if direction in {'CE', 'PE'} else None,
                 'preliminary_only': True,
                 'requires_runner_final_score': True,
+                'raw_setup_score': strategy_score,
+                'setup_score': strategy_score,
+                'setup_min': 5.5,
+                'setup_pass': True,
+                'execution_required': True,
+                'regime_required': True,
+                'strategy_family': 'vwap_continuation_pullback',
+                'context_required': False,
                 'direction_score': strategy_score,
                 'strategy_score': strategy_score,
                 'data_score': 8.0 if not stale_data else 3.0,

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -5320,6 +5320,33 @@ class StrategyRunner:
             extra={"event": "REGIME_GATE_DECISION"},
         )
         return allowed_for_regime
+    def _strategy_regime_decision(
+        self, *, strategy: str, regime: MarketRegime, symbol: str, metadata: Mapping[str, Any] | None = None
+    ) -> tuple[bool, str]:
+        """Return strategy-regime compatibility decision. Args: strategy/regime/symbol/metadata; Returns: tuple[bool,str]; Raises: none."""
+        del symbol
+        normalized = (strategy or "").strip().lower()
+        regime_name = str(regime.value or "").upper()
+        canonical = {"VOLATILE": "HIGH_VOLATILITY", "HIGHVOL": "HIGH_VOLATILITY", "HIGH_VOL": "HIGH_VOLATILITY", "TRENDING": "TREND", "RANGING": "RANGE"}.get(regime_name, regime_name)
+        meta = dict(metadata or {})
+        selected = bool(meta.get("candidate_selected") or meta.get("is_selected_option"))
+        try:
+            spread_pct = float(meta.get("spread_pct") or meta.get("candidate_spread_pct") or 999.0)
+        except (TypeError, ValueError):
+            spread_pct = 999.0
+        try:
+            rr = float(meta.get("candidate_rr") or 0.0)
+        except (TypeError, ValueError):
+            rr = 0.0
+        if self._strategy_allowed_for_regime(strategy, regime):
+            return True, "regime_in_allowed_list"
+        if normalized in {"vwap_pro", "vwappro"} and canonical == "HIGH_VOLATILITY":
+            max_spread = float(os.getenv("VWAP_HIGH_VOL_MAX_SPREAD_PCT", "0.75") or "0.75")
+            min_rr = float(os.getenv("VWAP_HIGH_VOL_MIN_RR", "1.6") or "1.6")
+            if selected and spread_pct <= max_spread and rr >= min_rr:
+                return True, "vwap_high_vol_execution_quality_soft_allow"
+            return False, "vwap_high_vol_execution_quality_failed"
+        return False, "regime_not_allowed"
 
     def _strategy_slots_available(self) -> bool:
         """Return True when active strategy slots are available for new entries."""
@@ -7468,10 +7495,15 @@ class StrategyRunner:
                 self._last_strategy_versions[symbol] = current_version
                 signal_strategy = str((signal.metadata or {}).get("strategy") or "")
                 current_regime = self._compute_regime_snapshot(symbol)
-                if not self._strategy_allowed_for_regime(
-                    signal_strategy, current_regime
-                ):
+                regime_allowed, regime_reason = self._strategy_regime_decision(
+                    strategy=signal_strategy, regime=current_regime, symbol=symbol, metadata=signal.metadata or {}
+                )
+                if not regime_allowed:
                     self._regime_block_counter += 1
+                    regime_metadata = dict(signal.metadata or {})
+                    selected = bool(regime_metadata.get("candidate_selected") or regime_metadata.get("is_selected_option"))
+                    spread_pct = regime_metadata.get("spread_pct") or regime_metadata.get("candidate_spread_pct")
+                    candidate_rr = regime_metadata.get("candidate_rr")
                     allowed_env = os.getenv("RUNNER_VWAP_ALLOWED_REGIMES", "TREND,NORMAL")
                     if signal_strategy.strip().lower() in {"premium_momentum", "premium_momentum_squeeze"}:
                         allowed_env = os.getenv(
@@ -7484,13 +7516,17 @@ class StrategyRunner:
                             "TREND,NORMAL,HIGH_VOLATILITY",
                         )
                     self._logger.info(
-                        "REGIME_GATE_REJECTED symbol=%s strategy=%s regime=%s allowed_regimes=%s side=%s score=%.2f trace_id=%s",
+                        "REGIME_GATE_REJECTED symbol=%s strategy=%s regime=%s allowed_regimes=%s side=%s score=%.2f reason=%s selected=%s spread_pct=%s candidate_rr=%s trace_id=%s",
                         symbol,
                         signal_strategy or "unknown",
                         current_regime.value,
                         allowed_env,
                         signal.action,
                         float(signal.confidence or 0.0),
+                        regime_reason,
+                        selected,
+                        spread_pct,
+                        candidate_rr,
                         trace_id,
                         extra={
                             "event": "REGIME_GATE_REJECTED",
@@ -7500,6 +7536,10 @@ class StrategyRunner:
                             "allowed_regimes": allowed_env,
                             "side": signal.action,
                             "score": float(signal.confidence or 0.0),
+                            "regime_reason": regime_reason,
+                            "selected": selected,
+                            "spread_pct": spread_pct,
+                            "candidate_rr": candidate_rr,
                             "trace_id": trace_id,
                             "regime_inputs": self._last_regime_inputs_by_symbol.get(symbol, {}),
                         },
@@ -8815,6 +8855,14 @@ class StrategyRunner:
                 metadata["spread_pct"] = candidate.spread_pct
                 metadata["candidate_score"] = candidate.score
                 metadata["candidate_selected"] = True
+                metadata["candidate_symbol"] = candidate.symbol
+                metadata["candidate_entry_price"] = candidate.entry_price
+                metadata["candidate_stop_loss"] = candidate.stop_loss
+                metadata["candidate_target"] = candidate.target
+                metadata["candidate_rr"] = candidate.rr
+                metadata["candidate_data_quality_score"] = candidate.data_quality_score
+                metadata["candidate_spread_pct"] = candidate.spread_pct
+                metadata["candidate_tick_age_s"] = getattr(candidate, "tick_age_s", None)
                 selected_snapshot = next(
                     (
                         snap
@@ -8985,40 +9033,53 @@ class StrategyRunner:
                 ]
 
                 if not (has_components and has_candidate and has_quote_usable):
+                    if missing_components:
+                        final_score_block_reason = "missing_final_score_components"
+                    elif not has_candidate:
+                        final_score_block_reason = "candidate_not_selected"
+                    elif not has_quote_usable:
+                        final_score_block_reason = "quote_not_usable_for_order_plan"
+                    else:
+                        final_score_block_reason = "final_score_required"
+                    strategy_name = metadata.get("strategy_name") or metadata.get("strategy") or signal.reason
                     self._logger.info(
-                        "SIGNAL_EXECUTION_RESULT accepted=False reason=final_score_required "
-                        "symbol=%s trace_id=%s has_components=%s missing_components=%s "
-                        "has_candidate=%s has_quote_usable=%s candidate_symbol=%s "
-                        "tradable_quote=%s quote_usable_for_order_plan=%s selected_snapshot_symbol=%s",
+                        "TRADE_DECISION_TRACE symbol=%s strategy=%s side=%s allowed=%s blocked_at=%s blocked_reason=%s missing_components=%s has_candidate=%s has_quote_usable=%s candidate_symbol=%s selected_snapshot_symbol=%s latest_bid=%s latest_ask=%s latest_quote_tradable=%s",
                         base_symbol,
-                        trace_id,
-                        has_components,
+                        strategy_name,
+                        infer_option_side(signal.symbol, metadata),
+                        False,
+                        "runner_final_score_precheck",
+                        final_score_block_reason,
                         missing_components,
                         has_candidate,
                         has_quote_usable,
                         metadata.get("candidate_symbol"),
-                        metadata.get("tradable_quote"),
-                        metadata.get("quote_usable_for_order_plan"),
                         metadata.get("selected_snapshot_symbol"),
+                        metadata.get("latest_quote_bid"),
+                        metadata.get("latest_quote_ask"),
+                        metadata.get("latest_quote_tradable"),
                         extra={
-                            "event": "SIGNAL_EXECUTION_RESULT",
-                            "accepted": False,
-                            "reason": "final_score_required",
+                            "event": "TRADE_DECISION_TRACE",
                             "symbol": base_symbol,
+                            "strategy": strategy_name,
+                            "side": infer_option_side(signal.symbol, metadata),
+                            "allowed": False,
+                            "blocked_at": "runner_final_score_precheck",
+                            "blocked_reason": final_score_block_reason,
                             "trace_id": trace_id,
-                            "has_components": has_components,
                             "missing_components": missing_components,
                             "has_candidate": has_candidate,
                             "has_quote_usable": has_quote_usable,
                             "candidate_symbol": metadata.get("candidate_symbol"),
-                            "tradable_quote": metadata.get("tradable_quote"),
-                            "quote_usable_for_order_plan": metadata.get("quote_usable_for_order_plan"),
                             "selected_snapshot_symbol": metadata.get("selected_snapshot_symbol"),
+                            "latest_bid": metadata.get("latest_quote_bid"),
+                            "latest_ask": metadata.get("latest_quote_ask"),
+                            "latest_quote_tradable": metadata.get("latest_quote_tradable"),
                         },
                     )
                     self._reset_execution_state(base_symbol)
-                    _trace("final_score_required")
-                    return SignalExecutionResult(False, "final_score_required")
+                    _trace(final_score_block_reason)
+                    return SignalExecutionResult(False, final_score_block_reason)
             missing_components = missing_score_components(metadata)
             if missing_components and reason_key == "premium_momentum_squeeze":
                 metadata["shadow_only"] = True
@@ -9085,22 +9146,42 @@ class StrategyRunner:
                 live_threshold = float(quality.components.get("threshold", 0.0) or 0.0)
                 if quality.final_score < live_threshold:
                     self._logger.info(
-                        "SIGNAL_EXECUTION_RESULT accepted=False reason=final_score_required symbol=%s trace_id=%s",
+                        "TRADE_DECISION_TRACE symbol=%s strategy=%s side=%s allowed=%s blocked_at=%s blocked_reason=%s final_score=%.2f threshold=%.2f direction_score=%.2f strategy_score=%.2f option_score=%.2f data_score=%.2f rr_score=%.2f reasons=%s trace_id=%s",
                         base_symbol,
+                        str(quality.components.get("strategy_name", "")),
+                        infer_option_side(signal.symbol, metadata),
+                        False,
+                        "runner_final_score",
+                        "final_score_below_live_threshold",
+                        quality.final_score,
+                        live_threshold,
+                        float(quality.components.get("direction_score", quality.direction_score) or 0.0),
+                        float(quality.components.get("strategy_score", quality.strategy_score) or 0.0),
+                        float(quality.components.get("option_score", quality.option_score) or 0.0),
+                        float(quality.components.get("data_score", quality.data_score) or 0.0),
+                        float(quality.components.get("rr_score", quality.rr_score) or 0.0),
+                        quality.reasons,
                         trace_id,
                         extra={
-                            "event": "SIGNAL_EXECUTION_RESULT",
-                            "accepted": False,
-                            "reason": "final_score_required",
+                            "event": "TRADE_DECISION_TRACE",
                             "symbol": base_symbol,
                             "trace_id": trace_id,
                             "final_score": quality.final_score,
-                            "required_score": live_threshold,
+                            "threshold": live_threshold,
+                            "allowed": False,
+                            "blocked_at": "runner_final_score",
+                            "blocked_reason": "final_score_below_live_threshold",
+                            "direction_score": quality.components.get("direction_score", quality.direction_score),
+                            "strategy_score": quality.components.get("strategy_score", quality.strategy_score),
+                            "option_score": quality.components.get("option_score", quality.option_score),
+                            "data_score": quality.components.get("data_score", quality.data_score),
+                            "rr_score": quality.components.get("rr_score", quality.rr_score),
+                            "reasons": quality.reasons,
                         },
                     )
                     self._reset_execution_state(base_symbol)
-                    _trace("final_score_required")
-                    return SignalExecutionResult(False, "final_score_required")
+                    _trace("final_score_below_live_threshold")
+                    return SignalExecutionResult(False, "final_score_below_live_threshold")
             if not quality.allowed:
                 delta = quality.final_score - float(quality.components.get("threshold", 0.0) or 0.0)
                 self._logger.info(

--- a/src/nifty_scalper_bot/strategies/signal_quality.py
+++ b/src/nifty_scalper_bot/strategies/signal_quality.py
@@ -176,5 +176,15 @@ def score_signal_quality(
         rr_score=rr,
         allowed=(final >= threshold and direction >= 6.0),
         reasons=reasons,
-        components={'threshold': threshold, 'strategy_name': strategy_name or '', 'normalized_strategy_name': normalized_strategy_name},
+        components={
+            'direction_score': direction,
+            'strategy_score': strategy,
+            'option_score': option,
+            'data_score': data,
+            'rr_score': rr,
+            'final_score': round(final, 3),
+            'threshold': threshold,
+            'strategy_name': strategy_name or '',
+            'normalized_strategy_name': normalized_strategy_name,
+        },
     )

--- a/tests/core/test_strategy_manager_context_only.py
+++ b/tests/core/test_strategy_manager_context_only.py
@@ -1,0 +1,12 @@
+from nifty_scalper_bot.core.strategy_manager import StrategyManager, StrategyVote
+from nifty_scalper_bot.strategies.signal_generator import Signal
+
+
+def test_context_only_vote_returns_none_with_trace(caplog):
+    manager = StrategyManager.__new__(StrategyManager)
+    signal = Signal(action='BUY', symbol='NFO:NIFTY25000CE', quantity=1, confidence=0.55, reason='OrderFlow', stop_loss=1.0, take_profit=2.0, metadata={})
+    vote = StrategyVote(strategy='OrderFlow', side='CE', score=6.0, confidence=0.55, reasons=[], metadata={'role': 'context'})
+    caplog.set_level('INFO')
+    out = manager._combine_strategy_votes(symbol=signal.symbol, signals=[(signal, vote)], indicators={})
+    assert out is None
+    assert any('TRADE_DECISION_TRACE' in rec.message and 'no_trigger_vote' in rec.message for rec in caplog.records)

--- a/tests/core/test_strategy_manager_single_vote_raw_score.py
+++ b/tests/core/test_strategy_manager_single_vote_raw_score.py
@@ -1,0 +1,15 @@
+from nifty_scalper_bot.core.strategy_manager import StrategyManager, StrategyVote
+from nifty_scalper_bot.strategies.signal_generator import Signal
+
+
+def test_single_vote_uses_raw_score_for_threshold(monkeypatch):
+    monkeypatch.setenv('STRATEGY_ALLOW_SINGLE_VOTE_SCALP', 'true')
+    monkeypatch.setenv('STRATEGY_SINGLE_VOTE_VWAP_MIN_SCORE', '5.5')
+    manager = StrategyManager.__new__(StrategyManager)
+    signal = Signal(action='BUY', symbol='NFO:NIFTY25000CE', quantity=1, confidence=0.55, reason='VWAPPro', stop_loss=1.0, take_profit=2.0, metadata={'is_selected_option': True})
+    vote = StrategyVote(strategy='VWAPPro', side='CE', score=4.4, confidence=0.55, reasons=[], metadata={'raw_setup_score': 5.5, 'regime_weight': 0.8})
+    combined = manager._combine_strategy_votes(symbol=signal.symbol, signals=[(signal, vote)], indicators={})
+    assert combined is not None
+    assert combined.metadata['raw_setup_score'] == 5.5
+    assert combined.metadata['regime_weighted_score'] == 4.4
+    assert combined.metadata['regime_weight'] == 0.8

--- a/tests/strategies/test_runner_final_score_reasons.py
+++ b/tests/strategies/test_runner_final_score_reasons.py
@@ -1,0 +1,53 @@
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from nifty_scalper_bot.strategies.runner import StrategyRunner
+from nifty_scalper_bot.strategies.signal_generator import Signal
+
+
+class _Snapshot:
+    def __init__(self, bid=0.0, ask=0.0, tradable_quote=False):
+        self.ltp = 431.05
+        self.bid = bid
+        self.ask = ask
+        self.tradable_quote = tradable_quote
+        self.source = 'ws'
+        self.tick_age_s = 0.1
+        self.real_ticks_last_60s = 5
+
+
+def _runner() -> StrategyRunner:
+    runner = StrategyRunner.__new__(StrategyRunner)
+    runner._logger = MagicMock()
+    runner._runtime_data_hard_ready = True
+    runner._runtime_evaluation_ready = True
+    runner._runtime_live_orders_armed = True
+    runner._runtime_readiness_reason = None
+    runner._order_manager = MagicMock()
+    runner._order_manager.is_kill_switch_active = MagicMock(return_value=False)
+    runner._reset_execution_state = MagicMock()
+    runner._materialize_option_trade_plan = MagicMock(side_effect=lambda s, **_: s)
+    return runner
+
+
+def _signal(metadata: dict) -> Signal:
+    return Signal(action='BUY', symbol='NFO:NIFTY26MAY23350CE', quantity=1, confidence=0.65, reason='VWAPPro', stop_loss=420.27, take_profit=452.60, metadata=metadata)
+
+
+@pytest.mark.parametrize(
+    'metadata,expected',
+    [
+        ({'preliminary_only': True, 'requires_runner_final_score': True, 'direction_score': 6.0, 'strategy_score': 6.0, 'option_score': 6.0, 'data_score': 8.0, 'candidate_selected': True, 'quote_usable_for_order_plan': True}, 'missing_final_score_components'),
+        ({'preliminary_only': True, 'requires_runner_final_score': True, 'direction_score': 6.0, 'strategy_score': 6.0, 'option_score': 6.0, 'data_score': 8.0, 'rr_score': 7.0, 'candidate_selected': False, 'quote_usable_for_order_plan': True}, 'candidate_not_selected'),
+        ({'preliminary_only': True, 'requires_runner_final_score': True, 'direction_score': 6.0, 'strategy_score': 6.0, 'option_score': 6.0, 'data_score': 8.0, 'rr_score': 7.0, 'candidate_selected': True, 'quote_usable_for_order_plan': False}, 'quote_not_usable_for_order_plan'),
+    ],
+)
+def test_precheck_reasons(monkeypatch, metadata, expected):
+    monkeypatch.setenv('EXECUTION_MODE', 'LIVE')
+    runner = _runner()
+    runner._market_data = SimpleNamespace(get_symbol_snapshot=lambda _symbol: _Snapshot())
+    result = runner._handle_entry_signal_inner(_signal(metadata), 'NFO:NIFTY26MAY23350CE', 'NFO:NIFTY26MAY23350CE', 431.05, datetime.now(timezone.utc), trace_id='r1')
+    assert result.reason == expected

--- a/tests/strategies/test_runner_regime_soft_allow.py
+++ b/tests/strategies/test_runner_regime_soft_allow.py
@@ -1,0 +1,18 @@
+from nifty_scalper_bot.strategies.market_regime_engine import MarketRegime
+from nifty_scalper_bot.strategies.runner import StrategyRunner
+
+
+def test_vwap_high_vol_soft_allow(monkeypatch):
+    monkeypatch.setenv('RUNNER_VWAP_ALLOWED_REGIMES', 'TREND,NORMAL')
+    runner = StrategyRunner.__new__(StrategyRunner)
+    allowed, reason = runner._strategy_regime_decision(strategy='VWAPPro', regime=MarketRegime.VOLATILE, symbol='NIFTY', metadata={'candidate_selected': True, 'candidate_spread_pct': 0.5, 'candidate_rr': 1.8})
+    assert allowed is True
+    assert reason == 'vwap_high_vol_execution_quality_soft_allow'
+
+
+def test_vwap_high_vol_soft_allow_fails_with_high_spread(monkeypatch):
+    monkeypatch.setenv('RUNNER_VWAP_ALLOWED_REGIMES', 'TREND,NORMAL')
+    runner = StrategyRunner.__new__(StrategyRunner)
+    allowed, reason = runner._strategy_regime_decision(strategy='VWAPPro', regime=MarketRegime.VOLATILE, symbol='NIFTY', metadata={'candidate_selected': True, 'candidate_spread_pct': 1.1, 'candidate_rr': 1.8})
+    assert allowed is False
+    assert reason == 'vwap_high_vol_execution_quality_failed'

--- a/tests/strategies/test_vwap_metadata_contract_side.py
+++ b/tests/strategies/test_vwap_metadata_contract_side.py
@@ -1,0 +1,17 @@
+from nifty_scalper_bot.strategies.elite_strategies.config_models import VWAPProStrategyConfig
+from nifty_scalper_bot.strategies.elite_strategies.vwap_pro import VWAPProStrategy
+
+
+class _DummyEngine:
+    pass
+
+
+def test_vwap_metadata_contract_side_and_setup_scores_present():
+    strategy = VWAPProStrategy(VWAPProStrategyConfig(), _DummyEngine())
+    signal = strategy._evaluate_signal('NFO:NIFTY26FEB22500CE', {'vwap': 100.0, 'atr': 5.0, 'close': 103.0, 'open': 100.0, 'high': 104.0, 'low': 99.0, 'volume': 1000.0, 'avg_volume': 900.0, 'spread_pct': 2.0, 'direction_bias': 'UNKNOWN'}, 101.0)
+    assert signal is not None
+    metadata = signal.metadata
+    assert metadata['contract_side'] == 'CE'
+    assert metadata['direction_bias'] is None
+    assert metadata['raw_setup_score'] is not None
+    assert metadata['setup_score'] is not None


### PR DESCRIPTION
### Motivation
- Eliminate hidden double-penalties where regime-weighted scores were being compared to setup thresholds, which caused high-quality raw setup signals (e.g., VWAPPro 5.50) to be silently rejected. 
- Make every evaluated symbol produce one canonical decision trace with a precise `blocked_at` and `blocked_reason` so no-trade decisions are actionable. 
- Preserve existing strategy interfaces and runtime guards while enabling controlled regime soft-allow for exceptional high-volatility VWAPPro cases using execution-quality checks.

### Description
- Strategy manager: preserve raw setup score and confidence in `signal_to_vote()` via `raw_setup_score`, `setup_score`, and `raw_confidence`, select triggers by raw setup quality, log both `raw` and `regime_weighted` scores, and emit explicit `TRADE_DECISION_TRACE` for context-only, single-vote gate blocks and combine-stage rejects (`strategy_manager` changes in `src/nifty_scalper_bot/core/strategy_manager.py`).
- Strategy runner: add `_strategy_regime_decision()` to keep hard regime-gate behavior but allow a controlled soft-allow for `VWAPPro` in high-volatility when candidate execution quality (selected, spread, RR) meets env-tunable thresholds, and include `regime_reason` and candidate metadata in regime-rejection logs (`src/nifty_scalper_bot/strategies/runner.py`).
- Final-score gating and candidate traceability: replace generic `final_score_required` with specific precheck reasons (`missing_final_score_components`, `candidate_not_selected`, `quote_not_usable_for_order_plan`) and use `final_score_below_live_threshold` for below-threshold failures, and retain candidate fields (`candidate_symbol`, `candidate_entry_price`, `candidate_stop_loss`, `candidate_target`, `candidate_rr`, `candidate_spread_pct`, `candidate_tick_age_s`) for traceability (`src/nifty_scalper_bot/strategies/runner.py`).
- Strategy metadata improvements: separate VWAPPro setup vs execution assumptions and avoid faking `direction_bias` (now `direction_bias` is real context or `None`) and add setup markers; make OrderFlow context-only by default while emitting explicit `context_role`, `context_bonus_score`, `context_veto_score`, and `can_trigger` for use by the manager (`src/nifty_scalper_bot/strategies/elite_strategies/vwap_pro.py`, `src/nifty_scalper_bot/strategies/elite_strategies/order_flow.py`).
- Signal quality: expand `score_signal_quality()` `components` to include full component breakdown (`direction_score`, `strategy_score`, `option_score`, `data_score`, `rr_score`, `final_score`, `threshold`, names) without breaking callers (`src/nifty_scalper_bot/strategies/signal_quality.py`).
- Tests: added focused unit tests to cover raw-vs-weighted single-vote behavior, context-only trigger gate traceability, runner final-score precheck reasons, regime soft-allow behavior for VWAPPro, and VWAP metadata fields (`tests/...`).

### Testing
- Ran `python -m compileall src` successfully to ensure the codebase compiles. 
- Ran targeted pytest suite: `pytest -q tests/core/test_strategy_manager_single_vote_raw_score.py tests/core/test_strategy_manager_context_only.py tests/strategies/test_runner_final_score_reasons.py tests/strategies/test_runner_regime_soft_allow.py tests/strategies/test_vwap_metadata_contract_side.py` and all targeted tests passed. 
- A full `pytest -q` run failed in this environment due to an unrelated test import issue (`tests/test_mdm_diagnostics.py` importing a top-level `market_data_manager` module path that is not present in this test environment), which does not reflect the changes in the decision path logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0446a2e8f88324a9c351d8a7f0cc70)