### PR TITLE
Tighten live entry recovery quote contract

### DIFF
--- a/src/nifty_scalper_bot/execution/entry_recovery.py
+++ b/src/nifty_scalper_bot/execution/entry_recovery.py
@@ -93,8 +93,43 @@ def _positive(quote: Mapping[str, Any], *keys: str) -> float | None:
     return None
 
 
-def _entry_price(plan: Any, quote: Mapping[str, Any]) -> float | None:
+def _manager_live_mode(manager: Any) -> bool:
+    checker = getattr(manager, "is_live_mode", None)
+    if callable(checker):
+        try:
+            return bool(checker())
+        except Exception:
+            return True
+    execution_mode = str(os.getenv("EXECUTION_MODE", "SHADOW") or "SHADOW").strip().upper()
+    live_enabled = str(os.getenv("ENABLE_LIVE", "") or os.getenv("ENABLE_LIVE_TRADING", "")).strip().lower() in {"1", "true", "yes", "y", "on"}
+    shadow_or_paper = str(os.getenv("SHADOW_MODE", "") or "").strip().lower() in {"1", "true", "yes", "y", "on"} or str(os.getenv("PAPER_MODE", "") or os.getenv("PAPER__ENABLED", "")).strip().lower() in {"1", "true", "yes", "y", "on"}
+    return execution_mode == "LIVE" and live_enabled and not shadow_or_paper
+
+
+def _is_entry_intent(plan: Any) -> bool:
+    intent = str(getattr(plan, "intent", "ENTRY") or "ENTRY").strip().upper()
+    return intent in {"", "ENTRY", "UNKNOWN"}
+
+
+def _is_live_entry(manager: Any, plan: Any) -> bool:
+    return _manager_live_mode(manager) and _is_entry_intent(plan)
+
+
+def _entry_price(manager: Any, plan: Any, quote: Mapping[str, Any]) -> float | None:
     side = str(getattr(plan, "side", "BUY") or "BUY").upper()
+    bid = _positive(quote, "bid", "best_bid", "buy_price")
+    ask = _positive(quote, "ask", "best_ask", "offer", "sell_price")
+
+    if _is_live_entry(manager, plan):
+        # Live option entries must be executable from fresh two-sided quotes.
+        # LTP is allowed for diagnostics and emergency exits elsewhere, but not
+        # for retrying a new risk-increasing entry after broker rejection.
+        if bid is None or ask is None or ask < bid:
+            return None
+        if side != "BUY":
+            return None
+        return float(ask)
+
     keys = ("ask", "best_ask", "offer", "sell_price") if side == "BUY" else ("bid", "best_bid", "buy_price")
     return _positive(quote, *keys) or _positive(quote, "ltp", "last_price", "last_traded_price", "price")
 
@@ -155,11 +190,22 @@ def _max_reprice_deviation_pct(manager: Any) -> float:
                 continue
             if math.isfinite(value) and value > 0:
                 return value
-    return 8.0
+    return 2.5 if _manager_live_mode(manager) else 8.0
 
 
 def _rebuild_plan(manager: Any, plan: Any, quote: Mapping[str, Any], decision: RecoveryDecision, *, quantity: int | None = None) -> Any | None:
-    fresh = _entry_price(plan, quote)
+    fresh = _entry_price(manager, plan, quote)
+    if _is_live_entry(manager, plan) and fresh is None:
+        _log(
+            manager,
+            "warning",
+            "ENTRY_RECOVERY_LIVE_QUOTE_BLOCKED symbol=%s reason=bid_ask_required",
+            getattr(plan, "symbol", ""),
+            event="ENTRY_RECOVERY_LIVE_QUOTE_BLOCKED",
+            symbol=getattr(plan, "symbol", ""),
+            side=getattr(plan, "side", ""),
+        )
+        return None
     deviation = _reprice_deviation_pct(plan, fresh)
     max_deviation = _max_reprice_deviation_pct(manager)
     if deviation is not None and deviation > max_deviation:
@@ -399,7 +445,9 @@ def _recover_submit(original: Callable[..., Any], manager: Any, plan: Any) -> An
                 return _result_like(result, accepted=False, order_id=None, reason="entry_order_state_ambiguous", details={"entry_recovery": {"outcome": state, **evidence}}, broker_attempted=True)
 
         quote = _fresh_quote(manager, str(plan.symbol), getattr(plan, "trace_id", None))
-        fresh = _entry_price(plan, quote)
+        fresh = _entry_price(manager, plan, quote)
+        if _is_live_entry(manager, plan) and fresh is None:
+            return _annotate(result, decision, outcome="live_bid_ask_unavailable")
         quantity: int | None = None
         if decision.action is RecoveryAction.RESIZE_AND_REVALIDATE:
             quantity = _affordable_quantity(manager, plan, float(fresh or 0.0))
@@ -487,6 +535,13 @@ def _finalize_partial_entry(manager: Any, order: Any, payload: Mapping[str, Any]
 
 
 def install_entry_recovery(order_manager_class: type[Any]) -> None:
+    """Compatibility installer for legacy tests only.
+
+    Production uses ``RuntimeOrderManager`` direct method overrides and must not
+    rely on import-time monkey-patching. This hook is retained so older focused
+    tests and external test doubles can exercise the same bounded recovery helper
+    without altering production package import behaviour.
+    """
     if getattr(order_manager_class, "_canonical_entry_recovery_installed", False):
         return
     original_submit = getattr(order_manager_class, "submit_trade_plan_result", None)
@@ -514,4 +569,4 @@ def install_entry_recovery(order_manager_class: type[Any]) -> None:
     setattr(order_manager_class, "_canonical_entry_recovery_installed", True)
 
 
-__all__ = ["install_entry_recovery"]
+__all__ = ["install_entry_recovery", "_recover_submit", "_finalize_partial_entry"]

--- a/tests/execution/test_entry_recovery_hardening.py
+++ b/tests/execution/test_entry_recovery_hardening.py
@@ -56,6 +56,7 @@ class _Manager:
         quote: dict[str, Any] | None = None,
         resolver: Any | None = None,
         margin: float = 20_000.0,
+        live: bool = False,
     ) -> None:
         self.responses = list(responses)
         self.plans: list[TradePlan] = []
@@ -67,6 +68,7 @@ class _Manager:
         self._margin_buffer = 0.95
         self._last_order_decision: dict[str, Any] = {}
         self.margin = margin
+        self.live = live
 
     def submit_trade_plan_result(self, plan: TradePlan) -> TradePlanSubmitResult:
         self.plans.append(plan)
@@ -75,14 +77,17 @@ class _Manager:
     def _resolve_available_margin(self) -> tuple[float, str]:
         return self.margin, "fresh"
 
+    def is_live_mode(self) -> bool:
+        return bool(self.live)
+
 
 install_entry_recovery(_Manager)
 
 
-def _plan(quantity: int = 130) -> TradePlan:
+def _plan(quantity: int = 130, side: str = "BUY") -> TradePlan:
     return TradePlan(
         symbol="NFO:NIFTY2662324050PE",
-        side="BUY",
+        side=side,  # type: ignore[arg-type]
         quantity=quantity,
         entry_price=100.0,
         stop_loss=90.0,
@@ -172,3 +177,52 @@ def test_price_recovery_blocks_excessive_reprice_before_duplicate_entry(monkeypa
     assert recovery["outcome"] == "rebuild_failed"
     assert recovery["reprice_deviation_pct"] == 45.0
     assert recovery["max_reprice_deviation_pct"] == 3.0
+
+
+def test_live_price_recovery_blocks_ltp_only_quote_before_retry(monkeypatch) -> None:
+    monkeypatch.delenv("ENTRY_RECOVERY_MAX_REPRICE_DEVIATION_PCT", raising=False)
+    manager = _Manager(
+        [_reject("invalid limit price: price out of range"), _accept("should-not-submit")],
+        quote={"ltp": 101.0, "last_price": 101.0},
+        live=True,
+    )
+
+    result = manager.submit_trade_plan_result(_plan(quantity=65))
+
+    assert result.accepted is False
+    assert len(manager.plans) == 1
+    recovery = result.details["entry_recovery"]
+    assert recovery["outcome"] == "live_bid_ask_unavailable"
+
+
+def test_live_price_recovery_rebuilds_from_ask_not_ltp(monkeypatch) -> None:
+    monkeypatch.delenv("ENTRY_RECOVERY_MAX_REPRICE_DEVIATION_PCT", raising=False)
+    manager = _Manager(
+        [_reject("invalid limit price: price out of range"), _accept("live-retry")],
+        quote={"bid": 100.5, "ask": 101.0, "ltp": 98.0},
+        live=True,
+    )
+
+    result = manager.submit_trade_plan_result(_plan(quantity=65))
+
+    assert result.accepted is True
+    assert len(manager.plans) == 2
+    assert manager.plans[1].entry_price == 101.0
+    assert manager.plans[1].stop_loss == 91.0
+    assert manager.plans[1].take_profit == 121.0
+    assert result.details["entry_recovery"]["retry_entry"] == 101.0
+
+
+def test_shadow_price_recovery_can_still_use_ltp_fallback() -> None:
+    manager = _Manager(
+        [_reject("invalid limit price: price out of range"), _accept("shadow-retry")],
+        quote={"ltp": 101.0},
+        live=False,
+    )
+
+    result = manager.submit_trade_plan_result(_plan(quantity=65))
+
+    assert result.accepted is True
+    assert len(manager.plans) == 2
+    assert manager.plans[1].entry_price == 101.0
+    assert result.details["entry_recovery"]["retry_entry"] == 101.0


### PR DESCRIPTION
## /plan
1. Keep this first simplification PR narrowly scoped to entry-recovery safety.
2. Preserve existing shadow/test behaviour and legacy focused-test compatibility.
3. For real live entries, require executable bid/ask before retrying a broker-rejected entry.
4. Do not allow LTP-only pricing to rebuild a live risk-increasing entry plan.
5. Add focused regression tests before merging.

## Summary
- live entry recovery now requires a valid two-sided quote and uses the ask for BUY retry plans
- LTP fallback remains available only for non-live/shadow recovery tests and diagnostics
- live SELL entry retry is blocked by the strict live-entry pricing contract
- live default reprice tolerance is tightened to 2.5% while non-live default remains 8%
- `install_entry_recovery()` is retained as a compatibility hook for existing focused tests; production `RuntimeOrderManager` continues to call recovery explicitly
- added regression coverage for live LTP-only rejection, ask-based live rebuild, and shadow LTP fallback

## Validation
- pending CI