### PR TITLE
Fail closed on broker auth, balance and reconciliation failures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ RUN mkdir -p /app/data \
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
-    CMD curl -f http://localhost:${PORT:-8000}/health || exit 1
+    CMD curl -f http://localhost:${PORT:-8000}/livez || exit 1
 
 # Create non-root user for security
 # NOTE: /app/data and /tmp/nifty_scalper_data are already chmod 777

--- a/docs/production_playbook.md
+++ b/docs/production_playbook.md
@@ -103,3 +103,33 @@ This document captures a battle-tested set of practices for operating the Nifty 
   ```
 
 Adopt these practices incrementally to keep the system safe, observable, and ready for production incidents.
+
+## Broker authentication, balance, and readiness fail-closed behavior
+
+- Zerodha terminal authentication failures (HTTP 401/403, token exceptions, invalid
+  sessions, incorrect API key/access token, and authentication-related permission
+  denials) are treated as fail-closed. The client latches the invalid-auth state,
+  clears REST caches, raises `BrokerAuthenticationError`, and suppresses repeated
+  authenticated REST calls until credentials are replaced by a controlled restart
+  or a future explicit credential-refresh lifecycle.
+- LIVE account funds are read only from `GET /user/margins/{segment}`. The legacy
+  `GET /margins/{segment}` endpoint is not an account-balance fallback and must
+  not be used for live risk capital.
+- LIVE mode never substitutes `RISK_CAPITAL`, `RISK__CAPITAL`,
+  `BACKTEST__CAPITAL`, cached simulation capital, default capital, or fabricated
+  zero for an unavailable broker balance. Those variables are simulation inputs
+  only and are ignored as live broker funds.
+- Live execution arming requires valid broker authentication, a valid broker
+  balance snapshot, and successful startup position reconciliation. Position
+  reconciliation failures leave the process alive for diagnostics while keeping
+  live orders unarmed.
+- Health endpoints are separated by purpose:
+  - `/livez`: process liveness for platform restarts; market closure and expired
+    broker tokens do not make this endpoint fail.
+  - `/readyz`: operational dependency readiness; broker auth or reconciliation
+    failures return 503.
+  - `/health/trading`: trading-domain status with blockers; returns a diagnostic
+    payload even when trading is blocked.
+- Closed-market conditions are expected, not subsystem failures. Off-hours basket
+  retries should wait for the next useful market event instead of polling live
+  depth repeatedly.

--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -4388,6 +4388,51 @@ def _setup_telegram(ctx: BotContext) -> None:
         LOGGER.error(f"❌ Telegram setup failed: {e}", exc_info=True)
 
 
+def _resolve_startup_risk_initial_balance(
+    *,
+    settings: Settings,
+    config: Any,
+    startup_available_balance: float | None,
+) -> float:
+    """Return the RiskManager opening balance without synthetic LIVE funding."""
+
+    execution_mode = str(
+        getattr(settings, "execution_mode", None)
+        or os.getenv("EXECUTION_MODE", "PAPER")
+    ).strip().upper()
+    if execution_mode == "LIVE":
+        if startup_available_balance is None:
+            raise BrokerBalanceUnavailableError(
+                "LIVE startup requires validated broker balance"
+            )
+        initial_balance = float(startup_available_balance)
+        if initial_balance != float(startup_available_balance):
+            raise ConfigurationError("live_risk_capital_must_equal_broker_balance")
+        return initial_balance
+    return float(getattr(config, "initial_balance", 0.0) or 0.0)
+
+
+def apply_broker_auth_failure_to_context(
+    ctx: Any,
+    snapshot: Mapping[str, Any] | None,
+) -> None:
+    """Atomically reflect a latched broker-auth failure in BotContext."""
+
+    snapshot = snapshot or {}
+    reason = str(snapshot.get("reason") or "broker_auth_invalid")
+    ctx.broker_auth_invalid = True
+    ctx.broker_auth_error = reason
+    ctx.broker_auth_invalid_at = datetime.now(timezone.utc)
+    ctx.broker_ready = False
+    ctx.broker_balance_valid = False
+    ctx.broker_balance_error = reason
+    ctx.live_orders_armed = False
+    ctx.execution_armed = False
+    ctx.trading_ready = False
+    ctx.live_block_reason = "broker_auth_invalid"
+    ctx.execution_block_reason = "broker_auth_invalid"
+
+
 def initialize_components(settings: Settings | None = None) -> BotContext:
     """Initialize all components in correct order."""
 
@@ -5120,8 +5165,10 @@ def initialize_components(settings: Settings | None = None) -> BotContext:
         total_timeout_sec=60.0,
     )
 
-    initial_balance = float(
-        getattr(config, "initial_balance", 1_000_000.0) or 1_000_000.0
+    initial_balance = _resolve_startup_risk_initial_balance(
+        settings=settings,
+        config=config,
+        startup_available_balance=startup_available_balance,
     )
 
     # 1. Initialize Risk Manager
@@ -6086,18 +6133,29 @@ def initialize_components(settings: Settings | None = None) -> BotContext:
         bracket_manager_attached=bracket_manager_attached,
     )
     ensure_bot_context_runtime_fields(ctx)
+
+    def _on_broker_auth_failure(snapshot: Mapping[str, Any]) -> None:
+        apply_broker_auth_failure_to_context(ctx, snapshot)
+        reason = str(snapshot.get("reason") or "broker_auth_invalid")
+        LOGGER.error(
+            "BROKER_AUTH_INVALID_PROPAGATED reason=%s generation=%s",
+            reason,
+            snapshot.get("generation"),
+            extra={
+                "event": "BROKER_AUTH_INVALID_PROPAGATED",
+                "reason": reason,
+                "generation": snapshot.get("generation"),
+            },
+        )
+
+    set_auth_callback = getattr(broker_client, "set_auth_failure_callback", None)
+    if callable(set_auth_callback):
+        set_auth_callback(_on_broker_auth_failure)
     if startup_broker_auth_error is not None:
-        ctx.broker_auth_invalid = True
-        ctx.broker_auth_error = startup_broker_auth_error
-        ctx.broker_auth_invalid_at = datetime.now(timezone.utc)
-        ctx.broker_ready = False
-        ctx.broker_balance_valid = False
-        ctx.broker_balance_error = startup_balance_error
-        ctx.live_orders_armed = False
-        ctx.execution_armed = False
-        ctx.trading_ready = False
-        ctx.live_block_reason = "broker_auth_invalid"
-        ctx.execution_block_reason = "broker_auth_invalid"
+        apply_broker_auth_failure_to_context(
+            ctx,
+            {"reason": startup_broker_auth_error},
+        )
     elif startup_available_balance is not None:
         ctx.broker_balance_valid = True
         ctx.broker_balance_error = None
@@ -8865,6 +8923,20 @@ def _register_and_subscribe_live_symbol(
         else:
             LOGGER.warning("LIVE_OPTION_SUBSCRIBE_FAILED symbol=%s subscribed=false reason=token_missing", normalized)
     return bool(resolved_token)
+
+
+def _next_nse_open_after(now_ist: datetime) -> datetime:
+    """Return the next likely NSE open timestamp after *now_ist*."""
+
+    if now_ist.tzinfo is None:
+        now_ist = now_ist.replace(tzinfo=ZoneInfo("Asia/Kolkata"))
+    candidate = now_ist.replace(hour=9, minute=15, second=0, microsecond=0)
+    if now_ist >= candidate:
+        candidate = candidate + timedelta(days=1)
+    while not is_nse_trading_day(candidate.date()):
+        candidate = candidate + timedelta(days=1)
+    return candidate
+
 async def _deferred_basket_hydration_retry(
     ctx: BotContext,
     *,
@@ -8881,10 +8953,11 @@ async def _deferred_basket_hydration_retry(
     for attempt in range(1, max_attempts + 1):
         market_state = get_market_state()
         if market_state != MarketState.OPEN and delay_seconds >= 15.0:
-            next_open = _next_nse_open_after(datetime.now(ZoneInfo("Asia/Kolkata")))
-            delay = 3600.0
+            now_ist = datetime.now(ZoneInfo("Asia/Kolkata"))
+            next_open = _next_nse_open_after(now_ist)
+            delay = 24 * 3600.0
             if next_open is not None:
-                delay = max(60.0, min((next_open - datetime.now(ZoneInfo("Asia/Kolkata"))).total_seconds(), 6 * 3600.0))
+                delay = max(60.0, (next_open - now_ist).total_seconds())
             LOGGER.info(
                 "DEFERRED_BASKET_RETRY_SKIPPED reason=market_closed next_retry_seconds=%d",
                 int(delay),
@@ -12309,10 +12382,6 @@ async def _reconcile_state(ctx: BotContext) -> None:
     if ctx.position_manager:
         try:
             broker_positions = await asyncio.to_thread(safe_sync_fetch)
-            ctx.position_reconciliation_failed = False
-            ctx.position_reconciliation_error = None
-            ctx.position_reconciliation_completed = True
-            ctx.position_reconciliation_completed_at = datetime.now(timezone.utc)
             if hasattr(ctx, "unresolved_reconciliation_symbols"):
                 ctx.unresolved_reconciliation_symbols.clear()
             if hasattr(ctx, "unprotected_broker_positions"):
@@ -12415,6 +12484,10 @@ async def _reconcile_state(ctx: BotContext) -> None:
                                 ghost_sym,
                                 extra={"event": "STALE_BRACKET_RECONCILED_FLAT", "symbol": ghost_sym},
                             )
+            ctx.position_reconciliation_failed = False
+            ctx.position_reconciliation_error = None
+            ctx.position_reconciliation_completed = True
+            ctx.position_reconciliation_completed_at = datetime.now(timezone.utc)
             LOGGER.info("POSITION_RECONCILE_SUCCESS", extra={"event": "POSITION_RECONCILE_SUCCESS"})
 
         except Exception as exc:

--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -1245,7 +1245,11 @@ from nifty_scalper_bot.utils.env import (
     get_str,
     normalize_path,
 )
-from nifty_scalper_bot.utils.errors import ConfigurationError
+from nifty_scalper_bot.utils.errors import (
+    BrokerAuthenticationError,
+    BrokerBalanceUnavailableError,
+    ConfigurationError,
+)
 from nifty_scalper_bot.utils.logging import get_logger, log_state_change, log_throttled, setup_logging
 from nifty_scalper_bot.utils.market_hours import (
     MarketState,
@@ -2393,47 +2397,102 @@ def get_http_app() -> FastAPI:
 
     @app.get("/health", response_class=JSONResponse)
     async def http_health() -> JSONResponse:
+        return await http_readyz()
+
+    @app.get("/livez", response_class=JSONResponse)
+    async def http_livez() -> JSONResponse:
+        return JSONResponse(
+            status_code=200,
+            content={
+                "status": "alive",
+                "uptime_seconds": int(time_module.monotonic() - _START_TIME),
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+            },
+        )
+
+    def _trading_health_payload(ctx: BotContext | None) -> tuple[int, dict[str, object]]:
         ctx = get_latest_bot_context()
-
-        # ✅ FIX 1: Handle Startup Gracefully (Return 200, not 503)
-        # This prevents Railway from killing the bot while it initializes.
-        # ✅ FIX: Return 200 during startup
         if not ctx:
-            return JSONResponse(
-                status_code=200,
-                content={
-                    "status": "starting",
-                    "ready": False,
-                    "reason": "Context initializing...",
-                },
-            )
+            return 503, {"status": "starting", "ready": False, "reason": "context_initializing"}
+        blockers: list[str] = []
+        if bool(getattr(ctx, "broker_auth_invalid", False)):
+            blockers.append("broker_auth_invalid")
+        if not bool(getattr(ctx, "broker_ready", False)):
+            blockers.append("broker_session_invalid")
+        if not bool(getattr(ctx, "broker_balance_valid", False)):
+            blockers.append("broker_balance_unavailable")
+        if bool(getattr(ctx, "position_reconciliation_failed", False)):
+            blockers.append("position_reconciliation_failed")
+        if not bool(getattr(ctx, "position_reconciliation_completed", False)):
+            blockers.append("position_reconciliation_incomplete")
+        if bool(getattr(ctx, "unprotected_broker_positions", set())) or bool(getattr(ctx, "unprotected_broker_position", False)):
+            blockers.append("unprotected_broker_position")
+        if bool(getattr(ctx, "live_block_reason", None)):
+            reason = str(getattr(ctx, "live_block_reason"))
+            if ":" in reason:
+                reason = reason.split(":", 1)[-1]
+            if reason:
+                blockers.append(reason)
+        blockers = list(dict.fromkeys(blockers))
+        primary = blockers[0] if blockers else None
+        payload: dict[str, object] = {
+            "status": "ready" if primary is None else "blocked",
+            "ready": primary is None,
+            "live_orders_armed": bool(getattr(ctx, "live_orders_armed", False)) and primary is None,
+            "primary_blocker": primary,
+            "blockers": blockers,
+            "market_state": str(getattr(ctx, "market_session_state", None) or get_runtime_market_mode()),
+            "broker": {
+                "ready": bool(getattr(ctx, "broker_ready", False)),
+                "auth_invalid": bool(getattr(ctx, "broker_auth_invalid", False)),
+                "balance_valid": bool(getattr(ctx, "broker_balance_valid", False)),
+                "balance_error": getattr(ctx, "broker_balance_error", None),
+            },
+            "reconciliation": {
+                "started": bool(getattr(ctx, "position_reconciliation_started", False)),
+                "completed": bool(getattr(ctx, "position_reconciliation_completed", False)),
+                "failed": bool(getattr(ctx, "position_reconciliation_failed", False)),
+                "error": getattr(ctx, "position_reconciliation_error", None),
+                "unprotected_broker_positions": sorted(getattr(ctx, "unprotected_broker_positions", set()) or []),
+            },
+            "market_data": {"data_hard_ready": bool(getattr(ctx, "data_hard_ready", False))},
+            "strategy": {"evaluation_ready": bool(getattr(ctx, "evaluation_ready", False))},
+            "uptime_seconds": int(time_module.monotonic() - _START_TIME),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
+        code = 200 if primary is None else 503
+        return code, payload
 
-        # ✅ FIX 2: Comprehensive Component Checks
+    @app.get("/readyz", response_class=JSONResponse)
+    async def http_readyz() -> JSONResponse:
+        code, payload = _trading_health_payload(get_latest_bot_context())
+        return JSONResponse(status_code=code, content=payload)
+
+    @app.get("/health/trading", response_class=JSONResponse)
+    async def http_health_trading() -> JSONResponse:
+        _code, payload = _trading_health_payload(get_latest_bot_context())
+        return JSONResponse(status_code=200, content=payload)
+
+    @app.get("/health/legacy", response_class=JSONResponse)
+    async def http_health_legacy() -> JSONResponse:
+        ctx = get_latest_bot_context()
+        if not ctx:
+            return JSONResponse(status_code=200, content={"status": "starting", "ready": False})
         checks = {
-            "broker": ctx.broker_client is not None
-            and ctx.broker_client.is_connected(),
+            "broker": ctx.broker_client is not None and ctx.broker_client.is_connected(),
             "position_manager": ctx.position_manager is not None,
             "risk_manager": ctx.risk_manager is not None,
             "data_hub": ctx.data_hub is not None,
         }
-
-        # Optional: Check Risk Breaker if available
         if ctx.risk_manager:
             try:
-                # Assuming snapshot() or similar property exists
                 checks["risk_breaker_ok"] = not getattr(
                     ctx.risk_manager, "breaker_tripped", False
                 )
             except Exception:
                 checks["risk_breaker_ok"] = False
-
-        # ✅ FIX 3: Determine Status
         all_healthy = all(checks.values())
         status = "healthy" if all_healthy else "degraded"
-
-        # We return 200 even if degraded so we can see the status JSON.
-        # Only return 503 if something catastrophic (like broker down) happens in Production mode.
-        # For now, 200 is safer for stability.
         return JSONResponse(
             status_code=200,
             content={
@@ -2621,6 +2680,23 @@ class BotContext:
     selected_pe_exec_ready: bool = False
     context_exec_ready: bool = False
     broker_ready: bool = False
+    broker_auth_invalid: bool = False
+    broker_auth_error: str | None = None
+    broker_auth_invalid_at: datetime | None = None
+    broker_balance_valid: bool = False
+    broker_balance_error: str | None = None
+    last_valid_broker_balance: float | None = None
+    last_valid_broker_balance_at: datetime | None = None
+    broker_session_invalid: bool = False
+    position_reconciliation_started: bool = False
+    position_reconciliation_completed: bool = False
+    position_reconciliation_failed: bool = False
+    position_reconciliation_error: str | None = None
+    position_reconciliation_started_at: datetime | None = None
+    position_reconciliation_completed_at: datetime | None = None
+    unresolved_reconciliation_symbols: set[str] = field(default_factory=set)
+    unprotected_broker_positions: set[str] = field(default_factory=set)
+    unprotected_broker_position: bool = False
     runner_task: asyncio.Task[Any] | None = None
     readiness_mode: str = "SHADOW"
     effective_mode: str = "SHADOW"
@@ -2856,12 +2932,16 @@ class RuntimeSelfChecker:
             results[name] = {"ok": bool(ok), "detail": detail, "meta": meta_payload}
             if not ok:
                 self._logger.error(
-                    "Runtime self-test detected failure",
+                    "RUNTIME_SELF_CHECK_FAILED check=%s detail=%s blocker=%s action=keep_execution_fail_closed",
+                    name,
+                    detail,
+                    meta_payload.get("blocker") or detail,
                     extra={
-                        "event": "runtime_self_check_failed",
+                        "event": "RUNTIME_SELF_CHECK_FAILED",
                         "check": name,
                         "detail": detail,
                         "meta": meta_payload,
+                        "blocker": meta_payload.get("blocker") or detail,
                     },
                 )
         self.last_run = datetime.now(timezone.utc)
@@ -2887,9 +2967,42 @@ class RuntimeSelfChecker:
             "canonical_history_ensurer": self._check_canonical_history_ensurer,
             "data_freshness": self._check_data_freshness,
             "streamer": self._check_streamer,
+            "broker_authentication": self._check_broker_authentication,
+            "broker_balance": self._check_broker_balance,
+            "position_reconciliation": self._check_position_reconciliation,
+            "readiness_consistency": self._check_readiness_consistency,
             "risk_breaker": self._check_risk_breaker,
             "session_guard": self._check_session_guard,
         }
+
+    def _check_broker_authentication(self) -> tuple[bool, str, dict[str, object]]:
+        if bool(getattr(self._context, "broker_auth_invalid", False)):
+            return False, "broker_auth_invalid", {"blocker": "broker_auth_invalid"}
+        broker = getattr(self._context, "broker_client", None)
+        if bool(getattr(broker, "auth_invalid", False)):
+            return False, "broker_auth_invalid", {"blocker": "broker_auth_invalid"}
+        return True, "broker_auth_valid", {}
+
+    def _check_broker_balance(self) -> tuple[bool, str, dict[str, object]]:
+        if bool(getattr(self._context, "broker_balance_valid", False)):
+            return True, "broker_balance_valid", {}
+        return False, "broker_balance_unavailable", {"blocker": "broker_balance_unavailable"}
+
+    def _check_position_reconciliation(self) -> tuple[bool, str, dict[str, object]]:
+        if bool(getattr(self._context, "position_reconciliation_failed", False)):
+            return False, "position_reconciliation_failed", {"blocker": "position_reconciliation_failed"}
+        if not bool(getattr(self._context, "position_reconciliation_completed", False)):
+            return False, "position_reconciliation_incomplete", {"blocker": "position_reconciliation_incomplete"}
+        if bool(getattr(self._context, "unprotected_broker_positions", set())):
+            return False, "unprotected_broker_position", {"blocker": "unprotected_broker_position"}
+        return True, "position_reconciliation_ready", {}
+
+    def _check_readiness_consistency(self) -> tuple[bool, str, dict[str, object]]:
+        armed = bool(getattr(self._context, "live_orders_armed", False))
+        block_reason = getattr(self._context, "live_block_reason", None)
+        if armed and block_reason:
+            return False, "live_armed_with_blocker", {"blocker": str(block_reason)}
+        return True, "readiness_consistent", {}
 
     def _check_canonical_history_ensurer(self) -> tuple[bool, str, dict[str, object]]:
         """Report canonical runtime-history callback injection failures. Args: none. Returns: status tuple. Raises: none."""
@@ -3188,6 +3301,10 @@ class RuntimeSelfChecker:
             return False, "no_status", {}
         as_dict = status.as_dict() if hasattr(status, "as_dict") else {}
         session_valid = bool(getattr(status, "session_valid", False))
+        if not session_valid and get_market_state() != MarketState.OPEN:
+            as_dict = dict(as_dict)
+            as_dict["market_closed"] = True
+            return True, "market_closed", as_dict
         return session_valid, "ok" if session_valid else "blocked", dict(as_dict)
 
     def _resolve_symbol(self) -> str:
@@ -4352,27 +4469,49 @@ def initialize_components(settings: Settings | None = None) -> BotContext:
     margin_segment = margin_segment_env.strip().lower()
     if margin_segment not in {"equity", "commodity"}:
         margin_segment = "equity"
+    startup_broker_auth_error: str | None = None
+    startup_balance_error: str | None = None
+    startup_available_balance: float | None = None
     try:
-        margin_summary = broker_client.get_margin_summary(segment=margin_segment)
-    except Exception as exc:  # noqa: BLE001
-        LOGGER.warning(
-            "broker_margin_summary_failed",
+        available_balance = broker_client.get_available_balance(segment=margin_segment)
+    except BrokerAuthenticationError as exc:
+        LOGGER.error(
+            "BROKER_AUTH_INVALID_AT_STARTUP reason=%s",
+            str(exc),
             extra={
-                "event": "broker_margin_summary_failed",
+                "event": "BROKER_AUTH_INVALID_AT_STARTUP",
                 "segment": margin_segment,
                 "error": str(exc),
             },
             exc_info=exc,
         )
+        startup_broker_auth_error = str(exc)
+        startup_balance_error = str(exc)
+    except BrokerBalanceUnavailableError as exc:
+        LOGGER.error(
+            "BROKER_BALANCE_UNAVAILABLE_AT_STARTUP reason=%s",
+            str(exc),
+            extra={"event": "BROKER_BALANCE_UNAVAILABLE_AT_STARTUP", "segment": margin_segment, "error": str(exc)},
+            exc_info=exc,
+        )
+        startup_balance_error = str(exc)
+    except Exception as exc:  # noqa: BLE001
+        LOGGER.error(
+            "BROKER_BALANCE_UNAVAILABLE_AT_STARTUP reason=%s",
+            str(exc),
+            extra={"event": "BROKER_BALANCE_UNAVAILABLE_AT_STARTUP", "segment": margin_segment, "error": str(exc)},
+            exc_info=exc,
+        )
+        startup_balance_error = str(exc)
     else:
+        startup_available_balance = float(available_balance)
         LOGGER.info(
-            "broker_margin_summary_loaded",
+            "BROKER_BALANCE_LOADED available=%.2f",
+            float(available_balance),
             extra={
-                "event": "broker_margin_summary_loaded",
+                "event": "BROKER_BALANCE_LOADED",
                 "segment": margin_segment,
-                "available": margin_summary.get("available"),
-                "used": margin_summary.get("used"),
-                "net": margin_summary.get("net"),
+                "available": float(available_balance),
             },
         )
 
@@ -5947,6 +6086,26 @@ def initialize_components(settings: Settings | None = None) -> BotContext:
         bracket_manager_attached=bracket_manager_attached,
     )
     ensure_bot_context_runtime_fields(ctx)
+    if startup_broker_auth_error is not None:
+        ctx.broker_auth_invalid = True
+        ctx.broker_auth_error = startup_broker_auth_error
+        ctx.broker_auth_invalid_at = datetime.now(timezone.utc)
+        ctx.broker_ready = False
+        ctx.broker_balance_valid = False
+        ctx.broker_balance_error = startup_balance_error
+        ctx.live_orders_armed = False
+        ctx.execution_armed = False
+        ctx.trading_ready = False
+        ctx.live_block_reason = "broker_auth_invalid"
+        ctx.execution_block_reason = "broker_auth_invalid"
+    elif startup_available_balance is not None:
+        ctx.broker_balance_valid = True
+        ctx.broker_balance_error = None
+        ctx.last_valid_broker_balance = startup_available_balance
+        ctx.last_valid_broker_balance_at = datetime.now(timezone.utc)
+    else:
+        ctx.broker_balance_valid = False
+        ctx.broker_balance_error = startup_balance_error or "broker_balance_unavailable"
 
     # Wire InstrumentManager to MDM and UnifiedManager for symbol/token resolution
     if ctx.instrument_manager is not None:
@@ -8194,11 +8353,19 @@ async def _recompute_and_push_runtime_readiness(ctx: BotContext, *, reason: str)
         if not broker_ready: missing.append('broker_not_ready')
         if bool(getattr(ctx, "position_reconciliation_failed", False)):
             missing.append("position_reconciliation_failed")
+        if (
+            live_mode
+            and hasattr(ctx, "position_reconciliation_completed")
+            and not bool(getattr(ctx, "position_reconciliation_completed", False))
+        ):
+            missing.append("position_reconciliation_incomplete")
         bracket_manager = getattr(ctx, "bracket_manager", None)
         has_unresolved_exit = getattr(bracket_manager, "has_unresolved_exit", None)
         if callable(has_unresolved_exit) and bool(has_unresolved_exit()):
             missing.append("unresolved_exit_position")
         if bool(getattr(ctx, "unprotected_broker_position", False)):
+            missing.append("unprotected_broker_position")
+        if bool(getattr(ctx, "unprotected_broker_positions", set())):
             missing.append("unprotected_broker_position")
     normalized_decision = normalize_readiness_blockers(
         list(dict.fromkeys(missing)),
@@ -8210,6 +8377,9 @@ async def _recompute_and_push_runtime_readiness(ctx: BotContext, *, reason: str)
         broker_state={
             "broker_auth_invalid": bool(getattr(ctx, "broker_auth_invalid", False)),
             "broker_session_invalid": bool(getattr(ctx, "broker_session_invalid", False)),
+            "broker_balance_unavailable": live_mode
+            and hasattr(ctx, "broker_balance_valid")
+            and not bool(getattr(ctx, "broker_balance_valid", False)),
         },
         risk_state={
             "risk_halt": bool(getattr(ctx, "risk_halt", False)),
@@ -8217,7 +8387,17 @@ async def _recompute_and_push_runtime_readiness(ctx: BotContext, *, reason: str)
         },
         live_mode=live_mode,
         evaluation_ready=evaluation_ready,
-        execution_ready=all_selected_options_exec_ready and context_exec_ready and broker_ready,
+        execution_ready=all_selected_options_exec_ready
+        and context_exec_ready
+        and broker_ready
+        and (
+            not hasattr(ctx, "broker_balance_valid")
+            or bool(getattr(ctx, "broker_balance_valid", False))
+        )
+        and (
+            not hasattr(ctx, "position_reconciliation_completed")
+            or bool(getattr(ctx, "position_reconciliation_completed", False))
+        ),
     )
     live_orders_armed = bool(live_mode and normalized_decision.live_orders_armed)
     block_reason = None if live_orders_armed else f"execution_not_armed:{normalized_decision.primary_blocker or 'unknown'}"
@@ -8675,9 +8855,15 @@ def _register_and_subscribe_live_symbol(
         hub.subscribe_ticks(
             normalized, runner.on_datahub_tick, token=resolved_token, force_live=True
         )
-    LOGGER.info("LIVE_SYMBOL_SUBSCRIBE_CONFIRMED symbol=%s token=%s role=%s subscribed=%s", normalized, resolved_token, role, bool(resolved_token))
+    if resolved_token:
+        LOGGER.info("LIVE_SYMBOL_SUBSCRIBE_REQUEST_SENT symbol=%s token=%s role=%s subscribed=false state=requested", normalized, resolved_token, role)
+    else:
+        LOGGER.warning("LIVE_SYMBOL_SUBSCRIBE_FAILED symbol=%s role=%s subscribed=false reason=token_missing", normalized, role)
     if role == "tradable_option":
-        LOGGER.info("LIVE_OPTION_SUBSCRIBE_CONFIRMED symbol=%s token=%s subscribed=%s", normalized, resolved_token, bool(resolved_token))
+        if resolved_token:
+            LOGGER.info("LIVE_OPTION_SUBSCRIBE_REQUEST_SENT symbol=%s token=%s subscribed=false state=requested", normalized, resolved_token)
+        else:
+            LOGGER.warning("LIVE_OPTION_SUBSCRIBE_FAILED symbol=%s subscribed=false reason=token_missing", normalized)
     return bool(resolved_token)
 async def _deferred_basket_hydration_retry(
     ctx: BotContext,
@@ -8693,6 +8879,24 @@ async def _deferred_basket_hydration_retry(
         max_attempts = int(os.getenv("DEFERRED_BASKET_MAX_ATTEMPTS", "160") or "160")
     policy = MarketDataPolicy.from_env()
     for attempt in range(1, max_attempts + 1):
+        market_state = get_market_state()
+        if market_state != MarketState.OPEN and delay_seconds >= 15.0:
+            next_open = _next_nse_open_after(datetime.now(ZoneInfo("Asia/Kolkata")))
+            delay = 3600.0
+            if next_open is not None:
+                delay = max(60.0, min((next_open - datetime.now(ZoneInfo("Asia/Kolkata"))).total_seconds(), 6 * 3600.0))
+            LOGGER.info(
+                "DEFERRED_BASKET_RETRY_SKIPPED reason=market_closed next_retry_seconds=%d",
+                int(delay),
+                extra={
+                    "event": "DEFERRED_BASKET_RETRY_SKIPPED",
+                    "reason": "market_closed",
+                    "market_state": getattr(market_state, "value", str(market_state)),
+                    "next_retry_seconds": int(delay),
+                },
+            )
+            await asyncio.sleep(delay)
+            continue
         await asyncio.sleep(delay_seconds)
         if getattr(ctx, "trading_ready", False) and getattr(ctx, "live_orders_armed", False):
             return
@@ -12097,13 +12301,23 @@ async def _reconcile_state(ctx: BotContext) -> None:
 
     # 1/2. SYNC ORDERS + POSITIONS & AUTO-GUARD ORPHANS
     LOGGER.info("POSITION_RECONCILE_STARTED", extra={"event": "POSITION_RECONCILE_STARTED"})
+    ctx.position_reconciliation_started = True
+    ctx.position_reconciliation_started_at = datetime.now(timezone.utc)
+    ctx.position_reconciliation_completed = False
+    ctx.position_reconciliation_failed = False
+    ctx.position_reconciliation_error = None
     if ctx.position_manager:
         try:
             broker_positions = await asyncio.to_thread(safe_sync_fetch)
-            setattr(ctx, "position_reconciliation_failed", False)
-            setattr(ctx, "position_reconciliation_error", None)
-            setattr(ctx, "position_reconciliation_last_success_at", datetime.now(timezone.utc).isoformat())
-            setattr(ctx, "unprotected_broker_position", False)
+            ctx.position_reconciliation_failed = False
+            ctx.position_reconciliation_error = None
+            ctx.position_reconciliation_completed = True
+            ctx.position_reconciliation_completed_at = datetime.now(timezone.utc)
+            if hasattr(ctx, "unresolved_reconciliation_symbols"):
+                ctx.unresolved_reconciliation_symbols.clear()
+            if hasattr(ctx, "unprotected_broker_positions"):
+                ctx.unprotected_broker_positions.clear()
+            ctx.unprotected_broker_position = False
             # A. Fetch Broker Positions (REQUIRED STEP)
             # Initialise bm here so the ghost-bracket cleanup below never hits NameError
             # even when ctx.order_manager or _bracket_manager is absent.
@@ -12129,7 +12343,9 @@ async def _reconcile_state(ctx: BotContext) -> None:
 
                     # 3. If NOT managed, it is an Orphan -> Guard it!
                     if not is_managed:
-                        setattr(ctx, "unprotected_broker_position", True)
+                        ctx.unprotected_broker_position = True
+                        if hasattr(ctx, "unprotected_broker_positions"):
+                            ctx.unprotected_broker_positions.add(str(norm_symbol))
                         LOGGER.warning(
                             f"⚠️ ORPHAN DETECTED: {norm_symbol} (Qty: {pos.quantity}). Auto-Guarding...",
                             extra={"event": "UNPROTECTED_POSITION_BLOCKING_ENTRIES", "symbol": norm_symbol},
@@ -12152,7 +12368,9 @@ async def _reconcile_state(ctx: BotContext) -> None:
                             average_price=avg_price,
                             position_side=pos.side,
                         )
-                        setattr(ctx, "unprotected_broker_position", False)
+                        ctx.unprotected_broker_position = False
+                        if hasattr(ctx, "unprotected_broker_positions"):
+                            ctx.unprotected_broker_positions.discard(str(norm_symbol))
                         LOGGER.info(
                             "POSITION_ADOPTED_TO_BRACKET symbol=%s quantity=%s",
                             norm_symbol,
@@ -12200,12 +12418,14 @@ async def _reconcile_state(ctx: BotContext) -> None:
             LOGGER.info("POSITION_RECONCILE_SUCCESS", extra={"event": "POSITION_RECONCILE_SUCCESS"})
 
         except Exception as exc:
-            setattr(ctx, "position_reconciliation_failed", True)
-            setattr(ctx, "position_reconciliation_error", str(exc))
-            setattr(ctx, "position_reconciliation_last_failed_at", datetime.now(timezone.utc).isoformat())
-            setattr(ctx, "live_orders_armed", False)
-            setattr(ctx, "execution_armed", False)
-            setattr(ctx, "live_block_reason", "position_reconciliation_failed")
+            ctx.position_reconciliation_completed = False
+            ctx.position_reconciliation_failed = True
+            ctx.position_reconciliation_error = str(exc)
+            ctx.live_orders_armed = False
+            ctx.execution_armed = False
+            ctx.trading_ready = False
+            ctx.live_block_reason = "position_reconciliation_failed"
+            ctx.execution_block_reason = "position_reconciliation_failed"
             LOGGER.error(
                 "POSITION_RECONCILE_FAILED error_type=%s error_message=%s",
                 type(exc).__name__,

--- a/src/nifty_scalper_bot/core/history_readiness.py
+++ b/src/nifty_scalper_bot/core/history_readiness.py
@@ -258,8 +258,6 @@ def build_symbol_hydration_status(
         blockers.append("insufficient_bars")
         if mdm_bars < required:
             blockers.append("mdm_bars_missing")
-        if datahub_bars < required:
-            blockers.append("datahub_bars_missing")
         if runner_bars < required:
             blockers.append("runner_bars_missing")
         if indicator_bars < required:

--- a/src/nifty_scalper_bot/data/data_hub.py
+++ b/src/nifty_scalper_bot/data/data_hub.py
@@ -1089,19 +1089,25 @@ class DataHub:
             mdm_sub(symbol, self.ingest_tick_sync)
             self._mdm_subscribed_symbols.add(symbol)
             LOGGER.info(
-                "datahub_live_symbol_subscribed symbol=%s",
+                "SUBSCRIPTION_STATE_CHANGED symbol=%s previous=pending_token current=queued reason=mdm_delegate_registered",
                 symbol,
-                extra={"event": "datahub_live_symbol_subscribed", "symbol": symbol},
+                extra={
+                    "event": "SUBSCRIPTION_STATE_CHANGED",
+                    "symbol": symbol,
+                    "previous": "pending_token",
+                    "current": "queued",
+                    "reason": "mdm_delegate_registered",
+                },
             )
             LOGGER.info(
-                "DATAHUB_LIVE_SUBSCRIBE symbol=%s subscribed=true reason=mdm_subscribed",
+                "DATAHUB_LIVE_SUBSCRIBE symbol=%s subscribed=false reason=queued_for_mdm",
                 symbol,
                 extra={
                     "event": "DATAHUB_LIVE_SUBSCRIBE",
                     "symbol": symbol,
                     "trace_id": trace_id,
-                    "subscribed": True,
-                    "reason": "mdm_subscribed",
+                    "subscribed": False,
+                    "reason": "queued_for_mdm",
                     "mdm_delegate_called": True,
                 },
             )

--- a/src/nifty_scalper_bot/data/data_hub.py
+++ b/src/nifty_scalper_bot/data/data_hub.py
@@ -24,6 +24,8 @@ Safe-edit notes:
 from __future__ import annotations
 
 import asyncio
+from dataclasses import dataclass
+from enum import Enum
 import logging
 import os
 import re
@@ -51,6 +53,26 @@ LOGGER = logging.getLogger(__name__)
 Tick = Dict[str, Any]
 TickListener = Callable[[Tick], None]
 OrderListener = Callable[[dict[str, Any]], None]
+
+
+class SubscriptionState(str, Enum):
+    PENDING_TOKEN = "pending_token"
+    QUEUED = "queued"
+    REQUESTED = "requested"
+    BROKER_CONFIRMED = "broker_confirmed"
+    LIVE = "live"
+    FAILED = "failed"
+    UNSUBSCRIBED = "unsubscribed"
+
+
+@dataclass(frozen=True, slots=True)
+class SubscriptionRecord:
+    symbol: str
+    token: int | None
+    state: SubscriptionState
+    generation: int
+    reason: str
+    updated_at: float
 
 
 class _EventBus:
@@ -165,6 +187,8 @@ class DataHub:
         self._symbol_aliases: dict[str, set[str]] = defaultdict(set)
         self._order_subscribers: list[OrderListener] = []
         self._mdm_subscribed_symbols: set[str] = set()
+        self._subscription_states: dict[str, SubscriptionRecord] = {}
+        self._subscription_generation = 0
         self._defer_live_symbol_subscriptions = bool(
             kwargs.get("defer_live_symbol_subscriptions", True)
         )
@@ -202,6 +226,55 @@ class DataHub:
 
         self._bind_to_mdm()
         self._restore_snapshots()
+
+    def _set_subscription_state(
+        self,
+        symbol: str,
+        state: SubscriptionState,
+        *,
+        reason: str,
+        token: int | None = None,
+    ) -> SubscriptionRecord:
+        normalized = canonical(symbol)
+        previous = self._subscription_states.get(normalized)
+        if previous is not None and previous.state == state and previous.token == token:
+            return previous
+        self._subscription_generation += 1
+        record = SubscriptionRecord(
+            symbol=normalized,
+            token=token,
+            state=state,
+            generation=self._subscription_generation,
+            reason=reason,
+            updated_at=float(self._clock()),
+        )
+        self._subscription_states[normalized] = record
+        LOGGER.info(
+            "SUBSCRIPTION_STATE_CHANGED symbol=%s token=%s previous=%s current=%s reason=%s generation=%s",
+            normalized,
+            token,
+            previous.state.value if previous else None,
+            state.value,
+            reason,
+            record.generation,
+            extra={
+                "event": "SUBSCRIPTION_STATE_CHANGED",
+                "symbol": normalized,
+                "token": token,
+                "previous": previous.state.value if previous else None,
+                "current": state.value,
+                "reason": reason,
+                "generation": record.generation,
+            },
+        )
+        return record
+
+    def get_subscription_state(self, symbol: str) -> SubscriptionState | None:
+        record = self._subscription_states.get(canonical(symbol))
+        return record.state if record is not None else None
+
+    def get_subscription_record(self, symbol: str) -> SubscriptionRecord | None:
+        return self._subscription_states.get(canonical(symbol))
 
     def _bind_to_mdm(self) -> None:
         attach_tick_bus = getattr(self._mdm, "attach_tick_bus", None)
@@ -918,6 +991,12 @@ class DataHub:
             if source in {"ws", "websocket", "stream"}:
                 self._last_ws_arrival[symbol] = now_ms
                 self._last_global_ws_arrival = now_ms
+                self._set_subscription_state(
+                    symbol,
+                    SubscriptionState.LIVE,
+                    reason="first_live_tick" if first_seen else "live_tick",
+                    token=token,
+                )
             elif source in {"poll", "rest"}:
                 self._last_poll_arrival[symbol] = now_ms
             self._stale_candidates[symbol] = 0
@@ -1057,6 +1136,11 @@ class DataHub:
     def _subscribe_symbol(self, symbol: str) -> None:
         trace_id = self._make_trace_id(symbol)
         if symbol.isdigit():
+            self._set_subscription_state(
+                symbol,
+                SubscriptionState.PENDING_TOKEN,
+                reason="symbol_is_token",
+            )
             LOGGER.info(
                 "DATAHUB_LIVE_SUBSCRIBE symbol=%s subscribed=false reason=symbol_is_token",
                 symbol,
@@ -1071,6 +1155,11 @@ class DataHub:
             )
             return
         if symbol in self._mdm_subscribed_symbols:
+            self._set_subscription_state(
+                symbol,
+                SubscriptionState.QUEUED,
+                reason="already_queued",
+            )
             LOGGER.info(
                 "DATAHUB_LIVE_SUBSCRIBE symbol=%s subscribed=true reason=already_subscribed",
                 symbol,
@@ -1088,16 +1177,10 @@ class DataHub:
         if callable(mdm_sub):
             mdm_sub(symbol, self.ingest_tick_sync)
             self._mdm_subscribed_symbols.add(symbol)
-            LOGGER.info(
-                "SUBSCRIPTION_STATE_CHANGED symbol=%s previous=pending_token current=queued reason=mdm_delegate_registered",
+            self._set_subscription_state(
                 symbol,
-                extra={
-                    "event": "SUBSCRIPTION_STATE_CHANGED",
-                    "symbol": symbol,
-                    "previous": "pending_token",
-                    "current": "queued",
-                    "reason": "mdm_delegate_registered",
-                },
+                SubscriptionState.QUEUED,
+                reason="mdm_delegate_registered",
             )
             LOGGER.info(
                 "DATAHUB_LIVE_SUBSCRIBE symbol=%s subscribed=false reason=queued_for_mdm",
@@ -1128,6 +1211,11 @@ class DataHub:
                 },
             )
         else:
+            self._set_subscription_state(
+                symbol,
+                SubscriptionState.FAILED,
+                reason="mdm_no_subscribe_callable",
+            )
             LOGGER.warning(
                 "DATAHUB_LIVE_SUBSCRIBE symbol=%s subscribed=false reason=mdm_no_subscribe",
                 symbol,

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -38,6 +38,7 @@ import math
 import os
 
 from nifty_scalper_bot.config.env_utils import parse_int_env
+from nifty_scalper_bot.utils.errors import BrokerAuthenticationError
 import re
 from random import uniform
 import threading
@@ -1421,39 +1422,13 @@ class MarketDataManager:
         snapshot: dict[str, float] = {}
         response: Any | None = None
         try:
-            summary_fetcher = getattr(self._broker, "get_margin_summary", None)
-            if callable(summary_fetcher):
-                response = await summary_fetcher(segment=segment)
-                snapshot = _coerce_margin_summary(response)
-                if snapshot:
-                    self._logger.info(
-                        "Condition met: mdm_account_summary_used",
-                        extra={
-                            "event": "mdm_account_summary_used",
-                            "segment": segment,
-                        },
-                    )
-
-            if not snapshot:
-                margins_fetcher = getattr(self._broker, "get_margins", None)
-                if callable(margins_fetcher):
-                    response = await margins_fetcher(segment=segment)
-                    normalizer = getattr(
-                        self._broker, "_normalize_margin_payload", None
-                    )
-                    if callable(normalizer):
-                        normalized = normalizer(response, segment=segment)
-                        snapshot = _coerce_margin_summary(normalized)
-                    else:
-                        snapshot = _coerce_margin_summary(response)
-
-            if not snapshot:
-                balance_fetcher = getattr(self._broker, "get_available_balance", None)
-                if callable(balance_fetcher):
-                    available = await balance_fetcher(segment=segment)
-                    available_value = _coerce_positive_float(available)
-                    if available_value is not None:
-                        snapshot = {"available": float(available_value)}
+            balance_fetcher = getattr(self._broker, "get_available_balance", None)
+            if callable(balance_fetcher):
+                available = await balance_fetcher(segment=segment)
+                if available is not None:
+                    numeric_available = float(available)
+                    if math.isfinite(numeric_available) and numeric_available >= 0.0:
+                        snapshot = {"available": numeric_available}
 
             if snapshot:
                 with self._account_lock:
@@ -1475,6 +1450,11 @@ class MarketDataManager:
                 "mdm_account_snapshot_empty",
                 extra={"event": "mdm_account_snapshot_empty", "segment": segment},
             )
+        except BrokerAuthenticationError:
+            with self._account_lock:
+                self._account_snapshot = {}
+                self._account_updated_at = 0.0
+            raise
         except Exception as exc:  # noqa: BLE001
             self._logger.error(
                 "Failure in MarketDataManager.get_account_snapshot: %s",
@@ -1522,11 +1502,9 @@ class MarketDataManager:
                 if hasattr(broker, "get_available_balance"):
                     try:
                         live_balance = broker.get_available_balance(segment=segment)  # type: ignore[call-arg]
-                        numeric_live = (
-                            _coerce_positive_float(live_balance)
-                            if live_balance is not None
-                            else None
-                        )
+                        numeric_live = float(live_balance) if live_balance is not None else None
+                        if numeric_live is not None and not math.isfinite(numeric_live):
+                            numeric_live = None
                         if numeric_live is not None:
                             resolved_balance = float(numeric_live)
                             # [FIX] Throttled INFO log
@@ -1542,6 +1520,8 @@ class MarketDataManager:
                                 )
                                 self._last_balance_log_time = time.time()
                             return resolved_balance
+                    except BrokerAuthenticationError:
+                        raise
                     except Exception as exc:  # noqa: BLE001
                         self._logger.error(
                             "mdm_available_balance_direct_error: %s",
@@ -1549,26 +1529,12 @@ class MarketDataManager:
                             extra={"event": "mdm_available_balance_direct_error"},
                             exc_info=exc,
                         )
-
-                if hasattr(broker, "get_margin_summary"):
-                    summary = broker.get_margin_summary(segment=segment)  # type: ignore[call-arg]
-                    if isinstance(summary, Mapping):
-                        flattened = _coerce_margin_summary(summary)
-                        for key in ("available", "available_cash", "cash", "net"):
-                            value = _coerce_positive_float(flattened.get(key))
-                            if value is not None:
-                                if time.time() - self._last_balance_log_time >= 60.0:
-                                    self._logger.debug(
-                                        "mdm_available_balance_resolved",
-                                        extra={
-                                            "event": "mdm_available_balance_resolved",
-                                            "key": key,
-                                            "balance": round(value, 2),
-                                            "source": "broker_margin",
-                                        },
-                                    )
-                                    self._last_balance_log_time = time.time()
-                                return float(value)
+                return None
+        except BrokerAuthenticationError:
+            with self._account_lock:
+                self._account_snapshot = {}
+                self._account_updated_at = 0.0
+            raise
         except Exception as exc:  # noqa: BLE001
             self._logger.error(
                 "mdm_available_balance_margin_error: %s",

--- a/src/nifty_scalper_bot/data/rest/zerodha_client.py
+++ b/src/nifty_scalper_bot/data/rest/zerodha_client.py
@@ -244,6 +244,7 @@ class ZerodhaKiteClient(BaseBrokerClient):
         self._auth_invalid_at: float | None = None
         self._auth_failure_generation = 0
         self._auth_failure_alerted_generation = -1
+        self._auth_failure_callback: Callable[[dict[str, Any]], None] | None = None
         self._quote_api_available = True
         self._quote_api_error: str | None = None
         self._quote_api_last_checked_at: float | None = None
@@ -263,6 +264,12 @@ class ZerodhaKiteClient(BaseBrokerClient):
             "invalid_at": self._auth_invalid_at,
             "generation": self._auth_failure_generation,
         }
+
+    def set_auth_failure_callback(
+        self, callback: Callable[[dict[str, Any]], None] | None
+    ) -> None:
+        """Register callback invoked when terminal authentication failure latches."""
+        self._auth_failure_callback = callback
 
     @staticmethod
     def _is_authentication_failure(
@@ -318,6 +325,10 @@ class ZerodhaKiteClient(BaseBrokerClient):
                     "generation": self._auth_failure_generation,
                 },
             )
+            callback = self._auth_failure_callback
+            if callback is not None:
+                with suppress(Exception):
+                    callback(self.authentication_status_snapshot())
         raise BrokerAuthenticationError(
             f"Zerodha authentication invalid: {self._auth_invalid_reason}"
         )
@@ -1671,6 +1682,18 @@ class ZerodhaKiteClient(BaseBrokerClient):
                 snapshot["opening_balance"],
                 snapshot["net"],
                 extra={"event": "ZERODHA_BALANCE_REFRESH_SUCCESS", "segment": normalized_segment, **snapshot},
+            )
+        else:
+            LOGGER.debug(
+                "ZERODHA_BALANCE_REFRESH_UNCHANGED available_cash=%.2f live_balance=%.2f net=%.2f",
+                snapshot["available_cash"],
+                snapshot["live_balance"],
+                snapshot["net"],
+                extra={
+                    "event": "ZERODHA_BALANCE_REFRESH_UNCHANGED",
+                    "segment": normalized_segment,
+                    **snapshot,
+                },
             )
         self._last_log_balance = now
         self._last_balance_snapshot = snapshot

--- a/src/nifty_scalper_bot/data/rest/zerodha_client.py
+++ b/src/nifty_scalper_bot/data/rest/zerodha_client.py
@@ -14,6 +14,7 @@ from datetime import datetime
 import io
 import json
 import logging
+import math
 import os
 from pathlib import Path
 import threading
@@ -51,6 +52,8 @@ from nifty_scalper_bot.data.rest.client import BaseBrokerClient
 from nifty_scalper_bot.data.market_data_policy import MarketDataPolicy
 from nifty_scalper_bot.utils.env import get_float, get_int, get_str
 from nifty_scalper_bot.utils.errors import (
+    BrokerAuthenticationError,
+    BrokerBalanceUnavailableError,
     BrokerError,
     ConfigurationError,
     OrderPlacementError,
@@ -236,11 +239,94 @@ class ZerodhaKiteClient(BaseBrokerClient):
         self._positions_cache: _RestCacheEntry | None = None
         self._orders_cache: _RestCacheEntry | None = None
         self._margins_cache: dict[str, _RestCacheEntry] = {}
+        self._auth_invalid = False
+        self._auth_invalid_reason: str | None = None
+        self._auth_invalid_at: float | None = None
+        self._auth_failure_generation = 0
+        self._auth_failure_alerted_generation = -1
         self._quote_api_available = True
         self._quote_api_error: str | None = None
         self._quote_api_last_checked_at: float | None = None
         self._md_policy = MarketDataPolicy.from_env()
         self._last_quote_error_log_at: dict[str, float] = {}
+
+    @property
+    def auth_invalid(self) -> bool:
+        """Return whether terminal broker authentication failure is latched."""
+        return bool(self._auth_invalid)
+
+    def authentication_status_snapshot(self) -> dict[str, Any]:
+        """Return sanitized broker authentication latch state."""
+        return {
+            "valid": not self._auth_invalid,
+            "reason": self._auth_invalid_reason,
+            "invalid_at": self._auth_invalid_at,
+            "generation": self._auth_failure_generation,
+        }
+
+    @staticmethod
+    def _is_authentication_failure(
+        *,
+        status_code: int | None,
+        payload: Mapping[str, Any] | None,
+        error_text: str,
+    ) -> bool:
+        """Classify terminal Zerodha authentication/session failures."""
+        if status_code in {401, 403}:
+            return True
+        fragments: list[str] = [error_text or ""]
+        if isinstance(payload, Mapping):
+            for key in ("message", "error_type", "status", "error"):
+                value = payload.get(key)
+                if value is not None:
+                    fragments.append(str(value))
+        text = " ".join(fragments).lower()
+        auth_tokens = (
+            "tokenexception",
+            "invalidtoken",
+            "incorrect api_key",
+            "incorrect access_token",
+            "invalid session",
+            "token expired",
+            "permission denied",
+            "authentication failed",
+            "unauthorized",
+        )
+        return any(token in text for token in auth_tokens)
+
+    def _clear_rest_caches(self) -> None:
+        self._positions_cache = None
+        self._orders_cache = None
+        self._margins_cache.clear()
+
+    def _mark_authentication_invalid(self, reason: str) -> NoReturn:
+        """Latch terminal authentication failure and raise typed broker error."""
+        safe_reason = str(reason or "authentication_failed")[:256]
+        if not self._auth_invalid:
+            self._auth_invalid = True
+            self._auth_invalid_reason = safe_reason
+            self._auth_invalid_at = self._log_time_fn()
+            self._auth_failure_generation += 1
+            self._clear_rest_caches()
+            LOGGER.error(
+                "ZERODHA_AUTH_INVALIDATED reason=%s generation=%s",
+                safe_reason,
+                self._auth_failure_generation,
+                extra={
+                    "event": "ZERODHA_AUTH_INVALIDATED",
+                    "reason": safe_reason,
+                    "generation": self._auth_failure_generation,
+                },
+            )
+        raise BrokerAuthenticationError(
+            f"Zerodha authentication invalid: {self._auth_invalid_reason}"
+        )
+
+    def _raise_if_authentication_latched(self) -> None:
+        if self._auth_invalid:
+            raise BrokerAuthenticationError(
+                f"Zerodha authentication invalid: {self._auth_invalid_reason}"
+            )
 
     def quote_api_available(self) -> bool:
         """Return quote API capability flag."""
@@ -1371,6 +1457,8 @@ class ZerodhaKiteClient(BaseBrokerClient):
                 error_message="Failed to fetch Zerodha account margins",
                 on_retry=on_retry,
             )
+        except BrokerAuthenticationError:
+            raise
         except Exception as exc:  # noqa: BLE001 - propagate after logging
             LOGGER.error(
                 "Failure in ZerodhaKiteClient.get_account_margins: %s",
@@ -1509,18 +1597,14 @@ class ZerodhaKiteClient(BaseBrokerClient):
         return summary
 
     def get_available_balance(self, segment: str = "equity") -> float:
-        """Return available margin balance for a Zerodha segment.
+        """Return broker-reported available account balance for a Zerodha segment.
 
-        Args:
-            segment: Zerodha segment identifier such as ``"equity"``.
-
-        Returns:
-            float: Available balance extracted from the margin payload.
-
-        Raises:
-            BrokerError: Propagated when the margin fetch fails.
+        Live account funds are fail-closed: only ``/user/margins/{segment}`` is
+        accepted, terminal authentication failures are re-raised, and missing or
+        malformed broker payloads raise ``BrokerBalanceUnavailableError``.
         """
 
+        self._raise_if_authentication_latched()
         normalized_segment = (
             str(segment or self._default_margin_segment).strip().lower()
             or self._default_margin_segment
@@ -1532,142 +1616,43 @@ class ZerodhaKiteClient(BaseBrokerClient):
                 "segment": normalized_segment,
             },
         )
-        summary: dict[str, float] | None = None
-        account_payload: Mapping[str, Any] | None = None
-        account_error: Exception | None = None
         try:
             account_payload = self.get_account_margins(segment=normalized_segment)
-            if account_payload:
-                summary = self._normalize_margin_payload(
-                    account_payload,
-                    segment=normalized_segment,
-                )
-        except Exception as exc:  # noqa: BLE001 - continue with fallback
-            account_error = exc
+            summary = self._parse_account_margin_summary(
+                account_payload,
+                segment=normalized_segment,
+            )
+        except BrokerAuthenticationError:
+            raise
+        except Exception as exc:  # noqa: BLE001 - convert to typed fail-closed error
             LOGGER.error(
-                "Failure in ZerodhaKiteClient.get_available_balance account fetch: %s",
-                exc,
+                "ZERODHA_BALANCE_REFRESH_FAILED segment=%s reason=%s",
+                normalized_segment,
+                str(exc),
                 extra={
-                    "event": "zerodha_available_balance_account_error",
+                    "event": "ZERODHA_BALANCE_REFRESH_FAILED",
                     "segment": normalized_segment,
+                    "reason": str(exc),
+                    "error_type": type(exc).__name__,
                 },
                 exc_info=exc,
             )
+            raise BrokerBalanceUnavailableError(
+                f"Broker balance unavailable for segment {normalized_segment}: {exc}"
+            ) from exc
 
-        if not summary:
-            try:
-                summary = self.get_margin_summary(segment=normalized_segment)
-                if account_error is not None:
-                    LOGGER.info(
-                        "Condition met: zerodha_available_balance_summary_fallback",
-                        extra={
-                            "event": "zerodha_available_balance_summary_fallback",
-                            "segment": normalized_segment,
-                        },
-                    )
-            except Exception as exc:  # noqa: BLE001 - fallback to env
-                LOGGER.error(
-                    "Failure in ZerodhaKiteClient.get_available_balance: %s",
-                    exc,
-                    extra={
-                        "event": "zerodha_available_balance_error",
-                        "segment": normalized_segment,
-                    },
-                    exc_info=exc,
-                )
-                fallback_balance = self._resolve_balance_fallback()
-                LOGGER.warning(
-                    "Condition met: zerodha_available_balance_env_fallback",
-                    extra={
-                        "event": "zerodha_available_balance_env_fallback",
-                        "segment": normalized_segment,
-                        "fallback": fallback_balance,
-                    },
-                )
-                return fallback_balance
-
-        summary = summary or {"available": 0.0}
-        available = float(summary.get("available", 0.0) or 0.0)
-        if available <= 0.0:
-            alternate_keys = ("available_cash", "cash", "net")
-            for key in alternate_keys:
-                raw_value = summary.get(key)
-                if raw_value is None:
-                    continue
-                try:
-                    candidate = float(raw_value)
-                except (TypeError, ValueError):
-                    continue
-                if candidate > 0.0:
-                    available = candidate
-                    LOGGER.info(
-                        "Condition met: zerodha_available_balance_alternate_key",
-                        extra={
-                            "event": "zerodha_available_balance_alternate_key",
-                            "segment": normalized_segment,
-                            "key": key,
-                            "available": available,
-                        },
-                    )
-                    break
-
-        if available <= 0.0:
-            fallback_balance = self._resolve_balance_fallback()
-            LOGGER.warning(
-                "Condition met: zerodha_available_balance_non_positive",
-                extra={
-                    "event": "zerodha_available_balance_non_positive",
-                    "segment": normalized_segment,
-                    "available": available,
-                    "fallback": fallback_balance,
-                },
-            )
-            return fallback_balance
-
-        available_cash = float(available)
-        live_balance = 0.0
-        opening_balance = 0.0
-        net = float(summary.get("net", available_cash) or available_cash)
-        if isinstance(account_payload, Mapping):
-            equity = account_payload.get("equity")
-            equity_map = equity if isinstance(equity, Mapping) else {}
-            available_map_raw = equity_map.get("available")
-            available_map = (
-                available_map_raw if isinstance(available_map_raw, Mapping) else {}
-            )
-            available_cash = float(
-                available_map.get("cash")
-                or available_map.get("live_balance")
-                or available_map.get("opening_balance")
-                or available_cash
-                or 0.0
-            )
-            live_balance = float(available_map.get("live_balance") or 0.0)
-            opening_balance = float(available_map.get("opening_balance") or 0.0)
-            net = float(equity_map.get("net") or summary.get("net") or available_cash or 0.0)
-        else:
-            live_balance = float(summary.get("live_balance", 0.0) or 0.0)
-            opening_balance = float(summary.get("opening_balance", 0.0) or 0.0)
-
+        available = float(summary["available"])
         snapshot = {
-            "available_cash": round(available_cash, 2),
-            "live_balance": round(live_balance, 2),
-            "opening_balance": round(opening_balance, 2),
-            "net": round(net, 2),
+            "available_cash": round(available, 2),
+            "live_balance": round(float(summary["live_balance"]), 2),
+            "opening_balance": round(float(summary["opening_balance"]), 2),
+            "net": round(float(summary["net"]), 2),
         }
         now = time.time()
-        refresh_interval = max(
-            60.0,
-            float(
-                os.getenv("RISK_EQUITY_REFRESH_SECONDS")
-                or os.getenv("EQUITY_REFRESH_SECONDS")
-                or "60"
-            ),
-        )
         snapshot_tuple = (
-            round(float(snapshot["available_cash"]), 2),
-            round(float(snapshot["live_balance"]), 2),
-            round(float(snapshot["net"]), 2),
+            snapshot["available_cash"],
+            snapshot["live_balance"],
+            snapshot["net"],
         )
         heartbeat_interval = float(os.getenv("BALANCE_SUCCESS_LOG_INTERVAL_SECONDS", "900"))
         should_log = (
@@ -1680,87 +1665,97 @@ class ZerodhaKiteClient(BaseBrokerClient):
             self._last_balance_success_log_ts = now
             self._last_balance_success_snapshot = snapshot_tuple
             LOGGER.info(
-                (
-                    "ZERODHA_BALANCE_REFRESH_SUCCESS available_cash=%.2f "
-                    "live_balance=%.2f opening_balance=%.2f net=%.2f"
-                ),
+                "ZERODHA_BALANCE_REFRESH_SUCCESS available_cash=%.2f live_balance=%.2f opening_balance=%.2f net=%.2f",
                 snapshot["available_cash"],
                 snapshot["live_balance"],
                 snapshot["opening_balance"],
                 snapshot["net"],
-                extra={
-                    "event": "ZERODHA_BALANCE_REFRESH_SUCCESS",
-                    "segment": normalized_segment,
-                    "available_cash": snapshot["available_cash"],
-                    "live_balance": snapshot["live_balance"],
-                    "opening_balance": snapshot["opening_balance"],
-                    "net": snapshot["net"],
-                },
+                extra={"event": "ZERODHA_BALANCE_REFRESH_SUCCESS", "segment": normalized_segment, **snapshot},
             )
-            self._last_log_balance = now
-            self._last_balance_snapshot = snapshot
-            self._last_balance_snapshot_at = now
-        else:
-            LOGGER.debug(
-                "ZERODHA_BALANCE_REFRESH_SUPPRESSED available_cash=%0.2f live_balance=%0.2f net=%0.2f",
-                snapshot["available_cash"], snapshot["live_balance"], snapshot["net"],
-                extra={
-                    "event": "ZERODHA_BALANCE_REFRESH_UNCHANGED",
-                    "segment": normalized_segment,
-                    "available_cash": snapshot["available_cash"],
-                    "net": snapshot["net"],
-                },
-            )
+        self._last_log_balance = now
+        self._last_balance_snapshot = snapshot
+        self._last_balance_snapshot_at = now
         return available
 
-    def _resolve_balance_fallback(self) -> float:
-        """Return environment configured fallback balance figure.
+    def _parse_account_margin_summary(
+        self,
+        payload: Mapping[str, Any],
+        *,
+        segment: str,
+    ) -> dict[str, float]:
+        """Strictly parse ``/user/margins/{segment}`` account-funds payload."""
+        if not isinstance(payload, Mapping) or not payload:
+            raise BrokerBalanceUnavailableError("empty_account_margin_payload")
+        if self._is_authentication_failure(status_code=None, payload=payload, error_text=""):
+            self._mark_authentication_invalid(str(payload.get("message") or payload.get("error_type") or "authentication_failed"))
+        if str(payload.get("status", "")).lower() == "error" or "error_type" in payload:
+            raise BrokerBalanceUnavailableError("broker_error_margin_payload")
 
-        Args:
-            None.
+        segment_key = str(segment or "equity").strip().lower() or "equity"
+        target: Mapping[str, Any]
+        candidate = payload.get(segment_key)
+        if isinstance(candidate, Mapping):
+            target = candidate
+        elif isinstance(payload.get("available"), Mapping) or "net" in payload:
+            target = payload
+        else:
+            raise BrokerBalanceUnavailableError("missing_segment_margin_payload")
 
-        Returns:
-            float: Non-negative fallback balance from environment variables.
+        available_map = target.get("available")
+        utilised_map = target.get("utilised")
+        if not isinstance(available_map, Mapping):
+            raise BrokerBalanceUnavailableError("missing_available_margin_fields")
+        if not isinstance(utilised_map, Mapping):
+            utilised_map = {}
 
-        Raises:
-            None.
-        """
+        def _number(name: str, value: Any, *, required: bool = True) -> float:
+            if value is None:
+                if required:
+                    raise BrokerBalanceUnavailableError(f"missing_margin_field:{name}")
+                return 0.0
+            try:
+                parsed = float(value)
+            except (TypeError, ValueError) as exc:
+                raise BrokerBalanceUnavailableError(f"invalid_margin_field:{name}") from exc
+            if not math.isfinite(parsed):
+                raise BrokerBalanceUnavailableError(f"non_finite_margin_field:{name}")
+            if parsed < 0.0:
+                raise BrokerBalanceUnavailableError(f"negative_margin_field:{name}")
+            return parsed
 
-        LOGGER.debug(
-            "Entered ZerodhaKiteClient._resolve_balance_fallback",
-            extra={"event": "zerodha_balance_fallback_enter"},
-        )
-        fallback_value = 1_000_000.0
-        try:
-            candidates = (
-                os.getenv("RISK__CAPITAL"),
-                os.getenv("RISK_CAPITAL"),
-                os.getenv("BACKTEST__CAPITAL"),
-            )
-            for candidate in candidates:
-                if candidate is None:
-                    continue
-                token = candidate.strip()
-                if not token:
-                    continue
-                fallback_value = max(float(token), 0.0)
-                break
-        except Exception as exc:  # noqa: BLE001 - defensive parsing
-            LOGGER.error(
-                "Failure in ZerodhaKiteClient._resolve_balance_fallback: %s",
-                exc,
-                extra={"event": "zerodha_balance_fallback_error"},
-                exc_info=exc,
-            )
-            fallback_value = 1_000_000.0
-        LOGGER.info(
-            "Condition met: zerodha_balance_fallback_resolved",
-            extra={
-                "event": "zerodha_balance_fallback_resolved",
-                "fallback": fallback_value,
-            },
-        )
-        return fallback_value
+        cash_value = available_map.get("cash")
+        if cash_value is None:
+            cash_value = available_map.get("live_balance")
+        if cash_value is None:
+            cash_value = available_map.get("opening_balance")
+        available = _number("available.cash", cash_value)
+        live_balance = _number("available.live_balance", available_map.get("live_balance"), required=False)
+        opening_balance = _number("available.opening_balance", available_map.get("opening_balance"), required=False)
+        used = 0.0
+        for key in ("debits", "span", "exposure", "option_premium", "holding_sales"):
+            value = utilised_map.get(key)
+            if value is not None:
+                used += _number(f"utilised.{key}", value, required=False)
+        net_value = target.get("net")
+        net = _number("net", net_value) if net_value is not None else available + used
+        return {
+            "available": available,
+            "used": used,
+            "net": net,
+            "live_balance": live_balance,
+            "opening_balance": opening_balance,
+        }
+
+    def _resolve_simulated_balance(self) -> float:
+        """Return explicit non-live simulation capital; never used as live fallback."""
+        for name in ("RISK__CAPITAL", "RISK_CAPITAL", "BACKTEST__CAPITAL"):
+            raw = os.getenv(name)
+            if raw is None or not raw.strip():
+                continue
+            value = float(raw)
+            if math.isfinite(value) and value >= 0.0:
+                return value
+        raise ConfigurationError("simulated_balance_requires_explicit_capital")
 
     def _resolve_margin_payload(
         self,
@@ -2669,6 +2664,7 @@ class ZerodhaKiteClient(BaseBrokerClient):
             BrokerError: If the request exhausts retries or encounters a fatal error.
         """
 
+        self._raise_if_authentication_latched()
         url = endpoint if endpoint.startswith("/") else f"/{endpoint}"
         label = operation_label or (url.lstrip("/") or "zerodha")
         should_retry, on_retry = self._build_retry_handlers(endpoint=url)
@@ -2720,6 +2716,16 @@ class ZerodhaKiteClient(BaseBrokerClient):
                             delay_hint=0.5,
                         ),
                     ) from exc
+                if self._is_authentication_failure(
+                    status_code=response.status_code,
+                    payload=payload if isinstance(payload, Mapping) else None,
+                    error_text="",
+                ):
+                    self._mark_authentication_invalid(
+                        str(payload.get("message") or payload.get("error_type") or "authentication_failed")
+                        if isinstance(payload, Mapping)
+                        else "authentication_failed"
+                    )
                 self._reset_transient_state()
                 return payload
 
@@ -2777,6 +2783,17 @@ class ZerodhaKiteClient(BaseBrokerClient):
 
         message = self._safe_error_message(response)
         status = response.status_code
+        payload: Mapping[str, Any] | None = None
+        with suppress(Exception):
+            raw_payload = response.json()
+            if isinstance(raw_payload, Mapping):
+                payload = raw_payload
+        if self._is_authentication_failure(
+            status_code=status,
+            payload=payload,
+            error_text=message,
+        ):
+            self._mark_authentication_invalid(message)
         error: Exception
         if status in {400, 404} and expect_order_response:
             error = OrderPlacementError(message)

--- a/src/nifty_scalper_bot/execution/order_manager.py
+++ b/src/nifty_scalper_bot/execution/order_manager.py
@@ -85,7 +85,7 @@ from nifty_scalper_bot.risk.session_gate import can_trade
 from nifty_scalper_bot.storage.journal import AtomicKV
 from nifty_scalper_bot.utils import metrics
 from nifty_scalper_bot.utils.circuit_breaker import CircuitBreaker
-from nifty_scalper_bot.utils.errors import RateLimitError
+from nifty_scalper_bot.utils.errors import BrokerAuthenticationError, RateLimitError
 from nifty_scalper_bot.utils.log_throttle import log_on_change, log_throttled as log_throttled_live
 from nifty_scalper_bot.utils.logging import get_logger
 from nifty_scalper_bot.utils.metrics import Counter, Gauge
@@ -2220,6 +2220,12 @@ class OrderManager:
         )
         if trace_id:
             self._last_trace_id = trace_id
+        broker = getattr(self, "_broker", None)
+        if bool(getattr(broker, "auth_invalid", False)):
+            self.set_last_skip_reason("broker_auth_invalid")
+            raise OrderPlacementError("broker_auth_invalid") from BrokerAuthenticationError(
+                "broker_auth_invalid"
+            )
 
         def _log_order_decision(
             *,

--- a/src/nifty_scalper_bot/execution/order_manager.py
+++ b/src/nifty_scalper_bot/execution/order_manager.py
@@ -85,7 +85,7 @@ from nifty_scalper_bot.risk.session_gate import can_trade
 from nifty_scalper_bot.storage.journal import AtomicKV
 from nifty_scalper_bot.utils import metrics
 from nifty_scalper_bot.utils.circuit_breaker import CircuitBreaker
-from nifty_scalper_bot.utils.errors import BrokerAuthenticationError, RateLimitError
+from nifty_scalper_bot.utils.errors import RateLimitError
 from nifty_scalper_bot.utils.log_throttle import log_on_change, log_throttled as log_throttled_live
 from nifty_scalper_bot.utils.logging import get_logger
 from nifty_scalper_bot.utils.metrics import Counter, Gauge
@@ -2223,9 +2223,7 @@ class OrderManager:
         broker = getattr(self, "_broker", None)
         if bool(getattr(broker, "auth_invalid", False)):
             self.set_last_skip_reason("broker_auth_invalid")
-            raise OrderPlacementError("broker_auth_invalid") from BrokerAuthenticationError(
-                "broker_auth_invalid"
-            )
+            raise OrderPlacementError("broker_auth_invalid")
 
         def _log_order_decision(
             *,

--- a/src/nifty_scalper_bot/execution/readiness.py
+++ b/src/nifty_scalper_bot/execution/readiness.py
@@ -56,15 +56,17 @@ _READINESS_PRIORITY = [
     "kill_switch_active",
     "broker_auth_invalid",
     "broker_session_invalid",
+    "broker_balance_unavailable",
+    "position_reconciliation_failed",
+    "position_reconciliation_incomplete",
+    "unresolved_exit_position",
+    "unprotected_broker_position",
+    "risk_halt",
+    "daily_loss_limit",
     "market_closed",
     "exchange_holiday",
     "outside_session",
-    "risk_halt",
-    "daily_loss_limit",
     "broker_health_block",
-    "position_reconciliation_failed",
-    "unresolved_exit_position",
-    "unprotected_broker_position",
     "futures_history_missing",
     "context_exec_not_ready",
     "selected_contract_missing",
@@ -154,6 +156,8 @@ def normalize_readiness_blockers(
         canonical.append("broker_auth_invalid")
     if broker_state.get("broker_session_invalid"):
         canonical.append("broker_session_invalid")
+    if broker_state.get("broker_balance_unavailable") or broker_state.get("broker_balance_valid") is False:
+        canonical.append("broker_balance_unavailable")
     if risk_state.get("risk_halt"):
         canonical.append("risk_halt")
     if risk_state.get("daily_loss_limit"):
@@ -167,7 +171,7 @@ def normalize_readiness_blockers(
             canonical.append("market_closed")
     canonical = list(dict.fromkeys(canonical))
 
-    high_priority = {"emergency_stop_active", "kill_switch_active", "broker_auth_invalid", "broker_session_invalid"}
+    high_priority = {"emergency_stop_active", "kill_switch_active", "broker_auth_invalid", "broker_session_invalid", "broker_balance_unavailable", "position_reconciliation_failed", "position_reconciliation_incomplete", "unresolved_exit_position", "unprotected_broker_position"}
     has_high_priority = any(item in canonical for item in high_priority)
     market_blocker = "exchange_holiday" if "exchange_holiday" in canonical else "outside_session" if "outside_session" in canonical else "market_closed" if "market_closed" in canonical else None
     secondary: list[str] = []

--- a/src/nifty_scalper_bot/main.py
+++ b/src/nifty_scalper_bot/main.py
@@ -17,7 +17,7 @@ import sys
 
 from dotenv import load_dotenv
 from fastapi import FastAPI, HTTPException
-from fastapi.responses import PlainTextResponse
+from fastapi.responses import JSONResponse, PlainTextResponse
 
 from nifty_scalper_bot.config.env_utils import normalise_live_env_defaults
 from nifty_scalper_bot.config.paths import get_data_dir
@@ -189,15 +189,39 @@ def root():
 
 @app.get("/health")
 def health():
+    return readyz()
+
+
+@app.get("/livez")
+def livez():
+    return {"status": "alive", "bot_loaded": app.state.bot is not None}
+
+
+@app.get("/readyz")
+def readyz():
     if app.state.bot_error:
-        return {
+        return JSONResponse(status_code=503, content={
             "status": "degraded",
+            "ready": False,
             "error": app.state.bot_error,
-        }
+        })
 
     return {
         "status": "running" if app.state.bot else "starting",
+        "ready": app.state.bot is not None,
         "bot_loaded": app.state.bot is not None,
+    }
+
+
+@app.get("/health/trading")
+def health_trading():
+    ready = app.state.bot_error is None and app.state.bot is not None
+    return {
+        "status": "ready" if ready else "blocked",
+        "ready": ready,
+        "live_orders_armed": False,
+        "primary_blocker": None if ready else "startup_incomplete",
+        "blockers": [] if ready else ["startup_incomplete"],
     }
 
 

--- a/src/nifty_scalper_bot/main.py
+++ b/src/nifty_scalper_bot/main.py
@@ -107,11 +107,14 @@ print("🚀 PYTHON START: Initializing...", flush=True)
 async def lifespan(app: FastAPI):
     app.state.bot = None
     app.state.bot_error = None
+    app.state.bot_started = False
+    app.state.bot_starting = False
 
     async def run_bot_background():
         try:
             print("⏳ BACKGROUND: Waiting 5s for Server Port Bind...", flush=True)
             await asyncio.sleep(5)
+            app.state.bot_starting = True
 
             print("📦 BACKGROUND: Importing Trading Engine...", flush=True)
             from nifty_scalper_bot.core.app import NiftyScalperApp
@@ -122,6 +125,8 @@ async def lifespan(app: FastAPI):
 
             print("▶️ BACKGROUND: Starting Trading Loop...", flush=True)
             await bot.start()
+            app.state.bot_started = True
+            app.state.bot_starting = False
 
             print("🟢 BACKGROUND: Bot fully operational", flush=True)
 
@@ -131,6 +136,8 @@ async def lifespan(app: FastAPI):
 
         except Exception as exc:
             app.state.bot_error = str(exc)
+            app.state.bot_started = False
+            app.state.bot_starting = False
             print(f"⚠️ BOT STARTUP WARNING: {exc}", flush=True)
             warmup_tokens = ('WARMING_UP', 'DATA_WARMUP', 'HISTORICAL_READY')
             is_warmup_like = any(token in str(exc).upper() for token in warmup_tokens)
@@ -168,6 +175,10 @@ async def lifespan(app: FastAPI):
 # -------------------------------------------------------
 
 app = FastAPI(lifespan=lifespan)
+app.state.bot = None
+app.state.bot_error = None
+app.state.bot_started = False
+app.state.bot_starting = False
 
 # Browser admin dashboard (credentials, logs, daily token, restart) for
 # non-technical operation on a plain VM. Routes are password-protected.
@@ -197,32 +208,154 @@ def livez():
     return {"status": "alive", "bot_loaded": app.state.bot is not None}
 
 
+def _latest_context():
+    bot = getattr(app.state, "bot", None)
+    ctx = getattr(bot, "_ctx", None)
+    if ctx is not None:
+        return ctx
+    try:
+        from nifty_scalper_bot.core.app import get_latest_bot_context
+
+        return get_latest_bot_context()
+    except Exception:
+        return None
+
+
+def _context_blockers(ctx) -> list[str]:  # noqa: ANN001
+    blockers: list[str] = []
+    decision = getattr(ctx, "readiness_decision", None)
+    decision_blockers = list(getattr(decision, "blocker_list", ()) or ())
+    blockers.extend(str(item) for item in decision_blockers if item)
+    if bool(getattr(ctx, "broker_auth_invalid", False)):
+        blockers.append("broker_auth_invalid")
+    if not bool(getattr(ctx, "broker_balance_valid", False)):
+        blockers.append("broker_balance_unavailable")
+    if bool(getattr(ctx, "position_reconciliation_failed", False)):
+        blockers.append("position_reconciliation_failed")
+    if not bool(getattr(ctx, "position_reconciliation_completed", False)):
+        blockers.append("position_reconciliation_incomplete")
+    if bool(getattr(ctx, "unprotected_broker_positions", set())):
+        blockers.append("unprotected_broker_position")
+    live_block_reason = getattr(ctx, "live_block_reason", None)
+    if live_block_reason:
+        reason = str(live_block_reason).split(":", 1)[-1]
+        if reason:
+            blockers.append(reason)
+    return list(dict.fromkeys(blockers))
+
+
+_NON_OPERATIONAL_READYZ_BLOCKERS = {
+    "market_closed",
+    "exchange_holiday",
+    "outside_session",
+}
+
+
 @app.get("/readyz")
 def readyz():
     if app.state.bot_error:
-        return JSONResponse(status_code=503, content={
-            "status": "degraded",
-            "ready": False,
-            "error": app.state.bot_error,
-        })
+        return JSONResponse(
+            status_code=503,
+            content={
+                "status": "degraded",
+                "ready": False,
+                "primary_blocker": "startup_failed",
+                "error": app.state.bot_error,
+            },
+        )
 
-    return {
-        "status": "running" if app.state.bot else "starting",
-        "ready": app.state.bot is not None,
-        "bot_loaded": app.state.bot is not None,
-    }
+    ctx = _latest_context()
+    if not bool(getattr(app.state, "bot_started", False)) or ctx is None:
+        return JSONResponse(
+            status_code=503,
+            content={
+                "status": "starting",
+                "ready": False,
+                "primary_blocker": "startup_incomplete",
+            },
+        )
+
+    blockers = _context_blockers(ctx)
+    operational_blockers = [
+        blocker
+        for blocker in blockers
+        if blocker not in _NON_OPERATIONAL_READYZ_BLOCKERS
+    ]
+    ready = (
+        not bool(getattr(ctx, "broker_auth_invalid", False))
+        and bool(getattr(ctx, "broker_balance_valid", False))
+        and bool(getattr(ctx, "position_reconciliation_completed", False))
+        and not bool(getattr(ctx, "position_reconciliation_failed", False))
+        and not operational_blockers
+    )
+    return JSONResponse(
+        status_code=200 if ready else 503,
+        content={
+            "status": "ready" if ready else "blocked",
+            "ready": ready,
+            "primary_blocker": (
+                operational_blockers[0]
+                if operational_blockers
+                else blockers[0]
+                if blockers
+                else None
+            ),
+            "blockers": blockers,
+        },
+    )
 
 
 @app.get("/health/trading")
 def health_trading():
-    ready = app.state.bot_error is None and app.state.bot is not None
-    return {
-        "status": "ready" if ready else "blocked",
-        "ready": ready,
-        "live_orders_armed": False,
-        "primary_blocker": None if ready else "startup_incomplete",
-        "blockers": [] if ready else ["startup_incomplete"],
-    }
+    ctx = _latest_context()
+    if ctx is None:
+        return JSONResponse(
+            status_code=200,
+            content={
+                "status": "starting",
+                "ready": False,
+                "live_orders_armed": False,
+                "primary_blocker": "startup_incomplete",
+                "blockers": ["startup_incomplete"],
+            },
+        )
+    decision = getattr(ctx, "readiness_decision", None)
+    blockers = _context_blockers(ctx)
+    live_orders_armed = bool(
+        getattr(decision, "live_orders_armed", getattr(ctx, "live_orders_armed", False))
+    )
+    execution_ready = bool(
+        getattr(decision, "execution_ready", getattr(ctx, "execution_armed", False))
+    )
+    primary = getattr(decision, "primary_blocker", None) or (
+        blockers[0] if blockers else None
+    )
+    return JSONResponse(
+        status_code=200,
+        content={
+            "status": "armed" if live_orders_armed else "blocked",
+            "ready": execution_ready and not blockers,
+            "live_orders_armed": live_orders_armed and not blockers,
+            "primary_blocker": primary,
+            "blockers": blockers,
+            "broker": {
+                "ready": bool(getattr(ctx, "broker_ready", False)),
+                "auth_invalid": bool(getattr(ctx, "broker_auth_invalid", False)),
+                "balance_valid": bool(getattr(ctx, "broker_balance_valid", False)),
+                "balance": getattr(ctx, "last_valid_broker_balance", None),
+                "balance_error": getattr(ctx, "broker_balance_error", None),
+            },
+            "reconciliation": {
+                "started": bool(getattr(ctx, "position_reconciliation_started", False)),
+                "completed": bool(getattr(ctx, "position_reconciliation_completed", False)),
+                "failed": bool(getattr(ctx, "position_reconciliation_failed", False)),
+                "error": getattr(ctx, "position_reconciliation_error", None),
+                "unprotected_positions": sorted(
+                    getattr(ctx, "unprotected_broker_positions", set()) or []
+                ),
+            },
+        },
+    )
 
 
 @app.get("/debug/env")

--- a/src/nifty_scalper_bot/utils/errors.py
+++ b/src/nifty_scalper_bot/utils/errors.py
@@ -19,6 +19,14 @@ class BrokerError(BotError):
     """Raised when broker integrations fail."""
 
 
+class BrokerAuthenticationError(BrokerError):
+    """Terminal broker authentication or session failure."""
+
+
+class BrokerBalanceUnavailableError(BrokerError):
+    """Broker account balance could not be obtained safely."""
+
+
 class OrderPlacementError(BrokerError):
     """Raised when order placement fails after retries or validation."""
 
@@ -36,6 +44,8 @@ __all__ = [
     "ConfigurationError",
     "RateLimitError",
     "BrokerError",
+    "BrokerAuthenticationError",
+    "BrokerBalanceUnavailableError",
     "OrderPlacementError",
     "DataStaleError",
     "WebSocketError",

--- a/tests/core/test_bot_context_attributes.py
+++ b/tests/core/test_bot_context_attributes.py
@@ -30,7 +30,10 @@ def test_every_ctx_attribute_write_is_declared() -> None:
     for node in ast.walk(tree):
         if isinstance(node, ast.ClassDef) and node.name == "BotContext":
             for stmt in node.body:
-                if isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name):
+                if (
+                    isinstance(stmt, ast.AnnAssign)
+                    and isinstance(stmt.target, ast.Name)
+                ):
                     declared.add(stmt.target.id)
     defaults = set(BOT_CONTEXT_RUNTIME_FIELD_DEFAULTS.keys())
     writes: set[str] = set()
@@ -44,6 +47,25 @@ def test_every_ctx_attribute_write_is_declared() -> None:
                     and target.value.id == "ctx"
                 ):
                     writes.add(target.attr)
+        if isinstance(node, ast.AnnAssign):
+            target = node.target
+            if (
+                isinstance(target, ast.Attribute)
+                and isinstance(target.value, ast.Name)
+                and target.value.id == "ctx"
+            ):
+                writes.add(target.attr)
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "setattr"
+            and len(node.args) >= 2
+            and isinstance(node.args[0], ast.Name)
+            and node.args[0].id == "ctx"
+            and isinstance(node.args[1], ast.Constant)
+            and isinstance(node.args[1].value, str)
+        ):
+            writes.add(node.args[1].value)
     undeclared = sorted(writes - declared - defaults)
     assert not undeclared, (
         f"Undeclared ctx attribute writes (would raise AttributeError on the "
@@ -57,6 +79,21 @@ def test_basket_build_pending_spot_ltp_is_declared_field() -> None:
 
     field_names = {f.name for f in dataclasses.fields(BotContext)}
     assert "basket_build_pending_spot_ltp" in field_names
+
+
+def test_broker_and_reconciliation_fields_are_declared() -> None:
+    import dataclasses
+
+    field_names = {f.name for f in dataclasses.fields(BotContext)}
+    required = {
+        "position_reconciliation_started",
+        "position_reconciliation_completed",
+        "position_reconciliation_failed",
+        "position_reconciliation_error",
+        "broker_auth_invalid",
+        "broker_balance_valid",
+    }
+    assert required <= field_names
 
 
 def test_rearm_loop_does_not_write_private_ctx_flags() -> None:

--- a/tests/core/test_hydration_status_propagation.py
+++ b/tests/core/test_hydration_status_propagation.py
@@ -119,12 +119,13 @@ def test_hydration_status_consistent_counts_across_all_layers() -> None:
     assert status.ready_for_evaluation is True
 
 
-def test_readiness_false_if_any_layer_has_fewer_bars() -> None:
-    status = app.build_symbol_hydration_status(_ctx(30, 29, 30, 30, _quote()), SYMBOL, "selected_ce", 30)
+def test_datahub_bars_do_not_gate_readiness() -> None:
+    status = app.build_symbol_hydration_status(
+        _ctx(30, 0, 30, 30, _quote()), SYMBOL, "selected_ce", 30
+    )
 
-    assert status.ready_for_evaluation is False
-    assert status.ready_for_execution is False
-    assert "datahub_bars_missing" in status.blocker_reasons
+    assert status.ready_for_evaluation is True
+    assert "datahub_bars_missing" not in status.blocker_reasons
 
 
 def test_readiness_true_when_all_layers_have_bars_and_quote_depth_valid() -> None:

--- a/tests/core/test_startup_risk_balance.py
+++ b/tests/core/test_startup_risk_balance.py
@@ -1,0 +1,81 @@
+from types import SimpleNamespace
+
+import pytest
+
+from nifty_scalper_bot.core.app import (
+    _resolve_startup_risk_initial_balance,
+    apply_broker_auth_failure_to_context,
+)
+from nifty_scalper_bot.utils.errors import BrokerBalanceUnavailableError
+
+
+def test_live_risk_initial_balance_uses_validated_broker_balance(monkeypatch):
+    monkeypatch.setenv("EXECUTION_MODE", "LIVE")
+    settings = SimpleNamespace(execution_mode="LIVE")
+    config = SimpleNamespace(initial_balance=1_000_000.0)
+
+    balance = _resolve_startup_risk_initial_balance(
+        settings=settings,
+        config=config,
+        startup_available_balance=16_436.10,
+    )
+
+    assert balance == pytest.approx(16_436.10)
+
+
+def test_live_risk_initial_balance_requires_broker_balance(monkeypatch):
+    monkeypatch.setenv("EXECUTION_MODE", "LIVE")
+    settings = SimpleNamespace(execution_mode="LIVE")
+    config = SimpleNamespace(initial_balance=1_000_000.0)
+
+    with pytest.raises(BrokerBalanceUnavailableError):
+        _resolve_startup_risk_initial_balance(
+            settings=settings,
+            config=config,
+            startup_available_balance=None,
+        )
+
+
+def test_paper_risk_initial_balance_uses_configured_capital(monkeypatch):
+    monkeypatch.setenv("EXECUTION_MODE", "PAPER")
+    settings = SimpleNamespace(execution_mode="PAPER")
+    config = SimpleNamespace(initial_balance=1_000_000.0)
+
+    balance = _resolve_startup_risk_initial_balance(
+        settings=settings,
+        config=config,
+        startup_available_balance=None,
+    )
+
+    assert balance == pytest.approx(1_000_000.0)
+
+
+def test_auth_failure_callback_marks_context_fail_closed():
+    ctx = SimpleNamespace(
+        broker_auth_invalid=False,
+        broker_auth_error=None,
+        broker_auth_invalid_at=None,
+        broker_ready=True,
+        broker_balance_valid=True,
+        broker_balance_error=None,
+        live_orders_armed=True,
+        execution_armed=True,
+        trading_ready=True,
+        live_block_reason=None,
+        execution_block_reason=None,
+    )
+
+    apply_broker_auth_failure_to_context(
+        ctx,
+        {"reason": "Incorrect api_key or access_token", "generation": 7},
+    )
+
+    assert ctx.broker_auth_invalid is True
+    assert ctx.broker_auth_error == "Incorrect api_key or access_token"
+    assert ctx.broker_ready is False
+    assert ctx.broker_balance_valid is False
+    assert ctx.live_orders_armed is False
+    assert ctx.execution_armed is False
+    assert ctx.trading_ready is False
+    assert ctx.live_block_reason == "broker_auth_invalid"
+    assert ctx.execution_block_reason == "broker_auth_invalid"

--- a/tests/data/test_datahub_subscription_state.py
+++ b/tests/data/test_datahub_subscription_state.py
@@ -1,0 +1,41 @@
+from nifty_scalper_bot.data.data_hub import DataHub, SubscriptionState
+
+
+class _Mdm:
+    def __init__(self):
+        self.subscribed = []
+
+    def subscribe(self, symbol, callback):
+        self.subscribed.append((symbol, callback))
+
+
+def test_datahub_subscription_queued_is_not_live():
+    mdm = _Mdm()
+    hub = DataHub(mdm)
+
+    hub.subscribe_ticks("NFO:NIFTY26MAY23750CE", lambda tick: None, force_live=True)
+
+    assert hub.get_subscription_state("NFO:NIFTY26MAY23750CE") == SubscriptionState.QUEUED
+    assert mdm.subscribed
+
+
+def test_datahub_first_ws_tick_advances_subscription_live():
+    mdm = _Mdm()
+    hub = DataHub(mdm)
+    symbol = "NFO:NIFTY26MAY23750CE"
+    hub.subscribe_ticks(symbol, lambda tick: None, force_live=True)
+
+    hub.ingest_tick_sync(
+        {
+            "symbol": symbol,
+            "instrument_token": 12345,
+            "last_price": 100.0,
+            "timestamp": "2026-06-21T09:16:00+05:30",
+            "source": "ws",
+        }
+    )
+
+    record = hub.get_subscription_record(symbol)
+    assert record is not None
+    assert record.state == SubscriptionState.LIVE
+    assert record.token == 12345

--- a/tests/data/test_zerodha_balance_logging.py
+++ b/tests/data/test_zerodha_balance_logging.py
@@ -1,8 +1,17 @@
 from __future__ import annotations
 
 import logging
+import math
+
+import httpx
+import pytest
 
 from nifty_scalper_bot.data.rest.zerodha_client import ZerodhaKiteClient
+from nifty_scalper_bot.utils.errors import (
+    BrokerAuthenticationError,
+    BrokerBalanceUnavailableError,
+    ConfigurationError,
+)
 
 
 def test_balance_refresh_logs_amount_fields(caplog) -> None:
@@ -21,8 +30,14 @@ def test_balance_refresh_logs_amount_fields(caplog) -> None:
         out = client.get_available_balance('equity')
 
     assert out == 100000.0
-    assert any('ZERODHA_BALANCE_REFRESH_SUCCESS' in r.getMessage() for r in caplog.records)
-    assert any(getattr(r, 'event', '') == 'ZERODHA_BALANCE_REFRESH_SUCCESS' for r in caplog.records)
+    assert any(
+        'ZERODHA_BALANCE_REFRESH_SUCCESS' in r.getMessage()
+        for r in caplog.records
+    )
+    assert any(
+        getattr(r, 'event', '') == 'ZERODHA_BALANCE_REFRESH_SUCCESS'
+        for r in caplog.records
+    )
 
 
 def test_balance_refresh_unchanged_is_debug(monkeypatch, caplog) -> None:
@@ -48,4 +63,99 @@ def test_balance_refresh_unchanged_is_debug(monkeypatch, caplog) -> None:
     with caplog.at_level(logging.DEBUG):
         client.get_available_balance('equity')
 
-    assert any('ZERODHA_BALANCE_REFRESH_UNCHANGED' in r.getMessage() for r in caplog.records)
+    assert any(
+        'ZERODHA_BALANCE_REFRESH_UNCHANGED' in r.getMessage()
+        for r in caplog.records
+    )
+
+
+
+def test_http_403_latches_and_second_balance_call_skips_http(monkeypatch) -> None:
+    client = ZerodhaKiteClient(api_key="k", access_token="t")
+    calls = {"count": 0}
+
+    def fake_request(method, url, **kwargs):  # noqa: ANN001
+        calls["count"] += 1
+        return httpx.Response(
+            403,
+            json={
+                "status": "error",
+                "message": "Incorrect api_key or access_token",
+                "error_type": "TokenException",
+            },
+            request=httpx.Request(method, "https://api.kite.trade" + url),
+        )
+
+    monkeypatch.setattr(client._client, "request", fake_request)
+    with pytest.raises(BrokerAuthenticationError):
+        client.get_available_balance("equity")
+    assert client.auth_invalid is True
+    assert calls["count"] == 1
+    with pytest.raises(BrokerAuthenticationError):
+        client.get_available_balance("equity")
+    assert calls["count"] == 1
+    client._client.close()
+
+
+def test_available_balance_never_calls_legacy_margins_endpoint(monkeypatch) -> None:
+    client = ZerodhaKiteClient(api_key="k", access_token="t")
+    seen: list[str] = []
+
+    def fake_make(method, endpoint, **kwargs):  # noqa: ANN001
+        seen.append(endpoint)
+        return {
+            "data": {
+                "equity": {
+                    "net": 0.0,
+                    "available": {
+                        "cash": 0.0,
+                        "live_balance": 0.0,
+                        "opening_balance": 0.0,
+                    },
+                    "utilised": {},
+                }
+            }
+        }
+
+    monkeypatch.setattr(client, "_make_request", fake_make)
+    assert client.get_available_balance("equity") == 0.0
+    assert "/user/margins/equity" in seen
+    assert "/margins/equity" not in seen
+    client._client.close()
+
+
+def test_invalid_balance_payload_and_non_finite_raise_typed_errors() -> None:
+    client = ZerodhaKiteClient(api_key="k", access_token="t")
+    with pytest.raises(BrokerBalanceUnavailableError):
+        client._parse_account_margin_summary(
+            {"equity": {"available": {}}}, segment="equity"
+        )
+    with pytest.raises(BrokerBalanceUnavailableError):
+        client._parse_account_margin_summary(
+            {"equity": {"available": {"cash": math.inf}, "utilised": {}}},
+            segment="equity",
+        )
+    client._client.close()
+
+
+def test_no_live_env_balance_fallback(monkeypatch) -> None:
+    monkeypatch.setenv("RISK_CAPITAL", "1000000")
+    client = ZerodhaKiteClient(api_key="k", access_token="t")
+    def fail_account_margins(segment="equity"):  # noqa: ANN001
+        raise RuntimeError("broker down")
+
+    client.get_account_margins = fail_account_margins
+    with pytest.raises(BrokerBalanceUnavailableError):
+        client.get_available_balance("equity")
+    client._client.close()
+
+
+def test_simulated_balance_requires_explicit_capital(monkeypatch) -> None:
+    for key in ("RISK__CAPITAL", "RISK_CAPITAL", "BACKTEST__CAPITAL"):
+        monkeypatch.delenv(key, raising=False)
+    client = ZerodhaKiteClient(api_key="k", access_token="t")
+    with pytest.raises(ConfigurationError):
+        client._resolve_simulated_balance()
+    monkeypatch.setenv("BACKTEST__CAPITAL", "12345")
+    assert client._resolve_simulated_balance() == 12345.0
+    client._client.close()

--- a/tests/execution/test_order_manager_live_guard.py
+++ b/tests/execution/test_order_manager_live_guard.py
@@ -99,3 +99,32 @@ def test_live_selected_option_ltp_only_rejected_before_broker(monkeypatch):
     assert broker.calls == 0
     assert om.get_last_skip_reason() == "selected_option_bid_ask_missing"
     assert om._last_order_decision["block_reason"] == "selected_option_bid_ask_missing"
+
+
+def test_auth_latch_blocks_order_before_broker(monkeypatch):
+    from nifty_scalper_bot.utils.errors import OrderPlacementError
+
+    monkeypatch.setenv("EXECUTION_MODE", "LIVE")
+    monkeypatch.setenv("ENABLE_LIVE_TRADING", "true")
+    broker = _Broker(connected=True)
+    broker.auth_invalid = True
+    broker.calls = 0
+
+    def _place_order(**_kwargs):
+        broker.calls += 1
+        return {"order_id": "OID"}
+
+    broker.place_order = _place_order
+    om = OrderManager(broker, _Positions(), _Limiter())
+
+    with pytest.raises(OrderPlacementError, match="broker_auth_invalid"):
+        om.place_order(
+            "NFO:NIFTY26MAY23750CE",
+            "BUY",
+            75,
+            stop_loss=90.0,
+            take_profit=120.0,
+        )
+
+    assert broker.calls == 0
+    assert om.get_last_skip_reason() == "broker_auth_invalid"

--- a/tests/test_main_health_readiness.py
+++ b/tests/test_main_health_readiness.py
@@ -1,0 +1,97 @@
+import json
+from types import SimpleNamespace
+
+from nifty_scalper_bot import main
+
+
+def _json(response):
+    return json.loads(response.body.decode())
+
+
+def _ctx(**overrides):
+    decision = SimpleNamespace(
+        blocker_list=tuple(overrides.pop("blockers", ())),
+        primary_blocker=overrides.pop("primary_blocker", None),
+        live_orders_armed=overrides.pop("live_orders_armed", False),
+        execution_ready=overrides.pop("execution_ready", False),
+    )
+    base = dict(
+        readiness_decision=decision,
+        broker_ready=False,
+        broker_auth_invalid=False,
+        broker_balance_valid=False,
+        last_valid_broker_balance=None,
+        broker_balance_error=None,
+        position_reconciliation_started=False,
+        position_reconciliation_completed=False,
+        position_reconciliation_failed=False,
+        position_reconciliation_error=None,
+        unprotected_broker_positions=set(),
+        live_orders_armed=False,
+        market_state="closed",
+        live_block_reason=None,
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def setup_function():
+    main.app.state.bot = None
+    main.app.state.bot_error = None
+    main.app.state.bot_started = False
+    main.app.state.bot_starting = False
+
+
+def test_readyz_returns_503_until_startup_completed():
+    response = main.readyz()
+    body = _json(response)
+
+    assert response.status_code == 503
+    assert body["ready"] is False
+    assert body["primary_blocker"] == "startup_incomplete"
+
+
+def test_readyz_uses_context_safety_blockers():
+    ctx = _ctx(
+        blockers=("broker_auth_invalid",),
+        primary_blocker="broker_auth_invalid",
+        broker_auth_invalid=True,
+        broker_balance_valid=False,
+        position_reconciliation_completed=True,
+    )
+    main.app.state.bot_started = True
+    main.app.state.bot = SimpleNamespace(_ctx=ctx)
+
+    response = main.readyz()
+    body = _json(response)
+
+    assert response.status_code == 503
+    assert body["ready"] is False
+    assert body["primary_blocker"] == "broker_auth_invalid"
+    assert "broker_auth_invalid" in body["blockers"]
+
+
+def test_health_trading_exposes_canonical_context():
+    ctx = _ctx(
+        blockers=("position_reconciliation_failed",),
+        primary_blocker="position_reconciliation_failed",
+        broker_ready=True,
+        broker_balance_valid=True,
+        last_valid_broker_balance=16_436.10,
+        position_reconciliation_started=True,
+        position_reconciliation_failed=True,
+        position_reconciliation_error="fetch failed",
+        unprotected_broker_positions={"NFO:NIFTY26MAY23750CE"},
+    )
+    main.app.state.bot = SimpleNamespace(_ctx=ctx)
+
+    response = main.health_trading()
+    body = _json(response)
+
+    assert response.status_code == 200
+    assert body["status"] == "blocked"
+    assert body["primary_blocker"] == "position_reconciliation_failed"
+    assert body["broker"]["balance_valid"] is True
+    assert body["broker"]["balance"] == 16_436.10
+    assert body["reconciliation"]["failed"] is True
+    assert body["reconciliation"]["unprotected_positions"] == ["NFO:NIFTY26MAY23750CE"]


### PR DESCRIPTION
### Motivation

- The bot treated some Zerodha broker failures (HTTP 401/403 / TokenException) and unavailable balances as recoverable, which allowed unsafe synthetic fallback balances and repeated broker calls after terminal auth failures.
- Startup position reconciliation could write undeclared BotContext attributes and leave the live-order gate ambiguous, causing AttributeError and contradictory readiness states.
- Health/readiness and subscription logs conflated process liveness, trading readiness, and subscription confirmation, causing misleading platform restarts and false “subscription successful” messages.

### Description

- Added typed broker exceptions `BrokerAuthenticationError` and `BrokerBalanceUnavailableError` and an auth-invalid latch in `ZerodhaKiteClient` to classify, record, and suppress repeated calls after terminal auth failures. (file: `src/nifty_scalper_bot/utils/errors.py`, `src/nifty_scalper_bot/data/rest/zerodha_client.py`).
- Rewrote `get_available_balance()` to use only the `/user/margins/{segment}` payload, implemented a strict parser that preserves legitimate zero balances and raises `BrokerBalanceUnavailableError` on malformed/unavailable payloads, and removed the unsafe environment/default fallback path; added `_resolve_simulated_balance()` usable only for non-live simulation modes. (file: `src/nifty_scalper_bot/data/rest/zerodha_client.py`).
- Latched auth failures clear REST caches and emit a single structured event `ZERODHA_AUTH_INVALIDATED`; added a fail-fast guard before authenticated requests. (file: `src/nifty_scalper_bot/data/rest/zerodha_client.py`).
- Declared missing reconciliation and broker state fields on the slotted `BotContext` and implemented a fail-closed reconciliation lifecycle that sets started/completed/failed fields and blocks live arming on failure. (file: `src/nifty_scalper_bot/core/app.py`).
- Consolidated broker / reconciliation / market-data blockers into the canonical readiness decision and added `broker_balance_unavailable` and reconciliation-incomplete blockers to priority ordering. (file: `src/nifty_scalper_bot/execution/readiness.py`, `src/nifty_scalper_bot/core/app.py`).
- Prevented MDM/DataHub from using legacy `GET /margins/{segment}` or margin-summary fallbacks for live funds and removed DataHub history as a readiness gate (DataHub counts retained for observability only). (files: `src/nifty_scalper_bot/data/market_data_manager.py`, `src/nifty_scalper_bot/core/history_readiness.py`).
- Fail-closed guard added to the live order path so attempts to place live orders while broker auth is latched are rejected before broker submission. (file: `src/nifty_scalper_bot/execution/order_manager.py`).
- Reworked subscription/logging semantics so DataHub logs queued/requested states and avoids false “subscribed=true” until broker/websocket confirmation or live tick. (file: `src/nifty_scalper_bot/data/data_hub.py`).
- Separated endpoints: added `/livez` (process liveness), `/readyz` (dependency readiness, returns 503 for broker auth/reconciliation failures), and `/health/trading` (detailed trading-domain status). Updated Docker healthcheck to use `/livez`. (files: `src/nifty_scalper_bot/core/app.py`, `src/nifty_scalper_bot/main.py`, `Dockerfile`).
- Enhanced runtime self-checker with market-aware semantics and added checks for broker auth, broker balance, reconciliation, and readiness consistency; improved failure log messages and severity. (file: `src/nifty_scalper_bot/core/app.py`).
- Added focused regression tests and static BotContext attribute checks to ensure declared fields and prevent `setattr(ctx, ...)` of undeclared fields. (files: `tests/data/test_zerodha_balance_logging.py`, `tests/core/test_bot_context_attributes.py`, updated hydration tests to reflect DataHub not gating readiness).

### Testing

- Ran `python -m compileall -q src` — passed.
- Ran focused pytest suites: `tests/data/test_zerodha_balance_logging.py`, `tests/data/test_zerodha_client_guards.py`, `tests/execution/test_readiness_priority.py`, `tests/execution/test_readiness_execution_safety_blockers.py`, `tests/core/test_runtime_self_checker_streamer.py`, `tests/core/test_bot_context_attributes.py`, `tests/core/test_hydration_datahub_not_gating.py`, `tests/core/test_hydration_status_propagation.py` — all focused regression tests passed.
- Ran full test collection and full test suite: `python -m pytest -q` — the project test suite completed successfully in this environment (2,339 tests collected and executed in local runs used for validation).
- Static/tooling checks: `ruff check .` and `ruff format --check .` reported pre-existing repository-wide lint/formatting issues (not introduced by this PR) and therefore failed; these are documented and unrelated to the safety fixes in this PR.
- `mypy src/nifty_scalper_bot` reported pre-existing type errors across many files (554 errors in 60 files); these are repository-wide type issues and were not introduced by this change.

Notes: the PR focuses narrowly on broker auth/balance fail-closed semantics, reconciliation lifecycle, readiness gating, subscription-state correctness, and related regression tests. Formatting/lint/type debt pre-existed and is recorded but out of scope for this safety remediation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36d44a68708324a840f8aff509f6ea)