### PR TITLE
Fail closed on missing/stale underlying direction for option entries (slice 3)

### DIFF
--- a/src/nifty_scalper_bot/core/strategy_manager.py
+++ b/src/nifty_scalper_bot/core/strategy_manager.py
@@ -3814,6 +3814,45 @@ class StrategyManager(_BaseStrategyManager):
                 context_votes.append((signal, vote))
             else:
                 trigger_votes.append((signal, vote))
+        # ── Underlying-direction authority gate (fail closed) ──
+        # An option ENTRY may only be approved with a fresh, valid underlying
+        # (spot/futures) direction that matches the option side. Missing or
+        # stale underlying context must skip the entry, never fail open.
+        # Close signals returned above are never gated.
+        if symbol_norm.endswith(("CE", "PE")):
+            _bias = str(
+                indicator_map.get("direction_bias")
+                or indicator_map.get("underlying_direction_bias")
+                or ""
+            ).upper()
+            _ctx_fresh = bool(indicator_map.get("context_fresh"))
+            _side_expected = "CE" if symbol_norm.endswith("CE") else "PE"
+            _gate_block: str | None = None
+            if _bias not in {"CE", "PE"} or not _ctx_fresh:
+                _gate_block = "underlying_direction_unresolved"
+            elif _bias != _side_expected:
+                _gate_block = "underlying_direction_conflict"
+            if _gate_block is not None:
+                _record_no_signal(
+                    "context",
+                    f"{_gate_block}_fail_closed",
+                    "underlying_direction_gate",
+                    trigger_vote_count=len(trigger_votes),
+                    context_vote_count=len(context_votes),
+                    final_block_reason=_gate_block,
+                )
+                log_throttled(
+                    log,
+                    f"underlying_direction_gate:{symbol_norm}",
+                    "UNDERLYING_DIRECTION_GATE_BLOCKED symbol=%s bias=%s context_fresh=%s reason=%s",
+                    symbol_norm,
+                    _bias or None,
+                    _ctx_fresh,
+                    _gate_block,
+                    interval_sec=30.0,
+                    level=logging.INFO,
+                )
+                return None
         approval_path = "multi_trigger"
         if not trigger_votes:
             promoted_candidate = self._try_context_promotion(symbol_norm, context_votes, indicator_map, mode_profile)

--- a/tests/strategies/test_single_vote_score_floor.py
+++ b/tests/strategies/test_single_vote_score_floor.py
@@ -57,3 +57,56 @@ async def test_malformed_score_env_does_not_crash() -> None:
     assert parse_float_env("high", 9.0) == 9.0
     assert parse_float_env("", 9.0) == 9.0
     assert parse_float_env("9.5", 9.0) == 9.5
+
+
+def _gate_probe(symbol: str, indicators: dict):
+    """Drive the real _combine_strategy_votes gate with one strong CE vote."""
+    from nifty_scalper_bot.core.strategy_manager import (
+        Signal,
+        StrategyManager,
+        StrategyVote,
+    )
+
+    mgr = StrategyManager.__new__(StrategyManager)
+    mgr._last_no_signal_decision_by_symbol = {}
+    sig = Signal(
+        action="BUY", symbol=symbol, quantity=65, confidence=0.9,
+        reason="t", stop_loss=140.0, take_profit=150.0, metadata={},
+    )
+    vote = StrategyVote(
+        strategy="VWAPPro", side="CE", score=9.9, confidence=0.9,
+        reasons=[], metadata={"role": "trigger"},
+    )
+    result = mgr._combine_strategy_votes(
+        symbol=symbol, signals=[(sig, vote)], indicators=indicators
+    )
+    decision = mgr._last_no_signal_decision_by_symbol.get(symbol.upper())
+    return result, decision
+
+
+async def test_option_entry_fails_closed_without_underlying_direction() -> None:
+    # Slice-3: missing underlying direction context must block, not fail open.
+    result, decision = _gate_probe("NFO:NIFTY2670724050CE", {})
+    assert result is None
+    assert decision is not None
+    assert decision.final_block_reason == "underlying_direction_unresolved"
+
+
+async def test_option_entry_fails_closed_on_stale_context() -> None:
+    # Direction present but context not fresh -> still blocked.
+    result, decision = _gate_probe(
+        "NFO:NIFTY2670724050CE",
+        {"direction_bias": "CE", "context_fresh": False},
+    )
+    assert result is None
+    assert decision.final_block_reason == "underlying_direction_unresolved"
+
+
+async def test_option_entry_blocked_when_bias_conflicts_option_side() -> None:
+    # PE bias can never approve a CE entry (and vice versa) - no side flip.
+    result, decision = _gate_probe(
+        "NFO:NIFTY2670724050CE",
+        {"direction_bias": "PE", "context_fresh": True},
+    )
+    assert result is None
+    assert decision.final_block_reason == "underlying_direction_conflict"


### PR DESCRIPTION
Confirmed direction cannot originate from option premium (all direction_bias writers source spot/futures context: strategy_manager.py:2936/:2974, runner.py:7848) and no CALL/PUT flip mechanism exists in selection - no changes there.

Real hole fixed: missing/stale underlying direction failed OPEN - single_trigger, multi_trigger and context_promotion approval paths could approve an option entry without any underlying direction (only two_trigger_aligned required it). Added one fail-closed guard clause inside the existing _combine_strategy_votes (after close-signal handling, exits never gated): option entry requires direction_bias in {CE,PE} + context_fresh + bias matching the option side; else structured no-signal (underlying_direction_unresolved / underlying_direction_conflict) and return None. Side-match also structurally prevents any flipped/invented direction from approval.

3 regression tests added to existing consensus test file driving the real function. Slices 1-2 protections untouched. Full suite: 1218 collected, 0 failed, flaky test deselected. compileall clean.