### PR TITLE
Fix LIVE_BASKET_BUILD_FAILED: guard empty/unresolvable futures token in canonical basket build

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -3539,7 +3539,23 @@ def _build_canonical_active_basket(
     pe_symbols = sorted([s for s in option_symbols if s.endswith("PE")])
     if not ce_symbols or not pe_symbols:
         raise RuntimeError("failed to resolve canonical option basket")
-    futures_token = instrument_manager.get_token(futures_symbol)
+    # Futures is optional context. When the active future is unresolved
+    # (futures_symbol empty), skip token resolution rather than calling
+    # get_token('') which raises and aborts the whole basket build.
+    futures_symbol = str(futures_symbol or "").strip()
+    futures_token = None
+    if futures_symbol:
+        try:
+            futures_token = instrument_manager.get_token(futures_symbol)
+        except Exception as exc:  # noqa: BLE001 - futures is optional context
+            LOGGER.warning(
+                "FUTURES_TOKEN_UNRESOLVED symbol=%s err=%s reason=basket_build_futures_optional",
+                futures_symbol,
+                exc,
+                extra={"event": "FUTURES_TOKEN_UNRESOLVED", "symbol": futures_symbol, "reason": "basket_build_futures_optional"},
+            )
+            futures_symbol = ""
+            futures_token = None
     spot_token: int | None = None
     if callable(spot_token_resolver):
         try:
@@ -3590,10 +3606,11 @@ def _build_canonical_active_basket(
         except Exception:  # noqa: BLE001
             pass
 
-    all_symbols = [spot_symbol, futures_symbol, *ce_symbols, *pe_symbols]
+    _context_symbols = [spot_symbol] + ([futures_symbol] if futures_symbol else [])
+    all_symbols = [*_context_symbols, *ce_symbols, *pe_symbols]
     all_tokens = [token_by_symbol[s] for s in all_symbols if s in token_by_symbol]
 
-    symbols = [spot_symbol, futures_symbol, *ce_symbols, *pe_symbols]
+    symbols = [*_context_symbols, *ce_symbols, *pe_symbols]
     return {
         "spot_symbol": spot_symbol,
         "spot_token": int(spot_token),

--- a/tests/test_app_canonical_basket.py
+++ b/tests/test_app_canonical_basket.py
@@ -59,3 +59,76 @@ def test_build_canonical_active_basket_includes_spot_futures_and_options() -> No
     assert basket["futures_token"] == 123456
     assert len(basket["ce_symbols"]) == 7
     assert len(basket["pe_symbols"]) == 7
+
+
+class _FakeIMWithOptions:
+    """InstrumentManager whose get_token RAISES for unknown/empty symbols,
+    mirroring the live FATAL 'token not found' behavior."""
+
+    def is_loaded(self) -> bool:
+        return True
+
+    def select_tokens_for_universe(self, *, base, spot_price, strikes_around_atm, strike_step):
+        return list(range(10, 24))
+
+    def get_symbol(self, token: int) -> str:
+        symbols = {
+            10: "NFO:NIFTY26APR25000CE", 11: "NFO:NIFTY26APR25050CE",
+            12: "NFO:NIFTY26APR25100CE", 13: "NFO:NIFTY26APR25150CE",
+            14: "NFO:NIFTY26APR25200CE", 15: "NFO:NIFTY26APR25250CE",
+            16: "NFO:NIFTY26APR25300CE", 17: "NFO:NIFTY26APR25000PE",
+            18: "NFO:NIFTY26APR25050PE", 19: "NFO:NIFTY26APR25100PE",
+            20: "NFO:NIFTY26APR25150PE", 21: "NFO:NIFTY26APR25200PE",
+            22: "NFO:NIFTY26APR25250PE", 23: "NFO:NIFTY26APR25300PE",
+        }
+        return symbols[token]
+
+    def get_token(self, symbol: str) -> int:
+        key = str(symbol).strip()
+        if not key:
+            raise RuntimeError(f"[FATAL] InstrumentManager: token not found for '{symbol}'.")
+        # deterministic fake token for any non-empty symbol
+        return abs(hash(key)) % 1_000_000
+
+
+async def test_empty_futures_symbol_does_not_abort_basket_build() -> None:
+    # Regression: an unresolved (empty) active future previously caused
+    # get_token('') to raise and abort the whole live basket build.
+    basket = _build_canonical_active_basket(
+        instrument_manager=_FakeIMWithOptions(),
+        spot_token_resolver=lambda _s: 256265,
+        spot_ltp=25125,
+        futures_symbol="",  # unresolved future
+        strike_step=50,
+        strikes_around_atm=3,
+    )
+    assert basket["spot_symbol"] == "NSE:NIFTY"
+    assert basket["futures_symbol"] == ""
+    assert basket["futures_token"] is None
+    assert len(basket["ce_symbols"]) == 7
+    assert len(basket["pe_symbols"]) == 7
+    # empty futures must NOT leak into the symbol lists
+    assert "" not in basket["symbols"]
+    assert "" not in basket["all_symbols"]
+
+
+async def test_unresolvable_futures_symbol_is_demoted_not_fatal() -> None:
+    # A futures symbol that the instrument manager cannot resolve must be
+    # demoted to "no futures context", not abort the build.
+    class _IM(_FakeIMWithOptions):
+        def get_token(self, symbol: str) -> int:
+            if "FUT" in str(symbol):
+                raise RuntimeError("token not found")
+            return super().get_token(symbol)
+
+    basket = _build_canonical_active_basket(
+        instrument_manager=_IM(),
+        spot_token_resolver=lambda _s: 256265,
+        spot_ltp=25125,
+        futures_symbol="NFO:NIFTY26JUNFUT",
+        strike_step=50,
+        strikes_around_atm=3,
+    )
+    assert basket["futures_symbol"] == ""
+    assert basket["futures_token"] is None
+    assert "" not in basket["all_symbols"]


### PR DESCRIPTION
## Problem (from live logs 2026-06-15 15:05 IST)

Trading was blocked by a repeating `LIVE_BASKET_BUILD_FAILED reason=[FATAL] InstrumentManager: token not found for ''`, retrying and failing every ~15s (`DEFERRED_BASKET_HYDRATION_FAILED attempt N/160`). The empty symbol `''` is an unresolved active future.

## Root cause

During startup the active future can be momentarily unresolved — `_resolve_active_futures_for_basket` returns `''`, a race the bot already logs as `FUTURES_CONTEXT_UNAVAILABLE` and tolerates elsewhere. But `_build_canonical_active_basket` then called `instrument_manager.get_token('')` with **no guard**, which raises `[FATAL] token not found for ''` and aborts the **entire** basket build. With no options basket committed, no trading can occur.

This is **not** from PR #571 (execution-state fix): the incident logs contain no tracebacks, and the one `signal_state_rejected` there flows through the reconciled path, which can only recover stale state, never create a rejection.

## Fix

Futures is optional context (every other path treats it that way, including the parallel resolver at `app.py:9915` which already guarded this). In `_build_canonical_active_basket`:
- skip token resolution when `futures_symbol` is empty;
- if a non-empty futures symbol fails to resolve, demote to no-futures (`FUTURES_TOKEN_UNRESOLVED`) instead of aborting;
- exclude an empty futures symbol from the basket symbol lists so `''` never leaks into subscriptions.

Spot + options (the tradable instruments) now build and commit successfully; futures context attaches once resolvable.

## Validation

- compileall src + tests: clean
- New async regression tests (proven to fail against un-fixed code, pass with fix): empty futures builds without aborting and does not leak `''`; unresolvable futures symbol is demoted not fatal.
- Targeted basket suites: 30 passed.
- Full suite: **2256 passed, 1 skipped, 0 failed**.

## Out of scope (separate follow-ups, unchanged)

The incident report's other P1/P2 items (SSOT 23900/23950 strike drift, cumulative-volume deltas, hydration labelling, dynamic partial-wiring, broker_ws_token semantics, 30s rearm churn). None cause the basket-build abort fixed here.