### PR TITLE
docs: add AI skill workflow for safe bot optimization

### DIFF
--- a/.agents/skills/domain-modeling-trading/SKILL.md
+++ b/.agents/skills/domain-modeling-trading/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: domain-modeling-trading
+description: Capture and refine the NIFTY scalper's domain language, ownership boundaries, state model, and irreversible design decisions. Use before PRD/design work or when agents confuse symbols, instruments, states, readiness, orders, or broker concepts.
+---
+
+# Domain Modeling for the NIFTY Scalper
+
+Use this skill to prevent agents from using loose language that creates unsafe code.
+
+The output should be durable vocabulary and invariants, not implementation code.
+
+## Canonical vocabulary
+
+When a term appears in a task, classify it:
+
+| Term group | Examples | Required clarity |
+|---|---|---|
+| Instruments | NIFTY spot, NIFTY future, NIFTY option, CE, PE, ATM, expiry | Context-only vs executable |
+| Tokens/symbols | internal symbol, Zerodha quote symbol, instrument token, tradingsymbol | Which module resolves it |
+| Market data | tick, quote, LTP, bid, ask, spread, depth, OI, IV, OHLC | Source, freshness, quality |
+| State | readiness, arming, cooldown, open position, pending order, kill switch | Owner and transition |
+| Signals | score, direction, entry, SL, target, blockers, reasons | Required output schema |
+| Execution | order request, acknowledgement, fill, rejection, timeout, retry | Idempotency and reconciliation |
+| Modes | LIVE, PAPER, SHADOW, backtest | Separation and allowed side effects |
+
+## Ownership map
+
+Always preserve:
+
+```text
+InstrumentManager      -> contract selection and token resolution
+MarketDataManager      -> ticks, subscriptions, quote quality, OHLC history
+DataHub                -> read-only facade over current market data
+StrategyRunner         -> evaluation loop and signal handoff
+RiskManager            -> risk limits and telemetry
+OrderManager           -> canonical live placement and lifecycle
+PositionManager        -> position and pending-order state
+BracketManager         -> protective exits and trailing decisions
+TelegramController     -> operator commands and diagnostics
+```
+
+## State model minimum
+
+For any stateful change, define:
+
+```text
+state name
+owner module
+entry condition
+exit condition
+allowed transitions
+forbidden transitions
+persistence/restart behavior
+operator diagnostic
+failure behavior
+```
+
+Examples of states that must not be implicit booleans scattered across modules:
+
+```text
+market data degraded
+option basket hydrated
+ready to evaluate
+signal rejected
+risk blocked
+order pending
+position open
+cooldown active
+emergency stopped
+```
+
+## Irreversible or ADR-worthy decisions
+
+Create or update an architecture decision note when changing:
+
+- canonical symbol format
+- contract selection ownership
+- broker response interpretation
+- paper/shadow/live semantics
+- order idempotency model
+- restart/recovery behavior
+- risk sizing semantics
+- strategy signal schema
+- persisted state format
+
+## Output format
+
+```markdown
+## Domain model notes
+Canonical terms:
+- term: meaning, owner, executable/context-only status if relevant
+
+State model:
+- state: owner, transitions, diagnostics
+
+Invariants:
+- invariant 1
+- invariant 2
+
+Architecture decision needed:
+YES/NO
+Reason:
+```
+
+## Reject
+
+Reject or rewrite language like:
+
+```text
+trade NIFTY
+use future as fallback option
+ignore missing token
+if no bid/ask use LTP as tradable quote
+order probably succeeded
+not ready
+some issue in websocket
+```
+
+Replace with explicit instrument, source, state, blocker, and owner language.

--- a/.agents/skills/grill-trading-plan/SKILL.md
+++ b/.agents/skills/grill-trading-plan/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: grill-trading-plan
+description: Stress-test a NIFTY scalper plan before implementation. Use when the request is fuzzy, broad, safety-critical, profit-oriented, or could affect market data, strategy, risk, execution, deployment, or live runtime behavior.
+disable-model-invocation: true
+---
+
+# Grill Trading Plan
+
+Use this skill before writing a PRD or code when the plan is not yet sharp enough.
+
+This is adapted from the spirit of Matt Pocock's `grill-me` / `grill-with-docs` approach, but constrained for a live NIFTY options trading bot.
+
+## Rule
+
+Ask one high-value question at a time only when the answer is not already available from the repository.
+
+Questions the codebase can answer must be answered by inspecting the codebase, not by asking the user.
+
+## First inspect
+
+Before asking the user, inspect:
+
+```text
+AGENTS.md
+docs/AGENT_START_HERE.md
+docs/REPO_MAP.md
+docs/AI_OPTIMIZATION_WORKFLOW.md
+relevant source files
+relevant tests
+recent PR/issue context if available
+```
+
+## Grill dimensions
+
+Resolve these before implementation:
+
+| Dimension | Required answer |
+|---|---|
+| Objective | What exact behavior should change? |
+| Non-goals | What must not change? |
+| Runtime layer | data, hydration, strategy, risk, execution, Telegram, deployment |
+| Owner module | Which module owns the behavior? |
+| Public interface | What should tests call? |
+| Safety invariant | What must remain true to protect capital? |
+| Failure mode | What happens when input/broker/runtime state is bad? |
+| Observability | What exact logs/blockers should operator see? |
+| Validation | Which focused tests prove the change? |
+| Rollback | How to revert safely? |
+
+## Trading-specific questions
+
+Prefer questions like:
+
+- Is this change allowed to affect live order placement, or only paper/shadow behavior?
+- Should this blocker prevent new entries only, or also exits?
+- Is the source of truth broker state, local state, or an already-defined reconciliation result?
+- What is the accepted behavior when quote quality is LTP-only?
+- Which module owns this state transition?
+- Which exact Telegram diagnostic should expose the result?
+
+Avoid vague questions like:
+
+- Should I improve this?
+- Do you want a refactor?
+- Should I add more indicators?
+
+## Output format
+
+Return this before moving to PRD or implementation:
+
+```markdown
+## Clarified plan
+Objective:
+Non-goals:
+Runtime layer:
+Owner module:
+Public interface:
+Safety invariant:
+Failure behavior:
+Observability:
+Validation:
+Rollback:
+
+## Open question
+<only if still required>
+```
+
+## Stop conditions
+
+Do not proceed to implementation when:
+
+- live execution impact is unclear
+- owner module is unclear
+- validation command is unclear
+- the request combines unrelated runtime layers
+- the plan depends on changing risk/profit behavior without explicit user acceptance

--- a/.agents/skills/runtime-contract-validation/SKILL.md
+++ b/.agents/skills/runtime-contract-validation/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: runtime-contract-validation
+description: Validate external and cross-module contracts in the NIFTY scalper. Use when touching config, broker APIs, websocket/polling data, instrument dumps, strategy signals, order requests, broker acknowledgements, Telegram commands, fixtures, or replay/backtest inputs.
+---
+
+# Runtime Contract Validation
+
+Use this skill to prevent malformed or stale external data from reaching strategy and execution logic.
+
+## Boundary rule
+
+All external or unstable input is unknown until validated.
+
+Validate at these boundaries:
+
+```text
+.env / runtime settings
+broker REST response
+websocket tick
+polling quote fallback
+instrument dump row
+active option basket
+DataHub read result
+strategy signal object
+risk decision result
+order request
+broker acknowledgement
+order update / fill event
+Telegram command
+backtest CSV / replay fixture
+```
+
+## Minimum contract fields
+
+### Tick / quote
+
+Require explicit handling of:
+
+```text
+symbol
+instrument token
+instrument type
+ltp
+bid
+ask
+spread
+depth
+source
+timestamp
+timestamp_ms
+fresh/stale decision
+LTP-only status
+```
+
+### Strategy signal
+
+Require:
+
+```text
+symbol
+instrument type
+direction
+score/confidence
+entry
+stop-loss
+target
+quantity intent if applicable
+reasons
+blockers
+bar identity
+timestamp
+```
+
+### Order request
+
+Require:
+
+```text
+symbol
+instrument token
+instrument type
+side
+quantity
+order type
+product
+mode: LIVE/PAPER/SHADOW
+idempotency key
+risk approval reference
+source strategy
+```
+
+### Broker response
+
+Require:
+
+```text
+status
+order id if accepted
+rejection reason if rejected
+raw status classification
+timestamp
+retryability
+position reconciliation requirement
+```
+
+## Failure behavior
+
+Invalid input must result in one of:
+
+```text
+safe rejection
+specific readiness blocker
+specific risk blocker
+operator diagnostic
+retry with bounded policy
+paper/shadow-only quarantine
+```
+
+Never:
+
+- silently coerce unknown data into tradable data
+- treat missing bid/ask as valid full quote
+- infer an option token
+- report failed broker operation as success
+- use broad exception handling to hide contract failures
+
+## Test requirements
+
+For each boundary change, add or identify tests for:
+
+- valid minimal payload
+- missing required field
+- wrong type or unit
+- stale timestamp
+- unsupported instrument type
+- rejection/error payload
+- duplicate or replayed event when relevant
+
+## Implementation guidance
+
+Prefer existing project conventions. In Python, use Pydantic models, dataclasses with explicit validation, enums, typed results, or narrow parser functions where appropriate.
+
+Validation should happen at module boundaries, not scattered across callers.
+
+## Output format
+
+```markdown
+## Contract reviewed
+Boundary:
+Owner module:
+Input shape:
+Validated fields:
+Invalid-input behavior:
+Tests required:
+Files touched:
+Residual risk:
+```

--- a/.agents/skills/to-issues-trading-change/SKILL.md
+++ b/.agents/skills/to-issues-trading-change/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: to-issues-trading-change
+description: Break a resolved NIFTY scalper PRD or plan into small vertical-slice implementation issues before TDD work.
+---
+
+# To Issues: Trading Change
+
+Convert a PRD into narrow, independently reviewable slices. Keep each issue small enough for one focused PR.
+
+## Issue template
+
+```markdown
+## Objective
+One observable behavior to add, fix, or protect.
+
+## Runtime layer
+data | hydration | timestamp | quote-quality | readiness | risk | execution | telegram | deployment | docs
+
+## Files likely touched
+- source file
+- test file
+
+## Files not to touch
+- high-risk or unrelated files
+
+## Acceptance criteria
+- [ ] Observable behavior
+- [ ] Safety invariant
+- [ ] Failure behavior
+- [ ] Operator diagnostic
+
+## TDD slice
+RED:
+GREEN:
+REFACTOR:
+
+## Validation
+Focused command:
+Full command:
+
+## Human checkpoint
+AFK | HITL
+Reason:
+```
+
+## Rules
+
+- Prefer vertical behavior slices over broad refactors.
+- Do not mix unrelated runtime layers in one issue.
+- Put data correctness before readiness, readiness before signal changes, and signal changes before risk or execution changes.
+- Mark a slice as `HITL` when it changes broker assumptions, risk limits, runtime order behavior, or architecture ownership.
+- Return 1 to 5 issues. If more are needed, create an epic first.

--- a/.agents/skills/to-prd-trading-change/SKILL.md
+++ b/.agents/skills/to-prd-trading-change/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: to-prd-trading-change
+description: Convert resolved NIFTY scalper context into a concise PRD before implementation. Use after grill/domain-modeling when a change needs durable requirements, tests, non-goals, rollback, and module impact mapping.
+---
+
+# To PRD: Trading Change
+
+Use this after `grill-trading-plan` and `domain-modeling-trading` have resolved the plan.
+
+Do not ask the user again for information the repository can answer. Inspect the relevant files and tests first.
+
+## PRD structure
+
+Create a PRD with this structure:
+
+```markdown
+# PRD: <change name>
+
+## 1. Problem statement
+What is broken, unsafe, unclear, or missing?
+
+## 2. Current behavior
+Observed behavior with file/function/runtime evidence.
+
+## 3. Desired behavior
+Specific observable behavior after the change.
+
+## 4. Non-goals
+What must not be changed.
+
+## 5. Domain and ownership
+Owner module:
+Affected runtime path:
+Public interface:
+State transition:
+Safety invariant:
+
+## 6. Operator stories
+1. As the operator, ...
+2. As the strategy runner, ...
+3. As the execution layer, ...
+
+## 7. Functional requirements
+FR-1:
+FR-2:
+FR-3:
+
+## 8. Failure behavior
+Bad input:
+Missing token:
+Stale quote:
+Broker rejection:
+Timeout:
+Restart/reconnect:
+
+## 9. Observability
+Logs:
+Metrics:
+Telegram diagnostics:
+Readiness/blocker names:
+
+## 10. Testing plan
+Focused tests:
+Negative tests:
+Fixture/replay tests:
+Validation commands:
+
+## 11. Out of scope
+Explicit exclusions.
+
+## 12. Implementation notes
+Smallest safe module changes.
+Deep-module or seam opportunity if any.
+
+## 13. Rollback
+How to revert safely.
+```
+
+## Impact classification
+
+Every PRD must state whether the change can affect:
+
+```text
+runtime entries
+runtime exits
+paper mode
+shadow mode
+backtest only
+Telegram only
+deployment only
+```
+
+Changes affecting runtime entries or exits require stronger review and focused tests.
+
+## Output rule
+
+The PRD is not an implementation plan. It defines observable behavior, ownership, tests, and non-goals. It must not prescribe broad refactors.
+
+## Quality bar
+
+A good PRD lets an agent implement a narrow TDD slice without guessing:
+
+- which file owns the behavior
+- which public interface to test
+- what failure looks like
+- which safety invariant must hold
+- which validation commands prove it
+- what is explicitly out of scope

--- a/docs/AI_OPTIMIZATION_WORKFLOW.md
+++ b/docs/AI_OPTIMIZATION_WORKFLOW.md
@@ -1,0 +1,178 @@
+# AI Optimization Workflow for NIFTY Scalper Bot
+
+This document defines the safe, sequential workflow for ChatGPT, Codex, Copilot, Claude Code, and human reviewers working on this repository.
+
+The goal is **slow, evidence-based optimization** of the NIFTY options scalper, not broad refactoring or speculative profit optimization.
+
+## Core principle
+
+Every change must improve one of these in order:
+
+1. Repository guardrails and validation
+2. Live option data correctness
+3. Contract/token/subscription correctness
+4. Option OHLC hydration
+5. Timestamp and same-bar evaluation
+6. Quote quality: bid/ask/spread/depth/source/freshness
+7. Readiness and rejection diagnostics
+8. Risk and execution safety
+9. Telegram/operator diagnostics
+10. Strategy scoring
+11. Profit optimization
+
+Do not jump to later layers before earlier layers are stable.
+
+## Skill chain
+
+Use this chain for non-trivial work:
+
+```text
+grill-trading-plan
+→ domain-modeling-trading
+→ to-prd-trading-change
+→ to-issues-trading-change
+→ diagnosing-trading-bugs when bug-driven
+→ tdd-trading-changes
+→ codebase-design when an ownership/interface decision is required
+→ runtime-contract-validation
+→ pre-merge-trading-review
+→ session-worklog
+```
+
+## When to use each skill
+
+| Skill | Use when | Output |
+|---|---|---|
+| `grill-trading-plan` | The request is fuzzy, high-risk, or could affect live behavior | Clarified objective, non-goals, constraints, accepted risks |
+| `domain-modeling-trading` | Terms or ownership are unclear | Canonical glossary and domain invariants |
+| `to-prd-trading-change` | A change needs a durable spec before implementation | PRD with problem, solution, user stories, tests, out-of-scope items |
+| `to-issues-trading-change` | A PRD or plan must become small implementation tasks | Vertical-slice issue breakdown |
+| `diagnosing-trading-bugs` | Runtime symptom, failed test, wrong signal, duplicate order, data issue | Reproduction, hypotheses, root cause |
+| `tdd-trading-changes` | Any behavior change | RED/GREEN/REFACTOR slice |
+| `codebase-design` | Ownership, interface, seam, or module design is unclear | Small design choice with rejected alternatives |
+| `runtime-contract-validation` | External data or cross-module payloads are involved | Boundary contract and invalid-input behavior |
+| `pre-merge-trading-review` | Before merge | Verdict with blockers, validation, and residual risk |
+| `session-worklog` | End of session or handoff | Durable state of work and next action |
+
+## Sequential optimization policy
+
+Agents must prefer one small PR at a time.
+
+Allowed PR scope examples:
+
+```text
+readiness-diagnostics only
+quote-depth propagation only
+same-bar duplicate prevention only
+Telegram command diagnostics only
+risk guard test coverage only
+runtime-contract validation for one broker response only
+```
+
+Disallowed mixed PR examples:
+
+```text
+market data + strategy optimization + execution rewrite
+Telegram cleanup + risk changes
+profit optimization + config defaults
+large refactor + bug fix
+```
+
+## Pre-edit contract
+
+Before editing code, write this mini-contract in the task notes or PR body:
+
+```text
+Objective:
+Non-goals:
+Affected runtime layer:
+Owner module:
+Public interface under test:
+Safety invariant:
+Files likely touched:
+Files explicitly not touched:
+Focused validation:
+Rollback:
+```
+
+## Runtime layer ownership
+
+Preserve these boundaries:
+
+```text
+InstrumentManager      -> contract selection and token resolution
+MarketDataManager      -> ticks, subscriptions, quote quality, OHLC history
+DataHub                -> read-only facade over current market data
+StrategyRunner         -> evaluation loop and signal handoff
+RiskManager            -> risk limits and telemetry
+OrderManager           -> canonical live placement and lifecycle
+PositionManager        -> position and pending-order state
+BracketManager         -> protective exits and trailing decisions
+TelegramController     -> operator commands and diagnostics
+```
+
+Do not introduce duplicate selectors, duplicate history stores, duplicate execution paths, or hidden fallbacks.
+
+## Safety invariants
+
+Every change must preserve:
+
+- NIFTY spot is context-only.
+- NIFTY futures are context-only unless explicitly configured otherwise.
+- Only resolved NIFTY option instruments are executable.
+- Readiness blockers must be specific and observable.
+- Risk, capital, cooldown, open-position, and max-loss guards remain active.
+- Failed broker operations cannot be reported as success.
+- Paper, shadow, and live modes remain separate.
+- No change silently increases live trading risk.
+
+## Runtime contract validation
+
+Treat external data as unknown until validated:
+
+```text
+.env / settings
+broker REST response
+websocket tick
+polling quote fallback
+instrument dump row
+active option basket
+DataHub read result
+strategy signal
+risk decision
+order request
+broker acknowledgement
+fill/order update
+Telegram command
+backtest/replay input
+```
+
+Invalid input must become a safe rejection, readiness blocker, risk blocker, operator diagnostic, or bounded retry. It must not be silently coerced into tradable data.
+
+## Required validation
+
+Minimum validation for code changes:
+
+```bash
+python -m compileall -q src dashboard
+python -m pytest -q
+```
+
+Focused tests must also be run for affected areas where available.
+
+For documentation-only changes, validate by reviewing changed paths and ensuring no production files are touched.
+
+## Merge policy
+
+A PR is mergeable only when:
+
+```text
+scope is narrow
+changed files match the stated objective
+no production trading behavior changes unless intentionally specified
+tests/validation are run or exact blockers are documented
+pre-merge-trading-review has no blocking findings
+residual risk is explicit
+```
+
+Do not merge because the explanation sounds plausible. Merge only when the diff and validation support it.


### PR DESCRIPTION
## Summary

Adds repository-scoped agent guidance for slow, evidence-based optimization of the NIFTY scalper bot.

## Changes

- Added `docs/AI_OPTIMIZATION_WORKFLOW.md`
- Added skill files for:
  - `grill-trading-plan`
  - `domain-modeling-trading`
  - `to-prd-trading-change`
  - `to-issues-trading-change`
  - `runtime-contract-validation`

## Scope

Documentation and agent-instruction files only. No production trading code, config, tests, deployment scripts, or runtime behavior changed.

## Validation

Validated by GitHub compare:

- Base: `main`
- Head: `docs-ai-skill-workflow`
- Status: ahead by 6 commits, behind by 0
- Changed files: 6 added docs/agent-skill markdown files only

No local `pytest`/`compileall` was run because this is documentation-only and the GitHub connector does not provide a runnable checkout.

## Runtime impact

- Market data: none
- Strategy: none
- Risk: none
- Execution: none
- Telegram: none
- Deployment: none

## Residual risk

Existing `.agents/skills/README.md` and `docs/AGENT_START_HERE.md` were not updated because update-file operations were blocked by the connector safety layer. The new workflow doc and skill files are present and isolated.