### PR TITLE
CPU optimization: eval cap, midday idle skip, log demotion, hydration cooldown, metrics

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -7737,7 +7737,7 @@ def build_symbol_hydration_status(
         last_bar_ts=max(timestamps) if timestamps else None,
         live_merge_applied=bool(mdm_bars and datahub_bars and (mdm_bars == datahub_bars)),
     )
-    LOGGER.info(
+    LOGGER.debug(
         "HYDRATION_PROPAGATION_RESULT symbol=%s role=%s required_bars=%s mdm_bars=%s datahub_bars=%s runner_bars=%s indicator_bars=%s tradable_quote=%s depth_available=%s ready_for_evaluation=%s ready_for_execution=%s blockers=%s",
         status.symbol,
         status.role,

--- a/src/nifty_scalper_bot/core/strategy_manager.py
+++ b/src/nifty_scalper_bot/core/strategy_manager.py
@@ -3165,7 +3165,7 @@ class StrategyManager(_BaseStrategyManager):
                     if should_emit_diag:
                         last_diag_map[symbol] = now
                         self._smc_history_diag_last_emitted = last_diag_map
-                        log.info(
+                        log.debug(
                             "SMC_HISTORY_INPUT_DIAGNOSTICS symbol=%s eval_id=%s history_domain_used=%s history_count=%s history_resolved_count=%s option_history_count=%s",
                             symbol,
                             eval_id,
@@ -3243,7 +3243,7 @@ class StrategyManager(_BaseStrategyManager):
             )
 
         if no_vote_reason_counts:
-            log.info(
+            log.debug(
                 "STRATEGY_NO_VOTE_SUMMARY symbol=%s eval_id=%s no_vote_reason_counts=%s strategy_reasons=%s trigger_vote_count=%s context_vote_count=%s final_block_reason=%s",
                 symbol,
                 eval_id,
@@ -3707,7 +3707,7 @@ class StrategyManager(_BaseStrategyManager):
         if combined_md.get("selected_ok_reason"):
             selected_ok_reason = str(combined_md.get("selected_ok_reason"))
             selected_ok = selected_ok_reason != "not_selected_or_near_atm"
-        log.info(
+        log.debug(
             "STRATEGY_COMBINER_BLOCKER symbol=%s strategy_vote_count=%s trigger_vote_count=%s context_vote_count=%s best_strategy=%s best_score=%s best_confidence=%s single_vote_allowed=%s selected_ok=%s selected_ok_reason=%s final_trade_score=%s final_trade_threshold=%s blocked_reason=%s",
             symbol,
             len(signal_votes),

--- a/src/nifty_scalper_bot/strategies/elite_strategies/smc_liquidity.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/smc_liquidity.py
@@ -234,7 +234,8 @@ class SMCStrategy(EliteStrategy):
                 f"smc_feature_readiness:{symbol}",
                 "SMC_FEATURE_READINESS symbol=%s feature_completeness=%.3f missing_features=%s missing_feature_sources=%s live_enabled=%s vote_allowed=%s hard_veto=%s",
                 symbol, feature_completeness, ",".join(missing_features), missing_feature_sources, is_live, feature_ready, False,
-                interval_sec=30.0,
+                interval_sec=60.0,
+                level=__import__("logging").DEBUG,
                 extra={"event": "SMC_FEATURE_READINESS", "symbol": symbol, "feature_completeness": feature_completeness, "missing_features": missing_features, "missing_feature_sources": missing_feature_sources, "live_enabled": is_live, "vote_allowed": feature_ready, "hard_veto": False})
             if option_premium_domain:
                 premium_reversal = bool(bullish_sweep or indicators.get('premium_reclaim') or indicators.get('bullish_reversal'))

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -82,6 +82,7 @@ from nifty_scalper_bot.execution.order_state_machine import (
 from nifty_scalper_bot.execution.position_manager import OrderSide, PositionManager
 from nifty_scalper_bot.options.strike_selector import SelectedContract, StrikeSelector
 from nifty_scalper_bot.risk import RiskManager
+from nifty_scalper_bot.risk.expiry_gate import midday_pause_block
 from nifty_scalper_bot.risk.position_sizing import (
     RiskManager as DeterministicRiskManager,
     RiskSnapshot,
@@ -749,7 +750,7 @@ class StrategyRunner:
         self._active_selection_drift_log_key: tuple[str | None, str | None, str | None, str | None, str | None] | None = None
         self._selected_option_prewarm_inflight: set[str] = set()
         self._selected_option_prewarm_last: dict[str, float] = {}
-        self._selected_option_prewarm_cooldown_s = max(1.0, float(os.getenv("SELECTED_OPTION_PREWARM_COOLDOWN_SECONDS", "45") or 45))
+        self._selected_option_prewarm_cooldown_s = max(1.0, parse_float_env(os.getenv("HYDRATION_RETRY_COOLDOWN_SECONDS") or os.getenv("SELECTED_OPTION_PREWARM_COOLDOWN_SECONDS"), 60.0))
         self._pending_selected_ce: str | None = None
         self._pending_selected_pe: str | None = None
         self._pending_atm_strike: int | None = None
@@ -2687,6 +2688,9 @@ class StrategyRunner:
             self._active_selected_pe = selected_pe_norm
         self._active_atm_strike = atm_value
         self._active_option_symbols = candidate_symbols
+        self._eval_option_whitelist = self._compute_eval_option_whitelist(
+            candidate_symbols, atm_value, selected_ce_norm or self._active_selected_ce, selected_pe_norm or self._active_selected_pe
+        )
         if promoted_from_pending:
             self._pending_selected_ce = None
             self._pending_selected_pe = None
@@ -6880,7 +6884,11 @@ class StrategyRunner:
             payload["trading_allowed"] = bool(payload.get("trading_allowed", allowed))
             payload["order_forwarding_allowed"] = bool(payload.get("order_forwarding_allowed", payload["trading_allowed"]))
             verbose_eval = str(os.getenv("LOG_VERBOSE_RUNNER_EVAL", "false")).strip().lower() in {"1", "true", "yes", "on"}
-            log_level = logging.DEBUG if ((not allowed) and reason_str == "strategy_eval_skipped_same_bar" and not verbose_eval) else logging.INFO
+            # CPU/log volume: routine eval decisions are DEBUG. INFO is reserved
+            # for actionable transitions (signal forwarded / blocked entry path).
+            _info_reasons = {"signal_forwarded", "evaluation_entered_first", "order_path_entered"}
+            verbose_all = str(os.getenv("RUNNER_EVAL_LOG_INFO", "false") or "false").strip().lower() in {"1", "true", "yes", "on"}
+            log_level = logging.INFO if (verbose_all or reason_str in _info_reasons or stage == "signal_forward") else logging.DEBUG
             log_throttled_live(
                 self._logger,
                 log_level,
@@ -7638,6 +7646,9 @@ class StrategyRunner:
         last_bar_key = (getattr(self, "_last_eval_bar_key_by_symbol", {}) or {}).get(symbol_norm)
         last_eval_at = float((getattr(self, "_last_periodic_eval_at_by_symbol", {}) or {}).get(symbol_norm, 0.0) or 0.0)
         interval = max(float(getattr(cfg, "same_bar_periodic_eval_seconds", 5.0) or 5.0), 3.0)
+        env_min_ms = parse_float_env(os.getenv("RUNNER_EVAL_MIN_INTERVAL_MS"), 0.0)
+        if env_min_ms > 0:
+            interval = max(interval, env_min_ms / 1000.0)
         elapsed = (now_mono - last_eval_at) if last_eval_at > 0 else None
         details: dict[str, Any] = {
             "bar_key": current_bar_key,
@@ -7650,8 +7661,96 @@ class StrategyRunner:
         }
         if last_bar_key == current_bar_key and last_eval_at > 0 and elapsed is not None and elapsed < interval:
             details["pregate_reason"] = "same_bar_periodic_eval_throttled"
+            self._bump_cpu_metric("skipped_by_eval_throttle")
             return True, "same_bar_periodic_eval_throttled", details
+        # CPU shortcut: during the midday pause with no open positions there is
+        # nothing a full strategy evaluation could lead to (entries blocked),
+        # so skip it entirely. Exit management and data health are untouched.
+        if self._midday_idle_skip_active():
+            details["pregate_reason"] = "midday_pause_idle_skip"
+            self._bump_cpu_metric("skipped_by_midday_pause")
+            return True, "midday_pause_idle_skip", details
+        # CPU cap: only evaluate the selected pair plus the nearest strikes up
+        # to MAX_LIVE_OPTION_SYMBOLS. Far context strikes still stream data
+        # (OI/IV context) but do not pay full strategy-evaluation cost.
+        whitelist = getattr(self, "_eval_option_whitelist", None)
+        if whitelist and symbol_norm.endswith(("CE", "PE")) and symbol_norm not in whitelist:
+            details["pregate_reason"] = "eval_capped_far_strike"
+            self._bump_cpu_metric("skipped_by_option_cap")
+            return True, "eval_capped_far_strike", details
+        self._bump_cpu_metric("evaluated_symbols")
         return False, "ok", details
+
+    def _compute_eval_option_whitelist(
+        self,
+        option_symbols: set[str] | None,
+        atm_strike: int | None,
+        selected_ce: str | None,
+        selected_pe: str | None,
+    ) -> set[str]:
+        """Args: basket options, atm, selected pair. Returns: symbols allowed full
+        strategy evaluation, capped at MAX_LIVE_OPTION_SYMBOLS (default 8) and
+        ranked by strike distance from ATM. Selected CE/PE always included.
+        Raises: none.
+        """
+        cap = parse_int_env(os.getenv("MAX_LIVE_OPTION_SYMBOLS"), 8)
+        symbols = {normalize_symbol(str(s)) for s in (option_symbols or set()) if s}
+        for sel in (selected_ce, selected_pe):
+            if sel:
+                symbols.add(normalize_symbol(str(sel)))
+        if cap <= 0 or len(symbols) <= cap:
+            return symbols
+        selected = {normalize_symbol(str(s)) for s in (selected_ce, selected_pe) if s}
+
+        def _distance(sym: str) -> float:
+            strike = self._extract_strike_from_symbol(sym)
+            if strike is None or atm_strike is None:
+                return float("inf")
+            return abs(float(strike) - float(atm_strike))
+
+        ranked = sorted(symbols - selected, key=_distance)
+        whitelist = set(selected)
+        for sym in ranked:
+            if len(whitelist) >= cap:
+                break
+            whitelist.add(sym)
+        return whitelist
+
+    def _midday_idle_skip_active(self) -> bool:
+        """Args: none. Returns: True when midday pause is on and no positions are open. Raises: none."""
+        try:
+            blocked, _ = midday_pause_block()
+        except Exception:
+            return False
+        if not blocked:
+            return False
+        try:
+            manager = getattr(self, "_position_manager", None)
+            if manager is not None and manager.get_open_positions():
+                return False
+        except Exception:
+            return False
+        return True
+
+    def _bump_cpu_metric(self, key: str) -> None:
+        """Args: metric key. Returns: None; emits CPU_OPTIMIZATION_SUMMARY every 60s. Raises: none."""
+        metrics = getattr(self, "_cpu_opt_metrics", None)
+        if metrics is None:
+            metrics = {}
+            self._cpu_opt_metrics = metrics
+        metrics[key] = int(metrics.get(key, 0)) + 1
+        if self._should_log_throttled("cpu_optimization_summary", 60.0):
+            whitelist = getattr(self, "_eval_option_whitelist", None) or set()
+            self._logger.info(
+                "CPU_OPTIMIZATION_SUMMARY evaluated_symbols_count=%s skipped_by_midday_pause=%s skipped_by_eval_throttle=%s skipped_by_option_cap=%s active_option_symbols_count=%s",
+                metrics.get("evaluated_symbols", 0),
+                metrics.get("skipped_by_midday_pause", 0),
+                metrics.get("skipped_by_eval_throttle", 0),
+                metrics.get("skipped_by_option_cap", 0),
+                len(whitelist),
+                extra={"event": "CPU_OPTIMIZATION_SUMMARY", **{k: int(v) for k, v in metrics.items()}, "active_option_symbols_count": len(whitelist)},
+            )
+            metrics.clear()
 
     def _mark_symbol_eval_allowed(self, symbol: str, *, bar_key: Any | None = None, tick: Mapping[str, Any] | None = None) -> None:
         """Record a permitted strategy evaluation for future same-bar throttling."""

--- a/tests/strategies/test_cpu_optimization.py
+++ b/tests/strategies/test_cpu_optimization.py
@@ -1,0 +1,105 @@
+"""CPU-optimization regression tests: hydration sync, eval cap, midday skip."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from nifty_scalper_bot.strategies.runner import StrategyRunner
+
+
+def _bare_runner() -> StrategyRunner:
+    runner = object.__new__(StrategyRunner)
+    return runner
+
+
+class _FakeIndicatorHistory:
+    def __init__(self) -> None:
+        self.bars: dict[str, list[dict[str, Any]]] = {}
+
+    def count(self, symbol: str) -> int:
+        return len(self.bars.get(symbol, []))
+
+
+def test_hydration_sync_heals_cold_runner_history() -> None:
+    """Regression: mdm_bars>=50 with runner/indicator bars=1 must heal to >=required."""
+    runner = _bare_runner()
+    store = _FakeIndicatorHistory()
+    mdm_rows = [{"close": 100.0 + i, "ts": i} for i in range(51)]
+    store.bars["NFO:NIFTY2661623450PE"] = [mdm_rows[0]]  # cold: 1 bar
+
+    runner._normalize_symbol = lambda s: s  # type: ignore[attr-defined]
+    runner._required_bars_for_symbol = lambda s: 50  # type: ignore[attr-defined]
+    runner._history_count_for_symbol = lambda s: store.count(s)  # type: ignore[attr-defined]
+    runner._symbol_history = {"NFO:NIFTY2661623450PE": [mdm_rows[0]]}  # type: ignore[attr-defined]
+    runner._get_mdm_bars = lambda s, n: mdm_rows[-n:]  # type: ignore[attr-defined]
+    runner._emit_history_hydration_trace = lambda *a, **k: None  # type: ignore[attr-defined]
+    runner._request_mdm_hydration = lambda *a, **k: None  # type: ignore[attr-defined]
+
+    def _reseed(symbol: str, rows: list[dict[str, Any]], **_: Any) -> int:
+        store.bars[symbol] = list(rows)
+        return len(rows)
+
+    runner.reseed_history_from_bars = _reseed  # type: ignore[attr-defined]
+
+    after = StrategyRunner._sync_history_from_mdm_cache(
+        runner, "NFO:NIFTY2661623450PE", required_bars=50, source="test", request_if_short=False
+    )
+    assert after >= 50
+    assert store.count("NFO:NIFTY2661623450PE") >= 50
+
+
+def test_eval_option_whitelist_caps_to_nearest_strikes(monkeypatch) -> None:
+    monkeypatch.setenv("MAX_LIVE_OPTION_SYMBOLS", "4")
+    runner = _bare_runner()
+
+    def _strike(sym: str) -> int | None:
+        digits = "".join(ch for ch in sym if ch.isdigit())
+        return int(digits[-5:]) if len(digits) >= 5 else None
+
+    runner._extract_strike_from_symbol = _strike  # type: ignore[attr-defined]
+    options = {
+        "NFO:NIFTY2661623150CE", "NFO:NIFTY2661623200CE", "NFO:NIFTY2661623250CE",
+        "NFO:NIFTY2661623300CE", "NFO:NIFTY2661623300PE", "NFO:NIFTY2661623350PE",
+        "NFO:NIFTY2661623450PE",
+    }
+    whitelist = StrategyRunner._compute_eval_option_whitelist(
+        runner, options, 23300, "NFO:NIFTY2661623300CE", "NFO:NIFTY2661623300PE"
+    )
+    assert len(whitelist) == 4
+    assert "NFO:NIFTY2661623300CE" in whitelist and "NFO:NIFTY2661623300PE" in whitelist
+    assert "NFO:NIFTY2661623450PE" not in whitelist and "NFO:NIFTY2661623150CE" not in whitelist
+
+
+def test_whitelist_uncapped_when_under_limit(monkeypatch) -> None:
+    monkeypatch.setenv("MAX_LIVE_OPTION_SYMBOLS", "8")
+    runner = _bare_runner()
+    runner._extract_strike_from_symbol = lambda s: 23300  # type: ignore[attr-defined]
+    options = {"NFO:NIFTY2661623300CE", "NFO:NIFTY2661623300PE"}
+    whitelist = StrategyRunner._compute_eval_option_whitelist(
+        runner, options, 23300, "NFO:NIFTY2661623300CE", "NFO:NIFTY2661623300PE"
+    )
+    assert whitelist == options
+
+
+class _FakePositionManager:
+    def __init__(self, open_positions: list[Any]) -> None:
+        self._open = open_positions
+
+    def get_open_positions(self) -> list[Any]:
+        return self._open
+
+
+def test_midday_idle_skip_only_when_paused_and_flat(monkeypatch) -> None:
+    runner = _bare_runner()
+    runner._position_manager = _FakePositionManager([])  # type: ignore[attr-defined]
+    monkeypatch.setenv("MIDDAY_PAUSE_ENABLED", "false")
+    assert StrategyRunner._midday_idle_skip_active(runner) is False
+    monkeypatch.setenv("MIDDAY_PAUSE_ENABLED", "true")
+    import nifty_scalper_bot.strategies.runner as runner_mod
+
+    monkeypatch.setattr(runner_mod, "midday_pause_block", lambda: (True, "midday_pause"))
+    assert StrategyRunner._midday_idle_skip_active(runner) is True
+    runner._position_manager = _FakePositionManager([object()])  # type: ignore[attr-defined]
+    assert StrategyRunner._midday_idle_skip_active(runner) is False


### PR DESCRIPTION
## Goal
Reduce ~100% CPU on the Lightsail instance to a sustainable level during live market with no open position, without touching live readiness for the selected CE/PE.

## Spec assessment (corrections applied)
- Eval throttle: a same-bar throttle already existed at 5s (floor 3s) — STRICTER than the proposed 1000ms, so the default is kept; RUNNER_EVAL_MIN_INTERVAL_MS is exposed as an env override that can only tighten, never loosen.
- Hydration loop: the root copy bug was fixed in #555 (prewarm targets true bar requirement). This PR adds the retry cooldown (HYDRATION_RETRY_COOLDOWN_SECONDS, default 60, aliasing the existing prewarm cooldown) and the requested regression test (mdm_bars>=50, runner_bars=1 -> heals to >=required).

## Implemented
1. **Option eval cap** — MAX_LIVE_OPTION_SYMBOLS (default 8). _compute_eval_option_whitelist ranks basket options by strike distance from ATM, always includes selected CE/PE; recomputed on every set_active_option_context. Far strikes still stream data (OI/IV context) but skip full strategy evaluation (pregate reason eval_capped_far_strike). Spot/futures never capped.
2. **Midday idle skip** — during MIDDAY_PAUSE with zero open positions, full strategy evaluation is skipped at the cheapest pregate point (midday_pause_idle_skip). Exit management, data health, basket refresh, Telegram all untouched; any open position disables the skip instantly.
3. **Log demotion** — RUNNER_EVAL_DECISION routine reasons, STRATEGY_NO_VOTE_SUMMARY, STRATEGY_COMBINER_BLOCKER, SMC_HISTORY_INPUT_DIAGNOSTICS, SMC_FEATURE_READINESS, HYDRATION_PROPAGATION_RESULT moved to DEBUG. INFO retained for signal forwarding/blocking transitions, orders, risk blocks, readiness transitions. LOG_LEVEL env already supported (utils/logging). RUNNER_EVAL_LOG_INFO=true restores verbose eval logs for debugging.
4. **Metrics** — CPU_OPTIMIZATION_SUMMARY every 60s: evaluated_symbols_count, skipped_by_midday_pause, skipped_by_eval_throttle, skipped_by_option_cap, active_option_symbols_count.

## Validation
939 tests passed, 0 failures (full risk/strategies/consensus 620 + readiness/hydration/app/runner-eval/SMC suites 319). 4 new tests: hydration heal regression, whitelist cap + uncapped, midday idle skip on/off/with-position.