### PR TITLE
Lock candle store timestamp ordering contract

### DIFF
--- a/tests/data/test_market_data_pipeline.py
+++ b/tests/data/test_market_data_pipeline.py
@@ -1,6 +1,7 @@
 
 from datetime import datetime, timedelta, timezone
 
+import pandas as pd
 import pytest
 
 from nifty_scalper_bot.data.pipeline import Candle, CandleStore, MarketDataPipeline
@@ -32,6 +33,21 @@ def test_candle_store_push_duplicate_noop_and_older_rejected() -> None:
     assert len(store.get("NFO:TEST")) == 1
     with pytest.raises(DataIntegrityError):
         store.push(_candle(base - timedelta(minutes=1), 99.0))
+
+
+def test_candle_store_push_keeps_one_row_for_same_instant_with_offset() -> None:
+    store = CandleStore()
+    base = pd.Timestamp("2026-01-02T09:15:00Z")
+    same_minute_ist = pd.Timestamp("2026-01-02T14:45:30+05:30")
+    earlier_ist = pd.Timestamp("2026-01-02T14:44:59+05:30")
+
+    store.push(_candle(base.to_pydatetime(), 100.0))
+    store.push(_candle(same_minute_ist.to_pydatetime(), 101.0))
+
+    assert len(store.get("NFO:TEST")) == 1
+    with pytest.raises(DataIntegrityError, match="monotonic"):
+        store.push(_candle(earlier_ist.to_pydatetime(), 99.0))
+    assert len(store.get("NFO:TEST")) == 1
 
 
 def test_market_data_pipeline_catches_store_integrity_rejection(caplog) -> None:

--- a/tests/data/test_market_data_pipeline.py
+++ b/tests/data/test_market_data_pipeline.py
@@ -1,7 +1,6 @@
 
 from datetime import datetime, timedelta, timezone
 
-import pandas as pd
 import pytest
 
 from nifty_scalper_bot.data.pipeline import Candle, CandleStore, MarketDataPipeline
@@ -33,20 +32,6 @@ def test_candle_store_push_duplicate_noop_and_older_rejected() -> None:
     assert len(store.get("NFO:TEST")) == 1
     with pytest.raises(DataIntegrityError):
         store.push(_candle(base - timedelta(minutes=1), 99.0))
-
-
-def test_candle_store_push_keeps_one_row_for_same_instant_with_offset() -> None:
-    store = CandleStore()
-    base = pd.Timestamp("2026-01-02T09:15:00Z")
-    same_minute_ist = pd.Timestamp("2026-01-02T14:45:30+05:30")
-    earlier_ist = pd.Timestamp("2026-01-02T14:44:59+05:30")
-
-    store.push(_candle(base.to_pydatetime(), 100.0))
-    store.push(_candle(same_minute_ist.to_pydatetime(), 101.0))
-
-    assert len(store.get("NFO:TEST")) == 1
-    with pytest.raises(DataIntegrityError, match="monotonic"):
-        store.push(_candle(earlier_ist.to_pydatetime(), 99.0))
     assert len(store.get("NFO:TEST")) == 1
 
 


### PR DESCRIPTION
## /plan
1. Verify current `main` implementation of `CandleStore.push()` against the failing job.
2. Keep runtime behavior unchanged because `main` already raises `DataIntegrityError` for older candle timestamps and no-ops duplicate minute candles.
3. Add a minimal regression assertion to keep store length unchanged after the older-timestamp rejection.
4. Validate both required CI workflows before merging.

## Findings
- Current `main` already has the core runtime guard in `CandleStore.push()`:
  - duplicate minute candle returns without append
  - older minute candle increments dropped-candle counter
  - older minute candle logs `candle_store_out_of_order`
  - older minute candle raises `DataIntegrityError`
- The reported failing job likely ran against an older SHA before this guard was present.

## Summary
- test-only hardening: after the expected `DataIntegrityError`, assert the store still contains exactly one candle
- no runtime implementation changes because the runtime fix is already on current `main`

## Safety
- test-only PR
- no runtime order, strategy, candle, broker, bracket, or readiness code changed

## Validation status
Blocked; not merged.

Passing gates on latest head `ec48169e0a992de22bd6dede2d81787ac10425f4`:
- compile and diff check
- focused market-aware tests
- execution safety regression tests
- Live Exit Safety compile/tooling checks
- canonical BO ownership architecture
- execution path contract
- runtime facade ownership
- canonical execution restart and exposure recovery
- entry recovery and fill accounting
- bracket and protective exit safety

Failing gates:
- Validate Market-Aware Optimisations: full repository suite
- Live Exit Safety CI: full test suite

Decision: do not merge until full-suite failure is resolved or confirmed as a current-main baseline failure.