### PR TITLE
🎨 Palette: Add proper label associations for accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-14 - Python String Literal Accessibility
+**Learning:** This app generates its HTML directly via Python string literals (FastAPI `HTMLResponse` in `admin_dashboard.py`). Standard UI accessibility linters do not scan these string literals, so it's easy to miss basic accessibility features like `for`/`id` bindings on `<label>` and `<input>`.
+**Action:** Always manually verify structural accessibility (like `for` and `id` linking for labels) when modifying the raw HTML strings in this backend file.

--- a/src/nifty_scalper_bot/admin_dashboard.py
+++ b/src/nifty_scalper_bot/admin_dashboard.py
@@ -372,7 +372,7 @@ def login_page(e: str = "") -> HTMLResponse:
     body = f"""<div class=wrap style="max-width:380px;margin-top:12vh">
     <div class=card><h2>Sign in</h2><p>Enter the admin password.</p>{err}
     <form method=post action="/admin/login">
-    <input type=password name=password autofocus placeholder="Password">
+    <input type=password id="password" name=password aria-label="Password" autofocus placeholder="Password">
     <button type=submit style="width:100%">Sign in</button></form></div></div>"""
     return HTMLResponse(_page(body))
 
@@ -417,7 +417,7 @@ def dashboard(request: Request) -> HTMLResponse:
     for label, key, sec in FIELDS:
         v = env.get(key, "")
         shown = ("••••••••" if v else "") if sec else v
-        rows += f'<label>{label} <span class=badge>{key}</span></label><input name="{key}" value="{shown}" placeholder="(unchanged)">'
+        rows += f'<label for="{key}">{label} <span class=badge>{key}</span></label><input id="{key}" name="{key}" value="{shown}" placeholder="(unchanged)">'
     body = f"""{_topbar(live_on)}<div class=wrap>{_flash(request)}
     <div class=card><h2>Live Trading</h2>
     <p>{'Placing REAL orders with REAL money.' if live_on else 'Analysing only — no real orders. Turn on when ready.'}</p>{toggle}</div>
@@ -425,8 +425,8 @@ def dashboard(request: Request) -> HTMLResponse:
     <div class=card><h2>Daily Token</h2>
     <p>Easiest: paste today's <b>request token</b> (from the Kite login redirect URL) and the bot will fetch the access token for you, then restart.</p>
     <form method=post action="/admin/token">
-    <label>Request Token (recommended)</label><input name="request_token" placeholder="paste request_token from login URL">
-    <label>…or Access Token (if you already have it)</label><input name="access_token" placeholder="paste access_token directly">
+    <label for="request_token">Request Token (recommended)</label><input id="request_token" name="request_token" placeholder="paste request_token from login URL">
+    <label for="access_token">…or Access Token (if you already have it)</label><input id="access_token" name="access_token" placeholder="paste access_token directly">
     <button class=blu type=submit>Update token &amp; restart</button></form></div>
 
     <div class=card><h2>Credentials &amp; Settings</h2>
@@ -529,9 +529,9 @@ def logs_page(request: Request, lines: int = 400, contains: str = "") -> HTMLRes
     body = f"""{_topbar(False)}<div class="wrap wide">
     <div class=card><h2>Logs <span class=muted id=stamp></span> <span id=botstat class=badge style="margin-left:8px">checking…</span> <span id=cnt class=badge></span></h2>
     <div class=grid>
-      <div><label>Lines</label><input id=lines value="{lines}"></div>
-      <div><label>Filter contains</label><input id=contains value="{html.escape(contains)}" placeholder="e.g. ORDER_SENT"></div>
-      <div><label>Auto-refresh</label>
+      <div><label for="lines">Lines</label><input id=lines value="{lines}"></div>
+      <div><label for="contains">Filter contains</label><input id=contains value="{html.escape(contains)}" placeholder="e.g. ORDER_SENT"></div>
+      <div><label for="auto">Auto-refresh</label>
         <select id=auto style="width:100%;padding:11px;border-radius:9px;background:#0a1019;color:var(--fg);border:1px solid var(--bd)">
           <option value=3>Every 3s</option><option value=5 selected>Every 5s</option>
           <option value=10>Every 10s</option><option value=0>Off</option></select></div>


### PR DESCRIPTION
💡 **What:** Added `for` attributes to all `<label>` tags and matching `id` attributes to their respective `<input>` elements in the HTML templates of the admin dashboard. Also added an `aria-label` to the password input field on the login page since it lacks a visible label text.

🎯 **Why:** To improve accessibility. Standard accessibility scanners often miss these inside backend string literals (e.g. FastAPI `HTMLResponse`). Explicit ID linking allows screen readers to announce inputs correctly, and clicking the label text now correctly focuses the input field (expanding the hit target).

📸 **Before/After:** Not visually noticeable, purely a semantic/structural improvement for assistive tech and mouse interactions on labels.

♿ **Accessibility:** Added explicit ID bindings across settings, tokens, and logs configurations, and `aria-label` for screen readers on the login view.

---
*PR created automatically by Jules for task [16093080403726067367](https://jules.google.com/task/16093080403726067367) started by @kundakarlabp*