### PR TITLE
Activate session readiness adapter

### DIFF
--- a/src/nifty_scalper_bot/core/__init__.py
+++ b/src/nifty_scalper_bot/core/__init__.py
@@ -71,7 +71,11 @@ def __getattr__(name: str) -> Any:
     )
     if name == "NiftyScalperApp":
         try:
-            from .app import NiftyScalperApp as _App
+            from . import app as _app_module
+            from nifty_scalper_bot.core.boot_readiness_safety import apply_app_patch as _ready_adapter
+
+            _ready_adapter(_app_module)
+            _App = _app_module.NiftyScalperApp
         except Exception as exc:  # noqa: BLE001
             _LOGGER.error(
                 "Failure in core.__getattr__: %s",

--- a/tests/core/test_core_init_session_adapter.py
+++ b/tests/core/test_core_init_session_adapter.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+
+def test_core_exports_app_with_session_adapter() -> None:
+    import nifty_scalper_bot.core as core
+    import nifty_scalper_bot.core.app as app_module
+
+    assert core.NiftyScalperApp is app_module.NiftyScalperApp
+    assert getattr(app_module.compute_live_readiness, "_session_readiness_adapted", False) is True


### PR DESCRIPTION
## /plan
1. Keep this follow-up narrow and based on the latest `main`.
2. Use the already-merged boot diagnostics helpers.
3. Wire the session-readiness adapter into the lazy `NiftyScalperApp` import path.
4. Add one focused regression test proving `core.NiftyScalperApp` activates the adapter.
5. Validate with required CI before merge.

## Summary
- applies `boot_readiness_safety.apply_app_patch()` when `core.NiftyScalperApp` is lazily resolved
- keeps live trading fail-closed outside the market session
- ensures selected-option quote/history details are quieted outside session once the app module is loaded
- adds a focused regression test

## Safety
- no order placement change
- no strategy score or threshold change
- no contract selection change
- no change that can arm live trading earlier

## Validation
- pending CI