### PR TITLE
Fix stale CE/PE direction lock and suppress opposite-side triggers under strong bias

### DIFF
--- a/src/nifty_scalper_bot/strategies/elite_strategies/smc_liquidity.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/smc_liquidity.py
@@ -14,7 +14,7 @@ LOGGER = get_logger(__name__)
 class SMCStrategy(EliteStrategy):
     """SMC liquidity sweep strategy producing structured votes only."""
 
-    MIN_BARS_REQUIRED = 15
+    MIN_BARS_REQUIRED = 30
     ROLE = 'trigger'
     TRIGGER_KEY = 'smc_lite'
 
@@ -37,21 +37,29 @@ class SMCStrategy(EliteStrategy):
             close = float(indicators.get('close') or current_price)
             open_price = float(indicators.get('open') or current_price)
             atr = max(float(indicators.get('atr') or 0.0), current_price * 0.01, 1.0)
-            direction = str(
-                indicators.get("direction_bias")
-                or indicators.get("underlying_direction_bias")
-                or ""
-            ).upper()
+            direction = str(indicators.get("direction_bias") or "").upper()
             stale_data = bool(indicators.get('stale_data_used')) or float(indicators.get('data_age_seconds') or 0.0) > 120.0
             try:
                 context_age_seconds = float(indicators.get("context_age_seconds") or 999.0)
             except (TypeError, ValueError):
                 context_age_seconds = 999.0
-            underlying_direction = str(
-                indicators.get("underlying_direction_bias")
-                or indicators.get("direction_bias")
-                or ""
-            ).upper()
+            underlying_direction = str(indicators.get("underlying_direction_bias") or "").upper()
+            effective_direction = underlying_direction or direction
+            if str(os.getenv('EXECUTION_MODE', 'SHADOW') or 'SHADOW').strip().upper() == 'LIVE' and not effective_direction:
+                self._no_vote("direction_context_not_ready")
+                LOGGER.warning(
+                    "STRATEGY_NO_VOTE strategy=SMC symbol=%s reason=direction_context_not_ready direction_bias=%s underlying_direction_bias=%s",
+                    symbol,
+                    direction,
+                    underlying_direction,
+                    extra={"event": "STRATEGY_NO_VOTE", "strategy": "SMC", "symbol": symbol, "reason": "direction_context_not_ready"},
+                )
+                return None
+            min_bars_required = int(os.getenv("SMC_MIN_BARS_REQUIRED", "30") or "30")
+            history_count = int(indicators.get("indicator_history_count") or indicators.get("history_count") or 0)
+            if history_count and history_count < min_bars_required:
+                self._no_vote("smc_insufficient_history")
+                return None
 
             if stale_data or current_price <= 0:
                 self._no_vote("stale_or_invalid_data")
@@ -142,7 +150,7 @@ class SMCStrategy(EliteStrategy):
             if retest_confirmed:
                 score += 1.0
                 reasons.append('retest_mitigation')
-            direction_aligned = direction in {'CE', 'PE'} and direction == side
+            direction_aligned = effective_direction in {'CE', 'PE'} and effective_direction == side
             if direction_aligned:
                 score += 2.0
                 reasons.append('direction_alignment')
@@ -158,7 +166,14 @@ class SMCStrategy(EliteStrategy):
             is_live = execution_mode == 'LIVE'
             min_score = float(os.getenv('SMC_MIN_SCORE_LIVE', '6.5') if is_live else os.getenv('SMC_MIN_SCORE_SHADOW', '4.5'))
             require_structure_live = str(os.getenv('SMC_REQUIRE_STRUCTURE_CONFIRMATION_LIVE', 'true')).lower() in {'1', 'true', 'yes', 'on'}
-            if is_live and require_structure_live and not structure_confirmed:
+            allow_momentum_without_structure = str(os.getenv("SMC_ALLOW_MOMENTUM_WITHOUT_STRUCTURE_LIVE", "true")).lower() in {"1", "true", "yes", "on"}
+            momentum_confirmed = (
+                allow_momentum_without_structure
+                and displacement_score >= float(os.getenv("SMC_MOMENTUM_DISPLACEMENT_MIN", "0.80") or "0.80")
+                and direction_aligned
+                and (premium_reclaim or retest_confirmed or str(os.getenv("SMC_MOMENTUM_REQUIRE_PREMIUM_RECLAIM_OR_RETEST", "true")).lower() not in {"1", "true", "yes", "on"})
+            )
+            if is_live and require_structure_live and not (structure_confirmed or momentum_confirmed):
                 self._no_vote('smc_structure_required_live')
                 LOGGER.info(
                     "STRATEGY_NO_VOTE strategy=SMC symbol=%s reason=smc_structure_required_live "
@@ -189,6 +204,7 @@ class SMCStrategy(EliteStrategy):
                         "direction": direction,
                         "underlying_direction": underlying_direction,
                         "context_age_seconds": context_age_seconds,
+                        "momentum_confirmed": momentum_confirmed,
                     },
                 )
                 return None
@@ -271,6 +287,8 @@ class SMCStrategy(EliteStrategy):
                 'sweep_level': sweep_level,
                 'displacement_score': round(displacement_score, 3),
                 'structure_confirmed': structure_confirmed,
+                'momentum_confirmed': momentum_confirmed,
+                'structure_or_momentum_confirmed': bool(structure_confirmed or momentum_confirmed),
                 'smc_sweep_type': 'bullish' if bullish_sweep else 'bearish',
                 'structure_confirmation_used': structure_confirmed,
                 'premium_reclaim_used': premium_reclaim,

--- a/src/nifty_scalper_bot/strategies/orchestrator.py
+++ b/src/nifty_scalper_bot/strategies/orchestrator.py
@@ -69,6 +69,69 @@ class StrategyOrchestrator:
         self._active_direction_symbol: str = ""
         self._direction_lock_time: float = 0.0
 
+    def _infer_option_direction(self, symbol: str) -> str | None:
+        value = str(symbol or "").upper()
+        if value.endswith("CE"):
+            return "CE"
+        if value.endswith("PE"):
+            return "PE"
+        return None
+
+    def clear_direction_lock(self, *, reason: str, symbol: str | None = None) -> None:
+        old_direction = self._active_direction
+        old_symbol = self._active_direction_symbol
+        self._active_direction = None
+        self._active_direction_symbol = ""
+        self._direction_lock_time = 0.0
+        self._logger.warning(
+            "DIRECTION_LOCK_CLEARED reason=%s old_direction=%s old_symbol=%s symbol=%s",
+            reason,
+            old_direction,
+            old_symbol,
+            symbol,
+            extra={"event": "orchestrator_direction_lock_cleared", "reason": reason, "old_direction": old_direction, "old_symbol": old_symbol, "symbol": symbol},
+        )
+
+    def notify_entry(self, symbol: str, *, reason: str = "order_accepted") -> None:
+        direction = self._infer_option_direction(symbol)
+        if not direction:
+            return
+        import time as _t
+        self._active_direction = direction
+        self._active_direction_symbol = symbol
+        self._direction_lock_time = _t.time()
+        self._logger.info(
+            "DIRECTION_LOCK_SET reason=%s direction=%s symbol=%s",
+            reason,
+            direction,
+            symbol,
+            extra={"event": "orchestrator_direction_lock_set", "reason": reason, "direction": direction, "symbol": symbol},
+        )
+
+    def _has_open_position_for_locked_symbol(self, position_manager: Any) -> bool:
+        symbol = str(self._active_direction_symbol or "")
+        if not symbol or position_manager is None:
+            return False
+        try:
+            pos = position_manager.get_position(symbol)
+            if pos and float(getattr(pos, "quantity", 0) or 0) > 0:
+                return True
+        except Exception:
+            return False
+        return False
+
+    def reconcile_direction_bias(self, *, resolved_bias: str | None, confidence: float | None, symbol: str | None = None, position_manager: Any | None = None) -> None:
+        bias = str(resolved_bias or "").upper()
+        conf = float(confidence or 0.0)
+        threshold = float(os.getenv("DIRECTION_LOCK_FLIP_CONFIDENCE", "0.90"))
+        if bias not in {"CE", "PE"} or conf < threshold or not self._active_direction:
+            return
+        if bias == self._active_direction:
+            return
+        if self._has_open_position_for_locked_symbol(position_manager):
+            return
+        self.clear_direction_lock(reason="resolved_bias_flip", symbol=symbol)
+
     def register_strategy(
         self, name: str, *, capital_fraction: float, correlation_tags: Iterable[str]
     ) -> None:
@@ -210,13 +273,11 @@ class StrategyOrchestrator:
         if action == "BUY":
             import time as _t
 
-            _sym_upper = symbol.upper()
-            _direction = (
-                "CE"
-                if _sym_upper.endswith("CE")
-                else ("PE" if _sym_upper.endswith("PE") else None)
-            )
-            _dir_cooldown = float(os.getenv("DIRECTION_LOCK_SECONDS", "20"))
+            _direction = self._infer_option_direction(symbol)
+            _dir_cooldown = float(os.getenv("DIRECTION_LOCK_SECONDS", "10"))
+
+            if self._active_direction and not self._has_open_position_for_locked_symbol(position_manager):
+                self.clear_direction_lock(reason="stale_lock_no_open_position", symbol=symbol)
 
             if _direction and self._active_direction:
                 _time_since_lock = _t.time() - self._direction_lock_time
@@ -224,14 +285,20 @@ class StrategyOrchestrator:
                     self._active_direction != _direction
                     and _time_since_lock < _dir_cooldown
                 ):
-                    self._logger.info(
-                        f"🛡️ DIRECTION CONFLICT: {symbol} is {_direction} but "
-                        f"active direction is {self._active_direction} "
-                        f"({self._active_direction_symbol}) | "
-                        f"Wait {_dir_cooldown - _time_since_lock:.0f}s",
+                    self._logger.warning(
+                        "DIRECTION_CONFLICT symbol=%s requested_direction=%s active_direction=%s active_symbol=%s wait_s=%.1f",
+                        symbol,
+                        _direction,
+                        self._active_direction,
+                        self._active_direction_symbol,
+                        _dir_cooldown - _time_since_lock,
                         extra={
                             "event": "orchestrator_direction_conflict",
                             "symbol": symbol,
+                            "requested_direction": _direction,
+                            "active_direction": self._active_direction,
+                            "active_direction_symbol": self._active_direction_symbol,
+                            "wait_s": _dir_cooldown - _time_since_lock,
                         },
                     )
                     self._set_skip_reason("direction_conflict")
@@ -372,19 +439,7 @@ class StrategyOrchestrator:
         if action in {"BUY"}:
             self._last_signal_time = now
 
-            # Lock direction ONLY after ALL checks pass
-            _sym_upper = symbol.upper()
-            _final_direction = (
-                "CE"
-                if _sym_upper.endswith("CE")
-                else ("PE" if _sym_upper.endswith("PE") else None)
-            )
-            if _final_direction:
-                import time as _t
-
-                self._active_direction = _final_direction
-                self._active_direction_symbol = symbol
-                self._direction_lock_time = _t.time()
+            # Direction lock is set only from notify_entry after order acceptance.
 
         self._logger.info(
             "ORCHESTRATOR_PREFILTER_PASSED symbol=%s action=%s conf=%.2f strategy=%s",
@@ -438,11 +493,7 @@ class StrategyOrchestrator:
         with self._lock:
             self._active.pop(normalized, None)
             self._pending_underlyings.pop(normalized, None)
-            # ✅ FIX (6 Feb 2026): Clear direction lock on exit
-            self._active_direction = None
-            self._active_direction_symbol = ""
-            self._direction_lock_time = 0.0
-            self._logger.info(f"🔓 Direction lock cleared on exit: {normalized}")
+            self.clear_direction_lock(reason="notify_exit", symbol=normalized)
         self._logger.info(
             "Condition met: orchestrator_release",
             extra={"event": "orchestrator_release", "underlying": normalized},

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -7952,6 +7952,46 @@ class StrategyRunner:
                                 trace_id=trace_id,
                             )
                             return
+                        direction_bias = str((indicators_ctx.get("direction_bias") or "")).upper()
+                        underlying_bias = str((indicators_ctx.get("underlying_direction_bias") or "")).upper()
+                        resolved_bias = underlying_bias or direction_bias
+                        resolved_confidence = float(
+                            indicators_ctx.get("direction_confidence")
+                            or indicators_ctx.get("underlying_direction_confidence")
+                            or 0.0
+                        )
+                        spot_fresh = bool(indicators_ctx.get("spot_fresh"))
+                        if spot_fresh and not direction_bias and not underlying_bias:
+                            self._logger.warning(
+                                "TRIGGER_EVAL_SKIPPED symbol=%s reason=direction_context_not_ready spot_fresh=%s",
+                                symbol,
+                                spot_fresh,
+                                extra={"event": "trigger_eval_skipped", "reason": "direction_context_not_ready", "symbol": symbol, "spot_fresh": spot_fresh},
+                            )
+                            self._emit_runner_eval_decision(symbol=symbol, stage="phase9", reason="direction_context_not_ready", allowed=False, trace_id=trace_id)
+                            return
+                        if getattr(self, "_orchestrator", None) is not None and hasattr(self._orchestrator, "reconcile_direction_bias"):
+                            self._orchestrator.reconcile_direction_bias(
+                                resolved_bias=resolved_bias or None,
+                                confidence=resolved_confidence,
+                                symbol=symbol,
+                                position_manager=getattr(self, "_position_manager", None),
+                            )
+                        suppress_opposite = str(os.getenv("SUPPRESS_OPPOSITE_SIDE_TRIGGERS", "true")).lower() in {"1", "true", "yes", "on"}
+                        suppress_conf = float(os.getenv("OPPOSITE_SIDE_SUPPRESSION_CONFIDENCE", "0.85"))
+                        if suppress_opposite and resolved_bias in {"CE", "PE"} and resolved_confidence >= suppress_conf:
+                            upper_sym = symbol.upper()
+                            opposite = (resolved_bias == "PE" and upper_sym.endswith("CE")) or (resolved_bias == "CE" and upper_sym.endswith("PE"))
+                            if opposite:
+                                self._logger.warning(
+                                    "TRIGGER_EVAL_SKIPPED symbol=%s reason=opposite_side_trigger_suppressed underlying_bias=%s confidence=%.2f",
+                                    symbol,
+                                    resolved_bias,
+                                    resolved_confidence,
+                                    extra={"event": "trigger_eval_skipped", "reason": "opposite_side_trigger_suppressed", "symbol": symbol, "underlying_bias": resolved_bias, "confidence": resolved_confidence},
+                                )
+                                self._emit_runner_eval_decision(symbol=symbol, stage="phase9", reason="opposite_side_trigger_suppressed", allowed=False, trace_id=trace_id)
+                                return
                         signal = self._strategy_manager.generate_signal(
                             symbol,
                             price,
@@ -10244,6 +10284,9 @@ class StrategyRunner:
             order_id = self._order_manager.submit_trade_plan(plan)
 
             if order_id:
+                orchestrator = getattr(self, "_orchestrator", None)
+                if orchestrator is not None and hasattr(orchestrator, "notify_entry"):
+                    orchestrator.notify_entry(signal.symbol, reason="order_accepted")
                 self._logger.info(
                     "ORDER_SUBMITTED order_id=%s symbol=%s side=%s qty=%s trace_id=%s",
                     order_id, base_symbol, signal.action, qty, trace_id,

--- a/tests/strategies/test_orchestrator.py
+++ b/tests/strategies/test_orchestrator.py
@@ -12,6 +12,7 @@ from nifty_scalper_bot.strategies.signal_generator import Signal
 @dataclass
 class _DummyPosition:
     symbol: str
+    quantity: int = 0
 
 
 class _OrderManagerStub:
@@ -35,6 +36,8 @@ class _PositionManagerStub:
 
     def get_all_positions(self) -> list[_DummyPosition]:
         return [_DummyPosition(symbol=s) for s in self._symbols]
+    def get_position(self, symbol: str):
+        return _DummyPosition(symbol=symbol, quantity=1) if symbol in self._symbols else None
 
 
 class _RiskStub:
@@ -62,6 +65,38 @@ def _make_signal(strategy: str, action: str = "BUY") -> Signal:
         take_profit=20.0,
         metadata={"strategy": strategy},
     )
+
+
+def test_filter_signal_does_not_set_direction_lock() -> None:
+    orchestrator = StrategyOrchestrator(risk_manager=_RiskStub(balance=10_000))
+    signal = Signal(action="BUY", symbol="NFO:NIFTY26MAY24000CE", quantity=1, confidence=0.8, reason="t", stop_loss=1, take_profit=2, metadata={})
+    result = orchestrator.filter_signal(signal, {}, _PositionManagerStub())
+    assert result is signal
+    assert orchestrator._active_direction is None
+
+
+def test_notify_entry_sets_direction_lock_and_notify_exit_clears() -> None:
+    orchestrator = StrategyOrchestrator(risk_manager=_RiskStub(balance=10_000))
+    orchestrator.notify_entry("NFO:NIFTY26MAY24000CE")
+    assert orchestrator._active_direction == "CE"
+    assert orchestrator._active_direction_symbol == "NFO:NIFTY26MAY24000CE"
+    orchestrator.notify_exit("NIFTY")
+    assert orchestrator._active_direction is None
+
+
+def test_stale_lock_clears_without_open_position_and_reconcile_respects_open_position() -> None:
+    orchestrator = StrategyOrchestrator(risk_manager=_RiskStub(balance=10_000))
+    orchestrator.notify_entry("NFO:NIFTY26MAY24000CE")
+    sig = Signal(action="BUY", symbol="NFO:NIFTY26MAY24000PE", quantity=1, confidence=0.9, reason="t", stop_loss=1, take_profit=2, metadata={})
+    allowed = orchestrator.filter_signal(sig, {}, _PositionManagerStub(symbols=()))
+    assert allowed is sig
+    assert orchestrator.get_skip_reason() != "direction_conflict"
+    assert orchestrator._active_direction is None
+
+    orchestrator.notify_entry("NFO:NIFTY26MAY24000CE")
+    blocked = orchestrator.filter_signal(sig, {}, _PositionManagerStub(symbols=("NFO:NIFTY26MAY24000CE",)))
+    assert blocked is None
+    assert orchestrator.get_skip_reason() == "direction_conflict"
 
 
 def test_orchestrator_blocks_when_capital_exceeded() -> None:

--- a/tests/strategies/test_runner_live_path_guards.py
+++ b/tests/strategies/test_runner_live_path_guards.py
@@ -209,6 +209,19 @@ def test_trade_plan_uses_env_preflight_values(monkeypatch) -> None:
     assert plan.allow_market_entry is True
 
 
+def test_order_acceptance_notifies_orchestrator_entry() -> None:
+    runner = _build_runner()
+    notified = {}
+    runner._orchestrator = SimpleNamespace(
+        notify_entry=lambda symbol, reason="order_accepted": notified.update({"symbol": symbol, "reason": reason})
+    )
+    runner._order_manager.submit_trade_plan = MagicMock(return_value='order-2')
+    signal = Signal(action='BUY', symbol='NFO:NIFTY26APR23800CE', quantity=1, confidence=0.9, reason='test', stop_loss=100.0, take_profit=120.0, metadata={'strategy_score': 7, 'option_score': 7, 'data_score': 7, 'rr_score': 7})
+    runner._handle_entry_signal_inner(signal, 'NFO:NIFTY26APR23800CE', 'NFO:NIFTY26APR23800CE', 110.0, datetime.now(timezone.utc), trace_id='notify')
+    assert notified["symbol"] == 'NFO:NIFTY26APR23800CE'
+    assert notified["reason"] == "order_accepted"
+
+
 def test_atr_fallback_used_for_insufficient_bars() -> None:
     runner = _build_runner()
     runner._required_candles = 20


### PR DESCRIPTION
### Motivation

- Production showed valid PE entries blocked by a stale CE direction lock that was set during prefilter rather than after an accepted order, causing no-entry churn across CE/PE symbols.
- Trigger evaluation continued during directionless but fresh spot context and evaluated opposite-side options under strong bias, producing noisy strategy no-votes and missed entries.
- SMC live gating was overly binary (requiring BOS/CHoCH) and small-history warmup allowed fragile live evaluations.

### Description

- Refactored orchestrator direction lock lifecycle by removing lock creation from `filter_signal()` and adding lifecycle APIs: `_infer_option_direction`, `notify_entry`, `clear_direction_lock`, `_has_open_position_for_locked_symbol`, and `reconcile_direction_bias` in `src/nifty_scalper_bot/strategies/orchestrator.py` so locks are set only after order acceptance or confirmed position and cleared with structured logs.
- Made `filter_signal()` perform stale-lock clearing before conflict checks and changed default cooldown fallback to `DIRECTION_LOCK_SECONDS=10` and conflict logging to warning with structured event fields.
- Wired `orchestrator.notify_entry(signal.symbol, reason="order_accepted")` into the runner only after a successful submission (`order_id`) in `src/nifty_scalper_bot/strategies/runner.py` and added a bias-reconcile + trigger-guard hook that: (a) skips trigger evaluation when spot is fresh but direction context is missing (`direction_context_not_ready`), and (b) optionally suppresses opposite-side triggers under high-confidence resolved bias using env flags `SUPPRESS_OPPOSITE_SIDE_TRIGGERS=true` and `OPPOSITE_SIDE_SUPPRESSION_CONFIDENCE=0.85`.
- Hardened SMC (`src/nifty_scalper_bot/strategies/elite_strategies/smc_liquidity.py`) by tightening direction field semantics to `direction` / `underlying_direction` / `effective_direction`, adding live no-vote when direction context is missing, increasing warmup to `MIN_BARS_REQUIRED=30` (configurable via `SMC_MIN_BARS_REQUIRED`), and providing an env-controlled composite allowance for momentum-without-structure (`SMC_ALLOW_MOMENTUM_WITHOUT_STRUCTURE_LIVE`, `SMC_MOMENTUM_DISPLACEMENT_MIN`, `SMC_MOMENTUM_REQUIRE_PREMIUM_RECLAIM_OR_RETEST`) with additional metadata fields (`momentum_confirmed`, `structure_or_momentum_confirmed`).
- Added/updated focused tests to cover the orchestrator lock lifecycle and runner notify wiring (`tests/strategies/test_orchestrator.py`, `tests/strategies/test_runner_live_path_guards.py`) and preserved existing SMC no-vote expectations (`tests/strategies/test_elite_no_vote_reasons.py`).

### Testing

- Ran compile and targeted tests with `python -m compileall -q src` and `pytest -q tests/strategies/test_orchestrator.py tests/strategies/test_runner_live_path_guards.py tests/strategies/test_elite_no_vote_reasons.py`, which all passed.
- Ran full test suite `pytest -q` which passed the strategy/orchestrator areas but produced one unrelated failure in `tests/telegram/test_um_commands.py::test_cmd_resolve_known_symbol` caused by a pandas CSV read error during `InstrumentResolver` test setup and not related to the orchestrator/SMC changes.
- New/updated unit tests include: no-lock-on-prefilter, `notify_entry` sets lock, stale-lock cleared when no open position, conflict blocking when a real open position exists, `notify_exit` clears lock, and runner-level notify on accepted order; these tests passed in the targeted run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a140dd3de0c83248ee6236043b53126)