### PR TITLE
Fix futures context rotation and clarify no-trade & order diagnostics

### DIFF
--- a/src/nifty_scalper_bot/core/strategy_manager.py
+++ b/src/nifty_scalper_bot/core/strategy_manager.py
@@ -3574,13 +3574,32 @@ class StrategyManager(_BaseStrategyManager):
             metadata["is_selected_option"] = selected_option
             metadata["selected_ok_reason"] = selected_ok_reason
             threshold_passed = bool(raw_trigger_score >= score_min and best_vote.confidence >= conf_min and selected_ok and not vetoed)
-            final_allowed = bool(allow_scalp_single and threshold_passed)
-            blocked_reason = None if final_allowed else ("single_vote_scalp_disabled" if threshold_passed and not allow_scalp_single else "threshold_not_met")
+            high_conviction_allowed = bool(raw_trigger_score >= single_high and selected_ok and not vetoed)
+            scalp_fallback_allowed = bool(allow_scalp_single and threshold_passed)
+            final_allowed = bool(high_conviction_allowed or scalp_fallback_allowed)
+            approval_path_single = "single_vote_high_conviction" if high_conviction_allowed else "single_vote_fallback" if scalp_fallback_allowed else None
+            blocked_reason = None
+            if not final_allowed:
+                if threshold_passed and not allow_scalp_single:
+                    blocked_reason = "single_vote_scalp_disabled"
+                elif not score_ok:
+                    blocked_reason = "raw_score_below_min"
+                elif not conf_ok:
+                    blocked_reason = "confidence_below_min"
+                elif not selected_ok:
+                    blocked_reason = "not_selected_or_near_atm"
+                elif vetoed:
+                    blocked_reason = "hard_context_veto"
+                else:
+                    blocked_reason = "single_vote_gate_failed_unknown"
             log.info(
-                "SINGLE_VOTE_DECISION threshold_passed=%s final_allowed=%s allow_scalp_single=%s reason=%s strategy=%s raw_score=%.2f weighted_score=%.2f regime_weight=%.2f score_min=%.2f confidence=%.2f conf_min=%.2f selected_ok=%s vetoed=%s",
+                "SINGLE_VOTE_DECISION threshold_passed=%s high_conviction_allowed=%s scalp_fallback_allowed=%s final_allowed=%s allow_scalp_single=%s approval_path=%s reason=%s strategy=%s raw_score=%.2f weighted_score=%.2f regime_weight=%.2f score_min=%.2f confidence=%.2f conf_min=%.2f selected_ok=%s vetoed=%s",
                 threshold_passed,
+                high_conviction_allowed,
+                scalp_fallback_allowed,
                 final_allowed,
                 allow_scalp_single,
+                approval_path_single,
                 blocked_reason or "ok",
                 best_vote.strategy,
                 raw_trigger_score,
@@ -3595,8 +3614,11 @@ class StrategyManager(_BaseStrategyManager):
                     "event": "SINGLE_VOTE_DECISION",
                     "allowed": final_allowed,
                     "threshold_passed": threshold_passed,
+                    "high_conviction_allowed": high_conviction_allowed,
+                    "scalp_fallback_allowed": scalp_fallback_allowed,
                     "final_allowed": final_allowed,
                     "allow_scalp_single": allow_scalp_single,
+                    "approval_path": approval_path_single,
                     "blocked_reason": blocked_reason,
                     "symbol": symbol_norm,
                     "strategy": best_vote.strategy,
@@ -3611,9 +3633,10 @@ class StrategyManager(_BaseStrategyManager):
                     "vetoed": vetoed,
                 },
             )
-            if raw_trigger_score >= single_high and selected_ok and not vetoed:
+            if high_conviction_allowed:
                 metadata_stage = "preliminary_single_high_conviction"
-            elif allow_scalp_single and score_ok and conf_ok and selected_ok and not vetoed:
+                approval_path = "single_vote_high_conviction"
+            elif scalp_fallback_allowed:
                 metadata_stage = "single_vote_scalp_controlled"
                 approval_path = "single_vote_fallback"
             else:
@@ -3743,6 +3766,7 @@ class StrategyManager(_BaseStrategyManager):
         metadata["manager_score_source"] = "strategy_score_plus_context_arbitration"
         metadata["approval_path"] = approval_path
         log.info("TRADE_DECISION_TRACE approval_path=%s symbol=%s strategy=%s", approval_path, symbol_norm, best_vote.strategy)
+        self._last_no_signal_decision_by_symbol.pop(symbol_norm, None)
         return Signal(
             action="BUY",
             symbol=best_signal.symbol,

--- a/src/nifty_scalper_bot/core/strategy_manager.py
+++ b/src/nifty_scalper_bot/core/strategy_manager.py
@@ -61,6 +61,24 @@ REGIME_STRATEGY_WEIGHTS: dict[str, dict[str, float]] = {
 }
 
 
+@dataclass(frozen=True)
+class StrategyNoSignalDecision:
+    symbol: str
+    category: str
+    reason: str
+    blocked_at: str
+    no_vote_reason_counts: dict[str, int]
+    strategy_reasons: dict[str, str]
+    direction_bias: str | None
+    underlying_direction_bias: str | None
+    context_age_seconds: float | None
+    trigger_vote_count: int
+    context_vote_count: int
+    selected_ce: str | None
+    selected_pe: str | None
+    trace_id: str | None = None
+
+
 class StrategyInterface(ABC):
     """Define the standardised contract expected from all strategies."""
 
@@ -1058,6 +1076,7 @@ class StrategyManager(_BaseStrategyManager):
         self._score_cache: dict[str, StrategyScore] = {}
         self._score_floor = 0.05
         self._score_ceiling = 3.0
+        self._last_no_signal_decision_by_symbol: dict[str, StrategyNoSignalDecision] = {}
         self._allocation_state: dict[str, float] = {}
         self._regime_last_key: str | None = None
         self._dynamic_disable_threshold = 0.2
@@ -3275,6 +3294,22 @@ class StrategyManager(_BaseStrategyManager):
     ) -> Signal | None:
         """Args: symbol/signals/indicators. Returns: consensus signal or None. Raises: none."""
         symbol_norm = str(symbol or "").strip().upper()
+        def _record_no_signal(category: str, reason_text: str, blocked_at: str, *, no_vote_reason_counts: dict[str, int] | None = None, strategy_reasons: dict[str, str] | None = None, trigger_vote_count: int = 0, context_vote_count: int = 0) -> None:
+            self._last_no_signal_decision_by_symbol[symbol_norm] = StrategyNoSignalDecision(
+                symbol=symbol_norm,
+                category=category,
+                reason=reason_text,
+                blocked_at=blocked_at,
+                no_vote_reason_counts=dict(no_vote_reason_counts or {}),
+                strategy_reasons=dict(strategy_reasons or {}),
+                direction_bias=str(indicator_map.get("direction_bias") or "").upper() or None,
+                underlying_direction_bias=str(indicator_map.get("underlying_direction_bias") or "").upper() or None,
+                context_age_seconds=float(indicator_map.get("context_age_seconds")) if indicator_map.get("context_age_seconds") is not None else None,
+                trigger_vote_count=trigger_vote_count,
+                context_vote_count=context_vote_count,
+                selected_ce=str(indicator_map.get("selected_ce") or "") or None,
+                selected_pe=str(indicator_map.get("selected_pe") or "") or None,
+            )
         indicator_map = dict(indicators or {})
         selected_symbols = {
             str(indicator_map.get("selected_ce") or "").strip().upper(),
@@ -3425,6 +3460,7 @@ class StrategyManager(_BaseStrategyManager):
                         "context_age_seconds": indicator_map.get("context_age_seconds"),
                     },
                 )
+                _record_no_signal("strategy_no_trigger", "no_trigger_vote", "no_trigger_vote", trigger_vote_count=0, context_vote_count=len(context_votes))
                 return None
         else:
             best_signal, best_vote = max(trigger_votes, key=lambda pair: self._extract_raw_score(pair[1]))
@@ -3590,6 +3626,8 @@ class StrategyManager(_BaseStrategyManager):
                         best_vote.confidence,
                         extra={"event": "TRADE_DECISION_TRACE", "symbol": symbol_norm, "strategy": best_vote.strategy, "side": best_vote.side, "allowed": False, "blocked_at": "single_vote_gate", "blocked_reason": blocked_reason, "selected_ce": selected_ce, "selected_pe": selected_pe, "strike_distance_from_atm": strike_distance_from_atm, "near_atm_threshold": near_atm_threshold, "selected_ok_reason": selected_ok_reason, "raw_score": raw_trigger_score, "confidence": best_vote.confidence},
                     )
+                    category = "strategy_single_vote_disabled" if blocked_reason == "single_vote_scalp_disabled" else ("context_direction_conflict" if blocked_reason == "underlying_direction_conflict" else "strategy_no_trigger")
+                    _record_no_signal(category, blocked_reason, "single_vote_gate", trigger_vote_count=len(trigger_votes), context_vote_count=len(context_votes))
                     return None
         elif trigger_votes:
             metadata_stage = "multi_vote_confirmed"
@@ -3612,6 +3650,7 @@ class StrategyManager(_BaseStrategyManager):
                 symbol_norm, best_vote.strategy, best_vote.side, True, raw_trigger_score, threshold, weighted_trigger_score, _regime_weight(best_vote), context_bonus, context_penalty, final_score, threshold, False, "strategy_manager_combine", blocked_reason,
                 extra={"event": "TRADE_DECISION_TRACE", "symbol": symbol_norm, "strategy": best_vote.strategy, "side": best_vote.side, "data_gate": True, "setup_score": raw_trigger_score, "setup_min": threshold, "weighted_score": weighted_trigger_score, "regime_weight": _regime_weight(best_vote), "context_bonus": context_bonus, "context_penalty": context_penalty, "final_score": final_score, "final_min": threshold, "allowed": False, "blocked_at": "strategy_manager_combine", "blocked_reason": blocked_reason},
             )
+            _record_no_signal("strategy_score_below_threshold", blocked_reason, "strategy_manager_combine", trigger_vote_count=len(trigger_votes), context_vote_count=len(context_votes))
             return None
         quality_score, quality_meta = self._compute_trade_quality_score(
             best_vote,
@@ -3645,6 +3684,7 @@ class StrategyManager(_BaseStrategyManager):
                 "trade_quality_gate",
                 metadata["quality_block_reason"],
             )
+            _record_no_signal("strategy_no_trigger", str(metadata["quality_block_reason"]), "trade_quality_gate", trigger_vote_count=len(trigger_votes), context_vote_count=len(context_votes))
             return None
 
         metadata.setdefault("trigger_strategy_score", metadata.get("strategy_score"))
@@ -3675,6 +3715,9 @@ class StrategyManager(_BaseStrategyManager):
             take_profit=best_signal.take_profit,
             metadata=metadata,
         )
+
+    def get_last_no_signal_decision(self, symbol: str) -> StrategyNoSignalDecision | None:
+        return self._last_no_signal_decision_by_symbol.get(str(symbol or "").strip().upper())
 
     def get_strategy_mode_profile(self) -> dict[str, t.Any]:
         """Return strategy gating profile based on effective execution mode."""

--- a/src/nifty_scalper_bot/core/strategy_manager.py
+++ b/src/nifty_scalper_bot/core/strategy_manager.py
@@ -2110,6 +2110,8 @@ class StrategyManager(_BaseStrategyManager):
         """
 
         symbol = normalize_symbol(symbol)
+        symbol_norm = str(symbol or "").strip().upper()
+        self._last_no_signal_decision_by_symbol.pop(symbol_norm, None)
         log.debug(
             "Entered StrategyManager.generate_signal",
             extra={"event": "scored_strategy_generate", "symbol": symbol},
@@ -3002,6 +3004,32 @@ class StrategyManager(_BaseStrategyManager):
                 indicators=indicators,
                 error_strategies=errors,
             )
+            primary_reason = "no_strategy_signal"
+            category = "strategy_no_trigger"
+            if no_vote_reason_counts.get("underlying_direction_conflict"):
+                primary_reason = "underlying_direction_conflict"
+                category = "context_direction_conflict"
+            elif no_vote_reason_counts.get("weak_score"):
+                primary_reason = "weak_score"
+                category = "strategy_score_below_threshold"
+            elif any(no_vote_reason_counts.get(r) for r in ("no_liquidity_sweep", "premium_not_reversing_up", "smc_structure_required_live")):
+                primary_reason = next((r for r in ("no_liquidity_sweep", "premium_not_reversing_up", "smc_structure_required_live") if no_vote_reason_counts.get(r)), "no_strategy_signal")
+                category = "strategy_no_trigger"
+            elif errors:
+                primary_reason = "strategy_error"
+                category = "strategy_error"
+            self._record_no_signal_decision(
+                symbol=symbol_norm,
+                category=category,
+                reason=primary_reason,
+                blocked_at="generate_signal_no_signals",
+                indicators=indicators,
+                no_vote_reason_counts=no_vote_reason_counts,
+                strategy_reasons=strategy_reasons,
+                trigger_vote_count=0,
+                context_vote_count=0,
+                trace_id=trace_id,
+            )
             _log_reject(
                 "no_strategy_signal",
                 {
@@ -3545,10 +3573,15 @@ class StrategyManager(_BaseStrategyManager):
             metadata["strike_distance_from_atm"] = strike_distance_from_atm
             metadata["is_selected_option"] = selected_option
             metadata["selected_ok_reason"] = selected_ok_reason
+            threshold_passed = bool(raw_trigger_score >= score_min and best_vote.confidence >= conf_min and selected_ok and not vetoed)
+            final_allowed = bool(allow_scalp_single and threshold_passed)
+            blocked_reason = None if final_allowed else ("single_vote_scalp_disabled" if threshold_passed and not allow_scalp_single else "threshold_not_met")
             log.info(
-                "SINGLE_VOTE_DECISION allowed=%s reason=%s strategy=%s raw_score=%.2f weighted_score=%.2f regime_weight=%.2f score_min=%.2f confidence=%.2f conf_min=%.2f selected_ok=%s vetoed=%s",
-                bool(raw_trigger_score >= score_min and best_vote.confidence >= conf_min and selected_ok and not vetoed),
-                "ok",
+                "SINGLE_VOTE_DECISION threshold_passed=%s final_allowed=%s allow_scalp_single=%s reason=%s strategy=%s raw_score=%.2f weighted_score=%.2f regime_weight=%.2f score_min=%.2f confidence=%.2f conf_min=%.2f selected_ok=%s vetoed=%s",
+                threshold_passed,
+                final_allowed,
+                allow_scalp_single,
+                blocked_reason or "ok",
                 best_vote.strategy,
                 raw_trigger_score,
                 weighted_trigger_score,
@@ -3560,6 +3593,11 @@ class StrategyManager(_BaseStrategyManager):
                 vetoed,
                 extra={
                     "event": "SINGLE_VOTE_DECISION",
+                    "allowed": final_allowed,
+                    "threshold_passed": threshold_passed,
+                    "final_allowed": final_allowed,
+                    "allow_scalp_single": allow_scalp_single,
+                    "blocked_reason": blocked_reason,
                     "symbol": symbol_norm,
                     "strategy": best_vote.strategy,
                     "raw_score": raw_trigger_score,
@@ -3718,6 +3756,38 @@ class StrategyManager(_BaseStrategyManager):
 
     def get_last_no_signal_decision(self, symbol: str) -> StrategyNoSignalDecision | None:
         return self._last_no_signal_decision_by_symbol.get(str(symbol or "").strip().upper())
+
+    def _record_no_signal_decision(
+        self,
+        *,
+        symbol: str,
+        category: str,
+        reason: str,
+        blocked_at: str,
+        indicators: t.Mapping[str, t.Any],
+        no_vote_reason_counts: t.Mapping[str, int] | None = None,
+        strategy_reasons: t.Mapping[str, str] | None = None,
+        trigger_vote_count: int = 0,
+        context_vote_count: int = 0,
+        trace_id: str | None = None,
+    ) -> None:
+        symbol_norm = str(symbol or "").strip().upper()
+        self._last_no_signal_decision_by_symbol[symbol_norm] = StrategyNoSignalDecision(
+            symbol=symbol_norm,
+            category=category,
+            reason=reason,
+            blocked_at=blocked_at,
+            no_vote_reason_counts=dict(no_vote_reason_counts or {}),
+            strategy_reasons=dict(strategy_reasons or {}),
+            direction_bias=str(indicators.get("direction_bias") or "").upper() or None,
+            underlying_direction_bias=str(indicators.get("underlying_direction_bias") or "").upper() or None,
+            context_age_seconds=float(indicators.get("context_age_seconds")) if indicators.get("context_age_seconds") is not None else None,
+            trigger_vote_count=trigger_vote_count,
+            context_vote_count=context_vote_count,
+            selected_ce=str(indicators.get("selected_ce") or "") or None,
+            selected_pe=str(indicators.get("selected_pe") or "") or None,
+            trace_id=trace_id,
+        )
 
     def get_strategy_mode_profile(self) -> dict[str, t.Any]:
         """Return strategy gating profile based on effective execution mode."""

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -137,6 +137,16 @@ class PollingPolicy:
             max_symbols=int(getattr(settings, "poll_max_symbols", 12)),
             error_log_throttle_seconds=float(getattr(settings, "poll_error_log_throttle_seconds", 30.0)),
         )
+
+
+@dataclass(frozen=True)
+class FuturesContextRotationResult:
+    symbol: str | None
+    old_symbol: str | None
+    rotated: bool
+    unresolved: bool
+    reason: str
+    source: str
 def canonical_symbol(symbol: str) -> str:
     """Canonicalize symbols (including NIFTY spot aliases) to EXCHANGE:SYMBOL."""
     normalized = enforce_canonical(normalize_symbol(str(symbol or "")))
@@ -6571,6 +6581,22 @@ class MarketDataManager:
                 best_symbol = f"NFO:{tradingsymbol}"
         return best_symbol
 
+    def _resolve_active_nifty_future_from_instruments(self, instruments: Iterable[Mapping[str, Any]], now: datetime | None = None) -> str | None:
+        ref_now = now or datetime.now(timezone.utc)
+        best_symbol: str | None = None
+        best_expiry: datetime | None = None
+        for row in instruments:
+            if not isinstance(row, Mapping) or not _is_nifty_index_future_row(row):
+                continue
+            tradingsymbol = str(row.get("tradingsymbol") or row.get("symbol") or "").upper()
+            expiry = _parse_instrument_expiry(row.get("expiry"))
+            if expiry is None or expiry < ref_now:
+                continue
+            if best_expiry is None or expiry < best_expiry:
+                best_expiry = expiry
+                best_symbol = f"NFO:{tradingsymbol}"
+        return best_symbol
+
     def maybe_rotate_nifty_futures_context(
         self,
         current_symbol: str | None,
@@ -6579,38 +6605,69 @@ class MarketDataManager:
         trace_id: str | None = None,
         now: datetime | None = None,
     ) -> str | None:
+        return self.maybe_rotate_nifty_futures_context_result(
+            current_symbol,
+            reason=reason,
+            trace_id=trace_id,
+            now=now,
+        ).symbol
+
+    def maybe_rotate_nifty_futures_context_result(
+        self,
+        current_symbol: str | None,
+        *,
+        reason: str,
+        trace_id: str | None = None,
+        now: datetime | None = None,
+        selected_option_symbols: Sequence[str] | None = None,
+    ) -> FuturesContextRotationResult:
         active = self.resolve_active_nifty_future_symbol(now=now)
+        source = "resolver"
+        selected_symbols = [str(s or "") for s in (selected_option_symbols or []) if s]
+        if not active:
+            broker_instruments = getattr(self._broker, "instruments", None)
+            if callable(broker_instruments):
+                try:
+                    rows = broker_instruments("NFO") or []
+                    resolved = self._resolve_active_nifty_future_from_instruments(rows, now=now)
+                    if resolved:
+                        active = resolved
+                        source = "broker_instruments"
+                except Exception:
+                    pass
+        if not active and selected_symbols:
+            months: set[str] = set()
+            for symbol in selected_symbols:
+                match = re.search(r"NIFTY(\d{2}[A-Z]{3})\d{5}(CE|PE)$", str(symbol).upper())
+                if match:
+                    months.add(match.group(1))
+            if len(months) == 1:
+                candidate = f"NFO:NIFTY{next(iter(months))}FUT"
+                if _NIFTY_FUT_RE.match(candidate.split(":", 1)[-1]):
+                    active = candidate
+                    source = "selected_option_month"
+                    self._logger.warning(
+                        "FUTURES_CONTEXT_FALLBACK_FROM_SELECTED_OPTION old_symbol=%s new_symbol=%s reason=%s source=%s",
+                        current_symbol, active, reason, source,
+                        extra={"event": "FUTURES_CONTEXT_FALLBACK_FROM_SELECTED_OPTION", "old_symbol": current_symbol, "new_symbol": active, "reason": reason, "source": source, "selected_ce": selected_symbols[0] if selected_symbols else None, "selected_pe": selected_symbols[1] if len(selected_symbols) > 1 else None, "trace_id": trace_id},
+                    )
         if not active:
             self._logger.warning(
                 "FUTURES_CONTEXT_STALE_OR_UNRESOLVED current_symbol=%s reason=%s",
-                current_symbol,
-                reason,
-                extra={
-                    "event": "FUTURES_CONTEXT_STALE_OR_UNRESOLVED",
-                    "current_symbol": current_symbol,
-                    "reason": reason,
-                    "trace_id": trace_id,
-                },
+                current_symbol, reason,
+                extra={"event": "FUTURES_CONTEXT_STALE_OR_UNRESOLVED", "current_symbol": current_symbol, "reason": reason, "trace_id": trace_id, "source": "unresolved"},
             )
-            return current_symbol
+            return FuturesContextRotationResult(current_symbol, current_symbol, False, True, reason, "unresolved")
         if current_symbol and self._canonical_symbol(current_symbol) == self._canonical_symbol(active):
-            return current_symbol
+            return FuturesContextRotationResult(current_symbol, current_symbol, False, False, reason, source)
         old_symbol = current_symbol
         self.request_symbol_subscription(active)
         self._logger.warning(
             "FUTURES_CONTEXT_SYMBOL_ROTATED old_symbol=%s new_symbol=%s reason=%s",
-            old_symbol,
-            active,
-            reason,
-            extra={
-                "event": "FUTURES_CONTEXT_SYMBOL_ROTATED",
-                "old_symbol": old_symbol,
-                "new_symbol": active,
-                "reason": reason,
-                "trace_id": trace_id,
-            },
+            old_symbol, active, reason,
+            extra={"event": "FUTURES_CONTEXT_SYMBOL_ROTATED", "old_symbol": old_symbol, "new_symbol": active, "reason": reason, "trace_id": trace_id, "source": source},
         )
-        return active
+        return FuturesContextRotationResult(active, old_symbol, True, False, reason, source)
 
     def get_symbol_snapshot(self, symbol: str) -> MarketSnapshot:
         """Return a unified MarketSnapshot for one symbol."""

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -6636,6 +6636,8 @@ class MarketDataManager:
                 except Exception:
                     pass
         if not active and selected_symbols:
+            selected_ce = next((s for s in selected_symbols if str(s).upper().endswith("CE")), None)
+            selected_pe = next((s for s in selected_symbols if str(s).upper().endswith("PE")), None)
             months: set[str] = set()
             for symbol in selected_symbols:
                 match = re.search(r"NIFTY(\d{2}[A-Z]{3})\d{5}(CE|PE)$", str(symbol).upper())
@@ -6649,7 +6651,7 @@ class MarketDataManager:
                     self._logger.warning(
                         "FUTURES_CONTEXT_FALLBACK_FROM_SELECTED_OPTION old_symbol=%s new_symbol=%s reason=%s source=%s",
                         current_symbol, active, reason, source,
-                        extra={"event": "FUTURES_CONTEXT_FALLBACK_FROM_SELECTED_OPTION", "old_symbol": current_symbol, "new_symbol": active, "reason": reason, "source": source, "selected_ce": selected_symbols[0] if selected_symbols else None, "selected_pe": selected_symbols[1] if len(selected_symbols) > 1 else None, "trace_id": trace_id},
+                        extra={"event": "FUTURES_CONTEXT_FALLBACK_FROM_SELECTED_OPTION", "old_symbol": current_symbol, "new_symbol": active, "reason": reason, "source": source, "selected_ce": selected_ce, "selected_pe": selected_pe, "trace_id": trace_id},
                     )
         if not active:
             self._logger.warning(
@@ -6657,7 +6659,7 @@ class MarketDataManager:
                 current_symbol, reason,
                 extra={"event": "FUTURES_CONTEXT_STALE_OR_UNRESOLVED", "current_symbol": current_symbol, "reason": reason, "trace_id": trace_id, "source": "unresolved"},
             )
-            return FuturesContextRotationResult(current_symbol, current_symbol, False, True, reason, "unresolved")
+            return FuturesContextRotationResult(None, current_symbol, False, True, reason, "unresolved")
         if current_symbol and self._canonical_symbol(current_symbol) == self._canonical_symbol(active):
             return FuturesContextRotationResult(current_symbol, current_symbol, False, False, reason, source)
         old_symbol = current_symbol

--- a/src/nifty_scalper_bot/execution/order_manager.py
+++ b/src/nifty_scalper_bot/execution/order_manager.py
@@ -3300,10 +3300,20 @@ class OrderManager:
         """Validate TradePlan and delegate to place_managed_order/place_order."""
         symbol = normalize_symbol(plan.symbol)
         if self.is_kill_switch_active():
+            ks = self.get_kill_switch_status()
+            self._logger.warning(
+                "ORDER_MANAGER_KILL_SWITCH_REJECTED symbol=%s reason=%s broker_attempted=False consecutive_failures=%s kill_reason=%s trace_id=%s",
+                symbol,
+                "order_manager_kill_switch_active",
+                ks.get("consecutive_failures"),
+                ks.get("last_reason"),
+                plan.trace_id,
+                extra={"event": "ORDER_MANAGER_KILL_SWITCH_REJECTED", "symbol": symbol, "reason": "order_manager_kill_switch_active", "broker_attempted": False, "kill_switch_status": ks, "trace_id": plan.trace_id},
+            )
             return TradePlanSubmitResult(
                 False,
                 reason="order_manager_kill_switch_active",
-                details={"kill_switch_status": self.get_kill_switch_status(), "symbol": symbol, "trace_id": plan.trace_id},
+                details={"kill_switch_status": ks, "symbol": symbol, "trace_id": plan.trace_id},
                 broker_attempted=False,
             )
         validation = self._validate_trade_plan(plan)

--- a/src/nifty_scalper_bot/execution/order_manager.py
+++ b/src/nifty_scalper_bot/execution/order_manager.py
@@ -3301,19 +3301,20 @@ class OrderManager:
         symbol = normalize_symbol(plan.symbol)
         if self.is_kill_switch_active():
             ks = self.get_kill_switch_status()
+            kill_reason = ks.get("kill_reason") or ks.get("last_reason") or ks.get("reason") or ks.get("last_exception_type")
             self._logger.warning(
                 "ORDER_MANAGER_KILL_SWITCH_REJECTED symbol=%s reason=%s broker_attempted=False consecutive_failures=%s kill_reason=%s trace_id=%s",
                 symbol,
                 "order_manager_kill_switch_active",
                 ks.get("consecutive_failures"),
-                ks.get("last_reason"),
+                kill_reason,
                 plan.trace_id,
                 extra={"event": "ORDER_MANAGER_KILL_SWITCH_REJECTED", "symbol": symbol, "reason": "order_manager_kill_switch_active", "broker_attempted": False, "kill_switch_status": ks, "trace_id": plan.trace_id},
             )
             return TradePlanSubmitResult(
                 False,
                 reason="order_manager_kill_switch_active",
-                details={"kill_switch_status": ks, "symbol": symbol, "trace_id": plan.trace_id},
+                details={"kill_switch_status": ks, "kill_reason": kill_reason, "symbol": symbol, "trace_id": plan.trace_id},
                 broker_attempted=False,
             )
         validation = self._validate_trade_plan(plan)

--- a/src/nifty_scalper_bot/execution/order_manager.py
+++ b/src/nifty_scalper_bot/execution/order_manager.py
@@ -3299,6 +3299,13 @@ class OrderManager:
     def submit_trade_plan_result(self, plan: TradePlan) -> TradePlanSubmitResult:
         """Validate TradePlan and delegate to place_managed_order/place_order."""
         symbol = normalize_symbol(plan.symbol)
+        if self.is_kill_switch_active():
+            return TradePlanSubmitResult(
+                False,
+                reason="order_manager_kill_switch_active",
+                details={"kill_switch_status": self.get_kill_switch_status(), "symbol": symbol, "trace_id": plan.trace_id},
+                broker_attempted=False,
+            )
         validation = self._validate_trade_plan(plan)
         if not validation.allowed:
             self._logger.warning(
@@ -7177,7 +7184,18 @@ class OrderManager:
             self._last_broker_health_emit_ts = now
             self._last_broker_health_effect = str(snapshot["trading_allowed_effect"])
             self._last_broker_health_circuit_state = bool(snapshot["margin_circuit_open"])
-            self._logger.info("BROKER_HEALTH_STATUS", extra={"event": "BROKER_HEALTH_STATUS", **snapshot})
+            self._logger.info(
+                "BROKER_HEALTH_STATUS broker_connected=%s margin_api_available=%s order_api_available=%s margin_circuit_open=%s balance_stale=%s trading_allowed_effect=%s last_order_api_error_type=%s last_margin_error_type=%s",
+                snapshot.get("broker_connected"),
+                snapshot.get("margin_api_available"),
+                snapshot.get("order_api_available"),
+                snapshot.get("margin_circuit_open"),
+                snapshot.get("balance_stale"),
+                snapshot.get("trading_allowed_effect"),
+                snapshot.get("last_order_api_error_type"),
+                snapshot.get("last_margin_error_type"),
+                extra={"event": "BROKER_HEALTH_STATUS", **snapshot},
+            )
         except Exception as exc:  # noqa: BLE001
             with suppress(Exception):
                 self._logger.debug(

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -6565,6 +6565,7 @@ class StrategyRunner:
     def _classify_no_trade_decision(
         self,
         *,
+        symbol: str,
         signal: Any | None,
         indicators_ctx: Mapping[str, Any],
         option_count: int,
@@ -6573,7 +6574,7 @@ class StrategyRunner:
     ) -> tuple[str, str]:
         latest_decision_getter = getattr(self._strategy_manager, "get_last_no_signal_decision", None)
         if callable(latest_decision_getter):
-            decision = latest_decision_getter(str(indicators_ctx.get("symbol") or ""))
+            decision = latest_decision_getter(symbol)
             if decision is not None:
                 return str(getattr(decision, "category", "strategy_no_trigger")), str(getattr(decision, "reason", "strategy_no_trigger"))
         if broker_attempted:
@@ -6775,6 +6776,14 @@ class StrategyRunner:
                         old_fut_symbol = fut_symbol
                         rotate_result = getattr(self._market_data, "maybe_rotate_nifty_futures_context_result", None)
                         rotated = rotate_result(fut_symbol, reason="context_futures_unresolved", trace_id=trace_id, selected_option_symbols=[self._active_selected_ce, self._active_selected_pe]) if callable(rotate_result) else self._market_data.maybe_rotate_nifty_futures_context(fut_symbol, reason="context_futures_unresolved", trace_id=trace_id)
+                        if bool(getattr(rotated, "unresolved", False)):
+                            self._logger.warning(
+                                "CONTEXT_FUTURES_UNRESOLVED_ACTIVE_RESOLUTION_FAILED old_symbol=%s reason=%s",
+                                fut_symbol,
+                                "context_futures_unresolved",
+                                extra={"event": "CONTEXT_FUTURES_UNRESOLVED_ACTIVE_RESOLUTION_FAILED", "old_symbol": fut_symbol, "trace_id": trace_id},
+                            )
+                            fut_symbol = ""
                         rotated_symbol = getattr(rotated, "symbol", rotated)
                         if rotated_symbol and rotated_symbol != fut_symbol:
                             self._active_symbols.discard(fut_symbol)
@@ -8670,6 +8679,7 @@ class StrategyRunner:
                             option_required = self._required_bars_for_symbol(symbol)
                             option_count = len(self._indicator_engine.get_history(symbol) or [])
                             category, reason = self._classify_no_trade_decision(
+                                symbol=symbol,
                                 signal=None,
                                 indicators_ctx=indicators_ctx,
                                 option_count=option_count,

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -166,6 +166,17 @@ def _env_bool(name: str, default: bool = False) -> bool:
     return str(raw).strip().lower() in {"1", "true", "yes", "y", "on"}
 
 
+def _safe_positive_float(value: object, fallback: float, *, minimum: float = 0.0) -> float:
+    fallback_value = max(float(fallback), float(minimum))
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return fallback_value
+    if parsed <= 0:
+        return fallback_value
+    return max(parsed, float(minimum))
+
+
 _STRATEGY_SKIP_COUNTER = Counter(
     "strategy_skips_total", "Strategy skip counts by reason", ["reason"]
 )
@@ -740,7 +751,10 @@ class StrategyRunner:
         self.ready = False
         self._active_symbols: set[str] = set()
         self._suspended_context_symbols: set[str] = set()
+        self._suspended_context_symbol_until: dict[str, float] = {}
         self._order_failure_cooldown_until: dict[str, float] = {}
+        self._order_failure_cooldown_seconds = _safe_positive_float(os.getenv("ORDER_FAILURE_COOLDOWN_SECONDS"), 120.0, minimum=1.0)
+        self._futures_context_suspension_seconds = _safe_positive_float(os.getenv("FUTURES_CONTEXT_SUSPENSION_SECONDS"), 300.0, minimum=1.0)
         self._tracked_symbols: set[str] = set()
         self._live_symbols: set[str] = set()
         self._symbol_state: Dict[str, SymbolRuntimeState] = {}
@@ -6564,6 +6578,17 @@ class StrategyRunner:
         value = str(symbol or "").upper()
         return value == "NSE:NIFTY" or (value.startswith("NFO:NIFTY") and value.endswith("FUT"))
 
+    def _is_context_symbol_suspended(self, symbol: str) -> bool:
+        until = self._suspended_context_symbol_until.get(symbol)
+        if until is None:
+            return False
+        if time.monotonic() >= until:
+            self._suspended_context_symbol_until.pop(symbol, None)
+            self._suspended_context_symbols.discard(symbol)
+            self._logger.info("CONTEXT_FUTURES_SYMBOL_SUSPENSION_EXPIRED symbol=%s", symbol, extra={"event": "CONTEXT_FUTURES_SYMBOL_SUSPENSION_EXPIRED", "symbol": symbol})
+            return False
+        return True
+
     def _classify_no_trade_decision(
         self,
         *,
@@ -6751,7 +6776,7 @@ class StrategyRunner:
                                 trace_id=trace_id,
                             )
                         spot_bars = len(self._indicator_engine.get_history("NSE:NIFTY") or [])
-                        fut_symbol = next((sym for sym in self._active_symbols if self._is_context_symbol(sym) and sym != "NSE:NIFTY"), "")
+                        fut_symbol = next((sym for sym in self._active_symbols if self._is_context_symbol(sym) and sym != "NSE:NIFTY" and not self._is_context_symbol_suspended(sym)), "")
                         fut_bars = len(self._indicator_engine.get_history(fut_symbol) or []) if fut_symbol else 0
                         if (spot_bars < self._context_required_bars or fut_bars < self._context_required_bars) and self._should_log_throttled(f"opt_ctx_cold:{symbol}", 120.0):
                             self._logger.warning("OPTION_EVAL_BLOCKED_CONTEXT_COLD option=%s spot_bars=%d futures_bars=%d required=%d", symbol, spot_bars, fut_bars, self._context_required_bars)
@@ -6765,7 +6790,7 @@ class StrategyRunner:
                     is_selected_option = normalize_symbol(symbol) in selected_symbols
                     option_eval_min_live_bars = int(os.getenv("OPTION_EVAL_MIN_LIVE_BARS", "1") or "1")
                     spot_symbol = "NSE:NIFTY"
-                    fut_symbol = next((sym for sym in self._active_symbols if self._symbol_role_for_runner(sym) == "futures_context"), "")
+                    fut_symbol = next((sym for sym in self._active_symbols if self._symbol_role_for_runner(sym) == "futures_context" and not self._is_context_symbol_suspended(sym)), "")
                     if not fut_symbol and self._should_log_throttled("fut_unresolved", 120.0):
                         self._logger.warning("CONTEXT_FUTURES_UNRESOLVED symbol=%s", symbol)
                     if not fut_symbol and hasattr(self._market_data, "maybe_rotate_nifty_futures_context"):
@@ -6783,13 +6808,15 @@ class StrategyRunner:
                             if stale_symbol:
                                 self._active_symbols.discard(stale_symbol)
                                 self._suspended_context_symbols.add(stale_symbol)
+                                cooldown_seconds = self._futures_context_suspension_seconds
+                                self._suspended_context_symbol_until[stale_symbol] = time.monotonic() + cooldown_seconds
                                 self._logger.warning(
                                     "CONTEXT_FUTURES_SYMBOL_SUSPENDED symbol=%s reason=%s trace_id=%s cooldown_seconds=%s",
                                     stale_symbol,
                                     "active_future_resolution_failed",
                                     trace_id,
-                                    300,
-                                    extra={"event": "CONTEXT_FUTURES_SYMBOL_SUSPENDED", "symbol": stale_symbol, "reason": "active_future_resolution_failed", "trace_id": trace_id, "cooldown_seconds": 300},
+                                    cooldown_seconds,
+                                    extra={"event": "CONTEXT_FUTURES_SYMBOL_SUSPENDED", "symbol": stale_symbol, "reason": "active_future_resolution_failed", "trace_id": trace_id, "cooldown_seconds": cooldown_seconds},
                                 )
                             self._logger.warning(
                                 "CONTEXT_FUTURES_UNRESOLVED_ACTIVE_RESOLUTION_FAILED old_symbol=%s reason=%s",
@@ -11306,7 +11333,7 @@ class StrategyRunner:
                     if submit_result.reason == "broker_placement_exception":
                         error_type = str((submit_details or {}).get("error_type") or "unknown")
                         cd_key = f"{base_symbol}|{signal.action}|{strategy_name}|{error_type}"
-                        cd_seconds = float(os.getenv("ORDER_FAILURE_COOLDOWN_SECONDS", "120") or "120")
+                        cd_seconds = self._order_failure_cooldown_seconds
                         self._order_failure_cooldown_until[cd_key] = now_epoch + cd_seconds
                         self._logger.warning(
                             "ORDER_FAILURE_COOLDOWN_MARKED symbol=%s side=%s strategy=%s error_type=%s cooldown_seconds=%s trace_id=%s",

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -6571,6 +6571,11 @@ class StrategyRunner:
         option_required: int,
         broker_attempted: bool = False,
     ) -> tuple[str, str]:
+        latest_decision_getter = getattr(self._strategy_manager, "get_last_no_signal_decision", None)
+        if callable(latest_decision_getter):
+            decision = latest_decision_getter(str(indicators_ctx.get("symbol") or ""))
+            if decision is not None:
+                return str(getattr(decision, "category", "strategy_no_trigger")), str(getattr(decision, "reason", "strategy_no_trigger"))
         if broker_attempted:
             return "broker_placement_failed", "broker_attempted_failed"
         if option_count < option_required:
@@ -6599,6 +6604,21 @@ class StrategyRunner:
         option_history_count: int | None = None,
         option_history_required: int | None = None,
     ) -> None:
+        if self._is_context_symbol(symbol):
+            self._logger.info(
+                "RUNNER_CONTEXT_EVAL_STATUS symbol=%s category=%s reason=%s",
+                symbol,
+                category,
+                reason,
+                extra={
+                    "event": "RUNNER_CONTEXT_EVAL_STATUS",
+                    "symbol": symbol,
+                    "trace_id": trace_id,
+                    "category": category,
+                    "reason": reason,
+                },
+            )
+            return
         try:
             ctx = dict(indicators_ctx or {})
             self._logger.info(
@@ -6746,21 +6766,20 @@ class StrategyRunner:
                     if not fut_symbol and self._should_log_throttled("fut_unresolved", 120.0):
                         self._logger.warning("CONTEXT_FUTURES_UNRESOLVED symbol=%s", symbol)
                     if not fut_symbol and hasattr(self._market_data, "maybe_rotate_nifty_futures_context"):
-                        rotated = self._market_data.maybe_rotate_nifty_futures_context(
-                            None, reason="context_futures_missing", trace_id=trace_id
-                        )
-                        if rotated:
-                            fut_symbol = str(rotated)
+                        rotate_result = getattr(self._market_data, "maybe_rotate_nifty_futures_context_result", None)
+                        rotated = rotate_result(None, reason="context_futures_missing", trace_id=trace_id, selected_option_symbols=[self._active_selected_ce, self._active_selected_pe]) if callable(rotate_result) else self._market_data.maybe_rotate_nifty_futures_context(None, reason="context_futures_missing", trace_id=trace_id)
+                        if getattr(rotated, "symbol", rotated):
+                            fut_symbol = str(getattr(rotated, "symbol", rotated))
                             self._active_symbols.add(fut_symbol)
                     if fut_symbol and hasattr(self._market_data, "maybe_rotate_nifty_futures_context"):
                         old_fut_symbol = fut_symbol
-                        rotated = self._market_data.maybe_rotate_nifty_futures_context(
-                            fut_symbol, reason="context_futures_unresolved", trace_id=trace_id
-                        )
-                        if rotated and rotated != fut_symbol:
+                        rotate_result = getattr(self._market_data, "maybe_rotate_nifty_futures_context_result", None)
+                        rotated = rotate_result(fut_symbol, reason="context_futures_unresolved", trace_id=trace_id, selected_option_symbols=[self._active_selected_ce, self._active_selected_pe]) if callable(rotate_result) else self._market_data.maybe_rotate_nifty_futures_context(fut_symbol, reason="context_futures_unresolved", trace_id=trace_id)
+                        rotated_symbol = getattr(rotated, "symbol", rotated)
+                        if rotated_symbol and rotated_symbol != fut_symbol:
                             self._active_symbols.discard(fut_symbol)
-                            self._active_symbols.add(str(rotated))
-                            fut_symbol = str(rotated)
+                            self._active_symbols.add(str(rotated_symbol))
+                            fut_symbol = str(rotated_symbol)
                             self._logger.info(
                                 "RUNNER_FUTURES_CONTEXT_ROTATED old_symbol=%s new_symbol=%s",
                                 old_fut_symbol,

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -739,6 +739,8 @@ class StrategyRunner:
         self._trading_paused = False
         self.ready = False
         self._active_symbols: set[str] = set()
+        self._suspended_context_symbols: set[str] = set()
+        self._order_failure_cooldown_until: dict[str, float] = {}
         self._tracked_symbols: set[str] = set()
         self._live_symbols: set[str] = set()
         self._symbol_state: Dict[str, SymbolRuntimeState] = {}
@@ -6572,11 +6574,6 @@ class StrategyRunner:
         option_required: int,
         broker_attempted: bool = False,
     ) -> tuple[str, str]:
-        latest_decision_getter = getattr(self._strategy_manager, "get_last_no_signal_decision", None)
-        if callable(latest_decision_getter):
-            decision = latest_decision_getter(symbol)
-            if decision is not None:
-                return str(getattr(decision, "category", "strategy_no_trigger")), str(getattr(decision, "reason", "strategy_no_trigger"))
         if broker_attempted:
             return "broker_placement_failed", "broker_attempted_failed"
         if option_count < option_required:
@@ -6588,6 +6585,11 @@ class StrategyRunner:
         if not direction_bias:
             return "context_direction_unavailable", "direction_context_not_ready"
         if signal is None:
+            latest_decision_getter = getattr(self._strategy_manager, "get_last_no_signal_decision", None)
+            if callable(latest_decision_getter):
+                decision = latest_decision_getter(symbol)
+                if decision is not None:
+                    return str(getattr(decision, "category", "strategy_no_trigger")), str(getattr(decision, "reason", "strategy_no_trigger"))
             return "strategy_no_trigger", "evaluation_no_signal"
         if not self._runtime_live_orders_armed:
             return "execution_readiness_false", str(self._runtime_readiness_reason or "runtime_live_orders_not_armed")
@@ -6777,9 +6779,21 @@ class StrategyRunner:
                         rotate_result = getattr(self._market_data, "maybe_rotate_nifty_futures_context_result", None)
                         rotated = rotate_result(fut_symbol, reason="context_futures_unresolved", trace_id=trace_id, selected_option_symbols=[self._active_selected_ce, self._active_selected_pe]) if callable(rotate_result) else self._market_data.maybe_rotate_nifty_futures_context(fut_symbol, reason="context_futures_unresolved", trace_id=trace_id)
                         if bool(getattr(rotated, "unresolved", False)):
+                            stale_symbol = old_fut_symbol
+                            if stale_symbol:
+                                self._active_symbols.discard(stale_symbol)
+                                self._suspended_context_symbols.add(stale_symbol)
+                                self._logger.warning(
+                                    "CONTEXT_FUTURES_SYMBOL_SUSPENDED symbol=%s reason=%s trace_id=%s cooldown_seconds=%s",
+                                    stale_symbol,
+                                    "active_future_resolution_failed",
+                                    trace_id,
+                                    300,
+                                    extra={"event": "CONTEXT_FUTURES_SYMBOL_SUSPENDED", "symbol": stale_symbol, "reason": "active_future_resolution_failed", "trace_id": trace_id, "cooldown_seconds": 300},
+                                )
                             self._logger.warning(
                                 "CONTEXT_FUTURES_UNRESOLVED_ACTIVE_RESOLUTION_FAILED old_symbol=%s reason=%s",
-                                fut_symbol,
+                                stale_symbol,
                                 "context_futures_unresolved",
                                 extra={"event": "CONTEXT_FUTURES_UNRESOLVED_ACTIVE_RESOLUTION_FAILED", "old_symbol": fut_symbol, "trace_id": trace_id},
                             )
@@ -11200,6 +11214,15 @@ class StrategyRunner:
                 or signal.metadata.get("strategy")
                 or "runner"
             )
+            failure_cd_prefix = f"{base_symbol}|{signal.action}|{strategy_name}|"
+            failure_cd_until = max((float(v) for k, v in self._order_failure_cooldown_until.items() if str(k).startswith(failure_cd_prefix)), default=0.0)
+            if now_epoch < failure_cd_until:
+                self._logger.warning(
+                    "ORDER_FAILURE_COOLDOWN_ACTIVE symbol=%s side=%s strategy=%s cooldown_remaining_s=%.1f trace_id=%s",
+                    base_symbol, signal.action, strategy_name, failure_cd_until - now_epoch, trace_id,
+                    extra={"event": "ORDER_FAILURE_COOLDOWN_ACTIVE", "symbol": base_symbol, "side": signal.action, "strategy": strategy_name, "cooldown_until": failure_cd_until, "trace_id": trace_id},
+                )
+                return self._reject_signal_execution(symbol=base_symbol, trace_id=trace_id, reason="order_failure_cooldown_active")
 
             if not self._transition_execution_state(
                 base_symbol, ExecutionState.ORDER_PENDING
@@ -11280,6 +11303,16 @@ class StrategyRunner:
                         base_symbol, order_symbol, submit_result.reason, submit_reason, submit_result.broker_attempted, trace_id,
                         extra={"event": "RUNNER_ORDER_MANAGER_REJECTED", "symbol": base_symbol, "order_symbol": order_symbol, "reason": submit_result.reason, "runner_reason": submit_reason, "broker_attempted": submit_result.broker_attempted, "details": submit_details, "trace_id": trace_id},
                     )
+                    if submit_result.reason == "broker_placement_exception":
+                        error_type = str((submit_details or {}).get("error_type") or "unknown")
+                        cd_key = f"{base_symbol}|{signal.action}|{strategy_name}|{error_type}"
+                        cd_seconds = float(os.getenv("ORDER_FAILURE_COOLDOWN_SECONDS", "120") or "120")
+                        self._order_failure_cooldown_until[cd_key] = now_epoch + cd_seconds
+                        self._logger.warning(
+                            "ORDER_FAILURE_COOLDOWN_MARKED symbol=%s side=%s strategy=%s error_type=%s cooldown_seconds=%s trace_id=%s",
+                            base_symbol, signal.action, strategy_name, error_type, cd_seconds, trace_id,
+                            extra={"event": "ORDER_FAILURE_COOLDOWN_MARKED", "symbol": base_symbol, "side": signal.action, "strategy": strategy_name, "error_type": error_type, "cooldown_seconds": cd_seconds, "trace_id": trace_id},
+                        )
             else:
                 order_id = self._order_manager.submit_trade_plan(plan)
                 broker_attempted = True

--- a/tests/core/test_strategy_manager_consensus.py
+++ b/tests/core/test_strategy_manager_consensus.py
@@ -96,6 +96,18 @@ def test_single_vote_scalp_disabled_rejects_single_vote(monkeypatch) -> None:
     assert combined is None
 
 
+def test_strategy_manager_records_single_vote_disabled_decision(monkeypatch) -> None:
+    monkeypatch.setenv('STRATEGY_ALLOW_SINGLE_VOTE_SCALP', 'false')
+    manager = _manager_stub()
+    manager._last_no_signal_decision_by_symbol = {}
+    signal = _make_signal()
+    vote = StrategyVote(strategy='VWAPPro', side='CE', score=7.5, confidence=0.8, reasons=[], metadata={})
+    manager._combine_strategy_votes(symbol='NFO:NIFTY25000CE', signals=[(signal, vote)], indicators={'selected_ce': 'NFO:NIFTY25000CE'})
+    decision = manager.get_last_no_signal_decision('NFO:NIFTY25000CE')
+    assert decision is not None
+    assert decision.reason == 'single_vote_scalp_disabled'
+
+
 
 def test_context_only_vote_returns_none_and_logs(caplog) -> None:
     manager = _manager_stub()

--- a/tests/core/test_strategy_manager_single_vote_disabled_reason.py
+++ b/tests/core/test_strategy_manager_single_vote_disabled_reason.py
@@ -40,3 +40,5 @@ def test_single_vote_scalp_disabled_reason(monkeypatch, caplog):
     assert combined is None
     assert any('single_vote_scalp_disabled' in r.message for r in caplog.records)
     assert not any('blocked_reason=context_veto' in r.message for r in caplog.records)
+    svd = next(r for r in caplog.records if "SINGLE_VOTE_DECISION" in r.message)
+    assert getattr(svd, "final_allowed", False) is False

--- a/tests/core/test_strategy_manager_single_vote_disabled_reason.py
+++ b/tests/core/test_strategy_manager_single_vote_disabled_reason.py
@@ -42,3 +42,16 @@ def test_single_vote_scalp_disabled_reason(monkeypatch, caplog):
     assert not any('blocked_reason=context_veto' in r.message for r in caplog.records)
     svd = next(r for r in caplog.records if "SINGLE_VOTE_DECISION" in r.message)
     assert getattr(svd, "final_allowed", False) is False
+
+
+def test_single_vote_decision_high_conviction_final_allowed_true_even_when_scalp_disabled(monkeypatch, caplog):
+    monkeypatch.setenv('STRATEGY_ALLOW_SINGLE_VOTE_SCALP', 'false')
+    monkeypatch.setenv('STRATEGY_SINGLE_VOTE_HIGH_CONVICTION', '8.8')
+    manager = StrategyManager.__new__(StrategyManager)
+    signal = Signal(action='BUY', symbol='NFO:NIFTY25000CE', quantity=1, confidence=0.9, reason='VWAPPro', stop_loss=1.0, take_profit=2.0, metadata={'is_selected_option': True})
+    vote = StrategyVote(strategy='VWAPPro', side='CE', score=9.2, confidence=0.9, reasons=[], metadata={'raw_setup_score': 9.2, 'regime_weight': 1.0})
+    with caplog.at_level(logging.INFO):
+        combined = manager._combine_strategy_votes(symbol=signal.symbol, signals=[(signal, vote)], indicators={})
+    assert combined is not None
+    svd = next(r for r in caplog.records if "SINGLE_VOTE_DECISION" in r.message)
+    assert getattr(svd, "final_allowed", False) is True

--- a/tests/data/test_market_data_manager.py
+++ b/tests/data/test_market_data_manager.py
@@ -1310,3 +1310,21 @@ def test_coerce_timestamp_prefers_exchange_timestamp() -> None:
     tick = {"exchange_timestamp": "2026-05-06T10:00:00+00:00", "timestamp": 0}
     coerced = MarketDataManager._coerce_timestamp(tick)  # noqa: SLF001
     assert coerced > 1_700_000_000
+
+
+def test_selected_option_month_fallback_rotates_may_future_to_jun_future(ws: DummyWebSocket) -> None:
+    manager = MarketDataManager(DummyBroker(), ws, resolver=None)
+    out = manager.maybe_rotate_nifty_futures_context_result(
+        "NFO:NIFTY26MAYFUT",
+        reason="test",
+        selected_option_symbols=["NFO:NIFTY26JUN23950CE", "NFO:NIFTY26JUN23950PE"],
+    )
+    assert out.symbol == "NFO:NIFTY26JUNFUT"
+    assert out.rotated is True
+
+
+def test_maybe_rotate_unresolved_returns_symbol_none(ws: DummyWebSocket) -> None:
+    manager = MarketDataManager(DummyBroker(), ws, resolver=None)
+    out = manager.maybe_rotate_nifty_futures_context_result("NFO:NIFTY26MAYFUT", reason="no_data")
+    assert out.unresolved is True
+    assert out.symbol is None

--- a/tests/execution/test_order_manager_trade_plan.py
+++ b/tests/execution/test_order_manager_trade_plan.py
@@ -51,6 +51,7 @@ def test_submit_trade_plan_kill_switch_returns_kill_switch_reason_without_broker
     out = OrderManager.submit_trade_plan_result(m, TradePlan(symbol='NFO:NIFTY', side='BUY', quantity=75, entry_price=100.0, stop_loss=90.0, take_profit=110.0, trace_id="t1"))
     assert out.reason == "order_manager_kill_switch_active"
     assert out.broker_attempted is False
+    assert out.details.get("kill_reason") == "unexpected_exception"
 
 
 def test_managed_order_local_reject_does_not_attempt_broker() -> None:

--- a/tests/execution/test_order_manager_trade_plan.py
+++ b/tests/execution/test_order_manager_trade_plan.py
@@ -44,6 +44,15 @@ def test_preflight_reject_does_not_attempt_broker() -> None:
     assert out.broker_attempted is False
 
 
+def test_submit_trade_plan_kill_switch_returns_kill_switch_reason_without_broker_attempt() -> None:
+    m = _manager_stub()
+    m.is_kill_switch_active = lambda: True
+    m.get_kill_switch_status = lambda: {"active": True, "consecutive_failures": 3, "last_reason": "unexpected_exception"}
+    out = OrderManager.submit_trade_plan_result(m, TradePlan(symbol='NFO:NIFTY', side='BUY', quantity=75, entry_price=100.0, stop_loss=90.0, take_profit=110.0, trace_id="t1"))
+    assert out.reason == "order_manager_kill_switch_active"
+    assert out.broker_attempted is False
+
+
 def test_managed_order_local_reject_does_not_attempt_broker() -> None:
     m = _manager_stub()
     m._lot_size_for_symbol = lambda s: 50

--- a/tests/strategies/test_runner_live_path_guards.py
+++ b/tests/strategies/test_runner_live_path_guards.py
@@ -2404,6 +2404,31 @@ def test_runner_rejects_broker_placement_exception_with_details(monkeypatch) -> 
     result = runner._handle_entry_signal_inner(signal, sym, sym, 100.0, datetime.now(timezone.utc), trace_id='bpx-1')
     assert result.reason == 'order_manager_broker_placement_exception'
     assert result.details.get('error_type') == 'RuntimeError'
+    assert any(str(k).startswith(f'{sym}|BUY|OrderFlow|RuntimeError') for k in runner._order_failure_cooldown_until.keys())
+
+
+def test_failure_cooldown_blocks_immediate_same_symbol_retry_without_broker_attempt(monkeypatch) -> None:
+    runner = _build_runner()
+    monkeypatch.setenv('EXECUTION_MODE', 'LIVE'); monkeypatch.setenv('ENABLE_LIVE_TRADING', 'true'); monkeypatch.setenv('PAPER__ENABLED', 'false'); monkeypatch.setenv('SHADOW_MODE', 'false')
+    sym='NFO:NIFTY26MAY23700PE'
+    runner._is_symbol_execution_ready = MagicMock(return_value=True)
+    runner._ensure_symbol_execution_ready_result = MagicMock(return_value=ExecutionReadinessResult(True,'ok',{}))
+    runner._trade_candidate_selector.select_ranked_candidates = MagicMock(return_value=[SimpleNamespace(symbol=sym, stop_loss=300.0, target=450.0, score=8.0, data_quality_score=9.0, spread_pct=0.1, rr=2.0, side='PE', entry_price=110.0, tick_age_s=0.1)])
+    runner._order_failure_cooldown_until[f"{sym}|BUY|OrderFlow|RuntimeError"] = time.time() + 60.0
+    runner._order_manager.submit_trade_plan_result = MagicMock(return_value=SimpleNamespace(accepted=True, order_id='oid', reason='accepted', details={}, broker_attempted=True))
+    signal=Signal(action='BUY',symbol=sym,quantity=1,confidence=0.9,reason='OrderFlow',stop_loss=300.0,take_profit=450.0,metadata={'strategy_name':'OrderFlow','candidate_snapshots':[{'symbol':sym,'side':'PE','strike':23700,'atm_strike':23700,'ltp':110.0,'bid':109.5,'ask':110.0,'tick_age_s':0.1,'tradable_quote':True}]})
+    result = runner._handle_entry_signal_inner(signal, sym, sym, 100.0, datetime.now(timezone.utc), trace_id='cooldown')
+    assert result.reason == "order_failure_cooldown_active"
+    runner._order_manager.submit_trade_plan_result.assert_not_called()
+
+
+def test_suspended_future_ttl_expiry_allows_reconsideration() -> None:
+    runner = _build_runner()
+    sym = "NFO:NIFTY26MAYFUT"
+    runner._suspended_context_symbols.add(sym)
+    runner._suspended_context_symbol_until[sym] = time.monotonic() - 1.0
+    assert runner._is_context_symbol_suspended(sym) is False
+    assert sym not in runner._suspended_context_symbols
 
 
 def test_entry_exception_rolls_back_dedup(monkeypatch) -> None:

--- a/tests/strategies/test_runner_readiness_diagnostics.py
+++ b/tests/strategies/test_runner_readiness_diagnostics.py
@@ -5,7 +5,7 @@ import time
 from types import SimpleNamespace
 
 from nifty_scalper_bot.data.market_data_manager import MarketDataManager
-from nifty_scalper_bot.strategies.runner import StrategyRunner
+from nifty_scalper_bot.strategies.runner import StrategyRunner, _safe_positive_float
 
 
 class _DummyIndicator:
@@ -225,6 +225,18 @@ def test_runner_history_cold_overrides_stale_strategy_no_signal_decision() -> No
     category, reason = runner._classify_no_trade_decision(symbol="NFO:CE", signal=None, indicators_ctx={}, option_count=1, option_required=5, broker_attempted=False)  # type: ignore[attr-defined]
     assert category == "data_history_cold"
     assert reason == "insufficient_indicator_bar_count"
+
+
+def test_order_failure_cooldown_invalid_env_does_not_crash() -> None:
+    assert _safe_positive_float("abc", 120.0, minimum=1.0) == 120.0
+
+
+def test_order_failure_cooldown_zero_env_uses_default() -> None:
+    assert _safe_positive_float("0", 120.0, minimum=1.0) == 120.0
+
+
+def test_order_failure_cooldown_negative_env_uses_default() -> None:
+    assert _safe_positive_float("-5", 120.0, minimum=1.0) == 120.0
 
 
 def test_runner_emits_no_trade_decision_on_history_cold_eval_block(caplog) -> None:

--- a/tests/strategies/test_runner_readiness_diagnostics.py
+++ b/tests/strategies/test_runner_readiness_diagnostics.py
@@ -219,6 +219,14 @@ def test_runner_no_trade_uses_strategy_decision_by_symbol_even_when_indicators_l
     assert reason == "single_vote_scalp_disabled"
 
 
+def test_runner_history_cold_overrides_stale_strategy_no_signal_decision() -> None:
+    runner = _make_runner()
+    runner._strategy_manager = SimpleNamespace(get_last_no_signal_decision=lambda _sym: SimpleNamespace(category="strategy_single_vote_disabled", reason="single_vote_scalp_disabled"))
+    category, reason = runner._classify_no_trade_decision(symbol="NFO:CE", signal=None, indicators_ctx={}, option_count=1, option_required=5, broker_attempted=False)  # type: ignore[attr-defined]
+    assert category == "data_history_cold"
+    assert reason == "insufficient_indicator_bar_count"
+
+
 def test_runner_emits_no_trade_decision_on_history_cold_eval_block(caplog) -> None:
     runner = _make_runner()
     runner._active_symbols = {"NFO:CE"}

--- a/tests/strategies/test_runner_readiness_diagnostics.py
+++ b/tests/strategies/test_runner_readiness_diagnostics.py
@@ -160,6 +160,7 @@ def test_stale_selected_symbol_does_not_arm_live_orders(caplog) -> None:
 def test_no_trade_decision_reports_history_cold_not_broker(caplog) -> None:
     runner = _make_runner()
     category, reason = runner._classify_no_trade_decision(  # type: ignore[attr-defined]
+        symbol="NFO:CE",
         signal=None,
         indicators_ctx={},
         option_count=1,
@@ -173,6 +174,7 @@ def test_no_trade_decision_reports_history_cold_not_broker(caplog) -> None:
 def test_runner_no_trade_decision_reports_context_direction_unavailable() -> None:
     runner = _make_runner()
     category, _ = runner._classify_no_trade_decision(  # type: ignore[attr-defined]
+        symbol="NFO:CE",
         signal=None,
         indicators_ctx={},
         option_count=10,
@@ -185,6 +187,7 @@ def test_runner_no_trade_decision_reports_context_direction_unavailable() -> Non
 def test_runner_no_trade_decision_reports_context_direction_conflict() -> None:
     runner = _make_runner()
     category, _ = runner._classify_no_trade_decision(  # type: ignore[attr-defined]
+        symbol="NFO:CE",
         signal=None,
         indicators_ctx={"direction_conflict": True},
         option_count=10,
@@ -198,6 +201,7 @@ def test_runner_no_trade_decision_reports_strategy_no_trigger_when_data_ready_bu
     runner = _make_runner()
     runner._runtime_live_orders_armed = False
     category, _ = runner._classify_no_trade_decision(  # type: ignore[attr-defined]
+        symbol="NFO:CE",
         signal=None,
         indicators_ctx={"direction_bias": "CE"},
         option_count=10,
@@ -205,6 +209,14 @@ def test_runner_no_trade_decision_reports_strategy_no_trigger_when_data_ready_bu
         broker_attempted=False,
     )
     assert category == "strategy_no_trigger"
+
+
+def test_runner_no_trade_uses_strategy_decision_by_symbol_even_when_indicators_lacks_symbol() -> None:
+    runner = _make_runner()
+    runner._strategy_manager = SimpleNamespace(get_last_no_signal_decision=lambda sym: SimpleNamespace(category="strategy_single_vote_disabled", reason="single_vote_scalp_disabled") if sym == "NFO:CE" else None)
+    category, reason = runner._classify_no_trade_decision(symbol="NFO:CE", signal=None, indicators_ctx={}, option_count=10, option_required=5, broker_attempted=False)  # type: ignore[attr-defined]
+    assert category == "strategy_single_vote_disabled"
+    assert reason == "single_vote_scalp_disabled"
 
 
 def test_runner_emits_no_trade_decision_on_history_cold_eval_block(caplog) -> None:


### PR DESCRIPTION
### Motivation
- Logs showed stale NIFTY FUT (MAY) being queried, contradictory no-trade diagnostics, and broker/kill-switch rejections being misclassified which prevented valid live trades while preserving safety.
- The intent is to ensure futures context is rotated/fallback safely, no-trade reasons reflect StrategyManager decisions, and order-manager kill-switch/broker failures are reported with correct taxonomy and richer diagnostics.

### Description
- Added structured futures-rotation API and result type `FuturesContextRotationResult` with resolver → broker-instruments → selected-option-month fallback and explicit unresolved/rotated events in `src/nifty_scalper_bot/data/market_data_manager.py`.
- Wired runner to call the structured rotation result and pass selected CE/PE symbols, and converted context-only symbol no-trade emissions to `RUNNER_CONTEXT_EVAL_STATUS` in `src/nifty_scalper_bot/strategies/runner.py` to avoid terminal no-trade events for context symbols.
- Introduced `StrategyNoSignalDecision` storage in `src/nifty_scalper_bot/core/strategy_manager.py` and recorded structured no-signal decisions for key blocked paths so the runner can emit the correct `RUNNER_NO_TRADE_DECISION` category/reason from StrategyManager metadata.
- Added a pre-broker kill-switch guard returning `order_manager_kill_switch_active` with `broker_attempted=False` and expanded plain-text `BROKER_HEALTH_STATUS` fields for clearer logs in `src/nifty_scalper_bot/execution/order_manager.py`.

### Testing
- Ran static/compile and focused test suite with: `python -m compileall -q src tests` and `pytest -q tests/data/test_market_data_manager.py tests/strategies/test_runner_readiness_diagnostics.py tests/core/test_strategy_manager_consensus.py tests/core/test_strategy_manager_single_vote_disabled_reason.py tests/execution/test_order_manager_trade_plan.py` and observed successful completion.
- Test result summary: `compileall: pass` and `pytest: 118 passed` for the targeted runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1689d85e34832488b20b1adccdfda7)