### PR TITLE
Export structured event fields in superlite console

### DIFF
--- a/dashboard/superlite_events.py
+++ b/dashboard/superlite_events.py
@@ -6,14 +6,18 @@ import io
 import re
 from collections.abc import Iterable
 
+from dashboard.event_buffer import SECRET
+
 STAMP = re.compile(r"\[(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} IST)\]")
-SECRET = re.compile(
-    r"(?i)(api[_ -]?key|api[_ -]?secret|access[_ -]?token|request[_ -]?token|password)"
-    r"\s*[:=]\s*\S+"
-)
 FIELD = re.compile(r"\b([a-zA-Z][a-zA-Z0-9_]*)=([^\s,}]+)")
 TRACE = re.compile(r"\btrace_id=([^\s,}]+)")
 RESULT = re.compile(r"\baccepted=([^\s]+).*?\breason=([^\s]+)")
+BASE_COLUMNS = ["timestamp_ist", "type", "message"]
+DETAIL_COLUMNS = [
+    "event", "symbol", "reason", "source", "attempt", "required_bars",
+    "rows", "incoming_ts", "last_ts", "blocker", "failure_reason",
+    "trace_id", "accepted",
+]
 
 EXPECTED_REJECTIONS = {
     "CANDIDATE_REJECTED",
@@ -60,6 +64,23 @@ def fields(message: str) -> dict[str, str]:
     return {key.lower(): value for key, value in FIELD.findall(message)}
 
 
+def _detail_fields(message: str, values: dict[str, str]) -> dict[str, str]:
+    details = {key: values[key] for key in DETAIL_COLUMNS if key in values}
+    upper = message.upper()
+    if "DATA_INTEGRITY_ERROR" in upper and "reason" not in details:
+        details["reason"] = "missing_structured_details"
+        details.setdefault("source", "journal_message")
+    return details
+
+
+def _fieldnames(rows: list[dict[str, str]]) -> list[str]:
+    names = list(BASE_COLUMNS)
+    for key in DETAIL_COLUMNS:
+        if any(row.get(key) for row in rows):
+            names.append(key)
+    return names
+
+
 def _explicit_failure(upper: str, values: dict[str, str]) -> bool:
     if any(token in upper for token in HARD_ERRORS):
         return True
@@ -99,7 +120,9 @@ def parse_event(line: str) -> dict[str, str] | None:
             kind = "RISK"
         else:
             kind = "SYSTEM"
-    return {"timestamp_ist": stamp.group(1), "type": kind, "message": message}
+    row = {"timestamp_ist": stamp.group(1), "type": kind, "message": message}
+    row.update(_detail_fields(message, values))
+    return row
 
 
 def _terminal_key(row: dict[str, str]) -> tuple[str, str] | None:
@@ -143,7 +166,7 @@ def filter_events(rows: list[dict[str, str]], event_type: str, query: str) -> li
 
 def csv_bytes(rows: list[dict[str, str]]) -> bytes:
     target = io.StringIO()
-    writer = csv.DictWriter(target, fieldnames=["timestamp_ist", "type", "message"])
+    writer = csv.DictWriter(target, fieldnames=_fieldnames(rows), extrasaction="ignore")
     writer.writeheader()
     writer.writerows(rows)
     return target.getvalue().encode("utf-8-sig")

--- a/tests/dashboard/test_superlite_event_details.py
+++ b/tests/dashboard/test_superlite_event_details.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from dashboard.superlite_events import csv_bytes, parse_event
+
+
+def test_data_integrity_event_exports_structured_fields() -> None:
+    row = parse_event(
+        "[2026-07-06 11:02:15 IST] ERROR data_integrity_error "
+        "event=data_integrity_error symbol=NFO:NIFTY2670724400CE "
+        "reason=historical_validation_failed source=fetch_historical_safe "
+        "attempt=1 required_bars=50 rows=44"
+    )
+
+    assert row is not None
+    assert row["type"] == "ERROR"
+    assert row["symbol"] == "NFO:NIFTY2670724400CE"
+    assert row["reason"] == "historical_validation_failed"
+    assert row["source"] == "fetch_historical_safe"
+    assert row["attempt"] == "1"
+    assert row["required_bars"] == "50"
+    assert row["rows"] == "44"
+
+    decoded = csv_bytes([row]).decode("utf-8-sig")
+    header = decoded.splitlines()[0]
+    assert "symbol" in header
+    assert "reason" in header
+    assert "source" in header
+    assert "NFO:NIFTY2670724400CE" in decoded
+
+
+def test_bare_data_integrity_event_is_marked_as_missing_details() -> None:
+    row = parse_event("[2026-07-06 11:02:15 IST] ERROR data_integrity_error")
+
+    assert row is not None
+    assert row["type"] == "ERROR"
+    assert row["reason"] == "missing_structured_details"
+    assert row["source"] == "journal_message"


### PR DESCRIPTION
Preserves key=value details from parsed journal events as CSV columns in the independent superlite console. Bare data_integrity_error rows are marked with missing_structured_details so future exports clearly show when source logs still lack symbol/reason/source.