### PR TITLE
fix(P0): zero/low balance must not mark broker balance_stale forever

### DIFF
--- a/src/nifty_scalper_bot/execution/order_manager.py
+++ b/src/nifty_scalper_bot/execution/order_manager.py
@@ -7652,20 +7652,23 @@ class OrderManager:
                 )
                 return None, "margin_read_failed"
             else:
-                if available is not None and available > 0:
+                # Record freshness whenever the broker returns a VALID reading,
+                # even if it is zero. Staleness must mean "we haven't reached the
+                # broker recently" — not "the number was zero". Previously only a
+                # >0 balance recorded success, so a healthy broker returning a low/
+                # zero available balance left _last_margin_success_ts=None forever
+                # -> balance_stale=True / margin_age_s=None permanently blocked live
+                # orders (observed: BROKER_HEALTH_LIVE_ORDERS_BLOCKED for the whole
+                # session). Sizing still independently refuses qty on balance<=0
+                # (live), so recording a zero reading as fresh cannot oversize.
+                if available is not None and math.isfinite(float(available)) and float(available) >= 0:
                     self._record_margin_refresh_success(float(available), "mdm")
                     return float(available), "mdm"
         risk_manager = self._risk_manager
         if risk_manager is not None:
             with suppress(Exception):
                 balance = float(getattr(risk_manager, "current_balance", 0.0))
-                if math.isfinite(balance) and balance > 0:
-                    # A positive balance from the risk manager is a valid margin
-                    # reading. Record it as a success so broker-health freshness is
-                    # established; otherwise, when the MDM margin snapshot isn't
-                    # primed yet at startup, _last_margin_success_ts stays None
-                    # forever -> balance_stale=True / margin_age_s=None permanently
-                    # blocks live orders even though the broker is healthy.
+                if math.isfinite(balance) and balance >= 0:
                     self._record_margin_refresh_success(balance, "risk")
                     return balance, "risk"
         return None, "unknown"

--- a/tests/execution/test_margin_freshness_zero_balance.py
+++ b/tests/execution/test_margin_freshness_zero_balance.py
@@ -1,0 +1,60 @@
+"""Root fix: a healthy broker returning a low/zero available balance must still
+record margin freshness, otherwise balance_stale=True / margin_age_s=None blocks
+live orders forever (observed: BROKER_HEALTH_LIVE_ORDERS_BLOCKED all session)."""
+from __future__ import annotations
+
+import math
+import time
+from contextlib import suppress
+from typing import Any
+
+from nifty_scalper_bot.execution.order_manager import OrderManager
+
+
+def _bare_om() -> OrderManager:
+    om = OrderManager.__new__(OrderManager)
+    om._last_margin_success_ts = None
+    om._last_margin_refresh_ts = None
+    om._last_margin_available_balance = None
+    om._last_margin_balance_source = None
+    om._last_margin_error_type = None
+    om._last_margin_error = None
+    om._margin_circuit_open = False
+    om._margin_circuit_until_ts = None
+    om._data_hub = None
+    om._market_data = None
+    om._risk_manager = None
+    return om
+
+
+class _MDMZero:
+    def refresh_margin_snapshot(self) -> None:
+        return None
+    def get_available_balance(self) -> float:
+        return 0.0  # healthy broker, genuinely zero/low available
+
+
+class _MDMPositive:
+    def refresh_margin_snapshot(self) -> None:
+        return None
+    def get_available_balance(self) -> float:
+        return 16248.60
+
+
+async def test_zero_balance_records_freshness() -> None:
+    om = _bare_om()
+    om._data_hub = _MDMZero()
+    available, source = om._resolve_available_margin_raw()
+    assert source == "mdm"
+    assert available == 0.0
+    # crucial: freshness timestamp set -> margin_age_s will be a real number,
+    # not None -> balance_stale resolves to False
+    assert om._last_margin_success_ts is not None
+
+
+async def test_positive_balance_still_records() -> None:
+    om = _bare_om()
+    om._data_hub = _MDMPositive()
+    available, source = om._resolve_available_margin_raw()
+    assert source == "mdm" and available == 16248.60
+    assert om._last_margin_success_ts is not None


### PR DESCRIPTION
## Root cause of the whole-session trading block
`BROKER_HEALTH_LIVE_ORDERS_BLOCKED` fired **82x** across the 09:15-15:30 log -> EXECUTION BLOCKED / ORDERS OFF / BROKER NOT READY, no trades. Block class `broker_health_stale` with `broker_connected=True, margin_api_available=True, balance_stale=True, margin_age_s=None`.

`_resolve_available_margin_raw` recorded a margin **success** (sets `_last_margin_success_ts`) **only when balance > 0** — both the MDM path and the risk-manager fallback. So when a healthy broker returns a genuinely low/zero available balance, success was never recorded, `_last_margin_success_ts` stayed None, `margin_age_s` stayed None, `balance_stale` stayed True **permanently**, and the self-heal fetch (also `>0`) never cleared it -> live orders blocked all day though the broker was responding.

## Fix
Record margin freshness on any **valid, finite, non-negative** reading (`>= 0`), not only `> 0`. Staleness now means "we haven't reached the broker recently", not "the number was zero". **Cannot oversize**: live sizing independently refuses qty on balance ≤ 0 (#668), so a fresh zero reading still blocks the trade on sizing — it just stops the false broker-stale block.

## Validation
Discrimination-verified (reverting `>=0` to `>0` fails the zero case): zero balance records freshness; positive still records. Full suite **2430 passed**.