### PR TITLE
fix: kill switch self-heals after cooldown (live mode)

### DIFF
--- a/src/nifty_scalper_bot/execution/order_manager.py
+++ b/src/nifty_scalper_bot/execution/order_manager.py
@@ -905,7 +905,7 @@ class OrderManager:
         self._consecutive_failures: int = 0
         self._max_failures: int = max(1, int(os.getenv("ORDER_KILL_SWITCH_MAX_FAILURES", "5") or 5))
         self._kill_switch_auto_reset_seconds: int = max(60, int(os.getenv("ORDER_KILL_SWITCH_AUTO_RESET_SECONDS", "900") or 900))
-        self._kill_switch_allow_auto_reset: bool = os.getenv("ORDER_KILL_SWITCH_ALLOW_AUTO_RESET", "false").strip().lower() in {"1", "true", "yes", "on"}
+        self._kill_switch_allow_auto_reset: bool = os.getenv("ORDER_KILL_SWITCH_ALLOW_AUTO_RESET", "true").strip().lower() in {"1", "true", "yes", "on"}
         self._kill_switch_engaged_at: datetime | None = None
         self._kill_switch_reason: str | None = None
         self._last_kill_switch_log_ts: float = 0.0
@@ -2056,10 +2056,13 @@ class OrderManager:
         """Return whether kill switch is currently blocking new entries. Args: none. Returns: bool. Raises: none."""
         if self._kill_switch_engaged_at is None:
             return False
-        if self._order_live_execution_enabled():
-            return True
         if not self._kill_switch_allow_auto_reset:
             return True
+        # Auto-reset after the cooldown even in live mode. Without this, a transient
+        # broker problem (e.g. an IP-allowlist/network blip that trips 5 consecutive
+        # failures) would halt trading for the rest of the day until a manual reset
+        # or restart. Resetting only after the full cooldown avoids instantly
+        # re-trying into a still-broken broker.
         elapsed = (datetime.now(timezone.utc) - self._kill_switch_engaged_at).total_seconds()
         if elapsed < float(self._kill_switch_auto_reset_seconds):
             return True

--- a/tests/execution/test_order_manager_trade_plan.py
+++ b/tests/execution/test_order_manager_trade_plan.py
@@ -85,7 +85,7 @@ def test_stale_last_order_decision_does_not_leak() -> None:
     assert out.reason == 'place_order_rejected_without_decision'
     assert out.broker_attempted is False
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from collections import deque
 import time
 import nifty_scalper_bot.execution.order_manager as order_manager_module
@@ -358,15 +358,38 @@ def test_broker_health_emit_never_raises(monkeypatch) -> None:
     OrderManager._emit_broker_health_status(om, force=True)
 
 
-def test_live_kill_switch_does_not_auto_reset(monkeypatch) -> None:
+def test_live_kill_switch_auto_resets_after_cooldown(monkeypatch) -> None:
+    # An unattended live bot must self-heal: a tripped kill switch (e.g. from a
+    # transient broker/IP failure) auto-resets after the cooldown rather than
+    # halting trading for the rest of the day. Within the cooldown it stays active;
+    # after it, it resets — even in live mode.
+    import time as _t
     monkeypatch.setenv("EXECUTION_MODE", "LIVE")
     monkeypatch.setenv("ENABLE_LIVE_TRADING", "true")
-    monkeypatch.setenv("PAPER__ENABLED", "false")
-    monkeypatch.setenv("SHADOW_MODE", "false")
     om = OrderManager.__new__(OrderManager)
     om._kill_switch_engaged_at = datetime.now(timezone.utc)
     om._kill_switch_allow_auto_reset = True
     om._kill_switch_auto_reset_seconds = 1
-    om.reset_kill_switch = lambda reason="manual": (_ for _ in ()).throw(AssertionError("must not auto reset in live"))
+    # within cooldown -> still active
     assert OrderManager.is_kill_switch_active(om) is True
-    assert om._kill_switch_engaged_at is not None
+    # after cooldown -> auto-resets
+    om._kill_switch_engaged_at = datetime.now(timezone.utc) - timedelta(seconds=5)
+    reset_called = {"n": 0}
+    real_reset = OrderManager.reset_kill_switch
+    def _spy_reset(self, reason="manual"):
+        reset_called["n"] += 1
+        return real_reset(self, reason=reason)
+    om.reset_kill_switch = lambda reason="manual": _spy_reset(om, reason=reason)
+    om._last_kill_switch_log_ts = 0.0
+    assert OrderManager.is_kill_switch_active(om) is False
+    assert reset_called["n"] == 1
+    assert om._kill_switch_engaged_at is None
+
+
+def test_kill_switch_blocks_within_cooldown_when_auto_reset_disabled(monkeypatch) -> None:
+    # With auto-reset disabled, it stays active (opt-out preserved).
+    om = OrderManager.__new__(OrderManager)
+    om._kill_switch_engaged_at = datetime.now(timezone.utc)
+    om._kill_switch_allow_auto_reset = False
+    om._kill_switch_auto_reset_seconds = 1
+    assert OrderManager.is_kill_switch_active(om) is True


### PR DESCRIPTION
## Image 2 findings
Entries blocked by `reason=order_manager_kill_switch_active`, plus `EXIT_FAILED_ESCALATED` (`place_order returned no order_id`, remaining_qty=65 stuck ~10min).

**Root cause chain:** orders/exits hit Zerodha 403 (IPv6 not allowlisted) -> `place_order returned no order_id` -> 5 consecutive failures trip the kill switch -> all entries blocked rest of session. These logs predate/lack the IPv4 fix (#613); once #613 is live the 403s stop.

## Robustness gap fixed regardless
`is_kill_switch_active()` returned True unconditionally in **live mode**, so even with auto-reset enabled it **never** reset live -> a transient broker/IP blip halted trading until manual reset/restart. Too brittle for an unattended bot.

Now: auto-reset after the **full cooldown** (default 900s) applies in live too, and `ORDER_KILL_SWITCH_ALLOW_AUTO_RESET` defaults **true**. Reset only after cooldown, so it won't instantly retry into a still-broken broker. Opt out with `=false`.

Telegram `TimedOut` is external (Telegram outage) — no code fix; #615 retries.

## Validation
Tests: live kill switch stays active within cooldown, auto-resets after; opt-out preserved. Full suite **2310 passed**.