### PR TITLE
Fix live-entry broker-health gate

### DIFF
--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -7347,6 +7347,109 @@ class StrategyRunner:
         except Exception as exc:
             return True, {"active": True, "kill_reason": "kill_switch_status_check_failed", "last_exception_type": type(exc).__name__, "last_exception_message": str(exc)}
 
+
+    def _resolve_order_manager_health_for_entry(self) -> tuple[bool, str, dict[str, Any]]:
+        """Resolve broker/order-manager health for live entry without blocking on unknown health APIs."""
+        om = getattr(self, "_order_manager", None)
+        details: dict[str, Any] = {
+            "order_manager_present": om is not None,
+            "order_manager_live_mode": None,
+            "order_manager_kill_switch_active": False,
+            "broker_health_available": False,
+            "broker_health_effect": None,
+            "broker_health_block_reason": None,
+            "broker_ready": False,
+            "broker_ready_assumed": False,
+            "last_broker_error": None,
+            "last_order_error": None,
+        }
+        if om is None:
+            details["broker_health_block_reason"] = "order_manager_missing"
+            return False, "order_manager_missing", details
+
+        live_mode: bool | None = None
+        live_fn = getattr(om, "is_live_mode", None)
+        if callable(live_fn):
+            try:
+                live_mode = bool(live_fn())
+            except Exception as exc:
+                live_mode = False
+                details["order_manager_live_mode_error_type"] = type(exc).__name__
+                details["order_manager_live_mode_error"] = str(exc)
+        elif isinstance(live_fn, bool):
+            live_mode = bool(live_fn)
+        details["order_manager_live_mode"] = live_mode
+        if live_mode is False:
+            details["broker_health_block_reason"] = "order_manager_not_live"
+            return False, "order_manager_not_live", details
+
+        ks_active, ks_status = self._order_manager_kill_switch_status_for_entry()
+        details["order_manager_kill_switch_active"] = bool(ks_active)
+        details["kill_switch_status"] = ks_status
+        if ks_active:
+            details["broker_health_block_reason"] = "order_manager_kill_switch_active"
+            return False, "order_manager_kill_switch_active", details
+
+        health_fn = getattr(om, "get_broker_health_snapshot", None)
+        health_source = "get_broker_health_snapshot"
+        if not callable(health_fn):
+            health_fn = getattr(om, "get_health", None)
+            health_source = "get_health"
+        if not callable(health_fn):
+            health_attr = getattr(om, "health", None)
+            if callable(health_attr):
+                health_fn = health_attr
+                health_source = "health"
+            elif isinstance(health_attr, Mapping):
+                health_fn = lambda: health_attr
+                health_source = "health"
+        if not callable(health_fn):
+            details["broker_ready"] = True
+            details["broker_ready_assumed"] = True
+            return True, "broker_health_unknown_assumed_ready", details
+
+        try:
+            raw_health = health_fn()
+        except Exception as exc:
+            details["broker_health_source"] = health_source
+            details["broker_health_error_type"] = type(exc).__name__
+            details["broker_health_error"] = str(exc)
+            details["broker_ready"] = True
+            details["broker_ready_assumed"] = True
+            return True, "broker_health_unknown_assumed_ready", details
+        if not isinstance(raw_health, Mapping):
+            details["broker_health_source"] = health_source
+            details["broker_ready"] = True
+            details["broker_ready_assumed"] = True
+            return True, "broker_health_unknown_assumed_ready", details
+
+        health = dict(raw_health)
+        details["broker_health_source"] = health_source
+        details["broker_health_available"] = True
+        effect = health.get("trading_allowed_effect") or health.get("effect")
+        details["broker_health_effect"] = effect
+        details["broker_health_ready"] = health.get("ready")
+        details["broker_order_api_ready"] = health.get("order_api_ready", health.get("order_api_available"))
+        details["broker_connected"] = health.get("broker_connected")
+        details["last_broker_error"] = health.get("last_broker_error") or health.get("last_margin_error")
+        details["last_order_error"] = health.get("last_order_error") or health.get("last_order_api_error")
+        details["last_order_error_type"] = health.get("last_order_error_type") or health.get("last_order_api_error_type")
+        if effect == "live_orders_blocked":
+            details["broker_health_block_reason"] = "trading_allowed_effect_live_orders_blocked"
+            return False, "broker_health_live_orders_blocked", details
+        for key, reason in (
+            ("ready", "broker_ready_false"),
+            ("order_api_ready", "order_api_ready_false"),
+            ("order_api_available", "order_api_available_false"),
+            ("broker_connected", "broker_connected_false"),
+        ):
+            if key in health and health.get(key) is False:
+                details["broker_health_block_reason"] = reason
+                return False, "broker_health_live_orders_blocked", details
+        details["broker_ready"] = True
+        details["broker_ready_assumed"] = False
+        return True, "broker_health_ready", details
+
     def _strategy_decision_is_current(self, decision: Any, *, symbol: str, trace_id: str | None, max_age_s: float = 3.0) -> bool:
         if decision is None:
             return False
@@ -7508,12 +7611,28 @@ class StrategyRunner:
             selected_ce = next((normalize_symbol(str(s.get("symbol") or "")) for s in snapshots if str(s.get("symbol") or "").upper().endswith("CE")), None)
             selected_pe = next((normalize_symbol(str(s.get("symbol") or "")) for s in snapshots if str(s.get("symbol") or "").upper().endswith("PE")), None)
             option_symbols = [normalize_symbol(str(s.get("symbol") or "")) for s in snapshots if s.get("symbol")]
+            token_updates: dict[str, int] = {}
+            for snap in snapshots:
+                snap_symbol = normalize_symbol(str(snap.get("symbol") or ""))
+                raw_token = snap.get("instrument_token") or snap.get("token")
+                if not snap_symbol or raw_token in (None, ""):
+                    continue
+                try:
+                    token_updates[snap_symbol] = int(raw_token)
+                except (TypeError, ValueError):
+                    continue
             self.set_active_option_context(
                 selected_ce=selected_ce,
                 selected_pe=selected_pe,
                 atm_strike=int(atm_reference),
                 option_symbols=option_symbols,
             )
+            if token_updates:
+                existing_tokens = getattr(self, "_active_basket_token_by_symbol", {}) or {}
+                if isinstance(existing_tokens, Mapping):
+                    merged_tokens = {normalize_symbol(str(k)): int(v) for k, v in dict(existing_tokens).items() if k and v not in (None, "")}
+                    merged_tokens.update(token_updates)
+                    self._active_basket_token_by_symbol = merged_tokens
             return bool(option_symbols)
 
         symbol_norm = normalize_symbol(symbol)
@@ -7535,15 +7654,20 @@ class StrategyRunner:
             ) or bool(quote.get("tradable_quote"))
             depth_available = bool(quote.get("depth_available") or quote.get("depth"))
         risk_kill_switch = self._risk_kill_switch_triggered()
-        broker_health_effect = None
-        broker_health_available = False
-        om = getattr(self, "_order_manager", None)
-        health_fn = getattr(om, "get_broker_health_snapshot", None)
-        if callable(health_fn):
-            health_snapshot = health_fn()
-            broker_health_available = health_snapshot is not None
-            health = dict(health_snapshot or {})
-            broker_health_effect = health.get("trading_allowed_effect")
+        broker_health_allowed = True
+        broker_health_reason = "broker_health_not_checked"
+        broker_health_details: dict[str, Any] = {
+            "order_manager_present": getattr(self, "_order_manager", None) is not None,
+            "order_manager_live_mode": mode_snapshot.order_manager_live,
+            "order_manager_kill_switch_active": False,
+            "broker_health_available": False,
+            "broker_health_effect": None,
+            "broker_ready": True,
+            "broker_ready_assumed": True,
+            "last_broker_error": None,
+            "last_order_error": None,
+            "broker_health_block_reason": None,
+        }
         selected_ce_norm = normalize_symbol(str(self._active_selected_ce or ""))
         selected_pe_norm = normalize_symbol(str(self._active_selected_pe or ""))
         is_selected_symbol = symbol_norm in {selected_ce_norm, selected_pe_norm}
@@ -7557,9 +7681,9 @@ class StrategyRunner:
             "enable_live_trading": bool(mode_snapshot.env_live_enabled),
             "paper_mode": bool(mode_snapshot.paper_enabled),
             "shadow_mode": bool(mode_snapshot.shadow_mode_enabled),
-            "broker_ready": bool(broker_health_effect != "live_orders_blocked" and not ks_active),
-            "broker_health_available": broker_health_available,
-            "broker_ready_assumed": not broker_health_available,
+            "broker_ready": bool(broker_health_details.get("broker_ready", True) and not ks_active),
+            "broker_health_available": bool(broker_health_details.get("broker_health_available", False)),
+            "broker_ready_assumed": bool(broker_health_details.get("broker_ready_assumed", True)),
             "risk_ready": bool(not risk_kill_switch),
             "data_hard_ready": bool(self._runtime_data_hard_ready),
             "kill_switch": bool(ks_active or risk_kill_switch),
@@ -7574,9 +7698,22 @@ class StrategyRunner:
             "approval_path": signal_metadata.get("approval_path"),
             "final_ready": False,
             "runtime_readiness_reason": self._runtime_readiness_reason,
+            "runtime_data_hard_ready": bool(self._runtime_data_hard_ready),
+            "runtime_evaluation_ready": bool(self._runtime_evaluation_ready),
             "order_manager_live": mode_snapshot.order_manager_live,
+            "order_manager_present": broker_health_details.get("order_manager_present"),
+            "order_manager_live_mode": broker_health_details.get("order_manager_live_mode"),
+            "order_manager_kill_switch_active": broker_health_details.get("order_manager_kill_switch_active"),
             "is_live_mode": mode_snapshot.is_live_mode,
-            "broker_health_effect": broker_health_effect,
+            "broker_health_effect": broker_health_details.get("broker_health_effect"),
+            "broker_health_block_reason": broker_health_details.get("broker_health_block_reason"),
+            "last_broker_error": broker_health_details.get("last_broker_error"),
+            "last_order_error": broker_health_details.get("last_order_error"),
+            "candidate_quote_ready": bool(tradable_quote),
+            "candidate_history_ready": False,
+            "candidate_token_valid": False,
+            "candidate_orderable": False,
+            "candidate_lot_size": 0,
             "tradable_quote": tradable_quote,
             "depth_available": depth_available,
             "spread_pct": spread_pct,
@@ -7584,12 +7721,25 @@ class StrategyRunner:
             "ask": ask,
             "bid_ask_source": bid_ask_source,
         }
+
+        def _finish(final_ready: bool, reason: str) -> tuple[bool, str, dict[str, Any]]:
+            details["final_ready"] = bool(final_ready)
+            self._logger.info(
+                "SYMBOL_LIVE_ENTRY_READY_CHECK symbol=%s final_ready=%s reason=%s trace_id=%s",
+                symbol,
+                bool(final_ready),
+                reason,
+                trace_id,
+                extra={"event": "SYMBOL_LIVE_ENTRY_READY_CHECK", "symbol": symbol, "final_ready": bool(final_ready), "reason": reason, "trace_id": trace_id, **details},
+            )
+            return final_ready, reason, details
+
         if not bool(self._runtime_live_orders_armed):
-            return False, "execution_not_armed", details
+            return _finish(False, "execution_not_armed")
         if not self._is_tradable_symbol(symbol):
-            return False, "non_tradable_symbol", details
+            return _finish(False, "non_tradable_symbol")
         if ks_active:
-            return False, "order_manager_kill_switch_active", details
+            return _finish(False, "order_manager_kill_switch_active")
         contract_side = self._contract_side_from_symbol(symbol)
         direction_bias = str(ctx.get("underlying_direction_bias") or ctx.get("direction_bias") or "").upper()
         details["contract_side"] = contract_side
@@ -7606,23 +7756,24 @@ class StrategyRunner:
                 or meta.get("bias_invalidated_by_microstructure")
             )
             if not orderflow_confirmed:
-                return False, "context_direction_conflict", details
+                return _finish(False, "context_direction_conflict")
             details["context_direction_conflict_overridden"] = True
         required_bars = max(self._required_bars_for_symbol(symbol), safe_positive_int_env("OPTION_EXECUTION_MIN_BARS", 5, minimum=1))
         history_count = len(self._indicator_engine.get_history(symbol) or [])
         details["history_count"] = history_count
         details["required_bars"] = required_bars
+        details["candidate_history_ready"] = history_count >= required_bars
         if history_count < required_bars:
-            return False, "insufficient_indicator_bar_count", details
+            return _finish(False, "insufficient_indicator_bar_count")
         quote_fresh = self._is_option_symbol_tick_fresh(symbol, max_age_s=60.0)
         details["quote_fresh"] = quote_fresh
         if not quote_fresh:
-            return False, "option_tick_stale", details
+            return _finish(False, "option_tick_stale")
         max_context_age = safe_positive_float_env("MAX_CONTEXT_AGE_SECONDS", 5.0, minimum=0.1)
         ctx_age = _extract_float(ctx, "context_age_seconds")
         details["context_age_seconds"] = ctx_age
         if ctx_age is not None and ctx_age > max_context_age:
-            return False, "context_stale", details
+            return _finish(False, "context_stale")
         eligible, eligibility_reason, eligibility_details = self._live_entry_candidate_eligibility(
             symbol_norm,
             direction_bias=direction_bias,
@@ -7670,7 +7821,41 @@ class StrategyRunner:
                     eligibility_reason,
                     extra={"event": "CANDIDATE_GATE_CHECK", "final_ready": False, "block_reason": eligibility_reason, **details},
                 )
-            return False, eligibility_reason, details
+            return _finish(False, eligibility_reason)
+
+        token_map_raw = getattr(self, "_active_basket_token_by_symbol", {}) or {}
+        token_map = {normalize_symbol(str(k)): v for k, v in dict(token_map_raw).items()} if isinstance(token_map_raw, Mapping) else {}
+        candidate_token = token_map.get(symbol_norm) or token_map.get(symbol_norm.split(":", 1)[-1])
+        try:
+            candidate_token_valid = int(candidate_token or 0) > 0
+        except (TypeError, ValueError):
+            candidate_token_valid = False
+        candidate_lot_size = 0
+        om_for_lot = getattr(self, "_order_manager", None)
+        lot_fn = getattr(om_for_lot, "resolve_lot_size", None)
+        if callable(lot_fn):
+            for lot_key in (symbol, symbol_norm, symbol_norm.split(":", 1)[-1]):
+                try:
+                    candidate_lot_size = int(lot_fn(lot_key) or 0)
+                except Exception:
+                    candidate_lot_size = 0
+                if candidate_lot_size > 0:
+                    break
+        if candidate_lot_size <= 0:
+            try:
+                candidate_lot_size = int(signal_metadata.get("lot_size") or 0)
+            except (TypeError, ValueError):
+                candidate_lot_size = 0
+        candidate_orderable = bool(candidate_token_valid and candidate_lot_size > 0)
+        details["candidate_token"] = candidate_token
+        details["candidate_token_valid"] = candidate_token_valid
+        details["candidate_lot_size"] = candidate_lot_size
+        details["candidate_orderable"] = candidate_orderable
+        if not is_selected_symbol:
+            if not candidate_token_valid:
+                return _finish(False, "option_token_missing")
+            if not candidate_orderable:
+                return _finish(False, "lot_size_unresolved")
         if not quote:
             details["tradable_quote"] = False
             details["depth_available"] = False
@@ -7679,7 +7864,7 @@ class StrategyRunner:
             details["ask"] = None
             details["bid_ask_source"] = "missing"
             details["selected_option_bid_ask_ready"] = False
-            return False, "quote_missing", details
+            return _finish(False, "quote_missing")
         # Use the canonical helper to resolve bid/ask/spread from ALL possible field
         # layouts (top-level bid/ask, best_bid/best_ask, depth.buy[0]/sell[0]).
         # This mirrors how OrderFlow resolves spread_pct in order_flow.py line 64.
@@ -7694,26 +7879,30 @@ class StrategyRunner:
         details["candidate_bid_ask_ready"] = bool(tradable_quote)
         details["selected_option_bid_ask_ready"] = bool(is_selected_symbol and tradable_quote)
         if not tradable_quote:
-            return False, "quote_not_tradable", details
+            return _finish(False, "quote_not_tradable")
         if _env_bool("LIVE_REQUIRE_OPTION_DEPTH", True) and not depth_available:
-            return False, "quote_depth_unavailable", details
+            return _finish(False, "quote_depth_unavailable")
         max_spread_pct = safe_positive_float_env("LIVE_MAX_SPREAD_PCT", 0.75, minimum=0.01)
         require_spread = _env_bool("LIVE_REQUIRE_SPREAD_PCT", True)
         if require_spread and spread_pct is None:
             # bid/ask were resolved but spread couldn't be derived — report precise reason
             if bid is None or ask is None:
-                return False, "bid_ask_missing", details
+                return _finish(False, "bid_ask_missing")
             if bid <= 0 or ask <= 0:
-                return False, "invalid_bid_ask", details
-            return False, "spread_unknown", details
+                return _finish(False, "invalid_bid_ask")
+            return _finish(False, "spread_unknown")
         if spread_pct is not None and spread_pct > max_spread_pct:
-            return False, "spread_too_wide", details
-        if details["broker_health_effect"] == "live_orders_blocked":
-            return False, "broker_health_live_orders_blocked", details
+            return _finish(False, "spread_too_wide")
+        broker_health_allowed, broker_health_reason, broker_health_details = self._resolve_order_manager_health_for_entry()
+        details.update(broker_health_details)
+        details["broker_ready"] = bool(broker_health_details.get("broker_ready", False))
+        details["broker_ready_assumed"] = bool(broker_health_details.get("broker_ready_assumed", False))
+        if not broker_health_allowed:
+            return _finish(False, broker_health_reason)
+        details["broker_health_reason"] = broker_health_reason
         details["final_ready"] = True
         self._logger.info("CANDIDATE_GATE_CHECK symbol=%s final_ready=%s block_reason=%s", symbol, True, "ok", extra={"event": "CANDIDATE_GATE_CHECK", "final_ready": True, "block_reason": "ok", **details})
-        self._logger.info("SYMBOL_LIVE_ENTRY_READY_CHECK symbol=%s final_ready=%s reason=%s trace_id=%s", symbol, True, "symbol_live_ready", trace_id, extra={"event": "SYMBOL_LIVE_ENTRY_READY_CHECK", "symbol": symbol, "final_ready": True, "reason": "symbol_live_ready", "trace_id": trace_id, **details})
-        return True, "symbol_live_ready", details
+        return _finish(True, "symbol_live_ready")
 
     def _classify_no_trade_decision(
         self,

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -7354,6 +7354,7 @@ class StrategyRunner:
         details: dict[str, Any] = {
             "order_manager_present": om is not None,
             "order_manager_live_mode": None,
+            "order_manager_live_mode_unknown": False,
             "order_manager_kill_switch_active": False,
             "broker_health_available": False,
             "broker_health_effect": None,
@@ -7369,16 +7370,23 @@ class StrategyRunner:
 
         live_mode: bool | None = None
         live_fn = getattr(om, "is_live_mode", None)
+        live_mode_check_failed = False
         if callable(live_fn):
             try:
                 live_mode = bool(live_fn())
             except Exception as exc:
-                live_mode = False
+                live_mode_check_failed = True
+                details["order_manager_live_mode_unknown"] = True
                 details["order_manager_live_mode_error_type"] = type(exc).__name__
                 details["order_manager_live_mode_error"] = str(exc)
         elif isinstance(live_fn, bool):
             live_mode = bool(live_fn)
+        else:
+            details["order_manager_live_mode_unknown"] = True
         details["order_manager_live_mode"] = live_mode
+        if live_mode_check_failed and str(os.getenv("EXECUTION_MODE", "")).strip().upper() == "LIVE":
+            details["broker_health_block_reason"] = "order_manager_not_live"
+            return False, "order_manager_not_live", details
         if live_mode is False:
             details["broker_health_block_reason"] = "order_manager_not_live"
             return False, "order_manager_not_live", details
@@ -7659,6 +7667,7 @@ class StrategyRunner:
         broker_health_details: dict[str, Any] = {
             "order_manager_present": getattr(self, "_order_manager", None) is not None,
             "order_manager_live_mode": mode_snapshot.order_manager_live,
+            "order_manager_live_mode_unknown": mode_snapshot.order_manager_live is None,
             "order_manager_kill_switch_active": False,
             "broker_health_available": False,
             "broker_health_effect": None,
@@ -7703,6 +7712,7 @@ class StrategyRunner:
             "order_manager_live": mode_snapshot.order_manager_live,
             "order_manager_present": broker_health_details.get("order_manager_present"),
             "order_manager_live_mode": broker_health_details.get("order_manager_live_mode"),
+            "order_manager_live_mode_unknown": broker_health_details.get("order_manager_live_mode_unknown"),
             "order_manager_kill_switch_active": broker_health_details.get("order_manager_kill_switch_active"),
             "is_live_mode": mode_snapshot.is_live_mode,
             "broker_health_effect": broker_health_details.get("broker_health_effect"),
@@ -7851,11 +7861,10 @@ class StrategyRunner:
         details["candidate_token_valid"] = candidate_token_valid
         details["candidate_lot_size"] = candidate_lot_size
         details["candidate_orderable"] = candidate_orderable
-        if not is_selected_symbol:
-            if not candidate_token_valid:
-                return _finish(False, "option_token_missing")
-            if not candidate_orderable:
-                return _finish(False, "lot_size_unresolved")
+        if not candidate_token_valid:
+            return _finish(False, "option_token_missing")
+        if not candidate_orderable:
+            return _finish(False, "lot_size_unresolved")
         if not quote:
             details["tradable_quote"] = False
             details["depth_available"] = False

--- a/tests/strategies/test_runner_live_path_guards.py
+++ b/tests/strategies/test_runner_live_path_guards.py
@@ -430,6 +430,68 @@ def test_selected_only_mode_marks_non_selected_active_basket_candidate_non_execu
 
 
 
+
+def test_selected_option_missing_token_blocks_live_entry() -> None:
+    runner = _build_runner()
+    symbol = "NFO:NIFTY26JUN23900CE"
+    _prime_live_entry_runner(runner, symbol=symbol, side="CE")
+    runner._active_selected_ce = symbol
+    runner._active_selected_pe = "NFO:NIFTY26JUN23900PE"
+    runner._active_option_symbols = {symbol, "NFO:NIFTY26JUN23900PE"}
+    runner._active_basket_token_by_symbol = {}
+    runner._active_atm_strike = 23900
+
+    ready, reason, details = runner._symbol_live_entry_ready(symbol, trace_id="selected-missing-token")
+
+    assert ready is False
+    assert reason == "option_token_missing"
+    assert details["is_selected_symbol"] is True
+    assert details["candidate_token_valid"] is False
+
+
+def test_selected_option_unresolved_lot_size_blocks_live_entry() -> None:
+    runner = _build_runner()
+    symbol = "NFO:NIFTY26JUN23900CE"
+    _prime_live_entry_runner(runner, symbol=symbol, side="CE")
+    runner._active_selected_ce = symbol
+    runner._active_selected_pe = "NFO:NIFTY26JUN23900PE"
+    runner._active_option_symbols = {symbol, "NFO:NIFTY26JUN23900PE"}
+    runner._active_atm_strike = 23900
+    runner._order_manager.resolve_lot_size = lambda _s: 0  # type: ignore[attr-defined]
+
+    ready, reason, details = runner._symbol_live_entry_ready(symbol, trace_id="selected-missing-lot")
+
+    assert ready is False
+    assert reason == "lot_size_unresolved"
+    assert details["is_selected_symbol"] is True
+    assert details["candidate_token_valid"] is True
+    assert details["candidate_orderable"] is False
+
+
+def test_order_manager_live_mode_exception_blocks_only_in_live_env(monkeypatch) -> None:
+    runner = _build_runner()
+
+    def _raises() -> bool:
+        raise RuntimeError("live mode unavailable")
+
+    runner._order_manager.is_live_mode = _raises  # type: ignore[attr-defined]
+    monkeypatch.setenv("EXECUTION_MODE", "LIVE")
+    allowed, reason, details = runner._resolve_order_manager_health_for_entry()
+
+    assert allowed is False
+    assert reason == "order_manager_not_live"
+    assert details["order_manager_live_mode_unknown"] is True
+    assert details["order_manager_live_mode_error_type"] == "RuntimeError"
+    assert details["order_manager_live_mode_error"] == "live mode unavailable"
+
+    monkeypatch.setenv("EXECUTION_MODE", "SHADOW")
+    allowed, reason, details = runner._resolve_order_manager_health_for_entry()
+
+    assert allowed is True
+    assert reason == "broker_health_unknown_assumed_ready"
+    assert details["order_manager_live_mode_unknown"] is True
+    assert details["broker_ready_assumed"] is True
+
 def test_symbol_live_entry_ready_missing_broker_health_assumes_ready(monkeypatch) -> None:
     monkeypatch.delenv("LIVE_ENTRY_SELECTED_ONLY", raising=False)
     runner = _build_runner()
@@ -439,6 +501,7 @@ def test_symbol_live_entry_ready_missing_broker_health_assumes_ready(monkeypatch
     runner._active_selected_pe = "NFO:NIFTY26JUN23900PE"
     runner._active_option_symbols = {symbol, "NFO:NIFTY26JUN23900PE"}
     runner._active_atm_strike = 23900
+    runner._order_manager.is_live_mode = lambda: True  # type: ignore[attr-defined]
     assert not hasattr(runner._order_manager, "get_broker_health_snapshot")
 
     ready, reason, details = runner._symbol_live_entry_ready(symbol, trace_id="health-unknown")

--- a/tests/strategies/test_runner_live_path_guards.py
+++ b/tests/strategies/test_runner_live_path_guards.py
@@ -303,6 +303,7 @@ def _prime_live_entry_runner(runner: StrategyRunner, *, symbol: str, side: str =
     runner._indicator_engine.get_history = lambda _s: [1, 2, 3, 4, 5]
     runner._is_option_symbol_tick_fresh = lambda *_a, **_k: True
     runner._runtime_indicators = {symbol: {"direction_bias": side, "context_age_seconds": 1.0}}
+    runner._active_basket_token_by_symbol = {symbol: 123456}
     runner._get_cached_quote_for_live_entry = lambda _s: {
         "tradable_quote": True,
         "depth_available": True,
@@ -427,6 +428,84 @@ def test_selected_only_mode_marks_non_selected_active_basket_candidate_non_execu
     assert details["is_selected_option"] is False
 
 
+
+
+def test_symbol_live_entry_ready_missing_broker_health_assumes_ready(monkeypatch) -> None:
+    monkeypatch.delenv("LIVE_ENTRY_SELECTED_ONLY", raising=False)
+    runner = _build_runner()
+    symbol = "NFO:NIFTY26JUN23900CE"
+    _prime_live_entry_runner(runner, symbol=symbol, side="CE")
+    runner._active_selected_ce = symbol
+    runner._active_selected_pe = "NFO:NIFTY26JUN23900PE"
+    runner._active_option_symbols = {symbol, "NFO:NIFTY26JUN23900PE"}
+    runner._active_atm_strike = 23900
+    assert not hasattr(runner._order_manager, "get_broker_health_snapshot")
+
+    ready, reason, details = runner._symbol_live_entry_ready(symbol, trace_id="health-unknown")
+
+    assert ready is True
+    assert reason == "symbol_live_ready"
+    assert details["broker_health_available"] is False
+    assert details["broker_ready_assumed"] is True
+    assert details["broker_health_reason"] == "broker_health_unknown_assumed_ready"
+
+
+def test_symbol_live_entry_ready_explicit_broker_health_blocks() -> None:
+    runner = _build_runner()
+    symbol = "NFO:NIFTY26JUN23900CE"
+    _prime_live_entry_runner(runner, symbol=symbol, side="CE")
+    runner._active_selected_ce = symbol
+    runner._active_selected_pe = "NFO:NIFTY26JUN23900PE"
+    runner._active_option_symbols = {symbol, "NFO:NIFTY26JUN23900PE"}
+    runner._active_atm_strike = 23900
+    runner._order_manager.is_live_mode = lambda: True  # type: ignore[attr-defined]
+    runner._order_manager.get_broker_health_snapshot = lambda: {  # type: ignore[attr-defined]
+        "trading_allowed_effect": "live_orders_blocked",
+        "ready": True,
+        "order_api_ready": True,
+        "broker_connected": True,
+        "last_broker_error": "margin stale",
+        "last_order_error": "previous order api error",
+    }
+
+    ready, reason, details = runner._symbol_live_entry_ready(symbol, trace_id="health-blocked")
+
+    assert ready is False
+    assert reason == "broker_health_live_orders_blocked"
+    assert details["broker_health_available"] is True
+    assert details["broker_health_effect"] == "live_orders_blocked"
+    assert details["broker_health_block_reason"] == "trading_allowed_effect_live_orders_blocked"
+    assert details["broker_ready_assumed"] is False
+    assert details["last_broker_error"] == "margin stale"
+    assert details["last_order_error"] == "previous order api error"
+
+
+def test_symbol_live_entry_ready_selected_only_blocks_candidate_before_broker_health(monkeypatch) -> None:
+    monkeypatch.setenv("LIVE_ENTRY_SELECTED_ONLY", "true")
+    runner = _build_runner()
+    symbol = "NFO:NIFTY26JUN23950CE"
+    _prime_live_entry_runner(runner, symbol=symbol, side="CE")
+    runner._active_selected_ce = "NFO:NIFTY26JUN23900CE"
+    runner._active_selected_pe = "NFO:NIFTY26JUN23900PE"
+    runner._active_option_symbols = {"NFO:NIFTY26JUN23900CE", "NFO:NIFTY26JUN23900PE", symbol}
+    runner._active_atm_strike = 23900
+    called = {"health": False}
+
+    def _health() -> dict[str, object]:
+        called["health"] = True
+        return {"trading_allowed_effect": "live_orders_blocked"}
+
+    runner._order_manager.is_live_mode = lambda: True  # type: ignore[attr-defined]
+    runner._order_manager.get_broker_health_snapshot = _health  # type: ignore[attr-defined]
+
+    ready, reason, details = runner._symbol_live_entry_ready(symbol, trace_id="selected-only")
+
+    assert ready is False
+    assert reason == "non_executable_candidate"
+    assert called["health"] is False
+    assert details["is_selected_symbol"] is False
+    assert details["broker_health_available"] is False
+
 def test_symbol_live_entry_ready_refreshes_stale_candidate_for_trigger_signal() -> None:
     runner = _build_runner()
     runner._runtime_live_orders_armed = True
@@ -445,7 +524,7 @@ def test_symbol_live_entry_ready_refreshes_stale_candidate_for_trigger_signal() 
         [
             {"symbol": "NFO:NIFTY26JUN23900CE"},
             {"symbol": "NFO:NIFTY26JUN23900PE"},
-            {"symbol": "NFO:NIFTY26JUN23850PE"},
+            {"symbol": "NFO:NIFTY26JUN23850PE", "instrument_token": 23850},
         ],
         False,
         "test",
@@ -500,7 +579,7 @@ def test_symbol_live_entry_ready_refresh_uses_context_spot_when_active_atm_missi
     runner._active_option_symbols = []
     runner._active_atm_strike = None
     runner._get_cached_quote_for_live_entry = lambda _s: {"tradable_quote": True, "depth_available": True, "spread_pct": 0.2}
-    runner._build_candidate_snapshots_sync_safe = lambda **_k: ([{"symbol": "NFO:NIFTY26JUN23800PE"}], False, "test")  # type: ignore[method-assign]
+    runner._build_candidate_snapshots_sync_safe = lambda **_k: ([{"symbol": "NFO:NIFTY26JUN23800PE", "instrument_token": 23800}], False, "test")  # type: ignore[method-assign]
     signal = Signal(action="BUY", symbol="NFO:NIFTY26JUN23800PE", quantity=1, confidence=0.8, reason="OrderFlow", metadata={"trigger_conditions_met": True})
     ready, reason, details = runner._symbol_live_entry_ready("NFO:NIFTY26JUN23800PE", signal=signal, trace_id="refresh-no-active-atm")
     assert ready is True
@@ -522,7 +601,7 @@ def test_symbol_live_entry_ready_refresh_uses_context_atm_when_active_atm_stale(
     runner._active_option_symbols = ["NFO:NIFTY26JUN25000CE", "NFO:NIFTY26JUN25000PE"]
     runner._active_atm_strike = None
     runner._get_cached_quote_for_live_entry = lambda _s: {"tradable_quote": True, "depth_available": True, "spread_pct": 0.2}
-    runner._build_candidate_snapshots_sync_safe = lambda **_k: ([{"symbol": "NFO:NIFTY26JUN23800PE"}], False, "test")  # type: ignore[method-assign]
+    runner._build_candidate_snapshots_sync_safe = lambda **_k: ([{"symbol": "NFO:NIFTY26JUN23800PE", "instrument_token": 23800}], False, "test")  # type: ignore[method-assign]
     signal = Signal(action="BUY", symbol="NFO:NIFTY26JUN23800PE", quantity=1, confidence=0.8, reason="OrderFlow", metadata={"trigger_conditions_met": True})
     ready, reason, details = runner._symbol_live_entry_ready("NFO:NIFTY26JUN23800PE", signal=signal, trace_id="refresh-stale-atm")
     assert ready is True

--- a/tests/strategies/test_runner_readiness_diagnostics.py
+++ b/tests/strategies/test_runner_readiness_diagnostics.py
@@ -55,6 +55,18 @@ def _make_runner() -> StrategyRunner:
 
 
 
+def _arm_live_entry_ready_runner(runner: StrategyRunner, *, symbol: str = "NFO:NIFTY26JUN23800PE") -> None:
+    runner._runtime_live_orders_armed = True
+    runner._runtime_data_hard_ready = True
+    runner._runtime_evaluation_ready = True
+    runner._order_manager = SimpleNamespace(
+        is_live_mode=lambda: True,
+        resolve_lot_size=lambda _s: 65,
+    )
+    runner._order_manager_kill_switch_status_for_entry = lambda: (False, {})
+    runner._active_basket_token_by_symbol = {symbol: 123456}
+
+
 def test_symbol_live_entry_ready_execution_not_armed_has_reason_chain(monkeypatch) -> None:
     monkeypatch.setenv("EXECUTION_MODE", "LIVE")
     monkeypatch.setenv("ENABLE_LIVE_TRADING", "true")
@@ -115,18 +127,20 @@ def test_symbol_live_entry_ready_no_runtime_indicators_attribute_does_not_crash(
     runner = _make_runner()
     if hasattr(runner, "_runtime_indicators"):
         delattr(runner, "_runtime_indicators")
-    runner._runtime_live_orders_armed = True
+    _arm_live_entry_ready_runner(runner)
     runner._is_tradable_symbol = lambda _s: True
-    runner._order_manager_kill_switch_status_for_entry = lambda: (False, {})
     runner._contract_side_from_symbol = lambda _s: "PE"
     runner._get_cached_quote_for_live_entry = lambda _s: {"tradable_quote": True, "depth_available": True, "spread_pct": 0.1}
+    runner._active_selected_pe = "NFO:NIFTY26JUN23800PE"
     runner._active_atm_strike = 23800
     runner._extract_strike_from_symbol = lambda _s: 23800
     runner._indicator_engine = _DummyIndicator({"NFO:NIFTY26JUN23800PE": [1, 2, 3, 4, 5, 6]})
     runner._required_bars_for_symbol = lambda _s: 1
-    ready, reason, _details = runner._symbol_live_entry_ready("NFO:NIFTY26JUN23800PE", trace_id="t-no-attr")
-    assert reason in {"symbol_live_ready", "quote_depth_unavailable", "spread_unknown", "spread_too_wide", "broker_health_live_orders_blocked"}
-    assert isinstance(ready, bool)
+    ready, reason, details = runner._symbol_live_entry_ready("NFO:NIFTY26JUN23800PE", trace_id="t-no-attr")
+    assert ready is True
+    assert reason == "symbol_live_ready"
+    assert details["candidate_token_valid"] is True
+    assert details["candidate_orderable"] is True
 
 
 def test_live_trading_readiness_snapshot_emitted(caplog) -> None:
@@ -418,8 +432,8 @@ def test_ce_signal_blocked_when_direction_bias_pe() -> None:
 
 def test_pe_signal_allowed_when_direction_bias_pe_and_other_gates_pass() -> None:
     runner = _make_runner()
+    _arm_live_entry_ready_runner(runner)
     runner._is_tradable_symbol = lambda _s: True
-    runner._order_manager_kill_switch_status_for_entry = lambda: (False, {})
     runner._runtime_indicators = {"NFO:NIFTY26JUN23800PE": {"direction_bias": "PE"}}
     runner._active_selected_pe = "NFO:NIFTY26JUN23800PE"
     runner._get_cached_quote_for_live_entry = lambda _s: {"tradable_quote": True, "depth_available": True, "spread_pct": 0.2}
@@ -440,8 +454,8 @@ def test_symbol_live_entry_ready_does_not_crash_when_active_atm_strike_missing()
     runner = _make_runner()
     if hasattr(runner, "_active_atm_strike"):
         delattr(runner, "_active_atm_strike")
+    _arm_live_entry_ready_runner(runner)
     runner._is_tradable_symbol = lambda _s: True
-    runner._order_manager_kill_switch_status_for_entry = lambda: (False, {})
     runner._active_selected_pe = "NFO:NIFTY26JUN23800PE"
     runner._get_cached_quote_for_live_entry = lambda _s: {"tradable_quote": True, "depth_available": True, "spread_pct": 0.2}
     ready, reason, _details = runner._symbol_live_entry_ready("NFO:NIFTY26JUN23800PE")
@@ -451,8 +465,8 @@ def test_symbol_live_entry_ready_does_not_crash_when_active_atm_strike_missing()
 
 def test_symbol_live_entry_ready_false_when_quote_missing() -> None:
     runner = _make_runner()
+    _arm_live_entry_ready_runner(runner)
     runner._is_tradable_symbol = lambda _s: True
-    runner._order_manager_kill_switch_status_for_entry = lambda: (False, {})
     runner._active_selected_pe = "NFO:NIFTY26JUN23800PE"
     runner._get_cached_quote_for_live_entry = lambda _s: {}
     ready, reason, _details = runner._symbol_live_entry_ready("NFO:NIFTY26JUN23800PE")
@@ -487,8 +501,8 @@ def test_runner_ignores_strategy_decision_for_wrong_trace_id() -> None:
 
 def test_symbol_live_entry_ready_false_when_depth_missing() -> None:
     runner = _make_runner()
+    _arm_live_entry_ready_runner(runner)
     runner._is_tradable_symbol = lambda _s: True
-    runner._order_manager_kill_switch_status_for_entry = lambda: (False, {})
     runner._active_selected_pe = "NFO:NIFTY26JUN23800PE"
     runner._get_cached_quote_for_live_entry = lambda _s: {"tradable_quote": True, "depth_available": False, "spread_pct": 0.2}
     ready, reason, _details = runner._symbol_live_entry_ready("NFO:NIFTY26JUN23800PE")
@@ -498,8 +512,8 @@ def test_symbol_live_entry_ready_false_when_depth_missing() -> None:
 
 def test_symbol_live_entry_ready_false_when_spread_unknown_by_default() -> None:
     runner = _make_runner()
+    _arm_live_entry_ready_runner(runner)
     runner._is_tradable_symbol = lambda _s: True
-    runner._order_manager_kill_switch_status_for_entry = lambda: (False, {})
     runner._active_selected_pe = "NFO:NIFTY26JUN23800PE"
     runner._get_cached_quote_for_live_entry = lambda _s: {"tradable_quote": True, "depth_available": True}
     ready, reason, _details = runner._symbol_live_entry_ready("NFO:NIFTY26JUN23800PE")


### PR DESCRIPTION
### Motivation

- Live-entry was being blocked by `broker_health_live_orders_blocked` even when broker-health APIs were missing or unknown, because `_symbol_live_entry_ready()` read `get_broker_health_snapshot()` directly and treated absent/unknown health the same as an explicit block.  This caused false-negative live-entry rejections despite `compute_live_readiness()` and upstream readiness being green.  

### Description

- Added `StrategyRunner._resolve_order_manager_health_for_entry()` which safely inspects `_order_manager` and returns a 3-tuple `(allowed: bool, reason: str, details: dict)` with explicit block reasons: `order_manager_missing`, `order_manager_not_live`, `order_manager_kill_switch_active`, `broker_health_live_orders_blocked` (when `trading_allowed_effect == "live_orders_blocked"`), and blocks when health fields like `ready`, `order_api_ready`/`order_api_available`, or `broker_connected` are explicitly false; missing/unknown health APIs return `broker_health_unknown_assumed_ready` and do not block.
- Reworked `_symbol_live_entry_ready()` to: use a single `_finish()` logging/return path, run candidate-selection / data / quote / depth checks (including candidate history, token and lot-size/orderability for non-selected candidates) before interrogating broker health, and call the new helper only when required; if the helper blocks, the helper reason is returned.
- Made `LIVE_ENTRY_SELECTED_ONLY` policy explicit by rejecting non-selected candidates (`non_executable_candidate`) before any broker-health access when enabled, and required candidate-specific readiness (active-basket membership, token presence, resolved lot-size/orderability) for candidate-mode entries.
- Preserve and enrich candidate refresh behavior by carrying `instrument_token`/`token` values from refreshed snapshots into `_active_basket_token_by_symbol` so token checks can succeed after a refresh.
- Improved readiness/log diagnostics: `SYMBOL_LIVE_ENTRY_READY_CHECK` now surfaces `order_manager_present`, `order_manager_live_mode`, `order_manager_kill_switch_active`, `broker_health_available`, `broker_health_effect`, `broker_ready`, `broker_ready_assumed`, `last_broker_error`, `last_order_error`, `is_selected_symbol`, `candidate_quote_ready`, `candidate_history_ready`, `candidate_token_valid`, `candidate_orderable`, `candidate_lot_size`, and runtime readiness flags.
- Added focused unit tests exercising: unknown/missing broker-health (assumed ready), explicit health snapshot blocking (`live_orders_blocked`) with details, and selected-only mode rejecting non-selected candidates before calling broker-health methods; also updated candidate-refresh tests to include `instrument_token` in snapshots.

### Testing

- Ran `python -m compileall -q src` which passed without errors.
- Ran focused tests `pytest -q tests/strategies/test_runner_live_path_guards.py` and `pytest -q tests/strategies/test_runner_readiness_diagnostics.py`, both passed.
- Ran full test suite `pytest -q`, which completed successfully. All added/modified tests passed.
- Verified no `git diff --check` issues were present after changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a229c7f4bf48324aa2082f4b9850fab)