### PR TITLE
Correct quote depth parsing and restart reconciliation

### DIFF
--- a/src/nifty_scalper_bot/execution/quote_readiness.py
+++ b/src/nifty_scalper_bot/execution/quote_readiness.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 from dataclasses import asdict, dataclass
 from typing import Any, Mapping
 
+from nifty_scalper_bot.execution.readiness import resolve_quote_bid_ask_spread
+
 
 def _value(payload: Mapping[str, Any] | object | None, key: str) -> Any:
     if payload is None:
@@ -80,8 +82,16 @@ def resolve_real_tick_count(
             return max(0, int(raw)), False
         except (TypeError, ValueError):
             return 0, False
-    explicit_ms = _value(payload, "tick_age_ms") is not None or _value(payload, "quote_age_ms") is not None
-    if explicit_ms and tick_age_ms is not None and tick_age_ms <= max_age_ms and has_bid_ask:
+    explicit_ms = (
+        _value(payload, "tick_age_ms") is not None
+        or _value(payload, "quote_age_ms") is not None
+    )
+    if (
+        explicit_ms
+        and tick_age_ms is not None
+        and tick_age_ms <= max_age_ms
+        and has_bid_ask
+    ):
         return 1, True
     return 0, False
 
@@ -115,14 +125,23 @@ def evaluate_execution_quote(
     require_depth: bool,
     min_real_ticks_last_60s: int = 0,
 ) -> ExecutionQuoteReadiness:
-    """Return one canonical fail-closed quote verdict."""
-    bid = _float(payload, "bid", "best_bid")
-    ask = _float(payload, "ask", "best_ask")
-    has_bid_ask = bool(bid is not None and ask is not None and bid > 0 and ask > bid)
+    """Return one canonical fail-closed quote verdict.
+
+    FULL Kite ticks commonly carry best prices only inside
+    ``depth.buy[0]``/``depth.sell[0]``.  Resolve those through the canonical
+    depth-aware helper before applying the execution gates.  This preserves
+    fail-closed behaviour: an absent, crossed, stale, wide, or one-sided book
+    remains non-tradable.
+    """
+    bid, ask, derived_spread_pct, _bid_ask_source = resolve_quote_bid_ask_spread(
+        payload
+    )
+    has_bid_ask = bool(
+        bid is not None and ask is not None and bid > 0 and ask > bid
+    )
     spread_pct = _float(payload, "spread_pct")
-    if spread_pct is None and has_bid_ask:
-        midpoint = ((bid or 0.0) + (ask or 0.0)) / 2.0
-        spread_pct = ((ask - bid) / midpoint * 100.0) if midpoint > 0 else None
+    if spread_pct is None:
+        spread_pct = derived_spread_pct
     tick_age_ms = resolve_tick_age_ms(payload)
     quote_version = resolve_quote_version(payload)
     depth = _value(payload, "depth")

--- a/src/nifty_scalper_bot/execution/runtime_bracket_manager.py
+++ b/src/nifty_scalper_bot/execution/runtime_bracket_manager.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from contextlib import suppress
 import os
 import time
-from typing import Any
+from typing import Any, Mapping
 
 from nifty_scalper_bot.execution import bracket_manager as _legacy
 from nifty_scalper_bot.execution.ledger_bracket_manager import LedgerBracketManager
@@ -18,6 +18,159 @@ from nifty_scalper_bot.execution.ledger_bracket_manager import LedgerBracketMana
 
 class RuntimeBracketManager(LedgerBracketManager):
     """Final runtime export for the staged lifecycle implementation."""
+
+    def _block_ledger_release(
+        self,
+        bracket: Any,
+        *,
+        reason: str,
+        payload: Mapping[str, Any] | None = None,
+    ) -> None:
+        """Persist enough identity to reconcile a ledger block after restart."""
+        release_payload = dict(payload or {})
+        release_payload.setdefault("symbol", str(bracket.symbol))
+        release_payload.setdefault("bracket_id", str(bracket.bracket_id))
+        release_payload.setdefault("exit_state", str(bracket.exit_state or ""))
+        release_payload.setdefault(
+            "remaining_quantity", int(bracket.remaining_quantity or 0)
+        )
+        super()._block_ledger_release(
+            bracket,
+            reason=reason,
+            payload=release_payload,
+        )
+
+    def _broker_all_positions_flat(self) -> bool | None:
+        """Return explicit all-account flatness, or ``None`` when unknowable."""
+        broker = getattr(getattr(self, "order_manager", None), "_broker", None)
+        getter = getattr(broker, "get_positions", None) if broker is not None else None
+        if not callable(getter):
+            return None
+        try:
+            payload = getter()
+        except Exception as exc:  # noqa: BLE001 - unknown must remain fail-closed
+            _legacy.LOGGER.error(
+                "FILL_LEDGER_ORPHAN_POSITION_CHECK_FAILED error=%s",
+                exc,
+                extra={
+                    "event": "FILL_LEDGER_ORPHAN_POSITION_CHECK_FAILED",
+                    "error_type": type(exc).__name__,
+                },
+            )
+            return None
+
+        rows: Any = payload
+        if isinstance(payload, Mapping):
+            found_collection = False
+            for key in ("net", "positions", "day"):
+                if key in payload:
+                    rows = payload.get(key)
+                    found_collection = True
+                    break
+            if not found_collection:
+                return True if not payload else None
+        if rows is None:
+            return None
+        try:
+            positions = list(rows)
+        except TypeError:
+            return None
+        if not positions:
+            return True
+
+        for position in positions:
+            if not isinstance(position, Mapping):
+                return None
+            raw_quantity = position.get(
+                "quantity",
+                position.get("net_quantity", position.get("net")),
+            )
+            if raw_quantity is None:
+                return None
+            try:
+                quantity = int(float(raw_quantity or 0))
+            except (TypeError, ValueError):
+                return None
+            if quantity != 0:
+                return False
+        return True
+
+    def _retry_orphan_ledger_block(
+        self,
+        bracket_id: str,
+        details: Mapping[str, Any] | None,
+    ) -> bool:
+        """Clear a restart orphan only after authoritative broker-flat proof."""
+        payload = details.get("payload", {}) if isinstance(details, Mapping) else {}
+        payload = payload if isinstance(payload, Mapping) else {}
+        symbol = str(payload.get("symbol") or "").strip()
+
+        flat: bool | None
+        if symbol:
+            try:
+                quantity = self._broker_position_quantity(symbol)
+            except Exception as exc:  # noqa: BLE001 - unknown remains blocked
+                _legacy.LOGGER.error(
+                    "FILL_LEDGER_ORPHAN_POSITION_CHECK_FAILED bracket_id=%s symbol=%s error=%s",
+                    bracket_id,
+                    symbol,
+                    exc,
+                    extra={
+                        "event": "FILL_LEDGER_ORPHAN_POSITION_CHECK_FAILED",
+                        "bracket_id": str(bracket_id),
+                        "symbol": symbol,
+                        "error_type": type(exc).__name__,
+                    },
+                )
+                flat = None
+            else:
+                flat = None if quantity is None else quantity == 0
+        else:
+            # Legacy rows predate persisted symbol metadata. They may be released
+            # only when the broker authoritatively reports the entire account flat.
+            flat = self._broker_all_positions_flat()
+
+        if flat is not True:
+            _legacy.LOGGER.warning(
+                "FILL_LEDGER_ORPHAN_BLOCK_RETAINED bracket_id=%s symbol=%s broker_flat=%s",
+                bracket_id,
+                symbol or "unknown",
+                flat,
+                extra={
+                    "event": "FILL_LEDGER_ORPHAN_BLOCK_RETAINED",
+                    "bracket_id": str(bracket_id),
+                    "symbol": symbol or None,
+                    "broker_flat": flat,
+                },
+            )
+            return False
+
+        self._ledger_blocked.pop(str(bracket_id), None)
+        if self._release_store is not None:
+            with suppress(Exception):
+                self._release_store.clear(str(bracket_id))
+        _legacy.LOGGER.warning(
+            "FILL_LEDGER_ORPHAN_BLOCK_CLEARED bracket_id=%s symbol=%s",
+            bracket_id,
+            symbol or "account_flat",
+            extra={
+                "event": "FILL_LEDGER_ORPHAN_BLOCK_CLEARED",
+                "bracket_id": str(bracket_id),
+                "symbol": symbol or None,
+            },
+        )
+        return True
+
+    def _retry_blocked_releases(self) -> None:
+        """Retry live brackets and reconcile restart-orphaned ledger rows."""
+        for bracket_id in list(self._ledger_blocked):
+            bracket = self._find_bracket_by_id(bracket_id)
+            if bracket is not None:
+                self._retry_ledger_block(bracket)
+                continue
+            self._retry_orphan_ledger_block(
+                str(bracket_id), self._ledger_blocked.get(str(bracket_id))
+            )
 
     def _strict_ledger_release_required(self) -> bool:
         checker = getattr(self.order_manager, "is_live_mode", None)

--- a/tests/execution/test_live_readiness_blocker_recovery.py
+++ b/tests/execution/test_live_readiness_blocker_recovery.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import Any
+
+from nifty_scalper_bot.execution.ledger_bracket_manager import LedgerBracketManager
+from nifty_scalper_bot.execution.quote_readiness import evaluate_execution_quote
+from nifty_scalper_bot.execution.runtime_bracket_manager import RuntimeBracketManager
+
+
+SYMBOL = "NFO:NIFTY26JUN24050CE"
+
+
+def test_execution_quote_accepts_fresh_full_depth_without_top_level_bid_ask() -> None:
+    verdict = evaluate_execution_quote(
+        SYMBOL,
+        {
+            "last_price": 101.0,
+            "tick_age_ms": 150.0,
+            "timestamp_ms": 1_782_443_000_000,
+            "depth": {
+                "buy": [{"price": 100.9, "quantity": 75}],
+                "sell": [{"price": 101.1, "quantity": 50}],
+            },
+        },
+        live_mode=True,
+        max_tick_age_ms=2_000.0,
+        max_spread_pct=1.0,
+        require_depth=True,
+    )
+
+    assert verdict.allowed is True
+    assert verdict.reason == "ready"
+    assert verdict.bid == 100.9
+    assert verdict.ask == 101.1
+    assert verdict.depth_available is True
+    assert verdict.tradable_quote is True
+
+
+def test_execution_quote_keeps_one_sided_depth_fail_closed() -> None:
+    verdict = evaluate_execution_quote(
+        SYMBOL,
+        {
+            "last_price": 101.0,
+            "tick_age_ms": 150.0,
+            "depth": {"buy": [{"price": 100.9, "quantity": 75}], "sell": []},
+        },
+        live_mode=True,
+        max_tick_age_ms=2_000.0,
+        max_spread_pct=1.0,
+        require_depth=True,
+    )
+
+    assert verdict.allowed is False
+    assert verdict.reason == "bid_ask_missing"
+    assert verdict.tradable_quote is False
+
+
+class _ReleaseStore:
+    def __init__(self) -> None:
+        self.cleared: list[str] = []
+
+    def clear(self, bracket_id: str) -> None:
+        self.cleared.append(str(bracket_id))
+
+
+@dataclass
+class _Broker:
+    positions: Any
+    raises: bool = False
+
+    def get_positions(self) -> Any:
+        if self.raises:
+            raise RuntimeError("broker unavailable")
+        return self.positions
+
+
+@dataclass
+class _OrderManager:
+    _broker: _Broker
+
+
+def _orphan_manager(*, payload: dict[str, Any], broker: _Broker) -> RuntimeBracketManager:
+    manager = object.__new__(RuntimeBracketManager)
+    manager._ledger_blocked = {
+        "old-bracket": {"reason": "final_exit_accounting_failed", "payload": payload}
+    }
+    manager._release_store = _ReleaseStore()
+    manager.order_manager = _OrderManager(broker)
+    manager._find_bracket_by_id = lambda _bracket_id: None  # type: ignore[method-assign]
+    manager._retry_ledger_block = lambda _bracket: False  # type: ignore[method-assign]
+    return manager
+
+
+def test_runtime_block_persists_restart_reconciliation_identity(monkeypatch) -> None:
+    captured: dict[str, Any] = {}
+
+    def _capture(
+        _self: Any,
+        _bracket: Any,
+        *,
+        reason: str,
+        payload: dict[str, Any] | None = None,
+    ) -> None:
+        captured["reason"] = reason
+        captured["payload"] = dict(payload or {})
+
+    monkeypatch.setattr(LedgerBracketManager, "_block_ledger_release", _capture)
+    manager = object.__new__(RuntimeBracketManager)
+    bracket = SimpleNamespace(
+        symbol=SYMBOL,
+        bracket_id="entry-1",
+        exit_state="CLOSED",
+        remaining_quantity=0,
+    )
+
+    manager._block_ledger_release(
+        bracket,
+        reason="final_exit_accounting_failed",
+        payload={"order_id": "exit-1"},
+    )
+
+    assert captured["payload"] == {
+        "order_id": "exit-1",
+        "symbol": SYMBOL,
+        "bracket_id": "entry-1",
+        "exit_state": "CLOSED",
+        "remaining_quantity": 0,
+    }
+
+
+def test_symbol_orphan_clears_only_after_explicit_broker_flat_proof() -> None:
+    manager = _orphan_manager(payload={"symbol": SYMBOL}, broker=_Broker([]))
+
+    manager._retry_blocked_releases()
+
+    assert manager._ledger_blocked == {}
+    assert manager._release_store.cleared == ["old-bracket"]
+
+
+def test_symbol_orphan_remains_blocked_when_position_is_open() -> None:
+    manager = _orphan_manager(
+        payload={"symbol": SYMBOL},
+        broker=_Broker([{"symbol": SYMBOL, "quantity": 50}]),
+    )
+
+    manager._retry_blocked_releases()
+
+    assert "old-bracket" in manager._ledger_blocked
+    assert manager._release_store.cleared == []
+
+
+def test_symbol_orphan_remains_blocked_when_broker_truth_is_unknown() -> None:
+    manager = _orphan_manager(
+        payload={"symbol": SYMBOL}, broker=_Broker([], raises=True)
+    )
+
+    manager._retry_blocked_releases()
+
+    assert "old-bracket" in manager._ledger_blocked
+    assert manager._release_store.cleared == []
+
+
+def test_legacy_orphan_without_symbol_clears_when_whole_account_is_flat() -> None:
+    manager = _orphan_manager(payload={}, broker=_Broker({"net": [], "day": []}))
+
+    manager._retry_blocked_releases()
+
+    assert manager._ledger_blocked == {}
+    assert manager._release_store.cleared == ["old-bracket"]
+
+
+def test_legacy_orphan_without_symbol_retains_block_for_open_position() -> None:
+    manager = _orphan_manager(
+        payload={},
+        broker=_Broker({"net": [{"symbol": SYMBOL, "quantity": 50}]}),
+    )
+
+    manager._retry_blocked_releases()
+
+    assert "old-bracket" in manager._ledger_blocked
+    assert manager._release_store.cleared == []


### PR DESCRIPTION
## Root cause

The runtime treated valid depth-only quotes as missing bid/ask, and persisted accounting rows without an in-memory bracket were never re-evaluated after restart.

## What changed

- Reuse the canonical depth-aware bid/ask resolver in execution quote checks.
- Preserve fail-closed handling for stale, crossed, one-sided, wide or incomplete quotes.
- Persist reconciliation identity with new accounting blocks.
- Clear orphaned rows only after an authoritative flat-position response; retain them when state is unknown or non-flat.
- Add focused regression tests for both recovery and safety cases.

## What did not change

Strategy logic, contract selection, sizing, risk limits, protective exits, deployment configuration and credentials are unchanged.

## Validation

This change requires source compilation, focused execution tests, architecture checks and the complete test suite before merge.

## Runtime impact

Valid full-depth snapshots are evaluated consistently, while uncertain position state remains blocked.

## Regression risk

Malformed market depth and ambiguous broker position responses remain fail-closed.