### PR TITLE
fix(execution): widen near-ATM window to one strike step; throttle SMC readiness spam

### DIFF
--- a/src/nifty_scalper_bot/strategies/elite_strategies/smc_liquidity.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/smc_liquidity.py
@@ -231,7 +231,13 @@ class SMCStrategy(EliteStrategy):
                 "bullish_reversal": {"missing": indicators.get("bullish_reversal") is None, "source": "reversal_detector", "required_inputs": ["open", "close", "high", "low", "atr"], "context_age_seconds": indicators.get("context_age_seconds")},
             }
             feature_ready = feature_completeness >= feature_threshold
-            LOGGER.info("SMC_FEATURE_READINESS symbol=%s feature_completeness=%.3f missing_features=%s missing_feature_sources=%s live_enabled=%s vote_allowed=%s hard_veto=%s", symbol, feature_completeness, ",".join(missing_features), missing_feature_sources, is_live, feature_ready, False, extra={"event": "SMC_FEATURE_READINESS", "symbol": symbol, "feature_completeness": feature_completeness, "missing_features": missing_features, "missing_feature_sources": missing_feature_sources, "live_enabled": is_live, "vote_allowed": feature_ready, "hard_veto": False})
+            log_throttled(
+                LOGGER,
+                f"smc_feature_readiness:{symbol}",
+                "SMC_FEATURE_READINESS symbol=%s feature_completeness=%.3f missing_features=%s missing_feature_sources=%s live_enabled=%s vote_allowed=%s hard_veto=%s",
+                symbol, feature_completeness, ",".join(missing_features), missing_feature_sources, is_live, feature_ready, False,
+                interval_sec=30.0,
+                extra={"event": "SMC_FEATURE_READINESS", "symbol": symbol, "feature_completeness": feature_completeness, "missing_features": missing_features, "missing_feature_sources": missing_feature_sources, "live_enabled": is_live, "vote_allowed": feature_ready, "hard_veto": False})
             if option_premium_domain:
                 premium_reversal = bool(bullish_sweep or indicators.get('premium_reclaim') or indicators.get('bullish_reversal'))
                 structure_flip = bool(indicators.get('choch_confirmed') or indicators.get('bos_confirmed'))

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -3022,7 +3022,7 @@ class StrategyRunner:
                 strike_distance = abs(float(strike) - float(atm_strike)) if strike and atm_strike else None
             except (TypeError, ValueError):
                 strike_distance = None
-            near_threshold = float(os.getenv("STRATEGY_NEAR_ATM_THRESHOLD_POINTS", "50") or "50")
+            near_threshold = float(os.getenv("STRATEGY_NEAR_ATM_THRESHOLD_POINTS", "100") or "100")
             candidate_selected = bool(
                 metadata.get("candidate_selected")
                 or metadata.get("is_selected_option")
@@ -7424,7 +7424,7 @@ class StrategyRunner:
             atm_strike = None
         max_allowed_distance = safe_positive_float_env(
             "LIVE_ENTRY_MAX_NEAR_ATM_DISTANCE",
-            safe_positive_float_env("STRATEGY_NEAR_ATM_THRESHOLD_POINTS", 50.0, minimum=0.0),
+            safe_positive_float_env("STRATEGY_NEAR_ATM_THRESHOLD_POINTS", 100.0, minimum=0.0),
             minimum=0.0,
         )
         strike_distance = None


### PR DESCRIPTION
Valid OrderFlow triggers at ATM+-1 (100pts) were blocked by a 50pt near-ATM window that admits only the exact ATM strike. Widened to 100pts (one strike step); far strikes still blocked. Also throttled SMC_FEATURE_READINESS spam to 30s. 1934 tests pass.