### PR TITLE
fix: adaptive trailing SL ratchet notifies Telegram (was log-only)

### DIFF
--- a/src/nifty_scalper_bot/execution/hardened_bracket_manager.py
+++ b/src/nifty_scalper_bot/execution/hardened_bracket_manager.py
@@ -259,6 +259,24 @@ class HardenedBracketManager(_LegacyBracketManager):
                 "ltp": ltp,
             },
         )
+        # Notify Telegram on a meaningful trail move (throttled) so dynamic SL
+        # tightening is visible to the operator, not just in logs.
+        try:
+            notify = getattr(self, "_should_notify_trail", None)
+            emit = getattr(self, "_notify_event", None)
+            if callable(notify) and callable(emit) and notify(target.bracket_id, proposed, current):
+                emit(
+                    "TRAILING_SL_UPDATED",
+                    {
+                        "symbol": target.symbol,
+                        "old_sl": round(current, 2),
+                        "new_sl": round(proposed, 2),
+                        "tp": round(float(target.tp_trigger_price), 2),
+                        "reason": "adaptive_atr_trail",
+                    },
+                )
+        except Exception:  # noqa: BLE001 - notification must never break trailing
+            pass
         return True
 
     # ------------------------------------------------------------------

--- a/tests/execution/test_adaptive_trail_telegram_notify.py
+++ b/tests/execution/test_adaptive_trail_telegram_notify.py
@@ -1,0 +1,52 @@
+"""Adaptive trailing SL ratchet (the production hardened path) must notify Telegram."""
+from __future__ import annotations
+
+from typing import Any
+
+from nifty_scalper_bot.execution.bracket_manager import BracketManager
+
+
+class _OM:
+    def __init__(self) -> None:
+        self._broker = None
+    def place_order(self, **k: Any) -> str:
+        return "x"
+    def cancel_order(self, _o: str) -> bool:
+        return True
+
+
+def _mgr_with_bracket(captured: list):
+    mgr = BracketManager(order_manager=_OM())
+    mgr._notify_event = lambda name, meta=None: captured.append((name, meta))  # type: ignore
+    mgr.register_virtual_bracket(
+        order_id="e1", symbol="NFO:NIFTY26JUN23950CE", side="BUY",
+        qty=65, price=216.35, sl=210.0, tp=230.0,
+    )
+    b = mgr._brackets["e1"]
+    b.last_ltp = 220.0
+    mgr._trail_notify_sl.clear()
+    mgr._trail_notify_at.clear()
+    captured.clear()
+    return mgr, b
+
+
+async def test_trail_ratchet_emits_telegram_event() -> None:
+    cap: list = []
+    mgr, b = _mgr_with_bracket(cap)
+    ok = mgr._virtual_modify_sl("vsl_e1", 215.0)  # BUY: 210 < 215 < ltp 220
+    assert ok is True
+    assert b.sl_trigger_price == 215.0
+    trail = [c for c in cap if c[0] == "TRAILING_SL_UPDATED"]
+    assert trail, "trail ratchet must emit TRAILING_SL_UPDATED"
+    assert trail[0][1]["reason"] == "adaptive_atr_trail"
+    assert trail[0][1]["new_sl"] == 215.0
+
+
+async def test_trail_ratchet_monotonic_rejects_backward_move() -> None:
+    cap: list = []
+    mgr, b = _mgr_with_bracket(cap)
+    # BUY SL can only move UP; a lower proposed SL is rejected (no notify)
+    ok = mgr._virtual_modify_sl("vsl_e1", 205.0)
+    assert ok is False
+    assert b.sl_trigger_price == 210.0
+    assert not [c for c in cap if c[0] == "TRAILING_SL_UPDATED"]


### PR DESCRIPTION
## BO lifecycle audit (rejection -> fill -> bracket -> dynamic trail -> exit -> P&L -> re-arm)
Most of the chain is **well-built**: entry uses a peg/ladder `ExecutionPolicy` that **re-prices toward the market across retries** (handles "LTP moved" rejections by chasing the fill via `modify_order`, then cancels on timeout); TP1/TP2 multi-target + partial-scaling infrastructure exists; protective-trail moves already notify Telegram.

## Gap found and fixed
The **production** trailing path is `HardenedBracketManager._virtual_modify_sl` (it overrides the base manager's method), and it **only logged** `VIRTUAL_TRAILING_SL_RATCHET` — dynamic SL tightening was **invisible on Telegram**. (The base `bracket_manager._virtual_modify_sl` that *did* notify is **dead code**, shadowed by the hardened override — a real trap I verified via `inspect.getsource`.)

**Fix:** after a successful monotonic ratchet, emit a throttled `TRAILING_SL_UPDATED` Telegram event (reusing `_should_notify_trail`'s 60s / 0.5% throttle) with symbol/old_sl/new_sl/tp/reason. Wrapped so it can never break trailing. Monotonic safety (BUY SL only moves up, never above LTP) unchanged.

## Validation
Tests: ratchet 210->215 emits the event; backward move 210->205 rejected, emits nothing. Full suite **2438 passed**.

## Deferred (need a clean market-hours log with real fills)
TP1/TP2 dynamic re-targeting on volume/indicator shifts, exit->re-arm timing for the next signal, end-to-end BO entry/exit latency.