### PR TITLE
Fix bot never arms: DataHub bar count must not gate hydration readiness (SSOT)

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -7793,13 +7793,19 @@ def build_symbol_hydration_status(
             live_tick_fresh = False
     exchange = normalized.split(":", 1)[0] if ":" in normalized else None
     tradingsymbol = normalized.split(":", 1)[1] if ":" in normalized else normalized or None
+    # SSOT: MarketDataManager is the sole history owner (PR #562). DataHub is a
+    # facade that stores no history of its own, so its bar count must NOT gate
+    # readiness — it lags MDM and would wedge arming with a false
+    # selected_option_history_cold even when the canonical readiness is ready.
+    # datahub_bars is retained below for observability only.
+    gating_counts = [mdm_bars, runner_bars, indicator_bars]
     counts = [mdm_bars, datahub_bars, runner_bars, indicator_bars]
     blockers: list[str] = []
     if not normalized:
         blockers.append(f"{role}_symbol_missing")
     if token is None and role in {"selected_ce", "selected_pe", "option_context", "futures_context"}:
         blockers.append("option_token_missing" if role.startswith("selected_") or role == "option_context" else "futures_token_missing")
-    if required > 0 and any(count < required for count in counts):
+    if required > 0 and any(count < required for count in gating_counts):
         blockers.append(f"{role}_history_missing")
         blockers.append("insufficient_bars")
         if mdm_bars < required:
@@ -7819,7 +7825,7 @@ def build_symbol_hydration_status(
         max_spread = float(os.getenv("HYDRATION_MAX_SPREAD_PCT", os.getenv("MAX_OPTION_SPREAD_PCT", "12")) or 12)
         if spread_pct is not None and spread_pct > max_spread:
             blockers.append("spread_too_wide")
-    ready_for_evaluation = bool(normalized and required >= 0 and all(count >= required for count in counts))
+    ready_for_evaluation = bool(normalized and required >= 0 and all(count >= required for count in gating_counts))
     ready_for_execution = bool(ready_for_evaluation and (not selected_role or (tradable_quote and depth_available and "spread_too_wide" not in blockers)))
     status = HydrationStatus(
         symbol=normalized,
@@ -8566,8 +8572,9 @@ async def _recompute_and_push_runtime_readiness(ctx: BotContext, *, reason: str)
     pe_datahub_bars = pe_status.datahub_bars if pe_status else 0
     pe_runner_bars = pe_status.runner_bars if pe_status else 0
     pe_indicator_bars = pe_status.indicator_bars if pe_status else 0
-    ce_bars = min(ce_mdm_bars, ce_datahub_bars, ce_runner_bars, ce_indicator_bars) if ce_status else 0
-    pe_bars = min(pe_mdm_bars, pe_datahub_bars, pe_runner_bars, pe_indicator_bars) if pe_status else 0
+    # datahub_bars excluded from gating min(): DataHub owns no history (PR #562).
+    ce_bars = min(ce_mdm_bars, ce_runner_bars, ce_indicator_bars) if ce_status else 0
+    pe_bars = min(pe_mdm_bars, pe_runner_bars, pe_indicator_bars) if pe_status else 0
     ce_quote_fresh = bool(ce_status and (ce_status.live_tick_fresh or ce_status.tradable_quote))
     pe_quote_fresh = bool(pe_status and (pe_status.live_tick_fresh or pe_status.tradable_quote))
     ce_bid_ask_complete = bool(ce_status and ce_status.tradable_quote)
@@ -11815,8 +11822,8 @@ async def startup_sequence(ctx: BotContext) -> None:
                             futures_hydration = _status_for_role(hydration_statuses, "futures_context")
                             ce_hydration = _status_for_role(hydration_statuses, "selected_ce")
                             pe_hydration = _status_for_role(hydration_statuses, "selected_pe")
-                            hydrated_ce = min(ce_hydration.mdm_bars, ce_hydration.datahub_bars, ce_hydration.runner_bars, ce_hydration.indicator_bars) if ce_hydration else 0
-                            hydrated_pe = min(pe_hydration.mdm_bars, pe_hydration.datahub_bars, pe_hydration.runner_bars, pe_hydration.indicator_bars) if pe_hydration else 0
+                            hydrated_ce = min(ce_hydration.mdm_bars, ce_hydration.runner_bars, ce_hydration.indicator_bars) if ce_hydration else 0
+                            hydrated_pe = min(pe_hydration.mdm_bars, pe_hydration.runner_bars, pe_hydration.indicator_bars) if pe_hydration else 0
                             ce_qr_runtime = _quote_readiness_for_symbol(ctx, selected_ce)
                             pe_qr_runtime = _quote_readiness_for_symbol(ctx, selected_pe)
                             quote_ce = selected_ce if ce_qr_runtime.tradable_quote_ready else None

--- a/tests/core/test_hydration_datahub_not_gating.py
+++ b/tests/core/test_hydration_datahub_not_gating.py
@@ -1,0 +1,70 @@
+"""DataHub owns no history (PR #562 SSOT), so its bar count must NOT gate
+readiness. Regression for the live blocker where SELECTED_OPTION_HISTORY_READINESS
+reported both_ready=True while READINESS_BLOCKER_SUMMARY still showed
+selected_option_history_cold because _hydration_status_map gated on a lagging
+datahub_bars. Async so it executes under the repo conftest hook.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from nifty_scalper_bot.core.app import build_symbol_hydration_status
+
+
+def _bars(n: int):
+    # minimal OHLC rows; only the count matters for gating
+    return [{"timestamp": i, "open": 1, "high": 1, "low": 1, "close": 1, "volume": 1} for i in range(n)]
+
+
+class _Provider:
+    def __init__(self, n):
+        self._n = n
+    def get_ohlc_bars(self, symbol, limit=None):
+        return _bars(self._n)
+
+
+class _Indicator:
+    def __init__(self, n):
+        self._n = n
+    def get_history(self, symbol):
+        return _bars(self._n)
+
+
+def _ctx(*, mdm_n, datahub_n, runner_n, indicator_n, sym):
+    mdm = _Provider(mdm_n)
+    datahub = _Provider(datahub_n)
+    runner = SimpleNamespace(
+        _symbol_history={sym: _bars(runner_n)},
+        _indicator_engine=_Indicator(indicator_n),
+    )
+    return SimpleNamespace(
+        market_data_manager=mdm,
+        data_hub=datahub,
+        strategy_runner=runner,
+        active_symbol_tokens={sym: 111},
+    )
+
+
+SYM = "NFO:NIFTY2661623850CE"
+
+
+async def test_lagging_datahub_does_not_block_execution() -> None:
+    # Exact live scenario: mdm/runner/indicator >= required(30), datahub lags (5).
+    ctx = _ctx(mdm_n=51, datahub_n=5, runner_n=46, indicator_n=46, sym=SYM)
+    status = build_symbol_hydration_status(ctx, SYM, "selected_ce", 30)
+    # datahub still reported for observability...
+    assert status.datahub_bars == 5
+    # ...but it must NOT gate: history is ready because mdm/runner/indicator >= 30
+    assert status.ready_for_evaluation is True
+    assert "insufficient_bars" not in status.blocker_reasons
+    assert "selected_ce_history_missing" not in status.blocker_reasons
+
+
+async def test_genuine_history_shortfall_still_blocks() -> None:
+    # If a REAL source (runner) is below required, it must still block.
+    ctx = _ctx(mdm_n=51, datahub_n=51, runner_n=10, indicator_n=46, sym=SYM)
+    status = build_symbol_hydration_status(ctx, SYM, "selected_ce", 30)
+    assert status.ready_for_evaluation is False
+    assert "insufficient_bars" in status.blocker_reasons
+    assert "runner_bars_missing" in status.blocker_reasons


### PR DESCRIPTION
## Problem (live logs 2026-06-15 15:29-15:30 IST)

The bot never arms: `RUNNER_STARTUP_READINESS_UPDATE startup_ready=False reason=execution_not_armed:selected_option_history_cold`, the deferred basket retry loops 21..24/160 (`data_not_ready`), and `Strategy evaluation stalled >120s`.

The smoking gun is two readiness computations disagreeing in the **same instant**:
- `SELECTED_OPTION_HISTORY_READINESS both_ready=True blocker=None` (canonical — correct)
- `READINESS_BLOCKER_SUMMARY primary_blocker=selected_option_history_cold` (live/arming path — wrong)

## Root cause

PR #562 made MarketDataManager the **sole** history owner; DataHub became a facade that stores no history. The canonical readiness (`compute_history_readiness` / `compute_selected_option_history_readiness`) correctly gates on **mdm/runner/indicator** only. But `build_symbol_hydration_status` still gated on **four** sources including `datahub_bars` (`counts=[mdm,datahub,runner,indicator]` via `any()<required` / `all()>=required`), and the two `min()` aggregations feeding `compute_live_readiness` also included `datahub_bars`.

Post-#562 `datahub_bars` lags MDM (observed: mdm=51, runner=46, indicator≥46, required=30, datahub far lower), so the live/arming path computed `insufficient_bars` → `ready_for_execution=False` → `selected_option_history_cold` → **never armed**, even though history was actually ready.

## Fix (SSOT, minimal — no new machinery)

Exclude `datahub_bars` from the three readiness **gates** so every path matches the canonical function's sources/threshold:
1. `build_symbol_hydration_status`: gate on `gating_counts=[mdm,runner,indicator]`. `datahub_bars` is still computed, stored, and its `datahub_bars_missing` blocker still listed (observability only — already classified non-gating in `CONTEXT_SYMBOL_BLOCKERS_NON_GATING`).
2. `_recompute_and_push_runtime_readiness` `ce_bars`/`pe_bars` `min()`: drop datahub.
3. startup arming `hydrated_ce`/`hydrated_pe` `min()`: drop datahub.

Genuine shortfalls still block: a real mdm/runner/indicator deficit still produces `insufficient_bars` (covered by test).

## End-to-end SSOT consistency verified

- `compute_history_readiness`: `mdm>=req and runner>=req and indicator>=req` (no datahub)
- `_hydration_status_map` / `build_symbol_hydration_status`: now identical 3-source gate
- both `min()` feeders into `compute_live_readiness`: now 3-source
- `execution/readiness.compute_live_readiness`: gates only on passed `ce_bars`/`pe_bars`; its `datahub_bars` is a stored observability field, not a gate

## Validation

- compileall src + tests: clean
- New async tests (proven to FAIL against un-fixed code): lagging datahub does not block while mdm/runner/indicator≥required; genuine runner shortfall still blocks.
- Targeted readiness/execution suites: 28 passed.
- Full suite: **2263 passed, 1 skipped, 0 failed**.