### PR TITLE
Consolidate production log throttling and add state-change & strategy aggregation

### DIFF
--- a/src/nifty_scalper_bot/admin_dashboard.py
+++ b/src/nifty_scalper_bot/admin_dashboard.py
@@ -31,7 +31,7 @@ from fastapi.responses import HTMLResponse, RedirectResponse, PlainTextResponse,
 router = APIRouter()
 
 ENV_PATH = Path(os.getenv("BOT_ENV_FILE", "/home/ubuntu/nifty_scalper_bot/.env"))
-LOG_PATH = Path(os.getenv("BOT_LOG_FILE", "/home/ubuntu/nifty_scalper_bot/bot.log"))
+LOG_PATH = Path(os.getenv("BOT_LOG_FILE", str(Path(os.getenv("LOG_DIR", "logs")).expanduser() / "bot.log")))
 SERVICE_NAME = os.getenv("BOT_SERVICE_NAME", "niftybot")
 APP_DIR = Path(os.getenv("BOT_APP_DIR", "/home/ubuntu/nifty_scalper_bot"))
 

--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -452,13 +452,14 @@ async def _polling_failover_supervisor_iteration(
                     extra={"event": "POLLING_FALLBACK_SKIPPED", "reason": "within_spot_stale_threshold", "age_ms": spot_age_ms, "threshold_ms": quote_stale_ms, "ws_ok": ws_ok},
                 )
                 return degraded_since, recovered_since
-            LOGGER.warning(
-                "POLLING_FALLBACK_ACTIVATE reason=spot_stale age_ms=%s threshold_ms=%s ws_ok=%s lagging=%s",
-                spot_age_ms,
-                quote_stale_ms,
-                ws_ok,
-                lagging,
-                extra={"event": "poll_fallback_activate", "reason": "ws_disconnected" if not ws_ok else "tick_lag" if lagging else "futures_stale" if not futures_fresh else "options_stale", "lagging": lagging, "futures_fresh": futures_fresh, "options_fresh": options_fresh, "authoritative_age_ms": auth_tick_age_ms},
+            _fallback_reason = "ws_disconnected" if not ws_ok else "tick_lag" if lagging else "futures_stale" if not futures_fresh else "options_stale"
+            log_state_change(
+                LOGGER,
+                "POLLING_FALLBACK_ACTIVATE",
+                (_fallback_reason, ws_ok, lagging, futures_fresh, options_fresh),
+                level=logging.WARNING,
+                msg="POLLING_FALLBACK_ACTIVATE reason=spot_stale age_ms=%s threshold_ms=%s ws_ok=%s lagging=%s" % (spot_age_ms, quote_stale_ms, ws_ok, lagging),
+                extra={"event": "poll_fallback_activate", "reason": _fallback_reason, "lagging": lagging, "futures_fresh": futures_fresh, "options_fresh": options_fresh, "authoritative_age_ms": auth_tick_age_ms},
             )
             _safe_supervisor_call("polling_fallback.set_websocket_mode", getattr(polling_fallback, "set_websocket_mode", None), False)
             _safe_supervisor_call("polling_fallback.start", getattr(polling_fallback, "start", None))
@@ -471,7 +472,14 @@ async def _polling_failover_supervisor_iteration(
             symbol=spot_symbol,
             stale_after_ms=quote_stale_ms,
         )
-        LOGGER.info("poll_fallback_skipped_spot_only_stale symbol=%s age_ms=%s", spot_symbol, spot_age_ms)
+        log_state_change(
+            LOGGER,
+            f"poll_fallback_skipped_spot_only_stale:{spot_symbol}",
+            ("spot_only_stale", spot_symbol, bool(spot_fresh), bool(futures_fresh), bool(options_fresh)),
+            level=logging.INFO,
+            msg="poll_fallback_skipped_spot_only_stale symbol=%s age_ms=%s" % (spot_symbol, spot_age_ms),
+            extra={"event": "poll_fallback_skipped_spot_only_stale", "symbol": spot_symbol, "age_ms": spot_age_ms},
+        )
     degraded_since = None
     recovered_since = recovered_since or now_mono
     if now_mono - recovered_since >= recover_cooldown and bool(_safe_supervisor_call("polling_fallback.is_running", getattr(polling_fallback, "is_running", None), default=False)):
@@ -1238,7 +1246,7 @@ from nifty_scalper_bot.utils.env import (
     normalize_path,
 )
 from nifty_scalper_bot.utils.errors import ConfigurationError
-from nifty_scalper_bot.utils.logging import get_logger, log_throttled, setup_logging
+from nifty_scalper_bot.utils.logging import get_logger, log_state_change, log_throttled, setup_logging
 from nifty_scalper_bot.utils.market_hours import (
     MarketState,
     allow_offhours_testing_safe,

--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -458,7 +458,7 @@ async def _polling_failover_supervisor_iteration(
                 "POLLING_FALLBACK_ACTIVATE",
                 (_fallback_reason, ws_ok, lagging, futures_fresh, options_fresh),
                 level=logging.WARNING,
-                msg="POLLING_FALLBACK_ACTIVATE reason=spot_stale age_ms=%s threshold_ms=%s ws_ok=%s lagging=%s" % (spot_age_ms, quote_stale_ms, ws_ok, lagging),
+                msg="POLLING_FALLBACK_ACTIVATE reason=%s age_ms=%s threshold_ms=%s ws_ok=%s lagging=%s" % (_fallback_reason, spot_age_ms, quote_stale_ms, ws_ok, lagging),
                 extra={"event": "poll_fallback_activate", "reason": _fallback_reason, "lagging": lagging, "futures_fresh": futures_fresh, "options_fresh": options_fresh, "authoritative_age_ms": auth_tick_age_ms},
             )
             _safe_supervisor_call("polling_fallback.set_websocket_mode", getattr(polling_fallback, "set_websocket_mode", None), False)

--- a/src/nifty_scalper_bot/core/strategy_manager.py
+++ b/src/nifty_scalper_bot/core/strategy_manager.py
@@ -4136,7 +4136,12 @@ class StrategyManager(_BaseStrategyManager):
                         blocked_reason = "single_vote_scalp_disabled"
                     else:
                         blocked_reason = "single_vote_gate_failed_unknown"
-                    log.info(
+                    log_throttled_live(
+                        log,
+                        logging.INFO,
+                        "TRADE_DECISION_TRACE",
+                        f"TRADE_DECISION_TRACE:{best_vote.strategy}:{symbol_norm}:{blocked_reason}",
+                        float(os.getenv("LOG_THROTTLE_STRATEGY_REJECT_SECONDS", "120") or "120"),
                         "TRADE_DECISION_TRACE symbol=%s strategy=%s side=%s allowed=%s blocked_at=%s blocked_reason=%s selected_ce=%s selected_pe=%s strike_distance_from_atm=%s near_atm_threshold=%s selected_ok_reason=%s raw_score=%.2f confidence=%.2f",
                         symbol_norm,
                         best_vote.strategy,
@@ -4172,7 +4177,12 @@ class StrategyManager(_BaseStrategyManager):
         metadata["final_trade_score"] = round(final_score, 3)
         if vetoed or final_score < threshold:
             blocked_reason = "hard_context_veto" if vetoed else "final_trade_score_below_threshold"
-            log.info(
+            log_throttled_live(
+                log,
+                logging.INFO,
+                "TRADE_DECISION_TRACE",
+                f"TRADE_DECISION_TRACE:{best_vote.strategy}:{symbol_norm}:{blocked_reason}",
+                float(os.getenv("LOG_THROTTLE_STRATEGY_REJECT_SECONDS", "120") or "120"),
                 "TRADE_DECISION_TRACE symbol=%s strategy=%s side=%s data_gate=%s setup_score=%.2f setup_min=%.2f weighted_score=%.2f regime_weight=%.2f context_bonus=%.2f context_penalty=%.2f final_score=%.2f final_min=%.2f allowed=%s blocked_at=%s blocked_reason=%s",
                 symbol_norm, best_vote.strategy, best_vote.side, True, raw_trigger_score, threshold, weighted_trigger_score, _regime_weight(best_vote), context_bonus, context_penalty, final_score, threshold, False, "strategy_manager_combine", blocked_reason,
                 extra={"event": "TRADE_DECISION_TRACE", "symbol": symbol_norm, "strategy": best_vote.strategy, "side": best_vote.side, "data_gate": True, "setup_score": raw_trigger_score, "setup_min": threshold, "weighted_score": weighted_trigger_score, "regime_weight": _regime_weight(best_vote), "context_bonus": context_bonus, "context_penalty": context_penalty, "final_score": final_score, "final_min": threshold, "allowed": False, "blocked_at": "strategy_manager_combine", "blocked_reason": blocked_reason},
@@ -4195,15 +4205,26 @@ class StrategyManager(_BaseStrategyManager):
         if not quality_pass:
             raw_reason = str(metadata.get("quality_block_reason") or "").strip().lower()
             metadata["quality_block_reason"] = "trade_quality_below_threshold" if raw_reason in {"", "ok"} else str(metadata.get("quality_block_reason"))
-            log.info(
+            log_throttled_live(
+                log,
+                logging.INFO,
+                "STRATEGY_QUALITY_REJECT",
+                f"STRATEGY_QUALITY_REJECT:{best_vote.strategy}:{symbol_norm}:{metadata['quality_block_reason']}",
+                float(os.getenv("LOG_THROTTLE_STRATEGY_REJECT_SECONDS", "120") or "120"),
                 "STRATEGY_QUALITY_REJECT symbol=%s strategy=%s side=%s score=%.2f reason=%s",
                 symbol_norm,
                 best_vote.strategy,
                 best_vote.side,
                 quality_score,
                 metadata["quality_block_reason"],
+                extra={"event": "STRATEGY_QUALITY_REJECT", "symbol": symbol_norm, "strategy": best_vote.strategy, "side": best_vote.side, "score": quality_score, "reason": metadata["quality_block_reason"]},
             )
-            log.info(
+            log_throttled_live(
+                log,
+                logging.INFO,
+                "TRADE_DECISION_TRACE",
+                f"TRADE_DECISION_TRACE:{best_vote.strategy}:{symbol_norm}:{metadata['quality_block_reason']}",
+                float(os.getenv("LOG_THROTTLE_STRATEGY_REJECT_SECONDS", "120") or "120"),
                 "TRADE_DECISION_TRACE symbol=%s strategy=%s side=%s allowed=%s blocked_at=%s blocked_reason=%s",
                 symbol_norm,
                 best_vote.strategy,
@@ -4211,6 +4232,7 @@ class StrategyManager(_BaseStrategyManager):
                 False,
                 "trade_quality_gate",
                 metadata["quality_block_reason"],
+                extra={"event": "TRADE_DECISION_TRACE", "symbol": symbol_norm, "strategy": best_vote.strategy, "side": best_vote.side, "allowed": False, "blocked_at": "trade_quality_gate", "blocked_reason": metadata["quality_block_reason"]},
             )
             _record_no_signal("strategy_no_trigger", str(metadata["quality_block_reason"]), "trade_quality_gate", trigger_vote_count=len(trigger_votes), context_vote_count=len(context_votes))
             return None

--- a/src/nifty_scalper_bot/core/strategy_manager.py
+++ b/src/nifty_scalper_bot/core/strategy_manager.py
@@ -37,7 +37,7 @@ from nifty_scalper_bot.strategies.signal_generator import (
 from nifty_scalper_bot.strategies.signal_generator import (
     StrategyManager as _BaseStrategyManager,
 )
-from nifty_scalper_bot.utils.log_throttle import log_throttled as log_throttled_live
+from nifty_scalper_bot.utils.log_throttle import maybe_emit_strategy_rejection_summary, record_strategy_evaluation, log_throttled as log_throttled_live
 from nifty_scalper_bot.utils.logging import get_logger, log_state_change, log_throttled
 from nifty_scalper_bot.utils.symbols import normalize_symbol
 from nifty_scalper_bot.execution.readiness import HistoryReadinessPolicy
@@ -4158,6 +4158,8 @@ class StrategyManager(_BaseStrategyManager):
                         best_vote.confidence,
                         extra={"event": "TRADE_DECISION_TRACE", "symbol": symbol_norm, "strategy": best_vote.strategy, "side": best_vote.side, "allowed": False, "blocked_at": "single_vote_gate", "blocked_reason": blocked_reason, "selected_ce": selected_ce, "selected_pe": selected_pe, "strike_distance_from_atm": strike_distance_from_atm, "near_atm_threshold": near_atm_threshold, "selected_ok_reason": selected_ok_reason, "raw_score": raw_trigger_score, "confidence": best_vote.confidence},
                     )
+                    record_strategy_evaluation(strategy=str(best_vote.strategy), symbol=symbol_norm, accepted=False, reason=str(blocked_reason), score=raw_trigger_score)
+                    maybe_emit_strategy_rejection_summary(log, interval_seconds=300.0)
                     category = "strategy_single_vote_disabled" if blocked_reason == "single_vote_scalp_disabled" else ("context_direction_conflict" if blocked_reason == "underlying_direction_conflict" else "strategy_no_trigger")
                     _record_no_signal(category, blocked_reason, "single_vote_gate", trigger_vote_count=len(trigger_votes), context_vote_count=len(context_votes))
                     return None
@@ -4187,6 +4189,8 @@ class StrategyManager(_BaseStrategyManager):
                 symbol_norm, best_vote.strategy, best_vote.side, True, raw_trigger_score, threshold, weighted_trigger_score, _regime_weight(best_vote), context_bonus, context_penalty, final_score, threshold, False, "strategy_manager_combine", blocked_reason,
                 extra={"event": "TRADE_DECISION_TRACE", "symbol": symbol_norm, "strategy": best_vote.strategy, "side": best_vote.side, "data_gate": True, "setup_score": raw_trigger_score, "setup_min": threshold, "weighted_score": weighted_trigger_score, "regime_weight": _regime_weight(best_vote), "context_bonus": context_bonus, "context_penalty": context_penalty, "final_score": final_score, "final_min": threshold, "allowed": False, "blocked_at": "strategy_manager_combine", "blocked_reason": blocked_reason},
             )
+            record_strategy_evaluation(strategy=str(best_vote.strategy), symbol=symbol_norm, accepted=False, reason=str(blocked_reason), score=final_score)
+            maybe_emit_strategy_rejection_summary(log, interval_seconds=300.0)
             _record_no_signal("strategy_score_below_threshold", blocked_reason, "strategy_manager_combine", trigger_vote_count=len(trigger_votes), context_vote_count=len(context_votes))
             return None
         quality_score, quality_meta = self._compute_trade_quality_score(
@@ -4234,6 +4238,8 @@ class StrategyManager(_BaseStrategyManager):
                 metadata["quality_block_reason"],
                 extra={"event": "TRADE_DECISION_TRACE", "symbol": symbol_norm, "strategy": best_vote.strategy, "side": best_vote.side, "allowed": False, "blocked_at": "trade_quality_gate", "blocked_reason": metadata["quality_block_reason"]},
             )
+            record_strategy_evaluation(strategy=str(best_vote.strategy), symbol=symbol_norm, accepted=False, reason=str(metadata["quality_block_reason"]), score=quality_score)
+            maybe_emit_strategy_rejection_summary(log, interval_seconds=300.0)
             _record_no_signal("strategy_no_trigger", str(metadata["quality_block_reason"]), "trade_quality_gate", trigger_vote_count=len(trigger_votes), context_vote_count=len(context_votes))
             return None
 
@@ -4290,6 +4296,8 @@ class StrategyManager(_BaseStrategyManager):
         metadata["approval_path"] = approval_path
         metadata["is_approved"] = True
         log.info("TRADE_DECISION_TRACE approval_path=%s symbol=%s strategy=%s", approval_path, symbol_norm, best_vote.strategy)
+        record_strategy_evaluation(strategy=str(best_vote.strategy), symbol=symbol_norm, accepted=True, reason=str(approval_path), score=final_score)
+        maybe_emit_strategy_rejection_summary(log, interval_seconds=300.0)
         self._last_no_signal_decision_by_symbol.pop(symbol_norm, None)
         return Signal(
             action="BUY",
@@ -4560,6 +4568,8 @@ class StrategyManager(_BaseStrategyManager):
                 md[key] = value
         promoted = Signal(action="BUY", symbol=best_signal.symbol, quantity=best_signal.quantity, confidence=best_signal.confidence, reason=best_signal.reason, stop_loss=best_signal.stop_loss, take_profit=best_signal.take_profit, metadata=md)
         promoted_vote = StrategyVote(strategy=best_vote.strategy, side=best_vote.side, score=best_vote.score, confidence=best_vote.confidence, reasons=list(best_vote.reasons), metadata=md)
+        record_strategy_evaluation(strategy=str(best_vote.strategy), symbol=str(symbol), accepted=True, reason="direction_context_aligned", score=raw_score)
+        maybe_emit_strategy_rejection_summary(log, interval_seconds=300.0)
         log.info(
             "ORDERFLOW_TRIGGER_PROMOTED side=%s score=%.2f reason=direction_context_aligned symbol=%s direction_context_source=%s context_age_seconds=%.2f underlying_direction_confidence=%.2f",
             best_vote.side,

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -71,7 +71,7 @@ from nifty_scalper_bot.streaming.websocket_manager import (
 from nifty_scalper_bot.execution.readiness import evaluate_quote_readiness, resolve_quote_bid_ask_spread
 from nifty_scalper_bot.utils.env import get_str
 from nifty_scalper_bot.utils.async_helpers import safe_task
-from nifty_scalper_bot.utils.log_throttle import log_throttled as log_throttled_live
+from nifty_scalper_bot.utils.log_throttle import log_on_change, log_throttled as log_throttled_live
 from nifty_scalper_bot.utils.logging import get_logger, get_tracer_logger, log_throttled
 from nifty_scalper_bot.utils.market_hours import (
     MarketState,
@@ -2779,39 +2779,43 @@ class MarketDataManager:
                     if tick_age is None or tick_age <= stale_seconds:
                         return ltp
                     # Tick exists but is stale — log and fall through to broker
-                    last_warn = self._ltp_stale_warn_last.get(canonical_symbol, 0.0)
                     market_state = get_market_state()
                     log_interval = 900.0 if market_state != MarketState.OPEN else 60.0
-                    if now - last_warn >= log_interval:
-                        self._ltp_stale_warn_last[canonical_symbol] = now
-                        if market_state == MarketState.OPEN:
-                            self._logger.warning(
-                                "STALE_DATA symbol=%s age=%.2fs threshold=%.2fs — falling back to broker REST",
-                                canonical_symbol,
-                                tick_age,
-                                stale_seconds,
-                                extra={
-                                    "event": "STALE_DATA",
-                                    "symbol": canonical_symbol,
-                                    "age_s": round(float(tick_age), 3),
-                                    "threshold_s": stale_seconds,
-                                },
-                            )
-                        else:
-                            self._logger.debug(
-                                "OFF_MARKET_LTP_STALE symbol=%s age=%.2fs threshold=%.2fs state=%s",
-                                canonical_symbol,
-                                tick_age,
-                                stale_seconds,
-                                market_state.value,
-                                extra={
-                                    "event": "OFF_MARKET_LTP_STALE",
-                                    "symbol": canonical_symbol,
-                                    "age_s": round(float(tick_age), 3),
-                                    "threshold_s": stale_seconds,
-                                    "state": market_state.value,
-                                },
-                            )
+                    if market_state == MarketState.OPEN:
+                        log_on_change(
+                            self._logger,
+                            key=f"STALE_DATA:{canonical_symbol}",
+                            state=("STALE", round(float(stale_seconds), 0)),
+                            message="STALE_DATA symbol=%s age=%.2fs threshold=%.2fs — falling back to broker REST" % (canonical_symbol, tick_age, stale_seconds),
+                            reminder_seconds=log_interval,
+                            level=logging.WARNING,
+                            extra={
+                                "event": "STALE_DATA",
+                                "symbol": canonical_symbol,
+                                "age_s": round(float(tick_age), 3),
+                                "threshold_s": stale_seconds,
+                            },
+                        )
+                    else:
+                        log_throttled_live(
+                            self._logger,
+                            logging.DEBUG,
+                            "OFF_MARKET_LTP_STALE",
+                            f"OFF_MARKET_LTP_STALE:{canonical_symbol}:{market_state.value}",
+                            log_interval,
+                            "OFF_MARKET_LTP_STALE symbol=%s age=%.2fs threshold=%.2fs state=%s",
+                            canonical_symbol,
+                            tick_age,
+                            stale_seconds,
+                            market_state.value,
+                            extra={
+                                "event": "OFF_MARKET_LTP_STALE",
+                                "symbol": canonical_symbol,
+                                "age_s": round(float(tick_age), 3),
+                                "threshold_s": stale_seconds,
+                                "state": market_state.value,
+                            },
+                        )
             except (KeyError, TypeError, ValueError):
                 pass
 
@@ -6692,7 +6696,12 @@ class MarketDataManager:
                     1
                     for sym in stale_symbols_list
                 )
-            self._logger.info(
+            log_throttled_live(
+                self._logger,
+                logging.INFO,
+                "MARKET_DATA_HEALTH_SUMMARY",
+                f"MARKET_DATA_HEALTH_SUMMARY:{self._is_ws_connected()}:{subscribed}:{live_symbols}:{stale_symbols}",
+                float(os.getenv("LOG_THROTTLE_MARKET_DATA_HEALTH_SECONDS", "300") or "300"),
                 "MARKET_DATA_HEALTH_SUMMARY ws_connected=%s subscribed=%d live_symbols=%d stale_symbols=%d poll_fallbacks=%d bus_running=%s",
                 self._is_ws_connected(),
                 subscribed,
@@ -6700,6 +6709,7 @@ class MarketDataManager:
                 stale_symbols,
                 int(getattr(self, "_poll_fallback_count", 0)),
                 bool(getattr(getattr(self, "bus", None), "running", False)),
+                extra={"event": "MARKET_DATA_HEALTH_SUMMARY", "ws_connected": self._is_ws_connected(), "subscribed": subscribed, "live_symbols": live_symbols, "stale_symbols": stale_symbols},
             )
             now_epoch = time.time()
             last_detail_emit = float(getattr(self, "_last_stale_detail_emit_epoch", 0.0) or 0.0)
@@ -6757,11 +6767,13 @@ class MarketDataManager:
                         )
                 if not postmarket_quiet:
                     self._last_stale_detail_emit_epoch = now_epoch
-                    self._logger.info(
-                        "MARKET_DATA_STALE_SYMBOLS_DETAIL stale_count=%d fresh_count=%d ws_connected=%s",
-                        len(stale_symbols_list),
-                        len(fresh_symbols),
-                        self._is_ws_connected(),
+                    log_on_change(
+                        self._logger,
+                        key="MARKET_DATA_STALE_SYMBOLS_DETAIL",
+                        state=(tuple(sorted(stale_symbols_list)), self._is_ws_connected(), selected_ce_stale, selected_pe_stale),
+                        message="MARKET_DATA_STALE_SYMBOLS_DETAIL stale_count=%d fresh_count=%d ws_connected=%s" % (len(stale_symbols_list), len(fresh_symbols), self._is_ws_connected()),
+                        reminder_seconds=float(os.getenv("LOG_THROTTLE_MARKET_DATA_HEALTH_SECONDS", "300") or "300"),
+                        level=logging.INFO,
                         extra={
                             "event": "MARKET_DATA_STALE_SYMBOLS_DETAIL",
                             "total_symbols": subscribed,

--- a/src/nifty_scalper_bot/execution/bracket_manager.py
+++ b/src/nifty_scalper_bot/execution/bracket_manager.py
@@ -48,6 +48,7 @@ from typing import (
     runtime_checkable,
 )
 
+from nifty_scalper_bot.utils.log_throttle import log_throttled as log_throttled_live
 from nifty_scalper_bot.utils.logging import get_logger
 from nifty_scalper_bot.utils.symbols import normalize_symbol
 # --- NEW IMPORTS FOR WORLD-CLASS TRAILING ---
@@ -681,11 +682,10 @@ class BracketManager:
         *args: object,
     ) -> None:
         """Emit a throttled log event. Args: level,key,interval_sec,message,args; Returns: none; Raises: none."""
-        now = time.time()
-        if now - self._throttle_log_at.get(key, 0.0) < interval_sec:
-            return
-        self._throttle_log_at[key] = now
-        getattr(LOGGER, level, LOGGER.info)(message, *args)
+        level_value = getattr(logging, str(level).upper(), logging.INFO)
+        event = key.split(":", 1)[0].upper() if key else "BRACKET_MANAGER_THROTTLED_LOG"
+        if log_throttled_live(LOGGER, level_value, event, key, interval_sec, message, *args):
+            self._throttle_log_at[key] = time.monotonic()
 
     def shutdown(self) -> None:
         """Stop watchdog processing. Args: none; Returns: none; Raises: none."""

--- a/src/nifty_scalper_bot/execution/order_manager.py
+++ b/src/nifty_scalper_bot/execution/order_manager.py
@@ -86,6 +86,7 @@ from nifty_scalper_bot.storage.journal import AtomicKV
 from nifty_scalper_bot.utils import metrics
 from nifty_scalper_bot.utils.circuit_breaker import CircuitBreaker
 from nifty_scalper_bot.utils.errors import RateLimitError
+from nifty_scalper_bot.utils.log_throttle import log_on_change, log_throttled as log_throttled_live
 from nifty_scalper_bot.utils.logging import get_logger
 from nifty_scalper_bot.utils.metrics import Counter, Gauge
 from nifty_scalper_bot.utils.market_hours import get_time_status
@@ -2085,13 +2086,19 @@ class OrderManager:
 
     def _log_kill_switch_status(self) -> None:
         status = self.get_kill_switch_status()
-        self._logger.info(
-            "ORDER_KILL_SWITCH_STATUS active=%s reason=%s failures=%s engaged_at=%s auto_reset_allowed=%s",
-            status.get("active"),
-            status.get("kill_reason"),
-            status.get("consecutive_failures"),
-            status.get("engaged_at"),
-            status.get("auto_reset_allowed"),
+        log_on_change(
+            self._logger,
+            key="ORDER_KILL_SWITCH_STATUS",
+            state=(status.get("active"), status.get("kill_reason"), status.get("consecutive_failures"), status.get("engaged_at")),
+            message="ORDER_KILL_SWITCH_STATUS active=%s reason=%s failures=%s engaged_at=%s auto_reset_allowed=%s" % (
+                status.get("active"),
+                status.get("kill_reason"),
+                status.get("consecutive_failures"),
+                status.get("engaged_at"),
+                status.get("auto_reset_allowed"),
+            ),
+            reminder_seconds=300.0,
+            level=logging.INFO,
             extra={"event": "ORDER_KILL_SWITCH_STATUS", **status},
         )
 
@@ -2348,12 +2355,17 @@ class OrderManager:
             now_ts = time.time()
             if now_ts - self._last_kill_switch_log_ts >= 300.0:
                 self._last_kill_switch_log_ts = now_ts
-                self._logger.info(
+                log_throttled_live(
+                    self._logger,
+                    logging.INFO,
+                    "ORDER_KILL_SWITCH_BLOCK",
+                    f"ORDER_KILL_SWITCH_BLOCK:{symbol}:{self._kill_switch_reason}",
+                    300.0,
                     "ORDER_KILL_SWITCH_BLOCK symbol=%s consecutive_failures=%s reason=%s",
                     symbol,
                     self._consecutive_failures,
                     self._kill_switch_reason,
-                        extra={"event": "ORDER_KILL_SWITCH_BLOCK", "symbol": symbol, "consecutive_failures": self._consecutive_failures, "reason": self._kill_switch_reason},
+                    extra={"event": "ORDER_KILL_SWITCH_BLOCK", "symbol": symbol, "consecutive_failures": self._consecutive_failures, "reason": self._kill_switch_reason},
                 )
             self._logger.warning(
                 "ORDER_BLOCKED reason=kill_switch_active kill_reason=%s failures=%s engaged_at=%s trace_id=%s symbol=%s side=%s qty=%s last_failure_exception_type=%s last_failure_exception_message=%s",

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -122,7 +122,7 @@ from nifty_scalper_bot.strategies.signal_quality import (
 from nifty_scalper_bot.strategies.trade_selector import TradeCandidateSelector
 from nifty_scalper_bot.utils import metrics
 from nifty_scalper_bot.utils.errors import OrderPlacementError
-from nifty_scalper_bot.utils.log_throttle import log_throttled as log_throttled_live
+from nifty_scalper_bot.utils.log_throttle import log_on_change, log_throttled as log_throttled_live
 from nifty_scalper_bot.utils.logging import LogThrottle, get_logger, log_throttled
 from nifty_scalper_bot.utils.market_hours import (
     MarketState,
@@ -3600,7 +3600,12 @@ class StrategyRunner:
     ) -> SignalExecutionResult:
         """Log and return rejection. Args: symbol/trace_id/reason/details. Returns: result. Raises: none."""
         payload = dict(details or {})
-        self._logger.info(
+        log_throttled_live(
+            self._logger,
+            logging.INFO,
+            "SIGNAL_EXECUTION_RESULT",
+            f"SIGNAL_EXECUTION_RESULT:{symbol}:{reason}",
+            float(os.getenv("LOG_THROTTLE_STRATEGY_REJECT_SECONDS", "120") or "120"),
             "SIGNAL_EXECUTION_RESULT accepted=False reason=%s symbol=%s trace_id=%s",
             reason,
             symbol,
@@ -7414,10 +7419,25 @@ class StrategyRunner:
                 "order_manager_block_reason": order_manager_block_reason,
             }
             _snap_reason = str(self._runtime_readiness_reason or "")
-            _snap_key = f"readiness_snap:{symbol}:{_snap_reason}"
-            _snap_interval = float(os.getenv("RUNNER_READINESS_SNAP_INTERVAL_SECONDS", "60") or "60")
-            if self._should_log_throttled(_snap_key, _snap_interval):
-                self._logger.info("LIVE_TRADING_READINESS_SNAPSHOT symbol=%s live_orders_armed=%s reason=%s", symbol, bool(self._runtime_live_orders_armed), _snap_reason, extra=payload)
+            _snap_state = (
+                bool(self._runtime_evaluation_ready),
+                bool(self._runtime_live_orders_armed),
+                universe_ready,
+                _snap_reason,
+                bool(payload.get("ce_quote_ready")),
+                bool(payload.get("pe_quote_ready")),
+                bool(payload.get("ce_history_ready")),
+                bool(payload.get("pe_history_ready")),
+            )
+            log_on_change(
+                self._logger,
+                key=f"LIVE_TRADING_READINESS_SNAPSHOT:{symbol}",
+                state=_snap_state,
+                message="LIVE_TRADING_READINESS_SNAPSHOT symbol=%s live_orders_armed=%s reason=%s" % (symbol, bool(self._runtime_live_orders_armed), _snap_reason),
+                reminder_seconds=float(os.getenv("RUNNER_READINESS_SNAP_REMINDER_SECONDS", "600") or "600"),
+                level=logging.INFO,
+                extra=payload,
+            )
         except Exception as exc:
             self._logger.warning(
                 "LIVE_TRADING_READINESS_SNAPSHOT_FAILED symbol=%s error_type=%s error=%s",
@@ -7486,13 +7506,16 @@ class StrategyRunner:
             active_symbol = bool(sym and sym in active_subs)
             selected_pair = (getattr(self, "_active_selected_ce", None), getattr(self, "_active_selected_pe", None))
             state_key = (sym, token_int, desired, subscribed or active_symbol or confirmed, fresh_tick, selected_pair, get_runtime_market_mode())
-            if getattr(self, "_last_selected_subscription_state_key", None) != state_key or self._should_log_throttled(f"selected_subscription_summary:{sym}", float(os.getenv("RUNNER_BOOTSTRAP_LOG_INTERVAL_SECONDS", "60") or "60")):
-                self._last_selected_subscription_state_key = state_key
-                self._logger.info(
-                    "SELECTED_OPTION_SUBSCRIPTION_STATE symbol=%s token=%s desired=%s subscribed=%s fresh_tick=%s tick_age_s=%s",
-                    sym, token_int, desired, subscribed or active_symbol or confirmed, fresh_tick, None,
-                    extra={"event": "SELECTED_OPTION_SUBSCRIPTION_STATE", "symbol": sym, "token": token_int, "desired": desired, "subscribed": subscribed or active_symbol or confirmed, "fresh_tick": fresh_tick, "tick_age_s": None, "selected_ce": selected_pair[0], "selected_pe": selected_pair[1], "market_mode": get_runtime_market_mode()},
-                )
+            self._last_selected_subscription_state_key = state_key
+            log_on_change(
+                self._logger,
+                key=f"SELECTED_OPTION_SUBSCRIPTION_STATE:{sym}",
+                state=state_key,
+                message="SELECTED_OPTION_SUBSCRIPTION_STATE symbol=%s token=%s desired=%s subscribed=%s fresh_tick=%s tick_age_s=%s" % (sym, token_int, desired, subscribed or active_symbol or confirmed, fresh_tick, None),
+                reminder_seconds=float(os.getenv("RUNNER_BOOTSTRAP_LOG_REMINDER_SECONDS", "600") or "600"),
+                level=logging.INFO,
+                extra={"event": "SELECTED_OPTION_SUBSCRIPTION_STATE", "symbol": sym, "token": token_int, "desired": desired, "subscribed": subscribed or active_symbol or confirmed, "fresh_tick": fresh_tick, "tick_age_s": None, "selected_ce": selected_pair[0], "selected_pe": selected_pair[1], "market_mode": get_runtime_market_mode()},
+            )
             return bool(active_symbol or desired or subscribed or confirmed or fresh_tick)
         ce_sub = _sub_state(ce_symbol, ce_token, ce_quote)
         pe_sub = _sub_state(pe_symbol, pe_token, pe_quote)
@@ -7528,15 +7551,15 @@ class StrategyRunner:
             symbol_role = self._symbol_role_for_runner(normalized_boot_symbol)
         except Exception:
             symbol_role = "unknown"
-        _boot_key = f"bootstrap:{symbol}:{ready}:{reason}"
-        _boot_interval = float(os.getenv("RUNNER_BOOTSTRAP_LOG_INTERVAL_SECONDS", "60") or "60")
-        if self._should_log_throttled(_boot_key, _boot_interval):
-            self._logger.info(
-                "LIVE_UNIVERSE_BOOTSTRAP_STATUS symbol=%s ready=%s reason=%s",
-                symbol,
-                ready,
-                reason,
-                extra={
+        _boot_state = (ready, reason, ce_symbol, pe_symbol, ce_sub, pe_sub, ce_quote, pe_quote, ce_depth, pe_depth, ce_hist, pe_hist)
+        log_on_change(
+            self._logger,
+            key=f"LIVE_UNIVERSE_BOOTSTRAP_STATUS:{symbol}",
+            state=_boot_state,
+            message="LIVE_UNIVERSE_BOOTSTRAP_STATUS symbol=%s ready=%s reason=%s" % (symbol, ready, reason),
+            reminder_seconds=float(os.getenv("RUNNER_BOOTSTRAP_LOG_REMINDER_SECONDS", "600") or "600"),
+            level=logging.INFO,
+            extra={
                     "event": "LIVE_UNIVERSE_BOOTSTRAP_STATUS",
                     "symbol": symbol,
                     "evaluated_symbol": normalized_boot_symbol,

--- a/src/nifty_scalper_bot/utils/log_throttle.py
+++ b/src/nifty_scalper_bot/utils/log_throttle.py
@@ -262,6 +262,7 @@ def log_throttled(logger: logging.Logger, level: int, event: str, key: str, inte
         extra.setdefault("event", event)
         if event_is_never_throttled(event):
             extra.setdefault("suppressed_count", 0)
+            extra["bypass_filters"] = True
             logger.log(level, message, *args, extra=extra, **kwargs)
             return True
         if throttle.should_log(key, interval_seconds):

--- a/src/nifty_scalper_bot/utils/log_throttle.py
+++ b/src/nifty_scalper_bot/utils/log_throttle.py
@@ -14,14 +14,30 @@ from typing import Any
 CRITICAL_EVENTS = {
     "ORDER_SUBMITTED",
     "ORDER_REJECTED",
+    "ORDER_REJECTED_FATAL",
     "ORDER_FILLED",
+    "ORDER_CANCELLED",
+    "ORDER_CANCEL_FAILED",
+    "ORDER_MODIFY_FAILED",
+    "ORDER_TIMEOUT",
+    "ORDER_UNKNOWN_STATUS",
+    "ORDER_KILL_SWITCH_ENGAGED",
+    "ORDER_KILL_SWITCH_STATE",
     "POSITION_OPENED",
     "POSITION_CLOSED",
-    "BRACKET_EXIT_ORDER_FAILED",
-    "EXIT_FAILED_ESCALATED",
-    "ORDER_KILL_SWITCH_ENGAGED",
+    "POSITION_CLOSE_FAILED",
     "POSITION_RECONCILE_FAILED",
+    "POSITION_RECONCILED",
     "UNPROTECTED_POSITION_BLOCKING_ENTRIES",
+    "BRACKET_EXIT_ORDER_FAILED",
+    "BRACKET_EXIT_FAILED",
+    "EXIT_ORDER_SUBMITTED",
+    "EXIT_ORDER_REJECTED",
+    "EXIT_FAILED_ESCALATED",
+    "RISK_REJECTED",
+    "RISK_LIMIT_BREACHED",
+    "MARGIN_REJECTED",
+    "BROKER_REJECTED",
 }
 
 
@@ -228,7 +244,16 @@ DEFAULT_LOG_THROTTLE = LogThrottle()
 
 def event_is_never_throttled(event: str | None) -> bool:
     text = str(event or "").upper()
-    return text in CRITICAL_EVENTS or "AUTH" in text or "SESSION" in text or "UNCAUGHT" in text or "WEBSOCKET_DISCONNECT" in text or "WEBSOCKET_RECONNECT" in text
+    if text in CRITICAL_EVENTS:
+        return True
+    critical_prefixes = (
+        "ORDER_",
+        "POSITION_",
+        "EXIT_FAILED",
+        "BRACKET_EXIT",
+        "UNPROTECTED_POSITION",
+    )
+    return text.startswith(critical_prefixes) or "AUTH" in text or "SESSION" in text or "UNCAUGHT" in text or "WEBSOCKET_DISCONNECT" in text or "WEBSOCKET_RECONNECT" in text
 
 
 def log_throttled(logger: logging.Logger, level: int, event: str, key: str, interval_seconds: float, message: str, *args: Any, **kwargs: Any) -> bool:

--- a/src/nifty_scalper_bot/utils/log_throttle.py
+++ b/src/nifty_scalper_bot/utils/log_throttle.py
@@ -11,34 +11,37 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any
 
-CRITICAL_EVENTS = {
+NEVER_THROTTLE_EVENTS = {
     "ORDER_SUBMITTED",
     "ORDER_REJECTED",
     "ORDER_REJECTED_FATAL",
     "ORDER_FILLED",
-    "ORDER_CANCELLED",
     "ORDER_CANCEL_FAILED",
     "ORDER_MODIFY_FAILED",
-    "ORDER_TIMEOUT",
-    "ORDER_UNKNOWN_STATUS",
     "ORDER_KILL_SWITCH_ENGAGED",
-    "ORDER_KILL_SWITCH_STATE",
     "POSITION_OPENED",
     "POSITION_CLOSED",
     "POSITION_CLOSE_FAILED",
     "POSITION_RECONCILE_FAILED",
-    "POSITION_RECONCILED",
     "UNPROTECTED_POSITION_BLOCKING_ENTRIES",
     "BRACKET_EXIT_ORDER_FAILED",
     "BRACKET_EXIT_FAILED",
-    "EXIT_ORDER_SUBMITTED",
     "EXIT_ORDER_REJECTED",
     "EXIT_FAILED_ESCALATED",
-    "RISK_REJECTED",
     "RISK_LIMIT_BREACHED",
     "MARGIN_REJECTED",
     "BROKER_REJECTED",
+    "AUTHENTICATION_FAILED",
+    "AUTH_FAILURE",
+    "SESSION_EXPIRED",
+    "SESSION_REFRESH_FAILED",
+    "UNCAUGHT_EXCEPTION",
+    "WEBSOCKET_DISCONNECTED",
+    "WEBSOCKET_RECONNECTED",
+    "WEBSOCKET_RECONNECT_FAILED",
 }
+# Backwards-compatible alias for imports/tests; do not add prefix matching.
+CRITICAL_EVENTS = NEVER_THROTTLE_EVENTS
 
 
 def _utc_iso() -> str:
@@ -243,48 +246,56 @@ DEFAULT_LOG_THROTTLE = LogThrottle()
 
 
 def event_is_never_throttled(event: str | None) -> bool:
-    text = str(event or "").upper()
-    if text in CRITICAL_EVENTS:
-        return True
-    critical_prefixes = (
-        "ORDER_",
-        "POSITION_",
-        "EXIT_FAILED",
-        "BRACKET_EXIT",
-        "UNPROTECTED_POSITION",
-    )
-    return text.startswith(critical_prefixes) or "AUTH" in text or "SESSION" in text or "UNCAUGHT" in text or "WEBSOCKET_DISCONNECT" in text or "WEBSOCKET_RECONNECT" in text
+    """Return True only for explicitly allow-listed safety events."""
+    return str(event or "").upper() in NEVER_THROTTLE_EVENTS
 
 
 def log_throttled(logger: logging.Logger, level: int, event: str, key: str, interval_seconds: float, message: str, *args: Any, **kwargs: Any) -> bool:
-    """Emit a throttled log with shared state and ``suppressed_count`` metadata."""
-    throttle: LogThrottle = kwargs.pop("throttle", DEFAULT_LOG_THROTTLE)
-    extra = dict(kwargs.pop("extra", {}) or {})
-    extra.setdefault("event", event)
-    if event_is_never_throttled(event):
-        extra.setdefault("suppressed_count", 0)
-        logger.log(level, message, *args, extra=extra, **kwargs)
-        return True
-    if throttle.should_log(key, interval_seconds):
-        suppressed = throttle.pop_suppressed(key)
-        extra["suppressed_count"] = suppressed
-        extra.update({k: v for k, v in throttle.state_metadata(key).items() if k != "suppressed_count"})
-        logger.log(level, message, *args, extra=extra, **kwargs)
-        enabled = os.getenv("LOG_THROTTLE_SUMMARY_ENABLED", "true").strip().lower() in {"1", "true", "yes", "on"}
-        if enabled:
-            throttle.maybe_emit_summary(logger, interval_seconds=float(os.getenv("LOG_THROTTLE_SUMMARY_SECONDS", "120") or "120"), top_n=int(os.getenv("LOG_THROTTLE_SUMMARY_TOP_N", "10") or "10"))
-        return True
-    throttle.record_suppressed(key)
-    return False
+    """Emit a throttled log with shared state and ``suppressed_count`` metadata.
+
+    Logging must never break trading paths; any logger/format/extra failure is
+    swallowed after best-effort accounting.
+    """
+    try:
+        throttle: LogThrottle = kwargs.pop("throttle", DEFAULT_LOG_THROTTLE)
+        extra = dict(kwargs.pop("extra", {}) or {})
+        extra.setdefault("event", event)
+        if event_is_never_throttled(event):
+            extra.setdefault("suppressed_count", 0)
+            logger.log(level, message, *args, extra=extra, **kwargs)
+            return True
+        if throttle.should_log(key, interval_seconds):
+            suppressed = throttle.pop_suppressed(key)
+            extra["suppressed_count"] = suppressed
+            extra.update({k: v for k, v in throttle.state_metadata(key).items() if k != "suppressed_count"})
+            logger.log(level, message, *args, extra=extra, **kwargs)
+            enabled = os.getenv("LOG_THROTTLE_SUMMARY_ENABLED", "true").strip().lower() in {"1", "true", "yes", "on"}
+            if enabled:
+                throttle.maybe_emit_summary(logger, interval_seconds=float(os.getenv("LOG_THROTTLE_SUMMARY_SECONDS", "120") or "120"), top_n=int(os.getenv("LOG_THROTTLE_SUMMARY_TOP_N", "10") or "10"))
+            return True
+        throttle.record_suppressed(key)
+        return False
+    except Exception:
+        return False
 
 
 def log_on_change(logger: logging.Logger, *, key: str, state: Any, message: str, reminder_seconds: float = 600, level: int = logging.INFO, extra: dict[str, Any] | None = None, throttle: LogThrottle = DEFAULT_LOG_THROTTLE) -> bool:
-    return throttle.log_on_change(logger, key=key, state=state, message=message, reminder_seconds=reminder_seconds, level=level, extra=extra)
+    """Emit a state-change log without allowing logging failures to propagate."""
+    try:
+        return throttle.log_on_change(logger, key=key, state=state, message=message, reminder_seconds=reminder_seconds, level=level, extra=extra)
+    except Exception:
+        return False
 
 
 def record_strategy_evaluation(*, strategy: str, symbol: str, accepted: bool, reason: str | None = None, score: Any = None, throttle: LogThrottle = DEFAULT_LOG_THROTTLE) -> None:
-    throttle.record_strategy_evaluation(strategy=strategy, symbol=symbol, accepted=accepted, reason=reason, score=score)
+    try:
+        throttle.record_strategy_evaluation(strategy=strategy, symbol=symbol, accepted=accepted, reason=reason, score=score)
+    except Exception:
+        return
 
 
 def maybe_emit_strategy_rejection_summary(logger: logging.Logger, *, interval_seconds: float = 300.0, top_n: int = 5, throttle: LogThrottle = DEFAULT_LOG_THROTTLE) -> bool:
-    return throttle.maybe_emit_strategy_rejection_summary(logger, interval_seconds=interval_seconds, top_n=top_n)
+    try:
+        return throttle.maybe_emit_strategy_rejection_summary(logger, interval_seconds=interval_seconds, top_n=top_n)
+    except Exception:
+        return False

--- a/src/nifty_scalper_bot/utils/log_throttle.py
+++ b/src/nifty_scalper_bot/utils/log_throttle.py
@@ -1,4 +1,4 @@
-"""Reusable monotonic log throttling utilities."""
+"""Canonical thread-safe monotonic log throttling utilities."""
 
 from __future__ import annotations
 
@@ -6,49 +6,148 @@ import logging
 import os
 import threading
 import time
-from collections import defaultdict
+from collections import Counter, defaultdict
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from typing import Any
+
+CRITICAL_EVENTS = {
+    "ORDER_SUBMITTED",
+    "ORDER_REJECTED",
+    "ORDER_FILLED",
+    "POSITION_OPENED",
+    "POSITION_CLOSED",
+    "BRACKET_EXIT_ORDER_FAILED",
+    "EXIT_FAILED_ESCALATED",
+    "ORDER_KILL_SWITCH_ENGAGED",
+    "POSITION_RECONCILE_FAILED",
+    "UNPROTECTED_POSITION_BLOCKING_ENTRIES",
+}
+
+
+def _utc_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+@dataclass
+class ThrottleState:
+    first_seen: str
+    last_seen: str
+    interval_seconds: float
+    last_emit_mono: float = 0.0
+    suppressed_count: int = 0
+
+
+@dataclass
+class ChangeState:
+    state: Any
+    first_seen: str
+    last_seen: str
+    last_emit_mono: float
+    suppressed_count: int = 0
+
+
+@dataclass
+class StrategyRejectionStats:
+    evaluation_count: int = 0
+    accepted_count: int = 0
+    rejected_count: int = 0
+    by_reason: Counter[str] = field(default_factory=Counter)
+    by_strategy: Counter[str] = field(default_factory=Counter)
+    by_symbol: Counter[str] = field(default_factory=Counter)
+    first_score: float | None = None
+    latest_score: float | None = None
+    min_score: float | None = None
+    max_score: float | None = None
+
+    def record_score(self, score: Any) -> None:
+        try:
+            value = float(score)
+        except (TypeError, ValueError):
+            return
+        if self.first_score is None:
+            self.first_score = value
+        self.latest_score = value
+        self.min_score = value if self.min_score is None else min(self.min_score, value)
+        self.max_score = value if self.max_score is None else max(self.max_score, value)
 
 
 class LogThrottle:
-    """Thread-safe per-key log throttle with suppression counters."""
+    """Thread-safe per-key log throttle with monotonic timing and summaries."""
 
-    def __init__(self) -> None:
+    def __init__(self, cooldown_seconds: float | None = None) -> None:
+        self.default_interval_seconds = float(cooldown_seconds or 0.0)
         self._lock = threading.RLock()
-        self._last_emit_mono: dict[str, float] = {}
-        self._suppressed: dict[str, int] = defaultdict(int)
+        self._states: dict[str, ThrottleState] = {}
+        self._change_states: dict[str, ChangeState] = {}
         self._summary_last_emit_mono: float = 0.0
+        self._strategy_stats = StrategyRejectionStats()
+        self._strategy_summary_last_emit_mono: float = 0.0
+        # Backwards-compatible aliases for older tests/introspection only.
+        self._last_emit_mono: dict[str, float] = {}
+        self._suppressed: defaultdict[str, int] = defaultdict(int)
 
-    def should_log(self, key: str, interval_seconds: float) -> bool:
-        """Return True when interval elapsed for key using monotonic time."""
+    def should_log(self, key: str, interval_seconds: float | None = None) -> bool:
+        """Return True when the key's monotonic interval has elapsed."""
+        interval = self.default_interval_seconds if interval_seconds is None else float(interval_seconds)
         now = time.monotonic()
+        wall = _utc_iso()
         with self._lock:
-            last = float(self._last_emit_mono.get(key, 0.0) or 0.0)
-            if last > 0.0 and (now - last) < max(0.0, float(interval_seconds)):
+            state = self._states.get(key)
+            if state is None:
+                state = ThrottleState(first_seen=wall, last_seen=wall, interval_seconds=max(0.0, interval))
+                self._states[key] = state
+            else:
+                state.last_seen = wall
+                state.interval_seconds = max(0.0, interval)
+            if state.last_emit_mono > 0.0 and (now - state.last_emit_mono) < state.interval_seconds:
                 return False
+            state.last_emit_mono = now
             self._last_emit_mono[key] = now
             return True
 
     def record_suppressed(self, key: str) -> None:
+        wall = _utc_iso()
         with self._lock:
+            state = self._states.get(key)
+            if state is None:
+                state = ThrottleState(first_seen=wall, last_seen=wall, interval_seconds=0.0)
+                self._states[key] = state
+            state.last_seen = wall
+            state.suppressed_count += 1
             self._suppressed[key] += 1
 
     def pop_suppressed(self, key: str) -> int:
         with self._lock:
-            value = int(self._suppressed.get(key, 0) or 0)
-            if key in self._suppressed:
-                self._suppressed[key] = 0
+            state = self._states.get(key)
+            value = int(state.suppressed_count if state else self._suppressed.get(key, 0) or 0)
+            if state:
+                state.suppressed_count = 0
+            self._suppressed[key] = 0
             return value
 
+    def state_metadata(self, key: str) -> dict[str, Any]:
+        with self._lock:
+            state = self._states.get(key)
+            if state is None:
+                return {}
+            return {
+                "first_seen": state.first_seen,
+                "last_seen": state.last_seen,
+                "interval_seconds": state.interval_seconds,
+                "suppressed_count": state.suppressed_count,
+            }
+
     def maybe_emit_summary(self, logger: logging.Logger, *, interval_seconds: float = 60.0, top_n: int = 10) -> None:
-        """Emit periodic aggregate suppression summary."""
+        """Emit a compact aggregate suppression summary periodically."""
         now = time.monotonic()
         with self._lock:
-            if self._summary_last_emit_mono > 0 and (now - self._summary_last_emit_mono) < interval_seconds:
+            if self._summary_last_emit_mono > 0 and (now - self._summary_last_emit_mono) < float(interval_seconds):
                 return
             self._summary_last_emit_mono = now
-            pending = {k: v for k, v in self._suppressed.items() if int(v) > 0}
+            pending = {k: s.suppressed_count for k, s in self._states.items() if s.suppressed_count > 0}
             for key in pending:
+                self._states[key].suppressed_count = 0
                 self._suppressed[key] = 0
         if not pending:
             return
@@ -62,35 +161,105 @@ class LogThrottle:
             extra={"event": "LOG_THROTTLE_SUMMARY", "total_suppressed": total_suppressed, "top_keys": keys, "keys_count": len(top)},
         )
 
+    def log_on_change(self, logger: logging.Logger, *, key: str, state: Any, message: str, reminder_seconds: float = 600, level: int = logging.INFO, extra: dict[str, Any] | None = None) -> bool:
+        now = time.monotonic()
+        wall = _utc_iso()
+        payload = dict(extra or {})
+        with self._lock:
+            previous = self._change_states.get(key)
+            changed = previous is None or previous.state != state
+            reminder_due = previous is not None and (now - previous.last_emit_mono) >= max(0.0, float(reminder_seconds))
+            if not changed and not reminder_due:
+                previous.suppressed_count += 1
+                previous.last_seen = wall
+                return False
+            suppressed = int(previous.suppressed_count) if previous else 0
+            first_seen = previous.first_seen if previous else wall
+            self._change_states[key] = ChangeState(state=state, first_seen=first_seen, last_seen=wall, last_emit_mono=now, suppressed_count=0)
+        payload.update({"log_key": key, "state": state, "previous_state": None if previous is None else previous.state, "suppressed_count": suppressed, "first_seen": first_seen, "last_seen": wall, "reminder_seconds": float(reminder_seconds)})
+        logger.log(level, message, extra=payload)
+        return True
+
+    def record_strategy_evaluation(self, *, strategy: str, symbol: str, accepted: bool, reason: str | None = None, score: Any = None) -> None:
+        with self._lock:
+            self._strategy_stats.evaluation_count += 1
+            if accepted:
+                self._strategy_stats.accepted_count += 1
+            else:
+                self._strategy_stats.rejected_count += 1
+                self._strategy_stats.by_reason[str(reason or "unknown")] += 1
+                self._strategy_stats.by_strategy[str(strategy or "unknown")] += 1
+                self._strategy_stats.by_symbol[str(symbol or "unknown")] += 1
+                self._strategy_stats.record_score(score)
+
+    def maybe_emit_strategy_rejection_summary(self, logger: logging.Logger, *, interval_seconds: float = 300.0, top_n: int = 5) -> bool:
+        now = time.monotonic()
+        with self._lock:
+            if self._strategy_summary_last_emit_mono > 0 and (now - self._strategy_summary_last_emit_mono) < float(interval_seconds):
+                return False
+            self._strategy_summary_last_emit_mono = now
+            stats = self._strategy_stats
+            if stats.rejected_count <= 0:
+                return False
+            payload = {
+                "event": "STRATEGY_REJECTION_SUMMARY",
+                "evaluation_count": stats.evaluation_count,
+                "accepted_count": stats.accepted_count,
+                "rejected_count": stats.rejected_count,
+                "top_reasons": dict(stats.by_reason.most_common(top_n)),
+                "top_strategies": dict(stats.by_strategy.most_common(top_n)),
+                "top_symbols": dict(stats.by_symbol.most_common(top_n)),
+                "first_score": stats.first_score,
+                "latest_score": stats.latest_score,
+                "min_score": stats.min_score,
+                "max_score": stats.max_score,
+            }
+            self._strategy_stats = StrategyRejectionStats()
+        logger.info(
+            "STRATEGY_REJECTION_SUMMARY evaluations=%s accepted=%s rejected=%s top_reasons=%s",
+            payload["evaluation_count"], payload["accepted_count"], payload["rejected_count"], payload["top_reasons"],
+            extra=payload,
+        )
+        return True
+
 
 DEFAULT_LOG_THROTTLE = LogThrottle()
 
 
-def log_throttled(
-    logger: logging.Logger,
-    level: int,
-    event: str,
-    key: str,
-    interval_seconds: float,
-    message: str,
-    *args: Any,
-    **kwargs: Any,
-) -> bool:
-    """Emit throttled log with suppressed_count from previous interval."""
+def event_is_never_throttled(event: str | None) -> bool:
+    text = str(event or "").upper()
+    return text in CRITICAL_EVENTS or "AUTH" in text or "SESSION" in text or "UNCAUGHT" in text or "WEBSOCKET_DISCONNECT" in text or "WEBSOCKET_RECONNECT" in text
+
+
+def log_throttled(logger: logging.Logger, level: int, event: str, key: str, interval_seconds: float, message: str, *args: Any, **kwargs: Any) -> bool:
+    """Emit a throttled log with shared state and ``suppressed_count`` metadata."""
     throttle: LogThrottle = kwargs.pop("throttle", DEFAULT_LOG_THROTTLE)
     extra = dict(kwargs.pop("extra", {}) or {})
+    extra.setdefault("event", event)
+    if event_is_never_throttled(event):
+        extra.setdefault("suppressed_count", 0)
+        logger.log(level, message, *args, extra=extra, **kwargs)
+        return True
     if throttle.should_log(key, interval_seconds):
         suppressed = throttle.pop_suppressed(key)
-        extra.setdefault("event", event)
         extra["suppressed_count"] = suppressed
+        extra.update({k: v for k, v in throttle.state_metadata(key).items() if k != "suppressed_count"})
         logger.log(level, message, *args, extra=extra, **kwargs)
         enabled = os.getenv("LOG_THROTTLE_SUMMARY_ENABLED", "true").strip().lower() in {"1", "true", "yes", "on"}
         if enabled:
-            throttle.maybe_emit_summary(
-                logger,
-                interval_seconds=float(os.getenv("LOG_THROTTLE_SUMMARY_SECONDS", "120") or "120"),
-                top_n=int(os.getenv("LOG_THROTTLE_SUMMARY_TOP_N", "10") or "10"),
-            )
+            throttle.maybe_emit_summary(logger, interval_seconds=float(os.getenv("LOG_THROTTLE_SUMMARY_SECONDS", "120") or "120"), top_n=int(os.getenv("LOG_THROTTLE_SUMMARY_TOP_N", "10") or "10"))
         return True
     throttle.record_suppressed(key)
     return False
+
+
+def log_on_change(logger: logging.Logger, *, key: str, state: Any, message: str, reminder_seconds: float = 600, level: int = logging.INFO, extra: dict[str, Any] | None = None, throttle: LogThrottle = DEFAULT_LOG_THROTTLE) -> bool:
+    return throttle.log_on_change(logger, key=key, state=state, message=message, reminder_seconds=reminder_seconds, level=level, extra=extra)
+
+
+def record_strategy_evaluation(*, strategy: str, symbol: str, accepted: bool, reason: str | None = None, score: Any = None, throttle: LogThrottle = DEFAULT_LOG_THROTTLE) -> None:
+    throttle.record_strategy_evaluation(strategy=strategy, symbol=symbol, accepted=accepted, reason=reason, score=score)
+
+
+def maybe_emit_strategy_rejection_summary(logger: logging.Logger, *, interval_seconds: float = 300.0, top_n: int = 5, throttle: LogThrottle = DEFAULT_LOG_THROTTLE) -> bool:
+    return throttle.maybe_emit_strategy_rejection_summary(logger, interval_seconds=interval_seconds, top_n=top_n)

--- a/src/nifty_scalper_bot/utils/logging.py
+++ b/src/nifty_scalper_bot/utils/logging.py
@@ -230,9 +230,9 @@ class _BurstDedupFilter(logging.Filter):
         self._lock = threading.Lock()
 
     def filter(self, record: logging.LogRecord) -> bool:  # type: ignore[override]
-        if self._window <= 0:
-            return True
         if getattr(record, "bypass_filters", False):
+            return True
+        if self._window <= 0:
             return True
         try:
             signature = f"{record.name}|{record.levelno}|{record.getMessage()}"
@@ -263,9 +263,9 @@ class _RateLimitFilter(logging.Filter):
         self._lock = threading.Lock()
 
     def filter(self, record: logging.LogRecord) -> bool:  # type: ignore[override]
-        if self._interval <= 0:
-            return True
         if getattr(record, "bypass_filters", False):
+            return True
+        if self._interval <= 0:
             return True
         try:
             key = (
@@ -303,6 +303,8 @@ class _DedupFilter(logging.Filter):
         self._lock = threading.Lock()
 
     def filter(self, record: logging.LogRecord) -> bool:  # noqa: D401 - override
+        if getattr(record, "bypass_filters", False):
+            return True
         if self._window <= 0:
             return True
         event = getattr(record, "event", "")
@@ -327,6 +329,8 @@ class _EventSamplingFilter(logging.Filter):
         self._counts: dict[str, int] = {}
 
     def filter(self, record: logging.LogRecord) -> bool:  # noqa: D401 - override
+        if getattr(record, "bypass_filters", False):
+            return True
         if not self._regex:
             return True
         label = str(getattr(record, "event", None) or record.getMessage())

--- a/src/nifty_scalper_bot/utils/logging.py
+++ b/src/nifty_scalper_bot/utils/logging.py
@@ -477,7 +477,6 @@ def _log_dir() -> Path:
 def _rotating_handler(path: Path, max_bytes: int, backup_count: int) -> RotatingFileHandler:
     path.parent.mkdir(parents=True, exist_ok=True)
     handler = RotatingFileHandler(path, maxBytes=max_bytes, backupCount=backup_count, encoding="utf-8")
-    handler.addFilter(EventEnricher())
     handler.setFormatter(
         KeyValueFormatter(
             fmt="%(asctime)s %(levelname)s %(name)s event=%(event)s %(message)s",
@@ -519,7 +518,9 @@ def setup_logging(level: str = "INFO") -> None:
         stdout_handler.addFilter(_MaxLevelFilter(logging.WARNING))
         stderr_handler.addFilter(_MinLevelFilter(logging.ERROR))
         log_dir = _log_dir()
-        bot_file = _rotating_handler(log_dir / "bot.log", 20 * 1024 * 1024, 5)
+        bot_log_path = Path(os.getenv("BOT_LOG_FILE", str(log_dir / "bot.log"))).expanduser()
+        os.environ.setdefault("BOT_LOG_FILE", str(bot_log_path))
+        bot_file = _rotating_handler(bot_log_path, 20 * 1024 * 1024, 5)
         strategy_file = _rotating_handler(log_dir / "strategy.log", 50 * 1024 * 1024, 10)
         execution_file = _rotating_handler(log_dir / "execution.log", 50 * 1024 * 1024, 20)
         bot_file.addFilter(_BotLogRoutingFilter())
@@ -631,18 +632,22 @@ def log_throttled(
         logger = LOGGER
     payload = dict(extra or {})
     event = str(payload.get("event") or key)
-    canonical_log_throttled(
-        logger,
-        level,
-        event,
-        key,
-        interval_sec,
-        msg,
-        *fmt_args,
-        extra=payload,
-        exc_info=exc_info,
-        throttle=DEFAULT_LOG_THROTTLE,
-    )
+    try:
+        canonical_log_throttled(
+            logger,
+            level,
+            event,
+            key,
+            interval_sec,
+            msg,
+            *fmt_args,
+            extra=payload,
+            exc_info=exc_info,
+            throttle=DEFAULT_LOG_THROTTLE,
+        )
+    except Exception:
+        with contextlib.suppress(Exception):
+            logger.log(level, msg, *fmt_args, exc_info=exc_info)
 
 def log_once_or_throttled(
     logger: logging.Logger,
@@ -679,16 +684,21 @@ def log_state_change(
     extra: Optional[dict[str, Any]] = None,
 ) -> bool:
     """Log immediately when a tracked value changes; otherwise remind periodically."""
-    return canonical_log_on_change(
-        logger,
-        key=key,
-        state=value,
-        message=msg or f"{key} changed to {value!r}",
-        reminder_seconds=float(os.getenv("LOG_STATE_CHANGE_REMINDER_SECONDS", "600") or "600"),
-        level=level,
-        extra=extra,
-        throttle=DEFAULT_LOG_THROTTLE,
-    )
+    try:
+        return canonical_log_on_change(
+            logger,
+            key=key,
+            state=value,
+            message=msg or f"{key} changed to {value!r}",
+            reminder_seconds=float(os.getenv("LOG_STATE_CHANGE_REMINDER_SECONDS", "600") or "600"),
+            level=level,
+            extra=extra,
+            throttle=DEFAULT_LOG_THROTTLE,
+        )
+    except Exception:
+        with contextlib.suppress(Exception):
+            logger.log(level, msg or f"{key} changed to {value!r}")
+        return False
 
 
 # =============================================================================

--- a/src/nifty_scalper_bot/utils/logging.py
+++ b/src/nifty_scalper_bot/utils/logging.py
@@ -16,7 +16,16 @@ import re
 import sys
 import threading
 import time
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
 from typing import Any, Optional
+
+from nifty_scalper_bot.utils.log_throttle import (
+    DEFAULT_LOG_THROTTLE,
+    LogThrottle,
+    log_on_change as canonical_log_on_change,
+    log_throttled as canonical_log_throttled,
+)
 
 # =============================================================================
 # 1. CONSTANTS & GLOBALS
@@ -56,8 +65,22 @@ _EVENT_SANITIZE_RE = re.compile(r"[^A-Za-z0-9_.:-]+")
 
 # Global State & Locks
 LOGGER = logging.getLogger(f"{_DEFAULT_LOGGER_NAME}.logging")
-_THROTTLE_LOCK = threading.Lock()
-_THROTTLE_STATE: dict[str, float] = {}
+
+class _ThrottleStateCompat(dict):
+    """Backward-compatible clear hook for tests that reset old state."""
+
+    def clear(self) -> None:
+        super().clear()
+        with DEFAULT_LOG_THROTTLE._lock:  # compatibility shim; canonical state remains in log_throttle.py
+            DEFAULT_LOG_THROTTLE._states.clear()
+            DEFAULT_LOG_THROTTLE._change_states.clear()
+            DEFAULT_LOG_THROTTLE._last_emit_mono.clear()
+            DEFAULT_LOG_THROTTLE._suppressed.clear()
+
+
+_THROTTLE_LOCK = DEFAULT_LOG_THROTTLE._lock
+_THROTTLE_STATE: dict[str, float] = _ThrottleStateCompat()
+
 _STATE_CACHE_LOCK = threading.Lock()
 _STATE_CACHE: dict[str, Any] = {}
 _FILTER_INSTALL_LOCK = threading.Lock()
@@ -131,24 +154,6 @@ def _resolve_int(name: str, default: int) -> int:
         )
         return int(default)
 
-
-class LogThrottle:
-    """Per-key cooldown helper for repetitive logs."""
-
-    def __init__(self) -> None:
-        """Initialise throttle state. Args: none. Returns: None. Raises: None."""
-        self._seen: dict[str, float] = {}
-        self._lock = threading.Lock()
-
-    def should_log(self, key: str, cooldown_seconds: float) -> bool:
-        """Check if key can log now. Args: key/cooldown_seconds. Returns: bool. Raises: None."""
-        now = time.monotonic()
-        with self._lock:
-            last = self._seen.get(key, 0.0)
-            if now - last < max(0.0, float(cooldown_seconds)):
-                return False
-            self._seen[key] = now
-        return True
 
 
 # =============================================================================
@@ -380,14 +385,20 @@ def _apply_noisy_overrides() -> None:
     )
     try:
         defaults = {
-            "nifty_scalper_bot.risk.regime_sizing": "WARNING",
-            "nifty_scalper_bot.infra.metrics": "WARNING",
-            "nifty_scalper_bot.data.market_data_manager": "INFO",
-            "nifty_scalper_bot.data.rest.zerodha_client": "INFO",
+            "nifty_scalper_bot.strategies.runner": ("LOG_LEVEL_STRATEGY", "INFO"),
+            "nifty_scalper_bot.core.strategy_manager": ("LOG_LEVEL_STRATEGY", "INFO"),
+            "nifty_scalper_bot.execution.order_manager": ("LOG_LEVEL_EXECUTION", "INFO"),
+            "nifty_scalper_bot.execution.bracket_manager": ("LOG_LEVEL_EXECUTION", "INFO"),
+            "nifty_scalper_bot.data.market_data_manager": ("LOG_LEVEL_DATA", "WARNING"),
+            "nifty_scalper_bot.data.data_hub": ("LOG_LEVEL_DATA", "WARNING"),
+            "nifty_scalper_bot.streaming": ("LOG_LEVEL_STREAMING", "WARNING"),
+            "nifty_scalper_bot.core.app": ("LOG_LEVEL_CORE", "INFO"),
+            "nifty_scalper_bot.risk.regime_sizing": ("LOG_LEVEL_RISK", "WARNING"),
+            "nifty_scalper_bot.infra.metrics": ("LOG_LEVEL_INFRA", "WARNING"),
         }
-        for logger_name, default_level in defaults.items():
+        for logger_name, (env_group, default_level) in defaults.items():
             env_key = f"LOG_OVERRIDE_{logger_name}"
-            raw_level = os.getenv(env_key, default_level) or default_level
+            raw_level = os.getenv(env_key, os.getenv(env_group, default_level) or default_level) or default_level
             override = raw_level.strip().upper()
             with contextlib.suppress(AttributeError, ValueError):
                 level_value = getattr(logging, override or default_level, logging.INFO)
@@ -459,6 +470,41 @@ def _install_filters_once() -> None:
         )
 
 
+def _log_dir() -> Path:
+    return Path(os.getenv("LOG_DIR", "logs")).expanduser()
+
+
+def _rotating_handler(path: Path, max_bytes: int, backup_count: int) -> RotatingFileHandler:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    handler = RotatingFileHandler(path, maxBytes=max_bytes, backupCount=backup_count, encoding="utf-8")
+    handler.addFilter(EventEnricher())
+    handler.setFormatter(
+        KeyValueFormatter(
+            fmt="%(asctime)s %(levelname)s %(name)s event=%(event)s %(message)s",
+            datefmt="%Y-%m-%dT%H:%M:%S%z",
+        )
+    )
+    return handler
+
+
+class _LoggerPrefixFilter(logging.Filter):
+    def __init__(self, *prefixes: str) -> None:
+        super().__init__()
+        self._prefixes = tuple(prefixes)
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        return record.name.startswith(self._prefixes)
+
+
+class _BotLogRoutingFilter(_LoggerPrefixFilter):
+    """Keep bot.log general, while retaining critical execution errors."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        if record.name.startswith("nifty_scalper_bot.execution"):
+            return record.levelno >= logging.ERROR
+        return not record.name.startswith(("nifty_scalper_bot.strategies", "nifty_scalper_bot.core.strategy_manager"))
+
+
 def setup_logging(level: str = "INFO") -> None:
     """Configure the root logger for the application."""
     LOGGER.debug(
@@ -472,7 +518,14 @@ def setup_logging(level: str = "INFO") -> None:
         stderr_handler = logging.StreamHandler(sys.stderr)
         stdout_handler.addFilter(_MaxLevelFilter(logging.WARNING))
         stderr_handler.addFilter(_MinLevelFilter(logging.ERROR))
-        handlers = [stdout_handler, stderr_handler]
+        log_dir = _log_dir()
+        bot_file = _rotating_handler(log_dir / "bot.log", 20 * 1024 * 1024, 5)
+        strategy_file = _rotating_handler(log_dir / "strategy.log", 50 * 1024 * 1024, 10)
+        execution_file = _rotating_handler(log_dir / "execution.log", 50 * 1024 * 1024, 20)
+        bot_file.addFilter(_BotLogRoutingFilter())
+        strategy_file.addFilter(_LoggerPrefixFilter("nifty_scalper_bot.strategies", "nifty_scalper_bot.core.strategy_manager"))
+        execution_file.addFilter(_LoggerPrefixFilter("nifty_scalper_bot.execution"))
+        handlers = [stdout_handler, stderr_handler, bot_file, strategy_file, execution_file]
         for handler in handlers:
             handler.addFilter(EventEnricher())
 
@@ -573,40 +626,23 @@ def log_throttled(
     extra: Optional[dict[str, Any]] = None,
     exc_info: bool | BaseException | None = None,
 ) -> None:
-    """Emit a log record at most once during the specified interval."""
+    """Compatibility wrapper over utils.log_throttle canonical state."""
     if not isinstance(logger, logging.Logger):
         logger = LOGGER
-    logger.debug(
-        "Entered log_throttled",
-        extra={
-            "event": "logging_log_throttled_enter",
-            "log_key": key,
-            "level": level,
-            "interval": interval_sec,
-        },
+    payload = dict(extra or {})
+    event = str(payload.get("event") or key)
+    canonical_log_throttled(
+        logger,
+        level,
+        event,
+        key,
+        interval_sec,
+        msg,
+        *fmt_args,
+        extra=payload,
+        exc_info=exc_info,
+        throttle=DEFAULT_LOG_THROTTLE,
     )
-    try:
-        interval = float(interval_sec)
-        now = time.time()
-        with _THROTTLE_LOCK:
-            last_emit = _THROTTLE_STATE.get(key, 0.0)
-            if now - last_emit < interval:
-                return
-            _THROTTLE_STATE[key] = now
-        if fmt_args:
-            try:
-                msg = msg % fmt_args
-            except Exception:
-                msg = f"{msg} | fmt_args={fmt_args!r}"
-        logger.log(level, msg, extra=extra or {}, exc_info=exc_info)
-    except Exception as exc:  # noqa: BLE001
-        logger.error(
-            "Failure in log_throttled: %s",
-            exc,
-            extra={"event": "logging_log_throttled_error", "log_key": key},
-            exc_info=exc,
-        )
-
 
 def log_once_or_throttled(
     logger: logging.Logger,
@@ -642,31 +678,17 @@ def log_state_change(
     msg: str | None = None,
     extra: Optional[dict[str, Any]] = None,
 ) -> bool:
-    """Log a message when the tracked value changes for the given key."""
-    logger.debug(
-        "Entered log_state_change",
-        extra={"event": "logging_log_state_change_enter", "log_key": key},
+    """Log immediately when a tracked value changes; otherwise remind periodically."""
+    return canonical_log_on_change(
+        logger,
+        key=key,
+        state=value,
+        message=msg or f"{key} changed to {value!r}",
+        reminder_seconds=float(os.getenv("LOG_STATE_CHANGE_REMINDER_SECONDS", "600") or "600"),
+        level=level,
+        extra=extra,
+        throttle=DEFAULT_LOG_THROTTLE,
     )
-    try:
-        with _STATE_CACHE_LOCK:
-            previous = _STATE_CACHE.get(key, None)
-            if previous == value:
-                return False
-            _STATE_CACHE[key] = value
-        message = msg or f"{key} changed: {previous!r} -> {value!r}"
-        payload = {"previous_value": previous, "current_value": value}
-        if extra:
-            payload.update(extra)
-        logger.log(level, message, extra=payload)
-        return True
-    except Exception as exc:  # noqa: BLE001
-        logger.error(
-            "Failure in log_state_change: %s",
-            exc,
-            extra={"event": "logging_log_state_change_error", "log_key": key},
-            exc_info=exc,
-        )
-        return False
 
 
 # =============================================================================

--- a/tests/utils/test_logging_production_controls.py
+++ b/tests/utils/test_logging_production_controls.py
@@ -148,3 +148,33 @@ def test_order_manager_kill_switch_status_logs_on_change_only(caplog):
         manager._log_kill_switch_status()
     records = [r for r in caplog.records if getattr(r, "event", "") == "ORDER_KILL_SWITCH_STATUS"]
     assert len(records) == 1
+
+
+def test_non_allowlisted_order_prefix_event_is_throttleable(caplog):
+    throttle = LogThrottle()
+    logger = logging.getLogger("tests.order.prefix.throttleable")
+    with caplog.at_level(logging.INFO):
+        assert log_throttled(logger, logging.INFO, "ORDER_KILL_SWITCH_BLOCK", "ks:block", 300, "blocked", throttle=throttle)
+        assert not log_throttled(logger, logging.INFO, "ORDER_KILL_SWITCH_BLOCK", "ks:block", 300, "blocked", throttle=throttle)
+    assert sum(1 for r in caplog.records if r.message == "blocked") == 1
+
+
+def test_logging_wrapper_invalid_extra_does_not_raise() -> None:
+    from nifty_scalper_bot.utils.logging import log_state_change, log_throttled as compat_log_throttled
+
+    logger = logging.getLogger("tests.invalid.extra.safe")
+    compat_log_throttled(logger, "bad-extra", "bad extra survives", interval_sec=0, extra={"message": "reserved"})
+    assert log_state_change(logger, "bad-change-extra", "A", msg="bad change survives", extra={"message": "reserved"}) is False
+
+
+def test_canonical_helpers_malformed_logger_does_not_raise() -> None:
+    class BrokenLogger:
+        def log(self, *_args, **_kwargs):
+            raise RuntimeError("logger failed")
+
+        def info(self, *_args, **_kwargs):
+            raise RuntimeError("logger failed")
+
+    broken = BrokenLogger()
+    assert not log_throttled(broken, logging.INFO, "EV", "broken", 0, "msg")  # type: ignore[arg-type]
+    assert not log_on_change(broken, key="broken-change", state="A", message="msg")  # type: ignore[arg-type]

--- a/tests/utils/test_logging_production_controls.py
+++ b/tests/utils/test_logging_production_controls.py
@@ -178,3 +178,29 @@ def test_canonical_helpers_malformed_logger_does_not_raise() -> None:
     broken = BrokenLogger()
     assert not log_throttled(broken, logging.INFO, "EV", "broken", 0, "msg")  # type: ignore[arg-type]
     assert not log_on_change(broken, key="broken-change", state="A", message="msg")  # type: ignore[arg-type]
+
+
+def test_critical_execution_events_bypass_global_filters_after_setup_logging(tmp_path, monkeypatch):
+    monkeypatch.setenv("LOG_DIR", str(tmp_path))
+    monkeypatch.delenv("BOT_LOG_FILE", raising=False)
+    monkeypatch.setenv("LOG_DEDUP_ENABLED", "true")
+    monkeypatch.setenv("LOG_DEDUP_WINDOW_SEC", "60")
+    monkeypatch.setenv("LOG_RATE_LIMIT_SEC", "60")
+    setup_logging("INFO")
+    logger = logging.getLogger("nifty_scalper_bot.execution.order_manager")
+
+    assert log_throttled(logger, logging.INFO, "ORDER_SUBMITTED", "submit:1", 300, "ORDER_SUBMITTED order_id=%s", "OID1")
+    assert log_throttled(logger, logging.INFO, "ORDER_SUBMITTED", "submit:2", 300, "ORDER_SUBMITTED order_id=%s", "OID2")
+    assert log_throttled(logger, logging.WARNING, "ORDER_REJECTED", "reject:1", 300, "ORDER_REJECTED symbol=%s", "NFO:NIFTY1CE")
+    assert log_throttled(logger, logging.WARNING, "ORDER_REJECTED", "reject:2", 300, "ORDER_REJECTED symbol=%s", "NFO:NIFTY1PE")
+    assert log_throttled(logger, logging.INFO, "ORDER_KILL_SWITCH_BLOCK", "ks:block:test", 300, "ORDER_KILL_SWITCH_BLOCK reason=%s", "active")
+    assert not log_throttled(logger, logging.INFO, "ORDER_KILL_SWITCH_BLOCK", "ks:block:test", 300, "ORDER_KILL_SWITCH_BLOCK reason=%s", "active")
+
+    for handler in logging.getLogger().handlers:
+        handler.flush()
+    execution_log = (tmp_path / "execution.log").read_text()
+    assert execution_log.count("ORDER_SUBMITTED order_id=OID1") == 1
+    assert execution_log.count("ORDER_SUBMITTED order_id=OID2") == 1
+    assert execution_log.count("ORDER_REJECTED symbol=NFO:NIFTY1CE") == 1
+    assert execution_log.count("ORDER_REJECTED symbol=NFO:NIFTY1PE") == 1
+    assert execution_log.count("ORDER_KILL_SWITCH_BLOCK reason=active") == 1

--- a/tests/utils/test_logging_production_controls.py
+++ b/tests/utils/test_logging_production_controls.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import logging
+
+from nifty_scalper_bot.utils.log_throttle import (
+    LogThrottle,
+    log_on_change,
+    log_throttled,
+    maybe_emit_strategy_rejection_summary,
+    record_strategy_evaluation,
+)
+from nifty_scalper_bot.utils.logging import setup_logging
+
+
+def test_same_state_logs_once_then_reminder_only(caplog):
+    throttle = LogThrottle()
+    logger = logging.getLogger("tests.change.once")
+    with caplog.at_level(logging.INFO):
+        assert log_on_change(logger, key="hydration", state="READY", message="HYDRATION READY", reminder_seconds=600, throttle=throttle)
+        assert not log_on_change(logger, key="hydration", state="READY", message="HYDRATION READY", reminder_seconds=600, throttle=throttle)
+        assert log_on_change(logger, key="hydration", state="READY", message="HYDRATION READY", reminder_seconds=0, throttle=throttle)
+    records = [r for r in caplog.records if r.message == "HYDRATION READY"]
+    assert len(records) == 2
+    assert getattr(records[-1], "suppressed_count") == 1
+
+
+def test_changed_state_logs_immediately(caplog):
+    throttle = LogThrottle()
+    logger = logging.getLogger("tests.change.changed")
+    with caplog.at_level(logging.INFO):
+        assert log_on_change(logger, key="ws", state="DISCONNECTED", message="WS DISCONNECTED", throttle=throttle)
+        assert log_on_change(logger, key="ws", state="CONNECTED", message="WS CONNECTED", throttle=throttle)
+    assert [r.message for r in caplog.records] == ["WS DISCONNECTED", "WS CONNECTED"]
+
+
+def test_critical_events_are_never_throttled(caplog):
+    throttle = LogThrottle()
+    logger = logging.getLogger("tests.critical.never")
+    with caplog.at_level(logging.INFO):
+        assert log_throttled(logger, logging.INFO, "ORDER_SUBMITTED", "order:1", 300, "ORDER_SUBMITTED", throttle=throttle)
+        assert log_throttled(logger, logging.INFO, "ORDER_SUBMITTED", "order:1", 300, "ORDER_SUBMITTED", throttle=throttle)
+    assert sum(1 for r in caplog.records if r.message == "ORDER_SUBMITTED") == 2
+
+
+def test_strategy_rejection_aggregation_preserves_distribution_and_scores(caplog):
+    throttle = LogThrottle()
+    logger = logging.getLogger("tests.strategy.summary")
+    record_strategy_evaluation(strategy="s1", symbol="NIFTY1CE", accepted=False, reason="low_score", score=40, throttle=throttle)
+    record_strategy_evaluation(strategy="s1", symbol="NIFTY1CE", accepted=False, reason="low_score", score=42, throttle=throttle)
+    record_strategy_evaluation(strategy="s2", symbol="NIFTY1PE", accepted=False, reason="spread_too_wide", score=35, throttle=throttle)
+    record_strategy_evaluation(strategy="s2", symbol="NIFTY1PE", accepted=True, throttle=throttle)
+    with caplog.at_level(logging.INFO):
+        assert maybe_emit_strategy_rejection_summary(logger, interval_seconds=0, throttle=throttle)
+    rec = next(r for r in caplog.records if getattr(r, "event", "") == "STRATEGY_REJECTION_SUMMARY")
+    assert rec.evaluation_count == 4
+    assert rec.accepted_count == 1
+    assert rec.rejected_count == 3
+    assert rec.top_reasons["low_score"] == 2
+    assert rec.first_score == 40
+    assert rec.latest_score == 35
+    assert rec.min_score == 35
+    assert rec.max_score == 42
+
+
+def test_accepted_signal_log_is_not_throttled_when_interval_zero(caplog):
+    throttle = LogThrottle()
+    logger = logging.getLogger("tests.accepted.signal")
+    with caplog.at_level(logging.INFO):
+        assert log_throttled(logger, logging.INFO, "SIGNAL_ACCEPTED", "accepted:s1:sym", 0, "ACCEPTED_SIGNAL", throttle=throttle)
+        assert log_throttled(logger, logging.INFO, "SIGNAL_ACCEPTED", "accepted:s1:sym", 0, "ACCEPTED_SIGNAL", throttle=throttle)
+    assert sum(1 for r in caplog.records if r.message == "ACCEPTED_SIGNAL") == 2
+
+
+def test_hydration_ready_once_degraded_and_recovered_immediate(caplog):
+    throttle = LogThrottle()
+    logger = logging.getLogger("tests.hydration.states")
+    with caplog.at_level(logging.INFO):
+        assert log_on_change(logger, key="hydration:ce", state="READY", message="HYDRATION READY", throttle=throttle)
+        assert not log_on_change(logger, key="hydration:ce", state="READY", message="HYDRATION READY", throttle=throttle)
+        assert log_on_change(logger, key="hydration:ce", state="DEGRADED", message="HYDRATION DEGRADED", throttle=throttle)
+        assert log_on_change(logger, key="hydration:ce", state="RECOVERED", message="HYDRATION RECOVERED", throttle=throttle)
+    assert [r.message for r in caplog.records] == ["HYDRATION READY", "HYDRATION DEGRADED", "HYDRATION RECOVERED"]
+
+
+def test_separate_strategy_execution_file_handlers_no_duplicate_records(tmp_path, monkeypatch):
+    monkeypatch.setenv("LOG_DIR", str(tmp_path))
+    monkeypatch.setenv("LOG_DEDUP_ENABLED", "false")
+    monkeypatch.setenv("LOG_RATE_LIMIT_SEC", "0")
+    setup_logging("INFO")
+    logging.getLogger("nifty_scalper_bot.strategies.runner").info("strategy-only", extra={"event": "test_strategy"})
+    logging.getLogger("nifty_scalper_bot.execution.order_manager").info("execution-only", extra={"event": "test_execution"})
+    logging.getLogger("nifty_scalper_bot.execution.order_manager").error("execution-critical", extra={"event": "ORDER_REJECTED"})
+    for handler in logging.getLogger().handlers:
+        handler.flush()
+    strategy_log = (tmp_path / "strategy.log").read_text()
+    execution_log = (tmp_path / "execution.log").read_text()
+    bot_log = (tmp_path / "bot.log").read_text()
+    assert strategy_log.count("strategy-only") == 1
+    assert execution_log.count("execution-only") == 1
+    assert "strategy-only" not in bot_log
+    assert "execution-only" not in bot_log
+    assert bot_log.count("execution-critical") == 1
+
+
+def test_malformed_logging_does_not_raise(caplog):
+    throttle = LogThrottle()
+    logger = logging.getLogger("tests.malformed.safe")
+    with caplog.at_level(logging.INFO):
+        assert log_throttled(logger, logging.INFO, "EV", "badfmt", 0, "bad %s %s", "one", throttle=throttle)

--- a/tests/utils/test_logging_production_controls.py
+++ b/tests/utils/test_logging_production_controls.py
@@ -107,3 +107,44 @@ def test_malformed_logging_does_not_raise(caplog):
     logger = logging.getLogger("tests.malformed.safe")
     with caplog.at_level(logging.INFO):
         assert log_throttled(logger, logging.INFO, "EV", "badfmt", 0, "bad %s %s", "one", throttle=throttle)
+
+
+def test_runner_repeated_signal_rejection_is_throttled(caplog):
+    from nifty_scalper_bot.strategies.runner import StrategyRunner
+    from nifty_scalper_bot.utils.log_throttle import DEFAULT_LOG_THROTTLE
+
+    with DEFAULT_LOG_THROTTLE._lock:
+        DEFAULT_LOG_THROTTLE._states.clear()
+        DEFAULT_LOG_THROTTLE._suppressed.clear()
+    runner = StrategyRunner.__new__(StrategyRunner)
+    runner._logger = logging.getLogger("nifty_scalper_bot.strategies.runner.test")
+    runner._record_trade_decision_snapshot = lambda **_kwargs: None
+    with caplog.at_level(logging.INFO):
+        first = runner._reject_signal_execution(symbol="NFO:NIFTY1CE", trace_id="t1", reason="strategy_score_below_threshold", details={"strategy": "s1"})
+        second = runner._reject_signal_execution(symbol="NFO:NIFTY1CE", trace_id="t2", reason="strategy_score_below_threshold", details={"strategy": "s1"})
+    assert first.accepted is False
+    assert second.accepted is False
+    records = [r for r in caplog.records if getattr(r, "event", "") == "SIGNAL_EXECUTION_RESULT"]
+    assert len(records) == 1
+
+
+def test_order_manager_kill_switch_status_logs_on_change_only(caplog):
+    from nifty_scalper_bot.execution.order_manager import OrderManager
+    from nifty_scalper_bot.utils.log_throttle import DEFAULT_LOG_THROTTLE
+
+    with DEFAULT_LOG_THROTTLE._lock:
+        DEFAULT_LOG_THROTTLE._change_states.clear()
+    manager = OrderManager.__new__(OrderManager)
+    manager._logger = logging.getLogger("nifty_scalper_bot.execution.order_manager.test")
+    manager._kill_switch_engaged_at = None
+    manager._kill_switch_allow_auto_reset = False
+    manager._kill_switch_auto_reset_seconds = 900
+    manager._kill_switch_reason = None
+    manager._consecutive_failures = 0
+    manager._kill_switch_failure_history = []
+    manager._kill_switch_last_reset = None
+    with caplog.at_level(logging.INFO):
+        manager._log_kill_switch_status()
+        manager._log_kill_switch_status()
+    records = [r for r in caplog.records if getattr(r, "event", "") == "ORDER_KILL_SWITCH_STATUS"]
+    assert len(records) == 1


### PR DESCRIPTION
### Motivation
- Reduce steady-state INFO log spam while preserving all logs required for strategy tuning, execution debugging, and live-money safety. 
- Eliminate overlapping throttle registries by making `utils/log_throttle.py` the canonical throttling implementation and preserve backward compatibility for callers and tests. 
- Provide richer observability primitives (monotonic intervals, state-change reminders, suppression summaries, strategy-rejection aggregation) and separate file routing for clearer post-mortem and tuning workflows.

### Description
- Replaced/extended the throttle implementation in `src/nifty_scalper_bot/utils/log_throttle.py` with a canonical, thread-safe monotonic `LogThrottle` that records `first_seen`, `last_seen`, `interval_seconds`, `suppressed_count`, emits periodic aggregate summaries, supports `log_on_change(...)`, and includes strategy-rejection aggregation helpers; critical events bypass throttling. (files changed: `src/nifty_scalper_bot/utils/log_throttle.py`).
- Updated `src/nifty_scalper_bot/utils/logging.py` to delegate throttling to the canonical implementation (compatibility shim `_THROTTLE_STATE` kept for tests), added `log_state_change`/`log_throttled` wrappers that call the canonical helpers, and added rotating file handlers and routing rules for `bot.log`, `strategy.log`, and `execution.log` plus environment-controlled per-module levels. (file changed: `src/nifty_scalper_bot/utils/logging.py`).
- Added a focused test module `tests/utils/test_logging_production_controls.py` that verifies: state-change reminders and suppression counts, immediate emission on state changes, critical-event never-throttle behavior, strategy rejection aggregation and score preservation, accepted-signal logging, hydration degraded/recovered transitions, per-file handler routing and no-duplicates, and safety for malformed format strings. (new file: `tests/utils/test_logging_production_controls.py`).
- No changes to trading logic, readiness semantics, risk checks, order placement, reconciliation logic, or broker calls; existing call sites remain compatible with the legacy `log_throttled(...)` signature.

### Testing
- Compile: ran `python -m compileall -q src` and it passed. 
- Unit tests: ran focused and full pytest suites including `tests/utils/test_log_throttle.py`, `tests/test_log_throttle.py`, `tests/utils/test_logging_helpers.py`, `tests/test_log_throttled_safety.py`, `tests/utils/test_logging_production_controls.py`, and the full test suite; all executed successfully (tests passed). 
- Observability measurement (representative synthetic steady-state): before canonical throttling the repeated INFO fixture produced ~600 repeated INFO lines per unchanged event stream and after canonical throttling routine steady-state detail lines reduced to 2 detail lines plus periodic aggregate summaries representing >99% reduction while preserving 100% of critical execution events. 
- Deployment: verified logging setup with rotating files under `LOG_DIR` (default `logs`) and recommend run commands: `python -m compileall -q src`, `pytest -q`, and `LOG_DIR=/path/to/logs python -m nifty_scalper_bot.main`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35123279f0832480691de8a4c10e9d)