### PR TITLE
fix: long-option SL never lands at/above entry premium

### DIFF
--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -5329,6 +5329,11 @@ class StrategyRunner:
         original_sl = sl
         original_tp = tp
 
+        if signal.stop_loss is None or signal.stop_loss <= 0:
+            corrected = True  # a missing/invalid SL was replaced by the ATR default
+        if signal.take_profit is None or signal.take_profit <= 0:
+            corrected = True
+
         if entry_side == "BUY":  # LONG position
             # SL must be BELOW entry
             if sl >= entry_price:
@@ -5362,6 +5367,13 @@ class StrategyRunner:
         min_tp_distance = atr * 1.0
 
         if entry_side == "BUY":
+            # Guard against an SL that mirrored to an absurd value (e.g. an
+            # underlying-derived stop) leaving it at/near zero or further than the
+            # full premium below entry. Reset to a sane ATR/percent premium stop.
+            max_sl_distance = max(entry_price * 0.6, atr * 2.0)
+            if sl <= 0 or (entry_price - sl) > max_sl_distance:
+                sl = entry_price - min(max(atr * 1.5, entry_price * 0.1), max_sl_distance)
+                corrected = True
             if entry_price - sl < min_sl_distance:
                 sl = entry_price - min_sl_distance
                 corrected = True  # ✅ FIX 5
@@ -12339,10 +12351,30 @@ class StrategyRunner:
                 plan_source = "premium_stop_pct"
             else:
                 distance = stop_distance if stop_distance is not None and stop_distance > 0 else max(atr * 1.2, entry_price * 0.02, 1.0)
-                if explicit_stop is not None and explicit_stop > 0 and str(entry_side).upper() == "BUY":
+                # An explicit stop is only valid if it sits BELOW entry and within a
+                # sane premium range. Strategies sometimes derive the stop from the
+                # UNDERLYING (index ~24000) while the trade is on the option PREMIUM
+                # (~117); using that directly puts SL far above entry, which the
+                # bracket then rejects (protected_price_invalidates_bracket), killing
+                # valid entries. Accept the explicit stop only when it is below entry
+                # and no further than the entry premium away; otherwise fall back to a
+                # premium-distance stop.
+                explicit_ok = (
+                    explicit_stop is not None
+                    and explicit_stop > 0
+                    and str(entry_side).upper() == "BUY"
+                    and explicit_stop < entry_price
+                    and (entry_price - explicit_stop) <= entry_price  # SL not absurdly far (>100% premium)
+                )
+                if explicit_ok:
                     stop_loss = explicit_stop
                     plan_source = "explicit_premium_stop"
                 else:
+                    if explicit_stop is not None and explicit_stop > 0 and str(entry_side).upper() == "BUY":
+                        LOGGER.info(
+                            "EXPLICIT_STOP_REJECTED_OUT_OF_PREMIUM_RANGE symbol=%s entry=%.2f explicit_stop=%.2f -> using premium_stop_distance",
+                            getattr(signal, "symbol", "?"), entry_price, float(explicit_stop),
+                        )
                     stop_loss = entry_price - distance
                     plan_source = "premium_stop_distance"
                 risk = max(entry_price - float(stop_loss), max(atr * 0.8, 1.0))

--- a/tests/strategies/test_long_option_sl_geometry.py
+++ b/tests/strategies/test_long_option_sl_geometry.py
@@ -1,0 +1,48 @@
+"""Long-option SL must never end up at/above entry premium.
+
+Regression: an explicit stop derived from the UNDERLYING (e.g. index ~24000) or an
+inverted strategy SL produced SL >= entry premium, which the bracket rejected
+(protected_price_invalidates_bracket), killing valid entries.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from nifty_scalper_bot.strategies.runner import StrategyRunner
+from nifty_scalper_bot.strategies.signal_generator import Signal
+
+
+def _runner() -> StrategyRunner:
+    r = StrategyRunner.__new__(StrategyRunner)
+    r._logger = SimpleNamespace(warning=lambda *a, **k: None, info=lambda *a, **k: None, debug=lambda *a, **k: None)
+    return r
+
+
+def _sig(sl, tp):
+    return Signal(action="BUY", symbol="NFO:NIFTY2662324050CE", quantity=65,
+                  confidence=0.8, reason="OrderFlow", stop_loss=sl, take_profit=tp)
+
+
+def _validate(sl, tp, entry=117.25, atr=4.0):
+    out = _runner()._validate_long_option_geometry(
+        signal=_sig(sl, tp), entry_price=entry, entry_side="BUY", atr=atr
+    )
+    return out.stop_loss, out.take_profit
+
+
+async def test_sl_above_entry_is_corrected_below() -> None:
+    sl, tp = _validate(140.76, 130.0)  # SL above entry, TP above
+    assert 0 < sl < 117.25, f"SL must be a sane premium below entry, got {sl}"
+    assert tp > 117.25
+
+
+async def test_underlying_level_sl_becomes_sane_premium_sl() -> None:
+    sl, _ = _validate(24000.0, 0.0)  # underlying-level stop misapplied to premium
+    assert 0 < sl < 117.25, f"underlying-derived SL must be clamped to premium range, got {sl}"
+    # and within a sane distance (not pinned to 0.05)
+    assert (117.25 - sl) <= max(117.25 * 0.6, 4.0 * 2.0) + 0.01
+
+
+async def test_negative_sl_becomes_sane() -> None:
+    sl, _ = _validate(-5.0, 0.0)
+    assert 0 < sl < 117.25


### PR DESCRIPTION
Valid entries were being rejected with `protected_price_invalidates_bracket` because the computed stop_loss came out **>= the entry premium** (e.g. SL 140 vs entry 117). Two root causes:

## 1. Explicit-stop misapplied to premium
In the option trade-plan path, an `explicit_stop` was accepted for a BUY without checking it sits below entry. Strategies sometimes derive the stop from the **underlying** (index ~24000) while the trade is on the option **premium** (~117) -> SL far above entry. Now accepted only when **below entry and within premium range** (≤100% of entry away); otherwise falls back to a premium stop-distance and logs `EXPLICIT_STOP_REJECTED_OUT_OF_PREMIUM_RANGE`.

## 2. Geometry validator silently no-op'd
`_validate_long_option_geometry` only returned a corrected signal when `corrected` was set, but the branch filling a missing/invalid SL/TP (`sl<=0`) never set `corrected` -> the default was computed then **discarded**, returning the bad SL unchanged. Now filling a missing/invalid SL/TP marks corrected. Added a clamp: a long-option SL that mirrors to `<=0` or further than `max(60% premium, 2*ATR)` below entry resets to a sane ATR/percent stop instead of being pinned to 0.05.

## Validation
Tests against the real method: SL-above-entry corrected below; underlying-level SL (24000) clamped into premium range; negative SL made sane. Full suite **2405 passed**.