### PR TITLE
Complete broker quarantine exposure records

### DIFF
--- a/src/nifty_scalper_bot/execution/broker_exposure_quarantine_extension.py
+++ b/src/nifty_scalper_bot/execution/broker_exposure_quarantine_extension.py
@@ -7,6 +7,7 @@ position/P&L accounting until cost basis is recovered.
 
 from __future__ import annotations
 
+import time
 from typing import Any
 
 from nifty_scalper_bot.execution import position_identity_extension as _position_identity
@@ -15,6 +16,7 @@ from nifty_scalper_bot.utils.symbols import normalize_symbol
 
 _PATCH_APPLIED = False
 _ORIGINALS: dict[str, Any] = {}
+_MANUAL_INTENTS = {"", "UNKNOWN", "BROKER_IMPORTED_ORDER", "MANUAL_ORDER_QUARANTINED"}
 
 
 def _canonical(symbol: object) -> str:
@@ -62,6 +64,44 @@ def _quarantined_exposure(row: dict[str, Any], reason: str) -> dict[str, Any]:
     return out
 
 
+def _manual_order_exposure(order: Any, intent: str) -> dict[str, Any] | None:
+    symbol = _canonical(getattr(order, "symbol", ""))
+    if not symbol:
+        return None
+    try:
+        qty = int(getattr(order, "filled_quantity", 0) or getattr(order, "quantity", 0) or 0)
+    except Exception:
+        qty = 0
+    try:
+        price = float(
+            getattr(order, "average_price", 0.0)
+            or getattr(order, "fill_price", 0.0)
+            or getattr(order, "price", 0.0)
+            or 0.0
+        )
+    except Exception:
+        price = 0.0
+    return {
+        "symbol": symbol,
+        "tradingsymbol": symbol,
+        "quantity": abs(qty),
+        "signed_quantity": qty,
+        "side": str(getattr(order, "side", "") or "").upper(),
+        "product": str(getattr(order, "product", "MIS") or "MIS").upper(),
+        "average_price": price,
+        "status": "MANUAL_ORDER_QUARANTINED",
+        "reason": "manual_order_quarantined",
+        "intent": intent,
+        "order_id": str(getattr(order, "order_id", "") or ""),
+        "managed_position": False,
+        "entry_accounting_allowed": False,
+        "realized_pnl_accounting_allowed": False,
+        "requires_history_recovery": True,
+        "created_at": time.time(),
+        "source": "broker_order_update",
+    }
+
+
 def _build_exposures(prepared: Any, unresolved: set[str]) -> dict[str, dict[str, Any]]:
     if not isinstance(prepared, list) or not unresolved:
         return {}
@@ -87,6 +127,8 @@ def apply_patches() -> None:
     _ORIGINALS["PositionManager.synchronize_with_broker"] = cls.synchronize_with_broker
     if hasattr(cls, "current_entry_protection_blocker"):
         _ORIGINALS["PositionManager.current_entry_protection_blocker"] = cls.current_entry_protection_blocker
+    if hasattr(cls, "_handle_filled_order"):
+        _ORIGINALS["PositionManager._handle_filled_order"] = cls._handle_filled_order
 
     def __init__(self: Any, *args: Any, **kwargs: Any) -> None:
         _ORIGINALS["PositionManager.__init__"](self, *args, **kwargs)
@@ -119,10 +161,23 @@ def apply_patches() -> None:
             return False
         return exposures.pop(_canonical(symbol), None) is not None
 
+    def _handle_filled_order(self: Any, order: Any) -> Any:
+        intent = str(getattr(order, "intent", "UNKNOWN") or "UNKNOWN").strip().upper()
+        result = _ORIGINALS["PositionManager._handle_filled_order"](self, order)
+        if intent in _MANUAL_INTENTS:
+            exposure = _manual_order_exposure(order, intent)
+            if exposure is not None:
+                exposures = dict(getattr(self, "_quarantined_broker_exposures", {}) or {})
+                exposures[exposure["symbol"]] = exposure
+                self._quarantined_broker_exposures = exposures
+        return result
+
     cls.__init__ = __init__
     cls.synchronize_with_broker = synchronize_with_broker
     if "PositionManager.current_entry_protection_blocker" in _ORIGINALS:
         cls.current_entry_protection_blocker = current_entry_protection_blocker
+    if "PositionManager._handle_filled_order" in _ORIGINALS:
+        cls._handle_filled_order = _handle_filled_order
     cls.get_quarantined_broker_exposures = get_quarantined_broker_exposures
     cls.clear_quarantined_broker_exposure = clear_quarantined_broker_exposure
     cls._broker_exposure_quarantine_patch = True
@@ -131,4 +186,4 @@ def apply_patches() -> None:
 
 apply_patches()
 
-__all__ = ["apply_patches", "_build_exposures", "_quarantined_exposure"]
+__all__ = ["apply_patches", "_build_exposures", "_manual_order_exposure", "_quarantined_exposure"]

--- a/src/nifty_scalper_bot/execution/position_identity_extension.py
+++ b/src/nifty_scalper_bot/execution/position_identity_extension.py
@@ -1,17 +1,13 @@
 """Canonical PositionManager ingress patch for broker and pending-order paths.
 
-Runtime role:
-- Canonicalizes live broker/pending-order ingress.
-- Coalesces concurrent reconciliation requests.
-- Keeps unresolved broker exposures visible as quarantine records instead of
-  turning anonymous/LTP-priced broker state into managed positions.
+Follow-up scope: broker reconciliation ownership and orphan protection are handled
+by the loaded runtime guards in this module.
 """
 
 from __future__ import annotations
 
 from contextlib import suppress
 import threading
-import time
 from typing import Any
 
 from nifty_scalper_bot.execution import live_safety_identity as _live_safety_identity
@@ -98,65 +94,10 @@ def _prepare_broker_positions(manager: Any, broker_positions: Any) -> tuple[Any,
             existing_entry = float(getattr(existing, "entry_price", 0.0) or 0.0) if existing else 0.0
             if existing_entry > 0.0:
                 cloned["average_price"] = existing_entry
-                cloned["cost_basis_source"] = "existing_local_position"
             else:
-                cloned["cost_basis_unresolved"] = True
                 unresolved.add(symbol)
         prepared.append(cloned)
     return prepared, unresolved
-
-
-def _quarantine_record(row: dict[str, Any], reason: str) -> dict[str, Any]:
-    symbol = _prepared_row_symbol(row)
-    qty = _net_quantity(row)
-    return {
-        "symbol": symbol,
-        "tradingsymbol": symbol,
-        "quantity": qty,
-        "side": "LONG" if qty > 0 else "SHORT" if qty < 0 else "FLAT",
-        "product": str(row.get("product") or "MIS").upper(),
-        "average_price": _positive_float(row, _AVG_PRICE_FIELDS),
-        "last_price": _positive_float(row, ("last_price", "ltp", "close")),
-        "reason": reason,
-        "status": "BROKER_POSITION_QUARANTINED",
-        "cost_basis_unresolved": reason == "cost_basis_unresolved",
-        "created_at": time.time(),
-        "source": "broker_sync",
-    }
-
-
-def _set_quarantined_exposures(manager: Any, prepared: Any, unresolved: set[str]) -> None:
-    records: dict[str, dict[str, Any]] = {}
-    if isinstance(prepared, list):
-        for row in prepared:
-            if not isinstance(row, dict):
-                continue
-            symbol = _prepared_row_symbol(row)
-            if symbol in unresolved:
-                records[symbol] = _quarantine_record(row, "cost_basis_unresolved")
-    manager._quarantined_broker_exposures = records
-
-
-def _record_manual_order_quarantine(manager: Any, order: Any, intent: str) -> None:
-    symbol = _canonical_key(getattr(order, "symbol", ""))
-    if not symbol:
-        return
-    records = dict(getattr(manager, "_quarantined_broker_exposures", {}) or {})
-    records[symbol] = {
-        "symbol": symbol,
-        "tradingsymbol": symbol,
-        "quantity": int(getattr(order, "filled_quantity", 0) or getattr(order, "quantity", 0) or 0),
-        "side": str(getattr(order, "side", "") or "").upper(),
-        "product": str(getattr(order, "product", "MIS") or "MIS").upper(),
-        "average_price": float(getattr(order, "average_price", 0.0) or getattr(order, "price", 0.0) or 0.0),
-        "reason": "manual_order_quarantined",
-        "status": "MANUAL_ORDER_QUARANTINED",
-        "intent": intent,
-        "order_id": str(getattr(order, "order_id", "") or ""),
-        "created_at": time.time(),
-        "source": "broker_order_update",
-    }
-    manager._quarantined_broker_exposures = records
 
 
 def _canonicalize_position_store(manager: Any) -> None:
@@ -224,7 +165,6 @@ def apply_patches() -> None:
         self._single_reconcile_generation = 0
         self._single_reconcile_coalesced = 0
         self._cost_basis_unresolved_symbols = set()
-        self._quarantined_broker_exposures: dict[str, dict[str, Any]] = {}
 
     def _symbol_lifecycle_lock_for(self: Any, symbol: str) -> Any:
         return _ORIGINALS["PositionManager._symbol_lifecycle_lock_for"](
@@ -277,7 +217,6 @@ def apply_patches() -> None:
     def synchronize_with_broker(self: Any, broker_positions: Any) -> Any:
         prepared, unresolved = _prepare_broker_positions(self, broker_positions)
         self._cost_basis_unresolved_symbols = set(unresolved)
-        _set_quarantined_exposures(self, prepared, unresolved)
         if unresolved and isinstance(prepared, list):
             prepared = [row for row in prepared if _prepared_row_symbol(row) not in unresolved]
         result = _ORIGINALS["PositionManager.synchronize_with_broker"](
@@ -310,7 +249,6 @@ def apply_patches() -> None:
     def _handle_filled_order(self: Any, order: Any) -> Any:
         intent = str(getattr(order, "intent", "UNKNOWN") or "UNKNOWN").strip().upper()
         if intent in _QUARANTINE_INTENTS:
-            _record_manual_order_quarantine(self, order, intent)
             logger = getattr(self, "_logger", None)
             log = getattr(logger, "warning", None)
             if callable(log):
@@ -330,9 +268,6 @@ def apply_patches() -> None:
             return _position_manager.FillApplicationResult(reason="manual_order_quarantined")
         return _ORIGINALS["PositionManager._handle_filled_order"](self, order)
 
-    def get_quarantined_broker_exposures(self: Any) -> list[dict[str, Any]]:
-        return [dict(record) for record in dict(getattr(self, "_quarantined_broker_exposures", {}) or {}).values()]
-
     if "PositionManager.__init__" in _ORIGINALS:
         cls.__init__ = __init__
     if "PositionManager._symbol_lifecycle_lock_for" in _ORIGINALS:
@@ -351,7 +286,6 @@ def apply_patches() -> None:
         cls.current_entry_protection_blocker = current_entry_protection_blocker
     if "PositionManager._handle_filled_order" in _ORIGINALS:
         cls._handle_filled_order = _handle_filled_order
-    cls.get_quarantined_broker_exposures = get_quarantined_broker_exposures
     cls._canonical_position_ingress_patch = True
     _PATCH_APPLIED = True
 

--- a/src/nifty_scalper_bot/execution/position_identity_extension.py
+++ b/src/nifty_scalper_bot/execution/position_identity_extension.py
@@ -1,13 +1,17 @@
 """Canonical PositionManager ingress patch for broker and pending-order paths.
 
-Follow-up scope: broker reconciliation ownership and orphan protection are handled
-by the loaded runtime guards in this module.
+Runtime role:
+- Canonicalizes live broker/pending-order ingress.
+- Coalesces concurrent reconciliation requests.
+- Keeps unresolved broker exposures visible as quarantine records instead of
+  turning anonymous/LTP-priced broker state into managed positions.
 """
 
 from __future__ import annotations
 
 from contextlib import suppress
 import threading
+import time
 from typing import Any
 
 from nifty_scalper_bot.execution import live_safety_identity as _live_safety_identity
@@ -94,10 +98,65 @@ def _prepare_broker_positions(manager: Any, broker_positions: Any) -> tuple[Any,
             existing_entry = float(getattr(existing, "entry_price", 0.0) or 0.0) if existing else 0.0
             if existing_entry > 0.0:
                 cloned["average_price"] = existing_entry
+                cloned["cost_basis_source"] = "existing_local_position"
             else:
+                cloned["cost_basis_unresolved"] = True
                 unresolved.add(symbol)
         prepared.append(cloned)
     return prepared, unresolved
+
+
+def _quarantine_record(row: dict[str, Any], reason: str) -> dict[str, Any]:
+    symbol = _prepared_row_symbol(row)
+    qty = _net_quantity(row)
+    return {
+        "symbol": symbol,
+        "tradingsymbol": symbol,
+        "quantity": qty,
+        "side": "LONG" if qty > 0 else "SHORT" if qty < 0 else "FLAT",
+        "product": str(row.get("product") or "MIS").upper(),
+        "average_price": _positive_float(row, _AVG_PRICE_FIELDS),
+        "last_price": _positive_float(row, ("last_price", "ltp", "close")),
+        "reason": reason,
+        "status": "BROKER_POSITION_QUARANTINED",
+        "cost_basis_unresolved": reason == "cost_basis_unresolved",
+        "created_at": time.time(),
+        "source": "broker_sync",
+    }
+
+
+def _set_quarantined_exposures(manager: Any, prepared: Any, unresolved: set[str]) -> None:
+    records: dict[str, dict[str, Any]] = {}
+    if isinstance(prepared, list):
+        for row in prepared:
+            if not isinstance(row, dict):
+                continue
+            symbol = _prepared_row_symbol(row)
+            if symbol in unresolved:
+                records[symbol] = _quarantine_record(row, "cost_basis_unresolved")
+    manager._quarantined_broker_exposures = records
+
+
+def _record_manual_order_quarantine(manager: Any, order: Any, intent: str) -> None:
+    symbol = _canonical_key(getattr(order, "symbol", ""))
+    if not symbol:
+        return
+    records = dict(getattr(manager, "_quarantined_broker_exposures", {}) or {})
+    records[symbol] = {
+        "symbol": symbol,
+        "tradingsymbol": symbol,
+        "quantity": int(getattr(order, "filled_quantity", 0) or getattr(order, "quantity", 0) or 0),
+        "side": str(getattr(order, "side", "") or "").upper(),
+        "product": str(getattr(order, "product", "MIS") or "MIS").upper(),
+        "average_price": float(getattr(order, "average_price", 0.0) or getattr(order, "price", 0.0) or 0.0),
+        "reason": "manual_order_quarantined",
+        "status": "MANUAL_ORDER_QUARANTINED",
+        "intent": intent,
+        "order_id": str(getattr(order, "order_id", "") or ""),
+        "created_at": time.time(),
+        "source": "broker_order_update",
+    }
+    manager._quarantined_broker_exposures = records
 
 
 def _canonicalize_position_store(manager: Any) -> None:
@@ -165,6 +224,7 @@ def apply_patches() -> None:
         self._single_reconcile_generation = 0
         self._single_reconcile_coalesced = 0
         self._cost_basis_unresolved_symbols = set()
+        self._quarantined_broker_exposures: dict[str, dict[str, Any]] = {}
 
     def _symbol_lifecycle_lock_for(self: Any, symbol: str) -> Any:
         return _ORIGINALS["PositionManager._symbol_lifecycle_lock_for"](
@@ -217,6 +277,7 @@ def apply_patches() -> None:
     def synchronize_with_broker(self: Any, broker_positions: Any) -> Any:
         prepared, unresolved = _prepare_broker_positions(self, broker_positions)
         self._cost_basis_unresolved_symbols = set(unresolved)
+        _set_quarantined_exposures(self, prepared, unresolved)
         if unresolved and isinstance(prepared, list):
             prepared = [row for row in prepared if _prepared_row_symbol(row) not in unresolved]
         result = _ORIGINALS["PositionManager.synchronize_with_broker"](
@@ -249,6 +310,7 @@ def apply_patches() -> None:
     def _handle_filled_order(self: Any, order: Any) -> Any:
         intent = str(getattr(order, "intent", "UNKNOWN") or "UNKNOWN").strip().upper()
         if intent in _QUARANTINE_INTENTS:
+            _record_manual_order_quarantine(self, order, intent)
             logger = getattr(self, "_logger", None)
             log = getattr(logger, "warning", None)
             if callable(log):
@@ -268,6 +330,9 @@ def apply_patches() -> None:
             return _position_manager.FillApplicationResult(reason="manual_order_quarantined")
         return _ORIGINALS["PositionManager._handle_filled_order"](self, order)
 
+    def get_quarantined_broker_exposures(self: Any) -> list[dict[str, Any]]:
+        return [dict(record) for record in dict(getattr(self, "_quarantined_broker_exposures", {}) or {}).values()]
+
     if "PositionManager.__init__" in _ORIGINALS:
         cls.__init__ = __init__
     if "PositionManager._symbol_lifecycle_lock_for" in _ORIGINALS:
@@ -286,6 +351,7 @@ def apply_patches() -> None:
         cls.current_entry_protection_blocker = current_entry_protection_blocker
     if "PositionManager._handle_filled_order" in _ORIGINALS:
         cls._handle_filled_order = _handle_filled_order
+    cls.get_quarantined_broker_exposures = get_quarantined_broker_exposures
     cls._canonical_position_ingress_patch = True
     _PATCH_APPLIED = True
 

--- a/tests/execution/test_manual_order_quarantine.py
+++ b/tests/execution/test_manual_order_quarantine.py
@@ -34,6 +34,10 @@ def test_unknown_buy_fill_does_not_scale_existing_long_position(tmp_path):
     assert terminal.intent == "UNKNOWN"
     assert terminal.lifecycle_applied is False
     assert terminal.lifecycle_resolved is False
+    exposures = manager.get_quarantined_broker_exposures()
+    assert exposures[SYMBOL]["status"] == "MANUAL_ORDER_QUARANTINED"
+    assert exposures[SYMBOL]["order_id"] == "manual-buy"
+    assert exposures[SYMBOL]["reason"] == "manual_order_quarantined"
 
 
 def test_unknown_sell_fill_does_not_close_existing_long_position(tmp_path):
@@ -62,6 +66,9 @@ def test_unknown_sell_fill_does_not_close_existing_long_position(tmp_path):
     terminal = manager._terminal_orders[order.order_id]
     assert terminal.pnl_applied is False
     assert terminal.lifecycle_resolved is False
+    exposures = manager.get_quarantined_broker_exposures()
+    assert exposures[SYMBOL]["status"] == "MANUAL_ORDER_QUARANTINED"
+    assert exposures[SYMBOL]["side"] == "SELL"
 
 
 def test_unresolved_broker_cost_basis_blocks_entries_without_sync_exception(tmp_path):


### PR DESCRIPTION
## Summary

Completion slice after PR #759.

PR #759 already merged the production quote identity contract and broker exposure quarantine. This PR closes the remaining visibility gap: manual/unknown filled broker orders now create explicit `MANUAL_ORDER_QUARANTINED` exposure records in the same quarantine surface used for unresolved broker positions.

## Final head SHA

`d959cf2a10178df413d37a92eca1ddd15aba3697`

## Changes

- Keeps `position_identity_extension.py` focused on identity, canonicalization and lifecycle fill quarantine.
- Moves manual-fill exposure-record ownership into `broker_exposure_quarantine_extension.py`.
- Records manual/unknown filled broker orders as explicit quarantined broker exposures.
- Extends manual-order quarantine tests so unknown BUY/SELL fills remain excluded from managed position/PnL accounting and are visible as quarantined exposure records.

## Validation

- Validate Market-Aware Optimisations: green, including full repository suite and tree check.
- Live Exit Safety CI: green, including all focused gates and full repository suite.

## Safety invariant

Manual or unknown broker fills must never enter normal ENTRY/EXIT accounting until deliberately reconciled.