### PR TITLE
⚡ Bolt: Optimize timestamp flooring performance

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-19 - Fast Timestamp Truncation
+**Learning:** For truncating `pd.Timestamp` to the nearest minute in performance-critical paths, `ts.floor('1min')` incurs significant overhead due to parsing the frequency string, validating the offset, and calculating the delta.
+**Action:** Use `ts.replace(second=0, microsecond=0, nanosecond=0)` instead to directly mutate the time components and bypass offset-logic overhead entirely, providing a significant latency reduction per tick. Be careful not to commit temporary test artifacts like `.coverage` files generated when running tests.

--- a/src/nifty_scalper_bot/data/candle_engine.py
+++ b/src/nifty_scalper_bot/data/candle_engine.py
@@ -70,7 +70,7 @@ class CandleEngine:
         validated = tick if isinstance(tick, Tick) else validate_tick(dict(tick))
         payload = validated.to_dict()
         timestamp = pd.Timestamp(timestamp)
-        minute = timestamp.floor('1min')
+        minute = timestamp.replace(second=0, microsecond=0, nanosecond=0)
 
         if self._last_tick_ts is not None:
             last_ts = pd.to_datetime(self._last_tick_ts, utc=True, errors='coerce')

--- a/src/nifty_scalper_bot/data/pipeline.py
+++ b/src/nifty_scalper_bot/data/pipeline.py
@@ -186,7 +186,7 @@ class CandleBuilder:
     def _process(self, tick: ValidatedTick) -> Optional[Candle]:
         sym = tick.symbol
         ts = tick.timestamp
-        minute = ts.floor("1min")
+        minute = ts.replace(second=0, microsecond=0, nanosecond=0)
 
         # STEP 2 guard: monotonic timestamp enforcement
         last = self._last_ts.get(sym)
@@ -359,7 +359,7 @@ class CandleStore:
                         continue
                     c = Candle(
                         symbol=symbol,
-                        timestamp=ts.floor("1min"),
+                        timestamp=ts.replace(second=0, microsecond=0, nanosecond=0),
                         open=float(row.get("open") or row.get("close") or 0),
                         high=float(row.get("high") or row.get("close") or 0),
                         low=float(row.get("low") or row.get("close") or 0),


### PR DESCRIPTION
💡 What: Replaced `.floor("1min")` with `.replace(second=0, microsecond=0, nanosecond=0)` on `pd.Timestamp` objects in `src/nifty_scalper_bot/data/pipeline.py` and `src/nifty_scalper_bot/data/candle_engine.py`.
🎯 Why: `.floor("1min")` invokes complex logic inside pandas to parse the frequency string, validate the offset, and calculate differences. The `replace()` method skips this entirely and directly manipulates the timestamp attributes, making it significantly faster for scalar timestamps processing in tick pipelines.
📊 Impact: Considerably reduces latency when constructing candles out of incoming market ticks since tick volume can be very high.
🔬 Measurement: Run the test suite and observe no functional regressions. A micro-benchmark confirms `replace()` is significantly faster than `floor("1min")` for scalar `pd.Timestamp`s.

---
*PR created automatically by Jules for task [16262671518209757081](https://jules.google.com/task/16262671518209757081) started by @kundakarlabp*