### PR TITLE
Fix bracket exit state machine and trailing-stop safety

### DIFF
--- a/.github/workflows/live-exit-safety-ci.yml
+++ b/.github/workflows/live-exit-safety-ci.yml
@@ -1,0 +1,39 @@
+name: Live Exit Safety CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: Install project and test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e '.[dev]'
+      - name: Compile production source
+        run: python -m compileall -q src
+      - name: Focused live-money safety regression tests
+        run: |
+          python -m pytest -q \
+            tests/execution/test_live_exit_hardening.py \
+            tests/execution/test_bracket_exit_state_machine.py \
+            tests/execution/test_virtual_bracket_safety.py \
+            tests/execution/test_bracket_manager_reliability.py \
+            tests/execution/test_bracket_open_position_priority_and_protective_exit.py \
+            tests/execution/test_order_manager_trade_plan.py \
+            tests/strategies/test_trade_selector_logging_controls.py \
+            tests/test_execution_path_contract.py
+      - name: Full test suite
+        run: python -m pytest -q

--- a/src/nifty_scalper_bot/execution/__init__.py
+++ b/src/nifty_scalper_bot/execution/__init__.py
@@ -1,0 +1,34 @@
+"""Canonical execution package exports and live-money safety hardening.
+
+The public module paths remain unchanged. Import-time replacement keeps every
+existing caller on the single production execution path while applying the
+hardened implementations before any manager instance is constructed.
+"""
+
+from __future__ import annotations
+
+from importlib import import_module
+
+
+_adaptive_module = import_module(f"{__name__}.adaptive_trailing")
+from nifty_scalper_bot.execution.hardened_adaptive_trailing import (  # noqa: E402
+    HardenedAdaptiveTrailingController,
+)
+
+_adaptive_module.AdaptiveTrailingController = HardenedAdaptiveTrailingController
+
+_bracket_module = import_module(f"{__name__}.bracket_manager")
+from nifty_scalper_bot.execution.hardened_bracket_manager import (  # noqa: E402
+    HardenedBracketManager,
+)
+
+# Preserve all established import paths, including
+# ``from ...execution.bracket_manager import BracketManager``.
+_bracket_module.AdaptiveTrailingController = HardenedAdaptiveTrailingController
+_bracket_module.BracketManager = HardenedBracketManager
+
+
+__all__ = [
+    "HardenedAdaptiveTrailingController",
+    "HardenedBracketManager",
+]

--- a/src/nifty_scalper_bot/execution/hardened_adaptive_trailing.py
+++ b/src/nifty_scalper_bot/execution/hardened_adaptive_trailing.py
@@ -1,0 +1,203 @@
+"""Safety-hardened adaptive trailing controller.
+
+This module preserves the public controller contract while correcting live-money
+edge cases in activation, stale ATR degradation, tick rounding, and stop ratchets.
+"""
+
+from __future__ import annotations
+
+import math
+import time
+from typing import Any
+
+from nifty_scalper_bot.execution import adaptive_trailing as _legacy
+
+
+_LegacyAdaptiveTrailingController = _legacy.AdaptiveTrailingController
+
+
+class HardenedAdaptiveTrailingController(_LegacyAdaptiveTrailingController):
+    """Adaptive trailing controller with deterministic protective invariants."""
+
+    _TICK_SIZE = 0.05
+
+    def on_tick(self, tick: dict | None = None) -> None:
+        """Process one tick without ever weakening an established stop."""
+        if self._halted:
+            if time.monotonic() < self._halt_until:
+                return
+            self._halted = False
+            self.failed_modifications = 0
+            self._logger.info(
+                "Trailing stop backoff expired for %s — resuming",
+                self.symbol,
+            )
+
+        ltp: Any = None
+        if tick:
+            ltp = tick.get("ltp") or tick.get("last_price")
+        if not ltp:
+            ltp = self._get_ltp(self.symbol)
+        try:
+            ltp = float(ltp)
+        except (TypeError, ValueError):
+            return
+        if not math.isfinite(ltp) or ltp <= 0 or self.entry_price <= 0:
+            return
+
+        if self.side == "LONG":
+            self.highest_price = max(float(self.highest_price), ltp)
+        else:
+            self.lowest_price = min(float(self.lowest_price), ltp)
+
+        atr_snapshot = self._atr.get_atr(self.symbol, fallback=self.spec.trail_by)
+        atr_fresh = bool(
+            atr_snapshot is not None
+            and getattr(atr_snapshot, "is_fresh", lambda **_: True)(max_age_sec=60.0)
+        )
+        if atr_fresh:
+            try:
+                atr_value = float(atr_snapshot.value)
+            except (TypeError, ValueError, AttributeError):
+                atr_value = 0.0
+        else:
+            atr_value = 0.0
+
+        if not math.isfinite(atr_value) or atr_value <= 0:
+            # Continue protecting the position when ATR is temporarily stale.
+            configured = max(float(self.spec.trail_by or 0.0), self._TICK_SIZE)
+            trail_distance = min(configured, self.entry_price * 0.10)
+            trail_distance = max(trail_distance, self.entry_price * 0.005)
+            self._last_atr_value = trail_distance
+            self._logger.warning(
+                "TRAILING_ATR_DEGRADED symbol=%s fallback_distance=%.2f",
+                self.symbol,
+                trail_distance,
+                extra={
+                    "event": "TRAILING_ATR_DEGRADED",
+                    "symbol": self.symbol,
+                    "fallback_distance": trail_distance,
+                },
+            )
+        else:
+            self._last_atr_value = atr_value
+            trail_distance = self._calculate_trail_distance(atr_snapshot, ltp)
+
+        configured_activation = max(float(self.spec.activation or 0.0), 0.0)
+        volatility_activation = (
+            (self._last_atr_value * 0.2) / self.entry_price
+        ) * 100.0
+        activation_pct = max(configured_activation, volatility_activation, 0.10)
+        profit_pct = self._calculate_profit_pct(ltp)
+        if not self.trailing_active:
+            if profit_pct < activation_pct:
+                return
+            self.trailing_active = True
+            self._logger.info(
+                "TRAILING_STOP_ACTIVATED symbol=%s profit_pct=%.3f threshold_pct=%.3f",
+                self.symbol,
+                profit_pct,
+                activation_pct,
+                extra={
+                    "event": "TRAILING_STOP_ACTIVATED",
+                    "symbol": self.symbol,
+                    "profit_pct": profit_pct,
+                    "activation_pct": activation_pct,
+                },
+            )
+
+        new_sl = self._calculate_new_sl(ltp, trail_distance)
+        if not math.isfinite(new_sl) or new_sl <= 0:
+            return
+
+        # A protective stop must remain on the non-triggered side of the current
+        # market price. The bracket manager independently enforces the same rule.
+        if self.side == "LONG":
+            new_sl = min(new_sl, ltp - self._TICK_SIZE)
+        else:
+            new_sl = max(new_sl, ltp + self._TICK_SIZE)
+        if new_sl <= 0:
+            return
+
+        try:
+            if not self._should_update_sl(new_sl):
+                return
+            success = self._execute_sl_update(new_sl)
+            if success:
+                self.failed_modifications = 0
+                return
+            self.failed_modifications += 1
+            if self.failed_modifications >= 5:
+                self._emergency_halt("5 consecutive SL modification failures")
+        except Exception as exc:  # noqa: BLE001 - trailing must not stop hard SL checks
+            self._logger.error(
+                "TRAILING_TICK_FAILED symbol=%s error=%s",
+                self.symbol,
+                exc,
+                extra={
+                    "event": "TRAILING_TICK_FAILED",
+                    "symbol": self.symbol,
+                    "error_type": type(exc).__name__,
+                },
+            )
+
+    def _calculate_trail_distance(self, atr: Any, ltp: float) -> float:
+        distance = float(super()._calculate_trail_distance(atr, ltp))
+        if not math.isfinite(distance) or distance <= 0:
+            return max(self.entry_price * 0.005, self._TICK_SIZE)
+        # Prevent a malformed ATR snapshot from effectively disabling the stop.
+        return min(distance, max(ltp * 0.20, self._TICK_SIZE))
+
+    def _execute_sl_update(self, new_sl: float) -> bool:
+        """Commit a broker-compatible 0.05-tick ratchet update."""
+        old_sl = float(self.current_sl)
+        rounded = round(round(float(new_sl) / self._TICK_SIZE) * self._TICK_SIZE, 2)
+        if self.side == "LONG" and rounded <= old_sl:
+            return False
+        if self.side == "SHORT" and rounded >= old_sl:
+            return False
+        try:
+            result = self._modify(self.sl_order_id, rounded)
+        except Exception as exc:  # noqa: BLE001
+            self._logger.error(
+                "TRAILING_SL_MODIFY_FAILED symbol=%s error=%s",
+                self.symbol,
+                exc,
+                extra={
+                    "event": "TRAILING_SL_MODIFY_FAILED",
+                    "symbol": self.symbol,
+                    "error_type": type(exc).__name__,
+                },
+            )
+            return False
+        if not result:
+            return False
+
+        self.current_sl = rounded
+        self.last_update_time = time.time()
+        self.update_count += 1
+        if hasattr(self._journal, "set"):
+            self._journal.set(
+                self.sl_order_id,
+                {
+                    "current_sl": rounded,
+                    "last_update": self.last_update_time,
+                    "update_count": self.update_count,
+                },
+            )
+        self._logger.info(
+            "TRAILING_SL_UPDATED symbol=%s old_sl=%.2f new_sl=%.2f",
+            self.symbol,
+            old_sl,
+            rounded,
+            extra={
+                "event": "TRAILING_SL_UPDATED",
+                "symbol": self.symbol,
+                "old_sl": old_sl,
+                "new_sl": rounded,
+            },
+        )
+        return True
+
+
+__all__ = ["HardenedAdaptiveTrailingController"]

--- a/src/nifty_scalper_bot/execution/hardened_bracket_manager.py
+++ b/src/nifty_scalper_bot/execution/hardened_bracket_manager.py
@@ -1,0 +1,570 @@
+"""Deterministic live-money hardening for the virtual bracket manager.
+
+The legacy manager remains the implementation owner. This subclass tightens its
+state transitions, rescues stale protective orders without duplicate exposure,
+and installs a final unresolved-exit guard on the attached OrderManager.
+"""
+
+from __future__ import annotations
+
+from contextlib import suppress
+import functools
+import math
+import os
+import time
+from typing import Any, Mapping
+
+from nifty_scalper_bot.execution import bracket_manager as _legacy
+
+
+_LegacyBracketManager = _legacy.BracketManager
+
+
+class HardenedBracketManager(_LegacyBracketManager):
+    """Virtual bracket manager with latched exits and controlled rescue orders."""
+
+    _OPEN_ORDER_STATUSES = {
+        "OPEN",
+        "OPEN PENDING",
+        "PENDING",
+        "TRIGGER PENDING",
+        "VALIDATION PENDING",
+        "PUT ORDER REQ RECEIVED",
+        "MODIFY PENDING",
+        "AMO REQ RECEIVED",
+    }
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        # Initialize hardening state before the parent starts its watchdog thread.
+        self._exit_order_open_since: dict[str, float] = {}
+        self._exit_rescue_attempts: dict[str, int] = {}
+        self._exit_escalation_notifications: set[tuple[str, str]] = set()
+        self._exit_open_order_timeout_seconds = max(
+            0.5,
+            _legacy.parse_float_env(
+                os.getenv("EXIT_OPEN_ORDER_RESCUE_AFTER_SECONDS"), 3.0
+            ),
+        )
+        self._exit_cancel_confirm_timeout_seconds = max(
+            0.25,
+            _legacy.parse_float_env(
+                os.getenv("EXIT_CANCEL_CONFIRM_TIMEOUT_SECONDS"), 1.5
+            ),
+        )
+        self._exit_cancel_poll_interval_seconds = max(
+            0.05,
+            _legacy.parse_float_env(
+                os.getenv("EXIT_CANCEL_POLL_INTERVAL_SECONDS"), 0.10
+            ),
+        )
+        self._exit_rescue_max_attempts = max(
+            1,
+            _legacy.parse_int_env(os.getenv("EXIT_RESCUE_MAX_ATTEMPTS"), 2),
+        )
+        super().__init__(*args, **kwargs)
+        self._install_unresolved_exit_entry_guard()
+
+    # ------------------------------------------------------------------
+    # Order-entry freeze: exits continue, new entries fail closed.
+    # ------------------------------------------------------------------
+    def _install_unresolved_exit_entry_guard(self) -> None:
+        order_manager = getattr(self, "order_manager", None)
+        if order_manager is None or getattr(
+            order_manager, "_unresolved_exit_guard_installed", False
+        ):
+            return
+
+        def blocked_details() -> dict[str, Any] | None:
+            if not self.has_unresolved_exit():
+                return None
+            bracket_id = self.get_first_unresolved_exit_bracket_id()
+            details = {
+                "block_reason": "unresolved_exit_position",
+                "bracket_id": bracket_id,
+                "broker_attempted": False,
+                "retryable": False,
+            }
+            setattr(order_manager, "_last_order_decision", dict(details))
+            setter = getattr(order_manager, "set_last_skip_reason", None)
+            if callable(setter):
+                with suppress(Exception):
+                    setter("unresolved_exit_position")
+            _legacy.LOGGER.critical(
+                "ENTRY_BLOCKED_UNRESOLVED_EXIT bracket_id=%s",
+                bracket_id,
+                extra={
+                    "event": "ENTRY_BLOCKED_UNRESOLVED_EXIT",
+                    "bracket_id": bracket_id,
+                    "broker_attempted": False,
+                },
+            )
+            return details
+
+        def is_protective_call(method_name: str, kwargs: Mapping[str, Any]) -> bool:
+            if method_name != "place_order":
+                return False
+            if bool(kwargs.get("reduce_only")) or bool(kwargs.get("is_exit")):
+                return True
+            tag = str(kwargs.get("tag") or "").strip().upper()
+            protective_prefixes = (
+                "EXIT_",
+                "SL_",
+                "TP_",
+                "EOD_",
+                "PANIC",
+                "FLATTEN",
+                "SQUAREOFF",
+            )
+            return tag.startswith(protective_prefixes)
+
+        def rejection_for(method_name: str, details: dict[str, Any]) -> Any:
+            if method_name == "submit_trade_plan_result":
+                from nifty_scalper_bot.execution.order_manager import (
+                    TradePlanSubmitResult,
+                )
+
+                return TradePlanSubmitResult(
+                    accepted=False,
+                    order_id=None,
+                    reason="unresolved_exit_position",
+                    details=details,
+                    broker_attempted=False,
+                )
+            if method_name == "place_managed_order_result":
+                from nifty_scalper_bot.execution.order_manager import ManagedOrderResult
+
+                return ManagedOrderResult(
+                    accepted=False,
+                    order_id=None,
+                    reason="unresolved_exit_position",
+                    details=details,
+                    broker_attempted=False,
+                )
+            return None
+
+        for method_name in (
+            "submit_trade_plan_result",
+            "submit_trade_plan",
+            "place_managed_order_result",
+            "place_managed_order",
+            "place_order",
+        ):
+            original = getattr(order_manager, method_name, None)
+            if not callable(original):
+                continue
+
+            @functools.wraps(original)
+            def guarded(
+                *args: Any,
+                __original: Any = original,
+                __method_name: str = method_name,
+                **method_kwargs: Any,
+            ) -> Any:
+                if is_protective_call(__method_name, method_kwargs):
+                    return __original(*args, **method_kwargs)
+                details = blocked_details()
+                if details is not None:
+                    return rejection_for(__method_name, details)
+                return __original(*args, **method_kwargs)
+
+            setattr(order_manager, method_name, guarded)
+
+        setattr(order_manager, "_unresolved_exit_guard_installed", True)
+        _legacy.LOGGER.info(
+            "UNRESOLVED_EXIT_ENTRY_GUARD_INSTALLED",
+            extra={"event": "UNRESOLVED_EXIT_ENTRY_GUARD_INSTALLED"},
+        )
+
+    # ------------------------------------------------------------------
+    # Virtual trailing-stop integrity.
+    # ------------------------------------------------------------------
+    def register_virtual_bracket(self, *args: Any, **kwargs: Any) -> None:
+        _LegacyBracketManager.register_virtual_bracket(self, *args, **kwargs)
+        order_id = str(kwargs.get("order_id") or (args[0] if args else ""))
+        bracket = self.get_bracket(order_id) if order_id else None
+        if bracket is None:
+            return
+        with self._lock:
+            if not bracket.exit_pending and bracket.exit_state in {
+                _legacy.BracketExitLifecycle.OPEN_PENDING_FILL.value,
+                _legacy.BracketExitLifecycle.OPEN_ACTIVE.value,
+            }:
+                bracket.exit_order_id = None
+                bracket.pending_exit_order_id = None
+                bracket.escalated_at = None
+                bracket.last_exit_error = None
+                bracket.next_exit_attempt_at = None
+            controller = self._trailing_controllers.get(bracket.entry_order_id)
+            if controller is not None:
+                controller.current_sl = float(bracket.sl_trigger_price)
+                controller.entry_price = float(bracket.entry_price)
+                controller.highest_price = float(bracket.entry_price)
+                controller.lowest_price = float(bracket.entry_price)
+
+    def confirm_entry_fill(self, order_id: str, fill_price: float) -> None:
+        _LegacyBracketManager.confirm_entry_fill(self, order_id, fill_price)
+        bracket = self.get_bracket(order_id)
+        if bracket is None:
+            return
+        with self._lock:
+            controller = self._trailing_controllers.get(order_id)
+            if controller is not None:
+                controller.entry_price = float(bracket.entry_price)
+                controller.current_sl = float(bracket.sl_trigger_price)
+                controller.highest_price = float(bracket.entry_price)
+                controller.lowest_price = float(bracket.entry_price)
+
+    def _virtual_modify_sl(self, order_id: str, price: float) -> bool:
+        """Apply only finite, market-side, monotonic virtual stop updates."""
+        try:
+            proposed = float(price)
+        except (TypeError, ValueError):
+            return False
+        if not math.isfinite(proposed) or proposed <= 0:
+            return False
+        proposed = _legacy._round_to_tick(proposed)
+
+        target = None
+        with self._lock:
+            for bracket in self._brackets.values():
+                if bracket.virtual_sl_id == order_id:
+                    target = bracket
+                    break
+            if target is None or target.exit_pending or target.exit_executed:
+                return False
+            current = float(target.sl_trigger_price)
+            ltp = float(target.last_ltp or 0.0)
+            if target.side == "BUY":
+                if proposed <= current or (ltp > 0 and proposed >= ltp):
+                    return False
+            else:
+                if proposed >= current or (ltp > 0 and proposed <= ltp):
+                    return False
+            target.sl_trigger_price = proposed
+            target.updated_at = time.time()
+
+        with suppress(Exception):
+            self.save_state()
+        _legacy.LOGGER.info(
+            "VIRTUAL_TRAILING_SL_RATCHET symbol=%s old_sl=%.2f new_sl=%.2f ltp=%.2f",
+            target.symbol,
+            current,
+            proposed,
+            ltp,
+            extra={
+                "event": "VIRTUAL_TRAILING_SL_RATCHET",
+                "symbol": target.symbol,
+                "old_sl": current,
+                "new_sl": proposed,
+                "ltp": ltp,
+            },
+        )
+        return True
+
+    # ------------------------------------------------------------------
+    # Protective exit state machine and stale-order rescue.
+    # ------------------------------------------------------------------
+    def _process_exit_state(
+        self,
+        bracket: Any,
+        action: Mapping[str, Any],
+        *,
+        now: float,
+    ) -> None:
+        symbol = _legacy.normalize_symbol(bracket.symbol)
+        qty = max(
+            0,
+            min(
+                int(action.get("qty") or bracket.remaining_quantity),
+                int(bracket.remaining_quantity),
+            ),
+        )
+        if not symbol or qty <= 0:
+            return
+
+        with self._lock:
+            if (
+                bracket.exit_state
+                == _legacy.BracketExitLifecycle.EXIT_FAILED_ESCALATED.value
+                and not self._exit_continue_retry_after_escalation
+            ):
+                self._log_exit_pending_summary_locked(bracket, now)
+                return
+            order_id = bracket.exit_order_id or bracket.pending_exit_order_id
+
+        if order_id:
+            status_payload = self._get_broker_order_status(str(order_id))
+            status = str((status_payload or {}).get("status") or "").strip().upper()
+            if status in _legacy._FILLED_STATUSES:
+                self._reconcile_exit_state(bracket, requested_by="hardening_filled")
+                return
+            if status in _legacy._CANCELLED_STATUSES:
+                with self._lock:
+                    bracket.exit_order_id = None
+                    bracket.pending_exit_order_id = None
+                self._submit_rescue_exit(bracket, qty=qty, prior_order_id=str(order_id))
+                return
+
+            base = float(
+                bracket.last_exit_attempt_at
+                or bracket.exit_triggered_at
+                or self._exit_order_open_since.get(str(order_id), now)
+            )
+            self._exit_order_open_since.setdefault(str(order_id), base)
+            open_age = max(0.0, now - self._exit_order_open_since[str(order_id)])
+            if status in self._OPEN_ORDER_STATUSES or not status:
+                if open_age >= self._exit_open_order_timeout_seconds:
+                    self._rescue_stale_exit_order(
+                        bracket,
+                        order_id=str(order_id),
+                        qty=qty,
+                        status=status or "UNKNOWN",
+                    )
+                    return
+
+            if self._reconcile_exit_state(bracket, requested_by="existing_exit_order"):
+                return
+            with self._lock:
+                # Reconciliation may have escalated. Never overwrite the terminal
+                # unresolved state merely because an old broker order id exists.
+                if (
+                    bracket.exit_state
+                    == _legacy.BracketExitLifecycle.EXIT_FAILED_ESCALATED.value
+                ):
+                    self._log_exit_pending_summary_locked(bracket, now)
+                    return
+                bracket.exit_state = (
+                    _legacy.BracketExitLifecycle.EXIT_ORDER_SUBMITTED.value
+                )
+                bracket.entry_status = bracket.exit_state
+                self._log_exit_pending_summary_locked(bracket, now)
+            return
+
+        if self._reconcile_exit_state(bracket, requested_by="pre_submit_hardened"):
+            return
+        with self._lock:
+            if (
+                bracket.exit_state
+                == _legacy.BracketExitLifecycle.EXIT_FAILED_ESCALATED.value
+                and not self._exit_continue_retry_after_escalation
+            ):
+                self._log_exit_pending_summary_locked(bracket, now)
+                return
+        _LegacyBracketManager._process_exit_state(self, bracket, action, now=now)
+
+    def _rescue_stale_exit_order(
+        self,
+        bracket: Any,
+        *,
+        order_id: str,
+        qty: int,
+        status: str,
+    ) -> None:
+        with self._lock:
+            if bracket.exit_in_progress:
+                return
+            attempts = self._exit_rescue_attempts.get(bracket.bracket_id, 0)
+            if attempts >= self._exit_rescue_max_attempts:
+                self._escalate_exit_locked(bracket, "rescue_attempts_exhausted")
+                return
+            bracket.exit_in_progress = True
+            self._exit_rescue_attempts[bracket.bracket_id] = attempts + 1
+
+        _legacy.LOGGER.critical(
+            "EXIT_STALE_ORDER_RESCUE bracket_id=%s order_id=%s status=%s qty=%s rescue_attempt=%s",
+            bracket.bracket_id,
+            order_id,
+            status,
+            qty,
+            attempts + 1,
+            extra={
+                "event": "EXIT_STALE_ORDER_RESCUE",
+                "bracket_id": bracket.bracket_id,
+                "order_id": order_id,
+                "status": status,
+                "qty": qty,
+                "rescue_attempt": attempts + 1,
+            },
+        )
+
+        cancel_requested = self._cancel_exit_order(order_id)
+        terminal = self._wait_for_cancel_or_fill(order_id) if cancel_requested else "unconfirmed"
+        if terminal == "filled" or self._safe_position_flat(bracket.symbol):
+            with self._lock:
+                bracket.exit_in_progress = False
+            self._close_bracket(bracket, close_source="rescue_reconciled_flat")
+            return
+        if terminal != "cancelled":
+            with self._lock:
+                bracket.exit_in_progress = False
+                bracket.last_exit_error = "stale_exit_cancel_unconfirmed"
+                self._escalate_exit_locked(bracket, "stale_exit_cancel_unconfirmed")
+            return
+
+        with self._lock:
+            bracket.exit_in_progress = False
+            bracket.exit_order_id = None
+            bracket.pending_exit_order_id = None
+            bracket.last_exit_error = None
+        self._submit_rescue_exit(bracket, qty=qty, prior_order_id=order_id)
+
+    def _submit_rescue_exit(
+        self,
+        bracket: Any,
+        *,
+        qty: int,
+        prior_order_id: str,
+    ) -> None:
+        if self._safe_position_flat(bracket.symbol):
+            self._close_bracket(bracket, close_source="rescue_pre_submit_flat")
+            return
+
+        with self._lock:
+            bracket.exit_in_progress = True
+            bracket.exit_attempt_count += 1
+            bracket.last_exit_attempt_at = time.time()
+            attempt = bracket.exit_attempt_count
+            bracket.exit_state = _legacy.BracketExitLifecycle.EXIT_ORDER_PENDING.value
+            bracket.entry_status = bracket.exit_state
+
+        result = self.submit_exit_order(
+            symbol=_legacy.normalize_symbol(bracket.symbol),
+            qty=qty,
+            reason="EXIT_ESCALATED_RESCUE",
+            bracket_id=bracket.bracket_id,
+            preferred_order_type="MARKET",
+        )
+
+        with self._lock:
+            bracket.exit_in_progress = False
+            if result.accepted and result.order_id:
+                new_order_id = str(result.order_id)
+                bracket.exit_order_id = new_order_id
+                bracket.pending_exit_order_id = new_order_id
+                bracket.exit_state = (
+                    _legacy.BracketExitLifecycle.EXIT_ORDER_SUBMITTED.value
+                )
+                bracket.entry_status = bracket.exit_state
+                bracket.last_exit_error = None
+                bracket.next_exit_attempt_at = None
+                bracket.escalated_at = None
+                self._exit_order_open_since[new_order_id] = time.time()
+                _legacy.LOGGER.critical(
+                    "EXIT_RESCUE_ORDER_SUBMITTED bracket_id=%s prior_order_id=%s new_order_id=%s attempt=%s qty=%s",
+                    bracket.bracket_id,
+                    prior_order_id,
+                    new_order_id,
+                    attempt,
+                    qty,
+                    extra={
+                        "event": "EXIT_RESCUE_ORDER_SUBMITTED",
+                        "bracket_id": bracket.bracket_id,
+                        "prior_order_id": prior_order_id,
+                        "new_order_id": new_order_id,
+                        "attempt": attempt,
+                        "qty": qty,
+                    },
+                )
+                return
+
+            bracket.exit_order_id = None
+            bracket.pending_exit_order_id = None
+            bracket.last_exit_error = result.error_message or result.status
+            if (
+                result.retryable
+                and self._exit_retry_enabled
+                and self._exit_rescue_attempts.get(bracket.bracket_id, 0)
+                < self._exit_rescue_max_attempts
+            ):
+                bracket.exit_state = (
+                    _legacy.BracketExitLifecycle.EXIT_REJECTED_RETRYABLE.value
+                )
+                bracket.entry_status = bracket.exit_state
+                bracket.next_exit_attempt_at = time.time() + self._retry_delay_for_attempt(
+                    max(attempt, 1)
+                )
+            else:
+                self._escalate_exit_locked(bracket, "rescue_submit_failed")
+
+    def _cancel_exit_order(self, order_id: str) -> bool:
+        targets = (
+            getattr(self, "order_manager", None),
+            getattr(getattr(self, "order_manager", None), "_broker", None),
+        )
+        last_error: Exception | None = None
+        for target in targets:
+            cancel = getattr(target, "cancel_order", None)
+            if not callable(cancel):
+                continue
+            calls = (
+                lambda: cancel(order_id),
+                lambda: cancel(order_id=order_id),
+                lambda: cancel("regular", order_id),
+                lambda: cancel(variety="regular", order_id=order_id),
+            )
+            for invoke in calls:
+                try:
+                    invoke()
+                    return True
+                except TypeError as exc:
+                    last_error = exc
+                    continue
+                except Exception as exc:  # noqa: BLE001
+                    last_error = exc
+                    break
+        _legacy.LOGGER.error(
+            "EXIT_CANCEL_REQUEST_FAILED order_id=%s error=%s",
+            order_id,
+            last_error,
+            extra={
+                "event": "EXIT_CANCEL_REQUEST_FAILED",
+                "order_id": order_id,
+                "error_type": type(last_error).__name__ if last_error else "missing_cancel_api",
+            },
+        )
+        return False
+
+    def _wait_for_cancel_or_fill(self, order_id: str) -> str:
+        deadline = time.monotonic() + self._exit_cancel_confirm_timeout_seconds
+        while time.monotonic() <= deadline:
+            status_payload = self._get_broker_order_status(order_id)
+            status = str((status_payload or {}).get("status") or "").strip().upper()
+            if status in _legacy._FILLED_STATUSES:
+                return "filled"
+            if status in _legacy._CANCELLED_STATUSES:
+                return "cancelled"
+            time.sleep(self._exit_cancel_poll_interval_seconds)
+        return "unconfirmed"
+
+    def _safe_position_flat(self, symbol: str) -> bool:
+        try:
+            return bool(self._position_flat_for_symbol(symbol))
+        except Exception as exc:  # noqa: BLE001
+            _legacy.LOGGER.error(
+                "EXIT_POSITION_RECONCILE_FAILED symbol=%s error=%s",
+                symbol,
+                exc,
+                extra={
+                    "event": "EXIT_POSITION_RECONCILE_FAILED",
+                    "symbol": symbol,
+                    "error_type": type(exc).__name__,
+                },
+            )
+            return False
+
+    def _escalate_exit_locked(self, bracket: Any, reason: str) -> None:
+        order_key = str(bracket.exit_order_id or bracket.pending_exit_order_id or "none")
+        key = (str(bracket.bracket_id), order_key)
+        if bracket.escalated_at is not None or key in self._exit_escalation_notifications:
+            bracket.exit_pending = True
+            bracket.exit_state = (
+                _legacy.BracketExitLifecycle.EXIT_FAILED_ESCALATED.value
+            )
+            bracket.entry_status = bracket.exit_state
+            self._exit_escalation_notifications.add(key)
+            return
+        _LegacyBracketManager._escalate_exit_locked(self, bracket, reason)
+        self._exit_escalation_notifications.add(key)
+
+
+__all__ = ["HardenedBracketManager"]

--- a/tests/execution/test_live_exit_hardening.py
+++ b/tests/execution/test_live_exit_hardening.py
@@ -1,0 +1,329 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import time
+from types import SimpleNamespace
+from typing import Any
+
+from nifty_scalper_bot.execution.adaptive_trailing import (
+    AdaptiveTrailingController,
+    TrailingSpec,
+)
+from nifty_scalper_bot.execution.bracket_manager import (
+    BracketExitLifecycle,
+    BracketManager,
+)
+from nifty_scalper_bot.execution.hardened_adaptive_trailing import (
+    HardenedAdaptiveTrailingController,
+)
+from nifty_scalper_bot.execution.hardened_bracket_manager import (
+    HardenedBracketManager,
+)
+
+
+SYMBOL = "NFO:NIFTY2662324050PE"
+
+
+class _Broker:
+    def __init__(self, *, cancel_confirms: bool = True) -> None:
+        self.cancel_confirms = cancel_confirms
+        self.statuses: dict[str, str] = {"old-exit": "OPEN PENDING"}
+        self.positions: list[dict[str, Any]] = [
+            {"symbol": SYMBOL, "quantity": 65}
+        ]
+        self.cancel_calls: list[str] = []
+
+    def get_order_status(self, order_id: str) -> dict[str, Any]:
+        return {"status": self.statuses.get(order_id, "")}
+
+    def get_positions(self) -> list[dict[str, Any]]:
+        return list(self.positions)
+
+    def cancel_order(self, order_id: str, *args: Any, **kwargs: Any) -> bool:
+        self.cancel_calls.append(str(order_id))
+        if self.cancel_confirms:
+            self.statuses[str(order_id)] = "CANCELLED"
+        return True
+
+
+class _OrderManager:
+    def __init__(self, broker: _Broker) -> None:
+        self._broker = broker
+        self._last_order_decision: dict[str, Any] = {}
+        self.place_calls: list[dict[str, Any]] = []
+        self.submit_plan_calls = 0
+        self._next_id = 1
+
+    def place_order(self, **kwargs: Any) -> str:
+        self.place_calls.append(dict(kwargs))
+        order_id = f"rescue-{self._next_id}"
+        self._next_id += 1
+        self._broker.statuses[order_id] = "OPEN"
+        return order_id
+
+    def cancel_order(self, order_id: str, *args: Any, **kwargs: Any) -> bool:
+        return self._broker.cancel_order(order_id, *args, **kwargs)
+
+    def submit_trade_plan_result(self, _plan: Any) -> str:
+        self.submit_plan_calls += 1
+        return "original-called"
+
+    def submit_trade_plan(self, _plan: Any) -> str:
+        self.submit_plan_calls += 1
+        return "original-called"
+
+    def place_managed_order_result(self, **_kwargs: Any) -> str:
+        return "original-called"
+
+    def place_managed_order(self, **_kwargs: Any) -> str:
+        return "original-called"
+
+    def set_last_skip_reason(self, reason: str) -> None:
+        self.last_skip_reason = reason
+
+
+class _DummyController:
+    def __init__(self) -> None:
+        self.entry_price = 0.0
+        self.current_sl = 0.0
+        self.highest_price = 0.0
+        self.lowest_price = 0.0
+
+    def on_tick(self, _tick: Any) -> None:
+        return None
+
+
+def _manager(*, cancel_confirms: bool = True) -> tuple[BracketManager, _OrderManager, _Broker]:
+    broker = _Broker(cancel_confirms=cancel_confirms)
+    order_manager = _OrderManager(broker)
+    manager = BracketManager(order_manager=order_manager)
+    manager._running = False
+    manager._watchdog_thread.join(timeout=1.0)
+    manager._exit_open_order_timeout_seconds = 0.01
+    manager._exit_cancel_confirm_timeout_seconds = 0.01
+    manager._exit_cancel_poll_interval_seconds = 0.001
+    manager.register_virtual_bracket(
+        order_id="entry-1",
+        symbol=SYMBOL,
+        side="BUY",
+        qty=65,
+        price=150.0,
+        sl=140.0,
+        tp=175.0,
+        activate_immediately=True,
+    )
+    return manager, order_manager, broker
+
+
+def _make_stale_exit(manager: BracketManager) -> Any:
+    bracket = manager.get_bracket("entry-1")
+    assert bracket is not None
+    bracket.exit_pending = True
+    bracket.exit_reason = "HARD_SL_BREACH"
+    bracket.exit_state = BracketExitLifecycle.EXIT_ORDER_SUBMITTED.value
+    bracket.entry_status = bracket.exit_state
+    bracket.exit_order_id = "old-exit"
+    bracket.pending_exit_order_id = "old-exit"
+    bracket.exit_attempt_count = 1
+    bracket.exit_triggered_at = time.time() - 60.0
+    bracket.last_exit_attempt_at = time.time() - 60.0
+    return bracket
+
+
+def test_canonical_imports_use_hardened_implementations() -> None:
+    assert BracketManager is HardenedBracketManager
+    assert AdaptiveTrailingController is HardenedAdaptiveTrailingController
+
+
+def test_stale_open_protective_exit_is_cancelled_then_replaced_once() -> None:
+    manager, order_manager, broker = _manager()
+    bracket = _make_stale_exit(manager)
+
+    manager._process_exit_state(
+        bracket,
+        {"qty": 65, "reason": "HARD_SL_BREACH"},
+        now=time.time(),
+    )
+
+    assert broker.cancel_calls == ["old-exit"]
+    assert len(order_manager.place_calls) == 1
+    rescue = order_manager.place_calls[0]
+    assert rescue["order_type"] == "MARKET"
+    assert rescue["check_risk"] is False
+    assert str(rescue["tag"]).startswith("exit_")
+    assert bracket.exit_order_id == "rescue-1"
+    assert bracket.exit_state == BracketExitLifecycle.EXIT_ORDER_SUBMITTED.value
+    assert bracket.exit_attempt_count == 2
+
+    # A fresh replacement order is reconciled, not duplicated.
+    manager._process_exit_state(
+        bracket,
+        {"qty": 65, "reason": "HARD_SL_BREACH"},
+        now=time.time(),
+    )
+    assert len(order_manager.place_calls) == 1
+
+
+def test_cancel_unconfirmed_escalates_once_and_state_remains_latched() -> None:
+    manager, _order_manager, _broker = _manager(cancel_confirms=False)
+    bracket = _make_stale_exit(manager)
+    events: list[tuple[str, dict[str, Any]]] = []
+    manager.set_notifier(lambda event, payload: events.append((event, dict(payload))))
+
+    manager._process_exit_state(
+        bracket,
+        {"qty": 65, "reason": "HARD_SL_BREACH"},
+        now=time.time(),
+    )
+    manager._process_exit_state(
+        bracket,
+        {"qty": 65, "reason": "HARD_SL_BREACH"},
+        now=time.time() + 1.0,
+    )
+
+    assert bracket.exit_state == BracketExitLifecycle.EXIT_FAILED_ESCALATED.value
+    assert bracket.exit_pending is True
+    assert [event for event, _ in events].count("EXIT_ESCALATED") == 1
+
+
+def test_unresolved_exit_blocks_entries_but_never_blocks_protective_exit() -> None:
+    manager, order_manager, _broker = _manager()
+    _make_stale_exit(manager)
+
+    result = order_manager.submit_trade_plan_result(SimpleNamespace(symbol=SYMBOL))
+    assert result.accepted is False
+    assert result.reason == "unresolved_exit_position"
+    assert result.broker_attempted is False
+    assert order_manager.submit_plan_calls == 0
+
+    normal = order_manager.place_order(
+        symbol=SYMBOL,
+        side="BUY",
+        quantity=65,
+        order_type="MARKET",
+        tag="runner_entry",
+    )
+    assert normal is None
+    assert len(order_manager.place_calls) == 0
+
+    protective = order_manager.place_order(
+        symbol=SYMBOL,
+        side="SELL",
+        quantity=65,
+        order_type="MARKET",
+        tag="exit_HAR_entry1",
+        check_risk=False,
+    )
+    assert protective == "rescue-1"
+    assert len(order_manager.place_calls) == 1
+
+
+def test_virtual_trailing_stop_is_monotonic_and_stays_below_market_for_long() -> None:
+    manager, _order_manager, _broker = _manager()
+    bracket = manager.get_bracket("entry-1")
+    assert bracket is not None
+    bracket.sl_trigger_price = 140.0
+    bracket.last_ltp = 160.0
+
+    assert manager._virtual_modify_sl(bracket.virtual_sl_id, 150.03) is True
+    assert bracket.sl_trigger_price == 150.05
+    assert manager._virtual_modify_sl(bracket.virtual_sl_id, 149.0) is False
+    assert manager._virtual_modify_sl(bracket.virtual_sl_id, 160.0) is False
+    assert bracket.sl_trigger_price == 150.05
+
+
+def test_actual_fill_resynchronizes_attached_trailing_controller() -> None:
+    broker = _Broker()
+    order_manager = _OrderManager(broker)
+    manager = BracketManager(order_manager=order_manager)
+    manager._running = False
+    manager._watchdog_thread.join(timeout=1.0)
+    controller = _DummyController()
+    manager.attach_trailing_controller_factory(lambda _state: controller)
+    manager.register_virtual_bracket(
+        order_id="entry-fill",
+        symbol=SYMBOL,
+        side="BUY",
+        qty=65,
+        price=100.0,
+        sl=90.0,
+        tp=120.0,
+        activate_immediately=False,
+    )
+
+    manager.confirm_entry_fill("entry-fill", 102.0)
+    bracket = manager.get_bracket("entry-fill")
+    assert bracket is not None
+    assert controller.entry_price == bracket.entry_price == 102.0
+    assert controller.current_sl == bracket.sl_trigger_price
+    assert controller.highest_price == 102.0
+    assert controller.lowest_price == 102.0
+
+
+@dataclass
+class _AtrSnapshot:
+    value: float
+    fresh: bool = True
+
+    def is_fresh(self, max_age_sec: float) -> bool:
+        assert max_age_sec == 60.0
+        return self.fresh
+
+
+class _AtrProvider:
+    def __init__(self, snapshot: _AtrSnapshot) -> None:
+        self.snapshot = snapshot
+
+    def get_atr(self, _symbol: str, fallback: float) -> _AtrSnapshot:
+        assert fallback > 0
+        return self.snapshot
+
+
+def test_adaptive_trailing_honours_configured_activation_and_tick_size() -> None:
+    updates: list[float] = []
+    controller = AdaptiveTrailingController(
+        symbol=SYMBOL,
+        side="LONG",
+        entry=100.0,
+        sl_order_id="vsl-1",
+        variety="virtual",
+        spec=TrailingSpec(trail_by=2.0, step=0.05, activation=1.0),
+        get_ltp=lambda _symbol: 100.0,
+        modify_order=lambda _order_id, price: updates.append(price) or True,
+        atr_provider=_AtrProvider(_AtrSnapshot(1.0)),
+        journal=SimpleNamespace(set=lambda *_args, **_kwargs: None),
+        atr_multiplier=1.0,
+    )
+    controller.current_sl = 90.0
+
+    controller.on_tick({"ltp": 100.5})
+    assert controller.trailing_active is False
+    assert updates == []
+
+    controller.on_tick({"ltp": 101.2})
+    assert controller.trailing_active is True
+    assert updates
+    assert round(updates[-1] / 0.05) * 0.05 == updates[-1]
+
+
+def test_stale_atr_degrades_to_bounded_fallback_instead_of_disabling_trailing() -> None:
+    updates: list[float] = []
+    controller = AdaptiveTrailingController(
+        symbol=SYMBOL,
+        side="LONG",
+        entry=100.0,
+        sl_order_id="vsl-2",
+        variety="virtual",
+        spec=TrailingSpec(trail_by=20.0, step=0.05, activation=0.3),
+        get_ltp=lambda _symbol: 102.0,
+        modify_order=lambda _order_id, price: updates.append(price) or True,
+        atr_provider=_AtrProvider(_AtrSnapshot(1.0, fresh=False)),
+        journal=SimpleNamespace(set=lambda *_args, **_kwargs: None),
+        atr_multiplier=2.0,
+    )
+    controller.current_sl = 80.0
+    controller.on_tick({"ltp": 102.0})
+
+    assert controller.trailing_active is True
+    assert updates
+    assert 80.0 < updates[-1] < 102.0


### PR DESCRIPTION
## Summary
- Latch terminal bracket states correctly.
- Add cancel-confirm-replace handling for stale pending protective orders.
- Prevent duplicate replacement submissions.
- Block new entry submissions while an exit is unresolved, while preserving exit calls.
- Harden trailing-stop activation, ratcheting, fill resynchronization, ATR fallback, and tick rounding.
- Add focused regression tests and a full CI workflow.

## Validation
The PR workflow runs source compilation, focused execution tests, existing bracket/order/candidate-selector tests, architecture checks, and the full pytest suite.