### PR TITLE
Add directional signal dedup & candidate-selection guard to reduce order-attempt spam

### DIFF
--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -600,6 +600,9 @@ class StrategyRunner:
         self._signal_direction_dedup_seconds = max(
             1.0, float(os.getenv("SIGNAL_DIRECTION_DEDUP_SECONDS", "45") or 45)
         )
+        self._signal_direction_dedup_min_improvement = float(
+            os.getenv("SIGNAL_DIRECTION_DEDUP_MIN_IMPROVEMENT", "2.0") or 2.0
+        )
         self._signal_direction_last_emit: dict[str, dict[str, Any]] = {}
         self._underlying_signal_cooldown_seconds = max(1.0, float(os.getenv("RUNNER_UNDERLYING_SIGNAL_COOLDOWN_SECONDS", "60") or 60))
         self._reason_signal_cooldown_seconds = max(1.0, float(os.getenv("RUNNER_REASON_SIGNAL_COOLDOWN_SECONDS", "120") or 120))
@@ -2363,6 +2366,17 @@ class StrategyRunner:
         self, *, underlying: str, option_side: str, reason: str
     ) -> str:
         return f"{underlying}:{option_side}:{reason}"
+
+    def _mark_directional_dedup_failed(
+        self, *, underlying: str, option_side: str, reason: str
+    ) -> None:
+        key = self._directional_dedup_key(
+            underlying=underlying, option_side=option_side, reason=reason
+        )
+        state = self._signal_direction_last_emit.get(key)
+        if isinstance(state, dict):
+            state["status"] = "failed"
+            self._signal_direction_last_emit.pop(key, None)
 
     def _resolve_candidate_contracts(
         self, *, side: str, target_strikes: set[int]
@@ -9061,38 +9075,56 @@ class StrategyRunner:
             underlying=underlying, option_side=option_side, reason=reason
         )
         prev = self._signal_direction_last_emit.get(key)
-        score = float(
-            metadata.get("candidate_score")
-            or metadata.get("strategy_score")
-            or signal.confidence
-            or 0.0
-        )
+        score_raw = metadata.get("candidate_score")
+        if score_raw is None:
+            score_raw = metadata.get("strategy_score")
+        if score_raw is None:
+            score_raw = signal.confidence
+        score = float(score_raw) if score_raw is not None else 0.0
         tradable_quote = bool(metadata.get("tradable_quote"))
-        spread_pct = float(
-            metadata.get("candidate_spread_pct") or metadata.get("spread_pct") or 999.0
-        )
-        tick_age_ms = float(metadata.get("candidate_tick_age_s") or 999.0) * 1000.0
+        spread_pct_raw = metadata.get("candidate_spread_pct")
+        if spread_pct_raw is None:
+            spread_pct_raw = metadata.get("spread_pct")
+        spread_pct = float(spread_pct_raw) if spread_pct_raw is not None else 999.0
+        tick_age_ms_raw = metadata.get("candidate_tick_age_ms")
+        if tick_age_ms_raw is None:
+            tick_age_ms_raw = metadata.get("tick_age_ms")
+        if tick_age_ms_raw is not None:
+            tick_age_ms = float(tick_age_ms_raw)
+        else:
+            tick_age_s_raw = metadata.get("candidate_tick_age_s")
+            if tick_age_s_raw is None:
+                tick_age_s_raw = metadata.get("tick_age_s")
+            tick_age_ms = float(tick_age_s_raw) * 1000.0 if tick_age_s_raw is not None else 999000.0
         depth_available = bool(
             selected_snapshot.get("depth_available") or selected_snapshot.get("depth")
         )
         premium_ok = bool(selected_snapshot.get("premium_within_range", True))
-        distance_atm = abs(
-            float(
-                selected_snapshot.get("distance_from_atm")
-                or selected_snapshot.get("strike_distance_from_atm")
-                or metadata.get("strike_distance_from_atm")
-                or 999.0
-            )
+        distance_raw = selected_snapshot.get("distance_from_atm")
+        if distance_raw is None:
+            distance_raw = selected_snapshot.get("strike_distance_from_atm")
+        if distance_raw is None:
+            distance_raw = metadata.get("strike_distance_from_atm")
+        distance_atm = abs(float(distance_raw)) if distance_raw is not None else 999.0
+        rank_score = (
+            score * 10.0
+            + (2.0 if tradable_quote else -5.0)
+            + (1.0 if depth_available else 0.0)
+            + (1.0 if premium_ok else -2.0)
+            - min(spread_pct, 10.0) * 1.5
+            - min(tick_age_ms / 1000.0, 10.0) * 0.5
+            - min(distance_atm / 100.0, 10.0) * 0.5
         )
-        ranking = (
-            score,
-            1.0 if tradable_quote else 0.0,
-            -spread_pct,
-            -tick_age_ms,
-            1.0 if depth_available else 0.0,
-            1.0 if premium_ok else 0.0,
-            -distance_atm,
-        )
+        ranking_fields = {
+            "score": score,
+            "tradable_quote": tradable_quote,
+            "spread_pct": spread_pct,
+            "tick_age_ms": tick_age_ms,
+            "depth_available": depth_available,
+            "premium_within_range": premium_ok,
+            "distance_from_atm": distance_atm,
+            "rank_score": rank_score,
+        }
         rejected_symbols: list[str] = []
         snapshots = metadata.get("candidate_snapshots")
         if isinstance(snapshots, list):
@@ -9108,21 +9140,13 @@ class StrategyRunner:
             option_side,
             selected_symbol,
             rejected_symbols,
-            {
-                "score": score,
-                "tradable_quote": tradable_quote,
-                "spread_pct": spread_pct,
-                "tick_age_ms": tick_age_ms,
-                "depth_available": depth_available,
-                "premium_within_range": premium_ok,
-                "distance_from_atm": distance_atm,
-            },
+            ranking_fields,
         )
         if prev is not None:
             elapsed = now_epoch - float(prev.get("ts", 0.0))
             if elapsed < self._signal_direction_dedup_seconds:
-                prev_rank = tuple(prev.get("ranking", ()))
-                if ranking <= prev_rank:
+                prev_rank_score = float(prev.get("rank_score", 0.0) or 0.0)
+                if (rank_score - prev_rank_score) < self._signal_direction_dedup_min_improvement:
                     remaining = max(0.0, self._signal_direction_dedup_seconds - elapsed)
                     self._logger.info(
                         "SIGNAL_DEDUP_BLOCKED symbol=%s direction=%s reason=%s key=%s seconds_remaining=%.2f",
@@ -9138,7 +9162,9 @@ class StrategyRunner:
         self._signal_direction_last_emit[key] = {
             "ts": now_epoch,
             "symbol": selected_symbol,
-            "ranking": ranking,
+            "status": "reserved",
+            "rank_score": rank_score,
+            "ranking_fields": ranking_fields,
         }
         return None
 
@@ -9559,6 +9585,9 @@ class StrategyRunner:
                 if is_live_mode and not self._ensure_symbol_execution_ready_for_order(
                     trade_symbol or base_symbol, trace_id=trace_id
                 ):
+                    self._mark_directional_dedup_failed(
+                        underlying=underlying, option_side=option_side, reason=reason_key
+                    )
                     self._execution_reject_cooldown_ts[
                         f"{normalize_symbol(trade_symbol or base_symbol)}:{reason_key}:runtime_symbol_execution_not_ready"
                     ] = now_epoch
@@ -9805,6 +9834,12 @@ class StrategyRunner:
                     )
                     self._reset_execution_state(base_symbol)
                     _trace(final_score_block_reason)
+                    if final_score_block_reason == "quote_not_usable_for_order_plan":
+                        self._mark_directional_dedup_failed(
+                            underlying=underlying,
+                            option_side=option_side,
+                            reason=reason_key,
+                        )
                     return SignalExecutionResult(False, final_score_block_reason)
             missing_components = missing_score_components(metadata)
             if missing_components and reason_key == "premium_momentum_squeeze":
@@ -9968,6 +10003,9 @@ class StrategyRunner:
                 )
             except Exception as lot_exc:
                 self._logger.warning("ORDER_BLOCKED: invalid_lot_quantity symbol=%s error=%s", trade_symbol or base_symbol, lot_exc)
+                self._mark_directional_dedup_failed(
+                    underlying=underlying, option_side=option_side, reason=reason_key
+                )
                 self._execution_reject_cooldown_ts[f"{normalize_symbol(trade_symbol or base_symbol)}:{reason_key}:invalid_lot_quantity"] = now_epoch
                 self._reset_execution_state(base_symbol)
                 return self._reject_signal_execution(
@@ -9976,6 +10014,9 @@ class StrategyRunner:
             qty = final_qty
             if qty <= 0 or (lot_size > 0 and qty % lot_size != 0):
                 self._logger.warning("ORDER_BLOCKED: invalid_lot_quantity symbol=%s qty=%s lot_size=%s", trade_symbol or base_symbol, qty, lot_size)
+                self._mark_directional_dedup_failed(
+                    underlying=underlying, option_side=option_side, reason=reason_key
+                )
                 self._execution_reject_cooldown_ts[f"{normalize_symbol(trade_symbol or base_symbol)}:{reason_key}:invalid_lot_quantity"] = now_epoch
                 self._reset_execution_state(base_symbol)
                 return self._reject_signal_execution(

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -9361,6 +9361,10 @@ class StrategyRunner:
                 return SignalExecutionResult(False, "unknown_option_side")
             candidate_snapshots_obj = metadata.get("candidate_snapshots")
             is_directional_option = option_side in {"CE", "PE"}
+            selected_symbol = normalize_symbol(
+                trade_symbol or base_symbol or signal.symbol
+            )
+            selected_snapshot: dict[str, Any] = {}
             if is_live_mode and is_directional_option and not isinstance(
                 candidate_snapshots_obj, list
             ):

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -597,6 +597,10 @@ class StrategyRunner:
         self._exec_reject_runtime_not_ready_seconds = max(1.0, float(os.getenv("EXEC_REJECT_COOLDOWN_RUNTIME_NOT_READY_SECONDS", "10") or 10))
         self._exec_reject_invalid_lot_seconds = max(1.0, float(os.getenv("EXEC_REJECT_COOLDOWN_INVALID_LOT_SECONDS", "300") or 300))
         self._order_attempt_window: Deque[float] = deque()
+        self._signal_direction_dedup_seconds = max(
+            1.0, float(os.getenv("SIGNAL_DIRECTION_DEDUP_SECONDS", "45") or 45)
+        )
+        self._signal_direction_last_emit: dict[str, dict[str, Any]] = {}
         self._underlying_signal_cooldown_seconds = max(1.0, float(os.getenv("RUNNER_UNDERLYING_SIGNAL_COOLDOWN_SECONDS", "60") or 60))
         self._reason_signal_cooldown_seconds = max(1.0, float(os.getenv("RUNNER_REASON_SIGNAL_COOLDOWN_SECONDS", "120") or 120))
         self._max_order_attempts_per_minute = max(1, int(os.getenv("RUNNER_MAX_ORDER_ATTEMPTS_PER_MINUTE", "3") or 3))
@@ -2354,6 +2358,11 @@ class StrategyRunner:
             },
         )
         return SignalExecutionResult(False, reason, details=payload)
+
+    def _directional_dedup_key(
+        self, *, underlying: str, option_side: str, reason: str
+    ) -> str:
+        return f"{underlying}:{option_side}:{reason}"
 
     def _resolve_candidate_contracts(
         self, *, side: str, target_strikes: set[int]
@@ -9036,6 +9045,103 @@ class StrategyRunner:
         finally:
             self._entry_lock.release()
 
+    def _apply_directional_signal_dedup(
+        self,
+        *,
+        signal: Signal,
+        metadata: dict[str, Any],
+        underlying: str,
+        now_epoch: float,
+        selected_symbol: str,
+        option_side: str,
+        selected_snapshot: dict[str, Any],
+    ) -> SignalExecutionResult | None:
+        reason = str(signal.reason or "unknown")
+        key = self._directional_dedup_key(
+            underlying=underlying, option_side=option_side, reason=reason
+        )
+        prev = self._signal_direction_last_emit.get(key)
+        score = float(
+            metadata.get("candidate_score")
+            or metadata.get("strategy_score")
+            or signal.confidence
+            or 0.0
+        )
+        tradable_quote = bool(metadata.get("tradable_quote"))
+        spread_pct = float(
+            metadata.get("candidate_spread_pct") or metadata.get("spread_pct") or 999.0
+        )
+        tick_age_ms = float(metadata.get("candidate_tick_age_s") or 999.0) * 1000.0
+        depth_available = bool(
+            selected_snapshot.get("depth_available") or selected_snapshot.get("depth")
+        )
+        premium_ok = bool(selected_snapshot.get("premium_within_range", True))
+        distance_atm = abs(
+            float(
+                selected_snapshot.get("distance_from_atm")
+                or selected_snapshot.get("strike_distance_from_atm")
+                or metadata.get("strike_distance_from_atm")
+                or 999.0
+            )
+        )
+        ranking = (
+            score,
+            1.0 if tradable_quote else 0.0,
+            -spread_pct,
+            -tick_age_ms,
+            1.0 if depth_available else 0.0,
+            1.0 if premium_ok else 0.0,
+            -distance_atm,
+        )
+        rejected_symbols: list[str] = []
+        snapshots = metadata.get("candidate_snapshots")
+        if isinstance(snapshots, list):
+            rejected_symbols = [
+                str(snap.get("symbol"))
+                for snap in snapshots
+                if isinstance(snap, dict)
+                and normalize_symbol(str(snap.get("symbol") or ""))
+                != normalize_symbol(selected_symbol)
+            ]
+        self._logger.info(
+            "SIGNAL_CANDIDATE_SELECTED direction=%s selected_symbol=%s rejected_symbols=%s ranking_fields=%s",
+            option_side,
+            selected_symbol,
+            rejected_symbols,
+            {
+                "score": score,
+                "tradable_quote": tradable_quote,
+                "spread_pct": spread_pct,
+                "tick_age_ms": tick_age_ms,
+                "depth_available": depth_available,
+                "premium_within_range": premium_ok,
+                "distance_from_atm": distance_atm,
+            },
+        )
+        if prev is not None:
+            elapsed = now_epoch - float(prev.get("ts", 0.0))
+            if elapsed < self._signal_direction_dedup_seconds:
+                prev_rank = tuple(prev.get("ranking", ()))
+                if ranking <= prev_rank:
+                    remaining = max(0.0, self._signal_direction_dedup_seconds - elapsed)
+                    self._logger.info(
+                        "SIGNAL_DEDUP_BLOCKED symbol=%s direction=%s reason=%s key=%s seconds_remaining=%.2f",
+                        selected_symbol,
+                        option_side,
+                        reason,
+                        key,
+                        remaining,
+                    )
+                    return SignalExecutionResult(
+                        False, "signal_duplicate_direction_cooldown"
+                    )
+        self._signal_direction_last_emit[key] = {
+            "ts": now_epoch,
+            "symbol": selected_symbol,
+            "ranking": ranking,
+        }
+        return None
+
     def _handle_entry_signal_inner(
         self,
         signal: Signal,
@@ -9438,6 +9544,18 @@ class StrategyRunner:
                 if reject_cooldown_result is not None:
                     self._reset_execution_state(base_symbol)
                     return reject_cooldown_result
+                dedup_result = self._apply_directional_signal_dedup(
+                    signal=signal,
+                    metadata=metadata,
+                    underlying=underlying,
+                    now_epoch=now_epoch,
+                    selected_symbol=selected_symbol,
+                    option_side=option_side,
+                    selected_snapshot=selected_snapshot,
+                )
+                if dedup_result is not None:
+                    self._reset_execution_state(base_symbol)
+                    return dedup_result
                 if is_live_mode and not self._ensure_symbol_execution_ready_for_order(
                     trade_symbol or base_symbol, trace_id=trace_id
                 ):

--- a/tests/strategies/test_runner_live_path_guards.py
+++ b/tests/strategies/test_runner_live_path_guards.py
@@ -58,6 +58,7 @@ def _build_runner() -> StrategyRunner:
     runner._order_attempt_window = deque()
     runner._max_order_attempts_per_minute = 100
     runner._signal_direction_dedup_seconds = 45.0
+    runner._signal_direction_dedup_min_improvement = 2.0
     runner._signal_direction_last_emit = {}
     runner._record_trade = lambda *args, **kwargs: None
     runner._reset_execution_state = lambda *_args, **_kwargs: None
@@ -1395,3 +1396,68 @@ def test_directional_dedup_allows_better_candidate_within_window() -> None:
     second = runner._apply_directional_signal_dedup(signal=signal, metadata=stronger, underlying='NIFTY', now_epoch=now_epoch + 5.0, selected_symbol='NFO:NIFTY26APR23850PE', option_side='PE', selected_snapshot={'depth_available': True, 'distance_from_atm': 50})
     assert first is None
     assert second is None
+
+
+def test_directional_dedup_blocks_tiny_score_bump_if_quality_worse() -> None:
+    runner = _build_runner()
+    signal = Signal(action='BUY', symbol='NFO:NIFTY26APR23800PE', quantity=1, confidence=0.9, reason='OrderFlow', stop_loss=100.0, take_profit=120.0, metadata={})
+    first = runner._apply_directional_signal_dedup(
+        signal=signal,
+        metadata={'candidate_score': 8.0, 'tradable_quote': True, 'candidate_spread_pct': 0.4, 'candidate_tick_age_ms': 10.0},
+        underlying='NIFTY',
+        now_epoch=1000.0,
+        selected_symbol=signal.symbol,
+        option_side='PE',
+        selected_snapshot={'depth_available': True, 'distance_from_atm': 10},
+    )
+    second = runner._apply_directional_signal_dedup(
+        signal=signal,
+        metadata={'candidate_score': 8.1, 'tradable_quote': False, 'candidate_spread_pct': 8.0, 'candidate_tick_age_ms': 7000.0},
+        underlying='NIFTY',
+        now_epoch=1003.0,
+        selected_symbol='NFO:NIFTY26APR23850PE',
+        option_side='PE',
+        selected_snapshot={'depth_available': False, 'distance_from_atm': 300},
+    )
+    assert first is None
+    assert second is not None
+    assert second.reason == 'signal_duplicate_direction_cooldown'
+
+
+def test_dedup_prefers_tick_age_ms_over_candidate_tick_age_s() -> None:
+    runner = _build_runner()
+    signal = Signal(action='BUY', symbol='NFO:NIFTY26APR23800PE', quantity=1, confidence=0.9, reason='OrderFlow', stop_loss=100.0, take_profit=120.0, metadata={})
+    runner._apply_directional_signal_dedup(
+        signal=signal,
+        metadata={'candidate_score': 8.0, 'tradable_quote': True, 'candidate_spread_pct': 0.5, 'candidate_tick_age_ms': 0.0, 'candidate_tick_age_s': 9.0},
+        underlying='NIFTY',
+        now_epoch=1000.0,
+        selected_symbol=signal.symbol,
+        option_side='PE',
+        selected_snapshot={},
+    )
+    state = runner._signal_direction_last_emit['NIFTY:PE:OrderFlow']
+    assert state['ranking_fields']['tick_age_ms'] == 0.0
+
+
+def test_dedup_uses_zero_candidate_tick_age_s_without_fallback_default() -> None:
+    runner = _build_runner()
+    signal = Signal(action='BUY', symbol='NFO:NIFTY26APR23800PE', quantity=1, confidence=0.9, reason='OrderFlow', stop_loss=100.0, take_profit=120.0, metadata={})
+    runner._apply_directional_signal_dedup(
+        signal=signal,
+        metadata={'candidate_score': 8.0, 'tradable_quote': True, 'candidate_spread_pct': 0.5, 'candidate_tick_age_s': 0.0},
+        underlying='NIFTY',
+        now_epoch=1000.0,
+        selected_symbol=signal.symbol,
+        option_side='PE',
+        selected_snapshot={},
+    )
+    state = runner._signal_direction_last_emit['NIFTY:PE:OrderFlow']
+    assert state['ranking_fields']['tick_age_ms'] == 0.0
+
+
+def test_mark_directional_dedup_failed_clears_reservation() -> None:
+    runner = _build_runner()
+    runner._signal_direction_last_emit['NIFTY:PE:OrderFlow'] = {'status': 'reserved', 'rank_score': 10.0}
+    runner._mark_directional_dedup_failed(underlying='NIFTY', option_side='PE', reason='OrderFlow')
+    assert 'NIFTY:PE:OrderFlow' not in runner._signal_direction_last_emit

--- a/tests/strategies/test_runner_live_path_guards.py
+++ b/tests/strategies/test_runner_live_path_guards.py
@@ -57,6 +57,8 @@ def _build_runner() -> StrategyRunner:
     runner._cooldown_log_throttle_seconds = 1.0
     runner._order_attempt_window = deque()
     runner._max_order_attempts_per_minute = 100
+    runner._signal_direction_dedup_seconds = 45.0
+    runner._signal_direction_last_emit = {}
     runner._record_trade = lambda *args, **kwargs: None
     runner._reset_execution_state = lambda *_args, **_kwargs: None
     runner._entry_lock = threading.Lock()
@@ -1347,3 +1349,49 @@ def test_early_runtime_not_ready_cooldown_resets_execution_state() -> None:
     )
     assert result.reason == "runtime_symbol_execution_not_ready_reject_cooldown"
     runner._reset_execution_state.assert_called()
+
+
+def test_directional_dedup_blocks_second_pe_same_reason_within_window() -> None:
+    runner = _build_runner()
+    now_epoch = 1000.0
+    signal = Signal(action='BUY', symbol='NFO:NIFTY26APR23800PE', quantity=1, confidence=0.9, reason='OrderFlow', stop_loss=100.0, take_profit=120.0, metadata={})
+    metadata = {'candidate_score': 8.0, 'tradable_quote': True, 'candidate_spread_pct': 0.8}
+    first = runner._apply_directional_signal_dedup(signal=signal, metadata=metadata, underlying='NIFTY', now_epoch=now_epoch, selected_symbol=signal.symbol, option_side='PE', selected_snapshot={})
+    second = runner._apply_directional_signal_dedup(signal=signal, metadata=metadata, underlying='NIFTY', now_epoch=now_epoch + 10.0, selected_symbol='NFO:NIFTY26APR23850PE', option_side='PE', selected_snapshot={})
+    assert first is None
+    assert second is not None
+    assert second.reason == 'signal_duplicate_direction_cooldown'
+
+
+def test_directional_dedup_separates_pe_and_ce_keys() -> None:
+    runner = _build_runner()
+    now_epoch = 1000.0
+    pe = Signal(action='BUY', symbol='NFO:NIFTY26APR23800PE', quantity=1, confidence=0.9, reason='OrderFlow', stop_loss=100.0, take_profit=120.0, metadata={})
+    ce = Signal(action='BUY', symbol='NFO:NIFTY26APR23800CE', quantity=1, confidence=0.9, reason='OrderFlow', stop_loss=100.0, take_profit=120.0, metadata={})
+    metadata = {'candidate_score': 8.0, 'tradable_quote': True, 'candidate_spread_pct': 0.8}
+    runner._apply_directional_signal_dedup(signal=pe, metadata=metadata, underlying='NIFTY', now_epoch=now_epoch, selected_symbol=pe.symbol, option_side='PE', selected_snapshot={})
+    result = runner._apply_directional_signal_dedup(signal=ce, metadata=metadata, underlying='NIFTY', now_epoch=now_epoch + 5.0, selected_symbol=ce.symbol, option_side='CE', selected_snapshot={})
+    assert result is None
+
+
+def test_directional_dedup_separates_reason_keys() -> None:
+    runner = _build_runner()
+    now_epoch = 1000.0
+    s1 = Signal(action='BUY', symbol='NFO:NIFTY26APR23800PE', quantity=1, confidence=0.9, reason='OrderFlow', stop_loss=100.0, take_profit=120.0, metadata={})
+    s2 = Signal(action='BUY', symbol='NFO:NIFTY26APR23850PE', quantity=1, confidence=0.9, reason='Momentum', stop_loss=100.0, take_profit=120.0, metadata={})
+    metadata = {'candidate_score': 8.0, 'tradable_quote': True, 'candidate_spread_pct': 0.8}
+    runner._apply_directional_signal_dedup(signal=s1, metadata=metadata, underlying='NIFTY', now_epoch=now_epoch, selected_symbol=s1.symbol, option_side='PE', selected_snapshot={})
+    result = runner._apply_directional_signal_dedup(signal=s2, metadata=metadata, underlying='NIFTY', now_epoch=now_epoch + 5.0, selected_symbol=s2.symbol, option_side='PE', selected_snapshot={})
+    assert result is None
+
+
+def test_directional_dedup_allows_better_candidate_within_window() -> None:
+    runner = _build_runner()
+    now_epoch = 1000.0
+    signal = Signal(action='BUY', symbol='NFO:NIFTY26APR23800PE', quantity=1, confidence=0.9, reason='OrderFlow', stop_loss=100.0, take_profit=120.0, metadata={})
+    weaker = {'candidate_score': 6.0, 'tradable_quote': True, 'candidate_spread_pct': 1.2, 'candidate_tick_age_s': 2.0}
+    stronger = {'candidate_score': 8.5, 'tradable_quote': True, 'candidate_spread_pct': 0.5, 'candidate_tick_age_s': 0.5}
+    first = runner._apply_directional_signal_dedup(signal=signal, metadata=weaker, underlying='NIFTY', now_epoch=now_epoch, selected_symbol=signal.symbol, option_side='PE', selected_snapshot={'depth_available': False, 'distance_from_atm': 100})
+    second = runner._apply_directional_signal_dedup(signal=signal, metadata=stronger, underlying='NIFTY', now_epoch=now_epoch + 5.0, selected_symbol='NFO:NIFTY26APR23850PE', option_side='PE', selected_snapshot={'depth_available': True, 'distance_from_atm': 50})
+    assert first is None
+    assert second is None

--- a/tests/strategies/test_runner_live_path_guards.py
+++ b/tests/strategies/test_runner_live_path_guards.py
@@ -1461,3 +1461,38 @@ def test_mark_directional_dedup_failed_clears_reservation() -> None:
     runner._signal_direction_last_emit['NIFTY:PE:OrderFlow'] = {'status': 'reserved', 'rank_score': 10.0}
     runner._mark_directional_dedup_failed(underlying='NIFTY', option_side='PE', reason='OrderFlow')
     assert 'NIFTY:PE:OrderFlow' not in runner._signal_direction_last_emit
+
+
+def test_directional_dedup_fallback_selected_symbol_snapshot_without_candidates(monkeypatch) -> None:
+    runner = _build_runner()
+    monkeypatch.setenv('EXECUTION_MODE', 'SHADOW')
+    captured: dict[str, object] = {}
+
+    def _capture_dedup(**kwargs):
+        captured['selected_symbol'] = kwargs.get('selected_symbol')
+        captured['selected_snapshot'] = kwargs.get('selected_snapshot')
+        return SignalExecutionResult(False, 'dedup_test_stop')
+
+    runner._apply_directional_signal_dedup = _capture_dedup  # type: ignore[method-assign]
+
+    signal = Signal(
+        action='BUY',
+        symbol='NFO:NIFTY26APR23800PE',
+        quantity=1,
+        confidence=0.9,
+        reason='OrderFlow',
+        stop_loss=100.0,
+        take_profit=120.0,
+        metadata={'strategy_score': 7, 'option_score': 7, 'data_score': 7, 'rr_score': 7},
+    )
+    result = runner._handle_entry_signal_inner(
+        signal,
+        base_symbol='NFO:NIFTY26APR23800PE',
+        trade_symbol='NFO:NIFTY26APR23800PE',
+        trade_price=110.0,
+        timestamp=datetime.now(timezone.utc),
+        trace_id='dedup-fallback',
+    )
+    assert result.reason == 'dedup_test_stop'
+    assert captured['selected_symbol'] == 'NFO:NIFTY26APR23800PE'
+    assert captured['selected_snapshot'] == {}


### PR DESCRIPTION
### Motivation

- Repeated nearby option evaluations (same underlying + direction + reason) were forwarded independently and each consumed order-attempt budget, causing frequent `max_order_attempts_per_minute` rejections and signal spam.
- The intent is to preserve execution safety while preventing duplicate directional intent from exhausting the runner's order-attempt throttle.

### Description

- Added an env-configurable directional dedup cooldown `SIGNAL_DIRECTION_DEDUP_SECONDS` (default 45s) and in-memory state `self._signal_direction_last_emit` in `StrategyRunner` to track last emitted directional signals by key `underlying:direction:reason`.
- Implemented `_directional_dedup_key(...)` and `_apply_directional_signal_dedup(...)` which rank candidates by strategy/confidence score, `tradable_quote`, `spread_pct` (lower better), `tick_age_ms` (lower better), `depth_available`, `premium` within configured range, and distance from ATM, then: allow a better-ranked candidate inside the window while blocking lower-or-equal-ranked duplicates.
- Wired the dedup check into the live candidate execution path in `_handle_entry_signal_inner(...)` before order readiness checks and before appending to the order-attempt window so duplicates are filtered prior to consuming order-attempt capacity.
- Added structured logs: `SIGNAL_DEDUP_BLOCKED symbol direction reason key seconds_remaining` and `SIGNAL_CANDIDATE_SELECTED direction selected_symbol rejected_symbols ranking_fields` for traceability.
- Added unit tests exercising dedup behavior and key separation and updated the test runner fixture to initialize the new fields; no changes were made to order execution, risk gates, or market-data flow.

### Testing

- Ran `python -m compileall -q src` (passed).
- Ran focused tests `pytest -q tests/strategies/test_runner_live_path_guards.py` (passed).
- Ran `pytest -q tests/strategies` (passed).
- Ran full test suite `pytest -q` which produced one unrelated test failure in `tests/notifications/test_telegram_controller.py::test_cmd_unsubscribe_stream_supervisor` (failure reproduced but unrelated to these changes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0fd973b5e48324b679b362936afb2b)