### PR TITLE
Fix basket token registration and warmup history token fallback

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -7729,6 +7729,8 @@ def _commit_active_dynamic_basket(
     requested_futures_symbol = basket.get("futures_symbol") or basket.get("future_symbol")
     requested_selected_ce = str(basket.get("selected_ce") or basket.get("atm_ce") or "") or None
     requested_selected_pe = str(basket.get("selected_pe") or basket.get("atm_pe") or "") or None
+    if not hasattr(ctx, "active_symbol_tokens") or getattr(ctx, "active_symbol_tokens", None) is None:
+        ctx.active_symbol_tokens = {}
     active_futures_symbol = canonical_nifty_future_symbol(requested_futures_symbol) or _resolve_active_futures_for_basket(ctx, requested_futures_symbol)
     basket_copy = dict(basket or {})
     basket_copy["futures_symbol"] = active_futures_symbol
@@ -7914,6 +7916,25 @@ def _commit_active_dynamic_basket(
         )
     ctx.active_symbol_tokens = token_map
     committed["token_by_symbol"] = token_map
+    if mdm is not None and token_map:
+        register_symbol = getattr(mdm, "register_symbol", None)
+        if callable(register_symbol):
+            for sym, tok in token_map.items():
+                try:
+                    register_symbol(str(sym), int(tok))
+                except (TypeError, ValueError) as exc:
+                    LOGGER.warning(
+                        "ACTIVE_BASKET_TOKEN_REGISTER_SKIPPED symbol=%s token=%s reason=%s",
+                        sym,
+                        tok,
+                        type(exc).__name__,
+                        extra={
+                            "event": "ACTIVE_BASKET_TOKEN_REGISTER_SKIPPED",
+                            "symbol": str(sym),
+                            "token": tok,
+                            "reason": type(exc).__name__,
+                        },
+                    )
     LOGGER.info(
         "ACTIVE_CONTRACT_BASKET_COMMITTED selected_ce=%s selected_pe=%s futures_symbol=%s atm_strike=%s symbol_count=%d",
         selected_ce,
@@ -7955,6 +7976,7 @@ def _commit_active_dynamic_basket(
     # universe and call reconcile_active_subscriptions() which does a clean
     # set-difference: subscribe new tokens, unsubscribe stale ones.
     # This replaces the old futures-specific purge path.
+    basket_tokens: set[int] = set()
     reconcile_fn = getattr(mdm, "reconcile_active_subscriptions", None)
     if callable(reconcile_fn):
         _im = getattr(ctx, "instrument_manager", None)
@@ -7965,6 +7987,13 @@ def _commit_active_dynamic_basket(
                     basket_tokens.add(tok)
             except Exception:
                 pass
+        for tok in token_map.values():
+            try:
+                token_int = int(tok)
+            except (TypeError, ValueError):
+                continue
+            if token_int > 0:
+                basket_tokens.add(token_int)
         # Always include raw tokens stored directly in basket
         for key in ("spot_token", "futures_token"):
             raw_tok = committed.get(key)

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -6059,6 +6059,44 @@ class MarketDataManager:
                 canonical_symbol = normalize_symbol(str(symbol))
                 token = self._token_by_symbol.get(canonical_symbol)
                 if not token:
+                    self._logger.info(
+                        "WARMUP_TOKEN_CACHE_MISS symbol=%s reason=attempting_resolver_broker_fallback",
+                        canonical_symbol,
+                        extra={
+                            "event": "warmup_token_cache_miss",
+                            "symbol": canonical_symbol,
+                            "reason": "attempting_resolver_broker_fallback",
+                        },
+                    )
+                    resolver = getattr(self, "_resolver", None)
+                    if resolver is not None:
+                        try:
+                            if hasattr(resolver, "resolve"):
+                                resolved = resolver.resolve(canonical_symbol)
+                                if resolved:
+                                    token = int(resolved)
+                            if not token and hasattr(resolver, "get_token"):
+                                resolved = resolver.get_token(canonical_symbol)
+                                if resolved:
+                                    token = int(resolved)
+                        except Exception:
+                            self._logger.exception("Unhandled exception", exc_info=True)
+                            raise
+                    if (
+                        not token
+                        and self._broker
+                        and hasattr(self._broker, "get_instrument_token")
+                    ):
+                        try:
+                            resolved = self._broker.get_instrument_token(canonical_symbol)
+                            if resolved:
+                                token = int(resolved)
+                        except Exception:
+                            self._logger.exception("Unhandled exception", exc_info=True)
+                            raise
+                    if token:
+                        self.register_symbol(canonical_symbol, int(token))
+                if not token:
                     # BUG-β FIX: Never raise — skip and warn so remaining
                     # symbols are still warmed and callers don't abort.
                     self._logger.warning(

--- a/tests/core/test_commit_active_dynamic_basket.py
+++ b/tests/core/test_commit_active_dynamic_basket.py
@@ -1,3 +1,4 @@
+import asyncio
 from types import SimpleNamespace
 
 from nifty_scalper_bot.core import app
@@ -141,6 +142,99 @@ def test_app_active_basket_uses_requested_future_not_mdm_fallback() -> None:
     assert "NFO:NIFTY26MAYFUT" in committed["symbols"]
     assert mdm.purged == [("NFO:NIFTY26MAYFUT", "active_dynamic_basket_commit")]
     assert mdm.rotated[0] == "NFO:NIFTY26MAYFUT"
+
+
+def test_commit_active_dynamic_basket_reconciles_without_name_error() -> None:
+    class _Mdm:
+        def __init__(self) -> None:
+            self.reconciled: set[int] | None = None
+
+        def register_symbol(self, symbol: str, token: int) -> None:
+            return None
+
+        def set_active_contract_basket(self, basket):
+            return None
+
+        def reconcile_active_subscriptions(self, tokens):
+            self.reconciled = set(tokens)
+
+    mdm = _Mdm()
+    ctx = SimpleNamespace(
+        selected_ce=None,
+        selected_pe=None,
+        atm_ce_symbol=None,
+        atm_pe_symbol=None,
+        active_trading_universe={},
+        strategy_runner=None,
+        market_data_manager=mdm,
+        strategy_manager=None,
+        basket_build_lock=asyncio.Lock(),
+    )
+    ce = "NFO:NIFTY26JUN23900CE"
+    pe = "NFO:NIFTY26JUN23900PE"
+
+    app._commit_active_dynamic_basket(
+        ctx,
+        basket={
+            "spot_symbol": "NSE:NIFTY",
+            "spot_token": 256265,
+            "futures_symbol": "NFO:NIFTY26JUNFUT",
+            "futures_token": 222,
+            "token_by_symbol": {"NSE:NIFTY": 256265, "NFO:NIFTY26JUNFUT": 222, ce: 11, pe: 12},
+        },
+        option_symbols=[ce, pe],
+        symbols=["NSE:NIFTY", "NFO:NIFTY26JUNFUT", ce, pe],
+        atm_strike=23900,
+    )
+
+    assert mdm.reconciled == {256265, 222, 11, 12}
+
+
+def test_commit_active_dynamic_basket_exposes_active_symbol_tokens_and_registers_futures() -> None:
+    class _Mdm:
+        def __init__(self) -> None:
+            self.registered: dict[str, int] = {}
+
+        def register_symbol(self, symbol: str, token: int) -> None:
+            self.registered[symbol] = int(token)
+
+        def set_active_contract_basket(self, basket):
+            return None
+
+    mdm = _Mdm()
+    ctx = SimpleNamespace(
+        selected_ce=None,
+        selected_pe=None,
+        atm_ce_symbol=None,
+        atm_pe_symbol=None,
+        active_trading_universe={},
+        strategy_runner=None,
+        market_data_manager=mdm,
+        strategy_manager=None,
+        basket_build_lock=asyncio.Lock(),
+    )
+    ce = "NFO:NIFTY26JUN23900CE"
+    pe = "NFO:NIFTY26JUN23900PE"
+
+    app._commit_active_dynamic_basket(
+        ctx,
+        basket={
+            "spot_symbol": "NSE:NIFTY",
+            "spot_token": 256265,
+            "futures_symbol": "NFO:NIFTY26JUNFUT",
+            "futures_token": 222,
+            "token_by_symbol": {"NSE:NIFTY": 256265, "NFO:NIFTY26JUNFUT": 222, ce: 11, pe: 12},
+        },
+        option_symbols=[ce, pe],
+        symbols=["NSE:NIFTY", "NFO:NIFTY26JUNFUT", ce, pe],
+        atm_strike=23900,
+    )
+
+    assert ctx.active_symbol_tokens["NFO:NIFTY26JUNFUT"] == 222
+    assert mdm.registered["NSE:NIFTY"] == 256265
+    assert mdm.registered["NFO:NIFTY26JUNFUT"] == 222
+    assert mdm.registered[ce] == 11
+    assert mdm.registered[pe] == 12
 
 
 def test_resolve_active_futures_for_basket_no_calendar_fallback(monkeypatch) -> None:

--- a/tests/data/test_market_data_manager.py
+++ b/tests/data/test_market_data_manager.py
@@ -1197,6 +1197,53 @@ async def test_warmup_history_primes_cache_without_emitting_callbacks(
     assert bars
 
 
+@pytest.mark.asyncio
+async def test_warmup_history_resolves_missing_token_with_resolver_broker_fallback(
+    ws: DummyWebSocket,
+) -> None:
+    class ResolverMiss:
+        def __init__(self) -> None:
+            self.calls: list[str] = []
+
+        def resolve(self, symbol: str):
+            self.calls.append(symbol)
+            return None
+
+    class BrokerFallback:
+        def __init__(self) -> None:
+            self.token_calls: list[str] = []
+            self.history_tokens: list[int] = []
+
+        def get_instrument_token(self, symbol: str) -> int:
+            self.token_calls.append(symbol)
+            return 222
+
+        async def get_historical_data(self, **kwargs: Any) -> list[dict[str, Any]]:
+            self.history_tokens.append(int(kwargs["instrument_token"]))
+            return [
+                {
+                    "date": datetime(2024, 1, 1, 10, 0, tzinfo=timezone.utc),
+                    "open": 100.0,
+                    "high": 101.0,
+                    "low": 99.0,
+                    "close": 100.5,
+                    "volume": 10,
+                }
+            ]
+
+    resolver = ResolverMiss()
+    broker = BrokerFallback()
+    manager = MarketDataManager(broker, ws, resolver=resolver)
+
+    await manager.warmup_history(["NFO:NIFTY26JUNFUT"], lookback_minutes=30)
+
+    assert resolver.calls == ["NFO:NIFTY26JUNFUT"]
+    assert broker.token_calls == ["NFO:NIFTY26JUNFUT"]
+    assert broker.history_tokens == [222]
+    assert manager._token_by_symbol["NFO:NIFTY26JUNFUT"] == 222  # noqa: SLF001
+    assert manager.get_ohlc_bars("NFO:NIFTY26JUNFUT")
+
+
 def test_out_of_order_tick_is_discarded(
     monkeypatch: pytest.MonkeyPatch, broker: DummyBroker, ws: DummyWebSocket
 ) -> None:


### PR DESCRIPTION
### Motivation
- A `NameError` and downstream AttributeError occurred because `basket_tokens` was used before initialization and `ctx.active_symbol_tokens` was only set after basket commit, preventing deferred hydration from seeing futures tokens. 
- `MarketDataManager.warmup_history` skipped symbols on `_token_by_symbol` cache misses instead of attempting the same resolver/broker fallbacks used by `fetch_history`, causing missing-history test failures.

### Description
- Ensure `ctx.active_symbol_tokens` exists at the start of `_commit_active_dynamic_basket` by initializing it when absent. 
- Immediately register all committed `token_by_symbol` entries into the `MarketDataManager` after writing `ctx.active_symbol_tokens` so spot, futures, and option tokens are available to hydration paths. 
- Initialize `basket_tokens: set[int]` before the reconcile block and include `token_map` values in the reconciliation set so `reconcile_active_subscriptions()` receives a complete token set and no `NameError` occurs. 
- Extend `MarketDataManager.warmup_history` to run resolver then broker `get_instrument_token` fallback when `_token_by_symbol` misses, register resolved tokens, and only then fetch historical candles. 
- Add focused tests and minor test-context updates: `tests/core/test_commit_active_dynamic_basket.py` gains reconciliation/registration checks and ensures test ctx includes required `basket_build_lock`, and `tests/data/test_market_data_manager.py` gains a warmup fallback regression test.

### Testing
- Ran `python -m compileall -q src` and `pytest -q` and the full test suite passed. 
- Ran focused validations `pytest -q tests/core/test_commit_active_dynamic_basket.py::test_commit_active_dynamic_basket_reconciles_without_name_error` and `pytest -q tests/data/test_market_data_manager.py::test_warmup_history_resolves_missing_token_with_resolver_broker_fallback` which both passed. 
- Ran the relevant basket/history regression subset with `pytest -q tests/core/test_commit_active_dynamic_basket.py tests/core/test_basket_commit_before_readiness.py tests/data/test_market_data_manager.py tests/data/test_mdm_subscribes_active_basket.py` which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ec63525a88324a244b5d89e4ac2f0)