### PR TITLE
Avoid reserved LogRecord keys in structured logging (fix startup crash)

### DIFF
--- a/src/nifty_scalper_bot/config/settings.py
+++ b/src/nifty_scalper_bot/config/settings.py
@@ -421,7 +421,7 @@ def _env_csv(*names: str) -> list[str]:
                 os.environ.pop(sentinel, None)
             LOGGER.debug(
                 "Condition met: settings_env_csv_resolved",
-                extra={"event": "settings_env_csv_resolved", "name": name},
+                extra={"event": "settings_env_csv_resolved", "env_name": name},
             )
             return values
         LOGGER.debug(

--- a/src/nifty_scalper_bot/core/strategy_manager.py
+++ b/src/nifty_scalper_bot/core/strategy_manager.py
@@ -783,7 +783,7 @@ def instantiate_strategy(name: str, **kwargs: t.Any) -> StrategyInterface:
         "Entered instantiate_strategy",
         extra={
             "event": "instantiate_strategy",
-            "name": name,
+            "strategy_name": name,
             "kwargs": list(kwargs.keys()),
         },
     )
@@ -1280,15 +1280,15 @@ class StrategyManager(_BaseStrategyManager):
 
         log.debug("Entered StrategyManager.__init__")
         log.info(
-            "RUNTIME_STRATEGY_MANAGER_CLASS module=%s class=%s id=%s",
+            "RUNTIME_STRATEGY_MANAGER_CLASS strategy_manager_module=%s strategy_manager_class=%s strategy_manager_id=%s",
             self.__class__.__module__,
             self.__class__.__name__,
             id(self),
             extra={
                 "event": "RUNTIME_STRATEGY_MANAGER_CLASS",
-                "module": self.__class__.__module__,
-                "class": self.__class__.__name__,
-                "id": id(self),
+                "strategy_manager_module": self.__class__.__module__,
+                "strategy_manager_class": self.__class__.__name__,
+                "strategy_manager_id": id(self),
             },
         )
         super().__init__(

--- a/src/nifty_scalper_bot/execution/readiness.py
+++ b/src/nifty_scalper_bot/execution/readiness.py
@@ -25,7 +25,7 @@ def _env_int(name: str, default: int, minimum: int = 1) -> int:
             name,
             raw,
             default,
-            extra={"event": "INVALID_HISTORY_POLICY_ENV", "name": name, "value": raw, "default": default},
+            extra={"event": "INVALID_HISTORY_POLICY_ENV", "env_name": name, "value": raw, "default": default},
         )
         return max(default, minimum)
 

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -153,7 +153,7 @@ def _env_flag(name: str, default: bool = False) -> bool:
         default,
         extra={
             "event": "INVALID_ENV_BOOL",
-            "name": name,
+            "env_name": name,
             "value": raw,
             "default": bool(default),
         },

--- a/src/nifty_scalper_bot/strategies/signal.py
+++ b/src/nifty_scalper_bot/strategies/signal.py
@@ -161,7 +161,7 @@ def build_default_strategy_manager(
                 module,
                 exc,
                 exc_info=exc,
-                extra={"event": "elite_strategy_load_error", "module": module},
+                extra={"event": "elite_strategy_load_error", "strategy_module": module},
             )
             continue
         strategies.append(strategy_instance)

--- a/tests/core/test_smc_enrichment.py
+++ b/tests/core/test_smc_enrichment.py
@@ -140,9 +140,21 @@ def test_runtime_strategy_manager_class_is_core_manager_or_enrichment_hook_execu
         manager = StrategyManager([st], _IE(), _PM())
         manager.generate_signal(symbol, 101)
 
+    runtime_records = [
+        record
+        for record in caplog.records
+        if getattr(record, "event", None) == "RUNTIME_STRATEGY_MANAGER_CLASS"
+    ]
+
     assert manager.__class__.__module__ == "nifty_scalper_bot.core.strategy_manager"
     assert st.last["smc_enrichment_source"] == "strategy_manager_pre_strategy"
     assert "RUNTIME_STRATEGY_MANAGER_CLASS" in caplog.text
+    assert "Attempt to overwrite 'module' in LogRecord" not in caplog.text
+    assert "degraded" not in caplog.text.lower()
+    assert runtime_records
+    assert runtime_records[0].strategy_manager_module == "nifty_scalper_bot.core.strategy_manager"
+    assert runtime_records[0].strategy_manager_class == "StrategyManager"
+    assert isinstance(runtime_records[0].strategy_manager_id, int)
 
 
 def test_history_provider_exception_does_not_crash_generate_signal(caplog):

--- a/tests/test_logging_extra_reserved_keys.py
+++ b/tests/test_logging_extra_reserved_keys.py
@@ -1,0 +1,65 @@
+"""Guardrails for logging ``extra`` keys.
+
+Python logging rejects ``extra`` dictionaries that overwrite built-in
+``LogRecord`` attributes.  This test catches obvious literal keys so startup
+paths cannot regress with failures like ``Attempt to overwrite 'module'``.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+RESERVED_LOG_RECORD_KEYS = {
+    "name",
+    "msg",
+    "args",
+    "levelname",
+    "levelno",
+    "pathname",
+    "filename",
+    "module",
+    "exc_info",
+    "exc_text",
+    "stack_info",
+    "lineno",
+    "funcName",
+    "created",
+    "msecs",
+    "relativeCreated",
+    "thread",
+    "threadName",
+    "processName",
+    "process",
+    "message",
+    "asctime",
+}
+
+
+def _literal_extra_reserved_keys(path: Path) -> list[tuple[int, str]]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    findings: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        for keyword in node.keywords:
+            if keyword.arg != "extra" or not isinstance(keyword.value, ast.Dict):
+                continue
+            for key in keyword.value.keys:
+                if (
+                    isinstance(key, ast.Constant)
+                    and isinstance(key.value, str)
+                    and key.value in RESERVED_LOG_RECORD_KEYS
+                ):
+                    findings.append((getattr(key, "lineno", node.lineno), key.value))
+    return findings
+
+
+def test_logging_extra_does_not_use_reserved_logrecord_keys() -> None:
+    failures: list[str] = []
+    for path in sorted(Path("src").rglob("*.py")):
+        for lineno, key in _literal_extra_reserved_keys(path):
+            failures.append(f"{path}:{lineno} uses reserved logging extra key {key!r}")
+
+    assert not failures, "\n".join(failures)


### PR DESCRIPTION
### Motivation

- Startup crashed with `Attempt to overwrite 'module' in LogRecord` because `StrategyManager.__init__` logged `extra={"module": ..., "class": ..., "id": ...}` and those keys collide with Python `LogRecord` attributes.
- Make a minimal, robust fix to structured logging keys so logging does not raise and startup/health paths remain stable, without touching strategy scoring, contract SSOT, or execution.

### Description

- Replaced unsafe structured fields in `StrategyManager.__init__`: `module` → `strategy_manager_module`, `class` → `strategy_manager_class`, and `id` → `strategy_manager_id` in both the log format string and `extra` dict (`src/nifty_scalper_bot/core/strategy_manager.py`).
- Adjusted a few other literal `extra` usages discovered by the new guard to non-reserved names (`name` → `strategy_name` or `env_name`, `module` → `strategy_module`) to ensure the repository-wide scan is clean (`src/nifty_scalper_bot/strategies/signal.py`, `src/nifty_scalper_bot/config/settings.py`, `src/nifty_scalper_bot/execution/readiness.py`, `src/nifty_scalper_bot/strategies/runner.py`).
- Added an AST-based guard test `tests/test_logging_extra_reserved_keys.py` that scans `src/**/*.py` for literal `extra={...}` dictionaries containing Python `LogRecord` reserved keys and fails if found while allowing `event`.
- Extended the focused startup test in `tests/core/test_smc_enrichment.py` to assert the runtime `RUNTIME_STRATEGY_MANAGER_CLASS` record is emitted, contains the new safe structured fields, and that the reserved-key crash text and degraded-mode text are absent.
- Did not add broad exception handling, did not change strategy scoring, SSOT, or execution logic, and did not add the optional `sanitize_log_extra` helper in this PR to keep the change minimal.

### Testing

- Commands run: `python -m compileall -q src`, `pytest -q tests/core/test_smc_enrichment.py`, `pytest -q tests/test_logging_extra_reserved_keys.py`, `pytest -q tests/strategies/test_runner_live_path_guards.py`, and a full `pytest -q` sweep.
- Results: `python -m compileall -q src` passed; `tests/core/test_smc_enrichment.py` passed; `tests/test_logging_extra_reserved_keys.py` passed; `tests/strategies/test_runner_live_path_guards.py` passed (117 tests); overall `pytest -q` passed in this environment.
- The new guard test found literal reserved keys prior to the fix and now passes with the updated keys, and the startup regression test confirms the `Attempt to overwrite 'module' in LogRecord` failure no longer occurs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d0c05ae2c83249aa8d5271d87e87e)