### PR TITLE
feat: daily profit-lock target (symmetric to day-loss limit)

### DIFF
--- a/src/nifty_scalper_bot/risk/limits.py
+++ b/src/nifty_scalper_bot/risk/limits.py
@@ -30,6 +30,7 @@ class RiskSwitches:
     max_consecutive_losses: int
     cooldown_minutes: float
     reset_hour_utc: int
+    max_day_profit: float = 0.0
     clock: Callable[[], datetime] = _now_utc
     _day_anchor: datetime = field(init=False, repr=False)
     _day_pnl: float = field(init=False, repr=False, default=0.0)
@@ -38,6 +39,7 @@ class RiskSwitches:
 
     def __post_init__(self) -> None:
         self.max_day_loss = max(0.0, float(self.max_day_loss))
+        self.max_day_profit = max(0.0, float(self.max_day_profit))
         self.max_consecutive_losses = max(0, int(self.max_consecutive_losses))
         self.cooldown_minutes = max(0.0, float(self.cooldown_minutes))
         self.reset_hour_utc = int(self.reset_hour_utc)
@@ -77,6 +79,8 @@ class RiskSwitches:
         self._reset_if_needed()
         if self.max_day_loss > 0 and self.day_loss() >= self.max_day_loss:
             return "Max day loss reached"
+        if self.max_day_profit > 0 and self.day_profit() >= self.max_day_profit:
+            return "Daily profit target reached"
         if (
             self.max_consecutive_losses > 0
             and self._consecutive_losses >= self.max_consecutive_losses
@@ -115,6 +119,9 @@ class RiskSwitches:
     def day_loss(self) -> float:
         pnl = self._day_pnl
         return max(-pnl, 0.0)
+
+    def day_profit(self) -> float:
+        return max(self._day_pnl, 0.0)
 
     def consecutive_losses(self) -> int:
         self._reset_if_needed()

--- a/src/nifty_scalper_bot/risk/risk_manager.py
+++ b/src/nifty_scalper_bot/risk/risk_manager.py
@@ -162,11 +162,25 @@ class RiskManager:
             day_loss_cap = min(pct_cap, abs_cap)
         else:
             day_loss_cap = max(pct_cap, abs_cap)
+        # Daily profit lock — symmetric to the day-loss cap. Configurable as a
+        # percent of balance and/or an absolute rupee amount. When both are set,
+        # use the smaller (lock in sooner); when one is set, use it; default 0=off.
+        profit_pct_cap = max(self.account_balance, 0.0) * (
+            self._daily_profit_target_pct() / 100.0
+        )
+        profit_abs_cap = max(
+            float(getattr(self.settings, "max_daily_profit_absolute", 0.0)), 0.0
+        )
+        if profit_pct_cap > 0 and profit_abs_cap > 0:
+            day_profit_cap = min(profit_pct_cap, profit_abs_cap)
+        else:
+            day_profit_cap = max(profit_pct_cap, profit_abs_cap)
         self._switches = RiskSwitches(
             max_day_loss=day_loss_cap,
             max_consecutive_losses=self.settings.max_consecutive_losses,
             cooldown_minutes=self.settings.loss_cooldown_seconds / 60.0,
             reset_hour_utc=self.settings.trading_day_reset_hour_utc,
+            max_day_profit=day_profit_cap,
         )
         self._m_blocks = Counter("risk_blocks_total", "Orders blocked by risk manager")
         self._m_blocks = Counter("risk_blocks_total", "Orders blocked by risk manager")
@@ -1287,6 +1301,13 @@ class RiskManager:
             self.settings,
             "daily_loss_pct",
             getattr(self.settings, "daily_pnl_cap_pct", 0.0),
+        )
+
+    def _daily_profit_target_pct(self) -> float:  # pragma: no cover
+        return getattr(
+            self.settings,
+            "daily_profit_pct",
+            getattr(self.settings, "daily_profit_target_pct", 0.0),
         )
 
 

--- a/tests/risk/test_switches.py
+++ b/tests/risk/test_switches.py
@@ -70,3 +70,46 @@ def test_day_reset_reinitialises_state() -> None:
 
     assert switches.day_loss() == pytest.approx(0.0)
     assert switches.consecutive_losses() == 0
+
+
+def test_day_profit_lock_triggers() -> None:
+    clock = Clock()
+    switches = RiskSwitches(
+        max_day_loss=0.0,
+        max_consecutive_losses=0,
+        cooldown_minutes=0.0,
+        reset_hour_utc=3,
+        max_day_profit=500.0,
+        clock=clock,
+    )
+    switches.record_pnl(300.0)
+    assert switches.breach_reason() is None  # below target
+    switches.record_pnl(250.0)
+    assert switches.day_profit() == pytest.approx(550.0)
+    assert switches.breach_reason() == "Daily profit target reached"
+
+
+def test_day_profit_lock_off_by_default() -> None:
+    clock = Clock()
+    switches = RiskSwitches(
+        max_day_loss=0.0,
+        max_consecutive_losses=0,
+        cooldown_minutes=0.0,
+        reset_hour_utc=3,
+        clock=clock,
+    )
+    switches.record_pnl(100000.0)  # huge profit
+    assert switches.breach_reason() is None  # no target set -> never locks
+
+
+def test_day_profit_resets_next_day() -> None:
+    clock = Clock()
+    switches = RiskSwitches(
+        max_day_loss=0.0, max_consecutive_losses=0, cooldown_minutes=0.0,
+        reset_hour_utc=3, max_day_profit=500.0, clock=clock,
+    )
+    switches.record_pnl(600.0)
+    assert switches.breach_reason() == "Daily profit target reached"
+    clock.advance(60 * 60 * 24)  # next day past reset
+    assert switches.day_profit() == pytest.approx(0.0)
+    assert switches.breach_reason() is None


### PR DESCRIPTION
Auto-stops new entries once the day's realized profit hits a target — symmetric to the existing day-loss breaker. Supports **both** percent-of-balance and absolute rupees, default **OFF** (0) so nothing changes until configured.

## Design decision (you asked me to choose)
Support **both** rupees and percent, with the **tighter one binding**, default off — safest and most flexible, and consistent with how the day-loss cap already resolves (`pct_cap` vs `abs_cap`).

## Changes
- `RiskSwitches`: new `max_day_profit` field + `day_profit()`; `breach_reason()` now also returns **"Daily profit target reached"** when `day_profit >= target`. Resets with the trading day.
- `risk_manager`: resolves the profit cap like the loss cap — `DAILY_PROFIT_PCT` (% of balance) and/or `max_daily_profit_absolute` (rupees); both set -> min; one set -> that one. `breach_reason` already blocks new entries (trips the breaker), so the lock halts the day's trading while **exits are unaffected**.

## Validation
Logic-verified directly + tests: trips at target; off by default even on huge profit; resets next day. Full suite **2405 passed**.

**Configure:** `DAILY_PROFIT_PCT=<pct>` and/or `max_daily_profit_absolute=<rupees>`.