### PR TITLE
Make OrderManager broker submission compatible with kwargs and payload adapters and add tests

### DIFF
--- a/src/nifty_scalper_bot/execution/order_manager.py
+++ b/src/nifty_scalper_bot/execution/order_manager.py
@@ -1904,11 +1904,28 @@ class OrderManager:
         normalized = (int(quantity) // lot_size) * lot_size
         return lot_size, normalized
 
+    def _looks_like_signature_type_error(self, exc: TypeError) -> bool:
+        """Return True only for TypeError raised by incompatible call signature."""
+        text = str(exc).lower()
+        signature_markers = (
+            "unexpected keyword argument",
+            "got an unexpected keyword",
+            "missing 1 required positional argument",
+            "missing required positional argument",
+            "takes",
+            "positional argument",
+            "positional arguments",
+            "required keyword-only argument",
+        )
+        return any(marker in text for marker in signature_markers)
+
     def _submit_broker_order(self, call_args: dict[str, Any]) -> Any:
-        """Submit broker order supporting both kwargs and single-payload broker adapters."""
+        """Submit broker order supporting kwargs and single-payload broker adapters safely."""
         try:
             return self._broker.place_order(**call_args)
         except TypeError as kwargs_exc:
+            if not self._looks_like_signature_type_error(kwargs_exc):
+                raise
             try:
                 return self._broker.place_order(dict(call_args))
             except TypeError:

--- a/src/nifty_scalper_bot/execution/order_manager.py
+++ b/src/nifty_scalper_bot/execution/order_manager.py
@@ -1904,6 +1904,16 @@ class OrderManager:
         normalized = (int(quantity) // lot_size) * lot_size
         return lot_size, normalized
 
+    def _submit_broker_order(self, call_args: dict[str, Any]) -> Any:
+        """Submit broker order supporting both kwargs and single-payload broker adapters."""
+        try:
+            return self._broker.place_order(**call_args)
+        except TypeError as kwargs_exc:
+            try:
+                return self._broker.place_order(dict(call_args))
+            except TypeError:
+                raise kwargs_exc
+
     def place_order(
         self,
         symbol: str,
@@ -2449,7 +2459,7 @@ class OrderManager:
         # Helper for threaded execution
         def _broker_call(kwargs):
             try:
-                return self._broker.place_order(**kwargs)
+                return self._submit_broker_order(kwargs)
             except Exception as exc:
                 return exc
 

--- a/tests/execution/test_order_manager_broker_submit_compat.py
+++ b/tests/execution/test_order_manager_broker_submit_compat.py
@@ -28,6 +28,15 @@ class _PayloadBroker:
         return {"order_id": "OID_PAYLOAD"}
 
 
+class _InternalTypeErrorBroker:
+    def __init__(self):
+        self.calls = 0
+
+    def place_order(self, **kwargs):
+        self.calls += 1
+        raise TypeError("unsupported operand type after broker response")
+
+
 class _RejectBroker:
     def __init__(self):
         self.calls = 0
@@ -57,6 +66,16 @@ def test_submit_broker_order_supports_payload_dict_broker():
     assert broker.payloads == [{"symbol": "NFO:NIFTY", "quantity": 75}]
 
 
+def test_signature_type_error_allows_payload_fallback():
+    broker = _PayloadBroker()
+    om = OrderManager(broker, _Pos(), _Limiter())
+
+    result = om._submit_broker_order({"symbol": "NFO:NIFTY", "quantity": 75})
+
+    assert result["order_id"] == "OID_PAYLOAD"
+    assert broker.payloads == [{"symbol": "NFO:NIFTY", "quantity": 75}]
+
+
 def test_submit_broker_order_does_not_swallow_real_rejection():
     broker = _RejectBroker()
     om = OrderManager(broker, _Pos(), _Limiter())
@@ -67,6 +86,20 @@ def test_submit_broker_order_does_not_swallow_real_rejection():
         assert str(exc) == "insufficient margin"
     else:
         raise AssertionError("ValueError should propagate")
+
+    assert broker.calls == 1
+
+
+def test_submit_broker_order_does_not_fallback_on_internal_type_error():
+    broker = _InternalTypeErrorBroker()
+    om = OrderManager(broker, _Pos(), _Limiter())
+
+    try:
+        om._submit_broker_order({"symbol": "NFO:NIFTY", "quantity": 75})
+    except TypeError as exc:
+        assert "unsupported operand type" in str(exc)
+    else:
+        raise AssertionError("internal TypeError should propagate")
 
     assert broker.calls == 1
 

--- a/tests/execution/test_order_manager_broker_submit_compat.py
+++ b/tests/execution/test_order_manager_broker_submit_compat.py
@@ -1,0 +1,91 @@
+from nifty_scalper_bot.execution.order_manager import OrderManager, OrderType
+
+
+class _Pos:
+    def has_open_position(self, symbol):
+        return False
+
+
+class _Limiter:
+    pass
+
+
+class _KwargsBroker:
+    def __init__(self):
+        self.received = None
+
+    def place_order(self, **kwargs):
+        self.received = kwargs
+        return {"order_id": "OID_KWARGS"}
+
+
+class _PayloadBroker:
+    def __init__(self):
+        self.payloads = []
+
+    def place_order(self, payload):
+        self.payloads.append(payload)
+        return {"order_id": "OID_PAYLOAD"}
+
+
+class _RejectBroker:
+    def __init__(self):
+        self.calls = 0
+
+    def place_order(self, **kwargs):
+        self.calls += 1
+        raise ValueError("insufficient margin")
+
+
+def test_submit_broker_order_supports_kwargs_broker():
+    broker = _KwargsBroker()
+    om = OrderManager(broker, _Pos(), _Limiter())
+
+    result = om._submit_broker_order({"symbol": "NFO:NIFTY", "quantity": 75})
+
+    assert result["order_id"] == "OID_KWARGS"
+    assert broker.received == {"symbol": "NFO:NIFTY", "quantity": 75}
+
+
+def test_submit_broker_order_supports_payload_dict_broker():
+    broker = _PayloadBroker()
+    om = OrderManager(broker, _Pos(), _Limiter())
+
+    result = om._submit_broker_order({"symbol": "NFO:NIFTY", "quantity": 75})
+
+    assert result["order_id"] == "OID_PAYLOAD"
+    assert broker.payloads == [{"symbol": "NFO:NIFTY", "quantity": 75}]
+
+
+def test_submit_broker_order_does_not_swallow_real_rejection():
+    broker = _RejectBroker()
+    om = OrderManager(broker, _Pos(), _Limiter())
+
+    try:
+        om._submit_broker_order({"symbol": "NFO:NIFTY", "quantity": 75})
+    except ValueError as exc:
+        assert str(exc) == "insufficient margin"
+    else:
+        raise AssertionError("ValueError should propagate")
+
+    assert broker.calls == 1
+
+
+def test_place_order_supports_payload_dict_broker(monkeypatch):
+    broker = _PayloadBroker()
+    om = OrderManager(broker, _Pos(), _Limiter())
+    monkeypatch.setattr(om, "_lot_size_for_symbol", lambda s: 1)
+    monkeypatch.setattr(om, "_validate_live_execution_safety", lambda: True)
+    monkeypatch.setattr(om, "_confirm_fill_fast", lambda order_id, timeout_ms=300: False)
+
+    oid = om.place_order(
+        "NFO:NIFTY26MAY23750CE",
+        "BUY",
+        1,
+        order_type=OrderType.MARKET,
+        stop_loss=10,
+        signal_id="compat_case",
+    )
+
+    assert oid == "OID_PAYLOAD"
+    assert broker.payloads, "payload fallback should be used"


### PR DESCRIPTION
### Motivation
- Ensure `OrderManager` can submit orders to broker adapters that accept either keyword-arguments or a single payload dictionary to avoid runtime `TypeError` and improve adapter compatibility.
- Prevent a potential undefined variable by ensuring `call_args` is defined before the execution loop.
- Add unit tests to capture compatibility and exception propagation behavior for different broker adapter styles.

### Description
- Add `_submit_broker_order` which tries `self._broker.place_order(**call_args)` and falls back to `self._broker.place_order(dict(call_args))`, re-raising the original `TypeError` if both attempts fail.
- Replace direct calls to `self._broker.place_order(**kwargs)` inside `place_order` with a call to the new `_submit_broker_order` helper and ensure `call_args` is defined before the execution loop.
- Add `tests/execution/test_order_manager_broker_submit_compat.py` containing tests for kwargs-style brokers, payload-style brokers, propagation of errors from brokers, and integration with `place_order` using monkeypatches.

### Testing
- Ran the new unit tests with `pytest tests/execution/test_order_manager_broker_submit_compat.py -q` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e6a619d9483248783d26c082d41ce)