### PR TITLE
Fix context direction derivation and quote-version propagation after PR441

### DIFF
--- a/src/nifty_scalper_bot/core/strategy_manager.py
+++ b/src/nifty_scalper_bot/core/strategy_manager.py
@@ -1934,7 +1934,22 @@ class StrategyManager(_BaseStrategyManager):
         if margin < 0.5:
             return None, min(0.55, total / 4.0), reasons + ["direction_tie"]
         side = "CE" if ce_score > pe_score else "PE"
-        confidence = min(0.95, max(0.50, 0.50 + margin / max(total, 1.0) * 0.45))
+        strong_reason_tags = {
+            "close_above_vwap",
+            "close_below_vwap",
+            "ema_fast_above_slow",
+            "ema_fast_below_slow",
+            "vwap_slope_positive",
+            "vwap_slope_negative",
+            "ema_slope_positive",
+            "ema_slope_negative",
+        }
+        has_strong_reasons = any(tag in strong_reason_tags for tag in reasons)
+        raw_confidence = 0.50 + margin / max(total, 1.0) * 0.45
+        if has_strong_reasons:
+            confidence = min(0.95, max(0.50, raw_confidence))
+        else:
+            confidence = min(0.70, max(0.55, raw_confidence))
         return side, confidence, reasons
 
     @staticmethod

--- a/src/nifty_scalper_bot/core/strategy_manager.py
+++ b/src/nifty_scalper_bot/core/strategy_manager.py
@@ -1876,6 +1876,11 @@ class StrategyManager(_BaseStrategyManager):
                 conf = 0.75
             return explicit, max(0.0, min(1.0, conf)), ["explicit_direction_bias"]
         close = _f("close") or _f("ltp") or _f("price")
+        ltp = _f("ltp") or _f("last_price") or _f("price")
+        previous_close = _f("previous_close") or _f("prev_close") or _f("previous_price")
+        day_open = _f("open") or _f("day_open") or _f("first_ltp")
+        recent_ltp_delta = _f("recent_ltp_delta") or _f("net_change") or _f("price_change_pct")
+        tick_slope = _f("tick_slope")
         vwap = _f("vwap") or _f("exchange_vwap") or _f("session_vwap")
         ema_fast = _f("ema_fast") or _f("ema_9") or _f("ema9")
         ema_slow = _f("ema_slow") or _f("ema_21") or _f("ema21")
@@ -1900,6 +1905,28 @@ class StrategyManager(_BaseStrategyManager):
         elif ema_slope < 0: pe_score += 0.5; reasons.append("ema_slope_negative")
         if role == "futures_context" and futures_volume_ratio >= 1.0:
             reasons.append("futures_volume_active")
+        if close is not None and previous_close is not None:
+            if close > previous_close:
+                ce_score += 0.8
+                reasons.append("close_above_previous_close")
+            elif close < previous_close:
+                pe_score += 0.8
+                reasons.append("close_below_previous_close")
+        if ltp is not None and day_open is not None:
+            if ltp > day_open:
+                ce_score += 0.7
+                reasons.append("ltp_above_open")
+            elif ltp < day_open:
+                pe_score += 0.7
+                reasons.append("ltp_below_open")
+        delta_signal = recent_ltp_delta if recent_ltp_delta not in (None, 0.0) else tick_slope
+        if delta_signal is not None:
+            if delta_signal > 0:
+                ce_score += 0.6
+                reasons.append("tick_slope_positive")
+            elif delta_signal < 0:
+                pe_score += 0.6
+                reasons.append("tick_slope_negative")
         total = ce_score + pe_score
         if total <= 0:
             return None, 0.0, ["direction_unavailable"]
@@ -1909,6 +1936,10 @@ class StrategyManager(_BaseStrategyManager):
         side = "CE" if ce_score > pe_score else "PE"
         confidence = min(0.95, max(0.50, 0.50 + margin / max(total, 1.0) * 0.45))
         return side, confidence, reasons
+
+    @staticmethod
+    def _context_direction_valid(ctx: t.Mapping[str, t.Any]) -> bool:
+        return str(ctx.get("direction_bias") or ctx.get("underlying_direction_bias") or "").upper() in {"CE", "PE"}
 
     def _strategy_required_indicator_union(self) -> set[str]:
         required = set(getattr(self, "_required_indicators", set()) or set())
@@ -2423,12 +2454,24 @@ class StrategyManager(_BaseStrategyManager):
                     return False
             spot_fresh = _fresh(spot_ctx)
             fut_fresh = _fresh(fut_ctx)
-            if spot_fresh:
+            spot_direction_valid = self._context_direction_valid(spot_ctx)
+            fut_direction_valid = self._context_direction_valid(fut_ctx)
+            spot_usable = spot_fresh and spot_direction_valid
+            fut_usable = fut_fresh and fut_direction_valid
+            if spot_fresh and not spot_direction_valid:
+                log_throttled(
+                    log, f"option_context_fresh_but_directionless:{symbol}",
+                    "OPTION_CONTEXT_FRESH_BUT_DIRECTIONLESS symbol=%s spot_fresh=%s spot_ctx_keys=%s",
+                    symbol, spot_fresh, sorted(list(spot_ctx.keys())),
+                    interval_sec=30.0, level=logging.INFO,
+                    extra={"event": "OPTION_CONTEXT_FRESH_BUT_DIRECTIONLESS", "symbol": symbol, "spot_fresh": spot_fresh, "spot_direction_valid": spot_direction_valid, "spot_ctx_keys": sorted(list(spot_ctx.keys()))},
+                )
+            if spot_usable:
                 indicators.setdefault("spot_context", spot_ctx)
-            if fut_fresh:
+            if fut_usable:
                 indicators.setdefault("futures_context", fut_ctx)
-            direction_bias = (indicators.get("direction_bias") or indicators.get("underlying_direction_bias") or (spot_ctx.get("direction_bias") if spot_fresh else None) or (fut_ctx.get("direction_bias") if fut_fresh else None))
-            direction_confidence = (indicators.get("underlying_direction_confidence") or (spot_ctx.get("underlying_direction_confidence") if spot_fresh else None) or (fut_ctx.get("underlying_direction_confidence") if fut_fresh else None) or 0.0)
+            direction_bias = (indicators.get("direction_bias") or indicators.get("underlying_direction_bias") or (spot_ctx.get("direction_bias") if spot_usable else None) or (fut_ctx.get("direction_bias") if fut_usable else None))
+            direction_confidence = (indicators.get("underlying_direction_confidence") or (spot_ctx.get("underlying_direction_confidence") if spot_usable else None) or (fut_ctx.get("underlying_direction_confidence") if fut_usable else None) or 0.0)
             if str(direction_bias or "").upper() in {"CE", "PE"}:
                 indicators["direction_bias"] = str(direction_bias).upper()
                 indicators["underlying_direction_bias"] = str(direction_bias).upper()
@@ -2436,15 +2479,17 @@ class StrategyManager(_BaseStrategyManager):
                     indicators["underlying_direction_confidence"] = float(direction_confidence)
                 except (TypeError, ValueError):
                     indicators["underlying_direction_confidence"] = 0.0
-                indicators["context_age_seconds"] = min(now_ts - float(spot_ctx.get("timestamp", now_ts)) if spot_fresh else max_context_age + 1, now_ts - float(fut_ctx.get("timestamp", now_ts)) if fut_fresh else max_context_age + 1)
+                indicators["context_age_seconds"] = min(now_ts - float(spot_ctx.get("timestamp", now_ts)) if spot_usable else max_context_age + 1, now_ts - float(fut_ctx.get("timestamp", now_ts)) if fut_usable else max_context_age + 1)
             else:
                 log_throttled(
                     log,
                     f"option_context_missing_direction_bias:{symbol}",
-                    "OPTION_CONTEXT_MISSING_DIRECTION_BIAS symbol=%s spot_fresh=%s fut_fresh=%s",
+                    "OPTION_CONTEXT_MISSING_DIRECTION_BIAS symbol=%s spot_fresh=%s fut_fresh=%s spot_direction_valid=%s fut_direction_valid=%s",
                     symbol,
                     spot_fresh,
                     fut_fresh,
+                    spot_direction_valid,
+                    fut_direction_valid,
                     interval_sec=30.0,
                     level=logging.INFO,
                     extra={
@@ -2452,6 +2497,12 @@ class StrategyManager(_BaseStrategyManager):
                         "symbol": symbol,
                         "spot_fresh": spot_fresh,
                         "fut_fresh": fut_fresh,
+                        "spot_direction_valid": spot_direction_valid,
+                        "fut_direction_valid": fut_direction_valid,
+                        "spot_direction_reasons": spot_ctx.get("direction_context_reasons"),
+                        "fut_direction_reasons": fut_ctx.get("direction_context_reasons"),
+                        "spot_ctx_keys": sorted(list(spot_ctx.keys())),
+                        "fut_ctx_keys": sorted(list(fut_ctx.keys())),
                     },
                 )
             if fut_fresh and fut_ctx.get("futures_volume_ratio") is not None:

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -811,6 +811,7 @@ class StrategyRunner:
         self._strategy_window_trailing_updates = 0
         self._candle_versions: dict[str, int] = defaultdict(int)
         self._last_strategy_versions: dict[str, int] = defaultdict(int)
+        self._quote_update_versions: dict[str, int] = defaultdict(int)
         self._gap_repair_inflight: set[str] = set()
         self._history_refresh_interval_seconds: float = 60.0
         self._last_history_refresh_by_symbol: dict[str, float] = {}
@@ -5497,6 +5498,29 @@ class StrategyRunner:
                 )
             ):
                 return
+            if reason == "insufficient_indicator_bar_count" and str(symbol).upper().endswith(("CE", "PE")):
+                selected_set = {
+                    normalize_symbol(str(getattr(self, "_active_selected_ce", "") or "")),
+                    normalize_symbol(str(getattr(self, "_active_selected_pe", "") or "")),
+                }
+                selected_set.discard("")
+                normalized_symbol = normalize_symbol(symbol)
+                selected_option = normalized_symbol in selected_set
+                near_atm = False
+                try:
+                    sym_strike = self._extract_strike_from_symbol(normalized_symbol)
+                    atm = float(getattr(self, "_active_atm_strike", 0) or 0)
+                    near_atm = sym_strike is not None and atm > 0 and abs(float(sym_strike) - atm) <= 100.0
+                except Exception:
+                    near_atm = False
+                warmup_only = not (selected_option or near_atm)
+                if warmup_only and not self._should_log_throttled(
+                    f"runner_eval_warmup_only:{symbol}:{stage}:{reason}", 30.0
+                ):
+                    return
+                context.setdefault("selected_option", selected_option)
+                context.setdefault("near_atm", near_atm)
+                context.setdefault("warmup_only", warmup_only)
             state_obj = self._symbol_state.get(symbol)
             state_active = bool(getattr(state_obj, "active", False)) if state_obj else False
             sym_state = self._symbol_states.get(symbol)
@@ -5813,6 +5837,13 @@ class StrategyRunner:
                 soft_pass = False
                 if history_count < required_bars:
                     if self._is_context_symbol(symbol):
+                        role = self._symbol_role_for_runner(symbol)
+                        self._logger.info(
+                            "CONTEXT_EVAL_ALLOWED_WITH_PARTIAL_BARS symbol=%s role=%s indicator_history_count=%s required=%s",
+                            symbol, role, history_count, required_bars,
+                            extra={"event": "CONTEXT_EVAL_ALLOWED_WITH_PARTIAL_BARS", "symbol": symbol, "role": role, "indicator_history_count": history_count, "required_bars": required_bars},
+                        )
+                        return True
                         if symbol == "NSE:NIFTY" and self._should_log_throttled(f"spot_cold:{symbol}", 120.0):
                             self._logger.warning("CONTEXT_SPOT_HISTORY_COLD symbol=NSE:NIFTY bars=%d required=%d", history_count, required_bars)
                         elif self._should_log_throttled(f"fut_cold:{symbol}", 120.0):
@@ -6438,6 +6469,16 @@ class StrategyRunner:
                     level=logging.WARNING,
                 )
                 return
+            has_quote_update = False
+            try:
+                has_quote_update = (
+                    _extract_float(tick, "bid", "best_bid", "best_bid_price", "buy_price") > 0
+                    and _extract_float(tick, "ask", "best_ask", "best_ask_price", "sell_price") > 0
+                ) or bool(tick.get("depth"))
+            except Exception:
+                has_quote_update = False
+            if has_quote_update:
+                self._quote_update_versions[symbol] = int(self._quote_update_versions.get(symbol, 0)) + 1
 
             # Bracket tick forwarding already happened at function entry.
             # Keep a single forward per tick so protective handlers do not churn

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -5715,6 +5715,31 @@ class StrategyRunner:
         """Compatibility alias for option-tradability checks."""
         return self._is_tradable_symbol(symbol)
 
+    @staticmethod
+    def _tick_has_quote_update(tick: Mapping[str, Any]) -> bool:
+        """Return True when tick carries depth or valid top-of-book quote."""
+        def _safe_float(value: Any) -> float:
+            try:
+                return float(value)
+            except (TypeError, ValueError):
+                return 0.0
+
+        depth_payload = tick.get("depth")
+        bid_value = _safe_float(
+            tick.get("bid")
+            or tick.get("best_bid")
+            or tick.get("best_bid_price")
+            or tick.get("buy_price")
+        )
+        ask_value = _safe_float(
+            tick.get("ask")
+            or tick.get("best_ask")
+            or tick.get("best_ask_price")
+            or tick.get("sell_price")
+        )
+        has_top_of_book = bid_value > 0.0 and ask_value > 0.0
+        return bool(depth_payload) or has_top_of_book
+
     def get_quote(self, symbol: str) -> dict[str, Any] | None:
         """Return freshest normalized quote available from DataHub/MDM."""
         normalized = normalize_symbol(symbol)
@@ -5844,10 +5869,6 @@ class StrategyRunner:
                             extra={"event": "CONTEXT_EVAL_ALLOWED_WITH_PARTIAL_BARS", "symbol": symbol, "role": role, "indicator_history_count": history_count, "required_bars": required_bars},
                         )
                         return True
-                        if symbol == "NSE:NIFTY" and self._should_log_throttled(f"spot_cold:{symbol}", 120.0):
-                            self._logger.warning("CONTEXT_SPOT_HISTORY_COLD symbol=NSE:NIFTY bars=%d required=%d", history_count, required_bars)
-                        elif self._should_log_throttled(f"fut_cold:{symbol}", 120.0):
-                            self._logger.warning("CONTEXT_FUTURES_HISTORY_COLD symbol=%s bars=%d required=%d", symbol, history_count, required_bars)
                     elif self._is_tradable_symbol(symbol):
                         if self._should_log_throttled(f"opt_cold:{symbol}", 120.0):
                             self._logger.warning("OPTION_HISTORY_COLD symbol=%s bars=%d required=%d", symbol, history_count, required_bars)
@@ -6469,14 +6490,7 @@ class StrategyRunner:
                     level=logging.WARNING,
                 )
                 return
-            has_quote_update = False
-            try:
-                has_quote_update = (
-                    _extract_float(tick, "bid", "best_bid", "best_bid_price", "buy_price") > 0
-                    and _extract_float(tick, "ask", "best_ask", "best_ask_price", "sell_price") > 0
-                ) or bool(tick.get("depth"))
-            except Exception:
-                has_quote_update = False
+            has_quote_update = self._tick_has_quote_update(tick)
             if has_quote_update:
                 self._quote_update_versions[symbol] = int(self._quote_update_versions.get(symbol, 0)) + 1
 

--- a/tests/core/test_strategy_manager_context_to_option_propagation.py
+++ b/tests/core/test_strategy_manager_context_to_option_propagation.py
@@ -52,6 +52,7 @@ def test_context_direction_fallback_from_previous_close():
     snap = m._latest_context_snapshots.get('spot_context', {})
     assert snap.get('direction_bias') == 'CE'
     assert float(snap.get('underlying_direction_confidence') or 0) >= 0.5
+    assert float(snap.get('underlying_direction_confidence') or 0) <= 0.70
 
 
 def test_option_context_fresh_but_directionless_not_used(caplog):

--- a/tests/core/test_strategy_manager_context_to_option_propagation.py
+++ b/tests/core/test_strategy_manager_context_to_option_propagation.py
@@ -43,3 +43,24 @@ def test_option_evaluation_receives_derived_spot_direction_bias():
     assert float(st.last.get('underlying_direction_confidence') or 0)>0
     assert float(st.last.get('context_age_seconds') or 999)<=120
     assert isinstance(st.last.get('spot_context'), dict)
+
+
+def test_context_direction_fallback_from_previous_close():
+    st=_S(); ie=_IE(); m=StrategyManager([st], ie, _PM())
+    ie.payload={'close':110,'previous_close':100,'volume':100,'avg_volume':100}
+    m.generate_signal('NSE:NIFTY',110)
+    snap = m._latest_context_snapshots.get('spot_context', {})
+    assert snap.get('direction_bias') == 'CE'
+    assert float(snap.get('underlying_direction_confidence') or 0) >= 0.5
+
+
+def test_option_context_fresh_but_directionless_not_used(caplog):
+    import logging
+    st=_S(); ie=_IE(); m=StrategyManager([st], ie, _PM())
+    ie.payload={'close':100,'volume':100,'avg_volume':100}
+    m.generate_signal('NSE:NIFTY',100)
+    ie.payload={'vwap':102,'volume':100,'avg_volume':100}
+    with caplog.at_level(logging.INFO):
+        m.generate_signal('NFO:NIFTY26MAY23750CE',102)
+    assert any("OPTION_CONTEXT_FRESH_BUT_DIRECTIONLESS" in rec.message for rec in caplog.records)
+    assert st.last.get('direction_bias') in (None, '')

--- a/tests/strategies/test_runner_same_bar_skip_diagnostics.py
+++ b/tests/strategies/test_runner_same_bar_skip_diagnostics.py
@@ -59,3 +59,44 @@ def test_runner_eval_decision_visible_message_uses_clear_version_names(caplog):
     assert 'indicator_history_count' in msg
     assert 'live_candle_version' in msg
     assert 'last_eval_live_candle_version' in msg
+
+
+def test_context_symbols_bypass_min_bars_for_snapshot_update():
+    runner = StrategyRunner.__new__(StrategyRunner)
+    runner._active_symbols = {'NSE:NIFTY'}
+    runner._required_bars_for_symbol = lambda _s: 50
+    runner._context_required_bars = 50
+    runner._option_required_bars = 5
+    runner._indicator_engine = type('E', (), {'get_history': lambda *_: [1, 2], 'has_min_bars': lambda *_: False})()
+    runner._is_context_symbol = lambda _s: True
+    runner._is_tradable_symbol = lambda _s: False
+    runner._symbol_role_for_runner = lambda _s: 'spot_context'
+    runner._logger = logging.getLogger('test_runner_context_bypass')
+    runner._emit_runner_eval_decision = lambda **_: None
+    assert runner._strategy_evaluation_allowed('NSE:NIFTY')
+
+
+def test_quote_update_version_increments_on_full_quote(caplog):
+    runner = StrategyRunner.__new__(StrategyRunner)
+    runner._logger = logging.getLogger('test_runner_quote_version')
+    runner._active_symbols = {'NFO:NIFTY26MAY25200CE'}
+    runner._data_phase = {'NFO:NIFTY26MAY25200CE': 'LIVE'}
+    runner._required_bars_for_symbol = lambda _s: 1
+    runner._symbol_state = {}
+    runner._symbol_states = {}
+    runner._candle_versions = {'NFO:NIFTY26MAY25200CE': 1}
+    runner._last_strategy_versions = {'NFO:NIFTY26MAY25200CE': 0}
+    runner._quote_update_versions = {}
+    runner._last_bar_ts = {}
+    runner._market_data = type('M', (), {'_last_tick_time': {}, 'get_ohlc_bars': lambda *_: []})()
+    runner._live_bar_seen = set()
+    runner._hydration_attempted_symbols = set()
+    runner._last_hydration_reason_by_symbol = {}
+    runner._indicator_engine = type('E', (), {'get_history': lambda *_: [1]})()
+    runner._should_log_throttled = lambda *_: True
+    with caplog.at_level(logging.INFO):
+        runner._quote_update_versions['NFO:NIFTY26MAY25200CE'] = runner._quote_update_versions.get('NFO:NIFTY26MAY25200CE', 0) + 1
+        runner._emit_runner_eval_decision(symbol='NFO:NIFTY26MAY25200CE',stage='phase9',reason='evaluation_no_signal',allowed=True)
+    payload = caplog.records[-1].__dict__
+    assert isinstance(payload['quote_update_version'], int)
+    assert payload['quote_update_version'] >= 1

--- a/tests/strategies/test_runner_same_bar_skip_diagnostics.py
+++ b/tests/strategies/test_runner_same_bar_skip_diagnostics.py
@@ -100,3 +100,8 @@ def test_quote_update_version_increments_on_full_quote(caplog):
     payload = caplog.records[-1].__dict__
     assert isinstance(payload['quote_update_version'], int)
     assert payload['quote_update_version'] >= 1
+
+
+def test_tick_has_quote_update_depth_without_bid_ask():
+    tick = {"depth": {"buy": [{"price": 100.0, "quantity": 10}], "sell": [{"price": 100.5, "quantity": 8}]}}
+    assert StrategyRunner._tick_has_quote_update(tick) is True


### PR DESCRIPTION
### Motivation
- Railway logs showed option evaluations receiving fresh but directionless spot snapshots and `VWAPPro` weak scores because direction fields were empty, and runner diagnostics reported `quote_update_version=None` while full quotes/depth were received.
- Context snapshots were also not being refreshed when context symbols had only partial warmup bars, preventing StrategyManager from updating derived context.
- The intent is to make context direction derivation and runner diagnostics robust without weakening execution/risk gates.

### Description
- Strengthened context usability in `StrategyManager` (`src/nifty_scalper_bot/core/strategy_manager.py`) by adding `_context_direction_valid` and using `spot_usable` / `fut_usable` (fresh + valid direction) so fresh-but-directionless snapshots are not injected; added `OPTION_CONTEXT_FRESH_BUT_DIRECTIONLESS` logging and enriched `OPTION_CONTEXT_MISSING_DIRECTION_BIAS` diagnostics (freshness, validity, reasons, snapshot keys).
- Extended `_derive_context_direction()` in `StrategyManager` to add fallback inputs and rules (`previous_close`, `open/day_open`, `recent_ltp_delta` / `tick_slope`, `ltp`), bounded confidence floors, and explicit `direction_context_reasons` tags (e.g. `close_above_previous_close`, `ltp_above_open`, `tick_slope_positive`).
- Allowed context-only symbols to update snapshots even when indicator history is below required bars by permitting `spot_context`/`futures_context` to pass phase9 min-bar gate for snapshot refresh (log `CONTEXT_EVAL_ALLOWED_WITH_PARTIAL_BARS`) while preserving normal option gating.
- Added quote/depth version tracking in `StrategyRunner` (`src/nifty_scalper_bot/strategies/runner.py`) by initializing `_quote_update_versions` and incrementing it when a full quote/depth update is observed so `RUNNER_EVAL_DECISION` contains an integer `quote_update_version`.
- Reduced noisy repeated evaluation logs for standby/outer-basket options by marking `selected_option`, `near_atm`, and `warmup_only` in `RUNNER_EVAL_DECISION` and throttling warmup-only messages.
- Tests added/updated:
  - `tests/core/test_strategy_manager_context_to_option_propagation.py`: added `test_context_direction_fallback_from_previous_close` and `test_option_context_fresh_but_directionless_not_used`.
  - `tests/strategies/test_runner_same_bar_skip_diagnostics.py`: added `test_context_symbols_bypass_min_bars_for_snapshot_update` and `test_quote_update_version_increments_on_full_quote`.

### Testing
- Commands run: `python -m compileall -q src tests` and focused `pytest -q` targets:
  - `pytest -q tests/test_log_throttled_no_args_keyword.py`
  - `pytest -q tests/core/test_strategy_manager_context_to_option_propagation.py`
  - `pytest -q tests/strategies/test_runner_same_bar_skip_diagnostics.py`
  - `pytest -q tests/strategies/test_vwap_pro_side_domain.py`
  - `pytest -q tests/strategies/test_elite_no_vote_reasons.py`
- Results: compile succeeded (existing unrelated `SyntaxWarning` in `order_manager.py` remained); all listed pytest targets passed.
- No execution or risk gate logic was bypassed or weakened during these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c33fac9788324a5d3c439716b6fbf)