### PR TITLE
fix: stop dashboard freeze — bounded log tail + throttle top log spammer

### DIFF
--- a/src/nifty_scalper_bot/admin_dashboard.py
+++ b/src/nifty_scalper_bot/admin_dashboard.py
@@ -130,6 +130,19 @@ def _clean_log_line(line: str) -> str:
     return f"{m.group(1)}  {msg}"
 
 
+def _tail_file(path: Path, lines: int, *, max_bytes: int = 2_000_000) -> str:
+    """Return roughly the last *lines* lines of *path* without loading the whole
+    file. Reads at most *max_bytes* from the end — bounded memory regardless of how
+    large bot.log grows (prevents the dashboard from spiking RAM on each refresh)."""
+    with open(path, "rb") as fh:
+        fh.seek(0, os.SEEK_END)
+        size = fh.tell()
+        read = min(size, max_bytes)
+        fh.seek(size - read)
+        chunk = fh.read(read)
+    return "\n".join(chunk.decode("utf-8", errors="replace").splitlines()[-lines:])
+
+
 def _gather_logs(lines: int, since: str = "", until: str = "", contains: str = "", clean: bool = True) -> str:
     lines = max(50, min(int(lines or 400), 20000))
     text = ""
@@ -146,7 +159,7 @@ def _gather_logs(lines: int, since: str = "", until: str = "", contains: str = "
         text = ""
     if not text and LOG_PATH.exists():
         try:
-            text = "\n".join(LOG_PATH.read_text(errors="replace").splitlines()[-lines:])
+            text = _tail_file(LOG_PATH, lines)
         except Exception as exc:  # noqa: BLE001
             text = f"log read error: {exc}"
     if not text:

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -1747,11 +1747,19 @@ class StrategyRunner:
             self._set_symbol_hydration_state(normalized, SymbolState.READY if success else SymbolState.HYDRATING)
         except Exception:  # noqa: BLE001 - state map is best-effort diagnostic
             pass
-        self._logger.info(
-            "RUNNER_HISTORY_SYNC_RESULT symbol=%s role=%s reason=%s required_bars=%s mdm_after=%s runner_after=%s indicator_after=%s success=%s failure_reason=%s",
-            normalized, role, reason, target, mdm_bars, runner_after, indicator_after, success, failure_reason,
-            extra={"event": "RUNNER_HISTORY_SYNC_RESULT", "symbol": normalized, "role": role, "reason": reason, "required_bars": target, "mdm_after": mdm_bars, "runner_after": runner_after, "indicator_after": indicator_after, "success": success, "failure_reason": failure_reason},
-        )
+        # This fires on every rearm-loop sync. In steady state (success, unchanged
+        # bar counts) it is pure repetition that floods the log/dashboard on the
+        # memory-tight host. Throttle the healthy/steady case per symbol+state
+        # (60s); failures and state changes still log immediately. Same pattern as
+        # LIVE_TRADING_READINESS_SNAPSHOT / LIVE_UNIVERSE_BOOTSTRAP_STATUS.
+        _sync_key = f"hist_sync:{normalized}:{role}:{success}:{reason}:{mdm_bars}:{runner_after}:{indicator_after}"
+        _sync_interval = float(os.getenv("RUNNER_HISTORY_SYNC_LOG_INTERVAL_SECONDS", "60") or "60")
+        if (not success) or self._should_log_throttled(_sync_key, _sync_interval):
+            self._logger.info(
+                "RUNNER_HISTORY_SYNC_RESULT symbol=%s role=%s reason=%s required_bars=%s mdm_after=%s runner_after=%s indicator_after=%s success=%s failure_reason=%s",
+                normalized, role, reason, target, mdm_bars, runner_after, indicator_after, success, failure_reason,
+                extra={"event": "RUNNER_HISTORY_SYNC_RESULT", "symbol": normalized, "role": role, "reason": reason, "required_bars": target, "mdm_after": mdm_bars, "runner_after": runner_after, "indicator_after": indicator_after, "success": success, "failure_reason": failure_reason},
+            )
         if not success and request_if_short:
             self._schedule_runtime_history_ensure(
                 normalized,
@@ -1893,10 +1901,14 @@ class StrategyRunner:
 
     def _should_log_throttled(self, key: str, interval_s: float = 30.0) -> bool:
         """Decide whether a throttled log should emit. Args: key/interval_s. Returns: bool. Raises: None."""
+        state = getattr(self, "_log_throttle_state", None)
+        if state is None:
+            state = {}
+            self._log_throttle_state = state
         now = time.monotonic()
-        last = float(self._log_throttle_state.get(key, 0.0))
+        last = float(state.get(key, 0.0))
         if now - last >= max(0.0, float(interval_s)):
-            self._log_throttle_state[key] = now
+            state[key] = now
             return True
         return False
 

--- a/tests/test_admin_dashboard_tail.py
+++ b/tests/test_admin_dashboard_tail.py
@@ -1,0 +1,29 @@
+"""The admin dashboard log viewer must tail the end of bot.log, not load the whole
+file into memory on every refresh — that spike was freezing the dashboard on the
+memory-tight Lightsail host as the log grew.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from nifty_scalper_bot.admin_dashboard import _tail_file
+
+
+async def test_tail_file_returns_last_n_lines(tmp_path: Path) -> None:
+    p = tmp_path / "bot.log"
+    p.write_text("\n".join(f"line {i}" for i in range(10_000)) + "\n")
+    rows = _tail_file(p, 200).splitlines()
+    assert len(rows) == 200
+    assert rows[-1] == "line 9999"
+    assert rows[0] == "line 9800"
+
+
+async def test_tail_file_is_byte_bounded(tmp_path: Path) -> None:
+    # Even asking for many lines, a small byte budget caps how much is read,
+    # proving the whole file is never loaded.
+    p = tmp_path / "bot.log"
+    p.write_text("\n".join(f"line {i}" for i in range(100_000)) + "\n")
+    rows = _tail_file(p, 50_000, max_bytes=20_000).splitlines()
+    assert 0 < len(rows) < 50_000  # capped by the byte budget, not the line count
+    assert rows[-1] == "line 99999"  # still anchored to the file's end


### PR DESCRIPTION
Addresses the dashboard freezing after restart on the 1.9GB Lightsail host (log spam + memory). Two root causes, both fixed by **simplifying**, no new subsystems. No trading behavior change.

## 1) Dashboard loaded the ENTIRE bot.log into memory on every refresh
`admin_dashboard.py` `_gather_logs` fallback did `LOG_PATH.read_text().splitlines()[-lines:]` — loading the whole ever-growing log file into RAM, splitting all lines, keeping only the last N, on **every auto-refresh**. As `bot.log` grows through the session this spikes memory/CPU and freezes the dashboard — exactly the "works after restart, then stuck" pattern.

**Fix:** new `_tail_file()` reads at most ~2MB from the **end** of the file via seek; the whole file is never loaded. Verified byte-bounded by test. (Primary `journalctl` path unchanged — this only fixes the file fallback.)

## 2) RUNNER_HISTORY_SYNC_RESULT — the #1 log spammer
26 lines in a 108s window: logged at INFO on **every** rearm-loop sync even in steady state (success, unchanged bar counts). Throttled per symbol+role+state via the existing `_should_log_throttled` (60s); failures and state changes still log immediately. `LIVE_TRADING_READINESS_SNAPSHOT` and `LIVE_UNIVERSE_BOOTSTRAP_STATUS` were already throttled — left as-is.

Also hardened `_should_log_throttled` to self-init its state dict so it's safe on all runner construction paths.

## Validation
- `_tail_file` returns correct last-N and is byte-bounded (whole file never loaded).
- Throttle hardening covered by existing canonical-history-sync tests.
- Full suite: **2298 passed, 1 skipped**.

## Operational note
Pair this with `MDM_TICK_CACHE_LEN=200` in `.env` (PR #584) for further memory headroom; the durable fix for sustained pressure remains the 4GB instance.