### PR TITLE
Tighten live-instance safety and canonical hydration diagnostics

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -3788,8 +3788,7 @@ def initialize_components(settings: Settings | None = None) -> BotContext:
         fingerprint["release"],
         extra={"event": "startup_fingerprint", **fingerprint},
     )
-    effective_mode = str(os.getenv("EXECUTION_MODE", "PAPER")).strip().upper()
-    live_enabled = _is_live_execution_mode(effective_mode) or str(os.getenv("ENABLE_LIVE_TRADING", "false")).strip().lower() in {"1", "true", "yes", "on"}
+    live_enabled = _compute_live_execution_enabled()
     LOGGER.info(
         "BOT_INSTANCE_FINGERPRINT deployment_id=%s replica_id=%s commit_sha=%s live_execution=%s",
         str(os.getenv("RAILWAY_DEPLOYMENT_ID", "")).strip() or "unknown",
@@ -6237,6 +6236,17 @@ def _enforce_live_single_replica_safety(*, is_live_execution: bool) -> None:
         raise RuntimeError("Multiple live trading replicas are unsafe")
 
 
+def _compute_live_execution_enabled() -> bool:
+    """Compute whether this instance should be treated as live-execution capable."""
+    truthy = {"1", "true", "yes", "on", "live"}
+    effective_mode = str(os.getenv("EXECUTION_MODE", "PAPER")).strip().upper()
+    return (
+        _is_live_execution_mode(effective_mode)
+        or str(os.getenv("ENABLE_LIVE_TRADING", "false")).strip().lower() in truthy
+        or str(os.getenv("ENABLE_LIVE", "false")).strip().lower() in truthy
+    )
+
+
 def _coerce_spot_price(tick: Mapping[str, Any] | None) -> float | None:
     """Pull a positive spot price out of an MDM tick payload."""
 
@@ -8611,8 +8621,8 @@ async def startup_sequence(ctx: BotContext) -> None:
                         runner_history_count = ctx.strategy_runner._indicator_engine.history_count(canonical_sym)
                     except Exception as runner_ingest_exc:
                         LOGGER.warning("startup_runner_hydration_replace_failed symbol=%s err=%s", canonical_sym, runner_ingest_exc)
-                LOGGER.info("RUNNER_MDM_HYDRATION_SYNC symbol=%s mdm_bars=%d runner_ingested=%d", sym, count, runner_ingested,extra={"event":"RUNNER_MDM_HYDRATION_SYNC","symbol":sym,"mdm_bars":count,"runner_ingested":runner_ingested})
-                hydrated_counts[sym] = count
+                LOGGER.info("RUNNER_MDM_HYDRATION_SYNC symbol=%s mdm_bars=%d runner_ingested=%d", canonical_sym, count, runner_ingested,extra={"event":"RUNNER_MDM_HYDRATION_SYNC","symbol":canonical_sym,"mdm_bars":count,"runner_ingested":runner_ingested})
+                hydrated_counts[canonical_sym] = count
                 LOGGER.info(f"✅ Hydrated {sym}: {count} bars")
                 if getattr(ctx, "strategy_runner", None) is not None:
                     mdm_history_count = 0
@@ -8638,7 +8648,7 @@ async def startup_sequence(ctx: BotContext) -> None:
                         mdm_history_count,
                         extra={
                             "event": "RUNNER_HISTORY_INGESTED",
-                            "symbol": sym,
+                            "symbol": canonical_sym,
                             "token": sym_token,
                             "bars_ingested": runner_ingested,
                             "source": "startup_hydration",

--- a/tests/core/test_spot_context_hydration.py
+++ b/tests/core/test_spot_context_hydration.py
@@ -21,3 +21,11 @@ def test_spot_required_falls_back_to_required_candles():
     src = open('src/nifty_scalper_bot/core/app.py', encoding='utf-8').read()
     assert 'getattr(ctx.strategy_runner, "_required_candles", 0)' in src
     assert 'or 50' in src
+
+
+def test_hydration_diagnostics_use_canonical_symbol():
+    src = open('src/nifty_scalper_bot/core/app.py', encoding='utf-8').read()
+    assert "hydrated_counts[canonical_sym] = count" in src
+    assert '"RUNNER_MDM_HYDRATION_SYNC symbol=%s mdm_bars=%d runner_ingested=%d", canonical_sym' in src
+    assert '"event": "RUNNER_HISTORY_INGESTED"' in src
+    assert '"symbol": canonical_sym' in src

--- a/tests/core/test_startup_instance_safety.py
+++ b/tests/core/test_startup_instance_safety.py
@@ -1,6 +1,9 @@
 import pytest
 
-from nifty_scalper_bot.core.app import _enforce_live_single_replica_safety
+from nifty_scalper_bot.core.app import (
+    _compute_live_execution_enabled,
+    _enforce_live_single_replica_safety,
+)
 
 
 def test_live_multi_replica_fail_fast(monkeypatch):
@@ -14,3 +17,13 @@ def test_live_multi_replica_warn_only(monkeypatch):
     monkeypatch.setenv('RAILWAY_REPLICA_COUNT', '2')
     monkeypatch.setenv('BOT_FAIL_FAST_ON_MULTI_REPLICA_LIVE', 'false')
     _enforce_live_single_replica_safety(is_live_execution=True)
+
+
+def test_enable_live_env_is_treated_as_live_for_replica_safety(monkeypatch):
+    monkeypatch.setenv('EXECUTION_MODE', 'PAPER')
+    monkeypatch.setenv('ENABLE_LIVE', 'true')
+    monkeypatch.setenv('RAILWAY_REPLICA_COUNT', '2')
+    monkeypatch.setenv('BOT_FAIL_FAST_ON_MULTI_REPLICA_LIVE', 'true')
+    assert _compute_live_execution_enabled() is True
+    with pytest.raises(RuntimeError, match='Multiple live trading replicas are unsafe'):
+        _enforce_live_single_replica_safety(is_live_execution=True)


### PR DESCRIPTION
### Motivation
- After PR #448, live-instance safety could be bypassed when `ENABLE_LIVE` was set because startup only considered `EXECUTION_MODE` and `ENABLE_LIVE_TRADING`.  This change centralizes live-detection to include `ENABLE_LIVE` for consistent multi-replica safety enforcement. 
- Hydration diagnostics mixed raw and canonical symbols which produced inconsistent telemetry keys/extra fields for the same instrument, reducing observability of hydration/runner ingestion state. 

### Description
- Added `_compute_live_execution_enabled()` in `src/nifty_scalper_bot/core/app.py` to centralize live-execution detection from `EXECUTION_MODE`, `ENABLE_LIVE_TRADING`, and `ENABLE_LIVE`, and wired startup to use it before `_enforce_live_single_replica_safety()` is invoked. 
- Canonicalized hydration diagnostics in `src/nifty_scalper_bot/core/app.py` by using `canonical_sym` for `RUNNER_MDM_HYDRATION_SYNC`, `hydrated_counts` keys, and the `RUNNER_HISTORY_INGESTED` log `extra["symbol"]` without changing hydration behavior. 
- Added a test in `tests/core/test_startup_instance_safety.py` to assert that `ENABLE_LIVE=true` with `EXECUTION_MODE=PAPER` is treated as live and still triggers multi-replica fail-fast behavior. 
- Extended `tests/core/test_spot_context_hydration.py` to assert the presence of canonical-symbol usage in the hydration diagnostics source. 

### Testing
- Ran compilation with `python -m compileall -q src tests` and the command completed successfully. 
- Ran focused tests with `pytest -q` for the requested matrix and the following suites passed: `tests/core/test_startup_instance_safety.py`, `tests/core/test_spot_context_hydration.py`, `tests/strategies/test_indicator_tick_direction.py`, `tests/strategies/test_orderflow_context_metadata.py`, `tests/core/test_strategy_manager_context_to_option_propagation.py`, `tests/execution/test_order_manager_timeout_reconcile.py`, and `tests/test_order_executor.py`. 
- Result: all listed tests passed.

Notes: This PR is strictly safety/observability focused — no strategy thresholds, trading gates, OrderFlow triggers, or order execution logic/behavior were changed, and live context promotion was not enabled.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e628a7798832498855258573a2e93)