### PR TITLE
Global option universe cap at basket source; post-close rearm slowdown

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -41,6 +41,7 @@ from typing import (
 )
 
 import pytz
+from nifty_scalper_bot.config.env_utils import parse_float_env
 from nifty_scalper_bot.journal.trade_journal import TradeJournal
 
 from nifty_scalper_bot.config.paths import get_data_dir
@@ -7329,6 +7330,13 @@ async def _live_readiness_rearm_loop(ctx: BotContext) -> None:
             except Exception:
                 market_open_now = False
             if not market_open_now:
+                # Market closed: nothing to rearm. Sleep the post-market
+                # interval (default 300s) to keep the loop near-idle overnight.
+                post_close = max(
+                    float(interval_seconds),
+                    parse_float_env(os.getenv("POST_MARKET_REARM_INTERVAL_SECONDS"), 300.0),
+                )
+                await asyncio.sleep(max(0.0, post_close - float(interval_seconds)))
                 continue
             runner = getattr(ctx, "strategy_runner", None)
             active_symbols = len(getattr(runner, "_active_symbols", set()) or [])

--- a/src/nifty_scalper_bot/core/instrument_manager.py
+++ b/src/nifty_scalper_bot/core/instrument_manager.py
@@ -9,11 +9,15 @@ Runtime role:
 from __future__ import annotations
 
 import logging
+import os
 import threading
 from dataclasses import dataclass
 from datetime import date, datetime, timedelta
 from zoneinfo import ZoneInfo
 from typing import Any, Dict, List, Mapping, Optional
+
+from nifty_scalper_bot.config.env_utils import parse_int_env
+from nifty_scalper_bot.instruments.active_contracts import cap_option_universe
 
 LOGGER = logging.getLogger("nifty_scalper_bot.core.instrument_manager")
 
@@ -588,6 +592,34 @@ class InstrumentManager:
         if not required_tokens.issubset({item[1] for item in selected_options}):
             selected_options.extend(item for item in (selected_ce, selected_pe) if item[1] not in {x[1] for x in selected_options})
             selected_options = sorted(selected_options, key=opt_sort)
+
+        # Global option-universe cap: applied here, at the single source of
+        # truth, so DataHub flush, MDM tracking, WS subscriptions, runner
+        # registration, hydration, and evaluation all inherit the same set.
+        max_options = parse_int_env(
+            os.getenv("MAX_ACTIVE_OPTION_SYMBOLS") or os.getenv("MAX_LIVE_OPTION_SYMBOLS"), 8
+        )
+        diagnostic_full = str(os.getenv("DIAGNOSTIC_FULL_UNIVERSE", "false") or "false").strip().lower() in {"1", "true", "yes", "on"}
+        if not diagnostic_full and max_options > 0 and len(selected_options) > max_options:
+            cap_items = [
+                (self._exchange_qualified(item[4]), int(item[1]), float(item[2]), str(item[3]))
+                for item in selected_options
+            ]
+            capped = cap_option_universe(
+                cap_items,
+                selected_ce=self._exchange_qualified(selected_ce[4]),
+                selected_pe=self._exchange_qualified(selected_pe[4]),
+                atm_strike=float(atm),
+                max_options=max_options,
+            )
+            kept_tokens = {item[1] for item in capped}
+            full_count = len(selected_options)
+            selected_options = [item for item in selected_options if int(item[1]) in kept_tokens]
+            LOGGER.info(
+                "CONTRACT_SSOT_UNIVERSE_CAPPED full_option_count=%d capped_option_count=%d max_options=%d atm_strike=%s",
+                full_count, len(selected_options), max_options, atm,
+                extra={"event": "CONTRACT_SSOT_UNIVERSE_CAPPED", "full_option_count": full_count, "capped_option_count": len(selected_options), "max_options": max_options, "atm_strike": atm},
+            )
 
         option_symbols = tuple(self._exchange_qualified(item[4]) for item in selected_options)
         option_tokens = tuple(int(item[1]) for item in selected_options)

--- a/src/nifty_scalper_bot/instruments/active_contracts.py
+++ b/src/nifty_scalper_bot/instruments/active_contracts.py
@@ -177,3 +177,40 @@ def resolve_active_nifty_future(
     if configured and not is_nifty_future_expired(configured, now=now):
         return ActiveFutureResolution(configured, "configured_symbol")
     return ActiveFutureResolution(None, "unresolved", reason="active_future_unresolved")
+
+
+def cap_option_universe(
+    option_items: list[tuple[str, int, float, str]],
+    *,
+    selected_ce: str,
+    selected_pe: str,
+    atm_strike: float,
+    max_options: int,
+) -> list[tuple[str, int, float, str]]:
+    """Args: (symbol, token, strike, side) items, selected pair, atm, cap.
+    Returns: capped list always containing selected CE/PE, remaining slots
+    filled by strikes nearest to ATM alternating CE/PE. Raises: none.
+
+    Single global cap for the active option universe. Applying it where the
+    basket is built means DataHub, MDM, WS subscriptions, runner registration,
+    hydration, and evaluation all inherit the same capped set.
+    """
+    if max_options <= 0 or len(option_items) <= max_options:
+        return list(option_items)
+    by_symbol = {item[0]: item for item in option_items}
+    capped: list[tuple[str, int, float, str]] = []
+    seen: set[str] = set()
+    for sel in (selected_ce, selected_pe):
+        item = by_symbol.get(sel)
+        if item and sel not in seen:
+            capped.append(item)
+            seen.add(sel)
+    remaining = [item for item in option_items if item[0] not in seen]
+    ce_ranked = sorted((i for i in remaining if i[3] == "CE"), key=lambda i: abs(i[2] - atm_strike))
+    pe_ranked = sorted((i for i in remaining if i[3] == "PE"), key=lambda i: abs(i[2] - atm_strike))
+    take_ce = True
+    while len(capped) < max_options and (ce_ranked or pe_ranked):
+        bucket = ce_ranked if (take_ce and ce_ranked) or not pe_ranked else pe_ranked
+        capped.append(bucket.pop(0))
+        take_ce = not take_ce
+    return capped

--- a/tests/instruments/test_option_universe_cap.py
+++ b/tests/instruments/test_option_universe_cap.py
@@ -1,0 +1,54 @@
+"""Regression tests for the single global option-universe cap."""
+
+from __future__ import annotations
+
+from nifty_scalper_bot.instruments.active_contracts import cap_option_universe
+
+
+def _full_universe(atm: int = 23300, step: int = 50, around: int = 3) -> list[tuple[str, int, float, str]]:
+    items: list[tuple[str, int, float, str]] = []
+    token = 1000
+    for i in range(-around, around + 1):
+        strike = atm + i * step
+        for side in ("CE", "PE"):
+            items.append((f"NFO:NIFTY26616{strike}{side}", token, float(strike), side))
+            token += 1
+    return items  # 14 options for around=3
+
+
+def test_cap_never_exceeds_max_and_keeps_selected_pair() -> None:
+    universe = _full_universe()
+    assert len(universe) == 14
+    capped = cap_option_universe(
+        universe,
+        selected_ce="NFO:NIFTY2661623300CE",
+        selected_pe="NFO:NIFTY2661623300PE",
+        atm_strike=23300.0,
+        max_options=8,
+    )
+    assert len(capped) == 8
+    symbols = {item[0] for item in capped}
+    assert "NFO:NIFTY2661623300CE" in symbols and "NFO:NIFTY2661623300PE" in symbols
+    # the basket consumers (DataHub flush, MDM, WS tokens, runner, eval) all
+    # derive from this list, so 8 here means <=8 everywhere downstream
+    assert len({item[1] for item in capped}) == 8  # unique tokens
+
+
+def test_cap_fills_nearest_strikes_alternating_sides() -> None:
+    capped = cap_option_universe(
+        _full_universe(),
+        selected_ce="NFO:NIFTY2661623300CE",
+        selected_pe="NFO:NIFTY2661623300PE",
+        atm_strike=23300.0,
+        max_options=6,
+    )
+    distances = [abs(item[2] - 23300.0) for item in capped]
+    assert max(distances) <= 50.0  # nearest strikes only
+    sides = [item[3] for item in capped]
+    assert sides.count("CE") == 3 and sides.count("PE") == 3  # balanced
+
+
+def test_cap_noop_when_under_limit_or_disabled() -> None:
+    universe = _full_universe(around=1)  # 6 options
+    assert cap_option_universe(universe, selected_ce=universe[0][0], selected_pe=universe[1][0], atm_strike=23300.0, max_options=8) == universe
+    assert cap_option_universe(universe, selected_ce=universe[0][0], selected_pe=universe[1][0], atm_strike=23300.0, max_options=0) == universe


### PR DESCRIPTION
## Diagnosis confirmed
The #556 cap applied only to strategy evaluation; the basket source still emitted 14 options / 16 tokens, so DataHub flush (12), WS (16 tokens), MDM tracking, dynamic hydration, and runner registration all ran uncapped.

## Design decision (prompt optimization)
Instead of enforcing the cap at 8 separate layers (readiness, runner, basket commit, DataHub, MDM, WS, dynamic hydration, eval) — which creates 8 places to drift out of sync — the cap is applied ONCE at the single source of truth: the CONTRACT_SSOT basket build in instrument_manager. Every downstream consumer (DataHub flush, MDM tracked symbols, WS token reconciliation, dynamic universe hydration, runner registration, eval whitelist) derives from basket.option_symbols/all_tokens and therefore inherits the same capped set automatically.

## Implemented
1. **cap_option_universe()** (instruments/active_contracts.py): pure, testable. Always includes selected CE/PE; fills remaining slots by strikes nearest ATM, alternating CE/PE.
2. **Applied at basket build**: MAX_ACTIVE_OPTION_SYMBOLS (alias MAX_LIVE_OPTION_SYMBOLS, default 8). DIAGNOSTIC_FULL_UNIVERSE=true bypasses for debugging. Logs CONTRACT_SSOT_UNIVERSE_CAPPED full_option_count=14 capped_option_count=8.
3. **Post-close rearm slowdown**: when market is closed the rearm loop sleeps POST_MARKET_REARM_INTERVAL_SECONDS (default 300) instead of cycling at the fast interval. Post-close dynamic hydration also shrinks to the capped set as a consequence of (2).
4. Items already correct in codebase (verified, no churn): readiness.py already promotes market_closed as the primary visible blocker when the market is closed (the misleading reason in the logs occurred DURING market hours and was the history-cold bug fixed in #555); CPU_OPTIMIZATION_SUMMARY from #556 already reports evaluated/skipped/active counts every 60s, now joined by the one-shot CONTRACT_SSOT_UNIVERSE_CAPPED full-vs-capped line per basket build.

## Regression test (as requested)
Given a full 14-option basket with selected CE/PE: capped output is exactly 8 unique tokens, always contains the selected pair, nearest strikes only, CE/PE balanced. Since all subscription/tracking layers consume this list, <=8 here guarantees <=8 at DataHub, WS, MDM, runner, and eval.

## Validation
1,017 tests passed, 0 failures (623 core risk/strategies/consensus + 394 instrument/basket/contract/readiness/app suites). 3 new cap tests.