### PR TITLE
fix: missing 'logging' import in bracket_manager (watchdog NameError)

### DIFF
--- a/src/nifty_scalper_bot/execution/bracket_manager.py
+++ b/src/nifty_scalper_bot/execution/bracket_manager.py
@@ -26,6 +26,7 @@ import threading
 from threading import RLock
 import time
 import json
+import logging
 import os
 from nifty_scalper_bot.config.env_utils import parse_float_env, parse_int_env
 from datetime import datetime, timezone 

--- a/tests/execution/test_bracket_log_throttled_import.py
+++ b/tests/execution/test_bracket_log_throttled_import.py
@@ -1,0 +1,23 @@
+"""Regression: _log_throttled used `logging` without importing it -> NameError in
+the watchdog exit loop (safety net), swallowed as 'Failure in _watchdog_exit_loop'."""
+from __future__ import annotations
+
+from typing import Any
+
+from nifty_scalper_bot.execution.bracket_manager import BracketManager
+
+
+class _OM:
+    def __init__(self) -> None:
+        self._broker = None
+    def place_order(self, **k: Any) -> str:
+        return "x"
+    def cancel_order(self, _o: str) -> bool:
+        return True
+
+
+async def test_log_throttled_does_not_raise_nameerror() -> None:
+    mgr = BracketManager(order_manager=_OM())
+    # Must not raise NameError: name 'logging' is not defined
+    mgr._log_throttled("info", "TEST:key", 0.0, "msg %s", "arg")
+    mgr._log_throttled("warning", "TEST:key2", 0.0, "msg2")


### PR DESCRIPTION
While auditing the trailing-SL / virtual-bracket / entry-exit paths (all requested), found `_log_throttled()` referenced `logging.INFO` / `getattr(logging, ...)` but the module was **never imported** -> NameError on every throttled log. It surfaced as repeated `Failure in _watchdog_exit_loop: name 'logging' is not defined` (the watchdog is the safety net that force-exits stuck positions; the per-iteration `except` kept it alive but its throttled logs were lost). One-line fix: `import logging`.

## Audit result (otherwise healthy)
Trailing SL, virtual bracket, and entry/exit are **correctly coded**:
- Ratchet only moves SL favorably, pegged to the high/low watermark (LONG can't drop, SHORT can't rise).
- Exit eval has correct BUY/SELL directionality with **jump-safe gap-through** SL detection (`crossed or breached`).
- Trailed SL writes back to `sl_trigger_price`, so exits honor the tightened stop.
- Verified by direct simulation: entry 100, trail SL->110, ltp 109 => `HARD_SL_BREACH`; ltp 121 => `HARD_TP_BREACH`.

## Validation
Test: `_log_throttled` no longer raises. Full suite **2409 passed**.