### PR TITLE
Fix runtime readiness and hydration consistency

### DIFF
--- a/src/nifty_scalper_bot/core/active_basket.py
+++ b/src/nifty_scalper_bot/core/active_basket.py
@@ -219,8 +219,17 @@ def normalize_active_basket_schema(basket: Mapping[str, object]) -> dict[str, ob
                 "pe_symbols": pe_symbols,
             }
         )
+    max_options = max(2, int(os.getenv("MAX_ACTIVE_OPTION_SYMBOLS", "8") or 8))
+    selected_core = [s for s in (selected_ce, selected_pe) if s and str(s).endswith(("CE", "PE"))]
+    option_symbols = list(dict.fromkeys([*selected_core, *option_symbols]))[:max_options]
+    ce_symbols = [s for s in option_symbols if s.endswith("CE")]
+    pe_symbols = [s for s in option_symbols if s.endswith("PE")]
+    token_by_symbol_raw = dict(out.get("token_by_symbol") or {})
+    symbols = list(dict.fromkeys([s for s in [spot_symbol, futures_symbol, *option_symbols] if s]))
+    token_by_symbol = {str(sym): int(tok) for sym, tok in token_by_symbol_raw.items() if str(sym) in symbols and tok}
+    all_tokens = list(dict.fromkeys(int(tok) for sym, tok in token_by_symbol.items() if sym in symbols and int(tok) > 0))
     out["spot_symbol"] = spot_symbol
-    out["futures_symbol"] = futures_symbol
+    out["futures_symbol"] = futures_symbol if futures_symbol.endswith("FUT") or not futures_symbol else futures_symbol
     out["option_symbols"] = option_symbols
     out["ce_symbols"] = ce_symbols
     out["pe_symbols"] = pe_symbols
@@ -228,10 +237,15 @@ def normalize_active_basket_schema(basket: Mapping[str, object]) -> dict[str, ob
     out["selected_pe"] = selected_pe
     out["atm_ce"] = out.get("atm_ce") or selected_ce
     out["atm_pe"] = out.get("atm_pe") or selected_pe
-    out["symbols"] = list(dict.fromkeys([s for s in [spot_symbol, futures_symbol, *option_symbols] if s]))
-    # Token fields must survive normalization untouched so MDM can consume them.
-    # They are already in `out` from the input dict; no action needed beyond
-    # the comment to make the invariant explicit.
+    out["symbols"] = symbols
+    out["all_symbols"] = symbols
+    out["token_by_symbol"] = token_by_symbol
+    out["all_tokens"] = all_tokens[: max_options + 2]
+    out["option_tokens"] = [token_by_symbol[s] for s in option_symbols if s in token_by_symbol]
+    out["basket_version"] = str(out.get("basket_version") or out.get("version") or out.get("committed_at") or "1")
+    out["basket_source"] = str(out.get("basket_source") or out.get("source") or "active_contract_basket")
+    out["basket_committed_at"] = str(out.get("basket_committed_at") or out.get("committed_at") or "")
+    out["context_only"] = not bool(selected_ce and selected_pe)
     return out
 
 

--- a/src/nifty_scalper_bot/core/active_basket.py
+++ b/src/nifty_scalper_bot/core/active_basket.py
@@ -226,10 +226,26 @@ def normalize_active_basket_schema(basket: Mapping[str, object]) -> dict[str, ob
     pe_symbols = [s for s in option_symbols if s.endswith("PE")]
     token_by_symbol_raw = dict(out.get("token_by_symbol") or {})
     symbols = list(dict.fromkeys([s for s in [spot_symbol, futures_symbol, *option_symbols] if s]))
-    token_by_symbol = {str(sym): int(tok) for sym, tok in token_by_symbol_raw.items() if str(sym) in symbols and tok}
-    all_tokens = list(dict.fromkeys(int(tok) for sym, tok in token_by_symbol.items() if sym in symbols and int(tok) > 0))
+
+    def _positive_int(value: object) -> int | None:
+        try:
+            parsed = int(value)
+        except (TypeError, ValueError):
+            return None
+        return parsed if parsed > 0 else None
+
+    token_by_symbol = dict(token_by_symbol_raw)
+    expected_token_symbols = [s for s in symbols if s]
+    complete_token_map = all(_positive_int(token_by_symbol_raw.get(sym)) for sym in expected_token_symbols)
+    if complete_token_map:
+        token_by_symbol = {sym: int(token_by_symbol_raw[sym]) for sym in expected_token_symbols}
+        all_tokens = list(dict.fromkeys(token_by_symbol[sym] for sym in expected_token_symbols))[: max_options + 2]
+        option_tokens = [token_by_symbol[s] for s in option_symbols if s in token_by_symbol]
+    else:
+        all_tokens = list(out.get("all_tokens") or [])[: max_options + 2]
+        option_tokens = list(out.get("option_tokens") or [])[:max_options]
     out["spot_symbol"] = spot_symbol
-    out["futures_symbol"] = futures_symbol if futures_symbol.endswith("FUT") or not futures_symbol else futures_symbol
+    out["futures_symbol"] = futures_symbol
     out["option_symbols"] = option_symbols
     out["ce_symbols"] = ce_symbols
     out["pe_symbols"] = pe_symbols
@@ -240,8 +256,8 @@ def normalize_active_basket_schema(basket: Mapping[str, object]) -> dict[str, ob
     out["symbols"] = symbols
     out["all_symbols"] = symbols
     out["token_by_symbol"] = token_by_symbol
-    out["all_tokens"] = all_tokens[: max_options + 2]
-    out["option_tokens"] = [token_by_symbol[s] for s in option_symbols if s in token_by_symbol]
+    out["all_tokens"] = all_tokens
+    out["option_tokens"] = option_tokens
     out["basket_version"] = str(out.get("basket_version") or out.get("version") or out.get("committed_at") or "1")
     out["basket_source"] = str(out.get("basket_source") or out.get("source") or "active_contract_basket")
     out["basket_committed_at"] = str(out.get("basket_committed_at") or out.get("committed_at") or "")

--- a/src/nifty_scalper_bot/core/active_basket.py
+++ b/src/nifty_scalper_bot/core/active_basket.py
@@ -244,6 +244,17 @@ def normalize_active_basket_schema(basket: Mapping[str, object]) -> dict[str, ob
     else:
         all_tokens = list(out.get("all_tokens") or [])[: max_options + 2]
         option_tokens = list(out.get("option_tokens") or [])[:max_options]
+        LOGGER.info(
+            "ACTIVE_BASKET_TOKEN_MAP_PARTIAL mapped_symbol_count=%d expected_symbol_count=%d preserved_all_token_count=%d preserved_option_token_count=%d",
+            len(token_by_symbol_raw), len(expected_token_symbols), len(all_tokens), len(option_tokens),
+            extra={
+                "event": "ACTIVE_BASKET_TOKEN_MAP_PARTIAL",
+                "mapped_symbol_count": len(token_by_symbol_raw),
+                "expected_symbol_count": len(expected_token_symbols),
+                "preserved_all_token_count": len(all_tokens),
+                "preserved_option_token_count": len(option_tokens),
+            },
+        )
     out["spot_symbol"] = spot_symbol
     out["futures_symbol"] = futures_symbol
     out["option_symbols"] = option_symbols

--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -43,6 +43,7 @@ from typing import (
 import pytz
 from nifty_scalper_bot.config.env_utils import parse_float_env
 from nifty_scalper_bot.journal.trade_journal import TradeJournal
+from nifty_scalper_bot.utils.smart_symbol import NSE_HOLIDAYS
 
 from nifty_scalper_bot.config.paths import get_data_dir
 from nifty_scalper_bot.core.active_basket import (
@@ -78,6 +79,22 @@ def _basket_attr(basket: Mapping[str, object] | object | None, key: str, default
     return getattr(basket, key, default)
 
 
+
+
+def _next_eod_flatten_time_ist(now_ist: datetime) -> datetime | None:
+    """Return the next trading-day EOD flatten time, skipping weekends/NSE holidays."""
+    if now_ist.tzinfo is None:
+        now_ist = now_ist.replace(tzinfo=ZoneInfo("Asia/Kolkata"))
+    else:
+        now_ist = now_ist.astimezone(ZoneInfo("Asia/Kolkata"))
+    for day_offset in range(0, 10):
+        candidate_day = (now_ist + timedelta(days=day_offset)).date()
+        if candidate_day.weekday() >= 5 or candidate_day in NSE_HOLIDAYS:
+            continue
+        candidate = datetime.combine(candidate_day, time(15, 24), tzinfo=ZoneInfo("Asia/Kolkata"))
+        if candidate > now_ist:
+            return candidate
+    return None
 
 
 BOT_CONTEXT_RUNTIME_FIELD_DEFAULTS: dict[str, Any] = {
@@ -8563,8 +8580,10 @@ def _commit_active_dynamic_basket(
         _val = basket.get(_token_key)
         if _val is not None:
             committed[_token_key] = _val
+    committed = normalize_active_basket_schema(committed)
     ctx.active_trading_universe = committed
-    ctx.active_contract_basket = committed
+    if not committed.get("context_only") or not getattr(ctx, "active_contract_basket", None):
+        ctx.active_contract_basket = committed
     selection = active_contract_selection_from_basket(committed)
     _sync_active_selection_from_basket(ctx, selection)
     runner = getattr(ctx, "strategy_runner", None)
@@ -10064,19 +10083,21 @@ async def startup_sequence(ctx: BotContext) -> None:
                 *active_option_symbols,
             ]))
             readiness_symbols = [str(sym) for sym in readiness_symbols if sym]
+            readiness_option_count = sum(1 for sym in readiness_symbols if str(sym).endswith(("CE", "PE")))
+            full_basket_option_count = len([sym for sym in (basket.get("option_symbols", []) or []) if str(sym).endswith(("CE", "PE"))])
             LOGGER.info(
-                "READINESS_SYMBOLS_SELECTED count=%d spot=%s futures=%s option_count=%d symbols=%s",
+                "READINESS_SYMBOLS_SELECTED readiness_symbol_count=%d readiness_option_count=%d full_basket_option_count=%d spot=%s futures=%s symbols=%s",
                 len(readiness_symbols),
+                readiness_option_count,
+                full_basket_option_count,
                 basket.get("spot_symbol"),
                 active_futures_symbol,
-                len(basket.get("option_symbols", []) or []),
                 readiness_symbols,
                 extra={
                     "event": "READINESS_SYMBOLS_SELECTED",
-                    "count": len(readiness_symbols),
-                    "spot": basket.get("spot_symbol"),
-                    "futures": active_futures_symbol,
-                    "option_count": len(basket.get("option_symbols", []) or []),
+                    "readiness_symbol_count": len(readiness_symbols),
+                    "readiness_option_count": readiness_option_count,
+                    "full_basket_option_count": full_basket_option_count,
                     "symbols": readiness_symbols,
                 },
             )
@@ -10890,7 +10911,7 @@ async def startup_sequence(ctx: BotContext) -> None:
                                         interval="minute",
                                         days=_history_lookback_days(required_bars),
                                         max_bars=required_bars,
-                                        reason="dynamic_option_universe",
+                                        reason=("futures_context_refresh" if str(sym).endswith("FUT") else "spot_context_refresh" if str(sym).startswith("NSE:") else "dynamic_option_universe"),
                                     )
                                     runner_ingested = 0
                                     bars = ctx.market_data_manager.get_ohlc_bars(sym, limit=required_bars)
@@ -11105,7 +11126,7 @@ async def startup_sequence(ctx: BotContext) -> None:
                                     committed_ce,
                                     committed_pe,
                                     (getattr(ctx, "active_trading_universe", {}) or {}).get("atm_strike"),
-                                    len(latest_symbols),
+                                    len([sym for sym in (getattr(ctx, "active_contract_basket", {}) or {}).get("option_symbols", []) if str(sym).endswith(("CE", "PE"))]),
                                     ce_bars >= _symbol_history_requirement(ctx),
                                     pe_bars >= _symbol_history_requirement(ctx),
                                 )
@@ -11523,11 +11544,11 @@ async def startup_sequence(ctx: BotContext) -> None:
                             ctx.data_hard_ready = bool(
                                 spot_ready_for_live and atm_ce_ready and atm_pe_ready
                             )
+                            quote_event = "OPTION_TRADABLE_QUOTE_READY" if option_ticks_ready else "OPTION_TRADABLE_QUOTE_NOT_READY"
                             LOGGER.info(
-                                "OPTION_QUOTE_READY selected_ce=%s selected_pe=%s",
-                                selected_ce,
-                                selected_pe,
-                                extra={"event": "OPTION_QUOTE_READY", "selected_ce": selected_ce, "selected_pe": selected_pe},
+                                "%s selected_ce=%s selected_pe=%s ce_tradable_quote=%s pe_tradable_quote=%s",
+                                quote_event, selected_ce, selected_pe, bool(quote_ce), bool(quote_pe),
+                                extra={"event": quote_event, "selected_ce": selected_ce, "selected_pe": selected_pe, "ce_tradable_quote": bool(quote_ce), "pe_tradable_quote": bool(quote_pe)},
                             )
                             LOGGER.info(
                                 "OPTION_HISTORY_READY selected_ce=%s selected_pe=%s",
@@ -12016,18 +12037,17 @@ async def startup_sequence(ctx: BotContext) -> None:
     if ctx.bracket_manager:
         try:
             now_ist = datetime.now(ZoneInfo("Asia/Kolkata"))
-            eod_target_ist = now_ist.replace(hour=15, minute=24, second=0, microsecond=0)
-            if now_ist >= eod_target_ist:
-                eod_target_ist = eod_target_ist + timedelta(days=1)
-            seconds_to_15h24 = max(
-                0.0, (eod_target_ist - now_ist).total_seconds()
-            )
-            loop.call_later(seconds_to_15h24, ctx.bracket_manager.eod_flatten_all)
-            LOGGER.info(
-                "EOD bracket flatten scheduled for %s IST (in %.1fs)",
-                eod_target_ist.isoformat(),
-                seconds_to_15h24,
-            )
+            eod_target_ist = _next_eod_flatten_time_ist(now_ist)
+            if eod_target_ist is None:
+                LOGGER.info("EOD bracket flatten not scheduled: no trading day found")
+            else:
+                seconds_to_15h24 = max(0.0, (eod_target_ist - now_ist).total_seconds())
+                loop.call_later(seconds_to_15h24, ctx.bracket_manager.eod_flatten_all)
+                LOGGER.info(
+                    "EOD bracket flatten scheduled for %s IST (in %.1fs)",
+                    eod_target_ist.isoformat(),
+                    seconds_to_15h24,
+                )
         except Exception as e:
             LOGGER.error("Failed to schedule EOD flatten: %s", e)
 

--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -43,7 +43,7 @@ from typing import (
 import pytz
 from nifty_scalper_bot.config.env_utils import parse_float_env
 from nifty_scalper_bot.journal.trade_journal import TradeJournal
-from nifty_scalper_bot.utils.smart_symbol import NSE_HOLIDAYS
+from nifty_scalper_bot.utils.smart_symbol import is_nse_trading_day
 
 from nifty_scalper_bot.config.paths import get_data_dir
 from nifty_scalper_bot.core.active_basket import (
@@ -89,7 +89,7 @@ def _next_eod_flatten_time_ist(now_ist: datetime) -> datetime | None:
         now_ist = now_ist.astimezone(ZoneInfo("Asia/Kolkata"))
     for day_offset in range(0, 10):
         candidate_day = (now_ist + timedelta(days=day_offset)).date()
-        if candidate_day.weekday() >= 5 or candidate_day in NSE_HOLIDAYS:
+        if not is_nse_trading_day(candidate_day):
             continue
         candidate = datetime.combine(candidate_day, time(15, 24), tzinfo=ZoneInfo("Asia/Kolkata"))
         if candidate > now_ist:
@@ -8589,6 +8589,12 @@ def _commit_active_dynamic_basket(
     runner = getattr(ctx, "strategy_runner", None)
     if runner is not None and hasattr(runner, "set_active_trading_universe"):
         runner.set_active_trading_universe(committed)
+    data_hub = getattr(ctx, "data_hub", None)
+    if data_hub is not None and hasattr(data_hub, "set_active_contract_basket"):
+        data_hub.set_active_contract_basket(committed)
+    option_universe = getattr(ctx, "option_universe", None)
+    if option_universe is not None and hasattr(option_universe, "set_active_contract_basket"):
+        option_universe.set_active_contract_basket(committed)
     strategy_manager = getattr(ctx, "strategy_manager", None)
     set_fut = getattr(strategy_manager, "set_active_futures_symbol", None)
     if callable(set_fut):

--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -59,7 +59,7 @@ from nifty_scalper_bot.data.robust_provider import (
 )
 from nifty_scalper_bot.infra.watchdog import start_watchdog
 from nifty_scalper_bot.instruments.active_contracts import canonical_nifty_future_symbol
-from nifty_scalper_bot.execution.readiness import normalize_readiness_blockers
+from nifty_scalper_bot.execution.readiness import evaluate_quote_readiness, normalize_readiness_blockers
 from nifty_scalper_bot.utils.market_hours import (
     get_runtime_market_mode,
     post_market_basket_refresh_seconds,
@@ -7549,6 +7549,22 @@ def _best_hydrated_option(
     return best_symbol
 
 
+def _quote_readiness_for_symbol(ctx: Any, symbol: str | None, *, max_age_s: float = 60.0) -> Any:
+    """Return canonical quote readiness for a runtime symbol without raising."""
+    snap = None
+    if symbol and getattr(ctx, "market_data_manager", None) is not None:
+        try:
+            snap = ctx.market_data_manager.get_symbol_snapshot(symbol)
+        except Exception:
+            snap = None
+    return evaluate_quote_readiness(
+        symbol or "",
+        snap,
+        max_spread_pct=float(os.getenv("OPTION_MAX_SPREAD_PCT", "10") or 10),
+        max_age_s=max_age_s,
+    )
+
+
 def _fresh_option_quote(
     ctx: BotContext, symbol: str | None, *, max_age_s: float = 60.0
 ) -> str | None:
@@ -11520,14 +11536,16 @@ async def startup_sequence(ctx: BotContext) -> None:
                                 getattr(ctx, "selected_pe", None)
                                 or basket_universe.get("selected_pe"),
                             )
-                            quote_ce = _fresh_option_quote(ctx, selected_ce) if selected_ce else None
-                            quote_pe = _fresh_option_quote(ctx, selected_pe) if selected_pe else None
+                            ce_qr = _quote_readiness_for_symbol(ctx, selected_ce)
+                            pe_qr = _quote_readiness_for_symbol(ctx, selected_pe)
+                            quote_ce = selected_ce if ce_qr.tradable_quote_ready else None
+                            quote_pe = selected_pe if pe_qr.tradable_quote_ready else None
                             hydrated_ce = _count_symbol_bars(ctx, selected_ce) if selected_ce else 0
                             hydrated_pe = _count_symbol_bars(ctx, selected_pe) if selected_pe else 0
-                            option_ticks_ready = bool(quote_ce is not None and quote_pe is not None)
+                            option_ticks_ready = bool(ce_qr.tradable_quote_ready and pe_qr.tradable_quote_ready)
                             futures_ready = "futures" not in set(missing_soft)
-                            atm_ce_ready = bool(selected_ce and (quote_ce is not None or hydrated_ce >= 3))
-                            atm_pe_ready = bool(selected_pe and (quote_pe is not None or hydrated_pe >= 3))
+                            atm_ce_ready = bool(selected_ce and (ce_qr.tradable_quote_ready or hydrated_ce >= 3))
+                            atm_pe_ready = bool(selected_pe and (pe_qr.tradable_quote_ready or hydrated_pe >= 3))
                             req_atm_ce = readiness_state.get("requirements", {}).get("atm_ce")
                             req_atm_pe = readiness_state.get("requirements", {}).get("atm_pe")
                             if quote_ce and req_atm_ce and quote_ce != req_atm_ce:
@@ -11552,9 +11570,9 @@ async def startup_sequence(ctx: BotContext) -> None:
                             )
                             quote_event = "OPTION_TRADABLE_QUOTE_READY" if option_ticks_ready else "OPTION_TRADABLE_QUOTE_NOT_READY"
                             LOGGER.info(
-                                "%s selected_ce=%s selected_pe=%s ce_tradable_quote=%s pe_tradable_quote=%s",
-                                quote_event, selected_ce, selected_pe, bool(quote_ce), bool(quote_pe),
-                                extra={"event": quote_event, "selected_ce": selected_ce, "selected_pe": selected_pe, "ce_tradable_quote": bool(quote_ce), "pe_tradable_quote": bool(quote_pe)},
+                                "%s selected_ce=%s selected_pe=%s ce_tradable_quote=%s pe_tradable_quote=%s ce_reason=%s pe_reason=%s",
+                                quote_event, selected_ce, selected_pe, ce_qr.tradable_quote_ready, pe_qr.tradable_quote_ready, ce_qr.reason, pe_qr.reason,
+                                extra={"event": quote_event, "selected_ce": selected_ce, "selected_pe": selected_pe, "ce_tradable_quote": ce_qr.tradable_quote_ready, "pe_tradable_quote": pe_qr.tradable_quote_ready, "ce_quote_readiness": ce_qr.to_dict(), "pe_quote_readiness": pe_qr.to_dict()},
                             )
                             LOGGER.info(
                                 "OPTION_HISTORY_READY selected_ce=%s selected_pe=%s",
@@ -11611,9 +11629,11 @@ async def startup_sequence(ctx: BotContext) -> None:
                             pe_hydration = _status_for_role(hydration_statuses, "selected_pe")
                             hydrated_ce = min(ce_hydration.mdm_bars, ce_hydration.datahub_bars, ce_hydration.runner_bars, ce_hydration.indicator_bars) if ce_hydration else 0
                             hydrated_pe = min(pe_hydration.mdm_bars, pe_hydration.datahub_bars, pe_hydration.runner_bars, pe_hydration.indicator_bars) if pe_hydration else 0
-                            quote_ce = selected_ce if ce_hydration and ce_hydration.tradable_quote else None
-                            quote_pe = selected_pe if pe_hydration and pe_hydration.tradable_quote else None
-                            option_ticks_ready = bool(quote_ce is not None and quote_pe is not None)
+                            ce_qr_runtime = _quote_readiness_for_symbol(ctx, selected_ce)
+                            pe_qr_runtime = _quote_readiness_for_symbol(ctx, selected_pe)
+                            quote_ce = selected_ce if ce_qr_runtime.tradable_quote_ready else None
+                            quote_pe = selected_pe if pe_qr_runtime.tradable_quote_ready else None
+                            option_ticks_ready = bool(ce_qr_runtime.tradable_quote_ready and pe_qr_runtime.tradable_quote_ready)
                             spot_ready = bool(spot_hydration and spot_hydration.ready_for_evaluation)
                             futures_ready = bool(futures_hydration and futures_hydration.ready_for_evaluation) if (basket_universe.get("futures_symbol") or basket_universe.get("future_symbol")) else True
                             atm_ce_ready = bool(ce_hydration and ce_hydration.ready_for_evaluation)

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -392,6 +392,7 @@ class MarketDataManager:
         self._polling_policy = PollingPolicy.from_settings(settings)
         self._poll_error_last_log: dict[str, float] = {}
         self._history_lock = asyncio.Lock()
+        self._history_inflight_lock = asyncio.Lock()
         self._history_inflight: dict[tuple[str, str], tuple[int, asyncio.Task[list[dict[str, Any]]]]] = {}
         self._last_history_request_ts = 0.0
         self._history_min_interval_sec = float(
@@ -9499,11 +9500,20 @@ class MarketDataManager:
         max_bars: int = 300,
         reason: str = "startup",
     ) -> list[dict[str, Any]]:
-        """Hydrate cached OHLC history for a symbol. Args: symbol/interval/days/max_bars/reason. Returns: normalized rows. Raises: none."""
+        """Hydrate cached OHLC history without overlapping same-symbol broker requests."""
         normalized = self._canonical_symbol(symbol)
         if not hasattr(self, "_history_inflight"):
             self._history_inflight = {}
+        if not hasattr(self, "_history_inflight_lock"):
+            self._history_inflight_lock = asyncio.Lock()
         key = (normalized, interval)
+
+        def _cached_rows() -> list[dict[str, Any]]:
+            try:
+                return list(self.get_ohlc_bars(normalized) or [])
+            except Exception:
+                return []
+
         async def _run_hydration(requested_bars: int) -> list[dict[str, Any]]:
             rows_inner = await self.fetch_history(normalized, interval, days)
             rows_inner = list(rows_inner or [])[-requested_bars:]
@@ -9515,22 +9525,45 @@ class MarketDataManager:
                 extra={"event":"HYDRATION_MDM_COMPLETE","symbol":normalized,"rows":len(rows_inner),"accepted":int(accepted_inner),"reason":reason},
             )
             return rows_inner
-        with suppress(KeyError):
-            inflight_bars, inflight_task = self._history_inflight[key]
-            if not inflight_task.done() and inflight_bars >= max_bars:
-                self._logger.info(
-                    "HYDRATION_REQUEST_JOINED symbol=%s requested_bars=%s inflight_bars=%s reason=%s",
-                    normalized, max_bars, inflight_bars, reason,
-                    extra={"event":"HYDRATION_REQUEST_JOINED","symbol":normalized,"requested_bars":max_bars,"inflight_bars":inflight_bars,"reason":reason},
-                )
-                return list(await inflight_task)[-max_bars:]
-        task = asyncio.create_task(_run_hydration(max_bars))
-        self._history_inflight[key] = (max_bars, task)
-        self._logger.info(
-            "HYDRATION_REQUEST_CREATED symbol=%s requested_bars=%s reason=%s",
-            normalized, max_bars, reason,
-            extra={"event":"HYDRATION_REQUEST_CREATED","symbol":normalized,"requested_bars":max_bars,"reason":reason},
-        )
+
+        while True:
+            async with self._history_inflight_lock:
+                current = self._history_inflight.get(key)
+                if current is not None and current[1].done():
+                    self._history_inflight.pop(key, None)
+                    current = None
+                if current is not None:
+                    inflight_bars, inflight_task = current
+                    self._logger.info(
+                        "HYDRATION_REQUEST_JOINED symbol=%s requested_bars=%s inflight_bars=%s reason=%s",
+                        normalized, max_bars, inflight_bars, reason,
+                        extra={"event":"HYDRATION_REQUEST_JOINED","symbol":normalized,"requested_bars":max_bars,"inflight_bars":inflight_bars,"reason":reason},
+                    )
+                else:
+                    task = asyncio.create_task(_run_hydration(max_bars))
+                    self._history_inflight[key] = (max_bars, task)
+                    self._logger.info(
+                        "HYDRATION_REQUEST_CREATED symbol=%s requested_bars=%s reason=%s",
+                        normalized, max_bars, reason,
+                        extra={"event":"HYDRATION_REQUEST_CREATED","symbol":normalized,"requested_bars":max_bars,"reason":reason},
+                    )
+                    break
+
+            try:
+                rows = await inflight_task
+            finally:
+                if inflight_task.done():
+                    async with self._history_inflight_lock:
+                        current = self._history_inflight.get(key)
+                        if current and current[1] is inflight_task:
+                            self._history_inflight.pop(key, None)
+            if inflight_bars >= max_bars:
+                return list(rows or [])[-max_bars:]
+            cached = _cached_rows()
+            if len(cached) >= max_bars:
+                return cached[-max_bars:]
+            # A smaller request completed first; loop and create a larger request only if still short.
+
         try:
             rows = await task
             self._logger.info(
@@ -9540,9 +9573,10 @@ class MarketDataManager:
             )
             return list(rows)[-max_bars:]
         finally:
-            current = self._history_inflight.get(key)
-            if current and current[1] is task:
-                self._history_inflight.pop(key, None)
+            async with self._history_inflight_lock:
+                current = self._history_inflight.get(key)
+                if current and current[1] is task:
+                    self._history_inflight.pop(key, None)
 
     async def fetch_history(
         self, symbol: str, interval: str, days: int = 3

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -46,7 +46,7 @@ from nifty_scalper_bot.streaming.websocket_manager import (
     ConnectionState,
     WebSocketManager,
 )
-from nifty_scalper_bot.execution.readiness import resolve_quote_bid_ask_spread
+from nifty_scalper_bot.execution.readiness import evaluate_quote_readiness, resolve_quote_bid_ask_spread
 from nifty_scalper_bot.utils.env import get_str
 from nifty_scalper_bot.utils.async_helpers import safe_task
 from nifty_scalper_bot.utils.log_throttle import log_throttled as log_throttled_live
@@ -392,6 +392,7 @@ class MarketDataManager:
         self._polling_policy = PollingPolicy.from_settings(settings)
         self._poll_error_last_log: dict[str, float] = {}
         self._history_lock = asyncio.Lock()
+        self._history_inflight: dict[tuple[str, str], tuple[int, asyncio.Task[list[dict[str, Any]]]]] = {}
         self._last_history_request_ts = 0.0
         self._history_min_interval_sec = float(
             getattr(settings, "history_min_interval_sec", 1.2)
@@ -1957,14 +1958,20 @@ class MarketDataManager:
             if is_future and raw_sym != self._basket_value(basket, "futures_symbol", None):
                 self._logger.warning("MDM_BASKET_ROLE_INCONSISTENCY symbol=%s role=%s", canonical, role, extra={"event": "MDM_BASKET_ROLE_INCONSISTENCY", "symbol": canonical, "role": role})
             token = token_map.get(sym) or token_map.get(sym.upper()) or token_map.get(canonical) or token_map.get(canonical.split(":", 1)[-1] if ":" in canonical else canonical)
-            entry = {"role": role, "token": token, "quote_ready": False, "ohlc_ready": True, "bars_count": 0, "oi_ready": False, "ohlc_provisional": False}
+            entry = {"role": role, "token": token, "ltp_ready": False, "depth_available": False, "bid_ask_available": False, "tradable_quote_ready": False, "quote_ready": False, "quote_ready_reason": "quote_missing", "ohlc_ready": True, "bars_count": 0, "oi_ready": False, "ohlc_provisional": False}
             if is_option and token is None:
                 report["missing"].append(f"{sym}:token_missing")
                 report["hard_ready"] = False
             quote = self.get_latest_tick(sym) or self.get_latest_tick(canonical) or self.get_quote(sym) or self.get_quote(canonical)
-            entry["quote_ready"] = bool(quote and float((quote or {}).get("ltp") or (quote or {}).get("last_price") or 0.0) > 0)
-            if is_option and not entry["quote_ready"]:
-                report["missing"].append(f"{sym}:quote_missing")
+            qr = evaluate_quote_readiness(canonical, quote, max_spread_pct=float(os.getenv("OPTION_MAX_SPREAD_PCT", "10") or 10), max_age_s=self._option_stale_seconds)
+            entry["ltp_ready"] = qr.ltp_ready
+            entry["depth_available"] = qr.depth_available
+            entry["bid_ask_available"] = qr.bid_ask_available
+            entry["tradable_quote_ready"] = qr.tradable_quote_ready
+            entry["quote_ready"] = qr.ltp_ready
+            entry["quote_ready_reason"] = qr.reason
+            if is_option and not qr.ltp_ready:
+                report["missing"].append(f"{sym}:quote_missing:{qr.reason}")
                 report["hard_ready"] = False
             bars = self.get_ohlc_bars(sym) or self.get_ohlc_bars(canonical) or []
             entry["bars_count"] = len(bars)
@@ -4358,9 +4365,10 @@ class MarketDataManager:
                     or ""
                 ).lower()
                 bid_ask_source = str(tick.get("bid_ask_source") or "").lower()
-                if bool(tick.get("tradable_quote")) and (
+                qr = evaluate_quote_readiness(symbol, tick, max_spread_pct=float(os.getenv("OPTION_MAX_SPREAD_PCT", "10") or 10), max_age_s=self._option_stale_seconds)
+                if qr.tradable_quote_ready and (
                     source in {"ws", "ws_full", "full"}
-                    or bid_ask_source in {"market_depth", "ws_full"}
+                    or bid_ask_source in {"market_depth", "ws_full", "top_level", "best_bid_ask"}
                 ):
                     return True
         return False
@@ -9493,19 +9501,48 @@ class MarketDataManager:
     ) -> list[dict[str, Any]]:
         """Hydrate cached OHLC history for a symbol. Args: symbol/interval/days/max_bars/reason. Returns: normalized rows. Raises: none."""
         normalized = self._canonical_symbol(symbol)
-        rows = await self.fetch_history(normalized, interval, days)
-        rows = list(rows or [])[-max_bars:]
-        accepted = self.ingest_historical_ohlc(normalized, rows)
-        self.update_hydration_status(normalized, self.get_ohlc_bars(normalized))
+        if not hasattr(self, "_history_inflight"):
+            self._history_inflight = {}
+        key = (normalized, interval)
+        async def _run_hydration(requested_bars: int) -> list[dict[str, Any]]:
+            rows_inner = await self.fetch_history(normalized, interval, days)
+            rows_inner = list(rows_inner or [])[-requested_bars:]
+            accepted_inner = self.ingest_historical_ohlc(normalized, rows_inner)
+            self.update_hydration_status(normalized, self.get_ohlc_bars(normalized))
+            self._logger.info(
+                "HYDRATION_MDM_COMPLETE symbol=%s rows=%d accepted=%d reason=%s",
+                normalized, len(rows_inner), int(accepted_inner), reason,
+                extra={"event":"HYDRATION_MDM_COMPLETE","symbol":normalized,"rows":len(rows_inner),"accepted":int(accepted_inner),"reason":reason},
+            )
+            return rows_inner
+        with suppress(KeyError):
+            inflight_bars, inflight_task = self._history_inflight[key]
+            if not inflight_task.done() and inflight_bars >= max_bars:
+                self._logger.info(
+                    "HYDRATION_REQUEST_JOINED symbol=%s requested_bars=%s inflight_bars=%s reason=%s",
+                    normalized, max_bars, inflight_bars, reason,
+                    extra={"event":"HYDRATION_REQUEST_JOINED","symbol":normalized,"requested_bars":max_bars,"inflight_bars":inflight_bars,"reason":reason},
+                )
+                return list(await inflight_task)[-max_bars:]
+        task = asyncio.create_task(_run_hydration(max_bars))
+        self._history_inflight[key] = (max_bars, task)
         self._logger.info(
-            "HYDRATION_MDM_COMPLETE symbol=%s rows=%d accepted=%d reason=%s",
-            normalized,
-            len(rows),
-            int(accepted),
-            reason,
-            extra={"event":"HYDRATION_MDM_COMPLETE","symbol":normalized,"rows":len(rows),"accepted":int(accepted),"reason":reason},
+            "HYDRATION_REQUEST_CREATED symbol=%s requested_bars=%s reason=%s",
+            normalized, max_bars, reason,
+            extra={"event":"HYDRATION_REQUEST_CREATED","symbol":normalized,"requested_bars":max_bars,"reason":reason},
         )
-        return rows
+        try:
+            rows = await task
+            self._logger.info(
+                "HYDRATION_REQUEST_COMPLETED symbol=%s requested_bars=%s returned_rows=%s reason=%s",
+                normalized, max_bars, len(rows), reason,
+                extra={"event":"HYDRATION_REQUEST_COMPLETED","symbol":normalized,"requested_bars":max_bars,"returned_rows":len(rows),"reason":reason},
+            )
+            return list(rows)[-max_bars:]
+        finally:
+            current = self._history_inflight.get(key)
+            if current and current[1] is task:
+                self._history_inflight.pop(key, None)
 
     async def fetch_history(
         self, symbol: str, interval: str, days: int = 3

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -1959,7 +1959,7 @@ class MarketDataManager:
             if is_future and raw_sym != self._basket_value(basket, "futures_symbol", None):
                 self._logger.warning("MDM_BASKET_ROLE_INCONSISTENCY symbol=%s role=%s", canonical, role, extra={"event": "MDM_BASKET_ROLE_INCONSISTENCY", "symbol": canonical, "role": role})
             token = token_map.get(sym) or token_map.get(sym.upper()) or token_map.get(canonical) or token_map.get(canonical.split(":", 1)[-1] if ":" in canonical else canonical)
-            entry = {"role": role, "token": token, "ltp_ready": False, "depth_available": False, "bid_ask_available": False, "tradable_quote_ready": False, "quote_ready": False, "quote_ready_reason": "quote_missing", "ohlc_ready": True, "bars_count": 0, "oi_ready": False, "ohlc_provisional": False}
+            entry = {"role": role, "token": token, "ltp_ready": False, "depth_available": False, "bid_ask_available": False, "tradable_quote_ready": False, "quote_ready": False, "quote_ready_alias": "ltp_ready_compat_only", "quote_ready_reason": "quote_missing", "ohlc_ready": True, "bars_count": 0, "oi_ready": False, "ohlc_provisional": False}
             if is_option and token is None:
                 report["missing"].append(f"{sym}:token_missing")
                 report["hard_ready"] = False

--- a/src/nifty_scalper_bot/execution/readiness.py
+++ b/src/nifty_scalper_bot/execution/readiness.py
@@ -324,6 +324,83 @@ def resolve_quote_bid_ask_spread(quote: dict | object) -> tuple[float | None, fl
     return bid, ask, spread_pct, source
 
 
+
+@dataclass(frozen=True, slots=True)
+class QuoteReadiness:
+    """Canonical quote readiness split into LTP, depth, bid/ask, and tradable states."""
+
+    symbol: str
+    ltp_ready: bool
+    depth_available: bool
+    bid_ask_available: bool
+    tradable_quote_ready: bool
+    reason: str
+    bid: float | None = None
+    ask: float | None = None
+    spread_pct: float | None = None
+    source: str = "missing"
+
+    def to_dict(self) -> dict[str, object]:
+        return asdict(self)
+
+
+def evaluate_quote_readiness(
+    symbol: str,
+    quote: dict | object | None,
+    *,
+    max_spread_pct: float | None = None,
+    require_fresh: bool = True,
+    max_age_s: float | None = None,
+) -> QuoteReadiness:
+    """Return canonical quote readiness for startup, runtime, execution, Telegram, and health.
+
+    Tradable quote readiness is stricter than LTP readiness: bid and ask must be
+    present, positive, non-crossed, fresh when age is known, and within the
+    configured spread limit.
+    """
+    if quote is None:
+        return QuoteReadiness(symbol=symbol, ltp_ready=False, depth_available=False, bid_ask_available=False, tradable_quote_ready=False, reason="quote_missing")
+    getter = quote.get if isinstance(quote, dict) else lambda key, default=None: getattr(quote, key, default)
+    ltp = _quote_float(quote, "ltp", "last_price", "last_traded_price")
+    ltp_ready = bool(ltp is not None and ltp > 0)
+    depth = getter("depth", None)
+    depth_available = bool(getter("depth_available", False) or depth)
+    bid, ask, spread_pct, source = resolve_quote_bid_ask_spread(quote)
+    bid_ask_available = bool(bid is not None and ask is not None and bid > 0 and ask > bid)
+    if not ltp_ready:
+        reason = "ltp_missing"
+    elif not bid_ask_available:
+        raw_bid = _quote_float(quote, "bid", "bid_price", "best_bid", "best_bid_price")
+        raw_ask = _quote_float(quote, "ask", "ask_price", "best_ask", "best_ask_price")
+        if raw_bid is not None and raw_ask is not None and raw_bid > 0 and raw_ask > 0 and raw_ask <= raw_bid:
+            reason = "bid_ask_crossed"
+        else:
+            reason = "bid_ask_missing"
+    else:
+        reason = "ready"
+    if reason == "ready" and require_fresh:
+        age = _quote_float(quote, "tick_age_s", "age_s")
+        if age is None:
+            ts = _quote_float(quote, "timestamp_ms", "last_tick_ts_ms")
+            if ts and ts > 10_000_000_000:
+                age = max(0.0, datetime.now(timezone.utc).timestamp() - (ts / 1000.0))
+        if max_age_s is not None and age is not None and age > max_age_s:
+            reason = "quote_stale"
+    if reason == "ready" and max_spread_pct is not None and spread_pct is not None and spread_pct > max_spread_pct:
+        reason = "spread_too_wide"
+    return QuoteReadiness(
+        symbol=symbol,
+        ltp_ready=ltp_ready,
+        depth_available=depth_available,
+        bid_ask_available=bid_ask_available,
+        tradable_quote_ready=reason == "ready",
+        reason=reason,
+        bid=bid,
+        ask=ask,
+        spread_pct=spread_pct,
+        source=source,
+    )
+
 def quote_has_tradable_bid_ask(quote: dict | object) -> bool:
     """Return True when quote has valid top-level/depth bid-ask proof."""
     bid, ask, _spread, _source = resolve_quote_bid_ask_spread(quote)

--- a/src/nifty_scalper_bot/execution/readiness.py
+++ b/src/nifty_scalper_bot/execution/readiness.py
@@ -384,7 +384,9 @@ def evaluate_quote_readiness(
             ts = _quote_float(quote, "timestamp_ms", "last_tick_ts_ms")
             if ts and ts > 10_000_000_000:
                 age = max(0.0, datetime.now(timezone.utc).timestamp() - (ts / 1000.0))
-        if max_age_s is not None and age is not None and age > max_age_s:
+        if age is None:
+            reason = "quote_age_unknown"
+        elif max_age_s is not None and age > max_age_s:
             reason = "quote_stale"
     if reason == "ready" and max_spread_pct is not None and spread_pct is not None and spread_pct > max_spread_pct:
         reason = "spread_too_wide"

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -2637,10 +2637,12 @@ class StrategyRunner:
             except Exception:  # noqa: BLE001
                 return False
 
-        candidate_symbols = {normalize_symbol(str(sym)) for sym in (option_symbols or []) if sym}
-        for sym in (selected_ce_norm, selected_pe_norm):
-            if sym:
-                candidate_symbols.add(sym)
+        raw_candidate_symbols = [normalize_symbol(str(sym)) for sym in (option_symbols or []) if sym]
+        max_active_options = max(2, int(os.getenv("MAX_ACTIVE_OPTION_SYMBOLS", "8") or 8))
+        selected_core = [sym for sym in (selected_ce_norm, selected_pe_norm) if sym]
+        candidate_symbols = set(dict.fromkeys([*selected_core, *raw_candidate_symbols]).keys())
+        if len(candidate_symbols) > max_active_options:
+            candidate_symbols = set(list(dict.fromkeys([*selected_core, *raw_candidate_symbols]))[:max_active_options])
         prev_ce = getattr(self, "_active_selected_ce", None)
         prev_pe = getattr(self, "_active_selected_pe", None)
         pair_requested = bool(selected_ce_norm and selected_pe_norm)
@@ -7339,6 +7341,14 @@ class StrategyRunner:
         result_event = "SELECTED_OPTION_HISTORY_PREWARM_RESULT" if selected else "OPTION_CONTEXT_HISTORY_PREWARM_RESULT"
         if not selected and bars_before >= required_bars:
             return
+        data_hub = getattr(self, "_data_hub", None)
+        mdm = getattr(data_hub, "_mdm", None)
+        inflight = getattr(mdm, "_history_inflight", {}) if mdm is not None else {}
+        inflight_entry = inflight.get((symbol, "minute")) if isinstance(inflight, Mapping) else None
+        if not selected and inflight_entry and int(inflight_entry[0] or 0) >= required_bars:
+            return
+        if not selected and get_runtime_market_mode() != "OPEN":
+            return
         last = float(self._selected_option_prewarm_last.get(symbol, 0.0) or 0.0)
         if (now - last) < self._selected_option_prewarm_cooldown_s or symbol in self._selected_option_prewarm_inflight:
             return
@@ -7352,7 +7362,6 @@ class StrategyRunner:
             required_bars,
             extra={"event": request_event, "symbol": symbol, "bars_before": bars_before, "required_bars": required_bars, "trace_id": trace_id},
         )
-        data_hub = getattr(self, "_data_hub", None)
         hydrate = getattr(data_hub, "hydrate_symbol_history", None)
         if not callable(hydrate):
             self._selected_option_prewarm_inflight.discard(symbol)

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -7330,20 +7330,27 @@ class StrategyRunner:
                 )
 
     def _request_selected_option_history_prewarm(
-        self, symbol: str, *, bars_before: int, required_bars: int, trace_id: str | None = None
+        self, symbol: str, *, bars_before: int, required_bars: int, trace_id: str | None = None, selected: bool | None = None
     ) -> None:
         now = time.monotonic()
+        if selected is None:
+            selected = True
+        request_event = "SELECTED_OPTION_HISTORY_PREWARM_REQUESTED" if selected else "OPTION_CONTEXT_HISTORY_PREWARM_REQUESTED"
+        result_event = "SELECTED_OPTION_HISTORY_PREWARM_RESULT" if selected else "OPTION_CONTEXT_HISTORY_PREWARM_RESULT"
+        if not selected and bars_before >= required_bars:
+            return
         last = float(self._selected_option_prewarm_last.get(symbol, 0.0) or 0.0)
         if (now - last) < self._selected_option_prewarm_cooldown_s or symbol in self._selected_option_prewarm_inflight:
             return
         self._selected_option_prewarm_last[symbol] = now
         self._selected_option_prewarm_inflight.add(symbol)
         self._logger.info(
-            "SELECTED_OPTION_HISTORY_PREWARM_REQUESTED symbol=%s bars_before=%s required_bars=%s",
+            "%s symbol=%s bars_before=%s required_bars=%s",
+            request_event,
             symbol,
             bars_before,
             required_bars,
-            extra={"event": "SELECTED_OPTION_HISTORY_PREWARM_REQUESTED", "symbol": symbol, "bars_before": bars_before, "required_bars": required_bars, "trace_id": trace_id},
+            extra={"event": request_event, "symbol": symbol, "bars_before": bars_before, "required_bars": required_bars, "trace_id": trace_id},
         )
         data_hub = getattr(self, "_data_hub", None)
         hydrate = getattr(data_hub, "hydrate_symbol_history", None)
@@ -7423,9 +7430,9 @@ class StrategyRunner:
                     reason = "insufficient_bars"
                 self._maybe_promote_pending_active_basket(source="selected_option_history_prewarm")
                 self._logger.info(
-                    "SELECTED_OPTION_HISTORY_PREWARM_RESULT symbol=%s bars_before=%s bars_after=%s required_bars=%s success=%s",
-                    symbol, bars_before, bars_after, required_bars, success,
-                    extra={"event": "SELECTED_OPTION_HISTORY_PREWARM_RESULT", "symbol": symbol, "bars_before": bars_before, "bars_after": bars_after, "required_bars": required_bars, "success": success, "reason": reason, "source": source, "trace_id": trace_id},
+                    "%s symbol=%s bars_before=%s bars_after=%s required_bars=%s success=%s",
+                    result_event, symbol, bars_before, bars_after, required_bars, success,
+                    extra={"event": result_event, "symbol": symbol, "bars_before": bars_before, "bars_after": bars_after, "required_bars": required_bars, "success": success, "reason": reason, "source": source, "trace_id": trace_id},
                 )
         try:
             loop = asyncio.get_running_loop()
@@ -7435,9 +7442,9 @@ class StrategyRunner:
         except Exception as exc:
             self._selected_option_prewarm_inflight.discard(symbol)
             self._logger.info(
-                "SELECTED_OPTION_HISTORY_PREWARM_RESULT symbol=%s bars_before=%s bars_after=%s required_bars=%s success=%s",
-                symbol, bars_before, bars_before, required_bars, False,
-                extra={"event": "SELECTED_OPTION_HISTORY_PREWARM_RESULT", "symbol": symbol, "bars_before": bars_before, "bars_after": bars_before, "required_bars": required_bars, "success": False, "reason": type(exc).__name__, "source": "prewarm_scheduler_exception", "trace_id": trace_id},
+                "%s symbol=%s bars_before=%s bars_after=%s required_bars=%s success=%s",
+                result_event, symbol, bars_before, bars_before, required_bars, False,
+                extra={"event": result_event, "symbol": symbol, "bars_before": bars_before, "bars_after": bars_before, "required_bars": required_bars, "success": False, "reason": type(exc).__name__, "source": "prewarm_scheduler_exception", "trace_id": trace_id},
             )
 
     def _history_count_for_symbol(self, symbol: str) -> int:
@@ -8735,6 +8742,7 @@ class StrategyRunner:
                                 bars_before=int(history_count),
                                 required_bars=int(required_bars),
                                 trace_id=trace_id,
+                                selected=self._is_selected_option_symbol(symbol),
                             )
                         spot_bars = len(self._indicator_engine.get_history("NSE:NIFTY") or [])
                         fut_symbol = next((sym for sym in self._active_symbols if self._is_context_symbol(sym) and sym != "NSE:NIFTY" and not self._is_context_symbol_suspended(sym)), "")

--- a/src/nifty_scalper_bot/utils/smart_symbol.py
+++ b/src/nifty_scalper_bot/utils/smart_symbol.py
@@ -30,6 +30,21 @@ NSE_HOLIDAYS = {
 }
 
 
+def is_nse_trading_day(day: date) -> bool:
+    """Return True when *day* is a weekday and not in the project NSE holiday set."""
+    return day.weekday() < 5 and day not in NSE_HOLIDAYS
+
+
+def next_nse_trading_day(start_day: date) -> date:
+    """Return the first NSE trading day on or after *start_day*."""
+    day = start_day
+    for _ in range(14):
+        if is_nse_trading_day(day):
+            return day
+        day += timedelta(days=1)
+    return day
+
+
 def now_ist() -> datetime:
     """Return current datetime in IST."""
     return datetime.now(IST)

--- a/tests/test_runtime_remaining_issues.py
+++ b/tests/test_runtime_remaining_issues.py
@@ -163,3 +163,100 @@ def test_eod_flatten_skips_weekend_and_holiday(monkeypatch):
     assert _next_eod_flatten_time_ist(datetime(2026, 6, 13, 10, 0, tzinfo=ist)).date().isoformat() == "2026-06-15"
     assert _next_eod_flatten_time_ist(datetime(2026, 6, 14, 10, 0, tzinfo=ist)).date().isoformat() == "2026-06-15"
     assert _next_eod_flatten_time_ist(datetime(2026, 10, 2, 10, 0, tzinfo=ist)).date().isoformat() == "2026-10-05"
+
+
+def test_startup_quote_event_uses_canonical_tradable_results():
+    source = __import__("pathlib").Path("src/nifty_scalper_bot/core/app.py").read_text()
+    assert "option_ticks_ready = bool(ce_qr.tradable_quote_ready and pe_qr.tradable_quote_ready)" in source
+    assert 'quote_event = "OPTION_TRADABLE_QUOTE_READY" if option_ticks_ready else "OPTION_TRADABLE_QUOTE_NOT_READY"' in source
+    assert '"ce_quote_readiness": ce_qr.to_dict()' in source
+
+
+def test_ltp_only_quote_does_not_arm_live_execution():
+    from nifty_scalper_bot.execution.readiness import compute_live_readiness
+
+    ce_qr = evaluate_quote_readiness(CE, {"ltp": 100.0, "tick_age_s": 1.0}, max_age_s=5.0)
+    pe_qr = evaluate_quote_readiness(PE, {"ltp": 90.0, "tick_age_s": 1.0}, max_age_s=5.0)
+    assert ce_qr.ltp_ready is True
+    assert pe_qr.ltp_ready is True
+    assert ce_qr.tradable_quote_ready is False
+    assert pe_qr.tradable_quote_ready is False
+
+    armed, reasons = compute_live_readiness(
+        live_mode=True,
+        hard_ready=True,
+        quote_available=True,
+        ws_quote_proof=True,
+        market_open=True,
+        runner_running=True,
+        selected_ce=CE,
+        selected_pe=PE,
+        ce_bars=30,
+        pe_bars=30,
+        option_exec_min_bars=30,
+        ce_quote_ready=ce_qr.tradable_quote_ready,
+        pe_quote_ready=pe_qr.tradable_quote_ready,
+    )
+    assert armed is False
+    assert "selected_ce_quote_missing" in reasons
+    assert "selected_pe_quote_missing" in reasons
+
+
+def test_no_execution_module_reads_ambiguous_quote_ready():
+    from pathlib import Path
+    for path in Path("src/nifty_scalper_bot/execution").glob("*.py"):
+        text = path.read_text()
+        assert 'get("quote_ready"' not in text
+        assert "['quote_ready']" not in text
+        assert '.quote_ready' not in text
+
+
+def test_partial_token_mapping_logs_diagnostic_and_preserves_tokens(caplog):
+    with caplog.at_level("INFO"):
+        basket = normalize_active_basket_schema({
+            "spot_symbol": "NSE:NIFTY",
+            "spot_token": 1,
+            "futures_symbol": "NFO:NIFTY26JUNFUT",
+            "futures_token": 2,
+            "selected_ce": CE,
+            "selected_pe": PE,
+            "selected_ce_token": 3,
+            "selected_pe_token": 4,
+            "option_symbols": [CE, PE],
+            "all_tokens": [1, 2, 3, 4],
+            "option_tokens": [3, 4],
+            "token_by_symbol": {CE: 3},
+        })
+    assert basket["all_tokens"] == [1, 2, 3, 4]
+    assert basket["option_tokens"] == [3, 4]
+    assert basket["selected_ce_token"] == 3
+    assert basket["selected_pe_token"] == 4
+    rec = next(record for record in caplog.records if getattr(record, "event", "") == "ACTIVE_BASKET_TOKEN_MAP_PARTIAL")
+    assert rec.mapped_symbol_count == 1
+    assert rec.expected_symbol_count == 4
+    assert rec.preserved_all_token_count == 4
+    assert rec.preserved_option_token_count == 2
+
+
+def test_mdm_runtime_clamp_keeps_8_options_and_10_total_tokens(monkeypatch):
+    monkeypatch.setenv("MAX_ACTIVE_OPTION_SYMBOLS", "8")
+    mdm = MarketDataManager(broker=SimpleNamespace(), settings=SimpleNamespace(history_min_interval_sec=0))
+    option_symbols = [f"NFO:NIFTY26JUN25{i:03d}CE" for i in range(10)]
+    token_by_symbol = {"NSE:NIFTY": 1, "NFO:NIFTY26JUNFUT": 2}
+    token_by_symbol.update({sym: idx + 3 for idx, sym in enumerate(option_symbols)})
+    basket = {
+        "spot_symbol": "NSE:NIFTY",
+        "futures_symbol": "NFO:NIFTY26JUNFUT",
+        "selected_ce": option_symbols[0],
+        "selected_pe": option_symbols[1],
+        "option_symbols": option_symbols,
+        "symbols": ["NSE:NIFTY", "NFO:NIFTY26JUNFUT", *option_symbols],
+        "all_symbols": ["NSE:NIFTY", "NFO:NIFTY26JUNFUT", *option_symbols],
+        "all_tokens": list(token_by_symbol.values()),
+        "token_by_symbol": token_by_symbol,
+    }
+    mdm.set_active_contract_basket(basket)
+    option_tokens = {token_by_symbol[s] for s in option_symbols}
+    desired = set(mdm._desired_tokens)
+    assert len(desired & option_tokens) <= 8
+    assert len(desired) <= 10

--- a/tests/test_runtime_remaining_issues.py
+++ b/tests/test_runtime_remaining_issues.py
@@ -1,0 +1,88 @@
+import asyncio
+from datetime import datetime
+from types import SimpleNamespace
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from nifty_scalper_bot.core.active_basket import normalize_active_basket_schema
+from nifty_scalper_bot.core.app import _next_eod_flatten_time_ist
+from nifty_scalper_bot.data.market_data_manager import MarketDataManager
+from nifty_scalper_bot.execution.readiness import evaluate_quote_readiness
+
+
+def test_quote_readiness_separates_ltp_and_tradable_quote():
+    ltp_only = {"ltp": 100.0, "source": "ws", "tick_age_s": 1.0}
+    status = evaluate_quote_readiness("NFO:NIFTY26JUN25000CE", ltp_only, max_spread_pct=5.0, max_age_s=5.0)
+    assert status.ltp_ready is True
+    assert status.bid_ask_available is False
+    assert status.tradable_quote_ready is False
+    assert status.reason == "bid_ask_missing"
+
+    crossed = {"ltp": 100.0, "bid": 101.0, "ask": 100.0, "tick_age_s": 1.0}
+    assert evaluate_quote_readiness("NFO:NIFTY26JUN25000CE", crossed, max_spread_pct=5.0).reason == "bid_ask_crossed"
+
+    ready = {"ltp": 100.0, "bid": 99.9, "ask": 100.1, "tick_age_s": 1.0, "source": "ws"}
+    status = evaluate_quote_readiness("NFO:NIFTY26JUN25000CE", ready, max_spread_pct=5.0, max_age_s=5.0)
+    assert status.ltp_ready is True
+    assert status.bid_ask_available is True
+    assert status.tradable_quote_ready is True
+    assert status.reason == "ready"
+
+
+@pytest.mark.asyncio
+async def test_hydration_request_coalesces_smaller_request(monkeypatch):
+    mdm = MarketDataManager(broker=SimpleNamespace(), settings=SimpleNamespace(history_min_interval_sec=0))
+    calls = 0
+
+    async def fake_fetch(symbol, interval, days):
+        nonlocal calls
+        calls += 1
+        await asyncio.sleep(0.05)
+        return [{"timestamp": datetime(2026, 6, 12, 9, 15, tzinfo=ZoneInfo("UTC")), "open": 1, "high": 1, "low": 1, "close": 1}]
+
+    monkeypatch.setattr(mdm, "fetch_history", fake_fetch)
+    monkeypatch.setattr(mdm, "ingest_historical_ohlc", lambda *_a, **_k: 1)
+    monkeypatch.setattr(mdm, "update_hydration_status", lambda *_a, **_k: None)
+    monkeypatch.setattr(mdm, "get_ohlc_bars", lambda *_a, **_k: [])
+
+    big = asyncio.create_task(mdm.hydrate_symbol_history("NFO:NIFTY26JUN25000CE", max_bars=300))
+    await asyncio.sleep(0)
+    small = asyncio.create_task(mdm.hydrate_symbol_history("NFO:NIFTY26JUN25000CE", max_bars=30))
+    await asyncio.gather(big, small)
+    assert calls == 1
+
+
+def test_active_basket_normalizes_option_counts_and_context_tokens():
+    basket = normalize_active_basket_schema({
+        "spot_symbol": "NSE:NIFTY",
+        "futures_symbol": "NFO:NIFTY26JUNFUT",
+        "selected_ce": "NFO:NIFTY26JUN25000CE",
+        "selected_pe": "NFO:NIFTY26JUN25000PE",
+        "option_symbols": [
+            "NSE:NIFTY", "NFO:NIFTY26JUNFUT", "NFO:NIFTY26JUN25000CE", "NFO:NIFTY26JUN25000PE",
+            "NFO:NIFTY26JUN25050CE", "NFO:NIFTY26JUN25050PE", "NFO:NIFTY26JUN25100CE", "NFO:NIFTY26JUN25100PE",
+            "NFO:NIFTY26JUN25150CE", "NFO:NIFTY26JUN25150PE", "NFO:NIFTY26JUN25200CE",
+        ],
+        "token_by_symbol": {"NSE:NIFTY": 1, "NFO:NIFTY26JUNFUT": 2, "NFO:NIFTY26JUN25000CE": 3, "NFO:NIFTY26JUN25000PE": 4},
+    })
+    assert all(str(sym).endswith(("CE", "PE")) for sym in basket["option_symbols"])
+    assert "NSE:NIFTY" not in basket["option_symbols"]
+    assert "NFO:NIFTY26JUNFUT" not in basket["option_symbols"]
+    assert len(basket["option_symbols"]) <= 8
+    assert len(basket["symbols"]) <= 10
+    assert len(basket["all_tokens"]) <= 10
+    assert basket["option_symbols"].count("NFO:NIFTY26JUN25000CE") == 1
+    assert basket["option_symbols"].count("NFO:NIFTY26JUN25000PE") == 1
+
+
+def test_eod_flatten_skips_weekend_and_holiday_and_after_cutoff():
+    ist = ZoneInfo("Asia/Kolkata")
+    # normal weekday before cutoff schedules same day
+    assert _next_eod_flatten_time_ist(datetime(2026, 6, 12, 15, 0, tzinfo=ist)).date().isoformat() == "2026-06-12"
+    # Friday after cutoff rolls to Monday (2026-06-13/14 are Saturday/Sunday)
+    assert _next_eod_flatten_time_ist(datetime(2026, 6, 12, 15, 25, tzinfo=ist)).date().isoformat() == "2026-06-15"
+    assert _next_eod_flatten_time_ist(datetime(2026, 6, 13, 10, 0, tzinfo=ist)).date().isoformat() == "2026-06-15"
+    assert _next_eod_flatten_time_ist(datetime(2026, 6, 14, 10, 0, tzinfo=ist)).date().isoformat() == "2026-06-15"
+    # 2026-10-02 is in the project NSE_HOLIDAYS set; roll to next weekday.
+    assert _next_eod_flatten_time_ist(datetime(2026, 10, 2, 10, 0, tzinfo=ist)).date().isoformat() == "2026-10-5"

--- a/tests/test_runtime_remaining_issues.py
+++ b/tests/test_runtime_remaining_issues.py
@@ -6,83 +6,160 @@ from zoneinfo import ZoneInfo
 import pytest
 
 from nifty_scalper_bot.core.active_basket import normalize_active_basket_schema
-from nifty_scalper_bot.core.app import _next_eod_flatten_time_ist
+import nifty_scalper_bot.core.app as app
+from nifty_scalper_bot.core.app import _commit_active_dynamic_basket, _next_eod_flatten_time_ist
+from nifty_scalper_bot.core.option_universe import OptionUniverseManager
 from nifty_scalper_bot.data.market_data_manager import MarketDataManager
 from nifty_scalper_bot.execution.readiness import evaluate_quote_readiness
 
+CE = "NFO:NIFTY26JUN25000CE"
+PE = "NFO:NIFTY26JUN25000PE"
 
-def test_quote_readiness_separates_ltp_and_tradable_quote():
+
+def test_quote_readiness_separates_ltp_and_blocks_unknown_age():
     ltp_only = {"ltp": 100.0, "source": "ws", "tick_age_s": 1.0}
-    status = evaluate_quote_readiness("NFO:NIFTY26JUN25000CE", ltp_only, max_spread_pct=5.0, max_age_s=5.0)
+    status = evaluate_quote_readiness(CE, ltp_only, max_spread_pct=5.0, max_age_s=5.0)
     assert status.ltp_ready is True
     assert status.bid_ask_available is False
     assert status.tradable_quote_ready is False
     assert status.reason == "bid_ask_missing"
 
     crossed = {"ltp": 100.0, "bid": 101.0, "ask": 100.0, "tick_age_s": 1.0}
-    assert evaluate_quote_readiness("NFO:NIFTY26JUN25000CE", crossed, max_spread_pct=5.0).reason == "bid_ask_crossed"
+    assert evaluate_quote_readiness(CE, crossed, max_spread_pct=5.0).reason == "bid_ask_crossed"
+
+    unknown_age = {"ltp": 100.0, "bid": 99.9, "ask": 100.1, "source": "ws"}
+    status = evaluate_quote_readiness(CE, unknown_age, max_spread_pct=5.0, max_age_s=5.0)
+    assert status.reason == "quote_age_unknown"
+    assert status.tradable_quote_ready is False
 
     ready = {"ltp": 100.0, "bid": 99.9, "ask": 100.1, "tick_age_s": 1.0, "source": "ws"}
-    status = evaluate_quote_readiness("NFO:NIFTY26JUN25000CE", ready, max_spread_pct=5.0, max_age_s=5.0)
-    assert status.ltp_ready is True
-    assert status.bid_ask_available is True
+    status = evaluate_quote_readiness(CE, ready, max_spread_pct=5.0, max_age_s=5.0)
     assert status.tradable_quote_ready is True
     assert status.reason == "ready"
 
 
+def test_quote_readiness_is_shared_by_mdm_startup_and_runtime(monkeypatch):
+    mdm = MarketDataManager(broker=SimpleNamespace(), settings=SimpleNamespace(history_min_interval_sec=0))
+    tick = {"ltp": 100.0, "bid": 99.9, "ask": 100.1, "tick_age_s": 1.0, "source": "ws", "bid_ask_source": "ws_full"}
+    monkeypatch.setattr(mdm, "get_latest_tick", lambda _s: tick)
+    monkeypatch.setattr(mdm, "get_quote", lambda _s: None)
+    monkeypatch.setattr(mdm, "get_ohlc_bars", lambda _s, **_k: [1] * 10)
+    mdm._latest_ticks[CE] = tick
+    report = mdm.hydrate_active_contract_basket({"selected_ce": CE, "selected_pe": PE, "option_symbols": [CE], "token_by_symbol": {CE: 1}, "all_symbols": [CE]})
+    assert report["symbols"][CE]["tradable_quote_ready"] is True
+    assert mdm.has_ws_tradable_quote([CE]) is True
+
+
 @pytest.mark.asyncio
-async def test_hydration_request_coalesces_smaller_request(monkeypatch):
+@pytest.mark.parametrize("first_bars,second_bars,expected_calls", [(300, 30, 1), (30, 300, 2), (300, 300, 1)])
+async def test_hydration_request_coalescing_orders(monkeypatch, first_bars, second_bars, expected_calls):
     mdm = MarketDataManager(broker=SimpleNamespace(), settings=SimpleNamespace(history_min_interval_sec=0))
     calls = 0
+    cached = []
 
     async def fake_fetch(symbol, interval, days):
         nonlocal calls
         calls += 1
         await asyncio.sleep(0.05)
-        return [{"timestamp": datetime(2026, 6, 12, 9, 15, tzinfo=ZoneInfo("UTC")), "open": 1, "high": 1, "low": 1, "close": 1}]
+        return [{"timestamp": datetime(2026, 6, 12, 9, 15, tzinfo=ZoneInfo("UTC")), "open": i, "high": i, "low": i, "close": i} for i in range(first_bars if calls == 1 else second_bars)]
+
+    def ingest(_symbol, rows):
+        cached[:] = list(rows)
+        return len(rows)
 
     monkeypatch.setattr(mdm, "fetch_history", fake_fetch)
+    monkeypatch.setattr(mdm, "ingest_historical_ohlc", ingest)
+    monkeypatch.setattr(mdm, "update_hydration_status", lambda *_a, **_k: None)
+    monkeypatch.setattr(mdm, "get_ohlc_bars", lambda *_a, **_k: list(cached))
+
+    first = asyncio.create_task(mdm.hydrate_symbol_history(CE, max_bars=first_bars))
+    await asyncio.sleep(0)
+    second = asyncio.create_task(mdm.hydrate_symbol_history(CE, max_bars=second_bars))
+    await asyncio.gather(first, second)
+    assert calls == expected_calls
+
+
+@pytest.mark.asyncio
+async def test_hydration_failed_task_cleanup_and_independent_symbols(monkeypatch):
+    mdm = MarketDataManager(broker=SimpleNamespace(), settings=SimpleNamespace(history_min_interval_sec=0))
+    calls = []
+
+    async def failing_fetch(symbol, interval, days):
+        calls.append(symbol)
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(mdm, "fetch_history", failing_fetch)
+    with pytest.raises(RuntimeError):
+        await mdm.hydrate_symbol_history(CE, max_bars=30)
+    assert mdm._history_inflight == {}
+
+    async def ok_fetch(symbol, interval, days):
+        calls.append(symbol)
+        await asyncio.sleep(0.02)
+        return [{"timestamp": datetime(2026, 6, 12, 9, 15, tzinfo=ZoneInfo("UTC")), "open": 1, "high": 1, "low": 1, "close": 1}]
+
+    monkeypatch.setattr(mdm, "fetch_history", ok_fetch)
     monkeypatch.setattr(mdm, "ingest_historical_ohlc", lambda *_a, **_k: 1)
     monkeypatch.setattr(mdm, "update_hydration_status", lambda *_a, **_k: None)
     monkeypatch.setattr(mdm, "get_ohlc_bars", lambda *_a, **_k: [])
-
-    big = asyncio.create_task(mdm.hydrate_symbol_history("NFO:NIFTY26JUN25000CE", max_bars=300))
-    await asyncio.sleep(0)
-    small = asyncio.create_task(mdm.hydrate_symbol_history("NFO:NIFTY26JUN25000CE", max_bars=30))
-    await asyncio.gather(big, small)
-    assert calls == 1
+    await asyncio.gather(mdm.hydrate_symbol_history(CE, max_bars=30), mdm.hydrate_symbol_history(PE, max_bars=30))
+    assert CE in calls and PE in calls
 
 
-def test_active_basket_normalizes_option_counts_and_context_tokens():
+def test_active_basket_normalizes_counts_and_preserves_partial_tokens():
     basket = normalize_active_basket_schema({
         "spot_symbol": "NSE:NIFTY",
         "futures_symbol": "NFO:NIFTY26JUNFUT",
-        "selected_ce": "NFO:NIFTY26JUN25000CE",
-        "selected_pe": "NFO:NIFTY26JUN25000PE",
-        "option_symbols": [
-            "NSE:NIFTY", "NFO:NIFTY26JUNFUT", "NFO:NIFTY26JUN25000CE", "NFO:NIFTY26JUN25000PE",
-            "NFO:NIFTY26JUN25050CE", "NFO:NIFTY26JUN25050PE", "NFO:NIFTY26JUN25100CE", "NFO:NIFTY26JUN25100PE",
-            "NFO:NIFTY26JUN25150CE", "NFO:NIFTY26JUN25150PE", "NFO:NIFTY26JUN25200CE",
-        ],
-        "token_by_symbol": {"NSE:NIFTY": 1, "NFO:NIFTY26JUNFUT": 2, "NFO:NIFTY26JUN25000CE": 3, "NFO:NIFTY26JUN25000PE": 4},
+        "selected_ce": CE,
+        "selected_pe": PE,
+        "option_symbols": ["NSE:NIFTY", "NFO:NIFTY26JUNFUT", CE, PE, CE, "NFO:NIFTY26JUN25050CE", "NFO:NIFTY26JUN25050PE", "NFO:NIFTY26JUN25100CE", "NFO:NIFTY26JUN25100PE", "NFO:NIFTY26JUN25150CE", "NFO:NIFTY26JUN25150PE", "NFO:NIFTY26JUN25200CE"],
+        "all_tokens": [1, 2, 3, 4, 5],
+        "option_tokens": [3, 4, 5],
+        "token_by_symbol": {CE: 3},
     })
     assert all(str(sym).endswith(("CE", "PE")) for sym in basket["option_symbols"])
     assert "NSE:NIFTY" not in basket["option_symbols"]
     assert "NFO:NIFTY26JUNFUT" not in basket["option_symbols"]
+    assert basket["futures_symbol"].endswith("FUT")
     assert len(basket["option_symbols"]) <= 8
     assert len(basket["symbols"]) <= 10
     assert len(basket["all_tokens"]) <= 10
-    assert basket["option_symbols"].count("NFO:NIFTY26JUN25000CE") == 1
-    assert basket["option_symbols"].count("NFO:NIFTY26JUN25000PE") == 1
+    assert basket["all_tokens"] == [1, 2, 3, 4, 5]
+    assert basket["option_tokens"] == [3, 4, 5]
+    assert basket["option_symbols"].count(CE) == 1
+    assert basket["option_symbols"].count(PE) == 1
 
 
-def test_eod_flatten_skips_weekend_and_holiday_and_after_cutoff():
+def test_context_only_basket_cannot_overwrite_tradable_basket_and_universe_stays_available():
+    class Dummy:
+        pass
+    ctx = Dummy()
+    ctx.active_trading_universe = {"selected_ce": CE, "selected_pe": PE, "option_symbols": [CE, PE], "token_by_symbol": {CE: 1, PE: 2}}
+    ctx.active_contract_basket = dict(ctx.active_trading_universe)
+    ctx.selected_ce = CE
+    ctx.selected_pe = PE
+    ctx.atm_ce_symbol = CE
+    ctx.atm_pe_symbol = PE
+    ctx.active_symbol_tokens = {CE: 1, PE: 2}
+    ctx.strategy_runner = SimpleNamespace(set_active_trading_universe=lambda basket: setattr(ctx, "runner_basket", basket))
+    ctx.data_hub = SimpleNamespace(set_active_contract_basket=lambda basket: setattr(ctx, "datahub_basket", basket))
+    ctx.option_universe = OptionUniverseManager(SimpleNamespace(strike_step=50, strikes_each_side=2))
+    ctx.strategy_manager = None
+    ctx.market_data_manager = None
+    ctx.instrument_manager = None
+    old_basket = ctx.active_contract_basket
+
+    _commit_active_dynamic_basket(ctx, basket={"spot_symbol": "NSE:NIFTY"}, option_symbols=[], symbols=["NSE:NIFTY"], atm_strike=None)
+    assert ctx.active_contract_basket is old_basket
+    assert ctx.option_universe.get_current_universe() == [CE, PE]
+
+
+def test_eod_flatten_skips_weekend_and_holiday(monkeypatch):
     ist = ZoneInfo("Asia/Kolkata")
-    # normal weekday before cutoff schedules same day
+    holidays = {datetime(2026, 10, 2, tzinfo=ist).date()}
+    monkeypatch.setattr(app, "is_nse_trading_day", lambda day: day.weekday() < 5 and day not in holidays)
     assert _next_eod_flatten_time_ist(datetime(2026, 6, 12, 15, 0, tzinfo=ist)).date().isoformat() == "2026-06-12"
-    # Friday after cutoff rolls to Monday (2026-06-13/14 are Saturday/Sunday)
     assert _next_eod_flatten_time_ist(datetime(2026, 6, 12, 15, 25, tzinfo=ist)).date().isoformat() == "2026-06-15"
     assert _next_eod_flatten_time_ist(datetime(2026, 6, 13, 10, 0, tzinfo=ist)).date().isoformat() == "2026-06-15"
     assert _next_eod_flatten_time_ist(datetime(2026, 6, 14, 10, 0, tzinfo=ist)).date().isoformat() == "2026-06-15"
-    # 2026-10-02 is in the project NSE_HOLIDAYS set; roll to next weekday.
-    assert _next_eod_flatten_time_ist(datetime(2026, 10, 2, 10, 0, tzinfo=ist)).date().isoformat() == "2026-10-5"
+    assert _next_eod_flatten_time_ist(datetime(2026, 10, 2, 10, 0, tzinfo=ist)).date().isoformat() == "2026-10-05"


### PR DESCRIPTION
### Motivation
- Logs showed inconsistent quote readiness and duplicate hydration calls because multiple partial checks were used across startup, MDM, runner, and execution, and there was no per-symbol hydration coalescing or canonical basket normalization.
- The project needs a single canonical quote-readiness contract and deterministic basket normalization to avoid contradictory readiness events, duplicate history fetches, misclassified context symbols, and incorrect counts.

### Description
- Added a canonical `QuoteReadiness` and `evaluate_quote_readiness` that separates `ltp_ready`, `depth_available`, `bid_ask_available`, and `tradable_quote_ready`, and used it from startup, MDM, execution readiness, and health logs (`src/nifty_scalper_bot/execution/readiness.py`).
- Wired MDM to use the canonical helper and emit precise reasons; replaced `OPTION_QUOTE_READY` with `OPTION_TRADABLE_QUOTE_READY` / `OPTION_TRADABLE_QUOTE_NOT_READY` and explicit CE/PE booleans (`src/nifty_scalper_bot/data/market_data_manager.py`, `src/nifty_scalper_bot/core/app.py`).
- Implemented per-symbol/interval hydration coalescing so a smaller `max_bars` join an inflight larger fetch and added `HYDRATION_REQUEST_CREATED`, `HYDRATION_REQUEST_JOINED`, and `HYDRATION_REQUEST_COMPLETED` logs while safely cleaning inflight tasks (`src/nifty_scalper_bot/data/market_data_manager.py`).
- Normalized active basket schema before commit to ensure only CE/PE options are in option lists, deduplicate symbols/tokens, enforce the 8-option / 10-token caps, preserve selected CE/PE exactly once, and avoid context-only updates clearing a valid tradable basket (`src/nifty_scalper_bot/core/active_basket.py`, `src/nifty_scalper_bot/core/app.py`).
- Renamed non-selected prewarm logs to `OPTION_CONTEXT_HISTORY_PREWARM_REQUESTED` / `OPTION_CONTEXT_HISTORY_PREWARM_RESULT` while keeping selected-option event names for selected CE/PE, and split hydration reasons so futures/spot context refreshes are not labeled `dynamic_option_universe` (`src/nifty_scalper_bot/strategies/runner.py`, `src/nifty_scalper_bot/core/app.py`).
- Made EOD flatten scheduler trading-calendar-aware to skip weekends and NSE holidays via `_next_eod_flatten_time_ist` and project calendar (`src/nifty_scalper_bot/core/app.py`, `src/nifty_scalper_bot/utils/smart_symbol.py`).
- Added focused regression tests covering quote readiness semantics, hydration coalescing, basket normalization/count caps, and EOD flatten calendar behavior (`tests/test_runtime_remaining_issues.py`).

### Testing
- Ran `python -m compileall -q src` and a full test suite with `pytest -q`; compilation and tests completed successfully.
- Ran focused tests: `pytest -q tests/test_runtime_remaining_issues.py`, `pytest -q tests/core/test_startup_readiness_regressions.py tests/core/test_startup_sequencing.py`, `pytest -q tests/data/test_mdm_datahub_hydration.py`, `pytest -q tests/strategies/test_runner_live_path_guards.py::test_selected_option_prewarm_accepts_async_hydrator_list_result`, and all passed.
- Full `pytest -q` was executed and passed in CI-local run; no regressions observed in market-data, hydration, readiness, or runner prewarm behaviors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d3cec927c83248d44ddcc1c25a81d)