### PR TITLE
Fix stale selected-option readiness blocker

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -8088,6 +8088,55 @@ async def _recompute_and_push_runtime_readiness(ctx: BotContext, *, reason: str)
     # datahub_bars excluded from gating min(): DataHub owns no history (PR #562).
     ce_bars = min(ce_mdm_bars, ce_runner_bars, ce_indicator_bars) if ce_status else 0
     pe_bars = min(pe_mdm_bars, pe_runner_bars, pe_indicator_bars) if pe_status else 0
+    selected_history_ready = bool(
+        selected_ce
+        and selected_pe
+        and ce_bars >= option_execution_min_bars
+        and pe_bars >= option_execution_min_bars
+    )
+    selected_history_blockers = {
+        "selected_option_history_cold",
+        "selected_ce_history_missing",
+        "selected_pe_history_missing",
+        "ce_eval_bars_missing",
+        "pe_eval_bars_missing",
+        "ce_exec_bars_missing",
+        "pe_exec_bars_missing",
+        "ce_exec_quote_or_history_not_ready",
+        "pe_exec_quote_or_history_not_ready",
+        "insufficient_bars",
+        "mdm_bars_missing",
+        "runner_bars_missing",
+        "indicator_bars_missing",
+    }
+    if selected_history_ready:
+        stale_history_blockers = [
+            blocker
+            for blocker in [*basket_missing, *status_blockers]
+            if blocker in selected_history_blockers
+        ]
+        if stale_history_blockers:
+            LOGGER.info(
+                "READINESS_BLOCKER_CLEARED blocker=selected_option_history_cold",
+                extra={
+                    "event": "READINESS_BLOCKER_CLEARED",
+                    "blocker": "selected_option_history_cold",
+                    "cleared_blockers": list(dict.fromkeys(stale_history_blockers)),
+                    "selected_ce": selected_ce,
+                    "selected_pe": selected_pe,
+                    "ce_bars_effective": ce_bars,
+                    "pe_bars_effective": pe_bars,
+                    "required_bars": option_execution_min_bars,
+                },
+            )
+        status_blockers = [
+            blocker for blocker in status_blockers if blocker not in selected_history_blockers
+        ]
+        basket_missing = [
+            blocker for blocker in basket_missing if blocker not in selected_history_blockers
+        ]
+        if not basket_missing:
+            basket_hard_ready = True
     ce_quote_fresh = bool(ce_status and (ce_status.live_tick_fresh or ce_status.tradable_quote))
     pe_quote_fresh = bool(pe_status and (pe_status.live_tick_fresh or pe_status.tradable_quote))
     ce_bid_ask_complete = bool(ce_status and ce_status.tradable_quote)
@@ -8119,10 +8168,11 @@ async def _recompute_and_push_runtime_readiness(ctx: BotContext, *, reason: str)
     if not futures_ready: missing.append('futures_history_missing')
     if not basket_hard_ready: missing.extend(basket_missing or ['active_basket_hydration_not_ready'])
     if not evaluation_ready: missing.append('eval_not_ready')
-    if ce_runner_bars < option_eval_min_live_bars or ce_indicator_bars < option_eval_min_live_bars: missing.append('ce_eval_bars_missing')
-    if pe_runner_bars < option_eval_min_live_bars or pe_indicator_bars < option_eval_min_live_bars: missing.append('pe_eval_bars_missing')
-    if ce_bars < option_execution_min_bars: missing.append('ce_exec_bars_missing')
-    if pe_bars < option_execution_min_bars: missing.append('pe_exec_bars_missing')
+    if not selected_history_ready:
+        if ce_runner_bars < option_eval_min_live_bars or ce_indicator_bars < option_eval_min_live_bars: missing.append('ce_eval_bars_missing')
+        if pe_runner_bars < option_eval_min_live_bars or pe_indicator_bars < option_eval_min_live_bars: missing.append('pe_eval_bars_missing')
+        if ce_bars < option_execution_min_bars: missing.append('ce_exec_bars_missing')
+        if pe_bars < option_execution_min_bars: missing.append('pe_exec_bars_missing')
     if ce_status and not ce_status.tradable_quote: missing.append('selected_ce_quote_missing')
     if pe_status and not pe_status.tradable_quote: missing.append('selected_pe_quote_missing')
     if ce_status and not ce_status.depth_available: missing.append('selected_ce_depth_missing')
@@ -8131,8 +8181,8 @@ async def _recompute_and_push_runtime_readiness(ctx: BotContext, *, reason: str)
     if not runner_running: missing.append('runner_not_running')
     if live_mode:
         if not market_open: missing.append('market_closed')
-        if not ce_exec_ready: missing.append('ce_exec_quote_or_history_not_ready')
-        if not pe_exec_ready: missing.append('pe_exec_quote_or_history_not_ready')
+        if not ce_exec_ready and not selected_history_ready: missing.append('ce_exec_quote_or_history_not_ready')
+        if not pe_exec_ready and not selected_history_ready: missing.append('pe_exec_quote_or_history_not_ready')
         if not context_exec_ready: missing.append('context_exec_not_ready')
         if not broker_ready: missing.append('broker_not_ready')
     normalized_decision = normalize_readiness_blockers(
@@ -8194,6 +8244,17 @@ async def _recompute_and_push_runtime_readiness(ctx: BotContext, *, reason: str)
     )
     LOGGER.info("LIVE_READINESS_COMPUTED selected_ce=%s selected_pe=%s ce_ltp_fresh=%s pe_ltp_fresh=%s ce_tick_age_s=%s pe_tick_age_s=%s ce_tradable_quote=%s pe_tradable_quote=%s ce_depth_available=%s pe_depth_available=%s ce_subscription_confirmed=%s pe_subscription_confirmed=%s ce_subscription_or_live_tick=%s pe_subscription_or_live_tick=%s ce_bars_effective=%s ce_mdm_bars=%s ce_runner_bars=%s pe_bars_effective=%s pe_mdm_bars=%s pe_runner_bars=%s data_hard_ready=%s evaluation_ready=%s live_orders_armed=%s ce_exec_ready=%s pe_exec_ready=%s execution_ready_by_symbol=%s live_block_reason=%s", selected_ce, selected_pe, ce_quote_fresh, pe_quote_fresh, getattr(_snapshot(selected_ce),'tick_age_s',None), getattr(_snapshot(selected_pe),'tick_age_s',None), _tradable_quote(selected_ce), _tradable_quote(selected_pe), bool(getattr(_snapshot(selected_ce),'depth_available',False)), bool(getattr(_snapshot(selected_pe),'depth_available',False)), _subscription_confirmed(selected_ce), _subscription_confirmed(selected_pe), _subscription_or_live_tick(selected_ce), _subscription_or_live_tick(selected_pe), ce_bars, ce_mdm_bars, ce_runner_bars, pe_bars, pe_mdm_bars, pe_runner_bars, data_hard_ready, evaluation_ready, live_orders_armed, ce_exec_ready, pe_exec_ready, execution_ready_by_symbol, block_reason, extra={"event":"LIVE_READINESS_COMPUTED","selected_ce":selected_ce,"selected_pe":selected_pe,"live_block_reason":block_reason,"primary_blocker":normalized_decision.primary_blocker,"secondary_blockers":normalized_decision.secondary_blockers,"market_mode":get_runtime_market_mode()})
     if ctx.strategy_runner is not None and hasattr(ctx.strategy_runner, 'set_runtime_readiness'):
+        try:
+            setattr(
+                ctx.strategy_runner,
+                "_runtime_readiness_recompute_callback",
+                lambda callback_reason: _recompute_and_push_runtime_readiness(
+                    ctx,
+                    reason=str(callback_reason or "strategy_eval_stall_watchdog"),
+                ),
+            )
+        except Exception:
+            LOGGER.debug("RUNNER_READINESS_CALLBACK_ATTACH_FAILED", exc_info=True)
         ctx.strategy_runner.set_runtime_readiness(data_hard_ready=bool(ctx.data_hard_ready), evaluation_ready=bool(ctx.evaluation_ready), live_orders_armed=bool(ctx.live_orders_armed), reason=str(ctx.live_block_reason or reason), selected_ce=selected_ce, selected_pe=selected_pe, atm_strike=basket.get('atm_strike'), option_symbols=option_symbols, execution_ready_by_symbol=dict(getattr(ctx, "execution_ready_by_symbol", {}) or {}))
 
 

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -783,6 +783,8 @@ class StrategyRunner:
         self._runtime_execution_ready_by_symbol: dict[str, bool] = {}
         self._runtime_symbol_last_ready_at: dict[str, float] = {}
         self._runtime_readiness_reason: str | None = None
+        self._runtime_readiness_recompute_callback: Callable[[str], Any] | None = None
+        self._eval_stall_recovery_attempted = False
         self._last_trade_decision: TradeDecisionSnapshot | None = None
         self._runtime_indicators: dict[str, dict[str, Any]] = {}
         self._last_direction_context: dict[str, Any] | None = None
@@ -6668,6 +6670,11 @@ class StrategyRunner:
                         "stall_sec": round(now - self._last_global_eval_ts, 1),
                     },
                 )
+                if not self._eval_stall_recovery_attempted:
+                    self._eval_stall_recovery_attempted = True
+                    self._recover_strategy_eval_stall_once(now)
+        elif self._eval_stall_recovery_attempted and not eval_stalled:
+            self._eval_stall_recovery_attempted = False
 
         now_wall = time.time()
         stale_count = 0
@@ -6780,6 +6787,43 @@ class StrategyRunner:
                     self._logger.exception(
                         "CRITICAL: Failure in StrategyRunner._health_watchdog.reconnect"
                     )
+
+    # Watchdog recovery for a genuine live eval stall while ticks are flowing.
+    def _recover_strategy_eval_stall_once(self, now: float | None = None) -> None:
+        """Recompute readiness and nudge evaluation after one genuine live stall."""
+        now = time.monotonic() if now is None else now
+        self._logger.warning(
+            "STRATEGY_EVAL_STALL_RECOVERY_ONCE stall_sec=%s action=recompute_readiness_and_restart_loop",
+            round(now - self._last_global_eval_ts, 1),
+            extra={
+                "event": "STRATEGY_EVAL_STALL_RECOVERY_ONCE",
+                "stall_sec": round(now - self._last_global_eval_ts, 1),
+                "action": "recompute_readiness_and_restart_loop",
+            },
+        )
+        callback = getattr(self, "_runtime_readiness_recompute_callback", None)
+        if callable(callback):
+            try:
+                result = callback("strategy_eval_stall_watchdog")
+                if inspect.isawaitable(result):
+                    try:
+                        loop = asyncio.get_running_loop()
+                    except RuntimeError:
+                        asyncio.run(result)
+                    else:
+                        loop.create_task(result)
+            except Exception:
+                self._logger.exception(
+                    "STRATEGY_EVAL_STALL_READINESS_RECOMPUTE_FAILED"
+                )
+        try:
+            self.start()
+        except Exception:
+            self._logger.exception("STRATEGY_EVAL_STALL_LOOP_RESTART_FAILED")
+        # Reset per-symbol eval throttles once so the next flowing tick can
+        # enter _on_tick instead of being held behind stale same-bar state.
+        self._last_eval_ts.clear()
+        self._last_periodic_eval_at_by_symbol.clear()
 
     # ✅ FIX: New Method to Prime Indicators
     async def _backfill_history(self) -> None:

--- a/tests/core/test_live_readiness_recompute.py
+++ b/tests/core/test_live_readiness_recompute.py
@@ -19,6 +19,10 @@ class _Runner:
     def set_active_trading_universe(self, basket):
         self.basket = basket
 
+    def sync_history_from_mdm(self, symbol, **kwargs):
+        bars = len(self._indicator_engine.get_history(symbol) or [])
+        return SimpleNamespace(success=True, runner_bars=bars, indicator_bars=bars)
+
 
 def _ctx(mdm):
     return SimpleNamespace(
@@ -29,6 +33,10 @@ def _ctx(mdm):
         order_manager=object(),
         active_trading_universe={},
     )
+
+
+async def _ok_history(*args, **kwargs):
+    return SimpleNamespace(failure_reason=None, fetched_rows=0, accepted_rows=0)
 
 
 def test_selected_options_derived_from_basket() -> None:
@@ -171,3 +179,75 @@ async def test_selected_option_ltp_only_blocks_live_execution_bid_ask_missing(mo
         'NFO:NIFTY24600PE': False,
     }
     assert ctx.live_block_reason == 'execution_not_armed:selected_option_quote_missing'
+
+
+@pytest.mark.asyncio
+async def test_selected_option_history_cold_clears_when_both_selected_histories_ready(monkeypatch, caplog) -> None:
+    monkeypatch.setattr(app, 'get_market_state', lambda: app.MarketState.OPEN)
+
+    class _Snap:
+        ltp = 100.0
+        tick_age_s = 1.0
+        bid = 99.0
+        ask = 101.0
+        tradable_quote = True
+        depth_available = True
+
+    mdm = SimpleNamespace(
+        get_ohlc_bars=lambda s, limit=None: list(range(118)),
+        get_symbol_snapshot=lambda s: _Snap(),
+        hydrate_active_contract_basket=lambda basket=None: {
+            "hard_ready": False,
+            "missing": ["selected_option_history_cold"],
+            "symbols": {},
+        },
+        ensure_history=_ok_history,
+    )
+    ctx = _ctx(mdm)
+    ctx.active_symbol_tokens = {'NFO:NIFTY24600CE': 1, 'NFO:NIFTY24600PE': 2}
+    ctx.active_trading_universe = {
+        'spot_symbol': 'NSE:NIFTY',
+        'selected_ce': 'NFO:NIFTY24600CE',
+        'selected_pe': 'NFO:NIFTY24600PE',
+        'option_symbols': ['NFO:NIFTY24600CE', 'NFO:NIFTY24600PE'],
+    }
+
+    with caplog.at_level('INFO'):
+        await app._recompute_and_push_runtime_readiness(ctx, reason='test')
+
+    assert 'selected_option_history_cold' not in (ctx.live_block_reason or '')
+    assert any('READINESS_BLOCKER_CLEARED blocker=selected_option_history_cold' in rec.message for rec in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_live_orders_armed_becomes_true_after_history_ready(monkeypatch) -> None:
+    monkeypatch.setattr(app, 'get_market_state', lambda: app.MarketState.OPEN)
+
+    class _Snap:
+        ltp = 100.0
+        tick_age_s = 1.0
+        bid = 99.0
+        ask = 101.0
+        tradable_quote = True
+        depth_available = True
+
+    mdm = SimpleNamespace(
+        get_ohlc_bars=lambda s, limit=None: list(range(118)),
+        get_symbol_snapshot=lambda s: _Snap(),
+        hydrate_active_contract_basket=lambda basket=None: {"hard_ready": True, "missing": [], "symbols": {}},
+        ensure_history=_ok_history,
+    )
+    ctx = _ctx(mdm)
+    ctx.active_symbol_tokens = {'NFO:NIFTY24600CE': 1, 'NFO:NIFTY24600PE': 2}
+    ctx.active_trading_universe = {
+        'spot_symbol': 'NSE:NIFTY',
+        'selected_ce': 'NFO:NIFTY24600CE',
+        'selected_pe': 'NFO:NIFTY24600PE',
+        'option_symbols': ['NFO:NIFTY24600CE', 'NFO:NIFTY24600PE'],
+    }
+
+    await app._recompute_and_push_runtime_readiness(ctx, reason='test')
+
+    assert ctx.live_orders_armed is True
+    assert ctx.live_block_reason is None
+    assert ctx.strategy_runner.calls[-1]['live_orders_armed'] is True

--- a/tests/strategies/test_runner_live_eval.py
+++ b/tests/strategies/test_runner_live_eval.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
+import time
+from collections import defaultdict
 
 from nifty_scalper_bot.strategies.runner import StrategyRunner
 
@@ -90,3 +92,28 @@ def test_set_runtime_readiness_logs_without_typeerror(caplog) -> None:
             selected_pe="NFO:NIFTY26MAY24200PE",
         )
     assert any("RUNNER_STARTUP_READINESS_UPDATE" in rec.message for rec in caplog.records)
+
+
+def test_strategy_eval_stall_recomputes_readiness_once(monkeypatch) -> None:
+    calls: list[str] = []
+    starts: list[bool] = []
+    runner = object.__new__(StrategyRunner)
+    runner.ready = True
+    runner._last_tick_seen_ts = time.monotonic()
+    runner._last_global_eval_ts = time.monotonic() - 91.0
+    runner._eval_stall_recovery_attempted = False
+    runner._runtime_readiness_recompute_callback = lambda reason: calls.append(reason)
+    runner._logger = logging.getLogger('test.stall.recovery')
+    runner._candle_engines = {}
+    runner._active_symbols = set()
+    runner._last_eval_ts = defaultdict(float)
+    runner._last_periodic_eval_at_by_symbol = {'NFO:XCE': time.monotonic()}
+    runner.start = lambda: starts.append(True)
+
+    monkeypatch.setattr('nifty_scalper_bot.strategies.runner.is_market_open_now', lambda: True)
+
+    runner._health_watchdog()
+    runner._health_watchdog()
+
+    assert calls == ['strategy_eval_stall_watchdog']
+    assert starts == [True]


### PR DESCRIPTION
### Motivation

- The app could carry a stale `selected_option_history_cold` blocker into final readiness normalization even after the selected CE and PE had synced sufficient effective bars, causing `LIVE_READINESS_COMPUTED` to report `live_orders_armed=False` despite `SELECTED_OPTION_HISTORY_READINESS` showing both ready. 
- The strategy runner watchdog logged genuine evaluation stalls (>90s while ticks flowing) but did not attempt a one-shot recovery or readiness recompute to nudge evaluation back into service.

### Description

- In `core/app.py` detect when both selected CE and PE have effective bars >= required execution bars, remove related stale selected-option history blockers from the hydration/basket blocker lists, set `basket_hard_ready` when appropriate, and emit `READINESS_BLOCKER_CLEARED blocker=selected_option_history_cold` for observability.
- Ensure the final `READINESS_BLOCKER_SUMMARY` / `LIVE_READINESS_COMPUTED` are built from the same, post-clear blocker list so `live_orders_armed` reflects the canonical readiness state.
- Attach a readiness-recompute callback from the app into the `StrategyRunner` so external watchers (watchdog) can request a readiness recompute asynchronously.
- In `strategies/runner.py` add a one-shot watchdog recovery for genuine eval stalls (>90s while ticks are flowing) that recomputes readiness via the attached callback, attempts a single `start()` to nudge the loop, and clears per-symbol eval throttles so the next tick can be processed.
- Add unit tests: `selected_option_history_cold_clears_when_both_selected_histories_ready`, `live_orders_armed_becomes_true_after_history_ready`, and `strategy_eval_stall_recomputes_readiness_once`, and small compatibility helpers for test harnesses.

### Testing

- Ran focused tests: `pytest -q tests/core/test_live_readiness_recompute.py tests/strategies/test_runner_live_eval.py` and the two targeted test invocations for the new cases, and all passed.
- Ran full repository checks: `python -m compileall -q src && pytest -q`, and the run completed successfully with no failures.
- New tests added and executed: `selected_option_history_cold_clears_when_both_selected_histories_ready` (passed), `live_orders_armed_becomes_true_after_history_ready` (passed), and `strategy_eval_stall_recomputes_readiness_once` (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31238169648324b640f765ad7d34a9)