### PR TITLE
perf: cache _gather_logs so dashboard is super-lite (no journalctl per request)

### DIFF
--- a/src/nifty_scalper_bot/admin_dashboard.py
+++ b/src/nifty_scalper_bot/admin_dashboard.py
@@ -177,8 +177,24 @@ def _tail_file(path: Path, lines: int, *, max_bytes: int = 2_000_000) -> str:
     return "\n".join(chunk.decode("utf-8", errors="replace").splitlines()[-lines:])
 
 
+_LOGS_CACHE: dict[tuple, tuple[float, str]] = {}
+
+
 def _gather_logs(lines: int, since: str = "", until: str = "", contains: str = "", clean: bool = True) -> str:
     lines = max(50, min(int(lines or 400), 20000))
+    # The Logs page polls this every few seconds and the page/status/download all
+    # call it. Each call otherwise spawns a journalctl subprocess (up to 15s),
+    # which saturates the shared threadpool and hangs the dashboard. Cache results
+    # for a couple of seconds keyed by the query so polling is near-instant while
+    # logs stay fresh. Time-window/download queries (since/until) bypass the cache.
+    ttl = float(os.getenv("ADMIN_LOGS_CACHE_SECONDS", "2.5") or "2.5")
+    cache_key = (lines, contains, clean)
+    cacheable = not since and not until
+    now = time.time()
+    if cacheable and ttl > 0:
+        hit = _LOGS_CACHE.get(cache_key)
+        if hit and now - hit[0] < ttl:
+            return hit[1]
     text = ""
     try:
         cmd = ["journalctl", "-u", SERVICE_NAME, "-n", str(lines), "--no-pager", "-o", "cat"]
@@ -204,7 +220,13 @@ def _gather_logs(lines: int, since: str = "", until: str = "", contains: str = "
     if contains:
         n = contains.lower()
         rows = [r for r in rows if n in r.lower()]
-    return "\n".join(rows) if rows else "No matching log lines."
+    result = "\n".join(rows) if rows else "No matching log lines."
+    if cacheable and ttl > 0:
+        _LOGS_CACHE[cache_key] = (now, result)
+        if len(_LOGS_CACHE) > 32:  # bound the cache
+            for k in list(_LOGS_CACHE)[:-16]:
+                _LOGS_CACHE.pop(k, None)
+    return result
 
 
 def _restart_service() -> None:

--- a/tests/test_admin_dashboard_tail.py
+++ b/tests/test_admin_dashboard_tail.py
@@ -120,3 +120,29 @@ async def test_app_uses_normalize_symbol_not_datahub_normalize() -> None:
     assert "norm_symbol = normalize_symbol(raw_symbol)" in src
     from nifty_scalper_bot.utils.symbols import normalize_symbol
     assert normalize_symbol("nfo:nifty2662324100ce") == "NFO:NIFTY2662324100CE"
+
+
+async def test_gather_logs_is_cached(monkeypatch) -> None:
+    # The Logs page polls + page + download + status all call _gather_logs. Each
+    # call otherwise spawns a journalctl subprocess (up to 15s) and saturates the
+    # shared threadpool, hanging the dashboard. Repeated identical calls within the
+    # TTL must spawn journalctl once.
+    import nifty_scalper_bot.admin_dashboard as dash
+    dash._LOGS_CACHE.clear()
+    monkeypatch.setenv("ADMIN_LOGS_CACHE_SECONDS", "5")
+    calls = {"n": 0}
+    class _O:
+        returncode = 0
+        stdout = "[2026-06-18 14:00:00 IST] ORDER_SENT x\n"
+    def _run(*a, **k):
+        calls["n"] += 1
+        return _O()
+    monkeypatch.setattr(dash.subprocess, "run", _run)
+    a = dash._gather_logs(400)
+    b = dash._gather_logs(400)
+    c = dash._gather_logs(400)
+    assert calls["n"] == 1, "journalctl must be spawned once, then served from cache"
+    assert a == b == c
+    # a download-style time-window query bypasses the cache (always fresh)
+    dash._gather_logs(400, since="2026-06-18")
+    assert calls["n"] == 2


### PR DESCRIPTION
Dashboard still hanging + download slow/unresponsive.

## Root cause
`_gather_logs` spawns a **journalctl subprocess** (timeout up to 15s) on **every call** — and it's called by the polled `logs.json` (every 5s), the page, `status.json`, `trades.json`, and every download. Under load these spawns saturate the shared sync threadpool (dashboard runs in the bot process), so the whole dashboard — including download links — stalls.

## Fix (super-lite)
Cache `_gather_logs` results for ~2.5s (`ADMIN_LOGS_CACHE_SECONDS`) keyed by (lines, contains, clean). Polling/page/status/download now share one cheap cached read instead of each spawning journalctl; logs stay ≤2.5s old (fresh for reading). Time-window/download queries with `since/until` bypass the cache so exports are always complete. Cache size-bounded (≤32 keys). Stacks with the status.json cache (#611) and env cache (#612).

**Effect:** log polling + downloads near-instant; no per-request subprocess storm; dashboard responsive and up to date.

## Validation
Test: 3 identical calls spawn journalctl once; `since/until` bypasses cache. Full suite **2311 passed**.

Note: `EXIT_FAILED_ESCALATED 'place_order returned no order_id'` in the logs is the IPv6/403 chain — needs #613 + #617 live via restart; not a dashboard issue.