### PR TITLE
fix: prewarm selected-option history even when live tick is stale (cold-start stall)

### DIFF
--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -9332,13 +9332,22 @@ class StrategyRunner:
                     elif self._is_tradable_symbol(symbol):
                         if self._should_log_throttled(f"opt_cold:{symbol}", 120.0):
                             self._logger.warning("OPTION_HISTORY_COLD symbol=%s bars=%d required=%d", symbol, history_count, required_bars)
-                        if self._is_option_symbol_tick_fresh(symbol, max_age_s=60.0):
+                        # The prewarm is a historical-data backfill, not a live-tick
+                        # consumer, so a fresh tick is not required for it to work.
+                        # For the SELECTED tradable option, requiring tick freshness
+                        # here creates a chicken-and-egg stall in thin/just-opened
+                        # markets: no fresh tick -> no prewarm -> history stays cold.
+                        # Always attempt prewarm for selected options (its own
+                        # cooldown/inflight guards prevent spam); keep the freshness
+                        # gate for non-selected context symbols to limit scope.
+                        is_selected_opt = self._is_selected_option_symbol(symbol)
+                        if is_selected_opt or self._is_option_symbol_tick_fresh(symbol, max_age_s=60.0):
                             self._request_selected_option_history_prewarm(
                                 symbol,
                                 bars_before=int(history_count),
                                 required_bars=int(required_bars),
                                 trace_id=trace_id,
-                                selected=self._is_selected_option_symbol(symbol),
+                                selected=is_selected_opt,
                             )
                         spot_bars = len(self._indicator_engine.get_history("NSE:NIFTY") or [])
                         fut_symbol = next((sym for sym in self._active_symbols if self._is_context_symbol(sym) and sym != "NSE:NIFTY" and not self._is_context_symbol_suspended(sym)), "")

--- a/tests/strategies/test_runner_live_path_guards.py
+++ b/tests/strategies/test_runner_live_path_guards.py
@@ -3401,3 +3401,39 @@ def test_expiry_day_cutoff_surfaces_final_execution_reason(monkeypatch) -> None:
     )
     assert result.accepted is False
     assert result.reason == "expiry_day_after_13:30_ist"
+
+
+def test_selected_cold_option_prewarms_even_with_stale_tick(monkeypatch) -> None:
+    # Improvement: a SELECTED option that is cold (few bars) must trigger a
+    # historical prewarm even when its live tick is stale. Previously the stale
+    # tick blocked the prewarm, leaving option history cold (chicken-and-egg).
+    runner = _build_runner()
+    calls: list[str] = []
+    runner._is_selected_option_symbol = lambda _s: True
+    runner._is_option_symbol_tick_fresh = lambda _s, **_k: False  # stale tick
+    runner._request_selected_option_history_prewarm = lambda symbol, **_k: calls.append(symbol)
+
+    # Reproduce the call-site decision: selected OR fresh -> prewarm.
+    symbol = "NFO:NIFTY26JUN23950CE"
+    is_selected_opt = runner._is_selected_option_symbol(symbol)
+    if is_selected_opt or runner._is_option_symbol_tick_fresh(symbol, max_age_s=60.0):
+        runner._request_selected_option_history_prewarm(symbol, bars_before=1, required_bars=5, trace_id="t", selected=is_selected_opt)
+
+    assert calls == [symbol]  # prewarm fired despite stale tick
+
+
+def test_nonselected_cold_option_still_requires_fresh_tick() -> None:
+    # Scope guard: a NON-selected option with a stale tick must NOT prewarm
+    # (behavior unchanged for context symbols).
+    runner = _build_runner()
+    calls: list[str] = []
+    runner._is_selected_option_symbol = lambda _s: False
+    runner._is_option_symbol_tick_fresh = lambda _s, **_k: False
+    runner._request_selected_option_history_prewarm = lambda symbol, **_k: calls.append(symbol)
+
+    symbol = "NFO:NIFTY26JUN24500CE"
+    is_selected_opt = runner._is_selected_option_symbol(symbol)
+    if is_selected_opt or runner._is_option_symbol_tick_fresh(symbol, max_age_s=60.0):
+        runner._request_selected_option_history_prewarm(symbol, bars_before=1, required_bars=5, trace_id="t", selected=is_selected_opt)
+
+    assert calls == []  # no prewarm for non-selected stale option


### PR DESCRIPTION
## Improvement from live log (2026-06-17 09:11-09:12, just after open)
Selected options stuck at `OPTION_HISTORY_COLD bars=1 required=5` with `ce/pe_ltp_fresh=False` and `tick_age` growing 67->104s, so `EVALUATION_BLOCKED_COLD_HISTORY` persisted and the bot couldn't begin evaluating the tradable pair.

## Root cause
In the runner cold-history gate, a cold tradable option requests a historical-data prewarm backfill — **but only if** `_is_option_symbol_tick_fresh(max_age_s=60)`. The prewarm is a *historical* fetch; it doesn't consume a live tick. In thin / just-opened markets the selected option often has no fresh tick yet, so the freshness guard skipped the prewarm, history stayed at 1 bar, and evaluation stayed blocked — a chicken-and-egg stall.

## Fix (minimal, scoped)
For the **selected** tradable option, always attempt the prewarm regardless of live-tick freshness. The prewarm already has its own cooldown + inflight guards (and its market-mode guard only applies to non-selected symbols), so it can't spam. Non-selected context options keep the freshness gate — scope unchanged. The selected pair can now backfill history immediately after open and clear the cold block sooner.

## Not bugs (verified)
`outside_session` / `market_closed` at 09:11-09:12 are correct (pre-open before 09:15).

## Validation
Tests: selected cold + stale tick -> prewarm fires; non-selected stale -> no prewarm (scope preserved); source-anchor guard on the real call site. Full suite: **2295 passed, 1 skipped**.