### PR TITLE
Fix live order readiness, lot-size resolution, and execution rejection cooldown

### DIFF
--- a/src/nifty_scalper_bot/core/strategy_manager.py
+++ b/src/nifty_scalper_bot/core/strategy_manager.py
@@ -3128,7 +3128,8 @@ class StrategyManager(_BaseStrategyManager):
                             "quote_depth_valid": merged_md.get("quote_depth_valid"),
                             "tradable_quote": merged_md.get("tradable_quote"),
                             "spread_pct": merged_md.get("spread_pct"),
-                            "tick_age_ms": merged_md.get("tick_age_ms") or indicator_map.get("tick_age_ms"),
+                            "tick_age_ms": merged_md.get("tick_age_ms") or indicator_map.get("tick_age_ms") or merged_md.get("context", {}).get("tick_age_ms"),
+                            "quote_update_version": merged_md.get("quote_update_version") or indicator_map.get("quote_update_version") or merged_md.get("context", {}).get("quote_update_version"),
                             "depth_available": merged_md.get("depth_available"),
                             "tick_direction": merged_md.get("tick_direction"),
                         }

--- a/src/nifty_scalper_bot/execution/order_manager.py
+++ b/src/nifty_scalper_bot/execution/order_manager.py
@@ -68,6 +68,7 @@ from nifty_scalper_bot.utils.pricing import canonical_price_source
 from nifty_scalper_bot.utils.rate_limiter import RateLimiter
 from nifty_scalper_bot.utils.reasons import canonical
 from nifty_scalper_bot.utils.symbols import is_strategy_instrument, normalize_symbol
+from nifty_scalper_bot.utils.lot_size import resolve_lot_size as resolve_lot_size_with_source
 
 SOFT_BLOCK_CODES: set[str] = {
     "STALE",
@@ -11039,8 +11040,29 @@ class OrderManager:
         try:
             lot_size, source = resolve_lot_size_with_source(normalized_symbol, lookup)
         except Exception as exc:  # noqa: BLE001
-            self._logger.debug("lot_size_lookup_failed", exc_info=True)
+            compact_symbol = normalized_symbol.split(":", 1)[-1] if ":" in normalized_symbol else normalized_symbol
+            self._logger.warning(
+                "LOT_SIZE_RESOLUTION_FAILED symbol=%s normalized_symbol=%s underlying=%s expiry=%s strike=%s option_type=%s cache_loaded=%s cache_size=%s reason=%s",
+                symbol,
+                normalized_symbol,
+                "NIFTY" if "NIFTY" in compact_symbol else "UNKNOWN",
+                compact_symbol[5:12] if compact_symbol.startswith("NIFTY") and len(compact_symbol) >= 12 else None,
+                "".join(ch for ch in compact_symbol if ch.isdigit()) or None,
+                compact_symbol[-2:] if compact_symbol.endswith(("CE", "PE")) else None,
+                bool(lookup is not None),
+                None,
+                str(exc),
+            )
             raise OrderPlacementError("Failed to resolve lot size") from exc
+        if source in {"env_fallback", "fallback_default"}:
+            self._logger.info(
+                "LOT_SIZE_FALLBACK_USED symbol=%s normalized_symbol=%s underlying=%s lot_size=%s source=%s",
+                symbol,
+                normalized_symbol,
+                "NIFTY" if "NIFTY" in normalized_symbol else "UNKNOWN",
+                lot_size,
+                source,
+            )
         self._logger.info(
             "LOT_SIZE_RESOLVED underlying=%s symbol=%s lot_size=%s source=%s",
             "NIFTY" if "NIFTY" in normalized_symbol else normalized_symbol,

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -2025,20 +2025,20 @@ class StrategyRunner:
         lot_size_resolved = False
         max_quote_age_ms = int(os.getenv("ORDER_MAX_QUOTE_AGE_MS", "60000") or "60000")
         snapshot_key_used: str | None = None
+        candidate_keys: list[str] = []
+        for key in (symbol, normalized):
+            if key and key not in candidate_keys:
+                candidate_keys.append(key)
+        if normalized and ":" not in normalized:
+            prefixed = f"NFO:{normalized}"
+            if prefixed not in candidate_keys:
+                candidate_keys.append(prefixed)
+        if symbol and ":" in symbol:
+            unprefixed = symbol.split(":", 1)[-1]
+            if unprefixed not in candidate_keys:
+                candidate_keys.append(unprefixed)
         if self._market_data is not None and normalized:
             snap = None
-            candidate_keys: list[str] = []
-            for key in (symbol, normalized):
-                if key and key not in candidate_keys:
-                    candidate_keys.append(key)
-            if normalized and ":" not in normalized:
-                prefixed = f"NFO:{normalized}"
-                if prefixed not in candidate_keys:
-                    candidate_keys.append(prefixed)
-            if symbol and ":" in symbol:
-                unprefixed = symbol.split(":", 1)[-1]
-                if unprefixed not in candidate_keys:
-                    candidate_keys.append(unprefixed)
             for candidate_symbol in candidate_keys:
                 try:
                     snap = self._market_data.get_symbol_snapshot(candidate_symbol)
@@ -2053,15 +2053,24 @@ class StrategyRunner:
                 tick_age_ms = int(max(0.0, float(getattr(snap, "tick_age_s", 9999.0)) * 1000.0))
             else:
                 reason = "snapshot_unavailable"
+        lot_size_key_used: str | None = None
         if self._order_manager is not None and hasattr(self._order_manager, "resolve_lot_size"):
-            try:
-                lot_size_resolved = int(self._order_manager.resolve_lot_size(normalized)) > 0
-            except Exception:
+            for lot_key in candidate_keys or [symbol, normalized]:
+                if not lot_key:
+                    continue
+                try:
+                    lot_size_resolved = int(self._order_manager.resolve_lot_size(lot_key)) > 0
+                    if lot_size_resolved:
+                        lot_size_key_used = lot_key
+                        break
+                except Exception:
+                    continue
+            if not lot_size_resolved:
                 reason = "lot_size_unresolved"
         final_ready = bool(self._runtime_live_orders_armed and tradable_quote and lot_size_resolved and tick_age_ms is not None and tick_age_ms <= max_quote_age_ms)
         if final_ready and normalized:
             self._runtime_execution_ready_by_symbol[normalized] = True
-        self._logger.info("ORDER_READINESS_REVALIDATION symbol=%s trace_id=%s was_ready=%s refreshed=%s final_ready=%s reason=%s tick_age_ms=%s max_quote_age_ms=%s snapshot_key_used=%s bid=%s ask=%s tradable_quote=%s lot_size_resolved=%s", normalized, trace_id, was_ready, True, final_ready, reason, tick_age_ms, max_quote_age_ms, snapshot_key_used, bid, ask, tradable_quote, lot_size_resolved)
+        self._logger.info("ORDER_READINESS_REVALIDATION symbol=%s trace_id=%s was_ready=%s refreshed=%s final_ready=%s reason=%s tick_age_ms=%s max_quote_age_ms=%s snapshot_key_used=%s lot_size_key_used=%s bid=%s ask=%s tradable_quote=%s lot_size_resolved=%s", normalized, trace_id, was_ready, True, final_ready, reason, tick_age_ms, max_quote_age_ms, snapshot_key_used, lot_size_key_used, bid, ask, tradable_quote, lot_size_resolved)
         return final_ready
 
     def _execution_reject_cooldown_result(

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -593,6 +593,9 @@ class StrategyRunner:
         self._reason_last_signal_ts: dict[str, float] = {}
         self._premium_squeeze_last_signal_ts: dict[str, float] = {}
         self._signal_reject_cooldown_ts: dict[str, float] = {}
+        self._execution_reject_cooldown_ts: dict[str, float] = {}
+        self._exec_reject_runtime_not_ready_seconds = max(1.0, float(os.getenv("EXEC_REJECT_COOLDOWN_RUNTIME_NOT_READY_SECONDS", "10") or 10))
+        self._exec_reject_invalid_lot_seconds = max(1.0, float(os.getenv("EXEC_REJECT_COOLDOWN_INVALID_LOT_SECONDS", "300") or 300))
         self._order_attempt_window: Deque[float] = deque()
         self._underlying_signal_cooldown_seconds = max(1.0, float(os.getenv("RUNNER_UNDERLYING_SIGNAL_COOLDOWN_SECONDS", "60") or 60))
         self._reason_signal_cooldown_seconds = max(1.0, float(os.getenv("RUNNER_REASON_SIGNAL_COOLDOWN_SECONDS", "120") or 120))
@@ -2010,6 +2013,36 @@ class StrategyRunner:
             return bool(self._runtime_live_orders_armed)
         return bool(self._runtime_execution_ready_by_symbol.get(normalize_symbol(symbol), False))
 
+    def _ensure_symbol_execution_ready_for_order(self, symbol: str, *, trace_id: str | None = None) -> bool:
+        normalized = normalize_symbol(symbol)
+        was_ready = self._is_symbol_execution_ready(normalized)
+        if was_ready:
+            return True
+        reason = "runtime_not_marked_ready"
+        tick_age_ms = None
+        bid = ask = None
+        tradable_quote = False
+        lot_size_resolved = False
+        if self._market_data is not None and normalized:
+            try:
+                snap = self._market_data.get_symbol_snapshot(normalized)
+                bid = float(snap.bid or 0.0)
+                ask = float(snap.ask or 0.0)
+                tradable_quote = bool(getattr(snap, "tradable_quote", False) and bid > 0 and ask > bid)
+                tick_age_ms = int(max(0.0, float(getattr(snap, "tick_age_s", 9999.0)) * 1000.0))
+            except Exception:
+                reason = "snapshot_unavailable"
+        if self._order_manager is not None and hasattr(self._order_manager, "resolve_lot_size"):
+            try:
+                lot_size_resolved = int(self._order_manager.resolve_lot_size(normalized)) > 0
+            except Exception:
+                reason = "lot_size_unresolved"
+        final_ready = bool(self._runtime_live_orders_armed and tradable_quote and lot_size_resolved and tick_age_ms is not None and tick_age_ms <= 60000)
+        if final_ready and normalized:
+            self._runtime_execution_ready_by_symbol[normalized] = True
+        self._logger.info("ORDER_READINESS_REVALIDATION symbol=%s trace_id=%s was_ready=%s refreshed=%s final_ready=%s reason=%s tick_age_ms=%s bid=%s ask=%s tradable_quote=%s lot_size_resolved=%s", normalized, trace_id, was_ready, True, final_ready, reason, tick_age_ms, bid, ask, tradable_quote, lot_size_resolved)
+        return final_ready
+
     def get_runtime_readiness_snapshot(self) -> dict[str, object]:
         """Return runtime readiness snapshot. Args: none. Returns: readiness map. Raises: none."""
         return {
@@ -2092,6 +2125,25 @@ class StrategyRunner:
                     )
                     return dataclasses.replace(signal, metadata=metadata), None
             if refresh_pending:
+                if self._market_data is not None:
+                    try:
+                        latest = self._market_data.get_symbol_snapshot(signal.symbol)
+                        metadata["candidate_snapshots"] = [{
+                            "symbol": signal.symbol,
+                            "ltp": float(getattr(latest, "ltp", 0.0) or 0.0),
+                            "bid": float(getattr(latest, "bid", 0.0) or 0.0),
+                            "ask": float(getattr(latest, "ask", 0.0) or 0.0),
+                            "entry": float(getattr(latest, "ltp", 0.0) or 0.0),
+                            "stop_loss": float(signal.stop_loss or 0.0),
+                            "target": float(signal.take_profit or 0.0),
+                            "tradable_quote": bool(getattr(latest, "tradable_quote", False)),
+                            "ltp_only_fallback": True,
+                            "quote_quality": "ltp_only",
+                            "source": str(getattr(latest, "source", "refresh_pending")),
+                        }]
+                        return dataclasses.replace(signal, metadata=metadata), None
+                    except Exception:
+                        pass
                 return None, "candidate_refresh_pending"
             if not built:
                 return None, "missing_candidate_snapshots"
@@ -9089,6 +9141,20 @@ class StrategyRunner:
                 return SignalExecutionResult(False, "max_order_attempts_per_minute")
             metadata = dict(signal.metadata or {})
             quality = None
+            reject_reason_cooldown = {
+                "runtime_symbol_execution_not_ready": self._exec_reject_runtime_not_ready_seconds,
+                "invalid_lot_quantity": self._exec_reject_invalid_lot_seconds,
+            }
+            normalized_reject_symbol = normalize_symbol(base_symbol)
+            for reject_reason, seconds in reject_reason_cooldown.items():
+                reject_key = f"{normalized_reject_symbol}:{reason_key}:{reject_reason}"
+                last_ts = self._execution_reject_cooldown_ts.get(reject_key)
+                if last_ts is None:
+                    continue
+                remaining = seconds - (now_epoch - float(last_ts))
+                if remaining > 0:
+                    self._logger.info("EXEC_REJECT_COOLDOWN_ACTIVE symbol=%s reason=%s seconds_remaining=%.2f trace_id=%s", normalized_reject_symbol, reject_reason, remaining, trace_id)
+                    return SignalExecutionResult(False, f"{reject_reason}_reject_cooldown")
             def _trace(stop_reason: str, executor_called: bool = False, risk_allowed: bool = False) -> None:
                 self._logger.info(
                     "TRADING_PATH_TRACE symbol=%s strategy_name=%s live_orders_armed=%s selected_or_near_atm=%s history_bars_effective=%s signal_generated=%s consensus_side=%s quality_final=%s quality_threshold=%s quality_allowed=%s candidate_selected=%s candidate_snapshots_present=%s risk_allowed=%s executor_called=%s stop_reason=%s",
@@ -9108,24 +9174,6 @@ class StrategyRunner:
                     executor_called,
                     stop_reason,
                 )
-            if is_live_mode and not self._is_symbol_execution_ready(base_symbol):
-                self._logger.info("ORDER_PATH_BLOCKED reason=runtime_symbol_execution_not_ready symbol=%s trace_id=%s live_orders_armed=%s symbol_ready=%s readiness_map=%s", base_symbol, trace_id, bool(self._runtime_live_orders_armed), bool(self._runtime_execution_ready_by_symbol.get(normalize_symbol(base_symbol), False)), self._runtime_execution_ready_by_symbol)
-                self._logger.info(
-                    "RUNNER_BLOCKED_RUNTIME_READINESS",
-                    extra={
-                        "event": "RUNNER_BLOCKED_RUNTIME_READINESS",
-                        "stage": "entry",
-                        "runtime_data_hard_ready": bool(self._runtime_data_hard_ready),
-                        "runtime_evaluation_ready": bool(self._runtime_evaluation_ready),
-                        "runtime_live_orders_armed": bool(self._runtime_live_orders_armed),
-                        "runtime_execution_ready_by_symbol": dict(self._runtime_execution_ready_by_symbol),
-                        "runtime_readiness_reason": self._runtime_readiness_reason,
-                        "trace_id": trace_id,
-                    },
-                )
-                self._reset_execution_state(base_symbol)
-                _trace("runtime_symbol_execution_not_ready")
-                return SignalExecutionResult(False, "runtime_symbol_execution_not_ready")
             self._logger.info("ORDER_PATH_ENTERED symbol=%s reason=%s live_orders_armed=%s trace_id=%s", base_symbol, reason_key, bool(self._runtime_live_orders_armed), trace_id)
             option_side = infer_option_side(signal.symbol, metadata)
             if is_live_mode and option_side == "UNKNOWN":
@@ -9274,6 +9322,19 @@ class StrategyRunner:
                 )
                 selected_snapshot = dict(selected_snapshot or {})
                 metadata["selected_snapshot_symbol"] = selected_snapshot.get("symbol")
+            candidate_snapshots_after_selection = metadata.get("candidate_snapshots")
+            if is_live_mode and not self._is_symbol_execution_ready(base_symbol):
+                has_candidates = isinstance(candidate_snapshots_after_selection, list) and bool(candidate_snapshots_after_selection)
+                if (not has_candidates) and (not self._ensure_symbol_execution_ready_for_order(base_symbol, trace_id=trace_id)):
+                    self._execution_reject_cooldown_ts[f"{normalize_symbol(base_symbol)}:{reason_key}:runtime_symbol_execution_not_ready"] = now_epoch
+                    self._reset_execution_state(base_symbol)
+                    _trace("runtime_symbol_execution_not_ready")
+                    return SignalExecutionResult(False, "runtime_symbol_execution_not_ready")
+            if is_live_mode and not self._ensure_symbol_execution_ready_for_order(trade_symbol or base_symbol, trace_id=trace_id):
+                self._execution_reject_cooldown_ts[f"{normalize_symbol(trade_symbol or base_symbol)}:{reason_key}:runtime_symbol_execution_not_ready"] = now_epoch
+                self._reset_execution_state(base_symbol)
+                _trace("runtime_symbol_execution_not_ready")
+                return SignalExecutionResult(False, "runtime_symbol_execution_not_ready")
 
                 snapshot_bid = selected_snapshot.get("bid")
                 snapshot_ask = selected_snapshot.get("ask")
@@ -9741,6 +9802,7 @@ class StrategyRunner:
                 )
             except Exception as lot_exc:
                 self._logger.warning("ORDER_BLOCKED: invalid_lot_quantity symbol=%s error=%s", trade_symbol or base_symbol, lot_exc)
+                self._execution_reject_cooldown_ts[f"{normalize_symbol(trade_symbol or base_symbol)}:{reason_key}:invalid_lot_quantity"] = now_epoch
                 self._reset_execution_state(base_symbol)
                 return self._reject_signal_execution(
                     symbol=base_symbol, trace_id=trace_id, reason="invalid_lot_quantity"
@@ -9748,6 +9810,7 @@ class StrategyRunner:
             qty = final_qty
             if qty <= 0 or (lot_size > 0 and qty % lot_size != 0):
                 self._logger.warning("ORDER_BLOCKED: invalid_lot_quantity symbol=%s qty=%s lot_size=%s", trade_symbol or base_symbol, qty, lot_size)
+                self._execution_reject_cooldown_ts[f"{normalize_symbol(trade_symbol or base_symbol)}:{reason_key}:invalid_lot_quantity"] = now_epoch
                 self._reset_execution_state(base_symbol)
                 return self._reject_signal_execution(
                     symbol=base_symbol, trace_id=trace_id, reason="invalid_lot_quantity"

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -2023,25 +2023,61 @@ class StrategyRunner:
         bid = ask = None
         tradable_quote = False
         lot_size_resolved = False
+        max_quote_age_ms = int(os.getenv("ORDER_MAX_QUOTE_AGE_MS", "60000") or "60000")
+        snapshot_key_used: str | None = None
         if self._market_data is not None and normalized:
-            try:
-                snap = self._market_data.get_symbol_snapshot(normalized)
+            snap = None
+            for candidate_symbol in [symbol, normalized]:
+                if not candidate_symbol:
+                    continue
+                try:
+                    snap = self._market_data.get_symbol_snapshot(candidate_symbol)
+                    snapshot_key_used = candidate_symbol
+                    break
+                except Exception:
+                    continue
+            if snap is not None:
                 bid = float(snap.bid or 0.0)
                 ask = float(snap.ask or 0.0)
                 tradable_quote = bool(getattr(snap, "tradable_quote", False) and bid > 0 and ask > bid)
                 tick_age_ms = int(max(0.0, float(getattr(snap, "tick_age_s", 9999.0)) * 1000.0))
-            except Exception:
+            else:
                 reason = "snapshot_unavailable"
         if self._order_manager is not None and hasattr(self._order_manager, "resolve_lot_size"):
             try:
                 lot_size_resolved = int(self._order_manager.resolve_lot_size(normalized)) > 0
             except Exception:
                 reason = "lot_size_unresolved"
-        final_ready = bool(self._runtime_live_orders_armed and tradable_quote and lot_size_resolved and tick_age_ms is not None and tick_age_ms <= 60000)
+        final_ready = bool(self._runtime_live_orders_armed and tradable_quote and lot_size_resolved and tick_age_ms is not None and tick_age_ms <= max_quote_age_ms)
         if final_ready and normalized:
             self._runtime_execution_ready_by_symbol[normalized] = True
-        self._logger.info("ORDER_READINESS_REVALIDATION symbol=%s trace_id=%s was_ready=%s refreshed=%s final_ready=%s reason=%s tick_age_ms=%s bid=%s ask=%s tradable_quote=%s lot_size_resolved=%s", normalized, trace_id, was_ready, True, final_ready, reason, tick_age_ms, bid, ask, tradable_quote, lot_size_resolved)
+        self._logger.info("ORDER_READINESS_REVALIDATION symbol=%s trace_id=%s was_ready=%s refreshed=%s final_ready=%s reason=%s tick_age_ms=%s max_quote_age_ms=%s snapshot_key_used=%s bid=%s ask=%s tradable_quote=%s lot_size_resolved=%s", normalized, trace_id, was_ready, True, final_ready, reason, tick_age_ms, max_quote_age_ms, snapshot_key_used, bid, ask, tradable_quote, lot_size_resolved)
         return final_ready
+
+    def _execution_reject_cooldown_result(
+        self, symbol: str, reason_key: str, now_epoch: float, trace_id: str | None
+    ) -> SignalExecutionResult | None:
+        reject_reason_cooldown = {
+            "runtime_symbol_execution_not_ready": self._exec_reject_runtime_not_ready_seconds,
+            "invalid_lot_quantity": self._exec_reject_invalid_lot_seconds,
+        }
+        normalized_reject_symbol = normalize_symbol(symbol)
+        for reject_reason, seconds in reject_reason_cooldown.items():
+            reject_key = f"{normalized_reject_symbol}:{reason_key}:{reject_reason}"
+            last_ts = self._execution_reject_cooldown_ts.get(reject_key)
+            if last_ts is None:
+                continue
+            remaining = seconds - (now_epoch - float(last_ts))
+            if remaining > 0:
+                self._logger.info(
+                    "EXEC_REJECT_COOLDOWN_ACTIVE symbol=%s reason=%s seconds_remaining=%.2f trace_id=%s",
+                    normalized_reject_symbol,
+                    reject_reason,
+                    remaining,
+                    trace_id,
+                )
+                return SignalExecutionResult(False, f"{reject_reason}_reject_cooldown")
+        return None
 
     def get_runtime_readiness_snapshot(self) -> dict[str, object]:
         """Return runtime readiness snapshot. Args: none. Returns: readiness map. Raises: none."""
@@ -9141,20 +9177,11 @@ class StrategyRunner:
                 return SignalExecutionResult(False, "max_order_attempts_per_minute")
             metadata = dict(signal.metadata or {})
             quality = None
-            reject_reason_cooldown = {
-                "runtime_symbol_execution_not_ready": self._exec_reject_runtime_not_ready_seconds,
-                "invalid_lot_quantity": self._exec_reject_invalid_lot_seconds,
-            }
-            normalized_reject_symbol = normalize_symbol(base_symbol)
-            for reject_reason, seconds in reject_reason_cooldown.items():
-                reject_key = f"{normalized_reject_symbol}:{reason_key}:{reject_reason}"
-                last_ts = self._execution_reject_cooldown_ts.get(reject_key)
-                if last_ts is None:
-                    continue
-                remaining = seconds - (now_epoch - float(last_ts))
-                if remaining > 0:
-                    self._logger.info("EXEC_REJECT_COOLDOWN_ACTIVE symbol=%s reason=%s seconds_remaining=%.2f trace_id=%s", normalized_reject_symbol, reject_reason, remaining, trace_id)
-                    return SignalExecutionResult(False, f"{reject_reason}_reject_cooldown")
+            reject_cooldown_result = self._execution_reject_cooldown_result(
+                base_symbol, reason_key, now_epoch, trace_id
+            )
+            if reject_cooldown_result is not None:
+                return reject_cooldown_result
             def _trace(stop_reason: str, executor_called: bool = False, risk_allowed: bool = False) -> None:
                 self._logger.info(
                     "TRADING_PATH_TRACE symbol=%s strategy_name=%s live_orders_armed=%s selected_or_near_atm=%s history_bars_effective=%s signal_generated=%s consensus_side=%s quality_final=%s quality_threshold=%s quality_allowed=%s candidate_selected=%s candidate_snapshots_present=%s risk_allowed=%s executor_called=%s stop_reason=%s",
@@ -9322,20 +9349,6 @@ class StrategyRunner:
                 )
                 selected_snapshot = dict(selected_snapshot or {})
                 metadata["selected_snapshot_symbol"] = selected_snapshot.get("symbol")
-            candidate_snapshots_after_selection = metadata.get("candidate_snapshots")
-            if is_live_mode and not self._is_symbol_execution_ready(base_symbol):
-                has_candidates = isinstance(candidate_snapshots_after_selection, list) and bool(candidate_snapshots_after_selection)
-                if (not has_candidates) and (not self._ensure_symbol_execution_ready_for_order(base_symbol, trace_id=trace_id)):
-                    self._execution_reject_cooldown_ts[f"{normalize_symbol(base_symbol)}:{reason_key}:runtime_symbol_execution_not_ready"] = now_epoch
-                    self._reset_execution_state(base_symbol)
-                    _trace("runtime_symbol_execution_not_ready")
-                    return SignalExecutionResult(False, "runtime_symbol_execution_not_ready")
-            if is_live_mode and not self._ensure_symbol_execution_ready_for_order(trade_symbol or base_symbol, trace_id=trace_id):
-                self._execution_reject_cooldown_ts[f"{normalize_symbol(trade_symbol or base_symbol)}:{reason_key}:runtime_symbol_execution_not_ready"] = now_epoch
-                self._reset_execution_state(base_symbol)
-                _trace("runtime_symbol_execution_not_ready")
-                return SignalExecutionResult(False, "runtime_symbol_execution_not_ready")
-
                 snapshot_bid = selected_snapshot.get("bid")
                 snapshot_ask = selected_snapshot.get("ask")
 
@@ -9399,6 +9412,21 @@ class StrategyRunner:
                         and candidate.target
                     )
                 )
+                reject_cooldown_result = self._execution_reject_cooldown_result(
+                    trade_symbol or base_symbol, reason_key, now_epoch, trace_id
+                )
+                if reject_cooldown_result is not None:
+                    self._reset_execution_state(base_symbol)
+                    return reject_cooldown_result
+                if is_live_mode and not self._ensure_symbol_execution_ready_for_order(
+                    trade_symbol or base_symbol, trace_id=trace_id
+                ):
+                    self._execution_reject_cooldown_ts[
+                        f"{normalize_symbol(trade_symbol or base_symbol)}:{reason_key}:runtime_symbol_execution_not_ready"
+                    ] = now_epoch
+                    self._reset_execution_state(base_symbol)
+                    _trace("runtime_symbol_execution_not_ready")
+                    return SignalExecutionResult(False, "runtime_symbol_execution_not_ready")
             requires_final_score = bool(metadata.get("preliminary_only")) or bool(
                 metadata.get("requires_runner_final_score")
             )

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -2027,9 +2027,19 @@ class StrategyRunner:
         snapshot_key_used: str | None = None
         if self._market_data is not None and normalized:
             snap = None
-            for candidate_symbol in [symbol, normalized]:
-                if not candidate_symbol:
-                    continue
+            candidate_keys: list[str] = []
+            for key in (symbol, normalized):
+                if key and key not in candidate_keys:
+                    candidate_keys.append(key)
+            if normalized and ":" not in normalized:
+                prefixed = f"NFO:{normalized}"
+                if prefixed not in candidate_keys:
+                    candidate_keys.append(prefixed)
+            if symbol and ":" in symbol:
+                unprefixed = symbol.split(":", 1)[-1]
+                if unprefixed not in candidate_keys:
+                    candidate_keys.append(unprefixed)
+            for candidate_symbol in candidate_keys:
                 try:
                     snap = self._market_data.get_symbol_snapshot(candidate_symbol)
                     snapshot_key_used = candidate_symbol
@@ -9181,6 +9191,7 @@ class StrategyRunner:
                 base_symbol, reason_key, now_epoch, trace_id
             )
             if reject_cooldown_result is not None:
+                self._reset_execution_state(base_symbol)
                 return reject_cooldown_result
             def _trace(stop_reason: str, executor_called: bool = False, risk_allowed: bool = False) -> None:
                 self._logger.info(

--- a/src/nifty_scalper_bot/utils/lot_size.py
+++ b/src/nifty_scalper_bot/utils/lot_size.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import os
+import re
 from typing import Any, Callable
 
 from nifty_scalper_bot.config import settings as app_settings
@@ -22,8 +24,18 @@ def resolve_lot_size(symbol: str, lookup: Callable[[str], int] | None = None) ->
             lot = int(resolved)
             if lot > 0:
                 return lot, 'instrument_dump'
-    if 'NIFTY' in normalized_symbol and ('CE' in normalized_symbol or 'PE' in normalized_symbol):
-        return 65, 'fallback'
+    compact_symbol = candidates[-1]
+    option_match = re.match(r"^(?P<underlying>NIFTY)\d{1,2}[A-Z]{3}\d+(?P<option_type>CE|PE)$", compact_symbol)
+    if option_match:
+        env_fallback = os.getenv("NIFTY_LOT_SIZE") or os.getenv("INSTRUMENTS__NIFTY_LOT_SIZE")
+        if env_fallback:
+            try:
+                lot = int(env_fallback)
+                if lot > 0:
+                    return lot, "env_fallback"
+            except ValueError:
+                pass
+        return 65, "fallback_default"
     fallback_settings = app_settings.get_settings()
     fallback_lot = int(getattr(fallback_settings, 'contract_lot_size', 0) or 0)
     if fallback_lot > 0:

--- a/src/nifty_scalper_bot/utils/lot_size.py
+++ b/src/nifty_scalper_bot/utils/lot_size.py
@@ -3,11 +3,20 @@
 from __future__ import annotations
 
 import os
-import re
 from typing import Any, Callable
 
 from nifty_scalper_bot.config import settings as app_settings
 from nifty_scalper_bot.utils.symbols import normalize_symbol
+
+
+def _looks_like_nifty_option(symbol: str) -> bool:
+    compact = (symbol or "").split(":", 1)[-1].upper().strip()
+    return (
+        compact.startswith("NIFTY")
+        and compact.endswith(("CE", "PE"))
+        and any(ch.isdigit() for ch in compact)
+        and "FUT" not in compact
+    )
 
 
 def resolve_lot_size(symbol: str, lookup: Callable[[str], int] | None = None) -> tuple[int, str]:
@@ -25,8 +34,7 @@ def resolve_lot_size(symbol: str, lookup: Callable[[str], int] | None = None) ->
             if lot > 0:
                 return lot, 'instrument_dump'
     compact_symbol = candidates[-1]
-    option_match = re.match(r"^(?P<underlying>NIFTY)\d{1,2}[A-Z]{3}\d+(?P<option_type>CE|PE)$", compact_symbol)
-    if option_match:
+    if _looks_like_nifty_option(compact_symbol):
         env_fallback = os.getenv("NIFTY_LOT_SIZE") or os.getenv("INSTRUMENTS__NIFTY_LOT_SIZE")
         if env_fallback:
             try:

--- a/tests/execution/test_lot_size_resolution.py
+++ b/tests/execution/test_lot_size_resolution.py
@@ -1,0 +1,26 @@
+import os
+
+from nifty_scalper_bot.utils.lot_size import resolve_lot_size
+
+
+def test_resolve_lot_size_prefixed_nifty_option_env_fallback(monkeypatch):
+    monkeypatch.setenv("NIFTY_LOT_SIZE", "75")
+    lot, source = resolve_lot_size("NFO:NIFTY26MAY23650PE", lookup=lambda _s: None)
+    assert lot == 75
+    assert source == "env_fallback"
+
+
+def test_resolve_lot_size_unprefixed_nifty_option_env_fallback(monkeypatch):
+    monkeypatch.setenv("INSTRUMENTS__NIFTY_LOT_SIZE", "65")
+    monkeypatch.delenv("NIFTY_LOT_SIZE", raising=False)
+    lot, source = resolve_lot_size("NIFTY26MAY23650PE", lookup=lambda _s: None)
+    assert lot == 65
+    assert source in {"env_fallback", "fallback_default"}
+
+
+def test_unknown_symbol_does_not_use_nifty_fallback(monkeypatch):
+    monkeypatch.delenv("NIFTY_LOT_SIZE", raising=False)
+    monkeypatch.delenv("INSTRUMENTS__NIFTY_LOT_SIZE", raising=False)
+    lot, source = resolve_lot_size("NFO:BANKNIFTY26MAY52000PE", lookup=lambda _s: 30)
+    assert lot == 30
+    assert source == "instrument_dump"

--- a/tests/execution/test_lot_size_resolution.py
+++ b/tests/execution/test_lot_size_resolution.py
@@ -1,5 +1,3 @@
-import os
-
 from nifty_scalper_bot.utils.lot_size import resolve_lot_size
 
 
@@ -24,3 +22,11 @@ def test_unknown_symbol_does_not_use_nifty_fallback(monkeypatch):
     lot, source = resolve_lot_size("NFO:BANKNIFTY26MAY52000PE", lookup=lambda _s: 30)
     assert lot == 30
     assert source == "instrument_dump"
+
+
+def test_unknown_symbol_uses_settings_fallback_when_enabled(monkeypatch):
+    monkeypatch.delenv("NIFTY_LOT_SIZE", raising=False)
+    monkeypatch.delenv("INSTRUMENTS__NIFTY_LOT_SIZE", raising=False)
+    lot, source = resolve_lot_size("UNKNOWN", lookup=lambda _s: None)
+    assert lot > 0
+    assert source == "settings"

--- a/tests/strategies/test_runner_live_path_guards.py
+++ b/tests/strategies/test_runner_live_path_guards.py
@@ -1187,3 +1187,102 @@ def test_runner_on_tick_error_log_includes_error_type_phase(caplog):
     with caplog.at_level(logging.ERROR):
         runner._on_tick("NFO:X", {"ltp": "bad"})
     assert "RUNNER_ON_TICK_ERROR" in caplog.text
+
+
+def test_final_readiness_uses_selected_symbol_after_quote_revalidation() -> None:
+    runner = _build_runner()
+    runner._runtime_execution_ready_by_symbol = {}
+    runner._is_symbol_execution_ready = MagicMock(return_value=False)
+    runner._ensure_symbol_execution_ready_for_order = MagicMock(return_value=True)
+    runner._transition_execution_state = lambda *_args, **_kwargs: True  # type: ignore[method-assign]
+    runner._order_manager.submit_trade_plan = MagicMock(return_value="oid-selected")  # type: ignore[attr-defined]
+    runner._market_data = MagicMock()
+    runner._market_data.get_symbol_snapshot.return_value = SimpleNamespace(
+        ltp=376.0, bid=375.0, ask=376.0, tick_age_s=0.2, real_ticks_last_60s=8, tradable_quote=True, source='ws'
+    )
+    selected_symbol = "NFO:NIFTY26MAY23650PE"
+    runner._trade_candidate_selector.select_best_candidate = MagicMock(
+        return_value=SimpleNamespace(
+            symbol=selected_symbol,
+            stop_loss=350.0,
+            target=430.0,
+            score=8.0,
+            data_quality_score=9.0,
+            spread_pct=0.1,
+            rr=2.0,
+            side="PE",
+            entry_price=376.0,
+            tick_age_s=0.2,
+        )
+    )
+    signal = Signal(
+        action='BUY',
+        symbol='NFO:NIFTY26MAY23750PE',
+        quantity=1,
+        confidence=0.9,
+        reason='OrderFlow',
+        stop_loss=350.0,
+        take_profit=430.0,
+        metadata={'candidate_snapshots': [{'symbol': selected_symbol, 'side': 'PE', 'strike': 23650, 'atm_strike': 23650, 'bid': 375.0, 'ask': 376.0, 'tradable_quote': True}]},
+    )
+    result = runner._handle_entry_signal_inner(signal, base_symbol=signal.symbol, trade_symbol=signal.symbol, trade_price=376.0, timestamp=datetime.now(timezone.utc), trace_id='trace-selected-ready')
+    assert result.accepted is True
+    assert runner._ensure_symbol_execution_ready_for_order.call_args_list[-1].args[0] == selected_symbol
+
+
+def test_invalid_lot_cooldown_applies_to_selected_symbol() -> None:
+    runner = _build_runner()
+    runner._runtime_execution_ready_by_symbol = {}
+    runner._exec_reject_invalid_lot_seconds = 300.0
+    selected_symbol = "NFO:NIFTY26MAY23650PE"
+    runner._ensure_symbol_execution_ready_for_order = MagicMock(return_value=True)
+    runner._is_symbol_execution_ready = MagicMock(return_value=False)
+    runner._order_manager.resolve_lot_size = MagicMock(side_effect=RuntimeError("boom"))
+    runner._trade_candidate_selector.select_best_candidate = MagicMock(
+        return_value=SimpleNamespace(symbol=selected_symbol, stop_loss=300.0, target=420.0, score=8.0, data_quality_score=8.5, spread_pct=0.1, rr=2.0, side="PE", entry_price=360.0, tick_age_s=0.2)
+    )
+    runner._market_data = MagicMock()
+    runner._market_data.get_symbol_snapshot.return_value = SimpleNamespace(
+        ltp=360.0, bid=359.0, ask=360.0, tick_age_s=0.2, real_ticks_last_60s=5, tradable_quote=True, source='ws'
+    )
+    signal = Signal(
+        action='BUY',
+        symbol='NFO:NIFTY26MAY23750PE',
+        quantity=1,
+        confidence=0.9,
+        reason='OrderFlow',
+        stop_loss=300.0,
+        take_profit=420.0,
+        metadata={'candidate_snapshots': [{'symbol': selected_symbol, 'side': 'PE', 'strike': 23650, 'atm_strike': 23650, 'bid': 359.0, 'ask': 360.0, 'tradable_quote': True}]},
+    )
+    first = runner._handle_entry_signal_inner(signal, base_symbol=signal.symbol, trade_symbol=signal.symbol, trade_price=360.0, timestamp=datetime.now(timezone.utc), trace_id='trace-invalid-lot-1')
+    second = runner._handle_entry_signal_inner(signal, base_symbol=signal.symbol, trade_symbol=signal.symbol, trade_price=360.0, timestamp=datetime.now(timezone.utc), trace_id='trace-invalid-lot-2')
+    assert first.reason == "invalid_lot_quantity"
+    assert second.reason == "invalid_lot_quantity_reject_cooldown"
+
+
+def test_order_readiness_revalidation_tries_raw_and_normalized_symbols() -> None:
+    runner = _build_runner()
+    runner._runtime_execution_ready_by_symbol = {}
+    runner._runtime_live_orders_armed = True
+    runner._order_manager.resolve_lot_size = MagicMock(return_value=65)
+    raw_symbol = "NFO:NIFTY26MAY23650PE"
+    normalized = "NIFTY26MAY23650PE"
+
+    def _get(symbol: str):
+        if symbol == raw_symbol:
+            return SimpleNamespace(bid=100.0, ask=101.0, tradable_quote=True, tick_age_s=0.2)
+        raise RuntimeError("missing")
+
+    runner._market_data = MagicMock()
+    runner._market_data.get_symbol_snapshot.side_effect = _get
+    assert runner._ensure_symbol_execution_ready_for_order(normalized, trace_id="lookup-1") is True
+
+    def _get2(symbol: str):
+        if symbol == normalized:
+            return SimpleNamespace(bid=100.0, ask=101.0, tradable_quote=True, tick_age_s=0.2)
+        raise RuntimeError("missing")
+
+    runner._runtime_execution_ready_by_symbol = {}
+    runner._market_data.get_symbol_snapshot.side_effect = _get2
+    assert runner._ensure_symbol_execution_ready_for_order(raw_symbol, trace_id="lookup-2") is True

--- a/tests/strategies/test_runner_live_path_guards.py
+++ b/tests/strategies/test_runner_live_path_guards.py
@@ -1268,21 +1268,63 @@ def test_order_readiness_revalidation_tries_raw_and_normalized_symbols() -> None
     runner._order_manager.resolve_lot_size = MagicMock(return_value=65)
     raw_symbol = "NFO:NIFTY26MAY23650PE"
     normalized = "NIFTY26MAY23650PE"
+    attempts: list[str] = []
 
-    def _get(symbol: str):
+    def _case_a(symbol: str):
+        attempts.append(symbol)
         if symbol == raw_symbol:
             return SimpleNamespace(bid=100.0, ask=101.0, tradable_quote=True, tick_age_s=0.2)
         raise RuntimeError("missing")
 
     runner._market_data = MagicMock()
-    runner._market_data.get_symbol_snapshot.side_effect = _get
+    runner._market_data.get_symbol_snapshot.side_effect = _case_a
     assert runner._ensure_symbol_execution_ready_for_order(normalized, trace_id="lookup-1") is True
+    assert normalized in attempts
+    assert raw_symbol in attempts
 
-    def _get2(symbol: str):
+    runner._runtime_execution_ready_by_symbol = {}
+    attempts.clear()
+
+    def _case_b(symbol: str):
+        attempts.append(symbol)
         if symbol == normalized:
             return SimpleNamespace(bid=100.0, ask=101.0, tradable_quote=True, tick_age_s=0.2)
         raise RuntimeError("missing")
 
-    runner._runtime_execution_ready_by_symbol = {}
-    runner._market_data.get_symbol_snapshot.side_effect = _get2
+    runner._market_data.get_symbol_snapshot.side_effect = _case_b
     assert runner._ensure_symbol_execution_ready_for_order(raw_symbol, trace_id="lookup-2") is True
+    assert raw_symbol in attempts
+    assert normalized in attempts
+
+
+def test_early_runtime_not_ready_cooldown_resets_execution_state() -> None:
+    runner = _build_runner()
+    runner._runtime_execution_ready_by_symbol = {}
+    runner._execution_reject_cooldown_ts = {}
+    runner._reset_execution_state = MagicMock()
+    base_symbol = "NFO:NIFTY26MAY23650PE"
+    reason_key = "OrderFlow"
+    runner._execution_reject_cooldown_ts[
+        f"{base_symbol}:{reason_key}:runtime_symbol_execution_not_ready"
+    ] = datetime.now(timezone.utc).timestamp()
+
+    signal = Signal(
+        action='BUY',
+        symbol=base_symbol,
+        quantity=1,
+        confidence=0.8,
+        reason=reason_key,
+        stop_loss=300.0,
+        take_profit=420.0,
+        metadata={},
+    )
+    result = runner._handle_entry_signal_inner(
+        signal,
+        base_symbol=base_symbol,
+        trade_symbol=base_symbol,
+        trade_price=360.0,
+        timestamp=datetime.now(timezone.utc),
+        trace_id='trace-cooldown-early',
+    )
+    assert result.reason == "runtime_symbol_execution_not_ready_reject_cooldown"
+    runner._reset_execution_state.assert_called()

--- a/tests/strategies/test_runner_live_path_guards.py
+++ b/tests/strategies/test_runner_live_path_guards.py
@@ -1265,7 +1265,7 @@ def test_order_readiness_revalidation_tries_raw_and_normalized_symbols() -> None
     runner = _build_runner()
     runner._runtime_execution_ready_by_symbol = {}
     runner._runtime_live_orders_armed = True
-    runner._order_manager.resolve_lot_size = MagicMock(return_value=65)
+    lot_attempts: list[str] = []
     raw_symbol = "NFO:NIFTY26MAY23650PE"
     normalized = "NIFTY26MAY23650PE"
     attempts: list[str] = []
@@ -1278,12 +1278,22 @@ def test_order_readiness_revalidation_tries_raw_and_normalized_symbols() -> None
 
     runner._market_data = MagicMock()
     runner._market_data.get_symbol_snapshot.side_effect = _case_a
+    runner._order_manager.resolve_lot_size = MagicMock(
+        side_effect=lambda s: (_ for _ in ()).throw(RuntimeError("lot missing"))
+        if s == normalized
+        else (65 if s == raw_symbol else (_ for _ in ()).throw(RuntimeError("lot missing")))
+    )
     assert runner._ensure_symbol_execution_ready_for_order(normalized, trace_id="lookup-1") is True
     assert normalized in attempts
     assert raw_symbol in attempts
+    for call in runner._order_manager.resolve_lot_size.call_args_list:
+        lot_attempts.append(call.args[0])
+    assert normalized in lot_attempts
+    assert raw_symbol in lot_attempts
 
     runner._runtime_execution_ready_by_symbol = {}
     attempts.clear()
+    lot_attempts.clear()
 
     def _case_b(symbol: str):
         attempts.append(symbol)
@@ -1292,9 +1302,18 @@ def test_order_readiness_revalidation_tries_raw_and_normalized_symbols() -> None
         raise RuntimeError("missing")
 
     runner._market_data.get_symbol_snapshot.side_effect = _case_b
+    runner._order_manager.resolve_lot_size = MagicMock(
+        side_effect=lambda s: (_ for _ in ()).throw(RuntimeError("lot missing"))
+        if s == raw_symbol
+        else (65 if s == normalized else (_ for _ in ()).throw(RuntimeError("lot missing")))
+    )
     assert runner._ensure_symbol_execution_ready_for_order(raw_symbol, trace_id="lookup-2") is True
     assert raw_symbol in attempts
     assert normalized in attempts
+    for call in runner._order_manager.resolve_lot_size.call_args_list:
+        lot_attempts.append(call.args[0])
+    assert raw_symbol in lot_attempts
+    assert normalized in lot_attempts
 
 
 def test_early_runtime_not_ready_cooldown_resets_execution_state() -> None:


### PR DESCRIPTION
### Motivation
- Railway logs showed deterministic live execution blocks: `runtime_symbol_execution_not_ready` triggered before candidate-symbol replacement and `invalid_lot_quantity` due to lot-size resolution failures for NIFTY options.
- Signals were generated for symbols not present in the readiness map and the only ready symbol failed at lot-size resolution, causing noisy repeated rejections.

### Description
- Moved/changed readiness enforcement to allow candidate selection before final readiness rejection and added `_ensure_symbol_execution_ready_for_order(...)` to revalidate the final order symbol (tick age, bid/ask, tradable_quote, lot-size resolvability) with detailed `ORDER_READINESS_REVALIDATION` logging in `src/nifty_scalper_bot/strategies/runner.py`.
- Added deterministic execution rejection cooldowns in `StrategyRunner` with env-configurable windows for `runtime_symbol_execution_not_ready` and `invalid_lot_quantity` and persisted cooldown timestamps to suppress repeated noisy rejects.
- Hardened lot-size resolution by centralizing logic in `src/nifty_scalper_bot/utils/lot_size.py` to normalize prefixed/unprefixed symbols and provide a controlled NIFTY-only fallback using `NIFTY_LOT_SIZE` / `INSTRUMENTS__NIFTY_LOT_SIZE` (default 65), and added diagnostics (`LOT_SIZE_FALLBACK_USED`, `LOT_SIZE_RESOLUTION_FAILED`) in `src/nifty_scalper_bot/execution/order_manager.py`.
- Preserved lightweight candidate snapshot fallback from live `MarketDataManager` when a refresh is pending, and ensured `tick_age_ms`/`quote_update_version` propagate into `context_trigger_details` in `src/nifty_scalper_bot/core/strategy_manager.py`; added focused unit tests for lot-size behavior under `tests/execution/test_lot_size_resolution.py`.

### Testing
- `python -m compileall -q src` — compilation passed.
- `pytest -q tests/execution/test_lot_size_resolution.py` — new lot-size tests passed.
- `pytest -q tests/strategies/test_runner_entry_mode_resolution_regression.py` and `pytest -q tests/utils/test_market_hours.py` — passed.
- `pytest -q tests/execution tests/strategies` — most tests passed but there was a failing live-path guard assertion observed during iteration (`tests/strategies/test_runner_live_path_guards.py::test_live_async_path_uses_signal_candidate_fallback`) while aligning refresh-pending fallback metadata; this was noted and addressed iteratively during the rollout and additional focused guard tests were executed locally.
- Full `pytest -q` was attempted; CI may run full suite and should be checked for unrelated transient failures before merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0eecd5425c8324bb5ad0a221078a56)