### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix SQL injection via string formatting for LIMIT clause

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** The admin dashboard manually generates HTML strings and was embedding unsanitized user query parameters (`msg`, `contains`) directly into attributes and elements, allowing for Reflected Cross-Site Scripting (XSS).
 **Learning:** In applications that construct raw HTML directly (like `FastAPI`'s `HTMLResponse` combined with Python f-strings) rather than using a templating engine (like Jinja2) with auto-escaping, every user-controlled input must be manually sanitized.
 **Prevention:** Always use `html.escape()` when embedding user input (such as query strings or form data) into raw HTML strings to prevent XSS attacks.
+## $(date +%Y-%m-%d) - Parameterized Limit Queries in SQLite
+**Vulnerability:** A `LIMIT` parameter was dynamically injected into a SQL query via f-strings (`f"{query} LIMIT {int(limit)}"`) in `PersistentStateDB.load_fills`. While `int(limit)` casting mitigates immediate arbitrary SQL injection in Python, it relies on application-level type enforcement rather than driver-level parameterization.
+**Learning:** Even when inputs are cast to safe types like `int`, standard security best practices demand using parameterized queries (`LIMIT ?`) for all dynamic SQL components to implement defense in depth and future-proof the codebase against changes to the type coercion logic.
+**Prevention:** Always use `sqlite3` placeholder parameterization (the `?` syntax) for `LIMIT`, `OFFSET`, and `ORDER BY` values (where supported by the driver) instead of Python string formatting.

--- a/src/nifty_scalper_bot/data/persistent_state.py
+++ b/src/nifty_scalper_bot/data/persistent_state.py
@@ -331,8 +331,10 @@ class PersistentStateDB:
             with self._lock:
                 query = "SELECT payload FROM fills ORDER BY id ASC"
                 if limit is not None and limit > 0:
-                    query = f"{query} LIMIT {int(limit)}"
-                cursor = self._conn.execute(query)  # type: ignore[attr-defined]
+                    query = f"{query} LIMIT ?"
+                    cursor = self._conn.execute(query, (int(limit),))  # type: ignore[attr-defined]
+                else:
+                    cursor = self._conn.execute(query)  # type: ignore[attr-defined]
                 rows = cursor.fetchall()
         except Exception as exc:  # noqa: BLE001
             self._logger.error("Failure in PersistentStateDB.load_fills: %s", exc)


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The `load_fills` query in `PersistentStateDB` was using string concatenation (`f"{query} LIMIT {int(limit)}"`) to inject a dynamic limit instead of parameterized queries. Although Python's `int()` cast provided a measure of protection, relying on manual casting instead of SQL-driver parametrization is an anti-pattern.
🎯 Impact: Minor given the casting, but could lead to SQL injection vulnerabilities if future changes bypass or misunderstand the type coercion.
🔧 Fix: Replaced string formatting `LIMIT {int(limit)}` with parameterized `LIMIT ?` placeholder per SQLite security best practices.
✅ Verification: Ran test suite using `run_checks.sh` and tests related to `persistent_state` manager. Validated no regressions occurred.

---
*PR created automatically by Jules for task [14617743307025059114](https://jules.google.com/task/14617743307025059114) started by @kundakarlabp*