### PR TITLE
fix: option quote_age_unknown wrongly blocks live arming

### DIFF
--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -2071,6 +2071,14 @@ class MarketDataManager:
                 report["missing"].append(f"{sym}:token_missing")
                 report["hard_ready"] = False
             quote = self.get_latest_tick(sym) or self.get_latest_tick(canonical) or self.get_quote(sym) or self.get_quote(canonical)
+            if isinstance(quote, dict) and quote.get("tick_age_s") is None and quote.get("age_s") is None and not quote.get("timestamp_ms") and not quote.get("last_tick_ts_ms"):
+                # The tick/quote dict may carry bid/ask but no age field, which makes
+                # evaluate_quote_readiness report quote_age_unknown and wrongly block a
+                # selected option. MDM already tracks the last quote timestamp, so
+                # surface it (read-only copy) to let freshness be evaluated.
+                _ts_ms = self._last_quote_ts_ms.get(canonical) or self._last_quote_ts_ms.get(sym)
+                if _ts_ms:
+                    quote = {**quote, "timestamp_ms": float(_ts_ms)}
             qr = evaluate_quote_readiness(canonical, quote, max_spread_pct=float(os.getenv("OPTION_MAX_SPREAD_PCT", "10") or 10), max_age_s=self._option_stale_seconds)
             entry["ltp_ready"] = qr.ltp_ready
             entry["depth_available"] = qr.depth_available

--- a/tests/data/test_market_data_manager.py
+++ b/tests/data/test_market_data_manager.py
@@ -1650,3 +1650,25 @@ async def test_stale_unsubscribed_token_tick_drops_quietly(
     assert out is None
     # ... and must NOT be logged as the WARNING-level unmapped_token anomaly.
     assert "unmapped" not in levels, "non-desired token must not warn as unmapped"
+
+
+async def test_quote_with_tracked_timestamp_is_fresh_not_unknown() -> None:
+    # Regression: a selected option with valid bid/ask but no age field was reported
+    # quote_age_unknown -> tradable_quote_not_ready -> blocked arming, even though
+    # MDM tracks the quote timestamp. evaluate_quote_readiness must treat an injected
+    # epoch-ms timestamp as fresh.
+    import time as _time
+    from nifty_scalper_bot.execution.readiness import evaluate_quote_readiness
+
+    base = {"ltp": 100.0, "bid": 99.5, "ask": 100.5, "bid_qty": 50, "ask_qty": 50}
+
+    # Without any age/timestamp -> quote_age_unknown (the pre-fix symptom).
+    qr_unknown = evaluate_quote_readiness("NFO:NIFTY2661623900CE", base, max_age_s=30.0)
+    assert qr_unknown.reason == "quote_age_unknown"
+    assert qr_unknown.tradable_quote_ready is False
+
+    # With the MDM-tracked epoch-ms timestamp injected -> ready.
+    fresh = {**base, "timestamp_ms": _time.time() * 1000.0}
+    qr_fresh = evaluate_quote_readiness("NFO:NIFTY2661623900CE", fresh, max_age_s=30.0)
+    assert qr_fresh.reason == "ready"
+    assert qr_fresh.tradable_quote_ready is True


### PR DESCRIPTION
## Symptom (live log 2026-06-16 10:07-10:08, market open)
Bot never arms: `READINESS_BLOCKER_SUMMARY primary_blocker=selected_option_history_cold`, `DEFERRED_BASKET_RETRY attempt 15-17/160`. But in the same instant `SELECTED_OPTION_HISTORY_READINESS both_ready=True` and `LIVE_READINESS_COMPUTED ce_ltp_fresh=True pe_ltp_fresh=True`. The real blockers were `NIFTY...CE:tradable_quote_not_ready:quote_age_unknown` (and PE) — history was ready; the `history_cold` label was misleading.

## Root cause
In MDM's hard-readiness scan the selected-option quote dict (from `get_latest_tick`/`get_quote`) carries valid bid/ask but **no age field** (`tick_age_s`/`age_s`/`timestamp_ms`/`last_tick_ts_ms`). `evaluate_quote_readiness` (execution/readiness.py:381-388) then can't confirm freshness and conservatively returns `quote_age_unknown` -> `tradable_quote_ready=False` -> selected option not tradable -> `hard_ready=False` -> never arms. MDM nevertheless tracks the quote timestamp in `self._last_quote_ts_ms` (epoch-ms via `time.time()*1000`).

## Fix (minimal, no new state)
At the readiness call site, when the quote dict lacks any age/timestamp field, inject MDM's tracked epoch-ms timestamp (read-only copy) as `timestamp_ms` so `evaluate_quote_readiness` computes a real age. epoch-ms satisfies its `>10_000_000_000` guard, so `age = now - ts/1000` is correct. If no tracked ts exists, behavior is unchanged.

## Validation
- New async test (discrimination-verified): bid/ask quote with no age field -> `quote_age_unknown` (not ready); same quote + injected epoch-ms `timestamp_ms` -> `ready`.
- Full suite: **2270 passed, 1 skipped** (1 pre-existing unrelated isolation failure deselected; fails identically on clean main).

## Out of scope (separate follow-up)
`RUNNER_OPTION_VOLUME_CLAMPED` — option cumulative volume (e.g. 163M) clamped to 1M; a volume-signal accuracy issue, not an arming blocker.