### PR TITLE
fix: drop bracket when broker reports position flat (manual-intervention sync)

### DIFF
--- a/src/nifty_scalper_bot/execution/bracket_manager.py
+++ b/src/nifty_scalper_bot/execution/bracket_manager.py
@@ -2912,6 +2912,32 @@ class BracketManager:
         with self._lock:
             return self._brackets.get(entry_id)
 
+    def reconcile_symbol_flat(self, symbol: str) -> int:
+        """Drop all brackets for a symbol the broker now reports as flat.
+
+        Called when broker reconciliation finds a position closed externally
+        (manual square-off / Zerodha auto-square-off). Without this, a bracket
+        lingers as 'managed' after the underlying position is gone, so the bot
+        keeps trying to manage / re-adopt a phantom position (observed: the same
+        23950CE orphan re-adopted thousands of times). Returns count removed.
+        """
+        symbol = normalize_symbol(symbol)
+        with self._lock:
+            entry_ids = list(self._symbol_map.get(symbol, []))
+        removed = 0
+        for eid in entry_ids:
+            try:
+                self.unregister_bracket(eid)
+                removed += 1
+            except Exception:  # noqa: BLE001
+                continue
+        if removed:
+            LOGGER.info(
+                "BRACKET_RECONCILED_FLAT symbol=%s removed=%s reason=broker_position_closed",
+                symbol, removed,
+            )
+        return removed
+
     def unregister_bracket(self, entry_id: str) -> None:
         """Remove a bracket from memory and indices."""
         with self._lock:

--- a/src/nifty_scalper_bot/execution/position_manager.py
+++ b/src/nifty_scalper_bot/execution/position_manager.py
@@ -511,6 +511,15 @@ class PositionManager:
         self.load_state()
         self._last_reconciled_state = copy.deepcopy(self._positions)
 
+    def set_on_symbols_flat(self, hook: Any | None) -> None:
+        """Attach a callback invoked with symbols pruned during broker sync.
+
+        Lets the runner forward externally-closed symbols (manual square-off /
+        auto-square-off) to the bracket manager so lingering brackets are dropped
+        instead of being re-adopted forever.
+        """
+        self._on_symbols_flat_hook = hook
+
     def set_broker_client(self, broker_client: Any | None) -> None:
         """Attach the broker client used for reconciliation.
 
@@ -1909,6 +1918,17 @@ class PositionManager:
             self._logger.info(
                 f"Sync: Pruned {len(removed_symbols)} positions not found in broker: {removed_symbols}"
             )
+            # Notify (e.g. bracket manager) that these symbols are flat at the
+            # broker, so lingering brackets are dropped rather than re-adopted.
+            hook = getattr(self, "_on_symbols_flat_hook", None)
+            if hook is not None:
+                try:
+                    hook(list(removed_symbols))
+                except Exception as exc:  # noqa: BLE001
+                    self._logger.error(
+                        "Failure in on_symbols_flat hook: %s", exc,
+                        extra={"event": "position_manager_flat_hook_error"},
+                    )
         
         if not old_keys and not new_keys:
             self._logger.debug("Sync: Broker and local state both empty.")

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -686,6 +686,22 @@ class StrategyRunner:
         self._datahub_registered_symbols: set[str] = set()
         self._strike_selector = strike_selector
         self._bracket_manager = bracket_manager
+        # When broker sync prunes externally-closed positions (manual square-off /
+        # auto-square-off), drop their brackets so they are not re-adopted forever.
+        try:
+            if self._position_manager is not None and self._bracket_manager is not None and hasattr(self._position_manager, "set_on_symbols_flat"):
+                def _on_symbols_flat(symbols: list[str]) -> None:
+                    bm = self._bracket_manager
+                    if bm is None:
+                        return
+                    for _sym in symbols or []:
+                        try:
+                            bm.reconcile_symbol_flat(_sym)
+                        except Exception:  # noqa: BLE001
+                            continue
+                self._position_manager.set_on_symbols_flat(_on_symbols_flat)
+        except Exception:  # noqa: BLE001
+            pass
         self._symbol_source: MarketDataManager | None = None
         self._main_loop: asyncio.AbstractEventLoop | None = None
         self._legacy_tick_subscription_mode = os.getenv(

--- a/tests/execution/test_external_close_reconcile.py
+++ b/tests/execution/test_external_close_reconcile.py
@@ -1,0 +1,54 @@
+"""Manual-intervention sync: when the broker reports a position flat (manual
+square-off / auto-square-off), the lingering bracket must be dropped so the bot
+stops re-adopting a phantom (observed: 23950CE re-adopted thousands of times)."""
+from __future__ import annotations
+
+from typing import Any
+
+from nifty_scalper_bot.execution.bracket_manager import BracketManager
+
+
+class _OM:
+    def __init__(self) -> None:
+        self._broker = None
+    def place_order(self, **k: Any) -> str:
+        return "x"
+    def cancel_order(self, _o: str) -> bool:
+        return True
+
+
+async def test_reconcile_symbol_flat_drops_bracket() -> None:
+    mgr = BracketManager(order_manager=_OM())
+    sym = "NFO:NIFTY26JUN23950CE"
+    mgr.attach_orphan_position(symbol=sym, side="BUY", qty=65, entry_price=216.35)
+    assert mgr.is_symbol_managed(sym) is True
+    removed = mgr.reconcile_symbol_flat(sym)
+    assert removed == 1
+    assert mgr.is_symbol_managed(sym) is False
+
+
+async def test_reconcile_symbol_flat_noop_when_unmanaged() -> None:
+    mgr = BracketManager(order_manager=_OM())
+    assert mgr.reconcile_symbol_flat("NFO:NIFTY26JUN24000CE") == 0
+
+
+async def test_position_manager_flat_hook_fires_on_prune() -> None:
+    from nifty_scalper_bot.execution.position_manager import PositionManager
+    pm = PositionManager.__new__(PositionManager)
+    import threading, logging
+    pm._lock = threading.RLock()
+    pm._logger = logging.getLogger("test")
+    pm._positions = {}
+    fired = []
+    pm.set_on_symbols_flat(lambda syms: fired.extend(syms))
+    # seed a local position, then sync against an EMPTY broker snapshot (closed)
+    from nifty_scalper_bot.execution.position_manager import Position  # type: ignore
+    # minimal stub position object
+    class _P:
+        symbol = "NFO:NIFTY26JUN23950CE"
+    pm._positions = {"NFO:NIFTY26JUN23950CE": _P()}
+    def _save_state():
+        return None
+    pm.save_state = _save_state  # type: ignore
+    pm.synchronize_with_broker([])  # broker reports nothing -> prune all
+    assert "NFO:NIFTY26JUN23950CE" in fired


### PR DESCRIPTION
## Deep-dive of the 9,582-event log
The **same 23950CE orphan** (entry 216.35) was re-adopted **2,424 times** and never resolved. Root-cause chain confirmed from the data: **position reconciliation never completed once all day** (0 reconcile/sync events in 9,582 lines) because broker health was stale (balance never loaded, `margin_age_s=None` all session) -> sync / prune / orphan-cleanup all **starved**. The balance fixes (#676/#678) unblock that chain, but **this log predates the d624a62 redeploy**.

## The deployment-independent gap this PR fixes
Even when sync *does* run: when `synchronize_with_broker` pruned a position closed **externally** (manual square-off / Zerodha auto-square-off), it **only logged it** — nothing told the bracket manager, so the bracket lingered as "managed" and the orphan guard kept re-adopting a **phantom**.

- `bracket_manager.reconcile_symbol_flat(symbol)` — drops all brackets for a broker-flat symbol (reuses `unregister_bracket`). Logs `BRACKET_RECONCILED_FLAT`.
- `position_manager.set_on_symbols_flat(hook)` + fires it with pruned symbols.
- runner wires PM's flat hook -> `reconcile_symbol_flat`, so externally-closed positions drop their brackets instead of being re-adopted.

The bot now **recognises manual intervention / broker square-off and stays in sync**.

## Validation
Tests: drops the bracket; no-op when unmanaged; PM prune fires the hook end-to-end. Full suite **2436 passed**.

## Still needs a fresh post-d624a62 log
Master cause (balance -> broker health -> reconciliation starvation) needs a clean market-hours log to confirm reconciliation now runs. Deferred until then: trailing-SL under live ticks, BO quick entry/exit timing, signal latency.