### PR TITLE
Use ActiveContractBasket for symbol resolution; add startup REST spot fallback and InstrumentManager SSOT integration

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -2285,6 +2285,8 @@ class BotContext:
     atm_ce_symbol: str | None = None
     atm_pe_symbol: str | None = None
     active_trading_universe: dict[str, Any] = field(default_factory=dict)
+    active_contract_basket: dict[str, object] | None = None
+    active_basket_hydration: dict[str, object] | None = None
     message_bus_tick_subscribed: bool = False
     datahub_runner_subscriptions: set[str] = field(default_factory=set)
     execution_locked_symbols: set[str] = field(default_factory=set)
@@ -2935,16 +2937,106 @@ def _find_existing_nifty_option_symbol(
     return None
 
 
+def _option_symbols_from_active_basket(basket: Mapping[str, Any] | Any | None) -> list[str]:
+    """Extract authoritative option symbols from an ActiveContractBasket."""
+    if basket is None:
+        return []
+
+    def _get(key: str, default: Any = None) -> Any:
+        if isinstance(basket, Mapping):
+            return basket.get(key, default)
+        return getattr(basket, key, default)
+
+    sources: list[Any] = []
+    option_symbols = _get("option_symbols")
+    if option_symbols:
+        sources.append(option_symbols)
+    else:
+        ce_symbols = _get("ce_symbols") or []
+        pe_symbols = _get("pe_symbols") or []
+        if ce_symbols or pe_symbols:
+            sources.extend([ce_symbols, pe_symbols])
+        else:
+            sources.append([_get("selected_ce"), _get("selected_pe")])
+
+    symbols: list[str] = []
+    for source in sources:
+        if isinstance(source, (str, bytes)):
+            iterable = [source]
+        else:
+            iterable = list(source or [])
+        for sym in iterable:
+            text = str(sym).strip() if sym is not None else ""
+            if text and text.upper().endswith(("CE", "PE")):
+                symbols.append(text)
+    return list(dict.fromkeys(symbols))
+
+
+def _active_basket_for_symbol_resolution(
+    explicit_basket: Mapping[str, Any] | Any | None,
+    market_data_manager: MarketDataManager | None,
+) -> Mapping[str, Any] | Any | None:
+    """Find the already-committed ActiveContractBasket without invoking selectors."""
+    if explicit_basket is not None:
+        return explicit_basket
+    ctx = _LATEST_CTX
+    if ctx is not None:
+        basket = getattr(ctx, "active_contract_basket", None) or getattr(ctx, "active_trading_universe", None)
+        if basket:
+            return basket
+        hub = getattr(ctx, "data_hub", None)
+        hub_get = getattr(hub, "get_active_contract_basket", None)
+        if callable(hub_get):
+            basket = hub_get()
+            if basket:
+                return basket
+        mdm = getattr(ctx, "market_data_manager", None)
+        mdm_get = getattr(mdm, "get_active_contract_basket", None)
+        if callable(mdm_get):
+            basket = mdm_get()
+            if basket:
+                return basket
+    mdm_get = getattr(market_data_manager, "get_active_contract_basket", None)
+    if callable(mdm_get):
+        return mdm_get()
+    return None
+
+
 def _get_symbols(
     config: AppConfig,
     resolver: Any | None = None,
     broker: Any | None = None,
     option_universe: OptionUniverseManager | None = None,
     market_data_manager: MarketDataManager | None = None,
+    active_contract_basket: Mapping[str, Any] | Any | None = None,
 ) -> list[str]:
     """Return validated option symbols for trading."""
     LOGGER.info("=" * 60)
     LOGGER.info("🔍 _get_symbols() STARTING - Symbol Resolution")
+
+    basket = _active_basket_for_symbol_resolution(active_contract_basket, market_data_manager)
+    basket_symbols = _option_symbols_from_active_basket(basket)
+    if basket_symbols:
+        if option_universe is not None and hasattr(option_universe, "set_active_contract_basket"):
+            option_universe.set_active_contract_basket(basket)
+        LOGGER.info(
+            "SYMBOL_RESOLUTION_ACTIVE_BASKET_USED count=%d selected_ce=%s selected_pe=%s",
+            len(basket_symbols),
+            getattr(basket, "selected_ce", None) if not isinstance(basket, Mapping) else basket.get("selected_ce"),
+            getattr(basket, "selected_pe", None) if not isinstance(basket, Mapping) else basket.get("selected_pe"),
+            extra={"event": "SYMBOL_RESOLUTION_ACTIVE_BASKET_USED", "count": len(basket_symbols)},
+        )
+        LOGGER.info("🎯 FINAL SYMBOLS TO TRADE: %s", basket_symbols)
+        LOGGER.info("=" * 60)
+        return basket_symbols
+
+    execution_mode = str(os.getenv("EXECUTION_MODE") or os.getenv("MODE") or getattr(config, "execution_mode", "") or "").upper()
+    if execution_mode == "LIVE":
+        LOGGER.warning(
+            "SYMBOL_RESOLUTION_BLOCKED reason=ACTIVE_BASKET_MISSING stage=_get_symbols",
+            extra={"event": "SYMBOL_RESOLUTION_BLOCKED", "reason": "ACTIVE_BASKET_MISSING", "stage": "_get_symbols"},
+        )
+        return []
 
     symbols = getattr(config, "symbols", None)
     if symbols:
@@ -6289,6 +6381,90 @@ def _coerce_spot_price(tick: Mapping[str, Any] | None) -> float | None:
     return None
 
 
+def _resolve_startup_rest_spot_ltp(ctx: BotContext, *, stage_prefix: str = "startup_spot") -> float | None:
+    """Resolve startup spot from cache/REST without treating it as WS proof."""
+    policy = MarketDataPolicy.from_env()
+    mdm = getattr(ctx, "market_data_manager", None)
+    if mdm is None:
+        return None
+
+    cached_fn = getattr(mdm, "get_cached_ltp", None)
+    if callable(cached_fn):
+        try:
+            cached = float(
+                cached_fn(
+                    policy.nifty_internal_symbol,
+                    max_age_seconds=policy.startup_spot_max_age_seconds,
+                    require_ws=False,
+                )
+                or 0.0
+            )
+            if cached > 0:
+                return cached
+        except (TypeError, ValueError, RuntimeError) as exc:
+            LOGGER.warning(
+                "STARTUP_SPOT_REST_FALLBACK_FAILED stage=%s reason=%s",
+                "get_cached_ltp",
+                type(exc).__name__,
+                extra={
+                    "event": "STARTUP_SPOT_REST_FALLBACK_FAILED",
+                    "stage": "get_cached_ltp",
+                    "reason": type(exc).__name__,
+                },
+            )
+
+    get_ltp_fn = getattr(mdm, "get_ltp", None)
+    if callable(get_ltp_fn):
+        for stage, call in (
+            (
+                "get_ltp",
+                lambda: get_ltp_fn(
+                    policy.nifty_internal_symbol, allow_rest_fallback=True
+                ),
+            ),
+            ("get_ltp_fallback", lambda: get_ltp_fn(policy.nifty_internal_symbol)),
+        ):
+            try:
+                value = call()
+                if isinstance(value, Mapping):
+                    price = _coerce_spot_price(value)
+                else:
+                    price = float(value or 0.0)
+                if price and price > 0:
+                    return float(price)
+            except (TypeError, ValueError, RuntimeError) as exc:
+                LOGGER.warning(
+                    "STARTUP_SPOT_REST_FALLBACK_FAILED stage=%s reason=%s",
+                    stage,
+                    type(exc).__name__,
+                    extra={
+                        "event": "STARTUP_SPOT_REST_FALLBACK_FAILED",
+                        "stage": stage,
+                        "reason": type(exc).__name__,
+                    },
+                )
+
+    refresh_fn = getattr(mdm, "refresh_quote_now", None)
+    if callable(refresh_fn):
+        try:
+            payload = refresh_fn(policy.nifty_internal_symbol)
+            price = _coerce_spot_price(payload if isinstance(payload, Mapping) else None)
+            if price and price > 0:
+                return float(price)
+        except (TypeError, ValueError, RuntimeError) as exc:
+            LOGGER.warning(
+                "STARTUP_SPOT_REST_FALLBACK_FAILED stage=%s reason=%s",
+                "refresh_quote_now",
+                type(exc).__name__,
+                extra={
+                    "event": "STARTUP_SPOT_REST_FALLBACK_FAILED",
+                    "stage": "refresh_quote_now",
+                    "reason": type(exc).__name__,
+                },
+            )
+    return None
+
+
 async def _wait_for_live_spot_or_raise(
     ctx: BotContext,
     *,
@@ -6392,38 +6568,51 @@ async def _wait_for_live_spot_or_raise(
             extra={"event": "SPOT_REST_USED_FOR_LIVE_STARTUP", "symbol": policy.nifty_internal_symbol},
         )
 
-    # Paper / off-hours fallback path: try cached REST/poll value first.
-    cached_ltp_fn = getattr(mdm, "get_cached_ltp", None)
-    cached = (
-        float(
-            cached_ltp_fn(
-                policy.nifty_internal_symbol,
-                max_age_seconds=policy.startup_spot_max_age_seconds,
-                require_ws=False,
-            )
-            or 0.0
-        )
-        if callable(cached_ltp_fn)
-        else 0.0
-    )
+    # Paper/off-hours fallback path: try cached REST/poll value first; in LIVE
+    # this may seed basket hydration but must not be logged as WebSocket proof.
+    cached = _resolve_startup_rest_spot_ltp(ctx) or 0.0
     if cached > 0:
-        if not live_mode:
+        if live_mode:
+            LOGGER.warning(
+                "STARTUP_SPOT_REST_FALLBACK_USED symbol=%s price=%.2f live_orders_armed=%s",
+                policy.nifty_internal_symbol,
+                cached,
+                False,
+                extra={
+                    "event": "STARTUP_SPOT_REST_FALLBACK_USED",
+                    "symbol": policy.nifty_internal_symbol,
+                    "price": cached,
+                    "live_orders_armed": False,
+                },
+            )
+            LOGGER.info(
+                "STARTUP_SPOT_REST_FALLBACK_READY symbol=%s price=%.2f live_proof=false",
+                policy.nifty_internal_symbol,
+                cached,
+                extra={
+                    "event": "STARTUP_SPOT_REST_FALLBACK_READY",
+                    "symbol": policy.nifty_internal_symbol,
+                    "price": cached,
+                    "live_proof": False,
+                },
+            )
+        else:
             LOGGER.info(
                 "STARTUP_SPOT_FALLBACK_PROBE mode=%s source=rest_or_poll symbol=%s",
                 (configured_mode or "PAPER"),
                 policy.nifty_internal_symbol,
             )
-        LOGGER.info(
-            "LIVE_SPOT_READY symbol=%s price=%.2f source=cache",
-            policy.nifty_internal_symbol,
-            cached,
-            extra={
-                "event": "LIVE_SPOT_READY",
-                "symbol": policy.nifty_internal_symbol,
-                "price": cached,
-                "source": "cache",
-            },
-        )
+            LOGGER.info(
+                "LIVE_SPOT_READY symbol=%s price=%.2f source=cache",
+                policy.nifty_internal_symbol,
+                cached,
+                extra={
+                    "event": "LIVE_SPOT_READY",
+                    "symbol": policy.nifty_internal_symbol,
+                    "price": cached,
+                    "source": "cache",
+                },
+            )
         return float(cached)
 
     if live_mode:
@@ -7469,6 +7658,79 @@ def _hydrate_committed_active_basket(ctx: BotContext, *, reason: str) -> dict[st
         )
     return report
 
+def _bare_symbol(symbol: str | None) -> str | None:
+    text = str(symbol or "").strip()
+    if not text:
+        return None
+    return text.split(":", 1)[-1] if ":" in text else text
+
+
+def _coerce_positive_int_token(value: Any) -> int | None:
+    try:
+        token = int(value)
+    except (TypeError, ValueError):
+        return None
+    return token if token > 0 else None
+
+
+def _resolve_committed_symbol_token(
+    ctx: BotContext,
+    committed: Mapping[str, object],
+    symbol: str | None,
+    explicit_token_key: str | None = None,
+) -> int | None:
+    """Resolve token for a committed basket symbol without selecting contracts."""
+    if not symbol:
+        return None
+    full_symbol = str(symbol).strip()
+    bare_symbol = _bare_symbol(full_symbol)
+    if explicit_token_key:
+        token = _coerce_positive_int_token(committed.get(explicit_token_key))
+        if token is not None:
+            return token
+
+    token_by_symbol = committed.get("token_by_symbol")
+    if isinstance(token_by_symbol, Mapping):
+        for key in (full_symbol, bare_symbol):
+            token = _coerce_positive_int_token(token_by_symbol.get(key)) if key else None
+            if token is not None:
+                return token
+
+    active_symbol_tokens = getattr(ctx, "active_symbol_tokens", None)
+    if isinstance(active_symbol_tokens, Mapping):
+        for key in (full_symbol, bare_symbol):
+            token = _coerce_positive_int_token(active_symbol_tokens.get(key)) if key else None
+            if token is not None:
+                return token
+
+    instrument_manager = getattr(ctx, "instrument_manager", None)
+    get_token = getattr(instrument_manager, "get_token", None)
+    if callable(get_token):
+        for key in (full_symbol, bare_symbol):
+            if not key:
+                continue
+            try:
+                token = _coerce_positive_int_token(get_token(key))
+            except (RuntimeError, KeyError, ValueError, TypeError):
+                token = None
+            if token is not None:
+                return token
+
+    broker_client = getattr(ctx, "broker_client", None)
+    get_instrument_token = getattr(broker_client, "get_instrument_token", None)
+    if callable(get_instrument_token):
+        for key in (full_symbol, bare_symbol):
+            if not key:
+                continue
+            try:
+                token = _coerce_positive_int_token(get_instrument_token(key))
+            except (RuntimeError, KeyError, ValueError, TypeError):
+                token = None
+            if token is not None:
+                return token
+    return None
+
+
 def _commit_active_dynamic_basket(
     ctx: BotContext,
     *,
@@ -7601,21 +7863,93 @@ def _commit_active_dynamic_basket(
         try:
             fut_token_int = int(futures_token)
             token_by_symbol.setdefault(active_futures_symbol, fut_token_int)
+            bare_future = _bare_symbol(active_futures_symbol)
+            if bare_future:
+                token_by_symbol.setdefault(bare_future, fut_token_int)
             symbol_by_token.setdefault(fut_token_int, active_futures_symbol)
             if fut_token_int not in [int(t) for t in all_tokens if t is not None]:
                 all_tokens.insert(1 if all_tokens else 0, fut_token_int)
         except (TypeError, ValueError):
             pass
+
+    token_resolution_view: dict[str, object] = {
+        **dict(basket or {}),
+        **dict(committed or {}),
+        "token_by_symbol": token_by_symbol,
+    }
+    selected_ce_token = _resolve_committed_symbol_token(
+        ctx, token_resolution_view, selected_ce, "selected_ce_token"
+    )
+    selected_pe_token = _resolve_committed_symbol_token(
+        ctx, token_resolution_view, selected_pe, "selected_pe_token"
+    )
+    futures_token_resolved = _resolve_committed_symbol_token(
+        ctx, token_resolution_view, active_futures_symbol, "futures_token"
+    )
+
+    for opt_symbol, opt_token, token_key in (
+        (selected_ce, selected_ce_token, "selected_ce_token"),
+        (selected_pe, selected_pe_token, "selected_pe_token"),
+    ):
+        if opt_symbol and opt_token is not None:
+            committed[token_key] = opt_token
+            token_by_symbol.setdefault(str(opt_symbol), opt_token)
+            bare_option = _bare_symbol(str(opt_symbol))
+            if bare_option:
+                token_by_symbol.setdefault(bare_option, opt_token)
+            symbol_by_token.setdefault(opt_token, str(opt_symbol))
+            if str(opt_symbol) not in all_symbols:
+                all_symbols.append(str(opt_symbol))
+            if opt_token not in [int(t) for t in all_tokens if t is not None]:
+                all_tokens.append(opt_token)
+
+    if active_futures_symbol and futures_token_resolved is not None:
+        committed["futures_token"] = futures_token_resolved
+        token_by_symbol.setdefault(str(active_futures_symbol), futures_token_resolved)
+        bare_future = _bare_symbol(str(active_futures_symbol))
+        if bare_future:
+            token_by_symbol.setdefault(bare_future, futures_token_resolved)
+        symbol_by_token.setdefault(futures_token_resolved, str(active_futures_symbol))
+
     if token_by_symbol and not all_tokens:
         all_tokens = [int(token_by_symbol[s]) for s in all_symbols if s in token_by_symbol]
     if token_by_symbol and all_symbols:
-        all_tokens = [int(token_by_symbol[s]) for s in all_symbols if s in token_by_symbol]
+        resolved_all_tokens: list[int] = []
+        for sym in all_symbols:
+            token = _coerce_positive_int_token(token_by_symbol.get(sym))
+            if token is None:
+                bare = _bare_symbol(str(sym))
+                token = _coerce_positive_int_token(token_by_symbol.get(bare)) if bare else None
+            if token is not None:
+                resolved_all_tokens.append(token)
+        if resolved_all_tokens:
+            all_tokens = resolved_all_tokens
     committed["all_symbols"] = list(dict.fromkeys(all_symbols))
     committed["all_tokens"] = list(dict.fromkeys(all_tokens))
     committed["token_by_symbol"] = token_by_symbol
     committed["symbol_by_token"] = symbol_by_token
+    LOGGER.info(
+        "ACTIVE_BASKET_SUBSCRIPTION_RECONCILED selected_ce=%s selected_ce_token=%s selected_pe=%s selected_pe_token=%s futures_symbol=%s futures_token=%s",
+        selected_ce,
+        selected_ce_token,
+        selected_pe,
+        selected_pe_token,
+        active_futures_symbol,
+        futures_token_resolved,
+        extra={
+            "event": "ACTIVE_BASKET_SUBSCRIPTION_RECONCILED",
+            "selected_ce": selected_ce,
+            "selected_ce_token": selected_ce_token,
+            "selected_pe": selected_pe,
+            "selected_pe_token": selected_pe_token,
+            "futures_symbol": active_futures_symbol,
+            "futures_token": futures_token_resolved,
+        },
+    )
     ctx.active_trading_universe = committed
     ctx.active_contract_basket = committed
+    if getattr(ctx, "option_universe", None) is not None and hasattr(ctx.option_universe, "set_active_contract_basket"):
+        ctx.option_universe.set_active_contract_basket(committed)
     ctx.active_symbol_tokens = dict(committed.get("token_by_symbol") or getattr(ctx, "active_symbol_tokens", {}) or {})
     mdm_set = getattr(getattr(ctx, "market_data_manager", None), "set_active_contract_basket", None)
     if callable(mdm_set):
@@ -8259,7 +8593,7 @@ async def startup_sequence(ctx: BotContext) -> None:
                 ctx.websocket_enabled,
                 symbol=policy.nifty_internal_symbol, token=policy.nifty_spot_token, desired_token_count=desired_tokens, ws_token_count=ws_status.get("tokens"), websocket_enabled=ctx.websocket_enabled, phase="spot_first",
             )
-            spot_wait_seconds = float(os.getenv("STARTUP_WAIT_FOR_WS_SPOT_SECONDS", "8"))
+            spot_wait_seconds = float(os.getenv("STARTUP_SPOT_WS_PROOF_TIMEOUT_SEC", os.getenv("STARTUP_WAIT_FOR_WS_SPOT_SECONDS", "8")))
             mode = str(getattr(ctx, "effective_mode", None) or os.getenv("EXECUTION_MODE", "PAPER")).upper()
             live_mode = mode == "LIVE" or str(os.getenv("ENABLE_LIVE", "false")).lower() in {"1", "true", "yes", "on"}
             try:
@@ -8283,23 +8617,63 @@ async def startup_sequence(ctx: BotContext) -> None:
                     await _refresh_readiness_after_first_tick(
                         ctx, reason="ws_spot_proof_ready"
                     )
-                elif live_mode and get_market_state() == MarketState.OPEN:
-                    ctx.live_orders_armed = False
-                    ctx.trading_ready = False
-                    ctx.live_block_reason = "fresh_spot_tick_missing"
-                    raise RuntimeError("fresh NIFTY WebSocket spot tick unavailable")
                 elif live_mode:
-                    ctx.live_orders_armed = False
-                    ctx.trading_ready = False
-                    ctx.readiness_mode = "DATA_WARMUP"
-                    ctx.effective_mode = "DATA_WARMUP"
-                    ctx.live_block_reason = "outside_market_waiting_for_spot_tick"
-                    LOGGER.warning(
-                        "STARTUP_WS_SPOT_PROOF_TIMEOUT_WARMUP symbol=%s mode=%s",
-                        policy.nifty_internal_symbol,
-                        mode,
-                        extra={"event": "STARTUP_WS_SPOT_PROOF_TIMEOUT_WARMUP"},
-                    )
+                    rest_spot = _resolve_startup_rest_spot_ltp(ctx)
+                    if rest_spot and rest_spot > 0:
+                        ctx.live_orders_armed = False
+                        ctx.trading_ready = False
+                        ctx.readiness_mode = "DATA_WARMUP"
+                        ctx.effective_mode = "DATA_WARMUP"
+                        ctx.live_block_reason = "rest_spot_fallback_waiting_for_ws_proof"
+                        LOGGER.warning(
+                            "STARTUP_SPOT_REST_FALLBACK_USED symbol=%s price=%.2f live_orders_armed=%s",
+                            policy.nifty_internal_symbol,
+                            rest_spot,
+                            False,
+                            extra={
+                                "event": "STARTUP_SPOT_REST_FALLBACK_USED",
+                                "symbol": policy.nifty_internal_symbol,
+                                "price": rest_spot,
+                                "live_orders_armed": False,
+                            },
+                        )
+                        LOGGER.info(
+                            "STARTUP_SPOT_REST_FALLBACK_READY symbol=%s price=%.2f live_proof=false",
+                            policy.nifty_internal_symbol,
+                            rest_spot,
+                            extra={
+                                "event": "STARTUP_SPOT_REST_FALLBACK_READY",
+                                "symbol": policy.nifty_internal_symbol,
+                                "price": rest_spot,
+                                "live_proof": False,
+                            },
+                        )
+                        await _build_and_hydrate_live_basket_from_spot(
+                            ctx,
+                            spot_ltp=float(rest_spot),
+                            configured_mode="LIVE",
+                            hydrate=True,
+                        )
+                        ctx.live_orders_armed = False
+                        if not getattr(ctx, "live_block_reason", None):
+                            ctx.live_block_reason = "rest_spot_fallback_waiting_for_ws_proof"
+                    elif get_market_state() == MarketState.OPEN:
+                        ctx.live_orders_armed = False
+                        ctx.trading_ready = False
+                        ctx.live_block_reason = "fresh_spot_tick_missing"
+                        raise RuntimeError("fresh NIFTY WebSocket spot tick unavailable")
+                    else:
+                        ctx.live_orders_armed = False
+                        ctx.trading_ready = False
+                        ctx.readiness_mode = "DATA_WARMUP"
+                        ctx.effective_mode = "DATA_WARMUP"
+                        ctx.live_block_reason = "outside_market_waiting_for_spot_tick"
+                        LOGGER.warning(
+                            "STARTUP_WS_SPOT_PROOF_TIMEOUT_WARMUP symbol=%s mode=%s",
+                            policy.nifty_internal_symbol,
+                            mode,
+                            extra={"event": "STARTUP_WS_SPOT_PROOF_TIMEOUT_WARMUP"},
+                        )
                 else:
                     LOGGER.warning(
                         "STARTUP_WS_SPOT_PROOF_TIMEOUT_NONLIVE symbol=%s mode=%s",
@@ -8486,6 +8860,7 @@ async def startup_sequence(ctx: BotContext) -> None:
                 ctx.broker_client,
                 option_universe=ctx.option_universe,
                 market_data_manager=ctx.market_data_manager,
+                active_contract_basket=getattr(ctx, "active_contract_basket", None) or getattr(ctx, "active_trading_universe", None),
             )
 
             active_futures_symbol = _resolve_active_futures_for_basket(ctx, None)
@@ -9751,40 +10126,12 @@ async def startup_sequence(ctx: BotContext) -> None:
                             pending_runner_symbols.clear()
                             pending_runner_symbols.update(still_pending)
 
-                        if not ctx.option_universe:
-                            await asyncio.sleep(30)
-                            continue
-
-                        spot = (
-                            ctx.market_data_manager.get_cached_ltp(
-                                policy.nifty_internal_symbol,
-                                max_age_seconds=policy.startup_spot_max_age_seconds,
-                                require_ws=False,
-                            )
-                            if ctx.market_data_manager
-                            and hasattr(ctx.market_data_manager, "get_cached_ltp")
-                            else None
-                        )
-                        
-                        # --- Objective 7: Auto ATM Resubscription via InstrumentManager ---
-                        _im = ctx.instrument_manager
-                        if spot and spot > 0 and _im and _im.is_loaded():
-                            target_tokens = _im.select_tokens_for_universe(
-                                base="NIFTY",
-                                spot_price=float(spot),
-                                strikes_around_atm=3,
-                                strike_step=ctx.settings.option_universe.strike_step
-                            )
-                            latest_symbols = set()
-                            for t in target_tokens:
-                                s = _im.get_symbol(t)
-                                if s:
-                                    qualified = f"NFO:{s}" if not s.startswith("NFO:") else s
-                                    if qualified.startswith("NFO:NIFTY"):
-                                        latest_symbols.add(qualified)
-                        else:
-                            latest_symbols = set(
-                                ctx.option_universe.get_current_universe()
+                        active_basket = getattr(ctx, "active_contract_basket", None) or getattr(ctx, "active_trading_universe", None)
+                        latest_symbols = set(_option_symbols_from_active_basket(active_basket))
+                        if not latest_symbols:
+                            LOGGER.warning(
+                                "OPTION_UNIVERSE_SYNC_SKIPPED reason=ACTIVE_BASKET_MISSING",
+                                extra={"event": "OPTION_UNIVERSE_SYNC_SKIPPED", "reason": "ACTIVE_BASKET_MISSING"},
                             )
 
                         added, removed = option_universe_controller.update(
@@ -10180,7 +10527,7 @@ async def startup_sequence(ctx: BotContext) -> None:
                 )
                 startup_trade_ready = True
             else:
-                norm_basket = normalize_active_basket_schema(dict(getattr(ctx, "active_trading_universe", {}) or {}))
+                norm_basket = normalize_active_basket_schema(dict((getattr(ctx, "active_contract_basket", None) or getattr(ctx, "active_trading_universe", {}) or {})))
                 LOGGER.exception(
                     "HYDRATION_TRACKING_FAILED error_type=%s error=%s basket_keys=%s selected_ce=%s selected_pe=%s spot_symbol=%s futures_symbol=%s",
                     type(e).__name__,
@@ -10203,17 +10550,19 @@ async def startup_sequence(ctx: BotContext) -> None:
                 )
                 ctx.live_orders_armed = False
                 ctx.trading_ready = False
-                ctx.live_block_reason = f"hydration_tracking_failed:{e}"
-            configured_mode = str(
-                getattr(ctx.settings, "execution_mode", None)
-                or os.getenv("EXECUTION_MODE", "PAPER")
-            ).upper()
-            if (
-                configured_mode == "LIVE"
-                and get_market_state() == MarketState.OPEN
-                and not is_warmup_like
-            ):
-                raise
+                if norm_basket.get("option_symbols") or norm_basket.get("selected_ce") or norm_basket.get("selected_pe"):
+                    ctx.live_block_reason = f"hydration_tracking_degraded:{type(e).__name__}"
+                    LOGGER.warning(
+                        "HYDRATION_TRACKING_DEGRADED_CONTINUE reason=%s active_basket_available=True",
+                        type(e).__name__,
+                        extra={"event": "HYDRATION_TRACKING_DEGRADED_CONTINUE", "reason": type(e).__name__, "active_basket_available": True},
+                    )
+                else:
+                    ctx.live_block_reason = "ACTIVE_BASKET_MISSING"
+                    LOGGER.warning(
+                        "LIVE_READINESS_BLOCKED reason=ACTIVE_BASKET_MISSING stage=hydration_tracking",
+                        extra={"event": "LIVE_READINESS_BLOCKED", "reason": "ACTIVE_BASKET_MISSING", "stage": "hydration_tracking"},
+                    )
 
     # ---------------------------------------------------------
     # 4. Start subsystems (guarded singleton startup)

--- a/src/nifty_scalper_bot/core/option_universe.py
+++ b/src/nifty_scalper_bot/core/option_universe.py
@@ -64,6 +64,8 @@ class OptionUniverseManager:
         self._current_universe: list[str] = []
         self._frozen_universe: set[str] = set()
         self._last_recalc_spot: float | None = None
+        self._active_contract_basket: Any | None = None
+        self._runtime_call_blocked_logged = False
 
     def update_underlying(self, spot_price: float) -> None:
         """Refresh ATM, expiry and universe based on latest underlying spot.
@@ -124,6 +126,66 @@ class OptionUniverseManager:
                 extra={"event": "option_universe_frozen_skip", "atm": new_atm},
             )
 
+    def set_active_contract_basket(self, basket: Any | None) -> None:
+        """Attach the InstrumentManager-selected ActiveContractBasket for runtime callers."""
+        self._active_contract_basket = basket
+
+    @classmethod
+    def from_active_contract_basket(
+        cls,
+        basket: Any,
+        config: OptionUniverseConfig | dict[str, Any] | Any | None = None,
+    ) -> "OptionUniverseManager":
+        """Create a compatibility wrapper backed by an ActiveContractBasket."""
+        manager = cls(config or OptionUniverseConfig())
+        manager.set_active_contract_basket(basket)
+        return manager
+
+    @staticmethod
+    def _basket_option_symbols(basket: Any | None) -> list[str]:
+        if basket is None:
+            return []
+        if isinstance(basket, dict):
+            symbols = basket.get("option_symbols")
+            if not symbols:
+                symbols = [basket.get("selected_ce"), basket.get("selected_pe")]
+        else:
+            symbols = getattr(basket, "option_symbols", None)
+            if not symbols:
+                symbols = [getattr(basket, "selected_ce", None), getattr(basket, "selected_pe", None)]
+        return [str(sym) for sym in dict.fromkeys(symbols or []) if sym]
+
+    @staticmethod
+    def _runtime_mode_is_live() -> bool:
+        return str(os.getenv("EXECUTION_MODE") or os.getenv("MODE") or "").strip().upper() == "LIVE"
+
+    def _runtime_blocked_universe(self, method: str) -> list[str]:
+        if self._runtime_mode_is_live():
+            if not self._runtime_call_blocked_logged:
+                LOGGER.warning(
+                    "OPTION_UNIVERSE_RUNTIME_CALL_BLOCKED method=%s reason=active_contract_basket_missing",
+                    method,
+                    extra={
+                        "event": "OPTION_UNIVERSE_RUNTIME_CALL_BLOCKED",
+                        "method": method,
+                        "reason": "active_contract_basket_missing",
+                    },
+                )
+                self._runtime_call_blocked_logged = True
+            return []
+        if not _legacy_fallback_enabled():
+            LOGGER.warning(
+                "OPTION_UNIVERSE_RUNTIME_CALL_BLOCKED method=%s reason=legacy_fallback_disabled",
+                method,
+                extra={
+                    "event": "OPTION_UNIVERSE_RUNTIME_CALL_BLOCKED",
+                    "method": method,
+                    "reason": "legacy_fallback_disabled",
+                },
+            )
+            return []
+        return list(self._current_universe)[:8]
+
     def get_current_universe(self) -> list[str]:
         """Return the latest full option universe.
 
@@ -136,6 +198,11 @@ class OptionUniverseManager:
         Raises:
             None.
         """
+        basket_symbols = self._basket_option_symbols(self._active_contract_basket)
+        if basket_symbols:
+            return basket_symbols
+        if not self._current_universe:
+            return self._runtime_blocked_universe("get_current_universe")
         return list(self._current_universe)[:8]
 
     def get_primary_symbols(self) -> list[str]:
@@ -150,10 +217,20 @@ class OptionUniverseManager:
         Raises:
             None.
         """
+        basket_symbols = self._basket_option_symbols(self._active_contract_basket)
+        if basket_symbols:
+            # Compatibility scan target cap only applies to primary symbols; full
+            # basket access remains available via get_current_universe().
+            return basket_symbols[:8]
         return self.get_current_universe()
 
     def get_filtered_universe(self, spot_ltp: float) -> list[str]:
         """Return the frozen intraday universe while tracking spot diagnostics."""
+        basket_symbols = self._basket_option_symbols(self._active_contract_basket)
+        if basket_symbols:
+            return basket_symbols
+        if self._runtime_mode_is_live():
+            return self._runtime_blocked_universe("get_filtered_universe")
         if spot_ltp <= 0:
             return list(self._current_universe)[:8]
         threshold = max(1.0, float(self._config.spot_recalc_threshold_points))

--- a/src/nifty_scalper_bot/options/contracts.py
+++ b/src/nifty_scalper_bot/options/contracts.py
@@ -22,11 +22,16 @@ Usage::
 from __future__ import annotations
 
 import logging
+import os
 from dataclasses import dataclass, field
 from datetime import date, datetime
-from typing import Any, Dict, List, Optional, Set
+from typing import Any, Dict, List, Mapping, Optional, Set
 
 LOGGER = logging.getLogger("nifty_scalper_bot.options.contracts")
+
+
+def _live_mode() -> bool:
+    return str(os.getenv("EXECUTION_MODE") or os.getenv("MODE") or "").strip().upper() == "LIVE"
 
 
 @dataclass(slots=True)
@@ -239,6 +244,34 @@ class OptionsContractStore:
         """
         return self._im.get_exchange(int(token))
     
+    @staticmethod
+    def _basket_get(basket: Any, key: str, default: Any = None) -> Any:
+        if isinstance(basket, Mapping):
+            return basket.get(key, default)
+        return getattr(basket, key, default)
+
+    def _active_basket_symbols(
+        self,
+        basket: Any,
+        *,
+        include_futures: bool,
+        include_spot: bool,
+    ) -> List[str]:
+        symbols: List[str] = []
+        if include_spot:
+            spot_symbol = self._basket_get(basket, "spot_symbol")
+            if spot_symbol:
+                symbols.append(str(spot_symbol))
+        if include_futures:
+            futures_symbol = self._basket_get(basket, "futures_symbol")
+            if futures_symbol:
+                symbols.append(str(futures_symbol))
+        option_symbols = self._basket_get(basket, "option_symbols") or []
+        if not option_symbols:
+            option_symbols = [self._basket_get(basket, "selected_ce"), self._basket_get(basket, "selected_pe")]
+        symbols.extend(str(sym) for sym in option_symbols if sym)
+        return list(dict.fromkeys(symbols))
+
     def get_trading_universe(
         self,
         spot_price: float,
@@ -261,50 +294,85 @@ class OptionsContractStore:
         """
         if spot_price <= 0:
             raise ValueError("spot_price must be positive")
-        
-        # Calculate ATM strike
+
+        get_active = getattr(self._im, "get_active_nifty_contracts", None)
+        if callable(get_active):
+            try:
+                basket = get_active(
+                    float(spot_price),
+                    strikes_around_atm=int(strikes_around_atm),
+                    strike_step=int(strike_step),
+                    include_future=bool(include_futures),
+                )
+                symbols = self._active_basket_symbols(
+                    basket,
+                    include_futures=include_futures,
+                    include_spot=include_spot,
+                )
+                LOGGER.info(
+                    "OPTIONS_CONTRACT_STORE_ACTIVE_BASKET_USED symbols=%d include_spot=%s include_futures=%s",
+                    len(symbols),
+                    include_spot,
+                    include_futures,
+                    extra={
+                        "event": "OPTIONS_CONTRACT_STORE_ACTIVE_BASKET_USED",
+                        "symbols": len(symbols),
+                        "include_spot": include_spot,
+                        "include_futures": include_futures,
+                    },
+                )
+                return symbols
+            except Exception as exc:
+                if _live_mode():
+                    LOGGER.error(
+                        "OPTIONS_CONTRACT_STORE_ACTIVE_BASKET_REQUIRED method=get_trading_universe reason=%s",
+                        exc,
+                        extra={
+                            "event": "OPTIONS_CONTRACT_STORE_ACTIVE_BASKET_REQUIRED",
+                            "method": "get_trading_universe",
+                            "reason": str(exc),
+                        },
+                    )
+                    return []
+                LOGGER.warning(
+                    "OPTIONS_CONTRACT_STORE_ACTIVE_BASKET_UNAVAILABLE reason=%s fallback=metadata_cache",
+                    exc,
+                    extra={"event": "OPTIONS_CONTRACT_STORE_ACTIVE_BASKET_UNAVAILABLE", "reason": str(exc)},
+                )
+
+        if _live_mode():
+            LOGGER.error(
+                "OPTIONS_CONTRACT_STORE_ACTIVE_BASKET_REQUIRED method=get_trading_universe reason=instrument_manager_method_missing",
+                extra={
+                    "event": "OPTIONS_CONTRACT_STORE_ACTIVE_BASKET_REQUIRED",
+                    "method": "get_trading_universe",
+                    "reason": "instrument_manager_method_missing",
+                },
+            )
+            return []
+
+        # Non-live compatibility fallback over already-loaded metadata cache only.
         atm_strike = int(round(spot_price / strike_step) * strike_step)
-        
-        # Find nearest expiry
-        today = date.today()
+        today = datetime.now().date()
         future_expiries = sorted([exp for exp in self._by_expiry.keys() if exp >= today])
         
         if not future_expiries:
             raise RuntimeError("No valid expiry dates found")
         
         active_expiry = future_expiries[0]
-        
-        # Generate target strikes
         target_strikes = {
             atm_strike + (i * strike_step)
             for i in range(-strikes_around_atm, strikes_around_atm + 1)
         }
-        
-        # Collect symbols
         symbols: List[str] = []
-        
-        # Add spot
         if include_spot and self._spot_token:
             symbols.append("NSE:NIFTY")
-        
-        # Add futures
         if include_futures and active_expiry in self._futures:
             symbols.append(self._futures[active_expiry].qualified_symbol)
-        
-        # Add options
         contracts_for_expiry = self._by_expiry.get(active_expiry, [])
         for contract in contracts_for_expiry:
             if contract.strike in target_strikes:
                 symbols.append(contract.qualified_symbol)
-        
-        LOGGER.info(
-            "Trading universe: spot=%.2f ATM=%d expiry=%s symbols=%d",
-            spot_price,
-            atm_strike,
-            active_expiry,
-            len(symbols),
-        )
-        
         return symbols
     
     def get_snapshot(self, spot_price: float) -> ContractsSnapshot:
@@ -316,19 +384,73 @@ class OptionsContractStore:
         Returns:
             ContractsSnapshot with all current contract data.
         """
+        get_active = getattr(self._im, "get_active_nifty_contracts", None)
+        if callable(get_active) and spot_price > 0:
+            try:
+                basket = get_active(float(spot_price), strikes_around_atm=2, strike_step=50, include_future=True)
+                atm_strike = int(self._basket_get(basket, "atm_strike", int(round(spot_price / 50) * 50)))
+                active_expiry = self._basket_get(basket, "option_expiry")
+                option_symbols = [str(sym).split(":", 1)[-1].upper() for sym in (self._basket_get(basket, "option_symbols") or [])]
+                selected_contracts = [self._contracts[sym] for sym in option_symbols if sym in self._contracts]
+                ce_contracts = [c for c in selected_contracts if c.instrument_type == "CE"]
+                pe_contracts = [c for c in selected_contracts if c.instrument_type == "PE"]
+                LOGGER.info(
+                    "OPTIONS_CONTRACT_STORE_ACTIVE_BASKET_USED snapshot=True option_count=%d",
+                    len(selected_contracts),
+                    extra={"event": "OPTIONS_CONTRACT_STORE_ACTIVE_BASKET_USED", "snapshot": True, "option_count": len(selected_contracts)},
+                )
+                return ContractsSnapshot(
+                    timestamp=datetime.now(),
+                    spot_price=spot_price,
+                    atm_strike=atm_strike,
+                    active_expiry=active_expiry,
+                    ce_contracts=ce_contracts,
+                    pe_contracts=pe_contracts,
+                    future_token=self._basket_get(basket, "futures_token"),
+                    spot_token=self._basket_get(basket, "spot_token", self._spot_token),
+                )
+            except Exception as exc:
+                if _live_mode():
+                    LOGGER.error(
+                        "OPTIONS_CONTRACT_STORE_ACTIVE_BASKET_REQUIRED method=get_snapshot reason=%s",
+                        exc,
+                        extra={
+                            "event": "OPTIONS_CONTRACT_STORE_ACTIVE_BASKET_REQUIRED",
+                            "method": "get_snapshot",
+                            "reason": str(exc),
+                        },
+                    )
+                    raise RuntimeError(
+                        "OPTIONS_CONTRACT_STORE_ACTIVE_BASKET_REQUIRED method=get_snapshot"
+                    ) from exc
+                LOGGER.warning(
+                    "OPTIONS_CONTRACT_STORE_ACTIVE_BASKET_UNAVAILABLE reason=%s fallback=snapshot_metadata_cache",
+                    exc,
+                    extra={"event": "OPTIONS_CONTRACT_STORE_ACTIVE_BASKET_UNAVAILABLE", "reason": str(exc), "fallback": "snapshot_metadata_cache"},
+                )
+
+        if _live_mode():
+            LOGGER.error(
+                "OPTIONS_CONTRACT_STORE_ACTIVE_BASKET_REQUIRED method=get_snapshot reason=instrument_manager_method_missing",
+                extra={
+                    "event": "OPTIONS_CONTRACT_STORE_ACTIVE_BASKET_REQUIRED",
+                    "method": "get_snapshot",
+                    "reason": "instrument_manager_method_missing",
+                },
+            )
+            raise RuntimeError("OPTIONS_CONTRACT_STORE_ACTIVE_BASKET_REQUIRED method=get_snapshot")
+
+        # Non-live compatibility fallback over loaded metadata cache only.
         atm_strike = int(round(spot_price / 50) * 50)
-        today = date.today()
+        today = datetime.now().date()
         future_expiries = sorted([exp for exp in self._by_expiry.keys() if exp >= today])
         active_expiry = future_expiries[0] if future_expiries else today
-        
         contracts_for_expiry = self._by_expiry.get(active_expiry, [])
         ce_contracts = [c for c in contracts_for_expiry if c.instrument_type == "CE"]
         pe_contracts = [c for c in contracts_for_expiry if c.instrument_type == "PE"]
-        
         future_token = None
         if active_expiry in self._futures:
             future_token = self._futures[active_expiry].instrument_token
-        
         return ContractsSnapshot(
             timestamp=datetime.now(),
             spot_price=spot_price,

--- a/tests/core/test_basket_commit_before_readiness.py
+++ b/tests/core/test_basket_commit_before_readiness.py
@@ -219,3 +219,47 @@ async def test_missing_hydration_method_blocks_live_readiness(monkeypatch, caplo
     assert ctx.active_basket_hydration["missing"] == ["hydrate_active_contract_basket_missing"]
     assert "ACTIVE_BASKET_HYDRATION_METHOD_MISSING" in caplog.text
     assert calls[-1]['evaluation_ready'] is False
+
+
+def test_botcontext_active_contract_basket_initialized():
+    from nifty_scalper_bot.config.settings import Settings
+    from nifty_scalper_bot.core.app import AppConfig, BotContext, RateLimiter
+
+    ctx = BotContext(
+        settings=Settings(),
+        config=AppConfig(),
+        rate_limiter=RateLimiter(),
+        broker_client=None,
+        websocket_client=None,
+        websocket_manager=None,
+        streamer=None,
+        stream_supervisor=None,
+        polling_fallback_streamer=None,
+        message_bus=None,
+    )
+
+    assert ctx.active_contract_basket is None
+    assert ctx.active_basket_hydration is None
+
+
+@pytest.mark.asyncio
+async def test_early_spot_basket_build_deferred_without_active_basket_attr_error(caplog):
+    ctx = SimpleNamespace(
+        instrument_manager=SimpleNamespace(is_loaded=lambda: False),
+        market_data_manager=_MDM(),
+        broker_client=_Broker(),
+        settings=SimpleNamespace(option_universe=SimpleNamespace(strike_step=50), execution_mode='LIVE'),
+        deferred_basket_retry_started=True,
+        basket_build_lock=None,
+        basket_build_in_progress=False,
+        basket_build_last_started_mono=0.0,
+        basket_build_last_completed_mono=0.0,
+        basket_build_last_error=None,
+    )
+
+    result = await app._build_and_hydrate_live_basket_from_spot(ctx, spot_ltp=23701.0, configured_mode='LIVE')
+
+    assert result["deferred"] is True
+    assert result["reason"] == "instrument_manager_not_ready"
+    assert "LIVE_BASKET_BUILD_DEFERRED" in caplog.text
+    assert "LIVE_BASKET_BUILD_FAILED" not in caplog.text

--- a/tests/core/test_commit_active_dynamic_basket.py
+++ b/tests/core/test_commit_active_dynamic_basket.py
@@ -172,3 +172,79 @@ def test_resolve_active_futures_for_basket_uses_active_universe_when_mdm_unresol
     )
 
     assert app._resolve_active_futures_for_basket(ctx, "NFO:NIFTY26MAYFUT") == "NFO:NIFTY26MAYFUT"
+
+
+def test_selected_option_token_resolution_accepts_bare_token_map(caplog) -> None:
+    ce = "NFO:NIFTY26JUN25000CE"
+    pe = "NFO:NIFTY26JUN25000PE"
+    ctx = SimpleNamespace(
+        selected_ce=None,
+        selected_pe=None,
+        atm_ce_symbol=None,
+        atm_pe_symbol=None,
+        active_trading_universe={},
+        active_symbol_tokens={},
+        strategy_runner=None,
+        market_data_manager=None,
+        strategy_manager=None,
+        instrument_manager=None,
+        broker_client=None,
+    )
+
+    app._commit_active_dynamic_basket(
+        ctx,
+        basket={
+            "selected_ce": ce,
+            "selected_pe": pe,
+            "token_by_symbol": {
+                "NIFTY26JUN25000CE": 2001,
+                "NIFTY26JUN25000PE": 2002,
+            },
+        },
+        option_symbols=[ce, pe],
+        symbols=["NSE:NIFTY", ce, pe],
+        atm_strike=25000,
+    )
+
+    assert ctx.active_trading_universe["selected_ce_token"] == 2001
+    assert ctx.active_trading_universe["selected_pe_token"] == 2002
+    assert ctx.active_trading_universe["token_by_symbol"][ce] == 2001
+    assert "option_token_missing" not in caplog.text
+
+
+def test_selected_option_token_resolution_uses_explicit_selected_tokens(caplog) -> None:
+    caplog.set_level("INFO", logger="nifty_scalper_bot.core.app")
+    ce = "NFO:NIFTY26JUN25000CE"
+    pe = "NFO:NIFTY26JUN25000PE"
+    ctx = SimpleNamespace(
+        selected_ce=None,
+        selected_pe=None,
+        atm_ce_symbol=None,
+        atm_pe_symbol=None,
+        active_trading_universe={},
+        active_symbol_tokens={},
+        strategy_runner=None,
+        market_data_manager=None,
+        strategy_manager=None,
+        instrument_manager=None,
+        broker_client=None,
+    )
+
+    app._commit_active_dynamic_basket(
+        ctx,
+        basket={
+            "selected_ce": ce,
+            "selected_pe": pe,
+            "selected_ce_token": 2001,
+            "selected_pe_token": 2002,
+        },
+        option_symbols=[ce, pe],
+        symbols=["NSE:NIFTY", ce, pe],
+        atm_strike=25000,
+    )
+
+    assert ctx.active_trading_universe["selected_ce_token"] == 2001
+    assert ctx.active_trading_universe["selected_pe_token"] == 2002
+    assert ctx.active_trading_universe["token_by_symbol"][ce] == 2001
+    assert "ACTIVE_BASKET_SUBSCRIPTION_RECONCILED" in caplog.text
+    assert "selected_ce_token=2001" in caplog.text

--- a/tests/core/test_startup_spot_watchdog.py
+++ b/tests/core/test_startup_spot_watchdog.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from nifty_scalper_bot.core import app
+
+
+class _RestFallbackMDM:
+    def get_cached_ltp(self, *_args, **_kwargs):
+        return 0
+
+    def get_ltp(self, *_args, **_kwargs):
+        raise RuntimeError("broker temporarily unavailable")
+
+    def refresh_quote_now(self, _symbol: str):
+        return {"last_price": 25000.0}
+
+
+def test_rest_fallback_get_ltp_runtime_error_does_not_crash(caplog):
+    ctx = SimpleNamespace(market_data_manager=_RestFallbackMDM())
+
+    price = app._resolve_startup_rest_spot_ltp(ctx)
+
+    assert price == 25000.0
+    assert "STARTUP_SPOT_REST_FALLBACK_FAILED" in caplog.text
+    assert "stage=get_ltp" in caplog.text

--- a/tests/options/test_contracts_ssot.py
+++ b/tests/options/test_contracts_ssot.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from datetime import date
+
+from nifty_scalper_bot.options.contracts import OptionContract, OptionsContractStore
+
+
+class _IM:
+    def __init__(self) -> None:
+        self.calls = []
+
+    def get_active_nifty_contracts(self, spot_price: float, **kwargs):
+        self.calls.append((spot_price, kwargs))
+        return {
+            "spot_symbol": "NSE:NIFTY",
+            "futures_symbol": "NFO:NIFTY26JUNFUT",
+            "option_symbols": ("NFO:NIFTY26JUN25000CE", "NFO:NIFTY26JUN25000PE"),
+            "selected_ce": "NFO:NIFTY26JUN25000CE",
+            "selected_pe": "NFO:NIFTY26JUN25000PE",
+            "option_expiry": date(2026, 6, 25),
+            "atm_strike": 25000,
+            "futures_token": 900,
+            "spot_token": 256265,
+        }
+
+    def is_loaded(self):
+        return True
+
+
+def test_options_contract_store_delegates_to_instrument_manager_basket():
+    im = _IM()
+    store = OptionsContractStore(im)
+
+    symbols = store.get_trading_universe(25001.0, include_spot=True, include_futures=False)
+
+    assert symbols == ["NSE:NIFTY", "NFO:NIFTY26JUN25000CE", "NFO:NIFTY26JUN25000PE"]
+    assert im.calls
+    assert im.calls[0][1]["include_future"] is False
+
+
+class _FailingIM:
+    def get_active_nifty_contracts(self, spot_price: float, **kwargs):
+        raise RuntimeError("active basket unavailable")
+
+    def is_loaded(self):
+        return True
+
+    def get_exchange(self, token: int):
+        return "NFO"
+
+
+def test_contract_store_live_does_not_fallback_to_metadata_cache(monkeypatch, caplog):
+    monkeypatch.setenv("EXECUTION_MODE", "LIVE")
+    store = OptionsContractStore(_FailingIM())
+    expiry = date(2099, 1, 1)
+    contract = OptionContract(
+        instrument_token=111,
+        tradingsymbol="NIFTY99JAN25000CE",
+        expiry=expiry,
+        strike=25000.0,
+        instrument_type="CE",
+    )
+    store._spot_token = 256265
+    store._by_expiry[expiry] = [contract]
+    store._contracts[contract.symbol_key] = contract
+
+    symbols = store.get_trading_universe(25001.0)
+
+    assert symbols == []
+    assert "NFO:NIFTY99JAN25000CE" not in symbols
+    assert "OPTIONS_CONTRACT_STORE_ACTIVE_BASKET_REQUIRED" in caplog.text

--- a/tests/test_app_symbol_resolution.py
+++ b/tests/test_app_symbol_resolution.py
@@ -154,3 +154,43 @@ def test_build_canonical_active_basket_is_limited_to_spot_futures_atm_pm3() -> N
     assert len(basket["ce_symbols"]) == 7
     assert len(basket["pe_symbols"]) == 7
     assert len(basket["symbols"]) == 16
+
+
+def test_hydration_tracking_uses_active_basket_not_option_universe(monkeypatch) -> None:
+    from nifty_scalper_bot.core.option_universe import OptionUniverseConfig, OptionUniverseManager
+
+    monkeypatch.setenv("EXECUTION_MODE", "LIVE")
+    monkeypatch.setattr(
+        OptionUniverseManager,
+        "_build_universe",
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("manual generation should not run")),
+    )
+    universe = OptionUniverseManager(OptionUniverseConfig())
+    basket = {
+        "selected_ce": "NFO:NIFTY26JUN25000CE",
+        "selected_pe": "NFO:NIFTY26JUN25000PE",
+        "option_symbols": ["NFO:NIFTY26JUN25000CE", "NFO:NIFTY26JUN25000PE"],
+    }
+
+    symbols = app._get_symbols(app.AppConfig(), option_universe=universe, active_contract_basket=basket)
+
+    assert symbols == ["NFO:NIFTY26JUN25000CE", "NFO:NIFTY26JUN25000PE"]
+
+
+def test_get_symbols_uses_ce_pe_symbol_fallback_without_option_symbols(monkeypatch) -> None:
+    monkeypatch.setenv("EXECUTION_MODE", "LIVE")
+    basket = {
+        "ce_symbols": ["NFO:NIFTY26JUN25000CE", "NFO:NIFTY26JUN25050CE"],
+        "pe_symbols": ["NFO:NIFTY26JUN25000PE", "NFO:NIFTY26JUN25050PE"],
+        "selected_ce": "NFO:NIFTY26JUN99999CE",
+        "selected_pe": "NFO:NIFTY26JUN99999PE",
+    }
+
+    symbols = app._get_symbols(app.AppConfig(), active_contract_basket=basket)
+
+    assert symbols == [
+        "NFO:NIFTY26JUN25000CE",
+        "NFO:NIFTY26JUN25050CE",
+        "NFO:NIFTY26JUN25000PE",
+        "NFO:NIFTY26JUN25050PE",
+    ]

--- a/tests/test_option_universe.py
+++ b/tests/test_option_universe.py
@@ -111,3 +111,41 @@ def test_option_universe_legacy_requires_env(monkeypatch) -> None:
     )
     with pytest.raises(RuntimeError, match="manual generation disabled"):
         manager.update_underlying(18638.0)
+
+
+def _active_basket() -> dict[str, object]:
+    return {
+        "selected_ce": "NFO:NIFTY26JUN25000CE",
+        "selected_pe": "NFO:NIFTY26JUN25000PE",
+        "option_symbols": ("NFO:NIFTY26JUN25000CE", "NFO:NIFTY26JUN25000PE"),
+        "all_symbols": ("NSE:NIFTY", "NFO:NIFTY26JUN25000CE", "NFO:NIFTY26JUN25000PE"),
+        "token_by_symbol": {"NFO:NIFTY26JUN25000CE": 111, "NFO:NIFTY26JUN25000PE": 112},
+    }
+
+
+def test_no_option_universe_runtime_crash_live(monkeypatch) -> None:
+    monkeypatch.setenv("EXECUTION_MODE", "LIVE")
+    manager = OptionUniverseManager(OptionUniverseConfig())
+    manager.set_active_contract_basket(_active_basket())
+
+    assert manager.get_primary_symbols() == ["NFO:NIFTY26JUN25000CE", "NFO:NIFTY26JUN25000PE"]
+    assert manager.get_current_universe() == ["NFO:NIFTY26JUN25000CE", "NFO:NIFTY26JUN25000PE"]
+
+
+def test_option_universe_live_without_basket_returns_empty_not_crash(monkeypatch, caplog) -> None:
+    monkeypatch.setenv("EXECUTION_MODE", "LIVE")
+    manager = OptionUniverseManager(OptionUniverseConfig())
+
+    assert manager.get_primary_symbols() == []
+    assert "OPTION_UNIVERSE_RUNTIME_CALL_BLOCKED" in caplog.text
+
+
+def test_active_basket_current_universe_returns_all_symbols_and_primary_is_capped(monkeypatch) -> None:
+    monkeypatch.setenv("EXECUTION_MODE", "LIVE")
+    symbols = tuple(f"NFO:NIFTY26JUN{25000 + i * 50}CE" for i in range(10))
+    manager = OptionUniverseManager(OptionUniverseConfig())
+    manager.set_active_contract_basket({"option_symbols": symbols})
+
+    assert manager.get_current_universe() == list(symbols)
+    assert manager.get_filtered_universe(25000.0) == list(symbols)
+    assert manager.get_primary_symbols() == list(symbols[:8])


### PR DESCRIPTION
### Motivation

- Avoid rebuilding synthetic option universes and ensure downstream components reuse an authoritative ActiveContractBasket selected by the InstrumentManager or runtime hub. 
- Improve startup robustness by allowing safe REST/cached spot fallbacks (without treating them as WebSocket proof) so LIVE startup can defer or hydrate gracefully. 
- Provide a single-source-of-truth options contract interface backed by InstrumentManager active-basket APIs for runtime correctness and to prevent unsafe legacy generation in LIVE.

### Description

- Add `active_contract_basket` and `active_basket_hydration` to `BotContext` and wire uses so committed baskets are available to runtime callers via `ctx.active_contract_basket`.
- Implement helpers to read symbols/tokens from an ActiveContractBasket: `_option_symbols_from_active_basket`, `_active_basket_for_symbol_resolution`, `_bare_symbol`, `_coerce_positive_int_token`, and `_resolve_committed_symbol_token` and integrate them into `_get_symbols` and `_commit_active_dynamic_basket` to reconcile tokens, bare symbol keys, and to populate `token_by_symbol`/`all_tokens` reliably.
- Add REST/cached startup spot fallback logic via `_resolve_startup_rest_spot_ltp` and use it in startup (`_wait_for_live_spot_or_raise` and spot-first flow) so the system can build/hydrate a live basket from a REST quote when WS proof is missing while preserving logging and live-arm semantics.
- Enhance option universe manager (`OptionUniverseManager`) to accept and honor an attached ActiveContractBasket with `set_active_contract_basket`, to block runtime manual generation in LIVE mode, and to provide compatibility wrappers `from_active_contract_basket` and basket-based retrieval methods used by runtime callers.
- Update the single-source-of-truth options contracts store (`OptionsContractStore`) to delegate to `InstrumentManager.get_active_nifty_contracts` when available, returning active basket symbols/tokens and falling back to legacy metadata-only behavior only for non-LIVE compatibility.
- Add logging events to surface active-basket usage, reconciliation, and blocked runtime calls, and ensure `option_universe` and `market_data_manager` are informed of the committed basket when available.

### Testing

- Unit tests added and modified to cover new flows and compatibility: `tests/core/test_basket_commit_before_readiness.py`, `tests/core/test_commit_active_dynamic_basket.py`, `tests/core/test_startup_spot_watchdog.py` (new), `tests/options/test_contracts_ssot.py` (new), `tests/test_app_symbol_resolution.py`, and `tests/test_option_universe.py`.
- Ran the test suite with `pytest` (unit tests exercising symbol resolution, basket commit, startup REST fallback, OptionUniverse runtime behavior and OptionsContractStore SSOT behavior), and the updated tests passed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d0f6cf0708324ad7a8fe721213110)