### PR TITLE
perf: standalone admin dashboard process isolated from the trading engine

### DIFF
--- a/src/nifty_scalper_bot/admin_app.py
+++ b/src/nifty_scalper_bot/admin_app.py
@@ -1,0 +1,40 @@
+"""Standalone admin dashboard ASGI app.
+
+The dashboard and the trading engine previously ran in ONE uvicorn process,
+sharing a single asyncio event loop (the engine runs as a lifespan task on the
+same loop). On the memory-tight host, engine CPU/loop load and swap pressure
+gradually starved the shared loop until the dashboard stopped responding —
+"works for a while, then hangs".
+
+This entrypoint serves ONLY the admin router, which is filesystem-only — it
+touches ``.env``, journald, git and systemctl, and imports no engine objects.
+Run it as its own service so the dashboard is fully isolated and stays
+responsive no matter how busy the engine is:
+
+    uvicorn nifty_scalper_bot.admin_app:app --host 0.0.0.0 --port 8081
+
+Token entry / mode changes are written to ``.env``; the engine (a separate
+service) reads them on its next restart, which the dashboard's Restart/Update
+buttons trigger.
+"""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.responses import RedirectResponse
+
+from nifty_scalper_bot.admin_dashboard import router as _admin_router
+
+app = FastAPI(title="Nifty Scalper Bot — Admin", docs_url=None, redoc_url=None)
+app.include_router(_admin_router)
+
+
+@app.get("/")
+def _root() -> RedirectResponse:
+    return RedirectResponse("/admin")
+
+
+@app.get("/healthz")
+def _healthz() -> dict[str, str]:
+    # Liveness for the admin process itself (independent of the engine).
+    return {"status": "ok"}

--- a/tests/test_admin_app_standalone.py
+++ b/tests/test_admin_app_standalone.py
@@ -1,0 +1,41 @@
+"""The standalone admin app must serve the dashboard routes end-to-end and stay
+isolated from the trading engine (it must not import core.app / the engine)."""
+
+from __future__ import annotations
+
+import pathlib
+
+from fastapi.testclient import TestClient
+
+from nifty_scalper_bot.admin_app import app
+
+_client = TestClient(app)
+
+
+async def test_healthz_independent_of_engine() -> None:
+    r = _client.get("/healthz")
+    assert r.status_code == 200
+    assert r.json() == {"status": "ok"}
+
+
+async def test_root_redirects_to_admin() -> None:
+    r = _client.get("/", follow_redirects=False)
+    assert r.status_code in (302, 307)
+    assert r.headers["location"] == "/admin"
+
+
+async def test_login_page_served() -> None:
+    r = _client.get("/admin/login")
+    assert r.status_code == 200
+
+
+async def test_logs_endpoint_mounted() -> None:
+    r = _client.get("/admin/logs.json", follow_redirects=False)
+    assert r.status_code != 404
+
+
+async def test_admin_app_does_not_import_engine_in_source() -> None:
+    src = pathlib.Path("src/nifty_scalper_bot/admin_app.py").read_text()
+    assert "core.app" not in src
+    assert "run_bot_background" not in src
+    assert "strategies" not in src


### PR DESCRIPTION
Permanent fix for the gradual dashboard hang. The dashboard + engine shared one uvicorn event loop (engine = lifespan task); engine load + swap on the 1.9GB host progressively starved the loop until the dashboard stopped responding. The admin router is filesystem-only (no engine imports), so it can run as its own process. Adds admin_app:app to run as a separate service/port, fully isolated. 5 tests. Requires a second systemd unit on the host (instructions in chat).