### PR TITLE
fix: escalation forces a MARKET exit to flatten a stuck position (not just freeze)

### DIFF
--- a/src/nifty_scalper_bot/execution/bracket_manager.py
+++ b/src/nifty_scalper_bot/execution/bracket_manager.py
@@ -224,6 +224,9 @@ class BracketState:
     close_source: str | None = None
     exit_price: float | None = None
     escalated_at: float | None = None
+    # True once the forced MARKET exit on escalation has been fired, so it happens
+    # exactly once per bracket (not every reconcile cycle).
+    _market_escalation_fired: bool = False
     _atr_warning_logged: bool = False
 
     @property
@@ -443,6 +446,7 @@ class BracketManager:
         self._exit_flat_confirmation_required = os.getenv("EXIT_FLAT_CONFIRMATION_REQUIRED", "true").strip().lower() in {"1", "true", "yes", "on"}
         self._exit_unresolved_escalation_seconds = max(1.0, parse_float_env(os.getenv("EXIT_UNRESOLVED_ESCALATION_SECONDS"), 15.0))
         self._exit_continue_retry_after_escalation = os.getenv("EXIT_CONTINUE_RETRY_AFTER_ESCALATION", "false").strip().lower() in {"1", "true", "yes", "on"}
+        self._exit_force_market_on_escalation = os.getenv("EXIT_FORCE_MARKET_ON_ESCALATION", "true").strip().lower() in {"1", "true", "yes", "on"}
         self._exit_protective_order_mode = str(os.getenv("EXIT_PROTECTIVE_ORDER_MODE", "MARKET") or "MARKET").strip().upper()
         self._exit_marketable_limit_slippage_ticks = max(0, parse_int_env(os.getenv("EXIT_MARKETABLE_LIMIT_SLIPPAGE_TICKS"), 5))
         self._exit_marketable_limit_max_slippage_pct = max(0.0, parse_float_env(os.getenv("EXIT_MARKETABLE_LIMIT_MAX_SLIPPAGE_PCT"), 2.0))
@@ -1678,9 +1682,73 @@ class BracketManager:
                 "remaining_qty": bracket.remaining_quantity,
                 "attempts": bracket.exit_attempt_count,
                 "last_error": bracket.last_exit_error,
-                "message": "⚠️ Exit unresolved. New entries frozen.",
+                "message": "⚠️ Exit unresolved. Forcing MARKET exit.",
             },
         )
+        # Escalation must actually FLATTEN the position, not just freeze. A stuck
+        # LIMIT exit (OPEN PENDING, never filling) previously left the position
+        # exposed for minutes while this method only logged. Cancel the dead
+        # pending order and fire ONE forced MARKET exit. Done outside the lock to
+        # avoid re-entrancy (place_order / cancel acquire their own locks).
+        if not self._exit_force_market_on_escalation:
+            return
+        if getattr(bracket, "_market_escalation_fired", False):
+            return
+        bracket._market_escalation_fired = True
+        stuck_order_id = bracket.exit_order_id or bracket.pending_exit_order_id
+        symbol = normalize_symbol(bracket.symbol)
+        qty = int(bracket.remaining_quantity or 0)
+        side = "SELL" if bracket.side == "BUY" else "BUY"
+
+        def _force_market_flatten() -> None:
+            # Cancel the unfilled pending limit so it can't fill alongside the market order.
+            if stuck_order_id:
+                try:
+                    self.order_manager.cancel_order(str(stuck_order_id))
+                    LOGGER.warning(
+                        "EXIT_ESCALATION_CANCELLED_STUCK_ORDER bracket_id=%s order_id=%s",
+                        bracket.bracket_id, stuck_order_id,
+                    )
+                except Exception as exc:  # noqa: BLE001 - cancel best-effort; still try market
+                    LOGGER.warning(
+                        "EXIT_ESCALATION_CANCEL_FAILED bracket_id=%s order_id=%s error=%s",
+                        bracket.bracket_id, stuck_order_id, exc,
+                    )
+            with self._lock:
+                bracket.exit_order_id = None
+                bracket.pending_exit_order_id = None
+            if not symbol or qty <= 0:
+                return
+            try:
+                order_id = self.order_manager.place_order(
+                    symbol=symbol, side=side, quantity=qty, order_type="MARKET",
+                    tag=f"EXIT_MKT_{bracket.bracket_id[:8]}", check_risk=False,
+                    product="MIS",
+                )
+            except Exception as exc:  # noqa: BLE001
+                LOGGER.critical(
+                    "EXIT_ESCALATION_MARKET_EXIT_FAILED bracket_id=%s symbol=%s error=%s",
+                    bracket.bracket_id, symbol, exc,
+                )
+                return
+            if order_id:
+                with self._lock:
+                    bracket.exit_order_id = str(order_id)
+                    bracket.pending_exit_order_id = str(order_id)
+                LOGGER.critical(
+                    "EXIT_ESCALATION_MARKET_EXIT_SENT bracket_id=%s symbol=%s order_id=%s qty=%s",
+                    bracket.bracket_id, symbol, order_id, qty,
+                )
+            else:
+                LOGGER.critical(
+                    "EXIT_ESCALATION_MARKET_EXIT_NO_ORDER_ID bracket_id=%s symbol=%s",
+                    bracket.bracket_id, symbol,
+                )
+
+        try:
+            _force_market_flatten()
+        except Exception as exc:  # noqa: BLE001 - never let escalation raise
+            LOGGER.error("EXIT_ESCALATION_DISPATCH_FAILED bracket_id=%s error=%s", bracket.bracket_id, exc)
 
     def on_tick_event(self, tick: dict[str, Any]) -> None:
         """Args: tick; Returns: none; Raises: none."""

--- a/tests/execution/test_exit_escalation_forces_market.py
+++ b/tests/execution/test_exit_escalation_forces_market.py
@@ -1,0 +1,91 @@
+"""Escalation must FLATTEN a stuck exit with a MARKET order, not just freeze.
+
+Regression: a LIMIT exit sat OPEN PENDING for 6+ minutes (EXIT_ESCALATED
+reason=unresolved_timeout repeating, attempts=1) while the position stayed
+exposed, because _escalate_exit_locked only logged/froze and never re-submitted.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from nifty_scalper_bot.execution.bracket_manager import (
+    BracketExitLifecycle,
+    BracketManager,
+)
+
+
+class _Broker:
+    def get_order_status(self, _oid: str) -> dict[str, Any]:
+        return {"status": "OPEN PENDING", "average_price": 0.0}
+
+    def get_positions(self) -> list[dict[str, Any]]:
+        return [{"symbol": "NFO:NIFTY2660923100CE", "quantity": 65}]
+
+
+class _OM:
+    def __init__(self) -> None:
+        self._broker = _Broker()
+        self.placed: list[dict[str, Any]] = []
+        self.cancelled: list[str] = []
+
+    def place_order(self, **kwargs: Any) -> str:
+        self.placed.append(kwargs)
+        return "mkt-exit-1"
+
+    def cancel_order(self, order_id: str) -> bool:
+        self.cancelled.append(order_id)
+        return True
+
+
+def _bracket(mgr: BracketManager):
+    mgr.register_virtual_bracket(
+        order_id="entry-1",
+        symbol="NFO:NIFTY2660923100CE",
+        side="BUY",
+        qty=65,
+        price=157.0,
+        sl=150.0,
+        tp=170.0,
+    )
+    return next(iter(mgr._brackets.values()))
+
+
+async def test_escalation_cancels_stuck_order_and_fires_market_exit():
+    om = _OM()
+    mgr = BracketManager(order_manager=om)
+    b = _bracket(mgr)
+    b.exit_order_id = "stuck-limit-1"          # the unfilled pending LIMIT
+    b.pending_exit_order_id = "stuck-limit-1"
+    b.remaining_quantity = 65
+
+    with mgr._lock:
+        mgr._escalate_exit_locked(b, "unresolved_timeout")
+
+    # stuck limit cancelled
+    assert "stuck-limit-1" in om.cancelled
+    # a MARKET exit was placed, SELL (entry was BUY), full qty
+    assert len(om.placed) == 1
+    mkt = om.placed[0]
+    assert mkt["order_type"] == "MARKET"
+    assert mkt["side"] == "SELL"
+    assert mkt["quantity"] == 65
+    # new exit order id recorded
+    assert b.exit_order_id == "mkt-exit-1"
+
+
+async def test_escalation_market_exit_fires_only_once():
+    om = _OM()
+    mgr = BracketManager(order_manager=om)
+    b = _bracket(mgr)
+    b.exit_order_id = "stuck-limit-1"
+    b.pending_exit_order_id = "stuck-limit-1"
+    b.remaining_quantity = 65
+
+    with mgr._lock:
+        mgr._escalate_exit_locked(b, "unresolved_timeout")
+    # reset state guard the way the reconcile loop would re-enter
+    b.exit_state = BracketExitLifecycle.EXIT_ORDER_SUBMITTED.value
+    with mgr._lock:
+        mgr._escalate_exit_locked(b, "unresolved_timeout")
+
+    assert len(om.placed) == 1, "forced market exit must fire exactly once"


### PR DESCRIPTION
## Critical: stuck exit left a live position exposed 6+ minutes

Yesterday (2026-06-22): bracket `2068919007121432576` NFO:NIFTY2662324050PE sat exposed **6+ minutes** (age 3081s -> 3442s). The exit was a **LIMIT that stayed OPEN PENDING and never filled**; every cycle re-logged `EXIT_ESCALATED reason=unresolved_timeout` with `attempts=1` (never incrementing). **111 escalation lines, one open position, no flatten** -> dangerous unhedged exposure.

## Root cause
`_escalate_exit_locked` only set `state=EXIT_FAILED_ESCALATED`, logged CRITICAL, and froze new entries. It **never re-submitted the exit**, and the stuck LIMIT order id stayed set, so `submit_exit_order` short-circuited (`if exit_order_id: return`; and `if EXIT_FAILED_ESCALATED and not continue_retry_after_escalation: return`). The position could only clear via manual action or EOD flatten.

## Fix — escalation now FLATTENS
On escalation: cancel the stuck pending limit (`cancel_order`), clear the dead exit-order ids, and fire **one forced MARKET exit**. Tag `EXIT_MKT_*` so the hardened entry-freeze guard's protective-call exemption lets it through (guard exempts `EXIT_/SL_/TP_/EOD_/PANIC/FLATTEN/SQUAREOFF` tags). Fires exactly once per bracket (`_market_escalation_fired`). RLock is reentrant so the inner re-lock is safe. Gated by `EXIT_FORCE_MARKET_ON_ESCALATION` (default true; false = freeze-only).

## Validation
Discrimination-verified tests: escalation cancels the stuck order + places a MARKET SELL for full qty; fires only once; flag off => no market exit. Full suite **2397 passed**.