### PR TITLE
fix: add missing DataHub.normalize static helper

### DIFF
--- a/src/nifty_scalper_bot/data/data_hub.py
+++ b/src/nifty_scalper_bot/data/data_hub.py
@@ -40,7 +40,7 @@ from nifty_scalper_bot.storage.hub_store import HubStore
 from nifty_scalper_bot.instruments.active_contracts import canonical_nifty_future_symbol
 from nifty_scalper_bot.utils.options_math import black_scholes_greeks, implied_volatility
 from nifty_scalper_bot.execution.readiness import resolve_quote_bid_ask_spread
-from nifty_scalper_bot.utils.symbols import canonical
+from nifty_scalper_bot.utils.symbols import canonical, normalize_symbol
 from nifty_scalper_bot.utils.serialization import to_json_safe
 
 if TYPE_CHECKING:
@@ -122,6 +122,20 @@ _OPTION_RE = re.compile(
 
 class DataHub:
     """Market data single source of truth."""
+
+    @staticmethod
+    def normalize(symbol: Any) -> str:
+        """Return the exchange-qualified canonical form of ``symbol``.
+
+        Numerous execution/risk/notification call sites use
+        ``DataHub.normalize(sym)`` as a static helper, but the method was
+        never defined on the class. Every such call raised
+        ``AttributeError: type object 'DataHub' has no attribute 'normalize'``
+        — silently aborting position sync/adoption and other reconciliation
+        paths wrapped in broad try/except. Delegates to the canonical
+        ``normalize_symbol`` helper already used across execution.
+        """
+        return normalize_symbol(symbol)
 
     def __init__(
         self,

--- a/tests/test_datahub_normalize.py
+++ b/tests/test_datahub_normalize.py
@@ -1,0 +1,36 @@
+"""Regression test: DataHub.normalize must exist and match normalize_symbol.
+
+~25 call sites across execution/risk/notifications use ``DataHub.normalize``
+as a static helper, but it was never defined on the class — every reached
+call raised ``AttributeError: type object 'DataHub' has no attribute
+'normalize'``, silently aborting position sync/adoption.
+"""
+
+from __future__ import annotations
+
+from nifty_scalper_bot.data.data_hub import DataHub
+from nifty_scalper_bot.utils.symbols import normalize_symbol
+
+
+async def test_datahub_normalize_exists() -> None:
+    assert hasattr(DataHub, "normalize")
+
+
+async def test_datahub_normalize_matches_helper() -> None:
+    cases = [
+        "NIFTY2662324050PE",
+        "NFO:NIFTY26JUNFUT",
+        "NIFTY",
+        "nse:nifty",
+        "",
+        "256265",
+    ]
+    for sym in cases:
+        assert DataHub.normalize(sym) == normalize_symbol(sym)
+
+
+async def test_datahub_normalize_callable_on_instance() -> None:
+    # Some call sites invoke it on an instance (hub.normalize(sym)); a
+    # staticmethod must work both ways without needing instance state.
+    hub = DataHub.__new__(DataHub)
+    assert hub.normalize("NIFTY2662324050CE") == "NFO:NIFTY2662324050CE"


### PR DESCRIPTION
~25 call sites call DataHub.normalize(symbol) but the method never existed on the class, raising AttributeError and silently aborting position sync/adoption (10x in live logs). Added a normalize staticmethod delegating to normalize_symbol. 3 async tests; discrimination-verified.