### PR TITLE
Add trade discipline: daily trade cap, midday pause, ORB once-per-direction

### DIFF
--- a/src/nifty_scalper_bot/config/settings.py
+++ b/src/nifty_scalper_bot/config/settings.py
@@ -732,6 +732,7 @@ class RiskSettings:
     per_trade_risk_pct: float = 10.0
     per_trade_cap_pct: float = 25.0
     max_consecutive_losses: int = 3
+    max_trades_per_day: int = 6  # enforced by RiskManager failsafe; 0 = unlimited
     loss_cooldown_seconds: float = 90.0
     cooldown_on_reject_seconds: float = 30.0
     trading_day_reset_hour_utc: int = 3
@@ -1178,6 +1179,7 @@ def _build_risk_settings() -> RiskSettings:
     max_losses = _env_int(
         "RISK__MAX_CONSEC_LOSSES", "RISK_MAX_CONSEC_LOSSES", default=3, minimum=1
     )
+    max_trades_day = _env_int("MAX_TRADES_PER_DAY", default=6, minimum=0)
     cooldown_minutes_raw = os.getenv("RISK__COOLDOWN_MIN")
     if cooldown_minutes_raw is not None and cooldown_minutes_raw.strip():
         try:
@@ -1198,6 +1200,7 @@ def _build_risk_settings() -> RiskSettings:
     contract_lot_size = _env_int("NIFTY_LOT_SIZE", default=65, minimum=1)
     return RiskSettings(
         daily_loss_pct=daily_loss_pct,
+        max_trades_per_day=max_trades_day,
         daily_pnl_cap_pct=_env_float(
             "RISK_DAILY_PNL_CAP_PCT", default=daily_loss_pct, minimum=0.0
         ),

--- a/src/nifty_scalper_bot/risk/expiry_gate.py
+++ b/src/nifty_scalper_bot/risk/expiry_gate.py
@@ -46,3 +46,30 @@ def expiry_theta_block(now: datetime | None = None) -> tuple[bool, str]:
     if current.time() < cutoff:
         return False, "before_cutoff"
     return True, f"expiry_day_after_{cutoff.strftime('%H:%M')}_ist"
+
+
+def _env_hhmm(name: str, default: dtime) -> dtime:
+    raw = str(os.getenv(name) or "").strip()
+    try:
+        hh, mm = raw.split(":", 1)
+        return dtime(hour=max(0, min(23, int(hh))), minute=max(0, min(59, int(mm))))
+    except (ValueError, AttributeError):
+        return default
+
+
+def midday_pause_block(now: datetime | None = None) -> tuple[bool, str]:
+    """Args: optional now (tz-aware). Returns: (blocked, reason). Raises: none.
+
+    Blocks NEW option-buy entries during the low-volatility midday window
+    (default 11:30-13:15 IST) where chop feeds transaction costs. Exits
+    untouched. Env: MIDDAY_PAUSE_ENABLED (true), MIDDAY_PAUSE_START (11:30),
+    MIDDAY_PAUSE_END (13:15).
+    """
+    if not parse_bool_env(os.getenv("MIDDAY_PAUSE_ENABLED"), True):
+        return False, "pause_disabled"
+    current = (now.astimezone(IST) if now else datetime.now(IST)).time()
+    start = _env_hhmm("MIDDAY_PAUSE_START", dtime(11, 30))
+    end = _env_hhmm("MIDDAY_PAUSE_END", dtime(13, 15))
+    if start <= current < end:
+        return True, f"midday_pause_{start.strftime('%H:%M')}-{end.strftime('%H:%M')}_ist"
+    return False, "outside_pause"

--- a/src/nifty_scalper_bot/strategies/elite_strategies/orb_pro.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/orb_pro.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 from nifty_scalper_bot.strategies.elite_strategies.base_elite import EliteSignal, EliteStrategy
@@ -19,6 +20,8 @@ class ORBProStrategy(EliteStrategy):
         """Args: config, indicator_engine. Returns: None. Raises: Exception."""
         super().__init__(config=config, indicator_engine=indicator_engine)
         self._cfg = config
+        # One breakout trade per direction per day: {(iso_date, 'CE'|'PE')}
+        self._fired_today: set[tuple[str, str]] = set()
 
     def get_required_indicators(self) -> set[str]:
         """Args: none. Returns: indicators set. Raises: Exception."""
@@ -57,6 +60,12 @@ class ORBProStrategy(EliteStrategy):
             breakout_side = 'CE' if close > orb_high else 'PE' if close < orb_low else 'UNKNOWN'
             if breakout_side == 'UNKNOWN':
                 self._no_vote('no_breakout')
+                return None
+
+            day_key = (datetime.now(timezone(timedelta(hours=5, minutes=30))).date().isoformat(), breakout_side)
+            if day_key in self._fired_today:
+                self._no_vote('direction_already_traded_today')
+                LOGGER.debug('STRATEGY_NO_VOTE strategy=ORBPro reason=direction_already_traded_today side=%s', breakout_side)
                 return None
 
             candle_range = max(abs(float(indicators.get('high') or close) - float(indicators.get('low') or close)), 1e-9)
@@ -108,6 +117,10 @@ class ORBProStrategy(EliteStrategy):
                 'invalidation_level': orb_low if breakout_side == 'CE' else orb_high,
             }
             LOGGER.info('STRATEGY_VOTE strategy=ORBPro side=%s score=%.2f', breakout_side, strategy_score)
+            self._fired_today.add(day_key)
+            if len(self._fired_today) > 8:
+                today = day_key[0]
+                self._fired_today = {k for k in self._fired_today if k[0] == today}
             return EliteSignal(
                 symbol=symbol,
                 signal='BUY',

--- a/src/nifty_scalper_bot/strategies/trade_selector.py
+++ b/src/nifty_scalper_bot/strategies/trade_selector.py
@@ -9,7 +9,7 @@ from typing import Any
 
 from nifty_scalper_bot.config.env_utils import parse_int_env
 from nifty_scalper_bot.risk.cost_model import passes_cost_edge_gate
-from nifty_scalper_bot.risk.expiry_gate import expiry_theta_block
+from nifty_scalper_bot.risk.expiry_gate import expiry_theta_block, midday_pause_block
 from nifty_scalper_bot.utils.logging import get_logger, log_once_or_throttled
 
 LOGGER = get_logger(__name__)
@@ -83,9 +83,11 @@ class TradeCandidateSelector:
 
     def select_ranked_candidates(self, *, direction_bias: str, atm_strike: int, snapshots: list[dict[str, Any]]) -> list[TradeCandidate]:
         blocked, gate_reason = expiry_theta_block()
+        if not blocked:
+            blocked, gate_reason = midday_pause_block()
         if blocked:
-            self._last_rejects = {'expiry_theta_cutoff': len(snapshots)}
-            log_once_or_throttled(LOGGER, f'expiry_theta_cutoff:{direction_bias}', f'CANDIDATE_SELECTION_BLOCKED reason=expiry_theta_cutoff detail={gate_reason} direction={direction_bias} total={len(snapshots)}', interval_sec=60.0, level=logging.INFO, extra={'event': 'CANDIDATE_SELECTION_BLOCKED', 'reason': 'expiry_theta_cutoff', 'detail': gate_reason, 'direction': direction_bias, 'total': len(snapshots)})
+            self._last_rejects = {'entry_window_blocked': len(snapshots)}
+            log_once_or_throttled(LOGGER, f'entry_window_blocked:{gate_reason}:{direction_bias}', f'CANDIDATE_SELECTION_BLOCKED reason={gate_reason} direction={direction_bias} total={len(snapshots)}', interval_sec=60.0, level=logging.INFO, extra={'event': 'CANDIDATE_SELECTION_BLOCKED', 'reason': gate_reason, 'direction': direction_bias, 'total': len(snapshots)})
             return []
         max_spread, max_age, min_ticks = self._limits()
         if self.max_option_spread_pct is not None:

--- a/tests/risk/test_expiry_gate.py
+++ b/tests/risk/test_expiry_gate.py
@@ -44,3 +44,24 @@ def test_bad_cutoff_falls_back(monkeypatch) -> None:
     monkeypatch.setenv("EXPIRY_ENTRY_CUTOFF_IST", "garbage")
     blocked, _ = expiry_theta_block(_ist(2026, 6, 9, 14, 0))
     assert blocked  # falls back to 13:30
+
+
+def test_midday_pause_blocks_within_window() -> None:
+    from nifty_scalper_bot.risk.expiry_gate import midday_pause_block
+    blocked, reason = midday_pause_block(_ist(2026, 6, 10, 12, 0))
+    assert blocked and "midday_pause" in reason
+
+
+def test_midday_pause_allows_outside_window() -> None:
+    from nifty_scalper_bot.risk.expiry_gate import midday_pause_block
+    blocked, _ = midday_pause_block(_ist(2026, 6, 10, 9, 45))
+    assert not blocked
+    blocked, _ = midday_pause_block(_ist(2026, 6, 10, 14, 0))
+    assert not blocked
+
+
+def test_midday_pause_disabled_via_env(monkeypatch) -> None:
+    from nifty_scalper_bot.risk.expiry_gate import midday_pause_block
+    monkeypatch.setenv("MIDDAY_PAUSE_ENABLED", "false")
+    blocked, reason = midday_pause_block(_ist(2026, 6, 10, 12, 0))
+    assert not blocked and reason == "pause_disabled"

--- a/tests/strategies/conftest.py
+++ b/tests/strategies/conftest.py
@@ -12,3 +12,9 @@ def _disable_expiry_theta_gate(monkeypatch: pytest.MonkeyPatch) -> None:
     The gate itself is tested explicitly in tests/risk/test_expiry_gate.py.
     """
     monkeypatch.setenv("EXPIRY_THETA_GATE_ENABLED", "false")
+
+
+@pytest.fixture(autouse=True)
+def _disable_midday_pause(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Disable the wall-clock midday pause so selector tests pass at any hour."""
+    monkeypatch.setenv("MIDDAY_PAUSE_ENABLED", "false")


### PR DESCRIPTION
## What (3 minimal, coordinated changes)
1. **MAX_TRADES_PER_DAY now actually enforced** — RiskManager already checked settings.max_trades_per_day, but the field never existed in RiskSettings, silently defaulting to 0 = unlimited trades. Added field + env wiring (default 6, 0 = unlimited).
2. **Midday pause gate** — new option-buy entries blocked 11:30-13:15 IST (low-volatility chop that feeds transaction costs). Added to existing risk/expiry_gate.py module, wired beside the expiry gate in trade_selector. Env: MIDDAY_PAUSE_ENABLED (true), MIDDAY_PAUSE_START, MIDDAY_PAUSE_END. Exits untouched.
3. **ORB Pro: one trade per direction per day** — repeat breakout votes in an already-traded direction are no-voted (direction_already_traded_today), preventing whipsaw re-entries.

## Deliberately NOT changed (avoiding over-engineering)
- Trailing SL: AdaptiveTrailingController already exists and is enabled.
- Trading window: already env-configurable (DATA__TIME_FILTER_START/END).
- Legacy MACD/EMA classics: not in the live elite path; removal would be churn.

## Validation
637 tests passed, 0 failures (tests/risk, tests/strategies, consensus suites). 3 new midday-pause tests; conftest pins wall-clock gates off in tests. Pre-existing note: duplicate test basenames (tests/test_log_throttle.py vs tests/utils/test_log_throttle.py, same for strategy_manager_consensus) break combined pytest collection on main as well — flagged for a future cleanup PR.