### PR TITLE
Add option-native signal scoring (IV/OI/depth) and RSI divergence noise filter

### DIFF
--- a/src/nifty_scalper_bot/strategies/elite_strategies/rsi_divergence.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/rsi_divergence.py
@@ -44,6 +44,11 @@ class RSIDivergenceStrategy(EliteStrategy):
 
             p1, r1 = hist[-4]
             p2, r2 = hist[-1]
+            # Noise filter: a divergence needs a real price displacement,
+            # not a few-tick wiggle, or every flat patch becomes a "signal".
+            if abs(p2 - p1) < 0.25 * atr:
+                self._no_vote('price_move_too_small')
+                return None
             bullish_div = p2 < p1 and r2 > r1
             bearish_div = p2 > p1 and r2 < r1
             if not bullish_div and not bearish_div:

--- a/src/nifty_scalper_bot/strategies/option_signal.py
+++ b/src/nifty_scalper_bot/strategies/option_signal.py
@@ -1,0 +1,101 @@
+"""Option-native candidate scoring: IV richness, OI buildup, depth imbalance.
+
+All current strategy signals read the underlying price series. This module
+adds the option-specific information that actually differentiates option
+trades: whether the premium is expensive (IV), whether positioning supports
+the move (open-interest buildup), and whether the order book leans with the
+trade (bid/ask depth imbalance).
+
+Design: one pure scoring function plus a tiny module-level OI cache. Every
+input is optional — missing data contributes nothing, so the scorer can
+never block trading or crash on sparse feeds.
+
+Env overrides:
+- OPTION_SIGNAL_ENABLED   (default true)
+- OPTION_IV_RICH          (default 0.60: IV above this is penalized)
+- OPTION_IV_CHEAP         (default 0.30: IV below this is rewarded)
+- OPTION_DEPTH_IMBALANCE  (default 1.5: bid/ask qty ratio for support)
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from nifty_scalper_bot.config.env_utils import parse_bool_env, parse_float_env
+
+# prior OI per symbol within this process; small and self-pruning
+_PRIOR_OI: dict[str, float] = {}
+_MAX_CACHE = 64
+
+
+def _f(value: Any) -> float | None:
+    try:
+        out = float(value)
+    except (TypeError, ValueError):
+        return None
+    return out if out == out else None  # reject NaN
+
+
+def _depth_totals(depth: Any) -> tuple[float, float]:
+    """Args: kite-style depth dict. Returns: (total_bid_qty, total_ask_qty)."""
+    if not isinstance(depth, dict):
+        return 0.0, 0.0
+    bid_qty = sum(_f(level.get("quantity")) or 0.0 for level in depth.get("buy") or [] if isinstance(level, dict))
+    ask_qty = sum(_f(level.get("quantity")) or 0.0 for level in depth.get("sell") or [] if isinstance(level, dict))
+    return bid_qty, ask_qty
+
+
+def score_option_candidate(symbol: str, metrics: dict[str, Any] | None) -> tuple[float, list[str]]:
+    """Args: option symbol, DataHub.get_option_metrics payload (or None).
+    Returns: (score_delta in [-1.5, +1.5], reasons). Raises: none.
+    """
+    if not parse_bool_env(os.getenv("OPTION_SIGNAL_ENABLED"), True):
+        return 0.0, ["option_signal_disabled"]
+    if not metrics:
+        return 0.0, ["option_metrics_unavailable"]
+
+    delta = 0.0
+    reasons: list[str] = []
+
+    iv = _f(metrics.get("iv"))
+    if iv is not None and iv > 0:
+        iv_rich = parse_float_env(os.getenv("OPTION_IV_RICH"), 0.60)
+        iv_cheap = parse_float_env(os.getenv("OPTION_IV_CHEAP"), 0.30)
+        if iv >= iv_rich:
+            delta -= 1.0
+            reasons.append(f"iv_rich_{iv:.2f}")
+        elif iv <= iv_cheap:
+            delta += 0.5
+            reasons.append(f"iv_reasonable_{iv:.2f}")
+
+    oi = _f(metrics.get("oi"))
+    if oi is not None and oi > 0:
+        prior = _PRIOR_OI.get(symbol)
+        if prior is not None and prior > 0:
+            change = (oi - prior) / prior
+            if change >= 0.01:
+                delta += 0.5
+                reasons.append("oi_buildup")
+            elif change <= -0.01:
+                delta -= 0.25
+                reasons.append("oi_unwinding")
+        _PRIOR_OI[symbol] = oi
+        if len(_PRIOR_OI) > _MAX_CACHE:
+            for stale in list(_PRIOR_OI)[: len(_PRIOR_OI) - _MAX_CACHE]:
+                _PRIOR_OI.pop(stale, None)
+
+    bid_qty, ask_qty = _depth_totals(metrics.get("depth"))
+    if bid_qty > 0 and ask_qty > 0:
+        ratio_min = parse_float_env(os.getenv("OPTION_DEPTH_IMBALANCE"), 1.5)
+        ratio = bid_qty / ask_qty
+        if ratio >= ratio_min:
+            delta += 0.5
+            reasons.append("depth_buy_support")
+        elif ratio <= 1.0 / ratio_min:
+            delta -= 0.5
+            reasons.append("depth_sell_pressure")
+
+    if not reasons:
+        reasons.append("option_neutral")
+    return max(-1.5, min(1.5, delta)), reasons

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -807,7 +807,9 @@ class StrategyRunner:
         self._execution_totals: Dict[str, Dict[str, int]] = defaultdict(
             lambda: {"success": 0, "error": 0}
         )
-        self._trade_candidate_selector = TradeCandidateSelector()
+        self._trade_candidate_selector = TradeCandidateSelector(
+            option_metrics_getter=getattr(self._data_hub, "get_option_metrics", None)
+        )
         self._trade_counter_by_symbol_candle: Dict[str, dict] = {}
         self._settings = get_settings()
         try:

--- a/src/nifty_scalper_bot/strategies/trade_selector.py
+++ b/src/nifty_scalper_bot/strategies/trade_selector.py
@@ -10,6 +10,7 @@ from typing import Any
 from nifty_scalper_bot.config.env_utils import parse_int_env
 from nifty_scalper_bot.risk.cost_model import passes_cost_edge_gate
 from nifty_scalper_bot.risk.expiry_gate import expiry_theta_block, midday_pause_block
+from nifty_scalper_bot.strategies.option_signal import score_option_candidate
 from nifty_scalper_bot.utils.logging import get_logger, log_once_or_throttled
 
 LOGGER = get_logger(__name__)
@@ -43,8 +44,9 @@ class TradeCandidate:
 
 
 class TradeCandidateSelector:
-    def __init__(self, *, quality_mode: str = 'normal', option_strike_window_each_side: int = 2, min_option_premium: float | None = None, max_option_premium: float | None = None, max_tick_age_s: float | None = None, max_option_spread_pct: float | None = None, require_real_ticks_last_60s: int | None = None) -> None:
+    def __init__(self, *, quality_mode: str = 'normal', option_strike_window_each_side: int = 2, min_option_premium: float | None = None, max_option_premium: float | None = None, max_tick_age_s: float | None = None, max_option_spread_pct: float | None = None, require_real_ticks_last_60s: int | None = None, option_metrics_getter: Any | None = None) -> None:
         self.quality_mode = quality_mode
+        self.option_metrics_getter = option_metrics_getter if callable(option_metrics_getter) else None
         self.option_strike_window_each_side = option_strike_window_each_side
         self.min_option_premium = float(min_option_premium if min_option_premium is not None else os.getenv('MIN_OPTION_PREMIUM', '40'))
         self.max_option_premium = float(max_option_premium if max_option_premium is not None else os.getenv('MAX_OPTION_PREMIUM', '650'))
@@ -208,6 +210,14 @@ class TradeCandidateSelector:
             score = 6.0 + liquidity * 0.2 + micro * 0.2 - atm_distance * 0.5 - score_penalty
             dq = self.evaluate_data_quality(s)
             final = max(0.0, min(10.0, 0.7 * score + 0.3 * dq.score))
+            if self.option_metrics_getter is not None:
+                try:
+                    opt_delta, opt_reasons = score_option_candidate(symbol, self.option_metrics_getter(symbol))
+                except Exception:
+                    opt_delta, opt_reasons = 0.0, ['option_metrics_error']
+                if opt_delta:
+                    final = max(0.0, min(10.0, final + opt_delta))
+                reasons.extend(opt_reasons)
             ranked.append(TradeCandidate(symbol=symbol, side=side, score=final, reasons=reasons, spread_pct=spread_pct, tick_age_s=tick_age_s, premium=premium, atm_distance=atm_distance, data_quality_score=dq.score, entry_price=entry, stop_loss=sl, target=target, rr=rr, liquidity_score=liquidity, microstructure_score=micro, final_score=final))
         sorted_ranked = sorted(ranked, key=lambda c: c.final_score or 0.0, reverse=True)
         self._last_rejects = dict(rejects)

--- a/tests/strategies/test_option_signal.py
+++ b/tests/strategies/test_option_signal.py
@@ -1,0 +1,60 @@
+"""Tests for the option-native candidate scorer."""
+
+from __future__ import annotations
+
+from nifty_scalper_bot.strategies.option_signal import (
+    _PRIOR_OI,
+    score_option_candidate,
+)
+
+
+def setup_function() -> None:
+    _PRIOR_OI.clear()
+
+
+def test_missing_metrics_is_neutral() -> None:
+    delta, reasons = score_option_candidate("NIFTY26JUN25000CE", None)
+    assert delta == 0.0 and reasons == ["option_metrics_unavailable"]
+
+
+def test_rich_iv_penalized_cheap_iv_rewarded() -> None:
+    delta, reasons = score_option_candidate("SYM1CE", {"iv": 0.75})
+    assert delta == -1.0 and any("iv_rich" in r for r in reasons)
+    delta, reasons = score_option_candidate("SYM2CE", {"iv": 0.22})
+    assert delta == 0.5 and any("iv_reasonable" in r for r in reasons)
+
+
+def test_oi_buildup_rewarded_on_second_observation() -> None:
+    d1, _ = score_option_candidate("SYM3CE", {"oi": 100000})
+    assert d1 == 0.0  # first sight: no prior
+    d2, reasons = score_option_candidate("SYM3CE", {"oi": 105000})
+    assert d2 == 0.5 and "oi_buildup" in reasons
+    d3, reasons = score_option_candidate("SYM3CE", {"oi": 100000})
+    assert d3 == -0.25 and "oi_unwinding" in reasons
+
+
+def test_depth_imbalance() -> None:
+    depth = {"buy": [{"quantity": 3000}], "sell": [{"quantity": 1000}]}
+    delta, reasons = score_option_candidate("SYM4CE", {"depth": depth})
+    assert delta == 0.5 and "depth_buy_support" in reasons
+    depth = {"buy": [{"quantity": 1000}], "sell": [{"quantity": 3000}]}
+    delta, reasons = score_option_candidate("SYM5CE", {"depth": depth})
+    assert delta == -0.5 and "depth_sell_pressure" in reasons
+
+
+def test_delta_clamped_and_disable_env(monkeypatch) -> None:
+    score_option_candidate("SYM6CE", {"oi": 100000})
+    delta, _ = score_option_candidate(
+        "SYM6CE",
+        {"iv": 0.20, "oi": 110000,
+         "depth": {"buy": [{"quantity": 5000}], "sell": [{"quantity": 1000}]}},
+    )
+    assert delta == 1.5  # 0.5+0.5+0.5 clamped at +1.5
+    monkeypatch.setenv("OPTION_SIGNAL_ENABLED", "false")
+    delta, reasons = score_option_candidate("SYM6CE", {"iv": 0.9})
+    assert delta == 0.0 and reasons == ["option_signal_disabled"]
+
+
+def test_malformed_inputs_never_raise() -> None:
+    delta, _ = score_option_candidate("SYM7CE", {"iv": "bad", "oi": object(), "depth": "junk"})
+    assert delta == 0.0


### PR DESCRIPTION
## What
### 1. Option-native signal module (strategies/option_signal.py)
First option-specific scoring layer — all prior signals read only the underlying price series. Pure function score_option_candidate adjusts candidate ranking [-1.5, +1.5] using:
- **IV richness**: IV >= 0.60 penalized -1.0 (expensive premium needs a bigger move); IV <= 0.30 rewarded +0.5
- **OI buildup**: rising open interest on the candidate (+0.5) vs unwinding (-0.25), via a small in-process prior-OI cache
- **Depth imbalance**: total bid-qty vs ask-qty from market depth; buy-side support +0.5, sell pressure -0.5
Every input optional; missing/malformed data is a guaranteed no-op (never blocks, never raises). Env: OPTION_SIGNAL_ENABLED, OPTION_IV_RICH, OPTION_IV_CHEAP, OPTION_DEPTH_IMBALANCE.

### 2. Wiring (minimal)
TradeCandidateSelector takes an optional option_metrics_getter; runner injects DataHub.get_option_metrics (already returns oi/iv/depth). Default None = identical legacy behavior. Reasons (iv_rich_0.72, oi_buildup, depth_buy_support...) appear in candidate logs for transparency.

### 3. Audit fix: RSI Divergence noise filter
Divergence detection compared raw closes 4 bars apart with no displacement floor — few-tick wiggles registered as divergences. Now requires |price move| >= 0.25*ATR (no_vote: price_move_too_small).

## Audit note (documented, deliberately not changed)
Several elite strategies add an unconditional +2.0 'clean_rr'/'rr_viable' score bonus without computing RR. It is a uniform calibration constant; removing it live would shift all votes below pass thresholds. Flagged for recalibration during the planned cost-aware backtesting phase.

## Validation
616 tests passed, 0 failures (full risk + strategies + consensus suites, incl. live-path guards and runner-selector integration). 6 new option-signal tests covering IV/OI/depth paths, clamping, env disable, and malformed-input safety.