### PR TITLE
feat: Telegram /logs and /dumplogs commands (Android log access, no SSH)

### DIFF
--- a/src/nifty_scalper_bot/notifications/operator_telegram.py
+++ b/src/nifty_scalper_bot/notifications/operator_telegram.py
@@ -690,6 +690,57 @@ async def cmd_stderror(update: Update, _: ContextTypes.DEFAULT_TYPE, service: An
     await safe_reply(update, str(err) if err else "No runtime exception captured.")
 
 
+def _parse_count(update: Update, default: int, lo: int, hi: int) -> int:
+    try:
+        msg = getattr(update, "effective_message", None)
+        parts = (getattr(msg, "text", "") or "").split()
+        if len(parts) > 1:
+            return max(lo, min(int(parts[1]), hi))
+    except Exception:
+        pass
+    return default
+
+
+def _log_ring_tail(n: int) -> list[str]:
+    # Lazy import to avoid a circular import (telegram_controller imports this
+    # module). RING is the in-process buffer fed by every log record.
+    from nifty_scalper_bot.notifications.telegram_controller import RING
+
+    return RING.tail(n)
+
+
+async def cmd_logs(update: Update, _: ContextTypes.DEFAULT_TYPE, service: Any) -> None:
+    """Show the most recent log lines inline (/logs [N], default 80)."""
+    del service
+    n = _parse_count(update, default=80, lo=10, hi=400)
+    lines = _log_ring_tail(n)
+    text = "\n".join(lines) if lines else "No logs buffered yet."
+    # Telegram hard-caps messages near 4096 chars; keep the newest tail.
+    if len(text) > 3500:
+        text = "…(truncated)…\n" + text[-3500:]
+    await safe_reply(update, text)
+
+
+async def cmd_dumplogs(update: Update, _: ContextTypes.DEFAULT_TYPE, service: Any) -> None:
+    """Send recent logs as a downloadable .txt file (/dumplogs [N], default 1500)."""
+    del service
+    import io
+    import time as _time
+
+    from telegram import InputFile
+
+    n = _parse_count(update, default=1500, lo=50, hi=5000)
+    text = "\n".join(_log_ring_tail(n)) or "No logs buffered yet."
+    bio = io.BytesIO(text.encode("utf-8"))
+    bio.name = f"niftybot-logs-{_time.strftime('%Y%m%d-%H%M%S')}.txt"
+    chat = getattr(update, "effective_chat", None)
+    sender = getattr(chat, "send_document", None) if chat is not None else None
+    if sender is None:
+        await safe_reply(update, "Cannot send a document to this chat.")
+        return
+    await sender(InputFile(bio))
+
+
 async def cmd_selftest(update: Update, _: ContextTypes.DEFAULT_TYPE, service: Any) -> None:
     snap = _runtime_snapshot(service)
     await safe_reply(update, _lines("Selftest (read-only)", {
@@ -755,6 +806,8 @@ OPERATOR_COMMANDS: list[CommandSpec] = [
     CommandSpec("check_core", "strategy runner, regime, session, startup/readiness state", cmd_check_core),
     CommandSpec("check_execution", "live-order arming, risk, positions, open orders, bracket status", cmd_check_execution),
     CommandSpec("errors", "recent error log summary", cmd_errors),
+    CommandSpec("logs", "recent log lines inline (/logs [N])", cmd_logs),
+    CommandSpec("dumplogs", "download recent logs as a .txt file (/dumplogs [N])", cmd_dumplogs),
     CommandSpec("stderror", "last runtime exception/error details", cmd_stderror),
     CommandSpec("selftest", "run non-invasive system self-test", cmd_selftest),
     CommandSpec("emergency", "emergency stop / disable live orders", cmd_emergency),

--- a/tests/telegram/test_logs_commands.py
+++ b/tests/telegram/test_logs_commands.py
@@ -1,0 +1,90 @@
+"""Telegram /logs (inline tail) and /dumplogs (downloadable file) commands.
+
+These give an Android-friendly, nil-cost way to read and download logs without
+SSH. Both read the in-process RING buffer. cmd_dump_logs existed but was never
+registered; these are the wired, tested entry points.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from nifty_scalper_bot.notifications import operator_telegram as ot
+from nifty_scalper_bot.notifications.telegram_controller import RING
+
+
+@pytest.fixture(autouse=True)
+def _seed_ring():
+    RING.buf.clear()
+    for i in range(1, 251):
+        RING.add(f"12:00:0{i % 10} [INFO] root: event line {i}")
+    yield
+    RING.buf.clear()
+
+
+async def test_cmd_logs_replies_with_tail(monkeypatch: pytest.MonkeyPatch) -> None:
+    reply = AsyncMock()
+    monkeypatch.setattr(ot, "safe_reply", reply)
+    update = SimpleNamespace(effective_message=SimpleNamespace(text="/logs 20"))
+
+    await ot.cmd_logs(update, SimpleNamespace(), service=None)
+
+    reply.assert_awaited_once()
+    text = reply.await_args.args[1]
+    assert "line 250" in text  # newest present
+    assert "line 231" in text  # 20 lines back
+    assert "line 230" not in text  # only the last 20
+
+
+async def test_cmd_logs_caps_message_length(monkeypatch: pytest.MonkeyPatch) -> None:
+    reply = AsyncMock()
+    monkeypatch.setattr(ot, "safe_reply", reply)
+    update = SimpleNamespace(effective_message=SimpleNamespace(text="/logs 400"))
+
+    await ot.cmd_logs(update, SimpleNamespace(), service=None)
+
+    text = reply.await_args.args[1]
+    assert len(text) <= 3520  # 3500 tail + truncation marker
+
+
+async def test_cmd_dumplogs_sends_document() -> None:
+    sent = {}
+
+    async def _send_document(doc):
+        sent["doc"] = doc
+
+    chat = SimpleNamespace(send_document=_send_document)
+    update = SimpleNamespace(
+        effective_message=SimpleNamespace(text="/dumplogs 100"),
+        effective_chat=chat,
+    )
+
+    await ot.cmd_dumplogs(update, SimpleNamespace(), service=None)
+
+    assert "doc" in sent  # a document was sent
+    # InputFile wraps the bytes; confirm our newest line is in the payload.
+    payload = sent["doc"].input_file_content
+    body = payload.decode() if isinstance(payload, (bytes, bytearray)) else str(payload)
+    assert "line 250" in body
+
+
+async def test_cmd_dumplogs_no_chat_falls_back_to_reply(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    reply = AsyncMock()
+    monkeypatch.setattr(ot, "safe_reply", reply)
+    update = SimpleNamespace(
+        effective_message=SimpleNamespace(text="/dumplogs"), effective_chat=None
+    )
+
+    await ot.cmd_dumplogs(update, SimpleNamespace(), service=None)
+
+    reply.assert_awaited_once()
+
+
+async def test_logs_commands_registered() -> None:
+    names = {spec.name for spec in ot.OPERATOR_COMMANDS}
+    assert {"logs", "dumplogs"} <= names


### PR DESCRIPTION
RING already buffers every log line; cmd_dump_logs existed but was never registered. Adds wired /logs [N] (inline tail, capped to message limit) and /dumplogs [N] (downloadable .txt). Nil-cost, Android-friendly log review/download that survives a slow dashboard, no scroll reset, no terminal. 5 tests; discrimination-verified.