### PR TITLE
Fix live alert root causes

### DIFF
--- a/src/nifty_scalper_bot/core/strategy_live_safety.py
+++ b/src/nifty_scalper_bot/core/strategy_live_safety.py
@@ -283,8 +283,8 @@ def apply_patches() -> None:
             signal = _final_filter(self, signal, trace_id)
             if signal is None:
                 return None
-        signal = _add_identity(signal)
-        metadata = dict(getattr(signal, "metadata", {}) or {})
+            signal = _add_identity(signal)
+            metadata = dict(getattr(signal, "metadata", {}) or {})
         orderflow_block = _orderflow_selected_option_block(signal)
         if orderflow_block is not None:
             _record(

--- a/src/nifty_scalper_bot/core/strategy_live_safety.py
+++ b/src/nifty_scalper_bot/core/strategy_live_safety.py
@@ -166,6 +166,8 @@ def _should_backfill_approved_identity(signal: Signal) -> bool:
     metadata = dict(getattr(signal, "metadata", {}) or {})
     if not bool(metadata.get("is_approved")):
         return False
+    if not (_env_true("ORDERS__ENABLE_LIVE") or _env_true("ALLOW_LIVE_ORDERS")):
+        return False
     return any(metadata.get(key) not in (None, "") for key in RUNTIME_CONTEXT_KEYS)
 
 

--- a/src/nifty_scalper_bot/core/strategy_live_safety.py
+++ b/src/nifty_scalper_bot/core/strategy_live_safety.py
@@ -164,9 +164,9 @@ def _add_identity(signal: Signal) -> Signal:
 
 def _should_backfill_approved_identity(signal: Signal) -> bool:
     metadata = dict(getattr(signal, "metadata", {}) or {})
-    if not bool(metadata.get("is_approved")):
+    if not _env_true("STRATEGY_LIVE_BACKFILL_APPROVED_IDENTITY"):
         return False
-    if not (_env_true("ORDERS__ENABLE_LIVE") or _env_true("ALLOW_LIVE_ORDERS")):
+    if not bool(metadata.get("is_approved")):
         return False
     return any(metadata.get(key) not in (None, "") for key in RUNTIME_CONTEXT_KEYS)
 

--- a/src/nifty_scalper_bot/core/strategy_live_safety.py
+++ b/src/nifty_scalper_bot/core/strategy_live_safety.py
@@ -283,7 +283,8 @@ def apply_patches() -> None:
             signal = _final_filter(self, signal, trace_id)
             if signal is None:
                 return None
-            metadata = dict(getattr(signal, "metadata", {}) or {})
+        signal = _add_identity(signal)
+        metadata = dict(getattr(signal, "metadata", {}) or {})
         orderflow_block = _orderflow_selected_option_block(signal)
         if orderflow_block is not None:
             _record(
@@ -303,7 +304,7 @@ def apply_patches() -> None:
                 {"metadata_keys": sorted(metadata.keys())},
             )
             return None
-        return _add_identity(signal)
+        return signal
 
     cls._strategy_live_safety_original_generate_signal = original
     cls.generate_signal = generate_signal

--- a/src/nifty_scalper_bot/core/strategy_live_safety.py
+++ b/src/nifty_scalper_bot/core/strategy_live_safety.py
@@ -304,7 +304,7 @@ def apply_patches() -> None:
                 {"metadata_keys": sorted(metadata.keys())},
             )
             return None
-        return signal
+        return _add_identity(signal)
 
     cls._strategy_live_safety_original_generate_signal = original
     cls.generate_signal = generate_signal

--- a/src/nifty_scalper_bot/core/strategy_live_safety.py
+++ b/src/nifty_scalper_bot/core/strategy_live_safety.py
@@ -25,6 +25,16 @@ IDENTITY_KEYS = (
     "signal_timestamp",
     "timestamp",
 )
+RUNTIME_CONTEXT_KEYS = (
+    "eval_id",
+    "strategy",
+    "strategy_name",
+    "approval_candidate",
+    "selected_ce",
+    "selected_pe",
+    "direction_bias",
+    "underlying_direction_bias",
+)
 
 
 def _env_true(name: str) -> bool:
@@ -150,6 +160,13 @@ def _add_identity(signal: Signal) -> Signal:
     metadata = dict(getattr(signal, "metadata", {}) or {})
     metadata.setdefault("deterministic_signal_id", signal.deterministic_id)
     return signal.with_metadata(**metadata)
+
+
+def _should_backfill_approved_identity(signal: Signal) -> bool:
+    metadata = dict(getattr(signal, "metadata", {}) or {})
+    if not bool(metadata.get("is_approved")):
+        return False
+    return any(metadata.get(key) not in (None, "") for key in RUNTIME_CONTEXT_KEYS)
 
 
 def _orderflow_selected_option_block(signal: Signal) -> dict[str, Any] | None:
@@ -283,7 +300,8 @@ def apply_patches() -> None:
             signal = _final_filter(self, signal, trace_id)
             if signal is None:
                 return None
-            signal = _add_identity(signal)
+            if _should_backfill_approved_identity(signal):
+                signal = _add_identity(signal)
             metadata = dict(getattr(signal, "metadata", {}) or {})
         orderflow_block = _orderflow_selected_option_block(signal)
         if orderflow_block is not None:

--- a/src/nifty_scalper_bot/data/validator.py
+++ b/src/nifty_scalper_bot/data/validator.py
@@ -46,17 +46,15 @@ def validate_tick(raw_tick: Mapping[str, Any]) -> Tick:
     if symbol_raw is None or str(symbol_raw).strip() == '':
         raise DataIntegrityError('Missing symbol')
 
-    # ── 2. TIMESTAMP — prefer exchange time, then internal timestamp ─────────
-    # Zerodha sends 'exchange_timestamp'. Prefer it over wall-clock/internal
-    # timestamps so candle ordering is based on exchange time consistently across
-    # the legacy and deterministic pipelines.
+    # ── 2. TIMESTAMP — accept exchange_timestamp fallback, then wall-clock ───
+    # Zerodha sends 'exchange_timestamp'; internal ticks use 'timestamp'.
+    # If neither is present (e.g. pre-open auction), use current UTC time so
+    # the candle engine can still process the tick rather than silently dropping it.
     timestamp_raw = (
-        raw_tick.get('exchange_timestamp')
-        or raw_tick.get('timestamp')
+        raw_tick.get('timestamp')
+        or raw_tick.get('exchange_timestamp')
     )
     if timestamp_raw is None:
-        # Fallback is kept for non-live/tooling ticks only; production live
-        # Zerodha ticks should carry exchange_timestamp.
         timestamp_raw = _dt.datetime.now(_dt.timezone.utc)
     timestamp = pd.to_datetime(timestamp_raw, utc=True, errors='coerce')
     if pd.isna(timestamp):

--- a/src/nifty_scalper_bot/data/validator.py
+++ b/src/nifty_scalper_bot/data/validator.py
@@ -46,15 +46,17 @@ def validate_tick(raw_tick: Mapping[str, Any]) -> Tick:
     if symbol_raw is None or str(symbol_raw).strip() == '':
         raise DataIntegrityError('Missing symbol')
 
-    # ── 2. TIMESTAMP — accept exchange_timestamp fallback, then wall-clock ───
-    # Zerodha sends 'exchange_timestamp'; internal ticks use 'timestamp'.
-    # If neither is present (e.g. pre-open auction), use current UTC time so
-    # the candle engine can still process the tick rather than silently dropping it.
+    # ── 2. TIMESTAMP — prefer exchange time, then internal timestamp ─────────
+    # Zerodha sends 'exchange_timestamp'. Prefer it over wall-clock/internal
+    # timestamps so candle ordering is based on exchange time consistently across
+    # the legacy and deterministic pipelines.
     timestamp_raw = (
-        raw_tick.get('timestamp')
-        or raw_tick.get('exchange_timestamp')
+        raw_tick.get('exchange_timestamp')
+        or raw_tick.get('timestamp')
     )
     if timestamp_raw is None:
+        # Fallback is kept for non-live/tooling ticks only; production live
+        # Zerodha ticks should carry exchange_timestamp.
         timestamp_raw = _dt.datetime.now(_dt.timezone.utc)
     timestamp = pd.to_datetime(timestamp_raw, utc=True, errors='coerce')
     if pd.isna(timestamp):


### PR DESCRIPTION
## Summary

- Fixes the live-safety identity guard ordering so approved live signals receive a deterministic identity before the identity check runs.
- Aligns the legacy tick validator with the deterministic pipeline by preferring `exchange_timestamp` over internal/wall-clock `timestamp`, reducing false out-of-order candle drops caused by mixed timestamp sources.

## Safety

- No execution/order placement code changed.
- Live-safety guard remains fail-closed.
- Candle monotonicity guards remain intact; this reduces timestamp-source inconsistency rather than weakening candle validation.

## Validation

- Pending GitHub Actions.