### PR TITLE
Harden active basket state propagation

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -7749,6 +7749,9 @@ async def _recompute_and_push_runtime_readiness(ctx: BotContext, *, reason: str)
         execution_ready_by_symbol[str(selected_pe)] = bool(pe_exec_ready)
     any_selected_option_exec_ready = bool(ce_exec_ready or pe_exec_ready)
     live_orders_armed=bool(live_mode and market_open and evaluation_ready and context_exec_ready and broker_ready and any_selected_option_exec_ready)
+    data_ready = bool(data_hard_ready)
+    strategy_evaluation_ready = bool(evaluation_ready)
+    trading_signal_ready = bool(data_ready and strategy_evaluation_ready)
     missing=[]
     if not selected_ce: missing.append('selected_ce_missing')
     if not selected_pe: missing.append('selected_pe_missing')
@@ -7777,13 +7780,14 @@ async def _recompute_and_push_runtime_readiness(ctx: BotContext, *, reason: str)
         block_reason = f"ACTIVE_BASKET_HYDRATION_NOT_READY:{','.join(hydration_blockers)}"
     else:
         block_reason=None if live_orders_armed else f"execution_not_armed:{','.join(dict.fromkeys(missing))}"
-    ctx.data_hard_ready=data_hard_ready; ctx.evaluation_ready=evaluation_ready; ctx.live_orders_armed=live_orders_armed; ctx.trading_ready=evaluation_ready; ctx.live_block_reason=block_reason
+    execution_block_reason = None if live_orders_armed else ("market_closed" if live_mode and not market_open else str(block_reason or "execution_not_armed"))
+    ctx.data_hard_ready=data_hard_ready; ctx.data_ready=data_ready; ctx.evaluation_ready=evaluation_ready; ctx.strategy_evaluation_ready=strategy_evaluation_ready; ctx.trading_signal_ready=trading_signal_ready; ctx.execution_armed=live_orders_armed; ctx.execution_block_reason=execution_block_reason; ctx.market_open=market_open; ctx.live_orders_armed=live_orders_armed; ctx.trading_ready=trading_signal_ready; ctx.live_block_reason=block_reason
     ctx.execution_ready_by_symbol = execution_ready_by_symbol
     ctx.selected_ce_exec_ready = bool(ce_exec_ready)
     ctx.selected_pe_exec_ready = bool(pe_exec_ready)
     ctx.context_exec_ready = bool(context_exec_ready)
     ctx.broker_ready = bool(broker_ready)
-    LOGGER.info("LIVE_READINESS_COMPUTED selected_ce=%s selected_pe=%s ce_ltp_fresh=%s pe_ltp_fresh=%s ce_tick_age_s=%s pe_tick_age_s=%s ce_tradable_quote=%s pe_tradable_quote=%s ce_depth_available=%s pe_depth_available=%s ce_subscription_confirmed=%s pe_subscription_confirmed=%s ce_subscription_or_live_tick=%s pe_subscription_or_live_tick=%s ce_bars_effective=%s ce_mdm_bars=%s ce_runner_bars=%s pe_bars_effective=%s pe_mdm_bars=%s pe_runner_bars=%s data_hard_ready=%s evaluation_ready=%s trading_ready=%s live_orders_armed=%s ce_quote_ready=%s pe_quote_ready=%s ce_exec_ready=%s pe_exec_ready=%s direction_context_ready=%s execution_ready_by_symbol=%s live_block_reason=%s", selected_ce, selected_pe, ce_quote_fresh, pe_quote_fresh, getattr(_snapshot(selected_ce),'tick_age_s',None), getattr(_snapshot(selected_pe),'tick_age_s',None), _tradable_quote(selected_ce), _tradable_quote(selected_pe), bool(getattr(_snapshot(selected_ce),'depth_available',False)), bool(getattr(_snapshot(selected_pe),'depth_available',False)), _subscription_confirmed(selected_ce), _subscription_confirmed(selected_pe), _subscription_or_live_tick(selected_ce), _subscription_or_live_tick(selected_pe), ce_bars, ce_mdm_bars, ce_runner_bars, pe_bars, pe_mdm_bars, pe_runner_bars, data_hard_ready, evaluation_ready, bool(ctx.trading_ready), live_orders_armed, ce_quote_fresh, pe_quote_fresh, ce_exec_ready, pe_exec_ready, bool(context_exec_ready), execution_ready_by_symbol, block_reason)
+    LOGGER.info("LIVE_READINESS_COMPUTED selected_ce=%s selected_pe=%s data_ready=%s strategy_evaluation_ready=%s trading_signal_ready=%s execution_armed=%s execution_block_reason=%s market_open=%s live_orders_armed=%s ce_ltp_fresh=%s pe_ltp_fresh=%s ce_tick_age_s=%s pe_tick_age_s=%s ce_tradable_quote=%s pe_tradable_quote=%s ce_depth_available=%s pe_depth_available=%s ce_subscription_confirmed=%s pe_subscription_confirmed=%s ce_subscription_or_live_tick=%s pe_subscription_or_live_tick=%s ce_bars_effective=%s ce_mdm_bars=%s ce_runner_bars=%s pe_bars_effective=%s pe_mdm_bars=%s pe_runner_bars=%s data_hard_ready=%s evaluation_ready=%s trading_ready=%s ce_quote_ready=%s pe_quote_ready=%s ce_exec_ready=%s pe_exec_ready=%s direction_context_ready=%s execution_ready_by_symbol=%s live_block_reason=%s", selected_ce, selected_pe, data_ready, strategy_evaluation_ready, trading_signal_ready, live_orders_armed, execution_block_reason, market_open, live_orders_armed, ce_quote_fresh, pe_quote_fresh, getattr(_snapshot(selected_ce),'tick_age_s',None), getattr(_snapshot(selected_pe),'tick_age_s',None), _tradable_quote(selected_ce), _tradable_quote(selected_pe), bool(getattr(_snapshot(selected_ce),'depth_available',False)), bool(getattr(_snapshot(selected_pe),'depth_available',False)), _subscription_confirmed(selected_ce), _subscription_confirmed(selected_pe), _subscription_or_live_tick(selected_ce), _subscription_or_live_tick(selected_pe), ce_bars, ce_mdm_bars, ce_runner_bars, pe_bars, pe_mdm_bars, pe_runner_bars, data_hard_ready, evaluation_ready, bool(ctx.trading_ready), ce_quote_fresh, pe_quote_fresh, ce_exec_ready, pe_exec_ready, bool(context_exec_ready), execution_ready_by_symbol, block_reason)
     if ctx.strategy_runner is not None and hasattr(ctx.strategy_runner, 'set_runtime_readiness'):
         ctx.strategy_runner.set_runtime_readiness(data_hard_ready=bool(ctx.data_hard_ready), evaluation_ready=bool(ctx.evaluation_ready), live_orders_armed=bool(ctx.live_orders_armed), reason=str(ctx.live_block_reason or reason), selected_ce=selected_ce, selected_pe=selected_pe, atm_strike=basket.get('atm_strike'), option_symbols=option_symbols, execution_ready_by_symbol=dict(getattr(ctx, "execution_ready_by_symbol", {}) or {}))
 
@@ -7951,6 +7955,46 @@ def _resolve_committed_symbol_token(
                 return token
     return None
 
+def _is_trade_complete_active_basket(basket: Mapping[str, object]) -> tuple[bool, list[str]]:
+    """Return whether a basket is complete enough to become active trading state."""
+    missing: list[str] = []
+    token_by_symbol = dict(basket.get("token_by_symbol") or {})
+    spot_symbol = str(basket.get("spot_symbol") or "NSE:NIFTY")
+    selected_ce = basket.get("selected_ce") or basket.get("atm_ce")
+    selected_pe = basket.get("selected_pe") or basket.get("atm_pe")
+    option_symbols = [s for s in (basket.get("option_symbols") or []) if s]
+    option_tokens = [_coerce_positive_token(t) for t in (basket.get("option_tokens") or [])]
+    all_tokens = [_coerce_positive_token(t) for t in (basket.get("all_tokens") or [])]
+
+    def _token_for(symbol: object, explicit_key: str) -> int | None:
+        if not symbol:
+            return None
+        sym = str(symbol)
+        bare = _bare_trading_symbol(sym)
+        return _coerce_positive_token(basket.get(explicit_key)) or _coerce_positive_token(token_by_symbol.get(sym)) or _coerce_positive_token(token_by_symbol.get(bare))
+
+    if not spot_symbol:
+        missing.append("spot_symbol")
+    if _coerce_positive_token(basket.get("spot_token")) is None and _coerce_positive_token(token_by_symbol.get(spot_symbol)) is None and spot_symbol != "NSE:NIFTY":
+        missing.append("spot_token")
+    if not selected_ce:
+        missing.append("selected_ce")
+    if not selected_pe:
+        missing.append("selected_pe")
+    if selected_ce and _token_for(selected_ce, "selected_ce_token") is None:
+        missing.append("selected_ce_token")
+    if selected_pe and _token_for(selected_pe, "selected_pe_token") is None:
+        missing.append("selected_pe_token")
+    if not option_symbols:
+        missing.append("option_symbols")
+    if not [t for t in option_tokens if t is not None]:
+        missing.append("option_tokens")
+    if not [t for t in all_tokens if t is not None]:
+        missing.append("all_tokens")
+    # Futures context is optional for trading readiness; do not reject an otherwise complete option basket here.
+    return not missing, list(dict.fromkeys(missing))
+
+
 def _commit_active_dynamic_basket(
     ctx: BotContext,
     *,
@@ -7967,10 +8011,6 @@ def _commit_active_dynamic_basket(
     basket_copy = dict(basket or {})
     basket_copy["futures_symbol"] = active_futures_symbol
     basket = normalize_active_basket_schema(basket_copy)
-    mdm_for_purge = getattr(ctx, "market_data_manager", None)
-    purge_stale_futures = getattr(mdm_for_purge, "purge_stale_nifty_futures", None)
-    if callable(purge_stale_futures):
-        purge_stale_futures(active_futures_symbol, reason="active_dynamic_basket_commit")
     current_options = [str(sym) for sym in option_symbols if str(sym).endswith(("CE", "PE"))]
     current_symbols = [str(sym) for sym in symbols if sym]
     local_basket = dict(basket or {})
@@ -8117,10 +8157,7 @@ def _commit_active_dynamic_basket(
     committed["all_tokens"] = list(dict.fromkeys(all_tokens))
     committed["token_by_symbol"] = token_by_symbol
     committed["symbol_by_token"] = symbol_by_token
-    ctx.active_trading_universe = committed
-    ctx.active_contract_basket = committed
     active_symbol_tokens = _ensure_active_symbol_tokens(ctx)
-    active_symbol_tokens.update(dict(committed.get("token_by_symbol") or {}))
     selected_ce_token = _resolve_committed_symbol_token(ctx, committed, selected_ce, "selected_ce_token")
     selected_pe_token = _resolve_committed_symbol_token(ctx, committed, selected_pe, "selected_pe_token")
     for selected_symbol, selected_token, token_key in (
@@ -8147,6 +8184,19 @@ def _commit_active_dynamic_basket(
     committed["symbol_by_token"] = symbol_by_token
     committed["all_tokens"] = list(dict.fromkeys(coerced for raw in (committed.get("all_tokens") or []) if (coerced := _coerce_positive_token(raw)) is not None))
     committed["option_tokens"] = list(dict.fromkeys(coerced for raw in (committed.get("option_tokens") or []) if (coerced := _coerce_positive_token(raw)) is not None))
+    complete, missing = _is_trade_complete_active_basket(committed)
+    if not complete:
+        ctx.pending_contract_basket = committed
+        LOGGER.warning(
+            "ACTIVE_BASKET_COMMIT_DEFERRED reason=incomplete_basket missing=%s selected_ce=%s selected_pe=%s option_count=%d token_count=%d",
+            missing, selected_ce, selected_pe, len(current_options), len(committed.get("all_tokens") or []),
+            extra={"event": "ACTIVE_BASKET_COMMIT_DEFERRED", "reason": "incomplete_basket", "missing": missing, "selected_ce": selected_ce, "selected_pe": selected_pe, "option_count": len(current_options), "token_count": len(committed.get("all_tokens") or [])},
+        )
+        return cast(str | None, old_ce), cast(str | None, old_pe)
+    ctx.active_trading_universe = committed
+    ctx.active_contract_basket = committed
+    active_symbol_tokens = _ensure_active_symbol_tokens(ctx)
+    active_symbol_tokens.update(dict(committed.get("token_by_symbol") or {}))
     if getattr(ctx, "option_universe", None) is not None and hasattr(ctx.option_universe, "set_active_contract_basket"):
         ctx.option_universe.set_active_contract_basket(committed)
     mdm = getattr(ctx, "market_data_manager", None)
@@ -9384,13 +9434,20 @@ async def startup_sequence(ctx: BotContext) -> None:
                         records = list(records)[-hydration_max_bars:]
                 record_count = len(records or [])
                 if record_count == 0:
-                    LOGGER.error(
-                        "hydration_zero_bars: %s returned 0 bars — "
-                        "Zerodha historical API returned empty data. "
-                        "Extending lookback or check broker auth.",
-                        symbol,
-                        extra={"event": "hydration_zero_bars", "symbol": symbol},
-                    )
+                    if str(symbol) == "NSE:NIFTY":
+                        LOGGER.info(
+                            "SPOT_INDEX_HISTORY_UNAVAILABLE_SOFT symbol=%s reason=zero_historical_bars",
+                            symbol,
+                            extra={"event": "SPOT_INDEX_HISTORY_UNAVAILABLE_SOFT", "symbol": symbol, "reason": "zero_historical_bars"},
+                        )
+                    else:
+                        LOGGER.error(
+                            "hydration_zero_bars: %s returned 0 bars — "
+                            "Zerodha historical API returned empty data. "
+                            "Extending lookback or check broker auth.",
+                            symbol,
+                            extra={"event": "hydration_zero_bars", "symbol": symbol},
+                        )
                 elif record_count < hydration_min_bars:
                     LOGGER.info(
                         "insufficient_bars_for_strategy: %s returned only %d bars (need ≥%d) — "
@@ -11227,11 +11284,13 @@ async def startup_sequence(ctx: BotContext) -> None:
                                     },
                                 )
                             LOGGER.info(
-                                "Startup | configured_mode=%s | effective_mode=%s | live_orders_armed=%s | trading_ready=%s",
+                                "Startup | configured_mode=%s | effective_mode=%s | data_ready=%s | strategy_evaluation_ready=%s | execution_armed=%s | execution_block_reason=%s",
                                 configured_runtime_mode,
-                                ctx.readiness_mode,
+                                "EVALUATION_READY" if bool(getattr(ctx, "trading_ready", False)) and not bool(getattr(ctx, "live_orders_armed", False)) else ctx.readiness_mode,
+                                bool(getattr(ctx, "data_ready", getattr(ctx, "data_hard_ready", False))),
+                                bool(getattr(ctx, "strategy_evaluation_ready", getattr(ctx, "evaluation_ready", False))),
                                 bool(getattr(ctx, "live_orders_armed", False)),
-                                bool(getattr(ctx, "trading_ready", False)),
+                                getattr(ctx, "execution_block_reason", getattr(ctx, "live_block_reason", None)),
                             )
                         except Exception as ready_exc:
                             LOGGER.critical(

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -291,6 +291,8 @@ class MarketDataManager:
         self._event_loop_lag_seconds: float = 0.0
         self._hydration_status: dict[str, str] = {}
         self._hydration_log_ts: dict[str, float] = {}
+        self._active_basket_reseed_inflight: set[str] = set()
+        self._active_basket_reseed_last: dict[str, float] = {}
         self._last_hb_mono: float | None = None
         self._heartbeat_callbacks: list[Callable[[float], None]] = []
         self._fallback_enabled = False
@@ -1749,6 +1751,40 @@ class MarketDataManager:
         )
 
 
+    def _safe_ws_tokens_snapshot(self) -> set[int]:
+        """Return websocket tokens for diagnostics without blocking basket commits."""
+        ws = self._ws
+        if ws is None:
+            return set()
+        snapshot = getattr(ws, "tokens_snapshot", None)
+        raw_tokens: Any
+        if callable(snapshot):
+            try:
+                raw_tokens = snapshot()
+            except Exception as exc:  # noqa: BLE001
+                self._logger.debug(
+                    "WS_TOKENS_SNAPSHOT_SKIPPED reason=tokens_snapshot_failed error=%s",
+                    exc,
+                    extra={"event": "WS_TOKENS_SNAPSHOT_SKIPPED", "reason": "tokens_snapshot_failed", "error": str(exc)},
+                )
+                return set()
+        else:
+            raw_tokens = snapshot if snapshot is not None else getattr(ws, "_tokens", set())
+        tokens: set[int] = set()
+        for raw in raw_tokens or ():
+            try:
+                token = int(raw)
+            except (TypeError, ValueError):
+                self._logger.debug(
+                    "WS_TOKENS_SNAPSHOT_TOKEN_SKIPPED token=%s reason=invalid_token",
+                    raw,
+                    extra={"event": "WS_TOKENS_SNAPSHOT_TOKEN_SKIPPED", "token": str(raw), "reason": "invalid_token"},
+                )
+                continue
+            if token > 0:
+                tokens.add(token)
+        return tokens
+
     def _log_active_basket_subscription_reconciliation(self, basket: ActiveContractBasket | Mapping[str, Any]) -> None:
         """Log role-aware subscription reconciliation state for the active basket."""
         token_by_symbol = dict(self._basket_get(basket, "token_by_symbol", {}) or {})
@@ -1762,7 +1798,7 @@ class MarketDataManager:
         selected_tokens = {int(t) for t in (selected_ce_token, selected_pe_token) if t}
         nearby_options = option_tokens - selected_tokens
         desired = set(int(t) for t in self._desired_tokens if int(t) > 0)
-        ws_tokens = set(int(t) for t in (getattr(self._ws, "tokens_snapshot", lambda: getattr(self._ws, "_tokens", set()) if self._ws is not None else set())() if self._ws is not None else set()))
+        ws_tokens = self._safe_ws_tokens_snapshot()
         protected = {int(t) for t in (spot_token, futures_token, selected_ce_token, selected_pe_token) if t}
         protected.update(option_tokens)
         missing_tokens = sorted(desired - ws_tokens)
@@ -1823,10 +1859,24 @@ class MarketDataManager:
 
     def _reseed_active_basket_symbol_bars(self, symbol: str, min_bars: int) -> dict[str, Any]:
         """Best-effort selected-option history reseed through the existing hydration path."""
-        status: dict[str, Any] = {"attempted": False, "deferred": False, "failed": False, "error": None}
+        status: dict[str, Any] = {"attempted": False, "deferred": False, "failed": False, "error": None, "reason": None}
         hydrate_fn = getattr(self, "hydrate_symbol_history", None)
         if not callable(hydrate_fn):
             return status
+        key = self._canonical_active_symbol(symbol)
+        now_mono = time.monotonic()
+        try:
+            cooldown_s = float(os.getenv("MDM_ACTIVE_BASKET_RESEED_COOLDOWN_SECONDS", "30") or "30")
+        except (TypeError, ValueError):
+            cooldown_s = 30.0
+        with self._lock:
+            if key in self._active_basket_reseed_inflight:
+                status.update({"attempted": True, "deferred": True, "reason": "reseed_already_inflight"})
+                return status
+            last = self._active_basket_reseed_last.get(key, 0.0)
+            if last > 0 and (now_mono - last) < max(0.0, cooldown_s):
+                status.update({"attempted": True, "deferred": True, "reason": "reseed_cooldown"})
+                return status
         status["attempted"] = True
         try:
             result = hydrate_fn(
@@ -1841,20 +1891,44 @@ class MarketDataManager:
                     loop = asyncio.get_running_loop()
                 except RuntimeError:
                     asyncio.run(result)
+                    with self._lock:
+                        self._active_basket_reseed_last[key] = time.monotonic()
                 else:
+                    with self._lock:
+                        if key in self._active_basket_reseed_inflight:
+                            status.update({"deferred": True, "reason": "reseed_already_inflight"})
+                            return status
+                        self._active_basket_reseed_inflight.add(key)
                     task = loop.create_task(result)
-                    status["deferred"] = True
+                    status.update({"deferred": True, "reason": "running_event_loop"})
+
                     def _done(done: asyncio.Task[Any]) -> None:
+                        with self._lock:
+                            self._active_basket_reseed_inflight.discard(key)
+                            self._active_basket_reseed_last[key] = time.monotonic()
                         try:
                             done.result()
                         except Exception as exc:  # noqa: BLE001
-                            self._logger.warning("MDM_BASKET_HYDRATION_RESEED_FAILED symbol=%s error=%s", symbol, exc, extra={"event": "MDM_BASKET_HYDRATION_RESEED_FAILED", "symbol": symbol, "error": str(exc)})
+                            self._logger.warning(
+                                "MDM_BASKET_HYDRATION_RESEED_FAILED symbol=%s error=%s",
+                                symbol,
+                                exc,
+                                extra={"event": "MDM_BASKET_HYDRATION_RESEED_FAILED", "symbol": symbol, "error": str(exc)},
+                            )
                             return
-                        self._logger.info("MDM_BASKET_HYDRATION_RESEED_COMPLETED symbol=%s", symbol, extra={"event": "MDM_BASKET_HYDRATION_RESEED_COMPLETED", "symbol": symbol})
+                        self._logger.info(
+                            "MDM_BASKET_HYDRATION_RESEED_COMPLETED symbol=%s",
+                            symbol,
+                            extra={"event": "MDM_BASKET_HYDRATION_RESEED_COMPLETED", "symbol": symbol},
+                        )
                         active = self._active_contract_basket
                         if active is not None:
                             self.hydrate_active_contract_basket(active)
-                            self._logger.info("ACTIVE_BASKET_HYDRATION_RETRY_READY symbol=%s", symbol, extra={"event": "ACTIVE_BASKET_HYDRATION_RETRY_READY", "symbol": symbol})
+                            self._logger.info(
+                                "ACTIVE_BASKET_HYDRATION_RETRY_READY symbol=%s",
+                                symbol,
+                                extra={"event": "ACTIVE_BASKET_HYDRATION_RETRY_READY", "symbol": symbol},
+                            )
                     task.add_done_callback(_done)
                     self._logger.info(
                         "MDM_BASKET_HYDRATION_RESEED_DEFERRED symbol=%s reason=running_event_loop",

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -1607,6 +1607,50 @@ class MarketDataManager:
             return basket.get(key, default)
         return getattr(basket, key, default)
 
+
+    def _validate_trade_complete_active_basket(self, basket: ActiveContractBasket | Mapping[str, Any]) -> tuple[bool, list[str]]:
+        """Validate that a basket is complete enough to become active trading state."""
+        missing: list[str] = []
+        token_by_symbol = dict(self._basket_get(basket, "token_by_symbol", {}) or {})
+        all_symbols = tuple(str(x) for x in (self._basket_get(basket, "all_symbols", None) or self._basket_get(basket, "symbols", ()) or ()) if x)
+        all_tokens = tuple(int(t) for t in (self._basket_get(basket, "all_tokens", ()) or ()) if t)
+        option_symbols = tuple(str(x) for x in (self._basket_get(basket, "option_symbols", ()) or ()) if x)
+        option_tokens = tuple(int(t) for t in (self._basket_get(basket, "option_tokens", ()) or ()) if t)
+        spot_symbol = str(self._basket_get(basket, "spot_symbol", "NSE:NIFTY") or "")
+        spot_token = self._basket_get(basket, "spot_token", None) or token_by_symbol.get(spot_symbol) or token_by_symbol.get(self._canonical_symbol(spot_symbol))
+        selected_ce = self._basket_get(basket, "selected_ce", None)
+        selected_pe = self._basket_get(basket, "selected_pe", None)
+
+        def _token_for(symbol: Any, explicit_key: str) -> Any:
+            if not symbol:
+                return None
+            sym = str(symbol)
+            bare = sym.split(":", 1)[-1]
+            return self._basket_get(basket, explicit_key, None) or token_by_symbol.get(sym) or token_by_symbol.get(bare) or token_by_symbol.get(self._canonical_symbol(sym))
+
+        if not spot_symbol:
+            missing.append("spot_symbol")
+        if spot_token in (None, "", 0) and spot_symbol != "NSE:NIFTY":
+            missing.append("spot_token")
+        if not selected_ce:
+            missing.append("selected_ce")
+        if not selected_pe:
+            missing.append("selected_pe")
+        if selected_ce and _token_for(selected_ce, "selected_ce_token") in (None, "", 0):
+            missing.append("selected_ce_token")
+        if selected_pe and _token_for(selected_pe, "selected_pe_token") in (None, "", 0):
+            missing.append("selected_pe_token")
+        if not option_symbols:
+            missing.append("option_symbols")
+        if not option_tokens:
+            missing.append("option_tokens")
+        if not all_tokens:
+            missing.append("all_tokens")
+        future_symbol = self._basket_get(basket, "futures_symbol", None)
+        future_token = self._basket_get(basket, "futures_token", None) or (token_by_symbol.get(str(future_symbol)) if future_symbol else None)
+        # Futures context is optional; missing future token is logged elsewhere and must not downgrade an option basket to context-only.
+        return not missing, list(dict.fromkeys(missing))
+
     def set_active_contract_basket(self, basket: ActiveContractBasket | Mapping[str, Any]) -> None:
         """Store active SSOT basket, register mappings, and reconcile subscriptions."""
         if basket is None:
@@ -1630,6 +1674,28 @@ class MarketDataManager:
             symbol_by_token = {int(tok): str(sym) for sym, tok in token_by_symbol.items()}
         if not all_tokens:
             all_tokens = tuple(token_by_symbol[s] for s in all_symbols if s in token_by_symbol)
+
+        complete, missing = self._validate_trade_complete_active_basket({
+            **(dict(basket) if isinstance(basket, Mapping) else {}),
+            "spot_symbol": spot_symbol,
+            "spot_token": self._basket_get(basket, "spot_token", None),
+            "futures_symbol": future_symbol,
+            "futures_token": future_token,
+            "selected_ce": selected_ce,
+            "selected_pe": selected_pe,
+            "option_symbols": option_symbols,
+            "option_tokens": option_tokens,
+            "all_symbols": all_symbols,
+            "all_tokens": all_tokens,
+            "token_by_symbol": token_by_symbol,
+        })
+        if not complete:
+            self._logger.warning(
+                "MDM_ACTIVE_BASKET_REJECTED reason=incomplete_basket missing=%s selected_ce=%s selected_pe=%s option_count=%d token_count=%d",
+                missing, selected_ce, selected_pe, len(option_symbols), len(all_tokens),
+                extra={"event": "MDM_ACTIVE_BASKET_REJECTED", "reason": "incomplete_basket", "missing": missing, "selected_ce": selected_ce, "selected_pe": selected_pe, "option_count": len(option_symbols), "token_count": len(all_tokens)},
+            )
+            return
 
         roles: dict[str, str] = {spot_symbol: "spot_context"}
         if future_symbol:
@@ -1675,10 +1741,41 @@ class MarketDataManager:
             self._active_nifty_future_cache_until_mono = time.monotonic() + 3600.0
         self.purge_stale_nifty_futures(str(future_symbol) if future_symbol else None, reason="active_contract_basket_set")
         self._reconcile_ws_subscriptions()
+        self._log_active_basket_subscription_reconciliation(basket)
         self._logger.info(
             "MDM_ACTIVE_BASKET_SET selected_ce=%s selected_pe=%s futures_symbol=%s atm_strike=%s option_count=%d token_count=%d",
             selected_ce, selected_pe, future_symbol, self._basket_get(basket, "atm_strike", None), len(option_symbols), len(self._desired_tokens),
             extra={"event": "MDM_ACTIVE_BASKET_SET", "selected_ce": selected_ce, "selected_pe": selected_pe, "futures_symbol": future_symbol, "atm_strike": self._basket_get(basket, "atm_strike", None), "option_count": len(option_symbols), "token_count": len(self._desired_tokens)},
+        )
+
+
+    def _log_active_basket_subscription_reconciliation(self, basket: ActiveContractBasket | Mapping[str, Any]) -> None:
+        """Log role-aware subscription reconciliation state for the active basket."""
+        token_by_symbol = dict(self._basket_get(basket, "token_by_symbol", {}) or {})
+        spot_token = self._basket_get(basket, "spot_token", None) or token_by_symbol.get(str(self._basket_get(basket, "spot_symbol", "NSE:NIFTY") or "NSE:NIFTY"))
+        futures_token = self._basket_get(basket, "futures_token", None)
+        selected_ce = self._basket_get(basket, "selected_ce", None)
+        selected_pe = self._basket_get(basket, "selected_pe", None)
+        selected_ce_token = self._basket_get(basket, "selected_ce_token", None) or (token_by_symbol.get(str(selected_ce)) if selected_ce else None)
+        selected_pe_token = self._basket_get(basket, "selected_pe_token", None) or (token_by_symbol.get(str(selected_pe)) if selected_pe else None)
+        option_tokens = {int(t) for t in (self._basket_get(basket, "option_tokens", ()) or ()) if t}
+        selected_tokens = {int(t) for t in (selected_ce_token, selected_pe_token) if t}
+        nearby_options = option_tokens - selected_tokens
+        desired = set(int(t) for t in self._desired_tokens if int(t) > 0)
+        ws_tokens = set(int(t) for t in (getattr(self._ws, "tokens_snapshot", lambda: getattr(self._ws, "_tokens", set()) if self._ws is not None else set())() if self._ws is not None else set()))
+        protected = {int(t) for t in (spot_token, futures_token, selected_ce_token, selected_pe_token) if t}
+        protected.update(option_tokens)
+        missing_tokens = sorted(desired - ws_tokens)
+        extra_tokens = sorted(ws_tokens - desired)
+        self._logger.info(
+            "SUBSCRIPTION_ROLE_SUMMARY spot=%d future=%d selected_options=%d nearby_options=%d context_only=%d desired_total=%d",
+            1 if spot_token else 0, 1 if futures_token else 0, len(selected_tokens), len(nearby_options), 0, len(desired),
+            extra={"event": "SUBSCRIPTION_ROLE_SUMMARY", "spot": 1 if spot_token else 0, "future": 1 if futures_token else 0, "selected_options": len(selected_tokens), "nearby_options": len(nearby_options), "context_only": 0, "desired_total": len(desired)},
+        )
+        self._logger.info(
+            "ACTIVE_BASKET_SUBSCRIPTION_RECONCILED desired_total=%d ws_total=%d missing_tokens=%s extra_tokens=%s selected_ce_token=%s selected_pe_token=%s",
+            len(desired), len(ws_tokens), missing_tokens, extra_tokens, selected_ce_token, selected_pe_token,
+            extra={"event": "ACTIVE_BASKET_SUBSCRIPTION_RECONCILED", "spot_token": spot_token, "futures_token": futures_token, "selected_ce_token": selected_ce_token, "selected_pe_token": selected_pe_token, "nearby_option_token_count": len(nearby_options), "diagnostic_token_count": 0, "desired_total": len(desired), "ws_total": len(ws_tokens), "missing_tokens": missing_tokens, "extra_tokens": extra_tokens, "protected_tokens": sorted(protected)},
         )
 
     def get_active_contract_basket(self) -> ActiveContractBasket | Mapping[str, Any] | None:
@@ -1745,8 +1842,20 @@ class MarketDataManager:
                 except RuntimeError:
                     asyncio.run(result)
                 else:
-                    loop.create_task(result)
+                    task = loop.create_task(result)
                     status["deferred"] = True
+                    def _done(done: asyncio.Task[Any]) -> None:
+                        try:
+                            done.result()
+                        except Exception as exc:  # noqa: BLE001
+                            self._logger.warning("MDM_BASKET_HYDRATION_RESEED_FAILED symbol=%s error=%s", symbol, exc, extra={"event": "MDM_BASKET_HYDRATION_RESEED_FAILED", "symbol": symbol, "error": str(exc)})
+                            return
+                        self._logger.info("MDM_BASKET_HYDRATION_RESEED_COMPLETED symbol=%s", symbol, extra={"event": "MDM_BASKET_HYDRATION_RESEED_COMPLETED", "symbol": symbol})
+                        active = self._active_contract_basket
+                        if active is not None:
+                            self.hydrate_active_contract_basket(active)
+                            self._logger.info("ACTIVE_BASKET_HYDRATION_RETRY_READY symbol=%s", symbol, extra={"event": "ACTIVE_BASKET_HYDRATION_RETRY_READY", "symbol": symbol})
+                    task.add_done_callback(_done)
                     self._logger.info(
                         "MDM_BASKET_HYDRATION_RESEED_DEFERRED symbol=%s reason=running_event_loop",
                         symbol,
@@ -1777,7 +1886,7 @@ class MarketDataManager:
         token_by_canonical = {self._canonical_active_symbol(sym): tok for sym, tok in token_by_symbol.items()}
         selected_canonical = {self._canonical_active_symbol(s) for s in (self._basket_get(active, "selected_ce", None), self._basket_get(active, "selected_pe", None)) if s}
         future_symbol = self._basket_get(active, "futures_symbol", None)
-        report: dict[str, Any] = {"hard_ready": True, "min_bars_required": hydration_min_bars, "hydration_min_bars_required": hydration_min_bars, "symbols": {}, "missing": []}
+        report: dict[str, Any] = {"hard_ready": True, "min_bars_required": hydration_min_bars, "hydration_min_bars_required": hydration_min_bars, "symbols": {}, "missing": [], "retry_scheduled": False}
         for sym in all_symbols:
             canonical_sym = self._canonical_active_symbol(sym)
             is_selected = canonical_sym in selected_canonical
@@ -1829,6 +1938,8 @@ class MarketDataManager:
                     last_error = f"bars_malformed_after_reseed:{type(exc).__name__}"
                 if not ohlc_ready and reseed_status.get("deferred"):
                     last_error = "reseed_deferred"
+                    report["retry_scheduled"] = True
+                    report["missing"].append(f"{sym}:reseed_deferred")
                 elif reseed_status.get("failed"):
                     last_error = str(reseed_status.get("error") or "reseed_failed")
             if role in {"spot_context", "futures_context"}:
@@ -5317,7 +5428,8 @@ class MarketDataManager:
         elif cumulative >= previous:
             delta = cumulative - previous
         else:
-            delta = 0.0
+            max_reset_delta = float(os.getenv("OPTION_MAX_REASONABLE_TICK_VOLUME_DELTA", "1000000") or "1000000")
+            delta = cumulative if 0 <= cumulative <= max_reset_delta else 0.0
         symbol_upper = str(symbol or "").upper()
         is_option_symbol = symbol_upper.endswith("CE") or symbol_upper.endswith("PE")
         if is_option_symbol:
@@ -5340,6 +5452,7 @@ class MarketDataManager:
                     },
                 )
                 delta = 0.0
+        self._logger.debug("OPTION_VOLUME_DELTA_NORMALIZED symbol=%s cumulative=%s previous=%s delta=%s", symbol, cumulative, previous, delta, extra={"event": "OPTION_VOLUME_DELTA_NORMALIZED", "symbol": symbol, "cumulative": cumulative, "previous": previous, "delta": delta})
         self._last_cumulative_volume_by_symbol[key] = cumulative
         payload["volume_cumulative"] = cumulative
         payload["volume_delta"] = delta
@@ -7311,7 +7424,7 @@ class MarketDataManager:
         return is_nifty_future_expired(canonical, now=now)
 
     def purge_stale_nifty_futures(self, active_symbol: str | None = None, *, reason: str = "active_future_rotation") -> list[int]:
-        """Purge stale NIFTY futures symbols/tokens from runtime subscription state."""
+        """Purge only positively identified stale NIFTY futures from runtime subscription state."""
         active = canonical_nifty_future_symbol(active_symbol) or canonical_nifty_future_symbol(
             self.get_active_nifty_future_symbol_cached()
         )
@@ -7319,49 +7432,88 @@ class MarketDataManager:
             return []
 
         stale_symbols: set[str] = set()
-        stale_tokens: set[int] = set()
+        candidate_tokens: set[int] = set()
+        purged_tokens: set[int] = set()
+        skipped_protected_tokens: set[int] = set()
+        unknown_tokens: set[int] = set()
+        protected_tokens: set[int] = {NIFTY_SPOT_TOKEN}
+        protected_symbols: set[str] = {"NSE:NIFTY", active}
 
-        def _mark_symbol(value: Any) -> None:
-            canonical = canonical_nifty_future_symbol(value)
-            if canonical and canonical != active:
-                stale_symbols.add(canonical)
-
-        def _mark_token(value: Any) -> None:
+        def _as_token(value: Any) -> int | None:
             try:
-                token_int = int(value)
+                token = int(value)
             except (TypeError, ValueError):
+                return None
+            return token if token > 0 else None
+
+        def _protect_symbol(symbol: Any) -> None:
+            if not symbol:
                 return
-            if token_int > 0:
-                stale_tokens.add(token_int)
+            text = str(symbol)
+            protected_symbols.add(text)
+            canonical = canonical_nifty_future_symbol(text)
+            if canonical:
+                protected_symbols.add(canonical)
 
         with self._lock:
+            active_basket = self._active_contract_basket
+            if active_basket is not None:
+                for key in ("spot_symbol", "futures_symbol", "selected_ce", "selected_pe"):
+                    _protect_symbol(self._basket_get(active_basket, key, None))
+                for key in ("spot_token", "futures_token", "selected_ce_token", "selected_pe_token"):
+                    token = _as_token(self._basket_get(active_basket, key, None))
+                    if token is not None:
+                        protected_tokens.add(token)
+                for symbol in self._basket_get(active_basket, "all_symbols", ()) or self._basket_get(active_basket, "symbols", ()) or ():
+                    _protect_symbol(symbol)
+                for symbol in self._basket_get(active_basket, "option_symbols", ()) or ():
+                    _protect_symbol(symbol)
+                for token in self._basket_get(active_basket, "all_tokens", ()) or ():
+                    token_int = _as_token(token)
+                    if token_int is not None:
+                        protected_tokens.add(token_int)
+                for token in self._basket_get(active_basket, "option_tokens", ()) or ():
+                    token_int = _as_token(token)
+                    if token_int is not None:
+                        protected_tokens.add(token_int)
+            protected_tokens.update(int(t) for t in getattr(self, "_active_option_tokens", set()) or set() if _as_token(t) is not None)
+            for symbol in getattr(self, "_active_option_symbols", ()) or ():
+                _protect_symbol(symbol)
+
+            def _consider_symbol(symbol: Any, token: Any = None) -> None:
+                canonical = canonical_nifty_future_symbol(symbol)
+                token_int = _as_token(token)
+                if token_int is not None and token_int in protected_tokens:
+                    skipped_protected_tokens.add(token_int)
+                    return
+                if canonical and canonical != active and canonical not in protected_symbols and str(symbol) not in protected_symbols:
+                    stale_symbols.add(canonical)
+                    if token_int is not None:
+                        candidate_tokens.add(token_int)
+                elif token_int is not None and canonical is None:
+                    unknown_tokens.add(token_int)
+
             for symbol in list(self._tracked_symbols) + list(self._active_subscribed_symbols):
-                _mark_symbol(symbol)
+                _consider_symbol(symbol)
             for mapping_name in ("_token_by_symbol", "_symbol_to_token"):
                 mapping = getattr(self, mapping_name, {})
                 if isinstance(mapping, dict):
                     for symbol, token in list(mapping.items()):
-                        canonical = canonical_nifty_future_symbol(symbol)
-                        if canonical and canonical != active:
-                            stale_symbols.add(canonical)
-                            _mark_token(token)
+                        _consider_symbol(symbol, token)
             for mapping_name in ("_symbol_by_token", "_token_to_symbol"):
                 mapping = getattr(self, mapping_name, {})
                 if isinstance(mapping, dict):
                     for token, symbol in list(mapping.items()):
-                        canonical = canonical_nifty_future_symbol(symbol)
-                        if canonical and canonical != active:
-                            stale_symbols.add(canonical)
-                            _mark_token(token)
+                        _consider_symbol(symbol, token)
             for cache_name in ("_latest_ticks", "_tick_cache", "_last_tick_snapshot", "_history", "_poll_bar_state", "_last_poll_bucket"):
                 cache = getattr(self, cache_name, {})
                 if isinstance(cache, dict):
                     for symbol in list(cache.keys()):
-                        _mark_symbol(symbol)
+                        _consider_symbol(symbol)
             reqs = dict(getattr(self, "_readiness_requirements", {}) or {})
             for key, value in list(reqs.items()):
                 canonical = canonical_nifty_future_symbol(value)
-                if canonical and canonical != active:
+                if canonical and canonical != active and canonical not in protected_symbols:
                     stale_symbols.add(canonical)
                     if key == "futures":
                         reqs[key] = active
@@ -7370,10 +7522,13 @@ class MarketDataManager:
             reqs["futures"] = active
             self._readiness_requirements = reqs
 
-            for symbol in list(stale_symbols):
-                token = self._token_by_symbol.get(symbol) or self._symbol_to_token.get(symbol)
+            for symbol in sorted(stale_symbols):
+                token = _as_token(self._token_by_symbol.get(symbol) or self._symbol_to_token.get(symbol))
                 if token is not None:
-                    _mark_token(token)
+                    if token in protected_tokens:
+                        skipped_protected_tokens.add(token)
+                        continue
+                    candidate_tokens.add(token)
                 self._tracked_symbols.discard(symbol)
                 self._active_subscribed_symbols.discard(symbol)
                 self._subscribers.pop(symbol, None)
@@ -7397,79 +7552,57 @@ class MarketDataManager:
                 self._quote_direct_miss_count.pop(symbol, None)
                 self._quote_direct_miss_until.pop(symbol, None)
                 self._quote_direct_miss_reason.pop(symbol, None)
-                mapped_token = self._token_by_symbol.pop(symbol, None)
-                if mapped_token is not None:
-                    _mark_token(mapped_token)
-                mapped_token = self._symbol_to_token.pop(symbol, None)
-                if mapped_token is not None:
-                    _mark_token(mapped_token)
+                self._token_by_symbol.pop(symbol, None)
+                self._symbol_to_token.pop(symbol, None)
                 self._suspended_context_symbols.add(symbol)
                 self._suspended_context_symbol_until[symbol] = time.monotonic() + (48.0 * 3600.0)
 
-            for token in list(stale_tokens):
+            for token in sorted(candidate_tokens):
                 mapped_symbol = self._symbol_by_token.get(token) or self._token_to_symbol.get(token)
                 canonical = canonical_nifty_future_symbol(mapped_symbol)
-                if canonical == active:
-                    stale_tokens.discard(token)
+                if token in protected_tokens or canonical == active or (mapped_symbol and str(mapped_symbol) in protected_symbols):
+                    skipped_protected_tokens.add(token)
                     continue
-                self._symbol_by_token.pop(token, None)
-                self._token_to_symbol.pop(token, None)
-                self._desired_tokens.discard(token)
-                self._pending_subscription_tokens.discard(token)
-                self._pending_subscriptions.discard(token)
-                self._dispatched_subscriptions.discard(token)
-                self._confirmed_subscriptions.discard(token)
+                if canonical and canonical != active:
+                    purged_tokens.add(token)
+                    self._symbol_by_token.pop(token, None)
+                    self._token_to_symbol.pop(token, None)
+                    self._desired_tokens.discard(token)
+                    self._pending_subscription_tokens.discard(token)
+                    self._pending_subscriptions.discard(token)
+                    self._dispatched_subscriptions.discard(token)
+                    self._confirmed_subscriptions.discard(token)
+                elif mapped_symbol is None:
+                    unknown_tokens.add(token)
+                    self._logger.info("FUTURES_PURGE_UNKNOWN_TOKEN_SKIPPED token=%s reason=symbol_unknown", token, extra={"event": "FUTURES_PURGE_UNKNOWN_TOKEN_SKIPPED", "token": token, "reason": "symbol_unknown"})
 
         ws_tokens: list[int] = []
         ws = self._ws
         if ws is not None:
             snapshot = getattr(ws, "tokens_snapshot", None)
-            if callable(snapshot):
-                try:
-                    ws_tokens = [int(token) for token in snapshot()]
-                except Exception:
-                    ws_tokens = []
-            else:
-                raw_tokens = getattr(ws, "_tokens", set()) or set()
-                ws_tokens = sorted(int(token) for token in raw_tokens)
-        for token in list(ws_tokens):
-            if token not in self._desired_tokens:
-                stale_tokens.add(token)
-        unknown_tokens: list[int] = []
-        for token in sorted(self._desired_tokens):
-            if self._resolve_symbol_for_token(int(token)) is None:
-                unknown_tokens.append(int(token))
-                self._logger.warning(
-                    "UNKNOWN_TOKEN_IN_DESIRED_SUBSCRIPTIONS token=%s",
-                    int(token),
-                    extra={"event": "UNKNOWN_TOKEN_IN_DESIRED_SUBSCRIPTIONS", "token": int(token)},
-                )
-        purged_tokens = sorted(stale_tokens)
-        if purged_tokens or any(token not in self._desired_tokens for token in ws_tokens):
+            try:
+                ws_tokens = [int(token) for token in (snapshot() if callable(snapshot) else (getattr(ws, "_tokens", set()) or set()))]
+            except Exception:
+                ws_tokens = []
+        extras = [token for token in ws_tokens if token not in self._desired_tokens and token not in protected_tokens]
+        if purged_tokens or extras:
             self._reconcile_ws_subscriptions()
         self._logger.info(
-            "FUTURES_PURGE_STATE active=%s desired_tokens=%d ws_tokens=%d purged_tokens=%s unknown_tokens=%s",
-            active,
-            len(self._desired_tokens),
-            len(ws_tokens),
-            purged_tokens,
-            unknown_tokens,
-            extra={"event": "FUTURES_PURGE_STATE", "active_symbol": active, "desired_tokens": len(self._desired_tokens), "ws_tokens": len(ws_tokens), "purged_tokens": purged_tokens, "unknown_tokens": unknown_tokens},
+            "FUTURES_PURGE_STATE active=%s protected_tokens_count=%d candidate_tokens=%s purged_tokens=%s skipped_protected_tokens=%s unknown_tokens=%s",
+            active, len(protected_tokens), sorted(candidate_tokens), sorted(purged_tokens), sorted(skipped_protected_tokens), sorted(unknown_tokens),
+            extra={"event": "FUTURES_PURGE_STATE", "active_symbol": active, "protected_tokens_count": len(protected_tokens), "candidate_tokens": sorted(candidate_tokens), "purged_tokens": sorted(purged_tokens), "skipped_protected_tokens": sorted(skipped_protected_tokens), "unknown_tokens": sorted(unknown_tokens), "desired_tokens": len(self._desired_tokens), "ws_tokens": len(ws_tokens)},
         )
         hub = getattr(self, "data_hub", None) or getattr(self, "_data_hub", None)
         purge_hub = getattr(hub, "purge_symbol_aliases", None)
         if callable(purge_hub):
-            purge_hub(symbols=sorted(stale_symbols), tokens=purged_tokens)
+            purge_hub(symbols=sorted(stale_symbols), tokens=sorted(purged_tokens))
         if stale_symbols or purged_tokens:
             self._logger.warning(
                 "FUTURES_STALE_SUBSCRIPTION_PURGED active=%s purged_symbols=%s purged_tokens=%s reason=%s",
-                active,
-                sorted(stale_symbols),
-                purged_tokens,
-                reason,
-                extra={"event": "FUTURES_STALE_SUBSCRIPTION_PURGED", "active_symbol": active, "purged_symbols": sorted(stale_symbols), "purged_tokens": purged_tokens, "reason": reason},
+                active, sorted(stale_symbols), sorted(purged_tokens), reason,
+                extra={"event": "FUTURES_STALE_SUBSCRIPTION_PURGED", "active_symbol": active, "purged_symbols": sorted(stale_symbols), "purged_tokens": sorted(purged_tokens), "reason": reason},
             )
-        return purged_tokens
+        return sorted(purged_tokens)
 
     def rotate_active_nifty_future_context(
         self,
@@ -8784,14 +8917,9 @@ class MarketDataManager:
         if broker_timestamp is not None:
             normalized["broker_timestamp"] = broker_timestamp
 
-        # 5. Volume Handling
-        volume = self._coerce_float(
-            tick,
-            "volume_traded_today",
-            "volume",
-            "volume_traded",
-            "total_traded_volume",
-        )
+        # 5. Volume Handling: broker volume is cumulative, expose per-tick delta.
+        volume_payload = self._normalise_tick_volume_delta(symbol, dict(tick))
+        volume = self._coerce_float(volume_payload, "volume_delta", "volume")
         if volume is None and previous:
             prev_vol = previous.get("volume")
             if isinstance(prev_vol, (int, float)):
@@ -8799,6 +8927,9 @@ class MarketDataManager:
 
         if volume is not None:
             normalized["volume"] = float(volume)
+            normalized["volume_delta"] = float(volume)
+        if volume_payload.get("volume_cumulative") is not None:
+            normalized["volume_cumulative"] = volume_payload.get("volume_cumulative")
 
         instrument_token = tick.get("instrument_token") or tick.get("token")
         if instrument_token is not None:

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -1614,12 +1614,18 @@ class MarketDataManager:
         """Validate that a basket is complete enough to become active trading state."""
         missing: list[str] = []
         token_by_symbol = dict(self._basket_get(basket, "token_by_symbol", {}) or {})
+        token_by_canonical_symbol = {self._canonical_active_symbol(sym): token for sym, token in token_by_symbol.items() if sym}
         all_symbols = tuple(str(x) for x in (self._basket_get(basket, "all_symbols", None) or self._basket_get(basket, "symbols", ()) or ()) if x)
         all_tokens = tuple(int(t) for t in (self._basket_get(basket, "all_tokens", ()) or ()) if t)
         option_symbols = tuple(str(x) for x in (self._basket_get(basket, "option_symbols", ()) or ()) if x)
         option_tokens = tuple(int(t) for t in (self._basket_get(basket, "option_tokens", ()) or ()) if t)
         spot_symbol = str(self._basket_get(basket, "spot_symbol", "NSE:NIFTY") or "")
-        spot_token = self._basket_get(basket, "spot_token", None) or token_by_symbol.get(spot_symbol) or token_by_symbol.get(self._canonical_symbol(spot_symbol))
+        spot_token = (
+            self._basket_get(basket, "spot_token", None)
+            or token_by_symbol.get(spot_symbol)
+            or token_by_symbol.get(self._canonical_active_symbol(spot_symbol))
+            or token_by_canonical_symbol.get(self._canonical_active_symbol(spot_symbol))
+        )
         selected_ce = self._basket_get(basket, "selected_ce", None)
         selected_pe = self._basket_get(basket, "selected_pe", None)
 
@@ -1628,7 +1634,14 @@ class MarketDataManager:
                 return None
             sym = str(symbol)
             bare = sym.split(":", 1)[-1]
-            return self._basket_get(basket, explicit_key, None) or token_by_symbol.get(sym) or token_by_symbol.get(bare) or token_by_symbol.get(self._canonical_symbol(sym))
+            canonical_sym = self._canonical_active_symbol(sym)
+            return (
+                self._basket_get(basket, explicit_key, None)
+                or token_by_symbol.get(sym)
+                or token_by_symbol.get(bare)
+                or token_by_symbol.get(canonical_sym)
+                or token_by_canonical_symbol.get(canonical_sym)
+            )
 
         if not spot_symbol:
             missing.append("spot_symbol")

--- a/src/nifty_scalper_bot/utils/logging.py
+++ b/src/nifty_scalper_bot/utils/logging.py
@@ -13,6 +13,7 @@ import contextlib
 import logging
 import os
 import re
+import sys
 import threading
 import time
 from typing import Any, Optional
@@ -153,6 +154,28 @@ class LogThrottle:
 # =============================================================================
 # 3. FORMATTERS & FILTERS
 # =============================================================================
+
+
+class _MaxLevelFilter(logging.Filter):
+    """Allow records below or equal to a maximum level."""
+
+    def __init__(self, max_level: int) -> None:
+        super().__init__()
+        self._max_level = int(max_level)
+
+    def filter(self, record: logging.LogRecord) -> bool:  # noqa: D401 - override
+        return int(record.levelno) <= self._max_level
+
+
+class _MinLevelFilter(logging.Filter):
+    """Allow records at or above a minimum level."""
+
+    def __init__(self, min_level: int) -> None:
+        super().__init__()
+        self._min_level = int(min_level)
+
+    def filter(self, record: logging.LogRecord) -> bool:  # noqa: D401 - override
+        return int(record.levelno) >= self._min_level
 
 
 class EventEnricher(logging.Filter):
@@ -445,34 +468,39 @@ def setup_logging(level: str = "INFO") -> None:
     try:
         resolved_level_name = os.getenv("LOG_LEVEL", level)
         numeric_level = getattr(logging, resolved_level_name.upper(), logging.INFO)
-        handler = logging.StreamHandler()
-        handler.addFilter(EventEnricher())
+        stdout_handler = logging.StreamHandler(sys.stdout)
+        stderr_handler = logging.StreamHandler(sys.stderr)
+        stdout_handler.addFilter(_MaxLevelFilter(logging.WARNING))
+        stderr_handler.addFilter(_MinLevelFilter(logging.ERROR))
+        handlers = [stdout_handler, stderr_handler]
+        for handler in handlers:
+            handler.addFilter(EventEnricher())
 
-        # Note: We add filters here for the new handler, but _install_filters_once
-        # attaches them to existing handlers on the root logger later as well.
-        if _resolve_bool("LOG_DEDUP_ENABLED", True):
-            handler.addFilter(_DedupFilter(_resolve_float("LOG_DEDUP_WINDOW_SEC", 2.0)))
+            # Note: We add filters here for the new handlers, but _install_filters_once
+            # attaches them to existing handlers on the root logger later as well.
+            if _resolve_bool("LOG_DEDUP_ENABLED", True):
+                handler.addFilter(_DedupFilter(_resolve_float("LOG_DEDUP_WINDOW_SEC", 2.0)))
 
-        # Standard format vs JSON format
-        if os.getenv("LOG_FORMAT", "").strip().lower() == "json":
-            handler.setFormatter(
-                logging.Formatter(
-                    '{"ts":"%(asctime)s","lvl":"%(levelname)s","logger":"%(name)s",'
-                    '"msg":"%(message)s","event":"%(event)s"}',
-                    datefmt="%Y-%m-%dT%H:%M:%S%z",
+            # Standard format vs JSON format
+            if os.getenv("LOG_FORMAT", "").strip().lower() == "json":
+                handler.setFormatter(
+                    logging.Formatter(
+                        '{"ts":"%(asctime)s","lvl":"%(levelname)s","logger":"%(name)s",'
+                        '"msg":"%(message)s","event":"%(event)s"}',
+                        datefmt="%Y-%m-%dT%H:%M:%S%z",
+                    )
                 )
-            )
-        else:
-            handler.setFormatter(
-                KeyValueFormatter(
-                    fmt=(
-                        "%(asctime)s %(levelname)s %(name)s "
-                        "event=%(event)s %(message)s"
-                    ),
-                    datefmt="%Y-%m-%dT%H:%M:%S%z",
+            else:
+                handler.setFormatter(
+                    KeyValueFormatter(
+                        fmt=(
+                            "%(asctime)s %(levelname)s %(name)s "
+                            "event=%(event)s %(message)s"
+                        ),
+                        datefmt="%Y-%m-%dT%H:%M:%S%z",
+                    )
                 )
-            )
-        logging.basicConfig(handlers=[handler], level=numeric_level, force=True)
+        logging.basicConfig(handlers=handlers, level=numeric_level, force=True)
         LOGGER.info(
             "Condition met: logging_initialized",
             extra={

--- a/tests/core/test_commit_active_dynamic_basket.py
+++ b/tests/core/test_commit_active_dynamic_basket.py
@@ -246,3 +246,37 @@ def test_real_botcontext_active_symbol_tokens_and_selected_subscription_aliases(
     assert ctx.active_symbol_tokens[pe] == 12
     assert ctx.active_symbol_tokens["NIFTY26JUN23900PE"] == 12
     assert {11, 12}.issubset(set(mdm.desired_tokens_snapshot()))
+
+
+def test_incomplete_basket_not_committed_and_does_not_call_mdm() -> None:
+    class _Mdm:
+        def __init__(self) -> None:
+            self.called = False
+            self.purged = False
+        def set_active_contract_basket(self, basket):
+            self.called = True
+        def purge_stale_nifty_futures(self, active_symbol, *, reason):
+            self.purged = True
+            return []
+
+    old = {"selected_ce": "OLDCE"}
+    mdm = _Mdm()
+    ctx = SimpleNamespace(
+        selected_ce=None,
+        selected_pe=None,
+        atm_ce_symbol=None,
+        atm_pe_symbol=None,
+        active_trading_universe=old,
+        active_contract_basket=old,
+        strategy_runner=None,
+        market_data_manager=mdm,
+        strategy_manager=None,
+    )
+
+    app._commit_active_dynamic_basket(ctx, basket={"spot_symbol": "NSE:NIFTY"}, option_symbols=[], symbols=["NSE:NIFTY"], atm_strike=None)
+
+    assert ctx.active_contract_basket is old
+    assert ctx.active_trading_universe is old
+    assert hasattr(ctx, "pending_contract_basket")
+    assert mdm.called is False
+    assert mdm.purged is False

--- a/tests/core/test_readiness_semantics.py
+++ b/tests/core/test_readiness_semantics.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from nifty_scalper_bot.core import app
+
+
+class _MDM:
+    def hydrate_active_contract_basket(self, basket=None):
+        return {"hard_ready": True, "missing": [], "symbols": {}}
+
+    def get_symbol_snapshot(self, symbol):
+        return SimpleNamespace(ltp=100.0, tick_age_s=1.0, bid=99.0, ask=101.0, tradable_quote=True, depth_available=True)
+
+    def has_ws_tradable_quote(self, symbols):
+        return True
+
+    def desired_tokens_snapshot(self):
+        return [11, 12]
+
+    def get_ohlc_bars(self, symbol):
+        return [{"close": 100.0}] * 30
+
+    def hydrate_symbol_history(self, symbol, **kwargs):
+        return self.get_ohlc_bars(symbol)
+
+    _subscribed_tokens = {11, 12}
+    _confirmed_subscriptions = {11, 12}
+    _symbol_to_token = {"NFO:NIFTY26JUN25000CE": 11, "NFO:NIFTY26JUN25000PE": 12}
+
+
+@pytest.mark.asyncio
+async def test_off_market_data_ready_splits_execution_arming(monkeypatch) -> None:
+    monkeypatch.setattr(app, "get_market_state", lambda: app.MarketState.CLOSED)
+    ce = "NFO:NIFTY26JUN25000CE"
+    pe = "NFO:NIFTY26JUN25000PE"
+    calls = []
+    ctx = SimpleNamespace(
+        active_trading_universe={"selected_ce": ce, "selected_pe": pe, "atm_strike": 25000, "option_symbols": [ce, pe], "token_by_symbol": {ce: 11, pe: 12}},
+        active_symbol_tokens={ce: 11, pe: 12},
+        selected_ce=ce,
+        selected_pe=pe,
+        market_data_manager=_MDM(),
+        settings=SimpleNamespace(execution_mode="LIVE"),
+        strategy_runner=SimpleNamespace(get_status=lambda: {"running": True}, _indicator_engine=SimpleNamespace(get_history=lambda s: [1] * 30), set_runtime_readiness=lambda **kw: calls.append(kw)),
+        order_manager=object(),
+        broker_client=object(),
+    )
+
+    await app._recompute_and_push_runtime_readiness(ctx, reason="unit_test")
+
+    assert ctx.data_ready is True
+    assert ctx.strategy_evaluation_ready is True
+    assert ctx.trading_ready is True
+    assert ctx.execution_armed is False
+    assert ctx.live_orders_armed is False
+    assert ctx.execution_block_reason == "market_closed"
+    assert calls[-1]["evaluation_ready"] is True

--- a/tests/data/test_futures_purge_safety.py
+++ b/tests/data/test_futures_purge_safety.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from nifty_scalper_bot.data.market_data_manager import MarketDataManager
+
+
+def _complete_basket() -> dict[str, object]:
+    ce = "NFO:NIFTY26JUN25000CE"
+    pe = "NFO:NIFTY26JUN25000PE"
+    fut = "NFO:NIFTY26JUNFUT"
+    return {
+        "spot_symbol": "NSE:NIFTY",
+        "spot_token": 256265,
+        "futures_symbol": fut,
+        "futures_token": 222,
+        "selected_ce": ce,
+        "selected_pe": pe,
+        "selected_ce_token": 11,
+        "selected_pe_token": 12,
+        "option_symbols": [ce, pe],
+        "option_tokens": [11, 12],
+        "all_symbols": ["NSE:NIFTY", fut, ce, pe],
+        "all_tokens": [256265, 222, 11, 12],
+        "token_by_symbol": {"NSE:NIFTY": 256265, fut: 222, ce: 11, pe: 12},
+        "symbol_by_token": {256265: "NSE:NIFTY", 222: fut, 11: ce, 12: pe},
+        "atm_strike": 25000,
+    }
+
+
+def test_purge_never_removes_spot_active_future_or_selected_options() -> None:
+    mdm = MarketDataManager(websocket=None)
+    basket = _complete_basket()
+    mdm.set_active_contract_basket(basket)
+
+    purged = mdm.purge_stale_nifty_futures("NFO:NIFTY26JUNFUT", reason="unit_test")
+
+    assert purged == []
+    assert 256265 in mdm._desired_tokens  # noqa: SLF001
+    assert 222 in mdm._desired_tokens  # noqa: SLF001
+    assert 11 in mdm._desired_tokens and 12 in mdm._desired_tokens  # noqa: SLF001
+
+
+def test_purge_removes_only_old_nifty_future_token() -> None:
+    mdm = MarketDataManager(websocket=None)
+    basket = _complete_basket()
+    mdm.set_active_contract_basket(basket)
+    old = "NFO:NIFTY26MAYFUT"
+    mdm._symbol_by_token[333] = old  # noqa: SLF001
+    mdm._token_to_symbol[333] = old  # noqa: SLF001
+    mdm._token_by_symbol[old] = 333  # noqa: SLF001
+    mdm._symbol_to_token[old] = 333  # noqa: SLF001
+    mdm._desired_tokens.add(333)  # noqa: SLF001
+
+    purged = mdm.purge_stale_nifty_futures("NFO:NIFTY26JUNFUT", reason="unit_test")
+
+    assert purged == [333]
+    assert 333 not in mdm._desired_tokens  # noqa: SLF001
+    assert 256265 in mdm._desired_tokens  # noqa: SLF001
+
+
+def test_unknown_token_not_purged_without_symbol_identity() -> None:
+    mdm = MarketDataManager(websocket=None)
+    basket = _complete_basket()
+    mdm.set_active_contract_basket(basket)
+    mdm._desired_tokens.add(999)  # noqa: SLF001
+
+    purged = mdm.purge_stale_nifty_futures("NFO:NIFTY26JUNFUT", reason="unit_test")
+
+    assert purged == []
+    assert 999 in mdm._desired_tokens  # noqa: SLF001

--- a/tests/data/test_mdm_subscribes_active_basket.py
+++ b/tests/data/test_mdm_subscribes_active_basket.py
@@ -180,3 +180,17 @@ def test_hydration_uses_hydration_min_bars_not_execution_min_bars(monkeypatch):
     assert report["hydration_min_bars_required"] == 5
     assert report["symbols"][b.selected_ce]["bars_count"] == 5
     assert report["hard_ready"] is True
+
+
+def test_incomplete_basket_does_not_clear_desired_tokens_or_set_active() -> None:
+    ws = WS()
+    mdm = MarketDataManager(websocket=ws)
+    b = basket()
+    mdm.set_active_contract_basket(b)
+    before = set(mdm._desired_tokens)  # noqa: SLF001
+    active_before = mdm.get_active_contract_basket()
+
+    mdm.set_active_contract_basket({"spot_symbol": "NSE:NIFTY", "spot_token": 256265, "all_tokens": []})
+
+    assert mdm._desired_tokens == before  # noqa: SLF001
+    assert mdm.get_active_contract_basket() is active_before

--- a/tests/data/test_mdm_subscribes_active_basket.py
+++ b/tests/data/test_mdm_subscribes_active_basket.py
@@ -267,3 +267,44 @@ async def test_deferred_reseed_deduplicates_inflight_and_clears(monkeypatch) -> 
     await asyncio.sleep(0)
 
     assert mdm._active_basket_reseed_inflight == set()  # noqa: SLF001
+
+
+def test_active_basket_validation_uses_canonical_fallback_without_private_missing_method(monkeypatch) -> None:
+    ws = WS()
+    mdm = MarketDataManager(websocket=ws)
+    assert not hasattr(mdm, "_canonical_symbol") or callable(getattr(mdm, "_canonical_symbol"))
+
+    def _missing_private_canonical_symbol(_symbol: str) -> str:
+        raise AttributeError("_canonical_symbol unavailable")
+
+    monkeypatch.setattr(mdm, "_canonical_symbol", _missing_private_canonical_symbol)
+    selected_ce = "NFO:NIFTY26JUN25000CE"
+    selected_pe = "NFO:NIFTY26JUN25000PE"
+    bare_ce = selected_ce.split(":", 1)[-1]
+    bare_pe = selected_pe.split(":", 1)[-1]
+    payload = {
+        "spot_symbol": "NSE:NIFTY",
+        "spot_token": 256265,
+        "selected_ce": selected_ce,
+        "selected_pe": selected_pe,
+        "option_symbols": [selected_ce, selected_pe],
+        "option_tokens": [11, 12],
+        "all_symbols": ["NSE:NIFTY", selected_ce, selected_pe],
+        "all_tokens": [256265, 11, 12],
+        "token_by_symbol": {
+            "nse:nifty": 256265,
+            selected_ce.lower(): 11,
+            selected_pe.lower(): 12,
+        },
+        "symbol_by_token": {256265: "NSE:NIFTY", 11: selected_ce, 12: selected_pe},
+        "atm_strike": 25000,
+    }
+    assert selected_ce not in payload["token_by_symbol"]
+    assert selected_pe not in payload["token_by_symbol"]
+    assert bare_ce not in payload["token_by_symbol"]
+    assert bare_pe not in payload["token_by_symbol"]
+
+    mdm.set_active_contract_basket(payload)
+
+    assert mdm.get_active_contract_basket() is payload
+    assert set(ws.tokens) == {256265, 11, 12}

--- a/tests/data/test_mdm_subscribes_active_basket.py
+++ b/tests/data/test_mdm_subscribes_active_basket.py
@@ -194,3 +194,76 @@ def test_incomplete_basket_does_not_clear_desired_tokens_or_set_active() -> None
 
     assert mdm._desired_tokens == before  # noqa: SLF001
     assert mdm.get_active_contract_basket() is active_before
+
+
+def test_active_basket_resolves_selected_tokens_from_alias_keys() -> None:
+    ws = WS()
+    mdm = MarketDataManager(websocket=ws)
+    payload = {
+        "spot_symbol": "NSE:NIFTY",
+        "spot_token": 256265,
+        "selected_ce": "NFO:NIFTY26JUN25000CE",
+        "selected_pe": "NFO:NIFTY26JUN25000PE",
+        "option_symbols": ["NFO:NIFTY26JUN25000CE", "NFO:NIFTY26JUN25000PE"],
+        "option_tokens": [11, 12],
+        "all_symbols": ["NSE:NIFTY", "NFO:NIFTY26JUN25000CE", "NFO:NIFTY26JUN25000PE"],
+        "all_tokens": [256265, 11, 12],
+        "token_by_symbol": {"NSE:NIFTY": 256265, "NIFTY26JUN25000CE": 11, "NFO:NIFTY26JUN25000PE": 12},
+        "symbol_by_token": {256265: "NSE:NIFTY", 11: "NFO:NIFTY26JUN25000CE", 12: "NFO:NIFTY26JUN25000PE"},
+        "atm_strike": 25000,
+    }
+
+    mdm.set_active_contract_basket(payload)
+
+    assert mdm.get_active_contract_basket() is payload
+    assert set(ws.tokens) == {256265, 11, 12}
+
+
+def test_subscription_reconciliation_snapshot_tuple_is_non_blocking() -> None:
+    class TupleSnapshotWS(WS):
+        tokens_snapshot = (256265, 11, 12)
+
+    ws = TupleSnapshotWS()
+    mdm = MarketDataManager(websocket=ws)
+
+    mdm.set_active_contract_basket(basket())
+
+    assert set(ws.tokens) == {256265, 11, 12}
+
+
+@pytest.mark.asyncio
+async def test_deferred_reseed_deduplicates_inflight_and_clears(monkeypatch) -> None:
+    import asyncio
+
+    mdm = MarketDataManager(websocket=WS())
+    b = basket()
+    monkeypatch.setenv("HYDRATION_SELECTED_OPTION_MIN_BARS", "3")
+    mdm.set_active_contract_basket(b)
+    quotes = {sym: {"ltp": 100.0, "bid": 99.0, "ask": 101.0, "source": "test"} for sym in b.all_symbols}
+    monkeypatch.setattr(mdm, "get_latest_tick", lambda sym: quotes.get(sym))
+    monkeypatch.setattr(mdm, "get_quote", lambda sym: quotes.get(sym))
+    monkeypatch.setattr(mdm, "get_ohlc_bars", lambda sym: [])
+    release = asyncio.Event()
+    attempts: list[str] = []
+
+    async def hydrate_symbol_history(symbol, **kwargs):
+        attempts.append(symbol)
+        await release.wait()
+        return []
+
+    monkeypatch.setattr(mdm, "hydrate_symbol_history", hydrate_symbol_history)
+
+    first = mdm.hydrate_active_contract_basket(b)
+    await asyncio.sleep(0)
+    second = mdm.hydrate_active_contract_basket(b)
+
+    assert first["retry_scheduled"] is True
+    assert second["retry_scheduled"] is True
+    assert attempts == [b.selected_ce, b.selected_pe]
+    assert set(mdm._active_basket_reseed_inflight) == {b.selected_ce, b.selected_pe}  # noqa: SLF001
+
+    release.set()
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    assert mdm._active_basket_reseed_inflight == set()  # noqa: SLF001

--- a/tests/data/test_option_volume_delta.py
+++ b/tests/data/test_option_volume_delta.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from nifty_scalper_bot.data.market_data_manager import MarketDataManager
+
+
+def test_cumulative_volume_normalized_to_delta() -> None:
+    mdm = MarketDataManager(websocket=None)
+    first = mdm._normalise_tick_volume_delta("NFO:NIFTY26JUN25000CE", {"volume_traded_today": 1000})  # noqa: SLF001
+    second = mdm._normalise_tick_volume_delta("NFO:NIFTY26JUN25000CE", {"volume_traded_today": 1300})  # noqa: SLF001
+
+    assert first["volume"] == 0
+    assert second["volume"] == 300
+    assert second["volume_delta"] == 300
+    assert second["volume_cumulative"] == 1300
+
+
+def test_cumulative_volume_reset_is_safe_delta() -> None:
+    mdm = MarketDataManager(websocket=None)
+    mdm._normalise_tick_volume_delta("NFO:NIFTY26JUN25000PE", {"volume_traded_today": 5000})  # noqa: SLF001
+    reset = mdm._normalise_tick_volume_delta("NFO:NIFTY26JUN25000PE", {"volume_traded_today": 100})  # noqa: SLF001
+
+    assert reset["volume"] == 100
+
+
+def test_huge_cumulative_first_tick_does_not_reach_volume() -> None:
+    mdm = MarketDataManager(websocket=None)
+    normalized = mdm._normalize_tick("NFO:NIFTY26JUN25000CE", {"last_price": 120.0, "volume_traded_today": 563803045})  # noqa: SLF001
+
+    assert normalized is not None
+    assert normalized["volume"] == 0
+    assert normalized["volume_cumulative"] == 563803045

--- a/tests/test_logging_severity_routing.py
+++ b/tests/test_logging_severity_routing.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import logging
+
+from nifty_scalper_bot.utils.logging import setup_logging
+
+
+def test_info_goes_stdout_and_error_goes_stderr(capsys, monkeypatch) -> None:
+    monkeypatch.setenv("LOG_DEDUP_ENABLED", "0")
+    setup_logging("INFO")
+    logger = logging.getLogger("nifty_scalper_bot.test_logging_severity")
+
+    logger.info("info-severity-check")
+    logger.error("error-severity-check")
+
+    captured = capsys.readouterr()
+    assert "info-severity-check" in captured.out
+    assert "info-severity-check" not in captured.err
+    assert "error-severity-check" in captured.err


### PR DESCRIPTION
### Motivation

- Fix unsafe early commits of empty/incomplete ActiveContractBasket that cleared desired token sets and triggered unsafe purges and reconcilers. 
- Prevent overly-broad stale-futures purge that could remove spot/active future/selected-option tokens. 
- Normalize cumulative option volume into per-tick deltas, make deferred reseed non-terminal, and clarify readiness vs execution arming to avoid confusing logs and false alerts. 
- Dependency: this PR expects the off-market polling supervisor fixes from PR #496 to be available first (it does not change polling supervisor logic). 

### Description

- Added active-basket completeness validation and commit deferral so incomplete baskets are stored as `pending_contract_basket` and do not overwrite active state or clear `_desired_tokens` (changes in `core/app.py` and `data/market_data_manager.py`).
- Hardened `MarketDataManager.set_active_contract_basket()` to reject incomplete trading baskets and added role-aware subscription diagnostics via `SUBSCRIPTION_ROLE_SUMMARY` / `ACTIVE_BASKET_SUBSCRIPTION_RECONCILED` (in `data/market_data_manager.py`).
- Reworked `purge_stale_nifty_futures()` to be role-aware and protective (never purge spot/active future/selected-option/active-basket tokens) and to log structured purge state and skipped/unknown tokens (in `data/market_data_manager.py`).
- Normalize broker cumulative volumes to reset-safe deltas (`_normalise_tick_volume_delta`) and ensure tick/ohlc ingestion uses the delta as per-tick/per-bar volume while preserving cumulative values; keep clamp as defensive last-resort (in `data/market_data_manager.py`).
- Make deferred OHLC reseed schedule attach a done-callback that logs completion/failure and recomputes hydration/readiness rather than leaving hydration in a terminal-failure state (in `data/market_data_manager.py`).
- Separate data/strategy readiness from execution arming: added `data_ready`, `strategy_evaluation_ready`, `trading_signal_ready`, `execution_armed`, `execution_block_reason`, and `market_open` in runtime readiness reporting and adjusted startup summary wording (in `core/app.py`).
- Soft-handle zero historical bars for `NSE:NIFTY` as `SPOT_INDEX_HISTORY_UNAVAILABLE_SOFT` when appropriate, to avoid alarming errors for off-market index history (in `core/app.py`).
- Fix logging severity routing to ensure INFO/WARNING go to stdout and ERROR+ to stderr to avoid platform false-error alerts (in `utils/logging.py`).

Files touched (key):
- `src/nifty_scalper_bot/core/app.py` (active-basket commit deferral, readiness split, startup messaging)
- `src/nifty_scalper_bot/data/market_data_manager.py` (active-basket guard, role-aware diagnostics, safe futures purge, volume delta normalization, reseed callbacks)
- `src/nifty_scalper_bot/utils/logging.py` (stdout/stderr routing filters)
- Added / updated focused tests under `tests/core` and `tests/data` covering the changes above.

### Testing

- Build: ran `python -m compileall -q src` and it succeeded. 
- Focused and full test suite runs: executed `pytest -q` and the focused test runs below; all reported green in CI run performed locally: 
  - `pytest -q tests/core/test_commit_active_dynamic_basket.py` — passed.
  - `pytest -q tests/core/test_basket_commit_before_readiness.py` — passed.
  - `pytest -q tests/data/test_mdm_subscribes_active_basket.py` — passed.
  - `pytest -q tests/test_live_basket_hydration.py` — passed.
  - `pytest -q tests/test_live_tick_pipeline_to_runner.py` — passed.
  - `pytest -q tests/strategies/test_runner_live_path_guards.py` — passed.
  - `pytest -q tests/data/test_market_data_health.py` — passed.
  - `pytest -q tests/core/test_app_polling_fallback_market_aware.py` — passed.
  - New/added tests: `tests/data/test_futures_purge_safety.py`, `tests/data/test_option_volume_delta.py`, `tests/core/test_readiness_semantics.py`, `tests/test_logging_severity_routing.py` — all passed.
  - `pytest -q` (full suite) — passed.

All automated tests completed successfully locally; compile and tests passed. If CI environment differs (external brokers/resolvers), the new deferred-reseed/hydration behavior is conservative and will only retry instead of failing startup.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1dd74f85688324a7c2758c20bb38b7)