### PR TITLE
fix: declare active_symbol_tokens and degraded_mode in BotContext (slots=True crash)

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -2434,6 +2434,12 @@ class BotContext:
     startup_failed: bool = False
     startup_failure_reason: str | None = None
     startup_failure_exception: str | None = None
+    # Token map for the active basket: symbol -> Zerodha instrument token.
+    # Must be declared here (not set dynamically) because BotContext uses
+    # slots=True which forbids any attribute that is not listed as a field.
+    active_symbol_tokens: dict[str, int] = field(default_factory=dict)
+    # Set True when startup pipeline fails but bot continues in degraded mode.
+    degraded_mode: bool = False
 
     def update_spot_price(
         self, underlying: str, price: float, max_size: int = 100
@@ -7742,8 +7748,7 @@ def _commit_active_dynamic_basket(
     requested_futures_symbol = basket.get("futures_symbol") or basket.get("future_symbol")
     requested_selected_ce = str(basket.get("selected_ce") or basket.get("atm_ce") or "") or None
     requested_selected_pe = str(basket.get("selected_pe") or basket.get("atm_pe") or "") or None
-    if not hasattr(ctx, "active_symbol_tokens") or getattr(ctx, "active_symbol_tokens", None) is None:
-        ctx.active_symbol_tokens = {}
+    # active_symbol_tokens is a declared BotContext field (default={}) — no guard needed.
     active_futures_symbol = canonical_nifty_future_symbol(requested_futures_symbol) or _resolve_active_futures_for_basket(ctx, requested_futures_symbol)
     basket_copy = dict(basket or {})
     basket_copy["futures_symbol"] = active_futures_symbol

--- a/tests/test_botcontext_startup_fields.py
+++ b/tests/test_botcontext_startup_fields.py
@@ -21,6 +21,14 @@ def test_botcontext_has_startup_spot_fields() -> None:
     assert 'broker_ready' in names
     assert 'active_contract_basket' in names
     assert 'active_basket_hydration' in names
+    # Basket token map and degraded-mode flag must be declared fields because
+    # BotContext uses slots=True — undeclared dynamic assignments raise AttributeError.
+    assert 'active_symbol_tokens' in names, (
+        "active_symbol_tokens must be a declared BotContext field (slots=True forbids dynamic attrs)"
+    )
+    assert 'degraded_mode' in names, (
+        "degraded_mode must be a declared BotContext field (slots=True forbids dynamic attrs)"
+    )
 
 
 def test_assigning_startup_fields_does_not_raise() -> None:
@@ -40,3 +48,15 @@ def test_assigning_startup_fields_does_not_raise() -> None:
     assert isinstance(ctx.execution_ready_by_symbol, dict)
     assert ctx.selected_ce_exec_ready is True
     assert ctx.active_basket_hydration['missing'] == ['hydrator_missing']
+
+
+def test_active_symbol_tokens_and_degraded_mode_assignable() -> None:
+    """Regression: slots=True raised AttributeError on dynamic ctx.active_symbol_tokens = {...}."""
+    ctx = object.__new__(BotContext)
+    # Must not raise AttributeError — these are now declared slots fields.
+    ctx.active_symbol_tokens = {'NSE:NIFTY': 256265, 'NFO:NIFTY2660923500CE': 12345678}
+    ctx.degraded_mode = True
+    assert isinstance(ctx.active_symbol_tokens, dict)
+    assert len(ctx.active_symbol_tokens) == 2
+    assert ctx.degraded_mode is True
+


### PR DESCRIPTION
## Problem

`BotContext` uses `@dataclass(slots=True)` which generates `__slots__` from declared fields only. Any undeclared attribute assignment raises `AttributeError`.

Two attributes were set dynamically at runtime but never declared:
- `ctx.active_symbol_tokens = token_map` (line 7930)
- `ctx.degraded_mode = True` (line 11069)

This caused the repeating crash seen in production logs:
```
LIVE_BASKET_BUILD_FAILED reason='BotContext' object has no attribute 'active_symbol_tokens'
DEFERRED_BASKET_HYDRATION_FAILED attempt=N/160 error='BotContext' object has no attribute 'active_symbol_tokens'
```

## Fix

- Declare `active_symbol_tokens: dict[str, int] = field(default_factory=dict)` as a proper BotContext field
- Declare `degraded_mode: bool = False` as a proper BotContext field
- Remove now-redundant `hasattr`/`getattr` guard in `_commit_active_dynamic_basket`
- Add regression tests asserting both fields are declared and assignable

## Tests

47/47 pass.