### PR TITLE
🎨 Palette: Improve label accessibility in dashboard forms

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - HTML String Templates Accessibility
+**Learning:** When UI HTML is rendered inside Python strings (like FastAPI `HTMLResponse`), standard frontend a11y linters (like eslint-plugin-jsx-a11y) do not scan them, allowing severe accessibility issues like unassociated labels (`<label>` without `for` matching an `<input id>`) to go undetected.
+**Action:** Always manually verify label bindings (`for` and `id`) and ARIA attributes when modifying or adding string-based HTML templates in Python backends.

--- a/src/nifty_scalper_bot/admin_dashboard.py
+++ b/src/nifty_scalper_bot/admin_dashboard.py
@@ -372,7 +372,7 @@ def login_page(e: str = "") -> HTMLResponse:
     body = f"""<div class=wrap style="max-width:380px;margin-top:12vh">
     <div class=card><h2>Sign in</h2><p>Enter the admin password.</p>{err}
     <form method=post action="/admin/login">
-    <input type=password name=password autofocus placeholder="Password">
+    <input type=password name=password autofocus placeholder="Password" aria-label="Password">
     <button type=submit style="width:100%">Sign in</button></form></div></div>"""
     return HTMLResponse(_page(body))
 
@@ -417,7 +417,7 @@ def dashboard(request: Request) -> HTMLResponse:
     for label, key, sec in FIELDS:
         v = env.get(key, "")
         shown = ("••••••••" if v else "") if sec else v
-        rows += f'<label>{label} <span class=badge>{key}</span></label><input name="{key}" value="{shown}" placeholder="(unchanged)">'
+        rows += f'<label for="in_{key}">{label} <span class=badge>{key}</span></label><input id="in_{key}" name="{key}" value="{shown}" placeholder="(unchanged)">'
     body = f"""{_topbar(live_on)}<div class=wrap>{_flash(request)}
     <div class=card><h2>Live Trading</h2>
     <p>{'Placing REAL orders with REAL money.' if live_on else 'Analysing only — no real orders. Turn on when ready.'}</p>{toggle}</div>
@@ -425,8 +425,8 @@ def dashboard(request: Request) -> HTMLResponse:
     <div class=card><h2>Daily Token</h2>
     <p>Easiest: paste today's <b>request token</b> (from the Kite login redirect URL) and the bot will fetch the access token for you, then restart.</p>
     <form method=post action="/admin/token">
-    <label>Request Token (recommended)</label><input name="request_token" placeholder="paste request_token from login URL">
-    <label>…or Access Token (if you already have it)</label><input name="access_token" placeholder="paste access_token directly">
+    <label for="request_token">Request Token (recommended)</label><input id="request_token" name="request_token" placeholder="paste request_token from login URL">
+    <label for="access_token">…or Access Token (if you already have it)</label><input id="access_token" name="access_token" placeholder="paste access_token directly">
     <button class=blu type=submit>Update token &amp; restart</button></form></div>
 
     <div class=card><h2>Credentials &amp; Settings</h2>
@@ -529,9 +529,9 @@ def logs_page(request: Request, lines: int = 400, contains: str = "") -> HTMLRes
     body = f"""{_topbar(False)}<div class="wrap wide">
     <div class=card><h2>Logs <span class=muted id=stamp></span> <span id=botstat class=badge style="margin-left:8px">checking…</span> <span id=cnt class=badge></span></h2>
     <div class=grid>
-      <div><label>Lines</label><input id=lines value="{lines}"></div>
-      <div><label>Filter contains</label><input id=contains value="{html.escape(contains)}" placeholder="e.g. ORDER_SENT"></div>
-      <div><label>Auto-refresh</label>
+      <div><label for="lines">Lines</label><input id=lines value="{lines}"></div>
+      <div><label for="contains">Filter contains</label><input id=contains value="{html.escape(contains)}" placeholder="e.g. ORDER_SENT"></div>
+      <div><label for="auto">Auto-refresh</label>
         <select id=auto style="width:100%;padding:11px;border-radius:9px;background:#0a1019;color:var(--fg);border:1px solid var(--bd)">
           <option value=3>Every 3s</option><option value=5 selected>Every 5s</option>
           <option value=10>Every 10s</option><option value=0>Off</option></select></div>


### PR DESCRIPTION
💡 **What:** Added explicit `for` attributes to `<label>` elements and matching `id` attributes to input fields across the admin dashboard, as well as an `aria-label` for the password login field.
🎯 **Why:** To drastically improve the dashboard's accessibility for screen readers by ensuring form inputs are programmatically associated with their labels. String-templated HTML forms in Python lack automatic linting for these associations.
♿ **Accessibility:** Screen readers will now correctly read the purpose of the setting/token/filter inputs when focused, instead of reading them as unlabeled text boxes. Added `aria-label="Password"` to the login input, providing context without modifying the visual design.

---
*PR created automatically by Jules for task [14919103503941913901](https://jules.google.com/task/14919103503941913901) started by @kundakarlabp*