### PR TITLE
Fix BotContext active-selection runtime fields and protective exit priority

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -77,8 +77,79 @@ def _basket_attr(basket: Mapping[str, object] | object | None, key: str, default
     return getattr(basket, key, default)
 
 
+
+
+def ensure_bot_context_runtime_fields(ctx: Any) -> None:
+    """Initialize optional BotContext runtime fields that may be absent on legacy contexts."""
+    defaults: dict[str, Any] = {
+        "hydration_status_by_symbol": dict,
+        "last_hydration_status_at": None,
+        "_active_selection_sync_log_key": None,
+        "_active_selection_drift_log_key": None,
+        "last_active_selection_synced_at": None,
+        "last_active_selection_drift_at": None,
+        "_bot_context_runtime_fields_patch_logged": False,
+    }
+    missing: list[str] = []
+    for name, default in defaults.items():
+        try:
+            getattr(ctx, name)
+            continue
+        except AttributeError:
+            missing.append(name)
+        value = default() if callable(default) else default
+        try:
+            setattr(ctx, name, value)
+        except AttributeError:
+            # Unknown/minimal slotted contexts cannot be repaired safely here.
+            LOGGER.error(
+                "BOT_CONTEXT_ATTRIBUTE_MISSING attribute=%s component=runtime_field_initializer repairable=False",
+                name,
+                extra={
+                    "event": "BOT_CONTEXT_ATTRIBUTE_MISSING",
+                    "attribute": name,
+                    "component": "runtime_field_initializer",
+                    "repairable": False,
+                },
+            )
+            raise
+    if missing:
+        try:
+            already_logged = bool(getattr(ctx, "_bot_context_runtime_fields_patch_logged", False))
+            if not already_logged:
+                LOGGER.warning(
+                    "BOT_CONTEXT_RUNTIME_FIELDS_INITIALIZED missing=%s",
+                    missing,
+                    extra={
+                        "event": "BOT_CONTEXT_RUNTIME_FIELDS_INITIALIZED",
+                        "missing": missing,
+                    },
+                )
+                try:
+                    setattr(ctx, "_bot_context_runtime_fields_patch_logged", True)
+                except AttributeError:
+                    pass
+        except AttributeError:
+            pass
+
+
+def _log_bot_context_attribute_missing(exc: AttributeError, *, component: str) -> None:
+    """Log BotContext AttributeError with the missing attribute when Python exposes it."""
+    attr = getattr(exc, "name", None) or str(exc)
+    LOGGER.error(
+        "BOT_CONTEXT_ATTRIBUTE_MISSING attribute=%s component=%s",
+        attr,
+        component,
+        extra={
+            "event": "BOT_CONTEXT_ATTRIBUTE_MISSING",
+            "attribute": attr,
+            "component": component,
+        },
+    )
+
 def get_active_contract_selection(ctx: Any) -> ActiveContractSelection:
     """Return canonical selected-contract snapshot from active_contract_basket SSOT."""
+    ensure_bot_context_runtime_fields(ctx)
     basket = getattr(ctx, "active_contract_basket", None) or getattr(ctx, "active_trading_universe", None)
     mdm = getattr(ctx, "market_data_manager", None)
     if basket is None and mdm is not None:
@@ -92,6 +163,7 @@ def get_active_contract_selection(ctx: Any) -> ActiveContractSelection:
 
 def _sync_active_selection_from_basket(ctx: Any, selection: ActiveContractSelection) -> None:
     """Synchronize legacy selected CE/PE fields from active basket only."""
+    ensure_bot_context_runtime_fields(ctx)
     new_ce, new_pe = selection.selected_ce, selection.selected_pe
     if not (new_ce or new_pe):
         return
@@ -100,7 +172,8 @@ def _sync_active_selection_from_basket(ctx: Any, selection: ActiveContractSelect
     drift = bool((old_ce and new_ce and str(old_ce) != str(new_ce)) or (old_pe and new_pe and str(old_pe) != str(new_pe)))
     drift_key = (str(old_ce), str(old_pe), str(new_ce), str(new_pe), selection.basket_version or selection.selected_at)
     if drift and getattr(ctx, "_active_selection_drift_log_key", None) != drift_key:
-        ctx._active_selection_drift_log_key = drift_key
+        setattr(ctx, "_active_selection_drift_log_key", drift_key)
+        setattr(ctx, "last_active_selection_drift_at", time_module.time())
         LOGGER.warning(
             "ACTIVE_SELECTION_DRIFT_CORRECTED old_ce=%s old_pe=%s new_ce=%s new_pe=%s source=active_contract_basket",
             old_ce, old_pe, new_ce, new_pe,
@@ -112,7 +185,8 @@ def _sync_active_selection_from_basket(ctx: Any, selection: ActiveContractSelect
     ctx.atm_pe_symbol = new_pe
     sync_key = (str(new_ce), str(new_pe), selection.basket_version or selection.selected_at)
     if getattr(ctx, "_active_selection_sync_log_key", None) != sync_key:
-        ctx._active_selection_sync_log_key = sync_key
+        setattr(ctx, "_active_selection_sync_log_key", sync_key)
+        setattr(ctx, "last_active_selection_synced_at", time_module.time())
         LOGGER.info(
             "ACTIVE_SELECTION_SYNCED selected_ce=%s selected_pe=%s basket_version=%s",
             new_ce, new_pe, selection.basket_version or selection.selected_at,
@@ -2505,6 +2579,11 @@ class BotContext:
         default_factory=dict
     )
     last_hydration_status_at: datetime | None = None
+    _active_selection_sync_log_key: object | None = None
+    _active_selection_drift_log_key: object | None = None
+    last_active_selection_synced_at: float | None = None
+    last_active_selection_drift_at: float | None = None
+    _bot_context_runtime_fields_patch_logged: bool = False
     message_bus_tick_subscribed: bool = False
     datahub_runner_subscriptions: set[str] = field(default_factory=set)
     execution_locked_symbols: set[str] = field(default_factory=set)
@@ -4977,6 +5056,12 @@ def initialize_components(settings: Settings | None = None) -> BotContext:
             )
 
             # Attach once; duplicate attachment can duplicate bracket listeners.
+            if hasattr(bracket_manager, "attach_open_position_priority_hooks") and hasattr(market_data_manager, "add_open_position_symbol") and hasattr(market_data_manager, "remove_open_position_symbol"):
+                bracket_manager.attach_open_position_priority_hooks(
+                    on_position_open=market_data_manager.add_open_position_symbol,
+                    on_position_closed=market_data_manager.remove_open_position_symbol,
+                )
+
             if not bracket_manager_attached:
                 order_manager.set_bracket_manager(bracket_manager=bracket_manager)
                 bracket_manager_attached = True
@@ -6897,6 +6982,16 @@ async def _refresh_readiness_after_first_tick(ctx: BotContext, reason: str) -> N
                                 symbols=basket.get("symbols") or [],
                                 atm_strike=basket.get("atm_strike"),
                             )
+                    except AttributeError as exc:
+                        _log_bot_context_attribute_missing(exc, component="live_basket_build")
+                        LOGGER.warning(
+                            "LIVE_BASKET_BUILD_FAILED reason=%s",
+                            exc,
+                            extra={
+                                "event": "LIVE_BASKET_BUILD_FAILED",
+                                "reason": str(exc),
+                            },
+                        )
                     except Exception as exc:  # noqa: BLE001
                         LOGGER.warning(
                             "LIVE_BASKET_BUILD_FAILED reason=%s",
@@ -7646,6 +7741,7 @@ def build_symbol_hydration_status(
 
 def _hydration_status_map(ctx: BotContext, *, required_option_bars: int, required_context_bars: int) -> dict[str, HydrationStatus]:
     """Build hydration statuses for spot, future, selected/pending CE/PE, and nearby options."""
+    ensure_bot_context_runtime_fields(ctx)
     basket = cast(Mapping[str, Any], getattr(ctx, "active_trading_universe", {}) or {})
     runner = getattr(ctx, "strategy_runner", None)
     spot_symbol = str(basket.get("spot_symbol") or getattr(ctx, "nifty_symbol", None) or "NSE:NIFTY")
@@ -7906,6 +8002,7 @@ async def _ensure_selected_options_hydrated(
 
 async def _recompute_and_push_runtime_readiness(ctx: BotContext, *, reason: str) -> None:
     """Recompute app runtime readiness and push to runner. Args: ctx/reason. Returns: none. Raises: none."""
+    ensure_bot_context_runtime_fields(ctx)
     source_basket = getattr(ctx, "active_contract_basket", None) or getattr(ctx, "active_trading_universe", {}) or {}
     basket = normalize_active_basket_schema(cast(dict[str, object], dict(source_basket) if isinstance(source_basket, Mapping) else {}))
     mdm = getattr(ctx, "market_data_manager", None)
@@ -8205,6 +8302,7 @@ def _commit_active_dynamic_basket(
     atm_strike: int | float | str | None,
 ) -> tuple[str | None, str | None]:
     """Commit active dynamic basket atomically. Args: ctx/basket/option_symbols/symbols/atm_strike. Returns: selected CE/PE. Raises: none."""
+    ensure_bot_context_runtime_fields(ctx)
     requested_futures_symbol = basket.get("futures_symbol") or basket.get("future_symbol")
     requested_selected_ce = str(basket.get("selected_ce") or basket.get("atm_ce") or "") or None
     requested_selected_pe = str(basket.get("selected_pe") or basket.get("atm_pe") or "") or None
@@ -11001,6 +11099,8 @@ async def startup_sequence(ctx: BotContext) -> None:
                 )
                 startup_trade_ready = True
             else:
+                if isinstance(e, AttributeError):
+                    _log_bot_context_attribute_missing(e, component="hydration_tracking")
                 norm_basket = normalize_active_basket_schema(dict(getattr(ctx, "active_trading_universe", {}) or {}))
                 LOGGER.exception(
                     "HYDRATION_TRACKING_FAILED error_type=%s error=%s basket_keys=%s selected_ce=%s selected_pe=%s spot_symbol=%s futures_symbol=%s",

--- a/src/nifty_scalper_bot/execution/bracket_manager.py
+++ b/src/nifty_scalper_bot/execution/bracket_manager.py
@@ -82,6 +82,20 @@ def _normalize_bracket_side(side: str) -> str:
 
 _FILLED_STATUSES = {"FILLED", "COMPLETE", "COMPLETED"}
 _CANCELLED_STATUSES = {"CANCELLED", "REJECTED", "CANCELED"}
+_PROTECTIVE_EXIT_REASON_TOKENS = (
+    "HARD_SL_BREACH",
+    "WATCHDOG_HARD_SL",
+    "FORCED_SL_EXIT",
+    "EOD_FLATTEN",
+    "EXIT_ESCALATED",
+)
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
 
 
 # --------------------------------------------------------------------------
@@ -370,6 +384,8 @@ class BracketManager:
         self._trailing_controller_factory: Callable[[BracketState], Any] | None = None
         # FIX S10-2: hook fired when bracket fully closes — lets runner clear orchestrator direction lock
         self._on_exit_complete_hook: Callable[[str], None] | None = None
+        self._on_position_open_priority_hook: Callable[[str], None] | None = None
+        self._on_position_closed_priority_hook: Callable[[str], None] | None = None
     
         # Real-time Data Cache (Legacy Fallback)
         self._current_atr: Dict[str, float] = {}
@@ -409,6 +425,10 @@ class BracketManager:
         self._exit_flat_confirmation_required = os.getenv("EXIT_FLAT_CONFIRMATION_REQUIRED", "true").strip().lower() in {"1", "true", "yes", "on"}
         self._exit_unresolved_escalation_seconds = max(1.0, parse_float_env(os.getenv("EXIT_UNRESOLVED_ESCALATION_SECONDS"), 15.0))
         self._exit_continue_retry_after_escalation = os.getenv("EXIT_CONTINUE_RETRY_AFTER_ESCALATION", "false").strip().lower() in {"1", "true", "yes", "on"}
+        self._exit_protective_order_mode = str(os.getenv("EXIT_PROTECTIVE_ORDER_MODE", "MARKET") or "MARKET").strip().upper()
+        self._exit_marketable_limit_slippage_ticks = max(0, parse_int_env(os.getenv("EXIT_MARKETABLE_LIMIT_SLIPPAGE_TICKS"), 5))
+        self._exit_marketable_limit_max_slippage_pct = max(0.0, parse_float_env(os.getenv("EXIT_MARKETABLE_LIMIT_MAX_SLIPPAGE_PCT"), 2.0))
+        self._exit_fallback_to_market_on_quote_missing = _env_bool("EXIT_FALLBACK_TO_MARKET_ON_QUOTE_MISSING", True)
         self._watchdog_thread = threading.Thread(
             target=self._watchdog_exit_loop,
             name='bracket-watchdog',
@@ -460,6 +480,51 @@ class BracketManager:
     def attach_on_exit_complete(self, hook: Callable[[str], None] | None) -> None:
         """Attach callback fired with symbol when bracket fully closes. Lets runner clear orchestrator direction lock."""
         self._on_exit_complete_hook = hook
+
+    def attach_open_position_priority_hooks(
+        self,
+        on_position_open: Callable[[str], None] | None = None,
+        on_position_closed: Callable[[str], None] | None = None,
+    ) -> None:
+        """Attach MDM open-position priority hooks for immediate tick prioritization."""
+        self._on_position_open_priority_hook = on_position_open
+        self._on_position_closed_priority_hook = on_position_closed
+
+    def _notify_open_position_priority(self, action: str, symbol: str) -> None:
+        hook = (
+            self._on_position_open_priority_hook
+            if action == "open"
+            else self._on_position_closed_priority_hook
+        )
+        if hook is None:
+            return
+        try:
+            hook(symbol)
+            if action == "open":
+                LOGGER.info(
+                    "OPEN_POSITION_PRIORITY_REGISTERED symbol=%s",
+                    symbol,
+                    extra={"event": "OPEN_POSITION_PRIORITY_REGISTERED", "symbol": symbol},
+                )
+            else:
+                LOGGER.info(
+                    "OPEN_POSITION_PRIORITY_REMOVED symbol=%s",
+                    symbol,
+                    extra={"event": "OPEN_POSITION_PRIORITY_REMOVED", "symbol": symbol},
+                )
+        except Exception as exc:  # noqa: BLE001 - hook must not break bracket lifecycle
+            LOGGER.exception(
+                "OPEN_POSITION_PRIORITY_HOOK_FAILED action=%s symbol=%s error=%s",
+                action,
+                symbol,
+                exc,
+                extra={
+                    "event": "OPEN_POSITION_PRIORITY_HOOK_FAILED",
+                    "action": action,
+                    "symbol": symbol,
+                    "error": str(exc),
+                },
+            )
 
 
     def attach_trailing_controller_factory(
@@ -1044,6 +1109,7 @@ class BracketManager:
                     'tp': round(bracket.tp_trigger_price, 2),
                 },
             )
+            self._notify_open_position_priority("open", bracket.symbol)
             
             # Persist state
             try:
@@ -1581,49 +1647,6 @@ class BracketManager:
         except Exception as e:
             LOGGER.error("Failure in BracketManager.on_tick_event: %s", e)
 
-    def _execute_exit_order(
-        self, 
-        bracket: BracketState, 
-        qty: int, 
-        exit_side: str, 
-        reason: str,
-        is_partial: bool
-    ) -> None:
-        """
-        Execute the actual exit order with slippage protection.
-        Called outside the main lock for better concurrency.
-        """
-        # All protective exits are MARKET to guarantee deterministic execution.
-        _order_type = "MARKET"
-        _price = None
-        
-        # Place order via OrderManager
-        order_id = self.order_manager.place_order(
-            symbol=bracket.symbol,
-            side=exit_side,
-            quantity=qty,
-            order_type=_order_type,
-            price=_price,
-            tag=f"exit_{reason[:3]}_{bracket.tag[:3] if bracket.tag else 'auto'}",
-            check_risk=False,
-            product="MIS"
-        )
-        
-        if not order_id:
-            raise RuntimeError(
-                f"Exit order BLOCKED for {bracket.symbol} ({reason}). "
-                f"place_order returned None — bracket state must be reverted."
-            )
-        
-        LOGGER.info(
-                f"✅ Exit order placed: {bracket.symbol} | order_id={order_id} | "
-                f"type={_order_type} | reason={reason}"
-        )
-        
-        # Cleanup if full exit
-        if not is_partial and bracket.remaining_quantity <= 0:
-            self.unregister_bracket(bracket.entry_order_id)
-
     @property
     def active_brackets(self) -> Dict[str, BracketState]:
         """Return symbol-indexed active bracket map for recovery hooks."""
@@ -2104,6 +2127,93 @@ class BracketManager:
                     bracket.sl_trigger_price = bracket.entry_price
                     LOGGER.info(f"🔒 {bracket.symbol}: SL Moved to Breakeven ({bracket.entry_price})")
 
+
+    def _extract_exit_quote(self, symbol: str) -> tuple[float | None, float | None, float | None]:
+        source = self._market_data
+        quote: Any = None
+        for name in ("get_quote", "get_latest_tick", "get_tick", "get_ltp_snapshot"):
+            getter = getattr(source, name, None) if source is not None else None
+            if not callable(getter):
+                continue
+            try:
+                quote = getter(symbol)
+                if quote:
+                    break
+            except TypeError:
+                try:
+                    quote = getter(symbol, allow_pull=False)
+                    if quote:
+                        break
+                except Exception:
+                    continue
+            except Exception:
+                continue
+        if quote is None:
+            return None, None, None
+        if not isinstance(quote, Mapping):
+            quote = getattr(quote, "__dict__", {}) or {}
+        def _num(*keys: str) -> float | None:
+            for key in keys:
+                try:
+                    value = float(quote.get(key) or 0.0)
+                except (TypeError, ValueError, AttributeError):
+                    continue
+                if value > 0:
+                    return value
+            return None
+        return _num("bid", "best_bid"), _num("ask", "best_ask"), _num("ltp", "last_price", "last_traded_price")
+
+    def _is_protective_exit_reason(self, reason: str) -> bool:
+        upper = str(reason or "").upper()
+        return any(token in upper for token in _PROTECTIVE_EXIT_REASON_TOKENS)
+
+    def _price_exit_order(
+        self,
+        *,
+        bracket: BracketState | None,
+        symbol: str,
+        side: str,
+        reason: str,
+        preferred_order_type: str,
+        qty: int,
+    ) -> tuple[str, float | None, dict[str, Any]]:
+        mode = str(preferred_order_type or "LIMIT").upper()
+        protective = self._is_protective_exit_reason(reason)
+        bid: float | None = None
+        ask: float | None = None
+        ltp: float | None = None
+        fallback = False
+        if protective:
+            configured = self._exit_protective_order_mode
+            mode = "MARKET" if configured not in {"AGGRESSIVE_LIMIT", "LIMIT"} else "LIMIT"
+            if configured == "AGGRESSIVE_LIMIT":
+                bid, ask, ltp = self._extract_exit_quote(symbol)
+                tick_size = 0.05
+                reference = bid if side == "SELL" else ask
+                if reference is None and ltp is not None:
+                    reference = ltp
+                if reference is None:
+                    if self._exit_fallback_to_market_on_quote_missing:
+                        mode = "MARKET"
+                        fallback = True
+                    else:
+                        return "LIMIT", None, {"quote_missing": True, "mode": "AGGRESSIVE_LIMIT", "bid": bid, "ask": ask, "ltp": ltp, "fallback": False}
+                else:
+                    tick_buffer = self._exit_marketable_limit_slippage_ticks * tick_size
+                    pct_buffer = reference * (self._exit_marketable_limit_max_slippage_pct / 100.0)
+                    buffer = min(max(tick_buffer, tick_size), pct_buffer if pct_buffer > 0 else tick_buffer)
+                    raw = reference - buffer if side == "SELL" else reference + buffer
+                    return "LIMIT", _round_to_tick(max(raw, tick_size), tick_size=tick_size), {"mode": "AGGRESSIVE_LIMIT", "bid": bid, "ask": ask, "ltp": ltp, "fallback": False}
+        elif mode == "LIMIT" and bracket is not None:
+            current_ltp = float(bracket.last_ltp or bracket.entry_price or 0.0)
+            if current_ltp > 0:
+                max_slippage_pct = parse_float_env(os.getenv("EXIT_MAX_SLIPPAGE_PCT"), 2.0)
+                raw = current_ltp * (1 - max_slippage_pct / 100) if side == "SELL" else current_ltp * (1 + max_slippage_pct / 100)
+                return "LIMIT", _round_to_tick(max(raw, 0.05), tick_size=0.05), {"mode": "LIMIT", "bid": bid, "ask": ask, "ltp": current_ltp, "fallback": False}
+            mode = "MARKET"
+            fallback = True
+        return mode, None, {"mode": "MARKET" if mode == "MARKET" else mode, "bid": bid, "ask": ask, "ltp": ltp, "fallback": fallback}
+
     def submit_exit_order(
         self,
         symbol: str,
@@ -2116,16 +2226,26 @@ class BracketManager:
         normalized_symbol = normalize_symbol(symbol)
         bracket = self.get_bracket(bracket_id)
         side = "SELL" if (bracket and bracket.side == "BUY") else "BUY"
-        order_type = str(preferred_order_type or "LIMIT").upper()
-        price: float | None = None
-        if order_type == "LIMIT" and bracket is not None:
-            current_ltp = float(bracket.last_ltp or bracket.entry_price or 0.0)
-            if current_ltp > 0:
-                max_slippage_pct = parse_float_env(os.getenv("EXIT_MAX_SLIPPAGE_PCT"), 2.0)
-                raw = current_ltp * (1 - max_slippage_pct / 100) if side == "SELL" else current_ltp * (1 + max_slippage_pct / 100)
-                price = _round_to_tick(max(raw, 0.05), tick_size=0.05)
-            else:
-                order_type = "MARKET"
+        order_type, price, pricing_meta = self._price_exit_order(
+            bracket=bracket,
+            symbol=normalized_symbol,
+            side=side,
+            reason=reason,
+            preferred_order_type=preferred_order_type,
+            qty=qty,
+        )
+        if pricing_meta.get("quote_missing"):
+            LOGGER.warning(
+                "EXIT_ORDER_PRICING_DECISION bracket_id=%s reason=%s mode=aggressive_limit side=%s qty=%s bid=%s ask=%s ltp=%s price=%s fallback=%s",
+                bracket_id, reason, side, qty, pricing_meta.get("bid"), pricing_meta.get("ask"), pricing_meta.get("ltp"), price, pricing_meta.get("fallback"),
+                extra={"event": "EXIT_ORDER_PRICING_DECISION", "bracket_id": bracket_id, "reason": reason, "mode": "aggressive_limit", "side": side, "qty": qty, "bid": pricing_meta.get("bid"), "ask": pricing_meta.get("ask"), "ltp": pricing_meta.get("ltp"), "price": price, "fallback": pricing_meta.get("fallback")},
+            )
+            return SubmitExitOrderResult(False, None, "quote_missing", "quote_missing", "protective aggressive limit quote missing", True, {})
+        LOGGER.info(
+            "EXIT_ORDER_PRICING_DECISION bracket_id=%s reason=%s mode=%s side=%s qty=%s bid=%s ask=%s ltp=%s price=%s fallback=%s",
+            bracket_id, reason, str(pricing_meta.get("mode") or order_type).lower(), side, qty, pricing_meta.get("bid"), pricing_meta.get("ask"), pricing_meta.get("ltp"), price, pricing_meta.get("fallback"),
+            extra={"event": "EXIT_ORDER_PRICING_DECISION", "bracket_id": bracket_id, "reason": reason, "mode": str(pricing_meta.get("mode") or order_type).lower(), "side": side, "qty": qty, "bid": pricing_meta.get("bid"), "ask": pricing_meta.get("ask"), "ltp": pricing_meta.get("ltp"), "price": price, "fallback": pricing_meta.get("fallback")},
+        )
         try:
             kwargs: dict[str, Any] = {
                 "symbol": normalized_symbol,
@@ -2342,6 +2462,7 @@ class BracketManager:
             bracket,
             meta={"close_source": close_source, "exit_order_id": bracket.exit_order_id},
         )
+        self._notify_open_position_priority("close", bracket.symbol)
         hook = self._on_exit_complete_hook
         if hook is not None:
             try:
@@ -2607,6 +2728,8 @@ class BracketManager:
                 # ✅ NEW: Cleanup Exit Cooldown
                 if entry_id in self._exit_cooldowns:
                     del self._exit_cooldowns[entry_id]
+
+                self._notify_open_position_priority("close", symbol)
 
                 # ✅ FIX: Persist removal immediately
                 self.save_state()

--- a/tests/core/test_botcontext_active_selection_runtime_fields.py
+++ b/tests/core/test_botcontext_active_selection_runtime_fields.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+
+from nifty_scalper_bot.core import app
+from nifty_scalper_bot.core.active_basket import ActiveContractSelection
+from nifty_scalper_bot.core.app import BotContext
+
+
+def _selection(ce: str = "NFO:NIFTY2661623350CE", pe: str = "NFO:NIFTY2661623350PE", version: str = "v1") -> ActiveContractSelection:
+    return ActiveContractSelection(
+        selected_ce=ce,
+        selected_pe=pe,
+        basket_version=version,
+        selected_at="2026-06-10T04:25:00Z",
+        source="unit_test",
+    )
+
+
+def test_botcontext_declares_active_selection_runtime_fields() -> None:
+    names = {field.name for field in __import__("dataclasses").fields(BotContext)}
+    assert "_active_selection_sync_log_key" in names
+    assert "_active_selection_drift_log_key" in names
+    assert "last_active_selection_synced_at" in names
+    assert "last_active_selection_drift_at" in names
+
+
+def test_sync_active_selection_fresh_legacy_context_does_not_crash() -> None:
+    ctx = SimpleNamespace()
+
+    app._sync_active_selection_from_basket(ctx, _selection())
+
+    assert ctx.selected_ce == "NFO:NIFTY2661623350CE"
+    assert ctx.selected_pe == "NFO:NIFTY2661623350PE"
+    assert ctx._active_selection_sync_log_key is not None
+    assert ctx.last_active_selection_synced_at is not None
+    assert isinstance(ctx.hydration_status_by_symbol, dict)
+
+
+def test_active_selection_synced_logs_only_on_state_change(caplog) -> None:
+    ctx = SimpleNamespace()
+    caplog.set_level(logging.INFO, logger="nifty_scalper_bot.core.app")
+
+    app._sync_active_selection_from_basket(ctx, _selection(version="v1"))
+    app._sync_active_selection_from_basket(ctx, _selection(version="v1"))
+    app._sync_active_selection_from_basket(ctx, _selection(version="v2"))
+
+    events = [r for r in caplog.records if getattr(r, "event", "") == "ACTIVE_SELECTION_SYNCED"]
+    assert len(events) == 2
+
+
+def test_active_selection_drift_logs_only_on_state_change(caplog) -> None:
+    ctx = SimpleNamespace(selected_ce="NFO:OLDCE", selected_pe="NFO:OLDPE")
+    caplog.set_level(logging.WARNING, logger="nifty_scalper_bot.core.app")
+
+    app._sync_active_selection_from_basket(ctx, _selection(version="v1"))
+    ctx.selected_ce = "NFO:OLDCE"
+    ctx.selected_pe = "NFO:OLDPE"
+    app._sync_active_selection_from_basket(ctx, _selection(version="v1"))
+    ctx.selected_ce = "NFO:OLDERCE"
+    ctx.selected_pe = "NFO:OLDERPE"
+    app._sync_active_selection_from_basket(ctx, _selection(version="v1"))
+
+    events = [r for r in caplog.records if getattr(r, "event", "") == "ACTIVE_SELECTION_DRIFT_CORRECTED"]
+    assert len(events) == 2
+
+
+def test_hydration_status_map_repairs_missing_runtime_fields(monkeypatch) -> None:
+    ctx = SimpleNamespace(
+        active_trading_universe={"spot_symbol": "NSE:NIFTY", "selected_ce": "NFO:NIFTY2661623350CE", "selected_pe": "NFO:NIFTY2661623350PE"},
+        strategy_runner=None,
+    )
+    monkeypatch.setattr(app, "build_symbol_hydration_status", lambda _ctx, sym, role, required: SimpleNamespace(to_dict=lambda: {"symbol": sym, "role": role}))
+
+    statuses = app._hydration_status_map(ctx, required_option_bars=3, required_context_bars=1)
+
+    assert set(statuses) == {"NSE:NIFTY", "NFO:NIFTY2661623350CE", "NFO:NIFTY2661623350PE"}
+    assert ctx.last_hydration_status_at is not None

--- a/tests/execution/test_bracket_open_position_priority_and_protective_exit.py
+++ b/tests/execution/test_bracket_open_position_priority_and_protective_exit.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from nifty_scalper_bot.execution.bracket_manager import BracketManager, BracketState
+
+
+def _active_bracket(manager: BracketManager, *, side: str = "BUY") -> BracketState:
+    bracket = BracketState(
+        entry_order_id="entry-1",
+        symbol="NFO:TEST",
+        side=side,
+        quantity=10,
+        entry_price=100.0,
+        sl_trigger_price=95.0,
+        tp_trigger_price=110.0,
+        remaining_quantity=10,
+        active=False,
+        entry_confirmed=False,
+    )
+    manager._brackets[bracket.entry_order_id] = bracket
+    return bracket
+
+
+def test_confirm_entry_fill_registers_open_position_priority_once() -> None:
+    manager = BracketManager(order_manager=MagicMock())
+    manager.shutdown()
+    bracket = _active_bracket(manager)
+    opened: list[str] = []
+    manager.attach_open_position_priority_hooks(on_position_open=opened.append)
+
+    manager.confirm_entry_fill(bracket.entry_order_id, 101.0)
+
+    assert opened == ["NFO:TEST"]
+    assert bracket.active is True
+
+
+def test_bracket_close_removes_open_position_priority() -> None:
+    manager = BracketManager(order_manager=MagicMock())
+    manager.shutdown()
+    bracket = _active_bracket(manager)
+    closed: list[str] = []
+    manager.attach_open_position_priority_hooks(on_position_closed=closed.append)
+
+    manager._close_bracket(bracket, close_source="unit_test")
+
+    assert closed == ["NFO:TEST"]
+    assert bracket.active is False
+
+
+def test_priority_hook_exception_does_not_block_activation() -> None:
+    manager = BracketManager(order_manager=MagicMock())
+    manager.shutdown()
+    bracket = _active_bracket(manager)
+    manager.attach_open_position_priority_hooks(on_position_open=lambda _symbol: (_ for _ in ()).throw(RuntimeError("boom")))
+
+    manager.confirm_entry_fill(bracket.entry_order_id, 101.0)
+
+    assert bracket.active is True
+
+
+def test_hard_sl_protective_exit_defaults_to_market(monkeypatch) -> None:
+    monkeypatch.delenv("EXIT_PROTECTIVE_ORDER_MODE", raising=False)
+    order_manager = MagicMock()
+    order_manager.place_order.return_value = "exit-1"
+    manager = BracketManager(order_manager=order_manager)
+    manager.shutdown()
+    _active_bracket(manager)
+
+    result = manager.submit_exit_order("NFO:TEST", 10, "HARD_SL_BREACH", "entry-1", preferred_order_type="LIMIT")
+
+    assert result.accepted is True
+    assert order_manager.place_order.call_args.kwargs["order_type"] == "MARKET"
+    assert "price" not in order_manager.place_order.call_args.kwargs
+
+
+def test_eod_flatten_protective_exit_defaults_to_market(monkeypatch) -> None:
+    monkeypatch.delenv("EXIT_PROTECTIVE_ORDER_MODE", raising=False)
+    order_manager = MagicMock()
+    order_manager.place_order.return_value = "exit-1"
+    manager = BracketManager(order_manager=order_manager)
+    manager.shutdown()
+    _active_bracket(manager)
+
+    manager.submit_exit_order("NFO:TEST", 10, "EOD_FLATTEN", "entry-1", preferred_order_type="LIMIT")
+
+    assert order_manager.place_order.call_args.kwargs["order_type"] == "MARKET"
+
+
+def test_aggressive_limit_sell_exit_prices_below_bid(monkeypatch) -> None:
+    monkeypatch.setenv("EXIT_PROTECTIVE_ORDER_MODE", "AGGRESSIVE_LIMIT")
+    order_manager = MagicMock()
+    order_manager.place_order.return_value = "exit-1"
+    market_data = MagicMock()
+    market_data.get_quote.return_value = {"bid": 100.0, "ask": 101.0, "ltp": 100.5}
+    manager = BracketManager(order_manager=order_manager, market_data=market_data)
+    manager.shutdown()
+    _active_bracket(manager, side="BUY")
+
+    manager.submit_exit_order("NFO:TEST", 10, "WATCHDOG_HARD_SL", "entry-1", preferred_order_type="LIMIT")
+
+    kwargs = order_manager.place_order.call_args.kwargs
+    assert kwargs["order_type"] == "LIMIT"
+    assert kwargs["price"] < 100.0
+
+
+def test_aggressive_limit_quote_missing_falls_back_to_market(monkeypatch) -> None:
+    monkeypatch.setenv("EXIT_PROTECTIVE_ORDER_MODE", "AGGRESSIVE_LIMIT")
+    monkeypatch.setenv("EXIT_FALLBACK_TO_MARKET_ON_QUOTE_MISSING", "true")
+    order_manager = MagicMock()
+    order_manager.place_order.return_value = "exit-1"
+    market_data = MagicMock()
+    market_data.get_quote.return_value = {}
+    manager = BracketManager(order_manager=order_manager, market_data=market_data)
+    manager.shutdown()
+    _active_bracket(manager)
+
+    manager.submit_exit_order("NFO:TEST", 10, "FORCED_SL_EXIT", "entry-1", preferred_order_type="LIMIT")
+
+    assert order_manager.place_order.call_args.kwargs["order_type"] == "MARKET"
+
+
+def test_legacy_execute_exit_order_removed_from_runtime_path() -> None:
+    assert not hasattr(BracketManager, "_execute_exit_order")

--- a/tests/execution/test_exit_order_type.py
+++ b/tests/execution/test_exit_order_type.py
@@ -1,78 +1,61 @@
 from __future__ import annotations
 
-import logging
 from unittest.mock import MagicMock
 
 from nifty_scalper_bot.execution.bracket_manager import BracketManager, BracketState
 
 
-def test_exit_order_type_uses_market_for_sl() -> None:
-    """Verify SL order type. Args: None. Returns: None. Raises: Exception."""
-    logger = logging.getLogger(__name__)
-    try:
-        order_manager = MagicMock()
-        manager = BracketManager(order_manager=order_manager)
-
-        bracket = BracketState(
-            entry_order_id="entry-1",
-            symbol="NFO:TEST",
-            side="BUY",
-            quantity=10,
-            entry_price=100.0,
-            sl_trigger_price=95.0,
-            tp_trigger_price=110.0,
-            remaining_quantity=10,
-        )
-        bracket.last_ltp = 98.0
-
-        manager._execute_exit_order(
-            bracket=bracket,
-            qty=10,
-            exit_side="SELL",
-            reason="SL Hit",
-            is_partial=False,
-            exit_type="SL",
-        )
-
-        kwargs = order_manager.place_order.call_args.kwargs
-        assert kwargs["order_type"] == "MARKET"
-        assert "price" not in kwargs
-    except Exception as e:
-        logger.error("Failure in test_exit_order_type_uses_market_for_sl: %s", e)
-        raise
+def _manager_with_bracket(monkeypatch, *, reason_mode: str | None = None) -> tuple[BracketManager, MagicMock]:
+    if reason_mode is None:
+        monkeypatch.delenv("EXIT_PROTECTIVE_ORDER_MODE", raising=False)
+    else:
+        monkeypatch.setenv("EXIT_PROTECTIVE_ORDER_MODE", reason_mode)
+    order_manager = MagicMock()
+    order_manager.place_order.return_value = "exit-1"
+    manager = BracketManager(order_manager=order_manager)
+    manager.shutdown()
+    bracket = BracketState(
+        entry_order_id="entry-1",
+        symbol="NFO:TEST",
+        side="BUY",
+        quantity=10,
+        entry_price=100.0,
+        sl_trigger_price=95.0,
+        tp_trigger_price=110.0,
+        remaining_quantity=10,
+    )
+    bracket.last_ltp = 98.0
+    manager._brackets[bracket.entry_order_id] = bracket
+    return manager, order_manager
 
 
-def test_exit_order_type_uses_limit_for_tp() -> None:
-    """Verify TP order type. Args: None. Returns: None. Raises: Exception."""
-    logger = logging.getLogger(__name__)
-    try:
-        order_manager = MagicMock()
-        manager = BracketManager(order_manager=order_manager)
+def test_exit_order_type_uses_market_for_sl(monkeypatch) -> None:
+    manager, order_manager = _manager_with_bracket(monkeypatch)
 
-        bracket = BracketState(
-            entry_order_id="entry-2",
-            symbol="NFO:TEST",
-            side="BUY",
-            quantity=10,
-            entry_price=100.0,
-            sl_trigger_price=95.0,
-            tp_trigger_price=110.0,
-            remaining_quantity=10,
-        )
-        bracket.last_ltp = 108.0
+    manager.submit_exit_order(
+        symbol="NFO:TEST",
+        qty=10,
+        reason="HARD_SL_BREACH",
+        bracket_id="entry-1",
+        preferred_order_type="LIMIT",
+    )
 
-        manager._execute_exit_order(
-            bracket=bracket,
-            qty=10,
-            exit_side="SELL",
-            reason="TP Hit",
-            is_partial=False,
-            exit_type="FINAL_TP",
-        )
+    kwargs = order_manager.place_order.call_args.kwargs
+    assert kwargs["order_type"] == "MARKET"
+    assert "price" not in kwargs
 
-        kwargs = order_manager.place_order.call_args.kwargs
-        assert kwargs["order_type"] == "LIMIT"
-        assert kwargs["price"] > 0
-    except Exception as e:
-        logger.error("Failure in test_exit_order_type_uses_limit_for_tp: %s", e)
-        raise
+
+def test_exit_order_type_keeps_limit_for_take_profit(monkeypatch) -> None:
+    manager, order_manager = _manager_with_bracket(monkeypatch)
+
+    manager.submit_exit_order(
+        symbol="NFO:TEST",
+        qty=10,
+        reason="HARD_TP_BREACH",
+        bracket_id="entry-1",
+        preferred_order_type="LIMIT",
+    )
+
+    kwargs = order_manager.place_order.call_args.kwargs
+    assert kwargs["order_type"] == "LIMIT"
+    assert kwargs["price"] > 0


### PR DESCRIPTION
### Motivation

- A slots/dataclass regression caused AttributeError when legacy contexts lacked active-selection runtime fields, which crashed live basket build and hydration tracking (LIVE_BASKET_BUILD_FAILED / HYDRATION_TRACKING_FAILED). 
- Ensure runtime code defensively initializes optional BotContext fields so older/serialized contexts do not crash the startup/readiness paths. 
- Improve exit safety and open-position tick prioritization by wiring BracketManager hooks and enforcing protective exit pricing modes.

### Description

- Declared and initialized active-selection runtime fields on `BotContext`: `_active_selection_sync_log_key`, `_active_selection_drift_log_key`, `last_active_selection_synced_at`, `last_active_selection_drift_at`, and `_bot_context_runtime_fields_patch_logged` (file: `src/nifty_scalper_bot/core/app.py`).
- Added `ensure_bot_context_runtime_fields(ctx)` to repair known optional runtime fields on legacy/minimal contexts and log `BOT_CONTEXT_RUNTIME_FIELDS_INITIALIZED` once; added `_log_bot_context_attribute_missing` for AttributeError diagnostics, and invoked the initializer early from active-selection sync, hydration mapping, readiness recompute, and basket commit (file: `src/nifty_scalper_bot/core/app.py`).
- Wired open-position tick priority: `BracketManager` gained `attach_open_position_priority_hooks(on_position_open, on_position_closed)` and calls `_notify_open_position_priority("open"/"close", symbol)` on entry fill and bracket close/unregister; `initialize_components` attaches these hooks to MDM `add_open_position_symbol` / `remove_open_position_symbol` when available (files: `src/nifty_scalper_bot/execution/bracket_manager.py`, `src/nifty_scalper_bot/core/app.py`).
- Removed legacy direct exit routine `_execute_exit_order` from `BracketManager` to ensure all exits follow the controlled submit/reconcile lifecycle, and updated tests accordingly (file: `src/nifty_scalper_bot/execution/bracket_manager.py`).
- Implemented protective exit pricing decision: introduced `EXIT_PROTECTIVE_ORDER_MODE` (default `MARKET`) and optional `AGGRESSIVE_LIMIT` that builds a marketable limit from bid/ask/LTP with tick/pct buffers and fallback to MARKET when configured (`EXIT_MARKETABLE_LIMIT_SLIPPAGE_TICKS`, `EXIT_MARKETABLE_LIMIT_MAX_SLIPPAGE_PCT`, `EXIT_FALLBACK_TO_MARKET_ON_QUOTE_MISSING`); added `EXIT_ORDER_PRICING_DECISION` logging (file: `src/nifty_scalper_bot/execution/bracket_manager.py`).
- Tests added/updated: regression tests for BotContext runtime-field repair and active-selection sync, BracketManager open-position priority hooks, protective exit pricing behavior and removal of legacy `_execute_exit_order`, and updated exit-order-type tests to use `submit_exit_order` lifecycle (files: `tests/core/test_botcontext_active_selection_runtime_fields.py`, `tests/execution/test_bracket_open_position_priority_and_protective_exit.py`, `tests/execution/test_exit_order_type.py`).

### Testing

- Ran `python -m compileall -q src` and the code compiles successfully.
- Ran focused regression tests: `PYTHONPATH=src pytest -q tests/core/test_botcontext_active_selection_runtime_fields.py tests/execution/test_bracket_open_position_priority_and_protective_exit.py tests/execution/test_exit_order_type.py` and they passed.
- Ran broader test sets `PYTHONPATH=src pytest -q tests/core tests/strategies tests/execution tests/data` and full `PYTHONPATH=src pytest -q`; results: full test suite passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a28e80f96fc8324b36371283447f18b)