### PR TITLE
fix: classify post-rotation stale-token tick drops as DEBUG not WARNING

### DIFF
--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -5636,13 +5636,27 @@ class MarketDataManager:
             )
 
         if not symbol:
-            log_throttled(
-                self._logger,
-                f"mdm_unmapped_token_{token}",
-                "MDM_TICK_DROPPED reason=unmapped_token token=%s" % token,
-                interval_sec=30.0,
-                level=logging.WARNING,
-            )
+            # A tick for a token not in the desired set is an expected artifact of
+            # basket rotation: the token was just removed from the desired set and
+            # its mapping pruned, but the broker may stream a few more ticks before
+            # the WS unsubscribe lands. Dropping it is correct; log at DEBUG. Only a
+            # token that IS still desired but unmapped is a genuine anomaly (WARN).
+            if token in self._desired_tokens:
+                log_throttled(
+                    self._logger,
+                    f"mdm_unmapped_token_{token}",
+                    "MDM_TICK_DROPPED reason=unmapped_token token=%s" % token,
+                    interval_sec=30.0,
+                    level=logging.WARNING,
+                )
+            else:
+                log_throttled(
+                    self._logger,
+                    f"mdm_stale_token_{token}",
+                    "MDM_TICK_DROPPED reason=stale_unsubscribed_token token=%s" % token,
+                    interval_sec=60.0,
+                    level=logging.DEBUG,
+                )
             return None
 
         price_raw = raw.get("last_price") or raw.get("ltp") or raw.get("price")

--- a/tests/data/test_market_data_manager.py
+++ b/tests/data/test_market_data_manager.py
@@ -1615,3 +1615,38 @@ async def test_futures_basket_missing_warning_is_throttled(
 
     # Throttled: at most one emission for the burst (definitely not 25).
     assert len(records) <= 1, f"expected throttled (<=1) warning, got {len(records)}"
+
+
+async def test_stale_unsubscribed_token_tick_drops_quietly(
+    broker: DummyBroker, ws: DummyWebSocket
+) -> None:
+    # A tick for a token NOT in the desired set (post-rotation artifact) must drop
+    # at DEBUG as stale_unsubscribed_token, not WARNING as unmapped_token.
+    import logging as _logging
+
+    manager = MarketDataManager(broker, ws)
+    manager._desired_tokens = {111}  # token 999 is NOT desired
+
+    levels: dict[str, int] = {}
+
+    class _Cap(_logging.Handler):
+        def emit(self, record: _logging.LogRecord) -> None:
+            msg = record.getMessage()
+            if "MDM_TICK_DROPPED" in msg:
+                if "stale_unsubscribed_token" in msg:
+                    levels["stale"] = record.levelno
+                elif "unmapped_token" in msg:
+                    levels["unmapped"] = record.levelno
+
+    h = _Cap(); h.setLevel(_logging.DEBUG)
+    root = _logging.getLogger()
+    root.addHandler(h); _prev = root.level; root.setLevel(_logging.DEBUG)
+    try:
+        out = manager._normalize_ws_tick({"instrument_token": 999, "last_price": 100.0})
+    finally:
+        root.removeHandler(h); root.setLevel(_prev)
+
+    # Tick for a non-desired token is dropped (returns None) ...
+    assert out is None
+    # ... and must NOT be logged as the WARNING-level unmapped_token anomaly.
+    assert "unmapped" not in levels, "non-desired token must not warn as unmapped"


### PR DESCRIPTION
## Symptom (live-hours log 2026-06-16 09:03-09:13)
10x `MDM_TICK_DROPPED reason=unmapped_token` WARNINGs for option tokens 12955906 (3850CE), 12956162 (3850PE), 12955394 (3800CE), 12955650 (3800PE).

## Root cause
During basket rotation, `_replace_desired_tokens_from_basket` prunes the token->symbol mapping for tokens removed from the desired set, then unsubscribes them from the WS via `_reconcile_ws_subscriptions()`. The broker streams a few more ticks for those just-removed context-option tokens before the unsubscribe lands, so they arrive with no mapping and drop. The dropped tokens are **never the active selected pair** (selected was 24000 then 23950; drops were 3850/3800 neighbour context) — so dropping is correct; the only issue was logging an expected rotation artifact at WARNING.

## Fix (minimal, no new state)
At the drop site: if the token is **not** in `self._desired_tokens`, it is an expected stale post-unsubscribe tick -> log at DEBUG (`reason=stale_unsubscribed_token`). A token that IS still desired but unmapped remains a genuine anomaly -> WARNING as before.

## Not bugs (verified)
`outside_session` blocker at 09:03-09:12 is correct (NSE pre-open 09:00-09:15). `BASKET_SELECTED_PAIR_REPAIRED`/`ACTIVE_SELECTION_DRIFT_CORRECTED` are the rotation working as designed.

## Validation
- New async test (discrimination-verified): non-desired token tick drops (returns None) and is not warned as unmapped.
- Full suite: **2269 passed, 1 skipped** (1 pre-existing unrelated isolation failure in `test_runtime_history_orchestration` deselected — fails identically on clean main at 371b284; tracked as separate follow-up).