### PR TITLE
Fix PR439 option-context regressions and live trigger diagnostics

### DIFF
--- a/src/nifty_scalper_bot/core/strategy_manager.py
+++ b/src/nifty_scalper_bot/core/strategy_manager.py
@@ -3256,11 +3256,26 @@ class StrategyManager(_BaseStrategyManager):
                 context_age = float(md0.get("context_age_seconds") or indicators.get("context_age_seconds") or 999.0)
             except (TypeError, ValueError):
                 context_age = 999.0
-            quote_depth_valid = bool(
+            try:
+                bid = float(md0.get("bid") or indicators.get("bid") or 0.0)
+            except (TypeError, ValueError):
+                bid = 0.0
+            try:
+                ask = float(md0.get("ask") or indicators.get("ask") or 0.0)
+            except (TypeError, ValueError):
+                ask = 0.0
+            bid_ask_valid = bid > 0.0 and ask > 0.0 and ask >= bid
+            depth_or_tradable = bool(
                 md0.get("quote_depth_valid")
                 or indicators.get("quote_depth_valid")
-                or ((md0.get("bid") or indicators.get("bid")) and (md0.get("ask") or indicators.get("ask")))
+                or md0.get("tradable_quote")
+                or indicators.get("tradable_quote")
             )
+            quote_depth_valid = bool(bid_ask_valid and depth_or_tradable)
+            if spread_pct >= 999.0 and bid_ask_valid:
+                midpoint = (bid + ask) / 2.0
+                if midpoint > 0.0:
+                    spread_pct = ((ask - bid) / midpoint) * 100.0
             live_reject_reason = None
             if raw_score < live_min_score:
                 live_reject_reason = "live_context_score_below_min"

--- a/src/nifty_scalper_bot/core/strategy_manager.py
+++ b/src/nifty_scalper_bot/core/strategy_manager.py
@@ -1950,6 +1950,12 @@ class StrategyManager(_BaseStrategyManager):
         )
         no_signal_reasons: list[str] = []
         error_strategies: list[str] = []
+        signals: list[Signal] = []
+        signal_votes: list[tuple[Signal, StrategyVote]] = []
+        disabled: list[str] = []
+        empty: list[str] = []
+        no_vote_reason_counts: dict[str, int] = {}
+        errors: list[str] = []
         disabled_strategies_snapshot: list[str] = []
         signal_action: str | None = None
         signal_score: float | None = None
@@ -2428,13 +2434,7 @@ class StrategyManager(_BaseStrategyManager):
 
         position = self._position_manager.get_position(symbol)
 
-        signals: list[Signal] = []
-        signal_votes: list[tuple[Signal, StrategyVote]] = []
         max_votes = max(1, int(getattr(app_settings, "MAX_STRATEGY_VOTES", 5)))
-        disabled: list[str] = []
-        empty: list[str] = []
-        no_vote_reason_counts: dict[str, int] = {}
-        errors: list[str] = []
         disabled_strategies_snapshot = disabled
         evaluation_start = time.monotonic()
         symbol_upper = symbol.upper()
@@ -2894,20 +2894,65 @@ class StrategyManager(_BaseStrategyManager):
                 approval_path = "context_promotion"
             else:
                 approval_path = "no_trade"
-                log.info("TRADE_DECISION_TRACE approval_path=%s blocked_at=%s blocked_reason=%s symbol=%s", approval_path, "no_trigger_vote", "no_trigger_vote", symbol_norm)
+                context_vote_names = [v.strategy for _, v in context_votes]
+                context_sides = [v.side for _, v in context_votes]
+                context_scores = [self._extract_raw_score(v) for _, v in context_votes]
+                context_confidences = [float(v.confidence) for _, v in context_votes]
+                log.info(
+                    "TRADE_DECISION_TRACE approval_path=%s blocked_at=%s blocked_reason=%s "
+                    "symbol=%s context_votes=%s context_sides=%s context_scores=%s "
+                    "direction_bias=%s underlying_direction_bias=%s context_age_seconds=%s",
+                    approval_path,
+                    "no_trigger_vote",
+                    "no_trigger_vote",
+                    symbol_norm,
+                    context_vote_names,
+                    context_sides,
+                    context_scores,
+                    indicator_map.get("direction_bias"),
+                    indicator_map.get("underlying_direction_bias"),
+                    indicator_map.get("context_age_seconds"),
+                    extra={
+                        "event": "TRADE_DECISION_TRACE",
+                        "symbol": symbol_norm,
+                        "approval_path": approval_path,
+                        "blocked_at": "no_trigger_vote",
+                        "blocked_reason": "no_trigger_vote",
+                        "context_vote_count": len(context_votes),
+                        "context_votes": context_vote_names,
+                        "context_sides": context_sides,
+                        "context_scores": context_scores,
+                        "context_confidences": context_confidences,
+                        "allow_context_promotion": bool(mode_profile.get("allow_context_promotion", False)),
+                        "execution_mode": mode_profile.get("mode"),
+                        "direction_bias": indicator_map.get("direction_bias"),
+                        "underlying_direction_bias": indicator_map.get("underlying_direction_bias"),
+                        "context_age_seconds": indicator_map.get("context_age_seconds"),
+                    },
+                )
                 log_throttled(
                     log,
                     f"strategy_no_trigger_vote:{symbol_norm}",
-                    "STRATEGY_NO_TRIGGER_VOTE symbol=%s context_votes=%s live_context_promotion_allowed=%s",
+                    "STRATEGY_NO_TRIGGER_VOTE symbol=%s context_votes=%s context_sides=%s live_context_promotion_allowed=%s",
                     symbol_norm,
-                    [v.strategy for _, v in context_votes],
+                    context_vote_names,
+                    context_sides,
                     bool(mode_profile.get("allow_context_promotion", False)),
                     interval_sec=30.0,
                     level=logging.INFO,
                     extra={
                         "event": "STRATEGY_NO_TRIGGER_VOTE",
                         "symbol": symbol_norm,
-                        "context_votes": [v.strategy for _, v in context_votes],
+                        "context_vote_count": len(context_votes),
+                        "context_votes": context_vote_names,
+                        "context_sides": context_sides,
+                        "context_scores": context_scores,
+                        "context_confidences": context_confidences,
+                        "allow_context_promotion": bool(mode_profile.get("allow_context_promotion", False)),
+                        "execution_mode": mode_profile.get("mode"),
+                        "direction_bias": indicator_map.get("direction_bias"),
+                        "underlying_direction_bias": indicator_map.get("underlying_direction_bias"),
+                        "context_age_seconds": indicator_map.get("context_age_seconds"),
                     },
                 )
                 return None
@@ -3189,16 +3234,82 @@ class StrategyManager(_BaseStrategyManager):
             return None
         if not bool(mode_profile.get("allow_context_promotion", True)):
             return None
-        if self._is_live_mode() and not self._env_bool("STRATEGY_CONTEXT_PROMOTION_LIVE_ALLOWED", False):
-            return None
         allowed_strategies = {s.strip() for s in str(os.getenv("STRATEGY_CONTEXT_PROMOTION_ALLOWED_STRATEGIES", "OrderFlow,VWAPPro")).split(",") if s.strip()}
         min_score = self._env_float("STRATEGY_CONTEXT_PROMOTION_MIN_SCORE", 5.0)
         min_conf = self._env_float("STRATEGY_CONTEXT_PROMOTION_MIN_CONFIDENCE", 0.45)
         best_signal, best_vote = max(context_votes, key=lambda pair: self._extract_raw_score(pair[1]))
-        selected_ok, selected_meta = self._is_selected_or_near_atm(symbol, dict(best_signal.metadata or {}), indicators)
+        raw_score = self._extract_raw_score(best_vote)
+        md0 = dict(best_signal.metadata or {})
+        selected_ok, selected_meta = self._is_selected_or_near_atm(symbol, md0, indicators)
+        if self._is_live_mode():
+            if not self._env_bool("STRATEGY_CONTEXT_PROMOTION_LIVE_ALLOWED", False):
+                return None
+            live_min_score = self._env_float("STRATEGY_CONTEXT_PROMOTION_LIVE_MIN_SCORE", 8.5)
+            live_min_conf = self._env_float("STRATEGY_CONTEXT_PROMOTION_LIVE_MIN_CONFIDENCE", 0.75)
+            max_spread = self._env_float("STRATEGY_MAX_SPREAD_PCT", 12.0)
+            max_context_age = self._env_float("STRATEGY_CONTEXT_MAX_AGE_SECONDS", 120.0)
+            try:
+                spread_pct = float(md0.get("spread_pct") or indicators.get("spread_pct") or 999.0)
+            except (TypeError, ValueError):
+                spread_pct = 999.0
+            try:
+                context_age = float(md0.get("context_age_seconds") or indicators.get("context_age_seconds") or 999.0)
+            except (TypeError, ValueError):
+                context_age = 999.0
+            quote_depth_valid = bool(
+                md0.get("quote_depth_valid")
+                or indicators.get("quote_depth_valid")
+                or ((md0.get("bid") or indicators.get("bid")) and (md0.get("ask") or indicators.get("ask")))
+            )
+            live_reject_reason = None
+            if raw_score < live_min_score:
+                live_reject_reason = "live_context_score_below_min"
+            elif float(best_vote.confidence) < live_min_conf:
+                live_reject_reason = "live_context_confidence_below_min"
+            elif best_vote.side not in {"CE", "PE"}:
+                live_reject_reason = "live_context_invalid_side"
+            elif not selected_ok:
+                live_reject_reason = "live_context_not_selected_or_near_atm"
+            elif not quote_depth_valid:
+                live_reject_reason = "live_context_quote_depth_missing"
+            elif spread_pct > max_spread:
+                live_reject_reason = "live_context_spread_too_wide"
+            elif context_age > max_context_age:
+                live_reject_reason = "live_context_stale"
+            if live_reject_reason:
+                log.info(
+                    "CONTEXT_PROMOTION_REJECTED_LIVE symbol=%s strategy=%s reason=%s "
+                    "raw_score=%.2f confidence=%.2f selected_ok=%s quote_depth_valid=%s "
+                    "spread_pct=%.2f context_age_seconds=%.2f",
+                    symbol,
+                    best_vote.strategy,
+                    live_reject_reason,
+                    raw_score,
+                    best_vote.confidence,
+                    selected_ok,
+                    quote_depth_valid,
+                    spread_pct,
+                    context_age,
+                    extra={
+                        "event": "CONTEXT_PROMOTION_REJECTED_LIVE",
+                        "symbol": symbol,
+                        "strategy": best_vote.strategy,
+                        "reason": live_reject_reason,
+                        "raw_score": raw_score,
+                        "min_score": live_min_score,
+                        "confidence": best_vote.confidence,
+                        "min_confidence": live_min_conf,
+                        "selected_ok": selected_ok,
+                        "quote_depth_valid": quote_depth_valid,
+                        "spread_pct": spread_pct,
+                        "max_spread": max_spread,
+                        "context_age_seconds": context_age,
+                        "max_context_age": max_context_age,
+                    },
+                )
+                return None
         opposite = [v for _, v in context_votes if v.side in {"CE", "PE"} and v.side != best_vote.side]
         vetoed = bool(opposite and max(self._extract_context_veto_score(v) for v in opposite) >= 8.0)
-        raw_score = self._extract_raw_score(best_vote)
         if best_vote.strategy not in allowed_strategies or raw_score < min_score or best_vote.confidence < min_conf or best_vote.side not in {"CE", "PE"} or not selected_ok or vetoed:
             return None
         md = dict(best_signal.metadata or {})

--- a/src/nifty_scalper_bot/strategies/elite_strategies/smc_liquidity.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/smc_liquidity.py
@@ -39,6 +39,15 @@ class SMCStrategy(EliteStrategy):
             atr = max(float(indicators.get('atr') or 0.0), current_price * 0.01, 1.0)
             direction = str(indicators.get('direction_bias') or '').upper()
             stale_data = bool(indicators.get('stale_data_used')) or float(indicators.get('data_age_seconds') or 0.0) > 120.0
+            try:
+                context_age_seconds = float(indicators.get("context_age_seconds") or 999.0)
+            except (TypeError, ValueError):
+                context_age_seconds = 999.0
+            underlying_direction = str(
+                indicators.get("underlying_direction_bias")
+                or indicators.get("direction_bias")
+                or ""
+            ).upper()
 
             if stale_data or current_price <= 0:
                 self._no_vote('no_liquidity_sweep')
@@ -62,7 +71,37 @@ class SMCStrategy(EliteStrategy):
                 structure_flip = bool(indicators.get('choch_confirmed') or indicators.get('bos_confirmed'))
                 if not premium_reversal and not structure_flip:
                     self._no_vote('premium_not_reversing_up')
-                    LOGGER.info("STRATEGY_NO_VOTE strategy=SMC symbol=%s reason=premium_not_reversing_up bullish_sweep=%s bearish_sweep=%s premium_reclaim=%s bullish_reversal=%s choch_confirmed=%s bos_confirmed=%s direction=%s underlying_direction=%s context_age_seconds=%.2f", symbol, bullish_sweep, bearish_sweep, bool(indicators.get('premium_reclaim')), bool(indicators.get('bullish_reversal')), bool(indicators.get('choch_confirmed')), bool(indicators.get('bos_confirmed')), direction, underlying_direction, context_age_seconds)
+                    LOGGER.info(
+                        "STRATEGY_NO_VOTE strategy=SMC symbol=%s reason=premium_not_reversing_up "
+                        "bullish_sweep=%s bearish_sweep=%s premium_reclaim=%s bullish_reversal=%s "
+                        "choch_confirmed=%s bos_confirmed=%s direction=%s underlying_direction=%s "
+                        "context_age_seconds=%.2f",
+                        symbol,
+                        bullish_sweep,
+                        bearish_sweep,
+                        bool(indicators.get("premium_reclaim")),
+                        bool(indicators.get("bullish_reversal")),
+                        bool(indicators.get("choch_confirmed")),
+                        bool(indicators.get("bos_confirmed")),
+                        direction,
+                        underlying_direction,
+                        context_age_seconds,
+                        extra={
+                            "event": "STRATEGY_NO_VOTE",
+                            "strategy": "SMC",
+                            "symbol": symbol,
+                            "reason": "premium_not_reversing_up",
+                            "bullish_sweep": bullish_sweep,
+                            "bearish_sweep": bearish_sweep,
+                            "premium_reclaim": bool(indicators.get("premium_reclaim")),
+                            "bullish_reversal": bool(indicators.get("bullish_reversal")),
+                            "choch_confirmed": bool(indicators.get("choch_confirmed")),
+                            "bos_confirmed": bool(indicators.get("bos_confirmed")),
+                            "direction": direction,
+                            "underlying_direction": underlying_direction,
+                            "context_age_seconds": context_age_seconds,
+                        },
+                    )
                     return None
                 side = contract_side
             else:
@@ -106,7 +145,37 @@ class SMCStrategy(EliteStrategy):
             require_structure_live = str(os.getenv('SMC_REQUIRE_STRUCTURE_CONFIRMATION_LIVE', 'true')).lower() in {'1', 'true', 'yes', 'on'}
             if is_live and require_structure_live and not structure_confirmed:
                 self._no_vote('smc_structure_required_live')
-                LOGGER.info("STRATEGY_NO_VOTE strategy=SMC symbol=%s reason=smc_structure_required_live choch_confirmed=%s bos_confirmed=%s retest_confirmed=%s displacement_score=%.3f premium_reclaim=%s direction_aligned=%s", symbol, choch_confirmed, bos_confirmed, retest_confirmed, displacement_score, premium_reclaim, direction_aligned)
+                LOGGER.info(
+                    "STRATEGY_NO_VOTE strategy=SMC symbol=%s reason=smc_structure_required_live "
+                    "choch_confirmed=%s bos_confirmed=%s retest_confirmed=%s displacement_score=%.3f "
+                    "premium_reclaim=%s direction_aligned=%s direction=%s underlying_direction=%s "
+                    "context_age_seconds=%.2f",
+                    symbol,
+                    choch_confirmed,
+                    bos_confirmed,
+                    retest_confirmed,
+                    displacement_score,
+                    premium_reclaim,
+                    direction_aligned,
+                    direction,
+                    underlying_direction,
+                    context_age_seconds,
+                    extra={
+                        "event": "STRATEGY_NO_VOTE",
+                        "strategy": "SMC",
+                        "symbol": symbol,
+                        "reason": "smc_structure_required_live",
+                        "choch_confirmed": choch_confirmed,
+                        "bos_confirmed": bos_confirmed,
+                        "retest_confirmed": retest_confirmed,
+                        "displacement_score": displacement_score,
+                        "premium_reclaim": premium_reclaim,
+                        "direction_aligned": direction_aligned,
+                        "direction": direction,
+                        "underlying_direction": underlying_direction,
+                        "context_age_seconds": context_age_seconds,
+                    },
+                )
                 return None
             if not (bullish_sweep or bearish_sweep or premium_reclaim) or not (displacement_score >= 0.6 or structure_confirmed) or not (direction_aligned or premium_reclaim):
                 self._no_vote('smc_quality_gate_failed')
@@ -124,6 +193,8 @@ class SMCStrategy(EliteStrategy):
                 'trade_side': side,
                 'side': side,
                 'direction_bias': side,
+                "underlying_direction_bias": underlying_direction if underlying_direction in {"CE", "PE"} else None,
+                "context_age_seconds": context_age_seconds,
                 'source_domain': 'option_premium' if option_premium_domain else 'underlying_price',
                 'preliminary_only': True,
                 'requires_runner_final_score': True,
@@ -164,7 +235,13 @@ class SMCStrategy(EliteStrategy):
                 metadata=metadata,
             )
         except Exception as e:
-            LOGGER.error('Failure in SMCStrategy._evaluate_signal: %s', e, exc_info=e)
+            LOGGER.error(
+                "Failure in SMCStrategy._evaluate_signal symbol=%s last_no_vote_reason=%s error=%s",
+                symbol,
+                getattr(self, "last_no_vote_reason", None),
+                e,
+                exc_info=e,
+            )
             return None
 
 

--- a/src/nifty_scalper_bot/strategies/elite_strategies/smc_liquidity.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/smc_liquidity.py
@@ -37,7 +37,11 @@ class SMCStrategy(EliteStrategy):
             close = float(indicators.get('close') or current_price)
             open_price = float(indicators.get('open') or current_price)
             atr = max(float(indicators.get('atr') or 0.0), current_price * 0.01, 1.0)
-            direction = str(indicators.get('direction_bias') or '').upper()
+            direction = str(
+                indicators.get("direction_bias")
+                or indicators.get("underlying_direction_bias")
+                or ""
+            ).upper()
             stale_data = bool(indicators.get('stale_data_used')) or float(indicators.get('data_age_seconds') or 0.0) > 120.0
             try:
                 context_age_seconds = float(indicators.get("context_age_seconds") or 999.0)

--- a/src/nifty_scalper_bot/strategies/elite_strategies/vwap_pro.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/vwap_pro.py
@@ -180,11 +180,16 @@ class VWAPProStrategy(EliteStrategy):
             except (TypeError, ValueError):
                 context_age_seconds = 999.0
             try:
-                underlying_direction_confidence = float(indicators.get("underlying_direction_confidence") or 0.0)
+                underlying_direction_confidence = float(
+                    indicators.get("underlying_direction_confidence")
+                    or spot_ctx.get("underlying_direction_confidence")
+                    or fut_ctx.get("underlying_direction_confidence")
+                    or 0.0
+                )
             except (TypeError, ValueError):
                 underlying_direction_confidence = 0.0
             context_fresh = context_age_seconds <= float(os.getenv('VWAP_CONTEXT_MAX_AGE_SECONDS', '120') or '120')
-            context_strong = float(indicators.get('underlying_direction_confidence') or 0.0) >= float(os.getenv('VWAP_CONTEXT_MIN_CONFIDENCE', '0.75') or '0.75')
+            context_strong = underlying_direction_confidence >= float(os.getenv('VWAP_CONTEXT_MIN_CONFIDENCE', '0.75') or '0.75')
             hard_conflict = bool(((is_live and require_alignment_live) or ((not is_live) and require_alignment_shadow)) and not trend_alignment and context_fresh and context_strong)
             if hard_conflict:
                 self._no_vote('underlying_direction_conflict')

--- a/src/nifty_scalper_bot/strategies/elite_strategies/vwap_pro.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/vwap_pro.py
@@ -45,8 +45,24 @@ class VWAPProStrategy(EliteStrategy):
             vol = float(indicators.get('volume') or 0.0)
             avg_vol = float(indicators.get('avg_volume') or 0.0)
             spread_pct = float(indicators.get('spread_pct') or 0.0)
-            direction = str(indicators.get('direction_bias') or '').upper()
-            underlying_direction = str(indicators.get('underlying_direction_bias') or '').upper()
+            spot_ctx = indicators.get("spot_context") if isinstance(indicators.get("spot_context"), dict) else {}
+            fut_ctx = indicators.get("futures_context") if isinstance(indicators.get("futures_context"), dict) else {}
+            direction = str(
+                indicators.get("direction_bias")
+                or indicators.get("underlying_direction_bias")
+                or spot_ctx.get("direction_bias")
+                or fut_ctx.get("direction_bias")
+                or ""
+            ).upper()
+            underlying_direction = str(
+                indicators.get("underlying_direction_bias")
+                or indicators.get("direction_bias")
+                or spot_ctx.get("underlying_direction_bias")
+                or spot_ctx.get("direction_bias")
+                or fut_ctx.get("underlying_direction_bias")
+                or fut_ctx.get("direction_bias")
+                or ""
+            ).upper()
             futures_vwap_slope = float(indicators.get('futures_vwap_slope') or 0.0)
             futures_volume_ratio = float(indicators.get('futures_volume_ratio') or 0.0)
             if current_price <= 0 or vwap <= 0:
@@ -178,19 +194,62 @@ class VWAPProStrategy(EliteStrategy):
             if score < min_score:
                 self._no_vote('weak_score')
                 LOGGER.info(
-                    'STRATEGY_NO_VOTE strategy=VWAPPro reason=weak_score score=%.2f direction=%s contract_side=%s current_price=%.2f vwap=%.2f distance_pct=%.4f atr=%.2f volume=%.2f avg_volume=%.2f trend_alignment=%s pullback_flag=%s',
+                    "STRATEGY_NO_VOTE strategy=VWAPPro reason=weak_score "
+                    "symbol=%s score=%.2f min_score=%.2f threshold_source=%s "
+                    "direction=%s underlying_direction=%s contract_side=%s current_price=%.2f "
+                    "vwap=%.2f distance_pct=%.4f allowed_distance=%.4f atr=%.2f "
+                    "volume=%.2f avg_volume=%.2f trend_alignment=%s pullback_flag=%s "
+                    "context_age_seconds=%.2f context_fresh=%s context_confidence=%.2f "
+                    "futures_vwap_slope=%.4f futures_volume_ratio=%.2f slope_support=%s "
+                    "premium_above_vwap=%s continuation_confirmed=%s reasons=%s",
+                    symbol,
                     score,
+                    min_score,
+                    threshold_source,
                     direction,
+                    underlying_direction,
                     contract_side,
                     current_price,
                     vwap,
                     distance_pct,
+                    allowed_distance,
                     atr_safe,
                     vol,
                     avg_vol,
                     trend_alignment,
                     pullback_flag,
-                    extra={'score_reasons': reasons},
+                    context_age_seconds,
+                    context_fresh,
+                    underlying_direction_confidence,
+                    futures_vwap_slope,
+                    futures_volume_ratio,
+                    slope_support,
+                    premium_above_vwap,
+                    continuation_confirmed,
+                    reasons,
+                    extra={
+                        "event": "STRATEGY_NO_VOTE",
+                        "strategy": "VWAPPro",
+                        "reason": "weak_score",
+                        "symbol": symbol,
+                        "score": score,
+                        "min_score": min_score,
+                        "threshold_source": threshold_source,
+                        "direction": direction,
+                        "underlying_direction": underlying_direction,
+                        "contract_side": contract_side,
+                        "score_reasons": reasons,
+                        "context_age_seconds": context_age_seconds,
+                        "context_fresh": context_fresh,
+                        "underlying_direction_confidence": underlying_direction_confidence,
+                        "futures_vwap_slope": futures_vwap_slope,
+                        "futures_volume_ratio": futures_volume_ratio,
+                        "slope_support": slope_support,
+                        "premium_above_vwap": premium_above_vwap,
+                        "continuation_confirmed": continuation_confirmed,
+                        "trend_alignment": trend_alignment,
+                        "pullback_flag": pullback_flag,
+                    },
                 )
                 return None
 
@@ -207,6 +266,11 @@ class VWAPProStrategy(EliteStrategy):
                 'contract_side': contract_side,
                 'premium_above_vwap': premium_above_vwap,
                 'direction_bias': direction if direction in {'CE', 'PE'} else None,
+                "underlying_direction_bias": underlying_direction if underlying_direction in {"CE", "PE"} else None,
+                "underlying_direction_confidence": underlying_direction_confidence,
+                "context_age_seconds": context_age_seconds,
+                "context_fresh": context_fresh,
+                "context_direction_used": direction if direction in {"CE", "PE"} else underlying_direction if underlying_direction in {"CE", "PE"} else None,
                 'preliminary_only': True,
                 'requires_runner_final_score': True,
                 'raw_setup_score': strategy_score,

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -5566,14 +5566,18 @@ class StrategyRunner:
             if context:
                 payload.update(context)
             self._logger.info(
-                "RUNNER_EVAL_DECISION symbol=%s allowed=%s stage=%s reason=%s candle_count=%s current_version=%s last_version=%s tick_age_ms=%s data_phase=%s",
+                "RUNNER_EVAL_DECISION symbol=%s allowed=%s stage=%s reason=%s "
+                "indicator_history_count=%s live_candle_version=%s "
+                "last_eval_live_candle_version=%s quote_update_version=%s "
+                "tick_age_ms=%s data_phase=%s",
                 symbol,
                 allowed,
                 stage,
                 reason,
-                candle_count,
-                current_version,
-                last_version,
+                payload.get("indicator_history_count"),
+                payload.get("live_candle_version"),
+                payload.get("last_eval_live_candle_version"),
+                payload.get("quote_update_version"),
                 tick_age_ms,
                 payload.get("data_phase"),
                 extra=payload,

--- a/tests/core/test_strategy_manager_consensus.py
+++ b/tests/core/test_strategy_manager_consensus.py
@@ -136,7 +136,7 @@ def test_live_context_promotion_rejects_without_depth_even_when_env_enabled(monk
     monkeypatch.setenv('STRATEGY_CONTEXT_PROMOTION_LIVE_ALLOWED', 'true')
     manager = _manager_stub()
     signal = _make_signal()
-    signal.metadata = {'is_selected_option': True, 'quote_depth_valid': False, 'spread_pct': 1, 'context_age_seconds': 10}
+    signal.metadata = {'is_selected_option': True, 'quote_depth_valid': True, 'spread_pct': 1, 'context_age_seconds': 10}
     vote = StrategyVote(strategy='OrderFlow', side='CE', score=9.0, confidence=0.8, reasons=[], metadata={'role': 'context'})
     caplog.set_level('INFO')
     out = manager._try_context_promotion('NFO:NIFTY25000CE', [(signal, vote)], {'context_age_seconds': 10}, manager.get_strategy_mode_profile())

--- a/tests/core/test_strategy_manager_consensus.py
+++ b/tests/core/test_strategy_manager_consensus.py
@@ -129,3 +129,40 @@ def test_live_context_only_vote_is_rejected_with_diagnostics(monkeypatch, caplog
     out = manager._combine_strategy_votes(symbol='NFO:NIFTY25000CE', signals=[(signal,vote)], indicators={'context_age_seconds':10})
     assert out is None
     assert any('no_trigger_vote' in r.message for r in caplog.records)
+
+
+def test_live_context_promotion_rejects_without_depth_even_when_env_enabled(monkeypatch, caplog) -> None:
+    monkeypatch.setenv('EXECUTION_MODE', 'LIVE')
+    monkeypatch.setenv('STRATEGY_CONTEXT_PROMOTION_LIVE_ALLOWED', 'true')
+    manager = _manager_stub()
+    signal = _make_signal()
+    signal.metadata = {'is_selected_option': True, 'quote_depth_valid': False, 'spread_pct': 1, 'context_age_seconds': 10}
+    vote = StrategyVote(strategy='OrderFlow', side='CE', score=9.0, confidence=0.8, reasons=[], metadata={'role': 'context'})
+    caplog.set_level('INFO')
+    out = manager._try_context_promotion('NFO:NIFTY25000CE', [(signal, vote)], {'context_age_seconds': 10}, manager.get_strategy_mode_profile())
+    assert out is None
+    assert any('CONTEXT_PROMOTION_REJECTED_LIVE' in r.message and 'live_context_quote_depth_missing' in r.message for r in caplog.records)
+
+
+def test_live_context_promotion_passes_only_with_strict_quality(monkeypatch) -> None:
+    monkeypatch.setenv('EXECUTION_MODE', 'LIVE')
+    monkeypatch.setenv('STRATEGY_CONTEXT_PROMOTION_LIVE_ALLOWED', 'true')
+    monkeypatch.setenv('STRATEGY_CONTEXT_PROMOTION_LIVE_MIN_SCORE', '8.5')
+    monkeypatch.setenv('STRATEGY_CONTEXT_PROMOTION_LIVE_MIN_CONFIDENCE', '0.75')
+    manager = _manager_stub()
+    signal = _make_signal()
+    signal.metadata = {
+        'role': 'context',
+        'strategy': 'OrderFlow',
+        'side': 'CE',
+        'strategy_score': 9,
+        'quote_depth_valid': True,
+        'bid': 100,
+        'ask': 101,
+        'spread_pct': 1,
+        'context_age_seconds': 10,
+        'is_selected_option': True,
+    }
+    vote = StrategyVote(strategy='OrderFlow', side='CE', score=9.0, confidence=0.8, reasons=[], metadata={'role': 'context'})
+    out = manager._try_context_promotion('NFO:NIFTY25000CE', [(signal, vote)], {'context_age_seconds': 10}, manager.get_strategy_mode_profile())
+    assert out is not None

--- a/tests/strategies/test_elite_no_vote_reasons.py
+++ b/tests/strategies/test_elite_no_vote_reasons.py
@@ -104,3 +104,30 @@ def test_smc_premium_not_reversing_up_does_not_raise_name_error(monkeypatch, cap
     assert signal is None
     assert strategy.last_no_vote_reason in {'premium_not_reversing_up', 'smc_structure_required_live', 'smc_quality_gate_failed'}
     assert any('STRATEGY_NO_VOTE strategy=SMC' in rec.message for rec in caplog.records)
+
+
+def test_smc_uses_underlying_direction_when_direction_bias_missing(monkeypatch) -> None:
+    monkeypatch.setenv('EXECUTION_MODE', 'LIVE')
+    monkeypatch.setenv('SMC_REQUIRE_STRUCTURE_CONFIRMATION_LIVE', 'false')
+    strategy = SMCStrategy(SMCStrategyConfig())
+    signal = strategy.generate_signal(
+        symbol='NFO:NIFTY26MAY23750CE',
+        indicators={
+            'high': 102,
+            'low': 98,
+            'open': 99,
+            'close': 101,
+            'atr': 2,
+            'underlying_direction_bias': 'CE',
+            'context_age_seconds': 10,
+            'liquidity_sweep_confirmed': True,
+            'premium_reclaim': True,
+            'choch_confirmed': True,
+            'bos_confirmed': True,
+            'data_age_seconds': 1,
+        },
+        current_price=100,
+        position=None,
+    )
+    assert signal is not None
+    assert signal.metadata['underlying_direction_bias'] == 'CE'

--- a/tests/strategies/test_elite_no_vote_reasons.py
+++ b/tests/strategies/test_elite_no_vote_reasons.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 from nifty_scalper_bot.strategies.elite_strategies.bb_squeeze import BBSqueezeStrategy
@@ -71,3 +72,35 @@ def test_smc_live_structure_reject_logs_specific_reason(monkeypatch) -> None:
     signal = strategy.generate_signal('NFO:NIFTY26MAY24350CE', {'high':10,'low':9,'close':9.5,'open':9.7,'atr':1,'liquidity_sweep_confirmed':True,'premium_reclaim':False,'bos_confirmed':False,'choch_confirmed':False,'retest_confirmed':False}, 9.5, None)
     assert signal is None
     assert getattr(strategy, 'last_no_vote_reason', None) == 'smc_structure_required_live'
+
+
+def test_smc_premium_not_reversing_up_does_not_raise_name_error(monkeypatch, caplog) -> None:
+    monkeypatch.setenv('EXECUTION_MODE', 'LIVE')
+    monkeypatch.setenv('SMC_REQUIRE_STRUCTURE_CONFIRMATION_LIVE', 'true')
+    strategy = SMCStrategy(SMCStrategyConfig())
+    caplog.set_level(logging.INFO)
+    signal = strategy.generate_signal(
+        symbol='NFO:NIFTY26MAY23750CE',
+        indicators={
+            'high': 102,
+            'low': 98,
+            'open': 101,
+            'close': 99,
+            'atr': 2,
+            'direction_bias': 'CE',
+            'underlying_direction_bias': 'CE',
+            'context_age_seconds': 10,
+            'liquidity_sweep_confirmed': False,
+            'liquidity_sweep_confirmed_bear': True,
+            'premium_reclaim': False,
+            'bullish_reversal': False,
+            'choch_confirmed': False,
+            'bos_confirmed': False,
+            'data_age_seconds': 1,
+        },
+        current_price=100,
+        position=None,
+    )
+    assert signal is None
+    assert strategy.last_no_vote_reason in {'premium_not_reversing_up', 'smc_structure_required_live', 'smc_quality_gate_failed'}
+    assert any('STRATEGY_NO_VOTE strategy=SMC' in rec.message for rec in caplog.records)

--- a/tests/strategies/test_runner_same_bar_skip_diagnostics.py
+++ b/tests/strategies/test_runner_same_bar_skip_diagnostics.py
@@ -34,7 +34,7 @@ def test_same_bar_skip_diagnostics_payload(caplog):
     assert payload['intrabar_non_selected_seconds'] == '60'
 
 
-def test_runner_eval_decision_uses_clear_version_fields(caplog):
+def test_runner_eval_decision_visible_message_uses_clear_version_names(caplog):
     runner = StrategyRunner.__new__(StrategyRunner)
     runner._logger = logging.getLogger('test_runner_versions')
     runner._symbol_state = {}
@@ -55,3 +55,7 @@ def test_runner_eval_decision_uses_clear_version_fields(caplog):
         runner._emit_runner_eval_decision(symbol='NFO:NIFTY26MAY25200CE',stage='phase9',reason='evaluation_no_signal',allowed=True)
     payload = caplog.records[-1].__dict__
     assert 'indicator_history_count' in payload and 'live_candle_version' in payload and 'last_eval_live_candle_version' in payload
+    msg = caplog.records[-1].message
+    assert 'indicator_history_count' in msg
+    assert 'live_candle_version' in msg
+    assert 'last_eval_live_candle_version' in msg

--- a/tests/strategies/test_vwap_pro_side_domain.py
+++ b/tests/strategies/test_vwap_pro_side_domain.py
@@ -71,5 +71,6 @@ def test_vwap_pro_reads_direction_from_spot_context_when_top_level_missing() -> 
     signal = strategy._evaluate_signal('NFO:NIFTY26MAY23750CE', indicators, 103)
     if signal is not None:
         assert signal.metadata['context_direction_used'] == 'CE'
+        assert signal.metadata['underlying_direction_confidence'] == 0.8
     else:
         assert getattr(strategy, 'last_no_vote_reason', None) != 'unknown_contract_side'

--- a/tests/strategies/test_vwap_pro_side_domain.py
+++ b/tests/strategies/test_vwap_pro_side_domain.py
@@ -49,3 +49,27 @@ def test_vwap_pro_uses_context_direction_when_direct_direction_missing() -> None
     indicators = {'vwap':200,'atr':4,'close':205,'open':203,'high':206,'low':202,'volume':10000,'avg_volume':9000,'spread_pct':1,'spot_context':{'direction_bias':'CE','underlying_direction_confidence':0.8},'context_age_seconds':10,'futures_vwap_slope':1,'futures_volume_ratio':1.2}
     signal = strategy._evaluate_signal('NFO:NIFTY26MAY23750CE', indicators, 205)
     assert signal is not None or getattr(strategy, 'last_no_vote_reason', '') != 'weak_score'
+
+
+def test_vwap_pro_reads_direction_from_spot_context_when_top_level_missing() -> None:
+    strategy = VWAPProStrategy(config=VWAPProStrategyConfig(), indicator_engine=_DummyEngine())
+    indicators = {
+        'vwap': 100,
+        'atr': 2,
+        'close': 103,
+        'open': 101,
+        'high': 104,
+        'low': 100,
+        'volume': 1000,
+        'avg_volume': 800,
+        'spread_pct': 1,
+        'spot_context': {'direction_bias': 'CE', 'underlying_direction_confidence': 0.8},
+        'context_age_seconds': 10,
+        'futures_vwap_slope': 1,
+        'futures_volume_ratio': 1.2,
+    }
+    signal = strategy._evaluate_signal('NFO:NIFTY26MAY23750CE', indicators, 103)
+    if signal is not None:
+        assert signal.metadata['context_direction_used'] == 'CE'
+    else:
+        assert getattr(strategy, 'last_no_vote_reason', None) != 'unknown_contract_side'


### PR DESCRIPTION
### Motivation

- Root causes: `SMCStrategy._evaluate_signal()` referenced undefined `underlying_direction`/`context_age_seconds` in a no-vote path causing a NameError that was silently swallowed.  
- `VWAPProStrategy` did not fall back to `spot_context`/`futures_context` for direction, causing blank direction in some runs.  
- VWAPPro weak-score logging and metadata omitted key context fields (threshold source, context age/freshness/confidence, slope/continuation details).  
- `StrategyManager.generate_signal()` could reference `no_vote_reason_counts` before initialization and `_try_context_promotion()` was too permissive in LIVE mode and lacked explicit rejection diagnostics.

### Description

- SMC fixes: derive `context_age_seconds` and `underlying_direction` early, replace fragile one-line no-vote logs with structured `LOGGER.info(..., extra={...})`, add `underlying_direction_bias` and `context_age_seconds` to SMC metadata, and strengthen exception logging to include `symbol` and `last_no_vote_reason` while still returning `None` safely. (file: `smc_liquidity.py`)  
- VWAPPro fixes: read direction/underlying-direction from `spot_context`/`futures_context` when top-level indicators are missing, expand the `weak_score` no-vote log to include `min_score`, `threshold_source`, context age/fresh/confidence, slope support and continuation details, and preserve context fields in metadata (`underlying_direction_bias`, confidence, `context_age_seconds`, `context_fresh`, `context_direction_used`). (file: `vwap_pro.py`)  
- StrategyManager fixes: initialize `signals`, `signal_votes`, `disabled`, `empty`, `no_vote_reason_counts`, and `errors` before any early-return branch; improve no-trigger diagnostics with context vote names/sides/scores/confidences and add throttled structured logs; implement strict LIVE-only context-promotion gates (score/confidence/side/selected/depth/spread/staleness) that emit explicit `CONTEXT_PROMOTION_REJECTED_LIVE` diagnostics while preserving the non-live generic promotion path. (file: `core/strategy_manager.py`)  
- Runner logging: update visible `RUNNER_EVAL_DECISION` message wording to use clear version field names (`indicator_history_count`, `live_candle_version`, `last_eval_live_candle_version`, `quote_update_version`) while retaining backward-compatible payload keys. (file: `strategies/runner.py`)  
- Tests: added/updated focused tests to cover the SMC no-vote NameError scenario, VWAPPro context-direction fallback, LIVE context-promotion gating and diagnostics, and the runner visible-message field names. (files under `tests/strategies` and `tests/core`)

All changes are surgical, preserve execution/risk gates, keep spot/futures context-only, and do not relax live thresholds or enable new live behavior unless explicitly turned on via environment flags.

### Testing

- Commands run: `python -m compileall src tests` and targeted pytest runs for modified areas.  
- Results: `compileall` passed (notes: pre-existing SyntaxWarning in `order_manager.py` about `return` in `finally`).  
- Targeted tests that were executed and passed: `pytest -q tests/strategies/test_elite_no_vote_reasons.py`, `pytest -q tests/strategies/test_vwap_pro_side_domain.py`, `pytest -q tests/core/test_strategy_manager_consensus.py`, `pytest -q tests/core/test_strategy_manager_context_to_option_propagation.py`, and `pytest -q tests/strategies/test_runner_same_bar_skip_diagnostics.py` (all succeeded).  
- Full test run: `pytest -q` produced one unrelated pre-existing failure in Telegram tests: `tests/notifications/test_telegram_controller.py::test_cmd_subscribe_stream_supervisor_resolves_symbols` (assertion expecting a specific resolved-message text vs an alternate message), which is outside the modified-area scope and does not indicate regression in these changes.  

If you want, I can open a follow-up PR to address the unrelated Telegram test failure, but this PR keeps changes narrow and focused on option-context diagnostics and safety.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c1d21d1bc832482d176c97de96a68)