### PR TITLE
Add robust active basket hydration gates

### DIFF
--- a/README.md
+++ b/README.md
@@ -633,3 +633,34 @@ STRATEGY_SINGLE_VOTE_VWAP_MIN_CONFIDENCE=0.45
 ```
 
 Live defaults remain stricter (`STRATEGY_ALLOW_SINGLE_VOTE_SCALP=false`, `STRATEGY_SINGLE_VOTE_VWAP_MIN_SCORE=5.8`).
+
+## Startup Hydration Sequence
+
+The live startup gate uses one hydration contract (`HydrationStatus`) so every
+layer reports the same symbol, role, token, quote, depth, and bar-count state.
+Startup must not arm live orders until the selected CE/PE have both evaluation
+and execution history.
+
+```text
+InstrumentManager resolves NIFTY spot, active future, selected CE/PE, nearby options
+→ MarketDataManager registers symbol/token maps and subscribes WebSocket tokens
+→ MarketDataManager fetches historical OHLC outside the tick path
+→ MarketDataManager ingests sorted UTC bars and merges live candles on top
+→ DataHub reads the MDM OHLC/quote cache
+→ StrategyRunner reseeds runner history from DataHub/MDM bars
+→ IndicatorEngine receives the same reseeded bars
+→ execution readiness checks quote/depth/spread + required execution bars
+→ live_orders_armed=true only after broker health + hydration + risk gates pass
+```
+
+Expected concise log sequence:
+
+```text
+ACTIVE_BASKET_INITIAL_HYDRATION_PENDING pending_ce=NFO:...CE pending_pe=NFO:...PE ce_bars=1 pe_bars=1 required=30
+HYDRATION_FETCH_ATTEMPT symbol=NFO:...CE token=... tradingsymbol=... interval=minute attempt=token
+HYDRATION_FETCH_RESULT symbol=NFO:...CE returned_rows=30 accepted_rows=30 first_ts=... last_ts=...
+HYDRATION_INGEST_RESULT symbol=NFO:...CE returned_rows=30 accepted_rows=29 final_mdm_bars=30
+RUNNER_HISTORY_RESEEDED symbol=NFO:...CE runner_bars=30 indicator_bars=30 min_bars=30 source=selected_option_history_prewarm
+ACTIVE_BASKET_PROMOTED selected_ce=NFO:...CE selected_pe=NFO:...PE ce_bars=30 pe_bars=30 required=30
+READINESS_BLOCKER_SUMMARY blockers=[] data_hard_ready=True evaluation_ready=True execution_ready=True live_orders_armed=True
+```

--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -996,7 +996,12 @@ from nifty_scalper_bot.execution.order_manager import OrderManager, OrderType
 from nifty_scalper_bot.execution.paper_fill_engine import PaperFillEngine
 from nifty_scalper_bot.execution.position_manager import ActiveContract, PositionManager
 from nifty_scalper_bot.execution.post_fill_monitor import PostFillMonitor
-from nifty_scalper_bot.execution.readiness import compute_live_readiness, quote_has_tradable_bid_ask
+from nifty_scalper_bot.execution.readiness import (
+    HydrationStatus,
+    compute_live_readiness,
+    quote_has_tradable_bid_ask,
+    resolve_quote_bid_ask_spread,
+)
 from nifty_scalper_bot.execution.safe_order_manager import SafeOrderManager
 from nifty_scalper_bot.execution.state_tracker import StateTracker
 from nifty_scalper_bot.infra.cron_refresh import schedule_instrument_refresh
@@ -7287,6 +7292,301 @@ def _fresh_option_quote(
     return symbol if ltp > 0 and age <= max_age_s else None
 
 
+
+
+def _count_bars_from_provider(provider: Any, symbol: str, *, limit: int = 500) -> int:
+    """Count OHLC bars from a provider without fetching history."""
+    if provider is None or not symbol:
+        return 0
+    fn = getattr(provider, "get_ohlc_bars", None)
+    if not callable(fn):
+        return 0
+    try:
+        return len(list(fn(symbol, limit=limit) or []))
+    except TypeError:
+        try:
+            return len(list(fn(symbol) or []))
+        except Exception:
+            return 0
+    except Exception:
+        return 0
+
+
+def _get_bars_from_provider(provider: Any, symbol: str, *, limit: int = 500) -> list[Any]:
+    """Read cached OHLC bars from a provider without triggering historical fetch."""
+    if provider is None or not symbol:
+        return []
+    fn = getattr(provider, "get_ohlc_bars", None)
+    if not callable(fn):
+        return []
+    try:
+        return list(fn(symbol, limit=limit) or [])
+    except TypeError:
+        try:
+            return list(fn(symbol) or [])
+        except Exception:
+            return []
+    except Exception:
+        return []
+
+
+def _bar_timestamp(row: Any) -> datetime | None:
+    """Extract a UTC timestamp from a cached bar-like object."""
+    value = None
+    if isinstance(row, Mapping):
+        value = row.get("timestamp") or row.get("start") or row.get("date") or row.get("time")
+    else:
+        value = getattr(row, "timestamp", None) or getattr(row, "start", None)
+    try:
+        if isinstance(value, datetime):
+            return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+        if isinstance(value, (int, float)):
+            return datetime.fromtimestamp(float(value), tz=timezone.utc)
+        if value:
+            return datetime.fromisoformat(str(value).replace("Z", "+00:00")).astimezone(timezone.utc)
+    except (TypeError, ValueError):
+        return None
+    return None
+
+
+def _get_cached_quote(ctx: BotContext, symbol: str) -> Mapping[str, Any]:
+    """Return cached quote/tick data without pulling broker APIs."""
+    for provider in (getattr(ctx, "data_hub", None), getattr(ctx, "datahub", None)):
+        if provider is None:
+            continue
+        fn = getattr(provider, "get_quote", None)
+        if callable(fn):
+            try:
+                quote = fn(symbol, allow_pull=False)
+            except TypeError:
+                try:
+                    quote = fn(symbol)
+                except Exception:
+                    quote = None
+            except Exception:
+                quote = None
+            if isinstance(quote, Mapping):
+                return quote
+    mdm = getattr(ctx, "market_data_manager", None)
+    for name in ("get_quote", "get_latest_tick", "get_last_tick"):
+        fn = getattr(mdm, name, None)
+        if callable(fn):
+            try:
+                quote = fn(symbol)
+            except Exception:
+                quote = None
+            if isinstance(quote, Mapping):
+                return quote
+    snap_fn = getattr(mdm, "get_symbol_snapshot", None)
+    if callable(snap_fn):
+        try:
+            snap = snap_fn(symbol)
+            if snap is not None:
+                return {
+                    "ltp": getattr(snap, "ltp", None),
+                    "bid": getattr(snap, "bid", None),
+                    "ask": getattr(snap, "ask", None),
+                    "spread_pct": getattr(snap, "spread_pct", None),
+                    "depth_available": getattr(snap, "depth_available", None),
+                    "depth": getattr(snap, "depth", None),
+                    "tradable_quote": getattr(snap, "tradable_quote", None),
+                    "tick_age_s": getattr(snap, "tick_age_s", None),
+                }
+        except Exception:
+            return {}
+    return {}
+
+
+def build_symbol_hydration_status(
+    ctx: BotContext,
+    symbol: str | None,
+    role: str,
+    required_bars: int,
+) -> HydrationStatus:
+    """Build the canonical startup hydration status for one symbol.
+
+    This reads only existing MDM/DataHub/Runner/Indicator caches; historical
+    fetching remains in scheduled hydration/backfill paths, never tick paths.
+    """
+    normalized = str(symbol or "").strip()
+    required = max(0, int(required_bars or 0))
+    mdm = getattr(ctx, "market_data_manager", None)
+    datahub = getattr(ctx, "data_hub", None) or getattr(ctx, "datahub", None)
+    runner = getattr(ctx, "strategy_runner", None)
+    token: int | None = None
+    for source in (
+        getattr(ctx, "active_symbol_tokens", None),
+        getattr(mdm, "_token_by_symbol", None),
+        getattr(mdm, "_symbol_to_token", None),
+        getattr(datahub, "_token_by_symbol", None),
+    ):
+        if isinstance(source, Mapping) and normalized in source:
+            try:
+                token = int(source[normalized])
+                break
+            except (TypeError, ValueError):
+                token = None
+    if token is None:
+        for provider in (datahub, mdm):
+            fn = getattr(provider, "resolve_symbol_token", None)
+            if callable(fn):
+                try:
+                    resolved = fn(normalized)
+                    if resolved:
+                        token = int(resolved)
+                        break
+                except (TypeError, ValueError):
+                    token = None
+                except Exception:
+                    token = None
+
+    mdm_bars = _count_bars_from_provider(mdm, normalized)
+    datahub_bars = _count_bars_from_provider(datahub, normalized) if datahub is not None else mdm_bars
+    runner_bars = 0
+    indicator_bars = 0
+    if runner is not None:
+        history = getattr(runner, "_symbol_history", None)
+        if isinstance(history, Mapping):
+            runner_bars = len(list(history.get(normalized, []) or []))
+        indicator = getattr(runner, "_indicator_engine", None)
+        get_history = getattr(indicator, "get_history", None)
+        if callable(get_history):
+            try:
+                indicator_bars = len(list(get_history(normalized) or []))
+            except Exception:
+                indicator_bars = 0
+        if runner_bars == 0 and indicator_bars > 0:
+            runner_bars = indicator_bars
+    bars_for_ts = _get_bars_from_provider(mdm, normalized) or _get_bars_from_provider(datahub, normalized)
+    timestamps = [ts for ts in (_bar_timestamp(row) for row in bars_for_ts) if ts is not None]
+    quote = _get_cached_quote(ctx, normalized)
+    bid, ask, spread_pct, _source = resolve_quote_bid_ask_spread(dict(quote))
+    depth = quote.get("depth") if isinstance(quote, Mapping) else None
+    depth_available = bool(quote.get("depth_available") or depth)
+    tradable_quote = bool(quote.get("tradable_quote") or (bid is not None and ask is not None and ask > bid))
+    live_tick_fresh = False
+    age_ms_fn = getattr(mdm, "symbol_data_age_ms", None)
+    if callable(age_ms_fn):
+        try:
+            live_tick_fresh = float(age_ms_fn(normalized)) <= float(os.getenv("HYDRATION_LIVE_TICK_MAX_AGE_MS", "60000"))
+        except (TypeError, ValueError):
+            live_tick_fresh = False
+    if not live_tick_fresh and isinstance(quote, Mapping):
+        try:
+            age_s = quote.get("tick_age_s") or quote.get("age_s")
+            live_tick_fresh = age_s is not None and float(age_s) <= 60.0
+        except (TypeError, ValueError):
+            live_tick_fresh = False
+    exchange = normalized.split(":", 1)[0] if ":" in normalized else None
+    tradingsymbol = normalized.split(":", 1)[1] if ":" in normalized else normalized or None
+    counts = [mdm_bars, datahub_bars, runner_bars, indicator_bars]
+    blockers: list[str] = []
+    if not normalized:
+        blockers.append(f"{role}_symbol_missing")
+    if token is None and role in {"selected_ce", "selected_pe", "option_context", "futures_context"}:
+        blockers.append("option_token_missing" if role.startswith("selected_") or role == "option_context" else "futures_token_missing")
+    if required > 0 and any(count < required for count in counts):
+        blockers.append(f"{role}_history_missing")
+        blockers.append("insufficient_bars")
+        if mdm_bars < required:
+            blockers.append("mdm_bars_missing")
+        if datahub_bars < required:
+            blockers.append("datahub_bars_missing")
+        if runner_bars < required:
+            blockers.append("runner_bars_missing")
+        if indicator_bars < required:
+            blockers.append("indicator_bars_missing")
+    selected_role = role in {"selected_ce", "selected_pe"}
+    if selected_role:
+        if not tradable_quote:
+            blockers.append(f"{role}_quote_missing")
+        if not depth_available:
+            blockers.append(f"{role}_depth_missing")
+        max_spread = float(os.getenv("HYDRATION_MAX_SPREAD_PCT", os.getenv("MAX_OPTION_SPREAD_PCT", "12")) or 12)
+        if spread_pct is not None and spread_pct > max_spread:
+            blockers.append("spread_too_wide")
+    ready_for_evaluation = bool(normalized and required >= 0 and all(count >= required for count in counts))
+    ready_for_execution = bool(ready_for_evaluation and (not selected_role or (tradable_quote and depth_available and "spread_too_wide" not in blockers)))
+    status = HydrationStatus(
+        symbol=normalized,
+        role=role,
+        token=token,
+        tradingsymbol=tradingsymbol,
+        exchange=exchange,
+        required_bars=required,
+        historical_rows_returned=mdm_bars,
+        historical_rows_accepted=mdm_bars,
+        mdm_bars=mdm_bars,
+        datahub_bars=datahub_bars,
+        runner_bars=runner_bars,
+        indicator_bars=indicator_bars,
+        live_tick_fresh=live_tick_fresh,
+        tradable_quote=tradable_quote,
+        depth_available=depth_available,
+        bid=bid,
+        ask=ask,
+        spread_pct=spread_pct,
+        ready_for_evaluation=ready_for_evaluation,
+        ready_for_execution=ready_for_execution,
+        blocker_reasons=list(dict.fromkeys(blockers)),
+        first_bar_ts=min(timestamps) if timestamps else None,
+        last_bar_ts=max(timestamps) if timestamps else None,
+        live_merge_applied=bool(mdm_bars and datahub_bars and (mdm_bars == datahub_bars)),
+    )
+    LOGGER.info(
+        "HYDRATION_PROPAGATION_RESULT symbol=%s role=%s required_bars=%s mdm_bars=%s datahub_bars=%s runner_bars=%s indicator_bars=%s tradable_quote=%s depth_available=%s ready_for_evaluation=%s ready_for_execution=%s blockers=%s",
+        status.symbol,
+        status.role,
+        status.required_bars,
+        status.mdm_bars,
+        status.datahub_bars,
+        status.runner_bars,
+        status.indicator_bars,
+        status.tradable_quote,
+        status.depth_available,
+        status.ready_for_evaluation,
+        status.ready_for_execution,
+        status.blocker_reasons,
+        extra={"event": "HYDRATION_PROPAGATION_RESULT", **status.to_dict()},
+    )
+    return status
+
+
+def _hydration_status_map(ctx: BotContext, *, required_option_bars: int, required_context_bars: int) -> dict[str, HydrationStatus]:
+    """Build hydration statuses for spot, future, selected/pending CE/PE, and nearby options."""
+    basket = cast(Mapping[str, Any], getattr(ctx, "active_trading_universe", {}) or {})
+    runner = getattr(ctx, "strategy_runner", None)
+    spot_symbol = str(basket.get("spot_symbol") or getattr(ctx, "nifty_symbol", None) or "NSE:NIFTY")
+    futures_symbol = str(basket.get("futures_symbol") or basket.get("future_symbol") or getattr(ctx, "active_futures_symbol", None) or "")
+    selected_ce = str(getattr(runner, "_pending_selected_ce", None) or getattr(ctx, "selected_ce", None) or basket.get("selected_ce") or basket.get("atm_ce") or "")
+    selected_pe = str(getattr(runner, "_pending_selected_pe", None) or getattr(ctx, "selected_pe", None) or basket.get("selected_pe") or basket.get("atm_pe") or "")
+    option_symbols = [str(sym) for sym in (basket.get("option_symbols") or basket.get("symbols") or []) if str(sym).endswith(("CE", "PE"))]
+    role_by_symbol: dict[str, str] = {spot_symbol: "spot"}
+    if futures_symbol:
+        role_by_symbol[futures_symbol] = "futures_context"
+    if selected_ce:
+        role_by_symbol[selected_ce] = "selected_ce"
+    if selected_pe:
+        role_by_symbol[selected_pe] = "selected_pe"
+    for sym in option_symbols:
+        role_by_symbol.setdefault(sym, "option_context")
+    statuses: dict[str, HydrationStatus] = {}
+    for sym, role in role_by_symbol.items():
+        if not sym:
+            continue
+        required = required_context_bars if role in {"spot", "futures_context"} else required_option_bars
+        statuses[sym] = build_symbol_hydration_status(ctx, sym, role, required)
+    ctx.hydration_status_by_symbol = {sym: status.to_dict() for sym, status in statuses.items()}
+    return statuses
+
+
+def _status_for_role(statuses: Mapping[str, HydrationStatus], role: str) -> HydrationStatus | None:
+    for status in statuses.values():
+        if status.role == role:
+            return status
+    return None
+
+
 def _count_symbol_bars(ctx: BotContext, symbol: str | None) -> int:
     """Count hydrated bars for symbol. Args: ctx/symbol. Returns: bars count. Raises: none."""
     if not symbol or ctx.market_data_manager is None:
@@ -7683,19 +7983,46 @@ async def _recompute_and_push_runtime_readiness(ctx: BotContext, *, reason: str)
             "ACTIVE_BASKET_HYDRATION_METHOD_MISSING hard_ready=False reason=hydrator_missing",
             extra={"event": "ACTIVE_BASKET_HYDRATION_METHOD_MISSING", "missing": list(basket_missing), "reason": "hydrator_missing"},
         )
+    statuses = _hydration_status_map(
+        ctx,
+        required_option_bars=option_execution_min_bars,
+        required_context_bars=context_execution_min_bars,
+    )
+    spot_status = _status_for_role(statuses, "spot")
+    futures_status = _status_for_role(statuses, "futures_context")
+    ce_status = _status_for_role(statuses, "selected_ce")
+    pe_status = _status_for_role(statuses, "selected_pe")
+    status_blockers = list(dict.fromkeys([reason for status in statuses.values() for reason in status.blocker_reasons]))
+    hydration_hard_blockers = [
+        blocker for blocker in status_blockers
+        if not (blocker.endswith("_quote_missing") or blocker.endswith("_depth_missing") or blocker == "spread_too_wide" or blocker.endswith("_token_missing") or blocker == "option_token_missing")
+    ]
+    if hydration_hard_blockers:
+        basket_hard_ready = False
+        basket_missing = list(dict.fromkeys([*basket_missing, *hydration_hard_blockers]))
     ctx.active_basket_hydration = {"hard_ready": bool(basket_hard_ready), "missing": list(basket_missing)}
-    ce_bars, ce_mdm_bars, ce_runner_bars = _readiness_bars(selected_ce)
-    pe_bars, pe_mdm_bars, pe_runner_bars = _readiness_bars(selected_pe)
-    ce_quote_fresh=_fresh_ltp(selected_ce); pe_quote_fresh=_fresh_ltp(selected_pe)
-    ce_bid_ask_complete = _selected_option_bid_ask_complete(selected_ce)
-    pe_bid_ask_complete = _selected_option_bid_ask_complete(selected_pe)
-    ce_exec_ready = bool(selected_ce) and basket_hard_ready and ce_quote_fresh and ce_bid_ask_complete and _tradable_quote(selected_ce) and ce_bars >= option_execution_min_bars
-    pe_exec_ready = bool(selected_pe) and basket_hard_ready and pe_quote_fresh and pe_bid_ask_complete and _tradable_quote(selected_pe) and pe_bars >= option_execution_min_bars
-    ce_eval_ready = bool(selected_ce) and ce_quote_fresh and ce_bars >= option_eval_min_live_bars
-    pe_eval_ready = bool(selected_pe) and pe_quote_fresh and pe_bars >= option_eval_min_live_bars
-    spot_ready=_fresh_ltp(spot_symbol) or _bars(spot_symbol)>=1
-    context_exec_ready = _bars(spot_symbol)>=context_execution_min_bars or _fresh_ltp(spot_symbol)
-    data_hard_ready=bool(basket_hard_ready and spot_ready and ce_eval_ready and pe_eval_ready)
+    ce_mdm_bars = ce_status.mdm_bars if ce_status else 0
+    ce_datahub_bars = ce_status.datahub_bars if ce_status else 0
+    ce_runner_bars = ce_status.runner_bars if ce_status else 0
+    ce_indicator_bars = ce_status.indicator_bars if ce_status else 0
+    pe_mdm_bars = pe_status.mdm_bars if pe_status else 0
+    pe_datahub_bars = pe_status.datahub_bars if pe_status else 0
+    pe_runner_bars = pe_status.runner_bars if pe_status else 0
+    pe_indicator_bars = pe_status.indicator_bars if pe_status else 0
+    ce_bars = min(ce_mdm_bars, ce_datahub_bars, ce_runner_bars, ce_indicator_bars) if ce_status else 0
+    pe_bars = min(pe_mdm_bars, pe_datahub_bars, pe_runner_bars, pe_indicator_bars) if pe_status else 0
+    ce_quote_fresh = bool(ce_status and (ce_status.live_tick_fresh or ce_status.tradable_quote))
+    pe_quote_fresh = bool(pe_status and (pe_status.live_tick_fresh or pe_status.tradable_quote))
+    ce_bid_ask_complete = bool(ce_status and ce_status.tradable_quote)
+    pe_bid_ask_complete = bool(pe_status and pe_status.tradable_quote)
+    ce_exec_ready = bool(ce_status and basket_hard_ready and ce_status.ready_for_execution)
+    pe_exec_ready = bool(pe_status and basket_hard_ready and pe_status.ready_for_execution)
+    ce_eval_ready = bool(ce_status and ce_status.ready_for_evaluation and ce_bars >= option_eval_min_live_bars)
+    pe_eval_ready = bool(pe_status and pe_status.ready_for_evaluation and pe_bars >= option_eval_min_live_bars)
+    spot_ready = bool(spot_status and spot_status.ready_for_evaluation)
+    futures_ready = bool(futures_status and futures_status.ready_for_evaluation) if futures_symbol else True
+    context_exec_ready = bool(spot_ready and futures_ready)
+    data_hard_ready=bool(basket_hard_ready and spot_ready and futures_ready and ce_eval_ready and pe_eval_ready)
     runner_running=_runner_is_running(getattr(ctx,'strategy_runner',None))
     evaluation_ready=bool(data_hard_ready and runner_running)
     live_mode = str(getattr(ctx.settings, "execution_mode", "PAPER")).upper() == "LIVE"
@@ -7706,23 +8033,24 @@ async def _recompute_and_push_runtime_readiness(ctx: BotContext, *, reason: str)
         execution_ready_by_symbol[str(selected_ce)] = bool(ce_exec_ready)
     if selected_pe:
         execution_ready_by_symbol[str(selected_pe)] = bool(pe_exec_ready)
-    any_selected_option_exec_ready = bool(ce_exec_ready or pe_exec_ready)
-    live_orders_armed=bool(live_mode and market_open and evaluation_ready and context_exec_ready and broker_ready and any_selected_option_exec_ready)
+    all_selected_options_exec_ready = bool(ce_exec_ready and pe_exec_ready)
+    live_orders_armed=bool(live_mode and market_open and evaluation_ready and context_exec_ready and broker_ready and all_selected_options_exec_ready)
     missing=[]
     if not selected_ce: missing.append('selected_ce_missing')
     if not selected_pe: missing.append('selected_pe_missing')
-    if not spot_ready: missing.append('spot_not_ready')
+    if not spot_ready: missing.append('spot_history_missing')
+    if not futures_ready: missing.append('futures_history_missing')
     if not basket_hard_ready: missing.extend(basket_missing or ['active_basket_hydration_not_ready'])
     if not evaluation_ready: missing.append('eval_not_ready')
-    if ce_runner_bars < option_eval_min_live_bars: missing.append('ce_eval_bars_missing')
-    if pe_runner_bars < option_eval_min_live_bars: missing.append('pe_eval_bars_missing')
-    if ce_runner_bars < option_execution_min_bars: missing.append('ce_exec_bars_missing')
-    if pe_runner_bars < option_execution_min_bars: missing.append('pe_exec_bars_missing')
-    if not ce_quote_fresh: missing.append('ce_quote_not_fresh')
-    if not pe_quote_fresh: missing.append('pe_quote_not_fresh')
-    if (selected_ce and not ce_bid_ask_complete) or (selected_pe and not pe_bid_ask_complete): missing.append('selected_option_bid_ask_missing')
-    if not _tradable_quote(selected_ce): missing.append('ce_depth_not_tradable')
-    if not _tradable_quote(selected_pe): missing.append('pe_depth_not_tradable')
+    if ce_runner_bars < option_eval_min_live_bars or ce_indicator_bars < option_eval_min_live_bars: missing.append('ce_eval_bars_missing')
+    if pe_runner_bars < option_eval_min_live_bars or pe_indicator_bars < option_eval_min_live_bars: missing.append('pe_eval_bars_missing')
+    if ce_bars < option_execution_min_bars: missing.append('ce_exec_bars_missing')
+    if pe_bars < option_execution_min_bars: missing.append('pe_exec_bars_missing')
+    if ce_status and not ce_status.tradable_quote: missing.append('selected_ce_quote_missing')
+    if pe_status and not pe_status.tradable_quote: missing.append('selected_pe_quote_missing')
+    if ce_status and not ce_status.depth_available: missing.append('selected_ce_depth_missing')
+    if pe_status and not pe_status.depth_available: missing.append('selected_pe_depth_missing')
+    if (ce_status and not ce_status.tradable_quote) or (pe_status and not pe_status.tradable_quote): missing.append('selected_option_bid_ask_missing')
     if not runner_running: missing.append('runner_not_running')
     if live_mode:
         if not market_open: missing.append('market_closed')
@@ -7748,6 +8076,22 @@ async def _recompute_and_push_runtime_readiness(ctx: BotContext, *, reason: str)
     ctx.selected_pe_exec_ready = bool(pe_exec_ready)
     ctx.context_exec_ready = bool(context_exec_ready)
     ctx.broker_ready = bool(broker_ready)
+    LOGGER.info(
+        "READINESS_BLOCKER_SUMMARY blockers=%s data_hard_ready=%s evaluation_ready=%s execution_ready=%s live_orders_armed=%s",
+        list(dict.fromkeys(missing)),
+        bool(data_hard_ready),
+        bool(evaluation_ready),
+        bool(all_selected_options_exec_ready),
+        bool(live_orders_armed),
+        extra={
+            "event": "READINESS_BLOCKER_SUMMARY",
+            "blockers": list(dict.fromkeys(missing)),
+            "data_hard_ready": bool(data_hard_ready),
+            "evaluation_ready": bool(evaluation_ready),
+            "execution_ready": bool(all_selected_options_exec_ready),
+            "live_orders_armed": bool(live_orders_armed),
+        },
+    )
     LOGGER.info("LIVE_READINESS_COMPUTED selected_ce=%s selected_pe=%s ce_ltp_fresh=%s pe_ltp_fresh=%s ce_tick_age_s=%s pe_tick_age_s=%s ce_tradable_quote=%s pe_tradable_quote=%s ce_depth_available=%s pe_depth_available=%s ce_subscription_confirmed=%s pe_subscription_confirmed=%s ce_subscription_or_live_tick=%s pe_subscription_or_live_tick=%s ce_bars_effective=%s ce_mdm_bars=%s ce_runner_bars=%s pe_bars_effective=%s pe_mdm_bars=%s pe_runner_bars=%s data_hard_ready=%s evaluation_ready=%s live_orders_armed=%s ce_exec_ready=%s pe_exec_ready=%s execution_ready_by_symbol=%s live_block_reason=%s", selected_ce, selected_pe, ce_quote_fresh, pe_quote_fresh, getattr(_snapshot(selected_ce),'tick_age_s',None), getattr(_snapshot(selected_pe),'tick_age_s',None), _tradable_quote(selected_ce), _tradable_quote(selected_pe), bool(getattr(_snapshot(selected_ce),'depth_available',False)), bool(getattr(_snapshot(selected_pe),'depth_available',False)), _subscription_confirmed(selected_ce), _subscription_confirmed(selected_pe), _subscription_or_live_tick(selected_ce), _subscription_or_live_tick(selected_pe), ce_bars, ce_mdm_bars, ce_runner_bars, pe_bars, pe_mdm_bars, pe_runner_bars, data_hard_ready, evaluation_ready, live_orders_armed, ce_exec_ready, pe_exec_ready, execution_ready_by_symbol, block_reason)
     if ctx.strategy_runner is not None and hasattr(ctx.strategy_runner, 'set_runtime_readiness'):
         ctx.strategy_runner.set_runtime_readiness(data_hard_ready=bool(ctx.data_hard_ready), evaluation_ready=bool(ctx.evaluation_ready), live_orders_armed=bool(ctx.live_orders_armed), reason=str(ctx.live_block_reason or reason), selected_ce=selected_ce, selected_pe=selected_pe, atm_strike=basket.get('atm_strike'), option_symbols=option_symbols, execution_ready_by_symbol=dict(getattr(ctx, "execution_ready_by_symbol", {}) or {}))
@@ -10912,6 +11256,38 @@ async def startup_sequence(ctx: BotContext) -> None:
                                     os.getenv("OPTION_EXECUTION_MIN_BARS", "30"),
                                 )
                                 or 30
+                            )
+                            context_min_bars = int(os.getenv("READINESS_CONTEXT_MIN_BARS", os.getenv("CONTEXT_EXECUTION_MIN_BARS", "20")) or 20)
+                            hydration_statuses = _hydration_status_map(
+                                ctx,
+                                required_option_bars=option_exec_min_bars,
+                                required_context_bars=context_min_bars,
+                            )
+                            spot_hydration = _status_for_role(hydration_statuses, "spot")
+                            futures_hydration = _status_for_role(hydration_statuses, "futures_context")
+                            ce_hydration = _status_for_role(hydration_statuses, "selected_ce")
+                            pe_hydration = _status_for_role(hydration_statuses, "selected_pe")
+                            hydrated_ce = min(ce_hydration.mdm_bars, ce_hydration.datahub_bars, ce_hydration.runner_bars, ce_hydration.indicator_bars) if ce_hydration else 0
+                            hydrated_pe = min(pe_hydration.mdm_bars, pe_hydration.datahub_bars, pe_hydration.runner_bars, pe_hydration.indicator_bars) if pe_hydration else 0
+                            quote_ce = selected_ce if ce_hydration and ce_hydration.tradable_quote else None
+                            quote_pe = selected_pe if pe_hydration and pe_hydration.tradable_quote else None
+                            option_ticks_ready = bool(quote_ce is not None and quote_pe is not None)
+                            spot_ready = bool(spot_hydration and spot_hydration.ready_for_evaluation)
+                            futures_ready = bool(futures_hydration and futures_hydration.ready_for_evaluation) if (basket_universe.get("futures_symbol") or basket_universe.get("future_symbol")) else True
+                            atm_ce_ready = bool(ce_hydration and ce_hydration.ready_for_evaluation)
+                            atm_pe_ready = bool(pe_hydration and pe_hydration.ready_for_evaluation)
+                            ctx.spot_ready = bool(spot_ready)
+                            ctx.evaluation_ready = bool(runner_running and spot_ready and futures_ready and atm_ce_ready and atm_pe_ready)
+                            ctx.data_hard_ready = bool(spot_ready and futures_ready and atm_ce_ready and atm_pe_ready)
+                            hydration_blockers = list(dict.fromkeys([reason for status in hydration_statuses.values() for reason in status.blocker_reasons]))
+                            LOGGER.info(
+                                "READINESS_BLOCKER_SUMMARY blockers=%s data_hard_ready=%s evaluation_ready=%s execution_ready=%s live_orders_armed=%s",
+                                hydration_blockers,
+                                bool(ctx.data_hard_ready),
+                                bool(ctx.evaluation_ready),
+                                bool(ce_hydration and pe_hydration and ce_hydration.ready_for_execution and pe_hydration.ready_for_execution),
+                                bool(getattr(ctx, "live_orders_armed", False)),
+                                extra={"event": "READINESS_BLOCKER_SUMMARY", "blockers": hydration_blockers, "data_hard_ready": bool(ctx.data_hard_ready), "evaluation_ready": bool(ctx.evaluation_ready)},
                             )
                             armed, blocking_reasons = compute_live_readiness(
                                 live_mode=bool(live_mode),

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -781,19 +781,50 @@ class MarketDataManager:
     def ingest_historical_ohlc(
         self, symbol: str, bars: Sequence[Mapping[str, Any]]
     ) -> int:
-        """Ingest historical OHLC bars into MDM and return accepted count.
-
-        Args: symbol, bars.
-        Returns: accepted bar count.
-        Raises: None.
-        """
+        """Ingest sorted UTC historical OHLC bars and return newly accepted rows."""
         accepted = 0
+        normalized_symbol = self._canonical_symbol(symbol) if hasattr(self, "_canonical_symbol") else str(symbol)
         try:
-            for row in bars:
-                data = dict(row)
-                data["symbol"] = symbol
-                self.ingest_historical_bar(data)
+            normalized_rows: dict[datetime, dict[str, Any]] = {}
+            for row in bars or ():
+                normalized = self.normalize_history_row(normalized_symbol, row, source="historical")
+                if normalized is None:
+                    continue
+                ts = normalized.get("timestamp")
+                if not isinstance(ts, datetime):
+                    continue
+                normalized["timestamp"] = ts.astimezone(timezone.utc).replace(microsecond=0)
+                normalized["symbol"] = normalized_symbol
+                normalized_rows[normalized["timestamp"]] = normalized
+            sorted_rows = [normalized_rows[ts] for ts in sorted(normalized_rows)]
+            key = self._bar_symbol_key(normalized_symbol) if hasattr(self, "_bar_symbol_key") else normalized_symbol
+            existing = list(getattr(self, "_ohlc", {}).get(key, []) or [])
+            existing_ts: set[datetime] = set()
+            for existing_row in existing:
+                ts = existing_row.get("timestamp") if isinstance(existing_row, Mapping) else None
+                if isinstance(ts, str):
+                    try:
+                        parsed = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+                    except ValueError:
+                        continue
+                    existing_ts.add(parsed.astimezone(timezone.utc).replace(microsecond=0))
+                elif isinstance(ts, datetime):
+                    existing_ts.add(ts.astimezone(timezone.utc).replace(microsecond=0))
+            for row in sorted_rows:
+                ts = row["timestamp"]
+                if ts in existing_ts:
+                    continue
+                self.ingest_historical_bar(row)
+                existing_ts.add(ts)
                 accepted += 1
+            final_count = len(self.get_ohlc_bars(normalized_symbol)) if hasattr(self, "get_ohlc_bars") else accepted
+            self._logger.info(
+                "HYDRATION_INGEST_RESULT symbol=%s returned_rows=%s accepted_rows=%s final_mdm_bars=%s first_ts=%s last_ts=%s",
+                normalized_symbol, len(bars or ()), accepted, final_count,
+                sorted_rows[0]["timestamp"].isoformat() if sorted_rows else None,
+                sorted_rows[-1]["timestamp"].isoformat() if sorted_rows else None,
+                extra={"event": "HYDRATION_INGEST_RESULT", "symbol": normalized_symbol, "returned_rows": len(bars or ()), "accepted_rows": accepted, "final_mdm_bars": final_count},
+            )
         except Exception as exc:  # noqa: BLE001
             self._logger.error("Failure in ingest_historical_ohlc: %s", exc, exc_info=exc)
         return accepted
@@ -8917,149 +8948,133 @@ class MarketDataManager:
     async def fetch_history(
         self, symbol: str, interval: str, days: int = 3
     ) -> list[dict]:
-        """
-        Fetch historical data with Aggressive Fetcher Detection & Auto-Token Resolution.
-        """
-        # 1. Normalize Symbol
-        symbol = symbol.strip().upper()
-
-        # 2. Resolve Token (Try Cache -> Resolver -> Broker)
+        """Fetch historical data with token, tradingsymbol, wider-window, and spot fallbacks."""
+        symbol = self._canonical_symbol(symbol.strip().upper()) if hasattr(self, "_canonical_symbol") else symbol.strip().upper()
+        exchange = symbol.split(":", 1)[0] if ":" in symbol else ""
+        tradingsymbol = symbol.split(":", 1)[1] if ":" in symbol else symbol
         token = getattr(self, "_token_by_symbol", {}).get(symbol)
 
-        if not token:
-            self._logger.info(
-                f"🔎 History: Cache miss for {symbol}. Attempting force resolution..."
-            )
+        if not token and symbol in {"NSE:NIFTY", "NSE:NIFTY 50", "NIFTY", "NIFTY 50"}:
+            for spot_key in ("NSE:NIFTY", "NSE:NIFTY 50", "NIFTY", "NIFTY 50"):
+                token = getattr(self, "_token_by_symbol", {}).get(spot_key)
+                if token:
+                    break
+            token = token or 256265
 
-            # Try Resolver
+        if not token:
             resolver = getattr(self, "_resolver", None)
             if resolver:
                 try:
-                    # Try resolve() method
-                    if hasattr(resolver, "resolve"):
-                        t = resolver.resolve(symbol)
-                        if t:
-                            token = int(t)
-                    # Try get_token() method (Fallback)
-                    if not token and hasattr(resolver, "get_token"):
-                        t = resolver.get_token(symbol)
-                        if t:
-                            token = int(t)
-                except Exception as e:
-                    self._logger.exception("Unhandled exception", exc_info=True)
-                    raise
-
-            # Try Broker Instrument Lookup (Final Fallback)
-            if (
-                not token
-                and self._broker
-                and hasattr(self._broker, "get_instrument_token")
-            ):
+                    for method in ("resolve", "get_token"):
+                        fn = getattr(resolver, method, None)
+                        if callable(fn):
+                            resolved = fn(symbol)
+                            if resolved:
+                                token = int(resolved)
+                                break
+                except (TypeError, ValueError) as exc:
+                    self._logger.warning(
+                        "HYDRATION_FETCH_RESOLVE_FAILED symbol=%s exception_type=%s exception_message=%s",
+                        symbol, type(exc).__name__, str(exc),
+                        extra={"event": "HYDRATION_FETCH_RESOLVE_FAILED", "symbol": symbol, "exception_type": type(exc).__name__, "exception_message": str(exc)},
+                    )
+            if not token and self._broker and hasattr(self._broker, "get_instrument_token"):
                 try:
-                    t = self._broker.get_instrument_token(symbol)
-                    if t:
-                        token = int(t)
-                except Exception as e:
-                    self._logger.exception("Unhandled exception", exc_info=True)
-                    raise
+                    resolved = self._broker.get_instrument_token(symbol)
+                    if resolved:
+                        token = int(resolved)
+                except (TypeError, ValueError) as exc:
+                    self._logger.warning(
+                        "HYDRATION_FETCH_RESOLVE_FAILED symbol=%s exception_type=%s exception_message=%s",
+                        symbol, type(exc).__name__, str(exc),
+                        extra={"event": "HYDRATION_FETCH_RESOLVE_FAILED", "symbol": symbol, "exception_type": type(exc).__name__, "exception_message": str(exc)},
+                    )
 
-        if not token:
-            self._logger.warning(
-                f"❌ History Aborted: Could not resolve token for {symbol}"
-            )
-            return []
-
-        # 3. Calculate Dates
-        to_date = datetime.now(timezone.utc)
-        from_date = to_date - timedelta(days=days)
-
-        # 4. Fetch Data (ROBUST SEARCH)
         if not self._broker:
-            self._logger.error("❌ Broker instance is None.")
+            self._logger.error("HYDRATION_FETCH_RESULT symbol=%s returned_rows=0 error=broker_unavailable", symbol, extra={"event": "HYDRATION_FETCH_RESULT", "symbol": symbol, "returned_rows": 0, "error": "broker_unavailable"})
             return []
 
-        try:
-            fetcher = None
-
-            # List of method names to hunt for
-            candidates = [
-                "historical_data",
-                "get_historical_data",
-                "history",
-                "get_history",
-            ]
-
-            # A. Check Broker Direct
+        candidates = ["historical_data", "get_historical_data", "history", "get_history"]
+        fetcher = None
+        for owner in (self._broker, getattr(self._broker, "kite", None), getattr(self._broker, "client", None)):
+            if owner is None:
+                continue
             for method in candidates:
-                f = getattr(self._broker, method, None)
-                if callable(f):
-                    fetcher = f
+                fn = getattr(owner, method, None)
+                if callable(fn):
+                    fetcher = fn
                     break
+            if fetcher:
+                break
+        if not callable(fetcher):
+            self._logger.error("HYDRATION_FETCH_RESULT symbol=%s returned_rows=0 error=history_capability_missing", symbol, extra={"event": "HYDRATION_FETCH_RESULT", "symbol": symbol, "returned_rows": 0, "error": "history_capability_missing"})
+            return []
 
-            # B. Check Inner Client (kite/client)
-            if not fetcher:
-                client = getattr(
-                    self._broker, "kite", getattr(self._broker, "client", None)
-                )
-                if client:
-                    for method in candidates:
-                        f = getattr(client, method, None)
-                        if callable(f):
-                            fetcher = f
-                            break
+        now = datetime.now(timezone.utc)
+        attempt_specs: list[tuple[str, object, int]] = []
+        if token:
+            attempt_specs.append(("token", int(token), int(days)))
+        if exchange and tradingsymbol:
+            attempt_specs.append(("exchange_tradingsymbol", f"{exchange}:{tradingsymbol}", int(days)))
+        if token:
+            attempt_specs.append(("token_wide", int(token), max(int(days), 5)))
+        if exchange and tradingsymbol:
+            attempt_specs.append(("exchange_tradingsymbol_wide", f"{exchange}:{tradingsymbol}", max(int(days), 5)))
+        if token:
+            attempt_specs.append(("token_previous_day", int(token), 1))
 
-            if callable(fetcher):
+        last_error: str | None = None
+        for attempt_name, instrument_key, lookback_days in attempt_specs:
+            to_date = now
+            from_date = to_date - timedelta(days=max(1, int(lookback_days)))
+            self._logger.info(
+                "HYDRATION_FETCH_ATTEMPT symbol=%s token=%s tradingsymbol=%s exchange=%s from_dt=%s to_dt=%s interval=%s required_bars=%s attempt=%s",
+                symbol, token, tradingsymbol, exchange, from_date.isoformat(), to_date.isoformat(), interval, None, attempt_name,
+                extra={"event": "HYDRATION_FETCH_ATTEMPT", "symbol": symbol, "token": token, "tradingsymbol": tradingsymbol, "exchange": exchange, "from_dt": from_date.isoformat(), "to_dt": to_date.isoformat(), "interval": interval, "attempt": attempt_name},
+            )
+            try:
                 async with self._history_lock:
                     now_mono = time.monotonic()
-                    wait = self._history_min_interval_sec - (
-                        now_mono - self._last_history_request_ts
-                    )
+                    wait = self._history_min_interval_sec - (now_mono - self._last_history_request_ts)
                     if wait > 0:
                         await asyncio.sleep(wait)
                     self._last_history_request_ts = time.monotonic()
                     try:
-                        data = await asyncio.to_thread(
-                            fetcher, token, from_date, to_date, interval
-                        )
-                    except Exception as exc:
-                        err = str(exc)
-                        if "Rate limit exceeded" in err or "zerodha.historical" in err:
-                            self._logger.warning(
-                                "HISTORY_RATE_LIMIT_BACKOFF symbol=%s sleep=2.5",
-                                symbol,
-                                extra={"event": "HISTORY_RATE_LIMIT_BACKOFF", "symbol": symbol},
-                            )
+                        raw_rows = await asyncio.to_thread(fetcher, instrument_key, from_date, to_date, interval)
+                    except Exception as exc:  # noqa: BLE001 - broker boundary with retry diagnostics
+                        if "Rate limit exceeded" in str(exc) or "zerodha.historical" in str(exc):
                             await asyncio.sleep(2.5)
                             self._last_history_request_ts = time.monotonic()
-                            data = await asyncio.to_thread(
-                                fetcher, token, from_date, to_date, interval
-                            )
+                            raw_rows = await asyncio.to_thread(fetcher, instrument_key, from_date, to_date, interval)
                         else:
                             raise
-                raw_rows = data or []
-                normalized = [
-                    bar
-                    for bar in (
-                        self.normalize_history_row(symbol, row, source="historical")
-                        for row in raw_rows
-                    )
-                    if bar is not None
-                ]
-
-                return normalized
-
-            # Debugging Dump if failure persists
-            self._logger.error(
-                f"⚠️ Broker {type(self._broker).__name__} missing history capability. "
-                f"Checked: {candidates}"
-            )
-            return []
-
-        except Exception as e:
-            self._logger.error(
-                f"History fetch crashed for {symbol}: {e}", exc_info=True
-            )
-            return []
+                rows = list(raw_rows or [])
+                normalized = [bar for bar in (self.normalize_history_row(symbol, row, source="historical") for row in rows) if bar is not None]
+                normalized.sort(key=lambda item: item["timestamp"])
+                deduped = list({row["timestamp"].astimezone(timezone.utc).replace(microsecond=0): row for row in normalized}.values())
+                deduped.sort(key=lambda item: item["timestamp"])
+                self._logger.info(
+                    "HYDRATION_FETCH_RESULT symbol=%s token=%s tradingsymbol=%s exchange=%s interval=%s attempt=%s returned_rows=%s accepted_rows=%s first_ts=%s last_ts=%s exception_type=%s exception_message=%s",
+                    symbol, token, tradingsymbol, exchange, interval, attempt_name, len(rows), len(deduped),
+                    deduped[0]["timestamp"].isoformat() if deduped else None,
+                    deduped[-1]["timestamp"].isoformat() if deduped else None, None, None,
+                    extra={"event": "HYDRATION_FETCH_RESULT", "symbol": symbol, "token": token, "tradingsymbol": tradingsymbol, "exchange": exchange, "interval": interval, "attempt": attempt_name, "returned_rows": len(rows), "accepted_rows": len(deduped)},
+                )
+                if deduped:
+                    return deduped
+            except Exception as exc:  # noqa: BLE001 - broker boundary with structured failure
+                last_error = str(exc)
+                self._logger.warning(
+                    "HYDRATION_FETCH_RESULT symbol=%s token=%s tradingsymbol=%s exchange=%s interval=%s attempt=%s returned_rows=0 accepted_rows=0 exception_type=%s exception_message=%s",
+                    symbol, token, tradingsymbol, exchange, interval, attempt_name, type(exc).__name__, str(exc),
+                    extra={"event": "HYDRATION_FETCH_RESULT", "symbol": symbol, "token": token, "tradingsymbol": tradingsymbol, "exchange": exchange, "interval": interval, "attempt": attempt_name, "returned_rows": 0, "accepted_rows": 0, "exception_type": type(exc).__name__, "exception_message": str(exc)},
+                )
+        self._logger.error(
+            "HYDRATION_FETCH_RESULT symbol=%s token=%s tradingsymbol=%s exchange=%s interval=%s returned_rows=0 accepted_rows=0 exception_message=%s",
+            symbol, token, tradingsymbol, exchange, interval, last_error,
+            extra={"event": "HYDRATION_FETCH_RESULT", "symbol": symbol, "token": token, "tradingsymbol": tradingsymbol, "exchange": exchange, "interval": interval, "returned_rows": 0, "accepted_rows": 0, "exception_message": last_error},
+        )
+        return []
 
 
 def _compose_chain_entry(

--- a/src/nifty_scalper_bot/execution/readiness.py
+++ b/src/nifty_scalper_bot/execution/readiness.py
@@ -6,9 +6,10 @@ consistently from app startup, health endpoints, and supervisor checks.
 """
 
 from __future__ import annotations
-from dataclasses import dataclass
+from dataclasses import dataclass, field, asdict
 import os
 import logging
+from datetime import datetime, timezone
 
 LOGGER = logging.getLogger(__name__)
 
@@ -47,6 +48,47 @@ def _safe_non_negative_int(value: object, fallback: int = 0) -> int:
     except (TypeError, ValueError):
         return max(int(fallback), 0)
     return max(parsed, 0)
+
+
+@dataclass(slots=True)
+class HydrationStatus:
+    """Canonical full-path hydration contract for startup/readiness gates."""
+
+    symbol: str
+    role: str
+    token: int | None = None
+    tradingsymbol: str | None = None
+    exchange: str | None = None
+    required_bars: int = 0
+    historical_rows_returned: int = 0
+    historical_rows_accepted: int = 0
+    mdm_bars: int = 0
+    datahub_bars: int = 0
+    runner_bars: int = 0
+    indicator_bars: int = 0
+    live_tick_fresh: bool = False
+    tradable_quote: bool = False
+    depth_available: bool = False
+    bid: float | None = None
+    ask: float | None = None
+    spread_pct: float | None = None
+    ready_for_evaluation: bool = False
+    ready_for_execution: bool = False
+    blocker_reasons: list[str] = field(default_factory=list)
+    last_historical_fetch_error: str | None = None
+    last_historical_fetch_at: datetime | None = None
+    first_bar_ts: datetime | None = None
+    last_bar_ts: datetime | None = None
+    live_merge_applied: bool = False
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a JSON-friendly hydration snapshot."""
+        payload = asdict(self)
+        for key in ("last_historical_fetch_at", "first_bar_ts", "last_bar_ts"):
+            value = payload.get(key)
+            if isinstance(value, datetime):
+                payload[key] = value.astimezone(timezone.utc).isoformat()
+        return payload
 
 
 @dataclass(frozen=True)

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -681,6 +681,10 @@ class StrategyRunner:
         self._selected_option_prewarm_inflight: set[str] = set()
         self._selected_option_prewarm_last: dict[str, float] = {}
         self._selected_option_prewarm_cooldown_s = max(1.0, float(os.getenv("SELECTED_OPTION_PREWARM_COOLDOWN_SECONDS", "45") or 45))
+        self._pending_selected_ce: str | None = None
+        self._pending_selected_pe: str | None = None
+        self._pending_atm_strike: int | None = None
+
 
         if self._message_bus is None:
             raise RuntimeError("MessageBus not injected into StrategyRunner")
@@ -2442,6 +2446,33 @@ class StrategyRunner:
         task.add_done_callback(_on_done)
         return True, "signal_preparation_scheduled"
 
+    def _maybe_promote_pending_active_basket(self, *, source: str = "hydration") -> bool:
+        """Promote pending CE/PE only after both have execution bars."""
+        pending_ce = getattr(self, "_pending_selected_ce", None)
+        pending_pe = getattr(self, "_pending_selected_pe", None)
+        if not (pending_ce and pending_pe):
+            return False
+        required = int(getattr(self, "_option_required_bars", 1) or 1)
+        ce_bars = self._history_count_for_symbol(pending_ce)
+        pe_bars = self._history_count_for_symbol(pending_pe)
+        if ce_bars < required or pe_bars < required:
+            return False
+        self._active_selected_ce = pending_ce
+        self._active_selected_pe = pending_pe
+        self._active_atm_strike = getattr(self, "_pending_atm_strike", None)
+        active = set(getattr(self, "_active_option_symbols", set()) or set())
+        active.update({pending_ce, pending_pe})
+        self._active_option_symbols = active
+        self._pending_selected_ce = None
+        self._pending_selected_pe = None
+        self._pending_atm_strike = None
+        self._logger.info(
+            "ACTIVE_BASKET_PROMOTED selected_ce=%s selected_pe=%s ce_bars=%s pe_bars=%s required=%s source=%s",
+            pending_ce, pending_pe, ce_bars, pe_bars, required, source,
+            extra={"event": "ACTIVE_BASKET_PROMOTED", "selected_ce": pending_ce, "selected_pe": pending_pe, "ce_bars": ce_bars, "pe_bars": pe_bars, "required_bars": required, "source": source},
+        )
+        return True
+
     def set_active_option_context(
         self,
         *,
@@ -2450,7 +2481,7 @@ class StrategyRunner:
         atm_strike: int | float | str | None = None,
         option_symbols: list[str] | tuple[str, ...] | set[str] | None = None,
     ) -> None:
-        """Set active option context. Args: selected_ce/selected_pe/atm_strike/option_symbols. Returns: none. Raises: none."""
+        """Set active option context without promoting cold selected options."""
         selected_ce_norm = normalize_symbol(str(selected_ce)) if selected_ce else None
         selected_pe_norm = normalize_symbol(str(selected_pe)) if selected_pe else None
         atm_value = None
@@ -2459,11 +2490,7 @@ class StrategyRunner:
                 atm_value = int(float(atm_strike))
             except (TypeError, ValueError):
                 atm_value = None
-        # Dynamic-basket switch guard: do not abandon a ready selected CE/PE for
-        # a freshly-rotated pair until BOTH new options have enough execution
-        # bars hydrated. Otherwise the new basket isn't execution-ready and we'd
-        # block trades during the warm-up. We still widen option_symbols so the
-        # new strikes hydrate; only the *selected* pair is held back until ready.
+
         def _exec_ready(sym: str | None) -> bool:
             if not sym:
                 return False
@@ -2472,37 +2499,73 @@ class StrategyRunner:
             except Exception:  # noqa: BLE001
                 return False
 
-        prev_ce, prev_pe = self._active_selected_ce, self._active_selected_pe
+        candidate_symbols = {normalize_symbol(str(sym)) for sym in (option_symbols or []) if sym}
+        for sym in (selected_ce_norm, selected_pe_norm):
+            if sym:
+                candidate_symbols.add(sym)
+        prev_ce = getattr(self, "_active_selected_ce", None)
+        prev_pe = getattr(self, "_active_selected_pe", None)
+        pair_requested = bool(selected_ce_norm and selected_pe_norm)
+        pair_ready = _exec_ready(selected_ce_norm) and _exec_ready(selected_pe_norm) if pair_requested else False
         switching = (
             (selected_ce_norm and selected_ce_norm != prev_ce)
             or (selected_pe_norm and selected_pe_norm != prev_pe)
         )
-        if switching and prev_ce and prev_pe:
-            new_ready = _exec_ready(selected_ce_norm) and _exec_ready(selected_pe_norm)
-            if not new_ready:
-                # Keep the previous ready selection; log and skip the swap.
-                self._logger.info(
-                    "ACTIVE_BASKET_SWITCH_DEFERRED keep_ce=%s keep_pe=%s new_ce=%s new_pe=%s "
-                    "new_ce_bars=%s new_pe_bars=%s required=%s",
-                    prev_ce, prev_pe, selected_ce_norm, selected_pe_norm,
-                    self._history_count_for_symbol(selected_ce_norm) if selected_ce_norm else None,
-                    self._history_count_for_symbol(selected_pe_norm) if selected_pe_norm else None,
-                    self._option_required_bars,
-                    extra={"event": "ACTIVE_BASKET_SWITCH_DEFERRED", "keep_ce": prev_ce, "keep_pe": prev_pe,
-                           "new_ce": selected_ce_norm, "new_pe": selected_pe_norm, "required_bars": self._option_required_bars},
-                )
-                # Still hydrate the wider universe (new strikes warm up for next time).
-                merged = {normalize_symbol(str(sym)) for sym in (option_symbols or []) if sym}
-                merged.update(s for s in (prev_ce, prev_pe) if s)
-                self._active_option_symbols = merged or self._active_option_symbols
-                return
 
+        if pair_requested and switching and not pair_ready:
+            self._pending_selected_ce = selected_ce_norm
+            self._pending_selected_pe = selected_pe_norm
+            self._pending_atm_strike = atm_value
+            if prev_ce and prev_pe:
+                candidate_symbols.update(s for s in (prev_ce, prev_pe) if s)
+            self._active_option_symbols = candidate_symbols or getattr(self, "_active_option_symbols", set())
+            event = "ACTIVE_BASKET_SWITCH_DEFERRED" if prev_ce and prev_pe else "ACTIVE_BASKET_INITIAL_HYDRATION_PENDING"
+            message = (
+                "ACTIVE_BASKET_SWITCH_DEFERRED keep_ce=%s keep_pe=%s new_ce=%s new_pe=%s new_ce_bars=%s new_pe_bars=%s required=%s"
+                if prev_ce and prev_pe
+                else "ACTIVE_BASKET_INITIAL_HYDRATION_PENDING pending_ce=%s pending_pe=%s ce_bars=%s pe_bars=%s required=%s"
+            )
+            args = (
+                (prev_ce, prev_pe, selected_ce_norm, selected_pe_norm, self._history_count_for_symbol(selected_ce_norm), self._history_count_for_symbol(selected_pe_norm), self._option_required_bars)
+                if prev_ce and prev_pe
+                else (selected_ce_norm, selected_pe_norm, self._history_count_for_symbol(selected_ce_norm), self._history_count_for_symbol(selected_pe_norm), self._option_required_bars)
+            )
+            self._logger.info(
+                message,
+                *args,
+                extra={
+                    "event": event,
+                    "keep_ce": prev_ce,
+                    "keep_pe": prev_pe,
+                    "pending_ce": selected_ce_norm,
+                    "pending_pe": selected_pe_norm,
+                    "required_bars": self._option_required_bars,
+                    "reason": "pending_initial_hydration" if not (prev_ce and prev_pe) else "pending_basket_promotion",
+                },
+            )
+            self._prewarm_active_option_history(source="active_option_context_pending")
+            return
+
+        promoted_from_pending = bool(
+            pair_ready
+            and selected_ce_norm == getattr(self, "_pending_selected_ce", None)
+            and selected_pe_norm == getattr(self, "_pending_selected_pe", None)
+        )
         if selected_ce_norm:
             self._active_selected_ce = selected_ce_norm
         if selected_pe_norm:
             self._active_selected_pe = selected_pe_norm
         self._active_atm_strike = atm_value
-        self._active_option_symbols = {normalize_symbol(str(sym)) for sym in (option_symbols or []) if sym}
+        self._active_option_symbols = candidate_symbols
+        if promoted_from_pending:
+            self._pending_selected_ce = None
+            self._pending_selected_pe = None
+            self._pending_atm_strike = None
+            self._logger.info(
+                "ACTIVE_BASKET_PROMOTED selected_ce=%s selected_pe=%s required=%s",
+                self._active_selected_ce, self._active_selected_pe, self._option_required_bars,
+                extra={"event": "ACTIVE_BASKET_PROMOTED", "selected_ce": self._active_selected_ce, "selected_pe": self._active_selected_pe, "required_bars": self._option_required_bars},
+            )
         self._logger.info(
             "RUNNER_ACTIVE_OPTION_CONTEXT selected_ce=%s selected_pe=%s atm_strike=%s option_count=%d",
             self._active_selected_ce,
@@ -3787,6 +3850,7 @@ class StrategyRunner:
                 target_min_bars,
                 source,
             )
+            self._maybe_promote_pending_active_basket(source=source)
             return min(runner_count, int(indicator_count or 0))
         except Exception as e:
             self._logger.exception(
@@ -7041,6 +7105,10 @@ class StrategyRunner:
                 reason = type(exc).__name__
             finally:
                 self._selected_option_prewarm_inflight.discard(symbol)
+                success = bool(success and bars_after >= required_bars)
+                if not success and bars_after < required_bars and reason == "scheduled":
+                    reason = "insufficient_bars"
+                self._maybe_promote_pending_active_basket(source="selected_option_history_prewarm")
                 self._logger.info(
                     "SELECTED_OPTION_HISTORY_PREWARM_RESULT symbol=%s bars_before=%s bars_after=%s required_bars=%s success=%s",
                     symbol, bars_before, bars_after, required_bars, success,

--- a/tests/core/test_hydration_status_propagation.py
+++ b/tests/core/test_hydration_status_propagation.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+from nifty_scalper_bot.core import app
+
+
+SYMBOL = "NFO:NIFTY26MAY23300CE"
+
+
+def _bars(count: int) -> list[dict[str, object]]:
+    start = datetime(2026, 5, 1, 9, 15, tzinfo=timezone.utc)
+    return [
+        {
+            "symbol": SYMBOL,
+            "timestamp": start + timedelta(minutes=idx),
+            "open": 100 + idx,
+            "high": 101 + idx,
+            "low": 99 + idx,
+            "close": 100.5 + idx,
+            "volume": 10,
+        }
+        for idx in range(count)
+    ]
+
+
+class _Provider:
+    def __init__(self, bars_by_symbol: dict[str, list[dict[str, object]]], quote: dict[str, object] | None = None) -> None:
+        self._bars = bars_by_symbol
+        self._quote = quote or {}
+        self._token_by_symbol = {SYMBOL: 12345}
+
+    def get_ohlc_bars(self, symbol: str, *, limit: int | None = None):
+        rows = list(self._bars.get(symbol, []))
+        return rows[-limit:] if limit else rows
+
+    def get_quote(self, symbol: str, allow_pull: bool = False):
+        return dict(self._quote) if symbol == SYMBOL else {}
+
+    def resolve_symbol_token(self, symbol: str):
+        return self._token_by_symbol.get(symbol)
+
+    def symbol_data_age_ms(self, symbol: str) -> float:
+        return 100.0
+
+
+class _Indicator:
+    def __init__(self, rows: list[dict[str, object]]) -> None:
+        self.rows = rows
+
+    def get_history(self, symbol: str):
+        return list(self.rows) if symbol == SYMBOL else []
+
+
+class _Runner:
+    def __init__(self, rows: list[dict[str, object]], indicator_rows: list[dict[str, object]]) -> None:
+        self._symbol_history = {SYMBOL: list(rows)}
+        self._indicator_engine = _Indicator(indicator_rows)
+
+    def reseed_history_from_bars(self, symbol: str, rows, source: str = "test", min_bars: int = 1) -> int:
+        self._symbol_history[symbol] = list(rows)
+        self._indicator_engine.rows = list(rows)
+        return len(list(rows))
+
+
+def _quote() -> dict[str, object]:
+    return {
+        "bid": 100.0,
+        "ask": 101.0,
+        "tradable_quote": True,
+        "depth_available": True,
+        "depth": {"buy": [{"price": 100.0}], "sell": [{"price": 101.0}]},
+        "tick_age_s": 1.0,
+    }
+
+
+def _ctx(mdm_rows: int, datahub_rows: int, runner_rows: int, indicator_rows: int, quote: dict[str, object] | None = None):
+    return SimpleNamespace(
+        market_data_manager=_Provider({SYMBOL: _bars(mdm_rows)}, quote),
+        data_hub=_Provider({SYMBOL: _bars(datahub_rows)}, quote),
+        strategy_runner=_Runner(_bars(runner_rows), _bars(indicator_rows)),
+        active_symbol_tokens={SYMBOL: 12345},
+    )
+
+
+def test_mdm_30_bars_propagate_to_datahub_30_bars() -> None:
+    status = app.build_symbol_hydration_status(_ctx(30, 30, 30, 30, _quote()), SYMBOL, "selected_ce", 30)
+
+    assert status.mdm_bars == 30
+    assert status.datahub_bars == 30
+
+
+def test_datahub_30_bars_propagate_to_runner_30_bars() -> None:
+    ctx = _ctx(30, 30, 0, 0, _quote())
+    rows = ctx.data_hub.get_ohlc_bars(SYMBOL, limit=30)
+    ctx.strategy_runner.reseed_history_from_bars(SYMBOL, rows, min_bars=30)
+
+    status = app.build_symbol_hydration_status(ctx, SYMBOL, "selected_ce", 30)
+
+    assert status.datahub_bars == 30
+    assert status.runner_bars == 30
+
+
+def test_runner_30_bars_propagate_to_indicator_30_bars() -> None:
+    ctx = _ctx(30, 30, 0, 0, _quote())
+    ctx.strategy_runner.reseed_history_from_bars(SYMBOL, ctx.data_hub.get_ohlc_bars(SYMBOL), min_bars=30)
+
+    status = app.build_symbol_hydration_status(ctx, SYMBOL, "selected_ce", 30)
+
+    assert status.runner_bars == 30
+    assert status.indicator_bars == 30
+
+
+def test_hydration_status_consistent_counts_across_all_layers() -> None:
+    status = app.build_symbol_hydration_status(_ctx(30, 30, 30, 30, _quote()), SYMBOL, "selected_ce", 30)
+
+    assert (status.mdm_bars, status.datahub_bars, status.runner_bars, status.indicator_bars) == (30, 30, 30, 30)
+    assert status.ready_for_evaluation is True
+
+
+def test_readiness_false_if_any_layer_has_fewer_bars() -> None:
+    status = app.build_symbol_hydration_status(_ctx(30, 29, 30, 30, _quote()), SYMBOL, "selected_ce", 30)
+
+    assert status.ready_for_evaluation is False
+    assert status.ready_for_execution is False
+    assert "datahub_bars_missing" in status.blocker_reasons
+
+
+def test_readiness_true_when_all_layers_have_bars_and_quote_depth_valid() -> None:
+    status = app.build_symbol_hydration_status(_ctx(30, 30, 30, 30, _quote()), SYMBOL, "selected_ce", 30)
+
+    assert status.ready_for_evaluation is True
+    assert status.ready_for_execution is True
+    assert status.tradable_quote is True
+    assert status.depth_available is True

--- a/tests/core/test_readiness_live_tick_proof.py
+++ b/tests/core/test_readiness_live_tick_proof.py
@@ -150,7 +150,7 @@ async def test_live_readiness_treats_depth_only_quote_as_tradable(monkeypatch) -
 
 
 @pytest.mark.asyncio
-async def test_insufficient_futures_context_is_soft_when_spot_and_options_ready(monkeypatch) -> None:
+async def test_insufficient_futures_context_blocks_when_full_hydration_required(monkeypatch) -> None:
     monkeypatch.setattr(app, 'get_market_state', lambda: app.MarketState.OPEN)
     snaps = {
         'NSE:NIFTY': Snap(25000, 2),
@@ -176,5 +176,6 @@ async def test_insufficient_futures_context_is_soft_when_spot_and_options_ready(
 
     await app._recompute_and_push_runtime_readiness(ctx, reason='futures-soft-test')
 
-    assert ctx.context_exec_ready is True
-    assert ctx.live_orders_armed is True
+    assert ctx.context_exec_ready is False
+    assert ctx.live_orders_armed is False
+    assert 'futures_history_missing' in str(ctx.live_block_reason)

--- a/tests/data/test_mdm_history_fetch_diagnostics.py
+++ b/tests/data/test_mdm_history_fetch_diagnostics.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+import pytest
+
+from nifty_scalper_bot.data.market_data_manager import MarketDataManager
+
+
+class _Logger:
+    def info(self, *args, **kwargs):
+        pass
+    def warning(self, *args, **kwargs):
+        pass
+    def error(self, *args, **kwargs):
+        pass
+
+
+class _Broker:
+    def __init__(self, rows_by_key: dict[object, list[dict[str, object]]]) -> None:
+        self.rows_by_key = rows_by_key
+        self.calls: list[object] = []
+
+    def historical_data(self, key, *_args):
+        self.calls.append(key)
+        return list(self.rows_by_key.get(key, []))
+
+
+def _row(ts: datetime | None = None) -> dict[str, object]:
+    return {
+        "date": ts or datetime(2026, 5, 1, 9, 15, tzinfo=timezone.utc),
+        "open": 1,
+        "high": 2,
+        "low": 1,
+        "close": 2,
+        "volume": 10,
+    }
+
+
+def _mdm(broker: _Broker) -> MarketDataManager:
+    mdm = MarketDataManager.__new__(MarketDataManager)
+    mdm._logger = _Logger()
+    mdm._canonical_symbol = lambda s: str(s).strip().upper()
+    mdm._token_by_symbol = {"NFO:NIFTY26MAY23300CE": 12345}
+    mdm._resolver = None
+    mdm._broker = broker
+    mdm._history_lock = asyncio.Lock()
+    mdm._history_min_interval_sec = 0.0
+    mdm._last_history_request_ts = 0.0
+    return mdm
+
+
+@pytest.mark.asyncio
+async def test_historical_fetch_zero_rows_uses_tradingsymbol_fallback() -> None:
+    broker = _Broker({12345: [], "NFO:NIFTY26MAY23300CE": [_row()]})
+    mdm = _mdm(broker)
+
+    rows = await mdm.fetch_history("NFO:NIFTY26MAY23300CE", "minute", 2)
+
+    assert len(rows) == 1
+    assert broker.calls[:2] == [12345, "NFO:NIFTY26MAY23300CE"]
+
+
+@pytest.mark.asyncio
+async def test_historical_fetch_zero_rows_remains_failure_not_success() -> None:
+    broker = _Broker({})
+    mdm = _mdm(broker)
+
+    rows = await mdm.fetch_history("NFO:NIFTY26MAY23300CE", "minute", 2)
+
+    assert rows == []
+    assert len(broker.calls) >= 2
+
+
+@pytest.mark.asyncio
+async def test_spot_historical_fetch_uses_nifty_token_fallback() -> None:
+    broker = _Broker({256265: [_row()]})
+    mdm = _mdm(broker)
+    mdm._token_by_symbol = {}
+
+    rows = await mdm.fetch_history("NSE:NIFTY", "minute", 2)
+
+    assert len(rows) == 1
+    assert broker.calls[0] == 256265
+
+
+def test_duplicate_rows_not_accepted_as_new_when_cache_is_short() -> None:
+    ts = datetime(2026, 5, 1, 9, 15, tzinfo=timezone.utc)
+    mdm = MarketDataManager.__new__(MarketDataManager)
+    mdm._logger = _Logger()
+    mdm._canonical_symbol = lambda s: s
+    mdm._bar_symbol_key = lambda s: s
+    mdm._ohlc = {"NFO:XCE": [{"timestamp": ts.isoformat(), "open": 1, "high": 2, "low": 1, "close": 2}]}
+    mdm.get_ohlc_bars = lambda _s: list(mdm._ohlc["NFO:XCE"])
+    mdm.ingest_historical_bar = lambda row: mdm._ohlc["NFO:XCE"].append(dict(row))
+
+    accepted = mdm.ingest_historical_ohlc("NFO:XCE", [_row(ts)])
+
+    assert accepted == 0
+    assert len(mdm._ohlc["NFO:XCE"]) == 1

--- a/tests/strategies/test_runner_active_basket_pending.py
+++ b/tests/strategies/test_runner_active_basket_pending.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import logging
+from nifty_scalper_bot.strategies.runner import StrategyRunner
+
+
+class _Indicator:
+    def __init__(self, counts: dict[str, int]) -> None:
+        self.counts = counts
+
+    def get_history(self, symbol: str):
+        return list(range(self.counts.get(symbol, 0)))
+
+
+def _runner(counts: dict[str, int]) -> StrategyRunner:
+    runner = object.__new__(StrategyRunner)
+    runner._indicator_engine = _Indicator(counts)
+    runner._logger = logging.getLogger("test.runner.pending")
+    runner._option_required_bars = 30
+    runner._active_selected_ce = None
+    runner._active_selected_pe = None
+    runner._active_atm_strike = None
+    runner._active_option_symbols = set()
+    runner._pending_selected_ce = None
+    runner._pending_selected_pe = None
+    runner._pending_atm_strike = None
+    runner._prewarm_active_option_history = lambda **_kwargs: None
+    return runner
+
+
+def test_first_selected_cold_basket_is_pending_not_execution_active() -> None:
+    runner = _runner({"NFO:NIFTY26MAY23300CE": 1, "NFO:NIFTY26MAY23300PE": 1})
+
+    runner.set_active_option_context(
+        selected_ce="NFO:NIFTY26MAY23300CE",
+        selected_pe="NFO:NIFTY26MAY23300PE",
+        atm_strike=23300,
+        option_symbols=["NFO:NIFTY26MAY23300CE", "NFO:NIFTY26MAY23300PE"],
+    )
+
+    assert runner._active_selected_ce is None
+    assert runner._active_selected_pe is None
+    assert runner._pending_selected_ce == "NFO:NIFTY26MAY23300CE"
+    assert runner._pending_selected_pe == "NFO:NIFTY26MAY23300PE"
+    assert "NFO:NIFTY26MAY23300CE" in runner._active_option_symbols
+    assert "NFO:NIFTY26MAY23300PE" in runner._active_option_symbols
+
+
+def test_pending_basket_promotes_only_after_both_legs_have_required_bars() -> None:
+    counts = {"NFO:NIFTY26MAY23300CE": 30, "NFO:NIFTY26MAY23300PE": 29}
+    runner = _runner(counts)
+    runner._pending_selected_ce = "NFO:NIFTY26MAY23300CE"
+    runner._pending_selected_pe = "NFO:NIFTY26MAY23300PE"
+    runner._pending_atm_strike = 23300
+
+    assert runner._maybe_promote_pending_active_basket(source="test") is False
+    assert runner._active_selected_ce is None
+
+    counts["NFO:NIFTY26MAY23300PE"] = 30
+
+    assert runner._maybe_promote_pending_active_basket(source="test") is True
+    assert runner._active_selected_ce == "NFO:NIFTY26MAY23300CE"
+    assert runner._active_selected_pe == "NFO:NIFTY26MAY23300PE"
+    assert runner._pending_selected_ce is None
+    assert runner._pending_selected_pe is None


### PR DESCRIPTION
### Motivation
- Startup could promote the first selected CE/PE into execution even when both legs had insufficient execution bars, causing execution to require 30 bars but only 0–1 existed.  
- MDM historical fetch path could return zero rows or misleading success without trying tradingsymbol fallbacks, wider lookback, or spot token fallbacks.  
- Historical ingestion and runner reseed flows were not normalizing/synchronizing bars (timestamp normalization, dedupe, live-merge), causing mismatched bar counts across MDM/DataHub/Runner/IndicatorEngine.

### Description
- Add a canonical hydration contract `HydrationStatus` with full-path fields and JSON-friendly serialization in `src/nifty_scalper_bot/execution/readiness.py`.  
- Change `StrategyRunner` to hold pending selected symbols (`_pending_selected_ce`, `_pending_selected_pe`, `_pending_atm_strike`) and defer promotion until both legs meet required execution bars, and add `_maybe_promote_pending_active_basket` with `ACTIVE_BASKET_PROMOTED`/`ACTIVE_BASKET_INITIAL_HYDRATION_PENDING` diagnostics in `src/nifty_scalper_bot/strategies/runner.py`.  
- Make selected-option prewarm require `bars_after >= required_bars` before reporting success and call promotion logic after reseed/prewarm.  
- Harden MDM historical ingestion: normalize timestamps to UTC, sort ascending, drop exact duplicate timestamps safely, ingest only new bars, and emit `HYDRATION_INGEST_RESULT` in `src/nifty_scalper_bot/data/market_data_manager.py`.  
- Improve MDM `fetch_history` with structured diagnostics and fallback attempts including token->tradingsymbol fallback, wider lookback, previous-day attempt, and NIFTY spot token fallback, emitting `HYDRATION_FETCH_ATTEMPT` / `HYDRATION_FETCH_RESULT` logs in `src/nifty_scalper_bot/data/market_data_manager.py`.  
- Document the startup hydration sequence and expected concise logs in `README.md`.  
- Add focused tests that cover pending-basket behavior, promotion only after both legs hydrated, zero-row fetch behavior, tradingsymbol fallback, spot token fallback, and duplicate historical rows in `tests/strategies/test_runner_active_basket_pending.py` and `tests/data/test_mdm_history_fetch_diagnostics.py`.

### Testing
- Ran `python -m compileall -q src` and the full compile passed.  
- Ran focused tests `pytest -q tests/data/test_mdm_history_fetch_diagnostics.py tests/strategies/test_runner_active_basket_pending.py` and they passed.  
- Ran the full test-suite with `pytest -q` and the suite completed successfully.  
- New tests added: `tests/strategies/test_runner_active_basket_pending.py` and `tests/data/test_mdm_history_fetch_diagnostics.py`, both reporting all assertions passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26871e274c8324b751f2292b237f0a)