### PR TITLE
perf: make MDM tick cache length env-tunable for low-memory hosts

### DIFF
--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -295,7 +295,15 @@ class MarketDataManager:
         self._resolver = resolver
         self._logger = get_logger(__name__)
         # FIX: Initialize cache_len before it is used
-        self._cache_len = cache_len
+        # Per-symbol tick deque length. Defaults to 1000 (unchanged). On
+        # memory-constrained hosts (e.g. a 1.9GB Lightsail box) this can be
+        # lowered via MDM_TICK_CACHE_LEN to cut per-symbol memory without code
+        # changes; a scalper building 1-minute bars rarely needs 1000 raw ticks.
+        try:
+            _env_cache_len = int(os.getenv("MDM_TICK_CACHE_LEN", "0") or 0)
+        except (TypeError, ValueError):
+            _env_cache_len = 0
+        self._cache_len = _env_cache_len if _env_cache_len > 0 else cache_len
 
         # FIX: Initialize duplicate window (Missing in your file, causing the crash)
         self._duplicate_window = self._parse_float_env(

--- a/tests/data/test_market_data_manager.py
+++ b/tests/data/test_market_data_manager.py
@@ -1672,3 +1672,15 @@ async def test_quote_with_tracked_timestamp_is_fresh_not_unknown() -> None:
     qr_fresh = evaluate_quote_readiness("NFO:NIFTY2661623900CE", fresh, max_age_s=30.0)
     assert qr_fresh.reason == "ready"
     assert qr_fresh.tradable_quote_ready is True
+
+
+async def test_tick_cache_len_env_override(monkeypatch) -> None:
+    # Default cache_len is unchanged; MDM_TICK_CACHE_LEN lowers it on
+    # memory-constrained hosts without code changes.
+    monkeypatch.delenv("MDM_TICK_CACHE_LEN", raising=False)
+    assert MarketDataManager()._cache_len == 1000
+    monkeypatch.setenv("MDM_TICK_CACHE_LEN", "250")
+    assert MarketDataManager()._cache_len == 250
+    # invalid value falls back to the default
+    monkeypatch.setenv("MDM_TICK_CACHE_LEN", "notanint")
+    assert MarketDataManager()._cache_len == 1000


### PR DESCRIPTION
## Two parts: (1) trading-log audit result, (2) memory optimization

### Trading log (2026-06-16 10:22-10:23) — no functional bug
The arming fix (#583) worked: `live_orders_armed=True`, `ORDER_PATH_ENTERED` on the selected pair (23900/23950CE), `final_ready=True`. The `option_token_missing` entries are all for **non-selected neighbour strikes** (24000 while the committed basket is 23900) — correct defensive rejection of out-of-basket signals, not a defect. `RUNNER_OPTION_VOLUME_CLAMPED` is a benign, already-defended volume-delta guard (tracked follow-up). No code fix needed for trading.

### Memory optimization (the actionable item)
Lightsail box is 1.9GB (942Mi used / 165Mi free; bot RSS ~362M) → dashboard slowness under memory pressure. MDM keeps `deque(maxlen=1000)` of raw ticks **per subscribed symbol** (~9-10 symbols). A scalper building 1-minute bars rarely needs 1000 raw ticks retained.

**Fix:** honor `MDM_TICK_CACHE_LEN` to override the per-symbol tick deque length. **Default stays 1000 (zero behavior change)**; set e.g. `MDM_TICK_CACHE_LEN=200` on the constrained host to cut per-symbol tick memory with no code change. Invalid/unset → default.

This is the only safe code-side memory lever. Deeper relief is operational (raise instance to 4GB, or split the dashboard to its own process) — no live-path monkey-patching.

### Validation
- New async test: default 1000; env override applied; invalid value falls back.
- Full suite: **2271 passed, 1 skipped** (1 pre-existing unrelated isolation failure deselected).