### PR TITLE
Startup: add bounded spot-first watchdog and REST fallback to enable basket commit

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -6416,14 +6416,14 @@ def _resolve_startup_rest_spot_ltp(ctx: BotContext, *, max_age_seconds: float | 
         except TypeError:
             try:
                 rest_value = get_ltp_fn(policy.nifty_internal_symbol)
-            except (TypeError, ValueError) as exc:
+            except (TypeError, RuntimeError, ValueError) as exc:
                 LOGGER.warning(
                     "STARTUP_SPOT_REST_FALLBACK_FAILED stage=get_ltp reason=%s",
                     type(exc).__name__,
                     extra={"event": "STARTUP_SPOT_REST_FALLBACK_FAILED", "stage": "get_ltp", "reason": type(exc).__name__},
                 )
                 rest_value = 0.0
-        except ValueError as exc:
+        except (RuntimeError, ValueError) as exc:
             LOGGER.warning(
                 "STARTUP_SPOT_REST_FALLBACK_FAILED stage=get_ltp reason=%s",
                 type(exc).__name__,
@@ -6564,14 +6564,15 @@ async def _wait_for_live_spot_or_raise(
                 policy.nifty_internal_symbol,
             )
         LOGGER.info(
-            "LIVE_SPOT_READY symbol=%s price=%.2f source=rest_fallback",
+            "STARTUP_SPOT_REST_FALLBACK_READY symbol=%s price=%.2f live_proof=%s",
             policy.nifty_internal_symbol,
             float(fallback),
+            False,
             extra={
-                "event": "LIVE_SPOT_READY",
+                "event": "STARTUP_SPOT_REST_FALLBACK_READY",
                 "symbol": policy.nifty_internal_symbol,
                 "price": float(fallback),
-                "source": "rest_fallback",
+                "live_proof": False,
             },
         )
         return float(fallback)
@@ -7626,6 +7627,70 @@ def _hydrate_committed_active_basket(ctx: BotContext, *, reason: str) -> dict[st
         )
     return report
 
+
+def _bare_trading_symbol(symbol: object) -> str:
+    """Return exchange-less trading symbol for token-map alias checks."""
+    raw = str(symbol or "").strip()
+    return raw.split(":", 1)[1] if ":" in raw else raw
+
+
+def _coerce_positive_token(value: object) -> int | None:
+    """Coerce valid positive instrument token values."""
+    try:
+        token = int(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None
+    return token if token > 0 else None
+
+
+def _resolve_committed_symbol_token(
+    ctx: BotContext,
+    committed: Mapping[str, object],
+    symbol: str | None,
+    explicit_token_key: str | None = None,
+) -> int | None:
+    """Resolve a committed basket symbol token from explicit, full, and bare aliases."""
+    if not symbol:
+        return None
+    aliases = list(dict.fromkeys([str(symbol), _bare_trading_symbol(symbol)]))
+    if explicit_token_key:
+        token = _coerce_positive_token(committed.get(explicit_token_key))
+        if token is not None:
+            return token
+    token_map = committed.get("token_by_symbol")
+    if isinstance(token_map, Mapping):
+        for alias in aliases:
+            token = _coerce_positive_token(token_map.get(alias))
+            if token is not None:
+                return token
+    active_tokens = getattr(ctx, "active_symbol_tokens", None)
+    if isinstance(active_tokens, Mapping):
+        for alias in aliases:
+            token = _coerce_positive_token(active_tokens.get(alias))
+            if token is not None:
+                return token
+    instrument_manager = getattr(ctx, "instrument_manager", None)
+    get_token = getattr(instrument_manager, "get_token", None)
+    if callable(get_token):
+        for alias in aliases:
+            try:
+                token = _coerce_positive_token(get_token(alias))
+            except (KeyError, RuntimeError, TypeError, ValueError):
+                token = None
+            if token is not None:
+                return token
+    broker_client = getattr(ctx, "broker_client", None)
+    get_instrument_token = getattr(broker_client, "get_instrument_token", None)
+    if callable(get_instrument_token):
+        for alias in aliases:
+            try:
+                token = _coerce_positive_token(get_instrument_token(alias))
+            except (KeyError, RuntimeError, TypeError, ValueError):
+                token = None
+            if token is not None:
+                return token
+    return None
+
 def _commit_active_dynamic_basket(
     ctx: BotContext,
     *,
@@ -7722,6 +7787,8 @@ def _commit_active_dynamic_basket(
             "spot_token": basket.get("spot_token"),
             "futures_symbol": active_futures_symbol,
             "futures_token": basket.get("futures_token"),
+            "selected_ce_token": basket.get("selected_ce_token"),
+            "selected_pe_token": basket.get("selected_pe_token"),
             "selected_ce": selected_ce,
             "selected_pe": selected_pe,
             "atm_ce": selected_ce,
@@ -7751,6 +7818,25 @@ def _commit_active_dynamic_basket(
     symbol_by_token = dict(basket.get("symbol_by_token") or {})
     all_symbols = list(basket.get("all_symbols") or committed.get("symbols") or [])
     all_tokens = list(basket.get("all_tokens") or [])
+    for explicit_symbol, explicit_key in (
+        (selected_ce, "selected_ce_token"),
+        (selected_pe, "selected_pe_token"),
+        (active_futures_symbol, "futures_token"),
+    ):
+        explicit_token = _coerce_positive_token(committed.get(explicit_key))
+        if explicit_symbol and explicit_token is not None:
+            token_by_symbol.setdefault(str(explicit_symbol), explicit_token)
+            token_by_symbol.setdefault(_bare_trading_symbol(explicit_symbol), explicit_token)
+            symbol_by_token.setdefault(explicit_token, str(explicit_symbol))
+    for sym in list(all_symbols):
+        sym_str = str(sym)
+        bare_sym = _bare_trading_symbol(sym_str)
+        full_token = _coerce_positive_token(token_by_symbol.get(sym_str))
+        bare_token = _coerce_positive_token(token_by_symbol.get(bare_sym))
+        if full_token is None and bare_token is not None:
+            token_by_symbol[sym_str] = bare_token
+        elif full_token is not None and bare_sym:
+            token_by_symbol.setdefault(bare_sym, full_token)
     if active_futures_symbol and active_futures_symbol not in all_symbols:
         all_symbols.insert(1 if all_symbols else 0, active_futures_symbol)
     futures_token = basket.get("futures_token")
@@ -7788,8 +7874,9 @@ def _commit_active_dynamic_basket(
     desired_token_count = int(desired_count_fn()) if callable(desired_count_fn) else len(committed.get("all_tokens") or [])
     ws_count_value = ws_count_fn() if callable(ws_count_fn) else None
     ws_token_count = int(ws_count_value) if ws_count_value is not None else None
-    selected_ce_token = token_by_symbol.get(str(selected_ce)) if selected_ce else None
-    selected_pe_token = token_by_symbol.get(str(selected_pe)) if selected_pe else None
+    selected_ce_token = _resolve_committed_symbol_token(ctx, committed, selected_ce, "selected_ce_token")
+    selected_pe_token = _resolve_committed_symbol_token(ctx, committed, selected_pe, "selected_pe_token")
+    futures_token_for_log = _resolve_committed_symbol_token(ctx, committed, active_futures_symbol, "futures_token")
     if selected_ce and selected_ce_token is None:
         ctx.live_orders_armed = False
         ctx.trading_ready = False
@@ -7805,10 +7892,10 @@ def _commit_active_dynamic_basket(
         selected_pe,
         selected_pe_token,
         active_futures_symbol,
-        committed.get("futures_token"),
+        futures_token_for_log,
         desired_token_count,
         ws_token_count,
-        extra={"event": "ACTIVE_BASKET_SUBSCRIPTION_RECONCILED", "selected_ce": selected_ce, "selected_ce_token": selected_ce_token, "selected_pe": selected_pe, "selected_pe_token": selected_pe_token, "futures_symbol": active_futures_symbol, "futures_token": committed.get("futures_token"), "desired_token_count": desired_token_count, "ws_token_count": ws_token_count},
+        extra={"event": "ACTIVE_BASKET_SUBSCRIPTION_RECONCILED", "selected_ce": selected_ce, "selected_ce_token": selected_ce_token, "selected_pe": selected_pe, "selected_pe_token": selected_pe_token, "futures_symbol": active_futures_symbol, "futures_token": futures_token_for_log, "desired_token_count": desired_token_count, "ws_token_count": ws_token_count},
     )
     _hydrate_committed_active_basket(ctx, reason="active_dynamic_basket_commit")
     LOGGER.info(

--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -6381,6 +6381,92 @@ def _coerce_spot_price(tick: Mapping[str, Any] | None) -> float | None:
     return None
 
 
+def _resolve_startup_rest_spot_ltp(ctx: BotContext, *, max_age_seconds: float | None = None) -> float | None:
+    """Resolve bounded startup spot from cached/REST fallback without treating it as live proof."""
+
+    policy = MarketDataPolicy.from_env()
+    mdm = getattr(ctx, "market_data_manager", None)
+    if mdm is None:
+        return None
+    cached_fn = getattr(mdm, "get_cached_ltp", None)
+    if callable(cached_fn):
+        try:
+            cached = float(
+                cached_fn(
+                    policy.nifty_internal_symbol,
+                    max_age_seconds=max_age_seconds,
+                    require_ws=False,
+                )
+                or 0.0
+            )
+        except (TypeError, ValueError) as exc:
+            LOGGER.warning(
+                "STARTUP_SPOT_REST_FALLBACK_FAILED stage=get_cached_ltp reason=%s",
+                type(exc).__name__,
+                extra={"event": "STARTUP_SPOT_REST_FALLBACK_FAILED", "stage": "get_cached_ltp", "reason": type(exc).__name__},
+            )
+            cached = 0.0
+        if cached > 0:
+            return cached
+    get_ltp_fn = getattr(mdm, "get_ltp", None) or getattr(mdm, "get_latest_price", None)
+    if callable(get_ltp_fn):
+        rest_ltp = 0.0
+        try:
+            rest_value = get_ltp_fn(policy.nifty_internal_symbol, allow_rest_fallback=True)
+        except TypeError:
+            try:
+                rest_value = get_ltp_fn(policy.nifty_internal_symbol)
+            except (TypeError, ValueError) as exc:
+                LOGGER.warning(
+                    "STARTUP_SPOT_REST_FALLBACK_FAILED stage=get_ltp reason=%s",
+                    type(exc).__name__,
+                    extra={"event": "STARTUP_SPOT_REST_FALLBACK_FAILED", "stage": "get_ltp", "reason": type(exc).__name__},
+                )
+                rest_value = 0.0
+        except ValueError as exc:
+            LOGGER.warning(
+                "STARTUP_SPOT_REST_FALLBACK_FAILED stage=get_ltp reason=%s",
+                type(exc).__name__,
+                extra={"event": "STARTUP_SPOT_REST_FALLBACK_FAILED", "stage": "get_ltp", "reason": type(exc).__name__},
+            )
+            rest_value = 0.0
+        try:
+            rest_ltp = float(rest_value or 0.0)
+        except (TypeError, ValueError) as exc:
+            LOGGER.warning(
+                "STARTUP_SPOT_REST_FALLBACK_FAILED stage=get_ltp_coerce reason=%s",
+                type(exc).__name__,
+                extra={"event": "STARTUP_SPOT_REST_FALLBACK_FAILED", "stage": "get_ltp_coerce", "reason": type(exc).__name__},
+            )
+        if rest_ltp > 0:
+            return rest_ltp
+    refresh_fn = getattr(mdm, "refresh_quote_now", None)
+    if callable(refresh_fn):
+        try:
+            quote = refresh_fn(policy.nifty_internal_symbol, trace_id="startup_spot_rest_fallback")
+        except TypeError:
+            try:
+                quote = refresh_fn(policy.nifty_internal_symbol)
+            except (TypeError, RuntimeError, ValueError) as exc:
+                LOGGER.warning(
+                    "STARTUP_SPOT_REST_FALLBACK_FAILED stage=refresh_quote_now reason=%s",
+                    type(exc).__name__,
+                    extra={"event": "STARTUP_SPOT_REST_FALLBACK_FAILED", "stage": "refresh_quote_now", "reason": type(exc).__name__},
+                )
+                quote = None
+        except (RuntimeError, ValueError) as exc:
+            LOGGER.warning(
+                "STARTUP_SPOT_REST_FALLBACK_FAILED stage=refresh_quote_now reason=%s",
+                type(exc).__name__,
+                extra={"event": "STARTUP_SPOT_REST_FALLBACK_FAILED", "stage": "refresh_quote_now", "reason": type(exc).__name__},
+            )
+            quote = None
+        price = _coerce_spot_price(quote if isinstance(quote, Mapping) else None)
+        if price and price > 0:
+            return float(price)
+    return None
+
+
 async def _wait_for_live_spot_or_raise(
     ctx: BotContext,
     *,
@@ -6389,11 +6475,11 @@ async def _wait_for_live_spot_or_raise(
 ) -> float:
     """Resolve the NIFTY spot price to use for live option universe selection.
 
-    In LIVE mode this requires fresh WebSocket tick proof for ``NSE:NIFTY``
-    so the ATM basket cannot be built from a stale REST quote or synthetic
-    fallback.  In PAPER/SHADOW mode it allows REST/cached values and finally
-    a synthetic 25600.0 reference (with a clear log) so off-hours
-    simulations keep working.
+    In LIVE mode this first waits for fresh WebSocket proof for ``NSE:NIFTY``.
+    If the bounded wait expires, a positive cached/REST spot may build and
+    hydrate the basket, but live orders remain disarmed until live option
+    quote/depth readiness passes.  PAPER/SHADOW may still use the synthetic
+    25600.0 reference (with a clear log) so off-hours simulations keep working.
 
     Args:
         ctx: Bot context with an attached MarketDataManager.
@@ -6404,8 +6490,8 @@ async def _wait_for_live_spot_or_raise(
         Positive NIFTY spot price.
 
     Raises:
-        RuntimeError: When LIVE mode is active but no fresh WebSocket
-            spot tick is available within ``timeout``.
+        RuntimeError: When LIVE mode is active and neither WebSocket nor
+            cached/REST spot LTP is available within ``timeout``.
     """
 
     policy = MarketDataPolicy.from_env()
@@ -6447,81 +6533,60 @@ async def _wait_for_live_spot_or_raise(
         )
         return float(price)
 
-    allow_rest_live = str(os.getenv("MARKETDATA_ALLOW_REST_SPOT_FOR_LIVE", "false")).strip().lower() in {"1", "true", "yes", "on"}
-    if live_mode and policy.block_live_if_no_ws_spot and not allow_rest_live:
-        cached_probe_fn = getattr(mdm, "get_cached_ltp", None)
-        rest_probe = (
-            float(
-                cached_probe_fn(
-                    policy.nifty_internal_symbol,
-                    max_age_seconds=policy.startup_spot_max_age_seconds,
-                    require_ws=False,
-                )
-                or 0.0
-            )
-            if callable(cached_probe_fn)
-            else 0.0
-        )
-        if rest_probe > 0:
+    # Bounded fallback: REST/cached spot may select and hydrate the option basket,
+    # but it is never live-order proof. Readiness still requires live option quote
+    # quality before live_orders_armed can become true.
+    fallback = _resolve_startup_rest_spot_ltp(
+        ctx,
+        max_age_seconds=policy.startup_spot_max_age_seconds,
+    )
+    if fallback and fallback > 0:
+        if live_mode:
+            ctx.live_orders_armed = False
+            ctx.trading_ready = False
+            ctx.live_block_reason = "live_option_quote_required_after_rest_spot_fallback"
             LOGGER.info(
-                "SPOT_REST_AVAILABLE_BUT_WS_REQUIRED rest_ltp=%.2f reason=live_requires_ws",
-                rest_probe,
+                "STARTUP_SPOT_REST_FALLBACK_USED symbol=%s price=%.2f live_orders_armed=%s",
+                policy.nifty_internal_symbol,
+                float(fallback),
+                bool(getattr(ctx, "live_orders_armed", False)),
                 extra={
-                    "event": "SPOT_REST_AVAILABLE_BUT_WS_REQUIRED",
-                    "rest_ltp": rest_probe,
-                    "reason": "live_requires_ws",
+                    "event": "STARTUP_SPOT_REST_FALLBACK_USED",
+                    "symbol": policy.nifty_internal_symbol,
+                    "price": float(fallback),
+                    "live_orders_armed": bool(getattr(ctx, "live_orders_armed", False)),
                 },
             )
-        raise RuntimeError(
-            "fresh NIFTY WebSocket spot tick unavailable; "
-            "cannot build live option universe"
-        )
-
-    if live_mode and allow_rest_live:
-        LOGGER.error(
-            "SPOT_REST_USED_FOR_LIVE_STARTUP symbol=%s severity=high",
-            policy.nifty_internal_symbol,
-            extra={"event": "SPOT_REST_USED_FOR_LIVE_STARTUP", "symbol": policy.nifty_internal_symbol},
-        )
-
-    # Paper / off-hours fallback path: try cached REST/poll value first.
-    cached_ltp_fn = getattr(mdm, "get_cached_ltp", None)
-    cached = (
-        float(
-            cached_ltp_fn(
-                policy.nifty_internal_symbol,
-                max_age_seconds=policy.startup_spot_max_age_seconds,
-                require_ws=False,
-            )
-            or 0.0
-        )
-        if callable(cached_ltp_fn)
-        else 0.0
-    )
-    if cached > 0:
-        if not live_mode:
+        else:
             LOGGER.info(
                 "STARTUP_SPOT_FALLBACK_PROBE mode=%s source=rest_or_poll symbol=%s",
                 (configured_mode or "PAPER"),
                 policy.nifty_internal_symbol,
             )
         LOGGER.info(
-            "LIVE_SPOT_READY symbol=%s price=%.2f source=cache",
+            "LIVE_SPOT_READY symbol=%s price=%.2f source=rest_fallback",
             policy.nifty_internal_symbol,
-            cached,
+            float(fallback),
             extra={
                 "event": "LIVE_SPOT_READY",
                 "symbol": policy.nifty_internal_symbol,
-                "price": cached,
-                "source": "cache",
+                "price": float(fallback),
+                "source": "rest_fallback",
             },
         )
-        return float(cached)
+        return float(fallback)
 
     if live_mode:
-        raise RuntimeError(
-            "fresh NIFTY spot unavailable; refusing synthetic spot in LIVE mode"
+        ctx.live_orders_armed = False
+        ctx.trading_ready = False
+        ctx.live_block_reason = "spot_ltp_unavailable"
+        LOGGER.warning(
+            "STARTUP_SPOT_PROOF_TIMEOUT symbol=%s timeout=%.2f reason=spot_ltp_unavailable",
+            policy.nifty_internal_symbol,
+            float(timeout),
+            extra={"event": "STARTUP_SPOT_PROOF_TIMEOUT", "symbol": policy.nifty_internal_symbol, "timeout": float(timeout), "reason": "spot_ltp_unavailable"},
         )
+        raise RuntimeError("spot_ltp_unavailable")
 
     LOGGER.warning(
         "SYNTHETIC_SPOT_USED mode=%s price=%.2f reason=no_live_tick",
@@ -7474,7 +7539,7 @@ async def _recompute_and_push_runtime_readiness(ctx: BotContext, *, reason: str)
     ctx.selected_pe_exec_ready = bool(pe_exec_ready)
     ctx.context_exec_ready = bool(context_exec_ready)
     ctx.broker_ready = bool(broker_ready)
-    LOGGER.info("LIVE_READINESS_COMPUTED selected_ce=%s selected_pe=%s ce_ltp_fresh=%s pe_ltp_fresh=%s ce_tick_age_s=%s pe_tick_age_s=%s ce_tradable_quote=%s pe_tradable_quote=%s ce_depth_available=%s pe_depth_available=%s ce_subscription_confirmed=%s pe_subscription_confirmed=%s ce_subscription_or_live_tick=%s pe_subscription_or_live_tick=%s ce_bars_effective=%s ce_mdm_bars=%s ce_runner_bars=%s pe_bars_effective=%s pe_mdm_bars=%s pe_runner_bars=%s data_hard_ready=%s evaluation_ready=%s live_orders_armed=%s ce_exec_ready=%s pe_exec_ready=%s execution_ready_by_symbol=%s live_block_reason=%s", selected_ce, selected_pe, ce_quote_fresh, pe_quote_fresh, getattr(_snapshot(selected_ce),'tick_age_s',None), getattr(_snapshot(selected_pe),'tick_age_s',None), _tradable_quote(selected_ce), _tradable_quote(selected_pe), bool(getattr(_snapshot(selected_ce),'depth_available',False)), bool(getattr(_snapshot(selected_pe),'depth_available',False)), _subscription_confirmed(selected_ce), _subscription_confirmed(selected_pe), _subscription_or_live_tick(selected_ce), _subscription_or_live_tick(selected_pe), ce_bars, ce_mdm_bars, ce_runner_bars, pe_bars, pe_mdm_bars, pe_runner_bars, data_hard_ready, evaluation_ready, live_orders_armed, ce_exec_ready, pe_exec_ready, execution_ready_by_symbol, block_reason)
+    LOGGER.info("LIVE_READINESS_COMPUTED selected_ce=%s selected_pe=%s ce_ltp_fresh=%s pe_ltp_fresh=%s ce_tick_age_s=%s pe_tick_age_s=%s ce_tradable_quote=%s pe_tradable_quote=%s ce_depth_available=%s pe_depth_available=%s ce_subscription_confirmed=%s pe_subscription_confirmed=%s ce_subscription_or_live_tick=%s pe_subscription_or_live_tick=%s ce_bars_effective=%s ce_mdm_bars=%s ce_runner_bars=%s pe_bars_effective=%s pe_mdm_bars=%s pe_runner_bars=%s data_hard_ready=%s evaluation_ready=%s trading_ready=%s live_orders_armed=%s ce_quote_ready=%s pe_quote_ready=%s ce_exec_ready=%s pe_exec_ready=%s direction_context_ready=%s execution_ready_by_symbol=%s live_block_reason=%s", selected_ce, selected_pe, ce_quote_fresh, pe_quote_fresh, getattr(_snapshot(selected_ce),'tick_age_s',None), getattr(_snapshot(selected_pe),'tick_age_s',None), _tradable_quote(selected_ce), _tradable_quote(selected_pe), bool(getattr(_snapshot(selected_ce),'depth_available',False)), bool(getattr(_snapshot(selected_pe),'depth_available',False)), _subscription_confirmed(selected_ce), _subscription_confirmed(selected_pe), _subscription_or_live_tick(selected_ce), _subscription_or_live_tick(selected_pe), ce_bars, ce_mdm_bars, ce_runner_bars, pe_bars, pe_mdm_bars, pe_runner_bars, data_hard_ready, evaluation_ready, bool(ctx.trading_ready), live_orders_armed, ce_quote_fresh, pe_quote_fresh, ce_exec_ready, pe_exec_ready, bool(context_exec_ready), execution_ready_by_symbol, block_reason)
     if ctx.strategy_runner is not None and hasattr(ctx.strategy_runner, 'set_runtime_readiness'):
         ctx.strategy_runner.set_runtime_readiness(data_hard_ready=bool(ctx.data_hard_ready), evaluation_ready=bool(ctx.evaluation_ready), live_orders_armed=bool(ctx.live_orders_armed), reason=str(ctx.live_block_reason or reason), selected_ce=selected_ce, selected_pe=selected_pe, atm_strike=basket.get('atm_strike'), option_symbols=option_symbols, execution_ready_by_symbol=dict(getattr(ctx, "execution_ready_by_symbol", {}) or {}))
 
@@ -7714,10 +7779,38 @@ def _commit_active_dynamic_basket(
     mdm_set = getattr(getattr(ctx, "market_data_manager", None), "set_active_contract_basket", None)
     if callable(mdm_set):
         mdm_set(committed)
-    _hydrate_committed_active_basket(ctx, reason="active_dynamic_basket_commit")
     hub_set = getattr(getattr(ctx, "data_hub", None), "set_active_contract_basket", None)
     if callable(hub_set):
         hub_set(committed)
+    mdm = getattr(ctx, "market_data_manager", None)
+    desired_count_fn = getattr(mdm, "desired_token_count", None)
+    ws_count_fn = getattr(mdm, "ws_token_count", None)
+    desired_token_count = int(desired_count_fn()) if callable(desired_count_fn) else len(committed.get("all_tokens") or [])
+    ws_count_value = ws_count_fn() if callable(ws_count_fn) else None
+    ws_token_count = int(ws_count_value) if ws_count_value is not None else None
+    selected_ce_token = token_by_symbol.get(str(selected_ce)) if selected_ce else None
+    selected_pe_token = token_by_symbol.get(str(selected_pe)) if selected_pe else None
+    if selected_ce and selected_ce_token is None:
+        ctx.live_orders_armed = False
+        ctx.trading_ready = False
+        ctx.live_block_reason = "option_token_missing:selected_ce"
+    if selected_pe and selected_pe_token is None:
+        ctx.live_orders_armed = False
+        ctx.trading_ready = False
+        ctx.live_block_reason = "option_token_missing:selected_pe"
+    LOGGER.info(
+        "ACTIVE_BASKET_SUBSCRIPTION_RECONCILED selected_ce=%s selected_ce_token=%s selected_pe=%s selected_pe_token=%s futures_symbol=%s futures_token=%s desired_token_count=%s ws_token_count=%s",
+        selected_ce,
+        selected_ce_token,
+        selected_pe,
+        selected_pe_token,
+        active_futures_symbol,
+        committed.get("futures_token"),
+        desired_token_count,
+        ws_token_count,
+        extra={"event": "ACTIVE_BASKET_SUBSCRIPTION_RECONCILED", "selected_ce": selected_ce, "selected_ce_token": selected_ce_token, "selected_pe": selected_pe, "selected_pe_token": selected_pe_token, "futures_symbol": active_futures_symbol, "futures_token": committed.get("futures_token"), "desired_token_count": desired_token_count, "ws_token_count": ws_token_count},
+    )
+    _hydrate_committed_active_basket(ctx, reason="active_dynamic_basket_commit")
     LOGGER.info(
         "ACTIVE_CONTRACT_BASKET_COMMITTED selected_ce=%s selected_pe=%s futures_symbol=%s atm_strike=%s option_count=%d token_count=%d",
         selected_ce, selected_pe, active_futures_symbol, atm_strike, len(current_options), len(committed.get("all_tokens") or []),
@@ -7805,22 +7898,29 @@ async def _deferred_basket_hydration_retry(
         await asyncio.sleep(delay_seconds)
         if getattr(ctx, "trading_ready", False) and getattr(ctx, "live_orders_armed", False):
             return
+        LOGGER.info(
+            "DEFERRED_BASKET_RETRY_STARTED attempt=%d/%d",
+            attempt,
+            max_attempts,
+            extra={"event": "DEFERRED_BASKET_RETRY_STARTED", "attempt": attempt, "max_attempts": max_attempts},
+        )
         try:
             spot_ltp = await _wait_for_live_spot_or_raise(
                 ctx,
                 timeout=min(10.0, float(policy.startup_wait_for_ws_spot_seconds or 60.0)),
                 configured_mode=configured_mode,
             )
-        except RuntimeError:
+        except RuntimeError as exc:
             LOGGER.info(
-                "DEFERRED_BASKET_RETRY_WAITING attempt=%d/%d reason=no_fresh_ws_spot",
+                "DEFERRED_BASKET_RETRY_FAILED attempt=%d/%d reason=%s",
                 attempt,
                 max_attempts,
+                str(exc) or "spot_ltp_unavailable",
                 extra={
-                    "event": "DEFERRED_BASKET_RETRY_WAITING",
+                    "event": "DEFERRED_BASKET_RETRY_FAILED",
                     "attempt": attempt,
                     "max_attempts": max_attempts,
-                    "reason": "no_fresh_ws_spot",
+                    "reason": str(exc) or "spot_ltp_unavailable",
                 },
             )
             continue
@@ -7831,6 +7931,15 @@ async def _deferred_basket_hydration_retry(
                 spot_ltp=float(spot_ltp),
                 configured_mode=configured_mode,
             )
+            if isinstance(basket, Mapping) and basket.get("deferred"):
+                LOGGER.info(
+                    "DEFERRED_BASKET_RETRY_FAILED attempt=%d/%d reason=%s",
+                    attempt,
+                    max_attempts,
+                    basket.get("reason") or "basket_build_deferred",
+                    extra={"event": "DEFERRED_BASKET_RETRY_FAILED", "attempt": attempt, "max_attempts": max_attempts, "reason": basket.get("reason") or "basket_build_deferred"},
+                )
+                continue
             if basket and not getattr(ctx, "selected_ce", None):
                 _commit_active_dynamic_basket(
                     ctx,
@@ -7859,16 +7968,16 @@ async def _deferred_basket_hydration_retry(
             return
         except Exception as exc:  # noqa: BLE001
             LOGGER.warning(
-                "DEFERRED_BASKET_HYDRATION_FAILED attempt=%d/%d error=%s",
+                "DEFERRED_BASKET_RETRY_FAILED attempt=%d/%d reason=%s",
                 attempt,
                 max_attempts,
                 exc,
                 exc_info=True,
                 extra={
-                    "event": "DEFERRED_BASKET_HYDRATION_FAILED",
+                    "event": "DEFERRED_BASKET_RETRY_FAILED",
                     "attempt": attempt,
                     "max_attempts": max_attempts,
-                    "error": str(exc),
+                    "reason": str(exc),
                 },
             )
     LOGGER.error(
@@ -8029,7 +8138,7 @@ def _schedule_deferred_basket_retry(ctx: BotContext, *, configured_mode: str, re
     ctx.trading_ready = False
     ctx.readiness_mode = "DATA_WARMUP"
     ctx.effective_mode = ctx.readiness_mode
-    ctx.live_block_reason = "fresh_ws_spot_unavailable"
+    ctx.live_block_reason = "spot_ltp_unavailable" if reason == "spot_ltp_unavailable" else "fresh_ws_spot_unavailable"
     if bool(getattr(ctx, "deferred_basket_retry_started", False)):
         LOGGER.info("DEFERRED_BASKET_RETRY_SCHEDULED reason=%s spot_ltp=%s already_scheduled=%s", reason, spot_ltp, True)
         return
@@ -8048,7 +8157,7 @@ def _schedule_deferred_basket_retry(ctx: BotContext, *, configured_mode: str, re
         reason,
         spot_ltp,
         extra={
-            "event": "BASKET_BUILD_DEFERRED",
+            "event": "DEFERRED_BASKET_RETRY_SCHEDULED",
             "reason": reason,
         },
     )
@@ -8196,7 +8305,13 @@ async def startup_sequence(ctx: BotContext) -> None:
                 def _startup_spot_tick_listener(tick: Mapping[str, Any]) -> None:
                     try:
                         symbol = str(tick.get("symbol") or "").upper()
-                        if symbol != policy.nifty_internal_symbol:
+                        token_raw = tick.get("instrument_token") or tick.get("token")
+                        try:
+                            token_int = int(token_raw) if token_raw is not None else None
+                        except (TypeError, ValueError):
+                            token_int = None
+                        spot_aliases = {policy.nifty_internal_symbol, "NIFTY", "NIFTY 50", "NSE:NIFTY50", "NIFTY50"}
+                        if symbol not in spot_aliases and token_int != int(policy.nifty_spot_token):
                             return
                         if ctx.startup_spot_refresh_done:
                             return
@@ -8353,7 +8468,7 @@ async def startup_sequence(ctx: BotContext) -> None:
                 ctx.websocket_enabled,
                 symbol=policy.nifty_internal_symbol, token=policy.nifty_spot_token, desired_token_count=desired_tokens, ws_token_count=ws_status.get("tokens"), websocket_enabled=ctx.websocket_enabled, phase="spot_first",
             )
-            spot_wait_seconds = float(os.getenv("STARTUP_WAIT_FOR_WS_SPOT_SECONDS", "8"))
+            spot_wait_seconds = float(os.getenv("STARTUP_SPOT_WS_PROOF_TIMEOUT_SEC", os.getenv("STARTUP_WAIT_FOR_WS_SPOT_SECONDS", "10")))
             mode = str(getattr(ctx, "effective_mode", None) or os.getenv("EXECUTION_MODE", "PAPER")).upper()
             live_mode = mode == "LIVE" or str(os.getenv("ENABLE_LIVE", "false")).lower() in {"1", "true", "yes", "on"}
             try:
@@ -8380,8 +8495,39 @@ async def startup_sequence(ctx: BotContext) -> None:
                 elif live_mode and get_market_state() == MarketState.OPEN:
                     ctx.live_orders_armed = False
                     ctx.trading_ready = False
-                    ctx.live_block_reason = "fresh_spot_tick_missing"
-                    raise RuntimeError("fresh NIFTY WebSocket spot tick unavailable")
+                    ctx.live_block_reason = "spot_ltp_unavailable"
+                    LOGGER.warning(
+                        "STARTUP_SPOT_PROOF_TIMEOUT symbol=%s timeout=%.2f reason=ws_tick_missing",
+                        policy.nifty_internal_symbol,
+                        spot_wait_seconds,
+                        extra={"event": "STARTUP_SPOT_PROOF_TIMEOUT", "symbol": policy.nifty_internal_symbol, "timeout": spot_wait_seconds, "reason": "ws_tick_missing"},
+                    )
+                    rest_spot = _resolve_startup_rest_spot_ltp(
+                        ctx,
+                        max_age_seconds=policy.startup_spot_max_age_seconds,
+                    )
+                    if rest_spot and rest_spot > 0:
+                        ctx.live_block_reason = "live_option_quote_required_after_rest_spot_fallback"
+                        LOGGER.info(
+                            "STARTUP_SPOT_REST_FALLBACK_USED symbol=%s price=%.2f live_orders_armed=%s",
+                            policy.nifty_internal_symbol,
+                            float(rest_spot),
+                            bool(getattr(ctx, "live_orders_armed", False)),
+                            extra={"event": "STARTUP_SPOT_REST_FALLBACK_USED", "symbol": policy.nifty_internal_symbol, "price": float(rest_spot), "live_orders_armed": bool(getattr(ctx, "live_orders_armed", False))},
+                        )
+                        await _build_and_hydrate_live_basket_from_spot(
+                            ctx,
+                            spot_ltp=float(rest_spot),
+                            configured_mode=mode,
+                            hydrate=True,
+                        )
+                    else:
+                        _schedule_deferred_basket_retry(
+                            ctx,
+                            configured_mode=mode,
+                            reason="spot_ltp_unavailable",
+                            spot_ltp=None,
+                        )
                 elif live_mode:
                     ctx.live_orders_armed = False
                     ctx.trading_ready = False
@@ -8406,8 +8552,16 @@ async def startup_sequence(ctx: BotContext) -> None:
                         },
                     )
             except RuntimeError as exc:
+                ctx.live_orders_armed = False
+                ctx.trading_ready = False
+                ctx.live_block_reason = str(exc) or "spot_ltp_unavailable"
                 LOGGER.error("STARTUP_WS_SPOT_PROOF_BLOCKED_LIVE symbol=%s reason=%s", policy.nifty_internal_symbol, exc, extra={"event": "STARTUP_WS_SPOT_PROOF_BLOCKED_LIVE", "symbol": policy.nifty_internal_symbol, "reason": str(exc)})
-                raise
+                _schedule_deferred_basket_retry(
+                    ctx,
+                    configured_mode=mode,
+                    reason=str(exc) or "spot_ltp_unavailable",
+                    spot_ltp=None,
+                )
         except Exception as _ws_spot_first_exc:  # noqa: BLE001
             is_live_configured = str(os.getenv("EXECUTION_MODE", "PAPER")).strip().upper() == "LIVE" or str(os.getenv("ENABLE_LIVE", "false")).strip().lower() in {"1", "true", "yes", "on"}
             if is_live_configured and get_market_state() == MarketState.OPEN:

--- a/tests/core/test_startup_spot_watchdog.py
+++ b/tests/core/test_startup_spot_watchdog.py
@@ -1,0 +1,243 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from nifty_scalper_bot.core import app
+
+
+class _Mdm:
+    def __init__(self, cached_ltp: float = 0.0, hydration: dict[str, Any] | None = None) -> None:
+        self.cached_ltp = cached_ltp
+        self.calls: list[tuple[str, Any]] = []
+        self.desired: set[int] = set()
+        self.hydration = hydration or {"hard_ready": False, "missing": ["NFO:CE:quote_missing"], "symbols": {}}
+
+    async def wait_for_fresh_spot_tick(self, *_a: Any, **_k: Any) -> None:
+        return None
+
+    def get_cached_ltp(self, *_a: Any, **_k: Any) -> float:
+        return self.cached_ltp
+
+    def set_active_contract_basket(self, basket: dict[str, Any]) -> None:
+        self.calls.append(("set_active_contract_basket", basket))
+        self.desired.update(int(t) for t in basket.get("all_tokens", []) if t)
+
+    def hydrate_active_contract_basket(self, basket: dict[str, Any]) -> dict[str, Any]:
+        self.calls.append(("hydrate_active_contract_basket", basket))
+        return self.hydration
+
+    def register_symbol(self, symbol: str, token: int) -> None:
+        self.calls.append(("register_symbol", (symbol, token)))
+
+    def request_token_subscription(self, token: int, *, symbol: str | None = None) -> bool:
+        self.calls.append(("request_token_subscription", (symbol, token)))
+        self.desired.add(int(token))
+        return True
+
+    def desired_token_count(self) -> int:
+        return len(self.desired)
+
+    def ws_token_count(self) -> int:
+        return len(self.desired)
+
+    def get_hydration_report(self) -> dict[str, Any]:
+        return self.hydration
+
+    def get_symbol_snapshot(self, symbol: str) -> SimpleNamespace:
+        return SimpleNamespace(ltp=25000.0 if symbol == "NSE:NIFTY" else 100.0, tick_age_s=0.1, bid=99.0, ask=101.0, tradable_quote=True, depth_available=True)
+
+    def has_ws_tradable_quote(self, _symbols: Any) -> bool:
+        return True
+
+    def get_ohlc_bars(self, _symbol: str) -> list[dict[str, float]]:
+        return [{"close": 100.0}] * 40
+
+
+class _Runner:
+    def __init__(self) -> None:
+        self._active_symbols: set[str] = set()
+        self._running = False
+        self.symbols: list[str] = []
+        self.universe: dict[str, Any] | None = None
+        self.readiness: dict[str, Any] | None = None
+
+    def add_symbol(self, symbol: str) -> None:
+        self.symbols.append(symbol)
+        self._active_symbols.add(symbol)
+
+    def set_active_trading_universe(self, universe: dict[str, Any]) -> None:
+        self.universe = universe
+
+    def set_runtime_readiness(self, **kwargs: Any) -> None:
+        self.readiness = kwargs
+
+    def on_datahub_tick(self, *_a: Any, **_k: Any) -> None:
+        return None
+
+
+def _basket() -> dict[str, Any]:
+    return {
+        "spot_symbol": "NSE:NIFTY",
+        "spot_token": 256265,
+        "futures_symbol": "NFO:NIFTY26JUNFUT",
+        "futures_token": 1001,
+        "selected_ce": "NFO:NIFTY26JUN25000CE",
+        "selected_pe": "NFO:NIFTY26JUN25000PE",
+        "atm_ce": "NFO:NIFTY26JUN25000CE",
+        "atm_pe": "NFO:NIFTY26JUN25000PE",
+        "option_symbols": ["NFO:NIFTY26JUN25000CE", "NFO:NIFTY26JUN25000PE"],
+        "ce_symbols": ["NFO:NIFTY26JUN25000CE"],
+        "pe_symbols": ["NFO:NIFTY26JUN25000PE"],
+        "symbols": ["NSE:NIFTY", "NFO:NIFTY26JUNFUT", "NFO:NIFTY26JUN25000CE", "NFO:NIFTY26JUN25000PE"],
+        "all_symbols": ["NSE:NIFTY", "NFO:NIFTY26JUNFUT", "NFO:NIFTY26JUN25000CE", "NFO:NIFTY26JUN25000PE"],
+        "all_tokens": [256265, 1001, 2001, 2002],
+        "option_tokens": [2001, 2002],
+        "token_by_symbol": {
+            "NSE:NIFTY": 256265,
+            "NFO:NIFTY26JUNFUT": 1001,
+            "NFO:NIFTY26JUN25000CE": 2001,
+            "NFO:NIFTY26JUN25000PE": 2002,
+        },
+        "symbol_by_token": {256265: "NSE:NIFTY", 1001: "NFO:NIFTY26JUNFUT", 2001: "NFO:NIFTY26JUN25000CE", 2002: "NFO:NIFTY26JUN25000PE"},
+        "atm_strike": 25000,
+    }
+
+
+def _ctx(mdm: _Mdm) -> SimpleNamespace:
+    runner = _Runner()
+    return SimpleNamespace(
+        active_trading_universe={},
+        active_contract_basket=None,
+        active_symbol_tokens={},
+        selected_ce=None,
+        selected_pe=None,
+        atm_ce_symbol=None,
+        atm_pe_symbol=None,
+        market_data_manager=mdm,
+        data_hub=SimpleNamespace(set_active_contract_basket=lambda basket: None, subscribe_ticks=lambda *_a, **_k: None),
+        strategy_runner=runner,
+        strategy_manager=None,
+        option_universe=None,
+        instrument_manager=SimpleNamespace(is_loaded=lambda: True, get_token=lambda symbol: _basket()["token_by_symbol"][symbol]),
+        broker_client=SimpleNamespace(get_instrument_token=lambda symbol: _basket()["token_by_symbol"].get(symbol, 256265)),
+        settings=SimpleNamespace(option_universe=SimpleNamespace(strike_step=50), execution_mode="LIVE"),
+        live_orders_armed=True,
+        trading_ready=True,
+        message_bus=SimpleNamespace(running=True),
+        data_observation_ready=False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_spot_ws_timeout_uses_rest_fallback_for_basket_build(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+    mdm = _Mdm(cached_ltp=25000.0)
+    ctx = _ctx(mdm)
+    monkeypatch.setattr(app, "_build_canonical_active_basket", lambda **_k: _basket())
+    caplog.set_level("INFO", logger="nifty_scalper_bot.core.app")
+
+    spot = await app._wait_for_live_spot_or_raise(ctx, timeout=0.01, configured_mode="LIVE")
+    await app._build_and_hydrate_live_basket_from_spot(ctx, spot_ltp=spot, configured_mode="LIVE", hydrate=True)
+
+    assert ctx.active_contract_basket["selected_ce"] == "NFO:NIFTY26JUN25000CE"
+    assert ctx.live_orders_armed is False
+    assert "STARTUP_SPOT_REST_FALLBACK_USED" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_spot_first_tick_routes_to_live_basket_build(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+    class TickMdm(_Mdm):
+        def get_fresh_spot_tick(self, *_a: Any, **_k: Any) -> dict[str, Any]:
+            return {"symbol": "NSE:NIFTY", "last_price": 25000.0, "source": "ws"}
+
+    ctx = _ctx(TickMdm())
+    monkeypatch.setattr(app, "_build_canonical_active_basket", lambda **_k: _basket())
+    caplog.set_level("INFO", logger="nifty_scalper_bot.core.app")
+
+    await app._refresh_readiness_after_first_tick(ctx, reason="first_spot_tick_listener")
+
+    assert ctx.active_contract_basket["selected_pe"] == "NFO:NIFTY26JUN25000PE"
+    assert "LIVE_BASKET_BUILD_STARTED" in caplog.text
+    assert "ACTIVE_CONTRACT_BASKET_COMMITTED" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_instrument_manager_not_ready_defers_then_retries(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+    ctx = _ctx(_Mdm(cached_ltp=25000.0))
+    loaded = {"value": False}
+    ctx.instrument_manager = SimpleNamespace(is_loaded=lambda: loaded["value"], get_token=lambda symbol: _basket()["token_by_symbol"][symbol])
+    scheduled: list[Any] = []
+    monkeypatch.setattr(app, "_build_canonical_active_basket", lambda **_k: _basket())
+    monkeypatch.setattr(app, "_ensure_strategy_runner_started", lambda *_a, **_k: asyncio.sleep(0))
+    monkeypatch.setattr(app, "_create_named_task", lambda coro, *, name: scheduled.append(coro) or SimpleNamespace(add_done_callback=lambda *_a: None))
+    caplog.set_level("INFO", logger="nifty_scalper_bot.core.app")
+
+    first = await app._build_and_hydrate_live_basket_from_spot(ctx, spot_ltp=25000.0, configured_mode="LIVE")
+    assert first["deferred"] is True
+    loaded["value"] = True
+    await app._deferred_basket_hydration_retry(ctx, configured_mode="LIVE", max_attempts=1, delay_seconds=0)
+
+    assert ctx.active_contract_basket["selected_ce"] == "NFO:NIFTY26JUN25000CE"
+    assert "LIVE_BASKET_BUILD_DEFERRED" in caplog.text
+    assert "DEFERRED_BASKET_RETRY_SUCCESS" in caplog.text
+    for coro in scheduled:
+        coro.close()
+
+
+def test_selected_option_tokens_subscribed_after_basket_commit(caplog: pytest.LogCaptureFixture) -> None:
+    mdm = _Mdm()
+    ctx = _ctx(mdm)
+    caplog.set_level("INFO", logger="nifty_scalper_bot.core.app")
+
+    app._commit_active_dynamic_basket(ctx, basket=_basket(), option_symbols=_basket()["option_symbols"], symbols=_basket()["symbols"], atm_strike=25000)
+
+    assert {2001, 2002}.issubset(mdm.desired)
+    assert "ACTIVE_BASKET_SUBSCRIPTION_RECONCILED" in caplog.text
+
+
+def test_hydration_runs_after_basket_commit() -> None:
+    mdm = _Mdm(hydration={"hard_ready": False, "missing": ["NFO:NIFTY26JUN25000CE:quote_missing"], "symbols": {}})
+    ctx = _ctx(mdm)
+
+    app._commit_active_dynamic_basket(ctx, basket=_basket(), option_symbols=_basket()["option_symbols"], symbols=_basket()["symbols"], atm_strike=25000)
+
+    call_names = [name for name, _ in mdm.calls]
+    assert call_names.index("set_active_contract_basket") < call_names.index("hydrate_active_contract_basket")
+    assert ctx.active_basket_hydration["hard_ready"] is False
+    assert ctx.live_orders_armed is False
+
+
+@pytest.mark.asyncio
+async def test_live_readiness_receives_selected_option_context(monkeypatch: pytest.MonkeyPatch) -> None:
+    mdm = _Mdm(hydration={"hard_ready": True, "missing": [], "symbols": {}})
+    ctx = _ctx(mdm)
+    app._commit_active_dynamic_basket(ctx, basket=_basket(), option_symbols=_basket()["option_symbols"], symbols=_basket()["symbols"], atm_strike=25000)
+    monkeypatch.setattr(app, "_ensure_selected_options_hydrated", lambda *_a, **_k: asyncio.sleep(0))
+    monkeypatch.setattr(app, "_runner_is_running", lambda _runner: True)
+
+    await app._recompute_and_push_runtime_readiness(ctx, reason="active_basket_hydrated")
+
+    assert ctx.strategy_runner.readiness["selected_ce"] == "NFO:NIFTY26JUN25000CE"
+    assert ctx.strategy_runner.readiness["selected_pe"] == "NFO:NIFTY26JUN25000PE"
+    assert "NFO:NIFTY26JUN25000CE" in ctx.strategy_runner.readiness["option_symbols"]
+
+
+@pytest.mark.asyncio
+async def test_no_silent_wait_after_startup_spot_token_request(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+    ctx = _ctx(_Mdm(cached_ltp=0.0))
+    tasks: list[Any] = []
+    monkeypatch.setattr(app, "_create_named_task", lambda coro, *, name: tasks.append((name, coro)) or SimpleNamespace(add_done_callback=lambda *_a: None))
+    caplog.set_level("INFO", logger="nifty_scalper_bot.core.app")
+
+    with pytest.raises(RuntimeError, match="spot_ltp_unavailable"):
+        await app._wait_for_live_spot_or_raise(ctx, timeout=0.01, configured_mode="LIVE")
+    app._schedule_deferred_basket_retry(ctx, configured_mode="LIVE", reason="spot_ltp_unavailable")
+
+    assert ctx.live_block_reason == "spot_ltp_unavailable"
+    assert tasks and tasks[0][0] == "deferred_basket_hydration_retry"
+    assert "STARTUP_SPOT_PROOF_TIMEOUT" in caplog.text
+    # prevent un-awaited coroutine warnings from the captured scheduled retry
+    tasks[0][1].close()

--- a/tests/core/test_startup_spot_watchdog.py
+++ b/tests/core/test_startup_spot_watchdog.py
@@ -144,7 +144,25 @@ async def test_spot_ws_timeout_uses_rest_fallback_for_basket_build(monkeypatch: 
 
     assert ctx.active_contract_basket["selected_ce"] == "NFO:NIFTY26JUN25000CE"
     assert ctx.live_orders_armed is False
+    assert ctx.live_block_reason is not None
     assert "STARTUP_SPOT_REST_FALLBACK_USED" in caplog.text
+
+
+def test_rest_fallback_get_ltp_runtime_error_does_not_crash(caplog: pytest.LogCaptureFixture) -> None:
+    class RuntimeMdm(_Mdm):
+        def get_cached_ltp(self, *_a: Any, **_k: Any) -> float:
+            return 0.0
+
+        def get_ltp(self, *_a: Any, **_k: Any) -> float:
+            raise RuntimeError("broker_unavailable")
+
+        def refresh_quote_now(self, *_a: Any, **_k: Any) -> dict[str, float]:
+            return {"last_price": 25000.0}
+
+    caplog.set_level("WARNING", logger="nifty_scalper_bot.core.app")
+    assert app._resolve_startup_rest_spot_ltp(_ctx(RuntimeMdm())) == 25000.0
+    assert "STARTUP_SPOT_REST_FALLBACK_FAILED stage=get_ltp" in caplog.text
+    assert "RuntimeError" in caplog.text
 
 
 @pytest.mark.asyncio
@@ -196,6 +214,51 @@ def test_selected_option_tokens_subscribed_after_basket_commit(caplog: pytest.Lo
 
     assert {2001, 2002}.issubset(mdm.desired)
     assert "ACTIVE_BASKET_SUBSCRIPTION_RECONCILED" in caplog.text
+
+
+def test_selected_option_token_resolution_accepts_bare_token_map(caplog: pytest.LogCaptureFixture) -> None:
+    basket = _basket()
+    basket["token_by_symbol"] = {
+        "NIFTY26JUN25000CE": 2001,
+        "NIFTY26JUN25000PE": 2002,
+        "NSE:NIFTY": 256265,
+        "NFO:NIFTY26JUNFUT": 1001,
+    }
+    basket["all_tokens"] = []
+    mdm = _Mdm()
+    ctx = _ctx(mdm)
+    ctx.instrument_manager = None
+    ctx.broker_client = None
+    caplog.set_level("INFO", logger="nifty_scalper_bot.core.app")
+
+    app._commit_active_dynamic_basket(ctx, basket=basket, option_symbols=basket["option_symbols"], symbols=basket["symbols"], atm_strike=25000)
+
+    assert ctx.live_block_reason != "option_token_missing:selected_ce"
+    assert ctx.live_block_reason != "option_token_missing:selected_pe"
+    assert {2001, 2002}.issubset(mdm.desired)
+    assert "selected_ce_token=2001" in caplog.text
+    assert "selected_pe_token=2002" in caplog.text
+
+
+def test_selected_option_token_resolution_uses_explicit_selected_tokens(caplog: pytest.LogCaptureFixture) -> None:
+    basket = _basket()
+    basket["token_by_symbol"] = {"NSE:NIFTY": 256265, "NFO:NIFTY26JUNFUT": 1001}
+    basket["all_tokens"] = [256265, 1001]
+    basket["option_tokens"] = []
+    basket["selected_ce_token"] = 2001
+    basket["selected_pe_token"] = 2002
+    mdm = _Mdm()
+    ctx = _ctx(mdm)
+    ctx.instrument_manager = None
+    ctx.broker_client = None
+    caplog.set_level("INFO", logger="nifty_scalper_bot.core.app")
+
+    app._commit_active_dynamic_basket(ctx, basket=basket, option_symbols=basket["option_symbols"], symbols=basket["symbols"], atm_strike=25000)
+
+    assert ctx.live_block_reason != "option_token_missing:selected_ce"
+    assert ctx.live_block_reason != "option_token_missing:selected_pe"
+    assert "selected_ce_token=2001" in caplog.text
+    assert "selected_pe_token=2002" in caplog.text
 
 
 def test_hydration_runs_after_basket_commit() -> None:

--- a/tests/test_no_fake_spot_live.py
+++ b/tests/test_no_fake_spot_live.py
@@ -75,7 +75,25 @@ def test_live_mode_without_fresh_tick_raises(
                 _ctx(mdm), timeout=0.1, configured_mode="LIVE"
             )
         )
-    assert "fresh NIFTY WebSocket spot tick unavailable" in str(excinfo.value)
+    assert "spot_ltp_unavailable" in str(excinfo.value)
+
+
+def test_live_mode_uses_rest_fallback_without_synthetic(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    monkeypatch.setenv("EXECUTION_MODE", "LIVE")
+    mdm = _StubMDM(ws_tick=None, cached_price=24123.45)
+    ctx = _ctx(mdm)
+    with caplog.at_level("INFO"):
+        price = asyncio.run(
+            _wait_for_live_spot_or_raise(
+                ctx, timeout=0.1, configured_mode="LIVE"
+            )
+        )
+    assert price == pytest.approx(24123.45)
+    assert price != _SYNTHETIC_FALLBACK_SPOT
+    assert ctx.live_orders_armed is False
+    assert "STARTUP_SPOT_REST_FALLBACK_USED" in caplog.text
 
 
 def test_paper_mode_falls_back_to_synthetic_with_log(

--- a/tests/test_no_fake_spot_live.py
+++ b/tests/test_no_fake_spot_live.py
@@ -94,6 +94,8 @@ def test_live_mode_uses_rest_fallback_without_synthetic(
     assert price != _SYNTHETIC_FALLBACK_SPOT
     assert ctx.live_orders_armed is False
     assert "STARTUP_SPOT_REST_FALLBACK_USED" in caplog.text
+    assert "STARTUP_SPOT_REST_FALLBACK_READY" in caplog.text
+    assert "LIVE_SPOT_READY symbol=NSE:NIFTY price=24123.45 source=rest_fallback" not in caplog.text
 
 
 def test_paper_mode_falls_back_to_synthetic_with_log(


### PR DESCRIPTION
### Motivation

- The startup path could stop after `STARTUP_SPOT_TOKEN_REQUEST_BEGIN` when a WebSocket NIFTY spot proof did not arrive, blocking ATM option selection and preventing `LIVE_BASKET_BUILD_STARTED` → `ACTIVE_CONTRACT_BASKET_COMMITTED` → hydration → readiness propagation.
- Provide a safe, bounded fallback so the app can proceed to build and hydrate an ActiveContractBasket from cached/REST LTP while preserving execution safety (no automatic arming of live orders).

### Description

- Implemented a REST/cached startup fallback helper ` _resolve_startup_rest_spot_ltp(ctx, ...)` and integrated it into the WS-first flow so a positive cached/REST LTP can be used to build/hydrate the basket while keeping `live_orders_armed=False` (`src/nifty_scalper_bot/core/app.py`).
- Bounded WS wait: introduced `STARTUP_SPOT_WS_PROOF_TIMEOUT_SEC` (default 10s) and explicit `STARTUP_SPOT_PROOF_TIMEOUT` logging when WS proof times out; when REST fallback exists, log `STARTUP_SPOT_REST_FALLBACK_USED` and proceed to hydrate; when none exists schedule deferred retries with `DEFERRED_BASKET_RETRY_SCHEDULED` and `spot_ltp_unavailable` blocker.
- Hardened basket commit flow: after committing `active_contract_basket`, reconcile subscriptions and log `ACTIVE_BASKET_SUBSCRIPTION_RECONCILED` with selected CE/PE tokens and token counts, block readiness with `option_token_missing:*` if selected option tokens are unresolved, then call MDM hydrate (`_hydrate_committed_active_basket`).
- Made startup spot tick listener tolerant to common NIFTY aliases and token-only spot ticks so first WS spot proof is not ignored (checks symbol aliases and `instrument_token`).
- Improved deferred retry diagnostics and behavior: add `DEFERRED_BASKET_RETRY_STARTED`, refine failure logs, and detect deferred basket returns to avoid treating them as success.
- Expanded readiness logging in `_recompute_and_push_runtime_readiness` to include `trading_ready`, quote-ready flags and direction-context readiness for clearer diagnostics.
- Tests: added/updated focused unit tests that cover WS timeout REST fallback, first-spot tick routing to basket build, instrument-manager-deferral-and-retry, subscription reconciliation, hydration ordering, readiness propagation, and no-silent-wait behavior (`tests/core/test_startup_spot_watchdog.py` and minor updates in `tests/test_no_fake_spot_live.py`).

Files changed:
- Modified: `src/nifty_scalper_bot/core/app.py` (spot-first watchdog, REST fallback resolver, commit/reconcile/hydration orchestration, logging & retry handling)
- Added: `tests/core/test_startup_spot_watchdog.py` (focused startup-to-trade-path tests)
- Modified: `tests/test_no_fake_spot_live.py` (adjusted assertions for new behavior)

What did not change:
- Strategy scoring, selector files, OptionUniverseManager legacy behavior, and execution/risk gates were not weakened; REST fallback never arms live orders by itself.

### Testing

- Commands run: `python -m compileall -q src` and `pytest -q` (focused and full suite runs described below).
- Focused test runs (all passed):
  - `pytest -q tests/core/test_basket_commit_before_readiness.py` — passed
  - `pytest -q tests/core/test_commit_active_dynamic_basket.py` — passed
  - `pytest -q tests/core/test_readiness_live_tick_proof.py` — passed
  - `pytest -q tests/test_runner_start_after_first_spot_tick.py` — passed
  - `pytest -q tests/test_live_basket_hydration.py` — passed
  - `pytest -q tests/test_live_tick_pipeline_to_runner.py` — passed
  - `pytest -q tests/data/test_mdm_subscribes_active_basket.py` — passed
  - `pytest -q tests/options/test_strike_selector_ssot.py` — passed
  - `pytest -q tests/strategies/test_runner_live_path_guards.py` — passed
  - `pytest -q tests/core/test_startup_spot_watchdog.py` — passed
  - `pytest -q tests/test_no_fake_spot_live.py` — passed
- Full test suite: `pytest -q` completed successfully in the environment used for validation.

All compile and test checks passed; runtime behavior now logs a clear startup timeout/fallback path, builds/hydrates the active basket when cached/REST spot is available, and preserves execution safety by keeping `live_orders_armed` false until live option quote/depth readiness is satisfied.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d171d94088324a8243c81e126fbb3)