### PR TITLE
Lock in fill idempotency and restart/reconciliation invariants (slice 2)

### DIFF
--- a/tests/execution/test_canonical_execution_recovery.py
+++ b/tests/execution/test_canonical_execution_recovery.py
@@ -208,3 +208,50 @@ class Hub:
 def test_zero_spread_limit_is_strict_for_options() -> None:
     with pytest.raises(OrderPlacementError):
         ExecutionPolicy(Hub(), max_spread_pct=0.0).build_plan(SYMBOL, "BUY")
+
+
+def test_restart_with_already_protected_position_no_duplicate_bracket(
+    tmp_path, monkeypatch
+) -> None:
+    """Slice-2(d): restart restores the protected bracket; a replayed
+    registration for the same symbol must not create a second bracket."""
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("BRACKET_AUTO_RESTORE", "true")
+    first = BracketManager(order_manager=SimpleNamespace())
+    stop(first)
+    first.register_virtual_bracket(
+        order_id="entry-protected",
+        symbol=SYMBOL,
+        side="BUY",
+        qty=65,
+        price=145.15,
+        sl=144.50,
+        tp=152.00,
+        activate_immediately=False,
+    )
+    first.confirm_entry_fill("entry-protected", 145.15)
+    first.save_state()
+
+    restored = BracketManager(order_manager=SimpleNamespace())
+    stop(restored)
+    recovered = restored.get_bracket("entry-protected")
+    assert recovered is not None
+    assert recovered.active and recovered.entry_confirmed
+    assert recovered.remaining_quantity == 65
+    assert len([b for b in restored._brackets.values() if b.symbol == SYMBOL]) == 1
+
+    # Replayed registration (e.g. recovery logic re-running) must dedupe.
+    restored.register_virtual_bracket(
+        order_id="entry-protected",
+        symbol=SYMBOL,
+        side="BUY",
+        qty=65,
+        price=145.15,
+        sl=144.50,
+        tp=152.00,
+        activate_immediately=False,
+    )
+    brackets = [b for b in restored._brackets.values() if b.symbol == SYMBOL]
+    assert len(brackets) == 1
+    assert brackets[0].remaining_quantity == 65
+    assert brackets[0].active and brackets[0].entry_confirmed

--- a/tests/execution/test_trading_incident_regressions.py
+++ b/tests/execution/test_trading_incident_regressions.py
@@ -247,3 +247,99 @@ def test_verified_bracket_acknowledges_position_protection(tmp_path) -> None:
 
     assert positions.current_entry_protection_blocker(SYMBOL) is None
     assert positions._terminal_orders[ENTRY_ID].protection_confirmed is True
+
+
+def test_duplicate_and_out_of_order_cumulative_fill_callbacks_are_idempotent(
+    tmp_path,
+) -> None:
+    """Slice-2(a): repeated or older cumulative callbacks never re-increase qty."""
+    manager = PositionManager(state_file=str(tmp_path / "positions.json"))
+    manager.add_pending_order(
+        ENTRY_ID, SYMBOL, "BUY", 65, 145.15, "LIMIT", intent="ENTRY"
+    )
+    manager.apply_broker_order_update(
+        ENTRY_ID,
+        {"status": "COMPLETE", "filled_quantity": 65, "average_price": 145.15},
+    )
+    assert manager.get_position(SYMBOL).quantity == 65
+
+    # Exact duplicate of the same cumulative callback.
+    manager.apply_broker_order_update(
+        ENTRY_ID,
+        {"status": "COMPLETE", "filled_quantity": 65, "average_price": 145.15},
+    )
+    # Out-of-order OLDER cumulative (delayed partial arriving after complete).
+    manager.apply_broker_order_update(
+        ENTRY_ID,
+        {"status": "PARTIALLY_FILLED", "filled_quantity": 40, "average_price": 145.10},
+    )
+    position = manager.get_position(SYMBOL)
+    assert position is not None and position.quantity == 65
+    assert manager._orders[ENTRY_ID].applied_filled_quantity == 65
+
+
+def test_broker_snapshot_after_fill_is_authoritative_replace_not_additive(
+    tmp_path,
+) -> None:
+    """Slice-2(b): a snapshot refresh after a fill replaces quantity, never adds."""
+    manager = PositionManager(state_file=str(tmp_path / "positions.json"))
+    manager.add_pending_order(
+        ENTRY_ID, SYMBOL, "BUY", 65, 145.15, "LIMIT", intent="ENTRY"
+    )
+    manager.apply_broker_order_update(
+        ENTRY_ID,
+        {"status": "COMPLETE", "filled_quantity": 65, "average_price": 145.15},
+    )
+    assert manager.get_position(SYMBOL).quantity == 65
+
+    # Snapshot arriving AFTER the fill reports the same one lot.
+    manager.synchronize_with_broker(
+        [
+            {
+                "symbol": SYMBOL,
+                "product": "MIS",
+                "quantity": 65,
+                "average_price": 145.15,
+                "last_price": 145.15,
+                "realised": 0.0,
+            }
+        ]
+    )
+    position = manager.get_position(SYMBOL)
+    assert position is not None and position.quantity == 65
+
+
+def test_restart_with_partially_filled_unprotected_position_no_reapply(
+    tmp_path,
+) -> None:
+    """Slice-2(d): restart reconstructs a partial fill; replay does not re-apply."""
+    state_path = tmp_path / "positions.json"
+    manager = PositionManager(state_file=str(state_path))
+    manager.add_pending_order(
+        ENTRY_ID, SYMBOL, "BUY", 65, 145.15, "LIMIT", intent="ENTRY"
+    )
+    manager.apply_broker_order_update(
+        ENTRY_ID,
+        {"status": "PARTIALLY_FILLED", "filled_quantity": 40, "average_price": 145.15},
+    )
+    assert manager.get_position(SYMBOL).quantity == 40
+    assert manager._orders[ENTRY_ID].applied_filled_quantity == 40
+
+    restarted = PositionManager(state_file=str(state_path))
+    # Replayed partial (same cumulative) must be a no-op after restart.
+    restarted.apply_broker_order_update(
+        ENTRY_ID,
+        {"status": "PARTIALLY_FILLED", "filled_quantity": 40, "average_price": 145.15},
+    )
+    position = restarted.get_position(SYMBOL)
+    assert position is not None and position.quantity == 40
+    assert restarted._orders[ENTRY_ID].applied_filled_quantity == 40
+
+    # The genuine completion still applies exactly the remaining 25.
+    restarted.apply_broker_order_update(
+        ENTRY_ID,
+        {"status": "COMPLETE", "filled_quantity": 65, "average_price": 145.15},
+    )
+    position = restarted.get_position(SYMBOL)
+    assert position is not None and position.quantity == 65
+    assert restarted._orders[ENTRY_ID].applied_filled_quantity == 65


### PR DESCRIPTION
No production code changed - audit found all four slice-2 behaviors already implemented (#744): (a) monotonic applied_filled_quantity delta rejects duplicate/out-of-order cumulative callbacks (position_manager.py:3150-3164); (b) synchronize_with_broker is atomic authoritative replace (:2563-2649); (c) local qty capped by per-order overfill reject + (a) + (b); (d) applied_filled_quantity persisted/restored (:607/:671/:2482), bracket re-registration dedupes.

Adds the four regression tests to existing files: duplicate + older out-of-order cumulative callback; broker snapshot AFTER fill (replace, not additive); restart with partially-filled unprotected position (no re-apply, remainder still applies); restart with already-protected position (one bracket, replayed registration dedupes).

Slice-1 protections untouched. Full suite: 1215 collected, 0 failed, flaky test deselected. compileall clean.