### PR TITLE
Fix live option quote readiness propagation

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -996,7 +996,7 @@ from nifty_scalper_bot.execution.order_manager import OrderManager, OrderType
 from nifty_scalper_bot.execution.paper_fill_engine import PaperFillEngine
 from nifty_scalper_bot.execution.position_manager import ActiveContract, PositionManager
 from nifty_scalper_bot.execution.post_fill_monitor import PostFillMonitor
-from nifty_scalper_bot.execution.readiness import compute_live_readiness
+from nifty_scalper_bot.execution.readiness import compute_live_readiness, quote_has_tradable_bid_ask
 from nifty_scalper_bot.execution.safe_order_manager import SafeOrderManager
 from nifty_scalper_bot.execution.state_tracker import StateTracker
 from nifty_scalper_bot.infra.cron_refresh import schedule_instrument_refresh
@@ -7591,21 +7591,21 @@ async def _recompute_and_push_runtime_readiness(ctx: BotContext, *, reason: str)
     def _selected_option_bid_ask_complete(sym:str|None)->bool:
         snap=_snapshot(sym)
         if snap is None: return False
-        bid=float(_snapshot_value(snap,'bid',0.0) or 0.0)
-        ask=float(_snapshot_value(snap,'ask',0.0) or 0.0)
-        return bid>0 and ask>bid
+        return bool(quote_has_tradable_bid_ask(snap))
     def _tradable_quote(sym:str|None)->bool:
         if not sym or mdm is None: return False
-        if not _selected_option_bid_ask_complete(sym): return False
+        snap=_snapshot(sym)
+        snap_has_bid_ask = bool(quote_has_tradable_bid_ask(snap)) if snap is not None else False
         h=getattr(mdm,'has_ws_tradable_quote',None)
         if callable(h):
-            try: return bool(h([sym]))
+            try:
+                if bool(h([sym])) and (snap_has_bid_ask or bool(_snapshot_value(snap,'tradable_quote',False))): return True
             except TypeError:
-                return bool(h(sym))
+                if bool(h(sym)) and (snap_has_bid_ask or bool(_snapshot_value(snap,'tradable_quote',False))): return True
             except Exception:
                 pass
-        snap=_snapshot(sym)
         if snap is None: return False
+        if snap_has_bid_ask: return True
         return bool(_snapshot_value(snap,'tradable_quote',False))
     def _live_tick_seen(sym:str|None)->bool:
         if _fresh_ltp(sym): return True
@@ -7694,7 +7694,7 @@ async def _recompute_and_push_runtime_readiness(ctx: BotContext, *, reason: str)
     ce_eval_ready = bool(selected_ce) and ce_quote_fresh and ce_bars >= option_eval_min_live_bars
     pe_eval_ready = bool(selected_pe) and pe_quote_fresh and pe_bars >= option_eval_min_live_bars
     spot_ready=_fresh_ltp(spot_symbol) or _bars(spot_symbol)>=1
-    context_exec_ready = _bars(spot_symbol)>=context_execution_min_bars or (_fresh_ltp(spot_symbol) and _bars(futures_symbol)>=context_execution_min_bars)
+    context_exec_ready = _bars(spot_symbol)>=context_execution_min_bars or _fresh_ltp(spot_symbol)
     data_hard_ready=bool(basket_hard_ready and spot_ready and ce_eval_ready and pe_eval_ready)
     runner_running=_runner_is_running(getattr(ctx,'strategy_runner',None))
     evaluation_ready=bool(data_hard_ready and runner_running)

--- a/src/nifty_scalper_bot/core/strategy_manager.py
+++ b/src/nifty_scalper_bot/core/strategy_manager.py
@@ -4255,6 +4255,7 @@ class StrategyManager(_BaseStrategyManager):
         metadata["consensus_stage"] = metadata_stage
         metadata["manager_score_source"] = "strategy_score_plus_context_arbitration"
         metadata["approval_path"] = approval_path
+        metadata["is_approved"] = True
         log.info("TRADE_DECISION_TRACE approval_path=%s symbol=%s strategy=%s", approval_path, symbol_norm, best_vote.strategy)
         self._last_no_signal_decision_by_symbol.pop(symbol_norm, None)
         return Signal(

--- a/src/nifty_scalper_bot/data/data_hub.py
+++ b/src/nifty_scalper_bot/data/data_hub.py
@@ -25,6 +25,7 @@ from nifty_scalper_bot.storage.hub_store import HubStore
 from nifty_scalper_bot.instruments.active_contracts import canonical_nifty_future_symbol
 from nifty_scalper_bot.utils.options_math import black_scholes_greeks, implied_volatility
 from nifty_scalper_bot.data.normalizers import normalize_history_row
+from nifty_scalper_bot.execution.readiness import resolve_quote_bid_ask_spread
 from nifty_scalper_bot.utils.symbols import canonical
 from nifty_scalper_bot.utils.serialization import to_json_safe
 
@@ -652,6 +653,25 @@ class DataHub:
             received_at = float(tick.get("received_at") or time.time())
         except Exception:
             received_at = time.time()
+        bid, ask, spread_pct, bid_ask_source = resolve_quote_bid_ask_spread(tick)
+        if bid is not None and ask is not None:
+            tick.setdefault("bid", bid)
+            tick.setdefault("ask", ask)
+            tick.setdefault("best_bid", bid)
+            tick.setdefault("best_ask", ask)
+        if spread_pct is not None:
+            tick.setdefault("spread_pct", spread_pct)
+        if bid_ask_source != "missing":
+            tick.setdefault("bid_ask_source", bid_ask_source)
+        if tick.get("depth"):
+            tick["depth_available"] = True
+        else:
+            tick.setdefault("depth_available", False)
+        if bid is not None and ask is not None and bid > 0 and ask > bid:
+            tick["tradable_quote"] = True
+        else:
+            tick.setdefault("tradable_quote", False)
+        tick.setdefault("quote_source", tick.get("source"))
         tick.update(
             {
                 "symbol": symbol,
@@ -875,6 +895,7 @@ class DataHub:
                 self._last_poll_arrival[symbol] = now_ms
             self._stale_candidates[symbol] = 0
             self._quote_update_versions[symbol] = int(self._quote_update_versions.get(symbol, 0)) + 1
+            canonical_tick["quote_update_version"] = int(self._quote_update_versions[symbol])
             token_value = canonical_tick.get("instrument_token") or canonical_tick.get("token")
             token_int = None
             try:

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -44,6 +44,7 @@ from nifty_scalper_bot.streaming.websocket_manager import (
     ConnectionState,
     WebSocketManager,
 )
+from nifty_scalper_bot.execution.readiness import resolve_quote_bid_ask_spread
 from nifty_scalper_bot.utils.env import get_str
 from nifty_scalper_bot.utils.async_helpers import safe_task
 from nifty_scalper_bot.utils.log_throttle import log_throttled as log_throttled_live
@@ -7505,12 +7506,7 @@ class MarketDataManager:
         canonical = self._canonical_symbol(symbol)
         tick = self.get_latest_tick(canonical) or {}
         ltp = _coerce_float(tick.get("ltp") or tick.get("last_price"))
-        bid = _coerce_float(tick.get("bid") or tick.get("best_bid") or tick.get("best_bid_price"))
-        ask = _coerce_float(tick.get("ask") or tick.get("best_ask") or tick.get("best_ask_price"))
-        if (bid is None or ask is None) and isinstance(tick.get("depth"), Mapping):
-            quote_fields = self._extract_depth_quote_fields(cast(Mapping[str, Any], tick))
-            bid = bid if bid is not None else _coerce_float(quote_fields.get("bid"))
-            ask = ask if ask is not None else _coerce_float(quote_fields.get("ask"))
+        bid, ask, _spread_pct, resolved_bid_ask_source = resolve_quote_bid_ask_spread(tick)
         mid = None
         if bid is not None and ask is not None and bid > 0 and ask > 0:
             mid = (float(bid) + float(ask)) / 2.0
@@ -7556,9 +7552,9 @@ class MarketDataManager:
         bid_missing = bool(tick.get("bid_missing")) or bid is None or bid <= 0
         ask_missing = bool(tick.get("ask_missing")) or ask is None or ask <= 0
         bid_ask_source = str(
-            tick.get("bid_ask_source") or ("market_depth" if depth_available else "missing")
+            tick.get("bid_ask_source") or resolved_bid_ask_source or ("market_depth" if depth_available else "missing")
         ).lower()
-        source_ok = bid_ask_source in {"market_depth", "quote", "rest_quote", "ws_full"}
+        source_ok = bid_ask_source in {"market_depth", "quote", "rest_quote", "ws_full", "depth", "top_level", "best_bid_ask"}
         quote_source = str(tick.get("source") or "").lower()
         rest_quote_source = quote_source in {"rest", "rest_quote", "quote"}
         tradable_quote = (

--- a/src/nifty_scalper_bot/execution/readiness.py
+++ b/src/nifty_scalper_bot/execution/readiness.py
@@ -70,6 +70,79 @@ class HistoryReadinessPolicy:
         )
 
 
+def _quote_float(payload: dict | object, *keys: str) -> float | None:
+    """Return first positive-compatible float field from a quote-like mapping."""
+    getter = payload.get if isinstance(payload, dict) else lambda key, default=None: getattr(payload, key, default)
+    for key in keys:
+        value = getter(key, None)
+        if value is None:
+            continue
+        try:
+            number = float(value)
+        except (TypeError, ValueError):
+            continue
+        if number == number:
+            return number
+    return None
+
+
+def resolve_quote_bid_ask_spread(quote: dict | object) -> tuple[float | None, float | None, float | None, str]:
+    """Resolve bid/ask/spread from top-level fields or Zerodha depth.
+
+    Fresh WebSocket FULL quotes are tradable when either top-level bid/ask or
+    depth.buy[0]/depth.sell[0] contains a valid crossed-safe best bid/ask.
+    """
+    if quote is None:
+        return None, None, None, "missing"
+    getter = quote.get if isinstance(quote, dict) else lambda key, default=None: getattr(quote, key, default)
+    bid: float | None = None
+    ask: float | None = None
+    source = "missing"
+
+    raw_bid = _quote_float(quote, "bid", "bid_price")
+    raw_ask = _quote_float(quote, "ask", "ask_price")
+    if raw_bid is not None and raw_bid > 0 and raw_ask is not None and raw_ask > raw_bid:
+        bid, ask, source = raw_bid, raw_ask, "top_level"
+
+    if bid is None:
+        raw_bid = _quote_float(quote, "best_bid", "best_bid_price")
+        raw_ask = _quote_float(quote, "best_ask", "best_ask_price")
+        if raw_bid is not None and raw_bid > 0 and raw_ask is not None and raw_ask > raw_bid:
+            bid, ask, source = raw_bid, raw_ask, "best_bid_ask"
+
+    if bid is None:
+        depth = getter("depth", None)
+        buy_levels = sell_levels = []
+        if isinstance(depth, dict):
+            buy_levels = depth.get("buy") or []
+            sell_levels = depth.get("sell") or []
+        buy_top = buy_levels[0] if isinstance(buy_levels, list) and buy_levels else {}
+        sell_top = sell_levels[0] if isinstance(sell_levels, list) and sell_levels else {}
+        raw_bid = _quote_float(buy_top, "price") if isinstance(buy_top, dict) else None
+        raw_ask = _quote_float(sell_top, "price") if isinstance(sell_top, dict) else None
+        if raw_bid is not None and raw_bid > 0 and raw_ask is not None and raw_ask > raw_bid:
+            bid, ask, source = raw_bid, raw_ask, "depth"
+
+    spread_pct: float | None = None
+    if bid is not None and ask is not None and bid > 0 and ask > bid:
+        mid = (bid + ask) / 2.0
+        spread_pct = ((ask - bid) / mid) * 100.0
+    else:
+        precomputed = _quote_float(quote, "spread_pct")
+        has_quote_proof = bool(getter("tradable_quote", False) or getter("depth_available", False) or getter("depth", None))
+        if precomputed is not None and precomputed > 0 and has_quote_proof:
+            spread_pct = precomputed
+            if source == "missing":
+                source = "derived_only"
+    return bid, ask, spread_pct, source
+
+
+def quote_has_tradable_bid_ask(quote: dict | object) -> bool:
+    """Return True when quote has valid top-level/depth bid-ask proof."""
+    bid, ask, _spread, _source = resolve_quote_bid_ask_spread(quote)
+    return bool(bid is not None and ask is not None and bid > 0 and ask > bid)
+
+
 def compute_live_readiness(
     *,
     live_mode: bool,

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -74,7 +74,7 @@ from nifty_scalper_bot.data.source import (
 )
 # Signals route directly through OrderManager submit/place APIs; no execution hub layer.
 from nifty_scalper_bot.execution.order_manager import OrderType, TradePlan
-from nifty_scalper_bot.execution.readiness import HistoryReadinessPolicy
+from nifty_scalper_bot.execution.readiness import HistoryReadinessPolicy, resolve_quote_bid_ask_spread
 from nifty_scalper_bot.execution.order_state_machine import (
     ExecutionState,
     OrderStateMachine,
@@ -455,84 +455,8 @@ def _extract_float(payload: Mapping[str, Any], *keys: str) -> float | None:
 
 
 def _resolve_quote_bid_ask_spread(quote: Mapping[str, Any]) -> tuple[float | None, float | None, float | None, str]:
-    """Resolve bid, ask and spread_pct from a quote/tick dict using every known field layout.
-
-    Tries in priority order:
-    1. Top-level ``bid``/``ask`` keys.
-    2. ``best_bid``/``best_ask`` keys.
-    3. ``depth.buy[0].price`` / ``depth.sell[0].price`` (Zerodha WS full-quote depth).
-    4. Derives ``spread_pct`` from resolved bid/ask when the key is absent.
-    5. Falls back to a pre-computed ``spread_pct`` key **only** when fresh bid/ask
-       proof also exists (so a stale derived indicator never masquerades as live).
-
-    Returns:
-        (bid, ask, spread_pct, bid_ask_source)
-        bid/ask are None when not resolved.
-        spread_pct is None when bid/ask are both missing or invalid.
-        bid_ask_source is one of: "top_level", "best_bid_ask", "depth", "derived_only", "missing".
-
-    This is the single source of truth for live-entry spread validation.
-    OrderFlow resolves spread_pct the same way at line 64 of order_flow.py:
-        spread_pct = float(indicators.get('spread_pct') or (((ask-bid)/mid)*100))
-    This helper mirrors that logic so the live-entry gate never disagrees.
-    """
-    bid: float | None = None
-    ask: float | None = None
-    bid_ask_source = "missing"
-
-    # 1. Top-level bid/ask
-    raw_bid = _extract_float(quote, "bid", "bid_price")
-    raw_ask = _extract_float(quote, "ask", "ask_price")
-    if raw_bid is not None and raw_bid > 0 and raw_ask is not None and raw_ask > raw_bid:
-        bid, ask, bid_ask_source = raw_bid, raw_ask, "top_level"
-
-    # 2. best_bid / best_ask
-    if bid is None:
-        raw_bid2 = _extract_float(quote, "best_bid", "best_bid_price")
-        raw_ask2 = _extract_float(quote, "best_ask", "best_ask_price")
-        if raw_bid2 is not None and raw_bid2 > 0 and raw_ask2 is not None and raw_ask2 > raw_bid2:
-            bid, ask, bid_ask_source = raw_bid2, raw_ask2, "best_bid_ask"
-
-    # 3. Depth best levels (Zerodha WS full-quote format: depth.buy[0] / depth.sell[0])
-    if bid is None:
-        depth = quote.get("depth")
-        if isinstance(depth, Mapping):
-            buy_levels = depth.get("buy") or []
-            sell_levels = depth.get("sell") or []
-        elif isinstance(depth, dict):
-            buy_levels = depth.get("buy") or []
-            sell_levels = depth.get("sell") or []
-        else:
-            buy_levels = sell_levels = []
-        buy_top = buy_levels[0] if isinstance(buy_levels, list) and buy_levels else {}
-        sell_top = sell_levels[0] if isinstance(sell_levels, list) and sell_levels else {}
-        depth_bid = _extract_float(buy_top, "price") if buy_top else None
-        depth_ask = _extract_float(sell_top, "price") if sell_top else None
-        if depth_bid is not None and depth_bid > 0 and depth_ask is not None and depth_ask > depth_bid:
-            bid, ask, bid_ask_source = depth_bid, depth_ask, "depth"
-
-    # Derive spread_pct from resolved bid/ask (mirrors OrderFlow line 64)
-    spread_pct: float | None = None
-    if bid is not None and ask is not None and bid > 0 and ask > bid:
-        mid = (bid + ask) / 2.0
-        spread_pct = ((ask - bid) / mid) * 100.0
-
-    # If bid/ask not resolved, check for a pre-computed spread_pct key —
-    # but only trust it when there is accompanying fresh quote evidence
-    # (tradable_quote or depth_available) to avoid accepting a stale indicator value.
-    if spread_pct is None:
-        pre_computed = _extract_float(quote, "spread_pct")
-        has_quote_proof = bool(
-            quote.get("tradable_quote")
-            or quote.get("depth_available")
-            or quote.get("depth")
-        )
-        if pre_computed is not None and pre_computed > 0 and has_quote_proof:
-            spread_pct = pre_computed
-            if bid_ask_source == "missing":
-                bid_ask_source = "derived_only"
-
-    return bid, ask, spread_pct, bid_ask_source
+    """Resolve bid/ask/spread via the shared execution-readiness quote helper."""
+    return resolve_quote_bid_ask_spread(dict(quote or {}))
 
 
 def _extract_int(payload: Mapping[str, Any], *keys: str) -> int:
@@ -7745,7 +7669,18 @@ class StrategyRunner:
             return final_ready, reason, details
 
         if not bool(self._runtime_live_orders_armed):
-            return _finish(False, "execution_not_armed")
+            hard_runtime_reason = str(self._runtime_readiness_reason or "")
+            runtime_hard_blockers = (
+                "market_closed",
+                "broker_not_ready",
+                "runner_not_running",
+                "eval_not_ready",
+                "not_live_mode",
+            )
+            if (not mode_snapshot.is_live_mode) or any(item in hard_runtime_reason for item in runtime_hard_blockers):
+                return _finish(False, "execution_not_armed")
+            details["global_live_orders_armed"] = False
+            details["candidate_specific_readiness_override"] = True
         if not self._is_tradable_symbol(symbol):
             return _finish(False, "non_tradable_symbol")
         if ks_active:

--- a/tests/core/test_readiness_live_tick_proof.py
+++ b/tests/core/test_readiness_live_tick_proof.py
@@ -117,3 +117,64 @@ async def test_ensure_selected_options_hydrated_handles_runner_reseed_failure() 
 
     result = await app._ensure_selected_options_hydrated(ctx, symbol, None, 2, 'test')
     assert result[symbol]['ready'] is False
+
+@pytest.mark.asyncio
+async def test_live_readiness_treats_depth_only_quote_as_tradable(monkeypatch) -> None:
+    monkeypatch.setattr(app, 'get_market_state', lambda: app.MarketState.OPEN)
+
+    class DepthSnap(Snap):
+        def __init__(self, ltp: float, age: float, bid: float, ask: float):
+            super().__init__(ltp, age, False, None, None, True)
+            self.depth = {'buy': [{'price': bid, 'quantity': 100}], 'sell': [{'price': ask, 'quantity': 100}]}
+
+    snaps = {
+        'NSE:NIFTY': Snap(25000, 2),
+        'NFO:CE': DepthSnap(100, 2, 99.95, 100.05),
+        'NFO:PE': DepthSnap(110, 2, 109.95, 110.05),
+    }
+    mdm = SimpleNamespace(
+        get_symbol_snapshot=lambda s: snaps.get(s),
+        get_ohlc_bars=lambda s, **k: list(range(60)),
+        has_ws_tradable_quote=lambda symbols: True,
+        _confirmed_subscriptions={1, 2},
+        _symbol_to_token={'NFO:CE': 1, 'NFO:PE': 2},
+        _last_tick_ts=_fresh_tick_ts(),
+    )
+    ctx = make_ctx(mdm)
+
+    await app._recompute_and_push_runtime_readiness(ctx, reason='depth-only-test')
+
+    assert ctx.live_orders_armed is True
+    assert ctx.selected_ce_exec_ready is True
+    assert ctx.selected_pe_exec_ready is True
+
+
+@pytest.mark.asyncio
+async def test_insufficient_futures_context_is_soft_when_spot_and_options_ready(monkeypatch) -> None:
+    monkeypatch.setattr(app, 'get_market_state', lambda: app.MarketState.OPEN)
+    snaps = {
+        'NSE:NIFTY': Snap(25000, 2),
+        'NFO:CE': Snap(100, 2, True, 99.95, 100.05, True),
+        'NFO:PE': Snap(110, 2, True, 109.95, 110.05, True),
+    }
+
+    def bars(symbol: str, **_kwargs):
+        if symbol == 'NFO:NIFTY26JUNFUT':
+            return []
+        return list(range(60))
+
+    mdm = SimpleNamespace(
+        get_symbol_snapshot=lambda s: snaps.get(s),
+        get_ohlc_bars=bars,
+        has_ws_tradable_quote=lambda symbols: True,
+        _confirmed_subscriptions={1, 2},
+        _symbol_to_token={'NFO:CE': 1, 'NFO:PE': 2},
+        _last_tick_ts=_fresh_tick_ts(),
+    )
+    ctx = make_ctx(mdm)
+    ctx.active_trading_universe['futures_symbol'] = 'NFO:NIFTY26JUNFUT'
+
+    await app._recompute_and_push_runtime_readiness(ctx, reason='futures-soft-test')
+
+    assert ctx.context_exec_ready is True
+    assert ctx.live_orders_armed is True

--- a/tests/core/test_strategy_manager_consensus.py
+++ b/tests/core/test_strategy_manager_consensus.py
@@ -471,3 +471,36 @@ def test_aligned_two_trigger_allows_strategy_feature_unavailable_neutral() -> No
     v2 = StrategyVote(strategy='OrderFlow', side='PE', score=8.2, confidence=0.85, reasons=[], metadata={'strategy_score':8.2})
     out = manager._combine_strategy_votes(symbol='NFO:NIFTY25000PE', signals=[(s1,v1),(s2,v2)], indicators={'direction_bias':'PE','context_age_seconds':2,'spread_pct':0.2,'quote_depth_valid':True,'is_selected_option':True}, no_vote_reason_counts={'strategy_feature_unavailable':1})
     assert out is not None
+
+
+def test_consensus_approved_signal_does_not_emit_combined_not_approved_blocker(caplog) -> None:
+    manager = _manager_stub()
+    signal = _make_signal()
+    vote1 = StrategyVote(strategy='OrderFlow', side='CE', score=9.0, confidence=0.85, reasons=[], metadata={'role': 'trigger', 'raw_setup_score': 9.0})
+    vote2 = StrategyVote(strategy='VWAPPro', side='CE', score=8.0, confidence=0.75, reasons=[], metadata={'role': 'trigger', 'raw_setup_score': 8.0})
+    caplog.set_level('INFO')
+
+    combined = manager._combine_strategy_votes(
+        symbol='NFO:NIFTY25000CE',
+        signals=[(signal, vote1), (signal, vote2)],
+        indicators={
+            'direction_bias': 'CE',
+            'underlying_direction_bias': 'CE',
+            'context_age_seconds': 1,
+            'spread_pct': 0.2,
+            'tradable_quote': True,
+            'quote_depth_valid': True,
+            'selected_ce': 'NFO:NIFTY25000CE',
+            'atm_strike': 25000,
+            'strike_distance_from_atm': 0,
+        },
+    )
+
+    assert combined is not None
+    assert combined.metadata['is_approved'] is True
+    assert any(getattr(rec, 'event', None) == 'CONSENSUS_SIGNAL_APPROVED' for rec in caplog.records)
+    assert not any(
+        getattr(rec, 'event', None) == 'STRATEGY_COMBINER_BLOCKER'
+        and getattr(rec, 'blocked_reason', None) == 'combined_not_approved'
+        for rec in caplog.records
+    )

--- a/tests/data/test_data_hub.py
+++ b/tests/data/test_data_hub.py
@@ -572,3 +572,26 @@ def test_datahub_purge_removes_prefixed_and_unprefixed_aliases() -> None:
     assert token not in hub._symbol_by_token  # noqa: SLF001
     assert token not in hub._token_quotes  # noqa: SLF001
     assert token not in hub._ticks  # noqa: SLF001
+
+
+def test_datahub_preserves_depth_quote_quality_and_update_version(hub: DataHub) -> None:
+    symbol = 'NFO:NIFTY26JUN23850PE'
+    hub.ingest_tick_sync({
+        'symbol': symbol,
+        'instrument_token': 23850,
+        'ltp': 100.0,
+        'last_price': 100.0,
+        'source': 'ws',
+        'depth': {'buy': [{'price': 99.95, 'quantity': 100}], 'sell': [{'price': 100.05, 'quantity': 100}]},
+    })
+
+    quote = hub.get_quote(symbol, allow_pull=False)
+
+    assert quote is not None
+    assert quote['bid'] == 99.95
+    assert quote['ask'] == 100.05
+    assert quote['depth_available'] is True
+    assert quote['tradable_quote'] is True
+    assert quote['quote_source'] == 'ws'
+    assert quote['quote_update_version'] == 1
+    assert hub.quote_update_version(symbol) == 1

--- a/tests/strategies/test_runner_live_path_guards.py
+++ b/tests/strategies/test_runner_live_path_guards.py
@@ -2919,3 +2919,41 @@ def test_on_tick_event_context_symbols_emit_global_readiness_not_eval_decision(c
     assert "context_symbol_not_strategy_candidate" not in caplog.text
     assert "RUNNER_EVAL_DECISION symbol=NSE:NIFTY" not in caplog.text
     assert "RUNNER_EVAL_DECISION symbol=NFO:NIFTY26JUNFUT" not in caplog.text
+
+
+def test_symbol_live_entry_ready_allows_near_atm_candidate_when_global_pair_not_armed(monkeypatch) -> None:
+    monkeypatch.setenv('EXECUTION_MODE', 'LIVE')
+    monkeypatch.setenv('ENABLE_LIVE_TRADING', 'true')
+    monkeypatch.delenv('PAPER_MODE', raising=False)
+    monkeypatch.delenv('PAPER__ENABLED', raising=False)
+    monkeypatch.delenv('SHADOW_MODE', raising=False)
+    runner = _build_runner()
+    runner._runtime_live_orders_armed = False
+    runner._runtime_readiness_reason = 'execution_not_armed:ce_exec_quote_or_history_not_ready,pe_exec_quote_or_history_not_ready'
+    runner._runtime_indicators = {'NFO:NIFTY26JUN23850PE': {'direction_bias': 'PE', 'context_age_seconds': 1.0, 'atm_strike': 23900}}
+    runner._active_selected_ce = 'NFO:NIFTY26JUN23900CE'
+    runner._active_selected_pe = 'NFO:NIFTY26JUN23900PE'
+    runner._active_option_symbols = ['NFO:NIFTY26JUN23850PE', 'NFO:NIFTY26JUN23900PE', 'NFO:NIFTY26JUN23900CE']
+    runner._active_atm_strike = 23900
+    runner._active_basket_token_by_symbol = {'NFO:NIFTY26JUN23850PE': 23850}
+    runner._indicator_engine = SimpleNamespace(get_history=lambda _s: [object()] * 40)
+    runner._is_tradable_symbol = lambda _s: True
+    runner._order_manager_kill_switch_status_for_entry = lambda: (False, {})
+    runner._risk_kill_switch_triggered = lambda: False
+    runner._required_bars_for_symbol = lambda _s: 5
+    runner._is_option_symbol_tick_fresh = lambda *_a, **_k: True
+    runner._get_cached_quote_for_live_entry = lambda _s: {
+        'ltp': 100,
+        'depth': {'buy': [{'price': 99.95}], 'sell': [{'price': 100.05}]},
+        'depth_available': True,
+        'timestamp': datetime.now(timezone.utc).isoformat(),
+    }
+    runner._order_manager.is_live_mode = lambda: True  # type: ignore[attr-defined]
+
+    signal = Signal(action='BUY', symbol='NFO:NIFTY26JUN23850PE', quantity=1, confidence=0.8, reason='OrderFlow', metadata={'trigger_conditions_met': True, 'lot_size': 65})
+    ready, reason, details = runner._symbol_live_entry_ready('NFO:NIFTY26JUN23850PE', signal=signal, trace_id='near-atm-global-stale')
+
+    assert ready is True
+    assert reason == 'symbol_live_ready'
+    assert details['candidate_specific_readiness_override'] is True
+    assert details['tradable_quote'] is True


### PR DESCRIPTION
### Motivation

- Signals with full WS depth (buy[0]/sell[0]) were producing `WS_FULL_QUOTE_PROOF` but downstream readiness recomputation and runner gates read the wrong/cropped fields and reported `ce_tradable_quote`/`pe_tradable_quote` as false, blocking execution at phase10 with `execution_not_armed`.
- Candidate-level live-entry was being hard-blocked whenever the global runtime `live_orders_armed` was false, even when the candidate itself had fresh quote/depth and sufficient history, causing valid consensus-approved signals to be shadowed.
- Strategy combiner returned approved consensus signals but did not set the metadata flag the caller expects, producing confusing `STRATEGY_COMBINER_BLOCKER combined_not_approved` logs.

### Description

- Introduced a single canonical quote resolver in `execution/readiness.py`: `resolve_quote_bid_ask_spread()` and `quote_has_tradable_bid_ask()` that derive bid/ask/spread from top-level `bid`/`ask`, `best_bid`/`best_ask`, or `depth.buy[0]/depth.sell[0]` and expose a consistent source label and spread_pct derivation used for all readiness checks.
- Delegated runner-local helper to the shared resolver by making `strategies/runner.py::_resolve_quote_bid_ask_spread()` call the shared helper and kept the existing API surface for the runner.
- Propagated WS full-quote fields and stable metadata through DataHub by enriching canonicalized ticks with derived `bid`, `ask`, `best_bid`, `best_ask`, `spread_pct`, `bid_ask_source`, `depth_available`, `tradable_quote`, `quote_source`, and a `quote_update_version` in `data/data_hub.py` so DataHub callers always see the canonical proof.
- Updated `data/market_data_manager.py::get_symbol_snapshot()` to use the shared resolver and accept `depth`/`top_level`/`best_bid_ask` as valid sources so MDM snapshot and runner logic agree on tradable-proof semantics.
- Changed `core/app.py::_recompute_and_push_runtime_readiness` to use the shared quote checks for `LIVE_READINESS_COMPUTED` and softened futures-history requirement for context arming when spot + selected options are valid (futures context remains advisory/soft-only for option execution arming).
- Adjusted `strategies/runner.py::_symbol_live_entry_ready()` so a candidate with fresh quote/history and valid token/lot/depth can proceed even when global `live_orders_armed` is false for stale selected-pair blocking, while preserving hard runtime blocks (`market_closed`, `broker_not_ready`, `runner_not_running`, `eval_not_ready`, `not_live_mode`) and all risk/order-manager safety gates.
- Fixed `core/strategy_manager.py` to mark consensus-approved signals with `metadata["is_approved"] = True` so downstream callers do not emit a combiner blocker for an actually-approved consensus; no change to strategy scoring logic otherwise.
- Added focused regression tests and small tests updates: depth-only WS quote accepted in live readiness, selected CE/PE armed with depth and bars, near-ATM candidate not blocked by stale selected-pair readiness, consensus-approved path does not emit `combined_not_approved`, futures-context insufficiency treated softly for option execution, and DataHub preserves depth-derived quote-quality and `quote_update_version`.

### Testing

- Ran `python -m compileall -q src`; compilation succeeded.
- Ran targeted pytest subsets and full suite: focused regressions `tests/core/test_readiness_live_tick_proof.py`, `tests/strategies/test_runner_live_path_guards.py::test_symbol_live_entry_ready_allows_near_atm_candidate_when_global_pair_not_armed`, `tests/core/test_strategy_manager_consensus.py::test_consensus_approved_signal_does_not_emit_combined_not_approved_blocker` passed.
- Ran combined readiness/runner/combiner subsets and `tests/data/test_data_hub.py::test_datahub_preserves_depth_quote_quality_and_update_version`; all passed.
- Ran full `pytest -q`; test suite passed in CI run used for validation (no failing automated tests observed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2644c702f08324bd84c72f91c67036)