### PR TITLE
market-data/readiness: reduce quote pull churn, resolve stale futures, centralize history policy

### DIFF
--- a/src/nifty_scalper_bot/core/strategy_manager.py
+++ b/src/nifty_scalper_bot/core/strategy_manager.py
@@ -34,6 +34,7 @@ from nifty_scalper_bot.strategies.signal_generator import (
 from nifty_scalper_bot.utils.log_throttle import log_throttled as log_throttled_live
 from nifty_scalper_bot.utils.logging import get_logger, log_state_change, log_throttled
 from nifty_scalper_bot.utils.symbols import normalize_symbol
+from nifty_scalper_bot.execution.readiness import HistoryReadinessPolicy
 
 log = get_logger(__name__)
 
@@ -2111,7 +2112,8 @@ class StrategyManager(_BaseStrategyManager):
         signal_score: float | None = None
         signal_confidence: float | None = None
         exit_result = "no_signal"
-        required_bars = int(getattr(self, "_required_candles", 20) or 20)
+        policy = HistoryReadinessPolicy.from_env()
+        required_bars = int(getattr(self, "_required_candles", policy.option_eval_min_bars) or policy.option_eval_min_bars)
         bars_available = len(self._indicator_engine.get_history(symbol) or [])
         indicators_ready = bars_available >= required_bars
         hub_ready = None
@@ -2398,7 +2400,7 @@ class StrategyManager(_BaseStrategyManager):
         # ✅ FIX S3: Inject exchange VWAP for options
         if self._data_hub is not None:
             try:
-                opt_quote = self._data_hub.get_quote(symbol)
+                opt_quote = _get_cached_quote_for_eval(self._data_hub, symbol)
                 if opt_quote:
                     _exch_vwap = self._extract_float(
                         opt_quote, ("vwap", "average_price")
@@ -4653,3 +4655,21 @@ __all__ = [
     "RegimeState",
     "RegimePerformanceBucket",
 ]
+def _get_cached_quote_for_eval(hub: t.Any, symbol: str) -> t.Mapping[str, t.Any] | None:
+    if hub is None:
+        return None
+    get_quote = getattr(hub, "get_quote", None)
+    if callable(get_quote):
+        try:
+            quote = get_quote(symbol, allow_pull=False)
+            if quote:
+                return t.cast(t.Mapping[str, t.Any], quote)
+        except TypeError:
+            pass
+    for method_name in ("get_latest_tick", "get_last_tick"):
+        method = getattr(hub, method_name, None)
+        if callable(method):
+            quote = method(symbol)
+            if quote:
+                return t.cast(t.Mapping[str, t.Any], dict(quote))
+    return None

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -12,6 +12,7 @@ from datetime import date, datetime, timedelta, timezone
 import logging
 import math
 import os
+import re
 from random import uniform
 import threading
 import time
@@ -73,6 +74,7 @@ _EXPIRY_FORMATS: tuple[str, ...] = (
 )
 
 _COMPACT_EXPIRY_FORMATS: tuple[str, ...] = ("%d%b%Y", "%d%b%y")
+_NIFTY_FUT_RE = re.compile(r"^NIFTY\d{2}[A-Z]{3}FUT$")
 
 _logger = get_tracer_logger(__name__)
 
@@ -141,6 +143,50 @@ def canonical_symbol(symbol: str) -> str:
     if normalized == "NSE:NIFTY 50":
         return "NSE:NIFTY"
     return normalized
+
+
+def _parse_instrument_expiry(value: Any) -> datetime | None:
+    if value is None or value == "":
+        return None
+    if isinstance(value, datetime):
+        parsed_dt = value
+    elif isinstance(value, date):
+        parsed_dt = datetime.combine(value, datetime.min.time())
+    else:
+        text = str(value).strip()
+        parsed_dt = None
+        for fmt in _EXPIRY_FORMATS + _COMPACT_EXPIRY_FORMATS:
+            try:
+                parsed_dt = datetime.strptime(text, fmt)
+                break
+            except ValueError:
+                continue
+        if parsed_dt is None:
+            try:
+                maybe = pd.to_datetime(text, utc=True, errors="coerce")
+                if pd.isna(maybe):
+                    return None
+                parsed_dt = maybe.to_pydatetime()
+            except Exception:
+                return None
+    if parsed_dt.tzinfo is None:
+        return parsed_dt.replace(tzinfo=timezone.utc)
+    return parsed_dt.astimezone(timezone.utc)
+
+
+def _is_nifty_index_future_row(row: Mapping[str, Any]) -> bool:
+    exchange = str(row.get("exchange") or "").upper()
+    segment = str(row.get("segment") or "").upper()
+    instrument_type = str(row.get("instrument_type") or row.get("type") or "").upper()
+    name = str(row.get("name") or "").upper()
+    tradingsymbol = str(row.get("tradingsymbol") or row.get("symbol") or "").upper()
+    if "NFO" not in {exchange, segment} and "NFO" not in segment:
+        return False
+    if instrument_type not in {"FUT", "FUTIDX"}:
+        return False
+    if name and name != "NIFTY":
+        return False
+    return bool(_NIFTY_FUT_RE.match(tradingsymbol))
 
 
 NIFTY_SPOT_TOKEN = 256265
@@ -2415,6 +2461,11 @@ class MarketDataManager:
             None.
         """
 
+        def _clear_quote_direct_miss(symbol_key: str) -> None:
+            self._quote_direct_miss_count.pop(symbol_key, None)
+            self._quote_direct_miss_until.pop(symbol_key, None)
+            self._quote_direct_miss_reason.pop(symbol_key, None)
+
         canonical_symbol = self._canonical_symbol(symbol)
         candidates: list[str | int] = self._candidate_quote_keys(canonical_symbol)
         if not candidates:
@@ -2423,6 +2474,7 @@ class MarketDataManager:
         cooldown_until = float(self._quote_direct_miss_until.get(canonical_symbol, 0.0) or 0.0)
         now_mono = time.monotonic()
         if cooldown_until > now_mono:
+            remaining = max(0.0, cooldown_until - now_mono)
             with self._lock:
                 cached_tick = self._latest_ticks.get(canonical_symbol)
             if isinstance(cached_tick, Mapping) and cached_tick:
@@ -2432,6 +2484,7 @@ class MarketDataManager:
             return {
                 "symbol": canonical_symbol,
                 "quote_unavailable_reason": "quote_symbol_missing_cooldown",
+                "cooldown_remaining_s": round(remaining, 3),
             }
         for key in candidates:
             broker_key: str | int
@@ -2442,6 +2495,7 @@ class MarketDataManager:
             fetched = self._broker_quote_any(broker_key)
             if fetched:
                 quote = fetched
+                _clear_quote_direct_miss(canonical_symbol)
                 break
         if quote is None:
             try:
@@ -2472,8 +2526,8 @@ class MarketDataManager:
                             "reason": "quote_data_missing",
                         },
                     )
-                log_fn = self._logger.warning if is_recoverable_miss else self._logger.error
-                log_fn(
+                if not is_recoverable_miss:
+                    self._logger.error(
                     "Failure in pull_quote direct get_quote: %s",
                     exc,
                     extra={
@@ -2485,13 +2539,11 @@ class MarketDataManager:
                         "symbol": canonical_symbol,
                         "error": error_text,
                     },
-                    exc_info=None if is_recoverable_miss else exc,
-                )
+                    exc_info=exc,
+                    )
                 raw_quote = None
             else:
-                self._quote_direct_miss_count.pop(canonical_symbol, None)
-                self._quote_direct_miss_until.pop(canonical_symbol, None)
-                self._quote_direct_miss_reason.pop(canonical_symbol, None)
+                _clear_quote_direct_miss(canonical_symbol)
             if isinstance(raw_quote, Mapping):
                 self._mark_quote_api_status(available=True)
                 quote = dict(raw_quote)
@@ -2511,6 +2563,14 @@ class MarketDataManager:
                         "reason": "no_quote_from_broker_or_cache",
                     },
                 )
+            miss_count = int(self._quote_direct_miss_count.get(canonical_symbol, 0) or 0)
+            if miss_count > 0:
+                return {
+                    "symbol": canonical_symbol,
+                    "quote_unavailable_reason": "quote_data_missing",
+                    "quote_miss_count": miss_count,
+                    "cooldown_remaining_s": self._quote_direct_miss_cooldown_seconds,
+                }
             return {"symbol": canonical_symbol}
         quote = self._prepare_rest_tick(quote, source="rest")
         with self._lock:
@@ -2519,6 +2579,7 @@ class MarketDataManager:
         normalized = self._normalize_tick(canonical_symbol, quote, previous)
         if normalized is not None:
             self._store_tick(canonical_symbol, normalized)
+            _clear_quote_direct_miss(canonical_symbol)
             return normalized
         return {"symbol": canonical_symbol, **quote}
 
@@ -6474,30 +6535,35 @@ class MarketDataManager:
             return None
         fetchers = ("list_instruments", "get_instruments", "instruments")
         instruments: list[Mapping[str, Any]] = []
+        def _call_instrument_fetcher(fetcher: Callable[..., Any]) -> list[Mapping[str, Any]]:
+            attempts = (lambda: fetcher(), lambda: fetcher("NFO"), lambda: fetcher(exchange="NFO"))
+            for call in attempts:
+                try:
+                    raw = call() or []
+                except TypeError:
+                    continue
+                except Exception:
+                    continue
+                if isinstance(raw, Mapping):
+                    raw = raw.values()
+                if isinstance(raw, Iterable):
+                    rows = [item for item in raw if isinstance(item, Mapping)]
+                    if rows:
+                        return rows
+            return []
         for fetcher_name in fetchers:
             fetcher = getattr(resolver, fetcher_name, None)
             if callable(fetcher):
-                try:
-                    raw = fetcher() or []
-                except Exception:
-                    continue
-                if isinstance(raw, Sequence):
-                    instruments = [item for item in raw if isinstance(item, Mapping)]
-                    if instruments:
-                        break
+                instruments = _call_instrument_fetcher(fetcher)
+                if instruments:
+                    break
         best_symbol: str | None = None
         best_expiry: datetime | None = None
         for row in instruments:
-            segment = str(row.get("segment") or row.get("exchange") or "").upper()
-            if "NFO" not in segment:
-                continue
-            instrument_type = str(row.get("instrument_type") or row.get("type") or "").upper()
-            if instrument_type not in {"FUT", "FUTIDX"}:
+            if not _is_nifty_index_future_row(row):
                 continue
             tradingsymbol = str(row.get("tradingsymbol") or row.get("symbol") or "").upper()
-            if "NIFTY" not in tradingsymbol:
-                continue
-            expiry = _parse_expiry(row.get("expiry"))
+            expiry = _parse_instrument_expiry(row.get("expiry"))
             if expiry is None or expiry < ref_now:
                 continue
             if best_expiry is None or expiry < best_expiry:

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -6571,6 +6571,47 @@ class MarketDataManager:
                 best_symbol = f"NFO:{tradingsymbol}"
         return best_symbol
 
+    def maybe_rotate_nifty_futures_context(
+        self,
+        current_symbol: str | None,
+        *,
+        reason: str,
+        trace_id: str | None = None,
+        now: datetime | None = None,
+    ) -> str | None:
+        active = self.resolve_active_nifty_future_symbol(now=now)
+        if not active:
+            self._logger.warning(
+                "FUTURES_CONTEXT_STALE_OR_UNRESOLVED current_symbol=%s reason=%s",
+                current_symbol,
+                reason,
+                extra={
+                    "event": "FUTURES_CONTEXT_STALE_OR_UNRESOLVED",
+                    "current_symbol": current_symbol,
+                    "reason": reason,
+                    "trace_id": trace_id,
+                },
+            )
+            return current_symbol
+        if current_symbol and self._canonical_symbol(current_symbol) == self._canonical_symbol(active):
+            return current_symbol
+        old_symbol = current_symbol
+        self.request_symbol_subscription(active)
+        self._logger.warning(
+            "FUTURES_CONTEXT_SYMBOL_ROTATED old_symbol=%s new_symbol=%s reason=%s",
+            old_symbol,
+            active,
+            reason,
+            extra={
+                "event": "FUTURES_CONTEXT_SYMBOL_ROTATED",
+                "old_symbol": old_symbol,
+                "new_symbol": active,
+                "reason": reason,
+                "trace_id": trace_id,
+            },
+        )
+        return active
+
     def get_symbol_snapshot(self, symbol: str) -> MarketSnapshot:
         """Return a unified MarketSnapshot for one symbol."""
         canonical = self._canonical_symbol(symbol)

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -243,6 +243,10 @@ class MarketDataManager:
         self._quote_api_available = True
         self._quote_api_error: str | None = None
         self._quote_api_last_checked_at: float | None = None
+        self._quote_direct_miss_count: dict[str, int] = {}
+        self._quote_direct_miss_until: dict[str, float] = {}
+        self._quote_direct_miss_reason: dict[str, str] = {}
+        self._quote_direct_miss_cooldown_seconds = float(os.getenv("MDM_QUOTE_SYMBOL_MISS_COOLDOWN_SECONDS", "45") or "45")
         self._spot_ready_logged = False
         self._spot_refresh_last_attempt_mono: float = 0.0
         # Bounded queue: drops oldest when full so a stall in the async
@@ -2416,6 +2420,19 @@ class MarketDataManager:
         if not candidates:
             candidates = [canonical_symbol]
         quote: dict[str, Any] | None = None
+        cooldown_until = float(self._quote_direct_miss_until.get(canonical_symbol, 0.0) or 0.0)
+        now_mono = time.monotonic()
+        if cooldown_until > now_mono:
+            with self._lock:
+                cached_tick = self._latest_ticks.get(canonical_symbol)
+            if isinstance(cached_tick, Mapping) and cached_tick:
+                cached_quote = dict(cached_tick)
+                cached_quote.setdefault("source", "cache")
+                return cached_quote
+            return {
+                "symbol": canonical_symbol,
+                "quote_unavailable_reason": "quote_symbol_missing_cooldown",
+            }
         for key in candidates:
             broker_key: str | int
             if isinstance(key, int):
@@ -2434,6 +2451,27 @@ class MarketDataManager:
                     self._mark_quote_api_status(available=False, error="access_denied")
                 error_text = str(exc)
                 is_recoverable_miss = "Quote data missing" in error_text
+                if is_recoverable_miss:
+                    miss_count = int(self._quote_direct_miss_count.get(canonical_symbol, 0) or 0) + 1
+                    self._quote_direct_miss_count[canonical_symbol] = miss_count
+                    self._quote_direct_miss_reason[canonical_symbol] = "quote_data_missing"
+                    self._quote_direct_miss_until[canonical_symbol] = (
+                        time.monotonic() + self._quote_direct_miss_cooldown_seconds
+                    )
+                    self._logger.warning(
+                        "MDM_PULL_QUOTE_SYMBOL_MISSING symbol=%s miss_count=%s",
+                        canonical_symbol,
+                        miss_count,
+                        extra={
+                            "event": "MDM_PULL_QUOTE_SYMBOL_MISSING",
+                            "symbol": symbol,
+                            "canonical_symbol": canonical_symbol,
+                            "candidate_keys": [str(item) for item in candidates],
+                            "miss_count": miss_count,
+                            "cooldown_remaining_s": self._quote_direct_miss_cooldown_seconds,
+                            "reason": "quote_data_missing",
+                        },
+                    )
                 log_fn = self._logger.warning if is_recoverable_miss else self._logger.error
                 log_fn(
                     "Failure in pull_quote direct get_quote: %s",
@@ -2450,6 +2488,10 @@ class MarketDataManager:
                     exc_info=None if is_recoverable_miss else exc,
                 )
                 raw_quote = None
+            else:
+                self._quote_direct_miss_count.pop(canonical_symbol, None)
+                self._quote_direct_miss_until.pop(canonical_symbol, None)
+                self._quote_direct_miss_reason.pop(canonical_symbol, None)
             if isinstance(raw_quote, Mapping):
                 self._mark_quote_api_status(available=True)
                 quote = dict(raw_quote)
@@ -6423,6 +6465,45 @@ class MarketDataManager:
             self._last_mid[canonical_symbol] = (mid, now_ms)
         self._last_quote_ts_ms[canonical_symbol] = now_ms
         return quote
+
+    def resolve_active_nifty_future_symbol(self, now: datetime | None = None) -> str | None:
+        """Resolve nearest non-expired NIFTY futures symbol from resolver/instrument master."""
+        ref_now = now or datetime.now(timezone.utc)
+        resolver = getattr(self, "_resolver", None)
+        if resolver is None:
+            return None
+        fetchers = ("list_instruments", "get_instruments", "instruments")
+        instruments: list[Mapping[str, Any]] = []
+        for fetcher_name in fetchers:
+            fetcher = getattr(resolver, fetcher_name, None)
+            if callable(fetcher):
+                try:
+                    raw = fetcher() or []
+                except Exception:
+                    continue
+                if isinstance(raw, Sequence):
+                    instruments = [item for item in raw if isinstance(item, Mapping)]
+                    if instruments:
+                        break
+        best_symbol: str | None = None
+        best_expiry: datetime | None = None
+        for row in instruments:
+            segment = str(row.get("segment") or row.get("exchange") or "").upper()
+            if "NFO" not in segment:
+                continue
+            instrument_type = str(row.get("instrument_type") or row.get("type") or "").upper()
+            if instrument_type not in {"FUT", "FUTIDX"}:
+                continue
+            tradingsymbol = str(row.get("tradingsymbol") or row.get("symbol") or "").upper()
+            if "NIFTY" not in tradingsymbol:
+                continue
+            expiry = _parse_expiry(row.get("expiry"))
+            if expiry is None or expiry < ref_now:
+                continue
+            if best_expiry is None or expiry < best_expiry:
+                best_expiry = expiry
+                best_symbol = f"NFO:{tradingsymbol}"
+        return best_symbol
 
     def get_symbol_snapshot(self, symbol: str) -> MarketSnapshot:
         """Return a unified MarketSnapshot for one symbol."""

--- a/src/nifty_scalper_bot/execution/readiness.py
+++ b/src/nifty_scalper_bot/execution/readiness.py
@@ -8,6 +8,33 @@ consistently from app startup, health endpoints, and supervisor checks.
 from __future__ import annotations
 from dataclasses import dataclass
 import os
+import logging
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _env_int(name: str, default: int, minimum: int = 1) -> int:
+    raw = os.getenv(name)
+    if raw is None or str(raw).strip() == "":
+        return max(default, minimum)
+    try:
+        return max(int(float(str(raw).strip())), minimum)
+    except (TypeError, ValueError):
+        LOGGER.warning(
+            "INVALID_HISTORY_POLICY_ENV name=%s value=%r default=%s",
+            name,
+            raw,
+            default,
+            extra={"event": "INVALID_HISTORY_POLICY_ENV", "name": name, "value": raw, "default": default},
+        )
+        return max(default, minimum)
+
+
+def _safe_positive_int(value: object, fallback: int) -> int:
+    try:
+        return max(int(float(value)), 1)
+    except (TypeError, ValueError):
+        return max(int(fallback), 1)
 
 
 @dataclass(frozen=True)
@@ -21,10 +48,10 @@ class HistoryReadinessPolicy:
     @classmethod
     def from_env(cls) -> "HistoryReadinessPolicy":
         return cls(
-            option_eval_min_bars=max(1, int(os.getenv("OPTION_EVAL_MIN_BARS", "5") or "5")),
-            option_entry_min_bars=max(1, int(os.getenv("OPTION_ENTRY_MIN_BARS", "5") or "5")),
-            context_min_bars=max(1, int(os.getenv("CONTEXT_MIN_BARS", "50") or "50")),
-            smc_min_bars=max(1, int(os.getenv("SMC_MIN_BARS_REQUIRED", "30") or "30")),
+            option_eval_min_bars=_env_int("OPTION_EVAL_MIN_BARS", 5),
+            option_entry_min_bars=_env_int("OPTION_ENTRY_MIN_BARS", 5),
+            context_min_bars=_env_int("CONTEXT_MIN_BARS", 50),
+            smc_min_bars=_env_int("SMC_MIN_BARS_REQUIRED", 30),
             allow_synthetic_option_bars_for_eval=str(
                 os.getenv("ALLOW_SYNTHETIC_OPTION_BARS_FOR_EVAL", "false")
             ).strip().lower() in {"1", "true", "yes", "on"},
@@ -85,7 +112,7 @@ def compute_live_readiness(
         reasons.append("strategy_runner_not_running")
     if not selected_ce or not selected_pe:
         reasons.append("selected_options_missing")
-    min_bars = int(option_exec_min_bars) if int(option_exec_min_bars) > 0 else HistoryReadinessPolicy.from_env().option_entry_min_bars
+    min_bars = _safe_positive_int(option_exec_min_bars, HistoryReadinessPolicy.from_env().option_entry_min_bars)
     if int(ce_bars) < min_bars:
         reasons.append("selected_ce_history_insufficient")
     if int(pe_bars) < min_bars:

--- a/src/nifty_scalper_bot/execution/readiness.py
+++ b/src/nifty_scalper_bot/execution/readiness.py
@@ -6,6 +6,29 @@ consistently from app startup, health endpoints, and supervisor checks.
 """
 
 from __future__ import annotations
+from dataclasses import dataclass
+import os
+
+
+@dataclass(frozen=True)
+class HistoryReadinessPolicy:
+    option_eval_min_bars: int = 5
+    option_entry_min_bars: int = 5
+    context_min_bars: int = 50
+    smc_min_bars: int = 30
+    allow_synthetic_option_bars_for_eval: bool = False
+
+    @classmethod
+    def from_env(cls) -> "HistoryReadinessPolicy":
+        return cls(
+            option_eval_min_bars=max(1, int(os.getenv("OPTION_EVAL_MIN_BARS", "5") or "5")),
+            option_entry_min_bars=max(1, int(os.getenv("OPTION_ENTRY_MIN_BARS", "5") or "5")),
+            context_min_bars=max(1, int(os.getenv("CONTEXT_MIN_BARS", "50") or "50")),
+            smc_min_bars=max(1, int(os.getenv("SMC_MIN_BARS_REQUIRED", "30") or "30")),
+            allow_synthetic_option_bars_for_eval=str(
+                os.getenv("ALLOW_SYNTHETIC_OPTION_BARS_FOR_EVAL", "false")
+            ).strip().lower() in {"1", "true", "yes", "on"},
+        )
 
 
 def compute_live_readiness(
@@ -20,7 +43,7 @@ def compute_live_readiness(
     selected_pe: str | None = None,
     ce_bars: int = 0,
     pe_bars: int = 0,
-    option_exec_min_bars: int = 30,
+    option_exec_min_bars: int = 0,
     ce_quote_ready: bool = False,
     pe_quote_ready: bool = False,
 ) -> tuple[bool, list[str]]:
@@ -62,9 +85,10 @@ def compute_live_readiness(
         reasons.append("strategy_runner_not_running")
     if not selected_ce or not selected_pe:
         reasons.append("selected_options_missing")
-    if int(ce_bars) < int(option_exec_min_bars):
+    min_bars = int(option_exec_min_bars) if int(option_exec_min_bars) > 0 else HistoryReadinessPolicy.from_env().option_entry_min_bars
+    if int(ce_bars) < min_bars:
         reasons.append("selected_ce_history_insufficient")
-    if int(pe_bars) < int(option_exec_min_bars):
+    if int(pe_bars) < min_bars:
         reasons.append("selected_pe_history_insufficient")
     if not ce_quote_ready:
         reasons.append("selected_ce_quote_missing")

--- a/src/nifty_scalper_bot/execution/readiness.py
+++ b/src/nifty_scalper_bot/execution/readiness.py
@@ -31,10 +31,22 @@ def _env_int(name: str, default: int, minimum: int = 1) -> int:
 
 
 def _safe_positive_int(value: object, fallback: int) -> int:
+    fallback_value = max(int(fallback), 1)
     try:
-        return max(int(float(value)), 1)
+        parsed = int(float(value))
     except (TypeError, ValueError):
-        return max(int(fallback), 1)
+        return fallback_value
+    if parsed <= 0:
+        return fallback_value
+    return parsed
+
+
+def _safe_non_negative_int(value: object, fallback: int = 0) -> int:
+    try:
+        parsed = int(float(value))
+    except (TypeError, ValueError):
+        return max(int(fallback), 0)
+    return max(parsed, 0)
 
 
 @dataclass(frozen=True)
@@ -112,10 +124,13 @@ def compute_live_readiness(
         reasons.append("strategy_runner_not_running")
     if not selected_ce or not selected_pe:
         reasons.append("selected_options_missing")
-    min_bars = _safe_positive_int(option_exec_min_bars, HistoryReadinessPolicy.from_env().option_entry_min_bars)
-    if int(ce_bars) < min_bars:
+    policy = HistoryReadinessPolicy.from_env()
+    min_bars = _safe_positive_int(option_exec_min_bars, policy.option_entry_min_bars)
+    ce_count = _safe_non_negative_int(ce_bars, 0)
+    pe_count = _safe_non_negative_int(pe_bars, 0)
+    if ce_count < min_bars:
         reasons.append("selected_ce_history_insufficient")
-    if int(pe_bars) < min_bars:
+    if pe_count < min_bars:
         reasons.append("selected_pe_history_insufficient")
     if not ce_quote_ready:
         reasons.append("selected_ce_quote_missing")

--- a/src/nifty_scalper_bot/strategies/elite_strategies/smc_liquidity.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/smc_liquidity.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 from typing import Any
 
+from nifty_scalper_bot.execution.readiness import HistoryReadinessPolicy
 from nifty_scalper_bot.strategies.elite_strategies.base_elite import EliteSignal, EliteStrategy
 from nifty_scalper_bot.strategies.elite_strategies.config_models import SMCStrategyConfig
 from nifty_scalper_bot.strategies.signal_quality import resolve_signal_domain
@@ -68,7 +69,7 @@ class SMCStrategy(EliteStrategy):
                     extra={"event": "STRATEGY_NO_VOTE", "strategy": "SMC", "symbol": symbol, "reason": "direction_context_not_ready"},
                 )
                 return None
-            min_bars_required = int(os.getenv("SMC_MIN_BARS_REQUIRED", "30") or "30")
+            min_bars_required = HistoryReadinessPolicy.from_env().smc_min_bars
             execution_mode = str(os.getenv('EXECUTION_MODE', 'SHADOW') or 'SHADOW').strip().upper()
             is_live = execution_mode == 'LIVE'
             history_domain_used = str(indicators.get("history_domain_used") or "unknown").lower()

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -67,6 +67,7 @@ from nifty_scalper_bot.data.source import (
 )
 # Signals route directly through OrderManager submit/place APIs; no execution hub layer.
 from nifty_scalper_bot.execution.order_manager import OrderType, TradePlan
+from nifty_scalper_bot.execution.readiness import HistoryReadinessPolicy
 from nifty_scalper_bot.execution.order_state_machine import (
     ExecutionState,
     OrderStateMachine,
@@ -644,6 +645,9 @@ class StrategyRunner:
         self._selected_pe_symbol: str | None = None
         self._active_atm_strike: int | None = None
         self._active_option_symbols: set[str] = set()
+        self._selected_option_prewarm_inflight: set[str] = set()
+        self._selected_option_prewarm_last: dict[str, float] = {}
+        self._selected_option_prewarm_cooldown_s = max(1.0, float(os.getenv("SELECTED_OPTION_PREWARM_COOLDOWN_SECONDS", "45") or 45))
 
         if self._message_bus is None:
             raise RuntimeError("MessageBus not injected into StrategyRunner")
@@ -6296,6 +6300,51 @@ class StrategyRunner:
         except Exception:
             return
 
+    def _request_selected_option_history_prewarm(
+        self, symbol: str, *, bars_before: int, required_bars: int, trace_id: str | None = None
+    ) -> None:
+        now = time.monotonic()
+        last = float(self._selected_option_prewarm_last.get(symbol, 0.0) or 0.0)
+        if (now - last) < self._selected_option_prewarm_cooldown_s or symbol in self._selected_option_prewarm_inflight:
+            return
+        self._selected_option_prewarm_last[symbol] = now
+        self._selected_option_prewarm_inflight.add(symbol)
+        self._logger.info(
+            "SELECTED_OPTION_HISTORY_PREWARM_REQUESTED symbol=%s bars_before=%s required_bars=%s",
+            symbol,
+            bars_before,
+            required_bars,
+            extra={"event": "SELECTED_OPTION_HISTORY_PREWARM_REQUESTED", "symbol": symbol, "bars_before": bars_before, "required_bars": required_bars, "trace_id": trace_id},
+        )
+        data_hub = getattr(self, "_data_hub", None)
+        hydrate = getattr(data_hub, "hydrate_symbol_history", None)
+        if not callable(hydrate):
+            self._selected_option_prewarm_inflight.discard(symbol)
+            return
+        policy = HistoryReadinessPolicy.from_env()
+        max_bars = max(required_bars, policy.smc_min_bars)
+        async def _do_prewarm() -> None:
+            success = False
+            bars_after = bars_before
+            try:
+                out = await hydrate(symbol, interval="minute", days=2, max_bars=max_bars, reason="selected_option_history_cold")
+                success = True
+                bars_after = len(out or []) if isinstance(out, list) else int(bars_before)
+            except Exception:
+                success = False
+            finally:
+                self._selected_option_prewarm_inflight.discard(symbol)
+                self._logger.info(
+                    "SELECTED_OPTION_HISTORY_PREWARM_RESULT symbol=%s bars_before=%s bars_after=%s required_bars=%s success=%s",
+                    symbol, bars_before, bars_after, required_bars, success,
+                    extra={"event": "SELECTED_OPTION_HISTORY_PREWARM_RESULT", "symbol": symbol, "bars_before": bars_before, "bars_after": bars_after, "required_bars": required_bars, "success": success, "reason": "selected_option_history_cold", "source": "data_hub_hydrate", "trace_id": trace_id},
+                )
+        try:
+            loop = asyncio.get_running_loop()
+            loop.create_task(_do_prewarm())
+        except RuntimeError:
+            self._selected_option_prewarm_inflight.discard(symbol)
+
     def _same_bar_eval_reason(
         self,
         *,
@@ -6553,6 +6602,13 @@ class StrategyRunner:
                     elif self._is_tradable_symbol(symbol):
                         if self._should_log_throttled(f"opt_cold:{symbol}", 120.0):
                             self._logger.warning("OPTION_HISTORY_COLD symbol=%s bars=%d required=%d", symbol, history_count, required_bars)
+                        if self._is_option_symbol_tick_fresh(symbol, max_age_s=60.0):
+                            self._request_selected_option_history_prewarm(
+                                symbol,
+                                bars_before=int(history_count),
+                                required_bars=int(required_bars),
+                                trace_id=trace_id,
+                            )
                         spot_bars = len(self._indicator_engine.get_history("NSE:NIFTY") or [])
                         fut_symbol = next((sym for sym in self._active_symbols if self._is_context_symbol(sym) and sym != "NSE:NIFTY"), "")
                         fut_bars = len(self._indicator_engine.get_history(fut_symbol) or []) if fut_symbol else 0
@@ -6571,6 +6627,13 @@ class StrategyRunner:
                     fut_symbol = next((sym for sym in self._active_symbols if self._symbol_role_for_runner(sym) == "futures_context"), "")
                     if not fut_symbol and self._should_log_throttled("fut_unresolved", 120.0):
                         self._logger.warning("CONTEXT_FUTURES_UNRESOLVED symbol=%s", symbol)
+                    if fut_symbol and hasattr(self._market_data, "maybe_rotate_nifty_futures_context"):
+                        rotated = self._market_data.maybe_rotate_nifty_futures_context(
+                            fut_symbol, reason="context_futures_unresolved", trace_id=trace_id
+                        )
+                        if rotated and rotated != fut_symbol:
+                            self._active_symbols.discard(fut_symbol)
+                            self._active_symbols.add(str(rotated))
                     spot_bars = len(self._indicator_engine.get_history(spot_symbol) or [])
                     fut_bars = len(self._indicator_engine.get_history(fut_symbol) or []) if fut_symbol else 0
                     opt_bars = history_count
@@ -8442,6 +8505,13 @@ class StrategyRunner:
                                 if state_after is not None:
                                     state_after._last_eval_bar_ts = pending_eval_bar_ts
                         if signal is None:
+                            option_required = self._required_bars_for_symbol(symbol)
+                            option_count = len(self._indicator_engine.get_history(symbol) or [])
+                            category = "strategy_no_trigger"
+                            reason = "evaluation_no_signal"
+                            if option_count < option_required:
+                                category = "data_history_cold"
+                                reason = "insufficient_indicator_bar_count"
                             self._emit_runner_eval_decision(
                                 symbol=symbol,
                                 stage="phase9",
@@ -8449,6 +8519,33 @@ class StrategyRunner:
                                 allowed=True,
                                 trace_id=trace_id,
                                 price=price,
+                            )
+                            self._logger.info(
+                                "RUNNER_NO_TRADE_DECISION symbol=%s category=%s reason=%s",
+                                symbol,
+                                category,
+                                reason,
+                                extra={
+                                    "event": "RUNNER_NO_TRADE_DECISION",
+                                    "symbol": symbol,
+                                    "trace_id": trace_id,
+                                    "broker_attempted": False,
+                                    "category": category,
+                                    "reason": reason,
+                                    "data_phase": self._data_phase.get(symbol),
+                                    "option_history_count": option_count,
+                                    "option_history_required": option_required,
+                                    "context_fresh": bool(indicators_ctx.get("spot_fresh") or indicators_ctx.get("futures_fresh")),
+                                    "context_direction_valid": bool((indicators_ctx.get("direction_bias") or indicators_ctx.get("underlying_direction_bias"))),
+                                    "direction_bias": indicators_ctx.get("underlying_direction_bias") or indicators_ctx.get("direction_bias"),
+                                    "strategy_vote_count": 0,
+                                    "no_vote_reason_counts": {},
+                                    "execution_readiness_allowed": bool(self._runtime_live_orders_armed),
+                                    "execution_readiness_reason": self._runtime_readiness_reason,
+                                    "broker_health_effect": None,
+                                    "margin_status": None,
+                                    "kill_switch_active": bool(getattr(self._order_manager, "is_kill_switch_active", lambda: False)()),
+                                },
                             )
                         else:
                             self._emit_runner_eval_decision(

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -12,7 +12,6 @@ from datetime import datetime, time as dt_time, timedelta, timezone
 from enum import Enum
 import json
 import inspect
-import inspect as pyinspect
 import logging
 import os
 from pathlib import Path
@@ -6330,8 +6329,17 @@ class StrategyRunner:
             reason = "selected_option_history_cold"
             source = "data_hub_hydrate"
             try:
-                result = hydrate(symbol, interval="minute", days=2, max_bars=max_bars, reason=reason)
-                if pyinspect.isawaitable(result):
+                kwargs = {
+                    "interval": "minute",
+                    "days": 2,
+                    "max_bars": max_bars,
+                    "reason": reason,
+                }
+                if inspect.iscoroutinefunction(hydrate):
+                    result = await hydrate(symbol, **kwargs)
+                else:
+                    result = await asyncio.to_thread(hydrate, symbol, **kwargs)
+                if inspect.isawaitable(result):
                     result = await result
                 success = result is not None
                 if isinstance(result, list):
@@ -6573,11 +6581,52 @@ class StrategyRunner:
         direction_bias = indicators_ctx.get("underlying_direction_bias") or indicators_ctx.get("direction_bias")
         if not direction_bias:
             return "context_direction_unavailable", "direction_context_not_ready"
-        if not self._runtime_live_orders_armed:
-            return "execution_readiness_false", str(self._runtime_readiness_reason or "runtime_live_orders_not_armed")
         if signal is None:
             return "strategy_no_trigger", "evaluation_no_signal"
+        if not self._runtime_live_orders_armed:
+            return "execution_readiness_false", str(self._runtime_readiness_reason or "runtime_live_orders_not_armed")
         return "strategy_no_trigger", "no_order_condition"
+
+    def _emit_no_trade_decision(
+        self,
+        *,
+        symbol: str,
+        trace_id: str | None,
+        category: str,
+        reason: str,
+        broker_attempted: bool = False,
+        indicators_ctx: Mapping[str, Any] | None = None,
+        option_history_count: int | None = None,
+        option_history_required: int | None = None,
+    ) -> None:
+        ctx = dict(indicators_ctx or {})
+        self._logger.info(
+            "RUNNER_NO_TRADE_DECISION symbol=%s category=%s reason=%s",
+            symbol,
+            category,
+            reason,
+            extra={
+                "event": "RUNNER_NO_TRADE_DECISION",
+                "symbol": symbol,
+                "trace_id": trace_id,
+                "broker_attempted": bool(broker_attempted),
+                "category": category,
+                "reason": reason,
+                "data_phase": self._data_phase.get(symbol),
+                "option_history_count": int(option_history_count or 0),
+                "option_history_required": int(option_history_required or 0),
+                "context_fresh": bool(ctx.get("spot_fresh") or ctx.get("futures_fresh")),
+                "context_direction_valid": bool((ctx.get("direction_bias") or ctx.get("underlying_direction_bias"))),
+                "direction_bias": ctx.get("underlying_direction_bias") or ctx.get("direction_bias"),
+                "strategy_vote_count": 0,
+                "no_vote_reason_counts": {},
+                "execution_readiness_allowed": bool(self._runtime_live_orders_armed),
+                "execution_readiness_reason": self._runtime_readiness_reason,
+                "broker_health_effect": None,
+                "margin_status": None,
+                "kill_switch_active": bool(getattr(self._order_manager, "is_kill_switch_active", lambda: False)()),
+            },
+        )
 
     def _symbol_role_for_runner(self, symbol: str) -> str:
         """Return runner role label for a symbol. Args: symbol. Returns: role. Raises: none."""
@@ -6623,6 +6672,12 @@ class StrategyRunner:
         """Args: symbol + trace_id. Returns: bool gate verdict. Raises: none."""
         try:
             if symbol not in self._active_symbols:
+                self._emit_no_trade_decision(
+                    symbol=symbol,
+                    trace_id=trace_id,
+                    category="execution_readiness_false",
+                    reason="symbol_not_active",
+                )
                 self._emit_runner_eval_decision(
                     symbol=symbol,
                     stage='phase9',
@@ -6738,6 +6793,14 @@ class StrategyRunner:
                                 "required": required_bars,
                             },
                         )
+                    self._emit_no_trade_decision(
+                        symbol=symbol,
+                        trace_id=trace_id,
+                        category="data_history_cold",
+                        reason="insufficient_indicator_bar_count",
+                        option_history_count=history_count,
+                        option_history_required=required_bars,
+                    )
                 reason = 'insufficient_indicator_bar_count' if history_count < required_bars else 'indicator_history_integrity_failed'
                 self._emit_runner_eval_decision(
                     symbol=symbol,
@@ -8588,32 +8651,14 @@ class StrategyRunner:
                                 trace_id=trace_id,
                                 price=price,
                             )
-                            self._logger.info(
-                                "RUNNER_NO_TRADE_DECISION symbol=%s category=%s reason=%s",
-                                symbol,
-                                category,
-                                reason,
-                                extra={
-                                    "event": "RUNNER_NO_TRADE_DECISION",
-                                    "symbol": symbol,
-                                    "trace_id": trace_id,
-                                    "broker_attempted": False,
-                                    "category": category,
-                                    "reason": reason,
-                                    "data_phase": self._data_phase.get(symbol),
-                                    "option_history_count": option_count,
-                                    "option_history_required": option_required,
-                                    "context_fresh": bool(indicators_ctx.get("spot_fresh") or indicators_ctx.get("futures_fresh")),
-                                    "context_direction_valid": bool((indicators_ctx.get("direction_bias") or indicators_ctx.get("underlying_direction_bias"))),
-                                    "direction_bias": indicators_ctx.get("underlying_direction_bias") or indicators_ctx.get("direction_bias"),
-                                    "strategy_vote_count": 0,
-                                    "no_vote_reason_counts": {},
-                                    "execution_readiness_allowed": bool(self._runtime_live_orders_armed),
-                                    "execution_readiness_reason": self._runtime_readiness_reason,
-                                    "broker_health_effect": None,
-                                    "margin_status": None,
-                                    "kill_switch_active": bool(getattr(self._order_manager, "is_kill_switch_active", lambda: False)()),
-                                },
+                            self._emit_no_trade_decision(
+                                symbol=symbol,
+                                trace_id=trace_id,
+                                category=category,
+                                reason=reason,
+                                indicators_ctx=indicators_ctx,
+                                option_history_count=option_count,
+                                option_history_required=option_required,
                             )
                         else:
                             self._emit_runner_eval_decision(

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -6599,34 +6599,46 @@ class StrategyRunner:
         option_history_count: int | None = None,
         option_history_required: int | None = None,
     ) -> None:
-        ctx = dict(indicators_ctx or {})
-        self._logger.info(
-            "RUNNER_NO_TRADE_DECISION symbol=%s category=%s reason=%s",
-            symbol,
-            category,
-            reason,
-            extra={
-                "event": "RUNNER_NO_TRADE_DECISION",
-                "symbol": symbol,
-                "trace_id": trace_id,
-                "broker_attempted": bool(broker_attempted),
-                "category": category,
-                "reason": reason,
-                "data_phase": self._data_phase.get(symbol),
-                "option_history_count": int(option_history_count or 0),
-                "option_history_required": int(option_history_required or 0),
-                "context_fresh": bool(ctx.get("spot_fresh") or ctx.get("futures_fresh")),
-                "context_direction_valid": bool((ctx.get("direction_bias") or ctx.get("underlying_direction_bias"))),
-                "direction_bias": ctx.get("underlying_direction_bias") or ctx.get("direction_bias"),
-                "strategy_vote_count": 0,
-                "no_vote_reason_counts": {},
-                "execution_readiness_allowed": bool(self._runtime_live_orders_armed),
-                "execution_readiness_reason": self._runtime_readiness_reason,
-                "broker_health_effect": None,
-                "margin_status": None,
-                "kill_switch_active": bool(getattr(self._order_manager, "is_kill_switch_active", lambda: False)()),
-            },
-        )
+        try:
+            ctx = dict(indicators_ctx or {})
+            self._logger.info(
+                "RUNNER_NO_TRADE_DECISION symbol=%s category=%s reason=%s",
+                symbol,
+                category,
+                reason,
+                extra={
+                    "event": "RUNNER_NO_TRADE_DECISION",
+                    "symbol": symbol,
+                    "trace_id": trace_id,
+                    "broker_attempted": bool(broker_attempted),
+                    "category": category,
+                    "reason": reason,
+                    "data_phase": self._data_phase.get(symbol),
+                    "option_history_count": int(option_history_count or 0),
+                    "option_history_required": int(option_history_required or 0),
+                    "context_fresh": bool(ctx.get("spot_fresh") or ctx.get("futures_fresh")),
+                    "context_direction_valid": bool((ctx.get("direction_bias") or ctx.get("underlying_direction_bias"))),
+                    "direction_bias": ctx.get("underlying_direction_bias") or ctx.get("direction_bias"),
+                    "strategy_vote_count": 0,
+                    "no_vote_reason_counts": {},
+                    "execution_readiness_allowed": bool(self._runtime_live_orders_armed),
+                    "execution_readiness_reason": self._runtime_readiness_reason,
+                    "broker_health_effect": None,
+                    "margin_status": None,
+                    "kill_switch_active": self._safe_kill_switch_active_for_diagnostics(),
+                },
+            )
+        except Exception:
+            return
+
+    def _safe_kill_switch_active_for_diagnostics(self) -> bool:
+        try:
+            checker = getattr(self._order_manager, "is_kill_switch_active", None)
+            if callable(checker):
+                return bool(checker())
+        except Exception:
+            return False
+        return False
 
     def _symbol_role_for_runner(self, symbol: str) -> str:
         """Return runner role label for a symbol. Args: symbol. Returns: role. Raises: none."""
@@ -6793,11 +6805,13 @@ class StrategyRunner:
                                 "required": required_bars,
                             },
                         )
+                    category = "data_history_cold" if history_count < required_bars else "data_history_integrity_failed"
+                    reason = 'insufficient_indicator_bar_count' if history_count < required_bars else 'indicator_history_integrity_failed'
                     self._emit_no_trade_decision(
                         symbol=symbol,
                         trace_id=trace_id,
-                        category="data_history_cold",
-                        reason="insufficient_indicator_bar_count",
+                        category=category,
+                        reason=reason,
                         option_history_count=history_count,
                         option_history_required=required_bars,
                     )

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -12,6 +12,7 @@ from datetime import datetime, time as dt_time, timedelta, timezone
 from enum import Enum
 import json
 import inspect
+import inspect as pyinspect
 import logging
 import os
 from pathlib import Path
@@ -6326,24 +6327,49 @@ class StrategyRunner:
         async def _do_prewarm() -> None:
             success = False
             bars_after = bars_before
+            reason = "selected_option_history_cold"
+            source = "data_hub_hydrate"
             try:
-                out = await hydrate(symbol, interval="minute", days=2, max_bars=max_bars, reason="selected_option_history_cold")
-                success = True
-                bars_after = len(out or []) if isinstance(out, list) else int(bars_before)
-            except Exception:
+                result = hydrate(symbol, interval="minute", days=2, max_bars=max_bars, reason=reason)
+                if pyinspect.isawaitable(result):
+                    result = await result
+                success = result is not None
+                if isinstance(result, list):
+                    bars_after = len(result)
+                elif isinstance(result, Mapping):
+                    bars_after = int(result.get("bars_after") or result.get("count") or bars_before)
+                    success = bool(result.get("success", success))
+                else:
+                    bars_after = self._history_count_for_symbol(symbol)
+            except Exception as exc:
                 success = False
+                source = "data_hub_hydrate_exception"
+                reason = type(exc).__name__
             finally:
                 self._selected_option_prewarm_inflight.discard(symbol)
                 self._logger.info(
                     "SELECTED_OPTION_HISTORY_PREWARM_RESULT symbol=%s bars_before=%s bars_after=%s required_bars=%s success=%s",
                     symbol, bars_before, bars_after, required_bars, success,
-                    extra={"event": "SELECTED_OPTION_HISTORY_PREWARM_RESULT", "symbol": symbol, "bars_before": bars_before, "bars_after": bars_after, "required_bars": required_bars, "success": success, "reason": "selected_option_history_cold", "source": "data_hub_hydrate", "trace_id": trace_id},
+                    extra={"event": "SELECTED_OPTION_HISTORY_PREWARM_RESULT", "symbol": symbol, "bars_before": bars_before, "bars_after": bars_after, "required_bars": required_bars, "success": success, "reason": reason, "source": source, "trace_id": trace_id},
                 )
         try:
             loop = asyncio.get_running_loop()
             loop.create_task(_do_prewarm())
         except RuntimeError:
+            threading.Thread(target=lambda: asyncio.run(_do_prewarm()), name=f"selected-option-prewarm-{symbol}", daemon=True).start()
+        except Exception as exc:
             self._selected_option_prewarm_inflight.discard(symbol)
+            self._logger.info(
+                "SELECTED_OPTION_HISTORY_PREWARM_RESULT symbol=%s bars_before=%s bars_after=%s required_bars=%s success=%s",
+                symbol, bars_before, bars_before, required_bars, False,
+                extra={"event": "SELECTED_OPTION_HISTORY_PREWARM_RESULT", "symbol": symbol, "bars_before": bars_before, "bars_after": bars_before, "required_bars": required_bars, "success": False, "reason": type(exc).__name__, "source": "prewarm_scheduler_exception", "trace_id": trace_id},
+            )
+
+    def _history_count_for_symbol(self, symbol: str) -> int:
+        try:
+            return len(self._indicator_engine.get_history(symbol) or [])
+        except Exception:
+            return 0
 
     def _same_bar_eval_reason(
         self,
@@ -6528,6 +6554,31 @@ class StrategyRunner:
         value = str(symbol or "").upper()
         return value == "NSE:NIFTY" or (value.startswith("NFO:NIFTY") and value.endswith("FUT"))
 
+    def _classify_no_trade_decision(
+        self,
+        *,
+        signal: Any | None,
+        indicators_ctx: Mapping[str, Any],
+        option_count: int,
+        option_required: int,
+        broker_attempted: bool = False,
+    ) -> tuple[str, str]:
+        if broker_attempted:
+            return "broker_placement_failed", "broker_attempted_failed"
+        if option_count < option_required:
+            return "data_history_cold", "insufficient_indicator_bar_count"
+        conflict = bool(indicators_ctx.get("direction_conflict") or indicators_ctx.get("underlying_direction_conflict"))
+        if conflict:
+            return "context_direction_conflict", "underlying_direction_conflict"
+        direction_bias = indicators_ctx.get("underlying_direction_bias") or indicators_ctx.get("direction_bias")
+        if not direction_bias:
+            return "context_direction_unavailable", "direction_context_not_ready"
+        if not self._runtime_live_orders_armed:
+            return "execution_readiness_false", str(self._runtime_readiness_reason or "runtime_live_orders_not_armed")
+        if signal is None:
+            return "strategy_no_trigger", "evaluation_no_signal"
+        return "strategy_no_trigger", "no_order_condition"
+
     def _symbol_role_for_runner(self, symbol: str) -> str:
         """Return runner role label for a symbol. Args: symbol. Returns: role. Raises: none."""
         s = normalize_symbol(str(symbol or "")).upper()
@@ -6627,13 +6678,28 @@ class StrategyRunner:
                     fut_symbol = next((sym for sym in self._active_symbols if self._symbol_role_for_runner(sym) == "futures_context"), "")
                     if not fut_symbol and self._should_log_throttled("fut_unresolved", 120.0):
                         self._logger.warning("CONTEXT_FUTURES_UNRESOLVED symbol=%s", symbol)
+                    if not fut_symbol and hasattr(self._market_data, "maybe_rotate_nifty_futures_context"):
+                        rotated = self._market_data.maybe_rotate_nifty_futures_context(
+                            None, reason="context_futures_missing", trace_id=trace_id
+                        )
+                        if rotated:
+                            fut_symbol = str(rotated)
+                            self._active_symbols.add(fut_symbol)
                     if fut_symbol and hasattr(self._market_data, "maybe_rotate_nifty_futures_context"):
+                        old_fut_symbol = fut_symbol
                         rotated = self._market_data.maybe_rotate_nifty_futures_context(
                             fut_symbol, reason="context_futures_unresolved", trace_id=trace_id
                         )
                         if rotated and rotated != fut_symbol:
                             self._active_symbols.discard(fut_symbol)
                             self._active_symbols.add(str(rotated))
+                            fut_symbol = str(rotated)
+                            self._logger.info(
+                                "RUNNER_FUTURES_CONTEXT_ROTATED old_symbol=%s new_symbol=%s",
+                                old_fut_symbol,
+                                fut_symbol,
+                                extra={"event": "RUNNER_FUTURES_CONTEXT_ROTATED", "old_symbol": old_fut_symbol, "new_symbol": fut_symbol, "trace_id": trace_id, "reason": "context_futures_unresolved", "stage": "phase9"},
+                            )
                     spot_bars = len(self._indicator_engine.get_history(spot_symbol) or [])
                     fut_bars = len(self._indicator_engine.get_history(fut_symbol) or []) if fut_symbol else 0
                     opt_bars = history_count
@@ -8507,11 +8573,13 @@ class StrategyRunner:
                         if signal is None:
                             option_required = self._required_bars_for_symbol(symbol)
                             option_count = len(self._indicator_engine.get_history(symbol) or [])
-                            category = "strategy_no_trigger"
-                            reason = "evaluation_no_signal"
-                            if option_count < option_required:
-                                category = "data_history_cold"
-                                reason = "insufficient_indicator_bar_count"
+                            category, reason = self._classify_no_trade_decision(
+                                signal=None,
+                                indicators_ctx=indicators_ctx,
+                                option_count=option_count,
+                                option_required=option_required,
+                                broker_attempted=False,
+                            )
                             self._emit_runner_eval_decision(
                                 symbol=symbol,
                                 stage="phase9",

--- a/src/nifty_scalper_bot/strategies/signal_generator.py
+++ b/src/nifty_scalper_bot/strategies/signal_generator.py
@@ -15,6 +15,7 @@ import os
 from typing import Any, Deque, Iterable, Literal, Mapping, MutableMapping, Protocol
 
 from nifty_scalper_bot.core.signal_arbitrator import SignalArbitrator
+from nifty_scalper_bot.execution.readiness import HistoryReadinessPolicy
 from nifty_scalper_bot.utils.logging import get_logger, log_throttled
 
 logger = get_logger(__name__)
@@ -79,7 +80,7 @@ def build_strategy_history_context(
         else spot_count if history_domain_used == "spot"
         else underlying_count
     )
-    min_required = int(os.getenv("SMC_MIN_BARS_REQUIRED", "30") or "30")
+    min_required = HistoryReadinessPolicy.from_env().smc_min_bars
     context: dict[str, Any] = {
         "history_count": resolved_history_count,
         "indicator_history_count": raw_count,

--- a/src/nifty_scalper_bot/strategies/signal_generator.py
+++ b/src/nifty_scalper_bot/strategies/signal_generator.py
@@ -80,7 +80,12 @@ def build_strategy_history_context(
         else spot_count if history_domain_used == "spot"
         else underlying_count
     )
-    min_required = HistoryReadinessPolicy.from_env().smc_min_bars
+    policy = HistoryReadinessPolicy.from_env()
+    if history_domain_used == "options":
+        domain_min_required = policy.option_eval_min_bars
+    else:
+        domain_min_required = policy.context_min_bars
+    smc_min_required = policy.smc_min_bars
     context: dict[str, Any] = {
         "history_count": resolved_history_count,
         "indicator_history_count": raw_count,
@@ -93,9 +98,11 @@ def build_strategy_history_context(
         "history_resolved_count": resolved_history_count,
         "oldest_bar_ts": None,
         "latest_bar_ts": None,
-        "history_quality": "warm" if resolved_history_count >= min_required else "cold",
-        "history_required_min": min_required,
-        "history_ready_for_smc": resolved_history_count >= min_required,
+        "history_quality": "warm" if resolved_history_count >= domain_min_required else "cold",
+        "history_required_min": domain_min_required,
+        "history_ready": resolved_history_count >= domain_min_required,
+        "smc_history_required_min": smc_min_required,
+        "history_ready_for_smc": resolved_history_count >= smc_min_required,
     }
     if bars:
         context["oldest_bar_ts"] = _bar_ts(bars[0])

--- a/tests/data/test_market_data_manager.py
+++ b/tests/data/test_market_data_manager.py
@@ -228,6 +228,31 @@ def test_active_future_resolver_replaces_expired_month_future(broker: DummyBroke
     assert symbol == "NFO:NIFTY26JUNFUT"
 
 
+def test_active_future_resolver_rejects_banknifty_and_finnifty(broker: DummyBroker, ws: DummyWebSocket) -> None:
+    resolver = type(
+        "Resolver",
+        (),
+        {"list_instruments": lambda self: [
+            {"segment": "NFO-FUT", "instrument_type": "FUT", "tradingsymbol": "BANKNIFTY26JUNFUT", "expiry": "2026-06-25"},
+            {"segment": "NFO-FUT", "instrument_type": "FUT", "tradingsymbol": "FINNIFTY26JUNFUT", "expiry": "2026-06-25"},
+            {"segment": "NFO-FUT", "instrument_type": "FUT", "tradingsymbol": "NIFTY26JUN24000CE", "expiry": "2026-06-25"},
+            {"segment": "NFO-FUT", "instrument_type": "FUT", "name": "NIFTY", "tradingsymbol": "NIFTY26JUNFUT", "expiry": "2026-06-25"},
+        ]}
+    )()
+    manager = MarketDataManager(broker, ws, resolver=resolver)
+    assert manager.resolve_active_nifty_future_symbol(now=datetime(2026, 5, 27, tzinfo=timezone.utc)) == "NFO:NIFTY26JUNFUT"
+
+
+def test_active_future_resolver_calls_instruments_with_nfo_when_required(broker: DummyBroker, ws: DummyWebSocket) -> None:
+    class Resolver:
+        def instruments(self, exchange=None):
+            if exchange == "NFO":
+                return [{"segment": "NFO-FUT", "instrument_type": "FUTIDX", "name": "NIFTY", "tradingsymbol": "NIFTY26JUNFUT", "expiry": "2026-06-25"}]
+            return []
+    manager = MarketDataManager(broker, ws, resolver=Resolver())
+    assert manager.resolve_active_nifty_future_symbol(now=datetime(2026, 5, 27, tzinfo=timezone.utc)) == "NFO:NIFTY26JUNFUT"
+
+
 @pytest.mark.asyncio
 async def test_wait_until_ready_not_ready_log_is_throttled(
     broker: DummyBroker,

--- a/tests/data/test_market_data_manager.py
+++ b/tests/data/test_market_data_manager.py
@@ -198,6 +198,36 @@ def test_pull_quote_403_marks_quote_api_unavailable(
     assert isinstance(status["last_checked_at"], float)
 
 
+def test_pull_quote_direct_missing_is_rate_limited(ws: DummyWebSocket) -> None:
+    class MissingBroker(DummyBroker):
+        def get_quote(self, symbol: str) -> dict[str, Any]:
+            self.calls.append(("get_quote", (symbol,)))
+            raise RuntimeError(f"Quote data missing for {symbol}")
+
+    manager = MarketDataManager(MissingBroker(), ws)
+    first = manager.pull_quote("NFO:NIFTY26MAYFUT")
+    second = manager.pull_quote("NFO:NIFTY26MAYFUT")
+    assert first["symbol"] == "NFO:NIFTY26MAYFUT"
+    assert second.get("quote_unavailable_reason") == "quote_symbol_missing_cooldown"
+    assert manager._quote_direct_miss_count["NFO:NIFTY26MAYFUT"] >= 1  # noqa: SLF001
+
+
+def test_active_future_resolver_replaces_expired_month_future(broker: DummyBroker, ws: DummyWebSocket) -> None:
+    resolver = type(
+        "Resolver",
+        (),
+        {
+            "list_instruments": lambda self: [
+                {"segment": "NFO-FUT", "instrument_type": "FUT", "tradingsymbol": "NIFTY26MAYFUT", "expiry": "2026-05-20"},
+                {"segment": "NFO-FUT", "instrument_type": "FUT", "tradingsymbol": "NIFTY26JUNFUT", "expiry": "2026-06-25"},
+            ]
+        },
+    )()
+    manager = MarketDataManager(broker, ws, resolver=resolver)
+    symbol = manager.resolve_active_nifty_future_symbol(now=datetime(2026, 5, 27, tzinfo=timezone.utc))
+    assert symbol == "NFO:NIFTY26JUNFUT"
+
+
 @pytest.mark.asyncio
 async def test_wait_until_ready_not_ready_log_is_throttled(
     broker: DummyBroker,

--- a/tests/data/test_market_data_manager.py
+++ b/tests/data/test_market_data_manager.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from datetime import datetime, timedelta, timezone
+from datetime import date
 import time
 from typing import Any, Iterable
 from unittest.mock import patch
@@ -250,6 +251,20 @@ def test_active_future_resolver_calls_instruments_with_nfo_when_required(broker:
                 return [{"segment": "NFO-FUT", "instrument_type": "FUTIDX", "name": "NIFTY", "tradingsymbol": "NIFTY26JUNFUT", "expiry": "2026-06-25"}]
             return []
     manager = MarketDataManager(broker, ws, resolver=Resolver())
+    assert manager.resolve_active_nifty_future_symbol(now=datetime(2026, 5, 27, tzinfo=timezone.utc)) == "NFO:NIFTY26JUNFUT"
+
+
+def test_active_future_resolver_accepts_mapping_payloads(broker: DummyBroker, ws: DummyWebSocket) -> None:
+    class Resolver:
+        def instruments(self, exchange=None):
+            return {"1": {"exchange": "NFO", "segment": "NFO-FUT", "instrument_type": "FUTIDX", "name": "NIFTY", "tradingsymbol": "NIFTY26JUNFUT", "expiry": "2026-06-25"}}
+    manager = MarketDataManager(broker, ws, resolver=Resolver())
+    assert manager.resolve_active_nifty_future_symbol(now=datetime(2026, 5, 27, tzinfo=timezone.utc)) == "NFO:NIFTY26JUNFUT"
+
+
+def test_active_future_resolver_handles_date_expiry(broker: DummyBroker, ws: DummyWebSocket) -> None:
+    resolver = type("Resolver", (), {"list_instruments": lambda self: [{"segment": "NFO-FUT", "instrument_type": "FUT", "name": "NIFTY", "tradingsymbol": "NIFTY26JUNFUT", "expiry": date(2026, 6, 25)}]})()
+    manager = MarketDataManager(broker, ws, resolver=resolver)
     assert manager.resolve_active_nifty_future_symbol(now=datetime(2026, 5, 27, tzinfo=timezone.utc)) == "NFO:NIFTY26JUNFUT"
 
 

--- a/tests/strategies/test_runner_live_path_guards.py
+++ b/tests/strategies/test_runner_live_path_guards.py
@@ -238,6 +238,19 @@ def test_order_acceptance_notifies_orchestrator_entry() -> None:
     signal = Signal(action='BUY', symbol='NFO:NIFTY26APR23800CE', quantity=1, confidence=0.9, reason='test', stop_loss=100.0, take_profit=120.0, metadata={'strategy_score': 7, 'option_score': 7, 'data_score': 7, 'rr_score': 7})
     runner._handle_entry_signal_inner(signal, 'NFO:NIFTY26APR23800CE', 'NFO:NIFTY26APR23800CE', 110.0, datetime.now(timezone.utc), trace_id='notify')
     assert notified["symbol"] == 'NFO:NIFTY26APR23800CE'
+
+
+def test_selected_option_prewarm_accepts_sync_hydrator_list_result() -> None:
+    runner = _build_runner()
+    runner._indicator_engine = SimpleNamespace(get_history=lambda _s: [1, 2, 3])
+    runner._selected_option_prewarm_last = {}
+    runner._selected_option_prewarm_inflight = set()
+    runner._selected_option_prewarm_cooldown_s = 0.0
+    runner._data_hub = SimpleNamespace(hydrate_symbol_history=lambda *a, **k: [1, 2, 3, 4, 5])
+    runner._request_selected_option_history_prewarm("NFO:NIFTY26JUN24000CE", bars_before=1, required_bars=5, trace_id="t1")
+    import time as _t
+    _t.sleep(0.05)
+    assert "NFO:NIFTY26JUN24000CE" not in runner._selected_option_prewarm_inflight
     assert notified["reason"] == "order_accepted"
 
 

--- a/tests/strategies/test_runner_live_path_guards.py
+++ b/tests/strategies/test_runner_live_path_guards.py
@@ -241,17 +241,23 @@ def test_order_acceptance_notifies_orchestrator_entry() -> None:
     assert notified["reason"] == "order_accepted"
 
 
-def test_selected_option_prewarm_accepts_sync_hydrator_list_result() -> None:
+def test_selected_option_prewarm_accepts_sync_hydrator_list_result(caplog) -> None:
     runner = _build_runner()
+    runner._logger = logging.getLogger("test.runner.prewarm.sync")
     runner._indicator_engine = SimpleNamespace(get_history=lambda _s: [1, 2, 3])
     runner._selected_option_prewarm_last = {}
     runner._selected_option_prewarm_inflight = set()
     runner._selected_option_prewarm_cooldown_s = 0.0
     runner._data_hub = SimpleNamespace(hydrate_symbol_history=lambda *a, **k: [1, 2, 3, 4, 5])
-    runner._request_selected_option_history_prewarm("NFO:NIFTY26JUN24000CE", bars_before=1, required_bars=5, trace_id="t1")
+    with caplog.at_level("INFO"):
+        runner._request_selected_option_history_prewarm("NFO:NIFTY26JUN24000CE", bars_before=1, required_bars=5, trace_id="t1")
     import time as _t
     _t.sleep(0.05)
     assert "NFO:NIFTY26JUN24000CE" not in runner._selected_option_prewarm_inflight
+    rec = next(r for r in caplog.records if getattr(r, "event", "") == "SELECTED_OPTION_HISTORY_PREWARM_RESULT")
+    assert rec.success is True
+    assert rec.bars_after == 5
+    assert rec.source == "data_hub_hydrate"
 
 
 @pytest.mark.asyncio
@@ -271,6 +277,24 @@ async def test_selected_option_prewarm_sync_hydrator_runs_off_event_loop() -> No
     await asyncio.sleep(0.05)
     assert called_thread["name"]
     assert called_thread["name"] != threading.current_thread().name
+
+
+@pytest.mark.asyncio
+async def test_selected_option_prewarm_accepts_async_hydrator_list_result(caplog) -> None:
+    runner = _build_runner()
+    runner._logger = logging.getLogger("test.runner.prewarm.async")
+    runner._indicator_engine = SimpleNamespace(get_history=lambda _s: [1, 2, 3])
+    runner._selected_option_prewarm_last = {}
+    runner._selected_option_prewarm_inflight = set()
+    runner._selected_option_prewarm_cooldown_s = 0.0
+    async def _hydrate(*_a, **_k):
+        return [1, 2, 3, 4, 5]
+    runner._data_hub = SimpleNamespace(hydrate_symbol_history=_hydrate)
+    with caplog.at_level("INFO"):
+        runner._request_selected_option_history_prewarm("NFO:NIFTY26JUN24000CE", bars_before=1, required_bars=5, trace_id="t3")
+        await asyncio.sleep(0.05)
+    rec = next(r for r in caplog.records if getattr(r, "event", "") == "SELECTED_OPTION_HISTORY_PREWARM_RESULT")
+    assert rec.success is True
 
 
 def test_atr_fallback_used_for_insufficient_bars() -> None:

--- a/tests/strategies/test_runner_live_path_guards.py
+++ b/tests/strategies/test_runner_live_path_guards.py
@@ -5,6 +5,7 @@ from collections import deque
 from datetime import datetime, timezone
 import logging
 from pathlib import Path
+import time
 from types import SimpleNamespace
 import threading
 from unittest.mock import AsyncMock, MagicMock
@@ -13,6 +14,24 @@ import pytest
 from nifty_scalper_bot.strategies.runner import ExecutionReadinessResult, SignalExecutionResult, StrategyRunner
 from nifty_scalper_bot.strategies.signal_generator import Signal
 from nifty_scalper_bot.strategies.trade_selector import TradeCandidateSelector
+
+
+def _wait_until(predicate, timeout: float = 1.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.01)
+    return bool(predicate())
+
+
+async def _wait_until_async(predicate, timeout: float = 1.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        await asyncio.sleep(0.01)
+    return bool(predicate())
 
 
 class _SilentLogger:
@@ -251,9 +270,7 @@ def test_selected_option_prewarm_accepts_sync_hydrator_list_result(caplog) -> No
     runner._data_hub = SimpleNamespace(hydrate_symbol_history=lambda *a, **k: [1, 2, 3, 4, 5])
     with caplog.at_level("INFO"):
         runner._request_selected_option_history_prewarm("NFO:NIFTY26JUN24000CE", bars_before=1, required_bars=5, trace_id="t1")
-    import time as _t
-    _t.sleep(0.05)
-    assert "NFO:NIFTY26JUN24000CE" not in runner._selected_option_prewarm_inflight
+    assert _wait_until(lambda: "NFO:NIFTY26JUN24000CE" not in runner._selected_option_prewarm_inflight)
     rec = next(r for r in caplog.records if getattr(r, "event", "") == "SELECTED_OPTION_HISTORY_PREWARM_RESULT")
     assert rec.success is True
     assert rec.bars_after == 5
@@ -274,8 +291,7 @@ async def test_selected_option_prewarm_sync_hydrator_runs_off_event_loop() -> No
         return [1, 2, 3]
     runner._data_hub = SimpleNamespace(hydrate_symbol_history=_hydrate)
     runner._request_selected_option_history_prewarm("NFO:NIFTY26JUN24000CE", bars_before=1, required_bars=5, trace_id="t2")
-    await asyncio.sleep(0.05)
-    assert called_thread["name"]
+    assert await _wait_until_async(lambda: bool(called_thread["name"]))
     assert called_thread["name"] != threading.current_thread().name
 
 
@@ -292,7 +308,7 @@ async def test_selected_option_prewarm_accepts_async_hydrator_list_result(caplog
     runner._data_hub = SimpleNamespace(hydrate_symbol_history=_hydrate)
     with caplog.at_level("INFO"):
         runner._request_selected_option_history_prewarm("NFO:NIFTY26JUN24000CE", bars_before=1, required_bars=5, trace_id="t3")
-        await asyncio.sleep(0.05)
+        assert await _wait_until_async(lambda: "NFO:NIFTY26JUN24000CE" not in runner._selected_option_prewarm_inflight)
     rec = next(r for r in caplog.records if getattr(r, "event", "") == "SELECTED_OPTION_HISTORY_PREWARM_RESULT")
     assert rec.success is True
 

--- a/tests/strategies/test_runner_live_path_guards.py
+++ b/tests/strategies/test_runner_live_path_guards.py
@@ -238,6 +238,7 @@ def test_order_acceptance_notifies_orchestrator_entry() -> None:
     signal = Signal(action='BUY', symbol='NFO:NIFTY26APR23800CE', quantity=1, confidence=0.9, reason='test', stop_loss=100.0, take_profit=120.0, metadata={'strategy_score': 7, 'option_score': 7, 'data_score': 7, 'rr_score': 7})
     runner._handle_entry_signal_inner(signal, 'NFO:NIFTY26APR23800CE', 'NFO:NIFTY26APR23800CE', 110.0, datetime.now(timezone.utc), trace_id='notify')
     assert notified["symbol"] == 'NFO:NIFTY26APR23800CE'
+    assert notified["reason"] == "order_accepted"
 
 
 def test_selected_option_prewarm_accepts_sync_hydrator_list_result() -> None:
@@ -251,7 +252,25 @@ def test_selected_option_prewarm_accepts_sync_hydrator_list_result() -> None:
     import time as _t
     _t.sleep(0.05)
     assert "NFO:NIFTY26JUN24000CE" not in runner._selected_option_prewarm_inflight
-    assert notified["reason"] == "order_accepted"
+
+
+@pytest.mark.asyncio
+async def test_selected_option_prewarm_sync_hydrator_runs_off_event_loop() -> None:
+    runner = _build_runner()
+    runner._indicator_engine = SimpleNamespace(get_history=lambda _s: [1, 2, 3])
+    runner._selected_option_prewarm_last = {}
+    runner._selected_option_prewarm_inflight = set()
+    runner._selected_option_prewarm_cooldown_s = 0.0
+    import threading
+    called_thread = {"name": ""}
+    def _hydrate(*_a, **_k):
+        called_thread["name"] = threading.current_thread().name
+        return [1, 2, 3]
+    runner._data_hub = SimpleNamespace(hydrate_symbol_history=_hydrate)
+    runner._request_selected_option_history_prewarm("NFO:NIFTY26JUN24000CE", bars_before=1, required_bars=5, trace_id="t2")
+    await asyncio.sleep(0.05)
+    assert called_thread["name"]
+    assert called_thread["name"] != threading.current_thread().name
 
 
 def test_atr_fallback_used_for_insufficient_bars() -> None:

--- a/tests/strategies/test_runner_readiness_diagnostics.py
+++ b/tests/strategies/test_runner_readiness_diagnostics.py
@@ -192,3 +192,32 @@ def test_runner_no_trade_decision_reports_context_direction_conflict() -> None:
         broker_attempted=False,
     )
     assert category == "context_direction_conflict"
+
+
+def test_runner_no_trade_decision_reports_strategy_no_trigger_when_data_ready_but_signal_none() -> None:
+    runner = _make_runner()
+    runner._runtime_live_orders_armed = False
+    category, _ = runner._classify_no_trade_decision(  # type: ignore[attr-defined]
+        signal=None,
+        indicators_ctx={"direction_bias": "CE"},
+        option_count=10,
+        option_required=5,
+        broker_attempted=False,
+    )
+    assert category == "strategy_no_trigger"
+
+
+def test_runner_emits_no_trade_decision_on_history_cold_eval_block(caplog) -> None:
+    runner = _make_runner()
+    runner._active_symbols = {"NFO:CE"}
+    runner._indicator_engine = _DummyIndicator({"NFO:CE": [1]})
+    runner._required_bars_for_symbol = lambda _s: 5
+    runner._is_tradable_symbol = lambda _s: True
+    runner._is_context_symbol = lambda _s: False
+    runner._is_option_symbol_tick_fresh = lambda _s, max_age_s=60.0: True
+    with caplog.at_level(logging.INFO):
+        allowed = runner._strategy_evaluation_allowed("NFO:CE", trace_id="t-cold")
+    assert allowed is False
+    rec = next(r for r in caplog.records if getattr(r, "event", "") == "RUNNER_NO_TRADE_DECISION")
+    assert rec.category == "data_history_cold"
+    assert rec.broker_attempted is False

--- a/tests/strategies/test_runner_readiness_diagnostics.py
+++ b/tests/strategies/test_runner_readiness_diagnostics.py
@@ -155,3 +155,24 @@ def test_stale_selected_symbol_does_not_arm_live_orders(caplog) -> None:
     rec = next(r for r in caplog.records if getattr(r, "event", "") == "RUNNER_EVAL_DECISION")
     assert rec.trading_allowed is False
     assert rec.order_forwarding_allowed is False
+
+
+def test_no_trade_decision_reports_history_cold_not_broker(caplog) -> None:
+    logger = logging.getLogger("test.runner.no_trade")
+    with caplog.at_level(logging.INFO):
+        logger.info(
+            "RUNNER_NO_TRADE_DECISION symbol=%s category=%s reason=%s",
+            "NFO:CE",
+            "data_history_cold",
+            "insufficient_indicator_bar_count",
+            extra={
+                "event": "RUNNER_NO_TRADE_DECISION",
+                "symbol": "NFO:CE",
+                "broker_attempted": False,
+                "category": "data_history_cold",
+                "reason": "insufficient_indicator_bar_count",
+            },
+        )
+    rec = next(r for r in caplog.records if getattr(r, "event", "") == "RUNNER_NO_TRADE_DECISION")
+    assert rec.broker_attempted is False
+    assert rec.category == "data_history_cold"

--- a/tests/strategies/test_runner_readiness_diagnostics.py
+++ b/tests/strategies/test_runner_readiness_diagnostics.py
@@ -158,21 +158,37 @@ def test_stale_selected_symbol_does_not_arm_live_orders(caplog) -> None:
 
 
 def test_no_trade_decision_reports_history_cold_not_broker(caplog) -> None:
-    logger = logging.getLogger("test.runner.no_trade")
-    with caplog.at_level(logging.INFO):
-        logger.info(
-            "RUNNER_NO_TRADE_DECISION symbol=%s category=%s reason=%s",
-            "NFO:CE",
-            "data_history_cold",
-            "insufficient_indicator_bar_count",
-            extra={
-                "event": "RUNNER_NO_TRADE_DECISION",
-                "symbol": "NFO:CE",
-                "broker_attempted": False,
-                "category": "data_history_cold",
-                "reason": "insufficient_indicator_bar_count",
-            },
-        )
-    rec = next(r for r in caplog.records if getattr(r, "event", "") == "RUNNER_NO_TRADE_DECISION")
-    assert rec.broker_attempted is False
-    assert rec.category == "data_history_cold"
+    runner = _make_runner()
+    category, reason = runner._classify_no_trade_decision(  # type: ignore[attr-defined]
+        signal=None,
+        indicators_ctx={},
+        option_count=1,
+        option_required=5,
+        broker_attempted=False,
+    )
+    assert category == "data_history_cold"
+    assert reason == "insufficient_indicator_bar_count"
+
+
+def test_runner_no_trade_decision_reports_context_direction_unavailable() -> None:
+    runner = _make_runner()
+    category, _ = runner._classify_no_trade_decision(  # type: ignore[attr-defined]
+        signal=None,
+        indicators_ctx={},
+        option_count=10,
+        option_required=5,
+        broker_attempted=False,
+    )
+    assert category == "context_direction_unavailable"
+
+
+def test_runner_no_trade_decision_reports_context_direction_conflict() -> None:
+    runner = _make_runner()
+    category, _ = runner._classify_no_trade_decision(  # type: ignore[attr-defined]
+        signal=None,
+        indicators_ctx={"direction_conflict": True},
+        option_count=10,
+        option_required=5,
+        broker_attempted=False,
+    )
+    assert category == "context_direction_conflict"

--- a/tests/strategies/test_runner_readiness_diagnostics.py
+++ b/tests/strategies/test_runner_readiness_diagnostics.py
@@ -221,3 +221,51 @@ def test_runner_emits_no_trade_decision_on_history_cold_eval_block(caplog) -> No
     rec = next(r for r in caplog.records if getattr(r, "event", "") == "RUNNER_NO_TRADE_DECISION")
     assert rec.category == "data_history_cold"
     assert rec.broker_attempted is False
+
+
+def test_runner_no_trade_decision_reports_integrity_failure_when_count_sufficient_but_has_min_bars_false(caplog) -> None:
+    runner = _make_runner()
+    runner._active_symbols = {"NFO:CE"}
+    runner._indicator_engine = _DummyIndicator({"NFO:CE": [1, 2, 3, 4, 5]})
+    runner._required_bars_for_symbol = lambda _s: 5
+    runner._is_tradable_symbol = lambda _s: True
+    runner._is_context_symbol = lambda _s: False
+    runner._is_option_symbol_tick_fresh = lambda _s, max_age_s=60.0: True
+    runner._indicator_engine.has_min_bars = lambda _s, _r: False  # type: ignore[attr-defined]
+    with caplog.at_level(logging.INFO):
+        allowed = runner._strategy_evaluation_allowed("NFO:CE", trace_id="t-integrity")
+    assert allowed is False
+    rec = next(r for r in caplog.records if getattr(r, "event", "") == "RUNNER_NO_TRADE_DECISION")
+    assert rec.category == "data_history_integrity_failed"
+    assert rec.reason == "indicator_history_integrity_failed"
+
+
+def test_emit_no_trade_decision_does_not_raise_when_kill_switch_status_raises() -> None:
+    runner = _make_runner()
+    runner._order_manager = SimpleNamespace(is_kill_switch_active=lambda: (_ for _ in ()).throw(RuntimeError("boom")))
+    runner._emit_no_trade_decision(symbol="NFO:CE", trace_id="t", category="strategy_no_trigger", reason="evaluation_no_signal")
+
+
+def test_emit_no_trade_decision_does_not_raise_with_missing_order_manager() -> None:
+    runner = _make_runner()
+    del runner._order_manager
+    runner._emit_no_trade_decision(symbol="NFO:CE", trace_id="t", category="strategy_no_trigger", reason="evaluation_no_signal")
+
+
+def test_runner_emits_no_trade_decision_on_signal_none_strategy_no_trigger(caplog) -> None:
+    runner = _make_runner()
+    with caplog.at_level(logging.INFO):
+        runner._emit_no_trade_decision(
+            symbol="NFO:CE",
+            trace_id="t-no-signal",
+            category="strategy_no_trigger",
+            reason="evaluation_no_signal",
+            broker_attempted=False,
+            indicators_ctx={"direction_bias": "CE"},
+            option_history_count=10,
+            option_history_required=5,
+        )
+    rec = next(r for r in caplog.records if getattr(r, "event", "") == "RUNNER_NO_TRADE_DECISION")
+    assert rec.category == "strategy_no_trigger"
+    assert rec.reason == "evaluation_no_signal"
+    assert rec.broker_attempted is False

--- a/tests/strategies/test_signal_generator_history_safety.py
+++ b/tests/strategies/test_signal_generator_history_safety.py
@@ -103,9 +103,22 @@ def test_build_strategy_history_context_falls_back_to_indicator_engine_when_data
 
 def test_history_policy_option_eval_min_bars_consistent_across_runner_and_signal_context(monkeypatch) -> None:
     monkeypatch.setenv("SMC_MIN_BARS_REQUIRED", "7")
+    monkeypatch.setenv("OPTION_EVAL_MIN_BARS", "5")
     ctx = build_strategy_history_context(
         symbol="NFO:NIFTY26MAY24350PE",
         indicator_engine=_IndicatorEngineBars(),
         data_hub=_DataHubBars(),
     )
-    assert ctx["history_required_min"] == 7
+    assert ctx["history_required_min"] == 5
+    assert ctx["smc_history_required_min"] == 7
+
+
+def test_context_history_uses_context_min_bars(monkeypatch) -> None:
+    monkeypatch.setenv("CONTEXT_MIN_BARS", "50")
+    ctx = build_strategy_history_context(
+        symbol="NSE:NIFTY",
+        indicator_engine=_IndicatorEngineBars(),
+        data_hub=None,
+    )
+    assert ctx["history_required_min"] == 50
+    assert ctx["history_ready_for_smc"] is True

--- a/tests/strategies/test_signal_generator_history_safety.py
+++ b/tests/strategies/test_signal_generator_history_safety.py
@@ -99,3 +99,13 @@ def test_build_strategy_history_context_falls_back_to_indicator_engine_when_data
     assert ctx["history_source"] == "indicator_engine"
     assert ctx["history_domain_used"] == "options"
     assert ctx["history_resolved_count"] == 35
+
+
+def test_history_policy_option_eval_min_bars_consistent_across_runner_and_signal_context(monkeypatch) -> None:
+    monkeypatch.setenv("SMC_MIN_BARS_REQUIRED", "7")
+    ctx = build_strategy_history_context(
+        symbol="NFO:NIFTY26MAY24350PE",
+        indicator_engine=_IndicatorEngineBars(),
+        data_hub=_DataHubBars(),
+    )
+    assert ctx["history_required_min"] == 7

--- a/tests/test_live_readiness_gate.py
+++ b/tests/test_live_readiness_gate.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from nifty_scalper_bot.execution.readiness import compute_live_readiness
+from nifty_scalper_bot.execution.readiness import HistoryReadinessPolicy, compute_live_readiness
 
 
 class TestComputeLiveReadiness:
@@ -121,3 +121,27 @@ def test_live_readiness_accepts_fresh_ws_ltp() -> None:
     text = Path('src/nifty_scalper_bot/core/app.py').read_text(encoding='utf-8')
     assert 'has_fresh_ws_ltp' in text
     assert 'ws_quote_for_gate = bool(ws_quote_proof or ws_ltp_proof)' in text
+
+
+def test_history_policy_invalid_env_falls_back(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPTION_ENTRY_MIN_BARS", "bad")
+    policy = HistoryReadinessPolicy.from_env()
+    assert policy.option_entry_min_bars == 5
+
+
+def test_compute_live_readiness_bad_option_exec_min_bars_does_not_crash() -> None:
+    armed, reasons = compute_live_readiness(
+        live_mode=True,
+        hard_ready=True,
+        quote_available=True,
+        ws_quote_proof=True,
+        market_open=True,
+        runner_running=True,
+        selected_ce="NFO:CE",
+        selected_pe="NFO:PE",
+        ce_bars=0,
+        pe_bars=0,
+        option_exec_min_bars="bad",  # type: ignore[arg-type]
+    )
+    assert armed is False
+    assert "selected_ce_history_insufficient" in reasons

--- a/tests/test_live_readiness_gate.py
+++ b/tests/test_live_readiness_gate.py
@@ -145,3 +145,24 @@ def test_compute_live_readiness_bad_option_exec_min_bars_does_not_crash() -> Non
     )
     assert armed is False
     assert "selected_ce_history_insufficient" in reasons
+
+
+def test_compute_live_readiness_default_uses_policy_entry_min_bars(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPTION_ENTRY_MIN_BARS", "5")
+    armed, reasons = compute_live_readiness(
+        live_mode=True, hard_ready=True, quote_available=True, ws_quote_proof=True, market_open=True, runner_running=True,
+        selected_ce="NFO:NIFTY26JUN24000CE", selected_pe="NFO:NIFTY26JUN24000PE", ce_bars=1, pe_bars=1, ce_quote_ready=True, pe_quote_ready=True
+    )
+    assert armed is False
+    assert "selected_ce_history_insufficient" in reasons
+    assert "selected_pe_history_insufficient" in reasons
+
+
+def test_compute_live_readiness_explicit_positive_override_still_works(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPTION_ENTRY_MIN_BARS", "5")
+    armed, reasons = compute_live_readiness(
+        live_mode=True, hard_ready=True, quote_available=True, ws_quote_proof=True, market_open=True, runner_running=True,
+        selected_ce="NFO:CE", selected_pe="NFO:PE", ce_bars=3, pe_bars=3, option_exec_min_bars=3, ce_quote_ready=True, pe_quote_ready=True
+    )
+    assert armed is True
+    assert reasons == []


### PR DESCRIPTION
### Motivation

- Production logs showed repeated recoverable broker misses for expired FUT symbols and noisy REST `get_quote` churn from the hot strategy loop, causing pre-execution no-trades.
- Selected options often had WS tradable-proof but cold history and inconsistent history thresholds caused strategies (SMC and runner) to block entries unpredictably.
- Need deterministic diagnostics and conservative fixes that reduce broker REST spam, rotate stale futures context, and make history readiness consistent without weakening execution safety.

### Description

- Hardened `MarketDataManager.pull_quote` to track per-symbol direct-miss state, emit structured `MDM_PULL_QUOTE_SYMBOL_MISSING` warnings, and apply a short per-symbol cooldown to avoid repeated broker calls while returning cached ticks when available (`src/nifty_scalper_bot/data/market_data_manager.py`).
- Added `MarketDataManager.resolve_active_nifty_future_symbol(now=None)` to deterministically select the nearest non-expired NIFTY FUT from the resolver/instrument master and enable rotation away from expired futures symbols (`src/nifty_scalper_bot/data/market_data_manager.py`).
- Centralized history/readiness thresholds into a new `HistoryReadinessPolicy` dataclass with env-backed defaults and used it in live-readiness gating so entry/eval/context/SMC thresholds are consistent and configurable (`src/nifty_scalper_bot/execution/readiness.py`).
- Prevented hot-path REST quote pulls by adding a cache-only accessor for evaluation and switching strategy hot-path quote enrichment to use `_get_cached_quote_for_eval` (tries `get_quote(..., allow_pull=False)` or `get_latest_tick`) so `generate_signal` no longer triggers `pull_quote` (`src/nifty_scalper_bot/core/strategy_manager.py`).
- Rewired `build_strategy_history_context` and SMC strategy min-bars to use the centralized policy to avoid contradictory min-bar values (`src/nifty_scalper_bot/strategies/signal_generator.py` and `src/nifty_scalper_bot/strategies/elite_strategies/smc_liquidity.py`).
- Added focused unit tests covering rate-limited pull-quote missing behavior and active future resolution, and a history-policy consistency test (`tests/data/test_market_data_manager.py`, `tests/strategies/test_signal_generator_history_safety.py`).

### Testing

- Ran compilation and focused unit tests: `python -m compileall -q src tests` and `pytest -q tests/data/test_market_data_manager.py tests/strategies/test_signal_generator_history_safety.py tests/strategies/test_runner_readiness_diagnostics.py` and all ran green in the CI subset executed locally (compile: pass, pytest subset: pass).
- Added tests exercised: `test_pull_quote_direct_missing_is_rate_limited`, `test_active_future_resolver_replaces_expired_month_future`, and `test_history_policy_option_eval_min_bars_consistent_across_runner_and_signal_context`, which passed in the run.
- No execution/order placing code or margin/kill-switch logic was changed and no live broker calls were added to hot paths; regression risk is limited to resolver payload variability and cooldown tuning, mitigated by conservative checks and a short, configurable cooldown.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a166f5b484083249d323aec45472c63)