### PR TITLE
fix: retry Telegram start on transient timeout instead of dying for the session

### DIFF
--- a/src/nifty_scalper_bot/notifications/telegram_controller.py
+++ b/src/nifty_scalper_bot/notifications/telegram_controller.py
@@ -132,7 +132,7 @@ from nifty_scalper_bot.utils.response_builder import EMOJI, RB, ResponseBuilder
 from nifty_scalper_bot.utils.symbols import canonical as canonical_symbol
 from telegram import Bot, Chat, InputFile, Message, Update
 from telegram.constants import ParseMode
-from telegram.error import BadRequest, NetworkError, RetryAfter, TelegramError
+from telegram.error import BadRequest, NetworkError, RetryAfter, TelegramError, TimedOut
 from telegram.ext import (
     Application,
     ApplicationBuilder,
@@ -713,6 +713,38 @@ class TelegramBot:
             release_polling_owner(token=self.deps.token, owner=type(self).__name__)
             self._started = False
             self._running = False
+            text = str(exc).lower()
+            transient = (
+                isinstance(exc, (NetworkError, TimedOut))
+                or "timed out" in text
+                or "timeout" in text
+                or "connection" in text
+            )
+            if transient:
+                # A network blip reaching api.telegram.org during startup must not
+                # leave Telegram dead for the whole session. Retry a few times in
+                # the background with backoff; commands recover on their own.
+                attempt = getattr(self, "_start_retry_attempt", 0) + 1
+                self._start_retry_attempt = attempt
+                max_retries = int(os.getenv("TELEGRAM_START_MAX_RETRIES", "5") or "5")
+                if attempt <= max_retries:
+                    delay = min(60.0, 5.0 * attempt)
+                    log.warning(
+                        "Telegram bot start transient failure (%s); retrying in %ss (attempt %s/%s)",
+                        type(exc).__name__, delay, attempt, max_retries,
+                        extra={"event": "telegram_start_retry", "attempt": attempt},
+                    )
+
+                    async def _retry_start() -> None:
+                        await asyncio.sleep(delay)
+                        await self.start()
+
+                    try:
+                        asyncio.create_task(_retry_start(), name="telegram-start-retry")
+                    except Exception as _t_exc:  # pragma: no cover - defensive
+                        log.debug("telegram start retry schedule failed: %s", _t_exc)
+                    return
+            self._start_retry_attempt = 0
             log.error(
                 "Telegram bot start failed type=%s err=%s",
                 type(exc).__name__,

--- a/tests/notifications/test_telegram_start_idempotent.py
+++ b/tests/notifications/test_telegram_start_idempotent.py
@@ -126,3 +126,33 @@ async def test_ptb_error_handler_classifies_conflict() -> None:
 
     assert any("TELEGRAM_POLLING_CONFLICT" in m for _lv, m in records), \
         "409 conflict must be logged explicitly so the duplicate-poller cause is visible"
+
+
+async def test_start_retries_on_transient_timeout(monkeypatch) -> None:
+    # A TimedOut during startup must NOT leave Telegram dead for the session; it
+    # should schedule a background retry (commands recover on their own).
+    from unittest.mock import AsyncMock, MagicMock
+    from telegram.error import TimedOut
+    import asyncio
+
+    deps = TelegramDeps(token="dummy", chat_id=1, app_version="t")
+    bot = TelegramBot(deps)
+    app = MagicMock()
+    app.initialize = AsyncMock(side_effect=TimedOut("Timed out"))  # fail at init
+    app.add_error_handler = MagicMock()
+    bot.application = app
+    bot._register_handlers = lambda: None  # type: ignore[method-assign]
+
+    scheduled = {"n": 0}
+    real_create_task = asyncio.create_task
+    def _spy(coro, **k):
+        if k.get("name") == "telegram-start-retry":
+            scheduled["n"] += 1
+            coro.close()  # don't actually run the retry
+            return MagicMock()
+        return real_create_task(coro, **k)
+    monkeypatch.setattr(asyncio, "create_task", _spy)
+
+    await bot.start()
+    assert scheduled["n"] == 1, "transient timeout must schedule a retry, not give up"
+    assert bot._started is False  # reset so the retry can re-enter


### PR DESCRIPTION
## Telegram cause finally visible (thanks to #605)

Live log 2026-06-18 13:37:55: `❌ Telegram bot start failed type=TimedOut err=Timed out`. **Not a 409 conflict** — startup's network call to api.telegram.org timed out, and `start()` logged the error and **gave up permanently**, so commands stayed dead until the next bot restart. This is why Telegram has been unresponsive.

## Fix
In `start()`'s exception path, treat a timeout / network blip as transient and schedule a **bounded background retry** (5 attempts, 5s..60s backoff, env `TELEGRAM_START_MAX_RETRIES`) instead of failing for good. `_started` reset so the retry re-enters cleanly. Non-transient errors still log+stop as before. Also imported `TimedOut` (was only matched by string).

## Validation
Discrimination-verified test: a `TimedOut` at init schedules a retry rather than permanently failing. Full suite: **2308 passed**.

Note: trading is working — other logs show a full bracket round trip (`EXIT_TRIGGERED HARD_TP_BREACH` → `BRACKET_EXIT_COMPLETE` → `EXIT_RECONCILED_FLAT`). IPv4 fix #613 holding; no 403s.