### PR TITLE
Fix deferred basket retry readiness crash

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -2456,9 +2456,15 @@ class BotContext:
     data_observation_ready: bool = False
     data_pipeline_ready: bool = False
     data_hard_ready: bool = False
+    data_ready: bool = False
     mdm_strict_hard_ready: bool = False
     spot_ready: bool = False
     evaluation_ready: bool = False
+    strategy_evaluation_ready: bool = False
+    trading_signal_ready: bool = False
+    execution_armed: bool = False
+    execution_block_reason: str | None = None
+    market_open: bool = False
     execution_ready_by_symbol: dict[str, bool] = field(default_factory=dict)
     selected_ce_exec_ready: bool = False
     selected_pe_exec_ready: bool = False
@@ -8397,6 +8403,20 @@ async def _deferred_basket_hydration_retry(
             await _recompute_and_push_runtime_readiness(
                 ctx, reason="deferred_basket_hydration_success"
             )
+            if not bool(getattr(ctx, "data_ready", False)):
+                LOGGER.info(
+                    "DEFERRED_BASKET_RETRY_FAILED attempt=%d/%d reason=%s",
+                    attempt,
+                    max_attempts,
+                    "data_not_ready",
+                    extra={
+                        "event": "DEFERRED_BASKET_RETRY_FAILED",
+                        "attempt": attempt,
+                        "max_attempts": max_attempts,
+                        "reason": "data_not_ready",
+                    },
+                )
+                continue
             LOGGER.info(
                 "DEFERRED_BASKET_RETRY_SUCCESS attempt=%d spot_ltp=%.2f",
                 attempt,

--- a/tests/core/test_deferred_basket_retry.py
+++ b/tests/core/test_deferred_basket_retry.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from nifty_scalper_bot.core import app
+
+
+@pytest.mark.asyncio
+async def test_deferred_basket_retry_without_ctx_data_ready_logs_data_not_ready(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Regression: slotted/legacy contexts without data_ready must not crash retries."""
+
+    async def _spot_ready(*args, **kwargs):
+        return 23701.0
+
+    async def _build_basket(*args, **kwargs):
+        return {
+            "selected_ce": "NFO:NIFTY26JUN23700CE",
+            "selected_pe": "NFO:NIFTY26JUN23700PE",
+            "option_symbols": ["NFO:NIFTY26JUN23700CE", "NFO:NIFTY26JUN23700PE"],
+            "symbols": ["NSE:NIFTY", "NFO:NIFTY26JUN23700CE", "NFO:NIFTY26JUN23700PE"],
+            "atm_strike": 23700,
+        }
+
+    async def _noop_async(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(app, "_wait_for_live_spot_or_raise", _spot_ready)
+    monkeypatch.setattr(app, "_build_and_hydrate_live_basket_from_spot", _build_basket)
+    monkeypatch.setattr(app, "_ensure_strategy_runner_started", _noop_async)
+    monkeypatch.setattr(app, "_recompute_and_push_runtime_readiness", _noop_async)
+
+    ctx = SimpleNamespace(
+        trading_ready=False,
+        live_orders_armed=False,
+        selected_ce="NFO:NIFTY26JUN23700CE",
+    )
+
+    caplog.set_level("INFO", logger=app.LOGGER.name)
+
+    await app._deferred_basket_hydration_retry(
+        ctx,
+        configured_mode="LIVE",
+        max_attempts=1,
+        delay_seconds=0,
+    )
+
+    assert "reason=data_not_ready" in caplog.text
+    assert "AttributeError" not in caplog.text
+    assert not hasattr(ctx, "data_ready")

--- a/tests/core/test_startup_spot_watchdog.py
+++ b/tests/core/test_startup_spot_watchdog.py
@@ -200,7 +200,8 @@ async def test_instrument_manager_not_ready_defers_then_retries(monkeypatch: pyt
 
     assert ctx.active_contract_basket["selected_ce"] == "NFO:NIFTY26JUN25000CE"
     assert "LIVE_BASKET_BUILD_DEFERRED" in caplog.text
-    assert "DEFERRED_BASKET_RETRY_SUCCESS" in caplog.text
+    assert "DEFERRED_BASKET_RETRY_FAILED attempt=1/1 reason=data_not_ready" in caplog.text
+    assert "DEFERRED_BASKET_RETRY_SUCCESS" not in caplog.text
     for coro in scheduled:
         coro.close()
 

--- a/tests/test_botcontext_startup_fields.py
+++ b/tests/test_botcontext_startup_fields.py
@@ -8,6 +8,12 @@ def test_botcontext_has_startup_spot_fields() -> None:
     names = {field.name for field in fields(BotContext)}
     assert 'startup_spot_refresh_done' in names
     assert 'startup_spot_listener_registered' in names
+    assert 'data_ready' in names
+    assert 'strategy_evaluation_ready' in names
+    assert 'trading_signal_ready' in names
+    assert 'execution_armed' in names
+    assert 'execution_block_reason' in names
+    assert 'market_open' in names
     assert 'execution_ready_by_symbol' in names
     assert 'selected_ce_exec_ready' in names
     assert 'selected_pe_exec_ready' in names
@@ -17,8 +23,16 @@ def test_botcontext_has_startup_spot_fields() -> None:
 
 def test_assigning_startup_fields_does_not_raise() -> None:
     ctx = object.__new__(BotContext)
+    ctx.data_ready = False
+    ctx.strategy_evaluation_ready = False
+    ctx.trading_signal_ready = False
+    ctx.execution_armed = False
+    ctx.execution_block_reason = 'data_not_ready'
+    ctx.market_open = False
     ctx.execution_ready_by_symbol = {}
     ctx.selected_ce_exec_ready = True
     ctx.selected_pe_exec_ready = False
+    assert ctx.data_ready is False
+    assert ctx.execution_block_reason == 'data_not_ready'
     assert isinstance(ctx.execution_ready_by_symbol, dict)
     assert ctx.selected_ce_exec_ready is True


### PR DESCRIPTION
### Motivation

- A deferred basket retry observed `DEFERRED_BASKET_RETRY_FAILED ... 'BotContext' object has no attribute 'data_ready'` because runtime readiness recomputation assigned `ctx.data_ready` on a slotted `BotContext` that did not declare that field.  
- The change is intended to prevent retries from crashing on legacy/slotted contexts and to make the retry decision rely on the authoritative readiness state instead of raising `AttributeError` or producing a false success.

### Description

- Added explicit slotted readiness fields to `BotContext` in `src/nifty_scalper_bot/core/app.py`, including `data_ready`, `strategy_evaluation_ready`, `trading_signal_ready`, `execution_armed`, `execution_block_reason`, and `market_open` with safe defaults.  
- Hardened `_deferred_basket_hydration_retry` to use `getattr(ctx, "data_ready", False)` after calling `_recompute_and_push_runtime_readiness` and to log and continue with an explicit `data_not_ready` reason when readiness is not met.  
- Added a regression test `tests/core/test_deferred_basket_retry.py` that verifies a context lacking `data_ready` does not raise `AttributeError` and logs `data_not_ready`.  
- Updated `tests/test_botcontext_startup_fields.py` to assert the new `BotContext` readiness fields exist and are assignable, and adjusted `tests/core/test_startup_spot_watchdog.py` expectations to reflect stricter readiness semantics.  
- No new dependencies were introduced and execution/risk/strategy code paths were not modified.

### Testing

- Ran compilation: `python -m compileall -q src` which completed successfully.  
- Ran focused tests: `pytest -q tests/core/test_deferred_basket_retry.py tests/test_botcontext_startup_fields.py tests/core/test_readiness_semantics.py` and they passed.  
- Ran broader checks: `pytest -q tests/core/test_startup_spot_watchdog.py tests/core/test_deferred_basket_retry.py` and full `pytest -q`, all tests passed in CI run after the fix.  
- Regression verified: deferred basket retry no longer raises `AttributeError` on contexts without `data_ready` and logs `reason=data_not_ready` instead of falsely reporting success.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e6c2a39788324badd870e72997dee)