### PR TITLE
Resolve missing live direction context, controlled OrderFlow promotion, and compact post-close logging

### DIFF
--- a/src/nifty_scalper_bot/core/strategy_manager.py
+++ b/src/nifty_scalper_bot/core/strategy_manager.py
@@ -2013,6 +2013,17 @@ class StrategyManager(_BaseStrategyManager):
     def _context_direction_valid(ctx: t.Mapping[str, t.Any]) -> bool:
         return str(ctx.get("direction_bias") or ctx.get("underlying_direction_bias") or "").upper() in {"CE", "PE"}
 
+    @staticmethod
+    def _context_tick_age_seconds(ctx: t.Mapping[str, t.Any]) -> float | None:
+        raw = ctx.get("tick_age_ms")
+        if raw is None:
+            return None
+        try:
+            age_ms = float(raw)
+        except (TypeError, ValueError):
+            return None
+        return age_ms / 1000.0 if age_ms >= 0 else None
+
     def _strategy_required_indicator_union(self) -> set[str]:
         required = set(getattr(self, "_required_indicators", set()) or set())
         try:
@@ -2553,6 +2564,8 @@ class StrategyManager(_BaseStrategyManager):
             fut_fresh = _fresh(fut_ctx)
             spot_direction_valid = self._context_direction_valid(spot_ctx)
             fut_direction_valid = self._context_direction_valid(fut_ctx)
+            spot_tick_age_s = self._context_tick_age_seconds(spot_ctx)
+            fut_tick_age_s = self._context_tick_age_seconds(fut_ctx)
             spot_usable = spot_fresh and spot_direction_valid
             fut_usable = fut_fresh and fut_direction_valid
             if spot_fresh and not spot_direction_valid:
@@ -2578,7 +2591,54 @@ class StrategyManager(_BaseStrategyManager):
                 except (TypeError, ValueError):
                     indicators["underlying_direction_confidence"] = 0.0
                 indicators["context_age_seconds"] = min(now_ts - float(spot_ctx.get("timestamp", now_ts)) if spot_usable else max_context_age + 1, now_ts - float(fut_ctx.get("timestamp", now_ts)) if fut_usable else max_context_age + 1)
+                indicators["context_fresh"] = True
+                indicators["direction_context_source"] = "primary"
+                log_throttled(
+                    log,
+                    f"direction_context_resolved_primary:{symbol}",
+                    "DIRECTION_CONTEXT_RESOLVED source=primary bias=%s confidence=%.2f age_s=%.2f symbol=%s",
+                    indicators["direction_bias"],
+                    float(indicators.get("underlying_direction_confidence") or 0.0),
+                    float(indicators.get("context_age_seconds") or 999.0),
+                    symbol,
+                    interval_sec=30.0,
+                    level=logging.INFO,
+                )
             else:
+                fallback_ctx = spot_ctx if spot_fresh else fut_ctx if fut_fresh else {}
+                fallback_direction, fallback_conf, fallback_reasons = self._derive_context_direction(
+                    fallback_ctx,
+                    role=str(fallback_ctx.get("role") or "spot_context"),
+                )
+                if str(fallback_direction or "").upper() in {"CE", "PE"}:
+                    fallback_age = (
+                        min(v for v in [spot_tick_age_s, fut_tick_age_s] if v is not None)
+                        if any(v is not None for v in [spot_tick_age_s, fut_tick_age_s])
+                        else (
+                            now_ts - float(fallback_ctx.get("timestamp", now_ts))
+                            if fallback_ctx
+                            else max_context_age + 1
+                        )
+                    )
+                    indicators["direction_bias"] = str(fallback_direction).upper()
+                    indicators["underlying_direction_bias"] = str(fallback_direction).upper()
+                    indicators["underlying_direction_confidence"] = float(max(fallback_conf, 0.05))
+                    indicators["context_age_seconds"] = float(max(0.0, fallback_age))
+                    indicators["context_fresh"] = bool(indicators["context_age_seconds"] <= max_context_age)
+                    indicators["direction_context_source"] = "fallback"
+                    indicators["direction_context_reasons"] = fallback_reasons
+                    log_throttled(
+                        log,
+                        f"direction_context_resolved_fallback:{symbol}",
+                        "DIRECTION_CONTEXT_RESOLVED source=fallback bias=%s confidence=%.2f age_s=%.2f symbol=%s reasons=%s",
+                        indicators["direction_bias"],
+                        float(indicators.get("underlying_direction_confidence") or 0.0),
+                        float(indicators.get("context_age_seconds") or 999.0),
+                        symbol,
+                        fallback_reasons,
+                        interval_sec=30.0,
+                        level=logging.INFO,
+                    )
                 log_throttled(
                     log,
                     f"option_underlying_context_missing:{symbol}",
@@ -2615,6 +2675,8 @@ class StrategyManager(_BaseStrategyManager):
                         "fut_direction_reasons": fut_ctx.get("direction_context_reasons"),
                         "spot_ctx_keys": sorted(list(spot_ctx.keys())),
                         "fut_ctx_keys": sorted(list(fut_ctx.keys())),
+                        "spot_tick_age_ms": spot_ctx.get("tick_age_ms"),
+                        "futures_tick_age_ms": fut_ctx.get("tick_age_ms"),
                     },
                 )
             if fut_fresh and fut_ctx.get("futures_volume_ratio") is not None:
@@ -3176,6 +3238,12 @@ class StrategyManager(_BaseStrategyManager):
                         "direction_bias": indicator_map.get("direction_bias"),
                         "underlying_direction_bias": indicator_map.get("underlying_direction_bias"),
                         "context_age_seconds": indicator_map.get("context_age_seconds"),
+                        "direction_context_source": indicator_map.get("direction_context_source"),
+                        "direction_context_age_s": indicator_map.get("context_age_seconds"),
+                        "direction_context_confidence": indicator_map.get("underlying_direction_confidence"),
+                        "spot_tick_age_ms": (indicator_map.get("spot_context") or {}).get("tick_age_ms") if isinstance(indicator_map.get("spot_context"), dict) else None,
+                        "futures_tick_age_ms": (indicator_map.get("futures_context") or {}).get("tick_age_ms") if isinstance(indicator_map.get("futures_context"), dict) else None,
+                        "direction_missing_reason": "direction_bias_none" if str(indicator_map.get("direction_bias") or "").upper() not in {"CE", "PE"} else None,
                     },
                 )
                 log_throttled(
@@ -3623,13 +3691,34 @@ class StrategyManager(_BaseStrategyManager):
                 return None
         opposite = [v for _, v in context_votes if v.side in {"CE", "PE"} and v.side != best_vote.side]
         vetoed = bool(opposite and max(self._extract_context_veto_score(v) for v in opposite) >= 8.0)
-        if best_vote.strategy not in allowed_strategies or raw_score < min_score or best_vote.confidence < min_conf or best_vote.side not in {"CE", "PE"} or not selected_ok or vetoed:
+        direction_bias = str(
+            md0.get("direction_bias")
+            or md0.get("underlying_direction_bias")
+            or indicators.get("direction_bias")
+            or indicators.get("underlying_direction_bias")
+            or ""
+        ).upper()
+        direction_aligned = direction_bias in {"CE", "PE"} and direction_bias == str(best_vote.side).upper()
+        if best_vote.strategy not in allowed_strategies or raw_score < min_score or best_vote.confidence < min_conf or best_vote.side not in {"CE", "PE"} or not selected_ok or vetoed or not direction_aligned:
             return None
         md = dict(best_signal.metadata or {})
         md.update(selected_meta)
         md.update({"role": "trigger", "promoted_from_context": True, "consensus_stage": "context_promoted_controlled", "promotion_reason": "context_only_quality_pass"})
         promoted = Signal(action="BUY", symbol=best_signal.symbol, quantity=best_signal.quantity, confidence=best_signal.confidence, reason=best_signal.reason, stop_loss=best_signal.stop_loss, take_profit=best_signal.take_profit, metadata=md)
         promoted_vote = StrategyVote(strategy=best_vote.strategy, side=best_vote.side, score=best_vote.score, confidence=best_vote.confidence, reasons=list(best_vote.reasons), metadata=md)
+        log.info(
+            "ORDERFLOW_TRIGGER_PROMOTED side=%s score=%.2f reason=direction_context_aligned symbol=%s",
+            best_vote.side,
+            raw_score,
+            symbol,
+            extra={
+                "event": "ORDERFLOW_TRIGGER_PROMOTED",
+                "symbol": symbol,
+                "side": best_vote.side,
+                "score": raw_score,
+                "reason": "direction_context_aligned",
+            },
+        )
         return promoted, promoted_vote
 
     def _compute_trade_quality_score(

--- a/src/nifty_scalper_bot/core/strategy_manager.py
+++ b/src/nifty_scalper_bot/core/strategy_manager.py
@@ -2583,6 +2583,8 @@ class StrategyManager(_BaseStrategyManager):
                 indicators.setdefault("futures_context", fut_ctx)
             direction_bias = (indicators.get("direction_bias") or indicators.get("underlying_direction_bias") or (spot_ctx.get("direction_bias") if spot_usable else None) or (fut_ctx.get("direction_bias") if fut_usable else None))
             direction_confidence = (indicators.get("underlying_direction_confidence") or (spot_ctx.get("underlying_direction_confidence") if spot_usable else None) or (fut_ctx.get("underlying_direction_confidence") if fut_usable else None) or 0.0)
+            context_resolved = False
+            direction_context_source: str | None = None
             if str(direction_bias or "").upper() in {"CE", "PE"}:
                 indicators["direction_bias"] = str(direction_bias).upper()
                 indicators["underlying_direction_bias"] = str(direction_bias).upper()
@@ -2593,6 +2595,8 @@ class StrategyManager(_BaseStrategyManager):
                 indicators["context_age_seconds"] = min(now_ts - float(spot_ctx.get("timestamp", now_ts)) if spot_usable else max_context_age + 1, now_ts - float(fut_ctx.get("timestamp", now_ts)) if fut_usable else max_context_age + 1)
                 indicators["context_fresh"] = True
                 indicators["direction_context_source"] = "primary"
+                context_resolved = True
+                direction_context_source = "primary"
                 log_throttled(
                     log,
                     f"direction_context_resolved_primary:{symbol}",
@@ -2627,6 +2631,8 @@ class StrategyManager(_BaseStrategyManager):
                     indicators["context_fresh"] = bool(indicators["context_age_seconds"] <= max_context_age)
                     indicators["direction_context_source"] = "fallback"
                     indicators["direction_context_reasons"] = fallback_reasons
+                    direction_context_source = "fallback"
+                    context_resolved = bool(indicators["context_fresh"])
                     log_throttled(
                         log,
                         f"direction_context_resolved_fallback:{symbol}",
@@ -2639,46 +2645,48 @@ class StrategyManager(_BaseStrategyManager):
                         interval_sec=30.0,
                         level=logging.INFO,
                     )
-                log_throttled(
-                    log,
-                    f"option_underlying_context_missing:{symbol}",
-                    "OPTION_UNDERLYING_CONTEXT_MISSING symbol=%s spot_ctx_present=%s futures_ctx_present=%s spot_ctx_age=%s futures_ctx_age=%s selected_ce=%s selected_pe=%s",
-                    symbol,
-                    bool(spot_ctx),
-                    bool(fut_ctx),
-                    (now_ts - float(spot_ctx.get("timestamp", now_ts))) if spot_ctx else None,
-                    (now_ts - float(fut_ctx.get("timestamp", now_ts))) if fut_ctx else None,
-                    indicators.get("selected_ce"),
-                    indicators.get("selected_pe"),
-                    interval_sec=30.0,
-                    level=logging.INFO,
-                )
-                log_throttled(
-                    log,
-                    f"option_context_missing_direction_bias:{symbol}",
-                    "OPTION_CONTEXT_MISSING_DIRECTION_BIAS symbol=%s spot_fresh=%s fut_fresh=%s spot_direction_valid=%s fut_direction_valid=%s",
-                    symbol,
-                    spot_fresh,
-                    fut_fresh,
-                    spot_direction_valid,
-                    fut_direction_valid,
-                    interval_sec=30.0,
-                    level=logging.INFO,
-                    extra={
-                        "event": "OPTION_CONTEXT_MISSING_DIRECTION_BIAS",
-                        "symbol": symbol,
-                        "spot_fresh": spot_fresh,
-                        "fut_fresh": fut_fresh,
-                        "spot_direction_valid": spot_direction_valid,
-                        "fut_direction_valid": fut_direction_valid,
-                        "spot_direction_reasons": spot_ctx.get("direction_context_reasons"),
-                        "fut_direction_reasons": fut_ctx.get("direction_context_reasons"),
-                        "spot_ctx_keys": sorted(list(spot_ctx.keys())),
-                        "fut_ctx_keys": sorted(list(fut_ctx.keys())),
-                        "spot_tick_age_ms": spot_ctx.get("tick_age_ms"),
-                        "futures_tick_age_ms": fut_ctx.get("tick_age_ms"),
-                    },
-                )
+                if not context_resolved:
+                    log_throttled(
+                        log,
+                        f"option_underlying_context_missing:{symbol}",
+                        "OPTION_UNDERLYING_CONTEXT_MISSING symbol=%s spot_ctx_present=%s futures_ctx_present=%s spot_ctx_age=%s futures_ctx_age=%s selected_ce=%s selected_pe=%s",
+                        symbol,
+                        bool(spot_ctx),
+                        bool(fut_ctx),
+                        (now_ts - float(spot_ctx.get("timestamp", now_ts))) if spot_ctx else None,
+                        (now_ts - float(fut_ctx.get("timestamp", now_ts))) if fut_ctx else None,
+                        indicators.get("selected_ce"),
+                        indicators.get("selected_pe"),
+                        interval_sec=30.0,
+                        level=logging.INFO,
+                    )
+                    log_throttled(
+                        log,
+                        f"option_context_missing_direction_bias:{symbol}",
+                        "OPTION_CONTEXT_MISSING_DIRECTION_BIAS symbol=%s spot_fresh=%s fut_fresh=%s spot_direction_valid=%s fut_direction_valid=%s",
+                        symbol,
+                        spot_fresh,
+                        fut_fresh,
+                        spot_direction_valid,
+                        fut_direction_valid,
+                        interval_sec=30.0,
+                        level=logging.INFO,
+                        extra={
+                            "event": "OPTION_CONTEXT_MISSING_DIRECTION_BIAS",
+                            "symbol": symbol,
+                            "spot_fresh": spot_fresh,
+                            "fut_fresh": fut_fresh,
+                            "spot_direction_valid": spot_direction_valid,
+                            "fut_direction_valid": fut_direction_valid,
+                            "spot_direction_reasons": spot_ctx.get("direction_context_reasons"),
+                            "fut_direction_reasons": fut_ctx.get("direction_context_reasons"),
+                            "spot_ctx_keys": sorted(list(spot_ctx.keys())),
+                            "fut_ctx_keys": sorted(list(fut_ctx.keys())),
+                            "spot_tick_age_ms": spot_ctx.get("tick_age_ms"),
+                            "futures_tick_age_ms": fut_ctx.get("tick_age_ms"),
+                            "direction_context_source": direction_context_source,
+                        },
+                    )
             if fut_fresh and fut_ctx.get("futures_volume_ratio") is not None:
                 indicators.setdefault("futures_volume_ratio", fut_ctx.get("futures_volume_ratio"))
             if fut_fresh and fut_ctx.get("vwap") is not None:
@@ -3603,6 +3611,7 @@ class StrategyManager(_BaseStrategyManager):
         allowed_strategies = {s.strip() for s in str(os.getenv("STRATEGY_CONTEXT_PROMOTION_ALLOWED_STRATEGIES", "OrderFlow,VWAPPro")).split(",") if s.strip()}
         min_score = self._env_float("STRATEGY_CONTEXT_PROMOTION_MIN_SCORE", 5.0)
         min_conf = self._env_float("STRATEGY_CONTEXT_PROMOTION_MIN_CONFIDENCE", 0.45)
+        min_direction_conf = self._env_float("STRATEGY_CONTEXT_PROMOTION_MIN_DIRECTION_CONF", 0.05)
         best_signal, best_vote = max(context_votes, key=lambda pair: self._extract_raw_score(pair[1]))
         raw_score = self._extract_raw_score(best_vote)
         md0 = dict(best_signal.metadata or {})
@@ -3699,18 +3708,54 @@ class StrategyManager(_BaseStrategyManager):
             or ""
         ).upper()
         direction_aligned = direction_bias in {"CE", "PE"} and direction_bias == str(best_vote.side).upper()
-        if best_vote.strategy not in allowed_strategies or raw_score < min_score or best_vote.confidence < min_conf or best_vote.side not in {"CE", "PE"} or not selected_ok or vetoed or not direction_aligned:
+        try:
+            context_age_seconds = float(
+                md0.get("context_age_seconds")
+                or indicators.get("context_age_seconds")
+                or 999.0
+            )
+        except (TypeError, ValueError):
+            context_age_seconds = 999.0
+        context_fresh = bool(
+            md0.get("context_fresh")
+            if md0.get("context_fresh") is not None
+            else indicators.get("context_fresh")
+        ) and context_age_seconds <= self._env_float("STRATEGY_CONTEXT_MAX_AGE_SECONDS", 120.0)
+        try:
+            direction_conf = float(
+                md0.get("underlying_direction_confidence")
+                or indicators.get("underlying_direction_confidence")
+                or 0.0
+            )
+        except (TypeError, ValueError):
+            direction_conf = 0.0
+        if best_vote.strategy not in allowed_strategies or raw_score < min_score or best_vote.confidence < min_conf or best_vote.side not in {"CE", "PE"} or not selected_ok or vetoed or not direction_aligned or not context_fresh or direction_conf < min_direction_conf:
             return None
         md = dict(best_signal.metadata or {})
         md.update(selected_meta)
-        md.update({"role": "trigger", "promoted_from_context": True, "consensus_stage": "context_promoted_controlled", "promotion_reason": "context_only_quality_pass"})
+        md.update({
+            "role": "trigger",
+            "promoted_from_context": True,
+            "consensus_stage": "context_promoted_controlled",
+            "promotion_reason": "direction_context_aligned",
+            "direction_bias": indicators.get("direction_bias"),
+            "underlying_direction_bias": indicators.get("underlying_direction_bias"),
+            "underlying_direction_confidence": indicators.get("underlying_direction_confidence"),
+            "context_age_seconds": indicators.get("context_age_seconds"),
+            "context_fresh": indicators.get("context_fresh"),
+            "direction_context_source": indicators.get("direction_context_source"),
+            "direction_context_reasons": indicators.get("direction_context_reasons"),
+        })
         promoted = Signal(action="BUY", symbol=best_signal.symbol, quantity=best_signal.quantity, confidence=best_signal.confidence, reason=best_signal.reason, stop_loss=best_signal.stop_loss, take_profit=best_signal.take_profit, metadata=md)
         promoted_vote = StrategyVote(strategy=best_vote.strategy, side=best_vote.side, score=best_vote.score, confidence=best_vote.confidence, reasons=list(best_vote.reasons), metadata=md)
         log.info(
-            "ORDERFLOW_TRIGGER_PROMOTED side=%s score=%.2f reason=direction_context_aligned symbol=%s",
+            "ORDERFLOW_TRIGGER_PROMOTED side=%s score=%.2f reason=direction_context_aligned symbol=%s direction_context_source=%s context_age_seconds=%.2f underlying_direction_confidence=%.2f",
             best_vote.side,
             raw_score,
             symbol,
+            md.get("direction_context_source"),
+            context_age_seconds,
+            direction_conf,
             extra={
                 "event": "ORDERFLOW_TRIGGER_PROMOTED",
                 "symbol": symbol,

--- a/src/nifty_scalper_bot/core/strategy_manager.py
+++ b/src/nifty_scalper_bot/core/strategy_manager.py
@@ -3720,12 +3720,11 @@ class StrategyManager(_BaseStrategyManager):
             if md0.get("context_fresh") is not None
             else indicators.get("context_fresh")
         ) and context_age_seconds <= self._env_float("STRATEGY_CONTEXT_MAX_AGE_SECONDS", 120.0)
+        conf_raw = md0.get("underlying_direction_confidence")
+        if conf_raw is None:
+            conf_raw = indicators.get("underlying_direction_confidence")
         try:
-            direction_conf = float(
-                md0.get("underlying_direction_confidence")
-                or indicators.get("underlying_direction_confidence")
-                or 0.0
-            )
+            direction_conf = float(conf_raw) if conf_raw is not None else 0.0
         except (TypeError, ValueError):
             direction_conf = 0.0
         if best_vote.strategy not in allowed_strategies or raw_score < min_score or best_vote.confidence < min_conf or best_vote.side not in {"CE", "PE"} or not selected_ok or vetoed or not direction_aligned or not context_fresh or direction_conf < min_direction_conf:

--- a/src/nifty_scalper_bot/core/strategy_manager.py
+++ b/src/nifty_scalper_bot/core/strategy_manager.py
@@ -2593,9 +2593,9 @@ class StrategyManager(_BaseStrategyManager):
                 except (TypeError, ValueError):
                     indicators["underlying_direction_confidence"] = 0.0
                 indicators["context_age_seconds"] = min(now_ts - float(spot_ctx.get("timestamp", now_ts)) if spot_usable else max_context_age + 1, now_ts - float(fut_ctx.get("timestamp", now_ts)) if fut_usable else max_context_age + 1)
-                indicators["context_fresh"] = True
+                indicators["context_fresh"] = bool(float(indicators.get("context_age_seconds") or max_context_age + 1) <= max_context_age)
                 indicators["direction_context_source"] = "primary"
-                context_resolved = True
+                context_resolved = bool(indicators["context_fresh"])
                 direction_context_source = "primary"
                 log_throttled(
                     log,
@@ -3738,14 +3738,19 @@ class StrategyManager(_BaseStrategyManager):
             "promoted_from_context": True,
             "consensus_stage": "context_promoted_controlled",
             "promotion_reason": "direction_context_aligned",
-            "direction_bias": indicators.get("direction_bias"),
-            "underlying_direction_bias": indicators.get("underlying_direction_bias"),
-            "underlying_direction_confidence": indicators.get("underlying_direction_confidence"),
-            "context_age_seconds": indicators.get("context_age_seconds"),
-            "context_fresh": indicators.get("context_fresh"),
-            "direction_context_source": indicators.get("direction_context_source"),
-            "direction_context_reasons": indicators.get("direction_context_reasons"),
         })
+        for key in (
+            "direction_bias",
+            "underlying_direction_bias",
+            "underlying_direction_confidence",
+            "context_age_seconds",
+            "context_fresh",
+            "direction_context_source",
+            "direction_context_reasons",
+        ):
+            value = indicators.get(key)
+            if value is not None:
+                md[key] = value
         promoted = Signal(action="BUY", symbol=best_signal.symbol, quantity=best_signal.quantity, confidence=best_signal.confidence, reason=best_signal.reason, stop_loss=best_signal.stop_loss, take_profit=best_signal.take_profit, metadata=md)
         promoted_vote = StrategyVote(strategy=best_vote.strategy, side=best_vote.side, score=best_vote.score, confidence=best_vote.confidence, reasons=list(best_vote.reasons), metadata=md)
         log.info(

--- a/src/nifty_scalper_bot/core/strategy_manager.py
+++ b/src/nifty_scalper_bot/core/strategy_manager.py
@@ -3708,12 +3708,11 @@ class StrategyManager(_BaseStrategyManager):
             or ""
         ).upper()
         direction_aligned = direction_bias in {"CE", "PE"} and direction_bias == str(best_vote.side).upper()
+        age_raw = md0.get("context_age_seconds")
+        if age_raw is None:
+            age_raw = indicators.get("context_age_seconds")
         try:
-            context_age_seconds = float(
-                md0.get("context_age_seconds")
-                or indicators.get("context_age_seconds")
-                or 999.0
-            )
+            context_age_seconds = float(age_raw) if age_raw is not None else 999.0
         except (TypeError, ValueError):
             context_age_seconds = 999.0
         context_fresh = bool(

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -7854,6 +7854,27 @@ class StrategyRunner:
                                 symbol_role=symbol_role,
                             )
                             return
+                        if not market_open and symbol_role == "tradable_option":
+                            log_throttled(
+                                self._logger,
+                                "market_session_closed_compact",
+                                "MARKET_SESSION_CLOSED orders_disabled=True reason=normal_close",
+                                interval_sec=120.0,
+                                level=logging.INFO,
+                                extra={
+                                    "event": "MARKET_SESSION_CLOSED",
+                                    "orders_disabled": True,
+                                    "reason": "normal_close",
+                                },
+                            )
+                            self._emit_runner_eval_decision(
+                                symbol=symbol,
+                                stage="phase9",
+                                reason="market_closed",
+                                allowed=False,
+                                trace_id=trace_id,
+                            )
+                            return
                         signal = self._strategy_manager.generate_signal(
                             symbol,
                             price,

--- a/tests/core/test_readiness_live_tick_proof.py
+++ b/tests/core/test_readiness_live_tick_proof.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
+from datetime import UTC, datetime
 
 import pytest
 
@@ -46,10 +47,15 @@ def make_ctx(mdm, live: bool = True):
     )
 
 
+def _fresh_tick_ts() -> dict[str, str]:
+    now_iso = datetime.now(UTC).isoformat().replace("+00:00", "Z")
+    return {'NFO:CE': now_iso, 'NFO:PE': now_iso}
+
+
 @pytest.mark.asyncio
 async def test_runtime_readiness_uses_live_tick_proof_when_confirmed_subscription_missing() -> None:
     snaps = {'NSE:NIFTY': Snap(25000, 2), 'NFO:CE': Snap(100, 2), 'NFO:PE': Snap(110, 3)}
-    mdm = SimpleNamespace(get_symbol_snapshot=lambda s: snaps.get(s), get_ohlc_bars=lambda s, **k: list(range(60)), _confirmed_subscriptions=set(), _symbol_to_token={'NFO:CE': 1, 'NFO:PE': 2}, _last_tick_ts={'NFO:CE': '2026-05-12T00:00:00Z', 'NFO:PE': '2026-05-12T00:00:00Z'})
+    mdm = SimpleNamespace(get_symbol_snapshot=lambda s: snaps.get(s), get_ohlc_bars=lambda s, **k: list(range(60)), _confirmed_subscriptions=set(), _symbol_to_token={'NFO:CE': 1, 'NFO:PE': 2}, _last_tick_ts=_fresh_tick_ts())
     ctx = make_ctx(mdm)
     await app._recompute_and_push_runtime_readiness(ctx, reason='test')
     assert ctx.data_hard_ready is True
@@ -62,7 +68,7 @@ async def test_runtime_readiness_uses_live_tick_proof_when_confirmed_subscriptio
 @pytest.mark.asyncio
 async def test_live_orders_not_armed_without_tradable_quote() -> None:
     snaps = {'NSE:NIFTY': Snap(25000, 2), 'NFO:CE': Snap(100, 2), 'NFO:PE': Snap(110, 2)}
-    mdm = SimpleNamespace(get_symbol_snapshot=lambda s: snaps.get(s), get_ohlc_bars=lambda s, **k: list(range(60)), _confirmed_subscriptions=set(), _symbol_to_token={'NFO:CE': 1, 'NFO:PE': 2}, _last_tick_ts={'NFO:CE': '2026-05-12T00:00:00Z', 'NFO:PE': '2026-05-12T00:00:00Z'})
+    mdm = SimpleNamespace(get_symbol_snapshot=lambda s: snaps.get(s), get_ohlc_bars=lambda s, **k: list(range(60)), _confirmed_subscriptions=set(), _symbol_to_token={'NFO:CE': 1, 'NFO:PE': 2}, _last_tick_ts=_fresh_tick_ts())
     ctx = make_ctx(mdm)
     await app._recompute_and_push_runtime_readiness(ctx, reason='test')
     assert ctx.data_hard_ready is True
@@ -72,9 +78,10 @@ async def test_live_orders_not_armed_without_tradable_quote() -> None:
 
 
 @pytest.mark.asyncio
-async def test_live_orders_armed_with_fresh_ltp_bars_and_tradable_depth() -> None:
+async def test_live_orders_armed_with_fresh_ltp_bars_and_tradable_depth(monkeypatch) -> None:
+    monkeypatch.setattr(app, 'get_market_state', lambda: app.MarketState.OPEN)
     snaps = {'NSE:NIFTY': Snap(25000, 2, True, 24999, 25001, True), 'NFO:CE': Snap(100, 2, True, 99.95, 100.05, True), 'NFO:PE': Snap(110, 2, True, 109.95, 110.05, True)}
-    mdm = SimpleNamespace(get_symbol_snapshot=lambda s: snaps.get(s), get_ohlc_bars=lambda s, **k: list(range(60)), has_ws_tradable_quote=lambda s: True, _confirmed_subscriptions=set(), _symbol_to_token={'NFO:CE': 1, 'NFO:PE': 2}, _last_tick_ts={'NFO:CE': '2026-05-12T00:00:00Z', 'NFO:PE': '2026-05-12T00:00:00Z'})
+    mdm = SimpleNamespace(get_symbol_snapshot=lambda s: snaps.get(s), get_ohlc_bars=lambda s, **k: list(range(60)), has_ws_tradable_quote=lambda s: True, _confirmed_subscriptions=set(), _symbol_to_token={'NFO:CE': 1, 'NFO:PE': 2}, _last_tick_ts=_fresh_tick_ts())
     ctx = make_ctx(mdm)
     await app._recompute_and_push_runtime_readiness(ctx, reason='test')
     assert ctx.data_hard_ready is True

--- a/tests/core/test_strategy_manager_consensus.py
+++ b/tests/core/test_strategy_manager_consensus.py
@@ -334,6 +334,38 @@ def test_fresh_primary_context_promotes_only_within_max_age(monkeypatch) -> None
     )
     assert promoted is None
 
+
+def test_context_promotion_accepts_zero_context_age(monkeypatch) -> None:
+    monkeypatch.setenv('EXECUTION_MODE', 'LIVE')
+    monkeypatch.setenv('STRATEGY_CONTEXT_PROMOTION_LIVE_ALLOWED', 'true')
+    manager = _manager_stub()
+    signal = _make_signal()
+    signal.metadata = {
+        'is_selected_option': True,
+        'quote_depth_valid': True,
+        'bid': 100,
+        'ask': 101,
+        'spread_pct': 1,
+        'context_age_seconds': 0.0,
+        'context_fresh': True,
+        'direction_bias': 'CE',
+    }
+    vote = StrategyVote(strategy='OrderFlow', side='CE', score=9.0, confidence=0.8, reasons=[], metadata={'role': 'context'})
+    promoted = manager._try_context_promotion(
+        'NFO:NIFTY25000CE',
+        [(signal, vote)],
+        {
+            'direction_bias': 'CE',
+            'underlying_direction_bias': 'CE',
+            'underlying_direction_confidence': 0.6,
+            'context_age_seconds': 0.0,
+            'context_fresh': True,
+            'direction_context_source': 'primary',
+        },
+        manager.get_strategy_mode_profile(),
+    )
+    assert promoted is not None
+
 def test_derive_direction_fresh_context_and_stale_context_age() -> None:
     manager = _manager_stub()
     side, conf, _ = manager._derive_context_direction(

--- a/tests/core/test_strategy_manager_consensus.py
+++ b/tests/core/test_strategy_manager_consensus.py
@@ -164,8 +164,26 @@ def test_live_context_promotion_passes_only_with_strict_quality(monkeypatch) -> 
         'is_selected_option': True,
     }
     vote = StrategyVote(strategy='OrderFlow', side='CE', score=9.0, confidence=0.8, reasons=[], metadata={'role': 'context'})
-    out = manager._try_context_promotion('NFO:NIFTY25000CE', [(signal, vote)], {'context_age_seconds': 10}, manager.get_strategy_mode_profile())
+    out = manager._try_context_promotion(
+        'NFO:NIFTY25000CE',
+        [(signal, vote)],
+        {
+            'direction_bias': 'CE',
+            'underlying_direction_bias': 'CE',
+            'underlying_direction_confidence': 0.6,
+            'context_age_seconds': 10,
+            'context_fresh': True,
+            'direction_context_source': 'fallback',
+            'direction_context_reasons': ['close_above_vwap'],
+        },
+        manager.get_strategy_mode_profile(),
+    )
     assert out is not None
+    promoted_signal, _ = out
+    assert promoted_signal.metadata is not None
+    assert promoted_signal.metadata.get('promotion_reason') == 'direction_context_aligned'
+    assert promoted_signal.metadata.get('direction_bias') == 'CE'
+    assert promoted_signal.metadata.get('direction_context_source') == 'fallback'
 
 
 def test_orderflow_context_only_without_direction_stays_context(monkeypatch) -> None:
@@ -185,8 +203,53 @@ def test_orderflow_context_promotes_with_aligned_fallback_direction(monkeypatch)
     signal = _make_signal()
     signal.metadata = {'is_selected_option': True, 'quote_depth_valid': True, 'bid': 100, 'ask': 101, 'spread_pct': 1, 'context_age_seconds': 10}
     vote = StrategyVote(strategy='OrderFlow', side='CE', score=9.0, confidence=0.8, reasons=[], metadata={'role': 'context'})
-    promoted = manager._try_context_promotion('NFO:NIFTY25000CE', [(signal, vote)], {'direction_bias': 'CE', 'context_age_seconds': 10}, manager.get_strategy_mode_profile())
+    promoted = manager._try_context_promotion(
+        'NFO:NIFTY25000CE',
+        [(signal, vote)],
+        {
+            'direction_bias': 'CE',
+            'underlying_direction_bias': 'CE',
+            'underlying_direction_confidence': 0.2,
+            'context_age_seconds': 10,
+            'context_fresh': True,
+            'direction_context_source': 'fallback',
+        },
+        manager.get_strategy_mode_profile(),
+    )
     assert promoted is not None
+
+
+def test_orderflow_context_not_promoted_when_fallback_context_stale(monkeypatch) -> None:
+    monkeypatch.setenv('EXECUTION_MODE', 'LIVE')
+    monkeypatch.setenv('STRATEGY_CONTEXT_PROMOTION_LIVE_ALLOWED', 'true')
+    manager = _manager_stub()
+    signal = _make_signal()
+    signal.metadata = {'is_selected_option': True, 'quote_depth_valid': True, 'bid': 100, 'ask': 101, 'spread_pct': 1, 'context_age_seconds': 240}
+    vote = StrategyVote(strategy='OrderFlow', side='CE', score=9.0, confidence=0.8, reasons=[], metadata={'role': 'context'})
+    promoted = manager._try_context_promotion(
+        'NFO:NIFTY25000CE',
+        [(signal, vote)],
+        {'direction_bias': 'CE', 'underlying_direction_confidence': 0.4, 'context_age_seconds': 240, 'context_fresh': False, 'direction_context_source': 'fallback'},
+        manager.get_strategy_mode_profile(),
+    )
+    assert promoted is None
+
+
+def test_orderflow_context_not_promoted_when_direction_conf_below_min(monkeypatch) -> None:
+    monkeypatch.setenv('EXECUTION_MODE', 'LIVE')
+    monkeypatch.setenv('STRATEGY_CONTEXT_PROMOTION_LIVE_ALLOWED', 'true')
+    monkeypatch.setenv('STRATEGY_CONTEXT_PROMOTION_MIN_DIRECTION_CONF', '0.25')
+    manager = _manager_stub()
+    signal = _make_signal()
+    signal.metadata = {'is_selected_option': True, 'quote_depth_valid': True, 'bid': 100, 'ask': 101, 'spread_pct': 1, 'context_age_seconds': 10}
+    vote = StrategyVote(strategy='OrderFlow', side='CE', score=9.0, confidence=0.8, reasons=[], metadata={'role': 'context'})
+    promoted = manager._try_context_promotion(
+        'NFO:NIFTY25000CE',
+        [(signal, vote)],
+        {'direction_bias': 'CE', 'underlying_direction_confidence': 0.1, 'context_age_seconds': 10, 'context_fresh': True},
+        manager.get_strategy_mode_profile(),
+    )
+    assert promoted is None
 
 
 def test_derive_direction_fresh_context_and_stale_context_age() -> None:

--- a/tests/core/test_strategy_manager_consensus.py
+++ b/tests/core/test_strategy_manager_consensus.py
@@ -252,6 +252,88 @@ def test_orderflow_context_not_promoted_when_direction_conf_below_min(monkeypatc
     assert promoted is None
 
 
+def test_orderflow_existing_direction_bias_stale_context_not_promoted(monkeypatch) -> None:
+    monkeypatch.setenv('EXECUTION_MODE', 'LIVE')
+    monkeypatch.setenv('STRATEGY_CONTEXT_PROMOTION_LIVE_ALLOWED', 'true')
+    manager = _manager_stub()
+    signal = _make_signal()
+    signal.metadata = {
+        'is_selected_option': True,
+        'quote_depth_valid': True,
+        'bid': 100,
+        'ask': 101,
+        'spread_pct': 1,
+        'direction_bias': 'CE',
+        'context_age_seconds': 999,
+        'context_fresh': False,
+    }
+    vote = StrategyVote(strategy='OrderFlow', side='CE', score=9.0, confidence=0.8, reasons=[], metadata={'role': 'context'})
+    promoted = manager._try_context_promotion(
+        'NFO:NIFTY25000CE',
+        [(signal, vote)],
+        {'direction_bias': 'CE', 'context_age_seconds': 999, 'context_fresh': False, 'underlying_direction_confidence': 0.9},
+        manager.get_strategy_mode_profile(),
+    )
+    assert promoted is None
+
+
+def test_promotion_metadata_not_overwritten_with_none_from_indicators(monkeypatch) -> None:
+    monkeypatch.setenv('EXECUTION_MODE', 'LIVE')
+    monkeypatch.setenv('STRATEGY_CONTEXT_PROMOTION_LIVE_ALLOWED', 'true')
+    manager = _manager_stub()
+    signal = _make_signal()
+    signal.metadata = {
+        'is_selected_option': True,
+        'quote_depth_valid': True,
+        'bid': 100,
+        'ask': 101,
+        'spread_pct': 1,
+        'direction_bias': 'CE',
+        'underlying_direction_bias': 'CE',
+        'underlying_direction_confidence': 0.7,
+        'context_age_seconds': 5,
+        'context_fresh': True,
+        'direction_context_source': 'primary',
+    }
+    vote = StrategyVote(strategy='OrderFlow', side='CE', score=9.0, confidence=0.8, reasons=[], metadata={'role': 'context'})
+    promoted = manager._try_context_promotion(
+        'NFO:NIFTY25000CE',
+        [(signal, vote)],
+        {'context_age_seconds': 5, 'context_fresh': True},
+        manager.get_strategy_mode_profile(),
+    )
+    assert promoted is not None
+    promoted_signal, _ = promoted
+    assert promoted_signal.metadata is not None
+    assert promoted_signal.metadata.get('direction_bias') == 'CE'
+    assert promoted_signal.metadata.get('direction_context_source') == 'primary'
+
+
+def test_fresh_primary_context_promotes_only_within_max_age(monkeypatch) -> None:
+    monkeypatch.setenv('EXECUTION_MODE', 'LIVE')
+    monkeypatch.setenv('STRATEGY_CONTEXT_PROMOTION_LIVE_ALLOWED', 'true')
+    monkeypatch.setenv('STRATEGY_CONTEXT_MAX_AGE_SECONDS', '120')
+    manager = _manager_stub()
+    signal = _make_signal()
+    signal.metadata = {
+        'is_selected_option': True,
+        'quote_depth_valid': True,
+        'bid': 100,
+        'ask': 101,
+        'spread_pct': 1,
+        'direction_bias': 'CE',
+        'context_age_seconds': 121,
+        'context_fresh': True,
+    }
+    vote = StrategyVote(strategy='OrderFlow', side='CE', score=9.0, confidence=0.8, reasons=[], metadata={'role': 'context'})
+    promoted = manager._try_context_promotion(
+        'NFO:NIFTY25000CE',
+        [(signal, vote)],
+        {'direction_bias': 'CE', 'underlying_direction_confidence': 0.6, 'context_age_seconds': 121, 'context_fresh': True},
+        manager.get_strategy_mode_profile(),
+    )
+    assert promoted is None
+
 def test_derive_direction_fresh_context_and_stale_context_age() -> None:
     manager = _manager_stub()
     side, conf, _ = manager._derive_context_direction(

--- a/tests/core/test_strategy_manager_consensus.py
+++ b/tests/core/test_strategy_manager_consensus.py
@@ -166,3 +166,34 @@ def test_live_context_promotion_passes_only_with_strict_quality(monkeypatch) -> 
     vote = StrategyVote(strategy='OrderFlow', side='CE', score=9.0, confidence=0.8, reasons=[], metadata={'role': 'context'})
     out = manager._try_context_promotion('NFO:NIFTY25000CE', [(signal, vote)], {'context_age_seconds': 10}, manager.get_strategy_mode_profile())
     assert out is not None
+
+
+def test_orderflow_context_only_without_direction_stays_context(monkeypatch) -> None:
+    monkeypatch.setenv('EXECUTION_MODE', 'LIVE')
+    monkeypatch.setenv('STRATEGY_CONTEXT_PROMOTION_LIVE_ALLOWED', 'true')
+    manager = _manager_stub()
+    signal = _make_signal()
+    signal.metadata = {'is_selected_option': True, 'quote_depth_valid': True, 'bid': 100, 'ask': 101, 'spread_pct': 1, 'context_age_seconds': 10}
+    vote = StrategyVote(strategy='OrderFlow', side='CE', score=9.0, confidence=0.8, reasons=[], metadata={'role': 'context'})
+    assert manager._try_context_promotion('NFO:NIFTY25000CE', [(signal, vote)], {}, manager.get_strategy_mode_profile()) is None
+
+
+def test_orderflow_context_promotes_with_aligned_fallback_direction(monkeypatch) -> None:
+    monkeypatch.setenv('EXECUTION_MODE', 'LIVE')
+    monkeypatch.setenv('STRATEGY_CONTEXT_PROMOTION_LIVE_ALLOWED', 'true')
+    manager = _manager_stub()
+    signal = _make_signal()
+    signal.metadata = {'is_selected_option': True, 'quote_depth_valid': True, 'bid': 100, 'ask': 101, 'spread_pct': 1, 'context_age_seconds': 10}
+    vote = StrategyVote(strategy='OrderFlow', side='CE', score=9.0, confidence=0.8, reasons=[], metadata={'role': 'context'})
+    promoted = manager._try_context_promotion('NFO:NIFTY25000CE', [(signal, vote)], {'direction_bias': 'CE', 'context_age_seconds': 10}, manager.get_strategy_mode_profile())
+    assert promoted is not None
+
+
+def test_derive_direction_fresh_context_and_stale_context_age() -> None:
+    manager = _manager_stub()
+    side, conf, _ = manager._derive_context_direction(
+        {'close': 102, 'vwap': 100, 'ema_fast': 101, 'ema_slow': 99, 'open': 100},
+        role='spot_context',
+    )
+    assert side == 'CE'
+    assert conf > 0.0

--- a/tests/strategies/test_runner_context_market_closed.py
+++ b/tests/strategies/test_runner_context_market_closed.py
@@ -1,4 +1,5 @@
 from nifty_scalper_bot.strategies.runner import StrategyRunner
+import inspect
 
 def test_runner_phase9_market_closed_context_skip():
     r = StrategyRunner.__new__(StrategyRunner)
@@ -6,6 +7,9 @@ def test_runner_phase9_market_closed_context_skip():
     assert r._symbol_role_for_runner('NFO:NIFTY26MAYFUT') == 'futures_context'
 
 
-def test_runner_market_closed_compact_log_present() -> None:
-    source = open('src/nifty_scalper_bot/strategies/runner.py', encoding='utf-8').read()
-    assert 'MARKET_SESSION_CLOSED orders_disabled=True reason=normal_close' in source
+def test_runner_market_closed_option_path_returns_before_strategy_manager_call() -> None:
+    source = inspect.getsource(StrategyRunner._on_tick)
+    compact_log_idx = source.index("MARKET_SESSION_CLOSED orders_disabled=True reason=normal_close")
+    market_closed_emit_idx = source.index('reason="market_closed"')
+    generate_signal_idx = source.index("self._strategy_manager.generate_signal(")
+    assert compact_log_idx < market_closed_emit_idx < generate_signal_idx

--- a/tests/strategies/test_runner_context_market_closed.py
+++ b/tests/strategies/test_runner_context_market_closed.py
@@ -4,3 +4,8 @@ def test_runner_phase9_market_closed_context_skip():
     r = StrategyRunner.__new__(StrategyRunner)
     assert r._symbol_role_for_runner('NSE:NIFTY') == 'spot_context'
     assert r._symbol_role_for_runner('NFO:NIFTY26MAYFUT') == 'futures_context'
+
+
+def test_runner_market_closed_compact_log_present() -> None:
+    source = open('src/nifty_scalper_bot/strategies/runner.py', encoding='utf-8').read()
+    assert 'MARKET_SESSION_CLOSED orders_disabled=True reason=normal_close' in source


### PR DESCRIPTION
### Motivation
- Live option evaluations lacked usable underlying direction context so `direction_bias` remained unset and `context_age_seconds` defaulted to stale values, preventing context-only strategies (notably `OrderFlow`) from promoting to trigger during market hours.
- The lack of tick-age propagation and insufficient diagnostics made it hard to determine whether spot/futures data were actually fresh and why promotions were blocked.
- The change aims to ensure fresh spot/futures context is used (or a safe fallback derived), require alignment before promoting `OrderFlow`, and improve diagnostics and post-close noise control.

### Description
- In `src/nifty_scalper_bot/core/strategy_manager.py` added `_context_tick_age_seconds`, primary/fallback direction resolution and propagation of `direction_bias`, `underlying_direction_confidence`, `context_age_seconds`, `context_fresh`, and `direction_context_source`, plus `DIRECTION_CONTEXT_RESOLVED` logs for visibility.
- Extended missing-direction diagnostics payload to include spot/futures tick ages and added richer fields into the `STRATEGY_NO_TRIGGER_VOTE` / `TRADE_DECISION_TRACE` logs to explain why `direction_bias` is `None`.
- Tightened context-promotion in `_try_context_promotion` to require the resolved direction to align with the promoting vote side and emit `ORDERFLOW_TRIGGER_PROMOTED` when promotion is allowed due to aligned context.
- In `src/nifty_scalper_bot/strategies/runner.py` added a compact `MARKET_SESSION_CLOSED orders_disabled=True reason=normal_close` log and an early return for post-close tradable-option phase-9 evaluations to reduce repetitive post-close noise, and added focused tests (`tests/core/test_strategy_manager_consensus.py` and `tests/strategies/test_runner_context_market_closed.py`) covering the new behaviors.

### Testing
- Ran `python -m compileall -q src` which passed successfully.
- Ran `pytest -q tests/strategies` which passed and confirms strategy-runner related tests are green after the changes.
- Ran `pytest -q tests/core` which produced a failure in an existing time-sensitive readiness test (`tests/core/test_readiness_live_tick_proof.py::test_live_orders_armed_with_fresh_ltp_bars_and_tradable_depth`) unrelated to these changes due to static timestamps in the test environment; `tests/signals` is not present in the repository so that command was skipped.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1039c05af483248f703daed6bdfa20)