### PR TITLE
Extend safe entry window to 15:25 and clarify market-hours gating

### DIFF
--- a/src/nifty_scalper_bot/strategies/orchestrator.py
+++ b/src/nifty_scalper_bot/strategies/orchestrator.py
@@ -133,19 +133,28 @@ class StrategyOrchestrator:
         # 🛡️ FIX 1: EARLY TIME GUARD
         # ═══════════════════════════════════════════════════════════
         try:
-            from nifty_scalper_bot.utils.market_hours import is_market_hours_cached
+            from nifty_scalper_bot.utils.market_hours import (
+                get_current_ist_time,
+                get_time_status_cached,
+            )
 
             settings = get_settings()
             if not settings.allow_offmarket_trading:
-                if not is_market_hours_cached():
+                allowed, time_reason = get_time_status_cached()
+                if not allowed:
+                    now_ist = get_current_ist_time()
                     self._logger.warning(
-                        "⛔ BLOCKED: Market hours filter active",
+                        "⛔ BLOCKED: Entry time filter active: %s",
+                        time_reason,
                         extra={
-                            "event": "orchestrator_market_hours_blocked",
+                            "event": "orchestrator_entry_time_blocked",
                             "symbol": symbol,
+                            "time_reason": time_reason,
+                            "now_ist": now_ist.isoformat(),
+                            "allow_offmarket_trading": bool(settings.allow_offmarket_trading),
                         },
                     )
-                    self._set_skip_reason("market_closed")
+                    self._set_skip_reason(time_reason)
                     return None
             else:
                 self._logger.warning(

--- a/src/nifty_scalper_bot/utils/market_hours.py
+++ b/src/nifty_scalper_bot/utils/market_hours.py
@@ -27,10 +27,36 @@ LOGGER = get_logger(__name__)
 IST = ZoneInfo("Asia/Kolkata")
 
 # Market timing constants
-MARKET_OPEN = dtime(9, 15)      # NSE opens
-SAFE_START = dtime(9, 20)       # Avoid opening volatility (was 9:30, now 9:20)
-SAFE_END = dtime(15, 15)        # Stop new entries 15 mins before close
-MARKET_CLOSE = dtime(15, 30)    # NSE closes
+def _env_truthy(name: str) -> bool:
+    return os.getenv(name, "false").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "y",
+        "on",
+    }
+
+
+def _env_time(name: str, default: dtime) -> dtime:
+    raw = os.getenv(name)
+    if not raw:
+        return default
+    try:
+        hour_s, minute_s = raw.strip().split(":", 1)
+        hour = int(hour_s)
+        minute = int(minute_s)
+        if not (0 <= hour <= 23 and 0 <= minute <= 59):
+            return default
+        return dtime(hour, minute)
+    except Exception:
+        return default
+
+
+# Market timing constants
+MARKET_OPEN = _env_time("MARKET_OPEN_TIME", dtime(9, 15))
+SAFE_START = _env_time("SAFE_START_TIME", dtime(9, 20))
+SAFE_END = _env_time("SAFE_END_TIME", dtime(15, 25))
+MARKET_CLOSE = _env_time("MARKET_CLOSE_TIME", dtime(15, 30))
 
 
 class MarketState(Enum):
@@ -50,22 +76,12 @@ def _override_enabled() -> bool:
 def allow_offhours_testing_safe() -> bool:
     """Args: none; Returns: safe off-hours override state; Raises: none."""
     execution_mode = os.getenv("EXECUTION_MODE", "SHADOW").strip().upper()
-    enable_live = os.getenv("ENABLE_LIVE", "false").strip().lower() in {
-        "1",
-        "true",
-        "yes",
-        "on",
-    }
-    if execution_mode == "LIVE" or enable_live:
+    live_enabled = _env_truthy("ENABLE_LIVE") or _env_truthy("ENABLE_LIVE_TRADING")
+    if execution_mode == "LIVE" or live_enabled:
         return False
-    return os.getenv(
-        "ALLOW_OFFHOURS_TESTING", os.getenv("SESSION_ALLOW_OUT_OF_HOURS", "")
-    ).strip().lower() in {
-        "1",
-        "true",
-        "yes",
-        "on",
-    }
+    return _env_truthy("ALLOW_OFFHOURS_TESTING") or _env_truthy(
+        "SESSION_ALLOW_OUT_OF_HOURS"
+    )
 
 
 def _now_ist() -> datetime:
@@ -92,26 +108,29 @@ def get_market_state() -> MarketState:
     return MarketState.CLOSED
 
 
-def is_market_hours(allow_override: bool = True) -> bool:
-    """
-    Check if current time is within safe trading hours.
-    
-    Args:
-        allow_override: If True, checks SESSION_ALLOW_OUT_OF_HOURS env var
-        
-    Returns:
-        True if trading is allowed, False otherwise
-    """
-    # Check environment override for testing
+def is_market_open_session(allow_override: bool = True) -> bool:
     if allow_override and _override_enabled():
         return True
-
     now_dt = _now_ist()
     if now_dt.weekday() >= 5:
         return False
+    now = now_dt.time()
+    return MARKET_OPEN <= now <= MARKET_CLOSE
 
+
+def is_safe_entry_window(allow_override: bool = True) -> bool:
+    if allow_override and _override_enabled():
+        return True
+    now_dt = _now_ist()
+    if now_dt.weekday() >= 5:
+        return False
     now = now_dt.time()
     return SAFE_START <= now <= SAFE_END
+
+
+def is_market_hours(allow_override: bool = True) -> bool:
+    """Backward-compatible alias for safe new-entry window."""
+    return is_safe_entry_window(allow_override=allow_override)
 
 
 def is_market_open() -> bool:
@@ -249,12 +268,12 @@ def get_time_status() -> Tuple[bool, str]:
         return False, f"Opening volatility buffer (Wait until {SAFE_START.strftime('%H:%M')})"
     
     if SAFE_START <= now <= SAFE_END:
-        return True, "Within safe trading window"
-    
+        return True, "Within safe entry window"
+
     if SAFE_END < now <= MARKET_CLOSE:
-        return False, f"EOD safety cutoff (No trades after {SAFE_END.strftime('%H:%M')})"
-    
-    return False, f"Market closed ({now.strftime('%H:%M')} > {MARKET_CLOSE.strftime('%H:%M')})"
+        return False, f"EOD safety cutoff (No new entries after {SAFE_END.strftime('%H:%M')})"
+
+    return False, f"Market closed after {MARKET_CLOSE.strftime('%H:%M')}"
 
 
 def get_current_ist_time() -> datetime:
@@ -274,6 +293,22 @@ def _cached_market_hours_check(minute_key: int, override_flag: str) -> bool:
     return is_market_hours(allow_override=True)
 
 
+@lru_cache(maxsize=128)
+def _cached_time_status_check(minute_key: int, override_flag: str) -> tuple[bool, str]:
+    return get_time_status()
+
+
+def get_time_status_cached() -> tuple[bool, str]:
+    now = datetime.now(IST)
+    minute_key = now.hour * 60 + now.minute
+    override_flag = (
+        os.getenv("SESSION_ALLOW_OUT_OF_HOURS", "").lower()
+        + "|"
+        + os.getenv("ALLOW_OFFHOURS_TESTING", "").lower()
+    )
+    return _cached_time_status_check(minute_key, override_flag)
+
+
 def is_market_hours_cached() -> bool:
     """
     Cached version of is_market_hours for high-frequency tick processing.
@@ -287,10 +322,13 @@ def is_market_hours_cached() -> bool:
 
 __all__ = [
     "is_market_hours",
+    "is_market_open_session",
+    "is_safe_entry_window",
     "is_market_open",
     "is_market_open_now",
     "is_market_hours_cached",
     "get_time_status",
+    "get_time_status_cached",
     "get_current_ist_time",
     "format_time_for_log",
     "get_market_session_state",

--- a/src/nifty_scalper_bot/utils/market_hours.py
+++ b/src/nifty_scalper_bot/utils/market_hours.py
@@ -301,10 +301,18 @@ def _cached_time_status_check(minute_key: int, override_flag: str) -> tuple[bool
 def get_time_status_cached() -> tuple[bool, str]:
     now = datetime.now(IST)
     minute_key = now.hour * 60 + now.minute
-    override_flag = (
-        os.getenv("SESSION_ALLOW_OUT_OF_HOURS", "").lower()
-        + "|"
-        + os.getenv("ALLOW_OFFHOURS_TESTING", "").lower()
+    override_flag = "|".join(
+        [
+            os.getenv("SESSION_ALLOW_OUT_OF_HOURS", "").lower(),
+            os.getenv("ALLOW_OFFHOURS_TESTING", "").lower(),
+            os.getenv("EXECUTION_MODE", "").lower(),
+            os.getenv("ENABLE_LIVE", "").lower(),
+            os.getenv("ENABLE_LIVE_TRADING", "").lower(),
+            os.getenv("SAFE_START_TIME", "").lower(),
+            os.getenv("SAFE_END_TIME", "").lower(),
+            os.getenv("MARKET_OPEN_TIME", "").lower(),
+            os.getenv("MARKET_CLOSE_TIME", "").lower(),
+        ]
     )
     return _cached_time_status_check(minute_key, override_flag)
 
@@ -316,7 +324,19 @@ def is_market_hours_cached() -> bool:
     """
     now = datetime.now(IST)
     minute_key = now.hour * 60 + now.minute
-    override_flag = os.getenv("SESSION_ALLOW_OUT_OF_HOURS", "").lower()
+    override_flag = "|".join(
+        [
+            os.getenv("SESSION_ALLOW_OUT_OF_HOURS", "").lower(),
+            os.getenv("ALLOW_OFFHOURS_TESTING", "").lower(),
+            os.getenv("EXECUTION_MODE", "").lower(),
+            os.getenv("ENABLE_LIVE", "").lower(),
+            os.getenv("ENABLE_LIVE_TRADING", "").lower(),
+            os.getenv("SAFE_START_TIME", "").lower(),
+            os.getenv("SAFE_END_TIME", "").lower(),
+            os.getenv("MARKET_OPEN_TIME", "").lower(),
+            os.getenv("MARKET_CLOSE_TIME", "").lower(),
+        ]
+    )
     return _cached_market_hours_check(minute_key, override_flag)
 
 

--- a/tests/strategies/test_orchestrator.py
+++ b/tests/strategies/test_orchestrator.py
@@ -125,3 +125,26 @@ def test_orchestrator_does_not_set_underlying_cooldown_before_submission() -> No
     second = orchestrator.filter_signal(signal, {}, pos_manager)
     assert first is signal
     assert second is signal
+
+
+def test_orchestrator_sets_detailed_entry_time_skip_reason(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+    monkeypatch.setattr(
+        "nifty_scalper_bot.strategies.orchestrator.get_settings",
+        lambda: SimpleNamespace(allow_offmarket_trading=False),
+    )
+    monkeypatch.setattr(
+        "nifty_scalper_bot.utils.market_hours.get_time_status_cached",
+        lambda: (False, "EOD safety cutoff (No new entries after 15:25)"),
+    )
+
+    risk = _RiskStub(balance=100_000.0)
+    orchestrator = StrategyOrchestrator(risk_manager=risk)
+    signal = _make_signal("unknown")
+    pos_manager = _PositionManagerStub()
+
+    with caplog.at_level("WARNING"):
+        result = orchestrator.filter_signal(signal, {}, pos_manager)
+
+    assert result is None
+    assert "EOD safety cutoff" in orchestrator.get_skip_reason()
+    assert "orchestrator_entry_time_blocked" in caplog.text

--- a/tests/strategies/test_orchestrator.py
+++ b/tests/strategies/test_orchestrator.py
@@ -147,4 +147,9 @@ def test_orchestrator_sets_detailed_entry_time_skip_reason(monkeypatch: pytest.M
 
     assert result is None
     assert "EOD safety cutoff" in orchestrator.get_skip_reason()
-    assert "orchestrator_entry_time_blocked" in caplog.text
+    assert "Entry time filter active" in caplog.text
+    assert "EOD safety cutoff" in caplog.text
+    assert any(
+        getattr(record, "event", None) == "orchestrator_entry_time_blocked"
+        for record in caplog.records
+    )

--- a/tests/utils/test_market_hours.py
+++ b/tests/utils/test_market_hours.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from datetime import datetime
+import importlib
+
+from nifty_scalper_bot.utils import market_hours
+
+
+class _FixedClock(datetime):
+    _fixed: datetime
+
+    @classmethod
+    def now(cls, tz=None):
+        return cls._fixed.astimezone(tz) if tz else cls._fixed
+
+
+def _set_now(monkeypatch, dt: datetime) -> None:
+    _FixedClock._fixed = dt
+    monkeypatch.setattr(market_hours, "datetime", _FixedClock)
+
+
+def _clear_caches() -> None:
+    market_hours._cached_market_hours_check.cache_clear()
+    market_hours._cached_time_status_check.cache_clear()
+
+
+def test_safe_window_1517_true(monkeypatch):
+    _set_now(monkeypatch, datetime(2026, 5, 21, 15, 17, tzinfo=market_hours.IST))
+    _clear_caches()
+    assert market_hours.is_safe_entry_window() is True
+
+
+def test_safe_window_1526_false(monkeypatch):
+    _set_now(monkeypatch, datetime(2026, 5, 21, 15, 26, tzinfo=market_hours.IST))
+    assert market_hours.is_safe_entry_window() is False
+
+
+def test_market_open_session_boundaries(monkeypatch):
+    _set_now(monkeypatch, datetime(2026, 5, 21, 15, 17, tzinfo=market_hours.IST))
+    assert market_hours.is_market_open_session() is True
+    _set_now(monkeypatch, datetime(2026, 5, 21, 15, 31, tzinfo=market_hours.IST))
+    assert market_hours.is_market_open_session() is False
+
+
+def test_open_but_not_safe_at_0916(monkeypatch):
+    _set_now(monkeypatch, datetime(2026, 5, 21, 9, 16, tzinfo=market_hours.IST))
+    assert market_hours.is_market_open_session() is True
+    assert market_hours.is_safe_entry_window() is False
+
+
+def test_safe_at_0921(monkeypatch):
+    _set_now(monkeypatch, datetime(2026, 5, 21, 9, 21, tzinfo=market_hours.IST))
+    assert market_hours.is_safe_entry_window() is True
+
+
+def test_time_status_messages(monkeypatch):
+    _set_now(monkeypatch, datetime(2026, 5, 21, 15, 17, tzinfo=market_hours.IST))
+    allowed, reason = market_hours.get_time_status()
+    assert allowed is True
+    assert reason == "Within safe entry window"
+    _set_now(monkeypatch, datetime(2026, 5, 21, 15, 26, tzinfo=market_hours.IST))
+    allowed, reason = market_hours.get_time_status()
+    assert allowed is False
+    assert "EOD safety cutoff" in reason
+
+
+def test_safe_end_env(monkeypatch):
+    monkeypatch.setenv("SAFE_END_TIME", "15:20")
+    reloaded = importlib.reload(market_hours)
+    monkeypatch.setattr(reloaded, "_now_ist", lambda: datetime(2026, 5, 21, 15, 21, tzinfo=reloaded.IST))
+    assert reloaded.is_safe_entry_window() is False
+
+    monkeypatch.setenv("SAFE_END_TIME", "15:25")
+    reloaded = importlib.reload(reloaded)
+    monkeypatch.setattr(reloaded, "_now_ist", lambda: datetime(2026, 5, 21, 15, 21, tzinfo=reloaded.IST))
+    assert reloaded.is_safe_entry_window() is True
+
+
+def test_live_mode_disables_offhours_override(monkeypatch):
+    monkeypatch.setenv("ALLOW_OFFHOURS_TESTING", "true")
+    monkeypatch.setenv("SESSION_ALLOW_OUT_OF_HOURS", "true")
+    monkeypatch.setenv("EXECUTION_MODE", "LIVE")
+    monkeypatch.setenv("ENABLE_LIVE_TRADING", "true")
+    assert market_hours.allow_offhours_testing_safe() is False

--- a/tests/utils/test_market_hours.py
+++ b/tests/utils/test_market_hours.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from datetime import datetime
 import importlib
 
+import pytest
+
 from nifty_scalper_bot.utils import market_hours
 
 
@@ -20,6 +22,15 @@ def _set_now(monkeypatch, dt: datetime) -> None:
 
 
 def _clear_caches() -> None:
+    market_hours._cached_market_hours_check.cache_clear()
+    market_hours._cached_time_status_check.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _restore_market_hours_module(monkeypatch):
+    yield
+    monkeypatch.delenv("SAFE_END_TIME", raising=False)
+    importlib.reload(market_hours)
     market_hours._cached_market_hours_check.cache_clear()
     market_hours._cached_time_status_check.cache_clear()
 
@@ -82,3 +93,17 @@ def test_live_mode_disables_offhours_override(monkeypatch):
     monkeypatch.setenv("EXECUTION_MODE", "LIVE")
     monkeypatch.setenv("ENABLE_LIVE_TRADING", "true")
     assert market_hours.allow_offhours_testing_safe() is False
+
+
+def test_get_time_status_cached_respects_safe_end_env(monkeypatch):
+    monkeypatch.setenv("SAFE_END_TIME", "15:20")
+    reloaded = importlib.reload(market_hours)
+    monkeypatch.setattr(reloaded, "_now_ist", lambda: datetime(2026, 5, 21, 15, 21, tzinfo=reloaded.IST))
+    reloaded._cached_time_status_check.cache_clear()
+    assert reloaded.get_time_status_cached()[0] is False
+
+    monkeypatch.setenv("SAFE_END_TIME", "15:25")
+    reloaded = importlib.reload(reloaded)
+    monkeypatch.setattr(reloaded, "_now_ist", lambda: datetime(2026, 5, 21, 15, 21, tzinfo=reloaded.IST))
+    reloaded._cached_time_status_check.cache_clear()
+    assert reloaded.get_time_status_cached()[0] is True


### PR DESCRIPTION
### Motivation
- Root cause: `is_market_hours()` in `src/nifty_scalper_bot/utils/market_hours.py` was acting as a safe-entry gate using `SAFE_END=15:15`, causing false "market closed" blocks (e.g. at 15:17 IST) even though the exchange session remained open.
- Intent: allow new entries until 15:25 IST by default, keep the actual market session until 15:30 IST, separate session vs safe-entry concepts, and make off-hours override safe in non-live modes while preventing any override in live mode.

### Description
- `src/nifty_scalper_bot/utils/market_hours.py`: added `_env_truthy()` and `_env_time()` helpers, made `MARKET_OPEN`, `SAFE_START`, `SAFE_END`, and `MARKET_CLOSE` env-configurable, changed default `SAFE_END` to `15:25`, added `is_market_open_session()` and `is_safe_entry_window()` and preserved `is_market_hours()` as a backward-compatible alias to the safe-entry window, hardened `allow_offhours_testing_safe()` to consider `ENABLE_LIVE_TRADING`, improved `get_time_status()` to return clear reasons (including dynamic EOD cutoff text), and added cached `get_time_status_cached()` for high-frequency callers.
- `src/nifty_scalper_bot/strategies/orchestrator.py`: replaced the previous generic `is_market_hours_cached()` check with `get_time_status_cached()`; when blocked the orchestrator now logs `"⛔ BLOCKED: Entry time filter active: %s"` with structured event `orchestrator_entry_time_blocked`, includes `time_reason` and `now_ist` in log context, and sets the skip reason to the precise `time_reason` (e.g. `EOD safety cutoff (No new entries after 15:25)`), while preserving explicit off-market-override logging when enabled.
- Tests: added `tests/utils/test_market_hours.py` covering the required IST boundary cases, `get_time_status` messages, env-driven `SAFE_END_TIME` behavior, and live-mode override safety; added a small orchestrator test in `tests/strategies/test_orchestrator.py` asserting skip-reason and log event when `get_time_status_cached()` reports an EOD cutoff.
- Backwards compatibility: exported new functions in `__all__` and kept `is_market_hours()` alias so existing call sites continue to function as safe-entry checks.

### Testing
- Ran `python -m compileall -q src` — PASS.
- Ran `pytest -q tests/utils/test_market_hours.py` — PASS (tests cover boundary times, status text, env override, and live override safety).
- Attempted `pytest -q tests/strategies/test_runner_entry_mode_resolution_regression.py tests/strategies/test_order_flow.py` but the run failed because `tests/strategies/test_order_flow.py` is not present in the repository (documented as not-found, not related to these changes).
- Full test run `pytest -q` fails on an unrelated existing test: `tests/core/test_readiness_live_tick_proof.py::test_live_orders_armed_with_fresh_ltp_bars_and_tradable_depth` (assertion in that test failed); this failure is unrelated to market-hours logic and reproduced on the current branch.
- Notes: caches used by the new cached functions are cleared in tests where necessary to ensure deterministic behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0edc7f34dc8324a474becbeecf24e0)