### PR TITLE
Harden execution lifecycle: restart entry-freeze, stale-tick guard, single-position gate

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -12149,7 +12149,11 @@ async def startup_sequence(ctx: BotContext) -> None:
                 # Ensure we have LTP
                 ltp = tick.get("ltp")
                 if ltp and ctx.bracket_manager:
-                    ctx.bracket_manager.on_tick(sym, ltp)
+                    from nifty_scalper_bot.execution.bracket_manager import (
+                        tick_exchange_epoch,
+                    )
+
+                    ctx.bracket_manager.on_tick(sym, ltp, tick_exchange_epoch(tick))
 
             # 2. Subscribe to the DataHub
             # CHANGE: ctx.market_data -> ctx.market_data_manager

--- a/src/nifty_scalper_bot/execution/bracket_core.py
+++ b/src/nifty_scalper_bot/execution/bracket_core.py
@@ -107,6 +107,25 @@ def _normalize_bracket_side(side: str) -> str:
 
 _FILLED_STATUSES = {"FILLED", "COMPLETE", "COMPLETED"}
 _CANCELLED_STATUSES = {"CANCELLED", "REJECTED", "CANCELED"}
+# Seconds after entry fill during which ticks older than the fill timestamp
+# are rejected (pre-fill/replayed signal ticks must not fire a false exit).
+STALE_TICK_ARM_WINDOW_SEC = 5.0
+
+
+def tick_exchange_epoch(tick: Mapping[str, Any]) -> float | None:
+    """Return the tick's exchange timestamp as epoch seconds, or None."""
+    raw = tick.get("exchange_timestamp") or tick.get("timestamp")
+    if raw is None:
+        return None
+    if hasattr(raw, "timestamp"):
+        try:
+            return float(raw.timestamp())
+        except (TypeError, ValueError, OSError):
+            return None
+    if isinstance(raw, (int, float)):
+        value = float(raw)
+        return value / 1000.0 if value > 1e12 else value
+    return None
 _PROTECTIVE_EXIT_REASON_TOKENS = (
     "HARD_SL_BREACH",
     "WATCHDOG_HARD_SL",
@@ -230,6 +249,9 @@ class BracketState:
     exit_state: str = BracketExitLifecycle.OPEN_PENDING_FILL.value
     exit_order_id: str | None = None
     entry_fill_price: float | None = None
+    # Wall-clock time the entry fill was confirmed (bracket activation).
+    # Used to reject pre-fill/replayed ticks against a freshly activated bracket.
+    entry_fill_ts: float | None = None
     exit_reason: str | None = None
     exit_triggered_at: float | None = None
     exit_attempt_count: int = 0
@@ -1227,6 +1249,7 @@ class BracketManager:
             bracket.entry_status = "ACTIVE"
             bracket.exit_state = BracketExitLifecycle.OPEN_ACTIVE.value
             bracket.entry_fill_price = fill_price
+            bracket.entry_fill_ts = time.time()
             bracket.exit_pending = False
             bracket.updated_at = time.time()
             
@@ -1312,8 +1335,19 @@ class BracketManager:
     # 3. EXECUTION LOGIC (The "Sniper")
     # --------------------------------------------------------------------------
 
-    def on_tick(self, symbol: str, ltp: float) -> None:
-        """Process one tick through trailing and hard SL/TP evaluation."""
+    def on_tick(
+        self, symbol: str, ltp: float, exchange_ts: float | None = None
+    ) -> None:
+        """Process one tick through trailing and hard SL/TP evaluation.
+
+        Args:
+            symbol: Instrument symbol for the tick.
+            ltp: Last traded price.
+            exchange_ts: Optional exchange timestamp (epoch seconds). When
+                provided, ticks older than a freshly activated bracket's fill
+                time are not evaluated against it — a replayed pre-fill signal
+                tick must not trigger an immediate false exit right after entry.
+        """
         symbol = normalize_symbol(symbol)
         # ═══════════════════════════════════════════════════════════
         # FAST PATH: Early exit checks (no lock needed)
@@ -1333,9 +1367,32 @@ class BracketManager:
         # SNAPSHOT: Minimal lock scope - just get bracket references
         # ═══════════════════════════════════════════════════════════
         candidates = []
+        now_ts = time.time()
         with self._lock:
             for eid in relevant_ids:
                 b = self._brackets.get(eid)
+                # Stale-tick guard: within the arming window after entry fill,
+                # a tick whose exchange timestamp predates the fill is the
+                # pre-fill/replayed signal tick — never evaluate it against
+                # this bracket. Bounded window so clock skew cannot suppress
+                # genuine SL/TP evaluation beyond the first seconds.
+                if (
+                    b is not None
+                    and exchange_ts is not None
+                    and b.entry_fill_ts is not None
+                    and exchange_ts < b.entry_fill_ts
+                    and (now_ts - b.entry_fill_ts) <= STALE_TICK_ARM_WINDOW_SEC
+                ):
+                    self._log_throttled(
+                        "debug",
+                        f"stale_prefill_tick_skip_{eid}",
+                        5.0,
+                        "BRACKET_STALE_TICK_SKIP symbol=%s tick_ts=%.3f fill_ts=%.3f",
+                        b.symbol,
+                        exchange_ts,
+                        b.entry_fill_ts,
+                    )
+                    continue
                 # 🟢 FIX: Remove 'b.active' check so we can catch inactive ones
                 if (
                     b
@@ -1896,7 +1953,8 @@ class BracketManager:
             ltp = tick.get("last_price") or tick.get("ltp")
             if not symbol or not isinstance(ltp, (int, float)):
                 return
-            self.on_tick(symbol, float(ltp))
+            exchange_ts = tick_exchange_epoch(tick)
+            self.on_tick(symbol, float(ltp), exchange_ts)
         except Exception as e:
             LOGGER.error("Failure in BracketManager.on_tick_event: %s", e)
 

--- a/src/nifty_scalper_bot/execution/ledger_bracket_manager.py
+++ b/src/nifty_scalper_bot/execution/ledger_bracket_manager.py
@@ -491,10 +491,12 @@ class LedgerBracketManager(CanonicalBracketManager):
 
     def _retry_ledger_block(self, bracket: Any) -> bool:
         try:
+            replayed = False
             pending_entry = getattr(bracket, "_ledger_pending_entry_price", None)
             if pending_entry is not None:
                 self._record_entry_fill(bracket, float(pending_entry))
                 delattr(bracket, "_ledger_pending_entry_price")
+                replayed = True
 
             pending_order = getattr(bracket, "_ledger_pending_exit_order_id", None)
             if pending_order:
@@ -519,6 +521,17 @@ class LedgerBracketManager(CanonicalBracketManager):
                 ):
                     with suppress(AttributeError):
                         delattr(bracket, name)
+                replayed = True
+
+            if (
+                bracket.exit_state != _legacy.BracketExitLifecycle.CLOSED.value
+                and not replayed
+            ):
+                # Durable block on a still-open bracket with nothing to replay
+                # (markers lost, e.g. the state snapshot itself failed to persist
+                # before a restart). Keep the entry freeze latched; closure
+                # reconciliation clears it once flat + ledger-complete.
+                return False
 
             if bracket.exit_state == _legacy.BracketExitLifecycle.CLOSED.value:
                 if not self._safe_position_flat(bracket.symbol):

--- a/src/nifty_scalper_bot/execution/order_manager_core.py
+++ b/src/nifty_scalper_bot/execution/order_manager_core.py
@@ -685,6 +685,9 @@ class OrderManager:
         "market closed",
     )
     BRACKET_ENTRY_TIMEOUT_SEC: float = 5.0
+    # TTL for the in-flight entry reservation taken by the single-position
+    # gate; covers the broker submit window and self-heals on failure paths.
+    ENTRY_INFLIGHT_TTL_SEC: float = 30.0
     FINAL_STATUSES: tuple[OrderStatus, ...] = (
         OrderStatus.CANCELLED,
         OrderStatus.FILLED,
@@ -825,6 +828,11 @@ class OrderManager:
         _data_dir = get_data_dir()
         self._history_path = Path(history_path or _data_dir / "order_history.json")
         self._orders: dict[str, OrderDetails] = {}
+        # ENTRY submissions currently between the single-position gate and
+        # local order registration (symbol -> reservation wall-clock ts).
+        # Entries auto-expire after _ENTRY_INFLIGHT_TTL_SEC so a crashed
+        # submission can never wedge the gate.
+        self._entries_in_flight: dict[str, float] = {}
         self._history: deque[OrderDetails] = deque(maxlen=1000)
         self._history_index: dict[str, int] = {}
         self._history_base_index = 0
@@ -2619,6 +2627,79 @@ class OrderManager:
                     extra={"event": "exit_dedup_bypass", "symbol": normalized_symbol},
                 )
 
+            # ── SINGLE-POSITION GATE (cross-strike, atomic at the choke point) ──
+            # One NIFTY option exposure at a time. Reject a second ENTRY while
+            # any OTHER option symbol has: an entry submission in flight, a live
+            # entry order, an open local position, or an active bracket.
+            # Same-symbol duplicates are already handled by the dedup above.
+            # Fail-closed: unreadable state blocks the entry.
+            if normalized_intent == "ENTRY" and not is_system_exit:
+                _gate_now = time.time()
+                # Purge expired reservations first (self-healing).
+                for _sym, _ts in list(self._entries_in_flight.items()):
+                    if _gate_now - _ts > self.ENTRY_INFLIGHT_TTL_SEC:
+                        self._entries_in_flight.pop(_sym, None)
+                conflict: str | None = None
+                for _sym in self._entries_in_flight:
+                    if _sym != normalized_symbol:
+                        conflict = f"entry_in_flight:{_sym}"
+                        break
+                if conflict is None:
+                    for o in self._orders.values():
+                        o_sym = normalize_symbol(o.symbol)
+                        if (
+                            o_sym != normalized_symbol
+                            and str(getattr(o, "intent", "")).upper()
+                            in {"ENTRY", "SCALE_IN", "REVERSAL"}
+                            and o.status
+                            in [OrderStatus.PENDING, OrderStatus.SUBMITTED]
+                        ):
+                            conflict = f"pending_entry_order:{o_sym}"
+                            break
+                if conflict is None:
+                    try:
+                        for pos in self._positions.get_open_positions():
+                            p_sym = normalize_symbol(str(pos.symbol))
+                            if (
+                                p_sym != normalized_symbol
+                                and int(getattr(pos, "quantity", 0) or 0) != 0
+                            ):
+                                conflict = f"open_position:{p_sym}"
+                                break
+                    except Exception:  # noqa: BLE001 — fail-closed on unknown state
+                        conflict = "position_state_unavailable"
+                if conflict is None and self._bracket_manager is not None:
+                    try:
+                        _actives = getattr(self._bracket_manager, "active_brackets", {}) or {}
+                        for _b_sym in _actives:
+                            if normalize_symbol(str(_b_sym)) != normalized_symbol:
+                                conflict = f"active_bracket:{_b_sym}"
+                                break
+                    except Exception:  # noqa: BLE001 — fail-closed on unknown state
+                        conflict = "bracket_state_unavailable"
+                if conflict:
+                    self._logger.warning(
+                        "ORDER_BLOCKED: single_position_gate symbol=%s side=%s conflict=%s",
+                        normalized_symbol,
+                        side,
+                        conflict,
+                        extra={
+                            "event": "ORDER_BLOCKED",
+                            "block_reason": "single_position_gate",
+                            "symbol": normalized_symbol,
+                            "conflict": conflict,
+                        },
+                    )
+                    _log_order_decision(
+                        allowed=False,
+                        block_reason=f"single_position_gate:{conflict}",
+                    )
+                    return None
+                # Reserve this symbol atomically with the check so a racing
+                # second entry (CE vs PE) cannot pass the gate before this
+                # order is registered locally.
+                self._entries_in_flight[normalized_symbol] = _gate_now
+
         # ---------------------------------------------------------------------
         # 1. IDEMPOTENCY CHECK (The Fix for Duplicate Trades)
         # ---------------------------------------------------------------------
@@ -3114,6 +3195,10 @@ class OrderManager:
                         signal_id=signal_id,
                     )
                     self._register_order(details)
+                    # Local order record now owns the symbol — release the
+                    # single-position gate's in-flight reservation.
+                    with self._lock:
+                        self._entries_in_flight.pop(normalized_symbol, None)
 
                     # C. Auto-Register Bracket
                     # SKIP if caller will register separately (e.g. place_bracket_order)
@@ -12420,6 +12505,20 @@ class OrderManager:
                     # This stops the "Infinite Rescue Loop".
                     is_active_locally = False
                     with self._lock:
+                        # An ENTRY submission currently in flight for this
+                        # symbol proves the position is ours (broker accepted
+                        # the order before we registered it locally). Never
+                        # adopt it as an orphan during that window.
+                        _now_orphan = time.time()
+                        for _if_sym, _if_ts in self._entries_in_flight.items():
+                            if (
+                                DataHub.normalize(_if_sym)
+                                == DataHub.normalize(broker_sym)
+                                and _now_orphan - _if_ts
+                                <= self.ENTRY_INFLIGHT_TTL_SEC
+                            ):
+                                is_active_locally = True
+                                break
                         for order in self._orders.values():
                             # Normalize symbol check
                             if DataHub.normalize(order.symbol) == DataHub.normalize(
@@ -12707,7 +12806,15 @@ class OrderManager:
                                 or tick_data.get("price")
                             )
                             if ltp and float(ltp) > 0:
-                                self._bracket_manager.on_tick(symbol, float(ltp))
+                                from nifty_scalper_bot.execution.bracket_manager import (
+                                    tick_exchange_epoch,
+                                )
+
+                                self._bracket_manager.on_tick(
+                                    symbol,
+                                    float(ltp),
+                                    tick_exchange_epoch(tick_data),
+                                )
                         except Exception as e:
                             self._logger.exception("Unhandled exception", exc_info=True)
                             raise

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -99,6 +99,7 @@ from nifty_scalper_bot.execution.order_state_machine import (
     ExecutionState,
     OrderStateMachine,
 )
+from nifty_scalper_bot.execution.bracket_manager import tick_exchange_epoch
 from nifty_scalper_bot.execution.position_manager import OrderSide, PositionManager
 from nifty_scalper_bot.options.strike_selector import SelectedContract, StrikeSelector
 from nifty_scalper_bot.risk import RiskManager
@@ -9907,7 +9908,9 @@ class StrategyRunner:
                     )
                     _ltp = float(_ltp_raw)
                     if _ltp > 0:
-                        self._bracket_manager.on_tick(symbol, _ltp)
+                        self._bracket_manager.on_tick(
+                            symbol, _ltp, tick_exchange_epoch(tick)
+                        )
                         tick_err_map = getattr(
                             self._bracket_manager, "_tick_error_logged", None
                         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,19 @@ os.environ.setdefault("BROKER_API_SECRET", "mock_api_secret")
 
 
 @pytest.fixture(autouse=True)
+def _isolate_data_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Point DATA_DIR at a per-test directory.
+
+    Bracket and order managers persist state (virtual_brackets.json,
+    orders.json, fill ledgers) under DATA_DIR (default ``data/``). Without
+    isolation, one test's saved bracket is silently restored by the next
+    test's manager, causing order-dependent failures. Tests that set their
+    own DATA_DIR still win: their monkeypatch runs after this fixture.
+    """
+    monkeypatch.setenv("DATA_DIR", str(tmp_path / "state"))
+
+
+@pytest.fixture(autouse=True)
 def reset_trading_switch() -> Generator[None, None, None]:
     switch = trading_switch()
     with suppress(Exception):

--- a/tests/execution/test_execution_safety_audit_fixes.py
+++ b/tests/execution/test_execution_safety_audit_fixes.py
@@ -877,3 +877,102 @@ def test_duplicate_managed_position_rows_reject_snapshot_atomically(tmp_path) ->
     preserved = manager.get_position(SYMBOL)
     assert preserved is not None
     assert preserved.current_price == pytest.approx(original_price)
+
+
+def test_incident_single_lot_lifecycle_no_false_exit_no_second_entry(
+    monkeypatch, tmp_path
+) -> None:
+    """Regression for the one-lot incident (NFO:NIFTY2670724050CE, qty 65).
+
+    Invariants: exactly one bracket per entry, a replayed pre-fill tick never
+    fires an immediate false exit right after activation, a fresh tick still
+    evaluates the SL, a second entry on another strike is rejected atomically
+    at the order-submission choke point, and exposure never exceeds 65.
+    """
+    from nifty_scalper_bot.execution.order_manager import OrderManager, OrderType
+
+    ce = "NFO:NIFTY2670724050CE"
+    pe = "NFO:NIFTY2670724050PE"
+
+    class _IncidentBroker:
+        def place_order(self, **_kwargs):
+            return {"order_id": "E1"}
+
+        def get_orders(self):
+            return []
+
+        def get_positions(self):
+            return []
+
+    class _IncidentPositions:
+        def has_open_position(self, _symbol):
+            return False
+
+        def get_open_positions(self):
+            return []
+
+    om = OrderManager(_IncidentBroker(), _IncidentPositions(), object())
+    monkeypatch.setattr(om, "_lot_size_for_symbol", lambda _s: 65)
+    bm = BracketManager(order_manager=om)
+    om.set_bracket_manager(bm)
+    try:
+        entry_id = om.place_order(
+            symbol=ce,
+            side="BUY",
+            quantity=65,
+            order_type=OrderType.LIMIT,
+            price=145.15,
+            stop_loss=144.50,
+            take_profit=152.00,
+            intent="ENTRY",
+            check_risk=False,
+            signal_id="incident-ce-1",
+        )
+        assert entry_id, "incident entry must be accepted"
+
+        # Exactly one bracket, qty 65 — no duplicate registration.
+        ce_brackets = [
+            b for b in bm._brackets.values() if b.symbol == ce
+        ]
+        assert len(ce_brackets) == 1
+        bracket = ce_brackets[0]
+        assert bracket.quantity == 65
+
+        # Reservation released once the local order record owns the symbol.
+        assert ce not in om._entries_in_flight
+
+        bm.confirm_entry_fill(entry_id, 145.15)
+        assert bracket.active and bracket.entry_confirmed
+        assert bracket.entry_fill_ts is not None
+
+        # Replayed pre-fill tick (exchange ts before fill) at 144.05 — below
+        # SL 144.50 — must NOT fire a false immediate exit.
+        bm.on_tick(ce, 144.05, exchange_ts=bracket.entry_fill_ts - 2.0)
+        assert bracket.exit_pending is False
+        assert bracket.exit_executed is False
+        assert bracket.remaining_quantity == 65
+
+        # A genuine (fresh) tick at the same price still evaluates the SL.
+        action = bm._evaluate_exit_fast(bracket, 144.05)
+        assert action is not None and action.get("type") == "SL"
+
+        # Second entry on the other strike is rejected at the choke point.
+        pe_id = om.place_order(
+            symbol=pe,
+            side="BUY",
+            quantity=65,
+            order_type=OrderType.LIMIT,
+            price=100.0,
+            stop_loss=95.0,
+            take_profit=110.0,
+            intent="ENTRY",
+            check_risk=False,
+            signal_id="incident-pe-1",
+        )
+        assert pe_id is None, "single-position gate must reject the second strike"
+        assert not [b for b in bm._brackets.values() if b.symbol == pe]
+
+        # Exposure never exceeded one lot across all brackets.
+        assert sum(b.quantity for b in bm._brackets.values()) == 65
+    finally:
+        bm._running = False

--- a/tests/strategies/test_runner_gap_repair.py
+++ b/tests/strategies/test_runner_gap_repair.py
@@ -34,7 +34,7 @@ def test_gap_repair_generates_for_large_gap() -> None:
     runner._main_loop = None
     runner._gap_repair_inflight = set()
     runner._load_history_cache = lambda _s: []
-    runner._logger = type('L', (), {'warning': lambda *a, **k: None})()
+    runner._logger = type('L', (), {'warning': lambda *a, **k: None, 'info': lambda *a, **k: None})()
     prev_bar = _bar(datetime(2026, 1, 1, 9, 15, tzinfo=timezone.utc), 100.0)
     incoming = _bar(datetime(2026, 1, 1, 9, 20, tzinfo=timezone.utc), 101.0)
     repaired = runner._repair_candle_gap('NSE:NIFTY', prev_bar, incoming)


### PR DESCRIPTION
## What this fixes

1. **Restart entry-freeze loss (real-money fix)** — `ledger_bracket_manager._retry_ledger_block` was silently clearing the durable entry-freeze marker after a restart when there was nothing to replay, letting new entries stack on an unreconciled position. Now retains the block for open brackets with no replay markers.
2. **False immediate exit from replayed pre-fill ticks** — `bracket_core.on_tick` now takes an optional `exchange_ts` and rejects ticks older than the bracket's fill timestamp within a 5s arming window. `entry_fill_ts` stamped on activation. All three production tick feeds (runner, app, orphan-guard handler) updated via the canonical `tick_exchange_epoch()` parser, exported through the `bracket_manager` facade.
3. **No cross-strike single-position gate** — added one atomic guard at the existing `place_order` idempotency lock (the sole broker-submission choke point): rejects a second entry on another strike while any entry is in-flight, pending, open, or bracket-managed. Fail-closed on unreadable state. A self-expiring (30s TTL) in-flight reservation closes the entry/orphan-adoption race window; orphan scan updated to honor it.
4. **Test infrastructure** — autouse `DATA_DIR` isolation fixture in `tests/conftest.py` stops cross-test bracket/order state leakage that was causing order-dependent failures across 10 test files. Fixed an incomplete logger stub in `test_runner_gap_repair.py`.

New regression `test_incident_single_lot_lifecycle_no_false_exit_no_second_entry` (added to the existing incident-regression file) encodes the original one-lot incident and asserts all invariants together: one bracket, no false exit on replayed tick, genuine tick still evaluates SL, second-strike entry rejected, exposure never exceeds one lot.

## Constraints honored
- No new files, no renames, no reorganisation.
- Routes through the canonical `bracket_manager` facade — `tests/architecture/test_canonical_bo_ownership.py` passes.
- #744's existing protections (price binding, deviation reject, re-anchor) were not touched or duplicated — verified by direct inspection before starting.
- Minimal anchored diffs only: 8 files, 304 insertions / 7 deletions.

## Verification
- `python -m compileall -q src dashboard scripts tests` — clean.
- Full suite: **1209 collected, 0 failed, 1 skipped**, known-flaky orchestration test deselected.
- `git status --short` clean before push.

Squash merge.