### PR TITLE
fix: order restore used undefined Order class (NameError)

### DIFF
--- a/src/nifty_scalper_bot/execution/order_manager.py
+++ b/src/nifty_scalper_bot/execution/order_manager.py
@@ -6993,8 +6993,10 @@ class OrderManager:
                     else:
                         order_type = OrderType.LIMIT
 
-                    # Create Order object (adjust based on your Order dataclass)
-                    order = Order(
+                    # Create the order object (OrderDetails is the class actually
+                    # stored in self._orders; 'Order' does not exist, which made
+                    # every restore raise NameError and silently skip).
+                    order = OrderDetails(
                         order_id=record.get("order_id", oid),
                         symbol=record.get("symbol", ""),
                         side=record.get("side", "BUY"),

--- a/tests/integration/test_persistent_recovery.py
+++ b/tests/integration/test_persistent_recovery.py
@@ -141,3 +141,26 @@ def test_persistent_state_recovery(tmp_path) -> None:
     assert "OPEN-1" in order_manager._brackets  # noqa: SLF001 - integration visibility
 
     restored_manager.close()
+
+
+async def test_load_orders_restores_orderdetails_not_nameerror(tmp_path, monkeypatch) -> None:
+    # Regression: _load_orders referenced an undefined `Order` class -> every saved
+    # order raised NameError and was silently skipped. Must restore as OrderDetails.
+    import json
+    from nifty_scalper_bot.execution.order_manager import OrderManager, OrderStatus
+
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    (tmp_path / "orders.json").write_text(json.dumps({
+        "OID-1": {"order_id": "OID-1", "symbol": "NFO:NIFTY26JUN23900CE", "side": "BUY",
+                  "quantity": 65, "price": 88.5, "order_type": "MARKET", "status": "SUBMITTED"},
+    }))
+    om = OrderManager.__new__(OrderManager)
+    om._orders = {}
+    from threading import RLock
+    om._lock = RLock()
+    import logging
+    om._logger = logging.getLogger("test_om_restore")
+    om._load_orders()
+    assert "OID-1" in om._orders
+    assert om._orders["OID-1"].symbol == "NFO:NIFTY26JUN23900CE"
+    assert om._orders["OID-1"].status == OrderStatus.SUBMITTED


### PR DESCRIPTION
Log: `Skipped restoring order <id>: name 'Order' is not defined`. `_load_orders` referenced an undefined `Order`; stored class is `OrderDetails`, so every saved order raised NameError and was silently skipped on startup. Fixed to `OrderDetails` (fields + save schema align). Discrimination-verified test. Full suite **2302 passed**.