### PR TITLE
fix: preserve candidate metadata and selected context for final-score gating

### DIFF
--- a/src/nifty_scalper_bot/core/strategy_manager.py
+++ b/src/nifty_scalper_bot/core/strategy_manager.py
@@ -2683,9 +2683,26 @@ class StrategyManager(_BaseStrategyManager):
         if opposite_context and max(_context_veto_score(v) for v in opposite_context) >= 8.0:
             vetoed = True
         if len(trigger_votes) == 1:
-            selected_option = bool(metadata.get("is_selected_option") or indicator_selected_option)
-            selected_ce = str(metadata.get("selected_ce") or "")
-            selected_pe = str(metadata.get("selected_pe") or "")
+            selected_ce = str(
+                metadata.get("selected_ce")
+                or indicator_map.get("selected_ce")
+                or ""
+            )
+            selected_pe = str(
+                metadata.get("selected_pe")
+                or indicator_map.get("selected_pe")
+                or ""
+            )
+            selected_symbol_set = {
+                str(selected_ce).strip().upper(),
+                str(selected_pe).strip().upper(),
+            }
+            selected_symbol_set.discard("")
+            selected_option = bool(
+                metadata.get("is_selected_option")
+                or indicator_selected_option
+                or symbol_norm in selected_symbol_set
+            )
             near_atm_threshold = float(os.getenv("STRATEGY_NEAR_ATM_THRESHOLD_POINTS", "50") or "50")
             try:
                 strike_distance_from_atm = float(metadata.get("strike_distance_from_atm"))
@@ -2693,12 +2710,26 @@ class StrategyManager(_BaseStrategyManager):
             except (TypeError, ValueError):
                 strike_distance_from_atm = None
                 near_atm = indicator_near_atm
+            def _extract_option_strike(sym: str) -> int | None:
+                match = re.search(r"(\d{5})(CE|PE)$", str(sym).upper())
+                return int(match.group(1)) if match else None
+            symbol_strike = _extract_option_strike(symbol_norm)
+            same_side_selected = selected_ce if symbol_norm.endswith("CE") else selected_pe if symbol_norm.endswith("PE") else ""
+            selected_strike = _extract_option_strike(same_side_selected)
+            if strike_distance_from_atm is None and symbol_strike is not None and selected_strike is not None:
+                strike_distance_from_atm = abs(float(symbol_strike) - float(selected_strike))
+                near_atm = strike_distance_from_atm <= near_atm_threshold
             score_min, conf_min = self._single_vote_thresholds(best_vote.strategy)
             regime_weight = _regime_weight(best_vote)
             score_ok = raw_trigger_score >= score_min
             conf_ok = best_vote.confidence >= conf_min
             selected_ok = selected_option or near_atm
             selected_ok_reason = "selected_option" if selected_option else "near_atm" if near_atm else "not_selected_or_near_atm"
+            metadata["selected_ce"] = selected_ce
+            metadata["selected_pe"] = selected_pe
+            metadata["strike_distance_from_atm"] = strike_distance_from_atm
+            metadata["is_selected_option"] = selected_option
+            metadata["selected_ok_reason"] = selected_ok_reason
             log.info(
                 "SINGLE_VOTE_DECISION strategy=%s raw_score=%.2f weighted_score=%.2f regime_weight=%.2f score_min=%.2f confidence=%.2f conf_min=%.2f selected_ok=%s vetoed=%s",
                 best_vote.strategy,

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -2101,6 +2101,21 @@ class StrategyRunner:
             parsed_strike = int(strike_match.group(1)) if strike_match is not None else 0
             strike = int(metadata.get("strike") or parsed_strike or metadata.get("atm_strike") or 0)
             atm_strike = int(metadata.get("atm_strike") or strike)
+            signal_norm = normalize_symbol(signal.symbol)
+            selected_ce = normalize_symbol(str(metadata.get("selected_ce") or self._active_selected_ce or ""))
+            selected_pe = normalize_symbol(str(metadata.get("selected_pe") or self._active_selected_pe or ""))
+            selected_set = {item for item in (selected_ce, selected_pe) if item}
+            try:
+                strike_distance = abs(float(strike) - float(atm_strike)) if strike and atm_strike else None
+            except (TypeError, ValueError):
+                strike_distance = None
+            near_threshold = float(os.getenv("STRATEGY_NEAR_ATM_THRESHOLD_POINTS", "50") or "50")
+            candidate_selected = bool(
+                metadata.get("candidate_selected")
+                or metadata.get("is_selected_option")
+                or signal_norm in selected_set
+                or (strike_distance is not None and strike_distance <= near_threshold)
+            )
             spread_pct = ((ask - bid) / ltp * 100.0) if has_bid_ask and ltp > 0 else None
             tick_age_raw = getattr(snapshot, "tick_age_s", None)
             tick_age_s = float(tick_age_raw) if tick_age_raw is not None else 0.0
@@ -2133,7 +2148,11 @@ class StrategyRunner:
                     else metadata.get("data_score", 0.0)
                     or 0.0
                 ),
-                "candidate_selected": bool(metadata.get("candidate_selected") or metadata.get("is_selected_option")),
+                "candidate_selected": candidate_selected,
+                "is_selected_option": candidate_selected,
+                "selected_ce": selected_ce,
+                "selected_pe": selected_pe,
+                "strike_distance_from_atm": strike_distance,
                 "quote_usable_for_order_plan": bool(snapshot.tradable_quote and has_bid_ask),
                 "tradable_quote": bool(snapshot.tradable_quote and has_bid_ask),
                 "effective_bars": int(metadata.get("effective_bars", metadata.get("history_bars", 0)) or 0),
@@ -7300,6 +7319,14 @@ class StrategyRunner:
                             runtime_ctx["direction_bias"] = str(existing_bias).upper()
                         if symbol_strike is not None and atm_strike is not None:
                             runtime_ctx["strike_distance_from_atm"] = abs(float(symbol_strike) - float(atm_strike))
+                        runtime_ctx["active_selected_ce"] = selected_ce
+                        runtime_ctx["active_selected_pe"] = selected_pe
+                        runtime_ctx["active_option_count"] = len(getattr(self, "_active_option_symbols", []) or [])
+                        if runtime_ctx.get("strike_distance_from_atm") is None:
+                            same_side_selected = selected_ce if option_side == "CE" else selected_pe if option_side == "PE" else None
+                            selected_strike = self._extract_strike_from_symbol(same_side_selected) if same_side_selected else None
+                            if symbol_strike is not None and selected_strike is not None:
+                                runtime_ctx["strike_distance_from_atm"] = abs(float(symbol_strike) - float(selected_strike))
                         quote_payload = self.get_quote(symbol) if hasattr(self, "get_quote") else {}
                         quote_map = dict(quote_payload) if isinstance(quote_payload, Mapping) else {}
                         last_tick_store = getattr(self, "_last_tick", None)
@@ -8955,13 +8982,33 @@ class StrategyRunner:
             )
             atr_for_plan = max(float(metadata.get("atr", 0.0) or 0.0), 1.0)
             try:
+                signal = dataclasses.replace(signal, metadata=dict(metadata))
                 signal = self._materialize_option_trade_plan(
                     signal,
                     execution_price=float(trade_price or 0.0),
                     atr=atr_for_plan,
                     entry_side=str(signal.action or "BUY"),
                 )
-                metadata = dict(signal.metadata or metadata)
+                materialized_metadata = dict(signal.metadata or {})
+                metadata = {
+                    **metadata,
+                    **materialized_metadata,
+                }
+                if "candidate_symbol" not in metadata and candidate is not None:
+                    metadata["candidate_symbol"] = candidate.symbol
+                if "candidate_selected" not in metadata and candidate is not None:
+                    metadata["candidate_selected"] = True
+                if "option_score" not in metadata and candidate is not None:
+                    metadata["option_score"] = float(candidate.score or 0.0)
+                if "data_score" not in metadata and candidate is not None:
+                    metadata["data_score"] = float(candidate.data_quality_score or 0.0)
+                if "candidate_rr" not in metadata and candidate is not None:
+                    metadata["candidate_rr"] = candidate.rr
+                if "candidate_spread_pct" not in metadata and candidate is not None:
+                    metadata["candidate_spread_pct"] = candidate.spread_pct
+                if "quote_usable_for_order_plan" not in metadata:
+                    metadata["quote_usable_for_order_plan"] = bool(metadata.get("tradable_quote"))
+                signal = dataclasses.replace(signal, metadata=dict(metadata))
                 metadata["entry_price"] = float(trade_price or metadata.get("entry_price") or 0.0)
                 metadata["stop_loss"] = signal.stop_loss
                 metadata["take_profit"] = signal.take_profit

--- a/tests/core/test_strategy_manager_selected_context_fallback.py
+++ b/tests/core/test_strategy_manager_selected_context_fallback.py
@@ -1,0 +1,14 @@
+from nifty_scalper_bot.core.strategy_manager import StrategyManager, StrategyVote
+from nifty_scalper_bot.strategies.signal_generator import Signal
+
+
+def test_selected_context_fallback_near_same_side(monkeypatch):
+    monkeypatch.setenv('STRATEGY_ALLOW_SINGLE_VOTE_SCALP', 'true')
+    manager = StrategyManager.__new__(StrategyManager)
+    signal = Signal(action='BUY', symbol='NFO:NIFTY26MAY23500CE', quantity=1, confidence=0.7, reason='SMC', stop_loss=1.0, take_profit=2.0, metadata={})
+    vote = StrategyVote(strategy='SMC', side='CE', score=6.5, confidence=0.7, reasons=[], metadata={'raw_setup_score': 6.5})
+    combined = manager._combine_strategy_votes(symbol=signal.symbol, signals=[(signal, vote)], indicators={'selected_ce': 'NFO:NIFTY26MAY23450CE'})
+    assert combined is not None
+    assert combined.metadata['selected_ce'] == 'NFO:NIFTY26MAY23450CE'
+    assert combined.metadata['strike_distance_from_atm'] == 50.0
+    assert combined.metadata['selected_ok_reason'] == 'near_atm'

--- a/tests/core/test_strategy_manager_trace_selected_fields.py
+++ b/tests/core/test_strategy_manager_trace_selected_fields.py
@@ -1,0 +1,18 @@
+from unittest.mock import patch
+
+from nifty_scalper_bot.core.strategy_manager import StrategyManager, StrategyVote
+from nifty_scalper_bot.strategies.signal_generator import Signal
+
+
+def test_trace_uses_indicator_selected_fields(monkeypatch):
+    monkeypatch.setenv('STRATEGY_ALLOW_SINGLE_VOTE_SCALP', 'false')
+    manager = StrategyManager.__new__(StrategyManager)
+    signal = Signal(action='BUY', symbol='NFO:NIFTY26MAY24000CE', quantity=1, confidence=0.4, reason='VWAPPro', stop_loss=1.0, take_profit=2.0, metadata={})
+    vote = StrategyVote(strategy='VWAPPro', side='CE', score=3.0, confidence=0.4, reasons=[], metadata={'raw_setup_score': 3.0})
+    with patch('nifty_scalper_bot.core.strategy_manager.log.info') as log_info:
+        combined = manager._combine_strategy_votes(symbol=signal.symbol, signals=[(signal, vote)], indicators={'selected_ce': 'NFO:NIFTY26MAY23450CE', 'selected_pe': 'NFO:NIFTY26MAY23450PE'})
+    assert combined is None
+    calls = ' '.join(str(c.args[0]) for c in log_info.call_args_list if c.args)
+    assert 'TRADE_DECISION_TRACE' in calls
+    found = any('selected_ce=%s selected_pe=%s' in str(c.args[0]) for c in log_info.call_args_list if c.args)
+    assert found

--- a/tests/strategies/test_runner_metadata_preserved_after_materialize.py
+++ b/tests/strategies/test_runner_metadata_preserved_after_materialize.py
@@ -1,0 +1,74 @@
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from nifty_scalper_bot.strategies.runner import StrategyRunner
+from nifty_scalper_bot.strategies.signal_generator import Signal
+
+
+class _Snapshot:
+    def __init__(self) -> None:
+        self.ltp = 382.55
+        self.bid = 382.4
+        self.ask = 382.7
+        self.tradable_quote = True
+        self.source = 'ws'
+        self.tick_age_s = 0.1
+        self.real_ticks_last_60s = 20
+
+
+def test_runner_preserves_candidate_metadata_after_materialize(monkeypatch):
+    monkeypatch.setenv('EXECUTION_MODE', 'LIVE')
+    runner = StrategyRunner.__new__(StrategyRunner)
+    runner._logger = MagicMock()
+    runner._runtime_data_hard_ready = True
+    runner._runtime_evaluation_ready = True
+    runner._runtime_live_orders_armed = True
+    runner._runtime_readiness_reason = None
+    runner._order_manager = MagicMock()
+    runner._order_manager.is_kill_switch_active = MagicMock(return_value=False)
+    runner._reset_execution_state = MagicMock()
+    runner._trade_candidate_selector = MagicMock()
+    runner._market_data = SimpleNamespace(get_symbol_snapshot=lambda _symbol: _Snapshot())
+    runner._extract_underlying = MagicMock(return_value='NIFTY')
+    runner._signal_reject_cooldown_ts = {}
+    runner._premium_squeeze_last_signal_ts = {}
+    runner._underlying_last_signal_ts = {}
+    runner._reason_last_signal_ts = {}
+    runner._order_attempt_window = []
+    runner._max_order_attempts_per_minute = 100
+    runner._underlying_signal_cooldown_seconds = 0.0
+    runner._reason_signal_cooldown_seconds = 0.0
+    runner._cooldown_log_throttle_seconds = 1.0
+    runner._is_option_symbol_tick_fresh = MagicMock(return_value=True)
+    runner._materialize_option_trade_plan = MagicMock(side_effect=lambda s, **_: s)
+    runner._compute_regime_snapshot = MagicMock(return_value=SimpleNamespace(value='normal'))
+    runner._last_regime_inputs_by_symbol = {}
+    runner._strategy_regime_decision = MagicMock(return_value=(True, 'ok'))
+    runner._reject_signal_execution = MagicMock(side_effect=lambda **kwargs: SimpleNamespace(accepted=False, reason=kwargs['reason']))
+    runner._validate_entry_signal_strength = MagicMock(return_value=(True, 'ok'))
+    runner._validate_execution_price = MagicMock(return_value=(True, 'ok'))
+    runner._place_order_via_manager = MagicMock(return_value=SimpleNamespace(accepted=True, reason='ok'))
+
+    candidate = SimpleNamespace(
+        symbol='NFO:NIFTY26MAY23400CE', score=7.2, data_quality_score=8.3, rr=1.8,
+        spread_pct=0.1, stop_loss=372.98, target=401.67, entry_price=382.55, side='CE'
+    )
+    runner._trade_candidate_selector.select_best_candidate.return_value = candidate
+
+    signal = Signal(
+        action='BUY', symbol='NFO:NIFTY26MAY23400CE', quantity=1, confidence=0.65,
+        reason='SMC', stop_loss=372.98, take_profit=401.67,
+        metadata={'preliminary_only': True, 'requires_runner_final_score': True, 'direction_score': 6.0, 'strategy_score': 6.0,
+                  'candidate_snapshots': [{'symbol': 'NFO:NIFTY26MAY23400CE', 'atm_strike': 23400, 'bid': 382.4, 'ask': 382.7, 'tradable_quote': True}]}
+    )
+    result = runner._handle_entry_signal_inner(signal, signal.symbol, signal.symbol, 382.55, datetime.now(timezone.utc), trace_id='t1')
+    assert result.reason != 'missing_final_score_components'
+    passed_signal = runner._materialize_option_trade_plan.call_args.args[0]
+    md = passed_signal.metadata
+    assert md['candidate_selected'] is True
+    assert md['candidate_symbol'] == candidate.symbol
+    assert md['option_score'] > 0
+    assert md['data_score'] > 0
+    assert md['rr_score'] > 0
+    assert md['quote_usable_for_order_plan'] is True

--- a/tests/strategies/test_runner_single_candidate_selected_context.py
+++ b/tests/strategies/test_runner_single_candidate_selected_context.py
@@ -1,0 +1,29 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from nifty_scalper_bot.strategies.runner import StrategyRunner
+from nifty_scalper_bot.strategies.signal_generator import Signal
+
+
+class _Snapshot:
+    ltp = 100.0
+    bid = 99.9
+    ask = 100.1
+    tradable_quote = True
+    source = 'ws'
+    tick_age_s = 0.1
+    real_ticks_last_60s = 5
+
+
+def test_single_candidate_uses_active_selected_context():
+    runner = StrategyRunner.__new__(StrategyRunner)
+    runner._logger = MagicMock()
+    runner._market_data = SimpleNamespace(get_symbol_snapshot=lambda _symbol: _Snapshot())
+    runner._active_selected_ce = 'NFO:NIFTY26MAY23400CE'
+    runner._active_selected_pe = None
+    signal = Signal(action='BUY', symbol='NFO:NIFTY26MAY23400CE', quantity=1, confidence=0.5, reason='SMC', stop_loss=95.0, take_profit=110.0, metadata={})
+    candidate = runner._build_single_candidate_from_signal(signal=signal, metadata={}, option_side='CE')
+    assert candidate is not None
+    assert candidate['candidate_selected'] is True
+    assert candidate['is_selected_option'] is True
+    assert candidate['selected_ce'] == 'NFO:NIFTY26MAY23400CE'


### PR DESCRIPTION
### Motivation
- Live signals reached `OPTION_TRADE_PLAN_MATERIALIZED` but were blocked at final-score precheck with `missing_final_score_components` because enriched candidate metadata was overwritten during trade-plan materialization. 
- The strategy manager trace logs and single-vote gating were missing selected CE/PE and strike-distance context, causing valid near‑ATM/selected candidates to be rejected. 

### Description
- In `StrategyRunner._handle_entry_signal_inner`, write the enriched candidate `metadata` into the `signal` before calling `_materialize_option_trade_plan`, then merge materialized metadata back without clobbering candidate scoring fields and reassert key candidate/final-score keys (e.g., `option_score`, `data_score`, `candidate_selected`, `candidate_symbol`, `quote_usable_for_order_plan`).
- In `StrategyRunner._build_single_candidate_from_signal`, treat fallback candidates as selected when they match the active selected CE/PE or are within the near‑ATM threshold and populate `selected_ce`, `selected_pe`, `is_selected_option`, and `strike_distance_from_atm` in the returned snapshot.
- During phase9 runtime context injection, add `active_selected_ce`, `active_selected_pe`, and `active_option_count` to the indicator runtime context and compute a same‑side strike‑distance fallback when `atm_strike` is missing.
- In `StrategyManager._combine_strategy_votes`, consume `selected_ce/selected_pe` from the `indicator_map` when metadata lacks them, infer same‑side strike distance fallback, compute `selected_ok_reason`, and persist `selected_ce`, `selected_pe`, `strike_distance_from_atm`, and `is_selected_option` back into metadata used by tracing and gating.
- Added focused regression tests: `tests/strategies/test_runner_metadata_preserved_after_materialize.py`, `tests/strategies/test_runner_single_candidate_selected_context.py`, `tests/core/test_strategy_manager_selected_context_fallback.py`, and `tests/core/test_strategy_manager_trace_selected_fields.py`.

### Testing
- `python -m compileall src` completed successfully (modules compiled). 
- Ran targeted pytest runs for the new/updated tests and they passed: `tests/strategies/test_runner_metadata_preserved_after_materialize.py`, `tests/strategies/test_runner_single_candidate_selected_context.py`, `tests/core/test_strategy_manager_selected_context_fallback.py`, and `tests/core/test_strategy_manager_trace_selected_fields.py` (all ✅).
- Full `pytest -q` stopped due to an unrelated existing test import error (`tests/test_mdm_diagnostics.py` raised `ModuleNotFoundError: market_data_manager`), so the repo-wide test suite did not complete (⚠️). 
- `run_checks.sh` required environment setup; an initial execution was permission‑denied and a subsequent `bash run_checks.sh` ran dependency installation but did not execute pytest in that flow (environment / CI differences), so overall CI script did not produce an all‑green run in this environment (⚠️).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0560a7f4ec83249c28230d978af0ef)