### PR TITLE
fix(P0): use live_balance when Zerodha available.cash=0

### DIFF
--- a/src/nifty_scalper_bot/data/rest/zerodha_client.py
+++ b/src/nifty_scalper_bot/data/rest/zerodha_client.py
@@ -1754,6 +1754,13 @@ class ZerodhaKiteClient(BaseBrokerClient):
         available = _number("available.cash", cash_value)
         live_balance = _number("available.live_balance", available_map.get("live_balance"), required=False)
         opening_balance = _number("available.opening_balance", available_map.get("opening_balance"), required=False)
+        # Zerodha frequently reports available.cash=0 while the real deployable
+        # intraday margin sits in live_balance (and net). Keying off cash alone made
+        # the bot see a ₹0 balance (dashboard 'BALANCE —') and refuse to size/trade
+        # despite funded margin. When cash is non-positive but live_balance is
+        # positive, prefer live_balance as the usable available balance.
+        if available <= 0.0 and live_balance > 0.0:
+            available = live_balance
         used = 0.0
         for key in ("debits", "span", "exposure", "option_premium", "holding_sales"):
             value = utilised_map.get(key)

--- a/tests/data/test_zerodha_margin_payload.py
+++ b/tests/data/test_zerodha_margin_payload.py
@@ -124,3 +124,48 @@ def test_negative_available_cash_still_rejected() -> None:
     }
     with pytest.raises(Exception):
         client._normalize_margin_payload(payload, segment="equity")
+
+
+def test_parse_uses_live_balance_when_cash_is_zero() -> None:
+    """Zerodha reports available.cash=0 while real deployable margin is in
+    live_balance/net. The bot must use live_balance, not see a ₹0 balance
+    (dashboard 'BALANCE —' + broker-stale block + no trades)."""
+    client = _build_client()
+    payload: Mapping[str, Any] = {
+        "equity": {
+            "available": {"cash": 0.0, "live_balance": 16_248.60, "opening_balance": 16_000.0},
+            "utilised": {"debits": 0.0},
+            "net": 16_248.60,
+        }
+    }
+    summary = client._parse_account_margin_summary(payload, segment="equity")
+    assert summary["available"] == 16_248.60
+
+
+def test_parse_prefers_positive_cash_over_live_balance() -> None:
+    """When available.cash is positive it is the deployable balance and must win."""
+    client = _build_client()
+    payload: Mapping[str, Any] = {
+        "equity": {
+            "available": {"cash": 50_000.0, "live_balance": 48_000.0},
+            "utilised": {"debits": 0.0},
+            "net": 50_000.0,
+        }
+    }
+    summary = client._parse_account_margin_summary(payload, segment="equity")
+    assert summary["available"] == 50_000.0
+
+
+def test_parse_zero_everywhere_stays_zero() -> None:
+    """If both cash and live_balance are zero, available is genuinely zero
+    (sizing then correctly blocks via #668 — no synthetic margin)."""
+    client = _build_client()
+    payload: Mapping[str, Any] = {
+        "equity": {
+            "available": {"cash": 0.0, "live_balance": 0.0},
+            "utilised": {"debits": 0.0},
+            "net": 0.0,
+        }
+    }
+    summary = client._parse_account_margin_summary(payload, segment="equity")
+    assert summary["available"] == 0.0


### PR DESCRIPTION
## Deeper root cause behind BROKER NOT READY / BALANCE '—' / no trades
The dashboard shows a **dash** (zero/None), not a number — the bot read a **₹0 balance despite a funded account**.

Zerodha's `/user/margins/equity` routinely returns `available.cash=0.00` while the real deployable intraday margin sits in `available.live_balance` (and `net`) — e.g. `cash=0.00, live_balance=16248.60, net=16248.60`. `_parse_account_margin_summary` only fell back from cash to live_balance when cash was **missing (None)**; a present **`cash=0.0` was taken as-is**. So `get_available_balance()` returned 0, sizing correctly refused to trade on ₹0 (#668), and broker-health showed balance unavailable -> **all orders blocked the whole session**.

## Fix
When `available.cash` is non-positive but `live_balance` is positive, use `live_balance` as the deployable available balance. Positive cash still wins; all-zero stays zero (sizing then blocks via #668 — no synthetic margin).

This is the **upstream** cause. #676 (record freshness on `>=0`) fixes the staleness flag, but the bot still needs the **correct non-zero balance** to size — that's this fix.

## Validation
Logic-verified: cash=0 + live_balance=16248 -> 16248; positive cash preserved; all-zero stays zero. Full suite **2433 passed**.