### PR TITLE
Fix Telegram not responding to commands: start polling early, independent of hydration

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -11488,6 +11488,25 @@ async def startup_sequence(ctx: BotContext) -> None:
     # 4. Start subsystems (guarded singleton startup)
     # ---------------------------------------------------------
     if broker_ready:
+        # Start Telegram polling EARLY and independently of the data-hydration
+        # pipeline below. The bot's start() is self-contained (claims the polling
+        # owner, registers operator command handlers, then begins polling) and
+        # does not depend on market-data readiness. Previously start() was the
+        # last step of the long subsystems_started block, so operator commands
+        # only became live after full hydration — and were skipped entirely if
+        # any earlier step in that block raised. start() is idempotent (no-ops
+        # when already started), so the later call in the pipeline is harmless.
+        if ctx.telegram_bot is not None:
+            try:
+                LOGGER.info("🚀 Starting Telegram Bot (Polling Mode, early)...")
+                await ctx.telegram_bot.start()
+                LOGGER.info("✅ Telegram Bot polling active — commands now live.")
+            except Exception as _tg_early_exc:  # noqa: BLE001 - never block startup on telegram
+                LOGGER.warning(
+                    "telegram_early_start_failed err=%s",
+                    _tg_early_exc,
+                    extra={"event": "telegram_early_start_failed", "err": str(_tg_early_exc)},
+                )
         try:
             if not ctx.subsystems_started:
                 # ── Subscribe handlers BEFORE starting the bus so dispatchers

--- a/tests/notifications/test_telegram_start_idempotent.py
+++ b/tests/notifications/test_telegram_start_idempotent.py
@@ -1,0 +1,44 @@
+"""TelegramBot.start() must be idempotent so it can be started early (before the
+data-hydration pipeline) and the later in-pipeline call becomes a safe no-op.
+This underpins the fix that makes operator commands live regardless of market
+data readiness. Async so it executes under the repo conftest hook.
+"""
+
+from __future__ import annotations
+
+from nifty_scalper_bot.notifications.telegram_controller import TelegramBot, TelegramDeps
+
+
+async def test_start_is_idempotent_when_already_started() -> None:
+    deps = TelegramDeps(token="dummy", chat_id=12345, app_version="test")
+    bot = TelegramBot(deps)
+    # Simulate a successful first start without touching the network.
+    bot._started = True
+    bot._running = True
+
+    register_calls = {"n": 0}
+    original = bot._register_handlers
+
+    def _counting_register() -> None:
+        register_calls["n"] += 1
+        return original()
+
+    bot._register_handlers = _counting_register  # type: ignore[method-assign]
+
+    # A second start() (the later in-pipeline call) must no-op: no handler
+    # re-registration, no polling attempt, no exception.
+    await bot.start()
+    assert register_calls["n"] == 0
+    assert bot._started is True
+
+
+async def test_handlers_registered_flag_guards_double_registration() -> None:
+    deps = TelegramDeps(token="dummy", chat_id=12345, app_version="test")
+    bot = TelegramBot(deps)
+    # _register_handlers must be safe to call twice (guard on _handlers_registered).
+    assert bot._handlers_registered is False
+    bot._register_handlers()
+    assert bot._handlers_registered is True
+    # second call is a no-op (would raise if it tried to re-add on a real app twice)
+    bot._register_handlers()
+    assert bot._handlers_registered is True


### PR DESCRIPTION
## Symptom

Telegram bot does not respond to commands (/status, /help, etc.). The only Telegram line in the after-hours log was a benign library-level `Exception happened while polling for updates` (transient network), which masked the real issue.

## Root cause

`TelegramBot.start()` — which claims the polling owner, **registers the operator command handlers**, and begins polling — was the **last step** inside the large `if not ctx.subsystems_started:` block in `startup_sequence` (app.py), i.e. it ran only **after** the entire ~550-line market-data hydration/readiness pipeline.

Two consequences:
1. Operator commands only became live **after full data hydration**. During the long warmup — or whenever the readiness pipeline stalled (the same startup stalls fixed in #571–#574) — the process polled Telegram but had **no live command handling**, so commands went unanswered precisely when an operator would reach for `/status`.
2. The whole block is wrapped in `try/except`; if any earlier hydration step raised, `start()` was **skipped entirely** and commands never worked.

Ruled out by code inspection (not the cause): duplicate pollers (`TelegramService.telegram_from_env` is never wired in the live path) and chat-id type mismatch (`_chat_id` / `_expected_chat_id` both coerce to `int`). The defect was purely the **ordering/gating** of `start()`.

## Fix (minimal)

Start Telegram polling **right after `broker_ready`, before** the hydration pipeline, wrapped so a Telegram failure can never block trading startup. `start()` is self-contained (does not touch market data) and idempotent (guards on `self._started`), so the pre-existing later call in the pipeline becomes a harmless no-op — no double polling, no duplicate handlers. `ctx.telegram_bot` is created earlier in `create_context`, so it is available at this point.

## Validation

- compile + import: clean
- New async tests (sentinel-verified to actually execute under the conftest hook): `start()` is idempotent when already started (no handler re-registration, no polling, no raise); `_register_handlers` guards against double registration.
- Telegram suites: 84 passed.
- Full suite: **2273 passed, 1 skipped, 0 failed**.

## Note

The benign `Exception happened while polling for updates` originates in the `python-telegram-bot` library (`telegram/ext/_updater.py`), is a transient network hiccup, self-recovers, and is unrelated to command handling — no change made for it.