### PR TITLE
Fix StrategyRunner selected-symbol fallback crash during live candidate-refresh pending path

### DIFF
--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -640,6 +640,8 @@ class StrategyRunner:
         self._startup_gate_last_log_ts = 0.0
         self._active_selected_ce: str | None = None
         self._active_selected_pe: str | None = None
+        self._selected_ce_symbol: str | None = None
+        self._selected_pe_symbol: str | None = None
         self._active_atm_strike: int | None = None
         self._active_option_symbols: set[str] = set()
 
@@ -1879,14 +1881,16 @@ class StrategyRunner:
                 )
                 return existing, False, "cached_existing_event_loop_active"
             self._logger.info(
-                "EXECUTION_CANDIDATE_BASKET_FALLBACK reason=event_loop_active_refresh_pending symbol=%s total=%s",
+                "EXECUTION_CANDIDATE_BASKET_REFRESH_PENDING reason=event_loop_active_refresh_pending symbol=%s total=%s source=%s",
                 symbol,
                 len(existing),
+                "event_loop_active_refresh_pending",
                 extra={
-                    "event": "EXECUTION_CANDIDATE_BASKET_FALLBACK",
+                    "event": "EXECUTION_CANDIDATE_BASKET_REFRESH_PENDING",
                     "reason": "event_loop_active_refresh_pending",
                     "symbol": symbol,
                     "total": len(existing),
+                    "source": "event_loop_active_refresh_pending",
                 },
             )
             return existing, True, "event_loop_active_refresh_pending"
@@ -1911,6 +1915,36 @@ class StrategyRunner:
                 )
                 return snapshots, pending, "async_refresh"
             return snapshots, pending, "async_refresh"
+
+    def _selected_option_symbol_for_side(
+        self,
+        side: str,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> str:
+        metadata = metadata or {}
+        side_u = str(side or "").upper()
+        if side_u == "CE":
+            raw = (
+                metadata.get("selected_ce")
+                or metadata.get("selected_ce_symbol")
+                or metadata.get("ce_symbol")
+                or getattr(self, "_selected_ce_symbol", None)
+                or ""
+            )
+        elif side_u == "PE":
+            raw = (
+                metadata.get("selected_pe")
+                or metadata.get("selected_pe_symbol")
+                or metadata.get("pe_symbol")
+                or getattr(self, "_selected_pe_symbol", None)
+                or ""
+            )
+        else:
+            raw = ""
+        try:
+            return normalize_symbol(str(raw or ""))
+        except Exception:
+            return ""
 
     def _schedule_signal_preparation(
         self,
@@ -9676,7 +9710,7 @@ class StrategyRunner:
                         metadata["candidate_snapshots"] = basket_snapshots
                         candidate_snapshots_obj = basket_snapshots
                         metadata["candidate_basket_source"] = _basket_source
-                    else:
+                    elif not basket_pending:
                         self._logger.info(
                             "EXECUTION_CANDIDATE_BASKET_FALLBACK reason=basket_unavailable symbol=%s",
                             signal.symbol,
@@ -9708,8 +9742,8 @@ class StrategyRunner:
                         "existing_snapshot_symbols": [normalize_symbol(str(s.get("symbol") or "")) for s in existing_snapshots if isinstance(s, dict)],
                         "atm_seed": atm_seed,
                         "active_atm_strike": self._active_atm_strike,
-                        "selected_ce": normalize_symbol(str(metadata.get("selected_ce") or self._selected_ce_symbol or "")),
-                        "selected_pe": normalize_symbol(str(metadata.get("selected_pe") or self._selected_pe_symbol or "")),
+                        "selected_ce": self._selected_option_symbol_for_side("CE", metadata),
+                        "selected_pe": self._selected_option_symbol_for_side("PE", metadata),
                         "reason": pending_reason,
                     }
                     self._logger.info(
@@ -9726,8 +9760,8 @@ class StrategyRunner:
                     )
             if is_live_mode and is_directional_option and not candidate_snapshots_obj:
                 signal_symbol = normalize_symbol(signal.symbol)
-                selected_ce = normalize_symbol(str(metadata.get("selected_ce") or self._selected_ce_symbol or ""))
-                selected_pe = normalize_symbol(str(metadata.get("selected_pe") or self._selected_pe_symbol or ""))
+                selected_ce = self._selected_option_symbol_for_side("CE", metadata)
+                selected_pe = self._selected_option_symbol_for_side("PE", metadata)
                 strike_distance = float(metadata.get("strike_distance_from_atm") or 999.0)
                 selected_or_near = (
                     signal_symbol in {selected_ce, selected_pe}

--- a/tests/strategies/test_runner_live_path_guards.py
+++ b/tests/strategies/test_runner_live_path_guards.py
@@ -4,6 +4,7 @@ import asyncio
 from collections import deque
 from datetime import datetime, timezone
 import logging
+from pathlib import Path
 from types import SimpleNamespace
 import threading
 from unittest.mock import AsyncMock, MagicMock
@@ -1315,6 +1316,12 @@ def test_candidate_refresh_pending_includes_diagnostics(monkeypatch) -> None:
     assert diag.get("trace_id") == "trace-pending"
     assert result.details.get("event_loop_active") is True
     assert result.details.get("reason") == "event_loop_active_refresh_pending"
+    assert result.details.get("selected_ce") == ""
+    assert result.details.get("selected_pe") == ""
+    fallback_events = [e for e in emitted if e.get("event") == "EXECUTION_CANDIDATE_BASKET_FALLBACK"]
+    assert not any(e.get("reason") == "basket_unavailable" for e in fallback_events)
+    refresh_pending = [e for e in emitted if e.get("event") == "EXECUTION_CANDIDATE_BASKET_REFRESH_PENDING"]
+    assert refresh_pending
 
 
 def test_candidate_refresh_pending_non_event_loop_reason(monkeypatch) -> None:
@@ -1328,6 +1335,60 @@ def test_candidate_refresh_pending_non_event_loop_reason(monkeypatch) -> None:
     assert result.details.get("event_loop_active") is False
     assert result.details.get("reason") == "candidate_snapshot_refresh_pending"
     assert result.details.get("basket_source") == "async_refresh"
+
+
+def test_missing_candidate_snapshots_without_selected_attrs_returns_clean_rejection(monkeypatch) -> None:
+    runner = _build_runner()
+    monkeypatch.setenv("EXECUTION_MODE", "LIVE")
+    symbol = "NFO:NIFTY26MAY24100PE"
+    if hasattr(runner, "_selected_ce_symbol"):
+        delattr(runner, "_selected_ce_symbol")
+    if hasattr(runner, "_selected_pe_symbol"):
+        delattr(runner, "_selected_pe_symbol")
+    runner._is_option_symbol_tick_fresh = MagicMock(return_value=False)
+    signal = Signal(
+        action="BUY",
+        symbol=symbol,
+        quantity=1,
+        confidence=0.9,
+        reason="OrderFlow",
+        stop_loss=300.0,
+        take_profit=450.0,
+        metadata={},
+    )
+    result = runner._handle_entry_signal_inner(
+        signal,
+        base_symbol=symbol,
+        trade_symbol=symbol,
+        trade_price=374.95,
+        timestamp=datetime.now(timezone.utc),
+        trace_id="trace-missing-candidates",
+    )
+    assert result.reason == "missing_candidate_snapshots"
+    assert result.reason != "entry_exception"
+
+
+def test_selected_option_symbol_for_side_prefers_metadata() -> None:
+    runner = StrategyRunner.__new__(StrategyRunner)
+    metadata = {
+        "selected_ce": "NFO:NIFTY26MAY24150CE",
+        "selected_pe": "NFO:NIFTY26MAY24100PE",
+    }
+    assert runner._selected_option_symbol_for_side("CE", metadata) == "NFO:NIFTY26MAY24150CE"
+    assert runner._selected_option_symbol_for_side("PE", metadata) == "NFO:NIFTY26MAY24100PE"
+
+
+def test_init_sets_selected_symbol_attrs() -> None:
+    runner = _build_runner()
+    assert hasattr(runner, "_selected_ce_symbol")
+    assert hasattr(runner, "_selected_pe_symbol")
+
+
+def test_runner_source_has_no_unsafe_selected_symbol_fallbacks() -> None:
+    source_path = Path("src/nifty_scalper_bot/strategies/runner.py")
+    source = source_path.read_text(encoding="utf-8")
+    assert "or self._selected_ce_symbol" not in source
+    assert "or self._selected_pe_symbol" not in source
 
 
 def test_multi_snapshot_candidate_skips_refresh_and_no_unboundlocal(monkeypatch) -> None:

--- a/tests/strategies/test_runner_live_path_guards.py
+++ b/tests/strategies/test_runner_live_path_guards.py
@@ -1320,8 +1320,33 @@ def test_candidate_refresh_pending_includes_diagnostics(monkeypatch) -> None:
     assert result.details.get("selected_pe") == ""
     fallback_events = [e for e in emitted if e.get("event") == "EXECUTION_CANDIDATE_BASKET_FALLBACK"]
     assert not any(e.get("reason") == "basket_unavailable" for e in fallback_events)
+    
+
+def test_build_candidate_snapshots_sync_safe_logs_refresh_pending_in_active_loop() -> None:
+    runner = _build_runner()
+    emitted: list[dict] = []
+    runner._logger.info = lambda *_args, **kwargs: emitted.append(kwargs.get("extra", {}))  # type: ignore[method-assign]
+    symbol = "NFO:NIFTY26MAY24050PE"
+
+    async def _invoke() -> tuple[list[dict], bool, str]:
+        return runner._build_candidate_snapshots_sync_safe(
+            symbol=symbol,
+            underlying="NIFTY",
+            direction_bias="PE",
+            atm_strike=24050,
+            existing_snapshots=[{"symbol": symbol}],
+            window_each_side=2,
+        )
+
+    snapshots, pending, source = asyncio.run(_invoke())
+    assert snapshots == [{"symbol": symbol}]
+    assert pending is True
+    assert source == "event_loop_active_refresh_pending"
     refresh_pending = [e for e in emitted if e.get("event") == "EXECUTION_CANDIDATE_BASKET_REFRESH_PENDING"]
     assert refresh_pending
+    assert refresh_pending[0].get("reason") == "event_loop_active_refresh_pending"
+    assert refresh_pending[0].get("source") == "event_loop_active_refresh_pending"
+    assert refresh_pending[0].get("total") == 1
 
 
 def test_candidate_refresh_pending_non_event_loop_reason(monkeypatch) -> None:


### PR DESCRIPTION
### Motivation
- Root cause: `StrategyRunner._handle_entry_signal_inner` accessed `self._selected_ce_symbol` / `self._selected_pe_symbol` directly in live fallback/diagnostic paths, which raised `AttributeError` when instances were created via `__new__` or those attrs were not initialized, causing `ENTRY LOGIC CRASH` and `entry_exception` instead of a clean `candidate_refresh_pending`/`missing_candidate_snapshots` rejection.

### Description
- Initialize defensive fallbacks in `StrategyRunner.__init__` by adding `self._selected_ce_symbol: str | None = None` and `self._selected_pe_symbol: str | None = None` to avoid missing-attribute crashes on normal construction.
- Add helper `def _selected_option_symbol_for_side(self, side: str, metadata: Mapping[str, Any] | None = None) -> str:` that prefers metadata keys (`selected_ce`, `selected_ce_symbol`, `ce_symbol`, etc.) and uses `getattr(..., None)` fallback with `normalize_symbol` and safe empty-string fallback.
- Replace direct unsafe references to `self._selected_ce_symbol` / `self._selected_pe_symbol` in the candidate-refresh diagnostics and missing-candidate branches with calls to `_selected_option_symbol_for_side("CE", metadata)` and `_selected_option_symbol_for_side("PE", metadata)` to prevent `AttributeError` in diagnostic construction.
- Improve sync-safe basket builder logging: emit `EXECUTION_CANDIDATE_BASKET_REFRESH_PENDING` (with `source`) when event-loop refresh is detected, and avoid emitting `basket_unavailable` for the same pending path to reduce confusing duplicate logs.
- Add/modify focused tests in `tests/strategies/test_runner_live_path_guards.py` to cover: event-loop refresh-pending behavior when selected attrs are absent, `missing_candidate_snapshots` rejection without selected attrs, metadata-preference of the helper, presence of initialized attrs on normal init, and a small regression assertion that unsafe direct fallback strings no longer appear in source.
- Scope: changes are narrow and defensive; no execution/risk checks or trading safety logic was modified.

### Testing
- Commands run: `python -m compileall -q src` and `pytest -q tests/strategies/test_runner_live_path_guards.py` and a broader targeted suite including strategy and execution contract tests listed in the branch validation.
- Results: compilation passed and all targeted tests passed (focused `test_runner_live_path_guards.py` and the broader strategy/execution suite run completed successfully), confirming the crash is resolved and the `candidate_refresh_pending` and `missing_candidate_snapshots` paths return structured rejections instead of raising `AttributeError`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a151cb31f7c8324a76543312426d380)