### PR TITLE
Fail closed for live strategy signals

### DIFF
--- a/src/nifty_scalper_bot/core/__init__.py
+++ b/src/nifty_scalper_bot/core/__init__.py
@@ -8,6 +8,17 @@ from nifty_scalper_bot.utils.logging import get_logger
 # TODO: remove compatibility shim once downstream modules are updated.
 from nifty_scalper_bot.utils.pricing import canonical_price_source  # compat
 
+try:
+    from nifty_scalper_bot.core.strategy_live_safety import apply_patches as _apply_strategy_live_safety
+
+    _apply_strategy_live_safety()
+except Exception as exc:  # noqa: BLE001 - core package import must not crash tooling
+    get_logger(__name__).error(
+        "STRATEGY_LIVE_SAFETY_PATCH_FAILED error=%s",
+        exc,
+        extra={"event": "STRATEGY_LIVE_SAFETY_PATCH_FAILED", "error_type": type(exc).__name__},
+    )
+
 __all__ = ["NiftyScalperApp", "canonical_price_source"]
 
 _LOGGER = get_logger(__name__)

--- a/src/nifty_scalper_bot/core/strategy_live_safety.py
+++ b/src/nifty_scalper_bot/core/strategy_live_safety.py
@@ -83,8 +83,8 @@ def _record(manager: Any, symbol: str, reason: str, trace_id: str | None, detail
             decisions[str(symbol).upper()] = payload
     log_throttled(
         LOG,
-        key=f"strategy_live_safety:{symbol}:{reason}",
-        msg="STRATEGY_LIVE_SAFETY_BLOCK symbol=%s reason=%s",
+        f"strategy_live_safety:{symbol}:{reason}",
+        "STRATEGY_LIVE_SAFETY_BLOCK symbol=%s reason=%s",
         symbol,
         reason,
         interval_sec=30.0,

--- a/src/nifty_scalper_bot/core/strategy_live_safety.py
+++ b/src/nifty_scalper_bot/core/strategy_live_safety.py
@@ -1,8 +1,8 @@
 """Live-safety guard for StrategyManager.
 
-The guard is intentionally narrow: real LIVE mode fails closed on cold history,
-missing DataHub readiness, approved-signal final-filter bypass, and missing live
-signal identity. PAPER/SHADOW behaviour is unchanged.
+Real LIVE mode fails closed on cold history, explicit DataHub indicator
+unreadiness, approved-signal filter bypass, and missing live signal identity.
+PAPER/SHADOW behaviour is unchanged.
 """
 
 from __future__ import annotations
@@ -18,7 +18,13 @@ from nifty_scalper_bot.utils.symbols import normalize_symbol
 
 LOG = get_logger(__name__)
 TRUTHY = {"1", "true", "yes", "y", "on", "live"}
-IDENTITY_KEYS = ("signal_id", "deterministic_signal_id", "bar_timestamp", "signal_timestamp", "timestamp")
+IDENTITY_KEYS = (
+    "signal_id",
+    "deterministic_signal_id",
+    "bar_timestamp",
+    "signal_timestamp",
+    "timestamp",
+)
 
 
 def _env_true(name: str) -> bool:
@@ -31,7 +37,9 @@ def _is_live(manager: Any) -> bool:
         with suppress(Exception):
             return bool(checker())
     mode = str(os.getenv("EXECUTION_MODE", "SHADOW") or "SHADOW").strip().upper()
-    return mode == "LIVE" and (_env_true("ENABLE_LIVE") or _env_true("ENABLE_LIVE_TRADING")) and not (_env_true("PAPER_MODE") or _env_true("PAPER__ENABLED") or _env_true("SHADOW_MODE"))
+    live = _env_true("ENABLE_LIVE") or _env_true("ENABLE_LIVE_TRADING")
+    paper_shadow = _env_true("PAPER_MODE") or _env_true("PAPER__ENABLED") or _env_true("SHADOW_MODE")
+    return mode == "LIVE" and live and not paper_shadow
 
 
 def _bars_available(manager: Any, symbol: str) -> int:
@@ -60,7 +68,13 @@ def _hub_ready(manager: Any) -> bool | None:
     return False
 
 
-def _record(manager: Any, symbol: str, reason: str, trace_id: str | None, details: dict[str, Any] | None = None) -> None:
+def _record(
+    manager: Any,
+    symbol: str,
+    reason: str,
+    trace_id: str | None,
+    details: dict[str, Any] | None = None,
+) -> None:
     payload = dict(details or {})
     payload.setdefault("reason", reason)
     payload.setdefault("trace_id", trace_id)
@@ -68,6 +82,7 @@ def _record(manager: Any, symbol: str, reason: str, trace_id: str | None, detail
     if isinstance(decisions, dict):
         try:
             from nifty_scalper_bot.core.strategy_manager import StrategyNoSignalDecision
+
             decisions[str(symbol).upper()] = StrategyNoSignalDecision(
                 symbol=str(symbol),
                 eval_id=str(trace_id or payload.get("eval_id") or ""),
@@ -78,6 +93,13 @@ def _record(manager: Any, symbol: str, reason: str, trace_id: str | None, detail
                 no_vote_reason_counts={},
                 strategy_reasons={},
                 direction_bias=None,
+                underlying_direction_bias=None,
+                context_age_seconds=None,
+                trigger_vote_count=0,
+                context_vote_count=0,
+                selected_ce=None,
+                selected_pe=None,
+                trace_id=trace_id,
             )
         except Exception:
             decisions[str(symbol).upper()] = payload
@@ -99,9 +121,17 @@ def _readiness_block(manager: Any, symbol: str) -> dict[str, Any] | None:
     required = _required_bars(manager)
     available = _bars_available(manager, symbol)
     if available < required:
-        return {"reason": "live_indicators_not_ready", "bars_available": available, "required_bars": required}
+        return {
+            "reason": "live_indicators_not_ready",
+            "bars_available": available,
+            "required_bars": required,
+        }
     if _hub_ready(manager) is False:
-        return {"reason": "live_hub_indicators_not_ready", "bars_available": available, "required_bars": required}
+        return {
+            "reason": "live_hub_indicators_not_ready",
+            "bars_available": available,
+            "required_bars": required,
+        }
     return None
 
 
@@ -121,21 +151,49 @@ def _final_filter(manager: Any, signal: Signal, trace_id: str | None) -> Signal 
     if callable(filter_fn):
         try:
             if not bool(filter_fn(signal)):
-                _record(manager, signal.symbol, "live_signal_final_filter_block", trace_id, {"confidence": signal.confidence, "action": signal.action})
+                _record(
+                    manager,
+                    signal.symbol,
+                    "live_signal_final_filter_block",
+                    trace_id,
+                    {"confidence": signal.confidence, "action": signal.action},
+                )
                 return None
         except Exception as exc:
-            _record(manager, signal.symbol, "live_signal_final_filter_error", trace_id, {"error": f"{type(exc).__name__}: {exc}"})
+            _record(
+                manager,
+                signal.symbol,
+                "live_signal_final_filter_error",
+                trace_id,
+                {"error": f"{type(exc).__name__}: {exc}"},
+            )
             return None
     orchestrator = getattr(manager, "_orchestrator", None)
     filter_signal = getattr(orchestrator, "filter_signal", None)
     if callable(filter_signal):
         try:
-            filtered = filter_signal(signal, dict(getattr(signal, "metadata", {}) or {}), getattr(manager, "_position_manager", None))
+            filtered = filter_signal(
+                signal,
+                dict(getattr(signal, "metadata", {}) or {}),
+                getattr(manager, "_position_manager", None),
+            )
         except Exception as exc:
-            _record(manager, signal.symbol, "live_signal_orchestrator_error", trace_id, {"error": f"{type(exc).__name__}: {exc}"})
+            _record(
+                manager,
+                signal.symbol,
+                "live_signal_orchestrator_error",
+                trace_id,
+                {"error": f"{type(exc).__name__}: {exc}"},
+            )
             return None
         if filtered is None:
-            _record(manager, signal.symbol, "live_signal_orchestrator_block", trace_id, {"confidence": signal.confidence, "action": signal.action})
+            _record(
+                manager,
+                signal.symbol,
+                "live_signal_orchestrator_block",
+                trace_id,
+                {"confidence": signal.confidence, "action": signal.action},
+            )
             return None
         if isinstance(filtered, Signal):
             return filtered
@@ -150,11 +208,23 @@ def apply_patches() -> None:
         return
     original = cls.generate_signal
 
-    def generate_signal(self: Any, symbol: str, current_price: float, *, trace_id: str | None = None) -> Signal | None:
+    def generate_signal(
+        self: Any,
+        symbol: str,
+        current_price: float,
+        *,
+        trace_id: str | None = None,
+    ) -> Signal | None:
         symbol_norm = normalize_symbol(symbol)
         block = _readiness_block(self, symbol_norm)
         if block is not None:
-            _record(self, symbol_norm, str(block.get("reason") or "live_indicators_not_ready"), trace_id, block)
+            _record(
+                self,
+                symbol_norm,
+                str(block.get("reason") or "live_indicators_not_ready"),
+                trace_id,
+                block,
+            )
             return None
         signal = original(self, symbol, current_price, trace_id=trace_id)
         if signal is None or not _is_live(self):
@@ -166,7 +236,13 @@ def apply_patches() -> None:
                 return None
             metadata = dict(getattr(signal, "metadata", {}) or {})
         if not _has_identity(signal):
-            _record(self, signal.symbol, "live_signal_missing_deterministic_identity", trace_id, {"metadata_keys": sorted(metadata.keys())})
+            _record(
+                self,
+                signal.symbol,
+                "live_signal_missing_deterministic_identity",
+                trace_id,
+                {"metadata_keys": sorted(metadata.keys())},
+            )
             return None
         return _add_identity(signal)
 

--- a/src/nifty_scalper_bot/core/strategy_live_safety.py
+++ b/src/nifty_scalper_bot/core/strategy_live_safety.py
@@ -1,0 +1,176 @@
+"""Live-safety guard for StrategyManager.
+
+The guard is intentionally narrow: real LIVE mode fails closed on cold history,
+missing DataHub readiness, approved-signal final-filter bypass, and missing live
+signal identity. PAPER/SHADOW behaviour is unchanged.
+"""
+
+from __future__ import annotations
+
+from contextlib import suppress
+import os
+from typing import Any
+
+from nifty_scalper_bot.execution.readiness import HistoryReadinessPolicy
+from nifty_scalper_bot.strategies.signal_generator import Signal
+from nifty_scalper_bot.utils.logging import get_logger, log_throttled
+from nifty_scalper_bot.utils.symbols import normalize_symbol
+
+LOG = get_logger(__name__)
+TRUTHY = {"1", "true", "yes", "y", "on", "live"}
+IDENTITY_KEYS = ("signal_id", "deterministic_signal_id", "bar_timestamp", "signal_timestamp", "timestamp")
+
+
+def _env_true(name: str) -> bool:
+    return str(os.getenv(name, "") or "").strip().lower() in TRUTHY
+
+
+def _is_live(manager: Any) -> bool:
+    checker = getattr(manager, "_is_live_mode", None)
+    if callable(checker):
+        with suppress(Exception):
+            return bool(checker())
+    mode = str(os.getenv("EXECUTION_MODE", "SHADOW") or "SHADOW").strip().upper()
+    return mode == "LIVE" and (_env_true("ENABLE_LIVE") or _env_true("ENABLE_LIVE_TRADING")) and not (_env_true("PAPER_MODE") or _env_true("PAPER__ENABLED") or _env_true("SHADOW_MODE"))
+
+
+def _bars_available(manager: Any, symbol: str) -> int:
+    getter = getattr(getattr(manager, "_indicator_engine", None), "get_history", None)
+    if not callable(getter):
+        return 0
+    with suppress(Exception):
+        return len(getter(symbol) or [])
+    return 0
+
+
+def _required_bars(manager: Any) -> int:
+    policy = HistoryReadinessPolicy.from_env()
+    raw = getattr(manager, "_required_candles", policy.option_eval_min_bars)
+    with suppress(Exception):
+        return max(1, int(raw or policy.option_eval_min_bars))
+    return max(1, int(policy.option_eval_min_bars))
+
+
+def _hub_ready(manager: Any) -> bool | None:
+    hub = getattr(manager, "_data_hub", None)
+    if hub is None or not hasattr(hub, "indicators_ready"):
+        return None
+    with suppress(Exception):
+        return bool(getattr(hub, "indicators_ready"))
+    return False
+
+
+def _record(manager: Any, symbol: str, reason: str, trace_id: str | None, details: dict[str, Any] | None = None) -> None:
+    payload = dict(details or {})
+    payload.setdefault("reason", reason)
+    payload.setdefault("trace_id", trace_id)
+    decisions = getattr(manager, "_last_no_signal_decision_by_symbol", None)
+    if isinstance(decisions, dict):
+        try:
+            from nifty_scalper_bot.core.strategy_manager import StrategyNoSignalDecision
+            decisions[str(symbol).upper()] = StrategyNoSignalDecision(
+                symbol=str(symbol),
+                eval_id=str(trace_id or payload.get("eval_id") or ""),
+                final_block_reason=reason,
+                category="live_safety",
+                reason=reason,
+                blocked_at="strategy_live_safety",
+                no_vote_reason_counts={},
+                strategy_reasons={},
+                direction_bias=None,
+            )
+        except Exception:
+            decisions[str(symbol).upper()] = payload
+    log_throttled(
+        LOG,
+        key=f"strategy_live_safety:{symbol}:{reason}",
+        msg="STRATEGY_LIVE_SAFETY_BLOCK symbol=%s reason=%s",
+        interval_sec=30.0,
+        level=30,
+        extra={"event": "STRATEGY_LIVE_SAFETY_BLOCK", "symbol": symbol, **payload},
+    )
+
+
+def _readiness_block(manager: Any, symbol: str) -> dict[str, Any] | None:
+    if not _is_live(manager):
+        return None
+    required = _required_bars(manager)
+    available = _bars_available(manager, symbol)
+    if available < required:
+        return {"reason": "live_indicators_not_ready", "bars_available": available, "required_bars": required}
+    if _hub_ready(manager) is False:
+        return {"reason": "live_hub_indicators_not_ready", "bars_available": available, "required_bars": required}
+    return None
+
+
+def _has_identity(signal: Signal) -> bool:
+    metadata = dict(getattr(signal, "metadata", {}) or {})
+    return any(metadata.get(key) not in (None, "") for key in IDENTITY_KEYS)
+
+
+def _add_identity(signal: Signal) -> Signal:
+    metadata = dict(getattr(signal, "metadata", {}) or {})
+    metadata.setdefault("deterministic_signal_id", signal.deterministic_id)
+    return signal.with_metadata(**metadata)
+
+
+def _final_filter(manager: Any, signal: Signal, trace_id: str | None) -> Signal | None:
+    filter_fn = getattr(manager, "_filter_signal", None)
+    if callable(filter_fn):
+        try:
+            if not bool(filter_fn(signal)):
+                _record(manager, signal.symbol, "live_signal_final_filter_block", trace_id, {"confidence": signal.confidence, "action": signal.action})
+                return None
+        except Exception as exc:
+            _record(manager, signal.symbol, "live_signal_final_filter_error", trace_id, {"error": f"{type(exc).__name__}: {exc}"})
+            return None
+    orchestrator = getattr(manager, "_orchestrator", None)
+    filter_signal = getattr(orchestrator, "filter_signal", None)
+    if callable(filter_signal):
+        try:
+            filtered = filter_signal(signal, dict(getattr(signal, "metadata", {}) or {}), getattr(manager, "_position_manager", None))
+        except Exception as exc:
+            _record(manager, signal.symbol, "live_signal_orchestrator_error", trace_id, {"error": f"{type(exc).__name__}: {exc}"})
+            return None
+        if filtered is None:
+            _record(manager, signal.symbol, "live_signal_orchestrator_block", trace_id, {"confidence": signal.confidence, "action": signal.action})
+            return None
+        if isinstance(filtered, Signal):
+            return filtered
+    return signal
+
+
+def apply_patches() -> None:
+    from nifty_scalper_bot.core import strategy_manager as strategy_module
+
+    cls = strategy_module.StrategyManager
+    if getattr(cls, "_strategy_live_safety_installed", False):
+        return
+    original = cls.generate_signal
+
+    def generate_signal(self: Any, symbol: str, current_price: float, *, trace_id: str | None = None) -> Signal | None:
+        symbol_norm = normalize_symbol(symbol)
+        block = _readiness_block(self, symbol_norm)
+        if block is not None:
+            _record(self, symbol_norm, str(block.get("reason") or "live_indicators_not_ready"), trace_id, block)
+            return None
+        signal = original(self, symbol, current_price, trace_id=trace_id)
+        if signal is None or not _is_live(self):
+            return signal
+        metadata = dict(getattr(signal, "metadata", {}) or {})
+        if bool(metadata.get("is_approved")):
+            signal = _final_filter(self, signal, trace_id)
+            if signal is None:
+                return None
+            metadata = dict(getattr(signal, "metadata", {}) or {})
+        if not _has_identity(signal):
+            _record(self, signal.symbol, "live_signal_missing_deterministic_identity", trace_id, {"metadata_keys": sorted(metadata.keys())})
+            return None
+        return _add_identity(signal)
+
+    cls._strategy_live_safety_original_generate_signal = original
+    cls.generate_signal = generate_signal
+    cls._strategy_live_safety_installed = True
+
+
+__all__ = ["apply_patches"]

--- a/src/nifty_scalper_bot/core/strategy_live_safety.py
+++ b/src/nifty_scalper_bot/core/strategy_live_safety.py
@@ -85,6 +85,8 @@ def _record(manager: Any, symbol: str, reason: str, trace_id: str | None, detail
         LOG,
         key=f"strategy_live_safety:{symbol}:{reason}",
         msg="STRATEGY_LIVE_SAFETY_BLOCK symbol=%s reason=%s",
+        symbol,
+        reason,
         interval_sec=30.0,
         level=30,
         extra={"event": "STRATEGY_LIVE_SAFETY_BLOCK", "symbol": symbol, **payload},

--- a/tests/core/test_strategy_live_safety.py
+++ b/tests/core/test_strategy_live_safety.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from nifty_scalper_bot.core import strategy_live_safety as guard
+from nifty_scalper_bot.core.strategy_manager import StrategyManager
+from nifty_scalper_bot.strategies.signal_generator import Signal
+
+
+class _Engine:
+    def __init__(self, bars: int) -> None:
+        self.bars = bars
+
+    def get_history(self, _symbol: str):
+        return [{} for _ in range(self.bars)]
+
+    def get_indicators(self, _symbol: str, _names):
+        return {}
+
+
+class _Positions:
+    def get_position(self, _symbol: str):
+        return None
+
+
+def _live_env(monkeypatch) -> None:
+    monkeypatch.setenv("EXECUTION_MODE", "LIVE")
+    monkeypatch.setenv("ENABLE_LIVE", "true")
+    monkeypatch.setenv("ENABLE_LIVE_TRADING", "true")
+    monkeypatch.setenv("PAPER_MODE", "false")
+    monkeypatch.setenv("PAPER__ENABLED", "false")
+    monkeypatch.setenv("SHADOW_MODE", "false")
+
+
+def _signal(**metadata) -> Signal:
+    return Signal(
+        action="BUY",
+        symbol="NFO:NIFTY2662324050CE",
+        quantity=1,
+        confidence=0.9,
+        reason="test",
+        stop_loss=90.0,
+        take_profit=120.0,
+        metadata=dict(metadata),
+    )
+
+
+def test_live_strategy_manager_fails_closed_on_cold_history(monkeypatch) -> None:
+    _live_env(monkeypatch)
+    monkeypatch.setenv("OPTION_EVAL_MIN_BARS", "10")
+    manager = StrategyManager([], _Engine(0), _Positions())
+    manager._required_candles = 10
+
+    result = manager.generate_signal("NFO:NIFTY2662324050CE", 100.0, trace_id="cold-history")
+
+    assert result is None
+    decision = manager.get_last_no_signal_decision("NFO:NIFTY2662324050CE")
+    assert decision is not None
+    assert decision.reason == "live_indicators_not_ready"
+    assert decision.category == "live_safety"
+
+
+def test_live_strategy_manager_fails_closed_when_hub_not_ready(monkeypatch) -> None:
+    _live_env(monkeypatch)
+    monkeypatch.setenv("OPTION_EVAL_MIN_BARS", "2")
+    manager = StrategyManager([], _Engine(5), _Positions())
+    manager._required_candles = 2
+    manager._data_hub = SimpleNamespace(indicators_ready=False)
+
+    result = manager.generate_signal("NFO:NIFTY2662324050CE", 100.0, trace_id="hub-not-ready")
+
+    assert result is None
+    decision = manager.get_last_no_signal_decision("NFO:NIFTY2662324050CE")
+    assert decision is not None
+    assert decision.reason == "live_hub_indicators_not_ready"
+
+
+def test_live_approved_signal_must_pass_final_filter(monkeypatch) -> None:
+    _live_env(monkeypatch)
+    manager = SimpleNamespace(
+        _filter_signal=lambda _signal: False,
+        _orchestrator=None,
+        _position_manager=None,
+        _last_no_signal_decision_by_symbol={},
+    )
+
+    result = guard._final_filter(manager, _signal(is_approved=True, timestamp="2026-07-05T09:20:00"), "approved")
+
+    assert result is None
+    decision = manager._last_no_signal_decision_by_symbol["NFO:NIFTY2662324050CE"]
+    assert decision.reason == "live_signal_final_filter_block"
+
+
+def test_live_signal_identity_is_required_and_enriched() -> None:
+    missing = _signal(strategy="SMC")
+    present = _signal(strategy="SMC", timestamp="2026-07-05T09:20:00")
+
+    assert guard._has_identity(missing) is False
+    assert guard._has_identity(present) is True
+    enriched = guard._add_identity(present)
+    assert enriched.metadata["deterministic_signal_id"] == present.deterministic_id


### PR DESCRIPTION
## /plan
1. Keep Step 3 narrow: add a boundary guard around `StrategyManager.generate_signal()` rather than rewriting the large strategy manager body.
2. Preserve paper/shadow/test behaviour.
3. In real LIVE mode, fail closed when strategy history or DataHub indicator readiness is unavailable.
4. Ensure `metadata.is_approved` no longer bypasses final signal filtering.
5. Require live signals to carry deterministic identity/timestamp metadata before they can leave StrategyManager.
6. Add focused unit tests before merge.

## Summary
- adds `core.strategy_live_safety` with a live-only StrategyManager boundary guard
- installs the guard from `core.__init__` with import-safe error logging
- blocks live signals on cold history or explicit DataHub indicator-not-ready state
- re-runs final filter/orchestrator checks for approved signals
- blocks live signals without timestamp/signal identity metadata
- enriches accepted live signals with `deterministic_signal_id`
- adds focused regression tests for readiness, approved-filter block, and signal identity

## Safety
- no strategy indicator changes
- no execution/order changes
- no shadow-mode behaviour change
- no broad rewrite of `strategy_manager.py`

## Validation
- Validate Market-Aware Optimisations: success on head `5e8ffc726c163da0120dbe65ed609f66be46f3ef`
- Live Exit Safety CI: success on head `5e8ffc726c163da0120dbe65ed609f66be46f3ef`