### PR TITLE
fix: convert market data timestamps to ist

### DIFF
--- a/src/nifty_scalper_bot/data/candle_engine.py
+++ b/src/nifty_scalper_bot/data/candle_engine.py
@@ -12,6 +12,7 @@ import time
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any, Callable, Mapping
+from zoneinfo import ZoneInfo
 
 import pandas as pd
 
@@ -22,123 +23,203 @@ from nifty_scalper_bot.utils.logging import log_throttled
 LOGGER = logging.getLogger(__name__)
 FetchHistoricalFn = Callable[[str], pd.DataFrame | None]
 FetchRecentFn = Callable[[str], pd.DataFrame | None]
-_OHLC_COLUMNS = ('timestamp', 'open', 'high', 'low', 'close', 'volume')
+IST = ZoneInfo("Asia/Kolkata")
+_OHLC_COLUMNS = ("timestamp", "open", "high", "low", "close", "volume")
 
+
+def _to_ist_timestamp(value: Any) -> pd.Timestamp:
+    timestamp = pd.to_datetime(value, utc=True, errors="coerce")
+    if pd.isna(timestamp):
+        return pd.NaT
+    return pd.Timestamp(timestamp).tz_convert(IST)
 
 
 def sanitize(df: pd.DataFrame | None) -> pd.DataFrame:
-    """Drop invalid OHLC rows without synthetic repair. Args: df. Returns: cleaned DataFrame. Raises: None."""
+    """Drop invalid OHLC rows without synthetic repair."""
     if df is None or df.empty:
         return pd.DataFrame(columns=_OHLC_COLUMNS)
     cleaned = df.copy()
-    for col in ('open', 'high', 'low', 'close', 'volume'):
+    for col in ("open", "high", "low", "close", "volume"):
         if col not in cleaned.columns:
             cleaned[col] = 0.0
-        cleaned[col] = pd.to_numeric(cleaned[col], errors='coerce')
-    cleaned['timestamp'] = pd.to_datetime(cleaned.get('timestamp'), utc=True, errors='coerce')
+        cleaned[col] = pd.to_numeric(cleaned[col], errors="coerce")
+    cleaned["timestamp"] = pd.to_datetime(
+        cleaned.get("timestamp"), utc=True, errors="coerce"
+    ).dt.tz_convert(IST)
     before = len(cleaned)
-    cleaned = cleaned.dropna(subset=['timestamp', 'open', 'high', 'low', 'close'])
-    cleaned = cleaned.drop_duplicates(subset='timestamp', keep='last')
-    cleaned = cleaned.sort_values('timestamp').reset_index(drop=True)
+    cleaned = cleaned.dropna(subset=["timestamp", "open", "high", "low", "close"])
+    cleaned = cleaned.drop_duplicates(subset="timestamp", keep="last")
+    cleaned = cleaned.sort_values("timestamp").reset_index(drop=True)
     dropped = before - len(cleaned)
     if dropped > 0:
-        LOGGER.warning('tick_invalid', extra={'event': 'tick_invalid', 'dropped_rows': dropped})
+        LOGGER.warning(
+            "tick_invalid", extra={"event": "tick_invalid", "dropped_rows": dropped}
+        )
     return cleaned[list(_OHLC_COLUMNS)]
 
 
 @dataclass(slots=True)
 class CandleEngine:
-    """Build deterministic 1-minute candles from validated ticks. Args: interval/max_bars. Returns: engine. Raises: ValueError."""
+    """Build deterministic 1-minute candles from validated ticks."""
 
-    interval: str = '1min'
+    interval: str = "1min"
     max_bars: int = 500
-    df: pd.DataFrame = field(default_factory=lambda: pd.DataFrame(columns=_OHLC_COLUMNS))
+    df: pd.DataFrame = field(
+        default_factory=lambda: pd.DataFrame(columns=_OHLC_COLUMNS)
+    )
     current_candle: dict[str, Any] | None = None
     last_candle_close: datetime | None = None
     _last_tick_ts: pd.Timestamp | None = None
 
     def on_tick(self, tick: Mapping[str, Any]) -> dict[str, Any] | None:
-        """Ingest one tick. Args: tick. Returns: finalized candle|None. Raises: DataIntegrityError."""
-        if self.interval != '1min':
-            raise ValueError(f'Unsupported interval: {self.interval}')
+        """Ingest one tick and return a finalized candle when a minute closes."""
+        if self.interval != "1min":
+            raise ValueError(f"Unsupported interval: {self.interval}")
 
-        raw_ts = tick.get('timestamp') if isinstance(tick, dict) else getattr(tick, 'timestamp', None)
-        timestamp = pd.to_datetime(raw_ts, utc=True, errors='coerce')
-        if pd.isna(timestamp) or getattr(timestamp, 'year', 1970) < 2020:
-            log_throttled(LOGGER, 'candle_tick_bad_timestamp', 'CANDLE_TICK_DROPPED reason=bad_timestamp', interval_sec=10.0, level=logging.WARNING)
+        raw_ts = (
+            tick.get("timestamp")
+            if isinstance(tick, dict)
+            else getattr(tick, "timestamp", None)
+        )
+        timestamp = _to_ist_timestamp(raw_ts)
+        if pd.isna(timestamp) or getattr(timestamp, "year", 1970) < 2020:
+            log_throttled(
+                LOGGER,
+                "candle_tick_bad_timestamp",
+                "CANDLE_TICK_DROPPED reason=bad_timestamp",
+                interval_sec=10.0,
+                level=logging.WARNING,
+            )
             return None
         validated = tick if isinstance(tick, Tick) else validate_tick(dict(tick))
         payload = validated.to_dict()
-        timestamp = pd.Timestamp(timestamp)
-        minute = timestamp.floor('1min')
+        timestamp = pd.Timestamp(payload["timestamp"])
+        minute = timestamp.floor("1min")
 
         if self._last_tick_ts is not None:
-            last_ts = pd.to_datetime(self._last_tick_ts, utc=True, errors='coerce')
+            last_ts = _to_ist_timestamp(self._last_tick_ts)
             if not pd.isna(last_ts) and timestamp < last_ts:
-                log_throttled(LOGGER, f"tick_out_of_order_{getattr(self, 'symbol', 'unknown')}", "tick_out_of_order symbol=%s tick_ts=%s last_ts=%s" % (getattr(self, 'symbol', 'unknown'), timestamp.isoformat(), last_ts.isoformat()), interval_sec=10.0, level=logging.DEBUG)
+                log_throttled(
+                    LOGGER,
+                    f"tick_out_of_order_{getattr(self, 'symbol', 'unknown')}",
+                    "tick_out_of_order symbol=%s tick_ts=%s last_ts=%s"
+                    % (
+                        getattr(self, "symbol", "unknown"),
+                        timestamp.isoformat(),
+                        last_ts.isoformat(),
+                    ),
+                    interval_sec=10.0,
+                    level=logging.DEBUG,
+                )
                 return None
 
         finalized: dict[str, Any] | None = None
         if self.current_candle is None:
             self.current_candle = self._start_candle(payload, minute)
-            LOGGER.debug('candle_created', extra={'event': 'candle_created', 'minute': minute.isoformat()})
+            LOGGER.debug(
+                "candle_created",
+                extra={"event": "candle_created", "minute": minute.isoformat()},
+            )
         else:
-            current_minute = pd.Timestamp(self.current_candle['timestamp'])
+            current_minute = pd.Timestamp(self.current_candle["timestamp"])
             if minute < current_minute:
-                log_throttled(LOGGER, f"tick_out_of_order_minute_{getattr(self, 'symbol', 'unknown')}", "tick_out_of_order symbol=%s tick_minute=%s current_minute=%s" % (getattr(self, 'symbol', 'unknown'), minute.isoformat(), current_minute.isoformat()), interval_sec=10.0, level=logging.DEBUG)
+                log_throttled(
+                    LOGGER,
+                    f"tick_out_of_order_minute_{getattr(self, 'symbol', 'unknown')}",
+                    "tick_out_of_order symbol=%s tick_minute=%s current_minute=%s"
+                    % (
+                        getattr(self, "symbol", "unknown"),
+                        minute.isoformat(),
+                        current_minute.isoformat(),
+                    ),
+                    interval_sec=10.0,
+                    level=logging.DEBUG,
+                )
                 return None
             if minute > current_minute:
                 finalized = self._finalize_current_candle()
                 self.current_candle = self._start_candle(payload, minute)
-                LOGGER.debug('candle_created', extra={'event': 'candle_created', 'minute': minute.isoformat()})
+                LOGGER.debug(
+                    "candle_created",
+                    extra={"event": "candle_created", "minute": minute.isoformat()},
+                )
             else:
                 self._update_candle(payload)
 
         self._last_tick_ts = timestamp
         return finalized
 
-    def _start_candle(self, tick: Mapping[str, Any], minute: pd.Timestamp) -> dict[str, Any]:
-        """Initialize a minute candle. Args: tick/minute. Returns: candle. Raises: None."""
-        price = float(tick['ltp'])
+    def _start_candle(
+        self, tick: Mapping[str, Any], minute: pd.Timestamp
+    ) -> dict[str, Any]:
+        """Initialize a minute candle."""
+        price = float(tick["ltp"])
         return {
-            'timestamp': minute,
-            'open': price,
-            'high': price,
-            'low': price,
-            'close': price,
-            'volume': float(tick.get('volume') or 0.0),
+            "timestamp": minute,
+            "open": price,
+            "high": price,
+            "low": price,
+            "close": price,
+            "volume": float(tick.get("volume") or 0.0),
         }
 
     def _update_candle(self, tick: Mapping[str, Any]) -> None:
-        """Update active candle OHLC. Args: tick. Returns: None. Raises: DataIntegrityError."""
+        """Update the active candle OHLC state."""
         if self.current_candle is None:
-            raise DataIntegrityError('missing current candle')
-        price = float(tick['ltp'])
-        self.current_candle['high'] = max(float(self.current_candle['high']), price)
-        self.current_candle['low'] = min(float(self.current_candle['low']), price)
-        self.current_candle['close'] = price
-        self.current_candle['volume'] = float(self.current_candle['volume']) + float(tick.get('volume') or 0.0)
+            raise DataIntegrityError("missing current candle")
+        price = float(tick["ltp"])
+        self.current_candle["high"] = max(float(self.current_candle["high"]), price)
+        self.current_candle["low"] = min(float(self.current_candle["low"]), price)
+        self.current_candle["close"] = price
+        self.current_candle["volume"] = float(self.current_candle["volume"]) + float(
+            tick.get("volume") or 0.0
+        )
 
     def _finalize_current_candle(self) -> dict[str, Any] | None:
-        """Finalize active candle. Args: none. Returns: candle|None. Raises: DataIntegrityError."""
+        """Finalize the active candle."""
         if self.current_candle is None:
             return None
         candle = dict(self.current_candle)
         _validate_ohlc_row(candle)
-        incoming_ts = pd.to_datetime(candle.get('timestamp'), utc=True, errors='coerce')
+        incoming_ts = _to_ist_timestamp(candle.get("timestamp"))
         if pd.isna(incoming_ts):
-            raise DataIntegrityError('candle timestamp is invalid')
-        existing = self.df.dropna(how='all') if self.df is not None else pd.DataFrame(columns=_OHLC_COLUMNS)
+            raise DataIntegrityError("candle timestamp is invalid")
+        existing = (
+            self.df.dropna(how="all")
+            if self.df is not None
+            else pd.DataFrame(columns=_OHLC_COLUMNS)
+        )
         if not existing.empty:
-            last_ts = pd.to_datetime(existing['timestamp'].iloc[-1], utc=True, errors='coerce')
+            last_ts = _to_ist_timestamp(existing["timestamp"].iloc[-1])
             if not pd.isna(last_ts):
                 if incoming_ts < last_ts:
-                    log_throttled(LOGGER, f"candle_out_of_order_{getattr(self, 'symbol', 'unknown')}", "candle_out_of_order symbol=%s incoming_ts=%s last_ts=%s source=candle_engine" % (getattr(self, 'symbol', 'unknown'), incoming_ts.isoformat(), last_ts.isoformat()), interval_sec=30.0, level=logging.WARNING, extra={'event': 'candle_out_of_order', 'symbol': getattr(self, 'symbol', 'unknown'), 'incoming_ts': incoming_ts.isoformat(), 'last_ts': last_ts.isoformat(), 'source': 'candle_engine'})
-                    raise DataIntegrityError('candle timestamps must be monotonic')
+                    log_throttled(
+                        LOGGER,
+                        f"candle_out_of_order_{getattr(self, 'symbol', 'unknown')}",
+                        (
+                            "candle_out_of_order symbol=%s incoming_ts=%s "
+                            "last_ts=%s source=candle_engine"
+                        )
+                        % (
+                            getattr(self, "symbol", "unknown"),
+                            incoming_ts.isoformat(),
+                            last_ts.isoformat(),
+                        ),
+                        interval_sec=30.0,
+                        level=logging.WARNING,
+                        extra={
+                            "event": "candle_out_of_order",
+                            "symbol": getattr(self, "symbol", "unknown"),
+                            "incoming_ts": incoming_ts.isoformat(),
+                            "last_ts": last_ts.isoformat(),
+                            "source": "candle_engine",
+                        },
+                    )
+                    raise DataIntegrityError("candle timestamps must be monotonic")
                 if incoming_ts == last_ts:
                     self.current_candle = None
                     return None
-        new_row = pd.DataFrame([candle]).dropna(how='all')
+        new_row = pd.DataFrame([candle]).dropna(how="all")
         if new_row.empty:
             return None
         if existing.empty:
@@ -146,17 +227,23 @@ class CandleEngine:
         else:
             frame = pd.concat([existing, new_row], ignore_index=True)
         frame = sanitize(frame).tail(self.max_bars).reset_index(drop=True)
-        if frame['timestamp'].duplicated().any():
-            raise DataIntegrityError('duplicate candle timestamps')
-        if not frame['timestamp'].is_monotonic_increasing:
-            raise DataIntegrityError('candle timestamps must be monotonic')
+        if frame["timestamp"].duplicated().any():
+            raise DataIntegrityError("duplicate candle timestamps")
+        if not frame["timestamp"].is_monotonic_increasing:
+            raise DataIntegrityError("candle timestamps must be monotonic")
         self.df = frame
-        self.last_candle_close = pd.to_datetime(candle['timestamp'], utc=True).to_pydatetime()
-        LOGGER.debug('candle_finalized', extra={'event': 'candle_finalized', 'timestamp': pd.Timestamp(candle['timestamp']).isoformat()})
+        self.last_candle_close = _to_ist_timestamp(candle["timestamp"]).to_pydatetime()
+        LOGGER.debug(
+            "candle_finalized",
+            extra={
+                "event": "candle_finalized",
+                "timestamp": pd.Timestamp(candle["timestamp"]).isoformat(),
+            },
+        )
         return candle
 
     def flush(self) -> dict[str, Any] | None:
-        """Flush active candle into finalized store idempotently. Args: none. Returns: candle|None. Raises: DataIntegrityError."""
+        """Flush the active candle into the finalized store."""
         finalized = self._finalize_current_candle()
         if finalized is not None:
             self.current_candle = None
@@ -168,15 +255,15 @@ class CandleEngine:
 
 
 def _validate_ohlc_row(row: Mapping[str, Any]) -> None:
-    """Validate OHLC consistency invariants. Args: row. Returns: None. Raises: DataIntegrityError."""
-    op = float(row['open'])
-    hi = float(row['high'])
-    lo = float(row['low'])
-    cl = float(row['close'])
+    """Validate OHLC consistency invariants."""
+    op = float(row["open"])
+    hi = float(row["high"])
+    lo = float(row["low"])
+    cl = float(row["close"])
     if hi < max(op, cl):
-        raise DataIntegrityError('high must be >= open/close')
+        raise DataIntegrityError("high must be >= open/close")
     if lo > min(op, cl):
-        raise DataIntegrityError('low must be <= open/close')
+        raise DataIntegrityError("low must be <= open/close")
 
 
 def detect_gap(df: pd.DataFrame) -> bool:
@@ -184,7 +271,7 @@ def detect_gap(df: pd.DataFrame) -> bool:
     clean = sanitize(df)
     if len(clean) < 2:
         return False
-    diffs = clean['timestamp'].diff().dropna()
+    diffs = clean["timestamp"].diff().dropna()
     return bool((diffs != pd.Timedelta(minutes=1)).any())
 
 
@@ -195,8 +282,15 @@ def repair_with_backfill(
     fetch_recent_rest: FetchRecentFn,
     max_bars: int = 500,
 ) -> pd.DataFrame:
-    """Merge deterministic recent candles only (no fill/backfill). Args: symbol/df/fetch_recent_rest/max_bars. Returns: DataFrame. Raises: DataIntegrityError."""
-    LOGGER.info('data_integrity_error', extra={'event': 'data_integrity_error', 'symbol': symbol, 'reason': 'repair_with_backfill_deprecated'})
+    """Merge deterministic recent candles only without synthetic fills."""
+    LOGGER.info(
+        "data_integrity_error",
+        extra={
+            "event": "data_integrity_error",
+            "symbol": symbol,
+            "reason": "repair_with_backfill_deprecated",
+        },
+    )
     recent = sanitize(fetch_recent_rest(symbol))
     merged = sanitize(pd.concat([sanitize(df), recent], ignore_index=True))
     return merged.tail(max_bars).reset_index(drop=True)
@@ -210,14 +304,19 @@ def fetch_historical_safe(
     retries: int = 3,
     sleep_seconds: float = 0.5,
 ) -> pd.DataFrame | None:
-    """Fetch historical candles with explicit retries and logs. Args: symbol/fetch_historical/min_required/retries/sleep_seconds. Returns: DataFrame|None. Raises: None."""
+    """Fetch historical candles with explicit retries and logs."""
     for attempt in range(1, retries + 1):
         frame = sanitize(fetch_historical(symbol))
         if validate_dataframe(frame, min_required=min_required):
             return frame
         LOGGER.warning(
-            'data_integrity_error',
-            extra={'event': 'data_integrity_error', 'symbol': symbol, 'attempt': attempt, 'reason': 'historical_validation_failed'},
+            "data_integrity_error",
+            extra={
+                "event": "data_integrity_error",
+                "symbol": symbol,
+                "attempt": attempt,
+                "reason": "historical_validation_failed",
+            },
         )
         if attempt < retries:
             time.sleep(sleep_seconds)
@@ -225,18 +324,21 @@ def fetch_historical_safe(
 
 
 def validate_dataframe(df: pd.DataFrame | None, min_required: int = 50) -> bool:
-    """Validate OHLC frame integrity. Args: df/min_required. Returns: bool. Raises: None."""
+    """Validate OHLC frame integrity."""
     if df is None:
         return False
     clean = sanitize(df)
     if len(clean) < min_required:
         return False
-    if clean['timestamp'].duplicated().any() or not clean['timestamp'].is_monotonic_increasing:
+    if (
+        clean["timestamp"].duplicated().any()
+        or not clean["timestamp"].is_monotonic_increasing
+    ):
         return False
     if detect_gap(clean):
         return False
     try:
-        for row in clean.to_dict(orient='records'):
+        for row in clean.to_dict(orient="records"):
             _validate_ohlc_row(row)
     except DataIntegrityError:
         return False
@@ -244,13 +346,15 @@ def validate_dataframe(df: pd.DataFrame | None, min_required: int = 50) -> bool:
 
 
 def normalize_ohlc_timezone(df: pd.DataFrame) -> pd.DataFrame:
-    """Normalize timestamp index to Asia/Kolkata. Args: df. Returns: DataFrame. Raises: DataIntegrityError."""
+    """Normalize the timestamp index to Asia/Kolkata."""
     normalized = sanitize(df)
-    ts = pd.to_datetime(normalized['timestamp'], errors='coerce', utc=True)
+    ts = pd.to_datetime(
+        normalized["timestamp"], errors="coerce", utc=True
+    ).dt.tz_convert(IST)
     if ts.isna().any():
-        raise DataIntegrityError('Invalid timestamp in normalize_ohlc_timezone')
-    normalized['timestamp'] = ts.dt.tz_convert('Asia/Kolkata')
-    return normalized.set_index('timestamp')
+        raise DataIntegrityError("Invalid timestamp in normalize_ohlc_timezone")
+    normalized["timestamp"] = ts
+    return normalized.set_index("timestamp")
 
 
 def ensure_valid_data(
@@ -261,7 +365,7 @@ def ensure_valid_data(
     fetch_recent_rest: FetchRecentFn,
     min_required: int = 50,
 ) -> pd.DataFrame | None:
-    """Ensure candle cache integrity with startup hydration only. Args: symbol/engine/fetch_historical/fetch_recent_rest/min_required. Returns: DataFrame|None. Raises: None."""
+    """Ensure candle cache integrity using startup hydration only."""
     del fetch_recent_rest
     frame = sanitize(engine.get_df())
     if validate_dataframe(frame, min_required=min_required):
@@ -274,7 +378,14 @@ def ensure_valid_data(
         retries=1,
     )
     if hydrated is None:
-        LOGGER.error('data_integrity_error', extra={'event': 'data_integrity_error', 'symbol': symbol, 'reason': 'insufficient_historical'})
+        LOGGER.error(
+            "data_integrity_error",
+            extra={
+                "event": "data_integrity_error",
+                "symbol": symbol,
+                "reason": "insufficient_historical",
+            },
+        )
         return None
     engine.df = hydrated.tail(engine.max_bars).reset_index(drop=True)
     return engine.get_df()

--- a/src/nifty_scalper_bot/data/pipeline.py
+++ b/src/nifty_scalper_bot/data/pipeline.py
@@ -21,9 +21,9 @@ from __future__ import annotations
 import logging
 import threading
 from collections import deque
-from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from dataclasses import dataclass
 from typing import Any, Dict, Mapping, Optional
+from zoneinfo import ZoneInfo
 
 import pandas as pd
 
@@ -31,6 +31,7 @@ from nifty_scalper_bot.data.source import DataIntegrityError
 from nifty_scalper_bot.utils.logging import log_throttled
 
 LOGGER = logging.getLogger(__name__)
+IST = ZoneInfo("Asia/Kolkata")
 
 MIN_REQUIRED_CANDLES: int = 50  # hard strategy gate
 
@@ -55,6 +56,13 @@ class _Counter:
 
 _DROPPED_TICKS = _Counter()
 _DROPPED_CANDLES = _Counter()
+
+
+def _to_ist_timestamp(value: Any) -> pd.Timestamp:
+    ts = pd.to_datetime(value, utc=True, errors="coerce")
+    if pd.isna(ts):
+        raise DataIntegrityError(f"unparseable timestamp: {value!r}")
+    return pd.Timestamp(ts).tz_convert(IST)
 
 
 def get_dropped_ticks() -> int:
@@ -82,7 +90,7 @@ class ValidatedTick:
 @dataclass(frozen=True, slots=True)
 class Candle:
     symbol: str
-    timestamp: pd.Timestamp   # minute-bucket open time
+    timestamp: pd.Timestamp  # minute-bucket open time
     open: float
     high: float
     low: float
@@ -114,12 +122,12 @@ class TickValidator:
             if not symbol_raw or str(symbol_raw).strip() == "":
                 raise DataIntegrityError("missing symbol")
 
-            ts_raw = raw.get("exchange_timestamp") or raw.get("timestamp") or raw.get("ts")
+            ts_raw = (
+                raw.get("exchange_timestamp") or raw.get("timestamp") or raw.get("ts")
+            )
             if ts_raw is None:
                 raise DataIntegrityError("missing timestamp")
-            ts = pd.to_datetime(ts_raw, utc=True, errors="coerce")
-            if pd.isna(ts):
-                raise DataIntegrityError(f"unparseable timestamp: {ts_raw!r}")
+            ts = _to_ist_timestamp(ts_raw)
 
             ltp_raw = raw.get("ltp") or raw.get("last_price") or raw.get("close")
             if ltp_raw is None:
@@ -174,8 +182,8 @@ class CandleBuilder:
     """
 
     def __init__(self) -> None:
-        self._active: dict[str, dict[str, Any]] = {}   # symbol → active candle
-        self._last_ts: dict[str, pd.Timestamp] = {}    # symbol → last tick ts
+        self._active: dict[str, dict[str, Any]] = {}  # symbol → active candle
+        self._last_ts: dict[str, pd.Timestamp] = {}  # symbol → last tick ts
         self._lock = threading.Lock()
 
     def on_tick(self, tick: ValidatedTick) -> Optional[Candle]:
@@ -224,10 +232,23 @@ class CandleBuilder:
             log_throttled(
                 LOGGER,
                 f"tick_late_bucket:{sym}",
-                f"tick_out_of_order symbol={sym} tick_minute={minute.isoformat()} current_minute={pd.Timestamp(active['timestamp']).isoformat()} total_dropped={_DROPPED_TICKS.value}",
+                (
+                    f"tick_out_of_order symbol={sym} "
+                    f"tick_minute={minute.isoformat()} "
+                    f"current_minute={pd.Timestamp(active['timestamp']).isoformat()} "
+                    f"total_dropped={_DROPPED_TICKS.value}"
+                ),
                 interval_sec=30.0,
                 level=logging.DEBUG,
-                extra={"event": "tick_out_of_order", "symbol": sym, "tick_ts": ts.isoformat(), "tick_minute": minute.isoformat(), "last_ts": last.isoformat() if last is not None else None, "source": "candle_builder", "total_dropped": _DROPPED_TICKS.value},
+                extra={
+                    "event": "tick_out_of_order",
+                    "symbol": sym,
+                    "tick_ts": ts.isoformat(),
+                    "tick_minute": minute.isoformat(),
+                    "last_ts": last.isoformat() if last is not None else None,
+                    "source": "candle_builder",
+                    "total_dropped": _DROPPED_TICKS.value,
+                },
             )
             return None
         elif minute > pd.Timestamp(active["timestamp"]):
@@ -253,8 +274,11 @@ class CandleBuilder:
                 return None
             LOGGER.debug(
                 "candle_closed",
-                extra={"event": "candle_closed", "symbol": sym,
-                       "ts": closed.timestamp.isoformat()},
+                extra={
+                    "event": "candle_closed",
+                    "symbol": sym,
+                    "ts": closed.timestamp.isoformat(),
+                },
             )
         return closed
 
@@ -269,9 +293,12 @@ class CandleBuilder:
                 _DROPPED_CANDLES.increment()
                 LOGGER.error(
                     "candle_ohlc_violation",
-                    extra={"event": "candle_ohlc_violation", "symbol": symbol,
-                           "candle": candle.as_dict(),
-                           "total_dropped": _DROPPED_CANDLES.value},
+                    extra={
+                        "event": "candle_ohlc_violation",
+                        "symbol": symbol,
+                        "candle": candle.as_dict(),
+                        "total_dropped": _DROPPED_CANDLES.value,
+                    },
                 )
                 return None
             return candle
@@ -301,12 +328,24 @@ def _update_candle(candle: dict[str, Any], price: float, volume: float) -> None:
 def _finalize(candle: dict[str, Any]) -> Candle:
     return Candle(
         symbol=str(candle["symbol"]),
-        timestamp=pd.Timestamp(candle["timestamp"]),
+        timestamp=_to_ist_timestamp(candle["timestamp"]),
         open=float(candle["open"]),
         high=float(candle["high"]),
         low=float(candle["low"]),
         close=float(candle["close"]),
         volume=float(candle["volume"]),
+    )
+
+
+def _normalize_candle_timestamp(candle: Candle) -> Candle:
+    return Candle(
+        symbol=candle.symbol,
+        timestamp=_to_ist_timestamp(candle.timestamp),
+        open=candle.open,
+        high=candle.high,
+        low=candle.low,
+        close=candle.close,
+        volume=candle.volume,
     )
 
 
@@ -341,32 +380,49 @@ class CandleStore:
 
     def push(self, candle: Candle) -> None:
         with self._lock:
-            if candle.symbol not in self._store:
-                self._store[candle.symbol] = deque(maxlen=self._maxlen)
-            buf = self._store[candle.symbol]
+            normalized_candle = _normalize_candle_timestamp(candle)
+            if normalized_candle.symbol not in self._store:
+                self._store[normalized_candle.symbol] = deque(maxlen=self._maxlen)
+            buf = self._store[normalized_candle.symbol]
             if buf:
-                last_ts = pd.Timestamp(buf[-1].timestamp).floor("1min")
-                incoming_ts = pd.Timestamp(candle.timestamp).floor("1min")
+                last_ts = _to_ist_timestamp(buf[-1].timestamp).floor("1min")
+                incoming_ts = normalized_candle.timestamp.floor("1min")
                 if incoming_ts == last_ts:
                     return
                 if incoming_ts < last_ts:
                     _DROPPED_CANDLES.increment()
                     log_throttled(
                         LOGGER,
-                        f"candle_store_out_of_order:{candle.symbol}",
-                        f"candle_store_out_of_order symbol={candle.symbol} incoming_ts={incoming_ts.isoformat()} last_ts={last_ts.isoformat()} source=candle_store",
+                        f"candle_store_out_of_order:{normalized_candle.symbol}",
+                        (
+                            "candle_store_out_of_order "
+                            f"symbol={normalized_candle.symbol} "
+                            f"incoming_ts={incoming_ts.isoformat()} "
+                            f"last_ts={last_ts.isoformat()} source=candle_store"
+                        ),
                         interval_sec=30.0,
                         level=logging.WARNING,
-                        extra={"event": "candle_store_out_of_order", "symbol": candle.symbol, "incoming_ts": incoming_ts.isoformat(), "last_ts": last_ts.isoformat(), "source": "candle_store", "total_dropped": _DROPPED_CANDLES.value},
+                        extra={
+                            "event": "candle_store_out_of_order",
+                            "symbol": normalized_candle.symbol,
+                            "incoming_ts": incoming_ts.isoformat(),
+                            "last_ts": last_ts.isoformat(),
+                            "source": "candle_store",
+                            "total_dropped": _DROPPED_CANDLES.value,
+                        },
                     )
-                    raise DataIntegrityError("candle store timestamps must be monotonic")
-            buf.append(candle)
+                    raise DataIntegrityError(
+                        "candle store timestamps must be monotonic"
+                    )
+            buf.append(normalized_candle)
 
     def get(self, symbol: str) -> list[Candle]:
         with self._lock:
             return list(self._store.get(symbol, []))
 
-    def candles_ready(self, symbol: str, min_required: int = MIN_REQUIRED_CANDLES) -> bool:
+    def candles_ready(
+        self, symbol: str, min_required: int = MIN_REQUIRED_CANDLES
+    ) -> bool:
         """STEP 7 gate: no flags — just count >= min_required."""
         return len(self.get(symbol)) >= min_required
 
@@ -382,9 +438,7 @@ class CandleStore:
             for row in bars:
                 try:
                     ts_raw = row.get("timestamp") or row.get("date")
-                    ts = pd.to_datetime(ts_raw, utc=True, errors="coerce")
-                    if pd.isna(ts):
-                        continue
+                    ts = _to_ist_timestamp(ts_raw)
                     c = Candle(
                         symbol=symbol,
                         timestamp=ts.floor("1min"),
@@ -395,12 +449,31 @@ class CandleStore:
                         volume=float(row.get("volume") or 0),
                     )
                     if not _check_ohlc(c):
-                        LOGGER.warning("candle_store_seed_rejected", extra={"event": "candle_store_seed_rejected", "symbol": symbol, "incoming_ts": c.timestamp.isoformat(), "source": "seed", "reason": "ohlc_invalid"})
+                        LOGGER.warning(
+                            "candle_store_seed_rejected",
+                            extra={
+                                "event": "candle_store_seed_rejected",
+                                "symbol": symbol,
+                                "incoming_ts": c.timestamp.isoformat(),
+                                "source": "seed",
+                                "reason": "ohlc_invalid",
+                            },
+                        )
                         continue
                     by_minute[c.timestamp] = c
                 except (TypeError, ValueError, DataIntegrityError) as exc:
-                    LOGGER.warning("candle_store_seed_rejected", extra={"event": "candle_store_seed_rejected", "symbol": symbol, "source": "seed", "reason": type(exc).__name__})
-            buf: deque[Candle] = deque((by_minute[key] for key in sorted(by_minute)), maxlen=self._maxlen)
+                    LOGGER.warning(
+                        "candle_store_seed_rejected",
+                        extra={
+                            "event": "candle_store_seed_rejected",
+                            "symbol": symbol,
+                            "source": "seed",
+                            "reason": type(exc).__name__,
+                        },
+                    )
+            buf: deque[Candle] = deque(
+                (by_minute[key] for key in sorted(by_minute)), maxlen=self._maxlen
+            )
             self._store[symbol] = buf
         LOGGER.info(
             "candle_store_seeded",
@@ -413,6 +486,7 @@ class CandleStore:
 
     def to_dataframe(self, symbol: str) -> "pd.DataFrame":
         import pandas as _pd
+
         candles = self.get(symbol)
         if not candles:
             return _pd.DataFrame()
@@ -464,7 +538,12 @@ class MarketDataPipeline:
                 log_throttled(
                     LOGGER,
                     f"pipeline_candle_store_rejected:{candle.symbol}",
-                    f"pipeline_candle_store_rejected symbol={candle.symbol} incoming_ts={candle.timestamp.isoformat()} error_type={type(exc).__name__} reason={exc} source=market_data_pipeline",
+                    (
+                        f"pipeline_candle_store_rejected symbol={candle.symbol} "
+                        f"incoming_ts={candle.timestamp.isoformat()} "
+                        f"error_type={type(exc).__name__} "
+                        f"reason={exc} source=market_data_pipeline"
+                    ),
                     interval_sec=30.0,
                     level=logging.WARNING,
                     extra={
@@ -479,7 +558,9 @@ class MarketDataPipeline:
                 return None
         return candle
 
-    def candles_ready(self, symbol: str, min_required: int = MIN_REQUIRED_CANDLES) -> bool:
+    def candles_ready(
+        self, symbol: str, min_required: int = MIN_REQUIRED_CANDLES
+    ) -> bool:
         """STEP 7: strategy gate — pure count, no boolean flags."""
         return self.store.candles_ready(symbol, min_required)
 

--- a/src/nifty_scalper_bot/data/pipeline_overlap_guard.py
+++ b/src/nifty_scalper_bot/data/pipeline_overlap_guard.py
@@ -9,11 +9,9 @@ dropping a small overlap window at the hydration/live boundary.
 
 from __future__ import annotations
 
-from collections import deque
 import os
+from collections import deque
 from typing import Any
-
-import pandas as pd
 
 
 def _float_env(name: str, default: float) -> float:
@@ -42,12 +40,15 @@ def install_candle_store_overlap_guard() -> bool:
 
     def push(self: Any, candle: Any) -> None:
         with self._lock:
-            if candle.symbol not in self._store:
-                self._store[candle.symbol] = deque(maxlen=self._maxlen)
-            buf = self._store[candle.symbol]
+            normalized_candle = pipeline_module._normalize_candle_timestamp(candle)
+            if normalized_candle.symbol not in self._store:
+                self._store[normalized_candle.symbol] = deque(maxlen=self._maxlen)
+            buf = self._store[normalized_candle.symbol]
             if buf:
-                last_ts = pd.Timestamp(buf[-1].timestamp).floor("1min")
-                incoming_ts = pd.Timestamp(candle.timestamp).floor("1min")
+                last_ts = pipeline_module._to_ist_timestamp(buf[-1].timestamp).floor(
+                    "1min"
+                )
+                incoming_ts = normalized_candle.timestamp.floor("1min")
                 if incoming_ts == last_ts:
                     return
                 if incoming_ts < last_ts:
@@ -58,14 +59,17 @@ def install_candle_store_overlap_guard() -> bool:
                     age_delta = max(0.0, (last_ts - incoming_ts).total_seconds())
                     if age_delta <= overlap_seconds:
                         pipeline_module.LOGGER.debug(
-                            "candle_store_overlap_duplicate symbol=%s incoming_ts=%s last_ts=%s age_delta_s=%.1f",
-                            candle.symbol,
+                            (
+                                "candle_store_overlap_duplicate symbol=%s "
+                                "incoming_ts=%s last_ts=%s age_delta_s=%.1f"
+                            ),
+                            normalized_candle.symbol,
                             incoming_ts.isoformat(),
                             last_ts.isoformat(),
                             age_delta,
                             extra={
                                 "event": "candle_store_overlap_duplicate",
-                                "symbol": candle.symbol,
+                                "symbol": normalized_candle.symbol,
                                 "incoming_ts": incoming_ts.isoformat(),
                                 "last_ts": last_ts.isoformat(),
                                 "age_delta_s": age_delta,
@@ -78,25 +82,31 @@ def install_candle_store_overlap_guard() -> bool:
                     pipeline_module._DROPPED_CANDLES.increment()
                     pipeline_module.log_throttled(
                         pipeline_module.LOGGER,
-                        f"candle_store_out_of_order:{candle.symbol}",
+                        f"candle_store_out_of_order:{normalized_candle.symbol}",
                         (
                             "candle_store_out_of_order symbol=%s incoming_ts=%s "
                             "last_ts=%s source=candle_store"
                         )
-                        % (candle.symbol, incoming_ts.isoformat(), last_ts.isoformat()),
+                        % (
+                            normalized_candle.symbol,
+                            incoming_ts.isoformat(),
+                            last_ts.isoformat(),
+                        ),
                         interval_sec=30.0,
                         level=pipeline_module.logging.WARNING,
                         extra={
                             "event": "candle_store_out_of_order",
-                            "symbol": candle.symbol,
+                            "symbol": normalized_candle.symbol,
                             "incoming_ts": incoming_ts.isoformat(),
                             "last_ts": last_ts.isoformat(),
                             "source": "candle_store",
                             "total_dropped": pipeline_module._DROPPED_CANDLES.value,
                         },
                     )
-                    raise pipeline_module.DataIntegrityError("candle store timestamps must be monotonic")
-            buf.append(candle)
+                    raise pipeline_module.DataIntegrityError(
+                        "candle store timestamps must be monotonic"
+                    )
+            buf.append(normalized_candle)
 
     push.__name__ = getattr(current, "__name__", "push")
     push.__doc__ = getattr(current, "__doc__", None)

--- a/src/nifty_scalper_bot/data/validator.py
+++ b/src/nifty_scalper_bot/data/validator.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 import datetime as _dt
 from dataclasses import dataclass
-from datetime import datetime
 from typing import Any, Mapping
+from zoneinfo import ZoneInfo
 
 import pandas as pd
 
 from nifty_scalper_bot.data.source import DataIntegrityError
+
+IST = ZoneInfo("Asia/Kolkata")
 
 
 @dataclass(frozen=True, slots=True)
@@ -24,10 +26,10 @@ class Tick:
     def to_dict(self) -> dict[str, Any]:
         """Return dictionary representation for legacy call sites."""
         return {
-            'symbol': self.symbol,
-            'timestamp': self.timestamp,
-            'ltp': self.ltp,
-            'volume': self.volume,
+            "symbol": self.symbol,
+            "timestamp": self.timestamp,
+            "ltp": self.ltp,
+            "volume": self.volume,
         }
 
 
@@ -42,41 +44,40 @@ def validate_tick(raw_tick: Mapping[str, Any]) -> Tick:
     Args: raw_tick. Returns: Tick. Raises: DataIntegrityError.
     """
     # ── 1. SYMBOL ────────────────────────────────────────────────────────────
-    symbol_raw = raw_tick.get('symbol')
-    if symbol_raw is None or str(symbol_raw).strip() == '':
-        raise DataIntegrityError('Missing symbol')
+    symbol_raw = raw_tick.get("symbol")
+    if symbol_raw is None or str(symbol_raw).strip() == "":
+        raise DataIntegrityError("Missing symbol")
 
     # ── 2. TIMESTAMP — accept exchange_timestamp fallback, then wall-clock ───
     # Zerodha sends 'exchange_timestamp'; internal ticks use 'timestamp'.
-    # If neither is present (e.g. pre-open auction), use current UTC time so
+    # If neither is present (e.g. pre-open auction), use current IST time so
     # the candle engine can still process the tick rather than silently dropping it.
-    timestamp_raw = (
-        raw_tick.get('timestamp')
-        or raw_tick.get('exchange_timestamp')
-    )
+    timestamp_raw = raw_tick.get("timestamp") or raw_tick.get("exchange_timestamp")
     if timestamp_raw is None:
-        timestamp_raw = _dt.datetime.now(_dt.timezone.utc)
-    timestamp = pd.to_datetime(timestamp_raw, utc=True, errors='coerce')
+        timestamp_raw = _dt.datetime.now(IST)
+    timestamp = pd.to_datetime(timestamp_raw, utc=True, errors="coerce")
     if pd.isna(timestamp):
-        raise DataIntegrityError('Invalid timestamp')
+        raise DataIntegrityError("Invalid timestamp")
+    timestamp = pd.Timestamp(timestamp).tz_convert(IST)
 
     # ── 3. LTP — accept last_price (Zerodha field name) as alias ─────────────
-    ltp_raw = raw_tick.get('ltp') or raw_tick.get('last_price')
+    ltp_raw = raw_tick.get("ltp") or raw_tick.get("last_price")
     if ltp_raw is None:
-        raise DataIntegrityError('Missing ltp/last_price')
+        raise DataIntegrityError("Missing ltp/last_price")
     ltp = float(ltp_raw)
     if ltp <= 0:
-        raise DataIntegrityError('Invalid price')
+        raise DataIntegrityError("Invalid price")
 
     # ── 4. VOLUME ────────────────────────────────────────────────────────────
-    volume_raw = 0.0
-    if 'volume_delta' in raw_tick:
-        volume_raw = raw_tick.get('volume_delta')
-    elif 'volume' in raw_tick:
-        volume_raw = raw_tick.get('volume')
-    elif 'volume_traded' in raw_tick:
-        # Legacy/raw fallback only. This path should not be used for MDM-normalized ticks.
-        volume_raw = raw_tick.get('volume_traded')
+    volume_raw: Any = 0.0
+    if "volume_delta" in raw_tick:
+        volume_raw = raw_tick.get("volume_delta")
+    elif "volume" in raw_tick:
+        volume_raw = raw_tick.get("volume")
+    elif "volume_traded" in raw_tick:
+        # Legacy/raw fallback only.
+        # This path should not be used for MDM-normalized ticks.
+        volume_raw = raw_tick.get("volume_traded")
     else:
         volume_raw = 0.0
 
@@ -87,7 +88,7 @@ def validate_tick(raw_tick: Mapping[str, Any]) -> Tick:
 
     return Tick(
         symbol=str(symbol_raw),
-        timestamp=pd.Timestamp(timestamp),
+        timestamp=timestamp,
         ltp=ltp,
         volume=volume,
     )

--- a/tests/data/test_candle_engine.py
+++ b/tests/data/test_candle_engine.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
 
 import pandas as pd
 
@@ -13,6 +14,8 @@ from nifty_scalper_bot.data.candle_engine import (
     sanitize,
     validate_dataframe,
 )
+
+IST = ZoneInfo("Asia/Kolkata")
 
 
 def _tick(ts: datetime, price: float) -> dict[str, float | datetime]:
@@ -33,6 +36,10 @@ def test_candle_engine_finalizes_closed_candle() -> None:
     assert row["high"] == 102.0
     assert row["low"] == 100.0
     assert row["close"] == 102.0
+    assert row["timestamp"].isoformat() == "2026-01-02T14:45:00+05:30"
+    assert row["timestamp"].tzinfo == IST
+    assert engine.last_candle_close is not None
+    assert engine.last_candle_close.isoformat() == "2026-01-02T14:45:00+05:30"
 
 
 def test_detect_gap_returns_true_for_missing_minute() -> None:
@@ -136,6 +143,26 @@ def test_sanitize_deduplicates_and_drops_missing_close() -> None:
     assert cleaned["close"].isna().sum() == 0
 
 
+def test_sanitize_converts_timestamps_to_ist() -> None:
+    dirty = pd.DataFrame(
+        [
+            {
+                "timestamp": "2026-01-02T09:15:00Z",
+                "open": 100.0,
+                "high": 101.0,
+                "low": 99.0,
+                "close": 100.5,
+                "volume": 10,
+            }
+        ]
+    )
+
+    cleaned = sanitize(dirty)
+
+    assert cleaned.iloc[0]["timestamp"].isoformat() == "2026-01-02T14:45:00+05:30"
+    assert cleaned.iloc[0]["timestamp"].tzinfo == IST
+
+
 def test_repair_with_backfill_merges_existing_and_recent() -> None:
     ts = datetime(2026, 1, 2, 9, 15, tzinfo=timezone.utc)
     old = pd.DataFrame(
@@ -194,12 +221,27 @@ def test_candle_engine_equal_duplicate_is_noop_and_older_rejected() -> None:
     ts = datetime(2026, 1, 2, 9, 15, tzinfo=timezone.utc)
     engine.on_tick(_tick(ts, 100.0))
     assert engine.flush() is not None
-    engine.current_candle = {"timestamp": pd.Timestamp(ts), "open": 100.0, "high": 100.0, "low": 100.0, "close": 100.0, "volume": 1.0}
+    engine.current_candle = {
+        "timestamp": pd.Timestamp(ts),
+        "open": 100.0,
+        "high": 100.0,
+        "low": 100.0,
+        "close": 100.0,
+        "volume": 1.0,
+    }
     assert engine.flush() is None
     assert engine.current_candle is None
     assert len(engine.get_df()) == 1
-    engine.current_candle = {"timestamp": pd.Timestamp(ts - timedelta(minutes=1)), "open": 99.0, "high": 99.0, "low": 99.0, "close": 99.0, "volume": 1.0}
+    engine.current_candle = {
+        "timestamp": pd.Timestamp(ts - timedelta(minutes=1)),
+        "open": 99.0,
+        "high": 99.0,
+        "low": 99.0,
+        "close": 99.0,
+        "volume": 1.0,
+    }
     from nifty_scalper_bot.data.source import DataIntegrityError
+
     try:
         engine.flush()
     except DataIntegrityError:

--- a/tests/data/test_market_data_pipeline.py
+++ b/tests/data/test_market_data_pipeline.py
@@ -1,26 +1,49 @@
-
 from datetime import datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
 
 import pytest
 
 from nifty_scalper_bot.data.pipeline import Candle, CandleStore, MarketDataPipeline
 from nifty_scalper_bot.data.source import DataIntegrityError
 
+IST = ZoneInfo("Asia/Kolkata")
+
 
 def _candle(ts: datetime, close: float = 100.0) -> Candle:
-    return Candle(symbol="NFO:TEST", timestamp=ts, open=close, high=close, low=close, close=close, volume=1.0)
+    return Candle(
+        symbol="NFO:TEST",
+        timestamp=ts,
+        open=close,
+        high=close,
+        low=close,
+        close=close,
+        volume=1.0,
+    )
 
 
 def test_candle_store_seed_sorts_and_deduplicates() -> None:
     store = CandleStore()
     base = datetime(2026, 1, 2, 9, 15, tzinfo=timezone.utc)
-    store.seed("NFO:TEST", [
-        {"timestamp": base + timedelta(minutes=1), "open": 101, "high": 101, "low": 101, "close": 101},
-        {"timestamp": base, "open": 100, "high": 100, "low": 100, "close": 100},
-        {"timestamp": base, "open": 102, "high": 102, "low": 102, "close": 102},
-    ])
+    store.seed(
+        "NFO:TEST",
+        [
+            {
+                "timestamp": base + timedelta(minutes=1),
+                "open": 101,
+                "high": 101,
+                "low": 101,
+                "close": 101,
+            },
+            {"timestamp": base, "open": 100, "high": 100, "low": 100, "close": 100},
+            {"timestamp": base, "open": 102, "high": 102, "low": 102, "close": 102},
+        ],
+    )
     rows = store.get("NFO:TEST")
-    assert [row.timestamp.to_pydatetime() for row in rows] == [base, base + timedelta(minutes=1)]
+    assert [row.timestamp.isoformat() for row in rows] == [
+        "2026-01-02T14:45:00+05:30",
+        "2026-01-02T14:46:00+05:30",
+    ]
+    assert all(row.timestamp.tzinfo == IST for row in rows)
     assert rows[0].close == 102.0
 
 
@@ -31,17 +54,56 @@ def test_candle_store_push_duplicate_noop_and_older_rejected() -> None:
     store.push(_candle(base, 101.0))
     assert len(store.get("NFO:TEST")) == 1
     with pytest.raises(DataIntegrityError):
-        store.push(_candle(base - timedelta(minutes=1), 99.0))
+        store.push(_candle(base - timedelta(minutes=3), 99.0))
     assert len(store.get("NFO:TEST")) == 1
 
 
 def test_market_data_pipeline_catches_store_integrity_rejection(caplog) -> None:
     pipeline = MarketDataPipeline()
     base = datetime(2026, 1, 2, 9, 15, tzinfo=timezone.utc)
-    pipeline.store.push(_candle(base + timedelta(minutes=1), 101.0))
+    pipeline.store.push(_candle(base + timedelta(minutes=3), 101.0))
 
-    assert pipeline.on_tick({"symbol": "NFO:TEST", "timestamp": base, "ltp": 100.0, "volume": 1}) is None
-    candle = pipeline.on_tick({"symbol": "NFO:TEST", "timestamp": base + timedelta(minutes=1), "ltp": 102.0, "volume": 1})
+    assert (
+        pipeline.on_tick(
+            {"symbol": "NFO:TEST", "timestamp": base, "ltp": 100.0, "volume": 1}
+        )
+        is None
+    )
+    candle = pipeline.on_tick(
+        {
+            "symbol": "NFO:TEST",
+            "timestamp": base + timedelta(minutes=1),
+            "ltp": 102.0,
+            "volume": 1,
+        }
+    )
 
     assert candle is None
-    assert any(getattr(record, "event", "") == "pipeline_candle_store_rejected" for record in caplog.records)
+    assert any(
+        getattr(record, "event", "") == "pipeline_candle_store_rejected"
+        for record in caplog.records
+    )
+
+
+def test_market_data_pipeline_emits_closed_candle_with_ist_timestamp() -> None:
+    pipeline = MarketDataPipeline()
+    base = datetime(2026, 1, 2, 9, 15, 42, tzinfo=timezone.utc)
+
+    assert (
+        pipeline.on_tick(
+            {"symbol": "NFO:TEST", "timestamp": base, "ltp": 100.0, "volume": 1}
+        )
+        is None
+    )
+    candle = pipeline.on_tick(
+        {
+            "symbol": "NFO:TEST",
+            "timestamp": base + timedelta(minutes=1),
+            "ltp": 102.0,
+            "volume": 1,
+        }
+    )
+
+    assert candle is not None
+    assert candle.timestamp.isoformat() == "2026-01-02T14:45:00+05:30"
+    assert candle.timestamp.tzinfo == IST

--- a/tests/data/test_pipeline_overlap_guard.py
+++ b/tests/data/test_pipeline_overlap_guard.py
@@ -19,7 +19,9 @@ def _candle(symbol: str, ts: str, close: float = 100.0) -> Candle:
     )
 
 
-def test_hydration_live_overlap_candle_is_quietly_dropped(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_hydration_live_overlap_candle_is_quietly_dropped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.setenv("PIPELINE_CANDLE_OVERLAP_TOLERANCE_SECONDS", "120")
     store = CandleStore()
     symbol = "NFO:NIFTY2670724400CE"
@@ -29,7 +31,7 @@ def test_hydration_live_overlap_candle_is_quietly_dropped(monkeypatch: pytest.Mo
 
     candles = store.get(symbol)
     assert len(candles) == 1
-    assert pd.Timestamp(candles[0].timestamp) == pd.Timestamp("2026-07-06T08:35:00Z")
+    assert pd.Timestamp(candles[0].timestamp).isoformat() == "2026-07-06T14:05:00+05:30"
 
 
 def test_old_out_of_order_candle_still_raises(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/data/test_volume_zero_preservation.py
+++ b/tests/data/test_volume_zero_preservation.py
@@ -1,16 +1,56 @@
+from zoneinfo import ZoneInfo
+
 from nifty_scalper_bot.data.validator import validate_tick
 
 
 def test_validate_tick_preserves_explicit_zero_volume() -> None:
-    tick = validate_tick({"symbol": "NFO:NIFTY26MAY23500CE", "timestamp": "2026-05-13T08:27:25Z", "ltp": 300, "volume": 0, "volume_traded": 6008275})
+    tick = validate_tick(
+        {
+            "symbol": "NFO:NIFTY26MAY23500CE",
+            "timestamp": "2026-05-13T08:27:25Z",
+            "ltp": 300,
+            "volume": 0,
+            "volume_traded": 6008275,
+        }
+    )
     assert tick.volume == 0
 
 
 def test_validate_tick_prefers_volume_delta_zero() -> None:
-    tick = validate_tick({"symbol": "NFO:NIFTY26MAY23500CE", "timestamp": "2026-05-13T08:27:25Z", "ltp": 300, "volume_delta": 0, "volume": 0, "volume_traded": 6008275})
+    tick = validate_tick(
+        {
+            "symbol": "NFO:NIFTY26MAY23500CE",
+            "timestamp": "2026-05-13T08:27:25Z",
+            "ltp": 300,
+            "volume_delta": 0,
+            "volume": 0,
+            "volume_traded": 6008275,
+        }
+    )
     assert tick.volume == 0
 
 
 def test_validate_tick_prefers_volume_delta_value() -> None:
-    tick = validate_tick({"symbol": "NFO:NIFTY26MAY23500CE", "timestamp": "2026-05-13T08:27:25Z", "ltp": 300, "volume_delta": 65, "volume_traded": 6008275})
+    tick = validate_tick(
+        {
+            "symbol": "NFO:NIFTY26MAY23500CE",
+            "timestamp": "2026-05-13T08:27:25Z",
+            "ltp": 300,
+            "volume_delta": 65,
+            "volume_traded": 6008275,
+        }
+    )
     assert tick.volume == 65
+
+
+def test_validate_tick_converts_timestamp_to_ist() -> None:
+    tick = validate_tick(
+        {
+            "symbol": "NFO:NIFTY26MAY23500CE",
+            "timestamp": "2026-05-13T08:27:25Z",
+            "ltp": 300,
+        }
+    )
+
+    assert tick.timestamp.isoformat() == "2026-05-13T13:57:25+05:30"
+    assert tick.timestamp.tzinfo == ZoneInfo("Asia/Kolkata")


### PR DESCRIPTION
## Root cause

src/nifty_scalper_bot/data/validator.py::validate_tick, src/nifty_scalper_bot/data/pipeline.py::{TickValidator.validate,CandleStore.push,CandleStore.seed}, src/nifty_scalper_bot/data/pipeline_overlap_guard.py::install_candle_store_overlap_guard, and src/nifty_scalper_bot/data/candle_engine.py::{sanitize,on_tick,_finalize_current_candle} were normalizing or storing timestamps in UTC on some paths and IST on others. That left the validator, candle pipeline, and candle engine out of contract with each other.

## What changed

- src/nifty_scalper_bot/data/validator.py: normalize validated tick timestamps to Asia/Kolkata and keep fallback wall-clock timestamps in IST.
- src/nifty_scalper_bot/data/pipeline.py: normalize pipeline tick timestamps, stored candles, seeded candles, and finalized candle timestamps to IST.
- src/nifty_scalper_bot/data/pipeline_overlap_guard.py: keep the overlap guard aligned with the new CandleStore IST storage contract.
- src/nifty_scalper_bot/data/candle_engine.py: convert sanitize/finalize/tick-processing paths to IST and keep finalized dataframe rows in IST.
- 	ests/data/test_volume_zero_preservation.py: assert validator timestamps are IST.
- 	ests/data/test_market_data_pipeline.py: assert seeded and emitted pipeline candles are IST; update overlap-sensitive expectations to current runtime behavior.
- 	ests/data/test_pipeline_overlap_guard.py: assert stored overlap-guard candles are IST.
- 	ests/data/test_candle_engine.py: assert sanitize/finalized candle timestamps are IST.

## What did not change

- No execution, risk, broker, contract-selection, or Telegram logic changed.
- No new project dependencies were added.
- No runtime path outside validator/pipeline/candle-engine timestamp handling was modified.

## Validation

Commands run:

- python -m compileall -q src
- python -m pytest -q tests/data/test_volume_zero_preservation.py tests/data/test_market_data_pipeline.py tests/data/test_pipeline_overlap_guard.py tests/data/test_candle_engine.py -q -rA
- python -m pytest -q tests --disable-warnings --ignore=tests/test_live_mode.py --ignore=tests/test_health_server.py --basetemp=.pytest-data-dir/full-suite
- python -m black --check src/nifty_scalper_bot/data/validator.py src/nifty_scalper_bot/data/pipeline.py src/nifty_scalper_bot/data/pipeline_overlap_guard.py src/nifty_scalper_bot/data/candle_engine.py tests/data/test_volume_zero_preservation.py tests/data/test_market_data_pipeline.py tests/data/test_pipeline_overlap_guard.py tests/data/test_candle_engine.py
- python -m isort --check-only src/nifty_scalper_bot/data/validator.py src/nifty_scalper_bot/data/pipeline.py src/nifty_scalper_bot/data/pipeline_overlap_guard.py src/nifty_scalper_bot/data/candle_engine.py tests/data/test_volume_zero_preservation.py tests/data/test_market_data_pipeline.py tests/data/test_pipeline_overlap_guard.py tests/data/test_candle_engine.py
- python -m ruff check src/nifty_scalper_bot/data/validator.py src/nifty_scalper_bot/data/pipeline.py src/nifty_scalper_bot/data/pipeline_overlap_guard.py src/nifty_scalper_bot/data/candle_engine.py tests/data/test_volume_zero_preservation.py tests/data/test_market_data_pipeline.py tests/data/test_pipeline_overlap_guard.py tests/data/test_candle_engine.py
- python -m black --check .
- python -m ruff check .
- python -m mypy src

Results:

`	ext
compileall: pass
focused data-path tests: pass
full pytest with workspace-local basetemp: pass
changed-file black/isort/ruff: pass
repo-wide black --check .: fails due existing formatting debt outside this change
repo-wide ruff check .: fails due existing lint debt outside this change
repo-wide mypy src: fails due existing type-check debt outside this change
`

## Runtime impact

- Startup: unchanged except timestamp-bearing market-data objects in the touched path now normalize to IST consistently.
- Market data: validated ticks, candle-store entries, seeded candles, and candle-engine rows now carry IST timestamps end to end.
- Option hydration: seeded OHLC rows are stored in IST minute buckets.
- Strategy evaluation: candle timestamps handed downstream from the touched path are IST-consistent.
- Risk: unchanged.
- Execution: unchanged.
- Telegram diagnostics: unchanged.

## Regression risk

- Low to medium. The change is isolated to timestamp normalization in market-data preprocessing and candle storage, with regression coverage added for validator, pipeline, overlap guard, and candle engine.
- Merge is intentionally blocked pending the pre-existing repo-wide black/ruff/mypy failures on the current base.
