### PR TITLE
Fix SymbolRuntimeState last_trade_at crash

### DIFF
--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -419,6 +419,9 @@ class SymbolRuntimeState:
     active: bool = True
     last_tick: dict[str, Any] | None = None
     last_signal_at: datetime | None = None
+    last_trade_at: float | None = None
+    last_order_id: str | None = None
+    last_trade_symbol: str | None = None
     strategy_data: dict[str, Any] = field(default_factory=dict)
     vwap: float | None = None
     session_vwap_volume: int = 0
@@ -429,16 +432,47 @@ class SymbolRuntimeState:
 
     def __post_init__(self) -> None:
         self.trade_history = deque(maxlen=self.history_limit)
+        self.last_trade_at = _coerce_epoch_seconds(self.last_trade_at)
+
+    def trade_cooldown_remaining(self, now: float, cooldown_seconds: float) -> float:
+        """Return remaining trade cooldown seconds without crashing on old state."""
+        last_trade_at = _coerce_epoch_seconds(getattr(self, "last_trade_at", None))
+        if last_trade_at is None or cooldown_seconds <= 0:
+            return 0.0
+
+        elapsed = max(0.0, float(now) - last_trade_at)
+        return max(0.0, float(cooldown_seconds) - elapsed)
 
     def snapshot(self) -> dict[str, Any]:
         """Return a serialisable snapshot of the symbol state."""
         return {
             "active": self.active,
             "last_signal_at": _format_dt(self.last_signal_at),
+            "last_trade_at": _coerce_epoch_seconds(getattr(self, "last_trade_at", None)),
+            "last_order_id": getattr(self, "last_order_id", None),
+            "last_trade_symbol": getattr(self, "last_trade_symbol", None),
             "trade_history": [record.to_dict() for record in self.trade_history],
             "strategy_data": dict(self.strategy_data),
         }
 
+
+def _coerce_epoch_seconds(value: float | int | str | datetime | None) -> float | None:
+    """Convert persisted runtime timestamps to epoch seconds for cooldown checks."""
+    if value is None:
+        return None
+
+    if isinstance(value, datetime):
+        normalized = value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+        return float(normalized.timestamp())
+
+    try:
+        epoch_seconds = float(value)
+    except (TypeError, ValueError, OverflowError):
+        return None
+
+    if epoch_seconds != epoch_seconds or epoch_seconds < 0.0:
+        return None
+    return epoch_seconds
 
 def _format_dt(value: datetime | None) -> str | None:
     """Format datetime to UTC ISO format string."""
@@ -3487,7 +3521,9 @@ class StrategyRunner:
                     self._symbol_state[symbol] = state
 
                 state.trade_history.append(record)
-                state.last_trade_at = record.timestamp
+                state.last_trade_at = _coerce_epoch_seconds(record.timestamp)
+                state.last_order_id = record.order_id
+                state.last_trade_symbol = symbol
 
             restored += 1
 
@@ -13808,6 +13844,9 @@ class StrategyRunner:
                 return
 
             state.trade_history.append(record)
+            state.last_trade_at = _coerce_epoch_seconds(record.timestamp)
+            state.last_order_id = record.order_id
+            state.last_trade_symbol = symbol
 
         manager = self._persistent_state
         if manager is not None:

--- a/tests/strategies/test_symbol_runtime_state_trade_runtime.py
+++ b/tests/strategies/test_symbol_runtime_state_trade_runtime.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+from nifty_scalper_bot.core.message_bus import MessageBus
+from nifty_scalper_bot.strategies.runner import (
+    StrategyRunner,
+    StrategyRunnerConfig,
+    SymbolRuntimeState,
+)
+
+
+class _StubOrderManager:
+    def place_order(self, **_kwargs):
+        raise AssertionError("order placement is not part of this test")
+
+    def place_reduce_only_exit(self, *_args, **_kwargs):
+        raise AssertionError("exit placement is not part of this test")
+
+    def consume_skip_reason(self):
+        return None
+
+    def get_order(self, _order_id):
+        return None
+
+
+class _StubPositionManager:
+    def get_active_contract(self, _underlying):
+        return None
+
+    def is_flat(self, _symbol):
+        return True
+
+    def clear_active_contract(self, _underlying):
+        return None
+
+    def get_position(self, _symbol):
+        return None
+
+    def set_active_contract(self, _underlying, _contract):
+        return None
+
+
+def _build_runner() -> StrategyRunner:
+    return StrategyRunner(
+        market_data_manager=SimpleNamespace(),
+        indicator_engine=SimpleNamespace(),
+        strategy_manager=SimpleNamespace(),
+        risk_manager=SimpleNamespace(),
+        order_manager=_StubOrderManager(),
+        position_manager=_StubPositionManager(),
+        message_bus=MessageBus(),
+        config=StrategyRunnerConfig(max_trade_history=5),
+    )
+
+
+def test_symbol_runtime_state_defaults_without_last_trade_at() -> None:
+    state = SymbolRuntimeState(symbol="NFO:NIFTY26JUN24000CE", history_limit=5)
+
+    assert state.last_trade_at is None
+    assert state.last_order_id is None
+    assert state.last_trade_symbol is None
+    assert state.snapshot()["last_trade_at"] is None
+
+
+def test_symbol_runtime_state_cooldown_handles_missing_and_none_last_trade_at() -> None:
+    state = SymbolRuntimeState(symbol="NFO:NIFTY26JUN24000CE", history_limit=5)
+
+    assert state.trade_cooldown_remaining(now=100.0, cooldown_seconds=10.0) == 0.0
+
+    # Simulate an old/unpickled object whose slots predate last_trade_at.
+    old_state = object.__new__(SymbolRuntimeState)
+    assert old_state.trade_cooldown_remaining(now=100.0, cooldown_seconds=10.0) == 0.0
+
+
+def test_symbol_runtime_state_setting_last_trade_at_controls_cooldown() -> None:
+    state = SymbolRuntimeState(symbol="NFO:NIFTY26JUN24000CE", history_limit=5)
+    state.last_trade_at = 95.0
+
+    assert state.trade_cooldown_remaining(now=100.0, cooldown_seconds=10.0) == 5.0
+    assert state.trade_cooldown_remaining(now=120.0, cooldown_seconds=10.0) == 0.0
+
+
+def test_symbol_runtime_state_invalid_or_future_last_trade_at_is_safe() -> None:
+    state = SymbolRuntimeState(symbol="NFO:NIFTY26JUN24000CE", history_limit=5)
+    state.last_trade_at = -1.0
+    assert state.trade_cooldown_remaining(now=100.0, cooldown_seconds=10.0) == 0.0
+
+    state.last_trade_at = 105.0
+    assert state.trade_cooldown_remaining(now=100.0, cooldown_seconds=10.0) == 10.0
+
+
+def test_runner_restore_old_trade_payload_sets_epoch_last_trade_at() -> None:
+    runner = _build_runner()
+    timestamp = datetime(2026, 6, 10, 4, 0, tzinfo=timezone.utc)
+
+    runner.restore_trades(
+        [
+            {
+                "symbol": "NFO:NIFTY26JUN24000CE",
+                "timestamp": timestamp.isoformat(),
+                "action": "BUY",
+                "quantity": 75,
+                "price": 100.5,
+                "status": "FILLED",
+                "order_id": "OID-1",
+            }
+        ]
+    )
+
+    state = runner._symbol_state["NFO:NIFTY26JUN24000CE"]
+    assert state.last_trade_at == timestamp.timestamp()
+    assert state.last_order_id == "OID-1"
+    assert state.last_trade_symbol == "NFO:NIFTY26JUN24000CE"
+    assert state.snapshot()["last_trade_at"] == timestamp.timestamp()
+
+
+def test_runner_initialization_path_has_last_trade_at_field() -> None:
+    runner = _build_runner()
+
+    runner.add_symbol("NFO:NIFTY26JUN24000CE")
+
+    assert runner._symbol_state["NFO:NIFTY26JUN24000CE"].last_trade_at is None


### PR DESCRIPTION
### Motivation
- Restore path and runtime code wrote `state.last_trade_at` into a `@dataclass(slots=True)` that did not declare that slot, causing an `AttributeError` in `run_bot_background` and breaking startup recovery.
- Ensure runtime trade metadata and cooldown logic are safe for old/serialized state and do not crash live trading paths.

### Description
- Added slotted fields to `SymbolRuntimeState`: `last_trade_at: float | None`, `last_order_id: str | None`, and `last_trade_symbol: str | None` in `src/nifty_scalper_bot/strategies/runner.py`.
- Introduced `_coerce_epoch_seconds()` helper to accept `datetime`, numeric, or string timestamps and normalize to epoch seconds (or `None` for invalid values).
- Added `trade_cooldown_remaining(now, cooldown_seconds)` to `SymbolRuntimeState` and used defensive `getattr(...)` + coercion to avoid AttributeError and handle missing/invalid timestamps safely.
- Included the new runtime fields in `SymbolRuntimeState.snapshot()` and updated `restore_trades()` and `_record_trade()` to set `last_trade_at` (epoch seconds), `last_order_id`, and `last_trade_symbol` rather than writing raw `datetime` into a missing slot.
- Added focused unit tests at `tests/strategies/test_symbol_runtime_state_trade_runtime.py` covering construction without `last_trade_at`, defensive cooldown reads, setting and validating cooldown behavior, invalid/future values handling, and restore behavior from old serialized payloads.

### Testing
- Ran `python -m compileall -q src` and the code compiled successfully.
- Ran focused tests: `pytest -q tests/strategies/test_symbol_runtime_state_trade_runtime.py` and all tests passed.
- Ran broader scoped tests: `pytest -q tests/strategies tests/core tests/execution` and the suite passed in this scope.
- Full test run `pytest -q` completed successfully; no `AttributeError` related to `last_trade_at` observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a28e3525efc8324a1b341e59f1aa59d)