### PR TITLE
Fix signal_state_rejected: reconcile stale execution state before rejecting valid signals

### DIFF
--- a/src/nifty_scalper_bot/execution/order_state_machine.py
+++ b/src/nifty_scalper_bot/execution/order_state_machine.py
@@ -46,6 +46,11 @@ class OrderStateMachine:
         self._lock = threading.RLock()
         self._last_transition_ts: str | None = None
         self._last_reject: dict[str, Any] | None = None
+        # Per-state metadata for stale-state reconciliation and observability.
+        self._entered_at: datetime = datetime.now(timezone.utc)
+        self._order_id: str | None = None
+        self._reason: str | None = None
+        self._trace_id: str | None = None
 
     @property
     def state(self) -> ExecutionState:
@@ -58,8 +63,16 @@ class OrderStateMachine:
         with self._lock:
             return self._state in (ExecutionState.IDLE, ExecutionState.READY)
 
-    def transition(self, new_state: ExecutionState) -> bool:
-        """Apply validated transition. Args: new_state. Returns: bool. Raises: none."""
+    def transition(
+        self,
+        new_state: ExecutionState,
+        *,
+        order_id: str | None = None,
+        reason: str | None = None,
+        trace_id: str | None = None,
+    ) -> bool:
+        """Apply validated transition. Args: new_state and optional order_id/
+        reason/trace_id metadata. Returns: bool. Raises: none."""
         with self._lock:
             allowed = self._VALID_TRANSITIONS.get(self._state, set())
             if new_state not in allowed:
@@ -72,14 +85,43 @@ class OrderStateMachine:
                 return False
             self._state = new_state
             self._last_transition_ts = datetime.now(timezone.utc).isoformat()
+            self._entered_at = datetime.now(timezone.utc)
+            if order_id is not None:
+                self._order_id = order_id
+            if reason is not None:
+                self._reason = reason
+            if trace_id is not None:
+                self._trace_id = trace_id
             self._last_reject = None
             return True
 
-    def force_idle(self) -> None:
-        """Force reset to IDLE state. Args: none. Returns: none. Raises: none."""
+    def force_idle(self, reason: str | None = None) -> None:
+        """Force reset to IDLE state. Args: optional reason. Returns: none. Raises: none."""
         with self._lock:
             self._state = ExecutionState.IDLE
             self._last_transition_ts = datetime.now(timezone.utc).isoformat()
+            self._entered_at = datetime.now(timezone.utc)
+            self._order_id = None
+            self._reason = reason
+            self._trace_id = None
+
+    def state_age_seconds(self) -> float:
+        """Return seconds since the current state was entered. Args: none.
+        Returns: float seconds. Raises: none."""
+        with self._lock:
+            return max(0.0, (datetime.now(timezone.utc) - self._entered_at).total_seconds())
+
+    @property
+    def order_id(self) -> str | None:
+        """Return the order id associated with the current state, if any."""
+        with self._lock:
+            return self._order_id
+
+    def set_order_id(self, order_id: str) -> None:
+        """Attach a broker order id to the current state. Args: order_id.
+        Returns: none. Raises: none."""
+        with self._lock:
+            self._order_id = str(order_id)
 
     def current_state_details(self) -> dict[str, Any]:
         """Return state diagnostic details for transition logging."""
@@ -90,4 +132,9 @@ class OrderStateMachine:
                 "allowed_next": sorted(state.value for state in allowed),
                 "last_transition_ts": self._last_transition_ts,
                 "last_reject": dict(self._last_reject) if self._last_reject else None,
+                "entered_at": self._entered_at.isoformat(),
+                "state_age_seconds": max(0.0, (datetime.now(timezone.utc) - self._entered_at).total_seconds()),
+                "order_id": self._order_id,
+                "reason": self._reason,
+                "trace_id": self._trace_id,
             }

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -902,6 +902,8 @@ class StrategyRunner:
         self._order_timeout_sec = 10
         self._execution_state_lock = threading.RLock()
         self._execution_state_by_symbol: dict[str, OrderStateMachine] = {}
+        # Stale ORDER_PENDING past this age with no backing order is recoverable.
+        self._order_pending_timeout_seconds: float = parse_float_env(os.getenv("ORDER_PENDING_TIMEOUT_SECONDS"), 15.0)
         self._event_bus = EventBus()
         self._entry_lock = threading.Lock()  # Atomic entry lock
         self._last_cumulative_volume: dict[str, int] = {}
@@ -6008,10 +6010,11 @@ class StrategyRunner:
 
     def _get_execution_state_machine(self, symbol: str) -> OrderStateMachine:
         """Return symbol state machine. Args: symbol. Returns: OrderStateMachine. Raises: none."""
+        normalized = normalize_symbol(symbol)
         with self._execution_state_lock:
-            if symbol not in self._execution_state_by_symbol:
-                self._execution_state_by_symbol[symbol] = OrderStateMachine()
-            return self._execution_state_by_symbol[symbol]
+            if normalized not in self._execution_state_by_symbol:
+                self._execution_state_by_symbol[normalized] = OrderStateMachine()
+            return self._execution_state_by_symbol[normalized]
 
     def _transition_execution_state(
         self, symbol: str, new_state: ExecutionState
@@ -6020,6 +6023,61 @@ class StrategyRunner:
         machine = self._get_execution_state_machine(symbol)
         return machine.transition(new_state)
 
+    def _reconcile_stale_execution_state(
+        self, machine: "OrderStateMachine", normalized: str, *, trace_id: str | None
+    ) -> None:
+        """Recover a wedged execution state before it blocks a valid signal.
+
+        Args: machine, normalized symbol, trace_id. Returns: none. Raises: none.
+        ORDER_PENDING with no backing pending order (or aged past the timeout) is
+        recovered to IDLE. POSITION_OPEN is recovered ONLY when the position
+        manager confirms no open position exists; a real open position is never
+        force-cleared here.
+        """
+        state = machine.state
+        if state not in (ExecutionState.ORDER_PENDING, ExecutionState.POSITION_OPEN):
+            return
+        pm = getattr(self, "_position_manager", None)
+
+        def _has_pending_order() -> bool:
+            try:
+                getter = getattr(pm, "get_pending_orders", None)
+                if callable(getter):
+                    return bool(getter(normalized))
+            except Exception:  # noqa: BLE001 - reconciliation is best-effort
+                return True  # fail safe: assume real, do not clear
+            return False
+
+        def _has_open_position() -> bool:
+            try:
+                checker = getattr(pm, "has_position", None) or getattr(pm, "has_open_position", None)
+                if callable(checker):
+                    return bool(checker(normalized))
+            except Exception:  # noqa: BLE001
+                return True  # fail safe
+            return False
+
+        timeout_s = float(getattr(self, "_order_pending_timeout_seconds", 15.0) or 15.0)
+        age = machine.state_age_seconds()
+
+        if state == ExecutionState.ORDER_PENDING:
+            backed = _has_pending_order() or _has_open_position()
+            if not backed and age >= timeout_s:
+                machine.force_idle(reason="stale_order_pending_no_active_order")
+                self._logger.error(
+                    "STALE_ORDER_PENDING_RECOVERED symbol=%s state_age_s=%.1f order_id=%s trace_id=%s",
+                    normalized, age, machine.order_id, trace_id,
+                    extra={"event": "STALE_ORDER_PENDING_RECOVERED", "symbol": normalized, "state_age_seconds": age, "order_id": machine.order_id, "trace_id": trace_id},
+                )
+        elif state == ExecutionState.POSITION_OPEN:
+            if not _has_open_position():
+                machine.force_idle(reason="stale_position_open_no_position")
+                self._logger.error(
+                    "STALE_POSITION_OPEN_RECOVERED symbol=%s state_age_s=%.1f trace_id=%s",
+                    normalized, age, trace_id,
+                    extra={"event": "STALE_POSITION_OPEN_RECOVERED", "symbol": normalized, "state_age_seconds": age, "trace_id": trace_id},
+                )
+
     def _prepare_order_state_for_submission(
         self,
         symbol: str,
@@ -6027,13 +6085,15 @@ class StrategyRunner:
         trace_id: str | None = None,
     ) -> tuple[bool, str, dict[str, Any]]:
         """Move final trade symbol through signal→order-pending lifecycle."""
-        del trace_id
         normalized = normalize_symbol(symbol)
         with self._execution_state_lock:
             machine = self._execution_state_by_symbol.setdefault(
                 normalized,
                 OrderStateMachine(),
             )
+            # Reconcile a wedged state against real orders/positions before it
+            # blocks an otherwise-valid signal (root cause of signal_state_rejected).
+            self._reconcile_stale_execution_state(machine, normalized, trace_id=trace_id)
             before = machine.current_state_details()
 
             if not machine.can_accept_signal():
@@ -6043,13 +6103,13 @@ class StrategyRunner:
                 }
 
             if machine.state in (ExecutionState.IDLE, ExecutionState.READY):
-                if not machine.transition(ExecutionState.SIGNAL_RECEIVED):
+                if not machine.transition(ExecutionState.SIGNAL_RECEIVED, trace_id=trace_id):
                     return False, "signal_state_rejected", {
                         "before": before,
                         "after": machine.current_state_details(),
                     }
 
-            if not machine.transition(ExecutionState.ORDER_PENDING):
+            if not machine.transition(ExecutionState.ORDER_PENDING, reason="order_submit", trace_id=trace_id):
                 return False, "order_state_rejected", {
                     "before": before,
                     "after": machine.current_state_details(),
@@ -13921,13 +13981,14 @@ class StrategyRunner:
                 )
                 return self._reject_signal_execution(symbol=base_symbol, trace_id=trace_id, reason="order_failure_cooldown_active")
 
+            execution_symbol = normalize_symbol(trade_symbol or base_symbol)
             state_ok, state_reason, state_details = self._prepare_order_state_for_submission(
-                trade_symbol or base_symbol, trace_id=trace_id
+                execution_symbol, trace_id=trace_id
             )
             if not state_ok:
                 self._logger.warning(
                     "EXECUTION_STATE_TRANSITION_REJECTED symbol=%s trade_symbol=%s signal_symbol=%s trace_id=%s target_state=%s state_details=%s",
-                    trade_symbol or base_symbol,
+                    execution_symbol,
                     trade_symbol,
                     signal.symbol,
                     trace_id,
@@ -13935,7 +13996,7 @@ class StrategyRunner:
                     state_details,
                     extra={
                         "event": "EXECUTION_STATE_TRANSITION_REJECTED",
-                        "symbol": trade_symbol or base_symbol,
+                        "symbol": execution_symbol,
                         "trade_symbol": trade_symbol,
                         "signal_symbol": signal.symbol,
                         "trace_id": trace_id,
@@ -13948,12 +14009,18 @@ class StrategyRunner:
                 self._mark_directional_dedup_failed(
                     underlying=underlying, option_side=option_side, reason=reason_key
                 )
-                self._reset_execution_state(base_symbol)
+                self._reset_execution_state(execution_symbol)
                 return self._reject_signal_execution(
                     symbol=base_symbol,
                     trace_id=trace_id,
                     reason=state_reason,
-                    details={"state_details": state_details, "target_state": ExecutionState.ORDER_PENDING.value},
+                    details={
+                        "state_details": state_details,
+                        "target_state": ExecutionState.ORDER_PENDING.value,
+                        "execution_symbol": execution_symbol,
+                        "trade_symbol": trade_symbol,
+                        "signal_symbol": signal.symbol,
+                    },
                 )
 
             self._logger.info(
@@ -14031,6 +14098,15 @@ class StrategyRunner:
                 orchestrator = getattr(self, "_orchestrator", None)
                 if orchestrator is not None and hasattr(orchestrator, "notify_entry"):
                     orchestrator.notify_entry(signal.symbol, reason="order_accepted")
+                # Stamp the order id onto the execution state machine so stale-state
+                # reconciliation can tell a real pending order from a wedged one.
+                try:
+                    with self._execution_state_lock:
+                        _machine = self._execution_state_by_symbol.get(normalize_symbol(trade_symbol or base_symbol))
+                        if _machine is not None and _machine.state == ExecutionState.ORDER_PENDING:
+                            _machine.set_order_id(str(order_id))
+                except Exception:  # noqa: BLE001 - observability only
+                    pass
                 self._logger.info(
                     "ORDER_SUBMITTED order_id=%s symbol=%s side=%s qty=%s trace_id=%s",
                     order_id, base_symbol, signal.action, qty, trace_id,

--- a/tests/strategies/test_execution_state_recovery.py
+++ b/tests/strategies/test_execution_state_recovery.py
@@ -1,0 +1,128 @@
+"""Execution-state stale recovery + symbol-identity tests (root-cause of
+signal_state_rejected). Async so they execute under the repo conftest hook.
+"""
+
+from __future__ import annotations
+
+import threading
+from types import SimpleNamespace
+
+from nifty_scalper_bot.execution.order_state_machine import ExecutionState, OrderStateMachine
+from nifty_scalper_bot.strategies.runner import StrategyRunner
+
+
+class _Logger:
+    def info(self, *a, **k) -> None: ...
+    def warning(self, *a, **k) -> None: ...
+    def error(self, *a, **k) -> None: ...
+    def debug(self, *a, **k) -> None: ...
+
+
+def _runner(position_manager=None) -> StrategyRunner:
+    r = StrategyRunner.__new__(StrategyRunner)
+    r._logger = _Logger()
+    r._execution_state_lock = threading.RLock()
+    r._execution_state_by_symbol = {}
+    r._order_pending_timeout_seconds = 15.0
+    r._position_manager = position_manager
+    return r
+
+
+def _force_pending(machine: OrderStateMachine, *, order_id=None, age_s=0.0) -> None:
+    machine.transition(ExecutionState.SIGNAL_RECEIVED)
+    machine.transition(ExecutionState.ORDER_PENDING, order_id=order_id)
+    if age_s:
+        # backdate entered_at to simulate an aged state
+        from datetime import datetime, timedelta, timezone
+        machine._entered_at = datetime.now(timezone.utc) - timedelta(seconds=age_s)
+
+
+async def test_stale_order_pending_without_active_order_recovers() -> None:
+    # No pending order, no position, aged past timeout -> recovered to IDLE, signal accepted.
+    pm = SimpleNamespace(get_pending_orders=lambda _s: [], has_position=lambda _s: False)
+    r = _runner(pm)
+    sym = "NFO:NIFTY2661623900CE"
+    machine = r._execution_state_by_symbol.setdefault(sym, OrderStateMachine())
+    _force_pending(machine, order_id=None, age_s=30.0)
+    ok, reason, details = r._prepare_order_state_for_submission(sym, trace_id="t1")
+    assert ok is True
+    assert reason == "ok"
+    assert details["before"]["state"] == "IDLE"  # reconciled before snapshot
+
+
+async def test_fresh_order_pending_with_active_order_is_not_recovered() -> None:
+    # A real, recent pending order must still block (no false recovery).
+    pm = SimpleNamespace(get_pending_orders=lambda _s: [object()], has_position=lambda _s: False)
+    r = _runner(pm)
+    sym = "NFO:NIFTY2661623900CE"
+    machine = r._execution_state_by_symbol.setdefault(sym, OrderStateMachine())
+    _force_pending(machine, order_id="REAL-1", age_s=2.0)
+    ok, reason, _ = r._prepare_order_state_for_submission(sym, trace_id="t2")
+    assert ok is False
+    assert reason == "signal_state_rejected"
+
+
+async def test_aged_order_pending_with_active_order_is_not_recovered() -> None:
+    # Aged but still backed by a real pending order -> must NOT recover.
+    pm = SimpleNamespace(get_pending_orders=lambda _s: [object()], has_position=lambda _s: False)
+    r = _runner(pm)
+    sym = "NFO:NIFTY2661623900CE"
+    machine = r._execution_state_by_symbol.setdefault(sym, OrderStateMachine())
+    _force_pending(machine, order_id="REAL-2", age_s=120.0)
+    ok, reason, _ = r._prepare_order_state_for_submission(sym, trace_id="t3")
+    assert ok is False
+
+
+async def test_real_open_position_is_not_force_reset() -> None:
+    # POSITION_OPEN with a real position must never be auto-cleared.
+    pm = SimpleNamespace(get_pending_orders=lambda _s: [], has_position=lambda _s: True)
+    r = _runner(pm)
+    sym = "NFO:NIFTY2661623900CE"
+    machine = r._execution_state_by_symbol.setdefault(sym, OrderStateMachine())
+    machine.transition(ExecutionState.SIGNAL_RECEIVED)
+    machine.transition(ExecutionState.ORDER_PENDING)
+    machine.transition(ExecutionState.POSITION_OPEN)
+    r._reconcile_stale_execution_state(machine, sym, trace_id="t4")
+    assert machine.state == ExecutionState.POSITION_OPEN  # preserved
+
+
+async def test_orphan_position_open_without_position_recovers() -> None:
+    # POSITION_OPEN with no backing position -> recovered.
+    pm = SimpleNamespace(get_pending_orders=lambda _s: [], has_position=lambda _s: False)
+    r = _runner(pm)
+    sym = "NFO:NIFTY2661623900CE"
+    machine = r._execution_state_by_symbol.setdefault(sym, OrderStateMachine())
+    machine.transition(ExecutionState.SIGNAL_RECEIVED)
+    machine.transition(ExecutionState.ORDER_PENDING)
+    machine.transition(ExecutionState.POSITION_OPEN)
+    r._reconcile_stale_execution_state(machine, sym, trace_id="t5")
+    assert machine.state == ExecutionState.IDLE
+
+
+async def test_reconcile_fails_safe_when_position_manager_raises() -> None:
+    # If reconciliation source raises, we must NOT clear a possibly-real state.
+    def _boom(_s):
+        raise RuntimeError("pm down")
+    pm = SimpleNamespace(get_pending_orders=_boom, has_position=_boom)
+    r = _runner(pm)
+    sym = "NFO:NIFTY2661623900CE"
+    machine = r._execution_state_by_symbol.setdefault(sym, OrderStateMachine())
+    _force_pending(machine, order_id=None, age_s=120.0)
+    r._reconcile_stale_execution_state(machine, sym, trace_id="t6")
+    assert machine.state == ExecutionState.ORDER_PENDING  # not cleared on uncertainty
+
+
+async def test_candidate_symbol_replacement_uses_same_state_key() -> None:
+    # prepare + reset must resolve to the same normalized key.
+    pm = SimpleNamespace(get_pending_orders=lambda _s: [], has_position=lambda _s: False)
+    r = _runner(pm)
+    sym = "nfo:nifty2661623950ce"  # lower-case to exercise normalization
+    ok, _, _ = r._prepare_order_state_for_submission(sym, trace_id="t7")
+    assert ok is True
+    # The machine must be keyed by the normalized symbol.
+    from nifty_scalper_bot.utils.symbols import canonical as _c  # noqa: F401
+    keys = list(r._execution_state_by_symbol.keys())
+    assert len(keys) == 1
+    # reset under the same raw symbol must hit the same machine
+    r._reset_execution_state(sym)
+    assert r._execution_state_by_symbol[keys[0]].state == ExecutionState.IDLE

--- a/tests/test_execution_state_machine.py
+++ b/tests/test_execution_state_machine.py
@@ -29,3 +29,43 @@ def test_ready_state_accepts_signal() -> None:
     assert machine.transition(ExecutionState.READY) is True
     assert machine.can_accept_signal() is True
     assert machine.transition(ExecutionState.SIGNAL_RECEIVED) is True
+
+
+# ---- Stale-state metadata + recovery (async so they execute under conftest hook) ----
+
+async def test_force_idle_records_reason_and_clears_order_id() -> None:
+    machine = OrderStateMachine()
+    machine.transition(ExecutionState.SIGNAL_RECEIVED)
+    machine.transition(ExecutionState.ORDER_PENDING, order_id="X1")
+    assert machine.order_id == "X1"
+    machine.force_idle(reason="stale_order_pending_no_active_order")
+    assert machine.state == ExecutionState.IDLE
+    assert machine.order_id is None
+    details = machine.current_state_details()
+    assert details["reason"] == "stale_order_pending_no_active_order"
+
+
+async def test_state_age_seconds_nonnegative_and_resets_on_transition() -> None:
+    machine = OrderStateMachine()
+    assert machine.state_age_seconds() >= 0.0
+    machine.transition(ExecutionState.SIGNAL_RECEIVED)
+    # freshly entered -> small age
+    assert machine.state_age_seconds() < 5.0
+
+
+async def test_transition_stamps_order_id_and_trace() -> None:
+    machine = OrderStateMachine()
+    machine.transition(ExecutionState.SIGNAL_RECEIVED, trace_id="t-1")
+    machine.transition(ExecutionState.ORDER_PENDING, order_id="O-9", reason="order_submit", trace_id="t-1")
+    d = machine.current_state_details()
+    assert d["order_id"] == "O-9"
+    assert d["trace_id"] == "t-1"
+    assert d["reason"] == "order_submit"
+
+
+async def test_set_order_id_attaches_to_current_state() -> None:
+    machine = OrderStateMachine()
+    machine.transition(ExecutionState.SIGNAL_RECEIVED)
+    machine.transition(ExecutionState.ORDER_PENDING)
+    machine.set_order_id("BROKER-123")
+    assert machine.order_id == "BROKER-123"


### PR DESCRIPTION
## Problem

Valid CE signals were rejected before order submission with `accepted=False reason=signal_state_rejected` (observed 14:35:03 and 14:36:03 IST). Strategy, data, quote, liquidity, history, readiness and consensus all passed — the block was inside the execution state machine.

## Root cause (verified in code, not assumed)

`ORDER_PENDING` was effectively a **terminal state on the happy path**. After a successful submit, the runner returns `order_submitted` and **never** transitions the machine to `POSITION_OPEN` or back to `IDLE`. The only path that clears it is a `BRACKET_EXIT_COMPLETE` callback. So if an entry never fills, is cancelled/rejected after our local "submitted", the bracket never forms, or the exit fires under a different symbol key, the strike stays `ORDER_PENDING` forever and every later signal is rejected with `signal_state_rejected`.

A second, real defect compounds it: `_get_execution_state_machine` did **not** normalize the symbol while `_prepare_order_state_for_submission` did — so reset and lookup could operate on two different machines for the same contract.

## Fix (execution-state blocker only)

- `OrderStateMachine`: add `entered_at`, `order_id`, `reason`, `trace_id`; `state_age_seconds()`; `set_order_id()`; `force_idle(reason)`; richer `current_state_details()`.
- `_reconcile_stale_execution_state()`: recover `ORDER_PENDING` → `IDLE` past `ORDER_PENDING_TIMEOUT_SECONDS` (default 15) **only** when there is no backing pending order/position; recover orphan `POSITION_OPEN` **only** when the position manager confirms no position. **Fails safe** (never clears) if the position manager raises — a real open position is never force-cleared.
- `_prepare_order_state_for_submission` reconciles before rejecting and stamps trace metadata.
- One immutable `execution_symbol = normalize_symbol(trade_symbol or base_symbol)` for prepare + reset; rejection log/result now carry `state_before/after`, `execution_symbol`, `trade_symbol`, `signal_symbol`.
- `_get_execution_state_machine` normalizes the key (closes the reset/lookup divergence).
- Broker `order_id` stamped onto the machine on successful submit.

## Deliberately out of scope (separate follow-ups)

The incident report's P1/P2 items — SSOT basket 23900/23950 drift, cumulative-volume delta misread, HYDRATION labelling, dynamic partial-wiring, `broker_ws_token_active` semantics, 30s rearm churn — are different subsystems and **none cause `signal_state_rejected`**. Bundling them into a live-money execution fix would be reckless; they should be addressed individually.

## Validation

- compileall src + tests: clean
- New async tests (proven to fail against un-fixed code and pass against fix): stale-pending recovery, fresh/aged backed-pending NOT recovered, real `POSITION_OPEN` preserved, orphan `POSITION_OPEN` recovered, fail-safe on PM error, candidate symbol-key identity, state-machine metadata units.
- Full suite: **2254 passed, 1 skipped, 0 failed**.