### PR TITLE
Replace flat +2.0 score bonuses with real measured quality grades

### DIFF
--- a/src/nifty_scalper_bot/strategies/elite_strategies/bb_squeeze.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/bb_squeeze.py
@@ -72,8 +72,17 @@ class BBSqueezeStrategy(EliteStrategy):
             if momentum_confirmed:
                 score += 1.0
                 reasons.append('volume_confirmation')
-            score += 2.0
-            reasons.append('clean_rr')
+            # Tighter squeezes store more energy: grade by width vs threshold
+            effective_threshold = max(squeeze_threshold, 0.008)
+            tightness = bb_width / effective_threshold
+            if tightness <= 0.6:
+                score += 2.0
+                reasons.append('squeeze_very_tight')
+            elif tightness <= 0.85:
+                score += 1.0
+                reasons.append('squeeze_tight')
+            else:
+                reasons.append('squeeze_marginal')
 
             strategy_score = max(0.0, min(10.0, score))
             metadata = {

--- a/src/nifty_scalper_bot/strategies/elite_strategies/cpr_breakout.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/cpr_breakout.py
@@ -72,8 +72,15 @@ class CPRBreakoutStrategy(EliteStrategy):
             if nearest_level_distance >= atr:
                 score += 2.0
                 reasons.append('adequate_distance_to_next_level')
-            score += 2.0
-            reasons.append('candidate_quality')
+            # Grade breakout momentum by ATR-normalized penetration beyond CPR
+            if breakout_quality >= 1.0:
+                score += 2.0
+                reasons.append(f'momentum_strong_{breakout_quality:.1f}')
+            elif breakout_quality >= 0.6:
+                score += 1.0
+                reasons.append(f'momentum_moderate_{breakout_quality:.1f}')
+            else:
+                reasons.append(f'momentum_weak_{breakout_quality:.1f}')
 
             strategy_score = max(0.0, min(10.0, score))
             metadata = {

--- a/src/nifty_scalper_bot/strategies/elite_strategies/orb_pro.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/orb_pro.py
@@ -91,8 +91,18 @@ class ORBProStrategy(EliteStrategy):
             if vol_tick:
                 score += 1.0
                 reasons.append('volume_or_tick_confirmation')
-            score += 2.0
-            reasons.append('clean_rr')
+            # Real RR from the actual stop (range invalidation) and target (2*ATR)
+            stop_level = orb_low if breakout_side == 'CE' else orb_high
+            risk = abs(close - stop_level)
+            rr = (2.0 * atr) / risk if risk > 1e-9 else 0.0
+            if rr >= 1.8:
+                score += 2.0
+                reasons.append(f'rr_strong_{rr:.1f}')
+            elif rr >= 1.2:
+                score += 1.0
+                reasons.append(f'rr_acceptable_{rr:.1f}')
+            else:
+                reasons.append(f'rr_thin_{rr:.1f}')
 
             strategy_score = max(0.0, min(10.0, score))
             metadata = {

--- a/src/nifty_scalper_bot/strategies/elite_strategies/rsi_divergence.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/rsi_divergence.py
@@ -82,8 +82,16 @@ class RSIDivergenceStrategy(EliteStrategy):
             if direction in {'CE', 'PE'} and direction == side:
                 score += 1.0
                 reasons.append('direction_context')
-            score += 2.0
-            reasons.append('rr_viable')
+            # Grade by RSI displacement: bigger divergence = stronger reversal evidence
+            rsi_delta = abs(r2 - r1)
+            if rsi_delta >= 5.0:
+                score += 2.0
+                reasons.append(f'divergence_strong_{rsi_delta:.1f}')
+            elif rsi_delta >= 2.5:
+                score += 1.0
+                reasons.append(f'divergence_moderate_{rsi_delta:.1f}')
+            else:
+                reasons.append(f'divergence_weak_{rsi_delta:.1f}')
 
             strategy_score = max(0.0, min(10.0, score))
             if strategy_score < 3.5:


### PR DESCRIPTION
## Verdict from full scoring-chain review
The architecture (0-10 multi-factor strategy votes with named reasons -> adaptive consensus weighting -> runner composite -> ranked selection with option-native delta and hard gates) is sound and KEPT. The defect was in vote arithmetic: four strategies awarded a flat +2.0 measuring nothing ('clean_rr', 'rr_viable', 'candidate_quality'), compressing score dispersion so weak setups scored 5-6 instead of 3-4 — leaking marginal trades past thresholds and corrupting the adaptive weighting that learns from these scores.

## What changed — each flat bonus replaced by a real quantity the strategy already computes
- **ORBPro**: actual risk-reward from the real stop (range invalidation) and target (2*ATR): rr>=1.8 -> +2 (rr_strong), >=1.2 -> +1 (rr_acceptable), else 0 (rr_thin)
- **BBSqueeze**: squeeze tightness (bb_width / threshold): <=0.6 -> +2 (squeeze_very_tight), <=0.85 -> +1, else 0 (marginal)
- **RSIDivergence**: RSI displacement magnitude: >=5.0 -> +2 (divergence_strong), >=2.5 -> +1, else 0 (weak)
- **CPRBreakout**: ATR-normalized penetration beyond CPR: >=1.0 -> +2 (momentum_strong), >=0.6 -> +1, else 0 (weak)

## Calibration safety
Strong setups score exactly as before (no regression in what passes at full quality). Weak setups now score up to 2 points lower — restoring dispersion. RSIDivergence internal cutoff (3.5) remains below its base score (4.0), so no previously-valid divergence is newly hard-blocked; quality differentiation happens downstream where it belongs. All graded reasons appear in logs with their measured values (e.g. rr_strong_2.3) for auditability.

## Validation
639 tests passed, 0 failures (full risk + strategies + consensus + elite suites).