### PR TITLE
Harden SMC history context propagation and no-vote diagnostics

### DIFF
--- a/src/nifty_scalper_bot/core/strategy_manager.py
+++ b/src/nifty_scalper_bot/core/strategy_manager.py
@@ -1555,6 +1555,9 @@ class StrategyManager(_BaseStrategyManager):
             extra={"event": "elite_stats_collect"},
         )
         stats: list[dict[str, t.Any]] = []
+        eval_id = f"{symbol}:{int(time.time())}"
+        indicators.setdefault("eval_id", eval_id)
+        strategy_reasons: dict[str, str] = {}
         for strategy in self._strategies:
             if not isinstance(strategy, EliteStrategy):
                 continue
@@ -2776,17 +2779,7 @@ class StrategyManager(_BaseStrategyManager):
                 empty.append(strategy.name)
                 reason = str(getattr(strategy, "last_no_vote_reason", "none") or "none")
                 no_vote_reason_counts[reason] = no_vote_reason_counts.get(reason, 0) + 1
-                log_throttled_live(
-                    log,
-                    logging.INFO,
-                    "STRATEGY_NO_VOTE",
-                    f"STRATEGY_NO_VOTE:{strategy.name}:{symbol}:{reason}",
-                    float(os.getenv("LOG_THROTTLE_STRATEGY_NO_VOTE_SECONDS", "45") or "45"),
-                    "STRATEGY_NO_VOTE strategy=%s symbol=%s reason=%s",
-                    strategy.name,
-                    symbol,
-                    reason,
-                )
+                strategy_reasons[strategy.name] = reason
                 continue
             entry = score_map.get(strategy.name)
             adjusted = self._apply_weighted_confidence(base_signal, strategy.name, entry)
@@ -2808,6 +2801,18 @@ class StrategyManager(_BaseStrategyManager):
                 },
             )
 
+        if no_vote_reason_counts:
+            log.info(
+                "STRATEGY_NO_VOTE_SUMMARY symbol=%s eval_id=%s no_vote_reason_counts=%s strategy_reasons=%s trigger_vote_count=%s context_vote_count=%s final_block_reason=%s",
+                symbol,
+                eval_id,
+                no_vote_reason_counts,
+                strategy_reasons,
+                len(signals),
+                0,
+                "no_strategy_signal" if not signals else "partial",
+                extra={"event": "STRATEGY_NO_VOTE_SUMMARY", "symbol": symbol, "eval_id": eval_id, "no_vote_reason_counts": no_vote_reason_counts, "strategy_reasons": strategy_reasons, "trigger_vote_count": len(signals), "context_vote_count": 0, "final_block_reason": "no_strategy_signal" if not signals else "partial"},
+            )
         if not signals:
             missing = sorted(
                 name

--- a/src/nifty_scalper_bot/core/strategy_manager.py
+++ b/src/nifty_scalper_bot/core/strategy_manager.py
@@ -2720,6 +2720,7 @@ class StrategyManager(_BaseStrategyManager):
                 continue
             strategy_name = str(getattr(strategy, "name", "") or "")
             if strategy_name in {"VWAPPro", "OrderFlow"} and not symbol_is_option:
+                strategy_reasons[strategy_name] = "context_symbol_skipped_for_option_strategy"
                 no_vote_reason_counts["context_symbol_skipped_for_option_strategy"] = (
                     no_vote_reason_counts.get(
                         "context_symbol_skipped_for_option_strategy", 0
@@ -2741,6 +2742,7 @@ class StrategyManager(_BaseStrategyManager):
                 )
                 continue
             if strategy_name == "BBSqueeze" and symbol_is_option:
+                strategy_reasons[strategy_name] = "context_symbol_skipped_for_underlying_strategy"
                 no_vote_reason_counts["context_symbol_skipped_for_underlying_strategy"] = (
                     no_vote_reason_counts.get(
                         "context_symbol_skipped_for_underlying_strategy", 0

--- a/src/nifty_scalper_bot/core/strategy_manager.py
+++ b/src/nifty_scalper_bot/core/strategy_manager.py
@@ -1555,9 +1555,6 @@ class StrategyManager(_BaseStrategyManager):
             extra={"event": "elite_stats_collect"},
         )
         stats: list[dict[str, t.Any]] = []
-        eval_id = f"{symbol}:{int(time.time())}"
-        indicators.setdefault("eval_id", eval_id)
-        strategy_reasons: dict[str, str] = {}
         for strategy in self._strategies:
             if not isinstance(strategy, EliteStrategy):
                 continue
@@ -2706,6 +2703,9 @@ class StrategyManager(_BaseStrategyManager):
         symbol_is_option = bool(re.search(r"(CE|PE)$", symbol_upper))
         symbol_is_future = symbol_upper.endswith("FUT")
         direction_bias = str(indicators.get("direction_bias") or "").upper()
+        eval_id = f"{symbol}:{int(time.time())}"
+        indicators.setdefault("eval_id", eval_id)
+        strategy_reasons: dict[str, str] = {}
         for strategy in self._strategies:
             if strategy.name in self._disabled_strategies:
                 disabled.append(strategy.name)

--- a/src/nifty_scalper_bot/notifications/telegram_webhook_enhanced.py
+++ b/src/nifty_scalper_bot/notifications/telegram_webhook_enhanced.py
@@ -118,6 +118,20 @@ async def safe_reply_text(
 
 
 @dataclass(slots=True)
+class NotificationDispatchResult:
+    alert_id: str
+    event_type: str
+    provider: str
+    status: str
+    attempts: int
+    latency_ms: float | None = None
+    error_type: str | None = None
+    error: str | None = None
+    degraded: bool = False
+    backoff_until: float | None = None
+
+
+@dataclass(slots=True)
 class TelegramEnhancedNotifier:
     """Asynchronous notifier with token-bucket rate limiting and retries."""
 
@@ -136,6 +150,9 @@ class TelegramEnhancedNotifier:
     _telegram_degraded_logged: bool = field(init=False, repr=False, default=False)
     _telegram_backoff_active: bool = field(init=False, repr=False, default=False)
     _telegram_backoff_until: float = field(init=False, repr=False, default=0.0)
+    _consecutive_failures: int = field(init=False, repr=False, default=0)
+    _last_success_ts: float = field(init=False, repr=False, default=0.0)
+    _last_error_type: str | None = field(init=False, repr=False, default=None)
 
     def __post_init__(self) -> None:
         self._logger = get_logger(__name__)

--- a/src/nifty_scalper_bot/strategies/elite_strategies/smc_liquidity.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/smc_liquidity.py
@@ -66,6 +66,15 @@ class SMCStrategy(EliteStrategy):
             raw_history_count = indicators.get("history_count")
             resolved_history_count = (
                 option_history_count if history_domain_used == "options"
+                else (
+                    spot_history_count
+                    if spot_history_count is not None
+                    else underlying_history_count
+                    if underlying_history_count is not None
+                    else raw_history_count
+                    if raw_history_count is not None
+                    else indicator_history_count
+                ) if history_domain_used == "spot"
                 else underlying_history_count if history_domain_used == "underlying"
                 else raw_history_count if raw_history_count is not None else indicator_history_count
             )

--- a/src/nifty_scalper_bot/strategies/elite_strategies/smc_liquidity.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/smc_liquidity.py
@@ -58,25 +58,41 @@ class SMCStrategy(EliteStrategy):
             min_bars_required = int(os.getenv("SMC_MIN_BARS_REQUIRED", "30") or "30")
             execution_mode = str(os.getenv('EXECUTION_MODE', 'SHADOW') or 'SHADOW').strip().upper()
             is_live = execution_mode == 'LIVE'
-            raw_history_count = indicators.get("indicator_history_count")
-            if raw_history_count is None:
-                raw_history_count = indicators.get("history_count")
-            if is_live and raw_history_count is None:
+            history_domain_used = str(indicators.get("history_domain_used") or "unknown")
+            option_history_count = indicators.get("option_history_count")
+            underlying_history_count = indicators.get("underlying_history_count")
+            spot_history_count = indicators.get("spot_history_count")
+            indicator_history_count = indicators.get("indicator_history_count")
+            raw_history_count = indicators.get("history_count")
+            resolved_history_count = (
+                option_history_count if history_domain_used == "options"
+                else underlying_history_count if history_domain_used == "underlying"
+                else raw_history_count if raw_history_count is not None else indicator_history_count
+            )
+            if is_live and resolved_history_count is None:
                 self._no_vote("smc_history_count_missing")
                 LOGGER.warning(
-                    "STRATEGY_NO_VOTE strategy=SMC symbol=%s reason=smc_history_count_missing min_bars=%s",
+                    "STRATEGY_NO_VOTE strategy=SMC symbol=%s reason=smc_history_count_missing min_bars=%s history_domain_used=%s",
                     symbol,
                     min_bars_required,
+                    history_domain_used,
                     extra={
                         "event": "STRATEGY_NO_VOTE",
                         "strategy": "SMC",
                         "symbol": symbol,
                         "reason": "smc_history_count_missing",
                         "min_bars_required": min_bars_required,
+                        "resolved_history_count": resolved_history_count,
+                        "history_domain_used": history_domain_used,
+                        "option_history_count": option_history_count,
+                        "underlying_history_count": underlying_history_count,
+                        "spot_history_count": spot_history_count,
+                        "indicator_history_count": indicator_history_count,
+                        "history_source": indicators.get("history_source"),
                     },
                 )
                 return None
-            history_count = int(raw_history_count or 0)
+            history_count = int(resolved_history_count or 0)
             if is_live and history_count < min_bars_required:
                 self._no_vote("smc_insufficient_history")
                 LOGGER.warning(
@@ -91,6 +107,13 @@ class SMCStrategy(EliteStrategy):
                         "reason": "smc_insufficient_history",
                         "history_count": history_count,
                         "min_bars_required": min_bars_required,
+                        "resolved_history_count": resolved_history_count,
+                        "history_domain_used": history_domain_used,
+                        "option_history_count": option_history_count,
+                        "underlying_history_count": underlying_history_count,
+                        "spot_history_count": spot_history_count,
+                        "indicator_history_count": indicator_history_count,
+                        "history_source": indicators.get("history_source"),
                     },
                 )
                 return None

--- a/src/nifty_scalper_bot/strategies/signal_generator.py
+++ b/src/nifty_scalper_bot/strategies/signal_generator.py
@@ -4,18 +4,68 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections import defaultdict, deque
+from contextlib import suppress
 import dataclasses
 import datetime as dt
 from dataclasses import dataclass, field
 from datetime import datetime, time
 import hashlib
 import math
+import os
 from typing import Any, Deque, Iterable, Literal, Mapping, MutableMapping, Protocol
 
 from nifty_scalper_bot.core.signal_arbitrator import SignalArbitrator
 from nifty_scalper_bot.utils.logging import get_logger, log_throttled
 
 logger = get_logger(__name__)
+
+
+def build_strategy_history_context(
+    *,
+    symbol: str,
+    indicator_engine: Any,
+    data_hub: Any | None,
+    runner_context: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build domain-aware strategy history metadata."""
+    del data_hub
+    bars: list[Any] = []
+    get_bars = getattr(indicator_engine, "get_ohlc_bars", None)
+    if callable(get_bars):
+        with suppress(Exception):
+            bars = list(get_bars(symbol) or [])
+    indicator_count = len(bars)
+    symbol_upper = str(symbol or "").upper()
+    is_option = symbol_upper.endswith("CE") or symbol_upper.endswith("PE")
+    option_count = indicator_count if is_option else 0
+    spot_count = indicator_count if symbol_upper.startswith("NSE:NIFTY") else 0
+    underlying_count = 0
+    if runner_context:
+        option_count = int(runner_context.get("option_history_count", option_count) or 0)
+        spot_count = int(runner_context.get("spot_history_count", spot_count) or 0)
+        underlying_count = int(runner_context.get("underlying_history_count", 0) or 0)
+    min_required = int(os.getenv("SMC_MIN_BARS_REQUIRED", "30") or "30")
+    context: dict[str, Any] = {
+        "history_count": indicator_count,
+        "indicator_history_count": indicator_count,
+        "option_history_count": option_count,
+        "spot_history_count": spot_count,
+        "underlying_history_count": underlying_count,
+        "history_symbol_key": symbol,
+        "history_source": "indicator_engine",
+        "history_domain_used": "options" if is_option else "underlying",
+        "oldest_bar_ts": None,
+        "latest_bar_ts": None,
+        "history_quality": "warm" if indicator_count >= min_required else "cold",
+        "history_required_min": min_required,
+        "history_ready_for_smc": indicator_count >= min_required,
+    }
+    if bars:
+        first = bars[0] if isinstance(bars[0], dict) else {}
+        last = bars[-1] if isinstance(bars[-1], dict) else {}
+        context["oldest_bar_ts"] = first.get("timestamp") or first.get("ts")
+        context["latest_bar_ts"] = last.get("timestamp") or last.get("ts")
+    return context
 
 
 class Position(Protocol):
@@ -1243,18 +1293,17 @@ class StrategyManager:
             logger.debug(f"SKIP {symbol}: No indicators returned from engine")
             return None
 
+        history_ctx = build_strategy_history_context(
+            symbol=symbol,
+            indicator_engine=self._indicator_engine,
+            data_hub=self._data_hub,
+        )
+        indicators.update(history_ctx)
         bars = []
         get_bars = getattr(self._indicator_engine, "get_ohlc_bars", None)
         if callable(get_bars):
-            try:
+            with suppress(Exception):
                 bars = list(get_bars(symbol) or [])
-            except Exception:
-                bars = []
-        history_count = len(bars)
-        indicators["indicator_history_count"] = history_count
-        indicators["history_count"] = history_count
-        indicators["history_symbol_key"] = symbol
-        indicators["history_source"] = "indicator_engine"
         if bars:
             first = bars[0] if isinstance(bars[0], dict) else {}
             last = bars[-1] if isinstance(bars[-1], dict) else {}

--- a/src/nifty_scalper_bot/strategies/signal_generator.py
+++ b/src/nifty_scalper_bot/strategies/signal_generator.py
@@ -28,9 +28,12 @@ def build_strategy_history_context(
     runner_context: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Build domain-aware strategy history metadata."""
-    del data_hub
     bars: list[Any] = []
-    get_bars = getattr(indicator_engine, "get_ohlc_bars", None)
+    get_bars = getattr(data_hub, "get_ohlc_bars", None) if data_hub is not None else None
+    history_source = "data_hub"
+    if not callable(get_bars):
+        get_bars = getattr(indicator_engine, "get_ohlc_bars", None)
+        history_source = "indicator_engine"
     if callable(get_bars):
         with suppress(Exception):
             bars = list(get_bars(symbol) or [])
@@ -39,7 +42,7 @@ def build_strategy_history_context(
     is_option = symbol_upper.endswith("CE") or symbol_upper.endswith("PE")
     option_count = indicator_count if is_option else 0
     spot_count = indicator_count if symbol_upper.startswith("NSE:NIFTY") else 0
-    underlying_count = 0
+    underlying_count = 0 if is_option else indicator_count
     if runner_context:
         option_count = int(runner_context.get("option_history_count", option_count) or 0)
         spot_count = int(runner_context.get("spot_history_count", spot_count) or 0)
@@ -52,7 +55,7 @@ def build_strategy_history_context(
         "spot_history_count": spot_count,
         "underlying_history_count": underlying_count,
         "history_symbol_key": symbol,
-        "history_source": "indicator_engine",
+        "history_source": history_source,
         "history_domain_used": "options" if is_option else "underlying",
         "oldest_bar_ts": None,
         "latest_bar_ts": None,

--- a/src/nifty_scalper_bot/strategies/signal_generator.py
+++ b/src/nifty_scalper_bot/strategies/signal_generator.py
@@ -40,9 +40,10 @@ def build_strategy_history_context(
     indicator_count = len(bars)
     symbol_upper = str(symbol or "").upper()
     is_option = symbol_upper.endswith("CE") or symbol_upper.endswith("PE")
+    is_spot = symbol_upper in {"NSE:NIFTY", "NIFTY", "NSE:NIFTY50", "NIFTY50"}
     option_count = indicator_count if is_option else 0
-    spot_count = indicator_count if symbol_upper.startswith("NSE:NIFTY") else 0
-    underlying_count = 0 if is_option else indicator_count
+    spot_count = indicator_count if is_spot else 0
+    underlying_count = 0 if (is_option or is_spot) else indicator_count
     if runner_context:
         option_count = int(runner_context.get("option_history_count", option_count) or 0)
         spot_count = int(runner_context.get("spot_history_count", spot_count) or 0)
@@ -56,7 +57,7 @@ def build_strategy_history_context(
         "underlying_history_count": underlying_count,
         "history_symbol_key": symbol,
         "history_source": history_source,
-        "history_domain_used": "options" if is_option else "underlying",
+        "history_domain_used": "options" if is_option else "spot" if is_spot else "underlying",
         "oldest_bar_ts": None,
         "latest_bar_ts": None,
         "history_quality": "warm" if indicator_count >= min_required else "cold",

--- a/tests/strategies/test_elite_no_vote_reasons.py
+++ b/tests/strategies/test_elite_no_vote_reasons.py
@@ -153,3 +153,35 @@ def test_smc_quality_gate_logs_specific_reason(caplog) -> None:
     signal = strategy.generate_signal('NFO:NIFTY26MAY24350CE', {'high':10,'low':9,'close':9.5,'open':9.0,'atr':1,'liquidity_sweep_confirmed':True,'premium_reclaim':False,'bos_confirmed':False,'choch_confirmed':False,'data_age_seconds':1}, 9.5, None)
     assert signal is None
     assert any('smc_quality_gate_failed' in r.message for r in caplog.records)
+
+
+def test_smc_resolves_spot_history_domain_in_live(monkeypatch) -> None:
+    monkeypatch.setenv("EXECUTION_MODE", "LIVE")
+    strategy = SMCStrategy(SMCStrategyConfig())
+    signal = strategy.generate_signal(
+        symbol="NSE:NIFTY",
+        indicators={
+            "high": 102,
+            "low": 98,
+            "open": 99,
+            "close": 101,
+            "atr": 2,
+            "history_domain_used": "spot",
+            "spot_history_count": 35,
+            "underlying_history_count": 0,
+            "history_count": 35,
+            "indicator_history_count": 35,
+            "liquidity_sweep_confirmed": True,
+            "premium_reclaim": True,
+            "choch_confirmed": True,
+            "bos_confirmed": True,
+            "direction_bias": "CE",
+            "underlying_direction_bias": "CE",
+            "data_age_seconds": 1,
+        },
+        current_price=100,
+        position=None,
+    )
+    assert strategy.last_no_vote_reason != "smc_history_count_missing"
+    assert strategy.last_no_vote_reason != "smc_insufficient_history"
+    assert signal is not None

--- a/tests/strategies/test_signal_generator_history_safety.py
+++ b/tests/strategies/test_signal_generator_history_safety.py
@@ -66,10 +66,21 @@ def test_build_strategy_history_context_uses_data_hub_source() -> None:
 
 def test_build_strategy_history_context_sets_underlying_for_non_option() -> None:
     ctx = build_strategy_history_context(
-        symbol="NSE:NIFTY",
+        symbol="NFO:NIFTY26MAY24FUT",
         indicator_engine=_IndicatorEngineBars(),
         data_hub=None,
     )
     assert ctx["history_domain_used"] == "underlying"
     assert ctx["underlying_history_count"] == 35
+    assert ctx["spot_history_count"] == 0
+
+
+def test_build_strategy_history_context_sets_spot_domain_for_nifty_spot() -> None:
+    ctx = build_strategy_history_context(
+        symbol="NSE:NIFTY",
+        indicator_engine=_IndicatorEngineBars(),
+        data_hub=None,
+    )
+    assert ctx["history_domain_used"] == "spot"
     assert ctx["spot_history_count"] == 35
+    assert ctx["underlying_history_count"] == 0

--- a/tests/strategies/test_signal_generator_history_safety.py
+++ b/tests/strategies/test_signal_generator_history_safety.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any, Iterable, Mapping
 
-from nifty_scalper_bot.strategies.signal_generator import StrategyManager
+from nifty_scalper_bot.strategies.signal_generator import StrategyManager, build_strategy_history_context
 
 
 class _IndicatorEngineNone:
@@ -21,6 +21,11 @@ class _IndicatorEngineBars:
 class _PositionManager:
     def get_position(self, symbol: str) -> None:
         return None
+
+
+class _DataHubBars:
+    def get_ohlc_bars(self, symbol: str) -> list[dict[str, Any]]:
+        return [{"timestamp": f"dh{i}"} for i in range(12)]
 
 
 def test_generate_signal_handles_none_indicators_without_crash() -> None:
@@ -46,3 +51,25 @@ def test_generate_signal_injects_history_count_for_strategies() -> None:
     manager.generate_signal("NSE:NIFTY", 25000.0)
     assert captured.get("indicator_history_count") == 35
     assert captured.get("history_count") == 35
+
+
+def test_build_strategy_history_context_uses_data_hub_source() -> None:
+    ctx = build_strategy_history_context(
+        symbol="NFO:NIFTY26MAY24350CE",
+        indicator_engine=_IndicatorEngineBars(),
+        data_hub=_DataHubBars(),
+    )
+    assert ctx["history_source"] == "data_hub"
+    assert ctx["indicator_history_count"] == 12
+    assert ctx["option_history_count"] == 12
+
+
+def test_build_strategy_history_context_sets_underlying_for_non_option() -> None:
+    ctx = build_strategy_history_context(
+        symbol="NSE:NIFTY",
+        indicator_engine=_IndicatorEngineBars(),
+        data_hub=None,
+    )
+    assert ctx["history_domain_used"] == "underlying"
+    assert ctx["underlying_history_count"] == 35
+    assert ctx["spot_history_count"] == 35

--- a/tests/strategies/test_strategy_no_vote_summary_domain_skips.py
+++ b/tests/strategies/test_strategy_no_vote_summary_domain_skips.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from nifty_scalper_bot.strategies.signal_generator import StrategyManager
+
+
+class _IndicatorEngine:
+    def get_indicators(self, symbol: str, names: list[str] | None = None) -> dict[str, Any]:
+        del symbol, names
+        return {"bar_count": 40, "vix": 15.0, "volume": 1.0, "avg_volume": 1.0, "minutes_since_open": 30.0, "minutes_until_close": 120.0}
+
+
+class _PositionManager:
+    def get_position(self, symbol: str) -> None:
+        del symbol
+        return None
+
+
+class _VWAPProLike:
+    name = "VWAPPro"
+    MIN_BARS_REQUIRED = 1
+
+    def get_required_indicators(self) -> list[str]:
+        return []
+
+    def generate_signal(self, symbol: str, indicators: dict[str, Any], current_price: float, position: Any) -> None:
+        del symbol, indicators, current_price, position
+        return None
+
+
+def test_strategy_no_vote_summary_includes_domain_skip_reason(caplog) -> None:
+    manager = StrategyManager(
+        strategies=[_VWAPProLike()],
+        indicator_engine=_IndicatorEngine(),
+        position_manager=_PositionManager(),
+    )
+    caplog.set_level(logging.INFO)
+    manager.generate_signal("NSE:NIFTY", 25000.0)
+    rec = next((r for r in caplog.records if "STRATEGY_NO_VOTE_SUMMARY" in r.message), None)
+    assert rec is not None
+    reasons = getattr(rec, "strategy_reasons", None)
+    assert isinstance(reasons, dict)
+    assert reasons.get("VWAPPro") == "context_symbol_skipped_for_option_strategy"


### PR DESCRIPTION
### Motivation

- Fix misleading/mixed history counts that caused SMC to no‑vote even when indicators logged warm history and reduce noisy duplicate no‑vote wrapper logs that obscured root cause.  
- Provide a canonical, domain-aware history metadata payload so strategies (SMC and others) receive unambiguous option vs underlying vs spot counts and timestamps for readiness decisions.

### Description

- Added a canonical helper `build_strategy_history_context(...)` to produce domain-aware history metadata (`history_count`, `indicator_history_count`, `option_history_count`, `spot_history_count`, `underlying_history_count`, `history_symbol_key`, `history_source`, `history_domain_used`, `oldest_bar_ts`, `latest_bar_ts`, `history_quality`, `history_required_min`, `history_ready_for_smc`) and wired it into `StrategyManager.generate_signal()` so every strategy gets consistent history fields. (src/nifty_scalper_bot/strategies/signal_generator.py)
- Hardened SMC readiness checks to resolve history using explicit domain precedence (`options` → `underlying` → fallback counts) and emit richer, structured LIVE no‑vote logs including resolved counts and domain fields when history is missing or insufficient. (src/nifty_scalper_bot/strategies/elite_strategies/smc_liquidity.py)
- Replaced per‑strategy duplicate wrapper no‑vote logging with a single aggregated `STRATEGY_NO_VOTE_SUMMARY` carrying an `eval_id`, aggregated reason counts and per‑strategy reasons to reduce spam and improve correlation. (src/nifty_scalper_bot/core/strategy_manager.py)
- Added a small `NotificationDispatchResult` dispatch model scaffold and a few notifier telemetry fields to the webhook notifier as groundwork for terminal alert dispatch observability (no behavior change to alert sending yet). (src/nifty_scalper_bot/notifications/telegram_webhook_enhanced.py)
- Kept execution safety unchanged; no execution/order placement, risk, or cooldown logic was modified.  The runner dedup initialization was confirmed present and unchanged (safe). (src/nifty_scalper_bot/strategies/runner.py)

### Testing

- Commands run: `python -m compileall -q src tests` (pass) and `pytest -q` plus focused suites.  
- Focused test results: `pytest tests/strategies -q` ✅ passed, `pytest tests/notifications -q` ✅ passed, `pytest tests/execution -q` ✅ passed.  
- Full test run `pytest -q` produced one unrelated failure: `tests/telegram/test_um_commands.py::test_cmd_resolve_known_symbol` fails in `InstrumentResolver.reload()` due to a `pandas` CSV parse `TypeError` when reading the local instrument CSV (this is external to the strategy/hardening changes introduced here).  
- Summary: changes compile and strategy/notification/execution suites passed; one unrelated test in Telegram instrument-loading failed and should be investigated separately before merging the entire repo test-suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a155431e2508324a6ca47c054f8785e)