### PR TITLE
Make watchdogs holiday-aware and throttle Telegram alert storms

### DIFF
--- a/src/nifty_scalper_bot/__init__.py
+++ b/src/nifty_scalper_bot/__init__.py
@@ -1,11 +1,3 @@
 """Nifty scalper bot package."""
 
-from nifty_scalper_bot.utils.runtime_session_guards import (
-    install_websocket_market_calendar_guard,
-)
-
-# Idempotent cross-cutting guard: WebSocket liveness/reconnect watchdogs must use
-# the same NSE trading calendar as strategy and execution session gates.
-install_websocket_market_calendar_guard()
-
 __all__: list[str] = []

--- a/src/nifty_scalper_bot/__init__.py
+++ b/src/nifty_scalper_bot/__init__.py
@@ -1,3 +1,11 @@
 """Nifty scalper bot package."""
 
+from nifty_scalper_bot.utils.runtime_session_guards import (
+    install_websocket_market_calendar_guard,
+)
+
+# Idempotent cross-cutting guard: WebSocket liveness/reconnect watchdogs must use
+# the same NSE trading calendar as strategy and execution session gates.
+install_websocket_market_calendar_guard()
+
 __all__: list[str] = []

--- a/src/nifty_scalper_bot/streaming/__init__.py
+++ b/src/nifty_scalper_bot/streaming/__init__.py
@@ -11,6 +11,14 @@ All streamers feed MarketDataManager, which re-emits into DataHub (SSOT).
 from .polling_streamer import PollingStreamer
 from .stream_supervisor import StreamHealth, StreamSupervisor
 from .websocket_manager import WebSocketManager
+from nifty_scalper_bot.utils.runtime_session_guards import (
+    install_websocket_market_calendar_guard,
+)
+
+# Direct and package imports both execute this module before exposing the
+# transport class, so every runtime instance receives the canonical holiday
+# gate without making the top-level package import side-effectful.
+install_websocket_market_calendar_guard()
 
 __all__ = [
     "PollingStreamer",

--- a/src/nifty_scalper_bot/utils/alerts.py
+++ b/src/nifty_scalper_bot/utils/alerts.py
@@ -17,8 +17,32 @@ from nifty_scalper_bot.utils.rate_limiter import LeakyBucket
 log = get_logger(__name__)
 
 _CONDITION_EVENT_RE = re.compile(
-    r"^\s*Condition met:\s*(?P<event>[A-Za-z0-9_.:-]+)"
+    r"^\s*Condition met:\s*(?P<event>[A-Za-z0-9_.:-]+)", re.IGNORECASE
 )
+_PERSISTENT_WARNING_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (
+        re.compile(r"strategy evaluation stalled", re.IGNORECASE),
+        "strategy_evaluation_stalled",
+    ),
+    (
+        re.compile(
+            r"strategy eval genuinely stalled while ticks flowing", re.IGNORECASE
+        ),
+        "strategy_eval_ticks_flowing_stalled",
+    ),
+    (
+        re.compile(
+            r"websocket_degraded\s+code=1006|closing[_ ]handshake[_ ]timeout",
+            re.IGNORECASE,
+        ),
+        "websocket_degraded_1006",
+    ),
+    (
+        re.compile(r"websocket stale\.\s*reconnecting", re.IGNORECASE),
+        "websocket_tick_stale",
+    ),
+)
+_GENERIC_RECORD_EVENTS = {"", "app.log", "log", "warning", "error"}
 
 
 @dataclass(slots=True)
@@ -44,25 +68,12 @@ class AlertDeduplicator:
         bucket_capacity: int = 100,
         bucket_refill_seconds: float = 100.0,
     ) -> None:
-        """Initialise deduplicator with quiet window and rate limiter.
-
-        Args:
-            quiet_window: Duration suppressing duplicate immediate sends.
-            bucket_capacity: Burst capacity for immediate dispatch tokens.
-            bucket_refill_seconds: Seconds per token refill for immediate dispatch.
-
-        Returns:
-            None.
-
-        Raises:
-            None.
-        """
-
         self._quiet_window = quiet_window
         refill_seconds = max(bucket_refill_seconds, 1.0)
         refill_rate = max(1.0 / refill_seconds, 0.01)
         self._bucket = LeakyBucket(
-            capacity=bucket_capacity, refill_rate_per_sec=refill_rate
+            capacity=bucket_capacity,
+            refill_rate_per_sec=refill_rate,
         )
         self._last_seen: MutableMapping[str, datetime] = {}
         self._last_severity: MutableMapping[str, str] = {}
@@ -79,21 +90,7 @@ class AlertDeduplicator:
         recovery: bool = False,
         now: datetime | None = None,
     ) -> bool:
-        """Return ``True`` when an alert should dispatch immediately.
-
-        Args:
-            key: Deduplication key for the alert source.
-            severity: Severity string (info|warning|critical).
-            hint_immediate: Caller preference for immediate delivery.
-            now: Optional override for the current timestamp.
-
-        Returns:
-            ``True`` when the alert should bypass aggregation.
-
-        Raises:
-            None.
-        """
-
+        """Return ``True`` when an alert should dispatch immediately."""
         try:
             moment = now or datetime.now(timezone.utc)
             normalized_key = str(key)
@@ -101,29 +98,28 @@ class AlertDeduplicator:
             normalized_outage = (outage_class or "").strip().lower()
             family_key = self._family_key(normalized_key)
             last_seen = self._last_seen.get(normalized_key)
-            quiet_elapsed = False
-            if last_seen is not None:
-                quiet_elapsed = moment - last_seen >= self._quiet_window
+            quiet_elapsed = bool(
+                last_seen is not None
+                and moment - last_seen >= self._quiet_window
+            )
             family_seen = self._last_seen.get(family_key)
-            family_quiet_elapsed = False
-            if family_seen is not None:
-                family_quiet_elapsed = moment - family_seen >= self._quiet_window
+            family_quiet_elapsed = bool(
+                family_seen is not None
+                and moment - family_seen >= self._quiet_window
+            )
 
             flood_hold_until = self._flood_hold_until.get(family_key)
-            if (
-                flood_hold_until is not None
-                and moment < flood_hold_until
-                and not recovery
-            ):
+            if flood_hold_until is not None and moment < flood_hold_until and not recovery:
                 self._last_seen[normalized_key] = moment
                 self._last_seen[family_key] = moment
                 return False
 
             immediate_requested = hint_immediate or normalized_severity == "critical"
-            severity_changed = self._last_severity.get(family_key) != normalized_severity
-            outage_changed = (
-                bool(normalized_outage)
-                and self._last_outage_class.get(family_key) != normalized_outage
+            severity_changed = (
+                self._last_severity.get(family_key) != normalized_severity
+            )
+            outage_changed = bool(normalized_outage) and (
+                self._last_outage_class.get(family_key) != normalized_outage
             )
             if recovery:
                 immediate_requested = True
@@ -132,49 +128,31 @@ class AlertDeduplicator:
                 immediate_requested = True
 
             if immediate_requested:
-                if (
+                eligible = (
                     last_seen is None
                     or family_seen is None
                     or quiet_elapsed
                     or family_quiet_elapsed
                     or severity_changed
                     or outage_changed
-                ):
-                    if self._acquire_token():
-                        self._last_seen[normalized_key] = moment
-                        self._last_seen[family_key] = moment
-                        self._last_severity[family_key] = normalized_severity
-                        if normalized_outage:
-                            self._last_outage_class[family_key] = normalized_outage
-                        if recovery:
-                            self._flood_hold_until.pop(family_key, None)
-                        return True
+                )
+                if eligible and self._acquire_token():
                     self._last_seen[normalized_key] = moment
                     self._last_seen[family_key] = moment
-                    log.debug(
-                        "Alert token bucket exhausted; aggregating",
-                        extra={
-                            "event": "alert_token_exhausted",
-                            "key": normalized_key,
-                        },
-                    )
-                    return False
+                    self._last_severity[family_key] = normalized_severity
+                    if normalized_outage:
+                        self._last_outage_class[family_key] = normalized_outage
+                    if recovery:
+                        self._flood_hold_until.pop(family_key, None)
+                    return True
                 self._last_seen[normalized_key] = moment
                 self._last_seen[family_key] = moment
-                log.debug(
-                    "Alert immediate suppressed within quiet window",
-                    extra={
-                        "event": "alert_immediate_suppressed",
-                        "key": normalized_key,
-                    },
-                )
                 return False
 
             if last_seen is None:
                 self._last_seen[normalized_key] = moment
                 self._last_seen[family_key] = moment
                 return False
-
             if quiet_elapsed and self._acquire_token():
                 self._last_seen[normalized_key] = moment
                 self._last_seen[family_key] = moment
@@ -182,19 +160,10 @@ class AlertDeduplicator:
                 if normalized_outage:
                     self._last_outage_class[family_key] = normalized_outage
                 return True
-
             self._last_seen[normalized_key] = moment
             self._last_seen[family_key] = moment
-            if quiet_elapsed:
-                log.debug(
-                    "Alert quiet window reached; aggregating",
-                    extra={
-                        "event": "alert_quiet_window_aggregate",
-                        "key": normalized_key,
-                    },
-                )
             return False
-        except Exception as exc:  # noqa: BLE001 - defensive catch
+        except Exception as exc:  # noqa: BLE001
             log.error(
                 "Failure in AlertDeduplicator.should_immediate: %s",
                 exc,
@@ -203,10 +172,13 @@ class AlertDeduplicator:
             return hint_immediate
 
     def mark_flood_limited(
-        self, key: str, *, now: datetime | None = None, hold_for: timedelta | None = None
+        self,
+        key: str,
+        *,
+        now: datetime | None = None,
+        hold_for: timedelta | None = None,
     ) -> None:
-        """Record send flood-control and suppress immediate retries for family."""
-
+        """Suppress immediate retries for an alert family after flood control."""
         moment = now or datetime.now(timezone.utc)
         family_key = self._family_key(str(key))
         effective_hold = (
@@ -216,23 +188,11 @@ class AlertDeduplicator:
         )
         hold_until = moment + effective_hold
         self._flood_hold_until[family_key] = hold_until
-        # Apply hold to all severities under the family to stop critical bypass spam.
         for severity in ("critical", "warning", "info"):
             self._flood_hold_until[f"{family_key}:{severity}"] = hold_until
 
     def prune(self, *, now: datetime | None = None) -> None:
-        """Drop dedupe entries older than the quiet window.
-
-        Args:
-            now: Optional override for the current timestamp.
-
-        Returns:
-            None.
-
-        Raises:
-            None.
-        """
-
+        """Drop expired dedupe and flood-control entries."""
         try:
             moment = now or datetime.now(timezone.utc)
             threshold = moment - self._quiet_window
@@ -248,7 +208,7 @@ class AlertDeduplicator:
             ]
             for key in expired:
                 self._flood_hold_until.pop(key, None)
-        except Exception as exc:  # noqa: BLE001 - defensive catch
+        except Exception as exc:  # noqa: BLE001
             log.error(
                 "Failure in AlertDeduplicator.prune: %s",
                 exc,
@@ -256,21 +216,10 @@ class AlertDeduplicator:
             )
 
     def snapshot(self) -> dict[str, str]:
-        """Return a shallow snapshot of dedupe state for diagnostics.
-
-        Args:
-            None.
-
-        Returns:
-            Mapping of dedupe keys to ISO-8601 timestamps.
-
-        Raises:
-            None.
-        """
-
+        """Return a shallow snapshot of dedupe state."""
         try:
             return {key: value.isoformat() for key, value in self._last_seen.items()}
-        except Exception as exc:  # noqa: BLE001 - defensive catch
+        except Exception as exc:  # noqa: BLE001
             log.error(
                 "Failure in AlertDeduplicator.snapshot: %s",
                 exc,
@@ -279,24 +228,12 @@ class AlertDeduplicator:
             return {}
 
     def _acquire_token(self) -> bool:
-        """Attempt to reserve a rate-limit token for immediate dispatch.
-
-        Args:
-            None.
-
-        Returns:
-            ``True`` when a token is acquired, else ``False``.
-
-        Raises:
-            None.
-        """
-
         try:
             self._bucket.acquire(timeout=0.01)
             return True
         except RateLimitError:
             return False
-        except Exception as exc:  # noqa: BLE001 - defensive catch
+        except Exception as exc:  # noqa: BLE001
             log.error(
                 "Failure in AlertDeduplicator._acquire_token: %s",
                 exc,
@@ -306,23 +243,20 @@ class AlertDeduplicator:
 
     @staticmethod
     def _family_key(key: str) -> str:
-        """Collapse alert keys into outage-family buckets."""
-
         normalized = str(key or "").strip().lower()
         if normalized.startswith("market_data."):
             parts = normalized.split(".")
             if len(parts) >= 3:
-                return ".".join(parts[:2]) + f".{parts[2]}"
+                return ".".join(parts[:3])
         return normalized.split(":", 1)[0] if ":" in normalized else normalized
 
 
 class AlertLogHandler(logging.Handler):
-    """Bridge warning/error log records into alert queue events.
+    """Bridge warning/error records into Telegram with semantic throttling.
 
-    Repeated ``Condition met: <event>`` records are collapsed before they enter
-    Telegram's queue. Dynamic fields such as ``age=`` therefore do not create a
-    new notification for every watchdog cycle. The original application log is
-    untouched, and the same condition may notify again after the repeat window.
+    Persistent watchdog messages often include changing ages or counters. They
+    are assigned stable event identities and throttled before queue insertion,
+    while unmatched warnings remain fully visible.
     """
 
     def __init__(
@@ -331,94 +265,102 @@ class AlertLogHandler(logging.Handler):
         *,
         exclude: Iterable[str] | None = None,
         repeat_window_seconds: float = 300.0,
+        persistent_repeat_window_seconds: float = 900.0,
         clock: Callable[[], float] | None = None,
     ) -> None:
-        """Configure handler with callback and optional exclusions.
-
-        Args:
-            emit_callback: Callable invoked with alert payload mapping.
-            exclude: Optional iterable of logger names to suppress.
-            repeat_window_seconds: Cooldown for the same semantic condition.
-            clock: Monotonic clock override for deterministic tests.
-
-        Returns:
-            None.
-
-        Raises:
-            None.
-        """
-
         super().__init__(level=logging.WARNING)
         self._emit = emit_callback
         self._exclude = set(exclude or [])
         self._exclude.add(__name__)
         self._repeat_window_seconds = max(0.0, float(repeat_window_seconds))
+        self._persistent_repeat_window_seconds = max(
+            self._repeat_window_seconds,
+            float(persistent_repeat_window_seconds),
+        )
         self._clock = clock or time.monotonic
-        self._last_condition_emit: MutableMapping[str, float] = {}
-        self._condition_lock = Lock()
+        self._last_semantic_emit: MutableMapping[str, float] = {}
+        self._semantic_lock = Lock()
 
     @staticmethod
     def _condition_event(message: str) -> str | None:
-        """Return the semantic condition name embedded in a log message."""
-
         match = _CONDITION_EVENT_RE.match(str(message or ""))
         if match is None:
             return None
         event = match.group("event").strip().lower()
         return event or None
 
-    def _allow_condition_emit(self, signature: str) -> bool:
-        """Return whether a semantic condition is outside its repeat window."""
+    @staticmethod
+    def _persistent_warning_event(message: str) -> str | None:
+        text = str(message or "")
+        for pattern, event in _PERSISTENT_WARNING_PATTERNS:
+            if pattern.search(text):
+                return event
+        return None
 
-        if self._repeat_window_seconds <= 0.0:
+    @staticmethod
+    def _structured_event(record: logging.LogRecord) -> str | None:
+        event = str(getattr(record, "event", "") or "").strip().lower()
+        if event in _GENERIC_RECORD_EVENTS:
+            return None
+        return event or None
+
+    def _semantic_event(
+        self,
+        record: logging.LogRecord,
+        message: str,
+    ) -> tuple[str | None, bool]:
+        persistent = self._persistent_warning_event(message)
+        if persistent is not None:
+            return persistent, True
+        condition = self._condition_event(message)
+        if condition is not None:
+            return condition, False
+        structured = self._structured_event(record)
+        if structured is not None:
+            return structured, False
+        return None, False
+
+    def _allow_semantic_emit(self, signature: str, window_seconds: float) -> bool:
+        if window_seconds <= 0.0:
             return True
         try:
             now = float(self._clock())
-        except Exception:  # noqa: BLE001 - alert delivery must remain fail-open
+        except Exception:  # noqa: BLE001
             return True
-        with self._condition_lock:
-            last = self._last_condition_emit.get(signature)
-            if last is not None and now - last < self._repeat_window_seconds:
+        with self._semantic_lock:
+            last = self._last_semantic_emit.get(signature)
+            if last is not None and now - last < window_seconds:
                 return False
-            self._last_condition_emit[signature] = now
-            cutoff = now - max(self._repeat_window_seconds * 4.0, 60.0)
+            self._last_semantic_emit[signature] = now
+            cutoff = now - max(window_seconds * 4.0, 60.0)
             stale = [
                 key
-                for key, emitted_at in self._last_condition_emit.items()
+                for key, emitted_at in self._last_semantic_emit.items()
                 if emitted_at < cutoff
             ]
             for key in stale:
-                self._last_condition_emit.pop(key, None)
+                self._last_semantic_emit.pop(key, None)
             return True
 
     def emit(self, record: logging.LogRecord) -> None:  # noqa: D401
-        """Format record and forward to the alert callback.
-
-        Args:
-            record: Log record forwarded from the logging framework.
-
-        Returns:
-            None.
-
-        Raises:
-            None.
-        """
-
-        if record.name in self._exclude:
-            return
-        if record.levelno < logging.WARNING:
+        if record.name in self._exclude or record.levelno < logging.WARNING:
             return
         try:
             message = record.getMessage()
-        except Exception:  # noqa: BLE001 - defensive formatting
+        except Exception:  # noqa: BLE001
             message = str(record.msg)
         severity = "critical" if record.levelno >= logging.ERROR else "warning"
         func = getattr(record, "funcName", "") or "unknown"
-        condition_event = self._condition_event(message)
+        semantic_event, persistent = self._semantic_event(record, message)
         key = f"log:{record.name}:{record.levelno}:{func}"
-        if condition_event is not None:
-            key = f"{key}:{condition_event}"
-            if not self._allow_condition_emit(key):
+        if semantic_event is not None:
+            key = f"{key}:{semantic_event}"
+            window = (
+                self._persistent_repeat_window_seconds
+                if persistent
+                else self._repeat_window_seconds
+            )
+            if not self._allow_semantic_emit(key, window):
                 return
         payload = {
             "key": key,
@@ -427,7 +369,7 @@ class AlertLogHandler(logging.Handler):
         }
         try:
             self._emit(payload)
-        except Exception as exc:  # noqa: BLE001 - defensive catch
+        except Exception as exc:  # noqa: BLE001
             log.error(
                 "Failure in AlertLogHandler.emit: %s",
                 exc,

--- a/src/nifty_scalper_bot/utils/market_hours.py
+++ b/src/nifty_scalper_bot/utils/market_hours.py
@@ -1,32 +1,21 @@
-"""
-===============================================================================
-NEW FILE: src/nifty_scalper_bot/utils/market_hours.py
-===============================================================================
-
-MARKET HOURS UTILITY - Single Source of Truth
-This module provides centralized market hours checking for the entire bot.
-
-CREATE THIS FILE AT: src/nifty_scalper_bot/utils/market_hours.py
-===============================================================================
-"""
+"""Canonical NSE market-session and safe-entry window utilities."""
 
 from __future__ import annotations
 
 import os
-from datetime import datetime, time as dtime
+from datetime import date, datetime, time as dtime
 from enum import Enum
 from functools import lru_cache
 from typing import Literal, Tuple
 from zoneinfo import ZoneInfo
 
 from nifty_scalper_bot.utils.logging import get_logger
+from nifty_scalper_bot.utils.nse_calendar import holiday_name as nse_holiday_name
 
 LOGGER = get_logger(__name__)
-
-# Indian Standard Time
 IST = ZoneInfo("Asia/Kolkata")
 
-# Market timing constants
+
 def _env_truthy(name: str) -> bool:
     return os.getenv(name, "false").strip().lower() in {
         "1",
@@ -52,7 +41,6 @@ def _env_time(name: str, default: dtime) -> dtime:
         return default
 
 
-# Market timing constants
 MARKET_OPEN = _env_time("MARKET_OPEN_TIME", dtime(9, 15))
 SAFE_START = _env_time("SAFE_START_TIME", dtime(9, 20))
 SAFE_END = _env_time("SAFE_END_TIME", dtime(15, 25))
@@ -62,19 +50,14 @@ MARKET_CLOSE = _env_time("MARKET_CLOSE_TIME", dtime(15, 30))
 class MarketState(Enum):
     """Market session state classification."""
 
-    CLOSED = 'closed'
-    PREOPEN = 'preopen'
-    OPEN = 'open'
-    POSTMARKET = 'postmarket'
-
-
-def _override_enabled() -> bool:
-    """Args: none; Returns: bool; Raises: none."""
-    return allow_offhours_testing_safe()
+    CLOSED = "closed"
+    PREOPEN = "preopen"
+    OPEN = "open"
+    POSTMARKET = "postmarket"
 
 
 def allow_offhours_testing_safe() -> bool:
-    """Args: none; Returns: safe off-hours override state; Raises: none."""
+    """Return whether off-hours testing is allowed without live-order risk."""
     execution_mode = os.getenv("EXECUTION_MODE", "SHADOW").strip().upper()
     live_enabled = _env_truthy("ENABLE_LIVE") or _env_truthy("ENABLE_LIVE_TRADING")
     if execution_mode == "LIVE" or live_enabled:
@@ -84,22 +67,49 @@ def allow_offhours_testing_safe() -> bool:
     )
 
 
+def _override_enabled() -> bool:
+    return allow_offhours_testing_safe()
+
+
 def _now_ist() -> datetime:
     return datetime.now(IST)
 
 
+def _coerce_ist(value: datetime | None) -> datetime:
+    if value is None:
+        return _now_ist()
+    return value.astimezone(IST) if value.tzinfo else value.replace(tzinfo=IST)
+
+
+def exchange_holiday_name(value: datetime | date | None = None) -> str | None:
+    """Return the NSE F&O holiday name for the supplied/current IST date."""
+    if value is None:
+        day = _now_ist().date()
+    elif isinstance(value, datetime):
+        day = _coerce_ist(value).date()
+    else:
+        day = value
+    return nse_holiday_name(day)
+
+
+def is_exchange_holiday(value: datetime | date | None = None) -> bool:
+    """Return whether the supplied/current IST date is an NSE F&O holiday."""
+    return exchange_holiday_name(value) is not None
+
+
+def _is_non_trading_day(now: datetime) -> bool:
+    return now.weekday() >= 5 or is_exchange_holiday(now)
+
+
 def get_market_state() -> MarketState:
-    """Args: none; Returns: current market state; Raises: none."""
+    """Return the current canonical NSE session state."""
     if _override_enabled():
         return MarketState.OPEN
-
     now = _now_ist()
-    if now.weekday() >= 5:
+    if _is_non_trading_day(now):
         return MarketState.CLOSED
-
     current = now.time()
-    preopen_start = dtime(9, 0)
-    if preopen_start <= current < MARKET_OPEN:
+    if dtime(9, 0) <= current < MARKET_OPEN:
         return MarketState.PREOPEN
     if MARKET_OPEN <= current <= MARKET_CLOSE:
         return MarketState.OPEN
@@ -108,14 +118,15 @@ def get_market_state() -> MarketState:
     return MarketState.CLOSED
 
 
-
-def get_runtime_market_mode() -> Literal["PRE_MARKET", "OPEN", "POST_MARKET", "HOLIDAY", "UNKNOWN"]:
-    """Return operator-facing runtime market mode from canonical market hours state."""
+def get_runtime_market_mode() -> Literal[
+    "PRE_MARKET", "OPEN", "POST_MARKET", "HOLIDAY", "UNKNOWN"
+]:
+    """Return the operator-facing runtime market mode."""
     try:
         if _override_enabled():
             return "OPEN"
         now = _now_ist()
-        if now.weekday() >= 5:
+        if _is_non_trading_day(now):
             return "HOLIDAY"
         state = get_market_state()
         if state == MarketState.OPEN:
@@ -124,10 +135,9 @@ def get_runtime_market_mode() -> Literal["PRE_MARKET", "OPEN", "POST_MARKET", "H
             return "PRE_MARKET"
         if state == MarketState.POSTMARKET:
             return "POST_MARKET"
-        current = now.time()
-        if current < MARKET_OPEN:
+        if now.time() < MARKET_OPEN:
             return "PRE_MARKET"
-        if current > MARKET_CLOSE:
+        if now.time() > MARKET_CLOSE:
             return "POST_MARKET"
         return "UNKNOWN"
     except Exception:
@@ -135,90 +145,92 @@ def get_runtime_market_mode() -> Literal["PRE_MARKET", "OPEN", "POST_MARKET", "H
 
 
 def post_market_quiet_mode_enabled() -> bool:
-    return os.getenv("POST_MARKET_QUIET_MODE", "true").strip().lower() in {"1", "true", "yes", "on"}
+    return os.getenv("POST_MARKET_QUIET_MODE", "true").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
 
 
 def post_market_basket_refresh_seconds() -> float:
     try:
-        return max(60.0, float(os.getenv("POST_MARKET_BASKET_REFRESH_SECONDS", "900") or 900))
+        return max(
+            60.0,
+            float(os.getenv("POST_MARKET_BASKET_REFRESH_SECONDS", "900") or 900),
+        )
     except (TypeError, ValueError):
         return 900.0
 
 
 def post_market_market_data_summary_seconds() -> float:
     try:
-        return max(60.0, float(os.getenv("POST_MARKET_MARKET_DATA_SUMMARY_SECONDS", "300") or 300))
+        return max(
+            60.0,
+            float(
+                os.getenv("POST_MARKET_MARKET_DATA_SUMMARY_SECONDS", "300") or 300
+            ),
+        )
     except (TypeError, ValueError):
         return 300.0
 
 
 def post_market_suppress_candle_gap_warnings() -> bool:
-    return os.getenv("POST_MARKET_SUPPRESS_CANDLE_GAP_WARNINGS", "true").strip().lower() in {"1", "true", "yes", "on"}
+    return os.getenv(
+        "POST_MARKET_SUPPRESS_CANDLE_GAP_WARNINGS", "true"
+    ).strip().lower() in {"1", "true", "yes", "on"}
 
 
 def is_market_open_session(allow_override: bool = True) -> bool:
     if allow_override and _override_enabled():
         return True
-    now_dt = _now_ist()
-    if now_dt.weekday() >= 5:
+    now = _now_ist()
+    if _is_non_trading_day(now):
         return False
-    now = now_dt.time()
-    return MARKET_OPEN <= now <= MARKET_CLOSE
+    return MARKET_OPEN <= now.time() <= MARKET_CLOSE
 
 
 def is_safe_entry_window(allow_override: bool = True) -> bool:
     if allow_override and _override_enabled():
         return True
-    now_dt = _now_ist()
-    if now_dt.weekday() >= 5:
+    now = _now_ist()
+    if _is_non_trading_day(now):
         return False
-    now = now_dt.time()
-    return SAFE_START <= now <= SAFE_END
+    return SAFE_START <= now.time() <= SAFE_END
 
 
 def is_market_hours(allow_override: bool = True) -> bool:
-    """Backward-compatible alias for safe new-entry window."""
+    """Backward-compatible alias for the safe new-entry window."""
     return is_safe_entry_window(allow_override=allow_override)
 
 
 def is_market_open() -> bool:
-    """Args: none; Returns: bool; Raises: none."""
     return get_market_state() == MarketState.OPEN
 
 
 def get_market_session_state(now: datetime | None = None) -> str:
-    """Return one of "open" | "closed" | "preopen" | "unknown" for the given
-    instant (defaults to current IST time)."""
+    """Return ``open``, ``closed``, ``preopen`` or ``unknown`` for an instant."""
     try:
-        if now is None:
-            current = _now_ist()
-        else:
-            current = now.astimezone(IST) if now.tzinfo else now.replace(tzinfo=IST)
+        current = _coerce_ist(now)
     except Exception:
         return "unknown"
-
     if _override_enabled():
         return "open"
-
-    if current.weekday() >= 5:
+    if _is_non_trading_day(current):
         return "closed"
-
-    t = current.time()
-    preopen_start = dtime(9, 0)
-    if preopen_start <= t < MARKET_OPEN:
+    current_time = current.time()
+    if dtime(9, 0) <= current_time < MARKET_OPEN:
         return "preopen"
-    if MARKET_OPEN <= t <= MARKET_CLOSE:
+    if MARKET_OPEN <= current_time <= MARKET_CLOSE:
         return "open"
     return "closed"
 
 
 def is_market_open_now() -> bool:
-    """Args: none; Returns: True iff session state is open. Raises: none."""
     return get_market_session_state() == "open"
 
 
 def _env_float(name: str, default: float) -> float:
-    """Args: env var name, default; Returns: float; Raises: none."""
     raw = os.getenv(name)
     if not raw:
         return float(default)
@@ -229,7 +241,6 @@ def _env_float(name: str, default: float) -> float:
 
 
 def is_nifty_index_symbol(symbol: str) -> bool:
-    """Args: symbol; Returns: True for NIFTY spot/index variants; Raises: none."""
     upper = (symbol or "").upper().strip()
     if not upper:
         return False
@@ -246,146 +257,124 @@ def is_nifty_index_symbol(symbol: str) -> bool:
         "NSE:BANKNIFTY",
     }:
         return True
-    if upper.endswith("CE") or upper.endswith("PE") or upper.endswith("FUT"):
+    if upper.endswith(("CE", "PE", "FUT")):
         return False
-    if "NIFTY" in upper and ":" in upper and not any(
-        upper.endswith(suf) for suf in ("CE", "PE", "FUT")
-    ):
-        return True
-    return False
+    return "NIFTY" in upper and ":" in upper
 
 
 def is_nifty_future_symbol(symbol: str) -> bool:
-    """Args: symbol; Returns: True if symbol is a NIFTY/BANKNIFTY future; Raises: none."""
-    upper = (symbol or "").upper().strip()
-    return upper.endswith("FUT")
+    return (symbol or "").upper().strip().endswith("FUT")
 
 
 def is_nifty_option_symbol(symbol: str) -> bool:
-    """Args: symbol; Returns: True if symbol is an NFO option (CE/PE); Raises: none."""
     upper = (symbol or "").upper().strip()
     return upper.endswith("CE") or upper.endswith("PE")
 
 
 def stale_threshold_for_symbol(symbol: str, market_open: bool) -> float:
-    """Return the canonical staleness threshold (seconds) for a symbol.
-
-    Index/Future spots: 120s when market open, 3600s otherwise.
-    Options:           900s when market open, 3600s otherwise.
-    Anything else:     60s when market open, 3600s otherwise.
-
-    Configurable via MDM_*_LTP_STALE_SECONDS / MDM_OFFMARKET_*_LTP_STALE_SECONDS env vars.
-    """
+    """Return the canonical staleness threshold in seconds for a symbol."""
     if is_nifty_index_symbol(symbol):
-        if market_open:
-            return _env_float("MDM_INDEX_LTP_STALE_SECONDS", 120.0)
-        return _env_float("MDM_OFFMARKET_INDEX_LTP_STALE_SECONDS", 3600.0)
+        return _env_float(
+            "MDM_INDEX_LTP_STALE_SECONDS" if market_open else "MDM_OFFMARKET_INDEX_LTP_STALE_SECONDS",
+            120.0 if market_open else 3600.0,
+        )
     if is_nifty_future_symbol(symbol):
-        if market_open:
-            return _env_float("MDM_FUTURE_LTP_STALE_SECONDS", 120.0)
-        return _env_float("MDM_OFFMARKET_FUTURE_LTP_STALE_SECONDS", 3600.0)
+        return _env_float(
+            "MDM_FUTURE_LTP_STALE_SECONDS" if market_open else "MDM_OFFMARKET_FUTURE_LTP_STALE_SECONDS",
+            120.0 if market_open else 3600.0,
+        )
     if is_nifty_option_symbol(symbol):
-        if market_open:
-            return _env_float("MDM_OPTION_LTP_STALE_SECONDS", 900.0)
-        return _env_float("MDM_OFFMARKET_OPTION_LTP_STALE_SECONDS", 3600.0)
-    if market_open:
-        return _env_float("MDM_GENERIC_LTP_STALE_SECONDS", 60.0)
-    return _env_float("MDM_OFFMARKET_GENERIC_LTP_STALE_SECONDS", 3600.0)
+        return _env_float(
+            "MDM_OPTION_LTP_STALE_SECONDS" if market_open else "MDM_OFFMARKET_OPTION_LTP_STALE_SECONDS",
+            900.0 if market_open else 3600.0,
+        )
+    return _env_float(
+        "MDM_GENERIC_LTP_STALE_SECONDS" if market_open else "MDM_OFFMARKET_GENERIC_LTP_STALE_SECONDS",
+        60.0 if market_open else 3600.0,
+    )
 
 
 def get_time_status() -> Tuple[bool, str]:
-    """
-    Get detailed time status for logging.
-    
-    Returns:
-        Tuple of (is_allowed, reason_string)
-    """
+    """Return whether new entries are time-allowed and a diagnostic reason."""
     if _override_enabled():
         return True, "Override enabled (SESSION_ALLOW_OUT_OF_HOURS=true)"
-
-    now_dt = _now_ist()
-    if now_dt.weekday() >= 5:
-        return False, f"Weekend closure ({now_dt.strftime('%A')})"
-
-    now = now_dt.time()
-
-    if now < MARKET_OPEN:
-        return False, f"Pre-market ({now.strftime('%H:%M')} < {MARKET_OPEN.strftime('%H:%M')})"
-    
-    if MARKET_OPEN <= now < SAFE_START:
-        return False, f"Opening volatility buffer (Wait until {SAFE_START.strftime('%H:%M')})"
-    
-    if SAFE_START <= now <= SAFE_END:
+    now = _now_ist()
+    if now.weekday() >= 5:
+        return False, f"Weekend closure ({now.strftime('%A')})"
+    holiday = exchange_holiday_name(now)
+    if holiday:
+        return False, f"Exchange holiday ({holiday})"
+    current = now.time()
+    if current < MARKET_OPEN:
+        return False, (
+            f"Pre-market ({current.strftime('%H:%M')} < "
+            f"{MARKET_OPEN.strftime('%H:%M')})"
+        )
+    if MARKET_OPEN <= current < SAFE_START:
+        return False, (
+            f"Opening volatility buffer (Wait until {SAFE_START.strftime('%H:%M')})"
+        )
+    if SAFE_START <= current <= SAFE_END:
         return True, "Within safe entry window"
-
-    if SAFE_END < now <= MARKET_CLOSE:
-        return False, f"EOD safety cutoff (No new entries after {SAFE_END.strftime('%H:%M')})"
-
+    if SAFE_END < current <= MARKET_CLOSE:
+        return False, (
+            f"EOD safety cutoff (No new entries after {SAFE_END.strftime('%H:%M')})"
+        )
     return False, f"Market closed after {MARKET_CLOSE.strftime('%H:%M')}"
 
 
 def get_current_ist_time() -> datetime:
-    """Get current time in IST."""
     return _now_ist()
 
 
 def format_time_for_log() -> str:
-    """Get formatted time string for logging."""
     return _now_ist().strftime("%H:%M:%S IST")
 
 
-# Cached version for high-frequency calls (1 second cache)
+def _cache_minute_key(now: datetime) -> int:
+    """Return a date-aware key so yesterday's state is never reused."""
+    return now.date().toordinal() * 1440 + now.hour * 60 + now.minute
+
+
+def _runtime_cache_flags() -> str:
+    return "|".join(
+        [
+            os.getenv("SESSION_ALLOW_OUT_OF_HOURS", "").lower(),
+            os.getenv("ALLOW_OFFHOURS_TESTING", "").lower(),
+            os.getenv("EXECUTION_MODE", "").lower(),
+            os.getenv("ENABLE_LIVE", "").lower(),
+            os.getenv("ENABLE_LIVE_TRADING", "").lower(),
+            os.getenv("SAFE_START_TIME", "").lower(),
+            os.getenv("SAFE_END_TIME", "").lower(),
+            os.getenv("MARKET_OPEN_TIME", "").lower(),
+            os.getenv("MARKET_CLOSE_TIME", "").lower(),
+            os.getenv("NSE_ADDITIONAL_HOLIDAYS", "").lower(),
+            os.getenv("NSE_REMOVED_HOLIDAYS", "").lower(),
+        ]
+    )
+
+
 @lru_cache(maxsize=128)
 def _cached_market_hours_check(minute_key: int, override_flag: str) -> bool:
-    """Internal cached check - cache key changes every minute + override state."""
+    del minute_key, override_flag
     return is_market_hours(allow_override=True)
 
 
 @lru_cache(maxsize=128)
 def _cached_time_status_check(minute_key: int, override_flag: str) -> tuple[bool, str]:
+    del minute_key, override_flag
     return get_time_status()
 
 
 def get_time_status_cached() -> tuple[bool, str]:
-    now = datetime.now(IST)
-    minute_key = now.hour * 60 + now.minute
-    override_flag = "|".join(
-        [
-            os.getenv("SESSION_ALLOW_OUT_OF_HOURS", "").lower(),
-            os.getenv("ALLOW_OFFHOURS_TESTING", "").lower(),
-            os.getenv("EXECUTION_MODE", "").lower(),
-            os.getenv("ENABLE_LIVE", "").lower(),
-            os.getenv("ENABLE_LIVE_TRADING", "").lower(),
-            os.getenv("SAFE_START_TIME", "").lower(),
-            os.getenv("SAFE_END_TIME", "").lower(),
-            os.getenv("MARKET_OPEN_TIME", "").lower(),
-            os.getenv("MARKET_CLOSE_TIME", "").lower(),
-        ]
-    )
-    return _cached_time_status_check(minute_key, override_flag)
+    now = _now_ist()
+    return _cached_time_status_check(_cache_minute_key(now), _runtime_cache_flags())
 
 
 def is_market_hours_cached() -> bool:
-    """
-    Cached version of is_market_hours for high-frequency tick processing.
-    Cache refreshes every minute and when SESSION_ALLOW_OUT_OF_HOURS changes.
-    """
-    now = datetime.now(IST)
-    minute_key = now.hour * 60 + now.minute
-    override_flag = "|".join(
-        [
-            os.getenv("SESSION_ALLOW_OUT_OF_HOURS", "").lower(),
-            os.getenv("ALLOW_OFFHOURS_TESTING", "").lower(),
-            os.getenv("EXECUTION_MODE", "").lower(),
-            os.getenv("ENABLE_LIVE", "").lower(),
-            os.getenv("ENABLE_LIVE_TRADING", "").lower(),
-            os.getenv("SAFE_START_TIME", "").lower(),
-            os.getenv("SAFE_END_TIME", "").lower(),
-            os.getenv("MARKET_OPEN_TIME", "").lower(),
-            os.getenv("MARKET_CLOSE_TIME", "").lower(),
-        ]
-    )
-    return _cached_market_hours_check(minute_key, override_flag)
+    """Return cached safe-window state, refreshed each IST calendar minute."""
+    now = _now_ist()
+    return _cached_market_hours_check(_cache_minute_key(now), _runtime_cache_flags())
 
 
 __all__ = [
@@ -400,8 +389,11 @@ __all__ = [
     "get_current_ist_time",
     "format_time_for_log",
     "get_market_session_state",
+    "get_runtime_market_mode",
     "MarketState",
     "get_market_state",
+    "exchange_holiday_name",
+    "is_exchange_holiday",
     "IST",
     "MARKET_OPEN",
     "SAFE_START",
@@ -412,4 +404,8 @@ __all__ = [
     "is_nifty_index_symbol",
     "is_nifty_future_symbol",
     "is_nifty_option_symbol",
+    "post_market_quiet_mode_enabled",
+    "post_market_basket_refresh_seconds",
+    "post_market_market_data_summary_seconds",
+    "post_market_suppress_candle_gap_warnings",
 ]

--- a/src/nifty_scalper_bot/utils/nse_calendar.py
+++ b/src/nifty_scalper_bot/utils/nse_calendar.py
@@ -1,0 +1,86 @@
+"""Canonical NSE equity-derivatives holiday calendar.
+
+The built-in 2026 dates follow the NSE F&O trading-holiday circular. Runtime
+add/remove overrides support exceptional exchange notices without weakening the
+normal fail-closed session gate.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import date
+from functools import lru_cache
+from typing import Mapping
+
+
+NSE_FO_HOLIDAYS_BY_YEAR: Mapping[int, Mapping[date, str]] = {
+    2026: {
+        date(2026, 1, 26): "Republic Day",
+        date(2026, 3, 3): "Holi",
+        date(2026, 3, 26): "Shri Ram Navami",
+        date(2026, 3, 31): "Shri Mahavir Jayanti",
+        date(2026, 4, 3): "Good Friday",
+        date(2026, 4, 14): "Dr. Baba Saheb Ambedkar Jayanti",
+        date(2026, 5, 1): "Maharashtra Day",
+        date(2026, 5, 28): "Bakri Id",
+        date(2026, 6, 26): "Muharram",
+        date(2026, 9, 14): "Ganesh Chaturthi",
+        date(2026, 10, 2): "Mahatma Gandhi Jayanti",
+        date(2026, 10, 20): "Dussehra",
+        date(2026, 11, 10): "Diwali-Balipratipada",
+        date(2026, 11, 24): "Prakash Gurpurb Sri Guru Nanak Dev",
+        date(2026, 12, 25): "Christmas",
+    }
+}
+
+
+def _parse_dates(raw: str | None) -> frozenset[date]:
+    parsed: set[date] = set()
+    for item in str(raw or "").split(","):
+        value = item.strip()
+        if not value:
+            continue
+        try:
+            parsed.add(date.fromisoformat(value))
+        except ValueError:
+            continue
+    return frozenset(parsed)
+
+
+@lru_cache(maxsize=32)
+def _runtime_overrides(
+    additional_raw: str,
+    removed_raw: str,
+) -> tuple[frozenset[date], frozenset[date]]:
+    return _parse_dates(additional_raw), _parse_dates(removed_raw)
+
+
+def holiday_name(day: date) -> str | None:
+    """Return the NSE F&O holiday name for ``day`` or ``None``."""
+    additional, removed = _runtime_overrides(
+        os.getenv("NSE_ADDITIONAL_HOLIDAYS", ""),
+        os.getenv("NSE_REMOVED_HOLIDAYS", ""),
+    )
+    if day in removed:
+        return None
+    if day in additional:
+        return "Exchange holiday (runtime override)"
+    return NSE_FO_HOLIDAYS_BY_YEAR.get(day.year, {}).get(day)
+
+
+def is_holiday(day: date) -> bool:
+    """Return whether ``day`` is an NSE equity-derivatives holiday."""
+    return holiday_name(day) is not None
+
+
+def calendar_available(year: int) -> bool:
+    """Return whether a built-in holiday calendar exists for ``year``."""
+    return int(year) in NSE_FO_HOLIDAYS_BY_YEAR
+
+
+__all__ = [
+    "NSE_FO_HOLIDAYS_BY_YEAR",
+    "calendar_available",
+    "holiday_name",
+    "is_holiday",
+]

--- a/src/nifty_scalper_bot/utils/runtime_session_guards.py
+++ b/src/nifty_scalper_bot/utils/runtime_session_guards.py
@@ -1,0 +1,63 @@
+"""Install cross-cutting market-session guards at package startup.
+
+This module keeps transport code independent of contract-selection logic while
+ensuring its private clock-window check also respects the canonical NSE holiday
+calendar. The installation is idempotent and does not alter custom intraday
+start/end times or off-hours test mode.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from threading import Lock
+from typing import Any, Callable
+
+from nifty_scalper_bot.utils.smart_symbol import is_nse_trading_day
+
+_INSTALL_LOCK = Lock()
+_INSTALLED = False
+
+
+def install_websocket_market_calendar_guard() -> bool:
+    """Make WebSocket watchdog/reconnect windows holiday-aware.
+
+    Returns ``True`` when the class is guarded after this call. The original
+    method remains authoritative for custom time-window and disabled-window
+    behavior; the wrapper adds only the missing exchange-calendar decision.
+    """
+    global _INSTALLED
+    with _INSTALL_LOCK:
+        if _INSTALLED:
+            return True
+        try:
+            from nifty_scalper_bot.streaming.websocket_manager import WebSocketManager
+        except Exception:
+            return False
+
+        original: Callable[[Any], bool] = WebSocketManager._is_within_trading_window
+        if bool(getattr(original, "_nse_calendar_guard", False)):
+            _INSTALLED = True
+            return True
+
+        def holiday_aware_window(self: Any) -> bool:
+            if not bool(getattr(self, "_trading_window_enabled", True)):
+                return original(self)
+            timezone = getattr(self, "_trading_tz", None)
+            try:
+                now = datetime.now(timezone) if timezone is not None else datetime.now()
+                if not is_nse_trading_day(now.date()):
+                    return False
+            except Exception:
+                # Fail back to the existing transport window logic. Trading and
+                # order arming retain their independent fail-closed gates.
+                pass
+            return original(self)
+
+        setattr(holiday_aware_window, "_nse_calendar_guard", True)
+        setattr(holiday_aware_window, "_unguarded_window", original)
+        WebSocketManager._is_within_trading_window = holiday_aware_window
+        _INSTALLED = True
+        return True
+
+
+__all__ = ["install_websocket_market_calendar_guard"]

--- a/src/nifty_scalper_bot/utils/runtime_session_guards.py
+++ b/src/nifty_scalper_bot/utils/runtime_session_guards.py
@@ -1,13 +1,8 @@
-"""Install cross-cutting market-session guards at package startup.
-
-This module keeps transport code independent of contract-selection logic while
-ensuring its private clock-window check also respects the canonical NSE holiday
-calendar. The installation is idempotent and does not alter custom intraday
-start/end times or off-hours test mode.
-"""
+"""Install cross-cutting market-session guards for streaming transport."""
 
 from __future__ import annotations
 
+import time
 from datetime import datetime
 from threading import Lock
 from typing import Any, Callable
@@ -19,43 +14,80 @@ _INSTALLED = False
 
 
 def install_websocket_market_calendar_guard() -> bool:
-    """Make WebSocket watchdog/reconnect windows holiday-aware.
+    """Make WebSocket liveness, reconnect and close handling session-aware.
 
-    Returns ``True`` when the class is guarded after this call. The original
-    method remains authoritative for custom time-window and disabled-window
-    behavior; the wrapper adds only the missing exchange-calendar decision.
+    The original transport time-window logic remains authoritative for custom
+    intraday start/end times. The wrapper adds the missing NSE holiday decision
+    and prevents normal off-session code-1006 closes from being escalated or
+    repeatedly reconnected.
     """
     global _INSTALLED
     with _INSTALL_LOCK:
         if _INSTALLED:
             return True
         try:
-            from nifty_scalper_bot.streaming.websocket_manager import WebSocketManager
+            from nifty_scalper_bot.streaming.websocket_manager import (
+                ConnectionState,
+                WebSocketManager,
+            )
         except Exception:
             return False
 
-        original: Callable[[Any], bool] = WebSocketManager._is_within_trading_window
-        if bool(getattr(original, "_nse_calendar_guard", False)):
+        original_window: Callable[[Any], bool] = (
+            WebSocketManager._is_within_trading_window
+        )
+        if bool(getattr(original_window, "_nse_calendar_guard", False)):
             _INSTALLED = True
             return True
+        original_close: Callable[[Any, Any, int, str], None] = WebSocketManager._on_close
 
         def holiday_aware_window(self: Any) -> bool:
             if not bool(getattr(self, "_trading_window_enabled", True)):
-                return original(self)
+                return original_window(self)
             timezone = getattr(self, "_trading_tz", None)
             try:
                 now = datetime.now(timezone) if timezone is not None else datetime.now()
                 if not is_nse_trading_day(now.date()):
                     return False
             except Exception:
-                # Fail back to the existing transport window logic. Trading and
-                # order arming retain their independent fail-closed gates.
+                # Fall back to the existing transport window logic. Order arming
+                # retains independent fail-closed session and readiness gates.
                 pass
-            return original(self)
+            return original_window(self)
+
+        def session_aware_close(self: Any, ws: Any, code: int, reason: str) -> None:
+            if int(code or 0) == 1006 and not holiday_aware_window(self):
+                try:
+                    self._connected.clear()
+                    self._state = ConnectionState.DISCONNECTED
+                    self._last_disconnect_at = time.time()
+                    self._stream_health = "idle"
+                    callback = getattr(self, "_on_disconnect_callback", None)
+                    if callable(callback):
+                        callback()
+                    self._logger.info(
+                        "WEBSOCKET_IDLE_CLOSED code=1006 reason=%s action=no_reconnect",
+                        reason or "closing_handshake_timeout",
+                        extra={
+                            "event": "WEBSOCKET_IDLE_CLOSED",
+                            "code": 1006,
+                            "reason": reason or "closing_handshake_timeout",
+                            "action": "no_reconnect",
+                        },
+                    )
+                    return
+                except Exception:
+                    # Preserve the original handler if the defensive quiet-close
+                    # path cannot update a legacy manager instance safely.
+                    pass
+            original_close(self, ws, code, reason)
 
         setattr(holiday_aware_window, "_nse_calendar_guard", True)
-        setattr(holiday_aware_window, "_unguarded_window", original)
+        setattr(holiday_aware_window, "_unguarded_window", original_window)
+        setattr(session_aware_close, "_nse_session_close_guard", True)
+        setattr(session_aware_close, "_unguarded_close", original_close)
         WebSocketManager._is_within_trading_window = holiday_aware_window
+        WebSocketManager._on_close = session_aware_close
         _INSTALLED = True
         return True
 

--- a/src/nifty_scalper_bot/utils/smart_symbol.py
+++ b/src/nifty_scalper_bot/utils/smart_symbol.py
@@ -1,42 +1,33 @@
 # src/nifty_scalper_bot/utils/smart_symbol.py
 #
-# ⚠️  LEGACY CE/PE SYMBOL-BUILDING FUNCTIONS REMOVED.
-#
-# All option contract selection now goes through:
-#   core/contract_selector.py  → get_atm_contracts(kite, underlying_price)
-#   core/instrument_manager.py → InstrumentManager.get_token(symbol)
-#   core/hydration.py          → hydrate(kite, token)
-#
-# Keeping only the pure date/calendar utilities that risk and strategy
-# modules legitimately depend on.
+# Legacy CE/PE symbol-building functions were removed. This module retains only
+# pure date/calendar helpers used by risk, expiry and orchestration code.
 
-from datetime import datetime, timedelta, date
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta
 from zoneinfo import ZoneInfo
-import logging
 
-logger = logging.getLogger(__name__)
+from nifty_scalper_bot.utils.nse_calendar import NSE_FO_HOLIDAYS_BY_YEAR, is_holiday
 
 IST = ZoneInfo("Asia/Kolkata")
-WEEKLY_EXPIRY_WEEKDAY = 1  # Tuesday (0=Mon, 1=Tue, …)
+WEEKLY_EXPIRY_WEEKDAY = 1  # Tuesday (0=Mon, 1=Tue, ...)
 
-# NSE market holidays — update annually
+# Backward-compatible set used by existing imports and diagnostics.
 NSE_HOLIDAYS = {
-    date(2026, 1, 26),   # Republic Day
-    date(2026, 3, 20),   # Id-ul-Fitr
-    date(2026, 4, 14),   # Dr. Baba Saheb Ambedkar Jayanti
-    date(2026, 5, 1),    # Maharashtra Day
-    date(2026, 10, 2),   # Gandhi Jayanti
-    date(2026, 12, 25),  # Christmas
+    holiday
+    for holidays in NSE_FO_HOLIDAYS_BY_YEAR.values()
+    for holiday in holidays
 }
 
 
 def is_nse_trading_day(day: date) -> bool:
-    """Return True when *day* is a weekday and not in the project NSE holiday set."""
-    return day.weekday() < 5 and day not in NSE_HOLIDAYS
+    """Return whether ``day`` is a weekday and not an NSE F&O holiday."""
+    return day.weekday() < 5 and not is_holiday(day)
 
 
 def next_nse_trading_day(start_day: date) -> date:
-    """Return the first NSE trading day on or after *start_day*."""
+    """Return the first NSE trading day on or after ``start_day``."""
     day = start_day
     for _ in range(14):
         if is_nse_trading_day(day):
@@ -46,44 +37,33 @@ def next_nse_trading_day(start_day: date) -> date:
 
 
 def now_ist() -> datetime:
-    """Return current datetime in IST."""
+    """Return the current datetime in IST."""
     return datetime.now(IST)
 
 
 def get_actual_expiry_date(start_date: date, target_weekday: int) -> date:
-    """Return the nearest *target_weekday* on or after *start_date*, adjusted
-    backwards past NSE holidays and weekends.
-
-    Args:
-        start_date: Reference date.
-        target_weekday: 0=Mon … 6=Sun.
-
-    Returns:
-        date: Adjusted expiry date.
-
-    Raises:
-        None.
-    """
+    """Return the next target weekday, moved backward over closed sessions."""
     days_ahead = target_weekday - start_date.weekday()
     if days_ahead < 0:
         days_ahead += 7
     expiry = start_date + timedelta(days=days_ahead)
-    while expiry in NSE_HOLIDAYS or expiry.weekday() >= 5:
+    while not is_nse_trading_day(expiry):
         expiry -= timedelta(days=1)
     return expiry
 
 
 def next_weekday(start_date: date, target_weekday: int) -> date:
-    """Holiday-adjusted *target_weekday* on or after *start_date*.
-
-    Args:
-        start_date: Reference date.
-        target_weekday: 0=Mon … 6=Sun.
-
-    Returns:
-        date: Adjusted date.
-
-    Raises:
-        None.
-    """
+    """Return the holiday-adjusted target weekday on or after ``start_date``."""
     return get_actual_expiry_date(start_date, target_weekday)
+
+
+__all__ = [
+    "IST",
+    "NSE_HOLIDAYS",
+    "WEEKLY_EXPIRY_WEEKDAY",
+    "get_actual_expiry_date",
+    "is_nse_trading_day",
+    "next_nse_trading_day",
+    "next_weekday",
+    "now_ist",
+]

--- a/tests/streaming/test_websocket_holiday_guard.py
+++ b/tests/streaming/test_websocket_holiday_guard.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from datetime import datetime, time as dtime
+from zoneinfo import ZoneInfo
+
+from nifty_scalper_bot.streaming.websocket_manager import WebSocketManager
+from nifty_scalper_bot.utils import runtime_session_guards
+
+
+class _FixedHolidayClock(datetime):
+    @classmethod
+    def now(cls, tz=None):
+        value = cls(2026, 6, 26, 11, 52)
+        return value.replace(tzinfo=tz) if tz is not None else value
+
+
+class _FixedOpenClock(datetime):
+    @classmethod
+    def now(cls, tz=None):
+        value = cls(2026, 6, 29, 11, 52)
+        return value.replace(tzinfo=tz) if tz is not None else value
+
+
+def _manager(*, window_enabled: bool = True) -> WebSocketManager:
+    manager = object.__new__(WebSocketManager)
+    manager._trading_window_enabled = window_enabled
+    manager._trading_tz = ZoneInfo("Asia/Kolkata")
+    manager._trading_start = dtime(9, 15)
+    manager._trading_end = dtime(15, 30)
+    manager._logger = __import__("logging").getLogger(__name__)
+    return manager
+
+
+def test_websocket_window_is_closed_on_nse_holiday(monkeypatch) -> None:
+    monkeypatch.setattr(runtime_session_guards, "datetime", _FixedHolidayClock)
+    assert _manager()._is_within_trading_window() is False
+
+
+def test_websocket_window_remains_open_on_regular_weekday(monkeypatch) -> None:
+    monkeypatch.setattr(runtime_session_guards, "datetime", _FixedOpenClock)
+    assert _manager()._is_within_trading_window() is True
+
+
+def test_disabled_transport_window_preserves_existing_override(monkeypatch) -> None:
+    monkeypatch.setattr(runtime_session_guards, "datetime", _FixedHolidayClock)
+    assert _manager(window_enabled=False)._is_within_trading_window() is True

--- a/tests/utils/test_alert_watchdog_dedupe.py
+++ b/tests/utils/test_alert_watchdog_dedupe.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import logging
+
+from nifty_scalper_bot.utils.alerts import AlertLogHandler
+
+
+def _record(message: str, *, name: str = "nifty_scalper_bot.strategies.runner") -> logging.LogRecord:
+    return logging.LogRecord(
+        name=name,
+        level=logging.WARNING,
+        pathname=__file__,
+        lineno=1,
+        msg=message,
+        args=(),
+        exc_info=None,
+        func="watchdog",
+    )
+
+
+def test_dynamic_strategy_stall_messages_share_one_semantic_cooldown() -> None:
+    emitted: list[dict[str, str]] = []
+    clock = iter([100.0, 220.0, 1001.0])
+    handler = AlertLogHandler(
+        emitted.append,
+        repeat_window_seconds=300.0,
+        persistent_repeat_window_seconds=900.0,
+        clock=lambda: next(clock),
+    )
+
+    handler.emit(_record("Strategy evaluation stalled >120s (once per 120s)"))
+    handler.emit(_record("Strategy evaluation stalled >241s (once per 120s)"))
+    handler.emit(_record("Strategy evaluation stalled >900s (once per 120s)"))
+
+    assert len(emitted) == 2
+    assert emitted[0]["key"].endswith(":strategy_evaluation_stalled")
+    assert emitted[1]["key"] == emitted[0]["key"]
+
+
+def test_ticks_flowing_stall_and_1006_are_independently_throttled() -> None:
+    emitted: list[dict[str, str]] = []
+    times = iter([1.0, 2.0, 3.0, 4.0])
+    handler = AlertLogHandler(
+        emitted.append,
+        persistent_repeat_window_seconds=900.0,
+        clock=lambda: next(times),
+    )
+
+    handler.emit(_record("Strategy eval genuinely stalled while ticks flowing (>90s)"))
+    handler.emit(_record("Strategy eval genuinely stalled while ticks flowing (>180s)"))
+    handler.emit(
+        _record(
+            "WEBSOCKET_DEGRADED code=1006 reason=closing_handshake_timeout",
+            name="nifty_scalper_bot.streaming.websocket_manager",
+        )
+    )
+    handler.emit(
+        _record(
+            "WEBSOCKET_DEGRADED code=1006 reason=closing_handshake_timeout",
+            name="nifty_scalper_bot.streaming.websocket_manager",
+        )
+    )
+
+    assert len(emitted) == 2
+    assert emitted[0]["key"].endswith(":strategy_eval_ticks_flowing_stalled")
+    assert emitted[1]["key"].endswith(":websocket_degraded_1006")
+
+
+def test_unmatched_warning_repeats_are_not_hidden() -> None:
+    emitted: list[dict[str, str]] = []
+    handler = AlertLogHandler(emitted.append, clock=lambda: 10.0)
+    record = _record("Unexpected warning that needs every occurrence")
+
+    handler.emit(record)
+    handler.emit(record)
+
+    assert len(emitted) == 2

--- a/tests/utils/test_nse_holiday_session.py
+++ b/tests/utils/test_nse_holiday_session.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from nifty_scalper_bot.utils import market_hours
+from nifty_scalper_bot.utils.nse_calendar import holiday_name, is_holiday
+from nifty_scalper_bot.utils.smart_symbol import is_nse_trading_day
+
+
+def test_muharram_2026_is_closed_during_normal_market_clock(monkeypatch) -> None:
+    now = datetime(2026, 6, 26, 11, 52, tzinfo=market_hours.IST)
+    monkeypatch.setattr(market_hours, "_now_ist", lambda: now)
+    monkeypatch.setenv("EXECUTION_MODE", "LIVE")
+    monkeypatch.setenv("ENABLE_LIVE", "true")
+
+    assert holiday_name(now.date()) == "Muharram"
+    assert is_holiday(now.date()) is True
+    assert is_nse_trading_day(now.date()) is False
+    assert market_hours.get_market_state() is market_hours.MarketState.CLOSED
+    assert market_hours.get_runtime_market_mode() == "HOLIDAY"
+    assert market_hours.get_market_session_state(now) == "closed"
+    assert market_hours.is_market_open_session() is False
+    assert market_hours.is_safe_entry_window() is False
+    allowed, reason = market_hours.get_time_status()
+    assert allowed is False
+    assert reason == "Exchange holiday (Muharram)"
+
+
+def test_regular_weekday_remains_open(monkeypatch) -> None:
+    now = datetime(2026, 6, 29, 11, 52, tzinfo=market_hours.IST)
+    monkeypatch.setattr(market_hours, "_now_ist", lambda: now)
+    monkeypatch.setenv("EXECUTION_MODE", "LIVE")
+    monkeypatch.setenv("ENABLE_LIVE", "true")
+
+    assert is_nse_trading_day(now.date()) is True
+    assert market_hours.get_market_state() is market_hours.MarketState.OPEN
+    assert market_hours.get_runtime_market_mode() == "OPEN"
+    assert market_hours.is_market_open_session() is True
+    assert market_hours.is_safe_entry_window() is True
+
+
+def test_market_hours_cache_key_changes_across_calendar_days() -> None:
+    first = datetime(2026, 6, 26, 11, 52, tzinfo=market_hours.IST)
+    second = datetime(2026, 6, 29, 11, 52, tzinfo=market_hours.IST)
+
+    assert market_hours._cache_minute_key(first) != market_hours._cache_minute_key(second)


### PR DESCRIPTION
## Root cause

The strategy and transport watchdogs treated every weekday inside the clock window as an open NSE session. On an exchange holiday this produced false strategy-stall, pong-timeout and code-1006 degradation alerts. Dynamic ages also bypassed Telegram log deduplication.

## Changes

- Add the canonical 2026 NSE F&O holiday calendar with runtime add/remove overrides.
- Use the same calendar in market-hours, expiry/trading-day utilities and WebSocket watchdog windows.
- Quiet normal off-session WebSocket code-1006 closes without reconnect churn.
- Make cached market-hour keys date-aware.
- Assign stable semantic identities to recurring strategy/WebSocket warnings and throttle them for 15 minutes.
- Preserve unmatched warning repeats and all critical execution/risk alerts.
- Add focused holiday, WebSocket-window and Telegram dedupe regression tests.

No signal scoring, order placement, sizing or risk limits are changed.