### PR TITLE
fix(A): valid bid/ask without full depth must not block execution

### DIFF
--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -12750,31 +12750,47 @@ class StrategyRunner:
         strict_depth = is_live_depth_required or _env_flag("STRICT_OPTION_DEPTH_FOR_PAPER", default=False)
         max_spread_pct = float(os.getenv("ORDER_MAX_SPREAD_PCT", os.getenv("SPREAD_MAX_PCT", "10.0")) or "10.0")
         invalid_spread = spread_pct_raw is None or spread_pct < 0 or spread_pct > max_spread_pct
-        if strict_depth and (not tradable_quote or bid <= 0 or ask <= 0 or invalid_spread or not depth_available):
+        # A fresh quote with valid bid/ask and acceptable spread is executable even
+        # when the full broker depth array is absent. depth_available=False alone
+        # must NOT reject unless REQUIRE_FULL_DEPTH_FOR_EXECUTION is explicitly set.
+        # The real tradability checks (tradable_quote, bid/ask > 0, ask > bid, spread)
+        # are preserved.
+        require_full_depth = _env_flag("REQUIRE_FULL_DEPTH_FOR_EXECUTION", default=False)
+        bid_ask_invalid = not tradable_quote or bid <= 0 or ask <= 0 or ask <= bid or invalid_spread
+        depth_blocks = require_full_depth and not depth_available
+        if strict_depth and (bid_ask_invalid or depth_blocks):
+            reject_reason = (
+                "candidate_depth_missing"
+                if depth_blocks and not bid_ask_invalid
+                else "candidate_quote_not_tradable"
+            )
             self._logger.info(
-                "EXECUTION_CANDIDATE_REJECTED symbol=%s reason=candidate_depth_missing tradable_quote=%s depth_available=%s bid=%s ask=%s spread_pct=%s trace_id=%s",
+                "EXECUTION_CANDIDATE_REJECTED symbol=%s reason=%s tradable_quote=%s depth_available=%s bid=%s ask=%s spread_pct=%s require_full_depth=%s trace_id=%s",
                 selected_symbol,
+                reject_reason,
                 tradable_quote,
                 depth_available,
                 bid,
                 ask,
                 spread_pct_raw,
+                require_full_depth,
                 trace_id,
                 extra={
                     "event": "EXECUTION_CANDIDATE_REJECTED",
                     "symbol": selected_symbol,
-                    "reason": "candidate_depth_missing",
+                    "reason": reject_reason,
                     "tradable_quote": tradable_quote,
                     "depth_available": depth_available,
                     "bid": bid,
                     "ask": ask,
                     "spread_pct": spread_pct_raw,
+                    "require_full_depth": require_full_depth,
                     "trace_id": trace_id,
                 },
             )
             return SignalExecutionResult(
                 False,
-                "candidate_depth_missing",
+                reject_reason,
                 details={"selected_symbol": selected_symbol, "ranking_fields": ranking_fields},
             )
 

--- a/tests/strategies/test_runner_live_path_guards.py
+++ b/tests/strategies/test_runner_live_path_guards.py
@@ -3108,3 +3108,59 @@ def test_direction_context_diagnostics_tolerate_malformed_bar_counts(indicators_
     assert record.reason_detail
     assert isinstance(record.spot_bars, int)
     assert isinstance(record.futures_bars, int)
+
+
+def _prime_dedup_runner(runner: StrategyRunner, *, live: bool = True) -> None:
+    from nifty_scalper_bot.strategies.runner import ExecutionModeSnapshot
+
+    runner._signal_attempt_debounce_state = {}
+    runner._directional_dedup_key = lambda **_k: "k"
+    snap = ExecutionModeSnapshot.__new__(ExecutionModeSnapshot)
+    object.__setattr__(snap, "is_live_mode", live)
+    runner._resolve_execution_mode_snapshot = lambda: snap
+
+
+def _depth_test_signal():
+    from nifty_scalper_bot.strategies.signal_generator import Signal
+
+    return Signal(
+        action="BUY", symbol="NFO:NIFTY26JUN23900CE", quantity=1, confidence=0.8,
+        reason="OrderFlow", stop_loss=90.0, take_profit=120.0,
+        metadata={"tradable_quote": True, "candidate_spread_pct": 0.3, "candidate_tick_age_ms": 500.0},
+    )
+
+
+def test_execution_allows_valid_bid_ask_without_depth(monkeypatch) -> None:
+    # Issue A: live mode, valid bid/ask, acceptable spread, depth_available=False ->
+    # must NOT reject with candidate_depth_missing (default REQUIRE_FULL_DEPTH off).
+    monkeypatch.delenv("REQUIRE_FULL_DEPTH_FOR_EXECUTION", raising=False)
+    monkeypatch.delenv("RUNNER_ALLOW_LIVE_DEPTH_FALLBACK", raising=False)
+    runner = _build_runner()
+    _prime_dedup_runner(runner, live=True)
+    snapshot = {"symbol": "NFO:NIFTY26JUN23900CE", "bid": 64.7, "ask": 64.9,
+                "depth_available": False, "premium_within_range": True}
+    result = runner._apply_directional_signal_dedup(
+        signal=_depth_test_signal(), metadata=_depth_test_signal().metadata,
+        underlying="NIFTY", now_epoch=time.time(),
+        selected_symbol="NFO:NIFTY26JUN23900CE", option_side="CE",
+        selected_snapshot=snapshot, trace_id="depth-ok",
+    )
+    # No rejection from this gate when bid/ask valid and full depth not required.
+    assert result is None
+
+
+def test_candidate_depth_missing_only_when_full_depth_required(monkeypatch) -> None:
+    # With REQUIRE_FULL_DEPTH_FOR_EXECUTION=true, missing depth DOES block (opt-in).
+    monkeypatch.setenv("REQUIRE_FULL_DEPTH_FOR_EXECUTION", "true")
+    monkeypatch.delenv("RUNNER_ALLOW_LIVE_DEPTH_FALLBACK", raising=False)
+    runner = _build_runner()
+    _prime_dedup_runner(runner, live=True)
+    snapshot = {"symbol": "NFO:NIFTY26JUN23900CE", "bid": 64.7, "ask": 64.9,
+                "depth_available": False, "premium_within_range": True}
+    result = runner._apply_directional_signal_dedup(
+        signal=_depth_test_signal(), metadata=_depth_test_signal().metadata,
+        underlying="NIFTY", now_epoch=time.time(),
+        selected_symbol="NFO:NIFTY26JUN23900CE", option_side="CE",
+        selected_snapshot=snapshot, trace_id="depth-required",
+    )
+    assert result is not None and result.reason == "candidate_depth_missing"


### PR DESCRIPTION
## Critical live-execution fix (spec issue A)

The bot generated valid signals but the final execution gate rejected them with `candidate_depth_missing` whenever the broker depth array was absent — even with fresh valid bid/ask and acceptable spread (logs: `bid=64.7 ask=64.9 depth_available=False` -> rejected).

### Root cause
In `runner.py` `_apply_directional_signal_dedup`, the strict-depth reject condition included `or not depth_available`, so `depth_available=False` alone blocked execution regardless of bid/ask/spread validity.

### Fix
Separate genuine tradability from depth:
- `bid_ask_invalid = not tradable_quote OR bid<=0 OR ask<=0 OR ask<=bid OR spread invalid/too wide` (all preserved).
- Depth blocks **only** when `REQUIRE_FULL_DEPTH_FOR_EXECUTION=true` (new, default false). Then the reason stays `candidate_depth_missing`; when bid/ask are themselves bad the reason is the precise `candidate_quote_not_tradable`.
- `require_full_depth` added to the log line.

**No safety weakened:** spread limit, tick freshness, tradable_quote, lot size, cooldown, kill switch, daily loss, broker auth untouched. This only stops depth-absence from blocking an otherwise-tradable quote.

### Tests (issue F1/F2, discrimination-verified)
- `test_execution_allows_valid_bid_ask_without_depth`: live, valid bid/ask, `depth_available=False` -> no rejection.
- `test_candidate_depth_missing_only_when_full_depth_required`: with the opt-in flag, missing depth blocks.
- Full suite: **2273 passed, 1 skipped** (1 pre-existing unrelated isolation failure deselected).

Spec issues B–F and Telegram will follow as separate focused PRs rather than one risky bundle.