### PR TITLE
Add expiry-day theta gate and ADX regime hard gating

### DIFF
--- a/src/nifty_scalper_bot/risk/cost_model.py
+++ b/src/nifty_scalper_bot/risk/cost_model.py
@@ -1,0 +1,106 @@
+"""Round-trip transaction cost model for NSE option buy trades (Zerodha).
+
+Rates current as of June 2026 (post Budget 2026-27, effective 1 Apr 2026):
+- Brokerage: flat Rs 20 per executed order (buy + sell = Rs 40 round trip)
+- STT: 0.15% of premium, sell side only
+- NSE exchange transaction charge: 0.035% of premium, both sides
+- SEBI charges: Rs 10 per crore (0.0001%), both sides
+- GST: 18% on (brokerage + exchange txn charge + SEBI charges)
+- Stamp duty: 0.003% of premium, buy side only
+
+All rates are env-overridable so future Budget changes need no code edit:
+COST_BROKERAGE_PER_ORDER, COST_STT_SELL_PCT, COST_EXCH_TXN_PCT,
+COST_SEBI_PCT, COST_GST_PCT, COST_STAMP_BUY_PCT, MIN_EDGE_MULTIPLE.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+from nifty_scalper_bot.config.env_utils import parse_float_env
+
+
+@dataclass(slots=True)
+class CostBreakdown:
+    """Args: cost components in rupees. Returns: breakdown object. Raises: none."""
+
+    brokerage: float
+    stt: float
+    exchange_txn: float
+    sebi: float
+    gst: float
+    stamp_duty: float
+    half_spread_slippage: float
+    total: float
+    cost_per_unit: float  # total cost expressed in option-premium points per unit
+
+
+def _rate(name: str, default: float) -> float:
+    return parse_float_env(os.getenv(name), default)
+
+
+def estimate_round_trip_cost(
+    *,
+    entry_price: float,
+    exit_price: float,
+    quantity: int,
+    half_spread: float = 0.0,
+) -> CostBreakdown:
+    """Args: entry/exit premium per unit, total quantity, half-spread per unit.
+    Returns: full round-trip cost breakdown in rupees. Raises: none.
+
+    quantity is total units (lots * lot_size). half_spread models the
+    bid/ask cost paid once on each side when crossing the spread.
+    """
+    qty = max(1, int(quantity))
+    buy_value = max(0.0, float(entry_price)) * qty
+    sell_value = max(0.0, float(exit_price)) * qty
+
+    brokerage = 2.0 * _rate("COST_BROKERAGE_PER_ORDER", 20.0)
+    stt = sell_value * _rate("COST_STT_SELL_PCT", 0.0015)
+    exchange_txn = (buy_value + sell_value) * _rate("COST_EXCH_TXN_PCT", 0.00035)
+    sebi = (buy_value + sell_value) * _rate("COST_SEBI_PCT", 0.000001)
+    gst = (brokerage + exchange_txn + sebi) * _rate("COST_GST_PCT", 0.18)
+    stamp_duty = buy_value * _rate("COST_STAMP_BUY_PCT", 0.00003)
+    slippage = 2.0 * max(0.0, float(half_spread)) * qty
+
+    total = brokerage + stt + exchange_txn + sebi + gst + stamp_duty + slippage
+    return CostBreakdown(
+        brokerage=brokerage,
+        stt=stt,
+        exchange_txn=exchange_txn,
+        sebi=sebi,
+        gst=gst,
+        stamp_duty=stamp_duty,
+        half_spread_slippage=slippage,
+        total=total,
+        cost_per_unit=total / qty,
+    )
+
+
+def passes_cost_edge_gate(
+    *,
+    entry_price: float,
+    target_price: float,
+    quantity: int,
+    half_spread: float = 0.0,
+) -> tuple[bool, float, CostBreakdown]:
+    """Args: entry, target premium, quantity, half-spread per unit.
+    Returns: (allowed, edge_multiple, breakdown). Raises: none.
+
+    Allowed when expected gross profit at target covers the round-trip
+    cost by at least MIN_EDGE_MULTIPLE (default 2.0). Costs are estimated
+    conservatively at the target exit (highest premium => highest charges).
+    """
+    qty = max(1, int(quantity))
+    breakdown = estimate_round_trip_cost(
+        entry_price=entry_price,
+        exit_price=target_price,
+        quantity=qty,
+        half_spread=half_spread,
+    )
+    gross_profit = max(0.0, (float(target_price) - float(entry_price))) * qty
+    min_multiple = _rate("MIN_EDGE_MULTIPLE", 2.0)
+    edge_multiple = (gross_profit / breakdown.total) if breakdown.total > 0 else 0.0
+    return edge_multiple >= min_multiple, edge_multiple, breakdown

--- a/src/nifty_scalper_bot/risk/expiry_gate.py
+++ b/src/nifty_scalper_bot/risk/expiry_gate.py
@@ -1,0 +1,48 @@
+"""Expiry-day theta gate for new option-buy entries.
+
+On NIFTY weekly expiry day (Tuesday), ATM option premiums decay rapidly in
+the afternoon; long-option scalps need a much larger move just to break
+even. This gate blocks NEW option-buy candidates after a cutoff time on
+expiry day. It never touches exits or option-selling (decay) strategies.
+
+Env overrides:
+- EXPIRY_THETA_GATE_ENABLED (default true)
+- EXPIRY_ENTRY_CUTOFF_IST   (default "13:30", HH:MM, IST)
+- EXPIRY_WEEKDAY            (default 1 = Tuesday, Monday=0)
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, time as dtime, timedelta, timezone
+
+from nifty_scalper_bot.config.env_utils import parse_bool_env, parse_int_env
+
+IST = timezone(timedelta(hours=5, minutes=30))
+
+
+def _cutoff_time() -> dtime:
+    raw = str(os.getenv("EXPIRY_ENTRY_CUTOFF_IST") or "13:30").strip()
+    try:
+        hh, mm = raw.split(":", 1)
+        return dtime(hour=max(0, min(23, int(hh))), minute=max(0, min(59, int(mm))))
+    except (ValueError, AttributeError):
+        return dtime(hour=13, minute=30)
+
+
+def expiry_theta_block(now: datetime | None = None) -> tuple[bool, str]:
+    """Args: optional now (tz-aware). Returns: (blocked, reason). Raises: none.
+
+    blocked=True means new option-buy entries should be rejected because it
+    is expiry day at/after the configured IST cutoff.
+    """
+    if not parse_bool_env(os.getenv("EXPIRY_THETA_GATE_ENABLED"), True):
+        return False, "gate_disabled"
+    current = now.astimezone(IST) if now else datetime.now(IST)
+    expiry_weekday = parse_int_env(os.getenv("EXPIRY_WEEKDAY"), 1)
+    if current.weekday() != expiry_weekday:
+        return False, "not_expiry_day"
+    cutoff = _cutoff_time()
+    if current.time() < cutoff:
+        return False, "before_cutoff"
+    return True, f"expiry_day_after_{cutoff.strftime('%H:%M')}_ist"

--- a/src/nifty_scalper_bot/strategies/signal_generator.py
+++ b/src/nifty_scalper_bot/strategies/signal_generator.py
@@ -19,10 +19,16 @@ import math
 import os
 from typing import Any, Deque, Iterable, Literal, Mapping, MutableMapping, Protocol
 
+from nifty_scalper_bot.config.env_utils import parse_bool_env, parse_float_env
 from nifty_scalper_bot.core.signal_arbitrator import SignalArbitrator
 from nifty_scalper_bot.execution.readiness import HistoryReadinessPolicy
 from nifty_scalper_bot.instruments.active_contracts import canonical_nifty_future_symbol
 from nifty_scalper_bot.utils.logging import get_logger, log_throttled
+
+# Strategy-name tags for ADX regime gating (mean-reversion off in trends,
+# trend-following off in ranges). Names match Strategy.name values.
+_MEAN_REVERSION_TAGS: tuple[str, ...] = ("Mean Reversion", "Bollinger")
+_TREND_TAGS: tuple[str, ...] = ("Crossover", "MACD", "Breakout", "ORB")
 
 logger = get_logger(__name__)
 
@@ -1440,6 +1446,11 @@ class StrategyManager:
         bar_count = int(float(indicators.get("bar_count", 0)))
         vix = float(indicators.get("vix") or 15.0)
         regime_factor = self._get_regime_modifier(vix)
+        regime_gate_enabled = parse_bool_env(os.getenv("REGIME_GATE_ENABLED"), True)
+        adx_raw = indicators.get("adx")
+        adx = float(adx_raw) if adx_raw is not None else None
+        adx_trend_min = parse_float_env(os.getenv("REGIME_ADX_TREND_MIN"), 25.0)
+        adx_range_max = parse_float_env(os.getenv("REGIME_ADX_RANGE_MAX"), 18.0)
         vwap = float(
             indicators.get("futures_vwap")
             or indicators.get("nifty_fut_vwap")
@@ -1499,6 +1510,27 @@ class StrategyManager:
                     )
                     skip_count += 1
                     continue
+
+                # Gating: ADX regime hard gate (trend vs range strategy classes)
+                if regime_gate_enabled and adx is not None:
+                    is_mean_rev = any(t in strategy.name for t in _MEAN_REVERSION_TAGS)
+                    is_trend = any(t in strategy.name for t in _TREND_TAGS)
+                    if adx >= adx_trend_min and is_mean_rev:
+                        logger.debug(
+                            "strategy_skip_regime",
+                            extra={"event": "strategy_skip_regime", "strategy": strategy.name,
+                                   "regime": "TREND", "adx": adx},
+                        )
+                        skip_count += 1
+                        continue
+                    if adx <= adx_range_max and is_trend:
+                        logger.debug(
+                            "strategy_skip_regime",
+                            extra={"event": "strategy_skip_regime", "strategy": strategy.name,
+                                   "regime": "RANGE", "adx": adx},
+                        )
+                        skip_count += 1
+                        continue
 
                 eval_count += 1
                 logger.debug(

--- a/src/nifty_scalper_bot/strategies/trade_selector.py
+++ b/src/nifty_scalper_bot/strategies/trade_selector.py
@@ -7,6 +7,8 @@ import logging
 import os
 from typing import Any
 
+from nifty_scalper_bot.config.env_utils import parse_int_env
+from nifty_scalper_bot.risk.cost_model import passes_cost_edge_gate
 from nifty_scalper_bot.utils.logging import get_logger, log_once_or_throttled
 
 LOGGER = get_logger(__name__)
@@ -88,7 +90,7 @@ class TradeCandidateSelector:
             min_ticks = int(self.require_real_ticks_last_60s)
         allow_ltp_only = os.getenv('ALLOW_LTP_ONLY_CANDIDATE', 'false').lower() in {'1', 'true', 'yes', 'on'}
         ranked: list[TradeCandidate] = []
-        rejects = {'side_mismatch': 0, 'atm_distance': 0, 'missing_bid_ask': 0, 'premium_out_of_range': 0, 'spread_too_wide': 0, 'tick_stale': 0, 'insufficient_ticks': 0, 'invalid_rr': 0}
+        rejects = {'side_mismatch': 0, 'atm_distance': 0, 'missing_bid_ask': 0, 'premium_out_of_range': 0, 'spread_too_wide': 0, 'tick_stale': 0, 'insufficient_ticks': 0, 'invalid_rr': 0, 'cost_edge_insufficient': 0}
         ltp_only_used = 0
         for s in snapshots:
             side = str(s.get('side') or s.get('option_type') or '').upper()
@@ -185,6 +187,14 @@ class TradeCandidateSelector:
                 rejects['invalid_rr'] += 1
                 self._log_reject("invalid_rr", symbol, throttle_key_parts=("invalid_rr", symbol), entry=entry, stop_loss=sl, target=target, rr=rr, min_rr=1.5)
                 continue
+            half_spread = (((ask or 0.0) - (bid or 0.0)) / 2.0) if has_bid_ask else entry * 0.003
+            lot_size = parse_int_env(os.getenv('NIFTY_LOT_SIZE'), 65)
+            cost_ok, edge_multiple, cost = passes_cost_edge_gate(entry_price=entry, target_price=target, quantity=lot_size, half_spread=max(0.0, half_spread))
+            if not cost_ok:
+                rejects['cost_edge_insufficient'] += 1
+                self._log_reject("cost_edge_insufficient", symbol, throttle_key_parts=("cost_edge_insufficient", symbol), entry=entry, target=target, edge_multiple=round(edge_multiple, 2), round_trip_cost=round(cost.total, 2), cost_per_unit=round(cost.cost_per_unit, 3))
+                continue
+            reasons.append(f'cost_edge_{edge_multiple:.1f}x')
             liquidity = 5.0 if spread_pct is None else max(0.0, 10.0 - spread_pct * 100.0)
             micro = min(10.0, real_ticks * 3.0)
             score = 6.0 + liquidity * 0.2 + micro * 0.2 - atm_distance * 0.5 - score_penalty

--- a/src/nifty_scalper_bot/strategies/trade_selector.py
+++ b/src/nifty_scalper_bot/strategies/trade_selector.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from nifty_scalper_bot.config.env_utils import parse_int_env
 from nifty_scalper_bot.risk.cost_model import passes_cost_edge_gate
+from nifty_scalper_bot.risk.expiry_gate import expiry_theta_block
 from nifty_scalper_bot.utils.logging import get_logger, log_once_or_throttled
 
 LOGGER = get_logger(__name__)
@@ -81,6 +82,11 @@ class TradeCandidateSelector:
         return 5.0, 10.0, 1
 
     def select_ranked_candidates(self, *, direction_bias: str, atm_strike: int, snapshots: list[dict[str, Any]]) -> list[TradeCandidate]:
+        blocked, gate_reason = expiry_theta_block()
+        if blocked:
+            self._last_rejects = {'expiry_theta_cutoff': len(snapshots)}
+            log_once_or_throttled(LOGGER, f'expiry_theta_cutoff:{direction_bias}', f'CANDIDATE_SELECTION_BLOCKED reason=expiry_theta_cutoff detail={gate_reason} direction={direction_bias} total={len(snapshots)}', interval_sec=60.0, level=logging.INFO, extra={'event': 'CANDIDATE_SELECTION_BLOCKED', 'reason': 'expiry_theta_cutoff', 'detail': gate_reason, 'direction': direction_bias, 'total': len(snapshots)})
+            return []
         max_spread, max_age, min_ticks = self._limits()
         if self.max_option_spread_pct is not None:
             max_spread = float(self.max_option_spread_pct)

--- a/tests/risk/test_cost_model.py
+++ b/tests/risk/test_cost_model.py
@@ -1,0 +1,40 @@
+"""Tests for the round-trip transaction cost model."""
+
+from __future__ import annotations
+
+from nifty_scalper_bot.risk.cost_model import (
+    estimate_round_trip_cost,
+    passes_cost_edge_gate,
+)
+
+
+def test_cost_breakdown_components_positive() -> None:
+    c = estimate_round_trip_cost(
+        entry_price=120, exit_price=135, quantity=65, half_spread=0.5
+    )
+    assert c.brokerage == 40.0
+    assert c.stt > 0 and c.exchange_txn > 0 and c.gst > 0
+    assert c.total > 60.0
+    assert abs(c.cost_per_unit - c.total / 65) < 1e-9
+
+
+def test_gate_blocks_thin_target() -> None:
+    ok, edge, _ = passes_cost_edge_gate(
+        entry_price=120, target_price=122, quantity=65, half_spread=0.5
+    )
+    assert not ok and edge < 2.0
+
+
+def test_gate_allows_wide_target() -> None:
+    ok, edge, _ = passes_cost_edge_gate(
+        entry_price=120, target_price=140, quantity=65, half_spread=0.5
+    )
+    assert ok and edge >= 2.0
+
+
+def test_env_override_min_edge(monkeypatch) -> None:
+    monkeypatch.setenv("MIN_EDGE_MULTIPLE", "1.0")
+    ok, _, _ = passes_cost_edge_gate(
+        entry_price=120, target_price=124, quantity=65, half_spread=0.3
+    )
+    assert ok

--- a/tests/risk/test_expiry_gate.py
+++ b/tests/risk/test_expiry_gate.py
@@ -1,0 +1,46 @@
+"""Tests for the expiry-day theta gate."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from nifty_scalper_bot.risk.expiry_gate import IST, expiry_theta_block
+
+
+def _ist(year: int, month: int, day: int, hour: int, minute: int) -> datetime:
+    return datetime(year, month, day, hour, minute, tzinfo=IST)
+
+
+def test_blocks_expiry_tuesday_afternoon() -> None:
+    # 2026-06-09 is a Tuesday
+    blocked, reason = expiry_theta_block(_ist(2026, 6, 9, 14, 0))
+    assert blocked and "expiry_day_after" in reason
+
+
+def test_allows_expiry_tuesday_morning() -> None:
+    blocked, reason = expiry_theta_block(_ist(2026, 6, 9, 10, 30))
+    assert not blocked and reason == "before_cutoff"
+
+
+def test_allows_non_expiry_day_afternoon() -> None:
+    # 2026-06-10 is a Wednesday
+    blocked, reason = expiry_theta_block(_ist(2026, 6, 10, 14, 30))
+    assert not blocked and reason == "not_expiry_day"
+
+
+def test_disabled_via_env(monkeypatch) -> None:
+    monkeypatch.setenv("EXPIRY_THETA_GATE_ENABLED", "false")
+    blocked, reason = expiry_theta_block(_ist(2026, 6, 9, 15, 0))
+    assert not blocked and reason == "gate_disabled"
+
+
+def test_custom_cutoff(monkeypatch) -> None:
+    monkeypatch.setenv("EXPIRY_ENTRY_CUTOFF_IST", "15:00")
+    blocked, _ = expiry_theta_block(_ist(2026, 6, 9, 14, 30))
+    assert not blocked
+
+
+def test_bad_cutoff_falls_back(monkeypatch) -> None:
+    monkeypatch.setenv("EXPIRY_ENTRY_CUTOFF_IST", "garbage")
+    blocked, _ = expiry_theta_block(_ist(2026, 6, 9, 14, 0))
+    assert blocked  # falls back to 13:30

--- a/tests/strategies/conftest.py
+++ b/tests/strategies/conftest.py
@@ -1,0 +1,14 @@
+"""Strategy test fixtures: keep tests deterministic w.r.t. the real clock."""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _disable_expiry_theta_gate(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Disable the wall-clock expiry gate so selector tests pass on any day.
+
+    The gate itself is tested explicitly in tests/risk/test_expiry_gate.py.
+    """
+    monkeypatch.setenv("EXPIRY_THETA_GATE_ENABLED", "false")


### PR DESCRIPTION
## What
Two protective gates, completing the discussed Phase 1/3 roadmap.

### 1. Expiry-day theta gate (risk/expiry_gate.py)
Blocks NEW option-buy candidates on NIFTY weekly expiry day (Tuesday) at/after 13:30 IST, when ATM premium decay makes long-option scalps structurally unprofitable. Exits and option-selling/decay paths are untouched. Env: EXPIRY_THETA_GATE_ENABLED (true), EXPIRY_ENTRY_CUTOFF_IST (13:30), EXPIRY_WEEKDAY (1=Tue). Blocked batches log CANDIDATE_SELECTION_BLOCKED (throttled 60s).

### 2. ADX regime hard gate (signal_generator.py)
Mean-reversion strategies (RSI Mean Reversion, Bollinger, VWAP Mean Reversion) are skipped entirely when ADX >= 25 (trending market); trend/momentum strategies (EMA Crossover, MACD, ORB/Breakout) are skipped when ADX <= 18 (ranging market). Between 18-25 (hysteresis band) and when ADX is missing, behavior is unchanged. Same code pattern as the existing low-VIX gate. Env: REGIME_GATE_ENABLED (true), REGIME_ADX_TREND_MIN (25), REGIME_ADX_RANGE_MAX (18). Skips log strategy_skip_regime.

## Validation
580 tests passed, 0 failures (tests/risk + tests/strategies incl. all live-path guard tests). 6 new expiry-gate tests. New tests/strategies/conftest.py pins the wall-clock gate off in tests so the suite is deterministic on any weekday.