### PR TITLE
Inject SMC history context into core StrategyManager and throttle SMC no-vote spam

### DIFF
--- a/src/nifty_scalper_bot/core/strategy_manager.py
+++ b/src/nifty_scalper_bot/core/strategy_manager.py
@@ -26,6 +26,7 @@ from nifty_scalper_bot.strategies.elite_strategies.base_elite import EliteStrate
 from nifty_scalper_bot.strategies.signal_quality import infer_option_side
 from nifty_scalper_bot.strategies.signal_generator import (
     Signal,
+    build_strategy_history_context,
 )
 from nifty_scalper_bot.strategies.signal_generator import (
     StrategyManager as _BaseStrategyManager,
@@ -2087,6 +2088,13 @@ class StrategyManager(_BaseStrategyManager):
         indicators: dict[str, t.Any] = dict(indicators_raw)
         symbol_role = classify_symbol_role(symbol)
         indicators["symbol_role"] = symbol_role
+        history_ctx = build_strategy_history_context(
+            symbol=symbol,
+            indicator_engine=self._indicator_engine,
+            data_hub=self._data_hub,
+            runner_context=indicators,
+        )
+        indicators.update(history_ctx)
         vwap = indicators.get("vwap")
         avg_volume = indicators.get("avg_volume")
         required_missing = sorted(
@@ -2764,6 +2772,56 @@ class StrategyManager(_BaseStrategyManager):
                 )
                 continue
             try:
+                if strategy_name == "SMC":
+                    now = time.monotonic()
+                    last_diag_map = getattr(self, "_smc_history_diag_last_emitted", {})
+                    if not isinstance(last_diag_map, dict):
+                        last_diag_map = {}
+                    ready_for_smc = bool(indicators.get("history_ready_for_smc"))
+                    should_emit_diag = (not ready_for_smc) or (
+                        now - float(last_diag_map.get(symbol, 0.0) or 0.0) >= 60.0
+                    )
+                    if should_emit_diag:
+                        last_diag_map[symbol] = now
+                        self._smc_history_diag_last_emitted = last_diag_map
+                        log.info(
+                            "SMC_HISTORY_INPUT_DIAGNOSTICS symbol=%s eval_id=%s history_domain_used=%s history_count=%s history_resolved_count=%s option_history_count=%s",
+                            symbol,
+                            eval_id,
+                            indicators.get("history_domain_used"),
+                            indicators.get("history_count"),
+                            indicators.get("history_resolved_count"),
+                            indicators.get("option_history_count"),
+                            extra={
+                                "event": "SMC_HISTORY_INPUT_DIAGNOSTICS",
+                                "symbol": symbol,
+                                "eval_id": eval_id,
+                                "history_domain_used": indicators.get("history_domain_used"),
+                                "history_count": indicators.get("history_count"),
+                                "history_resolved_count": indicators.get("history_resolved_count"),
+                                "indicator_history_count": indicators.get("indicator_history_count"),
+                                "option_history_count": indicators.get("option_history_count"),
+                                "spot_history_count": indicators.get("spot_history_count"),
+                                "underlying_history_count": indicators.get("underlying_history_count"),
+                                "history_source": indicators.get("history_source"),
+                                "history_symbol_key": indicators.get("history_symbol_key"),
+                                "history_ready_for_smc": indicators.get("history_ready_for_smc"),
+                                "history_quality": indicators.get("history_quality"),
+                                "history_required_min": indicators.get("history_required_min"),
+                                "oldest_bar_ts": indicators.get("oldest_bar_ts"),
+                                "latest_bar_ts": indicators.get("latest_bar_ts"),
+                                "available_indicator_keys_count": len(indicators),
+                                "has_open": indicators.get("open") is not None,
+                                "has_high": indicators.get("high") is not None,
+                                "has_low": indicators.get("low") is not None,
+                                "has_close": indicators.get("close") is not None,
+                                "has_vwap": indicators.get("vwap") is not None,
+                                "has_volume": indicators.get("volume") is not None,
+                                "data_phase": indicators.get("data_phase"),
+                                "quote_update_version": indicators.get("quote_update_version"),
+                                "live_candle_version": indicators.get("live_candle_version"),
+                            },
+                        )
                 base_signal = strategy.generate_signal(
                     symbol, indicators, current_price, position
                 )
@@ -2815,6 +2873,45 @@ class StrategyManager(_BaseStrategyManager):
                 "no_strategy_signal" if not signals else "partial",
                 extra={"event": "STRATEGY_NO_VOTE_SUMMARY", "symbol": symbol, "eval_id": eval_id, "no_vote_reason_counts": no_vote_reason_counts, "strategy_reasons": strategy_reasons, "trigger_vote_count": len(signals), "context_vote_count": 0, "final_block_reason": "no_strategy_signal" if not signals else "partial"},
             )
+            smc_reasons = {"smc_history_count_missing", "smc_insufficient_history"}
+            smc_reason_counts = {k: v for k, v in no_vote_reason_counts.items() if k in smc_reasons}
+            if smc_reason_counts:
+                now = time.monotonic()
+                win = 30.0
+                summary = getattr(self, "_smc_history_no_vote_summary", None)
+                if not isinstance(summary, dict) or now - float(summary.get("window_start", 0.0) or 0.0) >= win:
+                    summary = {"window_start": now, "symbols": set(), "total_no_votes": 0, "reason_counts": {}, "domain_counts": {}, "symbol_counts": {}}
+                    self._smc_history_no_vote_summary = summary
+                summary["symbols"].add(symbol)
+                domain = str(indicators.get("history_domain_used") or "unknown")
+                summary["domain_counts"][domain] = int(summary["domain_counts"].get(domain, 0)) + sum(smc_reason_counts.values())
+                for reason, count in smc_reason_counts.items():
+                    summary["reason_counts"][reason] = int(summary["reason_counts"].get(reason, 0)) + int(count)
+                    summary["total_no_votes"] = int(summary["total_no_votes"]) + int(count)
+                    summary["symbol_counts"][symbol] = int(summary["symbol_counts"].get(symbol, 0)) + int(count)
+                last_emit = float(summary.get("last_emit", 0.0) or 0.0)
+                if now - last_emit >= win:
+                    top_symbols = sorted(summary["symbol_counts"].items(), key=lambda item: item[1], reverse=True)[:5]
+                    log.info(
+                        "SMC_HISTORY_NO_VOTE_SUMMARY window_seconds=%s symbol_count=%s total_no_votes=%s reason_counts=%s",
+                        int(win),
+                        len(summary["symbols"]),
+                        summary["total_no_votes"],
+                        summary["reason_counts"],
+                        extra={
+                            "event": "SMC_HISTORY_NO_VOTE_SUMMARY",
+                            "window_seconds": int(win),
+                            "symbol_count": len(summary["symbols"]),
+                            "total_no_votes": summary["total_no_votes"],
+                            "reason_counts": dict(summary["reason_counts"]),
+                            "history_domain_used_counts": dict(summary["domain_counts"]),
+                            "top_symbols": top_symbols,
+                            "min_bars": int(os.getenv("SMC_MIN_BARS_REQUIRED", "30") or "30"),
+                            "live_mode": str(os.getenv("EXECUTION_MODE", "SHADOW") or "SHADOW").strip().upper() == "LIVE",
+                            "data_phase": indicators.get("data_phase"),
+                        },
+                    )
+                    summary["last_emit"] = now
         if not signals:
             missing = sorted(
                 name

--- a/src/nifty_scalper_bot/strategies/elite_strategies/smc_liquidity.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/smc_liquidity.py
@@ -6,9 +6,18 @@ from typing import Any
 from nifty_scalper_bot.strategies.elite_strategies.base_elite import EliteSignal, EliteStrategy
 from nifty_scalper_bot.strategies.elite_strategies.config_models import SMCStrategyConfig
 from nifty_scalper_bot.strategies.signal_quality import resolve_signal_domain
-from nifty_scalper_bot.utils.logging import get_logger
+from nifty_scalper_bot.utils.logging import get_logger, log_throttled
 
 LOGGER = get_logger(__name__)
+
+
+def _safe_history_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
 
 
 class SMCStrategy(EliteStrategy):
@@ -58,33 +67,32 @@ class SMCStrategy(EliteStrategy):
             min_bars_required = int(os.getenv("SMC_MIN_BARS_REQUIRED", "30") or "30")
             execution_mode = str(os.getenv('EXECUTION_MODE', 'SHADOW') or 'SHADOW').strip().upper()
             is_live = execution_mode == 'LIVE'
-            history_domain_used = str(indicators.get("history_domain_used") or "unknown")
-            option_history_count = indicators.get("option_history_count")
-            underlying_history_count = indicators.get("underlying_history_count")
-            spot_history_count = indicators.get("spot_history_count")
-            indicator_history_count = indicators.get("indicator_history_count")
-            raw_history_count = indicators.get("history_count")
-            resolved_history_count = (
-                option_history_count if history_domain_used == "options"
-                else (
-                    spot_history_count
-                    if spot_history_count is not None
-                    else underlying_history_count
-                    if underlying_history_count is not None
-                    else raw_history_count
-                    if raw_history_count is not None
-                    else indicator_history_count
-                ) if history_domain_used == "spot"
-                else underlying_history_count if history_domain_used == "underlying"
-                else raw_history_count if raw_history_count is not None else indicator_history_count
-            )
+            history_domain_used = str(indicators.get("history_domain_used") or "unknown").lower()
+            option_history_count = _safe_history_int(indicators.get("option_history_count"))
+            underlying_history_count = _safe_history_int(indicators.get("underlying_history_count"))
+            spot_history_count = _safe_history_int(indicators.get("spot_history_count"))
+            indicator_history_count = _safe_history_int(indicators.get("indicator_history_count"))
+            raw_history_count = _safe_history_int(indicators.get("history_count"))
+            resolved_count = _safe_history_int(indicators.get("history_resolved_count"))
+            if history_domain_used == "options":
+                resolved_history_count = option_history_count or resolved_count or raw_history_count or indicator_history_count
+            elif history_domain_used == "spot":
+                resolved_history_count = spot_history_count or underlying_history_count or resolved_count or raw_history_count or indicator_history_count
+            elif history_domain_used == "underlying":
+                resolved_history_count = underlying_history_count or spot_history_count or resolved_count or raw_history_count or indicator_history_count
+            else:
+                resolved_history_count = resolved_count or raw_history_count or indicator_history_count or option_history_count or underlying_history_count or spot_history_count
             if is_live and resolved_history_count is None:
                 self._no_vote("smc_history_count_missing")
-                LOGGER.warning(
+                log_throttled(
+                    LOGGER,
+                    f"smc_history_no_vote:{symbol}:smc_history_count_missing:{history_domain_used}",
                     "STRATEGY_NO_VOTE strategy=SMC symbol=%s reason=smc_history_count_missing min_bars=%s history_domain_used=%s",
                     symbol,
                     min_bars_required,
                     history_domain_used,
+                    interval_sec=float(os.getenv("SMC_HISTORY_NO_VOTE_LOG_THROTTLE_SECONDS", "60") or "60"),
+                    level=30,
                     extra={
                         "event": "STRATEGY_NO_VOTE",
                         "strategy": "SMC",
@@ -98,17 +106,26 @@ class SMCStrategy(EliteStrategy):
                         "spot_history_count": spot_history_count,
                         "indicator_history_count": indicator_history_count,
                         "history_source": indicators.get("history_source"),
+                        "history_symbol_key": indicators.get("history_symbol_key"),
+                        "oldest_bar_ts": indicators.get("oldest_bar_ts"),
+                        "latest_bar_ts": indicators.get("latest_bar_ts"),
+                        "data_phase": indicators.get("data_phase"),
+                        "eval_id": indicators.get("eval_id"),
                     },
                 )
                 return None
             history_count = int(resolved_history_count or 0)
             if is_live and history_count < min_bars_required:
                 self._no_vote("smc_insufficient_history")
-                LOGGER.warning(
+                log_throttled(
+                    LOGGER,
+                    f"smc_history_no_vote:{symbol}:smc_insufficient_history:{history_domain_used}",
                     "STRATEGY_NO_VOTE strategy=SMC symbol=%s reason=smc_insufficient_history history_count=%s min_bars=%s",
                     symbol,
                     history_count,
                     min_bars_required,
+                    interval_sec=float(os.getenv("SMC_HISTORY_NO_VOTE_LOG_THROTTLE_SECONDS", "60") or "60"),
+                    level=30,
                     extra={
                         "event": "STRATEGY_NO_VOTE",
                         "strategy": "SMC",
@@ -123,6 +140,11 @@ class SMCStrategy(EliteStrategy):
                         "spot_history_count": spot_history_count,
                         "indicator_history_count": indicator_history_count,
                         "history_source": indicators.get("history_source"),
+                        "history_symbol_key": indicators.get("history_symbol_key"),
+                        "oldest_bar_ts": indicators.get("oldest_bar_ts"),
+                        "latest_bar_ts": indicators.get("latest_bar_ts"),
+                        "data_phase": indicators.get("data_phase"),
+                        "eval_id": indicators.get("eval_id"),
                     },
                 )
                 return None

--- a/src/nifty_scalper_bot/strategies/signal_generator.py
+++ b/src/nifty_scalper_bot/strategies/signal_generator.py
@@ -28,47 +28,77 @@ def build_strategy_history_context(
     runner_context: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Build domain-aware strategy history metadata."""
-    bars: list[Any] = []
-    get_bars = getattr(data_hub, "get_ohlc_bars", None) if data_hub is not None else None
-    history_source = "data_hub"
-    if not callable(get_bars):
-        get_bars = getattr(indicator_engine, "get_ohlc_bars", None)
-        history_source = "indicator_engine"
-    if callable(get_bars):
-        with suppress(Exception):
-            bars = list(get_bars(symbol) or [])
-    indicator_count = len(bars)
+    def _safe_get_bars(source: Any, sym: str) -> list[Any]:
+        if source is None:
+            return []
+        for method_name in ("get_ohlc_bars", "get_history", "get_bars"):
+            method = getattr(source, method_name, None)
+            if callable(method):
+                with suppress(Exception):
+                    bars = list(method(sym) or [])
+                    if bars:
+                        return bars
+        return []
+
+    def _safe_int(value: Any, default: int = 0) -> int:
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return default
+
+    def _bar_ts(bar: Any) -> Any:
+        if isinstance(bar, Mapping):
+            return bar.get("timestamp") or bar.get("ts") or bar.get("datetime") or bar.get("time")
+        return (
+            getattr(bar, "timestamp", None)
+            or getattr(bar, "ts", None)
+            or getattr(bar, "datetime", None)
+            or getattr(bar, "time", None)
+        )
+
+    data_hub_bars = _safe_get_bars(data_hub, symbol)
+    indicator_bars = _safe_get_bars(indicator_engine, symbol)
+    bars: list[Any] = data_hub_bars or indicator_bars
+    history_source = "data_hub" if data_hub_bars else "indicator_engine" if indicator_bars else "unavailable"
+
     symbol_upper = str(symbol or "").upper()
-    is_option = symbol_upper.endswith("CE") or symbol_upper.endswith("PE")
+    is_option = symbol_upper.endswith(("CE", "PE"))
     is_spot = symbol_upper in {"NSE:NIFTY", "NIFTY", "NSE:NIFTY50", "NIFTY50"}
-    option_count = indicator_count if is_option else 0
-    spot_count = indicator_count if is_spot else 0
-    underlying_count = 0 if (is_option or is_spot) else indicator_count
+    is_underlying_or_future = not is_option and not is_spot
+    raw_count = len(bars)
+    option_count = raw_count if is_option else 0
+    spot_count = raw_count if is_spot else 0
+    underlying_count = raw_count if is_underlying_or_future else 0
     if runner_context:
-        option_count = int(runner_context.get("option_history_count", option_count) or 0)
-        spot_count = int(runner_context.get("spot_history_count", spot_count) or 0)
-        underlying_count = int(runner_context.get("underlying_history_count", 0) or 0)
+        option_count = max(option_count, _safe_int(runner_context.get("option_history_count"), 0))
+        spot_count = max(spot_count, _safe_int(runner_context.get("spot_history_count"), 0))
+        underlying_count = max(underlying_count, _safe_int(runner_context.get("underlying_history_count"), 0))
+    history_domain_used = "options" if is_option else "spot" if is_spot else "underlying"
+    resolved_history_count = (
+        option_count if history_domain_used == "options"
+        else spot_count if history_domain_used == "spot"
+        else underlying_count
+    )
     min_required = int(os.getenv("SMC_MIN_BARS_REQUIRED", "30") or "30")
     context: dict[str, Any] = {
-        "history_count": indicator_count,
-        "indicator_history_count": indicator_count,
+        "history_count": resolved_history_count,
+        "indicator_history_count": raw_count,
         "option_history_count": option_count,
         "spot_history_count": spot_count,
         "underlying_history_count": underlying_count,
         "history_symbol_key": symbol,
         "history_source": history_source,
-        "history_domain_used": "options" if is_option else "spot" if is_spot else "underlying",
+        "history_domain_used": history_domain_used,
+        "history_resolved_count": resolved_history_count,
         "oldest_bar_ts": None,
         "latest_bar_ts": None,
-        "history_quality": "warm" if indicator_count >= min_required else "cold",
+        "history_quality": "warm" if resolved_history_count >= min_required else "cold",
         "history_required_min": min_required,
-        "history_ready_for_smc": indicator_count >= min_required,
+        "history_ready_for_smc": resolved_history_count >= min_required,
     }
     if bars:
-        first = bars[0] if isinstance(bars[0], dict) else {}
-        last = bars[-1] if isinstance(bars[-1], dict) else {}
-        context["oldest_bar_ts"] = first.get("timestamp") or first.get("ts")
-        context["latest_bar_ts"] = last.get("timestamp") or last.get("ts")
+        context["oldest_bar_ts"] = _bar_ts(bars[0])
+        context["latest_bar_ts"] = _bar_ts(bars[-1])
     return context
 
 

--- a/tests/core/test_strategy_manager_smc_history_context.py
+++ b/tests/core/test_strategy_manager_smc_history_context.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from typing import Any
+
+from nifty_scalper_bot.core.strategy_manager import StrategyManager
+
+
+class _IndicatorEngine:
+    def __init__(self, bars: int) -> None:
+        self._bars = bars
+
+    def get_indicators(self, symbol: str, names: Any) -> dict[str, Any]:
+        return {"open": 100.0, "high": 102.0, "low": 99.0, "close": 101.0, "vwap": 100.5, "volume": 10.0}
+
+    def get_history(self, symbol: str) -> list[dict[str, Any]]:
+        return [{"timestamp": i} for i in range(self._bars)]
+
+    def get_ohlc_bars(self, symbol: str) -> list[dict[str, Any]]:
+        return [{"timestamp": i} for i in range(self._bars)]
+
+
+class _DataHub:
+    def __init__(self, bars_by_symbol: dict[str, int]) -> None:
+        self._bars_by_symbol = bars_by_symbol
+
+    def get_ohlc_bars(self, symbol: str) -> list[dict[str, Any]]:
+        size = self._bars_by_symbol.get(symbol, 0)
+        return [{"timestamp": i} for i in range(size)]
+
+
+class _PositionManager:
+    def get_position(self, symbol: str) -> None:
+        return None
+
+
+class _CaptureSMC:
+    name = "SMC"
+
+    def __init__(self) -> None:
+        self.last: dict[str, Any] | None = None
+        self.last_no_vote_reason = "none"
+
+    def generate_signal(self, symbol: str, indicators: dict[str, Any], current_price: float, position: Any) -> None:
+        self.last = dict(indicators)
+        return None
+
+
+def test_strategy_manager_injects_smc_history_context_option_domain() -> None:
+    smc = _CaptureSMC()
+    symbol = "NFO:NIFTY26MAY23850PE"
+    manager = StrategyManager([smc], _IndicatorEngine(35), _PositionManager(), data_hub=_DataHub({symbol: 35}))
+    manager.generate_signal(symbol, 100.0)
+    assert smc.last is not None
+    assert smc.last.get("history_domain_used") == "options"
+    assert smc.last.get("option_history_count") == 35
+    assert smc.last.get("history_ready_for_smc") is True
+    assert smc.last.get("history_source") in {"data_hub", "indicator_engine"}
+
+
+def test_strategy_manager_option_history_not_overwritten_by_underlying() -> None:
+    smc = _CaptureSMC()
+    symbol = "NFO:NIFTY26MAY23850PE"
+    manager = StrategyManager([smc], _IndicatorEngine(341), _PositionManager(), data_hub=_DataHub({symbol: 5}))
+    manager.generate_signal(symbol, 100.0)
+    assert smc.last is not None
+    assert smc.last.get("history_domain_used") == "options"
+    assert smc.last.get("option_history_count") == 5
+    assert smc.last.get("history_ready_for_smc") is False
+    assert smc.last.get("history_quality") == "cold"

--- a/tests/strategies/test_signal_generator_history_safety.py
+++ b/tests/strategies/test_signal_generator_history_safety.py
@@ -84,3 +84,18 @@ def test_build_strategy_history_context_sets_spot_domain_for_nifty_spot() -> Non
     assert ctx["history_domain_used"] == "spot"
     assert ctx["spot_history_count"] == 35
     assert ctx["underlying_history_count"] == 0
+
+
+def test_build_strategy_history_context_falls_back_to_indicator_engine_when_data_hub_empty() -> None:
+    class _DataHubEmpty:
+        def get_ohlc_bars(self, symbol: str) -> list[dict[str, Any]]:
+            return []
+
+    ctx = build_strategy_history_context(
+        symbol="NFO:NIFTY26MAY24350PE",
+        indicator_engine=_IndicatorEngineBars(),
+        data_hub=_DataHubEmpty(),
+    )
+    assert ctx["history_source"] == "indicator_engine"
+    assert ctx["history_domain_used"] == "options"
+    assert ctx["history_resolved_count"] == 35


### PR DESCRIPTION
### Motivation
- Production SMC strategies were repeatedly no-voting with `history_domain_used=unknown`, causing a Telegram alert storm because the active core path did not provide the domain-aware history metadata the SMC logic expects. The core `StrategyManager` used indicator snapshots but never merged `build_strategy_history_context(...)` into the evaluation `indicators` before calling SMC.

### Description
- Injected history context into active core path by calling `build_strategy_history_context(...)` in `StrategyManager.generate_signal()` before strategy execution so all strategies (notably `SMC`) receive domain-aware history metadata (`history_domain_used`, `option_history_count`, `history_source`, `history_ready_for_smc`, etc.). (file: `src/nifty_scalper_bot/core/strategy_manager.py`)
- Hardened `build_strategy_history_context()` to safely fetch bars from `data_hub` or `indicator_engine` via multiple method fallbacks (`get_ohlc_bars`, `get_history`, `get_bars`), to extract timestamps from dict/object bars, and to compute strict domain counts and a resolved history count and readiness fields. (file: `src/nifty_scalper_bot/strategies/signal_generator.py`)
- Made SMC history resolution robust: added safe int parsing, explicit domain-based resolved-count logic, and preserved live safety gates (emit `smc_history_count_missing` only when truly missing and `smc_insufficient_history` when present but below min). Replaced repeated per-symbol unthrottled warnings with throttled warnings via `log_throttled`. (file: `src/nifty_scalper_bot/strategies/elite_strategies/smc_liquidity.py`)
- Added targeted diagnostics and aggregation to reduce alert noise: emit `SMC_HISTORY_INPUT_DIAGNOSTICS` (rate-limited: always when not ready, otherwise once per symbol/60s) immediately before SMC runs, and aggregate SMC history no-votes into `SMC_HISTORY_NO_VOTE_SUMMARY` (30s window) so downstream notifiers (Telegram) can prefer summaries over individual repeated alerts. (file: `src/nifty_scalper_bot/core/strategy_manager.py`)
- Kept all safety rules intact: `SMC_MIN_BARS_REQUIRED` is not lowered, execution/risk/ordering logic untouched, and no strategy thresholds were adjusted.
- Tests added/updated: new `tests/core/test_strategy_manager_smc_history_context.py` to assert active core-path injection and domain counts; extended `tests/strategies/test_signal_generator_history_safety.py` to assert data_hub-empty fallback to `indicator_engine`. (files: `tests/core/test_strategy_manager_smc_history_context.py`, `tests/strategies/test_signal_generator_history_safety.py`)

### Testing
- Run compilation: `python -m compileall -q src tests` — success.
- Focused pytest run: `pytest -q tests/core/test_strategy_manager_smc_history_context.py tests/strategies/test_signal_generator_history_safety.py tests/strategies/test_elite_no_vote_reasons.py tests/notifications -q` — all tests passed.
- Broader validation: `pytest -q tests/strategies tests/core` — suite passed in the CI-local environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15937d9164832494cd42073b649e38)