### PR TITLE
feat(deploy): one-command Lightsail setup + operator guide

### DIFF
--- a/deploy/LIGHTSAIL_SETUP.md
+++ b/deploy/LIGHTSAIL_SETUP.md
@@ -1,0 +1,66 @@
+# Nifty Scalper Bot — Lightsail Setup (one time, then browser-only)
+
+You only use the terminal **once**. After this, you manage everything from a web
+dashboard in your browser — credentials, daily access token, logs, restart.
+
+Your Lightsail static IP: **15.206.3.6** (this is what Zerodha must allowlist.)
+
+---
+
+## STEP 1 — Allowlist the IP on Zerodha (do this first, in your browser)
+
+1. Go to https://developers.kite.trade
+2. Open your app.
+3. In the **Allowed IPs** field, enter: `15.206.3.6`
+4. Save.
+
+---
+
+## STEP 2 — Open the firewall for the dashboard (in Lightsail website)
+
+1. Lightsail → your instance **Ubuntu-2** → **Networking** tab.
+2. Under **IPv4 Firewall**, click **Add rule**:
+   - Application: **Custom**
+   - Protocol: **TCP**
+   - Port: **8080**
+3. Save.
+
+---
+
+## STEP 3 — One-time install (paste ONCE into the Lightsail terminal)
+
+Open the instance terminal ("Connect using SSH" button) and paste this whole block.
+It installs Python, downloads the bot, sets up the dashboard, and starts it as a
+background service that auto-restarts and survives reboots.
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/kundakarlabp/nifty_scalper_bot/main/deploy/lightsail_setup.sh | bash
+```
+
+When it finishes it prints your dashboard URL and admin password.
+
+---
+
+## STEP 4 — Use the dashboard (browser, no terminal ever again)
+
+Open: **http://15.206.3.6:8080/admin**
+
+- Sign in with the admin password the script printed.
+- Enter your Zerodha API key, API secret, access token, Telegram details. Save.
+- Click **Restart Bot**.
+
+### Every morning
+- Generate your fresh Zerodha access token (as you do now).
+- Open the dashboard → **Daily Access Token** box → paste → **Update token & restart**.
+- Done.
+
+### Anytime
+- **View Logs** — see live activity (like Railway logs).
+- **Restart Bot** — one click.
+
+---
+
+## If something looks wrong
+- Dashboard won't open → re-check STEP 2 (port 8080 firewall rule).
+- Orders rejected with "No IPs configured" → re-check STEP 1 (IP `15.206.3.6` saved on Zerodha).
+- Need to re-run setup → it is safe to run STEP 3 again; it updates in place.

--- a/deploy/lightsail_setup.sh
+++ b/deploy/lightsail_setup.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Nifty Scalper Bot — one-time Lightsail/Ubuntu setup.
+# Safe to re-run: updates code and restarts in place.
+set -euo pipefail
+
+REPO="https://github.com/kundakarlabp/nifty_scalper_bot.git"
+APP_DIR="/home/ubuntu/nifty_scalper_bot"
+ENV_FILE="$APP_DIR/.env"
+SERVICE="niftybot"
+PORT="8080"
+
+echo "==> Installing system packages (Python, git)..."
+sudo apt-get update -y -qq
+sudo apt-get install -y -qq python3 python3-venv python3-pip git
+
+echo "==> Fetching the bot code..."
+if [ -d "$APP_DIR/.git" ]; then
+  git -C "$APP_DIR" fetch --quiet origin main
+  git -C "$APP_DIR" reset --hard --quiet origin/main
+else
+  git clone --quiet "$REPO" "$APP_DIR"
+fi
+
+echo "==> Creating Python environment and installing dependencies..."
+cd "$APP_DIR"
+python3 -m venv .venv
+. .venv/bin/activate
+pip install --quiet --upgrade pip
+pip install --quiet -e .
+pip install --quiet python-multipart uvicorn fastapi
+
+# --- .env: create on first run, preserve on re-run ---
+if [ ! -f "$ENV_FILE" ]; then
+  echo "==> Creating .env with safe defaults (you fill credentials in the dashboard)..."
+  ADMIN_PW="$(python3 -c 'import secrets;print(secrets.token_urlsafe(9))')"
+  cat > "$ENV_FILE" <<EOF
+# Filled in via the web dashboard. Do not share this file.
+ADMIN_PASSWORD=$ADMIN_PW
+PORT=$PORT
+BOT_ENV_FILE=$ENV_FILE
+BOT_SERVICE_NAME=$SERVICE
+# Trading off until you enter credentials and turn it on in the dashboard:
+ENABLE_LIVE=false
+EXECUTION_MODE=SHADOW
+# Zerodha (enter in dashboard):
+KITE_API_KEY=
+KITE_API_SECRET=
+KITE_ACCESS_TOKEN=
+# Telegram (optional, enter in dashboard):
+TELEGRAM_BOT_TOKEN=
+TELEGRAM_CHAT_ID=
+TELEGRAM_ALLOWED_ID=
+EOF
+  chmod 600 "$ENV_FILE"
+else
+  echo "==> Existing .env kept (credentials preserved)."
+  ADMIN_PW="$(grep -E '^ADMIN_PASSWORD=' "$ENV_FILE" | head -1 | cut -d= -f2-)"
+fi
+
+# --- systemd service: auto-start, auto-restart, survives reboot ---
+echo "==> Installing background service..."
+sudo tee /etc/systemd/system/${SERVICE}.service >/dev/null <<EOF
+[Unit]
+Description=Nifty Scalper Bot
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=ubuntu
+WorkingDirectory=$APP_DIR
+EnvironmentFile=$ENV_FILE
+ExecStart=$APP_DIR/.venv/bin/python -m uvicorn nifty_scalper_bot.main:app --host 0.0.0.0 --port $PORT
+Restart=always
+RestartSec=3
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+# Allow the dashboard's restart button to run systemctl without a password.
+echo "ubuntu ALL=(ALL) NOPASSWD: /bin/systemctl restart ${SERVICE}, /usr/bin/systemctl restart ${SERVICE}" | \
+  sudo tee /etc/sudoers.d/niftybot >/dev/null
+sudo chmod 440 /etc/sudoers.d/niftybot
+
+sudo systemctl daemon-reload
+sudo systemctl enable --quiet ${SERVICE}
+sudo systemctl restart ${SERVICE}
+
+IP="$(curl -fsSL https://checkip.amazonaws.com 2>/dev/null || echo 'YOUR_STATIC_IP')"
+echo ""
+echo "============================================================"
+echo " ✅ Setup complete."
+echo " Dashboard:  http://${IP}:${PORT}/admin"
+echo " Password :  ${ADMIN_PW}"
+echo ""
+echo " Next: open the dashboard, enter your Zerodha + Telegram"
+echo " details, Save, then Restart Bot. Update the access token"
+echo " each morning from the dashboard."
+echo " Reminder: add ${IP} to Zerodha Allowed IPs (developers.kite.trade)."
+echo "============================================================"


### PR DESCRIPTION
Idempotent curl|bash installer + plain-language guide. Sets up systemd service on port 8080, generated admin password, browser-only operation. Lightsail static IPv4 satisfies Zerodha allowlist.