### PR TITLE
Fix live PE consensus blockers — cache-only tick freshness & strict live context staleness

### DIFF
--- a/src/nifty_scalper_bot/core/strategy_manager.py
+++ b/src/nifty_scalper_bot/core/strategy_manager.py
@@ -3347,6 +3347,7 @@ class StrategyManager(_BaseStrategyManager):
         symbol: str,
         signals: list[tuple[Signal, StrategyVote]],
         indicators: t.Mapping[str, t.Any],
+        no_vote_reason_counts: t.Mapping[str, int] | None = None,
     ) -> Signal | None:
         """Args: symbol/signals/indicators. Returns: consensus signal or None. Raises: none."""
         symbol_norm = str(symbol or "").strip().upper()
@@ -3788,7 +3789,7 @@ class StrategyManager(_BaseStrategyManager):
         spread_pct = float(metadata.get("spread_pct") or indicator_map.get("spread_pct") or 999.0)
         selected_ok_combined = bool(selected_ok or near_atm)
         quote_depth_ok = bool(metadata.get("quote_depth_valid") or indicator_map.get("quote_depth_valid") or metadata.get("tradable_quote") or indicator_map.get("tradable_quote"))
-        no_vote_counts = dict(indicator_map.get("no_vote_reason_counts") or {}) if isinstance(indicator_map.get("no_vote_reason_counts"), dict) else {}
+        no_vote_counts = dict(no_vote_reason_counts or indicator_map.get("no_vote_reason_counts") or {})
         hard_veto_reasons = [r for r in ("underlying_direction_conflict", "negative_premium_flow", "smc_structure_required_live") if no_vote_counts.get(r)]
         two_trigger_aligned = bool(
             len(trigger_votes) >= 2
@@ -3797,7 +3798,7 @@ class StrategyManager(_BaseStrategyManager):
             and context_age_seconds <= max_context_age
             and selected_ok_combined
             and quote_depth_ok
-            and spread_pct <= float(os.getenv("LIVE_MAX_SPREAD_PCT", "0.75") or "0.75")
+            and spread_pct <= self._env_float("LIVE_MAX_SPREAD_PCT", 0.75)
             and quality_pass
             and not hard_veto_reasons
             and not no_vote_counts.get("negative_premium_flow")

--- a/src/nifty_scalper_bot/core/strategy_manager.py
+++ b/src/nifty_scalper_bot/core/strategy_manager.py
@@ -3779,6 +3779,33 @@ class StrategyManager(_BaseStrategyManager):
             _record_no_signal("strategy_no_trigger", str(metadata["quality_block_reason"]), "trade_quality_gate", trigger_vote_count=len(trigger_votes), context_vote_count=len(context_votes))
             return None
 
+        direction_bias = str(indicator_map.get("direction_bias") or indicator_map.get("underlying_direction_bias") or "").upper()
+        max_context_age = self._live_context_max_age_seconds()
+        try:
+            context_age_seconds = float(indicator_map.get("context_age_seconds"))
+        except (TypeError, ValueError):
+            context_age_seconds = 999.0
+        spread_pct = float(metadata.get("spread_pct") or indicator_map.get("spread_pct") or 999.0)
+        selected_ok_combined = bool(selected_ok or near_atm)
+        quote_depth_ok = bool(metadata.get("quote_depth_valid") or indicator_map.get("quote_depth_valid") or metadata.get("tradable_quote") or indicator_map.get("tradable_quote"))
+        no_vote_counts = dict(indicator_map.get("no_vote_reason_counts") or {}) if isinstance(indicator_map.get("no_vote_reason_counts"), dict) else {}
+        hard_veto_reasons = [r for r in ("underlying_direction_conflict", "negative_premium_flow", "smc_structure_required_live") if no_vote_counts.get(r)]
+        two_trigger_aligned = bool(
+            len(trigger_votes) >= 2
+            and best_vote.side in {"CE", "PE"}
+            and direction_bias == str(best_vote.side).upper()
+            and context_age_seconds <= max_context_age
+            and selected_ok_combined
+            and quote_depth_ok
+            and spread_pct <= float(os.getenv("LIVE_MAX_SPREAD_PCT", "0.75") or "0.75")
+            and quality_pass
+            and not hard_veto_reasons
+            and not no_vote_counts.get("negative_premium_flow")
+        )
+        if two_trigger_aligned:
+            approval_path = "aligned_two_trigger_consensus"
+            log.info("CONSENSUS_SIGNAL_APPROVED symbol=%s side=%s approval_path=%s trigger_vote_count=%s context_vote_count=%s", symbol_norm, best_vote.side, approval_path, len(trigger_votes), len(context_votes), extra={"event":"CONSENSUS_SIGNAL_APPROVED","symbol":symbol_norm,"side":best_vote.side,"approval_path":"aligned_two_trigger_consensus","trigger_vote_count":len(trigger_votes),"context_vote_count":len(context_votes),"ignored_neutral_no_votes":[r for r in ("smc_insufficient_history","strategy_feature_unavailable") if no_vote_counts.get(r)],"hard_veto_reasons":hard_veto_reasons,"trade_quality_score":quality_score,"direction_bias":direction_bias,"context_age_seconds":context_age_seconds,"spread_pct":spread_pct,"selected_ok":bool(selected_ok),"near_atm_ok":bool(near_atm)})
+
         metadata.setdefault("trigger_strategy_score", metadata.get("strategy_score"))
         metadata["setup_score"] = round(raw_trigger_score, 3)
         metadata["raw_setup_score"] = round(raw_trigger_score, 3)

--- a/src/nifty_scalper_bot/core/strategy_manager.py
+++ b/src/nifty_scalper_bot/core/strategy_manager.py
@@ -3082,6 +3082,7 @@ class StrategyManager(_BaseStrategyManager):
             symbol=symbol,
             signals=signal_votes,
             indicators=indicators,
+            no_vote_reason_counts=no_vote_reason_counts,
         )
         if combined and bool(getattr(combined, "metadata", {}).get("is_approved")):
             exit_result = "signal"
@@ -3790,7 +3791,14 @@ class StrategyManager(_BaseStrategyManager):
         selected_ok_combined = bool(selected_ok or near_atm)
         quote_depth_ok = bool(metadata.get("quote_depth_valid") or indicator_map.get("quote_depth_valid") or metadata.get("tradable_quote") or indicator_map.get("tradable_quote"))
         no_vote_counts = dict(no_vote_reason_counts or indicator_map.get("no_vote_reason_counts") or {})
-        hard_veto_reasons = [r for r in ("underlying_direction_conflict", "negative_premium_flow", "smc_structure_required_live") if no_vote_counts.get(r)]
+        neutral_no_votes = {"smc_insufficient_history", "strategy_feature_unavailable"}
+        hard_veto_reasons: list[str] = []
+        if no_vote_counts.get("underlying_direction_conflict"):
+            hard_veto_reasons.append("underlying_direction_conflict")
+        if no_vote_counts.get("negative_premium_flow"):
+            hard_veto_reasons.append("negative_premium_flow")
+        if no_vote_counts.get("smc_structure_required_live"):
+            hard_veto_reasons.append("smc_structure_required_live")
         two_trigger_aligned = bool(
             len(trigger_votes) >= 2
             and best_vote.side in {"CE", "PE"}
@@ -3805,7 +3813,7 @@ class StrategyManager(_BaseStrategyManager):
         )
         if two_trigger_aligned:
             approval_path = "aligned_two_trigger_consensus"
-            log.info("CONSENSUS_SIGNAL_APPROVED symbol=%s side=%s approval_path=%s trigger_vote_count=%s context_vote_count=%s", symbol_norm, best_vote.side, approval_path, len(trigger_votes), len(context_votes), extra={"event":"CONSENSUS_SIGNAL_APPROVED","symbol":symbol_norm,"side":best_vote.side,"approval_path":"aligned_two_trigger_consensus","trigger_vote_count":len(trigger_votes),"context_vote_count":len(context_votes),"ignored_neutral_no_votes":[r for r in ("smc_insufficient_history","strategy_feature_unavailable") if no_vote_counts.get(r)],"hard_veto_reasons":hard_veto_reasons,"trade_quality_score":quality_score,"direction_bias":direction_bias,"context_age_seconds":context_age_seconds,"spread_pct":spread_pct,"selected_ok":bool(selected_ok),"near_atm_ok":bool(near_atm)})
+            log.info("CONSENSUS_SIGNAL_APPROVED symbol=%s side=%s approval_path=%s trigger_vote_count=%s context_vote_count=%s", symbol_norm, best_vote.side, approval_path, len(trigger_votes), len(context_votes), extra={"event":"CONSENSUS_SIGNAL_APPROVED","symbol":symbol_norm,"side":best_vote.side,"approval_path":"aligned_two_trigger_consensus","trigger_vote_count":len(trigger_votes),"context_vote_count":len(context_votes),"ignored_neutral_no_votes":[r for r in neutral_no_votes if no_vote_counts.get(r)],"hard_veto_reasons":hard_veto_reasons,"trade_quality_score":quality_score,"direction_bias":direction_bias,"context_age_seconds":context_age_seconds,"spread_pct":spread_pct,"selected_ok":bool(selected_ok),"near_atm_ok":bool(near_atm)})
 
         metadata.setdefault("trigger_strategy_score", metadata.get("strategy_score"))
         metadata["setup_score"] = round(raw_trigger_score, 3)

--- a/src/nifty_scalper_bot/core/strategy_manager.py
+++ b/src/nifty_scalper_bot/core/strategy_manager.py
@@ -2639,7 +2639,7 @@ class StrategyManager(_BaseStrategyManager):
             context_snapshots = getattr(self, "_latest_context_snapshots", {})
             spot_ctx = context_snapshots.get("spot_context", {})
             fut_ctx = context_snapshots.get("futures_context", {})
-            max_context_age = self._env_float("STRATEGY_CONTEXT_MAX_AGE_SECONDS", 120.0)
+            max_context_age = self._live_context_max_age_seconds()
             now_ts = time.time()
             def _fresh(ctx: t.Mapping[str, t.Any]) -> bool:
                 try:
@@ -3277,6 +3277,14 @@ class StrategyManager(_BaseStrategyManager):
             return float(os.getenv(name, str(default)) or default)
         except (TypeError, ValueError):
             return float(default)
+
+
+    def _live_context_max_age_seconds(self) -> float:
+        """Args: none. Returns: live context max age seconds. Raises: none."""
+        default_age = self._env_float("MAX_CONTEXT_AGE_SECONDS", 5.0)
+        if self._is_live_mode():
+            return max(0.1, default_age)
+        return max(0.1, self._env_float("STRATEGY_CONTEXT_MAX_AGE_SECONDS", 120.0))
 
     def _extract_raw_score(self, vote: StrategyVote) -> float:
         """Args: vote. Returns: raw score. Raises: none."""
@@ -3930,7 +3938,7 @@ class StrategyManager(_BaseStrategyManager):
             live_min_score = self._env_float("STRATEGY_CONTEXT_PROMOTION_LIVE_MIN_SCORE", 8.5)
             live_min_conf = self._env_float("STRATEGY_CONTEXT_PROMOTION_LIVE_MIN_CONFIDENCE", 0.75)
             max_spread = self._env_float("STRATEGY_MAX_SPREAD_PCT", 12.0)
-            max_context_age = self._env_float("STRATEGY_CONTEXT_MAX_AGE_SECONDS", 120.0)
+            max_context_age = self._live_context_max_age_seconds()
             try:
                 spread_pct = float(md0.get("spread_pct") or indicators.get("spread_pct") or 999.0)
             except (TypeError, ValueError):
@@ -4027,7 +4035,7 @@ class StrategyManager(_BaseStrategyManager):
             md0.get("context_fresh")
             if md0.get("context_fresh") is not None
             else indicators.get("context_fresh")
-        ) and context_age_seconds <= self._env_float("STRATEGY_CONTEXT_MAX_AGE_SECONDS", 120.0)
+        ) and context_age_seconds <= self._live_context_max_age_seconds()
         conf_raw = md0.get("underlying_direction_confidence")
         if conf_raw is None:
             conf_raw = indicators.get("underlying_direction_confidence")

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -2022,6 +2022,18 @@ class MarketDataManager:
             await asyncio.sleep(0.1)
         raise RuntimeError("Live tick unavailable")
 
+    def _extract_ltp_from_quote(self, quote: Mapping[str, Any]) -> float | None:
+        for key in ("ltp", "last_price", "price", "close"):
+            try:
+                value = quote.get(key)
+                if value is not None:
+                    parsed = float(value)
+                    if parsed > 0:
+                        return parsed
+            except (TypeError, ValueError):
+                continue
+        return None
+
     def get_cached_ltp(
         self,
         symbol: str,
@@ -2034,11 +2046,9 @@ class MarketDataManager:
         if canonical_symbol in getattr(self, "_suspended_context_symbols", set()):
             with self._lock:
                 cached_tick = self._latest_ticks.get(canonical_symbol)
-            if isinstance(cached_tick, Mapping) and cached_tick:
-                cached_quote = dict(cached_tick)
-                cached_quote.setdefault("source", "cache")
-                return cached_quote
-            return {"symbol": canonical_symbol, "quote_unavailable_reason": "suspended_stale_future"}
+            if isinstance(cached_tick, Mapping):
+                return self._extract_ltp_from_quote(cached_tick)
+            return None
         tick = self.get_latest_tick(canonical_symbol)
         if not isinstance(tick, Mapping):
             return None
@@ -2051,13 +2061,7 @@ class MarketDataManager:
         ).lower()
         if require_ws and source not in {"ws", "ws_full", "full"}:
             return None
-        price = _coerce_positive_float(
-            tick.get("last_price")
-            or tick.get("ltp")
-            or tick.get("price")
-            or tick.get("close")
-        )
-        return float(price) if price and price > 0 else None
+        return self._extract_ltp_from_quote(tick)
 
     def get_ltp(
         self,

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -2031,6 +2031,14 @@ class MarketDataManager:
     ) -> float | None:
         """Cached-only LTP accessor. Args: symbol/guards. Returns: ltp. Raises: none."""
         canonical_symbol = self._canonical_symbol(symbol)
+        if canonical_symbol in getattr(self, "_suspended_context_symbols", set()):
+            with self._lock:
+                cached_tick = self._latest_ticks.get(canonical_symbol)
+            if isinstance(cached_tick, Mapping) and cached_tick:
+                cached_quote = dict(cached_tick)
+                cached_quote.setdefault("source", "cache")
+                return cached_quote
+            return {"symbol": canonical_symbol, "quote_unavailable_reason": "suspended_stale_future"}
         tick = self.get_latest_tick(canonical_symbol)
         if not isinstance(tick, Mapping):
             return None
@@ -2477,6 +2485,14 @@ class MarketDataManager:
             self._quote_direct_miss_reason.pop(symbol_key, None)
 
         canonical_symbol = self._canonical_symbol(symbol)
+        if canonical_symbol in getattr(self, "_suspended_context_symbols", set()):
+            with self._lock:
+                cached_tick = self._latest_ticks.get(canonical_symbol)
+            if isinstance(cached_tick, Mapping) and cached_tick:
+                cached_quote = dict(cached_tick)
+                cached_quote.setdefault("source", "cache")
+                return cached_quote
+            return {"symbol": canonical_symbol, "quote_unavailable_reason": "suspended_stale_future"}
         candidates: list[str | int] = self._candidate_quote_keys(canonical_symbol)
         if not candidates:
             candidates = [canonical_symbol]
@@ -5153,6 +5169,13 @@ class MarketDataManager:
                         % (tick.get("symbol"), exc),
                         interval_sec=10.0,
                         level=logging.ERROR,
+                    )
+                    log_throttled(
+                        self._logger,
+                        "mdm_bus_backpressure",
+                        "MDM_BUS_BACKPRESSURE symbol=%s dropped_ticks=%s coalesced_ticks=%s latest_cache_updated=True" % (tick.get("symbol"), 1, 1),
+                        interval_sec=10.0,
+                        level=logging.WARNING,
                     )
 
             future.add_done_callback(_done)

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -325,6 +325,8 @@ class MarketDataManager:
         self._account_snapshot: dict[str, float] = {}
         self._account_updated_at: float = 0.0
         self._tracked_symbols: set[str] = set()
+        self._suspended_context_symbols: set[str] = set()
+        self._suspended_context_symbol_until: dict[str, float] = {}
         self._active_subscribed_symbols: set[str] = set()
         self._symbols_with_tick: set[str] = set()
         self._ticks_received_per_symbol: dict[str, int] = defaultdict(int)
@@ -2022,6 +2024,31 @@ class MarketDataManager:
             await asyncio.sleep(0.1)
         raise RuntimeError("Live tick unavailable")
 
+
+    def suspend_context_symbol(self, symbol: str, *, reason: str, ttl_s: float = 300.0) -> None:
+        canonical = self._canonical_symbol(symbol)
+        ttl = max(1.0, float(ttl_s or 300.0))
+        self._suspended_context_symbols.add(canonical)
+        self._suspended_context_symbol_until[canonical] = time.monotonic() + ttl
+        self._logger.warning(
+            "CONTEXT_SYMBOL_SUSPENDED symbol=%s reason=%s ttl_s=%.1f",
+            canonical,
+            reason,
+            ttl,
+            extra={"event": "CONTEXT_SYMBOL_SUSPENDED", "symbol": canonical, "reason": reason, "ttl_s": ttl},
+        )
+
+    def is_context_symbol_suspended(self, symbol: str) -> bool:
+        canonical = self._canonical_symbol(symbol)
+        until = self._suspended_context_symbol_until.get(canonical)
+        if until is None:
+            return canonical in self._suspended_context_symbols
+        if time.monotonic() >= until:
+            self._suspended_context_symbol_until.pop(canonical, None)
+            self._suspended_context_symbols.discard(canonical)
+            return False
+        return True
+
     def _extract_ltp_from_quote(self, quote: Mapping[str, Any]) -> float | None:
         for key in ("ltp", "last_price", "price", "close"):
             try:
@@ -2043,7 +2070,7 @@ class MarketDataManager:
     ) -> float | None:
         """Cached-only LTP accessor. Args: symbol/guards. Returns: ltp. Raises: none."""
         canonical_symbol = self._canonical_symbol(symbol)
-        if canonical_symbol in getattr(self, "_suspended_context_symbols", set()):
+        if self.is_context_symbol_suspended(canonical_symbol):
             with self._lock:
                 cached_tick = self._latest_ticks.get(canonical_symbol)
             if isinstance(cached_tick, Mapping):
@@ -2489,7 +2516,7 @@ class MarketDataManager:
             self._quote_direct_miss_reason.pop(symbol_key, None)
 
         canonical_symbol = self._canonical_symbol(symbol)
-        if canonical_symbol in getattr(self, "_suspended_context_symbols", set()):
+        if self.is_context_symbol_suspended(canonical_symbol):
             with self._lock:
                 cached_tick = self._latest_ticks.get(canonical_symbol)
             if isinstance(cached_tick, Mapping) and cached_tick:

--- a/src/nifty_scalper_bot/strategies/elite_strategies/order_flow.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/order_flow.py
@@ -11,6 +11,13 @@ from nifty_scalper_bot.utils.logging import get_logger
 LOGGER = get_logger(__name__)
 
 
+def safe_float_env(name: str, default: float) -> float:
+    try:
+        return float(os.getenv(name, str(default)) or default)
+    except (TypeError, ValueError):
+        return float(default)
+
+
 class OrderFlowStrategy(EliteStrategy):
     """Order-flow vote using spread, depth imbalance and tick direction."""
 
@@ -41,8 +48,8 @@ class OrderFlowStrategy(EliteStrategy):
             is_live_mode = execution_mode == 'LIVE'
             allow_orderflow_trigger = str(os.getenv('ORDERFLOW_ALLOW_LIVE_TRIGGER' if is_live_mode else 'ORDERFLOW_ALLOW_TRIGGER_ROLE', 'true')).strip().lower() in {'1', 'true', 'yes', 'on'}
             allow_ltp_trigger = str(os.getenv('ORDERFLOW_ALLOW_LTP_FALLBACK_TRIGGER', os.getenv('ORDERFLOW_ALLOW_LTP_FALLBACK_TRIGGER', 'false'))).strip().lower() in {'1', 'true', 'yes', 'on'}
-            trigger_min_score = float(os.getenv('ORDERFLOW_MIN_SCORE_LIVE' if is_live_mode else 'ORDERFLOW_TRIGGER_MIN_SCORE', '8.0' if is_live_mode else '5.0') or ('8.0' if is_live_mode else '5.0'))
-            trigger_max_spread_pct = float(os.getenv('ORDERFLOW_MAX_SPREAD_PCT' if is_live_mode else 'ORDERFLOW_TRIGGER_MAX_SPREAD_PCT', '0.75' if is_live_mode else '12.0') or ('0.75' if is_live_mode else '12.0'))
+            trigger_min_score = safe_float_env('ORDERFLOW_MIN_SCORE_LIVE', 8.0) if is_live_mode else safe_float_env('ORDERFLOW_TRIGGER_MIN_SCORE', 5.0)
+            trigger_max_spread_pct = safe_float_env('ORDERFLOW_MAX_SPREAD_PCT', 0.75) if is_live_mode else safe_float_env('ORDERFLOW_TRIGGER_MAX_SPREAD_PCT', 12.0)
             context_min_score = float(os.getenv('ORDERFLOW_CONTEXT_MIN_SCORE', '4.0') or '4.0')
             require_tradable_quote_live = str(os.getenv('ORDERFLOW_REQUIRE_TRADABLE_QUOTE_LIVE', 'true')).strip().lower() in {'1', 'true', 'yes', 'on'}
             tradable_quote = bool(indicators.get('tradable_quote', True))
@@ -183,7 +190,7 @@ class OrderFlowStrategy(EliteStrategy):
             direction_context_missing = direction not in {'CE', 'PE'}
             allow_without_direction_live = str(os.getenv('ORDERFLOW_ALLOW_TRIGGER_WITHOUT_DIRECTION_LIVE', 'false')).strip().lower() in {'1', 'true', 'yes', 'on'}
             direction_context_ok = (direction in {'CE', 'PE'}) or (not is_live_mode) or allow_without_direction_live
-            max_context_age = float(os.getenv('ORDERFLOW_MAX_CONTEXT_AGE_SECONDS', '5') or '5')
+            max_context_age = safe_float_env('ORDERFLOW_MAX_CONTEXT_AGE_SECONDS', 5.0)
             age_raw = indicators.get('context_age_seconds')
             try:
                 context_age_ok = age_raw is not None and float(age_raw) <= max_context_age

--- a/src/nifty_scalper_bot/strategies/elite_strategies/order_flow.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/order_flow.py
@@ -183,6 +183,12 @@ class OrderFlowStrategy(EliteStrategy):
             direction_context_missing = direction not in {'CE', 'PE'}
             allow_without_direction_live = str(os.getenv('ORDERFLOW_ALLOW_TRIGGER_WITHOUT_DIRECTION_LIVE', 'false')).strip().lower() in {'1', 'true', 'yes', 'on'}
             direction_context_ok = (direction in {'CE', 'PE'}) or (not is_live_mode) or allow_without_direction_live
+            max_context_age = float(os.getenv('ORDERFLOW_MAX_CONTEXT_AGE_SECONDS', '5') or '5')
+            age_raw = indicators.get('context_age_seconds')
+            try:
+                context_age_ok = age_raw is not None and float(age_raw) <= max_context_age
+            except (TypeError, ValueError):
+                context_age_ok = False
             trigger_conditions_met = bool(
                 allow_orderflow_trigger
                 and quote_depth_valid
@@ -194,7 +200,7 @@ class OrderFlowStrategy(EliteStrategy):
                 and spread_pct <= trigger_max_spread_pct
                 and side_alignment_ok
                 and direction_context_ok
-                and float(indicators.get('context_age_seconds') or 0.0) <= float(os.getenv('ORDERFLOW_MAX_CONTEXT_AGE_SECONDS', '5') or '5')
+                and context_age_ok
                 and tick_supports
                 and tick_age_ms <= max_tick_age_ms
             )
@@ -211,6 +217,10 @@ class OrderFlowStrategy(EliteStrategy):
                 trigger_block_reason = 'tick_direction_missing_or_neutral'
             elif not direction_context_ok:
                 trigger_block_reason = 'direction_context_missing_live'
+            elif age_raw is None:
+                trigger_block_reason = 'context_age_missing'
+            elif not context_age_ok:
+                trigger_block_reason = 'context_stale'
             elif not side_alignment_ok:
                 trigger_block_reason = 'direction_bias_conflict'
             elif spread_pct > trigger_max_spread_pct:

--- a/src/nifty_scalper_bot/strategies/elite_strategies/order_flow.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/order_flow.py
@@ -39,10 +39,10 @@ class OrderFlowStrategy(EliteStrategy):
             atr = max(float(indicators.get('atr') or 0.0), current_price * 0.01, 1.0)
             execution_mode = str(os.getenv('EXECUTION_MODE', 'SHADOW') or 'SHADOW').strip().upper()
             is_live_mode = execution_mode == 'LIVE'
-            allow_orderflow_trigger = str(os.getenv('ORDERFLOW_ALLOW_TRIGGER_ROLE', 'true')).strip().lower() in {'1', 'true', 'yes', 'on'}
+            allow_orderflow_trigger = str(os.getenv('ORDERFLOW_ALLOW_LIVE_TRIGGER' if is_live_mode else 'ORDERFLOW_ALLOW_TRIGGER_ROLE', 'true')).strip().lower() in {'1', 'true', 'yes', 'on'}
             allow_ltp_trigger = str(os.getenv('ORDERFLOW_ALLOW_LTP_FALLBACK_TRIGGER', os.getenv('ORDERFLOW_ALLOW_LTP_FALLBACK_TRIGGER', 'false'))).strip().lower() in {'1', 'true', 'yes', 'on'}
-            trigger_min_score = float(os.getenv('ORDERFLOW_TRIGGER_MIN_SCORE_LIVE' if is_live_mode else 'ORDERFLOW_TRIGGER_MIN_SCORE', '6.5' if is_live_mode else '5.0') or ('6.5' if is_live_mode else '5.0'))
-            trigger_max_spread_pct = float(os.getenv('ORDERFLOW_TRIGGER_MAX_SPREAD_PCT_LIVE' if is_live_mode else 'ORDERFLOW_TRIGGER_MAX_SPREAD_PCT', '8.0' if is_live_mode else '12.0') or ('8.0' if is_live_mode else '12.0'))
+            trigger_min_score = float(os.getenv('ORDERFLOW_MIN_SCORE_LIVE' if is_live_mode else 'ORDERFLOW_TRIGGER_MIN_SCORE', '8.0' if is_live_mode else '5.0') or ('8.0' if is_live_mode else '5.0'))
+            trigger_max_spread_pct = float(os.getenv('ORDERFLOW_MAX_SPREAD_PCT' if is_live_mode else 'ORDERFLOW_TRIGGER_MAX_SPREAD_PCT', '0.75' if is_live_mode else '12.0') or ('0.75' if is_live_mode else '12.0'))
             context_min_score = float(os.getenv('ORDERFLOW_CONTEXT_MIN_SCORE', '4.0') or '4.0')
             require_tradable_quote_live = str(os.getenv('ORDERFLOW_REQUIRE_TRADABLE_QUOTE_LIVE', 'true')).strip().lower() in {'1', 'true', 'yes', 'on'}
             tradable_quote = bool(indicators.get('tradable_quote', True))
@@ -194,6 +194,7 @@ class OrderFlowStrategy(EliteStrategy):
                 and spread_pct <= trigger_max_spread_pct
                 and side_alignment_ok
                 and direction_context_ok
+                and float(indicators.get('context_age_seconds') or 0.0) <= float(os.getenv('ORDERFLOW_MAX_CONTEXT_AGE_SECONDS', '5') or '5')
                 and tick_supports
                 and tick_age_ms <= max_tick_age_ms
             )
@@ -250,7 +251,7 @@ class OrderFlowStrategy(EliteStrategy):
             if trigger_conditions_met:
                 metadata['approval_candidate'] = 'orderflow_live_depth_trigger'
             metadata.update({'context_role': 'confirmation', 'context_bonus_score': strategy_score if side_aligns else 0.0, 'context_veto_score': strategy_score if (direction in {'CE', 'PE'} and direction != side) else 0.0})
-            return EliteSignal(symbol=symbol, signal='BUY', confidence=max(0.1, min(0.85, strategy_score / 10.0)), entry_price=current_price, stop_loss=None, target=None, quantity=self._cfg.quantity or 1, strategy_name='OrderFlow', metadata=metadata)
+            LOGGER.info('ORDERFLOW_TRIGGER_DECISION symbol=%s side=%s trigger_conditions_met=%s trigger_block_reason=%s score=%.2f spread_pct=%.2f context_age_seconds=%s', symbol, side, trigger_conditions_met, trigger_block_reason, strategy_score, spread_pct, indicators.get('context_age_seconds'), extra={'event':'ORDERFLOW_TRIGGER_DECISION','symbol':symbol,'side':side,'trigger_conditions_met':trigger_conditions_met,'trigger_block_reason':trigger_block_reason}); return EliteSignal(symbol=symbol, signal='BUY', confidence=max(0.1, min(0.85, strategy_score / 10.0)), entry_price=current_price, stop_loss=None, target=None, quantity=self._cfg.quantity or 1, strategy_name='OrderFlow', metadata=metadata)
         except Exception as e:
             LOGGER.error('Failure in OrderFlowStrategy._evaluate_signal: %s', e, exc_info=e)
             return None

--- a/src/nifty_scalper_bot/strategies/elite_strategies/smc_liquidity.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/smc_liquidity.py
@@ -206,9 +206,19 @@ class SMCStrategy(EliteStrategy):
                 return None
 
             contract_side, option_premium_domain, _ = resolve_signal_domain(symbol, indicators)
+            required_features = ("premium_reclaim", "bullish_reversal", "choch_confirmed", "bos_confirmed", "retest_confirmed")
+            present_features = [name for name in required_features if indicators.get(name) is not None]
+            feature_completeness = float(len(present_features)) / float(len(required_features))
+            feature_threshold = float(os.getenv("SMC_FEATURE_COMPLETENESS_THRESHOLD", "0.6") or "0.6")
+            missing_features = [name for name in required_features if name not in present_features]
+            feature_ready = feature_completeness >= feature_threshold
+            LOGGER.info("SMC_FEATURE_READINESS symbol=%s feature_completeness=%.3f missing_features=%s live_enabled=%s vote_allowed=%s hard_veto=%s", symbol, feature_completeness, ",".join(missing_features), is_live, feature_ready, False, extra={"event": "SMC_FEATURE_READINESS", "symbol": symbol, "feature_completeness": feature_completeness, "missing_features": missing_features, "live_enabled": is_live, "vote_allowed": feature_ready, "hard_veto": False})
             if option_premium_domain:
                 premium_reversal = bool(bullish_sweep or indicators.get('premium_reclaim') or indicators.get('bullish_reversal'))
                 structure_flip = bool(indicators.get('choch_confirmed') or indicators.get('bos_confirmed'))
+                if not feature_ready:
+                    self._no_vote('strategy_feature_unavailable')
+                    return None
                 if not premium_reversal and not structure_flip:
                     self._no_vote('premium_not_reversing_up')
                     LOGGER.info(
@@ -288,7 +298,7 @@ class SMCStrategy(EliteStrategy):
                 and direction_aligned
                 and (premium_reclaim or retest_confirmed or str(os.getenv("SMC_MOMENTUM_REQUIRE_PREMIUM_RECLAIM_OR_RETEST", "true")).lower() not in {"1", "true", "yes", "on"})
             )
-            if is_live and require_structure_live and not (structure_confirmed or momentum_confirmed):
+            if is_live and require_structure_live and feature_ready and not (structure_confirmed or momentum_confirmed):
                 self._no_vote('smc_structure_required_live')
                 premium_reclaim_source = indicators.get("premium_reclaim_source")
                 premium_current = indicators.get("premium_current")

--- a/src/nifty_scalper_bot/strategies/elite_strategies/smc_liquidity.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/smc_liquidity.py
@@ -25,6 +25,13 @@ def _first_not_none(*values: int | None) -> int | None:
     return next((value for value in values if value is not None), None)
 
 
+def safe_float_env(name: str, default: float) -> float:
+    try:
+        return float(os.getenv(name, str(default)) or default)
+    except (TypeError, ValueError):
+        return float(default)
+
+
 class SMCStrategy(EliteStrategy):
     """SMC liquidity sweep strategy producing structured votes only."""
 
@@ -209,7 +216,7 @@ class SMCStrategy(EliteStrategy):
             required_features = ("premium_reclaim", "bullish_reversal", "choch_confirmed", "bos_confirmed", "retest_confirmed")
             present_features = [name for name in required_features if indicators.get(name) is not None]
             feature_completeness = float(len(present_features)) / float(len(required_features))
-            feature_threshold = float(os.getenv("SMC_FEATURE_COMPLETENESS_THRESHOLD", "0.6") or "0.6")
+            feature_threshold = safe_float_env("SMC_FEATURE_COMPLETENESS_THRESHOLD", 0.6)
             missing_features = [name for name in required_features if name not in present_features]
             feature_ready = feature_completeness >= feature_threshold
             LOGGER.info("SMC_FEATURE_READINESS symbol=%s feature_completeness=%.3f missing_features=%s live_enabled=%s vote_allowed=%s hard_veto=%s", symbol, feature_completeness, ",".join(missing_features), is_live, feature_ready, False, extra={"event": "SMC_FEATURE_READINESS", "symbol": symbol, "feature_completeness": feature_completeness, "missing_features": missing_features, "live_enabled": is_live, "vote_allowed": feature_ready, "hard_veto": False})

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -6294,6 +6294,7 @@ class StrategyRunner:
 
     def _emit_live_trading_readiness_snapshot(self, *, symbol: str, strategy_signal_present: bool, order_path_entered: bool, order_manager_block_reason: str | None = None) -> None:
         try:
+            universe_ready, universe_reason = self._emit_live_universe_bootstrap_status(symbol=symbol)
             ce_symbol = self._selected_option_symbol_for_side("CE", {}) or getattr(self, "_active_selected_ce", None)
             pe_symbol = self._selected_option_symbol_for_side("PE", {}) or getattr(self, "_active_selected_pe", None)
             ce_history = len(self._indicator_engine.get_history(ce_symbol) or []) if ce_symbol else 0
@@ -6338,7 +6339,19 @@ class StrategyRunner:
                 "order_manager_block_reason": order_manager_block_reason,
             }
             self._logger.info("LIVE_TRADING_READINESS_SNAPSHOT symbol=%s live_orders_armed=%s reason=%s", symbol, bool(self._runtime_live_orders_armed), self._runtime_readiness_reason, extra=payload)
-        except Exception:
+        except Exception as exc:
+            self._logger.warning(
+                "LIVE_TRADING_READINESS_SNAPSHOT_FAILED symbol=%s error_type=%s error=%s",
+                symbol,
+                type(exc).__name__,
+                str(exc),
+                extra={
+                    "event": "LIVE_TRADING_READINESS_SNAPSHOT_FAILED",
+                    "symbol": symbol,
+                    "error_type": type(exc).__name__,
+                    "error": str(exc),
+                },
+            )
             return
 
 

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -6086,6 +6086,7 @@ class StrategyRunner:
         )
         try:
             reserved_extra_keys = set(logging.makeLogRecord({}).__dict__)
+            universe_ready, universe_reason = self._emit_live_universe_bootstrap_status(symbol=symbol)
             payload = {
                 "level": "WARNING",
                 "symbol": symbol,
@@ -6308,7 +6309,7 @@ class StrategyRunner:
                 "trading_allowed": bool(self._runtime_evaluation_ready),
                 "diagnostic_allowed": True,
                 "live_orders_armed": bool(self._runtime_live_orders_armed),
-                "live_block_reason": self._runtime_readiness_reason,
+                "live_block_reason": universe_reason or self._runtime_readiness_reason,
                 "selected_ce_symbol": ce_symbol,
                 "selected_pe_symbol": pe_symbol,
                 "ce_exec_ready": bool(self._runtime_execution_ready_by_symbol.get(ce_symbol, False)) if ce_symbol else False,
@@ -6331,11 +6332,47 @@ class StrategyRunner:
                 "candidate_refresh_pending": False,
                 "strategy_signal_present": bool(strategy_signal_present),
                 "order_path_entered": bool(order_path_entered),
+                "live_universe_ready": universe_ready,
                 "order_manager_block_reason": order_manager_block_reason,
             }
             self._logger.info("LIVE_TRADING_READINESS_SNAPSHOT symbol=%s live_orders_armed=%s reason=%s", symbol, bool(self._runtime_live_orders_armed), self._runtime_readiness_reason, extra=payload)
         except Exception:
             return
+
+
+    def _emit_live_universe_bootstrap_status(self, *, symbol: str) -> tuple[bool, str | None]:
+        ce_symbol = self._selected_option_symbol_for_side("CE", {}) or getattr(self, "_active_selected_ce", None)
+        pe_symbol = self._selected_option_symbol_for_side("PE", {}) or getattr(self, "_active_selected_pe", None)
+        fut_symbol = next((sym for sym in self._active_symbols if self._symbol_role_for_runner(sym) == "futures_context" and not self._is_context_symbol_suspended(sym)), "")
+        mdm = getattr(self, "_market_data", None)
+        token_by_symbol = getattr(mdm, "_token_by_symbol", {}) if mdm is not None else {}
+        ce_token = token_by_symbol.get(ce_symbol) if ce_symbol else None
+        pe_token = token_by_symbol.get(pe_symbol) if pe_symbol else None
+        fut_token = token_by_symbol.get(fut_symbol) if fut_symbol else None
+        active_subs = set(getattr(mdm, "_active_subscribed_symbols", set()) or set())
+        ce_sub = bool(ce_symbol and ce_symbol in active_subs)
+        pe_sub = bool(pe_symbol and pe_symbol in active_subs)
+        fut_sub = bool(fut_symbol and fut_symbol in active_subs)
+        ce_quote = bool(ce_symbol and self._is_option_symbol_tick_fresh(ce_symbol, max_age_s=60.0))
+        pe_quote = bool(pe_symbol and self._is_option_symbol_tick_fresh(pe_symbol, max_age_s=60.0))
+        fut_quote = bool(fut_symbol and self._is_option_symbol_tick_fresh(fut_symbol, max_age_s=60.0)) if fut_symbol else False
+        ce_depth = bool(ce_symbol and self._is_symbol_execution_ready(ce_symbol))
+        pe_depth = bool(pe_symbol and self._is_symbol_execution_ready(pe_symbol))
+        ce_hist = len(self._indicator_engine.get_history(ce_symbol) or []) if ce_symbol else 0
+        pe_hist = len(self._indicator_engine.get_history(pe_symbol) or []) if pe_symbol else 0
+        min_bars = int(self._required_bars_for_symbol(ce_symbol or pe_symbol or symbol))
+        reason = None
+        if not (ce_sub and pe_sub):
+            reason = "selected_option_subscription_pending"
+        elif not (ce_quote and pe_quote):
+            reason = "selected_option_quote_missing"
+        elif not (ce_depth and pe_depth):
+            reason = "selected_option_depth_missing"
+        elif ce_hist < min_bars or pe_hist < min_bars:
+            reason = "selected_option_history_cold"
+        ready = reason is None
+        self._logger.info("LIVE_UNIVERSE_BOOTSTRAP_STATUS symbol=%s ready=%s reason=%s", symbol, ready, reason, extra={"event":"LIVE_UNIVERSE_BOOTSTRAP_STATUS","symbol":symbol,"selected_ce":ce_symbol,"selected_pe":pe_symbol,"active_future":fut_symbol or None,"ce_token":ce_token,"pe_token":pe_token,"fut_token":fut_token,"ce_subscribed":ce_sub,"pe_subscribed":pe_sub,"fut_subscribed":fut_sub,"ce_quote_fresh":ce_quote,"pe_quote_fresh":pe_quote,"fut_quote_fresh":fut_quote,"ce_depth_available":ce_depth,"pe_depth_available":pe_depth,"ce_history_count":ce_hist,"pe_history_count":pe_hist,"ready":ready,"reason":reason})
+        return ready, reason
 
     def _request_selected_option_history_prewarm(
         self, symbol: str, *, bars_before: int, required_bars: int, trace_id: str | None = None

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -6604,7 +6604,7 @@ class StrategyRunner:
         if not self._is_tradable_symbol(symbol):
             return False
         limit = float(max_age_s or os.getenv("OPTION_TICK_FRESH_MAX_AGE_S", "60") or 60.0)
-        quote = self.get_quote(symbol)
+        quote = self._get_cached_quote_for_live_entry(symbol)
         if isinstance(quote, Mapping):
             age = _extract_float(quote, "tick_age_s", "age_s")
             if age is not None:

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -818,6 +818,8 @@ class StrategyRunner:
         self._last_global_eval_ts: float = time.monotonic()
         self._last_tick_seen_ts: float = time.monotonic()
         self._last_tick_time_by_symbol: dict[str, float] = defaultdict(float)
+        self._runtime_indicators: dict[str, dict[str, Any]] = {}
+        self._last_direction_context: dict[str, Any] | None = None
         self._last_tick: dict[str, dict[str, Any]] = {}
         self._symbol_locks: defaultdict[str, threading.Lock] = defaultdict(
             threading.Lock
@@ -6747,7 +6749,8 @@ class StrategyRunner:
         details["kill_switch_status"] = ks_status
         if ks_active:
             return False, "order_manager_kill_switch_active", details
-        ctx = self._runtime_indicators.get(symbol, {}) or {}
+        runtime_indicators = getattr(self, "_runtime_indicators", {}) or {}
+        ctx = runtime_indicators.get(symbol, {}) or {}
         contract_side = self._contract_side_from_symbol(symbol)
         direction_bias = str(ctx.get("underlying_direction_bias") or ctx.get("direction_bias") or "").upper()
         details["contract_side"] = contract_side

--- a/tests/core/test_strategy_manager_consensus.py
+++ b/tests/core/test_strategy_manager_consensus.py
@@ -411,3 +411,12 @@ def test_aligned_two_trigger_pe_consensus_allowed_without_smc_confirmation() -> 
     assert out is not None
     assert out.metadata is not None
     assert out.metadata.get('approval_path') in {'aligned_two_trigger_consensus','multi_trigger'}
+
+def test_negative_premium_flow_in_no_vote_counts_blocks_two_trigger() -> None:
+    manager = _manager_stub()
+    s1 = _make_signal(); s1.symbol='NFO:NIFTY25000PE'; s1.metadata={'quote_depth_valid':True,'spread_pct':0.2,'is_selected_option':True,'context_age_seconds':2}
+    s2 = _make_signal(); s2.symbol='NFO:NIFTY25000PE'; s2.metadata={'quote_depth_valid':True,'spread_pct':0.2,'is_selected_option':True,'context_age_seconds':2}
+    v1 = StrategyVote(strategy='VWAPPro', side='PE', score=8.5, confidence=0.9, reasons=[], metadata={})
+    v2 = StrategyVote(strategy='OrderFlow', side='PE', score=8.2, confidence=0.85, reasons=[], metadata={})
+    out = manager._combine_strategy_votes(symbol='NFO:NIFTY25000PE', signals=[(s1,v1),(s2,v2)], indicators={'direction_bias':'PE','context_age_seconds':2,'spread_pct':0.2,'quote_depth_valid':True,'is_selected_option':True}, no_vote_reason_counts={'negative_premium_flow':1})
+    assert out is None

--- a/tests/core/test_strategy_manager_consensus.py
+++ b/tests/core/test_strategy_manager_consensus.py
@@ -390,3 +390,24 @@ def test_derive_direction_fresh_context_and_stale_context_age() -> None:
     )
     assert side == 'CE'
     assert conf > 0.0
+
+def test_ce_two_trigger_blocked_when_direction_bias_pe() -> None:
+    manager = _manager_stub()
+    s1 = _make_signal(); s1.symbol='NFO:NIFTY25000CE'; s1.metadata={'quote_depth_valid':True,'spread_pct':0.2,'is_selected_option':True,'context_age_seconds':2}
+    s2 = _make_signal(); s2.symbol='NFO:NIFTY25000CE'; s2.metadata={'quote_depth_valid':True,'spread_pct':0.2,'is_selected_option':True,'context_age_seconds':2}
+    v1 = StrategyVote(strategy='VWAPPro', side='CE', score=8.5, confidence=0.9, reasons=[], metadata={'strategy_score':8.5})
+    v2 = StrategyVote(strategy='OrderFlow', side='CE', score=8.2, confidence=0.85, reasons=[], metadata={'strategy_score':8.2})
+    out = manager._combine_strategy_votes(symbol='NFO:NIFTY25000CE', signals=[(s1,v1),(s2,v2)], indicators={'direction_bias':'PE','context_age_seconds':2,'spread_pct':0.2,'quote_depth_valid':True,'is_selected_option':True})
+    assert out is None
+
+
+def test_aligned_two_trigger_pe_consensus_allowed_without_smc_confirmation() -> None:
+    manager = _manager_stub()
+    s1 = _make_signal(); s1.symbol='NFO:NIFTY25000PE'; s1.metadata={'quote_depth_valid':True,'spread_pct':0.2,'is_selected_option':True,'context_age_seconds':2,'strategy_score':8.5}
+    s2 = _make_signal(); s2.symbol='NFO:NIFTY25000PE'; s2.metadata={'quote_depth_valid':True,'spread_pct':0.2,'is_selected_option':True,'context_age_seconds':2,'strategy_score':8.2}
+    v1 = StrategyVote(strategy='VWAPPro', side='PE', score=8.5, confidence=0.9, reasons=[], metadata={'strategy_score':8.5})
+    v2 = StrategyVote(strategy='OrderFlow', side='PE', score=8.2, confidence=0.85, reasons=[], metadata={'strategy_score':8.2})
+    out = manager._combine_strategy_votes(symbol='NFO:NIFTY25000PE', signals=[(s1,v1),(s2,v2)], indicators={'direction_bias':'PE','context_age_seconds':2,'spread_pct':0.2,'quote_depth_valid':True,'is_selected_option':True})
+    assert out is not None
+    assert out.metadata is not None
+    assert out.metadata.get('approval_path') in {'aligned_two_trigger_consensus','multi_trigger'}

--- a/tests/core/test_strategy_manager_consensus.py
+++ b/tests/core/test_strategy_manager_consensus.py
@@ -420,3 +420,54 @@ def test_negative_premium_flow_in_no_vote_counts_blocks_two_trigger() -> None:
     v2 = StrategyVote(strategy='OrderFlow', side='PE', score=8.2, confidence=0.85, reasons=[], metadata={})
     out = manager._combine_strategy_votes(symbol='NFO:NIFTY25000PE', signals=[(s1,v1),(s2,v2)], indicators={'direction_bias':'PE','context_age_seconds':2,'spread_pct':0.2,'quote_depth_valid':True,'is_selected_option':True}, no_vote_reason_counts={'negative_premium_flow':1})
     assert out is None
+
+def test_combine_receives_no_vote_reason_counts_from_generate_signal(monkeypatch) -> None:
+    manager = _manager_stub()
+    received = {}
+    def _capture(**kwargs):
+        received.update(kwargs)
+        return None
+    manager._combine_strategy_votes = _capture  # type: ignore[method-assign]
+    manager._required_indicators = set()
+    manager._active_strategies = []
+    manager._record_no_signal_summary = lambda **_k: None
+    manager._record_no_signal_decision = lambda **_k: None
+    manager._emit_no_signal_event = lambda *_a, **_k: None
+    manager._symbol_filter_allows = lambda *_a, **_k: True
+    manager._strategy_for_role = lambda *_a, **_k: []
+    manager._filter_signal = lambda _s: True
+    manager._orchestrator = None
+    manager.generate_signal('NFO:NIFTY25000PE', {'direction_bias':'PE'})
+    assert 'no_vote_reason_counts' in received
+
+
+def test_aligned_two_trigger_blocks_underlying_direction_conflict_from_no_vote_counts() -> None:
+    manager = _manager_stub()
+    s1 = _make_signal(); s1.symbol='NFO:NIFTY25000PE'; s1.metadata={'quote_depth_valid':True,'spread_pct':0.2,'is_selected_option':True,'context_age_seconds':2}
+    s2 = _make_signal(); s2.symbol='NFO:NIFTY25000PE'; s2.metadata={'quote_depth_valid':True,'spread_pct':0.2,'is_selected_option':True,'context_age_seconds':2}
+    v1 = StrategyVote(strategy='VWAPPro', side='PE', score=8.5, confidence=0.9, reasons=[], metadata={})
+    v2 = StrategyVote(strategy='OrderFlow', side='PE', score=8.2, confidence=0.85, reasons=[], metadata={})
+    out = manager._combine_strategy_votes(symbol='NFO:NIFTY25000PE', signals=[(s1,v1),(s2,v2)], indicators={'direction_bias':'PE','context_age_seconds':2,'spread_pct':0.2,'quote_depth_valid':True,'is_selected_option':True}, no_vote_reason_counts={'underlying_direction_conflict':1})
+    assert out is None
+
+
+def test_aligned_two_trigger_allows_smc_insufficient_history_neutral() -> None:
+    manager = _manager_stub()
+    s1 = _make_signal(); s1.symbol='NFO:NIFTY25000PE'; s1.metadata={'quote_depth_valid':True,'spread_pct':0.2,'is_selected_option':True,'context_age_seconds':2,'strategy_score':8.5}
+    s2 = _make_signal(); s2.symbol='NFO:NIFTY25000PE'; s2.metadata={'quote_depth_valid':True,'spread_pct':0.2,'is_selected_option':True,'context_age_seconds':2,'strategy_score':8.2}
+    v1 = StrategyVote(strategy='VWAPPro', side='PE', score=8.5, confidence=0.9, reasons=[], metadata={'strategy_score':8.5})
+    v2 = StrategyVote(strategy='OrderFlow', side='PE', score=8.2, confidence=0.85, reasons=[], metadata={'strategy_score':8.2})
+    out = manager._combine_strategy_votes(symbol='NFO:NIFTY25000PE', signals=[(s1,v1),(s2,v2)], indicators={'direction_bias':'PE','context_age_seconds':2,'spread_pct':0.2,'quote_depth_valid':True,'is_selected_option':True}, no_vote_reason_counts={'smc_insufficient_history':1})
+    assert out is not None
+    assert out.metadata is not None
+    assert out.metadata.get('approval_path') == 'aligned_two_trigger_consensus'
+
+
+def test_aligned_two_trigger_allows_strategy_feature_unavailable_neutral() -> None:
+    manager = _manager_stub()
+    s1 = _make_signal(); s1.symbol='NFO:NIFTY25000PE'; s1.metadata={'quote_depth_valid':True,'spread_pct':0.2,'is_selected_option':True,'context_age_seconds':2,'strategy_score':8.5}
+    s2 = _make_signal(); s2.symbol='NFO:NIFTY25000PE'; s2.metadata={'quote_depth_valid':True,'spread_pct':0.2,'is_selected_option':True,'context_age_seconds':2,'strategy_score':8.2}
+    v1 = StrategyVote(strategy='VWAPPro', side='PE', score=8.5, confidence=0.9, reasons=[], metadata={'strategy_score':8.5})
+    v2 = StrategyVote(strategy='OrderFlow', side='PE', score=8.2, confidence=0.85, reasons=[], metadata={'strategy_score':8.2})
+    out = manager._combine_strategy_votes(symbol='NFO:NIFTY25000PE', signals=[(s1,v1),(s2,v2)], indicators={'direction_bias':'PE','context_age_seconds':2,'spread_pct':0.2,'quote_depth_valid':True,'is_selected_option':True}, no_vote_reason_counts={'strategy_feature_unavailable':1})
+    assert out is not None

--- a/tests/data/test_market_data_manager.py
+++ b/tests/data/test_market_data_manager.py
@@ -1358,3 +1358,23 @@ def test_pull_quote_suspended_future_returns_unavailable_dict_without_broker_cal
     manager._suspended_context_symbols.add("NFO:NIFTY26MAYFUT")  # noqa: SLF001
     out = manager.pull_quote("NFO:NIFTY26MAYFUT")
     assert out.get("quote_unavailable_reason") == "suspended_stale_future"
+
+def test_market_data_manager_initializes_suspended_context_symbols(broker: DummyBroker, ws: DummyWebSocket) -> None:
+    manager = MarketDataManager(broker, ws)
+    assert isinstance(manager._suspended_context_symbols, set)  # noqa: SLF001
+    assert isinstance(manager._suspended_context_symbol_until, dict)  # noqa: SLF001
+
+
+def test_suspend_context_symbol_blocks_pull_quote_until_ttl(broker: DummyBroker, ws: DummyWebSocket) -> None:
+    manager = MarketDataManager(broker, ws)
+    manager.suspend_context_symbol('NFO:NIFTY26MAYFUT', reason='stale', ttl_s=300)
+    out = manager.pull_quote('NFO:NIFTY26MAYFUT')
+    assert out.get('quote_unavailable_reason') == 'suspended_stale_future'
+
+
+def test_suspended_context_symbol_expires_after_ttl(broker: DummyBroker, ws: DummyWebSocket) -> None:
+    manager = MarketDataManager(broker, ws)
+    manager.suspend_context_symbol('NFO:NIFTY26MAYFUT', reason='stale', ttl_s=0.001)
+    import time as _t
+    _t.sleep(0.01)
+    assert manager.is_context_symbol_suspended('NFO:NIFTY26MAYFUT') is False

--- a/tests/data/test_market_data_manager.py
+++ b/tests/data/test_market_data_manager.py
@@ -1328,3 +1328,33 @@ def test_maybe_rotate_unresolved_returns_symbol_none(ws: DummyWebSocket) -> None
     out = manager.maybe_rotate_nifty_futures_context_result("NFO:NIFTY26MAYFUT", reason="no_data")
     assert out.unresolved is True
     assert out.symbol is None
+
+def test_get_cached_ltp_suspended_future_returns_float_from_cache(broker: DummyBroker, ws: DummyWebSocket) -> None:
+    manager = MarketDataManager(broker, ws)
+    manager._suspended_context_symbols.add("NFO:NIFTY26MAYFUT")  # noqa: SLF001
+    manager._latest_ticks["NFO:NIFTY26MAYFUT"] = {"ltp": 123.5}  # noqa: SLF001
+    assert manager.get_cached_ltp("NFO:NIFTY26MAYFUT") == 123.5
+
+
+def test_get_cached_ltp_suspended_future_returns_none_without_cache(broker: DummyBroker, ws: DummyWebSocket) -> None:
+    manager = MarketDataManager(broker, ws)
+    manager._suspended_context_symbols.add("NFO:NIFTY26MAYFUT")  # noqa: SLF001
+    assert manager.get_cached_ltp("NFO:NIFTY26MAYFUT") is None
+
+
+def test_get_cached_ltp_never_returns_dict(broker: DummyBroker, ws: DummyWebSocket) -> None:
+    manager = MarketDataManager(broker, ws)
+    manager._suspended_context_symbols.add("NFO:NIFTY26MAYFUT")  # noqa: SLF001
+    value = manager.get_cached_ltp("NFO:NIFTY26MAYFUT")
+    assert value is None or isinstance(value, float)
+
+
+def test_pull_quote_suspended_future_returns_unavailable_dict_without_broker_call(ws: DummyWebSocket) -> None:
+    class FailBroker(DummyBroker):
+        def get_quote(self, symbol: str) -> dict[str, Any]:
+            raise AssertionError("broker must not be called")
+
+    manager = MarketDataManager(FailBroker(), ws)
+    manager._suspended_context_symbols.add("NFO:NIFTY26MAYFUT")  # noqa: SLF001
+    out = manager.pull_quote("NFO:NIFTY26MAYFUT")
+    assert out.get("quote_unavailable_reason") == "suspended_stale_future"

--- a/tests/strategies/test_runner_readiness_diagnostics.py
+++ b/tests/strategies/test_runner_readiness_diagnostics.py
@@ -470,3 +470,22 @@ def test_symbol_live_entry_ready_does_not_call_datahub_get_quote_with_allow_pull
     runner._data_hub = SimpleNamespace(get_quote=lambda *_a, **kwargs: pulled.__setitem__("called", kwargs.get("allow_pull", True)))
     assert runner._is_option_symbol_tick_fresh("NFO:CE", max_age_s=5.0) is True
     assert pulled["called"] is False
+
+def test_symbol_live_entry_ready_no_runtime_indicators_attribute_does_not_crash() -> None:
+    runner = _make_runner()
+    delattr(runner, '_runtime_execution_ready_by_symbol') if hasattr(runner, '_runtime_execution_ready_by_symbol') else None
+    if hasattr(runner, '_runtime_indicators'):
+        delattr(runner, '_runtime_indicators')
+    runner._runtime_live_orders_armed = True
+    runner._is_tradable_symbol = lambda _s: True
+    runner._order_manager_kill_switch_status_for_entry = lambda: (False, {})
+    runner._indicator_engine = _DummyIndicator({'NFO:CE':[1,2,3,4,5,6]})
+    runner._required_bars_for_symbol = lambda _s: 1
+    runner._is_option_symbol_tick_fresh = lambda _s, max_age_s=60.0: True
+    runner._active_selected_ce = 'NFO:CE'; runner._active_selected_pe = 'NFO:PE'
+    runner._extract_strike_from_symbol = lambda _s: 24000
+    runner._active_atm_strike = 24000
+    runner._get_cached_quote_for_live_entry = lambda _s: {'tradable_quote':True,'quote_depth_valid':True,'spread_pct':0.2}
+    ready, reason, _ = runner._symbol_live_entry_ready('NFO:CE')
+    assert isinstance(ready, bool)
+    assert reason != 'runner_error'

--- a/tests/strategies/test_runner_readiness_diagnostics.py
+++ b/tests/strategies/test_runner_readiness_diagnostics.py
@@ -489,3 +489,30 @@ def test_symbol_live_entry_ready_no_runtime_indicators_attribute_does_not_crash(
     ready, reason, _ = runner._symbol_live_entry_ready('NFO:CE')
     assert isinstance(ready, bool)
     assert reason != 'runner_error'
+
+
+def test_live_trading_readiness_snapshot_defines_universe_status(caplog) -> None:
+    runner = _make_runner()
+    runner._emit_live_universe_bootstrap_status = lambda **_k: (False, "selected_option_quote_missing")
+    with caplog.at_level(logging.INFO):
+        runner._emit_live_trading_readiness_snapshot(symbol="NFO:SYM", strategy_signal_present=False, order_path_entered=False)
+    rec = next(r for r in caplog.records if getattr(r, "event", "") == "LIVE_TRADING_READINESS_SNAPSHOT")
+    assert rec.live_universe_ready is False
+    assert rec.live_block_reason == "selected_option_quote_missing"
+
+
+def test_live_trading_readiness_snapshot_emits_when_universe_not_ready(caplog) -> None:
+    runner = _make_runner()
+    runner._emit_live_universe_bootstrap_status = lambda **_k: (False, "selected_option_subscription_pending")
+    with caplog.at_level(logging.INFO):
+        runner._emit_live_trading_readiness_snapshot(symbol="NFO:SYM", strategy_signal_present=False, order_path_entered=False)
+    assert any(getattr(r, "event", "") == "LIVE_TRADING_READINESS_SNAPSHOT" for r in caplog.records)
+
+
+def test_live_trading_readiness_snapshot_failure_is_logged_not_silent(caplog) -> None:
+    runner = _make_runner()
+    runner._emit_live_universe_bootstrap_status = lambda **_k: (_ for _ in ()).throw(RuntimeError("boom"))
+    with caplog.at_level(logging.WARNING):
+        runner._emit_live_trading_readiness_snapshot(symbol="NFO:SYM", strategy_signal_present=False, order_path_entered=False)
+    rec = next(r for r in caplog.records if getattr(r, "event", "") == "LIVE_TRADING_READINESS_SNAPSHOT_FAILED")
+    assert rec.error_type == "RuntimeError"

--- a/tests/strategies/test_runner_readiness_diagnostics.py
+++ b/tests/strategies/test_runner_readiness_diagnostics.py
@@ -443,3 +443,30 @@ def test_runner_emits_no_trade_decision_on_signal_none_strategy_no_trigger(caplo
     assert rec.category == "strategy_no_trigger"
     assert rec.reason == "evaluation_no_signal"
     assert rec.broker_attempted is False
+
+def test_is_option_symbol_tick_fresh_uses_cache_only_no_pull_quote() -> None:
+    runner = _make_runner()
+    calls: list[bool] = []
+    runner._is_tradable_symbol = lambda _s: True
+    runner._get_cached_quote_for_live_entry = lambda _s: {"tick_age_s": 1.0}
+    runner._data_hub = SimpleNamespace(get_quote=lambda *_a, **_k: calls.append(True))
+    assert runner._is_option_symbol_tick_fresh("NFO:CE", max_age_s=5.0) is True
+    assert calls == []
+
+
+def test_tick_fresh_returns_false_when_cache_missing() -> None:
+    runner = _make_runner()
+    runner._is_tradable_symbol = lambda _s: True
+    runner._get_cached_quote_for_live_entry = lambda _s: {}
+    runner._market_data = SimpleNamespace(time_since_last_tick=lambda _s: None)
+    runner._data_hub = SimpleNamespace(time_since_last_tick=lambda _s: None)
+    assert runner._is_option_symbol_tick_fresh("NFO:CE", max_age_s=5.0) is False
+
+def test_symbol_live_entry_ready_does_not_call_datahub_get_quote_with_allow_pull_true() -> None:
+    runner = _make_runner()
+    pulled = {"called": False}
+    runner._is_tradable_symbol = lambda _s: True
+    runner._get_cached_quote_for_live_entry = lambda _s: {"tick_age_s": 0.5}
+    runner._data_hub = SimpleNamespace(get_quote=lambda *_a, **kwargs: pulled.__setitem__("called", kwargs.get("allow_pull", True)))
+    assert runner._is_option_symbol_tick_fresh("NFO:CE", max_age_s=5.0) is True
+    assert pulled["called"] is False

--- a/tests/test_live_readiness_gate.py
+++ b/tests/test_live_readiness_gate.py
@@ -166,3 +166,8 @@ def test_compute_live_readiness_explicit_positive_override_still_works(monkeypat
     )
     assert armed is True
     assert reasons == []
+
+def test_runner_emits_live_universe_bootstrap_status_hook_present() -> None:
+    text = Path('src/nifty_scalper_bot/strategies/runner.py').read_text(encoding='utf-8')
+    assert 'LIVE_UNIVERSE_BOOTSTRAP_STATUS' in text
+    assert 'selected_option_subscription_pending' in text


### PR DESCRIPTION
### Motivation
- Live PE candidates were being rejected by mixed freshness/context thresholds and aggressive SMC vetoes while runner freshness checks could fall back to REST; this resulted in `final_block_reason=partial` for otherwise aligned PE triggers. 
- Aim: enable valid PE-side signals to reach final consensus when safe, without weakening execution safety or direction-bias rules.

### Description
- Unified live-context freshness: added `_live_context_max_age_seconds()` in `StrategyManager` and applied it to context freshness and promotion checks so live context age uses `MAX_CONTEXT_AGE_SECONDS` (default 5s). (`src/nifty_scalper_bot/core/strategy_manager.py`).
- Cache-only tick freshness for live entry: `StrategyRunner._is_option_symbol_tick_fresh()` now uses `_get_cached_quote_for_live_entry()` and `time_since_last_tick` only; it no longer calls `DataHub`/`get_quote` with pull/REST. (`src/nifty_scalper_bot/strategies/runner.py`).
- SMC feature readiness: added `SMC_FEATURE_READINESS` diagnostics and made insufficient/missing SMC features emit neutral no-votes (e.g. `strategy_feature_unavailable`, `smc_insufficient_history`), and limited `smc_structure_required_live` hard-veto to when feature completeness passes. (`src/nifty_scalper_bot/strategies/elite_strategies/smc_liquidity.py`).
- OrderFlow live promotion tightened: introduced stricter live env knobs and a context-age check for OrderFlow live triggers, preserved direction-bias blocking, and emitted `ORDERFLOW_TRIGGER_DECISION` logging for audit. (`src/nifty_scalper_bot/strategies/elite_strategies/order_flow.py`).
- Suppress stale future REST polling and add MDM backpressure diagnostics: `MarketDataManager.pull_quote()` now returns cached/suspended response for suspended stale futures (avoids polling a stale MAY FUT), and MDM emits a rate-limited `MDM_BUS_BACKPRESSURE` event when tick bus publish fails, while ensuring tick cache updates are not blocked. (`src/nifty_scalper_bot/data/market_data_manager.py`).
- Kept all execution/risk/broker safety gates unchanged (no bypasses, no REST pulls from the signal/readiness freshness path, and no CE/PE bias relaxations).

### Testing
- Ran compilation: `python -m compileall -q src tests` — passed.
- Ran targeted tests: `pytest -q tests/strategies/test_runner_readiness_diagnostics.py tests/core/test_strategy_manager_consensus.py tests/core/test_strategy_manager_single_vote_disabled_reason.py tests/data/test_market_data_manager.py` — all passed.
- Ran broader suites: `pytest -q tests/data tests/strategies tests/execution tests/core tests/test_live_readiness_gate.py` — all passed.
- Summary: focused and broader test suites passed in this environment; no behavioral changes to broker/margin/kill-switch checks were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16a4c602348324b9bc2b81e085e452)