### PR TITLE
fix(live): remove crashing OptionUniverseManager build + relax phase-10 direction veto

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -3208,15 +3208,9 @@ def _get_symbols(
         return []
 
     global _LATEST_CTX
-    universe = option_universe
-    if universe is None:
-        settings = getattr(_LATEST_CTX, "settings", None)
-        universe_config = getattr(settings, "option_universe", {})
-        universe = OptionUniverseManager(universe_config)
-
-    universe.update_underlying(float(ltp))
-    final_symbols = universe.get_filtered_universe(float(ltp))
-
+    # Options are resolved directly from the InstrumentManager (SSOT) below.
+    # The legacy OptionUniverseManager build is disabled in live mode (raises by
+    # design) and its result was overwritten here anyway, so it is removed.
     if resolver is None:
         LOGGER.error("Strategy skipped — instrument resolver unavailable")
         return []

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -7493,7 +7493,18 @@ class StrategyRunner:
         details["direction_bias"] = direction_bias
         details["underlying_direction_bias"] = ctx.get("underlying_direction_bias")
         if direction_bias in {"CE", "PE"} and contract_side in {"CE", "PE"} and direction_bias != contract_side:
-            return False, "context_direction_conflict", details
+            # A stale directional bias must not hard-block an entry when the
+            # OrderFlow signal already cleared its own (microstructure-aware) gate.
+            # OrderFlow sets trigger_conditions_met=True only after confirming the
+            # candidate side via live tick + depth, so trust that here.
+            meta = (getattr(signal, "metadata", {}) or {}) if signal is not None else {}
+            orderflow_confirmed = bool(
+                meta.get("trigger_conditions_met")
+                or meta.get("bias_invalidated_by_microstructure")
+            )
+            if not orderflow_confirmed:
+                return False, "context_direction_conflict", details
+            details["context_direction_conflict_overridden"] = True
         required_bars = max(self._required_bars_for_symbol(symbol), safe_positive_int_env("OPTION_EXECUTION_MIN_BARS", 5, minimum=1))
         history_count = len(self._indicator_engine.get_history(symbol) or [])
         details["history_count"] = history_count


### PR DESCRIPTION
Fixes fatal run_bot_background crash (deprecated OptionUniverseManager called in live mode) and context_direction_conflict hard-block at runner phase-10. Unblocks live trading.