### PR TITLE
Fix off-market polling supervisor health checks

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -196,6 +196,31 @@ async def _polling_failover_supervisor_iteration(
     """Run one polling failover supervisor pass. Args: ctx/fallback/state. Returns: state."""
 
     market_open = bool(_safe_supervisor_call("is_market_open_now", is_market_open_now, default=False))
+    spot_symbol = "NSE:NIFTY"
+    spot_age_ms = None
+    now_mono = time_module.monotonic()
+    if not market_open:
+        # Off-market: never aggressively activate the REST polling fallback
+        # just because the last quote crossed the open-market threshold.
+        log_throttled(
+            LOGGER,
+            f"polling_fallback_skipped:{spot_symbol}:market_closed",
+            "POLLING_FALLBACK_SKIPPED reason=market_closed age_ms=%s"
+            % spot_age_ms,
+            interval_sec=60.0,
+            level=logging.DEBUG,
+            extra={
+                "event": "POLLING_FALLBACK_SKIPPED",
+                "reason": "market_closed",
+                "age_ms": spot_age_ms,
+            },
+        )
+        degraded_since = None
+        if polling_fallback.is_running():
+            polling_fallback.set_websocket_mode(True)
+            polling_fallback.stop()
+        return degraded_since, recovered_since
+
     ws_ok = bool(_safe_supervisor_call(
         "websocket_manager.is_connected",
         getattr(ctx.websocket_manager, "is_connected", None),
@@ -230,28 +255,6 @@ async def _polling_failover_supervisor_iteration(
         futures_fresh=futures_fresh,
         options_fresh=options_fresh,
     )
-    now_mono = time_module.monotonic()
-    if not market_open:
-        # Off-market: never aggressively activate the REST polling fallback
-        # just because the last quote crossed the open-market threshold.
-        log_throttled(
-            LOGGER,
-            f"polling_fallback_skipped:{spot_symbol}:market_closed",
-            "POLLING_FALLBACK_SKIPPED reason=market_closed age_ms=%s"
-            % spot_age_ms,
-            interval_sec=60.0,
-            level=logging.DEBUG,
-            extra={
-                "event": "POLLING_FALLBACK_SKIPPED",
-                "reason": "market_closed",
-                "age_ms": spot_age_ms,
-            },
-        )
-        degraded_since = None
-        if polling_fallback.is_running():
-            polling_fallback.set_websocket_mode(True)
-            polling_fallback.stop()
-        return degraded_since, recovered_since
     if degraded:
         recovered_since = None
         degraded_since = degraded_since or now_mono

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -4321,10 +4321,16 @@ class MarketDataManager:
         """Return whether a symbol has a fresh enough tick age."""
         return self.symbol_data_age_ms(symbol) <= int(max(max_age_ms, 1))
 
-    def _active_option_symbols(self) -> list[str]:
+    def _active_option_symbol_list(self) -> list[str]:
         """Return currently active option symbols used for hard feed checks."""
-        requirements = dict(self._readiness_requirements)
-        symbols = [str(s) for s in requirements.get("options") or [] if s]
+        requirements = self._readiness_requirements if isinstance(self._readiness_requirements, Mapping) else {}
+        raw_symbols = requirements.get("options") or []
+        if isinstance(raw_symbols, str):
+            symbols = [raw_symbols]
+        elif isinstance(raw_symbols, Iterable):
+            symbols = [str(s) for s in raw_symbols if s]
+        else:
+            symbols = []
         if not symbols:
             with self._lock:
                 symbols = [
@@ -4345,41 +4351,152 @@ class MarketDataManager:
         threshold = int(max_age_ms or self._tick_stale_threshold_ms)
         futures_symbol = str(self._readiness_requirements.get("futures") or "")
         if not futures_symbol:
-            return False
+            return True
         return self._is_symbol_fresh(futures_symbol, threshold)
 
     def _are_active_options_fresh(self, max_age_ms: int | None = None) -> bool:
         """Return whether active options feed is fresh enough for trading safety."""
         threshold = int(max_age_ms or self._tick_stale_threshold_ms)
-        option_symbols = self._active_option_symbols()
+        option_symbols = self._active_option_symbol_list()
         if not option_symbols:
             return False
         return all(self._is_symbol_fresh(symbol, threshold) for symbol in option_symbols)
 
-    def trading_feed_health(self, max_age_ms: int | None = None) -> dict[str, Any]:
-        """Return trading-critical feed health where spot is advisory only."""
-        threshold = int(max_age_ms or self._tick_stale_threshold_ms)
-        requirements = dict(self._readiness_requirements)
-        spot_symbol = str(requirements.get("spot") or "NSE:NIFTY")
-        futures_symbol = str(requirements.get("futures") or "")
-        option_symbols = self._active_option_symbols()
-        futures_fresh = self._is_futures_fresh(threshold)
-        options_fresh = self._are_active_options_fresh(threshold)
-        spot_fresh = self._is_spot_fresh(threshold)
-        return {
-            "trading_feed_healthy": futures_fresh and options_fresh,
-            "futures_fresh": futures_fresh,
-            "options_fresh": options_fresh,
-            "spot_fresh": spot_fresh,
-            "spot_symbol": spot_symbol,
-            "spot_age_ms": self.symbol_data_age_ms(spot_symbol),
-            "futures_symbol": futures_symbol,
-            "futures_age_ms": self.symbol_data_age_ms(futures_symbol)
-            if futures_symbol
-            else 1_000_000_000,
-            "option_symbols": option_symbols,
+    def trading_feed_health(self, max_age_ms: int | float | None = None) -> dict[str, Any]:
+        """Return trading-critical feed health where spot is advisory only.
+
+        This method is used by the polling-failover supervisor, so it must be
+        conservative and non-raising even when readiness state is malformed.
+        """
+
+        threshold = int(max(float(max_age_ms or self._tick_stale_threshold_ms), 1.0))
+        fallback: dict[str, Any] = {
+            "trading_feed_healthy": False,
+            "futures_fresh": False,
+            "options_fresh": False,
+            "spot_fresh": False,
+            "spot_symbol": "NSE:NIFTY",
+            "spot_age_ms": 1_000_000_000,
+            "futures_symbol": "",
+            "futures_age_ms": 1_000_000_000,
+            "option_symbols": [],
+            "options_age_ms": {},
             "threshold_ms": threshold,
         }
+        try:
+            reqs = self._readiness_requirements or {}
+            if not isinstance(reqs, Mapping):
+                raise TypeError(f"readiness_requirements_type={type(reqs).__name__}")
+
+            def _scalar_symbol(name: str, default: str = "") -> str:
+                value = reqs.get(name)
+                if value is None or value == "":
+                    return default
+                if isinstance(value, str):
+                    return normalize_symbol(value)
+                raise TypeError(f"{name}_symbol_type={type(value).__name__}")
+
+            def _option_symbol_list(value: Any) -> list[str]:
+                if value is None:
+                    return []
+                if isinstance(value, str):
+                    return [normalize_symbol(value)] if value.strip() else []
+                if isinstance(value, Iterable):
+                    return [normalize_symbol(str(symbol)) for symbol in value if symbol]
+                raise TypeError(f"options_type={type(value).__name__}")
+
+            spot_symbol = _scalar_symbol("spot", "NSE:NIFTY")
+            futures_symbol = _scalar_symbol("futures", "")
+            option_symbols = _option_symbol_list(reqs.get("options") or [])
+            if not option_symbols:
+                with self._lock:
+                    option_symbols = sorted(
+                        {
+                            symbol
+                            for symbol in self._active_subscribed_symbols
+                            if symbol.endswith("CE") or symbol.endswith("PE")
+                        }
+                    )
+
+            def _quote_for_symbol(symbol: str) -> Mapping[str, Any] | None:
+                quote = self.get_quote(symbol)
+                if quote:
+                    return quote
+                return self.get_latest_tick(symbol)
+
+            def _age_for_symbol(symbol: str) -> int | None:
+                if not symbol:
+                    return None
+                quote = _quote_for_symbol(symbol) or {}
+                raw_ts = (
+                    quote.get("timestamp_ms")
+                    or quote.get("last_trade_time_ms")
+                    or quote.get("received_at_ms")
+                )
+                if raw_ts is not None:
+                    try:
+                        raw_ms = float(raw_ts)
+                        if raw_ms > 1_000_000_000_000:
+                            return int(max(0.0, time.time() * 1000.0 - raw_ms))
+                        return int(max(0.0, time.time() * 1000.0 - raw_ms * 1000.0))
+                    except (TypeError, ValueError):
+                        pass
+                raw_ts = quote.get("timestamp") or quote.get("arrival_time") or quote.get("received_at")
+                if isinstance(raw_ts, datetime):
+                    ts = raw_ts.timestamp()
+                    return int(max(0.0, (time.time() - ts) * 1000.0))
+                if raw_ts is not None:
+                    try:
+                        return int(max(0.0, (time.time() - float(raw_ts)) * 1000.0))
+                    except (TypeError, ValueError):
+                        pass
+                age = self.symbol_data_age_ms_or_none(symbol)
+                return age
+
+            def _symbol_fresh(symbol: str) -> tuple[bool, int | None]:
+                age_ms = _age_for_symbol(symbol)
+                return (age_ms is not None and 0 <= int(age_ms) <= threshold), age_ms
+
+            spot_fresh, spot_age_ms = _symbol_fresh(spot_symbol)
+            if futures_symbol:
+                futures_fresh, futures_age_ms = _symbol_fresh(futures_symbol)
+            else:
+                futures_fresh, futures_age_ms = True, None
+
+            option_ages: dict[str, int | None] = {}
+            options_fresh = bool(option_symbols)
+            for symbol in option_symbols:
+                fresh, age_ms = _symbol_fresh(symbol)
+                option_ages[symbol] = age_ms
+                options_fresh = options_fresh and fresh
+
+            return {
+                "trading_feed_healthy": bool(futures_fresh and options_fresh),
+                "futures_fresh": bool(futures_fresh),
+                "options_fresh": bool(options_fresh),
+                "spot_fresh": bool(spot_fresh),
+                "spot_symbol": spot_symbol,
+                "spot_age_ms": spot_age_ms if spot_age_ms is not None else 1_000_000_000,
+                "futures_symbol": futures_symbol,
+                "futures_age_ms": futures_age_ms if futures_age_ms is not None else 1_000_000_000,
+                "option_symbols": option_symbols,
+                "options_age_ms": option_ages,
+                "threshold_ms": threshold,
+            }
+        except Exception as exc:  # noqa: BLE001 - supervisor health must never raise
+            self._logger.warning(
+                "TRADING_FEED_HEALTH_FAILED error_type=%s error=%s",
+                type(exc).__name__,
+                str(exc),
+                extra={
+                    "event": "TRADING_FEED_HEALTH_FAILED",
+                    "error_type": type(exc).__name__,
+                    "error": str(exc),
+                },
+            )
+            fallback["error"] = str(exc)
+            fallback["error_type"] = type(exc).__name__
+            return fallback
 
     def ensure_spot_reference_fresh(
         self,

--- a/tests/core/test_app_polling_fallback_market_aware.py
+++ b/tests/core/test_app_polling_fallback_market_aware.py
@@ -152,3 +152,57 @@ async def test_polling_failover_supervisor_offmarket_no_activation(monkeypatch):
     )
 
     fallback.start.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_polling_failover_supervisor_offmarket_does_not_call_feed_health(monkeypatch):
+    monkeypatch.setattr(app, "is_market_open_now", lambda: False)
+    ctx = _supervisor_ctx(is_connected=False)
+    ctx.websocket_manager.is_connected = MagicMock(side_effect=AssertionError("should not be called"))
+    ctx.market_data_manager.trading_feed_health = MagicMock(
+        side_effect=AssertionError("should not be called")
+    )
+    ctx.market_data_manager.data_age_ms = MagicMock(
+        side_effect=AssertionError("should not be called")
+    )
+    fallback = _Fallback()
+
+    await app._polling_failover_supervisor_iteration(
+        ctx,
+        fallback,
+        quote_stale_ms=1000,
+        degraded_since=0.0,
+        recovered_since=None,
+        activate_after=0.0,
+    )
+
+    fallback.start.assert_not_called()
+    fallback.stop.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_polling_failover_supervisor_offmarket_stops_running_fallback(monkeypatch):
+    monkeypatch.setattr(app, "is_market_open_now", lambda: False)
+    ctx = _supervisor_ctx(is_connected=False)
+    ctx.websocket_manager.is_connected = MagicMock(side_effect=AssertionError("should not be called"))
+    ctx.market_data_manager.trading_feed_health = MagicMock(
+        side_effect=AssertionError("should not be called")
+    )
+    ctx.market_data_manager.data_age_ms = MagicMock(
+        side_effect=AssertionError("should not be called")
+    )
+    fallback = _Fallback()
+    fallback._running = True
+
+    await app._polling_failover_supervisor_iteration(
+        ctx,
+        fallback,
+        quote_stale_ms=1000,
+        degraded_since=0.0,
+        recovered_since=None,
+        activate_after=0.0,
+    )
+
+    fallback.start.assert_not_called()
+    fallback.set_websocket_mode.assert_called_once_with(True)
+    fallback.stop.assert_called_once()

--- a/tests/data/test_market_data_health.py
+++ b/tests/data/test_market_data_health.py
@@ -106,3 +106,39 @@ def test_spot_stale_only_does_not_flip_trading_feed_health() -> None:
     _seed_tick(manager, 'NFO:NIFTYATMPE', age_seconds=0.2)
 
     assert manager.trading_feed_health(max_age_ms=5_000)['trading_feed_healthy'] is True
+
+
+def test_trading_feed_health_handles_tuple_fields_without_calling() -> None:
+    manager = _build_manager()
+    manager._readiness_requirements["options"] = (  # noqa: SLF001
+        "NFO:NIFTYATMCE",
+        "NFO:NIFTYATMPE",
+    )
+    _seed_tick(manager, "NFO:NIFTYFUT", age_seconds=0.2)
+    _seed_tick(manager, "NFO:NIFTYATMCE", age_seconds=0.2)
+    _seed_tick(manager, "NFO:NIFTYATMPE", age_seconds=0.2)
+
+    health = manager.trading_feed_health(max_age_ms=5_000)
+
+    assert isinstance(health, dict)
+    assert "futures_fresh" in health
+    assert "options_fresh" in health
+    assert "trading_feed_healthy" in health
+    assert health["futures_fresh"] is True
+    assert health["options_fresh"] is True
+    assert health["trading_feed_healthy"] is True
+
+
+def test_trading_feed_health_never_raises_when_requirements_malformed() -> None:
+    manager = _build_manager()
+    manager._readiness_requirements = {  # noqa: SLF001
+        "options": ("NFO:XCE", "NFO:XPE"),
+        "futures": ("NFO:FUT",),
+        "spot": ("NSE:NIFTY",),
+    }
+
+    health = manager.trading_feed_health(max_age_ms=5_000)
+
+    assert health["trading_feed_healthy"] is False
+    assert health["error_type"] == "TypeError"
+    assert "futures_symbol_type" in health["error"] or "spot_symbol_type" in health["error"]


### PR DESCRIPTION
### Motivation
- Root cause: the polling supervisor called WebSocket state, `market_data_manager.trading_feed_health()`, and `data_age_ms()` before short-circuiting for a closed market, allowing off-market iterations to call feed health and emit `POLLING_SUPERVISOR_CALL_FAILED` logs.
- Secondary root cause: `MarketDataManager.trading_feed_health()` could raise `TypeError: 'tuple' object is not callable` because a tuple-valued readiness field/attribute shadowed a same-named helper call.

### Description
- Reordered `_polling_failover_supervisor_iteration()` in `src/nifty_scalper_bot/core/app.py` so the market-closed short-circuit runs immediately after `is_market_open_now`, logging `POLLING_FALLBACK_SKIPPED reason=market_closed` and stopping a running fallback before any WebSocket/feed-health/data-age calls.
- Fixed the tuple-call bug and hardened health diagnostics in `src/nifty_scalper_bot/data/market_data_manager.py` by renaming the active-option helper to `_active_option_symbol_list`, defensively parsing readiness fields as values, computing per-symbol ages via `get_quote`/`get_latest_tick` fallback, treating missing configured futures as soft when unconfigured, keeping spot advisory, and returning a conservative diagnostic (with `TRADING_FEED_HEALTH_FAILED`) on internal errors.
- Added focused regression tests: `tests/core/test_app_polling_fallback_market_aware.py` (ensures off-market supervisor does not call `is_connected`, `trading_feed_health`, or `data_age_ms` and stops an already-running fallback), and `tests/data/test_market_data_health.py` (ensures tuple or malformed readiness fields do not raise and return conservative diagnostics).
- No changes to strategy scoring, execution/risk gates, contract SSOT, or readiness gate semantics beyond defensive handling and ordering.

### Testing
- Commands run: `python -m compileall -q src` and `pytest -q` focused suite including `tests/core/test_app_polling_fallback_market_aware.py` and `tests/data/test_market_data_health.py` (and additional related tests referenced by the suite).
- Result: compilation passed and the focused tests passed (regressions fixed); full test suite completed with no failures in the runs executed (see test runs for `tests/core/test_basket_commit_before_readiness.py` and `tests/strategies/test_runner_live_path_guards.py`, which also passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1dcef2a3088324ae34fb8ad4b5639e)