### PR TITLE
Stage 3: bounded entry recovery and partial-fill protection

### DIFF
--- a/.github/workflows/live-exit-safety-ci.yml
+++ b/.github/workflows/live-exit-safety-ci.yml
@@ -27,6 +27,7 @@ jobs:
       - name: Focused live-money safety regression tests
         run: |
           python -m pytest -q \
+            tests/execution/test_canonical_entry_recovery.py \
             tests/execution/test_fill_ledger.py \
             tests/execution/test_ledger_bracket_runtime.py \
             tests/execution/test_canonical_bracket_fill_integrity.py \

--- a/src/nifty_scalper_bot/execution/__init__.py
+++ b/src/nifty_scalper_bot/execution/__init__.py
@@ -1,9 +1,8 @@
 """Canonical execution package exports and live-money safety hardening.
 
-Public import paths remain stable while one runtime bracket authority applies
-fill integrity, durable LIVE accounting and compatible PAPER/SHADOW behaviour.
-Import replacement remains a temporary bridge until explicit composition-root
-construction is migrated.
+Public import paths remain stable while one bracket authority applies fill
+integrity and durable accounting, and the established OrderManager receives a
+bounded recovery layer without changing its class identity.
 """
 
 from __future__ import annotations
@@ -37,6 +36,14 @@ _bracket_module.AdaptiveTrailingController = HardenedAdaptiveTrailingController
 _bracket_module.BracketManager = RuntimeBracketManager
 _canonical_module.CanonicalBracketManager = RuntimeBracketManager
 CanonicalBracketManager = RuntimeBracketManager
+
+# Preserve the existing OrderManager class and all unbound method contracts.
+_order_manager_module = import_module(f"{__name__}.order_manager")
+from nifty_scalper_bot.execution.entry_recovery import (  # noqa: E402
+    install_entry_recovery,
+)
+
+install_entry_recovery(_order_manager_module.OrderManager)
 
 
 __all__ = [

--- a/src/nifty_scalper_bot/execution/broker_recovery.py
+++ b/src/nifty_scalper_bot/execution/broker_recovery.py
@@ -1,0 +1,99 @@
+"""Deterministic broker rejection classification and permitted recovery action."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+class BrokerFailure(Enum):
+    MIS_CUTOFF = "MIS_CUTOFF"
+    MARKET_CLOSED = "MARKET_CLOSED"
+    INSUFFICIENT_FUNDS = "INSUFFICIENT_FUNDS"
+    PRICE_INVALID = "PRICE_INVALID"
+    TRIGGER_INVALID = "TRIGGER_INVALID"
+    QUANTITY_INVALID = "QUANTITY_INVALID"
+    FREEZE_LIMIT = "FREEZE_LIMIT"
+    INSTRUMENT_INVALID = "INSTRUMENT_INVALID"
+    DUPLICATE_OR_AMBIGUOUS = "DUPLICATE_OR_AMBIGUOUS"
+    ORDER_STATE_UNKNOWN = "ORDER_STATE_UNKNOWN"
+    THROTTLED = "THROTTLED"
+    TRANSIENT = "TRANSIENT"
+    AUTHENTICATION = "AUTHENTICATION"
+    UNKNOWN = "UNKNOWN"
+
+
+class RecoveryAction(Enum):
+    REFRESH_AND_REVALIDATE = "REFRESH_AND_REVALIDATE"
+    RESIZE_AND_REVALIDATE = "RESIZE_AND_REVALIDATE"
+    CAP_QUANTITY_AND_REVALIDATE = "CAP_QUANTITY_AND_REVALIDATE"
+    RECONCILE_BEFORE_RETRY = "RECONCILE_BEFORE_RETRY"
+    BACKOFF_AND_REVALIDATE = "BACKOFF_AND_REVALIDATE"
+    STOP_AND_ALERT = "STOP_AND_ALERT"
+
+
+@dataclass(frozen=True, slots=True)
+class RecoveryDecision:
+    failure: BrokerFailure
+    action: RecoveryAction
+    retryable: bool
+    reconcile_first: bool = False
+
+
+def classify_broker_failure(message: object) -> BrokerFailure:
+    text = " ".join(str(message or "").strip().lower().split())
+    if not text:
+        return BrokerFailure.UNKNOWN
+    if any(subject in text for subject in (
+        "trigger price", "stop loss trigger", "stoploss trigger", "sl trigger"
+    )) and any(word in text for word in (
+        "invalid", "should be", "must be", "higher", "lower"
+    )):
+        return BrokerFailure.TRIGGER_INVALID
+    ordered = (
+        (BrokerFailure.MIS_CUTOFF, ("mis only till", "mis order is not allowed", "intraday orders (mis) are allowed only till")),
+        (BrokerFailure.MARKET_CLOSED, ("market is closed", "markets are closed", "outside market hours")),
+        (BrokerFailure.INSUFFICIENT_FUNDS, ("insufficient funds", "required margin", "margin required", "not enough balance")),
+        (BrokerFailure.FREEZE_LIMIT, ("freeze quantity", "freeze limit", "maximum order quantity")),
+        (BrokerFailure.QUANTITY_INVALID, ("invalid quantity", "quantity is not a multiple", "minimum quantity")),
+        (BrokerFailure.INSTRUMENT_INVALID, ("invalid instrument", "invalid tradingsymbol", "expired contract", "instrument is not tradable")),
+        (BrokerFailure.DUPLICATE_OR_AMBIGUOUS, ("duplicate order", "duplicate request", "request already processed", "order already placed")),
+        (BrokerFailure.ORDER_STATE_UNKNOWN, ("order not found", "invalid order id", "unknown order", "invalid order status")),
+        (BrokerFailure.THROTTLED, ("rate limit", "too many requests", "throttle", "http 429", "status 429")),
+        (BrokerFailure.TRANSIENT, ("gateway timeout", "service unavailable", "temporarily unavailable", "connection reset", "connection timed out", "read timed out", "http 502", "http 503", "http 504")),
+        (BrokerFailure.AUTHENTICATION, ("invalid access token", "session expired", "authentication failed", "permission denied", "http 403")),
+        (BrokerFailure.PRICE_INVALID, ("price out of range", "price bands", "circuit limit", "invalid limit price", "limit price is outside")),
+    )
+    for failure, phrases in ordered:
+        if any(phrase in text for phrase in phrases):
+            return failure
+    if "amo" in text and ("post" in text or "outside market" in text):
+        return BrokerFailure.MARKET_CLOSED
+    return BrokerFailure.UNKNOWN
+
+
+def decide_recovery(message: object) -> RecoveryDecision:
+    failure = classify_broker_failure(message)
+    mapping = {
+        BrokerFailure.PRICE_INVALID: RecoveryDecision(failure, RecoveryAction.REFRESH_AND_REVALIDATE, True),
+        BrokerFailure.TRIGGER_INVALID: RecoveryDecision(failure, RecoveryAction.REFRESH_AND_REVALIDATE, True),
+        BrokerFailure.INSUFFICIENT_FUNDS: RecoveryDecision(failure, RecoveryAction.RESIZE_AND_REVALIDATE, True),
+        BrokerFailure.FREEZE_LIMIT: RecoveryDecision(failure, RecoveryAction.CAP_QUANTITY_AND_REVALIDATE, True),
+        BrokerFailure.DUPLICATE_OR_AMBIGUOUS: RecoveryDecision(failure, RecoveryAction.RECONCILE_BEFORE_RETRY, True, True),
+        BrokerFailure.ORDER_STATE_UNKNOWN: RecoveryDecision(failure, RecoveryAction.RECONCILE_BEFORE_RETRY, True, True),
+        BrokerFailure.TRANSIENT: RecoveryDecision(failure, RecoveryAction.RECONCILE_BEFORE_RETRY, True, True),
+        BrokerFailure.THROTTLED: RecoveryDecision(failure, RecoveryAction.BACKOFF_AND_REVALIDATE, True),
+    }
+    return mapping.get(
+        failure,
+        RecoveryDecision(failure, RecoveryAction.STOP_AND_ALERT, False),
+    )
+
+
+__all__ = [
+    "BrokerFailure",
+    "RecoveryAction",
+    "RecoveryDecision",
+    "classify_broker_failure",
+    "decide_recovery",
+]

--- a/src/nifty_scalper_bot/execution/entry_recovery.py
+++ b/src/nifty_scalper_bot/execution/entry_recovery.py
@@ -1,0 +1,605 @@
+"""Bounded recovery for the authoritative runner-facing entry path.
+
+The installer wraps the existing OrderManager methods without replacing the
+class. This preserves unbound-method tests and all established callers.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+import math
+import os
+import time
+from typing import Any, Callable, Mapping
+
+from nifty_scalper_bot.execution.broker_recovery import (
+    BrokerFailure,
+    RecoveryAction,
+    RecoveryDecision,
+    decide_recovery,
+)
+
+
+def _log(manager: Any, level: str, message: str, *args: Any, **extra: Any) -> None:
+    logger = getattr(manager, "_logger", None)
+    fn = getattr(logger, level, None)
+    if callable(fn):
+        fn(message, *args, extra={"event": extra.pop("event", "ENTRY_RECOVERY"), **extra})
+
+
+def _result_like(
+    previous: Any,
+    *,
+    accepted: bool,
+    order_id: str | None,
+    reason: str,
+    details: Mapping[str, Any],
+    broker_attempted: bool,
+) -> Any:
+    cls = type(previous)
+    try:
+        return cls(
+            accepted=accepted,
+            order_id=order_id,
+            reason=reason,
+            details=dict(details),
+            broker_attempted=broker_attempted,
+        )
+    except Exception:
+        from nifty_scalper_bot.execution.order_manager import TradePlanSubmitResult
+
+        return TradePlanSubmitResult(
+            accepted=accepted,
+            order_id=order_id,
+            reason=reason,
+            details=dict(details),
+            broker_attempted=broker_attempted,
+        )
+
+
+def _failure_text(manager: Any, result: Any) -> str:
+    fields: list[str] = [str(getattr(result, "reason", "") or "")]
+    details = getattr(result, "details", {}) or {}
+    if isinstance(details, Mapping):
+        fields.extend(str(value) for value in details.values())
+    decision = getattr(manager, "_last_order_decision", {}) or {}
+    if isinstance(decision, Mapping):
+        fields.extend(str(value) for value in decision.values())
+    return " | ".join(fields)
+
+
+def _symbol_key(value: object) -> str:
+    token = str(value or "").strip().upper()
+    return token.split(":", 1)[-1]
+
+
+def _provider(manager: Any) -> Any | None:
+    return getattr(manager, "_data_hub", None) or getattr(manager, "_market_data", None)
+
+
+def _fresh_quote(manager: Any, symbol: str, trace_id: str | None) -> dict[str, Any]:
+    provider = _provider(manager)
+    if provider is None:
+        return {}
+    for name in ("refresh_quote_now", "pull_quote", "refresh_quote"):
+        fn = getattr(provider, name, None)
+        if not callable(fn):
+            continue
+        try:
+            refreshed = fn(symbol, trace_id=trace_id)
+        except TypeError:
+            try:
+                refreshed = fn(symbol)
+            except Exception:
+                continue
+        except Exception:
+            continue
+        if isinstance(refreshed, Mapping) and refreshed:
+            return dict(refreshed)
+    for name in ("get_quote", "get_latest_tick", "get_tick"):
+        fn = getattr(provider, name, None)
+        if callable(fn):
+            try:
+                quote = fn(symbol)
+            except Exception:
+                continue
+            if isinstance(quote, Mapping) and quote:
+                return dict(quote)
+    return {}
+
+
+def _positive(quote: Mapping[str, Any], *keys: str) -> float | None:
+    for key in keys:
+        try:
+            value = float(quote.get(key) or 0.0)
+        except (TypeError, ValueError):
+            continue
+        if math.isfinite(value) and value > 0:
+            return value
+    return None
+
+
+def _entry_price(plan: Any, quote: Mapping[str, Any]) -> float | None:
+    side = str(getattr(plan, "side", "BUY") or "BUY").upper()
+    if side == "BUY":
+        price = _positive(quote, "ask", "best_ask", "offer", "sell_price")
+    else:
+        price = _positive(quote, "bid", "best_bid", "buy_price")
+    return price or _positive(quote, "ltp", "last_price", "last_traded_price", "price")
+
+
+def _tick(value: float, size: float = 0.05) -> float:
+    return round(round(float(value) / size) * size, 2)
+
+
+def _valid_geometry(plan: Any) -> bool:
+    try:
+        entry = float(plan.entry_price or 0.0)
+        stop = float(plan.stop_loss or 0.0)
+        target = float(plan.take_profit or 0.0)
+    except (TypeError, ValueError):
+        return False
+    if min(entry, stop, target) <= 0:
+        return False
+    side = str(plan.side).upper()
+    return stop < entry < target if side == "BUY" else target < entry < stop
+
+
+def _rebuild_plan(
+    manager: Any,
+    plan: Any,
+    quote: Mapping[str, Any],
+    decision: RecoveryDecision,
+    *,
+    quantity: int | None = None,
+) -> Any | None:
+    callback = getattr(manager, "_trade_plan_rebuilder", None)
+    if callable(callback):
+        try:
+            rebuilt = callback(plan, dict(quote), decision)
+        except TypeError:
+            rebuilt = callback(plan, dict(quote))
+        if rebuilt is not None and _valid_geometry(rebuilt):
+            return replace(rebuilt, quantity=quantity) if quantity is not None else rebuilt
+
+    engine = getattr(manager, "_indicator_engine", None)
+    for name in ("rebuild_trade_plan", "revalidate_trade_plan"):
+        fn = getattr(engine, name, None) if engine is not None else None
+        if not callable(fn):
+            continue
+        try:
+            rebuilt = fn(plan=plan, quote=dict(quote), decision=decision)
+        except TypeError:
+            try:
+                rebuilt = fn(plan, dict(quote))
+            except Exception:
+                continue
+        except Exception:
+            continue
+        if rebuilt is not None and _valid_geometry(rebuilt):
+            return replace(rebuilt, quantity=quantity) if quantity is not None else rebuilt
+
+    fresh = _entry_price(plan, quote)
+    try:
+        old_entry = float(plan.entry_price or 0.0)
+        old_stop = float(plan.stop_loss or 0.0)
+        old_target = float(plan.take_profit or 0.0)
+    except (TypeError, ValueError):
+        return None
+    if fresh is None or old_entry <= 0 or old_stop <= 0 or old_target <= 0:
+        return None
+    side = str(plan.side).upper()
+    if side == "BUY":
+        risk = old_entry - old_stop
+        reward = old_target - old_entry
+        stop = fresh - risk
+        target = fresh + reward
+    else:
+        risk = old_stop - old_entry
+        reward = old_entry - old_target
+        stop = fresh + risk
+        target = fresh - reward
+    if risk <= 0 or reward <= 0:
+        return None
+    rebuilt = replace(
+        plan,
+        entry_price=_tick(fresh),
+        stop_loss=_tick(stop),
+        take_profit=_tick(target),
+        quantity=int(quantity if quantity is not None else plan.quantity),
+    )
+    return rebuilt if _valid_geometry(rebuilt) else None
+
+
+def _available_margin(manager: Any) -> float | None:
+    fn = getattr(manager, "_resolve_available_margin", None)
+    if not callable(fn):
+        return None
+    try:
+        value = fn()
+    except Exception:
+        return None
+    raw = value[0] if isinstance(value, tuple) else value
+    try:
+        margin = float(raw or 0.0)
+    except (TypeError, ValueError):
+        return None
+    return margin if math.isfinite(margin) and margin > 0 else None
+
+
+def _lot_size(manager: Any, symbol: str) -> int:
+    fn = getattr(manager, "_lot_size_for_symbol", None)
+    if callable(fn):
+        try:
+            return max(1, int(fn(symbol)))
+        except Exception:
+            pass
+    return max(1, int(os.getenv("DEFAULT_OPTION_LOT_SIZE", "1") or 1))
+
+
+def _affordable_quantity(manager: Any, plan: Any, fresh_price: float) -> int:
+    available = _available_margin(manager)
+    if available is None or fresh_price <= 0:
+        return 0
+    lot = _lot_size(manager, str(plan.symbol))
+    factor = max(float(getattr(manager, "_margin_factor", 1.0) or 1.0), 1.0)
+    configured_buffer = float(getattr(manager, "_margin_buffer", 0.95) or 0.95)
+    buffer = min(max(configured_buffer, 0.5), 0.98)
+    per_lot = fresh_price * lot * factor
+    lots = int((available * buffer) // per_lot) if per_lot > 0 else 0
+    return min(int(plan.quantity), max(lots, 0) * lot)
+
+
+def _freeze_quantity(manager: Any, plan: Any) -> int:
+    resolver = getattr(manager, "_instrument_resolver", None)
+    cap = 0
+    for name in ("get_freeze_quantity", "freeze_quantity", "get_freeze_limit"):
+        fn = getattr(resolver, name, None) if resolver is not None else None
+        if callable(fn):
+            try:
+                cap = int(fn(plan.symbol) or 0)
+            except Exception:
+                continue
+            if cap > 0:
+                break
+    if cap <= 0:
+        cap = int(os.getenv("ORDER_FREEZE_QUANTITY", "0") or 0)
+    lot = _lot_size(manager, str(plan.symbol))
+    if cap <= 0:
+        return 0
+    capped = min(int(plan.quantity), cap)
+    return (capped // lot) * lot
+
+
+def _broker_orders(manager: Any) -> list[Mapping[str, Any]] | None:
+    broker = getattr(manager, "_broker", None)
+    for name in ("get_orders", "orders"):
+        fn = getattr(broker, name, None) if broker is not None else None
+        if callable(fn):
+            try:
+                rows = fn() or []
+            except Exception:
+                return None
+            return [row for row in rows if isinstance(row, Mapping)]
+    return None
+
+
+def _broker_positions(manager: Any) -> list[Mapping[str, Any]] | None:
+    broker = getattr(manager, "_broker", None)
+    fn = getattr(broker, "get_positions", None) if broker is not None else None
+    if not callable(fn):
+        return None
+    try:
+        payload = fn() or []
+    except Exception:
+        return None
+    if isinstance(payload, Mapping):
+        payload = payload.get("net") or payload.get("day") or payload.get("positions") or []
+    return [row for row in payload if isinstance(row, Mapping)]
+
+
+def _reconcile_intent(manager: Any, plan: Any) -> tuple[str, str | None, dict[str, Any]]:
+    keys = [
+        str(getattr(plan, "signal_id", "") or ""),
+        str(getattr(plan, "trace_id", "") or ""),
+        str(getattr(plan, "tag", "") or ""),
+    ]
+    finder = getattr(manager, "_find_open_order", None)
+    if callable(finder):
+        for key in keys:
+            if not key:
+                continue
+            try:
+                order = finder(key)
+            except Exception:
+                order = None
+            if isinstance(order, Mapping):
+                oid = str(order.get("order_id") or order.get("id") or "")
+                if oid:
+                    return "order_found", oid, {"order": dict(order)}
+
+    orders = _broker_orders(manager)
+    if orders is None:
+        return "unknown", None, {"reason": "orders_unavailable"}
+    wanted_symbol = _symbol_key(plan.symbol)
+    wanted = {key.upper() for key in keys if key}
+    for order in orders:
+        if _symbol_key(order.get("tradingsymbol") or order.get("symbol")) != wanted_symbol:
+            continue
+        candidates = {
+            str(order.get("tag") or "").upper(),
+            str(order.get("client_order_id") or "").upper(),
+            str(order.get("guid") or "").upper(),
+        }
+        if wanted and not any(
+            key == candidate or (key and candidate and key[-8:] in candidate)
+            for key in wanted for candidate in candidates
+        ):
+            continue
+        status = str(order.get("status") or "").upper()
+        if status not in {"REJECTED", "CANCELLED", "CANCELED", "EXPIRED"}:
+            oid = str(order.get("order_id") or order.get("id") or "")
+            return "order_found", oid or None, {"order": dict(order)}
+
+    positions = _broker_positions(manager)
+    if positions is None:
+        return "unknown", None, {"reason": "positions_unavailable"}
+    for position in positions:
+        if _symbol_key(position.get("tradingsymbol") or position.get("symbol")) != wanted_symbol:
+            continue
+        try:
+            qty = abs(int(float(position.get("quantity", position.get("net_quantity", 0)) or 0)))
+        except (TypeError, ValueError):
+            return "unknown", None, {"reason": "position_quantity_invalid"}
+        if qty > 0:
+            return "exposure_found", None, {"position": dict(position), "quantity": qty}
+    return "absent", None, {}
+
+
+def _annotate(result: Any, decision: RecoveryDecision, **extra: Any) -> Any:
+    details = dict(getattr(result, "details", {}) or {})
+    details["entry_recovery"] = {
+        "failure": decision.failure.value,
+        "action": decision.action.value,
+        "retryable": decision.retryable,
+        **extra,
+    }
+    try:
+        result.details = details
+        return result
+    except Exception:
+        return _result_like(
+            result,
+            accepted=bool(getattr(result, "accepted", False)),
+            order_id=getattr(result, "order_id", None),
+            reason=str(getattr(result, "reason", "unknown")),
+            details=details,
+            broker_attempted=bool(getattr(result, "broker_attempted", False)),
+        )
+
+
+def _recover_submit(original: Callable[..., Any], manager: Any, plan: Any) -> Any:
+    result = original(manager, plan)
+    if bool(getattr(result, "accepted", False)) or not bool(
+        getattr(result, "broker_attempted", False)
+    ):
+        return result
+    if getattr(manager, "_entry_recovery_active", False):
+        return result
+
+    decision = decide_recovery(_failure_text(manager, result))
+    if not decision.retryable:
+        return _annotate(result, decision, outcome="terminal")
+
+    setattr(manager, "_entry_recovery_active", True)
+    try:
+        if decision.reconcile_first:
+            state, order_id, evidence = _reconcile_intent(manager, plan)
+            if state == "order_found" and order_id:
+                return _result_like(
+                    result,
+                    accepted=True,
+                    order_id=order_id,
+                    reason="broker_order_reconciled",
+                    details={
+                        "entry_recovery": {
+                            "failure": decision.failure.value,
+                            "action": decision.action.value,
+                            "outcome": state,
+                            **evidence,
+                        }
+                    },
+                    broker_attempted=True,
+                )
+            if state == "exposure_found":
+                return _result_like(
+                    result,
+                    accepted=False,
+                    order_id=None,
+                    reason="entry_exposure_reconciliation_required",
+                    details={"entry_recovery": {"outcome": state, **evidence}},
+                    broker_attempted=True,
+                )
+            if state != "absent":
+                return _result_like(
+                    result,
+                    accepted=False,
+                    order_id=None,
+                    reason="entry_order_state_ambiguous",
+                    details={"entry_recovery": {"outcome": state, **evidence}},
+                    broker_attempted=True,
+                )
+
+        quote = _fresh_quote(manager, str(plan.symbol), getattr(plan, "trace_id", None))
+        fresh = _entry_price(plan, quote)
+        quantity: int | None = None
+        if decision.action is RecoveryAction.RESIZE_AND_REVALIDATE:
+            quantity = _affordable_quantity(manager, plan, float(fresh or 0.0))
+            if quantity < _lot_size(manager, str(plan.symbol)):
+                return _annotate(result, decision, outcome="no_affordable_lot")
+        elif decision.action is RecoveryAction.CAP_QUANTITY_AND_REVALIDATE:
+            quantity = _freeze_quantity(manager, plan)
+            if quantity <= 0 or quantity >= int(plan.quantity):
+                return _annotate(result, decision, outcome="freeze_cap_unavailable")
+        elif decision.action is RecoveryAction.BACKOFF_AND_REVALIDATE:
+            delay = min(max(float(os.getenv("ENTRY_RECOVERY_BACKOFF_SECONDS", "0.25")), 0.0), 1.0)
+            if delay:
+                time.sleep(delay)
+
+        rebuilt = _rebuild_plan(
+            manager,
+            plan,
+            quote,
+            decision,
+            quantity=quantity,
+        )
+        if rebuilt is None:
+            return _annotate(result, decision, outcome="rebuild_failed")
+
+        signal_id = str(getattr(plan, "signal_id", "") or "")
+        clearer = getattr(manager, "_clear_pending_signal", None)
+        if signal_id and callable(clearer):
+            clearer(signal_id)
+        retried = original(manager, rebuilt)
+        return _annotate(
+            retried,
+            decision,
+            outcome="retried_once",
+            original_quantity=int(plan.quantity),
+            retry_quantity=int(rebuilt.quantity),
+            original_entry=getattr(plan, "entry_price", None),
+            retry_entry=getattr(rebuilt, "entry_price", None),
+        )
+    finally:
+        setattr(manager, "_entry_recovery_active", False)
+
+
+def _is_entry_order(order: Any) -> bool:
+    tag = str(getattr(order, "tag", "") or "").upper()
+    return not any(token in tag for token in (
+        "EXIT", "STOP", "TARGET", "SQUARE", "GUARD", "SL_", "TP_"
+    ))
+
+
+def _finalize_partial_entry(manager: Any, order: Any, payload: Mapping[str, Any]) -> None:
+    status = str(getattr(getattr(order, "status", None), "name", getattr(order, "status", ""))).upper()
+    if status != "PARTIALLY_FILLED" or not _is_entry_order(order):
+        return
+    order_id = str(getattr(order, "order_id", "") or "")
+    if not order_id or getattr(order, "_partial_entry_finalized", False):
+        return
+    setattr(order, "_partial_entry_finalized", True)
+
+    broker = getattr(manager, "_broker", None)
+    cancel = getattr(broker, "cancel_order", None)
+    if callable(cancel):
+        try:
+            cancel(order_id)
+        except TypeError:
+            try:
+                cancel(order_id=order_id)
+            except Exception:
+                pass
+        except Exception:
+            pass
+
+    final_payload: Mapping[str, Any] = payload
+    getter = getattr(broker, "get_order_status", None)
+    if callable(getter):
+        try:
+            refreshed = getter(order_id)
+            if isinstance(refreshed, Mapping):
+                final_payload = refreshed
+        except Exception:
+            pass
+    try:
+        filled = int(
+            final_payload.get("filled_quantity")
+            or getattr(order, "filled_quantity", 0)
+            or 0
+        )
+        average = float(
+            final_payload.get("average_price")
+            or final_payload.get("avg_price")
+            or getattr(order, "fill_price", 0.0)
+            or getattr(order, "average_price", 0.0)
+            or 0.0
+        )
+    except (TypeError, ValueError):
+        return
+    if filled <= 0 or average <= 0:
+        return
+
+    bracket_manager = getattr(manager, "_bracket_manager", None)
+    confirmer = getattr(bracket_manager, "confirm_partial_entry_fill", None)
+    if callable(confirmer):
+        confirmer(order_id, filled, average)
+    marker = getattr(manager, "_mark_order_uncertain", None)
+    if callable(marker):
+        marker(str(getattr(order, "client_order_id", None) or order_id))
+    setattr(manager, "_last_order_decision", {
+        "block_reason": "partial_entry_fill_reconciled",
+        "broker_attempted": True,
+        "details": {
+            "order_id": order_id,
+            "filled_quantity": filled,
+            "average_price": average,
+            "remainder_cancel_requested": True,
+        },
+    })
+    _log(
+        manager,
+        "critical",
+        "ENTRY_PARTIAL_FILL_RECONCILED order_id=%s symbol=%s filled=%s average=%s",
+        order_id,
+        getattr(order, "symbol", ""),
+        filled,
+        average,
+        event="ENTRY_PARTIAL_FILL_RECONCILED",
+        order_id=order_id,
+        filled_quantity=filled,
+    )
+
+
+def install_entry_recovery(order_manager_class: type[Any]) -> None:
+    if getattr(order_manager_class, "_canonical_entry_recovery_installed", False):
+        return
+
+    original_submit = getattr(order_manager_class, "submit_trade_plan_result", None)
+    if callable(original_submit):
+        setattr(order_manager_class, "_entry_recovery_original_submit", original_submit)
+
+        def submit_trade_plan_result(self: Any, plan: Any) -> Any:
+            return _recover_submit(original_submit, self, plan)
+
+        setattr(order_manager_class, "submit_trade_plan_result", submit_trade_plan_result)
+
+    original_update = getattr(order_manager_class, "_update_from_response", None)
+    if callable(original_update):
+        setattr(order_manager_class, "_entry_recovery_original_update", original_update)
+
+        def update_from_response(self: Any, order: Any, payload: dict[str, Any]) -> Any:
+            updated = original_update(self, order, payload)
+            try:
+                _finalize_partial_entry(self, updated, payload)
+            except Exception as exc:  # noqa: BLE001
+                _log(
+                    self,
+                    "error",
+                    "ENTRY_PARTIAL_FILL_RECONCILE_FAILED order_id=%s error=%s",
+                    getattr(order, "order_id", ""),
+                    exc,
+                    event="ENTRY_PARTIAL_FILL_RECONCILE_FAILED",
+                )
+            return updated
+
+        setattr(order_manager_class, "_update_from_response", update_from_response)
+
+    def set_trade_plan_rebuilder(self: Any, callback: Callable[..., Any] | None) -> None:
+        setattr(self, "_trade_plan_rebuilder", callback)
+
+    setattr(order_manager_class, "set_trade_plan_rebuilder", set_trade_plan_rebuilder)
+    setattr(order_manager_class, "_canonical_entry_recovery_installed", True)
+
+
+__all__ = ["install_entry_recovery"]

--- a/src/nifty_scalper_bot/execution/runtime_bracket_manager.py
+++ b/src/nifty_scalper_bot/execution/runtime_bracket_manager.py
@@ -1,6 +1,6 @@
 """Runtime bracket authority with strict LIVE and compatible non-live closure.
 
-LIVE execution uses the durable ledger release gate.  PAPER/SHADOW/SIMULATION
+LIVE execution uses the durable ledger release gate. PAPER/SHADOW/SIMULATION
 retain legacy close and hook behaviour so tests, dry runs and dashboards do not
 lose functionality when broker fill identity is intentionally absent.
 """
@@ -31,6 +31,87 @@ class RuntimeBracketManager(LedgerBracketManager):
             or "false"
         ).lower() in {"1", "true", "yes", "on"}
         return mode == "LIVE" and live_flag
+
+    def confirm_partial_entry_fill(
+        self,
+        order_id: str,
+        filled_quantity: int,
+        fill_price: float,
+    ) -> bool:
+        """Arm protection for the final broker-confirmed partial entry quantity."""
+
+        bracket = self.get_bracket(order_id)
+        if bracket is None:
+            _legacy.LOGGER.critical(
+                "PARTIAL_ENTRY_BRACKET_MISSING order_id=%s qty=%s price=%s",
+                order_id,
+                filled_quantity,
+                fill_price,
+                extra={
+                    "event": "PARTIAL_ENTRY_BRACKET_MISSING",
+                    "order_id": order_id,
+                    "filled_quantity": filled_quantity,
+                },
+            )
+            return False
+        try:
+            quantity = int(filled_quantity)
+            price = float(fill_price)
+        except (TypeError, ValueError):
+            return False
+        if quantity <= 0 or price <= 0:
+            return False
+
+        with self._lock:
+            planned_quantity = int(bracket.quantity or 0)
+            if planned_quantity > 0:
+                quantity = min(quantity, planned_quantity)
+            bracket.quantity = quantity
+            bracket.remaining_quantity = quantity
+            allocation_left = quantity
+            retained_targets = []
+            for target in bracket.tp_levels:
+                allocated = min(int(target.quantity or 0), allocation_left)
+                if allocated <= 0:
+                    continue
+                target.quantity = allocated
+                retained_targets.append(target)
+                allocation_left -= allocated
+            bracket.tp_levels = retained_targets
+            bracket.updated_at = time.time()
+
+        self.confirm_entry_fill(order_id, price)
+        with suppress(Exception):
+            self.save_state()
+        _legacy.LOGGER.critical(
+            "PARTIAL_ENTRY_PROTECTED order_id=%s symbol=%s planned_qty=%s filled_qty=%s fill_price=%.2f",
+            order_id,
+            bracket.symbol,
+            planned_quantity,
+            quantity,
+            price,
+            extra={
+                "event": "PARTIAL_ENTRY_PROTECTED",
+                "order_id": order_id,
+                "symbol": bracket.symbol,
+                "planned_quantity": planned_quantity,
+                "filled_quantity": quantity,
+                "fill_price": price,
+            },
+        )
+        with suppress(Exception):
+            self._notify_event(
+                "PARTIAL_ENTRY_PROTECTED",
+                {
+                    "symbol": bracket.symbol,
+                    "planned_quantity": planned_quantity,
+                    "filled_quantity": quantity,
+                    "fill_price": round(price, 2),
+                    "sl": round(float(bracket.sl_trigger_price), 2),
+                    "tp": round(float(bracket.tp_trigger_price), 2),
+                },
+            )
+        return True
 
     def _close_bracket(
         self,

--- a/tests/execution/test_canonical_entry_recovery.py
+++ b/tests/execution/test_canonical_entry_recovery.py
@@ -1,0 +1,278 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import Any
+
+from nifty_scalper_bot.execution.broker_recovery import (
+    BrokerFailure,
+    RecoveryAction,
+    classify_broker_failure,
+    decide_recovery,
+)
+from nifty_scalper_bot.execution.entry_recovery import install_entry_recovery
+from nifty_scalper_bot.execution.order_manager import TradePlan, TradePlanSubmitResult
+
+
+class _Logger:
+    def info(self, *_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    def warning(self, *_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    def error(self, *_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    def critical(self, *_args: Any, **_kwargs: Any) -> None:
+        return None
+
+
+class _Quotes:
+    def __init__(self, quote: dict[str, Any]) -> None:
+        self.quote = quote
+        self.refreshes = 0
+
+    def refresh_quote_now(self, _symbol: str, **_kwargs: Any) -> None:
+        self.refreshes += 1
+
+    def get_quote(self, _symbol: str) -> dict[str, Any]:
+        return dict(self.quote)
+
+
+class _Broker:
+    def __init__(self) -> None:
+        self.orders_payload: list[dict[str, Any]] = []
+        self.positions_payload: list[dict[str, Any]] = []
+        self.cancel_calls: list[str] = []
+        self.status_payload: dict[str, Any] = {}
+
+    def get_orders(self) -> list[dict[str, Any]]:
+        return list(self.orders_payload)
+
+    def get_positions(self) -> list[dict[str, Any]]:
+        return list(self.positions_payload)
+
+    def cancel_order(self, order_id: str, **_kwargs: Any) -> bool:
+        self.cancel_calls.append(order_id)
+        return True
+
+    def get_order_status(self, _order_id: str) -> dict[str, Any]:
+        return dict(self.status_payload)
+
+
+class _RecoveryManager:
+    responses: list[TradePlanSubmitResult] = []
+
+    def __init__(self, responses: list[TradePlanSubmitResult]) -> None:
+        self.responses = list(responses)
+        self.plans: list[TradePlan] = []
+        self._logger = _Logger()
+        self._market_data = _Quotes({"ask": 103.0, "bid": 102.5, "ltp": 102.8})
+        self._data_hub = None
+        self._broker = _Broker()
+        self._last_order_decision: dict[str, Any] = {}
+        self._margin_factor = 1.0
+        self._margin_buffer = 0.95
+        self._instrument_resolver = None
+        self.cleared: list[str] = []
+
+    def submit_trade_plan_result(self, plan: TradePlan) -> TradePlanSubmitResult:
+        self.plans.append(plan)
+        return self.responses.pop(0)
+
+    def _clear_pending_signal(self, signal_id: str) -> None:
+        self.cleared.append(signal_id)
+
+    def _lot_size_for_symbol(self, _symbol: str) -> int:
+        return 50
+
+    def _resolve_available_margin(self) -> tuple[float, str]:
+        return 8_000.0, "fresh"
+
+    def _find_open_order(self, _key: str) -> dict[str, Any] | None:
+        return None
+
+
+install_entry_recovery(_RecoveryManager)
+
+
+def _plan(quantity: int = 100) -> TradePlan:
+    return TradePlan(
+        symbol="NFO:NIFTY2662324050PE",
+        side="BUY",
+        quantity=quantity,
+        entry_price=100.0,
+        stop_loss=90.0,
+        take_profit=120.0,
+        signal_id="signal-1",
+        trace_id="trace-1",
+        tag="runner-entry",
+    )
+
+
+def _reject(message: str) -> TradePlanSubmitResult:
+    return TradePlanSubmitResult(
+        accepted=False,
+        reason="broker_rejected",
+        details={"broker_message": message},
+        broker_attempted=True,
+    )
+
+
+def _accept(order_id: str = "new-order") -> TradePlanSubmitResult:
+    return TradePlanSubmitResult(
+        accepted=True,
+        order_id=order_id,
+        reason="accepted",
+        broker_attempted=True,
+    )
+
+
+def test_classifier_prefers_trigger_error_and_marks_terminal_auth() -> None:
+    trigger = decide_recovery("Trigger price must be lower than limit price")
+    assert trigger.failure is BrokerFailure.TRIGGER_INVALID
+    assert trigger.action is RecoveryAction.REFRESH_AND_REVALIDATE
+    assert trigger.retryable is True
+
+    auth = decide_recovery("Invalid access token; session expired")
+    assert auth.failure is BrokerFailure.AUTHENTICATION
+    assert auth.retryable is False
+    assert classify_broker_failure("HTTP 503 service unavailable") is BrokerFailure.TRANSIENT
+
+
+def test_price_reject_refreshes_and_rebuilds_geometry_once() -> None:
+    manager = _RecoveryManager([
+        _reject("invalid limit price: price out of range"),
+        _accept(),
+    ])
+
+    result = manager.submit_trade_plan_result(_plan())
+
+    assert result.accepted is True
+    assert len(manager.plans) == 2
+    retry = manager.plans[1]
+    assert retry.entry_price == 103.0
+    assert retry.stop_loss == 93.0
+    assert retry.take_profit == 123.0
+    assert retry.quantity == 100
+    assert manager._market_data.refreshes == 1
+    assert manager.cleared == ["signal-1"]
+    assert result.details["entry_recovery"]["outcome"] == "retried_once"
+
+
+def test_margin_reject_resizes_to_affordable_lot_and_reruns_original() -> None:
+    manager = _RecoveryManager([
+        _reject("insufficient funds; required margin exceeds available margin"),
+        _accept("resized-order"),
+    ])
+
+    result = manager.submit_trade_plan_result(_plan(quantity=100))
+
+    assert result.accepted is True
+    assert result.order_id == "resized-order"
+    assert len(manager.plans) == 2
+    assert manager.plans[1].quantity == 50
+    assert result.details["entry_recovery"]["retry_quantity"] == 50
+
+
+def test_duplicate_response_reconciles_existing_order_without_resubmit() -> None:
+    manager = _RecoveryManager([_reject("duplicate order request already processed")])
+    manager._broker.orders_payload = [
+        {
+            "order_id": "existing-123",
+            "symbol": "NIFTY2662324050PE",
+            "tag": "runner-entry",
+            "status": "OPEN",
+        }
+    ]
+
+    result = manager.submit_trade_plan_result(_plan())
+
+    assert result.accepted is True
+    assert result.order_id == "existing-123"
+    assert result.reason == "broker_order_reconciled"
+    assert len(manager.plans) == 1
+
+
+def test_ambiguous_timeout_with_broker_exposure_never_retries() -> None:
+    manager = _RecoveryManager([_reject("gateway timeout HTTP 504")])
+    manager._broker.positions_payload = [
+        {"tradingsymbol": "NIFTY2662324050PE", "quantity": 50}
+    ]
+
+    result = manager.submit_trade_plan_result(_plan())
+
+    assert result.accepted is False
+    assert result.reason == "entry_exposure_reconciliation_required"
+    assert len(manager.plans) == 1
+
+
+def test_terminal_authentication_failure_is_not_retried() -> None:
+    manager = _RecoveryManager([_reject("invalid access token; session expired")])
+
+    result = manager.submit_trade_plan_result(_plan())
+
+    assert result.accepted is False
+    assert len(manager.plans) == 1
+    assert result.details["entry_recovery"]["outcome"] == "terminal"
+
+
+@dataclass
+class _Order:
+    order_id: str = "entry-partial"
+    symbol: str = "NFO:NIFTY2662324050PE"
+    tag: str = "runner-entry"
+    client_order_id: str = "client-partial"
+    filled_quantity: int = 50
+    fill_price: float = 101.5
+    average_price: float = 101.5
+    status: Any = None
+
+
+class _PartialManager:
+    def __init__(self) -> None:
+        self._logger = _Logger()
+        self._broker = _Broker()
+        self._broker.status_payload = {
+            "status": "CANCELLED",
+            "filled_quantity": 50,
+            "average_price": 101.5,
+        }
+        self._last_order_decision: dict[str, Any] = {}
+        self.uncertain: list[str] = []
+        self.confirmed: list[tuple[str, int, float]] = []
+        self._bracket_manager = SimpleNamespace(
+            confirm_partial_entry_fill=lambda order_id, qty, price: self.confirmed.append(
+                (order_id, qty, price)
+            )
+        )
+
+    def submit_trade_plan_result(self, _plan: Any) -> TradePlanSubmitResult:
+        return _accept()
+
+    def _update_from_response(self, order: _Order, _payload: dict[str, Any]) -> _Order:
+        order.status = SimpleNamespace(name="PARTIALLY_FILLED")
+        return order
+
+    def _mark_order_uncertain(self, key: str) -> None:
+        self.uncertain.append(key)
+
+
+install_entry_recovery(_PartialManager)
+
+
+def test_partial_entry_cancels_remainder_and_arms_actual_quantity() -> None:
+    manager = _PartialManager()
+    order = _Order()
+
+    updated = manager._update_from_response(
+        order,
+        {"status": "PARTIALLY_FILLED", "filled_quantity": 50, "average_price": 101.5},
+    )
+
+    assert updated is order
+    assert manager._broker.cancel_calls == ["entry-partial"]
+    assert manager.confirmed == [("entry-partial", 50, 101.5)]
+    assert manager.uncertain == ["client-partial"]
+    assert manager._last_order_decision["block_reason"] == "partial_entry_fill_reconciled"


### PR DESCRIPTION
Adds bounded recovery to the authoritative `submit_trade_plan_result` path without replacing OrderManager. Price/trigger rejects refresh quotes and rebuild SL/TP geometry; margin failures resize to an affordable lot; freeze rejects cap quantity; ambiguous/time-out responses reconcile orders and positions before retry; terminal failures never retry. Partial entry fills cancel the remainder and arm the canonical bracket for actual quantity/VWAP. Every recovery reruns the existing preflight through one bounded original-method call.