### PR TITLE
Stage 1: prevent false BO closure and protect TP1 residuals

### DIFF
--- a/.github/workflows/live-exit-safety-ci.yml
+++ b/.github/workflows/live-exit-safety-ci.yml
@@ -27,6 +27,7 @@ jobs:
       - name: Focused live-money safety regression tests
         run: |
           python -m pytest -q \
+            tests/execution/test_canonical_bracket_fill_integrity.py \
             tests/execution/test_live_exit_hardening.py \
             tests/execution/test_bracket_exit_state_machine.py \
             tests/execution/test_virtual_bracket_safety.py \

--- a/src/nifty_scalper_bot/execution/__init__.py
+++ b/src/nifty_scalper_bot/execution/__init__.py
@@ -3,6 +3,10 @@
 The public module paths remain unchanged. Import-time replacement keeps every
 existing caller on the single production execution path while applying the
 hardened implementations before any manager instance is constructed.
+
+The replacement mechanism is retained only for compatibility during staged
+canonicalisation.  ``CanonicalBracketManager`` is the sole runtime bracket
+class; later stages will construct it explicitly at the composition root.
 """
 
 from __future__ import annotations
@@ -21,14 +25,19 @@ _bracket_module = import_module(f"{__name__}.bracket_manager")
 from nifty_scalper_bot.execution.hardened_bracket_manager import (  # noqa: E402
     HardenedBracketManager,
 )
+from nifty_scalper_bot.execution.canonical_bracket_manager import (  # noqa: E402
+    CanonicalBracketManager,
+)
 
 # Preserve all established import paths, including
-# ``from ...execution.bracket_manager import BracketManager``.
+# ``from ...execution.bracket_manager import BracketManager``.  There is one
+# runtime export: the canonical fill-integrity manager.
 _bracket_module.AdaptiveTrailingController = HardenedAdaptiveTrailingController
-_bracket_module.BracketManager = HardenedBracketManager
+_bracket_module.BracketManager = CanonicalBracketManager
 
 
 __all__ = [
+    "CanonicalBracketManager",
     "HardenedAdaptiveTrailingController",
     "HardenedBracketManager",
 ]

--- a/src/nifty_scalper_bot/execution/canonical_bracket_manager.py
+++ b/src/nifty_scalper_bot/execution/canonical_bracket_manager.py
@@ -1,0 +1,467 @@
+"""Canonical runtime bracket manager for staged BO lifecycle consolidation.
+
+Stage 1 intentionally preserves the established hardened manager behaviour and
+adds only fill-integrity invariants:
+
+* confirmed entry slippage re-anchors every unexecuted target;
+* a broker FILLED exit cannot close local state while broker exposure remains;
+* a confirmed TP1 fill resumes protection for the residual position;
+* any other FILLED/non-flat mismatch fails closed and blocks new entries.
+
+The compatibility inheritance is temporary.  Later stages will fold these
+invariants into the single explicit bracket implementation and remove runtime
+class replacement.
+"""
+
+from __future__ import annotations
+
+from contextlib import suppress
+import time
+from typing import Any, Mapping
+
+from nifty_scalper_bot.execution import bracket_manager as _legacy
+from nifty_scalper_bot.execution.hardened_bracket_manager import (
+    HardenedBracketManager,
+)
+
+
+class CanonicalBracketManager(HardenedBracketManager):
+    """Single runtime-exported bracket manager with strict fill reconciliation."""
+
+    _FILLED_NONFLAT_PREFIX = "filled_exit_nonflat"
+
+    def confirm_entry_fill(self, order_id: str, fill_price: float) -> None:
+        """Activate a confirmed entry and re-anchor every outstanding target.
+
+        The legacy implementation already re-anchors SL and the final TP.  This
+        wrapper captures planned partial targets before that call and applies the
+        same proportional re-anchor exactly once.
+        """
+
+        before = self.get_bracket(order_id)
+        planned_entry = 0.0
+        planned_targets: list[float] = []
+        if before is not None:
+            with self._lock:
+                planned_entry = float(before.entry_price or 0.0)
+                planned_targets = [float(target.price or 0.0) for target in before.tp_levels]
+
+        super().confirm_entry_fill(order_id, fill_price)
+
+        bracket = self.get_bracket(order_id)
+        if bracket is None:
+            return
+        try:
+            confirmed_fill = float(fill_price or 0.0)
+        except (TypeError, ValueError):
+            return
+        if planned_entry <= 0 or confirmed_fill <= 0 or confirmed_fill == planned_entry:
+            return
+
+        ratio = confirmed_fill / planned_entry
+        changed: list[dict[str, object]] = []
+        with self._lock:
+            for index, target in enumerate(bracket.tp_levels):
+                if target.executed or index >= len(planned_targets):
+                    continue
+                old_price = planned_targets[index]
+                if old_price <= 0:
+                    continue
+                new_price = _legacy._round_to_tick(old_price * ratio)
+                if new_price <= 0 or new_price == float(target.price):
+                    continue
+                target.price = new_price
+                changed.append(
+                    {
+                        "name": str(target.name),
+                        "old_price": old_price,
+                        "new_price": new_price,
+                    }
+                )
+            if changed:
+                bracket.updated_at = time.time()
+
+        if not changed:
+            return
+        with suppress(Exception):
+            self.save_state()
+        _legacy.LOGGER.info(
+            "BRACKET_TARGETS_REANCHORED bracket_id=%s symbol=%s planned_entry=%.2f fill_price=%.2f targets=%s",
+            bracket.bracket_id,
+            bracket.symbol,
+            planned_entry,
+            confirmed_fill,
+            changed,
+            extra={
+                "event": "BRACKET_TARGETS_REANCHORED",
+                "bracket_id": bracket.bracket_id,
+                "symbol": bracket.symbol,
+                "planned_entry": planned_entry,
+                "fill_price": confirmed_fill,
+                "targets": changed,
+            },
+        )
+        with suppress(Exception):
+            self._notify_event(
+                "BRACKET_TARGETS_REANCHORED",
+                {
+                    "symbol": bracket.symbol,
+                    "planned_entry": round(planned_entry, 2),
+                    "fill_price": round(confirmed_fill, 2),
+                    "targets": changed,
+                },
+            )
+
+    def _broker_position_quantity(self, symbol: str) -> int | None:
+        """Return absolute broker net quantity, or ``None`` when truth is unknown."""
+
+        broker = getattr(getattr(self, "order_manager", None), "_broker", None)
+        getter = getattr(broker, "get_positions", None) if broker is not None else None
+        if not callable(getter):
+            return None
+
+        payload = getter()
+        if isinstance(payload, Mapping):
+            rows = payload.get("net") or payload.get("day") or payload.get("positions") or []
+        else:
+            rows = payload
+        if rows is None:
+            return None
+        try:
+            positions = list(rows)
+        except TypeError:
+            return None
+        if not positions:
+            return 0
+
+        target_symbol = _legacy.normalize_symbol(symbol)
+        matched = False
+        net_quantity = 0
+        for position in positions:
+            if not isinstance(position, Mapping):
+                continue
+            position_symbol = _legacy.normalize_symbol(
+                str(
+                    position.get("tradingsymbol")
+                    or position.get("symbol")
+                    or position.get("instrument")
+                    or ""
+                )
+            )
+            if position_symbol != target_symbol:
+                continue
+            matched = True
+            raw_quantity = position.get(
+                "quantity",
+                position.get("net_quantity", position.get("net", 0)),
+            )
+            try:
+                net_quantity += int(float(raw_quantity or 0))
+            except (TypeError, ValueError):
+                return None
+
+        if not matched:
+            # A non-empty broker response that omits the symbol is not sufficient
+            # proof of flatness; preserve the entry freeze until reconciliation.
+            return None
+        return abs(net_quantity)
+
+    @staticmethod
+    def _matching_partial_target(bracket: Any) -> Any | None:
+        reason = str(getattr(bracket, "exit_reason", "") or "").strip().upper()
+        for target in getattr(bracket, "tp_levels", []) or []:
+            if bool(getattr(target, "executed", False)):
+                continue
+            name = str(getattr(target, "name", "") or "").strip().upper()
+            if name and (reason.startswith(name) or f"{name} HIT" in reason):
+                return target
+        return None
+
+    def _resume_after_partial_target(
+        self,
+        bracket: Any,
+        *,
+        target: Any,
+        residual_quantity: int,
+        order_id: str,
+        status_payload: Mapping[str, Any],
+        requested_by: str,
+    ) -> bool:
+        previous_remaining = int(bracket.remaining_quantity or 0)
+        expected_residual = max(previous_remaining - int(target.quantity or 0), 0)
+        if residual_quantity >= previous_remaining or residual_quantity > expected_residual:
+            return False
+
+        fill_price = self._extract_status_price(status_payload)
+        filled_quantity = previous_remaining - residual_quantity
+        with self._lock:
+            target.executed = True
+            bracket.remaining_quantity = residual_quantity
+            bracket.exit_order_id = None
+            bracket.pending_exit_order_id = None
+            bracket.exit_pending = False
+            bracket.exit_in_progress = False
+            bracket.exit_executed = False
+            bracket.active = True
+            bracket.entry_confirmed = True
+            bracket.position_flat_confirmed = False
+            bracket.exit_state = _legacy.BracketExitLifecycle.OPEN_ACTIVE.value
+            bracket.entry_status = "ACTIVE"
+            bracket.last_exit_error = None
+            bracket.exit_reason = None
+            bracket.exit_triggered_at = None
+            bracket.exit_attempt_count = 0
+            bracket.last_exit_attempt_at = None
+            bracket.next_exit_attempt_at = None
+            bracket.escalated_at = None
+            bracket._market_escalation_fired = False
+            bracket.updated_at = time.time()
+            self._exit_order_open_since.pop(order_id, None)
+            self._exit_rescue_attempts.pop(bracket.bracket_id, None)
+
+        self._move_sl_to_breakeven(bracket)
+        with suppress(Exception):
+            self.save_state()
+        _legacy.LOGGER.info(
+            "PARTIAL_EXIT_CONFIRMED_RESIDUAL_PROTECTED bracket_id=%s symbol=%s target=%s filled_qty=%s remaining_qty=%s fill_price=%s requested_by=%s",
+            bracket.bracket_id,
+            bracket.symbol,
+            target.name,
+            filled_quantity,
+            residual_quantity,
+            fill_price,
+            requested_by,
+            extra={
+                "event": "PARTIAL_EXIT_CONFIRMED_RESIDUAL_PROTECTED",
+                "bracket_id": bracket.bracket_id,
+                "symbol": bracket.symbol,
+                "target": str(target.name),
+                "filled_qty": filled_quantity,
+                "remaining_qty": residual_quantity,
+                "fill_price": fill_price,
+                "requested_by": requested_by,
+            },
+        )
+        with suppress(Exception):
+            self._notify_event(
+                "PARTIAL_EXIT_CONFIRMED",
+                {
+                    "symbol": bracket.symbol,
+                    "target": str(target.name),
+                    "filled_qty": filled_quantity,
+                    "remaining_qty": residual_quantity,
+                    "fill_price": fill_price,
+                    "sl": round(float(bracket.sl_trigger_price), 2),
+                },
+            )
+        return True
+
+    def _latch_filled_nonflat_mismatch(
+        self,
+        bracket: Any,
+        *,
+        residual_quantity: int | None,
+        order_id: str | None,
+        requested_by: str,
+    ) -> None:
+        now = time.time()
+        error = (
+            f"{self._FILLED_NONFLAT_PREFIX}:"
+            f"residual={residual_quantity if residual_quantity is not None else 'unknown'}"
+        )
+        with self._lock:
+            if residual_quantity is not None and residual_quantity > 0:
+                bracket.remaining_quantity = residual_quantity
+            bracket.exit_order_id = None
+            bracket.pending_exit_order_id = None
+            bracket.exit_in_progress = False
+            bracket.exit_pending = True
+            bracket.exit_executed = False
+            bracket.active = True
+            bracket.position_flat_confirmed = False
+            bracket.exit_state = _legacy.BracketExitLifecycle.EXIT_FAILED_ESCALATED.value
+            bracket.entry_status = bracket.exit_state
+            bracket.last_exit_error = error
+            bracket.escalated_at = bracket.escalated_at or now
+            bracket._market_escalation_fired = True
+            bracket.updated_at = now
+            if order_id:
+                self._exit_order_open_since.pop(order_id, None)
+
+        with suppress(Exception):
+            self.save_state()
+        _legacy.LOGGER.critical(
+            "EXIT_FILLED_POSITION_MISMATCH bracket_id=%s symbol=%s order_id=%s residual_qty=%s requested_by=%s",
+            bracket.bracket_id,
+            bracket.symbol,
+            order_id,
+            residual_quantity,
+            requested_by,
+            extra={
+                "event": "EXIT_FILLED_POSITION_MISMATCH",
+                "bracket_id": bracket.bracket_id,
+                "symbol": bracket.symbol,
+                "order_id": order_id,
+                "residual_qty": residual_quantity,
+                "requested_by": requested_by,
+            },
+        )
+        with suppress(Exception):
+            self._notify_event(
+                "EXIT_FILLED_POSITION_MISMATCH",
+                {
+                    "symbol": bracket.symbol,
+                    "order_id": order_id,
+                    "remaining_qty": residual_quantity,
+                    "message": "Exit order filled but broker position remains. New entries are blocked pending reconciliation.",
+                },
+            )
+
+    def _reconcile_exit_state(self, bracket: Any, *, requested_by: str) -> bool:
+        """Reconcile filled exits without allowing optimistic local closure."""
+
+        with self._lock:
+            order_id = bracket.exit_order_id or bracket.pending_exit_order_id
+            mismatch_latched = str(bracket.last_exit_error or "").startswith(
+                self._FILLED_NONFLAT_PREFIX
+            )
+
+        if mismatch_latched and not order_id:
+            residual = self._broker_position_quantity(bracket.symbol)
+            if residual == 0:
+                self._close_bracket(
+                    bracket,
+                    close_source="filled_nonflat_reconciled_flat",
+                )
+                return True
+            return False
+
+        if order_id:
+            try:
+                status_payload = self._get_broker_order_status(str(order_id))
+                status = str((status_payload or {}).get("status") or "").strip().upper()
+            except Exception:
+                return super()._reconcile_exit_state(bracket, requested_by=requested_by)
+
+            if status in _legacy._FILLED_STATUSES:
+                residual = self._broker_position_quantity(bracket.symbol)
+                if residual == 0:
+                    return super()._reconcile_exit_state(
+                        bracket,
+                        requested_by=requested_by,
+                    )
+
+                target = self._matching_partial_target(bracket)
+                if (
+                    residual is not None
+                    and target is not None
+                    and self._resume_after_partial_target(
+                        bracket,
+                        target=target,
+                        residual_quantity=residual,
+                        order_id=str(order_id),
+                        status_payload=status_payload,
+                        requested_by=requested_by,
+                    )
+                ):
+                    return False
+
+                self._latch_filled_nonflat_mismatch(
+                    bracket,
+                    residual_quantity=residual,
+                    order_id=str(order_id),
+                    requested_by=requested_by,
+                )
+                return False
+
+        return super()._reconcile_exit_state(bracket, requested_by=requested_by)
+
+    def _process_exit_state(
+        self,
+        bracket: Any,
+        action: Mapping[str, Any],
+        *,
+        now: float,
+    ) -> None:
+        """Keep a filled/non-flat mismatch frozen until broker truth becomes flat."""
+
+        if str(bracket.last_exit_error or "").startswith(self._FILLED_NONFLAT_PREFIX):
+            residual = self._broker_position_quantity(bracket.symbol)
+            if residual == 0:
+                self._close_bracket(
+                    bracket,
+                    close_source="filled_nonflat_reconciled_flat",
+                )
+            else:
+                with self._lock:
+                    if residual is not None and residual > 0:
+                        bracket.remaining_quantity = residual
+                    self._log_exit_pending_summary_locked(bracket, now)
+            return
+        super()._process_exit_state(bracket, action, now=now)
+
+    def _rescue_stale_exit_order(
+        self,
+        bracket: Any,
+        *,
+        order_id: str,
+        qty: int,
+        status: str,
+    ) -> None:
+        """Cancel/replace stale exits without treating a non-flat fill as closure."""
+
+        with self._lock:
+            if bracket.exit_in_progress:
+                return
+            attempts = self._exit_rescue_attempts.get(bracket.bracket_id, 0)
+            if attempts >= self._exit_rescue_max_attempts:
+                self._escalate_exit_locked(bracket, "rescue_attempts_exhausted")
+                return
+            bracket.exit_in_progress = True
+            self._exit_rescue_attempts[bracket.bracket_id] = attempts + 1
+
+        _legacy.LOGGER.critical(
+            "EXIT_STALE_ORDER_RESCUE bracket_id=%s order_id=%s status=%s qty=%s rescue_attempt=%s",
+            bracket.bracket_id,
+            order_id,
+            status,
+            qty,
+            attempts + 1,
+            extra={
+                "event": "EXIT_STALE_ORDER_RESCUE",
+                "bracket_id": bracket.bracket_id,
+                "order_id": order_id,
+                "status": status,
+                "qty": qty,
+                "rescue_attempt": attempts + 1,
+            },
+        )
+
+        cancel_requested = self._cancel_exit_order(order_id)
+        terminal = self._wait_for_cancel_or_fill(order_id) if cancel_requested else "unconfirmed"
+        if terminal == "filled":
+            with self._lock:
+                bracket.exit_in_progress = False
+            self._reconcile_exit_state(bracket, requested_by="stale_rescue_filled")
+            return
+        if self._safe_position_flat(bracket.symbol):
+            with self._lock:
+                bracket.exit_in_progress = False
+            self._close_bracket(bracket, close_source="rescue_reconciled_flat")
+            return
+        if terminal != "cancelled":
+            with self._lock:
+                bracket.exit_in_progress = False
+                bracket.last_exit_error = "stale_exit_cancel_unconfirmed"
+                self._escalate_exit_locked(bracket, "stale_exit_cancel_unconfirmed")
+            return
+
+        with self._lock:
+            bracket.exit_in_progress = False
+            bracket.exit_order_id = None
+            bracket.pending_exit_order_id = None
+            bracket.last_exit_error = None
+        self._submit_rescue_exit(bracket, qty=qty, prior_order_id=order_id)
+
+
+__all__ = ["CanonicalBracketManager"]

--- a/src/nifty_scalper_bot/execution/canonical_bracket_manager.py
+++ b/src/nifty_scalper_bot/execution/canonical_bracket_manager.py
@@ -8,7 +8,7 @@ adds only fill-integrity invariants:
 * a confirmed TP1 fill resumes protection for the residual position;
 * any other FILLED/non-flat mismatch fails closed and blocks new entries.
 
-The compatibility inheritance is temporary.  Later stages will fold these
+The compatibility inheritance is temporary. Later stages will fold these
 invariants into the single explicit bracket implementation and remove runtime
 class replacement.
 """
@@ -16,6 +16,7 @@ class replacement.
 from __future__ import annotations
 
 from contextlib import suppress
+import os
 import time
 from typing import Any, Mapping
 
@@ -29,11 +30,24 @@ class CanonicalBracketManager(HardenedBracketManager):
     """Single runtime-exported bracket manager with strict fill reconciliation."""
 
     _FILLED_NONFLAT_PREFIX = "filled_exit_nonflat"
+    _FILLED_SYNC_PREFIX = "filled_exit_position_sync_pending"
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        # Broker order status can lead the positions endpoint briefly.  Keep this
+        # bounded: we defer a decision, but never declare the position flat.
+        self._filled_position_sync_grace_seconds = max(
+            0.0,
+            _legacy.parse_float_env(
+                os.getenv("EXIT_FILLED_POSITION_SYNC_GRACE_SECONDS"),
+                1.5,
+            ),
+        )
+        super().__init__(*args, **kwargs)
 
     def confirm_entry_fill(self, order_id: str, fill_price: float) -> None:
         """Activate a confirmed entry and re-anchor every outstanding target.
 
-        The legacy implementation already re-anchors SL and the final TP.  This
+        The legacy implementation already re-anchors SL and the final TP. This
         wrapper captures planned partial targets before that call and applies the
         same proportional re-anchor exactly once.
         """
@@ -44,7 +58,9 @@ class CanonicalBracketManager(HardenedBracketManager):
         if before is not None:
             with self._lock:
                 planned_entry = float(before.entry_price or 0.0)
-                planned_targets = [float(target.price or 0.0) for target in before.tp_levels]
+                planned_targets = [
+                    float(target.price or 0.0) for target in before.tp_levels
+                ]
 
         super().confirm_entry_fill(order_id, fill_price)
 
@@ -122,7 +138,12 @@ class CanonicalBracketManager(HardenedBracketManager):
 
         payload = getter()
         if isinstance(payload, Mapping):
-            rows = payload.get("net") or payload.get("day") or payload.get("positions") or []
+            rows = (
+                payload.get("net")
+                or payload.get("day")
+                or payload.get("positions")
+                or []
+            )
         else:
             rows = payload
         if rows is None:
@@ -177,6 +198,70 @@ class CanonicalBracketManager(HardenedBracketManager):
                 return target
         return None
 
+    @staticmethod
+    def _clear_fill_sync_state(bracket: Any) -> None:
+        for name in (
+            "_filled_exit_sync_started_at",
+            "_filled_exit_sync_order_id",
+        ):
+            with suppress(AttributeError):
+                delattr(bracket, name)
+
+    def _fill_sync_grace_expired(self, bracket: Any, order_id: str) -> bool:
+        now = time.time()
+        previous_order = str(
+            getattr(bracket, "_filled_exit_sync_order_id", "") or ""
+        )
+        started_at = float(
+            getattr(bracket, "_filled_exit_sync_started_at", 0.0) or 0.0
+        )
+        if previous_order != order_id or started_at <= 0:
+            setattr(bracket, "_filled_exit_sync_order_id", order_id)
+            setattr(bracket, "_filled_exit_sync_started_at", now)
+            started_at = now
+        return (now - started_at) >= self._filled_position_sync_grace_seconds
+
+    def _defer_filled_position_sync(
+        self,
+        bracket: Any,
+        *,
+        residual_quantity: int | None,
+        order_id: str,
+        requested_by: str,
+    ) -> None:
+        with self._lock:
+            bracket.exit_in_progress = False
+            bracket.exit_pending = True
+            bracket.exit_executed = False
+            bracket.active = True
+            bracket.position_flat_confirmed = False
+            bracket.exit_state = _legacy.BracketExitLifecycle.EXIT_PARTIALLY_FILLED.value
+            bracket.entry_status = bracket.exit_state
+            bracket.last_exit_error = (
+                f"{self._FILLED_SYNC_PREFIX}:"
+                f"residual={residual_quantity if residual_quantity is not None else 'unknown'}"
+            )
+            bracket.updated_at = time.time()
+
+        _legacy.LOGGER.warning(
+            "EXIT_FILLED_POSITION_SYNC_PENDING bracket_id=%s symbol=%s order_id=%s residual_qty=%s requested_by=%s grace_seconds=%.2f",
+            bracket.bracket_id,
+            bracket.symbol,
+            order_id,
+            residual_quantity,
+            requested_by,
+            self._filled_position_sync_grace_seconds,
+            extra={
+                "event": "EXIT_FILLED_POSITION_SYNC_PENDING",
+                "bracket_id": bracket.bracket_id,
+                "symbol": bracket.symbol,
+                "order_id": order_id,
+                "residual_qty": residual_quantity,
+                "requested_by": requested_by,
+                "grace_seconds": self._filled_position_sync_grace_seconds,
+            },
+        )
+
     def _resume_after_partial_target(
         self,
         bracket: Any,
@@ -218,6 +303,7 @@ class CanonicalBracketManager(HardenedBracketManager):
             bracket.updated_at = time.time()
             self._exit_order_open_since.pop(order_id, None)
             self._exit_rescue_attempts.pop(bracket.bracket_id, None)
+            self._clear_fill_sync_state(bracket)
 
         self._move_sl_to_breakeven(bracket)
         with suppress(Exception):
@@ -272,8 +358,7 @@ class CanonicalBracketManager(HardenedBracketManager):
         with self._lock:
             if residual_quantity is not None and residual_quantity > 0:
                 bracket.remaining_quantity = residual_quantity
-            bracket.exit_order_id = None
-            bracket.pending_exit_order_id = None
+            # Retain the completed order id for audit and later reconciliation.
             bracket.exit_in_progress = False
             bracket.exit_pending = True
             bracket.exit_executed = False
@@ -283,6 +368,7 @@ class CanonicalBracketManager(HardenedBracketManager):
             bracket.entry_status = bracket.exit_state
             bracket.last_exit_error = error
             bracket.escalated_at = bracket.escalated_at or now
+            # Prevent inherited escalation from sending a guessed extra market exit.
             bracket._market_escalation_fired = True
             bracket.updated_at = now
             if order_id:
@@ -329,6 +415,7 @@ class CanonicalBracketManager(HardenedBracketManager):
         if mismatch_latched and not order_id:
             residual = self._broker_position_quantity(bracket.symbol)
             if residual == 0:
+                self._clear_fill_sync_state(bracket)
                 self._close_bracket(
                     bracket,
                     close_source="filled_nonflat_reconciled_flat",
@@ -341,11 +428,15 @@ class CanonicalBracketManager(HardenedBracketManager):
                 status_payload = self._get_broker_order_status(str(order_id))
                 status = str((status_payload or {}).get("status") or "").strip().upper()
             except Exception:
-                return super()._reconcile_exit_state(bracket, requested_by=requested_by)
+                return super()._reconcile_exit_state(
+                    bracket,
+                    requested_by=requested_by,
+                )
 
             if status in _legacy._FILLED_STATUSES:
                 residual = self._broker_position_quantity(bracket.symbol)
                 if residual == 0:
+                    self._clear_fill_sync_state(bracket)
                     return super()._reconcile_exit_state(
                         bracket,
                         requested_by=requested_by,
@@ -366,6 +457,15 @@ class CanonicalBracketManager(HardenedBracketManager):
                 ):
                     return False
 
+                if not self._fill_sync_grace_expired(bracket, str(order_id)):
+                    self._defer_filled_position_sync(
+                        bracket,
+                        residual_quantity=residual,
+                        order_id=str(order_id),
+                        requested_by=requested_by,
+                    )
+                    return False
+
                 self._latch_filled_nonflat_mismatch(
                     bracket,
                     residual_quantity=residual,
@@ -374,7 +474,10 @@ class CanonicalBracketManager(HardenedBracketManager):
                 )
                 return False
 
-        return super()._reconcile_exit_state(bracket, requested_by=requested_by)
+        return super()._reconcile_exit_state(
+            bracket,
+            requested_by=requested_by,
+        )
 
     def _process_exit_state(
         self,
@@ -383,19 +486,15 @@ class CanonicalBracketManager(HardenedBracketManager):
         *,
         now: float,
     ) -> None:
-        """Keep a filled/non-flat mismatch frozen until broker truth becomes flat."""
+        """Keep a filled/non-flat mismatch frozen until broker truth is resolved."""
 
         if str(bracket.last_exit_error or "").startswith(self._FILLED_NONFLAT_PREFIX):
-            residual = self._broker_position_quantity(bracket.symbol)
-            if residual == 0:
-                self._close_bracket(
-                    bracket,
-                    close_source="filled_nonflat_reconciled_flat",
-                )
-            else:
+            self._reconcile_exit_state(
+                bracket,
+                requested_by="filled_nonflat_followup",
+            )
+            if bracket.exit_state != _legacy.BracketExitLifecycle.CLOSED.value:
                 with self._lock:
-                    if residual is not None and residual > 0:
-                        bracket.remaining_quantity = residual
                     self._log_exit_pending_summary_locked(bracket, now)
             return
         super()._process_exit_state(bracket, action, now=now)
@@ -438,22 +537,35 @@ class CanonicalBracketManager(HardenedBracketManager):
         )
 
         cancel_requested = self._cancel_exit_order(order_id)
-        terminal = self._wait_for_cancel_or_fill(order_id) if cancel_requested else "unconfirmed"
+        terminal = (
+            self._wait_for_cancel_or_fill(order_id)
+            if cancel_requested
+            else "unconfirmed"
+        )
         if terminal == "filled":
             with self._lock:
                 bracket.exit_in_progress = False
-            self._reconcile_exit_state(bracket, requested_by="stale_rescue_filled")
+            self._reconcile_exit_state(
+                bracket,
+                requested_by="stale_rescue_filled",
+            )
             return
         if self._safe_position_flat(bracket.symbol):
             with self._lock:
                 bracket.exit_in_progress = False
-            self._close_bracket(bracket, close_source="rescue_reconciled_flat")
+            self._close_bracket(
+                bracket,
+                close_source="rescue_reconciled_flat",
+            )
             return
         if terminal != "cancelled":
             with self._lock:
                 bracket.exit_in_progress = False
                 bracket.last_exit_error = "stale_exit_cancel_unconfirmed"
-                self._escalate_exit_locked(bracket, "stale_exit_cancel_unconfirmed")
+                self._escalate_exit_locked(
+                    bracket,
+                    "stale_exit_cancel_unconfirmed",
+                )
             return
 
         with self._lock:
@@ -461,7 +573,11 @@ class CanonicalBracketManager(HardenedBracketManager):
             bracket.exit_order_id = None
             bracket.pending_exit_order_id = None
             bracket.last_exit_error = None
-        self._submit_rescue_exit(bracket, qty=qty, prior_order_id=order_id)
+        self._submit_rescue_exit(
+            bracket,
+            qty=qty,
+            prior_order_id=order_id,
+        )
 
 
 __all__ = ["CanonicalBracketManager"]

--- a/tests/execution/test_canonical_bracket_fill_integrity.py
+++ b/tests/execution/test_canonical_bracket_fill_integrity.py
@@ -55,7 +55,11 @@ class _OrderManager:
         return None
 
 
-def _manager(*, fill_price: float = 100.0) -> tuple[CanonicalBracketManager, _OrderManager, _Broker]:
+def _manager(
+    *,
+    fill_price: float = 100.0,
+    sync_grace_seconds: float = 0.0,
+) -> tuple[CanonicalBracketManager, _OrderManager, _Broker]:
     broker = _Broker()
     order_manager = _OrderManager(broker)
     manager = BracketManager(order_manager=order_manager)
@@ -64,6 +68,7 @@ def _manager(*, fill_price: float = 100.0) -> tuple[CanonicalBracketManager, _Or
     manager._watchdog_thread.join(timeout=1.0)
     manager._exit_cancel_confirm_timeout_seconds = 0.01
     manager._exit_cancel_poll_interval_seconds = 0.001
+    manager._filled_position_sync_grace_seconds = sync_grace_seconds
     manager.register_virtual_bracket(
         order_id="entry-1",
         symbol=SYMBOL,
@@ -151,6 +156,55 @@ def test_confirmed_tp1_fill_keeps_residual_position_open_and_protected() -> None
     assert any(event == "PARTIAL_EXIT_CONFIRMED" for event, _ in events)
 
 
+def test_tp1_tick_submit_then_fill_reconciles_through_live_path() -> None:
+    manager, order_manager, broker = _manager()
+
+    manager.on_tick(SYMBOL, 110.0)
+    bracket = manager.get_bracket("entry-1")
+    assert bracket is not None
+    assert len(order_manager.place_calls) == 1
+    assert bracket.exit_order_id == "exit-1"
+    assert bracket.exit_pending is True
+
+    broker.statuses["exit-1"] = {
+        "status": "COMPLETE",
+        "average_price": 110.05,
+    }
+    broker.positions = [{"symbol": SYMBOL, "quantity": 40}]
+    manager.on_tick(SYMBOL, 110.5)
+
+    assert bracket.remaining_quantity == 40
+    assert bracket.tp_levels[0].executed is True
+    assert bracket.exit_state == BracketExitLifecycle.OPEN_ACTIVE.value
+    assert bracket.exit_pending is False
+    assert len(order_manager.place_calls) == 1
+
+
+def test_completed_order_waits_for_positions_endpoint_to_catch_up() -> None:
+    manager, order_manager, broker = _manager(sync_grace_seconds=5.0)
+    bracket = _mark_exit_submitted(
+        manager,
+        broker,
+        order_id="tp1-sync",
+        reason="TP1 Hit (110.00)",
+        residual_quantity=65,
+        average_price=110.05,
+    )
+
+    assert manager._reconcile_exit_state(bracket, requested_by="sync_first") is False
+    assert bracket.exit_state == BracketExitLifecycle.EXIT_PARTIALLY_FILLED.value
+    assert bracket.exit_order_id == "tp1-sync"
+    assert bracket.tp_levels[0].executed is False
+    assert order_manager.place_calls == []
+
+    broker.positions = [{"symbol": SYMBOL, "quantity": 40}]
+    assert manager._reconcile_exit_state(bracket, requested_by="sync_second") is False
+    assert bracket.exit_state == BracketExitLifecycle.OPEN_ACTIVE.value
+    assert bracket.remaining_quantity == 40
+    assert bracket.tp_levels[0].executed is True
+    assert bracket.exit_order_id is None
+
+
 def test_filled_full_exit_with_residual_never_closes_or_rearms() -> None:
     manager, order_manager, broker = _manager()
     close_calls: list[str] = []
@@ -171,7 +225,7 @@ def test_filled_full_exit_with_residual_never_closes_or_rearms() -> None:
     assert bracket.exit_state == BracketExitLifecycle.EXIT_FAILED_ESCALATED.value
     assert bracket.exit_pending is True
     assert bracket.position_flat_confirmed is False
-    assert bracket.exit_order_id is None
+    assert bracket.exit_order_id == "sl-exit"
     assert manager.has_unresolved_exit() is True
     assert close_calls == []
     assert order_manager.place_calls == []

--- a/tests/execution/test_canonical_bracket_fill_integrity.py
+++ b/tests/execution/test_canonical_bracket_fill_integrity.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from nifty_scalper_bot.execution.bracket_manager import (
+    BracketExitLifecycle,
+    BracketManager,
+)
+from nifty_scalper_bot.execution.canonical_bracket_manager import (
+    CanonicalBracketManager,
+)
+
+
+SYMBOL = "NFO:NIFTY2662324050PE"
+
+
+class _Broker:
+    def __init__(self) -> None:
+        self.statuses: dict[str, dict[str, Any]] = {}
+        self.positions: list[dict[str, Any]] = [
+            {"symbol": SYMBOL, "quantity": 65}
+        ]
+        self.cancel_terminal_status = "CANCELLED"
+
+    def get_order_status(self, order_id: str) -> dict[str, Any]:
+        return dict(self.statuses.get(order_id, {"status": ""}))
+
+    def get_positions(self) -> list[dict[str, Any]]:
+        return list(self.positions)
+
+    def cancel_order(self, order_id: str, *args: Any, **kwargs: Any) -> bool:
+        payload = dict(self.statuses.get(order_id, {}))
+        payload["status"] = self.cancel_terminal_status
+        self.statuses[order_id] = payload
+        return True
+
+
+class _OrderManager:
+    def __init__(self, broker: _Broker) -> None:
+        self._broker = broker
+        self._last_order_decision: dict[str, Any] = {}
+        self.place_calls: list[dict[str, Any]] = []
+
+    def place_order(self, **kwargs: Any) -> str:
+        self.place_calls.append(dict(kwargs))
+        order_id = f"exit-{len(self.place_calls)}"
+        self._broker.statuses[order_id] = {"status": "OPEN"}
+        return order_id
+
+    def cancel_order(self, order_id: str, *args: Any, **kwargs: Any) -> bool:
+        return self._broker.cancel_order(order_id, *args, **kwargs)
+
+    def set_last_skip_reason(self, _reason: str) -> None:
+        return None
+
+
+def _manager(*, fill_price: float = 100.0) -> tuple[CanonicalBracketManager, _OrderManager, _Broker]:
+    broker = _Broker()
+    order_manager = _OrderManager(broker)
+    manager = BracketManager(order_manager=order_manager)
+    assert isinstance(manager, CanonicalBracketManager)
+    manager._running = False
+    manager._watchdog_thread.join(timeout=1.0)
+    manager._exit_cancel_confirm_timeout_seconds = 0.01
+    manager._exit_cancel_poll_interval_seconds = 0.001
+    manager.register_virtual_bracket(
+        order_id="entry-1",
+        symbol=SYMBOL,
+        side="BUY",
+        qty=65,
+        price=100.0,
+        sl=90.0,
+        tp=120.0,
+        tp1_price=110.0,
+        tp1_qty=25,
+        activate_immediately=False,
+    )
+    manager.confirm_entry_fill("entry-1", fill_price)
+    return manager, order_manager, broker
+
+
+def _mark_exit_submitted(
+    manager: CanonicalBracketManager,
+    broker: _Broker,
+    *,
+    order_id: str,
+    reason: str,
+    residual_quantity: int,
+    average_price: float,
+) -> Any:
+    bracket = manager.get_bracket("entry-1")
+    assert bracket is not None
+    bracket.exit_pending = True
+    bracket.exit_reason = reason
+    bracket.exit_state = BracketExitLifecycle.EXIT_ORDER_SUBMITTED.value
+    bracket.entry_status = bracket.exit_state
+    bracket.exit_order_id = order_id
+    bracket.pending_exit_order_id = order_id
+    bracket.exit_triggered_at = time.time()
+    broker.statuses[order_id] = {
+        "status": "COMPLETE",
+        "average_price": average_price,
+    }
+    broker.positions = [{"symbol": SYMBOL, "quantity": residual_quantity}]
+    return bracket
+
+
+def test_confirmed_fill_reanchors_sl_final_tp_and_tp1() -> None:
+    manager, _order_manager, _broker = _manager(fill_price=102.0)
+    bracket = manager.get_bracket("entry-1")
+
+    assert bracket is not None
+    assert bracket.entry_price == 102.0
+    assert bracket.sl_trigger_price == 91.8
+    assert bracket.tp_trigger_price == 122.4
+    assert len(bracket.tp_levels) == 1
+    assert bracket.tp_levels[0].price == 112.2
+
+
+def test_confirmed_tp1_fill_keeps_residual_position_open_and_protected() -> None:
+    manager, order_manager, broker = _manager()
+    events: list[tuple[str, dict[str, Any]]] = []
+    close_calls: list[str] = []
+    manager.set_notifier(lambda event, payload: events.append((event, dict(payload))))
+    manager._on_exit_complete_hook = close_calls.append
+    bracket = _mark_exit_submitted(
+        manager,
+        broker,
+        order_id="tp1-exit",
+        reason="TP1 Hit (110.00)",
+        residual_quantity=40,
+        average_price=110.10,
+    )
+
+    closed = manager._reconcile_exit_state(bracket, requested_by="test_tp1")
+
+    assert closed is False
+    assert bracket.remaining_quantity == 40
+    assert bracket.tp_levels[0].executed is True
+    assert bracket.sl_trigger_price == bracket.entry_price
+    assert bracket.exit_state == BracketExitLifecycle.OPEN_ACTIVE.value
+    assert bracket.entry_status == "ACTIVE"
+    assert bracket.exit_pending is False
+    assert bracket.exit_order_id is None
+    assert bracket.pending_exit_order_id is None
+    assert bracket.position_flat_confirmed is False
+    assert manager.has_unresolved_exit() is False
+    assert close_calls == []
+    assert order_manager.place_calls == []
+    assert any(event == "PARTIAL_EXIT_CONFIRMED" for event, _ in events)
+
+
+def test_filled_full_exit_with_residual_never_closes_or_rearms() -> None:
+    manager, order_manager, broker = _manager()
+    close_calls: list[str] = []
+    manager._on_exit_complete_hook = close_calls.append
+    bracket = _mark_exit_submitted(
+        manager,
+        broker,
+        order_id="sl-exit",
+        reason="HARD_SL_BREACH",
+        residual_quantity=20,
+        average_price=89.75,
+    )
+
+    closed = manager._reconcile_exit_state(bracket, requested_by="test_nonflat")
+
+    assert closed is False
+    assert bracket.remaining_quantity == 20
+    assert bracket.exit_state == BracketExitLifecycle.EXIT_FAILED_ESCALATED.value
+    assert bracket.exit_pending is True
+    assert bracket.position_flat_confirmed is False
+    assert bracket.exit_order_id is None
+    assert manager.has_unresolved_exit() is True
+    assert close_calls == []
+    assert order_manager.place_calls == []
+
+    broker.positions = []
+    assert manager._reconcile_exit_state(bracket, requested_by="test_manual_flat") is True
+    assert bracket.exit_state == BracketExitLifecycle.CLOSED.value
+    assert bracket.position_flat_confirmed is True
+    assert close_calls == [SYMBOL]
+
+
+def test_stale_rescue_fill_with_residual_uses_same_fail_closed_rule() -> None:
+    manager, order_manager, broker = _manager()
+    bracket = _mark_exit_submitted(
+        manager,
+        broker,
+        order_id="stale-exit",
+        reason="HARD_SL_BREACH",
+        residual_quantity=20,
+        average_price=89.50,
+    )
+    broker.statuses["stale-exit"]["status"] = "OPEN PENDING"
+    broker.cancel_terminal_status = "COMPLETE"
+
+    manager._rescue_stale_exit_order(
+        bracket,
+        order_id="stale-exit",
+        qty=65,
+        status="OPEN PENDING",
+    )
+
+    assert bracket.exit_state == BracketExitLifecycle.EXIT_FAILED_ESCALATED.value
+    assert bracket.exit_pending is True
+    assert bracket.remaining_quantity == 20
+    assert bracket.position_flat_confirmed is False
+    assert order_manager.place_calls == []

--- a/tests/execution/test_live_exit_hardening.py
+++ b/tests/execution/test_live_exit_hardening.py
@@ -13,6 +13,9 @@ from nifty_scalper_bot.execution.bracket_manager import (
     BracketExitLifecycle,
     BracketManager,
 )
+from nifty_scalper_bot.execution.canonical_bracket_manager import (
+    CanonicalBracketManager,
+)
 from nifty_scalper_bot.execution.hardened_adaptive_trailing import (
     HardenedAdaptiveTrailingController,
 )
@@ -131,7 +134,8 @@ def _make_stale_exit(manager: BracketManager) -> Any:
 
 
 def test_canonical_imports_use_hardened_implementations() -> None:
-    assert BracketManager is HardenedBracketManager
+    assert BracketManager is CanonicalBracketManager
+    assert issubclass(CanonicalBracketManager, HardenedBracketManager)
     assert AdaptiveTrailingController is HardenedAdaptiveTrailingController
 
 


### PR DESCRIPTION
## Stage 1 of #686 — fill integrity before canonicalisation

This PR fixes the highest-risk BO lifecycle errors without changing signal generation, trade selection, entry pricing, SL/trailing formulas, or existing exit-order pricing.

## Runtime invariants added

1. **Entry-fill re-anchoring**
   - The established path already re-anchored SL and final TP after entry slippage.
   - Every unexecuted partial target is now re-anchored by the same fill-price ratio and broker tick size.

2. **Order FILLED is not position flat**
   - A completed exit order cannot call the full-close hook until broker position truth confirms zero quantity.
   - A bounded reconciliation grace handles the case where Zerodha order status updates before its positions endpoint.

3. **TP1 residual lifecycle**
   - Confirmed TP1 fill updates remaining quantity from broker truth.
   - TP1 is marked executed only after fill confirmation.
   - The completed exit order is cleared, SL moves to breakeven, and the residual quantity returns to `OPEN_ACTIVE` protection.
   - No full-close callback or runner re-arm occurs.

4. **Unexpected FILLED/nonflat mismatch**
   - The bracket is latched unresolved and new entries remain blocked.
   - The completed order ID is retained for audit/reconciliation.
   - The inherited escalation path is prevented from sending a guessed duplicate market exit.
   - The bracket closes only when a later broker snapshot proves flat.

5. **Stale-order rescue**
   - A rescue/cancel race that resolves as FILLED uses the same position-truth reconciliation instead of optimistic closure.

## Compatibility strategy

`CanonicalBracketManager` temporarily subclasses the established hardened implementation and becomes the single `BracketManager` runtime export. This preserves current behavior while new invariants are introduced. Import-time replacement is deliberately retained in this stage and will be removed only after native composition-root construction is tested.

## Explicit non-goals

- No fill-leg ledger or exact scaled-exit P&L yet.
- No runner-facing dynamic entry repricing yet.
- No margin-resize retry yet.
- No removal of legacy compatibility APIs yet.

## Regression coverage

- Planned entry 100 → actual fill 102 re-anchors SL, final TP, and TP1.
- Direct TP1 fill with residual quantity remains open and protected.
- Full live tick path: TP1 trigger → submit → broker fill → residual protection.
- Order/position endpoint synchronization delay does not cause false closure or premature mismatch escalation.
- Full-exit fill with residual exposure never closes or re-arms.
- Later broker-flat confirmation safely completes the bracket.
- Stale-exit rescue fill with residual exposure uses the same fail-closed rule.
- Existing hardened trailing, exit rescue, bracket, runner and order-manager tests remain unchanged.

## Validation

- Production source compilation: PASS
- Focused live-money safety regression suite: PASS
- Full repository test suite: PASS

This PR remains staged and reviewable independently. Stage 2 will add persisted fill legs and quantity-weighted realized P&L on top of these invariants.