### PR TITLE
Repair NIFTY market data hydration path

### DIFF
--- a/src/nifty_scalper_bot/bot/__init__.py
+++ b/src/nifty_scalper_bot/bot/__init__.py
@@ -12,7 +12,7 @@ from nifty_scalper_bot.bot.components import (
     StrategyRunner,
     StrategyRunnerConfig,
     TradeSignal,
-    ZerodhaKiteClient,
+    LegacyDummyZerodhaKiteClient,
     ZerodhaKiteWebSocket,
 )
 
@@ -28,6 +28,6 @@ __all__ = [
     "StrategyRunner",
     "StrategyRunnerConfig",
     "TradeSignal",
-    "ZerodhaKiteClient",
+    "LegacyDummyZerodhaKiteClient",
     "ZerodhaKiteWebSocket",
 ]

--- a/src/nifty_scalper_bot/bot/components.py
+++ b/src/nifty_scalper_bot/bot/components.py
@@ -1,4 +1,8 @@
-"""Core runtime components for the trading bot."""
+"""Legacy/testing-only bot components.
+
+Production startup uses core.app and data.rest.zerodha_client for the real broker;
+classes in this module are lightweight test/demo placeholders only.
+"""
 
 from __future__ import annotations
 
@@ -30,8 +34,8 @@ class TradeSignal:
     metadata: dict[str, Any] = field(default_factory=dict)
 
 
-class ZerodhaKiteClient(DummyBrokerClient):
-    """Lightweight Zerodha client placeholder backed by the dummy broker."""
+class LegacyDummyZerodhaKiteClient(DummyBrokerClient):
+    """Legacy/testing-only Zerodha placeholder backed by the dummy broker."""
 
     def __init__(
         self,
@@ -138,7 +142,7 @@ class MarketDataManager:
 
     def __init__(
         self,
-        broker_client: ZerodhaKiteClient,
+        broker_client: LegacyDummyZerodhaKiteClient,
         websocket_client: ZerodhaKiteWebSocket,
     ) -> None:
         self._broker = broker_client
@@ -361,7 +365,7 @@ class OrderManager:
     def __init__(
         self,
         *,
-        broker_client: ZerodhaKiteClient,
+        broker_client: LegacyDummyZerodhaKiteClient,
         position_manager: PositionManager,
         rate_limiter: Any,
     ) -> None:
@@ -1038,6 +1042,6 @@ __all__ = [
     "StrategyRunner",
     "StrategyRunnerConfig",
     "TradeSignal",
-    "ZerodhaKiteClient",
+    "LegacyDummyZerodhaKiteClient",
     "ZerodhaKiteWebSocket",
 ]

--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -7561,8 +7561,19 @@ async def _recompute_and_push_runtime_readiness(ctx: BotContext, *, reason: str)
         dt=pd.to_datetime(ts,utc=True,errors='coerce')
         if pd.isna(dt): return False
         return (pd.Timestamp.utcnow()-dt).total_seconds()<=age_limit
+    def _snapshot_value(snap: Any, key: str, default: Any = None) -> Any:
+        if isinstance(snap, Mapping):
+            return snap.get(key, default)
+        return getattr(snap, key, default)
+    def _selected_option_bid_ask_complete(sym:str|None)->bool:
+        snap=_snapshot(sym)
+        if snap is None: return False
+        bid=float(_snapshot_value(snap,'bid',0.0) or 0.0)
+        ask=float(_snapshot_value(snap,'ask',0.0) or 0.0)
+        return bid>0 and ask>bid
     def _tradable_quote(sym:str|None)->bool:
         if not sym or mdm is None: return False
+        if not _selected_option_bid_ask_complete(sym): return False
         h=getattr(mdm,'has_ws_tradable_quote',None)
         if callable(h):
             try: return bool(h([sym]))
@@ -7572,8 +7583,7 @@ async def _recompute_and_push_runtime_readiness(ctx: BotContext, *, reason: str)
                 pass
         snap=_snapshot(sym)
         if snap is None: return False
-        bid=float(getattr(snap,'bid',0.0) or 0.0); ask=float(getattr(snap,'ask',0.0) or 0.0)
-        return bool(getattr(snap,'tradable_quote',False)) and bid>0 and ask>bid
+        return bool(_snapshot_value(snap,'tradable_quote',False))
     def _live_tick_seen(sym:str|None)->bool:
         if _fresh_ltp(sym): return True
         if not sym or mdm is None: return False
@@ -7654,8 +7664,10 @@ async def _recompute_and_push_runtime_readiness(ctx: BotContext, *, reason: str)
     ce_bars, ce_mdm_bars, ce_runner_bars = _readiness_bars(selected_ce)
     pe_bars, pe_mdm_bars, pe_runner_bars = _readiness_bars(selected_pe)
     ce_quote_fresh=_fresh_ltp(selected_ce); pe_quote_fresh=_fresh_ltp(selected_pe)
-    ce_exec_ready = bool(selected_ce) and ce_quote_fresh and _tradable_quote(selected_ce) and ce_bars >= option_execution_min_bars
-    pe_exec_ready = bool(selected_pe) and pe_quote_fresh and _tradable_quote(selected_pe) and pe_bars >= option_execution_min_bars
+    ce_bid_ask_complete = _selected_option_bid_ask_complete(selected_ce)
+    pe_bid_ask_complete = _selected_option_bid_ask_complete(selected_pe)
+    ce_exec_ready = bool(selected_ce) and ce_quote_fresh and ce_bid_ask_complete and _tradable_quote(selected_ce) and ce_bars >= option_execution_min_bars
+    pe_exec_ready = bool(selected_pe) and pe_quote_fresh and pe_bid_ask_complete and _tradable_quote(selected_pe) and pe_bars >= option_execution_min_bars
     ce_eval_ready = bool(selected_ce) and ce_quote_fresh and ce_bars >= option_eval_min_live_bars
     pe_eval_ready = bool(selected_pe) and pe_quote_fresh and pe_bars >= option_eval_min_live_bars
     spot_ready=_fresh_ltp(spot_symbol) or _bars(spot_symbol)>=1
@@ -7685,6 +7697,7 @@ async def _recompute_and_push_runtime_readiness(ctx: BotContext, *, reason: str)
     if pe_runner_bars < option_execution_min_bars: missing.append('pe_exec_bars_missing')
     if not ce_quote_fresh: missing.append('ce_quote_not_fresh')
     if not pe_quote_fresh: missing.append('pe_quote_not_fresh')
+    if (selected_ce and not ce_bid_ask_complete) or (selected_pe and not pe_bid_ask_complete): missing.append('selected_option_bid_ask_missing')
     if not _tradable_quote(selected_ce): missing.append('ce_depth_not_tradable')
     if not _tradable_quote(selected_pe): missing.append('pe_depth_not_tradable')
     if not runner_running: missing.append('runner_not_running')

--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -7614,7 +7614,7 @@ async def _recompute_and_push_runtime_readiness(ctx: BotContext, *, reason: str)
             except Exception: runner_bars=0
         return min(mdm_bars, runner_bars), mdm_bars, runner_bars
     spot_symbol=str(basket.get('spot_symbol') or 'NSE:NIFTY')
-    option_eval_min_live_bars = int(os.getenv("READINESS_OPTION_EVAL_MIN_BARS", os.getenv("OPTION_EVAL_MIN_LIVE_BARS", "20")) or 20)
+    option_eval_min_live_bars = int(os.getenv("READINESS_OPTION_EVAL_MIN_BARS", os.getenv("OPTION_EVAL_MIN_LIVE_BARS", "5")) or 5)
     option_execution_min_bars = int(os.getenv("READINESS_OPTION_EXEC_MIN_BARS", os.getenv("OPTION_EXECUTION_MIN_BARS", "30")) or 30)
     configured_context_min_bars = int(os.getenv("READINESS_CONTEXT_MIN_BARS", os.getenv("CONTEXT_EXECUTION_MIN_BARS", "20")) or 20)
     runner_context_required_bars = int(getattr(getattr(ctx, "strategy_runner", None), "_context_required_bars", 0) or 0)

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -528,6 +528,7 @@ class MarketDataManager:
         # for the callback slot here — process_ticks is the single
         # ingress for WS ticks.
         self._m_ticks = Counter("mdm_ticks_total", "Normalized ticks processed")
+        self._m_subs = Counter("mdm_subscriptions_total", "Market data subscriptions registered")
         self._last_balance_log_time = 0.0
         self._started = False
         if self._ws is not None and hasattr(self._ws, "on_tick"):
@@ -894,11 +895,27 @@ class MarketDataManager:
             if not option_contracts and hasattr(self._broker, "instruments"):
                 self._logger.info(f"Resolver failed. Fetching NIFTY chain directly from broker for {expiry}")
                 all_nfo = self._broker.instruments("NFO")
+                target_expiry = _select_expiry(expiry, sorted({
+                    parsed
+                    for ins in all_nfo
+                    if isinstance(ins, Mapping)
+                    and str(ins.get("name") or normalized_underlying).upper() == normalized_underlying
+                    and str(ins.get("instrument_type") or ins.get("option_type") or ins.get("type") or "").upper() in {"CE", "PE"}
+                    for parsed in [_parse_instrument_expiry(ins.get("expiry"))]
+                    if parsed is not None
+                }), datetime.now(timezone.utc))
                 option_contracts = [
-                    ins for ins in all_nfo 
-                    if ins["name"] == normalized_underlying 
-                    and ins["instrument_type"] in ("CE", "PE")
-                    and str(ins["expiry"]) == expiry
+                    ins for ins in all_nfo
+                    if isinstance(ins, Mapping)
+                    and str(ins.get("name") or normalized_underlying).upper() == normalized_underlying
+                    and str(ins.get("instrument_type") or ins.get("option_type") or ins.get("type") or "").upper() in {"CE", "PE"}
+                    and (
+                        target_expiry is None
+                        or (
+                            (parsed_expiry := _parse_instrument_expiry(ins.get("expiry"))) is not None
+                            and parsed_expiry.date() == target_expiry.date()
+                        )
+                    )
                 ]
         except Exception as exc:
             self._logger.error(f"Option chain recovery failed: {exc}")
@@ -918,7 +935,9 @@ class MarketDataManager:
                 token = int(instrument_token)  # type: ignore[arg-type]
             except (TypeError, ValueError):
                 continue
-            option_type = str(contract.get("option_type") or "").upper()
+            option_type = str(
+                contract.get("option_type") or contract.get("instrument_type") or contract.get("type") or ""
+            ).upper()
             if option_type not in {"CE", "PE"}:
                 continue
             tradingsymbol = str(
@@ -1762,7 +1781,7 @@ class MarketDataManager:
         symbols = list(self._basket_value(basket, "all_symbols", None) or self._basket_value(basket, "symbols", None) or [])
         if not symbols:
             symbols = [self._basket_value(basket, "spot_symbol", "NSE:NIFTY"), *list(self._basket_value(basket, "option_symbols", []) or [])]
-        min_bars = int(os.getenv("HYDRATION_SELECTED_OPTION_MIN_BARS", "0") or 0) or int(getattr(self, "_min_required_bars", 20) or 20)
+        min_bars = int(os.getenv("HYDRATION_SELECTED_OPTION_MIN_BARS", "0") or 0) or int(getattr(self, "_selected_option_min_bars", 5) or 5)
         report: dict[str, Any] = {"hard_ready": True, "missing": [], "symbols": {}, "hydration_min_bars_required": min_bars, "retry_scheduled": False}
         for raw_sym in symbols:
             sym = str(raw_sym or "")
@@ -1775,7 +1794,7 @@ class MarketDataManager:
             if is_future and raw_sym != self._basket_value(basket, "futures_symbol", None):
                 self._logger.warning("MDM_BASKET_ROLE_INCONSISTENCY symbol=%s role=%s", canonical, role, extra={"event": "MDM_BASKET_ROLE_INCONSISTENCY", "symbol": canonical, "role": role})
             token = token_map.get(sym) or token_map.get(sym.upper()) or token_map.get(canonical) or token_map.get(canonical.split(":", 1)[-1] if ":" in canonical else canonical)
-            entry = {"role": role, "token": token, "quote_ready": False, "ohlc_ready": True, "bars_count": 0, "oi_ready": False}
+            entry = {"role": role, "token": token, "quote_ready": False, "ohlc_ready": True, "bars_count": 0, "oi_ready": False, "ohlc_provisional": False}
             if is_option and token is None:
                 report["missing"].append(f"{sym}:token_missing")
                 report["hard_ready"] = False
@@ -1809,6 +1828,8 @@ class MarketDataManager:
                     entry["ohlc_ready"] = False
                     report["missing"].append(f"{sym}:ohlc_insufficient")
                     report["hard_ready"] = False
+                elif 0 < entry["bars_count"] < int(getattr(self, "_min_required_bars", 20) or 20):
+                    entry["ohlc_provisional"] = True
             report["symbols"][sym] = entry
         return report
 

--- a/src/nifty_scalper_bot/data/source.py
+++ b/src/nifty_scalper_bot/data/source.py
@@ -128,26 +128,89 @@ class MarketDataSource:
         self._state = market_state
 
     def get_ltp_poll(self, tokens: Sequence[int]) -> dict[int, float]:
-        """Fetch LTP by polling API. Args: tokens. Returns: token->price. Raises: none."""
+        """Fetch LTP by polling API. Args: tokens. Returns: token->price. Raises: DataIntegrityError."""
 
-        if not tokens:
+        normalized_tokens = [int(token) for token in tokens]
+        if not normalized_tokens:
             return {}
-        query = [f'NFO:{int(token)}' for token in tokens]
         try:
-            payload = self._kite.ltp(query)
+            if hasattr(self._kite, "get_ltp_bulk"):
+                payload = self._kite.get_ltp_bulk(normalized_tokens)
+                return self._extract_token_ltps(payload, normalized_tokens)
+            if hasattr(self._kite, "get_quote_bulk"):
+                payload = self._kite.get_quote_bulk(normalized_tokens)
+                return self._extract_token_ltps(payload, normalized_tokens)
+            if hasattr(self._kite, "quote_any"):
+                payload = self._kite.quote_any(normalized_tokens)
+                return self._extract_token_ltps(payload, normalized_tokens)
+
+            token_to_symbol = self._token_symbol_lookup(normalized_tokens)
+            if token_to_symbol and hasattr(self._kite, "ltp"):
+                query = [token_to_symbol[token] for token in normalized_tokens if token in token_to_symbol]
+                if not query:
+                    return {}
+                payload = self._kite.ltp(query)
+                return self._extract_token_ltps(payload, normalized_tokens, token_to_symbol=token_to_symbol)
         except Exception as e:
-            raise DataIntegrityError(f'Polling LTP failed: {e}') from e
+            raise DataIntegrityError(f"Polling LTP failed: {e}") from e
+        return {}
+
+    def _extract_token_ltps(
+        self,
+        payload: Any,
+        tokens: Sequence[int],
+        *,
+        token_to_symbol: Mapping[int, str] | None = None,
+    ) -> dict[int, float]:
+        """Extract token-keyed LTPs from broker bulk payloads."""
+
+        if not isinstance(payload, Mapping):
+            return {}
         parsed: dict[int, float] = {}
-        for token in tokens:
-            key = f'NFO:{int(token)}'
-            entry = payload.get(key) if isinstance(payload, Mapping) else None
-            if not isinstance(entry, Mapping):
+        symbol_to_token = {str(symbol): int(token) for token, symbol in (token_to_symbol or {}).items()}
+        wanted = {int(token) for token in tokens}
+        for raw_key, raw_entry in payload.items():
+            token: int | None = None
+            if isinstance(raw_key, int) or (isinstance(raw_key, str) and raw_key.isdigit()):
+                token = int(raw_key)
+            elif str(raw_key) in symbol_to_token:
+                token = symbol_to_token[str(raw_key)]
+            if isinstance(raw_entry, (int, float)):
+                if token is not None and token in wanted and float(raw_entry) > 0:
+                    parsed[int(token)] = float(raw_entry)
                 continue
-            ltp = entry.get('last_price')
+            entry = raw_entry if isinstance(raw_entry, Mapping) else {}
+            if token is None:
+                entry_token = entry.get("instrument_token") or entry.get("token")
+                try:
+                    token = int(entry_token) if entry_token is not None else None
+                except (TypeError, ValueError):
+                    token = None
+            if token is None or token not in wanted:
+                continue
+            ltp = entry.get("last_price") or entry.get("ltp")
             if ltp is None:
                 continue
             parsed[int(token)] = float(ltp)
         return parsed
+
+    def _token_symbol_lookup(self, tokens: Sequence[int]) -> dict[int, str]:
+        """Return broker tradingsymbol lookup for raw kite.ltp fallback only."""
+
+        wanted = {int(token) for token in tokens}
+        lookup: dict[int, str] = {}
+        for attr in ("token_to_symbol", "symbol_by_token", "_token_to_symbol", "_symbol_by_token"):
+            mapping = getattr(self._kite, attr, None) or getattr(self._state, attr, None)
+            if not isinstance(mapping, Mapping):
+                continue
+            for raw_token, raw_symbol in mapping.items():
+                try:
+                    token = int(raw_token)
+                except (TypeError, ValueError):
+                    continue
+                if token in wanted and raw_symbol:
+                    lookup[token] = str(raw_symbol)
+        return lookup
 
     def get_ltp(self, tokens: Sequence[int], *, stale_after_seconds: int = 5) -> dict[int, float]:
         """Get token LTPs using WS first and polling fallback. Args: tokens/stale_after_seconds. Returns: token->price. Raises: none."""
@@ -165,8 +228,15 @@ class MarketDataSource:
         merged.update(polled)
         return merged
 
-    def get_ohlc(self, token: int, interval: str, ttl: int = 60) -> list[dict[str, Any]]:
-        """Get token OHLC with TTL cache. Args: token/interval/ttl. Returns: rows. Raises: DataIntegrityError."""
+    def get_ohlc(
+        self,
+        token: int,
+        interval: str,
+        ttl: int = 60,
+        *,
+        min_required_bars: int = 30,
+    ) -> list[dict[str, Any]]:
+        """Get token OHLC with TTL cache. Args: token/interval/ttl/min_required_bars. Returns: rows. Raises: DataIntegrityError."""
 
         cached = self._state.get_ohlc_cache(token, interval, ttl=ttl)
         if cached is not None:
@@ -180,8 +250,11 @@ class MarketDataSource:
             )
         except Exception as e:
             raise DataIntegrityError(f'OHLC fetch failed for token {token}: {e}') from e
-        if len(rows) < 30:
-            raise DataIntegrityError(f'Insufficient OHLC candles for token {token}: {len(rows)}')
+        required = max(1, int(min_required_bars))
+        if len(rows) < required:
+            raise DataIntegrityError(
+                f"Insufficient OHLC candles for token {token}: {len(rows)}/{required}"
+            )
         normalized = [dict(row) for row in rows]
         self._state.set_ohlc_cache(int(token), interval, normalized)
         return normalized

--- a/src/nifty_scalper_bot/data/source.py
+++ b/src/nifty_scalper_bot/data/source.py
@@ -130,7 +130,7 @@ class MarketDataSource:
     def get_ltp_poll(self, tokens: Sequence[int]) -> dict[int, float]:
         """Fetch LTP by polling API. Args: tokens. Returns: token->price. Raises: DataIntegrityError."""
 
-        normalized_tokens = [int(token) for token in tokens]
+        normalized_tokens = self._normalize_poll_tokens(tokens)
         if not normalized_tokens:
             return {}
         try:
@@ -154,6 +154,23 @@ class MarketDataSource:
         except Exception as e:
             raise DataIntegrityError(f"Polling LTP failed: {e}") from e
         return {}
+
+    @staticmethod
+    def _normalize_poll_tokens(tokens: Sequence[Any]) -> list[int]:
+        """Return positive integer tokens, skipping malformed inputs."""
+
+        normalized: list[int] = []
+        seen: set[int] = set()
+        for raw_token in tokens:
+            try:
+                token = int(raw_token)
+            except (TypeError, ValueError):
+                continue
+            if token <= 0 or token in seen:
+                continue
+            normalized.append(token)
+            seen.add(token)
+        return normalized
 
     def _extract_token_ltps(
         self,
@@ -209,8 +226,23 @@ class MarketDataSource:
                 except (TypeError, ValueError):
                     continue
                 if token in wanted and raw_symbol:
-                    lookup[token] = str(raw_symbol)
+                    normalized_symbol = self._normalize_ltp_symbol(str(raw_symbol))
+                    if normalized_symbol:
+                        lookup[token] = normalized_symbol
         return lookup
+
+    @staticmethod
+    def _normalize_ltp_symbol(symbol: str) -> str:
+        """Normalize token-symbol mappings for raw Kite LTP compatibility."""
+
+        text = str(symbol or "").strip().upper()
+        if not text:
+            return ""
+        if text in {"NIFTY", "NIFTY 50", "NSE:NIFTY"}:
+            return "NSE:NIFTY 50"
+        if ":" not in text and (text.endswith("CE") or text.endswith("PE") or text.endswith("FUT")):
+            return f"NFO:{text}"
+        return text
 
     def get_ltp(self, tokens: Sequence[int], *, stale_after_seconds: int = 5) -> dict[int, float]:
         """Get token LTPs using WS first and polling fallback. Args: tokens/stale_after_seconds. Returns: token->price. Raises: none."""

--- a/src/nifty_scalper_bot/execution/order_manager.py
+++ b/src/nifty_scalper_bot/execution/order_manager.py
@@ -2302,6 +2302,35 @@ class OrderManager:
         normalized_symbol = normalize_symbol(symbol)
         if not is_strategy_instrument(normalized_symbol):
             raise RuntimeError("Blocked non-NIFTY instrument")
+        if (
+            self._execution_mode_env() == "LIVE"
+            and self._is_selected_option_for_live_execution(normalized_symbol)
+        ):
+            quote = self._get_latest_quote_safe(normalized_symbol) or {}
+            quote_diag = self._extract_quote_diagnostics(quote)
+            if float(quote_diag.get("bid") or 0.0) <= 0 or float(quote_diag.get("ask") or 0.0) <= 0:
+                self.set_last_skip_reason("selected_option_bid_ask_missing")
+                self._logger.warning(
+                    "ORDER_BLOCKED: selected_option_bid_ask_missing symbol=%s bid=%s ask=%s ltp=%s",
+                    normalized_symbol,
+                    quote_diag.get("bid"),
+                    quote_diag.get("ask"),
+                    quote_diag.get("ltp"),
+                    extra={
+                        "event": "ORDER_BLOCKED",
+                        "block_reason": "selected_option_bid_ask_missing",
+                        "symbol": normalized_symbol,
+                        "bid": quote_diag.get("bid"),
+                        "ask": quote_diag.get("ask"),
+                        "ltp": quote_diag.get("ltp"),
+                    },
+                )
+                _log_order_decision(
+                    allowed=False,
+                    block_reason="selected_option_bid_ask_missing",
+                    details={"quote": quote_diag},
+                )
+                return None
         try:
             lot_size = self._lot_size_for_symbol(normalized_symbol)
         except OrderPlacementError as exc:
@@ -3125,6 +3154,54 @@ class OrderManager:
                 except Exception:
                     pass
         return None
+
+    def _selected_option_symbols_for_execution(self) -> set[str]:
+        """Return selected CE/PE symbols from the attached active basket context."""
+
+        selected: set[str] = set()
+        providers = (
+            getattr(self, "_market_data", None),
+            getattr(self, "_data_hub", None),
+            getattr(self, "market_data_manager", None),
+            getattr(self, "data_hub", None),
+        )
+        for provider in providers:
+            if provider is None:
+                continue
+            baskets: list[Any] = []
+            getter = getattr(provider, "get_active_contract_basket", None)
+            if callable(getter):
+                try:
+                    baskets.append(getter())
+                except Exception as exc:  # noqa: BLE001 - provider diagnostics only
+                    self._logger.debug(
+                        "selected_option_basket_lookup_failed",
+                        extra={"event": "selected_option_basket_lookup_failed", "error": str(exc)},
+                    )
+            baskets.append(getattr(provider, "active_trading_universe", None))
+            baskets.append(getattr(provider, "active_contract_basket", None))
+            for basket in baskets:
+                for key in ("selected_ce", "selected_pe", "atm_ce", "atm_pe"):
+                    value = None
+                    if isinstance(basket, Mapping):
+                        value = basket.get(key)
+                    elif basket is not None:
+                        value = getattr(basket, key, None)
+                    if value:
+                        normalized = normalize_symbol(str(value))
+                        if normalized:
+                            selected.add(normalized)
+            for attr in ("selected_ce", "selected_pe", "atm_ce_symbol", "atm_pe_symbol"):
+                value = getattr(provider, attr, None)
+                if value:
+                    normalized = normalize_symbol(str(value))
+                    if normalized:
+                        selected.add(normalized)
+        return selected
+
+    def _is_selected_option_for_live_execution(self, symbol: str) -> bool:
+        normalized = normalize_symbol(symbol)
+        return bool(normalized and normalized in self._selected_option_symbols_for_execution())
 
     def _extract_quote_diagnostics(self, quote: Mapping[str, Any]) -> dict[str, Any]:
         def _safe_float(value: object, default: float = 0.0) -> float:

--- a/tests/bot/test_trading_path_trace.py
+++ b/tests/bot/test_trading_path_trace.py
@@ -1,3 +1,9 @@
 def test_placeholder_trading_path_trace_contract():
     # Guard rail placeholder: implementation-level logging path is integration-tested elsewhere.
     assert True
+
+
+def test_production_startup_imports_real_zerodha_not_legacy_dummy() -> None:
+    source = open('src/nifty_scalper_bot/core/app.py', encoding='utf-8').read()
+    assert 'from nifty_scalper_bot.data.rest.zerodha_client import ZerodhaKiteClient' in source
+    assert 'from nifty_scalper_bot.bot.components import ZerodhaKiteClient' not in source

--- a/tests/core/test_live_readiness_recompute.py
+++ b/tests/core/test_live_readiness_recompute.py
@@ -135,3 +135,39 @@ async def test_dynamic_basket_commit_sets_selected_symbols_and_readiness() -> No
     assert ctx.selected_pe == 'NFO:NIFTY24600PE'
     assert ctx.data_hard_ready is True
     assert ctx.evaluation_ready is True
+
+
+@pytest.mark.asyncio
+async def test_selected_option_ltp_only_blocks_live_execution_bid_ask_missing(monkeypatch) -> None:
+    monkeypatch.setattr(app, 'get_market_state', lambda: app.MarketState.OPEN)
+
+    class _Snap:
+        ltp = 100.0
+        tick_age_s = 1.0
+        bid = None
+        ask = None
+        tradable_quote = False
+        depth_available = False
+
+    mdm = SimpleNamespace(
+        get_ohlc_bars=lambda s, limit=None: list(range(40)),
+        get_symbol_snapshot=lambda s: _Snap(),
+        hydrate_active_contract_basket=lambda basket=None: {"hard_ready": True, "missing": [], "symbols": {}},
+    )
+    ctx = _ctx(mdm)
+    ctx.active_trading_universe = {
+        'spot_symbol': 'NSE:NIFTY',
+        'selected_ce': 'NFO:NIFTY24600CE',
+        'selected_pe': 'NFO:NIFTY24600PE',
+        'option_symbols': ['NFO:NIFTY24600CE', 'NFO:NIFTY24600PE'],
+    }
+
+    await app._recompute_and_push_runtime_readiness(ctx, reason='test')
+
+    assert ctx.evaluation_ready is True
+    assert ctx.live_orders_armed is False
+    assert ctx.execution_ready_by_symbol == {
+        'NFO:NIFTY24600CE': False,
+        'NFO:NIFTY24600PE': False,
+    }
+    assert 'selected_option_bid_ask_missing' in str(ctx.live_block_reason)

--- a/tests/data/test_market_data_manager_option_chain.py
+++ b/tests/data/test_market_data_manager_option_chain.py
@@ -179,3 +179,61 @@ def test_option_chain_handles_expiry_with_time_component() -> None:
     assert chain is not None
     assert {row["instrument_token"] for row in chain} == {701, 702}
     assert all(row["expiry"].date() == base.date() for row in chain)
+
+
+def test_option_chain_falls_back_to_raw_zerodha_nfo_instruments() -> None:
+    expiry_dt = (datetime.now(timezone.utc) + timedelta(days=3)).date()
+
+    class EmptyResolver:
+        def option_contracts(self, underlying: str, *, force_refresh: bool = False) -> list[dict[str, Any]]:
+            return []
+
+    class RawBroker(_StubBroker):
+        def instruments(self, exchange: str) -> list[dict[str, Any]]:
+            assert exchange == "NFO"
+            return [
+                {
+                    "name": "NIFTY",
+                    "instrument_type": "CE",
+                    "tradingsymbol": "NIFTY26JUN25000CE",
+                    "instrument_token": 901,
+                    "expiry": datetime.combine(expiry_dt, datetime.min.time()),
+                    "strike": 25000,
+                    "lot_size": 25,
+                    "tick_size": 0.05,
+                },
+                {
+                    "name": "NIFTY",
+                    "instrument_type": "PE",
+                    "tradingsymbol": "NIFTY26JUN25000PE",
+                    "instrument_token": 902,
+                    "expiry": expiry_dt.isoformat(),
+                    "strike": 25000,
+                    "lot_size": 25,
+                    "tick_size": 0.05,
+                },
+                {
+                    "name": "NIFTY",
+                    "instrument_type": "FUT",
+                    "tradingsymbol": "NIFTY26JUNFUT",
+                    "instrument_token": 903,
+                    "expiry": expiry_dt.isoformat(),
+                    "strike": 0,
+                },
+            ]
+
+    broker = RawBroker(
+        {
+            901: {"last_price": 110.0, "depth": {"buy": [{"price": 109.5}], "sell": [{"price": 110.5}]}},
+            902: {"last_price": 111.0, "depth": {"buy": [{"price": 110.5}], "sell": [{"price": 111.5}]}},
+        },
+        underlying_price=25010.0,
+    )
+    manager = MarketDataManager(broker, None, resolver=EmptyResolver())
+
+    chain = manager.get_option_chain(expiry_dt.isoformat())
+
+    assert chain is not None
+    assert {row["instrument_token"] for row in chain} == {901, 902}
+    assert {row["option_type"] for row in chain} == {"CE", "PE"}
+    assert all(row["expiry"].date() == expiry_dt for row in chain)

--- a/tests/data/test_market_data_manager_subscriptions.py
+++ b/tests/data/test_market_data_manager_subscriptions.py
@@ -447,3 +447,12 @@ def test_websocket_replay_after_purge_has_no_may() -> None:
     assert 111 not in mdm.desired_tokens_snapshot()
     assert 111 not in ws.tokens_snapshot()
     assert fake.subscribed == [222]
+
+
+def test_subscribe_initializes_subscription_metric_and_does_not_raise() -> None:
+    mdm = MarketDataManager(DummyBroker(), websocket=None, resolver=DummyResolver())
+    received: list[dict[str, object]] = []
+
+    mdm.subscribe('NSE:NIFTY', lambda tick: received.append(tick))
+
+    assert 'NSE:NIFTY' in mdm._subscribers  # noqa: SLF001

--- a/tests/data/test_market_state_source.py
+++ b/tests/data/test_market_state_source.py
@@ -11,6 +11,7 @@ from nifty_scalper_bot.data.source import DataIntegrityError, MarketDataSource
 class _StubKite:
     def __init__(self) -> None:
         self.ltp_payload = {101: {"last_price": 100.5}}
+        self.bulk_calls: list[list[int]] = []
         self.ltp_calls: list[list[str]] = []
         self.rows = [
             {
@@ -24,6 +25,7 @@ class _StubKite:
         ]
 
     def get_ltp_bulk(self, tokens: list[int]) -> dict[int, dict[str, float]]:
+        self.bulk_calls.append(list(tokens))
         return {int(token): self.ltp_payload.get(int(token), {}) for token in tokens}
 
     def ltp(self, symbols: list[str]) -> dict[str, dict[str, float]]:
@@ -86,6 +88,19 @@ def test_integer_token_polling_uses_bulk_without_nfo_token_ltp_key() -> None:
     prices = source.get_ltp_poll([101])
 
     assert prices == {101: pytest.approx(100.5)}
+    assert kite.bulk_calls == [[101]]
+    assert kite.ltp_calls == []
+
+
+def test_polling_skips_invalid_empty_and_non_positive_tokens() -> None:
+    state = MarketState()
+    kite = _StubKite()
+    source = MarketDataSource(kite, state)
+
+    prices = source.get_ltp_poll([101, None, "", "bad", -1])  # type: ignore[list-item]
+
+    assert prices == {101: pytest.approx(100.5)}
+    assert kite.bulk_calls == [[101]]
     assert kite.ltp_calls == []
 
 
@@ -104,6 +119,6 @@ def test_raw_ltp_fallback_requires_token_symbol_mapping() -> None:
     source = MarketDataSource(kite, state)
     assert source.get_ltp_poll([101]) == {}
 
-    kite.token_to_symbol = {101: "NFO:NIFTY26JUN25000CE"}
+    kite.token_to_symbol = {101: "NIFTY26JUN25000CE"}
     assert source.get_ltp_poll([101]) == {101: pytest.approx(123.0)}
     assert kite.ltp_calls == [["NFO:NIFTY26JUN25000CE"]]

--- a/tests/data/test_market_state_source.py
+++ b/tests/data/test_market_state_source.py
@@ -10,7 +10,8 @@ from nifty_scalper_bot.data.source import DataIntegrityError, MarketDataSource
 
 class _StubKite:
     def __init__(self) -> None:
-        self.ltp_payload = {"NFO:101": {"last_price": 100.5}}
+        self.ltp_payload = {101: {"last_price": 100.5}}
+        self.ltp_calls: list[list[str]] = []
         self.rows = [
             {
                 "date": datetime.now(timezone.utc).isoformat(),
@@ -22,8 +23,12 @@ class _StubKite:
             for _ in range(35)
         ]
 
+    def get_ltp_bulk(self, tokens: list[int]) -> dict[int, dict[str, float]]:
+        return {int(token): self.ltp_payload.get(int(token), {}) for token in tokens}
+
     def ltp(self, symbols: list[str]) -> dict[str, dict[str, float]]:
-        return {key: self.ltp_payload.get(key, {}) for key in symbols}
+        self.ltp_calls.append(list(symbols))
+        return {key: {"last_price": 999.0} for key in symbols}
 
     def historical_data(
         self,
@@ -60,3 +65,45 @@ def test_get_ohlc_validates_minimum_rows() -> None:
     source = MarketDataSource(kite, state)
     with pytest.raises(DataIntegrityError):
         source.get_ohlc(101, "minute")
+
+
+def test_get_ohlc_allows_selected_option_provisional_minimum() -> None:
+    state = MarketState()
+    kite = _StubKite()
+    kite.rows = kite.rows[:5]
+    source = MarketDataSource(kite, state)
+
+    rows = source.get_ohlc(101, "minute", min_required_bars=5)
+
+    assert len(rows) == 5
+
+
+def test_integer_token_polling_uses_bulk_without_nfo_token_ltp_key() -> None:
+    state = MarketState()
+    kite = _StubKite()
+    source = MarketDataSource(kite, state)
+
+    prices = source.get_ltp_poll([101])
+
+    assert prices == {101: pytest.approx(100.5)}
+    assert kite.ltp_calls == []
+
+
+def test_raw_ltp_fallback_requires_token_symbol_mapping() -> None:
+    class RawOnlyKite:
+        def __init__(self) -> None:
+            self.ltp_calls: list[list[str]] = []
+
+        def ltp(self, symbols: list[str]) -> dict[str, dict[str, float]]:
+            self.ltp_calls.append(list(symbols))
+            assert "NFO:101" not in symbols
+            return {symbols[0]: {"instrument_token": 101, "last_price": 123.0}}
+
+    state = MarketState()
+    kite = RawOnlyKite()
+    source = MarketDataSource(kite, state)
+    assert source.get_ltp_poll([101]) == {}
+
+    kite.token_to_symbol = {101: "NFO:NIFTY26JUN25000CE"}
+    assert source.get_ltp_poll([101]) == {101: pytest.approx(123.0)}
+    assert kite.ltp_calls == [["NFO:NIFTY26JUN25000CE"]]

--- a/tests/execution/test_order_manager_live_guard.py
+++ b/tests/execution/test_order_manager_live_guard.py
@@ -62,3 +62,40 @@ def test_live_guard_blocks_live_without_any_live_flag(monkeypatch):
 def test_live_guard_blocks_disconnected_broker(monkeypatch):
     om = _manager(monkeypatch, mode="LIVE", enable_live_trading="true", connected=False)
     assert om._validate_live_execution_safety() is False
+
+
+def test_live_selected_option_ltp_only_rejected_before_broker(monkeypatch):
+    monkeypatch.setenv("EXECUTION_MODE", "LIVE")
+    monkeypatch.setenv("ENABLE_LIVE_TRADING", "true")
+    broker = _Broker(connected=True)
+    broker.calls = 0
+
+    def _place_order(**_kwargs):
+        broker.calls += 1
+        return {"order_id": "OID"}
+
+    broker.place_order = _place_order
+    om = OrderManager(broker, _Positions(), _Limiter())
+    monkeypatch.setattr(om, "_validate_live_execution_safety", lambda: True)
+    selected = "NFO:NIFTY26MAY23750CE"
+    om._market_data = type(
+        "MDM",
+        (),
+        {
+            "get_active_contract_basket": lambda self: {"selected_ce": selected, "selected_pe": "NFO:NIFTY26MAY23750PE"},
+            "get_quote": lambda self, symbol: {"ltp": 100.0, "last_price": 100.0},
+        },
+    )()
+
+    result = om.place_order(
+        selected,
+        "BUY",
+        1,
+        stop_loss=90.0,
+        take_profit=120.0,
+    )
+
+    assert result is None
+    assert broker.calls == 0
+    assert om.get_last_skip_reason() == "selected_option_bid_ask_missing"
+    assert om._last_order_decision["block_reason"] == "selected_option_bid_ask_missing"


### PR DESCRIPTION
### Motivation

- Fix incorrect integer-token polling and fragile option-chain fallback that prevented option tokens, quotes, and OHLC from hydrating reliably.  
- Prevent a metrics crash from an uninitialized subscription counter and quarantine a legacy dummy Zerodha client name to avoid confusion with the production broker.  
- Allow selected ATM options to become provisionally evaluable with fewer initial bars while preserving strict live-execution gates.

### Description

- MarketDataSource LTP polling: reworked `MarketDataSource.get_ltp_poll()` to prefer token-native bulk APIs (`get_ltp_bulk`, `get_quote_bulk`, `quote_any`) and avoid constructing invalid `"NFO:<token>"` keys; added `_extract_token_ltps()` and `_token_symbol_lookup()` helpers for robust token↔ltp extraction and a safe fallback to raw `ltp()` only when a token→symbol mapping exists.  
- OHLC fetch flexibility: `get_ohlc()` accepts a caller `min_required_bars` and raises `DataIntegrityError` only if fetched rows are below the requested minimum; this supports provisional hydration for selected options.  
- Option-chain broker fallback: updated `MarketDataManager.get_option_chain()` to accept raw Zerodha `instruments("NFO")` rows by parsing `instrument_type` / `option_type` / `type`, using date-aware expiry parsing (`_parse_instrument_expiry` / `_select_expiry`), and preserving Zerodha raw fields (lot/tick/strike/token) when building the chain.  
- Subscription metric crash: initialized the missing `_m_subs` metric in `MarketDataManager.__init__()` to match existing metrics pattern so `subscribe()` can safely call `_m_subs.inc()`.  
- Selected-option hydration/readiness: lowered the default selected-option provisional minimum to 5 bars (`_selected_option_min_bars`) and mark entries with 0 < bars < required as `ohlc_provisional` so strategies can evaluate provisionally while live execution still requires fresh bid/ask and the stricter execution bar threshold.  
- Quarantine legacy dummy broker: renamed placeholder `ZerodhaKiteClient` in `bot/components.py` to `LegacyDummyZerodhaKiteClient` and added a top note that the module is legacy/testing-only so production import paths remain tied to `data.rest.zerodha_client.ZerodhaKiteClient`.  
- Tests: added focused regression tests covering integer-token polling without fabricated `NFO:<token>` calls, provisional OHLC minimum, raw Zerodha `instruments("NFO")` option-chain fallback, subscription metric initialization, and a startup import guard to ensure production code imports the real zerodha client rather than the legacy dummy.

### Testing

- Commands run: `python -m compileall -q src` and `pytest -q` (full test-suite) and focused runs for modified areas: `pytest -q tests/data/test_market_state_source.py tests/data/test_market_data_manager_option_chain.py tests/data/test_market_data_manager_subscriptions.py tests/data/test_mdm_subscribes_active_basket.py tests/bot/test_trading_path_trace.py`.  
- Results: all focused tests passed and the full test-suite passed locally (no failures).  
- Notes: tests assert integer-token bulk polling, provisional OHLC behavior, option-chain fallback from raw Zerodha NFO payloads, and that `MarketDataManager.subscribe()` no longer raises due to a missing metric.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1eeca87c988324b533dd985792e9c6)