### PR TITLE
Make midday pause env configuration explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,9 @@ pytest
 | `RISK_MAX_DAILY_TRADES` | Daily trade cap | `20` |
 | `RISK_MAX_ORDER_NOTIONAL` | Max order notional | `200000.0` |
 | `RISK_ALLOW_SHORT` | Allow short selling | `true` |
+| `MIDDAY_PAUSE_ENABLED` | Block only new option-buy candidate selection during the configurable midday pause; set `false` to disable without code changes. Does not affect exits or order management. | `true` |
+| `MIDDAY_PAUSE_START` | Midday pause start time in IST (`HH:MM`). Invalid values fall back safely to `11:30`. | `11:30` |
+| `MIDDAY_PAUSE_END` | Midday pause end time in IST (`HH:MM`). Invalid values fall back safely to `13:15`. | `13:15` |
 | `RISK_PER_TRADE_CAP_PCT` | Per-trade capital cap percentage for sizing | `1.0` |
 | `RATE_LIMIT_ORDERS_CAPACITY` | Order bucket size | `5` |
 | `RATE_LIMIT_ORDERS_REFILL_PER_SEC` | Order bucket refill rate | `5.0` |

--- a/src/nifty_scalper_bot/risk/expiry_gate.py
+++ b/src/nifty_scalper_bot/risk/expiry_gate.py
@@ -52,7 +52,11 @@ def _env_hhmm(name: str, default: dtime) -> dtime:
     raw = str(os.getenv(name) or "").strip()
     try:
         hh, mm = raw.split(":", 1)
-        return dtime(hour=max(0, min(23, int(hh))), minute=max(0, min(59, int(mm))))
+        hour = int(hh)
+        minute = int(mm)
+        if not (0 <= hour <= 23 and 0 <= minute <= 59):
+            return default
+        return dtime(hour=hour, minute=minute)
     except (ValueError, AttributeError):
         return default
 

--- a/tests/risk/test_expiry_gate.py
+++ b/tests/risk/test_expiry_gate.py
@@ -65,3 +65,76 @@ def test_midday_pause_disabled_via_env(monkeypatch) -> None:
     monkeypatch.setenv("MIDDAY_PAUSE_ENABLED", "false")
     blocked, reason = midday_pause_block(_ist(2026, 6, 10, 12, 0))
     assert not blocked and reason == "pause_disabled"
+
+
+def test_midday_pause_default_enabled_and_window(monkeypatch) -> None:
+    from nifty_scalper_bot.risk.expiry_gate import midday_pause_block
+
+    monkeypatch.delenv("MIDDAY_PAUSE_ENABLED", raising=False)
+    monkeypatch.delenv("MIDDAY_PAUSE_START", raising=False)
+    monkeypatch.delenv("MIDDAY_PAUSE_END", raising=False)
+
+    blocked, reason = midday_pause_block(_ist(2026, 6, 10, 12, 0))
+
+    assert blocked
+    assert reason == "midday_pause_11:30-13:15_ist"
+
+
+def test_midday_pause_false_allows_inside_window(monkeypatch) -> None:
+    from nifty_scalper_bot.risk.expiry_gate import midday_pause_block
+
+    monkeypatch.setenv("MIDDAY_PAUSE_ENABLED", "false")
+
+    blocked, reason = midday_pause_block(_ist(2026, 6, 10, 12, 0))
+
+    assert not blocked
+    assert reason == "pause_disabled"
+
+
+def test_midday_pause_truthy_values_enable_pause(monkeypatch) -> None:
+    from nifty_scalper_bot.risk.expiry_gate import midday_pause_block
+
+    for value in ("true", "yes", "1", "on"):
+        monkeypatch.setenv("MIDDAY_PAUSE_ENABLED", value)
+        blocked, reason = midday_pause_block(_ist(2026, 6, 10, 12, 0))
+        assert blocked, value
+        assert "midday_pause" in reason
+
+
+def test_midday_pause_falsey_values_disable_pause(monkeypatch) -> None:
+    from nifty_scalper_bot.risk.expiry_gate import midday_pause_block
+
+    for value in ("false", "no", "0", "off"):
+        monkeypatch.setenv("MIDDAY_PAUSE_ENABLED", value)
+        blocked, reason = midday_pause_block(_ist(2026, 6, 10, 12, 0))
+        assert not blocked, value
+        assert reason == "pause_disabled"
+
+
+def test_midday_pause_invalid_times_fall_back_to_default_window(monkeypatch) -> None:
+    from nifty_scalper_bot.risk.expiry_gate import midday_pause_block
+
+    monkeypatch.setenv("MIDDAY_PAUSE_ENABLED", "true")
+    monkeypatch.setenv("MIDDAY_PAUSE_START", "25:00")
+    monkeypatch.setenv("MIDDAY_PAUSE_END", "garbage")
+
+    blocked, reason = midday_pause_block(_ist(2026, 6, 10, 12, 0))
+
+    assert blocked
+    assert reason == "midday_pause_11:30-13:15_ist"
+
+
+def test_midday_pause_custom_window_blocks_and_allows(monkeypatch) -> None:
+    from nifty_scalper_bot.risk.expiry_gate import midday_pause_block
+
+    monkeypatch.setenv("MIDDAY_PAUSE_ENABLED", "true")
+    monkeypatch.setenv("MIDDAY_PAUSE_START", "12:00")
+    monkeypatch.setenv("MIDDAY_PAUSE_END", "12:30")
+
+    blocked, reason = midday_pause_block(_ist(2026, 6, 10, 12, 15))
+    assert blocked
+    assert reason == "midday_pause_12:00-12:30_ist"
+
+    blocked, reason = midday_pause_block(_ist(2026, 6, 10, 12, 45))
+    assert not blocked
+    assert reason == "outside_pause"

--- a/tests/strategies/test_trade_selector.py
+++ b/tests/strategies/test_trade_selector.py
@@ -115,3 +115,58 @@ def test_selector_allows_higher_nifty_premium_default_cap() -> None:
         snapshots=[_snapshot('NFO:NIFTY26MAY24050PE', 24050, ltp=374.95, bid=374.5, ask=375.4)],
     )
     assert best is not None
+
+
+def _candidate_snapshot(**overrides: object) -> dict[str, object]:
+    payload = _snapshot('NFO:NIFTY23500CE', 23500, side='CE')
+    payload.update(overrides)
+    return payload
+
+
+def test_selector_midday_pause_enabled_blocks_candidates(monkeypatch, caplog) -> None:
+    from nifty_scalper_bot.strategies import trade_selector as trade_selector_mod
+
+    monkeypatch.setattr(trade_selector_mod, 'expiry_theta_block', lambda: (False, 'not_expiry_day'))
+    monkeypatch.setattr(
+        trade_selector_mod,
+        'midday_pause_block',
+        lambda: (True, 'midday_pause_11:30-13:15_ist'),
+    )
+    selector = TradeCandidateSelector()
+
+    with caplog.at_level('INFO', logger=trade_selector_mod.LOGGER.name):
+        ranked = selector.select_ranked_candidates(
+            direction_bias='CE',
+            atm_strike=23500,
+            snapshots=[_candidate_snapshot()],
+        )
+
+    assert ranked == []
+    assert any(
+        record.__dict__.get('event') == 'CANDIDATE_SELECTION_BLOCKED'
+        and 'midday_pause' in str(record.__dict__.get('reason'))
+        for record in caplog.records
+    )
+
+
+def test_selector_midday_pause_disabled_continues_to_quality_filtering(monkeypatch, caplog) -> None:
+    from nifty_scalper_bot.strategies import trade_selector as trade_selector_mod
+
+    monkeypatch.setattr(trade_selector_mod, 'expiry_theta_block', lambda: (False, 'not_expiry_day'))
+    monkeypatch.setattr(trade_selector_mod, 'midday_pause_block', lambda: (False, 'pause_disabled'))
+    selector = TradeCandidateSelector()
+
+    with caplog.at_level('INFO', logger=trade_selector_mod.LOGGER.name):
+        ranked = selector.select_ranked_candidates(
+            direction_bias='CE',
+            atm_strike=23500,
+            snapshots=[_candidate_snapshot()],
+        )
+
+    assert ranked
+    assert ranked[0].symbol == 'NFO:NIFTY23500CE'
+    assert not any(
+        record.__dict__.get('event') == 'CANDIDATE_SELECTION_BLOCKED'
+        and 'midday_pause' in str(record.__dict__.get('reason'))
+        for record in caplog.records
+    )


### PR DESCRIPTION
### Motivation

- Make the midday trading pause clearly configurable via environment variables while keeping the existing env keys `MIDDAY_PAUSE_ENABLED`, `MIDDAY_PAUSE_START`, and `MIDDAY_PAUSE_END`.
- Ensure the default behaviour is safe: enabled by default, window 11:30–13:15 IST, and only blocks new option-buy candidate selection (must not affect exits or order management).
- Harden parsing so invalid `HH:MM` values fall back to documented safe defaults rather than silently producing unexpected times.

### Description

- Tightened the env time parser in `src/nifty_scalper_bot/risk/expiry_gate.py` (`_env_hhmm`) to validate hour/minute ranges and return the caller-provided default when inputs are invalid or out-of-range.
- Left `midday_pause_block` semantics unchanged (default enabled, default window `11:30-13:15` IST, only blocks new option-buy entries and returns explicit reasons such as `pause_disabled`, `outside_pause`, or `midday_pause_11:30-13:15_ist`).
- Added focused unit tests in `tests/risk/test_expiry_gate.py` to verify default enabled behaviour, truthy/falsey env forms, invalid time fallbacks, and a custom window case.
- Added selector-level tests in `tests/strategies/test_trade_selector.py` that monkeypatch the imported gate functions to assert `TradeCandidateSelector.select_ranked_candidates()` returns `[]` and logs `CANDIDATE_SELECTION_BLOCKED` only when the midday pause gate indicates blocking, and continues normal quality filtering when the gate is disabled.
- Documented `MIDDAY_PAUSE_ENABLED`, `MIDDAY_PAUSE_START`, and `MIDDAY_PAUSE_END` in `README.md` with defaults and the guarantee that the pause only affects new candidate selection and not exits/order management.

### Testing

- Commands run: `python -m compileall -q src`, `python -m compileall -q tests`, `pytest -q tests/risk/test_expiry_gate.py`, `pytest -q tests/strategies/test_runner_live_path_guards.py`, `pytest -q tests/strategies`, `pytest -q`.
- Results: `python -m compileall -q src`: passed, `python -m compileall -q tests`: passed.
- `pytest -q tests/risk/test_expiry_gate.py`: 15 passed, 0 failed, 0 skipped, 0 errors.
- `pytest -q tests/strategies/test_runner_live_path_guards.py`: 140 passed, 0 failed, 0 skipped, 0 errors.
- `pytest -q tests/strategies`: 590 passed, 0 failed, 0 skipped, 0 errors.
- Full test run `pytest -q`: 2250 passed, 0 failed, 1 skipped, 0 errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2fbfda311c832494a83e2fdab55fb9)