### PR TITLE
fix: negative utilised margin field must not fail balance refresh

### DIFF
--- a/src/nifty_scalper_bot/data/rest/zerodha_client.py
+++ b/src/nifty_scalper_bot/data/rest/zerodha_client.py
@@ -1731,7 +1731,7 @@ class ZerodhaKiteClient(BaseBrokerClient):
         if not isinstance(utilised_map, Mapping):
             utilised_map = {}
 
-        def _number(name: str, value: Any, *, required: bool = True) -> float:
+        def _number(name: str, value: Any, *, required: bool = True, allow_negative: bool = False) -> float:
             if value is None:
                 if required:
                     raise BrokerBalanceUnavailableError(f"missing_margin_field:{name}")
@@ -1742,7 +1742,7 @@ class ZerodhaKiteClient(BaseBrokerClient):
                 raise BrokerBalanceUnavailableError(f"invalid_margin_field:{name}") from exc
             if not math.isfinite(parsed):
                 raise BrokerBalanceUnavailableError(f"non_finite_margin_field:{name}")
-            if parsed < 0.0:
+            if parsed < 0.0 and not allow_negative:
                 raise BrokerBalanceUnavailableError(f"negative_margin_field:{name}")
             return parsed
 
@@ -1758,7 +1758,10 @@ class ZerodhaKiteClient(BaseBrokerClient):
         for key in ("debits", "span", "exposure", "option_premium", "holding_sales"):
             value = utilised_map.get(key)
             if value is not None:
-                used += _number(f"utilised.{key}", value, required=False)
+                # Utilised components can legitimately be negative (e.g. a debits
+                # reversal/credit). A negative utilised field must NOT fail the whole
+                # balance refresh (which previously cascaded to BROKER NOT READY).
+                used += _number(f"utilised.{key}", value, required=False, allow_negative=True)
         net_value = target.get("net")
         net = _number("net", net_value) if net_value is not None else available + used
         return {

--- a/tests/data/test_zerodha_margin_payload.py
+++ b/tests/data/test_zerodha_margin_payload.py
@@ -94,3 +94,33 @@ def test_normalize_margin_payload_supports_available_cash() -> None:
     assert summary["available"] == pytest.approx(175_000.0)
     assert summary["net"] == pytest.approx(175_000.0)
 
+
+
+def test_negative_utilised_debits_does_not_fail_refresh() -> None:
+    """A negative utilised.debits (legit reversal/credit) must NOT fail the whole
+    balance refresh — it previously raised negative_margin_field and cascaded to
+    BROKER NOT READY."""
+    client = _build_client()
+    payload: Mapping[str, Any] = {
+        "equity": {
+            "available": {"cash": 16_248.60, "live_balance": 16_248.60},
+            "utilised": {"debits": -1_500.0, "exposure": 500.0},
+            "net": 16_248.60,
+        }
+    }
+    summary = client._normalize_margin_payload(payload, segment="equity")
+    assert summary["available"] == 16_248.60  # balance preserved
+    assert summary["used"] == -1_000.0  # -1500 + 500, negative debits honoured
+
+
+def test_negative_available_cash_still_rejected() -> None:
+    """Available (deployable) balance must remain strictly non-negative."""
+    client = _build_client()
+    payload: Mapping[str, Any] = {
+        "equity": {
+            "available": {"cash": -100.0},
+            "utilised": {"debits": 0.0},
+        }
+    }
+    with pytest.raises(Exception):
+        client._normalize_margin_payload(payload, segment="equity")


### PR DESCRIPTION
## Root-level fix
Log showed `ZERODHA_BALANCE_REFRESH_FAILED segment=equity reason=negative_margin_field:utilised.debits` cascading to **BROKER NOT READY / BALANCE unavailable**. Root cause: the margin parser rejected **any** negative field, but Zerodha's `utilised.*` components (debits/exposure/etc.) can legitimately be negative (a debits reversal/credit). A negative there must not invalidate the whole refresh.

**Fix:** `_number()` gains `allow_negative`; `utilised.*` fields parse with `allow_negative=True` (a negative debit is summed as-is), while `available.*` (deployable balance) stays **strictly non-negative** — a negative available balance is still rejected.

Tests: negative `utilised.debits` flows through (balance preserved); negative `available.cash` still rejected. Full suite **2425 passed**.

## The rest of this log is already fixed in main — it's a deployment lag
The flood of `name 'logging' is not defined` (watchdog) and the repeating **ORPHAN AUTO-ADOPT** loop are **both already fixed in main**: #669 (`import logging`) and the symbol-stable orphan-id dedup. Verified on main: orphan attach is **idempotent** (`is_symbol_managed` True after first attach, 1 bracket; loop does not reproduce). They persist in the log only because the deployment is still on old commit `6263c62` and has not been redeployed.