### PR TITLE
fix: stabilize windows pytest isolation and exit tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,22 +1,24 @@
 from __future__ import annotations
 
 import asyncio
-import inspect
-import os
 from contextlib import suppress
 from dataclasses import dataclass
+import inspect
+import os
 from pathlib import Path
+import shutil
+import tempfile
 from typing import Any, Generator
 
 import numpy as np
 import pandas as pd
 import pytest
+
+from nifty_scalper_bot.core.trading_switch import trading_switch
 from src.nifty_scalper_bot.backtesting.backtest_engine import (
     BacktestConfig,
     BacktestEngine,
 )
-
-from nifty_scalper_bot.core.trading_switch import trading_switch
 
 _ORIGINAL_PATH_READ_TEXT = Path.read_text
 
@@ -27,7 +29,7 @@ os.environ.setdefault("BROKER_API_SECRET", "mock_api_secret")
 
 
 @pytest.fixture(autouse=True)
-def _isolate_data_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def _isolate_data_dir(monkeypatch: pytest.MonkeyPatch) -> Generator[None, None, None]:
     """Point DATA_DIR at a per-test directory.
 
     Bracket and order managers persist state (virtual_brackets.json,
@@ -36,7 +38,14 @@ def _isolate_data_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     test's manager, causing order-dependent failures. Tests that set their
     own DATA_DIR still win: their monkeypatch runs after this fixture.
     """
-    monkeypatch.setenv("DATA_DIR", str(tmp_path / "state"))
+    root = Path.cwd() / ".pytest-data-dir"
+    root.mkdir(parents=True, exist_ok=True)
+    sandbox = Path(tempfile.mkdtemp(prefix="data-dir-", dir=root))
+    monkeypatch.setenv("DATA_DIR", str(sandbox / "state"))
+    try:
+        yield
+    finally:
+        shutil.rmtree(sandbox, ignore_errors=True)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/execution/test_bracket_manager_reliability.py
+++ b/tests/execution/test_bracket_manager_reliability.py
@@ -5,14 +5,7 @@ from __future__ import annotations
 import time
 from unittest.mock import Mock
 
-import pytest
-
 from nifty_scalper_bot.execution.bracket_manager import BracketManager
-
-
-@pytest.fixture(autouse=True)
-def isolated_bracket_store(tmp_path, monkeypatch) -> None:
-    monkeypatch.setenv("DATA_DIR", str(tmp_path))
 
 
 def _build_manager() -> tuple[BracketManager, Mock]:
@@ -23,6 +16,15 @@ def _build_manager() -> tuple[BracketManager, Mock]:
     manager = BracketManager(order_manager=order_manager)
     manager.attach_exit_executor(lambda symbol, qty: f"exit-{symbol}-{qty}")
     return manager, order_manager
+
+
+def _wait_for_exit(manager: BracketManager, entry_id: str, timeout_s: float = 1.0):
+    deadline = time.time() + timeout_s
+    bracket = manager.get_bracket(entry_id)
+    while time.time() < deadline and bracket is not None and not bracket.exit_executed:
+        time.sleep(0.01)
+        bracket = manager.get_bracket(entry_id)
+    return bracket
 
 
 def test_stop_loss_cross_detection_on_jump() -> None:
@@ -43,7 +45,7 @@ def test_stop_loss_cross_detection_on_jump() -> None:
     manager.on_tick("NFO:NIFTYTEST", 104.0)
     manager.on_tick("NFO:NIFTYTEST", 97.0)
 
-    bracket = manager.get_bracket("entry-1")
+    bracket = _wait_for_exit(manager, "entry-1")
     assert bracket is not None
     assert bracket.exit_executed is True
     assert bracket.active is False
@@ -95,10 +97,9 @@ def test_fallback_market_exit_executes_after_retry_exhaustion() -> None:
         time.sleep(0.01)
 
     assert order_manager.place_order.called
-    bracket = manager.get_bracket("entry-3")
-    while time.time() < deadline and bracket is not None and not bracket.exit_executed:
-        time.sleep(0.01)
-        bracket = manager.get_bracket("entry-3")
+    bracket = _wait_for_exit(
+        manager, "entry-3", timeout_s=max(0.0, deadline - time.time())
+    )
     assert bracket is not None
     assert bracket.exit_executed is True
 
@@ -146,6 +147,6 @@ def test_websocket_tick_jump_scenario_triggers_sl() -> None:
     for tick in [105.0, 104.0, 97.0]:
         manager.on_tick_event({"symbol": "NFO:NIFTYTEST5", "ltp": tick})
 
-    bracket = manager.get_bracket("entry-5")
+    bracket = _wait_for_exit(manager, "entry-5")
     assert bracket is not None
     assert bracket.exit_executed is True


### PR DESCRIPTION
## Root cause

- `tests/conftest.py::_isolate_data_dir` depended on `tmp_path`, which uses pytest's default temp root and can fail on this Windows machine with `PermissionError` before test setup.
- `tests/execution/test_bracket_manager_reliability.py` still assumed synchronous exit completion in jump-trigger paths even though the bracket exit confirm path can complete a fraction later on the worker/reconcile path.

## What changed

- `tests/conftest.py`
  - Moved autouse `DATA_DIR` isolation off pytest's temp root and onto a workspace-local temporary sandbox with explicit cleanup.
- `tests/execution/test_bracket_manager_reliability.py`
  - Removed the redundant file-local `tmp_path`-based `DATA_DIR` fixture.
  - Added a bounded `_wait_for_exit(...)` helper and used it in jump-trigger reliability assertions.

## What did not change

- No runtime trading logic changed.
- No order execution, strategy, risk, contract-selection, or market-data production code changed.
- The merged runtime fix from PR #753 remains untouched.

## Validation

Commands run:

- `python -m compileall -q src`
- `pytest -q tests/data/test_data_hub_freshness_sources.py`
- `pytest -q tests/execution/test_bracket_manager_reliability.py`
- `pytest -q tests --disable-warnings --ignore=tests/test_live_mode.py --ignore=tests/test_health_server.py --basetemp=.pytest-goal-resume3`

Results:

```text
compileall passed
standalone freshness test passed
reliability test file passed
broader local pytest run passed
```

## Runtime impact

- startup: none
- market data: none
- option hydration: none
- strategy evaluation: none
- risk: none
- execution: none in runtime; test timing expectations only
- Telegram diagnostics: none

## Regression risk

- Low.
- Scope is test-only and limited to Windows-safe temp isolation plus bounded waits for asynchronous exit confirmation.