### PR TITLE
market-data: fix active futures propagation fallbacks

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -1104,6 +1104,25 @@ def _resolve_active_futures_for_basket(ctx: BotContext, requested: object | None
         canonical = canonical_nifty_future_symbol(resolved)
         if canonical:
             return canonical
+
+    active_universe = getattr(ctx, "active_trading_universe", {}) or {}
+    if isinstance(active_universe, Mapping):
+        canonical = canonical_nifty_future_symbol(
+            active_universe.get("futures_symbol") or active_universe.get("future_symbol")
+        )
+        if canonical:
+            return canonical
+
+    runner = getattr(ctx, "strategy_runner", None)
+    canonical = canonical_nifty_future_symbol(getattr(runner, "_active_futures_symbol", None))
+    if canonical:
+        return canonical
+
+    strategy_manager = getattr(ctx, "strategy_manager", None)
+    canonical = canonical_nifty_future_symbol(getattr(strategy_manager, "_futures_symbol", None))
+    if canonical:
+        return canonical
+
     LOGGER.warning(
         "FUTURES_CONTEXT_UNAVAILABLE requested=%s reason=active_future_unresolved",
         requested,

--- a/src/nifty_scalper_bot/data/data_hub.py
+++ b/src/nifty_scalper_bot/data/data_hub.py
@@ -1313,22 +1313,53 @@ class DataHub:
 
 
     def get_active_futures_symbol(self) -> str | None:
-        """Return authoritative active NIFTY future from MDM."""
+        """Return canonical active NIFTY future from MDM runtime state."""
         mdm = getattr(self, "_mdm", None)
-        for method_name in ("get_active_nifty_future_symbol_cached", "resolve_active_nifty_future_symbol"):
-            method = getattr(mdm, method_name, None)
-            if not callable(method):
-                continue
+
+        cached = getattr(mdm, "get_active_nifty_future_symbol_cached", None)
+        if callable(cached):
             try:
-                symbol = method()
+                canonical = canonical_nifty_future_symbol(cached())
             except TypeError:
                 try:
-                    symbol = method(now=None)
+                    canonical = canonical_nifty_future_symbol(cached(now=None))
                 except Exception:
-                    continue
+                    canonical = None
             except Exception:
-                continue
-            canonical = canonical_nifty_future_symbol(symbol)
+                canonical = None
+            if canonical:
+                return canonical
+
+        for attr_name in ("active_trading_universe", "_active_trading_universe"):
+            universe = getattr(mdm, attr_name, None)
+            if isinstance(universe, Mapping):
+                canonical = canonical_nifty_future_symbol(
+                    universe.get("futures_symbol") or universe.get("future_symbol")
+                )
+                if canonical:
+                    return canonical
+
+        requirements = getattr(mdm, "_readiness_requirements", None)
+        if isinstance(requirements, Mapping):
+            canonical = canonical_nifty_future_symbol(
+                requirements.get("futures")
+                or requirements.get("futures_symbol")
+                or requirements.get("future_symbol")
+            )
+            if canonical:
+                return canonical
+
+        resolve = getattr(mdm, "resolve_active_nifty_future_symbol", None)
+        if callable(resolve):
+            try:
+                canonical = canonical_nifty_future_symbol(resolve())
+            except TypeError:
+                try:
+                    canonical = canonical_nifty_future_symbol(resolve(now=None))
+                except Exception:
+                    canonical = None
+            except Exception:
+                canonical = None
             if canonical:
                 return canonical
         return None

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -6734,13 +6734,11 @@ class MarketDataManager:
         return quote
 
     def resolve_active_nifty_future_symbol(self, now: datetime | None = None) -> str | None:
-        """Resolve nearest non-expired NIFTY futures symbol from resolver/instrument master."""
+        """Resolve nearest non-expired NIFTY futures symbol from instrument masters."""
         ref_now = now or datetime.now(timezone.utc)
-        resolver = getattr(self, "_resolver", None)
-        if resolver is None:
-            return None
         fetchers = ("list_instruments", "get_instruments", "instruments")
         instruments: list[Mapping[str, Any]] = []
+
         def _call_instrument_fetcher(fetcher: Callable[..., Any]) -> list[Mapping[str, Any]]:
             attempts = (lambda: fetcher(), lambda: fetcher("NFO"), lambda: fetcher(exchange="NFO"))
             for call in attempts:
@@ -6757,12 +6755,16 @@ class MarketDataManager:
                     if rows:
                         return rows
             return []
-        for fetcher_name in fetchers:
-            fetcher = getattr(resolver, fetcher_name, None)
-            if callable(fetcher):
-                instruments = _call_instrument_fetcher(fetcher)
-                if instruments:
-                    break
+
+        resolver = getattr(self, "_resolver", None)
+        if resolver is not None:
+            for fetcher_name in fetchers:
+                fetcher = getattr(resolver, fetcher_name, None)
+                if callable(fetcher):
+                    instruments = _call_instrument_fetcher(fetcher)
+                    if instruments:
+                        break
+
         best_symbol: str | None = None
         best_expiry: datetime | None = None
         for row in instruments:
@@ -6775,7 +6777,30 @@ class MarketDataManager:
             if best_expiry is None or expiry < best_expiry:
                 best_expiry = expiry
                 best_symbol = f"NFO:{tradingsymbol}"
-        return best_symbol
+        if best_symbol:
+            return self._set_active_nifty_future_cache(best_symbol)
+
+        broker_instruments = getattr(self._broker, "instruments", None)
+        if callable(broker_instruments):
+            try:
+                rows = broker_instruments("NFO") or []
+            except Exception as exc:  # noqa: BLE001
+                self._logger.debug(
+                    "ACTIVE_NIFTY_FUTURE_BROKER_INSTRUMENTS_FAILED error=%s",
+                    exc,
+                    extra={"event": "ACTIVE_NIFTY_FUTURE_BROKER_INSTRUMENTS_FAILED", "error": str(exc)},
+                )
+            else:
+                if isinstance(rows, Mapping):
+                    rows = rows.values()
+                if isinstance(rows, Iterable):
+                    resolved = self._resolve_active_nifty_future_from_instruments(
+                        [row for row in rows if isinstance(row, Mapping)],
+                        now=now,
+                    )
+                    if resolved:
+                        return self._set_active_nifty_future_cache(resolved)
+        return None
 
     def get_active_nifty_future_symbol_cached(self, *, now: datetime | None = None, ttl_seconds: float = 30.0) -> str | None:
         now_mono = time.monotonic()

--- a/src/nifty_scalper_bot/strategies/signal_generator.py
+++ b/src/nifty_scalper_bot/strategies/signal_generator.py
@@ -1320,7 +1320,7 @@ class StrategyManager:
         return canonical
 
     def _resolve_active_futures_symbol_for_metrics(self) -> str | None:
-        """Resolve active NIFTY future from DataHub/MDM SSOT only."""
+        """Resolve active NIFTY future for metrics without calendar generation."""
         data_hub = getattr(self, "_data_hub", None)
         get_active = getattr(data_hub, "get_active_futures_symbol", None)
         if callable(get_active):
@@ -1332,6 +1332,19 @@ class StrategyManager:
             if canonical:
                 self.set_active_futures_symbol(canonical, source="data_hub.get_active_futures_symbol")
                 return canonical
+
+        canonical = canonical_nifty_future_symbol(self._futures_symbol)
+        if canonical:
+            self._logger.info(
+                "STRATEGY_MANAGER_ACTIVE_FUTURES_FALLBACK_USED symbol=%s source=self._futures_symbol",
+                canonical,
+                extra={
+                    "event": "STRATEGY_MANAGER_ACTIVE_FUTURES_FALLBACK_USED",
+                    "symbol": canonical,
+                    "source": "self._futures_symbol",
+                },
+            )
+            return canonical
         return None
 
     def generate_signal(self, symbol: str, current_price: float) -> Signal | None:

--- a/tests/core/test_commit_active_dynamic_basket.py
+++ b/tests/core/test_commit_active_dynamic_basket.py
@@ -142,3 +142,21 @@ def test_resolve_active_futures_for_basket_no_calendar_fallback(monkeypatch) -> 
     ctx = SimpleNamespace(market_data_manager=_Mdm())
 
     assert app._resolve_active_futures_for_basket(ctx, "NFO:NIFTY26MAYFUT") == ""
+
+
+def test_resolve_active_futures_for_basket_uses_active_universe_when_mdm_unresolved(monkeypatch) -> None:
+    class _Mdm:
+        def get_active_nifty_future_symbol_cached(self):
+            return None
+        def resolve_active_nifty_future_symbol(self):
+            return None
+
+    monkeypatch.setattr(app, "_get_current_nifty_futures_symbol", lambda: (_ for _ in ()).throw(AssertionError("calendar fallback used")))
+    ctx = SimpleNamespace(
+        market_data_manager=_Mdm(),
+        active_trading_universe={"futures_symbol": "NFO:NIFTY26JUNFUT"},
+        strategy_runner=None,
+        strategy_manager=None,
+    )
+
+    assert app._resolve_active_futures_for_basket(ctx, "NFO:NIFTY26MAYFUT") == "NFO:NIFTY26JUNFUT"

--- a/tests/data/test_market_data_manager.py
+++ b/tests/data/test_market_data_manager.py
@@ -229,6 +229,20 @@ def test_active_future_resolver_replaces_expired_month_future(broker: DummyBroke
     assert symbol == "NFO:NIFTY26JUNFUT"
 
 
+def test_active_future_resolver_uses_broker_instruments_when_resolver_unavailable(ws: DummyWebSocket) -> None:
+    class BrokerWithInstruments(DummyBroker):
+        def instruments(self, exchange: str):
+            assert exchange == "NFO"
+            return [
+                {"segment": "NFO-FUT", "instrument_type": "FUT", "name": "NIFTY", "tradingsymbol": "NIFTY26MAYFUT", "expiry": "2026-05-20"},
+                {"segment": "NFO-FUT", "instrument_type": "FUT", "name": "NIFTY", "tradingsymbol": "NIFTY26JUNFUT", "expiry": "2026-06-25"},
+            ]
+
+    manager = MarketDataManager(BrokerWithInstruments(), ws, resolver=None)
+
+    assert manager.get_active_nifty_future_symbol_cached(now=datetime(2026, 5, 27, tzinfo=timezone.utc)) == "NFO:NIFTY26JUNFUT"
+
+
 def test_active_future_resolver_rejects_banknifty_and_finnifty(broker: DummyBroker, ws: DummyWebSocket) -> None:
     resolver = type(
         "Resolver",

--- a/tests/strategies/test_active_futures_resolution.py
+++ b/tests/strategies/test_active_futures_resolution.py
@@ -62,7 +62,16 @@ def test_configured_bare_nifty_does_not_generate_nfo_niftyfut() -> None:
     assert manager._resolve_active_futures_symbol_for_metrics() != "NFO:NIFTYFUT"
 
 
-def test_resolve_active_future_does_not_fallback_to_cached_stale_symbol() -> None:
+def test_resolve_active_future_falls_back_to_configured_runtime_future() -> None:
     hub = _Hub(active=None)
-    manager = _manager(futures_symbol="NFO:NIFTY26MAYFUT", hub=hub)
-    assert manager._resolve_active_futures_symbol_for_metrics() is None
+    manager = _manager(futures_symbol="NFO:NIFTY26JUNFUT", hub=hub)
+    assert manager._resolve_active_futures_symbol_for_metrics() == "NFO:NIFTY26JUNFUT"
+
+
+def test_augment_futures_metrics_tries_configured_runtime_future_when_hub_unresolved() -> None:
+    hub = _Hub(active=None)
+    manager = _manager(futures_symbol="NFO:NIFTY26JUNFUT", hub=hub)
+    indicators: dict[str, Any] = {}
+    manager._augment_futures_metrics(indicators)
+    assert "NFO:NIFTY26JUNFUT" in hub.calls
+    assert "NFO:NIFTY26MAYFUT" not in hub.calls


### PR DESCRIPTION
### Motivation

- Prevent transient MDM/DataHub resolver outages from causing empty active-futures context and FUTURES_VWAP fallback failures while avoiding reintroducing calendar-generated futures.
- Ensure runtime-committed futures (strategy/runner/context) are used as a safe fallback for metrics and basket commits when authoritative lookups are unresolved.

### Description

- `StrategyManager._resolve_active_futures_symbol_for_metrics()` now first asks `DataHub.get_active_futures_symbol()` and, if unresolved, falls back to the configured runtime `self._futures_symbol` when `canonical_nifty_future_symbol(self._futures_symbol)` is valid, and logs `STRATEGY_MANAGER_ACTIVE_FUTURES_FALLBACK_USED` when that fallback is used.
- `MarketDataManager.resolve_active_nifty_future_symbol()` retains the resolver/instrument-master lookup, adds a broker fallback using `self._broker.instruments("NFO")`, and caches any resolved symbol via `_set_active_nifty_future_cache()`; it does not enable selected-option-derived calendar fallbacks by default.
- `DataHub.get_active_futures_symbol()` now prefers `MDM.get_active_nifty_future_symbol_cached()`, then checks MDM runtime `active_trading_universe` and `_readiness_requirements` for futures, and returns only canonical NIFTY future symbols.
- `core/app.py::_resolve_active_futures_for_basket()` consults MDM first and then checks `ctx.active_trading_universe`, `ctx.strategy_runner._active_futures_symbol`, and `ctx.strategy_manager._futures_symbol` before logging `FUTURES_CONTEXT_UNAVAILABLE`; it never calls the old calendar builder.
- Added focused tests covering: StrategyManager fallback to configured runtime future and VWAP symbol attempts, MDM broker-instruments fallback when resolver is unavailable, and app basket resolution using active_trading_universe when MDM is unresolved.

### Testing

- Ran `python -m compileall -q src` — passed.
- Ran targeted pytest suites and focused tests: `tests/strategies/test_active_futures_resolution.py`, `tests/strategies/test_signal_generator_futures_volume.py`, `tests/data/test_market_data_manager.py`, and `tests/core/test_commit_active_dynamic_basket.py` — all passed.
- Ran full `pytest -q` in the repository — passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1957bd06648324945ee913c6df1d90)