### PR TITLE
fix(P0): TP exit prices off bid (not ltp*0.98) + post-fill RR check

### DIFF
--- a/src/nifty_scalper_bot/execution/bracket_manager.py
+++ b/src/nifty_scalper_bot/execution/bracket_manager.py
@@ -1101,6 +1101,30 @@ class BracketManager:
                     )
             
             # ✅ Activate only after explicit fill confirmation
+            # Post-fill reward:risk check. The real incident activated entry=223.90
+            # SL=214.61 TP=227.76 -> risk 9.29, reward 3.86, RR 0.42 (reward < risk),
+            # silently. Surface poor geometry loudly so it is auditable. We do NOT
+            # reject here (the position is already filled; rejecting would leave it
+            # unprotected) — but a sub-floor RR is logged CRITICAL for visibility.
+            try:
+                rr_risk = abs(fill_price - bracket.sl_trigger_price)
+                rr_reward = abs(bracket.tp_trigger_price - fill_price)
+                rr = (rr_reward / rr_risk) if rr_risk > 0 else 0.0
+                rr_floor = parse_float_env(os.getenv("MIN_BRACKET_RR"), 1.5)
+                if rr_risk <= 0 or rr_reward <= 0 or rr < rr_floor:
+                    LOGGER.critical(
+                        "BRACKET_RR_BELOW_FLOOR symbol=%s entry=%.2f sl=%.2f tp=%.2f risk=%.2f reward=%.2f rr=%.2f floor=%.2f",
+                        bracket.symbol, fill_price, bracket.sl_trigger_price,
+                        bracket.tp_trigger_price, rr_risk, rr_reward, rr, rr_floor,
+                    )
+                    self._notify_event(
+                        "BRACKET_RR_BELOW_FLOOR",
+                        {"symbol": bracket.symbol, "entry": round(fill_price, 2),
+                         "sl": round(bracket.sl_trigger_price, 2), "tp": round(bracket.tp_trigger_price, 2),
+                         "rr": round(rr, 2), "floor": rr_floor},
+                    )
+            except Exception:  # noqa: BLE001 - never let RR check block protection
+                pass
             bracket.active = True
             bracket.entry_confirmed = True
             bracket.entry_status = "ACTIVE"
@@ -2320,13 +2344,37 @@ class BracketManager:
                     raw = reference - buffer if side == "SELL" else reference + buffer
                     return "LIMIT", _round_to_tick(max(raw, tick_size), tick_size=tick_size), {"mode": "AGGRESSIVE_LIMIT", "bid": bid, "ask": ask, "ltp": ltp, "fallback": False}
         elif mode == "LIMIT" and bracket is not None:
-            current_ltp = float(bracket.last_ltp or bracket.entry_price or 0.0)
-            if current_ltp > 0:
-                max_slippage_pct = parse_float_env(os.getenv("EXIT_MAX_SLIPPAGE_PCT"), 2.0)
-                raw = current_ltp * (1 - max_slippage_pct / 100) if side == "SELL" else current_ltp * (1 + max_slippage_pct / 100)
-                return "LIMIT", _round_to_tick(max(raw, 0.05), tick_size=0.05), {"mode": "LIMIT", "bid": bid, "ask": ask, "ltp": current_ltp, "fallback": False}
-            mode = "MARKET"
-            fallback = True
+            # Profit-target exits (TP/TP1/TP2/trailing-profit) must NOT take the 2%
+            # downward concession used for generic limits — that converts a winning
+            # TP into a loss (real incident: TP latched, SELL LIMIT priced at
+            # ltp*0.98 = 224.35, cancelled, replacement filled at 222.30 => -₹104).
+            # Price profit exits at the executable bid (SELL) / ask (BUY) with only a
+            # small tick buffer; fall back to LTP minus a tick, never minus 2%.
+            is_profit_exit = any(
+                tok in str(reason or "").upper()
+                for tok in ("TP", "TAKE_PROFIT", "TRAILING_PROFIT", "TARGET")
+            )
+            if is_profit_exit:
+                bid, ask, ltp = self._extract_exit_quote(symbol)
+                tick_size = 0.05
+                reference = (bid if side == "SELL" else ask)
+                if reference is None or reference <= 0:
+                    reference = ltp if (ltp and ltp > 0) else float(bracket.last_ltp or 0.0)
+                if reference and reference > 0:
+                    tick_buffer = self._exit_marketable_limit_slippage_ticks * tick_size
+                    raw = reference - tick_buffer if side == "SELL" else reference + tick_buffer
+                    return "LIMIT", _round_to_tick(max(raw, tick_size), tick_size=tick_size), {"mode": "PROFIT_LIMIT", "bid": bid, "ask": ask, "ltp": ltp, "fallback": False}
+                # no usable quote -> fall through to MARKET (do not give 2% away)
+                mode = "MARKET"
+                fallback = True
+            else:
+                current_ltp = float(bracket.last_ltp or bracket.entry_price or 0.0)
+                if current_ltp > 0:
+                    max_slippage_pct = parse_float_env(os.getenv("EXIT_MAX_SLIPPAGE_PCT"), 2.0)
+                    raw = current_ltp * (1 - max_slippage_pct / 100) if side == "SELL" else current_ltp * (1 + max_slippage_pct / 100)
+                    return "LIMIT", _round_to_tick(max(raw, 0.05), tick_size=0.05), {"mode": "LIMIT", "bid": bid, "ask": ask, "ltp": current_ltp, "fallback": False}
+                mode = "MARKET"
+                fallback = True
         return mode, None, {"mode": "MARKET" if mode == "MARKET" else mode, "bid": bid, "ask": ask, "ltp": ltp, "fallback": fallback}
 
     def submit_exit_order(

--- a/tests/execution/test_tp_exit_pricing_and_rr.py
+++ b/tests/execution/test_tp_exit_pricing_and_rr.py
@@ -1,0 +1,73 @@
+"""Regression for the real 23750CE incident:
+BUY 223.90 -> TP latched -> SELL LIMIT 224.35 (ltp*0.98) cancelled -> filled 222.30 (-₹104).
+
+Two defects: (1) TP exit priced at ltp*0.98 (a 2% giveaway that turns a win into a
+loss); (2) a sub-1.0 reward:risk bracket (RR 0.42) activated silently.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from nifty_scalper_bot.execution.bracket_manager import BracketManager
+
+
+class _OM:
+    def __init__(self) -> None:
+        self._broker = None
+    def place_order(self, **k: Any) -> str:
+        return "x"
+    def cancel_order(self, _o: str) -> bool:
+        return True
+
+
+def _mgr_with_bracket():
+    mgr = BracketManager(order_manager=_OM())
+    mgr.register_virtual_bracket(
+        order_id="e1", symbol="NFO:NIFTY26JUN23750CE", side="BUY",
+        qty=65, price=223.90, sl=214.61, tp=227.76,
+    )
+    return mgr, next(iter(mgr._brackets.values()))
+
+
+async def test_tp_exit_prices_off_bid_not_ltp_concession() -> None:
+    mgr, b = _mgr_with_bracket()
+    b.last_ltp = 228.90
+    mgr._extract_exit_quote = lambda s: (227.80, 228.00, 228.90)  # bid, ask, ltp
+    ot, price, meta = mgr._price_exit_order(
+        bracket=b, symbol=b.symbol, side="SELL", reason="HARD_TP_BREACH",
+        preferred_order_type="LIMIT", qty=65,
+    )
+    assert ot == "LIMIT"
+    assert meta["mode"] == "PROFIT_LIMIT"
+    # must be well above entry (locking profit), NOT ltp*0.98 = 224.32
+    assert price > 223.90
+    assert abs(price - 228.90 * 0.98) > 1.0
+
+
+async def test_protective_exit_still_market() -> None:
+    mgr, b = _mgr_with_bracket()
+    b.last_ltp = 210.0
+    ot, price, meta = mgr._price_exit_order(
+        bracket=b, symbol=b.symbol, side="SELL", reason="HARD_SL_BREACH",
+        preferred_order_type="MARKET", qty=65,
+    )
+    assert ot == "MARKET"  # protective exits unchanged (flatten fast)
+
+
+async def test_post_fill_rr_below_floor_logged(caplog) -> None:
+    mgr, b = _mgr_with_bracket()
+    with caplog.at_level(logging.CRITICAL):
+        mgr.confirm_entry_fill("e1", 223.90)  # RR = 3.86/9.29 = 0.42
+    assert any("BRACKET_RR_BELOW_FLOOR" in r.getMessage() for r in caplog.records)
+
+
+async def test_good_rr_not_flagged(caplog) -> None:
+    mgr = BracketManager(order_manager=_OM())
+    mgr.register_virtual_bracket(
+        order_id="e2", symbol="NFO:NIFTY26JUN23750CE", side="BUY",
+        qty=65, price=100.0, sl=95.0, tp=110.0,  # risk 5, reward 10, RR 2.0
+    )
+    with caplog.at_level(logging.CRITICAL):
+        mgr.confirm_entry_fill("e2", 100.0)
+    assert not any("BRACKET_RR_BELOW_FLOOR" in r.getMessage() for r in caplog.records)


### PR DESCRIPTION
Reproduces and fixes the real **23750CE incident**: BUY 223.90 -> TP latched -> SELL LIMIT 224.35 (= `ltp*0.98`) cancelled 0/65 -> replacement filled 222.30 = **-₹104** on what should have been a winning TP.

## Root cause 1 — TP exit priced with a 2% concession
`_price_exit_order`'s non-protective LIMIT branch priced **every** exit (incl. TP) at `current_ltp*(1 - 2%)`. For a profit-target SELL that prices *below* the target and *below entry*, turning a win into a loss. **Fix:** profit-target reasons (TP/TAKE_PROFIT/TRAILING_PROFIT/TARGET) now price at the **executable bid** (SELL) / ask (BUY) minus a small tick buffer (`PROFIT_LIMIT`); no quote -> MARKET, never give 2% away. Protective exits (HARD_SL/WATCHDOG/FORCED/EOD/ESCALATED) stay MARKET, unchanged. Verified: with bid 227.80 the TP exit prices **227.55** (locks profit) instead of 224.32.

## Root cause 2 — sub-floor reward:risk activated silently
The bracket was entry 223.90 / SL 214.61 / TP 227.76 => risk 9.29, reward 3.86, **RR 0.42**. `confirm_entry_fill` now logs **CRITICAL `BRACKET_RR_BELOW_FLOOR`** (+ Telegram) when risk/reward<=0 or RR < `MIN_BRACKET_RR` (default 1.5). Does **not** reject (position already filled; rejecting would leave it unprotected) — surfaces loudly for audit.

## Validation
Tests: incident values flagged; TP prices off bid not *0.98; protective stays MARKET; good RR (2.0) not flagged. Full suite **2423 passed**.

## Deferred (to avoid over-engineering a live path; staged follow-up)
ExecutionPermit SSOT, BasketSnapshot atomicity, global candidate arbitration, canonical quote object, TP confirmation-ticks, signal-age/drift gate, trading-date P&L persistence.