### PR TITLE
Fix SMC feature enrichment and narrow live trigger gating for Nifty options

### DIFF
--- a/src/nifty_scalper_bot/core/strategy_manager.py
+++ b/src/nifty_scalper_bot/core/strategy_manager.py
@@ -72,24 +72,48 @@ def _safe_float_value(value: t.Any) -> float | None:
     return result
 
 
-def _normalise_ohlcv_bars(bars: t.Sequence[t.Mapping[str, t.Any]] | t.Sequence[t.Any]) -> list[dict[str, float]]:
+def _normalise_ohlcv_bars(bars: t.Any) -> list[dict[str, float]]:
     normalised: list[dict[str, float]] = []
-    for bar in bars or []:
+    rows: t.Iterable[t.Any]
+    if bars is None:
+        rows = []
+    elif hasattr(bars, "tail") and hasattr(bars, "to_dict"):
+        try:
+            rows = bars.tail(100).to_dict("records")
+        except Exception as exc:  # noqa: BLE001 - malformed provider data is non-fatal
+            log.debug(
+                "SMC_OHLCV_NORMALISE_DATAFRAME_FAILED error=%s",
+                exc,
+                extra={"event": "SMC_OHLCV_NORMALISE_DATAFRAME_FAILED", "error": str(exc)},
+            )
+            rows = []
+    elif isinstance(bars, (list, tuple, deque)):
+        rows = bars
+    else:
+        rows = []
+    if not isinstance(rows, (list, tuple, deque)):
+        rows = []
+    for bar in rows:
         if not isinstance(bar, t.Mapping):
             continue
-        open_v = _safe_float_value(bar.get("open") or bar.get("o"))
-        high_v = _safe_float_value(bar.get("high") or bar.get("h"))
-        low_v = _safe_float_value(bar.get("low") or bar.get("l"))
-        close_v = _safe_float_value(bar.get("close") or bar.get("c"))
-        volume_v = _safe_float_value(bar.get("volume") or bar.get("v") or 0.0)
+        raw_open = bar.get("open") if bar.get("open") is not None else bar.get("o")
+        raw_high = bar.get("high") if bar.get("high") is not None else bar.get("h")
+        raw_low = bar.get("low") if bar.get("low") is not None else bar.get("l")
+        raw_close = bar.get("close") if bar.get("close") is not None else bar.get("c")
+        raw_volume = bar.get("volume") if bar.get("volume") is not None else bar.get("v")
+        open_v = _safe_float_value(raw_open)
+        high_v = _safe_float_value(raw_high)
+        low_v = _safe_float_value(raw_low)
+        close_v = _safe_float_value(raw_close)
+        volume_v = _safe_float_value(raw_volume)
         if open_v is None or high_v is None or low_v is None or close_v is None:
             continue
-        normalised.append({"open": open_v, "high": high_v, "low": low_v, "close": close_v, "volume": float(volume_v or 0.0)})
+        normalised.append({"open": open_v, "high": high_v, "low": low_v, "close": close_v, "volume": float(volume_v if volume_v is not None else 0.0)})
     return normalised
 
 
 def _extract_option_strike(symbol: str) -> int | None:
-    match = re.search(r"(\d{5})(CE|PE)$", str(symbol or "").strip().upper())
+    match = re.search(r"(\d{4,6})(CE|PE)$", str(symbol or "").strip().upper())
     return int(match.group(1)) if match else None
 
 
@@ -228,15 +252,23 @@ def _enrich_smc_pre_strategy(
             enriched[key] = value
 
     required = ("premium_reclaim", "bullish_reversal", "choch_confirmed", "bos_confirmed", "retest_confirmed")
-    feature_completeness = sum(1 for name in required if enriched.get(name) is not None) / float(len(required))
+    presence_ratio = sum(1 for name in required if enriched.get(name) is not None) / float(len(required))
+    positive_features = [name for name in required if enriched.get(name) is True]
+    positive_feature_count = len(positive_features)
     if enriched.get("feature_completeness") is None:
-        enriched["feature_completeness"] = feature_completeness
+        enriched["feature_completeness"] = presence_ratio
+    enriched["smc_feature_presence_ratio"] = presence_ratio
+    enriched["smc_positive_feature_count"] = positive_feature_count
+    enriched["smc_positive_features"] = positive_features
     log_throttled(
         log,
         f"smc_feature_enriched:{symbol}",
-        "SMC_FEATURE_ENRICHED symbol=%s feature_completeness=%.3f swing_high=%s swing_low=%s premium_current=%s premium_vwap=%s premium_reclaim=%s bos_confirmed=%s choch_confirmed=%s retest_confirmed=%s",
+        "SMC_FEATURE_ENRICHED symbol=%s feature_completeness=%.3f presence_ratio=%.3f positive_feature_count=%s positive_features=%s swing_high=%s swing_low=%s premium_current=%s premium_vwap=%s premium_reclaim=%s bos_confirmed=%s choch_confirmed=%s retest_confirmed=%s",
         symbol,
-        feature_completeness,
+        presence_ratio,
+        presence_ratio,
+        positive_feature_count,
+        positive_features,
         enriched.get("swing_high"),
         enriched.get("swing_low"),
         enriched.get("premium_current"),
@@ -247,7 +279,7 @@ def _enrich_smc_pre_strategy(
         enriched.get("retest_confirmed"),
         interval_sec=30.0,
         level=logging.INFO,
-        extra={"event": "SMC_FEATURE_ENRICHED", "symbol": symbol, "feature_completeness": feature_completeness},
+        extra={"event": "SMC_FEATURE_ENRICHED", "symbol": symbol, "feature_completeness": presence_ratio, "presence_ratio": presence_ratio, "positive_feature_count": positive_feature_count, "positive_features": positive_features},
     )
     return enriched
 
@@ -1242,6 +1274,18 @@ class StrategyManager(_BaseStrategyManager):
         """
 
         log.debug("Entered StrategyManager.__init__")
+        log.info(
+            "RUNTIME_STRATEGY_MANAGER_CLASS module=%s class=%s id=%s",
+            self.__class__.__module__,
+            self.__class__.__name__,
+            id(self),
+            extra={
+                "event": "RUNTIME_STRATEGY_MANAGER_CLASS",
+                "module": self.__class__.__module__,
+                "class": self.__class__.__name__,
+                "id": id(self),
+            },
+        )
         super().__init__(
             strategies,
             indicator_engine,
@@ -3002,11 +3046,34 @@ class StrategyManager(_BaseStrategyManager):
                 method = getattr(owner, method_name, None)
                 if not callable(method):
                     continue
+                provider_name = owner.__class__.__name__
+                raw_bars: t.Any = []
                 try:
-                    raw_bars = method(symbol, limit=100) if method_name == "get_ohlc_bars" else method(symbol)
-                except TypeError:
-                    raw_bars = method(symbol)
-                recent_bars = _normalise_ohlcv_bars(raw_bars or [])[-100:]
+                    try:
+                        raw_bars = method(symbol, limit=100) if method_name == "get_ohlc_bars" else method(symbol)
+                    except TypeError:
+                        raw_bars = method(symbol)
+                except Exception as exc:  # noqa: BLE001 - provider failure must not crash strategy evaluation
+                    raw_bars = []
+                    log_throttled(
+                        log,
+                        f"smc_history_provider_failed:{symbol}:{provider_name}:{method_name}",
+                        "SMC_HISTORY_PROVIDER_FAILED symbol=%s provider=%s method=%s error=%s",
+                        symbol,
+                        provider_name,
+                        method_name,
+                        str(exc),
+                        interval_sec=30.0,
+                        level=logging.WARNING,
+                        extra={
+                            "event": "SMC_HISTORY_PROVIDER_FAILED",
+                            "symbol": symbol,
+                            "provider": provider_name,
+                            "method": method_name,
+                            "error": str(exc),
+                        },
+                    )
+                recent_bars = _normalise_ohlcv_bars(raw_bars)[-100:]
             indicators = _enrich_smc_pre_strategy(symbol, indicators, recent_bars)
 
         position = self._position_manager.get_position(symbol)
@@ -3903,9 +3970,15 @@ class StrategyManager(_BaseStrategyManager):
             else:
                 allow_candidate_switch = str(os.getenv("STRATEGY_ALLOW_CANDIDATE_SWITCH_ON_HIGH_SCORE", "false")).lower() in {"1", "true", "yes", "on"}
                 max_candidate_switch_distance = float(os.getenv("CANDIDATE_SWITCH_MAX_DISTANCE_POINTS", "100") or "100")
-                quote_depth_valid = bool(metadata.get("quote_depth_valid") or indicator_map.get("quote_depth_valid"))
+                raw_qdv = metadata.get("quote_depth_valid")
+                if raw_qdv is None:
+                    raw_qdv = indicator_map.get("quote_depth_valid")
+                quote_depth_valid = bool(raw_qdv)
+                raw_spread = metadata.get("spread_pct")
+                if raw_spread is None:
+                    raw_spread = indicator_map.get("spread_pct")
                 try:
-                    switch_spread_pct = float(metadata.get("spread_pct") or indicator_map.get("spread_pct") or 999.0)
+                    switch_spread_pct = float(raw_spread) if raw_spread is not None else 999.0
                 except (TypeError, ValueError):
                     switch_spread_pct = 999.0
                 switch_min_score = 8.0 if best_vote.strategy == "OrderFlow" else 8.5

--- a/src/nifty_scalper_bot/core/strategy_manager.py
+++ b/src/nifty_scalper_bot/core/strategy_manager.py
@@ -62,6 +62,196 @@ REGIME_STRATEGY_WEIGHTS: dict[str, dict[str, float]] = {
 }
 
 
+def _safe_float_value(value: t.Any) -> float | None:
+    try:
+        if value is None:
+            return None
+        result = float(value)
+    except (TypeError, ValueError):
+        return None
+    return result
+
+
+def _normalise_ohlcv_bars(bars: t.Sequence[t.Mapping[str, t.Any]] | t.Sequence[t.Any]) -> list[dict[str, float]]:
+    normalised: list[dict[str, float]] = []
+    for bar in bars or []:
+        if not isinstance(bar, t.Mapping):
+            continue
+        open_v = _safe_float_value(bar.get("open") or bar.get("o"))
+        high_v = _safe_float_value(bar.get("high") or bar.get("h"))
+        low_v = _safe_float_value(bar.get("low") or bar.get("l"))
+        close_v = _safe_float_value(bar.get("close") or bar.get("c"))
+        volume_v = _safe_float_value(bar.get("volume") or bar.get("v") or 0.0)
+        if open_v is None or high_v is None or low_v is None or close_v is None:
+            continue
+        normalised.append({"open": open_v, "high": high_v, "low": low_v, "close": close_v, "volume": float(volume_v or 0.0)})
+    return normalised
+
+
+def _extract_option_strike(symbol: str) -> int | None:
+    match = re.search(r"(\d{5})(CE|PE)$", str(symbol or "").strip().upper())
+    return int(match.group(1)) if match else None
+
+
+def _enrich_option_candidate_metadata(symbol: str, indicators: t.Mapping[str, t.Any]) -> dict[str, t.Any]:
+    enriched = dict(indicators or {})
+    symbol_norm = str(symbol or "").strip().upper()
+    selected_ce = str(enriched.get("selected_ce") or "").strip().upper()
+    selected_pe = str(enriched.get("selected_pe") or "").strip().upper()
+    selected_same_side = selected_ce if symbol_norm.endswith("CE") else selected_pe if symbol_norm.endswith("PE") else ""
+    selected_symbols = {selected_ce, selected_pe}
+    selected_symbols.discard("")
+    if enriched.get("is_selected_option") is None:
+        enriched["is_selected_option"] = bool(symbol_norm in selected_symbols) if selected_symbols else False
+    if enriched.get("strike_distance_from_atm") is None:
+        symbol_strike = _extract_option_strike(symbol_norm)
+        atm_strike = _safe_float_value(enriched.get("atm_strike"))
+        if symbol_strike is not None and atm_strike is not None:
+            enriched["strike_distance_from_atm"] = abs(float(symbol_strike) - atm_strike)
+        else:
+            selected_strike = _extract_option_strike(selected_same_side)
+            if symbol_strike is not None and selected_strike is not None:
+                enriched["strike_distance_from_atm"] = abs(float(symbol_strike) - float(selected_strike))
+    return enriched
+
+
+def _enrich_smc_pre_strategy(
+    symbol: str,
+    indicators: t.Mapping[str, t.Any],
+    bars: t.Sequence[t.Mapping[str, t.Any]],
+) -> dict[str, t.Any]:
+    enriched = dict(indicators or {})
+    ohlcv = _normalise_ohlcv_bars(bars)
+    bar_count = len(ohlcv)
+    if bar_count < 20:
+        enriched.setdefault("smc_enrichment_bars", bar_count)
+        return enriched
+
+    window = 5
+    scan_start = max(0, bar_count - 100)
+    latest_high: float | None = None
+    latest_low: float | None = None
+    for idx in range(bar_count - 1 - window, scan_start - 1, -1):
+        left = max(0, idx - window)
+        right = min(bar_count, idx + window + 1)
+        segment = ohlcv[left:right]
+        candidate_high = ohlcv[idx]["high"]
+        candidate_low = ohlcv[idx]["low"]
+        if latest_high is None and candidate_high == max(item["high"] for item in segment):
+            latest_high = candidate_high
+        if latest_low is None and candidate_low == min(item["low"] for item in segment):
+            latest_low = candidate_low
+        if latest_high is not None and latest_low is not None:
+            break
+
+    latest = ohlcv[-1]
+    previous = ohlcv[-2]
+    closes = [bar["close"] for bar in ohlcv[-5:]]
+    symbol_side = "CE" if str(symbol).upper().endswith("CE") else "PE" if str(symbol).upper().endswith("PE") else ""
+    direction_bias = str(enriched.get("direction_bias") or enriched.get("underlying_direction_bias") or "").upper()
+    side = symbol_side if symbol_side in {"CE", "PE"} else direction_bias if direction_bias in {"CE", "PE"} else ""
+
+    bos_side: str | None = None
+    bos_confirmed = False
+    if latest_high is not None and any(close > latest_high for close in closes):
+        if side in {"", "CE"}:
+            bos_confirmed = True
+            bos_side = "CE"
+    if latest_low is not None and any(close < latest_low for close in closes):
+        if side in {"", "PE"}:
+            bos_confirmed = True
+            bos_side = "PE"
+
+    choch_side: str | None = None
+    choch_confirmed = False
+    if direction_bias == "CE" and latest_low is not None and any(close < latest_low for close in closes):
+        choch_confirmed = True
+        choch_side = "PE"
+    elif direction_bias == "PE" and latest_high is not None and any(close > latest_high for close in closes):
+        choch_confirmed = True
+        choch_side = "CE"
+
+    premium_current = latest["close"]
+    fallback_price = _safe_float_value(enriched.get("current_price") or enriched.get("ltp") or enriched.get("price"))
+    if premium_current <= 0 and fallback_price is not None:
+        premium_current = fallback_price
+    premium_prev_close = previous["close"]
+    premium_vwap = _safe_float_value(enriched.get("vwap"))
+    if premium_vwap is None:
+        premium_vwap = _safe_float_value(enriched.get("exchange_vwap"))
+    if premium_vwap is None:
+        volume_sum = sum(max(0.0, bar["volume"]) for bar in ohlcv)
+        if volume_sum > 0:
+            premium_vwap = sum(((bar["high"] + bar["low"] + bar["close"]) / 3.0) * max(0.0, bar["volume"]) for bar in ohlcv) / volume_sum
+        else:
+            premium_vwap = premium_current
+
+    tolerance = max(abs(premium_current) * 0.003, 0.05)
+    recent_bars = ohlcv[-5:]
+    retest_confirmed = False
+    if latest_high is not None and side in {"", "CE"}:
+        retest_confirmed = any(abs(bar["low"] - latest_high) <= tolerance or abs(bar["close"] - latest_high) <= tolerance for bar in recent_bars)
+    if not retest_confirmed and latest_low is not None and side in {"", "PE"}:
+        retest_confirmed = any(abs(bar["high"] - latest_low) <= tolerance or abs(bar["close"] - latest_low) <= tolerance for bar in recent_bars)
+    if not retest_confirmed and premium_vwap is not None:
+        retest_confirmed = any(bar["low"] - tolerance <= premium_vwap <= bar["high"] + tolerance for bar in recent_bars)
+
+    current_body = abs(latest["close"] - latest["open"])
+    previous_body = abs(previous["close"] - previous["open"])
+    body_floor = max(current_body, 0.05)
+    lower_wick = min(latest["open"], latest["close"]) - latest["low"]
+    upper_wick = latest["high"] - max(latest["open"], latest["close"])
+    bullish_reversal = bool(latest["close"] > latest["open"] and current_body >= previous_body and lower_wick >= 0.3 * body_floor)
+    bearish_reversal = bool(latest["close"] < latest["open"] and current_body >= previous_body and upper_wick >= 0.3 * body_floor)
+    premium_reclaim = bool(premium_vwap is not None and premium_prev_close < premium_vwap and premium_current >= premium_vwap)
+
+    derived: dict[str, t.Any] = {
+        "swing_high": latest_high,
+        "swing_low": latest_low,
+        "bos_confirmed": bos_confirmed,
+        "bos_side": bos_side,
+        "choch_confirmed": choch_confirmed,
+        "choch_side": choch_side,
+        "retest_confirmed": retest_confirmed,
+        "premium_current": premium_current,
+        "premium_prev_close": premium_prev_close,
+        "premium_vwap": premium_vwap,
+        "premium_reclaim": premium_reclaim,
+        "bullish_reversal": bullish_reversal,
+        "bearish_reversal": bearish_reversal,
+        "smc_enrichment_source": "strategy_manager_pre_strategy",
+        "smc_enrichment_bars": bar_count,
+        "smc_enrichment_lookahead_safe": True,
+    }
+    for key, value in derived.items():
+        if enriched.get(key) is None:
+            enriched[key] = value
+
+    required = ("premium_reclaim", "bullish_reversal", "choch_confirmed", "bos_confirmed", "retest_confirmed")
+    feature_completeness = sum(1 for name in required if enriched.get(name) is not None) / float(len(required))
+    if enriched.get("feature_completeness") is None:
+        enriched["feature_completeness"] = feature_completeness
+    log_throttled(
+        log,
+        f"smc_feature_enriched:{symbol}",
+        "SMC_FEATURE_ENRICHED symbol=%s feature_completeness=%.3f swing_high=%s swing_low=%s premium_current=%s premium_vwap=%s premium_reclaim=%s bos_confirmed=%s choch_confirmed=%s retest_confirmed=%s",
+        symbol,
+        feature_completeness,
+        enriched.get("swing_high"),
+        enriched.get("swing_low"),
+        enriched.get("premium_current"),
+        enriched.get("premium_vwap"),
+        enriched.get("premium_reclaim"),
+        enriched.get("bos_confirmed"),
+        enriched.get("choch_confirmed"),
+        enriched.get("retest_confirmed"),
+        interval_sec=30.0,
+        level=logging.INFO,
+        extra={"event": "SMC_FEATURE_ENRICHED", "symbol": symbol, "feature_completeness": feature_completeness},
+    )
+    return enriched
+
+
 @dataclass(frozen=True)
 class StrategyNoSignalDecision:
     symbol: str
@@ -2799,6 +2989,26 @@ class StrategyManager(_BaseStrategyManager):
             if fut_fresh and fut_ctx.get("vwap_slope") is not None:
                 indicators.setdefault("futures_vwap_slope", fut_ctx.get("vwap_slope"))
 
+        if symbol_role == "tradable_option":
+            indicators = _enrich_option_candidate_metadata(symbol, indicators)
+            recent_bars: list[dict[str, float]] = []
+            for owner, method_name in (
+                (self._data_hub, "get_ohlc_bars"),
+                (self._indicator_engine, "get_history"),
+                (self._indicator_engine, "get_bars"),
+            ):
+                if recent_bars or owner is None:
+                    continue
+                method = getattr(owner, method_name, None)
+                if not callable(method):
+                    continue
+                try:
+                    raw_bars = method(symbol, limit=100) if method_name == "get_ohlc_bars" else method(symbol)
+                except TypeError:
+                    raw_bars = method(symbol)
+                recent_bars = _normalise_ohlcv_bars(raw_bars or [])[-100:]
+            indicators = _enrich_smc_pre_strategy(symbol, indicators, recent_bars)
+
         position = self._position_manager.get_position(symbol)
 
         max_votes = max(1, int(getattr(app_settings, "MAX_STRATEGY_VOTES", 5)))
@@ -3693,19 +3903,24 @@ class StrategyManager(_BaseStrategyManager):
             else:
                 allow_candidate_switch = str(os.getenv("STRATEGY_ALLOW_CANDIDATE_SWITCH_ON_HIGH_SCORE", "false")).lower() in {"1", "true", "yes", "on"}
                 max_candidate_switch_distance = float(os.getenv("CANDIDATE_SWITCH_MAX_DISTANCE_POINTS", "100") or "100")
-                quote_depth_valid = bool(metadata.get("quote_depth_valid", True))
+                quote_depth_valid = bool(metadata.get("quote_depth_valid") or indicator_map.get("quote_depth_valid"))
+                try:
+                    switch_spread_pct = float(metadata.get("spread_pct") or indicator_map.get("spread_pct") or 999.0)
+                except (TypeError, ValueError):
+                    switch_spread_pct = 999.0
+                switch_min_score = 8.0 if best_vote.strategy == "OrderFlow" else 8.5
                 switch_allowed = (
                     allow_candidate_switch
                     and (strike_distance_from_atm is not None)
-                    and raw_trigger_score >= 7.0
-                    and best_vote.confidence >= 0.60
+                    and raw_trigger_score >= switch_min_score
                     and quote_depth_valid
+                    and switch_spread_pct <= self._env_float("LIVE_MAX_SPREAD_PCT", 0.75)
                     and strike_distance_from_atm <= max_candidate_switch_distance
                 )
                 if switch_allowed:
                     metadata_stage = "single_vote_candidate_switch"
                     metadata["candidate_switch_requested"] = True
-                    metadata["candidate_switch_reason"] = "high_raw_score_nearby_strike"
+                    metadata["candidate_switch_reason"] = "high_score_nearby_option_candidate"
                 else:
                     if not score_ok:
                         blocked_reason = "raw_score_below_min"

--- a/src/nifty_scalper_bot/strategies/elite_strategies/order_flow.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/order_flow.py
@@ -169,6 +169,9 @@ class OrderFlowStrategy(EliteStrategy):
             if abs(depth_imbalance) >= 0.15:
                 score += 2.0
                 reasons.append('depth_imbalance')
+            if abs(depth_imbalance) >= 0.50:
+                score += 1.0
+                reasons.append('strong_depth_imbalance')
             tick_supports = tick_direction in {'UP', 'BUY'} if option_premium_domain else ((side == 'CE' and tick_direction in {'UP', 'BUY'}) or (side == 'PE' and tick_direction in {'DOWN', 'SELL'}))
             if tick_supports:
                 score += 2.0
@@ -211,6 +214,45 @@ class OrderFlowStrategy(EliteStrategy):
                 and tick_supports
                 and tick_age_ms <= max_tick_age_ms
             )
+            near_atm_threshold = safe_float_env('STRATEGY_NEAR_ATM_THRESHOLD_POINTS', 50.0)
+            selected_meta_available = any(indicators.get(name) is not None for name in ('is_selected_option', 'strike_distance_from_atm', 'selected_ce', 'selected_pe'))
+            selected_or_near_atm = bool(indicators.get('is_selected_option'))
+            if not selected_or_near_atm and indicators.get('strike_distance_from_atm') is not None:
+                try:
+                    selected_or_near_atm = float(indicators.get('strike_distance_from_atm')) <= near_atm_threshold
+                except (TypeError, ValueError):
+                    selected_or_near_atm = False
+            if is_live_mode and not selected_meta_available:
+                selected_or_near_atm = False
+            conflict_override = bool(
+                not side_alignment_ok
+                and strategy_score >= float(os.getenv('ORDERFLOW_CONFLICT_OVERRIDE_MIN_SCORE', '9.0') or '9.0')
+                and quote_depth_valid is True
+                and depth_available is True
+                and spread_pct <= trigger_max_spread_pct
+                and context_age_ok is True
+                and tick_supports is True
+                and tick_age_ms <= max_tick_age_ms
+                and selected_or_near_atm is True
+            )
+            if conflict_override and not trigger_conditions_met:
+                trigger_conditions_met = bool(
+                    allow_orderflow_trigger
+                    and (tradable_quote or not (is_live_mode and require_tradable_quote_live))
+                    and bid > 0.0
+                    and ask > 0.0
+                    and direction_context_ok
+                )
+                if trigger_conditions_met:
+                    LOGGER.info(
+                        'ORDERFLOW_HIGH_CONVICTION_OVERRIDE symbol=%s side=%s score=%.2f spread_pct=%.2f context_age=%s',
+                        symbol,
+                        side,
+                        strategy_score,
+                        spread_pct,
+                        age_raw,
+                        extra={'event': 'ORDERFLOW_HIGH_CONVICTION_OVERRIDE', 'symbol': symbol, 'side': side, 'score': strategy_score, 'spread_pct': spread_pct, 'context_age': age_raw},
+                    )
             trigger_block_reason = ''
             if not allow_orderflow_trigger:
                 trigger_block_reason = 'trigger_role_disabled'
@@ -228,7 +270,7 @@ class OrderFlowStrategy(EliteStrategy):
                 trigger_block_reason = 'context_age_missing'
             elif not context_age_ok:
                 trigger_block_reason = 'context_stale'
-            elif not side_alignment_ok:
+            elif not side_alignment_ok and not conflict_override:
                 trigger_block_reason = 'direction_bias_conflict'
             elif spread_pct > trigger_max_spread_pct:
                 trigger_block_reason = 'spread_too_wide'
@@ -264,6 +306,9 @@ class OrderFlowStrategy(EliteStrategy):
                 'negative_premium_flow_mode': 'hard' if clear_adverse_flow else 'soft',
                 'tick_age_ms': tick_age_ms,
                 'quote_update_version': indicators.get('quote_update_version'),
+                'selected_or_near_atm': selected_or_near_atm,
+                'orderflow_conflict_override': conflict_override,
+                'conflict_override_reason': 'high_conviction_depth_spread_tick_near_atm' if conflict_override else '',
             }
             if trigger_conditions_met:
                 metadata['approval_candidate'] = 'orderflow_live_depth_trigger'

--- a/src/nifty_scalper_bot/strategies/elite_strategies/order_flow.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/order_flow.py
@@ -224,18 +224,19 @@ class OrderFlowStrategy(EliteStrategy):
                     selected_or_near_atm = False
             if is_live_mode and not selected_meta_available:
                 selected_or_near_atm = False
-            conflict_override = bool(
+            conflict_override_requested = bool(
                 not side_alignment_ok
                 and strategy_score >= float(os.getenv('ORDERFLOW_CONFLICT_OVERRIDE_MIN_SCORE', '9.0') or '9.0')
-                and quote_depth_valid is True
-                and depth_available is True
+                and bool(quote_depth_valid)
+                and bool(depth_available)
                 and spread_pct <= trigger_max_spread_pct
-                and context_age_ok is True
-                and tick_supports is True
+                and bool(context_age_ok)
+                and bool(tick_supports)
                 and tick_age_ms <= max_tick_age_ms
-                and selected_or_near_atm is True
+                and bool(selected_or_near_atm)
             )
-            if conflict_override and not trigger_conditions_met:
+            conflict_override_applied = False
+            if conflict_override_requested and not trigger_conditions_met:
                 trigger_conditions_met = bool(
                     allow_orderflow_trigger
                     and (tradable_quote or not (is_live_mode and require_tradable_quote_live))
@@ -243,7 +244,8 @@ class OrderFlowStrategy(EliteStrategy):
                     and ask > 0.0
                     and direction_context_ok
                 )
-                if trigger_conditions_met:
+                conflict_override_applied = bool(trigger_conditions_met)
+                if conflict_override_applied:
                     LOGGER.info(
                         'ORDERFLOW_HIGH_CONVICTION_OVERRIDE symbol=%s side=%s score=%.2f spread_pct=%.2f context_age=%s',
                         symbol,
@@ -270,7 +272,7 @@ class OrderFlowStrategy(EliteStrategy):
                 trigger_block_reason = 'context_age_missing'
             elif not context_age_ok:
                 trigger_block_reason = 'context_stale'
-            elif not side_alignment_ok and not conflict_override:
+            elif not side_alignment_ok and not conflict_override_applied:
                 trigger_block_reason = 'direction_bias_conflict'
             elif spread_pct > trigger_max_spread_pct:
                 trigger_block_reason = 'spread_too_wide'
@@ -307,8 +309,10 @@ class OrderFlowStrategy(EliteStrategy):
                 'tick_age_ms': tick_age_ms,
                 'quote_update_version': indicators.get('quote_update_version'),
                 'selected_or_near_atm': selected_or_near_atm,
-                'orderflow_conflict_override': conflict_override,
-                'conflict_override_reason': 'high_conviction_depth_spread_tick_near_atm' if conflict_override else '',
+                'orderflow_conflict_override_requested': conflict_override_requested,
+                'orderflow_conflict_override_applied': conflict_override_applied,
+                'orderflow_conflict_override': conflict_override_applied,
+                'conflict_override_reason': 'high_conviction_depth_spread_tick_near_atm' if conflict_override_applied else '',
             }
             if trigger_conditions_met:
                 metadata['approval_candidate'] = 'orderflow_live_depth_trigger'

--- a/src/nifty_scalper_bot/strategies/elite_strategies/smc_liquidity.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/smc_liquidity.py
@@ -231,16 +231,44 @@ class SMCStrategy(EliteStrategy):
             if option_premium_domain:
                 premium_reversal = bool(bullish_sweep or indicators.get('premium_reclaim') or indicators.get('bullish_reversal'))
                 structure_flip = bool(indicators.get('choch_confirmed') or indicators.get('bos_confirmed'))
+                partial_features_used = False
                 if not feature_ready:
-                    self._no_vote('strategy_feature_unavailable')
-                    LOGGER.info(
-                        "SMC_FEATURE_UNAVAILABLE symbol=%s missing_features=%s missing_feature_sources=%s",
-                        symbol,
-                        ",".join(missing_features),
-                        missing_feature_sources,
-                        extra={"event": "SMC_FEATURE_UNAVAILABLE", "symbol": symbol, "missing_features": missing_features, "missing_feature_sources": missing_feature_sources},
+                    fallback_enabled = str(os.getenv("SMC_ALLOW_DERIVED_FEATURE_FALLBACK_LIVE", "false")).lower() in {"1", "true", "yes", "on"}
+                    momentum_min = float(os.getenv("SMC_MOMENTUM_DISPLACEMENT_MIN", "0.80") or "0.80")
+                    fallback_signal_present = bool(
+                        indicators.get("premium_reclaim")
+                        or indicators.get("bos_confirmed")
+                        or indicators.get("choch_confirmed")
+                        or indicators.get("retest_confirmed")
+                        or (bullish_sweep and displacement_score >= 0.9)
                     )
-                    return None
+                    fallback_allowed = bool(
+                        is_live
+                        and fallback_enabled
+                        and effective_direction in {"CE", "PE"}
+                        and displacement_score >= momentum_min
+                        and fallback_signal_present
+                    )
+                    if fallback_allowed:
+                        partial_features_used = True
+                        LOGGER.info(
+                            "SMC_DERIVED_FEATURE_FALLBACK symbol=%s feature_completeness=%.3f displacement_score=%.3f effective_direction=%s",
+                            symbol,
+                            feature_completeness,
+                            displacement_score,
+                            effective_direction,
+                            extra={"event": "SMC_DERIVED_FEATURE_FALLBACK", "symbol": symbol, "feature_completeness": feature_completeness, "displacement_score": displacement_score, "effective_direction": effective_direction},
+                        )
+                    else:
+                        self._no_vote('strategy_feature_unavailable')
+                        LOGGER.info(
+                            "SMC_FEATURE_UNAVAILABLE symbol=%s missing_features=%s missing_feature_sources=%s",
+                            symbol,
+                            ",".join(missing_features),
+                            missing_feature_sources,
+                            extra={"event": "SMC_FEATURE_UNAVAILABLE", "symbol": symbol, "missing_features": missing_features, "missing_feature_sources": missing_feature_sources},
+                        )
+                        return None
                 if not premium_reversal and not structure_flip:
                     self._no_vote('premium_not_reversing_up')
                     LOGGER.info(
@@ -277,6 +305,7 @@ class SMCStrategy(EliteStrategy):
                     return None
                 side = contract_side
             else:
+                partial_features_used = False
                 side = 'CE' if bullish_sweep else 'PE'
             sweep_level = low if bullish_sweep else high
             choch_confirmed = bool(indicators.get('choch_confirmed'))
@@ -311,6 +340,9 @@ class SMCStrategy(EliteStrategy):
                 reasons.append('clean_invalidation_rr')
 
             strategy_score = max(0.0, min(10.0, score))
+            if partial_features_used:
+                strategy_score = max(0.0, strategy_score - 0.5)
+                reasons.append('derived_feature_fallback')
             min_score = float(os.getenv('SMC_MIN_SCORE_LIVE', '6.5') if is_live else os.getenv('SMC_MIN_SCORE_SHADOW', '4.5'))
             require_structure_live = str(os.getenv('SMC_REQUIRE_STRUCTURE_CONFIRMATION_LIVE', 'true')).lower() in {'1', 'true', 'yes', 'on'}
             allow_momentum_without_structure = str(os.getenv("SMC_ALLOW_MOMENTUM_WITHOUT_STRUCTURE_LIVE", "true")).lower() in {"1", "true", "yes", "on"}
@@ -497,6 +529,9 @@ class SMCStrategy(EliteStrategy):
                 'premium_stop_distance': max(atr * 1.2, current_price * 0.025, 1.0),
                 'premium_target_rr': 2.0,
                 'premium_reversal_gate_mode': 'hard' if option_premium_domain and not premium_reclaim and not structure_confirmed else 'soft',
+                'partial_features_used': partial_features_used,
+                'feature_completeness': feature_completeness,
+                'smc_fallback_reason': 'derived_feature_fallback' if partial_features_used else '',
             }
             LOGGER.info('STRATEGY_VOTE strategy=SMC side=%s score=%.2f', side, strategy_score)
             return EliteSignal(

--- a/src/nifty_scalper_bot/strategies/elite_strategies/vwap_pro.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/vwap_pro.py
@@ -242,6 +242,16 @@ class VWAPProStrategy(EliteStrategy):
             if early_trend_pullback:
                 score += 1.2
                 reasons.append("early_trend_pullback_context")
+            if (
+                trend_alignment
+                and context_fresh
+                and underlying_direction_confidence >= float(os.getenv("VWAP_CONTEXT_BOOST_MIN_CONFIDENCE", "0.90") or "0.90")
+                and spread_pct <= float(os.getenv("LIVE_MAX_SPREAD_PCT", "0.75") or "0.75")
+                and premium_above_vwap
+            ):
+                boost = float(os.getenv("VWAP_PRO_TREND_CONTEXT_BOOST", "0.5") or "0.5")
+                score = min(10.0, score + boost)
+                reasons.append("trend_context_boost")
             threshold_source = 'trend_aligned' if trend_alignment else 'base'
 
             if score < min_score:

--- a/tests/core/test_candidate_gate_metadata.py
+++ b/tests/core/test_candidate_gate_metadata.py
@@ -70,3 +70,21 @@ def test_high_score_candidate_switch_only_within_configured_distance(monkeypatch
     assert near.metadata["candidate_switch_requested"] is True
     assert near.metadata["candidate_switch_reason"] == "high_score_nearby_option_candidate"
     assert far is None
+
+
+def test_candidate_switch_does_not_override_metadata_false_with_indicator_true(monkeypatch):
+    monkeypatch.setenv("STRATEGY_ALLOW_CANDIDATE_SWITCH_ON_HIGH_SCORE", "true")
+    monkeypatch.setenv("CANDIDATE_SWITCH_MAX_DISTANCE_POINTS", "75")
+    monkeypatch.setenv("LIVE_MAX_SPREAD_PCT", "0.75")
+    manager = StrategyManager()
+    signal, vote = _signal_vote(50.0)
+    signal.metadata["quote_depth_valid"] = False
+    vote.metadata["quote_depth_valid"] = False
+
+    result = manager._combine_strategy_votes(
+        symbol="NFO:NIFTY26MAY24050CE",
+        signals=[(signal, vote)],
+        indicators={"quote_depth_valid": True, "spread_pct": 0.5},
+    )
+
+    assert result is None

--- a/tests/core/test_candidate_gate_metadata.py
+++ b/tests/core/test_candidate_gate_metadata.py
@@ -1,0 +1,72 @@
+from nifty_scalper_bot.core.strategy_manager import StrategyManager, StrategyVote, _enrich_option_candidate_metadata
+from nifty_scalper_bot.strategies.signal_generator import Signal
+
+
+def test_candidate_metadata_derives_strike_distance_from_same_side_selected():
+    enriched = _enrich_option_candidate_metadata(
+        "NFO:NIFTY26MAY24050CE",
+        {"selected_ce": "NFO:NIFTY26MAY24000CE", "selected_pe": "NFO:NIFTY26MAY24000PE"},
+    )
+
+    assert enriched["selected_ce"] == "NFO:NIFTY26MAY24000CE"
+    assert enriched["selected_pe"] == "NFO:NIFTY26MAY24000PE"
+    assert enriched["is_selected_option"] is False
+    assert enriched["strike_distance_from_atm"] == 50.0
+
+
+def _signal_vote(distance: float):
+    metadata = {
+        "strategy": "OrderFlow",
+        "role": "trigger",
+        "strategy_score": 8.0,
+        "raw_setup_score": 8.0,
+        "quote_depth_valid": True,
+        "spread_pct": 0.5,
+        "selected_ce": "NFO:NIFTY26MAY24000CE",
+        "selected_pe": "NFO:NIFTY26MAY24000PE",
+        "is_selected_option": False,
+        "strike_distance_from_atm": distance,
+        "trigger_conditions_met": True,
+    }
+    signal = Signal(
+        action="BUY",
+        symbol="NFO:NIFTY26MAY24050CE",
+        quantity=1,
+        confidence=0.85,
+        reason="orderflow",
+        stop_loss=None,
+        take_profit=None,
+        metadata=dict(metadata),
+    )
+    vote = StrategyVote(
+        strategy="OrderFlow",
+        side="CE",
+        score=8.0,
+        confidence=0.85,
+        reasons=["depth"],
+        metadata=dict(metadata),
+    )
+    return signal, vote
+
+
+def test_high_score_candidate_switch_only_within_configured_distance(monkeypatch):
+    monkeypatch.setenv("STRATEGY_ALLOW_CANDIDATE_SWITCH_ON_HIGH_SCORE", "true")
+    monkeypatch.setenv("CANDIDATE_SWITCH_MAX_DISTANCE_POINTS", "75")
+    monkeypatch.setenv("LIVE_MAX_SPREAD_PCT", "0.75")
+    manager = StrategyManager()
+
+    near = manager._combine_strategy_votes(
+        symbol="NFO:NIFTY26MAY24050CE",
+        signals=[_signal_vote(50.0)],
+        indicators={"quote_depth_valid": True, "spread_pct": 0.5},
+    )
+    far = manager._combine_strategy_votes(
+        symbol="NFO:NIFTY26MAY24150CE",
+        signals=[_signal_vote(150.0)],
+        indicators={"quote_depth_valid": True, "spread_pct": 0.5},
+    )
+
+    assert near is not None
+    assert near.metadata["candidate_switch_requested"] is True
+    assert near.metadata["candidate_switch_reason"] == "high_score_nearby_option_candidate"
+    assert far is None

--- a/tests/core/test_smc_enrichment.py
+++ b/tests/core/test_smc_enrichment.py
@@ -47,3 +47,146 @@ def test_feature_completeness_counts_false_booleans_as_present():
     assert enriched["bos_confirmed"] is False
     assert enriched["feature_completeness"] > 0
     assert enriched["feature_completeness"] == 1.0
+
+
+def test_normalise_ohlcv_bars_handles_dataframe_and_zero_values():
+    from nifty_scalper_bot.core.strategy_manager import _normalise_ohlcv_bars
+
+    class _Frame:
+        def __init__(self, rows):
+            self._rows = rows
+
+        def tail(self, _limit):
+            return self
+
+        def to_dict(self, orient):
+            assert orient == "records"
+            return self._rows
+
+    rows = _Frame([
+        {"open": 0, "o": 999, "high": 0, "h": 999, "low": 0, "l": 999, "close": 0, "c": 999, "volume": 0, "v": 999},
+        {"o": 1, "h": 2, "l": 0.5, "c": 1.5, "v": 0},
+        "bad-row",
+        {"open": None, "high": 2, "low": 1, "close": 1.5},
+    ])
+
+    normalised = _normalise_ohlcv_bars(rows)
+
+    assert normalised == [
+        {"open": 0.0, "high": 0.0, "low": 0.0, "close": 0.0, "volume": 0.0},
+        {"open": 1.0, "high": 2.0, "low": 0.5, "close": 1.5, "volume": 0.0},
+    ]
+
+
+def test_extract_option_strike_accepts_4_to_6_digits():
+    from nifty_scalper_bot.core.strategy_manager import _extract_option_strike
+
+    assert _extract_option_strike("NFO:NIFTY26MAY9500CE") == 9500
+    assert _extract_option_strike("NFO:NIFTY26MAY24000PE") == 24000
+    assert _extract_option_strike("NFO:NIFTY26MAY124000CE") == 124000
+
+
+def test_smc_enrichment_separates_presence_from_positive_signal_count():
+    bars = [_bar(100, 102, 99, 101) for _ in range(25)]
+    enriched = _enrich_smc_pre_strategy(
+        "NFO:NIFTY26MAY24000CE",
+        {
+            "premium_reclaim": False,
+            "bullish_reversal": False,
+            "choch_confirmed": False,
+            "bos_confirmed": False,
+            "retest_confirmed": False,
+        },
+        bars,
+    )
+
+    assert enriched["feature_completeness"] == 1.0
+    assert enriched["smc_feature_presence_ratio"] == 1.0
+    assert enriched["smc_positive_feature_count"] == 0
+    assert enriched["smc_positive_features"] == []
+
+
+def test_runtime_strategy_manager_class_is_core_manager_or_enrichment_hook_executes(caplog):
+    import logging
+    import typing as t
+    from nifty_scalper_bot.core.strategy_manager import StrategyManager
+
+    symbol = "NFO:NIFTY26MAY24000CE"
+
+    class _Strategy:
+        name = "SMC"
+        last = {}
+
+        def get_required_indicators(self):
+            return []
+
+        def generate_signal(self, symbol: str, indicators: t.Mapping[str, t.Any], current_price: float, position: t.Any):
+            self.last = dict(indicators)
+            return None
+
+    class _IE:
+        def get_history(self, _symbol):
+            return [_bar(100, 102, 99, 101) for _ in range(30)]
+
+        def get_indicators(self, _symbol, _names):
+            return {"vwap": 100, "exchange_vwap": 100, "volume": 100, "avg_volume": 100}
+
+    class _PM:
+        def get_position(self, _symbol):
+            return None
+
+    st = _Strategy()
+    with caplog.at_level(logging.INFO):
+        manager = StrategyManager([st], _IE(), _PM())
+        manager.generate_signal(symbol, 101)
+
+    assert manager.__class__.__module__ == "nifty_scalper_bot.core.strategy_manager"
+    assert st.last["smc_enrichment_source"] == "strategy_manager_pre_strategy"
+    assert "RUNTIME_STRATEGY_MANAGER_CLASS" in caplog.text
+
+
+def test_history_provider_exception_does_not_crash_generate_signal(caplog):
+    import logging
+    import typing as t
+    from nifty_scalper_bot.core.strategy_manager import StrategyManager
+
+    symbol = "NFO:NIFTY26MAY24000CE"
+
+    class _Strategy:
+        name = "SMC"
+        seen = False
+
+        def get_required_indicators(self):
+            return []
+
+        def generate_signal(self, symbol: str, indicators: t.Mapping[str, t.Any], current_price: float, position: t.Any):
+            self.seen = True
+            return None
+
+    class _Hub:
+        indicators_ready = True
+
+        def get_ohlc_bars(self, *_args, **_kwargs):
+            raise RuntimeError("history provider down")
+
+        def get_quote(self, *_args, **_kwargs):
+            return {}
+
+    class _IE:
+        def get_history(self, _symbol):
+            return [_bar(100, 102, 99, 101) for _ in range(30)]
+
+        def get_indicators(self, _symbol, _names):
+            return {"vwap": 100, "exchange_vwap": 100, "volume": 100, "avg_volume": 100}
+
+    class _PM:
+        def get_position(self, _symbol):
+            return None
+
+    st = _Strategy()
+    manager = StrategyManager([st], _IE(), _PM(), data_hub=_Hub())
+    with caplog.at_level(logging.WARNING):
+        manager.generate_signal(symbol, 101)
+
+    assert st.seen is True
+    assert "SMC_HISTORY_PROVIDER_FAILED" in caplog.text

--- a/tests/core/test_smc_enrichment.py
+++ b/tests/core/test_smc_enrichment.py
@@ -1,0 +1,49 @@
+from nifty_scalper_bot.core.strategy_manager import _enrich_smc_pre_strategy
+
+
+def _bar(open_, high, low, close, volume=100):
+    return {"open": open_, "high": high, "low": low, "close": close, "volume": volume}
+
+
+def test_rolling_pivot_detects_latest_confirmed_without_current_lookahead():
+    bars = [_bar(100, 101 + (i % 3), 99 - (i % 2), 100 + (i % 4) * 0.1) for i in range(80)]
+    pivot_idx = len(bars) - 1 - 5 - 3
+    bars[pivot_idx] = _bar(100, 150, 80, 110)
+    bars[-1] = _bar(120, 999, 119, 121)  # unfinished/current bar must not become pivot
+
+    enriched = _enrich_smc_pre_strategy("NFO:NIFTY26MAY24000CE", {}, bars)
+
+    assert enriched["swing_high"] == 150
+    assert enriched["swing_low"] == 80
+    assert enriched["swing_high"] != 999
+    assert enriched["smc_enrichment_lookahead_safe"] is True
+
+
+def test_premium_domain_fields_use_option_premium_values():
+    bars = [_bar(100, 106, 99, 103) for _ in range(25)]
+    bars[-2] = _bar(103, 106, 102, 104)
+    bars[-1] = _bar(104, 111, 103, 110)
+
+    enriched = _enrich_smc_pre_strategy(
+        "NFO:NIFTY26MAY24000CE",
+        {"vwap": 105},
+        bars,
+    )
+
+    assert enriched["premium_current"] == 110
+    assert enriched["premium_prev_close"] == 104
+    assert enriched["premium_vwap"] == 105
+    assert enriched["premium_reclaim"] is True
+
+
+def test_feature_completeness_counts_false_booleans_as_present():
+    bars = [_bar(100, 102, 99, 101) for _ in range(25)]
+    enriched = _enrich_smc_pre_strategy(
+        "NFO:NIFTY26MAY24000CE",
+        {"bos_confirmed": False},
+        bars,
+    )
+
+    assert enriched["bos_confirmed"] is False
+    assert enriched["feature_completeness"] > 0
+    assert enriched["feature_completeness"] == 1.0

--- a/tests/strategies/test_order_flow_conflict_override.py
+++ b/tests/strategies/test_order_flow_conflict_override.py
@@ -46,3 +46,20 @@ def test_orderflow_high_conviction_conflict_override_requires_depth_tick_and_nea
     assert signal.metadata["trigger_conditions_met"] is True
     assert signal.metadata["orderflow_conflict_override"] is True
     assert signal.metadata["conflict_override_reason"] == "high_conviction_depth_spread_tick_near_atm"
+
+
+def test_orderflow_override_requested_vs_applied(monkeypatch):
+    monkeypatch.setenv("EXECUTION_MODE", "LIVE")
+    strategy = OrderFlowStrategy(OrderFlowStrategyConfig(enabled=True, quantity=1), indicator_engine=None)
+    indicators = _ind(score_high=True)
+    indicators["tradable_quote"] = False
+
+    signal = strategy._evaluate_signal("NFO:NIFTY26MAY24000CE", indicators, current_price=100.2)
+
+    assert signal is not None
+    assert signal.metadata["orderflow_conflict_override_requested"] is True
+    assert signal.metadata["orderflow_conflict_override_applied"] is False
+    assert signal.metadata["orderflow_conflict_override"] is False
+    assert signal.metadata["conflict_override_reason"] == ""
+    assert signal.metadata["trigger_conditions_met"] is False
+    assert signal.metadata["trigger_block_reason"] == "tradable_quote_false"

--- a/tests/strategies/test_order_flow_conflict_override.py
+++ b/tests/strategies/test_order_flow_conflict_override.py
@@ -1,0 +1,48 @@
+from nifty_scalper_bot.strategies.elite_strategies.config_models import OrderFlowStrategyConfig
+from nifty_scalper_bot.strategies.elite_strategies.order_flow import OrderFlowStrategy
+
+
+def _ind(score_high: bool):
+    buy_qty = 300 if score_high else 180
+    sell_qty = 100
+    return {
+        "bid": 100.0,
+        "ask": 100.5,
+        "spread_pct": 0.5,
+        "depth": {"buy": [{"quantity": buy_qty}], "sell": [{"quantity": sell_qty}]},
+        "tick_direction": "UP",
+        "direction_bias": "PE",
+        "atr": 2.0,
+        "data_age_seconds": 0.1,
+        "context_age_seconds": 1.0,
+        "tick_age_ms": 100,
+        "quote_depth_valid": True,
+        "tradable_quote": True,
+        "is_selected_option": True,
+        "strike_distance_from_atm": 0,
+    }
+
+
+def test_orderflow_direction_conflict_score_eight_remains_blocked(monkeypatch):
+    monkeypatch.setenv("EXECUTION_MODE", "LIVE")
+    strategy = OrderFlowStrategy(OrderFlowStrategyConfig(enabled=True, quantity=1), indicator_engine=None)
+
+    signal = strategy._evaluate_signal("NFO:NIFTY26MAY24000CE", _ind(score_high=False), current_price=100.2)
+
+    assert signal is not None
+    assert signal.metadata["trigger_conditions_met"] is False
+    assert signal.metadata["trigger_block_reason"] == "direction_bias_conflict"
+    assert signal.metadata["strategy_score"] == 8.0
+
+
+def test_orderflow_high_conviction_conflict_override_requires_depth_tick_and_near_atm(monkeypatch):
+    monkeypatch.setenv("EXECUTION_MODE", "LIVE")
+    strategy = OrderFlowStrategy(OrderFlowStrategyConfig(enabled=True, quantity=1), indicator_engine=None)
+
+    signal = strategy._evaluate_signal("NFO:NIFTY26MAY24000CE", _ind(score_high=True), current_price=100.2)
+
+    assert signal is not None
+    assert signal.metadata["strategy_score"] >= 9.0
+    assert signal.metadata["trigger_conditions_met"] is True
+    assert signal.metadata["orderflow_conflict_override"] is True
+    assert signal.metadata["conflict_override_reason"] == "high_conviction_depth_spread_tick_near_atm"

--- a/tests/strategies/test_vwap_pro_context_boost.py
+++ b/tests/strategies/test_vwap_pro_context_boost.py
@@ -1,0 +1,28 @@
+from nifty_scalper_bot.strategies.elite_strategies.config_models import VWAPProStrategyConfig
+from nifty_scalper_bot.strategies.elite_strategies.vwap_pro import VWAPProStrategy
+
+
+def test_vwap_pro_trend_context_boost_avoids_weak_score(monkeypatch):
+    monkeypatch.setenv("EXECUTION_MODE", "LIVE")
+    strategy = VWAPProStrategy(VWAPProStrategyConfig(enabled=True, quantity=1), indicator_engine=None)
+    indicators = {
+        "vwap": 100.0,
+        "open": 108.9,
+        "high": 109.4,
+        "low": 108.5,
+        "close": 109.0,
+        "atr": 2.0,
+        "volume": 0,
+        "avg_volume": 0,
+        "direction_bias": "CE",
+        "underlying_direction_bias": "CE",
+        "underlying_direction_confidence": 0.95,
+        "context_age_seconds": 1.0,
+        "spread_pct": 0.29,
+    }
+
+    signal = strategy._evaluate_signal("NFO:NIFTY26MAY24000CE", indicators, current_price=109.0)
+
+    assert signal is not None
+    assert "trend_context_boost" in signal.metadata["score_reasons"]
+    assert signal.metadata["strategy_score"] >= 5.5


### PR DESCRIPTION
### Motivation

- SMC readiness fields (premium_reclaim, bos/choch/retest, swing pivots) were not being derived before strategy evaluation, leaving SMC perpetually blocked. 
- VWAPPro was failing marginally-aligned live setups due to a score gap despite high-confidence, fresh underlying context. 
- OrderFlow produced high microstructure scores but was blocked by strict direction/candidate gates without a safe high-conviction override for near-ATM, deep/clean depth signals.

### Description

- Added a zero-lookahead SMC pre-strategy enrichment helper `_enrich_smc_pre_strategy` that normalises OHLCV bars, finds rolling confirmed pivots (window=5, lookback up to 100 bars), computes premium fields (`premium_current`, `premium_prev_close`, `premium_vwap`), BOS/CHOCH/retest/bullish/bearish reversal flags, `premium_reclaim`, `feature_completeness`, and enrichment metadata; injected only when indicators are missing values and never mutating caller inputs. 
- Hooked the enrichment into `StrategyManager.generate_signal` after history/quote enrichment and before strategy loop, sourcing recent bars from `data_hub.get_ohlc_bars`, `indicator_engine.get_history`, or `indicator_engine.get_bars` and normalising them first. 
- Added option-candidate metadata derivation `_enrich_option_candidate_metadata` to ensure `selected_ce`, `selected_pe`, `is_selected_option`, `strike_distance_from_atm` and related fields exist (derives strike from symbol when possible) so candidate gates behave deterministically. 
- Kept SMC strict by default but added an opt-in LIVE-only derived-feature fallback (`SMC_ALLOW_DERIVED_FEATURE_FALLBACK_LIVE`) that is only allowed under tight conditions (execution LIVE, effective CE/PE direction, displacement threshold, and at least one derived signal), applies a small score penalty and annotates metadata (`partial_features_used`, `smc_fallback_reason`). 
- Added a narrow VWAPPro context boost applied just before the weak-score check when trend is aligned, context is fresh and high-confidence, spread is tight and premium is above VWAP (configurable via `VWAP_PRO_TREND_CONTEXT_BOOST` and `VWAP_CONTEXT_BOOST_MIN_CONFIDENCE`). 
- Added a strict, narrow OrderFlow high-conviction override that can bypass direction conflict only when many safety checks pass (min override score, quote depth valid, depth available, spread cap, context/tick freshness and support, and selected-or-near-ATM metadata); override is logged and annotated (`orderflow_conflict_override`, `conflict_override_reason`). 
- Tightened high-score candidate-switch logic to require env opt-in, higher score thresholds for non-OrderFlow strategies, quote-depth validity, live spread cap, and max candidate distance; candidate-switch metadata is set when applicable. 
- Small depth scoring tweak (additive bonus for very strong imbalance) and multiple structured metadata fields/logging added for diagnostics and observability. 
- Added focused tests: SMC enrichment pivots/premium/completeness, VWAPPro trend-context boost, OrderFlow conflict-override behavior, and candidate gate metadata / candidate-switch behavior.

### Testing

- Ran `python -m compileall -q src` and the codebase compiled successfully. 
- Executed the new focused tests and related guard/regression tests: `pytest -q tests/core/test_smc_enrichment.py`, `pytest -q tests/strategies/test_vwap_pro_context_boost.py`, `pytest -q tests/strategies/test_order_flow_conflict_override.py`, `pytest -q tests/core/test_candidate_gate_metadata.py` and they all passed. 
- Ran additional strategy/manager regression checks (`tests/core/test_strategy_manager_context_to_option_propagation.py`, `tests/strategies/test_runner_live_path_guards.py`, `tests/strategies/test_active_futures_resolution.py`) and the full test suite (`pytest -q`) in CI locally; these passed with no regressions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a3e6f382083248631f9a479b41ee1)