### PR TITLE
🧹 [Code Health] Remove canonical_price_source compatibility shim

### DIFF
--- a/src/nifty_scalper_bot/core/__init__.py
+++ b/src/nifty_scalper_bot/core/__init__.py
@@ -5,10 +5,8 @@ from __future__ import annotations
 from typing import Any
 
 from nifty_scalper_bot.utils.logging import get_logger
-# TODO: remove compatibility shim once downstream modules are updated.
-from nifty_scalper_bot.utils.pricing import canonical_price_source  # compat
 
-__all__ = ["NiftyScalperApp", "canonical_price_source"]
+__all__ = ["NiftyScalperApp"]
 
 _LOGGER = get_logger(__name__)
 


### PR DESCRIPTION
- Removed the deprecated compatibility export of `canonical_price_source` from `nifty_scalper_bot/core/__init__.py`.
- Updated `__all__` correctly to remove the reference.
- Ensures codebase maintainability by preventing the accidental use of the old import path. Downstream code has already been updated to use the direct path.

---
*PR created automatically by Jules for task [13527680915080531217](https://jules.google.com/task/13527680915080531217) started by @kundakarlabp*