### PR TITLE
fix: clear webhook + drop pending updates before Telegram polling

### DIFF
--- a/src/nifty_scalper_bot/notifications/telegram_controller.py
+++ b/src/nifty_scalper_bot/notifications/telegram_controller.py
@@ -648,7 +648,20 @@ class TelegramBot:
             await self.application.start()
             if self.application.updater is not None:
                 log.info("TELEGRAM_POLLING_START_REQUESTED")
-                await self.application.updater.start_polling()
+                # Guarantee polling mode: a leftover webhook makes getUpdates return
+                # 409 Conflict and silently kills command polling (commands appear
+                # unresponsive, especially after a restart). Clearing it and dropping
+                # the stale backlog first makes start_polling reliable. Mirrors the
+                # fallback/manual paths which already do this.
+                try:
+                    await self.application.bot.delete_webhook(drop_pending_updates=True)
+                except Exception as _wh_exc:  # noqa: BLE001
+                    log.warning(
+                        "telegram_delete_webhook_failed err=%s",
+                        _wh_exc,
+                        extra={"event": "telegram_delete_webhook_failed"},
+                    )
+                await self.application.updater.start_polling(drop_pending_updates=True)
                 log.info("TELEGRAM_POLLING_STARTED")
             await self._safe_send("🤖 Telegram bot started")
             log.info("Telegram bot started")

--- a/tests/notifications/test_telegram_start_idempotent.py
+++ b/tests/notifications/test_telegram_start_idempotent.py
@@ -42,3 +42,31 @@ async def test_handlers_registered_flag_guards_double_registration() -> None:
     # second call is a no-op (would raise if it tried to re-add on a real app twice)
     bot._register_handlers()
     assert bot._handlers_registered is True
+
+
+async def test_start_clears_webhook_and_drops_pending_before_polling() -> None:
+    # Regression: operator commands were unresponsive because start_polling ran
+    # without first clearing a possible webhook / stale backlog, causing a 409
+    # Conflict on getUpdates. start() must delete the webhook (drop_pending=True)
+    # and start polling with drop_pending_updates=True.
+    from unittest.mock import AsyncMock, MagicMock
+
+    deps = TelegramDeps(token="dummy", chat_id=12345, app_version="test")
+    bot = TelegramBot(deps)
+
+    app = MagicMock()
+    app.initialize = AsyncMock()
+    app.start = AsyncMock()
+    app.bot.delete_webhook = AsyncMock()
+    app.updater = MagicMock()
+    app.updater.start_polling = AsyncMock()
+    bot.application = app
+    bot._register_handlers = lambda: None  # type: ignore[method-assign]
+    bot._safe_send = AsyncMock()  # type: ignore[method-assign]
+    bot._ensure_alert_worker = lambda: None  # type: ignore[method-assign]
+    bot._bg_task_started = True  # skip heartbeat task creation
+
+    await bot.start()
+
+    app.bot.delete_webhook.assert_awaited_once_with(drop_pending_updates=True)
+    app.updater.start_polling.assert_awaited_once_with(drop_pending_updates=True)


### PR DESCRIPTION
## Root-cause fix: operator commands not responding

**Symptom:** Telegram bot sends messages but does not react to commands, often after a restart.

**Root cause** (`telegram_controller.py` `start()`): the primary polling path called `updater.start_polling()` **without** first deleting any existing webhook and without dropping the pending-update backlog. If a webhook is set (or left over), Telegram returns **409 Conflict** on `getUpdates` and polling silently dies → commands never arrive. The fallback/manual polling paths in this same file already call `delete_webhook(drop_pending_updates=True)`; only the primary `start()` path missed it.

**Fix:** before `start_polling()`, call `bot.delete_webhook(drop_pending_updates=True)` (guarded) and pass `drop_pending_updates=True` to `start_polling()`. Guarantees clean polling mode and clears stale backlog, matching the other paths. `start()` stays idempotent (PR #576) and is still started early.

**Test (async, discrimination-verified):** `start()` awaits `delete_webhook(drop_pending_updates=True)` then `start_polling(drop_pending_updates=True)`. Full suite: **2274 passed, 1 skipped**.