### PR TITLE
Prepare final execution candidate state before ORDER_PENDING

### DIFF
--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -1751,11 +1751,14 @@ class StrategyRunner:
         """Compatibility wrapper around canonical Runner history sync."""
         normalized = self._normalize_symbol(symbol)
         target = max(1, int(required_bars or self._required_bars_for_symbol(normalized) or 1)) if normalized else 1
+        role = self._symbol_role_for_runner(symbol) if hasattr(self, "_symbol_role_for_runner") else None
+        if str(source or "").endswith("option_cache_sync"):
+            role = "option_context_cache_sync"
         result = self.sync_history_from_mdm(
             symbol,
             required_bars=target,
             reason=source,
-            role=self._symbol_role_for_runner(symbol) if hasattr(self, "_symbol_role_for_runner") else None,
+            role=role,
             request_if_short=request_if_short,
         )
         return result.indicator_bars
@@ -6016,6 +6019,32 @@ class StrategyRunner:
         machine = self._get_execution_state_machine(symbol)
         return machine.transition(new_state)
 
+    def _prepare_order_state_for_submission(
+        self,
+        symbol: str,
+        *,
+        trace_id: str | None = None,
+    ) -> tuple[bool, str, dict[str, Any]]:
+        """Move the final execution symbol through signal/order states before submit."""
+        normalized = normalize_symbol(symbol)
+        with self._execution_state_lock:
+            machine = self._execution_state_by_symbol.setdefault(
+                normalized,
+                OrderStateMachine(),
+            )
+
+        if not machine.can_accept_signal():
+            return False, "signal_state_rejected", machine.current_state_details()
+
+        if machine.state in (ExecutionState.IDLE, ExecutionState.READY):
+            if not machine.transition(ExecutionState.SIGNAL_RECEIVED):
+                return False, "signal_state_rejected", machine.current_state_details()
+
+        if not machine.transition(ExecutionState.ORDER_PENDING):
+            return False, "order_state_rejected", machine.current_state_details()
+
+        return True, "ok", machine.current_state_details()
+
     def _reset_execution_state(self, symbol: str) -> None:
         """Reset execution state to IDLE. Args: symbol. Returns: none. Raises: none."""
         machine = self._get_execution_state_machine(symbol)
@@ -8821,6 +8850,25 @@ class StrategyRunner:
             return "context_direction_conflict", "underlying_direction_conflict"
         direction_bias = indicators_ctx.get("underlying_direction_bias") or indicators_ctx.get("direction_bias")
         if not direction_bias:
+            direction_reason_flags = {
+                "missing_spot_snapshot": not bool(indicators_ctx.get("spot_snapshot") or indicators_ctx.get("spot_ltp") or indicators_ctx.get("spot_price")),
+                "missing_futures_snapshot": not bool(indicators_ctx.get("futures_snapshot") or indicators_ctx.get("futures_ltp") or indicators_ctx.get("futures_price")),
+                "missing_vwap": indicators_ctx.get("vwap") is None and indicators_ctx.get("underlying_vwap") is None,
+                "missing_vwap_slope": indicators_ctx.get("vwap_slope") is None and indicators_ctx.get("underlying_vwap_slope") is None,
+                "missing_volume_ratio": indicators_ctx.get("volume_ratio") is None and indicators_ctx.get("underlying_volume_ratio") is None,
+                "stale_context": bool(indicators_ctx.get("stale_context") or indicators_ctx.get("context_stale")),
+                "insufficient_context_bars": bool(indicators_ctx.get("insufficient_context_bars")) or int(indicators_ctx.get("context_bar_count") or indicators_ctx.get("underlying_context_bar_count") or 0) < int(self._context_required_bars or 0),
+            }
+            if not any(direction_reason_flags.values()):
+                direction_reason_flags["unknown"] = True
+            else:
+                direction_reason_flags["unknown"] = False
+            self._logger.info(
+                "CONTEXT_DIRECTION_UNAVAILABLE symbol=%s reasons=%s",
+                symbol,
+                direction_reason_flags,
+                extra={"event": "CONTEXT_DIRECTION_UNAVAILABLE", "symbol": symbol, **direction_reason_flags},
+            )
             return "context_direction_unavailable", "direction_context_not_ready"
         if signal is None:
             return "strategy_no_trigger", "evaluation_no_signal"
@@ -12060,14 +12108,6 @@ class StrategyRunner:
             trade_price = price
 
             if action in {"BUY", "SELL"}:
-                if not self._transition_execution_state(
-                    base_symbol, ExecutionState.SIGNAL_RECEIVED
-                ):
-                    return SignalExecutionResult(
-                        False,
-                        "signal_state_rejected",
-                        details={"trace_id": trace_id},
-                    )
                 return self._handle_entry_signal(
                     signal,
                     base_symbol,
@@ -12549,6 +12589,17 @@ class StrategyRunner:
                 and normalize_symbol(str(snap.get("symbol") or ""))
                 != normalize_symbol(selected_symbol)
             ]
+        mode = str(os.getenv("EXECUTION_MODE", "SHADOW")).strip().upper()
+        strict_depth = mode == "LIVE" or (
+            str(os.getenv("ENABLE_LIVE", "false")).strip().lower() in {"1", "true", "yes", "on"}
+        ) or _env_flag("STRICT_OPTION_DEPTH_FOR_PAPER", default=False)
+        if strict_depth and not depth_available:
+            return SignalExecutionResult(
+                False,
+                "candidate_depth_missing",
+                details={"selected_symbol": selected_symbol, "ranking_fields": ranking_fields},
+            )
+
         self._logger.info(
             "SIGNAL_CANDIDATE_SELECTED direction=%s selected_symbol=%s rejected_symbols=%s ranking_fields=%s",
             option_side,
@@ -13768,20 +13819,28 @@ class StrategyRunner:
                 )
                 return self._reject_signal_execution(symbol=base_symbol, trace_id=trace_id, reason="order_failure_cooldown_active")
 
-            if not self._transition_execution_state(
-                base_symbol, ExecutionState.ORDER_PENDING
-            ):
-                state_details = self._get_execution_state_machine(base_symbol).current_state_details()
+            state_ok, state_reason, state_details = self._prepare_order_state_for_submission(
+                trade_symbol or base_symbol, trace_id=trace_id
+            )
+            if not state_ok:
                 self._logger.warning(
-                    "EXECUTION_STATE_TRANSITION_REJECTED symbol=%s base_symbol=%s trade_symbol=%s signal_symbol=%s trace_id=%s target_state=%s state_details=%s",
-                    base_symbol,
-                    base_symbol,
+                    "EXECUTION_STATE_TRANSITION_REJECTED symbol=%s trade_symbol=%s signal_symbol=%s trace_id=%s target_state=%s state_details=%s",
+                    trade_symbol or base_symbol,
                     trade_symbol,
                     signal.symbol,
                     trace_id,
                     ExecutionState.ORDER_PENDING.value,
                     state_details,
-                    extra={"event": "EXECUTION_STATE_TRANSITION_REJECTED", "symbol": base_symbol, "trace_id": trace_id, "state_details": state_details, "target_state": ExecutionState.ORDER_PENDING.value, "reason_key": reason_key},
+                    extra={
+                        "event": "EXECUTION_STATE_TRANSITION_REJECTED",
+                        "symbol": trade_symbol or base_symbol,
+                        "trade_symbol": trade_symbol,
+                        "signal_symbol": signal.symbol,
+                        "trace_id": trace_id,
+                        "state_details": state_details,
+                        "target_state": ExecutionState.ORDER_PENDING.value,
+                        "reason_key": reason_key,
+                    },
                 )
                 self._mark_directional_dedup_failed(
                     underlying=underlying, option_side=option_side, reason=reason_key
@@ -13790,7 +13849,7 @@ class StrategyRunner:
                 return self._reject_signal_execution(
                     symbol=base_symbol,
                     trace_id=trace_id,
-                    reason="order_state_rejected",
+                    reason=state_reason,
                     details={"state_details": state_details, "target_state": ExecutionState.ORDER_PENDING.value},
                 )
 

--- a/tests/strategies/test_runner_live_path_guards.py
+++ b/tests/strategies/test_runner_live_path_guards.py
@@ -11,6 +11,7 @@ import threading
 from unittest.mock import AsyncMock, MagicMock
 import pytest
 
+from nifty_scalper_bot.execution.order_state_machine import ExecutionState
 from nifty_scalper_bot.strategies.runner import ExecutionReadinessResult, SignalExecutionResult, StrategyRunner
 from nifty_scalper_bot.strategies.signal_generator import Signal
 from nifty_scalper_bot.strategies.trade_selector import TradeCandidateSelector
@@ -2371,6 +2372,8 @@ def test_live_execution_uses_basket_and_submits_alternate_candidate(monkeypatch)
     assert result.reason == "order_submitted"
     submitted_plan = runner._order_manager.submit_trade_plan.call_args.args[0]
     assert submitted_plan.symbol == alt_symbol
+    assert runner._get_execution_state_machine(alt_symbol).state == ExecutionState.ORDER_PENDING
+    assert result.reason != "order_state_rejected"
 
 
 def test_order_rejected_does_not_mark_duplicate_cooldown(monkeypatch) -> None:
@@ -2965,3 +2968,55 @@ def test_symbol_live_entry_ready_allows_near_atm_candidate_when_global_pair_not_
     assert reason == 'symbol_live_ready'
     assert details['candidate_specific_readiness_override'] is True
     assert details['tradable_quote'] is True
+
+
+def test_live_candidate_with_tradable_quote_without_depth_rejected(monkeypatch) -> None:
+    runner = _build_runner()
+    monkeypatch.setenv('EXECUTION_MODE', 'LIVE')
+    signal = Signal(
+        action='BUY',
+        symbol='NFO:NIFTY2661623900PE',
+        quantity=1,
+        confidence=0.9,
+        reason='OrderFlow',
+        stop_loss=100.0,
+        take_profit=130.0,
+        metadata={},
+    )
+    result = runner._apply_directional_signal_dedup(
+        signal=signal,
+        metadata={'candidate_score': 9.0, 'tradable_quote': True, 'candidate_spread_pct': 0.1},
+        underlying='NIFTY',
+        now_epoch=1000.0,
+        selected_symbol='NFO:NIFTY2661623900PE',
+        option_side='PE',
+        selected_snapshot={'tradable_quote': True, 'bid': 100.0, 'ask': 101.0, 'depth_available': False},
+    )
+
+    assert result is not None
+    assert result.accepted is False
+    assert result.reason == 'candidate_depth_missing'
+
+
+def test_option_context_cache_sync_role_for_five_bar_cache_sync() -> None:
+    runner = _build_runner()
+    captured = {}
+
+    def fake_sync(symbol, *, required_bars, reason, role, request_if_short):
+        captured.update(symbol=symbol, required_bars=required_bars, reason=reason, role=role, request_if_short=request_if_short)
+        return SimpleNamespace(indicator_bars=required_bars)
+
+    runner._normalize_symbol = lambda symbol: symbol
+    runner._required_bars_for_symbol = lambda _symbol: 5
+    runner.sync_history_from_mdm = fake_sync
+
+    after = runner._sync_history_from_mdm_cache(
+        'NFO:NIFTY2661623900PE',
+        required_bars=5,
+        source='active_option_context_option_cache_sync',
+        request_if_short=False,
+    )
+
+    assert after == 5
+    assert captured['required_bars'] == 5
+    assert captured['role'] == 'option_context_cache_sync'

--- a/tests/strategies/test_runner_signal_result.py
+++ b/tests/strategies/test_runner_signal_result.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from types import SimpleNamespace
 
+import pytest
+
 from nifty_scalper_bot.execution.order_state_machine import ExecutionState
 from nifty_scalper_bot.strategies.runner import SignalExecutionResult, StrategyRunner
 
@@ -39,3 +41,56 @@ def test_handle_signal_returns_outside_market_hours_result(monkeypatch) -> None:
     assert isinstance(result, SignalExecutionResult)
     assert result.accepted is False
     assert result.reason == 'outside_market_hours'
+
+
+def _state_runner() -> StrategyRunner:
+    import threading
+
+    runner = StrategyRunner.__new__(StrategyRunner)
+    runner._execution_state_lock = threading.RLock()
+    runner._execution_state_by_symbol = {}
+    return runner
+
+
+def test_prepare_order_state_from_idle_reaches_order_pending() -> None:
+    runner = _state_runner()
+
+    ok, reason, details = runner._prepare_order_state_for_submission(
+        'NFO:NIFTY2661623900PE', trace_id='idle-final'
+    )
+
+    assert ok is True
+    assert reason == 'ok'
+    assert details['state'] == ExecutionState.ORDER_PENDING.value
+
+
+def test_prepare_order_state_from_ready_reaches_order_pending() -> None:
+    runner = _state_runner()
+    machine = runner._get_execution_state_machine('NFO:NIFTY2661623900PE')
+    assert machine.transition(ExecutionState.READY) is True
+
+    ok, reason, details = runner._prepare_order_state_for_submission(
+        'NFO:NIFTY2661623900PE', trace_id='ready-final'
+    )
+
+    assert ok is True
+    assert reason == 'ok'
+    assert details['state'] == ExecutionState.ORDER_PENDING.value
+
+
+@pytest.mark.parametrize('busy_state', [ExecutionState.ORDER_PENDING, ExecutionState.POSITION_OPEN])
+def test_prepare_order_state_rejects_busy_final_symbol(busy_state) -> None:
+    runner = _state_runner()
+    machine = runner._get_execution_state_machine('NFO:NIFTY2661623900PE')
+    assert machine.transition(ExecutionState.SIGNAL_RECEIVED) is True
+    assert machine.transition(ExecutionState.ORDER_PENDING) is True
+    if busy_state == ExecutionState.POSITION_OPEN:
+        assert machine.transition(ExecutionState.POSITION_OPEN) is True
+
+    ok, reason, details = runner._prepare_order_state_for_submission(
+        'NFO:NIFTY2661623900PE', trace_id='busy-final'
+    )
+
+    assert ok is False
+    assert reason == 'signal_state_rejected'
+    assert details['state'] == busy_state.value


### PR DESCRIPTION
### Motivation
- A BUY/SELL signal could have SIGNAL_RECEIVED applied on the original signal symbol, then be replaced by a final candidate; the final candidate later attempted to go straight to `ORDER_PENDING` while still `IDLE`, which the `OrderStateMachine` correctly rejects. 
- The intent is to ensure the final selected trade symbol always advances through the required lifecycle (`IDLE/READY → SIGNAL_RECEIVED → ORDER_PENDING`) without changing the state-machine rules or bypassing safety gates.

### Description
- Added `StrategyRunner._prepare_order_state_for_submission(symbol, trace_id=None)` that normalizes the final trade symbol and moves its per-symbol `OrderStateMachine` through `SIGNAL_RECEIVED` (if needed) then `ORDER_PENDING`, returning structured (ok|reason|state_details) results without creating a new state store.
- Stopped applying `SIGNAL_RECEIVED` prematurely on the original signal symbol in `_handle_signal()` so state preparation is performed only after candidate selection and final trade-symbol resolution, and replaced direct `ORDER_PENDING` calls with the new helper in the entry path.
- Preserved and extended diagnostics when the helper fails by emitting `EXECUTION_STATE_TRANSITION_REJECTED` with `symbol`, `trade_symbol`, `signal_symbol`, `trace_id`, `target_state`, and `state_details`, and returning the appropriate `SignalExecutionResult` reasons (`signal_state_rejected` / `order_state_rejected`).
- Added a live/strict candidate depth gate that rejects selected candidates before `SIGNAL_CANDIDATE_SELECTED` when `depth_available` is not True (reason `candidate_depth_missing`), while paper/shadow retains existing behavior unless strict env is enabled.
- Renamed cache-sync role for 5-bar option-cache syncs to `option_context_cache_sync` (instead of `tradable_option`) to avoid mislabeling 5-bar cache-only context options as executable; added richer `CONTEXT_DIRECTION_UNAVAILABLE` diagnostic fields without changing decision logic.
- Tests updated/added to cover: final-symbol lifecycle preparation from `IDLE`/`READY`, rejection for busy states (`ORDER_PENDING`/`POSITION_OPEN`), replacement-candidate path reaching `ORDER_PENDING`, candidate depth-missing rejection, and option cache-sync role behavior.

### Testing
- Validation commands run: `python -m compileall -q src`, `python -m compileall -q tests`, and `pytest -q` with focused runs on the affected suites.
- Focused pytest runs and results: `tests/test_execution_state_machine.py` passed; `tests/strategies/test_runner_signal_result.py` passed; `tests/strategies/test_runner_live_path_guards.py` passed; full `tests/strategies` and overall `pytest -q` also passed in the environment used for this change.
- New/modified unit tests were added to `tests/strategies/test_runner_signal_result.py` and `tests/strategies/test_runner_live_path_guards.py` and executed successfully. No automated tests failed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f88d0bcec83249676543dd128ce78)