### PR TITLE
Fix no-trigger strategy diagnostics and safe trigger calibration

### DIFF
--- a/src/nifty_scalper_bot/core/strategy_manager.py
+++ b/src/nifty_scalper_bot/core/strategy_manager.py
@@ -1808,6 +1808,7 @@ class StrategyManager(_BaseStrategyManager):
         """Store latest spot/futures context snapshots for option strategies."""
         if not hasattr(self, "_latest_context_snapshots"):
             self._latest_context_snapshots: dict[str, dict[str, t.Any]] = {}
+        previous_snapshot = dict(self._latest_context_snapshots.get(role, {}) or {})
 
         def _num(*keys: str) -> float | None:
             for key in keys:
@@ -1828,6 +1829,40 @@ class StrategyManager(_BaseStrategyManager):
             if role == "futures_context"
             else "unknown"
         )
+        current_volume = _num("volume")
+        current_avg_volume = _num("avg_volume")
+        current_vwap = _num("vwap", "exchange_vwap", "session_vwap")
+        current_close = _num("close", "ltp", "price")
+        futures_volume_ratio = _num("futures_volume_ratio")
+        futures_volume_ratio_source = "indicator"
+        if role == "futures_context" and (futures_volume_ratio is None or futures_volume_ratio <= 0):
+            if (
+                current_volume is not None
+                and current_avg_volume is not None
+                and current_avg_volume > 0
+            ):
+                futures_volume_ratio = current_volume / max(current_avg_volume, 1e-9)
+                futures_volume_ratio_source = "derived_volume_avg"
+        vwap_slope = _num("vwap_slope")
+        vwap_slope_source = "indicator"
+        if role == "futures_context" and (vwap_slope is None or abs(vwap_slope) <= 1e-12):
+            prev_vwap = previous_snapshot.get("vwap")
+            try:
+                prev_vwap_f = float(prev_vwap) if prev_vwap is not None else None
+            except (TypeError, ValueError):
+                prev_vwap_f = None
+            if current_vwap is not None and prev_vwap_f and prev_vwap_f > 0:
+                vwap_slope = (current_vwap - prev_vwap_f) / prev_vwap_f
+                vwap_slope_source = "derived_previous_snapshot"
+        ema_slope = _num("ema_slope")
+        if role == "futures_context" and (ema_slope is None or abs(ema_slope) <= 1e-12):
+            prev_close = previous_snapshot.get("close") or previous_snapshot.get("ltp")
+            try:
+                prev_close_f = float(prev_close) if prev_close is not None else None
+            except (TypeError, ValueError):
+                prev_close_f = None
+            if current_close is not None and prev_close_f and prev_close_f > 0:
+                ema_slope = (current_close - prev_close_f) / prev_close_f
         snapshot = {
             "symbol": symbol, "role": role, "context_kind": context_kind, "timestamp": time.time(),
             "ltp": _num("ltp", "close", "price"), "close": _num("close", "ltp", "price"),
@@ -1835,14 +1870,16 @@ class StrategyManager(_BaseStrategyManager):
             "ema_fast": _num("ema_fast", "ema_9", "ema9"),
             "ema_slow": _num("ema_slow", "ema_21", "ema21"), "ema_50": _num("ema_50", "ema50"),
             "adx": _num("adx"), "atr": _num("atr"), "volume": _num("volume"),
-            "avg_volume": _num("avg_volume"), "futures_volume_ratio": _num("futures_volume_ratio"),
-            "vwap_slope": _num("vwap_slope"), "ema_slope": _num("ema_slope"),
+            "avg_volume": _num("avg_volume"), "futures_volume_ratio": futures_volume_ratio,
+            "vwap_slope": vwap_slope, "ema_slope": ema_slope,
             "direction_bias": derived_direction,
             "underlying_direction_bias": derived_direction,
             "underlying_direction_confidence": derived_confidence,
             "direction_context_reasons": derived_reasons,
             "context_timestamp_epoch": time.time(),
             "regime": indicators.get("regime") or indicators.get("market_regime"),
+            "futures_volume_ratio_source": futures_volume_ratio_source,
+            "vwap_slope_source": vwap_slope_source,
         }
         self._latest_context_snapshots[role] = snapshot
         if derived_direction not in {"CE", "PE"}:
@@ -2501,12 +2538,13 @@ class StrategyManager(_BaseStrategyManager):
             spot_usable = spot_fresh and spot_direction_valid
             fut_usable = fut_fresh and fut_direction_valid
             if spot_fresh and not spot_direction_valid:
+                spot_direction_reasons = spot_ctx.get("direction_context_reasons")
                 log_throttled(
                     log, f"option_context_fresh_but_directionless:{symbol}",
-                    "OPTION_CONTEXT_FRESH_BUT_DIRECTIONLESS symbol=%s spot_fresh=%s spot_ctx_keys=%s",
-                    symbol, spot_fresh, sorted(list(spot_ctx.keys())),
+                    "OPTION_CONTEXT_FRESH_BUT_DIRECTIONLESS symbol=%s spot_fresh=%s spot_direction_bias=%s spot_underlying_direction_bias=%s spot_confidence=%s spot_direction_reasons=%s spot_ctx_keys=%s",
+                    symbol, spot_fresh, spot_ctx.get("direction_bias"), spot_ctx.get("underlying_direction_bias"), spot_ctx.get("underlying_direction_confidence"), spot_direction_reasons, sorted(list(spot_ctx.keys())),
                     interval_sec=30.0, level=logging.INFO,
-                    extra={"event": "OPTION_CONTEXT_FRESH_BUT_DIRECTIONLESS", "symbol": symbol, "spot_fresh": spot_fresh, "spot_direction_valid": spot_direction_valid, "spot_ctx_keys": sorted(list(spot_ctx.keys()))},
+                    extra={"event": "OPTION_CONTEXT_FRESH_BUT_DIRECTIONLESS", "symbol": symbol, "spot_fresh": spot_fresh, "spot_direction_valid": spot_direction_valid, "spot_ctx_keys": sorted(list(spot_ctx.keys())), "spot_direction_bias": spot_ctx.get("direction_bias"), "spot_underlying_direction_bias": spot_ctx.get("underlying_direction_bias"), "spot_confidence": spot_ctx.get("underlying_direction_confidence"), "spot_direction_reasons": spot_direction_reasons, "spot_ltp": spot_ctx.get("ltp"), "spot_close": spot_ctx.get("close"), "spot_vwap": spot_ctx.get("vwap"), "spot_ema_fast": spot_ctx.get("ema_fast"), "spot_ema_slow": spot_ctx.get("ema_slow"), "spot_ema_50": spot_ctx.get("ema_50"), "spot_vwap_slope": spot_ctx.get("vwap_slope"), "spot_ema_slope": spot_ctx.get("ema_slope"), "fut_fresh": fut_fresh, "fut_direction_valid": fut_direction_valid, "fut_direction_bias": fut_ctx.get("direction_bias"), "fut_underlying_direction_bias": fut_ctx.get("underlying_direction_bias"), "fut_confidence": fut_ctx.get("underlying_direction_confidence"), "fut_direction_reasons": fut_ctx.get("direction_context_reasons"), "fut_ctx_keys": sorted(list(fut_ctx.keys())), "fut_ltp": fut_ctx.get("ltp"), "fut_close": fut_ctx.get("close"), "fut_vwap": fut_ctx.get("vwap"), "fut_ema_fast": fut_ctx.get("ema_fast"), "fut_ema_slow": fut_ctx.get("ema_slow"), "fut_ema_50": fut_ctx.get("ema_50"), "fut_vwap_slope": fut_ctx.get("vwap_slope"), "fut_ema_slope": fut_ctx.get("ema_slope")},
                 )
             if spot_usable:
                 indicators.setdefault("spot_context", spot_ctx)
@@ -2790,8 +2828,16 @@ class StrategyManager(_BaseStrategyManager):
         elif combined is None:
             log_throttled(
                 log,
-                key=f"strategy_manager_no_combined:{symbol}",
-                msg="strategy_manager_no_combined_signal",
+                f"strategy_manager_no_combined:{symbol}",
+                (
+                    "strategy_manager_no_combined_signal symbol=%s no_vote_reason_counts=%s "
+                    "direction_bias=%s underlying_direction_bias=%s context_age_seconds=%s"
+                ),
+                symbol,
+                no_vote_reason_counts,
+                indicators.get("direction_bias"),
+                indicators.get("underlying_direction_bias"),
+                indicators.get("context_age_seconds"),
                 interval_sec=30.0,
                 extra={
                     "event": "strategy_manager_no_combined_signal",
@@ -3020,6 +3066,29 @@ class StrategyManager(_BaseStrategyManager):
                 context_sides = [v.side for _, v in context_votes]
                 context_scores = [self._extract_raw_score(v) for _, v in context_votes]
                 context_confidences = [float(v.confidence) for _, v in context_votes]
+                context_trigger_details = []
+                for signal, vote in context_votes:
+                    md = dict(getattr(signal, "metadata", {}) or {})
+                    vote_md = dict(getattr(vote, "metadata", {}) or {})
+                    merged_md = {**md, **vote_md}
+                    context_trigger_details.append(
+                        {
+                            "strategy": vote.strategy,
+                            "side": vote.side,
+                            "score": self._extract_raw_score(vote),
+                            "confidence": float(vote.confidence),
+                            "role": merged_md.get("role"),
+                            "can_trigger": merged_md.get("can_trigger"),
+                            "trigger_conditions_met": merged_md.get("trigger_conditions_met"),
+                            "trigger_block_reason": merged_md.get("trigger_block_reason"),
+                            "quote_depth_valid": merged_md.get("quote_depth_valid"),
+                            "tradable_quote": merged_md.get("tradable_quote"),
+                            "spread_pct": merged_md.get("spread_pct"),
+                            "tick_age_ms": merged_md.get("tick_age_ms") or indicator_map.get("tick_age_ms"),
+                            "depth_available": merged_md.get("depth_available"),
+                            "tick_direction": merged_md.get("tick_direction"),
+                        }
+                    )
                 log.info(
                     "TRADE_DECISION_TRACE approval_path=%s blocked_at=%s blocked_reason=%s "
                     "symbol=%s context_votes=%s context_sides=%s context_scores=%s "
@@ -3045,6 +3114,7 @@ class StrategyManager(_BaseStrategyManager):
                         "context_sides": context_sides,
                         "context_scores": context_scores,
                         "context_confidences": context_confidences,
+                        "context_trigger_details": context_trigger_details,
                         "allow_context_promotion": bool(mode_profile.get("allow_context_promotion", False)),
                         "execution_mode": mode_profile.get("mode"),
                         "direction_bias": indicator_map.get("direction_bias"),
@@ -3055,11 +3125,12 @@ class StrategyManager(_BaseStrategyManager):
                 log_throttled(
                     log,
                     f"strategy_no_trigger_vote:{symbol_norm}",
-                    "STRATEGY_NO_TRIGGER_VOTE symbol=%s context_votes=%s context_sides=%s live_context_promotion_allowed=%s",
+                    "STRATEGY_NO_TRIGGER_VOTE symbol=%s context_votes=%s context_sides=%s live_context_promotion_allowed=%s context_trigger_details=%s",
                     symbol_norm,
                     context_vote_names,
                     context_sides,
                     bool(mode_profile.get("allow_context_promotion", False)),
+                    context_trigger_details,
                     interval_sec=30.0,
                     level=logging.INFO,
                     extra={
@@ -3070,6 +3141,7 @@ class StrategyManager(_BaseStrategyManager):
                         "context_sides": context_sides,
                         "context_scores": context_scores,
                         "context_confidences": context_confidences,
+                        "context_trigger_details": context_trigger_details,
                         "allow_context_promotion": bool(mode_profile.get("allow_context_promotion", False)),
                         "execution_mode": mode_profile.get("mode"),
                         "direction_bias": indicator_map.get("direction_bias"),

--- a/src/nifty_scalper_bot/execution/order_manager.py
+++ b/src/nifty_scalper_bot/execution/order_manager.py
@@ -2680,22 +2680,39 @@ class OrderManager:
                     fill_confirmed = self._confirm_fill_fast(order_id, timeout_ms=300)
                     if fill_confirmed and self._bracket_manager:
                         bracket = self._bracket_manager.get_bracket(order_id)
-                        if bracket and bracket.stop_order_id and bracket.trailing_spec:
-                            try:
-                                self.attach_trailing_stop(
-                                    entry_order_id=order_id,
-                                    sl_order_id=bracket.stop_order_id,
-                                    symbol=normalized_symbol,
-                                    side=normalized_side,
-                                    entry_price=bracket.entry_price,
-                                    spec=bracket.trailing_spec,
-                                )
-                                self._logger.info(
-                                    f"📈 TRAILING SL ATTACHED | {normalized_symbol} | order={order_id}"
-                                )
-                            except Exception as exc:
-                                self._logger.error(
-                                    f"Trailing attach failed for {order_id}: {exc}"
+                        if bracket:
+                            stop_order_id = (
+                                getattr(bracket, "stop_order_id", None)
+                                or getattr(bracket, "virtual_sl_id", None)
+                            )
+                            trailing_spec = getattr(bracket, "trailing_spec", None)
+
+                            if stop_order_id and trailing_spec:
+                                try:
+                                    self.attach_trailing_stop(
+                                        entry_order_id=order_id,
+                                        sl_order_id=stop_order_id,
+                                        symbol=normalized_symbol,
+                                        side=normalized_side,
+                                        entry_price=bracket.entry_price,
+                                        spec=trailing_spec,
+                                    )
+                                    self._logger.info(
+                                        "📈 TRAILING SL ATTACHED | %s | order=%s",
+                                        normalized_symbol,
+                                        order_id,
+                                    )
+                                except Exception as exc:
+                                    self._logger.error(
+                                        "Trailing attach failed for %s: %s",
+                                        order_id,
+                                        exc,
+                                    )
+                            else:
+                                self._logger.debug(
+                                    "TRAILING_ATTACH_SKIPPED order_id=%s symbol=%s reason=no_stop_order_or_trailing_spec",
+                                    order_id,
+                                    normalized_symbol,
                                 )
 
                     if fill_confirmed:

--- a/src/nifty_scalper_bot/strategies/elite_strategies/vwap_pro.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/vwap_pro.py
@@ -26,6 +26,14 @@ class VWAPProStrategy(EliteStrategy):
         self._slack_atr_mult = float(os.getenv('VWAP_SLACK_ATR_MULT', '1.5') or 1.5)
         self._max_distance_pct = float(os.getenv('VWAP_MAX_OPTION_DISTANCE_PCT', '0.18') or 0.18)
         self._max_atr_distance_mult = float(os.getenv('VWAP_MAX_ATR_DISTANCE_MULT', '1.5') or 1.5)
+        self._futures_slope_neutral_eps = float(os.getenv("VWAP_FUTURES_SLOPE_NEUTRAL_EPS", "0.00005") or 0.00005)
+        self._allow_early_trend_pullback = str(
+            os.getenv("VWAP_PRO_ALLOW_EARLY_TREND_PULLBACK_LIVE", "false")
+            if str(os.getenv("EXECUTION_MODE", "SHADOW")).strip().upper() == "LIVE"
+            else os.getenv("VWAP_PRO_ALLOW_EARLY_TREND_PULLBACK", "false")
+        ).strip().lower() in {"1", "true", "yes", "on"}
+        self._early_trend_min_context_conf = float(os.getenv("VWAP_EARLY_TREND_MIN_CONTEXT_CONF", "0.90") or 0.90)
+        self._early_trend_max_context_age = float(os.getenv("VWAP_EARLY_TREND_MAX_CONTEXT_AGE", "2.0") or 2.0)
 
     def get_required_indicators(self) -> set[str]:
         """Args: none. Returns: indicators set. Raises: Exception."""
@@ -177,12 +185,17 @@ class VWAPProStrategy(EliteStrategy):
                     score -= 2.0
                     reasons.append('direction_conflict')
 
-            slope_support = (contract_side == 'CE' and futures_vwap_slope > 0) or (contract_side == 'PE' and futures_vwap_slope < 0)
-            if slope_support:
-                score += 1.0
-                reasons.append('futures_slope_alignment')
+            slope_available = abs(futures_vwap_slope) > self._futures_slope_neutral_eps
+            if slope_available:
+                slope_support = (contract_side == 'CE' and futures_vwap_slope > 0) or (contract_side == 'PE' and futures_vwap_slope < 0)
+                if slope_support:
+                    score += 1.0
+                    reasons.append('futures_slope_alignment')
+                else:
+                    reasons.append('futures_slope_conflict')
             else:
-                reasons.append('futures_slope_conflict')
+                slope_support = False
+                reasons.append('futures_slope_neutral')
             if not trend_alignment and bias in {'CE', 'PE'}:
                 if 'direction_conflict' not in reasons:
                     conflict_penalty_applied = float(os.getenv('VWAP_PRO_CONFLICT_PENALTY', '2.0') or '2.0')
@@ -215,6 +228,20 @@ class VWAPProStrategy(EliteStrategy):
             if hard_conflict:
                 self._no_vote('underlying_direction_conflict')
                 return None
+            early_trend_pullback = bool(
+                self._allow_early_trend_pullback
+                and trend_alignment
+                and context_fresh
+                and context_age_seconds <= self._early_trend_max_context_age
+                and underlying_direction_confidence >= self._early_trend_min_context_conf
+                and not premium_above_vwap
+                and not pullback_flag
+                and distance_pct <= min(self._max_distance_pct * 0.15, 0.03)
+                and spread_pct <= float(os.getenv("VWAP_EARLY_TREND_MAX_SPREAD_PCT", "8.0") or 8.0)
+            )
+            if early_trend_pullback:
+                score += 1.2
+                reasons.append("early_trend_pullback_context")
             threshold_source = 'trend_aligned' if trend_alignment else 'base'
 
             if score < min_score:
@@ -275,6 +302,7 @@ class VWAPProStrategy(EliteStrategy):
                         "continuation_confirmed": continuation_confirmed,
                         "trend_alignment": trend_alignment,
                         "pullback_flag": pullback_flag,
+                        "early_trend_pullback": early_trend_pullback,
                     },
                 )
                 return None
@@ -335,6 +363,7 @@ class VWAPProStrategy(EliteStrategy):
                 'futures_volume_ratio': futures_volume_ratio,
                 'trigger_block_reason': '' if strategy_score >= min_score else 'weak_score',
                 'continuation_confirmed': continuation_confirmed,
+                'early_trend_pullback': early_trend_pullback,
                 'setup_invalidation_premium': current_price - atr_safe,
                 'premium_stop_distance': atr_safe,
                 'premium_target_rr': 2.0,

--- a/tests/core/test_strategy_manager_context_to_option_propagation.py
+++ b/tests/core/test_strategy_manager_context_to_option_propagation.py
@@ -80,4 +80,30 @@ def test_option_context_fresh_but_directionless_not_used(caplog):
     with caplog.at_level(logging.INFO):
         m.generate_signal('NFO:NIFTY26MAY23750CE',102)
     assert any("OPTION_CONTEXT_FRESH_BUT_DIRECTIONLESS" in rec.message for rec in caplog.records)
+    assert any("direction_tie" in rec.message for rec in caplog.records)
     assert st.last.get('direction_bias') in (None, '')
+
+
+def test_context_vote_logs_context_trigger_details(caplog):
+    import logging
+    from nifty_scalper_bot.core.strategy_manager import StrategyVote
+    from nifty_scalper_bot.strategies.signal_generator import Signal
+    m = StrategyManager([], _IE(), _PM())
+    signal = Signal(action='BUY', symbol='NFO:NIFTY26MAY23750PE', quantity=1, confidence=0.8, metadata={'role': 'context', 'trigger_block_reason': 'score_below_live_trigger_min'})
+    vote = StrategyVote(strategy='OrderFlow', side='PE', confidence=0.8, score=8.0, metadata={'role': 'context', 'trigger_block_reason': 'score_below_live_trigger_min'})
+    with caplog.at_level(logging.INFO):
+        out = m._combine_strategy_votes(symbol='NFO:NIFTY26MAY23750PE', signals=[(signal, vote)], indicators={})
+    assert out is None
+    assert "context_trigger_details" in caplog.text
+    assert "score_below_live_trigger_min" in caplog.text
+
+
+def test_futures_snapshot_derives_slope_and_volume_ratio():
+    st=_S(); ie=_IE(); m=StrategyManager([st], ie, _PM())
+    ie.payload={'vwap':100,'close':100,'volume':1000,'avg_volume':1000}
+    m.generate_signal('NFO:NIFTY26MAYFUT',100)
+    ie.payload={'vwap':101,'close':102,'volume':2000,'avg_volume':1000}
+    m.generate_signal('NFO:NIFTY26MAYFUT',102)
+    snap = m._latest_context_snapshots.get('futures_context', {})
+    assert float(snap.get('futures_volume_ratio') or 0.0) == 2.0
+    assert float(snap.get('vwap_slope') or 0.0) > 0.0

--- a/tests/core/test_strategy_manager_no_trigger_diagnostics.py
+++ b/tests/core/test_strategy_manager_no_trigger_diagnostics.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import logging
+
+from nifty_scalper_bot.core.strategy_manager import StrategyManager
+from nifty_scalper_bot.core.strategy_manager import StrategyVote
+from nifty_scalper_bot.strategies.signal_generator import Signal
+
+
+class _IE:
+    def get_history(self, symbol: str):
+        return [1] * 30
+
+    def get_indicators(self, symbol: str, names):
+        return {}
+
+
+class _PM:
+    def get_position(self, symbol: str):
+        return None
+
+
+def test_no_trigger_vote_logs_context_trigger_details(caplog):
+    m = StrategyManager([], _IE(), _PM())
+    signal = Signal(action='BUY', symbol='NFO:NIFTY26MAY23750PE', quantity=8.0, confidence=0.8, metadata={'role': 'context', 'trigger_block_reason': 'negative_premium_flow'})
+    vote = StrategyVote(strategy='OrderFlow', side='PE', confidence=0.8, score=8.0, metadata={'role': 'context', 'trigger_block_reason': 'negative_premium_flow'})
+    with caplog.at_level(logging.INFO):
+        out = m._combine_strategy_votes(symbol='NFO:NIFTY26MAY23750PE', signals=[(signal, vote)], indicators={})
+    assert out is None
+    assert 'blocked_at=no_trigger_vote' in caplog.text
+    assert 'context_trigger_details' in caplog.text
+    assert 'negative_premium_flow' in caplog.text
+
+
+def test_context_promotion_live_default_false(monkeypatch):
+    monkeypatch.setenv('EXECUTION_MODE', 'LIVE')
+    monkeypatch.delenv('STRATEGY_CONTEXT_PROMOTION_LIVE_ALLOWED', raising=False)
+    m = StrategyManager([], _IE(), _PM())
+    profile = m.get_strategy_mode_profile()
+    assert profile['allow_context_promotion'] is False
+
+
+def test_context_promotion_live_can_be_enabled_explicitly(monkeypatch):
+    monkeypatch.setenv('EXECUTION_MODE', 'LIVE')
+    monkeypatch.setenv('STRATEGY_CONTEXT_PROMOTION_LIVE_ALLOWED', 'true')
+    m = StrategyManager([], _IE(), _PM())
+    profile = m.get_strategy_mode_profile()
+    assert profile['allow_context_promotion'] is True

--- a/tests/execution/test_order_manager_idempotency.py
+++ b/tests/execution/test_order_manager_idempotency.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timezone
+from types import SimpleNamespace
 
 from nifty_scalper_bot.execution.order_manager import OrderManager, OrderType
 
@@ -65,3 +66,14 @@ def test_timestamp_seconds_variants():
     assert OrderManager._timestamp_seconds(now) > 0
     assert OrderManager._timestamp_seconds('2026-05-19T10:00:00Z') > 0
     assert OrderManager._timestamp_seconds('bad-ts') == 0.0
+
+
+def test_place_order_fast_fill_bracket_without_trailing_fields_does_not_raise(monkeypatch):
+    om = _om('ok')
+    monkeypatch.setattr(om, '_lot_size_for_symbol', lambda s: 1)
+    monkeypatch.setattr(om, '_validate_live_execution_safety', lambda: True)
+    monkeypatch.setattr(om, '_confirm_fill_fast', lambda order_id, timeout_ms=300: True)
+    om._bracket_manager = SimpleNamespace(
+        get_bracket=lambda order_id: SimpleNamespace(entry_price=100.0, virtual_sl_id="SL1")
+    )
+    assert om.place_order('NFO:NIFTY26MAY23750CE', 'BUY', 1, order_type=OrderType.MARKET, stop_loss=10) == 'OID1'

--- a/tests/strategies/test_vwap_pro_side_domain.py
+++ b/tests/strategies/test_vwap_pro_side_domain.py
@@ -80,3 +80,45 @@ def test_vwap_pro_required_indicators_include_context_fields() -> None:
     required = strategy.get_required_indicators()
     for key in {"underlying_direction_bias","underlying_direction_confidence","context_age_seconds","futures_vwap_slope","futures_volume_ratio","spread_pct","spot_context","futures_context"}:
         assert key in required
+
+
+def test_vwap_pro_flat_futures_slope_is_neutral_not_conflict() -> None:
+    strategy = VWAPProStrategy(config=VWAPProStrategyConfig(), indicator_engine=_DummyEngine())
+    indicators = _base_indicators('CE')
+    indicators.update({'futures_vwap_slope': 0.0, 'futures_volume_ratio': 1.2})
+    signal = strategy._evaluate_signal('NFO:NIFTY26FEB22500CE', indicators, 101.0)
+    assert signal is not None
+    reasons = signal.metadata.get('score_reasons', [])
+    assert 'futures_slope_neutral' in reasons
+    assert 'futures_slope_conflict' not in reasons
+
+
+def test_vwap_pro_opposite_nonzero_futures_slope_conflicts() -> None:
+    strategy = VWAPProStrategy(config=VWAPProStrategyConfig(), indicator_engine=_DummyEngine())
+    indicators = _base_indicators('PE')
+    indicators.update({'futures_vwap_slope': 0.2, 'futures_volume_ratio': 1.2})
+    strategy._evaluate_signal('NFO:NIFTY26FEB22500PE', indicators, 99.0)
+    assert getattr(strategy, 'last_vote_reasons', []) or getattr(strategy, 'last_no_vote_reason', None) is not None
+    reasons = getattr(strategy, 'last_vote_reasons', [])
+    if not reasons:
+        # fallback if no signal
+        reasons = []
+    assert 'futures_slope_conflict' in reasons or getattr(strategy, 'last_no_vote_reason', '') == 'weak_score'
+
+
+def test_vwap_pro_early_trend_pullback_env_gated(monkeypatch) -> None:
+    base = {
+        'vwap': 100.0, 'atr': 5.0, 'close': 99.0, 'open': 101.0, 'high': 101.0, 'low': 99.0,
+        'volume': 1000.0, 'avg_volume': 900.0, 'spread_pct': 2.0, 'direction_bias': 'PE',
+        'underlying_direction_confidence': 0.95, 'context_age_seconds': 1.0, 'futures_vwap_slope': -0.2, 'futures_volume_ratio': 1.5,
+    }
+    strategy_default = VWAPProStrategy(config=VWAPProStrategyConfig(), indicator_engine=_DummyEngine())
+    signal_default = strategy_default._evaluate_signal('NFO:NIFTY26FEB22500PE', dict(base), 99.0)
+    reasons_default = (signal_default.metadata.get('score_reasons', []) if signal_default else [])
+    assert 'early_trend_pullback_context' not in reasons_default
+
+    monkeypatch.setenv('VWAP_PRO_ALLOW_EARLY_TREND_PULLBACK', 'true')
+    strategy_enabled = VWAPProStrategy(config=VWAPProStrategyConfig(), indicator_engine=_DummyEngine())
+    signal_enabled = strategy_enabled._evaluate_signal('NFO:NIFTY26FEB22500PE', dict(base), 99.0)
+    assert signal_enabled is not None
+    assert 'early_trend_pullback_context' in signal_enabled.metadata.get('score_reasons', [])


### PR DESCRIPTION
### Motivation
- Live-market logs showed options being evaluated but no orders were submitted because the combine stage repeatedly ended at `no_trigger_vote` with opaque diagnostics.
- VWAPPro produced repeated `futures_slope_conflict` entries because futures slope/volume indicators were often zero/unavailable, preventing sensible neutrality.
- OrderManager risked an AttributeError after fast-fill when trying to read bracket attributes that are not present on all BracketState representations.

### Description
- Hardened OrderManager trailing attach after fast-fill to use `getattr` with `virtual_sl_id` fallback and to skip attach with a clear debug message when stop/trailing fields are absent, avoiding AttributeError while preserving bracket ownership of trailing logic (`src/.../execution/order_manager.py`).
- Made StrategyManager no-trigger path actionable by adding `context_trigger_details` to `TRADE_DECISION_TRACE` and `STRATEGY_NO_TRIGGER_VOTE` logs so context-only votes surface `trigger_block_reason` and quote/age/spread diagnostics (`src/.../core/strategy_manager.py`).
- Improved option-context diagnostics by including concrete spot/futures direction values, confidence, reasons and core context fields (not only key lists), and derived missing futures indicators (`futures_volume_ratio`, `vwap_slope`, `ema_slope`) from previous snapshots when unavailable, with source metadata for traceability (`src/.../core/strategy_manager.py`).
- Calibrated VWAPPro to treat near-zero/flat futures slope as neutral (env epsilon `VWAP_FUTURES_SLOPE_NEUTRAL_EPS`) and added a conservative, env-gated early trend-pullback scoring hook (disabled by default in LIVE) to reduce false `weak_score` rejections while keeping strict gating (`src/.../strategies/elite_strategies/vwap_pro.py`).
- Added focused regression tests and small test updates covering bracket fast-fill attach compatibility, no-trigger diagnostics, futures derivation, slope neutrality, and early-trend gating (`tests/execution/test_order_manager_idempotency.py`, `tests/core/test_strategy_manager_context_to_option_propagation.py`, `tests/core/test_strategy_manager_no_trigger_diagnostics.py`, `tests/strategies/test_vwap_pro_side_domain.py`).

### Testing
- Ran `python -m compileall -q src tests` with no compile errors.
- Executed the targeted pytest matrix including: `tests/execution/test_order_manager_idempotency.py`, `tests/execution/test_bracket_manager_state.py`, `tests/core/test_strategy_manager_context_to_option_propagation.py`, `tests/core/test_strategy_manager_no_trigger_diagnostics.py`, `tests/strategies/test_vwap_pro_side_domain.py`, `tests/strategies/test_elite_no_vote_reasons.py`, `tests/strategies/test_runner_same_bar_skip_diagnostics.py`, `tests/execution/test_order_manager_timeout_reconcile.py`, `tests/execution/test_execution_policy.py`, and `tests/test_order_executor.py`; all tests passed (selected matrix: 67 passed).
- Notes: changes are surgical and preserve all execution/risk gates, do not enable live context promotion by default, and do not make OrderFlow context votes trigger trades automatically; regression risks were mitigated via the added focused tests and by avoiding broad interface or architecture changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d3d9ff63083248590b9a8df973c4d)