### PR TITLE
Add enforceable descriptive file headers

### DIFF
--- a/.github/workflows/live-exit-safety-ci.yml
+++ b/.github/workflows/live-exit-safety-ci.yml
@@ -1,3 +1,7 @@
+# File purpose: Validate canonical BO safety, deployment freshness, and repository regressions.
+# Key responsibilities: Compile production code, run focused lifecycle checks, enforce file headers, and execute the full test suite.
+# Operational constraints: Focused safety gates and the complete suite must pass before merge.
+
 name: Live Exit Safety CI
 
 on:
@@ -24,6 +28,8 @@ jobs:
           python -m pip install -e '.[dev]' -q
       - name: Compile production source
         run: python -m compileall -q src
+      - name: File header standard
+        run: python -m pytest -q tests/architecture/test_file_header_standard.py
       - name: Canonical BO ownership architecture
         run: python -m pytest -q tests/architecture/test_canonical_bo_ownership.py
       - name: Release guard unit tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,7 @@
+# File purpose: Build the production image for the release-verified trading service.
+# Key responsibilities: Install dependencies, embed the Railway commit SHA, run health checks, and start the verified ASGI entrypoint.
+# Operational constraints: Preserve the embedded revision and do not bypass deployment_main.py or /releasez.
+
 # Multi-stage build for optimized production image
 FROM python:3.11-slim as builder
 

--- a/docs/FILE_HEADER_STANDARD.md
+++ b/docs/FILE_HEADER_STANDARD.md
@@ -1,0 +1,44 @@
+# File Header Standard
+
+Every production or deployment file modified in this repository must begin with a concise header that explains the file before implementation details.
+
+## Required content
+
+The header must contain these three labels:
+
+- **File purpose:** why the file exists.
+- **Key responsibilities:** the behaviour or configuration owned by the file.
+- **Operational constraints:** safety boundaries, non-responsibilities, or invariants that must not be broken.
+
+## Formats
+
+### Python
+
+Use the module docstring at the first line:
+
+```python
+"""File purpose:
+    Brief purpose.
+
+Key responsibilities:
+    - Responsibility one.
+    - Responsibility two.
+
+Operational constraints:
+    - Important invariant or ownership boundary.
+"""
+```
+
+### Dockerfile, TOML, YAML and shell files
+
+Use comments at the beginning of the file:
+
+```text
+# File purpose: Brief purpose.
+# Key responsibilities: Main behaviour owned by this file.
+# Operational constraints: Important invariant or safety boundary.
+```
+
+## Editing rule
+
+When a listed canonical BO or deployment file is edited, its header must be reviewed and updated if ownership or behaviour changed. CI validates the required labels so later edits cannot remove the file-level explanation silently.

--- a/railway.toml
+++ b/railway.toml
@@ -1,3 +1,7 @@
+# File purpose: Configure Railway build, health-gated activation, draining, and restart behaviour.
+# Key responsibilities: Build from Dockerfile, activate only after /releasez passes, and prevent overlapping trading instances.
+# Operational constraints: overlapSeconds must remain zero and the healthcheck must continue to use the release-verified endpoint.
+
 [build]
 builder = "DOCKERFILE"
 dockerfilePath = "Dockerfile"

--- a/src/nifty_scalper_bot/deployment_main.py
+++ b/src/nifty_scalper_bot/deployment_main.py
@@ -1,9 +1,13 @@
-"""Release-verified ASGI entrypoint.
+"""File purpose:
+    Start the ASGI trading application only after verifying the deployed release.
 
-The release identity is verified before importing the trading application. This
-prevents a cached or mismatched image from binding the service port and arming
-orders. A daemon then stops an instance when GitHub ``main`` is confirmed to be
-newer than the running commit.
+Key responsibilities:
+    - Enforce embedded-versus-runtime commit identity before importing the app.
+    - Start the stale-release watchdog and expose the ``/releasez`` endpoint.
+
+Operational constraints:
+    - Trading code must not be imported before release verification succeeds.
+    - A stale or mismatched image must never bind the service port or arm orders.
 """
 
 from __future__ import annotations

--- a/src/nifty_scalper_bot/execution/adaptive_trailing.py
+++ b/src/nifty_scalper_bot/execution/adaptive_trailing.py
@@ -1,4 +1,14 @@
-"""Stable adaptive trailing API with one hardened runtime controller."""
+"""File purpose:
+    Provide the stable public API for adaptive stop-loss trailing.
+
+Key responsibilities:
+    - Re-export trailing models and helpers from ``adaptive_trailing_core``.
+    - Expose ``HardenedAdaptiveTrailingController`` as the production controller.
+
+Operational constraints:
+    - The public controller may tighten protection but must not weaken an active stop.
+    - This facade must not create a second trailing authority.
+"""
 
 from __future__ import annotations
 

--- a/src/nifty_scalper_bot/execution/bracket_manager.py
+++ b/src/nifty_scalper_bot/execution/bracket_manager.py
@@ -1,4 +1,14 @@
-"""Stable public bracket API with explicit runtime ownership."""
+"""File purpose:
+    Provide the stable public API for the canonical bracket and exit lifecycle.
+
+Key responsibilities:
+    - Re-export bracket state models and helpers from ``bracket_core``.
+    - Expose ``BoundBracketManager`` as the single production bracket authority.
+
+Operational constraints:
+    - This facade must not own independent bracket state or exit execution logic.
+    - Entry release remains blocked until the bound runtime confirms durable closure.
+"""
 
 from __future__ import annotations
 

--- a/src/nifty_scalper_bot/execution/lifecycle_manager.py
+++ b/src/nifty_scalper_bot/execution/lifecycle_manager.py
@@ -1,9 +1,13 @@
-"""Retired compatibility shell for the former standalone lifecycle manager.
+"""File purpose:
+    Preserve the retired lifecycle-manager interface required by startup context.
 
-The canonical :class:`BracketManager` owns TP1/TP2, stop-loss, trailing,
-confirmed-fill accounting and closure.  This class remains only because the
-startup context still exposes the historical field; it never subscribes to
-market data or mutates a position.
+Key responsibilities:
+    - Provide no-op startup, shutdown and update methods for compatibility.
+    - Log ignored legacy fill callbacks so accidental use remains visible.
+
+Operational constraints:
+    - This module must not subscribe to ticks, mutate positions or submit exits.
+    - ``BracketManager`` remains the sole TP, SL, trailing and closure authority.
 """
 
 from __future__ import annotations

--- a/src/nifty_scalper_bot/execution/order_manager.py
+++ b/src/nifty_scalper_bot/execution/order_manager.py
@@ -1,8 +1,13 @@
-"""Stable public order API with one explicit runtime manager.
+"""File purpose:
+    Provide the stable public order-execution API used by the strategy runner.
 
-The complete order engine lives in ``order_manager_core``. Public models, enums
-and helpers remain available from this module, while ``OrderManager`` resolves
-directly to ``RuntimeOrderManager``.
+Key responsibilities:
+    - Re-export public order models and helpers from ``order_manager_core``.
+    - Expose ``RuntimeOrderManager`` as the single production ``OrderManager``.
+
+Operational constraints:
+    - This facade must not add a second execution path or duplicate order state.
+    - Runtime recovery and entry gating remain owned by ``RuntimeOrderManager``.
 """
 
 from __future__ import annotations

--- a/src/nifty_scalper_bot/execution/ownership.py
+++ b/src/nifty_scalper_bot/execution/ownership.py
@@ -1,4 +1,14 @@
-"""Explicit execution ownership bindings."""
+"""File purpose:
+    Bind the canonical bracket authority to the canonical order-entry gate.
+
+Key responsibilities:
+    - Register the active bracket manager as the unresolved-exit provider.
+    - Preserve a compatibility fallback for noncanonical external test doubles.
+
+Operational constraints:
+    - Production wiring must use the native provider contract, not method replacement.
+    - Protective exits must remain executable while new entries are blocked.
+"""
 
 from __future__ import annotations
 

--- a/src/nifty_scalper_bot/execution/runtime_order_manager.py
+++ b/src/nifty_scalper_bot/execution/runtime_order_manager.py
@@ -1,4 +1,15 @@
-"""Explicit runtime order manager composition."""
+"""File purpose:
+    Implement the single production order manager used by the trading runtime.
+
+Key responsibilities:
+    - Apply unresolved-exit entry blocking before broker submission.
+    - Run bounded entry recovery and finalize partial-entry reconciliation.
+    - Delegate unchanged order operations to ``order_manager_core``.
+
+Operational constraints:
+    - Protective exits must bypass entry blocking.
+    - Recovery must remain bounded and must not create duplicate broker orders.
+"""
 
 from __future__ import annotations
 

--- a/src/nifty_scalper_bot/execution/safe_order_manager.py
+++ b/src/nifty_scalper_bot/execution/safe_order_manager.py
@@ -1,10 +1,13 @@
-"""Compatibility adapter for the canonical :class:`OrderManager`.
+"""File purpose:
+    Preserve the historical ``SafeOrderManager`` constructor shape for startup code.
 
-Historically this module implemented a second order path with its own throttling,
-retry, monitoring and regime logic.  The canonical runtime now owns those
-concerns.  ``SafeOrderManager`` remains only because startup and operator
-components still accept that constructor shape; every execution operation is
-delegated to the single runtime ``OrderManager`` instance.
+Key responsibilities:
+    - Delegate monitoring, counters, skip reasons and order placement to ``OrderManager``.
+    - Keep operator-facing compatibility without owning execution state.
+
+Operational constraints:
+    - This adapter must not retry, throttle, reprice or submit an order independently.
+    - The canonical ``OrderManager`` remains the only execution authority.
 """
 
 from __future__ import annotations

--- a/tests/architecture/test_file_header_standard.py
+++ b/tests/architecture/test_file_header_standard.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+REQUIRED_LABELS = (
+    "File purpose:",
+    "Key responsibilities:",
+    "Operational constraints:",
+)
+
+PYTHON_FILES = (
+    "src/nifty_scalper_bot/execution/order_manager.py",
+    "src/nifty_scalper_bot/execution/bracket_manager.py",
+    "src/nifty_scalper_bot/execution/adaptive_trailing.py",
+    "src/nifty_scalper_bot/execution/ownership.py",
+    "src/nifty_scalper_bot/execution/safe_order_manager.py",
+    "src/nifty_scalper_bot/execution/lifecycle_manager.py",
+    "src/nifty_scalper_bot/deployment_main.py",
+)
+
+COMMENT_HEADER_FILES = (
+    "Dockerfile",
+    "railway.toml",
+    ".github/workflows/live-exit-safety-ci.yml",
+)
+
+
+def test_critical_python_files_have_descriptive_module_headers() -> None:
+    failures: list[str] = []
+    for relative in PYTHON_FILES:
+        path = ROOT / relative
+        module = ast.parse(path.read_text(encoding="utf-8"))
+        docstring = ast.get_docstring(module, clean=False) or ""
+        missing = [label for label in REQUIRED_LABELS if label not in docstring]
+        if missing:
+            failures.append(f"{relative}: missing {', '.join(missing)}")
+    assert not failures, failures
+
+
+def test_critical_configuration_files_have_descriptive_comment_headers() -> None:
+    failures: list[str] = []
+    for relative in COMMENT_HEADER_FILES:
+        path = ROOT / relative
+        header = "\n".join(path.read_text(encoding="utf-8").splitlines()[:12])
+        missing = [label for label in REQUIRED_LABELS if label not in header]
+        if missing:
+            failures.append(f"{relative}: missing {', '.join(missing)}")
+    assert not failures, failures
+
+
+def test_file_header_editing_rule_is_documented() -> None:
+    standard = (ROOT / "docs" / "FILE_HEADER_STANDARD.md").read_text(
+        encoding="utf-8"
+    )
+    for label in REQUIRED_LABELS:
+        assert label in standard
+    assert "When a listed canonical BO or deployment file is edited" in standard


### PR DESCRIPTION
Adds concise file-level descriptions to the canonical BO facades, compatibility adapters, deployment entrypoint, Dockerfile, Railway configuration, and CI workflow. Standardizes three required sections: File purpose, Key responsibilities, and Operational constraints. Adds documentation plus an architecture test so later edits cannot silently remove these headers. No runtime behavior is changed; full compilation, focused BO safety tests, and the complete suite remain required.