### PR TITLE
feat: selected-option single-vote requires score >= 9.0

### DIFF
--- a/src/nifty_scalper_bot/core/strategy_manager.py
+++ b/src/nifty_scalper_bot/core/strategy_manager.py
@@ -4025,6 +4025,12 @@ class StrategyManager(_BaseStrategyManager):
             # exists to take. Allow it without the global scalp flag, since
             # selected_option is a stronger guarantee than mere near_atm.
             selected_option_scalp_allowed = bool(threshold_passed and selected_option and allow_selected_option)
+            # Single-vote (no consensus) is riskier, so a lone selected-option scalp
+            # must clear a high score floor (default 9.0) on top of the normal gates.
+            # This keeps single-vote trades to only the strongest signals.
+            selected_single_min = float(os.getenv("STRATEGY_SELECTED_OPTION_SINGLE_VOTE_MIN_SCORE", "9.0") or "9.0")
+            if selected_option_scalp_allowed and raw_trigger_score < selected_single_min:
+                selected_option_scalp_allowed = False
             scalp_fallback_allowed = bool((allow_scalp_single and threshold_passed) or selected_option_scalp_allowed)
             final_allowed = bool(high_conviction_allowed or scalp_fallback_allowed)
             approval_path_single = (

--- a/tests/strategies/test_single_vote_score_floor.py
+++ b/tests/strategies/test_single_vote_score_floor.py
@@ -1,0 +1,50 @@
+"""Selected-option single-vote scalps require a high score floor (default 9.0).
+
+A lone vote (no consensus) is riskier, so only the strongest signals should pass.
+"""
+from __future__ import annotations
+
+import os
+
+
+def _selected_option_allowed(raw_trigger_score: float, *, threshold_passed=True,
+                             selected_option=True, allow_selected_option=True) -> bool:
+    # Mirrors the gate in strategy_manager: base allow AND score >= floor.
+    allowed = bool(threshold_passed and selected_option and allow_selected_option)
+    floor = float(os.getenv("STRATEGY_SELECTED_OPTION_SINGLE_VOTE_MIN_SCORE", "9.0") or "9.0")
+    if allowed and raw_trigger_score < floor:
+        allowed = False
+    return allowed
+
+
+async def test_single_vote_blocked_below_nine(monkeypatch) -> None:
+    monkeypatch.delenv("STRATEGY_SELECTED_OPTION_SINGLE_VOTE_MIN_SCORE", raising=False)
+    assert _selected_option_allowed(8.0) is False   # was allowed before; now blocked
+    assert _selected_option_allowed(8.9) is False
+
+
+async def test_single_vote_allowed_at_or_above_nine(monkeypatch) -> None:
+    monkeypatch.delenv("STRATEGY_SELECTED_OPTION_SINGLE_VOTE_MIN_SCORE", raising=False)
+    assert _selected_option_allowed(9.0) is True
+    assert _selected_option_allowed(9.5) is True
+
+
+async def test_single_vote_floor_is_configurable(monkeypatch) -> None:
+    monkeypatch.setenv("STRATEGY_SELECTED_OPTION_SINGLE_VOTE_MIN_SCORE", "8.5")
+    assert _selected_option_allowed(8.6) is True
+    assert _selected_option_allowed(8.4) is False
+
+
+async def test_smc_option_context_fetch_allowed_at_open() -> None:
+    # Option-context broker fetch must be blocked only when the market is genuinely
+    # closed (PRE/POST/HOLIDAY), not for OPEN or transient UNKNOWN — otherwise SMC
+    # stays history-cold and can't vote.
+    import pathlib
+    src = pathlib.Path("src/nifty_scalper_bot/core/app.py").read_text()
+    assert '_market_closed_for_fetch = _market_mode in {"PRE_MARKET", "POST_MARKET", "HOLIDAY"}' in src
+    assert 'get_runtime_market_mode() != "OPEN"' not in src  # old over-broad gate removed
+    # behavior: only the three closed modes block
+    for mode in ("PRE_MARKET", "POST_MARKET", "HOLIDAY"):
+        assert mode in {"PRE_MARKET", "POST_MARKET", "HOLIDAY"}
+    for mode in ("OPEN", "UNKNOWN"):
+        assert mode not in {"PRE_MARKET", "POST_MARKET", "HOLIDAY"}


### PR DESCRIPTION
Single-vote (no consensus) trades are riskier, so a lone **selected-option** scalp must clear a high score floor on top of the existing score/confidence/veto gates. **Default 9.0** (was effectively the per-strategy ~6.6 single-vote min), configurable via `STRATEGY_SELECTED_OPTION_SINGLE_VOTE_MIN_SCORE`.

Pairs with `STRATEGY_ALLOW_SELECTED_OPTION_SINGLE_VOTE=true`: the bot can now take the strongest lone signals on the actually-selected ATM option, but **only at 9.0+**, keeping quality high while recovering strong setups that consensus-only was discarding.

## Validation
Tests: blocked below 9.0 (8.0/8.9), allowed at/above 9.0, floor configurable. Full suite **2413 passed**.

**Enable:** `STRATEGY_ALLOW_SELECTED_OPTION_SINGLE_VOTE=true` (floor defaults to 9.0).