### PR TITLE
fix: tighten spot hydration diagnostics and single-vote gating

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -8168,6 +8168,8 @@ async def startup_sequence(ctx: BotContext) -> None:
 
             active_symbol_tokens: dict[str, int] = {}
             symbols_to_hydrate_raw = build_active_trading_basket_symbols(ctx, basket)
+            if "NSE:NIFTY" not in symbols_to_hydrate_raw:
+                symbols_to_hydrate_raw = ["NSE:NIFTY", *symbols_to_hydrate_raw]
             symbols_to_hydrate: list[str] = []
             for _sym in symbols_to_hydrate_raw:
                 _tok = _resolve_startup_token(_sym)
@@ -8339,6 +8341,27 @@ async def startup_sequence(ctx: BotContext) -> None:
                             "mdm_history_count": mdm_history_count,
                         },
                     )
+                    if sym == "NSE:NIFTY":
+                        required = int(getattr(ctx.strategy_runner, "_context_required_bars", 0) or 0)
+                        success = runner_history_count >= required and mdm_history_count >= required
+                        reason = "hydrated" if success else "insufficient_bars_after_hydration"
+                        LOGGER.info(
+                            "SPOT_CONTEXT_HYDRATION_RESULT symbol=NSE:NIFTY mdm_bars=%d runner_bars=%d required=%d success=%s reason=%s",
+                            mdm_history_count,
+                            runner_history_count,
+                            required,
+                            success,
+                            reason,
+                            extra={
+                                "event": "SPOT_CONTEXT_HYDRATION_RESULT",
+                                "symbol": "NSE:NIFTY",
+                                "mdm_bars": mdm_history_count,
+                                "runner_bars": runner_history_count,
+                                "required": required,
+                                "success": success,
+                                "reason": reason,
+                            },
+                        )
                 if ctx.market_data_manager:
                     bars_snapshot = ctx.market_data_manager.get_ohlc_bars(sym)
                     ctx.market_data_manager.update_hydration_status(

--- a/src/nifty_scalper_bot/core/strategy_manager.py
+++ b/src/nifty_scalper_bot/core/strategy_manager.py
@@ -1087,6 +1087,17 @@ class StrategyManager(_BaseStrategyManager):
             getattr(strategy, "name", strategy.__class__.__name__): set(strategy.get_required_indicators())
             for strategy in strategies
         }
+        allow_scalp_single = str(os.getenv("STRATEGY_ALLOW_SINGLE_VOTE_SCALP", "false")).lower() in {"1", "true", "yes", "on"}
+        vwap_min_score, vwap_min_conf = self._single_vote_thresholds("VWAPPro")
+        generic_min_score, generic_min_conf = self._single_vote_thresholds("generic")
+        log.info(
+            "STRATEGY_SINGLE_VOTE_CONFIG allow_scalp_single=%s vwap_min_score=%s vwap_min_conf=%s generic_min_score=%s generic_min_conf=%s",
+            allow_scalp_single,
+            vwap_min_score,
+            vwap_min_conf,
+            generic_min_score,
+            generic_min_conf,
+        )
 
     def record_trade_result(
         self,
@@ -2673,15 +2684,21 @@ class StrategyManager(_BaseStrategyManager):
             vetoed = True
         if len(trigger_votes) == 1:
             selected_option = bool(metadata.get("is_selected_option") or indicator_selected_option)
+            selected_ce = str(metadata.get("selected_ce") or "")
+            selected_pe = str(metadata.get("selected_pe") or "")
+            near_atm_threshold = float(os.getenv("STRATEGY_NEAR_ATM_THRESHOLD_POINTS", "50") or "50")
             try:
-                near_atm = float(metadata.get("strike_distance_from_atm")) <= 50.0
+                strike_distance_from_atm = float(metadata.get("strike_distance_from_atm"))
+                near_atm = strike_distance_from_atm <= near_atm_threshold
             except (TypeError, ValueError):
+                strike_distance_from_atm = None
                 near_atm = indicator_near_atm
             score_min, conf_min = self._single_vote_thresholds(best_vote.strategy)
             regime_weight = _regime_weight(best_vote)
             score_ok = raw_trigger_score >= score_min
             conf_ok = best_vote.confidence >= conf_min
             selected_ok = selected_option or near_atm
+            selected_ok_reason = "selected_option" if selected_option else "near_atm" if near_atm else "not_selected_or_near_atm"
             log.info(
                 "SINGLE_VOTE_DECISION strategy=%s raw_score=%.2f weighted_score=%.2f regime_weight=%.2f score_min=%.2f confidence=%.2f conf_min=%.2f selected_ok=%s vetoed=%s",
                 best_vote.strategy,
@@ -2704,6 +2721,7 @@ class StrategyManager(_BaseStrategyManager):
                     "confidence": best_vote.confidence,
                     "conf_min": conf_min,
                     "selected_ok": selected_ok,
+                    "selected_ok_reason": selected_ok_reason,
                     "vetoed": vetoed,
                 },
             )
@@ -2712,26 +2730,51 @@ class StrategyManager(_BaseStrategyManager):
             elif allow_scalp_single and score_ok and conf_ok and selected_ok and not vetoed:
                 metadata_stage = "single_vote_scalp_controlled"
             else:
-                blocked_reason = (
-                    "raw_score_below_min" if not score_ok else "confidence_below_min"
-                    if not conf_ok else "not_selected_or_near_atm" if not selected_ok
-                    else "context_veto"
+                allow_candidate_switch = str(os.getenv("STRATEGY_ALLOW_CANDIDATE_SWITCH_ON_HIGH_SCORE", "false")).lower() in {"1", "true", "yes", "on"}
+                max_candidate_switch_distance = float(os.getenv("CANDIDATE_SWITCH_MAX_DISTANCE_POINTS", "100") or "100")
+                quote_depth_valid = bool(metadata.get("quote_depth_valid", True))
+                switch_allowed = (
+                    allow_candidate_switch
+                    and (strike_distance_from_atm is not None)
+                    and raw_trigger_score >= 7.0
+                    and best_vote.confidence >= 0.60
+                    and quote_depth_valid
+                    and strike_distance_from_atm <= max_candidate_switch_distance
                 )
-                log.info(
-                    "TRADE_DECISION_TRACE symbol=%s strategy=%s side=%s allowed=%s blocked_at=%s blocked_reason=%s",
-                    symbol_norm,
-                    best_vote.strategy,
-                    best_vote.side,
-                    False,
-                    "single_vote_gate",
-                    blocked_reason,
-                    extra={"event": "TRADE_DECISION_TRACE", "symbol": symbol_norm, "strategy": best_vote.strategy, "side": best_vote.side, "allowed": False, "blocked_at": "single_vote_gate", "blocked_reason": blocked_reason},
-                )
-                return None
+                if switch_allowed:
+                    metadata_stage = "single_vote_candidate_switch"
+                    metadata["candidate_switch_requested"] = True
+                    metadata["candidate_switch_reason"] = "high_raw_score_nearby_strike"
+                else:
+                    blocked_reason = (
+                        "raw_score_below_min" if not score_ok else "confidence_below_min"
+                        if not conf_ok else "not_selected_or_near_atm" if not selected_ok
+                        else "context_veto"
+                    )
+                    log.info(
+                        "TRADE_DECISION_TRACE symbol=%s strategy=%s side=%s allowed=%s blocked_at=%s blocked_reason=%s selected_ce=%s selected_pe=%s strike_distance_from_atm=%s near_atm_threshold=%s selected_ok_reason=%s raw_score=%.2f confidence=%.2f",
+                        symbol_norm,
+                        best_vote.strategy,
+                        best_vote.side,
+                        False,
+                        "single_vote_gate",
+                        blocked_reason,
+                        selected_ce,
+                        selected_pe,
+                        strike_distance_from_atm,
+                        near_atm_threshold,
+                        selected_ok_reason,
+                        raw_trigger_score,
+                        best_vote.confidence,
+                        extra={"event": "TRADE_DECISION_TRACE", "symbol": symbol_norm, "strategy": best_vote.strategy, "side": best_vote.side, "allowed": False, "blocked_at": "single_vote_gate", "blocked_reason": blocked_reason, "selected_ce": selected_ce, "selected_pe": selected_pe, "strike_distance_from_atm": strike_distance_from_atm, "near_atm_threshold": near_atm_threshold, "selected_ok_reason": selected_ok_reason, "raw_score": raw_trigger_score, "confidence": best_vote.confidence},
+                    )
+                    return None
         else:
             metadata_stage = "multi_vote_confirmed"
         metadata["is_selected_option"] = bool(metadata.get("is_selected_option") or indicator_selected_option)
         metadata["indicator_near_atm"] = bool(indicator_near_atm)
+        metadata["selected_ok_reason"] = metadata.get("selected_ok_reason", "selected_or_near_atm")
+        metadata["near_atm_threshold"] = float(os.getenv("STRATEGY_NEAR_ATM_THRESHOLD_POINTS", "50") or "50")
         metadata["raw_setup_score"] = round(raw_trigger_score, 3)
         metadata["setup_score"] = round(raw_trigger_score, 3)
         metadata["regime_weighted_score"] = round(weighted_trigger_score, 3)

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -759,6 +759,7 @@ class StrategyRunner:
         self._last_readiness_update_by_symbol: dict[str, datetime] = {}
         self._rate_limit_backoff_until_by_symbol: dict[str, float] = {}
         self._hydration_attempted_symbols: set[str] = set()
+        self._last_hydration_reason_by_symbol: dict[str, str] = {}
         self._strategy_slot_limit: int = max(
             1,
             int(os.getenv("MAX_CONCURRENT_STRATEGIES", "3")),
@@ -1230,6 +1231,8 @@ class StrategyRunner:
 
     def _request_mdm_hydration(self, symbol: str, min_bars: int) -> None:
         """Request async hydration from owner service. Args: symbol/min_bars. Returns: None. Raises: None."""
+        self._hydration_attempted_symbols.add(symbol)
+        self._last_hydration_reason_by_symbol[symbol] = "runner_missing_bars"
         for source in (self._market_data, self._data_hub):
             fn = getattr(source, "request_hydration", None)
             if callable(fn):
@@ -5433,6 +5436,15 @@ class StrategyRunner:
         ``signal_forward``; ``reason`` names the specific gate.
         """
         try:
+            if (
+                symbol == "NSE:NIFTY"
+                and reason == "insufficient_indicator_bar_count"
+                and not self._should_log_throttled(
+                    f"runner_eval_insufficient:{symbol}:{stage}:{reason}",
+                    30.0,
+                )
+            ):
+                return
             state_obj = self._symbol_state.get(symbol)
             state_active = bool(getattr(state_obj, "active", False)) if state_obj else False
             sym_state = self._symbol_states.get(symbol)
@@ -5464,6 +5476,12 @@ class StrategyRunner:
             except Exception:  # pragma: no cover - defensive
                 pass
             has_live_bars = symbol in getattr(self, "_live_bar_seen", set())
+            required_bars = self._required_bars_for_symbol(symbol)
+            mdm_bars = None
+            try:
+                mdm_bars = len(self._market_data.get_ohlc_bars(symbol) or [])
+            except Exception:
+                mdm_bars = None
             payload = {
                 "event": "RUNNER_EVAL_DECISION",
                 "symbol": symbol,
@@ -5483,6 +5501,11 @@ class StrategyRunner:
                 "tick_age_ms": tick_age_ms,
                 "has_live_bars": has_live_bars,
                 "data_phase": self._data_phase.get(symbol),
+                "required_bars": required_bars,
+                "runner_bars": candle_count,
+                "mdm_bars": mdm_bars,
+                "hydration_attempted": symbol in self._hydration_attempted_symbols,
+                "last_hydration_reason": self._last_hydration_reason_by_symbol.get(symbol),
             }
             if context:
                 payload.update(context)

--- a/tests/core/test_nifty_insufficient_bar_log_throttle.py
+++ b/tests/core/test_nifty_insufficient_bar_log_throttle.py
@@ -1,0 +1,7 @@
+from nifty_scalper_bot.strategies.runner import StrategyRunner
+
+
+def test_nifty_insufficient_log_throttle_key_present():
+    src = open('src/nifty_scalper_bot/strategies/runner.py', encoding='utf-8').read()
+    assert 'runner_eval_insufficient:{symbol}:{stage}:{reason}' in src
+    assert '30.0' in src

--- a/tests/core/test_spot_context_hydration.py
+++ b/tests/core/test_spot_context_hydration.py
@@ -1,0 +1,12 @@
+from nifty_scalper_bot.core import app
+
+
+def test_nifty_token_fallback_present():
+    # Startup token resolver fallback map should contain NSE:NIFTY spot token.
+    src = open('src/nifty_scalper_bot/core/app.py', encoding='utf-8').read()
+    assert '"NSE:NIFTY": 256265' in src
+
+
+def test_spot_context_hydration_log_present():
+    src = open('src/nifty_scalper_bot/core/app.py', encoding='utf-8').read()
+    assert 'SPOT_CONTEXT_HYDRATION_RESULT symbol=NSE:NIFTY' in src

--- a/tests/core/test_strategy_manager_nonselected_high_score.py
+++ b/tests/core/test_strategy_manager_nonselected_high_score.py
@@ -1,0 +1,24 @@
+from nifty_scalper_bot.core.strategy_manager import StrategyManager, StrategyVote
+from nifty_scalper_bot.strategies.signal_generator import Signal
+
+
+def _signal() -> Signal:
+    return Signal(action='BUY', symbol='NFO:NIFTY25100CE', quantity=1, confidence=0.65, reason='VWAPPro', stop_loss=1.0, take_profit=2.0, metadata={'is_selected_option': False, 'strike_distance_from_atm': 80, 'quote_depth_valid': True})
+
+
+def test_nonselected_high_score_blocked_default(monkeypatch):
+    monkeypatch.delenv('STRATEGY_ALLOW_CANDIDATE_SWITCH_ON_HIGH_SCORE', raising=False)
+    monkeypatch.setenv('STRATEGY_ALLOW_SINGLE_VOTE_SCALP', 'true')
+    manager = StrategyManager.__new__(StrategyManager)
+    vote = StrategyVote(strategy='VWAPPro', side='CE', score=7.0, confidence=0.65, reasons=[], metadata={'raw_setup_score': 7.0})
+    assert manager._combine_strategy_votes(symbol='NFO:NIFTY25100CE', signals=[(_signal(), vote)], indicators={}) is None
+
+
+def test_nonselected_high_score_candidate_switch(monkeypatch):
+    monkeypatch.setenv('STRATEGY_ALLOW_CANDIDATE_SWITCH_ON_HIGH_SCORE', 'true')
+    monkeypatch.setenv('STRATEGY_ALLOW_SINGLE_VOTE_SCALP', 'true')
+    manager = StrategyManager.__new__(StrategyManager)
+    vote = StrategyVote(strategy='VWAPPro', side='CE', score=7.0, confidence=0.65, reasons=[], metadata={'raw_setup_score': 7.0})
+    out = manager._combine_strategy_votes(symbol='NFO:NIFTY25100CE', signals=[(_signal(), vote)], indicators={})
+    assert out is not None
+    assert out.metadata.get('candidate_switch_requested') is True

--- a/tests/core/test_strategy_manager_vwap_threshold_behavior.py
+++ b/tests/core/test_strategy_manager_vwap_threshold_behavior.py
@@ -1,0 +1,22 @@
+from nifty_scalper_bot.core.strategy_manager import StrategyManager, StrategyVote
+from nifty_scalper_bot.strategies.signal_generator import Signal
+
+
+def _base_signal() -> Signal:
+    return Signal(action='BUY', symbol='NFO:NIFTY25000CE', quantity=1, confidence=0.55, reason='VWAPPro', stop_loss=1.0, take_profit=2.0, metadata={'is_selected_option': True})
+
+
+def test_vwap_threshold_blocks_default(monkeypatch):
+    monkeypatch.setenv('STRATEGY_ALLOW_SINGLE_VOTE_SCALP', 'true')
+    monkeypatch.setenv('STRATEGY_SINGLE_VOTE_VWAP_MIN_SCORE', '5.8')
+    manager = StrategyManager.__new__(StrategyManager)
+    vote = StrategyVote(strategy='VWAPPro', side='CE', score=4.4, confidence=0.55, reasons=[], metadata={'raw_setup_score': 5.5})
+    assert manager._combine_strategy_votes(symbol='NFO:NIFTY25000CE', signals=[(_base_signal(), vote)], indicators={}) is None
+
+
+def test_vwap_threshold_allows_when_lowered(monkeypatch):
+    monkeypatch.setenv('STRATEGY_ALLOW_SINGLE_VOTE_SCALP', 'true')
+    monkeypatch.setenv('STRATEGY_SINGLE_VOTE_VWAP_MIN_SCORE', '5.5')
+    manager = StrategyManager.__new__(StrategyManager)
+    vote = StrategyVote(strategy='VWAPPro', side='CE', score=4.4, confidence=0.55, reasons=[], metadata={'raw_setup_score': 5.5})
+    assert manager._combine_strategy_votes(symbol='NFO:NIFTY25000CE', signals=[(_base_signal(), vote)], indicators={}) is not None


### PR DESCRIPTION
### Motivation
- Persistent RUNNER logs showed `NSE:NIFTY` under-hydrated (insufficient bars) and produced noisy phase9 spam without a clear root cause.  
- Single-vote VWAPPro path lacked explicit, configurable thresholds and diagnostic fields so borderline scores (e.g. raw_score=5.5) were silently blocked and high-score non-selected candidates (raw_score=7.0) had poor traceability.  
- Preserve conservative default safety while making thresholds and candidate-switch behavior explicit and observable for operators.

### Description
- Startup hydration: always include `NSE:NIFTY` in the startup hydration list and keep a spot-token fallback of `256265`, and push successful MDM/historical hydration into the runner; added `SPOT_CONTEXT_HYDRATION_RESULT` log with `mdm_bars`, `runner_bars`, `required`, `success`, and `reason` (changes in `src/nifty_scalper_bot/core/app.py`).
- Runner observability/throttle: record hydration attempts/reasons and throttle repeated `RUNNER_EVAL_DECISION` logs for `NSE:NIFTY` insufficient-bar cases to once per 30s; enrich `RUNNER_EVAL_DECISION` payload with `required_bars`, `runner_bars`, `mdm_bars`, `hydration_attempted`, and `last_hydration_reason` (changes in `src/nifty_scalper_bot/strategies/runner.py`).
- StrategyManager single-vote config + diagnostics: log `STRATEGY_SINGLE_VOTE_CONFIG` at startup showing `STRATEGY_ALLOW_SINGLE_VOTE_SCALP`, `STRATEGY_SINGLE_VOTE_VWAP_MIN_SCORE`, and `STRATEGY_SINGLE_VOTE_VWAP_MIN_CONFIDENCE` values; add detailed selected-option diagnostics and enrich `TRADE_DECISION_TRACE` with `selected_ce`, `selected_pe`, `strike_distance_from_atm`, `near_atm_threshold`, and `selected_ok_reason` (changes in `src/nifty_scalper_bot/core/strategy_manager.py`).
- Candidate-switch guard: add opt-in controlled candidate-switch behavior behind `STRATEGY_ALLOW_CANDIDATE_SWITCH_ON_HIGH_SCORE` which, when enabled, allows metadata `candidate_switch_requested=True`/`candidate_switch_reason=high_raw_score_nearby_strike` for votes meeting `raw_score >= 7.0`, `confidence >= 0.60`, valid quote/depth, and a strike-distance constraint (env `CANDIDATE_SWITCH_MAX_DISTANCE_POINTS`, default `100`).
- Metadata preservation: ensure score refactor fields remain present (`raw_setup_score`, `setup_score`, `strategy_score`, `regime_weighted_score`, `regime_weight`, `context_bonus`, `context_penalty`, `final_trade_score`, `consensus_score`, `trade_side`, `contract_side`) and add the new selected-context fields for traceability.
- Tests: added focused unit tests (under `tests/core/`) that assert VWAP threshold behavior, non-selected high-score handling, presence of spot hydration logging/token fallback, and presence of the runner throttle key.

### Testing
- Ran `python -m compileall src` and compilation succeeded (no syntax errors introduced).
- Ran the new/updated focused tests:  
  - `pytest -q tests/core/test_strategy_manager_vwap_threshold_behavior.py` — passed.  
  - `pytest -q tests/core/test_strategy_manager_nonselected_high_score.py` — passed.  
  - `pytest -q tests/core/test_spot_context_hydration.py` — passed.  
  - `pytest -q tests/core/test_nifty_insufficient_bar_log_throttle.py` — passed.  
- Full test-suite run (`pytest -q`) stops on a pre-existing unrelated failure: `tests/test_mdm_diagnostics.py` imports `market_data_manager` and raises `ModuleNotFoundError`; this is not caused by these changes and appears to be an environment/import issue in the test harness.  

Notes / operational knobs: defaults remain conservative (VWAP single-vote min score defaults to `5.8`); operators can control behavior via env vars `STRATEGY_ALLOW_SINGLE_VOTE_SCALP`, `STRATEGY_SINGLE_VOTE_VWAP_MIN_SCORE`, `STRATEGY_SINGLE_VOTE_VWAP_MIN_CONFIDENCE`, `STRATEGY_ALLOW_CANDIDATE_SWITCH_ON_HIGH_SCORE`, and `CANDIDATE_SWITCH_MAX_DISTANCE_POINTS`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a054e9f28788324b865239dfa81ebf0)