### PR TITLE
Quarantine manual broker fills

### DIFF
--- a/src/nifty_scalper_bot/execution/position_identity_extension.py
+++ b/src/nifty_scalper_bot/execution/position_identity_extension.py
@@ -19,6 +19,7 @@ _ORIGINALS: dict[str, Any] = {}
 _SYMBOL_FIELDS = ("symbol", "tradingsymbol", "trading_symbol")
 _AVG_PRICE_FIELDS = ("average_price", "avg_price", "buy_price", "price")
 _QTY_FIELDS = ("quantity", "net_qty", "net_quantity", "netQuantity", "net")
+_QUARANTINE_INTENTS = {"", "UNKNOWN", "BROKER_IMPORTED_ORDER", "MANUAL_ORDER_QUARANTINED"}
 
 
 def _canonical_key(symbol: object) -> str:
@@ -63,6 +64,12 @@ def _net_quantity(payload: dict[str, Any]) -> int:
         with suppress(Exception):
             return int(float(payload.get(key) or 0))
     return 0
+
+
+def _prepared_row_symbol(row: Any) -> str:
+    if not isinstance(row, dict):
+        return ""
+    return _canonical_key(row.get("symbol") or row.get("tradingsymbol"))
 
 
 def _prepare_broker_positions(manager: Any, broker_positions: Any) -> tuple[Any, set[str]]:
@@ -147,6 +154,7 @@ def apply_patches() -> None:
         "synchronize_with_broker",
         "apply_broker_order_update",
         "current_entry_protection_blocker",
+        "_handle_filled_order",
     ):
         if hasattr(cls, name):
             _ORIGINALS[f"PositionManager.{name}"] = getattr(cls, name)
@@ -209,8 +217,8 @@ def apply_patches() -> None:
     def synchronize_with_broker(self: Any, broker_positions: Any) -> Any:
         prepared, unresolved = _prepare_broker_positions(self, broker_positions)
         self._cost_basis_unresolved_symbols = set(unresolved)
-        if unresolved:
-            raise ValueError("cost_basis_unresolved")
+        if unresolved and isinstance(prepared, list):
+            prepared = [row for row in prepared if _prepared_row_symbol(row) not in unresolved]
         result = _ORIGINALS["PositionManager.synchronize_with_broker"](
             self,
             prepared,
@@ -238,6 +246,28 @@ def apply_patches() -> None:
             return original(self, _canonical_key(symbol) if symbol else None)
         return None
 
+    def _handle_filled_order(self: Any, order: Any) -> Any:
+        intent = str(getattr(order, "intent", "UNKNOWN") or "UNKNOWN").strip().upper()
+        if intent in _QUARANTINE_INTENTS:
+            logger = getattr(self, "_logger", None)
+            log = getattr(logger, "warning", None)
+            if callable(log):
+                log(
+                    "MANUAL_ORDER_QUARANTINED order_id=%s symbol=%s side=%s",
+                    getattr(order, "order_id", None),
+                    getattr(order, "symbol", None),
+                    getattr(order, "side", None),
+                    extra={
+                        "event": "MANUAL_ORDER_QUARANTINED",
+                        "order_id": getattr(order, "order_id", None),
+                        "symbol": getattr(order, "symbol", None),
+                        "side": getattr(order, "side", None),
+                        "intent": intent,
+                    },
+                )
+            return _position_manager.FillApplicationResult(reason="manual_order_quarantined")
+        return _ORIGINALS["PositionManager._handle_filled_order"](self, order)
+
     if "PositionManager.__init__" in _ORIGINALS:
         cls.__init__ = __init__
     if "PositionManager._symbol_lifecycle_lock_for" in _ORIGINALS:
@@ -254,6 +284,8 @@ def apply_patches() -> None:
         cls.apply_broker_order_update = apply_broker_order_update
     if "PositionManager.current_entry_protection_blocker" in _ORIGINALS:
         cls.current_entry_protection_blocker = current_entry_protection_blocker
+    if "PositionManager._handle_filled_order" in _ORIGINALS:
+        cls._handle_filled_order = _handle_filled_order
     cls._canonical_position_ingress_patch = True
     _PATCH_APPLIED = True
 

--- a/tests/execution/test_manual_order_quarantine.py
+++ b/tests/execution/test_manual_order_quarantine.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from nifty_scalper_bot.execution import position_identity_extension as identity_ext
+from nifty_scalper_bot.execution.position_manager import Order, PositionManager
+
+
+SYMBOL = "NFO:NIFTY2670724250PE"
+
+
+def test_unknown_buy_fill_does_not_scale_existing_long_position(tmp_path):
+    manager = PositionManager(state_file=str(tmp_path / "positions.json"))
+    manager.open_position(SYMBOL, "LONG", 65, 75.0, order_id="entry-1")
+    order = Order(
+        order_id="manual-buy",
+        symbol=SYMBOL,
+        side="BUY",
+        order_type="MARKET",
+        quantity=65,
+        price=80.0,
+        status="FILLED",
+        filled_quantity=65,
+        fill_price=80.0,
+        intent="UNKNOWN",
+    )
+    manager._orders[order.order_id] = order
+
+    manager.update_order_status(order.order_id, "COMPLETE", fill_price=80.0)
+
+    position = manager.get_position(SYMBOL)
+    assert position is not None
+    assert position.quantity == 65
+    assert position.entry_price == 75.0
+    terminal = manager._terminal_orders[order.order_id]
+    assert terminal.intent == "UNKNOWN"
+    assert terminal.lifecycle_applied is False
+    assert terminal.lifecycle_resolved is False
+
+
+def test_unknown_sell_fill_does_not_close_existing_long_position(tmp_path):
+    manager = PositionManager(state_file=str(tmp_path / "positions.json"))
+    manager.open_position(SYMBOL, "LONG", 65, 75.0, order_id="entry-1")
+    order = Order(
+        order_id="manual-sell",
+        symbol=SYMBOL,
+        side="SELL",
+        order_type="MARKET",
+        quantity=65,
+        price=80.0,
+        status="FILLED",
+        filled_quantity=65,
+        fill_price=80.0,
+        intent="UNKNOWN",
+    )
+    manager._orders[order.order_id] = order
+
+    manager.update_order_status(order.order_id, "COMPLETE", fill_price=80.0)
+
+    position = manager.get_position(SYMBOL)
+    assert position is not None
+    assert position.quantity == 65
+    assert manager.get_realized_pnl() == 0.0
+    terminal = manager._terminal_orders[order.order_id]
+    assert terminal.pnl_applied is False
+    assert terminal.lifecycle_resolved is False
+
+
+def test_unresolved_broker_cost_basis_blocks_entries_without_sync_exception(tmp_path):
+    manager = PositionManager(state_file=str(tmp_path / "positions.json"))
+
+    manager.synchronize_with_broker(
+        [
+            {
+                "tradingsymbol": "NIFTY2670724250PE",
+                "quantity": 65,
+                "average_price": 0,
+                "last_price": 88.55,
+                "product": "MIS",
+            }
+        ]
+    )
+
+    assert manager.get_position(SYMBOL) is None
+    assert manager.current_entry_protection_blocker(SYMBOL) == "cost_basis_unresolved"
+    prepared, unresolved = identity_ext._prepare_broker_positions(
+        manager,
+        [
+            {
+                "tradingsymbol": "NIFTY2670724250PE",
+                "quantity": 65,
+                "average_price": 0,
+                "last_price": 88.55,
+                "product": "MIS",
+            }
+        ],
+    )
+    assert prepared[0]["symbol"] == SYMBOL
+    assert unresolved == {SYMBOL}


### PR DESCRIPTION
Focused runtime guard for manual/unknown broker-order lifecycle isolation.

Base SHA: 80c195ea7f9de7e486dbb62f1d2c30feb241dfa2
Final head SHA: d9ce4f002346a527508ea6683b10ba84369ddee5

Changes:
- UNKNOWN / manual broker fills are quarantined before they can mutate positions or P&L.
- Unknown same-side BUY no longer scales an existing LONG.
- Unknown opposite-side SELL no longer closes an existing LONG or applies realized P&L.
- Unresolved broker cost-basis rows remain as entry blockers without throwing from direct broker synchronization.
- Added focused regression tests for unknown BUY, unknown SELL and unresolved broker cost basis.

Validation:
- Validate Market-Aware Optimisations: green, including full repository suite and committed-tree check.
- Live Exit Safety CI: green, including full repository suite.

Known follow-up:
- Candidate/quote identity hardening remains the next live-order safety slice.