### PR TITLE
Finalize canonical history hydration SSOT and remove legacy bypasses

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -5883,13 +5883,40 @@ def initialize_components(settings: Settings | None = None) -> BotContext:
     # Spec §4: inject the canonical hydration callback so Runner prewarm routes
     # through the single orchestration path instead of its own reseed lifecycle.
     # The closure binds ctx here in app.py; Runner never imports app (no cycle).
-    async def _runtime_history_ensurer(symbol: str, **kwargs: Any) -> Any:
-        return await ensure_symbol_runtime_history(ctx, symbol, **kwargs)
+    async def _runtime_history_ensurer(
+        symbol: str,
+        *,
+        role: str,
+        phase: str,
+        reason: str,
+        required_bars: int,
+        target_bars: int | None = None,
+    ) -> RuntimeHistoryResult:
+        return await ensure_symbol_runtime_history(
+            ctx,
+            symbol,
+            role=role,
+            phase=phase,
+            reason=reason,
+            required_bars=required_bars,
+            target_bars=target_bars,
+        )
 
     try:
         strategy_runner.set_runtime_history_ensurer(_runtime_history_ensurer)
-    except Exception:  # pragma: no cover - defensive
-        LOGGER.debug("strategy_runner lacks set_runtime_history_ensurer", exc_info=True)
+    except Exception as exc:  # pragma: no cover - defensive
+        setattr(ctx, "canonical_history_ensurer_injection_failed", True)
+        LOGGER.error(
+            "CANONICAL_HISTORY_ENSURER_INJECTION_FAILED exception_type=%s exception_message=%s",
+            type(exc).__name__,
+            str(exc),
+            extra={
+                "event": "CANONICAL_HISTORY_ENSURER_INJECTION_FAILED",
+                "exception_type": type(exc).__name__,
+                "exception_message": str(exc),
+            },
+            exc_info=exc,
+        )
     runtime_selfchecker = RuntimeSelfChecker(ctx)
     ctx.selfchecker = runtime_selfchecker
     try:

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -831,7 +831,8 @@ class MarketDataManager:
                 "timestamp": ts.isoformat(),
                 "source": "historical",
             }
-            self._raw_tick_history[symbol].append(dict(payload))
+            # Historical OHLC belongs only in the canonical candle store.
+            # _raw_tick_history is reserved for raw/live tick payloads.
             self._ohlc[self._bar_symbol_key(symbol)].append(dict(payload))
             if isinstance(ts, datetime):
                 self._last_historical_ts[symbol] = ts.timestamp()
@@ -4082,11 +4083,26 @@ class MarketDataManager:
                 "Failure in update_hydration_status: %s", exc, exc_info=exc
             )
 
-    def is_symbol_ready(self, symbol: str) -> bool:
-        """Args: symbol; Returns: bool; Raises: none."""
+    def is_tick_ready(self, symbol: str) -> bool:
+        """Return live/raw tick readiness for a symbol; OHLC bars do not count."""
         normalized = normalize_symbol(str(symbol or ""))
         with self._lock:
             return len(self._raw_tick_history.get(normalized, ())) >= self._min_required_bars
+
+    def is_ohlc_ready(self, symbol: str, required_bars: int | None = None) -> bool:
+        """Return canonical OHLC readiness for a symbol; raw ticks do not count."""
+        normalized = normalize_symbol(str(symbol or ""))
+        needed = max(1, int(required_bars if required_bars is not None else self._min_required_bars))
+        with self._lock:
+            return len(self._ohlc.get(self._bar_symbol_key(normalized), ())) >= needed
+
+    def is_market_data_ready(self, symbol: str) -> bool:
+        """Return live-market readiness: raw ticks and canonical OHLC are both ready."""
+        return self.is_tick_ready(symbol) and self.is_ohlc_ready(symbol)
+
+    def is_symbol_ready(self, symbol: str) -> bool:
+        """Deprecated: raw/live tick readiness only; use is_tick_ready/is_ohlc_ready."""
+        return self.is_tick_ready(symbol)
 
     def is_ready(self) -> bool:
         """Args: none; Returns: bool; Raises: none."""
@@ -4094,10 +4110,7 @@ class MarketDataManager:
             active = sorted(self._active_subscribed_symbols)
             if not active:
                 return False
-            return all(
-                len(self._raw_tick_history.get(symbol, ())) >= self._min_required_bars
-                for symbol in active
-            )
+        return all(self.is_tick_ready(symbol) for symbol in active)
 
     async def wait_until_ready(self, timeout: float = 30.0) -> None:
         """Args: timeout; Returns: None; Raises: None."""
@@ -4111,11 +4124,10 @@ class MarketDataManager:
             with self._lock:
                 subscribed_symbols = sorted(self._active_subscribed_symbols)
                 min_bars = self._min_required_bars
+                # Startup/live data readiness is raw tick readiness.  Historical
+                # OHLC readiness is checked separately by ensure_history/app gates.
                 bars = {
-                    symbol: max(
-                        len(self._raw_tick_history.get(symbol, ())),
-                        len(self._ohlc.get(self._bar_symbol_key(symbol), ())),
-                    )
+                    symbol: len(self._raw_tick_history.get(symbol, ()))
                     for symbol in subscribed_symbols
                 }
             requirements = dict(self._readiness_requirements)

--- a/src/nifty_scalper_bot/data/source.py
+++ b/src/nifty_scalper_bot/data/source.py
@@ -1,14 +1,13 @@
 """Data-source integrity helpers for strategy execution.
 
 Runtime role:
-- Low-level broker data adapter for quote/LTP/historical fetches.
-- Consumed by MarketDataManager hydration.
+- Low-level broker data adapter for quote/LTP helpers.
+- Must not fetch historical broker candles; MarketDataManager owns runtime history hydration.
 - Must not select contracts."""
 
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime, timezone
 from typing import Any, Callable, Mapping, Sequence
 
 import time
@@ -268,25 +267,14 @@ class MarketDataSource:
         *,
         min_required_bars: int = 30,
     ) -> list[dict[str, Any]]:
-        """Get token OHLC with TTL cache. Args: token/interval/ttl/min_required_bars. Returns: rows. Raises: DataIntegrityError."""
+        """Return cached OHLC only; broker history fetch is MDM-owned.
 
+        Runtime historical hydration must flow through
+        MarketDataManager.ensure_history(), never this legacy data source.
+        """
         cached = self._state.get_ohlc_cache(token, interval, ttl=ttl)
         if cached is not None:
             return cached
-        try:
-            rows = self._kite.historical_data(
-                int(token),
-                datetime.now(timezone.utc).replace(hour=3, minute=45, second=0, microsecond=0),
-                datetime.now(timezone.utc),
-                interval,
-            )
-        except Exception as e:
-            raise DataIntegrityError(f'OHLC fetch failed for token {token}: {e}') from e
-        required = max(1, int(min_required_bars))
-        if len(rows) < required:
-            raise DataIntegrityError(
-                f"Insufficient OHLC candles for token {token}: {len(rows)}/{required}"
-            )
-        normalized = [dict(row) for row in rows]
-        self._state.set_ohlc_cache(int(token), interval, normalized)
-        return normalized
+        raise DataIntegrityError(
+            "Historical OHLC fetch is owned by MarketDataManager.ensure_history"
+        )

--- a/tests/architecture/test_history_ownership.py
+++ b/tests/architecture/test_history_ownership.py
@@ -5,11 +5,10 @@ These tests are written as ``async def`` deliberately. The repository conftest's
 plain sync test bodies; writing the guards as coroutines guarantees their
 assertions actually run instead of silently passing.
 
-Broker historical-data access is allow-listed to the real architecture: the
+Broker historical-data access is allow-listed to the final architecture: the
 canonical owner (MarketDataManager) plus the broker adapter that defines the
-raw client method, and the known legacy ``data/source.py`` fetch path (tracked
-for removal). The allowlist is intentionally explicit so a NEW unexpected caller
-fails the guard.
+raw client method. The allowlist is intentionally explicit so a NEW unexpected
+caller fails the guard.
 """
 
 from __future__ import annotations
@@ -23,7 +22,6 @@ SRC = ROOT / "src" / "nifty_scalper_bot"
 BROKER_HISTORY_ALLOWLIST = {
     "src/nifty_scalper_bot/data/market_data_manager.py",
     "src/nifty_scalper_bot/data/rest/zerodha_client.py",
-    "src/nifty_scalper_bot/data/source.py",
 }
 
 HYDRATION_FORBIDDEN_DIRS = ("execution", "notifications")
@@ -120,7 +118,7 @@ async def test_canonical_readiness_function_exists_and_is_pure() -> None:
 def _func_source(path: Path, func_name: str) -> str:
     tree = ast.parse(path.read_text())
     for node in ast.walk(tree):
-        if isinstance(node, ast.FunctionDef) and node.name == func_name:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == func_name:
             return ast.get_source_segment(path.read_text(), node) or ""
     return ""
 
@@ -187,3 +185,44 @@ async def test_request_mdm_hydration_is_thin_canonical_delegate() -> None:
     if src:
         assert "_schedule_runtime_history_ensure" in src
         assert "request_hydration" not in src.replace("request_hydration; routes", "")
+
+
+async def test_runtime_history_ensurer_callback_contract_is_explicit() -> None:
+    text = (SRC / "core" / "app.py").read_text()
+    tree = ast.parse(text)
+    funcs = [n for n in ast.walk(tree) if isinstance(n, ast.AsyncFunctionDef) and n.name == "_runtime_history_ensurer"]
+    assert len(funcs) == 1
+    fn = funcs[0]
+    assert fn.args.vararg is None
+    assert fn.args.kwarg is None, "production runtime history ensurer must not accept **kwargs"
+    assert [a.arg for a in fn.args.args] == ["symbol"]
+    assert [a.arg for a in fn.args.kwonlyargs] == ["role", "phase", "reason", "required_bars", "target_bars"]
+
+
+async def test_only_one_production_history_ensurer_injection_point() -> None:
+    text = (SRC / "core" / "app.py").read_text()
+    assert text.count("set_runtime_history_ensurer(") == 1
+    assert "CANONICAL_HISTORY_ENSURER_INJECTION_FAILED" in text
+    assert "LOGGER.error" in text[text.index("CANONICAL_HISTORY_ENSURER_INJECTION_FAILED") - 400:]
+
+
+async def test_mdm_readiness_concepts_are_explicit_and_separate() -> None:
+    text = (SRC / "data" / "market_data_manager.py").read_text()
+    assert "def is_tick_ready" in text
+    assert "def is_ohlc_ready" in text
+    assert "def is_market_data_ready" in text
+    wait_src = _func_source(SRC / "data" / "market_data_manager.py", "wait_until_ready")
+    assert "len(self._ohlc" not in wait_src
+    assert "len(self._raw_tick_history" in wait_src
+
+
+async def test_historical_bar_ingestion_does_not_write_raw_tick_history() -> None:
+    src = _func_source(SRC / "data" / "market_data_manager.py", "ingest_historical_bar")
+    assert "_ohlc" in src
+    assert "_raw_tick_history[symbol].append" not in src
+
+
+async def test_data_source_no_longer_calls_broker_historical_data() -> None:
+    text = (SRC / "data" / "source.py").read_text()
+    assert ".historical_data(" not in text
+    assert "MarketDataManager.ensure_history" in text

--- a/tests/data/test_canonical_history_hydration.py
+++ b/tests/data/test_canonical_history_hydration.py
@@ -297,3 +297,63 @@ async def test_mdm_hydrate_explicit_max_bars_maps_to_target(monkeypatch) -> None
     await mdm.hydrate_symbol_history("NFO:NIFTYCE", max_bars=300)
     assert captured["target_bars"] == 300
     assert captured["required_bars"] < 300  # required stays modest
+
+# ---- Raw tick vs canonical OHLC storage/readiness semantics ----
+
+from collections import defaultdict, deque
+import threading
+
+
+def _storage_mdm() -> MarketDataManager:
+    mdm = MarketDataManager.__new__(MarketDataManager)
+    mdm._logger = SimpleNamespace(info=lambda *a, **k: None, warning=lambda *a, **k: None, error=lambda *a, **k: None, debug=lambda *a, **k: None)
+    mdm._lock = threading.RLock()
+    mdm._min_required_bars = 2
+    mdm._raw_tick_history = defaultdict(lambda: deque(maxlen=100))
+    mdm._ohlc = defaultdict(lambda: deque(maxlen=100))
+    mdm._last_historical_ts = {}
+    mdm._bar_symbol_key = lambda s: str(s)
+    mdm._canonical_symbol = lambda s: str(s)
+    mdm._active_subscribed_symbols = set()
+    mdm._readiness_requirements = {}
+    mdm._last_readiness_state = {}
+    mdm._spot_ready_logged = False
+    mdm.update_hydration_status = lambda *_a, **_k: None
+    # tick ingestion support
+    mdm._symbol_by_token = {}
+    mdm._token_to_symbol = {}
+    mdm._symbol_to_token = {}
+    mdm._token_by_symbol = {}
+    mdm._latest_ticks = {}
+    mdm._tick_cache = {}
+    mdm._last_tick_time = {}
+    mdm._ticks_received_per_symbol = defaultdict(int)
+    mdm._symbols_with_tick = set()
+    mdm._last_tick_wallclock = {}
+    mdm._last_quote_ts_ms = {}
+    mdm._tick_wallclock = lambda tick: tick.get("timestamp")
+    mdm._now_ms = lambda: 1
+    mdm._dedupe_symbol_history = lambda *_a, **_k: None
+    mdm._refresh_ohlc_from_tick = lambda *_a, **_k: None
+    return mdm
+
+
+def test_historical_bar_writes_only_canonical_ohlc_not_raw_ticks() -> None:
+    mdm = _storage_mdm()
+    bar = {"symbol": "NSE:NIFTY", "timestamp": datetime(2026, 1, 1, tzinfo=timezone.utc), "open": 1, "high": 2, "low": 1, "close": 2, "volume": 10}
+    mdm.ingest_historical_bar(bar)
+    assert len(mdm._ohlc["NSE:NIFTY"]) == 1
+    assert len(mdm._raw_tick_history["NSE:NIFTY"]) == 0
+    assert mdm.is_ohlc_ready("NSE:NIFTY", required_bars=1) is True
+    assert mdm.is_tick_ready("NSE:NIFTY") is False
+
+
+def test_live_tick_writes_raw_tick_history_without_implying_ohlc_ready() -> None:
+    mdm = _storage_mdm()
+    tick = {"symbol": "NSE:NIFTY", "ltp": 100.0, "timestamp": 1.0, "source": "ws"}
+    mdm._store_tick("NSE:NIFTY", dict(tick))
+    mdm._store_tick("NSE:NIFTY", dict(tick, timestamp=2.0, ltp=101.0))
+    assert len(mdm._raw_tick_history["NSE:NIFTY"]) == 2
+    assert mdm.is_tick_ready("NSE:NIFTY") is True
+    assert mdm.is_ohlc_ready("NSE:NIFTY") is False
+    assert mdm.is_market_data_ready("NSE:NIFTY") is False

--- a/tests/data/test_market_data_manager.py
+++ b/tests/data/test_market_data_manager.py
@@ -511,16 +511,15 @@ async def test_readiness_passes_with_required_quorum(
         option_symbols=symbols[2:],
     )
     for symbol in symbols:
-        manager.ingest_historical_bar(
+        manager._store_tick(  # noqa: SLF001 - readiness is raw/live tick based
+            symbol,
             {
                 "symbol": symbol,
-                "open": 1,
-                "high": 2,
-                "low": 1,
-                "close": 1.5,
-                "volume": 1,
+                "ltp": 1.5,
                 "timestamp": datetime.now(timezone.utc),
-            }
+                "received_at": datetime.now(timezone.utc),
+                "source": "ws",
+            },
         )
     await manager.wait_until_ready(timeout=0.5)
     assert manager.ready is True
@@ -553,16 +552,15 @@ async def test_readiness_allows_outer_option_basket_to_lag(
         option_symbols=symbols[2:],
     )
     for symbol in symbols[:4]:
-        manager.ingest_historical_bar(
+        manager._store_tick(  # noqa: SLF001 - readiness is raw/live tick based
+            symbol,
             {
                 "symbol": symbol,
-                "open": 1,
-                "high": 2,
-                "low": 1,
-                "close": 1.5,
-                "volume": 1,
+                "ltp": 1.5,
                 "timestamp": datetime.now(timezone.utc),
-            }
+                "received_at": datetime.now(timezone.utc),
+                "source": "ws",
+            },
         )
     await manager.wait_until_ready(timeout=0.5)
     assert manager.ready is True


### PR DESCRIPTION
### Motivation
- Remove transitional/duplicate historical-hydration paths so a single canonical SSOT owns OHLC: MarketDataManager._ohlc, and prevent runtime code from calling broker history directly.
- Stop treating historical OHLC as raw tick payloads so live tick readiness and OHLC readiness are separate and unambiguous.
- Harden the app→runner injection boundary so the runtime history ensurer has an explicit contract and injection failures are visible/serious.

### Description
- Enforce canonical hydration ownership and broker-fetch allowlist by removing `data/source.py` from the broker-history allowlist and changing `MarketDataSource.get_ohlc()` to refuse broker fetches (cached-only or raise), directing callers to `MarketDataManager.ensure_history()` (file: `src/nifty_scalper_bot/data/source.py`).
- Stop writing historical bars into raw tick storage: `MarketDataManager.ingest_historical_bar()` now appends only to `_ohlc` and no longer writes into `_raw_tick_history` (file: `src/nifty_scalper_bot/data/market_data_manager.py`).
- Split readiness semantics: added `is_tick_ready()`, `is_ohlc_ready()`, and `is_market_data_ready()`; deprecated `is_symbol_ready()` as a tick-readiness delegate; `wait_until_ready()` now uses raw tick readiness only (file: `src/nifty_scalper_bot/data/market_data_manager.py`).
- Make runtime history callback signature explicit and strict: replace `**kwargs` ensurer with a keyword-only signature (`role`, `phase`, `reason`, `required_bars`, `target_bars`) and forward to `ensure_symbol_runtime_history()`; on injection failure log `CANONICAL_HISTORY_ENSURER_INJECTION_FAILED` at ERROR and mark context state (file: `src/nifty_scalper_bot/core/app.py`).
- Remove/clean compatibility leakage and add AST-based guards/tests to prevent callback-contract drift and non-MDM broker fetches (tests updated: `tests/architecture/test_history_ownership.py`).
- Add focused unit tests proving storage/readiness semantics: historical ingestion affects only `_ohlc`, live ticks populate `_raw_tick_history`, and OHLC readiness does not imply tick-ready (file: `tests/data/test_canonical_history_hydration.py`), and updated MDM readiness tests to use live tick seeding (file: `tests/data/test_market_data_manager.py`).

### Testing
- Commands run: `python -m compileall -q src`, `python -m compileall -q tests`, and focused/full pytest runs described below.
- Focused: `pytest -q tests/architecture/test_history_ownership.py` and other targeted suites — 220 passed, 0 failed, 0 skipped, 0 xfailed, 0 errors; 31 warnings.
- Related suites: `pytest -q tests/core tests/data tests/strategies tests/architecture` (combined related run) — 1253 passed, 0 failed, 0 skipped, 0 xfailed, 0 errors; 104 warnings.
- Full suite: `pytest` — 2213 passed, 0 failed, 1 skipped, 0 xfailed, 0 errors; 208 warnings.
- Static checks: `python -m compileall` passed and `git diff --check` returned no merge-conflict markers.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e778bee2c832480b9f0fa0316e41a)