### PR TITLE
Fix live basket subscription and runner hydration sync

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -2287,6 +2287,7 @@ class BotContext:
     active_trading_universe: dict[str, Any] = field(default_factory=dict)
     active_contract_basket: dict[str, object] | None = None
     active_basket_hydration: dict[str, object] | None = None
+    active_symbol_tokens: dict[str, int] = field(default_factory=dict)
     message_bus_tick_subscribed: bool = False
     datahub_runner_subscriptions: set[str] = field(default_factory=set)
     execution_locked_symbols: set[str] = field(default_factory=set)
@@ -7251,7 +7252,7 @@ async def _ensure_selected_options_hydrated(
             }
             continue
         hydrate_fn = getattr(mdm, "hydrate_symbol_history", None)
-        if callable(hydrate_fn):
+        if before_mdm_bars < required_bars and callable(hydrate_fn):
             await hydrate_fn(sym, interval="minute", days=_history_lookback_days(required_bars), max_bars=required_bars, reason=f"{reason}_selected_option_force_hydration")
         try:
             bars = mdm.get_ohlc_bars(sym, limit=required_bars) or []
@@ -7292,6 +7293,16 @@ async def _ensure_selected_options_hydrated(
                     required_bars,
                     reason,
                 )
+                if reseeded_count >= required_bars:
+                    LOGGER.info(
+                        "SELECTED_OPTION_RUNNER_SYNC_FROM_MDM symbol=%s mdm_bars=%d runner_bars=%d required_bars=%d reason=%s",
+                        sym,
+                        len(normalized_bars),
+                        reseeded_count,
+                        required_bars,
+                        reason,
+                        extra={"event": "SELECTED_OPTION_RUNNER_SYNC_FROM_MDM", "symbol": sym, "mdm_bars": len(normalized_bars), "runner_bars": reseeded_count, "required_bars": required_bars, "reason": reason},
+                    )
             except Exception:
                 LOGGER.exception(
                     "SELECTED_OPTION_RUNNER_RESEED_FAILED symbol=%s required_bars=%d reason=%s",
@@ -7442,20 +7453,56 @@ async def _recompute_and_push_runtime_readiness(ctx: BotContext, *, reason: str)
                 if not pd.isna(dt) and (pd.Timestamp.utcnow()-dt).total_seconds()<=limit:
                     return True
         return False
+    def _selected_option_subscription_state(sym: str | None) -> dict[str, Any]:
+        state = {"symbol": sym, "token": None, "desired": False, "subscribed": False, "confirmed": False, "fresh_tick": False, "tick_age_s": None}
+        if not sym or mdm is None:
+            return state
+        active_tokens = getattr(ctx, "active_symbol_tokens", None)
+        aliases = [str(sym), _bare_trading_symbol(sym)]
+        token = None
+        for alias in aliases:
+            token = _coerce_positive_token((active_tokens or {}).get(alias) if isinstance(active_tokens, Mapping) else None)
+            if token is not None:
+                break
+        if token is None:
+            try:
+                token = _coerce_positive_token(getattr(mdm, "_resolve_token_for_symbol", lambda _s: None)(sym))
+            except Exception:
+                token = None
+        if token is None:
+            token = _coerce_positive_token(getattr(mdm, "_symbol_to_token", {}).get(sym))
+        state["token"] = token
+        snap = _snapshot(sym)
+        state["tick_age_s"] = getattr(snap, "tick_age_s", None) if snap is not None else None
+        state["fresh_tick"] = _live_tick_seen(sym)
+        if token is not None:
+            desired_snapshot = getattr(mdm, "desired_tokens_snapshot", None)
+            desired_tokens = set(desired_snapshot() if callable(desired_snapshot) else getattr(mdm, "_desired_tokens", set()) or set())
+            subscribed_tokens = set(getattr(mdm, "_subscribed_tokens", set()) or set())
+            ws = getattr(mdm, "_ws", None) or getattr(mdm, "websocket", None)
+            subscribed_tokens.update(set(getattr(ws, "_tokens", set()) or set()))
+            confirmed_tokens = set(getattr(mdm, "_confirmed_subscriptions", set()) or set())
+            desired_ints = {coerced for raw in desired_tokens if (coerced := _coerce_positive_token(raw)) is not None}
+            subscribed_ints = {coerced for raw in subscribed_tokens if (coerced := _coerce_positive_token(raw)) is not None}
+            confirmed_ints = {coerced for raw in confirmed_tokens if (coerced := _coerce_positive_token(raw)) is not None}
+            state["desired"] = int(token) in desired_ints
+            state["subscribed"] = int(token) in subscribed_ints
+            state["confirmed"] = int(token) in confirmed_ints
+        LOGGER.info(
+            "SELECTED_OPTION_SUBSCRIPTION_STATE symbol=%s token=%s desired=%s subscribed=%s fresh_tick=%s tick_age_s=%s",
+            sym, state["token"], state["desired"], state["subscribed"], state["fresh_tick"], state["tick_age_s"],
+            extra={"event": "SELECTED_OPTION_SUBSCRIPTION_STATE", **state},
+        )
+        return state
     def _subscription_confirmed(sym: str | None) -> bool:
-        if not sym or mdm is None: return False
-        try:
-            token = getattr(mdm, "_resolve_token_for_symbol", lambda _s: None)(sym) or getattr(mdm, "_symbol_to_token", {}).get(sym)
-            confirmed = getattr(mdm, "_confirmed_subscriptions", set()) or set()
-            return bool(token is not None and int(token) in confirmed)
-        except Exception:
-            return False
+        state = _selected_option_subscription_state(sym)
+        return bool(state.get("confirmed") or state.get("desired") or state.get("subscribed") or state.get("fresh_tick"))
     def _subscription_or_live_tick(sym:str|None)->bool:
-        sub=_subscription_confirmed(sym)
-        if sub: return True
-        if _live_tick_seen(sym):
-            token=getattr(mdm, "_symbol_to_token", {}).get(sym) if mdm is not None else None
-            LOGGER.info("READINESS_SUBSCRIPTION_PROOF_FROM_LIVE_TICK symbol=%s token=%s", sym, token)
+        state = _selected_option_subscription_state(sym)
+        if state.get("confirmed") or state.get("desired") or state.get("subscribed"):
+            return True
+        if state.get("fresh_tick"):
+            LOGGER.info("READINESS_SUBSCRIPTION_PROOF_FROM_LIVE_TICK symbol=%s token=%s", sym, state.get("token"))
             return True
         return False
     def _bars(sym: str | None) -> int:
@@ -7626,6 +7673,23 @@ def _hydrate_committed_active_basket(ctx: BotContext, *, reason: str) -> dict[st
             extra={"event": "ACTIVE_BASKET_HYDRATION_NOT_READY", "reason": reason, "missing": missing},
         )
     return report
+
+
+def _ensure_active_symbol_tokens(ctx: Any) -> dict[str, int]:
+    """Return ctx.active_symbol_tokens, defensively initializing legacy contexts."""
+    current = getattr(ctx, "active_symbol_tokens", None)
+    if not isinstance(current, dict):
+        current = {}
+        try:
+            setattr(ctx, "active_symbol_tokens", current)
+        except AttributeError:
+            LOGGER.warning(
+                "ACTIVE_SYMBOL_TOKENS_INIT_FAILED context_type=%s",
+                type(ctx).__name__,
+                extra={"event": "ACTIVE_SYMBOL_TOKENS_INIT_FAILED", "context_type": type(ctx).__name__},
+            )
+            return {}
+    return current
 
 
 def _bare_trading_symbol(symbol: object) -> str:
@@ -7859,23 +7923,58 @@ def _commit_active_dynamic_basket(
     committed["symbol_by_token"] = symbol_by_token
     ctx.active_trading_universe = committed
     ctx.active_contract_basket = committed
+    active_symbol_tokens = _ensure_active_symbol_tokens(ctx)
+    active_symbol_tokens.update(dict(committed.get("token_by_symbol") or {}))
+    selected_ce_token = _resolve_committed_symbol_token(ctx, committed, selected_ce, "selected_ce_token")
+    selected_pe_token = _resolve_committed_symbol_token(ctx, committed, selected_pe, "selected_pe_token")
+    for selected_symbol, selected_token, token_key in (
+        (selected_ce, selected_ce_token, "selected_ce_token"),
+        (selected_pe, selected_pe_token, "selected_pe_token"),
+    ):
+        token_int = _coerce_positive_token(selected_token)
+        if selected_symbol and token_int is not None:
+            full_symbol = str(selected_symbol)
+            bare_symbol = _bare_trading_symbol(full_symbol)
+            token_by_symbol[full_symbol] = token_int
+            token_by_symbol[bare_symbol] = token_int
+            active_symbol_tokens[full_symbol] = token_int
+            active_symbol_tokens[bare_symbol] = token_int
+            symbol_by_token.setdefault(token_int, full_symbol)
+            committed[token_key] = token_int
+            existing_all_tokens = {coerced for raw in committed.get("all_tokens", []) if (coerced := _coerce_positive_token(raw)) is not None}
+            existing_option_tokens = {coerced for raw in committed.get("option_tokens", []) if (coerced := _coerce_positive_token(raw)) is not None}
+            if token_int not in existing_all_tokens:
+                committed.setdefault("all_tokens", []).append(token_int)
+            if token_int not in existing_option_tokens:
+                committed.setdefault("option_tokens", []).append(token_int)
+    committed["token_by_symbol"] = token_by_symbol
+    committed["symbol_by_token"] = symbol_by_token
+    committed["all_tokens"] = list(dict.fromkeys(coerced for raw in (committed.get("all_tokens") or []) if (coerced := _coerce_positive_token(raw)) is not None))
+    committed["option_tokens"] = list(dict.fromkeys(coerced for raw in (committed.get("option_tokens") or []) if (coerced := _coerce_positive_token(raw)) is not None))
     if getattr(ctx, "option_universe", None) is not None and hasattr(ctx.option_universe, "set_active_contract_basket"):
         ctx.option_universe.set_active_contract_basket(committed)
-    ctx.active_symbol_tokens = dict(committed.get("token_by_symbol") or getattr(ctx, "active_symbol_tokens", {}) or {})
-    mdm_set = getattr(getattr(ctx, "market_data_manager", None), "set_active_contract_basket", None)
+    mdm = getattr(ctx, "market_data_manager", None)
+    mdm_set = getattr(mdm, "set_active_contract_basket", None)
     if callable(mdm_set):
         mdm_set(committed)
+    request_subscription = getattr(mdm, "request_token_subscription", None)
+    request_subscriptions = getattr(mdm, "request_token_subscriptions", None)
+    selected_subscription_tokens = [tok for tok in (selected_ce_token, selected_pe_token) if tok is not None]
+    if callable(request_subscription):
+        for selected_symbol, selected_token in ((selected_ce, selected_ce_token), (selected_pe, selected_pe_token)):
+            token_int = _coerce_positive_token(selected_token)
+            if selected_symbol and token_int is not None:
+                request_subscription(token_int, symbol=str(selected_symbol))
+    elif callable(request_subscriptions) and selected_subscription_tokens:
+        request_subscriptions(int(tok) for tok in selected_subscription_tokens if tok is not None)
     hub_set = getattr(getattr(ctx, "data_hub", None), "set_active_contract_basket", None)
     if callable(hub_set):
         hub_set(committed)
-    mdm = getattr(ctx, "market_data_manager", None)
     desired_count_fn = getattr(mdm, "desired_token_count", None)
     ws_count_fn = getattr(mdm, "ws_token_count", None)
     desired_token_count = int(desired_count_fn()) if callable(desired_count_fn) else len(committed.get("all_tokens") or [])
     ws_count_value = ws_count_fn() if callable(ws_count_fn) else None
     ws_token_count = int(ws_count_value) if ws_count_value is not None else None
-    selected_ce_token = _resolve_committed_symbol_token(ctx, committed, selected_ce, "selected_ce_token")
-    selected_pe_token = _resolve_committed_symbol_token(ctx, committed, selected_pe, "selected_pe_token")
     futures_token_for_log = _resolve_committed_symbol_token(ctx, committed, active_futures_symbol, "futures_token")
     if selected_ce and selected_ce_token is None:
         ctx.live_orders_armed = False
@@ -7896,6 +7995,16 @@ def _commit_active_dynamic_basket(
         desired_token_count,
         ws_token_count,
         extra={"event": "ACTIVE_BASKET_SUBSCRIPTION_RECONCILED", "selected_ce": selected_ce, "selected_ce_token": selected_ce_token, "selected_pe": selected_pe, "selected_pe_token": selected_pe_token, "futures_symbol": active_futures_symbol, "futures_token": futures_token_for_log, "desired_token_count": desired_token_count, "ws_token_count": ws_token_count},
+    )
+    LOGGER.info(
+        "SELECTED_OPTION_SUBSCRIPTION_CONFIRMED selected_ce=%s selected_ce_token=%s selected_pe=%s selected_pe_token=%s desired_token_count=%s ws_token_count=%s",
+        selected_ce,
+        selected_ce_token,
+        selected_pe,
+        selected_pe_token,
+        desired_token_count,
+        ws_token_count,
+        extra={"event": "SELECTED_OPTION_SUBSCRIPTION_CONFIRMED", "selected_ce": selected_ce, "selected_ce_token": selected_ce_token, "selected_pe": selected_pe, "selected_pe_token": selected_pe_token, "desired_token_count": desired_token_count, "ws_token_count": ws_token_count},
     )
     _hydrate_committed_active_basket(ctx, reason="active_dynamic_basket_commit")
     LOGGER.info(
@@ -8291,6 +8400,7 @@ async def startup_sequence(ctx: BotContext) -> None:
     ctx.trading_ready = False
     ctx.readiness_mode = "DATA_WARMUP" if configured_mode == "LIVE" else configured_mode
     ctx.effective_mode = ctx.readiness_mode
+    _ensure_active_symbol_tokens(ctx)
     LOGGER.info(
         "Startup | configured_mode=%s | effective_mode=%s | live_orders_armed=%s | trading_ready=%s | data_dir=%s | port=%s",
         configured_mode,

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -1841,7 +1841,8 @@ class MarketDataManager:
             oi_val = quote.get("oi", quote.get("open_interest")) if isinstance(quote, Mapping) else None
             ltp_only = quote_ready and not depth_ready
             source = str(quote.get("source") or quote.get("quote_source") or "cache") if isinstance(quote, Mapping) else "missing"
-            symbol_hard_ready = not (is_selected and (not quote_ready or not ohlc_ready))
+            required_for_readiness = bool(is_selected)
+            symbol_hard_ready = not (required_for_readiness and (not quote_ready or not ohlc_ready))
             if is_selected and not quote_ready:
                 report["hard_ready"] = False
                 report["missing"].append(f"{sym}:quote_missing")
@@ -1860,14 +1861,16 @@ class MarketDataManager:
                 "oi_ready": (oi_val is not None) if role == "tradable_option" else None,
                 "ltp_only": bool(ltp_only),
                 "hard_ready": bool(symbol_hard_ready),
+                "required_for_readiness": required_for_readiness,
+                "symbol_hard_ready": bool(symbol_hard_ready),
                 "reseed_deferred": bool(reseed_status.get("deferred")),
                 "last_error": last_error,
                 "source": source,
             }
             report["symbols"][sym] = symbol_report
             self._logger.info(
-                "MDM_BASKET_HYDRATION_SYMBOL_RESULT symbol=%s token=%s role=%s quote_ready=%s ohlc_ready=%s bars_count=%s depth_ready=%s oi_ready=%s ltp_only=%s hard_ready=%s error=%s",
-                sym, symbol_report["token"], role, quote_ready, ohlc_ready, bars_count, depth_ready, symbol_report["oi_ready"], ltp_only, symbol_hard_ready, last_error,
+                "MDM_BASKET_HYDRATION_SYMBOL_RESULT symbol=%s token=%s role=%s quote_ready=%s ohlc_ready=%s bars_count=%s depth_ready=%s oi_ready=%s ltp_only=%s required_for_readiness=%s symbol_hard_ready=%s error=%s",
+                sym, symbol_report["token"], role, quote_ready, ohlc_ready, bars_count, depth_ready, symbol_report["oi_ready"], ltp_only, required_for_readiness, symbol_hard_ready, last_error,
                 extra={"event": "MDM_BASKET_HYDRATION_SYMBOL_RESULT", "symbol": sym, **symbol_report},
             )
         report["missing"] = list(dict.fromkeys(report["missing"]))

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -6398,12 +6398,47 @@ class StrategyRunner:
         pe_token = token_by_symbol.get(pe_symbol) if pe_symbol else None
         fut_token = token_by_symbol.get(fut_symbol) if fut_symbol else None
         active_subs = set(getattr(mdm, "_active_subscribed_symbols", set()) or set())
-        ce_sub = bool(ce_symbol and ce_symbol in active_subs)
-        pe_sub = bool(pe_symbol and pe_symbol in active_subs)
-        fut_sub = bool(fut_symbol and fut_symbol in active_subs)
+        desired_tokens = set(getattr(mdm, "_desired_tokens", set()) or set())
+        subscribed_tokens = set(getattr(mdm, "_subscribed_tokens", set()) or set())
+        ws = getattr(mdm, "_ws", None) if mdm is not None else None
+        subscribed_tokens.update(set(getattr(ws, "_tokens", set()) or set()))
+        confirmed_tokens = set(getattr(mdm, "_confirmed_subscriptions", set()) or set())
         ce_quote = bool(ce_symbol and self._is_option_symbol_tick_fresh(ce_symbol, max_age_s=60.0))
         pe_quote = bool(pe_symbol and self._is_option_symbol_tick_fresh(pe_symbol, max_age_s=60.0))
         fut_quote = bool(fut_symbol and self._is_option_symbol_tick_fresh(fut_symbol, max_age_s=60.0)) if fut_symbol else False
+        def _sub_state(sym: str | None, token: Any, fresh_tick: bool) -> bool:
+            token_int = None
+            try:
+                token_int = int(token) if token is not None else None
+            except (TypeError, ValueError):
+                token_int = None
+            def _int_set(values: set[Any]) -> set[int]:
+                normalized: set[int] = set()
+                for value in values:
+                    try:
+                        value_int = int(value)
+                    except (TypeError, ValueError):
+                        continue
+                    if value_int > 0:
+                        normalized.add(value_int)
+                return normalized
+            desired = bool(token_int is not None and token_int in _int_set(desired_tokens))
+            subscribed = bool(token_int is not None and token_int in _int_set(subscribed_tokens))
+            confirmed = bool(token_int is not None and token_int in _int_set(confirmed_tokens))
+            active_symbol = bool(sym and sym in active_subs)
+            self._logger.info(
+                "SELECTED_OPTION_SUBSCRIPTION_STATE symbol=%s token=%s desired=%s subscribed=%s fresh_tick=%s tick_age_s=%s",
+                sym, token_int, desired, subscribed or active_symbol or confirmed, fresh_tick, None,
+                extra={"event": "SELECTED_OPTION_SUBSCRIPTION_STATE", "symbol": sym, "token": token_int, "desired": desired, "subscribed": subscribed or active_symbol or confirmed, "fresh_tick": fresh_tick, "tick_age_s": None},
+            )
+            return bool(active_symbol or desired or subscribed or confirmed or fresh_tick)
+        ce_sub = _sub_state(ce_symbol, ce_token, ce_quote)
+        pe_sub = _sub_state(pe_symbol, pe_token, pe_quote)
+        try:
+            fut_token_int = int(fut_token) if fut_token is not None else None
+        except (TypeError, ValueError):
+            fut_token_int = None
+        fut_sub = bool(fut_symbol and (fut_symbol in active_subs or (fut_token_int is not None and fut_token_int in desired_tokens)))
         ce_depth = bool(ce_symbol and self._is_symbol_execution_ready(ce_symbol))
         pe_depth = bool(pe_symbol and self._is_symbol_execution_ready(pe_symbol))
         ce_hist = len(self._indicator_engine.get_history(ce_symbol) or []) if ce_symbol else 0
@@ -7115,6 +7150,21 @@ class StrategyRunner:
     ) -> bool:
         """Args: symbol + trace_id. Returns: bool gate verdict. Raises: none."""
         try:
+            if self._is_context_symbol(symbol):
+                self._logger.info(
+                    "RUNNER_GLOBAL_READINESS_DECISION symbol=%s allowed=%s reason=%s",
+                    symbol,
+                    False,
+                    "context_symbol_not_strategy_candidate",
+                    extra={
+                        "event": "RUNNER_GLOBAL_READINESS_DECISION",
+                        "symbol": symbol,
+                        "stage": "phase9",
+                        "allowed": False,
+                        "reason": "context_symbol_not_strategy_candidate",
+                    },
+                )
+                return False
             if symbol not in self._active_symbols:
                 self._emit_no_trade_decision(
                     symbol=symbol,

--- a/tests/core/test_basket_commit_before_readiness.py
+++ b/tests/core/test_basket_commit_before_readiness.py
@@ -263,3 +263,96 @@ async def test_early_spot_basket_build_deferred_without_active_basket_attr_error
     assert result["reason"] == "instrument_manager_not_ready"
     assert "LIVE_BASKET_BUILD_DEFERRED" in caplog.text
     assert "LIVE_BASKET_BUILD_FAILED" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_readiness_syncs_selected_option_runner_history_from_mdm_and_desired_subscription(caplog):
+    ce = "NFO:NIFTY26JUN23900CE"
+    pe = "NFO:NIFTY26JUN23900PE"
+    base_bars = [
+        {
+            "timestamp": f"2026-05-01T09:{idx % 60:02d}:00+00:00",
+            "open": 100.0 + idx,
+            "high": 101.0 + idx,
+            "low": 99.0 + idx,
+            "close": 100.5 + idx,
+            "volume": 100 + idx,
+        }
+        for idx in range(305)
+    ]
+
+    class _Runner:
+        def __init__(self) -> None:
+            self.counts = {ce: 18, pe: 18}
+            self._running = True
+            self.runtime_payloads = []
+            self._indicator_engine = SimpleNamespace(get_history=lambda sym: [object()] * self.counts.get(sym, 0))
+
+        def reseed_history_from_bars(self, sym, bars, source, min_bars):
+            self.counts[sym] = max(len(bars), min_bars)
+            return self.counts[sym]
+
+        def set_runtime_readiness(self, **kwargs):
+            self.runtime_payloads.append(kwargs)
+
+    class _Mdm:
+        _desired_tokens = {11, 12}
+        _confirmed_subscriptions = set()
+        _subscribed_tokens = set()
+        _symbol_to_token = {ce: 11, pe: 12}
+
+        def hydrate_active_contract_basket(self, basket):
+            return {"hard_ready": True, "missing": [], "symbols": {}}
+
+        def get_ohlc_bars(self, sym, limit=None):
+            bars = list(base_bars)
+            return bars[-limit:] if limit else bars
+
+        async def hydrate_symbol_history(self, *args, **kwargs):
+            raise AssertionError("MDM already has enough bars; broker hydration should not be called")
+
+        def get_symbol_snapshot(self, sym):
+            return SimpleNamespace(ltp=100.0, bid=99.0, ask=101.0, tradable_quote=True, depth_available=True, tick_age_s=0.1)
+
+        def has_ws_tradable_quote(self, sym):
+            return True
+
+        def desired_tokens_snapshot(self):
+            return [11, 12]
+
+    runner = _Runner()
+    ctx = SimpleNamespace(
+        market_data_manager=_Mdm(),
+        strategy_runner=runner,
+        settings=SimpleNamespace(execution_mode="SHADOW"),
+        broker_client=object(),
+        order_manager=object(),
+        selected_ce=ce,
+        selected_pe=pe,
+        active_symbol_tokens={ce: 11, "NIFTY26JUN23900CE": 11, pe: 12, "NIFTY26JUN23900PE": 12},
+        active_trading_universe={
+            "spot_symbol": "NSE:NIFTY",
+            "selected_ce": ce,
+            "selected_pe": pe,
+            "option_symbols": [ce, pe],
+            "all_symbols": ["NSE:NIFTY", ce, pe],
+            "token_by_symbol": {ce: 11, pe: 12},
+            "all_tokens": [256265, 11, 12],
+        },
+        active_contract_basket=None,
+        data_hard_ready=False,
+        evaluation_ready=False,
+        live_orders_armed=False,
+        trading_ready=False,
+    )
+
+    with caplog.at_level("INFO"):
+        await app._recompute_and_push_runtime_readiness(ctx, reason="test")
+
+    assert runner.counts[ce] >= 30
+    assert runner.counts[pe] >= 30
+    assert runner.runtime_payloads[-1]["evaluation_ready"] is True
+    assert "ce_eval_bars_missing" not in str(ctx.live_block_reason)
+    assert "pe_eval_bars_missing" not in str(ctx.live_block_reason)
+    assert "SELECTED_OPTION_RUNNER_SYNC_FROM_MDM" in caplog.text
+    assert "SELECTED_OPTION_RESEED_FAILED" not in caplog.text

--- a/tests/core/test_commit_active_dynamic_basket.py
+++ b/tests/core/test_commit_active_dynamic_basket.py
@@ -172,3 +172,77 @@ def test_resolve_active_futures_for_basket_uses_active_universe_when_mdm_unresol
     )
 
     assert app._resolve_active_futures_for_basket(ctx, "NFO:NIFTY26MAYFUT") == "NFO:NIFTY26MAYFUT"
+
+
+def test_real_botcontext_active_symbol_tokens_and_selected_subscription_aliases() -> None:
+    from nifty_scalper_bot.config.settings import Settings
+    from nifty_scalper_bot.core.app import AppConfig, BotContext, RateLimiter
+
+    class _Mdm:
+        def __init__(self) -> None:
+            self.desired: set[int] = set()
+            self.received_basket = None
+
+        def purge_stale_nifty_futures(self, active_symbol, *, reason):
+            return []
+
+        def set_active_contract_basket(self, basket):
+            self.received_basket = basket
+            self.desired.update(int(t) for t in basket.get("all_tokens", []) if t)
+
+        def request_token_subscription(self, token: int, symbol: str | None = None) -> bool:
+            self.desired.add(int(token))
+            return True
+
+        def desired_token_count(self) -> int:
+            return len(self.desired)
+
+        def desired_tokens_snapshot(self) -> list[int]:
+            return sorted(self.desired)
+
+        def ws_token_count(self):
+            return None
+
+    mdm = _Mdm()
+    ctx = BotContext(
+        settings=Settings(),
+        config=AppConfig(),
+        rate_limiter=RateLimiter(),
+        broker_client=None,
+        websocket_client=None,
+        websocket_manager=None,
+        streamer=None,
+        stream_supervisor=None,
+        polling_fallback_streamer=None,
+        message_bus=None,
+        market_data_manager=mdm,
+        strategy_runner=None,
+        strategy_manager=None,
+    )
+    assert hasattr(ctx, "active_symbol_tokens")
+
+    ce = "NFO:NIFTY26JUN23900CE"
+    pe = "NFO:NIFTY26JUN23900PE"
+    app._commit_active_dynamic_basket(
+        ctx,
+        basket={
+            "spot_symbol": "NSE:NIFTY",
+            "spot_token": 256265,
+            "selected_ce": ce,
+            "selected_pe": pe,
+            "selected_ce_token": 11,
+            "selected_pe_token": 12,
+            "all_symbols": ["NSE:NIFTY", ce, pe],
+            "all_tokens": [256265, 11, 12],
+            "token_by_symbol": {"NSE:NIFTY": 256265, ce: 11, pe: 12},
+        },
+        option_symbols=[ce, pe],
+        symbols=["NSE:NIFTY", ce, pe],
+        atm_strike=23900,
+    )
+
+    assert ctx.active_symbol_tokens[ce] == 11
+    assert ctx.active_symbol_tokens["NIFTY26JUN23900CE"] == 11
+    assert ctx.active_symbol_tokens[pe] == 12
+    assert ctx.active_symbol_tokens["NIFTY26JUN23900PE"] == 12
+    assert {11, 12}.issubset(set(mdm.desired_tokens_snapshot()))

--- a/tests/strategies/test_runner_live_path_guards.py
+++ b/tests/strategies/test_runner_live_path_guards.py
@@ -2589,3 +2589,44 @@ def test_entry_exception_rolls_back_dedup(monkeypatch) -> None:
     result = runner._handle_entry_signal_inner(signal, sym, sym, 100.0, datetime.now(timezone.utc), trace_id='entry-exc')
     assert result.reason == 'entry_exception'
     assert 'NIFTY:PE:OrderFlow' not in runner._signal_attempt_debounce_state
+
+
+def test_strategy_evaluation_allowed_excludes_spot_and_futures_context_symbols(caplog):
+    runner = StrategyRunner()
+    runner._active_symbols.update({"NSE:NIFTY", "NFO:NIFTY26JUNFUT", "NFO:NIFTY26JUN23900CE"})
+    runner._indicator_engine.has_min_bars = MagicMock(return_value=True)
+    runner._indicator_engine.get_history = MagicMock(return_value=[object()] * 40)
+
+    with caplog.at_level(logging.INFO):
+        assert runner._strategy_evaluation_allowed("NSE:NIFTY", trace_id="spot") is False
+        assert runner._strategy_evaluation_allowed("NFO:NIFTY26JUNFUT", trace_id="fut") is False
+
+    assert runner._indicator_engine.has_min_bars.call_count == 0
+    assert "RUNNER_GLOBAL_READINESS_DECISION" in caplog.text
+
+
+def test_live_universe_bootstrap_accepts_desired_tokens_and_fresh_ticks(caplog):
+    ce = "NFO:NIFTY26JUN23900CE"
+    pe = "NFO:NIFTY26JUN23900PE"
+    runner = StrategyRunner()
+    runner._active_selected_ce = ce
+    runner._active_selected_pe = pe
+    runner._active_symbols.update({ce, pe})
+    runner._market_data = SimpleNamespace(
+        _token_by_symbol={ce: 11, pe: 12},
+        _desired_tokens={11, 12},
+        _subscribed_tokens=set(),
+        _confirmed_subscriptions=set(),
+        _active_subscribed_symbols=set(),
+    )
+    runner._is_option_symbol_tick_fresh = MagicMock(return_value=True)
+    runner._is_symbol_execution_ready = MagicMock(return_value=True)
+    runner._indicator_engine.get_history = MagicMock(return_value=[object()] * 40)
+
+    with caplog.at_level(logging.INFO):
+        ready, reason = runner._emit_live_universe_bootstrap_status(symbol=ce)
+
+    assert ready is True
+    assert reason is None
+    assert "selected_option_subscription_pending" not in caplog.text
+    assert "SELECTED_OPTION_SUBSCRIPTION_STATE" in caplog.text


### PR DESCRIPTION
### Motivation
- Fix a runtime crash where `BotContext` lacked `active_symbol_tokens` causing `_commit_active_dynamic_basket()` to fail and prevent basket commit/subscription reconciliation. 
- Resolve readiness blockers where MDM had sufficient OHLC bars but the runner/indicator history stayed short, producing `*_eval_bars_missing` blockers. 
- Broaden selected-option subscription proof to include desired/subscribed tokens and fresh ticks so bootstrap readiness is not overly strict. 

### Description
- Initialize `active_symbol_tokens` on the real `BotContext` and add `_ensure_active_symbol_tokens(ctx)` defensive init at startup. (add `active_symbol_tokens: dict[str,int] = field(default_factory=dict)`)
- Harden `_commit_active_dynamic_basket()` to defensively use `active_symbol_tokens`, store both full and bare aliases for selected CE/PE tokens, update committed token lists, and request MDM token subscriptions; emit `ACTIVE_BASKET_SUBSCRIPTION_RECONCILED` and `SELECTED_OPTION_SUBSCRIPTION_CONFIRMED` logs.
- Improve selected-option hydration/resync path in `_ensure_selected_options_hydrated()` to: only call broker/MDM hydrate when MDM lacks bars, reseed runner via `reseed_history_from_bars()` and emit `SELECTED_OPTION_RUNNER_SYNC_FROM_MDM` on successful sync instead of reporting false reseed failures.
- Add `SELECTED_OPTION_SUBSCRIPTION_STATE` diagnostics and change readiness helpers so subscription confirmation accepts desired/subscribed/confirmed tokens or a fresh WS tick as valid proof.
- Improve MDM hydration diagnostics by exposing `required_for_readiness` and `symbol_hard_ready` per-symbol so non-selected nearby options do not incorrectly look like hard blockers.
- Prevent the runner from treating spot/futures context symbols as strategy candidates by emitting `RUNNER_GLOBAL_READINESS_DECISION` and returning early in `_strategy_evaluation_allowed()`; this preserves strategy scoring while avoiding mis-evaluation of context symbols.
- Add focused regression tests that instantiate real `BotContext`, validate `active_symbol_tokens` behavior, assert selected CE/PE alias mapping and MDM subscription requests, assert runner reseed sync from MDM bars, and assert runner excludes context symbols from strategy evaluation.

### Testing
- Commands run: `python -m compileall -q src` and `pytest -q` (focused suites: `tests/core/test_startup_spot_watchdog.py`, `tests/core/test_commit_active_dynamic_basket.py`, `tests/core/test_basket_commit_before_readiness.py`, `tests/data/test_mdm_subscribes_active_basket.py`, `tests/test_live_basket_hydration.py`, `tests/test_live_tick_pipeline_to_runner.py`, `tests/strategies/test_runner_live_path_guards.py`).
- Results: compilation passed and the test suites passed (no failing tests); added regression tests executed and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d54c8b61c83248cc83d2f759b900a)