### PR TITLE
perf: serve dashboard logs from in-memory ring (zero hot-path subprocess)

### DIFF
--- a/src/nifty_scalper_bot/admin_dashboard.py
+++ b/src/nifty_scalper_bot/admin_dashboard.py
@@ -18,7 +18,9 @@ import os
 import re
 import secrets
 import subprocess
+import threading
 import time
+from collections import deque
 import urllib.parse
 import urllib.request
 from pathlib import Path
@@ -177,24 +179,63 @@ def _tail_file(path: Path, lines: int, *, max_bytes: int = 2_000_000) -> str:
     return "\n".join(chunk.decode("utf-8", errors="replace").splitlines()[-lines:])
 
 
-_LOGS_CACHE: dict[tuple, tuple[float, str]] = {}
+# ── Super-lite logs: one background journalctl --follow streams into an
+# in-memory ring buffer; request handlers read from memory only. No per-request
+# subprocess, no disk storage — so a slow journal can never block the shared
+# threadpool or starve the trading engine.
+_RING_MAX = max(500, int(os.getenv("ADMIN_LOG_RING_LINES", "6000") or "6000"))
+_LOG_RING: "deque[str]" = deque(maxlen=_RING_MAX)
+_LOG_FOLLOWER_STARTED = False
+_LOG_FOLLOWER_LOCK = threading.Lock()
 
 
-def _gather_logs(lines: int, since: str = "", until: str = "", contains: str = "", clean: bool = True) -> str:
-    lines = max(50, min(int(lines or 400), 20000))
-    # The Logs page polls this every few seconds and the page/status/download all
-    # call it. Each call otherwise spawns a journalctl subprocess (up to 15s),
-    # which saturates the shared threadpool and hangs the dashboard. Cache results
-    # for a couple of seconds keyed by the query so polling is near-instant while
-    # logs stay fresh. Time-window/download queries (since/until) bypass the cache.
-    ttl = float(os.getenv("ADMIN_LOGS_CACHE_SECONDS", "2.5") or "2.5")
-    cache_key = (lines, contains, clean)
-    cacheable = not since and not until
-    now = time.time()
-    if cacheable and ttl > 0:
-        hit = _LOGS_CACHE.get(cache_key)
-        if hit and now - hit[0] < ttl:
-            return hit[1]
+def _log_follower_loop() -> None:
+    """Stream the service journal into the in-memory ring for the process life."""
+    while True:
+        try:
+            proc = subprocess.Popen(
+                [
+                    "journalctl", "-u", SERVICE_NAME,
+                    "-n", str(_RING_MAX), "-f", "--no-pager", "-o", "cat",
+                ],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
+                text=True,
+                bufsize=1,
+            )
+            if proc.stdout is not None:
+                for line in proc.stdout:
+                    _LOG_RING.append(line.rstrip("\n"))
+        except Exception:
+            pass
+        # journalctl unavailable/exited: backfill from the log file if present,
+        # then wait briefly and re-attach.
+        try:
+            if LOG_PATH.exists():
+                for line in _tail_file(LOG_PATH, _RING_MAX).splitlines():
+                    _LOG_RING.append(line)
+        except Exception:
+            pass
+        time.sleep(2.0)
+
+
+def _ensure_log_follower() -> None:
+    global _LOG_FOLLOWER_STARTED
+    if _LOG_FOLLOWER_STARTED:
+        return
+    with _LOG_FOLLOWER_LOCK:
+        if _LOG_FOLLOWER_STARTED:
+            return
+        threading.Thread(
+            target=_log_follower_loop, name="admin-log-follower", daemon=True
+        ).start()
+        _LOG_FOLLOWER_STARTED = True
+
+
+def _gather_logs_window(
+    lines: int, since: str, until: str, contains: str, clean: bool
+) -> str:
+    """One-off journalctl for explicit time-window downloads (never polled)."""
     text = ""
     try:
         cmd = ["journalctl", "-u", SERVICE_NAME, "-n", str(lines), "--no-pager", "-o", "cat"]
@@ -211,22 +252,35 @@ def _gather_logs(lines: int, since: str = "", until: str = "", contains: str = "
         try:
             text = _tail_file(LOG_PATH, lines)
         except Exception as exc:  # noqa: BLE001
-            text = f"log read error: {exc}"
-    if not text:
-        return "Waiting for logs…"
+            return f"log read error: {exc}"
     rows = text.splitlines()
     if clean:
         rows = [c for c in (_clean_log_line(r) for r in rows) if c]
     if contains:
         n = contains.lower()
         rows = [r for r in rows if n in r.lower()]
-    result = "\n".join(rows) if rows else "No matching log lines."
-    if cacheable and ttl > 0:
-        _LOGS_CACHE[cache_key] = (now, result)
-        if len(_LOGS_CACHE) > 32:  # bound the cache
-            for k in list(_LOGS_CACHE)[:-16]:
-                _LOGS_CACHE.pop(k, None)
-    return result
+    return "\n".join(rows) if rows else "No matching log lines."
+
+
+def _gather_logs(lines: int, since: str = "", until: str = "", contains: str = "", clean: bool = True) -> str:
+    lines = max(50, min(int(lines or 400), 20000))
+    # Explicit time-window queries are manual download-only (never polled), so a
+    # one-off subprocess there is fine. Everything else — the polling Logs page,
+    # status, trades — is served straight from the in-memory ring with no
+    # subprocess and no disk access, so the request path never blocks.
+    if since or until:
+        return _gather_logs_window(lines, since, until, contains, clean)
+    _ensure_log_follower()
+    rows = list(_LOG_RING)
+    if clean:
+        rows = [c for c in (_clean_log_line(r) for r in rows) if c]
+    if contains:
+        n = contains.lower()
+        rows = [r for r in rows if n in r.lower()]
+    rows = rows[-lines:]
+    if not rows:
+        return "Waiting for logs…"
+    return "\n".join(rows)
 
 
 def _restart_service() -> None:
@@ -541,23 +595,16 @@ def status_json(request: Request) -> JSONResponse:
     ttl = float(os.getenv("ADMIN_STATUS_CACHE_SECONDS", "10") or "10")
     if now - float(_STATUS_CACHE["at"]) < ttl:
         return JSONResponse({"label": _STATUS_CACHE["label"], "color": _STATUS_CACHE["color"]})
-    # Lightweight health: is the trading engine up, or degraded/stopped?
+    # The dashboard runs inside the bot process: if this handler is answering,
+    # the process is alive. Derive health from the in-memory log tail only — no
+    # systemctl/journalctl subprocess on the request path.
     label, color = "running", "#3fb950"
     try:
-        out = subprocess.run(
-            ["systemctl", "is-active", SERVICE_NAME],
-            capture_output=True, text=True, timeout=5,
-        )
-        active = out.stdout.strip()
-        if active != "active":
-            label, color = active or "stopped", "#f85149"
-        else:
-            # Look for a recent degraded/crash marker in the tail.
-            tail = _gather_logs(60, clean=True)
-            if "degraded mode" in tail or "Missing required env" in tail:
-                label, color = "degraded", "#d29922"
-            elif "Bot fully operational" in tail or "fully operational" in tail:
-                label, color = "operational", "#3fb950"
+        tail = _gather_logs(60, clean=True)
+        if "degraded mode" in tail or "Missing required env" in tail:
+            label, color = "degraded", "#d29922"
+        elif "fully operational" in tail:
+            label, color = "operational", "#3fb950"
     except Exception:
         label, color = "unknown", "#8b97a6"
     _STATUS_CACHE.update({"at": now, "label": label, "color": color})

--- a/tests/test_admin_dashboard_log_ring.py
+++ b/tests/test_admin_dashboard_log_ring.py
@@ -1,0 +1,67 @@
+"""Dashboard is super-lite: logs served from an in-memory ring, never a
+subprocess on the polled request path.
+
+Regression guard for the dashboard-hang root cause: ``_gather_logs`` used to
+run ``journalctl`` (15s timeout) on every cache miss, blocking the shared
+threadpool. It now reads a background-filled ring buffer with zero subprocess
+on the hot path.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import nifty_scalper_bot.admin_dashboard as dash
+
+
+@pytest.fixture(autouse=True)
+def _prime_ring(monkeypatch: pytest.MonkeyPatch):
+    # Pretend the follower already runs so _gather_logs never tries to spawn it.
+    monkeypatch.setattr(dash, "_LOG_FOLLOWER_STARTED", True, raising=False)
+    dash._LOG_RING.clear()
+    for i in range(1, 201):
+        dash._LOG_RING.append(f"[2026-06-19 11:13:00 IST] line {i} EXIT done")
+    # Any subprocess on the hot path must fail the test loudly.
+    def _boom(*a, **k):
+        raise AssertionError("subprocess invoked on the hot log path")
+    monkeypatch.setattr(dash.subprocess, "run", _boom)
+    monkeypatch.setattr(dash.subprocess, "Popen", _boom)
+    yield
+    dash._LOG_RING.clear()
+
+
+async def test_gather_logs_reads_ring_without_subprocess() -> None:
+    out = dash._gather_logs(50, clean=True)
+    rows = out.splitlines()
+    assert len(rows) == 50  # last 50 of 200
+    assert "line 200" in rows[-1]
+    assert "line 151" in rows[0]
+
+
+async def test_gather_logs_contains_filter() -> None:
+    dash._LOG_RING.append("[2026-06-19 11:14:00 IST] ORDER_REJECTED foo")
+    out = dash._gather_logs(400, contains="ORDER_REJECTED", clean=True)
+    assert out.splitlines() == ["2026-06-19 11:14:00 IST  ORDER_REJECTED foo"]
+
+
+async def test_gather_logs_empty_ring_message(monkeypatch: pytest.MonkeyPatch) -> None:
+    dash._LOG_RING.clear()
+    out = dash._gather_logs(100)
+    assert out == "Waiting for logs…"
+
+
+async def test_ensure_follower_is_idempotent(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Already-started flag means no new thread is spawned (and no subprocess).
+    started = {"n": 0}
+
+    class _FakeThread:
+        def __init__(self, *a, **k):
+            started["n"] += 1
+
+        def start(self):
+            pass
+
+    monkeypatch.setattr(dash.threading, "Thread", _FakeThread)
+    monkeypatch.setattr(dash, "_LOG_FOLLOWER_STARTED", True, raising=False)
+    dash._ensure_log_follower()
+    assert started["n"] == 0

--- a/tests/test_admin_dashboard_tail.py
+++ b/tests/test_admin_dashboard_tail.py
@@ -29,31 +29,30 @@ async def test_tail_file_is_byte_bounded(tmp_path: Path) -> None:
     assert rows[-1] == "line 99999"  # still anchored to the file's end
 
 
-async def test_status_json_caches_subprocess(monkeypatch) -> None:
-    # The Logs page polls status.json every few seconds; it must NOT spawn a
-    # systemctl subprocess on every poll (that saturated the threadpool and hung
-    # the dashboard). Second call within TTL must be served from cache.
+async def test_status_json_uses_no_subprocess(monkeypatch) -> None:
+    # The Logs page polls status.json every few seconds. It must derive health
+    # from the in-memory log tail (the dashboard runs inside the bot process, so
+    # answering at all means it's alive) and spawn NO subprocess — the old
+    # systemctl-per-poll saturated the threadpool and hung the dashboard.
+    import json as _json
+
     import nifty_scalper_bot.admin_dashboard as dash
 
     calls = {"n": 0}
 
-    class _Out:
-        stdout = "active"
-
-    def _fake_run(*_a, **_k):
+    def _boom(*_a, **_k):
         calls["n"] += 1
-        return _Out()
+        raise AssertionError("status.json must not spawn a subprocess")
 
-    monkeypatch.setattr(dash.subprocess, "run", _fake_run)
-    monkeypatch.setattr(dash, "_gather_logs", lambda *_a, **_k: "Bot fully operational")
+    monkeypatch.setattr(dash.subprocess, "run", _boom)
+    monkeypatch.setattr(dash.subprocess, "Popen", _boom)
+    monkeypatch.setattr(dash, "_gather_logs", lambda *_a, **_k: "fully operational")
     monkeypatch.setattr(dash, "_check_auth", lambda _r: None)
-    monkeypatch.setenv("ADMIN_STATUS_CACHE_SECONDS", "10")
-    dash._STATUS_CACHE.update({"at": 0.0})  # force a cold first call
+    dash._STATUS_CACHE.update({"at": 0.0})  # force a cold call
 
-    dash.status_json(request=None)  # cold -> spawns
-    dash.status_json(request=None)  # cached -> no spawn
-    dash.status_json(request=None)  # cached -> no spawn
-    assert calls["n"] == 1, "status.json must cache, not spawn systemctl every poll"
+    resp = dash.status_json(request=None)
+    assert calls["n"] == 0
+    assert _json.loads(bytes(resp.body))["label"] == "operational"
 
 
 async def test_read_env_is_cached(tmp_path, monkeypatch) -> None:
@@ -122,27 +121,37 @@ async def test_app_uses_normalize_symbol_not_datahub_normalize() -> None:
     assert normalize_symbol("nfo:nifty2662324100ce") == "NFO:NIFTY2662324100CE"
 
 
-async def test_gather_logs_is_cached(monkeypatch) -> None:
-    # The Logs page polls + page + download + status all call _gather_logs. Each
-    # call otherwise spawns a journalctl subprocess (up to 15s) and saturates the
-    # shared threadpool, hanging the dashboard. Repeated identical calls within the
-    # TTL must spawn journalctl once.
+async def test_gather_logs_reads_ring_not_subprocess(monkeypatch) -> None:
+    # The Logs page / status / trades all call _gather_logs on a poll. It must
+    # read the in-memory ring with NO subprocess on the request path (the old
+    # per-call journalctl saturated the threadpool and hung the dashboard). Only
+    # an explicit since/until download does a one-off journalctl.
     import nifty_scalper_bot.admin_dashboard as dash
-    dash._LOGS_CACHE.clear()
-    monkeypatch.setenv("ADMIN_LOGS_CACHE_SECONDS", "5")
+
+    monkeypatch.setattr(dash, "_LOG_FOLLOWER_STARTED", True, raising=False)
+    dash._LOG_RING.clear()
+    dash._LOG_RING.append("[2026-06-18 14:00:00 IST] ORDER_SENT x")
+
     calls = {"n": 0}
+
     class _O:
         returncode = 0
         stdout = "[2026-06-18 14:00:00 IST] ORDER_SENT x\n"
+
     def _run(*a, **k):
         calls["n"] += 1
         return _O()
+
     monkeypatch.setattr(dash.subprocess, "run", _run)
+
     a = dash._gather_logs(400)
     b = dash._gather_logs(400)
     c = dash._gather_logs(400)
-    assert calls["n"] == 1, "journalctl must be spawned once, then served from cache"
+    assert calls["n"] == 0, "polled path must read the ring, never spawn journalctl"
     assert a == b == c
-    # a download-style time-window query bypasses the cache (always fresh)
+    assert "ORDER_SENT x" in a
+
+    # An explicit time-window download bypasses the ring and does a one-off call.
     dash._gather_logs(400, since="2026-06-18")
-    assert calls["n"] == 2
+    assert calls["n"] == 1
+    dash._LOG_RING.clear()


### PR DESCRIPTION
Root cause of the dashboard hang: _gather_logs ran journalctl (15s timeout) on the request thread per cache miss, and status.json ran systemctl is-active. Under multi-tab polling on the 1.9GB host these blocked the shared threadpool (shared with the trading engine); caching only shrank the window.

Now one background journalctl --follow thread streams into a bounded in-memory ring; all polled handlers read from memory only -> instant, engine never starved, no disk storage. status.json infers health from the log tail (no systemctl). Only since/until downloads do a one-off journalctl. _LOGS_CACHE removed; tests updated to the no-subprocess contract. Suite 2333 passed.