### PR TITLE
feat: realized P&L on BRACKET_CLOSED + daily P&L card in Streamlit

### DIFF
--- a/dashboard/operations_console.py
+++ b/dashboard/operations_console.py
@@ -6,6 +6,7 @@ import html
 import io
 import json
 import os
+import re
 import subprocess
 import time as clock
 from datetime import date, datetime, time
@@ -171,6 +172,47 @@ _TRADE_MARKERS = (
 
 def filter_trades_only(rows: list[dict[str, str]]) -> list[dict[str, str]]:
     return [r for r in rows if any(m.lower() in r["message"].lower() for m in _TRADE_MARKERS)]
+
+
+_PNL_RE = re.compile(r"\bpnl=(-?\d+(?:\.\d+)?)")
+
+
+def realized_pnl_summary(rows: list[dict[str, str]]) -> dict[str, Any]:
+    """Aggregate realized P&L from BRACKET_CLOSED events in the given rows.
+
+    Each closed bracket logs `pnl=<rupees>`; sum them for the day's realized P&L,
+    with win/loss counts. Returns zeros when no closes are present yet.
+    """
+    total = 0.0
+    wins = losses = trades = 0
+    best = worst = None
+    for row in rows:
+        msg = row.get("message", "")
+        if "BRACKET_CLOSED" not in msg:
+            continue
+        m = _PNL_RE.search(msg)
+        if not m:
+            continue
+        try:
+            pnl = float(m.group(1))
+        except ValueError:
+            continue
+        total += pnl
+        trades += 1
+        if pnl >= 0:
+            wins += 1
+        else:
+            losses += 1
+        best = pnl if best is None else max(best, pnl)
+        worst = pnl if worst is None else min(worst, pnl)
+    return {
+        "total": round(total, 2),
+        "trades": trades,
+        "wins": wins,
+        "losses": losses,
+        "best": best,
+        "worst": worst,
+    }
 
 
 def render_feed(rows: list[dict[str, str]]) -> str:
@@ -470,11 +512,31 @@ events = event_ring()
 
 
 def render_live_feed() -> None:
-    rows = filter_events(events.snapshot(), event_type, search_query)
+    snapshot = events.snapshot()
+    rows = filter_events(snapshot, event_type, search_query)
     if st.session_state.get("trades_only_view"):
         rows = filter_trades_only(rows)
     rows = rows[-event_limit:]
     stats = events.stats()
+
+    # Daily realized P&L (from BRACKET_CLOSED pnl= across the whole buffer, not just
+    # the visible window) so the day's running result is visible at a glance.
+    pnl = realized_pnl_summary(snapshot)
+    if pnl["trades"]:
+        win_rate = round(100.0 * pnl["wins"] / pnl["trades"])
+        pnl_cls = "good" if pnl["total"] >= 0 else "bad-text"
+        sign = "+" if pnl["total"] >= 0 else "−"
+        st.markdown(
+            '<div class="kpi-row" style="grid-template-columns:repeat(5,minmax(0,1fr))">'
+            f'<div class="kpi"><div class="kpi-label">Realized P&amp;L (today)</div>'
+            f'<div class="kpi-value {pnl_cls}">{sign}₹{abs(pnl["total"]):,.2f}</div></div>'
+            f'<div class="kpi"><div class="kpi-label">Closed trades</div><div class="kpi-value">{pnl["trades"]}</div></div>'
+            f'<div class="kpi"><div class="kpi-label">Win rate</div><div class="kpi-value">{win_rate}% ({pnl["wins"]}/{pnl["trades"]})</div></div>'
+            f'<div class="kpi"><div class="kpi-label">Best</div><div class="kpi-value good">+₹{(pnl["best"] or 0):,.0f}</div></div>'
+            f'<div class="kpi"><div class="kpi-label">Worst</div><div class="kpi-value bad-text">₹{(pnl["worst"] or 0):,.0f}</div></div>'
+            "</div>",
+            unsafe_allow_html=True,
+        )
     values = [
         ("Visible", len(rows)),
         ("Trades", sum(row["type"] == "TRADE" for row in rows)),

--- a/src/nifty_scalper_bot/execution/bracket_manager.py
+++ b/src/nifty_scalper_bot/execution/bracket_manager.py
@@ -2582,16 +2582,44 @@ class BracketManager:
                 bracket.exit_price = exit_price
             bracket.updated_at = bracket.closed_at
             self._exit_cooldowns.pop(bracket.entry_order_id, None)
+        # Compute realized P&L so the log/event carries it (lets the dashboard and
+        # Streamlit terminal show daily P&L without re-deriving from the broker).
+        # Long option (BUY): (exit-entry)*qty; short: (entry-exit)*qty.
+        entry_px = bracket.entry_fill_price if bracket.entry_fill_price is not None else bracket.entry_price
+        exit_px = bracket.exit_price
+        filled_qty = int(bracket.quantity or 0)
+        realized_pnl: float | None = None
+        try:
+            if entry_px is not None and exit_px is not None and filled_qty > 0:
+                if bracket.side == "BUY":
+                    realized_pnl = round((float(exit_px) - float(entry_px)) * filled_qty, 2)
+                else:
+                    realized_pnl = round((float(entry_px) - float(exit_px)) * filled_qty, 2)
+        except Exception:  # noqa: BLE001 - never let P&L math break a close
+            realized_pnl = None
         LOGGER.info(
-            "BRACKET_CLOSED bracket_id=%s symbol=%s close_source=%s",
+            "BRACKET_CLOSED bracket_id=%s symbol=%s close_source=%s side=%s qty=%s entry=%s exit=%s pnl=%s",
             bracket.bracket_id,
             bracket.symbol,
             close_source,
+            bracket.side,
+            filled_qty,
+            entry_px,
+            exit_px,
+            realized_pnl,
         )
         self._log_bracket_event(
             "BRACKET_CLOSED",
             bracket,
-            meta={"close_source": close_source, "exit_order_id": bracket.exit_order_id},
+            meta={
+                "close_source": close_source,
+                "exit_order_id": bracket.exit_order_id,
+                "side": bracket.side,
+                "qty": filled_qty,
+                "entry": entry_px,
+                "exit": exit_px,
+                "pnl": realized_pnl,
+            },
         )
         self._notify_open_position_priority("close", bracket.symbol)
         hook = self._on_exit_complete_hook

--- a/tests/execution/test_bracket_closed_pnl.py
+++ b/tests/execution/test_bracket_closed_pnl.py
@@ -1,0 +1,46 @@
+"""BRACKET_CLOSED must carry realized P&L so terminals can show daily P&L."""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from nifty_scalper_bot.execution.bracket_manager import BracketManager
+
+
+class _OM:
+    def __init__(self) -> None:
+        self._broker = None
+    def place_order(self, **k: Any) -> str:
+        return "x"
+    def cancel_order(self, _o: str) -> bool:
+        return True
+
+
+def _mgr_with_bracket():
+    mgr = BracketManager(order_manager=_OM())
+    mgr.register_virtual_bracket(
+        order_id="e1", symbol="NFO:NIFTY2660923100CE", side="BUY",
+        qty=65, price=137.25, sl=130.0, tp=150.0,
+    )
+    return mgr, next(iter(mgr._brackets.values()))
+
+
+async def test_bracket_closed_logs_realized_pnl(caplog) -> None:
+    mgr, b = _mgr_with_bracket()
+    b.entry_fill_price = 137.25
+    with caplog.at_level(logging.INFO):
+        mgr._close_bracket(b, close_source="broker_fill", exit_price=140.0)
+    line = next((r.getMessage() for r in caplog.records if "BRACKET_CLOSED" in r.getMessage()), "")
+    # (140.0 - 137.25) * 65 = 178.75
+    assert "pnl=178.75" in line
+    assert "entry=137.25" in line and "exit=140.0" in line
+
+
+async def test_bracket_closed_pnl_negative_on_loss(caplog) -> None:
+    mgr, b = _mgr_with_bracket()
+    b.entry_fill_price = 137.25
+    with caplog.at_level(logging.INFO):
+        mgr._close_bracket(b, close_source="reconciled_flat", exit_price=133.55)
+    line = next((r.getMessage() for r in caplog.records if "BRACKET_CLOSED" in r.getMessage()), "")
+    # (133.55 - 137.25) * 65 = -240.5
+    assert "pnl=-240.5" in line


### PR DESCRIPTION
See the day's running result in the terminal without opening Zerodha.

## Bot side (`_close_bracket`)
`BRACKET_CLOSED` previously logged only bracket_id/symbol/close_source. Now computes **realized P&L** from the bracket (entry_fill_price or entry_price, exit_price, qty; BUY `(exit-entry)*qty`, SELL inverse) and includes `side/qty/entry/exit/pnl` in both the log line and event meta. P&L math is defensive (never breaks a close).

## Streamlit side (`operations_console`)
`realized_pnl_summary()` parses `pnl=` from BRACKET_CLOSED across the whole event buffer; a **P&L card** above the feed shows Realized P&L (today), closed trades, win rate, best, worst — color-coded. Shown once ≥1 trade has closed.

## Validation
Discrimination-verified: BRACKET_CLOSED logs exact pnl on win and loss; reverting the math fails the test. P&L parser unit-checked. Streamlit boots headless clean. Full suite **2399 passed**.