### PR TITLE
Fix SMC history count correctness and no-vote summary window aggregation

### DIFF
--- a/src/nifty_scalper_bot/core/strategy_manager.py
+++ b/src/nifty_scalper_bot/core/strategy_manager.py
@@ -1799,6 +1799,40 @@ class StrategyManager(_BaseStrategyManager):
                 extra={"event": "strategy_no_signal_summary_error", "symbol": symbol},
             )
 
+    def _emit_smc_history_no_vote_summary(
+        self,
+        *,
+        summary: dict[str, t.Any],
+        indicators: t.Mapping[str, t.Any],
+        window_seconds: float,
+    ) -> None:
+        total_no_votes = int(summary.get("total_no_votes", 0) or 0)
+        if total_no_votes <= 0:
+            return
+        symbols = summary.get("symbols")
+        symbol_count = len(symbols) if isinstance(symbols, set) else 0
+        symbol_counts = summary.get("symbol_counts", {})
+        top_symbols = sorted(symbol_counts.items(), key=lambda item: item[1], reverse=True)[:5]
+        log.info(
+            "SMC_HISTORY_NO_VOTE_SUMMARY window_seconds=%s symbol_count=%s total_no_votes=%s reason_counts=%s",
+            int(window_seconds),
+            symbol_count,
+            total_no_votes,
+            summary.get("reason_counts", {}),
+            extra={
+                "event": "SMC_HISTORY_NO_VOTE_SUMMARY",
+                "window_seconds": int(window_seconds),
+                "symbol_count": symbol_count,
+                "total_no_votes": total_no_votes,
+                "reason_counts": dict(summary.get("reason_counts", {})),
+                "history_domain_used_counts": dict(summary.get("domain_counts", {})),
+                "top_symbols": top_symbols,
+                "min_bars": int(os.getenv("SMC_MIN_BARS_REQUIRED", "30") or "30"),
+                "live_mode": str(os.getenv("EXECUTION_MODE", "SHADOW") or "SHADOW").strip().upper() == "LIVE",
+                "data_phase": indicators.get("data_phase"),
+            },
+        )
+
 
     def _update_context_snapshot(
         self,
@@ -2897,7 +2931,16 @@ class StrategyManager(_BaseStrategyManager):
                 now = time.monotonic()
                 win = 30.0
                 summary = getattr(self, "_smc_history_no_vote_summary", None)
-                if not isinstance(summary, dict) or now - float(summary.get("window_start", 0.0) or 0.0) >= win:
+                if isinstance(summary, dict):
+                    window_start = float(summary.get("window_start", now) or now)
+                    if now - window_start >= win:
+                        self._emit_smc_history_no_vote_summary(
+                            summary=summary,
+                            indicators=indicators,
+                            window_seconds=win,
+                        )
+                        summary = None
+                if not isinstance(summary, dict):
                     summary = {"window_start": now, "symbols": set(), "total_no_votes": 0, "reason_counts": {}, "domain_counts": {}, "symbol_counts": {}}
                     self._smc_history_no_vote_summary = summary
                 summary["symbols"].add(symbol)
@@ -2907,29 +2950,6 @@ class StrategyManager(_BaseStrategyManager):
                     summary["reason_counts"][reason] = int(summary["reason_counts"].get(reason, 0)) + int(count)
                     summary["total_no_votes"] = int(summary["total_no_votes"]) + int(count)
                     summary["symbol_counts"][symbol] = int(summary["symbol_counts"].get(symbol, 0)) + int(count)
-                last_emit = float(summary.get("last_emit", 0.0) or 0.0)
-                if now - last_emit >= win:
-                    top_symbols = sorted(summary["symbol_counts"].items(), key=lambda item: item[1], reverse=True)[:5]
-                    log.info(
-                        "SMC_HISTORY_NO_VOTE_SUMMARY window_seconds=%s symbol_count=%s total_no_votes=%s reason_counts=%s",
-                        int(win),
-                        len(summary["symbols"]),
-                        summary["total_no_votes"],
-                        summary["reason_counts"],
-                        extra={
-                            "event": "SMC_HISTORY_NO_VOTE_SUMMARY",
-                            "window_seconds": int(win),
-                            "symbol_count": len(summary["symbols"]),
-                            "total_no_votes": summary["total_no_votes"],
-                            "reason_counts": dict(summary["reason_counts"]),
-                            "history_domain_used_counts": dict(summary["domain_counts"]),
-                            "top_symbols": top_symbols,
-                            "min_bars": int(os.getenv("SMC_MIN_BARS_REQUIRED", "30") or "30"),
-                            "live_mode": str(os.getenv("EXECUTION_MODE", "SHADOW") or "SHADOW").strip().upper() == "LIVE",
-                            "data_phase": indicators.get("data_phase"),
-                        },
-                    )
-                    summary["last_emit"] = now
         if not signals:
             missing = sorted(
                 name

--- a/src/nifty_scalper_bot/strategies/elite_strategies/smc_liquidity.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/smc_liquidity.py
@@ -20,6 +20,10 @@ def _safe_history_int(value: Any) -> int | None:
         return None
 
 
+def _first_not_none(*values: int | None) -> int | None:
+    return next((value for value in values if value is not None), None)
+
+
 class SMCStrategy(EliteStrategy):
     """SMC liquidity sweep strategy producing structured votes only."""
 
@@ -75,13 +79,37 @@ class SMCStrategy(EliteStrategy):
             raw_history_count = _safe_history_int(indicators.get("history_count"))
             resolved_count = _safe_history_int(indicators.get("history_resolved_count"))
             if history_domain_used == "options":
-                resolved_history_count = option_history_count or resolved_count or raw_history_count or indicator_history_count
+                resolved_history_count = _first_not_none(
+                    option_history_count,
+                    resolved_count,
+                    raw_history_count,
+                    indicator_history_count,
+                )
             elif history_domain_used == "spot":
-                resolved_history_count = spot_history_count or underlying_history_count or resolved_count or raw_history_count or indicator_history_count
+                resolved_history_count = _first_not_none(
+                    spot_history_count,
+                    underlying_history_count,
+                    resolved_count,
+                    raw_history_count,
+                    indicator_history_count,
+                )
             elif history_domain_used == "underlying":
-                resolved_history_count = underlying_history_count or spot_history_count or resolved_count or raw_history_count or indicator_history_count
+                resolved_history_count = _first_not_none(
+                    underlying_history_count,
+                    spot_history_count,
+                    resolved_count,
+                    raw_history_count,
+                    indicator_history_count,
+                )
             else:
-                resolved_history_count = resolved_count or raw_history_count or indicator_history_count or option_history_count or underlying_history_count or spot_history_count
+                resolved_history_count = _first_not_none(
+                    resolved_count,
+                    raw_history_count,
+                    indicator_history_count,
+                    option_history_count,
+                    underlying_history_count,
+                    spot_history_count,
+                )
             if is_live and resolved_history_count is None:
                 self._no_vote("smc_history_count_missing")
                 log_throttled(

--- a/tests/core/test_strategy_manager_smc_history_context.py
+++ b/tests/core/test_strategy_manager_smc_history_context.py
@@ -46,6 +46,12 @@ class _CaptureSMC:
         return None
 
 
+class _CaptureSMCNoVote(_CaptureSMC):
+    def __init__(self, reason: str) -> None:
+        super().__init__()
+        self.last_no_vote_reason = reason
+
+
 class _IndicatorEngineNone(_IndicatorEngine):
     def get_indicators(self, symbol: str, names: Any) -> None:
         return None
@@ -95,3 +101,47 @@ def test_smc_history_input_diagnostics_throttled_when_not_ready(caplog: Any) -> 
     manager.generate_signal(symbol, 100.0)
     diag_records = [r for r in caplog.records if getattr(r, "event", "") == "SMC_HISTORY_INPUT_DIAGNOSTICS" and getattr(r, "symbol", "") == symbol]
     assert len(diag_records) == 1
+
+
+def test_smc_summary_window_flushes_before_reset(caplog: Any, monkeypatch: Any) -> None:
+    symbol = "NFO:NIFTY26MAY23850PE"
+    smc = _CaptureSMCNoVote("smc_insufficient_history")
+    manager = StrategyManager([smc], _IndicatorEngine(5), _PositionManager(), data_hub=_DataHub({symbol: 5}))
+    manager._smc_history_no_vote_summary = {
+        "window_start": 1.0,
+        "symbols": {"NFO:NIFTY26MAY23800PE"},
+        "total_no_votes": 3,
+        "reason_counts": {"smc_insufficient_history": 2, "smc_history_count_missing": 1},
+        "domain_counts": {"options": 3},
+        "symbol_counts": {"NFO:NIFTY26MAY23800PE": 3},
+    }
+    monotonic_values = iter([40.0])
+    monkeypatch.setattr("nifty_scalper_bot.core.strategy_manager.time.monotonic", lambda: next(monotonic_values))
+    caplog.set_level(logging.INFO)
+
+    manager.generate_signal(symbol, 100.0)
+
+    summary_logs = [r for r in caplog.records if getattr(r, "event", "") == "SMC_HISTORY_NO_VOTE_SUMMARY"]
+    assert len(summary_logs) == 1
+    assert getattr(summary_logs[0], "total_no_votes", None) == 3
+    summary = manager._smc_history_no_vote_summary
+    assert isinstance(summary, dict)
+    assert summary["total_no_votes"] == 1
+    assert summary["symbol_counts"][symbol] == 1
+    assert "NFO:NIFTY26MAY23800PE" not in summary["symbol_counts"]
+
+
+def test_smc_summary_first_event_does_not_prematurely_emit(caplog: Any) -> None:
+    symbol = "NFO:NIFTY26MAY23850PE"
+    smc = _CaptureSMCNoVote("smc_history_count_missing")
+    manager = StrategyManager([smc], _IndicatorEngine(5), _PositionManager(), data_hub=_DataHub({symbol: 5}))
+    caplog.set_level(logging.INFO)
+
+    manager.generate_signal(symbol, 100.0)
+
+    summary_logs = [r for r in caplog.records if getattr(r, "event", "") == "SMC_HISTORY_NO_VOTE_SUMMARY"]
+    assert summary_logs == []
+    summary = manager._smc_history_no_vote_summary
+    assert isinstance(summary, dict)
+    assert summary["total_no_votes"] == 1
+    assert summary["symbol_counts"][symbol] == 1

--- a/tests/strategies/test_elite_no_vote_reasons.py
+++ b/tests/strategies/test_elite_no_vote_reasons.py
@@ -185,3 +185,50 @@ def test_smc_resolves_spot_history_domain_in_live(monkeypatch) -> None:
     assert strategy.last_no_vote_reason != "smc_history_count_missing"
     assert strategy.last_no_vote_reason != "smc_insufficient_history"
     assert signal is not None
+
+
+def test_smc_option_history_zero_does_not_fallback_to_nonzero(monkeypatch) -> None:
+    monkeypatch.setenv("EXECUTION_MODE", "LIVE")
+    strategy = SMCStrategy(SMCStrategyConfig())
+    signal = strategy.generate_signal(
+        symbol="NFO:NIFTY26MAY23850PE",
+        indicators={
+            "history_domain_used": "options",
+            "option_history_count": 0,
+            "history_resolved_count": 35,
+            "history_count": 35,
+            "indicator_history_count": 35,
+            "high": 102,
+            "low": 98,
+            "open": 99,
+            "close": 101,
+            "atr": 2,
+            "data_age_seconds": 1,
+        },
+        current_price=100,
+        position=None,
+    )
+    assert signal is None
+    assert strategy.last_no_vote_reason == "smc_insufficient_history"
+    assert strategy.last_no_vote_reason != "smc_history_count_missing"
+
+
+def test_smc_missing_history_only_when_all_counts_none(monkeypatch) -> None:
+    monkeypatch.setenv("EXECUTION_MODE", "LIVE")
+    strategy = SMCStrategy(SMCStrategyConfig())
+    signal = strategy.generate_signal(
+        symbol="NFO:NIFTY26MAY23850PE",
+        indicators={
+            "history_domain_used": "options",
+            "high": 102,
+            "low": 98,
+            "open": 99,
+            "close": 101,
+            "atr": 2,
+            "data_age_seconds": 1,
+        },
+        current_price=100,
+        position=None,
+    )
+    assert signal is None
+    assert strategy.last_no_vote_reason == "smc_history_count_missing"


### PR DESCRIPTION
### Motivation

- Correct SMC history-count resolution so a valid zero (`0`) history count in the selected domain is preserved and not masked by falsy `or` fallbacks. 
- Make SMC no-vote summary aggregation deterministic so expired windows are flushed (emitted) before reset and the first event of a new window does not cause premature emission.

### Description

- Replaced `or`-chained history count fallback in `SMCStrategy._evaluate_signal()` with a `None`-preserving helper `def _first_not_none(*values: int | None) -> int | None:` and domain-aware selection to ensure `0` remains a valid resolved count (`src/nifty_scalper_bot/strategies/elite_strategies/smc_liquidity.py`).
- Added `_emit_smc_history_no_vote_summary(...)` and updated the SMC window logic in `StrategyManager.generate_signal()` to flush expired windows before creating a new summary and to only emit one consolidated `SMC_HISTORY_NO_VOTE_SUMMARY` event per flush (`src/nifty_scalper_bot/core/strategy_manager.py`).
- Added focused unit tests covering: option-domain `0` history preservation and missing-history semantics, expired-window flush behavior, and that the first event of a newly-created window does not immediately emit (`tests/strategies/test_elite_no_vote_reasons.py`, `tests/core/test_strategy_manager_smc_history_context.py`).

### Testing

- Ran compilation with `python -m compileall -q src tests` which succeeded. 
- Ran focused tests with `pytest -q tests/core/test_strategy_manager_smc_history_context.py tests/strategies/test_elite_no_vote_reasons.py tests/strategies/test_signal_generator_history_safety.py` and these passed. 
- Ran full test-suite with `pytest -q` which reported an unrelated failure in `tests/telegram/test_um_commands.py::test_cmd_resolve_known_symbol` caused by a pandas CSV parsing error in the `InstrumentResolver.reload()` path (`TypeError: bad argument type for built-in operation`), which is outside this PR's scope.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15af2f03b4832483c6cba520cb1426)