### PR TITLE
Fix rearm-loop crash: no ad-hoc attrs on slotted BotContext; permanent AST guard test

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -92,6 +92,7 @@ BOT_CONTEXT_RUNTIME_FIELD_DEFAULTS: dict[str, Any] = {
     "_deferred_basket_hydration_log_key": None,
     "last_deferred_basket_hydration_log_at": None,
     "_live_basket_build_log_key": None,
+    "basket_build_pending_spot_ltp": None,
     "last_live_basket_build_log_at": None,
     "_hydration_tracking_log_key": None,
     "last_hydration_tracking_log_at": None,
@@ -2646,6 +2647,7 @@ class BotContext:
     basket_build_last_started_mono: float = 0.0
     basket_build_last_completed_mono: float = 0.0
     basket_build_last_error: str | None = None
+    basket_build_pending_spot_ltp: float | None = None
     startup_phase: str = "created"
     startup_failed: bool = False
     startup_failure_reason: str | None = None
@@ -7349,6 +7351,7 @@ async def _live_readiness_rearm_loop(ctx: BotContext) -> None:
     if not hasattr(ctx, "effective_mode"):
         ctx.effective_mode = str(ctx.readiness_mode)
     LOGGER.info("LIVE_READINESS_REARM_LOOP_STARTED")
+    rearm_sleep_logged = False
     while True:
         try:
             await asyncio.sleep(interval_seconds)
@@ -7368,8 +7371,8 @@ async def _live_readiness_rearm_loop(ctx: BotContext) -> None:
                     float(interval_seconds),
                     parse_float_env(os.getenv("POST_MARKET_REARM_INTERVAL_SECONDS"), 300.0),
                 )
-                if not getattr(ctx, "_rearm_sleep_logged", False):
-                    ctx._rearm_sleep_logged = True
+                if not rearm_sleep_logged:
+                    rearm_sleep_logged = True
                     LOGGER.info(
                         "LIVE_READINESS_REARM_SLEEPING market_state=closed sleep_s=%d",
                         int(post_close),
@@ -7377,7 +7380,7 @@ async def _live_readiness_rearm_loop(ctx: BotContext) -> None:
                     )
                 await asyncio.sleep(max(0.0, post_close - float(interval_seconds)))
                 continue
-            ctx._rearm_sleep_logged = False
+            rearm_sleep_logged = False
             runner = getattr(ctx, "strategy_runner", None)
             active_symbols = len(getattr(runner, "_active_symbols", set()) or [])
             if active_symbols == 0:

--- a/tests/core/test_bot_context_attributes.py
+++ b/tests/core/test_bot_context_attributes.py
@@ -1,0 +1,66 @@
+"""Permanent guard against BotContext AttributeError crashes.
+
+BotContext is @dataclass(slots=True): assigning an undeclared attribute at
+runtime raises AttributeError (e.g. the LIVE_READINESS_REARM_LOOP_CRASHED
+incident on 2026-06-12). This test statically audits every `ctx.<attr> =`
+assignment in core/app.py and fails if any attribute is neither declared on
+the BotContext dataclass nor registered in BOT_CONTEXT_RUNTIME_FIELD_DEFAULTS.
+Any future edit that reintroduces an ad-hoc ctx attribute fails CI here
+instead of crashing a production loop.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import nifty_scalper_bot.core.app as app_module
+from nifty_scalper_bot.core.app import BOT_CONTEXT_RUNTIME_FIELD_DEFAULTS, BotContext
+
+
+def _app_source() -> str:
+    return Path(app_module.__file__).read_text()
+
+
+def test_every_ctx_attribute_write_is_declared() -> None:
+    src = _app_source()
+    tree = ast.parse(src)
+    declared: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == "BotContext":
+            for stmt in node.body:
+                if isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name):
+                    declared.add(stmt.target.id)
+    defaults = set(BOT_CONTEXT_RUNTIME_FIELD_DEFAULTS.keys())
+    writes: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Assign, ast.AugAssign)):
+            targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+            for target in targets:
+                if (
+                    isinstance(target, ast.Attribute)
+                    and isinstance(target.value, ast.Name)
+                    and target.value.id == "ctx"
+                ):
+                    writes.add(target.attr)
+    undeclared = sorted(writes - declared - defaults)
+    assert not undeclared, (
+        f"Undeclared ctx attribute writes (would raise AttributeError on the "
+        f"slots=True BotContext): {undeclared}. Declare the field on BotContext "
+        f"and register it in BOT_CONTEXT_RUNTIME_FIELD_DEFAULTS, or use local state."
+    )
+
+
+def test_basket_build_pending_spot_ltp_is_declared_field() -> None:
+    import dataclasses
+
+    field_names = {f.name for f in dataclasses.fields(BotContext)}
+    assert "basket_build_pending_spot_ltp" in field_names
+
+
+def test_rearm_loop_does_not_write_private_ctx_flags() -> None:
+    # The crashed code path used ctx._rearm_sleep_logged; the flag must be
+    # loop-local now and never assigned on ctx.
+    src = _app_source()
+    assert not re.search(r"ctx\._rearm_sleep_logged\s*=", src)


### PR DESCRIPTION
## Incident
LIVE_READINESS_REARM_LOOP_CRASHED error_type=AttributeError ('BotContext' object has no attribute '_rearm_sleep_logged') at 00:18:00 IST.

## Root cause
BotContext is @dataclass(slots=True) — runtime assignment of undeclared attributes raises AttributeError. PR #559 assigned ctx._rearm_sleep_logged inside the rearm loop; the first closed-market pass after deploy crashed the loop. PR #558's ctx.basket_build_pending_spot_ltp had the same latent defect (that code path calls ensure_bot_context_runtime_fields first, which would have raised BOT_CONTEXT_ATTRIBUTE_MISSING on first deferred build).

## Fix
1. Rearm sleep flag is now a loop-local variable — correct scope; it never belonged on the shared context.
2. basket_build_pending_spot_ltp declared as a proper BotContext field (float | None = None) and registered in BOT_CONTEXT_RUNTIME_FIELD_DEFAULTS, following the codebase's existing convention for runtime scratchpad fields.

## Permanent prevention (the 'no attribute errors, permanently' requirement)
New test tests/core/test_bot_context_attributes.py statically AST-audits EVERY `ctx.<attr> =` assignment in core/app.py and fails CI if any attribute is neither declared on BotContext nor registered in the runtime defaults. The audit currently passes with 61 ctx writes, 128 declared fields, 0 undeclared. Any future edit reintroducing an ad-hoc ctx attribute fails this test instead of crashing a production loop. Also audited and verified safe: StrategyRunner and MarketDataManager are NOT slotted, so the recent _cpu_opt_metrics/_eval_option_whitelist/_last_futures_purge_key additions are valid; the slots=True dataclasses in runner.py are small config/state records that were not touched.

## Validation
962 tests passed, 0 failures (3 new guard tests + 635 core + 324 app/rearm/basket/context suites).