### PR TITLE
fix: per-symbol live readiness and relax strategy arbitration / intrabar reeval

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -7069,15 +7069,13 @@ async def _recompute_and_push_runtime_readiness(ctx: BotContext, *, reason: str)
     picked_ce, picked_pe = pick_atm_option_symbols_from_basket(basket)
     selected_ce = cast(
         str | None,
-        getattr(ctx, "selected_ce", None)
-        or basket.get("selected_ce")
+        basket.get("selected_ce")
         or basket.get("atm_ce")
         or picked_ce,
     )
     selected_pe = cast(
         str | None,
-        getattr(ctx, "selected_pe", None)
-        or basket.get("selected_pe")
+        basket.get("selected_pe")
         or basket.get("atm_pe")
         or picked_pe,
     )
@@ -7087,13 +7085,13 @@ async def _recompute_and_push_runtime_readiness(ctx: BotContext, *, reason: str)
         selected_pe = old_pe
     basket.update({"selected_ce": selected_ce, "selected_pe": selected_pe, "option_symbols": option_symbols, "symbols": option_symbols})
     ctx.active_trading_universe = basket
-    if selected_ce and not getattr(ctx, "selected_ce", None):
+    if selected_ce:
         ctx.selected_ce = str(selected_ce)
-    elif selected_ce is None:
+    else:
         ctx.selected_ce = None
-    if selected_pe and not getattr(ctx, "selected_pe", None):
+    if selected_pe:
         ctx.selected_pe = str(selected_pe)
-    elif selected_pe is None:
+    else:
         ctx.selected_pe = None
     ctx.atm_ce_symbol = selected_ce
     ctx.atm_pe_symbol = selected_pe
@@ -7192,7 +7190,12 @@ async def _recompute_and_push_runtime_readiness(ctx: BotContext, *, reason: str)
     live_mode = str(getattr(ctx.settings, "execution_mode", "PAPER")).upper() == "LIVE"
     market_open = get_market_state() == MarketState.OPEN
     broker_ready = bool(getattr(ctx, "broker_client", None) and getattr(ctx, "order_manager", None))
-    live_orders_armed=bool(live_mode and market_open and evaluation_ready and ce_exec_ready and pe_exec_ready and context_exec_ready and broker_ready)
+    execution_ready_by_symbol = {
+        str(selected_ce or ""): bool(ce_exec_ready),
+        str(selected_pe or ""): bool(pe_exec_ready),
+    }
+    any_selected_option_exec_ready = bool(ce_exec_ready or pe_exec_ready)
+    live_orders_armed=bool(live_mode and market_open and evaluation_ready and context_exec_ready and broker_ready and any_selected_option_exec_ready)
     missing=[]
     if not selected_ce: missing.append('selected_ce_missing')
     if not selected_pe: missing.append('selected_pe_missing')
@@ -7208,9 +7211,12 @@ async def _recompute_and_push_runtime_readiness(ctx: BotContext, *, reason: str)
         if not broker_ready: missing.append('broker_or_order_manager_not_ready')
     block_reason=None if live_orders_armed else ((f"execution_not_armed:{','.join(missing)}" if evaluation_ready else f"startup_pipeline_incomplete:{','.join(missing)}"))
     ctx.data_hard_ready=data_hard_ready; ctx.evaluation_ready=evaluation_ready; ctx.live_orders_armed=live_orders_armed; ctx.trading_ready=live_orders_armed; ctx.live_block_reason=block_reason
-    LOGGER.info("LIVE_READINESS_COMPUTED selected_ce=%s selected_pe=%s ce_ltp_fresh=%s pe_ltp_fresh=%s ce_tick_age_s=%s pe_tick_age_s=%s ce_tradable_quote=%s pe_tradable_quote=%s ce_depth_available=%s pe_depth_available=%s ce_subscription_confirmed=%s pe_subscription_confirmed=%s ce_subscription_or_live_tick=%s pe_subscription_or_live_tick=%s ce_bars_effective=%s ce_mdm_bars=%s ce_runner_bars=%s pe_bars_effective=%s pe_mdm_bars=%s pe_runner_bars=%s data_hard_ready=%s evaluation_ready=%s live_orders_armed=%s live_block_reason=%s", selected_ce, selected_pe, ce_quote_fresh, pe_quote_fresh, getattr(_snapshot(selected_ce),'tick_age_s',None), getattr(_snapshot(selected_pe),'tick_age_s',None), _tradable_quote(selected_ce), _tradable_quote(selected_pe), bool(getattr(_snapshot(selected_ce),'depth_available',False)), bool(getattr(_snapshot(selected_pe),'depth_available',False)), _subscription_confirmed(selected_ce), _subscription_confirmed(selected_pe), _subscription_or_live_tick(selected_ce), _subscription_or_live_tick(selected_pe), ce_bars, ce_mdm_bars, ce_runner_bars, pe_bars, pe_mdm_bars, pe_runner_bars, data_hard_ready, evaluation_ready, live_orders_armed, block_reason)
+    ctx.execution_ready_by_symbol = execution_ready_by_symbol
+    ctx.selected_ce_exec_ready = bool(ce_exec_ready)
+    ctx.selected_pe_exec_ready = bool(pe_exec_ready)
+    LOGGER.info("LIVE_READINESS_COMPUTED selected_ce=%s selected_pe=%s ce_ltp_fresh=%s pe_ltp_fresh=%s ce_tick_age_s=%s pe_tick_age_s=%s ce_tradable_quote=%s pe_tradable_quote=%s ce_depth_available=%s pe_depth_available=%s ce_subscription_confirmed=%s pe_subscription_confirmed=%s ce_subscription_or_live_tick=%s pe_subscription_or_live_tick=%s ce_bars_effective=%s ce_mdm_bars=%s ce_runner_bars=%s pe_bars_effective=%s pe_mdm_bars=%s pe_runner_bars=%s data_hard_ready=%s evaluation_ready=%s live_orders_armed=%s ce_exec_ready=%s pe_exec_ready=%s execution_ready_by_symbol=%s live_block_reason=%s", selected_ce, selected_pe, ce_quote_fresh, pe_quote_fresh, getattr(_snapshot(selected_ce),'tick_age_s',None), getattr(_snapshot(selected_pe),'tick_age_s',None), _tradable_quote(selected_ce), _tradable_quote(selected_pe), bool(getattr(_snapshot(selected_ce),'depth_available',False)), bool(getattr(_snapshot(selected_pe),'depth_available',False)), _subscription_confirmed(selected_ce), _subscription_confirmed(selected_pe), _subscription_or_live_tick(selected_ce), _subscription_or_live_tick(selected_pe), ce_bars, ce_mdm_bars, ce_runner_bars, pe_bars, pe_mdm_bars, pe_runner_bars, data_hard_ready, evaluation_ready, live_orders_armed, ce_exec_ready, pe_exec_ready, execution_ready_by_symbol, block_reason)
     if ctx.strategy_runner is not None and hasattr(ctx.strategy_runner, 'set_runtime_readiness'):
-        ctx.strategy_runner.set_runtime_readiness(data_hard_ready=bool(ctx.data_hard_ready), evaluation_ready=bool(ctx.evaluation_ready), live_orders_armed=bool(ctx.live_orders_armed), reason=str(ctx.live_block_reason or reason), selected_ce=selected_ce, selected_pe=selected_pe, atm_strike=basket.get('atm_strike'), option_symbols=option_symbols)
+        ctx.strategy_runner.set_runtime_readiness(data_hard_ready=bool(ctx.data_hard_ready), evaluation_ready=bool(ctx.evaluation_ready), live_orders_armed=bool(ctx.live_orders_armed), reason=str(ctx.live_block_reason or reason), selected_ce=selected_ce, selected_pe=selected_pe, atm_strike=basket.get('atm_strike'), option_symbols=option_symbols, execution_ready_by_symbol=execution_ready_by_symbol)
 
 
 def _commit_active_dynamic_basket(

--- a/src/nifty_scalper_bot/core/strategy_manager.py
+++ b/src/nifty_scalper_bot/core/strategy_manager.py
@@ -2831,8 +2831,21 @@ class StrategyManager(_BaseStrategyManager):
         context_penalty = min(1.5, 0.60 * negative_context)
         final_score = raw_trigger_score + context_bonus - context_penalty
         final_score = max(0.0, min(10.0, final_score))
-        if opposite_context and max(self._extract_context_veto_score(v) for v in opposite_context) >= 8.0:
-            vetoed = True
+        context_confidence_floor = float(os.getenv("STRATEGY_CONTEXT_HARD_VETO_MIN_CONFIDENCE", "0.80") or "0.80")
+        context_freshness_max_age_s = float(os.getenv("STRATEGY_CONTEXT_HARD_VETO_MAX_AGE_SECONDS", "120") or "120")
+        now_epoch = time.time()
+        hard_veto_candidates = []
+        for vote in opposite_context:
+            md = dict(vote.metadata or {})
+            vote_ts = float(md.get("timestamp_epoch") or md.get("ts") or now_epoch)
+            age_s = max(0.0, now_epoch - vote_ts)
+            if (
+                self._extract_context_veto_score(vote) >= 8.0
+                and float(vote.confidence) >= context_confidence_floor
+                and age_s <= context_freshness_max_age_s
+            ):
+                hard_veto_candidates.append(vote)
+        vetoed = bool(hard_veto_candidates)
         selected_ok = True
         near_atm = indicator_near_atm
         if trigger_votes and len(trigger_votes) == 1:
@@ -2940,8 +2953,10 @@ class StrategyManager(_BaseStrategyManager):
                         blocked_reason = "confidence_below_min"
                     elif not selected_ok:
                         blocked_reason = "not_selected_or_near_atm"
+                    elif not bool(metadata.get("quote_depth_valid", True)):
+                        blocked_reason = "quote_depth_invalid"
                     elif vetoed:
-                        blocked_reason = "context_veto"
+                        blocked_reason = "hard_context_veto"
                     elif not allow_scalp_single:
                         blocked_reason = "single_vote_scalp_disabled"
                     else:
@@ -2979,7 +2994,7 @@ class StrategyManager(_BaseStrategyManager):
         metadata["context_penalty"] = round(context_penalty, 3)
         metadata["final_trade_score"] = round(final_score, 3)
         if vetoed or final_score < threshold:
-            blocked_reason = "context_veto" if vetoed else "final_trade_score_below_threshold"
+            blocked_reason = "hard_context_veto" if vetoed else "final_trade_score_below_threshold"
             log.info(
                 "TRADE_DECISION_TRACE symbol=%s strategy=%s side=%s data_gate=%s setup_score=%.2f setup_min=%.2f weighted_score=%.2f regime_weight=%.2f context_bonus=%.2f context_penalty=%.2f final_score=%.2f final_min=%.2f allowed=%s blocked_at=%s blocked_reason=%s",
                 symbol_norm, best_vote.strategy, best_vote.side, True, raw_trigger_score, threshold, weighted_trigger_score, _regime_weight(best_vote), context_bonus, context_penalty, final_score, threshold, False, "strategy_manager_combine", blocked_reason,

--- a/src/nifty_scalper_bot/strategies/elite_strategies/order_flow.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/order_flow.py
@@ -147,7 +147,8 @@ class OrderFlowStrategy(EliteStrategy):
 
             depth_imbalance = (total_bid - total_ask) / max(total_bid + total_ask, 1.0)
             side = contract_side if option_premium_domain else ('CE' if depth_imbalance > 0 else 'PE')
-            if option_premium_domain and depth_imbalance <= 0 and tick_direction not in {'UP', 'BUY'}:
+            clear_adverse_flow = bool(option_premium_domain and quote_depth_valid and depth_available and depth_imbalance <= -0.10 and tick_direction not in {'UP', 'BUY'})
+            if clear_adverse_flow:
                 self._no_vote('negative_premium_flow')
                 return None
 
@@ -229,6 +230,7 @@ class OrderFlowStrategy(EliteStrategy):
                 'tradable_quote': tradable_quote,
                 'depth_available': depth_available,
                 'premium_flow_direction': tick_direction,
+                'negative_premium_flow_mode': 'hard' if clear_adverse_flow else 'soft',
             }
             if trigger_conditions_met:
                 metadata['approval_candidate'] = 'orderflow_live_depth_trigger'

--- a/src/nifty_scalper_bot/strategies/elite_strategies/smc_liquidity.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/smc_liquidity.py
@@ -59,7 +59,8 @@ class SMCStrategy(EliteStrategy):
             contract_side, option_premium_domain, _ = resolve_signal_domain(symbol, indicators)
             if option_premium_domain:
                 premium_reversal = bool(bullish_sweep or indicators.get('premium_reclaim') or indicators.get('bullish_reversal'))
-                if not premium_reversal:
+                structure_flip = bool(indicators.get('choch_confirmed') or indicators.get('bos_confirmed'))
+                if not premium_reversal and not structure_flip:
                     self._no_vote('premium_not_reversing_up')
                     return None
                 side = contract_side
@@ -146,6 +147,7 @@ class SMCStrategy(EliteStrategy):
                 'underlying_invalidation_level': sweep_level,
                 'premium_stop_distance': max(atr * 1.2, current_price * 0.025, 1.0),
                 'premium_target_rr': 2.0,
+                'premium_reversal_gate_mode': 'hard' if option_premium_domain and not premium_reclaim and not structure_confirmed else 'soft',
             }
             LOGGER.info('STRATEGY_VOTE strategy=SMC side=%s score=%.2f', side, strategy_score)
             return EliteSignal(

--- a/src/nifty_scalper_bot/strategies/elite_strategies/vwap_pro.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/vwap_pro.py
@@ -159,7 +159,10 @@ class VWAPProStrategy(EliteStrategy):
             min_score_default = '5.8' if is_live else '5.0'
             min_trend_score_default = '5.5' if is_live else '4.5'
             min_score = float(os.getenv('VWAP_PRO_MIN_TREND_ALIGNED_SCORE', min_trend_score_default) if trend_alignment else os.getenv('VWAP_PRO_MIN_SCORE', min_score_default))
-            if ((is_live and require_alignment_live) or ((not is_live) and require_alignment_shadow)) and not trend_alignment:
+            context_fresh = float(indicators.get('context_age_seconds') or 0.0) <= float(os.getenv('VWAP_CONTEXT_MAX_AGE_SECONDS', '120') or '120')
+            context_strong = float(indicators.get('underlying_direction_confidence') or 0.0) >= float(os.getenv('VWAP_CONTEXT_MIN_CONFIDENCE', '0.75') or '0.75')
+            hard_conflict = bool(((is_live and require_alignment_live) or ((not is_live) and require_alignment_shadow)) and not trend_alignment and context_fresh and context_strong)
+            if hard_conflict:
                 self._no_vote('underlying_direction_conflict')
                 return None
             threshold_source = 'trend_aligned' if trend_alignment else 'base'
@@ -238,6 +241,7 @@ class VWAPProStrategy(EliteStrategy):
                 'premium_stop_distance': atr_safe,
                 'premium_target_rr': 2.0,
                 'underlying_invalidation_level': (vwap - atr_safe) if contract_side == 'CE' else (vwap + atr_safe),
+                'no_vote_conflict_mode': 'hard' if hard_conflict else 'soft',
             }
             LOGGER.info('STRATEGY_VOTE strategy=VWAPPro side=%s score=%.2f', contract_side, strategy_score)
             return EliteSignal(

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -601,6 +601,7 @@ class StrategyRunner:
         self._runtime_data_hard_ready = False
         self._runtime_evaluation_ready = False
         self._runtime_live_orders_armed = False
+        self._runtime_execution_ready_by_symbol: dict[str, bool] = {}
         self._runtime_readiness_reason: str | None = None
         self._runtime_startup_ready = False
         self._startup_gate_last_log_ts = 0.0
@@ -1961,11 +1962,19 @@ class StrategyRunner:
         selected_pe: str | None = None,
         atm_strike: int | float | str | None = None,
         option_symbols: list[str] | tuple[str, ...] | set[str] | None = None,
+        execution_ready_by_symbol: Mapping[str, bool] | None = None,
     ) -> None:
         """Set app-level runtime readiness flags. Args: flags/reason. Returns: none. Raises: none."""
         self._runtime_data_hard_ready = bool(data_hard_ready)
         self._runtime_evaluation_ready = bool(evaluation_ready)
         self._runtime_live_orders_armed = bool(live_orders_armed)
+        normalized_execution_ready: dict[str, bool] = {}
+        if execution_ready_by_symbol:
+            for raw_symbol, ready in execution_ready_by_symbol.items():
+                normalized = normalize_symbol(str(raw_symbol or ""))
+                if normalized:
+                    normalized_execution_ready[normalized] = bool(ready)
+        self._runtime_execution_ready_by_symbol = normalized_execution_ready
         self._runtime_readiness_reason = reason
         self._runtime_startup_ready = bool(
             self._runtime_data_hard_ready and self._runtime_evaluation_ready
@@ -1983,6 +1992,21 @@ class StrategyRunner:
             self._active_selected_pe,
             len(self._active_option_symbols),
         )
+
+    def _is_symbol_execution_ready(self, symbol: str) -> bool:
+        """Return per-symbol execution readiness in live mode. Args: symbol. Returns: bool. Raises: none."""
+        mode = str(os.getenv("EXECUTION_MODE", "SHADOW")).strip().upper()
+        is_live_mode = mode == "LIVE" or (
+            str(os.getenv("ENABLE_LIVE", "false")).strip().lower()
+            in {"1", "true", "yes", "on"}
+        )
+        if not is_live_mode:
+            return True
+        if not bool(self._runtime_live_orders_armed):
+            return False
+        if not self._runtime_execution_ready_by_symbol:
+            return bool(self._runtime_live_orders_armed)
+        return bool(self._runtime_execution_ready_by_symbol.get(normalize_symbol(symbol), False))
 
     def get_runtime_readiness_snapshot(self) -> dict[str, object]:
         """Return runtime readiness snapshot. Args: none. Returns: readiness map. Raises: none."""
@@ -5564,7 +5588,10 @@ class StrategyRunner:
         now_ts: float,
     ) -> str | None:
         """Return reason for intentional same-bar strategy evaluation, else None."""
-        _ = tick
+        bid = float(tick.get("bid") or 0.0)
+        ask = float(tick.get("ask") or 0.0)
+        volume_now = float(tick.get("volume") or 0.0)
+        tick_ts = float(tick.get("timestamp_epoch") or tick.get("ts") or 0.0)
         if not _env_bool("RUNNER_ENABLE_INTRABAR_STRATEGY_EVAL", True):
             self._last_same_bar_eval_block_reason_by_symbol[symbol] = "intrabar_eval_env_disabled"
             return None
@@ -5610,15 +5637,34 @@ class StrategyRunner:
             return None
         if is_selected_option or near_selected:
             last_price = float(self._last_eval_price_by_symbol.get(symbol, 0.0) or 0.0)
+            detail: dict[str, Any] = {}
             if last_price > 0 and price > 0:
                 move_pct = abs(price - last_price) / last_price * 100.0
                 min_move_pct = float(os.getenv("RUNNER_INTRABAR_EVAL_MIN_PRICE_MOVE_PCT", "0.12") or "0.12")
+                detail["price_move_pct"] = round(move_pct, 4)
                 if move_pct >= min_move_pct:
                     self._last_same_bar_eval_block_reason_by_symbol.pop(symbol, None)
                     self._last_same_bar_eval_block_detail_by_symbol.pop(symbol, None)
                     return "same_bar_price_move_eval"
-                self._last_same_bar_eval_block_reason_by_symbol[symbol] = "intrabar_eval_price_move_too_small"
-                return None
+            last_quote = self._last_same_bar_eval_block_detail_by_symbol.get(symbol, {})
+            spread_now = (ask - bid) if ask > bid > 0 else 0.0
+            last_spread = float(last_quote.get("spread_now") or 0.0)
+            spread_delta = abs(spread_now - last_spread)
+            spread_trigger = spread_delta >= float(os.getenv("RUNNER_INTRABAR_SPREAD_DELTA_MIN", "0.25") or "0.25")
+            ts_changed = tick_ts > float(last_quote.get("tick_ts") or 0.0)
+            volume_delta = max(0.0, volume_now - float(last_quote.get("volume_now") or 0.0))
+            volume_trigger = volume_delta >= float(os.getenv("RUNNER_INTRABAR_VOLUME_DELTA_MIN", "100") or "100")
+            current_score = float(tick.get("candidate_score") or 0.0)
+            prev_score = float(last_quote.get("candidate_score") or 0.0)
+            score_trigger = current_score > prev_score + float(os.getenv("RUNNER_INTRABAR_CANDIDATE_SCORE_DELTA_MIN", "0.15") or "0.15")
+            detail.update({"volume_delta": round(volume_delta, 2), "spread_now": round(spread_now, 4), "spread_delta": round(spread_delta, 4), "bid_ask_fresh": bool(ts_changed), "tick_ts": tick_ts, "volume_now": volume_now, "candidate_score": current_score})
+            if spread_trigger or ts_changed or volume_trigger or score_trigger:
+                self._last_same_bar_eval_block_reason_by_symbol.pop(symbol, None)
+                self._last_same_bar_eval_block_detail_by_symbol.pop(symbol, None)
+                return "same_bar_market_update_eval"
+            self._last_same_bar_eval_block_reason_by_symbol[symbol] = "intrabar_eval_conditions_not_met"
+            self._last_same_bar_eval_block_detail_by_symbol[symbol] = detail
+            return None
         self._last_same_bar_eval_block_reason_by_symbol[symbol] = "intrabar_eval_interval_not_elapsed"
         return None
 
@@ -8905,8 +8951,8 @@ class StrategyRunner:
                 str(os.getenv("ENABLE_LIVE", "false")).strip().lower()
                 in {"1", "true", "yes", "on"}
             )
-            if is_live_mode and not bool(self._runtime_live_orders_armed):
-                self._logger.info("ORDER_PATH_BLOCKED reason=runtime_live_orders_not_armed symbol=%s trace_id=%s", base_symbol, trace_id)
+            if is_live_mode and not self._is_symbol_execution_ready(base_symbol):
+                self._logger.info("ORDER_PATH_BLOCKED reason=runtime_symbol_execution_not_ready symbol=%s trace_id=%s live_orders_armed=%s symbol_ready=%s readiness_map=%s", base_symbol, trace_id, bool(self._runtime_live_orders_armed), bool(self._runtime_execution_ready_by_symbol.get(normalize_symbol(base_symbol), False)), self._runtime_execution_ready_by_symbol)
                 self._logger.info(
                     "RUNNER_BLOCKED_RUNTIME_READINESS",
                     extra={
@@ -8915,13 +8961,14 @@ class StrategyRunner:
                         "runtime_data_hard_ready": bool(self._runtime_data_hard_ready),
                         "runtime_evaluation_ready": bool(self._runtime_evaluation_ready),
                         "runtime_live_orders_armed": bool(self._runtime_live_orders_armed),
+                        "runtime_execution_ready_by_symbol": dict(self._runtime_execution_ready_by_symbol),
                         "runtime_readiness_reason": self._runtime_readiness_reason,
                         "trace_id": trace_id,
                     },
                 )
                 self._reset_execution_state(base_symbol)
-                _trace("runtime_live_orders_not_armed")
-                return SignalExecutionResult(False, "runtime_live_orders_not_armed")
+                _trace("runtime_symbol_execution_not_ready")
+                return SignalExecutionResult(False, "runtime_symbol_execution_not_ready")
             self._logger.info("ORDER_PATH_ENTERED symbol=%s reason=%s live_orders_armed=%s trace_id=%s", base_symbol, reason_key, bool(self._runtime_live_orders_armed), trace_id)
             option_side = infer_option_side(signal.symbol, metadata)
             if is_live_mode and option_side == "UNKNOWN":


### PR DESCRIPTION
### Motivation
- Live execution was blocked because global `live_orders_armed` required both CE and PE to be execution-ready, causing one unready side to block the other and preventing expected trades.
- Strategy arbitration and same-bar gating were overly defensive, rejecting high-conviction selected/near‑ATM signals and preventing reasonable intrabar reevaluations.

### Description
- Implemented per-symbol execution readiness in `app.py` and propagated it to the runner via `execution_ready_by_symbol`, and exposed `ctx.selected_ce_exec_ready` / `ctx.selected_pe_exec_ready`. (src/nifty_scalper_bot/core/app.py)
- Extended `StrategyRunner.set_runtime_readiness()` to accept `execution_ready_by_symbol`, store normalized readiness map, and added `_is_symbol_execution_ready()` to enforce symbol-level readiness in the order entry path; replaced the old global live-block check with per-symbol blocking that logs symbol/global/map state. (src/nifty_scalper_bot/strategies/runner.py)
- Relaxed same-bar blocking in the runner by allowing controlled intrabar reevaluation for selected/near-selected options when material conditions are met (price move %, bid/ask freshness or spread delta, volume delta, or candidate score improvement), while preserving periodic interval gating and throttled logs. (src/nifty_scalper_bot/strategies/runner.py)
- Softened strategy-manager hard veto semantics so opposite-context only hard-vetoes when the opposing context vote is sufficiently strong and fresh; changed blocked reasons to distinguish hard context veto. (src/nifty_scalper_bot/core/strategy_manager.py)
- Converted several elite-strategy no-vote hard blocks into safer soft/hard modes with metadata flags so that VWAPPro, OrderFlow, and SMC no-votes remain safe but less likely to overblock valid, high-conviction selected setups. (src/nifty_scalper_bot/strategies/elite_strategies/vwap_pro.py, src/nifty_scalper_bot/strategies/elite_strategies/order_flow.py, src/nifty_scalper_bot/strategies/elite_strategies/smc_liquidity.py)
- Ensured readiness recompute prefers fresh basket selection (active universe) over stale `ctx.selected_*` values when populating `ctx.selected_ce` and `ctx.selected_pe`. (src/nifty_scalper_bot/core/app.py)

### Testing
- `python -m compileall -q src/nifty_scalper_bot` — succeeded without errors.
- Targeted unit tests: `pytest -q tests/core/test_runtime_readiness.py tests/test_live_readiness_gate.py tests/test_execution_path_contract.py tests/test_strategy_manager_consensus.py tests/test_single_vote_score_decomposition.py tests/test_direction_arbitration.py` — all passed.
- Full test run: `pytest -q` — completed but there is one unrelated existing failure in `tests/notifications/test_telegram_controller.py::test_cmd_subscribe_stream_supervisor` (not introduced by these changes); all modified-area tests (readiness, runner, strategy manager, elite strategies) passed.

Files changed: src/nifty_scalper_bot/core/app.py, src/nifty_scalper_bot/strategies/runner.py, src/nifty_scalper_bot/core/strategy_manager.py, src/nifty_scalper_bot/strategies/elite_strategies/vwap_pro.py, src/nifty_scalper_bot/strategies/elite_strategies/order_flow.py, src/nifty_scalper_bot/strategies/elite_strategies/smc_liquidity.py

Notes: these edits are localized, preserve existing risk/cooldown/quality/executor checks, and do not introduce new architecture or duplicate readiness systems. Please run `./run_checks.sh` locally/CI per repo guidelines before merging.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a94721ddc832495f47272e6b5461e)