### PR TITLE
Simplify Telegram operator command registry

### DIFF
--- a/src/nifty_scalper_bot/notifications/operator_telegram.py
+++ b/src/nifty_scalper_bot/notifications/operator_telegram.py
@@ -1,0 +1,501 @@
+"""
+Runtime role:
+- Owns the single active Telegram operator command registry.
+- Reports runtime state from attached services using read-only probes.
+- Must not place, cancel, flatten, or modify broker/order state except /emergency via an existing kill-switch hook.
+"""
+
+from __future__ import annotations
+
+import inspect
+import logging
+from collections.abc import Awaitable, Callable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from telegram import Update
+from telegram.ext import Application, CommandHandler, ContextTypes
+
+from nifty_scalper_bot.infra.diagnostics import LOG_TAP
+
+LOG = logging.getLogger(__name__)
+
+Handler = Callable[[Update, ContextTypes.DEFAULT_TYPE, Any], Awaitable[None]]
+
+
+@dataclass(frozen=True, slots=True)
+class CommandSpec:
+    name: str
+    description: str
+    handler: Handler
+
+
+async def safe_reply(update: Update, text: str) -> None:
+    """Reply to a Telegram update when a message is present."""
+
+    message = getattr(update, "effective_message", None) or getattr(update, "message", None)
+    if message is None:
+        LOG.warning("TELEGRAM_REPLY_SKIPPED reason=message_missing")
+        return
+    await message.reply_text(str(text))
+
+
+def _chat_id(update: Update) -> int | None:
+    chat = getattr(update, "effective_chat", None)
+    if chat is None:
+        message = getattr(update, "effective_message", None) or getattr(update, "message", None)
+        chat = getattr(message, "chat", None)
+    raw = getattr(chat, "id", None)
+    try:
+        return int(raw) if raw is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _expected_chat_id(service: Any) -> int | None:
+    for source in (service, getattr(service, "deps", None)):
+        raw = getattr(source, "chat_id", None)
+        if raw is None:
+            continue
+        try:
+            return int(raw)
+        except (TypeError, ValueError):
+            return None
+    return None
+
+
+async def require_authorized_chat(update: Update, service: Any) -> bool:
+    """Return whether the update is from the configured operator chat."""
+
+    received = _chat_id(update)
+    expected = _expected_chat_id(service)
+    if expected is None or received == expected:
+        return True
+    LOG.warning(
+        "TELEGRAM_UNAUTHORIZED_CHAT received_chat_id=%s expected_chat_id=%s",
+        received,
+        expected,
+    )
+    return False
+
+
+def _bool(value: Any) -> str:
+    if value is None:
+        return "WARN"
+    return "OK" if bool(value) else "BLOCKED"
+
+
+def _value(value: Any, missing: str = "WARN: unavailable") -> str:
+    if value is None or value == "":
+        return missing
+    return str(value)
+
+
+def _first_attr(obj: Any, names: Sequence[str]) -> Any:
+    for name in names:
+        if obj is None:
+            return None
+        if hasattr(obj, name):
+            value = getattr(obj, name)
+            if callable(value) and not inspect.iscoroutinefunction(value):
+                try:
+                    value = value()
+                except TypeError:
+                    pass
+                except Exception as exc:  # noqa: BLE001 - read-only diagnostic boundary
+                    return f"WARN: {name} failed: {type(exc).__name__}"
+            if value is not None:
+                return value
+    return None
+
+
+def _dep(service: Any, *names: str) -> Any:
+    deps = getattr(service, "deps", service)
+    for name in names:
+        value = getattr(deps, name, None)
+        if value is not None:
+            return value
+    return None
+
+
+def _context(service: Any) -> Any:
+    return _dep(service, "bot_context") or service
+
+
+def _runtime_snapshot(service: Any) -> dict[str, Any]:
+    ctx = _context(service)
+    mdm = _dep(service, "market_data_manager")
+    data_hub = _dep(service, "data_hub")
+    runner = _dep(service, "strategy_runner")
+    risk = _dep(service, "risk_manager")
+    order = _dep(service, "order_manager", "safe_order_manager")
+    broker = _dep(service, "broker_client", "broker")
+
+    get_status = getattr(service, "get_status", None)
+    status_text = None
+    if callable(get_status):
+        try:
+            status_text = get_status()
+        except Exception as exc:  # noqa: BLE001 - diagnostic only
+            status_text = f"WARN: get_status failed: {type(exc).__name__}"
+
+    selected_ce = _first_attr(ctx, ("selected_ce", "atm_ce", "ce_symbol", "call_symbol"))
+    selected_pe = _first_attr(ctx, ("selected_pe", "atm_pe", "pe_symbol", "put_symbol"))
+    basket = _first_attr(ctx, ("active_basket", "contract_basket", "basket"))
+    if basket is not None and not isinstance(basket, str):
+        selected_ce = selected_ce or _first_attr(basket, ("ce_symbol", "call_symbol", "selected_ce"))
+        selected_pe = selected_pe or _first_attr(basket, ("pe_symbol", "put_symbol", "selected_pe"))
+
+    live_orders_armed = _first_attr(ctx, ("live_orders_armed", "live_order_armed"))
+    if live_orders_armed is None:
+        live_orders_armed = _first_attr(order, ("live_orders_armed", "is_live_armed"))
+    live_block_reason = _first_attr(ctx, ("live_block_reason", "block_reason"))
+
+    return {
+        "mode": _first_attr(ctx, ("mode", "trading_mode", "effective_mode")) or getattr(service, "mode", None),
+        "effective_mode": _first_attr(ctx, ("effective_mode", "execution_mode")),
+        "market_state": _first_attr(ctx, ("market_state", "market_open", "session_state")),
+        "selected_ce": selected_ce,
+        "selected_pe": selected_pe,
+        "spot_price": _first_attr(mdm, ("spot_ltp", "nifty_spot", "spot_price")) or _first_attr(data_hub, ("spot_ltp", "spot_price")),
+        "futures_symbol": _first_attr(ctx, ("futures_symbol", "future_symbol")),
+        "data_hard_ready": _first_attr(ctx, ("data_hard_ready", "market_data_ready")),
+        "evaluation_ready": _first_attr(ctx, ("evaluation_ready", "strategy_ready")),
+        "live_orders_armed": live_orders_armed,
+        "live_block_reason": live_block_reason,
+        "mdm": mdm,
+        "data_hub": data_hub,
+        "runner": runner,
+        "risk": risk,
+        "order": order,
+        "broker": broker,
+        "websocket": _dep(service, "websocket_manager", "streamer", "stream_supervisor"),
+        "status_text": status_text,
+    }
+
+
+def _lines(title: str, items: Mapping[str, Any]) -> str:
+    body = [title]
+    for key, value in items.items():
+        body.append(f"{key}: {_value(value)}")
+    return "\n".join(body)
+
+
+def _make_bound_handler(service: Any, func: Handler) -> Callable[[Update, ContextTypes.DEFAULT_TYPE], Awaitable[None]]:
+    async def _bound(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        if not await require_authorized_chat(update, service):
+            return
+        try:
+            await func(update, context, service)  # type: ignore[arg-type]
+        except Exception as exc:  # noqa: BLE001 - Telegram boundary must reply
+            LOG.error("TELEGRAM_COMMAND_FAILED command=%s error=%s", getattr(func, "__name__", "unknown"), exc, exc_info=True)
+            await safe_reply(update, f"ERROR: {type(exc).__name__}: {exc}")
+
+    return _bound
+
+
+async def cmd_start(update: Update, _: ContextTypes.DEFAULT_TYPE, service: Any) -> None:
+    snap = _runtime_snapshot(service)
+    await safe_reply(
+        update,
+        "✅ Nifty Scalper Bot online\n"
+        f"mode: {_value(snap.get('effective_mode') or snap.get('mode'))}\n"
+        f"market: {_value(snap.get('market_state'))}\n"
+        f"live_orders_armed: {_bool(snap.get('live_orders_armed'))}\n"
+        "Use /help",
+    )
+
+
+async def cmd_help(update: Update, _: ContextTypes.DEFAULT_TYPE, service: Any) -> None:
+    del service
+    await safe_reply(update, "\n".join(f"{spec.name} - {spec.description}" for spec in OPERATOR_COMMANDS))
+
+
+async def cmd_ping(update: Update, _: ContextTypes.DEFAULT_TYPE, service: Any) -> None:
+    del service
+    await safe_reply(update, "pong")
+
+
+async def cmd_status(update: Update, _: ContextTypes.DEFAULT_TYPE, service: Any) -> None:
+    snap = _runtime_snapshot(service)
+    await safe_reply(
+        update,
+        _lines(
+            "Status",
+            {
+                "mode": snap.get("mode"),
+                "effective_mode": snap.get("effective_mode"),
+                "market": snap.get("market_state"),
+                "selected_ce": snap.get("selected_ce"),
+                "selected_pe": snap.get("selected_pe"),
+                "data_hard_ready": _bool(snap.get("data_hard_ready")),
+                "evaluation_ready": _bool(snap.get("evaluation_ready")),
+                "live_orders_armed": _bool(snap.get("live_orders_armed")),
+                "live_block_reason": snap.get("live_block_reason") or "none",
+            },
+        ),
+    )
+
+
+def _component_state(name: str, value: Any) -> str:
+    return "OK" if value is not None else f"WARN: {name} not attached"
+
+
+async def cmd_health(update: Update, _: ContextTypes.DEFAULT_TYPE, service: Any) -> None:
+    snap = _runtime_snapshot(service)
+    top = snap.get("live_block_reason") or _why_reason(snap) or "none"
+    overall = "BLOCKED" if snap.get("live_block_reason") else "WARN" if any(snap.get(k) is None for k in ("mdm", "broker", "runner", "risk", "order")) else "OK"
+    await safe_reply(
+        update,
+        _lines(
+            f"Health: {overall}",
+            {
+                "market_data": _component_state("MarketDataManager", snap.get("mdm")),
+                "broker": _component_state("Broker", snap.get("broker")),
+                "telegram": "OK",
+                "strategy_runner": _component_state("StrategyRunner", snap.get("runner")),
+                "risk_execution": "OK" if snap.get("risk") is not None and snap.get("order") is not None else "WARN: risk/execution not fully attached",
+                "top_blocker": top,
+            },
+        ),
+    )
+
+
+async def cmd_diag(update: Update, _: ContextTypes.DEFAULT_TYPE, service: Any) -> None:
+    snap = _runtime_snapshot(service)
+    await safe_reply(
+        update,
+        "Diagnostics\n"
+        "Connectivity\n"
+        f"broker: {_component_state('Broker', snap.get('broker'))}\n"
+        f"websocket: {_component_state('WebSocket', snap.get('websocket'))}\n"
+        "Market Data\n"
+        f"mdm: {_component_state('MarketDataManager', snap.get('mdm'))}\n"
+        f"selected_ce: {_value(snap.get('selected_ce'))}\nselected_pe: {_value(snap.get('selected_pe'))}\n"
+        "Hydration\n"
+        f"data_hard_ready: {_bool(snap.get('data_hard_ready'))}\nevaluation_ready: {_bool(snap.get('evaluation_ready'))}\n"
+        "Strategy/Core\n"
+        f"runner: {_component_state('StrategyRunner', snap.get('runner'))}\n"
+        "Execution/Risk\n"
+        f"live_orders_armed: {_bool(snap.get('live_orders_armed'))}\nrisk: {_component_state('RiskManager', snap.get('risk'))}\norder: {_component_state('OrderManager', snap.get('order'))}\n"
+        "Last Errors\n"
+        f"{_recent_errors_text()}"
+    )
+
+
+def _why_reason(snap: Mapping[str, Any]) -> str | None:
+    for obj_key, attrs in (
+        ("runner", ("last_gate_reason", "last_block_reason", "latest_rejection_reason")),
+        ("order", ("last_preflight_reject_reason", "last_reject_reason", "last_rejection")),
+        ("risk", ("last_rejection", "last_reason", "last_reject_reason")),
+    ):
+        reason = _first_attr(snap.get(obj_key), attrs)
+        if reason:
+            return str(reason)
+    return None
+
+
+async def cmd_why(update: Update, _: ContextTypes.DEFAULT_TYPE, service: Any) -> None:
+    snap = _runtime_snapshot(service)
+    reason = snap.get("live_block_reason") or _why_reason(snap) or "No current rejection; waiting for valid signal"
+    await safe_reply(update, f"Why\nreason: {reason}")
+
+
+async def cmd_check(update: Update, _: ContextTypes.DEFAULT_TYPE, service: Any) -> None:
+    snap = _runtime_snapshot(service)
+    await safe_reply(update, _lines("Check", {
+        "connectivity": "OK" if snap.get("broker") or snap.get("websocket") else "WARN: broker/websocket not attached",
+        "market": "OK" if snap.get("mdm") else "WARN: MarketDataManager not attached",
+        "core": "OK" if snap.get("runner") else "WARN: StrategyRunner not attached",
+        "execution": "OK" if snap.get("risk") and snap.get("order") else "WARN: risk/execution not fully attached",
+        "errors": _recent_errors_text(short=True),
+    }))
+
+
+async def cmd_check_connectivity(update: Update, _: ContextTypes.DEFAULT_TYPE, service: Any) -> None:
+    snap = _runtime_snapshot(service)
+    websocket = snap.get("websocket")
+    await safe_reply(update, _lines("Connectivity", {
+        "broker_session": _first_attr(snap.get("broker"), ("is_session_valid", "session_valid", "is_connected")) or _component_state("Broker", snap.get("broker")),
+        "websocket_connected": _first_attr(websocket, ("is_connected", "connected", "is_running")) or _component_state("WebSocket", websocket),
+        "mdm_ready": _bool(_first_attr(snap.get("mdm"), ("is_ready", "ready"))),
+        "datahub_live": _component_state("DataHub", snap.get("data_hub")),
+        "telegram": "OK",
+    }))
+
+
+async def cmd_check_market(update: Update, _: ContextTypes.DEFAULT_TYPE, service: Any) -> None:
+    snap = _runtime_snapshot(service)
+    mdm = snap.get("mdm")
+    await safe_reply(update, _lines("Market", {
+        "selected_ce": snap.get("selected_ce"),
+        "selected_pe": snap.get("selected_pe"),
+        "spot_price": snap.get("spot_price"),
+        "futures_symbol": snap.get("futures_symbol"),
+        "subscriptions": _first_attr(mdm, ("subscribed_tokens", "subscriptions", "get_subscription_snapshot")),
+        "tick_freshness": _first_attr(mdm, ("tick_freshness", "last_tick_age", "freshness")),
+        "quote_depth": _first_attr(mdm, ("quote_quality", "depth_status", "quote_depth_status")),
+        "hydration_bars": _first_attr(mdm, ("hydration_bars", "bar_count", "ohlc_status")),
+    }))
+
+
+async def cmd_check_core(update: Update, _: ContextTypes.DEFAULT_TYPE, service: Any) -> None:
+    snap = _runtime_snapshot(service)
+    ctx = _context(service)
+    await safe_reply(update, _lines("Core", {
+        "startup_phase": _first_attr(ctx, ("startup_phase", "phase")),
+        "data_phase": _first_attr(ctx, ("data_phase",)),
+        "runner": _component_state("StrategyRunner", snap.get("runner")),
+        "regime": _first_attr(_dep(service, "regime_manager", "market_regime"), ("current_regime", "regime", "snapshot")),
+        "evaluation_ready": _bool(snap.get("evaluation_ready")),
+        "strategy_gate_reason": _why_reason(snap) or "none",
+    }))
+
+
+async def cmd_check_execution(update: Update, _: ContextTypes.DEFAULT_TYPE, service: Any) -> None:
+    snap = _runtime_snapshot(service)
+    order = snap.get("order")
+    risk = snap.get("risk")
+    await safe_reply(update, _lines("Execution", {
+        "live_orders_armed": _bool(snap.get("live_orders_armed")),
+        "broker_health": _component_state("Broker", snap.get("broker")),
+        "risk_breaker": _first_attr(risk, ("breaker_tripped", "is_breaker_tripped")) or _component_state("RiskManager", risk),
+        "open_positions": _first_attr(_dep(service, "position_manager"), ("open_positions", "positions", "get_open_positions")),
+        "open_orders": _first_attr(order, ("open_orders", "get_open_orders", "pending_orders")),
+        "bracket_manager": _component_state("BracketManager", _dep(service, "bracket_manager")),
+        "emergency_stop": _first_attr(order, ("emergency_stopped", "kill_switch_engaged", "is_kill_switch_engaged")) or "WARN: state unavailable",
+    }))
+
+
+def _recent_errors_text(short: bool = False) -> str:
+    try:
+        recent = LOG_TAP.recent(5 if short else 10, level="ERROR")
+        if recent:
+            return " | ".join(str(item) for item in recent[:3]) if short else "\n".join(str(item) for item in recent)
+    except Exception as exc:  # noqa: BLE001 - optional diagnostics
+        LOG.debug("LOG_TAP unavailable: %s", exc)
+    return "No recent errors available from runtime buffer."
+
+
+async def cmd_errors(update: Update, _: ContextTypes.DEFAULT_TYPE, service: Any) -> None:
+    del service
+    await safe_reply(update, _recent_errors_text())
+
+
+async def cmd_stderror(update: Update, _: ContextTypes.DEFAULT_TYPE, service: Any) -> None:
+    err = _first_attr(_context(service), ("last_exception", "last_error", "runtime_exception"))
+    await safe_reply(update, str(err) if err else "No runtime exception captured.")
+
+
+async def cmd_selftest(update: Update, _: ContextTypes.DEFAULT_TYPE, service: Any) -> None:
+    snap = _runtime_snapshot(service)
+    await safe_reply(update, _lines("Selftest (read-only)", {
+        "settings": "OK" if _expected_chat_id(service) is not None else "WARN: Telegram chat id missing",
+        "telegram_authorized": "OK",
+        "mdm": _component_state("MarketDataManager", snap.get("mdm")),
+        "datahub": _component_state("DataHub", snap.get("data_hub")),
+        "runner": _component_state("StrategyRunner", snap.get("runner")),
+        "broker": _component_state("Broker", snap.get("broker")),
+        "selected_ce": snap.get("selected_ce"),
+        "selected_pe": snap.get("selected_pe"),
+        "hydration": _bool(snap.get("data_hard_ready")),
+        "readiness": _bool(snap.get("evaluation_ready")),
+    }))
+
+
+async def _maybe_await(value: Any) -> Any:
+    if inspect.isawaitable(value):
+        return await value
+    return value
+
+
+async def _call_emergency_hook(func: Callable[..., Any], *, name: str) -> Any:
+    for args, kwargs in (
+        ((), {"reason": "telegram_emergency"}),
+        (("telegram_emergency",), {}),
+        ((), {}),
+    ):
+        try:
+            return await _maybe_await(func(*args, **kwargs))
+        except TypeError:
+            continue
+    raise TypeError(f"{name} emergency hook signature unsupported")
+
+
+async def cmd_emergency(update: Update, _: ContextTypes.DEFAULT_TYPE, service: Any) -> None:
+    order = _dep(service, "order_manager", "safe_order_manager")
+    close_all = getattr(service, "close_all_positions", None)
+    if callable(close_all):
+        result = await _maybe_await(close_all())
+        await safe_reply(update, f"Emergency triggered: {result if result is not None else 'handler completed'}")
+        return
+    for name in ("emergency_stop", "engage_kill_switch", "kill_switch"):
+        func = getattr(order, name, None)
+        if callable(func):
+            result = await _call_emergency_hook(func, name=name)
+            await safe_reply(update, f"Emergency triggered: {result if result is not None else name}")
+            return
+    await safe_reply(update, "Emergency handler not wired.")
+
+
+OPERATOR_COMMANDS: list[CommandSpec] = [
+    CommandSpec("start", "show bot online and compact command menu", cmd_start),
+    CommandSpec("help", "list available commands", cmd_help),
+    CommandSpec("ping", "simple bot responsiveness check", cmd_ping),
+    CommandSpec("status", "compact current runtime status", cmd_status),
+    CommandSpec("health", "system health and important alerts", cmd_health),
+    CommandSpec("diag", "full diagnostics summary", cmd_diag),
+    CommandSpec("why", "reason no trade was taken / current trade rejection reason", cmd_why),
+    CommandSpec("check", "subsystem readiness overview", cmd_check),
+    CommandSpec("check_connectivity", "broker, websocket, data, Telegram connectivity", cmd_check_connectivity),
+    CommandSpec("check_market", "market data, selected CE/PE, hydration, quote/depth status", cmd_check_market),
+    CommandSpec("check_core", "strategy runner, regime, session, startup/readiness state", cmd_check_core),
+    CommandSpec("check_execution", "live-order arming, risk, positions, open orders, bracket status", cmd_check_execution),
+    CommandSpec("errors", "recent error log summary", cmd_errors),
+    CommandSpec("stderror", "last runtime exception/error details", cmd_stderror),
+    CommandSpec("selftest", "run non-invasive system self-test", cmd_selftest),
+    CommandSpec("emergency", "emergency stop / disable live orders", cmd_emergency),
+]
+
+OPERATOR_COMMAND_NAMES: tuple[str, ...] = tuple(spec.name for spec in OPERATOR_COMMANDS)
+
+
+def _remove_command_handlers(application: Application) -> None:
+    handlers = getattr(application, "handlers", None)
+    if not isinstance(handlers, dict):
+        return
+    for group, group_handlers in list(handlers.items()):
+        handlers[group] = [h for h in group_handlers if not isinstance(h, CommandHandler)]
+
+
+def registered_command_names(application: Application) -> list[str]:
+    commands: set[str] = set()
+    handlers = getattr(application, "handlers", {})
+    for group_handlers in getattr(handlers, "values", lambda: [])():
+        for handler in group_handlers:
+            raw = getattr(handler, "commands", None)
+            if raw:
+                commands.update(str(cmd) for cmd in raw)
+    return sorted(commands)
+
+
+def register_operator_commands(application: Application, service: Any) -> list[str]:
+    """Install the one active operator command set on a PTB application."""
+
+    _remove_command_handlers(application)
+    for spec in OPERATOR_COMMANDS:
+        application.add_handler(CommandHandler(spec.name, _make_bound_handler(service, spec.handler)))
+    commands = registered_command_names(application)
+    LOG.info("TELEGRAM_COMMAND_REGISTRY_FINAL commands=%s", commands)
+    return commands
+
+
+__all__ = [
+    "CommandSpec",
+    "OPERATOR_COMMANDS",
+    "OPERATOR_COMMAND_NAMES",
+    "register_operator_commands",
+    "registered_command_names",
+    "safe_reply",
+    "require_authorized_chat",
+]

--- a/src/nifty_scalper_bot/notifications/telegram_commands.py
+++ b/src/nifty_scalper_bot/notifications/telegram_commands.py
@@ -647,71 +647,13 @@ def _command_exists(application: TelegramApplication, command: str) -> bool:
 
 
 def register_telegram_commands(bot: Any, application: TelegramApplication, services: Services) -> bool:
-    """Register production commands with security wrapping."""
-    command_handler_cls = _load_command_handler()
-    if command_handler_cls is None:
-        return False
+    """Deprecated compatibility hook; active commands are registered by operator_telegram.
 
-    # 1. Inject correct chat ID from the bot instance if not already set
-    if hasattr(bot, "deps") and hasattr(bot.deps, "chat_id"):
-        # We modify the services instance in-place to carry the auth ID
-        object.__setattr__(services, "allowed_chat_id", int(bot.deps.chat_id))
+    The Telegram runtime now has exactly one active registration path:
+    :func:`nifty_scalper_bot.notifications.operator_telegram.register_operator_commands`.
+    This legacy hook intentionally does not add aliases or duplicate commands.
+    """
 
-    # 2. Register aliases from the main bot controller
-    aliases: dict[str, Callable] = {}
-    if hasattr(bot, "cmd_positions"): aliases["pos"] = bot.cmd_positions
-    if hasattr(bot, "cmd_trades"): aliases["fills"] = bot.cmd_trades
-    if hasattr(bot, "cmd_tail"): aliases["logs"] = bot.cmd_tail
-    if hasattr(bot, "cmd_debug_on"): aliases["trace"] = bot.cmd_debug_on
-    if hasattr(bot, "cmd_kpi"): aliases["perf"] = bot.cmd_kpi
-
-    for name, handler in aliases.items():
-        if not _command_exists(application, name):
-            application.add_handler(command_handler_cls(name, handler))
-
-    # 3. Register local commands with security wrapper
-    new_commands: dict[str, CommandFunc] = {
-        "mode": cmd_mode,
-        "live": cmd_live,
-        "flat": cmd_flat,
-        "brk": cmd_brk,
-        "entry": cmd_entry,
-        "exit": cmd_exit,
-        "dryrun": cmd_dryrun,
-        "diag": cmd_diag,
-        "uptime": cmd_uptime,
-        "limits": cmd_limits,
-        "net": cmd_net,
-        "save": cmd_save,
-        "book": cmd_book,
-        "ohlc": cmd_ohlc,
-        "chain": cmd_chain,
-        "atm": cmd_atm,
-        "spot": cmd_spot,
-        "greeks": cmd_greeks,
-        "iv": cmd_iv,
-        "prevclose": cmd_prevclose,
-        "session": cmd_session,
-        "holiday": cmd_holiday,
-        "sig": cmd_sig,
-        "state": cmd_state,
-        "score": cmd_score,
-        "regime": cmd_regime,
-        "gate_why": cmd_gate_why,
-        "size": cmd_size,
-        "trail": cmd_trail,
-        "riskstate": cmd_riskstate,
-        "journal": cmd_journal_read,
-        "execstate": cmd_execstate,
-        "execqueue": cmd_execqueue,
-        "execlast": cmd_execlast,
-        "execwhy": cmd_execwhy,
-        "emergencystop": cmd_emergencystop,
-    }
-
-    for name, func in new_commands.items():
-        if not _command_exists(application, name):
-            application.add_handler(
-                command_handler_cls(name, _wrap_command(services, func, name))
-            )
+    del bot, application, services
+    LOG.info("TELEGRAM_LEGACY_COMMAND_REGISTRATION_SKIPPED reason=operator_registry_active")
     return True

--- a/src/nifty_scalper_bot/notifications/telegram_controller.py
+++ b/src/nifty_scalper_bot/notifications/telegram_controller.py
@@ -96,6 +96,7 @@ from nifty_scalper_bot.infra.diagnostics import LOG_TAP
 from nifty_scalper_bot.infra.metrics import METRICS, MetricsCollector
 from nifty_scalper_bot.infra.ws_diag import WsDiag, run_diag
 from nifty_scalper_bot.notifications.safe_messenger import SafeMessenger
+from nifty_scalper_bot.notifications.operator_telegram import register_operator_commands
 from nifty_scalper_bot.utils.alerts import (
     AggregatedAlert,
     AlertDeduplicator,
@@ -705,13 +706,10 @@ class TelegramBot:
             await self._safe_send("💓 Bot alive")
 
     def _register_handlers(self) -> None:
-        """Register core handlers once; Args: none. Returns: None. Raises: None."""
+        """Register the single active operator command set once."""
         if self._handlers_registered:
             return
-        self.application.add_handler(CommandHandler("start", self._cmd_start))
-        self.application.add_handler(CommandHandler("stop", self._cmd_stop))
-        self.application.add_handler(CommandHandler("status", self._cmd_status))
-        self.application.add_handler(CommandHandler("summary", self._cmd_summary))
+        register_operator_commands(self.application, self)
         self.application.add_handler(
             MessageHandler(filters.TEXT & ~filters.COMMAND, self._handle_text)
         )
@@ -4225,22 +4223,11 @@ class TelegramBot:
     # Command wiring
     # --------------
     def _wire_handlers(self, app: Application) -> None:
+        """Wire the single active production-operator command registry."""
+
         async def _debug_message(
             update: Update, context: ContextTypes.DEFAULT_TYPE
         ) -> None:
-            """Log every incoming Telegram message for diagnostics.
-
-            Args:
-                update: Telegram update payload.
-                context: Callback context from python-telegram-bot.
-
-            Returns:
-                None.
-
-            Raises:
-                None.
-            """
-
             del context
             message = getattr(update, "message", None)
             text = getattr(message, "text", None)
@@ -4249,220 +4236,7 @@ class TelegramBot:
         if not self._message_debug_handler_registered:
             app.add_handler(MessageHandler(filters.ALL, _debug_message))
             self._message_debug_handler_registered = True
-
-        def register(
-            cmd: str,
-            handler: t.Callable[[Update, t.Any], t.Coroutine[t.Any, t.Any, t.Any]],
-        ) -> None:
-            if self._command_registered(app, cmd):
-                return
-            app.add_handler(CommandHandler(cmd, handler))
-            self._register_command_doc(cmd, handler)
-
-        def register_with_aliases(
-            primary: str,
-            handler: t.Callable[[Update, t.Any], t.Coroutine[t.Any, t.Any, t.Any]],
-            aliases: tuple[str, ...] = (),
-        ) -> None:
-            register(primary, handler)
-            for alias in aliases:
-                register(alias, handler)
-
-        CommandHandlerType = t.Callable[
-            [Update, t.Any],
-            t.Coroutine[t.Any, t.Any, t.Any],
-        ]
-        CommandEntry = tuple[str, CommandHandlerType, tuple[str, ...]]
-        CommandGroup = tuple[str, tuple[CommandEntry, ...]]
-
-        command_groups: tuple[CommandGroup, ...] = (
-            (
-                "top_level_diagnostics",
-                (
-                    ("help", self.cmd_help, ()),
-                    ("status", self.cmd_status, ()),
-                    ("session", self.cmd_session, ()),
-                    ("quick", self.cmd_quick, ()),
-                    ("health", self.cmd_health, ()),
-                    ("version", self.cmd_version, ()),
-                    ("whoami", self.cmd_whoami, ()),
-                ),
-            ),
-            (
-                "core_functionality_state",
-                (
-                    ("start", self.cmd_start, ()),
-                    ("stop", self.cmd_stop, ()),
-                    ("mode", self.cmd_shadow, ("shadow",)),
-                    ("plan", self.cmd_plan, ()),
-                    ("limits", self.cmd_gate, ("gate",)),
-                    ("save", self.cmd_dump_logs, ()),
-                    ("reload", self.cmd_reload, ()),
-                ),
-            ),
-            (
-                "market_data_connectivity",
-                (
-                    ("mdm", self.cmd_mdm, ()),
-                    ("ws_status", self.cmd_ws_status, ("ws",)),
-                    ("ws_diag", self.cmd_ws_diag, ()),
-                    ("ws_reconnect", self.cmd_ws_reconnect, ()),
-                    ("poll_status", self.cmd_poll_status, ()),
-                    ("subscribe", self.cmd_subscribe, ("sub",)),
-                    ("unsubscribe", self.cmd_unsubscribe, ("unsub",)),
-                    ("watch", self.cmd_watch, ()),
-                    ("unwatch", self.cmd_unwatch, ()),
-                    ("tracking", self.cmd_tracking, ()),
-                    ("iv", self.cmd_iv, ()),
-                    ("greeks", self.cmd_greeks, ()),
-                    (
-                        "quote",
-                        self.cmd_quote,
-                        ("book", "ohlc", "chain", "atm", "spot"),
-                    ),
-                    ("tick", self.cmd_tick, ()),
-                    ("diag_price", self.cmd_diag_price, ()),
-                    ("fresh", self.cmd_fresh, ()),
-                    ("transport", self.cmd_transport, ()),
-                    ("resolve", self.cmd_resolve, ()),
-                    ("broker_quote", self.cmd_broker_quote, ()),
-                    ("qprobe", self.cmd_qprobe, ()),
-                    ("ingestprobe", self.cmd_ingestprobe, ("iprobe", "pipe")),
-                    ("quote_probe", self.cmd_quote_probe, ()),
-                    ("probe", self.cmd_probe, ()),
-                ),
-            ),
-            (
-                "unified_manager",
-                (
-                    ("um", self.cmd_um, ()),
-                    ("umlearn", self.cmd_umlearn, ()),
-                    ("umprobe", self.cmd_umprobe, ()),
-                    ("umtransport", self.cmd_umtransport, ()),
-                    ("umplan", self.cmd_umplan, ()),
-                    ("umwatch", self.cmd_umwatch, ()),
-                    ("uminstruments", self.cmd_uminstruments, ()),
-                    ("umwarm", self.cmd_umwarm, ()),
-                    ("umstats", self.cmd_umstats, ()),
-                ),
-            ),
-            (
-                "orders_positions_trades",
-                (
-                    ("positions", self.cmd_positions, ()),
-                    ("orders", self.cmd_orders, ()),
-                    ("trades", self.cmd_trades, ("fills",)),
-                    ("buy", self.cmd_buy, ("entry",)),
-                    ("sell", self.cmd_sell, ("exit",)),
-                    ("cancel", self.cmd_cancel, ("flat",)),
-                    ("net", self.cmd_ping, ("ping",)),
-                ),
-            ),
-            (
-                "risk_performance_regimes",
-                (
-                    ("risk", self.cmd_risk, ("riskstate",)),
-                    ("diag_risk", self.cmd_diag_risk, ()),
-                    ("regime", self.cmd_regime, ()),
-                    ("diag", self.cmd_diag, ()),
-                    ("balance", self.cmd_balance, ()),
-                    ("balance_probe", self.cmd_balance_probe, ()),
-                    ("margin", self.cmd_margin, ()),
-                    ("pnl", self.cmd_pnl, ()),
-                    ("heatmap", self.cmd_heatmap, ("metrics_heatmap",)),
-                    ("report", self.cmd_report, ()),
-                    ("kpi", self.cmd_kpi, ("score",)),
-                    ("trail", self.cmd_guard, ()),
-                    ("size", self.cmd_plan, ()),
-                    ("journal", self.cmd_issues, ()),
-                ),
-            ),
-            (
-                "strategy_execution_management",
-                (
-                    ("strategies", self.cmd_strategies, ("sig",)),
-                    ("signals", self.cmd_signals, ()),
-                    (
-                        "strategy_scores",
-                        self.cmd_strategy_scores,
-                        ("scores",),
-                    ),
-                    (
-                        "strategy_allocate",
-                        self.cmd_strategy_allocate,
-                        ("strategy_alloc",),
-                    ),
-                    ("score", self.cmd_score, ()),
-                    ("alloc", self.cmd_allocations, ()),
-                    (
-                        "strategy_disable",
-                        self.cmd_strategy_disable,
-                        ("strategy_off",),
-                    ),
-                    (
-                        "strategy_enable",
-                        self.cmd_strategy_enable,
-                        ("strategy_on",),
-                    ),
-                    ("regime_bypass", self.cmd_regime_bypass, ()),
-                    ("guard", self.cmd_guard, ()),
-                    ("selftest", self.cmd_selftest, ()),
-                    ("assess", self.cmd_assess, ()),
-                    ("reset_kill", self.cmd_reset_kill, ("riskreset", "reset_kill_switch")),
-                    ("killstatus", self.cmd_killstatus, ("kill_status",)),
-                    ("cooldown", self.cmd_cooldown, ()),
-                    ("pause", self.cmd_pause, ()),
-                    ("resume", self.cmd_resume, ()),
-                    ("test_trade", self.cmd_test_trade, ()),
-                    ("engine_test", self.cmd_engine_test, ()),
-                    ("test_flow", self.cmd_test_flow, ()),
-                    ("paper", self.cmd_paper, ()),
-                    ("paper_on", self.cmd_paper_on, ()),
-                    ("paper_off", self.cmd_paper_off, ()),
-                    ("shadow_on", self.cmd_shadow_on, ()),
-                    ("shadow_off", self.cmd_shadow_off, ()),
-                ),
-            ),
-            (
-                "logging_error_reporting",
-                (
-                    ("logs", self.cmd_tail, ("tail",)),
-                    ("dumpLogs", self.cmd_dump_logs, ()),
-                    ("errors", self.cmd_errors, ()),
-                    ("issues", self.cmd_issues, ()),
-                    ("stderror", self.cmd_stderr, ()),
-                    ("check", self.cmd_check, ()),
-                    ("check_core", self.cmd_check_core, ()),
-                    ("check_market", self.cmd_check_market, ()),
-                    ("check_execution", self.cmd_check_execution, ()),
-                    ("check_connectivity", self.cmd_check_connectivity, ()),
-                    ("why", self.cmd_why, ()),
-                    ("preflight", self.cmd_preflight, ()),
-                    ("flow", self.cmd_flow, ()),
-                    ("profile", self.cmd_profile, ()),
-                    ("metrics", self.cmd_metrics, ()),
-                    ("config", self.cmd_config, ()),
-                    ("env", self.cmd_env, ()),
-                    ("gc", self.cmd_gc, ()),
-                ),
-            ),
-            (
-                "advanced_administrative",
-                (
-                    ("opshelp", self.cmd_opshelp, ()),
-                    ("confirm", self.cmd_confirm, ()),
-                    ("debug_on", self.cmd_debug_on, ()),
-                    ("debug_off", self.cmd_debug_off, ()),
-                    ("replay", self.cmd_replay, ("replay_day",)),
-                    ("backtest", self.cmd_backtest, ()),
-                    ("go_flat", self.cmd_go_flat, ()),
-                ),
-            ),
-        )
-
-        for _, entries in command_groups:
-            for primary, handler, aliases in entries:
-                register_with_aliases(primary, handler, aliases)
+        register_operator_commands(app, self)
 
     # ------------------
     # Helper pretty print

--- a/src/nifty_scalper_bot/notifications/telegram_service.py
+++ b/src/nifty_scalper_bot/notifications/telegram_service.py
@@ -12,6 +12,7 @@ from telegram.error import Conflict, NetworkError, RetryAfter, TimedOut
 from telegram.ext import Application, ApplicationBuilder, CommandHandler, ContextTypes
 
 from nifty_scalper_bot.utils.async_helpers import safe_task
+from nifty_scalper_bot.notifications.operator_telegram import register_operator_commands
 
 _LOG = logging.getLogger("nifty_scalper_bot.telegram")
 
@@ -477,28 +478,7 @@ class TelegramService:
             .build()
         )
         app.add_error_handler(self._on_error)
-        _LOG.info(
-            "telegram.cmd.inventory.initial",
-            extra={"commands": _list_existing_commands(app)},
-        )
-        command_specs: tuple[tuple[str, CommandCallback, tuple[str, ...]], ...] = (
-            ("help", self._cmd_help_admin, ("opshelp", "help_admin")),
-            ("status", self._cmd_status, ("session",)),
-            ("statusv", self._cmd_status_verbose, ()),
-            ("health", self._cmd_selftest, ("selftest", "diag")),
-            ("ping", self._cmd_ping, ("net",)),
-            ("start", self._cmd_start, ()),
-            ("ws_status", self._cmd_ws, ("ws",)),
-            ("emergency", self._cmd_emergency, ()),
-        )
-        for primary, handler, aliases in command_specs:
-            safe_add(app, primary, handler)
-            for alias in aliases:
-                safe_add(app, alias, handler)
-        _LOG.info(
-            "telegram.cmd.inventory.final",
-            extra={"commands": _list_existing_commands(app)},
-        )
+        register_operator_commands(app, self)
         return app
 
     async def _start_polling(self) -> None:

--- a/tests/notifications/test_operator_telegram.py
+++ b/tests/notifications/test_operator_telegram.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from telegram.ext import CommandHandler
+
+from nifty_scalper_bot.notifications.operator_telegram import (
+    OPERATOR_COMMAND_NAMES,
+    register_operator_commands,
+    registered_command_names,
+)
+
+
+class FakeApp:
+    def __init__(self) -> None:
+        self.handlers: dict[int, list[object]] = {0: []}
+
+    def add_handler(self, handler: object, group: int = 0) -> None:
+        self.handlers.setdefault(group, []).append(handler)
+
+
+class DummyMessage:
+    def __init__(self) -> None:
+        self.replies: list[str] = []
+        self.chat = SimpleNamespace(id=12345)
+
+    async def reply_text(self, text: str, **_: Any) -> None:
+        self.replies.append(text)
+
+
+class DummyUpdate:
+    def __init__(self, chat_id: int = 12345) -> None:
+        self.effective_chat = SimpleNamespace(id=chat_id)
+        self.effective_message = DummyMessage()
+        self.effective_message.chat = self.effective_chat
+        self.message = self.effective_message
+
+
+class DummyContext:
+    pass
+
+
+def _handler(app: FakeApp, command: str) -> CommandHandler:
+    for item in app.handlers.get(0, []):
+        if isinstance(item, CommandHandler) and command in item.commands:
+            return item
+    raise AssertionError(f"missing command {command}")
+
+
+@pytest.mark.asyncio
+async def test_operator_registry_keeps_only_production_commands(caplog: pytest.LogCaptureFixture) -> None:
+    app = FakeApp()
+    app.add_handler(CommandHandler("legacy", lambda *_: None))
+    service = SimpleNamespace(chat_id=12345)
+
+    with caplog.at_level("INFO"):
+        commands = register_operator_commands(app, service)  # type: ignore[arg-type]
+
+    assert commands == sorted(OPERATOR_COMMAND_NAMES)
+    assert registered_command_names(app) == sorted(OPERATOR_COMMAND_NAMES)  # type: ignore[arg-type]
+    assert "legacy" not in commands
+    assert any("TELEGRAM_COMMAND_REGISTRY_FINAL" in rec.getMessage() for rec in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_help_lists_exactly_kept_commands() -> None:
+    app = FakeApp()
+    service = SimpleNamespace(chat_id=12345)
+    register_operator_commands(app, service)  # type: ignore[arg-type]
+    update = DummyUpdate()
+
+    await _handler(app, "help").callback(update, DummyContext())  # type: ignore[arg-type]
+
+    lines = update.effective_message.replies[-1].splitlines()
+    assert [line.split(" - ", 1)[0] for line in lines] == list(OPERATOR_COMMAND_NAMES)
+    assert "mode -" not in update.effective_message.replies[-1]
+    assert "emergencystop -" not in update.effective_message.replies[-1]
+
+
+@pytest.mark.asyncio
+async def test_ping_replies_pong_with_missing_subsystems() -> None:
+    app = FakeApp()
+    service = SimpleNamespace(chat_id=12345)
+    register_operator_commands(app, service)  # type: ignore[arg-type]
+    update = DummyUpdate()
+
+    await _handler(app, "ping").callback(update, DummyContext())  # type: ignore[arg-type]
+
+    assert update.effective_message.replies == ["pong"]
+
+
+@pytest.mark.asyncio
+async def test_unauthorized_chat_is_rejected_and_logged(caplog: pytest.LogCaptureFixture) -> None:
+    app = FakeApp()
+    service = SimpleNamespace(chat_id=12345)
+    register_operator_commands(app, service)  # type: ignore[arg-type]
+    update = DummyUpdate(chat_id=999)
+
+    with caplog.at_level("WARNING"):
+        await _handler(app, "ping").callback(update, DummyContext())  # type: ignore[arg-type]
+
+    assert update.effective_message.replies == []
+    assert "received_chat_id=999 expected_chat_id=12345" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_missing_subsystem_warns_not_silent() -> None:
+    app = FakeApp()
+    service = SimpleNamespace(chat_id=12345)
+    register_operator_commands(app, service)  # type: ignore[arg-type]
+    update = DummyUpdate()
+
+    await _handler(app, "check_core").callback(update, DummyContext())  # type: ignore[arg-type]
+
+    assert "WARN: StrategyRunner not attached" in update.effective_message.replies[-1]
+
+
+@pytest.mark.asyncio
+async def test_selftest_is_read_only() -> None:
+    app = FakeApp()
+    broker = SimpleNamespace(place_order=lambda *a, **k: (_ for _ in ()).throw(AssertionError("should not trade")))
+    order = SimpleNamespace(cancel_order=lambda *a, **k: (_ for _ in ()).throw(AssertionError("should not cancel")))
+    service = SimpleNamespace(chat_id=12345, deps=SimpleNamespace(broker_client=broker, order_manager=order))
+    register_operator_commands(app, service)  # type: ignore[arg-type]
+    update = DummyUpdate()
+
+    await _handler(app, "selftest").callback(update, DummyContext())  # type: ignore[arg-type]
+
+    assert "Selftest (read-only)" in update.effective_message.replies[-1]
+
+
+@pytest.mark.asyncio
+async def test_emergency_calls_kill_switch_only_when_available() -> None:
+    app = FakeApp()
+    called: list[str] = []
+
+    def kill_switch(reason: str) -> str:
+        called.append(reason)
+        return "armed"
+
+    service = SimpleNamespace(
+        chat_id=12345,
+        deps=SimpleNamespace(order_manager=SimpleNamespace(engage_kill_switch=kill_switch)),
+    )
+    register_operator_commands(app, service)  # type: ignore[arg-type]
+    update = DummyUpdate()
+
+    await _handler(app, "emergency").callback(update, DummyContext())  # type: ignore[arg-type]
+
+    assert called == ["telegram_emergency"]
+    assert "Emergency triggered" in update.effective_message.replies[-1]
+
+
+@pytest.mark.asyncio
+async def test_emergency_reports_unwired_without_side_effect() -> None:
+    app = FakeApp()
+    service = SimpleNamespace(chat_id=12345)
+    register_operator_commands(app, service)  # type: ignore[arg-type]
+    update = DummyUpdate()
+
+    await _handler(app, "emergency").callback(update, DummyContext())  # type: ignore[arg-type]
+
+    assert update.effective_message.replies == ["Emergency handler not wired."]


### PR DESCRIPTION
### Motivation

- Multiple competing Telegram command registration paths caused inconsistent `/help` output and command non-response; operators saw legacy aliases registered in code but not active at runtime.
- The goal was to provide one clear, minimal operator-facing command surface that is compact, read-only by default, and reliably registered at startup.

### Description

- Introduced a single active operator registry `src/nifty_scalper_bot/notifications/operator_telegram.py` with `CommandSpec`, `OPERATOR_COMMANDS`, and `register_operator_commands` implementing the requested keep-list of commands and safe read-only diagnostics.
- Rewired active registration to call `register_operator_commands(...)` from the two startup paths (`telegram_controller.TelegramBot` and `telegram_service.TelegramService`) so there is exactly one registration path; legacy registration now becomes inert.
- Made the legacy `telegram_commands.register_telegram_commands` a deprecated compatibility/no-op hook so legacy modules do not add duplicate or unexpected commands at startup, and added `_remove_command_handlers` to remove prior handlers before installing the operator set; registration logs `TELEGRAM_COMMAND_REGISTRY_FINAL commands=[...]` as required.
- Implemented compact handlers that always reply (warnings if subsystems missing), log unauthorized chat attempts with received/expected chat ids only, ensure `/selftest` is read-only, and make `/emergency` call existing kill-switch/emergency hooks only when wired and supporting multiple common signatures.
- Added focused unit tests `tests/notifications/test_operator_telegram.py` to assert final registry contents, exact `/help` output, `/ping` behavior, unauthorized chat rejection logging, missing-subsystem WARN replies, read-only `/selftest`, and `/emergency` behavior; kept legacy diagnostic code available but no longer actively registered.

### Testing

- Ran `python -m compileall -q src` (success).  
- Ran focused tests: `pytest -q tests/notifications/test_operator_telegram.py` (8 passed).  
- Ran additional notification compatibility tests: `pytest -q tests/notifications/test_telegram_registration.py tests/notifications/test_telegram_commands.py tests/notifications/test_telegram_execution_commands.py` (all passed in this run).  
- Ran full test-suite: `pytest -q` (completed successfully in this environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26dd6727688324a095f12092632a66)