### PR TITLE
Harden active basket hydration readiness

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -7372,7 +7372,8 @@ async def _recompute_and_push_runtime_readiness(ctx: BotContext, *, reason: str)
         if not context_exec_ready: missing.append('context_exec_not_ready')
         if not broker_ready: missing.append('broker_not_ready')
     if not hydration_hard_ready:
-        block_reason = f"ACTIVE_BASKET_HYDRATION_NOT_READY:{','.join(dict.fromkeys(str(m) for m in hydration_missing))}"
+        hydration_blockers = list(dict.fromkeys([*(str(m) for m in hydration_missing), *(str(m) for m in missing)]))
+        block_reason = f"ACTIVE_BASKET_HYDRATION_NOT_READY:{','.join(hydration_blockers)}"
     else:
         block_reason=None if live_orders_armed else f"execution_not_armed:{','.join(dict.fromkeys(missing))}"
     ctx.data_hard_ready=data_hard_ready; ctx.evaluation_ready=evaluation_ready; ctx.live_orders_armed=live_orders_armed; ctx.trading_ready=evaluation_ready; ctx.live_block_reason=block_reason
@@ -7391,15 +7392,25 @@ def _hydrate_committed_active_basket(ctx: BotContext, *, reason: str) -> dict[st
     """Hydrate the committed ActiveContractBasket before strategy evaluation."""
     mdm = getattr(ctx, "market_data_manager", None)
     hydrate = getattr(mdm, "hydrate_active_contract_basket", None)
+    mode = str(getattr(getattr(ctx, "settings", None), "execution_mode", os.getenv("EXECUTION_MODE", "PAPER")) or "PAPER").upper()
+    allow_missing_gate = str(os.getenv("ALLOW_MISSING_HYDRATION_GATE", "false") or "false").strip().lower() == "true"
+    basket = getattr(ctx, "active_contract_basket", None) or getattr(ctx, "active_trading_universe", None)
     if not callable(hydrate):
+        hard_ready = bool(mode in {"PAPER", "SHADOW"} and allow_missing_gate)
         report: dict[str, object] = {
-            "hard_ready": True,
-            "missing": [],
+            "hard_ready": hard_ready,
+            "missing": [] if hard_ready else ["hydrate_active_contract_basket_missing"],
             "symbols": {},
         }
+        LOGGER.warning(
+            "ACTIVE_BASKET_HYDRATION_METHOD_MISSING mode=%s hard_ready=%s reason=%s",
+            mode,
+            hard_ready,
+            reason,
+            extra={"event": "ACTIVE_BASKET_HYDRATION_METHOD_MISSING", "mode": mode, "hard_ready": hard_ready, "reason": reason},
+        )
         ctx.active_basket_hydration = report
         return report
-    basket = getattr(ctx, "active_contract_basket", None) or getattr(ctx, "active_trading_universe", None)
     try:
         report = dict(hydrate(basket))
     except Exception as exc:  # noqa: BLE001
@@ -7410,6 +7421,43 @@ def _hydrate_committed_active_basket(ctx: BotContext, *, reason: str) -> dict[st
             extra={"event": "ACTIVE_BASKET_HYDRATION_FAILED", "reason": reason, "error": str(exc)},
         )
         report = {"hard_ready": False, "missing": [f"hydration_exception:{type(exc).__name__}"], "symbols": {}}
+
+    spot_symbol = "NSE:NIFTY"
+    if isinstance(basket, Mapping):
+        spot_symbol = str(basket.get("spot_symbol") or spot_symbol)
+    else:
+        spot_symbol = str(getattr(basket, "spot_symbol", spot_symbol) or spot_symbol)
+    spot_quote = None
+    if mdm is not None:
+        try:
+            snap = getattr(mdm, "get_symbol_snapshot", lambda _s: None)(spot_symbol)
+            spot_quote = snap if snap is not None else getattr(mdm, "get_latest_tick", lambda _s: None)(spot_symbol)
+        except Exception:
+            spot_quote = None
+    try:
+        spot_bars = getattr(mdm, "get_ohlc_bars", lambda _s: [])(spot_symbol) if mdm is not None else []
+        spot_bars_count = len(spot_bars) if spot_bars is not None else 0
+    except Exception:
+        spot_bars_count = 0
+    direction_ctx = getattr(ctx, "direction_context", None) or getattr(ctx, "underlying_direction_context", None) or {}
+    if not isinstance(direction_ctx, Mapping):
+        direction_ctx = {}
+    direction_bias = (
+        direction_ctx.get("direction_bias")
+        or direction_ctx.get("underlying_direction_bias")
+        or getattr(ctx, "underlying_direction_bias", None)
+        or getattr(ctx, "direction_bias", None)
+    )
+    direction_age = direction_ctx.get("context_age_seconds") or direction_ctx.get("direction_context_age_seconds")
+    report.update(
+        {
+            "spot_quote_ready": bool(spot_quote),
+            "spot_bars_count": int(spot_bars_count),
+            "underlying_direction_bias": direction_bias,
+            "direction_context_age_seconds": direction_age,
+            "direction_context_ready": bool(str(direction_bias or "").upper() in {"CE", "PE"}),
+        }
+    )
     ctx.active_basket_hydration = report
     if not bool(report.get("hard_ready")):
         missing = list(report.get("missing") or [])

--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -7315,9 +7315,16 @@ async def _recompute_and_push_runtime_readiness(ctx: BotContext, *, reason: str)
     option_eval_min_live_bars = int(os.getenv("READINESS_OPTION_EVAL_MIN_BARS", os.getenv("OPTION_EVAL_MIN_LIVE_BARS", "20")) or 20)
     option_execution_min_bars = int(os.getenv("READINESS_OPTION_EXEC_MIN_BARS", os.getenv("OPTION_EXECUTION_MIN_BARS", "30")) or 30)
     context_execution_min_bars = int(os.getenv("READINESS_CONTEXT_MIN_BARS", os.getenv("CONTEXT_EXECUTION_MIN_BARS", "20")) or 20)
+    hydration_report = _hydrate_committed_active_basket(ctx, reason=reason)
+    hydration_hard_ready = bool(hydration_report.get("hard_ready"))
+    hydration_missing = list(hydration_report.get("missing") or [])
     _ = await _ensure_selected_options_hydrated(
         ctx, selected_ce, selected_pe, option_execution_min_bars, reason
     )
+    if not hydration_hard_ready:
+        hydration_report = _hydrate_committed_active_basket(ctx, reason=f"{reason}_post_selected_option_hydration")
+        hydration_hard_ready = bool(hydration_report.get("hard_ready"))
+        hydration_missing = list(hydration_report.get("missing") or hydration_missing)
     ce_bars, ce_mdm_bars, ce_runner_bars = _readiness_bars(selected_ce)
     pe_bars, pe_mdm_bars, pe_runner_bars = _readiness_bars(selected_pe)
     ce_quote_fresh=_fresh_ltp(selected_ce); pe_quote_fresh=_fresh_ltp(selected_pe)
@@ -7328,7 +7335,7 @@ async def _recompute_and_push_runtime_readiness(ctx: BotContext, *, reason: str)
     spot_ready=_fresh_ltp(spot_symbol) or _bars(spot_symbol)>=1
     futures_symbol = str(basket.get("futures_symbol") or "")
     context_exec_ready = _bars(spot_symbol)>=context_execution_min_bars or (_fresh_ltp(spot_symbol) and _bars(futures_symbol)>=context_execution_min_bars)
-    data_hard_ready=bool(spot_ready and ce_eval_ready and pe_eval_ready)
+    data_hard_ready=bool(spot_ready and ce_eval_ready and pe_eval_ready and hydration_hard_ready)
     runner_running=_runner_is_running(getattr(ctx,'strategy_runner',None))
     evaluation_ready=bool(data_hard_ready and runner_running)
     live_mode = str(getattr(ctx.settings, "execution_mode", "PAPER")).upper() == "LIVE"
@@ -7346,6 +7353,9 @@ async def _recompute_and_push_runtime_readiness(ctx: BotContext, *, reason: str)
     if not selected_pe: missing.append('selected_pe_missing')
     if not spot_ready: missing.append('spot_not_ready')
     if not evaluation_ready: missing.append('eval_not_ready')
+    if not hydration_hard_ready:
+        missing.append('ACTIVE_BASKET_HYDRATION_NOT_READY')
+        missing.extend(str(item) for item in hydration_missing)
     if ce_runner_bars < option_eval_min_live_bars: missing.append('ce_eval_bars_missing')
     if pe_runner_bars < option_eval_min_live_bars: missing.append('pe_eval_bars_missing')
     if ce_runner_bars < option_execution_min_bars: missing.append('ce_exec_bars_missing')
@@ -7361,7 +7371,10 @@ async def _recompute_and_push_runtime_readiness(ctx: BotContext, *, reason: str)
         if not pe_exec_ready: missing.append('pe_exec_quote_or_history_not_ready')
         if not context_exec_ready: missing.append('context_exec_not_ready')
         if not broker_ready: missing.append('broker_not_ready')
-    block_reason=None if live_orders_armed else f"execution_not_armed:{','.join(dict.fromkeys(missing))}"
+    if not hydration_hard_ready:
+        block_reason = f"ACTIVE_BASKET_HYDRATION_NOT_READY:{','.join(dict.fromkeys(str(m) for m in hydration_missing))}"
+    else:
+        block_reason=None if live_orders_armed else f"execution_not_armed:{','.join(dict.fromkeys(missing))}"
     ctx.data_hard_ready=data_hard_ready; ctx.evaluation_ready=evaluation_ready; ctx.live_orders_armed=live_orders_armed; ctx.trading_ready=evaluation_ready; ctx.live_block_reason=block_reason
     ctx.execution_ready_by_symbol = execution_ready_by_symbol
     ctx.selected_ce_exec_ready = bool(ce_exec_ready)
@@ -7372,6 +7385,41 @@ async def _recompute_and_push_runtime_readiness(ctx: BotContext, *, reason: str)
     if ctx.strategy_runner is not None and hasattr(ctx.strategy_runner, 'set_runtime_readiness'):
         ctx.strategy_runner.set_runtime_readiness(data_hard_ready=bool(ctx.data_hard_ready), evaluation_ready=bool(ctx.evaluation_ready), live_orders_armed=bool(ctx.live_orders_armed), reason=str(ctx.live_block_reason or reason), selected_ce=selected_ce, selected_pe=selected_pe, atm_strike=basket.get('atm_strike'), option_symbols=option_symbols, execution_ready_by_symbol=dict(getattr(ctx, "execution_ready_by_symbol", {}) or {}))
 
+
+
+def _hydrate_committed_active_basket(ctx: BotContext, *, reason: str) -> dict[str, object]:
+    """Hydrate the committed ActiveContractBasket before strategy evaluation."""
+    mdm = getattr(ctx, "market_data_manager", None)
+    hydrate = getattr(mdm, "hydrate_active_contract_basket", None)
+    if not callable(hydrate):
+        report: dict[str, object] = {
+            "hard_ready": True,
+            "missing": [],
+            "symbols": {},
+        }
+        ctx.active_basket_hydration = report
+        return report
+    basket = getattr(ctx, "active_contract_basket", None) or getattr(ctx, "active_trading_universe", None)
+    try:
+        report = dict(hydrate(basket))
+    except Exception as exc:  # noqa: BLE001
+        LOGGER.warning(
+            "ACTIVE_BASKET_HYDRATION_FAILED reason=%s error=%s",
+            reason,
+            exc,
+            extra={"event": "ACTIVE_BASKET_HYDRATION_FAILED", "reason": reason, "error": str(exc)},
+        )
+        report = {"hard_ready": False, "missing": [f"hydration_exception:{type(exc).__name__}"], "symbols": {}}
+    ctx.active_basket_hydration = report
+    if not bool(report.get("hard_ready")):
+        missing = list(report.get("missing") or [])
+        LOGGER.warning(
+            "ACTIVE_BASKET_HYDRATION_NOT_READY reason=%s missing=%s",
+            reason,
+            missing,
+            extra={"event": "ACTIVE_BASKET_HYDRATION_NOT_READY", "reason": reason, "missing": missing},
+        )
+    return report
 
 def _commit_active_dynamic_basket(
     ctx: BotContext,
@@ -7524,6 +7572,7 @@ def _commit_active_dynamic_basket(
     mdm_set = getattr(getattr(ctx, "market_data_manager", None), "set_active_contract_basket", None)
     if callable(mdm_set):
         mdm_set(committed)
+    _hydrate_committed_active_basket(ctx, reason="active_dynamic_basket_commit")
     hub_set = getattr(getattr(ctx, "data_hub", None), "set_active_contract_basket", None)
     if callable(hub_set):
         hub_set(committed)

--- a/src/nifty_scalper_bot/core/instrument_manager.py
+++ b/src/nifty_scalper_bot/core/instrument_manager.py
@@ -12,6 +12,7 @@ import logging
 import threading
 from dataclasses import dataclass
 from datetime import date, datetime, timedelta
+from zoneinfo import ZoneInfo
 from typing import Any, Dict, List, Mapping, Optional
 
 LOGGER = logging.getLogger("nifty_scalper_bot.core.instrument_manager")
@@ -52,6 +53,11 @@ class ActiveContractBasket:
     symbol_by_token: Mapping[int, str]
 
     metadata: Mapping[str, Any]
+
+
+def _exchange_trading_date() -> date:
+    """Return the current NSE trading date in IST. TODO: holiday calendar handling."""
+    return datetime.now(ZoneInfo("Asia/Kolkata")).date()
 
 
 def _atm_strike_for_spot(spot: float, step: int) -> int:
@@ -303,7 +309,7 @@ class InstrumentManager:
         Returns: List of upcoming Tuesday expiry dates.
         Raises: None.
         """
-        today = date.today()
+        today = _exchange_trading_date()
         expiries = []
         
         # Find next Tuesday
@@ -383,7 +389,7 @@ class InstrumentManager:
         Raises: None.
         """
         key = str(underlying).strip().upper()
-        today = date.today()
+        today = _exchange_trading_date()
         contracts: List[Dict[str, Any]] = []
 
         with self._lock:
@@ -436,7 +442,7 @@ class InstrumentManager:
         Raises: None.
         """
         key = str(underlying).strip().upper()
-        today = date.today()
+        today = _exchange_trading_date()
         contracts: List[Dict[str, Any]] = []
 
         with self._lock:
@@ -505,7 +511,7 @@ class InstrumentManager:
         if strike_step <= 0:
             raise ValueError("strike_step must be positive")
 
-        today = date.today()
+        today = _exchange_trading_date()
         rows = self._nifty_rows_snapshot()
 
         futures: list[tuple[date, int, dict[str, Any]]] = []
@@ -659,7 +665,7 @@ class InstrumentManager:
         if base_upper in _WELL_KNOWN_TOKENS:
             tokens.add(_WELL_KNOWN_TOKENS[base_upper])
 
-        today = date.today()
+        today = _exchange_trading_date()
         nearest_future: tuple[date, int] | None = None
         nearest_option_expiry: date | None = None
         with self._lock:

--- a/src/nifty_scalper_bot/data/data_hub.py
+++ b/src/nifty_scalper_bot/data/data_hub.py
@@ -166,6 +166,8 @@ class DataHub:
         self._drift_budget_ms = float(os.getenv("DRIFT_BUDGET_MS", "250"))
         self._warmup_grace_s = float(os.getenv("WARMUP_GRACE_S", "3"))
         self._tick_error_log_cooldown_sec = float(os.getenv("TICK_ERROR_LOG_COOLDOWN_SEC", "30"))
+        self._missing_data_log_cooldown_sec = float(os.getenv("DATAHUB_MISSING_DATA_LOG_COOLDOWN_SEC", "30"))
+        self._missing_data_log_at: dict[tuple[str, str], float] = {}
 
         self._main_loop: Optional[asyncio.AbstractEventLoop] = None
         self.tick_bus = TickBus()
@@ -234,7 +236,17 @@ class DataHub:
             basket = mdm_get()
             if basket is not None:
                 return basket
-        LOGGER.warning("DATAHUB_ACTIVE_BASKET_UNAVAILABLE", extra={"event": "DATAHUB_ACTIVE_BASKET_UNAVAILABLE"})
+        self._log_missing_market_data("DATAHUB_ACTIVE_BASKET_UNAVAILABLE", "active_contract_basket")
+        return None
+
+    def get_hydration_report(self) -> Mapping[str, Any] | None:
+        """Return the latest MDM active-basket hydration report when available."""
+        mdm_get = getattr(self._mdm, "get_hydration_report", None)
+        if callable(mdm_get):
+            try:
+                return mdm_get()
+            except Exception as exc:  # noqa: BLE001
+                LOGGER.debug("DATAHUB_HYDRATION_REPORT_UNAVAILABLE error=%s", exc)
         return None
 
     def get_selected_option_symbols(self) -> tuple[str | None, str | None]:
@@ -278,10 +290,17 @@ class DataHub:
         return lookup in {self._canonical_quote_symbol(s) for s in selected if s}
 
     def _log_missing_market_data(self, event: str, symbol: Any) -> None:
+        symbol_key = str(symbol)
+        now = self._monotonic()
+        cache_key = (event, symbol_key)
+        last = float(self._missing_data_log_at.get(cache_key, 0.0))
+        if now - last < self._missing_data_log_cooldown_sec:
+            return
+        self._missing_data_log_at[cache_key] = now
         if self._is_active_selected_symbol(symbol):
-            LOGGER.warning("%s symbol=%s", event, symbol, extra={"event": event, "symbol": str(symbol)})
+            LOGGER.warning("%s symbol=%s", event, symbol, extra={"event": event, "symbol": symbol_key})
         else:
-            LOGGER.debug("%s symbol=%s", event, symbol, extra={"event": event, "symbol": str(symbol)})
+            LOGGER.debug("%s symbol=%s", event, symbol, extra={"event": event, "symbol": symbol_key})
 
     def checkpoint(self) -> None:
         if self._store is None:

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -360,6 +360,7 @@ class MarketDataManager:
         self._selected_ce: str | None = None
         self._selected_pe: str | None = None
         self._active_atm_strike: int | None = None
+        self._active_basket_hydration_report: dict[str, Any] | None = None
 
         self._margin_lock = threading.RLock()
         self._margin_snapshot: dict[str, Any] | None = None
@@ -1683,17 +1684,75 @@ class MarketDataManager:
     def get_active_contract_basket(self) -> ActiveContractBasket | Mapping[str, Any] | None:
         return self._active_contract_basket
 
+    def get_hydration_report(self) -> dict[str, Any] | None:
+        """Return the last active-basket hydration report without triggering a fetch."""
+        return dict(self._active_basket_hydration_report) if self._active_basket_hydration_report is not None else None
+
+    @staticmethod
+    def _bars_count(bars: Any) -> int:
+        """Return a safe bar count for list/deque/tuple/DataFrame-like inputs."""
+        if bars is None:
+            return 0
+        if isinstance(bars, pd.DataFrame):
+            return int(len(bars.index))
+        try:
+            return int(len(bars))
+        except (TypeError, ValueError, AttributeError):
+            return 0
+
+    @classmethod
+    def _bars_ready(cls, bars: Any, min_bars: int) -> tuple[bool, int]:
+        """Safely check OHLC readiness without relying on ambiguous truthiness."""
+        count = cls._bars_count(bars)
+        return bool(count >= max(1, int(min_bars or 1))), count
+
+    def _reseed_active_basket_symbol_bars(self, symbol: str, min_bars: int) -> None:
+        """Best-effort selected-option history reseed through the existing hydration path."""
+        hydrate_fn = getattr(self, "hydrate_symbol_history", None)
+        if not callable(hydrate_fn):
+            return
+        try:
+            result = hydrate_fn(
+                symbol,
+                interval="minute",
+                days=max(1, int(math.ceil(float(min_bars) / 375.0)) + 1),
+                max_bars=max(int(min_bars), self._min_required_bars),
+                reason="active_basket_selected_option_reseed",
+            )
+            if inspect.isawaitable(result):
+                try:
+                    loop = asyncio.get_running_loop()
+                except RuntimeError:
+                    asyncio.run(result)
+                else:
+                    loop.create_task(result)
+                    self._logger.info(
+                        "MDM_BASKET_HYDRATION_RESEED_DEFERRED symbol=%s reason=running_event_loop",
+                        symbol,
+                        extra={"event": "MDM_BASKET_HYDRATION_RESEED_DEFERRED", "symbol": symbol},
+                    )
+        except Exception as exc:  # noqa: BLE001
+            self._logger.warning(
+                "MDM_BASKET_HYDRATION_RESEED_FAILED symbol=%s error=%s",
+                symbol,
+                exc,
+                extra={"event": "MDM_BASKET_HYDRATION_RESEED_FAILED", "symbol": symbol, "error": str(exc)},
+            )
+
     def hydrate_active_contract_basket(self, basket: ActiveContractBasket | Mapping[str, Any] | None = None) -> dict[str, Any]:
         """Hydrate cached quote/OHLC readiness for every active basket symbol."""
         active = basket or self._active_contract_basket
+        min_bars = max(1, int(getattr(self, "_min_required_bars", 1) or 1))
         if active is None:
-            return {"hard_ready": False, "symbols": {}, "missing": ["active_contract_basket_missing"]}
-        self._logger.info("MDM_BASKET_HYDRATION_STARTED", extra={"event": "MDM_BASKET_HYDRATION_STARTED"})
+            report = {"hard_ready": False, "min_bars_required": min_bars, "symbols": {}, "missing": ["active_contract_basket_missing"]}
+            self._active_basket_hydration_report = report
+            return report
+        self._logger.info("MDM_BASKET_HYDRATION_STARTED", extra={"event": "MDM_BASKET_HYDRATION_STARTED", "min_bars_required": min_bars})
         all_symbols = tuple(str(s) for s in (self._basket_get(active, "all_symbols", None) or self._basket_get(active, "symbols", ()) or ()) if s)
         token_by_symbol = dict(self._basket_get(active, "token_by_symbol", {}) or {})
-        selected = {self._basket_get(active, "selected_ce", None), self._basket_get(active, "selected_pe", None)}
+        selected = {str(s) for s in (self._basket_get(active, "selected_ce", None), self._basket_get(active, "selected_pe", None)) if s}
         future_symbol = self._basket_get(active, "futures_symbol", None)
-        report: dict[str, Any] = {"hard_ready": True, "symbols": {}, "missing": []}
+        report: dict[str, Any] = {"hard_ready": True, "min_bars_required": min_bars, "symbols": {}, "missing": []}
         for sym in all_symbols:
             token = token_by_symbol.get(sym) or self._token_by_symbol.get(sym)
             if sym in self._active_contract_roles:
@@ -1723,46 +1782,67 @@ class MarketDataManager:
                 except Exception as exc:  # noqa: BLE001
                     last_error = f"quote_refresh_failed:{type(exc).__name__}"
                     quote = None
-            bars = self.get_ohlc_bars(sym)
+            try:
+                bars = self.get_ohlc_bars(sym)
+                ohlc_ready, bars_count = self._bars_ready(bars, min_bars)
+            except Exception as exc:  # noqa: BLE001
+                bars = []
+                bars_count = 0
+                ohlc_ready = False
+                last_error = f"bars_malformed:{type(exc).__name__}"
+            if sym in selected and not ohlc_ready:
+                self._reseed_active_basket_symbol_bars(sym, min_bars)
+                try:
+                    bars = self.get_ohlc_bars(sym)
+                    ohlc_ready, bars_count = self._bars_ready(bars, min_bars)
+                except Exception as exc:  # noqa: BLE001
+                    bars_count = 0
+                    ohlc_ready = False
+                    last_error = f"bars_malformed_after_reseed:{type(exc).__name__}"
+            if role in {"spot_context", "futures_context"}:
+                ohlc_ready = True
             quote_ready = bool(quote)
-            ohlc_ready = bool(bars) or role in {"spot_context", "futures_context"}
             depth = quote.get("depth") if isinstance(quote, Mapping) else None
             bid = quote.get("bid") if isinstance(quote, Mapping) else None
             ask = quote.get("ask") if isinstance(quote, Mapping) else None
             depth_ready = bool(depth) or (bid is not None and ask is not None)
-            oi_val = None
-            if isinstance(quote, Mapping):
-                oi_val = quote.get("oi", quote.get("open_interest"))
+            oi_val = quote.get("oi", quote.get("open_interest")) if isinstance(quote, Mapping) else None
             ltp_only = quote_ready and not depth_ready
             source = str(quote.get("source") or quote.get("quote_source") or "cache") if isinstance(quote, Mapping) else "missing"
+            symbol_hard_ready = not (sym in selected and (not quote_ready or not ohlc_ready))
             if sym in selected and not quote_ready:
                 report["hard_ready"] = False
                 report["missing"].append(f"{sym}:quote_missing")
             if sym in selected and not ohlc_ready:
                 report["hard_ready"] = False
-                report["missing"].append(f"{sym}:ohlc_missing")
+                report["missing"].append(f"{sym}:ohlc_insufficient")
             symbol_report = {
                 "token": int(token) if token is not None else None,
                 "role": role,
+                "min_bars_required": min_bars,
+                "bars_count": int(bars_count),
                 "quote_ready": quote_ready,
-                "ohlc_ready": ohlc_ready,
+                "ohlc_ready": bool(ohlc_ready),
                 "depth_ready": depth_ready,
                 "oi_ready": (oi_val is not None) if role == "tradable_option" else None,
                 "ltp_only": bool(ltp_only),
+                "hard_ready": bool(symbol_hard_ready),
                 "last_error": last_error,
                 "source": source,
             }
             report["symbols"][sym] = symbol_report
             self._logger.info(
-                "MDM_BASKET_HYDRATION_SYMBOL_RESULT symbol=%s token=%s role=%s quote_ready=%s ohlc_ready=%s depth_ready=%s oi_ready=%s ltp_only=%s error=%s",
-                sym, symbol_report["token"], role, quote_ready, ohlc_ready, depth_ready, symbol_report["oi_ready"], ltp_only, last_error,
+                "MDM_BASKET_HYDRATION_SYMBOL_RESULT symbol=%s token=%s role=%s quote_ready=%s ohlc_ready=%s bars_count=%s depth_ready=%s oi_ready=%s ltp_only=%s hard_ready=%s error=%s",
+                sym, symbol_report["token"], role, quote_ready, ohlc_ready, bars_count, depth_ready, symbol_report["oi_ready"], ltp_only, symbol_hard_ready, last_error,
                 extra={"event": "MDM_BASKET_HYDRATION_SYMBOL_RESULT", "symbol": sym, **symbol_report},
             )
+        report["missing"] = list(dict.fromkeys(report["missing"]))
         self._logger.info(
             "MDM_BASKET_HYDRATION_COMPLETED hard_ready=%s missing=%s",
             report["hard_ready"], report["missing"],
-            extra={"event": "MDM_BASKET_HYDRATION_COMPLETED", "hard_ready": report["hard_ready"], "missing": list(report["missing"])},
+            extra={"event": "MDM_BASKET_HYDRATION_COMPLETED", "hard_ready": report["hard_ready"], "missing": list(report["missing"]), "min_bars_required": min_bars},
         )
+        self._active_basket_hydration_report = dict(report)
         return report
 
     def request_token_subscription(

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -1706,17 +1706,37 @@ class MarketDataManager:
         count = cls._bars_count(bars)
         return bool(count >= max(1, int(min_bars or 1))), count
 
-    def _reseed_active_basket_symbol_bars(self, symbol: str, min_bars: int) -> None:
+    @staticmethod
+    def _canonical_active_symbol(symbol: Any) -> str:
+        """Canonicalize active-basket symbols for alias-safe selected-symbol matching."""
+        if symbol is None:
+            return ""
+        try:
+            return canonical_symbol(str(symbol))
+        except Exception:
+            return str(symbol or "").strip().upper()
+
+    @staticmethod
+    def _hydration_selected_option_min_bars() -> int:
+        """Return the lightweight hydration minimum separate from strategy/execution gates."""
+        try:
+            return max(1, int(os.getenv("HYDRATION_SELECTED_OPTION_MIN_BARS", "5") or "5"))
+        except (TypeError, ValueError):
+            return 5
+
+    def _reseed_active_basket_symbol_bars(self, symbol: str, min_bars: int) -> dict[str, Any]:
         """Best-effort selected-option history reseed through the existing hydration path."""
+        status: dict[str, Any] = {"attempted": False, "deferred": False, "failed": False, "error": None}
         hydrate_fn = getattr(self, "hydrate_symbol_history", None)
         if not callable(hydrate_fn):
-            return
+            return status
+        status["attempted"] = True
         try:
             result = hydrate_fn(
                 symbol,
                 interval="minute",
                 days=max(1, int(math.ceil(float(min_bars) / 375.0)) + 1),
-                max_bars=max(int(min_bars), self._min_required_bars),
+                max_bars=max(int(min_bars), self._hydration_selected_option_min_bars()),
                 reason="active_basket_selected_option_reseed",
             )
             if inspect.isawaitable(result):
@@ -1726,35 +1746,42 @@ class MarketDataManager:
                     asyncio.run(result)
                 else:
                     loop.create_task(result)
+                    status["deferred"] = True
                     self._logger.info(
                         "MDM_BASKET_HYDRATION_RESEED_DEFERRED symbol=%s reason=running_event_loop",
                         symbol,
                         extra={"event": "MDM_BASKET_HYDRATION_RESEED_DEFERRED", "symbol": symbol},
                     )
         except Exception as exc:  # noqa: BLE001
+            status["failed"] = True
+            status["error"] = f"{type(exc).__name__}:{exc}"
             self._logger.warning(
                 "MDM_BASKET_HYDRATION_RESEED_FAILED symbol=%s error=%s",
                 symbol,
                 exc,
                 extra={"event": "MDM_BASKET_HYDRATION_RESEED_FAILED", "symbol": symbol, "error": str(exc)},
             )
+        return status
 
     def hydrate_active_contract_basket(self, basket: ActiveContractBasket | Mapping[str, Any] | None = None) -> dict[str, Any]:
         """Hydrate cached quote/OHLC readiness for every active basket symbol."""
         active = basket or self._active_contract_basket
-        min_bars = max(1, int(getattr(self, "_min_required_bars", 1) or 1))
+        hydration_min_bars = self._hydration_selected_option_min_bars()
         if active is None:
-            report = {"hard_ready": False, "min_bars_required": min_bars, "symbols": {}, "missing": ["active_contract_basket_missing"]}
+            report = {"hard_ready": False, "min_bars_required": hydration_min_bars, "hydration_min_bars_required": hydration_min_bars, "symbols": {}, "missing": ["active_contract_basket_missing"]}
             self._active_basket_hydration_report = report
             return report
-        self._logger.info("MDM_BASKET_HYDRATION_STARTED", extra={"event": "MDM_BASKET_HYDRATION_STARTED", "min_bars_required": min_bars})
+        self._logger.info("MDM_BASKET_HYDRATION_STARTED", extra={"event": "MDM_BASKET_HYDRATION_STARTED", "hydration_min_bars_required": hydration_min_bars})
         all_symbols = tuple(str(s) for s in (self._basket_get(active, "all_symbols", None) or self._basket_get(active, "symbols", ()) or ()) if s)
         token_by_symbol = dict(self._basket_get(active, "token_by_symbol", {}) or {})
-        selected = {str(s) for s in (self._basket_get(active, "selected_ce", None), self._basket_get(active, "selected_pe", None)) if s}
+        token_by_canonical = {self._canonical_active_symbol(sym): tok for sym, tok in token_by_symbol.items()}
+        selected_canonical = {self._canonical_active_symbol(s) for s in (self._basket_get(active, "selected_ce", None), self._basket_get(active, "selected_pe", None)) if s}
         future_symbol = self._basket_get(active, "futures_symbol", None)
-        report: dict[str, Any] = {"hard_ready": True, "min_bars_required": min_bars, "symbols": {}, "missing": []}
+        report: dict[str, Any] = {"hard_ready": True, "min_bars_required": hydration_min_bars, "hydration_min_bars_required": hydration_min_bars, "symbols": {}, "missing": []}
         for sym in all_symbols:
-            token = token_by_symbol.get(sym) or self._token_by_symbol.get(sym)
+            canonical_sym = self._canonical_active_symbol(sym)
+            is_selected = canonical_sym in selected_canonical
+            token = token_by_symbol.get(sym) or token_by_canonical.get(canonical_sym) or self._token_by_symbol.get(sym) or self._token_by_symbol.get(canonical_sym)
             if sym in self._active_contract_roles:
                 role = self._active_contract_roles[sym]
             elif str(sym).upper().endswith("FUT"):
@@ -1771,7 +1798,7 @@ class MarketDataManager:
             if token is None:
                 last_error = "token_missing"
                 report["missing"].append(f"{sym}:token_missing")
-                if sym in selected or role != "futures_context":
+                if is_selected or role != "futures_context":
                     report["hard_ready"] = False
             else:
                 self.register_symbol(sym, int(token))
@@ -1784,21 +1811,26 @@ class MarketDataManager:
                     quote = None
             try:
                 bars = self.get_ohlc_bars(sym)
-                ohlc_ready, bars_count = self._bars_ready(bars, min_bars)
+                ohlc_ready, bars_count = self._bars_ready(bars, hydration_min_bars)
             except Exception as exc:  # noqa: BLE001
                 bars = []
                 bars_count = 0
                 ohlc_ready = False
                 last_error = f"bars_malformed:{type(exc).__name__}"
-            if sym in selected and not ohlc_ready:
-                self._reseed_active_basket_symbol_bars(sym, min_bars)
+            reseed_status: dict[str, Any] = {"attempted": False, "deferred": False, "failed": False, "error": None}
+            if is_selected and not ohlc_ready:
+                reseed_status = self._reseed_active_basket_symbol_bars(sym, hydration_min_bars)
                 try:
                     bars = self.get_ohlc_bars(sym)
-                    ohlc_ready, bars_count = self._bars_ready(bars, min_bars)
+                    ohlc_ready, bars_count = self._bars_ready(bars, hydration_min_bars)
                 except Exception as exc:  # noqa: BLE001
                     bars_count = 0
                     ohlc_ready = False
                     last_error = f"bars_malformed_after_reseed:{type(exc).__name__}"
+                if not ohlc_ready and reseed_status.get("deferred"):
+                    last_error = "reseed_deferred"
+                elif reseed_status.get("failed"):
+                    last_error = str(reseed_status.get("error") or "reseed_failed")
             if role in {"spot_context", "futures_context"}:
                 ohlc_ready = True
             quote_ready = bool(quote)
@@ -1809,17 +1841,18 @@ class MarketDataManager:
             oi_val = quote.get("oi", quote.get("open_interest")) if isinstance(quote, Mapping) else None
             ltp_only = quote_ready and not depth_ready
             source = str(quote.get("source") or quote.get("quote_source") or "cache") if isinstance(quote, Mapping) else "missing"
-            symbol_hard_ready = not (sym in selected and (not quote_ready or not ohlc_ready))
-            if sym in selected and not quote_ready:
+            symbol_hard_ready = not (is_selected and (not quote_ready or not ohlc_ready))
+            if is_selected and not quote_ready:
                 report["hard_ready"] = False
                 report["missing"].append(f"{sym}:quote_missing")
-            if sym in selected and not ohlc_ready:
+            if is_selected and not ohlc_ready:
                 report["hard_ready"] = False
                 report["missing"].append(f"{sym}:ohlc_insufficient")
             symbol_report = {
                 "token": int(token) if token is not None else None,
                 "role": role,
-                "min_bars_required": min_bars,
+                "min_bars_required": hydration_min_bars,
+                "hydration_min_bars_required": hydration_min_bars,
                 "bars_count": int(bars_count),
                 "quote_ready": quote_ready,
                 "ohlc_ready": bool(ohlc_ready),
@@ -1827,6 +1860,7 @@ class MarketDataManager:
                 "oi_ready": (oi_val is not None) if role == "tradable_option" else None,
                 "ltp_only": bool(ltp_only),
                 "hard_ready": bool(symbol_hard_ready),
+                "reseed_deferred": bool(reseed_status.get("deferred")),
                 "last_error": last_error,
                 "source": source,
             }
@@ -1840,7 +1874,7 @@ class MarketDataManager:
         self._logger.info(
             "MDM_BASKET_HYDRATION_COMPLETED hard_ready=%s missing=%s",
             report["hard_ready"], report["missing"],
-            extra={"event": "MDM_BASKET_HYDRATION_COMPLETED", "hard_ready": report["hard_ready"], "missing": list(report["missing"]), "min_bars_required": min_bars},
+            extra={"event": "MDM_BASKET_HYDRATION_COMPLETED", "hard_ready": report["hard_ready"], "missing": list(report["missing"]), "hydration_min_bars_required": hydration_min_bars},
         )
         self._active_basket_hydration_report = dict(report)
         return report

--- a/src/nifty_scalper_bot/options/strike_selector.py
+++ b/src/nifty_scalper_bot/options/strike_selector.py
@@ -395,6 +395,18 @@ class StrikeSelector:
         token_by_symbol = dict(self._basket_get(basket, "token_by_symbol", {}) or {})
         if token is None:
             token = token_by_symbol.get(symbol)
+        try:
+            token_int = int(token)
+        except (TypeError, ValueError):
+            token_int = 0
+        if token_int <= 0:
+            LOGGER.warning(
+                "STRIKE_SELECTOR_TOKEN_MISSING symbol=%s option_type=%s",
+                symbol,
+                option_type,
+                extra={"event": "STRIKE_SELECTOR_TOKEN_MISSING", "symbol": symbol, "option_type": option_type},
+            )
+            return None
         quote = None
         get_quote = getattr(self._data_hub, "get_quote", None)
         if callable(get_quote):
@@ -413,6 +425,14 @@ class StrikeSelector:
                     break
             if ltp <= 0:
                 ltp = float(_mid_price(_coerce_float(quote.get("bid")), _coerce_float(quote.get("ask"))) or 0.0)
+        if ltp <= 0:
+            LOGGER.warning(
+                "STRIKE_SELECTOR_QUOTE_MISSING symbol=%s option_type=%s",
+                symbol,
+                option_type,
+                extra={"event": "STRIKE_SELECTOR_QUOTE_MISSING", "symbol": symbol, "option_type": option_type},
+            )
+            return None
         expiry_raw = self._basket_get(basket, "option_expiry", None)
         expiry = _parse_expiry(expiry_raw) or datetime.now(timezone.utc)
         strike = float(self._basket_get(basket, "atm_strike", 0) or 0) or self._symbol_strike(symbol)
@@ -424,7 +444,7 @@ class StrikeSelector:
             ltp=float(ltp),
             delta=None,
             metadata={
-                "instrument_token": token,
+                "instrument_token": token_int,
                 "source": "active_contract_basket",
                 "underlying_price": float(underlying_price),
             },

--- a/tests/core/test_basket_commit_before_readiness.py
+++ b/tests/core/test_basket_commit_before_readiness.py
@@ -186,3 +186,36 @@ async def test_hydration_ready_allows_strategy_evaluation(monkeypatch):
     await app._recompute_and_push_runtime_readiness(ctx, reason='test')
     assert ctx.evaluation_ready is True
     assert calls[-1]['evaluation_ready'] is True
+
+
+@pytest.mark.asyncio
+async def test_missing_hydration_method_blocks_live_readiness(monkeypatch, caplog):
+    monkeypatch.delenv("ALLOW_MISSING_HYDRATION_GATE", raising=False)
+    monkeypatch.setattr(app, 'get_market_state', lambda: app.MarketState.CLOSED)
+    calls = []
+    ctx = SimpleNamespace(
+        active_trading_universe={
+            'selected_ce': 'NFO:NIFTY26MAY23700CE',
+            'selected_pe': 'NFO:NIFTY26MAY23700PE',
+            'atm_strike': 23700,
+            'option_symbols': ['NFO:NIFTY26MAY23700CE', 'NFO:NIFTY26MAY23700PE'],
+            'symbols': ['NSE:NIFTY', 'NFO:NIFTY26MAY23700CE', 'NFO:NIFTY26MAY23700PE'],
+        },
+        market_data_manager=_MDM(),
+        settings=SimpleNamespace(execution_mode='LIVE'),
+        strategy_runner=SimpleNamespace(
+            _indicator_engine=SimpleNamespace(get_history=lambda s: [1] * 30),
+            set_runtime_readiness=lambda **kwargs: calls.append(kwargs),
+            is_running=True,
+        ),
+        order_manager=object(),
+        broker_client=object(),
+        selected_ce=None,
+        selected_pe=None,
+    )
+    await app._recompute_and_push_runtime_readiness(ctx, reason='test')
+    assert ctx.evaluation_ready is False
+    assert ctx.active_basket_hydration["hard_ready"] is False
+    assert ctx.active_basket_hydration["missing"] == ["hydrate_active_contract_basket_missing"]
+    assert "ACTIVE_BASKET_HYDRATION_METHOD_MISSING" in caplog.text
+    assert calls[-1]['evaluation_ready'] is False

--- a/tests/core/test_basket_commit_before_readiness.py
+++ b/tests/core/test_basket_commit_before_readiness.py
@@ -113,3 +113,76 @@ async def test_startup_does_not_generate_calendar_future(monkeypatch):
 
     assert out.get('futures_symbol') == 'NFO:NIFTY26JUNFUT'
     assert 'NFO:NIFTY26MAYFUT' not in (out.get('symbols') or [])
+
+
+@pytest.mark.asyncio
+async def test_hydration_not_ready_blocks_strategy_evaluation(monkeypatch):
+    monkeypatch.setattr(app, 'get_market_state', lambda: app.MarketState.CLOSED)
+
+    class MDM(_MDM):
+        def hydrate_active_contract_basket(self, basket=None):
+            return {
+                "hard_ready": False,
+                "missing": ["NFO:NIFTY26MAY23700CE:ohlc_insufficient"],
+                "symbols": {},
+            }
+
+    calls = []
+    ctx = SimpleNamespace(
+        active_trading_universe={
+            'selected_ce': 'NFO:NIFTY26MAY23700CE',
+            'selected_pe': 'NFO:NIFTY26MAY23700PE',
+            'atm_strike': 23700,
+            'option_symbols': ['NFO:NIFTY26MAY23700CE', 'NFO:NIFTY26MAY23700PE'],
+            'symbols': ['NSE:NIFTY', 'NFO:NIFTY26MAY23700CE', 'NFO:NIFTY26MAY23700PE'],
+        },
+        market_data_manager=MDM(),
+        settings=SimpleNamespace(execution_mode='LIVE'),
+        strategy_runner=SimpleNamespace(
+            _indicator_engine=SimpleNamespace(get_history=lambda s: [1] * 30),
+            set_runtime_readiness=lambda **kwargs: calls.append(kwargs),
+            is_running=True,
+        ),
+        order_manager=object(),
+        broker_client=object(),
+        selected_ce=None,
+        selected_pe=None,
+    )
+    await app._recompute_and_push_runtime_readiness(ctx, reason='test')
+    assert ctx.evaluation_ready is False
+    assert str(ctx.live_block_reason).startswith('ACTIVE_BASKET_HYDRATION_NOT_READY')
+    assert calls[-1]['evaluation_ready'] is False
+
+
+@pytest.mark.asyncio
+async def test_hydration_ready_allows_strategy_evaluation(monkeypatch):
+    monkeypatch.setattr(app, 'get_market_state', lambda: app.MarketState.CLOSED)
+
+    class MDM(_MDM):
+        def hydrate_active_contract_basket(self, basket=None):
+            return {"hard_ready": True, "missing": [], "symbols": {}}
+
+    calls = []
+    ctx = SimpleNamespace(
+        active_trading_universe={
+            'selected_ce': 'NFO:NIFTY26MAY23700CE',
+            'selected_pe': 'NFO:NIFTY26MAY23700PE',
+            'atm_strike': 23700,
+            'option_symbols': ['NFO:NIFTY26MAY23700CE', 'NFO:NIFTY26MAY23700PE'],
+            'symbols': ['NSE:NIFTY', 'NFO:NIFTY26MAY23700CE', 'NFO:NIFTY26MAY23700PE'],
+        },
+        market_data_manager=MDM(),
+        settings=SimpleNamespace(execution_mode='LIVE'),
+        strategy_runner=SimpleNamespace(
+            _indicator_engine=SimpleNamespace(get_history=lambda s: [1] * 30),
+            set_runtime_readiness=lambda **kwargs: calls.append(kwargs),
+            get_status=lambda: {"running": True},
+        ),
+        order_manager=object(),
+        broker_client=object(),
+        selected_ce=None,
+        selected_pe=None,
+    )
+    await app._recompute_and_push_runtime_readiness(ctx, reason='test')
+    assert ctx.evaluation_ready is True
+    assert calls[-1]['evaluation_ready'] is True

--- a/tests/core/test_instrument_manager_active_contract_basket.py
+++ b/tests/core/test_instrument_manager_active_contract_basket.py
@@ -88,3 +88,18 @@ def test_select_tokens_for_universe_uses_nearest_option_expiry_not_future_expiry
     monthly_option_tokens = {r["instrument_token"] for r in rows if r.get("expiry") == monthly and r.get("instrument_type") in {"CE", "PE"}}
     assert tokens & weekly_tokens
     assert not (tokens & monthly_option_tokens)
+
+
+def test_instrument_manager_uses_ist_exchange_trading_date(monkeypatch):
+    from datetime import datetime
+    from zoneinfo import ZoneInfo
+    from nifty_scalper_bot.core import instrument_manager as im
+
+    class FixedDateTime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            assert tz == ZoneInfo("Asia/Kolkata")
+            return cls(2026, 6, 2, 1, 0, tzinfo=tz)
+
+    monkeypatch.setattr(im, "datetime", FixedDateTime)
+    assert im._exchange_trading_date().isoformat() == "2026-06-02"

--- a/tests/core/test_live_readiness_recompute.py
+++ b/tests/core/test_live_readiness_recompute.py
@@ -59,6 +59,7 @@ async def test_recompute_readiness_arms_with_spot_selected_ce_pe() -> None:
     mdm = SimpleNamespace(
         get_ohlc_bars=lambda s: list(range(40)) if s != 'NSE:NIFTY' else list(range(40)),
         get_symbol_snapshot=lambda s: _Snap() if s in {'NSE:NIFTY', 'NFO:NIFTY24600CE', 'NFO:NIFTY24600PE'} else None,
+        hydrate_active_contract_basket=lambda basket=None: {"hard_ready": True, "missing": [], "symbols": {}},
     )
     ctx = _ctx(mdm)
     ctx.active_trading_universe = {
@@ -75,6 +76,7 @@ async def test_runtime_readiness_arms_with_option_candles() -> None:
     mdm = SimpleNamespace(
         get_ohlc_bars=lambda s: [1, 2, 3] if s.startswith('NFO:') else [1],
         get_symbol_snapshot=lambda s: None,
+        hydrate_active_contract_basket=lambda basket=None: {"hard_ready": True, "missing": [], "symbols": {}},
     )
     ctx = _ctx(mdm)
     ctx.active_trading_universe = {
@@ -117,6 +119,7 @@ async def test_dynamic_basket_commit_sets_selected_symbols_and_readiness() -> No
     mdm = SimpleNamespace(
         get_ohlc_bars=lambda s: list(range(60)),
         get_symbol_snapshot=lambda s: _Snap(),
+        hydrate_active_contract_basket=lambda basket=None: {"hard_ready": True, "missing": [], "symbols": {}},
     )
     ctx = _ctx(mdm)
     ctx.active_trading_universe = {'spot_symbol': 'NSE:NIFTY', 'atm_strike': 24600}

--- a/tests/core/test_readiness_live_tick_proof.py
+++ b/tests/core/test_readiness_live_tick_proof.py
@@ -29,6 +29,8 @@ class Runner:
 
 
 def make_ctx(mdm, live: bool = True):
+    if not hasattr(mdm, "hydrate_active_contract_basket"):
+        mdm.hydrate_active_contract_basket = lambda basket=None: {"hard_ready": True, "missing": [], "symbols": {}}
     return SimpleNamespace(
         settings=SimpleNamespace(execution_mode='LIVE' if live else 'PAPER'),
         market_data_manager=mdm,

--- a/tests/data/test_datahub_missing_throttle.py
+++ b/tests/data/test_datahub_missing_throttle.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import logging
+
+from nifty_scalper_bot.data.data_hub import DataHub
+
+
+class MDM:
+    def get_active_contract_basket(self):
+        return {"selected_ce": "NFO:ABC25000CE", "selected_pe": "NFO:ABC25000PE"}
+
+
+def test_datahub_missing_quote_logs_are_throttled(caplog):
+    hub = DataHub(MDM())
+    hub._missing_data_log_cooldown_sec = 30.0
+    caplog.set_level(logging.WARNING)
+    assert hub.get_quote("NFO:ABC25000CE", allow_pull=False) is None
+    assert hub.get_quote("NFO:ABC25000CE", allow_pull=False) is None
+    assert caplog.text.count("DATAHUB_QUOTE_MISSING") == 1

--- a/tests/data/test_mdm_subscribes_active_basket.py
+++ b/tests/data/test_mdm_subscribes_active_basket.py
@@ -69,3 +69,51 @@ def test_mdm_hydration_never_classifies_fut_as_tradable_option(caplog):
     assert report["symbols"]["NFO:NIFTY26JUNFUT"]["ohlc_ready"] is True
     assert "NFO:NIFTY26JUNFUT:quote_missing" not in report["missing"]
     assert "MDM_BASKET_ROLE_INCONSISTENCY" in caplog.text
+
+
+def test_mdm_hydrate_counts_list_and_dataframe_bars(monkeypatch):
+    import pandas as pd
+
+    mdm = MarketDataManager(websocket=WS())
+    b = basket()
+    mdm._min_required_bars = 2
+    mdm.set_active_contract_basket(b)
+    quotes = {sym: {"ltp": 100.0, "bid": 99.0, "ask": 101.0, "source": "test"} for sym in b.all_symbols}
+    monkeypatch.setattr(mdm, "get_latest_tick", lambda sym: quotes.get(sym))
+    monkeypatch.setattr(mdm, "get_quote", lambda sym: quotes.get(sym))
+
+    def bars(sym):
+        if sym == b.selected_ce:
+            return [{"close": 1}, {"close": 2}]
+        if sym == b.selected_pe:
+            return pd.DataFrame([{"close": 1}, {"close": 2}])
+        return []
+
+    monkeypatch.setattr(mdm, "get_ohlc_bars", bars)
+    report = mdm.hydrate_active_contract_basket(b)
+    assert report["hard_ready"] is True
+    assert report["symbols"][b.selected_ce]["bars_count"] == 2
+    assert report["symbols"][b.selected_pe]["bars_count"] == 2
+
+
+def test_mdm_selected_missing_ohlc_triggers_reseed_attempt(monkeypatch):
+    mdm = MarketDataManager(websocket=WS())
+    b = basket()
+    mdm._min_required_bars = 3
+    mdm.set_active_contract_basket(b)
+    quotes = {sym: {"ltp": 100.0, "bid": 99.0, "ask": 101.0, "source": "test"} for sym in b.all_symbols}
+    monkeypatch.setattr(mdm, "get_latest_tick", lambda sym: quotes.get(sym))
+    monkeypatch.setattr(mdm, "get_quote", lambda sym: quotes.get(sym))
+    attempts = []
+
+    def hydrate_symbol_history(symbol, **kwargs):
+        attempts.append((symbol, kwargs))
+        return []
+
+    monkeypatch.setattr(mdm, "hydrate_symbol_history", hydrate_symbol_history)
+    monkeypatch.setattr(mdm, "get_ohlc_bars", lambda sym: [])
+    report = mdm.hydrate_active_contract_basket(b)
+    assert b.selected_ce in [item[0] for item in attempts]
+    assert b.selected_pe in [item[0] for item in attempts]
+    assert report["hard_ready"] is False
+    assert f"{b.selected_ce}:ohlc_insufficient" in report["missing"]

--- a/tests/data/test_mdm_subscribes_active_basket.py
+++ b/tests/data/test_mdm_subscribes_active_basket.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from datetime import date
 
+import pytest
+
 from nifty_scalper_bot.core.instrument_manager import ActiveContractBasket
 from nifty_scalper_bot.data.market_data_manager import MarketDataManager
 
@@ -76,7 +78,8 @@ def test_mdm_hydrate_counts_list_and_dataframe_bars(monkeypatch):
 
     mdm = MarketDataManager(websocket=WS())
     b = basket()
-    mdm._min_required_bars = 2
+    monkeypatch.setenv("HYDRATION_SELECTED_OPTION_MIN_BARS", "2")
+    mdm._min_required_bars = 20
     mdm.set_active_contract_basket(b)
     quotes = {sym: {"ltp": 100.0, "bid": 99.0, "ask": 101.0, "source": "test"} for sym in b.all_symbols}
     monkeypatch.setattr(mdm, "get_latest_tick", lambda sym: quotes.get(sym))
@@ -99,7 +102,8 @@ def test_mdm_hydrate_counts_list_and_dataframe_bars(monkeypatch):
 def test_mdm_selected_missing_ohlc_triggers_reseed_attempt(monkeypatch):
     mdm = MarketDataManager(websocket=WS())
     b = basket()
-    mdm._min_required_bars = 3
+    monkeypatch.setenv("HYDRATION_SELECTED_OPTION_MIN_BARS", "3")
+    mdm._min_required_bars = 20
     mdm.set_active_contract_basket(b)
     quotes = {sym: {"ltp": 100.0, "bid": 99.0, "ask": 101.0, "source": "test"} for sym in b.all_symbols}
     monkeypatch.setattr(mdm, "get_latest_tick", lambda sym: quotes.get(sym))
@@ -117,3 +121,62 @@ def test_mdm_selected_missing_ohlc_triggers_reseed_attempt(monkeypatch):
     assert b.selected_pe in [item[0] for item in attempts]
     assert report["hard_ready"] is False
     assert f"{b.selected_ce}:ohlc_insufficient" in report["missing"]
+
+
+def test_mdm_selected_matching_uses_canonical_symbol_alias(monkeypatch):
+    mdm = MarketDataManager(websocket=WS())
+    payload = {
+        "spot_symbol": "NSE:NIFTY",
+        "spot_token": 256265,
+        "selected_ce": "NFO:NIFTY26JUN25000CE",
+        "selected_pe": "NFO:NIFTY26JUN25000PE",
+        "option_symbols": ["NIFTY26JUN25000CE", "NIFTY26JUN25000PE"],
+        "all_symbols": ["NSE:NIFTY", "NIFTY26JUN25000CE", "NIFTY26JUN25000PE"],
+        "token_by_symbol": {"NSE:NIFTY": 256265, "NIFTY26JUN25000PE": 12},
+        "atm_strike": 25000,
+    }
+    monkeypatch.setenv("HYDRATION_SELECTED_OPTION_MIN_BARS", "2")
+    mdm.set_active_contract_basket(payload)
+    monkeypatch.setattr(mdm, "get_latest_tick", lambda sym: {"ltp": 100.0, "bid": 99.0, "ask": 101.0} if sym.endswith("PE") else None)
+    monkeypatch.setattr(mdm, "get_quote", lambda sym: {"ltp": 100.0, "bid": 99.0, "ask": 101.0} if sym.endswith("PE") else None)
+    monkeypatch.setattr(mdm, "get_ohlc_bars", lambda sym: [{"close": 1}, {"close": 2}])
+    report = mdm.hydrate_active_contract_basket(payload)
+    assert report["hard_ready"] is False
+    assert "NIFTY26JUN25000CE:token_missing" in report["missing"]
+
+
+@pytest.mark.asyncio
+async def test_async_reseed_deferred_is_reported_not_silent(monkeypatch):
+    mdm = MarketDataManager(websocket=WS())
+    b = basket()
+    monkeypatch.setenv("HYDRATION_SELECTED_OPTION_MIN_BARS", "3")
+    mdm.set_active_contract_basket(b)
+    quotes = {sym: {"ltp": 100.0, "bid": 99.0, "ask": 101.0, "source": "test"} for sym in b.all_symbols}
+    monkeypatch.setattr(mdm, "get_latest_tick", lambda sym: quotes.get(sym))
+    monkeypatch.setattr(mdm, "get_quote", lambda sym: quotes.get(sym))
+    monkeypatch.setattr(mdm, "get_ohlc_bars", lambda sym: [])
+
+    async def hydrate_symbol_history(symbol, **kwargs):
+        return []
+
+    monkeypatch.setattr(mdm, "hydrate_symbol_history", hydrate_symbol_history)
+    report = mdm.hydrate_active_contract_basket(b)
+    assert report["symbols"][b.selected_ce]["reseed_deferred"] is True
+    assert report["symbols"][b.selected_ce]["last_error"] == "reseed_deferred"
+    assert report["hard_ready"] is False
+
+
+def test_hydration_uses_hydration_min_bars_not_execution_min_bars(monkeypatch):
+    mdm = MarketDataManager(websocket=WS())
+    b = basket()
+    mdm._min_required_bars = 30
+    monkeypatch.setenv("HYDRATION_SELECTED_OPTION_MIN_BARS", "5")
+    mdm.set_active_contract_basket(b)
+    quotes = {sym: {"ltp": 100.0, "bid": 99.0, "ask": 101.0, "source": "test"} for sym in b.all_symbols}
+    monkeypatch.setattr(mdm, "get_latest_tick", lambda sym: quotes.get(sym))
+    monkeypatch.setattr(mdm, "get_quote", lambda sym: quotes.get(sym))
+    monkeypatch.setattr(mdm, "get_ohlc_bars", lambda sym: [{"close": i} for i in range(5)] if sym in {b.selected_ce, b.selected_pe} else [])
+    report = mdm.hydrate_active_contract_basket(b)
+    assert report["hydration_min_bars_required"] == 5
+    assert report["symbols"][b.selected_ce]["bars_count"] == 5
+    assert report["hard_ready"] is True

--- a/tests/options/test_strike_selector_ssot.py
+++ b/tests/options/test_strike_selector_ssot.py
@@ -110,3 +110,29 @@ def test_non_live_strike_selector_prefers_active_basket_without_option_chain_env
     assert selected.symbol == "NFO:NIFTY26JUN25000CE"
     assert selected.metadata["source"] == "active_contract_basket"
     assert hub.option_chain_called is False
+
+
+def test_live_strike_selector_active_basket_token_missing_returns_none(monkeypatch, caplog):
+    monkeypatch.setenv("EXECUTION_MODE", "LIVE")
+    b = _basket()
+    b.pop("selected_ce_token")
+    b["token_by_symbol"].pop("NFO:NIFTY26JUN25000CE")
+    selected = _selector(Hub(b)).select_contract(
+        underlying="NIFTY", side="BUY", option_type="CE", underlying_price=25001.0
+    )
+    assert selected is None
+    assert "STRIKE_SELECTOR_TOKEN_MISSING" in caplog.text
+
+
+def test_live_strike_selector_active_basket_quote_missing_returns_none(monkeypatch, caplog):
+    monkeypatch.setenv("EXECUTION_MODE", "LIVE")
+
+    class NoQuoteHub(Hub):
+        def get_quote(self, symbol: str, allow_pull: bool = False):
+            return {"ltp": 0.0, "bid": 0.0, "ask": 0.0}
+
+    selected = _selector(NoQuoteHub(_basket())).select_contract(
+        underlying="NIFTY", side="BUY", option_type="CE", underlying_price=25001.0
+    )
+    assert selected is None
+    assert "STRIKE_SELECTOR_QUOTE_MISSING" in caplog.text


### PR DESCRIPTION
### Motivation

- The active ActiveContractBasket was being committed to MDM/DataHub without enforcing a clear MDM hydration gate, causing strategies to evaluate against incomplete option data.
- MDM used ambiguous truthiness for OHLC (e.g., `bool(bars)`), did not reseed missing selected-option history, and reported terse/misleading hydration state.
- Strike selection could yield SelectedContract objects with missing tokens or zero LTP, and DataHub emitted repeated missing-data warnings that spam logs.

### Description

- Added robust MDM bar helpers and reseed: `MarketDataManager._bars_count` and `_bars_ready` to handle lists/deques/tuples and `pandas.DataFrame`, plus `_reseed_active_basket_symbol_bars` which invokes the existing `hydrate_symbol_history` path when selected CE/PE OHLC are insufficient.
- Expanded MDM hydration report to include `min_bars_required`, `bars_count`, `quote_ready`, `ohlc_ready`, `depth_ready`, `oi_ready`, `ltp_only`, `hard_ready`, and `last_error`, and cache the latest report via `get_hydration_report`.
- App-level gating: after committing the ActiveContractBasket the app now calls `MarketDataManager.hydrate_active_contract_basket()`, stores the report on `ctx.active_basket_hydration`, retries once after selected-option reseed, and blocks strategy evaluation with `ACTIVE_BASKET_HYDRATION_NOT_READY` (including exact missing symbol reasons) when `hard_ready` is false.
- Throttled DataHub missing-data logs and added `get_hydration_report()` facade: DataHub now rate-limits `DATAHUB_ACTIVE_BASKET_UNAVAILABLE`, `DATAHUB_QUOTE_MISSING`, and `DATAHUB_OHLC_MISSING` warnings and can return the latest MDM hydration snapshot without selecting contracts.
- Hardened StrikeSelector SSOT reads: `_contract_from_active_basket` now returns `None` and logs `STRIKE_SELECTOR_TOKEN_MISSING` when the token is missing/invalid and logs `STRIKE_SELECTOR_QUOTE_MISSING` and returns `None` when LTP ≤ 0, preserving active-basket primary behavior.
- InstrumentManager timezone fix: replaced `date.today()` uses with an IST trading-date helper ` _exchange_trading_date()` (uses `ZoneInfo('Asia/Kolkata')`) with a TODO note for holiday calendar handling.
- Tests: added and updated focused unit tests for bar-counting (list/DataFrame), reseed invocation on missing OHLC, hydration gating blocking/allowing evaluation, StrikeSelector token/quote failure cases, DataHub missing-data log throttling, and InstrumentManager IST date helper.

### Testing

- Commands run: `python -m compileall -q src` and the full test matrix including `pytest -q tests/data`, `pytest -q tests/core/test_basket_commit_before_readiness.py`, `pytest -q tests/test_live_basket_hydration.py`, `pytest -q tests/test_live_tick_pipeline_to_runner.py`, `pytest -q tests/options/test_strike_selector_ssot.py`, `pytest -q tests/strategies/test_runner_live_path_guards.py`, and `pytest -q`.
- Results: `compileall` succeeded and the focused and full pytest runs completed with all tests passing (no failures recorded).
- Focused validations exercised: MDM hydration list/DataFrame bar handling, selected-option reseed attempt path, app readiness blocking when hydration `hard_ready` is false, StrikeSelector returning `None` for missing token/LTP, DataHub log throttling, and InstrumentManager IST date behavior (all passed).
- Notes: no strategy scoring, execution, or order placement logic was modified and readiness gating is now explicit and logged with actionable missing-symbol reasons.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d01ee32ec832494ccafa50f6bb609)