### PR TITLE
telegram-diagnostics: add terminal dispatch results and observability

### DIFF
--- a/src/nifty_scalper_bot/notifications/telegram_webhook_enhanced.py
+++ b/src/nifty_scalper_bot/notifications/telegram_webhook_enhanced.py
@@ -5,10 +5,11 @@ and robust command replies (/ping, /status, /start).
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import random
 from contextlib import suppress
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
 from logging import Logger
 from time import monotonic
 from typing import Any, Callable, Iterable, Mapping, Sequence, cast
@@ -49,6 +50,11 @@ def _truncate(text: str, limit: int = 3500) -> str:
     if len(text) <= limit:
         return text
     return f"{text[: limit - 1]}…"
+
+
+def _hash_chat_id(chat_id: int) -> str:
+    digest = hashlib.sha256(str(chat_id).encode("utf-8")).hexdigest()
+    return digest[:12]
 
 
 _TELEGRAM_MAX_CHARS = 3500
@@ -190,21 +196,39 @@ class TelegramEnhancedNotifier:
 
     async def send_event(
         self, event: str, payload: Mapping[str, object] | None = None
-    ) -> None:
+    ) -> list[NotificationDispatchResult]:
         """Send ``event`` with optional ``payload`` to authorised chats."""
 
+        alert_id = f"evt-{int(_current_loop_time() * 1000)}-{random.randint(1000, 9999)}"
         if not self._chat_whitelist:
-            self._logger.debug(
-                "telegram_notifier_skip",
-                extra={"event": event, "reason": "no_whitelisted_chats"},
+            result = NotificationDispatchResult(
+                alert_id=alert_id,
+                event_type=event,
+                provider="telegram",
+                status="no_whitelisted_chats",
+                attempts=0,
             )
-            return
+            self._logger.info(
+                "NOTIFICATION_DISPATCH_RESULT",
+                extra=asdict(result),
+            )
+            self._log_provider_health()
+            return [result]
 
         message = self._format_message(event, payload)
+        results: list[NotificationDispatchResult] = []
 
         for chat_id in self._chat_whitelist:
             await self._acquire_token()
-            await self._send_single(chat_id, message)
+            results.append(
+                await self._send_single(
+                    chat_id,
+                    message,
+                    alert_id=alert_id,
+                    event_type=event,
+                )
+            )
+        return results
 
     def send_alert(self, message: str) -> None:
         """Send alert synchronously with proper event loop handling.
@@ -227,30 +251,39 @@ class TelegramEnhancedNotifier:
         if not self._chat_whitelist:
             return
 
-        async def _dispatch() -> None:
-            """Deliver alert to all whitelisted chats."""
+        alert_id = f"alert-{int(_current_loop_time() * 1000)}-{random.randint(1000, 9999)}"
 
+        async def _dispatch() -> list[NotificationDispatchResult]:
+            """Deliver alert to all whitelisted chats."""
+            results: list[NotificationDispatchResult] = []
             for chat_id in self._chat_whitelist:
                 await self._acquire_token()
-                await self._send_single(chat_id, _clamp(str(message)))
+                results.append(
+                    await self._send_single(
+                        chat_id,
+                        _clamp(str(message)),
+                        alert_id=alert_id,
+                        event_type="alert",
+                    )
+                )
+            return results
 
         try:
             # Check if we're already in an event loop
             try:
                 loop = asyncio.get_running_loop()
                 # We're in a running loop - schedule as task
-                safe_task(_dispatch())
-                self._logger.info(
-                    "Alert scheduled on running loop",
-                    extra={"event": "notifier.send_alert.scheduled"},
-                )
+                task = safe_task(_dispatch())
+                self._logger.info("NOTIFICATION_DISPATCH_QUEUED", extra={"status": "queued", "alert_id": alert_id, "provider": "telegram", "event_type": "alert"})
+                def _on_done(done_task: asyncio.Task[list[NotificationDispatchResult]]) -> None:
+                    with suppress(asyncio.CancelledError):
+                        exc = done_task.exception()
+                        if exc is not None:
+                            self._logger.error("NOTIFICATION_DISPATCH_FAILED", extra={"alert_id": alert_id, "provider": "telegram", "event_type": "alert", "error_type": type(exc).__name__, "error": str(exc)})
+                task.add_done_callback(_on_done)
             except RuntimeError:
                 # No running loop - create one
                 asyncio.run(_dispatch())
-                self._logger.info(
-                    "Alert sent via new loop",
-                    extra={"event": "notifier.send_alert.completed"},
-                )
         except Exception as exc:
             self._logger.error(
                 f"Alert send failed: {exc}",
@@ -278,7 +311,14 @@ class TelegramEnhancedNotifier:
         self._tokens = min(self._capacity, self._tokens + refill)
         self._last_refill = now
 
-    async def _send_single(self, chat_id: int, text: str) -> None:
+    def _log_provider_health(self) -> None:
+        now = _current_loop_time()
+        last_success_age_s = (now - self._last_success_ts) if self._last_success_ts > 0 else None
+        self._logger.info("TELEGRAM_PROVIDER_HEALTH", extra={"provider": "telegram", "degraded": self._telegram_degraded, "degraded_until": self._telegram_degraded_until, "backoff_active": self._telegram_backoff_active and now < self._telegram_backoff_until, "backoff_until": self._telegram_backoff_until, "consecutive_failures": self._consecutive_failures, "last_success_age_s": last_success_age_s, "last_error_type": self._last_error_type})
+
+    async def _send_single(
+        self, chat_id: int, text: str, *, alert_id: str, event_type: str
+    ) -> NotificationDispatchResult:
         attempt = 1
         max_attempts = 5
         retry_window_s = 300.0
@@ -287,12 +327,18 @@ class TelegramEnhancedNotifier:
         # Circuit-breaker latch prevents unbounded retry storms during outages.
         now = _current_loop_time()
         if self._telegram_backoff_active and now < self._telegram_backoff_until:
-            return
+            result = NotificationDispatchResult(alert_id=alert_id, event_type=event_type, provider="telegram", status="dropped_degraded", attempts=0, degraded=True, backoff_until=self._telegram_backoff_until)
+            self._logger.info("NOTIFICATION_DISPATCH_RESULT", extra=asdict(result))
+            self._log_provider_health()
+            return result
         if self._telegram_backoff_active and now >= self._telegram_backoff_until:
             self._telegram_backoff_active = False
             self._telegram_backoff_until = 0.0
         if self._telegram_degraded and now < self._telegram_degraded_until:
-            return
+            result = NotificationDispatchResult(alert_id=alert_id, event_type=event_type, provider="telegram", status="dropped_degraded", attempts=0, degraded=True, backoff_until=self._telegram_degraded_until)
+            self._logger.info("NOTIFICATION_DISPATCH_RESULT", extra=asdict(result))
+            self._log_provider_health()
+            return result
         if self._telegram_degraded and now >= self._telegram_degraded_until:
             self._telegram_degraded = False
             self._telegram_degraded_logged = False
@@ -315,6 +361,8 @@ class TelegramEnhancedNotifier:
                     )
                 return
             try:
+                self._logger.info("NOTIFICATION_DISPATCH_ATTEMPT", extra={"alert_id": alert_id, "event_type": event_type, "provider": "telegram", "chat_id_hash": _hash_chat_id(chat_id), "attempt": attempt})
+                started = _current_loop_time()
                 await self.bot.send_message(
                     chat_id=chat_id,
                     text=text,
@@ -329,7 +377,13 @@ class TelegramEnhancedNotifier:
                 self._telegram_degraded_until = 0.0
                 self._telegram_backoff_active = False
                 self._telegram_backoff_until = 0.0
-                return
+                self._last_success_ts = _current_loop_time()
+                self._consecutive_failures = 0
+                self._last_error_type = None
+                result = NotificationDispatchResult(alert_id=alert_id, event_type=event_type, provider="telegram", status="sent", attempts=attempt, latency_ms=(_current_loop_time() - started) * 1000.0, degraded=False)
+                self._logger.info("NOTIFICATION_DISPATCH_RESULT", extra=asdict(result))
+                self._log_provider_health()
+                return result
             except RetryAfter as exc:  # pragma: no cover - depends on API
                 delay = float(getattr(exc, "retry_after", 1.0) or 1.0)
                 delay = max(delay, 1.0)
@@ -346,6 +400,13 @@ class TelegramEnhancedNotifier:
                 self._telegram_backoff_until = _current_loop_time() + delay
                 await asyncio.sleep(delay)
                 attempt += 1
+                if attempt > max_attempts:
+                    self._consecutive_failures += 1
+                    self._last_error_type = "RetryAfter"
+                    result = NotificationDispatchResult(alert_id=alert_id, event_type=event_type, provider="telegram", status="queued_retry", attempts=max_attempts, error_type="RetryAfter", error=str(exc), degraded=self._telegram_degraded, backoff_until=self._telegram_backoff_until)
+                    self._logger.info("NOTIFICATION_DISPATCH_RESULT", extra=asdict(result))
+                    self._log_provider_health()
+                    return result
             except (TimedOut, NetworkError) as exc:  # pragma: no cover - network
                 if attempt >= max_attempts:
                     self._logger.error(
@@ -371,7 +432,13 @@ class TelegramEnhancedNotifier:
                                 "cooldown_s": retry_window_s,
                             },
                         )
-                    return
+                    self._consecutive_failures += 1
+                    err_type = type(exc).__name__
+                    self._last_error_type = err_type
+                    result = NotificationDispatchResult(alert_id=alert_id, event_type=event_type, provider="telegram", status="failed_timeout" if isinstance(exc, TimedOut) else "failed_network", attempts=attempt, error_type=err_type, error=str(exc), degraded=True, backoff_until=self._telegram_degraded_until)
+                    self._logger.info("NOTIFICATION_DISPATCH_RESULT", extra=asdict(result))
+                    self._log_provider_health()
+                    return result
                 delay = min(2.0**attempt, 30.0)
                 self._logger.warning(
                     "telegram_network_retry",
@@ -397,7 +464,12 @@ class TelegramEnhancedNotifier:
                         "err": str(exc),
                     },
                 )
-                return
+                self._consecutive_failures += 1
+                self._last_error_type = "Forbidden"
+                result = NotificationDispatchResult(alert_id=alert_id, event_type=event_type, provider="telegram", status="failed_forbidden", attempts=attempt, error_type="Forbidden", error=str(exc), degraded=self._telegram_degraded, backoff_until=self._telegram_backoff_until)
+                self._logger.info("NOTIFICATION_DISPATCH_RESULT", extra=asdict(result))
+                self._log_provider_health()
+                return result
             except TelegramError as exc:  # pragma: no cover - network
                 if attempt >= max_attempts:
                     self._logger.error(
@@ -423,7 +495,12 @@ class TelegramEnhancedNotifier:
                                 "cooldown_s": retry_window_s,
                             },
                         )
-                    return
+                    self._consecutive_failures += 1
+                    self._last_error_type = "TelegramError"
+                    result = NotificationDispatchResult(alert_id=alert_id, event_type=event_type, provider="telegram", status="failed_telegram", attempts=attempt, error_type="TelegramError", error=str(exc), degraded=True, backoff_until=self._telegram_degraded_until)
+                    self._logger.info("NOTIFICATION_DISPATCH_RESULT", extra=asdict(result))
+                    self._log_provider_health()
+                    return result
                 delay = min(2.0**attempt, 30.0)
                 self._logger.warning(
                     "telegram_send_retry",

--- a/src/nifty_scalper_bot/notifications/telegram_webhook_enhanced.py
+++ b/src/nifty_scalper_bot/notifications/telegram_webhook_enhanced.py
@@ -451,7 +451,7 @@ class TelegramEnhancedNotifier:
                             "telegram_notifier_degraded",
                             extra={
                                 "event": "telegram_notifier_degraded",
-                                "chat_id": chat_id,
+                                "chat_id_hash": _hash_chat_id(chat_id),
                                 "cooldown_s": retry_window_s,
                             },
                         )
@@ -467,7 +467,7 @@ class TelegramEnhancedNotifier:
                     "telegram_network_retry",
                     extra={
                         "event": "network_retry",
-                        "chat_id": chat_id,
+                        "chat_id_hash": _hash_chat_id(chat_id),
                         "attempt": attempt,
                         "delay": delay,
                         "err": str(exc),
@@ -482,7 +482,7 @@ class TelegramEnhancedNotifier:
                     "telegram_forbidden",
                     extra={
                         "event": "forbidden",
-                        "chat_id": chat_id,
+                        "chat_id_hash": _hash_chat_id(chat_id),
                         "attempt": attempt,
                         "err": str(exc),
                     },
@@ -514,7 +514,7 @@ class TelegramEnhancedNotifier:
                             "telegram_notifier_degraded",
                             extra={
                                 "event": "telegram_notifier_degraded",
-                                "chat_id": chat_id,
+                                "chat_id_hash": _hash_chat_id(chat_id),
                                 "cooldown_s": retry_window_s,
                             },
                         )
@@ -885,7 +885,7 @@ class TelegramWebhookController:
             "telegram_message",
             extra={
                 "event": "message",
-                "chat_id": chat_id,
+                "chat_id_hash": _hash_chat_id(chat_id),
                 "text": _truncate(text, 120),
             },
         )
@@ -906,7 +906,7 @@ class TelegramWebhookController:
             "telegram_callback",
             extra={
                 "event": "callback",
-                "chat_id": chat_id,
+                "chat_id_hash": _hash_chat_id(chat_id) if chat_id is not None else None,
                 "data": _truncate(str(data), 200) if data else None,
             },
         )
@@ -935,7 +935,11 @@ class TelegramWebhookController:
                 )
                 self.logger.debug(
                     "telegram_reply_sent",
-                    extra={"event": "reply", "chat_id": chat_id, "attempt": attempt},
+                    extra={
+                        "event": "reply",
+                        "chat_id_hash": _hash_chat_id(chat_id),
+                        "attempt": attempt,
+                    },
                 )
                 return
             except RetryAfter as exc:

--- a/src/nifty_scalper_bot/notifications/telegram_webhook_enhanced.py
+++ b/src/nifty_scalper_bot/notifications/telegram_webhook_enhanced.py
@@ -248,10 +248,18 @@ class TelegramEnhancedNotifier:
             extra={"event": "notifier.send_alert.enter"},
         )
 
-        if not self._chat_whitelist:
-            return
-
         alert_id = f"alert-{int(_current_loop_time() * 1000)}-{random.randint(1000, 9999)}"
+        if not self._chat_whitelist:
+            result = NotificationDispatchResult(
+                alert_id=alert_id,
+                event_type="alert",
+                provider="telegram",
+                status="no_whitelisted_chats",
+                attempts=0,
+            )
+            self._logger.info("NOTIFICATION_DISPATCH_RESULT", extra=asdict(result))
+            self._log_provider_health()
+            return
 
         async def _dispatch() -> list[NotificationDispatchResult]:
             """Deliver alert to all whitelisted chats."""
@@ -355,11 +363,26 @@ class TelegramEnhancedNotifier:
                         "telegram_notifier_degraded",
                         extra={
                             "event": "telegram_notifier_degraded",
-                            "chat_id": chat_id,
+                            "chat_id_hash": _hash_chat_id(chat_id),
                             "cooldown_s": retry_window_s,
                         },
                     )
-                return
+                self._consecutive_failures += 1
+                self._last_error_type = "RetryWindowExceeded"
+                result = NotificationDispatchResult(
+                    alert_id=alert_id,
+                    event_type=event_type,
+                    provider="telegram",
+                    status="dropped_degraded",
+                    attempts=max(0, attempt - 1),
+                    error_type="RetryWindowExceeded",
+                    error=f"retry_window_exceeded_after_{retry_window_s}s",
+                    degraded=True,
+                    backoff_until=self._telegram_degraded_until,
+                )
+                self._logger.info("NOTIFICATION_DISPATCH_RESULT", extra=asdict(result))
+                self._log_provider_health()
+                return result
             try:
                 self._logger.info("NOTIFICATION_DISPATCH_ATTEMPT", extra={"alert_id": alert_id, "event_type": event_type, "provider": "telegram", "chat_id_hash": _hash_chat_id(chat_id), "attempt": attempt})
                 started = _current_loop_time()
@@ -370,7 +393,7 @@ class TelegramEnhancedNotifier:
                 )
                 self._logger.debug(
                     "telegram_send_success",
-                    extra={"event": "send", "chat_id": chat_id, "attempt": attempt},
+                    extra={"event": "send", "chat_id_hash": _hash_chat_id(chat_id), "attempt": attempt},
                 )
                 self._telegram_degraded = False
                 self._telegram_degraded_logged = False
@@ -391,7 +414,7 @@ class TelegramEnhancedNotifier:
                     "telegram_retry_after",
                     extra={
                         "event": "retry_after",
-                        "chat_id": chat_id,
+                        "chat_id_hash": _hash_chat_id(chat_id),
                         "attempt": attempt,
                         "delay": delay,
                     },
@@ -413,7 +436,7 @@ class TelegramEnhancedNotifier:
                         "telegram_network_error",
                         extra={
                             "event": "network_error",
-                            "chat_id": chat_id,
+                            "chat_id_hash": _hash_chat_id(chat_id),
                             "attempt": attempt,
                             "err": str(exc),
                         },
@@ -476,7 +499,7 @@ class TelegramEnhancedNotifier:
                         "telegram_send_failed",
                         extra={
                             "event": "send_failed",
-                            "chat_id": chat_id,
+                            "chat_id_hash": _hash_chat_id(chat_id),
                             "attempt": attempt,
                             "err": str(exc),
                         },
@@ -506,7 +529,7 @@ class TelegramEnhancedNotifier:
                     "telegram_send_retry",
                     extra={
                         "event": "send_retry",
-                        "chat_id": chat_id,
+                        "chat_id_hash": _hash_chat_id(chat_id),
                         "attempt": attempt,
                         "delay": delay,
                         "err": str(exc),
@@ -789,7 +812,7 @@ class TelegramWebhookController:
                     "telegram_update_rejected",
                     extra={
                         "event": "update_rejected",
-                        "chat_id": chat_id,
+                        "chat_id_hash": _hash_chat_id(chat_id),
                         "user_id": user_id,
                         "reason": "chat_not_whitelisted",
                     },
@@ -802,7 +825,7 @@ class TelegramWebhookController:
                     "telegram_update_rejected",
                     extra={
                         "event": "update_rejected",
-                        "chat_id": chat_id,
+                            "chat_id_hash": _hash_chat_id(chat_id),
                         "user_id": user_id,
                         "reason": "user_not_whitelisted",
                     },
@@ -830,7 +853,7 @@ class TelegramWebhookController:
             "telegram_command",
             extra={
                 "event": "command",
-                "chat_id": chat_id,
+                            "chat_id_hash": _hash_chat_id(chat_id),
                 "command": command,
                 # ``args`` is a reserved LogRecord attribute; avoid KeyError
                 "cmd_args": list(args),
@@ -925,7 +948,7 @@ class TelegramWebhookController:
                     "telegram_reply_failed",
                     extra={
                         "event": "reply_failed",
-                        "chat_id": chat_id,
+                        "chat_id_hash": _hash_chat_id(chat_id),
                         "err": str(exc),
                     },
                 )

--- a/tests/notifications/test_telegram_webhook_enhanced.py
+++ b/tests/notifications/test_telegram_webhook_enhanced.py
@@ -5,7 +5,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from telegram.error import Forbidden, TimedOut
+from telegram.error import Forbidden, TelegramError, TimedOut
 
 from nifty_scalper_bot.notifications.telegram_webhook_enhanced import (
     NotificationDispatchResult,
@@ -243,6 +243,46 @@ async def test_telegram_logs_do_not_emit_raw_chat_id(
     notifier = TelegramEnhancedNotifier(bot=bot, settings=settings)
     await notifier._send_single(chat_id=chat_id, text='x', alert_id='a7', event_type='alert')
     assert str(chat_id) not in caplog.text
+    assert any(hasattr(record, 'chat_id_hash') for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_timeout_final_failure_logs_only_chat_id_hash(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    caplog.set_level('INFO')
+    async def _noop_sleep(_seconds: float) -> None:
+        return None
+    monkeypatch.setattr(
+        'nifty_scalper_bot.notifications.telegram_webhook_enhanced.asyncio.sleep',
+        _noop_sleep,
+    )
+    bot = MagicMock()
+    bot.send_message = AsyncMock(side_effect=TimedOut('timeout'))
+    settings = SimpleNamespace(rate_per_second=20.0, burst_capacity=20.0, whitelist_chat_ids=[123456789], whitelist_user_ids=None)
+    notifier = TelegramEnhancedNotifier(bot=bot, settings=settings)
+    await notifier._send_single(chat_id=123456789, text='x', alert_id='a8', event_type='alert')
+    assert all(not hasattr(record, 'chat_id') for record in caplog.records)
+    assert any(hasattr(record, 'chat_id_hash') for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_telegram_error_final_failure_logs_only_chat_id_hash(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    caplog.set_level('INFO')
+    async def _noop_sleep(_seconds: float) -> None:
+        return None
+    monkeypatch.setattr(
+        'nifty_scalper_bot.notifications.telegram_webhook_enhanced.asyncio.sleep',
+        _noop_sleep,
+    )
+    bot = MagicMock()
+    bot.send_message = AsyncMock(side_effect=TelegramError('tg failed'))
+    settings = SimpleNamespace(rate_per_second=20.0, burst_capacity=20.0, whitelist_chat_ids=[123456789], whitelist_user_ids=None)
+    notifier = TelegramEnhancedNotifier(bot=bot, settings=settings)
+    await notifier._send_single(chat_id=123456789, text='x', alert_id='a9', event_type='alert')
+    assert all(not hasattr(record, 'chat_id') for record in caplog.records)
     assert any(hasattr(record, 'chat_id_hash') for record in caplog.records)
 
 

--- a/tests/notifications/test_telegram_webhook_enhanced.py
+++ b/tests/notifications/test_telegram_webhook_enhanced.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
+import asyncio
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from telegram.error import TimedOut
+from telegram.error import Forbidden, TimedOut
 
 from nifty_scalper_bot.notifications.telegram_webhook_enhanced import (
     TelegramEnhancedNotifier,
@@ -51,15 +52,21 @@ async def test_send_single_latches_degraded_after_retry_budget(
     )
     notifier = TelegramEnhancedNotifier(bot=bot, settings=settings)
 
-    await notifier._send_single(chat_id=1, text='x')
+    result = await notifier._send_single(
+        chat_id=1, text='x', alert_id='a1', event_type='alert'
+    )
 
     assert notifier._telegram_degraded is True
     assert notifier._telegram_degraded_until == pytest.approx(400.0)
     assert bot.send_message.await_count == 5
+    assert result.status == 'failed_timeout'
 
     bot.send_message.reset_mock()
-    await notifier._send_single(chat_id=1, text='x')
+    result_2 = await notifier._send_single(
+        chat_id=1, text='x', alert_id='a2', event_type='alert'
+    )
     assert bot.send_message.await_count == 0
+    assert result_2.status == 'dropped_degraded'
 
 
 @pytest.mark.asyncio
@@ -97,8 +104,64 @@ async def test_send_single_recovers_after_degraded_cooldown(
     notifier._telegram_degraded_logged = True
     notifier._telegram_degraded_until = 450.0
 
-    await notifier._send_single(chat_id=1, text='ok')
+    result = await notifier._send_single(
+        chat_id=1, text='ok', alert_id='a3', event_type='alert'
+    )
 
     assert bot.send_message.await_count == 1
     assert notifier._telegram_degraded is False
     assert notifier._telegram_degraded_until == pytest.approx(0.0)
+    assert result.status == 'sent'
+
+
+@pytest.mark.asyncio
+async def test_send_single_success_returns_sent(caplog: pytest.LogCaptureFixture) -> None:
+    caplog.set_level('INFO')
+    bot = MagicMock()
+    bot.send_message = AsyncMock(return_value=None)
+    settings = SimpleNamespace(rate_per_second=20.0, burst_capacity=20.0, whitelist_chat_ids=[1], whitelist_user_ids=None)
+    notifier = TelegramEnhancedNotifier(bot=bot, settings=settings)
+
+    result = await notifier._send_single(chat_id=1, text='ok', alert_id='a4', event_type='alert')
+    assert result.status == 'sent'
+    assert 'NOTIFICATION_DISPATCH_RESULT' in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_send_event_no_whitelisted_chats_terminal_result() -> None:
+    bot = MagicMock()
+    bot.send_message = AsyncMock(return_value=None)
+    settings = SimpleNamespace(rate_per_second=20.0, burst_capacity=20.0, whitelist_chat_ids=None, whitelist_user_ids=None)
+    notifier = TelegramEnhancedNotifier(bot=bot, settings=settings)
+    results = await notifier.send_event('event_x', {'a': 1})
+    assert len(results) == 1
+    assert results[0].status == 'no_whitelisted_chats'
+
+
+@pytest.mark.asyncio
+async def test_send_alert_running_loop_logs_queued_not_sent(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    caplog.set_level('INFO')
+    bot = MagicMock()
+    bot.send_message = AsyncMock(return_value=None)
+    settings = SimpleNamespace(rate_per_second=20.0, burst_capacity=20.0, whitelist_chat_ids=[1], whitelist_user_ids=None)
+    notifier = TelegramEnhancedNotifier(bot=bot, settings=settings)
+    monkeypatch.setattr(
+        'nifty_scalper_bot.notifications.telegram_webhook_enhanced.safe_task',
+        lambda coro: asyncio.create_task(coro),
+    )
+    notifier.send_alert('hello')
+    await asyncio.sleep(0)
+    assert 'NOTIFICATION_DISPATCH_QUEUED' in caplog.text
+    assert 'NOTIFICATION_DISPATCH_RESULT' in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_forbidden_returns_failed_forbidden() -> None:
+    bot = MagicMock()
+    bot.send_message = AsyncMock(side_effect=Forbidden('forbidden'))
+    settings = SimpleNamespace(rate_per_second=20.0, burst_capacity=20.0, whitelist_chat_ids=[1], whitelist_user_ids=None)
+    notifier = TelegramEnhancedNotifier(bot=bot, settings=settings)
+    result = await notifier._send_single(chat_id=1, text='x', alert_id='a5', event_type='alert')
+    assert result.status == 'failed_forbidden'

--- a/tests/notifications/test_telegram_webhook_enhanced.py
+++ b/tests/notifications/test_telegram_webhook_enhanced.py
@@ -8,6 +8,7 @@ import pytest
 from telegram.error import Forbidden, TimedOut
 
 from nifty_scalper_bot.notifications.telegram_webhook_enhanced import (
+    NotificationDispatchResult,
     TelegramEnhancedNotifier,
 )
 
@@ -165,3 +166,94 @@ async def test_forbidden_returns_failed_forbidden() -> None:
     notifier = TelegramEnhancedNotifier(bot=bot, settings=settings)
     result = await notifier._send_single(chat_id=1, text='x', alert_id='a5', event_type='alert')
     assert result.status == 'failed_forbidden'
+
+
+@pytest.mark.asyncio
+async def test_send_single_retry_window_exceeded_returns_terminal_result(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    caplog.set_level('INFO')
+    current = 100.0
+    monkeypatch.setattr(
+        'nifty_scalper_bot.notifications.telegram_webhook_enhanced._current_loop_time',
+        lambda: current,
+    )
+    bot = MagicMock()
+    bot.send_message = AsyncMock(side_effect=TimedOut('timeout'))
+    settings = SimpleNamespace(rate_per_second=20.0, burst_capacity=20.0, whitelist_chat_ids=[1], whitelist_user_ids=None)
+    notifier = TelegramEnhancedNotifier(bot=bot, settings=settings)
+    notifier._telegram_backoff_active = True
+    notifier._telegram_backoff_until = 99.0
+
+    async def _advance_sleep(_seconds: float) -> None:
+        nonlocal current
+        current += 301.0
+
+    monkeypatch.setattr(
+        'nifty_scalper_bot.notifications.telegram_webhook_enhanced.asyncio.sleep',
+        _advance_sleep,
+    )
+    result = await notifier._send_single(chat_id=1, text='x', alert_id='a6', event_type='alert')
+    assert result is not None
+    assert result.status == 'dropped_degraded'
+    assert result.error_type == 'RetryWindowExceeded'
+    assert notifier._telegram_degraded is True
+    assert 'NOTIFICATION_DISPATCH_RESULT' in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_send_event_never_returns_none_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    current = 100.0
+    monkeypatch.setattr(
+        'nifty_scalper_bot.notifications.telegram_webhook_enhanced._current_loop_time',
+        lambda: current,
+    )
+    bot = MagicMock()
+    bot.send_message = AsyncMock(side_effect=TimedOut('timeout'))
+    settings = SimpleNamespace(rate_per_second=20.0, burst_capacity=20.0, whitelist_chat_ids=[1], whitelist_user_ids=None)
+    notifier = TelegramEnhancedNotifier(bot=bot, settings=settings)
+    notifier._telegram_backoff_active = True
+    notifier._telegram_backoff_until = 99.0
+
+    async def _advance_sleep(_seconds: float) -> None:
+        nonlocal current
+        current += 301.0
+
+    monkeypatch.setattr(
+        'nifty_scalper_bot.notifications.telegram_webhook_enhanced.asyncio.sleep',
+        _advance_sleep,
+    )
+    results = await notifier.send_event('event_y', {'k': 'v'})
+    assert results
+    assert all(isinstance(r, NotificationDispatchResult) for r in results)
+    assert all(r is not None for r in results)
+
+
+@pytest.mark.asyncio
+async def test_telegram_logs_do_not_emit_raw_chat_id(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level('INFO')
+    chat_id = 123456789
+    bot = MagicMock()
+    bot.send_message = AsyncMock(side_effect=Forbidden('forbidden'))
+    settings = SimpleNamespace(rate_per_second=20.0, burst_capacity=20.0, whitelist_chat_ids=[chat_id], whitelist_user_ids=None)
+    notifier = TelegramEnhancedNotifier(bot=bot, settings=settings)
+    await notifier._send_single(chat_id=chat_id, text='x', alert_id='a7', event_type='alert')
+    assert str(chat_id) not in caplog.text
+    assert any(hasattr(record, 'chat_id_hash') for record in caplog.records)
+
+
+def test_send_alert_no_whitelist_logs_terminal_result(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level('INFO')
+    bot = MagicMock()
+    bot.send_message = AsyncMock(return_value=None)
+    settings = SimpleNamespace(rate_per_second=20.0, burst_capacity=20.0, whitelist_chat_ids=None, whitelist_user_ids=None)
+    notifier = TelegramEnhancedNotifier(bot=bot, settings=settings)
+    notifier.send_alert('hello')
+    assert 'NOTIFICATION_DISPATCH_RESULT' in caplog.text
+    assert 'no_whitelisted_chats' in caplog.text


### PR DESCRIPTION
### Motivation
- Observability gaps allowed scheduled/queued Telegram notifications to be mistaken for delivered because `_send_single()` did not return terminal delivery outcomes and `send_alert()` logged scheduling as if delivery completed. 
- Production incidents showed alert floods and uncertainty about retry/backoff/circuit state, requiring explicit terminal statuses and provider health emissions. 
- The change must preserve existing retry/backoff/degraded behavior and must not let Telegram failures block trading or expose secrets. 

### Description
- Changed `_send_single(...)` to return `NotificationDispatchResult` with terminal statuses (`sent`, `failed_timeout`, `failed_network`, `failed_forbidden`, `failed_telegram`, `dropped_degraded`, `queued_retry`) and updated internal state (`_last_success_ts`, `_consecutive_failures`, `_last_error_type`) on terminal outcomes. 
- Added structured logs for each attempt and terminal outcomes: `NOTIFICATION_DISPATCH_ATTEMPT` (includes `chat_id_hash`), `NOTIFICATION_DISPATCH_RESULT` (terminal fields), and `TELEGRAM_PROVIDER_HEALTH` (provider health snapshot), without logging tokens or raw chat IDs. 
- Updated `send_event(...)` to return `list[NotificationDispatchResult]` and emit a terminal `no_whitelisted_chats` result when appropriate, and changed `send_alert(...)` to log queued state (`NOTIFICATION_DISPATCH_QUEUED`) when scheduling on a running loop while retaining non-blocking dispatch and adding a done-callback to log task failures. 
- Files changed: `src/nifty_scalper_bot/notifications/telegram_webhook_enhanced.py` (implementation + logging + chat-id hashing) and `tests/notifications/test_telegram_webhook_enhanced.py` (tests updated/added). 

### Testing
- Commands run: `python -m compileall -q src tests` and `pytest -q tests/notifications`. 
- Results: compile succeeded and `tests/notifications` passed (61 passed). 
- Focused tests added/updated cover success (`sent`), timeout -> degraded (`failed_timeout`), forbidden (`failed_forbidden`), no-whitelist terminal result, and queued-vs-terminal semantics for `send_alert()`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15b164abe08324bc928e54bd52b44d)