### PR TITLE
fix: record margin success on risk-balance fallback (clears permanent balance_stale block)

### DIFF
--- a/src/nifty_scalper_bot/execution/order_manager.py
+++ b/src/nifty_scalper_bot/execution/order_manager.py
@@ -1239,7 +1239,7 @@ class OrderManager:
                 extra={"event": "MARGIN_PRIME_FAILED", "reason": reason, "error_type": type(exc).__name__},
             )
             return False
-        ok = bool(available is not None and available > 0 and source in {"mdm", "margin_cache_used"})
+        ok = bool(available is not None and available > 0 and source in {"mdm", "margin_cache_used", "risk"})
         self._logger.info(
             "MARGIN_PRIMED reason=%s ok=%s source=%s available=%s",
             reason, ok, source, available,
@@ -7660,6 +7660,13 @@ class OrderManager:
             with suppress(Exception):
                 balance = float(getattr(risk_manager, "current_balance", 0.0))
                 if math.isfinite(balance) and balance > 0:
+                    # A positive balance from the risk manager is a valid margin
+                    # reading. Record it as a success so broker-health freshness is
+                    # established; otherwise, when the MDM margin snapshot isn't
+                    # primed yet at startup, _last_margin_success_ts stays None
+                    # forever -> balance_stale=True / margin_age_s=None permanently
+                    # blocks live orders even though the broker is healthy.
+                    self._record_margin_refresh_success(balance, "risk")
                     return balance, "risk"
         return None, "unknown"
 

--- a/tests/execution/test_order_manager_trade_plan.py
+++ b/tests/execution/test_order_manager_trade_plan.py
@@ -393,3 +393,47 @@ def test_kill_switch_blocks_within_cooldown_when_auto_reset_disabled(monkeypatch
     om._kill_switch_allow_auto_reset = False
     om._kill_switch_auto_reset_seconds = 1
     assert OrderManager.is_kill_switch_active(om) is True
+
+
+def test_risk_fallback_records_margin_success_clears_stale() -> None:
+    # Root cause of BROKER_HEALTH_LIVE_ORDERS_BLOCKED with balance_stale=True /
+    # margin_age_s=None: when the MDM margin snapshot isn't primed yet (returns
+    # None, no error), the risk_manager fallback returned a balance WITHOUT
+    # recording success, so _last_margin_success_ts stayed None forever and live
+    # orders were permanently blocked though the broker was healthy. A positive
+    # risk balance must record success.
+    om = OrderManager.__new__(OrderManager)
+    om._data_hub = SimpleNamespace(
+        refresh_margin_snapshot=lambda: None,
+        get_available_balance=lambda: None,  # MDM not primed yet
+    )
+    om._market_data = None
+    om._risk_manager = SimpleNamespace(current_balance=22792.35)
+    om._logger = SimpleNamespace(error=lambda *a, **k: None, info=lambda *a, **k: None, debug=lambda *a, **k: None)
+    om._last_margin_success_ts = None
+    om._last_margin_refresh_ts = None
+    om._last_margin_available_balance = None
+    om._last_margin_balance_source = None
+    om._last_margin_error_type = None
+    om._last_margin_error = None
+    om._margin_circuit_open = False
+    om._margin_circuit_until_ts = None
+
+    available, source = OrderManager._resolve_available_margin_raw(om)
+    assert available == 22792.35 and source == "risk"
+    assert om._last_margin_success_ts is not None, "risk balance must record margin success"
+
+    # broker-health snapshot must now report fresh, not stale -> live orders allowed
+    om._broker = SimpleNamespace(is_connected=True)
+    om._margin_cache_max_age_seconds = 120
+    om._allow_entry_with_stale_margin = False
+    om._last_order_api_error = None
+    om._last_order_api_error_type = None
+    om._last_broker_health_emit_ts = 0.0
+    om._last_broker_health_effect = "none"
+    om._last_broker_health_circuit_state = False
+    om._emit_broker_health_status = lambda **k: None
+    snap = OrderManager.get_broker_health_snapshot(om)
+    assert snap["balance_stale"] is False
+    assert snap["last_margin_success_age_s"] is not None
+    assert snap["trading_allowed_effect"] != "live_orders_blocked"


### PR DESCRIPTION
## Symptom
`BROKER_HEALTH_LIVE_ORDERS_BLOCKED` with `broker_connected=True, margin_api_available=True, balance_stale=True, margin_age_s=None`. Approved signals never reach live order placement.

## Audit vs the suggested theory
The "prime_margin not called" theory is **not** the cause — `prime_margin` IS called (in `set_broker_client`) and a self-heal re-fetch already exists. The real root cause is deeper:

`_resolve_available_margin_raw` only recorded a margin **success** on the **MDM path** (`refresh_margin_snapshot` → `get_available_balance > 0`). Its **risk_manager fallback returned a valid positive balance WITHOUT calling `_record_margin_refresh_success`**. So when the MDM margin snapshot isn't primed yet at startup (returns None, raises no error), neither success nor failure is recorded → `_last_margin_success_ts` stays `None` → `margin_age_s=None` → `balance_stale=True` **forever**, and the self-heal can't help because re-running the same MDM path keeps returning nothing. Live orders permanently blocked though the broker is healthy.

## Fix (minimal, root cause)
When the risk_manager fallback yields a finite positive balance, record it via `_record_margin_refresh_success(balance, "risk")`. That sets the success timestamp → `balance_stale` clears → gate allows live orders. A genuine fetch failure still records an error and still blocks (no safety bypass). `prime_margin` ok now also recognizes source `risk`.

## Validation
Verified directly: risk balance 22792.35 → success_ts set → `balance_stale=False` → `trading_allowed_effect != live_orders_blocked`. Test added (discrimination-checked via direct logic call due to known pytest module-cache artifact); 16 existing margin/broker tests green; **full suite 2395 passed**.

**ACTION:** redeploy latest main + restart; startup should then show `MARGIN_PRIMED ok=True` and broker health `balance_stale=False margin_age_s=<number>`.