### PR TITLE
readiness-diagnostics: add BotContext runtime field schema

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -79,29 +79,40 @@ def _basket_attr(basket: Mapping[str, object] | object | None, key: str, default
 
 
 
+BOT_CONTEXT_RUNTIME_FIELD_DEFAULTS: dict[str, Any] = {
+    "hydration_status_by_symbol": dict,
+    "last_hydration_status_at": None,
+    "_active_selection_sync_log_key": None,
+    "_active_selection_drift_log_key": None,
+    "last_active_selection_synced_at": None,
+    "last_active_selection_drift_at": None,
+    "_post_market_basket_skip_log_key": None,
+    "last_post_market_basket_skip_log_at": None,
+    "_deferred_basket_hydration_log_key": None,
+    "last_deferred_basket_hydration_log_at": None,
+    "_live_basket_build_log_key": None,
+    "last_live_basket_build_log_at": None,
+    "_hydration_tracking_log_key": None,
+    "last_hydration_tracking_log_at": None,
+    "_runtime_readiness_log_key": None,
+    "last_runtime_readiness_log_at": None,
+    "_bot_context_runtime_fields_patch_logged": False,
+}
+
+
 def ensure_bot_context_runtime_fields(ctx: Any) -> None:
-    """Initialize optional BotContext runtime fields that may be absent on legacy contexts."""
-    defaults: dict[str, Any] = {
-        "hydration_status_by_symbol": dict,
-        "last_hydration_status_at": None,
-        "_active_selection_sync_log_key": None,
-        "_active_selection_drift_log_key": None,
-        "last_active_selection_synced_at": None,
-        "last_active_selection_drift_at": None,
-        "_bot_context_runtime_fields_patch_logged": False,
-    }
+    """Initialize declared BotContext runtime scratchpad fields on legacy contexts."""
     missing: list[str] = []
-    for name, default in defaults.items():
+    for name, default in BOT_CONTEXT_RUNTIME_FIELD_DEFAULTS.items():
         try:
             getattr(ctx, name)
             continue
         except AttributeError:
-            missing.append(name)
+            pass
         value = default() if callable(default) else default
         try:
             setattr(ctx, name, value)
         except AttributeError:
-            # Unknown/minimal slotted contexts cannot be repaired safely here.
             LOGGER.error(
                 "BOT_CONTEXT_ATTRIBUTE_MISSING attribute=%s component=runtime_field_initializer repairable=False",
                 name,
@@ -113,24 +124,17 @@ def ensure_bot_context_runtime_fields(ctx: Any) -> None:
                 },
             )
             raise
-    if missing:
-        try:
-            already_logged = bool(getattr(ctx, "_bot_context_runtime_fields_patch_logged", False))
-            if not already_logged:
-                LOGGER.warning(
-                    "BOT_CONTEXT_RUNTIME_FIELDS_INITIALIZED missing=%s",
-                    missing,
-                    extra={
-                        "event": "BOT_CONTEXT_RUNTIME_FIELDS_INITIALIZED",
-                        "missing": missing,
-                    },
-                )
-                try:
-                    setattr(ctx, "_bot_context_runtime_fields_patch_logged", True)
-                except AttributeError:
-                    pass
-        except AttributeError:
-            pass
+        missing.append(name)
+    if missing and not bool(getattr(ctx, "_bot_context_runtime_fields_patch_logged", False)):
+        LOGGER.warning(
+            "BOT_CONTEXT_RUNTIME_FIELDS_INITIALIZED missing=%s",
+            missing,
+            extra={
+                "event": "BOT_CONTEXT_RUNTIME_FIELDS_INITIALIZED",
+                "missing": missing,
+            },
+        )
+        setattr(ctx, "_bot_context_runtime_fields_patch_logged", True)
 
 
 def _log_bot_context_attribute_missing(exc: AttributeError, *, component: str) -> None:
@@ -195,6 +199,7 @@ def _sync_active_selection_from_basket(ctx: Any, selection: ActiveContractSelect
 
 
 def _should_skip_post_market_basket_refresh(ctx: Any, *, force: bool = False) -> tuple[bool, float]:
+    ensure_bot_context_runtime_fields(ctx)
     if force or not post_market_quiet_mode_enabled():
         return False, 0.0
     mode = get_runtime_market_mode()
@@ -211,7 +216,8 @@ def _should_skip_post_market_basket_refresh(ctx: Any, *, force: bool = False) ->
         return False, 0.0
     key = (mode, int(remaining // 60))
     if getattr(ctx, "_post_market_basket_skip_log_key", None) != key:
-        ctx._post_market_basket_skip_log_key = key
+        setattr(ctx, "_post_market_basket_skip_log_key", key)
+        setattr(ctx, "last_post_market_basket_skip_log_at", time_module.time())
         LOGGER.info(
             "ACTIVE_BASKET_REFRESH_SKIPPED reason=post_market_quiet_mode next_refresh_in_s=%d",
             int(remaining),
@@ -2583,6 +2589,16 @@ class BotContext:
     _active_selection_drift_log_key: object | None = None
     last_active_selection_synced_at: float | None = None
     last_active_selection_drift_at: float | None = None
+    _post_market_basket_skip_log_key: object | None = None
+    last_post_market_basket_skip_log_at: float | None = None
+    _deferred_basket_hydration_log_key: object | None = None
+    last_deferred_basket_hydration_log_at: float | None = None
+    _live_basket_build_log_key: object | None = None
+    last_live_basket_build_log_at: float | None = None
+    _hydration_tracking_log_key: object | None = None
+    last_hydration_tracking_log_at: float | None = None
+    _runtime_readiness_log_key: object | None = None
+    last_runtime_readiness_log_at: float | None = None
     _bot_context_runtime_fields_patch_logged: bool = False
     message_bus_tick_subscribed: bool = False
     datahub_runner_subscriptions: set[str] = field(default_factory=set)
@@ -5844,6 +5860,7 @@ def initialize_components(settings: Settings | None = None) -> BotContext:
         risk_manager_data_hub_attached=risk_manager_data_hub_attached,
         bracket_manager_attached=bracket_manager_attached,
     )
+    ensure_bot_context_runtime_fields(ctx)
 
     # Wire InstrumentManager to MDM and UnifiedManager for symbol/token resolution
     if ctx.instrument_manager is not None:
@@ -8679,6 +8696,7 @@ async def _deferred_basket_hydration_retry(
 ) -> None:
     """Retry startup basket hydration until fresh WS spot arrives. Args: ctx/mode. Returns: none. Raises: none."""
 
+    ensure_bot_context_runtime_fields(ctx)
     if max_attempts is None:
         max_attempts = int(os.getenv("DEFERRED_BASKET_MAX_ATTEMPTS", "160") or "160")
     policy = MarketDataPolicy.from_env()
@@ -8793,6 +8811,7 @@ async def _build_and_hydrate_live_basket_from_spot(
 ) -> dict[str, Any]:
     """Build/register/hydrate live basket from a trusted spot. Args: ctx/spot/mode. Returns: basket. Raises: RuntimeError."""
 
+    ensure_bot_context_runtime_fields(ctx)
     del configured_mode
     lock = _get_basket_build_lock(ctx)
     if lock.locked():
@@ -8958,6 +8977,7 @@ def _get_basket_build_lock(ctx: BotContext) -> asyncio.Lock:
 def _schedule_deferred_basket_retry(ctx: BotContext, *, configured_mode: str, reason: str = "market_closed_or_spot_not_ready", spot_ltp: float | None = None) -> None:
     """Schedule one deferred basket retry task. Args: ctx/mode. Returns: none. Raises: none."""
 
+    ensure_bot_context_runtime_fields(ctx)
     ctx.live_orders_armed = False
     ctx.trading_ready = False
     ctx.readiness_mode = "DATA_WARMUP"
@@ -9019,6 +9039,7 @@ def _resolve_quote_capability(ctx: BotContext) -> dict[str, Any]:
 
 async def startup_sequence(ctx: BotContext) -> None:
     """Execute startup sequence with Smart Hydration and Option-Only Trading."""
+    ensure_bot_context_runtime_fields(ctx)
     policy = MarketDataPolicy.from_env()
     _set_startup_phase(ctx, "create_context")
     configured_mode = str(os.getenv("EXECUTION_MODE", "SHADOW")).strip().upper()
@@ -11099,6 +11120,7 @@ async def startup_sequence(ctx: BotContext) -> None:
                 )
                 startup_trade_ready = True
             else:
+                ensure_bot_context_runtime_fields(ctx)
                 if isinstance(e, AttributeError):
                     _log_bot_context_attribute_missing(e, component="hydration_tracking")
                 norm_basket = normalize_active_basket_schema(dict(getattr(ctx, "active_trading_universe", {}) or {}))

--- a/tests/core/test_botcontext_active_selection_runtime_fields.py
+++ b/tests/core/test_botcontext_active_selection_runtime_fields.py
@@ -1,11 +1,17 @@
 from __future__ import annotations
 
+import dataclasses
 import logging
+import re
+from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+
+from nifty_scalper_bot.config.settings import Settings
 from nifty_scalper_bot.core import app
 from nifty_scalper_bot.core.active_basket import ActiveContractSelection
-from nifty_scalper_bot.core.app import BotContext
+from nifty_scalper_bot.core.app import AppConfig, BOT_CONTEXT_RUNTIME_FIELD_DEFAULTS, BotContext, RateLimiter
 
 
 def _selection(ce: str = "NFO:NIFTY2661623350CE", pe: str = "NFO:NIFTY2661623350PE", version: str = "v1") -> ActiveContractSelection:
@@ -77,3 +83,117 @@ def test_hydration_status_map_repairs_missing_runtime_fields(monkeypatch) -> Non
 
     assert set(statuses) == {"NSE:NIFTY", "NFO:NIFTY2661623350CE", "NFO:NIFTY2661623350PE"}
     assert ctx.last_hydration_status_at is not None
+
+
+def _minimal_bot_context() -> BotContext:
+    return BotContext(
+        settings=Settings(),
+        config=AppConfig(),
+        rate_limiter=RateLimiter(),
+        broker_client=None,
+        websocket_client=None,
+        websocket_manager=None,
+        streamer=None,
+        stream_supervisor=None,
+        polling_fallback_streamer=None,
+        message_bus=None,
+    )
+
+
+def test_botcontext_runtime_fields_declared_or_ensured() -> None:
+    app_text = Path(app.__file__).read_text(encoding="utf-8")
+    patterns = [
+        r"ctx\.(_[A-Za-z0-9_]*log_key)",
+        r"ctx\.(last_[A-Za-z0-9_]*_at)",
+        r"getattr\(ctx, ['\"](_[A-Za-z0-9_]*log_key)['\"]",
+        r"getattr\(ctx, ['\"](last_[A-Za-z0-9_]*_at)['\"]",
+        r"setattr\(ctx, ['\"](_[A-Za-z0-9_]*log_key)['\"]",
+        r"setattr\(ctx, ['\"](last_[A-Za-z0-9_]*_at)['\"]",
+    ]
+    extracted = set()
+    for pattern in patterns:
+        extracted.update(re.findall(pattern, app_text))
+
+    declared = {field.name for field in dataclasses.fields(BotContext)}
+    ensured = set(BOT_CONTEXT_RUNTIME_FIELD_DEFAULTS)
+    missing = sorted(extracted - declared - ensured)
+
+    assert not missing, (
+        "BotContext runtime fields must be declared on BotContext or listed in "
+        f"BOT_CONTEXT_RUNTIME_FIELD_DEFAULTS: {missing}"
+    )
+
+
+def test_botcontext_has_post_market_basket_skip_fields() -> None:
+    ctx = _minimal_bot_context()
+
+    assert hasattr(ctx, "_post_market_basket_skip_log_key")
+    assert ctx._post_market_basket_skip_log_key is None
+    assert hasattr(ctx, "last_post_market_basket_skip_log_at")
+    assert ctx.last_post_market_basket_skip_log_at is None
+
+
+def test_ensure_bot_context_runtime_fields_adds_post_market_key_to_legacy_context() -> None:
+    ctx = SimpleNamespace()
+
+    app.ensure_bot_context_runtime_fields(ctx)
+
+    assert hasattr(ctx, "_post_market_basket_skip_log_key")
+    assert ctx._post_market_basket_skip_log_key is None
+    assert hasattr(ctx, "last_post_market_basket_skip_log_at")
+    assert ctx.last_post_market_basket_skip_log_at is None
+
+
+@pytest.mark.asyncio
+async def test_deferred_basket_hydration_no_attribute_error_for_post_market_skip_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ctx = SimpleNamespace(
+        trading_ready=False,
+        live_orders_armed=False,
+        selected_ce=None,
+        active_contract_basket={"selected_ce": "NFO:NIFTY2661623350CE"},
+        active_trading_universe={"selected_ce": "NFO:NIFTY2661623350CE"},
+        basket_build_last_completed_mono=app.time_module.monotonic(),
+        basket_build_lock=None,
+        basket_build_in_progress=False,
+        basket_build_last_started_mono=0.0,
+        basket_build_last_error=None,
+    )
+
+    async def _spot_ready(*args, **kwargs) -> float:
+        return 23500.0
+
+    monkeypatch.setattr(app, "post_market_quiet_mode_enabled", lambda: True)
+    monkeypatch.setattr(app, "get_runtime_market_mode", lambda: "POST_MARKET")
+    monkeypatch.setattr(app, "post_market_basket_refresh_seconds", lambda: 3600.0)
+    monkeypatch.setattr(app, "_wait_for_live_spot_or_raise", _spot_ready)
+
+    await app._deferred_basket_hydration_retry(
+        ctx,
+        configured_mode="LIVE",
+        max_attempts=1,
+        delay_seconds=0,
+    )
+
+    assert hasattr(ctx, "_post_market_basket_skip_log_key")
+    assert ctx._post_market_basket_skip_log_key is not None
+
+
+def test_post_market_basket_skip_path_no_attribute_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ctx = SimpleNamespace(
+        active_contract_basket={"selected_ce": "NFO:NIFTY2661623350CE"},
+        basket_build_last_completed_mono=app.time_module.monotonic(),
+    )
+    monkeypatch.setattr(app, "post_market_quiet_mode_enabled", lambda: True)
+    monkeypatch.setattr(app, "get_runtime_market_mode", lambda: "POST_MARKET")
+    monkeypatch.setattr(app, "post_market_basket_refresh_seconds", lambda: 3600.0)
+
+    skip, remaining = app._should_skip_post_market_basket_refresh(ctx)
+
+    assert skip is True
+    assert remaining > 0
+    assert ctx._post_market_basket_skip_log_key is not None
+    assert ctx.last_post_market_basket_skip_log_at is not None


### PR DESCRIPTION
### Motivation
- Prevent AttributeError crashes caused by ad-hoc runtime fields being accessed on slotted `BotContext` (e.g. `_post_market_basket_skip_log_key`) during deferred hydration and readiness flows. 
- Provide a single authoritative schema for BotContext runtime scratchpad/log-key/debounce fields so future runtime attributes are declared or repaired consistently.
- Make repairs explicit and testable rather than silently patching or masking slotted-context failures.

### Description
- Added a central schema constant `BOT_CONTEXT_RUNTIME_FIELD_DEFAULTS` containing the set of runtime fields and defaults (e.g. `_post_market_basket_skip_log_key`, `last_post_market_basket_skip_log_at`, hydration/log keys and timestamps). 
- Declared the corresponding runtime fields on the slotted `BotContext` dataclass so these attributes exist for constructed contexts. 
- Rewrote `ensure_bot_context_runtime_fields(ctx)` to iterate the central schema, initialize missing fields on legacy/simple contexts, log the repair once, and re-raise when a slotted context cannot be patched. 
- Ensured `ensure_bot_context_runtime_fields(ctx)` is invoked at key entry points (context construction/startup, deferred basket retry, live-basket build, schedule retry, readiness/hydration tracking) and changed direct writes to guarded `setattr()`/`getattr()` uses where appropriate. 
- Added static/regression tests and a file-level audit that fails when `ctx.*_log_key` / `last_*_at` uses are neither declared on `BotContext` nor listed in the central defaults.

### Testing
- Ran compilation: `python -m compileall -q src` and it completed successfully. 
- Ran focused tests: `PYTHONPATH=src pytest -q tests/core/test_botcontext_active_selection_runtime_fields.py` and they passed (regressions and audit checks). 
- Ran grouped suites: `PYTHONPATH=src pytest -q tests/core tests/strategies tests/execution tests/data` which completed successfully. 
- Ran full test suite: `PYTHONPATH=src pytest -q` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a296b6b0ef483249c7000fde1aac7c4)