### PR TITLE
fix: throttle FUTURES_CONTEXT_UNAVAILABLE_BASKET_MISSING startup log flood

### DIFF
--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -7697,8 +7697,16 @@ class MarketDataManager:
         canonical = canonical_nifty_future_symbol(symbol)
         if canonical:
             return self._canonical_symbol(canonical)
-        self._logger.warning(
+        # Pre-commit, the basket has no futures_symbol yet; this method is polled
+        # many times during startup. The app-level resolver handles the fallback
+        # (FUTURES_CONTEXT_RESOLVED_FROM_INSTRUMENTS), so emit at most once per
+        # minute instead of flooding the log on every call.
+        log_throttled(
+            self._logger,
+            "futures_context_unavailable_basket_missing",
             "FUTURES_CONTEXT_UNAVAILABLE_BASKET_MISSING",
+            interval_sec=60.0,
+            level=logging.WARNING,
             extra={"event": "FUTURES_CONTEXT_UNAVAILABLE_BASKET_MISSING"},
         )
         return None

--- a/tests/data/test_market_data_manager.py
+++ b/tests/data/test_market_data_manager.py
@@ -1584,3 +1584,34 @@ def test_process_poll_quote_option_volume_uses_cumulative_delta() -> None:
     assert emitted
     assert emitted[0]["volume"] == 80
     assert emitted[0]["volume_source"] == "cumulative_delta"
+
+
+async def test_futures_basket_missing_warning_is_throttled(
+    broker: DummyBroker, ws: DummyWebSocket
+) -> None:
+    # Pre-commit, get_active_nifty_future_symbol_cached returns None and previously
+    # logged a WARNING on EVERY call, flooding startup logs (44x in 32s observed).
+    # It must now return None and emit the warning at most once per throttle window.
+    import logging as _logging
+
+    manager = MarketDataManager(broker, ws)
+    manager._active_contract_basket = None  # no committed basket -> no futures symbol
+
+    records: list[str] = []
+
+    class _Capture(_logging.Handler):
+        def emit(self, record: _logging.LogRecord) -> None:
+            if getattr(record, "event", "") == "FUTURES_CONTEXT_UNAVAILABLE_BASKET_MISSING":
+                records.append(record.getMessage())
+
+    handler = _Capture()
+    manager._logger.addHandler(handler)
+    try:
+        # Many calls (mimicking the startup poll storm)
+        for _ in range(25):
+            assert manager.get_active_nifty_future_symbol_cached() is None
+    finally:
+        manager._logger.removeHandler(handler)
+
+    # Throttled: at most one emission for the burst (definitely not 25).
+    assert len(records) <= 1, f"expected throttled (<=1) warning, got {len(records)}"


### PR DESCRIPTION
## Symptom (logs 2026-06-16 07:39 IST, pre-market startup)

44 occurrences of `FUTURES_CONTEXT_UNAVAILABLE_BASKET_MISSING` in a 32-second window, drowning the startup log.

## This is log noise, not a functional bug

The same log shows everything working: `CONTRACT_SSOT_FUTURE_SELECTED symbol=NFO:NIFTY26JUNFUT`, its history hydrating (`final_mdm_bars=50`), and the basket committing with `futures_symbol=NFO:NIFTY26JUNFUT`. The pre-market blockers (`market_closed`, `selected_option_quote_missing`, `data_not_ready`) are all correct for 07:39 when no live quotes flow. No trading defect.

## Root cause

`get_active_nifty_future_symbol_cached` (market_data_manager.py) is polled many times during startup. Before the active basket commits, it correctly returns `None` (InstrumentManager/SSOT owns selection; the app-level resolver provides the instrument fallback per PR #573) — but it logged a WARNING on **every** call, so the expected transient pre-commit window produced a flood.

## Fix (minimal, uses existing utility)

Replace the unconditional `self._logger.warning(...)` with the `log_throttled(...)` helper already used throughout this file, emitting at most once per 60s. Observability preserved (you still see it once); flood gone.

The other futures-context warnings (`requested=None`, `STALE_OR_UNRESOLVED`) fire only 2–5× per cycle and mark genuine state transitions — intentionally left as-is (throttling them would be over-engineering).

## Validation

- compile + import clean.
- New async test (sentinel + discrimination verified): 25 rapid calls with no committed basket emit ≤1 warning (was 25).
- Full suite: **2269 passed, 1 skipped, 0 failed**.