### PR TITLE
Promote ORBPro and BBSqueeze to production directional roster

### DIFF
--- a/src/nifty_scalper_bot/strategies/elite_strategies/builder.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/builder.py
@@ -28,7 +28,7 @@ from nifty_scalper_bot.utils.logging import get_logger
 
 LOGGER = get_logger(__name__)
 
-_PRODUCTION_DIRECTIONAL = {'smc', 'vwap', 'order_flow'}
+_PRODUCTION_DIRECTIONAL = {'smc', 'vwap', 'order_flow', 'orb', 'bb_squeeze'}
 _CONTEXT_ONLY = {'oi_max_pain'}
 _DISABLED_UNTIL_FEATURE_COMPLETE = {'cpr', 'rsi_div'}
 _EXPIRY_ONLY = {'gamma_scalping', 'tuesday_gamma_buyer'}


### PR DESCRIPTION
## Roster decision (full elite-strategy review)
In directional_scalp mode only SMC, VWAPPro, OrderFlow (+OIMaxPain context) were live. This PR promotes **ORBPro** and **BBSqueeze** into _PRODUCTION_DIRECTIONAL.

**Why these two**: ORBPro is the best-evidenced intraday edge class (time-anchored opening volatility) and now carries once-per-direction-per-day discipline (#550) and real computed-RR grading (#553). BBSqueeze covers a setup class the current trio lacks — volatility contraction-to-expansion — and now grades squeeze tightness honestly (#553). Roster becomes 5 complementary triggers: structure (SMC), continuation (VWAPPro), flow (OrderFlow), time-anchored breakout (ORBPro), volatility expansion (BBSqueeze) + OI context.

**Deliberate non-changes**: CPR/RSIDivergence remain experimental-gated (env-promotable). Gamma/straddle remain mode-gated. Orphaned trend_momentum.py NOT registered (naive logic, ambiguous domain). No new strategies added — more correlated triggers means noise, not edge. BBSqueeze deliberately NOT added to the ADX regime gate tags: squeezes form in low-ADX ranges; gating them there would disable the strategy exactly when its setup occurs.

## Validation
Roster build verified in directional_scalp mode: active = [BBSqueeze, ORBPro, OrderFlow, SMC, VWAPPro]. 642 tests passed, 0 failures (risk + strategies + consensus + elite/builder suites).