### PR TITLE
fix(orderflow): adaptive stale-bias invalidation for intraday reversals

### DIFF
--- a/src/nifty_scalper_bot/strategies/elite_strategies/order_flow.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/order_flow.py
@@ -188,7 +188,30 @@ class OrderFlowStrategy(EliteStrategy):
                 return None
 
             side_aligns = direction in {'CE', 'PE'} and direction == side
-            side_alignment_ok = direction not in {'CE', 'PE'} or side_aligns
+            # A directional context bias (CE/PE) normally gates the opposite side.
+            # But an intraday reversal makes that bias stale: the slower VWAP/EMA
+            # context still leans one way while live microstructure has already
+            # flipped. When the order book in front of us independently and freshly
+            # confirms the *opposite* side, the stale bias should not veto it.
+            # Confirmation = candidate-side tick support + meaningful same-side depth
+            # imbalance. This is the live-microstructure-beats-stale-lean rule a
+            # scalper applies by hand; it needs no score inflation or near-ATM meta.
+            bias_conflict = direction in {'CE', 'PE'} and not side_aligns
+            min_reversal_imbalance = safe_float_env('ORDERFLOW_REVERSAL_MIN_IMBALANCE', 0.20)
+            # In premium domain, depth_imbalance is on the option's OWN book, so
+            # positive imbalance (more buyers of this option) always confirms the
+            # candidate side. Outside premium domain it is underlying-directional,
+            # so CE wants positive and PE wants negative imbalance.
+            if option_premium_domain:
+                imbalance_confirms = depth_imbalance >= min_reversal_imbalance
+            else:
+                imbalance_confirms = (
+                    (side == 'CE' and depth_imbalance >= min_reversal_imbalance)
+                    or (side == 'PE' and depth_imbalance <= -min_reversal_imbalance)
+                )
+            microstructure_confirms_side = bool(tick_supports and depth_available and imbalance_confirms)
+            bias_invalidated_by_microstructure = bool(bias_conflict and microstructure_confirms_side)
+            side_alignment_ok = (direction not in {'CE', 'PE'}) or side_aligns or bias_invalidated_by_microstructure
             tick_direction_missing = tick_direction not in {'UP', 'DOWN', 'BUY', 'SELL'}
             direction_context_missing = direction not in {'CE', 'PE'}
             allow_without_direction_live = str(os.getenv('ORDERFLOW_ALLOW_TRIGGER_WITHOUT_DIRECTION_LIVE', 'false')).strip().lower() in {'1', 'true', 'yes', 'on'}
@@ -199,6 +222,40 @@ class OrderFlowStrategy(EliteStrategy):
                 context_age_ok = age_raw is not None and float(age_raw) <= max_context_age
             except (TypeError, ValueError):
                 context_age_ok = False
+            if bias_invalidated_by_microstructure:
+                LOGGER.info(
+                    'ORDERFLOW_STALE_BIAS_INVALIDATED symbol=%s side=%s stale_bias=%s '
+                    'depth_imbalance=%.3f tick_direction=%s score=%.2f',
+                    symbol, side, direction, depth_imbalance, tick_direction, strategy_score,
+                    extra={
+                        'event': 'ORDERFLOW_STALE_BIAS_INVALIDATED',
+                        'symbol': symbol, 'side': side, 'stale_bias': direction,
+                        'depth_imbalance': round(depth_imbalance, 4),
+                        'tick_direction': tick_direction, 'score': strategy_score,
+                    },
+                )
+            near_atm_threshold = safe_float_env('STRATEGY_NEAR_ATM_THRESHOLD_POINTS', 50.0)
+            selected_meta_available = any(indicators.get(name) is not None for name in ('is_selected_option', 'strike_distance_from_atm', 'selected_ce', 'selected_pe'))
+            selected_or_near_atm = bool(indicators.get('is_selected_option'))
+            if not selected_or_near_atm and indicators.get('strike_distance_from_atm') is not None:
+                try:
+                    selected_or_near_atm = float(indicators.get('strike_distance_from_atm')) <= near_atm_threshold
+                except (TypeError, ValueError):
+                    selected_or_near_atm = False
+            if is_live_mode and not selected_meta_available:
+                selected_or_near_atm = False
+            if bias_invalidated_by_microstructure:
+                LOGGER.info(
+                    'ORDERFLOW_STALE_BIAS_INVALIDATED symbol=%s side=%s stale_bias=%s '
+                    'depth_imbalance=%.3f tick_direction=%s score=%.2f',
+                    symbol, side, direction, depth_imbalance, tick_direction, strategy_score,
+                    extra={
+                        'event': 'ORDERFLOW_STALE_BIAS_INVALIDATED',
+                        'symbol': symbol, 'side': side, 'stale_bias': direction,
+                        'depth_imbalance': round(depth_imbalance, 4),
+                        'tick_direction': tick_direction, 'score': strategy_score,
+                    },
+                )
             trigger_conditions_met = bool(
                 allow_orderflow_trigger
                 and quote_depth_valid
@@ -214,16 +271,6 @@ class OrderFlowStrategy(EliteStrategy):
                 and tick_supports
                 and tick_age_ms <= max_tick_age_ms
             )
-            near_atm_threshold = safe_float_env('STRATEGY_NEAR_ATM_THRESHOLD_POINTS', 50.0)
-            selected_meta_available = any(indicators.get(name) is not None for name in ('is_selected_option', 'strike_distance_from_atm', 'selected_ce', 'selected_pe'))
-            selected_or_near_atm = bool(indicators.get('is_selected_option'))
-            if not selected_or_near_atm and indicators.get('strike_distance_from_atm') is not None:
-                try:
-                    selected_or_near_atm = float(indicators.get('strike_distance_from_atm')) <= near_atm_threshold
-                except (TypeError, ValueError):
-                    selected_or_near_atm = False
-            if is_live_mode and not selected_meta_available:
-                selected_or_near_atm = False
             conflict_override_requested = bool(
                 not side_alignment_ok
                 and strategy_score >= float(os.getenv('ORDERFLOW_CONFLICT_OVERRIDE_MIN_SCORE', '9.0') or '9.0')
@@ -309,6 +356,9 @@ class OrderFlowStrategy(EliteStrategy):
                 'tick_age_ms': tick_age_ms,
                 'quote_update_version': indicators.get('quote_update_version'),
                 'selected_or_near_atm': selected_or_near_atm,
+                'bias_invalidated_by_microstructure': bias_invalidated_by_microstructure,
+                'microstructure_confirms_side': microstructure_confirms_side,
+                'raw_direction_bias': direction if direction in {'CE', 'PE'} else None,
                 'orderflow_conflict_override_requested': conflict_override_requested,
                 'orderflow_conflict_override_applied': conflict_override_applied,
                 'orderflow_conflict_override': conflict_override_applied,

--- a/tests/strategies/test_order_flow_conflict_override.py
+++ b/tests/strategies/test_order_flow_conflict_override.py
@@ -1,65 +1,88 @@
+"""OrderFlow adaptive direction-conflict tests.
+
+A stale directional bias must not veto a fresh signal when live microstructure
+(tick + same-side depth imbalance) independently confirms the candidate side.
+"""
+import os
+import pytest
 from nifty_scalper_bot.strategies.elite_strategies.config_models import OrderFlowStrategyConfig
 from nifty_scalper_bot.strategies.elite_strategies.order_flow import OrderFlowStrategy
 
 
-def _ind(score_high: bool):
-    buy_qty = 300 if score_high else 180
-    sell_qty = 100
-    return {
-        "bid": 100.0,
-        "ask": 100.5,
-        "spread_pct": 0.5,
-        "depth": {"buy": [{"quantity": buy_qty}], "sell": [{"quantity": sell_qty}]},
-        "tick_direction": "UP",
-        "direction_bias": "PE",
-        "atr": 2.0,
-        "data_age_seconds": 0.1,
-        "context_age_seconds": 1.0,
-        "tick_age_ms": 100,
-        "quote_depth_valid": True,
-        "tradable_quote": True,
-        "is_selected_option": True,
-        "strike_distance_from_atm": 0,
+def _ind(bias, tick, buy, sell, **kw):
+    d = {
+        "bid": 100.0, "ask": 100.25, "spread_pct": 0.24,
+        "depth": {"buy": [{"quantity": buy}], "sell": [{"quantity": sell}]},
+        "tick_direction": tick, "direction_bias": bias, "atr": 2.0,
+        "data_age_seconds": 0.1, "context_age_seconds": 1.0, "tick_age_ms": 100,
+        "quote_depth_valid": True, "tradable_quote": True,
+        "is_selected_option": True, "strike_distance_from_atm": 0,
     }
+    d.update(kw)
+    return d
 
 
-def test_orderflow_direction_conflict_score_eight_remains_blocked(monkeypatch):
+@pytest.fixture
+def strat():
+    return OrderFlowStrategy(OrderFlowStrategyConfig(enabled=True, quantity=1), indicator_engine=None)
+
+
+def _eval(strat, sym, ind):
+    return strat._evaluate_signal(sym, ind, current_price=100.1)
+
+
+# A. Stale PE bias + CE candidate WITHOUT confirming microstructure -> blocked
+def test_stale_pe_weak_micro_ce_blocked(monkeypatch, strat):
     monkeypatch.setenv("EXECUTION_MODE", "LIVE")
-    strategy = OrderFlowStrategy(OrderFlowStrategyConfig(enabled=True, quantity=1), indicator_engine=None)
-
-    signal = strategy._evaluate_signal("NFO:NIFTY26MAY24000CE", _ind(score_high=False), current_price=100.2)
-
-    assert signal is not None
-    assert signal.metadata["trigger_conditions_met"] is False
-    assert signal.metadata["trigger_block_reason"] == "direction_bias_conflict"
-    assert signal.metadata["strategy_score"] == 8.0
+    sig = _eval(strat, "NFO:NIFTY26MAY24000CE", _ind("PE", "UP", buy=150, sell=140))
+    assert sig.metadata["trigger_conditions_met"] is False
+    assert sig.metadata["trigger_block_reason"] == "direction_bias_conflict"
+    assert sig.metadata["bias_invalidated_by_microstructure"] is False
 
 
-def test_orderflow_high_conviction_conflict_override_requires_depth_tick_and_near_atm(monkeypatch):
+# B. Stale PE bias + CE candidate WITH confirming microstructure -> allowed
+def test_stale_pe_strong_micro_ce_allowed(monkeypatch, strat):
     monkeypatch.setenv("EXECUTION_MODE", "LIVE")
-    strategy = OrderFlowStrategy(OrderFlowStrategyConfig(enabled=True, quantity=1), indicator_engine=None)
-
-    signal = strategy._evaluate_signal("NFO:NIFTY26MAY24000CE", _ind(score_high=True), current_price=100.2)
-
-    assert signal is not None
-    assert signal.metadata["strategy_score"] >= 9.0
-    assert signal.metadata["trigger_conditions_met"] is True
-    assert signal.metadata["orderflow_conflict_override"] is True
-    assert signal.metadata["conflict_override_reason"] == "high_conviction_depth_spread_tick_near_atm"
+    sig = _eval(strat, "NFO:NIFTY26MAY24000CE", _ind("PE", "UP", buy=400, sell=80))
+    assert sig.metadata["trigger_conditions_met"] is True
+    assert sig.metadata["bias_invalidated_by_microstructure"] is True
 
 
-def test_orderflow_override_requested_vs_applied(monkeypatch):
+# C. Reversal down: stale CE bias + PE candidate with confirming PE demand -> allowed
+def test_stale_ce_strong_micro_pe_allowed(monkeypatch, strat):
     monkeypatch.setenv("EXECUTION_MODE", "LIVE")
-    strategy = OrderFlowStrategy(OrderFlowStrategyConfig(enabled=True, quantity=1), indicator_engine=None)
-    indicators = _ind(score_high=True)
-    indicators["tradable_quote"] = False
+    sig = _eval(strat, "NFO:NIFTY26MAY24000PE", _ind("CE", "UP", buy=400, sell=80))
+    assert sig.metadata["trigger_conditions_met"] is True
+    assert sig.metadata["bias_invalidated_by_microstructure"] is True
 
-    signal = strategy._evaluate_signal("NFO:NIFTY26MAY24000CE", indicators, current_price=100.2)
 
-    assert signal is not None
-    assert signal.metadata["orderflow_conflict_override_requested"] is True
-    assert signal.metadata["orderflow_conflict_override_applied"] is False
-    assert signal.metadata["orderflow_conflict_override"] is False
-    assert signal.metadata["conflict_override_reason"] == ""
-    assert signal.metadata["trigger_conditions_met"] is False
-    assert signal.metadata["trigger_block_reason"] == "tradable_quote_false"
+# D. Tick contradicts candidate side -> not invalidated -> blocked
+def test_tick_contradicts_blocked(monkeypatch, strat):
+    monkeypatch.setenv("EXECUTION_MODE", "LIVE")
+    sig = _eval(strat, "NFO:NIFTY26MAY24000CE", _ind("PE", "DOWN", buy=400, sell=80))
+    assert sig.metadata["trigger_conditions_met"] is False
+    assert sig.metadata["bias_invalidated_by_microstructure"] is False
+
+
+# E. Aligned bias (CE bias, CE candidate) -> allowed normally, not via invalidation
+def test_aligned_bias_allowed_normally(monkeypatch, strat):
+    monkeypatch.setenv("EXECUTION_MODE", "LIVE")
+    sig = _eval(strat, "NFO:NIFTY26MAY24000CE", _ind("CE", "UP", buy=400, sell=80))
+    assert sig.metadata["trigger_conditions_met"] is True
+    assert sig.metadata["bias_invalidated_by_microstructure"] is False
+
+
+# F. Below default imbalance threshold -> not confirmed -> blocked
+def test_below_imbalance_threshold_blocked(monkeypatch, strat):
+    monkeypatch.setenv("EXECUTION_MODE", "LIVE")
+    # imbalance (210-180)/390 = 0.077 < 0.20 default -> not confirmed
+    sig = _eval(strat, "NFO:NIFTY26MAY24000CE", _ind("PE", "UP", buy=210, sell=180))
+    assert sig.metadata["bias_invalidated_by_microstructure"] is False
+    assert sig.metadata["trigger_conditions_met"] is False
+
+
+# G. No directional bias at all -> not gated by conflict
+def test_no_bias_not_conflict_gated(monkeypatch, strat):
+    monkeypatch.setenv("EXECUTION_MODE", "LIVE")
+    sig = _eval(strat, "NFO:NIFTY26MAY24000CE", _ind("", "UP", buy=400, sell=80))
+    assert sig.metadata["trigger_block_reason"] != "direction_bias_conflict"


### PR DESCRIPTION
Stale directional bias no longer vetoes a signal when live tick+depth confirm the opposite side. Stops direction_bias_conflict blocking CE during up-reversals. No execution/sizing/SL-TP/basket changes.