### PR TITLE
⚡ Bolt: [performance improvement] optimize instrument upsert via executemany

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-03-24 - [Avoid N+1 queries by using executemany]
+**Learning:** Found a loop doing `conn.execute(...)` for each row inside `upsert_instruments`. In Python/SQLite, accumulating parameters in a list and calling `conn.executemany` is much faster than executing statements individually inside a loop. This is mentioned in memory too: "For repetitive SQLite data insertions in Python, avoid N+1 queries by accumulating parameters in a list and using a single conn.executemany() instead of executing statements individually inside a loop."
+**Action:** When inserting multiple rows, always try to use `executemany` instead of looping with `execute`.

--- a/src/nifty_scalper_bot/data/instrument_loader.py
+++ b/src/nifty_scalper_bot/data/instrument_loader.py
@@ -275,6 +275,7 @@ def upsert_instruments(
             "NIFTY,BANKNIFTY,FINNIFTY,MIDCPNIFTY",
         )
     )
+    insert_params = []
     try:
         with conn:
             for raw_row in rows:
@@ -352,7 +353,20 @@ def upsert_instruments(
                     if underlying
                     else _derive_underlying(tradingsymbol)
                 )
-                conn.execute(
+                insert_params.append((
+                    token_int,
+                    exchange,
+                    tradingsymbol,
+                    lot_size,
+                    expiry_str,
+                    underlying_str,
+                    strike_value,
+                    opt_type,
+                    timestamp,
+                ))
+
+            if insert_params:
+                conn.executemany(
                     """
                     INSERT INTO instruments(
                         token,
@@ -375,19 +389,10 @@ def upsert_instruments(
                         opt_type=excluded.opt_type,
                         updated_at=excluded.updated_at
                     """,
-                    (
-                        token_int,
-                        exchange,
-                        tradingsymbol,
-                        lot_size,
-                        expiry_str,
-                        underlying_str,
-                        strike_value,
-                        opt_type,
-                        timestamp,
-                    ),
+                    insert_params
                 )
-                stored += 1
+                stored = len(insert_params)
+
     except Exception as exc:  # noqa: BLE001
         LOGGER.error(
             "Failure in upsert_instruments: %s",


### PR DESCRIPTION
💡 What: The optimization implemented
Refactored the `upsert_instruments` function in `src/nifty_scalper_bot/data/instrument_loader.py` to use `conn.executemany` instead of calling `conn.execute` in a `for` loop.

🎯 Why: The performance problem it solves
Executing individual SQL inserts in a tight loop is a classic N+1 bottleneck and adds substantial overhead due to Python-to-SQLite interactions per iteration. Accumulating the arguments into a single list and calling `executemany` resolves this.

📊 Impact: Expected performance improvement
Reduces database interaction overhead significantly when inserting thousands of rows.

🔬 Measurement: How to verify the improvement
Verified correctness by running `./run_checks.sh` which executes the full test suite and checking the logs to ensure no regressions were introduced.

---
*PR created automatically by Jules for task [7981545812380561334](https://jules.google.com/task/7981545812380561334) started by @kundakarlabp*