### PR TITLE
Fix NIFTY context and option history hydration sync

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -7119,6 +7119,77 @@ def _pick_atm_option_symbols_from_basket(basket: dict[str, object]) -> tuple[str
     return pick_atm_option_symbols_from_basket(basket)
 
 
+async def _ensure_context_history_hydrated(
+    ctx: BotContext, spot_symbol: str | None, futures_symbol: str | None, required_bars: int, reason: str
+) -> dict[str, dict[str, int | bool]]:
+    """Ensure spot/futures history is visible to MDM and runner IndicatorEngine."""
+    mdm = getattr(ctx, "market_data_manager", None)
+    runner = getattr(ctx, "strategy_runner", None)
+    result: dict[str, dict[str, int | bool]] = {}
+    if mdm is None:
+        return result
+    symbols = [sym for sym in (spot_symbol or "NSE:NIFTY", futures_symbol) if sym]
+    for sym in symbols:
+        before_mdm = len(mdm.get_ohlc_bars(sym) or [])
+        before_runner = len(runner._indicator_engine.get_history(sym) or []) if runner is not None and hasattr(runner, "_indicator_engine") else 0
+        if before_mdm < required_bars:
+            hydrate_fn = getattr(mdm, "hydrate_symbol_history", None)
+            if callable(hydrate_fn):
+                try:
+                    await hydrate_fn(sym, interval="minute", days=_history_lookback_days(required_bars), max_bars=required_bars, reason=f"{reason}_context_force_hydration")
+                except Exception as exc:  # noqa: BLE001 - readiness remains blocked and logged
+                    LOGGER.warning(
+                        "CONTEXT_HISTORY_HYDRATION_FAILED symbol=%s source=%s error=%s",
+                        sym,
+                        f"{reason}_context_force_hydration",
+                        exc,
+                        extra={"event": "CONTEXT_HISTORY_HYDRATION_FAILED", "symbol": sym, "source": f"{reason}_context_force_hydration", "error": str(exc)},
+                    )
+        try:
+            bars = mdm.get_ohlc_bars(sym, limit=required_bars) or []
+        except TypeError:
+            bars = mdm.get_ohlc_bars(sym) or []
+        ingested = 0
+        if runner is not None and hasattr(runner, "reseed_history_from_bars") and bars:
+            try:
+                ingested = int(
+                    runner.reseed_history_from_bars(
+                        sym,
+                        bars,
+                        source=f"{reason}_context_reseed",
+                        min_bars=required_bars,
+                    )
+                    or 0
+                )
+            except Exception as exc:  # noqa: BLE001 - readiness remains blocked and logged
+                LOGGER.warning(
+                    "CONTEXT_HISTORY_HYDRATION_FAILED symbol=%s source=%s error=%s",
+                    sym,
+                    f"{reason}_context_reseed",
+                    exc,
+                    extra={"event": "CONTEXT_HISTORY_HYDRATION_FAILED", "symbol": sym, "source": f"{reason}_context_reseed", "error": str(exc)},
+                )
+        after_mdm = len(mdm.get_ohlc_bars(sym) or [])
+        after_runner = len(runner._indicator_engine.get_history(sym) or []) if runner is not None and hasattr(runner, "_indicator_engine") else 0
+        LOGGER.info(
+            "HISTORY_HYDRATION_TRACE symbol=%s source=%s fetched_bars=%d ingested_bars=%d indicator_history_count=%d",
+            sym,
+            f"{reason}_context",
+            len(bars),
+            ingested,
+            after_runner,
+            extra={"event": "HISTORY_HYDRATION_TRACE", "symbol": sym, "source": f"{reason}_context", "fetched_bars": len(bars), "ingested_bars": ingested, "indicator_history_count": after_runner},
+        )
+        result[sym] = {
+            "before_mdm_bars": before_mdm,
+            "after_mdm_bars": after_mdm,
+            "before_runner_bars": before_runner,
+            "after_runner_bars": after_runner,
+            "ready": bool(after_mdm >= required_bars and after_runner >= required_bars),
+        }
+    return result
+
+
 async def _ensure_selected_options_hydrated(
     ctx: BotContext, selected_ce: str | None, selected_pe: str | None, required_bars: int, reason: str
 ) -> dict[str, dict[str, int | bool]]:
@@ -7143,7 +7214,7 @@ async def _ensure_selected_options_hydrated(
             }
             continue
         hydrate_fn = getattr(mdm, "hydrate_symbol_history", None)
-        if callable(hydrate_fn):
+        if before_mdm_bars < required_bars and callable(hydrate_fn):
             await hydrate_fn(sym, interval="minute", days=_history_lookback_days(required_bars), max_bars=required_bars, reason=f"{reason}_selected_option_force_hydration")
         try:
             bars = mdm.get_ohlc_bars(sym, limit=required_bars) or []
@@ -7180,6 +7251,14 @@ async def _ensure_selected_options_hydrated(
                 LOGGER.info(
                     "SELECTED_OPTION_RUNNER_RESEED_DONE symbol=%s reseeded_count=%s required_bars=%d reason=%s",
                     sym,
+                    reseeded_count,
+                    required_bars,
+                    reason,
+                )
+                LOGGER.info(
+                    "SELECTED_OPTION_RUNNER_SYNC_FROM_MDM symbol=%s mdm_bars=%d runner_bars=%s required_bars=%d reason=%s",
+                    sym,
+                    len(normalized_bars),
                     reseeded_count,
                     required_bars,
                     reason,
@@ -7365,9 +7444,38 @@ async def _recompute_and_push_runtime_readiness(ctx: BotContext, *, reason: str)
     option_eval_min_live_bars = int(os.getenv("READINESS_OPTION_EVAL_MIN_BARS", os.getenv("OPTION_EVAL_MIN_LIVE_BARS", "20")) or 20)
     option_execution_min_bars = int(os.getenv("READINESS_OPTION_EXEC_MIN_BARS", os.getenv("OPTION_EXECUTION_MIN_BARS", "30")) or 30)
     context_execution_min_bars = int(os.getenv("READINESS_CONTEXT_MIN_BARS", os.getenv("CONTEXT_EXECUTION_MIN_BARS", "20")) or 20)
+    futures_symbol = str(basket.get("futures_symbol") or "")
+    _ = await _ensure_context_history_hydrated(
+        ctx, spot_symbol, futures_symbol, context_execution_min_bars, reason
+    )
     _ = await _ensure_selected_options_hydrated(
         ctx, selected_ce, selected_pe, option_execution_min_bars, reason
     )
+    basket_hard_ready = True
+    basket_missing: list[str] = []
+    hydrate_basket = getattr(mdm, "hydrate_active_contract_basket", None) if mdm is not None else None
+    if callable(hydrate_basket):
+        try:
+            hydration_status = hydrate_basket(basket)
+            if isinstance(hydration_status, Mapping):
+                basket_hard_ready = bool(hydration_status.get("hard_ready", True))
+                basket_missing = [str(item) for item in hydration_status.get("missing", []) or []]
+        except Exception as exc:  # noqa: BLE001 - readiness remains blocked by explicit diagnostic
+            basket_hard_ready = False
+            basket_missing = [f"active_basket_hydration_failed:{type(exc).__name__}"]
+            LOGGER.warning(
+                "ACTIVE_BASKET_HYDRATION_STATUS_FAILED reason=%s",
+                exc,
+                extra={"event": "ACTIVE_BASKET_HYDRATION_STATUS_FAILED", "error": str(exc)},
+            )
+    elif str(os.getenv("ALLOW_MISSING_HYDRATION_GATE", "false") or "false").strip().lower() not in {"1", "true", "yes", "on"}:
+        basket_hard_ready = False
+        basket_missing = ["hydrate_active_contract_basket_missing"]
+        LOGGER.warning(
+            "ACTIVE_BASKET_HYDRATION_METHOD_MISSING hard_ready=False",
+            extra={"event": "ACTIVE_BASKET_HYDRATION_METHOD_MISSING", "missing": list(basket_missing)},
+        )
+    ctx.active_basket_hydration = {"hard_ready": bool(basket_hard_ready), "missing": list(basket_missing)}
     ce_bars, ce_mdm_bars, ce_runner_bars = _readiness_bars(selected_ce)
     pe_bars, pe_mdm_bars, pe_runner_bars = _readiness_bars(selected_pe)
     ce_quote_fresh=_fresh_ltp(selected_ce); pe_quote_fresh=_fresh_ltp(selected_pe)
@@ -7376,9 +7484,8 @@ async def _recompute_and_push_runtime_readiness(ctx: BotContext, *, reason: str)
     ce_eval_ready = bool(selected_ce) and ce_quote_fresh and ce_bars >= option_eval_min_live_bars
     pe_eval_ready = bool(selected_pe) and pe_quote_fresh and pe_bars >= option_eval_min_live_bars
     spot_ready=_fresh_ltp(spot_symbol) or _bars(spot_symbol)>=1
-    futures_symbol = str(basket.get("futures_symbol") or "")
     context_exec_ready = _bars(spot_symbol)>=context_execution_min_bars or (_fresh_ltp(spot_symbol) and _bars(futures_symbol)>=context_execution_min_bars)
-    data_hard_ready=bool(spot_ready and ce_eval_ready and pe_eval_ready)
+    data_hard_ready=bool(basket_hard_ready and spot_ready and ce_eval_ready and pe_eval_ready)
     runner_running=_runner_is_running(getattr(ctx,'strategy_runner',None))
     evaluation_ready=bool(data_hard_ready and runner_running)
     live_mode = str(getattr(ctx.settings, "execution_mode", "PAPER")).upper() == "LIVE"
@@ -7395,6 +7502,7 @@ async def _recompute_and_push_runtime_readiness(ctx: BotContext, *, reason: str)
     if not selected_ce: missing.append('selected_ce_missing')
     if not selected_pe: missing.append('selected_pe_missing')
     if not spot_ready: missing.append('spot_not_ready')
+    if not basket_hard_ready: missing.extend(basket_missing or ['active_basket_hydration_not_ready'])
     if not evaluation_ready: missing.append('eval_not_ready')
     if ce_runner_bars < option_eval_min_live_bars: missing.append('ce_eval_bars_missing')
     if pe_runner_bars < option_eval_min_live_bars: missing.append('pe_eval_bars_missing')
@@ -7411,7 +7519,12 @@ async def _recompute_and_push_runtime_readiness(ctx: BotContext, *, reason: str)
         if not pe_exec_ready: missing.append('pe_exec_quote_or_history_not_ready')
         if not context_exec_ready: missing.append('context_exec_not_ready')
         if not broker_ready: missing.append('broker_not_ready')
-    block_reason=None if live_orders_armed else f"execution_not_armed:{','.join(dict.fromkeys(missing))}"
+    if live_orders_armed:
+        block_reason = None
+    elif not basket_hard_ready:
+        block_reason = f"ACTIVE_BASKET_HYDRATION_NOT_READY:{','.join(dict.fromkeys(missing))}"
+    else:
+        block_reason = f"execution_not_armed:{','.join(dict.fromkeys(missing))}"
     ctx.data_hard_ready=data_hard_ready; ctx.evaluation_ready=evaluation_ready; ctx.live_orders_armed=live_orders_armed; ctx.trading_ready=evaluation_ready; ctx.live_block_reason=block_reason
     ctx.execution_ready_by_symbol = execution_ready_by_symbol
     ctx.selected_ce_exec_ready = bool(ce_exec_ready)
@@ -7433,7 +7546,7 @@ def _commit_active_dynamic_basket(
 ) -> tuple[str | None, str | None]:
     """Commit active dynamic basket atomically. Args: ctx/basket/option_symbols/symbols/atm_strike. Returns: selected CE/PE. Raises: none."""
     requested_futures_symbol = basket.get("futures_symbol") or basket.get("future_symbol")
-    active_futures_symbol = _resolve_active_futures_for_basket(ctx, requested_futures_symbol)
+    active_futures_symbol = canonical_nifty_future_symbol(requested_futures_symbol) or _resolve_active_futures_for_basket(ctx, requested_futures_symbol)
     basket_copy = dict(basket or {})
     basket_copy["futures_symbol"] = active_futures_symbol
     basket = normalize_active_basket_schema(basket_copy)
@@ -7698,6 +7811,20 @@ async def _deferred_basket_hydration_retry(
             await _recompute_and_push_runtime_readiness(
                 ctx, reason="deferred_basket_hydration_success"
             )
+            data_ready = bool(getattr(ctx, "data_ready", getattr(ctx, "evaluation_ready", False)))
+            if not data_ready:
+                LOGGER.info(
+                    "DEFERRED_BASKET_RETRY_WAITING attempt=%d/%d reason=data_not_ready",
+                    attempt,
+                    max_attempts,
+                    extra={
+                        "event": "DEFERRED_BASKET_RETRY_WAITING",
+                        "attempt": attempt,
+                        "max_attempts": max_attempts,
+                        "reason": "data_not_ready",
+                    },
+                )
+                continue
             LOGGER.info(
                 "DEFERRED_BASKET_RETRY_SUCCESS attempt=%d spot_ltp=%.2f",
                 attempt,

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -1324,25 +1324,30 @@ class StrategyRunner:
                     continue
         return []
 
-    def _request_mdm_hydration(self, symbol: str, min_bars: int) -> None:
-        """Request async hydration from owner service. Args: symbol/min_bars. Returns: None. Raises: None."""
+    def _request_mdm_hydration(self, symbol: str, min_bars: int, *, reason: str = "runner_missing_bars") -> None:
+        """Request async hydration from owner service. Args: symbol/min_bars/reason. Returns: None. Raises: None."""
         self._hydration_attempted_symbols.add(symbol)
-        self._last_hydration_reason_by_symbol[symbol] = "runner_missing_bars"
+        self._last_hydration_reason_by_symbol[symbol] = reason
         for source in (self._market_data, self._data_hub):
             fn = getattr(source, "request_hydration", None)
             if callable(fn):
                 try:
-                    fn(symbol, min_bars=min_bars, reason="runner_missing_bars")
+                    fn(symbol, min_bars=min_bars, reason=reason)
                     return
-                except Exception:
-                    pass
+                except Exception as exc:  # noqa: BLE001 - owner request failures are diagnostic only
+                    self._logger.warning(
+                        "CONTEXT_HISTORY_HYDRATION_FAILED symbol=%s source=request_hydration error=%s",
+                        symbol,
+                        exc,
+                        extra={"event": "CONTEXT_HISTORY_HYDRATION_FAILED", "symbol": symbol, "source": "request_hydration", "error": str(exc), "reason": reason},
+                    )
         log_throttled(
             self._logger,
             f"runner_waiting_for_mdm_hydration:{symbol}",
             f"RUNNER_WAITING_FOR_MDM_HYDRATION symbol={symbol} min_bars={min_bars}",
             interval_sec=60.0,
             level=logging.INFO,
-            extra={"event": "RUNNER_WAITING_FOR_MDM_HYDRATION", "symbol": symbol, "min_bars": min_bars},
+            extra={"event": "RUNNER_WAITING_FOR_MDM_HYDRATION", "symbol": symbol, "min_bars": min_bars, "reason": reason},
         )
 
     def _hydrate_from_mdm_cache(self, symbol: str) -> int:
@@ -1369,6 +1374,149 @@ class StrategyRunner:
             extra={"event": "RUNNER_MDM_CACHE_HYDRATION", "symbol": symbol, "ingested": ingested, "target": target},
         )
         return ingested
+
+    def _emit_history_hydration_trace(
+        self,
+        symbol: str,
+        *,
+        source: str,
+        fetched_bars: int,
+        ingested_bars: int,
+    ) -> None:
+        """Emit concise hydration trace. Args: symbol/source/counts. Returns: None. Raises: None."""
+        indicator_count = self._history_count_for_symbol(symbol)
+        self._logger.info(
+            "HISTORY_HYDRATION_TRACE symbol=%s source=%s fetched_bars=%d ingested_bars=%d indicator_history_count=%d",
+            symbol,
+            source,
+            int(fetched_bars),
+            int(ingested_bars),
+            int(indicator_count),
+            extra={
+                "event": "HISTORY_HYDRATION_TRACE",
+                "symbol": symbol,
+                "source": source,
+                "fetched_bars": int(fetched_bars),
+                "ingested_bars": int(ingested_bars),
+                "indicator_history_count": int(indicator_count),
+            },
+        )
+
+    def _sync_history_from_mdm_cache(
+        self,
+        symbol: str,
+        *,
+        required_bars: int | None = None,
+        source: str = "mdm_cache_sync",
+        request_if_short: bool = True,
+    ) -> int:
+        """Sync cached DataHub/MDM bars into IndicatorEngine. Args: symbol/required/source. Returns: indicator count."""
+        normalized = self._normalize_symbol(symbol)
+        if not normalized:
+            return 0
+        target = max(1, int(required_bars or self._required_bars_for_symbol(normalized) or 1))
+        indicator_before = self._history_count_for_symbol(normalized)
+        rows = self._get_mdm_bars(normalized, max(target, indicator_before))
+        ingested = 0
+        if rows and indicator_before < min(target, len(rows)):
+            ingested = int(
+                self.reseed_history_from_bars(
+                    normalized,
+                    rows,
+                    source=source,
+                    min_bars=target,
+                )
+                or 0
+            )
+        indicator_after = self._history_count_for_symbol(normalized)
+        self._emit_history_hydration_trace(
+            normalized,
+            source=source,
+            fetched_bars=len(rows),
+            ingested_bars=ingested if ingested else max(0, indicator_after - indicator_before),
+        )
+        if indicator_after < target and request_if_short:
+            self._request_mdm_hydration(normalized, target, reason=source)
+        return indicator_after
+
+    def _active_context_symbols_for_history(self) -> list[str]:
+        """Return canonical spot/futures context symbols. Args: none. Returns: symbols."""
+        symbols = ["NSE:NIFTY"]
+        futures_symbol = normalize_symbol(str(getattr(self, "_active_futures_symbol", "") or ""))
+        if not futures_symbol:
+            futures_symbol = next(
+                (
+                    sym
+                    for sym in getattr(self, "_active_symbols", set())
+                    if self._symbol_role_for_runner(sym) == "futures_context"
+                    and not self._is_context_symbol_suspended(sym)
+                ),
+                "",
+            )
+        if futures_symbol:
+            symbols.append(futures_symbol)
+        return symbols
+
+    def _sync_context_history_if_cold(self, *, source: str = "context_history_sync") -> None:
+        """Ensure spot/futures cached history is visible to IndicatorEngine."""
+        for ctx_symbol in self._active_context_symbols_for_history():
+            count = self._history_count_for_symbol(ctx_symbol)
+            if count >= self._context_required_bars:
+                self._emit_history_hydration_trace(
+                    ctx_symbol,
+                    source=source,
+                    fetched_bars=0,
+                    ingested_bars=0,
+                )
+                continue
+            try:
+                after = self._sync_history_from_mdm_cache(
+                    ctx_symbol,
+                    required_bars=self._context_required_bars,
+                    source=source,
+                )
+                if after < self._context_required_bars:
+                    self._logger.warning(
+                        "CONTEXT_HISTORY_HYDRATION_FAILED symbol=%s source=%s error=%s",
+                        ctx_symbol,
+                        source,
+                        "insufficient_cached_bars",
+                        extra={"event": "CONTEXT_HISTORY_HYDRATION_FAILED", "symbol": ctx_symbol, "source": source, "error": "insufficient_cached_bars", "indicator_history_count": after, "required_bars": self._context_required_bars},
+                    )
+            except Exception as exc:  # noqa: BLE001 - keep evaluation safely blocked with diagnostics
+                self._logger.warning(
+                    "CONTEXT_HISTORY_HYDRATION_FAILED symbol=%s source=%s error=%s",
+                    ctx_symbol,
+                    source,
+                    exc,
+                    extra={"event": "CONTEXT_HISTORY_HYDRATION_FAILED", "symbol": ctx_symbol, "source": source, "error": str(exc)},
+                )
+
+    def _prewarm_active_option_history(self, *, trace_id: str | None = None, source: str = "active_basket_commit") -> None:
+        """Proactively prewarm selected and active-basket option history."""
+        symbols: list[str] = []
+        for raw in (getattr(self, "_active_selected_ce", None), getattr(self, "_active_selected_pe", None)):
+            if raw:
+                symbols.append(normalize_symbol(str(raw)))
+        for raw in sorted(getattr(self, "_active_option_symbols", set()) or set()):
+            normalized = normalize_symbol(str(raw))
+            if normalized and normalized not in symbols:
+                symbols.append(normalized)
+        required = max(self._option_required_bars, safe_positive_int_env("OPTION_EXECUTION_MIN_BARS", 5, minimum=1))
+        for option_symbol in symbols:
+            before = self._sync_history_from_mdm_cache(
+                option_symbol,
+                required_bars=required,
+                source=f"{source}_option_cache_sync",
+                request_if_short=False,
+            )
+            if before < required:
+                self._request_selected_option_history_prewarm(
+                    option_symbol,
+                    bars_before=before,
+                    required_bars=required,
+                    trace_id=trace_id,
+                )
 
     def _should_log_throttled(self, key: str, interval_s: float = 30.0) -> bool:
         """Decide whether a throttled log should emit. Args: key/interval_s. Returns: bool. Raises: None."""
@@ -2280,6 +2428,7 @@ class StrategyRunner:
             len(self._active_option_symbols),
             extra={"event": "RUNNER_ACTIVE_OPTION_CONTEXT", "selected_ce": self._active_selected_ce, "selected_pe": self._active_selected_pe, "atm_strike": self._active_atm_strike, "option_count": len(self._active_option_symbols)},
         )
+        self._prewarm_active_option_history(source="active_option_context")
 
     def set_active_trading_universe(self, basket: Mapping[str, Any]) -> None:
         """Set active trading universe snapshot. Args: basket. Returns: none. Raises: none."""
@@ -2322,6 +2471,7 @@ class StrategyRunner:
             len(self._active_option_symbols),
             extra={"event": "RUNNER_ACTIVE_BASKET_UPDATED", "selected_ce": self._active_selected_ce, "selected_pe": self._active_selected_pe, "futures_symbol": self._active_futures_symbol, "option_count": len(self._active_option_symbols)},
         )
+        self._sync_context_history_if_cold(source="active_basket_context_sync")
 
     def set_runtime_readiness(
         self,
@@ -6729,10 +6879,40 @@ class StrategyRunner:
                     result = await result
                 success = result is not None
                 if isinstance(result, list):
-                    bars_after = len(result)
+                    fetched = len(result)
+                    if fetched:
+                        self.reseed_history_from_bars(
+                            symbol,
+                            result,
+                            source="selected_option_history_prewarm",
+                            min_bars=required_bars,
+                        )
+                    bars_after = self._history_count_for_symbol(symbol)
+                    self._emit_history_hydration_trace(
+                        symbol,
+                        source="selected_option_history_prewarm",
+                        fetched_bars=fetched,
+                        ingested_bars=bars_after,
+                    )
                 elif isinstance(result, Mapping):
-                    bars_after = int(result.get("bars_after") or result.get("count") or bars_before)
+                    rows = result.get("bars") or result.get("rows")
+                    if isinstance(rows, list) and rows:
+                        self.reseed_history_from_bars(
+                            symbol,
+                            rows,
+                            source="selected_option_history_prewarm",
+                            min_bars=required_bars,
+                        )
+                    bars_after = self._history_count_for_symbol(symbol)
+                    if bars_after <= bars_before:
+                        bars_after = int(result.get("bars_after") or result.get("count") or bars_before)
                     success = bool(result.get("success", success))
+                    self._emit_history_hydration_trace(
+                        symbol,
+                        source="selected_option_history_prewarm",
+                        fetched_bars=len(rows) if isinstance(rows, list) else int(result.get("count") or 0),
+                        ingested_bars=bars_after,
+                    )
                 else:
                     bars_after = self._history_count_for_symbol(symbol)
             except Exception as exc:
@@ -7414,6 +7594,12 @@ class StrategyRunner:
             if self._is_tradable_symbol(symbol):
                 option_execution_min_bars = safe_positive_int_env("OPTION_EXECUTION_MIN_BARS", 5, minimum=1)
                 required_bars = max(required_bars, option_execution_min_bars)
+                self._sync_context_history_if_cold(source="pre_option_eval_context_sync")
+                self._sync_history_from_mdm_cache(
+                    symbol,
+                    required_bars=required_bars,
+                    source="pre_option_eval_option_sync",
+                )
             history_count = len(self._indicator_engine.get_history(symbol) or [])
             restored_from_cache = symbol in self._restored_from_cache_symbols
             if restored_from_cache and history_count >= required_bars:
@@ -9371,7 +9557,32 @@ class StrategyRunner:
                         context_fresh = bool(indicators_ctx.get("context_fresh") or spot_fresh or fut_fresh)
                         live_mode = str(os.getenv("EXECUTION_MODE", "SHADOW") or "SHADOW").strip().upper() == "LIVE"
                         if live_mode and (resolved_bias not in {"CE", "PE"} or not context_fresh):
-                            log_throttled(
+                            refreshed_context = self._underlying_context_from_strategy_manager()
+                            if refreshed_context:
+                                runtime_ctx.update(refreshed_context)
+                                indicators_ctx.update(refreshed_context)
+                                direction_bias = str((indicators_ctx.get("direction_bias") or "")).upper()
+                                underlying_bias = str((indicators_ctx.get("underlying_direction_bias") or "")).upper()
+                                resolved_bias = underlying_bias or direction_bias
+                                resolved_confidence = float(
+                                    indicators_ctx.get("direction_confidence")
+                                    or indicators_ctx.get("underlying_direction_confidence")
+                                    or 0.0
+                                )
+                                spot_fresh = bool(indicators_ctx.get("spot_fresh"))
+                                fut_fresh = bool(indicators_ctx.get("futures_fresh") or indicators_ctx.get("fut_fresh"))
+                                context_fresh = bool(indicators_ctx.get("context_fresh") or spot_fresh or fut_fresh)
+                            if resolved_bias in {"CE", "PE"} and context_fresh:
+                                runtime_indicators[symbol] = {
+                                    **(runtime_indicators.get(symbol, {}) or {}),
+                                    "direction_bias": indicators_ctx.get("direction_bias"),
+                                    "underlying_direction_bias": indicators_ctx.get("underlying_direction_bias"),
+                                    "context_age_seconds": indicators_ctx.get("context_age_seconds"),
+                                    "underlying_direction_confidence": indicators_ctx.get("underlying_direction_confidence"),
+                                }
+                                self._last_direction_context = runtime_indicators[symbol]
+                            else:
+                                log_throttled(
                                 self._logger,
                                 f"direction_context_missing_live:{symbol}",
                                 "TRIGGER_EVAL_SKIPPED symbol=%s reason=direction_context_missing_live spot_fresh=%s fut_fresh=%s",
@@ -9381,9 +9592,9 @@ class StrategyRunner:
                                 interval_sec=30.0,
                                 level=logging.WARNING,
                                 extra={"event": "trigger_eval_skipped", "reason": "direction_context_missing_live", "symbol": symbol, "spot_fresh": spot_fresh, "fut_fresh": fut_fresh},
-                            )
-                            self._emit_runner_eval_decision(symbol=symbol, stage="phase9", reason="direction_context_missing_live", allowed=False, trace_id=trace_id)
-                            return
+                                )
+                                self._emit_runner_eval_decision(symbol=symbol, stage="phase9", reason="direction_context_missing_live", allowed=False, trace_id=trace_id)
+                                return
                         if getattr(self, "_orchestrator", None) is not None and hasattr(self._orchestrator, "reconcile_direction_bias"):
                             self._orchestrator.reconcile_direction_bias(
                                 resolved_bias=resolved_bias or None,

--- a/tests/strategies/test_runner_mdm_hydration_paths.py
+++ b/tests/strategies/test_runner_mdm_hydration_paths.py
@@ -181,3 +181,77 @@ def test_runner_emergency_backfill_disabled_by_default(monkeypatch) -> None:
         assert r._backfill_task_started is False
     finally:
         r._main_loop.close()
+
+from datetime import timedelta
+
+from nifty_scalper_bot.strategies.indicators import IndicatorEngine
+
+
+def _bars(count: int, *, start_close: float = 100.0) -> list[dict]:
+    base = datetime(2026, 1, 1, 9, 15, tzinfo=timezone.utc)
+    return [
+        {
+            "timestamp": base + timedelta(minutes=i),
+            "open": start_close + i,
+            "high": start_close + i + 1,
+            "low": start_close + i - 1,
+            "close": start_close + i + 0.5,
+            "volume": 100 + i,
+        }
+        for i in range(count)
+    ]
+
+
+def test_datahub_context_bars_sync_into_indicator_engine() -> None:
+    r = _runner()
+    r._indicator_engine = IndicatorEngine()
+    r._market_data = None
+    r._data_hub = SimpleNamespace(
+        get_ohlc_bars=lambda symbol, limit=None: _bars(50, start_close=200.0 if symbol == "NFO:NIFTY26JUNFUT" else 100.0)[-(limit or 50):]
+    )
+    r._symbol_history = {}
+    r._context_required_bars = 50
+    r._option_required_bars = 5
+    r._active_symbols = {"NSE:NIFTY", "NFO:NIFTY26JUNFUT"}
+    r._active_futures_symbol = "NFO:NIFTY26JUNFUT"
+    r._tracked_symbols = set()
+    r._data_phase = {}
+    r._last_bar_ts = {}
+    r._symbol_states = {}
+    r._hydration_attempted_symbols = set()
+    r._last_hydration_reason_by_symbol = {}
+    r._set_symbol_hydration_state = lambda _s, st: st
+    r._seed_pipeline_store = lambda _s: None
+    r._seed_candle_engine_from_history = lambda _s: None
+
+    r._sync_context_history_if_cold(source="test_context_sync")
+
+    assert len(r._indicator_engine.get_history("NSE:NIFTY")) >= 50
+    assert len(r._indicator_engine.get_history("NFO:NIFTY26JUNFUT")) >= 50
+
+
+def test_selected_option_prewarm_reseeds_indicator_from_datahub_result(monkeypatch) -> None:
+    r = _runner()
+    r._indicator_engine = IndicatorEngine()
+    r._symbol_history = {}
+    r._tracked_symbols = set()
+    r._data_phase = {}
+    r._last_bar_ts = {}
+    r._symbol_states = {}
+    r._set_symbol_hydration_state = lambda _s, st: st
+    r._seed_pipeline_store = lambda _s: None
+    r._seed_candle_engine_from_history = lambda _s: None
+    r._selected_option_prewarm_last = {}
+    r._selected_option_prewarm_inflight = set()
+    r._selected_option_prewarm_cooldown_s = 0.0
+    symbol = "NFO:NIFTY26JUN24000CE"
+
+    async def hydrate(_symbol: str, **_kwargs):
+        return _bars(5, start_close=50.0)
+
+    r._data_hub = SimpleNamespace(hydrate_symbol_history=hydrate)
+    monkeypatch.setattr("threading.Thread", lambda target, **_kwargs: SimpleNamespace(start=target))
+
+    r._request_selected_option_history_prewarm(symbol, bars_before=0, required_bars=5)
+
+    assert len(r._indicator_engine.get_history(symbol)) >= 5


### PR DESCRIPTION
### Motivation
- Live evaluation saw `OPTION_HISTORY_COLD` and `OPTION_EVAL_BLOCKED_CONTEXT_COLD` because MDM/DataHub had OHLC cached while the runner `IndicatorEngine` remained cold and strategy gates queried the runner-only history.
- Selected-option prewarm fetched bars into MDM/DataHub but did not reseed the runner `IndicatorEngine`, causing evaluation and readiness races and a direction-context miss before re-reading StrategyManager snapshots.
- The change aims to keep the runner's indicator history and MDM/DataHub caches consistent so readiness and option evaluation see the same OHLC history without weakening gates or lowering required bars.

### Description
- Ensure cached MDM/DataHub history is synced into the runner `IndicatorEngine` with concise diagnostics via `HISTORY_HYDRATION_TRACE` and `CONTEXT_HISTORY_HYDRATION_FAILED` logs by adding `_sync_history_from_mdm_cache`, `_sync_context_history_if_cold`, and `_emit_history_hydration_trace` in `StrategyRunner` and calling them where appropriate (`_prewarm_active_option_history`, active-basket updates, and pre-option evaluation). (`src/nifty_scalper_bot/strategies/runner.py`)
- Make selected-option prewarm results reseed the `IndicatorEngine` instead of leaving bars only in MDM/DataHub, and emit `SELECTED_OPTION_RUNNER_SYNC_FROM_MDM` diagnostic when reseed occurs. (`src/nifty_scalper_bot/strategies/runner.py`)
- On app-level readiness recomputation, proactively hydrate/reseed spot and active futures history into the same `IndicatorEngine` used by the runner, avoid unnecessary broker hydration when MDM already has sufficient bars, and surface explicit active-basket hydration diagnostics. (`src/nifty_scalper_bot/core/app.py`)
- Preserve requested SSOT futures symbols during basket commit by preferring a canonical SSOT future if provided before falling back to rotation logic. (`src/nifty_scalper_bot/core/app.py`)
- Improve pre-skip behavior for direction-context misses by re-reading `StrategyManager` snapshots immediately before emitting `direction_context_missing_live` so transient snapshot races don't cause premature skips. (`src/nifty_scalper_bot/strategies/runner.py`)
- Added focused regression tests to validate DataHub context bars sync and selected-option prewarm reseeding into `IndicatorEngine`. (`tests/strategies/test_runner_mdm_hydration_paths.py`)

### Testing
- Commands run: `python -m compileall -q src` and targeted pytest runs: `pytest -q tests/strategies/test_runner_mdm_hydration_paths.py`, `pytest -q tests/strategies/test_runner_execution_gates.py`, `pytest -q tests/core/test_basket_commit_before_readiness.py`, `pytest -q tests/core/test_strategy_manager_context_to_option_propagation.py`, `pytest -q tests/test_subscription_reconciliation.py`, `pytest -q tests/core/test_deferred_basket_retry.py`.
- Results: focused test groups listed above passed after the changes; compile succeeded.
- Full test run: the full test-suite run previously surfaced an unrelated polling-supervisor test that expected a module-level attribute (`app._polling_failover_supervisor_iteration`) to be present; this failure is orthogonal to the hydration/readiness fixes and is documented in the validation section of the commit message.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e748e5fb48324a191dc4458911272)