### PR TITLE
Fix missing pandas dependency in Streamlit console

### DIFF
--- a/dashboard/requirements.txt
+++ b/dashboard/requirements.txt
@@ -1,2 +1,3 @@
 streamlit>=1.37,<2
 requests>=2.31,<3
+pandas>=2.0,<3


### PR DESCRIPTION
The operations console imports pandas, but dashboard/requirements.txt did not install it. This caused the systemd service to exit immediately with status 1. Adds pandas to the dashboard environment dependencies.