### PR TITLE
execution-safety: fix OrderManager.place_order local time shadowing crash

### DIFF
--- a/src/nifty_scalper_bot/execution/order_manager.py
+++ b/src/nifty_scalper_bot/execution/order_manager.py
@@ -8,6 +8,7 @@ from contextlib import suppress
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from enum import Enum
+import hashlib
 import json
 import math
 import os
@@ -2167,11 +2168,6 @@ class OrderManager:
                 return None  # ❌ STOP HERE. DO NOT CALL BROKER.
 
         # =========================================================
-        from datetime import datetime, time as dtime, timezone
-        import hashlib
-        import time
-        from zoneinfo import ZoneInfo
-
         from nifty_scalper_bot.core.trading_switch import trading_switch
         from nifty_scalper_bot.risk import OrderSignal
 

--- a/tests/execution/test_order_manager_idempotency.py
+++ b/tests/execution/test_order_manager_idempotency.py
@@ -77,3 +77,41 @@ def test_place_order_fast_fill_bracket_without_trailing_fields_does_not_raise(mo
         get_bracket=lambda order_id: SimpleNamespace(entry_price=100.0, virtual_sl_id="SL1")
     )
     assert om.place_order('NFO:NIFTY26MAY23750CE', 'BUY', 1, order_type=OrderType.MARKET, stop_loss=10) == 'OID1'
+
+def test_place_order_kill_switch_path_does_not_raise_unboundlocalerror(monkeypatch):
+    om = _om('ok')
+    monkeypatch.setattr(om, '_lot_size_for_symbol', lambda s: 1)
+    om._kill_switch_active = True
+
+    result = om.place_order(
+        'NFO:NIFTY26MAY23750CE',
+        'BUY',
+        1,
+        order_type=OrderType.MARKET,
+        stop_loss=10,
+        signal_id='ks1',
+    )
+
+    assert result is None
+
+
+def test_place_order_live_option_signal_calls_broker_once_and_propagates_order_id(monkeypatch):
+    broker = _Broker('ok')
+    om = OrderManager(broker, _Pos(), _Limiter())
+    monkeypatch.setattr(om, '_lot_size_for_symbol', lambda s: 1)
+    monkeypatch.setattr(om, '_validate_live_execution_safety', lambda: True)
+    monkeypatch.setattr(om, '_confirm_fill_fast', lambda order_id, timeout_ms=300: False)
+
+    order_id = om.place_order(
+        'NFO:NIFTY26MAY23750CE',
+        'BUY',
+        1,
+        order_type=OrderType.MARKET,
+        stop_loss=10,
+        take_profit=20,
+        signal_id='ok1',
+        strategy_name='runner',
+    )
+
+    assert broker.calls == 1
+    assert order_id == 'OID1'


### PR DESCRIPTION
### Motivation
- Fix a production crash where `OrderManager.place_order()` raised `UnboundLocalError: cannot access local variable 'time'` because `time` was imported inside the function after earlier uses of `time.time()`. 
- Logs showed live trade attempts reached order placement and exploded on the early kill-switch/entry path; the root cause was Python treating `time` as a local name for the whole function when it was later imported there.

### Description
- Removed in-function shadowing imports from `place_order()` and ensured required modules are imported at module scope (`import time`, `import hashlib`, `from datetime import time as dtime`, `from datetime import datetime, timezone`, `from zoneinfo import ZoneInfo`).
- Kept `place_order()` logic intact so all calls to `time.time()` resolve to the module-level `time` and do not raise `UnboundLocalError`.
- Added two focused regression tests in `tests/execution/test_order_manager_idempotency.py`: one that exercises the kill-switch/early-exit path to assert no `UnboundLocalError`, and one that verifies a valid option signal reaches the broker mock once and the returned `order_id` is propagated.

### Testing
- Ran `python -m compileall -q src` and it passed without compilation errors.
- Ran `pytest -q tests/execution` and all tests (including the two new regressions) passed.
- Ran `pytest -q tests/strategies/test_runner_live_path_guards.py` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a100e7fba608324a9ad0d1bdead0c03)