### PR TITLE
Fix: context strikes no longer disarm execution; prewarm targets true bar requirement

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -8182,7 +8182,28 @@ async def _recompute_and_push_runtime_readiness(ctx: BotContext, *, reason: str)
     futures_status = _status_for_role(statuses, "futures_context")
     ce_status = _status_for_role(statuses, "selected_ce")
     pe_status = _status_for_role(statuses, "selected_pe")
-    status_blockers = list(dict.fromkeys([reason for status in statuses.values() for reason in status.blocker_reasons]))
+    # Only roles the bot actually trades or requires for direction may disarm
+    # execution. option_context strikes feed OI/IV context; if they are cold
+    # they must degrade context, never block trading on the ready ATM pair.
+    _execution_gating_roles = {"spot", "futures_context", "selected_ce", "selected_pe"}
+    status_blockers = list(dict.fromkeys([
+        reason
+        for status in statuses.values()
+        if getattr(status, "role", "") in _execution_gating_roles
+        for reason in status.blocker_reasons
+    ]))
+    context_only_blockers = list(dict.fromkeys([
+        reason
+        for status in statuses.values()
+        if getattr(status, "role", "") not in _execution_gating_roles
+        for reason in status.blocker_reasons
+    ]))
+    if context_only_blockers:
+        LOGGER.info(
+            "CONTEXT_SYMBOL_BLOCKERS_NON_GATING blockers=%s",
+            context_only_blockers,
+            extra={"event": "CONTEXT_SYMBOL_BLOCKERS_NON_GATING", "blockers": context_only_blockers},
+        )
     hydration_hard_blockers = [
         blocker for blocker in status_blockers
         if not (blocker.endswith("_quote_missing") or blocker.endswith("_depth_missing") or blocker == "spread_too_wide" or blocker.endswith("_token_missing") or blocker == "option_token_missing")

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -1623,17 +1623,23 @@ class StrategyRunner:
                 symbols.append(normalized)
         required = max(self._option_required_bars, safe_positive_int_env("OPTION_EXECUTION_MIN_BARS", 5, minimum=1))
         for option_symbol in symbols:
+            # Sync to the symbol's true readiness requirement, not just the
+            # execution minimum. With a 5-bar target the cache sync fetched 5
+            # bars from an MDM holding 50+, leaving dynamically added strikes
+            # permanently below the 30/50-bar readiness threshold (the rearm
+            # loop retried forever without ever closing the gap).
+            symbol_required = max(required, int(self._required_bars_for_symbol(option_symbol) or 0))
             before = self._sync_history_from_mdm_cache(
                 option_symbol,
-                required_bars=required,
+                required_bars=symbol_required,
                 source=f"{source}_option_cache_sync",
                 request_if_short=False,
             )
-            if before < required:
+            if before < symbol_required:
                 self._request_selected_option_history_prewarm(
                     option_symbol,
                     bars_before=before,
-                    required_bars=required,
+                    required_bars=symbol_required,
                     trace_id=trace_id,
                 )
 


### PR DESCRIPTION
## Live incident fix (from 2026-06-11 logs)
After a dynamic basket refresh added far strikes (23150/23450), three context-only symbols stayed at 6-8 runner bars while MDM held 50+. Their history blockers (option_context_history_missing, insufficient_bars, runner_bars_missing, indicator_bars_missing) flipped basket_hard_ready=False, which disarmed live orders (execution_not_armed:selected_option_history_cold) even though the selected ATM CE/PE were fully ready (60 bars, fresh ticks, depth, tradable quotes). Bot was frozen from 12:44:50 onward.

## Fix 1 — core/app.py: scope execution arming to gating roles
Hard blockers are now aggregated only from roles the bot actually trades or needs for direction: spot, futures_context, selected_ce, selected_pe. option_context strikes feed OI/IV context — if cold they degrade context, never disarm execution. Their blockers are still logged via new CONTEXT_SYMBOL_BLOCKERS_NON_GATING event for visibility.

## Fix 2 — strategies/runner.py: prewarm to the true bar requirement
_prewarm_active_option_history synced cache history with a 5-bar target (OPTION_EXECUTION_MIN_BARS), so the sync fetched only 5 of MDM's 50+ bars and could never satisfy the 30/50-bar readiness threshold — the rearm loop retried forever without closing the gap. The sync now targets max(execution_min, _required_bars_for_symbol(symbol)), making each rearm pass pull the full requirement from MDM and self-heal cold dynamically-added strikes.

## Validation
898 tests passed, 0 failures: full risk + strategies + consensus suites (616) plus all readiness/hydration/app suites (282).