### PR TITLE
Reduce live market data noise and prioritize protected ticks

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -4743,6 +4743,8 @@ def initialize_components(settings: Settings | None = None) -> BotContext:
     position_state_path = Path(data_dir) / "positions.json"
     position_manager = PositionManager(state_file=str(position_state_path))
     position_manager.attach_persistent_state(persistent_state)
+    if hasattr(market_data_manager, "set_position_manager"):
+        market_data_manager.set_position_manager(position_manager)
 
     broker_sync_attempts = max(
         1,

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -301,6 +301,8 @@ class MarketDataManager:
         self._last_historical_ts: dict[str, float] = {}
         self._last_tick_ts: dict[str, float] = {}
         self._last_cumulative_volume_by_symbol: dict[str, float] = {}
+        self._volume_delta_clamp_stats: dict[str, dict[str, float]] = {}
+        self._last_volume_delta_clamp_summary_ts: dict[str, float] = {}
         self._last_tick_snapshot: dict[str, dict[str, Any]] = {}
         self._readiness_requirements: dict[str, Any] = {}
         self._last_readiness_state: dict[str, Any] = {
@@ -327,7 +329,18 @@ class MarketDataManager:
             maxsize=self._tick_queue_maxsize
         )
         self._tick_queue_dropped = 0
+        self._tick_queue_priority_drops: dict[str, int] = defaultdict(int)
+        self._tick_queue_priority_coalesced: dict[str, int] = defaultdict(int)
         self._last_tick_queue_full_log = 0.0
+        self._last_bus_priority_summary_ts = 0.0
+        self._bus_priority_counts: dict[str, int] = defaultdict(int)
+        self._bus_backpressure_counts: dict[str, int] = {}
+        self._bus_backpressure_drops_by_priority: dict[str, int] = defaultdict(int)
+        self._bus_backpressure_coalesced_by_priority: dict[str, int] = defaultdict(int)
+        self._bus_latest_coalesced_ticks: dict[str, dict[str, Any]] = {}
+        self._last_open_position_priority_log: dict[str, float] = {}
+        self._position_manager: Any | None = None
+        self._open_position_symbols: set[str] = set()
         self._tick_consumer_task: asyncio.Task[None] | None = None
         # Fallback worker thread for when no asyncio loop is registered
         # (e.g. early boot, polling-only mode).  Isolates the WS thread
@@ -4720,9 +4733,205 @@ class MarketDataManager:
         else:
             loop.call_soon_threadsafe(_start)
 
+
+    def set_position_manager(self, position_manager: Any | None) -> None:
+        """Attach position manager for tick-priority decisions only."""
+        self._position_manager = position_manager
+
+    def set_open_position_symbols(self, symbols: Iterable[str]) -> None:
+        """Set open-position symbols for tests/adapters. Args: symbols. Returns: None."""
+        self._open_position_symbols = {
+            self._canonical_symbol(str(symbol)) for symbol in symbols if str(symbol or "").strip()
+        }
+
+    def _open_position_symbol_set(self) -> set[str]:
+        """Return canonical symbols with open positions without changing execution state."""
+        symbols = set(getattr(self, "_open_position_symbols", set()) or set())
+        manager = getattr(self, "_position_manager", None)
+        getter = getattr(manager, "get_open_positions", None) if manager is not None else None
+        if callable(getter):
+            try:
+                for pos in getter() or []:
+                    raw_symbol = getattr(pos, "symbol", None)
+                    if raw_symbol is None and isinstance(pos, Mapping):
+                        raw_symbol = pos.get("symbol")
+                    if raw_symbol:
+                        symbols.add(self._canonical_symbol(str(raw_symbol)))
+            except Exception as exc:  # noqa: BLE001 - diagnostics only; never block ticks
+                log_throttled(
+                    self._logger,
+                    "mdm_open_position_priority_lookup_failed",
+                    "MDM_OPEN_POSITION_PRIORITY_LOOKUP_FAILED error=%s" % exc,
+                    interval_sec=60.0,
+                    level=logging.WARNING,
+                )
+        return symbols
+
+    def _selected_option_symbol_set(self) -> set[str]:
+        """Return selected CE/PE symbols from the active basket."""
+        basket = getattr(self, "_active_contract_basket", None)
+        symbols: set[str] = set()
+        for key in ("selected_ce", "selected_pe"):
+            raw = self._basket_value(basket, key, None) if basket is not None else None
+            if raw:
+                symbols.add(self._canonical_symbol(str(raw)))
+        for attr in ("_selected_ce_symbol", "_selected_pe_symbol", "selected_ce_symbol", "selected_pe_symbol"):
+            raw = getattr(self, attr, None)
+            if raw:
+                symbols.add(self._canonical_symbol(str(raw)))
+        return symbols
+
+    def _near_atm_symbol_set(self) -> set[str]:
+        """Return canonical active basket option symbols treated as near-ATM context."""
+        basket = getattr(self, "_active_contract_basket", None)
+        raw_symbols = []
+        if basket is not None:
+            raw_symbols = list(
+                self._basket_value(basket, "option_symbols", None)
+                or self._basket_value(basket, "all_symbols", None)
+                or self._basket_value(basket, "symbols", [])
+                or []
+            )
+        return {
+            self._canonical_symbol(str(symbol))
+            for symbol in raw_symbols
+            if str(symbol or "").strip().upper().endswith(("CE", "PE"))
+        }
+
+    def _resolve_tick_symbol_for_priority(self, tick: Mapping[str, Any]) -> str:
+        """Resolve canonical tick symbol for priority/coalescing."""
+        raw_symbol = str(tick.get("symbol") or "").strip()
+        if raw_symbol:
+            return self._canonical_symbol(raw_symbol)
+        token_raw = tick.get("instrument_token") or tick.get("token")
+        if token_raw is not None:
+            try:
+                token = int(token_raw)
+            except (TypeError, ValueError):
+                token = 0
+            if token > 0:
+                with self._lock:
+                    mapped = self._symbol_by_token.get(token) or self._token_to_symbol.get(token)
+                if mapped:
+                    return self._canonical_symbol(str(mapped))
+        return "UNKNOWN"
+
+    def _tick_priority(self, symbol: str) -> tuple[int, str]:
+        """Return lower-is-higher priority for tick fan-out."""
+        canonical = self._canonical_symbol(symbol) if symbol and symbol != "UNKNOWN" else symbol
+        if canonical in self._open_position_symbol_set():
+            return 0, "open_position"
+        if canonical in self._selected_option_symbol_set():
+            return 1, "selected_option"
+        if canonical in self._near_atm_symbol_set():
+            return 2, "near_atm"
+        return 3, "context_or_far"
+
+    def _emit_priority_summaries_if_due(self) -> None:
+        """Emit throttled bus/tick priority and backpressure summaries."""
+        now = time.monotonic()
+        if now - float(getattr(self, "_last_bus_priority_summary_ts", 0.0) or 0.0) < 30.0:
+            return
+        self._last_bus_priority_summary_ts = now
+        priority_counts = dict(getattr(self, "_bus_priority_counts", {}) or {})
+        queue_drops = dict(getattr(self, "_tick_queue_priority_drops", {}) or {})
+        queue_coalesced = dict(getattr(self, "_tick_queue_priority_coalesced", {}) or {})
+        bp_drops = dict(getattr(self, "_bus_backpressure_drops_by_priority", {}) or {})
+        bp_coalesced = dict(getattr(self, "_bus_backpressure_coalesced_by_priority", {}) or {})
+        if priority_counts:
+            self._logger.info(
+                "MDM_BUS_PRIORITY_SUMMARY published=%s queue_drops=%s queue_coalesced=%s",
+                priority_counts,
+                queue_drops,
+                queue_coalesced,
+                extra={"event": "MDM_BUS_PRIORITY_SUMMARY", "published": priority_counts, "queue_drops": queue_drops, "queue_coalesced": queue_coalesced},
+            )
+            self._bus_priority_counts.clear()
+        if bp_drops or bp_coalesced:
+            self._logger.warning(
+                "MDM_BUS_BACKPRESSURE_SUMMARY dropped_by_priority=%s coalesced_by_priority=%s latest_cache_size=%d",
+                bp_drops,
+                bp_coalesced,
+                len(getattr(self, "_bus_latest_coalesced_ticks", {}) or {}),
+                extra={"event": "MDM_BUS_BACKPRESSURE_SUMMARY", "dropped_by_priority": bp_drops, "coalesced_by_priority": bp_coalesced},
+            )
+            self._bus_backpressure_drops_by_priority.clear()
+            self._bus_backpressure_coalesced_by_priority.clear()
+        self._tick_queue_priority_drops.clear()
+        self._tick_queue_priority_coalesced.clear()
+
+    def _log_open_position_priority_if_needed(self, symbol: str) -> None:
+        """Log once per minute when open-position priority is active."""
+        now = time.monotonic()
+        last = float(self._last_open_position_priority_log.get(symbol, 0.0) or 0.0)
+        if now - last < 60.0:
+            return
+        self._last_open_position_priority_log[symbol] = now
+        self._logger.info(
+            "OPEN_POSITION_TICK_PRIORITY_ACTIVE symbol=%s",
+            symbol,
+            extra={"event": "OPEN_POSITION_TICK_PRIORITY_ACTIVE", "symbol": symbol},
+        )
+
+    def _put_priority_tick_nowait(self, queue: asyncio.Queue, tick_payload: dict[str, Any]) -> bool:
+        """Insert tick into queue, evicting/coalescing lower priority first when full."""
+        symbol = self._resolve_tick_symbol_for_priority(tick_payload)
+        priority, bucket = self._tick_priority(symbol)
+        tick_payload["_mdm_priority"] = priority
+        tick_payload["_mdm_priority_bucket"] = bucket
+        if priority == 0:
+            self._log_open_position_priority_if_needed(symbol)
+        try:
+            queue.put_nowait(tick_payload)
+            self._bus_priority_counts[bucket] += 1
+            return True
+        except asyncio.QueueFull:
+            retained: list[dict[str, Any]] = []
+            dropped = False
+            try:
+                while True:
+                    existing = queue.get_nowait()
+                    existing_symbol = self._resolve_tick_symbol_for_priority(existing if isinstance(existing, Mapping) else {})
+                    existing_priority, existing_bucket = self._tick_priority(existing_symbol)
+                    if not dropped and existing_priority > priority:
+                        dropped = True
+                        self._tick_queue_priority_drops[existing_bucket] += 1
+                        continue
+                    if not dropped and existing_symbol == symbol and existing_priority >= priority:
+                        dropped = True
+                        self._tick_queue_priority_coalesced[existing_bucket] += 1
+                        continue
+                    retained.append(existing)
+            except asyncio.QueueEmpty:
+                pass
+            for item in retained:
+                try:
+                    queue.put_nowait(item)
+                except asyncio.QueueFull:
+                    break
+            if not dropped and priority >= 2:
+                self._tick_queue_priority_drops[bucket] += 1
+                return False
+            if not dropped:
+                try:
+                    _ = queue.get_nowait()
+                    self._tick_queue_priority_drops["forced_oldest"] += 1
+                except asyncio.QueueEmpty:
+                    pass
+            try:
+                queue.put_nowait(tick_payload)
+                self._bus_priority_counts[bucket] += 1
+                return True
+            except asyncio.QueueFull:
+                self._tick_queue_priority_drops[bucket] += 1
+                return False
+
     async def push_tick(self, raw_tick: dict[str, Any]) -> None:
-        """Queue one raw websocket tick for deterministic consumption."""
-        await self._tick_queue.put(dict(raw_tick))
+        """Queue one raw websocket tick for deterministic consumption without blocking WS callbacks."""
+        payload = dict(raw_tick)
+        if not self._put_priority_tick_nowait(self._tick_queue, payload):
+            self._tick_queue_dropped += 1
+        self._emit_priority_summaries_if_due()
 
     def _enqueue_tick_threadsafe(self, tick: dict[str, Any]) -> None:
         """Enqueue websocket ticks from sync callbacks onto the async queue.
@@ -4752,25 +4961,16 @@ class MarketDataManager:
         # thread never performs processing work inline.
         self._ensure_tick_worker()
         try:
-            self._tick_queue.put_nowait(tick_payload)
-        except asyncio.QueueFull:
-            # Drop oldest to make room; throttle-log every 5 s.
-            self._tick_queue_dropped += 1
-            try:
-                _ = self._tick_queue.get_nowait()
-            except asyncio.QueueEmpty:
-                pass
-            try:
-                self._tick_queue.put_nowait(tick_payload)
-            except asyncio.QueueFull:  # pragma: no cover
-                pass
-            now = time.monotonic()
-            if now - self._last_tick_queue_full_log > 5.0:
-                self._last_tick_queue_full_log = now
-                self._logger.warning(
-                    "Tick queue full — dropped %d ticks so far",
-                    self._tick_queue_dropped,
-                )
+            if not self._put_priority_tick_nowait(self._tick_queue, tick_payload):
+                self._tick_queue_dropped += 1
+                now = time.monotonic()
+                if now - self._last_tick_queue_full_log > 5.0:
+                    self._last_tick_queue_full_log = now
+                    self._logger.warning(
+                        "Tick queue full — dropped %d ticks so far",
+                        self._tick_queue_dropped,
+                    )
+            self._emit_priority_summaries_if_due()
         except Exception as exc:  # pragma: no cover — defensive
             self._logger.debug("WS enqueue failed: %s", exc)
 
@@ -5234,30 +5434,44 @@ class MarketDataManager:
             delta = 0.0
         symbol_upper = str(symbol or "").upper()
         is_option_symbol = symbol_upper.endswith("CE") or symbol_upper.endswith("PE")
+        volume_delta_untrusted = False
+        if previous is not None and cumulative < previous:
+            payload["volume_delta_reset"] = True
         if is_option_symbol:
             max_delta = float(os.getenv("OPTION_MAX_REASONABLE_TICK_VOLUME_DELTA", "1000000") or "1000000")
             if delta > max_delta:
-                self._logger.warning(
-                    "OPTION_VOLUME_DELTA_CLAMPED symbol=%s cumulative=%s previous=%s delta=%s max_delta=%s",
-                    symbol,
-                    cumulative,
-                    previous,
-                    delta,
-                    max_delta,
-                    extra={
-                        "event": "OPTION_VOLUME_DELTA_CLAMPED",
-                        "symbol": symbol,
-                        "cumulative": cumulative,
-                        "previous": previous,
-                        "delta": delta,
-                        "max_delta": max_delta,
-                    },
+                volume_delta_untrusted = True
+                stats = self._volume_delta_clamp_stats.setdefault(
+                    key, {"count": 0.0, "max_delta": 0.0}
                 )
-                delta = 0.0
+                stats["count"] = float(stats.get("count", 0.0)) + 1.0
+                stats["max_delta"] = max(float(stats.get("max_delta", 0.0)), float(delta))
+                now_mono = time.monotonic()
+                last_summary = float(self._last_volume_delta_clamp_summary_ts.get(key, 0.0) or 0.0)
+                if now_mono - last_summary >= 60.0:
+                    self._last_volume_delta_clamp_summary_ts[key] = now_mono
+                    self._logger.warning(
+                        "OPTION_VOLUME_DELTA_CLAMP_SUMMARY symbol=%s count=%d max_delta=%s threshold=%s",
+                        symbol,
+                        int(stats.get("count", 0.0)),
+                        stats.get("max_delta", 0.0),
+                        max_delta,
+                        extra={
+                            "event": "OPTION_VOLUME_DELTA_CLAMP_SUMMARY",
+                            "symbol": symbol,
+                            "count": int(stats.get("count", 0.0)),
+                            "max_delta": stats.get("max_delta", 0.0),
+                            "threshold": max_delta,
+                        },
+                    )
+                    stats["count"] = 0.0
+                    stats["max_delta"] = 0.0
+                delta = max_delta
         self._last_cumulative_volume_by_symbol[key] = cumulative
         payload["volume_cumulative"] = cumulative
         payload["volume_delta"] = delta
         payload["volume"] = delta
+        payload["volume_delta_untrusted"] = volume_delta_untrusted
         return payload
 
     def _process_queued_tick(self, raw: dict[str, Any]) -> None:
@@ -5610,6 +5824,77 @@ class MarketDataManager:
                 },
             )
 
+
+    async def _publish_tick_message_with_priority(self, bus: Any, msg: Message, *, symbol: str, priority: int, bucket: str) -> None:
+        """Publish tick message while protecting high-priority symbols from queue pressure."""
+        queues = getattr(bus, "queues", None)
+        queue = queues.get(MessageType.TICK) if isinstance(queues, Mapping) else None
+        if queue is None:
+            await bus.publish(msg)
+            return
+        if priority == 0:
+            self._log_open_position_priority_if_needed(symbol)
+        try:
+            queue.put_nowait(msg)
+            self._bus_priority_counts[bucket] += 1
+            return
+        except asyncio.QueueFull:
+            pass
+
+        # Queue is full. Low-priority universe ticks are coalesced in the latest
+        # cache first; selected/open-position ticks try to evict lower priority
+        # messages already waiting in the bus queue.
+        if priority >= 2:
+            self._bus_latest_coalesced_ticks[symbol] = dict(msg.data or {})
+            self._bus_backpressure_coalesced_by_priority[bucket] += 1
+            self._bus_backpressure_drops_by_priority[bucket] += 1
+            self._emit_priority_summaries_if_due()
+            return
+
+        retained: list[Message] = []
+        evicted = False
+        try:
+            while True:
+                existing = queue.get_nowait()
+                existing_symbol = str((getattr(existing, "data", {}) or {}).get("symbol") or "UNKNOWN")
+                existing_priority, existing_bucket = self._tick_priority(existing_symbol)
+                if not evicted and existing_priority > priority:
+                    evicted = True
+                    self._bus_backpressure_drops_by_priority[existing_bucket] += 1
+                    continue
+                retained.append(existing)
+        except asyncio.QueueEmpty:
+            pass
+        for item in retained:
+            try:
+                queue.put_nowait(item)
+            except asyncio.QueueFull:
+                break
+        if not evicted and priority == 0:
+            try:
+                removed = queue.get_nowait()
+                removed_symbol = str((getattr(removed, "data", {}) or {}).get("symbol") or "UNKNOWN")
+                _, removed_bucket = self._tick_priority(removed_symbol)
+                self._bus_backpressure_drops_by_priority[removed_bucket] += 1
+                evicted = True
+            except asyncio.QueueEmpty:
+                evicted = False
+        if not evicted:
+            self._bus_latest_coalesced_ticks[symbol] = dict(msg.data or {})
+            self._bus_backpressure_coalesced_by_priority[bucket] += 1
+            self._bus_backpressure_drops_by_priority[bucket] += 1
+            self._emit_priority_summaries_if_due()
+            return
+        try:
+            queue.put_nowait(msg)
+            self._bus_priority_counts[bucket] += 1
+        except asyncio.QueueFull:
+            self._bus_latest_coalesced_ticks[symbol] = dict(msg.data or {})
+            self._bus_backpressure_coalesced_by_priority[bucket] += 1
+            self._bus_backpressure_drops_by_priority[bucket] += 1
+            self._emit_priority_summaries_if_due()
+            return
+
     def _publish_tick_to_bus_safe(self, tick: dict[str, Any]) -> None:
         """Publish a normalized tick to MessageBus without ever crashing MDM."""
         bus = getattr(self, "bus", None) or getattr(self, "_tick_bus", None)
@@ -5661,7 +5946,15 @@ class MarketDataManager:
                 source="market_data_manager",
                 timestamp=time.time(),
             )
-            future = asyncio.run_coroutine_threadsafe(bus.publish(msg), loop)
+            _symbol = str(payload.get("symbol") or tick.get("symbol") or "UNKNOWN")
+            _priority, _bucket = self._tick_priority(_symbol)
+            future = asyncio.run_coroutine_threadsafe(
+                self._publish_tick_message_with_priority(
+                    bus, msg, symbol=_symbol, priority=_priority, bucket=_bucket
+                ),
+                loop,
+            )
+            self._emit_priority_summaries_if_due()
 
             def _done(fut: Any) -> None:
                 try:
@@ -5673,6 +5966,8 @@ class MarketDataManager:
                         self._bus_backpressure_counts: dict[str, int] = {}
                         _bp_counts = self._bus_backpressure_counts
                     _bp_counts[_bp_sym] = _bp_counts.get(_bp_sym, 0) + 1
+                    _bp_priority, _bp_bucket = self._tick_priority(str(_bp_sym))
+                    self._bus_backpressure_drops_by_priority[_bp_bucket] += 1
                     log_throttled(
                         self._logger,
                         "mdm_bus_publish_failed",
@@ -8487,6 +8782,8 @@ class MarketDataManager:
                 "volume": volume_delta_value,
                 "volume_delta": volume_delta_value,
                 "volume_cumulative": volume_cumulative_value,
+                "volume_delta_untrusted": bool(raw.get("volume_delta_untrusted")),
+                "volume_delta_reset": bool(raw.get("volume_delta_reset")),
                 "oi": _coerce_int(raw.get("oi")),
                 "depth": depth_obj,
                 "depth_available": bool(depth_obj),

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -341,6 +341,13 @@ class MarketDataManager:
         self._last_open_position_priority_log: dict[str, float] = {}
         self._position_manager: Any | None = None
         self._open_position_symbols: set[str] = set()
+        self._priority_context_cached_at = 0.0
+        self._priority_context_ttl_s = self._parse_float_env(
+            "MDM_PRIORITY_CONTEXT_TTL_SECONDS", default=0.25, minimum=0.01
+        )
+        self._cached_open_position_symbols: set[str] = set()
+        self._cached_selected_option_symbols: set[str] = set()
+        self._cached_near_atm_symbols: set[str] = set()
         self._tick_consumer_task: asyncio.Task[None] | None = None
         # Fallback worker thread for when no asyncio loop is registered
         # (e.g. early boot, polling-only mode).  Isolates the WS thread
@@ -1848,6 +1855,7 @@ class MarketDataManager:
         )
         with self._lock:
             self._active_contract_basket = basket
+            self._invalidate_priority_context_cache()
             self._desired_tokens.update(tokens)
             for sym, tok in token_map.items():
                 canonical = self._safe_canonical_for_basket(sym)
@@ -4734,15 +4742,38 @@ class MarketDataManager:
             loop.call_soon_threadsafe(_start)
 
 
+    def _invalidate_priority_context_cache(self) -> None:
+        """Clear cached priority context sets. Args: none. Returns: None."""
+        self._priority_context_cached_at = 0.0
+        self._cached_open_position_symbols = set()
+        self._cached_selected_option_symbols = set()
+        self._cached_near_atm_symbols = set()
+
     def set_position_manager(self, position_manager: Any | None) -> None:
-        """Attach position manager for tick-priority decisions only."""
+        """Attach position manager for read-only tick-priority decisions only."""
         self._position_manager = position_manager
+        self._invalidate_priority_context_cache()
 
     def set_open_position_symbols(self, symbols: Iterable[str]) -> None:
         """Set open-position symbols for tests/adapters. Args: symbols. Returns: None."""
         self._open_position_symbols = {
             self._canonical_symbol(str(symbol)) for symbol in symbols if str(symbol or "").strip()
         }
+        self._invalidate_priority_context_cache()
+
+    def add_open_position_symbol(self, symbol: str) -> None:
+        """Add one open-position symbol for priority protection. Args: symbol. Returns: None."""
+        normalized = self._canonical_symbol(str(symbol)) if str(symbol or "").strip() else ""
+        if normalized:
+            self._open_position_symbols.add(normalized)
+            self._invalidate_priority_context_cache()
+
+    def remove_open_position_symbol(self, symbol: str) -> None:
+        """Remove one open-position symbol from priority protection. Args: symbol. Returns: None."""
+        normalized = self._canonical_symbol(str(symbol)) if str(symbol or "").strip() else ""
+        if normalized:
+            self._open_position_symbols.discard(normalized)
+            self._invalidate_priority_context_cache()
 
     def _open_position_symbol_set(self) -> set[str]:
         """Return canonical symbols with open positions without changing execution state."""
@@ -4816,14 +4847,34 @@ class MarketDataManager:
                     return self._canonical_symbol(str(mapped))
         return "UNKNOWN"
 
+    def _get_priority_context_sets(self) -> tuple[set[str], set[str], set[str]]:
+        """Return cached open/selected/near-ATM symbol sets for hot tick path."""
+        now = time.monotonic()
+        cached_at = float(getattr(self, "_priority_context_cached_at", 0.0) or 0.0)
+        if cached_at > 0.0 and (now - cached_at) <= float(getattr(self, "_priority_context_ttl_s", 0.25) or 0.25):
+            return (
+                set(getattr(self, "_cached_open_position_symbols", set()) or set()),
+                set(getattr(self, "_cached_selected_option_symbols", set()) or set()),
+                set(getattr(self, "_cached_near_atm_symbols", set()) or set()),
+            )
+        open_symbols = self._open_position_symbol_set()
+        selected_symbols = self._selected_option_symbol_set()
+        near_atm_symbols = self._near_atm_symbol_set()
+        self._cached_open_position_symbols = set(open_symbols)
+        self._cached_selected_option_symbols = set(selected_symbols)
+        self._cached_near_atm_symbols = set(near_atm_symbols)
+        self._priority_context_cached_at = now
+        return set(open_symbols), set(selected_symbols), set(near_atm_symbols)
+
     def _tick_priority(self, symbol: str) -> tuple[int, str]:
         """Return lower-is-higher priority for tick fan-out."""
         canonical = self._canonical_symbol(symbol) if symbol and symbol != "UNKNOWN" else symbol
-        if canonical in self._open_position_symbol_set():
+        open_symbols, selected_symbols, near_atm_symbols = self._get_priority_context_sets()
+        if canonical in open_symbols:
             return 0, "open_position"
-        if canonical in self._selected_option_symbol_set():
+        if canonical in selected_symbols:
             return 1, "selected_option"
-        if canonical in self._near_atm_symbol_set():
+        if canonical in near_atm_symbols:
             return 2, "near_atm"
         return 3, "context_or_far"
 
@@ -4873,8 +4924,24 @@ class MarketDataManager:
             extra={"event": "OPEN_POSITION_TICK_PRIORITY_ACTIVE", "symbol": symbol},
         )
 
+
+    @staticmethod
+    def _mark_queue_item_done(queue: asyncio.Queue) -> None:
+        """Balance unfinished task count when queue surgery permanently removes an item."""
+        try:
+            queue.task_done()
+        except ValueError:
+            # Tests and some fallback paths may remove items that were not tracked
+            # by join() callers. Never let accounting diagnostics block tick intake.
+            pass
+
     def _put_priority_tick_nowait(self, queue: asyncio.Queue, tick_payload: dict[str, Any]) -> bool:
-        """Insert tick into queue, evicting/coalescing lower priority first when full."""
+        """Insert tick, evicting/coalescing lower-value work when full.
+
+        This queue is consumed with task_done() in _consume_ticks(). Queue
+        surgery calls _mark_queue_item_done() exactly once for every get_nowait();
+        retained items are requeued as new unfinished tasks, preserving join counts.
+        """
         symbol = self._resolve_tick_symbol_for_priority(tick_payload)
         priority, bucket = self._tick_priority(symbol)
         tick_payload["_mdm_priority"] = priority
@@ -4887,19 +4954,28 @@ class MarketDataManager:
             return True
         except asyncio.QueueFull:
             retained: list[dict[str, Any]] = []
-            dropped = False
+            removed = False
+            removed_reason = ""
+            removed_bucket = ""
             try:
                 while True:
                     existing = queue.get_nowait()
+                    self._mark_queue_item_done(queue)
                     existing_symbol = self._resolve_tick_symbol_for_priority(existing if isinstance(existing, Mapping) else {})
                     existing_priority, existing_bucket = self._tick_priority(existing_symbol)
-                    if not dropped and existing_priority > priority:
-                        dropped = True
-                        self._tick_queue_priority_drops[existing_bucket] += 1
+                    if not removed and existing_priority > priority:
+                        removed = True
+                        removed_reason = "drop_lower_priority"
+                        removed_bucket = existing_bucket
                         continue
-                    if not dropped and existing_symbol == symbol and existing_priority >= priority:
-                        dropped = True
-                        self._tick_queue_priority_coalesced[existing_bucket] += 1
+                    if (
+                        not removed
+                        and existing_symbol == symbol
+                        and existing_priority >= priority
+                    ):
+                        removed = True
+                        removed_reason = "coalesce_same_symbol"
+                        removed_bucket = existing_bucket
                         continue
                     retained.append(existing)
             except asyncio.QueueEmpty:
@@ -4909,13 +4985,34 @@ class MarketDataManager:
                     queue.put_nowait(item)
                 except asyncio.QueueFull:
                     break
-            if not dropped and priority >= 2:
+            if removed:
+                if removed_reason == "coalesce_same_symbol":
+                    self._tick_queue_priority_coalesced[removed_bucket or bucket] += 1
+                else:
+                    self._tick_queue_priority_drops[removed_bucket or bucket] += 1
+            elif priority >= 1:
                 self._tick_queue_priority_drops[bucket] += 1
                 return False
-            if not dropped:
+            else:
+                # Queue contains only other priority-0 ticks. Do not silently
+                # discard another protected position tick; emit a critical log.
                 try:
-                    _ = queue.get_nowait()
-                    self._tick_queue_priority_drops["forced_oldest"] += 1
+                    removed_item = queue.get_nowait()
+                    self._mark_queue_item_done(queue)
+                    removed_symbol = self._resolve_tick_symbol_for_priority(
+                        removed_item if isinstance(removed_item, Mapping) else {}
+                    )
+                    self._tick_queue_priority_drops["open_position"] += 1
+                    self._logger.critical(
+                        "MDM_OPEN_POSITION_TICK_FORCED_DROP dropped_symbol=%s incoming_symbol=%s",
+                        removed_symbol,
+                        symbol,
+                        extra={
+                            "event": "MDM_OPEN_POSITION_TICK_FORCED_DROP",
+                            "dropped_symbol": removed_symbol,
+                            "incoming_symbol": symbol,
+                        },
+                    )
                 except asyncio.QueueEmpty:
                     pass
             try:
@@ -4925,6 +5022,7 @@ class MarketDataManager:
             except asyncio.QueueFull:
                 self._tick_queue_priority_drops[bucket] += 1
                 return False
+
 
     async def push_tick(self, raw_tick: dict[str, Any]) -> None:
         """Queue one raw websocket tick for deterministic consumption without blocking WS callbacks."""
@@ -5442,30 +5540,30 @@ class MarketDataManager:
             if delta > max_delta:
                 volume_delta_untrusted = True
                 stats = self._volume_delta_clamp_stats.setdefault(
-                    key, {"count": 0.0, "max_delta": 0.0}
+                    key, {"interval_count": 0.0, "interval_max_delta": 0.0}
                 )
-                stats["count"] = float(stats.get("count", 0.0)) + 1.0
-                stats["max_delta"] = max(float(stats.get("max_delta", 0.0)), float(delta))
+                stats["interval_count"] = float(stats.get("interval_count", 0.0)) + 1.0
+                stats["interval_max_delta"] = max(float(stats.get("interval_max_delta", 0.0)), float(delta))
                 now_mono = time.monotonic()
                 last_summary = float(self._last_volume_delta_clamp_summary_ts.get(key, 0.0) or 0.0)
                 if now_mono - last_summary >= 60.0:
                     self._last_volume_delta_clamp_summary_ts[key] = now_mono
                     self._logger.warning(
-                        "OPTION_VOLUME_DELTA_CLAMP_SUMMARY symbol=%s count=%d max_delta=%s threshold=%s",
+                        "OPTION_VOLUME_DELTA_CLAMP_SUMMARY symbol=%s interval_count=%d interval_max_delta=%s threshold=%s",
                         symbol,
-                        int(stats.get("count", 0.0)),
-                        stats.get("max_delta", 0.0),
+                        int(stats.get("interval_count", 0.0)),
+                        stats.get("interval_max_delta", 0.0),
                         max_delta,
                         extra={
                             "event": "OPTION_VOLUME_DELTA_CLAMP_SUMMARY",
                             "symbol": symbol,
-                            "count": int(stats.get("count", 0.0)),
-                            "max_delta": stats.get("max_delta", 0.0),
+                            "interval_count": int(stats.get("interval_count", 0.0)),
+                            "interval_max_delta": stats.get("interval_max_delta", 0.0),
                             "threshold": max_delta,
                         },
                     )
-                    stats["count"] = 0.0
-                    stats["max_delta"] = 0.0
+                    stats["interval_count"] = 0.0
+                    stats["interval_max_delta"] = 0.0
                 delta = max_delta
         self._last_cumulative_volume_by_symbol[key] = cumulative
         payload["volume_cumulative"] = cumulative
@@ -5841,9 +5939,6 @@ class MarketDataManager:
         except asyncio.QueueFull:
             pass
 
-        # Queue is full. Low-priority universe ticks are coalesced in the latest
-        # cache first; selected/open-position ticks try to evict lower priority
-        # messages already waiting in the bus queue.
         if priority >= 2:
             self._bus_latest_coalesced_ticks[symbol] = dict(msg.data or {})
             self._bus_backpressure_coalesced_by_priority[bucket] += 1
@@ -5852,15 +5947,27 @@ class MarketDataManager:
             return
 
         retained: list[Message] = []
-        evicted = False
+        removed = False
+        removed_reason = ""
+        removed_bucket = ""
+        removed_symbol = ""
         try:
             while True:
                 existing = queue.get_nowait()
+                self._mark_queue_item_done(queue)
                 existing_symbol = str((getattr(existing, "data", {}) or {}).get("symbol") or "UNKNOWN")
                 existing_priority, existing_bucket = self._tick_priority(existing_symbol)
-                if not evicted and existing_priority > priority:
-                    evicted = True
-                    self._bus_backpressure_drops_by_priority[existing_bucket] += 1
+                if not removed and existing_priority > priority:
+                    removed = True
+                    removed_reason = "drop_lower_priority"
+                    removed_bucket = existing_bucket
+                    removed_symbol = existing_symbol
+                    continue
+                if not removed and existing_symbol == symbol and existing_priority >= priority:
+                    removed = True
+                    removed_reason = "coalesce_same_symbol"
+                    removed_bucket = existing_bucket
+                    removed_symbol = existing_symbol
                     continue
                 retained.append(existing)
         except asyncio.QueueEmpty:
@@ -5870,16 +5977,30 @@ class MarketDataManager:
                 queue.put_nowait(item)
             except asyncio.QueueFull:
                 break
-        if not evicted and priority == 0:
+        if removed:
+            if removed_reason == "coalesce_same_symbol":
+                self._bus_backpressure_coalesced_by_priority[removed_bucket or bucket] += 1
+            else:
+                self._bus_backpressure_drops_by_priority[removed_bucket or bucket] += 1
+        elif priority == 0:
             try:
                 removed = queue.get_nowait()
+                self._mark_queue_item_done(queue)
                 removed_symbol = str((getattr(removed, "data", {}) or {}).get("symbol") or "UNKNOWN")
-                _, removed_bucket = self._tick_priority(removed_symbol)
-                self._bus_backpressure_drops_by_priority[removed_bucket] += 1
-                evicted = True
+                self._bus_backpressure_drops_by_priority["open_position"] += 1
+                self._logger.critical(
+                    "MDM_OPEN_POSITION_TICK_FORCED_DROP dropped_symbol=%s incoming_symbol=%s",
+                    removed_symbol,
+                    symbol,
+                    extra={
+                        "event": "MDM_OPEN_POSITION_TICK_FORCED_DROP",
+                        "dropped_symbol": removed_symbol,
+                        "incoming_symbol": symbol,
+                    },
+                )
             except asyncio.QueueEmpty:
-                evicted = False
-        if not evicted:
+                pass
+        else:
             self._bus_latest_coalesced_ticks[symbol] = dict(msg.data or {})
             self._bus_backpressure_coalesced_by_priority[bucket] += 1
             self._bus_backpressure_drops_by_priority[bucket] += 1
@@ -5892,8 +6013,8 @@ class MarketDataManager:
             self._bus_latest_coalesced_ticks[symbol] = dict(msg.data or {})
             self._bus_backpressure_coalesced_by_priority[bucket] += 1
             self._bus_backpressure_drops_by_priority[bucket] += 1
-            self._emit_priority_summaries_if_due()
-            return
+        self._emit_priority_summaries_if_due()
+
 
     def _publish_tick_to_bus_safe(self, tick: dict[str, Any]) -> None:
         """Publish a normalized tick to MessageBus without ever crashing MDM."""

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -1454,7 +1454,11 @@ class StrategyRunner:
             return 0
         target = max(1, int(required_bars or self._required_bars_for_symbol(normalized) or 1))
         indicator_before = self._history_count_for_symbol(normalized)
+        runner_bars = len(getattr(self, "_symbol_history", {}).get(normalized, []) or [])
         rows = self._get_mdm_bars(normalized, max(target, indicator_before))
+        mdm_bars = len(rows)
+        if mdm_bars >= target and runner_bars >= target and indicator_before >= target:
+            return indicator_before
         ingested = 0
         if rows and indicator_before < min(target, len(rows)):
             ingested = int(
@@ -4466,12 +4470,55 @@ class StrategyRunner:
                     )
                 return self._set_symbol_hydration_state(symbol, SymbolState.READY)
             is_option = symbol.startswith("NFO:") and symbol.endswith(("CE", "PE"))
+            now_wall = time.time()
+            candle_interval_s = float(os.getenv("RUNNER_CANDLE_GAP_INTERVAL_SECONDS", "60") or "60")
+            gap_grace_s = float(os.getenv("RUNNER_CANDLE_GAP_GRACE_SECONDS", "10") or "10")
             last_tick_ts = float(self._last_tick_time_by_symbol.get(symbol, 0.0) or 0.0)
-            recent_tick = last_tick_ts > 0 and (time.time() - last_tick_ts) <= 120.0
-            tick_age_s = round(time.time() - last_tick_ts, 2) if recent_tick else None
-            if gap_count > 1:
-                reason = "repeated_missing_candles" if recent_tick else "no_recent_tick_for_gap_assessment"
-                log_level = logging.INFO if is_option and recent_tick else logging.WARNING
+            tick_age_s = round(now_wall - last_tick_ts, 2) if last_tick_ts > 0 else None
+            fresh_tick = bool(tick_age_s is not None and tick_age_s < gap_grace_s)
+            last_bar_ts = 0.0
+            try:
+                last_bar = bars[-1] if bars else None
+                bar_ts = getattr(last_bar, "timestamp", None)
+                if isinstance(last_bar, Mapping):
+                    bar_ts = last_bar.get("timestamp")
+                parsed_bar_ts = pd.to_datetime(bar_ts, utc=True, errors="coerce")
+                if not pd.isna(parsed_bar_ts):
+                    last_bar_ts = float(pd.Timestamp(parsed_bar_ts).timestamp())
+            except Exception:
+                last_bar_ts = 0.0
+            elapsed_since_close = (now_wall - last_bar_ts) if last_bar_ts > 0 else 0.0
+            no_candle_close_produced = bool(last_bar_ts <= 0 or elapsed_since_close > (candle_interval_s + gap_grace_s))
+            if fresh_tick:
+                log_throttled_live(
+                    self._logger,
+                    logging.INFO,
+                    "CANDLE_GAP_SUPPRESSED_FRESH_TICK",
+                    f"CANDLE_GAP_SUPPRESSED_FRESH_TICK:{symbol}",
+                    float(os.getenv("LOG_THROTTLE_SOFT_DATA_SECONDS", "60") or "60"),
+                    "CANDLE_GAP_SUPPRESSED_FRESH_TICK symbol=%s gaps=%s age_s=%s grace_s=%s",
+                    symbol, gap_count, tick_age_s, gap_grace_s,
+                    extra={"event": "CANDLE_GAP_SUPPRESSED_FRESH_TICK", "symbol": symbol, "gaps": gap_count, "age_s": tick_age_s, "grace_s": gap_grace_s},
+                )
+                gap_summary = getattr(self, "_candle_gap_summary", None)
+                if gap_summary is None:
+                    gap_summary = {}
+                    self._candle_gap_summary = gap_summary
+                gap_summary[symbol] = int(gap_summary.get(symbol, 0)) + 1
+            elif gap_count > 1 and elapsed_since_close > (candle_interval_s + gap_grace_s) and no_candle_close_produced and last_tick_ts <= 0:
+                reason = "no_recent_tick_for_gap_assessment"
+                log_throttled_live(
+                    self._logger,
+                    logging.WARNING,
+                    "SOFT_DATA_ISSUE",
+                    f"SOFT_DATA_ISSUE:{symbol}:{reason}",
+                    float(os.getenv("LOG_THROTTLE_SOFT_DATA_SECONDS", "60") or "60"),
+                    f"SOFT_DATA_ISSUE symbol={symbol} reason={reason} source=candle_gap_detector age_s={tick_age_s}",
+                    extra={"event": "SOFT_DATA_ISSUE", "symbol": symbol, "reason": reason, "source": "candle_gap_detector", "age_s": tick_age_s, "details": {"gaps": gap_count}, "gaps": gap_count},
+                )
+            elif gap_count > 1 and elapsed_since_close > (candle_interval_s + gap_grace_s) and no_candle_close_produced:
+                reason = "repeated_missing_candles"
+                log_level = logging.INFO if is_option else logging.WARNING
                 log_throttled_live(
                     self._logger,
                     log_level,
@@ -4481,21 +4528,23 @@ class StrategyRunner:
                     f"SOFT_DATA_ISSUE symbol={symbol} reason={reason} source=candle_gap_detector age_s={tick_age_s}",
                     extra={"event": "SOFT_DATA_ISSUE", "symbol": symbol, "reason": reason, "source": "candle_gap_detector", "age_s": tick_age_s, "details": {"gaps": gap_count}, "gaps": gap_count},
                 )
-                if gap_count > 1 and recent_tick:
-                    return self._set_symbol_hydration_state(symbol, SymbolState.DEGRADED)
+                return self._set_symbol_hydration_state(symbol, SymbolState.DEGRADED)
             else:
-                reason = "single_missing_candle" if recent_tick else "no_recent_tick_for_gap_assessment"
+                gap_summary = getattr(self, "_candle_gap_summary", None)
+                if gap_summary is None:
+                    gap_summary = {}
+                    self._candle_gap_summary = gap_summary
+                gap_summary[symbol] = int(gap_summary.get(symbol, 0)) + 1
                 log_throttled_live(
                     self._logger,
                     logging.INFO,
-                    "SOFT_DATA_ISSUE",
-                    f"SOFT_DATA_ISSUE:{symbol}:{reason}",
+                    "CANDLE_GAP_SUMMARY",
+                    f"CANDLE_GAP_SUMMARY:{symbol}",
                     float(os.getenv("LOG_THROTTLE_SOFT_DATA_SECONDS", "60") or "60"),
-                    f"SOFT_DATA_ISSUE symbol={symbol} reason={reason} source=candle_gap_detector age_s={tick_age_s}",
-                    extra={"event": "SOFT_DATA_ISSUE", "symbol": symbol, "reason": reason, "source": "candle_gap_detector", "age_s": tick_age_s, "details": {"gaps": gap_count}},
+                    "CANDLE_GAP_SUMMARY symbol=%s suppressed=%s gaps=%s age_s=%s elapsed_since_close_s=%.2f",
+                    symbol, gap_summary.get(symbol, 0), gap_count, tick_age_s, elapsed_since_close,
+                    extra={"event": "CANDLE_GAP_SUMMARY", "symbol": symbol, "suppressed": gap_summary.get(symbol, 0), "gaps": gap_count, "age_s": tick_age_s, "elapsed_since_close_s": elapsed_since_close},
                 )
-                if gap_count > 1 and recent_tick:
-                    return self._set_symbol_hydration_state(symbol, SymbolState.DEGRADED)
 
         if valid_vwap and valid_volume:
             self._hydration_ready_streak[symbol] = int(self._hydration_ready_streak.get(symbol, 0)) + 1
@@ -6875,6 +6924,13 @@ class StrategyRunner:
             reason = "selected_option_depth_missing"
         elif ce_hist < min_bars or pe_hist < min_bars:
             reason = "selected_option_history_cold"
+        normalized_boot_symbol = normalize_symbol(str(symbol or ""))
+        selected_boot_symbols = {normalize_symbol(str(item)) for item in (ce_symbol, pe_symbol) if item}
+        if reason == "selected_option_depth_missing" and normalized_boot_symbol not in selected_boot_symbols:
+            if normalized_boot_symbol.startswith("NFO:") and normalized_boot_symbol.endswith(("CE", "PE")):
+                reason = "option_context_depth_missing"
+            else:
+                reason = "context_symbol_not_tradable"
         ready = reason is None
         _boot_key = f"bootstrap:{symbol}:{ready}:{reason}"
         _boot_interval = float(os.getenv("RUNNER_BOOTSTRAP_LOG_INTERVAL_SECONDS", "60") or "60")
@@ -8934,7 +8990,10 @@ class StrategyRunner:
                 return
 
             volume = 0
-            if has_explicit_delta:
+            volume_delta_untrusted = bool(tick.get("volume_delta_untrusted"))
+            if volume_delta_untrusted:
+                volume = 0
+            elif has_explicit_delta:
                 volume = max(int(raw_volume_delta), 0)
             elif has_explicit_volume:
                 if raw_volume_cumulative > 0 and raw_volume_delta == raw_volume_cumulative:

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -4487,8 +4487,8 @@ class StrategyRunner:
                     last_bar_ts = float(pd.Timestamp(parsed_bar_ts).timestamp())
             except Exception:
                 last_bar_ts = 0.0
-            elapsed_since_close = (now_wall - last_bar_ts) if last_bar_ts > 0 else 0.0
-            no_candle_close_produced = bool(last_bar_ts <= 0 or elapsed_since_close > (candle_interval_s + gap_grace_s))
+            elapsed_since_last_bar_s = (now_wall - last_bar_ts) if last_bar_ts > 0 else 0.0
+            no_candle_close_produced = bool(last_bar_ts <= 0 or elapsed_since_last_bar_s > (candle_interval_s + gap_grace_s))
             if fresh_tick:
                 log_throttled_live(
                     self._logger,
@@ -4505,7 +4505,7 @@ class StrategyRunner:
                     gap_summary = {}
                     self._candle_gap_summary = gap_summary
                 gap_summary[symbol] = int(gap_summary.get(symbol, 0)) + 1
-            elif gap_count > 1 and elapsed_since_close > (candle_interval_s + gap_grace_s) and no_candle_close_produced and last_tick_ts <= 0:
+            elif last_tick_ts <= 0:
                 reason = "no_recent_tick_for_gap_assessment"
                 log_throttled_live(
                     self._logger,
@@ -4516,7 +4516,18 @@ class StrategyRunner:
                     f"SOFT_DATA_ISSUE symbol={symbol} reason={reason} source=candle_gap_detector age_s={tick_age_s}",
                     extra={"event": "SOFT_DATA_ISSUE", "symbol": symbol, "reason": reason, "source": "candle_gap_detector", "age_s": tick_age_s, "details": {"gaps": gap_count}, "gaps": gap_count},
                 )
-            elif gap_count > 1 and elapsed_since_close > (candle_interval_s + gap_grace_s) and no_candle_close_produced:
+            elif gap_count > 1 and elapsed_since_last_bar_s <= (candle_interval_s + gap_grace_s):
+                reason = "stale_tick_for_gap_assessment"
+                log_throttled_live(
+                    self._logger,
+                    logging.INFO,
+                    "SOFT_DATA_ISSUE",
+                    f"SOFT_DATA_ISSUE:{symbol}:{reason}",
+                    float(os.getenv("LOG_THROTTLE_SOFT_DATA_SECONDS", "60") or "60"),
+                    f"SOFT_DATA_ISSUE symbol={symbol} reason={reason} source=candle_gap_detector age_s={tick_age_s}",
+                    extra={"event": "SOFT_DATA_ISSUE", "symbol": symbol, "reason": reason, "source": "candle_gap_detector", "age_s": tick_age_s, "details": {"gaps": gap_count}, "gaps": gap_count},
+                )
+            elif gap_count > 1 and no_candle_close_produced:
                 reason = "repeated_missing_candles"
                 log_level = logging.INFO if is_option else logging.WARNING
                 log_throttled_live(
@@ -4541,9 +4552,9 @@ class StrategyRunner:
                     "CANDLE_GAP_SUMMARY",
                     f"CANDLE_GAP_SUMMARY:{symbol}",
                     float(os.getenv("LOG_THROTTLE_SOFT_DATA_SECONDS", "60") or "60"),
-                    "CANDLE_GAP_SUMMARY symbol=%s suppressed=%s gaps=%s age_s=%s elapsed_since_close_s=%.2f",
-                    symbol, gap_summary.get(symbol, 0), gap_count, tick_age_s, elapsed_since_close,
-                    extra={"event": "CANDLE_GAP_SUMMARY", "symbol": symbol, "suppressed": gap_summary.get(symbol, 0), "gaps": gap_count, "age_s": tick_age_s, "elapsed_since_close_s": elapsed_since_close},
+                    "CANDLE_GAP_SUMMARY symbol=%s suppressed=%s gaps=%s age_s=%s elapsed_since_last_bar_s=%.2f",
+                    symbol, gap_summary.get(symbol, 0), gap_count, tick_age_s, elapsed_since_last_bar_s,
+                    extra={"event": "CANDLE_GAP_SUMMARY", "symbol": symbol, "suppressed": gap_summary.get(symbol, 0), "gaps": gap_count, "age_s": tick_age_s, "elapsed_since_last_bar_s": elapsed_since_last_bar_s},
                 )
 
         if valid_vwap and valid_volume:
@@ -6932,10 +6943,44 @@ class StrategyRunner:
             else:
                 reason = "context_symbol_not_tradable"
         ready = reason is None
+        try:
+            symbol_role = self._symbol_role_for_runner(normalized_boot_symbol)
+        except Exception:
+            symbol_role = "unknown"
         _boot_key = f"bootstrap:{symbol}:{ready}:{reason}"
         _boot_interval = float(os.getenv("RUNNER_BOOTSTRAP_LOG_INTERVAL_SECONDS", "60") or "60")
         if self._should_log_throttled(_boot_key, _boot_interval):
-            self._logger.info("LIVE_UNIVERSE_BOOTSTRAP_STATUS symbol=%s ready=%s reason=%s", symbol, ready, reason, extra={"event":"LIVE_UNIVERSE_BOOTSTRAP_STATUS","symbol":symbol,"selected_ce":ce_symbol,"selected_pe":pe_symbol,"active_future":fut_symbol or None,"ce_token":ce_token,"pe_token":pe_token,"fut_token":fut_token,"ce_subscribed":ce_sub,"pe_subscribed":pe_sub,"fut_subscribed":fut_sub,"ce_quote_fresh":ce_quote,"pe_quote_fresh":pe_quote,"fut_quote_fresh":fut_quote,"ce_depth_available":ce_depth,"pe_depth_available":pe_depth,"ce_history_count":ce_hist,"pe_history_count":pe_hist,"ready":ready,"reason":reason})
+            self._logger.info(
+                "LIVE_UNIVERSE_BOOTSTRAP_STATUS symbol=%s ready=%s reason=%s",
+                symbol,
+                ready,
+                reason,
+                extra={
+                    "event": "LIVE_UNIVERSE_BOOTSTRAP_STATUS",
+                    "symbol": symbol,
+                    "evaluated_symbol": normalized_boot_symbol,
+                    "selected_ce": ce_symbol,
+                    "selected_pe": pe_symbol,
+                    "selected_pair": [ce_symbol, pe_symbol],
+                    "symbol_role": symbol_role,
+                    "active_future": fut_symbol or None,
+                    "ce_token": ce_token,
+                    "pe_token": pe_token,
+                    "fut_token": fut_token,
+                    "ce_subscribed": ce_sub,
+                    "pe_subscribed": pe_sub,
+                    "fut_subscribed": fut_sub,
+                    "ce_quote_fresh": ce_quote,
+                    "pe_quote_fresh": pe_quote,
+                    "fut_quote_fresh": fut_quote,
+                    "ce_depth_available": ce_depth,
+                    "pe_depth_available": pe_depth,
+                    "ce_history_count": ce_hist,
+                    "pe_history_count": pe_hist,
+                    "ready": ready,
+                    "reason": reason,
+                },
+            )
         return ready, reason
 
 

--- a/tests/data/test_market_data_priority_noise.py
+++ b/tests/data/test_market_data_priority_noise.py
@@ -159,7 +159,7 @@ def test_repeated_missing_candles_suppressed_if_fresh_tick_exists(caplog, monkey
     assert "repeated_missing_candles" not in text
 
 
-def test_selected_option_depth_missing_not_emitted_for_context_symbol() -> None:
+def test_selected_option_depth_missing_not_emitted_for_context_symbol(caplog) -> None:
     runner = _runner()
     runner._current_active_contract_selection = lambda: SimpleNamespace(
         selected_ce="NFO:NIFTY2660923250CE", selected_pe="NFO:NIFTY2660923250PE"
@@ -178,7 +178,194 @@ def test_selected_option_depth_missing_not_emitted_for_context_symbol() -> None:
         _ws=SimpleNamespace(_tokens={1, 2}),
     )
 
+    caplog.set_level(logging.INFO)
+
     ready, reason = runner._emit_live_universe_bootstrap_status(symbol="NSE:NIFTY")
 
     assert ready is False
     assert reason == "context_symbol_not_tradable"
+    record = next(record for record in caplog.records if record.getMessage().startswith("LIVE_UNIVERSE_BOOTSTRAP_STATUS"))
+    assert record.evaluated_symbol == "NSE:NIFTY"
+    assert record.selected_ce == "NFO:NIFTY2660923250CE"
+    assert record.selected_pe == "NFO:NIFTY2660923250PE"
+    assert record.selected_pair == ["NFO:NIFTY2660923250CE", "NFO:NIFTY2660923250PE"]
+    assert record.symbol_role == "spot_context"
+    assert record.reason == "context_symbol_not_tradable"
+    assert record.ready is False
+
+
+def _queued_symbols(manager: MarketDataManager) -> list[str]:
+    return [manager._tick_queue.get_nowait()["symbol"] for _ in range(manager._tick_queue.qsize())]
+
+
+def test_same_symbol_open_position_tick_is_coalesced() -> None:
+    manager = _mdm()
+    symbol = "NFO:NIFTY2660923250CE"
+    manager.set_open_position_symbols([symbol])
+    assert manager._put_priority_tick_nowait(manager._tick_queue, {"symbol": symbol, "ltp": 1})
+    assert manager._put_priority_tick_nowait(manager._tick_queue, {"symbol": "NFO:NIFTY2660923250PE", "ltp": 2})
+
+    assert manager._put_priority_tick_nowait(manager._tick_queue, {"symbol": symbol, "ltp": 3})
+
+    queued = _queued_symbols(manager)
+    assert queued.count(symbol) == 1
+    assert manager._tick_queue_priority_coalesced["open_position"] == 1
+
+
+def test_different_open_position_symbol_forced_drop_logs_critical(caplog) -> None:
+    manager = _mdm()
+    first = "NFO:NIFTY2660923250CE"
+    second = "NFO:NIFTY2660923250PE"
+    third = "NFO:NIFTY2660923300CE"
+    manager.set_open_position_symbols([first, second, third])
+    caplog.set_level(logging.CRITICAL)
+    assert manager._put_priority_tick_nowait(manager._tick_queue, {"symbol": first, "ltp": 1})
+    assert manager._put_priority_tick_nowait(manager._tick_queue, {"symbol": second, "ltp": 2})
+
+    assert manager._put_priority_tick_nowait(manager._tick_queue, {"symbol": third, "ltp": 3})
+
+    queued = _queued_symbols(manager)
+    assert third in queued
+    assert "MDM_OPEN_POSITION_TICK_FORCED_DROP" in "\n".join(r.getMessage() for r in caplog.records)
+
+
+def test_selected_option_displaces_context_or_far_tick() -> None:
+    manager = _mdm()
+    selected = "NFO:NIFTY2660923250PE"
+    assert manager._put_priority_tick_nowait(manager._tick_queue, {"symbol": "NFO:NIFTY2660923600CE", "ltp": 1})
+    assert manager._put_priority_tick_nowait(manager._tick_queue, {"symbol": "NSE:NIFTY", "ltp": 2})
+
+    assert manager._put_priority_tick_nowait(manager._tick_queue, {"symbol": selected, "ltp": 3})
+
+    queued = _queued_symbols(manager)
+    assert selected in queued
+    assert len(queued) == 2
+
+
+def test_context_tick_does_not_displace_selected_or_open_position_tick() -> None:
+    manager = _mdm()
+    open_symbol = "NFO:NIFTY2660923250CE"
+    selected = "NFO:NIFTY2660923250PE"
+    manager.set_open_position_symbols([open_symbol])
+    assert manager._put_priority_tick_nowait(manager._tick_queue, {"symbol": open_symbol, "ltp": 1})
+    assert manager._put_priority_tick_nowait(manager._tick_queue, {"symbol": selected, "ltp": 2})
+
+    assert not manager._put_priority_tick_nowait(manager._tick_queue, {"symbol": "NFO:NIFTY2660923800CE", "ltp": 3})
+
+    queued = _queued_symbols(manager)
+    assert open_symbol in queued
+    assert selected in queued
+
+
+def test_position_manager_exception_does_not_block_tick_enqueue(caplog) -> None:
+    class BrokenPositionManager:
+        def get_open_positions(self):
+            raise RuntimeError("boom")
+
+        def place_order(self):  # must never be called
+            raise AssertionError("order placement must not be called")
+
+    manager = _mdm()
+    manager.set_position_manager(BrokenPositionManager())
+    caplog.set_level(logging.WARNING)
+
+    assert manager._put_priority_tick_nowait(manager._tick_queue, {"symbol": "NFO:NIFTY2660923250CE", "ltp": 1})
+    assert "MDM_OPEN_POSITION_PRIORITY_LOOKUP_FAILED" in "\n".join(r.getMessage() for r in caplog.records)
+
+
+def test_priority_lookup_never_calls_order_or_risk_mutation() -> None:
+    class ReadOnlyProbe:
+        def __init__(self) -> None:
+            self.get_open_positions_called = 0
+            self.place_order_called = 0
+            self.risk_mutation_called = 0
+
+        def get_open_positions(self):
+            self.get_open_positions_called += 1
+            return [SimpleNamespace(symbol="NFO:NIFTY2660923250CE")]
+
+        def place_order(self):
+            self.place_order_called += 1
+            raise AssertionError("must not place orders")
+
+        def update_risk(self):
+            self.risk_mutation_called += 1
+            raise AssertionError("must not mutate risk")
+
+    probe = ReadOnlyProbe()
+    manager = _mdm()
+    manager.set_position_manager(probe)
+
+    assert manager._tick_priority("NFO:NIFTY2660923250CE") == (0, "open_position")
+    assert probe.get_open_positions_called == 1
+    assert probe.place_order_called == 0
+    assert probe.risk_mutation_called == 0
+
+
+def test_set_position_manager_only_used_for_read_only_priority_lookup() -> None:
+    from pathlib import Path
+
+    source = Path("src/nifty_scalper_bot/data/market_data_manager.py").read_text(encoding="utf-8")
+    assert "get_open_positions" in source
+    assert "place_order(" not in source[source.index("def _open_position_symbol_set"):source.index("def _selected_option_symbol_set")]
+    assert "risk_manager" not in source[source.index("def _open_position_symbol_set"):source.index("def _selected_option_symbol_set")]
+
+
+def _exercise_gap_case(runner: StrategyRunner, symbol: str, *, tick_ts: float, last_bar_age_s: float, caplog, monkeypatch):
+    import time
+
+    runner._has_session_candle_gaps = lambda _symbol: True
+    runner._session_gap_count[symbol] = 3
+    if tick_ts > 0:
+        runner._last_tick_time_by_symbol[symbol] = tick_ts
+    caplog.set_level(logging.INFO)
+    monkeypatch.setenv("RUNNER_CANDLE_GAP_GRACE_SECONDS", "10")
+    monkeypatch.setenv("RUNNER_CANDLE_GAP_INTERVAL_SECONDS", "60")
+    bar = SimpleNamespace(timestamp=datetime.now(timezone.utc) - timedelta(seconds=last_bar_age_s))
+    return runner.update_symbol_hydration(symbol, [bar, bar], {symbol: {"vwap": 1.0, "cum_volume": 1.0}})
+
+
+def test_candle_gap_no_tick_reason(caplog, monkeypatch) -> None:
+    runner = _runner()
+    symbol = "NFO:NIFTY2660923300CE"
+
+    _exercise_gap_case(runner, symbol, tick_ts=0.0, last_bar_age_s=30.0, caplog=caplog, monkeypatch=monkeypatch)
+
+    text = "\n".join(record.getMessage() for record in caplog.records)
+    assert "reason=no_recent_tick_for_gap_assessment" in text
+
+
+def test_candle_gap_stale_tick_reason_before_bar_grace(caplog, monkeypatch) -> None:
+    import time
+
+    runner = _runner()
+    symbol = "NFO:NIFTY2660923350CE"
+
+    _exercise_gap_case(runner, symbol, tick_ts=time.time() - 30.0, last_bar_age_s=30.0, caplog=caplog, monkeypatch=monkeypatch)
+
+    text = "\n".join(record.getMessage() for record in caplog.records)
+    assert "reason=stale_tick_for_gap_assessment" in text
+
+
+def test_candle_gap_repeated_missing_after_grace_with_stale_tick(caplog, monkeypatch) -> None:
+    import time
+
+    runner = _runner()
+    symbol = "NFO:NIFTY2660923400CE"
+
+    state = _exercise_gap_case(runner, symbol, tick_ts=time.time() - 30.0, last_bar_age_s=90.0, caplog=caplog, monkeypatch=monkeypatch)
+
+    text = "\n".join(record.getMessage() for record in caplog.records)
+    assert "reason=repeated_missing_candles" in text
+    assert state == SymbolState.DEGRADED
+
+
+def test_open_position_add_remove_invalidates_priority_cache() -> None:
+    manager = _mdm()
+    symbol = "NFO:NIFTY2660923450CE"
+
+    assert manager._tick_priority(symbol) != (0, "open_position")
+    manager.add_open_position_symbol(symbol)
+    assert manager._tick_priority(symbol) == (0, "open_position")
+    manager.remove_open_position_symbol(symbol)
+    assert manager._tick_priority(symbol) != (0, "open_position")

--- a/tests/data/test_market_data_priority_noise.py
+++ b/tests/data/test_market_data_priority_noise.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime, timezone, timedelta
+from types import SimpleNamespace
+
+import pytest
+
+from nifty_scalper_bot.core.message_bus import Message, MessageType
+from nifty_scalper_bot.data.market_data_manager import MarketDataManager
+from nifty_scalper_bot.strategies.runner import StrategyRunner, SymbolState
+
+
+class DummyIndicatorEngine:
+    def __init__(self, count: int = 0) -> None:
+        self.count = count
+
+    def get_history(self, _symbol):
+        return [object()] * self.count
+
+    def has_min_bars(self, _symbol, required):
+        return self.count >= required
+
+
+class DummyRisk:
+    available_balance = 1.0
+
+
+def _mdm() -> MarketDataManager:
+    manager = MarketDataManager(broker=None, settings={})
+    manager._tick_queue = asyncio.Queue(maxsize=2)
+    manager._active_contract_basket = {
+        "selected_ce": "NFO:NIFTY2660923250CE",
+        "selected_pe": "NFO:NIFTY2660923250PE",
+        "option_symbols": [
+            "NFO:NIFTY2660923250CE",
+            "NFO:NIFTY2660923250PE",
+            "NFO:NIFTY2660923500CE",
+        ],
+    }
+    return manager
+
+
+def test_queue_full_drops_low_priority_before_open_position_symbol() -> None:
+    manager = _mdm()
+    manager.set_open_position_symbols(["NFO:NIFTY2660923250CE"])
+
+    assert manager._put_priority_tick_nowait(manager._tick_queue, {"symbol": "NFO:NIFTY2660923500CE", "ltp": 1})
+    assert manager._put_priority_tick_nowait(manager._tick_queue, {"symbol": "NFO:NIFTY2660923500PE", "ltp": 2})
+    assert manager._put_priority_tick_nowait(manager._tick_queue, {"symbol": "NFO:NIFTY2660923250CE", "ltp": 3})
+
+    queued = [manager._tick_queue.get_nowait()["symbol"] for _ in range(manager._tick_queue.qsize())]
+    assert "NFO:NIFTY2660923250CE" in queued
+    assert len(queued) == 2
+    assert sum(manager._tick_queue_priority_drops.values()) >= 1
+
+
+@pytest.mark.asyncio
+async def test_open_position_tick_delivered_under_bus_queue_pressure() -> None:
+    manager = _mdm()
+    manager.set_open_position_symbols(["NFO:NIFTY2660923250CE"])
+    queue: asyncio.Queue = asyncio.Queue(maxsize=1)
+    bus = SimpleNamespace(queues={MessageType.TICK: queue})
+    low = Message(MessageType.TICK, datetime.now(timezone.utc), {"symbol": "NFO:NIFTY2660923500CE"}, "test")
+    high = Message(MessageType.TICK, datetime.now(timezone.utc), {"symbol": "NFO:NIFTY2660923250CE"}, "test")
+    queue.put_nowait(low)
+
+    await manager._publish_tick_message_with_priority(
+        bus, high, symbol="NFO:NIFTY2660923250CE", priority=0, bucket="open_position"
+    )
+
+    delivered = queue.get_nowait()
+    assert delivered.data["symbol"] == "NFO:NIFTY2660923250CE"
+
+
+def test_volume_delta_clamp_summarized_not_per_tick(caplog, monkeypatch) -> None:
+    manager = _mdm()
+    symbol = "NFO:NIFTY2660923250CE"
+    manager._last_cumulative_volume_by_symbol[symbol] = 100.0
+    monkeypatch.setenv("OPTION_MAX_REASONABLE_TICK_VOLUME_DELTA", "10")
+    caplog.set_level(logging.WARNING)
+
+    normalized = manager._normalise_tick_volume_delta(symbol, {"volume_traded_today": 1000})
+
+    assert normalized["volume_delta"] == 10.0
+    assert normalized["volume_delta_untrusted"] is True
+    text = "\n".join(record.getMessage() for record in caplog.records)
+    assert "OPTION_VOLUME_DELTA_CLAMP_SUMMARY" in text
+    assert "OPTION_VOLUME_DELTA_CLAMPED" not in text
+
+
+def _runner() -> StrategyRunner:
+    runner = StrategyRunner.__new__(StrategyRunner)
+    runner._logger = logging.getLogger("test.runner")
+    runner._symbol_states = {}
+    runner._symbol_bar_count = {}
+    runner._hydration_ready_streak = {}
+    runner._required_candles = 2
+    runner._session_gap_count = {}
+    runner._last_tick_time_by_symbol = {}
+    runner._indicator_engine = DummyIndicatorEngine(2)
+    runner._symbol_history = {}
+    runner._context_required_bars = 2
+    runner._market_data = SimpleNamespace()
+    runner._active_symbols = set()
+    runner._active_selected_ce = "NFO:NIFTY2660923250CE"
+    runner._active_selected_pe = "NFO:NIFTY2660923250PE"
+    runner._selected_ce_symbol = None
+    runner._selected_pe_symbol = None
+    runner._active_futures_symbol = "NFO:NIFTY26JUNFUT"
+    runner._runtime_execution_ready_by_symbol = {}
+    runner._runtime_readiness_reason = None
+    runner._runtime_live_orders_armed = True
+    runner._runtime_evaluation_ready = True
+    runner._last_selected_subscription_state_key = None
+    runner._should_log_throttled = lambda *_args, **_kwargs: True
+    runner._set_symbol_hydration_state = lambda symbol, state: state
+    runner._normalize_symbol = lambda symbol: symbol
+    runner._required_bars_for_symbol = lambda _symbol: 2
+    runner._history_count_for_symbol = lambda _symbol: 2
+    runner._get_mdm_bars = lambda _symbol, _target: [{"timestamp": i} for i in range(2)]
+    return runner
+
+
+def test_duplicate_noop_history_sync_not_emitted_when_all_stores_warm(caplog) -> None:
+    runner = _runner()
+    symbol = "NFO:NIFTY2660923250CE"
+    runner._symbol_history[symbol] = [object(), object()]
+    called = False
+
+    def emit(*_args, **_kwargs):
+        nonlocal called
+        called = True
+
+    runner._emit_history_hydration_trace = emit
+
+    result = runner._sync_history_from_mdm_cache(symbol, required_bars=2, source="pre_option_eval_option_sync")
+
+    assert result == 2
+    assert called is False
+
+
+def test_repeated_missing_candles_suppressed_if_fresh_tick_exists(caplog, monkeypatch) -> None:
+    runner = _runner()
+    symbol = "NFO:NIFTY2660923250CE"
+    runner._has_session_candle_gaps = lambda _symbol: True
+    runner._session_gap_count[symbol] = 3
+    runner._last_tick_time_by_symbol[symbol] = __import__("time").time()
+    caplog.set_level(logging.INFO)
+    monkeypatch.setenv("RUNNER_CANDLE_GAP_GRACE_SECONDS", "30")
+    old_bar = SimpleNamespace(timestamp=datetime.now(timezone.utc) - timedelta(minutes=5))
+
+    state = runner.update_symbol_hydration(symbol, [old_bar, old_bar], {symbol: {"vwap": 1.0, "cum_volume": 1.0}})
+
+    assert state != SymbolState.DEGRADED
+    text = "\n".join(record.getMessage() for record in caplog.records)
+    assert "CANDLE_GAP_SUPPRESSED_FRESH_TICK" in text
+    assert "repeated_missing_candles" not in text
+
+
+def test_selected_option_depth_missing_not_emitted_for_context_symbol() -> None:
+    runner = _runner()
+    runner._current_active_contract_selection = lambda: SimpleNamespace(
+        selected_ce="NFO:NIFTY2660923250CE", selected_pe="NFO:NIFTY2660923250PE"
+    )
+    runner._selected_option_symbol_for_side = lambda _side, _meta: None
+    runner._symbol_role_for_runner = lambda symbol: "spot_context" if symbol == "NSE:NIFTY" else "option_context"
+    runner._is_context_symbol_suspended = lambda _symbol: False
+    runner._is_option_symbol_tick_fresh = lambda _symbol, max_age_s=60.0: True
+    runner._selected_option_has_real_depth = lambda _symbol: False
+    runner._market_data = SimpleNamespace(
+        _token_by_symbol={"NFO:NIFTY2660923250CE": 1, "NFO:NIFTY2660923250PE": 2},
+        _active_subscribed_symbols={"NFO:NIFTY2660923250CE", "NFO:NIFTY2660923250PE"},
+        _desired_tokens={1, 2},
+        _subscribed_tokens={1, 2},
+        _confirmed_subscriptions={1, 2},
+        _ws=SimpleNamespace(_tokens={1, 2}),
+    )
+
+    ready, reason = runner._emit_live_universe_bootstrap_status(symbol="NSE:NIFTY")
+
+    assert ready is False
+    assert reason == "context_symbol_not_tradable"


### PR DESCRIPTION
### Motivation

- Live tick pipeline created high CPU/log pressure and risked delaying open-position tick handling because all ticks were treated equally under queue/backpressure conditions.  Symptoms included frequent `OPTION_VOLUME_DELTA_CLAMPED`, `HISTORY_HYDRATION_TRACE duplicate_noop`, `SOFT_DATA_ISSUE repeated_missing_candles` with age_s≈0, noisy `LIVE_UNIVERSE_BOOTSTRAP_STATUS` for non-selected symbols, and repeated `MDM_BUS_*` backpressure events.
- The intent is to reduce log/CPU pressure and protect open-position/selected-symbol handling without changing execution, risk, or bracket semantics.

### Description

- Prioritize and coalesce ticks in `MarketDataManager` so `open-position` symbols get highest priority, `selected CE/PE` next, `near-ATM` next, and far/context last; under queue-full conditions low-priority ticks are coalesced/dropped first rather than blocking protected ticks, and summaries are emitted via `MDM_BUS_PRIORITY_SUMMARY`, `MDM_BUS_BACKPRESSURE_SUMMARY`, and `OPEN_POSITION_TICK_PRIORITY_ACTIVE`. (changes in `src/nifty_scalper_bot/data/market_data_manager.py`)
- Implement robust volume-delta model in `MarketDataManager`: treat broker values as cumulative session volume, reset baseline on decreases, mark unrealistic deltas as `volume_delta_untrusted`, clamp and record per-symbol statistics, and emit aggregated `OPTION_VOLUME_DELTA_CLAMP_SUMMARY` instead of per-tick clamp spam; propagate `volume_delta_untrusted` into normalized ticks. (changes in `src/nifty_scalper_bot/data/market_data_manager.py`)
- Suppress duplicate history sync traces in `StrategyRunner` by skipping `pre_option_eval_option_sync` when MDM bars, runner bars, and indicator bars already meet required counts, eliminating `duplicate_noop` spam while preserving real failure traces. (changes in `src/nifty_scalper_bot/strategies/runner.py`)
- Make candle-gap detector less sensitive: require elapsed wall-clock > (`candle_interval` + `grace`) and absence of a fresh tick/close before emitting `repeated_missing_candles`; when a fresh tick exists emit `CANDLE_GAP_SUPPRESSED_FRESH_TICK` and update `CANDLE_GAP_SUMMARY`. (changes in `src/nifty_scalper_bot/strategies/runner.py`)
- Improve bootstrap reason hygiene so `selected_option_depth_missing` is only used for selected CE/PE; non-selected option/context symbols get `option_context_depth_missing` or `context_symbol_not_tradable`. (changes in `src/nifty_scalper_bot/strategies/runner.py`)
- Wire `PositionManager` (read-only) into `MarketDataManager` for priority lookups only; this does not change execution/risk behavior. (change in `src/nifty_scalper_bot/core/app.py`)
- Added focused regression tests covering queue-pressure priority/coalesce/drop behavior, open-position delivery under bus queue pressure, volume clamp summary behavior, duplicate-history sync suppression, fresh-tick candle-gap suppression, and bootstrap reason hygiene. (new `tests/data/test_market_data_priority_noise.py`)

### Testing

- Ran `python -m compileall -q src` and compilation succeeded.
- Ran focused tests: `pytest -q tests/data/test_market_data_priority_noise.py tests/strategies/test_runner_noise_gates.py` and all focused tests passed (green).
- Ran the full test suite: `pytest -q` and the suite passed in this environment.

All automated checks executed during the rollout succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a284fb0c0ec83249c5474e8d48851eb)