### PR TITLE
Canonicalize runtime history SSOT: shared role resolver, MDM OHLC owner, and target-aware Runner scheduler

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -8101,7 +8101,22 @@ async def ensure_symbol_runtime_history(
     failure_reason: str | None = None
     if mdm is None or not callable(getattr(mdm, "ensure_history", None)):
         failure_reason = "mdm_ensure_history_missing"
-        return RuntimeHistoryResult(symbol, policy.role, policy.phase, reason, policy.required_bars, policy.target_bars, 0, 0, 0, False, False, False, None, failure_reason)
+        return RuntimeHistoryResult(
+            symbol=symbol,
+            role=policy.role,
+            phase=policy.phase,
+            reason=reason,
+            required_bars=policy.required_bars,
+            target_bars=policy.target_bars,
+            mdm_bars=0,
+            runner_bars=0,
+            indicator_bars=0,
+            minimum_ready=False,
+            target_ready=False,
+            sync_success=False,
+            hydration=None,
+            failure_reason=failure_reason,
+        )
     if policy.allow_broker_fetch:
         hydration = await mdm.ensure_history(
             symbol,
@@ -8151,7 +8166,22 @@ async def ensure_symbol_runtime_history(
         symbol, policy.role, policy.phase, reason, policy.required_bars, policy.target_bars, mdm_bars, runner_bars, indicator_bars, minimum_ready, target_ready, failure_reason,
         extra={"event": "CANONICAL_HISTORY_RESULT", "symbol": symbol, "role": policy.role, "phase": policy.phase, "reason": reason, "required_bars": policy.required_bars, "target_bars": policy.target_bars, "mdm_bars": mdm_bars, "runner_bars": runner_bars, "indicator_bars": indicator_bars, "minimum_ready": minimum_ready, "target_ready": target_ready, "failure_reason": failure_reason},
     )
-    return RuntimeHistoryResult(symbol, policy.role, policy.phase, reason, policy.required_bars, policy.target_bars, mdm_bars, runner_bars, indicator_bars, minimum_ready, target_ready, sync_success, hydration, failure_reason)
+    return RuntimeHistoryResult(
+        symbol=symbol,
+        role=policy.role,
+        phase=policy.phase,
+        reason=reason,
+        required_bars=policy.required_bars,
+        target_bars=policy.target_bars,
+        mdm_bars=mdm_bars,
+        runner_bars=runner_bars,
+        indicator_bars=indicator_bars,
+        minimum_ready=minimum_ready,
+        target_ready=target_ready,
+        sync_success=sync_success,
+        hydration=hydration,
+        failure_reason=failure_reason,
+    )
 
 
 async def _ensure_context_history_hydrated(

--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -53,6 +53,8 @@ from nifty_scalper_bot.core.active_basket import (
     pick_atm_option_symbols_from_basket,
 )
 
+from nifty_scalper_bot.core.history_roles import resolve_symbol_history_role as _shared_resolve_symbol_history_role
+
 from nifty_scalper_bot.data.robust_provider import (
     CircuitBreakerConfig,
     RobustDataProvider,
@@ -4228,10 +4230,7 @@ def initialize_components(settings: Settings | None = None) -> BotContext:
     rate_limiter = _configure_rate_limiter(config.ratelimit)
     message_bus = MessageBus()
 
-    from nifty_scalper_bot.data.robust_provider import (
-        CircuitBreakerConfig,
-        RobustDataProvider,
-    )
+
 
     broker_client = ZerodhaKiteClient(
         api_key=config.broker.api_key,
@@ -7898,41 +7897,28 @@ def resolve_symbol_history_role(ctx: "BotContext", symbol: str) -> str:
     normalized before comparison; not every CE/PE is 'selected'. Raises: none.
     """
     runner = getattr(ctx, "strategy_runner", None)
-
-    def _n(value: Any) -> str:
-        s = str(value or "").strip().upper()
-        return s
-
-    norm = _n(symbol)
-    if not norm:
-        return "option_context"
-
-    selected = set()
     basket = getattr(ctx, "active_contract_basket", None)
-    for src_obj, attrs in ((basket, ("selected_ce", "selected_pe")), (runner, ("_active_selected_ce", "_active_selected_pe"))):
-        for attr in attrs:
-            val = _n(getattr(src_obj, attr, None))
-            if val:
-                selected.add(val)
-    if norm in selected:
-        return "selected_option"
 
-    spot = _n(getattr(ctx, "spot_symbol", None)) or _n(getattr(runner, "_spot_symbol", None))
-    if norm == spot or (norm.startswith("NSE:") and "NIFTY" in norm):
-        return "spot_context"
+    def _attr(obj: Any, name: str) -> Any:
+        if isinstance(obj, Mapping):
+            return obj.get(name)
+        return getattr(obj, name, None)
 
-    fut = _n(getattr(runner, "_active_futures_symbol", None)) or _n(getattr(ctx, "active_futures_symbol", None))
-    if norm == fut or norm.endswith("FUT"):
-        return "futures_context"
-
+    manager = getattr(ctx, "position_manager", None) or getattr(runner, "_position_manager", None)
+    open_symbols: list[str] = []
     try:
-        manager = getattr(ctx, "position_manager", None) or getattr(runner, "_position_manager", None)
-        open_syms = {_n(getattr(p, "symbol", p)) for p in (manager.get_open_positions() if manager else [])}
-        if norm in open_syms:
-            return "recovery_or_open_position"
+        if manager is not None and callable(getattr(manager, "get_open_positions", None)):
+            open_symbols = [str(getattr(p, "symbol", p)) for p in manager.get_open_positions()]
     except Exception:
-        pass
-    return "option_context"
+        open_symbols = []
+    return _shared_resolve_symbol_history_role(
+        symbol=symbol,
+        selected_ce=_attr(basket, "selected_ce") or getattr(runner, "_active_selected_ce", None),
+        selected_pe=_attr(basket, "selected_pe") or getattr(runner, "_active_selected_pe", None),
+        spot_symbol=getattr(ctx, "spot_symbol", None) or getattr(runner, "_spot_symbol", None) or "NSE:NIFTY",
+        futures_symbol=getattr(runner, "_active_futures_symbol", None) or getattr(ctx, "active_futures_symbol", None),
+        open_position_symbols=open_symbols,
+    )
 
 
 def compute_selected_option_history_readiness(
@@ -8156,13 +8142,14 @@ async def ensure_symbol_runtime_history(
         mdm_bars = 0
     runner_bars = int(getattr(sync_result, "runner_bars", 0) or 0)
     indicator_bars = int(getattr(sync_result, "indicator_bars", 0) or 0)
-    minimum_ready = bool(mdm_bars >= policy.required_bars and runner_bars >= policy.required_bars and indicator_bars >= policy.required_bars and failure_reason is None)
+    readiness = compute_history_readiness(symbol=symbol, role=policy.role, required_bars=policy.required_bars, mdm_bars=mdm_bars, runner_bars=runner_bars, indicator_bars=indicator_bars)
+    minimum_ready = readiness.minimum_ready and failure_reason is None
     target_ready = bool(mdm_bars >= policy.target_bars and failure_reason is None)
     sync_success = bool(getattr(sync_result, "success", False)) if policy.sync_runner else True
     LOGGER.info(
-        "HISTORY_READINESS_COMPUTED symbol=%s role=%s phase=%s reason=%s required_bars=%s target_bars=%s mdm_bars=%s runner_bars=%s indicator_bars=%s minimum_ready=%s target_ready=%s failure_reason=%s",
+        "CANONICAL_HISTORY_RESULT symbol=%s role=%s phase=%s reason=%s required_bars=%s target_bars=%s mdm_bars=%s runner_bars=%s indicator_bars=%s minimum_ready=%s target_ready=%s failure_reason=%s",
         symbol, policy.role, policy.phase, reason, policy.required_bars, policy.target_bars, mdm_bars, runner_bars, indicator_bars, minimum_ready, target_ready, failure_reason,
-        extra={"event": "HISTORY_READINESS_COMPUTED", "symbol": symbol, "role": policy.role, "phase": policy.phase, "reason": reason, "required_bars": policy.required_bars, "target_bars": policy.target_bars, "mdm_bars": mdm_bars, "runner_bars": runner_bars, "indicator_bars": indicator_bars, "minimum_ready": minimum_ready, "target_ready": target_ready, "failure_reason": failure_reason},
+        extra={"event": "CANONICAL_HISTORY_RESULT", "symbol": symbol, "role": policy.role, "phase": policy.phase, "reason": reason, "required_bars": policy.required_bars, "target_bars": policy.target_bars, "mdm_bars": mdm_bars, "runner_bars": runner_bars, "indicator_bars": indicator_bars, "minimum_ready": minimum_ready, "target_ready": target_ready, "failure_reason": failure_reason},
     )
     return RuntimeHistoryResult(symbol, policy.role, policy.phase, reason, policy.required_bars, policy.target_bars, mdm_bars, runner_bars, indicator_bars, minimum_ready, target_ready, sync_success, hydration, failure_reason)
 

--- a/src/nifty_scalper_bot/core/history_roles.py
+++ b/src/nifty_scalper_bot/core/history_roles.py
@@ -11,8 +11,36 @@ from __future__ import annotations
 from collections.abc import Collection
 
 
+HISTORY_ROLE_PRIORITY: dict[str, int] = {
+    "option_context": 10,
+    "spot_context": 20,
+    "futures_context": 20,
+    "selected_option": 30,
+    "recovery_or_open_position": 40,
+}
+
+
 def _normalize(value: str | None) -> str:
     return str(value or "").strip().upper()
+
+
+def _spot_alias_key(value: str | None) -> str:
+    normalized = _normalize(value)
+    if normalized.startswith("NSE:"):
+        normalized = normalized.split(":", 1)[1]
+    return normalized.replace(" ", "")
+
+
+def is_same_spot_symbol(left: str | None, right: str | None) -> bool:
+    left_key = _spot_alias_key(left)
+    right_key = _spot_alias_key(right)
+    if not left_key or not right_key:
+        return False
+    return left_key in {"NIFTY", "NIFTY50"} and right_key in {"NIFTY", "NIFTY50"}
+
+
+def history_role_priority(role: str | None) -> int:
+    return HISTORY_ROLE_PRIORITY.get(_normalize(role).lower(), HISTORY_ROLE_PRIORITY["option_context"])
 
 
 def resolve_symbol_history_role(
@@ -33,8 +61,7 @@ def resolve_symbol_history_role(
     if normalized in selected:
         return "selected_option"
 
-    spot = _normalize(spot_symbol)
-    if normalized == spot or (not spot and normalized == "NSE:NIFTY"):
+    if is_same_spot_symbol(normalized, spot_symbol) or (not _normalize(spot_symbol) and is_same_spot_symbol(normalized, "NSE:NIFTY")):
         return "spot_context"
 
     future = _normalize(futures_symbol)

--- a/src/nifty_scalper_bot/core/history_roles.py
+++ b/src/nifty_scalper_bot/core/history_roles.py
@@ -1,0 +1,48 @@
+"""Shared runtime-history role resolution.
+
+Runtime role:
+- Provides the single neutral SSOT for symbol-to-history-role classification.
+- Consumes caller-provided selected/context/open-position symbols only.
+- Must not import app, runner, broker, DataHub, or MarketDataManager.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Collection
+
+
+def _normalize(value: str | None) -> str:
+    return str(value or "").strip().upper()
+
+
+def resolve_symbol_history_role(
+    *,
+    symbol: str | None,
+    selected_ce: str | None = None,
+    selected_pe: str | None = None,
+    spot_symbol: str | None = None,
+    futures_symbol: str | None = None,
+    open_position_symbols: Collection[str] = (),
+) -> str:
+    """Resolve the canonical runtime-history role for a symbol."""
+    normalized = _normalize(symbol)
+    if not normalized:
+        return "option_context"
+
+    selected = {_normalize(selected_ce), _normalize(selected_pe)}
+    if normalized in selected:
+        return "selected_option"
+
+    spot = _normalize(spot_symbol)
+    if normalized == spot or (not spot and normalized == "NSE:NIFTY"):
+        return "spot_context"
+
+    future = _normalize(futures_symbol)
+    if normalized == future or (not future and normalized.endswith("FUT")):
+        return "futures_context"
+
+    open_positions = {_normalize(str(item)) for item in open_position_symbols}
+    if normalized in open_positions:
+        return "recovery_or_open_position"
+
+    return "option_context"

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -284,7 +284,7 @@ class MarketDataManager:
         self._subscribers: dict[str, set[TickCallback]] = defaultdict(set)
         self._bar_subscribers: list[Callable[[dict[str, Any]], None]] = []
         self._latest_ticks: dict[str, dict[str, Any]] = {}
-        self._history: dict[str, Deque[dict[str, Any]]] = defaultdict(
+        self._raw_tick_history: dict[str, Deque[dict[str, Any]]] = defaultdict(
             lambda: deque(maxlen=self._cache_len)
         )
         self._token_by_symbol: dict[str, int] = {}
@@ -425,11 +425,11 @@ class MarketDataManager:
         )
         self._polling_policy = PollingPolicy.from_settings(settings)
         self._poll_error_last_log: dict[str, float] = {}
-        self._history_lock = asyncio.Lock()
-        self._history_inflight_lock = asyncio.Lock()
-        self._history_inflight: dict[tuple[str, str], tuple[int, asyncio.Task[list[dict[str, Any]]]]] = {}
+        self._canonical_history_lock = asyncio.Lock()
+        self._canonical_history_inflight_lock = asyncio.Lock()
+        self._canonical_history_inflight: dict[tuple[str, str], tuple[int, asyncio.Task[list[dict[str, Any]]]]] = {}
         self._last_history_request_ts = 0.0
-        self._history_min_interval_sec = float(
+        self._canonical_history_min_interval_sec = float(
             getattr(settings, "history_min_interval_sec", 1.2)
             if settings is not None
             else 1.2
@@ -831,7 +831,7 @@ class MarketDataManager:
                 "timestamp": ts.isoformat(),
                 "source": "historical",
             }
-            self._history[symbol].append(dict(payload))
+            self._raw_tick_history[symbol].append(dict(payload))
             self._ohlc[self._bar_symbol_key(symbol)].append(dict(payload))
             if isinstance(ts, datetime):
                 self._last_historical_ts[symbol] = ts.timestamp()
@@ -2999,7 +2999,7 @@ class MarketDataManager:
 
     def get_tick_history(self, symbol: str) -> list[dict[str, Any]]:
         with self._lock:
-            history = self._history.get(symbol)
+            history = self._raw_tick_history.get(symbol)
             if history is None:
                 return []
             return [dict(item) for item in history]
@@ -4086,7 +4086,7 @@ class MarketDataManager:
         """Args: symbol; Returns: bool; Raises: none."""
         normalized = normalize_symbol(str(symbol or ""))
         with self._lock:
-            return len(self._history.get(normalized, ())) >= self._min_required_bars
+            return len(self._raw_tick_history.get(normalized, ())) >= self._min_required_bars
 
     def is_ready(self) -> bool:
         """Args: none; Returns: bool; Raises: none."""
@@ -4095,7 +4095,7 @@ class MarketDataManager:
             if not active:
                 return False
             return all(
-                len(self._history.get(symbol, ())) >= self._min_required_bars
+                len(self._raw_tick_history.get(symbol, ())) >= self._min_required_bars
                 for symbol in active
             )
 
@@ -4113,7 +4113,7 @@ class MarketDataManager:
                 min_bars = self._min_required_bars
                 bars = {
                     symbol: max(
-                        len(self._history.get(symbol, ())),
+                        len(self._raw_tick_history.get(symbol, ())),
                         len(self._ohlc.get(self._bar_symbol_key(symbol), ())),
                     )
                     for symbol in subscribed_symbols
@@ -6001,7 +6001,7 @@ class MarketDataManager:
                     extra={"event": "mdm_history_append_rejected", "symbol": symbol},
                 )
                 return
-            self._history[symbol].append(cached_tick)
+            self._raw_tick_history[symbol].append(cached_tick)
             self._ticks_received_per_symbol[symbol] += 1
             self._symbols_with_tick.add(symbol)
             self._last_tick_wallclock[symbol] = float(now_wall)
@@ -6498,7 +6498,7 @@ class MarketDataManager:
                         if sym in self._active_subscribed_symbols
                     }
                     history_lengths = {
-                        sym: len(self._history.get(sym, ()))
+                        sym: len(self._raw_tick_history.get(sym, ()))
                         for sym in sorted(self._active_subscribed_symbols)
                     }
                     self._last_tick_rate_snapshot = dict(
@@ -7926,7 +7926,7 @@ class MarketDataManager:
                 self._latest_ticks.pop(symbol, None)
                 self._tick_cache.pop(symbol, None)
                 self._last_tick_snapshot.pop(symbol, None)
-                self._history.pop(symbol, None)
+                self._raw_tick_history.pop(symbol, None)
                 self._ohlc.pop(self._bar_symbol_key(symbol), None)
                 self._poll_bar_state.pop(symbol, None)
                 self._last_poll_bucket.pop(symbol, None)
@@ -8071,7 +8071,7 @@ class MarketDataManager:
                 self._subscribers.pop(old_canonical, None)
                 self._latest_ticks.pop(old_canonical, None)
                 self._tick_cache.pop(old_canonical, None)
-                self._history.pop(old_canonical, None)
+                self._raw_tick_history.pop(old_canonical, None)
                 self._ohlc.pop(self._bar_symbol_key(old_canonical), None)
                 self._last_tick_time.pop(old_canonical, None)
                 self._last_tick_wallclock.pop(old_canonical, None)
@@ -8153,7 +8153,7 @@ class MarketDataManager:
                 self._last_tick_source.get(canonical) or tick.get("source") or "unknown"
             ).lower()
             recent_cutoff = time.time() - 60.0
-            history = list(self._history.get(canonical, ()))
+            history = list(self._raw_tick_history.get(canonical, ()))
             real_ticks = sum(
                 1
                 for row in history
@@ -9521,6 +9521,24 @@ class MarketDataManager:
         """Normalize broker/DataHub OHLC row. Args: symbol/row/source. Returns: canonical bar or None. Raises: None."""
         return normalize_history_row(symbol, row, source=source)
 
+    @property
+    def _history(self) -> dict[str, Deque[dict[str, Any]]]:
+        """Deprecated compatibility alias for raw tick history, not OHLC history."""
+        return self._raw_tick_history
+
+    @_history.setter
+    def _history(self, value: dict[str, Deque[dict[str, Any]]]) -> None:
+        self._raw_tick_history = value
+
+    @property
+    def _history_inflight(self) -> dict[tuple[str, str], tuple[int, asyncio.Task[list[dict[str, Any]]]]]:
+        """Deprecated compatibility alias for the canonical history coordinator."""
+        return self._canonical_history_inflight
+
+    @_history_inflight.setter
+    def _history_inflight(self, value: dict[tuple[str, str], tuple[int, asyncio.Task[list[dict[str, Any]]]]]) -> None:
+        self._canonical_history_inflight = value
+
     # -------------------------------------------------------------------------
     # ✅ "HUNTER-KILLER" FIX: Robust History Fetching
     # -------------------------------------------------------------------------
@@ -9605,7 +9623,7 @@ class MarketDataManager:
             skip_reason = "minimum_cache_sufficient"
         if skip_reason:
             self._logger.info(
-                "HISTORY_ENSURE_SKIPPED symbol=%s role=%s phase=%s reason=%s required_bars=%s target_bars=%s cached_before=%s skip_reason=%s minimum_ready=%s target_ready=%s",
+                "CANONICAL_HISTORY_FETCH_RESULT symbol=%s role=%s phase=%s reason=%s required_bars=%s target_bars=%s cached_before=%s skip_reason=%s minimum_ready=%s target_ready=%s",
                 normalized,
                 role,
                 phase,
@@ -9617,7 +9635,7 @@ class MarketDataManager:
                 cached_before >= required,
                 cached_before >= target,
                 extra={
-                    "event": "HISTORY_ENSURE_SKIPPED",
+                    "event": "CANONICAL_HISTORY_FETCH_RESULT",
                     "symbol": normalized,
                     "role": role,
                     "phase": phase,
@@ -9641,10 +9659,10 @@ class MarketDataManager:
                 accepted_rows=0,
             )
 
-        if not hasattr(self, "_history_inflight"):
-            self._history_inflight = {}
-        if not hasattr(self, "_history_inflight_lock"):
-            self._history_inflight_lock = asyncio.Lock()
+        if not hasattr(self, "_canonical_history_inflight"):
+            self._canonical_history_inflight = {}
+        if not hasattr(self, "_canonical_history_inflight_lock"):
+            self._canonical_history_inflight_lock = asyncio.Lock()
 
         async def _run_hydration(requested_bars: int, request_cached_before: int) -> HydrationResult:
             fetched_rows = 0
@@ -9659,14 +9677,14 @@ class MarketDataManager:
             except Exception as exc:  # noqa: BLE001 - broker/data boundary diagnostics
                 failure_reason = f"{type(exc).__name__}: {exc}"
                 self._logger.warning(
-                    "HISTORY_ENSURE_FAILED symbol=%s role=%s phase=%s reason=%s exception_type=%s exception_message=%s",
+                    "CANONICAL_HISTORY_FETCH_RESULT symbol=%s role=%s phase=%s reason=%s exception_type=%s exception_message=%s",
                     normalized,
                     role,
                     phase,
                     reason,
                     type(exc).__name__,
                     str(exc),
-                    extra={"event": "HISTORY_ENSURE_FAILED", "symbol": normalized, "role": role, "phase": phase, "reason": reason, "exception_type": type(exc).__name__, "exception_message": str(exc)},
+                    extra={"event": "CANONICAL_HISTORY_FETCH_RESULT", "symbol": normalized, "role": role, "phase": phase, "reason": reason, "exception_type": type(exc).__name__, "exception_message": str(exc)},
                 )
             after = _cached_count()
             result = _result(
@@ -9680,7 +9698,7 @@ class MarketDataManager:
                 failure_reason=failure_reason,
             )
             self._logger.info(
-                "HISTORY_ENSURE_COMPLETED symbol=%s role=%s phase=%s reason=%s required_bars=%s target_bars=%s cached_before=%s fetched_rows=%s accepted_rows=%s cached_after=%s minimum_ready=%s target_ready=%s failure_reason=%s",
+                "CANONICAL_HISTORY_FETCH_RESULT symbol=%s role=%s phase=%s reason=%s required_bars=%s target_bars=%s cached_before=%s fetched_rows=%s accepted_rows=%s cached_after=%s minimum_ready=%s target_ready=%s failure_reason=%s",
                 normalized,
                 role,
                 phase,
@@ -9694,7 +9712,7 @@ class MarketDataManager:
                 result.minimum_ready,
                 result.target_ready,
                 failure_reason,
-                extra={"event": "HISTORY_ENSURE_COMPLETED", "symbol": normalized, "role": role, "phase": phase, "reason": reason, "required_bars": required, "target_bars": requested_bars, "cached_before": request_cached_before, "fetched_rows": fetched_rows, "accepted_rows": accepted_rows, "cached_after": after, "minimum_ready": result.minimum_ready, "target_ready": result.target_ready, "failure_reason": failure_reason},
+                extra={"event": "CANONICAL_HISTORY_FETCH_RESULT", "symbol": normalized, "role": role, "phase": phase, "reason": reason, "required_bars": required, "target_bars": requested_bars, "cached_before": request_cached_before, "fetched_rows": fetched_rows, "accepted_rows": accepted_rows, "cached_after": after, "minimum_ready": result.minimum_ready, "target_ready": result.target_ready, "failure_reason": failure_reason},
             )
             return result
 
@@ -9710,15 +9728,15 @@ class MarketDataManager:
                 return _result(cached_before=cached_before, cached_after=cached_now, broker_fetch_started=False, joined_inflight=joined_any, broker_fetch_observed=joined_observed_fetch, fetched_rows=joined_fetched_rows, accepted_rows=joined_accepted_rows, failure_reason=joined_failure)
             if not force and minimum_only and cached_now >= required:
                 return _result(cached_before=cached_before, cached_after=cached_now, broker_fetch_started=False, joined_inflight=joined_any, broker_fetch_observed=joined_observed_fetch, fetched_rows=joined_fetched_rows, accepted_rows=joined_accepted_rows, failure_reason=joined_failure)
-            async with self._history_inflight_lock:
-                current = self._history_inflight.get(key)
+            async with self._canonical_history_inflight_lock:
+                current = self._canonical_history_inflight.get(key)
                 if current is not None and current[1].done():
-                    self._history_inflight.pop(key, None)
+                    self._canonical_history_inflight.pop(key, None)
                     current = None
                 if current is not None:
                     inflight_bars, inflight_task = current
                     self._logger.info(
-                        "HISTORY_ENSURE_JOINED symbol=%s role=%s phase=%s reason=%s required_bars=%s target_bars=%s inflight_bars=%s",
+                        "CANONICAL_HISTORY_FETCH_RESULT symbol=%s role=%s phase=%s reason=%s required_bars=%s target_bars=%s inflight_bars=%s",
                         normalized,
                         role,
                         phase,
@@ -9726,11 +9744,11 @@ class MarketDataManager:
                         required,
                         target,
                         inflight_bars,
-                        extra={"event": "HISTORY_ENSURE_JOINED", "symbol": normalized, "role": role, "phase": phase, "reason": reason, "required_bars": required, "target_bars": target, "inflight_bars": inflight_bars},
+                        extra={"event": "CANONICAL_HISTORY_FETCH_RESULT", "symbol": normalized, "role": role, "phase": phase, "reason": reason, "required_bars": required, "target_bars": target, "inflight_bars": inflight_bars},
                     )
                 else:
                     self._logger.info(
-                        "HISTORY_ENSURE_REQUESTED symbol=%s role=%s phase=%s reason=%s required_bars=%s target_bars=%s cached_before=%s",
+                        "CANONICAL_HISTORY_FETCH_RESULT symbol=%s role=%s phase=%s reason=%s required_bars=%s target_bars=%s cached_before=%s",
                         normalized,
                         role,
                         phase,
@@ -9738,10 +9756,10 @@ class MarketDataManager:
                         required,
                         target,
                         cached_now,
-                        extra={"event": "HISTORY_ENSURE_REQUESTED", "symbol": normalized, "role": role, "phase": phase, "reason": reason, "required_bars": required, "target_bars": target, "cached_before": cached_now},
+                        extra={"event": "CANONICAL_HISTORY_FETCH_RESULT", "symbol": normalized, "role": role, "phase": phase, "reason": reason, "required_bars": required, "target_bars": target, "cached_before": cached_now},
                     )
                     task = asyncio.create_task(_run_hydration(target, cached_now))
-                    self._history_inflight[key] = (target, task)
+                    self._canonical_history_inflight[key] = (target, task)
                     break
             try:
                 joined = await inflight_task
@@ -9752,10 +9770,10 @@ class MarketDataManager:
                 joined_failure = joined.failure_reason
             finally:
                 if inflight_task.done():
-                    async with self._history_inflight_lock:
-                        current = self._history_inflight.get(key)
+                    async with self._canonical_history_inflight_lock:
+                        current = self._canonical_history_inflight.get(key)
                         if current and current[1] is inflight_task:
-                            self._history_inflight.pop(key, None)
+                            self._canonical_history_inflight.pop(key, None)
             # If a larger/sufficient request completed, this caller only joined —
             # it never started a broker task itself (spec §7).
             if inflight_bars >= target:
@@ -9787,10 +9805,10 @@ class MarketDataManager:
                 )
             return result
         finally:
-            async with self._history_inflight_lock:
-                current = self._history_inflight.get(key)
+            async with self._canonical_history_inflight_lock:
+                current = self._canonical_history_inflight.get(key)
                 if current and current[1] is task:
-                    self._history_inflight.pop(key, None)
+                    self._canonical_history_inflight.pop(key, None)
 
     async def hydrate_symbol_history(
         self,
@@ -9919,9 +9937,14 @@ class MarketDataManager:
                 extra={"event": "HYDRATION_FETCH_ATTEMPT", "symbol": symbol, "token": token, "tradingsymbol": tradingsymbol, "exchange": exchange, "from_dt": from_date.isoformat(), "to_dt": to_date.isoformat(), "interval": interval, "attempt": attempt_name},
             )
             try:
-                async with self._history_lock:
+                lock = getattr(self, "_canonical_history_lock", None) or getattr(self, "_history_lock", None)
+                if lock is None:
+                    lock = asyncio.Lock()
+                    self._canonical_history_lock = lock
+                min_interval = float(getattr(self, "_canonical_history_min_interval_sec", getattr(self, "_history_min_interval_sec", 0.0)) or 0.0)
+                async with lock:
                     now_mono = time.monotonic()
-                    wait = self._history_min_interval_sec - (now_mono - self._last_history_request_ts)
+                    wait = min_interval - (now_mono - self._last_history_request_ts)
                     if wait > 0:
                         await asyncio.sleep(wait)
                     self._last_history_request_ts = time.monotonic()

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -46,7 +46,7 @@ import pandas as pd
 from nifty_scalper_bot.config.settings import get_settings
 from nifty_scalper_bot.core.active_basket import ActiveContractSelection, active_contract_selection_from_basket, extract_symbol_strike
 from nifty_scalper_bot.core.event_bus import EventBus
-from nifty_scalper_bot.core.history_roles import resolve_symbol_history_role
+from nifty_scalper_bot.core.history_roles import history_role_priority, resolve_symbol_history_role
 from nifty_scalper_bot.core.message_bus import Message, MessageBus, MessageType
 from nifty_scalper_bot.core.strategy_manager import StrategyManager
 from nifty_scalper_bot.core.trade_manager import TradeManager
@@ -1472,14 +1472,32 @@ class StrategyRunner:
             self._runtime_history_ensure_roles = roles
         previous_target = inflight.get(normalized)
         previous_role = roles.get(normalized)
-        if previous_target is not None and previous_target >= requested_target:
-            log_throttled(self._logger, f"canonical_history_ensure_inflight:{normalized}", f"CANONICAL_HISTORY_ENSURE_ALREADY_INFLIGHT symbol={normalized} role={role}", interval_sec=60.0, level=logging.DEBUG, extra={"event": "CANONICAL_HISTORY_ENSURE_ALREADY_INFLIGHT", "symbol": normalized, "role": role, "target_bars": requested_target, "inflight_target_bars": previous_target})
+        target_upgraded = previous_target is not None and requested_target > previous_target
+        role_upgraded = previous_role is not None and history_role_priority(role) > history_role_priority(previous_role)
+        if previous_target is not None and not target_upgraded and not role_upgraded:
+            log_throttled(
+                self._logger,
+                f"canonical_history_ensure_inflight:{normalized}",
+                f"CANONICAL_HISTORY_ENSURE_ALREADY_INFLIGHT symbol={normalized} role={role}",
+                interval_sec=60.0,
+                level=logging.DEBUG,
+                extra={
+                    "event": "CANONICAL_HISTORY_ENSURE_ALREADY_INFLIGHT",
+                    "symbol": normalized,
+                    "role": role,
+                    "previous_role": previous_role,
+                    "target_bars": requested_target,
+                    "inflight_target_bars": previous_target,
+                    "target_upgraded": False,
+                    "role_upgraded": False,
+                },
+            )
             return True
         inflight[normalized] = requested_target
         roles[normalized] = role
 
         def restore_after_schedule_failure() -> None:
-            if inflight.get(normalized) != requested_target:
+            if inflight.get(normalized) != requested_target or roles.get(normalized) != role:
                 return
             if previous_target is None:
                 inflight.pop(normalized, None)
@@ -1494,7 +1512,33 @@ class StrategyRunner:
         self._hydration_attempted_symbols.add(normalized)
         self._last_hydration_reason_by_symbol[normalized] = reason
         event = "CANONICAL_HISTORY_ENSURE_UPGRADED" if previous_target is not None else "CANONICAL_HISTORY_ENSURE_SCHEDULED"
-        self._logger.info("%s symbol=%s role=%s phase=%s reason=%s required_bars=%s target_bars=%s previous_target_bars=%s", event, normalized, role, phase, reason, requested_required, requested_target, previous_target, extra={"event": event, "symbol": normalized, "role": role, "phase": phase, "reason": reason, "required_bars": requested_required, "target_bars": requested_target, "previous_target_bars": previous_target})
+        self._logger.info(
+            "%s symbol=%s role=%s phase=%s reason=%s required_bars=%s target_bars=%s previous_target_bars=%s previous_role=%s target_upgraded=%s role_upgraded=%s",
+            event,
+            normalized,
+            role,
+            phase,
+            reason,
+            requested_required,
+            requested_target,
+            previous_target,
+            previous_role,
+            target_upgraded,
+            role_upgraded,
+            extra={
+                "event": event,
+                "symbol": normalized,
+                "role": role,
+                "previous_role": previous_role,
+                "phase": phase,
+                "reason": reason,
+                "required_bars": requested_required,
+                "target_bars": requested_target,
+                "previous_target_bars": previous_target,
+                "target_upgraded": target_upgraded,
+                "role_upgraded": role_upgraded,
+            },
+        )
 
         async def _run() -> None:
             try:
@@ -1504,7 +1548,10 @@ class StrategyRunner:
             except Exception as exc:  # noqa: BLE001 - orchestration boundary
                 self._logger.warning("CANONICAL_HISTORY_ENSURE_CALLBACK_FAILED symbol=%s role=%s reason=%s error_type=%s error=%s", normalized, role, reason, type(exc).__name__, exc, extra={"event": "CANONICAL_HISTORY_ENSURE_CALLBACK_FAILED", "symbol": normalized, "role": role, "reason": reason, "error_type": type(exc).__name__, "error": str(exc)})
             finally:
-                if self._runtime_history_ensure_inflight.get(normalized) == requested_target:
+                if (
+                    self._runtime_history_ensure_inflight.get(normalized) == requested_target
+                    and self._runtime_history_ensure_roles.get(normalized) == role
+                ):
                     self._runtime_history_ensure_inflight.pop(normalized, None)
                     self._runtime_history_ensure_roles.pop(normalized, None)
 
@@ -1515,7 +1562,12 @@ class StrategyRunner:
                 thread = threading.Thread(target=lambda: asyncio.run(_run()), name=f"runtime-history-ensure-{normalized}", daemon=True)
                 thread.start()
             else:
-                loop.create_task(_run())
+                scheduled_coro = _run()
+                try:
+                    loop.create_task(scheduled_coro)
+                except Exception:
+                    scheduled_coro.close()
+                    raise
         except Exception as exc:  # noqa: BLE001 - scheduling boundary
             restore_after_schedule_failure()
             self._logger.warning("CANONICAL_HISTORY_ENSURE_SCHEDULE_FAILED symbol=%s error_type=%s error=%s", normalized, type(exc).__name__, exc, extra={"event": "CANONICAL_HISTORY_ENSURE_SCHEDULE_FAILED", "symbol": normalized, "error_type": type(exc).__name__, "error": str(exc)})

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -46,6 +46,7 @@ import pandas as pd
 from nifty_scalper_bot.config.settings import get_settings
 from nifty_scalper_bot.core.active_basket import ActiveContractSelection, active_contract_selection_from_basket, extract_symbol_strike
 from nifty_scalper_bot.core.event_bus import EventBus
+from nifty_scalper_bot.core.history_roles import resolve_symbol_history_role
 from nifty_scalper_bot.core.message_bus import Message, MessageBus, MessageType
 from nifty_scalper_bot.core.strategy_manager import StrategyManager
 from nifty_scalper_bot.core.trade_manager import TradeManager
@@ -661,7 +662,8 @@ class StrategyRunner:
         # Runner-level dedupe for canonical history scheduling (not MDM's own
         # inflight map). Keyed by canonical symbol; added before scheduling,
         # removed in finally.
-        self._runtime_history_ensure_inflight: set[str] = set()
+        self._runtime_history_ensure_inflight: dict[str, int] = {}
+        self._runtime_history_ensure_roles: dict[str, str | None] = {}
         self._datahub_registered_symbols: set[str] = set()
         self._strike_selector = strike_selector
         self._bracket_manager = bracket_manager
@@ -1449,84 +1451,74 @@ class StrategyRunner:
         required_bars: int,
         target_bars: int | None = None,
     ) -> bool:
-        """Schedule canonical history hydration via the injected runtime callback.
-
-        Args: symbol, role, phase, reason, required/target bars. Returns: True if
-        scheduled (or already inflight), False if no canonical callback. Raises:
-        none. Never blocks the synchronous Runner path and never calls DataHub
-        or MDM hydration directly.
-        """
+        """Schedule canonical target-aware runtime history hydration."""
         normalized = self._normalize_symbol(symbol)
         if not normalized:
             return False
         ensurer = getattr(self, "_runtime_history_ensurer", None)
         if not callable(ensurer):
-            log_throttled(
-                self._logger,
-                f"canonical_history_ensurer_missing:{normalized}",
-                f"CANONICAL_HISTORY_ENSURER_MISSING symbol={normalized} role={role}",
-                interval_sec=60.0,
-                level=logging.WARNING,
-                extra={"event": "CANONICAL_HISTORY_ENSURER_MISSING", "symbol": normalized, "role": role, "phase": phase, "reason": reason, "required_bars": required_bars},
-            )
+            log_throttled(self._logger, f"canonical_history_ensurer_missing:{normalized}", f"CANONICAL_HISTORY_ENSURER_MISSING symbol={normalized} role={role}", interval_sec=60.0, level=logging.WARNING, extra={"event": "CANONICAL_HISTORY_ENSURER_MISSING", "symbol": normalized, "role": role, "phase": phase, "reason": reason, "required_bars": required_bars})
             return False
+        requested_required = max(1, int(required_bars or 1))
+        requested_target = max(requested_required, int(target_bars) if target_bars is not None else requested_required)
         inflight = getattr(self, "_runtime_history_ensure_inflight", None)
-        if inflight is None:
-            inflight = set()
+        roles = getattr(self, "_runtime_history_ensure_roles", None)
+        if not isinstance(inflight, dict):
+            getattr(self._logger, "error", self._logger.warning)("CANONICAL_HISTORY_ENSURE_INVALID_STATE symbol=%s state_type=%s", normalized, type(inflight).__name__, extra={"event": "CANONICAL_HISTORY_ENSURE_INVALID_STATE", "symbol": normalized, "state_type": type(inflight).__name__})
+            inflight = {}
             self._runtime_history_ensure_inflight = inflight
-        if normalized in inflight:
-            log_throttled(
-                self._logger,
-                f"canonical_history_ensure_inflight:{normalized}",
-                f"CANONICAL_HISTORY_ENSURE_ALREADY_INFLIGHT symbol={normalized} role={role}",
-                interval_sec=60.0,
-                level=logging.DEBUG,
-                extra={"event": "CANONICAL_HISTORY_ENSURE_ALREADY_INFLIGHT", "symbol": normalized, "role": role},
-            )
+        if not isinstance(roles, dict):
+            roles = {}
+            self._runtime_history_ensure_roles = roles
+        previous_target = inflight.get(normalized)
+        previous_role = roles.get(normalized)
+        if previous_target is not None and previous_target >= requested_target:
+            log_throttled(self._logger, f"canonical_history_ensure_inflight:{normalized}", f"CANONICAL_HISTORY_ENSURE_ALREADY_INFLIGHT symbol={normalized} role={role}", interval_sec=60.0, level=logging.DEBUG, extra={"event": "CANONICAL_HISTORY_ENSURE_ALREADY_INFLIGHT", "symbol": normalized, "role": role, "target_bars": requested_target, "inflight_target_bars": previous_target})
             return True
+        inflight[normalized] = requested_target
+        roles[normalized] = role
+
+        def restore_after_schedule_failure() -> None:
+            if inflight.get(normalized) != requested_target:
+                return
+            if previous_target is None:
+                inflight.pop(normalized, None)
+                roles.pop(normalized, None)
+            else:
+                inflight[normalized] = previous_target
+                if previous_role is None:
+                    roles.pop(normalized, None)
+                else:
+                    roles[normalized] = previous_role
+
         self._hydration_attempted_symbols.add(normalized)
         self._last_hydration_reason_by_symbol[normalized] = reason
-        tgt = int(target_bars) if target_bars is not None else int(required_bars)
-        self._logger.info(
-            "CANONICAL_HISTORY_ENSURE_SCHEDULED symbol=%s role=%s phase=%s reason=%s required_bars=%s target_bars=%s",
-            normalized, role, phase, reason, required_bars, tgt,
-            extra={"event": "CANONICAL_HISTORY_ENSURE_SCHEDULED", "symbol": normalized, "role": role, "phase": phase, "reason": reason, "required_bars": required_bars, "target_bars": tgt},
-        )
+        event = "CANONICAL_HISTORY_ENSURE_UPGRADED" if previous_target is not None else "CANONICAL_HISTORY_ENSURE_SCHEDULED"
+        self._logger.info("%s symbol=%s role=%s phase=%s reason=%s required_bars=%s target_bars=%s previous_target_bars=%s", event, normalized, role, phase, reason, requested_required, requested_target, previous_target, extra={"event": event, "symbol": normalized, "role": role, "phase": phase, "reason": reason, "required_bars": requested_required, "target_bars": requested_target, "previous_target_bars": previous_target})
 
         async def _run() -> None:
             try:
-                result = ensurer(
-                    symbol,
-                    role=role,
-                    phase=phase,
-                    reason=reason,
-                    required_bars=int(required_bars),
-                    target_bars=tgt,
-                )
+                result = ensurer(normalized, role=role, phase=phase, reason=reason, required_bars=requested_required, target_bars=requested_target)
                 if inspect.isawaitable(result):
                     await result
             except Exception as exc:  # noqa: BLE001 - orchestration boundary
-                self._logger.warning(
-                    "CANONICAL_HISTORY_ENSURE_FAILED symbol=%s role=%s reason=%s error_type=%s error=%s",
-                    normalized, role, reason, type(exc).__name__, exc,
-                    extra={"event": "CANONICAL_HISTORY_ENSURE_FAILED", "symbol": normalized, "role": role, "reason": reason, "error_type": type(exc).__name__, "error": str(exc)},
-                )
+                self._logger.warning("CANONICAL_HISTORY_ENSURE_CALLBACK_FAILED symbol=%s role=%s reason=%s error_type=%s error=%s", normalized, role, reason, type(exc).__name__, exc, extra={"event": "CANONICAL_HISTORY_ENSURE_CALLBACK_FAILED", "symbol": normalized, "role": role, "reason": reason, "error_type": type(exc).__name__, "error": str(exc)})
             finally:
-                self._runtime_history_ensure_inflight.discard(normalized)
+                if self._runtime_history_ensure_inflight.get(normalized) == requested_target:
+                    self._runtime_history_ensure_inflight.pop(normalized, None)
+                    self._runtime_history_ensure_roles.pop(normalized, None)
 
-        inflight.add(normalized)
         try:
-            loop = asyncio.get_running_loop()
-            loop.create_task(_run())
-        except RuntimeError:
-            threading.Thread(target=lambda: asyncio.run(_run()), name=f"runtime-history-ensure-{normalized}", daemon=True).start()
+            try:
+                loop = asyncio.get_running_loop()
+            except RuntimeError:
+                thread = threading.Thread(target=lambda: asyncio.run(_run()), name=f"runtime-history-ensure-{normalized}", daemon=True)
+                thread.start()
+            else:
+                loop.create_task(_run())
         except Exception as exc:  # noqa: BLE001 - scheduling boundary
-            self._runtime_history_ensure_inflight.discard(normalized)
-            self._logger.warning(
-                "CANONICAL_HISTORY_ENSURE_SCHEDULE_FAILED symbol=%s error_type=%s error=%s",
-                normalized, type(exc).__name__, exc,
-                extra={"event": "CANONICAL_HISTORY_ENSURE_SCHEDULE_FAILED", "symbol": normalized, "error_type": type(exc).__name__, "error": str(exc)},
-            )
+            restore_after_schedule_failure()
+            self._logger.warning("CANONICAL_HISTORY_ENSURE_SCHEDULE_FAILED symbol=%s error_type=%s error=%s", normalized, type(exc).__name__, exc, extra={"event": "CANONICAL_HISTORY_ENSURE_SCHEDULE_FAILED", "symbol": normalized, "error_type": type(exc).__name__, "error": str(exc)})
             return False
         return True
 
@@ -1550,21 +1542,13 @@ class StrategyRunner:
         only (no app import). Selected CE/PE -> selected_option; spot -> spot
         context; future -> futures_context; else option_context. Raises: none.
         """
-        norm = normalize_symbol(str(symbol or "")).upper()
-        if not norm:
-            return "option_context"
-        sel = {
-            normalize_symbol(str(getattr(self, "_active_selected_ce", "") or "")).upper(),
-            normalize_symbol(str(getattr(self, "_active_selected_pe", "") or "")).upper(),
-        }
-        if norm in sel:
-            return "selected_option"
-        if norm.startswith("NSE:") and "NIFTY" in norm:
-            return "spot_context"
-        fut = normalize_symbol(str(getattr(self, "_active_futures_symbol", "") or "")).upper()
-        if norm == fut or norm.endswith("FUT"):
-            return "futures_context"
-        return "option_context"
+        return resolve_symbol_history_role(
+            symbol=normalize_symbol(str(symbol or "")),
+            selected_ce=normalize_symbol(str(getattr(self, "_active_selected_ce", "") or "")),
+            selected_pe=normalize_symbol(str(getattr(self, "_active_selected_pe", "") or "")),
+            spot_symbol=getattr(self, "_spot_symbol", None),
+            futures_symbol=getattr(self, "_active_futures_symbol", None),
+        )
 
     def _hydrate_from_mdm_cache(self, symbol: str) -> int:
         """Thin compatibility delegate to the canonical Runner sync path.
@@ -1689,9 +1673,9 @@ class StrategyRunner:
         except Exception:  # noqa: BLE001 - state map is best-effort diagnostic
             pass
         self._logger.info(
-            "RUNNER_HISTORY_SYNC_COMPLETED symbol=%s role=%s reason=%s required_bars=%s mdm_after=%s runner_after=%s indicator_after=%s success=%s failure_reason=%s",
+            "RUNNER_HISTORY_SYNC_RESULT symbol=%s role=%s reason=%s required_bars=%s mdm_after=%s runner_after=%s indicator_after=%s success=%s failure_reason=%s",
             normalized, role, reason, target, mdm_bars, runner_after, indicator_after, success, failure_reason,
-            extra={"event": "RUNNER_HISTORY_SYNC_COMPLETED", "symbol": normalized, "role": role, "reason": reason, "required_bars": target, "mdm_after": mdm_bars, "runner_after": runner_after, "indicator_after": indicator_after, "success": success, "failure_reason": failure_reason},
+            extra={"event": "RUNNER_HISTORY_SYNC_RESULT", "symbol": normalized, "role": role, "reason": reason, "required_bars": target, "mdm_after": mdm_bars, "runner_after": runner_after, "indicator_after": indicator_after, "success": success, "failure_reason": failure_reason},
         )
         if not success and request_if_short:
             self._schedule_runtime_history_ensure(

--- a/tests/core/test_history_readiness_ssot.py
+++ b/tests/core/test_history_readiness_ssot.py
@@ -101,3 +101,29 @@ async def test_runner_cold_indicator_warm_not_ready() -> None:
     r = app.compute_selected_option_history_readiness(ctx, "NFO:NIFTY2661623300CE", "NFO:NIFTY2661623300PE")
     assert r.both_ready is False
     assert r.blocker == "selected_option_history_cold"
+
+
+async def test_shared_role_resolver_spot_aliases_are_consistent() -> None:
+    from nifty_scalper_bot.core.history_roles import resolve_symbol_history_role
+
+    aliases = ["NIFTY", "NSE:NIFTY", "NIFTY50", "NSE:NIFTY50"]
+    for configured in aliases:
+        for symbol in aliases:
+            assert resolve_symbol_history_role(symbol=symbol, spot_symbol=configured) == "spot_context"
+
+
+async def test_shared_role_resolver_keeps_selected_option_exact() -> None:
+    from nifty_scalper_bot.core.history_roles import resolve_symbol_history_role
+
+    assert resolve_symbol_history_role(
+        symbol="NFO:NIFTY26JUN24000CE",
+        selected_ce="NFO:NIFTY26JUN24000CE",
+        selected_pe="NFO:NIFTY26JUN24000PE",
+        spot_symbol="NSE:NIFTY",
+    ) == "selected_option"
+    assert resolve_symbol_history_role(
+        symbol="NFO:NIFTY26JUN24100CE",
+        selected_ce="NFO:NIFTY26JUN24000CE",
+        selected_pe="NFO:NIFTY26JUN24000PE",
+        spot_symbol="NSE:NIFTY",
+    ) == "option_context"

--- a/tests/strategies/test_canonical_runner_history_sync.py
+++ b/tests/strategies/test_canonical_runner_history_sync.py
@@ -164,3 +164,115 @@ async def test_reseed_runtime_error_returns_structured_failure() -> None:
     result = r.sync_history_from_mdm("NSE:NIFTY", required_bars=30, reason="t", role="spot_context", request_if_short=False)
     assert result.success is False
     assert "runner_reseed_failed:RuntimeError" in (result.failure_reason or "")
+
+
+async def test_same_target_stronger_role_schedules_upgrade_selected_option() -> None:
+    r = _runner_for_scheduling()
+    calls = []
+    async def _ensurer(symbol, **kw):
+        calls.append((symbol, kw))
+    r.set_runtime_history_ensurer(_ensurer)
+    r._runtime_history_ensure_inflight["NFO:NIFTY26JUN24000CE"] = 30
+    r._runtime_history_ensure_roles["NFO:NIFTY26JUN24000CE"] = "option_context"
+
+    assert r._schedule_runtime_history_ensure("NFO:NIFTY26JUN24000CE", role="selected_option", phase="runner_sync", reason="upgrade", required_bars=30)
+
+    import asyncio as _asyncio
+    for _ in range(5):
+        await _asyncio.sleep(0)
+        if calls:
+            break
+    assert calls and calls[0][1]["role"] == "selected_option"
+    assert calls[0][1]["target_bars"] == 30
+
+
+async def test_same_target_weaker_role_suppresses_existing_selected_option() -> None:
+    r = _runner_for_scheduling()
+    calls = []
+    async def _ensurer(symbol, **kw):
+        calls.append((symbol, kw))
+    r.set_runtime_history_ensurer(_ensurer)
+    r._runtime_history_ensure_inflight["NFO:NIFTY26JUN24000CE"] = 30
+    r._runtime_history_ensure_roles["NFO:NIFTY26JUN24000CE"] = "selected_option"
+
+    assert r._schedule_runtime_history_ensure("NFO:NIFTY26JUN24000CE", role="option_context", phase="runner_sync", reason="weaker", required_bars=30)
+    import asyncio as _asyncio
+    await _asyncio.sleep(0)
+    assert calls == []
+
+
+async def test_same_target_recovery_role_schedules_upgrade() -> None:
+    r = _runner_for_scheduling()
+    calls = []
+    async def _ensurer(symbol, **kw):
+        calls.append((symbol, kw))
+    r.set_runtime_history_ensurer(_ensurer)
+    r._runtime_history_ensure_inflight["NFO:NIFTY26JUN24000CE"] = 30
+    r._runtime_history_ensure_roles["NFO:NIFTY26JUN24000CE"] = "option_context"
+
+    assert r._schedule_runtime_history_ensure("NFO:NIFTY26JUN24000CE", role="recovery_or_open_position", phase="runner_sync", reason="recovery", required_bars=30)
+    import asyncio as _asyncio
+    for _ in range(5):
+        await _asyncio.sleep(0)
+        if calls:
+            break
+    assert calls and calls[0][1]["role"] == "recovery_or_open_position"
+
+
+async def test_smaller_target_weaker_role_suppresses_larger_selected_option() -> None:
+    r = _runner_for_scheduling()
+    calls = []
+    async def _ensurer(symbol, **kw):
+        calls.append((symbol, kw))
+    r.set_runtime_history_ensurer(_ensurer)
+    r._runtime_history_ensure_inflight["NFO:NIFTY26JUN24000CE"] = 75
+    r._runtime_history_ensure_roles["NFO:NIFTY26JUN24000CE"] = "selected_option"
+
+    assert r._schedule_runtime_history_ensure("NFO:NIFTY26JUN24000CE", role="option_context", phase="runner_sync", reason="smaller", required_bars=30)
+    import asyncio as _asyncio
+    await _asyncio.sleep(0)
+    assert calls == []
+
+
+async def test_larger_target_and_stronger_role_preserves_both_upgrades() -> None:
+    r = _runner_for_scheduling()
+    calls = []
+    async def _ensurer(symbol, **kw):
+        calls.append((symbol, kw))
+    r.set_runtime_history_ensurer(_ensurer)
+    r._runtime_history_ensure_inflight["NFO:NIFTY26JUN24000CE"] = 30
+    r._runtime_history_ensure_roles["NFO:NIFTY26JUN24000CE"] = "option_context"
+
+    assert r._schedule_runtime_history_ensure("NFO:NIFTY26JUN24000CE", role="selected_option", phase="runner_sync", reason="both", required_bars=30, target_bars=75)
+    import asyncio as _asyncio
+    for _ in range(5):
+        await _asyncio.sleep(0)
+        if calls:
+            break
+    assert calls and calls[0][1]["role"] == "selected_option"
+    assert calls[0][1]["target_bars"] == 75
+
+
+async def test_create_task_failure_closes_coroutine_and_does_not_overwrite_newer_upgrade(monkeypatch, recwarn) -> None:
+    r = _runner_for_scheduling()
+    async def _ensurer(symbol, **kw):
+        raise AssertionError("callback must not run when scheduling fails")
+    r.set_runtime_history_ensurer(_ensurer)
+    r._runtime_history_ensure_inflight["NFO:NIFTY26JUN24000CE"] = 30
+    r._runtime_history_ensure_roles["NFO:NIFTY26JUN24000CE"] = "option_context"
+
+    class _Loop:
+        def create_task(self, _coro):
+            # Simulate a concurrent stronger same-target upgrade that wins before
+            # rollback executes; rollback must not overwrite this role marker.
+            r._runtime_history_ensure_inflight["NFO:NIFTY26JUN24000CE"] = 30
+            r._runtime_history_ensure_roles["NFO:NIFTY26JUN24000CE"] = "recovery_or_open_position"
+            raise RuntimeError("create_task boom")
+
+    monkeypatch.setattr("nifty_scalper_bot.strategies.runner.asyncio.get_running_loop", lambda: _Loop())
+    scheduled = r._schedule_runtime_history_ensure("NFO:NIFTY26JUN24000CE", role="selected_option", phase="runner_sync", reason="fail", required_bars=30)
+
+    assert scheduled is False
+    assert r._runtime_history_ensure_inflight["NFO:NIFTY26JUN24000CE"] == 30
+    assert r._runtime_history_ensure_roles["NFO:NIFTY26JUN24000CE"] == "recovery_or_open_position"
+    assert [w for w in recwarn if "was never awaited" in str(w.message)] == []

--- a/tests/strategies/test_canonical_runner_history_sync.py
+++ b/tests/strategies/test_canonical_runner_history_sync.py
@@ -23,7 +23,8 @@ def _runner(rows: list[dict] | None = None) -> StrategyRunner:
     r._seed_pipeline_store = lambda *_a, **_k: None
     r._seed_candle_engine_from_history = lambda *_a, **_k: None
     r._active_symbols = set(); r._tracked_symbols = set(); r._data_phase = {}; r._last_bar_ts = {}
-    r._runtime_history_ensure_inflight = set()
+    r._runtime_history_ensure_inflight = {}
+    r._runtime_history_ensure_roles = {}
     r._hydration_attempted_symbols = set()
     r._last_hydration_reason_by_symbol = {}
     r._history_role_for_symbol = lambda _s: "spot_context"
@@ -97,7 +98,8 @@ def _runner_for_scheduling():
     r._indicator_engine = IndicatorEngine()
     r._get_mdm_bars = lambda _s, limit: []  # cold -> short -> schedule
     r._set_symbol_hydration_state = lambda *_a, **_k: None
-    r._runtime_history_ensure_inflight = set()
+    r._runtime_history_ensure_inflight = {}
+    r._runtime_history_ensure_roles = {}
     r._hydration_attempted_symbols = set()
     r._last_hydration_reason_by_symbol = {}
     r._history_role_for_symbol = lambda _s: "selected_option"
@@ -145,7 +147,8 @@ async def test_duplicate_scheduling_suppressed() -> None:
         n["count"] += 1
     r.set_runtime_history_ensurer(_ensurer)
     # pre-mark inflight to simulate an active request
-    r._runtime_history_ensure_inflight.add("NFO:NIFTY26JUN24000CE")
+    r._runtime_history_ensure_inflight["NFO:NIFTY26JUN24000CE"] = 30
+    r._runtime_history_ensure_roles["NFO:NIFTY26JUN24000CE"] = "selected_option"
     scheduled = r._schedule_runtime_history_ensure("NFO:NIFTY26JUN24000CE", role="selected_option", phase="runner_sync", reason="t", required_bars=30)
     assert scheduled is True  # already inflight counts as scheduled
     assert n["count"] == 0  # callback not invoked again


### PR DESCRIPTION
### Motivation

- Eliminate parallel/duplicated history role logic and scheduler state so a single canonical runtime-history orchestration exists (app → MDM.ensure_history → Runner.sync_history_from_mdm). 
- Make MarketDataManager the single owner of broker fetch, normalization, canonical OHLC (`_ohlc`) and inflight broker coordination. 
- Make StrategyRunner scheduling target-aware so larger hydration requests are never lost and duplicate suppression is safe. 
- Provide a single shared role resolver to remove duplicate decision trees in app and runner.

### Description

- Added `src/nifty_scalper_bot/core/history_roles.py` implementing `resolve_symbol_history_role(...)` as the single neutral resolver for `selected_option`, `spot_context`, `futures_context`, `recovery_or_open_position`, and `option_context` and updated app/runner to delegate to it. 
- Updated `core/app.py` to use `compute_history_readiness()` for final readiness projection and emit one canonical `CANONICAL_HISTORY_RESULT` event; role resolution now delegates to the shared resolver. 
- Converted Runner scheduler state from a set to a target-aware mapping (`_runtime_history_ensure_inflight: dict[str,int]`) with companion `_runtime_history_ensure_roles`, added larger-request upgrade semantics, race-safe rollback on schedule failure, callback failure handling, precise callback args, and canonical log events (`CANONICAL_HISTORY_ENSURE_*`). 
- Consolidated MDM raw tick vs canonical OHLC ownership by renaming internal raw tick storage to `_raw_tick_history`, keeping `_ohlc` as the authoritative OHLC cache, introducing `_canonical_history_inflight` and `_canonical_history_inflight_lock`, and preserving compatibility aliases for `_history` and `_history_inflight`. 
- Harmonised log/event names for canonical fetch/sync (`CANONICAL_HISTORY_FETCH_RESULT`, `RUNNER_HISTORY_SYNC_RESULT`) and removed duplicate readiness computation paths. 
- Adjusted small runner tests to use dict-based inflight state and kept thin compatibility delegates where necessary.

### Testing

- Commands run: `python -m compileall -q src`, `python -m compileall -q tests`, and `pytest -q` (focused/related/full suites as below).
- Focused runs: `pytest -q tests/architecture/test_history_ownership.py tests/core/test_history_readiness_ssot.py tests/core/test_runtime_history_orchestration.py tests/data/test_canonical_history_hydration.py tests/strategies/test_canonical_runner_history_sync.py tests/strategies/test_runner_mdm_hydration_paths.py tests/strategies/test_runner_live_path_guards.py` — 205 passed, 0 failed, 0 skipped, 0 xfailed, 0 errors. 
- Related and full suites: `pytest -q tests/core tests/data tests/strategies tests/architecture` — 1238 passed, 0 failed, 0 skipped, 0 xfailed, 0 errors; `pytest -q` full run — 2198 passed, 0 failed, 0 skipped, 0 xfailed, 0 errors. 
- Additional checks: `git diff --check` and conflict-marker grep returned clean results; note that this environment had no configured `origin` remote so the branch/PR push was not performed from here (commit exists locally on branch `codex/canonical-history-ssot-clean`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e6100ab1483249ca02deb2096176c)