### PR TITLE
docs: module-purpose headers (7 core files) + REPO_MAP rewrite + AGENTS module table

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,49 @@ Do not bypass this flow with side-channel patches.
 
 ---
 
+## Module map (one line per major file)
+
+Each core runtime file below carries a standardized module docstring (Runtime
+role / Position in the pipeline / Owns–does NOT own / Safe-edit notes). See
+`docs/REPO_MAP.md` for the fuller map.
+
+### Core runtime path
+| File | Purpose | Owns | Does NOT own |
+| --- | --- | --- | --- |
+| `core/app.py` | Orchestrator; builds context, wires subsystems, runs startup, computes readiness/arming SSOT | wiring, startup ordering, readiness SSOT | contract selection, history, order placement |
+| `data/market_data_manager.py` | Sole owner of ticks + OHLC history; broker fetch; tick fan-out | tick cache, OHLC history, history fetch | contract selection, strategy logic |
+| `data/data_hub.py` | Read facade over MDM (quotes/OHLC/OI/context) | read/derive helpers | history (none), contract selection |
+| `strategies/runner.py` | Evaluation loop; gates; signal→order handoff | eval loop, exec state, runner/indicator history | contract selection, broker fetch, placement |
+| `execution/order_manager.py` | THE live order path: placement, retries, lifecycle | order placement + lifecycle of record | signal generation, contract selection |
+| `execution/bracket_manager.py` | Virtual SL/TP, ATR trailing, multi-target, partial scaling | bracket state, exit-fire decision | entry decisions, raw placement |
+| `notifications/telegram_controller.py` | Operator console: commands, auth, diagnostics, alerts | handler registration, single-chat auth, messaging | trading decisions, order placement |
+
+### Key support modules
+| File | Purpose |
+| --- | --- |
+| `core/instrument_manager.py` | Authoritative contract selection + token resolution from the instrument dump |
+| `instruments/active_contracts.py` | Canonical symbol helpers; active NIFTY future resolution |
+| `execution/safe_order_manager.py` | Safety wrapper (guards/idempotency) around OrderManager |
+| `execution/position_manager.py` | Position + pending-order state of record |
+| `execution/readiness.py` | Pure readiness/arming decision helpers |
+| `execution/order_executor.py` | Separate non-live executor — NOT the live order path |
+| `core/strategy_manager.py` | Scores strategies and allocates between them |
+| `strategies/signal_generator.py` | Produces scored signals from indicators |
+| `core/market_regime.py` | Market-regime detection and fan-out |
+| `data/rest/zerodha_client.py` | Low-level Kite REST + websocket client |
+| `streaming/websocket_manager.py` | Hardened KiteTicker streaming |
+| `risk/risk_manager.py` | Risk guardrails and telemetry |
+| `config/settings.py` | Runtime settings facade |
+| `backtesting/backtest_engine.py` | Event-driven historical replay with simulated fills/costs |
+
+### SSOT invariants
+- History is owned only by MDM; DataHub stores none. Never gate readiness on DataHub bars.
+- Readiness gates on mdm/runner/indicator counts via the canonical functions in `core/app.py`.
+- Contract selection lives in InstrumentManager; MDM/DataHub/runner consume, never select.
+
+
+---
+
 ## Market-data architecture
 
 ### Required live-data flow

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -1,40 +1,79 @@
 # Repository Map
 
+> Accurate as of the current `main`. Paths are relative to `src/nifty_scalper_bot/`.
+> For the non-negotiable runtime rules and the authoritative pipeline, see `AGENTS.md`.
+
 ## Top-Level Layout
-- `src/` – Production bot source code including execution, data pipelines, strategies, risk, and utilities.
-- `tests/` – Unit and integration tests mirroring the `src/` structure.
-- `deploy/`, `ops/`, `scripts/` – Operational tooling for deployments, monitoring, and local helpers.
-- `docs/` – Reference documentation (this map).
+- `src/nifty_scalper_bot/` – Production bot source (data, strategies, execution, risk, notifications, infra).
+- `tests/` – Unit/integration tests mirroring `src/`. Note: many sync tests are no-ops under the
+  current conftest hook — new/critical tests must be `async def` to actually execute.
+- `deploy/`, `ops/`, `scripts/` – Deployment, monitoring, and local helper tooling.
+- `docs/` – Reference documentation (this map, playbooks, prompts).
 
-## Key Modules
+## Authoritative Runtime Path
+```text
+core/app.py
+→ data/market_data_manager.py
+→ data/data_hub.py
+→ strategies/runner.py
+→ execution/order_manager.py
+→ execution/bracket_manager.py
+→ notifications/telegram_controller.py
+```
+Do not bypass this flow with side-channel patches. Options are the only tradable
+instrument; spot is direction/context only; futures is optional volume/context.
 
-### Notifications
-- [src/notifications/telegram_controller.py](../nifty_scalper_bot/src/notifications/telegram_controller.py#L527-L680): Production Telegram controller wiring status/diagnostic providers, admin controls, and throttled decision alerts for live operations.
+## Core Runtime Files (each carries a standardized module docstring)
+- `core/app.py` – Orchestrator. Builds BotContext, wires every subsystem, owns the
+  startup sequence and the readiness/arming SSOT.
+- `data/market_data_manager.py` (MDM) – **Sole owner** of ticks and OHLC history;
+  broker history fetch; tick fan-out via the message bus.
+- `data/data_hub.py` – Read facade over MDM (quotes/OHLC/OI/context). Owns no history;
+  selects no contracts.
+- `strategies/runner.py` – Event-driven evaluation loop; applies gates; hands accepted
+  signals to the order path; tracks runner/indicator history counts.
+- `execution/order_manager.py` – THE live order path: placement, retries, idempotency,
+  lifecycle against the broker.
+- `execution/bracket_manager.py` – Virtual (internal) SL/TP, ATR trailing, multi-target
+  exits, partial scaling, orphan resync.
+- `notifications/telegram_controller.py` – Operator console: command handlers, single-chat
+  auth, diagnostics, guarded controls, alerts.
 
-### Execution
-- [src/execution/order_executor.py](../nifty_scalper_bot/src/execution/order_executor.py#L1138-L1270): Kite order router managing placement, microstructure validation, retries, circuit breakers, and order state machines for live and paper modes.
-- [src/execution/micro_filters.py](../nifty_scalper_bot/src/execution/micro_filters.py#L23-L200): Microstructure guardrails deriving spread/depth metrics from quotes and applying configurable entry waits and depth requirements.
+## Key Support Modules
+### Contracts & instruments
+- `core/instrument_manager.py` – Authoritative contract selection from the instrument dump
+  (futures/options/ATM). Token resolution.
+- `instruments/active_contracts.py` – Canonical symbol helpers and active NIFTY future
+  resolution from instruments.
 
-### Data
-- [src/data/source.py](../nifty_scalper_bot/src/data/source.py#L1232-L1320): `LiveKiteSource` fetches ticks/quotes via Kite APIs with TTL caching, subscription tracking, and resilience gates for websocket and REST data.
+### Execution support
+- `execution/safe_order_manager.py` – Safety wrapper around OrderManager (guards/idempotency).
+- `execution/position_manager.py` – Position and pending-order state of record.
+- `execution/readiness.py` – Pure readiness/arming decision helpers used by the live gate.
+- `execution/order_executor.py` – Separate non-live executor. **NOT** the live order path.
 
-### Strategies
-- [src/strategies/atr_gate.py](../nifty_scalper_bot/src/strategies/atr_gate.py#L1-L160): ATR-based gating utilities throttling noisy logs and enforcing configurable volatility floors before taking signals.
-- [src/strategies/scoring.py](../nifty_scalper_bot/src/strategies/scoring.py#L1-L176): Feature scoring helpers computing adjusted totals, regime-aware thresholds, and diagnostics used by strategy runners.
-- [src/strategies/scalper.py](../nifty_scalper_bot/src/strategies/scalper.py#L1-L200): Simplified scalper orchestrator coordinating broker margin probes, entry timing, and hedging controls around short straddles.
+### Strategy support
+- `core/strategy_manager.py` – Scores strategies and allocates between them.
+- `strategies/signal_generator.py` – Produces scored signals from indicators.
+- `strategies/indicators.py` – Technical indicator calculations.
+- `core/market_regime.py` – Market-regime detection and fan-out.
 
-### Risk
-- [src/risk/position_sizing.py](../nifty_scalper_bot/src/risk/position_sizing.py#L1-L200): Position sizing utilities deriving live equity, enforcing premium caps, and returning structured block reasons for trade gating.
+### Data & streaming
+- `data/rest/zerodha_client.py` – Low-level Kite REST + websocket client.
+- `streaming/websocket_manager.py` – Hardened KiteTicker streaming.
+- `data/persistent_state.py` – Persisted runtime state.
 
-### Costs
-- [src/backtesting/sim_connector.py](../nifty_scalper_bot/src/backtesting/sim_connector.py#L21-L68): `CostModel` dataclass encapsulating brokerage, exchange, tax, and stamp duty parameters consumed by simulators (no standalone `costs/model.py` module).
+### Risk, config, infra
+- `risk/risk_manager.py` – Risk guardrails and telemetry.
+- `config/settings.py` – Runtime settings facade.
+- `infra/metrics.py` – Metrics.
 
 ### Backtesting
-- [src/backtesting/backtest_engine.py](../nifty_scalper_bot/src/backtesting/backtest_engine.py#L1-L200): Event-driven engine streaming historical bars through strategies, applying simulated fills/costs, and persisting trade results.
+- `backtesting/backtest_engine.py` – Event-driven historical replay through strategies
+  with simulated fills/costs.
 
-### Utilities
-- [src/utils/market_time.py](../nifty_scalper_bot/src/utils/market_time.py#L1-L110): Market session utilities providing IST-aware time helpers, trading window resolution, and session bounds.
-- [src/utils/freshness.py](../nifty_scalper_bot/src/utils/freshness.py#L1-L73): Freshness computations converting timestamps and scoring tick/bar latency vs. configured thresholds.
-- [src/utils/circuit_breaker.py](../nifty_scalper_bot/src/utils/circuit_breaker.py#L1-L170): Thread-safe circuit breaker implementation tracking failure counts, cooldowns, and health metadata.
-- [src/utils/rate_limiter.py](../nifty_scalper_bot/src/utils/rate_limiter.py#L1-L155): Shared leaky-bucket rate limiter with environment-driven buckets for broker REST throttling.
-
+## SSOT Invariants (read before editing the data/readiness path)
+- History is owned only by MDM. DataHub stores none; never gate readiness on DataHub bars.
+- Readiness gates on mdm/runner/indicator bar counts via the canonical functions in
+  `core/app.py` (`compute_history_readiness`, `compute_selected_option_history_readiness`).
+- Contract selection lives in InstrumentManager; MDM/DataHub/runner consume, never select.

--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -1,8 +1,34 @@
 """Core orchestration for the Nifty scalper trading bot.
 
-Polling mode is more reliable for Railway/Heroku/Cloud deploys; WebSocket/
-webhook should be used only on static public IP/server with trusted domain and
-TLS certificate.
+Runtime role:
+- Builds the BotContext and wires every subsystem together (data, strategy,
+  execution, risk, notifications) in one place.
+- Owns the startup sequence: broker auth, instrument load, subsystem bring-up,
+  the data-hydration/readiness pipeline, and the live-arming gate.
+- Computes the canonical readiness/arming decision (history + quote freshness)
+  and pushes it to the runner.
+
+Position in the pipeline (authoritative runtime path):
+    THIS FILE (app.py)
+    → data/market_data_manager.py → data/data_hub.py
+    → strategies/runner.py
+    → execution/order_manager.py → execution/bracket_manager.py
+    → notifications/telegram_controller.py
+
+Owns / does NOT own:
+- Owns: subsystem wiring, startup ordering, the readiness/arming SSOT
+  (compute_history_readiness / compute_selected_option_history_readiness).
+- Does NOT own: contract selection (InstrumentManager), history storage (MDM),
+  or order placement (OrderManager). app.py coordinates; it does not re-implement.
+
+Safe-edit notes:
+- Readiness gates on mdm/runner/indicator bar counts only — never DataHub bars
+  (DataHub owns no history). Keep all readiness paths consistent with the
+  canonical functions.
+- Telegram polling is started early (right after broker_ready), independent of
+  the hydration pipeline; do not move it back inside the hydration block.
+- Polling mode is more reliable for cloud deploys; WebSocket/webhook is only for
+  a static public IP with a trusted domain and TLS certificate.
 """
 
 # ruff: noqa: I001

--- a/src/nifty_scalper_bot/data/data_hub.py
+++ b/src/nifty_scalper_bot/data/data_hub.py
@@ -1,9 +1,24 @@
-"""Canonical SSOT cache for ticks, positions, orders, and broker facades.
+"""Read facade over MarketDataManager for quotes, OHLC, OI, and context.
 
 Runtime role:
-- Read facade over active basket and market data.
-- Exposes quote/OHLC/OI/context to strategies.
-- Must not select contracts or infer active futures/options independently.
+- Single read surface that strategies/execution use to access ticks, quotes,
+  OHLC, open interest, and active-basket context.
+- Delegates all data access to MarketDataManager; binds to the MDM tick bus.
+
+Position in the pipeline:
+    data/market_data_manager.py → THIS FILE (data_hub.py)
+    → strategies/runner.py / execution/*
+
+Owns / does NOT own:
+- Owns: convenience read/derive helpers (e.g. quote bid/ask/spread, greeks) and
+  a thin store for non-history state.
+- Does NOT own: price history (MDM is the sole owner — DataHub stores none), and
+  does NOT select contracts or infer active futures/options independently.
+
+Safe-edit notes:
+- DataHub.get_ohlc_bars delegates to MDM; its bar count must NEVER be used to
+  gate readiness (doing so previously wedged live arming — fixed in PR #574).
+- Keep this a facade: no contract selection, no broker history fetching here.
 """
 
 from __future__ import annotations

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -1,4 +1,28 @@
-"""Central market data manager responsible for tick fan-out and broker cache."""
+"""Central market data manager: the single owner of ticks and OHLC history.
+
+Runtime role:
+- Receives broker ticks (WebSocket/REST), maintains the live quote cache, and
+  builds one-minute OHLC bars per symbol.
+- Fans ticks out to subscribers via the message bus.
+- Performs broker history fetch/backfill (ensure_history) and is the sole holder
+  of the OHLC bar cache used for readiness and indicators.
+
+Position in the pipeline:
+    core/app.py → THIS FILE (market_data_manager.py)
+    → data/data_hub.py → strategies/runner.py
+
+Owns / does NOT own:
+- Owns: tick cache, OHLC bar history, broker history fetch, tick fan-out, the
+  committed active-contract basket's futures symbol (read via the basket).
+- Does NOT own: contract selection (InstrumentManager owns that) and strategy
+  logic. MDM returns the active future from the committed basket only.
+
+Safe-edit notes:
+- This is the SSOT for history (PR #562). DataHub is a read facade over MDM and
+  stores no history; never reintroduce a parallel history cache elsewhere.
+- get_ohlc_bars normalizes the symbol via _bar_symbol_key; keep symbol
+  normalization consistent so bar counts agree across the readiness chain.
+"""
 
 from __future__ import annotations
 from nifty_scalper_bot.core.message_bus import Message, MessageType

--- a/src/nifty_scalper_bot/execution/bracket_manager.py
+++ b/src/nifty_scalper_bot/execution/bracket_manager.py
@@ -1,7 +1,24 @@
-"""
-Thread-safe Bracket Manager with VIRTUAL Execution capabilities.
-Production-Grade: Replaces legacy broker-side brackets with high-speed internal monitoring.
-Enhanced with ATR Trailing, Multi-Target (TP1/TP2), Partial Scaling, and Orphan Sync.
+"""Thread-safe bracket manager with virtual (internal) SL/TP execution.
+
+Runtime role:
+- Replaces broker-side bracket orders with high-speed internal monitoring of
+  stop-loss and take-profit for each open position.
+- Supports ATR trailing, multi-target exits (TP1/TP2), partial scaling, and
+  orphan/position resync.
+
+Position in the pipeline:
+    execution/order_manager.py -> THIS FILE (bracket_manager.py)
+    (monitors fills/positions and issues exit orders back through the order path)
+
+Owns / does NOT own:
+- Owns: the virtual bracket state per position (SL/TP/trailing) and the decision
+  to fire an exit.
+- Does NOT own: entry decisions (runner) or raw order placement mechanics
+  (order_manager). It decides WHEN to exit; placement still goes through the path.
+
+Safe-edit notes:
+- Live money and thread-sensitive (RLock-guarded). Preserve locking and the
+  exit-trigger logic; a missed/duplicated exit is a real financial risk.
 """
 from __future__ import annotations
 

--- a/src/nifty_scalper_bot/execution/order_manager.py
+++ b/src/nifty_scalper_bot/execution/order_manager.py
@@ -1,4 +1,27 @@
-"""Order lifecycle management utilities."""
+"""Order lifecycle management: the live order path.
+
+Runtime role:
+- THE production order path. Places, modifies, and tracks orders against the
+  broker (Kite), handling retries, idempotency, and lifecycle transitions.
+- Coordinates with the bracket manager (SL/TP), position manager, and risk
+  guardrails around each order.
+
+Position in the pipeline:
+    strategies/runner.py -> THIS FILE (order_manager.py)
+    -> execution/bracket_manager.py / execution/position_manager.py
+
+Owns / does NOT own:
+- Owns: order placement and lifecycle against the broker, order-level retry and
+  idempotency, and the live order state of record.
+- Does NOT own: signal generation (runner) or contract selection. It executes
+  what the runner approved; it does not decide whether to trade.
+
+Safe-edit notes:
+- Live money. Order placement is wrapped by SafeOrderManager; preserve the
+  guard/idempotency boundaries and do not introduce a second placement route.
+- order_executor.py is NOT the live path (it is a separate, non-live executor);
+  do not confuse the two.
+"""
 
 from __future__ import annotations
 

--- a/src/nifty_scalper_bot/notifications/telegram_controller.py
+++ b/src/nifty_scalper_bot/notifications/telegram_controller.py
@@ -1,5 +1,26 @@
 """Telegram operator console: single-chat, production-grade commands.
 
+Runtime role:
+- The operator's control and diagnostics surface. Registers command handlers and
+  polls Telegram for operator commands; sends status/decision/alert messages.
+- Provides read-only diagnostics (status, positions, orders, risk, market data)
+  and guarded controls (pause/resume, shadow/paper toggles, ws reconnect).
+
+Position in the pipeline:
+    core/app.py wires this last and starts polling early (independent of data
+    hydration) so commands are live as soon as the process is up.
+
+Owns / does NOT own:
+- Owns: command handler registration, single-chat authorization, and operator
+  messaging/alert throttling.
+- Does NOT own: trading decisions or order placement. Control commands toggle
+  flags/managers; they never place orders directly.
+
+Safe-edit notes:
+- start() is idempotent and claims a single polling owner; do not add a second
+  poller for the same bot token (Telegram allows one getUpdates consumer).
+- Authorization compares chat ids as ints on both sides; keep that coercion.
+
 Commands (core):
   /opshelp               – show commands
   /ping                  – round-trip latency

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -1,9 +1,28 @@
-"""Event-driven strategy runner coordinating trading managers.
+"""Event-driven strategy runner: the evaluation loop that turns data into orders.
 
 Runtime role:
-- Runs strategy evaluation over active basket symbols and cached bars.
-- Consumes DataHub/MDM context only.
-- Must not own contract selection or direct broker history fetching."""
+- Runs strategy evaluation over the active basket symbols using cached bars and
+  live quotes; applies readiness, regime, and quality gates.
+- On an accepted signal, prepares execution state and hands off to the order
+  path (OrderManager) for placement.
+- Maintains per-symbol runner/indicator history counts used by the readiness SSOT.
+
+Position in the pipeline:
+    data/data_hub.py / data/market_data_manager.py -> THIS FILE (runner.py)
+    -> execution/order_manager.py -> execution/bracket_manager.py
+
+Owns / does NOT own:
+- Owns: strategy evaluation loop, signal->order handoff, execution state machine
+  transitions, runner-side history (_symbol_history) and indicator history counts.
+- Does NOT own: contract selection, broker history fetching (consumes MDM/DataHub
+  context only), or final order placement mechanics (delegates to OrderManager).
+
+Safe-edit notes:
+- The execution path is live money. Keep signal gating and the order handoff
+  intact; do not add side-channel order placement.
+- History readiness uses runner/indicator/MDM counts; keep them consistent with
+  app.py's canonical readiness functions.
+"""
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Documentation only — no logic/behavior change

Verified: the code-AST below the module docstring is byte-identical for all 7 edited source files (docstring-only change). Full suite **2273 passed, 1 skipped, 0 failed** (unchanged).

## What changed

**1. Standardized module-purpose headers on the 7 authoritative runtime-path files:**
`core/app.py`, `data/market_data_manager.py`, `data/data_hub.py`, `strategies/runner.py`, `execution/order_manager.py`, `execution/bracket_manager.py`, `notifications/telegram_controller.py`.

Each header now states: one-line purpose, **Runtime role**, **Position in the pipeline**, **Owns / does NOT own**, and **Safe-edit notes**. The existing Telegram command list is preserved verbatim.

**2. Rewrote `docs/REPO_MAP.md`** — it was stale and actively misleading: it referenced removed/secondary files (`data/source.py`/`LiveKiteSource`, `order_executor.py` as if primary, `micro_filters.py`, `scalper.py`) with broken `../nifty_scalper_bot/src/...` path prefixes. It now matches current `main`: the authoritative runtime path, the 7 core files, key support modules, and the SSOT invariants.

**3. Added a compact module map table to `AGENTS.md`** (one line per major file with Owns / does NOT own) plus the SSOT invariants, immediately after the authoritative runtime path.

## Why

Encode the SSOT/ownership boundaries where editors (human or AI) actually look. The Owns / does-NOT-own + Safe-edit notes capture the invariants behind the recent readiness/hydration fixes — DataHub owns no history, readiness gates on mdm/runner/indicator only, `order_executor.py` is not the live path — to prevent re-introducing those classes of bug.

## Scope note

This is the documentation pass agreed as step 1. Subsequent de-duplication / dead-code removal will be handled serially in separate, behavior-verified PRs.