### PR TITLE
Add mobile-friendly Streamlit monitoring dashboard

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -14,9 +14,27 @@ A read-only dashboard for checking the bot from an Android phone or desktop brow
 
 The dashboard does not place, modify, or cancel orders.
 
+## Production bot endpoint
+
+The current bot admin page is:
+
+`http://15.206.3.6:8080/admin`
+
+For the Streamlit dashboard, use only the base URL:
+
+```toml
+BOT_API_URL = "http://15.206.3.6:8080"
+```
+
+Do not append `/admin`. The dashboard automatically calls:
+
+- `/livez`
+- `/readyz`
+- `/health/trading`
+
 ## Deploy on Streamlit Community Cloud
 
-1. Push/merge this folder to GitHub.
+1. Push or merge this folder to GitHub.
 2. Open Streamlit Community Cloud and create a new app.
 3. Select this repository and branch.
 4. Set the main file path to:
@@ -26,10 +44,8 @@ The dashboard does not place, modify, or cancel orders.
 5. In the app's **Secrets** section, add:
 
 ```toml
-BOT_API_URL = "https://YOUR-BOT-SERVICE.example.com"
+BOT_API_URL = "http://15.206.3.6:8080"
 ```
-
-The URL must be the public base URL of the running bot, without a trailing slash.
 
 If a reverse proxy later protects the health endpoints with a bearer token, also add:
 
@@ -52,13 +68,13 @@ From the repository root:
 
 ```bash
 python -m pip install -r dashboard/requirements.txt
-BOT_API_URL=http://localhost:8080 streamlit run dashboard/streamlit_app.py
+BOT_API_URL=http://15.206.3.6:8080 streamlit run dashboard/streamlit_app.py
 ```
 
 On Windows PowerShell:
 
 ```powershell
-$env:BOT_API_URL="http://localhost:8080"
+$env:BOT_API_URL="http://15.206.3.6:8080"
 streamlit run dashboard/streamlit_app.py
 ```
 
@@ -67,4 +83,5 @@ streamlit run dashboard/streamlit_app.py
 - Keep the dashboard read-only.
 - Do not expose broker API keys, access tokens, Telegram tokens, or `.env` contents.
 - Prefer a private Streamlit deployment or place authentication in front of the app.
+- The current production endpoint uses plain HTTP on a public IP; migrate it to HTTPS before broader exposure.
 - The current bot health endpoints reveal operational status but not broker credentials.

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -11,6 +11,7 @@ A read-only dashboard for checking the bot from an Android phone or desktop brow
 - Position reconciliation status
 - Current safety blockers
 - Raw health diagnostics
+- One-click CSV export of all available logs from 09:15 to 15:30 IST for a selected date
 
 The dashboard does not place, modify, or cancel orders.
 
@@ -45,7 +46,10 @@ Do not append `/admin`. The dashboard automatically calls:
 
 ```toml
 BOT_API_URL = "http://15.206.3.6:8080"
+BOT_ADMIN_PASSWORD = "YOUR_EXISTING_ADMIN_PASSWORD"
 ```
+
+`BOT_ADMIN_PASSWORD` is used only server-side by the Streamlit app to authenticate to the existing admin log-download endpoint. It is not displayed in the dashboard or browser.
 
 If a reverse proxy later protects the health endpoints with a bearer token, also add:
 
@@ -54,6 +58,20 @@ BOT_DASHBOARD_TOKEN = "replace-with-a-long-random-token"
 ```
 
 6. Deploy the Streamlit app.
+
+## Market-hours CSV download
+
+1. Open the Streamlit dashboard.
+2. Choose the trading date.
+3. Tap **Prepare market-hours CSV**.
+4. Tap **Download one CSV file**.
+
+The generated UTF-8 CSV contains:
+
+- `timestamp_ist`
+- `message`
+
+Only timestamped rows between **09:15:00 and 15:30:00 IST** are included. The dashboard requests up to the latest 20,000 available log lines from the existing admin service, then filters them by date and market hours.
 
 ## Android access
 
@@ -68,19 +86,21 @@ From the repository root:
 
 ```bash
 python -m pip install -r dashboard/requirements.txt
-BOT_API_URL=http://15.206.3.6:8080 streamlit run dashboard/streamlit_app.py
+BOT_API_URL=http://15.206.3.6:8080 BOT_ADMIN_PASSWORD='your-password' streamlit run dashboard/streamlit_app.py
 ```
 
 On Windows PowerShell:
 
 ```powershell
 $env:BOT_API_URL="http://15.206.3.6:8080"
+$env:BOT_ADMIN_PASSWORD="your-password"
 streamlit run dashboard/streamlit_app.py
 ```
 
 ## Security notes
 
 - Keep the dashboard read-only.
+- Never commit `BOT_ADMIN_PASSWORD` to GitHub; store it only in Streamlit Secrets.
 - Do not expose broker API keys, access tokens, Telegram tokens, or `.env` contents.
 - Prefer a private Streamlit deployment or place authentication in front of the app.
 - The current production endpoint uses plain HTTP on a public IP; migrate it to HTTPS before broader exposure.

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -1,0 +1,70 @@
+# Nifty Scalper Streamlit Monitor
+
+A read-only dashboard for checking the bot from an Android phone or desktop browser.
+
+## What it shows
+
+- Bot API availability
+- Trading engine readiness
+- Whether live orders are armed
+- Broker authentication and balance status
+- Position reconciliation status
+- Current safety blockers
+- Raw health diagnostics
+
+The dashboard does not place, modify, or cancel orders.
+
+## Deploy on Streamlit Community Cloud
+
+1. Push/merge this folder to GitHub.
+2. Open Streamlit Community Cloud and create a new app.
+3. Select this repository and branch.
+4. Set the main file path to:
+
+   `dashboard/streamlit_app.py`
+
+5. In the app's **Secrets** section, add:
+
+```toml
+BOT_API_URL = "https://YOUR-BOT-SERVICE.example.com"
+```
+
+The URL must be the public base URL of the running bot, without a trailing slash.
+
+If a reverse proxy later protects the health endpoints with a bearer token, also add:
+
+```toml
+BOT_DASHBOARD_TOKEN = "replace-with-a-long-random-token"
+```
+
+6. Deploy the Streamlit app.
+
+## Android access
+
+1. Open the generated Streamlit URL in Chrome.
+2. Sign in if the Streamlit deployment is private.
+3. Open Chrome's menu and tap **Add to Home screen**.
+4. Launch it from the home-screen icon like an app.
+
+## Local run
+
+From the repository root:
+
+```bash
+python -m pip install -r dashboard/requirements.txt
+BOT_API_URL=http://localhost:8080 streamlit run dashboard/streamlit_app.py
+```
+
+On Windows PowerShell:
+
+```powershell
+$env:BOT_API_URL="http://localhost:8080"
+streamlit run dashboard/streamlit_app.py
+```
+
+## Security notes
+
+- Keep the dashboard read-only.
+- Do not expose broker API keys, access tokens, Telegram tokens, or `.env` contents.
+- Prefer a private Streamlit deployment or place authentication in front of the app.
+- The current bot health endpoints reveal operational status but not broker credentials.

--- a/dashboard/requirements.txt
+++ b/dashboard/requirements.txt
@@ -1,0 +1,2 @@
+streamlit>=1.37,<2
+requests>=2.31,<3

--- a/dashboard/streamlit_app.py
+++ b/dashboard/streamlit_app.py
@@ -7,8 +7,11 @@ submits broker orders or mutates trading state.
 
 from __future__ import annotations
 
+import csv
+import io
 import os
-from datetime import datetime
+import re
+from datetime import date, datetime, time
 from typing import Any
 
 import requests
@@ -40,6 +43,10 @@ st.markdown(
     </style>
     """,
     unsafe_allow_html=True,
+)
+
+_LOG_RE = re.compile(
+    r"^(?P<timestamp>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}) IST\s+(?P<message>.*)$"
 )
 
 
@@ -82,6 +89,57 @@ def _get_json(path: str) -> tuple[dict[str, Any] | None, str | None, int | None]
         return None, str(exc), status_code
     except ValueError as exc:
         return None, f"Invalid JSON response: {exc}", None
+
+
+def _market_hours_csv(selected_date: date) -> tuple[bytes | None, str | None, int]:
+    """Authenticate to admin, fetch recent logs, and export 09:15–15:30 IST rows."""
+    base_url = _base_url()
+    admin_password = _secret("BOT_ADMIN_PASSWORD")
+    if not base_url:
+        return None, "BOT_API_URL is not configured", 0
+    if not admin_password:
+        return None, "BOT_ADMIN_PASSWORD is not configured in Streamlit secrets", 0
+
+    session = requests.Session()
+    try:
+        login = session.post(
+            f"{base_url}/admin/login",
+            data={"password": admin_password},
+            timeout=10,
+            allow_redirects=False,
+        )
+        if login.status_code not in {302, 303} or not session.cookies.get("admin_session"):
+            return None, "Admin login failed. Check BOT_ADMIN_PASSWORD.", 0
+
+        response = session.get(
+            f"{base_url}/admin/logs/download",
+            params={"fmt": "txt", "lines": 20000},
+            timeout=20,
+        )
+        response.raise_for_status()
+    except requests.RequestException as exc:
+        return None, f"Log download failed: {exc}", 0
+
+    start_at = datetime.combine(selected_date, time(9, 15))
+    end_at = datetime.combine(selected_date, time(15, 30))
+    rows: list[tuple[str, str]] = []
+
+    for raw_line in response.text.splitlines():
+        match = _LOG_RE.match(raw_line.strip())
+        if not match:
+            continue
+        try:
+            stamp = datetime.strptime(match.group("timestamp"), "%Y-%m-%d %H:%M:%S")
+        except ValueError:
+            continue
+        if start_at <= stamp <= end_at:
+            rows.append((f"{stamp:%Y-%m-%d %H:%M:%S} IST", match.group("message")))
+
+    output = io.StringIO()
+    writer = csv.writer(output)
+    writer.writerow(["timestamp_ist", "message"])
+    writer.writerows(rows)
+    return output.getvalue().encode("utf-8-sig"), None, len(rows)
 
 
 def _label(value: Any, fallback: str = "—") -> str:
@@ -167,6 +225,36 @@ if blockers:
         st.warning(str(blocker))
 else:
     st.success("No reported blockers")
+
+st.subheader("Download market-hours logs")
+st.caption("Creates one CSV containing all available bot logs from 09:15 to 15:30 IST.")
+selected_log_date = st.date_input("Trading date", value=date.today(), max_value=date.today())
+
+if st.button("Prepare market-hours CSV", type="primary", use_container_width=True):
+    with st.spinner("Collecting and filtering logs…"):
+        csv_data, csv_error, row_count = _market_hours_csv(selected_log_date)
+    if csv_error:
+        st.session_state.pop("market_log_csv", None)
+        st.error(csv_error)
+    else:
+        st.session_state["market_log_csv"] = csv_data
+        st.session_state["market_log_date"] = selected_log_date.isoformat()
+        st.session_state["market_log_rows"] = row_count
+
+if st.session_state.get("market_log_csv") is not None:
+    export_date = st.session_state.get("market_log_date", selected_log_date.isoformat())
+    export_rows = int(st.session_state.get("market_log_rows", 0))
+    if export_rows:
+        st.success(f"CSV ready: {export_rows:,} log rows")
+    else:
+        st.warning("CSV is ready, but no timestamped logs were found in the selected market-hours window.")
+    st.download_button(
+        "⬇️ Download one CSV file",
+        data=st.session_state["market_log_csv"],
+        file_name=f"niftybot-market-logs-{export_date}.csv",
+        mime="text/csv",
+        use_container_width=True,
+    )
 
 with st.expander("Raw diagnostics"):
     st.write(

--- a/dashboard/streamlit_app.py
+++ b/dashboard/streamlit_app.py
@@ -1,0 +1,185 @@
+"""Mobile-friendly, read-only Streamlit dashboard for Nifty Scalper Bot.
+
+Deploy this app separately from the trading process (for example on Streamlit
+Community Cloud). It reads the bot's existing HTTP health endpoints and never
+submits broker orders or mutates trading state.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime
+from typing import Any
+
+import requests
+import streamlit as st
+
+
+st.set_page_config(
+    page_title="Nifty Scalper Monitor",
+    page_icon="📈",
+    layout="wide",
+    initial_sidebar_state="collapsed",
+)
+
+st.markdown(
+    """
+    <style>
+      .block-container {padding-top: 1rem; padding-bottom: 2rem; max-width: 1100px;}
+      div[data-testid="stMetric"] {
+        border: 1px solid rgba(128,128,128,.25);
+        border-radius: 12px;
+        padding: .7rem .8rem;
+      }
+      div[data-testid="stMetricValue"] {font-size: 1.35rem;}
+      @media (max-width: 640px) {
+        .block-container {padding-left: .7rem; padding-right: .7rem;}
+        h1 {font-size: 1.65rem !important;}
+        div[data-testid="stMetricValue"] {font-size: 1.1rem;}
+      }
+    </style>
+    """,
+    unsafe_allow_html=True,
+)
+
+
+def _secret(name: str, default: str = "") -> str:
+    """Read a value from Streamlit secrets first, then environment variables."""
+    try:
+        value = st.secrets.get(name, default)
+    except Exception:
+        value = default
+    return str(value or os.getenv(name, default)).strip()
+
+
+def _base_url() -> str:
+    return _secret("BOT_API_URL").rstrip("/")
+
+
+def _headers() -> dict[str, str]:
+    token = _secret("BOT_DASHBOARD_TOKEN")
+    return {"Authorization": f"Bearer {token}"} if token else {}
+
+
+def _get_json(path: str) -> tuple[dict[str, Any] | None, str | None, int | None]:
+    base_url = _base_url()
+    if not base_url:
+        return None, "BOT_API_URL is not configured", None
+    try:
+        response = requests.get(
+            f"{base_url}{path}",
+            headers=_headers(),
+            timeout=8,
+        )
+        status_code = response.status_code
+        response.raise_for_status()
+        payload = response.json()
+        if not isinstance(payload, dict):
+            return None, "Unexpected non-object API response", status_code
+        return payload, None, status_code
+    except requests.RequestException as exc:
+        status_code = getattr(getattr(exc, "response", None), "status_code", None)
+        return None, str(exc), status_code
+    except ValueError as exc:
+        return None, f"Invalid JSON response: {exc}", None
+
+
+def _label(value: Any, fallback: str = "—") -> str:
+    if value is None or value == "":
+        return fallback
+    if isinstance(value, bool):
+        return "YES" if value else "NO"
+    return str(value)
+
+
+def _status_banner(livez: dict[str, Any] | None, trading: dict[str, Any] | None) -> None:
+    if not livez:
+        st.error("🔴 Bot API is unreachable")
+        return
+    if trading and trading.get("live_orders_armed"):
+        st.success("🟢 Bot online — live orders armed")
+    elif trading and trading.get("status") == "blocked":
+        blocker = trading.get("primary_blocker") or "unknown blocker"
+        st.warning(f"🟠 Bot online — trading blocked: {blocker}")
+    else:
+        st.info("🔵 Bot process online — trading engine starting or not armed")
+
+
+st.title("📈 Nifty Scalper Monitor")
+st.caption("Read-only mobile dashboard • No order controls")
+
+with st.sidebar:
+    st.subheader("Connection")
+    configured_url = _base_url()
+    st.code(configured_url or "BOT_API_URL not set", language=None)
+    st.caption("Configure BOT_API_URL in Streamlit app secrets.")
+    if st.button("Refresh now", use_container_width=True):
+        st.rerun()
+
+livez, livez_error, livez_code = _get_json("/livez")
+readyz, readyz_error, readyz_code = _get_json("/readyz")
+trading, trading_error, trading_code = _get_json("/health/trading")
+
+_status_banner(livez, trading)
+
+st.caption(f"Last checked: {datetime.now().astimezone().strftime('%d %b %Y, %I:%M:%S %p %Z')}")
+
+col1, col2 = st.columns(2)
+with col1:
+    st.metric("API", "ONLINE" if livez else "OFFLINE")
+with col2:
+    st.metric("Bot loaded", _label((livez or {}).get("bot_loaded")))
+
+col3, col4 = st.columns(2)
+with col3:
+    st.metric("Execution ready", _label((trading or {}).get("ready")))
+with col4:
+    st.metric("Live orders armed", _label((trading or {}).get("live_orders_armed")))
+
+broker = (trading or {}).get("broker") or {}
+reconciliation = (trading or {}).get("reconciliation") or {}
+
+st.subheader("Broker and safety state")
+col5, col6 = st.columns(2)
+with col5:
+    st.metric("Broker ready", _label(broker.get("ready")))
+    st.metric("Balance valid", _label(broker.get("balance_valid")))
+with col6:
+    st.metric("Available balance", _label(broker.get("balance")))
+    st.metric("Auth invalid", _label(broker.get("auth_invalid")))
+
+st.subheader("Position reconciliation")
+col7, col8 = st.columns(2)
+with col7:
+    st.metric("Completed", _label(reconciliation.get("completed")))
+with col8:
+    st.metric("Failed", _label(reconciliation.get("failed")))
+
+unprotected = reconciliation.get("unprotected_positions") or []
+if unprotected:
+    st.error("Unprotected broker positions detected")
+    st.json(unprotected)
+
+blockers = (trading or {}).get("blockers") or (readyz or {}).get("blockers") or []
+st.subheader("Current blockers")
+if blockers:
+    for blocker in blockers:
+        st.warning(str(blocker))
+else:
+    st.success("No reported blockers")
+
+with st.expander("Raw diagnostics"):
+    st.write(
+        {
+            "livez": {"http": livez_code, "data": livez, "error": livez_error},
+            "readyz": {"http": readyz_code, "data": readyz, "error": readyz_error},
+            "health_trading": {
+                "http": trading_code,
+                "data": trading,
+                "error": trading_error,
+            },
+        }
+    )
+
+st.divider()
+st.caption("Open this URL in Chrome on Android, then use Add to Home screen for app-like access.")


### PR DESCRIPTION
## Summary
- Adds a separate, read-only Streamlit dashboard under `dashboard/`
- Uses existing `/livez`, `/readyz`, and `/health/trading` endpoints
- Optimized for Android/mobile browser use
- Includes Streamlit Community Cloud deployment instructions
- Keeps order execution and bot controls isolated from the dashboard

## Production configuration
Use the current bot base URL:

```toml
BOT_API_URL = "http://15.206.3.6:8080"
```

Do not append `/admin`; the dashboard calls the health endpoints automatically.

## Security
- No broker credentials or environment secrets are displayed
- No order placement, cancellation, or state-changing controls are included
- Optional bearer-token header support is included for future reverse-proxy protection
- Current endpoint is plain HTTP on a public IP; HTTPS is recommended before broader exposure
