### PR TITLE
Harden polling failover supervisor off-market handling

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -138,6 +138,199 @@ def _polling_fallback_degraded(
     return False
 
 
+def _safe_supervisor_call(
+    name: str,
+    candidate: Any,
+    *args: Any,
+    default: Any = None,
+    **kwargs: Any,
+) -> Any:
+    """Call supervisor dependencies safely without letting bad attributes spam the loop."""
+
+    if not callable(candidate):
+        log_throttled(
+            LOGGER,
+            f"polling_supervisor_noncallable:{name}",
+            "POLLING_SUPERVISOR_NONCALLABLE name=%s type=%s repr=%s"
+            % (name, type(candidate).__name__, repr(candidate)[:160]),
+            interval_sec=60.0,
+            level=logging.WARNING,
+            extra={
+                "event": "POLLING_SUPERVISOR_NONCALLABLE",
+                "callable_name": name,
+                "candidate_type": type(candidate).__name__,
+                "candidate_repr": repr(candidate)[:160],
+            },
+        )
+        return default
+    try:
+        return candidate(*args, **kwargs)
+    except Exception as exc:  # noqa: BLE001 - supervisor dependencies must degrade safely
+        log_throttled(
+            LOGGER,
+            f"polling_supervisor_call_failed:{name}:{type(exc).__name__}",
+            "POLLING_SUPERVISOR_CALL_FAILED name=%s error_type=%s error=%s"
+            % (name, type(exc).__name__, str(exc)),
+            interval_sec=60.0,
+            level=logging.WARNING,
+            extra={
+                "event": "POLLING_SUPERVISOR_CALL_FAILED",
+                "callable_name": name,
+                "error_type": type(exc).__name__,
+                "error": str(exc),
+            },
+        )
+        return default
+
+
+async def _polling_failover_supervisor_iteration(
+    ctx: Any,
+    polling_fallback: Any,
+    *,
+    quote_stale_ms: int,
+    degraded_since: float | None,
+    recovered_since: float | None,
+    activate_after: float = 3.0,
+    recover_cooldown: float = 10.0,
+) -> tuple[float | None, float | None]:
+    """Run one polling failover supervisor pass. Args: ctx/fallback/state. Returns: state."""
+
+    market_open = bool(_safe_supervisor_call("is_market_open_now", is_market_open_now, default=False))
+    ws_ok = bool(_safe_supervisor_call(
+        "websocket_manager.is_connected",
+        getattr(ctx.websocket_manager, "is_connected", None),
+        default=False,
+    ))
+    feed_health = _safe_supervisor_call(
+        "market_data_manager.trading_feed_health",
+        getattr(ctx.market_data_manager, "trading_feed_health", None),
+        max_age_ms=quote_stale_ms,
+        default={},
+    )
+    if not isinstance(feed_health, Mapping):
+        feed_health = {}
+    futures_fresh = bool(feed_health.get("futures_fresh"))
+    options_fresh = bool(feed_health.get("options_fresh"))
+    spot_fresh = bool(feed_health.get("spot_fresh"))
+    spot_symbol = str(feed_health.get("spot_symbol") or "NSE:NIFTY")
+    spot_age_ms = feed_health.get("spot_age_ms")
+    auth_tick_age_raw = _safe_supervisor_call(
+        "market_data_manager.data_age_ms",
+        getattr(ctx.market_data_manager, "data_age_ms", None),
+        default=10**9,
+    )
+    try:
+        auth_tick_age_ms = float(auth_tick_age_raw)
+    except (TypeError, ValueError):
+        auth_tick_age_ms = float(10**9)
+    lagging = auth_tick_age_ms > quote_stale_ms
+    degraded = _polling_fallback_degraded(
+        ws_ok=ws_ok,
+        lagging=lagging,
+        futures_fresh=futures_fresh,
+        options_fresh=options_fresh,
+    )
+    now_mono = time_module.monotonic()
+    if not market_open:
+        # Off-market: never aggressively activate the REST polling fallback
+        # just because the last quote crossed the open-market threshold.
+        log_throttled(
+            LOGGER,
+            f"polling_fallback_skipped:{spot_symbol}:market_closed",
+            "POLLING_FALLBACK_SKIPPED reason=market_closed age_ms=%s"
+            % spot_age_ms,
+            interval_sec=60.0,
+            level=logging.DEBUG,
+            extra={
+                "event": "POLLING_FALLBACK_SKIPPED",
+                "reason": "market_closed",
+                "age_ms": spot_age_ms,
+            },
+        )
+        degraded_since = None
+        if polling_fallback.is_running():
+            polling_fallback.set_websocket_mode(True)
+            polling_fallback.stop()
+        return degraded_since, recovered_since
+    if degraded:
+        recovered_since = None
+        degraded_since = degraded_since or now_mono
+        if (
+            now_mono - degraded_since >= activate_after
+            and not polling_fallback.is_running()
+        ):
+            if (
+                spot_age_ms is not None
+                and float(spot_age_ms) <= float(quote_stale_ms)
+                and ws_ok
+            ):
+                log_throttled(
+                    LOGGER,
+                    f"polling_fallback_skipped:{spot_symbol}:within_spot_stale_threshold",
+                    "POLLING_FALLBACK_SKIPPED reason=within_spot_stale_threshold age_ms=%s threshold_ms=%s ws_ok=%s"
+                    % (spot_age_ms, quote_stale_ms, ws_ok),
+                    interval_sec=60.0,
+                    level=logging.INFO,
+                    extra={
+                        "event": "POLLING_FALLBACK_SKIPPED",
+                        "reason": "within_spot_stale_threshold",
+                        "age_ms": spot_age_ms,
+                        "threshold_ms": quote_stale_ms,
+                        "ws_ok": ws_ok,
+                    },
+                )
+                return degraded_since, recovered_since
+            LOGGER.warning(
+                "POLLING_FALLBACK_ACTIVATE reason=spot_stale age_ms=%s threshold_ms=%s ws_ok=%s lagging=%s",
+                spot_age_ms,
+                quote_stale_ms,
+                ws_ok,
+                lagging,
+                extra={
+                    "event": "POLLING_FALLBACK_ACTIVATE",
+                    "reason": (
+                        "ws_disconnected"
+                        if not ws_ok
+                        else "tick_lag"
+                        if lagging
+                        else "futures_stale"
+                        if not futures_fresh
+                        else "options_stale"
+                    ),
+                    "lagging": lagging,
+                    "futures_fresh": futures_fresh,
+                    "options_fresh": options_fresh,
+                    "authoritative_age_ms": auth_tick_age_ms,
+                },
+            )
+            polling_fallback.set_websocket_mode(False)
+            polling_fallback.start()
+    else:
+        if not spot_fresh:
+            ctx.market_data_manager.ensure_spot_reference_fresh(
+                symbol=spot_symbol,
+                stale_after_ms=quote_stale_ms,
+            )
+            LOGGER.info(
+                "poll_fallback_skipped_spot_only_stale symbol=%s age_ms=%s",
+                spot_symbol,
+                spot_age_ms,
+            )
+        degraded_since = None
+        recovered_since = recovered_since or now_mono
+        if (
+            now_mono - recovered_since >= recover_cooldown
+            and polling_fallback.is_running()
+        ):
+            LOGGER.info(
+                "Polling fallback deactivate (supervisor) after ws recovery cooldown",
+                extra={"event": "polling_fallback_deactivated"},
+            )
+            polling_fallback.set_websocket_mode(True)
+            polling_fallback.stop()
+    return degraded_since, recovered_since
+
+
 def _run_sync_locked(operation: Callable[[], Any]) -> Any:
     """Run synchronization-critical broker operations under a process-wide lock."""
     with SYNC_LOCK:
@@ -9958,130 +10151,25 @@ async def startup_sequence(ctx: BotContext) -> None:
                         quote_stale_ms = int(fallback_stale_sec * 1000.0)
                         while True:
                             try:
-                                market_open = is_market_open_now()
-                                ws_ok = bool(ctx.websocket_manager.is_connected())
-                                feed_health = ctx.market_data_manager.trading_feed_health(
-                                    max_age_ms=quote_stale_ms
+                                degraded_since, recovered_since = await _polling_failover_supervisor_iteration(
+                                    ctx,
+                                    polling_fallback,
+                                    quote_stale_ms=quote_stale_ms,
+                                    degraded_since=degraded_since,
+                                    recovered_since=recovered_since,
+                                    activate_after=activate_after,
+                                    recover_cooldown=recover_cooldown,
                                 )
-                                futures_fresh = bool(feed_health.get("futures_fresh"))
-                                options_fresh = bool(feed_health.get("options_fresh"))
-                                spot_fresh = bool(feed_health.get("spot_fresh"))
-                                spot_symbol = str(feed_health.get("spot_symbol") or "NSE:NIFTY")
-                                spot_age_ms = feed_health.get("spot_age_ms")
-                                auth_tick_age_ms = ctx.market_data_manager.data_age_ms()
-                                lagging = auth_tick_age_ms > quote_stale_ms
-                                degraded = _polling_fallback_degraded(
-                                    ws_ok=ws_ok,
-                                    lagging=lagging,
-                                    futures_fresh=futures_fresh,
-                                    options_fresh=options_fresh,
-                                )
-                                now_mono = time_module.monotonic()
-                                if not market_open:
-                                    # Off-market: never aggressively activate
-                                    # the REST polling fallback just because the
-                                    # last quote crossed the open-market threshold.
-                                    log_throttled(
-                                        LOGGER,
-                                        f"polling_fallback_skipped:{spot_symbol}:market_closed",
-                                        "POLLING_FALLBACK_SKIPPED reason=market_closed age_ms=%s"
-                                        % spot_age_ms,
-                                        interval_sec=60.0,
-                                        level=logging.DEBUG,
-                                        extra={
-                                            "event": "POLLING_FALLBACK_SKIPPED",
-                                            "reason": "market_closed",
-                                            "age_ms": spot_age_ms,
-                                        },
-                                    )
-                                    degraded_since = None
-                                    if polling_fallback.is_running():
-                                        polling_fallback.set_websocket_mode(True)
-                                        polling_fallback.stop()
-                                    await asyncio.sleep(1.0)
-                                    continue
-                                if degraded:
-                                    recovered_since = None
-                                    degraded_since = degraded_since or now_mono
-                                    if (
-                                        now_mono - degraded_since >= activate_after
-                                        and not polling_fallback.is_running()
-                                    ):
-                                        if (
-                                            spot_age_ms is not None
-                                            and float(spot_age_ms) <= float(quote_stale_ms)
-                                            and ws_ok
-                                        ):
-                                            log_throttled(
-                                                LOGGER,
-                                                f"polling_fallback_skipped:{spot_symbol}:within_spot_stale_threshold",
-                                                "POLLING_FALLBACK_SKIPPED reason=within_spot_stale_threshold age_ms=%s threshold_ms=%s ws_ok=%s"
-                                                % (spot_age_ms, quote_stale_ms, ws_ok),
-                                                interval_sec=60.0,
-                                                level=logging.INFO,
-                                                extra={
-                                                    "event": "POLLING_FALLBACK_SKIPPED",
-                                                    "reason": "within_spot_stale_threshold",
-                                                    "age_ms": spot_age_ms,
-                                                    "threshold_ms": quote_stale_ms,
-                                                    "ws_ok": ws_ok,
-                                                },
-                                            )
-                                            await asyncio.sleep(1.0)
-                                            continue
-                                        LOGGER.warning(
-                                            "POLLING_FALLBACK_ACTIVATE reason=spot_stale age_ms=%s threshold_ms=%s ws_ok=%s lagging=%s",
-                                            spot_age_ms,
-                                            quote_stale_ms,
-                                            ws_ok,
-                                            lagging,
-                                            extra={
-                                                "event": "poll_fallback_activate",
-                                                "reason": (
-                                                    "ws_disconnected"
-                                                    if not ws_ok
-                                                    else "tick_lag"
-                                                    if lagging
-                                                    else "futures_stale"
-                                                    if not futures_fresh
-                                                    else "options_stale"
-                                                ),
-                                                "lagging": lagging,
-                                                "futures_fresh": futures_fresh,
-                                                "options_fresh": options_fresh,
-                                                "authoritative_age_ms": auth_tick_age_ms,
-                                            },
-                                        )
-                                        polling_fallback.set_websocket_mode(False)
-                                        polling_fallback.start()
-                                else:
-                                    if not spot_fresh:
-                                        ctx.market_data_manager.ensure_spot_reference_fresh(
-                                            symbol=spot_symbol,
-                                            stale_after_ms=quote_stale_ms,
-                                        )
-                                        LOGGER.info(
-                                            "poll_fallback_skipped_spot_only_stale symbol=%s age_ms=%s",
-                                            spot_symbol,
-                                            spot_age_ms,
-                                        )
-                                    degraded_since = None
-                                    recovered_since = recovered_since or now_mono
-                                    if (
-                                        now_mono - recovered_since >= recover_cooldown
-                                        and polling_fallback.is_running()
-                                    ):
-                                        LOGGER.info(
-                                            "Polling fallback deactivate (supervisor) after ws recovery cooldown",
-                                            extra={"event": "polling_fallback_deactivated"},
-                                        )
-                                        polling_fallback.set_websocket_mode(True)
-                                        polling_fallback.stop()
                             except Exception as failover_exc:  # noqa: BLE001
                                 LOGGER.error(
                                     "Failure in polling failover supervisor: %s",
                                     failover_exc,
-                                    exc_info=failover_exc,
+                                    exc_info=True,
+                                    extra={
+                                        "event": "POLLING_FAILOVER_SUPERVISOR_FAILED",
+                                        "error_type": type(failover_exc).__name__,
+                                        "error": str(failover_exc),
+                                    },
                                 )
                             await asyncio.sleep(1.0)
 
@@ -11018,14 +11106,22 @@ async def startup_sequence(ctx: BotContext) -> None:
                                     else "DATA_WARMUP"
                                 )
                                 ctx.effective_mode = ctx.readiness_mode
+                                pre_final_reason = (
+                                    "selected_option_history_or_quote_pending_pre_final_readiness"
+                                    if ctx.readiness_mode == "EVALUATION_READY"
+                                    else "awaiting_spot_or_active_basket_pre_final_readiness"
+                                )
                                 LOGGER.info(
-                                    "STARTUP_MODE_BLOCKED current=%s reason=%s",
+                                    "STARTUP_MODE_PRE_FINAL_READINESS current=%s reason=%s stage=%s",
                                     ctx.readiness_mode,
-                                    (
-                                        "selected_option_history_or_quote_not_ready"
-                                        if ctx.readiness_mode == "EVALUATION_READY"
-                                        else "awaiting_spot_or_active_basket"
-                                    ),
+                                    pre_final_reason,
+                                    "pre_final_readiness",
+                                    extra={
+                                        "event": "STARTUP_MODE_PRE_FINAL_READINESS",
+                                        "current": ctx.readiness_mode,
+                                        "reason": pre_final_reason,
+                                        "stage": "pre_final_readiness",
+                                    },
                                 )
                                 if previous_mode != ctx.readiness_mode:
                                     LOGGER.info(

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -5457,6 +5457,22 @@ class StrategyRunner:
             # Reuse an upstream trace_id if the tick payload already carries one
             # (set by RunnerCallback or by an outer caller); otherwise mint here.
             trace_id = tick.get("trace_id") or f"{normalized_symbol}-{time_module.monotonic_ns()}"
+            if self._is_context_symbol(normalized_symbol):
+                self._logger.info(
+                    "RUNNER_GLOBAL_READINESS_DECISION symbol=%s allowed=%s reason=%s",
+                    normalized_symbol,
+                    False,
+                    "context_symbol_not_strategy_candidate",
+                    extra={
+                        "event": "RUNNER_GLOBAL_READINESS_DECISION",
+                        "symbol": normalized_symbol,
+                        "trace_id": trace_id,
+                        "stage": "tick_ingress",
+                        "allowed": False,
+                        "reason": "context_symbol_not_strategy_candidate",
+                    },
+                )
+                return
             # RUNNER_TICK_CONSUMED: the tick has been pulled off the event bus
             # and accepted by the runner's evaluation entry point.  This is the
             # canonical observability breakpoint between publication and

--- a/tests/core/test_app_polling_fallback_market_aware.py
+++ b/tests/core/test_app_polling_fallback_market_aware.py
@@ -3,8 +3,15 @@ DATA_WARMUP readiness gate are now market-session aware."""
 
 from __future__ import annotations
 
+import logging
 import re
 from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from nifty_scalper_bot.core import app
 
 
 _APP_PATH = Path(__file__).resolve().parents[2] / "src" / "nifty_scalper_bot" / "core" / "app.py"
@@ -19,9 +26,9 @@ def test_polling_fallback_skipped_when_market_closed():
     s = _source()
     # The supervisor must check market_open and short-circuit with
     # POLLING_FALLBACK_SKIPPED reason=market_closed.
-    assert "polling_fallback_skipped_market_closed" in s
+    assert "polling_fallback_skipped:{spot_symbol}:market_closed" in s
     assert "POLLING_FALLBACK_SKIPPED reason=market_closed" in s
-    assert "market_open = is_market_open_now()" in s
+    assert 'market_open = bool(_safe_supervisor_call("is_market_open_now", is_market_open_now, default=False))' in s
 
 
 def test_within_threshold_polling_skip_log_is_throttled():
@@ -56,3 +63,92 @@ def test_market_session_state_logged_on_startup():
     """Args: none. Returns: None. Raises: AssertionError."""
     s = _source()
     assert "MARKET_SESSION_STATE state=%s" in s
+
+
+class _Fallback:
+    def __init__(self) -> None:
+        self.start = MagicMock()
+        self.stop = MagicMock()
+        self.set_websocket_mode = MagicMock()
+        self._running = False
+
+    def is_running(self) -> bool:
+        return self._running
+
+
+def _supervisor_ctx(*, is_connected=True, feed_health=None, data_age_ms=10**9):
+    if feed_health is None:
+        feed_health = {
+            "futures_fresh": False,
+            "options_fresh": False,
+            "spot_fresh": False,
+            "spot_symbol": "NSE:NIFTY",
+            "spot_age_ms": 10**9,
+        }
+    return SimpleNamespace(
+        websocket_manager=SimpleNamespace(is_connected=is_connected),
+        market_data_manager=SimpleNamespace(
+            trading_feed_health=MagicMock(return_value=feed_health),
+            data_age_ms=MagicMock(return_value=data_age_ms),
+            ensure_spot_reference_fresh=MagicMock(),
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_polling_failover_supervisor_handles_tuple_is_connected(caplog, monkeypatch):
+    monkeypatch.setattr(app, "is_market_open_now", lambda: True)
+    ctx = _supervisor_ctx(is_connected=(False,))
+    fallback = _Fallback()
+
+    with caplog.at_level(logging.WARNING, logger="nifty_scalper_bot.core.app"):
+        await app._polling_failover_supervisor_iteration(
+            ctx,
+            fallback,
+            quote_stale_ms=1000,
+            degraded_since=0.0,
+            recovered_since=None,
+            activate_after=0.0,
+        )
+
+    assert "POLLING_SUPERVISOR_NONCALLABLE" in caplog.text
+    assert "websocket_manager.is_connected" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_polling_failover_supervisor_handles_tuple_market_open_fn(caplog, monkeypatch):
+    monkeypatch.setattr(app, "is_market_open_now", (False,))
+    ctx = _supervisor_ctx(is_connected=False)
+    fallback = _Fallback()
+
+    with caplog.at_level(logging.WARNING, logger="nifty_scalper_bot.core.app"):
+        await app._polling_failover_supervisor_iteration(
+            ctx,
+            fallback,
+            quote_stale_ms=1000,
+            degraded_since=0.0,
+            recovered_since=None,
+            activate_after=0.0,
+        )
+
+    assert "POLLING_SUPERVISOR_NONCALLABLE" in caplog.text
+    assert "is_market_open_now" in caplog.text
+    assert "Failure in polling failover supervisor" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_polling_failover_supervisor_offmarket_no_activation(monkeypatch):
+    monkeypatch.setattr(app, "is_market_open_now", lambda: False)
+    ctx = _supervisor_ctx(is_connected=False)
+    fallback = _Fallback()
+
+    await app._polling_failover_supervisor_iteration(
+        ctx,
+        fallback,
+        quote_stale_ms=1000,
+        degraded_since=0.0,
+        recovered_since=None,
+        activate_after=0.0,
+    )
+
+    fallback.start.assert_not_called()

--- a/tests/strategies/test_runner_live_path_guards.py
+++ b/tests/strategies/test_runner_live_path_guards.py
@@ -2630,3 +2630,16 @@ def test_live_universe_bootstrap_accepts_desired_tokens_and_fresh_ticks(caplog):
     assert reason is None
     assert "selected_option_subscription_pending" not in caplog.text
     assert "SELECTED_OPTION_SUBSCRIPTION_STATE" in caplog.text
+
+
+def test_on_tick_event_context_symbols_emit_global_readiness_not_eval_decision(caplog):
+    runner = StrategyRunner()
+    runner._active_symbols.update({"NSE:NIFTY", "NFO:NIFTY26JUNFUT", "NFO:NIFTY26JUN23900CE"})
+    with caplog.at_level(logging.INFO):
+        runner.on_tick_event({"symbol": "NSE:NIFTY", "last_price": 24000.0, "trace_id": "spot-tick"})
+        runner.on_tick_event({"symbol": "NFO:NIFTY26JUNFUT", "last_price": 24100.0, "trace_id": "fut-tick"})
+
+    assert "RUNNER_GLOBAL_READINESS_DECISION" in caplog.text
+    assert "context_symbol_not_strategy_candidate" in caplog.text
+    assert "RUNNER_EVAL_DECISION symbol=NSE:NIFTY" not in caplog.text
+    assert "RUNNER_EVAL_DECISION symbol=NFO:NIFTY26JUNFUT" not in caplog.text


### PR DESCRIPTION
### Motivation

- Prevent the polling failover supervisor from raising and spamming "'tuple' object is not callable" when runtime attributes are non-callable, and avoid repeating the failure every second.  
- Keep off-market behavior unchanged (do not activate REST polling while market closed) and avoid misleading startup diagnostics claiming a stale blocked state.  
- Ensure context-only symbols (spot/futures) do not generate strategy evaluation logs and instead emit a clear global readiness decision.  

### Description

- Added `_safe_supervisor_call(name, candidate, *args, default=..., **kwargs)` in `src/nifty_scalper_bot/core/app.py` to validate/call supervisor dependencies, throttle diagnostics, and avoid LogRecord reserved-key collisions.  
- Extracted a single supervisor pass into `_polling_failover_supervisor_iteration(...)` and replaced direct calls to `is_market_open_now`, `ctx.websocket_manager.is_connected`, `ctx.market_data_manager.trading_feed_health`, and `ctx.market_data_manager.data_age_ms` with `_safe_supervisor_call(...)` so non-callable attributes and exceptions degrade safely.  
- Fixed supervisor exception logging to use `exc_info=True` and include structured `POLLING_FAILOVER_SUPERVISOR_FAILED` metadata instead of passing the exception object directly to `exc_info`.  
- Replaced the pre-final startup blocked wording with `STARTUP_MODE_PRE_FINAL_READINESS` (stage=`pre_final_readiness`) to avoid stale "blocked" messages before final readiness recomputation.  
- Added an early ingress guard in `src/nifty_scalper_bot/strategies/runner.py` so spot/futures ticks emit `RUNNER_GLOBAL_READINESS_DECISION reason=context_symbol_not_strategy_candidate` and return before strategy evaluation diagnostics.  
- Added/updated focused tests: tuple/non-callable safety and off-market no-activation for the supervisor, and a test ensuring context-symbol tick ingress logs global readiness rather than `RUNNER_EVAL_DECISION`.  

### Testing

- Commands run: `python -m compileall -q src` and the focused test commands `pytest -q tests/core/test_app_polling_fallback_market_aware.py`, `pytest -q tests/core/test_basket_commit_before_readiness.py`, `pytest -q tests/strategies/test_runner_live_path_guards.py`, `pytest -q tests/core/test_startup_spot_watchdog.py`, and the full `pytest -q`.  
- Results: compilation passed and the focused tests passed (new/updated tests included); focused counts in this run: `tests/core/test_app_polling_fallback_market_aware.py` (8 passed), `tests/core/test_basket_commit_before_readiness.py` (9 passed), `tests/strategies/test_runner_live_path_guards.py` (passed), `tests/core/test_startup_spot_watchdog.py` (10 passed), and the full test suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d82c4b4548324ae6eee83ee145da9)