### PR TITLE
Stage 2B: persist confirmed fills before BO release

### DIFF
--- a/.github/workflows/live-exit-safety-ci.yml
+++ b/.github/workflows/live-exit-safety-ci.yml
@@ -28,6 +28,7 @@ jobs:
         run: |
           python -m pytest -q \
             tests/execution/test_fill_ledger.py \
+            tests/execution/test_ledger_bracket_runtime.py \
             tests/execution/test_canonical_bracket_fill_integrity.py \
             tests/execution/test_live_exit_hardening.py \
             tests/execution/test_bracket_exit_state_machine.py \

--- a/src/nifty_scalper_bot/execution/__init__.py
+++ b/src/nifty_scalper_bot/execution/__init__.py
@@ -1,9 +1,9 @@
 """Canonical execution package exports and live-money safety hardening.
 
-Public import paths remain stable while the runtime bracket authority adds
-fill-integrity and durable confirmed-fill accounting. Import replacement is a
-compatibility bridge only; explicit composition-root construction follows after
-all lifecycle invariants are merged and proven.
+Public import paths remain stable while one runtime bracket authority applies
+fill integrity, durable LIVE accounting and compatible PAPER/SHADOW behaviour.
+Import replacement remains a temporary bridge until explicit composition-root
+construction is migrated.
 """
 
 from __future__ import annotations
@@ -29,13 +29,14 @@ from nifty_scalper_bot.execution.canonical_bracket_manager import (  # noqa: E40
 from nifty_scalper_bot.execution.ledger_bracket_manager import (  # noqa: E402
     LedgerBracketManager,
 )
+from nifty_scalper_bot.execution.runtime_bracket_manager import (  # noqa: E402
+    RuntimeBracketManager,
+)
 
 _bracket_module.AdaptiveTrailingController = HardenedAdaptiveTrailingController
-_bracket_module.BracketManager = LedgerBracketManager
-# Existing tests and external callers importing CanonicalBracketManager continue
-# to resolve to the single runtime authority during the compatibility stage.
-_canonical_module.CanonicalBracketManager = LedgerBracketManager
-CanonicalBracketManager = LedgerBracketManager
+_bracket_module.BracketManager = RuntimeBracketManager
+_canonical_module.CanonicalBracketManager = RuntimeBracketManager
+CanonicalBracketManager = RuntimeBracketManager
 
 
 __all__ = [
@@ -43,5 +44,6 @@ __all__ = [
     "HardenedAdaptiveTrailingController",
     "HardenedBracketManager",
     "LedgerBracketManager",
+    "RuntimeBracketManager",
     "_FillIntegrityBracketManager",
 ]

--- a/src/nifty_scalper_bot/execution/__init__.py
+++ b/src/nifty_scalper_bot/execution/__init__.py
@@ -1,12 +1,9 @@
 """Canonical execution package exports and live-money safety hardening.
 
-The public module paths remain unchanged. Import-time replacement keeps every
-existing caller on the single production execution path while applying the
-hardened implementations before any manager instance is constructed.
-
-The replacement mechanism is retained only for compatibility during staged
-canonicalisation.  ``CanonicalBracketManager`` is the sole runtime bracket
-class; later stages will construct it explicitly at the composition root.
+Public import paths remain stable while the runtime bracket authority adds
+fill-integrity and durable confirmed-fill accounting.  Import replacement is
+retained only as a compatibility bridge until composition-root construction is
+migrated in the final canonicalisation stage.
 """
 
 from __future__ import annotations
@@ -28,16 +25,17 @@ from nifty_scalper_bot.execution.hardened_bracket_manager import (  # noqa: E402
 from nifty_scalper_bot.execution.canonical_bracket_manager import (  # noqa: E402
     CanonicalBracketManager,
 )
+from nifty_scalper_bot.execution.ledger_bracket_manager import (  # noqa: E402
+    LedgerBracketManager,
+)
 
-# Preserve all established import paths, including
-# ``from ...execution.bracket_manager import BracketManager``.  There is one
-# runtime export: the canonical fill-integrity manager.
 _bracket_module.AdaptiveTrailingController = HardenedAdaptiveTrailingController
-_bracket_module.BracketManager = CanonicalBracketManager
+_bracket_module.BracketManager = LedgerBracketManager
 
 
 __all__ = [
     "CanonicalBracketManager",
     "HardenedAdaptiveTrailingController",
     "HardenedBracketManager",
+    "LedgerBracketManager",
 ]

--- a/src/nifty_scalper_bot/execution/__init__.py
+++ b/src/nifty_scalper_bot/execution/__init__.py
@@ -1,9 +1,9 @@
 """Canonical execution package exports and live-money safety hardening.
 
 Public import paths remain stable while the runtime bracket authority adds
-fill-integrity and durable confirmed-fill accounting.  Import replacement is
-retained only as a compatibility bridge until composition-root construction is
-migrated in the final canonicalisation stage.
+fill-integrity and durable confirmed-fill accounting. Import replacement is a
+compatibility bridge only; explicit composition-root construction follows after
+all lifecycle invariants are merged and proven.
 """
 
 from __future__ import annotations
@@ -19,11 +19,12 @@ from nifty_scalper_bot.execution.hardened_adaptive_trailing import (  # noqa: E4
 _adaptive_module.AdaptiveTrailingController = HardenedAdaptiveTrailingController
 
 _bracket_module = import_module(f"{__name__}.bracket_manager")
+_canonical_module = import_module(f"{__name__}.canonical_bracket_manager")
 from nifty_scalper_bot.execution.hardened_bracket_manager import (  # noqa: E402
     HardenedBracketManager,
 )
 from nifty_scalper_bot.execution.canonical_bracket_manager import (  # noqa: E402
-    CanonicalBracketManager,
+    CanonicalBracketManager as _FillIntegrityBracketManager,
 )
 from nifty_scalper_bot.execution.ledger_bracket_manager import (  # noqa: E402
     LedgerBracketManager,
@@ -31,6 +32,10 @@ from nifty_scalper_bot.execution.ledger_bracket_manager import (  # noqa: E402
 
 _bracket_module.AdaptiveTrailingController = HardenedAdaptiveTrailingController
 _bracket_module.BracketManager = LedgerBracketManager
+# Existing tests and external callers importing CanonicalBracketManager continue
+# to resolve to the single runtime authority during the compatibility stage.
+_canonical_module.CanonicalBracketManager = LedgerBracketManager
+CanonicalBracketManager = LedgerBracketManager
 
 
 __all__ = [
@@ -38,4 +43,5 @@ __all__ = [
     "HardenedAdaptiveTrailingController",
     "HardenedBracketManager",
     "LedgerBracketManager",
+    "_FillIntegrityBracketManager",
 ]

--- a/src/nifty_scalper_bot/execution/ledger_bracket_manager.py
+++ b/src/nifty_scalper_bot/execution/ledger_bracket_manager.py
@@ -1,0 +1,553 @@
+"""Canonical bracket lifecycle with durable confirmed-fill accounting.
+
+Protective execution never depends on the ledger being healthy.  A persistence
+failure therefore cannot stop SL/TP handling, but it does block the runner from
+re-arming until fill history and broker-flat state are reconciled.
+"""
+
+from __future__ import annotations
+
+from contextlib import suppress
+import json
+import os
+from pathlib import Path
+import sqlite3
+import time
+from typing import Any, Mapping
+
+from nifty_scalper_bot.execution import bracket_manager as _legacy
+from nifty_scalper_bot.execution.canonical_bracket_manager import (
+    CanonicalBracketManager,
+)
+from nifty_scalper_bot.execution.fill_ledger import (
+    BracketFillLedgerStore,
+    FillLedgerError,
+    FillLeg,
+    FillValidationError,
+)
+
+
+class _LedgerReleaseStore:
+    """Persist entry-freeze markers independently of in-memory bracket state."""
+
+    def __init__(self, db_path: Path) -> None:
+        self.db_path = db_path
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        with self._connect() as connection:
+            connection.execute(
+                """
+                CREATE TABLE IF NOT EXISTS bracket_ledger_blocks (
+                    bracket_id TEXT PRIMARY KEY,
+                    reason TEXT NOT NULL,
+                    payload_json TEXT NOT NULL,
+                    updated_at REAL NOT NULL
+                )
+                """
+            )
+
+    def _connect(self) -> sqlite3.Connection:
+        connection = sqlite3.connect(self.db_path, timeout=30.0)
+        connection.execute("PRAGMA journal_mode=WAL")
+        connection.execute("PRAGMA synchronous=FULL")
+        return connection
+
+    def block(self, bracket_id: str, reason: str, payload: Mapping[str, Any]) -> None:
+        with self._connect() as connection:
+            connection.execute(
+                """
+                INSERT INTO bracket_ledger_blocks (
+                    bracket_id, reason, payload_json, updated_at
+                ) VALUES (?, ?, ?, ?)
+                ON CONFLICT(bracket_id) DO UPDATE SET
+                    reason = excluded.reason,
+                    payload_json = excluded.payload_json,
+                    updated_at = excluded.updated_at
+                """,
+                (
+                    str(bracket_id),
+                    str(reason),
+                    json.dumps(dict(payload), sort_keys=True, default=str),
+                    time.time(),
+                ),
+            )
+
+    def clear(self, bracket_id: str) -> None:
+        with self._connect() as connection:
+            connection.execute(
+                "DELETE FROM bracket_ledger_blocks WHERE bracket_id = ?",
+                (str(bracket_id),),
+            )
+
+    def load(self) -> dict[str, dict[str, Any]]:
+        with self._connect() as connection:
+            rows = connection.execute(
+                "SELECT bracket_id, reason, payload_json FROM bracket_ledger_blocks"
+            ).fetchall()
+        result: dict[str, dict[str, Any]] = {}
+        for bracket_id, reason, payload_json in rows:
+            try:
+                payload = json.loads(str(payload_json or "{}"))
+            except json.JSONDecodeError:
+                payload = {}
+            result[str(bracket_id)] = {
+                "reason": str(reason),
+                "payload": payload if isinstance(payload, Mapping) else {},
+            }
+        return result
+
+
+class LedgerBracketManager(CanonicalBracketManager):
+    """Runtime bracket authority with durable fills and release gating."""
+
+    _LEDGER_ERROR_PREFIX = "fill_ledger_degraded"
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        data_dir = Path(os.getenv("DATA_DIR", "data"))
+        configured = os.getenv("BRACKET_FILL_LEDGER_PATH")
+        self._ledger_path = Path(configured) if configured else data_dir / "bot_state.db"
+        self._fill_ledger: BracketFillLedgerStore | None = None
+        self._release_store: _LedgerReleaseStore | None = None
+        self._ledger_blocked: dict[str, dict[str, Any]] = {}
+        try:
+            self._fill_ledger = BracketFillLedgerStore(self._ledger_path)
+            self._release_store = _LedgerReleaseStore(self._ledger_path)
+            self._ledger_blocked = self._release_store.load()
+        except Exception as exc:  # noqa: BLE001 - protection must still initialize
+            _legacy.LOGGER.critical(
+                "FILL_LEDGER_INIT_FAILED path=%s error=%s",
+                self._ledger_path,
+                exc,
+                extra={
+                    "event": "FILL_LEDGER_INIT_FAILED",
+                    "path": str(self._ledger_path),
+                    "error_type": type(exc).__name__,
+                },
+            )
+        super().__init__(*args, **kwargs)
+
+    @staticmethod
+    def _entry_fill_id(order_id: str) -> str:
+        return f"ENTRY:{order_id}"
+
+    @staticmethod
+    def _exit_fill_id(order_id: str) -> str:
+        return f"EXIT:{order_id}"
+
+    def _find_bracket_by_id(self, bracket_id: str) -> Any | None:
+        with self._lock:
+            for bracket in self._brackets.values():
+                if str(bracket.bracket_id) == str(bracket_id):
+                    return bracket
+        return None
+
+    def _block_ledger_release(
+        self,
+        bracket: Any,
+        *,
+        reason: str,
+        payload: Mapping[str, Any] | None = None,
+    ) -> None:
+        details = {"reason": str(reason), "payload": dict(payload or {})}
+        self._ledger_blocked[str(bracket.bracket_id)] = details
+        with self._lock:
+            bracket.last_exit_error = f"{self._LEDGER_ERROR_PREFIX}:{reason}"
+            bracket.updated_at = time.time()
+        if self._release_store is not None:
+            with suppress(Exception):
+                self._release_store.block(
+                    str(bracket.bracket_id),
+                    str(reason),
+                    dict(payload or {}),
+                )
+        _legacy.LOGGER.critical(
+            "FILL_LEDGER_RELEASE_BLOCKED bracket_id=%s symbol=%s reason=%s payload=%s",
+            bracket.bracket_id,
+            bracket.symbol,
+            reason,
+            dict(payload or {}),
+            extra={
+                "event": "FILL_LEDGER_RELEASE_BLOCKED",
+                "bracket_id": bracket.bracket_id,
+                "symbol": bracket.symbol,
+                "reason": reason,
+            },
+        )
+        with suppress(Exception):
+            self._notify_event(
+                "FILL_LEDGER_DEGRADED",
+                {
+                    "symbol": bracket.symbol,
+                    "bracket_id": bracket.bracket_id,
+                    "reason": reason,
+                    "message": "Broker protection remains active; new entries are blocked until fill accounting is reconciled.",
+                },
+            )
+
+    def _clear_ledger_release(self, bracket: Any) -> None:
+        self._ledger_blocked.pop(str(bracket.bracket_id), None)
+        if self._release_store is not None:
+            with suppress(Exception):
+                self._release_store.clear(str(bracket.bracket_id))
+        with self._lock:
+            if str(bracket.last_exit_error or "").startswith(self._LEDGER_ERROR_PREFIX):
+                bracket.last_exit_error = None
+
+    def _record_fill(self, leg: FillLeg) -> bool:
+        if self._fill_ledger is None:
+            raise FillLedgerError("fill ledger is unavailable")
+        inserted = self._fill_ledger.record_fill(leg)
+        _legacy.LOGGER.info(
+            "FILL_LEDGER_RECORDED bracket_id=%s fill_id=%s kind=%s side=%s qty=%s price=%.2f inserted=%s",
+            leg.bracket_id,
+            leg.fill_id,
+            leg.kind,
+            leg.side,
+            leg.quantity,
+            leg.price,
+            inserted,
+            extra={
+                "event": "FILL_LEDGER_RECORDED",
+                "bracket_id": leg.bracket_id,
+                "fill_id": leg.fill_id,
+                "kind": leg.kind,
+                "qty": leg.quantity,
+                "price": leg.price,
+                "inserted": inserted,
+            },
+        )
+        return inserted
+
+    def _record_entry_fill(self, bracket: Any, fill_price: float) -> None:
+        self._record_fill(
+            FillLeg(
+                fill_id=self._entry_fill_id(str(bracket.entry_order_id)),
+                bracket_id=str(bracket.bracket_id),
+                order_id=str(bracket.entry_order_id),
+                kind="ENTRY",
+                side="BUY" if bracket.side == "BUY" else "SELL",
+                quantity=int(bracket.quantity),
+                price=float(fill_price),
+                reason="ENTRY_CONFIRMED",
+                metadata={"symbol": bracket.symbol},
+            )
+        )
+
+    def _record_exit_fill(
+        self,
+        bracket: Any,
+        *,
+        order_id: str,
+        quantity: int,
+        price: float,
+        target: str | None,
+        reason: str | None,
+    ) -> None:
+        self._record_fill(
+            FillLeg(
+                fill_id=self._exit_fill_id(str(order_id)),
+                bracket_id=str(bracket.bracket_id),
+                order_id=str(order_id),
+                kind="EXIT",
+                side="SELL" if bracket.side == "BUY" else "BUY",
+                quantity=int(quantity),
+                price=float(price),
+                target=target,
+                reason=reason,
+                metadata={"symbol": bracket.symbol},
+            )
+        )
+
+    def confirm_entry_fill(self, order_id: str, fill_price: float) -> None:
+        bracket = self.get_bracket(order_id)
+        ledger_ok = True
+        if bracket is not None:
+            try:
+                self._record_entry_fill(bracket, float(fill_price))
+            except Exception as exc:  # noqa: BLE001
+                ledger_ok = False
+                setattr(bracket, "_ledger_pending_entry_price", float(fill_price))
+                self._block_ledger_release(
+                    bracket,
+                    reason="entry_fill_persist_failed",
+                    payload={"order_id": order_id, "error": str(exc)},
+                )
+        super().confirm_entry_fill(order_id, fill_price)
+        bracket = self.get_bracket(order_id)
+        if bracket is not None and ledger_ok:
+            self._clear_ledger_release(bracket)
+
+    def _resume_after_partial_target(
+        self,
+        bracket: Any,
+        *,
+        target: Any,
+        residual_quantity: int,
+        order_id: str,
+        status_payload: Mapping[str, Any],
+        requested_by: str,
+    ) -> bool:
+        previous_remaining = int(bracket.remaining_quantity or 0)
+        filled_quantity = previous_remaining - int(residual_quantity)
+        fill_price = self._extract_status_price(status_payload)
+        ledger_ok = True
+        try:
+            if filled_quantity <= 0 or fill_price is None:
+                raise FillValidationError("partial exit fill quantity/price unavailable")
+            self._record_exit_fill(
+                bracket,
+                order_id=order_id,
+                quantity=filled_quantity,
+                price=fill_price,
+                target=str(target.name),
+                reason=str(bracket.exit_reason or requested_by),
+            )
+        except Exception as exc:  # noqa: BLE001
+            ledger_ok = False
+            setattr(bracket, "_ledger_pending_exit_order_id", str(order_id))
+            setattr(bracket, "_ledger_pending_exit_quantity", max(filled_quantity, 0))
+            setattr(bracket, "_ledger_pending_exit_price", fill_price)
+            setattr(bracket, "_ledger_pending_exit_target", str(target.name))
+            self._block_ledger_release(
+                bracket,
+                reason="partial_exit_persist_failed",
+                payload={"order_id": order_id, "error": str(exc)},
+            )
+
+        resumed = super()._resume_after_partial_target(
+            bracket,
+            target=target,
+            residual_quantity=residual_quantity,
+            order_id=order_id,
+            status_payload=status_payload,
+            requested_by=requested_by,
+        )
+        if resumed and ledger_ok and self._fill_ledger is not None:
+            pnl = self._fill_ledger.realized_pnl(str(bracket.bracket_id))
+            self._clear_ledger_release(bracket)
+            with suppress(Exception):
+                self._notify_event(
+                    "PARTIAL_EXIT_ACCOUNTED",
+                    {
+                        "symbol": bracket.symbol,
+                        "target": str(target.name),
+                        "remaining_qty": residual_quantity,
+                        "realized_gross_pnl": pnl.gross_pnl,
+                        "realized_net_pnl": pnl.net_pnl,
+                    },
+                )
+        return resumed
+
+    def _resolved_exit_price(self, bracket: Any, exit_price: float | None) -> float | None:
+        if exit_price is not None and float(exit_price) > 0:
+            return float(exit_price)
+        order_id = bracket.exit_order_id or bracket.pending_exit_order_id
+        if not order_id:
+            return None
+        with suppress(Exception):
+            return self._extract_status_price(
+                self._get_broker_order_status(str(order_id))
+            )
+        return None
+
+    def _close_bracket(
+        self,
+        bracket: Any,
+        *,
+        close_source: str,
+        exit_price: float | None = None,
+    ) -> None:
+        order_id = str(bracket.exit_order_id or bracket.pending_exit_order_id or "")
+        closing_quantity = int(bracket.remaining_quantity or 0)
+        resolved_price = self._resolved_exit_price(bracket, exit_price)
+        ledger_complete = False
+        ledger_pnl = None
+        try:
+            if not order_id or closing_quantity <= 0 or resolved_price is None:
+                raise FillValidationError("final exit identity, quantity or fill price unavailable")
+            self._record_exit_fill(
+                bracket,
+                order_id=order_id,
+                quantity=closing_quantity,
+                price=resolved_price,
+                target="FINAL",
+                reason=str(bracket.exit_reason or close_source),
+            )
+            if self._fill_ledger is None:
+                raise FillLedgerError("fill ledger unavailable after final fill")
+            ledger_pnl = self._fill_ledger.realized_pnl(str(bracket.bracket_id))
+            if not ledger_pnl.complete:
+                raise FillValidationError(
+                    f"ledger incomplete entry={ledger_pnl.entry_quantity} exit={ledger_pnl.exit_quantity}"
+                )
+            ledger_complete = True
+        except Exception as exc:  # noqa: BLE001
+            setattr(bracket, "_ledger_pending_exit_order_id", order_id or None)
+            setattr(bracket, "_ledger_pending_exit_quantity", closing_quantity)
+            setattr(bracket, "_ledger_pending_exit_price", resolved_price)
+            setattr(bracket, "_ledger_pending_exit_target", "FINAL")
+            self._block_ledger_release(
+                bracket,
+                reason="final_exit_accounting_failed",
+                payload={"order_id": order_id, "error": str(exc)},
+            )
+
+        with self._lock:
+            bracket.remaining_quantity = 0
+            bracket.exit_executed = True
+            bracket.exit_pending = False
+            bracket.exit_in_progress = False
+            bracket.active = False
+            bracket.position_flat_confirmed = True
+            bracket.exit_state = _legacy.BracketExitLifecycle.CLOSED.value
+            bracket.entry_status = "CLOSED"
+            bracket.pending_exit_order_id = None
+            bracket.close_source = close_source
+            bracket.closed_at = time.time()
+            if resolved_price is not None:
+                bracket.exit_price = resolved_price
+            bracket.updated_at = bracket.closed_at
+            self._exit_cooldowns.pop(bracket.entry_order_id, None)
+            setattr(
+                bracket,
+                "ledger_realized_pnl",
+                ledger_pnl.to_dict() if ledger_pnl is not None else None,
+            )
+
+        snapshot_persisted = True
+        try:
+            self.save_state()
+        except Exception as exc:  # noqa: BLE001
+            snapshot_persisted = False
+            self._block_ledger_release(
+                bracket,
+                reason="closed_snapshot_persist_failed",
+                payload={"error": str(exc)},
+            )
+
+        gross_pnl = ledger_pnl.gross_pnl if ledger_pnl is not None else None
+        net_pnl = ledger_pnl.net_pnl if ledger_pnl is not None else None
+        _legacy.LOGGER.info(
+            "BRACKET_CLOSED bracket_id=%s symbol=%s close_source=%s side=%s qty=%s entry=%s exit=%s pnl=%s net_pnl=%s ledger_complete=%s",
+            bracket.bracket_id,
+            bracket.symbol,
+            close_source,
+            bracket.side,
+            int(bracket.quantity or 0),
+            ledger_pnl.entry_vwap if ledger_pnl is not None else bracket.entry_price,
+            ledger_pnl.exit_vwap if ledger_pnl is not None else resolved_price,
+            gross_pnl,
+            net_pnl,
+            ledger_complete,
+        )
+        self._log_bracket_event(
+            "BRACKET_CLOSED",
+            bracket,
+            meta={
+                "close_source": close_source,
+                "exit_order_id": order_id,
+                "gross_pnl": gross_pnl,
+                "net_pnl": net_pnl,
+                "ledger_complete": ledger_complete,
+            },
+        )
+        self._notify_open_position_priority("close", bracket.symbol)
+        with suppress(Exception):
+            self._notify_event(
+                "BRACKET_CLOSED",
+                {
+                    "symbol": bracket.symbol,
+                    "quantity": int(bracket.quantity or 0),
+                    "gross_pnl": gross_pnl,
+                    "net_pnl": net_pnl,
+                    "ledger_complete": ledger_complete,
+                    "close_source": close_source,
+                },
+            )
+
+        if ledger_complete and snapshot_persisted:
+            self._clear_ledger_release(bracket)
+            hook = self._on_exit_complete_hook
+            if hook is not None and not getattr(bracket, "_ledger_release_hook_fired", False):
+                try:
+                    hook(bracket.symbol)
+                    setattr(bracket, "_ledger_release_hook_fired", True)
+                except Exception:
+                    _legacy.LOGGER.exception(
+                        "BRACKET_EXIT_COMPLETE_HOOK_FAILED symbol=%s", bracket.symbol
+                    )
+
+    def _retry_ledger_block(self, bracket: Any) -> bool:
+        try:
+            pending_entry = getattr(bracket, "_ledger_pending_entry_price", None)
+            if pending_entry is not None:
+                self._record_entry_fill(bracket, float(pending_entry))
+                delattr(bracket, "_ledger_pending_entry_price")
+
+            pending_order = getattr(bracket, "_ledger_pending_exit_order_id", None)
+            if pending_order:
+                quantity = int(getattr(bracket, "_ledger_pending_exit_quantity", 0) or 0)
+                price = getattr(bracket, "_ledger_pending_exit_price", None)
+                target = getattr(bracket, "_ledger_pending_exit_target", None)
+                if quantity <= 0 or price is None:
+                    return False
+                self._record_exit_fill(
+                    bracket,
+                    order_id=str(pending_order),
+                    quantity=quantity,
+                    price=float(price),
+                    target=str(target or "RECOVERED"),
+                    reason="LEDGER_RECONCILIATION",
+                )
+                for name in (
+                    "_ledger_pending_exit_order_id",
+                    "_ledger_pending_exit_quantity",
+                    "_ledger_pending_exit_price",
+                    "_ledger_pending_exit_target",
+                ):
+                    with suppress(AttributeError):
+                        delattr(bracket, name)
+
+            if bracket.exit_state == _legacy.BracketExitLifecycle.CLOSED.value:
+                if not self._safe_position_flat(bracket.symbol):
+                    return False
+                if self._fill_ledger is None:
+                    return False
+                pnl = self._fill_ledger.realized_pnl(str(bracket.bracket_id))
+                if not pnl.complete:
+                    return False
+                setattr(bracket, "ledger_realized_pnl", pnl.to_dict())
+                self.save_state()
+                hook = self._on_exit_complete_hook
+                if hook is not None and not getattr(
+                    bracket, "_ledger_release_hook_fired", False
+                ):
+                    hook(bracket.symbol)
+                    setattr(bracket, "_ledger_release_hook_fired", True)
+            self._clear_ledger_release(bracket)
+            return True
+        except Exception as exc:  # noqa: BLE001
+            _legacy.LOGGER.error(
+                "FILL_LEDGER_RECONCILE_FAILED bracket_id=%s error=%s",
+                bracket.bracket_id,
+                exc,
+            )
+            return False
+
+    def _retry_blocked_releases(self) -> None:
+        for bracket_id in list(self._ledger_blocked):
+            bracket = self._find_bracket_by_id(bracket_id)
+            if bracket is not None:
+                self._retry_ledger_block(bracket)
+
+    def has_unresolved_exit(self) -> bool:
+        self._retry_blocked_releases()
+        return bool(self._ledger_blocked) or super().has_unresolved_exit()
+
+    def get_first_unresolved_exit_bracket_id(self) -> str | None:
+        self._retry_blocked_releases()
+        if self._ledger_blocked:
+            return next(iter(self._ledger_blocked))
+        return super().get_first_unresolved_exit_bracket_id()
+
+
+__all__ = ["LedgerBracketManager"]

--- a/src/nifty_scalper_bot/execution/runtime_bracket_manager.py
+++ b/src/nifty_scalper_bot/execution/runtime_bracket_manager.py
@@ -1,0 +1,173 @@
+"""Runtime bracket authority with strict LIVE and compatible non-live closure.
+
+LIVE execution uses the durable ledger release gate.  PAPER/SHADOW/SIMULATION
+retain legacy close and hook behaviour so tests, dry runs and dashboards do not
+lose functionality when broker fill identity is intentionally absent.
+"""
+
+from __future__ import annotations
+
+from contextlib import suppress
+import os
+import time
+from typing import Any
+
+from nifty_scalper_bot.execution import bracket_manager as _legacy
+from nifty_scalper_bot.execution.ledger_bracket_manager import LedgerBracketManager
+
+
+class RuntimeBracketManager(LedgerBracketManager):
+    """Final runtime export for the staged lifecycle implementation."""
+
+    def _strict_ledger_release_required(self) -> bool:
+        checker = getattr(self.order_manager, "is_live_mode", None)
+        if callable(checker):
+            with suppress(Exception):
+                return bool(checker())
+        mode = str(os.getenv("EXECUTION_MODE", "SHADOW") or "SHADOW").upper()
+        live_flag = str(
+            os.getenv("ENABLE_LIVE")
+            or os.getenv("ENABLE_LIVE_TRADING")
+            or "false"
+        ).lower() in {"1", "true", "yes", "on"}
+        return mode == "LIVE" and live_flag
+
+    def _close_bracket(
+        self,
+        bracket: Any,
+        *,
+        close_source: str,
+        exit_price: float | None = None,
+    ) -> None:
+        if self._strict_ledger_release_required():
+            super()._close_bracket(
+                bracket,
+                close_source=close_source,
+                exit_price=exit_price,
+            )
+            return
+
+        order_id = str(bracket.exit_order_id or bracket.pending_exit_order_id or "")
+        closing_quantity = int(bracket.remaining_quantity or 0)
+        resolved_price = self._resolved_exit_price(bracket, exit_price)
+        ledger_pnl = None
+        if order_id and closing_quantity > 0 and resolved_price is not None:
+            with suppress(Exception):
+                self._record_exit_fill(
+                    bracket,
+                    order_id=order_id,
+                    quantity=closing_quantity,
+                    price=resolved_price,
+                    target="FINAL",
+                    reason=str(bracket.exit_reason or close_source),
+                )
+                if self._fill_ledger is not None:
+                    candidate = self._fill_ledger.realized_pnl(str(bracket.bracket_id))
+                    if candidate.complete:
+                        ledger_pnl = candidate
+
+        with self._lock:
+            bracket.remaining_quantity = 0
+            bracket.exit_executed = True
+            bracket.exit_pending = False
+            bracket.exit_in_progress = False
+            bracket.active = False
+            bracket.position_flat_confirmed = True
+            bracket.exit_state = _legacy.BracketExitLifecycle.CLOSED.value
+            bracket.entry_status = "CLOSED"
+            bracket.pending_exit_order_id = None
+            bracket.close_source = close_source
+            bracket.closed_at = time.time()
+            if resolved_price is not None:
+                bracket.exit_price = resolved_price
+            bracket.updated_at = bracket.closed_at
+            self._exit_cooldowns.pop(bracket.entry_order_id, None)
+
+        entry_px = (
+            ledger_pnl.entry_vwap
+            if ledger_pnl is not None
+            else (
+                bracket.entry_fill_price
+                if bracket.entry_fill_price is not None
+                else bracket.entry_price
+            )
+        )
+        final_exit_px = (
+            ledger_pnl.exit_vwap if ledger_pnl is not None else bracket.exit_price
+        )
+        filled_qty = int(bracket.quantity or 0)
+        realized_pnl = ledger_pnl.gross_pnl if ledger_pnl is not None else None
+        if realized_pnl is None:
+            try:
+                if entry_px is not None and final_exit_px is not None and filled_qty > 0:
+                    if bracket.side == "BUY":
+                        realized_pnl = round(
+                            (float(final_exit_px) - float(entry_px)) * filled_qty,
+                            2,
+                        )
+                    else:
+                        realized_pnl = round(
+                            (float(entry_px) - float(final_exit_px)) * filled_qty,
+                            2,
+                        )
+            except Exception:  # noqa: BLE001
+                realized_pnl = None
+
+        try:
+            self.save_state()
+        except Exception as exc:  # noqa: BLE001
+            _legacy.LOGGER.error(
+                "BRACKET_CLOSE_PERSIST_FAILED bracket_id=%s error=%s",
+                bracket.bracket_id,
+                exc,
+            )
+
+        _legacy.LOGGER.info(
+            "BRACKET_CLOSED bracket_id=%s symbol=%s close_source=%s side=%s qty=%s entry=%s exit=%s pnl=%s",
+            bracket.bracket_id,
+            bracket.symbol,
+            close_source,
+            bracket.side,
+            filled_qty,
+            entry_px,
+            final_exit_px,
+            realized_pnl,
+        )
+        self._log_bracket_event(
+            "BRACKET_CLOSED",
+            bracket,
+            meta={
+                "close_source": close_source,
+                "exit_order_id": order_id,
+                "side": bracket.side,
+                "qty": filled_qty,
+                "entry": entry_px,
+                "exit": final_exit_px,
+                "pnl": realized_pnl,
+                "ledger_complete": bool(ledger_pnl and ledger_pnl.complete),
+            },
+        )
+        self._notify_open_position_priority("close", bracket.symbol)
+        with suppress(Exception):
+            self._notify_event(
+                "BRACKET_CLOSED",
+                {
+                    "symbol": bracket.symbol,
+                    "quantity": filled_qty,
+                    "gross_pnl": realized_pnl,
+                    "ledger_complete": bool(ledger_pnl and ledger_pnl.complete),
+                    "close_source": close_source,
+                },
+            )
+        self._clear_ledger_release(bracket)
+        hook = self._on_exit_complete_hook
+        if hook is not None:
+            try:
+                hook(bracket.symbol)
+            except Exception:
+                _legacy.LOGGER.exception(
+                    "BRACKET_EXIT_COMPLETE_HOOK_FAILED symbol=%s", bracket.symbol
+                )
+
+
+__all__ = ["RuntimeBracketManager"]

--- a/tests/execution/test_ledger_bracket_runtime.py
+++ b/tests/execution/test_ledger_bracket_runtime.py
@@ -1,0 +1,229 @@
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from nifty_scalper_bot.execution.bracket_manager import BracketExitLifecycle
+from nifty_scalper_bot.execution.ledger_bracket_manager import LedgerBracketManager
+
+
+SYMBOL = "NFO:NIFTY2662324050PE"
+
+
+class _Broker:
+    def __init__(self) -> None:
+        self.statuses: dict[str, dict[str, Any]] = {}
+        self.positions: list[dict[str, Any]] = [{"symbol": SYMBOL, "quantity": 65}]
+
+    def get_order_status(self, order_id: str) -> dict[str, Any]:
+        return dict(self.statuses.get(order_id, {"status": ""}))
+
+    def get_positions(self) -> list[dict[str, Any]]:
+        return list(self.positions)
+
+    def cancel_order(self, order_id: str, *args: Any, **kwargs: Any) -> bool:
+        payload = dict(self.statuses.get(order_id, {}))
+        payload["status"] = "CANCELLED"
+        self.statuses[order_id] = payload
+        return True
+
+
+class _OrderManager:
+    def __init__(self, broker: _Broker) -> None:
+        self._broker = broker
+        self._last_order_decision: dict[str, Any] = {}
+        self.place_calls: list[dict[str, Any]] = []
+
+    def place_order(self, **kwargs: Any) -> str:
+        self.place_calls.append(dict(kwargs))
+        order_id = f"exit-{len(self.place_calls)}"
+        self._broker.statuses[order_id] = {"status": "OPEN"}
+        return order_id
+
+    def cancel_order(self, order_id: str, *args: Any, **kwargs: Any) -> bool:
+        return self._broker.cancel_order(order_id, *args, **kwargs)
+
+    def set_last_skip_reason(self, _reason: str) -> None:
+        return None
+
+
+def _manager(monkeypatch, tmp_path) -> tuple[LedgerBracketManager, _OrderManager, _Broker]:
+    monkeypatch.setenv("BRACKET_FILL_LEDGER_PATH", str(tmp_path / "lifecycle.db"))
+    broker = _Broker()
+    order_manager = _OrderManager(broker)
+    manager = LedgerBracketManager(order_manager=order_manager)
+    manager._running = False
+    manager._watchdog_thread.join(timeout=1.0)
+    manager._filled_position_sync_grace_seconds = 0.0
+    manager._exit_reconcile_interval_seconds = 0.0
+    manager.register_virtual_bracket(
+        order_id="entry-1",
+        symbol=SYMBOL,
+        side="BUY",
+        qty=65,
+        price=100.0,
+        sl=90.0,
+        tp=120.0,
+        tp1_price=110.0,
+        tp1_qty=25,
+        activate_immediately=False,
+    )
+    return manager, order_manager, broker
+
+
+def _mark_filled_exit(
+    manager: LedgerBracketManager,
+    broker: _Broker,
+    *,
+    order_id: str,
+    reason: str,
+    price: float,
+    residual: int,
+) -> Any:
+    bracket = manager.get_bracket("entry-1")
+    assert bracket is not None
+    bracket.exit_pending = True
+    bracket.exit_reason = reason
+    bracket.exit_state = BracketExitLifecycle.EXIT_ORDER_SUBMITTED.value
+    bracket.entry_status = bracket.exit_state
+    bracket.exit_order_id = order_id
+    bracket.pending_exit_order_id = order_id
+    bracket.exit_triggered_at = time.time()
+    broker.statuses[order_id] = {"status": "COMPLETE", "average_price": price}
+    broker.positions = [] if residual == 0 else [{"symbol": SYMBOL, "quantity": residual}]
+    return bracket
+
+
+def test_scaled_fills_persist_and_close_uses_exact_weighted_pnl(monkeypatch, tmp_path) -> None:
+    manager, _order_manager, broker = _manager(monkeypatch, tmp_path)
+    manager.confirm_entry_fill("entry-1", 100.0)
+
+    bracket = _mark_filled_exit(
+        manager,
+        broker,
+        order_id="tp1-order",
+        reason="TP1 Hit (110.00)",
+        price=110.0,
+        residual=40,
+    )
+    assert manager._reconcile_exit_state(bracket, requested_by="tp1") is False
+    assert bracket.remaining_quantity == 40
+    assert bracket.exit_state == BracketExitLifecycle.OPEN_ACTIVE.value
+
+    ordering: list[str] = []
+    manager.save_state = lambda: ordering.append("save")  # type: ignore[method-assign]
+    manager.attach_on_exit_complete(lambda _symbol: ordering.append("hook"))
+    bracket = _mark_filled_exit(
+        manager,
+        broker,
+        order_id="final-order",
+        reason="HARD_SL_BREACH",
+        price=95.0,
+        residual=0,
+    )
+    assert manager._reconcile_exit_state(bracket, requested_by="final") is True
+
+    assert manager._fill_ledger is not None
+    fills = manager._fill_ledger.load_fills(bracket.bracket_id)
+    assert [(fill.kind, fill.quantity, fill.price) for fill in fills] == [
+        ("ENTRY", 65, 100.0),
+        ("EXIT", 25, 110.0),
+        ("EXIT", 40, 95.0),
+    ]
+    pnl = manager._fill_ledger.realized_pnl(bracket.bracket_id)
+    assert pnl.gross_pnl == 50.0
+    assert pnl.complete is True
+    assert ordering == ["save", "hook"]
+    assert bracket.ledger_realized_pnl["gross_pnl"] == 50.0
+    assert manager.has_unresolved_exit() is False
+
+
+def test_duplicate_entry_callback_is_idempotent(monkeypatch, tmp_path) -> None:
+    manager, _order_manager, _broker = _manager(monkeypatch, tmp_path)
+    manager.confirm_entry_fill("entry-1", 100.0)
+    manager.confirm_entry_fill("entry-1", 100.0)
+    assert manager._fill_ledger is not None
+    fills = manager._fill_ledger.load_fills("entry-1")
+    assert len(fills) == 1
+    assert fills[0].fill_id == "ENTRY:entry-1"
+
+
+def test_partial_exit_persistence_failure_keeps_residual_protected_and_blocks_entries(
+    monkeypatch, tmp_path
+) -> None:
+    manager, _order_manager, broker = _manager(monkeypatch, tmp_path)
+    manager.confirm_entry_fill("entry-1", 100.0)
+
+    class _FailingLedger:
+        def record_fill(self, _leg: Any) -> bool:
+            raise OSError("disk unavailable")
+
+    manager._fill_ledger = _FailingLedger()  # type: ignore[assignment]
+    bracket = _mark_filled_exit(
+        manager,
+        broker,
+        order_id="tp1-failed-ledger",
+        reason="TP1 Hit (110.00)",
+        price=110.0,
+        residual=40,
+    )
+    assert manager._reconcile_exit_state(bracket, requested_by="tp1-failure") is False
+    assert bracket.remaining_quantity == 40
+    assert bracket.exit_state == BracketExitLifecycle.OPEN_ACTIVE.value
+    assert bracket.sl_trigger_price == bracket.entry_price
+    assert manager.has_unresolved_exit() is True
+    assert bracket.bracket_id in manager._ledger_blocked
+
+
+def test_final_close_does_not_release_runner_when_ledger_is_incomplete(
+    monkeypatch, tmp_path
+) -> None:
+    manager, _order_manager, broker = _manager(monkeypatch, tmp_path)
+    released: list[str] = []
+    manager.attach_on_exit_complete(released.append)
+    bracket = manager.get_bracket("entry-1")
+    assert bracket is not None
+    bracket.entry_confirmed = True
+    bracket.active = True
+    bracket.entry_status = "ACTIVE"
+
+    bracket = _mark_filled_exit(
+        manager,
+        broker,
+        order_id="final-without-entry-ledger",
+        reason="HARD_SL_BREACH",
+        price=95.0,
+        residual=0,
+    )
+    assert manager._reconcile_exit_state(bracket, requested_by="missing-entry") is True
+    assert bracket.exit_state == BracketExitLifecycle.CLOSED.value
+    assert released == []
+    assert manager.has_unresolved_exit() is True
+
+
+def test_release_block_survives_manager_restart(monkeypatch, tmp_path) -> None:
+    path = tmp_path / "restart.db"
+    monkeypatch.setenv("BRACKET_FILL_LEDGER_PATH", str(path))
+    broker = _Broker()
+    first = LedgerBracketManager(order_manager=_OrderManager(broker))
+    first._running = False
+    first._watchdog_thread.join(timeout=1.0)
+    first.register_virtual_bracket(
+        order_id="entry-restart",
+        symbol=SYMBOL,
+        side="BUY",
+        qty=65,
+        price=100.0,
+        sl=90.0,
+        tp=120.0,
+        activate_immediately=True,
+    )
+    bracket = first.get_bracket("entry-restart")
+    assert bracket is not None
+    first._block_ledger_release(bracket, reason="test_restart", payload={})
+
+    second = LedgerBracketManager(order_manager=_OrderManager(broker))
+    second._running = False
+    second._watchdog_thread.join(timeout=1.0)
+    assert bracket.bracket_id in second._ledger_blocked
+    assert second.has_unresolved_exit() is True


### PR DESCRIPTION
Integrates the merged fill ledger into the canonical bracket lifecycle. Confirmed entry, TP1 and final exit fills are persisted idempotently; scaled P&L is ledger-derived; bracket snapshot persistence now precedes notifications and runner release. Ledger degradation never blocks protective exits but durably blocks new entries/re-arm until reconciliation. Includes exact scaled-P&L, duplicate callback, persistence failure, hook ordering and restart-block tests.