### PR TITLE
Hotfix: guard StrategyRunner runtime indicators in phase10 live execution

### DIFF
--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -661,6 +661,8 @@ class StrategyRunner:
         self._runtime_execution_ready_by_symbol: dict[str, bool] = {}
         self._runtime_symbol_last_ready_at: dict[str, float] = {}
         self._runtime_readiness_reason: str | None = None
+        self._runtime_indicators: dict[str, dict[str, Any]] = {}
+        self._last_direction_context: dict[str, Any] | None = None
         self._runtime_startup_ready = False
         self._startup_gate_last_log_ts = 0.0
         self._active_selected_ce: str | None = None
@@ -6710,7 +6712,8 @@ class StrategyRunner:
         details["kill_switch_status"] = ks_status
         if ks_active:
             return False, "order_manager_kill_switch_active", details
-        ctx = self._runtime_indicators.get(symbol, {}) or {}
+        runtime_indicators = getattr(self, "_runtime_indicators", {}) or {}
+        ctx = runtime_indicators.get(symbol, {}) or {}
         contract_side = self._contract_side_from_symbol(symbol)
         direction_bias = str(ctx.get("underlying_direction_bias") or ctx.get("direction_bias") or "").upper()
         details["contract_side"] = contract_side
@@ -7057,11 +7060,15 @@ class StrategyRunner:
                     )
                     if soft_pass and not context_ready:
                         self._logger.warning("LIVE_CONTEXT_COLD_CONTINUE domain=futures penalty=quality_threshold_plus_1")
-                        self._runtime_indicators.setdefault(symbol, {})
-                        self._runtime_indicators[symbol]["underlying_context_quality"] = "cold"
-                        self._runtime_indicators[symbol]["futures_context_quality"] = "cold" if fut_symbol else "missing"
-                        self._runtime_indicators[symbol]["context_confidence_multiplier"] = 0.75
-                        self._runtime_indicators[symbol]["context_cold_reasons"] = ["spot_context_cold" if spot_bars < self._context_required_bars else "", "futures_context_cold" if fut_bars < self._context_required_bars else ""]
+                        runtime_indicators = getattr(self, "_runtime_indicators", None)
+                        if runtime_indicators is None:
+                            self._runtime_indicators = {}
+                            runtime_indicators = self._runtime_indicators
+                        runtime_indicators.setdefault(symbol, {})
+                        runtime_indicators[symbol]["underlying_context_quality"] = "cold"
+                        runtime_indicators[symbol]["futures_context_quality"] = "cold" if fut_symbol else "missing"
+                        runtime_indicators[symbol]["context_confidence_multiplier"] = 0.75
+                        runtime_indicators[symbol]["context_cold_reasons"] = ["spot_context_cold" if spot_bars < self._context_required_bars else "", "futures_context_cold" if fut_bars < self._context_required_bars else ""]
                     if soft_pass:
                         self._logger.info(
                             "EVALUATION_ALLOWED_COLD_HISTORY_SOFT_PASS symbol=%s bars=%d required=%d",
@@ -8880,6 +8887,18 @@ class StrategyRunner:
                             or indicators_ctx.get("underlying_direction_confidence")
                             or 0.0
                         )
+                        runtime_indicators = getattr(self, "_runtime_indicators", None)
+                        if runtime_indicators is None:
+                            self._runtime_indicators = {}
+                            runtime_indicators = self._runtime_indicators
+                        runtime_indicators[symbol] = {
+                            **(runtime_indicators.get(symbol, {}) or {}),
+                            "direction_bias": indicators_ctx.get("direction_bias"),
+                            "underlying_direction_bias": indicators_ctx.get("underlying_direction_bias"),
+                            "context_age_seconds": indicators_ctx.get("context_age_seconds"),
+                            "underlying_direction_confidence": indicators_ctx.get("underlying_direction_confidence"),
+                        }
+                        self._last_direction_context = runtime_indicators[symbol]
                         spot_fresh = bool(indicators_ctx.get("spot_fresh"))
                         if spot_fresh and not direction_bias and not underlying_bias:
                             self._logger.warning(

--- a/tests/strategies/test_runner_live_path_guards.py
+++ b/tests/strategies/test_runner_live_path_guards.py
@@ -259,6 +259,28 @@ def test_order_acceptance_notifies_orchestrator_entry() -> None:
     assert notified["symbol"] == 'NFO:NIFTY26APR23800CE'
     assert notified["reason"] == "order_accepted"
 
+
+def test_phase10_no_runtime_indicators_attribute_logs_clean_block_not_runner_error(caplog) -> None:
+    runner = _build_runner()
+    runner._runtime_live_orders_armed = True
+    runner._is_tradable_symbol = lambda _s: True
+    runner._order_manager_kill_switch_status_for_entry = lambda: (True, {"active": True})
+    if hasattr(runner, "_runtime_indicators"):
+        delattr(runner, "_runtime_indicators")
+    with caplog.at_level(logging.INFO):
+        ready, reason, details = runner._symbol_live_entry_ready("NFO:NIFTY26JUN23800PE", trace_id="phase10-guard")
+        runner._reject_signal_execution(
+            symbol="NFO:NIFTY26JUN23800PE",
+            trace_id="phase10-guard",
+            reason=reason,
+            details=details,
+        )
+    assert ready is False
+    assert reason == "order_manager_kill_switch_active"
+    events = {getattr(r, "event", "") for r in caplog.records}
+    assert "RUNNER_ON_TICK_ERROR" not in events
+    assert "SIGNAL_EXECUTION_RESULT" in events
+
 def test_selected_option_prewarm_accepts_sync_hydrator_list_result(caplog) -> None:
     runner = _build_runner()
     runner._logger = logging.getLogger("test.runner.prewarm.sync")

--- a/tests/strategies/test_runner_readiness_diagnostics.py
+++ b/tests/strategies/test_runner_readiness_diagnostics.py
@@ -45,7 +45,32 @@ def _make_runner() -> StrategyRunner:
     runner._selected_option_symbol_for_side = lambda side, _metadata: "NFO:CE" if side == "CE" else "NFO:PE"
     runner._is_option_symbol_tick_fresh = lambda _sym, max_age_s=60.0: True
     runner._is_symbol_execution_ready = lambda _sym: False
+    runner._runtime_indicators = {}
     return runner
+
+
+def test_runtime_indicators_initialized_in_constructor() -> None:
+    runner = _make_runner()
+    assert hasattr(runner, "_runtime_indicators")
+    assert isinstance(runner._runtime_indicators, dict)
+
+
+def test_symbol_live_entry_ready_no_runtime_indicators_attribute_does_not_crash() -> None:
+    runner = _make_runner()
+    if hasattr(runner, "_runtime_indicators"):
+        delattr(runner, "_runtime_indicators")
+    runner._runtime_live_orders_armed = True
+    runner._is_tradable_symbol = lambda _s: True
+    runner._order_manager_kill_switch_status_for_entry = lambda: (False, {})
+    runner._contract_side_from_symbol = lambda _s: "PE"
+    runner._get_cached_quote_for_live_entry = lambda _s: {"tradable_quote": True, "depth_available": True, "spread_pct": 0.1}
+    runner._active_atm_strike = 23800
+    runner._extract_strike_from_symbol = lambda _s: 23800
+    runner._indicator_engine = _DummyIndicator({"NFO:NIFTY26JUN23800PE": [1, 2, 3, 4, 5, 6]})
+    runner._required_bars_for_symbol = lambda _s: 1
+    ready, reason, _details = runner._symbol_live_entry_ready("NFO:NIFTY26JUN23800PE", trace_id="t-no-attr")
+    assert reason in {"symbol_live_ready", "quote_depth_unavailable", "spread_unknown", "spread_too_wide", "broker_health_live_orders_blocked"}
+    assert isinstance(ready, bool)
 
 
 def test_live_trading_readiness_snapshot_emitted(caplog) -> None:


### PR DESCRIPTION
### Motivation
- A `StrategyRunner` could enter phase10 signal execution and access `self._runtime_indicators` when that attribute was not present, causing an `AttributeError` and crashing the runner before clean readiness rejection or safe blocking.
- The change ensures phase10/phase9 paths produce clean readiness diagnostics instead of raising when runtime context is missing.

### Description
- Initialize runtime containers in `StrategyRunner.__init__` by adding `self._runtime_indicators: dict[str, dict[str, Any]] = {}` and `self._last_direction_context: dict[str, Any] | None = None` to guarantee existence on new instances.
- Make reads defensive in `_symbol_live_entry_ready` by using `runtime_indicators = getattr(self, "_runtime_indicators", {}) or {}` and reading `ctx = runtime_indicators.get(symbol, {}) or {}` to avoid `AttributeError` when the attribute is absent.
- Make writes defensive in the phase9 cold-context path by lazily creating `_runtime_indicators` when missing and storing cold-context metadata under `runtime_indicators[symbol]` instead of assuming the dict exists.
- Persist latest direction context during strategy evaluation into `self._runtime_indicators[symbol]` and mirror it to `self._last_direction_context` so later phase10 checks have access to recent direction context.
- Modified files: `src/nifty_scalper_bot/strategies/runner.py`, `tests/strategies/test_runner_readiness_diagnostics.py`, `tests/strategies/test_runner_live_path_guards.py`.

### Testing
- Ran compile and focused tests: `python -m compileall -q src tests` and `pytest -q tests/strategies/test_runner_readiness_diagnostics.py tests/strategies/test_runner_live_path_guards.py tests/core/test_strategy_manager_consensus.py`; all passed.
- Ran broader test suites: `pytest -q tests/data tests/strategies tests/execution tests/core tests/test_live_readiness_gate.py`; all tests passed.
- Added tests: `test_runtime_indicators_initialized_in_constructor`, `test_symbol_live_entry_ready_no_runtime_indicators_attribute_does_not_crash`, and `test_phase10_no_runtime_indicators_attribute_logs_clean_block_not_runner_error`, which verify the runner no longer raises `AttributeError` and emits clean readiness/blocking events.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16a523894083249caefc1646fd4b4a)