### PR TITLE
Harden market data ingress and freshness checks

### DIFF
--- a/docs/market_data_hardening_prd_tdd.md
+++ b/docs/market_data_hardening_prd_tdd.md
@@ -1,0 +1,43 @@
+# Market data hardening PRD/TDD
+
+## Product requirement
+
+The live market-data layer must have one deterministic WebSocket tick ingress path, strict freshness semantics for execution-critical symbols, resilient reconnect cleanup, and regression tests that prevent duplicate tick processing or stale-data promotion.
+
+## Problem statement
+
+The current implementation has several high-risk edge cases:
+
+1. WebSocket batch ticks can be routed through both `MarketDataManager.process_ticks()` and a legacy per-tick callback when both are wired.
+2. Missing or malformed tick timestamps can be normalized to current wall-clock time, making old data appear fresh.
+3. WebSocket reconnect cleanup can raise from `ticker.close()` and interrupt recovery.
+4. Candle closure depends on next-tick arrival unless a periodic flush path is added later.
+
+## Scope in this PR
+
+In scope:
+
+- Prevent duplicate WebSocket tick enqueue when MDM batch ingress is present.
+- Make ticker cleanup best-effort during reconnect handling.
+- Tag normalized WebSocket ticks with timestamp quality.
+- Reject synthetic/unknown timestamp quality from hard WebSocket LTP freshness.
+- Add focused unit tests for the above.
+
+Out of scope for this PR:
+
+- Full refactor of `market_data_manager.py` into smaller modules.
+- Replacing the fallback worker queue implementation.
+- Wall-clock candle flush scheduler. This should be implemented as a follow-up because it touches lifecycle timing and readiness behavior.
+
+## TDD acceptance tests
+
+1. A WebSocket batch with one tick and an attached MDM must call `process_ticks()` once and must not call the legacy per-tick callback.
+2. A WebSocket batch without an attached MDM must still use the legacy callback fallback.
+3. `ticker.close()` errors must be suppressed and logged so reconnect cleanup survives.
+4. A WebSocket tick with no broker/exchange timestamp must be marked `timestamp_quality=synthetic`.
+5. `has_fresh_ws_ltp()` must not treat synthetic timestamp ticks as fresh.
+6. A valid fresh WebSocket tick with exchange/broker timestamp must still pass freshness.
+
+## Operational notes
+
+This PR intentionally uses narrow hardening hooks rather than rewriting the 10k-line MDM file. The next larger cleanup should inline these changes after full local CI and live-paper validation.

--- a/src/nifty_scalper_bot/data/__init__.py
+++ b/src/nifty_scalper_bot/data/__init__.py
@@ -23,6 +23,16 @@ try:
 except Exception:
     pass
 
+try:
+    from nifty_scalper_bot.data.market_data_manager import MarketDataManager
+    from nifty_scalper_bot.data.market_data_hardening import (
+        install_market_data_manager_hardening,
+    )
+
+    install_market_data_manager_hardening(MarketDataManager)
+except Exception:
+    pass
+
 __all__ = [
     "Instrument",
     "InstrumentResolver",

--- a/src/nifty_scalper_bot/data/market_data_hardening.py
+++ b/src/nifty_scalper_bot/data/market_data_hardening.py
@@ -1,0 +1,157 @@
+"""Runtime hardening hooks for MarketDataManager freshness handling."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import time
+from typing import Any, Mapping
+
+import pandas as pd
+
+_INSTALLED_ATTR = "_freshness_hardening_installed"
+_ORIGINAL_NORMALIZE_ATTR = "_freshness_hardening_original_normalize_ws_tick"
+_ORIGINAL_FAST_RECORD_ATTR = "_freshness_hardening_original_record_ws_arrival_fast"
+
+_SYNTHETIC_QUALITIES = {"synthetic", "unknown", "invalid"}
+_ALLOWED_WS_SOURCES = {"ws", "ws_full", "full"}
+
+
+def install_market_data_manager_hardening(manager_cls: type[Any]) -> None:
+    """Install idempotent MDM freshness hardening hooks."""
+    if bool(getattr(manager_cls, _INSTALLED_ATTR, False)):
+        return
+
+    original_normalize = getattr(manager_cls, "_normalize_ws_tick", None)
+    if callable(original_normalize):
+        setattr(manager_cls, _ORIGINAL_NORMALIZE_ATTR, original_normalize)
+
+        def _normalize_ws_tick_with_quality(self: Any, raw: dict[str, Any]) -> dict[str, Any] | None:
+            quality = _timestamp_quality(raw)
+            normalized = original_normalize(self, raw)
+            if normalized is not None:
+                normalized["timestamp_quality"] = quality
+            return normalized
+
+        setattr(manager_cls, "_normalize_ws_tick", _normalize_ws_tick_with_quality)
+
+    original_fast_record = getattr(manager_cls, "_record_ws_arrival_fast", None)
+    if callable(original_fast_record):
+        setattr(manager_cls, _ORIGINAL_FAST_RECORD_ATTR, original_fast_record)
+
+        def _record_ws_arrival_fast_with_quality(self: Any, *, symbol: str, token: int | None, ltp: Any, raw_tick: dict[str, Any]) -> None:
+            quality = _timestamp_quality(raw_tick)
+            original_fast_record(self, symbol=symbol, token=token, ltp=ltp, raw_tick=raw_tick)
+            _tag_fast_cache_quality(self, symbol=symbol, token=token, quality=quality)
+
+        setattr(manager_cls, "_record_ws_arrival_fast", _record_ws_arrival_fast_with_quality)
+
+    setattr(manager_cls, "has_fresh_ws_ltp", _has_fresh_ws_ltp_strict)
+    setattr(manager_cls, _INSTALLED_ATTR, True)
+
+
+def _timestamp_quality(raw: Mapping[str, Any]) -> str:
+    """Classify source timestamp quality before any synthetic fallback."""
+    if _valid_timestamp(raw.get("exchange_timestamp")):
+        return "exchange"
+    if _valid_timestamp(raw.get("timestamp")):
+        return "broker"
+    if _valid_timestamp(raw.get("received_at")):
+        return "received_at"
+    return "synthetic"
+
+
+def _valid_timestamp(value: Any) -> bool:
+    if value is None or value == "":
+        return False
+    try:
+        ts = pd.to_datetime(value, utc=True, errors="coerce")
+    except Exception:
+        return False
+    if pd.isna(ts):
+        return False
+    try:
+        return int(ts.year) >= 2020
+    except Exception:
+        return False
+
+
+def _tag_fast_cache_quality(self: Any, *, symbol: str, token: int | None, quality: str) -> None:
+    try:
+        canonical = self._canonical_symbol(symbol)
+    except Exception:
+        canonical = str(symbol or "")
+    keys = {canonical}
+    try:
+        if self._is_nifty_spot_tick(canonical, token):
+            keys.add("NSE:NIFTY")
+    except Exception:
+        pass
+    lock = getattr(self, "_lock", None)
+    if lock is None:
+        return
+    with lock:
+        for key in keys:
+            tick = self._latest_ticks.get(key)
+            if isinstance(tick, dict):
+                tick["timestamp_quality"] = quality
+            cached = self._tick_cache.get(key)
+            if isinstance(cached, dict):
+                cached["timestamp_quality"] = quality
+
+
+def _tick_age_seconds(tick_ts: Any, now: float) -> float | None:
+    if isinstance(tick_ts, datetime):
+        ts = tick_ts if tick_ts.tzinfo is not None else tick_ts.replace(tzinfo=timezone.utc)
+        return max((datetime.now(timezone.utc) - ts).total_seconds(), 0.0)
+    if tick_ts is None:
+        return None
+    try:
+        raw = float(tick_ts)
+    except (TypeError, ValueError):
+        try:
+            parsed = pd.to_datetime(tick_ts, utc=True, errors="coerce")
+        except Exception:
+            return None
+        if pd.isna(parsed):
+            return None
+        return max(now - float(pd.Timestamp(parsed).timestamp()), 0.0)
+    if raw > 1e12:
+        raw /= 1000.0
+    if raw < 946684800:
+        return None
+    return max(now - raw, 0.0)
+
+
+def _has_fresh_ws_ltp_strict(self: Any, symbols: list[str] | tuple[str, ...] | None = None, max_age_seconds: float = 5.0) -> bool:
+    """Return fresh WS LTP proof only when timestamp quality is acceptable."""
+    now = time.time()
+    max_age = max(float(max_age_seconds), 0.1)
+    with self._lock:
+        candidate_symbols = (
+            [self._canonical_symbol(sym) for sym in symbols]
+            if symbols is not None
+            else list(self._active_subscribed_symbols)
+        )
+        if not candidate_symbols:
+            candidate_symbols = list(self._latest_ticks.keys())
+        for symbol in candidate_symbols:
+            tick = self._latest_ticks.get(symbol)
+            if not isinstance(tick, Mapping):
+                continue
+            source = str(tick.get("source") or self._last_tick_source.get(symbol) or "").lower()
+            if source not in _ALLOWED_WS_SOURCES:
+                continue
+            quality = str(tick.get("timestamp_quality") or "").lower()
+            if quality in _SYNTHETIC_QUALITIES:
+                continue
+            price = tick.get("ltp", tick.get("last_price", tick.get("price", 0)))
+            try:
+                ltp = float(price)
+            except (TypeError, ValueError):
+                continue
+            if ltp <= 0:
+                continue
+            age = _tick_age_seconds(tick.get("exchange_timestamp") or tick.get("timestamp"), now)
+            if age is not None and age <= max_age:
+                return True
+    return False

--- a/src/nifty_scalper_bot/streaming/__init__.py
+++ b/src/nifty_scalper_bot/streaming/__init__.py
@@ -11,6 +11,7 @@ All streamers feed MarketDataManager, which re-emits into DataHub (SSOT).
 from .polling_streamer import PollingStreamer
 from .stream_supervisor import StreamHealth, StreamSupervisor
 from .websocket_manager import WebSocketManager
+from .market_data_hardening import install_websocket_market_data_hardening
 from nifty_scalper_bot.utils.runtime_session_guards import (
     install_websocket_market_calendar_guard,
 )
@@ -19,6 +20,7 @@ from nifty_scalper_bot.utils.runtime_session_guards import (
 # transport class, so every runtime instance receives the canonical holiday
 # gate without making the top-level package import side-effectful.
 install_websocket_market_calendar_guard()
+install_websocket_market_data_hardening(WebSocketManager)
 
 __all__ = [
     "PollingStreamer",

--- a/src/nifty_scalper_bot/streaming/market_data_hardening.py
+++ b/src/nifty_scalper_bot/streaming/market_data_hardening.py
@@ -1,0 +1,141 @@
+"""Runtime hardening hooks for WebSocket tick ingress."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any
+
+from nifty_scalper_bot.streaming.websocket_manager import ConnectionState
+
+_INSTALLED_ATTR = "_market_data_hardening_installed"
+_ORIGINAL_BUILD_ATTR = "_market_data_hardening_original_build_ticker"
+
+
+def install_websocket_market_data_hardening(manager_cls: type[Any]) -> None:
+    """Install idempotent WebSocketManager hardening hooks."""
+    if bool(getattr(manager_cls, _INSTALLED_ATTR, False)):
+        return
+
+    original_build_ticker = getattr(manager_cls, "_build_ticker", None)
+    if callable(original_build_ticker):
+        setattr(manager_cls, _ORIGINAL_BUILD_ATTR, original_build_ticker)
+
+        def _build_ticker_with_safe_close(self: Any) -> Any:
+            ticker = original_build_ticker(self)
+            _wrap_ticker_close(self, ticker)
+            return ticker
+
+        setattr(manager_cls, "_build_ticker", _build_ticker_with_safe_close)
+
+    setattr(manager_cls, "_on_ticks", _hardened_on_ticks)
+    setattr(manager_cls, _INSTALLED_ATTR, True)
+
+
+def _wrap_ticker_close(manager: Any, ticker: Any) -> None:
+    """Make ticker.close best-effort so cleanup cannot interrupt reconnect."""
+    close = getattr(ticker, "close", None)
+    if not callable(close) or bool(getattr(ticker, "_nifty_safe_close_installed", False)):
+        return
+
+    def _safe_close(*args: Any, **kwargs: Any) -> Any:
+        try:
+            return close(*args, **kwargs)
+        except Exception as exc:  # noqa: BLE001
+            logger = getattr(manager, "_logger", None)
+            if logger is not None:
+                logger.warning(
+                    "WS_TICKER_CLOSE_SUPPRESSED error=%r",
+                    exc,
+                    exc_info=True,
+                    extra={"event": "WS_TICKER_CLOSE_SUPPRESSED", "error": repr(exc)},
+                )
+            return None
+
+    try:
+        setattr(ticker, "close", _safe_close)
+        setattr(ticker, "_nifty_safe_close_installed", True)
+    except Exception as exc:  # pragma: no cover
+        logger = getattr(manager, "_logger", None)
+        if logger is not None:
+            logger.debug("WS safe-close wrapper skipped: %s", exc)
+
+
+def _hardened_on_ticks(self: Any, ws: Any, ticks: Any) -> None:
+    """Route each WS batch through exactly one ingress path."""
+    del ws
+    if not ticks:
+        return
+    if not isinstance(ticks, list):
+        self._logger.error("Invalid ticks payload type: %s", type(ticks))
+        return
+
+    mdm = getattr(self, "_market_data_manager", None)
+    process_ticks = getattr(mdm, "process_ticks", None)
+    dispatched_to_mdm = False
+    if callable(process_ticks):
+        try:
+            process_ticks(ticks)
+            dispatched_to_mdm = True
+        except Exception as exc:  # noqa: BLE001
+            self._logger.error("Failure in _on_ticks.process_ticks: %s", exc)
+
+    now = time.monotonic()
+    self._last_tick_mono = now
+    self._last_pong_mono = now
+    restored = not self._connected.is_set() or self._state != ConnectionState.CONNECTED
+    self._connected.set()
+    self._state = ConnectionState.CONNECTED
+    self._stream_health = "healthy"
+    self._circuit.failures = 0
+    self._circuit.open_until_mono = 0.0
+    if restored:
+        self._logger.info(
+            "WEBSOCKET_CONNECTION_RESTORED_BY_TICK",
+            extra={"event": "WEBSOCKET_CONNECTION_RESTORED_BY_TICK"},
+        )
+
+    update_authoritative = getattr(mdm, "update_authoritative_ticks", None)
+    if callable(update_authoritative):
+        try:
+            update_authoritative(ticks)
+        except Exception as exc:  # noqa: BLE001
+            self._logger.error("Failure in _on_ticks.update_authoritative: %s", exc)
+
+    if self._fallback_active and self._fallback_stop_callback is not None:
+        self._fallback_active = False
+        try:
+            self._fallback_stop_callback()
+        except Exception as exc:  # noqa: BLE001
+            self._logger.error("Failure in _on_ticks.fallback_stop: %s", exc)
+
+    if not self._first_tick_logged and ticks:
+        first = ticks[0]
+        first_token = first.get("instrument_token", "?") if isinstance(first, dict) else "?"
+        self._first_tick_logged = True
+        self._logger.info(
+            "FIRST_TICK_RECEIVED instrument_token=%s — pipeline is live",
+            first_token,
+        )
+
+    if dispatched_to_mdm:
+        return
+
+    callback = self._on_tick_callback
+    if not callable(callback):
+        return
+
+    for tick in ticks:
+        if not isinstance(tick, dict) or "instrument_token" not in tick:
+            self._logger.debug(
+                "Skipping tick without instrument_token: %s",
+                list(tick.keys())[:5] if isinstance(tick, dict) else type(tick),
+            )
+            continue
+        try:
+            result = callback(tick)
+            if asyncio.iscoroutine(result):
+                loop = self._resolve_loop()
+                self._schedule_coroutine(loop, result)
+        except Exception as exc:  # noqa: BLE001
+            self._logger.error("Failure dispatching tick: %s", exc, exc_info=True)

--- a/tests/data/test_market_data_hardening.py
+++ b/tests/data/test_market_data_hardening.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import time
+
+from nifty_scalper_bot.data.market_data_hardening import (
+    install_market_data_manager_hardening,
+)
+from nifty_scalper_bot.data.market_data_manager import MarketDataManager
+
+
+SYMBOL = "NFO:NIFTY26JUL25000CE"
+TOKEN = 987654
+
+
+def _manager() -> MarketDataManager:
+    install_market_data_manager_hardening(MarketDataManager)
+    mdm = MarketDataManager(broker=None, websocket=None)
+    mdm.register_symbol(SYMBOL, TOKEN)
+    return mdm
+
+
+def test_ws_tick_without_broker_timestamp_is_tagged_synthetic() -> None:
+    mdm = _manager()
+
+    normalized = mdm._normalize_ws_tick(
+        {"instrument_token": TOKEN, "last_price": 100.0}
+    )
+
+    assert normalized is not None
+    assert normalized["timestamp_quality"] == "synthetic"
+
+
+def test_synthetic_timestamp_does_not_pass_fresh_ws_ltp() -> None:
+    mdm = _manager()
+    with mdm._lock:
+        mdm._latest_ticks[SYMBOL] = {
+            "symbol": SYMBOL,
+            "source": "ws",
+            "ltp": 100.0,
+            "timestamp": time.time(),
+            "timestamp_quality": "synthetic",
+        }
+        mdm._last_tick_source[SYMBOL] = "ws"
+
+    assert mdm.has_fresh_ws_ltp([SYMBOL], max_age_seconds=5.0) is False
+
+
+def test_exchange_timestamp_passes_fresh_ws_ltp() -> None:
+    mdm = _manager()
+    ts = datetime.now(timezone.utc)
+    with mdm._lock:
+        mdm._latest_ticks[SYMBOL] = {
+            "symbol": SYMBOL,
+            "source": "ws",
+            "ltp": 100.0,
+            "exchange_timestamp": ts,
+            "timestamp": ts,
+            "timestamp_quality": "exchange",
+        }
+        mdm._last_tick_source[SYMBOL] = "ws"
+
+    assert mdm.has_fresh_ws_ltp([SYMBOL], max_age_seconds=5.0) is True

--- a/tests/streaming/test_market_data_hardening.py
+++ b/tests/streaming/test_market_data_hardening.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import logging
+
+from nifty_scalper_bot.streaming.market_data_hardening import (
+    install_websocket_market_data_hardening,
+)
+from nifty_scalper_bot.streaming.websocket_manager import WebSocketManager
+
+
+class _BatchMdm:
+    def __init__(self) -> None:
+        self.processed: list[list[dict]] = []
+        self.authoritative: list[list[dict]] = []
+
+    def process_ticks(self, ticks: list[dict]) -> None:
+        self.processed.append(list(ticks))
+
+    def update_authoritative_ticks(self, ticks: list[dict]) -> None:
+        self.authoritative.append(list(ticks))
+
+
+def test_ws_batch_ingress_suppresses_legacy_callback_when_mdm_present() -> None:
+    install_websocket_market_data_hardening(WebSocketManager)
+    callback_ticks: list[dict] = []
+    manager = WebSocketManager(
+        "api_key",
+        "access_token",
+        on_tick=lambda tick: callback_ticks.append(dict(tick)),
+        trading_window_enabled=False,
+    )
+    mdm = _BatchMdm()
+    manager._market_data_manager = mdm
+
+    tick = {"instrument_token": 101, "last_price": 123.45}
+    manager._on_ticks(object(), [tick])
+
+    assert mdm.processed == [[tick]]
+    assert mdm.authoritative == [[tick]]
+    assert callback_ticks == []
+
+
+def test_ws_legacy_callback_still_runs_without_mdm_batch_ingress() -> None:
+    install_websocket_market_data_hardening(WebSocketManager)
+    callback_ticks: list[dict] = []
+    manager = WebSocketManager(
+        "api_key",
+        "access_token",
+        on_tick=lambda tick: callback_ticks.append(dict(tick)),
+        trading_window_enabled=False,
+    )
+
+    tick = {"instrument_token": 202, "last_price": 234.56}
+    manager._on_ticks(object(), [tick])
+
+    assert callback_ticks == [tick]
+
+
+def test_ticker_close_error_is_suppressed() -> None:
+    class BadTicker:
+        def close(self) -> None:
+            raise RuntimeError("close failed")
+
+    class DummyManager:
+        _logger = logging.getLogger("test.websocket_hardening")
+
+        def _build_ticker(self) -> BadTicker:
+            return BadTicker()
+
+    install_websocket_market_data_hardening(DummyManager)
+    ticker = DummyManager()._build_ticker()
+
+    assert ticker.close() is None


### PR DESCRIPTION
## Summary

Implements the PRD/TDD plan for market-data safety hardening:

- Adds a PRD/TDD document for the live market-data hardening work.
- Installs a WebSocket hardening hook that routes each tick batch through exactly one ingress path.
- Suppresses the legacy per-tick callback when `MarketDataManager.process_ticks()` is present to prevent duplicate enqueue/candle pressure.
- Wraps `ticker.close()` as best-effort so reconnect cleanup errors do not interrupt recovery.
- Adds MDM freshness hardening hooks that tag timestamp quality and reject synthetic/unknown timestamps from hard WS LTP freshness proof.
- Adds focused tests for duplicate-ingress prevention, callback fallback, safe close, timestamp quality, and strict freshness behavior.

## TDD coverage

- `tests/streaming/test_market_data_hardening.py`
  - batch ingress suppresses legacy callback when MDM is attached
  - legacy callback still works when no MDM batch ingress exists
  - ticker close errors are suppressed

- `tests/data/test_market_data_hardening.py`
  - WS ticks without broker/exchange timestamp are tagged synthetic
  - synthetic timestamp ticks do not pass hard WS freshness
  - fresh exchange timestamp ticks still pass hard WS freshness

## Notes

This PR intentionally avoids a high-risk full rewrite of `market_data_manager.py`. The hardening is installed through narrow hooks and should be inlined later after local CI plus paper-live validation.

## Validation

- Connector-level compare: branch is ahead of `main` by 7 commits and modifies 7 files.
- Local pytest was not executed in this environment because the repository cannot be cloned from GitHub here.