### PR TITLE
perf: skip periodic broker reconcile when market closed and flat

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -11979,6 +11979,43 @@ async def shutdown_sequence(ctx: BotContext, *, reason: str = "shutdown") -> Non
     LOGGER.info("Bot shutdown complete")
 
 
+def _should_reconcile_now(ctx: BotContext) -> bool:
+    """Whether the periodic broker reconcile should run this cycle.
+
+    Post-close, with a flat book, the loop was hammering Zerodha (~3 calls/min all
+    night) to reconcile orders that can no longer change — needless API load, log
+    noise, and battery on a small host. Skip the broker reconcile only when BOTH
+    the market is closed AND there is no open position; otherwise always reconcile
+    (safety-first: open exposure must keep syncing, and any uncertainty reconciles).
+    Disable this optimization with HEALTH_RECONCILE_SKIP_WHEN_CLOSED=false.
+    """
+    try:
+        if os.getenv("HEALTH_RECONCILE_SKIP_WHEN_CLOSED", "true").strip().lower() not in {"1", "true", "yes", "on"}:
+            return True
+        from nifty_scalper_bot.risk.session_gate import (
+            MARKET_CLOSE,
+            MARKET_OPEN,
+            _is_market_open,
+        )
+        from datetime import datetime
+        from zoneinfo import ZoneInfo
+
+        now_ist = datetime.now(ZoneInfo("Asia/Kolkata"))
+        if _is_market_open(now_ist, start=MARKET_OPEN, end=MARKET_CLOSE):
+            return True  # market open -> always reconcile
+        # Market closed: reconcile only if a position is still open (overnight safety).
+        pm = getattr(ctx, "position_manager", None)
+        if pm is not None and hasattr(pm, "get_open_positions"):
+            try:
+                if list(pm.get_open_positions()):
+                    return True
+            except Exception:  # noqa: BLE001 - if unsure, reconcile
+                return True
+        return False
+    except Exception:  # noqa: BLE001 - never let the guard break the loop
+        return True
+
+
 async def _reconcile_state(ctx: BotContext) -> None:
     """
     Syncs local state with Broker (Orders & Positions).
@@ -12788,7 +12825,8 @@ class NiftyScalperApp:
                         )
                         await asyncio.sleep(5.0)
                     try:
-                        await _reconcile_state(self._ctx)
+                        if _should_reconcile_now(self._ctx):
+                            await _reconcile_state(self._ctx)
                     except Exception as exc:  # noqa: BLE001
                         LOGGER.warning(
                             "Periodic state reconciliation failed",

--- a/tests/core/test_should_reconcile_now.py
+++ b/tests/core/test_should_reconcile_now.py
@@ -1,0 +1,36 @@
+"""Post-close reconcile gating: don't hammer the broker all night when flat."""
+from __future__ import annotations
+
+import types
+from unittest.mock import patch
+
+from nifty_scalper_bot.core.app import _should_reconcile_now
+
+
+def _ctx(open_positions):
+    pm = types.SimpleNamespace(get_open_positions=lambda: open_positions)
+    return types.SimpleNamespace(position_manager=pm)
+
+
+async def test_skips_when_closed_and_flat(monkeypatch):
+    monkeypatch.setenv("HEALTH_RECONCILE_SKIP_WHEN_CLOSED", "true")
+    with patch("nifty_scalper_bot.risk.session_gate._is_market_open", return_value=False):
+        assert _should_reconcile_now(_ctx([])) is False
+
+
+async def test_reconciles_when_closed_but_position_open(monkeypatch):
+    monkeypatch.setenv("HEALTH_RECONCILE_SKIP_WHEN_CLOSED", "true")
+    with patch("nifty_scalper_bot.risk.session_gate._is_market_open", return_value=False):
+        assert _should_reconcile_now(_ctx([{"symbol": "X"}])) is True
+
+
+async def test_reconciles_during_market_hours(monkeypatch):
+    monkeypatch.setenv("HEALTH_RECONCILE_SKIP_WHEN_CLOSED", "true")
+    with patch("nifty_scalper_bot.risk.session_gate._is_market_open", return_value=True):
+        assert _should_reconcile_now(_ctx([])) is True
+
+
+async def test_disabled_always_reconciles(monkeypatch):
+    monkeypatch.setenv("HEALTH_RECONCILE_SKIP_WHEN_CLOSED", "false")
+    with patch("nifty_scalper_bot.risk.session_gate._is_market_open", return_value=False):
+        assert _should_reconcile_now(_ctx([])) is True


### PR DESCRIPTION
## Log review
Window **19:28-21:31 IST** (hours after the 15:30 close) is **clean** — no errors, no 403s, no kill-switch trips. The IPv4 (#613), kill-switch self-heal (#617), and dashboard (#618) fixes are holding.

## The one enhancement
The health loop's heavy branch fired `_reconcile_state` every cycle with **no market-hours check**, so post-close with a flat book it hammered Zerodha **~3 calls/min all night** (`positions_fetch` + `orders_fetch count=14` + reconcile) to reconcile orders that can no longer change — needless API load, log noise, battery on the 1.9GB host.

## Fix
`_should_reconcile_now(ctx)`: skip the broker reconcile **only when BOTH** the market is closed **AND** no position is open; otherwise always reconcile. Safety-first — open overnight exposure keeps syncing, market hours always reconcile, any uncertainty/exception reconciles. Disable with `HEALTH_RECONCILE_SKIP_WHEN_CLOSED=false`. `_health_check` and overnight-exposure checks still run every cycle.

## Validation
Discrimination tests: closed+flat → skip; closed+open → reconcile; market hours → reconcile; disabled → reconcile. Full suite **2315 passed**.