### PR TITLE
Fix remaining broker-call, reconciliation and readiness safety defects

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install project and test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e '.[dev]'
+      - name: Syntax check
+        run: python -m compileall -q src
+      - name: Collect tests
+        run: python -m pytest --collect-only -q
+      - name: Focused production-safety tests
+        run: |
+          python -m pytest -q \
+            tests/data/test_zerodha_balance_logging.py \
+            tests/data/test_market_data_manager.py \
+            tests/data/test_market_data_manager_broker_boundary.py \
+            tests/data/test_datahub_subscription_state.py \
+            tests/core/test_startup_risk_balance.py \
+            tests/core/test_bot_context_attributes.py \
+            tests/core/test_deferred_basket_retry.py \
+            tests/execution/test_order_manager_live_guard.py \
+            tests/test_main_health_readiness.py \
+            tests/test_exception_identity.py
+      - name: Full pytest suite
+        run: python -m pytest -q

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
             tests/core/test_deferred_basket_retry.py \
             tests/execution/test_order_manager_live_guard.py \
             tests/test_main_health_readiness.py \
-            tests/test_exception_identity.py
+            tests/test_exception_identity.py \
+            tests/core/test_runtime_safety_wiring.py
       - name: Full pytest suite
         run: python -m pytest -q

--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -1248,6 +1248,7 @@ from nifty_scalper_bot.utils.env import (
 from nifty_scalper_bot.utils.errors import (
     BrokerAuthenticationError,
     BrokerBalanceUnavailableError,
+    BrokerReconciliationError,
     ConfigurationError,
 )
 from nifty_scalper_bot.utils.logging import get_logger, log_state_change, log_throttled, setup_logging
@@ -2683,6 +2684,8 @@ class BotContext:
     broker_auth_invalid: bool = False
     broker_auth_error: str | None = None
     broker_auth_invalid_at: datetime | None = None
+    readiness_generation: int = 0
+    readiness_decision: Any | None = None
     broker_balance_valid: bool = False
     broker_balance_error: str | None = None
     last_valid_broker_balance: float | None = None
@@ -4406,8 +4409,10 @@ def _resolve_startup_risk_initial_balance(
                 "LIVE startup requires validated broker balance"
             )
         initial_balance = float(startup_available_balance)
-        if initial_balance != float(startup_available_balance):
-            raise ConfigurationError("live_risk_capital_must_equal_broker_balance")
+        if not math.isfinite(initial_balance):
+            raise BrokerBalanceUnavailableError("non_finite_live_broker_balance")
+        if initial_balance < 0.0:
+            raise BrokerBalanceUnavailableError("negative_live_broker_balance")
         return initial_balance
     return float(getattr(config, "initial_balance", 0.0) or 0.0)
 
@@ -8377,7 +8382,23 @@ async def _recompute_and_push_runtime_readiness(ctx: BotContext, *, reason: str)
     evaluation_ready=bool(data_hard_ready and runner_running)
     live_mode = str(getattr(ctx.settings, "execution_mode", "PAPER")).upper() == "LIVE"
     market_open = get_market_state() == MarketState.OPEN
-    broker_ready = bool(getattr(ctx, "broker_client", None) and getattr(ctx, "order_manager", None))
+    broker_components_present = bool(getattr(ctx, "broker_client", None) and getattr(ctx, "order_manager", None))
+    broker_connected = False
+    broker_client = getattr(ctx, "broker_client", None)
+    is_connected = getattr(broker_client, "is_connected", None)
+    if callable(is_connected):
+        try:
+            broker_connected = bool(is_connected())
+        except Exception:
+            broker_connected = False
+    else:
+        broker_connected = broker_components_present
+    broker_ready = bool(
+        broker_components_present
+        and broker_connected
+        and not bool(getattr(ctx, "broker_auth_invalid", False))
+        and not bool(getattr(ctx, "broker_session_invalid", False))
+    )
     execution_ready_by_symbol: dict[str, bool] = {}
     if selected_ce:
         execution_ready_by_symbol[str(selected_ce)] = bool(ce_exec_ready)
@@ -8457,20 +8478,34 @@ async def _recompute_and_push_runtime_readiness(ctx: BotContext, *, reason: str)
             or bool(getattr(ctx, "position_reconciliation_completed", False))
         ),
     )
+    ctx.readiness_generation = int(getattr(ctx, "readiness_generation", 0) or 0) + 1
+    normalized_decision = replace(
+        normalized_decision,
+        generation=ctx.readiness_generation,
+        calculated_at=datetime.now(timezone.utc),
+        broker_ready=broker_ready,
+        reconciliation_ready=not (
+            bool(getattr(ctx, "position_reconciliation_failed", False))
+            or not bool(getattr(ctx, "position_reconciliation_completed", False))
+            or bool(getattr(ctx, "unprotected_broker_positions", set()))
+        ),
+        market_state=str(get_market_state().value if hasattr(get_market_state(), "value") else get_market_state()),
+    )
+    ctx.readiness_decision = normalized_decision
     live_orders_armed = bool(live_mode and normalized_decision.live_orders_armed)
     block_reason = None if live_orders_armed else f"execution_not_armed:{normalized_decision.primary_blocker or 'unknown'}"
     ctx.data_hard_ready=data_hard_ready; ctx.evaluation_ready=evaluation_ready; ctx.live_orders_armed=live_orders_armed; ctx.trading_ready=evaluation_ready; ctx.live_block_reason=block_reason
     ctx.data_ready = bool(data_hard_ready)
     ctx.strategy_evaluation_ready = bool(evaluation_ready)
     ctx.trading_signal_ready = bool(evaluation_ready)
-    ctx.execution_armed = bool(live_orders_armed)
+    ctx.execution_armed = bool(normalized_decision.live_orders_armed)
     ctx.execution_block_reason = "market_closed" if (live_mode and not market_open and evaluation_ready) else block_reason
     ctx.market_open = bool(market_open)
     ctx.execution_ready_by_symbol = execution_ready_by_symbol
     ctx.selected_ce_exec_ready = bool(ce_exec_ready)
     ctx.selected_pe_exec_ready = bool(pe_exec_ready)
     ctx.context_exec_ready = bool(context_exec_ready)
-    ctx.broker_ready = bool(broker_ready)
+    ctx.broker_ready = bool(normalized_decision.broker_ready)
     LOGGER.info(
         "READINESS_BLOCKER_SUMMARY primary_blocker=%s blockers=%s secondary_blockers=%s data_hard_ready=%s evaluation_ready=%s execution_ready=%s live_orders_armed=%s",
         normalized_decision.primary_blocker,
@@ -12308,6 +12343,37 @@ def _should_reconcile_now(ctx: BotContext) -> bool:
         return True
 
 
+def _normalize_broker_positions_payload(raw: Any) -> list[Mapping[str, Any]]:
+    """Strictly normalize broker position payload; never fabricate emptiness."""
+    if raw is None:
+        raise BrokerReconciliationError("broker_positions_payload_missing")
+    if inspect.isawaitable(raw):
+        if asyncio.iscoroutine(raw):
+            raw.close()
+        elif hasattr(raw, "cancel"):
+            raw.cancel()
+        raise BrokerReconciliationError("broker_position_fetch_returned_awaitable")
+    if isinstance(raw, list):
+        if not all(isinstance(item, Mapping) for item in raw):
+            raise BrokerReconciliationError("broker_positions_payload_invalid_list")
+        return list(cast(list[Mapping[str, Any]], raw))
+    if isinstance(raw, Mapping):
+        if not raw:
+            raise BrokerReconciliationError("broker_positions_payload_empty_mapping")
+        if str(raw.get("status") or "").lower() == "error" or raw.get("error_type"):
+            raise BrokerReconciliationError("broker_positions_payload_error")
+        net = raw.get("net")
+        day = raw.get("day", [])
+        if not isinstance(net, list):
+            raise BrokerReconciliationError("broker_positions_payload_missing_net")
+        if day is not None and not isinstance(day, list):
+            raise BrokerReconciliationError("broker_positions_payload_invalid_day")
+        if not all(isinstance(item, Mapping) for item in net):
+            raise BrokerReconciliationError("broker_positions_payload_invalid_net")
+        return list(cast(list[Mapping[str, Any]], net))
+    raise BrokerReconciliationError("broker_positions_payload_invalid_type")
+
+
 async def _reconcile_state(ctx: BotContext) -> None:
     """
     Syncs local state with Broker (Orders & Positions).
@@ -12330,19 +12396,12 @@ async def _reconcile_state(ctx: BotContext) -> None:
             )
             try:
                 raw = _sync_broker.get_positions()
-                # Guard: if the resolved broker method is async it returns an awaitable
-                # (coroutine, Task, or Future) instead of positions.  Clean up the
-                # awaitable correctly and fall back to an empty result.
                 if inspect.isawaitable(raw):
-                    LOGGER.error(
-                        "get_positions() returned an awaitable in sync context – "
-                        "broker client wrapping is incorrect. Falling back to empty list."
-                    )
                     if asyncio.iscoroutine(raw):
-                        raw.close()          # suppress ResourceWarning on coroutines
+                        raw.close()
                     elif hasattr(raw, "cancel"):
-                        raw.cancel()         # cancel Tasks / Futures
-                    raw = {}
+                        raw.cancel()
+                    raise BrokerReconciliationError("broker_position_fetch_returned_awaitable")
             except Exception as _pos_err:
                 LOGGER.error(
                     "POSITION_RECONCILE_FAILED stage=broker_position_fetch error_type=%s error_message=%s",
@@ -12357,15 +12416,7 @@ async def _reconcile_state(ctx: BotContext) -> None:
                     exc_info=True,
                 )
                 raise RuntimeError(f"broker_position_fetch_failed:{_pos_err}") from _pos_err
-            broker_positions: list[Mapping[str, Any]] = []
-            if isinstance(raw, list):
-                broker_positions = [p for p in raw if isinstance(p, Mapping)]
-            elif isinstance(raw, Mapping):
-                src = raw.get("net", raw)
-                if isinstance(src, list):
-                    broker_positions = [p for p in src if isinstance(p, Mapping)]
-                elif isinstance(src, Mapping):
-                    broker_positions = [src]
+            broker_positions = _normalize_broker_positions_payload(raw)
             if ctx.position_manager:
                 ctx.position_manager.synchronize_with_broker(broker_positions)
             return broker_positions
@@ -12433,13 +12484,23 @@ async def _reconcile_state(ctx: BotContext) -> None:
                         )
                         om.guard_orphan_position(
                             symbol=norm_symbol,
-                            quantity=signed_qty,  # ✅ Now negative for SHORT
+                            quantity=signed_qty,
                             average_price=avg_price,
                             position_side=pos.side,
                         )
-                        ctx.unprotected_broker_position = False
+                        protection_confirmed = bool(bm.is_symbol_managed(norm_symbol))
+                        if not protection_confirmed:
+                            if hasattr(ctx, "unprotected_broker_positions"):
+                                ctx.unprotected_broker_positions.add(str(norm_symbol))
+                            ctx.unprotected_broker_position = True
+                            raise BrokerReconciliationError(
+                                f"orphan_protection_not_confirmed:{norm_symbol}"
+                            )
                         if hasattr(ctx, "unprotected_broker_positions"):
                             ctx.unprotected_broker_positions.discard(str(norm_symbol))
+                        ctx.unprotected_broker_position = bool(
+                            getattr(ctx, "unprotected_broker_positions", set())
+                        )
                         LOGGER.info(
                             "POSITION_ADOPTED_TO_BRACKET symbol=%s quantity=%s",
                             norm_symbol,

--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -2599,6 +2599,18 @@ def get_telegram_notifier() -> TelegramEnhancedNotifier | None:
     return _HTTP_NOTIFIER
 
 
+@dataclass(frozen=True, slots=True)
+class ReconciliationResult:
+    success: bool
+    broker_positions_count: int
+    broker_open_orders_count: int
+    cancelled_zombie_orders: tuple[str, ...]
+    unresolved_symbols: tuple[str, ...]
+    unprotected_symbols: tuple[str, ...]
+    error: str | None
+    completed_at: datetime | None
+
+
 @dataclass(slots=True)
 class BotContext:
     """Container for all bot components."""
@@ -4438,6 +4450,43 @@ def apply_broker_auth_failure_to_context(
     ctx.execution_block_reason = "broker_auth_invalid"
 
 
+def attach_canonical_entry_execution_guard(ctx: Any) -> None:
+    """Attach the canonical live-entry guard to the production OrderManager."""
+    order_manager = getattr(ctx, "order_manager", None)
+    set_guard = getattr(order_manager, "set_entry_execution_guard", None)
+    if not callable(set_guard):
+        LOGGER.error("ENTRY_EXECUTION_GUARD_ATTACH_FAILED target=OrderManager reason=missing_setter")
+        return
+
+    def _canonical_entry_execution_guard() -> tuple[bool, str | None]:
+        if bool(getattr(ctx, "broker_auth_invalid", False)):
+            return False, "broker_auth_invalid"
+        if bool(getattr(ctx, "broker_session_invalid", False)):
+            return False, "broker_session_invalid"
+        if not bool(getattr(ctx, "broker_balance_valid", False)):
+            return False, "broker_balance_unavailable"
+        if bool(getattr(ctx, "position_reconciliation_failed", False)):
+            return False, "position_reconciliation_failed"
+        if not bool(getattr(ctx, "position_reconciliation_completed", False)):
+            return False, "position_reconciliation_incomplete"
+        if set(getattr(ctx, "unresolved_reconciliation_symbols", set()) or set()):
+            return False, "unresolved_exit_position"
+        if set(getattr(ctx, "unprotected_broker_positions", set()) or set()):
+            return False, "unprotected_broker_position"
+        decision = getattr(ctx, "readiness_decision", None)
+        if decision is None:
+            return False, "readiness_snapshot_missing"
+        if not bool(getattr(decision, "live_orders_armed", False)):
+            return False, str(getattr(decision, "primary_blocker", None) or "live_execution_not_armed")
+        return True, None
+
+    set_guard(_canonical_entry_execution_guard)
+    LOGGER.info(
+        "ENTRY_EXECUTION_GUARD_ATTACHED target=OrderManager",
+        extra={"event": "ENTRY_EXECUTION_GUARD_ATTACHED", "target": "OrderManager"},
+    )
+
+
 def initialize_components(settings: Settings | None = None) -> BotContext:
     """Initialize all components in correct order."""
 
@@ -6138,9 +6187,35 @@ def initialize_components(settings: Settings | None = None) -> BotContext:
         bracket_manager_attached=bracket_manager_attached,
     )
     ensure_bot_context_runtime_fields(ctx)
+    with suppress(Exception):
+        setattr(ctx.market_data_manager, "data_hub", ctx.data_hub)
+    attach_canonical_entry_execution_guard(ctx)
+    app_loop = None
+    try:
+        app_loop = asyncio.get_running_loop()
+    except RuntimeError:
+        app_loop = None
 
     def _on_broker_auth_failure(snapshot: Mapping[str, Any]) -> None:
         apply_broker_auth_failure_to_context(ctx, snapshot)
+        invalidate = getattr(ctx.market_data_manager, "invalidate_account_cache", None)
+        if callable(invalidate):
+            invalidate(reason="broker_auth_invalid")
+        ctx.live_orders_armed = False
+        ctx.execution_armed = False
+        ctx.trading_ready = False
+        ctx.broker_ready = False
+        if app_loop is not None:
+            def _publish_auth_failure() -> None:
+                asyncio.create_task(
+                    _recompute_and_push_runtime_readiness(ctx, reason="broker_auth_invalid")
+                )
+            try:
+                app_loop.call_soon_threadsafe(_publish_auth_failure)
+            except RuntimeError:
+                LOGGER.error(
+                    "BROKER_AUTH_READINESS_PUBLICATION_FAILED reason=event_loop_unavailable"
+                )
         reason = str(snapshot.get("reason") or "broker_auth_invalid")
         LOGGER.error(
             "BROKER_AUTH_INVALID_PROPAGATED reason=%s generation=%s",
@@ -8203,14 +8278,29 @@ async def _recompute_and_push_runtime_readiness(ctx: BotContext, *, reason: str)
                 if not pd.isna(dt) and (pd.Timestamp.utcnow()-dt).total_seconds()<=limit:
                     return True
         return False
-    def _subscription_confirmed(sym: str | None) -> bool:
-        if not sym or mdm is None: return False
+    def _subscription_record(sym: str | None) -> Any:
+        if not sym or getattr(ctx, "data_hub", None) is None:
+            return None
+        getter = getattr(ctx.data_hub, "get_subscription_snapshot", None)
+        if not callable(getter):
+            return None
         try:
-            token = getattr(mdm, "_resolve_token_for_symbol", lambda _s: None)(sym) or getattr(mdm, "_symbol_to_token", {}).get(sym)
-            confirmed = getattr(mdm, "_confirmed_subscriptions", set()) or set()
-            return bool(token is not None and int(token) in confirmed)
+            return getter(sym)
         except Exception:
-            return False
+            return None
+
+    def _subscription_confirmed(sym: str | None) -> bool:
+        record = _subscription_record(sym)
+        state = getattr(record, "state", None)
+        value = getattr(state, "value", state)
+        return str(value or "").lower() in {"broker_confirmed", "live"}
+
+    def _subscription_live(sym: str | None) -> bool:
+        record = _subscription_record(sym)
+        state = getattr(record, "state", None)
+        value = getattr(state, "value", state)
+        return str(value or "").lower() == "live"
+
     def _subscription_or_live_tick(sym:str|None)->bool:
         sub=_subscription_confirmed(sym)
         if sub: return True
@@ -8370,8 +8460,14 @@ async def _recompute_and_push_runtime_readiness(ctx: BotContext, *, reason: str)
     pe_quote_fresh = bool(pe_status and (pe_status.live_tick_fresh or pe_status.tradable_quote))
     ce_bid_ask_complete = bool(ce_status and ce_status.tradable_quote)
     pe_bid_ask_complete = bool(pe_status and pe_status.tradable_quote)
-    ce_exec_ready = bool(ce_status and basket_hard_ready and ce_status.ready_for_execution)
-    pe_exec_ready = bool(pe_status and basket_hard_ready and pe_status.ready_for_execution)
+    ce_subscription_live = _subscription_live(selected_ce)
+    pe_subscription_live = _subscription_live(selected_pe)
+    ce_exec_ready = bool(
+        ce_status and basket_hard_ready and ce_status.ready_for_execution and ce_subscription_live
+    )
+    pe_exec_ready = bool(
+        pe_status and basket_hard_ready and pe_status.ready_for_execution and pe_subscription_live
+    )
     ce_eval_ready = bool(ce_status and ce_status.ready_for_evaluation and ce_bars >= option_eval_min_live_bars)
     pe_eval_ready = bool(pe_status and pe_status.ready_for_evaluation and pe_bars >= option_eval_min_live_bars)
     spot_ready = bool(spot_status and spot_status.ready_for_evaluation)
@@ -8392,7 +8488,7 @@ async def _recompute_and_push_runtime_readiness(ctx: BotContext, *, reason: str)
         except Exception:
             broker_connected = False
     else:
-        broker_connected = broker_components_present
+        broker_connected = False
     broker_ready = bool(
         broker_components_present
         and broker_connected
@@ -8422,6 +8518,8 @@ async def _recompute_and_push_runtime_readiness(ctx: BotContext, *, reason: str)
     if pe_status and not pe_status.tradable_quote: missing.append('selected_pe_quote_missing')
     if ce_status and not ce_status.depth_available: missing.append('selected_ce_depth_missing')
     if pe_status and not pe_status.depth_available: missing.append('selected_pe_depth_missing')
+    if selected_ce and not ce_subscription_live: missing.append('selected_ce_subscription_not_live')
+    if selected_pe and not pe_subscription_live: missing.append('selected_pe_subscription_not_live')
     if (ce_status and not ce_status.tradable_quote) or (pe_status and not pe_status.tradable_quote): missing.append('selected_option_bid_ask_missing')
     if not runner_running: missing.append('runner_not_running')
     if live_mode:
@@ -8429,6 +8527,7 @@ async def _recompute_and_push_runtime_readiness(ctx: BotContext, *, reason: str)
         if not ce_exec_ready and not selected_history_ready: missing.append('ce_exec_quote_or_history_not_ready')
         if not pe_exec_ready and not selected_history_ready: missing.append('pe_exec_quote_or_history_not_ready')
         if not context_exec_ready: missing.append('context_exec_not_ready')
+        if not callable(is_connected): missing.append("broker_connectivity_unknown")
         if not broker_ready: missing.append('broker_not_ready')
         if bool(getattr(ctx, "position_reconciliation_failed", False)):
             missing.append("position_reconciliation_failed")
@@ -11986,8 +12085,14 @@ async def startup_sequence(ctx: BotContext) -> None:
                     extra={"event": "INDICATOR_READINESS_SYNC", "ready": indicator_ready},
                 )
 
-                ctx.subsystems_started = True
-                LOGGER.info("✅ All subsystems started.")
+                ctx.live_orders_armed = False
+                ctx.execution_armed = False
+                ctx.trading_ready = False
+                ctx.position_reconciliation_completed = False
+                LOGGER.info(
+                    "OBSERVATION_SUBSYSTEMS_STARTED live_orders_armed=false",
+                    extra={"event": "OBSERVATION_SUBSYSTEMS_STARTED", "live_orders_armed": False},
+                )
         except Exception as e:
             LOGGER.critical(f"Subsystem start failed: {e}")
 
@@ -12015,7 +12120,40 @@ async def startup_sequence(ctx: BotContext) -> None:
                     logger=LOGGER,
                 )
             except Exception as reconcile_exc:
-                LOGGER.error("reconcile_with_broker failed (non-fatal): %s", reconcile_exc)
+                ctx.position_reconciliation_completed = False
+                ctx.position_reconciliation_failed = True
+                ctx.position_reconciliation_error = str(reconcile_exc)
+                ctx.live_orders_armed = False
+                ctx.execution_armed = False
+                ctx.trading_ready = False
+                ctx.live_block_reason = "position_reconciliation_failed"
+                ctx.execution_block_reason = "position_reconciliation_failed"
+                LOGGER.error(
+                    "STARTUP_RECONCILIATION_FAILED process_liveness_preserved=true live_entry_execution_blocked=true error=%s",
+                    reconcile_exc,
+                    extra={
+                        "event": "STARTUP_RECONCILIATION_FAILED",
+                        "process_liveness_preserved": True,
+                        "live_entry_execution_blocked": True,
+                    },
+                )
+            startup_reconciliation = await run_startup_reconciliation(ctx)
+            if not startup_reconciliation.success:
+                LOGGER.error(
+                    "STARTUP_RECONCILIATION_FAILED process_liveness_preserved=true live_entry_execution_blocked=true error=%s",
+                    startup_reconciliation.error,
+                    extra={
+                        "event": "STARTUP_RECONCILIATION_FAILED",
+                        "process_liveness_preserved": True,
+                        "live_entry_execution_blocked": True,
+                    },
+                )
+            else:
+                ctx.subsystems_started = True
+                LOGGER.info(
+                    "LIVE_EXECUTION_STARTUP_RECONCILIATION_SUCCEEDED",
+                    extra={"event": "LIVE_EXECUTION_STARTUP_RECONCILIATION_SUCCEEDED"},
+                )
             # ────────────────────────────────────────────────────────────────
 
             async def _sync_loop():
@@ -12488,7 +12626,19 @@ async def _reconcile_state(ctx: BotContext) -> None:
                             average_price=avg_price,
                             position_side=pos.side,
                         )
-                        protection_confirmed = bool(bm.is_symbol_managed(norm_symbol))
+                        protection_status = None
+                        get_protection = getattr(bm, "get_position_protection_status", None)
+                        if callable(get_protection):
+                            protection_status = get_protection(norm_symbol)
+                        expected_quantity = abs(int(pos.quantity))
+                        protection_confirmed = bool(
+                            protection_status is not None
+                            and getattr(protection_status, "managed", False)
+                            and getattr(protection_status, "stop_active", False)
+                            and int(getattr(protection_status, "protected_quantity", 0) or 0) == expected_quantity
+                            and str(getattr(protection_status, "position_side", "") or "") == str(pos.side)
+                            and not bool(getattr(protection_status, "exit_failed", False))
+                        )
                         if not protection_confirmed:
                             if hasattr(ctx, "unprotected_broker_positions"):
                                 ctx.unprotected_broker_positions.add(str(norm_symbol))
@@ -12578,6 +12728,56 @@ async def _reconcile_state(ctx: BotContext) -> None:
     # 3. SITUATION REPORT
     if ctx.order_manager:
         ctx.order_manager._log_status_report()
+
+
+
+async def run_startup_reconciliation(ctx: BotContext) -> ReconciliationResult:
+    """Canonical startup reconciliation result used by LIVE entry gating."""
+    try:
+        await _reconcile_state(ctx)
+        unresolved = tuple(sorted(getattr(ctx, "unresolved_reconciliation_symbols", set()) or set()))
+        unprotected = tuple(sorted(getattr(ctx, "unprotected_broker_positions", set()) or set()))
+        success = bool(
+            getattr(ctx, "position_reconciliation_completed", False)
+            and not getattr(ctx, "position_reconciliation_failed", False)
+            and not unresolved
+            and not unprotected
+        )
+        if not success:
+            ctx.position_reconciliation_completed = False
+            ctx.position_reconciliation_failed = True
+            ctx.live_orders_armed = False
+            ctx.execution_armed = False
+            ctx.trading_ready = False
+        return ReconciliationResult(
+            success=success,
+            broker_positions_count=len(getattr(ctx.position_manager, "get_open_positions", lambda: [])()),
+            broker_open_orders_count=0,
+            cancelled_zombie_orders=(),
+            unresolved_symbols=unresolved,
+            unprotected_symbols=unprotected,
+            error=None if success else (getattr(ctx, "position_reconciliation_error", None) or "startup_reconciliation_incomplete"),
+            completed_at=datetime.now(timezone.utc),
+        )
+    except Exception as exc:
+        ctx.position_reconciliation_completed = False
+        ctx.position_reconciliation_failed = True
+        ctx.position_reconciliation_error = str(exc)
+        ctx.live_orders_armed = False
+        ctx.execution_armed = False
+        ctx.trading_ready = False
+        ctx.live_block_reason = "position_reconciliation_failed"
+        ctx.execution_block_reason = "position_reconciliation_failed"
+        return ReconciliationResult(
+            success=False,
+            broker_positions_count=0,
+            broker_open_orders_count=0,
+            cancelled_zombie_orders=(),
+            unresolved_symbols=tuple(sorted(getattr(ctx, "unresolved_reconciliation_symbols", set()) or set())),
+            unprotected_symbols=tuple(sorted(getattr(ctx, "unprotected_broker_positions", set()) or set())),
+            error=str(exc),
+            completed_at=datetime.now(timezone.utc),
+        )
 
 
 def _close_all_positions(ctx: BotContext, *, reason: str) -> None:

--- a/src/nifty_scalper_bot/data/data_hub.py
+++ b/src/nifty_scalper_bot/data/data_hub.py
@@ -72,7 +72,9 @@ class SubscriptionRecord:
     state: SubscriptionState
     generation: int
     reason: str
+    source: str | None
     updated_at: float
+    first_live_tick_at: float | None = None
 
 
 class _EventBus:
@@ -234,6 +236,8 @@ class DataHub:
         *,
         reason: str,
         token: int | None = None,
+        source: str | None = None,
+        first_live_tick_at: float | None = None,
     ) -> SubscriptionRecord:
         normalized = canonical(symbol)
         previous = self._subscription_states.get(normalized)
@@ -246,7 +250,9 @@ class DataHub:
             state=state,
             generation=self._subscription_generation,
             reason=reason,
+            source=source,
             updated_at=float(self._clock()),
+            first_live_tick_at=first_live_tick_at if first_live_tick_at is not None else (previous.first_live_tick_at if previous else None),
         )
         self._subscription_states[normalized] = record
         LOGGER.info(
@@ -275,6 +281,15 @@ class DataHub:
 
     def get_subscription_record(self, symbol: str) -> SubscriptionRecord | None:
         return self._subscription_states.get(canonical(symbol))
+
+    def get_subscription_snapshot(self, symbol: str) -> SubscriptionRecord | None:
+        return self.get_subscription_record(symbol)
+
+    def mark_subscription_requested(self, symbol: str, *, token: int | None = None, reason: str = "subscribe_requested") -> SubscriptionRecord:
+        return self._set_subscription_state(symbol, SubscriptionState.REQUESTED, reason=reason, token=token, source="mdm")
+
+    def mark_subscription_confirmed(self, symbol: str, *, token: int | None = None, reason: str = "broker_confirmed") -> SubscriptionRecord:
+        return self._set_subscription_state(symbol, SubscriptionState.BROKER_CONFIRMED, reason=reason, token=token, source="broker")
 
     def _bind_to_mdm(self) -> None:
         attach_tick_bus = getattr(self._mdm, "attach_tick_bus", None)
@@ -996,6 +1011,8 @@ class DataHub:
                     SubscriptionState.LIVE,
                     reason="first_live_tick" if first_seen else "live_tick",
                     token=token,
+                    source=source,
+                    first_live_tick_at=mono_now if first_seen else None,
                 )
             elif source in {"poll", "rest"}:
                 self._last_poll_arrival[symbol] = now_ms
@@ -1161,14 +1178,14 @@ class DataHub:
                 reason="already_queued",
             )
             LOGGER.info(
-                "DATAHUB_LIVE_SUBSCRIBE symbol=%s subscribed=true reason=already_subscribed",
+                "DATAHUB_LIVE_SUBSCRIBE symbol=%s subscribed=false reason=already_queued",
                 symbol,
                 extra={
                     "event": "DATAHUB_LIVE_SUBSCRIBE",
                     "symbol": symbol,
                     "trace_id": trace_id,
-                    "subscribed": True,
-                    "reason": "already_subscribed",
+                    "subscribed": False,
+                    "reason": "already_queued",
                     "mdm_delegate_called": False,
                 },
             )

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -31,14 +31,17 @@ import asyncio
 import inspect
 from collections import defaultdict, deque
 from contextlib import suppress
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from datetime import date, datetime, timedelta, timezone
 import logging
 import math
 import os
 
 from nifty_scalper_bot.config.env_utils import parse_int_env
-from nifty_scalper_bot.utils.errors import BrokerAuthenticationError
+from nifty_scalper_bot.utils.errors import (
+    BrokerAuthenticationError,
+    BrokerBalanceUnavailableError,
+)
 import re
 from random import uniform
 import threading
@@ -48,6 +51,7 @@ from typing import (
     Callable,
     Deque,
     Iterable,
+    Literal,
     Mapping,
     Sequence,
     cast,
@@ -112,6 +116,18 @@ _COMPACT_EXPIRY_FORMATS: tuple[str, ...] = ("%d%b%Y", "%d%b%y")
 _NIFTY_FUT_RE = re.compile(r"^NIFTY\d{2}[A-Z]{3}FUT$")
 
 _logger = get_tracer_logger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class AccountBalanceSnapshot:
+    available: float
+    fetched_at: float
+    source: Literal["broker"]
+    valid: bool
+    stale: bool = False
+
+    def to_dict(self) -> dict[str, float | str | bool]:
+        return asdict(self)
 
 
 @dataclass(slots=True)
@@ -1381,203 +1397,142 @@ class MarketDataManager:
 
     # ------------------------------------------------------------------
     # Broker account snapshot accessors
-    async def get_account_snapshot(self, *, force: bool = False) -> dict[str, float]:
-        """Return cached broker margin snapshot sourced via the MDM.
+    def _validate_account_balance(self, value: Any) -> float:
+        if value is None:
+            raise BrokerBalanceUnavailableError("broker_balance_missing")
+        try:
+            numeric = float(value)
+        except (TypeError, ValueError) as exc:
+            raise BrokerBalanceUnavailableError("broker_balance_non_numeric") from exc
+        if not math.isfinite(numeric):
+            raise BrokerBalanceUnavailableError("broker_balance_non_finite")
+        if numeric < 0.0:
+            raise BrokerBalanceUnavailableError("broker_balance_negative")
+        return numeric
 
-        Args:
-            force: Force refresh from the broker when ``True``.
+    async def _invoke_broker_async(self, method_name: str, /, **kwargs: Any) -> Any:
+        broker = getattr(self, "_broker_client", None) or getattr(self, "_broker", None)
+        if broker is None:
+            raise BrokerBalanceUnavailableError("broker_client_missing")
+        method = getattr(broker, method_name, None)
+        if not callable(method):
+            raise BrokerBalanceUnavailableError(f"broker_method_missing:{method_name}")
+        if inspect.iscoroutinefunction(method):
+            return await method(**kwargs)
+        result = await asyncio.to_thread(method, **kwargs)
+        if inspect.isawaitable(result):
+            return await result
+        return result
 
-        Returns:
-            dict[str, float]: Normalized margin snapshot keyed by broker fields.
+    def _invoke_broker_sync(self, method_name: str, /, **kwargs: Any) -> Any:
+        broker = getattr(self, "_broker_client", None) or getattr(self, "_broker", None)
+        if broker is None:
+            raise BrokerBalanceUnavailableError("broker_client_missing")
+        method = getattr(broker, method_name, None)
+        if not callable(method):
+            raise BrokerBalanceUnavailableError(f"broker_method_missing:{method_name}")
+        result = method(**kwargs)
+        if inspect.isawaitable(result):
+            if asyncio.iscoroutine(result):
+                result.close()
+            elif hasattr(result, "cancel"):
+                result.cancel()
+            raise BrokerBalanceUnavailableError(
+                f"async_broker_method_used_in_sync_context:{method_name}"
+            )
+        return result
 
-        Raises:
-            None.
-        """
+    def _clear_account_cache(self) -> None:
+        with self._account_lock:
+            self._account_snapshot = {}
+            self._account_updated_at = 0.0
 
-        self._logger.debug(
-            "Entered MarketDataManager.get_account_snapshot",
-            extra={"event": "mdm_account_snapshot_enter", "force": force},
-        )
-
+    async def get_account_snapshot(self, *, force: bool = False) -> dict[str, Any]:
+        """Return a non-stale broker account snapshot or raise a typed error."""
         now = time.time()
         with self._account_lock:
             cache_age = now - self._account_updated_at
-            cache_valid = (
-                bool(self._account_snapshot)
-                and cache_age < self._account_cache_ttl
-                and not force
-            )
-            if cache_valid:
-                self._logger.debug(
-                    "Condition met: mdm_account_cache_hit",
-                    extra={
-                        "event": "mdm_account_cache_hit",
-                        "age": round(cache_age, 2),
-                        "ttl": self._account_cache_ttl,
-                    },
-                )
+            if self._account_snapshot and cache_age < self._account_cache_ttl and not force:
                 return dict(self._account_snapshot)
-
-        segment = self._account_segment
-        snapshot: dict[str, float] = {}
-        response: Any | None = None
         try:
-            balance_fetcher = getattr(self._broker, "get_available_balance", None)
-            if callable(balance_fetcher):
-                available = await balance_fetcher(segment=segment)
-                if available is not None:
-                    numeric_available = float(available)
-                    if math.isfinite(numeric_available) and numeric_available >= 0.0:
-                        snapshot = {"available": numeric_available}
-
-            if snapshot:
-                with self._account_lock:
-                    self._account_snapshot = snapshot
-                    self._account_updated_at = time.time()
-                self._logger.info(
-                    "mdm_account_snapshot_updated",
-                    extra={
-                        "event": "mdm_account_snapshot_updated",
-                        "segment": segment,
-                        "available": snapshot.get("available"),
-                        "net": snapshot.get("net"),
-                        "used": snapshot.get("used"),
-                    },
-                )
-                return dict(snapshot)
-
-            self._logger.error(
-                "mdm_account_snapshot_empty",
-                extra={"event": "mdm_account_snapshot_empty", "segment": segment},
+            available = await self._invoke_broker_async(
+                "get_available_balance", segment=self._account_segment
             )
-        except BrokerAuthenticationError:
+            numeric_available = self._validate_account_balance(available)
+            snapshot_obj = AccountBalanceSnapshot(
+                available=numeric_available,
+                fetched_at=time.time(),
+                source="broker",
+                valid=True,
+                stale=False,
+            )
+            snapshot = dict(snapshot_obj.to_dict())
             with self._account_lock:
-                self._account_snapshot = {}
-                self._account_updated_at = 0.0
-            raise
-        except Exception as exc:  # noqa: BLE001
-            self._logger.error(
-                "Failure in MarketDataManager.get_account_snapshot: %s",
-                exc,
-                extra={"event": "mdm_account_snapshot_error", "segment": segment},
-                exc_info=exc,
-            )
-
-        with self._account_lock:
-            fallback = dict(self._account_snapshot)
-        if fallback:
+                self._account_snapshot = snapshot
+                self._account_updated_at = float(snapshot_obj.fetched_at)
             self._logger.info(
-                "Condition met: mdm_account_snapshot_fallback",
+                "mdm_account_snapshot_updated",
                 extra={
-                    "event": "mdm_account_snapshot_fallback",
-                    "segment": segment,
-                    "available": fallback.get("available"),
+                    "event": "mdm_account_snapshot_updated",
+                    "segment": self._account_segment,
+                    "available": numeric_available,
+                    "usable_for_execution": True,
                 },
             )
-        return fallback
-
-    def get_available_balance(self, *, force: bool = False) -> float | None:
-        """Return latest available margin balance from cached snapshot.
-
-        Args:
-            force: Force refresh of the underlying account snapshot when ``True``.
-
-        Returns:
-            float | None: Positive available margin balance when present.
-
-        Raises:
-            None.
-        """
-
-        self._logger.debug(
-            "Entered MarketDataManager.get_available_balance",
-            extra={"event": "mdm_available_balance_enter", "force": force},
-        )
-        try:
-            broker = getattr(self, "_broker_client", None) or getattr(
-                self, "_broker", None
-            )
-            if broker is not None:
-                segment = _resolve_account_segment()
-                if hasattr(broker, "get_available_balance"):
-                    try:
-                        live_balance = broker.get_available_balance(segment=segment)  # type: ignore[call-arg]
-                        numeric_live = float(live_balance) if live_balance is not None else None
-                        if numeric_live is not None and not math.isfinite(numeric_live):
-                            numeric_live = None
-                        if numeric_live is not None:
-                            resolved_balance = float(numeric_live)
-                            # [FIX] Throttled INFO log
-                            if time.time() - self._last_balance_log_time >= 60.0:
-                                self._logger.debug(
-                                    "mdm_available_balance_resolved",
-                                    extra={
-                                        "event": "mdm_available_balance_resolved",
-                                        "key": "available",
-                                        "balance": round(resolved_balance, 2),
-                                        "source": "broker_available",
-                                    },
-                                )
-                                self._last_balance_log_time = time.time()
-                            return resolved_balance
-                    except BrokerAuthenticationError:
-                        raise
-                    except Exception as exc:  # noqa: BLE001
-                        self._logger.error(
-                            "mdm_available_balance_direct_error: %s",
-                            exc,
-                            extra={"event": "mdm_available_balance_direct_error"},
-                            exc_info=exc,
-                        )
-                return None
+            return dict(snapshot)
         except BrokerAuthenticationError:
-            with self._account_lock:
-                self._account_snapshot = {}
-                self._account_updated_at = 0.0
+            self._clear_account_cache()
+            raise
+        except BrokerBalanceUnavailableError:
+            self._clear_account_cache()
             raise
         except Exception as exc:  # noqa: BLE001
+            self._clear_account_cache()
             self._logger.error(
-                "mdm_available_balance_margin_error: %s",
-                exc,
-                extra={"event": "mdm_available_balance_margin_error"},
-                exc_info=exc,
+                "mdm_account_snapshot_error",
+                extra={
+                    "event": "mdm_account_snapshot_error",
+                    "segment": self._account_segment,
+                    "error_type": type(exc).__name__,
+                    "error_message": str(exc),
+                },
+                exc_info=True,
             )
+            raise BrokerBalanceUnavailableError("broker_balance_refresh_failed") from exc
 
-        snapshot = self.get_account_snapshot(force=force)
-        if not isinstance(snapshot, Mapping):
-            self._logger.error(
-                "mdm_available_balance_missing_snapshot",
-                extra={"event": "mdm_available_balance_missing_snapshot"},
+    async def refresh_available_balance(self, *, force: bool = False) -> float:
+        snapshot = await self.get_account_snapshot(force=force)
+        return self._validate_account_balance(snapshot.get("available"))
+
+    def get_available_balance(self, *, force: bool = False) -> float | None:
+        """Return a synchronous, non-stale available broker balance."""
+        now = time.time()
+        with self._account_lock:
+            cache_age = now - self._account_updated_at
+            if self._account_snapshot and cache_age < self._account_cache_ttl and not force:
+                return self._validate_account_balance(self._account_snapshot.get("available"))
+        try:
+            available = self._invoke_broker_sync(
+                "get_available_balance", segment=self._account_segment
             )
-            return None
-
-        candidate_keys = (
-            "available",
-            "available_cash",
-            "live_balance",
-            "cash",
-            "net",
-        )
-        for key in candidate_keys:
-            value = snapshot.get(key)
-            numeric = _coerce_positive_float(value)
-            if numeric is not None:
-                self._logger.debug(
-                    "mdm_available_balance_resolved",
-                    extra={
-                        "event": "mdm_available_balance_resolved",
-                        "key": key,
-                        "balance": round(numeric, 2),
-                        "source": "account_snapshot",
-                    },
-                )
-                return float(numeric)
-
-        self._logger.error(
-            "mdm_available_balance_unavailable",
-            extra={"event": "mdm_available_balance_unavailable"},
-        )
-        return None
+            numeric_available = self._validate_account_balance(available)
+            snapshot_obj = AccountBalanceSnapshot(
+                available=numeric_available,
+                fetched_at=time.time(),
+                source="broker",
+                valid=True,
+                stale=False,
+            )
+            with self._account_lock:
+                self._account_snapshot = dict(snapshot_obj.to_dict())
+                self._account_updated_at = float(snapshot_obj.fetched_at)
+            return numeric_available
+        except BrokerAuthenticationError:
+            self._clear_account_cache()
+            raise
+        except BrokerBalanceUnavailableError:
+            self._clear_account_cache()
+            raise
 
     # ------------------------------------------------------------------
     # Public API

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -1447,13 +1447,29 @@ class MarketDataManager:
             self._account_snapshot = {}
             self._account_updated_at = 0.0
 
+    def invalidate_account_cache(self, *, reason: str) -> None:
+        self._clear_account_cache()
+        self._logger.warning(
+            "MDM_ACCOUNT_CACHE_INVALIDATED reason=%s",
+            reason,
+            extra={"event": "MDM_ACCOUNT_CACHE_INVALIDATED", "reason": reason},
+        )
+
+    def _raise_if_broker_auth_invalid(self) -> None:
+        broker = getattr(self, "_broker_client", None) or getattr(self, "_broker", None)
+        if bool(getattr(broker, "auth_invalid", False)):
+            self._clear_account_cache()
+            raise BrokerAuthenticationError("broker_authentication_invalid")
+
     async def get_account_snapshot(self, *, force: bool = False) -> dict[str, Any]:
         """Return a non-stale broker account snapshot or raise a typed error."""
+        self._raise_if_broker_auth_invalid()
         now = time.time()
         with self._account_lock:
             cache_age = now - self._account_updated_at
             if self._account_snapshot and cache_age < self._account_cache_ttl and not force:
                 return dict(self._account_snapshot)
+        self._raise_if_broker_auth_invalid()
         try:
             available = await self._invoke_broker_async(
                 "get_available_balance", segment=self._account_segment
@@ -1506,11 +1522,13 @@ class MarketDataManager:
 
     def get_available_balance(self, *, force: bool = False) -> float | None:
         """Return a synchronous, non-stale available broker balance."""
+        self._raise_if_broker_auth_invalid()
         now = time.time()
         with self._account_lock:
             cache_age = now - self._account_updated_at
             if self._account_snapshot and cache_age < self._account_cache_ttl and not force:
                 return self._validate_account_balance(self._account_snapshot.get("available"))
+        self._raise_if_broker_auth_invalid()
         try:
             available = self._invoke_broker_sync(
                 "get_available_balance", segment=self._account_segment
@@ -1533,6 +1551,18 @@ class MarketDataManager:
         except BrokerBalanceUnavailableError:
             self._clear_account_cache()
             raise
+        except Exception as exc:  # noqa: BLE001
+            self._clear_account_cache()
+            self._logger.error(
+                "mdm_available_balance_refresh_failed",
+                extra={
+                    "event": "mdm_available_balance_refresh_failed",
+                    "error_type": type(exc).__name__,
+                    "error_message": str(exc),
+                },
+                exc_info=True,
+            )
+            raise BrokerBalanceUnavailableError("broker_balance_refresh_failed") from exc
 
     # ------------------------------------------------------------------
     # Public API
@@ -9050,6 +9080,14 @@ class MarketDataManager:
                             "token": token,
                         },
                     )
+                    hub = getattr(self, "data_hub", None) or getattr(self, "_data_hub", None)
+                    mark_requested = getattr(hub, "mark_subscription_requested", None)
+                    if callable(mark_requested):
+                        mark_requested(
+                            symbol,
+                            token=int(token),
+                            reason="transport_subscribe_sent",
+                        )
                     if not hasattr(self._ws, "is_connected") or self._is_ws_connected():
                         self._dispatched_subscriptions.add(int(token))
                         self._logger.info(

--- a/src/nifty_scalper_bot/execution/bracket_manager.py
+++ b/src/nifty_scalper_bot/execution/bracket_manager.py
@@ -362,6 +362,18 @@ class MockJournal:
     def set(self, key, value): pass
     def get(self, key): return None
 
+@dataclass(frozen=True, slots=True)
+class PositionProtectionStatus:
+    symbol: str
+    managed: bool
+    stop_active: bool
+    protected_quantity: int
+    position_side: str | None
+    exit_failed: bool
+    bracket_id: str | None
+    reason: str | None = None
+
+
 class BracketManager:
     """
     The 'Sniper' Engine.
@@ -2741,6 +2753,40 @@ class BracketManager:
     # --------------------------------------------------------------------------
     # 6. HOUSEKEEPING & UTILS
     # --------------------------------------------------------------------------
+
+
+    def get_position_protection_status(self, symbol: str) -> PositionProtectionStatus:
+        """Return immutable protection status for a broker position symbol."""
+        normalized = normalize_symbol(symbol) or symbol
+        with self._lock:
+            entry_ids = list(self._symbol_map.get(normalized, []))
+            if not entry_ids:
+                return PositionProtectionStatus(normalized, False, False, 0, None, False, None, "not_managed")
+            for entry_id in entry_ids:
+                bracket = self._brackets.get(entry_id)
+                if bracket is None:
+                    continue
+                exit_failed = bracket.exit_state in {
+                    BracketExitLifecycle.EXIT_REJECTED_FATAL.value,
+                    BracketExitLifecycle.EXIT_FAILED_ESCALATED.value,
+                }
+                stop_active = bool(
+                    bracket.active
+                    and bracket.remaining_quantity > 0
+                    and float(bracket.sl_trigger_price or 0.0) > 0.0
+                )
+                side = "LONG" if bracket.side == "BUY" else "SHORT" if bracket.side == "SELL" else bracket.side
+                return PositionProtectionStatus(
+                    symbol=normalized,
+                    managed=bool(bracket.active and bracket.remaining_quantity > 0),
+                    stop_active=stop_active,
+                    protected_quantity=abs(int(bracket.remaining_quantity or bracket.quantity or 0)),
+                    position_side=side,
+                    exit_failed=exit_failed,
+                    bracket_id=bracket.bracket_id,
+                    reason=None if stop_active and not exit_failed else "protection_incomplete",
+                )
+        return PositionProtectionStatus(normalized, False, False, 0, None, False, None, "bracket_missing")
 
     def is_symbol_managed(self, symbol: str) -> bool:
         """

--- a/src/nifty_scalper_bot/execution/exceptions.py
+++ b/src/nifty_scalper_bot/execution/exceptions.py
@@ -1,18 +1,17 @@
-"""Execution exception hierarchy for granular error handling."""
+"""Execution exception hierarchy for granular error handling.
+
+Canonical execution/broker base classes live in ``utils.errors`` so imports from
+``nifty_scalper_bot.execution.exceptions`` and ``nifty_scalper_bot.utils.errors``
+refer to the same runtime class objects.
+"""
 
 from __future__ import annotations
 
-
-class OrderExecutionError(Exception):
-    """Base exception for all order execution failures."""
-
-
-class BrokerError(OrderExecutionError):
-    """Broker API errors (network, auth, rate limit, reject)."""
-
-
-class OrderPlacementError(OrderExecutionError):
-    """Order placement validation failed before reaching broker."""
+from nifty_scalper_bot.utils.errors import (
+    BrokerError,
+    OrderExecutionError,
+    OrderPlacementError,
+)
 
 
 class MarginCheckError(OrderPlacementError):
@@ -25,3 +24,13 @@ class OrderModificationError(OrderExecutionError):
 
 class RiskBlockError(OrderPlacementError):
     """Order blocked by risk manager gates."""
+
+
+__all__ = [
+    "OrderExecutionError",
+    "BrokerError",
+    "OrderPlacementError",
+    "MarginCheckError",
+    "OrderModificationError",
+    "RiskBlockError",
+]

--- a/src/nifty_scalper_bot/execution/order_manager.py
+++ b/src/nifty_scalper_bot/execution/order_manager.py
@@ -113,6 +113,7 @@ OrderPlacementError = execution_exceptions.OrderPlacementError
 MarginCheckError = execution_exceptions.MarginCheckError
 OrderModificationError = execution_exceptions.OrderModificationError
 RiskBlockError = execution_exceptions.RiskBlockError
+EntryExecutionGuard = Callable[[], tuple[bool, str | None]]
 
 if TYPE_CHECKING:
     from journal.trade_journal import TradeJournal
@@ -914,6 +915,7 @@ class OrderManager:
         self._kill_switch_last_reset: dict[str, Any] | None = None
         self._missing_counts: dict[str, int] = {}
         self._last_order_decision: dict[str, Any] = {}
+        self._entry_execution_guard: EntryExecutionGuard | None = None
         self._margin_cache_max_age_seconds: int = max(1, int(os.getenv("MARGIN_CACHE_MAX_AGE_SECONDS", "120") or 120))
         self._allow_entry_with_stale_margin: bool = os.getenv("ALLOW_ENTRY_WITH_STALE_MARGIN", "false").strip().lower() in {"1", "true", "yes", "on"}
         self._last_margin_refresh_ts: float | None = None
@@ -1977,6 +1979,11 @@ class OrderManager:
         # 3. Fallback: Return as is (assuming it's already a tradingsymbol)
         return symbol
 
+
+    def set_entry_execution_guard(self, guard: EntryExecutionGuard | None) -> None:
+        """Set the final live-entry readiness guard used before broker submission."""
+        self._entry_execution_guard = guard
+
     def _round_to_tick(self, price: float, tick_size: float = 0.05) -> float:
         """
         ✅ Round price to nearest valid tick size.
@@ -2398,6 +2405,13 @@ class OrderManager:
                 self._logger.warning("ORDER_BLOCKED: live_execution_safety_check_failed symbol=%s", symbol)
                 _log_order_decision(allowed=False, block_reason="live_execution_safety_check_failed")
                 return None
+            if self._entry_execution_guard is not None:
+                allowed, guard_reason = self._entry_execution_guard()
+                if not allowed:
+                    reason_text = guard_reason or "entry_execution_guard_blocked"
+                    self.set_last_skip_reason(reason_text)
+                    _log_order_decision(allowed=False, block_reason=reason_text)
+                    raise OrderPlacementError(reason_text)
 
         # 🛡️ SAFETY GUARD: ENFORCE VIRTUAL BRACKETS
         is_entry = (side == "BUY") and not is_system_exit

--- a/src/nifty_scalper_bot/execution/order_manager.py
+++ b/src/nifty_scalper_bot/execution/order_manager.py
@@ -159,6 +159,13 @@ def _mid(bid: float | None, ask: float | None) -> float | None:
     return (bid + ask) / 2.0
 
 
+class OrderIntent(str, Enum):
+    ENTRY = "entry"
+    EXIT = "exit"
+    PROTECTIVE = "protective"
+    EMERGENCY_EXIT = "emergency_exit"
+
+
 class OrderStatus(Enum):
     PENDING = "pending"
     SUBMITTED = "submitted"
@@ -2216,6 +2223,7 @@ class OrderManager:
         signal_id: str | None = None,
         strategy_name: str = "manual",
         trace_id: str | None = None,
+        intent: OrderIntent | str | None = None,
     ) -> str | None:
         """
         Execute order with Idempotency, Safe Trading Window, Risk Gating, and Auto-Recovery.
@@ -2314,9 +2322,31 @@ class OrderManager:
         # ---------------------------------------------------------
         # 🛡️ DETECT EXIT vs ENTRY (must be BEFORE any guard)
         normalized_tag = (tag or "").lower()
-        is_system_exit = any(
-            x in normalized_tag for x in ["exit", "stop", "target", "square", "guard"]
-        )
+        order_intent: OrderIntent
+        if intent is not None:
+            order_intent = intent if isinstance(intent, OrderIntent) else OrderIntent(str(intent).lower())
+        else:
+            inferred_exit = any(
+                x in normalized_tag for x in ["exit", "stop", "target", "square", "guard"]
+            )
+            order_intent = OrderIntent.EXIT if inferred_exit else OrderIntent.ENTRY
+            self._logger.warning(
+                "ORDER_INTENT_INFERRED_LEGACY symbol=%s tag=%s inferred_intent=%s",
+                symbol,
+                tag,
+                order_intent.value,
+                extra={
+                    "event": "ORDER_INTENT_INFERRED_LEGACY",
+                    "symbol": symbol,
+                    "tag": tag,
+                    "intent": order_intent.value,
+                },
+            )
+        is_system_exit = order_intent in {
+            OrderIntent.EXIT,
+            OrderIntent.PROTECTIVE,
+            OrderIntent.EMERGENCY_EXIT,
+        }
 
         if not is_system_exit and self._bracket_manager is not None:
             has_unresolved_exit = getattr(self._bracket_manager, "has_unresolved_exit", None)
@@ -2405,7 +2435,11 @@ class OrderManager:
                 self._logger.warning("ORDER_BLOCKED: live_execution_safety_check_failed symbol=%s", symbol)
                 _log_order_decision(allowed=False, block_reason="live_execution_safety_check_failed")
                 return None
-            if self._entry_execution_guard is not None:
+            if order_intent == OrderIntent.ENTRY:
+                if self._entry_execution_guard is None:
+                    self.set_last_skip_reason("entry_execution_guard_missing")
+                    _log_order_decision(allowed=False, block_reason="entry_execution_guard_missing")
+                    raise OrderPlacementError("entry_execution_guard_missing")
                 allowed, guard_reason = self._entry_execution_guard()
                 if not allowed:
                     reason_text = guard_reason or "entry_execution_guard_blocked"
@@ -3714,7 +3748,7 @@ class OrderManager:
                 self._last_order_api_error = None
             return TradePlanSubmitResult(bool(oid), order_id=oid, reason="accepted" if oid else "place_order_rejected", details={"protected_price": price}, broker_attempted=bool(oid))
         try:
-            oid = self.place_order(symbol=symbol, side=plan.side, quantity=plan.quantity, order_type=OrderType.LIMIT, price=price, stop_loss=plan.stop_loss, take_profit=plan.take_profit, tag=plan.tag, check_risk=True, product=plan.product)
+            oid = self.place_order(symbol=symbol, side=plan.side, quantity=plan.quantity, order_type=OrderType.LIMIT, price=price, stop_loss=plan.stop_loss, take_profit=plan.take_profit, tag=plan.tag, check_risk=True, product=plan.product, intent=OrderIntent.ENTRY)
         except Exception as exc:  # noqa: BLE001
             err = self._sanitize_broker_error(exc)
             self._last_order_api_error_type = type(exc).__name__
@@ -6356,6 +6390,7 @@ class OrderManager:
                 price=_exit_ltp,  # supply live LTP for accounting; None is safe
                 tag=tag,
                 check_risk=False,  # exits MUST never be blocked by risk-manager
+                intent=OrderIntent.EXIT,
             )
 
             if not exit_id:
@@ -12747,6 +12782,7 @@ class OrderManager:
                 trigger_price=trigger_price,  # ✅ Trigger Price
                 tag="safety_sl_hard",
                 variety="regular",
+                intent=OrderIntent.PROTECTIVE,
             )
             self._logger.info(
                 f"✅ Hard SL Placed: Trigger {trigger_price}, Limit {limit_price}"
@@ -12764,6 +12800,7 @@ class OrderManager:
                 price=tp_price,
                 tag="safety_tp_wide",
                 variety="regular",
+                intent=OrderIntent.PROTECTIVE,
             )
             self._logger.info(f"✅ Wide TP Placed: {tp_price}")
         except Exception as e:

--- a/src/nifty_scalper_bot/execution/readiness.py
+++ b/src/nifty_scalper_bot/execution/readiness.py
@@ -104,16 +104,26 @@ _BLOCKER_ALIASES = {
 
 @dataclass(frozen=True, slots=True)
 class ReadinessDecision:
-    primary_blocker: str | None
-    blocker_list: list[str]
-    live_orders_armed: bool
-    evaluation_ready: bool
-    execution_ready: bool
-    human_reason: str
-    secondary_blockers: list[str] = field(default_factory=list)
+    generation: int = 0
+    calculated_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    primary_blocker: str | None = None
+    blocker_list: tuple[str, ...] = ()
+    secondary_blockers: tuple[str, ...] = ()
+    live_orders_armed: bool = False
+    evaluation_ready: bool = False
+    execution_ready: bool = False
+    broker_ready: bool = False
+    reconciliation_ready: bool = False
+    market_state: str = "unknown"
+    human_reason: str = "not_evaluated"
 
     def to_dict(self) -> dict[str, object]:
-        return asdict(self)
+        payload = asdict(self)
+        if isinstance(self.calculated_at, datetime):
+            payload["calculated_at"] = self.calculated_at.astimezone(timezone.utc).isoformat()
+        payload["blocker_list"] = list(self.blocker_list)
+        payload["secondary_blockers"] = list(self.secondary_blockers)
+        return payload
 
 
 def _normalize_market_state_name(market_state: object) -> str:
@@ -193,11 +203,14 @@ def normalize_readiness_blockers(
     human = "ready" if primary is None else primary
     return ReadinessDecision(
         primary_blocker=primary,
-        blocker_list=ordered_visible,
-        secondary_blockers=ordered_secondary,
+        blocker_list=tuple(ordered_visible),
+        secondary_blockers=tuple(ordered_secondary),
         live_orders_armed=armed,
         evaluation_ready=bool(evaluation_ready and not primary),
         execution_ready=bool(execution_ready and not primary),
+        broker_ready=not any(item in canonical for item in {"broker_auth_invalid", "broker_session_invalid", "broker_balance_unavailable", "broker_health_block"}),
+        reconciliation_ready=not any(item in canonical for item in {"position_reconciliation_failed", "position_reconciliation_incomplete", "unresolved_exit_position", "unprotected_broker_position"}),
+        market_state=market_name or "unknown",
         human_reason=human,
     )
 

--- a/src/nifty_scalper_bot/execution/readiness.py
+++ b/src/nifty_scalper_bot/execution/readiness.py
@@ -99,6 +99,9 @@ _BLOCKER_ALIASES = {
     "strategy_runner_not_running": "strategy_not_ready",
     "eval_not_ready": "strategy_not_ready",
     "broker_not_ready": "broker_health_block",
+    "broker_connectivity_unknown": "broker_health_block",
+    "selected_ce_subscription_not_live": "selected_option_subscription_missing",
+    "selected_pe_subscription_not_live": "selected_option_subscription_missing",
 }
 
 

--- a/src/nifty_scalper_bot/utils/errors.py
+++ b/src/nifty_scalper_bot/utils/errors.py
@@ -15,7 +15,11 @@ class RateLimitError(BotError):
     """Raised when rate limit thresholds are exceeded."""
 
 
-class BrokerError(BotError):
+class OrderExecutionError(BotError):
+    """Base for execution and broker request errors."""
+
+
+class BrokerError(OrderExecutionError):
     """Raised when broker integrations fail."""
 
 
@@ -25,6 +29,10 @@ class BrokerAuthenticationError(BrokerError):
 
 class BrokerBalanceUnavailableError(BrokerError):
     """Broker account balance could not be obtained safely."""
+
+
+class BrokerReconciliationError(BrokerError):
+    """Broker position/order state could not be reconciled safely."""
 
 
 class OrderPlacementError(BrokerError):
@@ -43,9 +51,11 @@ __all__ = [
     "BotError",
     "ConfigurationError",
     "RateLimitError",
+    "OrderExecutionError",
     "BrokerError",
     "BrokerAuthenticationError",
     "BrokerBalanceUnavailableError",
+    "BrokerReconciliationError",
     "OrderPlacementError",
     "DataStaleError",
     "WebSocketError",

--- a/tests/core/test_live_readiness_recompute.py
+++ b/tests/core/test_live_readiness_recompute.py
@@ -29,8 +29,13 @@ def _ctx(mdm):
         settings=SimpleNamespace(execution_mode='LIVE'),
         market_data_manager=mdm,
         strategy_runner=_Runner(),
-        broker_client=object(),
+        broker_client=SimpleNamespace(is_connected=lambda: True),
         order_manager=object(),
+        data_hub=SimpleNamespace(
+            get_subscription_snapshot=lambda symbol: SimpleNamespace(
+                state=SimpleNamespace(value="live"), generation=1, updated_at=1.0
+            )
+        ),
         active_trading_universe={},
     )
 

--- a/tests/core/test_readiness_live_tick_proof.py
+++ b/tests/core/test_readiness_live_tick_proof.py
@@ -35,8 +35,13 @@ def make_ctx(mdm, live: bool = True):
         settings=SimpleNamespace(execution_mode='LIVE' if live else 'PAPER'),
         market_data_manager=mdm,
         strategy_runner=Runner(),
-        broker_client=object(),
+        broker_client=SimpleNamespace(is_connected=lambda: True),
         order_manager=object(),
+        data_hub=SimpleNamespace(
+            get_subscription_snapshot=lambda symbol: SimpleNamespace(
+                state=SimpleNamespace(value="live"), generation=1, updated_at=1.0
+            )
+        ),
         active_trading_universe={
             'spot_symbol': 'NSE:NIFTY',
             'selected_ce': 'NFO:CE',

--- a/tests/core/test_runtime_safety_wiring.py
+++ b/tests/core/test_runtime_safety_wiring.py
@@ -1,0 +1,88 @@
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from nifty_scalper_bot.core import app
+from nifty_scalper_bot.data.data_hub import SubscriptionState
+from nifty_scalper_bot.execution.readiness import ReadinessDecision
+from nifty_scalper_bot.utils.errors import BrokerReconciliationError
+
+
+def test_attach_canonical_entry_guard_blocks_missing_readiness():
+    order_manager = SimpleNamespace(guard=None)
+    order_manager.set_entry_execution_guard = lambda guard: setattr(order_manager, "guard", guard)
+    ctx = SimpleNamespace(
+        order_manager=order_manager,
+        broker_auth_invalid=False,
+        broker_session_invalid=False,
+        broker_balance_valid=True,
+        position_reconciliation_failed=False,
+        position_reconciliation_completed=True,
+        unresolved_reconciliation_symbols=set(),
+        unprotected_broker_positions=set(),
+        readiness_decision=None,
+    )
+
+    app.attach_canonical_entry_execution_guard(ctx)
+
+    assert order_manager.guard is not None
+    assert order_manager.guard() == (False, "readiness_snapshot_missing")
+
+
+@pytest.mark.parametrize("payload", [{}, None, 1, {"status": "error"}, {"error_type": "x"}])
+def test_normalize_broker_positions_payload_rejects_invalid(payload):
+    with pytest.raises(BrokerReconciliationError):
+        app._normalize_broker_positions_payload(payload)
+
+
+def test_normalize_broker_positions_payload_accepts_verified_empty():
+    assert app._normalize_broker_positions_payload({"net": [], "day": []}) == []
+
+
+@pytest.mark.asyncio
+async def test_auth_failure_callback_style_recompute_increments_generation(monkeypatch):
+    calls = []
+    ctx = SimpleNamespace(
+        active_trading_universe={},
+        active_contract_basket={},
+        market_data_manager=None,
+        data_hub=None,
+        settings=SimpleNamespace(execution_mode="LIVE"),
+        strategy_runner=SimpleNamespace(
+            get_status=lambda: {"running": False},
+            set_runtime_readiness=lambda **kwargs: calls.append(kwargs),
+        ),
+        order_manager=object(),
+        broker_client=SimpleNamespace(is_connected=lambda: True),
+        readiness_generation=0,
+        broker_auth_invalid=True,
+        broker_session_invalid=False,
+        broker_balance_valid=False,
+        position_reconciliation_completed=False,
+        position_reconciliation_failed=False,
+        unprotected_broker_positions=set(),
+        selected_ce=None,
+        selected_pe=None,
+    )
+    async def _noop(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(app, "_ensure_context_history_hydrated", _noop)
+    monkeypatch.setattr(app, "_ensure_selected_options_hydrated", _noop)
+
+    await app._recompute_and_push_runtime_readiness(ctx, reason="broker_auth_invalid")
+
+    assert ctx.readiness_generation == 1
+    assert ctx.readiness_decision.primary_blocker == "broker_auth_invalid"
+    assert ctx.live_orders_armed is False
+
+
+def test_subscription_record_live_state_required():
+    class Hub:
+        def __init__(self, state):
+            self.state = state
+        def get_subscription_snapshot(self, symbol):
+            return SimpleNamespace(state=self.state)
+
+    assert Hub(SubscriptionState.LIVE).get_subscription_snapshot("x").state is SubscriptionState.LIVE

--- a/tests/core/test_startup_risk_balance.py
+++ b/tests/core/test_startup_risk_balance.py
@@ -79,3 +79,27 @@ def test_auth_failure_callback_marks_context_fail_closed():
     assert ctx.trading_ready is False
     assert ctx.live_block_reason == "broker_auth_invalid"
     assert ctx.execution_block_reason == "broker_auth_invalid"
+
+@pytest.mark.parametrize("bad_balance", [float("nan"), float("inf"), -1.0])
+def test_live_risk_initial_balance_rejects_invalid_numbers(monkeypatch, bad_balance):
+    monkeypatch.setenv("EXECUTION_MODE", "LIVE")
+    settings = SimpleNamespace(execution_mode="LIVE")
+    config = SimpleNamespace(initial_balance=1_000_000.0)
+
+    with pytest.raises(BrokerBalanceUnavailableError):
+        _resolve_startup_risk_initial_balance(
+            settings=settings,
+            config=config,
+            startup_available_balance=bad_balance,
+        )
+
+
+def test_live_risk_initial_balance_accepts_zero(monkeypatch):
+    monkeypatch.setenv("EXECUTION_MODE", "LIVE")
+    settings = SimpleNamespace(execution_mode="LIVE")
+    config = SimpleNamespace(initial_balance=1_000_000.0)
+    assert _resolve_startup_risk_initial_balance(
+        settings=settings,
+        config=config,
+        startup_available_balance=0.0,
+    ) == 0.0

--- a/tests/data/test_market_data_manager_broker_boundary.py
+++ b/tests/data/test_market_data_manager_broker_boundary.py
@@ -1,0 +1,108 @@
+import asyncio
+import math
+
+import pytest
+
+from nifty_scalper_bot.data.market_data_manager import MarketDataManager
+from nifty_scalper_bot.utils.errors import BrokerAuthenticationError, BrokerBalanceUnavailableError
+
+
+class _WS:
+    on_tick = None
+
+    def subscribe_tokens(self, *_args, **_kwargs):
+        return None
+
+    def is_connected(self):
+        return True
+
+
+class _SyncBroker:
+    def __init__(self, value=0.0):
+        self.value = value
+        self.calls = 0
+
+    def get_available_balance(self, segment="equity"):
+        self.calls += 1
+        return self.value
+
+
+class _AsyncBroker:
+    def __init__(self, value=0.0):
+        self.value = value
+        self.calls = 0
+
+    async def get_available_balance(self, segment="equity"):
+        self.calls += 1
+        return self.value
+
+
+@pytest.mark.asyncio
+async def test_async_account_snapshot_accepts_async_broker_zero():
+    mdm = MarketDataManager(_AsyncBroker(0.0), _WS())
+    snapshot = await mdm.get_account_snapshot(force=True)
+    assert snapshot["available"] == 0.0
+    assert snapshot["valid"] is True
+    assert snapshot["stale"] is False
+
+
+@pytest.mark.asyncio
+async def test_async_account_snapshot_runs_sync_broker():
+    broker = _SyncBroker(123.45)
+    mdm = MarketDataManager(broker, _WS())
+    assert await mdm.refresh_available_balance(force=True) == pytest.approx(123.45)
+    assert broker.calls == 1
+
+
+def test_sync_balance_rejects_async_broker_without_leaking_coroutine():
+    mdm = MarketDataManager(_AsyncBroker(10.0), _WS())
+    with pytest.raises(BrokerBalanceUnavailableError, match="async_broker_method_used_in_sync_context"):
+        mdm.get_available_balance(force=True)
+
+
+@pytest.mark.parametrize("value", [-1.0, math.nan, math.inf, -math.inf])
+def test_sync_balance_rejects_invalid_values(value):
+    mdm = MarketDataManager(_SyncBroker(value), _WS())
+    with pytest.raises(BrokerBalanceUnavailableError):
+        mdm.get_available_balance(force=True)
+
+
+def test_sync_balance_uses_fresh_cache_without_broker_call():
+    broker = _SyncBroker(5.0)
+    mdm = MarketDataManager(broker, _WS())
+    assert mdm.get_available_balance(force=True) == 5.0
+    broker.value = 99.0
+    assert mdm.get_available_balance(force=False) == 5.0
+    assert broker.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_expired_cache_not_returned_after_failed_refresh():
+    class Broker(_SyncBroker):
+        def get_available_balance(self, segment="equity"):
+            self.calls += 1
+            if self.calls == 1:
+                return 10.0
+            raise RuntimeError("network")
+
+    broker = Broker()
+    mdm = MarketDataManager(broker, _WS())
+    mdm._account_cache_ttl = 0.0
+    assert await mdm.refresh_available_balance(force=True) == 10.0
+    with pytest.raises(BrokerBalanceUnavailableError):
+        await mdm.get_account_snapshot(force=True)
+    assert mdm._account_snapshot == {}
+
+
+@pytest.mark.asyncio
+async def test_auth_failure_clears_cache_and_propagates():
+    class Broker(_SyncBroker):
+        def get_available_balance(self, segment="equity"):
+            raise BrokerAuthenticationError("bad token")
+
+    mdm = MarketDataManager(Broker(), _WS())
+    mdm._account_snapshot = {"available": 10.0}
+    mdm._account_updated_at = 1.0
+    with pytest.raises(BrokerAuthenticationError):
+        await mdm.get_account_snapshot(force=True)
+    assert mdm._account_snapshot == {}

--- a/tests/data/test_market_data_manager_broker_boundary.py
+++ b/tests/data/test_market_data_manager_broker_boundary.py
@@ -106,3 +106,42 @@ async def test_auth_failure_clears_cache_and_propagates():
     with pytest.raises(BrokerAuthenticationError):
         await mdm.get_account_snapshot(force=True)
     assert mdm._account_snapshot == {}
+
+
+def test_sync_cached_balance_rejected_when_broker_auth_invalid():
+    broker = _SyncBroker(10.0)
+    mdm = MarketDataManager(broker, _WS())
+    assert mdm.get_available_balance(force=True) == 10.0
+    broker.auth_invalid = True
+    with pytest.raises(BrokerAuthenticationError):
+        mdm.get_available_balance(force=False)
+    assert mdm._account_snapshot == {}
+
+
+@pytest.mark.asyncio
+async def test_async_cached_balance_rejected_when_broker_auth_invalid():
+    broker = _AsyncBroker(10.0)
+    mdm = MarketDataManager(broker, _WS())
+    assert await mdm.refresh_available_balance(force=True) == 10.0
+    broker.auth_invalid = True
+    with pytest.raises(BrokerAuthenticationError):
+        await mdm.get_account_snapshot(force=False)
+    assert mdm._account_snapshot == {}
+
+
+def test_sync_generic_refresh_failure_clears_cache_and_raises_typed():
+    class Broker(_SyncBroker):
+        def get_available_balance(self, segment="equity"):
+            self.calls += 1
+            if self.calls == 1:
+                return 10.0
+            raise RuntimeError("boom")
+
+    broker = Broker()
+    mdm = MarketDataManager(broker, _WS())
+    assert mdm.get_available_balance(force=True) == 10.0
+    with pytest.raises(BrokerBalanceUnavailableError):
+        mdm.get_available_balance(force=True)
+    assert mdm._account_snapshot == {}
+    with pytest.raises(BrokerBalanceUnavailableError):
+        mdm.get_available_balance(force=False)

--- a/tests/execution/test_order_manager_live_guard.py
+++ b/tests/execution/test_order_manager_live_guard.py
@@ -128,3 +128,43 @@ def test_auth_latch_blocks_order_before_broker(monkeypatch):
 
     assert broker.calls == 0
     assert om.get_last_skip_reason() == "broker_auth_invalid"
+
+
+def test_entry_execution_guard_blocks_entry_before_broker(monkeypatch):
+    from nifty_scalper_bot.utils.errors import OrderPlacementError
+
+    monkeypatch.setenv("EXECUTION_MODE", "LIVE")
+    monkeypatch.setenv("ENABLE_LIVE_TRADING", "true")
+    broker = _Broker(connected=True)
+    broker.calls = 0
+    broker.place_order = lambda **_kwargs: {"order_id": "OID"}
+    om = OrderManager(broker, _Positions(), _Limiter())
+    monkeypatch.setattr(om, "_validate_live_execution_safety", lambda: True)
+    om.set_entry_execution_guard(lambda: (False, "position_reconciliation_incomplete"))
+
+    with pytest.raises(OrderPlacementError, match="position_reconciliation_incomplete"):
+        om.place_order("NFO:NIFTY26MAY23750CE", "BUY", 75, stop_loss=90, take_profit=120)
+
+    assert broker.calls == 0
+    assert om.get_last_skip_reason() == "position_reconciliation_incomplete"
+
+
+def test_entry_execution_guard_does_not_block_protective_exit(monkeypatch):
+    monkeypatch.setenv("EXECUTION_MODE", "LIVE")
+    monkeypatch.setenv("ENABLE_LIVE_TRADING", "true")
+    broker = _Broker(connected=True)
+    broker.calls = 0
+
+    def _place_order(**_kwargs):
+        broker.calls += 1
+        return {"order_id": "OID"}
+
+    broker.place_order = _place_order
+    om = OrderManager(broker, _Positions(), _Limiter())
+    monkeypatch.setattr(om, "_validate_live_execution_safety", lambda: True)
+    om.set_entry_execution_guard(lambda: (False, "selected_option_subscription_missing"))
+
+    result = om.place_order("NFO:NIFTY26MAY23750CE", "SELL", 75, tag="protective_exit")
+
+    assert result == "OID"
+    assert broker.calls == 1

--- a/tests/execution/test_order_manager_live_guard.py
+++ b/tests/execution/test_order_manager_live_guard.py
@@ -1,6 +1,6 @@
 import pytest
 
-from nifty_scalper_bot.execution.order_manager import OrderManager
+from nifty_scalper_bot.execution.order_manager import OrderIntent, OrderManager
 
 
 class _Broker:
@@ -77,6 +77,7 @@ def test_live_selected_option_ltp_only_rejected_before_broker(monkeypatch):
     broker.place_order = _place_order
     om = OrderManager(broker, _Positions(), _Limiter())
     monkeypatch.setattr(om, "_validate_live_execution_safety", lambda: True)
+    om.set_entry_execution_guard(lambda: (True, None))
     selected = "NFO:NIFTY26MAY23750CE"
     om._market_data = type(
         "MDM",
@@ -143,7 +144,7 @@ def test_entry_execution_guard_blocks_entry_before_broker(monkeypatch):
     om.set_entry_execution_guard(lambda: (False, "position_reconciliation_incomplete"))
 
     with pytest.raises(OrderPlacementError, match="position_reconciliation_incomplete"):
-        om.place_order("NFO:NIFTY26MAY23750CE", "BUY", 75, stop_loss=90, take_profit=120)
+        om.place_order("NFO:NIFTY26MAY23750CE", "BUY", 75, stop_loss=90, take_profit=120, intent=OrderIntent.ENTRY)
 
     assert broker.calls == 0
     assert om.get_last_skip_reason() == "position_reconciliation_incomplete"
@@ -164,7 +165,55 @@ def test_entry_execution_guard_does_not_block_protective_exit(monkeypatch):
     monkeypatch.setattr(om, "_validate_live_execution_safety", lambda: True)
     om.set_entry_execution_guard(lambda: (False, "selected_option_subscription_missing"))
 
-    result = om.place_order("NFO:NIFTY26MAY23750CE", "SELL", 75, tag="protective_exit")
+    result = om.place_order("NFO:NIFTY26MAY23750CE", "SELL", 75, tag="protective_exit", intent=OrderIntent.PROTECTIVE)
 
     assert result == "OID"
+    assert broker.calls == 1
+
+
+def test_live_entry_fails_closed_when_entry_guard_missing(monkeypatch):
+    from nifty_scalper_bot.utils.errors import OrderPlacementError
+
+    monkeypatch.setenv("EXECUTION_MODE", "LIVE")
+    monkeypatch.setenv("ENABLE_LIVE_TRADING", "true")
+    broker = _Broker(connected=True)
+    broker.calls = 0
+    broker.place_order = lambda **_kwargs: {"order_id": "OID"}
+    om = OrderManager(broker, _Positions(), _Limiter())
+    monkeypatch.setattr(om, "_validate_live_execution_safety", lambda: True)
+
+    with pytest.raises(OrderPlacementError, match="entry_execution_guard_missing"):
+        om.place_order(
+            "NFO:NIFTY26MAY23750CE",
+            "BUY",
+            75,
+            stop_loss=90,
+            take_profit=120,
+            intent=OrderIntent.ENTRY,
+        )
+
+    assert broker.calls == 0
+
+
+def test_explicit_exit_intent_bypasses_entry_guard(monkeypatch):
+    monkeypatch.setenv("EXECUTION_MODE", "LIVE")
+    monkeypatch.setenv("ENABLE_LIVE_TRADING", "true")
+    broker = _Broker(connected=True)
+    broker.calls = 0
+
+    def _place_order(**_kwargs):
+        broker.calls += 1
+        return {"order_id": "OID"}
+
+    broker.place_order = _place_order
+    om = OrderManager(broker, _Positions(), _Limiter())
+    monkeypatch.setattr(om, "_validate_live_execution_safety", lambda: True)
+    om.set_entry_execution_guard(lambda: (False, "readiness_snapshot_missing"))
+
+    assert om.place_order(
+        "NFO:NIFTY26MAY23750CE",
+        "SELL",
+        75,
+        intent=OrderIntent.EXIT,
+    ) == "OID"
     assert broker.calls == 1

--- a/tests/test_exception_identity.py
+++ b/tests/test_exception_identity.py
@@ -1,0 +1,7 @@
+from nifty_scalper_bot.execution import exceptions as execution_exceptions
+from nifty_scalper_bot.utils import errors as utils_errors
+
+
+def test_execution_exceptions_reexport_canonical_order_error():
+    assert execution_exceptions.OrderPlacementError is utils_errors.OrderPlacementError
+    assert execution_exceptions.BrokerError is utils_errors.BrokerError


### PR DESCRIPTION
### Motivation

- Broker call boundaries and account-snapshot semantics allowed async/sync mismatches and stale/invalid balances to leak into sizing and readiness decisions.  
- Reconciliation accepted malformed or awaitable broker payloads as empty books and cleared orphan blockers without verifying protection.  
- Duplicate exception classes and mutable readiness state risked inconsistent catch behaviour and contradictory runtime readiness.  

### Description

- MarketDataManager: added explicit `_invoke_broker_async` and `_invoke_broker_sync` adapters, an immutable `AccountBalanceSnapshot`, validation of numeric/finiteness/non-negativity, `refresh_available_balance`, and fail-closed cache-clearing on auth/unavailable errors.  (src/nifty_scalper_bot/data/market_data_manager.py)  
- Reconciliation: added `_normalize_broker_positions_payload` and changed `_reconcile_state` to fail closed on awaitable/invalid position payloads and verify orphan protection via BracketManager before clearing blockers.  (src/nifty_scalper_bot/core/app.py)  
- Exceptions: unified hierarchy in `utils.errors` (added `OrderExecutionError`, `BrokerReconciliationError`) and re-exported canonical types from `execution.exceptions` to ensure single runtime classes.  (src/nifty_scalper_bot/utils/errors.py, src/nifty_scalper_bot/execution/exceptions.py)  
- Readiness: made `ReadinessDecision` immutable with generation, timestamps, broker/reconciliation flags, and stored the canonical decision on `BotContext.readiness_decision` while incrementing `readiness_generation` once per recompute; broker_ready now requires connectivity/auth/session checks.  (src/nifty_scalper_bot/execution/readiness.py, src/nifty_scalper_bot/core/app.py)  
- OrderManager: added injectable final `EntryExecutionGuard`, wired into pre-broker submission checks, and preserved protective/exit bypass behaviour.  (src/nifty_scalper_bot/execution/order_manager.py)  
- DataHub subscriptions: extended `SubscriptionRecord` with `source` and `first_live_tick_at`, added `mark_subscription_requested/confirmed` and `get_subscription_snapshot`, and fixed queued logging semantics.  (src/nifty_scalper_bot/data/data_hub.py)  
- Tests and CI: added focused tests for MDM broker boundaries, exception identity, startup balance validation, and entry-guard behaviour; added a CI workflow that runs compile and focused + full pytest.  (tests/*, .github/workflows/ci.yml)

### Testing

- Ran `python -m compileall -q src` and it succeeded.  
- Ran focused test set: `python -m pytest -q tests/data/test_zerodha_balance_logging.py tests/data/test_market_data_manager.py tests/data/test_market_data_manager_broker_boundary.py tests/data/test_datahub_subscription_state.py tests/core/test_startup_risk_balance.py tests/core/test_bot_context_attributes.py tests/core/test_deferred_basket_retry.py tests/execution/test_order_manager_live_guard.py tests/test_main_health_readiness.py tests/test_exception_identity.py` and all focused tests passed.  
- Ran full test suite: `python -m pytest -q` and the test suite completed successfully.  
- Ran `ruff check .` and observed a repository-wide lint baseline with many pre-existing findings; this is reported but not required to pass in the CI workflow for this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a374f749fa8832485ac1ab2f56efe4b)