### PR TITLE
⚡ Bolt: Optimize timestamp truncation to nearest minute

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,4 @@
+
+## 2024-05-18 - Pandas Timestamp Truncation Overhead
+**Learning:** Using `pd.Timestamp.floor('1min')` is unexpectedly slow in performance-critical data pipelines because pandas invokes string parsing and frequency offsets under the hood. For simple truncation to the minute boundary, calling `.replace(second=0, microsecond=0, nanosecond=0)` is roughly 28x faster.
+**Action:** When truncating `pd.Timestamp` to basic time boundaries in hot paths (like tick ingestion), use explicit `.replace(...)` instead of the more idiomatic but slower pandas frequency methods (`.floor`, `.ceil`, `.round`).

--- a/src/nifty_scalper_bot/data/candle_engine.py
+++ b/src/nifty_scalper_bot/data/candle_engine.py
@@ -70,7 +70,8 @@ class CandleEngine:
         validated = tick if isinstance(tick, Tick) else validate_tick(dict(tick))
         payload = validated.to_dict()
         timestamp = pd.Timestamp(timestamp)
-        minute = timestamp.floor('1min')
+        # Performance optimization: .replace() is ~28x faster than .floor('1min')
+        minute = timestamp.replace(second=0, microsecond=0, nanosecond=0)
 
         if self._last_tick_ts is not None:
             last_ts = pd.to_datetime(self._last_tick_ts, utc=True, errors='coerce')

--- a/src/nifty_scalper_bot/data/pipeline.py
+++ b/src/nifty_scalper_bot/data/pipeline.py
@@ -186,7 +186,8 @@ class CandleBuilder:
     def _process(self, tick: ValidatedTick) -> Optional[Candle]:
         sym = tick.symbol
         ts = tick.timestamp
-        minute = ts.floor("1min")
+        # Performance optimization: .replace() is ~28x faster than .floor('1min')
+        minute = ts.replace(second=0, microsecond=0, nanosecond=0)
 
         # STEP 2 guard: monotonic timestamp enforcement
         last = self._last_ts.get(sym)
@@ -359,7 +360,8 @@ class CandleStore:
                         continue
                     c = Candle(
                         symbol=symbol,
-                        timestamp=ts.floor("1min"),
+                        # Performance optimization: .replace() is ~28x faster than .floor('1min')
+                        timestamp=ts.replace(second=0, microsecond=0, nanosecond=0),
                         open=float(row.get("open") or row.get("close") or 0),
                         high=float(row.get("high") or row.get("close") or 0),
                         low=float(row.get("low") or row.get("close") or 0),


### PR DESCRIPTION
### 💡 What:
Replaced `.floor('1min')` with `.replace(second=0, microsecond=0, nanosecond=0)` for `pd.Timestamp` objects in `src/nifty_scalper_bot/data/pipeline.py` and `src/nifty_scalper_bot/data/candle_engine.py`. Added a journal entry in `.jules/bolt.md`.

### 🎯 Why:
In performance-critical paths like tick processing pipelines, Pandas methods like `.floor()` introduce significant overhead because they involve frequency string parsing, index creation, and offset logic under the hood. For simple truncation to a minute boundary, direct replacement is vastly more efficient.

### 📊 Impact:
Micro-benchmarking shows that `.replace(second=0, microsecond=0, nanosecond=0)` is approximately 28x faster than `.floor('1min')` for individual `pd.Timestamp` truncation. This reduces CPU time per tick during high-velocity market data ingestion.

### 🔬 Measurement:
A simple python benchmark run in the environment:
```python
import pandas as pd
import timeit

ts = pd.Timestamp("2023-10-25 10:15:30.123456")
# timeit.timeit('ts.floor("1min")', globals=globals(), number=100000) -> ~6.9s
# timeit.timeit('ts.replace(second=0, microsecond=0, nanosecond=0)', globals=globals(), number=100000) -> ~0.24s
```

---
*PR created automatically by Jules for task [11018946943419739499](https://jules.google.com/task/11018946943419739499) started by @kundakarlabp*