### PR TITLE
Stage 2A: add immutable BO fill ledger

### DIFF
--- a/.github/workflows/live-exit-safety-ci.yml
+++ b/.github/workflows/live-exit-safety-ci.yml
@@ -27,6 +27,7 @@ jobs:
       - name: Focused live-money safety regression tests
         run: |
           python -m pytest -q \
+            tests/execution/test_fill_ledger.py \
             tests/execution/test_canonical_bracket_fill_integrity.py \
             tests/execution/test_live_exit_hardening.py \
             tests/execution/test_bracket_exit_state_machine.py \

--- a/src/nifty_scalper_bot/execution/fill_ledger.py
+++ b/src/nifty_scalper_bot/execution/fill_ledger.py
@@ -1,0 +1,298 @@
+"""Restart-safe, idempotent fill ledger for the canonical BO lifecycle."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+import json
+import math
+from pathlib import Path
+import sqlite3
+import time
+from typing import Any, Iterable, Literal, Mapping, Sequence
+
+FillKind = Literal["ENTRY", "EXIT"]
+FillSide = Literal["BUY", "SELL"]
+
+
+class FillLedgerError(RuntimeError):
+    """Base persistence or integrity error."""
+
+
+class FillConflictError(FillLedgerError):
+    """A broker fill identity was reused with different economics."""
+
+
+class FillValidationError(FillLedgerError):
+    """A fill or fill set is economically invalid."""
+
+
+@dataclass(frozen=True, slots=True)
+class FillLeg:
+    fill_id: str
+    bracket_id: str
+    order_id: str
+    kind: FillKind
+    side: FillSide
+    quantity: int
+    price: float
+    target: str | None = None
+    reason: str | None = None
+    fees: float = 0.0
+    recorded_at: float = field(default_factory=time.time)
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        fill_id = str(self.fill_id or "").strip()
+        bracket_id = str(self.bracket_id or "").strip()
+        order_id = str(self.order_id or "").strip()
+        kind = str(self.kind or "").strip().upper()
+        side = str(self.side or "").strip().upper()
+        quantity = int(self.quantity or 0)
+        price = float(self.price or 0.0)
+        fees = float(self.fees or 0.0)
+        recorded_at = float(self.recorded_at or 0.0)
+        if not fill_id or not bracket_id or not order_id:
+            raise FillValidationError("fill_id, bracket_id and order_id are required")
+        if kind not in {"ENTRY", "EXIT"}:
+            raise FillValidationError(f"invalid fill kind: {self.kind!r}")
+        if side not in {"BUY", "SELL"}:
+            raise FillValidationError(f"invalid fill side: {self.side!r}")
+        if quantity <= 0:
+            raise FillValidationError("fill quantity must be positive")
+        if not math.isfinite(price) or price <= 0:
+            raise FillValidationError("fill price must be finite and positive")
+        if not math.isfinite(fees) or fees < 0:
+            raise FillValidationError("fees must be finite and non-negative")
+        if not math.isfinite(recorded_at) or recorded_at <= 0:
+            raise FillValidationError("recorded_at must be finite and positive")
+        object.__setattr__(self, "fill_id", fill_id)
+        object.__setattr__(self, "bracket_id", bracket_id)
+        object.__setattr__(self, "order_id", order_id)
+        object.__setattr__(self, "kind", kind)
+        object.__setattr__(self, "side", side)
+        object.__setattr__(self, "quantity", quantity)
+        object.__setattr__(self, "price", price)
+        object.__setattr__(self, "fees", fees)
+        object.__setattr__(self, "recorded_at", recorded_at)
+        object.__setattr__(self, "metadata", dict(self.metadata or {}))
+
+    def economics(self) -> tuple[object, ...]:
+        return (
+            self.fill_id,
+            self.bracket_id,
+            self.order_id,
+            self.kind,
+            self.side,
+            self.quantity,
+            round(self.price, 10),
+            self.target,
+            self.reason,
+            round(self.fees, 10),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+        payload["metadata"] = dict(self.metadata)
+        return payload
+
+
+@dataclass(frozen=True, slots=True)
+class RealizedPnl:
+    entry_side: FillSide
+    entry_quantity: int
+    exit_quantity: int
+    entry_vwap: float
+    exit_vwap: float | None
+    gross_pnl: float
+    fees: float
+    net_pnl: float
+    complete: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def _vwap(legs: Sequence[FillLeg]) -> float | None:
+    quantity = sum(leg.quantity for leg in legs)
+    if quantity <= 0:
+        return None
+    return sum(leg.quantity * leg.price for leg in legs) / quantity
+
+
+def calculate_realized_pnl(legs: Iterable[FillLeg]) -> RealizedPnl:
+    all_legs = list(legs)
+    entries = [leg for leg in all_legs if leg.kind == "ENTRY"]
+    exits = [leg for leg in all_legs if leg.kind == "EXIT"]
+    if not entries:
+        raise FillValidationError("at least one confirmed entry fill is required")
+    entry_sides = {leg.side for leg in entries}
+    if len(entry_sides) != 1:
+        raise FillValidationError("entry fills must have one consistent side")
+    entry_side = next(iter(entry_sides))
+    reducing_side = "SELL" if entry_side == "BUY" else "BUY"
+    if any(leg.side != reducing_side for leg in exits):
+        raise FillValidationError("exit side does not reduce the entry exposure")
+    entry_quantity = sum(leg.quantity for leg in entries)
+    exit_quantity = sum(leg.quantity for leg in exits)
+    if exit_quantity > entry_quantity:
+        raise FillValidationError("confirmed exit quantity exceeds confirmed entry quantity")
+    entry_vwap = _vwap(entries)
+    if entry_vwap is None:
+        raise FillValidationError("entry VWAP unavailable")
+    exit_vwap = _vwap(exits)
+    if entry_side == "BUY":
+        gross = sum((leg.price - entry_vwap) * leg.quantity for leg in exits)
+    else:
+        gross = sum((entry_vwap - leg.price) * leg.quantity for leg in exits)
+    fees = sum(leg.fees for leg in all_legs)
+    return RealizedPnl(
+        entry_side=entry_side,
+        entry_quantity=entry_quantity,
+        exit_quantity=exit_quantity,
+        entry_vwap=round(entry_vwap, 8),
+        exit_vwap=round(exit_vwap, 8) if exit_vwap is not None else None,
+        gross_pnl=round(gross, 2),
+        fees=round(fees, 2),
+        net_pnl=round(gross - fees, 2),
+        complete=exit_quantity == entry_quantity,
+    )
+
+
+class BracketFillLedgerStore:
+    """SQLite-backed immutable fill ledger with replay protection."""
+
+    def __init__(self, db_path: str | Path) -> None:
+        self.db_path = Path(db_path)
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._initialize()
+
+    def _connect(self) -> sqlite3.Connection:
+        connection = sqlite3.connect(self.db_path, timeout=30.0)
+        connection.row_factory = sqlite3.Row
+        connection.execute("PRAGMA journal_mode=WAL")
+        connection.execute("PRAGMA synchronous=FULL")
+        return connection
+
+    def _initialize(self) -> None:
+        try:
+            with self._connect() as connection:
+                connection.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS bracket_fill_legs (
+                        fill_id TEXT PRIMARY KEY,
+                        bracket_id TEXT NOT NULL,
+                        order_id TEXT NOT NULL,
+                        kind TEXT NOT NULL CHECK(kind IN ('ENTRY','EXIT')),
+                        side TEXT NOT NULL CHECK(side IN ('BUY','SELL')),
+                        quantity INTEGER NOT NULL CHECK(quantity > 0),
+                        price REAL NOT NULL CHECK(price > 0),
+                        target TEXT,
+                        reason TEXT,
+                        fees REAL NOT NULL DEFAULT 0 CHECK(fees >= 0),
+                        recorded_at REAL NOT NULL,
+                        metadata_json TEXT NOT NULL
+                    )
+                    """
+                )
+                connection.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_fill_bracket ON bracket_fill_legs(bracket_id, recorded_at, fill_id)"
+                )
+        except sqlite3.Error as exc:
+            raise FillLedgerError(f"unable to initialize fill ledger: {exc}") from exc
+
+    @staticmethod
+    def _from_row(row: sqlite3.Row) -> FillLeg:
+        try:
+            metadata = json.loads(str(row["metadata_json"] or "{}"))
+        except json.JSONDecodeError:
+            metadata = {}
+        return FillLeg(
+            fill_id=str(row["fill_id"]),
+            bracket_id=str(row["bracket_id"]),
+            order_id=str(row["order_id"]),
+            kind=str(row["kind"]),  # type: ignore[arg-type]
+            side=str(row["side"]),  # type: ignore[arg-type]
+            quantity=int(row["quantity"]),
+            price=float(row["price"]),
+            target=str(row["target"]) if row["target"] is not None else None,
+            reason=str(row["reason"]) if row["reason"] is not None else None,
+            fees=float(row["fees"]),
+            recorded_at=float(row["recorded_at"]),
+            metadata=metadata if isinstance(metadata, Mapping) else {},
+        )
+
+    def get_fill(self, fill_id: str) -> FillLeg | None:
+        try:
+            with self._connect() as connection:
+                row = connection.execute(
+                    "SELECT * FROM bracket_fill_legs WHERE fill_id = ?", (str(fill_id),)
+                ).fetchone()
+        except sqlite3.Error as exc:
+            raise FillLedgerError(f"unable to read fill {fill_id}: {exc}") from exc
+        return self._from_row(row) if row is not None else None
+
+    def record_fill(self, leg: FillLeg) -> bool:
+        existing = self.get_fill(leg.fill_id)
+        if existing is not None:
+            if existing.economics() != leg.economics():
+                raise FillConflictError(
+                    f"fill_id {leg.fill_id!r} already exists with different economics"
+                )
+            return False
+        try:
+            with self._connect() as connection:
+                connection.execute(
+                    """
+                    INSERT INTO bracket_fill_legs (
+                        fill_id, bracket_id, order_id, kind, side, quantity,
+                        price, target, reason, fees, recorded_at, metadata_json
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        leg.fill_id,
+                        leg.bracket_id,
+                        leg.order_id,
+                        leg.kind,
+                        leg.side,
+                        leg.quantity,
+                        leg.price,
+                        leg.target,
+                        leg.reason,
+                        leg.fees,
+                        leg.recorded_at,
+                        json.dumps(dict(leg.metadata), sort_keys=True, default=str),
+                    ),
+                )
+        except sqlite3.IntegrityError:
+            replay = self.get_fill(leg.fill_id)
+            if replay is not None and replay.economics() == leg.economics():
+                return False
+            raise FillConflictError(f"fill_id {leg.fill_id!r} was concurrently changed")
+        except sqlite3.Error as exc:
+            raise FillLedgerError(f"unable to persist fill {leg.fill_id}: {exc}") from exc
+        return True
+
+    def load_fills(self, bracket_id: str) -> list[FillLeg]:
+        try:
+            with self._connect() as connection:
+                rows = connection.execute(
+                    "SELECT * FROM bracket_fill_legs WHERE bracket_id = ? ORDER BY recorded_at, fill_id",
+                    (str(bracket_id),),
+                ).fetchall()
+        except sqlite3.Error as exc:
+            raise FillLedgerError(f"unable to load fills for {bracket_id}: {exc}") from exc
+        return [self._from_row(row) for row in rows]
+
+    def realized_pnl(self, bracket_id: str) -> RealizedPnl:
+        return calculate_realized_pnl(self.load_fills(bracket_id))
+
+
+__all__ = [
+    "BracketFillLedgerStore",
+    "FillConflictError",
+    "FillLedgerError",
+    "FillLeg",
+    "FillValidationError",
+    "RealizedPnl",
+    "calculate_realized_pnl",
+]

--- a/tests/execution/test_fill_ledger.py
+++ b/tests/execution/test_fill_ledger.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from nifty_scalper_bot.execution.fill_ledger import (
+    BracketFillLedgerStore,
+    FillConflictError,
+    FillLeg,
+    FillValidationError,
+    calculate_realized_pnl,
+)
+
+
+def _leg(
+    *,
+    fill_id: str,
+    order_id: str,
+    kind: str,
+    side: str,
+    quantity: int,
+    price: float,
+    fees: float = 0.0,
+    target: str | None = None,
+    recorded_at: float = 1_700_000_000.0,
+) -> FillLeg:
+    return FillLeg(
+        fill_id=fill_id,
+        bracket_id="entry-1",
+        order_id=order_id,
+        kind=kind,  # type: ignore[arg-type]
+        side=side,  # type: ignore[arg-type]
+        quantity=quantity,
+        price=price,
+        fees=fees,
+        target=target,
+        recorded_at=recorded_at,
+    )
+
+
+def test_rejects_invalid_quantity_and_price() -> None:
+    with pytest.raises(FillValidationError):
+        _leg(
+            fill_id="bad-q",
+            order_id="entry",
+            kind="ENTRY",
+            side="BUY",
+            quantity=0,
+            price=100.0,
+        )
+    with pytest.raises(FillValidationError):
+        _leg(
+            fill_id="bad-p",
+            order_id="entry",
+            kind="ENTRY",
+            side="BUY",
+            quantity=65,
+            price=float("nan"),
+        )
+
+
+def test_replay_is_idempotent_but_conflict_fails(tmp_path) -> None:
+    store = BracketFillLedgerStore(tmp_path / "fills.db")
+    leg = _leg(
+        fill_id="trade-1",
+        order_id="entry-order",
+        kind="ENTRY",
+        side="BUY",
+        quantity=65,
+        price=100.0,
+    )
+    assert store.record_fill(leg) is True
+    assert store.record_fill(leg) is False
+    with pytest.raises(FillConflictError):
+        store.record_fill(
+            _leg(
+                fill_id="trade-1",
+                order_id="entry-order",
+                kind="ENTRY",
+                side="BUY",
+                quantity=65,
+                price=101.0,
+            )
+        )
+
+
+def test_scaled_long_exit_uses_each_confirmed_fill() -> None:
+    pnl = calculate_realized_pnl(
+        [
+            _leg(
+                fill_id="entry",
+                order_id="entry-order",
+                kind="ENTRY",
+                side="BUY",
+                quantity=65,
+                price=100.0,
+                fees=3.0,
+            ),
+            _leg(
+                fill_id="tp1",
+                order_id="tp1-order",
+                kind="EXIT",
+                side="SELL",
+                quantity=25,
+                price=110.0,
+                fees=2.0,
+                target="TP1",
+            ),
+            _leg(
+                fill_id="final",
+                order_id="final-order",
+                kind="EXIT",
+                side="SELL",
+                quantity=40,
+                price=95.0,
+                fees=2.0,
+                target="SL",
+            ),
+        ]
+    )
+    assert pnl.entry_quantity == 65
+    assert pnl.exit_quantity == 65
+    assert pnl.entry_vwap == 100.0
+    assert math.isclose(pnl.exit_vwap or 0.0, 6550.0 / 65.0, rel_tol=1e-8)
+    assert pnl.gross_pnl == 50.0
+    assert pnl.fees == 7.0
+    assert pnl.net_pnl == 43.0
+    assert pnl.complete is True
+
+
+def test_partial_exit_is_not_complete() -> None:
+    pnl = calculate_realized_pnl(
+        [
+            _leg(
+                fill_id="entry",
+                order_id="entry-order",
+                kind="ENTRY",
+                side="BUY",
+                quantity=65,
+                price=100.0,
+            ),
+            _leg(
+                fill_id="tp1",
+                order_id="tp1-order",
+                kind="EXIT",
+                side="SELL",
+                quantity=25,
+                price=110.0,
+            ),
+        ]
+    )
+    assert pnl.gross_pnl == 250.0
+    assert pnl.exit_quantity == 25
+    assert pnl.complete is False
+
+
+def test_short_pnl_direction_and_over_exit_validation() -> None:
+    pnl = calculate_realized_pnl(
+        [
+            _leg(
+                fill_id="short-entry",
+                order_id="entry-order",
+                kind="ENTRY",
+                side="SELL",
+                quantity=10,
+                price=200.0,
+            ),
+            _leg(
+                fill_id="short-exit",
+                order_id="exit-order",
+                kind="EXIT",
+                side="BUY",
+                quantity=10,
+                price=190.0,
+            ),
+        ]
+    )
+    assert pnl.gross_pnl == 100.0
+    with pytest.raises(FillValidationError):
+        calculate_realized_pnl(
+            [
+                _leg(
+                    fill_id="entry",
+                    order_id="entry-order",
+                    kind="ENTRY",
+                    side="BUY",
+                    quantity=10,
+                    price=100.0,
+                ),
+                _leg(
+                    fill_id="too-much",
+                    order_id="exit-order",
+                    kind="EXIT",
+                    side="SELL",
+                    quantity=11,
+                    price=101.0,
+                ),
+            ]
+        )
+
+
+def test_sqlite_reopen_preserves_order_and_economics(tmp_path) -> None:
+    path = tmp_path / "fills.db"
+    store = BracketFillLedgerStore(path)
+    legs = [
+        _leg(
+            fill_id="entry",
+            order_id="entry-order",
+            kind="ENTRY",
+            side="BUY",
+            quantity=65,
+            price=100.0,
+            recorded_at=1_700_000_001.0,
+        ),
+        _leg(
+            fill_id="tp1",
+            order_id="tp1-order",
+            kind="EXIT",
+            side="SELL",
+            quantity=25,
+            price=110.0,
+            target="TP1",
+            recorded_at=1_700_000_002.0,
+        ),
+    ]
+    for leg in legs:
+        assert store.record_fill(leg) is True
+    reopened = BracketFillLedgerStore(path)
+    restored = reopened.load_fills("entry-1")
+    assert [leg.fill_id for leg in restored] == ["entry", "tp1"]
+    assert [leg.economics() for leg in restored] == [leg.economics() for leg in legs]
+    assert reopened.realized_pnl("entry-1").gross_pnl == 250.0


### PR DESCRIPTION
Clean Stage 2A diff based on merged main. Adds restart-safe immutable fill storage, idempotent replay handling, conflict detection, scaled-exit VWAP/P&L, fee accounting, partial-completion semantics, and focused tests. No live order or bracket behavior changes.