### PR TITLE
fix: ghost-position reconcile crashed attaching safety bracket

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -3862,11 +3862,12 @@ async def reconcile_with_broker(
                     sym, qty, avg_price,
                 )
 
-                # Attach orphan position with default ATR-based SL (2% fallback)
+                # Attach orphan position. BracketManager computes its own
+                # ATR-based rescue SL/TP internally and does NOT accept sl/tp
+                # kwargs — passing them raised TypeError and left the ghost
+                # position unprotected.
                 if bracket_manager and avg_price > 0:
                     try:
-                        sl_default = round(avg_price * 0.98, 2)  # 2% below entry
-                        tp_default = round(avg_price * 1.04, 2)  # 4% above entry
                         side = "BUY" if qty > 0 else "SELL"
 
                         attach_fn = getattr(bracket_manager, "attach_orphan_position", None)
@@ -3876,12 +3877,10 @@ async def reconcile_with_broker(
                                 side=side,
                                 qty=abs(qty),
                                 entry_price=avg_price,
-                                sl=sl_default,
-                                tp=tp_default,
                             )
                             logger.warning(
-                                "SAFETY_BRACKET_ATTACHED: symbol=%s sl=%.2f tp=%.2f",
-                                sym, sl_default, tp_default,
+                                "SAFETY_BRACKET_ATTACHED: symbol=%s qty=%d entry=%.2f",
+                                sym, abs(qty), avg_price,
                             )
                         else:
                             logger.warning(

--- a/tests/test_reconcile_ghost_bracket.py
+++ b/tests/test_reconcile_ghost_bracket.py
@@ -1,0 +1,84 @@
+"""Regression test for ghost/orphan safety-bracket attachment on reconcile.
+
+``reconcile_with_broker`` adopts naked broker positions by calling
+``BracketManager.attach_orphan_position(symbol, side, qty, entry_price)``.
+The method computes its own ATR-based rescue levels and does NOT accept
+``sl``/``tp`` kwargs; passing them raised TypeError, logged
+``SAFETY_BRACKET_FAILED`` and left the ghost position unprotected.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from nifty_scalper_bot.core.app import reconcile_with_broker
+
+
+class _RecordingLogger:
+    def __init__(self) -> None:
+        self.messages: list[str] = []
+
+    def _record(self, msg: str, *args: Any, **kwargs: Any) -> None:
+        try:
+            self.messages.append(msg % args if args else msg)
+        except Exception:
+            self.messages.append(msg)
+
+    info = warning = error = debug = exception = _record
+
+
+class _BracketManager:
+    """Mirrors the real attach_orphan_position signature exactly."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    def is_symbol_managed(self, symbol: str) -> bool:
+        return False
+
+    def attach_orphan_position(
+        self, symbol: str, side: str, qty: int, entry_price: float
+    ) -> str:
+        self.calls.append(
+            {"symbol": symbol, "side": side, "qty": qty, "entry_price": entry_price}
+        )
+        return f"orphan_{symbol}"
+
+
+class _Broker:
+    def get_orders(self) -> list[dict[str, Any]]:
+        return []
+
+    def get_positions(self) -> list[dict[str, Any]]:
+        return [
+            {
+                "tradingsymbol": "NIFTY2662324050PE",
+                "quantity": 65,
+                "average_price": 94.72,
+                "product": "MIS",
+            }
+        ]
+
+
+class _DummyOM:
+    def __getattr__(self, _name: str) -> Any:
+        return lambda *a, **k: None
+
+
+async def test_ghost_position_attaches_bracket_without_sl_tp() -> None:
+    bm = _BracketManager()
+    logger = _RecordingLogger()
+
+    await reconcile_with_broker(_Broker(), bm, _DummyOM(), logger)
+
+    # Exactly one adoption, with the four supported args and no sl/tp.
+    assert len(bm.calls) == 1
+    call = bm.calls[0]
+    assert call["symbol"] == "NIFTY2662324050PE"
+    assert call["side"] == "BUY"  # qty > 0
+    assert call["qty"] == 65
+    assert call["entry_price"] == 94.72
+
+    joined = "\n".join(logger.messages)
+    assert "SAFETY_BRACKET_ATTACHED" in joined
+    assert "SAFETY_BRACKET_FAILED" not in joined


### PR DESCRIPTION
reconcile_with_broker passed unsupported sl=/tp= kwargs to attach_orphan_position (signature: symbol, side, qty, entry_price; it computes its own ATR rescue levels). The TypeError logged SAFETY_BRACKET_FAILED and left adopted ghost positions unprotected. Removed the kwargs. Async regression test added (drives the ghost path; discrimination-verified).