### PR TITLE
Trade plan identity guard

### DIFF
--- a/src/nifty_scalper_bot/execution/__init__.py
+++ b/src/nifty_scalper_bot/execution/__init__.py
@@ -23,10 +23,12 @@ from nifty_scalper_bot.execution.order_manager import (
 from nifty_scalper_bot.execution.live_safety_identity import apply_patches as _apply_live_safety_identity_patches
 from nifty_scalper_bot.execution.position_identity_extension import apply_patches as _apply_position_identity_extension_patches
 import nifty_scalper_bot.execution.bracket_ownership_extension as _bracket_ownership_extension
+import nifty_scalper_bot.execution.trade_plan_identity_guard as _trade_plan_identity_guard
 
 _apply_live_safety_identity_patches()
 _apply_position_identity_extension_patches()
 _bracket_ownership_extension.apply_patches()
+_trade_plan_identity_guard.apply_patches()
 
 CanonicalBracketManager = BracketManager
 

--- a/src/nifty_scalper_bot/execution/trade_plan_identity_guard.py
+++ b/src/nifty_scalper_bot/execution/trade_plan_identity_guard.py
@@ -1,0 +1,112 @@
+"""Trade-plan to quote identity guard.
+
+This is a final live-entry choke-point guard: a TradePlan must be validated
+against a quote snapshot that identifies the same canonical instrument before
+broker placement can be attempted.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from nifty_scalper_bot.execution import order_manager_core as _core
+from nifty_scalper_bot.utils.symbols import normalize_symbol
+
+_PATCH_APPLIED = False
+_ORIGINAL_VALIDATE = None
+_IDENTITY_KEYS = (
+    "symbol",
+    "tradingsymbol",
+    "trading_symbol",
+    "instrument",
+    "instrument_symbol",
+    "exchange_symbol",
+)
+
+
+def _quote_identity_values(quote: Any) -> set[str]:
+    if not isinstance(quote, Mapping):
+        return set()
+    values: set[str] = set()
+    for key in _IDENTITY_KEYS:
+        value = quote.get(key)
+        if isinstance(value, str) and value.strip():
+            values.add(normalize_symbol(value))
+    instrument = quote.get("instrument")
+    if isinstance(instrument, Mapping):
+        for key in _IDENTITY_KEYS:
+            value = instrument.get(key)
+            if isinstance(value, str) and value.strip():
+                values.add(normalize_symbol(value))
+    meta = quote.get("meta") or quote.get("metadata")
+    if isinstance(meta, Mapping):
+        for key in _IDENTITY_KEYS:
+            value = meta.get(key)
+            if isinstance(value, str) and value.strip():
+                values.add(normalize_symbol(value))
+    return {value for value in values if value}
+
+
+def _is_entry_plan(plan: Any) -> bool:
+    intent = str(getattr(plan, "intent", "ENTRY") or "ENTRY").strip().upper()
+    return intent in {"ENTRY", "SCALE_IN", "REVERSAL"}
+
+
+def _details(symbol: str, quote_symbols: set[str]) -> dict[str, Any]:
+    return {
+        "symbol": symbol,
+        "quote_symbols": sorted(quote_symbols),
+        "identity_chain": "quote.symbol->trade_plan.symbol",
+    }
+
+
+def apply_patches() -> None:
+    global _PATCH_APPLIED, _ORIGINAL_VALIDATE
+    if _PATCH_APPLIED:
+        return
+    cls = getattr(_core, "OrderManager", None)
+    if cls is None or getattr(cls, "_trade_plan_identity_guard_patch", False):
+        _PATCH_APPLIED = True
+        return
+    _ORIGINAL_VALIDATE = cls._validate_trade_plan
+
+    def _validate_trade_plan(self: Any, plan: Any) -> Any:
+        result = _ORIGINAL_VALIDATE(self, plan)
+        if not getattr(result, "allowed", False):
+            return result
+        symbol = normalize_symbol(str(getattr(plan, "symbol", "") or ""))
+        if not symbol or not _is_entry_plan(plan):
+            return result
+        live = False
+        live_fn = getattr(self, "_order_live_execution_enabled", None)
+        if callable(live_fn):
+            try:
+                live = bool(live_fn())
+            except Exception:
+                live = False
+        if not live:
+            return result
+        quote = self._get_latest_quote_safe(symbol)
+        quote_symbols = _quote_identity_values(quote)
+        if quote_symbols and symbol not in quote_symbols:
+            return _core.OrderPreflightResult(
+                False,
+                "quote_symbol_identity_mismatch",
+                _details(symbol, quote_symbols),
+            )
+        if not quote_symbols:
+            return _core.OrderPreflightResult(
+                False,
+                "quote_symbol_identity_missing",
+                _details(symbol, quote_symbols),
+            )
+        return result
+
+    cls._validate_trade_plan = _validate_trade_plan
+    cls._trade_plan_identity_guard_patch = True
+    _PATCH_APPLIED = True
+
+
+apply_patches()
+
+__all__ = ["apply_patches"]

--- a/tests/execution/test_trade_plan_identity_guard.py
+++ b/tests/execution/test_trade_plan_identity_guard.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import nifty_scalper_bot.execution  # noqa: F401 - applies runtime safety patches
+from nifty_scalper_bot.execution import order_manager_core as core
+
+
+GOOD_SYMBOL = "NFO:NIFTY2670724250PE"
+BAD_SYMBOL = "NFO:NIFTY2670724300PE"
+
+
+class _Manager:
+    def __init__(self, quote: dict[str, Any]) -> None:
+        self.quote = dict(quote)
+
+    def _lot_size_for_symbol(self, _symbol: str) -> int:
+        return 65
+
+    def _get_latest_quote_safe(self, _symbol: str) -> dict[str, Any]:
+        return dict(self.quote)
+
+    def _extract_quote_diagnostics(self, quote: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "age_ms": quote.get("age_ms", 10),
+            "bid": quote.get("bid", 88.0),
+            "ask": quote.get("ask", 88.5),
+            "spread_pct": quote.get("spread_pct", 0.5),
+            "bid_qty": quote.get("bid_qty", 500),
+            "ask_qty": quote.get("ask_qty", 500),
+            "depth_qty": quote.get("depth_qty", 500),
+            "ltp": quote.get("ltp", 88.25),
+        }
+
+    def _order_live_execution_enabled(self) -> bool:
+        return True
+
+
+def _plan(symbol: str = GOOD_SYMBOL) -> core.TradePlan:
+    return core.TradePlan(
+        symbol=symbol,
+        side="BUY",
+        quantity=65,
+        entry_price=88.25,
+        stop_loss=83.0,
+        take_profit=96.0,
+        trace_id="trace-identity",
+    )
+
+
+def test_live_trade_plan_rejects_quote_symbol_mismatch() -> None:
+    manager = _Manager({"symbol": BAD_SYMBOL})
+
+    result = core.OrderManager._validate_trade_plan(manager, _plan())
+
+    assert result.allowed is False
+    assert result.reason == "quote_symbol_identity_mismatch"
+    assert result.details["symbol"] == GOOD_SYMBOL
+    assert result.details["quote_symbols"] == [BAD_SYMBOL]
+
+
+def test_live_trade_plan_rejects_missing_quote_identity() -> None:
+    manager = _Manager({"bid": 88.0, "ask": 88.5, "ltp": 88.25})
+
+    result = core.OrderManager._validate_trade_plan(manager, _plan())
+
+    assert result.allowed is False
+    assert result.reason == "quote_symbol_identity_missing"
+
+
+def test_live_trade_plan_allows_matching_quote_identity() -> None:
+    manager = _Manager({"tradingsymbol": "NIFTY2670724250PE"})
+
+    result = core.OrderManager._validate_trade_plan(manager, _plan())
+
+    assert result.allowed is True


### PR DESCRIPTION
Final execution-lifecycle safety slice for TradePlan-to-quote identity.

Base SHA: 421bec02625326e3c923095b125b3b05e1df360d
Final head SHA: b6dcef5c8e51b9870f028cf0a5c6aec7d88ad1be

Changes:
- Adds a live-entry TradePlan identity guard.
- Rejects broker submission if a live quote payload identifies a different canonical contract than the TradePlan symbol.
- Rejects broker submission if live quote identity is missing, rather than allowing an anonymous quote to price an entry.
- Preserves existing non-live/test behavior and existing price-deviation guard.
- Adds focused tests for quote-symbol mismatch, missing quote identity and matching identity acceptance.

Validation:
- Validate Market-Aware Optimisations: green, including full repository suite and committed-tree check.
- Live Exit Safety CI: green, including full repository suite.