### PR TITLE
Fix live basket SSOT symbol resolution and prevent OptionUniverseManager runtime crash

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -2941,19 +2941,35 @@ def _option_symbols_from_active_basket(basket: Mapping[str, Any] | Any | None) -
     """Extract authoritative option symbols from an ActiveContractBasket."""
     if basket is None:
         return []
-    if isinstance(basket, Mapping):
-        symbols = basket.get("option_symbols")
-        if not symbols:
-            symbols = [basket.get("selected_ce"), basket.get("selected_pe")]
+
+    def _get(key: str, default: Any = None) -> Any:
+        if isinstance(basket, Mapping):
+            return basket.get(key, default)
+        return getattr(basket, key, default)
+
+    sources: list[Any] = []
+    option_symbols = _get("option_symbols")
+    if option_symbols:
+        sources.append(option_symbols)
     else:
-        symbols = getattr(basket, "option_symbols", None)
-        if not symbols:
-            symbols = [getattr(basket, "selected_ce", None), getattr(basket, "selected_pe", None)]
-    return [
-        str(sym)
-        for sym in dict.fromkeys(symbols or [])
-        if sym and str(sym).upper().endswith(("CE", "PE"))
-    ]
+        ce_symbols = _get("ce_symbols") or []
+        pe_symbols = _get("pe_symbols") or []
+        if ce_symbols or pe_symbols:
+            sources.extend([ce_symbols, pe_symbols])
+        else:
+            sources.append([_get("selected_ce"), _get("selected_pe")])
+
+    symbols: list[str] = []
+    for source in sources:
+        if isinstance(source, (str, bytes)):
+            iterable = [source]
+        else:
+            iterable = list(source or [])
+        for sym in iterable:
+            text = str(sym).strip() if sym is not None else ""
+            if text and text.upper().endswith(("CE", "PE")):
+                symbols.append(text)
+    return list(dict.fromkeys(symbols))
 
 
 def _active_basket_for_symbol_resolution(

--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -2285,6 +2285,8 @@ class BotContext:
     atm_ce_symbol: str | None = None
     atm_pe_symbol: str | None = None
     active_trading_universe: dict[str, Any] = field(default_factory=dict)
+    active_contract_basket: dict[str, object] | None = None
+    active_basket_hydration: dict[str, object] | None = None
     message_bus_tick_subscribed: bool = False
     datahub_runner_subscriptions: set[str] = field(default_factory=set)
     execution_locked_symbols: set[str] = field(default_factory=set)
@@ -2935,16 +2937,90 @@ def _find_existing_nifty_option_symbol(
     return None
 
 
+def _option_symbols_from_active_basket(basket: Mapping[str, Any] | Any | None) -> list[str]:
+    """Extract authoritative option symbols from an ActiveContractBasket."""
+    if basket is None:
+        return []
+    if isinstance(basket, Mapping):
+        symbols = basket.get("option_symbols")
+        if not symbols:
+            symbols = [basket.get("selected_ce"), basket.get("selected_pe")]
+    else:
+        symbols = getattr(basket, "option_symbols", None)
+        if not symbols:
+            symbols = [getattr(basket, "selected_ce", None), getattr(basket, "selected_pe", None)]
+    return [
+        str(sym)
+        for sym in dict.fromkeys(symbols or [])
+        if sym and str(sym).upper().endswith(("CE", "PE"))
+    ]
+
+
+def _active_basket_for_symbol_resolution(
+    explicit_basket: Mapping[str, Any] | Any | None,
+    market_data_manager: MarketDataManager | None,
+) -> Mapping[str, Any] | Any | None:
+    """Find the already-committed ActiveContractBasket without invoking selectors."""
+    if explicit_basket is not None:
+        return explicit_basket
+    ctx = _LATEST_CTX
+    if ctx is not None:
+        basket = getattr(ctx, "active_contract_basket", None) or getattr(ctx, "active_trading_universe", None)
+        if basket:
+            return basket
+        hub = getattr(ctx, "data_hub", None)
+        hub_get = getattr(hub, "get_active_contract_basket", None)
+        if callable(hub_get):
+            basket = hub_get()
+            if basket:
+                return basket
+        mdm = getattr(ctx, "market_data_manager", None)
+        mdm_get = getattr(mdm, "get_active_contract_basket", None)
+        if callable(mdm_get):
+            basket = mdm_get()
+            if basket:
+                return basket
+    mdm_get = getattr(market_data_manager, "get_active_contract_basket", None)
+    if callable(mdm_get):
+        return mdm_get()
+    return None
+
+
 def _get_symbols(
     config: AppConfig,
     resolver: Any | None = None,
     broker: Any | None = None,
     option_universe: OptionUniverseManager | None = None,
     market_data_manager: MarketDataManager | None = None,
+    active_contract_basket: Mapping[str, Any] | Any | None = None,
 ) -> list[str]:
     """Return validated option symbols for trading."""
     LOGGER.info("=" * 60)
     LOGGER.info("🔍 _get_symbols() STARTING - Symbol Resolution")
+
+    basket = _active_basket_for_symbol_resolution(active_contract_basket, market_data_manager)
+    basket_symbols = _option_symbols_from_active_basket(basket)
+    if basket_symbols:
+        if option_universe is not None and hasattr(option_universe, "set_active_contract_basket"):
+            option_universe.set_active_contract_basket(basket)
+        LOGGER.info(
+            "SYMBOL_RESOLUTION_ACTIVE_BASKET_USED count=%d selected_ce=%s selected_pe=%s",
+            len(basket_symbols),
+            getattr(basket, "selected_ce", None) if not isinstance(basket, Mapping) else basket.get("selected_ce"),
+            getattr(basket, "selected_pe", None) if not isinstance(basket, Mapping) else basket.get("selected_pe"),
+            extra={"event": "SYMBOL_RESOLUTION_ACTIVE_BASKET_USED", "count": len(basket_symbols)},
+        )
+        LOGGER.info("🎯 FINAL SYMBOLS TO TRADE: %s", basket_symbols)
+        LOGGER.info("=" * 60)
+        return basket_symbols
+
+    execution_mode = str(os.getenv("EXECUTION_MODE") or os.getenv("MODE") or getattr(config, "execution_mode", "") or "").upper()
+    if execution_mode == "LIVE":
+        LOGGER.warning(
+            "SYMBOL_RESOLUTION_BLOCKED reason=ACTIVE_BASKET_MISSING stage=_get_symbols",
+            extra={"event": "SYMBOL_RESOLUTION_BLOCKED", "reason": "ACTIVE_BASKET_MISSING", "stage": "_get_symbols"},
+        )
+        return []
 
     symbols = getattr(config, "symbols", None)
     if symbols:
@@ -7616,6 +7692,8 @@ def _commit_active_dynamic_basket(
     committed["symbol_by_token"] = symbol_by_token
     ctx.active_trading_universe = committed
     ctx.active_contract_basket = committed
+    if getattr(ctx, "option_universe", None) is not None and hasattr(ctx.option_universe, "set_active_contract_basket"):
+        ctx.option_universe.set_active_contract_basket(committed)
     ctx.active_symbol_tokens = dict(committed.get("token_by_symbol") or getattr(ctx, "active_symbol_tokens", {}) or {})
     mdm_set = getattr(getattr(ctx, "market_data_manager", None), "set_active_contract_basket", None)
     if callable(mdm_set):
@@ -8486,6 +8564,7 @@ async def startup_sequence(ctx: BotContext) -> None:
                 ctx.broker_client,
                 option_universe=ctx.option_universe,
                 market_data_manager=ctx.market_data_manager,
+                active_contract_basket=getattr(ctx, "active_contract_basket", None) or getattr(ctx, "active_trading_universe", None),
             )
 
             active_futures_symbol = _resolve_active_futures_for_basket(ctx, None)
@@ -9751,40 +9830,12 @@ async def startup_sequence(ctx: BotContext) -> None:
                             pending_runner_symbols.clear()
                             pending_runner_symbols.update(still_pending)
 
-                        if not ctx.option_universe:
-                            await asyncio.sleep(30)
-                            continue
-
-                        spot = (
-                            ctx.market_data_manager.get_cached_ltp(
-                                policy.nifty_internal_symbol,
-                                max_age_seconds=policy.startup_spot_max_age_seconds,
-                                require_ws=False,
-                            )
-                            if ctx.market_data_manager
-                            and hasattr(ctx.market_data_manager, "get_cached_ltp")
-                            else None
-                        )
-                        
-                        # --- Objective 7: Auto ATM Resubscription via InstrumentManager ---
-                        _im = ctx.instrument_manager
-                        if spot and spot > 0 and _im and _im.is_loaded():
-                            target_tokens = _im.select_tokens_for_universe(
-                                base="NIFTY",
-                                spot_price=float(spot),
-                                strikes_around_atm=3,
-                                strike_step=ctx.settings.option_universe.strike_step
-                            )
-                            latest_symbols = set()
-                            for t in target_tokens:
-                                s = _im.get_symbol(t)
-                                if s:
-                                    qualified = f"NFO:{s}" if not s.startswith("NFO:") else s
-                                    if qualified.startswith("NFO:NIFTY"):
-                                        latest_symbols.add(qualified)
-                        else:
-                            latest_symbols = set(
-                                ctx.option_universe.get_current_universe()
+                        active_basket = getattr(ctx, "active_contract_basket", None) or getattr(ctx, "active_trading_universe", None)
+                        latest_symbols = set(_option_symbols_from_active_basket(active_basket))
+                        if not latest_symbols:
+                            LOGGER.warning(
+                                "OPTION_UNIVERSE_SYNC_SKIPPED reason=ACTIVE_BASKET_MISSING",
+                                extra={"event": "OPTION_UNIVERSE_SYNC_SKIPPED", "reason": "ACTIVE_BASKET_MISSING"},
                             )
 
                         added, removed = option_universe_controller.update(
@@ -10180,7 +10231,7 @@ async def startup_sequence(ctx: BotContext) -> None:
                 )
                 startup_trade_ready = True
             else:
-                norm_basket = normalize_active_basket_schema(dict(getattr(ctx, "active_trading_universe", {}) or {}))
+                norm_basket = normalize_active_basket_schema(dict((getattr(ctx, "active_contract_basket", None) or getattr(ctx, "active_trading_universe", {}) or {})))
                 LOGGER.exception(
                     "HYDRATION_TRACKING_FAILED error_type=%s error=%s basket_keys=%s selected_ce=%s selected_pe=%s spot_symbol=%s futures_symbol=%s",
                     type(e).__name__,
@@ -10203,17 +10254,19 @@ async def startup_sequence(ctx: BotContext) -> None:
                 )
                 ctx.live_orders_armed = False
                 ctx.trading_ready = False
-                ctx.live_block_reason = f"hydration_tracking_failed:{e}"
-            configured_mode = str(
-                getattr(ctx.settings, "execution_mode", None)
-                or os.getenv("EXECUTION_MODE", "PAPER")
-            ).upper()
-            if (
-                configured_mode == "LIVE"
-                and get_market_state() == MarketState.OPEN
-                and not is_warmup_like
-            ):
-                raise
+                if norm_basket.get("option_symbols") or norm_basket.get("selected_ce") or norm_basket.get("selected_pe"):
+                    ctx.live_block_reason = f"hydration_tracking_degraded:{type(e).__name__}"
+                    LOGGER.warning(
+                        "HYDRATION_TRACKING_DEGRADED_CONTINUE reason=%s active_basket_available=True",
+                        type(e).__name__,
+                        extra={"event": "HYDRATION_TRACKING_DEGRADED_CONTINUE", "reason": type(e).__name__, "active_basket_available": True},
+                    )
+                else:
+                    ctx.live_block_reason = "ACTIVE_BASKET_MISSING"
+                    LOGGER.warning(
+                        "LIVE_READINESS_BLOCKED reason=ACTIVE_BASKET_MISSING stage=hydration_tracking",
+                        extra={"event": "LIVE_READINESS_BLOCKED", "reason": "ACTIVE_BASKET_MISSING", "stage": "hydration_tracking"},
+                    )
 
     # ---------------------------------------------------------
     # 4. Start subsystems (guarded singleton startup)

--- a/src/nifty_scalper_bot/core/option_universe.py
+++ b/src/nifty_scalper_bot/core/option_universe.py
@@ -200,7 +200,7 @@ class OptionUniverseManager:
         """
         basket_symbols = self._basket_option_symbols(self._active_contract_basket)
         if basket_symbols:
-            return basket_symbols[:8]
+            return basket_symbols
         if not self._current_universe:
             return self._runtime_blocked_universe("get_current_universe")
         return list(self._current_universe)[:8]
@@ -217,13 +217,18 @@ class OptionUniverseManager:
         Raises:
             None.
         """
+        basket_symbols = self._basket_option_symbols(self._active_contract_basket)
+        if basket_symbols:
+            # Compatibility scan target cap only applies to primary symbols; full
+            # basket access remains available via get_current_universe().
+            return basket_symbols[:8]
         return self.get_current_universe()
 
     def get_filtered_universe(self, spot_ltp: float) -> list[str]:
         """Return the frozen intraday universe while tracking spot diagnostics."""
         basket_symbols = self._basket_option_symbols(self._active_contract_basket)
         if basket_symbols:
-            return basket_symbols[:8]
+            return basket_symbols
         if self._runtime_mode_is_live():
             return self._runtime_blocked_universe("get_filtered_universe")
         if spot_ltp <= 0:

--- a/src/nifty_scalper_bot/core/option_universe.py
+++ b/src/nifty_scalper_bot/core/option_universe.py
@@ -64,6 +64,8 @@ class OptionUniverseManager:
         self._current_universe: list[str] = []
         self._frozen_universe: set[str] = set()
         self._last_recalc_spot: float | None = None
+        self._active_contract_basket: Any | None = None
+        self._runtime_call_blocked_logged = False
 
     def update_underlying(self, spot_price: float) -> None:
         """Refresh ATM, expiry and universe based on latest underlying spot.
@@ -124,6 +126,66 @@ class OptionUniverseManager:
                 extra={"event": "option_universe_frozen_skip", "atm": new_atm},
             )
 
+    def set_active_contract_basket(self, basket: Any | None) -> None:
+        """Attach the InstrumentManager-selected ActiveContractBasket for runtime callers."""
+        self._active_contract_basket = basket
+
+    @classmethod
+    def from_active_contract_basket(
+        cls,
+        basket: Any,
+        config: OptionUniverseConfig | dict[str, Any] | Any | None = None,
+    ) -> "OptionUniverseManager":
+        """Create a compatibility wrapper backed by an ActiveContractBasket."""
+        manager = cls(config or OptionUniverseConfig())
+        manager.set_active_contract_basket(basket)
+        return manager
+
+    @staticmethod
+    def _basket_option_symbols(basket: Any | None) -> list[str]:
+        if basket is None:
+            return []
+        if isinstance(basket, dict):
+            symbols = basket.get("option_symbols")
+            if not symbols:
+                symbols = [basket.get("selected_ce"), basket.get("selected_pe")]
+        else:
+            symbols = getattr(basket, "option_symbols", None)
+            if not symbols:
+                symbols = [getattr(basket, "selected_ce", None), getattr(basket, "selected_pe", None)]
+        return [str(sym) for sym in dict.fromkeys(symbols or []) if sym]
+
+    @staticmethod
+    def _runtime_mode_is_live() -> bool:
+        return str(os.getenv("EXECUTION_MODE") or os.getenv("MODE") or "").strip().upper() == "LIVE"
+
+    def _runtime_blocked_universe(self, method: str) -> list[str]:
+        if self._runtime_mode_is_live():
+            if not self._runtime_call_blocked_logged:
+                LOGGER.warning(
+                    "OPTION_UNIVERSE_RUNTIME_CALL_BLOCKED method=%s reason=active_contract_basket_missing",
+                    method,
+                    extra={
+                        "event": "OPTION_UNIVERSE_RUNTIME_CALL_BLOCKED",
+                        "method": method,
+                        "reason": "active_contract_basket_missing",
+                    },
+                )
+                self._runtime_call_blocked_logged = True
+            return []
+        if not _legacy_fallback_enabled():
+            LOGGER.warning(
+                "OPTION_UNIVERSE_RUNTIME_CALL_BLOCKED method=%s reason=legacy_fallback_disabled",
+                method,
+                extra={
+                    "event": "OPTION_UNIVERSE_RUNTIME_CALL_BLOCKED",
+                    "method": method,
+                    "reason": "legacy_fallback_disabled",
+                },
+            )
+            return []
+        return list(self._current_universe)[:8]
+
     def get_current_universe(self) -> list[str]:
         """Return the latest full option universe.
 
@@ -136,6 +198,11 @@ class OptionUniverseManager:
         Raises:
             None.
         """
+        basket_symbols = self._basket_option_symbols(self._active_contract_basket)
+        if basket_symbols:
+            return basket_symbols[:8]
+        if not self._current_universe:
+            return self._runtime_blocked_universe("get_current_universe")
         return list(self._current_universe)[:8]
 
     def get_primary_symbols(self) -> list[str]:
@@ -154,6 +221,11 @@ class OptionUniverseManager:
 
     def get_filtered_universe(self, spot_ltp: float) -> list[str]:
         """Return the frozen intraday universe while tracking spot diagnostics."""
+        basket_symbols = self._basket_option_symbols(self._active_contract_basket)
+        if basket_symbols:
+            return basket_symbols[:8]
+        if self._runtime_mode_is_live():
+            return self._runtime_blocked_universe("get_filtered_universe")
         if spot_ltp <= 0:
             return list(self._current_universe)[:8]
         threshold = max(1.0, float(self._config.spot_recalc_threshold_points))

--- a/src/nifty_scalper_bot/options/contracts.py
+++ b/src/nifty_scalper_bot/options/contracts.py
@@ -22,11 +22,16 @@ Usage::
 from __future__ import annotations
 
 import logging
+import os
 from dataclasses import dataclass, field
 from datetime import date, datetime
 from typing import Any, Dict, List, Mapping, Optional, Set
 
 LOGGER = logging.getLogger("nifty_scalper_bot.options.contracts")
+
+
+def _live_mode() -> bool:
+    return str(os.getenv("EXECUTION_MODE") or os.getenv("MODE") or "").strip().upper() == "LIVE"
 
 
 @dataclass(slots=True)
@@ -318,11 +323,33 @@ class OptionsContractStore:
                 )
                 return symbols
             except Exception as exc:
+                if _live_mode():
+                    LOGGER.error(
+                        "OPTIONS_CONTRACT_STORE_ACTIVE_BASKET_REQUIRED method=get_trading_universe reason=%s",
+                        exc,
+                        extra={
+                            "event": "OPTIONS_CONTRACT_STORE_ACTIVE_BASKET_REQUIRED",
+                            "method": "get_trading_universe",
+                            "reason": str(exc),
+                        },
+                    )
+                    return []
                 LOGGER.warning(
                     "OPTIONS_CONTRACT_STORE_ACTIVE_BASKET_UNAVAILABLE reason=%s fallback=metadata_cache",
                     exc,
                     extra={"event": "OPTIONS_CONTRACT_STORE_ACTIVE_BASKET_UNAVAILABLE", "reason": str(exc)},
                 )
+
+        if _live_mode():
+            LOGGER.error(
+                "OPTIONS_CONTRACT_STORE_ACTIVE_BASKET_REQUIRED method=get_trading_universe reason=instrument_manager_method_missing",
+                extra={
+                    "event": "OPTIONS_CONTRACT_STORE_ACTIVE_BASKET_REQUIRED",
+                    "method": "get_trading_universe",
+                    "reason": "instrument_manager_method_missing",
+                },
+            )
+            return []
 
         # Non-live compatibility fallback over already-loaded metadata cache only.
         atm_strike = int(round(spot_price / strike_step) * strike_step)
@@ -383,11 +410,35 @@ class OptionsContractStore:
                     spot_token=self._basket_get(basket, "spot_token", self._spot_token),
                 )
             except Exception as exc:
+                if _live_mode():
+                    LOGGER.error(
+                        "OPTIONS_CONTRACT_STORE_ACTIVE_BASKET_REQUIRED method=get_snapshot reason=%s",
+                        exc,
+                        extra={
+                            "event": "OPTIONS_CONTRACT_STORE_ACTIVE_BASKET_REQUIRED",
+                            "method": "get_snapshot",
+                            "reason": str(exc),
+                        },
+                    )
+                    raise RuntimeError(
+                        "OPTIONS_CONTRACT_STORE_ACTIVE_BASKET_REQUIRED method=get_snapshot"
+                    ) from exc
                 LOGGER.warning(
                     "OPTIONS_CONTRACT_STORE_ACTIVE_BASKET_UNAVAILABLE reason=%s fallback=snapshot_metadata_cache",
                     exc,
                     extra={"event": "OPTIONS_CONTRACT_STORE_ACTIVE_BASKET_UNAVAILABLE", "reason": str(exc), "fallback": "snapshot_metadata_cache"},
                 )
+
+        if _live_mode():
+            LOGGER.error(
+                "OPTIONS_CONTRACT_STORE_ACTIVE_BASKET_REQUIRED method=get_snapshot reason=instrument_manager_method_missing",
+                extra={
+                    "event": "OPTIONS_CONTRACT_STORE_ACTIVE_BASKET_REQUIRED",
+                    "method": "get_snapshot",
+                    "reason": "instrument_manager_method_missing",
+                },
+            )
+            raise RuntimeError("OPTIONS_CONTRACT_STORE_ACTIVE_BASKET_REQUIRED method=get_snapshot")
 
         # Non-live compatibility fallback over loaded metadata cache only.
         atm_strike = int(round(spot_price / 50) * 50)

--- a/src/nifty_scalper_bot/options/contracts.py
+++ b/src/nifty_scalper_bot/options/contracts.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass, field
 from datetime import date, datetime
-from typing import Any, Dict, List, Optional, Set
+from typing import Any, Dict, List, Mapping, Optional, Set
 
 LOGGER = logging.getLogger("nifty_scalper_bot.options.contracts")
 
@@ -239,6 +239,34 @@ class OptionsContractStore:
         """
         return self._im.get_exchange(int(token))
     
+    @staticmethod
+    def _basket_get(basket: Any, key: str, default: Any = None) -> Any:
+        if isinstance(basket, Mapping):
+            return basket.get(key, default)
+        return getattr(basket, key, default)
+
+    def _active_basket_symbols(
+        self,
+        basket: Any,
+        *,
+        include_futures: bool,
+        include_spot: bool,
+    ) -> List[str]:
+        symbols: List[str] = []
+        if include_spot:
+            spot_symbol = self._basket_get(basket, "spot_symbol")
+            if spot_symbol:
+                symbols.append(str(spot_symbol))
+        if include_futures:
+            futures_symbol = self._basket_get(basket, "futures_symbol")
+            if futures_symbol:
+                symbols.append(str(futures_symbol))
+        option_symbols = self._basket_get(basket, "option_symbols") or []
+        if not option_symbols:
+            option_symbols = [self._basket_get(basket, "selected_ce"), self._basket_get(basket, "selected_pe")]
+        symbols.extend(str(sym) for sym in option_symbols if sym)
+        return list(dict.fromkeys(symbols))
+
     def get_trading_universe(
         self,
         spot_price: float,
@@ -261,50 +289,63 @@ class OptionsContractStore:
         """
         if spot_price <= 0:
             raise ValueError("spot_price must be positive")
-        
-        # Calculate ATM strike
+
+        get_active = getattr(self._im, "get_active_nifty_contracts", None)
+        if callable(get_active):
+            try:
+                basket = get_active(
+                    float(spot_price),
+                    strikes_around_atm=int(strikes_around_atm),
+                    strike_step=int(strike_step),
+                    include_future=bool(include_futures),
+                )
+                symbols = self._active_basket_symbols(
+                    basket,
+                    include_futures=include_futures,
+                    include_spot=include_spot,
+                )
+                LOGGER.info(
+                    "OPTIONS_CONTRACT_STORE_ACTIVE_BASKET_USED symbols=%d include_spot=%s include_futures=%s",
+                    len(symbols),
+                    include_spot,
+                    include_futures,
+                    extra={
+                        "event": "OPTIONS_CONTRACT_STORE_ACTIVE_BASKET_USED",
+                        "symbols": len(symbols),
+                        "include_spot": include_spot,
+                        "include_futures": include_futures,
+                    },
+                )
+                return symbols
+            except Exception as exc:
+                LOGGER.warning(
+                    "OPTIONS_CONTRACT_STORE_ACTIVE_BASKET_UNAVAILABLE reason=%s fallback=metadata_cache",
+                    exc,
+                    extra={"event": "OPTIONS_CONTRACT_STORE_ACTIVE_BASKET_UNAVAILABLE", "reason": str(exc)},
+                )
+
+        # Non-live compatibility fallback over already-loaded metadata cache only.
         atm_strike = int(round(spot_price / strike_step) * strike_step)
-        
-        # Find nearest expiry
-        today = date.today()
+        today = datetime.now().date()
         future_expiries = sorted([exp for exp in self._by_expiry.keys() if exp >= today])
         
         if not future_expiries:
             raise RuntimeError("No valid expiry dates found")
         
         active_expiry = future_expiries[0]
-        
-        # Generate target strikes
         target_strikes = {
             atm_strike + (i * strike_step)
             for i in range(-strikes_around_atm, strikes_around_atm + 1)
         }
-        
-        # Collect symbols
         symbols: List[str] = []
-        
-        # Add spot
         if include_spot and self._spot_token:
             symbols.append("NSE:NIFTY")
-        
-        # Add futures
         if include_futures and active_expiry in self._futures:
             symbols.append(self._futures[active_expiry].qualified_symbol)
-        
-        # Add options
         contracts_for_expiry = self._by_expiry.get(active_expiry, [])
         for contract in contracts_for_expiry:
             if contract.strike in target_strikes:
                 symbols.append(contract.qualified_symbol)
-        
-        LOGGER.info(
-            "Trading universe: spot=%.2f ATM=%d expiry=%s symbols=%d",
-            spot_price,
-            atm_strike,
-            active_expiry,
-            len(symbols),
-        )
-        
         return symbols
     
     def get_snapshot(self, spot_price: float) -> ContractsSnapshot:
@@ -316,19 +357,49 @@ class OptionsContractStore:
         Returns:
             ContractsSnapshot with all current contract data.
         """
+        get_active = getattr(self._im, "get_active_nifty_contracts", None)
+        if callable(get_active) and spot_price > 0:
+            try:
+                basket = get_active(float(spot_price), strikes_around_atm=2, strike_step=50, include_future=True)
+                atm_strike = int(self._basket_get(basket, "atm_strike", int(round(spot_price / 50) * 50)))
+                active_expiry = self._basket_get(basket, "option_expiry")
+                option_symbols = [str(sym).split(":", 1)[-1].upper() for sym in (self._basket_get(basket, "option_symbols") or [])]
+                selected_contracts = [self._contracts[sym] for sym in option_symbols if sym in self._contracts]
+                ce_contracts = [c for c in selected_contracts if c.instrument_type == "CE"]
+                pe_contracts = [c for c in selected_contracts if c.instrument_type == "PE"]
+                LOGGER.info(
+                    "OPTIONS_CONTRACT_STORE_ACTIVE_BASKET_USED snapshot=True option_count=%d",
+                    len(selected_contracts),
+                    extra={"event": "OPTIONS_CONTRACT_STORE_ACTIVE_BASKET_USED", "snapshot": True, "option_count": len(selected_contracts)},
+                )
+                return ContractsSnapshot(
+                    timestamp=datetime.now(),
+                    spot_price=spot_price,
+                    atm_strike=atm_strike,
+                    active_expiry=active_expiry,
+                    ce_contracts=ce_contracts,
+                    pe_contracts=pe_contracts,
+                    future_token=self._basket_get(basket, "futures_token"),
+                    spot_token=self._basket_get(basket, "spot_token", self._spot_token),
+                )
+            except Exception as exc:
+                LOGGER.warning(
+                    "OPTIONS_CONTRACT_STORE_ACTIVE_BASKET_UNAVAILABLE reason=%s fallback=snapshot_metadata_cache",
+                    exc,
+                    extra={"event": "OPTIONS_CONTRACT_STORE_ACTIVE_BASKET_UNAVAILABLE", "reason": str(exc), "fallback": "snapshot_metadata_cache"},
+                )
+
+        # Non-live compatibility fallback over loaded metadata cache only.
         atm_strike = int(round(spot_price / 50) * 50)
-        today = date.today()
+        today = datetime.now().date()
         future_expiries = sorted([exp for exp in self._by_expiry.keys() if exp >= today])
         active_expiry = future_expiries[0] if future_expiries else today
-        
         contracts_for_expiry = self._by_expiry.get(active_expiry, [])
         ce_contracts = [c for c in contracts_for_expiry if c.instrument_type == "CE"]
         pe_contracts = [c for c in contracts_for_expiry if c.instrument_type == "PE"]
-        
         future_token = None
         if active_expiry in self._futures:
             future_token = self._futures[active_expiry].instrument_token
-        
         return ContractsSnapshot(
             timestamp=datetime.now(),
             spot_price=spot_price,

--- a/tests/core/test_basket_commit_before_readiness.py
+++ b/tests/core/test_basket_commit_before_readiness.py
@@ -219,3 +219,47 @@ async def test_missing_hydration_method_blocks_live_readiness(monkeypatch, caplo
     assert ctx.active_basket_hydration["missing"] == ["hydrate_active_contract_basket_missing"]
     assert "ACTIVE_BASKET_HYDRATION_METHOD_MISSING" in caplog.text
     assert calls[-1]['evaluation_ready'] is False
+
+
+def test_botcontext_active_contract_basket_initialized():
+    from nifty_scalper_bot.config.settings import Settings
+    from nifty_scalper_bot.core.app import AppConfig, BotContext, RateLimiter
+
+    ctx = BotContext(
+        settings=Settings(),
+        config=AppConfig(),
+        rate_limiter=RateLimiter(),
+        broker_client=None,
+        websocket_client=None,
+        websocket_manager=None,
+        streamer=None,
+        stream_supervisor=None,
+        polling_fallback_streamer=None,
+        message_bus=None,
+    )
+
+    assert ctx.active_contract_basket is None
+    assert ctx.active_basket_hydration is None
+
+
+@pytest.mark.asyncio
+async def test_early_spot_basket_build_deferred_without_active_basket_attr_error(caplog):
+    ctx = SimpleNamespace(
+        instrument_manager=SimpleNamespace(is_loaded=lambda: False),
+        market_data_manager=_MDM(),
+        broker_client=_Broker(),
+        settings=SimpleNamespace(option_universe=SimpleNamespace(strike_step=50), execution_mode='LIVE'),
+        deferred_basket_retry_started=True,
+        basket_build_lock=None,
+        basket_build_in_progress=False,
+        basket_build_last_started_mono=0.0,
+        basket_build_last_completed_mono=0.0,
+        basket_build_last_error=None,
+    )
+
+    result = await app._build_and_hydrate_live_basket_from_spot(ctx, spot_ltp=23701.0, configured_mode='LIVE')
+
+    assert result["deferred"] is True
+    assert result["reason"] == "instrument_manager_not_ready"
+    assert "LIVE_BASKET_BUILD_DEFERRED" in caplog.text
+    assert "LIVE_BASKET_BUILD_FAILED" not in caplog.text

--- a/tests/options/test_contracts_ssot.py
+++ b/tests/options/test_contracts_ssot.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from datetime import date
 
-from nifty_scalper_bot.options.contracts import OptionsContractStore
+from nifty_scalper_bot.options.contracts import OptionContract, OptionsContractStore
 
 
 class _IM:
@@ -36,3 +36,36 @@ def test_options_contract_store_delegates_to_instrument_manager_basket():
     assert symbols == ["NSE:NIFTY", "NFO:NIFTY26JUN25000CE", "NFO:NIFTY26JUN25000PE"]
     assert im.calls
     assert im.calls[0][1]["include_future"] is False
+
+
+class _FailingIM:
+    def get_active_nifty_contracts(self, spot_price: float, **kwargs):
+        raise RuntimeError("active basket unavailable")
+
+    def is_loaded(self):
+        return True
+
+    def get_exchange(self, token: int):
+        return "NFO"
+
+
+def test_contract_store_live_does_not_fallback_to_metadata_cache(monkeypatch, caplog):
+    monkeypatch.setenv("EXECUTION_MODE", "LIVE")
+    store = OptionsContractStore(_FailingIM())
+    expiry = date(2099, 1, 1)
+    contract = OptionContract(
+        instrument_token=111,
+        tradingsymbol="NIFTY99JAN25000CE",
+        expiry=expiry,
+        strike=25000.0,
+        instrument_type="CE",
+    )
+    store._spot_token = 256265
+    store._by_expiry[expiry] = [contract]
+    store._contracts[contract.symbol_key] = contract
+
+    symbols = store.get_trading_universe(25001.0)
+
+    assert symbols == []
+    assert "NFO:NIFTY99JAN25000CE" not in symbols
+    assert "OPTIONS_CONTRACT_STORE_ACTIVE_BASKET_REQUIRED" in caplog.text

--- a/tests/options/test_contracts_ssot.py
+++ b/tests/options/test_contracts_ssot.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from datetime import date
+
+from nifty_scalper_bot.options.contracts import OptionsContractStore
+
+
+class _IM:
+    def __init__(self) -> None:
+        self.calls = []
+
+    def get_active_nifty_contracts(self, spot_price: float, **kwargs):
+        self.calls.append((spot_price, kwargs))
+        return {
+            "spot_symbol": "NSE:NIFTY",
+            "futures_symbol": "NFO:NIFTY26JUNFUT",
+            "option_symbols": ("NFO:NIFTY26JUN25000CE", "NFO:NIFTY26JUN25000PE"),
+            "selected_ce": "NFO:NIFTY26JUN25000CE",
+            "selected_pe": "NFO:NIFTY26JUN25000PE",
+            "option_expiry": date(2026, 6, 25),
+            "atm_strike": 25000,
+            "futures_token": 900,
+            "spot_token": 256265,
+        }
+
+    def is_loaded(self):
+        return True
+
+
+def test_options_contract_store_delegates_to_instrument_manager_basket():
+    im = _IM()
+    store = OptionsContractStore(im)
+
+    symbols = store.get_trading_universe(25001.0, include_spot=True, include_futures=False)
+
+    assert symbols == ["NSE:NIFTY", "NFO:NIFTY26JUN25000CE", "NFO:NIFTY26JUN25000PE"]
+    assert im.calls
+    assert im.calls[0][1]["include_future"] is False

--- a/tests/test_app_symbol_resolution.py
+++ b/tests/test_app_symbol_resolution.py
@@ -154,3 +154,24 @@ def test_build_canonical_active_basket_is_limited_to_spot_futures_atm_pm3() -> N
     assert len(basket["ce_symbols"]) == 7
     assert len(basket["pe_symbols"]) == 7
     assert len(basket["symbols"]) == 16
+
+
+def test_hydration_tracking_uses_active_basket_not_option_universe(monkeypatch) -> None:
+    from nifty_scalper_bot.core.option_universe import OptionUniverseConfig, OptionUniverseManager
+
+    monkeypatch.setenv("EXECUTION_MODE", "LIVE")
+    monkeypatch.setattr(
+        OptionUniverseManager,
+        "_build_universe",
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("manual generation should not run")),
+    )
+    universe = OptionUniverseManager(OptionUniverseConfig())
+    basket = {
+        "selected_ce": "NFO:NIFTY26JUN25000CE",
+        "selected_pe": "NFO:NIFTY26JUN25000PE",
+        "option_symbols": ["NFO:NIFTY26JUN25000CE", "NFO:NIFTY26JUN25000PE"],
+    }
+
+    symbols = app._get_symbols(app.AppConfig(), option_universe=universe, active_contract_basket=basket)
+
+    assert symbols == ["NFO:NIFTY26JUN25000CE", "NFO:NIFTY26JUN25000PE"]

--- a/tests/test_app_symbol_resolution.py
+++ b/tests/test_app_symbol_resolution.py
@@ -175,3 +175,22 @@ def test_hydration_tracking_uses_active_basket_not_option_universe(monkeypatch) 
     symbols = app._get_symbols(app.AppConfig(), option_universe=universe, active_contract_basket=basket)
 
     assert symbols == ["NFO:NIFTY26JUN25000CE", "NFO:NIFTY26JUN25000PE"]
+
+
+def test_get_symbols_uses_ce_pe_symbol_fallback_without_option_symbols(monkeypatch) -> None:
+    monkeypatch.setenv("EXECUTION_MODE", "LIVE")
+    basket = {
+        "ce_symbols": ["NFO:NIFTY26JUN25000CE", "NFO:NIFTY26JUN25050CE"],
+        "pe_symbols": ["NFO:NIFTY26JUN25000PE", "NFO:NIFTY26JUN25050PE"],
+        "selected_ce": "NFO:NIFTY26JUN99999CE",
+        "selected_pe": "NFO:NIFTY26JUN99999PE",
+    }
+
+    symbols = app._get_symbols(app.AppConfig(), active_contract_basket=basket)
+
+    assert symbols == [
+        "NFO:NIFTY26JUN25000CE",
+        "NFO:NIFTY26JUN25050CE",
+        "NFO:NIFTY26JUN25000PE",
+        "NFO:NIFTY26JUN25050PE",
+    ]

--- a/tests/test_option_universe.py
+++ b/tests/test_option_universe.py
@@ -138,3 +138,14 @@ def test_option_universe_live_without_basket_returns_empty_not_crash(monkeypatch
 
     assert manager.get_primary_symbols() == []
     assert "OPTION_UNIVERSE_RUNTIME_CALL_BLOCKED" in caplog.text
+
+
+def test_active_basket_current_universe_returns_all_symbols_and_primary_is_capped(monkeypatch) -> None:
+    monkeypatch.setenv("EXECUTION_MODE", "LIVE")
+    symbols = tuple(f"NFO:NIFTY26JUN{25000 + i * 50}CE" for i in range(10))
+    manager = OptionUniverseManager(OptionUniverseConfig())
+    manager.set_active_contract_basket({"option_symbols": symbols})
+
+    assert manager.get_current_universe() == list(symbols)
+    assert manager.get_filtered_universe(25000.0) == list(symbols)
+    assert manager.get_primary_symbols() == list(symbols[:8])

--- a/tests/test_option_universe.py
+++ b/tests/test_option_universe.py
@@ -111,3 +111,30 @@ def test_option_universe_legacy_requires_env(monkeypatch) -> None:
     )
     with pytest.raises(RuntimeError, match="manual generation disabled"):
         manager.update_underlying(18638.0)
+
+
+def _active_basket() -> dict[str, object]:
+    return {
+        "selected_ce": "NFO:NIFTY26JUN25000CE",
+        "selected_pe": "NFO:NIFTY26JUN25000PE",
+        "option_symbols": ("NFO:NIFTY26JUN25000CE", "NFO:NIFTY26JUN25000PE"),
+        "all_symbols": ("NSE:NIFTY", "NFO:NIFTY26JUN25000CE", "NFO:NIFTY26JUN25000PE"),
+        "token_by_symbol": {"NFO:NIFTY26JUN25000CE": 111, "NFO:NIFTY26JUN25000PE": 112},
+    }
+
+
+def test_no_option_universe_runtime_crash_live(monkeypatch) -> None:
+    monkeypatch.setenv("EXECUTION_MODE", "LIVE")
+    manager = OptionUniverseManager(OptionUniverseConfig())
+    manager.set_active_contract_basket(_active_basket())
+
+    assert manager.get_primary_symbols() == ["NFO:NIFTY26JUN25000CE", "NFO:NIFTY26JUN25000PE"]
+    assert manager.get_current_universe() == ["NFO:NIFTY26JUN25000CE", "NFO:NIFTY26JUN25000PE"]
+
+
+def test_option_universe_live_without_basket_returns_empty_not_crash(monkeypatch, caplog) -> None:
+    monkeypatch.setenv("EXECUTION_MODE", "LIVE")
+    manager = OptionUniverseManager(OptionUniverseConfig())
+
+    assert manager.get_primary_symbols() == []
+    assert "OPTION_UNIVERSE_RUNTIME_CALL_BLOCKED" in caplog.text


### PR DESCRIPTION
### Motivation

- Prevent startup crash caused by residual runtime calls into `OptionUniverseManager` which raise in LIVE mode when manual universe generation is disabled.
- Ensure all runtime symbol resolution/hydration consumes the committed ActiveContractBasket SSOT instead of rebuilding or falling back to deprecated calendar generation.

### Description

- Prefer authoritative ActiveContractBasket for symbol resolution by changing `_get_symbols()` to accept/lookup an explicit or committed basket and return `basket["option_symbols"]`/selected CE/PE when available, and to block LIVE resolution if no basket exists (`SYMBOL_RESOLUTION_BLOCKED`).
- Make `OptionUniverseManager` tolerant for accidental runtime calls by adding `set_active_contract_basket()` / `from_active_contract_basket()` and returning basket-backed symbols in `get_current_universe()`, `get_primary_symbols()`, and `get_filtered_universe()` while preserving `_build_universe()` behavior (still raises in LIVE for manual generation).
- Add `active_contract_basket` and `active_basket_hydration` fields to `BotContext` and ensure the committed basket is attached to MDM/DataHub/OptionUniverse compatibility wrapper during `_commit_active_dynamic_basket()`.
- Harden dynamic-universe sync to consume `_option_symbols_from_active_basket(...)` instead of calling legacy `OptionUniverseManager` selection, and change hydration failure handling to degrade readiness or emit `ACTIVE_BASKET_MISSING` instead of crashing startup.
- Harden `OptionsContractStore` so `get_trading_universe()` and `get_snapshot()` delegate to `InstrumentManager.get_active_nifty_contracts()` when available, logging `OPTIONS_CONTRACT_STORE_ACTIVE_BASKET_USED`, and only fall back to local metadata for non-live compatibility.
- Added focused tests that assert: `OptionUniverseManager` no longer crashes when given an active basket in LIVE, it returns empty (and logs) when no basket exists in LIVE, `_get_symbols()` prefers the active basket, `BotContext` contains the new fields, and `OptionsContractStore` delegates to `InstrumentManager`.

### Testing

- Ran `python -m compileall -q src` and the compilation passed. 
- Ran focused and full test suites with `pytest -q` including `tests/test_option_universe.py`, `tests/test_app_symbol_resolution.py`, `tests/core/test_basket_commit_before_readiness.py`, `tests/core/test_commit_active_dynamic_basket.py`, `tests/data/test_mdm_subscribes_active_basket.py`, `tests/test_live_basket_hydration.py`, `tests/test_live_tick_pipeline_to_runner.py`, `tests/options/test_strike_selector_ssot.py`, and the newly added `tests/options/test_contracts_ssot.py`; all executed and passed (no failures).
- Summary: compile and automated tests succeeded (focused suites and full `pytest -q` run reported all tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d0f6cf0708324ad7a8fe721213110)