### PR TITLE
fix: safe env-float parser for single-vote score floor

### DIFF
--- a/src/nifty_scalper_bot/core/strategy_manager.py
+++ b/src/nifty_scalper_bot/core/strategy_manager.py
@@ -4028,7 +4028,7 @@ class StrategyManager(_BaseStrategyManager):
             # Single-vote (no consensus) is riskier, so a lone selected-option scalp
             # must clear a high score floor (default 9.0) on top of the normal gates.
             # This keeps single-vote trades to only the strongest signals.
-            selected_single_min = float(os.getenv("STRATEGY_SELECTED_OPTION_SINGLE_VOTE_MIN_SCORE", "9.0") or "9.0")
+            selected_single_min = self._env_float("STRATEGY_SELECTED_OPTION_SINGLE_VOTE_MIN_SCORE", 9.0)
             if selected_option_scalp_allowed and raw_trigger_score < selected_single_min:
                 selected_option_scalp_allowed = False
             scalp_fallback_allowed = bool((allow_scalp_single and threshold_passed) or selected_option_scalp_allowed)

--- a/tests/strategies/test_single_vote_score_floor.py
+++ b/tests/strategies/test_single_vote_score_floor.py
@@ -48,3 +48,12 @@ async def test_smc_option_context_fetch_allowed_at_open() -> None:
         assert mode in {"PRE_MARKET", "POST_MARKET", "HOLIDAY"}
     for mode in ("OPEN", "UNKNOWN"):
         assert mode not in {"PRE_MARKET", "POST_MARKET", "HOLIDAY"}
+
+
+async def test_malformed_score_env_does_not_crash() -> None:
+    # #13: a malformed STRATEGY_SELECTED_OPTION_SINGLE_VOTE_MIN_SCORE must fall back
+    # to the default, not raise ValueError inside signal combination.
+    from nifty_scalper_bot.config.env_utils import parse_float_env
+    assert parse_float_env("high", 9.0) == 9.0
+    assert parse_float_env("", 9.0) == 9.0
+    assert parse_float_env("9.5", 9.0) == 9.5


### PR DESCRIPTION
PR #670 read `STRATEGY_SELECTED_OPTION_SINGLE_VOTE_MIN_SCORE` via raw `float(os.getenv(...))`. A malformed value (e.g. `=high`) would raise **ValueError inside signal combination**, killing the evaluation. Switched to the existing `_env_float` safe parser, which falls back to the 9.0 default on bad input. Defends against an operator env typo taking down signal generation.

Test: `parse_float_env('high', 9.0)` -> 9.0; valid values pass through. Full suite green.