### PR TITLE
feat: /admin/trades.json — trade-only log view

### DIFF
--- a/src/nifty_scalper_bot/admin_dashboard.py
+++ b/src/nifty_scalper_bot/admin_dashboard.py
@@ -549,6 +549,25 @@ def logs_json(request: Request, lines: int = 400, contains: str = "") -> JSONRes
     return JSONResponse({"text": text})
 
 
+# Trade-relevant event markers — entry, fill, exit, P&L, rejections.
+_TRADE_MARKERS = (
+    "ORDER_SENT", "Sending Order", "FILLED", "average_price", "EXIT",
+    "TRADE_ATTEMPT", "ORDER_REJECTED", "ORDER_BROKER_CONFIG_ERROR", "pnl",
+    "TRADE_CLOSED", "ORDER_COMPLETE", "SIGNAL_GENERATED",
+)
+
+
+@router.get("/admin/trades.json")
+def trades_json(request: Request, lines: int = 4000) -> JSONResponse:
+    # Just the trade-relevant lines (entry / fill / exit / P&L / rejections) so the
+    # trade can be reviewed without scrolling the whole log. Reuses the bounded
+    # tail reader, so it stays cheap even as bot.log grows.
+    _check_auth(request)
+    text = _gather_logs(lines, clean=True)
+    hits = [ln for ln in text.splitlines() if any(m in ln for m in _TRADE_MARKERS)]
+    return JSONResponse({"text": "\n".join(hits) or "No trade events in the recent log window."})
+
+
 @router.get("/admin/logs/download")
 def logs_download(request: Request, fmt: str = "txt", lines: int = 2000, contains: str = "") -> PlainTextResponse:
     _check_auth(request)

--- a/tests/test_admin_dashboard_tail.py
+++ b/tests/test_admin_dashboard_tail.py
@@ -92,3 +92,19 @@ async def test_sessions_are_bounded_and_expire(monkeypatch) -> None:
     dash._SESSIONS["old"] = 1.0  # far in the past
     assert dash._session_valid("old") is False
     assert "old" not in dash._SESSIONS  # cleaned on check
+
+
+async def test_trades_json_filters_trade_events(tmp_path, monkeypatch) -> None:
+    # The trades endpoint returns only trade-relevant lines so the trade can be
+    # reviewed without scrolling the whole log.
+    import nifty_scalper_bot.admin_dashboard as dash
+    sample = "\n".join([
+        "[2026-06-18 13:20:08 IST] ORDER_SENT symbol=NFO:NIFTY26JUN24150PE side=BUY qty=65",
+        "[2026-06-18 13:20:09 IST] RUNNER_NO_TRADE_DECISION symbol=X reason=no_vote",
+        "[2026-06-18 13:25:00 IST] EXIT symbol=NFO:NIFTY26JUN24150PE pnl=325.0",
+    ])
+    monkeypatch.setattr(dash, "_gather_logs", lambda *a, **k: sample)
+    monkeypatch.setattr(dash, "_check_auth", lambda _r: None)
+    out = dash.trades_json(request=None).body.decode()
+    assert "ORDER_SENT" in out and "EXIT" in out
+    assert "RUNNER_NO_TRADE_DECISION" not in out  # noise filtered out


### PR DESCRIPTION
Adds `/admin/trades.json` — returns only trade-relevant lines (entry / fill / exit / P&L / rejections) from the **bounded** log tail, so a trade can be reviewed without scrolling the whole log and without the heavy full-log fetch. Reuses `_gather_logs`->`_tail_file` (bounded, cheap). No other behavior change. Full suite **2307 passed**.