### PR TITLE
Harden lifecycle entry gates

### DIFF
--- a/src/nifty_scalper_bot/execution/native_entry_gate.py
+++ b/src/nifty_scalper_bot/execution/native_entry_gate.py
@@ -18,6 +18,11 @@ _LEGACY_PROTECTIVE_TAG_PREFIXES = (
     "FLATTEN",
     "SQUAREOFF",
 )
+_PROVIDER_BLOCKER_METHODS = (
+    "current_entry_blocker",
+    "current_execution_blocker",
+    "current_reconciliation_blocker",
+)
 
 
 def configure_provider(manager: Any, provider: Any | None) -> None:
@@ -75,8 +80,65 @@ def _protective_place_order(
     return tag.startswith(_LEGACY_PROTECTIVE_TAG_PREFIXES)
 
 
+def _normalise_provider_block(result: Any, *, source: str) -> dict[str, Any] | None:
+    if not result:
+        return None
+    if isinstance(result, Mapping):
+        reason = (
+            result.get("block_reason")
+            or result.get("reason")
+            or result.get("blocker")
+            or source
+        )
+        details = dict(result)
+    else:
+        reason = str(result)
+        details = {"reason": reason}
+    reason_token = str(reason or source).strip() or source
+    details.update(
+        {
+            "block_reason": reason_token,
+            "broker_attempted": False,
+            "retryable": False,
+            "provider_blocker": True,
+            "provider_blocker_source": source,
+        }
+    )
+    return details
+
+
+def _provider_block_details(provider: Any, manager: Any) -> dict[str, Any] | None:
+    for method_name in _PROVIDER_BLOCKER_METHODS:
+        checker = getattr(provider, method_name, None)
+        if not callable(checker):
+            continue
+        try:
+            try:
+                result = checker()
+            except TypeError:
+                result = checker(manager)
+        except Exception as exc:
+            return {
+                "block_reason": "entry_blocker_provider_error",
+                "provider_error": f"{type(exc).__name__}: {exc}",
+                "provider_blocker": True,
+                "provider_blocker_source": method_name,
+                "broker_attempted": False,
+                "retryable": False,
+            }
+        details = _normalise_provider_block(result, source=method_name)
+        if details is not None:
+            return details
+    return None
+
+
 def unresolved_details(manager: Any) -> dict[str, Any] | None:
     provider = getattr(manager, "_unresolved_exit_provider", None)
+    provider_block = _provider_block_details(provider, manager)
+    if provider_block is not None:
+        _record_block(manager, provider_block)
+        return provider_block
+
     checker = getattr(provider, "has_unresolved_exit", None)
     if not callable(checker):
         return None
@@ -101,24 +163,31 @@ def unresolved_details(manager: Any) -> dict[str, Any] | None:
     }
     if provider_error:
         details["provider_error"] = provider_error
+    _record_block(manager, details)
+    return details
+
+
+def _record_block(manager: Any, details: Mapping[str, Any]) -> None:
+    reason = str(details.get("block_reason") or "entry_blocked")
     manager._last_order_decision = dict(details)
     setter = getattr(manager, "set_last_skip_reason", None)
     if callable(setter):
         with suppress(Exception):
-            setter("unresolved_exit_position")
+            setter(reason)
     logger = getattr(manager, "_logger", None)
     log = getattr(logger, "critical", None)
     if callable(log):
         log(
-            "ENTRY_BLOCKED_UNRESOLVED_EXIT bracket_id=%s",
-            bracket_id,
+            "ENTRY_BLOCKED_NATIVE_GATE reason=%s bracket_id=%s",
+            reason,
+            details.get("bracket_id"),
             extra={
-                "event": "ENTRY_BLOCKED_UNRESOLVED_EXIT",
-                "bracket_id": bracket_id,
+                "event": "ENTRY_BLOCKED_NATIVE_GATE",
+                "block_reason": reason,
+                "bracket_id": details.get("bracket_id"),
                 "native_gate": True,
             },
         )
-    return details
 
 
 def block_result(
@@ -139,11 +208,12 @@ def block_result(
     details = unresolved_details(manager)
     if details is None:
         return NO_BLOCK
+    reason = str(details.get("block_reason") or "entry_blocked")
     if method_name == "submit_trade_plan_result":
         return base_module.TradePlanSubmitResult(
             accepted=False,
             order_id=None,
-            reason="unresolved_exit_position",
+            reason=reason,
             details=details,
             broker_attempted=False,
         )
@@ -151,7 +221,7 @@ def block_result(
         return base_module.ManagedOrderResult(
             accepted=False,
             order_id=None,
-            reason="unresolved_exit_position",
+            reason=reason,
             details=details,
             broker_attempted=False,
         )

--- a/src/nifty_scalper_bot/execution/ownership.py
+++ b/src/nifty_scalper_bot/execution/ownership.py
@@ -3,6 +3,7 @@
 
 Key responsibilities:
     - Register the active bracket manager as the unresolved-exit provider.
+    - Surface bracket, protection, P&L and reconciliation blockers to the gate.
     - Preserve a compatibility fallback for noncanonical external test doubles.
 
 Operational constraints:
@@ -13,8 +14,37 @@ Operational constraints:
 from __future__ import annotations
 
 from contextlib import suppress
+from typing import Any, Mapping
 
 from nifty_scalper_bot.execution.runtime_bracket_manager import RuntimeBracketManager
+
+
+def _order_manager_position_manager(order_manager: Any) -> Any | None:
+    for name in ("_position_manager", "position_manager", "positions"):
+        value = getattr(order_manager, name, None)
+        if value is not None:
+            return value
+    return None
+
+
+def _call_blocker(source: Any, method_name: str) -> Any | None:
+    method = getattr(source, method_name, None)
+    if not callable(method):
+        return None
+    try:
+        return method()
+    except TypeError:
+        return None
+
+
+def _block(reason: str, *, source: str, **details: Any) -> dict[str, Any]:
+    return {
+        "block_reason": str(reason),
+        "block_source": source,
+        "broker_attempted": False,
+        "retryable": False,
+        **details,
+    }
 
 
 class BoundBracketManager(RuntimeBracketManager):
@@ -34,6 +64,63 @@ class BoundBracketManager(RuntimeBracketManager):
                 )
             return
         super()._install_unresolved_exit_entry_guard()
+
+    def current_entry_blocker(self) -> Mapping[str, Any] | None:
+        """Return the first live-safety blocker for new entries.
+
+        This keeps the bracket manager as the single provider registered with
+        RuntimeOrderManager while allowing the native entry gate to consume
+        position-manager safety state: unprotected fills, P&L mismatch,
+        unresolved terminal exits, and broker/local reconciliation uncertainty.
+        """
+
+        checker = getattr(self, "has_unresolved_exit", None)
+        try:
+            if callable(checker) and bool(checker()):
+                bracket_id = None
+                getter = getattr(self, "get_first_unresolved_exit_bracket_id", None)
+                if callable(getter):
+                    with suppress(Exception):
+                        bracket_id = getter()
+                return _block(
+                    "unresolved_exit_position",
+                    source="bracket_manager",
+                    bracket_id=bracket_id,
+                )
+        except Exception as exc:  # noqa: BLE001 - fail closed
+            return _block(
+                "entry_blocker_provider_error",
+                source="bracket_manager",
+                provider_error=f"{type(exc).__name__}: {exc}",
+            )
+
+        position_manager = _order_manager_position_manager(getattr(self, "order_manager", None))
+        if position_manager is None:
+            return None
+
+        for method_name in (
+            "current_entry_protection_blocker",
+            "current_pnl_reconciliation_blocker",
+            "current_position_reconciliation_blocker",
+            "current_orphan_position_blocker",
+            "current_exit_lifecycle_blocker",
+        ):
+            reason = _call_blocker(position_manager, method_name)
+            if reason:
+                return _block(str(reason), source=method_name)
+
+        summary_getter = getattr(position_manager, "unresolved_terminal_summary", None)
+        if callable(summary_getter):
+            with suppress(Exception):
+                summary = summary_getter()
+                if isinstance(summary, Mapping) and int(summary.get("count") or 0) > 0:
+                    return _block(
+                        "unresolved_terminal_order",
+                        source="unresolved_terminal_summary",
+                        unresolved_terminal_count=int(summary.get("count") or 0),
+                        oldest_unresolved_terminal_age_s=summary.get("oldest_age_s"),
+                    )
+        return None
 
 
 __all__ = ["BoundBracketManager"]

--- a/src/nifty_scalper_bot/execution/ownership.py
+++ b/src/nifty_scalper_bot/execution/ownership.py
@@ -14,7 +14,7 @@ Operational constraints:
 from __future__ import annotations
 
 from contextlib import suppress
-from typing import Any, Mapping
+from typing import Any, Mapping, Sequence
 
 from nifty_scalper_bot.execution.runtime_bracket_manager import RuntimeBracketManager
 
@@ -37,6 +37,25 @@ def _call_blocker(source: Any, method_name: str) -> Any | None:
         return None
 
 
+def _call_sequence(source: Any, names: Sequence[str]) -> list[Any]:
+    for name in names:
+        method = getattr(source, name, None)
+        if callable(method):
+            try:
+                value = method()
+            except Exception:
+                continue
+        else:
+            value = getattr(source, name, None)
+        if value is None:
+            continue
+        try:
+            return list(value)
+        except TypeError:
+            continue
+    return []
+
+
 def _block(reason: str, *, source: str, **details: Any) -> dict[str, Any]:
     return {
         "block_reason": str(reason),
@@ -45,6 +64,37 @@ def _block(reason: str, *, source: str, **details: Any) -> dict[str, Any]:
         "retryable": False,
         **details,
     }
+
+
+def _synthetic_position_blocker(position_manager: Any) -> dict[str, Any] | None:
+    failures = int(getattr(position_manager, "_consecutive_reconcile_failures", 0) or 0)
+    last_error = getattr(position_manager, "_last_reconcile_error", None)
+    if failures > 0 or last_error:
+        return _block(
+            "position_reconciliation_unhealthy",
+            source="position_manager_reconciliation_state",
+            consecutive_reconcile_failures=failures,
+            last_reconcile_error=last_error,
+        )
+
+    positions = _call_sequence(
+        position_manager,
+        ("get_open_positions", "get_all_positions", "open_positions"),
+    )
+    unmanaged = [
+        getattr(position, "symbol", None)
+        for position in positions
+        if getattr(position, "order_id", None) in (None, "")
+    ]
+    unmanaged = [str(symbol) for symbol in unmanaged if symbol]
+    if unmanaged:
+        return _block(
+            "broker_synced_unmanaged_position",
+            source="position_manager_positions",
+            unmanaged_position_count=len(unmanaged),
+            unmanaged_symbols=unmanaged[:5],
+        )
+    return None
 
 
 class BoundBracketManager(RuntimeBracketManager):
@@ -71,7 +121,8 @@ class BoundBracketManager(RuntimeBracketManager):
         This keeps the bracket manager as the single provider registered with
         RuntimeOrderManager while allowing the native entry gate to consume
         position-manager safety state: unprotected fills, P&L mismatch,
-        unresolved terminal exits, and broker/local reconciliation uncertainty.
+        unresolved terminal exits, broker/local reconciliation uncertainty, and
+        broker-synced positions that do not yet have local order ownership.
         """
 
         checker = getattr(self, "has_unresolved_exit", None)
@@ -120,7 +171,8 @@ class BoundBracketManager(RuntimeBracketManager):
                         unresolved_terminal_count=int(summary.get("count") or 0),
                         oldest_unresolved_terminal_age_s=summary.get("oldest_age_s"),
                     )
-        return None
+
+        return _synthetic_position_blocker(position_manager)
 
 
 __all__ = ["BoundBracketManager"]

--- a/tests/execution/test_lifecycle_entry_guards.py
+++ b/tests/execution/test_lifecycle_entry_guards.py
@@ -39,6 +39,14 @@ def _base_place_order(_manager: Any, *, intent: str | None = None, tag: str | No
     return None
 
 
+def _bound_manager(position_manager: Any) -> BoundBracketManager:
+    order_manager = SimpleNamespace(_position_manager=position_manager)
+    manager = BoundBracketManager.__new__(BoundBracketManager)
+    manager.order_manager = order_manager
+    manager.has_unresolved_exit = lambda: False
+    return manager
+
+
 def test_native_entry_gate_blocks_generic_provider_reason() -> None:
     provider = SimpleNamespace(current_entry_blocker=lambda: "pnl_reconciliation_mismatch")
     manager = _Manager(provider)
@@ -104,10 +112,7 @@ def test_bound_bracket_manager_surfaces_position_manager_reason() -> None:
         current_pnl_reconciliation_blocker=lambda: "pnl_reconciliation_mismatch",
         unresolved_terminal_summary=lambda: {"count": 0},
     )
-    order_manager = SimpleNamespace(_position_manager=position_manager)
-    manager = BoundBracketManager.__new__(BoundBracketManager)
-    manager.order_manager = order_manager
-    manager.has_unresolved_exit = lambda: False
+    manager = _bound_manager(position_manager)
 
     blocker = manager.current_entry_blocker()
 
@@ -126,10 +131,7 @@ def test_bound_bracket_manager_surfaces_unresolved_terminal_summary() -> None:
         current_exit_lifecycle_blocker=lambda: None,
         unresolved_terminal_summary=lambda: {"count": 2, "oldest_age_s": 17.5},
     )
-    order_manager = SimpleNamespace(_position_manager=position_manager)
-    manager = BoundBracketManager.__new__(BoundBracketManager)
-    manager.order_manager = order_manager
-    manager.has_unresolved_exit = lambda: False
+    manager = _bound_manager(position_manager)
 
     blocker = manager.current_entry_blocker()
 
@@ -137,6 +139,44 @@ def test_bound_bracket_manager_surfaces_unresolved_terminal_summary() -> None:
     assert blocker["block_reason"] == "unresolved_terminal_order"
     assert blocker["unresolved_terminal_count"] == 2
     assert blocker["oldest_unresolved_terminal_age_s"] == 17.5
+
+
+def test_bound_bracket_manager_blocks_unmanaged_broker_synced_positions() -> None:
+    position_manager = SimpleNamespace(
+        current_entry_protection_blocker=lambda: None,
+        current_pnl_reconciliation_blocker=lambda: None,
+        current_position_reconciliation_blocker=lambda: None,
+        current_orphan_position_blocker=lambda: None,
+        current_exit_lifecycle_blocker=lambda: None,
+        unresolved_terminal_summary=lambda: {"count": 0},
+        get_open_positions=lambda: [SimpleNamespace(symbol="NFO:NIFTY2662324050PE", order_id=None)],
+    )
+    manager = _bound_manager(position_manager)
+
+    blocker = manager.current_entry_blocker()
+
+    assert blocker is not None
+    assert blocker["block_reason"] == "broker_synced_unmanaged_position"
+    assert blocker["unmanaged_position_count"] == 1
+
+
+def test_bound_bracket_manager_blocks_unhealthy_reconciliation_state() -> None:
+    position_manager = SimpleNamespace(
+        current_entry_protection_blocker=lambda: None,
+        current_pnl_reconciliation_blocker=lambda: None,
+        unresolved_terminal_summary=lambda: {"count": 0},
+        get_open_positions=lambda: [],
+        _consecutive_reconcile_failures=2,
+        _last_reconcile_error="fetch_error",
+    )
+    manager = _bound_manager(position_manager)
+
+    blocker = manager.current_entry_blocker()
+
+    assert blocker is not None
+    assert blocker["block_reason"] == "position_reconciliation_unhealthy"
+    assert blocker["consecutive_reconcile_failures"] == 2
+    assert blocker["last_reconcile_error"] == "fetch_error"
 
 
 def test_bound_bracket_manager_keeps_unresolved_bracket_priority() -> None:

--- a/tests/execution/test_lifecycle_entry_guards.py
+++ b/tests/execution/test_lifecycle_entry_guards.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+
+def test_lifecycle_guard_smoke() -> None:
+    assert True

--- a/tests/execution/test_lifecycle_entry_guards.py
+++ b/tests/execution/test_lifecycle_entry_guards.py
@@ -1,5 +1,79 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
+from typing import Any
 
-def test_lifecycle_guard_smoke() -> None:
-    assert True
+from nifty_scalper_bot.execution import native_entry_gate
+from nifty_scalper_bot.execution.ownership import BoundBracketManager
+
+
+class _Result:
+    def __init__(self, *, accepted: bool, order_id: str | None, reason: str, details: dict[str, Any], broker_attempted: bool) -> None:
+        self.accepted = accepted
+        self.order_id = order_id
+        self.reason = reason
+        self.details = details
+        self.broker_attempted = broker_attempted
+
+
+class _BaseModule:
+    TradePlanSubmitResult = _Result
+    ManagedOrderResult = _Result
+
+
+class _Manager:
+    def __init__(self, provider: Any) -> None:
+        self._unresolved_exit_provider = provider
+        self._last_order_decision: dict[str, Any] = {}
+        self.skip_reasons: list[str] = []
+        self._logger = SimpleNamespace(critical=lambda *_args, **_kwargs: None)
+
+    def set_last_skip_reason(self, reason: str) -> None:
+        self.skip_reasons.append(reason)
+
+    def is_live_mode(self) -> bool:
+        return True
+
+
+def _base_place_order(_manager: Any, *, intent: str | None = None, tag: str | None = None) -> None:
+    return None
+
+
+def test_native_entry_gate_blocks_generic_provider_reason() -> None:
+    provider = SimpleNamespace(current_entry_blocker=lambda: "pnl_reconciliation_mismatch")
+    manager = _Manager(provider)
+
+    result = native_entry_gate.block_result(
+        manager,
+        _BaseModule,
+        _base_place_order,
+        "submit_trade_plan_result",
+        (object(),),
+        {},
+    )
+
+    assert result.accepted is False
+    assert result.reason == "pnl_reconciliation_mismatch"
+    assert result.broker_attempted is False
+    assert result.details["provider_blocker"] is True
+    assert manager._last_order_decision["block_reason"] == "pnl_reconciliation_mismatch"
+    assert manager.skip_reasons == ["pnl_reconciliation_mismatch"]
+
+
+def test_bound_bracket_manager_surfaces_position_manager_reason() -> None:
+    position_manager = SimpleNamespace(
+        current_entry_protection_blocker=lambda: None,
+        current_pnl_reconciliation_blocker=lambda: "pnl_reconciliation_mismatch",
+        unresolved_terminal_summary=lambda: {"count": 0},
+    )
+    order_manager = SimpleNamespace(_position_manager=position_manager)
+    manager = BoundBracketManager.__new__(BoundBracketManager)
+    manager.order_manager = order_manager
+    manager.has_unresolved_exit = lambda: False
+
+    blocker = manager.current_entry_blocker()
+
+    assert blocker is not None
+    assert blocker["block_reason"] == "pnl_reconciliation_mismatch"
+    assert blocker["block_source"] == "current_pnl_reconciliation_blocker"
+    assert blocker["broker_attempted"] is False

--- a/tests/execution/test_lifecycle_entry_guards.py
+++ b/tests/execution/test_lifecycle_entry_guards.py
@@ -60,6 +60,44 @@ def test_native_entry_gate_blocks_generic_provider_reason() -> None:
     assert manager.skip_reasons == ["pnl_reconciliation_mismatch"]
 
 
+def test_native_entry_gate_fails_closed_when_provider_raises() -> None:
+    def _broken() -> str:
+        raise RuntimeError("position manager unavailable")
+
+    manager = _Manager(SimpleNamespace(current_entry_blocker=_broken))
+
+    result = native_entry_gate.block_result(
+        manager,
+        _BaseModule,
+        _base_place_order,
+        "submit_trade_plan_result",
+        (object(),),
+        {},
+    )
+
+    assert result.accepted is False
+    assert result.reason == "entry_blocker_provider_error"
+    assert "RuntimeError" in result.details["provider_error"]
+    assert result.broker_attempted is False
+
+
+def test_protective_order_is_not_stopped_by_entry_blocker() -> None:
+    provider = SimpleNamespace(current_entry_blocker=lambda: "unresolved_terminal_order")
+    manager = _Manager(provider)
+
+    result = native_entry_gate.block_result(
+        manager,
+        _BaseModule,
+        _base_place_order,
+        "place_order",
+        (),
+        {"intent": "EXIT", "tag": "risk-reduction"},
+    )
+
+    assert result is native_entry_gate.NO_BLOCK
+    assert manager._last_order_decision == {}
+
+
 def test_bound_bracket_manager_surfaces_position_manager_reason() -> None:
     position_manager = SimpleNamespace(
         current_entry_protection_blocker=lambda: None,
@@ -77,3 +115,40 @@ def test_bound_bracket_manager_surfaces_position_manager_reason() -> None:
     assert blocker["block_reason"] == "pnl_reconciliation_mismatch"
     assert blocker["block_source"] == "current_pnl_reconciliation_blocker"
     assert blocker["broker_attempted"] is False
+
+
+def test_bound_bracket_manager_surfaces_unresolved_terminal_summary() -> None:
+    position_manager = SimpleNamespace(
+        current_entry_protection_blocker=lambda: None,
+        current_pnl_reconciliation_blocker=lambda: None,
+        current_position_reconciliation_blocker=lambda: None,
+        current_orphan_position_blocker=lambda: None,
+        current_exit_lifecycle_blocker=lambda: None,
+        unresolved_terminal_summary=lambda: {"count": 2, "oldest_age_s": 17.5},
+    )
+    order_manager = SimpleNamespace(_position_manager=position_manager)
+    manager = BoundBracketManager.__new__(BoundBracketManager)
+    manager.order_manager = order_manager
+    manager.has_unresolved_exit = lambda: False
+
+    blocker = manager.current_entry_blocker()
+
+    assert blocker is not None
+    assert blocker["block_reason"] == "unresolved_terminal_order"
+    assert blocker["unresolved_terminal_count"] == 2
+    assert blocker["oldest_unresolved_terminal_age_s"] == 17.5
+
+
+def test_bound_bracket_manager_keeps_unresolved_bracket_priority() -> None:
+    position_manager = SimpleNamespace(current_pnl_reconciliation_blocker=lambda: "pnl_reconciliation_mismatch")
+    order_manager = SimpleNamespace(_position_manager=position_manager)
+    manager = BoundBracketManager.__new__(BoundBracketManager)
+    manager.order_manager = order_manager
+    manager.has_unresolved_exit = lambda: True
+    manager.get_first_unresolved_exit_bracket_id = lambda: "bracket-1"
+
+    blocker = manager.current_entry_blocker()
+
+    assert blocker is not None
+    assert blocker["block_reason"] == "unresolved_exit_position"
+    assert blocker["bracket_id"] == "bracket-1"


### PR DESCRIPTION
## Summary
- extend the native entry gate to consume generic lifecycle blockers, not only unresolved bracket exits
- surface position-manager blockers through the bound bracket authority: incomplete entry protection, P&L mismatch, reconciliation/orphan hooks, unresolved terminal orders
- fail closed when blocker provider errors
- keep protective exit/reduce orders executable while new entries are blocked
- block new entries when reconciliation is unhealthy or broker-synced positions have no local order ownership
- add regression tests for these lifecycle safety paths

## Scope exclusions
- does not touch PR #764
- does not change shadow-mode policy
- does not add strategy indicators

## Validation
- Validate Market-Aware Optimisations: success on head 62f820caf2ce541a64e2bb1993f45c0f2396d8ef
- Live Exit Safety CI: success on head 62f820caf2ce541a64e2bb1993f45c0f2396d8ef