### PR TITLE
fix: quiet transient alert-send timeouts instead of logging as ERROR

### DIFF
--- a/src/nifty_scalper_bot/notifications/telegram_controller.py
+++ b/src/nifty_scalper_bot/notifications/telegram_controller.py
@@ -1904,6 +1904,15 @@ class TelegramBot:
                         extra={"event": "TELEGRAM_FLOOD_HOLD", "retry_after": retry_after_seconds, "hold_until": self._telegram_hold_until.isoformat() if self._telegram_hold_until else None},
                     )
                 return
+            # A timeout or transient network blip means this best-effort alert
+            # simply didn't go out — not an error worth a scary ❌ ERROR line.
+            if "timed out" in lowered or "timeout" in lowered or "connection" in lowered:
+                log.debug(
+                    "telegram alert send transient failure: %s",
+                    exc,
+                    extra={"event": "telegram_alert_dispatch_transient"},
+                )
+                return
             log.error(
                 "Failure in _dispatch_alert send: %s",
                 exc,

--- a/tests/notifications/test_telegram_start_idempotent.py
+++ b/tests/notifications/test_telegram_start_idempotent.py
@@ -70,3 +70,30 @@ async def test_start_clears_webhook_and_drops_pending_before_polling() -> None:
 
     app.bot.delete_webhook.assert_awaited_once_with(drop_pending_updates=True)
     app.updater.start_polling.assert_awaited_once_with(drop_pending_updates=True)
+
+
+async def test_dispatch_alert_timeout_is_quiet_not_error(caplog) -> None:
+    # A transient timeout while sending a best-effort alert must be logged quietly
+    # (debug), not as a scary ❌ ERROR. Alerts are best-effort; a timeout just means
+    # the message didn't go out.
+    import logging
+    from unittest.mock import AsyncMock, MagicMock
+
+    deps = TelegramDeps(token="dummy", chat_id=12345, app_version="test")
+    bot = TelegramBot(deps)
+    app = MagicMock()
+    app.bot = MagicMock()
+    bot._app = app
+    bot._telegram_hold_until = None
+    bot._telegram_last_dispatch_at = None
+
+    messenger = MagicMock()
+    messenger.send_text = AsyncMock(side_effect=TimeoutError("Timed out"))
+    bot._ensure_messenger = lambda *_a, **_k: messenger
+
+    with caplog.at_level(logging.DEBUG):
+        await bot._dispatch_alert("hello", "info")
+
+    msgs = [r.getMessage() for r in caplog.records]
+    assert not any("Failure in _dispatch_alert send" in m for m in msgs), "timeout must not log as ERROR"
+    assert any("transient failure" in m for m in msgs), "timeout should log a quiet transient line"


### PR DESCRIPTION
## From live log (2026-06-17 09:17)
`❌ Failure in _dispatch_alert send: Timed out` — a best-effort Telegram alert send timed out and fell through the existing flood/RetryAfter handling to the final `log.error`, surfacing a scary ❌ ERROR for a benign transient network blip.

## Fix (simplify, no new mechanism)
In the existing send-exception branch, treat a timeout / transient connection error like the flood case — log quietly at debug and return, instead of ERROR. Alerts are best-effort; a timeout just means the message didn't go out. Genuine non-transient send failures still log ERROR.

## Rest of the log is healthy
Post-open evaluation is active (`ORDERFLOW_TRIGGER_DECISION`, `STRATEGY_NO_VOTE`/`TRADE_DECISION_TRACE`); the cold-history stall from the prior log is gone (#600). `LIVE_ENTRY_CANDIDATE_REJECTED` (23900 while ATM=24050, distance 150>100) is correct out-of-window rejection; `TRIGGER_EVAL_SKIPPED direction_context_missing_live` and the volume clamp are benign transients.

## Validation
Async test (discrimination-verified): a `TimeoutError` during send logs a quiet transient line, never `Failure in _dispatch_alert send`. Full suite: **2296 passed, 1 skipped**.