### PR TITLE
Fix post-#633 candidate logging crash and remaining throttle defects

### DIFF
--- a/src/nifty_scalper_bot/strategies/trade_selector.py
+++ b/src/nifty_scalper_bot/strategies/trade_selector.py
@@ -59,18 +59,21 @@ class TradeCandidateSelector:
         self.require_real_ticks_last_60s = require_real_ticks_last_60s
         self._last_rejects: dict[str, int] = {}
         self._candidate_reject_log_throttle_seconds = max(
-            1.0, float(os.getenv("CANDIDATE_REJECT_LOG_THROTTLE_SECONDS", "15") or 15)
+            1.0,
+            float(os.getenv("CANDIDATE_REJECT_LOG_THROTTLE_SECONDS", "120") or 120),
+        )
+        self._candidate_summary_log_throttle_seconds = max(
+            1.0,
+            float(os.getenv("CANDIDATE_SUMMARY_LOG_THROTTLE_SECONDS", "300") or 300),
         )
 
     def _log_reject(self, reason: str, symbol: str, *, throttle_key_parts: tuple[Any, ...], **fields: Any) -> None:
         key = "CANDIDATE_REJECTED:" + ":".join(str(part) for part in throttle_key_parts)
+        message = f"CANDIDATE_REJECTED symbol={symbol} reason={reason} fields={fields}"
         log_once_or_throttled(
             LOGGER,
             key,
-            "CANDIDATE_REJECTED symbol=%s reason=%s fields=%s",
-            symbol,
-            reason,
-            fields,
+            message,
             interval_sec=self._candidate_reject_log_throttle_seconds,
             level=logging.INFO,
             extra={"event": "CANDIDATE_REJECTED", "symbol": symbol, "reason": reason, **fields},
@@ -89,7 +92,14 @@ class TradeCandidateSelector:
             blocked, gate_reason = midday_pause_block()
         if blocked:
             self._last_rejects = {'entry_window_blocked': len(snapshots)}
-            log_once_or_throttled(LOGGER, f'entry_window_blocked:{gate_reason}:{direction_bias}', f'CANDIDATE_SELECTION_BLOCKED reason={gate_reason} direction={direction_bias} total={len(snapshots)}', interval_sec=60.0, level=logging.INFO, extra={'event': 'CANDIDATE_SELECTION_BLOCKED', 'reason': gate_reason, 'direction': direction_bias, 'total': len(snapshots)})
+            log_once_or_throttled(
+                LOGGER,
+                f'entry_window_blocked:{gate_reason}:{direction_bias}',
+                f'CANDIDATE_SELECTION_BLOCKED reason={gate_reason} direction={direction_bias} total={len(snapshots)}',
+                interval_sec=self._candidate_summary_log_throttle_seconds,
+                level=logging.INFO,
+                extra={'event': 'CANDIDATE_SELECTION_BLOCKED', 'reason': gate_reason, 'direction': direction_bias, 'total': len(snapshots)},
+            )
             return []
         max_spread, max_age, min_ticks = self._limits()
         if self.max_option_spread_pct is not None:
@@ -143,32 +153,19 @@ class TradeCandidateSelector:
                 )
             if (premium < self.min_option_premium and not premium_dynamic_override) or premium > self.max_option_premium:
                 rejects['premium_out_of_range'] += 1
-                LOGGER.info(
-                    "CANDIDATE_REJECTED symbol=%s reason=premium_out_of_range premium=%s min=%s max=%s ltp=%s bid=%s ask=%s strike=%s atm=%s atm_distance=%s",
+                self._log_reject(
+                    "premium_out_of_range",
                     symbol,
-                    premium,
-                    self.min_option_premium,
-                    self.max_option_premium,
-                    ltp,
-                    bid,
-                    ask,
-                    strike,
-                    atm_strike,
-                    atm_distance,
-                    extra={
-                        "event": "CANDIDATE_REJECTED",
-                        "symbol": symbol,
-                        "reason": "premium_out_of_range",
-                        "premium": premium,
-                        "min_option_premium": self.min_option_premium,
-                        "max_option_premium": self.max_option_premium,
-                        "ltp": ltp,
-                        "bid": bid,
-                        "ask": ask,
-                        "strike": strike,
-                        "atm": atm_strike,
-                        "atm_distance": atm_distance,
-                    },
+                    throttle_key_parts=("premium_out_of_range", symbol, int(self.min_option_premium), int(self.max_option_premium)),
+                    premium=premium,
+                    min_option_premium=self.min_option_premium,
+                    max_option_premium=self.max_option_premium,
+                    ltp=ltp,
+                    bid=bid,
+                    ask=ask,
+                    strike=strike,
+                    atm=atm_strike,
+                    atm_distance=atm_distance,
                 )
                 continue
             tick_age_s = self._f(s.get('tick_age_s'))
@@ -247,7 +244,14 @@ class TradeCandidateSelector:
         if sorted_ranked:
             LOGGER.debug('CANDIDATE_SELECTION_SUMMARY direction=%s atm=%s total=%s ranked=%s ltp_only_used=%s rejects=%s', direction_bias, atm_strike, len(snapshots), len(sorted_ranked), ltp_only_used, rejects, extra=event_extra)
         else:
-            log_once_or_throttled(LOGGER, key, f'CANDIDATE_SELECTION_SUMMARY direction={direction_bias} atm={atm_strike} total={len(snapshots)} ranked=0 ltp_only_used={ltp_only_used} rejects={rejects}', interval_sec=30.0, level=logging.INFO, extra=event_extra)
+            log_once_or_throttled(
+                LOGGER,
+                key,
+                f'CANDIDATE_SELECTION_SUMMARY direction={direction_bias} atm={atm_strike} total={len(snapshots)} ranked=0 ltp_only_used={ltp_only_used} rejects={rejects}',
+                interval_sec=self._candidate_summary_log_throttle_seconds,
+                level=logging.INFO,
+                extra=event_extra,
+            )
         return sorted_ranked
 
     def select_best_candidate(self, *, underlying: str, direction_bias: str, atm_strike: int, snapshots: list[dict[str, Any]]) -> TradeCandidate | None:

--- a/src/nifty_scalper_bot/utils/log_throttle.py
+++ b/src/nifty_scalper_bot/utils/log_throttle.py
@@ -163,13 +163,13 @@ class LogThrottle:
         with self._lock:
             if self._summary_last_emit_mono > 0 and (now - self._summary_last_emit_mono) < float(interval_seconds):
                 return
-            self._summary_last_emit_mono = now
             pending = {k: s.suppressed_count for k, s in self._states.items() if s.suppressed_count > 0}
+            if not pending:
+                return
+            self._summary_last_emit_mono = now
             for key in pending:
                 self._states[key].suppressed_count = 0
                 self._suppressed[key] = 0
-        if not pending:
-            return
         top = sorted(pending.items(), key=lambda item: item[1], reverse=True)[: max(1, int(top_n))]
         total_suppressed = sum(int(v) for v in pending.values())
         keys = ",".join(f"{k}:{v}" for k, v in top)
@@ -216,10 +216,10 @@ class LogThrottle:
         with self._lock:
             if self._strategy_summary_last_emit_mono > 0 and (now - self._strategy_summary_last_emit_mono) < float(interval_seconds):
                 return False
-            self._strategy_summary_last_emit_mono = now
             stats = self._strategy_stats
             if stats.rejected_count <= 0:
                 return False
+            self._strategy_summary_last_emit_mono = now
             payload = {
                 "event": "STRATEGY_REJECTION_SUMMARY",
                 "evaluation_count": stats.evaluation_count,

--- a/tests/strategies/test_trade_selector_logging_controls.py
+++ b/tests/strategies/test_trade_selector_logging_controls.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import logging
+
+import nifty_scalper_bot.strategies.trade_selector as trade_selector_module
+from nifty_scalper_bot.strategies.trade_selector import TradeCandidateSelector
+from nifty_scalper_bot.utils.log_throttle import DEFAULT_LOG_THROTTLE
+
+
+def _reset_default_throttle() -> None:
+    with DEFAULT_LOG_THROTTLE._lock:
+        DEFAULT_LOG_THROTTLE._states.clear()
+        DEFAULT_LOG_THROTTLE._change_states.clear()
+        DEFAULT_LOG_THROTTLE._last_emit_mono.clear()
+        DEFAULT_LOG_THROTTLE._suppressed.clear()
+
+
+def test_candidate_reject_logging_does_not_raise_and_is_throttled(caplog, monkeypatch) -> None:
+    _reset_default_throttle()
+    monkeypatch.setenv("CANDIDATE_REJECT_LOG_THROTTLE_SECONDS", "120")
+    selector = TradeCandidateSelector()
+
+    with caplog.at_level(logging.INFO):
+        selector._log_reject(
+            "side_mismatch",
+            "NFO:NIFTY1CE",
+            throttle_key_parts=("side_mismatch", "NFO:NIFTY1CE", "PE", "CE"),
+            side="PE",
+            expected_direction="CE",
+        )
+        selector._log_reject(
+            "side_mismatch",
+            "NFO:NIFTY1CE",
+            throttle_key_parts=("side_mismatch", "NFO:NIFTY1CE", "PE", "CE"),
+            side="PE",
+            expected_direction="CE",
+        )
+
+    records = [
+        record
+        for record in caplog.records
+        if getattr(record, "event", "") == "CANDIDATE_REJECTED"
+    ]
+    assert len(records) == 1
+    assert records[0].message.startswith(
+        "CANDIDATE_REJECTED symbol=NFO:NIFTY1CE reason=side_mismatch"
+    )
+
+
+def test_premium_out_of_range_uses_shared_rejection_throttle(caplog, monkeypatch) -> None:
+    _reset_default_throttle()
+    monkeypatch.setattr(trade_selector_module, "expiry_theta_block", lambda: (False, ""))
+    monkeypatch.setattr(trade_selector_module, "midday_pause_block", lambda: (False, ""))
+    monkeypatch.setenv("CANDIDATE_REJECT_LOG_THROTTLE_SECONDS", "120")
+    selector = TradeCandidateSelector(min_option_premium=40, max_option_premium=650)
+    snapshots = [
+        {
+            "symbol": "NFO:NIFTY1CE",
+            "side": "CE",
+            "strike": 24000,
+            "ltp": 20.0,
+            "bid": 19.9,
+            "ask": 20.1,
+            "tick_age_s": 0.5,
+            "real_ticks_last_60s": 5,
+        }
+    ]
+
+    with caplog.at_level(logging.INFO):
+        assert selector.select_ranked_candidates(
+            direction_bias="CE", atm_strike=24000, snapshots=snapshots
+        ) == []
+        assert selector.select_ranked_candidates(
+            direction_bias="CE", atm_strike=24000, snapshots=snapshots
+        ) == []
+
+    rejection_records = [
+        record
+        for record in caplog.records
+        if getattr(record, "event", "") == "CANDIDATE_REJECTED"
+        and getattr(record, "reason", "") == "premium_out_of_range"
+    ]
+    assert len(rejection_records) == 1
+
+
+def test_candidate_logging_defaults_are_long_enough_for_production(monkeypatch) -> None:
+    monkeypatch.delenv("CANDIDATE_REJECT_LOG_THROTTLE_SECONDS", raising=False)
+    monkeypatch.delenv("CANDIDATE_SUMMARY_LOG_THROTTLE_SECONDS", raising=False)
+    selector = TradeCandidateSelector()
+    assert selector._candidate_reject_log_throttle_seconds == 120.0
+    assert selector._candidate_summary_log_throttle_seconds == 300.0

--- a/tests/utils/test_log_throttle_pending_regressions.py
+++ b/tests/utils/test_log_throttle_pending_regressions.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import logging
+
+from nifty_scalper_bot.utils.log_throttle import LogThrottle
+
+
+def test_empty_suppression_summary_does_not_start_cooldown(caplog) -> None:
+    throttle = LogThrottle()
+    logger = logging.getLogger("tests.log_throttle.empty_summary")
+
+    throttle.maybe_emit_summary(logger, interval_seconds=300)
+    assert throttle._summary_last_emit_mono == 0.0
+
+    throttle.record_suppressed("candidate:rejected")
+    with caplog.at_level(logging.INFO):
+        throttle.maybe_emit_summary(logger, interval_seconds=300)
+
+    records = [
+        record
+        for record in caplog.records
+        if getattr(record, "event", "") == "LOG_THROTTLE_SUMMARY"
+    ]
+    assert len(records) == 1
+    assert records[0].total_suppressed == 1
+    assert throttle._summary_last_emit_mono > 0.0
+
+
+def test_empty_strategy_summary_does_not_start_cooldown(caplog) -> None:
+    throttle = LogThrottle()
+    logger = logging.getLogger("tests.log_throttle.empty_strategy_summary")
+
+    assert not throttle.maybe_emit_strategy_rejection_summary(
+        logger, interval_seconds=300
+    )
+    assert throttle._strategy_summary_last_emit_mono == 0.0
+
+    throttle.record_strategy_evaluation(
+        strategy="OrderFlow",
+        symbol="NFO:NIFTY1CE",
+        accepted=False,
+        reason="final_trade_score_below_threshold",
+        score=4.5,
+    )
+    with caplog.at_level(logging.INFO):
+        assert throttle.maybe_emit_strategy_rejection_summary(
+            logger, interval_seconds=300
+        )
+
+    records = [
+        record
+        for record in caplog.records
+        if getattr(record, "event", "") == "STRATEGY_REJECTION_SUMMARY"
+    ]
+    assert len(records) == 1
+    assert records[0].rejected_count == 1
+    assert throttle._strategy_summary_last_emit_mono > 0.0


### PR DESCRIPTION
### Why
PR #633 improved logging substantially, but current `main` still contains two operational defects:

1. `TradeCandidateSelector._log_reject()` passes logger formatting arguments to `log_once_or_throttled()`, whose current signature accepts only three positional arguments. This reproduces the runtime error: `log_once_or_throttled() takes 3 positional arguments but 6 were given`.
2. Suppression and strategy-summary cooldown timestamps are advanced even when there is nothing to emit, delaying the first useful summary.

### Changes
- Preformat candidate-rejection messages before calling `log_once_or_throttled`, eliminating the runtime TypeError without changing trade-selection behavior.
- Route `premium_out_of_range` through the same rejection throttle instead of raw `LOGGER.info`.
- Increase production defaults to 120 seconds for identical candidate rejections and 300 seconds for empty candidate summaries; both remain environment configurable.
- Fix throttle summary timestamps so cooldown starts only after an actual summary is emitted.
- Add regression tests for the candidate-rejection path, premium rejection throttling, production intervals, and empty-summary cooldown behavior.

### Scope
Logging-only. No strategy thresholds, candidate eligibility, risk calculations, broker calls, execution mode, or order behavior are changed.

### Suggested verification
```bash
python -m compileall -q src
pytest tests/strategies/test_trade_selector_logging_controls.py tests/utils/test_log_throttle_pending_regressions.py tests/utils/test_logging_production_controls.py -q
```
