### PR TITLE
Runtime option-token clamp, post-close dynamic skip, rearm/startup log clarity, risk state summary

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -7355,11 +7355,12 @@ async def _live_readiness_rearm_loop(ctx: BotContext) -> None:
             configured_mode = str(getattr(ctx.settings, "execution_mode", None) or os.getenv("EXECUTION_MODE", "PAPER")).upper()
             if configured_mode != "LIVE":
                 continue
-            LOGGER.info("LIVE_READINESS_REARM_CHECK")
             try:
                 market_open_now = get_market_state() == MarketState.OPEN
             except Exception:
                 market_open_now = False
+            if market_open_now:
+                LOGGER.info("LIVE_READINESS_REARM_CHECK")
             if not market_open_now:
                 # Market closed: nothing to rearm. Sleep the post-market
                 # interval (default 300s) to keep the loop near-idle overnight.
@@ -7367,8 +7368,16 @@ async def _live_readiness_rearm_loop(ctx: BotContext) -> None:
                     float(interval_seconds),
                     parse_float_env(os.getenv("POST_MARKET_REARM_INTERVAL_SECONDS"), 300.0),
                 )
+                if not getattr(ctx, "_rearm_sleep_logged", False):
+                    ctx._rearm_sleep_logged = True
+                    LOGGER.info(
+                        "LIVE_READINESS_REARM_SLEEPING market_state=closed sleep_s=%d",
+                        int(post_close),
+                        extra={"event": "LIVE_READINESS_REARM_SLEEPING", "market_state": "closed", "sleep_s": int(post_close)},
+                    )
                 await asyncio.sleep(max(0.0, post_close - float(interval_seconds)))
                 continue
+            ctx._rearm_sleep_logged = False
             runner = getattr(ctx, "strategy_runner", None)
             active_symbols = len(getattr(runner, "_active_symbols", set()) or [])
             if active_symbols == 0:
@@ -11649,11 +11658,17 @@ async def startup_sequence(ctx: BotContext) -> None:
                                     else "DATA_WARMUP"
                                 )
                                 ctx.effective_mode = ctx.readiness_mode
+                                try:
+                                    _market_closed_now = get_market_state() != MarketState.OPEN
+                                except Exception:
+                                    _market_closed_now = False
                                 LOGGER.info(
                                     "STARTUP_MODE_BLOCKED current=%s reason=%s",
                                     ctx.readiness_mode,
                                     (
-                                        "selected_option_history_or_quote_not_ready"
+                                        "market_closed"
+                                        if (ctx.readiness_mode == "EVALUATION_READY" and _market_closed_now)
+                                        else "selected_option_history_or_quote_not_ready"
                                         if ctx.readiness_mode == "EVALUATION_READY"
                                         else "awaiting_spot_or_active_basket"
                                     ),

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -12,6 +12,8 @@ from datetime import date, datetime, timedelta, timezone
 import logging
 import math
 import os
+
+from nifty_scalper_bot.config.env_utils import parse_int_env
 import re
 from random import uniform
 import threading
@@ -1798,6 +1800,62 @@ class MarketDataManager:
                     token_map.setdefault(key, token)
         return token_map
 
+    def _clamp_option_tokens(
+        self,
+        tokens: list[int],
+        token_map: Mapping[str, int],
+        selected_ce: str,
+        selected_pe: str,
+    ) -> list[int]:
+        """Args: token list, symbol->token map, selected pair. Returns: tokens
+        with option tokens clamped to MAX_ACTIVE_OPTION_SYMBOLS (alias
+        MAX_LIVE_OPTION_SYMBOLS, default 8); selected CE/PE always kept; non
+        option tokens (spot/futures) never clamped. DIAGNOSTIC_FULL_UNIVERSE
+        bypasses. Raises: none.
+        """
+        max_options = parse_int_env(
+            os.getenv("MAX_ACTIVE_OPTION_SYMBOLS") or os.getenv("MAX_LIVE_OPTION_SYMBOLS"), 8
+        )
+        diagnostic = str(os.getenv("DIAGNOSTIC_FULL_UNIVERSE", "false") or "false").strip().lower() in {"1", "true", "yes", "on"}
+        if diagnostic or max_options <= 0:
+            return tokens
+        symbol_by_token: dict[int, str] = {}
+        for sym, tok in (token_map or {}).items():
+            try:
+                symbol_by_token.setdefault(int(tok), str(sym))
+            except (TypeError, ValueError):
+                continue
+
+        def _is_option(tok: int) -> bool:
+            sym = symbol_by_token.get(tok, "")
+            return sym.endswith(("CE", "PE"))
+
+        option_tokens = [t for t in tokens if _is_option(t)]
+        if len(option_tokens) <= max_options:
+            return tokens
+        priority: list[int] = []
+        for sel in (selected_ce, selected_pe):
+            tok = token_map.get(sel) or token_map.get(sel.split(":", 1)[-1] if ":" in sel else sel)
+            if tok:
+                try:
+                    priority.append(int(tok))
+                except (TypeError, ValueError):
+                    pass
+        kept: list[int] = list(dict.fromkeys(priority))
+        for tok in option_tokens:
+            if len(kept) >= max_options:
+                break
+            if tok not in kept:
+                kept.append(tok)
+        kept_set = set(kept)
+        clamped = [t for t in tokens if (not _is_option(t)) or t in kept_set]
+        self._logger.warning(
+            "MDM_OPTION_TOKENS_CLAMPED full_option_count=%d capped_option_count=%d max_options=%d",
+            len(option_tokens), len(kept), max_options,
+            extra={"event": "MDM_OPTION_TOKENS_CLAMPED", "full_option_count": len(option_tokens), "capped_option_count": len(kept), "max_options": max_options},
+        )
+        return clamped
+
     def set_active_contract_basket(self, basket: Any) -> None:
         """Commit active basket tokens/subscriptions without clearing on incomplete payloads."""
         tokens = [int(tok) for tok in (self._basket_value(basket, "all_tokens", []) or []) if tok]
@@ -1827,6 +1885,10 @@ class MarketDataManager:
         token_map = self._basket_token_map(basket)
         selected_ce = str(self._basket_value(basket, "selected_ce", "") or "")
         selected_pe = str(self._basket_value(basket, "selected_pe", "") or "")
+        # Hard fail-safe: regardless of which path built this basket (SSOT,
+        # dynamic refresh, legacy), the option token set is clamped to the
+        # canonical cap before any WS/MDM/polling subscription derives from it.
+        tokens = self._clamp_option_tokens(tokens, token_map, selected_ce, selected_pe)
         selected_ce_token = (
             self._basket_value(basket, "selected_ce_token", None)
             or token_map.get(selected_ce)

--- a/src/nifty_scalper_bot/risk/risk_manager.py
+++ b/src/nifty_scalper_bot/risk/risk_manager.py
@@ -17,7 +17,7 @@ from nifty_scalper_bot.execution.position_manager import Position
 from nifty_scalper_bot.infra.metrics import METRICS
 from nifty_scalper_bot.risk.limits import RiskSwitches
 from nifty_scalper_bot.utils.env import get_float
-from nifty_scalper_bot.utils.logging import get_logger
+from nifty_scalper_bot.utils.logging import get_logger, log_once_or_throttled
 from nifty_scalper_bot.utils.metrics import Counter, Gauge
 from nifty_scalper_bot.utils.reasons import SOFT, canonical
 
@@ -967,6 +967,21 @@ class RiskManager:
         if snap.daily_loss_limit > 0 and snap.daily_realized <= -snap.daily_loss_limit:
             self._last_rejection = (
                 f"DAILY_REALIZED_LIMIT:{snap.daily_realized:.2f}/{-snap.daily_loss_limit:.2f}"
+            )
+            try:
+                next_day = self._current_trading_day() + timedelta(days=1)
+                reset_time = next_day.isoformat()
+            except Exception:
+                reset_time = "next_trading_day"
+            log_once_or_throttled(
+                self._logger,
+                "risk_state_summary_daily_realized",
+                "RISK_STATE_SUMMARY realized_pnl=%.2f realized_limit=%.2f trading_blocked=true reset_time=%s",
+                snap.daily_realized,
+                -snap.daily_loss_limit,
+                reset_time,
+                interval_sec=300.0,
+                extra={"event": "RISK_STATE_SUMMARY", "realized_pnl": round(snap.daily_realized, 2), "realized_limit": round(-snap.daily_loss_limit, 2), "trading_blocked": True, "reset_time": reset_time},
             )
             return False
         max_trades = int(getattr(self.settings, "max_trades_per_day", 0) or 0)

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -1329,6 +1329,13 @@ class StrategyRunner:
                 and normalized not in self._frozen_universe
             ):
                 if is_dynamic_option_symbol:
+                    if self._dynamic_add_blocked_market_closed():
+                        self._logger.info(
+                            "DYNAMIC_OPTION_UNIVERSE_SKIPPED reason=market_closed symbol=%s",
+                            normalized,
+                            extra={"event": "DYNAMIC_OPTION_UNIVERSE_SKIPPED", "reason": "market_closed", "symbol": normalized},
+                        )
+                        return
                     self._frozen_universe.add(normalized)
                     self._logger.info(
                         "Dynamic option symbol admitted to frozen universe",
@@ -7717,6 +7724,26 @@ class StrategyRunner:
                 break
             whitelist.add(sym)
         return whitelist
+
+    def _dynamic_add_blocked_market_closed(self) -> bool:
+        """Args: none. Returns: True when market is closed, no positions are
+        open, and DIAGNOSTIC_FULL_UNIVERSE is not set — i.e. there is no
+        reason to grow the option universe. Raises: none.
+        """
+        if str(os.getenv("DIAGNOSTIC_FULL_UNIVERSE", "false") or "false").strip().lower() in {"1", "true", "yes", "on"}:
+            return False
+        try:
+            if get_market_state() == MarketState.OPEN:
+                return False
+        except Exception:
+            return False
+        try:
+            manager = getattr(self, "_position_manager", None)
+            if manager is not None and manager.get_open_positions():
+                return False
+        except Exception:
+            return False
+        return True
 
     def _midday_idle_skip_active(self) -> bool:
         """Args: none. Returns: True when midday pause is on and no positions are open. Raises: none."""

--- a/tests/data/test_runtime_option_cap.py
+++ b/tests/data/test_runtime_option_cap.py
@@ -1,0 +1,88 @@
+"""Regression tests: runtime option-token clamp, post-close dynamic skip."""
+
+from __future__ import annotations
+
+from nifty_scalper_bot.data.market_data_manager import MarketDataManager
+from nifty_scalper_bot.strategies.runner import StrategyRunner
+
+
+class _BareMDM:
+    _clamp_option_tokens = MarketDataManager._clamp_option_tokens
+
+    def __init__(self) -> None:
+        import logging
+
+        self._logger = logging.getLogger("test_mdm")
+
+
+def _token_map(n_options: int = 14) -> tuple[list[int], dict[str, int]]:
+    token_map: dict[str, int] = {"NSE:NIFTY": 1, "NFO:NIFTY26JUNFUT": 2}
+    tokens = [1, 2]
+    for i in range(n_options):
+        side = "CE" if i % 2 == 0 else "PE"
+        strike = 23150 + (i // 2) * 50
+        sym = f"NFO:NIFTY26616{strike}{side}"
+        tok = 100 + i
+        token_map[sym] = tok
+        tokens.append(tok)
+    return tokens, token_map
+
+
+def test_runtime_clamp_caps_option_tokens_to_8(monkeypatch) -> None:
+    monkeypatch.setenv("MAX_ACTIVE_OPTION_SYMBOLS", "8")
+    monkeypatch.delenv("DIAGNOSTIC_FULL_UNIVERSE", raising=False)
+    tokens, token_map = _token_map(14)
+    assert len(tokens) == 16
+    mdm = _BareMDM()
+    clamped = mdm._clamp_option_tokens(tokens, token_map, "NFO:NIFTY2661623300CE", "NFO:NIFTY2661623300PE")
+    option_tokens = [t for t in clamped if t >= 100]
+    assert len(option_tokens) == 8
+    assert len(clamped) == 10  # 8 options + spot + future
+    assert token_map["NFO:NIFTY2661623300CE"] in clamped
+    assert token_map["NFO:NIFTY2661623300PE"] in clamped
+    assert 1 in clamped and 2 in clamped  # spot/future never clamped
+
+
+def test_runtime_clamp_diagnostic_bypass(monkeypatch) -> None:
+    monkeypatch.setenv("MAX_ACTIVE_OPTION_SYMBOLS", "8")
+    monkeypatch.setenv("DIAGNOSTIC_FULL_UNIVERSE", "true")
+    tokens, token_map = _token_map(14)
+    mdm = _BareMDM()
+    assert mdm._clamp_option_tokens(tokens, token_map, "NFO:NIFTY2661623300CE", "NFO:NIFTY2661623300PE") == tokens
+
+
+def test_runtime_clamp_noop_under_cap(monkeypatch) -> None:
+    monkeypatch.setenv("MAX_ACTIVE_OPTION_SYMBOLS", "8")
+    monkeypatch.delenv("DIAGNOSTIC_FULL_UNIVERSE", raising=False)
+    tokens, token_map = _token_map(6)
+    mdm = _BareMDM()
+    assert mdm._clamp_option_tokens(tokens, token_map, "NFO:NIFTY2661623150CE", "NFO:NIFTY2661623150PE") == tokens
+
+
+class _FakePositions:
+    def __init__(self, open_positions: list[object]) -> None:
+        self._open = open_positions
+
+    def get_open_positions(self) -> list[object]:
+        return self._open
+
+
+def test_dynamic_add_blocked_when_closed_and_flat(monkeypatch) -> None:
+    import nifty_scalper_bot.strategies.runner as runner_mod
+
+    runner = object.__new__(StrategyRunner)
+    runner._position_manager = _FakePositions([])  # type: ignore[attr-defined]
+    monkeypatch.delenv("DIAGNOSTIC_FULL_UNIVERSE", raising=False)
+    monkeypatch.setattr(runner_mod, "get_market_state", lambda: runner_mod.MarketState.CLOSED)
+    assert StrategyRunner._dynamic_add_blocked_market_closed(runner) is True
+    # open position -> allowed (exit management may need new symbols)
+    runner._position_manager = _FakePositions([object()])  # type: ignore[attr-defined]
+    assert StrategyRunner._dynamic_add_blocked_market_closed(runner) is False
+    # market open -> allowed
+    runner._position_manager = _FakePositions([])  # type: ignore[attr-defined]
+    monkeypatch.setattr(runner_mod, "get_market_state", lambda: runner_mod.MarketState.OPEN)
+    assert StrategyRunner._dynamic_add_blocked_market_closed(runner) is False
+    # diagnostic bypass
+    monkeypatch.setattr(runner_mod, "get_market_state", lambda: runner_mod.MarketState.CLOSED)
+    monkeypatch.setenv("DIAGNOSTIC_FULL_UNIVERSE", "true")
+    assert StrategyRunner._dynamic_add_blocked_market_closed(runner) is False


### PR DESCRIPTION
## Scope
Production logs showed the #557 basket-source cap being bypassed by runtime/dynamic paths (option_count climbing back to 14-15, token_count 16), plus post-close noise and unclear block reasons.

## Implemented
1. **Hard runtime fail-safe clamp (MDM chokepoint)** — _clamp_option_tokens applied in set_active_contract_basket before ANY WS/MDM/polling subscription derives from the token set. Whatever path built the basket (SSOT, dynamic refresh, legacy), option tokens are clamped to MAX_ACTIVE_OPTION_SYMBOLS (canonical; MAX_LIVE_OPTION_SYMBOLS honored as alias), selected CE/PE always kept, spot/futures never clamped, DIAGNOSTIC_FULL_UNIVERSE bypasses. Emits MDM_OPTION_TOKENS_CLAMPED full/capped counts when it fires — if this appears in logs it also identifies the uncapped upstream path for a root-cause follow-up.
2. **Post-close dynamic universe skip** — runner.add_symbol no longer admits dynamic option symbols when market is CLOSED and no positions are open (open positions keep dynamic adds enabled for exit management). Emits DYNAMIC_OPTION_UNIVERSE_SKIPPED reason=market_closed. DIAGNOSTIC_FULL_UNIVERSE bypasses.
3. **Rearm loop clarity** — LIVE_READINESS_REARM_CHECK now logs only when market is open; closed market logs LIVE_READINESS_REARM_SLEEPING market_state=closed sleep_s=300 exactly once per close, then sleeps POST_MARKET_REARM_INTERVAL_SECONDS (from #557).
4. **STARTUP_MODE_BLOCKED honesty** — when readiness is EVALUATION_READY and the market is closed, reason is now market_closed instead of selected_option_history_or_quote_not_ready.
5. **RISK_STATE_SUMMARY** — on daily realized-limit block: realized_pnl, realized_limit, trading_blocked=true, reset_time (next trading-day boundary from the existing _current_trading_day reset logic), throttled to once per 5 min. The terse RISK BLOCK string remains for compatibility.

## Validation
1,074 tests passed, 0 failures (635 core + 439 risk/MDM/basket/rearm/app suites). 4 new regression tests: clamp 16->10 tokens (8 options + spot + future) preserving selected pair, diagnostic bypass, under-cap no-op, and the post-close dynamic-add guard in all four states (closed+flat blocks; open position, open market, or diagnostic allows).