### PR TITLE
Fix expired NIFTY futures regeneration and make futures-resolution idempotent

### DIFF
--- a/src/nifty_scalper_bot/core/active_basket.py
+++ b/src/nifty_scalper_bot/core/active_basket.py
@@ -66,6 +66,14 @@ def normalize_active_basket_schema(basket: Mapping[str, object]) -> dict[str, ob
     out = dict(basket or {})
     spot_symbol = str(out.get("spot_symbol") or "NSE:NIFTY")
     futures_symbol = str(out.get("futures_symbol") or out.get("future_symbol") or "")
+    futures_symbol_valid = (
+        not futures_symbol
+        or (
+            futures_symbol.startswith("NFO:NIFTY")
+            and futures_symbol.endswith("FUT")
+            and len(futures_symbol.split(":", 1)[-1]) >= len("NIFTY26JUNFUT")
+        )
+    )
     option_symbols = [
         str(s)
         for s in list(out.get("option_symbols") or out.get("symbols") or [])
@@ -102,6 +110,7 @@ def normalize_active_basket_schema(basket: Mapping[str, object]) -> dict[str, ob
     out["selected_pe"] = selected_pe
     out["atm_ce"] = out.get("atm_ce") or selected_ce
     out["atm_pe"] = out.get("atm_pe") or selected_pe
+    out["futures_symbol_valid_shape"] = futures_symbol_valid
     out["symbols"] = list(dict.fromkeys([s for s in [spot_symbol, futures_symbol, *option_symbols] if s]))
     return out
 

--- a/src/nifty_scalper_bot/core/active_basket.py
+++ b/src/nifty_scalper_bot/core/active_basket.py
@@ -66,14 +66,6 @@ def normalize_active_basket_schema(basket: Mapping[str, object]) -> dict[str, ob
     out = dict(basket or {})
     spot_symbol = str(out.get("spot_symbol") or "NSE:NIFTY")
     futures_symbol = str(out.get("futures_symbol") or out.get("future_symbol") or "")
-    futures_symbol_valid = (
-        not futures_symbol
-        or (
-            futures_symbol.startswith("NFO:NIFTY")
-            and futures_symbol.endswith("FUT")
-            and len(futures_symbol.split(":", 1)[-1]) >= len("NIFTY26JUNFUT")
-        )
-    )
     option_symbols = [
         str(s)
         for s in list(out.get("option_symbols") or out.get("symbols") or [])
@@ -110,7 +102,6 @@ def normalize_active_basket_schema(basket: Mapping[str, object]) -> dict[str, ob
     out["selected_pe"] = selected_pe
     out["atm_ce"] = out.get("atm_ce") or selected_ce
     out["atm_pe"] = out.get("atm_pe") or selected_pe
-    out["futures_symbol_valid_shape"] = futures_symbol_valid
     out["symbols"] = list(dict.fromkeys([s for s in [spot_symbol, futures_symbol, *option_symbols] if s]))
     return out
 

--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -7406,6 +7406,10 @@ def _commit_active_dynamic_basket(
     active_futures_symbol = _resolve_active_futures_for_basket(ctx, requested_futures_symbol)
     basket = dict(basket)
     basket["futures_symbol"] = active_futures_symbol
+    mdm_for_purge = getattr(ctx, "market_data_manager", None)
+    purge_stale_futures = getattr(mdm_for_purge, "purge_stale_nifty_futures", None)
+    if callable(purge_stale_futures):
+        purge_stale_futures(active_futures_symbol, reason="active_dynamic_basket_commit")
     current_options = [str(sym) for sym in option_symbols if str(sym).endswith(("CE", "PE"))]
     current_symbols = [str(sym) for sym in symbols if sym]
     local_basket = dict(basket or {})
@@ -7519,7 +7523,7 @@ def _commit_active_dynamic_basket(
     if callable(rotate_result):
         try:
             rotate_result(
-                active_futures_symbol,
+                requested_futures_symbol,
                 reason="active_dynamic_basket_commit",
                 selected_option_symbols=list(current_options),
             )

--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -7519,7 +7519,7 @@ def _commit_active_dynamic_basket(
     if callable(rotate_result):
         try:
             rotate_result(
-                requested_futures_symbol,
+                active_futures_symbol,
                 reason="active_dynamic_basket_commit",
                 selected_option_symbols=list(current_options),
             )
@@ -8554,7 +8554,7 @@ async def startup_sequence(ctx: BotContext) -> None:
                 dict.fromkeys(
                     [
                         "NSE:NIFTY",
-                        requested_futures_symbol,
+                        active_futures_symbol,
                         *selected_symbols,
                         *other_option_symbols,
                     ]
@@ -8805,6 +8805,7 @@ async def startup_sequence(ctx: BotContext) -> None:
                     )
 
             basket = normalize_active_basket_schema(basket)
+            active_futures_symbol = str(basket.get("futures_symbol") or "")
             active_option_symbols = select_active_option_symbols(
                 option_symbols=basket.get("option_symbols", []) or [],
                 atm=basket.get("atm_strike"),
@@ -8812,7 +8813,7 @@ async def startup_sequence(ctx: BotContext) -> None:
             )
             readiness_symbols = list(dict.fromkeys([
                 basket.get("spot_symbol"),
-                requested_futures_symbol,
+                active_futures_symbol,
                 *active_option_symbols,
             ]))
             readiness_symbols = [str(sym) for sym in readiness_symbols if sym]
@@ -8820,14 +8821,14 @@ async def startup_sequence(ctx: BotContext) -> None:
                 "READINESS_SYMBOLS_SELECTED count=%d spot=%s futures=%s option_count=%d symbols=%s",
                 len(readiness_symbols),
                 basket.get("spot_symbol"),
-                requested_futures_symbol,
+                active_futures_symbol,
                 len(basket.get("option_symbols", []) or []),
                 readiness_symbols,
                 extra={
                     "event": "READINESS_SYMBOLS_SELECTED",
                     "count": len(readiness_symbols),
                     "spot": basket.get("spot_symbol"),
-                    "futures": basket.get("futures_symbol"),
+                    "futures": active_futures_symbol,
                     "option_count": len(basket.get("option_symbols", []) or []),
                     "symbols": readiness_symbols,
                 },

--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -54,6 +54,7 @@ from nifty_scalper_bot.data.robust_provider import (
     RobustDataProvider,
 )
 from nifty_scalper_bot.infra.watchdog import start_watchdog
+from nifty_scalper_bot.instruments.active_contracts import canonical_nifty_future_symbol
 
 LOGGER = logging.getLogger("nifty_scalper_bot.core.app")
 SYNC_LOCK = threading.Lock()
@@ -1086,24 +1087,28 @@ _LATEST_CTX: "BotContext | None" = None
 
 def _resolve_active_futures_for_basket(ctx: BotContext, requested: object | None) -> str:
     """Return authoritative active NIFTY futures symbol for runtime basket."""
-    requested_symbol = str(requested or "").strip().upper()
     mdm = getattr(ctx, "market_data_manager", None)
     for method_name in ("get_active_nifty_future_symbol_cached", "resolve_active_nifty_future_symbol"):
         method = getattr(mdm, method_name, None)
-        if callable(method):
+        if not callable(method):
+            continue
+        try:
+            resolved = method()
+        except TypeError:
             try:
-                resolved = method()
-            except TypeError:
-                try:
-                    resolved = method(now=None)
-                except Exception:
-                    resolved = None
+                resolved = method(now=None)
             except Exception:
                 resolved = None
-            if resolved:
-                return str(resolved).strip().upper()
-    fallback = _get_current_nifty_futures_symbol()
-    return fallback or requested_symbol
+        except Exception:
+            resolved = None
+        canonical = canonical_nifty_future_symbol(resolved)
+        if canonical:
+            return canonical
+    fallback = canonical_nifty_future_symbol(_get_current_nifty_futures_symbol())
+    if fallback:
+        return fallback
+    requested_canonical = canonical_nifty_future_symbol(requested)
+    return requested_canonical or ""
 
 
 class _LifecycleTrackerAdapter:
@@ -7396,11 +7401,9 @@ def _commit_active_dynamic_basket(
     atm_strike: int | float | str | None,
 ) -> tuple[str | None, str | None]:
     """Commit active dynamic basket atomically. Args: ctx/basket/option_symbols/symbols/atm_strike. Returns: selected CE/PE. Raises: none."""
+    requested_futures_symbol = basket.get("futures_symbol") or basket.get("future_symbol")
     basket = normalize_active_basket_schema(basket)
-    active_futures_symbol = _resolve_active_futures_for_basket(
-        ctx,
-        basket.get("futures_symbol") or basket.get("future_symbol"),
-    )
+    active_futures_symbol = _resolve_active_futures_for_basket(ctx, requested_futures_symbol)
     basket = dict(basket)
     basket["futures_symbol"] = active_futures_symbol
     current_options = [str(sym) for sym in option_symbols if str(sym).endswith(("CE", "PE"))]
@@ -7489,9 +7492,13 @@ def _commit_active_dynamic_basket(
             "symbols": list(
                 dict.fromkeys(
                     [
-                        basket.get("spot_symbol") or "NSE:NIFTY",
-                        active_futures_symbol,
-                        *current_options,
+                        s
+                        for s in [
+                            basket.get("spot_symbol") or "NSE:NIFTY",
+                            active_futures_symbol or None,
+                            *current_options,
+                        ]
+                        if s
                     ]
                 )
             ),
@@ -7512,7 +7519,7 @@ def _commit_active_dynamic_basket(
     if callable(rotate_result):
         try:
             rotate_result(
-                basket.get("futures_symbol"),
+                requested_futures_symbol,
                 reason="active_dynamic_basket_commit",
                 selected_option_symbols=list(current_options),
             )
@@ -8547,7 +8554,7 @@ async def startup_sequence(ctx: BotContext) -> None:
                 dict.fromkeys(
                     [
                         "NSE:NIFTY",
-                        basket.get("futures_symbol"),
+                        requested_futures_symbol,
                         *selected_symbols,
                         *other_option_symbols,
                     ]
@@ -8805,7 +8812,7 @@ async def startup_sequence(ctx: BotContext) -> None:
             )
             readiness_symbols = list(dict.fromkeys([
                 basket.get("spot_symbol"),
-                basket.get("futures_symbol"),
+                requested_futures_symbol,
                 *active_option_symbols,
             ]))
             readiness_symbols = [str(sym) for sym in readiness_symbols if sym]
@@ -8813,7 +8820,7 @@ async def startup_sequence(ctx: BotContext) -> None:
                 "READINESS_SYMBOLS_SELECTED count=%d spot=%s futures=%s option_count=%d symbols=%s",
                 len(readiness_symbols),
                 basket.get("spot_symbol"),
-                basket.get("futures_symbol"),
+                requested_futures_symbol,
                 len(basket.get("option_symbols", []) or []),
                 readiness_symbols,
                 extra={

--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -1084,6 +1084,28 @@ _HTTP_CONTROLLER: TelegramWebhookController | None = None
 _LATEST_CTX: "BotContext | None" = None
 
 
+def _resolve_active_futures_for_basket(ctx: BotContext, requested: object | None) -> str:
+    """Return authoritative active NIFTY futures symbol for runtime basket."""
+    requested_symbol = str(requested or "").strip().upper()
+    mdm = getattr(ctx, "market_data_manager", None)
+    for method_name in ("get_active_nifty_future_symbol_cached", "resolve_active_nifty_future_symbol"):
+        method = getattr(mdm, method_name, None)
+        if callable(method):
+            try:
+                resolved = method()
+            except TypeError:
+                try:
+                    resolved = method(now=None)
+                except Exception:
+                    resolved = None
+            except Exception:
+                resolved = None
+            if resolved:
+                return str(resolved).strip().upper()
+    fallback = _get_current_nifty_futures_symbol()
+    return fallback or requested_symbol
+
+
 class _LifecycleTrackerAdapter:
     """Adapter exposing tracker hooks required by the lifecycle manager."""
 
@@ -7375,6 +7397,12 @@ def _commit_active_dynamic_basket(
 ) -> tuple[str | None, str | None]:
     """Commit active dynamic basket atomically. Args: ctx/basket/option_symbols/symbols/atm_strike. Returns: selected CE/PE. Raises: none."""
     basket = normalize_active_basket_schema(basket)
+    active_futures_symbol = _resolve_active_futures_for_basket(
+        ctx,
+        basket.get("futures_symbol") or basket.get("future_symbol"),
+    )
+    basket = dict(basket)
+    basket["futures_symbol"] = active_futures_symbol
     current_options = [str(sym) for sym in option_symbols if str(sym).endswith(("CE", "PE"))]
     current_symbols = [str(sym) for sym in symbols if sym]
     local_basket = dict(basket or {})
@@ -7449,7 +7477,7 @@ def _commit_active_dynamic_basket(
         {
             "spot_symbol": basket.get("spot_symbol") or "NSE:NIFTY",
             "spot_token": basket.get("spot_token"),
-            "futures_symbol": basket.get("futures_symbol") or "",
+            "futures_symbol": active_futures_symbol,
             "futures_token": basket.get("futures_token"),
             "selected_ce": selected_ce,
             "selected_pe": selected_pe,
@@ -7462,7 +7490,7 @@ def _commit_active_dynamic_basket(
                 dict.fromkeys(
                     [
                         basket.get("spot_symbol") or "NSE:NIFTY",
-                        basket.get("futures_symbol") or "",
+                        active_futures_symbol,
                         *current_options,
                     ]
                 )
@@ -7475,6 +7503,25 @@ def _commit_active_dynamic_basket(
     runner = getattr(ctx, "strategy_runner", None)
     if runner is not None and hasattr(runner, "set_active_trading_universe"):
         runner.set_active_trading_universe(committed)
+    strategy_manager = getattr(ctx, "strategy_manager", None)
+    set_fut = getattr(strategy_manager, "set_active_futures_symbol", None)
+    if callable(set_fut):
+        set_fut(active_futures_symbol, source="active_dynamic_basket_commit")
+    mdm = getattr(ctx, "market_data_manager", None)
+    rotate_result = getattr(mdm, "maybe_rotate_nifty_futures_context_result", None)
+    if callable(rotate_result):
+        try:
+            rotate_result(
+                basket.get("futures_symbol"),
+                reason="active_dynamic_basket_commit",
+                selected_option_symbols=list(current_options),
+            )
+        except Exception as exc:
+            LOGGER.warning(
+                "ACTIVE_BASKET_FUTURES_ROTATION_CHECK_FAILED error=%s",
+                exc,
+                extra={"event": "ACTIVE_BASKET_FUTURES_ROTATION_CHECK_FAILED", "error": str(exc)},
+            )
     return selected_ce, selected_pe
 
 

--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -1104,11 +1104,12 @@ def _resolve_active_futures_for_basket(ctx: BotContext, requested: object | None
         canonical = canonical_nifty_future_symbol(resolved)
         if canonical:
             return canonical
-    fallback = canonical_nifty_future_symbol(_get_current_nifty_futures_symbol())
-    if fallback:
-        return fallback
-    requested_canonical = canonical_nifty_future_symbol(requested)
-    return requested_canonical or ""
+    LOGGER.warning(
+        "FUTURES_CONTEXT_UNAVAILABLE requested=%s reason=active_future_unresolved",
+        requested,
+        extra={"event": "FUTURES_CONTEXT_UNAVAILABLE", "requested_symbol": str(requested or ""), "reason": "active_future_unresolved"},
+    )
+    return ""
 
 
 class _LifecycleTrackerAdapter:
@@ -4900,8 +4901,19 @@ def initialize_components(settings: Settings | None = None) -> BotContext:
                     LOGGER.warning(
                         f"Failed to inject DataHub into {strategy.name}: {exc}"
                     )
-    futures_symbol = _get_current_nifty_futures_symbol()
-    LOGGER.info("📅 Using futures symbol: %s", futures_symbol)
+    futures_symbol = ""
+    for _method_name in ("get_active_nifty_future_symbol_cached", "resolve_active_nifty_future_symbol"):
+        _method = getattr(market_data_manager, _method_name, None)
+        if callable(_method):
+            try:
+                futures_symbol = canonical_nifty_future_symbol(_method()) or ""
+            except TypeError:
+                futures_symbol = canonical_nifty_future_symbol(_method(now=None)) or ""
+            except Exception:
+                futures_symbol = ""
+            if futures_symbol:
+                break
+    LOGGER.info("📅 Using active futures symbol: %s", futures_symbol or "unavailable")
     orchestrator = StrategyOrchestrator(
         risk_manager=risk_manager,
         order_manager=safe_order_manager,
@@ -7402,10 +7414,10 @@ def _commit_active_dynamic_basket(
 ) -> tuple[str | None, str | None]:
     """Commit active dynamic basket atomically. Args: ctx/basket/option_symbols/symbols/atm_strike. Returns: selected CE/PE. Raises: none."""
     requested_futures_symbol = basket.get("futures_symbol") or basket.get("future_symbol")
-    basket = normalize_active_basket_schema(basket)
     active_futures_symbol = _resolve_active_futures_for_basket(ctx, requested_futures_symbol)
-    basket = dict(basket)
-    basket["futures_symbol"] = active_futures_symbol
+    basket_copy = dict(basket or {})
+    basket_copy["futures_symbol"] = active_futures_symbol
+    basket = normalize_active_basket_schema(basket_copy)
     mdm_for_purge = getattr(ctx, "market_data_manager", None)
     purge_stale_futures = getattr(mdm_for_purge, "purge_stale_nifty_futures", None)
     if callable(purge_stale_futures):
@@ -7718,15 +7730,16 @@ async def _build_and_hydrate_live_basket_from_spot(
             if ctx.broker_client is None:
                 raise RuntimeError('broker_client_unavailable_for_live_basket')
 
-            import calendar
-            now = datetime.now()
-            year, month = now.year, now.month
-            last_day = calendar.monthrange(year, month)[1]
-            expiry_date = datetime(year, month, last_day)
-            while expiry_date.weekday() != 1:
-                expiry_date -= timedelta(days=1)
-            target_date = expiry_date + timedelta(days=7) if now.date() > expiry_date.date() else now
-            future_symbol = f"NFO:NIFTY{target_date.strftime('%y')}{target_date.strftime('%b').upper()}FUT"
+            future_symbol = _resolve_active_futures_for_basket(ctx, None)
+            if future_symbol:
+                purge_stale = getattr(ctx.market_data_manager, "purge_stale_nifty_futures", None)
+                if callable(purge_stale):
+                    purge_stale(future_symbol, reason="startup_active_future_resolution")
+            else:
+                LOGGER.warning(
+                    "FUTURES_CONTEXT_UNAVAILABLE reason=startup_active_future_unresolved",
+                    extra={"event": "FUTURES_CONTEXT_UNAVAILABLE", "reason": "startup_active_future_unresolved"},
+                )
 
             basket = _build_canonical_active_basket(
                 instrument_manager=ctx.instrument_manager,
@@ -8380,40 +8393,37 @@ async def startup_sequence(ctx: BotContext) -> None:
                 market_data_manager=ctx.market_data_manager,
             )
 
-            # ---------- Futures rollover logic (unchanged) ----------
-            import calendar
-
-            now = datetime.now()
-            year, month = now.year, now.month
-            last_day = calendar.monthrange(year, month)[1]
-            expiry_date = datetime(year, month, last_day)
-
-            while expiry_date.weekday() != 1:  # Tuesday
-                expiry_date -= timedelta(days=1)
-
-            target_date = (
-                expiry_date + timedelta(days=7)
-                if now.date() > expiry_date.date()
-                else now
-            )
-            y_str = target_date.strftime("%y")
-            m_str = target_date.strftime("%b").upper()
-            future_symbol = f"NFO:NIFTY{y_str}{m_str}FUT"
-
-            if ctx.instrument_manager and ctx.instrument_manager.is_loaded():
+            active_futures_symbol = _resolve_active_futures_for_basket(ctx, None)
+            if active_futures_symbol:
                 try:
-                    fut_token = ctx.instrument_manager.get_token(future_symbol)
-                    if fut_token:
-                        LOGGER.info(
-                            f"✅ Resolved Futures (Data Only): {future_symbol} -> {fut_token}"
-                        )
-                        targets.append(future_symbol)
-                        if ctx.strategy_manager and hasattr(
-                            ctx.strategy_manager, "orchestrator"
-                        ):
-                            ctx.strategy_manager.orchestrator.futures_symbol = future_symbol
-                except RuntimeError:
-                    LOGGER.warning(f"⚠️ Could not resolve Futures: {future_symbol}")
+                    fut_token = ctx.instrument_manager.get_token(active_futures_symbol) if ctx.instrument_manager and ctx.instrument_manager.is_loaded() else None
+                except Exception:
+                    fut_token = None
+                if fut_token:
+                    LOGGER.info(
+                        "ACTIVE_FUTURES_TARGET_RESOLVED symbol=%s token=%s",
+                        active_futures_symbol,
+                        fut_token,
+                        extra={"event": "ACTIVE_FUTURES_TARGET_RESOLVED", "symbol": active_futures_symbol, "token": int(fut_token)},
+                    )
+                    targets.append(active_futures_symbol)
+                    purge_stale = getattr(ctx.market_data_manager, "purge_stale_nifty_futures", None)
+                    if callable(purge_stale):
+                        purge_stale(active_futures_symbol, reason="startup_active_future_resolution")
+                    orchestrator = getattr(getattr(ctx, "strategy_manager", None), "orchestrator", None)
+                    if orchestrator is not None:
+                        orchestrator.futures_symbol = active_futures_symbol
+                else:
+                    LOGGER.warning(
+                        "FUTURES_CONTEXT_UNAVAILABLE symbol=%s reason=startup_active_future_token_missing",
+                        active_futures_symbol,
+                        extra={"event": "FUTURES_CONTEXT_UNAVAILABLE", "symbol": active_futures_symbol, "reason": "startup_active_future_token_missing"},
+                    )
+            else:
+                LOGGER.warning(
+                    "FUTURES_CONTEXT_UNAVAILABLE reason=startup_active_future_unresolved",
+                    extra={"event": "FUTURES_CONTEXT_UNAVAILABLE", "reason": "startup_active_future_unresolved"},
+                )
 
             if "NSE:NIFTY" not in targets:
                 targets.append("NSE:NIFTY")
@@ -9366,7 +9376,15 @@ async def startup_sequence(ctx: BotContext) -> None:
 
             if tokens_to_poll:
                 if mdm is not None:
-                    seeded = mdm.request_token_subscriptions(tokens_to_poll)
+                    seeded = 0
+                    seeded_tokens: set[int] = set()
+                    for _sym, _tok in sorted(active_symbol_tokens.items()):
+                        if _tok in tokens_to_poll and mdm.request_token_subscription(int(_tok), str(_sym)):
+                            seeded += 1
+                            seeded_tokens.add(int(_tok))
+                    remaining_tokens = [int(_tok) for _tok in tokens_to_poll if int(_tok) not in seeded_tokens]
+                    if remaining_tokens:
+                        seeded += mdm.request_token_subscriptions(remaining_tokens)
                     LOGGER.info(
                         "✅ Routed %d/%d startup tokens via MarketDataManager",
                         seeded,

--- a/src/nifty_scalper_bot/core/strategy_manager.py
+++ b/src/nifty_scalper_bot/core/strategy_manager.py
@@ -22,6 +22,7 @@ from nifty_scalper_bot.core.adaptive_calibration import (
 from nifty_scalper_bot.core.market_regime import RegimeSnapshot
 from nifty_scalper_bot.core.market_regime_manager import MarketRegimeManager
 from nifty_scalper_bot.infra.metrics import METRICS
+from nifty_scalper_bot.instruments.active_contracts import canonical_nifty_future_symbol
 from nifty_scalper_bot.strategies.elite_strategies.base_elite import EliteStrategy
 from nifty_scalper_bot.strategies.signal_quality import infer_option_side
 from nifty_scalper_bot.strategies.signal_generator import (
@@ -2639,6 +2640,23 @@ class StrategyManager(_BaseStrategyManager):
             context_snapshots = getattr(self, "_latest_context_snapshots", {})
             spot_ctx = context_snapshots.get("spot_context", {})
             fut_ctx = context_snapshots.get("futures_context", {})
+            active_fut = self._resolve_active_futures_symbol_for_metrics()
+            fut_ctx_symbol = canonical_nifty_future_symbol((fut_ctx or {}).get("symbol") if isinstance(fut_ctx, dict) else None)
+            active_fut_canonical = canonical_nifty_future_symbol(active_fut)
+            if fut_ctx_symbol and active_fut_canonical and fut_ctx_symbol != active_fut_canonical:
+                fut_ctx = {}
+                indicators.setdefault("context_discard_reasons", []).append("stale_futures_context_discarded")
+                log_throttled(
+                    log,
+                    f"stale_futures_context_discarded:{symbol}",
+                    "STALE_FUTURES_CONTEXT_DISCARDED symbol=%s stale=%s active=%s",
+                    symbol,
+                    fut_ctx_symbol,
+                    active_fut_canonical,
+                    interval_sec=60.0,
+                    level=logging.WARNING,
+                    extra={"event": "STALE_FUTURES_CONTEXT_DISCARDED", "symbol": symbol, "stale_symbol": fut_ctx_symbol, "active_symbol": active_fut_canonical},
+                )
             max_context_age = self._live_context_max_age_seconds()
             now_ts = time.time()
             def _fresh(ctx: t.Mapping[str, t.Any]) -> bool:

--- a/src/nifty_scalper_bot/data/data_hub.py
+++ b/src/nifty_scalper_bot/data/data_hub.py
@@ -1318,6 +1318,16 @@ class DataHub:
             except Exception as exc:  # noqa: BLE001
                 LOGGER.debug("pull_quote delegate failed for %s: %s", symbol, exc)
                 return {}
+            if isinstance(quote, Mapping) and quote.get("quote_unavailable_reason"):
+                LOGGER.info(
+                    "DATAHUB_PULL_QUOTE_UNAVAILABLE symbol=%s reason=%s active_future_symbol=%s",
+                    symbol,
+                    quote.get("quote_unavailable_reason"),
+                    quote.get("active_future_symbol"),
+                    extra={"event": "DATAHUB_PULL_QUOTE_UNAVAILABLE", "symbol": symbol, "reason": quote.get("quote_unavailable_reason"), "active_future_symbol": quote.get("active_future_symbol")},
+                )
+                return dict(quote)
+
             if quote:
                 self.store_quote(symbol, quote, source=str(quote.get("source") or "poll"))
                 return self.get_quote(symbol, allow_pull=False) or {}

--- a/src/nifty_scalper_bot/data/data_hub.py
+++ b/src/nifty_scalper_bot/data/data_hub.py
@@ -1327,8 +1327,9 @@ class DataHub:
                     continue
             except Exception:
                 continue
-            if symbol:
-                return str(symbol).strip().upper()
+            canonical = canonical_nifty_future_symbol(symbol)
+            if canonical:
+                return canonical
         return None
 
     def pull_quote(self, symbol: str) -> Dict[str, Any]:

--- a/src/nifty_scalper_bot/data/data_hub.py
+++ b/src/nifty_scalper_bot/data/data_hub.py
@@ -16,6 +16,7 @@ import pandas as pd
 from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, Mapping, Optional
 
 from nifty_scalper_bot.storage.hub_store import HubStore
+from nifty_scalper_bot.instruments.active_contracts import canonical_nifty_future_symbol
 from nifty_scalper_bot.utils.options_math import black_scholes_greeks, implied_volatility
 from nifty_scalper_bot.data.normalizers import normalize_history_row
 from nifty_scalper_bot.utils.symbols import canonical
@@ -1331,6 +1332,39 @@ class DataHub:
             if canonical:
                 return canonical
         return None
+
+
+    def purge_symbol_aliases(self, symbols: Iterable[str] = (), tokens: Iterable[int] = ()) -> int:
+        """Remove stale symbol/token aliases from DataHub caches."""
+        normalized_symbols = {str(sym or "").strip().upper() for sym in symbols if str(sym or "").strip()}
+        normalized_tokens: set[int] = set()
+        for token in tokens:
+            try:
+                token_int = int(token)
+            except (TypeError, ValueError):
+                continue
+            if token_int > 0:
+                normalized_tokens.add(token_int)
+        with self._lock:
+            for token in list(normalized_tokens):
+                mapped = self._symbol_by_token.pop(token, None)
+                if mapped:
+                    normalized_symbols.add(str(mapped).strip().upper())
+                self._ticks.pop(token, None)
+                self._token_quotes.pop(token, None)
+            for symbol in list(normalized_symbols):
+                token = self._token_by_symbol.pop(symbol, None)
+                if token is not None:
+                    normalized_tokens.add(int(token))
+                    self._symbol_by_token.pop(int(token), None)
+                    self._ticks.pop(int(token), None)
+                    self._token_quotes.pop(int(token), None)
+                aliases = set(self._symbol_aliases.pop(symbol, set()))
+                for alias in aliases:
+                    self._symbol_aliases.get(alias, set()).discard(symbol)
+                for cache in (self._quotes, self._last_ts, self._last_arrival, self._last_ws_arrival, self._last_poll_arrival, self._last_arrival_mono):
+                    cache.pop(symbol, None)
+            return len(normalized_symbols) + len(normalized_tokens)
 
     def pull_quote(self, symbol: str) -> Dict[str, Any]:
         mdm_fn = getattr(self._mdm, "pull_quote", None)

--- a/src/nifty_scalper_bot/data/data_hub.py
+++ b/src/nifty_scalper_bot/data/data_hub.py
@@ -1336,8 +1336,14 @@ class DataHub:
 
     def purge_symbol_aliases(self, symbols: Iterable[str] = (), tokens: Iterable[int] = ()) -> int:
         """Remove stale symbol/token aliases from DataHub caches."""
-        normalized_symbols = {str(sym or "").strip().upper() for sym in symbols if str(sym or "").strip()}
+        normalized_symbols: set[str] = set()
         normalized_tokens: set[int] = set()
+        for sym in symbols:
+            canonical_sym = self._canonical_quote_symbol(sym)
+            if canonical_sym:
+                normalized_symbols.add(canonical_sym)
+                if ":" in canonical_sym:
+                    normalized_symbols.add(canonical_sym.split(":", 1)[1])
         for token in tokens:
             try:
                 token_int = int(token)
@@ -1345,11 +1351,15 @@ class DataHub:
                 continue
             if token_int > 0:
                 normalized_tokens.add(token_int)
+                normalized_symbols.add(str(token_int))
         with self._lock:
             for token in list(normalized_tokens):
                 mapped = self._symbol_by_token.pop(token, None)
                 if mapped:
-                    normalized_symbols.add(str(mapped).strip().upper())
+                    canonical_mapped = self._canonical_quote_symbol(mapped)
+                    normalized_symbols.add(canonical_mapped)
+                    if ":" in canonical_mapped:
+                        normalized_symbols.add(canonical_mapped.split(":", 1)[1])
                 self._ticks.pop(token, None)
                 self._token_quotes.pop(token, None)
             for symbol in list(normalized_symbols):
@@ -1360,10 +1370,20 @@ class DataHub:
                     self._ticks.pop(int(token), None)
                     self._token_quotes.pop(int(token), None)
                 aliases = set(self._symbol_aliases.pop(symbol, set()))
-                for alias in aliases:
-                    self._symbol_aliases.get(alias, set()).discard(symbol)
+                normalized_symbols.update(str(alias).strip().upper() for alias in aliases if str(alias).strip())
                 for cache in (self._quotes, self._last_ts, self._last_arrival, self._last_ws_arrival, self._last_poll_arrival, self._last_arrival_mono):
                     cache.pop(symbol, None)
+            for symbol, aliases in list(self._symbol_aliases.items()):
+                aliases.difference_update(normalized_symbols)
+                if not aliases:
+                    self._symbol_aliases.pop(symbol, None)
+            for symbol in list(normalized_symbols):
+                self._quotes.pop(symbol, None)
+                self._last_ts.pop(symbol, None)
+                self._last_arrival.pop(symbol, None)
+                self._last_ws_arrival.pop(symbol, None)
+                self._last_poll_arrival.pop(symbol, None)
+                self._last_arrival_mono.pop(symbol, None)
             return len(normalized_symbols) + len(normalized_tokens)
 
     def pull_quote(self, symbol: str) -> Dict[str, Any]:

--- a/src/nifty_scalper_bot/data/data_hub.py
+++ b/src/nifty_scalper_bot/data/data_hub.py
@@ -1310,6 +1310,27 @@ class DataHub:
             return None
         return self._tick_price(quote)
 
+
+    def get_active_futures_symbol(self) -> str | None:
+        """Return authoritative active NIFTY future from MDM."""
+        mdm = getattr(self, "_mdm", None)
+        for method_name in ("get_active_nifty_future_symbol_cached", "resolve_active_nifty_future_symbol"):
+            method = getattr(mdm, method_name, None)
+            if not callable(method):
+                continue
+            try:
+                symbol = method()
+            except TypeError:
+                try:
+                    symbol = method(now=None)
+                except Exception:
+                    continue
+            except Exception:
+                continue
+            if symbol:
+                return str(symbol).strip().upper()
+        return None
+
     def pull_quote(self, symbol: str) -> Dict[str, Any]:
         mdm_fn = getattr(self._mdm, "pull_quote", None)
         if callable(mdm_fn):
@@ -1318,16 +1339,6 @@ class DataHub:
             except Exception as exc:  # noqa: BLE001
                 LOGGER.debug("pull_quote delegate failed for %s: %s", symbol, exc)
                 return {}
-            if isinstance(quote, Mapping) and quote.get("quote_unavailable_reason"):
-                LOGGER.info(
-                    "DATAHUB_PULL_QUOTE_UNAVAILABLE symbol=%s reason=%s active_future_symbol=%s",
-                    symbol,
-                    quote.get("quote_unavailable_reason"),
-                    quote.get("active_future_symbol"),
-                    extra={"event": "DATAHUB_PULL_QUOTE_UNAVAILABLE", "symbol": symbol, "reason": quote.get("quote_unavailable_reason"), "active_future_symbol": quote.get("active_future_symbol")},
-                )
-                return dict(quote)
-
             if quote:
                 self.store_quote(symbol, quote, source=str(quote.get("source") or "poll"))
                 return self.get_quote(symbol, allow_pull=False) or {}

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -2531,14 +2531,34 @@ class MarketDataManager:
         canonical_symbol = self._canonical_symbol(symbol)
         if self._is_nifty_future_symbol_expired(canonical_symbol):
             active = self.get_active_nifty_future_symbol_cached()
-            if active and self._canonical_symbol(active) != canonical_symbol:
-                self.rotate_active_nifty_future_context(canonical_symbol, active, reason="pull_quote_expired_future")
-            self._logger.warning(
-                "EXPIRED_FUTURE_SUPPRESSED symbol=%s active=%s stage=pull_quote",
-                canonical_symbol,
-                active,
-                extra={"event": "EXPIRED_FUTURE_SUPPRESSED", "symbol": canonical_symbol, "active_symbol": active, "stage": "pull_quote"},
-            )
+            already_suspended = self.is_context_symbol_suspended(canonical_symbol)
+            if active and self._canonical_symbol(active) != canonical_symbol and not already_suspended:
+                self.rotate_active_nifty_future_context(
+                    canonical_symbol,
+                    active,
+                    reason="pull_quote_expired_future",
+                )
+            log_fn = getattr(self, "_log_throttled", None)
+            log_key = f"expired_future_suppressed:{canonical_symbol}:pull_quote"
+            if callable(log_fn):
+                log_fn(
+                    log_key,
+                    "EXPIRED_FUTURE_SUPPRESSED symbol=%s active=%s stage=pull_quote already_suspended=%s",
+                    canonical_symbol,
+                    active,
+                    already_suspended,
+                    interval_sec=60.0,
+                    level=logging.WARNING,
+                    extra={"event": "EXPIRED_FUTURE_SUPPRESSED", "symbol": canonical_symbol, "active_symbol": active, "stage": "pull_quote", "already_suspended": already_suspended},
+                )
+            else:
+                self._logger.warning(
+                    "EXPIRED_FUTURE_SUPPRESSED symbol=%s active=%s stage=pull_quote already_suspended=%s",
+                    canonical_symbol,
+                    active,
+                    already_suspended,
+                    extra={"event": "EXPIRED_FUTURE_SUPPRESSED", "symbol": canonical_symbol, "active_symbol": active, "stage": "pull_quote", "already_suspended": already_suspended},
+                )
             return {"symbol": canonical_symbol, "quote_unavailable_reason": "suspended_expired_future", "active_future_symbol": active}
         if self.is_context_symbol_suspended(canonical_symbol):
             with self._lock:
@@ -6812,6 +6832,7 @@ class MarketDataManager:
             raise RuntimeError("rotate_active_nifty_future_context requires new_symbol")
         old_token_to_unsubscribe: int | None = None
         with self._lock:
+            already_suspended_old = bool(old_canonical and old_canonical in self._suspended_context_symbols)
             if old_canonical and old_canonical != new_canonical:
                 old_token = self._token_by_symbol.get(old_canonical)
                 self._tracked_symbols.discard(old_canonical)
@@ -6866,13 +6887,15 @@ class MarketDataManager:
         reqs = dict(self._readiness_requirements)
         reqs["futures"] = new_canonical
         self._readiness_requirements = reqs
-        self._logger.warning(
-            "FUTURES_CONTEXT_ROTATED old=%s new=%s reason=%s",
-            old_canonical or None,
-            new_canonical,
-            reason,
-            extra={"event": "FUTURES_CONTEXT_ROTATED", "old_symbol": old_canonical or None, "new_symbol": new_canonical, "reason": reason, "trace_id": trace_id},
-        )
+        rotated = bool(old_canonical and old_canonical != new_canonical)
+        if rotated and not already_suspended_old:
+            self._logger.warning(
+                "FUTURES_CONTEXT_ROTATED old=%s new=%s reason=%s",
+                old_canonical or None,
+                new_canonical,
+                reason,
+                extra={"event": "FUTURES_CONTEXT_ROTATED", "old_symbol": old_canonical or None, "new_symbol": new_canonical, "reason": reason, "trace_id": trace_id},
+            )
         self._logger.info(
             "ACTIVE_FUTURE_READY symbol=%s reason=%s",
             new_canonical,

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -1548,6 +1548,43 @@ class MarketDataManager:
             self._pending_subscriptions.update(self._desired_tokens)
             return
 
+
+    def _resolve_symbol_for_token(self, token: int) -> str | None:
+        """Best-effort reverse token lookup for subscription safety."""
+        token_int = int(token)
+        mapped = self._symbol_by_token.get(token_int) or self._token_to_symbol.get(token_int)
+        if mapped:
+            return self._canonical_symbol(str(mapped))
+        resolver = getattr(self, "_resolver", None)
+        for method_name in ("get_symbol", "resolve_token_to_symbol", "symbol_for_token"):
+            method = getattr(resolver, method_name, None)
+            if callable(method):
+                try:
+                    symbol = method(token_int)
+                except Exception:
+                    symbol = None
+                if symbol:
+                    return self._canonical_symbol(str(symbol))
+        for method_name in ("lookup", "get_instrument"):
+            method = getattr(resolver, method_name, None)
+            if callable(method):
+                try:
+                    row = method(token_int)
+                except Exception:
+                    row = None
+                if isinstance(row, Mapping):
+                    symbol = row.get("symbol") or row.get("tradingsymbol")
+                    exchange = row.get("exchange") or "NFO"
+                    if symbol:
+                        raw = str(symbol).upper()
+                        return self._canonical_symbol(raw if ":" in raw else f"{exchange}:{raw}")
+        return None
+
+    def _is_stale_nifty_future_subscription(self, symbol: str | None, active_future: str | None) -> bool:
+        canonical = canonical_nifty_future_symbol(symbol)
+        active = canonical_nifty_future_symbol(active_future)
+        return bool(canonical and active and canonical != active)
+
     def request_token_subscription(
         self,
         token: int,
@@ -1560,9 +1597,20 @@ class MarketDataManager:
             return False
         if token_int <= 0:
             return False
+        active_future = self.get_active_nifty_future_symbol_cached()
         normalized_symbol: str | None = None
         if symbol:
             normalized_symbol = self._canonical_symbol(symbol)
+            if self._is_stale_nifty_future_subscription(normalized_symbol, active_future):
+                self._logger.warning(
+                    "STALE_FUTURE_TOKEN_SUBSCRIPTION_REJECTED symbol=%s token=%s active=%s",
+                    normalized_symbol,
+                    token_int,
+                    active_future,
+                    extra={"event": "STALE_FUTURE_TOKEN_SUBSCRIPTION_REJECTED", "symbol": normalized_symbol, "token": token_int, "active_symbol": active_future},
+                )
+                self.purge_stale_nifty_futures(active_future, reason="stale_future_subscription_rejected")
+                return False
             self.register_symbol(normalized_symbol, token_int)
             if normalized_symbol.endswith(("CE", "PE")):
                 self._logger.info(
@@ -1571,7 +1619,6 @@ class MarketDataManager:
                     token_int,
                 )
 
-        active_future = self.get_active_nifty_future_symbol_cached()
         if active_future:
             self.purge_stale_nifty_futures(active_future, reason="request_token_subscription_pre")
         with self._lock:
@@ -1609,9 +1656,30 @@ class MarketDataManager:
         active_future = self.get_active_nifty_future_symbol_cached()
         if active_future:
             self.purge_stale_nifty_futures(active_future, reason="request_token_subscriptions_pre")
+        accepted: set[int] = set()
+        for token_int in sorted(normalized):
+            symbol = self._resolve_symbol_for_token(token_int)
+            if self._is_stale_nifty_future_subscription(symbol, active_future):
+                self._logger.warning(
+                    "STALE_FUTURE_TOKEN_SUBSCRIPTION_REJECTED symbol=%s token=%s active=%s",
+                    symbol,
+                    token_int,
+                    active_future,
+                    extra={"event": "STALE_FUTURE_TOKEN_SUBSCRIPTION_REJECTED", "symbol": symbol, "token": token_int, "active_symbol": active_future},
+                )
+                continue
+            if active_future and symbol is None:
+                self._logger.warning(
+                    "UNKNOWN_TOKEN_IN_DESIRED_SUBSCRIPTIONS token=%s",
+                    token_int,
+                    extra={"event": "UNKNOWN_TOKEN_IN_DESIRED_SUBSCRIPTIONS", "token": token_int},
+                )
+            accepted.add(token_int)
+        if not accepted:
+            return 0
         with self._lock:
             before = len(self._desired_tokens)
-            self._desired_tokens.update(normalized)
+            self._desired_tokens.update(accepted)
             added_count = len(self._desired_tokens) - before
         if active_future:
             self.purge_stale_nifty_futures(active_future, reason="request_token_subscriptions_post")
@@ -6913,9 +6981,42 @@ class MarketDataManager:
                 self._dispatched_subscriptions.discard(token)
                 self._confirmed_subscriptions.discard(token)
 
+        ws_tokens: list[int] = []
+        ws = self._ws
+        if ws is not None:
+            snapshot = getattr(ws, "tokens_snapshot", None)
+            if callable(snapshot):
+                try:
+                    ws_tokens = [int(token) for token in snapshot()]
+                except Exception:
+                    ws_tokens = []
+            else:
+                raw_tokens = getattr(ws, "_tokens", set()) or set()
+                ws_tokens = sorted(int(token) for token in raw_tokens)
+        for token in list(ws_tokens):
+            if token not in self._desired_tokens:
+                stale_tokens.add(token)
+        unknown_tokens: list[int] = []
+        for token in sorted(self._desired_tokens):
+            if self._resolve_symbol_for_token(int(token)) is None:
+                unknown_tokens.append(int(token))
+                self._logger.warning(
+                    "UNKNOWN_TOKEN_IN_DESIRED_SUBSCRIPTIONS token=%s",
+                    int(token),
+                    extra={"event": "UNKNOWN_TOKEN_IN_DESIRED_SUBSCRIPTIONS", "token": int(token)},
+                )
         purged_tokens = sorted(stale_tokens)
-        if purged_tokens:
+        if purged_tokens or any(token not in self._desired_tokens for token in ws_tokens):
             self._reconcile_ws_subscriptions()
+        self._logger.info(
+            "FUTURES_PURGE_STATE active=%s desired_tokens=%d ws_tokens=%d purged_tokens=%s unknown_tokens=%s",
+            active,
+            len(self._desired_tokens),
+            len(ws_tokens),
+            purged_tokens,
+            unknown_tokens,
+            extra={"event": "FUTURES_PURGE_STATE", "active_symbol": active, "desired_tokens": len(self._desired_tokens), "ws_tokens": len(ws_tokens), "purged_tokens": purged_tokens, "unknown_tokens": unknown_tokens},
+        )
         hub = getattr(self, "data_hub", None) or getattr(self, "_data_hub", None)
         purge_hub = getattr(hub, "purge_symbol_aliases", None)
         if callable(purge_hub):

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -1571,12 +1571,17 @@ class MarketDataManager:
                     token_int,
                 )
 
+        active_future = self.get_active_nifty_future_symbol_cached()
+        if active_future:
+            self.purge_stale_nifty_futures(active_future, reason="request_token_subscription_pre")
         with self._lock:
             self._desired_tokens.add(token_int)
             if normalized_symbol:
                 self._symbol_to_token[normalized_symbol] = token_int
                 self._token_to_symbol[token_int] = normalized_symbol
                 self._symbol_by_token[token_int] = normalized_symbol
+        if active_future:
+            self.purge_stale_nifty_futures(active_future, reason="request_token_subscription_post")
         self._reconcile_ws_subscriptions()
         if normalized_symbol and normalized_symbol.endswith(("CE", "PE")):
             with self._lock:
@@ -1601,10 +1606,15 @@ class MarketDataManager:
                 normalized.add(token_int)
         if not normalized:
             return 0
+        active_future = self.get_active_nifty_future_symbol_cached()
+        if active_future:
+            self.purge_stale_nifty_futures(active_future, reason="request_token_subscriptions_pre")
         with self._lock:
             before = len(self._desired_tokens)
             self._desired_tokens.update(normalized)
             added_count = len(self._desired_tokens) - before
+        if active_future:
+            self.purge_stale_nifty_futures(active_future, reason="request_token_subscriptions_post")
         self._reconcile_ws_subscriptions()
         return added_count
 
@@ -2555,6 +2565,7 @@ class MarketDataManager:
                 level=logging.WARNING,
                 extra={"event": "EXPIRED_FUTURE_SUPPRESSED", "symbol": canonical_symbol, "active_symbol": active, "stage": "pull_quote", "already_suspended": already_suspended},
             )
+            self.purge_stale_nifty_futures(active, reason="pull_quote_expired_future")
             return {}
         if self.is_context_symbol_suspended(canonical_symbol):
             with self._lock:
@@ -6771,9 +6782,11 @@ class MarketDataManager:
             )
             return FuturesContextRotationResult(None, current_symbol, False, True, reason, "unresolved")
         if current_symbol and self._canonical_symbol(current_symbol) == self._canonical_symbol(active):
+            self.purge_stale_nifty_futures(active, reason=reason)
             return FuturesContextRotationResult(current_symbol, current_symbol, False, False, reason, source)
         old_symbol = current_symbol
         self.rotate_active_nifty_future_context(old_symbol, active, reason=reason, trace_id=trace_id)
+        self.purge_stale_nifty_futures(active, reason=reason)
         self._logger.warning(
             "FUTURES_CONTEXT_SYMBOL_ROTATED old_symbol=%s new_symbol=%s reason=%s",
             old_symbol, active, reason,
@@ -6789,6 +6802,134 @@ class MarketDataManager:
         if active:
             return canonical_nifty_future_symbol(active) != canonical
         return is_nifty_future_expired(canonical, now=now)
+
+    def purge_stale_nifty_futures(self, active_symbol: str | None = None, *, reason: str = "active_future_rotation") -> list[int]:
+        """Purge stale NIFTY futures symbols/tokens from runtime subscription state."""
+        active = canonical_nifty_future_symbol(active_symbol) or canonical_nifty_future_symbol(
+            self.get_active_nifty_future_symbol_cached()
+        )
+        if not active:
+            return []
+
+        stale_symbols: set[str] = set()
+        stale_tokens: set[int] = set()
+
+        def _mark_symbol(value: Any) -> None:
+            canonical = canonical_nifty_future_symbol(value)
+            if canonical and canonical != active:
+                stale_symbols.add(canonical)
+
+        def _mark_token(value: Any) -> None:
+            try:
+                token_int = int(value)
+            except (TypeError, ValueError):
+                return
+            if token_int > 0:
+                stale_tokens.add(token_int)
+
+        with self._lock:
+            for symbol in list(self._tracked_symbols) + list(self._active_subscribed_symbols):
+                _mark_symbol(symbol)
+            for mapping_name in ("_token_by_symbol", "_symbol_to_token"):
+                mapping = getattr(self, mapping_name, {})
+                if isinstance(mapping, dict):
+                    for symbol, token in list(mapping.items()):
+                        canonical = canonical_nifty_future_symbol(symbol)
+                        if canonical and canonical != active:
+                            stale_symbols.add(canonical)
+                            _mark_token(token)
+            for mapping_name in ("_symbol_by_token", "_token_to_symbol"):
+                mapping = getattr(self, mapping_name, {})
+                if isinstance(mapping, dict):
+                    for token, symbol in list(mapping.items()):
+                        canonical = canonical_nifty_future_symbol(symbol)
+                        if canonical and canonical != active:
+                            stale_symbols.add(canonical)
+                            _mark_token(token)
+            for cache_name in ("_latest_ticks", "_tick_cache", "_last_tick_snapshot", "_history", "_poll_bar_state", "_last_poll_bucket"):
+                cache = getattr(self, cache_name, {})
+                if isinstance(cache, dict):
+                    for symbol in list(cache.keys()):
+                        _mark_symbol(symbol)
+            reqs = dict(getattr(self, "_readiness_requirements", {}) or {})
+            for key, value in list(reqs.items()):
+                canonical = canonical_nifty_future_symbol(value)
+                if canonical and canonical != active:
+                    stale_symbols.add(canonical)
+                    if key == "futures":
+                        reqs[key] = active
+                    else:
+                        reqs.pop(key, None)
+            reqs["futures"] = active
+            self._readiness_requirements = reqs
+
+            for symbol in list(stale_symbols):
+                token = self._token_by_symbol.get(symbol) or self._symbol_to_token.get(symbol)
+                if token is not None:
+                    _mark_token(token)
+                self._tracked_symbols.discard(symbol)
+                self._active_subscribed_symbols.discard(symbol)
+                self._subscribers.pop(symbol, None)
+                self._latest_ticks.pop(symbol, None)
+                self._tick_cache.pop(symbol, None)
+                self._last_tick_snapshot.pop(symbol, None)
+                self._history.pop(symbol, None)
+                self._ohlc.pop(self._bar_symbol_key(symbol), None)
+                self._poll_bar_state.pop(symbol, None)
+                self._last_poll_bucket.pop(symbol, None)
+                self._last_tick_time.pop(symbol, None)
+                self._last_tick_ts.pop(symbol, None)
+                self._last_tick_wallclock.pop(symbol, None)
+                self._last_quote_ts_ms.pop(symbol, None)
+                self._last_tick_source.pop(symbol, None)
+                self._last_signature.pop(symbol, None)
+                self._last_tick_hash.pop(symbol, None)
+                self._symbols_with_tick.discard(symbol)
+                self._ticks_received_per_symbol.pop(symbol, None)
+                self._last_rest_refresh_attempt.pop(symbol, None)
+                self._quote_direct_miss_count.pop(symbol, None)
+                self._quote_direct_miss_until.pop(symbol, None)
+                self._quote_direct_miss_reason.pop(symbol, None)
+                mapped_token = self._token_by_symbol.pop(symbol, None)
+                if mapped_token is not None:
+                    _mark_token(mapped_token)
+                mapped_token = self._symbol_to_token.pop(symbol, None)
+                if mapped_token is not None:
+                    _mark_token(mapped_token)
+                self._suspended_context_symbols.add(symbol)
+                self._suspended_context_symbol_until[symbol] = time.monotonic() + (48.0 * 3600.0)
+
+            for token in list(stale_tokens):
+                mapped_symbol = self._symbol_by_token.get(token) or self._token_to_symbol.get(token)
+                canonical = canonical_nifty_future_symbol(mapped_symbol)
+                if canonical == active:
+                    stale_tokens.discard(token)
+                    continue
+                self._symbol_by_token.pop(token, None)
+                self._token_to_symbol.pop(token, None)
+                self._desired_tokens.discard(token)
+                self._pending_subscription_tokens.discard(token)
+                self._pending_subscriptions.discard(token)
+                self._dispatched_subscriptions.discard(token)
+                self._confirmed_subscriptions.discard(token)
+
+        purged_tokens = sorted(stale_tokens)
+        if purged_tokens:
+            self._reconcile_ws_subscriptions()
+        hub = getattr(self, "data_hub", None) or getattr(self, "_data_hub", None)
+        purge_hub = getattr(hub, "purge_symbol_aliases", None)
+        if callable(purge_hub):
+            purge_hub(symbols=sorted(stale_symbols), tokens=purged_tokens)
+        if stale_symbols or purged_tokens:
+            self._logger.warning(
+                "FUTURES_STALE_SUBSCRIPTION_PURGED active=%s purged_symbols=%s purged_tokens=%s reason=%s",
+                active,
+                sorted(stale_symbols),
+                purged_tokens,
+                reason,
+                extra={"event": "FUTURES_STALE_SUBSCRIPTION_PURGED", "active_symbol": active, "purged_symbols": sorted(stale_symbols), "purged_tokens": purged_tokens, "reason": reason},
+            )
+        return purged_tokens
 
     def rotate_active_nifty_future_context(
         self,
@@ -6859,6 +7000,7 @@ class MarketDataManager:
         reqs = dict(self._readiness_requirements)
         reqs["futures"] = new_canonical
         self._readiness_requirements = reqs
+        self.purge_stale_nifty_futures(new_canonical, reason=reason)
         rotated = bool(old_canonical and old_canonical != new_canonical)
         if rotated and not already_suspended_old:
             self._logger.warning(

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -33,6 +33,12 @@ from nifty_scalper_bot.data.market_data_policy import MarketDataPolicy
 from nifty_scalper_bot.data.normalizers import normalize_history_row
 from nifty_scalper_bot.data.validator import validate_tick
 from nifty_scalper_bot.data.source import DataIntegrityError
+from nifty_scalper_bot.instruments.active_contracts import (
+    canonical_nifty_future_symbol,
+    is_nifty_future_expired,
+    resolve_active_nifty_future,
+    resolve_active_nifty_future_from_instruments,
+)
 from nifty_scalper_bot.infra.metrics import METRICS
 from nifty_scalper_bot.streaming.websocket_manager import (
     ConnectionState,
@@ -2538,28 +2544,18 @@ class MarketDataManager:
                     active,
                     reason="pull_quote_expired_future",
                 )
-            log_fn = getattr(self, "_log_throttled", None)
-            log_key = f"expired_future_suppressed:{canonical_symbol}:pull_quote"
-            if callable(log_fn):
-                log_fn(
-                    log_key,
-                    "EXPIRED_FUTURE_SUPPRESSED symbol=%s active=%s stage=pull_quote already_suspended=%s",
-                    canonical_symbol,
-                    active,
-                    already_suspended,
-                    interval_sec=60.0,
-                    level=logging.WARNING,
-                    extra={"event": "EXPIRED_FUTURE_SUPPRESSED", "symbol": canonical_symbol, "active_symbol": active, "stage": "pull_quote", "already_suspended": already_suspended},
-                )
-            else:
-                self._logger.warning(
-                    "EXPIRED_FUTURE_SUPPRESSED symbol=%s active=%s stage=pull_quote already_suspended=%s",
-                    canonical_symbol,
-                    active,
-                    already_suspended,
-                    extra={"event": "EXPIRED_FUTURE_SUPPRESSED", "symbol": canonical_symbol, "active_symbol": active, "stage": "pull_quote", "already_suspended": already_suspended},
-                )
-            return {"symbol": canonical_symbol, "quote_unavailable_reason": "suspended_expired_future", "active_future_symbol": active}
+            log_throttled(
+                self._logger,
+                f"expired_future_suppressed:{canonical_symbol}:pull_quote",
+                "EXPIRED_FUTURE_SUPPRESSED symbol=%s active=%s stage=pull_quote already_suspended=%s",
+                canonical_symbol,
+                active,
+                already_suspended,
+                interval_sec=60.0,
+                level=logging.WARNING,
+                extra={"event": "EXPIRED_FUTURE_SUPPRESSED", "symbol": canonical_symbol, "active_symbol": active, "stage": "pull_quote", "already_suspended": already_suspended},
+            )
+            return {}
         if self.is_context_symbol_suspended(canonical_symbol):
             with self._lock:
                 cached_tick = self._latest_ticks.get(canonical_symbol)
@@ -2567,7 +2563,7 @@ class MarketDataManager:
                 cached_quote = dict(cached_tick)
                 cached_quote.setdefault("source", "cache")
                 return cached_quote
-            return {"symbol": canonical_symbol, "quote_unavailable_reason": "suspended_stale_future"}
+            return {}
         candidates: list[str | int] = self._candidate_quote_keys(canonical_symbol)
         if not candidates:
             candidates = [canonical_symbol]
@@ -6719,20 +6715,7 @@ class MarketDataManager:
         return canonical
 
     def _resolve_active_nifty_future_from_instruments(self, instruments: Iterable[Mapping[str, Any]], now: datetime | None = None) -> str | None:
-        ref_now = now or datetime.now(timezone.utc)
-        best_symbol: str | None = None
-        best_expiry: datetime | None = None
-        for row in instruments:
-            if not isinstance(row, Mapping) or not _is_nifty_index_future_row(row):
-                continue
-            tradingsymbol = str(row.get("tradingsymbol") or row.get("symbol") or "").upper()
-            expiry = _parse_instrument_expiry(row.get("expiry"))
-            if expiry is None or expiry < ref_now:
-                continue
-            if best_expiry is None or expiry < best_expiry:
-                best_expiry = expiry
-                best_symbol = f"NFO:{tradingsymbol}"
-        return best_symbol
+        return resolve_active_nifty_future_from_instruments(instruments, now=now).symbol
 
     def maybe_rotate_nifty_futures_context(
         self,
@@ -6773,23 +6756,13 @@ class MarketDataManager:
                 except Exception:
                     pass
         if not active and selected_symbols:
-            selected_ce = next((s for s in selected_symbols if str(s).upper().endswith("CE")), None)
-            selected_pe = next((s for s in selected_symbols if str(s).upper().endswith("PE")), None)
-            months: set[str] = set()
-            for symbol in selected_symbols:
-                match = re.search(r"NIFTY(\d{2}[A-Z]{3})\d{5}(CE|PE)$", str(symbol).upper())
-                if match:
-                    months.add(match.group(1))
-            if len(months) == 1:
-                candidate = f"NFO:NIFTY{next(iter(months))}FUT"
-                if _NIFTY_FUT_RE.match(candidate.split(":", 1)[-1]):
-                    active = self._set_active_nifty_future_cache(candidate)
-                    source = "selected_option_month"
-                    self._logger.warning(
-                        "FUTURES_CONTEXT_FALLBACK_FROM_SELECTED_OPTION old_symbol=%s new_symbol=%s reason=%s source=%s",
-                        current_symbol, active, reason, source,
-                        extra={"event": "FUTURES_CONTEXT_FALLBACK_FROM_SELECTED_OPTION", "old_symbol": current_symbol, "new_symbol": active, "reason": reason, "source": source, "selected_ce": selected_ce, "selected_pe": selected_pe, "trace_id": trace_id},
-                    )
+            resolved = resolve_active_nifty_future(
+                selected_option_symbols=selected_symbols,
+                now=now,
+            )
+            if resolved.symbol:
+                active = self._set_active_nifty_future_cache(resolved.symbol)
+                source = resolved.source
         if not active:
             self._logger.warning(
                 "FUTURES_CONTEXT_STALE_OR_UNRESOLVED current_symbol=%s reason=%s",
@@ -6809,14 +6782,13 @@ class MarketDataManager:
         return FuturesContextRotationResult(active, old_symbol, True, False, reason, source)
 
     def _is_nifty_future_symbol_expired(self, symbol: str, *, now: datetime | None = None) -> bool:
-        canonical = self._canonical_symbol(symbol)
-        symbol_part = canonical.split(":", 1)[-1].upper()
-        if not _NIFTY_FUT_RE.match(symbol_part):
+        canonical = canonical_nifty_future_symbol(symbol)
+        if not canonical:
             return False
         active = self.get_active_nifty_future_symbol_cached(now=now)
-        if not active:
-            return False
-        return self._canonical_symbol(active) != canonical
+        if active:
+            return canonical_nifty_future_symbol(active) != canonical
+        return is_nifty_future_expired(canonical, now=now)
 
     def rotate_active_nifty_future_context(
         self,

--- a/src/nifty_scalper_bot/instruments/__init__.py
+++ b/src/nifty_scalper_bot/instruments/__init__.py
@@ -1,0 +1,1 @@
+"""Instrument and active-contract resolution helpers."""

--- a/src/nifty_scalper_bot/instruments/active_contracts.py
+++ b/src/nifty_scalper_bot/instruments/active_contracts.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import date, datetime, timezone
+from datetime import date, datetime
+from zoneinfo import ZoneInfo
 import calendar
 import re
 from typing import Any, Iterable, Mapping, Sequence
@@ -9,6 +10,7 @@ from typing import Any, Iterable, Mapping, Sequence
 NIFTY_FUT_RE = re.compile(r"^NIFTY(?P<yy>\d{2})(?P<mon>[A-Z]{3})FUT$")
 NIFTY_OPT_RE = re.compile(r"^NIFTY(?P<yy>\d{2})(?P<mon>[A-Z]{3})(?P<strike>\d{4,6})(?P<side>CE|PE)$")
 MONTH_ABBR_TO_NUM = {m.upper(): i for i, m in enumerate(calendar.month_abbr) if m}
+IST = ZoneInfo("Asia/Kolkata")
 
 
 @dataclass(frozen=True)
@@ -28,6 +30,16 @@ def normalize_symbol(symbol: Any) -> str:
             return "NSE:NIFTY"
         return f"NFO:{raw}"
     return raw
+
+
+def _trading_date(now: datetime | date | None = None) -> date:
+    if now is None:
+        return datetime.now(IST).date()
+    if isinstance(now, datetime):
+        if now.tzinfo is None:
+            return now.date()
+        return now.astimezone(IST).date()
+    return now
 
 
 def canonical_nifty_future_symbol(symbol: Any) -> str | None:
@@ -94,8 +106,7 @@ def is_nifty_future_expired(symbol: Any, *, now: datetime | date | None = None) 
     expiry = parse_nifty_future_expiry(symbol)
     if expiry is None:
         return False
-    today = (datetime.now(timezone.utc).date() if now is None else now.date() if isinstance(now, datetime) else now)
-    return today > expiry
+    return _trading_date(now) > expiry
 
 
 def _is_nifty_future_row(row: Mapping[str, Any]) -> bool:
@@ -107,7 +118,7 @@ def _is_nifty_future_row(row: Mapping[str, Any]) -> bool:
 
 
 def resolve_active_nifty_future_from_instruments(instruments: Iterable[Mapping[str, Any]], *, now: datetime | date | None = None) -> ActiveFutureResolution:
-    today = (datetime.now(timezone.utc).date() if now is None else now.date() if isinstance(now, datetime) else now)
+    today = _trading_date(now)
     best_symbol: str | None = None
     best_expiry: date | None = None
     for row in instruments:
@@ -138,14 +149,22 @@ def derive_nifty_future_from_selected_options(selected_option_symbols: Sequence[
     return ActiveFutureResolution(candidate, "selected_options")
 
 
-def resolve_active_nifty_future(*, instruments: Iterable[Mapping[str, Any]] | None = None, selected_option_symbols: Sequence[Any] | None = None, configured_symbol: Any | None = None, now: datetime | date | None = None) -> ActiveFutureResolution:
+def resolve_active_nifty_future(
+    *,
+    instruments: Iterable[Mapping[str, Any]] | None = None,
+    selected_option_symbols: Sequence[Any] | None = None,
+    configured_symbol: Any | None = None,
+    now: datetime | date | None = None,
+    allow_selected_option_fallback: bool = False,
+) -> ActiveFutureResolution:
     if instruments is not None:
         resolved = resolve_active_nifty_future_from_instruments(instruments, now=now)
         if resolved.symbol:
             return resolved
-    selected = derive_nifty_future_from_selected_options(selected_option_symbols, now=now)
-    if selected.symbol:
-        return selected
+    if allow_selected_option_fallback:
+        selected = derive_nifty_future_from_selected_options(selected_option_symbols, now=now)
+        if selected.symbol:
+            return selected
     configured = canonical_nifty_future_symbol(configured_symbol)
     if configured and not is_nifty_future_expired(configured, now=now):
         return ActiveFutureResolution(configured, "configured_symbol")

--- a/src/nifty_scalper_bot/instruments/active_contracts.py
+++ b/src/nifty_scalper_bot/instruments/active_contracts.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime, timezone
+import calendar
+import re
+from typing import Any, Iterable, Mapping, Sequence
+
+NIFTY_FUT_RE = re.compile(r"^NIFTY(?P<yy>\d{2})(?P<mon>[A-Z]{3})FUT$")
+NIFTY_OPT_RE = re.compile(r"^NIFTY(?P<yy>\d{2})(?P<mon>[A-Z]{3})(?P<strike>\d{4,6})(?P<side>CE|PE)$")
+MONTH_ABBR_TO_NUM = {m.upper(): i for i, m in enumerate(calendar.month_abbr) if m}
+
+
+@dataclass(frozen=True)
+class ActiveFutureResolution:
+    symbol: str | None
+    source: str
+    expired_input: bool = False
+    reason: str | None = None
+
+
+def normalize_symbol(symbol: Any) -> str:
+    raw = str(symbol or "").strip().upper()
+    if not raw:
+        return ""
+    if ":" not in raw and raw.startswith("NIFTY"):
+        if raw in {"NIFTY", "NIFTY50", "NSE:NIFTY", "NSE:NIFTY50"}:
+            return "NSE:NIFTY"
+        return f"NFO:{raw}"
+    return raw
+
+
+def canonical_nifty_future_symbol(symbol: Any) -> str | None:
+    canonical = normalize_symbol(symbol)
+    if not canonical or ":" not in canonical:
+        return None
+    exchange, tradingsymbol = canonical.split(":", 1)
+    if exchange != "NFO" or not NIFTY_FUT_RE.fullmatch(tradingsymbol):
+        return None
+    return f"NFO:{tradingsymbol}"
+
+
+def canonical_nifty_option_symbol(symbol: Any) -> str | None:
+    canonical = normalize_symbol(symbol)
+    if not canonical or ":" not in canonical:
+        return None
+    exchange, tradingsymbol = canonical.split(":", 1)
+    if exchange != "NFO" or not NIFTY_OPT_RE.fullmatch(tradingsymbol):
+        return None
+    return f"NFO:{tradingsymbol}"
+
+
+def _last_thursday(year: int, month: int) -> date:
+    d = date(year, month, calendar.monthrange(year, month)[1])
+    while d.weekday() != 3:
+        d = date.fromordinal(d.toordinal() - 1)
+    return d
+
+
+def parse_nifty_future_expiry(symbol: Any) -> date | None:
+    canonical = canonical_nifty_future_symbol(symbol)
+    if not canonical:
+        return None
+    match = NIFTY_FUT_RE.fullmatch(canonical.split(":", 1)[1])
+    if not match:
+        return None
+    year = 2000 + int(match.group("yy"))
+    month = MONTH_ABBR_TO_NUM.get(match.group("mon"))
+    return _last_thursday(year, month) if month else None
+
+
+def parse_instrument_expiry(value: Any) -> date | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, date):
+        return value
+    raw = str(value).strip()
+    if not raw:
+        return None
+    for fmt in ("%Y-%m-%d", "%d-%m-%Y", "%d/%m/%Y", "%Y/%m/%d"):
+        try:
+            return datetime.strptime(raw[:10], fmt).date()
+        except ValueError:
+            continue
+    try:
+        return datetime.fromisoformat(raw.replace("Z", "+00:00")).date()
+    except ValueError:
+        return None
+
+
+def is_nifty_future_expired(symbol: Any, *, now: datetime | date | None = None) -> bool:
+    expiry = parse_nifty_future_expiry(symbol)
+    if expiry is None:
+        return False
+    today = (datetime.now(timezone.utc).date() if now is None else now.date() if isinstance(now, datetime) else now)
+    return today > expiry
+
+
+def _is_nifty_future_row(row: Mapping[str, Any]) -> bool:
+    tradingsymbol = str(row.get("tradingsymbol") or row.get("symbol") or "").upper()
+    name = str(row.get("name") or "").upper()
+    instrument_type = str(row.get("instrument_type") or row.get("segment") or "").upper()
+    exchange = str(row.get("exchange") or "NFO").upper()
+    return exchange == "NFO" and (name == "NIFTY" or tradingsymbol.startswith("NIFTY")) and tradingsymbol.endswith("FUT") and "FUT" in instrument_type and bool(NIFTY_FUT_RE.fullmatch(tradingsymbol))
+
+
+def resolve_active_nifty_future_from_instruments(instruments: Iterable[Mapping[str, Any]], *, now: datetime | date | None = None) -> ActiveFutureResolution:
+    today = (datetime.now(timezone.utc).date() if now is None else now.date() if isinstance(now, datetime) else now)
+    best_symbol: str | None = None
+    best_expiry: date | None = None
+    for row in instruments:
+        if not isinstance(row, Mapping) or not _is_nifty_future_row(row):
+            continue
+        tradingsymbol = str(row.get("tradingsymbol") or row.get("symbol") or "").upper()
+        expiry = parse_instrument_expiry(row.get("expiry")) or parse_nifty_future_expiry(f"NFO:{tradingsymbol}")
+        if expiry is None or expiry < today:
+            continue
+        if best_expiry is None or expiry < best_expiry:
+            best_expiry = expiry
+            best_symbol = f"NFO:{tradingsymbol}"
+    return ActiveFutureResolution(best_symbol, "instrument_master", reason=None if best_symbol else "no_unexpired_nifty_future_found")
+
+
+def derive_nifty_future_from_selected_options(selected_option_symbols: Sequence[Any] | None, *, now: datetime | date | None = None) -> ActiveFutureResolution:
+    symbols = [canonical_nifty_option_symbol(s) for s in (selected_option_symbols or [])]
+    months = set()
+    for symbol in [s for s in symbols if s]:
+        match = NIFTY_OPT_RE.fullmatch(symbol.split(":", 1)[1])
+        if match:
+            months.add(f"{match.group('yy')}{match.group('mon')}")
+    if len(months) != 1:
+        return ActiveFutureResolution(None, "selected_options", reason="ambiguous_or_missing_option_month")
+    candidate = f"NFO:NIFTY{next(iter(months))}FUT"
+    if is_nifty_future_expired(candidate, now=now):
+        return ActiveFutureResolution(None, "selected_options", expired_input=True, reason="derived_future_expired")
+    return ActiveFutureResolution(candidate, "selected_options")
+
+
+def resolve_active_nifty_future(*, instruments: Iterable[Mapping[str, Any]] | None = None, selected_option_symbols: Sequence[Any] | None = None, configured_symbol: Any | None = None, now: datetime | date | None = None) -> ActiveFutureResolution:
+    if instruments is not None:
+        resolved = resolve_active_nifty_future_from_instruments(instruments, now=now)
+        if resolved.symbol:
+            return resolved
+    selected = derive_nifty_future_from_selected_options(selected_option_symbols, now=now)
+    if selected.symbol:
+        return selected
+    configured = canonical_nifty_future_symbol(configured_symbol)
+    if configured and not is_nifty_future_expired(configured, now=now):
+        return ActiveFutureResolution(configured, "configured_symbol")
+    return ActiveFutureResolution(None, "unresolved", reason="active_future_unresolved")

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -2278,7 +2278,30 @@ class StrategyRunner:
 
     def set_active_trading_universe(self, basket: Mapping[str, Any]) -> None:
         """Set active trading universe snapshot. Args: basket. Returns: none. Raises: none."""
-        option_symbols = basket.get("option_symbols") or basket.get("symbols") or []
+        option_symbols = [
+            normalize_symbol(str(sym))
+            for sym in (basket.get("option_symbols") or basket.get("symbols") or [])
+            if str(sym).endswith(("CE", "PE"))
+        ]
+        futures_symbol = normalize_symbol(str(basket.get("futures_symbol") or ""))
+        previous_futures = normalize_symbol(str(getattr(self, "_active_futures_symbol", "") or ""))
+        self._active_futures_symbol = futures_symbol or None
+        if previous_futures and futures_symbol and previous_futures != futures_symbol:
+            active_symbols = getattr(self, "_active_symbols", set())
+            if isinstance(active_symbols, set):
+                active_symbols.discard(previous_futures)
+                active_symbols.add(futures_symbol)
+            context_snapshots = getattr(self, "_latest_context_snapshots", None)
+            if isinstance(context_snapshots, dict):
+                fut_ctx = context_snapshots.get("futures_context")
+                if isinstance(fut_ctx, dict) and normalize_symbol(str(fut_ctx.get("symbol") or "")) == previous_futures:
+                    context_snapshots.pop("futures_context", None)
+            self._logger.warning(
+                "RUNNER_FUTURES_CONTEXT_ROTATED old=%s new=%s source=active_trading_universe",
+                previous_futures,
+                futures_symbol,
+                extra={"event": "RUNNER_FUTURES_CONTEXT_ROTATED", "old_symbol": previous_futures, "new_symbol": futures_symbol, "source": "active_trading_universe"},
+            )
         self.set_active_option_context(
             selected_ce=cast(str | None, basket.get("selected_ce") or basket.get("atm_ce")),
             selected_pe=cast(str | None, basket.get("selected_pe") or basket.get("atm_pe")),
@@ -2286,10 +2309,12 @@ class StrategyRunner:
             option_symbols=cast(list[str] | tuple[str, ...] | set[str], option_symbols),
         )
         self._logger.info(
-            "RUNNER_ACTIVE_BASKET_UPDATED selected_ce=%s selected_pe=%s option_count=%d",
+            "RUNNER_ACTIVE_BASKET_UPDATED selected_ce=%s selected_pe=%s futures_symbol=%s option_count=%d",
             self._active_selected_ce,
             self._active_selected_pe,
+            self._active_futures_symbol,
             len(self._active_option_symbols),
+            extra={"event": "RUNNER_ACTIVE_BASKET_UPDATED", "selected_ce": self._active_selected_ce, "selected_pe": self._active_selected_pe, "futures_symbol": self._active_futures_symbol, "option_count": len(self._active_option_symbols)},
         )
 
     def set_runtime_readiness(

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -2278,11 +2278,12 @@ class StrategyRunner:
 
     def set_active_trading_universe(self, basket: Mapping[str, Any]) -> None:
         """Set active trading universe snapshot. Args: basket. Returns: none. Raises: none."""
-        option_symbols = [
-            normalize_symbol(str(sym))
-            for sym in (basket.get("option_symbols") or basket.get("symbols") or [])
-            if str(sym).endswith(("CE", "PE"))
-        ]
+        raw_symbols = basket.get("option_symbols") or basket.get("symbols") or []
+        option_symbols: list[str] = []
+        for sym in raw_symbols:
+            normalized = normalize_symbol(str(sym))
+            if normalized.endswith(("CE", "PE")):
+                option_symbols.append(normalized)
         futures_symbol = normalize_symbol(str(basket.get("futures_symbol") or ""))
         previous_futures = normalize_symbol(str(getattr(self, "_active_futures_symbol", "") or ""))
         self._active_futures_symbol = futures_symbol or None

--- a/src/nifty_scalper_bot/strategies/signal_generator.py
+++ b/src/nifty_scalper_bot/strategies/signal_generator.py
@@ -12,6 +12,7 @@ from datetime import datetime, time
 import hashlib
 import math
 import os
+import re
 from typing import Any, Deque, Iterable, Literal, Mapping, MutableMapping, Protocol
 
 from nifty_scalper_bot.core.signal_arbitrator import SignalArbitrator
@@ -1257,7 +1258,7 @@ class StrategyManager:
         self._data_hub = data_hub
         self._logger = logger
         self._orchestrator = orchestrator
-        self._futures_symbol = (futures_symbol or 'NIFTY').strip().upper()
+        self._futures_symbol = self._canonical_futures_symbol(futures_symbol)
         self._futures_volume_history: Deque[float] = deque(maxlen=120)
         self._last_index_ltp: float | None = None
         self._last_index_vwap: float | None = None
@@ -1296,6 +1297,71 @@ class StrategyManager:
             self.min_delta = 0.30
             self.max_iv_percentile = 85.0
             self.max_spread_pct = 5.0
+
+    @staticmethod
+    def _canonical_futures_symbol(symbol: Any) -> str | None:
+        """Return canonical NFO:NIFTYYYMONFUT or None for non-specific/invalid values."""
+        raw = str(symbol or "").strip().upper()
+        if not raw or raw in {"NIFTY", "NSE:NIFTY", "NIFTY50", "NSE:NIFTY50"}:
+            return None
+        if ":" not in raw:
+            raw = f"NFO:{raw}"
+        exchange, tradingsymbol = raw.split(":", 1)
+        exchange = exchange.strip().upper()
+        tradingsymbol = tradingsymbol.strip().upper()
+        if exchange != "NFO":
+            return None
+        if not re.fullmatch(r"NIFTY\d{2}[A-Z]{3}FUT", tradingsymbol):
+            return None
+        return f"NFO:{tradingsymbol}"
+
+    def set_active_futures_symbol(self, symbol: Any, *, source: str = "external") -> str | None:
+        """Update StrategyManager's active futures symbol from the authoritative resolver."""
+        canonical = self._canonical_futures_symbol(symbol)
+        if not canonical:
+            return self._futures_symbol
+        previous = self._futures_symbol
+        if previous != canonical:
+            self._logger.info(
+                "STRATEGY_MANAGER_ACTIVE_FUTURES_SYMBOL_UPDATED old=%s new=%s source=%s",
+                previous,
+                canonical,
+                source,
+                extra={"event": "STRATEGY_MANAGER_ACTIVE_FUTURES_SYMBOL_UPDATED", "old_symbol": previous, "new_symbol": canonical, "source": source},
+            )
+        self._futures_symbol = canonical
+        return canonical
+
+    def _resolve_active_futures_symbol_for_metrics(self) -> str | None:
+        """Resolve active NIFTY future from MDM/DataHub; never construct from calendar month."""
+        data_hub = getattr(self, "_data_hub", None)
+        candidate_sources = [
+            data_hub,
+            getattr(data_hub, "_mdm", None) if data_hub is not None else None,
+            getattr(data_hub, "market_data_manager", None) if data_hub is not None else None,
+            getattr(data_hub, "mdm", None) if data_hub is not None else None,
+        ]
+        for source_obj in candidate_sources:
+            if source_obj is None:
+                continue
+            for method_name in ("get_active_nifty_future_symbol_cached", "resolve_active_nifty_future_symbol"):
+                method = getattr(source_obj, method_name, None)
+                if not callable(method):
+                    continue
+                try:
+                    resolved = method()
+                except TypeError:
+                    try:
+                        resolved = method(now=None)
+                    except Exception:
+                        continue
+                except Exception:
+                    continue
+                canonical = self._canonical_futures_symbol(resolved)
+                if canonical:
+                    self.set_active_futures_symbol(canonical, source=f"{type(source_obj).__name__}.{method_name}")
+                    return canonical
+        return self._canonical_futures_symbol(self._futures_symbol)
 
     def generate_signal(self, symbol: str, current_price: float) -> Signal | None:
         """
@@ -1954,29 +2020,20 @@ class StrategyManager:
             # ✅ FALLBACK: Use futures VWAP if index VWAP unavailable
             # ═══════════════════════════════════════════════════════
             if not indicators.get('nifty_index_vwap'):
-                now = dt.datetime.now()
-                y_str = now.strftime('%y')
-                m_str = now.strftime('%b').upper()
+                symbols_to_try: list[str] = []
+                active_fut = self._resolve_active_futures_symbol_for_metrics()
+                if active_fut:
+                    symbols_to_try.append(active_fut)
 
-                # Build list of symbols to try (in order of preference)
-                symbols_to_try = [
-                    f'NFO:NIFTY{y_str}{m_str}FUT',  # Current month: NFO:NIFTY26FEBFUT
-                ]
+                configured_fut = self._canonical_futures_symbol(self._futures_symbol)
+                if configured_fut and configured_fut not in symbols_to_try:
+                    symbols_to_try.append(configured_fut)
 
-                # Add configured symbol and variations
-                if self._futures_symbol:
-                    if self._futures_symbol not in symbols_to_try:
-                        symbols_to_try.append(self._futures_symbol)
-                    # Try with NFO: prefix if not present
-                    if not self._futures_symbol.startswith('NFO:'):
-                        prefixed = f'NFO:{self._futures_symbol}'
-                        if prefixed not in symbols_to_try:
-                            symbols_to_try.append(prefixed)
-                        # Also try NFO:NIFTY{symbol}FUT pattern
-                        if 'FUT' not in self._futures_symbol.upper():
-                            fut_pattern = f'NFO:{self._futures_symbol}FUT'
-                            if fut_pattern not in symbols_to_try:
-                                symbols_to_try.append(fut_pattern)
+                if not symbols_to_try:
+                    self._logger.warning(
+                        "FUTURES_VWAP_FALLBACK_SKIPPED reason=active_future_unresolved",
+                        extra={"event": "FUTURES_VWAP_FALLBACK_SKIPPED", "reason": "active_future_unresolved", "configured_futures_symbol": self._futures_symbol},
+                    )
 
                 fut_quote = None
                 working_symbol = None
@@ -1984,7 +2041,16 @@ class StrategyManager:
                 for fut_sym in symbols_to_try:
                     try:
                         fut_quote = data_hub.get_quote(fut_sym, allow_pull=True)
-                        if fut_quote:
+                        if isinstance(fut_quote, Mapping) and fut_quote.get("quote_unavailable_reason"):
+                            self._logger.info(
+                                "FUTURES_VWAP_QUOTE_UNAVAILABLE symbol=%s reason=%s active_future_symbol=%s",
+                                fut_sym,
+                                fut_quote.get("quote_unavailable_reason"),
+                                fut_quote.get("active_future_symbol"),
+                                extra={"event": "FUTURES_VWAP_QUOTE_UNAVAILABLE", "symbol": fut_sym, "reason": fut_quote.get("quote_unavailable_reason"), "active_future_symbol": fut_quote.get("active_future_symbol")},
+                            )
+                            continue
+                        if fut_quote and (self._extract_float(fut_quote, ("vwap", "average_price", "last_price", "ltp", "close")) is not None):
                             working_symbol = fut_sym
                             if not getattr(self, '_vwap_source_logged', False):
                                 self._logger.info(

--- a/src/nifty_scalper_bot/strategies/signal_generator.py
+++ b/src/nifty_scalper_bot/strategies/signal_generator.py
@@ -12,11 +12,11 @@ from datetime import datetime, time
 import hashlib
 import math
 import os
-import re
 from typing import Any, Deque, Iterable, Literal, Mapping, MutableMapping, Protocol
 
 from nifty_scalper_bot.core.signal_arbitrator import SignalArbitrator
 from nifty_scalper_bot.execution.readiness import HistoryReadinessPolicy
+from nifty_scalper_bot.instruments.active_contracts import canonical_nifty_future_symbol
 from nifty_scalper_bot.utils.logging import get_logger, log_throttled
 
 logger = get_logger(__name__)
@@ -1300,23 +1300,10 @@ class StrategyManager:
 
     @staticmethod
     def _canonical_futures_symbol(symbol: Any) -> str | None:
-        """Return canonical NFO:NIFTYYYMONFUT or None for non-specific/invalid values."""
-        raw = str(symbol or "").strip().upper()
-        if not raw or raw in {"NIFTY", "NSE:NIFTY", "NIFTY50", "NSE:NIFTY50"}:
-            return None
-        if ":" not in raw:
-            raw = f"NFO:{raw}"
-        exchange, tradingsymbol = raw.split(":", 1)
-        exchange = exchange.strip().upper()
-        tradingsymbol = tradingsymbol.strip().upper()
-        if exchange != "NFO":
-            return None
-        if not re.fullmatch(r"NIFTY\d{2}[A-Z]{3}FUT", tradingsymbol):
-            return None
-        return f"NFO:{tradingsymbol}"
+        return canonical_nifty_future_symbol(symbol)
 
     def set_active_futures_symbol(self, symbol: Any, *, source: str = "external") -> str | None:
-        """Update StrategyManager's active futures symbol from the authoritative resolver."""
+        """Cache latest active futures symbol from SSOT; not an independent resolver."""
         canonical = self._canonical_futures_symbol(symbol)
         if not canonical:
             return self._futures_symbol
@@ -1333,35 +1320,19 @@ class StrategyManager:
         return canonical
 
     def _resolve_active_futures_symbol_for_metrics(self) -> str | None:
-        """Resolve active NIFTY future from MDM/DataHub; never construct from calendar month."""
+        """Resolve active NIFTY future from DataHub/MDM SSOT only."""
         data_hub = getattr(self, "_data_hub", None)
-        candidate_sources = [
-            data_hub,
-            getattr(data_hub, "_mdm", None) if data_hub is not None else None,
-            getattr(data_hub, "market_data_manager", None) if data_hub is not None else None,
-            getattr(data_hub, "mdm", None) if data_hub is not None else None,
-        ]
-        for source_obj in candidate_sources:
-            if source_obj is None:
-                continue
-            for method_name in ("get_active_nifty_future_symbol_cached", "resolve_active_nifty_future_symbol"):
-                method = getattr(source_obj, method_name, None)
-                if not callable(method):
-                    continue
-                try:
-                    resolved = method()
-                except TypeError:
-                    try:
-                        resolved = method(now=None)
-                    except Exception:
-                        continue
-                except Exception:
-                    continue
-                canonical = self._canonical_futures_symbol(resolved)
-                if canonical:
-                    self.set_active_futures_symbol(canonical, source=f"{type(source_obj).__name__}.{method_name}")
-                    return canonical
-        return self._canonical_futures_symbol(self._futures_symbol)
+        get_active = getattr(data_hub, "get_active_futures_symbol", None)
+        if callable(get_active):
+            try:
+                symbol = get_active()
+            except Exception:
+                symbol = None
+            canonical = canonical_nifty_future_symbol(symbol)
+            if canonical:
+                self.set_active_futures_symbol(canonical, source="data_hub.get_active_futures_symbol")
+                return canonical
+        return None
 
     def generate_signal(self, symbol: str, current_price: float) -> Signal | None:
         """
@@ -2025,57 +1996,44 @@ class StrategyManager:
                 if active_fut:
                     symbols_to_try.append(active_fut)
 
-                configured_fut = self._canonical_futures_symbol(self._futures_symbol)
-                if configured_fut and configured_fut not in symbols_to_try:
-                    symbols_to_try.append(configured_fut)
-
                 if not symbols_to_try:
                     self._logger.warning(
                         "FUTURES_VWAP_FALLBACK_SKIPPED reason=active_future_unresolved",
                         extra={"event": "FUTURES_VWAP_FALLBACK_SKIPPED", "reason": "active_future_unresolved", "configured_futures_symbol": self._futures_symbol},
                     )
 
-                fut_quote = None
+                usable_fut_quote = None
                 working_symbol = None
 
                 for fut_sym in symbols_to_try:
                     try:
-                        fut_quote = data_hub.get_quote(fut_sym, allow_pull=True)
-                        if isinstance(fut_quote, Mapping) and fut_quote.get("quote_unavailable_reason"):
-                            self._logger.info(
-                                "FUTURES_VWAP_QUOTE_UNAVAILABLE symbol=%s reason=%s active_future_symbol=%s",
-                                fut_sym,
-                                fut_quote.get("quote_unavailable_reason"),
-                                fut_quote.get("active_future_symbol"),
-                                extra={"event": "FUTURES_VWAP_QUOTE_UNAVAILABLE", "symbol": fut_sym, "reason": fut_quote.get("quote_unavailable_reason"), "active_future_symbol": fut_quote.get("active_future_symbol")},
-                            )
+                        candidate_quote = data_hub.get_quote(fut_sym, allow_pull=True) or {}
+                        if not candidate_quote:
                             continue
-                        if fut_quote and (self._extract_float(fut_quote, ("vwap", "average_price", "last_price", "ltp", "close")) is not None):
-                            working_symbol = fut_sym
-                            if not getattr(self, '_vwap_source_logged', False):
-                                self._logger.info(
-                                    f'✅ Futures VWAP source resolved: {fut_sym}',
-                                    extra={
-                                        'event': 'futures_vwap_resolved',
-                                        'symbol': fut_sym,
-                                    },
-                                )
-                                self._vwap_source_logged = True
-                            break
-
+                        if self._extract_float(candidate_quote, ("vwap", "average_price", "last_price", "ltp", "close")) is None:
+                            continue
+                        usable_fut_quote = candidate_quote
+                        working_symbol = fut_sym
+                        if not getattr(self, '_vwap_source_logged', False):
+                            self._logger.info(
+                                f'✅ Futures VWAP source resolved: {fut_sym}',
+                                extra={'event': 'futures_vwap_resolved', 'symbol': fut_sym},
+                            )
+                            self._vwap_source_logged = True
+                        break
                     except Exception as e:
-                        self._logger.debug(f"Futures symbol {fut_sym} failed: {e}")
+                        self._logger.debug("Futures symbol %s failed: %s", fut_sym, e)
                         continue
 
-                if not fut_quote:
-                    self._logger.error(
-                        f"❌ CRITICAL: Could not get futures quote from any symbol: {symbols_to_try}",
-                        extra={
-                            "event": "futures_vwap_fallback_failed",
-                            "symbols_tried": symbols_to_try,
-                        },
+                if not usable_fut_quote:
+                    self._logger.warning(
+                        "FUTURES_VWAP_FALLBACK_FAILED symbols_tried=%s",
+                        symbols_to_try,
+                        extra={"event": "futures_vwap_fallback_failed", "symbols_tried": symbols_to_try},
                     )
+                    return
 
+                fut_quote = usable_fut_quote
                 if fut_quote:
                     fut_vwap = self._extract_float(fut_quote, ("vwap", "average_price"))
                     fut_ltp = self._extract_float(

--- a/src/nifty_scalper_bot/streaming/stream_supervisor.py
+++ b/src/nifty_scalper_bot/streaming/stream_supervisor.py
@@ -207,8 +207,21 @@ class StreamSupervisor:
     def subscribe_symbols(self, symbols: Iterable[str]) -> int:
         """Resolve *symbols* into tokens and subscribe."""
 
-        tokens, _, _ = self.resolve_symbols(symbols)
-        return self.subscribe_tokens(tokens)
+        tokens, _, mapping = self.resolve_symbols(symbols)
+        mdm = self.market_data_manager
+        if mdm is None:
+            return self.subscribe_tokens(tokens)
+        added = 0
+        for symbol, token in mapping.items():
+            request_one = getattr(mdm, "request_token_subscription", None)
+            if callable(request_one):
+                if request_one(int(token), symbol):
+                    added += 1
+            else:
+                added += int(self.subscribe_tokens([int(token)]) > 0)
+        if self._autostart and mapping:
+            self.ensure_started()
+        return self.token_count()
 
     def resolve_symbols(
         self, symbols: Iterable[str]

--- a/src/nifty_scalper_bot/streaming/websocket_manager.py
+++ b/src/nifty_scalper_bot/streaming/websocket_manager.py
@@ -314,6 +314,11 @@ class WebSocketManager:
         )
         return True
 
+
+    def tokens_snapshot(self) -> list[int]:
+        """Return a sorted snapshot of websocket transport tokens."""
+        return sorted(self._tokens)
+
     def add_tokens(self, tokens: Sequence[int]) -> bool:
         """Add transport tokens. Args: tokens. Returns: changed flag. Raises: none."""
 

--- a/tests/core/test_active_basket.py
+++ b/tests/core/test_active_basket.py
@@ -48,3 +48,17 @@ def test_build_canonical_active_basket_returns_selected_symbols() -> None:
     )
     assert basket['selected_ce'] == basket['atm_ce']
     assert basket['selected_pe'] == basket['atm_pe']
+
+from nifty_scalper_bot.core.active_basket import normalize_active_basket_schema
+
+
+def test_normalize_active_basket_marks_futures_symbol_shape() -> None:
+    out = normalize_active_basket_schema({"futures_symbol": "NFO:NIFTY26JUNFUT", "option_symbols": ["NFO:NIFTY26JUN23900CE"]})
+    assert out["futures_symbol"] == "NFO:NIFTY26JUNFUT"
+    assert out["futures_symbol_valid_shape"] is True
+
+
+def test_normalize_active_basket_marks_invalid_shape_without_expiry_decision() -> None:
+    out = normalize_active_basket_schema({"futures_symbol": "NFO:NIFTYFUT", "option_symbols": []})
+    assert out["futures_symbol"] == "NFO:NIFTYFUT"
+    assert out["futures_symbol_valid_shape"] is False

--- a/tests/core/test_active_basket.py
+++ b/tests/core/test_active_basket.py
@@ -49,16 +49,3 @@ def test_build_canonical_active_basket_returns_selected_symbols() -> None:
     assert basket['selected_ce'] == basket['atm_ce']
     assert basket['selected_pe'] == basket['atm_pe']
 
-from nifty_scalper_bot.core.active_basket import normalize_active_basket_schema
-
-
-def test_normalize_active_basket_marks_futures_symbol_shape() -> None:
-    out = normalize_active_basket_schema({"futures_symbol": "NFO:NIFTY26JUNFUT", "option_symbols": ["NFO:NIFTY26JUN23900CE"]})
-    assert out["futures_symbol"] == "NFO:NIFTY26JUNFUT"
-    assert out["futures_symbol_valid_shape"] is True
-
-
-def test_normalize_active_basket_marks_invalid_shape_without_expiry_decision() -> None:
-    out = normalize_active_basket_schema({"futures_symbol": "NFO:NIFTYFUT", "option_symbols": []})
-    assert out["futures_symbol"] == "NFO:NIFTYFUT"
-    assert out["futures_symbol_valid_shape"] is False

--- a/tests/core/test_basket_commit_before_readiness.py
+++ b/tests/core/test_basket_commit_before_readiness.py
@@ -80,3 +80,36 @@ async def test_startup_hydration_uses_active_future_not_requested_expired_future
     out = await app._build_and_hydrate_live_basket_from_spot(ctx, spot_ltp=23701.0, configured_mode='LIVE')
     assert out.get("futures_symbol") == "NFO:NIFTY26JUNFUT"
     assert "NFO:NIFTY26MAYFUT" not in (out.get("symbols") or [])
+
+
+@pytest.mark.asyncio
+async def test_startup_does_not_generate_calendar_future(monkeypatch):
+    basket = {
+        'futures_symbol': 'NFO:NIFTY26MAYFUT',
+        'selected_ce': 'NFO:NIFTY26JUN23700CE',
+        'selected_pe': 'NFO:NIFTY26JUN23700PE',
+        'atm_ce': 'NFO:NIFTY26JUN23700CE',
+        'atm_pe': 'NFO:NIFTY26JUN23700PE',
+        'atm_strike': 23700,
+        'symbols': ['NSE:NIFTY', 'NFO:NIFTY26MAYFUT', 'NFO:NIFTY26JUN23700CE', 'NFO:NIFTY26JUN23700PE'],
+        'option_symbols': ['NFO:NIFTY26JUN23700CE', 'NFO:NIFTY26JUN23700PE'],
+    }
+    monkeypatch.setattr(app, '_get_current_nifty_futures_symbol', lambda: (_ for _ in ()).throw(AssertionError('calendar future generated')))
+    monkeypatch.setattr(app, '_build_canonical_active_basket', lambda **kwargs: {**basket, 'futures_symbol': kwargs.get('futures_symbol') or ''})
+    monkeypatch.setattr(app, 'get_market_state', lambda: app.MarketState.CLOSED)
+    ctx = SimpleNamespace(
+        instrument_manager=_IM(),
+        market_data_manager=_MDM(),
+        broker_client=_Broker(),
+        settings=SimpleNamespace(option_universe=SimpleNamespace(strike_step=50), execution_mode='LIVE'),
+        strategy_runner=SimpleNamespace(_indicator_engine=SimpleNamespace(get_history=lambda s: [1] * 30)),
+        order_manager=object(),
+        active_trading_universe={},
+        selected_ce=None,
+        selected_pe=None,
+    )
+
+    out = await app._build_and_hydrate_live_basket_from_spot(ctx, spot_ltp=23701.0, configured_mode='LIVE')
+
+    assert out.get('futures_symbol') == 'NFO:NIFTY26JUNFUT'
+    assert 'NFO:NIFTY26MAYFUT' not in (out.get('symbols') or [])

--- a/tests/core/test_basket_commit_before_readiness.py
+++ b/tests/core/test_basket_commit_before_readiness.py
@@ -17,6 +17,7 @@ class _MDM:
     def get_ohlc_bars(self, symbol, limit=None): return [1] * 30
     def get_symbol_snapshot(self, symbol): return SimpleNamespace(ltp=100.0, bid=99.0, ask=101.0, tradable_quote=True, tick_age_s=0.1)
     async def hydrate_symbol_history(self, *args, **kwargs): return []
+    def get_active_nifty_future_symbol_cached(self): return "NFO:NIFTY26JUNFUT"
 
 
 @pytest.mark.asyncio
@@ -49,3 +50,33 @@ async def test_build_commits_selected_before_readiness(monkeypatch):
     assert out.get('selected_ce') == ctx.selected_ce
     await app._recompute_and_push_runtime_readiness(ctx, reason='test')
     assert ctx.selected_ce is not None and ctx.selected_pe is not None
+
+
+@pytest.mark.asyncio
+async def test_startup_hydration_uses_active_future_not_requested_expired_future(monkeypatch):
+    basket = {
+        'futures_symbol': 'NFO:NIFTY26MAYFUT',
+        'selected_ce': 'NFO:NIFTY26JUN23700CE',
+        'selected_pe': 'NFO:NIFTY26JUN23700PE',
+        'atm_ce': 'NFO:NIFTY26JUN23700CE',
+        'atm_pe': 'NFO:NIFTY26JUN23700PE',
+        'atm_strike': 23700,
+        'symbols': ['NSE:NIFTY', 'NFO:NIFTY26MAYFUT', 'NFO:NIFTY26JUN23700CE', 'NFO:NIFTY26JUN23700PE'],
+        'option_symbols': ['NFO:NIFTY26JUN23700CE', 'NFO:NIFTY26JUN23700PE'],
+    }
+    monkeypatch.setattr(app, '_build_canonical_active_basket', lambda **kwargs: basket)
+    monkeypatch.setattr(app, 'get_market_state', lambda: app.MarketState.CLOSED)
+    ctx = SimpleNamespace(
+        instrument_manager=_IM(),
+        market_data_manager=_MDM(),
+        broker_client=_Broker(),
+        settings=SimpleNamespace(option_universe=SimpleNamespace(strike_step=50), execution_mode='LIVE'),
+        strategy_runner=SimpleNamespace(_indicator_engine=SimpleNamespace(get_history=lambda s: [1] * 30)),
+        order_manager=object(),
+        active_trading_universe={},
+        selected_ce=None,
+        selected_pe=None,
+    )
+    out = await app._build_and_hydrate_live_basket_from_spot(ctx, spot_ltp=23701.0, configured_mode='LIVE')
+    assert out.get("futures_symbol") == "NFO:NIFTY26JUNFUT"
+    assert "NFO:NIFTY26MAYFUT" not in (out.get("symbols") or [])

--- a/tests/core/test_commit_active_dynamic_basket.py
+++ b/tests/core/test_commit_active_dynamic_basket.py
@@ -53,8 +53,15 @@ def test_commit_active_dynamic_basket_preserves_old_selected_when_valid() -> Non
 
 def test_commit_active_dynamic_basket_replaces_stale_futures_with_active_mdm_future() -> None:
     class _Mdm:
+        def __init__(self) -> None:
+            self.rotate_args = None
+
         def get_active_nifty_future_symbol_cached(self) -> str:
             return "NFO:NIFTY26JUNFUT"
+        def maybe_rotate_nifty_futures_context_result(self, current_symbol, **kwargs):
+            self.rotate_args = (current_symbol, kwargs)
+            return None
+    mdm = _Mdm()
 
     ctx = SimpleNamespace(
         selected_ce=None,
@@ -63,7 +70,7 @@ def test_commit_active_dynamic_basket_replaces_stale_futures_with_active_mdm_fut
         atm_pe_symbol=None,
         active_trading_universe={},
         strategy_runner=None,
-        market_data_manager=_Mdm(),
+        market_data_manager=mdm,
         strategy_manager=None,
     )
     ce = "NFO:NIFTY26JUN23900CE"
@@ -78,3 +85,5 @@ def test_commit_active_dynamic_basket_replaces_stale_futures_with_active_mdm_fut
     committed = ctx.active_trading_universe
     assert committed["futures_symbol"] == "NFO:NIFTY26JUNFUT"
     assert "NFO:NIFTY26MAYFUT" not in committed["symbols"]
+    assert mdm.rotate_args is not None
+    assert mdm.rotate_args[0] == "NFO:NIFTY26MAYFUT"

--- a/tests/core/test_commit_active_dynamic_basket.py
+++ b/tests/core/test_commit_active_dynamic_basket.py
@@ -49,3 +49,32 @@ def test_commit_active_dynamic_basket_preserves_old_selected_when_valid() -> Non
     )
     assert selected_ce == old_ce
     assert selected_pe == old_pe
+
+
+def test_commit_active_dynamic_basket_replaces_stale_futures_with_active_mdm_future() -> None:
+    class _Mdm:
+        def get_active_nifty_future_symbol_cached(self) -> str:
+            return "NFO:NIFTY26JUNFUT"
+
+    ctx = SimpleNamespace(
+        selected_ce=None,
+        selected_pe=None,
+        atm_ce_symbol=None,
+        atm_pe_symbol=None,
+        active_trading_universe={},
+        strategy_runner=None,
+        market_data_manager=_Mdm(),
+        strategy_manager=None,
+    )
+    ce = "NFO:NIFTY26JUN23900CE"
+    pe = "NFO:NIFTY26JUN23900PE"
+    app._commit_active_dynamic_basket(
+        ctx,
+        basket={"futures_symbol": "NFO:NIFTY26MAYFUT"},
+        option_symbols=[ce, pe],
+        symbols=["NSE:NIFTY", "NFO:NIFTY26MAYFUT", ce, pe],
+        atm_strike=23900,
+    )
+    committed = ctx.active_trading_universe
+    assert committed["futures_symbol"] == "NFO:NIFTY26JUNFUT"
+    assert "NFO:NIFTY26MAYFUT" not in committed["symbols"]

--- a/tests/core/test_commit_active_dynamic_basket.py
+++ b/tests/core/test_commit_active_dynamic_basket.py
@@ -129,3 +129,16 @@ def test_app_active_basket_uses_active_future_not_requested() -> None:
     assert "NFO:NIFTY26MAYFUT" not in committed["symbols"]
     assert mdm.purged == [("NFO:NIFTY26JUNFUT", "active_dynamic_basket_commit")]
     assert mdm.rotated[0] == "NFO:NIFTY26MAYFUT"
+
+
+def test_resolve_active_futures_for_basket_no_calendar_fallback(monkeypatch) -> None:
+    class _Mdm:
+        def get_active_nifty_future_symbol_cached(self):
+            return None
+        def resolve_active_nifty_future_symbol(self):
+            return None
+
+    monkeypatch.setattr(app, "_get_current_nifty_futures_symbol", lambda: (_ for _ in ()).throw(AssertionError("calendar fallback used")))
+    ctx = SimpleNamespace(market_data_manager=_Mdm())
+
+    assert app._resolve_active_futures_for_basket(ctx, "NFO:NIFTY26MAYFUT") == ""

--- a/tests/core/test_commit_active_dynamic_basket.py
+++ b/tests/core/test_commit_active_dynamic_basket.py
@@ -87,3 +87,45 @@ def test_commit_active_dynamic_basket_replaces_stale_futures_with_active_mdm_fut
     assert "NFO:NIFTY26MAYFUT" not in committed["symbols"]
     assert mdm.rotate_args is not None
     assert mdm.rotate_args[0] == "NFO:NIFTY26MAYFUT"
+
+
+def test_app_active_basket_uses_active_future_not_requested() -> None:
+    class _Mdm:
+        def __init__(self) -> None:
+            self.purged: list[tuple[str, str]] = []
+        def get_active_nifty_future_symbol_cached(self) -> str:
+            return "NFO:NIFTY26JUNFUT"
+        def purge_stale_nifty_futures(self, active_symbol, *, reason):
+            self.purged.append((active_symbol, reason))
+            return [111]
+        def maybe_rotate_nifty_futures_context_result(self, current_symbol, **kwargs):
+            self.rotated = (current_symbol, kwargs)
+            return None
+
+    mdm = _Mdm()
+    ctx = SimpleNamespace(
+        selected_ce=None,
+        selected_pe=None,
+        atm_ce_symbol=None,
+        atm_pe_symbol=None,
+        active_trading_universe={},
+        strategy_runner=None,
+        market_data_manager=mdm,
+        strategy_manager=None,
+    )
+    ce = "NFO:NIFTY26JUN23900CE"
+    pe = "NFO:NIFTY26JUN23900PE"
+    app._commit_active_dynamic_basket(
+        ctx,
+        basket={"futures_symbol": "NFO:NIFTY26MAYFUT", "spot_symbol": "NSE:NIFTY"},
+        option_symbols=[ce, pe],
+        symbols=["NSE:NIFTY", "NFO:NIFTY26MAYFUT", ce, pe],
+        atm_strike=23900,
+    )
+
+    committed = ctx.active_trading_universe
+    assert committed["futures_symbol"] == "NFO:NIFTY26JUNFUT"
+    assert "NFO:NIFTY26JUNFUT" in committed["symbols"]
+    assert "NFO:NIFTY26MAYFUT" not in committed["symbols"]
+    assert mdm.purged == [("NFO:NIFTY26JUNFUT", "active_dynamic_basket_commit")]
+    assert mdm.rotated[0] == "NFO:NIFTY26MAYFUT"

--- a/tests/core/test_strategy_manager_context_to_option_propagation.py
+++ b/tests/core/test_strategy_manager_context_to_option_propagation.py
@@ -116,3 +116,23 @@ def test_futures_snapshot_derives_slope_and_volume_ratio():
     snap = m._latest_context_snapshots.get('futures_context', {})
     assert float(snap.get('futures_volume_ratio') or 0.0) == 2.0
     assert float(snap.get('vwap_slope') or 0.0) > 0.0
+
+
+def test_strategy_context_discards_stale_future() -> None:
+    class _Hub:
+        indicators_ready = True
+        def get_active_futures_symbol(self):
+            return "NFO:NIFTY26JUNFUT"
+        def get_quote(self, *_args, **_kwargs):
+            return {}
+
+    st = _S(); ie = _IE(); m = StrategyManager([st], ie, _PM(), data_hub=_Hub())
+    ie.payload = {'close': 110, 'previous_close': 100, 'volume': 100, 'avg_volume': 100}
+    m.generate_signal('NSE:NIFTY', 110)
+    ie.payload = {'close': 100, 'tick_slope': 0.2, 'volume': 100, 'avg_volume': 100}
+    m.generate_signal('NFO:NIFTY26MAYFUT', 100)
+    ie.payload = {'vwap': 102, 'exchange_vwap': 102, 'volume': 100, 'avg_volume': 100}
+    m.generate_signal('NFO:NIFTY26JUN23900CE', 102)
+    assert st.last.get('futures_context') is None
+    assert 'stale_futures_context_discarded' in st.last.get('context_discard_reasons', [])
+    assert st.last.get('spot_context')

--- a/tests/data/test_data_hub.py
+++ b/tests/data/test_data_hub.py
@@ -188,16 +188,16 @@ def test_get_quote_pulls_when_missing(
     assert quote["ltp"] == pytest.approx(150.0)
 
 
-def test_datahub_does_not_store_quote_unavailable_payload() -> None:
+def test_datahub_does_not_store_expired_future_empty_quote_payload() -> None:
     class _Mdm:
         def pull_quote(self, _symbol: str) -> dict[str, Any]:
-            return {"symbol": "NFO:NIFTY26MAYFUT", "quote_unavailable_reason": "suspended_expired_future", "active_future_symbol": "NFO:NIFTY26JUNFUT"}
+            return {}
 
     hub = DataHub(_Mdm(), _StubResolver(), options_only=True)
     out = hub.pull_quote("NFO:NIFTY26MAYFUT")
-    assert out.get("quote_unavailable_reason") == "suspended_expired_future"
+    assert out == {}
     cached = hub.get_quote("NFO:NIFTY26MAYFUT", allow_pull=False)
-    assert cached is None or not any(key in cached for key in ("ltp", "last_price", "timestamp"))
+    assert cached in (None, {})
 
 
 def test_upsert_order_drops_duplicate_sequences(hub: DataHub) -> None:

--- a/tests/data/test_data_hub.py
+++ b/tests/data/test_data_hub.py
@@ -539,3 +539,29 @@ def test_quote_update_version_by_token_string(hub: DataHub) -> None:
         }
     )
     assert hub.quote_update_version("256265") == 1
+
+
+def test_datahub_purge_symbol_aliases_removes_stale_future_caches() -> None:
+    hub = DataHub(_StubMarketDataManager(), _StubResolver(), options_only=True)
+    symbol = "NFO:NIFTY26MAYFUT"
+    token = 111
+    hub._token_by_symbol[symbol] = token  # noqa: SLF001
+    hub._symbol_by_token[token] = symbol  # noqa: SLF001
+    hub._quotes[symbol] = {"ltp": 100.0}  # noqa: SLF001
+    hub._token_quotes[token] = {"ltp": 100.0}  # noqa: SLF001
+    hub._ticks[token] = {"ltp": 100.0}  # noqa: SLF001
+    hub._last_ts[symbol] = 1.0  # noqa: SLF001
+    hub._last_arrival[symbol] = 1.0  # noqa: SLF001
+    hub._last_ws_arrival[symbol] = 1.0  # noqa: SLF001
+    hub._last_poll_arrival[symbol] = 1.0  # noqa: SLF001
+    hub._symbol_aliases[symbol].add("NIFTY26MAYFUT")  # noqa: SLF001
+
+    removed = hub.purge_symbol_aliases(symbols=[symbol], tokens=[token])
+
+    assert removed > 0
+    assert symbol not in hub._token_by_symbol  # noqa: SLF001
+    assert token not in hub._symbol_by_token  # noqa: SLF001
+    assert symbol not in hub._quotes  # noqa: SLF001
+    assert token not in hub._token_quotes  # noqa: SLF001
+    assert token not in hub._ticks  # noqa: SLF001
+    assert symbol not in hub._last_ts  # noqa: SLF001

--- a/tests/data/test_data_hub.py
+++ b/tests/data/test_data_hub.py
@@ -541,27 +541,34 @@ def test_quote_update_version_by_token_string(hub: DataHub) -> None:
     assert hub.quote_update_version("256265") == 1
 
 
-def test_datahub_purge_symbol_aliases_removes_stale_future_caches() -> None:
+def test_datahub_purge_removes_prefixed_and_unprefixed_aliases() -> None:
     hub = DataHub(_StubMarketDataManager(), _StubResolver(), options_only=True)
     symbol = "NFO:NIFTY26MAYFUT"
+    bare = "NIFTY26MAYFUT"
     token = 111
+    for key in (symbol, bare, str(token)):
+        hub._quotes[key] = {"ltp": 100.0}  # noqa: SLF001
+        hub._last_ts[key] = 1.0  # noqa: SLF001
+        hub._last_arrival[key] = 1.0  # noqa: SLF001
+        hub._last_ws_arrival[key] = 1.0  # noqa: SLF001
+        hub._last_poll_arrival[key] = 1.0  # noqa: SLF001
     hub._token_by_symbol[symbol] = token  # noqa: SLF001
+    hub._token_by_symbol[bare] = token  # noqa: SLF001
     hub._symbol_by_token[token] = symbol  # noqa: SLF001
-    hub._quotes[symbol] = {"ltp": 100.0}  # noqa: SLF001
     hub._token_quotes[token] = {"ltp": 100.0}  # noqa: SLF001
     hub._ticks[token] = {"ltp": 100.0}  # noqa: SLF001
-    hub._last_ts[symbol] = 1.0  # noqa: SLF001
-    hub._last_arrival[symbol] = 1.0  # noqa: SLF001
-    hub._last_ws_arrival[symbol] = 1.0  # noqa: SLF001
-    hub._last_poll_arrival[symbol] = 1.0  # noqa: SLF001
-    hub._symbol_aliases[symbol].add("NIFTY26MAYFUT")  # noqa: SLF001
+    hub._symbol_aliases[symbol].update({bare, str(token)})  # noqa: SLF001
+    hub._symbol_aliases[bare].add(symbol)  # noqa: SLF001
 
     removed = hub.purge_symbol_aliases(symbols=[symbol], tokens=[token])
 
     assert removed > 0
+    for key in (symbol, bare, str(token)):
+        assert key not in hub._quotes  # noqa: SLF001
+        assert key not in hub._last_ts  # noqa: SLF001
+        assert key not in hub._symbol_aliases  # noqa: SLF001
     assert symbol not in hub._token_by_symbol  # noqa: SLF001
+    assert bare not in hub._token_by_symbol  # noqa: SLF001
     assert token not in hub._symbol_by_token  # noqa: SLF001
-    assert symbol not in hub._quotes  # noqa: SLF001
     assert token not in hub._token_quotes  # noqa: SLF001
     assert token not in hub._ticks  # noqa: SLF001
-    assert symbol not in hub._last_ts  # noqa: SLF001

--- a/tests/data/test_data_hub.py
+++ b/tests/data/test_data_hub.py
@@ -188,6 +188,18 @@ def test_get_quote_pulls_when_missing(
     assert quote["ltp"] == pytest.approx(150.0)
 
 
+def test_datahub_does_not_store_quote_unavailable_payload() -> None:
+    class _Mdm:
+        def pull_quote(self, _symbol: str) -> dict[str, Any]:
+            return {"symbol": "NFO:NIFTY26MAYFUT", "quote_unavailable_reason": "suspended_expired_future", "active_future_symbol": "NFO:NIFTY26JUNFUT"}
+
+    hub = DataHub(_Mdm(), _StubResolver(), options_only=True)
+    out = hub.pull_quote("NFO:NIFTY26MAYFUT")
+    assert out.get("quote_unavailable_reason") == "suspended_expired_future"
+    cached = hub.get_quote("NFO:NIFTY26MAYFUT", allow_pull=False)
+    assert cached is None or not any(key in cached for key in ("ltp", "last_price", "timestamp"))
+
+
 def test_upsert_order_drops_duplicate_sequences(hub: DataHub) -> None:
     payload = {
         "order_id": "OID1",

--- a/tests/data/test_market_data_manager.py
+++ b/tests/data/test_market_data_manager.py
@@ -1413,6 +1413,24 @@ def test_pull_quote_expired_future_is_suppressed_without_broker_call(ws: DummyWe
     assert out.get("quote_unavailable_reason") == "suspended_expired_future"
 
 
+def test_repeated_expired_future_pull_quote_rotates_only_once(ws: DummyWebSocket, monkeypatch: pytest.MonkeyPatch) -> None:
+    manager = MarketDataManager(DummyBroker(), ws)
+    monkeypatch.setattr(manager, "_is_nifty_future_symbol_expired", lambda sym: str(sym).upper() == "NFO:NIFTY26MAYFUT")
+    monkeypatch.setattr(manager, "get_active_nifty_future_symbol_cached", lambda: "NFO:NIFTY26JUNFUT")
+    calls: list[tuple[str | None, str, str]] = []
+
+    def _rotate(old_symbol: str | None, new_symbol: str, *, reason: str, trace_id: str | None = None) -> None:
+        calls.append((old_symbol, new_symbol, reason))
+        manager._suspended_context_symbols.add("NFO:NIFTY26MAYFUT")  # noqa: SLF001
+
+    monkeypatch.setattr(manager, "rotate_active_nifty_future_context", _rotate)
+    first = manager.pull_quote("NFO:NIFTY26MAYFUT")
+    second = manager.pull_quote("NFO:NIFTY26MAYFUT")
+    assert first.get("quote_unavailable_reason") == "suspended_expired_future"
+    assert second.get("quote_unavailable_reason") == "suspended_expired_future"
+    assert len(calls) == 1
+
+
 def test_symbols_for_poll_excludes_expired_futures(monkeypatch: pytest.MonkeyPatch, ws: DummyWebSocket) -> None:
     manager = MarketDataManager(DummyBroker(), ws)
     manager._tracked_symbols.update({"NFO:NIFTY26MAYFUT", "NFO:NIFTY26JUNFUT"})  # noqa: SLF001

--- a/tests/data/test_market_data_manager.py
+++ b/tests/data/test_market_data_manager.py
@@ -1415,20 +1415,29 @@ def test_pull_quote_expired_future_is_suppressed_without_broker_call(ws: DummyWe
 
 def test_repeated_expired_future_pull_quote_rotates_only_once(ws: DummyWebSocket, monkeypatch: pytest.MonkeyPatch) -> None:
     manager = MarketDataManager(DummyBroker(), ws)
-    monkeypatch.setattr(manager, "_is_nifty_future_symbol_expired", lambda sym: str(sym).upper() == "NFO:NIFTY26MAYFUT")
-    monkeypatch.setattr(manager, "get_active_nifty_future_symbol_cached", lambda: "NFO:NIFTY26JUNFUT")
+    may = "NFO:NIFTY26MAYFUT"
+    jun = "NFO:NIFTY26JUNFUT"
+    manager._token_by_symbol.update({may: 111, jun: 222})  # noqa: SLF001
+    manager._symbol_to_token.update({may: 111, jun: 222})  # noqa: SLF001
+    manager._symbol_by_token.update({111: may, 222: jun})  # noqa: SLF001
+    manager._token_to_symbol.update({111: may, 222: jun})  # noqa: SLF001
+    manager._desired_tokens.update({111, 222})  # noqa: SLF001
+    monkeypatch.setattr(manager, "_is_nifty_future_symbol_expired", lambda sym: str(sym).upper() == may)
+    monkeypatch.setattr(manager, "get_active_nifty_future_symbol_cached", lambda *args, **kwargs: jun)
     calls: list[tuple[str | None, str, str]] = []
 
     def _rotate(old_symbol: str | None, new_symbol: str, *, reason: str, trace_id: str | None = None) -> None:
         calls.append((old_symbol, new_symbol, reason))
-        manager._suspended_context_symbols.add("NFO:NIFTY26MAYFUT")  # noqa: SLF001
+        manager._suspended_context_symbols.add(may)  # noqa: SLF001
 
     monkeypatch.setattr(manager, "rotate_active_nifty_future_context", _rotate)
-    first = manager.pull_quote("NFO:NIFTY26MAYFUT")
-    second = manager.pull_quote("NFO:NIFTY26MAYFUT")
+    first = manager.pull_quote(may)
+    second = manager.pull_quote(may)
     assert first == {}
     assert second == {}
     assert len(calls) == 1
+    assert 111 not in manager.desired_tokens_snapshot()
+    assert 222 in manager.desired_tokens_snapshot()
 
 
 def test_symbols_for_poll_excludes_expired_futures(monkeypatch: pytest.MonkeyPatch, ws: DummyWebSocket) -> None:

--- a/tests/data/test_market_data_manager.py
+++ b/tests/data/test_market_data_manager.py
@@ -1357,7 +1357,7 @@ def test_pull_quote_suspended_future_returns_unavailable_dict_without_broker_cal
     manager = MarketDataManager(FailBroker(), ws)
     manager._suspended_context_symbols.add("NFO:NIFTY26MAYFUT")  # noqa: SLF001
     out = manager.pull_quote("NFO:NIFTY26MAYFUT")
-    assert out.get("quote_unavailable_reason") == "suspended_stale_future"
+    assert out == {}
 
 def test_market_data_manager_initializes_suspended_context_symbols(broker: DummyBroker, ws: DummyWebSocket) -> None:
     manager = MarketDataManager(broker, ws)
@@ -1369,7 +1369,7 @@ def test_suspend_context_symbol_blocks_pull_quote_until_ttl(broker: DummyBroker,
     manager = MarketDataManager(broker, ws)
     manager.suspend_context_symbol('NFO:NIFTY26MAYFUT', reason='stale', ttl_s=300)
     out = manager.pull_quote('NFO:NIFTY26MAYFUT')
-    assert out.get('quote_unavailable_reason') == 'suspended_stale_future'
+    assert out == {}
 
 
 def test_suspended_context_symbol_expires_after_ttl(broker: DummyBroker, ws: DummyWebSocket) -> None:
@@ -1410,7 +1410,7 @@ def test_pull_quote_expired_future_is_suppressed_without_broker_call(ws: DummyWe
 
     manager = MarketDataManager(FailBroker(), ws, resolver=Resolver())
     out = manager.pull_quote("NFO:NIFTY26MAYFUT")
-    assert out.get("quote_unavailable_reason") == "suspended_expired_future"
+    assert out == {}
 
 
 def test_repeated_expired_future_pull_quote_rotates_only_once(ws: DummyWebSocket, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1426,8 +1426,8 @@ def test_repeated_expired_future_pull_quote_rotates_only_once(ws: DummyWebSocket
     monkeypatch.setattr(manager, "rotate_active_nifty_future_context", _rotate)
     first = manager.pull_quote("NFO:NIFTY26MAYFUT")
     second = manager.pull_quote("NFO:NIFTY26MAYFUT")
-    assert first.get("quote_unavailable_reason") == "suspended_expired_future"
-    assert second.get("quote_unavailable_reason") == "suspended_expired_future"
+    assert first == {}
+    assert second == {}
     assert len(calls) == 1
 
 

--- a/tests/data/test_market_data_manager_subscriptions.py
+++ b/tests/data/test_market_data_manager_subscriptions.py
@@ -40,10 +40,15 @@ class DummyWebSocket:
     def __init__(self) -> None:
         self.calls: list[list[int]] = []
         self.connected = True
+        self._tokens: set[int] = set()
 
     def set_tokens(self, tokens) -> bool:  # noqa: ANN001
+        self._tokens = {int(token) for token in tokens}
         self.calls.append(list(tokens))
         return True
+
+    def tokens_snapshot(self) -> list[int]:
+        return sorted(self._tokens)
 
     def is_connected(self) -> bool:
         return self.connected
@@ -400,3 +405,45 @@ def test_mdm_purge_stale_nifty_future_removes_old_desired_token() -> None:
     assert jun in mdm._tracked_symbols  # noqa: SLF001
     assert ce in mdm._tracked_symbols and pe in mdm._tracked_symbols  # noqa: SLF001
     assert ws.calls[-1] == [256265, 222, 333, 444]
+
+
+def test_request_token_subscriptions_rejects_stale_future_token_when_mapping_exists() -> None:
+    ws = DummyWebSocket()
+    mdm = MarketDataManager(DummyBroker(), ws, resolver=DummyResolver())
+    may = "NFO:NIFTY26MAYFUT"
+    jun = "NFO:NIFTY26JUNFUT"
+    mdm._symbol_by_token.update({111: may, 222: jun})  # noqa: SLF001
+    mdm._token_to_symbol.update({111: may, 222: jun})  # noqa: SLF001
+    mdm._token_by_symbol.update({may: 111, jun: 222})  # noqa: SLF001
+    mdm._symbol_to_token.update({may: 111, jun: 222})  # noqa: SLF001
+    mdm._set_active_nifty_future_cache(jun)  # noqa: SLF001
+
+    added = mdm.request_token_subscriptions([111, 222])
+
+    assert added == 1
+    assert mdm.desired_tokens_snapshot() == [222]
+    assert ws.tokens_snapshot() == [222]
+
+
+def test_websocket_replay_after_purge_has_no_may() -> None:
+    from nifty_scalper_bot.streaming.websocket_manager import WebSocketManager
+    from tests.streaming.test_websocket_manager import FakeKiteTicker
+
+    ws = WebSocketManager("k", "t", [111, 222], trading_window_enabled=False)
+    mdm = MarketDataManager(DummyBroker(), ws, resolver=DummyResolver())
+    may = "NFO:NIFTY26MAYFUT"
+    jun = "NFO:NIFTY26JUNFUT"
+    mdm._token_by_symbol.update({may: 111, jun: 222})  # noqa: SLF001
+    mdm._symbol_to_token.update({may: 111, jun: 222})  # noqa: SLF001
+    mdm._symbol_by_token.update({111: may, 222: jun})  # noqa: SLF001
+    mdm._token_to_symbol.update({111: may, 222: jun})  # noqa: SLF001
+    mdm._desired_tokens.update({111, 222})  # noqa: SLF001
+    mdm._set_active_nifty_future_cache(jun)  # noqa: SLF001
+
+    mdm.purge_stale_nifty_futures(jun, reason="unit_test")
+    fake = FakeKiteTicker("k", "t")
+    ws._on_connect(fake, {"status": "ok"})  # noqa: SLF001
+
+    assert 111 not in mdm.desired_tokens_snapshot()
+    assert 111 not in ws.tokens_snapshot()
+    assert fake.subscribed == [222]

--- a/tests/data/test_market_data_manager_subscriptions.py
+++ b/tests/data/test_market_data_manager_subscriptions.py
@@ -372,3 +372,31 @@ def test_request_token_subscriptions_ignores_invalid_tokens() -> None:
 
     assert added == 2
     assert ws.calls == [[101, 202]]
+
+
+def test_mdm_purge_stale_nifty_future_removes_old_desired_token() -> None:
+    ws = DummyWebSocket()
+    mdm = MarketDataManager(DummyBroker(), ws, resolver=DummyResolver())
+    may = "NFO:NIFTY26MAYFUT"
+    jun = "NFO:NIFTY26JUNFUT"
+    ce = "NFO:NIFTY26JUN23900CE"
+    pe = "NFO:NIFTY26JUN23900PE"
+    mapping = {"NSE:NIFTY": 256265, may: 111, jun: 222, ce: 333, pe: 444}
+    mdm._token_by_symbol.update(mapping)  # noqa: SLF001
+    mdm._symbol_to_token.update(mapping)  # noqa: SLF001
+    mdm._symbol_by_token.update({token: sym for sym, token in mapping.items()})  # noqa: SLF001
+    mdm._token_to_symbol.update({token: sym for sym, token in mapping.items()})  # noqa: SLF001
+    mdm._tracked_symbols.update(mapping)  # noqa: SLF001
+    mdm._active_subscribed_symbols.update(mapping)  # noqa: SLF001
+    mdm._desired_tokens.update(mapping.values())  # noqa: SLF001
+    mdm._set_active_nifty_future_cache(jun)  # noqa: SLF001
+
+    purged = mdm.purge_stale_nifty_futures(jun, reason="unit_test")
+
+    assert purged == [111]
+    assert 111 not in mdm.desired_tokens_snapshot()
+    assert set(mdm.desired_tokens_snapshot()) == {256265, 222, 333, 444}
+    assert may not in mdm._tracked_symbols  # noqa: SLF001
+    assert jun in mdm._tracked_symbols  # noqa: SLF001
+    assert ce in mdm._tracked_symbols and pe in mdm._tracked_symbols  # noqa: SLF001
+    assert ws.calls[-1] == [256265, 222, 333, 444]

--- a/tests/instruments/test_active_contracts.py
+++ b/tests/instruments/test_active_contracts.py
@@ -1,0 +1,25 @@
+from datetime import date
+
+from nifty_scalper_bot.instruments.active_contracts import (
+    derive_nifty_future_from_selected_options,
+    parse_nifty_future_expiry,
+    resolve_active_nifty_future_from_instruments,
+)
+
+
+def test_parse_nifty_future_expiry_last_thursday() -> None:
+    assert parse_nifty_future_expiry("NFO:NIFTY26MAYFUT") == date(2026, 5, 28)
+
+
+def test_resolve_active_nifty_future_from_instruments_earliest_non_expired() -> None:
+    rows = [
+        {"exchange": "NFO", "instrument_type": "FUT", "name": "NIFTY", "tradingsymbol": "NIFTY26MAYFUT", "expiry": "2026-05-26"},
+        {"exchange": "NFO", "instrument_type": "FUT", "name": "NIFTY", "tradingsymbol": "NIFTY26JUNFUT", "expiry": "2026-06-25"},
+    ]
+    out = resolve_active_nifty_future_from_instruments(rows, now=date(2026, 5, 27))
+    assert out.symbol == "NFO:NIFTY26JUNFUT"
+
+
+def test_derive_nifty_future_from_selected_options() -> None:
+    out = derive_nifty_future_from_selected_options(["NFO:NIFTY26JUN23900CE", "NFO:NIFTY26JUN23900PE"])
+    assert out.symbol == "NFO:NIFTY26JUNFUT"

--- a/tests/instruments/test_active_contracts.py
+++ b/tests/instruments/test_active_contracts.py
@@ -23,3 +23,12 @@ def test_resolve_active_nifty_future_from_instruments_earliest_non_expired() -> 
 def test_derive_nifty_future_from_selected_options() -> None:
     out = derive_nifty_future_from_selected_options(["NFO:NIFTY26JUN23900CE", "NFO:NIFTY26JUN23900PE"])
     assert out.symbol == "NFO:NIFTY26JUNFUT"
+
+
+def test_active_contracts_no_selected_option_fallback_by_default() -> None:
+    out = resolve_active_nifty_future_from_instruments([], now=date(2026, 5, 27))
+    assert out.symbol is None
+    from nifty_scalper_bot.instruments.active_contracts import resolve_active_nifty_future
+    selected = ["NFO:NIFTY26MAY23900CE"]
+    assert resolve_active_nifty_future(selected_option_symbols=selected, now=date(2026, 5, 27)).symbol is None
+    assert resolve_active_nifty_future(selected_option_symbols=selected, now=date(2026, 5, 27), allow_selected_option_fallback=True).symbol == "NFO:NIFTY26MAYFUT"

--- a/tests/instruments/test_active_contracts.py
+++ b/tests/instruments/test_active_contracts.py
@@ -7,7 +7,7 @@ from nifty_scalper_bot.instruments.active_contracts import (
 )
 
 
-def test_parse_nifty_future_expiry_last_thursday() -> None:
+def test_parse_nifty_future_expiry_last_thursday_fallback_calendar_only() -> None:
     assert parse_nifty_future_expiry("NFO:NIFTY26MAYFUT") == date(2026, 5, 28)
 
 

--- a/tests/strategies/test_active_futures_resolution.py
+++ b/tests/strategies/test_active_futures_resolution.py
@@ -19,9 +19,13 @@ class _MDM:
 
 
 class _Hub:
-    def __init__(self) -> None:
+    def __init__(self, active: str | None = "NFO:NIFTY26JUNFUT") -> None:
         self._mdm = _MDM()
         self.calls: list[str] = []
+        self._active = active
+
+    def get_active_futures_symbol(self):
+        return self._active
 
     def get_quote(self, symbol: str, allow_pull: bool = False):
         self.calls.append(symbol)
@@ -56,3 +60,9 @@ def test_configured_bare_nifty_does_not_generate_nfo_niftyfut() -> None:
     manager = _manager(futures_symbol="NIFTY")
     assert manager._futures_symbol is None
     assert manager._resolve_active_futures_symbol_for_metrics() != "NFO:NIFTYFUT"
+
+
+def test_resolve_active_future_does_not_fallback_to_cached_stale_symbol() -> None:
+    hub = _Hub(active=None)
+    manager = _manager(futures_symbol="NFO:NIFTY26MAYFUT", hub=hub)
+    assert manager._resolve_active_futures_symbol_for_metrics() is None

--- a/tests/strategies/test_active_futures_resolution.py
+++ b/tests/strategies/test_active_futures_resolution.py
@@ -1,0 +1,58 @@
+from typing import Any
+
+from nifty_scalper_bot.strategies.signal_generator import StrategyManager
+
+
+class _PM:
+    def get_position(self, _symbol: str):
+        return None
+
+
+class _IE:
+    def get_indicators(self, _symbol: str, _names: list[str]):
+        return {}
+
+
+class _MDM:
+    def get_active_nifty_future_symbol_cached(self):
+        return "NFO:NIFTY26JUNFUT"
+
+
+class _Hub:
+    def __init__(self) -> None:
+        self._mdm = _MDM()
+        self.calls: list[str] = []
+
+    def get_quote(self, symbol: str, allow_pull: bool = False):
+        self.calls.append(symbol)
+        if symbol == "NSE:NIFTY":
+            return {"ltp": 24000.0}
+        if symbol == "NFO:NIFTY26JUNFUT":
+            return {"vwap": 24100.0, "ltp": 24120.0}
+        return {}
+
+
+def _manager(futures_symbol: str | None = None, hub: Any | None = None) -> StrategyManager:
+    return StrategyManager([], _IE(), _PM(), data_hub=hub, futures_symbol=futures_symbol)
+
+
+def test_signal_generator_does_not_construct_calendar_month_may_future_after_expiry() -> None:
+    hub = _Hub()
+    manager = _manager(hub=hub)
+    assert manager._resolve_active_futures_symbol_for_metrics() == "NFO:NIFTY26JUNFUT"
+    assert "NFO:NIFTY26MAYFUT" not in hub.calls
+
+
+def test_augment_futures_metrics_uses_mdm_active_future_only() -> None:
+    hub = _Hub()
+    manager = _manager(hub=hub)
+    indicators: dict[str, Any] = {}
+    manager._augment_futures_metrics(indicators)
+    assert "NFO:NIFTY26JUNFUT" in hub.calls
+    assert "NFO:NIFTY26MAYFUT" not in hub.calls
+
+
+def test_configured_bare_nifty_does_not_generate_nfo_niftyfut() -> None:
+    manager = _manager(futures_symbol="NIFTY")
+    assert manager._futures_symbol is None
+    assert manager._resolve_active_futures_symbol_for_metrics() != "NFO:NIFTYFUT"

--- a/tests/strategies/test_runner_live_path_guards.py
+++ b/tests/strategies/test_runner_live_path_guards.py
@@ -260,6 +260,19 @@ def test_order_acceptance_notifies_orchestrator_entry() -> None:
     assert notified["reason"] == "order_accepted"
 
 
+def test_runner_set_active_trading_universe_rotates_futures_symbol() -> None:
+    runner = _build_runner()
+    runner._active_symbols = {"NFO:NIFTY26MAYFUT", "NFO:NIFTY26JUN23900CE"}
+    runner._active_futures_symbol = "NFO:NIFTY26MAYFUT"
+    runner._latest_context_snapshots = {"futures_context": {"symbol": "NFO:NIFTY26MAYFUT"}}
+    runner.set_active_trading_universe(
+        {"futures_symbol": "NFO:NIFTY26JUNFUT", "option_symbols": ["NFO:NIFTY26JUN23900CE"]}
+    )
+    assert "NFO:NIFTY26MAYFUT" not in runner._active_symbols
+    assert "NFO:NIFTY26JUNFUT" in runner._active_symbols
+    assert runner._active_futures_symbol == "NFO:NIFTY26JUNFUT"
+
+
 def test_phase10_no_runtime_indicators_attribute_logs_clean_block_not_runner_error(caplog) -> None:
     runner = _build_runner()
     runner._runtime_live_orders_armed = True

--- a/tests/streaming/test_stream_supervisor.py
+++ b/tests/streaming/test_stream_supervisor.py
@@ -49,6 +49,12 @@ class _DummyMarketDataManager:
         self.subscribe_calls = 0
         self.unsubscribe_calls = 0
 
+    def request_token_subscription(self, token: int, symbol: str | None = None) -> bool:
+        self.subscribe_calls += 1
+        before = len(self.desired)
+        self.desired.add(int(token))
+        return len(self.desired) > before
+
     def request_token_subscriptions(self, tokens: list[int]) -> int:
         self.subscribe_calls += 1
         before = len(self.desired)
@@ -155,3 +161,32 @@ def test_supervisor_subscription_methods_route_via_mdm() -> None:
     assert remaining == 1
     assert mdm.unsubscribe_calls == 1
     assert streamer.unsubscribe_calls == 0
+
+
+def test_stream_supervisor_preserves_symbol_token_mapping() -> None:
+    class _MappingMdm(_DummyMarketDataManager):
+        def __init__(self) -> None:
+            super().__init__()
+            self.calls: list[tuple[int, str | None]] = []
+            self.active = "NFO:NIFTY26JUNFUT"
+
+        def request_token_subscription(self, token: int, symbol: str | None = None) -> bool:
+            self.calls.append((int(token), symbol))
+            if symbol == "NFO:NIFTY26MAYFUT":
+                return False
+            return super().request_token_subscription(token, symbol)
+
+    mdm = _MappingMdm()
+    supervisor = StreamSupervisor(
+        streamer=_DummyStreamer(),
+        resolver=_DummyResolver({"NFO:NIFTY26MAYFUT": 111, "NFO:NIFTY26JUNFUT": 222}),
+        market_data_manager=mdm,
+        autostart=False,
+    )
+
+    supervisor.subscribe_symbols(["NFO:NIFTY26MAYFUT", "NFO:NIFTY26JUNFUT"])
+
+    assert (111, "NFO:NIFTY26MAYFUT") in mdm.calls
+    assert (222, "NFO:NIFTY26JUNFUT") in mdm.calls
+    assert 111 not in mdm.desired_tokens_snapshot()
+    assert mdm.desired_tokens_snapshot() == [222]

--- a/tests/streaming/test_websocket_manager.py
+++ b/tests/streaming/test_websocket_manager.py
@@ -315,3 +315,15 @@ def test_resubscribe_delegates_to_set_tokens(monkeypatch: pytest.MonkeyPatch) ->
     manager.resubscribe([1, 2, 2])
 
     assert called == [[1, 2, 2]]
+
+
+def test_websocket_reconnect_replays_only_clean_tokens() -> None:
+    manager = ws_module.WebSocketManager("k", "t", [111, 222], trading_window_enabled=False)
+    manager.set_tokens([222])
+    fake = FakeKiteTicker("k", "t")
+
+    manager._on_connect(fake, {"status": "ok"})
+
+    assert manager.tokens_snapshot() == [222]
+    assert fake.subscribed == [222]
+    assert fake.mode_set == [222]


### PR DESCRIPTION
### Motivation
- Expired monthly futures (e.g. `NFO:NIFTY26MAYFUT`) were being reconstructed in strategy fallback logic using calendar-month string construction, bypassing expiry-aware MDM resolution and causing repeated `pull_quote` calls and `FUTURES_CONTEXT_ROTATED` churn.  
- Multiple components retained or reintroduced stale futures symbols (StrategyManager, runner, app commit flow, active_basket, DataHub), allowing upstream regeneration of expired contracts after rollover.  
- Goal: centralize authoritative active-future resolution to MarketDataManager (MDM)/DataHub, prevent calendar-month generation of expired FUT, and make expired-future suppression/rotation idempotent and non-spammy.

### Description
- Strategy manager: removed calendar-month FUT construction and added canonical parsing/validation and resolver methods (`_canonical_futures_symbol`, `set_active_futures_symbol`, `_resolve_active_futures_symbol_for_metrics`) so futures fallbacks prefer MDM/DataHub-provided active futures and never build `NFO:NIFTY{yy}{MON}FUT` from `datetime.now()`. (`src/nifty_scalper_bot/strategies/signal_generator.py`)  
- VWAP fallback hardened to only use validated futures quotes and to ignore diagnostic `quote_unavailable_reason` payloads (prevents diagnostics from becoming VWAP source). (`signal_generator.py`)  
- DataHub: changed `pull_quote` to NOT cache diagnostic `quote_unavailable_reason` payloads into the quote cache and instead return the diagnostic payload to caller without storing it. (`src/nifty_scalper_bot/data/data_hub.py`)  
- MarketDataManager: made expired-future suppression in `pull_quote()` idempotent by checking `is_context_symbol_suspended()` before rotating, and introduced throttled suppression logging; made `rotate_active_nifty_future_context()` avoid re-logging `FUTURES_CONTEXT_ROTATED` when the old symbol was already suspended. (`src/nifty_scalper_bot/data/market_data_manager.py`)  
- Runner: `set_active_trading_universe()` updated to accept an authoritative `futures_symbol`, rotate runner-level futures state, remove stale futures from `_active_symbols`, and drop stale futures snapshots. (`src/nifty_scalper_bot/strategies/runner.py`)  
- App commit flow: `_commit_active_dynamic_basket()` now resolves/commits the authoritative active futures symbol via MDM/cache before committing the basket and propagates the active-future into `StrategyManager` (via `set_active_futures_symbol`) and into an MDM rotation check. (`src/nifty_scalper_bot/core/app.py`)  
- Active basket normalization: kept pure normalization but added `futures_symbol_valid_shape` marker to flag malformed/fallback-shaped futures without making expiry decisions here. (`src/nifty_scalper_bot/core/active_basket.py`)  
- Tests: added focused unit tests and updated existing tests to cover: strategy resolution not constructing May FUT post-expiry, futures VWAP fallback behavior, DataHub not caching diagnostic payloads, MDM idempotent suppression/rotation, runner basket rotation behavior, and app commit replacement of stale futures. (new/updated tests under `tests/strategies`, `tests/data`, `tests/core`).

### Testing
- Commands run: `python -m compileall -q src` and targeted pytest runs for modified areas using: `pytest -q tests/data/test_market_data_manager.py tests/data/test_data_hub.py tests/strategies/test_active_futures_resolution.py tests/strategies/test_runner_live_path_guards.py tests/core/test_active_basket.py tests/core/test_commit_active_dynamic_basket.py`.  
- Results: compile succeeded and all targeted tests passed (no regressions in the tested modules).  
- Scope of tests: focused unit tests for futures rollover lifecycle, DataHub diagnostic handling, MDM suppression idempotence, runner active-universe rotation, and active-basket normalization; full test matrix not run in this PR but targeted suites covering the changed modules passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16c43fec848324baf1241a76c728c1)