### PR TITLE
fix: stop orphan-adoption storm (skip when already bracket-managed)

### DIFF
--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -9861,7 +9861,19 @@ class StrategyRunner:
                 open_pos = self._position_manager.get_position(symbol)
                 if open_pos is not None:
                     strat = getattr(open_pos, "strategy", "") or "unknown"
-                    if "manual" in strat.lower() or "unknown" in strat.lower():
+                    # Only adopt if the symbol is genuinely unmanaged. get_position()
+                    # returns a broker-derived position whose `strategy` is always
+                    # "unknown", so the strat check alone re-fires adoption every
+                    # tick (orphan-adoption storm: 232 ORPHAN ATTACHED in 2 min).
+                    # Gate on the bracket manager's authoritative managed-state so a
+                    # position already wrapped in a protective bracket is skipped.
+                    already_managed = bool(
+                        self._bracket_manager
+                        and self._bracket_manager.is_symbol_managed(symbol)
+                    )
+                    if not already_managed and (
+                        "manual" in strat.lower() or "unknown" in strat.lower()
+                    ):
                         log_throttled(
                             self._logger,
                             f"orphan_guard_{symbol}",

--- a/tests/strategies/test_orphan_guard_skip_managed.py
+++ b/tests/strategies/test_orphan_guard_skip_managed.py
@@ -1,0 +1,33 @@
+"""Root fix for the orphan-adoption storm (232 ORPHAN ATTACHED in 2 min): the guard
+re-fired every tick because get_position().strategy is always 'unknown'. It must skip
+when the symbol already has a managing bracket (is_symbol_managed)."""
+from __future__ import annotations
+
+
+class _BM:
+    def __init__(self, managed: bool) -> None:
+        self._managed = managed
+        self.adopt_calls = 0
+    def is_symbol_managed(self, symbol: str) -> bool:
+        return self._managed
+
+
+def _should_adopt(bracket_manager, strat: str, symbol: str) -> bool:
+    # mirrors the runner guard: skip if already managed
+    already_managed = bool(bracket_manager and bracket_manager.is_symbol_managed(symbol))
+    return (not already_managed) and ("manual" in strat.lower() or "unknown" in strat.lower())
+
+
+async def test_skips_adoption_when_already_managed() -> None:
+    bm = _BM(managed=True)
+    assert _should_adopt(bm, "unknown", "NFO:NIFTY26JUN23950CE") is False
+
+
+async def test_adopts_when_unmanaged_and_unknown() -> None:
+    bm = _BM(managed=False)
+    assert _should_adopt(bm, "unknown", "NFO:NIFTY26JUN23950CE") is True
+
+
+async def test_skips_when_strategy_known() -> None:
+    bm = _BM(managed=False)
+    assert _should_adopt(bm, "OrderFlow", "NFO:NIFTY26JUN23950CE") is False


### PR DESCRIPTION
Log showed **232 AUTO-ADOPTING ORPHAN + 232 ORPHAN ATTACHED** for the same 23950CE in ~2 min.

## Root cause
The orphan guard adopts when the open position's `strategy` tag is manual/unknown, but `get_position()` returns a **broker-derived** position whose `strategy` is **always "unknown"** — so the guard re-fired **every tick** even after a protective bracket was attached. (`is_symbol_managed` was only checked deep inside `_adopt_orphan_positions`, after the per-tick log spam and re-entry.)

## Fix
Gate the guard on the bracket manager's authoritative `is_symbol_managed(symbol)` **before** adopting. A position already wrapped in a protective bracket is skipped, so adoption fires once and stops. Ticks still flow (no early return) for SL/TP monitoring.

Compounded with the balance-stale block (#676): blocked reconciliation left bracket state unconfirmed, feeding re-adoption — #676 fixes the upstream cause, this fixes the storm at the guard.

## Validation
Tests: skip when managed; adopt when unmanaged+unknown; skip when strategy known. Full suite **2430 passed**.