### PR TITLE
fix: position sync used nonexistent DataHub.normalize

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -1250,7 +1250,7 @@ from nifty_scalper_bot.utils.market_hours import (
 from nifty_scalper_bot.utils.metrics import ensure_multiproc_dir
 from nifty_scalper_bot.utils.rate_limiter import RateLimiter
 from nifty_scalper_bot.utils.reasons import SOFT, canonical as canonical_reason
-from nifty_scalper_bot.utils.symbols import canonical, unique_normalized_symbols
+from nifty_scalper_bot.utils.symbols import canonical, normalize_symbol, unique_normalized_symbols
 
 if TYPE_CHECKING:
     from nifty_scalper_bot.notifications.telegram_enhanced import TelegramEnhancedNotifier
@@ -12054,7 +12054,7 @@ async def _reconcile_state(ctx: BotContext) -> None:
 
                     # 1. Normalize Symbol
                     raw_symbol = pos.symbol
-                    norm_symbol = DataHub.normalize(raw_symbol) or raw_symbol
+                    norm_symbol = normalize_symbol(raw_symbol) or raw_symbol
 
                     # 2. Check if this symbol is actively managed
                     is_managed = bm.is_symbol_managed(norm_symbol)

--- a/tests/test_admin_dashboard_tail.py
+++ b/tests/test_admin_dashboard_tail.py
@@ -108,3 +108,15 @@ async def test_trades_json_filters_trade_events(tmp_path, monkeypatch) -> None:
     out = dash.trades_json(request=None).body.decode()
     assert "ORDER_SENT" in out and "EXIT" in out
     assert "RUNNER_NO_TRADE_DECISION" not in out  # noise filtered out
+
+
+async def test_app_uses_normalize_symbol_not_datahub_normalize() -> None:
+    # Regression: position sync/adoption called DataHub.normalize (does not exist),
+    # raising 'type object DataHub has no attribute normalize' and aborting adoption.
+    # Must use the normalize_symbol helper instead.
+    import pathlib
+    src = pathlib.Path("src/nifty_scalper_bot/core/app.py").read_text()
+    assert "DataHub.normalize(" not in src
+    assert "norm_symbol = normalize_symbol(raw_symbol)" in src
+    from nifty_scalper_bot.utils.symbols import normalize_symbol
+    assert normalize_symbol("nfo:nifty2662324100ce") == "NFO:NIFTY2662324100CE"


### PR DESCRIPTION
Log: `Position Sync/Adoption Failed: type object 'DataHub' has no attribute 'normalize'`. `app.py` called `DataHub.normalize(raw_symbol)` on the class — no such method — so position adoption raised every cycle and open positions weren't re-attached to bracket management. Fixed to the canonical `normalize_symbol` helper (added to imports).

Telegram `TimedOut` is an external Telegram outage — no code fix needed; #615 already retries on it.

Test (source-anchor + helper). Full suite **2309 passed**.