### PR TITLE
Reduce pre-market boot log noise safely

### DIFF
--- a/src/nifty_scalper_bot/core/__init__.py
+++ b/src/nifty_scalper_bot/core/__init__.py
@@ -19,6 +19,17 @@ except Exception as exc:  # noqa: BLE001 - core package import must not crash to
         extra={"event": "STRATEGY_LIVE_SAFETY_PATCH_FAILED", "error_type": type(exc).__name__},
     )
 
+try:
+    from nifty_scalper_bot.core.boot_log_safety import apply_filters as _apply_boot_log_rate_controls
+
+    _apply_boot_log_rate_controls()
+except Exception as exc:  # noqa: BLE001 - core package import must not crash tooling
+    get_logger(__name__).error(
+        "BOOT_LOG_RATE_CONTROL_FAILED error=%s",
+        exc,
+        extra={"event": "BOOT_LOG_RATE_CONTROL_FAILED", "error_type": type(exc).__name__},
+    )
+
 __all__ = ["NiftyScalperApp", "canonical_price_source"]
 
 _LOGGER = get_logger(__name__)

--- a/src/nifty_scalper_bot/core/boot_log_safety.py
+++ b/src/nifty_scalper_bot/core/boot_log_safety.py
@@ -23,6 +23,10 @@ RUNNER_EVENTS = {
     "runner_post_grace_blocked",
     "RUNNER_EVAL_DECISION",
 }
+BOOTSTRAP_EVENTS = {
+    "LIVE_UNIVERSE_BOOTSTRAP_STATUS",
+    "SELECTED_OPTION_SUBSCRIPTION_STATE",
+}
 
 
 def _event(record: logging.LogRecord) -> str:
@@ -35,8 +39,11 @@ def _event(record: logging.LogRecord) -> str:
 def _fingerprint(record: logging.LogRecord) -> tuple[Any, ...]:
     return (
         _event(record),
+        getattr(record, "symbol", None),
         getattr(record, "selected_ce", None),
         getattr(record, "selected_pe", None),
+        getattr(record, "ce_symbol", None),
+        getattr(record, "pe_symbol", None),
         getattr(record, "futures_symbol", None),
         getattr(record, "atm_strike", None),
         getattr(record, "expiry", None),
@@ -44,6 +51,9 @@ def _fingerprint(record: logging.LogRecord) -> tuple[Any, ...]:
         getattr(record, "token_count", None),
         getattr(record, "count", None),
         getattr(record, "reason", None),
+        getattr(record, "ready", None),
+        getattr(record, "fresh_tick", None),
+        getattr(record, "subscribed", None),
     )
 
 
@@ -57,7 +67,7 @@ class BootLogRateControl(logging.Filter):
 
     def filter(self, record: logging.LogRecord) -> bool:
         event = _event(record)
-        if event not in CONTRACT_EVENTS and event not in RUNNER_EVENTS:
+        if event not in CONTRACT_EVENTS and event not in RUNNER_EVENTS and event not in BOOTSTRAP_EVENTS:
             return True
         fp = _fingerprint(record)
         now = time.monotonic()
@@ -77,6 +87,7 @@ def apply_filters() -> None:
 
     for name in (
         "nifty_scalper_bot.core.instrument_manager",
+        "nifty_scalper_bot.core.app",
         "nifty_scalper_bot.strategies.runner",
     ):
         logger = logging.getLogger(name)

--- a/src/nifty_scalper_bot/core/boot_log_safety.py
+++ b/src/nifty_scalper_bot/core/boot_log_safety.py
@@ -1,0 +1,87 @@
+"""Rate controls for unchanged boot diagnostics.
+
+This module is observational only. It does not alter contracts, orders,
+strategy scores, or readiness decisions.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any
+
+CONTRACT_EVENTS = {
+    "CONTRACT_SSOT_INSTRUMENTS_READY",
+    "CONTRACT_SSOT_FUTURE_SELECTED",
+    "CONTRACT_SSOT_OPTION_EXPIRY_SELECTED",
+    "CONTRACT_SSOT_UNIVERSE_CAPPED",
+    "CONTRACT_SSOT_ATM_PAIR_SELECTED",
+    "CONTRACT_SSOT_BASKET_SELECTED",
+}
+RUNNER_EVENTS = {
+    "strategy_stall_check_skipped_market_closed",
+    "runner_post_grace_blocked",
+    "RUNNER_EVAL_DECISION",
+}
+
+
+def _event(record: logging.LogRecord) -> str:
+    value = getattr(record, "event", "")
+    if value:
+        return str(value)
+    return str(record.getMessage() or "").split(" ", 1)[0]
+
+
+def _fingerprint(record: logging.LogRecord) -> tuple[Any, ...]:
+    return (
+        _event(record),
+        getattr(record, "selected_ce", None),
+        getattr(record, "selected_pe", None),
+        getattr(record, "futures_symbol", None),
+        getattr(record, "atm_strike", None),
+        getattr(record, "expiry", None),
+        getattr(record, "option_count", None),
+        getattr(record, "token_count", None),
+        getattr(record, "count", None),
+        getattr(record, "reason", None),
+    )
+
+
+class BootLogRateControl(logging.Filter):
+    """Allow state changes and periodic unchanged-state heartbeats."""
+
+    def __init__(self, interval_seconds: float = 300.0) -> None:
+        super().__init__()
+        self.interval_seconds = max(30.0, float(interval_seconds))
+        self._last: dict[str, tuple[tuple[Any, ...], float]] = {}
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        event = _event(record)
+        if event not in CONTRACT_EVENTS and event not in RUNNER_EVENTS:
+            return True
+        fp = _fingerprint(record)
+        now = time.monotonic()
+        last = self._last.get(event)
+        if last is None or last[0] != fp or now - last[1] >= self.interval_seconds:
+            self._last[event] = (fp, now)
+            return True
+        return False
+
+
+def _installed(logger: logging.Logger) -> bool:
+    return any(isinstance(item, BootLogRateControl) for item in logger.filters)
+
+
+def apply_filters() -> None:
+    """Install idempotent boot diagnostic rate controls."""
+
+    for name in (
+        "nifty_scalper_bot.core.instrument_manager",
+        "nifty_scalper_bot.strategies.runner",
+    ):
+        logger = logging.getLogger(name)
+        if not _installed(logger):
+            logger.addFilter(BootLogRateControl())
+
+
+__all__ = ["BootLogRateControl", "apply_filters"]

--- a/src/nifty_scalper_bot/core/boot_readiness_safety.py
+++ b/src/nifty_scalper_bot/core/boot_readiness_safety.py
@@ -1,0 +1,36 @@
+"""Session readiness adapter for startup diagnostics."""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+
+def adapt_compute_live_readiness(original: Callable[..., tuple[bool, list[str]]]) -> Callable[..., tuple[bool, list[str]]]:
+    """Return an adapter that keeps option quote checks quiet outside session."""
+
+    def wrapped(**kwargs: Any) -> tuple[bool, list[str]]:
+        if bool(kwargs.get("live_mode")) and not bool(kwargs.get("market_open")):
+            min_bars = int(kwargs.get("option_exec_min_bars") or 1)
+            adjusted = dict(kwargs)
+            adjusted["ce_quote_ready"] = True
+            adjusted["pe_quote_ready"] = True
+            adjusted["ce_bars"] = max(int(adjusted.get("ce_bars") or 0), min_bars)
+            adjusted["pe_bars"] = max(int(adjusted.get("pe_bars") or 0), min_bars)
+            return original(**adjusted)
+        return original(**kwargs)
+
+    return wrapped
+
+
+def apply_app_patch(app_module: Any) -> None:
+    """Install the adapter on a loaded app module."""
+
+    current = getattr(app_module, "compute_live_readiness", None)
+    if not callable(current) or getattr(current, "_session_readiness_adapted", False):
+        return
+    wrapped = adapt_compute_live_readiness(current)
+    setattr(wrapped, "_session_readiness_adapted", True)
+    setattr(app_module, "compute_live_readiness", wrapped)
+
+
+__all__ = ["adapt_compute_live_readiness", "apply_app_patch"]

--- a/tests/core/test_boot_log_safety.py
+++ b/tests/core/test_boot_log_safety.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import logging
+
+from nifty_scalper_bot.core.boot_log_safety import BootLogRateControl
+from nifty_scalper_bot.core.boot_readiness_safety import adapt_compute_live_readiness
+
+
+def _record(event: str, **extra):
+    record = logging.LogRecord(
+        name="nifty_scalper_bot.core.instrument_manager",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg=event,
+        args=(),
+        exc_info=None,
+    )
+    record.event = event
+    for key, value in extra.items():
+        setattr(record, key, value)
+    return record
+
+
+def test_rate_control_allows_changed_basket_state() -> None:
+    control = BootLogRateControl(interval_seconds=30.0)
+    first = _record("CONTRACT_SSOT_BASKET_SELECTED", selected_ce="CE1", selected_pe="PE1", atm_strike=24250)
+    same = _record("CONTRACT_SSOT_BASKET_SELECTED", selected_ce="CE1", selected_pe="PE1", atm_strike=24250)
+    changed = _record("CONTRACT_SSOT_BASKET_SELECTED", selected_ce="CE2", selected_pe="PE2", atm_strike=24300)
+
+    assert control.filter(first) is True
+    assert control.filter(same) is False
+    assert control.filter(changed) is True
+
+
+def test_rate_control_covers_bootstrap_state() -> None:
+    control = BootLogRateControl(interval_seconds=30.0)
+    first = _record("LIVE_UNIVERSE_BOOTSTRAP_STATUS", symbol="NSE:NIFTY", ready=False, reason="waiting")
+    same = _record("LIVE_UNIVERSE_BOOTSTRAP_STATUS", symbol="NSE:NIFTY", ready=False, reason="waiting")
+
+    assert control.filter(first) is True
+    assert control.filter(same) is False
+
+
+def test_session_readiness_adapter_removes_option_details_outside_session() -> None:
+    def original(**kwargs):
+        reasons = []
+        if not kwargs["market_open"]:
+            reasons.append("market_closed")
+        if not kwargs["ce_quote_ready"]:
+            reasons.append("ce_quote")
+        if not kwargs["pe_quote_ready"]:
+            reasons.append("pe_quote")
+        if kwargs["ce_bars"] < kwargs["option_exec_min_bars"]:
+            reasons.append("ce_history")
+        if kwargs["pe_bars"] < kwargs["option_exec_min_bars"]:
+            reasons.append("pe_history")
+        return False, reasons
+
+    adapted = adapt_compute_live_readiness(original)
+    _armed, reasons = adapted(
+        live_mode=True,
+        market_open=False,
+        ce_quote_ready=False,
+        pe_quote_ready=False,
+        ce_bars=0,
+        pe_bars=0,
+        option_exec_min_bars=30,
+    )
+
+    assert reasons == ["market_closed"]


### PR DESCRIPTION
## /plan
1. Keep production behaviour fail-closed: no order, strategy, risk, or contract-selection logic changes.
2. Suppress repeated unchanged boot diagnostics while allowing state changes and periodic heartbeat logs.
3. Cover the noisy events seen in the uploaded logs: CONTRACT_SSOT basket events, selected-option subscription state, live-universe bootstrap status, and closed-market runner diagnostics.
4. Add a pure session-readiness adapter helper for pre-open quote/history checks, but do not force broad app rewiring in this PR after connector write filters blocked direct readiness/app edits.
5. Add focused regression tests and validate through required CI before merge.

## Summary
- adds `core.boot_log_safety.BootLogRateControl`
- installs boot diagnostic rate controls from `core.__init__`
- rate-controls unchanged repeated:
  - `CONTRACT_SSOT_*`
  - `LIVE_UNIVERSE_BOOTSTRAP_STATUS`
  - `SELECTED_OPTION_SUBSCRIPTION_STATE`
  - closed-market runner diagnostics
- adds `core.boot_readiness_safety` pure helper for pre-open readiness normalization
- adds focused tests for basket log state-change behavior, bootstrap log rate control, and the readiness adapter helper

## Safety
- no order placement change
- no bracket/exit change
- no strategy score/threshold change
- no contract selection change
- no change that can arm live trading earlier
- repeated unchanged logs are reduced; state changes still pass through immediately

## Validation
- pending CI