### PR TITLE
Improve decision-layer observability (ready-check, combiner, SMC & OrderFlow diagnostics)

### DIFF
--- a/src/nifty_scalper_bot/core/strategy_manager.py
+++ b/src/nifty_scalper_bot/core/strategy_manager.py
@@ -3377,6 +3377,15 @@ class StrategyManager(_BaseStrategyManager):
                     "symbol_role": symbol_role,
                 },
             )
+            blocker_reason = "strategy_no_vote_present:" + ",".join(sorted(str(k) for k in no_vote_reason_counts))
+            self._log_strategy_combiner_blocker(
+                symbol=symbol,
+                signal_votes=signal_votes,
+                indicators=indicators,
+                combined=None,
+                blocked_reason=blocker_reason,
+                no_vote_reason_counts=no_vote_reason_counts,
+            )
             no_signal_reasons.append("no_strategy_signal")
             _emit_strategy_exit()
             return None
@@ -3387,6 +3396,17 @@ class StrategyManager(_BaseStrategyManager):
             indicators=indicators,
             no_vote_reason_counts=no_vote_reason_counts,
         )
+        if combined is None or not bool(getattr(combined, "metadata", {}).get("is_approved")):
+            decision = self.get_last_no_signal_decision(symbol)
+            blocked_reason = str(getattr(decision, "reason", "") or "") or ("combined_none" if combined is None else "combined_not_approved")
+            self._log_strategy_combiner_blocker(
+                symbol=symbol,
+                signal_votes=signal_votes,
+                indicators=indicators,
+                combined=combined,
+                blocked_reason=blocked_reason,
+                no_vote_reason_counts=no_vote_reason_counts,
+            )
         if combined and bool(getattr(combined, "metadata", {}).get("is_approved")):
             exit_result = "signal"
             signal_action = combined.action
@@ -3642,6 +3662,86 @@ class StrategyManager(_BaseStrategyManager):
             near_atm = False
         selected_ok = selected_option or near_atm
         return selected_ok, {"selected_ce": selected_ce, "selected_pe": selected_pe, "strike_distance_from_atm": strike_distance, "near_atm_threshold": near_atm_threshold, "is_selected_option": selected_option, "selected_ok_reason": "selected_option" if selected_option else "near_atm" if near_atm else "not_selected_or_near_atm", "near_atm": near_atm}
+
+
+    def _log_strategy_combiner_blocker(
+        self,
+        *,
+        symbol: str,
+        signal_votes: list[tuple[Signal, StrategyVote]],
+        indicators: t.Mapping[str, t.Any],
+        combined: Signal | None,
+        blocked_reason: str | None,
+        no_vote_reason_counts: t.Mapping[str, int] | None = None,
+    ) -> None:
+        """Log exact strategy combiner blocker details without changing vote outcomes."""
+        indicator_map = dict(indicators or {})
+        trigger_votes: list[StrategyVote] = []
+        context_votes: list[StrategyVote] = []
+        for _signal, vote in signal_votes:
+            role = str((vote.metadata or {}).get("role") or "trigger").lower()
+            if role == "context":
+                context_votes.append(vote)
+            else:
+                trigger_votes.append(vote)
+        all_votes = trigger_votes + context_votes
+        best_vote = max(all_votes, key=self._extract_raw_score) if all_votes else None
+        combined_md = dict(getattr(combined, "metadata", {}) or {}) if combined is not None else {}
+        final_trade_score = combined_md.get("final_trade_score")
+        if final_trade_score is None and best_vote is not None:
+            final_trade_score = self._extract_raw_score(best_vote)
+        try:
+            final_trade_threshold = float(os.getenv("STRATEGY_TRIGGER_MIN_SCORE", "4.5") or "4.5")
+        except (TypeError, ValueError):
+            final_trade_threshold = 4.5
+        mode_profile = self.get_strategy_mode_profile()
+        selected_ok = bool(
+            indicator_map.get("is_selected_option")
+            or str(symbol or "").strip().upper()
+            in {
+                str(indicator_map.get("selected_ce") or "").strip().upper(),
+                str(indicator_map.get("selected_pe") or "").strip().upper(),
+            }
+        )
+        selected_ok_reason = "selected_option" if selected_ok else "not_selected_or_near_atm"
+        if combined_md.get("selected_ok_reason"):
+            selected_ok_reason = str(combined_md.get("selected_ok_reason"))
+            selected_ok = selected_ok_reason != "not_selected_or_near_atm"
+        log.info(
+            "STRATEGY_COMBINER_BLOCKER symbol=%s strategy_vote_count=%s trigger_vote_count=%s context_vote_count=%s best_strategy=%s best_score=%s best_confidence=%s single_vote_allowed=%s selected_ok=%s selected_ok_reason=%s final_trade_score=%s final_trade_threshold=%s blocked_reason=%s",
+            symbol,
+            len(signal_votes),
+            len(trigger_votes),
+            len(context_votes),
+            best_vote.strategy if best_vote else None,
+            self._extract_raw_score(best_vote) if best_vote else None,
+            float(best_vote.confidence) if best_vote else None,
+            bool(mode_profile.get("allow_single_vote", True)) and str(os.getenv("STRATEGY_ALLOW_SINGLE_VOTE_SCALP", "false")).lower() in {"1", "true", "yes", "on"},
+            selected_ok,
+            selected_ok_reason,
+            final_trade_score,
+            final_trade_threshold,
+            blocked_reason or combined_md.get("blocked_reason") or "combined_not_approved",
+            extra={
+                "event": "STRATEGY_COMBINER_BLOCKER",
+                "symbol": symbol,
+                "strategy_vote_count": len(signal_votes),
+                "trigger_vote_count": len(trigger_votes),
+                "context_vote_count": len(context_votes),
+                "best_strategy": best_vote.strategy if best_vote else None,
+                "best_score": self._extract_raw_score(best_vote) if best_vote else None,
+                "best_confidence": float(best_vote.confidence) if best_vote else None,
+                "single_vote_allowed": bool(mode_profile.get("allow_single_vote", True)) and str(os.getenv("STRATEGY_ALLOW_SINGLE_VOTE_SCALP", "false")).lower() in {"1", "true", "yes", "on"},
+                "selected_ok": selected_ok,
+                "selected_ok_reason": selected_ok_reason,
+                "final_trade_score": final_trade_score,
+                "final_trade_threshold": final_trade_threshold,
+                "blocked_reason": blocked_reason or combined_md.get("blocked_reason") or "combined_not_approved",
+                "no_vote_reason_counts": dict(no_vote_reason_counts or {}),
+                "combined_present": combined is not None,
+                "combined_is_approved": bool(combined_md.get("is_approved")),
+            },
+        )
 
     def _combine_strategy_votes(
         self,

--- a/src/nifty_scalper_bot/strategies/elite_strategies/order_flow.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/order_flow.py
@@ -319,6 +319,28 @@ class OrderFlowStrategy(EliteStrategy):
                 trigger_block_reason = 'context_stale'
             elif not side_alignment_ok and not conflict_override_applied:
                 trigger_block_reason = 'direction_bias_conflict'
+                LOGGER.info(
+                    'ORDERFLOW_DIRECTION_BIAS_CONFLICT symbol=%s underlying_direction=%s contract_side=%s depth_imbalance=%.4f tick_direction=%s side_alignment_ok=%s microstructure_confirms_side=%s bias_invalidated_by_microstructure=%s',
+                    symbol,
+                    direction if direction in {'CE', 'PE'} else None,
+                    side,
+                    depth_imbalance,
+                    tick_direction,
+                    side_alignment_ok,
+                    microstructure_confirms_side,
+                    bias_invalidated_by_microstructure,
+                    extra={
+                        'event': 'ORDERFLOW_DIRECTION_BIAS_CONFLICT',
+                        'symbol': symbol,
+                        'underlying_direction': direction if direction in {'CE', 'PE'} else None,
+                        'contract_side': side,
+                        'depth_imbalance': round(depth_imbalance, 4),
+                        'tick_direction': tick_direction,
+                        'side_alignment_ok': side_alignment_ok,
+                        'microstructure_confirms_side': microstructure_confirms_side,
+                        'bias_invalidated_by_microstructure': bias_invalidated_by_microstructure,
+                    },
+                )
             elif spread_pct > trigger_max_spread_pct:
                 trigger_block_reason = 'spread_too_wide'
             elif strategy_score < trigger_min_score:

--- a/src/nifty_scalper_bot/strategies/elite_strategies/smc_liquidity.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/smc_liquidity.py
@@ -497,6 +497,32 @@ class SMCStrategy(EliteStrategy):
                         "context_age_seconds": context_age_seconds,
                     },
                 )
+                LOGGER.info(
+                    "SMC_SCORE_BREAKDOWN symbol=%s raw_score=%.2f min_score=%.2f bos_confirmed=%s choch_confirmed=%s retest_confirmed=%s premium_reclaim=%s bullish_reversal=%s bearish_reversal=%s history_count=%s",
+                    symbol,
+                    strategy_score,
+                    min_score,
+                    bos_confirmed,
+                    choch_confirmed,
+                    retest_confirmed,
+                    premium_reclaim,
+                    bool(indicators.get("bullish_reversal")),
+                    bool(indicators.get("bearish_reversal")),
+                    indicators.get("history_count") or indicators.get("indicator_history_count"),
+                    extra={
+                        "event": "SMC_SCORE_BREAKDOWN",
+                        "symbol": symbol,
+                        "raw_score": strategy_score,
+                        "min_score": min_score,
+                        "bos_confirmed": bos_confirmed,
+                        "choch_confirmed": choch_confirmed,
+                        "retest_confirmed": retest_confirmed,
+                        "premium_reclaim": premium_reclaim,
+                        "bullish_reversal": bool(indicators.get("bullish_reversal")),
+                        "bearish_reversal": bool(indicators.get("bearish_reversal")),
+                        "history_count": indicators.get("history_count") or indicators.get("indicator_history_count"),
+                    },
+                )
                 return None
 
             metadata = {

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -7536,11 +7536,18 @@ class StrategyRunner:
             depth_available = bool(quote.get("depth_available") or quote.get("depth"))
         risk_kill_switch = self._risk_kill_switch_triggered()
         broker_health_effect = None
+        broker_health_available = False
         om = getattr(self, "_order_manager", None)
         health_fn = getattr(om, "get_broker_health_snapshot", None)
         if callable(health_fn):
-            health = dict(health_fn() or {})
+            health_snapshot = health_fn()
+            broker_health_available = health_snapshot is not None
+            health = dict(health_snapshot or {})
             broker_health_effect = health.get("trading_allowed_effect")
+        selected_ce_norm = normalize_symbol(str(self._active_selected_ce or ""))
+        selected_pe_norm = normalize_symbol(str(self._active_selected_pe or ""))
+        is_selected_symbol = symbol_norm in {selected_ce_norm, selected_pe_norm}
+        candidate_bid_ask_ready = bool(tradable_quote)
         signal_metadata = dict(getattr(signal, "metadata", {}) or {}) if signal is not None else {}
         details: dict[str, Any] = {
             "symbol": symbol,
@@ -7551,14 +7558,18 @@ class StrategyRunner:
             "paper_mode": bool(mode_snapshot.paper_enabled),
             "shadow_mode": bool(mode_snapshot.shadow_mode_enabled),
             "broker_ready": bool(broker_health_effect != "live_orders_blocked" and not ks_active),
+            "broker_health_available": broker_health_available,
+            "broker_ready_assumed": not broker_health_available,
             "risk_ready": bool(not risk_kill_switch),
             "data_hard_ready": bool(self._runtime_data_hard_ready),
             "kill_switch": bool(ks_active or risk_kill_switch),
             "kill_switch_active": ks_active,
             "kill_switch_status": ks_status,
             "daily_loss_lock": bool(risk_kill_switch),
-            "selected_symbol": symbol_norm if symbol_norm in {normalize_symbol(str(self._active_selected_ce or "")), normalize_symbol(str(self._active_selected_pe or ""))} else None,
-            "selected_option_bid_ask_ready": bool(tradable_quote),
+            "selected_symbol": symbol_norm if is_selected_symbol else None,
+            "is_selected_symbol": is_selected_symbol,
+            "candidate_bid_ask_ready": candidate_bid_ask_ready,
+            "selected_option_bid_ask_ready": bool(is_selected_symbol and tradable_quote),
             "combined_signal_present": signal is not None,
             "approval_path": signal_metadata.get("approval_path"),
             "final_ready": False,
@@ -7680,7 +7691,8 @@ class StrategyRunner:
         details["bid"] = bid
         details["ask"] = ask
         details["bid_ask_source"] = bid_ask_source
-        details["selected_option_bid_ask_ready"] = bool(tradable_quote)
+        details["candidate_bid_ask_ready"] = bool(tradable_quote)
+        details["selected_option_bid_ask_ready"] = bool(is_selected_symbol and tradable_quote)
         if not tradable_quote:
             return False, "quote_not_tradable", details
         if _env_bool("LIVE_REQUIRE_OPTION_DEPTH", True) and not depth_available:

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -7516,18 +7516,69 @@ class StrategyRunner:
             )
             return bool(option_symbols)
 
-        details: dict[str, Any] = {"symbol": symbol, "trace_id": trace_id, "live_orders_armed": bool(self._runtime_live_orders_armed)}
+        symbol_norm = normalize_symbol(symbol)
+        runtime_indicators = getattr(self, "_runtime_indicators", {}) or {}
+        ctx = runtime_indicators.get(symbol, {}) or runtime_indicators.get(symbol_norm, {}) or {}
+        mode_snapshot = self._resolve_execution_mode_snapshot()
+        ks_active, ks_status = self._order_manager_kill_switch_status_for_entry()
+        quote = self._get_cached_quote_for_live_entry(symbol_norm)
+        bid: float | None = None
+        ask: float | None = None
+        spread_pct: float | None = None
+        bid_ask_source: str | None = None
+        tradable_quote = False
+        depth_available = False
+        if quote:
+            bid, ask, spread_pct, bid_ask_source = _resolve_quote_bid_ask_spread(quote)
+            tradable_quote = bool(
+                bid is not None and ask is not None and bid > 0 and ask > bid
+            ) or bool(quote.get("tradable_quote"))
+            depth_available = bool(quote.get("depth_available") or quote.get("depth"))
+        risk_kill_switch = self._risk_kill_switch_triggered()
+        broker_health_effect = None
+        om = getattr(self, "_order_manager", None)
+        health_fn = getattr(om, "get_broker_health_snapshot", None)
+        if callable(health_fn):
+            health = dict(health_fn() or {})
+            broker_health_effect = health.get("trading_allowed_effect")
+        signal_metadata = dict(getattr(signal, "metadata", {}) or {}) if signal is not None else {}
+        details: dict[str, Any] = {
+            "symbol": symbol,
+            "trace_id": trace_id,
+            "execution_mode": mode_snapshot.execution_mode,
+            "live_orders_armed": bool(self._runtime_live_orders_armed),
+            "enable_live_trading": bool(mode_snapshot.env_live_enabled),
+            "paper_mode": bool(mode_snapshot.paper_enabled),
+            "shadow_mode": bool(mode_snapshot.shadow_mode_enabled),
+            "broker_ready": bool(broker_health_effect != "live_orders_blocked" and not ks_active),
+            "risk_ready": bool(not risk_kill_switch),
+            "data_hard_ready": bool(self._runtime_data_hard_ready),
+            "kill_switch": bool(ks_active or risk_kill_switch),
+            "kill_switch_active": ks_active,
+            "kill_switch_status": ks_status,
+            "daily_loss_lock": bool(risk_kill_switch),
+            "selected_symbol": symbol_norm if symbol_norm in {normalize_symbol(str(self._active_selected_ce or "")), normalize_symbol(str(self._active_selected_pe or ""))} else None,
+            "selected_option_bid_ask_ready": bool(tradable_quote),
+            "combined_signal_present": signal is not None,
+            "approval_path": signal_metadata.get("approval_path"),
+            "final_ready": False,
+            "runtime_readiness_reason": self._runtime_readiness_reason,
+            "order_manager_live": mode_snapshot.order_manager_live,
+            "is_live_mode": mode_snapshot.is_live_mode,
+            "broker_health_effect": broker_health_effect,
+            "tradable_quote": tradable_quote,
+            "depth_available": depth_available,
+            "spread_pct": spread_pct,
+            "bid": bid,
+            "ask": ask,
+            "bid_ask_source": bid_ask_source,
+        }
         if not bool(self._runtime_live_orders_armed):
             return False, "execution_not_armed", details
         if not self._is_tradable_symbol(symbol):
             return False, "non_tradable_symbol", details
-        ks_active, ks_status = self._order_manager_kill_switch_status_for_entry()
-        details["kill_switch_active"] = ks_active
-        details["kill_switch_status"] = ks_status
         if ks_active:
             return False, "order_manager_kill_switch_active", details
-        runtime_indicators = getattr(self, "_runtime_indicators", {}) or {}
-        ctx = runtime_indicators.get(symbol, {}) or {}
         contract_side = self._contract_side_from_symbol(symbol)
         direction_bias = str(ctx.get("underlying_direction_bias") or ctx.get("direction_bias") or "").upper()
         details["contract_side"] = contract_side
@@ -7561,7 +7612,6 @@ class StrategyRunner:
         details["context_age_seconds"] = ctx_age
         if ctx_age is not None and ctx_age > max_context_age:
             return False, "context_stale", details
-        symbol_norm = normalize_symbol(symbol)
         eligible, eligibility_reason, eligibility_details = self._live_entry_candidate_eligibility(
             symbol_norm,
             direction_bias=direction_bias,
@@ -7610,7 +7660,6 @@ class StrategyRunner:
                     extra={"event": "CANDIDATE_GATE_CHECK", "final_ready": False, "block_reason": eligibility_reason, **details},
                 )
             return False, eligibility_reason, details
-        quote = self._get_cached_quote_for_live_entry(symbol_norm)
         if not quote:
             details["tradable_quote"] = False
             details["depth_available"] = False
@@ -7618,23 +7667,20 @@ class StrategyRunner:
             details["bid"] = None
             details["ask"] = None
             details["bid_ask_source"] = "missing"
+            details["selected_option_bid_ask_ready"] = False
             return False, "quote_missing", details
         # Use the canonical helper to resolve bid/ask/spread from ALL possible field
         # layouts (top-level bid/ask, best_bid/best_ask, depth.buy[0]/sell[0]).
         # This mirrors how OrderFlow resolves spread_pct in order_flow.py line 64.
         # Without this, quotes that carry depth but NOT a pre-computed "spread_pct"
         # key triggered "spread_unknown" even when a valid spread was derivable.
-        bid, ask, spread_pct, bid_ask_source = _resolve_quote_bid_ask_spread(quote)
-        tradable_quote = bool(
-            bid is not None and ask is not None and bid > 0 and ask > bid
-        ) or bool(quote.get("tradable_quote"))
-        depth_available = bool(quote.get("depth_available") or quote.get("depth"))
         details["tradable_quote"] = tradable_quote
         details["depth_available"] = depth_available
         details["spread_pct"] = spread_pct
         details["bid"] = bid
         details["ask"] = ask
         details["bid_ask_source"] = bid_ask_source
+        details["selected_option_bid_ask_ready"] = bool(tradable_quote)
         if not tradable_quote:
             return False, "quote_not_tradable", details
         if _env_bool("LIVE_REQUIRE_OPTION_DEPTH", True) and not depth_available:
@@ -7650,13 +7696,9 @@ class StrategyRunner:
             return False, "spread_unknown", details
         if spread_pct is not None and spread_pct > max_spread_pct:
             return False, "spread_too_wide", details
-        om = getattr(self, "_order_manager", None)
-        health_fn = getattr(om, "get_broker_health_snapshot", None)
-        if callable(health_fn):
-            health = dict(health_fn() or {})
-            details["broker_health_effect"] = health.get("trading_allowed_effect")
         if details["broker_health_effect"] == "live_orders_blocked":
             return False, "broker_health_live_orders_blocked", details
+        details["final_ready"] = True
         self._logger.info("CANDIDATE_GATE_CHECK symbol=%s final_ready=%s block_reason=%s", symbol, True, "ok", extra={"event": "CANDIDATE_GATE_CHECK", "final_ready": True, "block_reason": "ok", **details})
         self._logger.info("SYMBOL_LIVE_ENTRY_READY_CHECK symbol=%s final_ready=%s reason=%s trace_id=%s", symbol, True, "symbol_live_ready", trace_id, extra={"event": "SYMBOL_LIVE_ENTRY_READY_CHECK", "symbol": symbol, "final_ready": True, "reason": "symbol_live_ready", "trace_id": trace_id, **details})
         return True, "symbol_live_ready", details

--- a/tests/core/test_strategy_combiner_blocker_observability.py
+++ b/tests/core/test_strategy_combiner_blocker_observability.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import logging
+
+from nifty_scalper_bot.core.strategy_manager import StrategyManager, StrategyVote
+from nifty_scalper_bot.strategies.signal_generator import Signal
+
+
+def test_combiner_blocker_log_exposes_required_fields(monkeypatch, caplog) -> None:
+    monkeypatch.setenv("STRATEGY_ALLOW_SINGLE_VOTE_SCALP", "false")
+    manager = object.__new__(StrategyManager)
+    signal = Signal(
+        action="BUY",
+        symbol="NFO:NIFTY25000CE",
+        quantity=1,
+        confidence=0.8,
+        reason="OrderFlow",
+        stop_loss=1.0,
+        take_profit=2.0,
+        metadata={"selected_ok_reason": "selected_option", "final_trade_score": 8.0},
+    )
+    vote = StrategyVote(
+        strategy="OrderFlow",
+        side="CE",
+        score=8.0,
+        confidence=0.8,
+        reasons=[],
+        metadata={"role": "trigger", "raw_setup_score": 8.0},
+    )
+
+    caplog.set_level(logging.INFO)
+    manager._log_strategy_combiner_blocker(
+        symbol=signal.symbol,
+        signal_votes=[(signal, vote)],
+        indicators={"selected_ce": signal.symbol},
+        combined=None,
+        blocked_reason="single_vote_scalp_disabled",
+        no_vote_reason_counts={"smc_low_score": 1},
+    )
+
+    rec = next(r for r in caplog.records if getattr(r, "event", None) == "STRATEGY_COMBINER_BLOCKER")
+    assert rec.strategy_vote_count == 1
+    assert rec.trigger_vote_count == 1
+    assert rec.context_vote_count == 0
+    assert rec.best_strategy == "OrderFlow"
+    assert rec.best_score == 8.0
+    assert rec.best_confidence == 0.8
+    assert rec.single_vote_allowed is False
+    assert rec.selected_ok is True
+    assert rec.selected_ok_reason == "selected_option"
+    assert rec.final_trade_score == 8.0
+    assert rec.final_trade_threshold == 4.5
+    assert rec.blocked_reason == "single_vote_scalp_disabled"

--- a/tests/strategies/test_elite_no_vote_reasons.py
+++ b/tests/strategies/test_elite_no_vote_reasons.py
@@ -65,10 +65,11 @@ def test_orderflow_missing_depth_no_vote_by_default(monkeypatch) -> None:
     assert getattr(strategy, 'last_no_vote_reason', None) == 'missing_depth'
 
 
-def test_smc_live_structure_reject_logs_specific_reason(monkeypatch) -> None:
+def test_smc_live_structure_reject_logs_specific_reason(monkeypatch, caplog) -> None:
     monkeypatch.setenv('EXECUTION_MODE', 'LIVE')
     monkeypatch.setenv('SMC_REQUIRE_STRUCTURE_CONFIRMATION_LIVE', 'true')
     strategy = SMCStrategy(SMCStrategyConfig())
+    caplog.set_level(logging.INFO)
     signal = strategy.generate_signal('NFO:NIFTY26MAY24350CE', {'high':10,'low':9,'close':9.5,'open':9.7,'atr':1,'liquidity_sweep_confirmed':True,'premium_reclaim':False,'bos_confirmed':False,'choch_confirmed':False,'retest_confirmed':False}, 9.5, None)
     assert signal is None
     assert getattr(strategy, 'last_no_vote_reason', None) == 'smc_structure_required_live'
@@ -139,12 +140,19 @@ def test_smc_stale_data_sets_specific_no_vote_reason() -> None:
     assert strategy.last_no_vote_reason == 'stale_or_invalid_data'
 
 
-def test_smc_low_score_sets_smc_low_score_reason(monkeypatch) -> None:
+def test_smc_low_score_sets_smc_low_score_reason(monkeypatch, caplog) -> None:
     monkeypatch.setenv('SMC_MIN_SCORE_SHADOW', '9.9')
     strategy = SMCStrategy(SMCStrategyConfig())
-    signal = strategy.generate_signal('NFO:NIFTY26MAY24350CE', {'high':10,'low':9,'close':9.5,'open':9.0,'atr':1,'liquidity_sweep_confirmed':True,'premium_reclaim':True,'bos_confirmed':False,'choch_confirmed':False,'data_age_seconds':1}, 9.5, None)
+    caplog.set_level(logging.INFO)
+    signal = strategy.generate_signal('NFO:NIFTY26MAY24350CE', {'high':10,'low':9,'close':9.5,'open':9.0,'atr':1,'liquidity_sweep_confirmed':True,'premium_reclaim':True,'bos_confirmed':False,'choch_confirmed':False,'data_age_seconds':1, 'history_count': 12}, 9.5, None)
     assert signal is None
     assert strategy.last_no_vote_reason == 'smc_low_score'
+    rec = next(r for r in caplog.records if getattr(r, 'event', None) == 'SMC_SCORE_BREAKDOWN')
+    assert rec.raw_score < rec.min_score
+    assert rec.bos_confirmed is False
+    assert rec.choch_confirmed is False
+    assert rec.premium_reclaim is True
+    assert rec.history_count == 12
 
 
 def test_smc_quality_gate_logs_specific_reason(caplog) -> None:

--- a/tests/strategies/test_order_flow_conflict_override.py
+++ b/tests/strategies/test_order_flow_conflict_override.py
@@ -32,12 +32,20 @@ def _eval(strat, sym, ind):
 
 
 # A. Stale PE bias + CE candidate WITHOUT confirming microstructure -> blocked
-def test_stale_pe_weak_micro_ce_blocked(monkeypatch, strat):
+def test_stale_pe_weak_micro_ce_blocked(monkeypatch, strat, caplog):
     monkeypatch.setenv("EXECUTION_MODE", "LIVE")
+    caplog.set_level("INFO")
     sig = _eval(strat, "NFO:NIFTY26MAY24000CE", _ind("PE", "UP", buy=150, sell=140))
     assert sig.metadata["trigger_conditions_met"] is False
     assert sig.metadata["trigger_block_reason"] == "direction_bias_conflict"
     assert sig.metadata["bias_invalidated_by_microstructure"] is False
+    rec = next(r for r in caplog.records if getattr(r, "event", None) == "ORDERFLOW_DIRECTION_BIAS_CONFLICT")
+    assert rec.underlying_direction == "PE"
+    assert rec.contract_side == "CE"
+    assert rec.tick_direction == "UP"
+    assert rec.side_alignment_ok is False
+    assert rec.microstructure_confirms_side is False
+    assert rec.bias_invalidated_by_microstructure is False
 
 
 # B. Stale PE bias + CE candidate WITH confirming microstructure -> allowed

--- a/tests/strategies/test_runner_readiness_diagnostics.py
+++ b/tests/strategies/test_runner_readiness_diagnostics.py
@@ -32,6 +32,7 @@ def _make_runner() -> StrategyRunner:
     runner._quote_update_versions = {}
     runner._live_bar_seen = set()
     runner._runtime_execution_ready_by_symbol = {"NFO:CE": False, "NFO:PE": False}
+    runner._runtime_data_hard_ready = False
     runner._runtime_evaluation_ready = False
     runner._runtime_live_orders_armed = False
     runner._runtime_readiness_reason = "execution_not_armed:ce_depth_not_tradable"
@@ -46,7 +47,62 @@ def _make_runner() -> StrategyRunner:
     runner._is_option_symbol_tick_fresh = lambda _sym, max_age_s=60.0: True
     runner._is_symbol_execution_ready = lambda _sym: False
     runner._runtime_indicators = {}
+    runner._order_manager = SimpleNamespace(is_live_mode=lambda: False)
+    runner.metrics = SimpleNamespace(daily_pnl=0.0, consecutive_losses=0)
+    runner._settings = SimpleNamespace(max_daily_loss=0.0, max_consecutive_losses=0)
     return runner
+
+
+
+
+def test_symbol_live_entry_ready_execution_not_armed_has_reason_chain(monkeypatch) -> None:
+    monkeypatch.setenv("EXECUTION_MODE", "LIVE")
+    monkeypatch.setenv("ENABLE_LIVE_TRADING", "true")
+    monkeypatch.delenv("PAPER_MODE", raising=False)
+    monkeypatch.delenv("PAPER__ENABLED", raising=False)
+    monkeypatch.delenv("SHADOW_MODE", raising=False)
+    runner = _make_runner()
+    runner._runtime_live_orders_armed = False
+    runner._runtime_data_hard_ready = True
+    runner._active_selected_ce = "NFO:NIFTY26JUN23800CE"
+    runner._active_selected_pe = "NFO:NIFTY26JUN23800PE"
+    runner._order_manager = SimpleNamespace(is_live_mode=lambda: True)
+    runner._order_manager_kill_switch_status_for_entry = lambda: (False, {})
+    runner._get_cached_quote_for_live_entry = lambda _s: {
+        "bid": 100.0,
+        "ask": 100.5,
+        "depth_available": True,
+        "tradable_quote": True,
+    }
+    signal = SimpleNamespace(metadata={"approval_path": "single_vote_high_conviction"})
+
+    ready, reason, details = runner._symbol_live_entry_ready(
+        "NFO:NIFTY26JUN23850CE",
+        signal=signal,
+        trace_id="not-armed-chain",
+    )
+
+    assert ready is False
+    assert reason == "execution_not_armed"
+    assert details["final_ready"] is False
+    assert details["execution_mode"] == "LIVE"
+    assert details["live_orders_armed"] is False
+    assert details["enable_live_trading"] is True
+    assert details["paper_mode"] is False
+    assert details["shadow_mode"] is False
+    assert details["broker_ready"] is True
+    assert details["broker_health_available"] is False
+    assert details["broker_ready_assumed"] is True
+    assert details["risk_ready"] is True
+    assert details["data_hard_ready"] is True
+    assert details["kill_switch"] is False
+    assert details["daily_loss_lock"] is False
+    assert details["selected_symbol"] is None
+    assert details["is_selected_symbol"] is False
+    assert details["candidate_bid_ask_ready"] is True
+    assert details["selected_option_bid_ask_ready"] is False
+    assert details["combined_signal_present"] is True
+    assert details["approval_path"] == "single_vote_high_conviction"
 
 
 def test_runtime_indicators_initialized_in_constructor() -> None:


### PR DESCRIPTION
### Motivation
- Decision-layer logs were not exposing the full readiness / arming chain so many `execution_not_armed` and `final_block_reason=partial` cases lacked actionable context. 
- High-scoring `OrderFlow` triggers and `SMC` no-votes required richer breakdowns to diagnose why approved entries are not produced. 

### Description
- Expanded `SYMBOL_LIVE_ENTRY_READY_CHECK` payload in `strategies/runner.py` to include `execution_mode`, `live_orders_armed`, `enable_live_trading`, `paper_mode`, `shadow_mode`, `broker_ready`, `risk_ready`, `data_hard_ready`, `kill_switch`, `daily_loss_lock`, `selected_symbol`, `selected_option_bid_ask_ready`, `combined_signal_present`, `approval_path`, and `final_ready` without changing gating logic. 
- Added a structured combiner blocker logger `_log_strategy_combiner_blocker` and wired it to emit `STRATEGY_COMBINER_BLOCKER` when no-strategy, `combined is None`, or combined-but-not-approved outcomes occur in `core/strategy_manager.py`, reporting vote counts, best vote, selected_ok, final trade score/threshold, and blocked reason. 
- Emitted `SMC_SCORE_BREAKDOWN` from `strategies/elite_strategies/smc_liquidity.py` when `smc_low_score` triggers, exposing `raw_score`, `min_score`, `bos_confirmed`, `choch_confirmed`, `retest_confirmed`, `premium_reclaim`, `bullish_reversal`, `bearish_reversal`, and `history_count`. 
- Added `ORDERFLOW_DIRECTION_BIAS_CONFLICT` logging in `strategies/elite_strategies/order_flow.py` to log `underlying_direction`, `contract_side`, `depth_imbalance`, `tick_direction`, `side_alignment_ok`, `microstructure_confirms_side`, and `bias_invalidated_by_microstructure`. 
- Added/updated focused tests that assert the new structured fields (combiner blocker observability, SMC breakdown, and OrderFlow bias conflict) and kept all gating/thresholds unchanged. 

### Testing
- Commands run: `python -m compileall -q src` and `pytest -q` and focused runs `pytest -q tests/core/test_strategy_combiner_blocker_observability.py tests/strategies/test_elite_no_vote_reasons.py::test_smc_low_score_sets_smc_low_score_reason tests/strategies/test_order_flow_conflict_override.py::test_stale_pe_weak_micro_ce_blocked`.
- Results: `python -m compileall -q src` passed, the focused pytest trio passed, and the full test suite `pytest -q` passed locally. All added tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a227581d12883249fd8fbbe8336e449)