### PR TITLE
fix: cache admin status.json to stop dashboard hang from per-poll subprocess storm

### DIFF
--- a/src/nifty_scalper_bot/admin_dashboard.py
+++ b/src/nifty_scalper_bot/admin_dashboard.py
@@ -471,9 +471,20 @@ def logs_page(request: Request, lines: int = 400, contains: str = "") -> HTMLRes
     return HTMLResponse(_page(body))
 
 
+_STATUS_CACHE: dict[str, object] = {"at": 0.0, "label": "running", "color": "#3fb950"}
+
+
 @router.get("/admin/status.json")
 def status_json(request: Request) -> JSONResponse:
     _check_auth(request)
+    # The Logs page polls this every few seconds. Spawning a `systemctl`
+    # subprocess + scanning logs on every poll saturated the sync threadpool
+    # (esp. with multiple tabs) and hung the dashboard. Cache for 10s so polling
+    # is cheap; status changes are still reflected within the interval.
+    now = time.time()
+    ttl = float(os.getenv("ADMIN_STATUS_CACHE_SECONDS", "10") or "10")
+    if now - float(_STATUS_CACHE["at"]) < ttl:
+        return JSONResponse({"label": _STATUS_CACHE["label"], "color": _STATUS_CACHE["color"]})
     # Lightweight health: is the trading engine up, or degraded/stopped?
     label, color = "running", "#3fb950"
     try:
@@ -493,6 +504,7 @@ def status_json(request: Request) -> JSONResponse:
                 label, color = "operational", "#3fb950"
     except Exception:
         label, color = "unknown", "#8b97a6"
+    _STATUS_CACHE.update({"at": now, "label": label, "color": color})
     return JSONResponse({"label": label, "color": color})
 
 

--- a/tests/test_admin_dashboard_tail.py
+++ b/tests/test_admin_dashboard_tail.py
@@ -27,3 +27,30 @@ async def test_tail_file_is_byte_bounded(tmp_path: Path) -> None:
     rows = _tail_file(p, 50_000, max_bytes=20_000).splitlines()
     assert 0 < len(rows) < 50_000  # capped by the byte budget, not the line count
     assert rows[-1] == "line 99999"  # still anchored to the file's end
+
+
+async def test_status_json_caches_subprocess(monkeypatch) -> None:
+    # The Logs page polls status.json every few seconds; it must NOT spawn a
+    # systemctl subprocess on every poll (that saturated the threadpool and hung
+    # the dashboard). Second call within TTL must be served from cache.
+    import nifty_scalper_bot.admin_dashboard as dash
+
+    calls = {"n": 0}
+
+    class _Out:
+        stdout = "active"
+
+    def _fake_run(*_a, **_k):
+        calls["n"] += 1
+        return _Out()
+
+    monkeypatch.setattr(dash.subprocess, "run", _fake_run)
+    monkeypatch.setattr(dash, "_gather_logs", lambda *_a, **_k: "Bot fully operational")
+    monkeypatch.setattr(dash, "_check_auth", lambda _r: None)
+    monkeypatch.setenv("ADMIN_STATUS_CACHE_SECONDS", "10")
+    dash._STATUS_CACHE.update({"at": 0.0})  # force a cold first call
+
+    dash.status_json(request=None)  # cold -> spawns
+    dash.status_json(request=None)  # cached -> no spawn
+    dash.status_json(request=None)  # cached -> no spawn
+    assert calls["n"] == 1, "status.json must cache, not spawn systemctl every poll"


### PR DESCRIPTION
Dashboard responsive after restart then hangs. Memory caps (#604) are working (screenshots: **730M after 2.5h, swap 4%** — was 1.2G/50%), so the hang is no longer swap thrash.

## Root cause
The Logs page JS polls `/admin/status.json` every few seconds, and that sync handler spawned a `systemctl is-active` **subprocess** plus a log scan on **every poll**. With auto-refresh and multiple browser tabs (screenshot showed 5 tabs), these blocking calls saturated FastAPI's sync threadpool and the dashboard stopped responding.

## Fix
Cache the status result for 10s (`ADMIN_STATUS_CACHE_SECONDS`). Polling is now cheap; status still updates within the interval. No new deps.

## Validation
Discrimination-verified test: repeated `status_json` calls within TTL spawn the subprocess once, not per call. Full suite: **2303 passed**.

Note: memory is now healthy (730M / 4% swap) thanks to #604; this addresses the remaining hang cause, which was threadpool saturation, not RAM.