### PR TITLE
fix: surface the real cause of Telegram polling failures (409 conflict visibility)

### DIFF
--- a/src/nifty_scalper_bot/notifications/telegram_controller.py
+++ b/src/nifty_scalper_bot/notifications/telegram_controller.py
@@ -621,6 +621,33 @@ class TelegramBot:
     # ✅ CORRECTED STARTUP LOGIC (Single Source of Truth)
     # =========================================================================
 
+    async def _on_ptb_error(self, update: object, context: object) -> None:
+        """Log the real cause of PTB polling/handler errors (was silently hidden)."""
+        exc = getattr(context, "error", None)
+        text = str(exc or "")
+        lowered = text.lower()
+        if "conflict" in lowered or "terminated by other getupdates" in lowered:
+            # Another process is polling the same bot token -> commands never
+            # arrive. This is the #1 cause of "Telegram not responding".
+            self._polling_conflict_count = getattr(self, "_polling_conflict_count", 0) + 1
+            log.error(
+                "TELEGRAM_POLLING_CONFLICT another process is polling this bot token "
+                "(duplicate instance?) — commands will not arrive until it stops. count=%s err=%s",
+                self._polling_conflict_count,
+                text,
+                extra={"event": "TELEGRAM_POLLING_CONFLICT", "count": self._polling_conflict_count},
+            )
+            return
+        if "timed out" in lowered or "timeout" in lowered or isinstance(exc, NetworkError):
+            log.warning("telegram polling transient error: %s", text, extra={"event": "telegram_polling_transient"})
+            return
+        log.error(
+            "TELEGRAM_UPDATER_ERROR type=%s err=%s",
+            type(exc).__name__ if exc else "None",
+            text,
+            extra={"event": "TELEGRAM_UPDATER_ERROR"},
+        )
+
     async def start(self) -> None:
         """Start Telegram polling once; Args: none. Returns: None. Raises: None."""
         if self._started:
@@ -636,6 +663,15 @@ class TelegramBot:
                 return
             log.info("Telegram bot startup initiated", extra={"event": "telegram_start_enter"})
             self._register_handlers()
+            # Surface the real cause of polling failures. The PTB updater otherwise
+            # logs only a generic "Exception happened while polling for updates"
+            # with no cause, which hides the common case: a 409 Conflict from a
+            # second poller (duplicate process / leftover webhook) silently killing
+            # command reception.
+            try:
+                self.application.add_error_handler(self._on_ptb_error)
+            except Exception as _eh_exc:  # noqa: BLE001
+                log.debug("telegram add_error_handler failed: %s", _eh_exc)
             command_count = len(registered_command_names(self.application))
             log.info(
                 "TELEGRAM_RUNTIME_CONFIG bot_token_present=%s chat_id_configured=%s command_count=%s polling_mode=%s",

--- a/tests/notifications/test_telegram_start_idempotent.py
+++ b/tests/notifications/test_telegram_start_idempotent.py
@@ -97,3 +97,32 @@ async def test_dispatch_alert_timeout_is_quiet_not_error(caplog) -> None:
     msgs = [r.getMessage() for r in caplog.records]
     assert not any("Failure in _dispatch_alert send" in m for m in msgs), "timeout must not log as ERROR"
     assert any("transient failure" in m for m in msgs), "timeout should log a quiet transient line"
+
+
+async def test_ptb_error_handler_classifies_conflict() -> None:
+    # The error handler must surface a 409 polling conflict explicitly (the #1
+    # cause of "Telegram not responding"), not let it vanish into PTB's generic
+    # "Exception happened while polling" with no cause.
+    import logging
+    from types import SimpleNamespace
+
+    deps = TelegramDeps(token="dummy", chat_id=12345, app_version="test")
+    bot = TelegramBot(deps)
+
+    records: list[tuple[int, str]] = []
+
+    class _Cap(logging.Handler):
+        def emit(self, r: logging.LogRecord) -> None:
+            records.append((r.levelno, r.getMessage()))
+
+    h = _Cap()
+    root = logging.getLogger("nifty_scalper_bot.notifications.telegram_controller")
+    root.addHandler(h)
+    try:
+        ctx = SimpleNamespace(error=Exception("Conflict: terminated by other getUpdates request"))
+        await bot._on_ptb_error(None, ctx)
+    finally:
+        root.removeHandler(h)
+
+    assert any("TELEGRAM_POLLING_CONFLICT" in m for _lv, m in records), \
+        "409 conflict must be logged explicitly so the duplicate-poller cause is visible"


### PR DESCRIPTION
## Symptom
Telegram bot not responding to commands, no messages. Logs showed only PTB's generic `❌ Exception happened while polling for updates.` with **no cause**.

## Root cause of the blindness
No error handler was registered on the PTB Application, so updater polling exceptions logged generically with no detail. The most common underlying cause is a **409 Conflict** — a second process polling the same bot token (duplicate instance during a restart/redeploy overlap; the service's `TimeoutStopSec=60` leaves a window where the old process is still draining while a new one starts) or a leftover webhook. When that happens `getUpdates` is rejected and commands silently never arrive.

## Fix (diagnosis-first)
Register `_on_ptb_error` on the application. It classifies and logs the real cause:
- `TELEGRAM_POLLING_CONFLICT` — explicit, actionable (duplicate poller)
- transient network/timeout → warning
- anything else → `TELEGRAM_UPDATER_ERROR` with type + message

Combined with the existing `delete_webhook(drop_pending_updates=True)` before `start_polling` (#586), the webhook cause is already handled; this makes the duplicate-process cause finally visible. The next live log will say definitively which it is, instead of guessing. No happy-path behavior change.

## Validation
Test: `_on_ptb_error` logs `TELEGRAM_POLLING_CONFLICT` for a 'terminated by other getUpdates' error. Full suite: **2301 passed, 1 skipped**.