### PR TITLE
Fix final-symbol execution state and live candidate depth gating

### DIFF
--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -3256,6 +3256,7 @@ class StrategyRunner:
                 getattr(self, "_runtime_readiness_reason", None)
                 or "startup_pipeline_not_ready"
             )
+        original_symbol = signal.symbol
         metadata = dict(signal.metadata or {})
         option_side = infer_option_side(signal.symbol, metadata)
         is_directional_option = option_side in {"CE", "PE"}
@@ -6025,25 +6026,39 @@ class StrategyRunner:
         *,
         trace_id: str | None = None,
     ) -> tuple[bool, str, dict[str, Any]]:
-        """Move the final execution symbol through signal/order states before submit."""
+        """Move final trade symbol through signal→order-pending lifecycle."""
+        del trace_id
         normalized = normalize_symbol(symbol)
         with self._execution_state_lock:
             machine = self._execution_state_by_symbol.setdefault(
                 normalized,
                 OrderStateMachine(),
             )
+            before = machine.current_state_details()
 
-        if not machine.can_accept_signal():
-            return False, "signal_state_rejected", machine.current_state_details()
+            if not machine.can_accept_signal():
+                return False, "signal_state_rejected", {
+                    "before": before,
+                    "after": machine.current_state_details(),
+                }
 
-        if machine.state in (ExecutionState.IDLE, ExecutionState.READY):
-            if not machine.transition(ExecutionState.SIGNAL_RECEIVED):
-                return False, "signal_state_rejected", machine.current_state_details()
+            if machine.state in (ExecutionState.IDLE, ExecutionState.READY):
+                if not machine.transition(ExecutionState.SIGNAL_RECEIVED):
+                    return False, "signal_state_rejected", {
+                        "before": before,
+                        "after": machine.current_state_details(),
+                    }
 
-        if not machine.transition(ExecutionState.ORDER_PENDING):
-            return False, "order_state_rejected", machine.current_state_details()
+            if not machine.transition(ExecutionState.ORDER_PENDING):
+                return False, "order_state_rejected", {
+                    "before": before,
+                    "after": machine.current_state_details(),
+                }
 
-        return True, "ok", machine.current_state_details()
+            return True, "ok", {
+                "before": before,
+                "after": machine.current_state_details(),
+            }
 
     def _reset_execution_state(self, symbol: str) -> None:
         """Reset execution state to IDLE. Args: symbol. Returns: none. Raises: none."""
@@ -8850,22 +8865,11 @@ class StrategyRunner:
             return "context_direction_conflict", "underlying_direction_conflict"
         direction_bias = indicators_ctx.get("underlying_direction_bias") or indicators_ctx.get("direction_bias")
         if not direction_bias:
-            direction_reason_flags = {
-                "missing_spot_snapshot": not bool(indicators_ctx.get("spot_snapshot") or indicators_ctx.get("spot_ltp") or indicators_ctx.get("spot_price")),
-                "missing_futures_snapshot": not bool(indicators_ctx.get("futures_snapshot") or indicators_ctx.get("futures_ltp") or indicators_ctx.get("futures_price")),
-                "missing_vwap": indicators_ctx.get("vwap") is None and indicators_ctx.get("underlying_vwap") is None,
-                "missing_vwap_slope": indicators_ctx.get("vwap_slope") is None and indicators_ctx.get("underlying_vwap_slope") is None,
-                "missing_volume_ratio": indicators_ctx.get("volume_ratio") is None and indicators_ctx.get("underlying_volume_ratio") is None,
-                "stale_context": bool(indicators_ctx.get("stale_context") or indicators_ctx.get("context_stale")),
-                "insufficient_context_bars": bool(indicators_ctx.get("insufficient_context_bars")) or int(indicators_ctx.get("context_bar_count") or indicators_ctx.get("underlying_context_bar_count") or 0) < int(self._context_required_bars or 0),
-            }
-            if not any(direction_reason_flags.values()):
-                direction_reason_flags["unknown"] = True
-            else:
-                direction_reason_flags["unknown"] = False
+            reason_detail, direction_reason_flags = self._direction_context_missing_reason(indicators_ctx)
             self._logger.info(
-                "CONTEXT_DIRECTION_UNAVAILABLE symbol=%s reasons=%s",
+                "CONTEXT_DIRECTION_UNAVAILABLE symbol=%s reason_detail=%s diagnostics=%s",
                 symbol,
+                reason_detail,
                 direction_reason_flags,
                 extra={"event": "CONTEXT_DIRECTION_UNAVAILABLE", "symbol": symbol, **direction_reason_flags},
             )
@@ -8875,6 +8879,53 @@ class StrategyRunner:
         if not self._runtime_live_orders_armed:
             return "execution_readiness_false", str(self._runtime_readiness_reason or "runtime_live_orders_not_armed")
         return "strategy_no_trigger", "no_order_condition"
+
+
+    def _direction_context_missing_reason(self, indicators_ctx: Mapping[str, Any]) -> tuple[str, dict[str, Any]]:
+        """Return precise diagnostics for missing direction context without changing decisions."""
+        spot_snapshot = indicators_ctx.get("spot_snapshot")
+        futures_snapshot = indicators_ctx.get("futures_snapshot")
+        spot_bars = int(indicators_ctx.get("spot_bars") or indicators_ctx.get("context_bar_count") or indicators_ctx.get("underlying_context_bar_count") or 0)
+        futures_bars = int(indicators_ctx.get("futures_bars") or indicators_ctx.get("futures_context_bar_count") or 0)
+        spot_fresh = not bool(indicators_ctx.get("spot_stale") or indicators_ctx.get("stale_context") or indicators_ctx.get("context_stale"))
+        fut_fresh = not bool(indicators_ctx.get("futures_stale") or indicators_ctx.get("fut_stale"))
+        spot_vwap = indicators_ctx.get("spot_vwap", indicators_ctx.get("vwap", indicators_ctx.get("underlying_vwap")))
+        futures_vwap = indicators_ctx.get("futures_vwap")
+        futures_vwap_slope = indicators_ctx.get("futures_vwap_slope", indicators_ctx.get("vwap_slope", indicators_ctx.get("underlying_vwap_slope")))
+        futures_volume_ratio = indicators_ctx.get("futures_volume_ratio", indicators_ctx.get("volume_ratio", indicators_ctx.get("underlying_volume_ratio")))
+        regime_available = bool(indicators_ctx.get("regime_snapshot") or indicators_ctx.get("regime") or indicators_ctx.get("market_regime"))
+        required_bars = int(getattr(self, "_context_required_bars", 0) or 0)
+
+        if not bool(spot_snapshot or indicators_ctx.get("spot_ltp") or indicators_ctx.get("spot_price")):
+            reason = "missing_spot_snapshot"
+        elif not bool(futures_snapshot or indicators_ctx.get("futures_ltp") or indicators_ctx.get("futures_price")):
+            reason = "missing_futures_snapshot"
+        elif not spot_fresh or not fut_fresh or bool(indicators_ctx.get("stale_context") or indicators_ctx.get("context_stale")):
+            reason = "stale_context"
+        elif bool(indicators_ctx.get("insufficient_context_bars")) or (required_bars > 0 and spot_bars < required_bars):
+            reason = "insufficient_context_bars"
+        elif spot_vwap is None and futures_vwap is None:
+            reason = "missing_vwap"
+        elif futures_vwap_slope in (None, 0, 0.0):
+            reason = "missing_futures_slope"
+        elif futures_volume_ratio is None:
+            reason = "missing_volume_ratio"
+        elif not regime_available:
+            reason = "missing_regime_snapshot"
+        else:
+            reason = "unknown"
+        return reason, {
+            "reason_detail": reason,
+            "spot_fresh": spot_fresh,
+            "fut_fresh": fut_fresh,
+            "spot_bars": spot_bars,
+            "futures_bars": futures_bars,
+            "spot_vwap": spot_vwap,
+            "futures_vwap": futures_vwap,
+            "futures_vwap_slope": futures_vwap_slope,
+            "futures_volume_ratio": futures_volume_ratio,
+            "regime_available": regime_available,
+        }
 
     def _emit_no_trade_decision(
         self,
@@ -12518,6 +12569,7 @@ class StrategyRunner:
         selected_symbol: str,
         option_side: str,
         selected_snapshot: dict[str, Any],
+        trace_id: str | None = None,
     ) -> SignalExecutionResult | None:
         reason = str(signal.reason or "unknown")
         key = self._directional_dedup_key(
@@ -12589,11 +12641,45 @@ class StrategyRunner:
                 and normalize_symbol(str(snap.get("symbol") or ""))
                 != normalize_symbol(selected_symbol)
             ]
-        mode = str(os.getenv("EXECUTION_MODE", "SHADOW")).strip().upper()
-        strict_depth = mode == "LIVE" or (
-            str(os.getenv("ENABLE_LIVE", "false")).strip().lower() in {"1", "true", "yes", "on"}
-        ) or _env_flag("STRICT_OPTION_DEPTH_FOR_PAPER", default=False)
-        if strict_depth and not depth_available:
+        bid_raw = selected_snapshot.get("bid")
+        ask_raw = selected_snapshot.get("ask")
+        try:
+            bid = float(bid_raw) if bid_raw is not None else 0.0
+        except (TypeError, ValueError):
+            bid = 0.0
+        try:
+            ask = float(ask_raw) if ask_raw is not None else 0.0
+        except (TypeError, ValueError):
+            ask = 0.0
+        mode_snapshot = self._resolve_execution_mode_snapshot()
+        is_live_depth_required = bool(mode_snapshot.is_live_mode) and not _env_flag(
+            "RUNNER_ALLOW_LIVE_DEPTH_FALLBACK", default=False
+        )
+        strict_depth = is_live_depth_required or _env_flag("STRICT_OPTION_DEPTH_FOR_PAPER", default=False)
+        max_spread_pct = float(os.getenv("ORDER_MAX_SPREAD_PCT", os.getenv("SPREAD_MAX_PCT", "10.0")) or "10.0")
+        invalid_spread = spread_pct_raw is None or spread_pct < 0 or spread_pct > max_spread_pct
+        if strict_depth and (not tradable_quote or bid <= 0 or ask <= 0 or invalid_spread or not depth_available):
+            self._logger.info(
+                "EXECUTION_CANDIDATE_REJECTED symbol=%s reason=candidate_depth_missing tradable_quote=%s depth_available=%s bid=%s ask=%s spread_pct=%s trace_id=%s",
+                selected_symbol,
+                tradable_quote,
+                depth_available,
+                bid,
+                ask,
+                spread_pct_raw,
+                trace_id,
+                extra={
+                    "event": "EXECUTION_CANDIDATE_REJECTED",
+                    "symbol": selected_symbol,
+                    "reason": "candidate_depth_missing",
+                    "tradable_quote": tradable_quote,
+                    "depth_available": depth_available,
+                    "bid": bid,
+                    "ask": ask,
+                    "spread_pct": spread_pct_raw,
+                    "trace_id": trace_id,
+                },
+            )
             return SignalExecutionResult(
                 False,
                 "candidate_depth_missing",
@@ -13238,6 +13324,8 @@ class StrategyRunner:
                         trace_id,
                         extra={
                             "event": "SIGNAL_SYMBOL_REPLACED_BY_CANDIDATE",
+                            "original_signal_symbol": original_symbol,
+                            "final_trade_symbol": selected_symbol,
                             "original_symbol": original_symbol,
                             "selected_symbol": candidate.symbol,
                             "original_trade_price": original_trade_price,
@@ -13336,6 +13424,7 @@ class StrategyRunner:
                     selected_symbol=selected_symbol,
                     option_side=option_side,
                     selected_snapshot=selected_snapshot,
+                    trace_id=trace_id,
                 )
                 if dedup_result is not None:
                     self._reset_execution_state(base_symbol)
@@ -13839,6 +13928,7 @@ class StrategyRunner:
                         "trace_id": trace_id,
                         "state_details": state_details,
                         "target_state": ExecutionState.ORDER_PENDING.value,
+                        "reason": state_reason,
                         "reason_key": reason_key,
                     },
                 )

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -8883,10 +8883,23 @@ class StrategyRunner:
 
     def _direction_context_missing_reason(self, indicators_ctx: Mapping[str, Any]) -> tuple[str, dict[str, Any]]:
         """Return precise diagnostics for missing direction context without changing decisions."""
+        def _safe_int(value: Any, default: int = 0) -> int:
+            try:
+                return int(value)
+            except (TypeError, ValueError):
+                return default
+
         spot_snapshot = indicators_ctx.get("spot_snapshot")
         futures_snapshot = indicators_ctx.get("futures_snapshot")
-        spot_bars = int(indicators_ctx.get("spot_bars") or indicators_ctx.get("context_bar_count") or indicators_ctx.get("underlying_context_bar_count") or 0)
-        futures_bars = int(indicators_ctx.get("futures_bars") or indicators_ctx.get("futures_context_bar_count") or 0)
+        spot_bars = _safe_int(
+            indicators_ctx.get("spot_bars")
+            or indicators_ctx.get("context_bar_count")
+            or indicators_ctx.get("underlying_context_bar_count")
+        )
+        futures_bars = _safe_int(
+            indicators_ctx.get("futures_bars")
+            or indicators_ctx.get("futures_context_bar_count")
+        )
         spot_fresh = not bool(indicators_ctx.get("spot_stale") or indicators_ctx.get("stale_context") or indicators_ctx.get("context_stale"))
         fut_fresh = not bool(indicators_ctx.get("futures_stale") or indicators_ctx.get("fut_stale"))
         spot_vwap = indicators_ctx.get("spot_vwap", indicators_ctx.get("vwap", indicators_ctx.get("underlying_vwap")))
@@ -8894,7 +8907,7 @@ class StrategyRunner:
         futures_vwap_slope = indicators_ctx.get("futures_vwap_slope", indicators_ctx.get("vwap_slope", indicators_ctx.get("underlying_vwap_slope")))
         futures_volume_ratio = indicators_ctx.get("futures_volume_ratio", indicators_ctx.get("volume_ratio", indicators_ctx.get("underlying_volume_ratio")))
         regime_available = bool(indicators_ctx.get("regime_snapshot") or indicators_ctx.get("regime") or indicators_ctx.get("market_regime"))
-        required_bars = int(getattr(self, "_context_required_bars", 0) or 0)
+        required_bars = _safe_int(getattr(self, "_context_required_bars", 0))
 
         if not bool(spot_snapshot or indicators_ctx.get("spot_ltp") or indicators_ctx.get("spot_price")):
             reason = "missing_spot_snapshot"

--- a/tests/strategies/test_runner_live_path_guards.py
+++ b/tests/strategies/test_runner_live_path_guards.py
@@ -3020,3 +3020,58 @@ def test_option_context_cache_sync_role_for_five_bar_cache_sync() -> None:
     assert after == 5
     assert captured['required_bars'] == 5
     assert captured['role'] == 'option_context_cache_sync'
+
+
+def test_prepare_signal_refresh_pending_fallback_uses_original_symbol_without_name_error(monkeypatch, caplog) -> None:
+    runner = _build_runner()
+    monkeypatch.setenv('EXECUTION_MODE', 'LIVE')
+    runner._resolve_execution_mode_snapshot = lambda: SimpleNamespace(is_live_mode=True)
+
+    async def fake_build(*, direction_bias, atm_strike, underlying):
+        return [], True
+
+    runner.build_candidate_snapshots_async = fake_build
+    runner._build_single_candidate_from_signal = lambda **_kwargs: {
+        'symbol': 'NFO:NIFTY2661623900PE',
+        'side': 'PE',
+        'option_type': 'PE',
+        'strike': 3900,
+        'atm_strike': 3950,
+        'ltp': 110.0,
+        'bid': 109.0,
+        'ask': 111.0,
+    }
+    runner._logger = logging.getLogger('test_prepare_signal_original_symbol')
+    signal = Signal(action='BUY', symbol='NFO:NIFTY2661623950PE', quantity=1, confidence=0.9, reason='OrderFlow')
+
+    with caplog.at_level(logging.INFO, logger='test_prepare_signal_original_symbol'):
+        prepared, reason = asyncio.run(runner._prepare_signal_for_handling(signal, price=110.0, trace_id='fallback'))
+
+    assert reason is None
+    assert prepared is not None
+    assert prepared.metadata['candidate_snapshots'][0]['symbol'] == 'NFO:NIFTY2661623900PE'
+    assert any(getattr(rec, 'event', '') == 'CANDIDATE_FALLBACK_FROM_SIGNAL_USED_AFTER_REFRESH_PENDING' for rec in caplog.records)
+
+
+def test_direction_context_unavailable_logs_precise_diagnostics(caplog) -> None:
+    runner = _build_runner()
+    runner._logger = logging.getLogger('test_direction_context_diag')
+    runner._strategy_manager = SimpleNamespace(get_last_no_signal_decision=lambda _symbol: None)
+    runner._context_required_bars = 30
+
+    with caplog.at_level(logging.INFO, logger='test_direction_context_diag'):
+        category, reason = runner._classify_no_trade_decision(
+            symbol='NFO:NIFTY2661623900PE',
+            signal=object(),
+            indicators_ctx={'spot_snapshot': {'ltp': 22000}, 'context_bar_count': 10},
+            option_count=30,
+            option_required=30,
+            trace_id='ctx',
+        )
+
+    assert category == 'context_direction_unavailable'
+    assert reason == 'direction_context_not_ready'
+    record = next(rec for rec in caplog.records if getattr(rec, 'event', '') == 'CONTEXT_DIRECTION_UNAVAILABLE')
+    assert record.reason_detail in {'missing_futures_snapshot', 'insufficient_context_bars'}
+    for field in ['spot_fresh', 'fut_fresh', 'spot_bars', 'futures_bars', 'spot_vwap', 'futures_vwap', 'futures_vwap_slope', 'futures_volume_ratio', 'regime_available']:
+        assert hasattr(record, field)

--- a/tests/strategies/test_runner_live_path_guards.py
+++ b/tests/strategies/test_runner_live_path_guards.py
@@ -3075,3 +3075,36 @@ def test_direction_context_unavailable_logs_precise_diagnostics(caplog) -> None:
     assert record.reason_detail in {'missing_futures_snapshot', 'insufficient_context_bars'}
     for field in ['spot_fresh', 'fut_fresh', 'spot_bars', 'futures_bars', 'spot_vwap', 'futures_vwap', 'futures_vwap_slope', 'futures_volume_ratio', 'regime_available']:
         assert hasattr(record, field)
+
+
+@pytest.mark.parametrize(
+    ('indicators_ctx', 'required_bars'),
+    [
+        ({'spot_snapshot': {'ltp': 22000}, 'context_bar_count': 'unknown'}, 30),
+        ({'spot_snapshot': {'ltp': 22000}, 'futures_snapshot': {'ltp': 22100}, 'futures_context_bar_count': 'NA'}, 30),
+        ({'spot_snapshot': {'ltp': 22000}, 'context_bar_count': 10}, 'bad-required'),
+    ],
+)
+def test_direction_context_diagnostics_tolerate_malformed_bar_counts(indicators_ctx, required_bars, caplog) -> None:
+    runner = _build_runner()
+    runner._logger = logging.getLogger('test_direction_context_malformed_counts')
+    runner._strategy_manager = SimpleNamespace(get_last_no_signal_decision=lambda _symbol: None)
+    runner._context_required_bars = required_bars
+
+    with caplog.at_level(logging.INFO, logger='test_direction_context_malformed_counts'):
+        category, reason = runner._classify_no_trade_decision(
+            symbol='NFO:NIFTY2661623900PE',
+            signal=object(),
+            indicators_ctx=indicators_ctx,
+            option_count=30,
+            option_required=30,
+            trace_id='ctx-malformed',
+        )
+
+    assert category == 'context_direction_unavailable'
+    assert reason == 'direction_context_not_ready'
+    record = next(rec for rec in caplog.records if getattr(rec, 'event', '') == 'CONTEXT_DIRECTION_UNAVAILABLE')
+    assert isinstance(record.reason_detail, str)
+    assert record.reason_detail
+    assert isinstance(record.spot_bars, int)
+    assert isinstance(record.futures_bars, int)

--- a/tests/strategies/test_runner_signal_result.py
+++ b/tests/strategies/test_runner_signal_result.py
@@ -61,7 +61,7 @@ def test_prepare_order_state_from_idle_reaches_order_pending() -> None:
 
     assert ok is True
     assert reason == 'ok'
-    assert details['state'] == ExecutionState.ORDER_PENDING.value
+    assert details['after']['state'] == ExecutionState.ORDER_PENDING.value
 
 
 def test_prepare_order_state_from_ready_reaches_order_pending() -> None:
@@ -75,7 +75,7 @@ def test_prepare_order_state_from_ready_reaches_order_pending() -> None:
 
     assert ok is True
     assert reason == 'ok'
-    assert details['state'] == ExecutionState.ORDER_PENDING.value
+    assert details['after']['state'] == ExecutionState.ORDER_PENDING.value
 
 
 @pytest.mark.parametrize('busy_state', [ExecutionState.ORDER_PENDING, ExecutionState.POSITION_OPEN])
@@ -93,4 +93,4 @@ def test_prepare_order_state_rejects_busy_final_symbol(busy_state) -> None:
 
     assert ok is False
     assert reason == 'signal_state_rejected'
-    assert details['state'] == busy_state.value
+    assert details['after']['state'] == busy_state.value


### PR DESCRIPTION
### Motivation

- Live logs showed execution-state ownership and submission were sometimes anchored to the original signal symbol instead of the final selected candidate, causing rejected `IDLE → ORDER_PENDING` transitions and mis-attributed diagnostics when a candidate replacement occurred. 
- The runner also allowed live candidates without confirmed depth/valid bid-ask/spread, and some non-selected 5-bar cache syncs were logged as executable `tradable_option` roles, creating misleading diagnostics. 
- `_prepare_signal_for_handling()` had a potential `original_symbol` undefined use in a fallback path and `CONTEXT_DIRECTION_UNAVAILABLE` emitted only a generic message without precise missing-prerequisite diagnostics. 

### Description

- Fixed final-symbol execution lifecycle by adding `StrategyRunner._prepare_order_state_for_submission()` which advances the final trade symbol using the existing `_execution_state_by_symbol` store through `SIGNAL_RECEIVED` then `ORDER_PENDING`, and returns `before`/`after` state details without changing `OrderStateMachine` rules, and the helper is called after any candidate replacement. 
- Anchored candidate-replacement ownership to the final selected symbol by ensuring `TradePlan.symbol`, cooldown/dedup keys, and logs use the `final_trade_symbol` while logging both the `original_signal_symbol` and `final_trade_symbol`. 
- Added strict live-depth gating in the candidate acceptance path so live mode requires `tradable_quote=True`, `bid>0`, `ask>0`, `spread_pct` valid and `depth_available=True` unless `RUNNER_ALLOW_LIVE_DEPTH_FALLBACK=true` is set, and emitted `EXECUTION_CANDIDATE_REJECTED` with full context when rejected. 
- Renamed non-selected 5-bar cache sync role to `option_context_cache_sync` (kept `required_bars=5` only for cache syncs) so it no longer appears as `tradable_option` in diagnostics. 
- Fixed potential `NameError` by defining `original_symbol = signal.symbol` at the top of `._prepare_signal_for_handling()` and added a unit test exercising the `CANDIDATE_FALLBACK_FROM_SIGNAL_USED_AFTER_REFRESH_PENDING` path. 
- Added `._direction_context_missing_reason()` to produce detailed `CONTEXT_DIRECTION_UNAVAILABLE` diagnostics (returned `reason_detail`, freshness flags, bar counts, VWAP/slope/volume, and regime availability) without changing gating logic. 
- Tests and small test assertions updated to reflect `before`/`after` state detail structure returned by the new helper. 

Files changed: `src/nifty_scalper_bot/strategies/runner.py` and focused test updates in `tests/strategies/test_runner_live_path_guards.py` and `tests/strategies/test_runner_signal_result.py`.

### Testing

- Compilation checks: `python -m compileall -q src` and `python -m compileall -q tests` both passed. 
- Focused tests run and results: `pytest -q tests/test_execution_state_machine.py` (3 passed), `pytest -q tests/strategies/test_runner_signal_result.py` (5 passed), `pytest -q tests/strategies/test_runner_live_path_guards.py` (137 passed), `pytest -q tests/strategies/test_runner_selector_integration.py` (8 passed), and `pytest -q tests/strategies/test_runner_reason_codes.py` (4 passed). 
- Full strategy test collection and suite: `pytest -q tests/strategies` and `pytest -q` completed successfully with the repo test cache showing 2240 tests collected and no failures. 
- Additional checks: `git diff --check` passed and no merge-conflict markers were found by `git grep` checks. 

All automated tests invoked passed; no new test failures introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f9d10059c8324b9102904407968f1)