### PR TITLE
fix: re-anchor stale SL/TP bracket to live protected price

### DIFF
--- a/src/nifty_scalper_bot/execution/order_manager.py
+++ b/src/nifty_scalper_bot/execution/order_manager.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 import asyncio
 from collections import deque
 from contextlib import suppress
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass, field, replace
 from datetime import datetime, timezone
 from enum import Enum
 import hashlib
@@ -3479,6 +3479,64 @@ class OrderManager:
             return OrderPreflightResult(False, "depth_insufficient", {"depth_qty": qd["depth_qty"], "limit_qty": plan.min_depth_qty})
         return OrderPreflightResult(True, "allowed", {"quote": qd, "lot_size": lot_size})
 
+    def _reanchor_bracket_to_price(
+        self, plan: TradePlan, price: float
+    ) -> TradePlan:
+        """Re-anchor a stale SL/TP bracket to the live protected ``price``.
+
+        Strategy SL/TP are computed off the option premium at signal time.
+        Premiums can move materially before submission, so the precomputed
+        band can land on the wrong side of the live protected price and the
+        order is rejected (``protected_price_invalidates_bracket``) — a lost
+        but valid entry. When (and only when) the existing band is invalid
+        against ``price``, rebuild it at ``price`` preserving the plan's
+        intended SL/TP distances (so the sized rupee risk is unchanged).
+        Valid brackets pass through untouched.
+        """
+        entry = plan.entry_price
+        sl = plan.stop_loss
+        tp = plan.take_profit
+        if (
+            not entry
+            or entry <= 0
+            or not price
+            or price <= 0
+            or sl is None
+            or tp is None
+        ):
+            return plan
+
+        if plan.side == "BUY":
+            bracket_valid = sl < price < tp
+        elif plan.side == "SELL":
+            bracket_valid = tp < price < sl
+        else:
+            return plan
+        if bracket_valid:
+            return plan
+
+        # Preserve the strategy's intended absolute distances from its entry.
+        sl_dist = abs(entry - sl)
+        tp_dist = abs(tp - entry)
+        if sl_dist <= 0 or tp_dist <= 0:
+            # Degenerate plan — leave it to be rejected by validation.
+            return plan
+
+        if plan.side == "BUY":
+            new_sl = max(0.05, round(price - sl_dist, 2))
+            new_tp = round(price + tp_dist, 2)
+        else:  # SELL
+            new_sl = round(price + sl_dist, 2)
+            new_tp = max(0.05, round(price - tp_dist, 2))
+
+        self._logger.warning(
+            "BRACKET_REANCHORED symbol=%s side=%s entry=%.2f price=%.2f "
+            "sl=%.2f->%.2f tp=%.2f->%.2f trace_id=%s",
+            plan.symbol, plan.side, entry, price, sl, new_sl, tp, new_tp,
+            plan.trace_id,
+        )
+        return replace(plan, stop_loss=new_sl, take_profit=new_tp)
+
     def _protected_limit_price(self, plan: TradePlan) -> float | None:
         quote = self._get_latest_quote_safe(plan.symbol)
         tick_size = 0.05
@@ -3554,6 +3612,7 @@ class OrderManager:
                 plan.trace_id,
             )
             return TradePlanSubmitResult(False, reason="protected_limit_unavailable", details={"entry_price": plan.entry_price}, broker_attempted=False)
+        plan = self._reanchor_bracket_to_price(plan, price)
         if plan.side == "BUY":
             if plan.stop_loss is not None and plan.stop_loss >= price:
                 details = {"protected_price": price, "stop_loss": plan.stop_loss, "take_profit": plan.take_profit, "side": plan.side, "violation": "stop_loss_above_or_equal_entry"}

--- a/tests/test_bracket_reanchor.py
+++ b/tests/test_bracket_reanchor.py
@@ -1,0 +1,119 @@
+"""Regression tests: stale SL/TP bracket re-anchored to live protected price.
+
+Strategy SL/TP are computed off the option premium at signal time. When the
+premium moves before submission, the precomputed band can land on the wrong
+side of the live protected price, which previously rejected the order with
+``protected_price_invalidates_bracket`` (a lost but valid entry). The order
+manager now re-anchors an *invalid* band to the live price, preserving the
+plan's intended SL/TP distances, while leaving valid brackets untouched.
+"""
+
+from __future__ import annotations
+
+import logging
+import types
+from typing import Any
+
+from nifty_scalper_bot.execution.order_manager import OrderManager, TradePlan
+
+
+def _plan(side: str, entry: float, sl: float, tp: float) -> TradePlan:
+    return TradePlan(
+        symbol="NFO:NIFTY2662324050CE",
+        side=side,  # type: ignore[arg-type]
+        quantity=65,
+        entry_price=entry,
+        stop_loss=sl,
+        take_profit=tp,
+    )
+
+
+class _Stub:
+    _logger = logging.getLogger("reanchor-test")
+
+
+def _reanchor(plan: TradePlan, price: float) -> TradePlan:
+    return OrderManager._reanchor_bracket_to_price(_Stub(), plan, price)
+
+
+async def test_buy_stale_band_reanchored_preserving_distances() -> None:
+    # Signal-time band [108.56, 116.93] around entry 112.7; live price jumped
+    # to 138.45 -> original TP (116.93) is below live price (invalid).
+    plan = _plan("BUY", entry=112.70, sl=108.56, tp=116.93)
+    out = _reanchor(plan, 138.45)
+
+    # Distances preserved: sl_dist=4.14, tp_dist=4.23
+    assert out.stop_loss == 134.31  # 138.45 - 4.14
+    assert out.take_profit == 142.68  # 138.45 + 4.23
+    # Now a valid long bracket.
+    assert out.stop_loss < 138.45 < out.take_profit
+
+
+async def test_sell_stale_band_reanchored() -> None:
+    # Short: valid means tp < price < sl. Signal entry 112.7, sl above, tp below.
+    plan = _plan("SELL", entry=112.70, sl=116.93, tp=108.56)
+    out = _reanchor(plan, 90.00)
+    # sl_dist=4.23, tp_dist=4.14
+    assert out.stop_loss == 94.23  # 90 + 4.23
+    assert out.take_profit == 85.86  # 90 - 4.14
+    assert out.take_profit < 90.00 < out.stop_loss
+
+
+async def test_valid_bracket_passes_through_unchanged() -> None:
+    plan = _plan("BUY", entry=130.0, sl=125.0, tp=140.0)
+    out = _reanchor(plan, 131.0)  # 125 < 131 < 140 already valid
+    assert out.stop_loss == 125.0
+    assert out.take_profit == 140.0
+    assert out is plan  # untouched
+
+
+async def test_missing_levels_untouched() -> None:
+    plan = TradePlan(
+        symbol="NFO:NIFTY2662324050CE",
+        side="BUY",
+        quantity=65,
+        entry_price=112.0,
+        stop_loss=None,
+        take_profit=None,
+    )
+    out = _reanchor(plan, 138.45)
+    assert out is plan
+
+
+async def test_submit_reanchors_instead_of_rejecting(monkeypatch: Any) -> None:
+    """End-to-end: a stale BUY plan is accepted (re-anchored), not rejected."""
+    from nifty_scalper_bot.execution.order_manager import OrderPreflightResult
+    from nifty_scalper_bot.execution.position_manager import PositionManager
+    from nifty_scalper_bot.utils.rate_limiter import RateLimiter
+
+    class _Broker:
+        def place_order(self, **k: Any) -> dict[str, Any]:
+            return {"order_id": "ORD-1", "status": "success"}
+
+    mgr = OrderManager(_Broker(), PositionManager(), RateLimiter())
+
+    captured: dict[str, Any] = {}
+
+    def _fake_managed(**kwargs: Any) -> Any:
+        captured.update(kwargs)
+        return types.SimpleNamespace(
+            accepted=True, order_id="ORD-1", reason="accepted",
+            details={}, broker_attempted=True,
+        )
+
+    monkeypatch.setattr(mgr, "is_kill_switch_active", lambda: False)
+    monkeypatch.setattr(
+        mgr, "_validate_trade_plan",
+        lambda plan: OrderPreflightResult(True, "ok", {}),
+    )
+    monkeypatch.setattr(mgr, "_protected_limit_price", lambda plan: 138.45)
+    monkeypatch.setattr(mgr, "place_managed_order_result", _fake_managed)
+
+    plan = _plan("BUY", entry=112.70, sl=108.56, tp=116.93)
+    result = mgr.submit_trade_plan_result(plan)
+
+    assert result.reason != "protected_price_invalidates_bracket"
+    assert result.accepted
+    # Re-anchored levels were what got submitted.
+    assert captured["entry_price"] == 138.45
+    assert captured["stop_loss"] < 138.45 < captured["take_profit"]


### PR DESCRIPTION
Strategy SL/TP are anchored to the signal-time premium; premium drift before submission left the band on the wrong side of the live price, rejecting valid entries (protected_price_invalidates_bracket; observed repeatedly in live logs). submit_trade_plan_result now re-anchors an invalid band to the live protected price, preserving the plan's SL/TP distances (sized rupee risk unchanged). Valid brackets untouched. 5 tests (4 direct + 1 end-to-end); discrimination-verified.