### PR TITLE
fix: let SMC option-context history warm up at market open

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -7904,10 +7904,18 @@ async def ensure_symbol_runtime_history(
     mdm = getattr(ctx, "market_data_manager", None)
     runner = getattr(ctx, "strategy_runner", None)
     policy = resolve_history_policy(ctx, symbol, role=role, phase=phase, reason=reason)
+    # Block broker fetch for option-context history only when the market is
+    # genuinely CLOSED (pre/post/holiday). Previously this fired for any mode that
+    # was not exactly "OPEN" — including transient "UNKNOWN" around the open bell —
+    # which kept SMC permanently history-cold (broker_fetch_not_allowed) and unable
+    # to vote, artificially suppressing consensus. Allowing the fetch while live
+    # lets option-context strategies warm up.
+    _market_mode = get_runtime_market_mode()
+    _market_closed_for_fetch = _market_mode in {"PRE_MARKET", "POST_MARKET", "HOLIDAY"}
     if (
         str(policy.role) == "option_context"
         and str(policy.phase) != "recovery"
-        and get_runtime_market_mode() != "OPEN"
+        and _market_closed_for_fetch
         and bool(getattr(policy, "allow_broker_fetch", True))
     ):
         policy = replace(policy, allow_broker_fetch=False)

--- a/tests/core/test_option_context_fetch_market_mode.py
+++ b/tests/core/test_option_context_fetch_market_mode.py
@@ -1,0 +1,21 @@
+"""Option-context broker fetch is blocked only when market is genuinely closed.
+
+Previously the gate fired for any mode != OPEN (including transient UNKNOWN around
+the open bell), keeping SMC history-cold (broker_fetch_not_allowed) so it could never
+vote — artificially suppressing consensus.
+"""
+from __future__ import annotations
+
+import pathlib
+
+
+async def test_fetch_gate_uses_closed_modes_only() -> None:
+    src = pathlib.Path("src/nifty_scalper_bot/core/app.py").read_text()
+    assert '_market_closed_for_fetch = _market_mode in {"PRE_MARKET", "POST_MARKET", "HOLIDAY"}' in src
+    assert 'get_runtime_market_mode() != "OPEN"' not in src
+
+
+async def test_closed_modes_block_open_and_unknown_allow() -> None:
+    closed = {"PRE_MARKET", "POST_MARKET", "HOLIDAY"}
+    assert all(m in closed for m in ("PRE_MARKET", "POST_MARKET", "HOLIDAY"))
+    assert "OPEN" not in closed and "UNKNOWN" not in closed


### PR DESCRIPTION
Big-review item #6 (history "required and forbidden at once"): option-context broker fetch was disabled whenever market mode `!= "OPEN"`. That over-broad gate also fired for the transient **UNKNOWN** mode around the open bell, so SMC's required option history was refused (`broker_fetch_not_allowed`), SMC stayed permanently **history-cold** (`smc_insufficient_history`), never voted, and **consensus was artificially suppressed** (can't get 2 votes when one strategy can't warm up).

## Fix (review's Policy A)
Block the option-context fetch only when the market is **genuinely closed** — `PRE_MARKET / POST_MARKET / HOLIDAY` — not for `OPEN` or transient `UNKNOWN`. SMC can now hydrate as soon as the session is live and contribute votes, improving signal frequency **and** consensus quality without lowering any quality bar. Still no pre/post-market broker hammering.

## Validation
Closed modes block; OPEN and UNKNOWN allow. The previously-deselected isolation test still passes in isolation (intent preserved). Full suite **2413 passed**.