### PR TITLE
fix(P0): never size against a synthetic balance in LIVE mode

### DIFF
--- a/src/nifty_scalper_bot/risk/risk_manager.py
+++ b/src/nifty_scalper_bot/risk/risk_manager.py
@@ -458,8 +458,19 @@ class RiskManager:
         )
 
     def _resolve_env_balance_fallback(self) -> float:
-        """Return fallback balance sourced from environment configuration."""
-        fallback_value = 1_000_000.0
+        """Return fallback balance sourced from environment configuration.
+
+        In LIVE mode a synthetic default must NEVER be injected — sizing against a
+        fake balance (the old ₹10,00,000 default) can massively oversize positions
+        when the broker reports ₹0/invalid. So in live we honour ONLY an explicit
+        RISK__CAPITAL/RISK_CAPITAL the user set, and otherwise return 0.0, which the
+        arming/stale-balance logic treats as not-ready. Paper/backtest keep the
+        convenience default.
+        """
+        from nifty_scalper_bot.core.app import _is_live_execution_mode
+
+        live = _is_live_execution_mode()
+        fallback_value = 0.0 if live else 1_000_000.0
         try:
             candidates = (
                 os.getenv("RISK__CAPITAL"),
@@ -784,11 +795,21 @@ class RiskManager:
                     f"⚠️ SL distance too small, using minimum: {sl_distance:.2f}"
                 )
 
-            # ✅ FIX 4: Fallback account balance when 0 or negative
+            # Fallback account balance when 0 or negative — but NEVER inject a
+            # synthetic margin in LIVE mode (sizing against a fake balance can
+            # massively oversize). In live, leave balance at 0 so sizing yields no
+            # quantity and the order is blocked upstream; paper/backtest keep it.
             balance = self.account_balance
             if balance <= 0:
                 balance = getattr(self, "_cached_balance", 0.0)
             if balance <= 0:
+                from nifty_scalper_bot.core.app import _is_live_execution_mode
+
+                if _is_live_execution_mode():
+                    self._logger.error(
+                        "LIVE_SIZING_BLOCKED_NO_VALID_BALANCE balance<=0; refusing synthetic FALLBACK_MARGIN"
+                    )
+                    return 0
                 balance = float(os.getenv("FALLBACK_MARGIN", "100000"))
                 self._logger.warning(f"⚠️ Using FALLBACK_MARGIN: ₹{balance:,.2f}")
 

--- a/tests/test_risk_manager_new.py
+++ b/tests/test_risk_manager_new.py
@@ -290,3 +290,40 @@ def test_risk_state_stale_soft_block() -> None:
     assert allowed is False
     assert reasons == ("STALE",)
     assert risk.cooldown_remaining() == 0.0
+
+
+def test_live_mode_blocks_sizing_when_balance_invalid(monkeypatch) -> None:
+    # P0: in LIVE mode a 0/invalid balance must NOT size against a synthetic
+    # FALLBACK_MARGIN (the old ₹10L/₹1L default) — that massively oversizes.
+    monkeypatch.setenv("EXECUTION_MODE", "LIVE")
+    monkeypatch.delenv("RISK__CAPITAL", raising=False)
+    monkeypatch.delenv("RISK_CAPITAL", raising=False)
+    settings = RiskSettings(per_trade_risk_pct=1.0)
+    pm = DummyPositionManager(realized=0.0)
+    risk = _make_risk_manager(settings=settings, pm=pm, balance=0.0)
+    risk._cached_balance = 0.0
+    qty = risk.suggest_position_size(
+        side="BUY", price=120.0, stop_loss=110.0, atr=None, requested_quantity=150,
+    )
+    assert qty == 0, "live sizing must block on invalid balance, not use a synthetic margin"
+
+
+def test_live_env_balance_fallback_is_zero(monkeypatch) -> None:
+    monkeypatch.setenv("EXECUTION_MODE", "LIVE")
+    monkeypatch.delenv("RISK__CAPITAL", raising=False)
+    monkeypatch.delenv("RISK_CAPITAL", raising=False)
+    monkeypatch.delenv("BACKTEST__CAPITAL", raising=False)
+    settings = RiskSettings(per_trade_risk_pct=1.0)
+    pm = DummyPositionManager(realized=0.0)
+    risk = _make_risk_manager(settings=settings, pm=pm, balance=50_000.0)
+    assert risk._resolve_env_balance_fallback() == 0.0  # no synthetic default in live
+
+
+def test_paper_mode_keeps_fallback(monkeypatch) -> None:
+    monkeypatch.setenv("EXECUTION_MODE", "PAPER")
+    monkeypatch.setenv("ENABLE_LIVE", "false")
+    monkeypatch.delenv("RISK__CAPITAL", raising=False)
+    settings = RiskSettings(per_trade_risk_pct=1.0)
+    pm = DummyPositionManager(realized=0.0)
+    risk = _make_risk_manager(settings=settings, pm=pm, balance=50_000.0)
+    assert risk._resolve_env_balance_fallback() == 1_000_000.0  # convenience default in paper


### PR DESCRIPTION
## Most dangerous defect in the review (P0)
When the broker reports 0/invalid balance, the risk engine fell back to a **synthetic margin** — ₹10,00,000 via `_resolve_env_balance_fallback` default, and ₹1,00,000 via `FALLBACK_MARGIN` in `suggest_position_size`. In LIVE this can **massively oversize** positions and invalidate risk-per-trade math (the review saw `MARGIN_PRIMED source=risk available=1000000.0` while broker net≈₹16k).

## Fix — fail CLOSED in live (two injection points, gated by canonical `_is_live_execution_mode`)
- `_resolve_env_balance_fallback()`: in LIVE, default to **0.0** (treated as not-ready by arming/stale logic) and honour **only** an explicit `RISK__CAPITAL`. Paper/backtest keep the ₹10L convenience default.
- `suggest_position_size()`: in LIVE, if `balance<=0` (no cached balance either), **refuse** the synthetic `FALLBACK_MARGIN` and return **0 quantity** (order blocked) with `LIVE_SIZING_BLOCKED_NO_VALID_BALANCE`.

Invalid balance now blocks the trade in live instead of sizing against a fake number.

Other review items (control-plane heartbeat, 13–15s signal latency, startup ordering, basket SSOT, history-fetch policy) **deferred for later** per request — bot keeps working.

## Validation
Direct + tests: live blocks sizing on 0 balance; live env fallback=0; paper keeps ₹10L. Full suite **2408 passed**.

**Note:** set `RISK__CAPITAL` to your real account size for an explicit live fallback; otherwise live arming correctly requires a valid broker balance.