### PR TITLE
Harden runner first-eval and execution reconciliation paths

### DIFF
--- a/src/nifty_scalper_bot/core/strategy_manager.py
+++ b/src/nifty_scalper_bot/core/strategy_manager.py
@@ -2161,11 +2161,15 @@ class StrategyManager(_BaseStrategyManager):
         regime_snapshot: RegimeSnapshot | None = None
         adjustments: dict[str, t.Any] = {}
         regime_scale = 1.0
+        regime_allowed: bool | None = None
+        regime_reasons: tuple[str, ...] = ()
         if regime_manager is not None:
             gate_context = {"component": "strategy_manager", "symbol": symbol}
             try:
                 allowed = regime_manager.can_trade(context=gate_context)
                 reasons = tuple(regime_manager.get_filter_reasons())
+                regime_allowed = bool(allowed)
+                regime_reasons = tuple(reasons)
                 regime_snapshot = regime_manager.get_latest_snapshot()
                 self._log_regime_gate_decision(
                     symbol=symbol,
@@ -2232,12 +2236,7 @@ class StrategyManager(_BaseStrategyManager):
         if regime_manager is not None:
             try:
                 if (
-                    not regime_manager.can_trade(
-                        context={
-                            "component": "strategy_manager_fallback",
-                            "symbol": symbol,
-                        }
-                    )
+                    regime_allowed is False
                     and self._use_regime_adaptive
                 ):
                     regime_scale = min(

--- a/src/nifty_scalper_bot/execution/bracket_manager.py
+++ b/src/nifty_scalper_bot/execution/bracket_manager.py
@@ -389,6 +389,30 @@ class BracketManager:
                             return True, float(avg_price) if avg_price else None
                         except (TypeError, ValueError):
                             return True, None
+        get_orders = getattr(broker, "get_orders", None)
+        if not callable(get_orders):
+            get_orders = getattr(broker, "orders", None)
+        if callable(get_orders):
+            try:
+                orders = get_orders() or []
+            except Exception:
+                orders = []
+            for order in orders:
+                if not isinstance(order, Mapping):
+                    continue
+                if str(order.get("order_id") or "") != str(order_id):
+                    continue
+                status_text = str(order.get("status") or "").upper()
+                if status_text in _FILLED_STATUSES:
+                    avg_price = (
+                        order.get("average_price")
+                        or order.get("avg_price")
+                        or order.get("price")
+                    )
+                    try:
+                        return True, float(avg_price) if avg_price else None
+                    except (TypeError, ValueError):
+                        return True, None
         return False, None
 
     def _reconcile_pending_entry(self, bracket: BracketState) -> None:

--- a/src/nifty_scalper_bot/execution/bracket_manager.py
+++ b/src/nifty_scalper_bot/execution/bracket_manager.py
@@ -278,6 +278,10 @@ class BracketManager:
         
         # Configuration
         self._auto_reduce_sl = True
+        self._pending_entry_reconcile_after_sec = max(
+            1.0,
+            float(os.getenv("BRACKET_PENDING_ENTRY_RECONCILE_AFTER_SEC", "5") or "5"),
+        )
         self._stale_cleanup_age = 86400  # 24 hours
         # Cache tiered-trailing thresholds once at startup — avoids os.getenv()
         # on every tick (100-300 ticks/sec × N active brackets = hot path).
@@ -312,8 +316,10 @@ class BracketManager:
         while self._running:
             try:
                 pending: list[tuple[BracketState, dict[str, Any]]] = []
+                reconcile_candidates: list[BracketState] = []
                 with self._lock:
                     for bracket in self._brackets.values():
+                        reconcile_candidates.append(bracket)
                         ltp = float(bracket.last_ltp or 0.0)
                         if (
                             not bracket.active
@@ -348,6 +354,8 @@ class BracketManager:
                                 'qty': bracket.remaining_quantity,
                                 'reason': 'WATCHDOG_HARD_SL',
                             }))
+                for bracket in reconcile_candidates:
+                    self._reconcile_pending_entry(bracket)
                 if pending:
                     self._log_throttled(
                         'critical',
@@ -361,6 +369,37 @@ class BracketManager:
             except Exception as e:
                 LOGGER.error('Failure in _watchdog_exit_loop: %s', e)
                 time.sleep(0.25)
+
+    def _broker_order_filled(self, order_id: str) -> tuple[bool, float | None]:
+        broker = getattr(self.order_manager, "_broker", None)
+        if broker is None:
+            return False, None
+        for attr in ("get_order_status", "order_status"):
+            fn = getattr(broker, attr, None)
+            if callable(fn):
+                try:
+                    status = fn(order_id)
+                except Exception:
+                    continue
+                if isinstance(status, Mapping):
+                    status_text = str(status.get("status") or "").upper()
+                    if status_text in _FILLED_STATUSES:
+                        avg_price = status.get("average_price") or status.get("avg_price") or status.get("price")
+                        try:
+                            return True, float(avg_price) if avg_price else None
+                        except (TypeError, ValueError):
+                            return True, None
+        return False, None
+
+    def _reconcile_pending_entry(self, bracket: BracketState) -> None:
+        if bracket.entry_confirmed or bracket.monitoring_only:
+            return
+        age = time.time() - float(bracket.created_at or 0.0)
+        if age < self._pending_entry_reconcile_after_sec:
+            return
+        filled, fill_price = self._broker_order_filled(bracket.entry_order_id)
+        if filled:
+            self.confirm_entry_fill(bracket.entry_order_id, fill_price or bracket.entry_price)
 
     def _log_throttled(
         self,

--- a/src/nifty_scalper_bot/execution/execution_policy.py
+++ b/src/nifty_scalper_bot/execution/execution_policy.py
@@ -16,6 +16,7 @@ and to enforce the overall timeout budget.
 from __future__ import annotations
 
 from dataclasses import dataclass
+import os
 from typing import Any, Callable, Literal, Mapping, Sequence
 
 from nifty_scalper_bot.data.data_hub import DataHub
@@ -118,9 +119,10 @@ class ExecutionPolicy:
         spread_pct = 0.0
         if mid > 0:
             spread_pct = spread / mid
-        if self.max_spread_pct and spread_pct > self.max_spread_pct:
+        effective_max_spread_pct = self._effective_max_spread_pct(normalized, last_price, mid)
+        if effective_max_spread_pct and spread_pct > effective_max_spread_pct:
             raise OrderPlacementError(
-                f"Spread too wide ({spread_pct:.3f} > {self.max_spread_pct:.3f})"
+                f"Spread too wide ({spread_pct:.3f} > {effective_max_spread_pct:.3f})"
             )
 
         if spread <= 0:
@@ -131,6 +133,27 @@ class ExecutionPolicy:
         return ExecutionPlan(
             limit_prices=tuple(prices), spread_pct=spread_pct, step_timeout=step_timeout
         )
+
+    def _effective_max_spread_pct(self, symbol: str, last_price: float, mid: float) -> float:
+        base = float(self.max_spread_pct or 0.0)
+        upper = symbol.upper()
+        is_option = upper.endswith("CE") or upper.endswith("PE")
+        if not is_option:
+            return base
+        try:
+            atm_limit = float(os.getenv("OPTION_EXEC_MAX_SPREAD_ATM_PCT", "0.03") or "0.03")
+            low_premium_limit = float(os.getenv("OPTION_EXEC_MAX_SPREAD_LOW_PREMIUM_PCT", "0.06") or "0.06")
+            hard_cap = float(os.getenv("OPTION_EXEC_MAX_SPREAD_HARD_CAP_PCT", "0.10") or "0.10")
+            low_premium_cutoff = float(os.getenv("OPTION_LOW_PREMIUM_CUTOFF", "50") or "50")
+        except ValueError:
+            atm_limit = 0.03
+            low_premium_limit = 0.06
+            hard_cap = 0.10
+            low_premium_cutoff = 50.0
+        reference = float(last_price or mid or 0.0)
+        if reference > 0 and reference <= low_premium_cutoff:
+            return min(max(base, low_premium_limit), hard_cap)
+        return min(max(base, atm_limit), hard_cap)
 
     # Internal helpers ---------------------------------------------------
     def _ladder_prices(self, mid: float, spread: float, side: Side) -> Sequence[float]:

--- a/src/nifty_scalper_bot/execution/order_executor.py
+++ b/src/nifty_scalper_bot/execution/order_executor.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from itertools import count
+import math
 import time
 from typing import Any, Dict, Iterable, Optional, Sequence, cast
 
@@ -16,6 +17,26 @@ from nifty_scalper_bot.utils.logging import get_logger
 class ExecutionError(OrderPlacementError):
     """Raised when broker execution fails hard."""
 
+
+def _safe_float(value: object, default: float) -> float:
+    if value in (None, ""):
+        return float(default)
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return float(default)
+    if not math.isfinite(number):
+        return float(default)
+    return number
+
+
+def _safe_int(value: object, default: int) -> int:
+    if value in (None, ""):
+        return int(default)
+    try:
+        return int(float(value))
+    except (TypeError, ValueError):
+        return int(default)
 
 class OrderExecutor:
     """Execute orders while enforcing risk limits."""
@@ -105,21 +126,26 @@ class OrderExecutor:
             )
         else:
             self._nonce_cache.pop(key, None)
-        payload: Dict[str, object] = {
+        broker_payload: Dict[str, object] = {
             "symbol": symbol,
             "side": side.upper(),
-            "qty": qty,
             "quantity": qty,
-            "type": "LIMIT",
             "order_type": "LIMIT",
             "price": rounded_price,
             "client_order_id": client_order_id,
+        }
+        legacy_payload: Dict[str, object] = {
+            **broker_payload,
+            "qty": qty,
+            "type": "LIMIT",
         }
         response: Dict[str, object] | None = None
         last_error: Exception | None = None
         for attempt in range(1, 4):
             try:
-                response = self._submit_broker_order(payload)
+                response = self._submit_broker_order(
+                    broker_payload, legacy_payload=legacy_payload
+                )
                 break
             except BrokerError as exc:
                 last_error = exc
@@ -162,17 +188,16 @@ class OrderExecutor:
         self._nonce_cache.pop(key, None)
         return order_id
 
-    def _submit_broker_order(self, payload: dict[str, object]) -> dict[str, object]:
-        kwargs_payload = dict(payload)
-        if "qty" in kwargs_payload and "quantity" not in kwargs_payload:
-            kwargs_payload["quantity"] = kwargs_payload["qty"]
-        if "type" in kwargs_payload and "order_type" not in kwargs_payload:
-            kwargs_payload["order_type"] = kwargs_payload["type"]
+    def _submit_broker_order(
+        self, payload: dict[str, object], *, legacy_payload: dict[str, object] | None = None
+    ) -> dict[str, object]:
         try:
-            response = self._broker.place_order(**kwargs_payload)
+            response = self._broker.place_order(**payload)
         except TypeError as exc:
+            if legacy_payload is None:
+                raise
             try:
-                response = self._broker.place_order(payload)
+                response = self._broker.place_order(legacy_payload)
             except TypeError:
                 raise exc
         if not isinstance(response, dict):
@@ -197,11 +222,22 @@ class OrderExecutor:
         quote = quote_getter(symbol)
         if not isinstance(quote, dict):
             return bid, ask, ts_ns
-        bid = float(quote.get("bid", bid))
-        ask = float(quote.get("ask", ask))
-        ts_val = quote.get("ts_ns")
-        if ts_val is not None:
-            ts_ns = int(ts_val)
+        bid = _safe_float(
+            quote.get("bid")
+            or quote.get("best_bid")
+            or quote.get("best_bid_price")
+            or quote.get("buy_price"),
+            bid,
+        )
+        ask = _safe_float(
+            quote.get("ask")
+            or quote.get("best_ask")
+            or quote.get("best_ask_price")
+            or quote.get("sell_price"),
+            ask,
+        )
+        ts_val = quote.get("ts_ns") or quote.get("timestamp_ns")
+        ts_ns = _safe_int(ts_val, ts_ns)
         return bid, ask, ts_ns
 
 
@@ -349,12 +385,47 @@ class OrderExecutor:
                 self._logger.warning("Failed to cancel order %s", order_id)
 
     def _find_open_order(self, client_order_id: str) -> Optional[Dict[str, object]]:
+        wanted = str(client_order_id or "").strip()
+        if not wanted:
+            return None
         for attr in ("get_order_by_client_order_id", "find_order_by_client_order_id"):
             finder = getattr(self._broker, attr, None)
             if callable(finder):
-                result = finder(client_order_id)
-                if result:
+                result = finder(wanted)
+                if isinstance(result, dict):
                     return result
+        get_orders = getattr(self._broker, "get_orders", None)
+        if not callable(get_orders):
+            get_orders = getattr(self._broker, "orders", None)
+        if not callable(get_orders):
+            return None
+        try:
+            orders = get_orders() or []
+        except Exception:
+            return None
+        terminal = {"CANCELLED", "CANCELED", "REJECTED", "COMPLETE", "COMPLETED"}
+        wanted_upper = wanted.upper()
+        wanted_suffix = wanted_upper[-8:]
+        for order in orders:
+            if not isinstance(order, dict):
+                continue
+            status = str(order.get("status") or "").strip().upper()
+            if status in terminal:
+                continue
+            values = [
+                order.get("client_order_id"),
+                order.get("tag"),
+                order.get("order_id"),
+                order.get("guid"),
+                order.get("exchange_order_id"),
+                order.get("parent_order_id"),
+            ]
+            candidates = {str(v or "").strip().upper() for v in values if v}
+            if wanted_upper in candidates:
+                return dict(order)
+            tag_value = str(order.get("tag") or "").strip().upper()
+            if tag_value and wanted_suffix and wanted_suffix in tag_value:
+                return dict(order)
         return None
 
 

--- a/src/nifty_scalper_bot/execution/order_manager.py
+++ b/src/nifty_scalper_bot/execution/order_manager.py
@@ -882,9 +882,9 @@ class OrderManager:
                 }
                 if wanted and wanted_upper in candidates:
                     return dict(order)
-                tag_value = str(order.get("tag") or "").strip()
-                if wanted and tag_value and (
-                    wanted in tag_value or wanted[-8:] in tag_value
+                tag_value_upper = str(order.get("tag") or "").strip().upper()
+                if wanted_upper and tag_value_upper and (
+                    wanted_upper in tag_value_upper or wanted_upper[-8:] in tag_value_upper
                 ):
                     return dict(order)
 
@@ -2316,8 +2316,13 @@ class OrderManager:
 
         trade_id = f"TRD_{signal_id}"
         unique_client_id = f"bot_{signal_id[-12:]}"  # Max 20 chars usually
+        suffix = unique_client_id[-8:]
         base_tag = str(tag or "bot").strip() or "bot"
-        broker_tag = f"{base_tag}_{unique_client_id[-8:]}"[:20]
+        safe_base = "".join(ch for ch in base_tag if ch.isalnum() or ch in {"_", "-"})
+        if not safe_base:
+            safe_base = "bot"
+        safe_base = safe_base[: max(1, 19 - len(suffix))]
+        broker_tag = f"{safe_base}_{suffix}"[:20]
 
         pending_signal_marked = False
         if signal_id:
@@ -2505,6 +2510,24 @@ class OrderManager:
             return None
 
         for attempt in range(1, 4):
+            if self._is_uncertain_order(unique_client_id):
+                existing_uncertain = self._find_open_order(unique_client_id)
+                if existing_uncertain is not None:
+                    existing_order_id = _extract_order_id(existing_uncertain)
+                    if existing_order_id:
+                        self._clear_uncertain_order(unique_client_id)
+                        if pending_signal_marked:
+                            self._clear_pending_signal(signal_id)
+                        if signal_id:
+                            self._remember_signal(signal_id)
+                        return existing_order_id
+                _log_order_decision(
+                    allowed=False,
+                    block_reason="uncertain_order_reconciliation_pending",
+                )
+                if pending_signal_marked:
+                    self._clear_pending_signal(signal_id)
+                return None
             # -----------------------------------------------------------------
             # ✅ FIX: Re-hydrate Enums to prevent Adapter Crash
             # The broker adapter expects Enum objects (e.g. OrderType.MARKET).
@@ -2546,11 +2569,17 @@ class OrderManager:
                         else:
                             self._mark_order_uncertain(unique_client_id)
                             self._logger.critical(
-                                "🚨 Broker API hung on attempt %s and no existing order was found for client_order_id=%s",
+                                "🚨 Broker API hung on attempt %s and no existing order was found for client_order_id=%s; marking uncertain and blocking retry",
                                 attempt,
                                 unique_client_id,
                             )
-                            raise TimeoutError("Broker API call timed out (10s)")
+                            _log_order_decision(
+                                allowed=False,
+                                block_reason="uncertain_order_reconciliation_pending",
+                            )
+                            if pending_signal_marked:
+                                self._clear_pending_signal(signal_id)
+                            return None
                     self._logger.info(
                         "Recovered late broker response inside grace window for %s",
                         normalized_symbol,

--- a/src/nifty_scalper_bot/execution/order_manager.py
+++ b/src/nifty_scalper_bot/execution/order_manager.py
@@ -670,6 +670,11 @@ class OrderManager:
             30.0,
             float(os.getenv("ORDER_SIGNAL_PENDING_TTL_SECONDS", "120") or 120),
         )
+        self._uncertain_client_order_ids: dict[str, float] = {}
+        self._uncertain_order_ttl_seconds: float = max(
+            15.0,
+            float(os.getenv("ORDER_UNCERTAIN_TTL_SECONDS", "60") or 60),
+        )
         if not hasattr(self, "_logger"):
             self._logger = get_logger(__name__)
         self._broker_circuit = CircuitBreaker()
@@ -815,6 +820,37 @@ class OrderManager:
         with self._lock:
             self._pending_signal_ids.pop(signal_id, None)
 
+    def _prune_uncertain_orders(self) -> None:
+        now_ts = time.time()
+        ttl = float(getattr(self, "_uncertain_order_ttl_seconds", 60.0) or 60.0)
+        expired = [
+            client_order_id
+            for client_order_id, ts in self._uncertain_client_order_ids.items()
+            if now_ts - float(ts or 0.0) > ttl
+        ]
+        for client_order_id in expired:
+            self._uncertain_client_order_ids.pop(client_order_id, None)
+
+    def _mark_order_uncertain(self, client_order_id: str) -> None:
+        if not client_order_id:
+            return
+        with self._lock:
+            self._prune_uncertain_orders()
+            self._uncertain_client_order_ids[str(client_order_id)] = time.time()
+
+    def _clear_uncertain_order(self, client_order_id: str | None) -> None:
+        if not client_order_id:
+            return
+        with self._lock:
+            self._uncertain_client_order_ids.pop(str(client_order_id), None)
+
+    def _is_uncertain_order(self, client_order_id: str) -> bool:
+        if not client_order_id:
+            return False
+        with self._lock:
+            self._prune_uncertain_orders()
+            return str(client_order_id) in self._uncertain_client_order_ids
+
     def _find_open_order(self, client_order_id: str) -> dict[str, Any] | None:
         """Find a live/open broker order by client_order_id/order tag/order_id."""
         try:
@@ -826,6 +862,7 @@ class OrderManager:
 
             orders = get_orders() or []
             wanted = str(client_order_id or "").strip()
+            wanted_upper = wanted.upper()
 
             for order in orders:
                 if not isinstance(order, Mapping):
@@ -836,12 +873,19 @@ class OrderManager:
                     continue
 
                 candidates = {
-                    str(order.get("client_order_id") or "").strip(),
-                    str(order.get("tag") or "").strip(),
-                    str(order.get("order_id") or "").strip(),
+                    str(order.get("client_order_id") or "").strip().upper(),
+                    str(order.get("tag") or "").strip().upper(),
+                    str(order.get("order_id") or "").strip().upper(),
+                    str(order.get("guid") or "").strip().upper(),
+                    str(order.get("exchange_order_id") or "").strip().upper(),
+                    str(order.get("parent_order_id") or "").strip().upper(),
                 }
-
-                if wanted and wanted in candidates:
+                if wanted and wanted_upper in candidates:
+                    return dict(order)
+                tag_value = str(order.get("tag") or "").strip()
+                if wanted and tag_value and (
+                    wanted in tag_value or wanted[-8:] in tag_value
+                ):
                     return dict(order)
 
             return None
@@ -2272,6 +2316,8 @@ class OrderManager:
 
         trade_id = f"TRD_{signal_id}"
         unique_client_id = f"bot_{signal_id[-12:]}"  # Max 20 chars usually
+        base_tag = str(tag or "bot").strip() or "bot"
+        broker_tag = f"{base_tag}_{unique_client_id[-8:]}"[:20]
 
         pending_signal_marked = False
         if signal_id:
@@ -2412,7 +2458,7 @@ class OrderManager:
             "order_type": final_order_type,
             "price": price,
             "trigger_price": trigger_price,
-            "tag": tag,
+            "tag": broker_tag,
             "variety": variety,
             "client_order_id": unique_client_id,
         }
@@ -2437,6 +2483,25 @@ class OrderManager:
                 return str(raw) if raw else None
             if response:
                 return str(response)
+            return None
+
+        if self._is_uncertain_order(unique_client_id):
+            existing_uncertain = self._find_open_order(unique_client_id)
+            if existing_uncertain is not None:
+                existing_order_id = _extract_order_id(existing_uncertain)
+                if existing_order_id:
+                    self._clear_uncertain_order(unique_client_id)
+                    if pending_signal_marked:
+                        self._clear_pending_signal(signal_id)
+                    if signal_id:
+                        self._remember_signal(signal_id)
+                    return existing_order_id
+            _log_order_decision(
+                allowed=False,
+                block_reason="uncertain_order_reconciliation_pending",
+            )
+            if pending_signal_marked:
+                self._clear_pending_signal(signal_id)
             return None
 
         for attempt in range(1, 4):
@@ -2479,6 +2544,7 @@ class OrderManager:
                         if existing_after_timeout is not None:
                             response = existing_after_timeout
                         else:
+                            self._mark_order_uncertain(unique_client_id)
                             self._logger.critical(
                                 "🚨 Broker API hung on attempt %s and no existing order was found for client_order_id=%s",
                                 attempt,
@@ -2508,6 +2574,7 @@ class OrderManager:
                 order_id = _extract_order_id(response)
 
                 if order_id:
+                    self._clear_uncertain_order(unique_client_id)
                     # ✅ RESET Kill Switch on success
                     self._consecutive_failures = 0
                     self._logger.info(
@@ -2707,6 +2774,7 @@ class OrderManager:
                 time.sleep(0.5 * attempt)
 
         self._logger.error("❌ Order placement failed after retries.")
+        self._clear_uncertain_order(unique_client_id)
         _log_order_decision(allowed=False, block_reason="order_placement_failed_after_retries")
         if pending_signal_marked:
             self._clear_pending_signal(signal_id)

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -7348,7 +7348,8 @@ class StrategyRunner:
                             )
                         disable_same_bar_skip = phase != "LIVE"
                         if (
-                            not same_bar_eval_allowed
+                            not first_hydrated_eval
+                            and not same_bar_eval_allowed
                             and not disable_same_bar_skip
                             and _effective_last_bar_ts
                             and state._last_eval_bar_ts
@@ -7684,7 +7685,11 @@ class StrategyRunner:
                             market_open = get_market_state() == MarketState.OPEN
                         except Exception:
                             market_open = True
-                        if symbol_role in {"spot_context", "futures_context"} and not market_open:
+                        if (
+                            symbol_role in {"spot_context", "futures_context"}
+                            and not market_open
+                            and not _env_bool("ALLOW_OFFMARKET_CONTEXT_DIAGNOSTICS", False)
+                        ):
                             self._emit_runner_eval_decision(
                                 symbol=symbol,
                                 stage="phase9",

--- a/tests/execution/test_bracket_manager_state.py
+++ b/tests/execution/test_bracket_manager_state.py
@@ -1,4 +1,7 @@
 from nifty_scalper_bot.execution.bracket_manager import ExitExecutionResult
+import time
+from types import SimpleNamespace
+from nifty_scalper_bot.execution.bracket_manager import BracketManager, BracketState
 
 
 def test_exit_execution_result_instantiation_safe() -> None:
@@ -6,3 +9,48 @@ def test_exit_execution_result_instantiation_safe() -> None:
     assert result.reason == 'test'
     assert not hasattr(result, 'stop_loss_price')
     assert not hasattr(result, 'target_price')
+
+
+def _mk_bm_with_broker(broker):
+    om = SimpleNamespace(_broker=broker)
+    bm = BracketManager(om)
+    bm._pending_entry_reconcile_after_sec = 0.0
+    return bm
+
+
+def test_pending_bracket_reconciles_filled_order_from_get_order_status():
+    class _Broker:
+        def get_order_status(self, oid):
+            return {"status": "COMPLETE", "average_price": 101.5}
+    bm = _mk_bm_with_broker(_Broker())
+    bracket = BracketState("E1", "NFO:NIFTYCE", "BUY", 1, 100.0, 95.0, 110.0, created_at=time.time() - 10, active=False, entry_confirmed=False)
+    bm._brackets["E1"] = bracket
+    bm._reconcile_pending_entry(bracket)
+    assert bracket.entry_confirmed is True
+    assert bracket.active is True
+
+
+def test_pending_bracket_reconciles_filled_order_from_get_orders():
+    class _Broker:
+        def get_order_status(self, oid):
+            return {}
+        def get_orders(self):
+            return [{"order_id": "E2", "status": "COMPLETE", "avg_price": 102.0}]
+    bm = _mk_bm_with_broker(_Broker())
+    bracket = BracketState("E2", "NFO:NIFTYCE", "BUY", 1, 100.0, 95.0, 110.0, created_at=time.time() - 10, active=False, entry_confirmed=False)
+    bm._brackets["E2"] = bracket
+    bm._reconcile_pending_entry(bracket)
+    assert bracket.entry_confirmed is True
+    assert bracket.active is True
+
+
+def test_pending_bracket_not_reconciled_before_threshold():
+    class _Broker:
+        def get_order_status(self, oid):
+            return {"status": "COMPLETE", "average_price": 101.0}
+    bm = _mk_bm_with_broker(_Broker())
+    bm._pending_entry_reconcile_after_sec = 30.0
+    bracket = BracketState("E3", "NFO:NIFTYCE", "BUY", 1, 100.0, 95.0, 110.0, created_at=time.time(), active=False, entry_confirmed=False)
+    bm._brackets["E3"] = bracket
+    bm._reconcile_pending_entry(bracket)
+    assert bracket.entry_confirmed is False

--- a/tests/execution/test_execution_policy.py
+++ b/tests/execution/test_execution_policy.py
@@ -39,3 +39,33 @@ def test_build_plan_rejects_wide_spread() -> None:
 
     with pytest.raises(OrderPlacementError):
         policy.build_plan("TEST", "SELL")
+
+
+def test_execution_policy_allows_configured_option_spread(monkeypatch) -> None:
+    monkeypatch.setenv("OPTION_EXEC_MAX_SPREAD_ATM_PCT", "0.03")
+    monkeypatch.setenv("OPTION_EXEC_MAX_SPREAD_LOW_PREMIUM_PCT", "0.06")
+    monkeypatch.setenv("OPTION_EXEC_MAX_SPREAD_HARD_CAP_PCT", "0.10")
+    monkeypatch.setenv("OPTION_LOW_PREMIUM_CUTOFF", "50")
+    hub = DummyHub({"best_bid": 9.0, "best_ask": 9.5, "ltp": 10.0})
+    policy = ExecutionPolicy(hub, max_spread_pct=0.015)
+    plan = policy.build_plan("NFO:NIFTY26MAY23750CE", "BUY")
+    assert plan.spread_pct > 0
+
+
+def test_execution_policy_rejects_option_spread_above_hard_cap(monkeypatch) -> None:
+    monkeypatch.setenv("OPTION_EXEC_MAX_SPREAD_ATM_PCT", "0.03")
+    monkeypatch.setenv("OPTION_EXEC_MAX_SPREAD_LOW_PREMIUM_PCT", "0.06")
+    monkeypatch.setenv("OPTION_EXEC_MAX_SPREAD_HARD_CAP_PCT", "0.10")
+    monkeypatch.setenv("OPTION_LOW_PREMIUM_CUTOFF", "50")
+    hub = DummyHub({"best_bid": 10.0, "best_ask": 12.0, "ltp": 10.0})
+    policy = ExecutionPolicy(hub, max_spread_pct=0.015)
+    with pytest.raises(OrderPlacementError):
+        policy.build_plan("NFO:NIFTY26MAY23750CE", "BUY")
+
+
+def test_execution_policy_keeps_strict_index_spread(monkeypatch) -> None:
+    monkeypatch.setenv("OPTION_EXEC_MAX_SPREAD_ATM_PCT", "0.03")
+    hub = DummyHub({"best_bid": 100.0, "best_ask": 103.0, "ltp": 101.0})
+    policy = ExecutionPolicy(hub, max_spread_pct=0.015)
+    with pytest.raises(OrderPlacementError):
+        policy.build_plan("NSE:NIFTY", "BUY")

--- a/tests/execution/test_order_manager_timeout_reconcile.py
+++ b/tests/execution/test_order_manager_timeout_reconcile.py
@@ -75,3 +75,77 @@ def test_exception_reconcile_returns_existing_order(monkeypatch):
     oid = om.place_order('NFO:NIFTY26MAY23750CE', 'BUY', 1, order_type=OrderType.MARKET, stop_loss=10, signal_id='se')
     assert oid == 'OID_TIMEOUT'
     assert broker.calls == 1
+
+
+def test_unresolved_timeout_marks_uncertain_and_does_not_retry(monkeypatch):
+    class _SlowBroker:
+        def __init__(self): self.calls = 0
+        def place_order(self, **kwargs):
+            import time as _t
+            self.calls += 1
+            _t.sleep(20)
+            return None
+    broker = _SlowBroker()
+    om = OrderManager(broker, _Pos(), _Limiter())
+    monkeypatch.setattr(om, '_lot_size_for_symbol', lambda s: 1)
+    monkeypatch.setattr(om, '_validate_live_execution_safety', lambda: True)
+    monkeypatch.setattr(om, '_confirm_fill_fast', lambda order_id, timeout_ms=300: False)
+    monkeypatch.setattr(om, '_find_open_order', lambda cid: None)
+    result = om.place_order('NFO:NIFTY26MAY23750CE', 'BUY', 1, order_type=OrderType.MARKET, stop_loss=10, signal_id='sig_timeout_case')
+    assert result is None
+    assert broker.calls == 1
+    assert 'bot__timeout_case' in om._uncertain_client_order_ids
+
+
+def test_uncertain_order_blocks_immediate_retry_without_broker_call(monkeypatch):
+    class _Broker:
+        def __init__(self): self.calls = 0
+        def place_order(self, **kwargs):
+            self.calls += 1
+            return {"order_id": "SHOULD_NOT_HAPPEN"}
+    broker = _Broker()
+    om = OrderManager(broker, _Pos(), _Limiter())
+    monkeypatch.setattr(om, '_lot_size_for_symbol', lambda s: 1)
+    monkeypatch.setattr(om, '_validate_live_execution_safety', lambda: True)
+    monkeypatch.setattr(om, '_find_open_order', lambda cid: None)
+    om._mark_order_uncertain('bot_certainretry')
+    result = om.place_order('NFO:NIFTY26MAY23750CE', 'BUY', 1, order_type=OrderType.MARKET, stop_loss=10, signal_id='manual_certainretry')
+    assert result is None
+    assert broker.calls == 0
+
+
+def test_uncertain_order_retry_returns_existing_order(monkeypatch):
+    broker = _BrokerHang()
+    om = OrderManager(broker, _Pos(), _Limiter())
+    monkeypatch.setattr(om, '_lot_size_for_symbol', lambda s: 1)
+    monkeypatch.setattr(om, '_validate_live_execution_safety', lambda: True)
+    monkeypatch.setattr(om, '_find_open_order', lambda cid: {'order_id': 'OID_RECOVERED'})
+    om._mark_order_uncertain('bot_case1234')
+    oid = om.place_order('NFO:NIFTY26MAY23750CE', 'BUY', 1, order_type=OrderType.MARKET, stop_loss=10, signal_id='manual_case1234')
+    assert oid == 'OID_RECOVERED'
+    assert 'bot_case1234' not in om._uncertain_client_order_ids
+
+
+def test_find_open_order_matches_tag_suffix_case_insensitive():
+    class _BrokerOrders:
+        def get_orders(self):
+            return [{"tag": "BOT_ABCD1234", "status": "OPEN", "order_id": "OID_TAG"}]
+    om = OrderManager(_BrokerOrders(), _Pos(), _Limiter())
+    found = om._find_open_order("bot_abcd1234")
+    assert found is not None
+    assert found["order_id"] == "OID_TAG"
+
+
+def test_broker_tag_keeps_unique_suffix_with_long_tag(monkeypatch):
+    captured = {}
+    class _BrokerCapture:
+        def place_order(self, **kwargs):
+            captured.update(kwargs)
+            return {"order_id": "OID1"}
+    om = OrderManager(_BrokerCapture(), _Pos(), _Limiter())
+    monkeypatch.setattr(om, '_lot_size_for_symbol', lambda s: 1)
+    monkeypatch.setattr(om, '_validate_live_execution_safety', lambda: True)
+    monkeypatch.setattr(om, '_confirm_fill_fast', lambda order_id, timeout_ms=300: False)
+    oid = om.place_order('NFO:NIFTY26MAY23750CE', 'BUY', 1, order_type=OrderType.MARKET, stop_loss=10, signal_id='manual_1234abcd', tag='superlongtagname_with_extra_chars')
+    assert oid == "OID1"
+    assert str(captured["tag"]).endswith("1234abcd")

--- a/tests/test_order_executor.py
+++ b/tests/test_order_executor.py
@@ -61,3 +61,49 @@ def test_order_executor_invalid_response_raises() -> None:
     executor = OrderExecutor(BadBroker(), risk, DummyMDM())
     with pytest.raises(ExecutionError):
         executor.place_market_order(symbol="NIFTY", side="BUY", qty=1, price=100.0)
+
+
+def test_order_executor_kwargs_payload_uses_strict_keys() -> None:
+    risk = RiskConfig(max_daily_trades=5, max_order_notional=1_000_000.0, allow_short=True)
+    broker = KwargsBroker()
+    executor = OrderExecutor(broker, risk, DummyMDM())
+    executor.place_market_order(symbol="NIFTY", side="BUY", qty=1, price=100.0)
+    assert "qty" not in broker.kwargs
+    assert "type" not in broker.kwargs
+    assert broker.kwargs["quantity"] == 1
+    assert broker.kwargs["order_type"] == "LIMIT"
+
+
+def test_order_executor_quote_context_handles_malformed_quote() -> None:
+    class BadMDM:
+        def get_last_quote(self, symbol: str): return {"bid": "bad", "ask": None, "ts_ns": "bad"}
+    risk = RiskConfig(max_daily_trades=5, max_order_notional=1_000_000.0, allow_short=True)
+    executor = OrderExecutor(KwargsBroker(), risk, BadMDM())
+    assert executor.place_market_order(symbol="NIFTY", side="BUY", qty=1, price=100.0) == "K1"
+
+
+def test_order_executor_find_open_order_scans_get_orders() -> None:
+    class B:
+        def get_orders(self):
+            return [{"client_order_id": "CID1", "status": "OPEN", "order_id": "OID1"}]
+    ex = OrderExecutor(B(), RiskConfig(max_daily_trades=5, max_order_notional=1_000_000.0, allow_short=True), DummyMDM())
+    assert ex._find_open_order("CID1")["order_id"] == "OID1"
+
+
+def test_order_executor_find_open_order_ignores_terminal_statuses() -> None:
+    class B:
+        def get_orders(self):
+            return [
+                {"client_order_id": "CID1", "status": "COMPLETE", "order_id": "OID1"},
+                {"client_order_id": "CID1", "status": "REJECTED", "order_id": "OID2"},
+            ]
+    ex = OrderExecutor(B(), RiskConfig(max_daily_trades=5, max_order_notional=1_000_000.0, allow_short=True), DummyMDM())
+    assert ex._find_open_order("CID1") is None
+
+
+def test_order_executor_find_open_order_matches_tag_suffix() -> None:
+    class B:
+        def get_orders(self):
+            return [{"tag": "BOT_ABCD1234", "status": "OPEN", "order_id": "OID3"}]
+    ex = OrderExecutor(B(), RiskConfig(max_daily_trades=5, max_order_notional=1_000_000.0, allow_short=True), DummyMDM())
+    assert ex._find_open_order("bot_abcd1234")["order_id"] == "OID3"


### PR DESCRIPTION
### Motivation

- Prevent the runner same-bar logic from accidentally blocking the first hydrated evaluation so a freshly-hydrated symbol is evaluated exactly once.
- Eliminate inconsistent regime gating by avoiding duplicate `regime_manager.can_trade()` calls that can diverge if the regime component has side effects.
- Close execution reconciliation gaps around broker timeouts, brittle broker payloads, open-order matching, and delayed bracket fills to reduce duplicate exposure and adapter incompatibilities.

### Description

- Runner / Strategy: adjusted the lower PHASE-9 same-bar skip to respect `first_hydrated_eval` and added an env-only `ALLOW_OFFMARKET_CONTEXT_DIAGNOSTICS` flag to permit off-market spot/futures diagnostics without enabling off-market trading (`src/nifty_scalper_bot/strategies/runner.py`).
- StrategyManager: capture and reuse the initial regime decision (`regime_allowed` / `regime_reasons`) so `can_trade()` is not invoked twice during a single `generate_signal()` evaluation (`src/nifty_scalper_bot/core/strategy_manager.py`).
- OrderManager: added uncertain-order cooldown tracking with TTL and helpers (`_mark_order_uncertain`, `_is_uncertain_order`, `_clear_uncertain_order`), pre-broker reconciliation/blocking for uncertain client IDs, marking of unresolved timeouts as uncertain, clearing on success/final failure, and embedding a broker tag suffix derived from the unique client id; also expanded `_find_open_order` matching to include `guid`, `exchange_order_id`, and `parent_order_id` plus case-insensitive and tag-suffix matching (`src/nifty_scalper_bot/execution/order_manager.py`).
- OrderExecutor: send strict kwargs payloads (`quantity`/`order_type`) with a legacy single-dict fallback only on `TypeError`, added defensive quote parsing helpers (`_safe_float`, `_safe_int`) with alternate key support, and extended `_find_open_order` to scan broker orders and ignore terminal statuses, improving reconciliation across broker adapters (`src/nifty_scalper_bot/execution/order_executor.py`).
- ExecutionPolicy: compute an effective, env-configurable max spread for options via `_effective_max_spread_pct()` (ATM/low-premium caps and hard cap) and use it in `build_plan()` instead of a fixed ceiling (`src/nifty_scalper_bot/execution/execution_policy.py`).
- BracketManager: added env-driven pending-entry reconciliation delay, `_broker_order_filled()` and `_reconcile_pending_entry()` helpers, and integrated a safe reconciliation pass from the watchdog loop outside the main bracket lock to catch delayed fills and activate pending brackets (`src/nifty_scalper_bot/execution/bracket_manager.py`).

### Testing

- Static checks: ran `python -m compileall -q src tests` and it completed without errors.
- Focused test suites executed with `pytest -q` and passed in this environment: `tests/strategies/test_runner_same_bar_skip_diagnostics.py`, `tests/core/test_strategy_manager_context_to_option_propagation.py`, `tests/execution/test_order_manager_timeout_reconcile.py`, `tests/test_order_executor.py`, `tests/execution/test_execution_policy.py`, `tests/execution/test_bracket_manager_state.py`, plus complementary execution and strategies tests (`tests/execution/test_order_manager_idempotency.py`, `tests/execution/test_order_manager_preflight.py`, `tests/execution/test_dynamic_tp_subscription.py`, `tests/strategies/test_vwap_pro_side_domain.py`, `tests/strategies/test_elite_no_vote_reasons.py`).
- Result: all listed tests passed in the CI-like environment used for validation and no unrelated failures were observed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d0b9bd3d08324ab5d0cd4e8080f02)