### PR TITLE
Add Copilot skill routing and durable worklogs

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -10,6 +10,7 @@ These skills are discovered automatically by Codex from `.agents/skills/` when C
 | `tdd-trading-changes` | Test-first implementation using one behavior slice at a time | `$tdd-trading-changes` |
 | `codebase-design` | Module/interface/seam design while preserving repository ownership | `$codebase-design` |
 | `pre-merge-trading-review` | Trading-specific code, backtest, risk, execution, and deployment review | `$pre-merge-trading-review` |
+| `session-worklog` | Durable record of decisions, changed files, validation, residual risk, and next action | `$session-worklog` |
 
 Codex may invoke a skill automatically when the request matches its description. Use `$skill-name` when you need to force a particular workflow.
 
@@ -28,7 +29,11 @@ $codebase-design Review whether reconnect recovery belongs in OrderManager or Po
 ```
 
 ```text
-$pre-merge-trading-review Review this PR for live-trading and backtest validity risks.
+$pre-merge-trading-review Review this PR for runtime and backtest validity risks.
+```
+
+```text
+$session-worklog Record the final decision, PR, validation evidence, and remaining rollout risk.
 ```
 
 ## Relationship to `AGENTS.md`
@@ -37,4 +42,6 @@ $pre-merge-trading-review Review this PR for live-trading and backtest validity 
 
 ## Source and adaptation
 
-The `diagnosing-trading-bugs`, TDD, and codebase-design workflows are adapted from Matt Pocock's `mattpocock/skills` repository and tailored to this NIFTY options scalper. The source repository is MIT licensed. See `THIRD_PARTY_NOTICE.md` in this directory.
+The diagnostic, TDD, and codebase-design workflows are adapted from Matt Pocock's `mattpocock/skills` repository and tailored to this NIFTY options scalper. `session-worklog` is vendored from `kundakarlabp/dr-bhanu-prasad` at source commit `c92ac30e6c2e2c7998fd8ebf2669f90b117151a3`.
+
+See `THIRD_PARTY_NOTICE.md` in this directory.

--- a/.agents/skills/session-worklog/SKILL.md
+++ b/.agents/skills/session-worklog/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: session-worklog
+description: Create a compact durable worklog after substantial medical, research, document, software, or operational work so future chats can recover goals, decisions, artifacts, validation, unresolved risks, and next actions without replaying the entire conversation.
+---
+
+# Session Worklog
+
+## Purpose
+
+Preserve high-value continuity while avoiding noisy transcripts. Use after multi-step work, before switching chats, or when a project will continue later.
+
+## What to record
+
+- task goal and scope
+- current status
+- key decisions and rationale
+- authoritative sources or files used
+- files, branches, PRs, documents, or datasets changed
+- validation performed and exact result
+- unresolved questions, risks, and blockers
+- single next action
+
+## What not to record
+
+- hidden reasoning or verbose chronological narration
+- temporary hypotheses that were disproved
+- credentials, access tokens, private keys, or secrets
+- patient names, identifiers, images, or other protected health information
+- unsupported claims of completion
+- duplicated material already present in authoritative project documents
+
+## Workflow
+
+1. Re-read the task and final state.
+2. Distinguish durable decisions from transient discussion.
+3. Link to the authoritative artifact rather than copying large content.
+4. Record verification evidence exactly; use `not run` or `blocked` when applicable.
+5. State unresolved risk plainly.
+6. Keep the entry short enough to load in a future session.
+
+## Output template
+
+```markdown
+# Worklog — <date> — <task>
+
+## Goal
+<one paragraph>
+
+## Current state
+<done / partial / blocked with evidence>
+
+## Decisions
+- <decision and rationale>
+
+## Artifacts
+- <file, PR, document, dataset, or link>
+
+## Validation
+- <command/check>: <result>
+
+## Residual risk
+- <risk or none identified>
+
+## Next action
+<one concrete action>
+```
+
+## Validation
+
+Before saving, confirm that the entry contains no secrets or patient identifiers and that every completion statement is supported by recorded evidence.
+
+## Failure and uncertainty handling
+
+When the final state is unclear, label the worklog `partial` and record the exact uncertainty. Do not turn an intended action into a completed action.

--- a/.agents/skills/session-worklog/SKILL.md
+++ b/.agents/skills/session-worklog/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: session-worklog
-description: Create a compact durable worklog after substantial medical, research, document, software, or operational work so future chats can recover goals, decisions, artifacts, validation, unresolved risks, and next actions without replaying the entire conversation.
+description: Create a compact durable worklog after substantial software, trading, research, or operational work so future chats can recover goals, decisions, artifacts, validation, unresolved risks, and next actions without replaying the entire conversation.
 ---
 
 # Session Worklog
@@ -15,7 +15,7 @@ Preserve high-value continuity while avoiding noisy transcripts. Use after multi
 - current status
 - key decisions and rationale
 - authoritative sources or files used
-- files, branches, PRs, documents, or datasets changed
+- files, branches, PRs, configurations, or datasets changed
 - validation performed and exact result
 - unresolved questions, risks, and blockers
 - single next action
@@ -25,7 +25,7 @@ Preserve high-value continuity while avoiding noisy transcripts. Use after multi
 - hidden reasoning or verbose chronological narration
 - temporary hypotheses that were disproved
 - credentials, access tokens, private keys, or secrets
-- patient names, identifiers, images, or other protected health information
+- real account numbers, broker session material, positions, financial details, or identifiable trading records
 - unsupported claims of completion
 - duplicated material already present in authoritative project documents
 
@@ -67,7 +67,7 @@ Preserve high-value continuity while avoiding noisy transcripts. Use after multi
 
 ## Validation
 
-Before saving, confirm that the entry contains no secrets or patient identifiers and that every completion statement is supported by recorded evidence.
+Before saving, confirm that the entry contains no secrets or real account data and that every completion statement is supported by recorded evidence.
 
 ## Failure and uncertainty handling
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,24 @@
+# GitHub Copilot instructions — NIFTY Scalper Bot
+
+Read `AGENTS.md`, `docs/REPO_MAP.md`, and `.agents/skills/README.md` before proposing or applying changes.
+
+## Skill routing
+
+- Use `.agents/skills/diagnosing-trading-bugs/SKILL.md` before proposing fixes for runtime, data, readiness, signal, broker, order-state, latency, reconnect, or deployment failures.
+- Use `.agents/skills/tdd-trading-changes/SKILL.md` for strategy, market-data, risk, execution, Telegram, and configuration implementation.
+- Use `.agents/skills/codebase-design/SKILL.md` for ownership, interfaces, seams, module boundaries, and architecture decisions.
+- Use `.agents/skills/pre-merge-trading-review/SKILL.md` for PR, backtest, execution, deployment, and merge review.
+- Use `.agents/skills/session-worklog/SKILL.md` after substantial work so later chats recover decisions and validation without replaying the full conversation.
+
+## Hard constraints
+
+- Preserve the authoritative runtime path and module ownership in `AGENTS.md`.
+- NIFTY options are the only executable instruments; spot and futures are context only.
+- Do not bypass readiness, freshness, quote-quality, risk, cooldown, position, capital, max-loss, or execution-mode gates.
+- Do not create duplicate contract selectors, history stores, order paths, state owners, or hidden fallbacks.
+- Never add credentials, access tokens, API secrets, broker session material, or real account data.
+- Never place a live order during testing.
+- Preserve paper, shadow, and live separation.
+- Require regression tests, focused validation, the complete repository-required suite, and final-head CI before claiming completion.
+
+When generic suggestions conflict with `AGENTS.md`, repository-local architecture and safety rules take precedence.

--- a/tests/architecture/test_agent_skills_catalog.py
+++ b/tests/architecture/test_agent_skills_catalog.py
@@ -22,6 +22,8 @@ def _parse_frontmatter(text: str) -> dict[str, str]:
     for line in raw.splitlines():
         if not line.strip():
             continue
+        if ":" not in line:
+            raise ValueError(f"Malformed frontmatter line (missing colon): {line}")
         key, value = line.split(":", 1)
         metadata[key.strip()] = value.strip()
     return metadata

--- a/tests/architecture/test_agent_skills_catalog.py
+++ b/tests/architecture/test_agent_skills_catalog.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SKILLS_ROOT = ROOT / ".agents" / "skills"
+EXPECTED_SKILLS = {
+    "codebase-design",
+    "diagnosing-trading-bugs",
+    "pre-merge-trading-review",
+    "session-worklog",
+    "tdd-trading-changes",
+}
+
+
+def _parse_frontmatter(text: str) -> dict[str, str]:
+    assert text.startswith("---\n"), "missing opening YAML delimiter"
+    raw, _body = text[4:].split("\n---\n", 1)
+    metadata: dict[str, str] = {}
+    for line in raw.splitlines():
+        if not line.strip():
+            continue
+        key, value = line.split(":", 1)
+        metadata[key.strip()] = value.strip()
+    return metadata
+
+
+def test_expected_agent_skill_catalog_is_present() -> None:
+    discovered = {
+        path.name
+        for path in SKILLS_ROOT.iterdir()
+        if path.is_dir() and (path / "SKILL.md").is_file()
+    }
+    assert discovered == EXPECTED_SKILLS
+
+
+def test_agent_skills_have_activation_metadata_and_core_sections() -> None:
+    for name in sorted(EXPECTED_SKILLS):
+        skill_file = SKILLS_ROOT / name / "SKILL.md"
+        text = skill_file.read_text(encoding="utf-8")
+        metadata = _parse_frontmatter(text)
+        assert metadata.get("name") == name
+        assert len(metadata.get("description", "")) >= 40
+        assert re.search(r"^## .+", text, re.MULTILINE)
+        assert text.endswith("\n")
+
+
+def test_skill_readme_routes_all_installed_skills() -> None:
+    readme = (SKILLS_ROOT / "README.md").read_text(encoding="utf-8")
+    for name in EXPECTED_SKILLS:
+        assert f"`{name}`" in readme
+    assert "kundakarlabp/dr-bhanu-prasad" in readme


### PR DESCRIPTION
## Purpose

Complete the repository-scoped AI workflow so ChatGPT, Codex, and GitHub Copilot consistently use the existing trading-specific skills and preserve durable context between sessions.

## Included

- `session-worklog` skill from the canonical personal skills repository
- GitHub Copilot routing to the existing diagnostic, TDD, architecture, pre-merge, and worklog skills
- updated skill catalog README and provenance
- architecture regression test validating the installed skill catalog, activation metadata, and README routing

## Safety

The Copilot instructions explicitly preserve the authoritative runtime path, option-only execution, readiness, quote-quality, risk, cooldown, position, capital, max-loss, execution-mode, credential, and paper/shadow/live boundaries.

No runtime, strategy, market-data, risk, execution, deployment, or configuration behavior is changed.

## Validation

The complete Live Exit Safety CI must pass on the final PR head, including compilation, deployment-script checks, architecture and execution safety suites, and the full pytest suite.