### PR TITLE
Narrow canonical execution package exports

### DIFF
--- a/src/nifty_scalper_bot/execution/__init__.py
+++ b/src/nifty_scalper_bot/execution/__init__.py
@@ -1,25 +1,20 @@
-"""Canonical execution package exports."""
+"""Canonical execution package exports.
+
+Only production runtime owners are part of the package-level public API. Older
+stage names are lazy compatibility aliases so existing imports do not create a
+second live lifecycle authority.
+"""
 
 from __future__ import annotations
+
+from typing import Any
 
 from nifty_scalper_bot.execution.adaptive_trailing import (
     AdaptiveTrailingController,
     HardenedAdaptiveTrailingController,
 )
-from nifty_scalper_bot.execution.bracket_manager import (
-    BoundBracketManager,
-    BracketManager,
-    RuntimeBracketManager,
-)
-from nifty_scalper_bot.execution.hardened_bracket_manager import HardenedBracketManager
-from nifty_scalper_bot.execution.canonical_bracket_manager import (
-    CanonicalBracketManager as FillIntegrityBracketManager,
-)
-from nifty_scalper_bot.execution.ledger_bracket_manager import LedgerBracketManager
-from nifty_scalper_bot.execution.order_manager import (
-    OrderManager,
-    RuntimeOrderManager,
-)
+from nifty_scalper_bot.execution.bracket_manager import BoundBracketManager, BracketManager
+from nifty_scalper_bot.execution.order_manager import OrderManager, RuntimeOrderManager
 from nifty_scalper_bot.execution.live_safety_identity import apply_patches as _apply_live_safety_identity_patches
 from nifty_scalper_bot.execution.position_identity_extension import apply_patches as _apply_position_identity_extension_patches
 import nifty_scalper_bot.data.quote_identity_extension as _quote_identity_extension
@@ -35,17 +30,26 @@ _bracket_ownership_extension.apply_patches()
 _trade_plan_identity_guard.apply_patches()
 
 CanonicalBracketManager = BracketManager
+_COMPAT_BRACKET_ALIASES = {
+    "FillIntegrityBracketManager",
+    "HardenedBracketManager",
+    "LedgerBracketManager",
+    "RuntimeBracketManager",
+}
+
+
+def __getattr__(name: str) -> Any:
+    if name in _COMPAT_BRACKET_ALIASES:
+        return BracketManager
+    raise AttributeError(name)
+
 
 __all__ = [
     "AdaptiveTrailingController",
     "BoundBracketManager",
     "BracketManager",
     "CanonicalBracketManager",
-    "FillIntegrityBracketManager",
     "HardenedAdaptiveTrailingController",
-    "HardenedBracketManager",
-    "LedgerBracketManager",
     "OrderManager",
-    "RuntimeBracketManager",
     "RuntimeOrderManager",
 ]

--- a/tests/architecture/test_canonical_bo_ownership.py
+++ b/tests/architecture/test_canonical_bo_ownership.py
@@ -52,10 +52,31 @@ def test_public_runtime_has_one_owner_per_lifecycle_domain() -> None:
     )
     assert execution.OrderManager is OrderManager
     assert execution.BracketManager is BracketManager
+    assert execution.CanonicalBracketManager is BracketManager
     assert execution.AdaptiveTrailingController is AdaptiveTrailingController
     assert issubclass(OrderManager, CoreOrderManager)
     assert issubclass(BracketManager, CoreBracketManager)
     assert issubclass(AdaptiveTrailingController, CoreAdaptiveTrailingController)
+
+
+def test_execution_package_exports_only_canonical_runtime_owners() -> None:
+    assert set(execution.__all__) == {
+        "AdaptiveTrailingController",
+        "BoundBracketManager",
+        "BracketManager",
+        "CanonicalBracketManager",
+        "HardenedAdaptiveTrailingController",
+        "OrderManager",
+        "RuntimeOrderManager",
+    }
+    for name in (
+        "FillIntegrityBracketManager",
+        "HardenedBracketManager",
+        "LedgerBracketManager",
+        "RuntimeBracketManager",
+    ):
+        assert name not in execution.__all__
+        assert getattr(execution, name) is BracketManager
 
 
 def test_execution_package_import_does_not_install_or_replace_runtime_methods() -> None:
@@ -162,6 +183,7 @@ def test_startup_compatibility_adapters_do_not_own_execution_logic() -> None:
     assert "_evaluate_tick" not in lifecycle_methods
     assert "_monitor_loop" not in lifecycle_methods
     assert "_execute_exit" not in lifecycle_methods
+
 
 def test_live_capable_strategies_do_not_bypass_trade_plan_execution() -> None:
     offenders: list[str] = []


### PR DESCRIPTION
## /plan
1. Keep implementation modules intact because the current runtime inheritance chain still depends on them.
2. Narrow package-level production exports to the canonical lifecycle owners.
3. Preserve backwards-compatible access to old bracket stage names as lazy aliases to the canonical `BracketManager`.
4. Add architecture tests so old bracket stage names do not re-enter `execution.__all__` as independent authorities.
5. Validate with the required CI workflows before merge.

## Summary
- `nifty_scalper_bot.execution.__all__` now advertises only canonical runtime owners.
- Deprecated bracket stage names are removed from public package exports.
- Compatibility access remains available via lazy aliases that resolve to `BracketManager`.
- Architecture tests now assert there is only one package-level bracket authority while preserving old import compatibility.

## Safety
- no runtime class deletion
- no strategy changes
- no order/bracket behaviour change
- no shadow-mode changes
- implementation modules remain available for current MRO/test dependencies

## Validation
- pending CI