### PR TITLE
Fix residual single-candidate premium override and tighten single-vote overrides

### DIFF
--- a/src/nifty_scalper_bot/core/strategy_manager.py
+++ b/src/nifty_scalper_bot/core/strategy_manager.py
@@ -4008,14 +4008,17 @@ class StrategyManager(_BaseStrategyManager):
             metadata["is_selected_option"] = selected_option
             metadata["selected_ok_reason"] = selected_ok_reason
             threshold_passed = bool(raw_trigger_score >= score_min and best_vote.confidence >= conf_min and selected_ok and not vetoed)
-            # Issue E: STRATEGY_ALLOW_SINGLE_VOTE_SCALP only governs the generic
-            # near-ATM scalp fallback. High-conviction and selected-option single
-            # votes are intentionally allowed independently (a single trigger on the
-            # SELECTED ATM option that cleared all gates is the core scalp). To let
-            # an operator disable EVERY single-vote path, these now have their own
-            # explicit flags, defaulting true so behavior is unchanged.
-            allow_high_conviction = str(os.getenv("STRATEGY_ALLOW_SINGLE_VOTE_HIGH_CONVICTION", "true")).lower() in {"1", "true", "yes", "on"}
-            allow_selected_option = str(os.getenv("STRATEGY_ALLOW_SINGLE_VOTE_SELECTED_OPTION", "true")).lower() in {"1", "true", "yes", "on"}
+            # STRATEGY_ALLOW_SINGLE_VOTE_SCALP=false is the master default block.
+            # Single-vote high-conviction/selected-option paths require explicit,
+            # narrower operator overrides to avoid accidental lone-vote approvals.
+            allow_high_conviction = self._env_bool(
+                "STRATEGY_ALLOW_HIGH_CONVICTION_SINGLE_VOTE",
+                self._env_bool("STRATEGY_ALLOW_SINGLE_VOTE_HIGH_CONVICTION", False),
+            )
+            allow_selected_option = self._env_bool(
+                "STRATEGY_ALLOW_SELECTED_OPTION_SINGLE_VOTE",
+                self._env_bool("STRATEGY_ALLOW_SINGLE_VOTE_SELECTED_OPTION", False),
+            )
             high_conviction_allowed = bool(raw_trigger_score >= single_high and selected_ok and not vetoed and allow_high_conviction)
             # A single trigger on the actually-SELECTED ATM option that already
             # cleared score/confidence/veto gates is the core scalp this platform
@@ -4090,7 +4093,7 @@ class StrategyManager(_BaseStrategyManager):
                 approval_path = "single_vote_high_conviction"
             elif scalp_fallback_allowed:
                 metadata_stage = "single_vote_scalp_controlled"
-                approval_path = "single_vote_fallback"
+                approval_path = approval_path_single or "single_vote_fallback"
             else:
                 allow_candidate_switch = str(os.getenv("STRATEGY_ALLOW_CANDIDATE_SWITCH_ON_HIGH_SCORE", "false")).lower() in {"1", "true", "yes", "on"}
                 max_candidate_switch_distance = float(os.getenv("CANDIDATE_SWITCH_MAX_DISTANCE_POINTS", "100") or "100")

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -13372,7 +13372,28 @@ class StrategyRunner:
                     bid_ask_ok = bid > 0 and ask > bid
                     allow_ltp_only = _env_flag("ALLOW_LTP_ONLY_CANDIDATE", default=False)
                     tradable = bool(lone.get("tradable_quote")) or bid_ask_ok or (allow_ltp_only and bool(lone.get("ltp_only_fallback")) and ltp > 0)
-                    premium_ok = self._trade_candidate_selector.min_option_premium <= ltp <= self._trade_candidate_selector.max_option_premium
+                    min_option_premium = float(self._trade_candidate_selector.min_option_premium)
+                    max_option_premium = float(self._trade_candidate_selector.max_option_premium)
+                    premium_dynamic_override = False
+                    dynamic_spread_pct = None
+                    if ltp < min_option_premium:
+                        dynamic_mid = (bid + ask) / 2.0 if bid_ask_ok else 0.0
+                        dynamic_spread_pct = ((ask - bid) / dynamic_mid * 100.0) if dynamic_mid > 0 else None
+                        dynamic_near_atm = bool(
+                            is_selected
+                            or strike_distance
+                            <= (50.0 * max(1, int(getattr(self._trade_candidate_selector, "option_strike_window_each_side", 2) or 2)))
+                        )
+                        premium_dynamic_override = bool(
+                            _env_flag("MIN_OPTION_PREMIUM_DYNAMIC", default=True)
+                            and ltp >= float(os.getenv("MIN_OPTION_PREMIUM_DYNAMIC_FLOOR", "25") or "25")
+                            and bid_ask_ok
+                            and is_fresh
+                            and dynamic_near_atm
+                            and dynamic_spread_pct is not None
+                            and dynamic_spread_pct <= float(os.getenv("MIN_OPTION_PREMIUM_DYNAMIC_MAX_SPREAD_PCT", "0.75") or "0.75")
+                        )
+                    premium_ok = bool((min_option_premium <= ltp <= max_option_premium) or premium_dynamic_override)
                     if not (is_selected and is_fresh and tradable and premium_ok and strike_distance <= float(os.getenv("PREMIUM_FALLBACK_MAX_STRIKE_DISTANCE", "100") or 100)):
                         basket_details = {
                             "symbol": signal.symbol,
@@ -13390,8 +13411,10 @@ class StrategyRunner:
                             "bid": bid,
                             "ask": ask,
                             "tick_age_s": tick_age_s,
-                            "min_option_premium": self._trade_candidate_selector.min_option_premium,
-                            "max_option_premium": self._trade_candidate_selector.max_option_premium,
+                            "min_option_premium": min_option_premium,
+                            "max_option_premium": max_option_premium,
+                            "premium_dynamic_override": premium_dynamic_override,
+                            "dynamic_spread_pct": dynamic_spread_pct,
                             "allow_ltp_only_candidate": allow_ltp_only,
                             "reason": "candidate_screen_failed",
                         }

--- a/tests/core/test_single_vote_scalp.py
+++ b/tests/core/test_single_vote_scalp.py
@@ -45,11 +45,44 @@ def test_selected_option_single_vote_can_be_disabled(monkeypatch):
     assert out is None
 
 
-def test_selected_option_single_vote_allowed_by_default(monkeypatch):
-    # Default (flags unset/true) preserves the core selected-option scalp.
+def test_single_vote_selected_option_requires_explicit_override(monkeypatch):
     monkeypatch.setenv('STRATEGY_ALLOW_SINGLE_VOTE_SCALP', 'false')
+    monkeypatch.delenv('STRATEGY_ALLOW_SELECTED_OPTION_SINGLE_VOTE', raising=False)
+    monkeypatch.delenv('STRATEGY_ALLOW_HIGH_CONVICTION_SINGLE_VOTE', raising=False)
     monkeypatch.delenv('STRATEGY_ALLOW_SINGLE_VOTE_SELECTED_OPTION', raising=False)
     monkeypatch.delenv('STRATEGY_ALLOW_SINGLE_VOTE_HIGH_CONVICTION', raising=False)
+    mgr = _mgr()
+    sig = Signal(action='BUY', symbol='NFO:NIFTY26MAY24100CE', quantity=1, confidence=0.7,
+                 reason='x', stop_loss=90, take_profit=110,
+                 metadata={'is_selected_option': True, 'spread_pct': 1.0})
+    trigger = StrategyVote(strategy='VWAPPro', side='CE', score=6.5, confidence=0.7,
+                           reasons=[], metadata={'role': 'trigger', 'raw_setup_score': 6.5, 'strategy_score': 6.5})
+    out = mgr._combine_strategy_votes(symbol=sig.symbol, signals=[(sig, trigger)],
+                                      indicators={'is_selected_option': True})
+    assert out is None
+
+
+def test_single_vote_disabled_blocks_high_conviction_by_default(monkeypatch):
+    monkeypatch.setenv('STRATEGY_ALLOW_SINGLE_VOTE_SCALP', 'false')
+    monkeypatch.delenv('STRATEGY_ALLOW_HIGH_CONVICTION_SINGLE_VOTE', raising=False)
+    monkeypatch.delenv('STRATEGY_ALLOW_SELECTED_OPTION_SINGLE_VOTE', raising=False)
+    monkeypatch.delenv('STRATEGY_ALLOW_SINGLE_VOTE_HIGH_CONVICTION', raising=False)
+    monkeypatch.delenv('STRATEGY_ALLOW_SINGLE_VOTE_SELECTED_OPTION', raising=False)
+    mgr = _mgr()
+    sig = Signal(action='BUY', symbol='NFO:NIFTY26MAY24100CE', quantity=1, confidence=0.95,
+                 reason='x', stop_loss=90, take_profit=110,
+                 metadata={'is_selected_option': True, 'spread_pct': 1.0})
+    trigger = StrategyVote(strategy='VWAPPro', side='CE', score=9.2, confidence=0.95,
+                           reasons=[], metadata={'role': 'trigger', 'raw_setup_score': 9.2, 'strategy_score': 9.2})
+    out = mgr._combine_strategy_votes(symbol=sig.symbol, signals=[(sig, trigger)],
+                                      indicators={'is_selected_option': True})
+    assert out is None
+
+
+def test_selected_option_single_vote_allows_explicit_override(monkeypatch):
+    monkeypatch.setenv('STRATEGY_ALLOW_SINGLE_VOTE_SCALP', 'false')
+    monkeypatch.setenv('STRATEGY_ALLOW_SELECTED_OPTION_SINGLE_VOTE', 'true')
+    monkeypatch.setenv('STRATEGY_ALLOW_HIGH_CONVICTION_SINGLE_VOTE', 'false')
     mgr = _mgr()
     sig = Signal(action='BUY', symbol='NFO:NIFTY26MAY24100CE', quantity=1, confidence=0.7,
                  reason='x', stop_loss=90, take_profit=110,

--- a/tests/strategies/test_runner_live_path_guards.py
+++ b/tests/strategies/test_runner_live_path_guards.py
@@ -1755,6 +1755,64 @@ def test_single_candidate_distance_fallback_from_strike_allows_selected_candidat
     assert result.reason != "candidate_basket_inadequate"
 
 
+def test_single_candidate_screen_uses_dynamic_premium_override(monkeypatch) -> None:
+    runner = _build_runner()
+    monkeypatch.setenv("EXECUTION_MODE", "LIVE")
+    monkeypatch.setenv("ENABLE_LIVE_TRADING", "true")
+    monkeypatch.setenv("ENABLE_LIVE", "true")
+    monkeypatch.setenv("PAPER__ENABLED", "false")
+    monkeypatch.setenv("SHADOW_MODE", "false")
+    monkeypatch.setenv("MIN_OPTION_PREMIUM_DYNAMIC", "true")
+    monkeypatch.setenv("MIN_OPTION_PREMIUM_DYNAMIC_FLOOR", "25")
+    monkeypatch.setenv("MIN_OPTION_PREMIUM_DYNAMIC_MAX_SPREAD_PCT", "0.75")
+    monkeypatch.setenv("PREMIUM_FALLBACK_MAX_STRIKE_DISTANCE", "100")
+    symbol = "NFO:NIFTY26MAY24050PE"
+    runner._trade_candidate_selector = TradeCandidateSelector(min_option_premium=40, max_option_premium=650)
+    runner._transition_execution_state = lambda *_args, **_kwargs: True  # type: ignore[method-assign]
+    runner._order_manager.submit_trade_plan = MagicMock(return_value="oid-dynamic-premium")  # type: ignore[attr-defined]
+    runner._market_data = MagicMock()
+    runner._market_data.get_symbol_snapshot.return_value = SimpleNamespace(
+        ltp=35.0, bid=34.95, ask=35.05, tick_age_s=0.2, real_ticks_last_60s=3, tradable_quote=True, source="ws"
+    )
+    runner._active_selected_pe = symbol
+    signal = Signal(
+        action="BUY",
+        symbol=symbol,
+        quantity=1,
+        confidence=0.9,
+        reason="OrderFlow",
+        stop_loss=30.0,
+        take_profit=48.0,
+        metadata={
+            "candidate_snapshots": [
+                {
+                    "symbol": symbol,
+                    "side": "PE",
+                    "strike": 24050,
+                    "atm_strike": 24050,
+                    "ltp": 35.0,
+                    "bid": 34.95,
+                    "ask": 35.05,
+                    "tick_age_s": 0.2,
+                    "real_ticks_last_60s": 3,
+                    "tradable_quote": True,
+                    "is_selected_option": True,
+                }
+            ],
+            "atm_strike": 24050,
+            "is_selected_option": True,
+        },
+    )
+    result = runner._handle_entry_signal_inner(
+        signal,
+        base_symbol=symbol,
+        trade_symbol=symbol,
+        trade_price=35.0,
+        timestamp=datetime.now(timezone.utc),
+        trace_id="trace-dynamic-premium",
+    )
+    assert result.reason != "candidate_basket_inadequate"
+
 def test_single_candidate_distance_fallback_rejects_far_strike(monkeypatch) -> None:
     runner = _build_runner()
     monkeypatch.setenv("EXECUTION_MODE", "LIVE")


### PR DESCRIPTION
### Motivation

- A one-item candidate screen in `StrategyRunner` used a static min/max premium check and could reject a low-premium but fresh, tight-spread, selected/near‑ATM option even though `TradeCandidateSelector` would have allowed it via dynamic premium override rules.
- Single-vote logic allowed high-conviction or selected-option single-vote approvals when the master scalp flag (`STRATEGY_ALLOW_SINGLE_VOTE_SCALP`) was false, leaving unintended lone-vote approvals.

### Description

- Mirror `TradeCandidateSelector` dynamic premium override in the single-candidate execution screen by replacing the static check with dynamic logic that honors `MIN_OPTION_PREMIUM_DYNAMIC`, `MIN_OPTION_PREMIUM_DYNAMIC_FLOOR`, and `MIN_OPTION_PREMIUM_DYNAMIC_MAX_SPREAD_PCT`, requires valid bid/ask, fresh tick, and near‑ATM/selected criteria so a low-premium tight ATM option is not blocked solely for being below the static floor (`src/nifty_scalper_bot/strategies/runner.py`).
- Introduce explicit operator override envs for single-vote paths and make them narrow by default: `STRATEGY_ALLOW_HIGH_CONVICTION_SINGLE_VOTE` and `STRATEGY_ALLOW_SELECTED_OPTION_SINGLE_VOTE`, with legacy env names used only as fallbacks; single-vote high-conviction/selected-option paths are blocked unless the specific override is explicitly enabled (`src/nifty_scalper_bot/core/strategy_manager.py`).
- Add and update focused tests: `test_single_candidate_screen_uses_dynamic_premium_override` and single-vote-related tests (`tests/strategies/test_runner_live_path_guards.py`, `tests/core/test_single_vote_scalp.py`) to cover dynamic premium override behavior and the tightened single-vote policy.
- Files changed: `src/nifty_scalper_bot/strategies/runner.py`, `src/nifty_scalper_bot/core/strategy_manager.py`, `tests/strategies/test_runner_live_path_guards.py`, `tests/core/test_single_vote_scalp.py`.

### Testing

- Ran the focused tests with `pytest tests/strategies/test_runner_live_path_guards.py tests/core/test_single_vote_scalp.py -q` and they passed.
- Ran full validation with `python -m compileall -q src && pytest -q` and the test suite passed.
- Automated test result summary: focused tests: passed; full `pytest`: passed; `compileall`: passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a310d4fe6bc8324b9277350e673a4f2)