### PR TITLE
Add expiry-day theta gate and ADX regime hard gating

### DIFF
--- a/src/nifty_scalper_bot/risk/expiry_gate.py
+++ b/src/nifty_scalper_bot/risk/expiry_gate.py
@@ -1,0 +1,48 @@
+"""Expiry-day theta gate for new option-buy entries.
+
+On NIFTY weekly expiry day (Tuesday), ATM option premiums decay rapidly in
+the afternoon; long-option scalps need a much larger move just to break
+even. This gate blocks NEW option-buy candidates after a cutoff time on
+expiry day. It never touches exits or option-selling (decay) strategies.
+
+Env overrides:
+- EXPIRY_THETA_GATE_ENABLED (default true)
+- EXPIRY_ENTRY_CUTOFF_IST   (default "13:30", HH:MM, IST)
+- EXPIRY_WEEKDAY            (default 1 = Tuesday, Monday=0)
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, time as dtime, timedelta, timezone
+
+from nifty_scalper_bot.config.env_utils import parse_bool_env, parse_int_env
+
+IST = timezone(timedelta(hours=5, minutes=30))
+
+
+def _cutoff_time() -> dtime:
+    raw = str(os.getenv("EXPIRY_ENTRY_CUTOFF_IST") or "13:30").strip()
+    try:
+        hh, mm = raw.split(":", 1)
+        return dtime(hour=max(0, min(23, int(hh))), minute=max(0, min(59, int(mm))))
+    except (ValueError, AttributeError):
+        return dtime(hour=13, minute=30)
+
+
+def expiry_theta_block(now: datetime | None = None) -> tuple[bool, str]:
+    """Args: optional now (tz-aware). Returns: (blocked, reason). Raises: none.
+
+    blocked=True means new option-buy entries should be rejected because it
+    is expiry day at/after the configured IST cutoff.
+    """
+    if not parse_bool_env(os.getenv("EXPIRY_THETA_GATE_ENABLED"), True):
+        return False, "gate_disabled"
+    current = now.astimezone(IST) if now else datetime.now(IST)
+    expiry_weekday = parse_int_env(os.getenv("EXPIRY_WEEKDAY"), 1)
+    if current.weekday() != expiry_weekday:
+        return False, "not_expiry_day"
+    cutoff = _cutoff_time()
+    if current.time() < cutoff:
+        return False, "before_cutoff"
+    return True, f"expiry_day_after_{cutoff.strftime('%H:%M')}_ist"

--- a/src/nifty_scalper_bot/strategies/signal_generator.py
+++ b/src/nifty_scalper_bot/strategies/signal_generator.py
@@ -19,10 +19,16 @@ import math
 import os
 from typing import Any, Deque, Iterable, Literal, Mapping, MutableMapping, Protocol
 
+from nifty_scalper_bot.config.env_utils import parse_bool_env, parse_float_env
 from nifty_scalper_bot.core.signal_arbitrator import SignalArbitrator
 from nifty_scalper_bot.execution.readiness import HistoryReadinessPolicy
 from nifty_scalper_bot.instruments.active_contracts import canonical_nifty_future_symbol
 from nifty_scalper_bot.utils.logging import get_logger, log_throttled
+
+# Strategy-name tags for ADX regime gating (mean-reversion off in trends,
+# trend-following off in ranges). Names match Strategy.name values.
+_MEAN_REVERSION_TAGS: tuple[str, ...] = ("Mean Reversion", "Bollinger")
+_TREND_TAGS: tuple[str, ...] = ("Crossover", "MACD", "Breakout", "ORB")
 
 logger = get_logger(__name__)
 
@@ -1440,6 +1446,11 @@ class StrategyManager:
         bar_count = int(float(indicators.get("bar_count", 0)))
         vix = float(indicators.get("vix") or 15.0)
         regime_factor = self._get_regime_modifier(vix)
+        regime_gate_enabled = parse_bool_env(os.getenv("REGIME_GATE_ENABLED"), True)
+        adx_raw = indicators.get("adx")
+        adx = float(adx_raw) if adx_raw is not None else None
+        adx_trend_min = parse_float_env(os.getenv("REGIME_ADX_TREND_MIN"), 25.0)
+        adx_range_max = parse_float_env(os.getenv("REGIME_ADX_RANGE_MAX"), 18.0)
         vwap = float(
             indicators.get("futures_vwap")
             or indicators.get("nifty_fut_vwap")
@@ -1499,6 +1510,27 @@ class StrategyManager:
                     )
                     skip_count += 1
                     continue
+
+                # Gating: ADX regime hard gate (trend vs range strategy classes)
+                if regime_gate_enabled and adx is not None:
+                    is_mean_rev = any(t in strategy.name for t in _MEAN_REVERSION_TAGS)
+                    is_trend = any(t in strategy.name for t in _TREND_TAGS)
+                    if adx >= adx_trend_min and is_mean_rev:
+                        logger.debug(
+                            "strategy_skip_regime",
+                            extra={"event": "strategy_skip_regime", "strategy": strategy.name,
+                                   "regime": "TREND", "adx": adx},
+                        )
+                        skip_count += 1
+                        continue
+                    if adx <= adx_range_max and is_trend:
+                        logger.debug(
+                            "strategy_skip_regime",
+                            extra={"event": "strategy_skip_regime", "strategy": strategy.name,
+                                   "regime": "RANGE", "adx": adx},
+                        )
+                        skip_count += 1
+                        continue
 
                 eval_count += 1
                 logger.debug(

--- a/src/nifty_scalper_bot/strategies/trade_selector.py
+++ b/src/nifty_scalper_bot/strategies/trade_selector.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from nifty_scalper_bot.config.env_utils import parse_int_env
 from nifty_scalper_bot.risk.cost_model import passes_cost_edge_gate
+from nifty_scalper_bot.risk.expiry_gate import expiry_theta_block
 from nifty_scalper_bot.utils.logging import get_logger, log_once_or_throttled
 
 LOGGER = get_logger(__name__)
@@ -81,6 +82,11 @@ class TradeCandidateSelector:
         return 5.0, 10.0, 1
 
     def select_ranked_candidates(self, *, direction_bias: str, atm_strike: int, snapshots: list[dict[str, Any]]) -> list[TradeCandidate]:
+        blocked, gate_reason = expiry_theta_block()
+        if blocked:
+            self._last_rejects = {'expiry_theta_cutoff': len(snapshots)}
+            log_once_or_throttled(LOGGER, f'expiry_theta_cutoff:{direction_bias}', f'CANDIDATE_SELECTION_BLOCKED reason=expiry_theta_cutoff detail={gate_reason} direction={direction_bias} total={len(snapshots)}', interval_sec=60.0, level=logging.INFO, extra={'event': 'CANDIDATE_SELECTION_BLOCKED', 'reason': 'expiry_theta_cutoff', 'detail': gate_reason, 'direction': direction_bias, 'total': len(snapshots)})
+            return []
         max_spread, max_age, min_ticks = self._limits()
         if self.max_option_spread_pct is not None:
             max_spread = float(self.max_option_spread_pct)

--- a/tests/risk/test_expiry_gate.py
+++ b/tests/risk/test_expiry_gate.py
@@ -1,0 +1,46 @@
+"""Tests for the expiry-day theta gate."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from nifty_scalper_bot.risk.expiry_gate import IST, expiry_theta_block
+
+
+def _ist(year: int, month: int, day: int, hour: int, minute: int) -> datetime:
+    return datetime(year, month, day, hour, minute, tzinfo=IST)
+
+
+def test_blocks_expiry_tuesday_afternoon() -> None:
+    # 2026-06-09 is a Tuesday
+    blocked, reason = expiry_theta_block(_ist(2026, 6, 9, 14, 0))
+    assert blocked and "expiry_day_after" in reason
+
+
+def test_allows_expiry_tuesday_morning() -> None:
+    blocked, reason = expiry_theta_block(_ist(2026, 6, 9, 10, 30))
+    assert not blocked and reason == "before_cutoff"
+
+
+def test_allows_non_expiry_day_afternoon() -> None:
+    # 2026-06-10 is a Wednesday
+    blocked, reason = expiry_theta_block(_ist(2026, 6, 10, 14, 30))
+    assert not blocked and reason == "not_expiry_day"
+
+
+def test_disabled_via_env(monkeypatch) -> None:
+    monkeypatch.setenv("EXPIRY_THETA_GATE_ENABLED", "false")
+    blocked, reason = expiry_theta_block(_ist(2026, 6, 9, 15, 0))
+    assert not blocked and reason == "gate_disabled"
+
+
+def test_custom_cutoff(monkeypatch) -> None:
+    monkeypatch.setenv("EXPIRY_ENTRY_CUTOFF_IST", "15:00")
+    blocked, _ = expiry_theta_block(_ist(2026, 6, 9, 14, 30))
+    assert not blocked
+
+
+def test_bad_cutoff_falls_back(monkeypatch) -> None:
+    monkeypatch.setenv("EXPIRY_ENTRY_CUTOFF_IST", "garbage")
+    blocked, _ = expiry_theta_block(_ist(2026, 6, 9, 14, 0))
+    assert blocked  # falls back to 13:30

--- a/tests/strategies/conftest.py
+++ b/tests/strategies/conftest.py
@@ -1,0 +1,14 @@
+"""Strategy test fixtures: keep tests deterministic w.r.t. the real clock."""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _disable_expiry_theta_gate(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Disable the wall-clock expiry gate so selector tests pass on any day.
+
+    The gate itself is tested explicitly in tests/risk/test_expiry_gate.py.
+    """
+    monkeypatch.setenv("EXPIRY_THETA_GATE_ENABLED", "false")


### PR DESCRIPTION
## What
Two protective gates, completing the discussed roadmap (rebuilt on current main; supersedes #548).

### 1. Expiry-day theta gate (risk/expiry_gate.py)
Blocks NEW option-buy candidates on NIFTY weekly expiry day (Tuesday) at/after 13:30 IST, when premium decay makes long-option scalps structurally unprofitable. Exits and decay paths untouched. Env: EXPIRY_THETA_GATE_ENABLED (true), EXPIRY_ENTRY_CUTOFF_IST (13:30), EXPIRY_WEEKDAY (1=Tue). Logs CANDIDATE_SELECTION_BLOCKED (throttled).

### 2. ADX regime hard gate (signal_generator.py)
Mean-reversion strategies (RSI MR, Bollinger, VWAP MR) skipped when ADX >= 25 (trend); trend/momentum strategies (EMA Crossover, MACD, ORB/Breakout) skipped when ADX <= 18 (range). Hysteresis band 18-25 and missing ADX = unchanged behavior. Same pattern as the existing low-VIX gate. Env: REGIME_GATE_ENABLED (true), REGIME_ADX_TREND_MIN (25), REGIME_ADX_RANGE_MAX (18). Logs strategy_skip_regime.

## Validation
580 tests passed, 0 failures (tests/risk + tests/strategies incl. live-path guards). 6 new expiry-gate tests. tests/strategies/conftest.py pins the wall-clock gate off in tests for determinism on any weekday.