### PR TITLE
Fix spot context hydration sync and OrderFlow trigger diagnostics

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -8625,8 +8625,8 @@ async def startup_sequence(ctx: BotContext) -> None:
                         canonical_sym,
                         mdm_history_count,
                         runner_history_count,
-                        bool(mdm_history_count == runner_history_count),
-                        extra={"event": "RUNNER_HISTORY_CONSISTENCY", "symbol": canonical_sym, "mdm_bars": mdm_history_count, "indicator_bars": runner_history_count, "consistent": bool(mdm_history_count == runner_history_count)},
+                        bool(runner_history_count >= required_bars and mdm_history_count >= required_bars),
+                        extra={"event": "RUNNER_HISTORY_CONSISTENCY", "symbol": canonical_sym, "mdm_bars": mdm_history_count, "indicator_bars": runner_history_count, "consistent": bool(runner_history_count >= required_bars and mdm_history_count >= required_bars)},
                     )
                     LOGGER.info(
                         "RUNNER_HISTORY_INGESTED symbol=%s token=%s bars_ingested=%d source=%s runner_history_count=%d mdm_history_count=%d",
@@ -8647,7 +8647,11 @@ async def startup_sequence(ctx: BotContext) -> None:
                         },
                     )
                     if canonical_sym == "NSE:NIFTY":
-                        required = int(getattr(ctx.strategy_runner, "_context_required_bars", 0) or 0)
+                        required = int(
+                            getattr(ctx.strategy_runner, "_context_required_bars", 0)
+                            or getattr(ctx.strategy_runner, "_required_candles", 0)
+                            or 50
+                        )
                         if mdm_history_count >= required and runner_history_count < required:
                             runner_before = runner_history_count
                             ctx.strategy_runner._indicator_engine.replace_history(canonical_sym, mdm_bars, source="startup_hydration", min_bars=required)
@@ -8679,9 +8683,9 @@ async def startup_sequence(ctx: BotContext) -> None:
                             },
                         )
                 if ctx.market_data_manager:
-                    bars_snapshot = ctx.market_data_manager.get_ohlc_bars(sym)
+                    bars_snapshot = ctx.market_data_manager.get_ohlc_bars(canonical_sym)
                     ctx.market_data_manager.update_hydration_status(
-                        sym, bars_snapshot or records
+                        canonical_sym, bars_snapshot or records
                     )
 
             LOGGER.info(

--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -3788,6 +3788,23 @@ def initialize_components(settings: Settings | None = None) -> BotContext:
         fingerprint["release"],
         extra={"event": "startup_fingerprint", **fingerprint},
     )
+    effective_mode = str(os.getenv("EXECUTION_MODE", "PAPER")).strip().upper()
+    live_enabled = _is_live_execution_mode(effective_mode) or str(os.getenv("ENABLE_LIVE_TRADING", "false")).strip().lower() in {"1", "true", "yes", "on"}
+    LOGGER.info(
+        "BOT_INSTANCE_FINGERPRINT deployment_id=%s replica_id=%s commit_sha=%s live_execution=%s",
+        str(os.getenv("RAILWAY_DEPLOYMENT_ID", "")).strip() or "unknown",
+        str(os.getenv("RAILWAY_REPLICA_ID", "")).strip() or "unknown",
+        str(os.getenv("RAILWAY_GIT_COMMIT_SHA", "")).strip() or fingerprint["release"],
+        bool(live_enabled),
+        extra={
+            "event": "BOT_INSTANCE_FINGERPRINT",
+            "deployment_id": str(os.getenv("RAILWAY_DEPLOYMENT_ID", "")).strip() or "unknown",
+            "replica_id": str(os.getenv("RAILWAY_REPLICA_ID", "")).strip() or "unknown",
+            "commit_sha": str(os.getenv("RAILWAY_GIT_COMMIT_SHA", "")).strip() or fingerprint["release"],
+            "live_execution": bool(live_enabled),
+        },
+    )
+    _enforce_live_single_replica_safety(is_live_execution=bool(live_enabled))
     config = settings.app
     raw_ws_disabled = os.getenv("WEBSOCKET__DISABLED")
     if raw_ws_disabled is None:
@@ -6192,6 +6209,34 @@ def _allow_synthetic_market_data() -> bool:
     return flag in {"1", "true", "yes", "on"}
 
 
+def _enforce_live_single_replica_safety(*, is_live_execution: bool) -> None:
+    """Warn/fail-fast when multiple live replicas/workers are configured."""
+    replica_count_raw = str(os.getenv("RAILWAY_REPLICA_COUNT", "")).strip()
+    worker_raw = (
+        str(os.getenv("WEB_CONCURRENCY", "")).strip()
+        or str(os.getenv("GUNICORN_WORKERS", "")).strip()
+    )
+    replica_count = int(replica_count_raw) if replica_count_raw.isdigit() else 0
+    workers = int(worker_raw) if worker_raw.isdigit() else 0
+    multi_runner = max(replica_count, workers) > 1
+    if not is_live_execution or not multi_runner:
+        return
+    LOGGER.warning(
+        "LIVE_EXECUTION_MULTI_REPLICA_RISK replicas=%s workers=%s reason=single_live_runner_required",
+        replica_count_raw or "unknown",
+        worker_raw or "unknown",
+        extra={
+            "event": "LIVE_EXECUTION_MULTI_REPLICA_RISK",
+            "replicas": replica_count_raw or "unknown",
+            "workers": worker_raw or "unknown",
+            "reason": "single_live_runner_required",
+        },
+    )
+    fail_fast = str(os.getenv("BOT_FAIL_FAST_ON_MULTI_REPLICA_LIVE", "false")).strip().lower() in {"1", "true", "yes", "on"}
+    if fail_fast:
+        raise RuntimeError("Multiple live trading replicas are unsafe")
+
+
 def _coerce_spot_price(tick: Mapping[str, Any] | None) -> float | None:
     """Pull a positive spot price out of an MDM tick payload."""
 
@@ -8553,34 +8598,39 @@ async def startup_sequence(ctx: BotContext) -> None:
                     sym_token = active_symbol_tokens.get(sym)
                 except Exception:
                     sym_token = None
-                mdm_bars = list(ctx.market_data_manager.get_ohlc_bars(sym, limit=hydration_max_bars) or [])
+                canonical_sym = canonical(sym)
+                mdm_bars = list(ctx.market_data_manager.get_ohlc_bars(canonical_sym, limit=hydration_max_bars) or [])
                 count = len(mdm_bars)
                 runner_ingested = 0
-                for bar in mdm_bars:
-                    if getattr(ctx, "strategy_runner", None) is not None and hasattr(ctx.strategy_runner, "ingest_historical_bar"):
-                        try:
-                            ctx.strategy_runner.ingest_historical_bar({**dict(bar), "symbol": sym})
-                            runner_ingested += 1
-                        except Exception as runner_ingest_exc:
-                            LOGGER.warning("startup_runner_hydration_ingest_failed symbol=%s err=%s",sym,runner_ingest_exc)
+                runner_history_count = 0
+                if getattr(ctx, "strategy_runner", None) is not None:
+                    required_bars = int(getattr(ctx.strategy_runner, "_context_required_bars", 0) or getattr(ctx.strategy_runner, "_required_candles", 0) or 50)
+                    try:
+                        ctx.strategy_runner._indicator_engine.replace_history(canonical_sym, mdm_bars, source="startup_hydration", min_bars=required_bars)
+                        runner_ingested = len(mdm_bars)
+                        runner_history_count = ctx.strategy_runner._indicator_engine.history_count(canonical_sym)
+                    except Exception as runner_ingest_exc:
+                        LOGGER.warning("startup_runner_hydration_replace_failed symbol=%s err=%s", canonical_sym, runner_ingest_exc)
                 LOGGER.info("RUNNER_MDM_HYDRATION_SYNC symbol=%s mdm_bars=%d runner_ingested=%d", sym, count, runner_ingested,extra={"event":"RUNNER_MDM_HYDRATION_SYNC","symbol":sym,"mdm_bars":count,"runner_ingested":runner_ingested})
                 hydrated_counts[sym] = count
                 LOGGER.info(f"✅ Hydrated {sym}: {count} bars")
                 if getattr(ctx, "strategy_runner", None) is not None:
-                    try:
-                        runner_history_count = len(
-                            ctx.strategy_runner._indicator_engine.get_history(sym) or []
-                        )
-                    except Exception:
-                        runner_history_count = 0
                     mdm_history_count = 0
                     if ctx.market_data_manager is not None:
                         mdm_history_count = len(
-                            ctx.market_data_manager.get_ohlc_bars(sym) or []
+                            ctx.market_data_manager.get_ohlc_bars(canonical_sym) or []
                         )
                     LOGGER.info(
+                        "RUNNER_HISTORY_CONSISTENCY symbol=%s mdm_bars=%d indicator_bars=%d consistent=%s",
+                        canonical_sym,
+                        mdm_history_count,
+                        runner_history_count,
+                        bool(mdm_history_count == runner_history_count),
+                        extra={"event": "RUNNER_HISTORY_CONSISTENCY", "symbol": canonical_sym, "mdm_bars": mdm_history_count, "indicator_bars": runner_history_count, "consistent": bool(mdm_history_count == runner_history_count)},
+                    )
+                    LOGGER.info(
                         "RUNNER_HISTORY_INGESTED symbol=%s token=%s bars_ingested=%d source=%s runner_history_count=%d mdm_history_count=%d",
-                        sym,
+                        canonical_sym,
                         sym_token,
                         runner_ingested,
                         "startup_hydration",
@@ -8596,8 +8646,19 @@ async def startup_sequence(ctx: BotContext) -> None:
                             "mdm_history_count": mdm_history_count,
                         },
                     )
-                    if sym == "NSE:NIFTY":
+                    if canonical_sym == "NSE:NIFTY":
                         required = int(getattr(ctx.strategy_runner, "_context_required_bars", 0) or 0)
+                        if mdm_history_count >= required and runner_history_count < required:
+                            runner_before = runner_history_count
+                            ctx.strategy_runner._indicator_engine.replace_history(canonical_sym, mdm_bars, source="startup_hydration", min_bars=required)
+                            runner_history_count = ctx.strategy_runner._indicator_engine.history_count(canonical_sym)
+                            LOGGER.info(
+                                "SPOT_CONTEXT_HISTORY_RESEEDED symbol=NSE:NIFTY mdm_bars=%d runner_before=%d runner_after=%d success=%s",
+                                mdm_history_count,
+                                runner_before,
+                                runner_history_count,
+                                bool(runner_history_count >= required),
+                            )
                         success = runner_history_count >= required and mdm_history_count >= required
                         reason = "hydrated" if success else "insufficient_bars_after_hydration"
                         LOGGER.info(

--- a/src/nifty_scalper_bot/core/strategy_manager.py
+++ b/src/nifty_scalper_bot/core/strategy_manager.py
@@ -2563,6 +2563,20 @@ class StrategyManager(_BaseStrategyManager):
             else:
                 log_throttled(
                     log,
+                    f"option_underlying_context_missing:{symbol}",
+                    "OPTION_UNDERLYING_CONTEXT_MISSING symbol=%s spot_ctx_present=%s futures_ctx_present=%s spot_ctx_age=%s futures_ctx_age=%s selected_ce=%s selected_pe=%s",
+                    symbol,
+                    bool(spot_ctx),
+                    bool(fut_ctx),
+                    (now_ts - float(spot_ctx.get("timestamp", now_ts))) if spot_ctx else None,
+                    (now_ts - float(fut_ctx.get("timestamp", now_ts))) if fut_ctx else None,
+                    indicators.get("selected_ce"),
+                    indicators.get("selected_pe"),
+                    interval_sec=30.0,
+                    level=logging.INFO,
+                )
+                log_throttled(
+                    log,
                     f"option_context_missing_direction_bias:{symbol}",
                     "OPTION_CONTEXT_MISSING_DIRECTION_BIAS symbol=%s spot_fresh=%s fut_fresh=%s spot_direction_valid=%s fut_direction_valid=%s",
                     symbol,

--- a/src/nifty_scalper_bot/strategies/elite_strategies/order_flow.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/order_flow.py
@@ -177,6 +177,10 @@ class OrderFlowStrategy(EliteStrategy):
 
             side_aligns = direction in {'CE', 'PE'} and direction == side
             side_alignment_ok = direction not in {'CE', 'PE'} or side_aligns
+            tick_direction_missing = tick_direction not in {'UP', 'DOWN', 'BUY', 'SELL'}
+            direction_context_missing = direction not in {'CE', 'PE'}
+            allow_without_direction_live = str(os.getenv('ORDERFLOW_ALLOW_TRIGGER_WITHOUT_DIRECTION_LIVE', 'false')).strip().lower() in {'1', 'true', 'yes', 'on'}
+            direction_context_ok = (direction in {'CE', 'PE'}) or (not is_live_mode) or allow_without_direction_live
             trigger_conditions_met = bool(
                 allow_orderflow_trigger
                 and quote_depth_valid
@@ -187,6 +191,7 @@ class OrderFlowStrategy(EliteStrategy):
                 and strategy_score >= trigger_min_score
                 and spread_pct <= trigger_max_spread_pct
                 and side_alignment_ok
+                and direction_context_ok
                 and tick_supports
                 and tick_age_ms <= max_tick_age_ms
             )
@@ -197,14 +202,18 @@ class OrderFlowStrategy(EliteStrategy):
                 trigger_block_reason = 'quote_depth_missing'
             elif is_live_mode and require_tradable_quote_live and not tradable_quote:
                 trigger_block_reason = 'tradable_quote_false'
-            elif strategy_score < trigger_min_score:
-                trigger_block_reason = 'score_below_live_trigger_min' if is_live_mode else 'score_below_trigger_min'
-            elif spread_pct > trigger_max_spread_pct:
-                trigger_block_reason = 'spread_too_wide'
             elif tick_age_ms > max_tick_age_ms:
                 trigger_block_reason = 'tick_stale'
+            elif tick_direction_missing:
+                trigger_block_reason = 'tick_direction_missing_or_neutral'
+            elif not direction_context_ok:
+                trigger_block_reason = 'direction_context_missing_live'
             elif not side_alignment_ok:
                 trigger_block_reason = 'direction_bias_conflict'
+            elif spread_pct > trigger_max_spread_pct:
+                trigger_block_reason = 'spread_too_wide'
+            elif strategy_score < trigger_min_score:
+                trigger_block_reason = 'score_below_live_trigger_min' if is_live_mode else 'score_below_trigger_min'
             elif not tick_supports:
                 trigger_block_reason = 'negative_premium_flow'
 
@@ -220,6 +229,8 @@ class OrderFlowStrategy(EliteStrategy):
                 'premium_target_rr': 1.8, 'can_trigger': bool(trigger_conditions_met), 'trigger_min_score': trigger_min_score,
                 'trigger_max_spread_pct': trigger_max_spread_pct, 'trigger_conditions_met': trigger_conditions_met,
                 'trigger_block_reason': trigger_block_reason, 'quote_depth_valid': bool(quote_depth_valid),
+                'tick_direction_missing': tick_direction_missing, 'direction_context_missing': direction_context_missing,
+                'direction_context_ok': direction_context_ok,
                 'trigger_eligible': bool(trigger_conditions_met),
                 'trigger_disqualified_by': trigger_block_reason or None,
                 'liquidity_score': 2.0 if spread_pct <= 12.0 else 0.5,

--- a/src/nifty_scalper_bot/strategies/indicators.py
+++ b/src/nifty_scalper_bot/strategies/indicators.py
@@ -666,6 +666,21 @@ class IndicatorEngine:
             context = self._runtime_context.get(symbol, {})
             for key, value in context.items():
                 requested.setdefault(key, value)
+            if "tick_direction" in all_names or "tick_direction" in requested:
+                runtime_tick = str(context.get("tick_direction") or "").upper()
+                if runtime_tick:
+                    requested["tick_direction"] = runtime_tick
+                    requested["tick_direction_source"] = "runtime_context"
+                elif history is not None:
+                    closes = history.get_closes(2)
+                    if len(closes) >= 2:
+                        if closes[-1] > closes[-2]:
+                            requested["tick_direction"] = "UP"
+                        elif closes[-1] < closes[-2]:
+                            requested["tick_direction"] = "DOWN"
+                        else:
+                            requested["tick_direction"] = "FLAT"
+                        requested["tick_direction_source"] = "history_close_delta"
             return requested
         except Exception as e:
             LOGGER.error(

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -2973,7 +2973,7 @@ class StrategyRunner:
         for _sym in symbols:
             norm_sym = enforce_canonical(normalize_symbol(_sym))
             try:
-                _bc = len(self._indicator_engine.get_history(norm_sym) or [])
+                _bc = int(self._indicator_engine.history_count(norm_sym))
                 _ok = self._indicator_engine.has_min_bars(
                     norm_sym, self._required_candles
                 )

--- a/tests/core/test_spot_context_hydration.py
+++ b/tests/core/test_spot_context_hydration.py
@@ -10,3 +10,14 @@ def test_nifty_token_fallback_present():
 def test_spot_context_hydration_log_present():
     src = open('src/nifty_scalper_bot/core/app.py', encoding='utf-8').read()
     assert 'SPOT_CONTEXT_HYDRATION_RESULT symbol=NSE:NIFTY' in src
+
+
+def test_runner_history_consistency_is_readiness_based():
+    src = open('src/nifty_scalper_bot/core/app.py', encoding='utf-8').read()
+    assert "runner_history_count >= required_bars and mdm_history_count >= required_bars" in src
+
+
+def test_spot_required_falls_back_to_required_candles():
+    src = open('src/nifty_scalper_bot/core/app.py', encoding='utf-8').read()
+    assert 'getattr(ctx.strategy_runner, "_required_candles", 0)' in src
+    assert 'or 50' in src

--- a/tests/core/test_startup_instance_safety.py
+++ b/tests/core/test_startup_instance_safety.py
@@ -1,0 +1,16 @@
+import pytest
+
+from nifty_scalper_bot.core.app import _enforce_live_single_replica_safety
+
+
+def test_live_multi_replica_fail_fast(monkeypatch):
+    monkeypatch.setenv('RAILWAY_REPLICA_COUNT', '2')
+    monkeypatch.setenv('BOT_FAIL_FAST_ON_MULTI_REPLICA_LIVE', 'true')
+    with pytest.raises(RuntimeError, match='Multiple live trading replicas are unsafe'):
+        _enforce_live_single_replica_safety(is_live_execution=True)
+
+
+def test_live_multi_replica_warn_only(monkeypatch):
+    monkeypatch.setenv('RAILWAY_REPLICA_COUNT', '2')
+    monkeypatch.setenv('BOT_FAIL_FAST_ON_MULTI_REPLICA_LIVE', 'false')
+    _enforce_live_single_replica_safety(is_live_execution=True)

--- a/tests/core/test_strategy_manager_context_to_option_propagation.py
+++ b/tests/core/test_strategy_manager_context_to_option_propagation.py
@@ -98,6 +98,15 @@ def test_context_vote_logs_context_trigger_details(caplog):
     assert "score_below_live_trigger_min" in caplog.text
 
 
+def test_option_underlying_context_missing_log(caplog):
+    import logging
+    st=_S(); ie=_IE(); m=StrategyManager([st], ie, _PM())
+    ie.payload={'vwap':102,'volume':100,'avg_volume':100}
+    with caplog.at_level(logging.INFO):
+        m.generate_signal('NFO:NIFTY26MAY23750CE',102)
+    assert "OPTION_UNDERLYING_CONTEXT_MISSING" in caplog.text
+
+
 def test_futures_snapshot_derives_slope_and_volume_ratio():
     st=_S(); ie=_IE(); m=StrategyManager([st], ie, _PM())
     ie.payload={'vwap':100,'close':100,'volume':1000,'avg_volume':1000}

--- a/tests/strategies/test_indicator_tick_direction.py
+++ b/tests/strategies/test_indicator_tick_direction.py
@@ -1,9 +1,22 @@
 from nifty_scalper_bot.strategies.indicators import IndicatorEngine
+from datetime import datetime, timedelta, timezone
 
 
 def _seed(engine, closes):
+    symbol = "NFO:NIFTY26MAY23750CE"
+    base = datetime(2026, 5, 20, 9, 15, tzinfo=timezone.utc)
     for idx, close in enumerate(closes):
-        engine.update_price('NFO:NIFTY26MAY23750CE', close, volume=100, timestamp=idx + 1, open_price=close, high=close, low=close)
+        engine.update_price(
+            symbol,
+            {
+                "open": close,
+                "high": close,
+                "low": close,
+                "close": close,
+            },
+            volume=100,
+            timestamp=base + timedelta(minutes=idx),
+        )
 
 
 def test_tick_direction_derived_from_history():

--- a/tests/strategies/test_indicator_tick_direction.py
+++ b/tests/strategies/test_indicator_tick_direction.py
@@ -1,0 +1,30 @@
+from nifty_scalper_bot.strategies.indicators import IndicatorEngine
+
+
+def _seed(engine, closes):
+    for idx, close in enumerate(closes):
+        engine.update_price('NFO:NIFTY26MAY23750CE', close, volume=100, timestamp=idx + 1, open_price=close, high=close, low=close)
+
+
+def test_tick_direction_derived_from_history():
+    engine = IndicatorEngine()
+    _seed(engine, [100, 101])
+    vals = engine.get_indicators('NFO:NIFTY26MAY23750CE', names={'tick_direction'})
+    assert vals['tick_direction'] == 'UP'
+
+    engine = IndicatorEngine(); _seed(engine, [101, 100])
+    vals = engine.get_indicators('NFO:NIFTY26MAY23750CE', names={'tick_direction'})
+    assert vals['tick_direction'] == 'DOWN'
+
+    engine = IndicatorEngine(); _seed(engine, [100, 100])
+    vals = engine.get_indicators('NFO:NIFTY26MAY23750CE', names={'tick_direction'})
+    assert vals['tick_direction'] == 'FLAT'
+
+
+def test_runtime_tick_direction_preserved():
+    engine = IndicatorEngine()
+    _seed(engine, [100, 101])
+    engine.set_runtime_context('NFO:NIFTY26MAY23750CE', {'tick_direction': 'BUY'})
+    vals = engine.get_indicators('NFO:NIFTY26MAY23750CE', names={'tick_direction'})
+    assert vals['tick_direction'] == 'BUY'
+    assert vals['tick_direction_source'] == 'runtime_context'

--- a/tests/strategies/test_orderflow_context_metadata.py
+++ b/tests/strategies/test_orderflow_context_metadata.py
@@ -41,3 +41,26 @@ def test_orderflow_trigger_role(monkeypatch) -> None:
     assert signal is not None
     assert signal.metadata['role'] == 'trigger'
     assert signal.metadata['can_trigger'] is True
+
+
+def test_orderflow_missing_tick_direction_reports_reason(monkeypatch) -> None:
+    monkeypatch.setenv('ORDERFLOW_ALLOW_TRIGGER_ROLE', 'true')
+    strategy = OrderFlowStrategy(OrderFlowStrategyConfig(), _Dummy())
+    inds = _indicators()
+    inds['tick_direction'] = ''
+    signal = strategy._evaluate_signal('NFO:NIFTY26FEB22500CE', inds, 100.5)
+    assert signal is not None
+    assert signal.metadata['role'] == 'context'
+    assert signal.metadata['trigger_block_reason'] == 'tick_direction_missing_or_neutral'
+
+
+def test_orderflow_live_requires_direction_context(monkeypatch) -> None:
+    monkeypatch.setenv('ORDERFLOW_ALLOW_TRIGGER_ROLE', 'true')
+    monkeypatch.setenv('EXECUTION_MODE', 'LIVE')
+    strategy = OrderFlowStrategy(OrderFlowStrategyConfig(), _Dummy())
+    inds = _indicators()
+    inds['direction_bias'] = None
+    signal = strategy._evaluate_signal('NFO:NIFTY26FEB22500CE', inds, 100.5)
+    assert signal is not None
+    assert signal.metadata['role'] == 'context'
+    assert signal.metadata['trigger_block_reason'] == 'direction_context_missing_live'


### PR DESCRIPTION
### Motivation
- Startup hydration could leave the StrategyRunner `IndicatorEngine` out-of-sync with the MarketDataManager (MDM), producing logs like `mdm_bars=301 runner_bars=1` and preventing warmup even though MDM had full history.
- OrderFlow was reporting `score_below_live_trigger_min` while the real blockers were missing `tick_direction` and missing underlying direction context, hiding the true root cause in diagnostics.
- Some deployments showed multiple replicas live which risks duplicated live execution without an explicit warning; add instance fingerprinting and a safety check.
- The change must be strictly data/diagnostic-focused and must not weaken execution/risk gates or enable spot/futures trading.

### Description
- Hydration sync and consistency: updated `src/nifty_scalper_bot/core/app.py` to canonicalize symbols and call `IndicatorEngine.replace_history(symbol, bars, source="startup_hydration", min_bars=...)`, added `RUNNER_HISTORY_CONSISTENCY` and `SPOT_CONTEXT_HISTORY_RESEEDED` logs, and corrected `SPOT_CONTEXT_HYDRATION_RESULT` to read counts from the same indicator engine object. (`app.py`)
- Warmup reporting: changed warmup summary in `src/nifty_scalper_bot/strategies/runner.py` to use `IndicatorEngine.history_count(...)` so reported bar counts reflect the live indicator engine. (`runner.py`)
- Safe tick-direction derivation: added a fallback in `IndicatorEngine.get_indicators()` to derive `tick_direction` from the last two closes when runtime `tick_direction` is absent, preserving runtime-provided `tick_direction` when present and adding `tick_direction_source`. (`src/nifty_scalper_bot/strategies/indicators.py`)
- OrderFlow diagnostics: in `src/nifty_scalper_bot/strategies/elite_strategies/order_flow.py` added `tick_direction_missing`, `direction_context_missing`, and `direction_context_ok` checks, required direction-context for live triggers by default (opt-out via `ORDERFLOW_ALLOW_TRIGGER_WITHOUT_DIRECTION_LIVE`), and reordered `trigger_block_reason` priority to surface the true missing-data blocker before score-based reasons. No trigger thresholds or gates were loosened. (`order_flow.py`)
- StrategyManager diagnostics: added `OPTION_UNDERLYING_CONTEXT_MISSING` diagnostic when an option evaluation lacks usable spot/futures context while leaving decision logic unchanged. (`src/nifty_scalper_bot/core/strategy_manager.py`)
- Deployment safety: added `BOT_INSTANCE_FINGERPRINT` startup log and `_enforce_live_single_replica_safety()` to warn (or fail fast with `BOT_FAIL_FAST_ON_MULTI_REPLICA_LIVE=true`) if multiple replicas/workers are configured while live execution is enabled. (`src/nifty_scalper_bot/core/app.py`)
- Tests added/updated: `tests/strategies/test_indicator_tick_direction.py`, `tests/core/test_startup_instance_safety.py`, extended `tests/strategies/test_orderflow_context_metadata.py`, and extended `tests/core/test_strategy_manager_context_to_option_propagation.py` to cover the new behaviors.
- Preserved all execution and risk safeguards; no changes to order placement, trade forcing, or tradable-instrument policy.

### Testing
- Static/compile checks: ran `python -m compileall -q src tests` and it completed successfully.
- Focused unit tests run via pytest: `pytest -q tests/core/test_spot_context_hydration.py tests/strategies/test_indicator_tick_direction.py tests/strategies/test_orderflow_context_metadata.py tests/core/test_strategy_manager_context_to_option_propagation.py tests/core/test_strategy_manager_no_trigger_diagnostics.py tests/core/test_startup_instance_safety.py tests/strategies/test_runner_same_bar_skip_diagnostics.py tests/strategies/test_vwap_pro_side_domain.py tests/execution/test_order_manager_timeout_reconcile.py tests/execution/test_execution_policy.py tests/test_order_executor.py` and all listed tests passed.
- Runtime note: the uploaded log which motivated this fix was from after market close so no live orders should have been attempted; in the observed run no `ORDER_SUBMIT_ATTEMPT` occurred and execution/risk gates stayed intact.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d888355f88324a541f1e80ad92fa6)