### PR TITLE
Enhance Telegram no-trade diagnostics

### DIFF
--- a/src/nifty_scalper_bot/notifications/operator_telegram.py
+++ b/src/nifty_scalper_bot/notifications/operator_telegram.py
@@ -10,13 +10,14 @@ from __future__ import annotations
 import inspect
 import logging
 from collections.abc import Awaitable, Callable, Mapping, Sequence
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass, is_dataclass
 from typing import Any
 
 from telegram import Update
 from telegram.ext import Application, CommandHandler, ContextTypes
 
 from nifty_scalper_bot.infra.diagnostics import LOG_TAP
+from nifty_scalper_bot.risk.expiry_gate import expiry_theta_block, midday_pause_block
 
 LOG = logging.getLogger(__name__)
 
@@ -110,6 +111,77 @@ def _first_attr(obj: Any, names: Sequence[str]) -> Any:
     return None
 
 
+def _safe_call(func: Any, *args: Any, **kwargs: Any) -> Any:
+    if not callable(func):
+        return None
+    try:
+        return func(*args, **kwargs)
+    except Exception as exc:  # noqa: BLE001 - read-only diagnostic boundary
+        return f"WARN: {getattr(func, '__name__', 'call')} failed: {type(exc).__name__}"
+
+
+def _obj_to_dict(value: Any) -> dict[str, Any]:
+    if value is None:
+        return {}
+    if isinstance(value, Mapping):
+        return dict(value)
+    if is_dataclass(value) and not isinstance(value, type):
+        try:
+            return asdict(value)
+        except Exception:  # noqa: BLE001 - diagnostic formatting only
+            return {}
+    data: dict[str, Any] = {}
+    for name in dir(value):
+        if name.startswith("_"):
+            continue
+        try:
+            attr = getattr(value, name)
+        except Exception:  # noqa: BLE001 - diagnostic formatting only
+            continue
+        if callable(attr):
+            continue
+        data[name] = attr
+    return data
+
+
+def _compact(value: Any, *, limit: int = 180) -> str:
+    if value is None or value == "":
+        return "WARN: unavailable"
+    if isinstance(value, Mapping):
+        items = list(value.items())
+        text = ", ".join(f"{k}={v}" for k, v in items[:8])
+        if len(items) > 8:
+            text += f", +{len(items) - 8} more"
+    elif isinstance(value, (list, tuple, set, frozenset)):
+        seq = list(value)
+        text = ", ".join(str(v) for v in seq[:8])
+        if len(seq) > 8:
+            text += f", +{len(seq) - 8} more"
+        text = f"[{text}]"
+    else:
+        text = str(value)
+    return text if len(text) <= limit else text[: limit - 3] + "..."
+
+
+def _count(value: Any) -> Any:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value
+    try:
+        return len(value)  # type: ignore[arg-type]
+    except TypeError:
+        return value
+
+
+def _format_gate(value: Any) -> str:
+    if isinstance(value, tuple) and len(value) == 2:
+        return f"blocked={bool(value[0])} reason={value[1]}"
+    if isinstance(value, Mapping):
+        return _compact(value)
+    return _value(value)
+
+
 def _dep(service: Any, *names: str) -> Any:
     deps = getattr(service, "deps", service)
     for name in names:
@@ -123,14 +195,74 @@ def _context(service: Any) -> Any:
     return _dep(service, "bot_context") or service
 
 
+def _extract_quote_summary(source: Any, symbol: Any) -> str | None:
+    if not source or not symbol:
+        return None
+    quote = None
+    get_quote = getattr(source, "get_quote", None)
+    if callable(get_quote):
+        try:
+            signature = inspect.signature(get_quote)
+            if "allow_pull" in signature.parameters:
+                quote = get_quote(str(symbol), allow_pull=False)
+            else:
+                quote = get_quote(str(symbol))
+        except Exception as exc:  # noqa: BLE001 - read-only diagnostic boundary
+            return f"WARN: quote failed: {type(exc).__name__}"
+    if quote is None:
+        return "missing"
+    q = _obj_to_dict(quote)
+    bid = q.get("bid") or q.get("best_bid")
+    ask = q.get("ask") or q.get("best_ask")
+    ltp = q.get("ltp") or q.get("last_price") or q.get("price")
+    depth = q.get("depth") or q.get("market_depth")
+    source_name = q.get("source") or q.get("quote_source")
+    stale = q.get("stale") if "stale" in q else q.get("is_stale")
+    parts = [f"ltp={ltp}", f"bid={bid}", f"ask={ask}", f"depth={'yes' if depth else 'no'}"]
+    if source_name:
+        parts.append(f"source={source_name}")
+    if stale is not None:
+        parts.append(f"stale={stale}")
+    return _compact(", ".join(parts), limit=180)
+
+
+def _symbol_metric(source: Any, symbol: Any, names: Sequence[str]) -> Any:
+    if not source or not symbol:
+        return None
+    for name in names:
+        func = getattr(source, name, None)
+        if callable(func):
+            value = _safe_call(func, str(symbol))
+            if value is not None:
+                return value
+        elif hasattr(source, name):
+            value = getattr(source, name)
+            if isinstance(value, Mapping):
+                return value.get(str(symbol)) or value.get(str(symbol).upper())
+            if value is not None:
+                return value
+    return None
+
+
+def _bar_count(source: Any, symbol: Any) -> Any:
+    bars = _symbol_metric(source, symbol, ("get_ohlc_bars", "get_ohlc", "bars_for_symbol"))
+    if isinstance(bars, str):
+        return bars
+    return _count(bars)
+
+
 def _runtime_snapshot(service: Any) -> dict[str, Any]:
     ctx = _context(service)
     mdm = _dep(service, "market_data_manager")
     data_hub = _dep(service, "data_hub")
     runner = _dep(service, "strategy_runner")
+    strategy_manager = _dep(service, "strategy_manager") or _first_attr(runner, ("strategy_manager",))
     risk = _dep(service, "risk_manager")
     order = _dep(service, "order_manager", "safe_order_manager")
     broker = _dep(service, "broker_client", "broker")
+    position_manager = _dep(service, "position_manager") or _first_attr(order, ("position_manager", "positions"))
+    bracket_manager = _dep(service, "bracket_manager") or _first_attr(order, ("bracket_manager",))
+    websocket = _dep(service, "websocket_manager", "streamer", "stream_supervisor")
 
     get_status = getattr(service, "get_status", None)
     status_text = None
@@ -140,40 +272,121 @@ def _runtime_snapshot(service: Any) -> dict[str, Any]:
         except Exception as exc:  # noqa: BLE001 - diagnostic only
             status_text = f"WARN: get_status failed: {type(exc).__name__}"
 
-    selected_ce = _first_attr(ctx, ("selected_ce", "atm_ce", "ce_symbol", "call_symbol"))
-    selected_pe = _first_attr(ctx, ("selected_pe", "atm_pe", "pe_symbol", "put_symbol"))
-    basket = _first_attr(ctx, ("active_basket", "contract_basket", "basket"))
+    selected_ce = _first_attr(ctx, ("selected_ce", "atm_ce_symbol", "atm_ce", "ce_symbol", "call_symbol"))
+    selected_pe = _first_attr(ctx, ("selected_pe", "atm_pe_symbol", "atm_pe", "pe_symbol", "put_symbol"))
+    basket = _first_attr(ctx, ("active_contract_basket", "active_basket", "contract_basket", "basket"))
     if basket is not None and not isinstance(basket, str):
         selected_ce = selected_ce or _first_attr(basket, ("ce_symbol", "call_symbol", "selected_ce"))
         selected_pe = selected_pe or _first_attr(basket, ("pe_symbol", "put_symbol", "selected_pe"))
 
-    live_orders_armed = _first_attr(ctx, ("live_orders_armed", "live_order_armed"))
+    live_orders_armed = _first_attr(ctx, ("live_orders_armed", "live_order_armed", "execution_armed"))
     if live_orders_armed is None:
         live_orders_armed = _first_attr(order, ("live_orders_armed", "is_live_armed"))
     live_block_reason = _first_attr(ctx, ("live_block_reason", "block_reason"))
 
-    return {
+    selector = _first_attr(runner, ("trade_candidate_selector",)) or _first_attr(runner, ("_trade_candidate_selector",))
+    candidate_rejects = (
+        _first_attr(runner, ("latest_candidate_rejects", "last_candidate_rejects", "candidate_rejects"))
+        or _first_attr(selector, ("last_rejects", "_last_rejects"))
+    )
+    strategy_decision = None
+    for symbol in (selected_ce, selected_pe):
+        getter = getattr(strategy_manager, "get_last_no_signal_decision", None)
+        if callable(getter) and symbol:
+            strategy_decision = _safe_call(getter, str(symbol))
+            if strategy_decision:
+                break
+    strategy_decision_dict = _obj_to_dict(strategy_decision)
+
+    risk_snapshot = _safe_call(getattr(risk, "snapshot", None)) if risk is not None else None
+    risk_snapshot_dict = _obj_to_dict(risk_snapshot)
+    risk_settings = getattr(risk, "settings", None)
+    trades_today = _first_attr(risk, ("trades_today", "daily_trade_count", "trade_count_today"))
+    if trades_today is None:
+        trades_today = _first_attr(position_manager, ("trades_today", "daily_trade_count", "trade_count_today"))
+    max_trades = _first_attr(risk, ("max_trades_per_day", "daily_trade_limit"))
+    if max_trades is None and risk_settings is not None:
+        max_trades = _first_attr(risk_settings, ("max_trades_per_day", "daily_trade_limit"))
+
+    midday_pause = _first_attr(ctx, ("midday_pause_active", "midday_pause_blocked"))
+    if midday_pause is None:
+        midday_pause = midday_pause_block()
+    expiry_theta = _first_attr(ctx, ("expiry_theta_blocked", "expiry_theta_gate"))
+    if expiry_theta is None:
+        expiry_theta = expiry_theta_block()
+
+    open_orders = _first_attr(order, ("open_orders", "get_open_orders", "pending_orders"))
+    open_positions = _first_attr(position_manager, ("open_positions", "positions", "get_open_positions"))
+    if open_positions is None:
+        open_positions = _first_attr(order, ("open_positions", "positions", "get_open_positions"))
+
+    last_trade_decision = (
+        _first_attr(ctx, ("last_trade_decision", "LAST_TRADE_DECISION_SNAPSHOT"))
+        or _first_attr(runner, ("last_trade_decision", "LAST_TRADE_DECISION_SNAPSHOT"))
+    )
+
+    snap: dict[str, Any] = {
         "mode": _first_attr(ctx, ("mode", "trading_mode", "effective_mode")) or getattr(service, "mode", None),
         "effective_mode": _first_attr(ctx, ("effective_mode", "execution_mode")),
-        "market_state": _first_attr(ctx, ("market_state", "market_open", "session_state")),
+        "market_state": _first_attr(ctx, ("market_state", "market_open", "market_session_state", "session_state")),
+        "market_open": _first_attr(ctx, ("market_open", "is_market_open")),
+        "market_session_state": _first_attr(ctx, ("market_session_state", "session_state")),
         "selected_ce": selected_ce,
         "selected_pe": selected_pe,
         "spot_price": _first_attr(mdm, ("spot_ltp", "nifty_spot", "spot_price")) or _first_attr(data_hub, ("spot_ltp", "spot_price")),
         "futures_symbol": _first_attr(ctx, ("futures_symbol", "future_symbol")),
         "data_hard_ready": _first_attr(ctx, ("data_hard_ready", "market_data_ready")),
-        "evaluation_ready": _first_attr(ctx, ("evaluation_ready", "strategy_ready")),
+        "evaluation_ready": _first_attr(ctx, ("evaluation_ready", "strategy_evaluation_ready", "strategy_ready")),
         "live_orders_armed": live_orders_armed,
         "live_block_reason": live_block_reason,
+        "execution_block_reason": _first_attr(ctx, ("execution_block_reason",)) or _first_attr(order, ("execution_block_reason", "last_execution_block_reason")),
+        "execution_ready_by_symbol": _first_attr(ctx, ("execution_ready_by_symbol",)) or _first_attr(runner, ("runtime_execution_ready_by_symbol", "_runtime_execution_ready_by_symbol")),
+        "selected_ce_exec_ready": _first_attr(ctx, ("selected_ce_exec_ready", "ce_exec_ready")),
+        "selected_pe_exec_ready": _first_attr(ctx, ("selected_pe_exec_ready", "pe_exec_ready")),
+        "context_exec_ready": _first_attr(ctx, ("context_exec_ready",)),
+        "broker_ready": _first_attr(ctx, ("broker_ready",)) or _first_attr(broker, ("is_ready", "ready", "is_connected", "session_valid", "is_session_valid")),
+        "candidate_rejects": candidate_rejects,
+        "last_signal_reason": _first_attr(runner, ("last_signal_reason", "last_signal_reasons", "latest_signal_reason")) or strategy_decision_dict.get("reason") or strategy_decision_dict.get("final_block_reason"),
+        "regime_gate": _first_attr(strategy_manager, ("last_regime_gate", "_last_regime_gate")) or _first_attr(_dep(service, "regime_manager", "market_regime"), ("last_gate_reason", "get_filter_reasons")),
+        "regime_state": _first_attr(strategy_manager, ("regime_state", "_regime_state")) or _first_attr(_dep(service, "regime_manager", "market_regime"), ("current_regime", "regime", "snapshot")),
+        "adx_gate": _first_attr(runner, ("adx_gate", "last_adx_gate", "adx_gate_reason", "last_adx_gate_reason")) or _first_attr(strategy_manager, ("adx_gate", "last_adx_gate_reason")),
+        "orb_direction_block": _first_attr(runner, ("orb_direction_block", "orb_direction_used", "orb_direction_state", "_orb_direction_used")) or _first_attr(strategy_manager, ("orb_direction_block", "orb_direction_state")),
+        "risk_reject": _first_attr(risk, ("last_rejection", "last_reason", "last_reject_reason", "_last_rejection")) or risk_snapshot_dict.get("last_rejection"),
+        "risk_breaker": _first_attr(risk, ("breaker_tripped", "is_breaker_tripped", "_breaker_tripped")) or risk_snapshot_dict.get("breaker_tripped"),
+        "order_reject": _first_attr(order, ("last_preflight_reject_reason", "last_reject_reason", "last_rejection", "last_skip_reason", "_last_skip_reason")),
+        "daily_trades": trades_today,
+        "max_trades_per_day": max_trades,
+        "midday_pause": midday_pause,
+        "expiry_theta_gate": expiry_theta,
+        "open_orders": open_orders,
+        "open_positions": open_positions,
+        "bracket_manager": bracket_manager,
+        "bracket_manager_attached": _first_attr(ctx, ("bracket_manager_attached",)) if _first_attr(ctx, ("bracket_manager_attached",)) is not None else bracket_manager is not None,
+        "unresolved_exit": _first_attr(bracket_manager, ("has_unresolved_exit", "unresolved_exit", "get_first_unresolved_exit_bracket_id")),
+        "active_basket": basket,
+        "active_symbol_tokens": _first_attr(ctx, ("active_symbol_tokens",)) or _first_attr(mdm, ("active_symbol_tokens", "symbol_tokens")),
+        "websocket_subscribed_tokens": _first_attr(websocket, ("subscribed_tokens", "tokens", "get_subscribed_tokens")),
+        "mdm_tracked": _first_attr(mdm, ("tracked_snapshot", "list_tracked", "tracked_symbols", "_tracked_symbols")),
+        "mdm_subscribers": _first_attr(mdm, ("subscribers", "_subscribers")),
+        "last_trade_decision": last_trade_decision,
         "mdm": mdm,
         "data_hub": data_hub,
         "runner": runner,
+        "strategy_manager": strategy_manager,
         "risk": risk,
         "order": order,
         "broker": broker,
-        "websocket": _dep(service, "websocket_manager", "streamer", "stream_supervisor"),
+        "position_manager": position_manager,
+        "websocket": websocket,
         "status_text": status_text,
     }
-
+    snap["selected_ce_quote"] = _extract_quote_summary(data_hub, selected_ce) or _extract_quote_summary(mdm, selected_ce)
+    snap["selected_pe_quote"] = _extract_quote_summary(data_hub, selected_pe) or _extract_quote_summary(mdm, selected_pe)
+    snap["selected_ce_tick_age"] = _symbol_metric(mdm, selected_ce, ("quote_age_ms", "tick_age_ms", "last_tick_age")) or _symbol_metric(data_hub, selected_ce, ("quote_age_ms", "quote_age_s", "last_tick_age"))
+    snap["selected_pe_tick_age"] = _symbol_metric(mdm, selected_pe, ("quote_age_ms", "tick_age_ms", "last_tick_age")) or _symbol_metric(data_hub, selected_pe, ("quote_age_ms", "quote_age_s", "last_tick_age"))
+    snap["selected_ce_bars"] = _bar_count(data_hub, selected_ce) or _bar_count(mdm, selected_ce)
+    snap["selected_pe_bars"] = _bar_count(data_hub, selected_pe) or _bar_count(mdm, selected_pe)
+    return snap
 
 def _lines(title: str, items: Mapping[str, Any]) -> str:
     body = [title]
@@ -310,10 +523,20 @@ async def cmd_diag(update: Update, _: ContextTypes.DEFAULT_TYPE, service: Any) -
 
 
 def _why_reason(snap: Mapping[str, Any]) -> str | None:
+    for key in (
+        "live_block_reason",
+        "execution_block_reason",
+        "order_reject",
+        "risk_reject",
+        "last_signal_reason",
+    ):
+        reason = snap.get(key)
+        if reason:
+            return str(reason)
     for obj_key, attrs in (
         ("runner", ("last_gate_reason", "last_block_reason", "latest_rejection_reason")),
-        ("order", ("last_preflight_reject_reason", "last_reject_reason", "last_rejection")),
-        ("risk", ("last_rejection", "last_reason", "last_reject_reason")),
+        ("order", ("last_preflight_reject_reason", "last_reject_reason", "last_rejection", "_last_skip_reason")),
+        ("risk", ("last_rejection", "last_reason", "last_reject_reason", "_last_rejection")),
     ):
         reason = _first_attr(snap.get(obj_key), attrs)
         if reason:
@@ -323,9 +546,40 @@ def _why_reason(snap: Mapping[str, Any]) -> str | None:
 
 async def cmd_why(update: Update, _: ContextTypes.DEFAULT_TYPE, service: Any) -> None:
     snap = _runtime_snapshot(service)
-    reason = snap.get("live_block_reason") or _why_reason(snap) or "No current rejection; waiting for valid signal"
-    await safe_reply(update, f"Why\nreason: {reason}")
-
+    reason = _why_reason(snap) or "waiting_for_valid_signal"
+    await safe_reply(
+        update,
+        "Why no trade?\n"
+        f"final_reason: {reason}\n"
+        "readiness:\n"
+        f"  market_open: {_bool(snap.get('market_open'))}\n"
+        f"  live_orders_armed: {_bool(snap.get('live_orders_armed'))}\n"
+        f"  live_block_reason: {_value(snap.get('live_block_reason'), 'none')}\n"
+        f"  selected_ce_exec_ready: {_bool(snap.get('selected_ce_exec_ready'))}\n"
+        f"  selected_pe_exec_ready: {_bool(snap.get('selected_pe_exec_ready'))}\n"
+        "data:\n"
+        f"  selected_ce: {_value(snap.get('selected_ce'))}\n"
+        f"  selected_pe: {_value(snap.get('selected_pe'))}\n"
+        f"  data_hard_ready: {_bool(snap.get('data_hard_ready'))}\n"
+        f"  evaluation_ready: {_bool(snap.get('evaluation_ready'))}\n"
+        "strategy:\n"
+        f"  last_signal_reason: {_value(snap.get('last_signal_reason'), 'none')}\n"
+        f"  candidate_rejects: {_compact(snap.get('candidate_rejects'))}\n"
+        f"  regime_gate: {_compact(snap.get('regime_gate'))}\n"
+        f"  adx_gate: {_value(snap.get('adx_gate'), 'none')}\n"
+        "discipline:\n"
+        f"  midday_pause: {_format_gate(snap.get('midday_pause'))}\n"
+        f"  expiry_theta_gate: {_format_gate(snap.get('expiry_theta_gate'))}\n"
+        f"  daily_trades: {_value(snap.get('daily_trades'))}\n"
+        f"  max_trades_per_day: {_value(snap.get('max_trades_per_day'))}\n"
+        f"  orb_direction_block: {_compact(snap.get('orb_direction_block'))}\n"
+        "execution:\n"
+        f"  broker_ready: {_bool(snap.get('broker_ready'))}\n"
+        f"  risk_reject: {_value(snap.get('risk_reject'), 'none')}\n"
+        f"  order_reject: {_value(snap.get('order_reject'), 'none')}\n"
+        f"  open_orders: {_compact(_count(snap.get('open_orders')))}\n"
+        f"  open_positions: {_compact(_count(snap.get('open_positions')))}"
+    )
 
 async def cmd_check(update: Update, _: ContextTypes.DEFAULT_TYPE, service: Any) -> None:
     snap = _runtime_snapshot(service)
@@ -352,43 +606,66 @@ async def cmd_check_connectivity(update: Update, _: ContextTypes.DEFAULT_TYPE, s
 
 async def cmd_check_market(update: Update, _: ContextTypes.DEFAULT_TYPE, service: Any) -> None:
     snap = _runtime_snapshot(service)
-    mdm = snap.get("mdm")
     await safe_reply(update, _lines("Market", {
         "selected_ce": snap.get("selected_ce"),
         "selected_pe": snap.get("selected_pe"),
+        "selected_ce_quote_depth": snap.get("selected_ce_quote"),
+        "selected_pe_quote_depth": snap.get("selected_pe_quote"),
+        "selected_ce_tick_age": snap.get("selected_ce_tick_age"),
+        "selected_pe_tick_age": snap.get("selected_pe_tick_age"),
+        "selected_ce_hydration_bars": snap.get("selected_ce_bars"),
+        "selected_pe_hydration_bars": snap.get("selected_pe_bars"),
         "spot_price": snap.get("spot_price"),
         "futures_symbol": snap.get("futures_symbol"),
-        "subscriptions": _first_attr(mdm, ("subscribed_tokens", "subscriptions", "get_subscription_snapshot")),
-        "tick_freshness": _first_attr(mdm, ("tick_freshness", "last_tick_age", "freshness")),
-        "quote_depth": _first_attr(mdm, ("quote_quality", "depth_status", "quote_depth_status")),
-        "hydration_bars": _first_attr(mdm, ("hydration_bars", "bar_count", "ohlc_status")),
+        "active_basket_symbols": _count(snap.get("active_basket")),
+        "active_symbol_tokens": _count(snap.get("active_symbol_tokens")),
+        "websocket_subscribed_tokens": _count(snap.get("websocket_subscribed_tokens")),
+        "mdm_tracked_symbols": _count(snap.get("mdm_tracked")),
+        "mdm_subscribers": _count(snap.get("mdm_subscribers")),
     }))
 
 
 async def cmd_check_core(update: Update, _: ContextTypes.DEFAULT_TYPE, service: Any) -> None:
     snap = _runtime_snapshot(service)
     ctx = _context(service)
+    runner = snap.get("runner")
     await safe_reply(update, _lines("Core", {
         "startup_phase": _first_attr(ctx, ("startup_phase", "phase")),
         "data_phase": _first_attr(ctx, ("data_phase",)),
-        "runner": _component_state("StrategyRunner", snap.get("runner")),
-        "regime": _first_attr(_dep(service, "regime_manager", "market_regime"), ("current_regime", "regime", "snapshot")),
+        "runner": _component_state("StrategyRunner", runner),
+        "runner_running": _bool(_first_attr(runner, ("running", "is_running", "started"))),
         "evaluation_ready": _bool(snap.get("evaluation_ready")),
-        "strategy_gate_reason": _why_reason(snap) or "none",
+        "last_strategy_gate_reason": _why_reason(snap) or "none",
+        "last_candidate_rejects": _compact(snap.get("candidate_rejects")),
+        "regime_current_state": _compact(snap.get("regime_state")),
+        "regime_gate": _compact(snap.get("regime_gate")),
+        "adx_gate": _value(snap.get("adx_gate"), "none"),
+        "orb_direction_state": _compact(snap.get("orb_direction_block")),
     }))
 
 
 async def cmd_check_execution(update: Update, _: ContextTypes.DEFAULT_TYPE, service: Any) -> None:
     snap = _runtime_snapshot(service)
     order = snap.get("order")
-    risk = snap.get("risk")
     await safe_reply(update, _lines("Execution", {
         "live_orders_armed": _bool(snap.get("live_orders_armed")),
-        "broker_health": _component_state("Broker", snap.get("broker")),
-        "risk_breaker": _first_attr(risk, ("breaker_tripped", "is_breaker_tripped")) or _component_state("RiskManager", risk),
-        "open_positions": _first_attr(_dep(service, "position_manager"), ("open_positions", "positions", "get_open_positions")),
-        "open_orders": _first_attr(order, ("open_orders", "get_open_orders", "pending_orders")),
-        "bracket_manager": _component_state("BracketManager", _dep(service, "bracket_manager")),
+        "live_block_reason": snap.get("live_block_reason") or "none",
+        "execution_block_reason": snap.get("execution_block_reason") or "none",
+        "selected_ce_exec_ready": _bool(snap.get("selected_ce_exec_ready")),
+        "selected_pe_exec_ready": _bool(snap.get("selected_pe_exec_ready")),
+        "broker_ready": _bool(snap.get("broker_ready")),
+        "risk_breaker": snap.get("risk_breaker") if snap.get("risk_breaker") is not None else _component_state("RiskManager", snap.get("risk")),
+        "daily_trades": snap.get("daily_trades"),
+        "max_trades_per_day": snap.get("max_trades_per_day"),
+        "midday_pause": _format_gate(snap.get("midday_pause")),
+        "expiry_theta_gate": _format_gate(snap.get("expiry_theta_gate")),
+        "orb_direction_flags": _compact(snap.get("orb_direction_block")),
+        "last_order_rejection": snap.get("order_reject") or "none",
+        "last_risk_rejection": snap.get("risk_reject") or "none",
+        "open_orders": _compact(_count(snap.get("open_orders"))),
+        "open_positions": _compact(_count(snap.get("open_positions"))),
+        "bracket_manager_attached": _bool(snap.get("bracket_manager_attached")),
+        "unresolved_exit": _value(snap.get("unresolved_exit"), "none"),
         "emergency_stop": _first_attr(order, ("emergency_stopped", "kill_switch_engaged", "is_kill_switch_engaged")) or "WARN: state unavailable",
     }))
 

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -240,6 +240,26 @@ _NIFTY_OPTION_SLIPPAGE_GAUGE = metrics.Gauge(
 
 
 @dataclass(slots=True)
+class TradeDecisionSnapshot:
+    """Latest read-only trade decision exposed to diagnostics."""
+
+    timestamp: str
+    symbol: str | None
+    direction: str | None
+    final_reason: str | None
+    live_orders_armed: bool
+    candidate_count: int | None = None
+    candidate_rejects: Mapping[str, Any] | None = None
+    selected_candidate: str | None = None
+    strategy_allowed: bool | None = None
+    risk_allowed: bool | None = None
+    order_submitted: bool = False
+
+
+LAST_TRADE_DECISION_SNAPSHOT: TradeDecisionSnapshot | None = None
+
+
+@dataclass(slots=True)
 class DeterministicExecutionPipeline:
     """Data->signal->validation->risk->execution pipeline."""
 
@@ -711,6 +731,7 @@ class StrategyRunner:
         self._runtime_execution_ready_by_symbol: dict[str, bool] = {}
         self._runtime_symbol_last_ready_at: dict[str, float] = {}
         self._runtime_readiness_reason: str | None = None
+        self._last_trade_decision: TradeDecisionSnapshot | None = None
         self._runtime_indicators: dict[str, dict[str, Any]] = {}
         self._last_direction_context: dict[str, Any] | None = None
         self._runtime_startup_ready = False
@@ -3222,6 +3243,46 @@ class StrategyRunner:
                 continue
         return []
 
+    def _record_trade_decision_snapshot(
+        self,
+        *,
+        symbol: str | None,
+        direction: str | None,
+        final_reason: str | None,
+        candidate_count: int | None = None,
+        candidate_rejects: Mapping[str, Any] | None = None,
+        selected_candidate: str | None = None,
+        strategy_allowed: bool | None = None,
+        risk_allowed: bool | None = None,
+        order_submitted: bool = False,
+    ) -> None:
+        """Update the diagnostic-only latest trade decision snapshot."""
+        try:
+            snapshot = TradeDecisionSnapshot(
+                timestamp=datetime.now(timezone.utc).isoformat(),
+                symbol=symbol,
+                direction=direction,
+                final_reason=final_reason,
+                live_orders_armed=bool(self._runtime_live_orders_armed),
+                candidate_count=candidate_count,
+                candidate_rejects=dict(candidate_rejects or {}),
+                selected_candidate=selected_candidate,
+                strategy_allowed=strategy_allowed,
+                risk_allowed=risk_allowed,
+                order_submitted=bool(order_submitted),
+            )
+            self._last_trade_decision = snapshot
+            globals()["LAST_TRADE_DECISION_SNAPSHOT"] = snapshot
+        except Exception as exc:  # noqa: BLE001 - diagnostics must never block trading
+            self._logger.debug(
+                "TRADE_DECISION_SNAPSHOT_UPDATE_FAILED error_type=%s",
+                type(exc).__name__,
+            )
+
+    @property
+    def last_trade_decision(self) -> TradeDecisionSnapshot | None:
+        return self._last_trade_decision
+
     def _reject_signal_execution(
         self,
         *,
@@ -3245,6 +3306,17 @@ class StrategyRunner:
                 "trace_id": trace_id,
                 **payload,
             },
+        )
+        self._record_trade_decision_snapshot(
+            symbol=symbol,
+            direction=str(payload.get("direction") or payload.get("option_side") or "") or None,
+            final_reason=reason,
+            candidate_count=payload.get("candidate_total") if isinstance(payload.get("candidate_total"), int) else None,
+            candidate_rejects=payload.get("candidate_rejects") if isinstance(payload.get("candidate_rejects"), Mapping) else None,
+            selected_candidate=str(payload.get("selected_candidate") or "") or None,
+            strategy_allowed=False,
+            risk_allowed=None,
+            order_submitted=False,
         )
         if reason == "candidate_refresh_pending" and not bool(payload.get("event_loop_active", False)):
             self._logger.info(
@@ -13415,6 +13487,17 @@ class StrategyRunner:
                     )
                 except Exception as rec_exc:
                     self._logger.error("record_trade failed: %s", rec_exc)
+                self._record_trade_decision_snapshot(
+                    symbol=base_symbol,
+                    direction=option_side,
+                    final_reason="order_submitted",
+                    candidate_count=len(valid_snapshots) if "valid_snapshots" in locals() else None,
+                    candidate_rejects=getattr(self._trade_candidate_selector, "_last_rejects", {}),
+                    selected_candidate=base_symbol,
+                    strategy_allowed=True,
+                    risk_allowed=True,
+                    order_submitted=True,
+                )
                 return SignalExecutionResult(True, "order_submitted", order_id=order_id, details={"trace_id": trace_id})
             else:
                 deterministic_rejections = {
@@ -13469,6 +13552,17 @@ class StrategyRunner:
                 )
                 log_throttled(self._logger, f"runner_order_rejected_{base_symbol}", "ORDER_REJECTED by order_manager", interval_sec=300.0, level=logging.WARNING, extra={"event": "ORDER_REJECTED", "symbol": base_symbol})
                 self._reset_execution_state(base_symbol)
+                self._record_trade_decision_snapshot(
+                    symbol=base_symbol,
+                    direction=option_side,
+                    final_reason=submit_reason,
+                    candidate_count=len(valid_snapshots) if "valid_snapshots" in locals() else None,
+                    candidate_rejects=getattr(self._trade_candidate_selector, "_last_rejects", {}),
+                    selected_candidate=base_symbol,
+                    strategy_allowed=True,
+                    risk_allowed=False,
+                    order_submitted=False,
+                )
                 return SignalExecutionResult(False, submit_reason, details=submit_details)
 
         except Exception as exc:

--- a/tests/notifications/test_operator_telegram.py
+++ b/tests/notifications/test_operator_telegram.py
@@ -187,3 +187,144 @@ async def test_handler_exception_logs_structured_error(caplog: pytest.LogCapture
 
     assert update.effective_message.replies == ["ERROR: RuntimeError: boom"]
     assert "TELEGRAM_COMMAND_HANDLER_ERROR command=boom error_type=RuntimeError error=boom" in caplog.text
+
+
+EXPECTED_OPERATOR_COMMANDS = (
+    "start",
+    "help",
+    "ping",
+    "status",
+    "health",
+    "diag",
+    "why",
+    "check",
+    "check_connectivity",
+    "check_market",
+    "check_core",
+    "check_execution",
+    "errors",
+    "stderror",
+    "selftest",
+    "emergency",
+)
+
+
+def test_registered_command_names_equal_expected_set() -> None:
+    assert OPERATOR_COMMAND_NAMES == EXPECTED_OPERATOR_COMMANDS
+    assert OPERATOR_COMMAND_NAMES.count("check_execution") == 1
+
+
+@pytest.mark.asyncio
+async def test_why_includes_diagnostic_sections() -> None:
+    app = FakeApp()
+    runner = SimpleNamespace(
+        _trade_candidate_selector=SimpleNamespace(_last_rejects={"cost_edge_insufficient": 2}),
+        last_signal_reason="adx_hard_gate",
+    )
+    risk = SimpleNamespace(_last_rejection="MAX_TRADES:3/3", settings=SimpleNamespace(max_trades_per_day=3))
+    order = SimpleNamespace(_last_skip_reason="order_preflight_rejected")
+    service = SimpleNamespace(
+        chat_id=12345,
+        deps=SimpleNamespace(
+            bot_context=SimpleNamespace(
+                market_open=True,
+                live_orders_armed=False,
+                live_block_reason="live_orders_not_armed",
+                selected_ce="NIFTY24JUN24000CE",
+                selected_pe="NIFTY24JUN24000PE",
+                data_hard_ready=True,
+                evaluation_ready=True,
+                selected_ce_exec_ready=False,
+                selected_pe_exec_ready=True,
+            ),
+            strategy_runner=runner,
+            risk_manager=risk,
+            order_manager=order,
+            broker_client=SimpleNamespace(is_connected=True),
+        ),
+    )
+    register_operator_commands(app, service)  # type: ignore[arg-type]
+    update = DummyUpdate(text="/why")
+
+    await _handler(app, "why").callback(update, DummyContext())  # type: ignore[arg-type]
+
+    reply = update.effective_message.replies[-1]
+    assert "Why no trade?" in reply
+    assert "readiness:" in reply
+    assert "strategy:" in reply
+    assert "discipline:" in reply
+    assert "execution:" in reply
+    assert "final_reason: live_orders_not_armed" in reply
+    assert "candidate_rejects: cost_edge_insufficient=2" in reply
+
+
+@pytest.mark.asyncio
+async def test_check_execution_includes_readiness_blockers() -> None:
+    app = FakeApp()
+    service = SimpleNamespace(
+        chat_id=12345,
+        deps=SimpleNamespace(
+            bot_context=SimpleNamespace(
+                live_orders_armed=False,
+                live_block_reason="hydration_quote_depth_not_ready",
+                execution_block_reason="broker_unavailable",
+                selected_ce_exec_ready=False,
+                selected_pe_exec_ready=False,
+                broker_ready=False,
+            ),
+            order_manager=SimpleNamespace(_last_skip_reason="selected_option_bid_ask_missing"),
+            risk_manager=SimpleNamespace(_breaker_tripped=True, _last_rejection="BREAKER"),
+        ),
+    )
+    register_operator_commands(app, service)  # type: ignore[arg-type]
+    update = DummyUpdate(text="/check_execution")
+
+    await _handler(app, "check_execution").callback(update, DummyContext())  # type: ignore[arg-type]
+
+    reply = update.effective_message.replies[-1]
+    assert "live_block_reason: hydration_quote_depth_not_ready" in reply
+    assert "execution_block_reason: broker_unavailable" in reply
+    assert "selected_ce_exec_ready: BLOCKED" in reply
+    assert "selected_pe_exec_ready: BLOCKED" in reply
+
+
+@pytest.mark.asyncio
+async def test_diagnostic_handlers_do_not_crash_with_missing_dependencies() -> None:
+    app = FakeApp()
+    service = SimpleNamespace(chat_id=12345)
+    register_operator_commands(app, service)  # type: ignore[arg-type]
+
+    for command in ("why", "check_execution", "check_market", "check_core"):
+        update = DummyUpdate(text=f"/{command}")
+        await _handler(app, command).callback(update, DummyContext())  # type: ignore[arg-type]
+        assert update.effective_message.replies
+        assert not update.effective_message.replies[-1].startswith("ERROR:")
+
+
+@pytest.mark.asyncio
+async def test_diagnostic_handlers_remain_read_only() -> None:
+    app = FakeApp()
+
+    def forbidden(*_: Any, **__: Any) -> None:
+        raise AssertionError("mutating method must not be called")
+
+    order = SimpleNamespace(
+        consume_skip_reason=forbidden,
+        place_order=forbidden,
+        cancel_order=forbidden,
+        _last_skip_reason="preflight_block",
+    )
+    service = SimpleNamespace(
+        chat_id=12345,
+        deps=SimpleNamespace(
+            bot_context=SimpleNamespace(selected_ce="CE", selected_pe="PE"),
+            order_manager=order,
+            risk_manager=SimpleNamespace(_last_rejection="risk_block"),
+        ),
+    )
+    register_operator_commands(app, service)  # type: ignore[arg-type]
+
+    for command in ("why", "check_execution"):
+        update = DummyUpdate(text=f"/{command}")
+        await _handler(app, command).callback(update, DummyContext())  # type: ignore[arg-type]
+        assert "preflight_block" in update.effective_message.replies[-1]


### PR DESCRIPTION
### Motivation
- Operators need richer, production-grade diagnostics for "why no trade" and execution readiness because the prior `/why` returned only a single reason and obscured readiness/data/strategy/discipline/risk/execution blockers.
- Changes must be read-only, exception-safe, and must not modify trading logic, strategy thresholds, or execution safety.

### Description
- Extended `src/nifty_scalper_bot/notifications/operator_telegram.py` with a robust `_runtime_snapshot` that probes context, MDM/DataHub, runner/strategy_manager, risk, order, position/bracket managers, websocket, selected CE/PE quotes, tick ages, and hydration bar counts using exception-safe helpers like `_safe_call`, `_obj_to_dict`, `_symbol_metric`, and compact renderers.
- Reworked `/why` to return a structured, compact diagnostic containing `final_reason`, `readiness`, `data`, `strategy`, `discipline`, and `execution` sections, and enhanced `cmd_check_market`, `cmd_check_core`, and `cmd_check_execution` to include the additional readiness, quote/hydration, regime/ADX/ORB, expiry/midday, and risk/order diagnostics without adding duplicate commands.
- Added a diagnostic-only `TradeDecisionSnapshot` and `LAST_TRADE_DECISION_SNAPSHOT` in `src/nifty_scalper_bot/strategies/runner.py` plus a best-effort `_record_trade_decision_snapshot` call-path that updates the snapshot on signal rejection and order submission/rejection paths; snapshot failures are logged and do not affect trading.
- Tests updated/added in `tests/notifications/test_operator_telegram.py` to assert the operator command registry is exact, `/why` contains the required sections, `/check_execution` surfaces readiness blockers, handlers tolerate missing dependencies, and diagnostic handlers remain read-only.

### Testing
- Ran `python -m compileall -q src` which passed successfully.
- Ran focused tests `PYTHONPATH=src pytest -q tests/notifications tests/core tests/strategies tests/risk tests/execution` and all tests passed.
- Ran full test suite `PYTHONPATH=src pytest -q` and it completed with all tests passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a29962167c08324953f1fe8bd8561ec)