### PR TITLE
feat(ops): one-click Live/Shadow toggle + HTTPS for the dashboard

### DIFF
--- a/deploy/LIGHTSAIL_SETUP.md
+++ b/deploy/LIGHTSAIL_SETUP.md
@@ -19,10 +19,9 @@ Your Lightsail static IP: **15.206.3.6** (this is what Zerodha must allowlist.)
 ## STEP 2 — Open the firewall for the dashboard (in Lightsail website)
 
 1. Lightsail → your instance **Ubuntu-2** → **Networking** tab.
-2. Under **IPv4 Firewall**, click **Add rule**:
-   - Application: **Custom**
-   - Protocol: **TCP**
-   - Port: **8080**
+2. Under **IPv4 Firewall**, click **Add rule** and add BOTH:
+   - **HTTPS:** Custom / TCP / Port **443**  (secure dashboard — recommended)
+   - **Dashboard:** Custom / TCP / Port **8080**  (plain fallback)
 3. Save.
 
 ---
@@ -30,8 +29,8 @@ Your Lightsail static IP: **15.206.3.6** (this is what Zerodha must allowlist.)
 ## STEP 3 — One-time install (paste ONCE into the Lightsail terminal)
 
 Open the instance terminal ("Connect using SSH" button) and paste this whole block.
-It installs Python, downloads the bot, sets up the dashboard, and starts it as a
-background service that auto-restarts and survives reboots.
+It installs Python, downloads the bot, sets up the dashboard, adds HTTPS, and starts
+it as a background service that auto-restarts and survives reboots.
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/kundakarlabp/nifty_scalper_bot/main/deploy/lightsail_setup.sh | bash
@@ -43,11 +42,20 @@ When it finishes it prints your dashboard URL and admin password.
 
 ## STEP 4 — Use the dashboard (browser, no terminal ever again)
 
-Open: **http://15.206.3.6:8080/admin**
+Open the **secure** link the script printed: **https://15.206.3.6/admin**
+(A one-time browser warning appears because it is your own server's certificate —
+click **Advanced → Proceed**. Plain fallback: http://15.206.3.6:8080/admin)
 
 - Sign in with the admin password the script printed.
 - Enter your Zerodha API key, API secret, access token, Telegram details. Save.
 - Click **Restart Bot**.
+
+### Turning live trading ON/OFF (one click)
+At the top of the dashboard there is a **Live Trading** banner:
+- **OFF (SHADOW)** = analysing only, no real orders. You start here.
+- Click **Turn ON Live Trading** (it asks you to confirm) to place real orders.
+- Click **Switch to SHADOW** anytime to stop real trading instantly.
+The toggle sets both required settings together and restarts the bot for you.
 
 ### Every morning
 - Generate your fresh Zerodha access token (as you do now).

--- a/deploy/lightsail_setup.sh
+++ b/deploy/lightsail_setup.sh
@@ -87,15 +87,43 @@ sudo systemctl daemon-reload
 sudo systemctl enable --quiet ${SERVICE}
 sudo systemctl restart ${SERVICE}
 
+# --- HTTPS via Caddy reverse proxy (encrypts password/token in transit) ---
+# Caddy serves HTTPS on 443 with a self-signed local certificate and forwards
+# to the bot on 127.0.0.1:$PORT. Your browser will show a one-time "not trusted"
+# warning (expected for an IP-only self-signed cert) — click Advanced -> Proceed.
+echo "==> Installing Caddy for HTTPS..."
+if ! command -v caddy >/dev/null 2>&1; then
+  sudo apt-get install -y -qq debian-keyring debian-archive-keyring apt-transport-https curl
+  curl -fsSL https://dl.cloudsmith.io/public/caddy/stable/gpg.key | sudo gpg --batch --yes --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
+  curl -fsSL https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt | sudo tee /etc/apt/sources.list.d/caddy-stable.list >/dev/null
+  sudo apt-get update -y -qq
+  sudo apt-get install -y -qq caddy
+fi
+
+PUB_IP="$(curl -fsSL https://checkip.amazonaws.com 2>/dev/null || echo '')"
+sudo tee /etc/caddy/Caddyfile >/dev/null <<EOF
+{
+  auto_https disable_redirects
+}
+:443 {
+  tls internal
+  reverse_proxy 127.0.0.1:${PORT}
+}
+EOF
+sudo systemctl restart caddy || echo "   (Caddy restart issue — HTTP on ${PORT} still works)"
+
 IP="$(curl -fsSL https://checkip.amazonaws.com 2>/dev/null || echo 'YOUR_STATIC_IP')"
 echo ""
 echo "============================================================"
 echo " ✅ Setup complete."
-echo " Dashboard:  http://${IP}:${PORT}/admin"
-echo " Password :  ${ADMIN_PW}"
 echo ""
-echo " Next: open the dashboard, enter your Zerodha + Telegram"
-echo " details, Save, then Restart Bot. Update the access token"
-echo " each morning from the dashboard."
+echo " Secure dashboard (recommended):  https://${IP}/admin"
+echo "   (one-time browser warning -> Advanced -> Proceed; it is your own server)"
+echo " Plain dashboard (fallback):       http://${IP}:${PORT}/admin"
+echo " Password:                         ${ADMIN_PW}"
+echo ""
+echo " Firewall: allow TCP 443 (for HTTPS) and TCP ${PORT} in Lightsail Networking."
+echo " Next: open the dashboard, enter Zerodha + Telegram details, Save,"
+echo " check logs look healthy in SHADOW, then use the Live Trading toggle."
 echo " Reminder: add ${IP} to Zerodha Allowed IPs (developers.kite.trade)."
 echo "============================================================"

--- a/src/nifty_scalper_bot/admin_dashboard.py
+++ b/src/nifty_scalper_bot/admin_dashboard.py
@@ -135,6 +135,28 @@ def login(password: str = Form(...)) -> RedirectResponse:
 def dashboard(request: Request) -> HTMLResponse:
     _check_auth(request)
     env = _read_env()
+    # Live-trading status: LIVE only when both flags agree.
+    live_on = env.get("ENABLE_LIVE", "false").strip().lower() in {"1", "true", "yes", "on"} \
+        and env.get("EXECUTION_MODE", "SHADOW").strip().upper() == "LIVE"
+    if live_on:
+        status_html = (
+            '<div class=card style="border-color:#3fb950">'
+            '<h2>Live Trading: <span class=ok>ON</span> 🟢</h2>'
+            '<p style="font-size:13px;color:#9da7b3">The bot will place REAL orders with REAL money. '
+            'Switch to SHADOW to stop placing real orders (it keeps analysing safely).</p>'
+            '<form method=post action="/admin/mode"><input type=hidden name=mode value=shadow>'
+            '<button class=warn type=submit>Switch to SHADOW (stop real trading)</button></form></div>'
+        )
+    else:
+        status_html = (
+            '<div class=card style="border-color:#9e6a03">'
+            '<h2>Live Trading: <span style="color:#d29922">OFF (SHADOW)</span> ⚪</h2>'
+            '<p style="font-size:13px;color:#9da7b3">The bot is analysing but NOT placing real orders. '
+            'Only turn this ON after you have entered credentials and checked the logs look healthy.</p>'
+            '<form method=post action="/admin/mode" onsubmit="return confirm(\'Turn ON live trading with REAL money?\')">'
+            '<input type=hidden name=mode value=live>'
+            '<button type=submit>Turn ON Live Trading (real money)</button></form></div>'
+        )
     rows = ""
     for label, key, is_secret in FIELDS:
         val = env.get(key, "")
@@ -142,6 +164,7 @@ def dashboard(request: Request) -> HTMLResponse:
         rows += f"<label>{label} <span class=badge>{key}</span></label>"
         rows += f'<input name="{key}" value="{shown}" placeholder="(unchanged)" {"type=text" if not is_secret else ""}>'
     body = f"""
+    {status_html}
     <div class=card><h2>Credentials & Settings</h2>
     <p style="font-size:13px;color:#9da7b3">Leave a secret field showing dots to keep it unchanged. Type a new value to replace it. Save, then Restart Bot.</p>
     <form method=post action="/admin/save">{rows}<button type=submit>Save settings</button></form></div>
@@ -158,6 +181,18 @@ def dashboard(request: Request) -> HTMLResponse:
     <form method=get action="/health"><button type=submit>Health</button></form>
     </div></div>"""
     return HTMLResponse(_PAGE.format(body=body))
+
+
+@router.post("/admin/mode")
+def set_mode(request: Request, mode: str = Form(...)) -> RedirectResponse:
+    """One-click Live/Shadow switch. Keeps ENABLE_LIVE and EXECUTION_MODE in sync."""
+    _check_auth(request)
+    if mode.strip().lower() == "live":
+        _write_env({"ENABLE_LIVE": "true", "EXECUTION_MODE": "LIVE"})
+    else:
+        _write_env({"ENABLE_LIVE": "false", "EXECUTION_MODE": "SHADOW"})
+    _restart_service()
+    return RedirectResponse("/admin?mode=1", status_code=303)
 
 
 async def _collect_form(request: Request) -> dict[str, str]:


### PR DESCRIPTION
Adds a prominent Live Trading ON/OFF toggle (syncs ENABLE_LIVE+EXECUTION_MODE, confirm-before-live) and HTTPS via Caddy reverse proxy (tls internal) so credentials are encrypted in transit. Guide updated. 1934 tests pass.