### PR TITLE
Add live-mode log throttling to reduce noisy Railway logs while preserving critical events

### DIFF
--- a/src/nifty_scalper_bot/core/strategy_manager.py
+++ b/src/nifty_scalper_bot/core/strategy_manager.py
@@ -30,6 +30,7 @@ from nifty_scalper_bot.strategies.signal_generator import (
 from nifty_scalper_bot.strategies.signal_generator import (
     StrategyManager as _BaseStrategyManager,
 )
+from nifty_scalper_bot.utils.log_throttle import log_throttled as log_throttled_live
 from nifty_scalper_bot.utils.logging import get_logger, log_state_change, log_throttled
 from nifty_scalper_bot.utils.symbols import normalize_symbol
 
@@ -2705,12 +2706,16 @@ class StrategyManager(_BaseStrategyManager):
                 empty.append(strategy.name)
                 reason = str(getattr(strategy, "last_no_vote_reason", "none") or "none")
                 no_vote_reason_counts[reason] = no_vote_reason_counts.get(reason, 0) + 1
-                log_throttled(
+                log_throttled_live(
                     log,
-                    key=f"strategy_no_vote:{symbol}:{strategy.name}:{reason}",
-                    msg=f"STRATEGY_NO_VOTE strategy={strategy.name} symbol={symbol} reason={reason}",
-                    interval_sec=15.0,
-                    level=logging.INFO,
+                    logging.INFO,
+                    "STRATEGY_NO_VOTE",
+                    f"STRATEGY_NO_VOTE:{strategy.name}:{symbol}:{reason}",
+                    float(os.getenv("LOG_THROTTLE_STRATEGY_NO_VOTE_SECONDS", "45") or "45"),
+                    "STRATEGY_NO_VOTE strategy=%s symbol=%s reason=%s",
+                    strategy.name,
+                    symbol,
+                    reason,
                 )
                 continue
             entry = score_map.get(strategy.name)
@@ -3134,7 +3139,12 @@ class StrategyManager(_BaseStrategyManager):
                             "tick_direction": merged_md.get("tick_direction"),
                         }
                     )
-                log.info(
+                log_throttled_live(
+                    log,
+                    logging.INFO,
+                    "TRADE_DECISION_TRACE",
+                    f"TRADE_DECISION_TRACE:{symbol_norm}:no_trigger_vote:{indicator_map.get('direction_bias')}",
+                    float(os.getenv("LOG_THROTTLE_NO_TRADE_TRACE_SECONDS", "30") or "30"),
                     "TRADE_DECISION_TRACE approval_path=%s blocked_at=%s blocked_reason=%s "
                     "symbol=%s context_votes=%s context_sides=%s context_scores=%s "
                     "direction_bias=%s underlying_direction_bias=%s context_age_seconds=%s context_trigger_details=%s",

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -39,6 +39,7 @@ from nifty_scalper_bot.streaming.websocket_manager import (
 )
 from nifty_scalper_bot.utils.env import get_str
 from nifty_scalper_bot.utils.async_helpers import safe_task
+from nifty_scalper_bot.utils.log_throttle import log_throttled as log_throttled_live
 from nifty_scalper_bot.utils.logging import get_logger, get_tracer_logger, log_throttled
 from nifty_scalper_bot.utils.market_hours import (
     MarketState,
@@ -4318,7 +4319,9 @@ class MarketDataManager:
                     last_logged = float(self._ws_raw_tick_log_at.get(symbol_resolved, 0.0))
                     if last_logged <= 0.0 or (now - last_logged) >= 60.0:
                         self._ws_raw_tick_log_at[symbol_resolved] = now
-                        self._logger.info(
+                        verbose_ticks = str(os.getenv("LOG_VERBOSE_TICKS", "false")).strip().lower() in {"1", "true", "yes", "y", "on"}
+                        self._logger.log(
+                            logging.INFO if verbose_ticks else logging.DEBUG,
                             "WS_RAW_TICK_RECEIVED token=%s symbol_resolved=%s ltp=%s",
                             token_int,
                             symbol_resolved,
@@ -4789,9 +4792,12 @@ class MarketDataManager:
             return
         self._ingest_normalized_tick(normalized_live)
         if bool(normalized_live.get("tradable_quote")):
-            log_throttled(
+            log_throttled_live(
                 self._logger,
-                f"ws_full_quote_proof:{symbol}",
+                logging.INFO,
+                "WS_FULL_QUOTE_PROOF",
+                f"WS_FULL_QUOTE_PROOF:{symbol}",
+                float(os.getenv("LOG_THROTTLE_WS_PROOF_SECONDS", "60") or "60"),
                 "WS_FULL_QUOTE_PROOF symbol=%s token=%s ltp=%s bid=%s ask=%s spread=%s depth_available=%s tradable_quote=%s",
                 symbol,
                 token_value,
@@ -4801,8 +4807,7 @@ class MarketDataManager:
                 normalized_live.get("spread"),
                 normalized_live.get("depth_available"),
                 normalized_live.get("tradable_quote"),
-                interval_sec=30.0,
-                level=logging.INFO,
+                extra={"event": "WS_FULL_QUOTE_PROOF", "symbol": symbol},
             )
         if candle:
             bar = {
@@ -4817,7 +4822,9 @@ class MarketDataManager:
             }
             self._ohlc[symbol].append(bar)
             self._publish_closed_bar(bar)
-            self._logger.info(
+            verbose_candles = str(os.getenv("LOG_VERBOSE_CANDLES", "false")).strip().lower() in {"1", "true", "yes", "y", "on"}
+            self._logger.log(
+                logging.INFO if verbose_candles else logging.DEBUG,
                 "LIVE_CANDLE_CLOSED symbol=%s source=ws_candle close=%s",
                 symbol,
                 bar["close"],

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -93,6 +93,7 @@ from nifty_scalper_bot.strategies.signal_quality import (
 from nifty_scalper_bot.strategies.trade_selector import TradeCandidateSelector
 from nifty_scalper_bot.utils import metrics
 from nifty_scalper_bot.utils.errors import OrderPlacementError
+from nifty_scalper_bot.utils.log_throttle import log_throttled as log_throttled_live
 from nifty_scalper_bot.utils.logging import LogThrottle, get_logger, log_throttled
 from nifty_scalper_bot.utils.market_hours import (
     MarketState,
@@ -3531,24 +3532,26 @@ class StrategyRunner:
             if gap_count > 1:
                 reason = "repeated_missing_candles" if recent_tick else "no_recent_tick_for_gap_assessment"
                 log_level = logging.INFO if is_option and recent_tick else logging.WARNING
-                log_throttled(
+                log_throttled_live(
                     self._logger,
-                    f"soft_data_issue:{symbol}",
+                    log_level,
+                    "SOFT_DATA_ISSUE",
+                    f"SOFT_DATA_ISSUE:{symbol}:{reason}",
+                    float(os.getenv("LOG_THROTTLE_SOFT_DATA_SECONDS", "60") or "60"),
                     f"SOFT_DATA_ISSUE symbol={symbol} reason={reason} source=candle_gap_detector age_s={tick_age_s}",
-                    interval_sec=60.0,
-                    level=log_level,
                     extra={"event": "SOFT_DATA_ISSUE", "symbol": symbol, "reason": reason, "source": "candle_gap_detector", "age_s": tick_age_s, "details": {"gaps": gap_count}, "gaps": gap_count},
                 )
                 if gap_count > 1 and recent_tick:
                     return self._set_symbol_hydration_state(symbol, SymbolState.DEGRADED)
             else:
                 reason = "single_missing_candle" if recent_tick else "no_recent_tick_for_gap_assessment"
-                log_throttled(
+                log_throttled_live(
                     self._logger,
-                    f"soft_data_issue:{symbol}",
+                    logging.INFO,
+                    "SOFT_DATA_ISSUE",
+                    f"SOFT_DATA_ISSUE:{symbol}:{reason}",
+                    float(os.getenv("LOG_THROTTLE_SOFT_DATA_SECONDS", "60") or "60"),
                     f"SOFT_DATA_ISSUE symbol={symbol} reason={reason} source=candle_gap_detector age_s={tick_age_s}",
-                    interval_sec=60.0,
-                    level=logging.INFO,
                     extra={"event": "SOFT_DATA_ISSUE", "symbol": symbol, "reason": reason, "source": "candle_gap_detector", "age_s": tick_age_s, "details": {"gaps": gap_count}},
                 )
                 if gap_count > 1 and recent_tick:
@@ -5732,7 +5735,12 @@ class StrategyRunner:
             }
             if context:
                 payload.update(context)
-            self._logger.info(
+            log_throttled_live(
+                self._logger,
+                logging.INFO,
+                "RUNNER_EVAL_DECISION",
+                f"RUNNER_EVAL_DECISION:{symbol}:{reason}:{stage}",
+                float(os.getenv("LOG_THROTTLE_RUNNER_EVAL_SECONDS", "15") or "15"),
                 "RUNNER_EVAL_DECISION symbol=%s allowed=%s stage=%s reason=%s "
                 "indicator_history_count=%s live_candle_version=%s "
                 "last_eval_live_candle_version=%s quote_update_version=%s "
@@ -9148,13 +9156,19 @@ class StrategyRunner:
                 prev_rank_score = float(prev.get("rank_score", 0.0) or 0.0)
                 if (rank_score - prev_rank_score) < self._signal_direction_dedup_min_improvement:
                     remaining = max(0.0, self._signal_direction_dedup_seconds - elapsed)
-                    self._logger.info(
+                    log_throttled_live(
+                        self._logger,
+                        logging.INFO,
+                        "SIGNAL_DEDUP_BLOCKED",
+                        f"SIGNAL_DEDUP_BLOCKED:{underlying}:{option_side}:{reason}",
+                        float(os.getenv("LOG_THROTTLE_DEDUP_SECONDS", "15") or "15"),
                         "SIGNAL_DEDUP_BLOCKED symbol=%s direction=%s reason=%s key=%s seconds_remaining=%.2f",
                         selected_symbol,
                         option_side,
                         reason,
                         key,
                         remaining,
+                        extra={"event": "SIGNAL_DEDUP_BLOCKED", "symbol": selected_symbol, "direction": option_side, "reason": reason},
                     )
                     return SignalExecutionResult(
                         False, "signal_duplicate_direction_cooldown"

--- a/src/nifty_scalper_bot/utils/log_throttle.py
+++ b/src/nifty_scalper_bot/utils/log_throttle.py
@@ -47,6 +47,8 @@ class LogThrottle:
                 return
             self._summary_last_emit_mono = now
             pending = {k: v for k, v in self._suppressed.items() if int(v) > 0}
+            for key in pending:
+                self._suppressed[key] = 0
         for key, suppressed in pending.items():
             event = key.split(":", 1)[0]
             logger.info(

--- a/src/nifty_scalper_bot/utils/log_throttle.py
+++ b/src/nifty_scalper_bot/utils/log_throttle.py
@@ -1,0 +1,85 @@
+"""Reusable monotonic log throttling utilities."""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from collections import defaultdict
+from typing import Any
+
+
+class LogThrottle:
+    """Thread-safe per-key log throttle with suppression counters."""
+
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
+        self._last_emit_mono: dict[str, float] = {}
+        self._suppressed: dict[str, int] = defaultdict(int)
+        self._summary_last_emit_mono: float = 0.0
+
+    def should_log(self, key: str, interval_seconds: float) -> bool:
+        """Return True when interval elapsed for key using monotonic time."""
+        now = time.monotonic()
+        with self._lock:
+            last = float(self._last_emit_mono.get(key, 0.0) or 0.0)
+            if last > 0.0 and (now - last) < max(0.0, float(interval_seconds)):
+                return False
+            self._last_emit_mono[key] = now
+            return True
+
+    def record_suppressed(self, key: str) -> None:
+        with self._lock:
+            self._suppressed[key] += 1
+
+    def pop_suppressed(self, key: str) -> int:
+        with self._lock:
+            value = int(self._suppressed.get(key, 0) or 0)
+            if key in self._suppressed:
+                self._suppressed[key] = 0
+            return value
+
+    def maybe_emit_summary(self, logger: logging.Logger, *, interval_seconds: float = 60.0) -> None:
+        """Emit periodic aggregate suppression summary."""
+        now = time.monotonic()
+        with self._lock:
+            if self._summary_last_emit_mono > 0 and (now - self._summary_last_emit_mono) < interval_seconds:
+                return
+            self._summary_last_emit_mono = now
+            pending = {k: v for k, v in self._suppressed.items() if int(v) > 0}
+        for key, suppressed in pending.items():
+            event = key.split(":", 1)[0]
+            logger.info(
+                "LOG_THROTTLE_SUMMARY event=%s suppressed=%s key=%s",
+                event,
+                suppressed,
+                key,
+                extra={"event": "LOG_THROTTLE_SUMMARY", "throttled_event": event, "suppressed": suppressed, "key": key},
+            )
+
+
+DEFAULT_LOG_THROTTLE = LogThrottle()
+
+
+def log_throttled(
+    logger: logging.Logger,
+    level: int,
+    event: str,
+    key: str,
+    interval_seconds: float,
+    message: str,
+    *args: Any,
+    **kwargs: Any,
+) -> bool:
+    """Emit throttled log with suppressed_count from previous interval."""
+    throttle: LogThrottle = kwargs.pop("throttle", DEFAULT_LOG_THROTTLE)
+    extra = dict(kwargs.pop("extra", {}) or {})
+    if throttle.should_log(key, interval_seconds):
+        suppressed = throttle.pop_suppressed(key)
+        extra.setdefault("event", event)
+        extra["suppressed_count"] = suppressed
+        logger.log(level, message, *args, extra=extra, **kwargs)
+        throttle.maybe_emit_summary(logger, interval_seconds=60.0)
+        return True
+    throttle.record_suppressed(key)
+    return False

--- a/tests/utils/test_log_throttle.py
+++ b/tests/utils/test_log_throttle.py
@@ -46,3 +46,35 @@ def test_critical_order_events_not_throttled(caplog):
 def test_verbose_env_flags_default_false():
     assert str(os.getenv("LOG_VERBOSE_TICKS", "false")).strip().lower() not in {"1", "true", "yes", "y", "on"}
     assert str(os.getenv("LOG_VERBOSE_CANDLES", "false")).strip().lower() not in {"1", "true", "yes", "y", "on"}
+
+
+def test_summary_clears_suppressed_counts(caplog):
+    throttle = LogThrottle()
+    logger = logging.getLogger("test.summary.clear")
+    with caplog.at_level(logging.INFO):
+        assert log_throttled(logger, logging.INFO, "EV", "EV:k1", 10.0, "first", throttle=throttle)
+        assert not log_throttled(logger, logging.INFO, "EV", "EV:k1", 10.0, "supp1", throttle=throttle)
+        assert not log_throttled(logger, logging.INFO, "EV", "EV:k1", 10.0, "supp2", throttle=throttle)
+        throttle.maybe_emit_summary(logger, interval_seconds=0.0)
+        first_summaries = [r for r in caplog.records if r.message.startswith("LOG_THROTTLE_SUMMARY")]
+        assert len(first_summaries) == 1
+        assert getattr(first_summaries[0], "suppressed", None) == 2
+        caplog.clear()
+        throttle._summary_last_emit_mono = 0.0
+        throttle.maybe_emit_summary(logger, interval_seconds=0.0)
+        second_summaries = [r for r in caplog.records if r.message.startswith("LOG_THROTTLE_SUMMARY")]
+        assert len(second_summaries) == 0
+
+
+def test_suppressed_count_after_summary_tracks_only_new_suppression(caplog):
+    throttle = LogThrottle()
+    logger = logging.getLogger("test.summary.new_only")
+    with caplog.at_level(logging.INFO):
+        assert log_throttled(logger, logging.INFO, "EV", "EV:k2", 10.0, "first", throttle=throttle)
+        assert not log_throttled(logger, logging.INFO, "EV", "EV:k2", 10.0, "supp1", throttle=throttle)
+        assert not log_throttled(logger, logging.INFO, "EV", "EV:k2", 10.0, "supp2", throttle=throttle)
+        throttle.maybe_emit_summary(logger, interval_seconds=0.0)
+        assert not log_throttled(logger, logging.INFO, "EV", "EV:k2", 10.0, "supp3", throttle=throttle)
+        assert log_throttled(logger, logging.INFO, "EV", "EV:k2", 0.0, "after", throttle=throttle)
+    emitted = [r for r in caplog.records if r.message == "after"][0]
+    assert getattr(emitted, "suppressed_count", None) == 1

--- a/tests/utils/test_log_throttle.py
+++ b/tests/utils/test_log_throttle.py
@@ -1,0 +1,48 @@
+import logging
+import os
+
+from nifty_scalper_bot.utils.log_throttle import LogThrottle, log_throttled
+
+
+def test_same_key_suppresses_within_interval(caplog):
+    throttle = LogThrottle()
+    logger = logging.getLogger("test.same_key")
+    with caplog.at_level(logging.INFO):
+        assert log_throttled(logger, logging.INFO, "EV", "k1", 10.0, "msg", throttle=throttle)
+        assert not log_throttled(logger, logging.INFO, "EV", "k1", 10.0, "msg", throttle=throttle)
+    assert [r.message for r in caplog.records if r.message == "msg"] == ["msg"]
+
+
+def test_different_keys_do_not_suppress_each_other(caplog):
+    throttle = LogThrottle()
+    logger = logging.getLogger("test.diff_keys")
+    with caplog.at_level(logging.INFO):
+        assert log_throttled(logger, logging.INFO, "EV", "k1", 10.0, "msg1", throttle=throttle)
+        assert log_throttled(logger, logging.INFO, "EV", "k2", 10.0, "msg2", throttle=throttle)
+    assert any(r.message == "msg1" for r in caplog.records)
+    assert any(r.message == "msg2" for r in caplog.records)
+
+
+def test_suppressed_count_emitted_on_next_log(caplog):
+    throttle = LogThrottle()
+    logger = logging.getLogger("test.suppressed_count")
+    with caplog.at_level(logging.INFO):
+        log_throttled(logger, logging.INFO, "EV", "k1", 10.0, "first", throttle=throttle)
+        log_throttled(logger, logging.INFO, "EV", "k1", 10.0, "supp", throttle=throttle)
+        assert log_throttled(logger, logging.INFO, "EV", "k1", 0.0, "second", throttle=throttle)
+    second = [r for r in caplog.records if r.message == "second"][0]
+    assert getattr(second, "suppressed_count", 0) == 1
+
+
+def test_critical_order_events_not_throttled(caplog):
+    throttle = LogThrottle()
+    logger = logging.getLogger("test.critical")
+    with caplog.at_level(logging.INFO):
+        assert log_throttled(logger, logging.INFO, "ORDER_PATH_ENTERED", "order:k1", 0.0, "order path", throttle=throttle)
+        assert log_throttled(logger, logging.INFO, "ORDER_PATH_ENTERED", "order:k1", 0.0, "order path", throttle=throttle)
+    assert sum(1 for r in caplog.records if r.message == "order path") == 2
+
+
+def test_verbose_env_flags_default_false():
+    assert str(os.getenv("LOG_VERBOSE_TICKS", "false")).strip().lower() not in {"1", "true", "yes", "y", "on"}
+    assert str(os.getenv("LOG_VERBOSE_CANDLES", "false")).strip().lower() not in {"1", "true", "yes", "y", "on"}


### PR DESCRIPTION
### Motivation

- Reduce high-frequency live logging (ticks, candle closes, runner evals, strategy no-vote/no-trade traces, dedup blocks) that floods Railway without hiding trading‑critical failures.
- Provide carry-forward suppressed counts and a periodic summary so operators can see when events were rate-limited.

### Description

- Added `src/nifty_scalper_bot/utils/log_throttle.py` implementing `LogThrottle` (thread-safe via `RLock`, monotonic time), with `should_log`, `record_suppressed`, `pop_suppressed`, periodic `LOG_THROTTLE_SUMMARY`, and a helper `log_throttled(...)` that attaches `suppressed_count` to emitted records.
- Wired throttling and verbosity controls into hot paths: updated `src/nifty_scalper_bot/strategies/runner.py` to throttle `RUNNER_EVAL_DECISION` (key `RUNNER_EVAL_DECISION:{symbol}:{reason}:{stage}`, env `LOG_THROTTLE_RUNNER_EVAL_SECONDS`, default 15s), throttle `SOFT_DATA_ISSUE` (env `LOG_THROTTLE_SOFT_DATA_SECONDS`, default 60s), and throttle `SIGNAL_DEDUP_BLOCKED` (env `LOG_THROTTLE_DEDUP_SECONDS`, default 15s).
- Updated `src/nifty_scalper_bot/core/strategy_manager.py` to throttle `STRATEGY_NO_VOTE` (key `STRATEGY_NO_VOTE:{strategy}:{symbol}:{reason}`, env `LOG_THROTTLE_STRATEGY_NO_VOTE_SECONDS`, default 45s) and the no‑trigger `TRADE_DECISION_TRACE` path (env `LOG_THROTTLE_NO_TRADE_TRACE_SECONDS`, default 30s).
- Updated `src/nifty_scalper_bot/data/market_data_manager.py` to make `WS_RAW_TICK_RECEIVED` DEBUG by default (opt-in `LOG_VERBOSE_TICKS=true` for INFO) and `LIVE_CANDLE_CLOSED` DEBUG by default (opt-in `LOG_VERBOSE_CANDLES=true`), and to throttle `WS_FULL_QUOTE_PROOF` (env `LOG_THROTTLE_WS_PROOF_SECONDS`, default 60s).
- Kept all critical execution/order/broker events unchanged (no throttling): errors/exceptions, order submission/response events, kill-switch/risk blocks, position open/close remain unthrottled.
- Added unit tests `tests/utils/test_log_throttle.py` covering same-key suppression, independent keys, suppressed_count carryover, critical zero‑interval behavior, and default verbose flags.

### Testing

- Ran `python -m compileall -q src` and compilation passed.
- Ran focused tests and they passed: `pytest -q tests/utils` (new throttle tests) — pass; `pytest -q tests/strategies/test_runner_live_path_guards.py` — pass; `pytest -q tests/data` — pass; `pytest -q tests/execution` — pass.
- No execution or risk logic was modified and no other tests regressed in the focused suites.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a101035964083248698178bfb986e57)