### PR TITLE
Add round-trip transaction cost gate to candidate selection

### DIFF
--- a/src/nifty_scalper_bot/risk/cost_model.py
+++ b/src/nifty_scalper_bot/risk/cost_model.py
@@ -1,0 +1,106 @@
+"""Round-trip transaction cost model for NSE option buy trades (Zerodha).
+
+Rates current as of June 2026 (post Budget 2026-27, effective 1 Apr 2026):
+- Brokerage: flat Rs 20 per executed order (buy + sell = Rs 40 round trip)
+- STT: 0.15% of premium, sell side only
+- NSE exchange transaction charge: 0.035% of premium, both sides
+- SEBI charges: Rs 10 per crore (0.0001%), both sides
+- GST: 18% on (brokerage + exchange txn charge + SEBI charges)
+- Stamp duty: 0.003% of premium, buy side only
+
+All rates are env-overridable so future Budget changes need no code edit:
+COST_BROKERAGE_PER_ORDER, COST_STT_SELL_PCT, COST_EXCH_TXN_PCT,
+COST_SEBI_PCT, COST_GST_PCT, COST_STAMP_BUY_PCT, MIN_EDGE_MULTIPLE.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+from nifty_scalper_bot.config.env_utils import parse_float_env
+
+
+@dataclass(slots=True)
+class CostBreakdown:
+    """Args: cost components in rupees. Returns: breakdown object. Raises: none."""
+
+    brokerage: float
+    stt: float
+    exchange_txn: float
+    sebi: float
+    gst: float
+    stamp_duty: float
+    half_spread_slippage: float
+    total: float
+    cost_per_unit: float  # total cost expressed in option-premium points per unit
+
+
+def _rate(name: str, default: float) -> float:
+    return parse_float_env(os.getenv(name), default)
+
+
+def estimate_round_trip_cost(
+    *,
+    entry_price: float,
+    exit_price: float,
+    quantity: int,
+    half_spread: float = 0.0,
+) -> CostBreakdown:
+    """Args: entry/exit premium per unit, total quantity, half-spread per unit.
+    Returns: full round-trip cost breakdown in rupees. Raises: none.
+
+    quantity is total units (lots * lot_size). half_spread models the
+    bid/ask cost paid once on each side when crossing the spread.
+    """
+    qty = max(1, int(quantity))
+    buy_value = max(0.0, float(entry_price)) * qty
+    sell_value = max(0.0, float(exit_price)) * qty
+
+    brokerage = 2.0 * _rate("COST_BROKERAGE_PER_ORDER", 20.0)
+    stt = sell_value * _rate("COST_STT_SELL_PCT", 0.0015)
+    exchange_txn = (buy_value + sell_value) * _rate("COST_EXCH_TXN_PCT", 0.00035)
+    sebi = (buy_value + sell_value) * _rate("COST_SEBI_PCT", 0.000001)
+    gst = (brokerage + exchange_txn + sebi) * _rate("COST_GST_PCT", 0.18)
+    stamp_duty = buy_value * _rate("COST_STAMP_BUY_PCT", 0.00003)
+    slippage = 2.0 * max(0.0, float(half_spread)) * qty
+
+    total = brokerage + stt + exchange_txn + sebi + gst + stamp_duty + slippage
+    return CostBreakdown(
+        brokerage=brokerage,
+        stt=stt,
+        exchange_txn=exchange_txn,
+        sebi=sebi,
+        gst=gst,
+        stamp_duty=stamp_duty,
+        half_spread_slippage=slippage,
+        total=total,
+        cost_per_unit=total / qty,
+    )
+
+
+def passes_cost_edge_gate(
+    *,
+    entry_price: float,
+    target_price: float,
+    quantity: int,
+    half_spread: float = 0.0,
+) -> tuple[bool, float, CostBreakdown]:
+    """Args: entry, target premium, quantity, half-spread per unit.
+    Returns: (allowed, edge_multiple, breakdown). Raises: none.
+
+    Allowed when expected gross profit at target covers the round-trip
+    cost by at least MIN_EDGE_MULTIPLE (default 2.0). Costs are estimated
+    conservatively at the target exit (highest premium => highest charges).
+    """
+    qty = max(1, int(quantity))
+    breakdown = estimate_round_trip_cost(
+        entry_price=entry_price,
+        exit_price=target_price,
+        quantity=qty,
+        half_spread=half_spread,
+    )
+    gross_profit = max(0.0, (float(target_price) - float(entry_price))) * qty
+    min_multiple = _rate("MIN_EDGE_MULTIPLE", 2.0)
+    edge_multiple = (gross_profit / breakdown.total) if breakdown.total > 0 else 0.0
+    return edge_multiple >= min_multiple, edge_multiple, breakdown

--- a/src/nifty_scalper_bot/strategies/trade_selector.py
+++ b/src/nifty_scalper_bot/strategies/trade_selector.py
@@ -7,6 +7,8 @@ import logging
 import os
 from typing import Any
 
+from nifty_scalper_bot.config.env_utils import parse_int_env
+from nifty_scalper_bot.risk.cost_model import passes_cost_edge_gate
 from nifty_scalper_bot.utils.logging import get_logger, log_once_or_throttled
 
 LOGGER = get_logger(__name__)
@@ -88,7 +90,7 @@ class TradeCandidateSelector:
             min_ticks = int(self.require_real_ticks_last_60s)
         allow_ltp_only = os.getenv('ALLOW_LTP_ONLY_CANDIDATE', 'false').lower() in {'1', 'true', 'yes', 'on'}
         ranked: list[TradeCandidate] = []
-        rejects = {'side_mismatch': 0, 'atm_distance': 0, 'missing_bid_ask': 0, 'premium_out_of_range': 0, 'spread_too_wide': 0, 'tick_stale': 0, 'insufficient_ticks': 0, 'invalid_rr': 0}
+        rejects = {'side_mismatch': 0, 'atm_distance': 0, 'missing_bid_ask': 0, 'premium_out_of_range': 0, 'spread_too_wide': 0, 'tick_stale': 0, 'insufficient_ticks': 0, 'invalid_rr': 0, 'cost_edge_insufficient': 0}
         ltp_only_used = 0
         for s in snapshots:
             side = str(s.get('side') or s.get('option_type') or '').upper()
@@ -185,6 +187,14 @@ class TradeCandidateSelector:
                 rejects['invalid_rr'] += 1
                 self._log_reject("invalid_rr", symbol, throttle_key_parts=("invalid_rr", symbol), entry=entry, stop_loss=sl, target=target, rr=rr, min_rr=1.5)
                 continue
+            half_spread = (((ask or 0.0) - (bid or 0.0)) / 2.0) if has_bid_ask else entry * 0.003
+            lot_size = parse_int_env(os.getenv('NIFTY_LOT_SIZE'), 65)
+            cost_ok, edge_multiple, cost = passes_cost_edge_gate(entry_price=entry, target_price=target, quantity=lot_size, half_spread=max(0.0, half_spread))
+            if not cost_ok:
+                rejects['cost_edge_insufficient'] += 1
+                self._log_reject("cost_edge_insufficient", symbol, throttle_key_parts=("cost_edge_insufficient", symbol), entry=entry, target=target, edge_multiple=round(edge_multiple, 2), round_trip_cost=round(cost.total, 2), cost_per_unit=round(cost.cost_per_unit, 3))
+                continue
+            reasons.append(f'cost_edge_{edge_multiple:.1f}x')
             liquidity = 5.0 if spread_pct is None else max(0.0, 10.0 - spread_pct * 100.0)
             micro = min(10.0, real_ticks * 3.0)
             score = 6.0 + liquidity * 0.2 + micro * 0.2 - atm_distance * 0.5 - score_penalty

--- a/tests/risk/test_cost_model.py
+++ b/tests/risk/test_cost_model.py
@@ -1,0 +1,40 @@
+"""Tests for the round-trip transaction cost model."""
+
+from __future__ import annotations
+
+from nifty_scalper_bot.risk.cost_model import (
+    estimate_round_trip_cost,
+    passes_cost_edge_gate,
+)
+
+
+def test_cost_breakdown_components_positive() -> None:
+    c = estimate_round_trip_cost(
+        entry_price=120, exit_price=135, quantity=65, half_spread=0.5
+    )
+    assert c.brokerage == 40.0
+    assert c.stt > 0 and c.exchange_txn > 0 and c.gst > 0
+    assert c.total > 60.0
+    assert abs(c.cost_per_unit - c.total / 65) < 1e-9
+
+
+def test_gate_blocks_thin_target() -> None:
+    ok, edge, _ = passes_cost_edge_gate(
+        entry_price=120, target_price=122, quantity=65, half_spread=0.5
+    )
+    assert not ok and edge < 2.0
+
+
+def test_gate_allows_wide_target() -> None:
+    ok, edge, _ = passes_cost_edge_gate(
+        entry_price=120, target_price=140, quantity=65, half_spread=0.5
+    )
+    assert ok and edge >= 2.0
+
+
+def test_env_override_min_edge(monkeypatch) -> None:
+    monkeypatch.setenv("MIN_EDGE_MULTIPLE", "1.0")
+    ok, _, _ = passes_cost_edge_gate(
+        entry_price=120, target_price=124, quantity=65, half_spread=0.3
+    )
+    assert ok


### PR DESCRIPTION
## What
Blocks any option-buy candidate whose profit target does not cover the full real-world round-trip cost by at least 2x (MIN_EDGE_MULTIPLE, env-tunable).

## Cost model (rates current June 2026, all env-overridable)
- Brokerage Rs 20/order flat (Rs 40 round trip)
- STT 0.15% of premium, sell side (Budget 2026-27, effective 1 Apr 2026)
- NSE exchange txn charge 0.035% both sides
- SEBI Rs 10/crore, GST 18% on broker+exchange+SEBI, stamp duty 0.003% buy side
- Bid-ask half-spread paid on each side

## Why
On a typical 1-lot ATM scalp (premium 120, Rs 1 spread) the round trip costs ~Rs 132 (~2 premium points). Thin scalp targets were silently net-negative. A 3-pt target is now rejected (1.49x edge); 15-pt passes (7.36x).

## Validation
574 tests passed (tests/risk + tests/strategies, incl. all live-path guard tests), 0 failures. Rejections logged as cost_edge_insufficient with rupee cost and edge multiple.