### PR TITLE
fix: force Zerodha HTTP over IPv4 so orders use the allowlisted IP (403 fix)

### DIFF
--- a/src/nifty_scalper_bot/data/rest/zerodha_client.py
+++ b/src/nifty_scalper_bot/data/rest/zerodha_client.py
@@ -2889,9 +2889,23 @@ class ZerodhaKiteClient(BaseBrokerClient):
             self._breaker_open_until = 0.0
 
     def _create_http_client(self, base_url: str) -> httpx.Client:
+        # Force outbound connections over IPv4. Zerodha's developer console
+        # allowlists the static IPv4 (15.206.3.6), but the host can otherwise
+        # reach Zerodha over IPv6, which is NOT allowlisted -> 403 "IP is not
+        # allowed to place orders". Binding the local address to the IPv4 stack
+        # makes every request present the allowlisted IPv4. Opt out with
+        # ZERODHA_FORCE_IPV4=false if ever needed.
+        transport = None
+        force_ipv4 = str(os.getenv("ZERODHA_FORCE_IPV4", "true")).strip().lower() in {"1", "true", "yes", "on"}
+        if force_ipv4:
+            try:
+                transport = httpx.HTTPTransport(local_address="0.0.0.0")
+            except Exception:  # pragma: no cover - defensive
+                transport = None
         return httpx.Client(
             base_url=base_url,
             timeout=self._timeout,
+            transport=transport,
             headers={
                 "X-Kite-Version": "3",
                 "Authorization": f"token {self._api_key}:{self._access_token}",

--- a/tests/data/test_zerodha_client_resilience.py
+++ b/tests/data/test_zerodha_client_resilience.py
@@ -128,3 +128,25 @@ def test_get_ltp_bulk_depth_maps_symbol_payload_to_token(
     assert out == {256265: 25382.4}
 
     client._client.close()
+
+
+def test_http_client_forces_ipv4_by_default(monkeypatch):
+    # Fix for Zerodha 403 "IP not allowed": the host can reach Zerodha over IPv6,
+    # which is not allowlisted. The client must bind outbound to the IPv4 stack so
+    # it presents the allowlisted IPv4. _create_http_client builds with an IPv4
+    # local_address transport unless disabled.
+    monkeypatch.delenv("ZERODHA_FORCE_IPV4", raising=False)
+    import httpx
+    captured = {}
+    real_client = httpx.Client
+    def _spy_client(*a, **k):
+        captured["transport"] = k.get("transport")
+        return real_client(*a, **k)
+    monkeypatch.setattr(httpx, "Client", _spy_client)
+    ZerodhaKiteClient(api_key="key", access_token="token")
+    assert captured["transport"] is not None, "default must force IPv4 transport"
+
+    captured.clear()
+    monkeypatch.setenv("ZERODHA_FORCE_IPV4", "false")
+    ZerodhaKiteClient(api_key="key", access_token="token")
+    assert captured["transport"] is None, "opt-out must disable the forced transport"


### PR DESCRIPTION
## Critical: orders denied by Zerodha 403 (IPv6 not allowlisted)

Live log 2026-06-18 13:20:08: the bot built and sent a valid order (`ORDER_SENT BUY 65 NFO:NIFTY2662324150PE`) but Zerodha returned **403: 'IP (2406:da1a:19b:...:a2c0) is not allowed to place orders'**. That is an **IPv6** address — the Kite developer console allowlists your **static IPv4 (15.206.3.6)**, but the host reached Zerodha over IPv6, which is not allowlisted, so every order is denied.

**Not a code bug in the order path** — the bot correctly built, sent, then classified the rejection as non-retryable (`ORDER_BROKER_CONFIG_ERROR non_retryable=True`). Fix is to make outbound calls present the allowlisted IPv4.

## Fix
In `ZerodhaKiteClient._create_http_client` (the single httpx.Client factory), bind the transport `local_address` to the IPv4 stack (`0.0.0.0`) so all Zerodha REST calls go out over IPv4. Gated by `ZERODHA_FORCE_IPV4` (default true; `false` to opt out). One factory → covers orders, quotes, margins, history.

## Also audited (correct behavior, not bugs)
- `protected_price_invalidates_bracket` ×2: bot refused orders whose computed SL was **above** entry premium — guard working, but flags an ATR-SL sizing issue worth a separate look.
- `CANDIDATE_REPLACEMENT_BLOCKED reason=config_disabled` ×2: the #587 guard working as designed.

## Validation
Discrimination-verified test: default builds an IPv4-forcing transport; `ZERODHA_FORCE_IPV4=false` disables it. Full suite: **2306 passed**.