### PR TITLE
fix: improve same-bar strategy eval gating and single-vote blocker transparency

### DIFF
--- a/README.md
+++ b/README.md
@@ -587,3 +587,14 @@ StrategyRunner → OrderManager → BracketManager
 - StrategyRunner builds and submits TradePlan objects.
 - OrderManager owns entry order placement to broker/paper execution.
 - BracketManager owns SL/TP/trailing/EOD virtual bracket exits.
+
+## Paper/Shadow single-vote tuning (optional)
+For paper or shadow validation only (keep live defaults conservative):
+
+```env
+STRATEGY_ALLOW_SINGLE_VOTE_SCALP=true
+STRATEGY_SINGLE_VOTE_VWAP_MIN_SCORE=5.5
+STRATEGY_SINGLE_VOTE_VWAP_MIN_CONFIDENCE=0.45
+```
+
+Live defaults remain stricter (`STRATEGY_ALLOW_SINGLE_VOTE_SCALP=false`, `STRATEGY_SINGLE_VOTE_VWAP_MIN_SCORE=5.8`).

--- a/src/nifty_scalper_bot/core/strategy_manager.py
+++ b/src/nifty_scalper_bot/core/strategy_manager.py
@@ -2777,11 +2777,18 @@ class StrategyManager(_BaseStrategyManager):
                     metadata["candidate_switch_requested"] = True
                     metadata["candidate_switch_reason"] = "high_raw_score_nearby_strike"
                 else:
-                    blocked_reason = (
-                        "raw_score_below_min" if not score_ok else "confidence_below_min"
-                        if not conf_ok else "not_selected_or_near_atm" if not selected_ok
-                        else "context_veto"
-                    )
+                    if not score_ok:
+                        blocked_reason = "raw_score_below_min"
+                    elif not conf_ok:
+                        blocked_reason = "confidence_below_min"
+                    elif not selected_ok:
+                        blocked_reason = "not_selected_or_near_atm"
+                    elif vetoed:
+                        blocked_reason = "context_veto"
+                    elif not allow_scalp_single:
+                        blocked_reason = "single_vote_scalp_disabled"
+                    else:
+                        blocked_reason = "single_vote_gate_failed_unknown"
                     log.info(
                         "TRADE_DECISION_TRACE symbol=%s strategy=%s side=%s allowed=%s blocked_at=%s blocked_reason=%s selected_ce=%s selected_pe=%s strike_distance_from_atm=%s near_atm_threshold=%s selected_ok_reason=%s raw_score=%.2f confidence=%.2f",
                         symbol_norm,

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -542,6 +542,7 @@ class StrategyRunner:
             float(os.getenv("RUNNER_EVAL_WITHOUT_NEW_BAR_SECONDS", "15")),
         )
         self._last_same_bar_eval_ts_by_symbol: dict[str, float] = {}
+        self._last_eval_price_by_symbol: dict[str, float] = {}
         self._tick_log_throttle_seconds = max(
             1.0,
             float(os.getenv("RUNNER_TICK_LOG_THROTTLE_SECONDS", "120")),
@@ -5551,6 +5552,45 @@ class StrategyRunner:
             except Exception:  # pragma: no cover - defensive
                 pass
 
+    def _same_bar_eval_reason(
+        self,
+        *,
+        symbol: str,
+        price: float,
+        tick: Mapping[str, Any],
+        candle_count: int,
+        now_ts: float,
+    ) -> str | None:
+        """Return reason for intentional same-bar strategy evaluation, else None."""
+        _ = tick
+        if not _env_bool("RUNNER_ENABLE_INTRABAR_STRATEGY_EVAL", True):
+            return None
+        if self._data_phase.get(symbol) != "LIVE":
+            return None
+        if candle_count < self._required_bars_for_symbol(symbol):
+            return None
+        normalized = normalize_symbol(symbol)
+        selected_ce = normalize_symbol(str(getattr(self, "_active_selected_ce", "") or ""))
+        selected_pe = normalize_symbol(str(getattr(self, "_active_selected_pe", "") or ""))
+        selected_set = {s for s in (selected_ce, selected_pe) if s}
+        is_selected_option = normalized in selected_set
+        is_context = normalized in {"NSE:NIFTY", "NIFTY", "NFO:NIFTY26MAYFUT"} or normalized.endswith("FUT")
+        if not is_selected_option and not is_context:
+            interval = float(os.getenv("RUNNER_INTRABAR_EVAL_NON_SELECTED_SECONDS", "60") or "60")
+        else:
+            interval = float(os.getenv("RUNNER_INTRABAR_EVAL_SELECTED_SECONDS", "10") or "10")
+        last_eval_ts = float(self._last_same_bar_eval_ts_by_symbol.get(symbol, 0.0))
+        if now_ts - last_eval_ts >= interval:
+            return "same_bar_periodic_eval"
+        if is_selected_option:
+            last_price = float(self._last_eval_price_by_symbol.get(symbol, 0.0) or 0.0)
+            if last_price > 0 and price > 0:
+                move_pct = abs(price - last_price) / last_price * 100.0
+                min_move_pct = float(os.getenv("RUNNER_INTRABAR_EVAL_MIN_PRICE_MOVE_PCT", "0.12") or "0.12")
+                if move_pct >= min_move_pct:
+                    return "same_bar_price_move_eval"
+        return None
+
     def _is_tradable_symbol(self, symbol: str) -> bool:
         """Return True when symbol is a tradable NIFTY option. Args: symbol. Returns: bool. Raises: none."""
         value = str(symbol or "").upper()
@@ -6892,52 +6932,43 @@ class StrategyRunner:
             current_version = int(self._candle_versions.get(symbol, 0))
             last_version = int(self._last_strategy_versions.get(symbol, 0))
             candle_count = len(self._indicator_engine.get_history(symbol) or [])
+            same_bar_eval_allowed = False
             if current_version <= last_version:
                 now_eval_ts = time_module.time()
-                last_same_bar_eval = float(
-                    self._last_same_bar_eval_ts_by_symbol.get(symbol, 0.0)
+                same_bar_eval_reason = self._same_bar_eval_reason(
+                    symbol=symbol,
+                    price=float(price),
+                    tick=tick,
+                    candle_count=candle_count,
+                    now_ts=now_eval_ts,
                 )
-                if (
-                    self._allow_eval_without_new_bar
-                    and candle_count >= self._required_candles
-                    and now_eval_ts - last_same_bar_eval
-                    >= self._eval_without_new_bar_seconds
-                ):
+                if same_bar_eval_reason:
+                    same_bar_eval_allowed = True
                     self._last_same_bar_eval_ts_by_symbol[symbol] = now_eval_ts
-                    self._logger.info(
-                        "RUNNER_EVAL_DECISION",
-                        extra={
-                            "event": "RUNNER_EVAL_DECISION",
-                            "symbol": symbol,
-                            "trace_id": trace_id,
-                            "allowed": True,
-                            "reason": "same_bar_periodic_eval",
-                            "current_version": current_version,
-                            "last_version": last_version,
-                            "runner_history_count": candle_count,
-                            "required_candles": self._required_candles,
-                            "tick_price": price,
-                        },
+                    self._emit_runner_eval_decision(
+                        symbol=symbol,
+                        stage="phase9",
+                        reason=same_bar_eval_reason,
+                        allowed=True,
+                        trace_id=trace_id,
+                        current_version=current_version,
+                        last_version=last_version,
+                        price=price,
                     )
                 else:
                     if self._should_log_throttled(
-                        f"runner_eval_same_bar_skip:{symbol}",
-                        self._eval_log_throttle_seconds,
+                        f"strategy_eval_skipped_same_bar:{symbol}",
+                        float(os.getenv("RUNNER_SAME_BAR_SKIP_LOG_SECONDS", "30") or "30"),
                     ):
-                        self._logger.info(
-                            "RUNNER_EVAL_DECISION",
-                            extra={
-                                "event": "RUNNER_EVAL_DECISION",
-                                "symbol": symbol,
-                                "trace_id": trace_id,
-                                "allowed": False,
-                                "reason": "same_bar_version",
-                                "current_version": current_version,
-                                "last_version": last_version,
-                                "runner_history_count": candle_count,
-                                "required_candles": self._required_candles,
-                                "tick_price": price,
-                            },
+                        self._emit_runner_eval_decision(
+                            symbol=symbol,
+                            stage="phase9",
+                            reason="strategy_eval_skipped_same_bar",
+                            allowed=False,
+                            trace_id=trace_id,
+                            current_version=current_version,
+                            last_version=last_version,
+                            price=price,
                         )
                     return
             else:
@@ -7097,7 +7128,8 @@ class StrategyRunner:
                             )
                         disable_same_bar_skip = phase != "LIVE"
                         if (
-                            not disable_same_bar_skip
+                            not same_bar_eval_allowed
+                            and not disable_same_bar_skip
                             and _effective_last_bar_ts
                             and state._last_eval_bar_ts
                         ):
@@ -7119,14 +7151,18 @@ class StrategyRunner:
                                         "Condition met: strategy_eval_skipped_same_bar",
                                         extra=extra_payload,
                                     )
-                                self._emit_runner_eval_decision(
-                                    symbol=symbol,
-                                    stage="phase9",
-                                    reason="strategy_eval_skipped_same_bar",
-                                    allowed=False,
-                                    trace_id=trace_id,
-                                    effective_bar_ts=_effective_last_bar_ts.isoformat(),
-                                )
+                                if self._should_log_throttled(
+                                    f"strategy_eval_skipped_same_bar:{symbol}",
+                                    float(os.getenv("RUNNER_SAME_BAR_SKIP_LOG_SECONDS", "30") or "30"),
+                                ):
+                                    self._emit_runner_eval_decision(
+                                        symbol=symbol,
+                                        stage="phase9",
+                                        reason="strategy_eval_skipped_same_bar",
+                                        allowed=False,
+                                        trace_id=trace_id,
+                                        effective_bar_ts=_effective_last_bar_ts.isoformat(),
+                                    )
                                 return
                         if last_bar_ts:
                             bar_age = (now - last_bar_ts).total_seconds()
@@ -7419,6 +7455,7 @@ class StrategyRunner:
                             price,
                             trace_id=trace_id,
                         )
+                        self._last_eval_price_by_symbol[symbol] = float(price)
                         if pending_eval_bar_ts is not None:
                             with self._lock:
                                 state_after = self._symbol_state.get(symbol)
@@ -7559,6 +7596,42 @@ class StrategyRunner:
             if signal and signal.action != "HOLD":
                 phase = "phase10_signal_execution"
                 self._last_strategy_versions[symbol] = current_version
+                signal_phase = self._data_phase.get(symbol)
+                if signal_phase != "LIVE":
+                    signal_metadata = dict(signal.metadata or {})
+                    signal_metadata["shadow_only"] = True
+                    signal_metadata["blocked_reason"] = "non_live_data_phase_signal"
+                    signal_metadata["data_phase"] = signal_phase
+                    self._logger.info(
+                        "TRADE_DECISION_TRACE symbol=%s strategy=%s side=%s allowed=%s blocked_at=%s blocked_reason=%s data_phase=%s",
+                        symbol,
+                        signal_metadata.get("strategy")
+                        or signal_metadata.get("strategy_name")
+                        or signal.reason,
+                        signal_metadata.get("trade_side")
+                        or signal_metadata.get("contract_side")
+                        or signal_metadata.get("side"),
+                        False,
+                        "runner_phase10",
+                        "non_live_data_phase_signal",
+                        signal_phase,
+                        extra={
+                            "event": "TRADE_DECISION_TRACE",
+                            "symbol": symbol,
+                            "strategy": signal_metadata.get("strategy")
+                            or signal_metadata.get("strategy_name")
+                            or signal.reason,
+                            "side": signal_metadata.get("trade_side")
+                            or signal_metadata.get("contract_side")
+                            or signal_metadata.get("side"),
+                            "allowed": False,
+                            "blocked_at": "runner_phase10",
+                            "blocked_reason": "non_live_data_phase_signal",
+                            "data_phase": signal_phase,
+                            "trace_id": trace_id,
+                        },
+                    )
+                    return
                 current_regime = self._compute_regime_snapshot(symbol)
                 signal_metadata = dict(signal.metadata or {})
                 signal_metadata["runtime_regime"] = current_regime.value

--- a/tests/core/test_strategy_manager_single_vote_disabled_reason.py
+++ b/tests/core/test_strategy_manager_single_vote_disabled_reason.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import logging
+
+from nifty_scalper_bot.core.strategy_manager import StrategyManager, StrategyVote
+from nifty_scalper_bot.strategies.signal_generator import Signal
+
+
+def test_single_vote_scalp_disabled_reason(monkeypatch, caplog):
+    monkeypatch.setenv('STRATEGY_ALLOW_SINGLE_VOTE_SCALP', 'false')
+    monkeypatch.setenv('STRATEGY_SINGLE_VOTE_VWAP_MIN_SCORE', '5.5')
+    monkeypatch.setenv('STRATEGY_SINGLE_VOTE_VWAP_MIN_CONFIDENCE', '0.45')
+
+    manager = StrategyManager.__new__(StrategyManager)
+    signal = Signal(
+        action='BUY',
+        symbol='NFO:NIFTY25000CE',
+        quantity=1,
+        confidence=0.60,
+        reason='VWAPPro',
+        stop_loss=1.0,
+        take_profit=2.0,
+        metadata={'is_selected_option': True},
+    )
+    vote = StrategyVote(
+        strategy='VWAPPro',
+        side='CE',
+        score=5.5,
+        confidence=0.60,
+        reasons=[],
+        metadata={'raw_setup_score': 5.5, 'regime_weight': 1.0},
+    )
+    with caplog.at_level(logging.INFO):
+        combined = manager._combine_strategy_votes(
+            symbol=signal.symbol,
+            signals=[(signal, vote)],
+            indicators={},
+        )
+
+    assert combined is None
+    assert any('single_vote_scalp_disabled' in r.message for r in caplog.records)

--- a/tests/strategies/test_runner_same_bar_eval.py
+++ b/tests/strategies/test_runner_same_bar_eval.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from nifty_scalper_bot.strategies.runner import StrategyRunner
+
+
+def _build_runner() -> StrategyRunner:
+    runner = StrategyRunner.__new__(StrategyRunner)
+    runner._data_phase = {"NFO:NIFTY26MAY25000CE": "LIVE", "NFO:NIFTY26MAY25200CE": "LIVE"}
+    runner._last_same_bar_eval_ts_by_symbol = {}
+    runner._last_eval_price_by_symbol = {}
+    runner._active_selected_ce = "NFO:NIFTY26MAY25000CE"
+    runner._active_selected_pe = "NFO:NIFTY26MAY25000PE"
+    runner._required_bars_for_symbol = lambda _s: 50
+    return runner
+
+
+def test_same_bar_periodic_eval_selected(monkeypatch):
+    runner = _build_runner()
+    symbol = "NFO:NIFTY26MAY25000CE"
+    monkeypatch.setenv("RUNNER_ENABLE_INTRABAR_STRATEGY_EVAL", "true")
+    monkeypatch.setenv("RUNNER_INTRABAR_EVAL_SELECTED_SECONDS", "10")
+    runner._last_same_bar_eval_ts_by_symbol[symbol] = 100.0
+    reason = runner._same_bar_eval_reason(
+        symbol=symbol,
+        price=100.0,
+        tick={},
+        candle_count=60,
+        now_ts=111.0,
+    )
+    assert reason == "same_bar_periodic_eval"
+
+
+def test_same_bar_price_move_eval_selected(monkeypatch):
+    runner = _build_runner()
+    symbol = "NFO:NIFTY26MAY25000CE"
+    monkeypatch.setenv("RUNNER_ENABLE_INTRABAR_STRATEGY_EVAL", "true")
+    monkeypatch.setenv("RUNNER_INTRABAR_EVAL_SELECTED_SECONDS", "10")
+    monkeypatch.setenv("RUNNER_INTRABAR_EVAL_MIN_PRICE_MOVE_PCT", "0.12")
+    runner._last_same_bar_eval_ts_by_symbol[symbol] = 100.0
+    runner._last_eval_price_by_symbol[symbol] = 100.0
+    reason = runner._same_bar_eval_reason(
+        symbol=symbol,
+        price=100.2,
+        tick={},
+        candle_count=60,
+        now_ts=104.0,
+    )
+    assert reason == "same_bar_price_move_eval"
+
+
+def test_same_bar_non_selected_small_move_none(monkeypatch):
+    runner = _build_runner()
+    symbol = "NFO:NIFTY26MAY25200CE"
+    monkeypatch.setenv("RUNNER_ENABLE_INTRABAR_STRATEGY_EVAL", "true")
+    monkeypatch.setenv("RUNNER_INTRABAR_EVAL_NON_SELECTED_SECONDS", "60")
+    runner._last_same_bar_eval_ts_by_symbol[symbol] = 100.0
+    runner._last_eval_price_by_symbol[symbol] = 100.0
+    reason = runner._same_bar_eval_reason(
+        symbol=symbol,
+        price=100.05,
+        tick={},
+        candle_count=60,
+        now_ts=110.0,
+    )
+    assert reason is None


### PR DESCRIPTION
### Motivation
- Resolve a contradiction where intentional same-bar periodic evaluations were allowed at the version gate but later blocked by the `_last_eval_bar_ts` same-bar timestamp gate, preventing controlled intrabar scalping.
- Reduce noisy repeated `strategy_eval_skipped_same_bar` logs that hide useful diagnostic information.
- Ensure signals generated during non-LIVE hydration/warmup do not reach the order path and improve observability when single-vote scalp is disabled.

### Description
- StrategyRunner (`src/nifty_scalper_bot/strategies/runner.py`): added a dedicated `_same_bar_eval_reason(...)` helper implementing controlled intrabar evaluation rules (configurable intervals for selected vs non-selected/context symbols and a price-move trigger for selected options), tracked last-eval price in `self._last_eval_price_by_symbol`, and introduced `same_bar_eval_allowed` so intentional same-bar evaluations bypass the later timestamp gate; last-eval price is updated after evaluation.
- StrategyRunner: throttled emission of `strategy_eval_skipped_same_bar` via the existing throttling helper and `RUNNER_SAME_BAR_SKIP_LOG_SECONDS` env var to reduce log spam while preserving gating behavior.
- StrategyRunner: phase10 guard added to block forwarding/execution of any signal when `self._data_phase[symbol] != 'LIVE'`, emitting a `TRADE_DECISION_TRACE` with `blocked_reason=non_live_data_phase_signal` for observability.
- StrategyManager (`src/nifty_scalper_bot/core/strategy_manager.py`): replaced compact ternary logic for single-vote blocking reason with explicit checks so that when single-vote scalp is disabled the blocked reason is `single_vote_scalp_disabled` (improves diagnostics and avoids mislabeling as `context_veto`).
- README: appended an optional paper/shadow-only env snippet documenting `STRATEGY_ALLOW_SINGLE_VOTE_SCALP` and VWAP single-vote tuning for non-live testing while keeping conservative defaults.
- Tests: added `tests/strategies/test_runner_same_bar_eval.py` for `_same_bar_eval_reason` behavior and `tests/core/test_strategy_manager_single_vote_disabled_reason.py` to assert the disabled single-vote reason.

### Testing
- Ran `python -m compileall src` and the codebase compiled successfully.
- Ran targeted tests: `pytest -q tests/strategies/test_runner_same_bar_eval.py` and `pytest -q tests/core/test_strategy_manager_single_vote_disabled_reason.py`, and both passed.
- Ran full test suite (`pytest -q`) which failed due to an unrelated repo/test-environment import issue: `ModuleNotFoundError: No module named 'market_data_manager'` in `tests/test_mdm_diagnostics.py`; this is a baseline environment/test import problem outside these changes and does not indicate regressions in the modified logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0567e1394c8324b03103eb204cb2ea)