### PR TITLE
Fix FUTURES_CONTEXT_UNAVAILABLE: resolve active future from instrument dump when basket pending

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -1415,6 +1415,35 @@ def _resolve_active_futures_for_basket(ctx: BotContext, requested: object | None
     if canonical:
         return canonical
 
+    # Final fallback: resolve directly from the InstrumentManager dump — the same
+    # authoritative source the SSOT uses (CONTRACT_SSOT_FUTURE_SELECTED). At
+    # startup the committed basket may not yet carry futures_symbol, so the
+    # MDM/basket/runner lookups above legitimately return empty; the dump is
+    # available and lets futures context resolve instead of being unavailable.
+    instrument_manager = getattr(ctx, "instrument_manager", None)
+    get_futures = getattr(instrument_manager, "get_future_contracts", None)
+    if callable(get_futures):
+        try:
+            if instrument_manager is not None and not instrument_manager.is_loaded():
+                instrument_manager.load()
+            contracts = get_futures("NIFTY") or []
+            # get_future_contracts returns nearest-expiry first.
+            for contract in contracts:
+                canonical = canonical_nifty_future_symbol(contract.get("tradingsymbol"))
+                if canonical:
+                    LOGGER.info(
+                        "FUTURES_CONTEXT_RESOLVED_FROM_INSTRUMENTS symbol=%s reason=basket_pending_dump_fallback",
+                        canonical,
+                        extra={"event": "FUTURES_CONTEXT_RESOLVED_FROM_INSTRUMENTS", "symbol": canonical, "reason": "basket_pending_dump_fallback"},
+                    )
+                    return canonical
+        except Exception as exc:  # noqa: BLE001 - fallback is best-effort
+            LOGGER.debug(
+                "FUTURES_CONTEXT_INSTRUMENT_FALLBACK_FAILED err=%s",
+                exc,
+                extra={"event": "FUTURES_CONTEXT_INSTRUMENT_FALLBACK_FAILED", "error": str(exc)},
+            )
+
     LOGGER.warning(
         "FUTURES_CONTEXT_UNAVAILABLE requested=%s reason=active_future_unresolved",
         requested,

--- a/tests/core/test_futures_resolver_fallback.py
+++ b/tests/core/test_futures_resolver_fallback.py
@@ -1,0 +1,84 @@
+"""Futures-context resolution must fall back to the InstrumentManager dump when
+the committed basket has no futures_symbol yet (startup race). Async so it runs
+under the repo conftest hook.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from nifty_scalper_bot.core.app import _resolve_active_futures_for_basket
+
+
+class _IM:
+    def __init__(self, loaded=True, contracts=None):
+        self._loaded = loaded
+        self._contracts = contracts if contracts is not None else [
+            {"tradingsymbol": "NIFTY26JUNFUT", "expiry": "2026-06-30", "instrument_token": 15956226},
+            {"tradingsymbol": "NIFTY26JULFUT", "expiry": "2026-07-28", "instrument_token": 15956300},
+        ]
+
+    def is_loaded(self):
+        return self._loaded
+
+    def load(self):
+        self._loaded = True
+
+    def get_future_contracts(self, underlying):
+        assert underlying == "NIFTY"
+        return list(self._contracts)
+
+
+def _ctx(*, mdm_future=None, instrument_manager=None):
+    mdm = SimpleNamespace(
+        get_active_nifty_future_symbol_cached=lambda: mdm_future,
+        resolve_active_nifty_future_symbol=lambda: mdm_future,
+    )
+    return SimpleNamespace(
+        market_data_manager=mdm,
+        active_trading_universe={},
+        strategy_runner=None,
+        strategy_manager=None,
+        instrument_manager=instrument_manager,
+    )
+
+
+async def test_resolves_from_instrument_dump_when_basket_empty() -> None:
+    # MDM/basket return nothing (startup), but the dump has futures -> resolve nearest.
+    ctx = _ctx(mdm_future=None, instrument_manager=_IM())
+    result = _resolve_active_futures_for_basket(ctx, None)
+    assert result == "NFO:NIFTY26JUNFUT"
+
+
+async def test_prefers_committed_basket_over_dump() -> None:
+    # When MDM already has the future, that wins (no dump fallback needed).
+    ctx = _ctx(mdm_future="NFO:NIFTY26JUNFUT", instrument_manager=_IM(contracts=[]))
+    result = _resolve_active_futures_for_basket(ctx, None)
+    assert result == "NFO:NIFTY26JUNFUT"
+
+
+async def test_loads_instrument_manager_if_not_loaded() -> None:
+    im = _IM(loaded=False)
+    ctx = _ctx(mdm_future=None, instrument_manager=im)
+    result = _resolve_active_futures_for_basket(ctx, None)
+    assert result == "NFO:NIFTY26JUNFUT"
+    assert im.is_loaded() is True
+
+
+async def test_returns_empty_when_no_future_anywhere() -> None:
+    # No MDM future and an empty dump -> graceful empty (no crash).
+    ctx = _ctx(mdm_future=None, instrument_manager=_IM(contracts=[]))
+    result = _resolve_active_futures_for_basket(ctx, None)
+    assert result == ""
+
+
+async def test_dump_fallback_failure_is_contained() -> None:
+    class _Boom:
+        def is_loaded(self):
+            return True
+        def get_future_contracts(self, _u):
+            raise RuntimeError("dump unavailable")
+    ctx = _ctx(mdm_future=None, instrument_manager=_Boom())
+    # must not raise
+    result = _resolve_active_futures_for_basket(ctx, None)
+    assert result == ""


### PR DESCRIPTION
## Problem (live logs 2026-06-15 15:23-15:24 IST)

After PR #572 stopped the basket-build crash, the logs show two remaining issues:
1. A flood of `FUTURES_CONTEXT_UNAVAILABLE reason=active_future_unresolved` / `FUTURES_CONTEXT_UNAVAILABLE_BASKET_MISSING` (dozens per cycle) — the bot runs with no futures context.
2. `CONTEXT_HISTORY_HYDRATION_FAILED symbol=NFO:NIFTY26JUNFUT error=insufficient_cached_bars` — the future's history never hydrates in time.

## Root cause

Two futures subsystems disagree at startup. The SSOT resolves `NIFTY26JUNFUT` directly from the instrument dump (`CONTRACT_SSOT_FUTURE_SELECTED` — visible in the same logs), but `_resolve_active_futures_for_basket` only consulted MDM / committed basket / runner / strategy_manager. `MDM.get_active_nifty_future_symbol_cached` deliberately reads **only the committed basket** ("InstrumentManager owns selection"), so before the basket is committed it returns `None` and logs `FUTURES_CONTEXT_UNAVAILABLE_BASKET_MISSING`. The future therefore stays "unresolved" even though the dump clearly contains it, and its history hydration is never requested in time (failing after the cold-grace passes).

## Fix

Add a final fallback in `_resolve_active_futures_for_basket`: when MDM/basket/runner/strategy_manager all return empty, resolve the nearest-expiry NIFTY future directly from `ctx.instrument_manager.get_future_contracts("NIFTY")` — the same dump the SSOT uses. Loads the dump if needed; best-effort and fully contained (never raises). Emits `FUTURES_CONTEXT_RESOLVED_FROM_INSTRUMENTS`.

Both subsystems now agree, so futures context is available from startup and its history hydration is requested in time — clearing both the warning flood and the downstream context-history failure.

The `DEFERRED_BASKET_RETRY ... data_not_ready` entries (attempts 4-5/160) are transient and self-correcting — the basket completes `LIVE_BASKET_BUILD_COMPLETE` on the same pass — so no change there.

## Validation

- compileall src + tests: clean
- New async tests (proven to fail against un-fixed code): resolves from dump when basket empty; prefers committed basket; loads IM if needed; empty when no future anywhere; dump-failure contained.
- Targeted basket/futures suites: 43 passed.
- Full suite: **2261 passed, 1 skipped, 0 failed**.

## Out of scope (separate follow-ups)

Incident-report P1/P2: SSOT 23900/23950 strike drift, cumulative-volume deltas, hydration labelling, dynamic partial-wiring, broker_ws_token semantics, 30s rearm churn.