### PR TITLE
Complete market data fallback and candle hardening

### DIFF
--- a/docs/market_data_completion_validation.md
+++ b/docs/market_data_completion_validation.md
@@ -1,0 +1,20 @@
+# Market data completion validation
+
+Run these checks locally before increasing live size:
+
+```bash
+python -m compileall -q src tests
+python -m pytest -q \
+  tests/streaming/test_market_data_hardening.py \
+  tests/data/test_market_data_hardening.py
+python -m pytest -q
+```
+
+Market-hours paper/live-small validation checklist:
+
+1. Confirm one `FIRST_TICK_RECEIVED` event per WS session and no duplicate-enqueue warnings.
+2. Confirm `MDM_CANDLE_FLUSH_TASK_STARTED` after the MDM event loop is wired.
+3. Watch for `MDM_CANDLE_CLOCK_FLUSHED` after idle one-minute buckets.
+4. Confirm stale/synthetic WS LTP does not arm hard trading readiness.
+5. Confirm fallback worker log appears only before the main asyncio loop is wired.
+6. Keep live order size minimal until one complete market session passes without feed-health degradation.

--- a/docs/market_data_hardening_prd_tdd.md
+++ b/docs/market_data_hardening_prd_tdd.md
@@ -2,32 +2,37 @@
 
 ## Product requirement
 
-The live market-data layer must have one deterministic WebSocket tick ingress path, strict freshness semantics for execution-critical symbols, resilient reconnect cleanup, and regression tests that prevent duplicate tick processing or stale-data promotion.
+The live market-data layer must have one deterministic WebSocket tick ingress path, strict freshness semantics for execution-critical symbols, resilient reconnect cleanup, thread-safe fallback ingestion, and deterministic one-minute candle closure even when the next tick is delayed.
 
 ## Problem statement
 
-The current implementation has several high-risk edge cases:
+The implementation had several high-risk edge cases:
 
-1. WebSocket batch ticks can be routed through both `MarketDataManager.process_ticks()` and a legacy per-tick callback when both are wired.
-2. Missing or malformed tick timestamps can be normalized to current wall-clock time, making old data appear fresh.
-3. WebSocket reconnect cleanup can raise from `ticker.close()` and interrupt recovery.
-4. Candle closure depends on next-tick arrival unless a periodic flush path is added later.
+1. WebSocket batch ticks could be routed through both `MarketDataManager.process_ticks()` and a legacy per-tick callback when both were wired.
+2. Missing or malformed tick timestamps could be normalized to current wall-clock time, making old data appear fresh.
+3. WebSocket reconnect cleanup could raise from `ticker.close()` and interrupt recovery.
+4. Candle closure depended on next-tick arrival.
+5. The fallback worker path used an asyncio queue from a synchronous/threaded callback context.
+6. WebSocket trading-window checks ignored the configured timezone object.
 
-## Scope in this PR
+## Completed scope
 
-In scope:
+Implemented:
 
 - Prevent duplicate WebSocket tick enqueue when MDM batch ingress is present.
 - Make ticker cleanup best-effort during reconnect handling.
 - Tag normalized WebSocket ticks with timestamp quality.
 - Reject synthetic/unknown timestamp quality from hard WebSocket LTP freshness.
-- Add focused unit tests for the above.
+- Replace the no-loop fallback ingestion path with a `queue.Queue` backed worker.
+- Add a clock-based candle flush task started with the MDM event-loop consumer.
+- Use the configured WebSocket trading timezone for trading-window checks.
+- Add focused unit tests for the above behavior.
 
-Out of scope for this PR:
+Still out of scope:
 
 - Full refactor of `market_data_manager.py` into smaller modules.
-- Replacing the fallback worker queue implementation.
-- Wall-clock candle flush scheduler. This should be implemented as a follow-up because it touches lifecycle timing and readiness behavior.
+- Inlining all hardening hooks back into the primary source files. The hooks are intentionally narrow to reduce regression risk.
+- Live broker validation. This must be done with paper/live-small mode during market hours.
 
 ## TDD acceptance tests
 
@@ -37,7 +42,11 @@ Out of scope for this PR:
 4. A WebSocket tick with no broker/exchange timestamp must be marked `timestamp_quality=synthetic`.
 5. `has_fresh_ws_ltp()` must not treat synthetic timestamp ticks as fresh.
 6. A valid fresh WebSocket tick with exchange/broker timestamp must still pass freshness.
+7. No-loop WS ingestion must use the thread-safe fallback queue, not the asyncio queue.
+8. The fallback queue must coalesce/drop lower-priority work before protected open-position ticks.
+9. Idle candles must finalize after the minute closes plus grace time, without requiring the next tick.
+10. WebSocket trading-window logic must use the configured timezone.
 
 ## Operational notes
 
-This PR intentionally uses narrow hardening hooks rather than rewriting the 10k-line MDM file. The next larger cleanup should inline these changes after full local CI and live-paper validation.
+The runtime remains designed for shadow/paper validation before increasing live size. The safest next larger cleanup is to inline these hooks into the source modules after local CI and one full market-session paper run.

--- a/src/nifty_scalper_bot/data/market_data_hardening.py
+++ b/src/nifty_scalper_bot/data/market_data_hardening.py
@@ -1,25 +1,48 @@
-"""Runtime hardening hooks for MarketDataManager freshness handling."""
+"""Runtime hardening hooks for MarketDataManager safety handling.
+
+The hooks here are deliberately narrow.  They harden live-data failure modes
+without changing contract selection, strategy logic, or order execution.
+"""
 
 from __future__ import annotations
 
+import asyncio
 from datetime import datetime, timezone
+import os
+import queue
+import threading
 import time
 from typing import Any, Mapping
 
 import pandas as pd
 
 _INSTALLED_ATTR = "_freshness_hardening_installed"
+_ORIGINAL_INIT_ATTR = "_freshness_hardening_original_init"
 _ORIGINAL_NORMALIZE_ATTR = "_freshness_hardening_original_normalize_ws_tick"
 _ORIGINAL_FAST_RECORD_ATTR = "_freshness_hardening_original_record_ws_arrival_fast"
+_ORIGINAL_ENQUEUE_ATTR = "_fallback_hardening_original_enqueue_tick_threadsafe"
+_ORIGINAL_ENSURE_CONSUMER_ATTR = "_candle_flush_original_ensure_tick_consumer"
+_ORIGINAL_STOP_ATTR = "_candle_flush_original_stop"
 
 _SYNTHETIC_QUALITIES = {"synthetic", "unknown", "invalid"}
 _ALLOWED_WS_SOURCES = {"ws", "ws_full", "full"}
+_IST_TZ = "Asia/Kolkata"
 
 
 def install_market_data_manager_hardening(manager_cls: type[Any]) -> None:
-    """Install idempotent MDM freshness hardening hooks."""
+    """Install idempotent MDM market-data hardening hooks."""
     if bool(getattr(manager_cls, _INSTALLED_ATTR, False)):
         return
+
+    original_init = getattr(manager_cls, "__init__", None)
+    if callable(original_init):
+        setattr(manager_cls, _ORIGINAL_INIT_ATTR, original_init)
+
+        def _init_with_hardening(self: Any, *args: Any, **kwargs: Any) -> None:
+            original_init(self, *args, **kwargs)
+            _initialise_hardening_state(self)
+
+        setattr(manager_cls, "__init__", _init_with_hardening)
 
     original_normalize = getattr(manager_cls, "_normalize_ws_tick", None)
     if callable(original_normalize):
@@ -45,8 +68,60 @@ def install_market_data_manager_hardening(manager_cls: type[Any]) -> None:
 
         setattr(manager_cls, "_record_ws_arrival_fast", _record_ws_arrival_fast_with_quality)
 
+    original_enqueue = getattr(manager_cls, "_enqueue_tick_threadsafe", None)
+    if callable(original_enqueue):
+        setattr(manager_cls, _ORIGINAL_ENQUEUE_ATTR, original_enqueue)
+        setattr(manager_cls, "_enqueue_tick_threadsafe", _enqueue_tick_threadsafe_hardened)
+
+    original_ensure_consumer = getattr(manager_cls, "_ensure_tick_consumer", None)
+    if callable(original_ensure_consumer):
+        setattr(manager_cls, _ORIGINAL_ENSURE_CONSUMER_ATTR, original_ensure_consumer)
+
+        def _ensure_tick_consumer_with_candle_flush(self: Any, reason: str) -> None:
+            original_ensure_consumer(self, reason)
+            self._ensure_candle_flush_task(reason=reason)
+
+        setattr(manager_cls, "_ensure_tick_consumer", _ensure_tick_consumer_with_candle_flush)
+
+    original_stop = getattr(manager_cls, "stop", None)
+    if callable(original_stop):
+        setattr(manager_cls, _ORIGINAL_STOP_ATTR, original_stop)
+
+        def _stop_with_hardening(self: Any) -> None:
+            self._stop_candle_flush_task()
+            self._stop_fallback_tick_worker()
+            original_stop(self)
+
+        setattr(manager_cls, "stop", _stop_with_hardening)
+
     setattr(manager_cls, "has_fresh_ws_ltp", _has_fresh_ws_ltp_strict)
+    setattr(manager_cls, "_ensure_tick_worker", _ensure_tick_worker_thread_queue)
+    setattr(manager_cls, "_tick_worker_loop", _tick_worker_loop_thread_queue)
+    setattr(manager_cls, "_put_fallback_tick_nowait", _put_fallback_tick_nowait)
+    setattr(manager_cls, "_ensure_candle_flush_task", _ensure_candle_flush_task)
+    setattr(manager_cls, "_stop_candle_flush_task", _stop_candle_flush_task)
+    setattr(manager_cls, "_stop_fallback_tick_worker", _stop_fallback_tick_worker)
+    setattr(manager_cls, "flush_due_candles", _flush_due_candles)
     setattr(manager_cls, _INSTALLED_ATTR, True)
+
+
+def _initialise_hardening_state(self: Any) -> None:
+    maxsize = max(int(getattr(self, "_tick_queue_maxsize", 10_000) or 10_000), 1)
+    self._fallback_tick_queue: queue.Queue[dict[str, Any]] = queue.Queue(maxsize=maxsize)
+    if not isinstance(getattr(self, "_tick_worker_stop", None), threading.Event):
+        self._tick_worker_stop = threading.Event()
+    self._candle_flush_task: asyncio.Task[None] | None = None
+    self._candle_flush_interval_s = _float_env("MDM_CANDLE_FLUSH_INTERVAL_SECONDS", 1.0, minimum=0.25)
+    self._candle_flush_grace_s = _float_env("MDM_CANDLE_FLUSH_GRACE_SECONDS", 1.5, minimum=0.0)
+    self._last_candle_flush_log_mono = 0.0
+
+
+def _float_env(name: str, default: float, *, minimum: float) -> float:
+    try:
+        value = float(os.getenv(name, str(default)) or default)
+    except (TypeError, ValueError):
+        value = default
+    return max(float(value), float(minimum))
 
 
 def _timestamp_quality(raw: Mapping[str, Any]) -> str:
@@ -155,3 +230,315 @@ def _has_fresh_ws_ltp_strict(self: Any, symbols: list[str] | tuple[str, ...] | N
             if age is not None and age <= max_age:
                 return True
     return False
+
+
+def _enqueue_tick_threadsafe_hardened(self: Any, tick: dict[str, Any]) -> None:
+    """Non-blocking WS enqueue with thread-safe fallback queue."""
+    try:
+        payload = dict(tick)
+    except Exception:
+        return
+    payload.setdefault("_enqueued_monotonic", time.monotonic())
+
+    loop = getattr(self, "_main_loop", None)
+    if loop is not None and loop.is_running():
+        self._enqueue_latest_tick_for_drain(payload, loop)
+        return
+
+    self._ensure_tick_worker()
+    if not self._put_fallback_tick_nowait(payload):
+        self._tick_queue_dropped += 1
+        now = time.monotonic()
+        if now - float(getattr(self, "_last_tick_queue_full_log", 0.0) or 0.0) > 5.0:
+            self._last_tick_queue_full_log = now
+            self._logger.warning(
+                "MDM_FALLBACK_TICK_QUEUE_FULL dropped=%d",
+                self._tick_queue_dropped,
+                extra={"event": "MDM_FALLBACK_TICK_QUEUE_FULL", "dropped": self._tick_queue_dropped},
+            )
+    self._emit_priority_summaries_if_due()
+
+
+def _ensure_tick_worker_thread_queue(self: Any) -> None:
+    """Start fallback worker backed by queue.Queue, not asyncio.Queue."""
+    if not isinstance(getattr(self, "_fallback_tick_queue", None), queue.Queue):
+        maxsize = max(int(getattr(self, "_tick_queue_maxsize", 10_000) or 10_000), 1)
+        self._fallback_tick_queue = queue.Queue(maxsize=maxsize)
+    thread = getattr(self, "_tick_worker_thread", None)
+    if thread is not None and thread.is_alive():
+        return
+    self._tick_worker_stop.clear()
+    self._tick_worker_thread = threading.Thread(
+        target=self._tick_worker_loop,
+        name="mdm-tick-worker",
+        daemon=True,
+    )
+    self._tick_worker_thread.start()
+    self._logger.info(
+        "MDM_FALLBACK_TICK_WORKER_STARTED queue_type=threading",
+        extra={"event": "MDM_FALLBACK_TICK_WORKER_STARTED", "queue_type": "queue.Queue"},
+    )
+
+
+def _safe_queue_task_done(q: queue.Queue[Any]) -> None:
+    try:
+        q.task_done()
+    except ValueError:
+        pass
+
+
+def _put_fallback_tick_nowait(self: Any, tick_payload: dict[str, Any]) -> bool:
+    """Insert fallback tick with priority-aware eviction/coalescing."""
+    q: queue.Queue[dict[str, Any]] = self._fallback_tick_queue
+    symbol = self._resolve_tick_symbol_for_priority(tick_payload)
+    priority, bucket = self._tick_priority(symbol)
+    tick_payload["_mdm_priority"] = priority
+    tick_payload["_mdm_priority_bucket"] = bucket
+    if priority == 0:
+        self._log_open_position_priority_if_needed(symbol)
+    try:
+        q.put_nowait(tick_payload)
+        self._bus_priority_counts[bucket] += 1
+        return True
+    except queue.Full:
+        pass
+
+    retained: list[dict[str, Any]] = []
+    removed = False
+    removed_bucket = bucket
+    removed_reason = ""
+    while True:
+        try:
+            existing = q.get_nowait()
+            _safe_queue_task_done(q)
+        except queue.Empty:
+            break
+        existing_symbol = self._resolve_tick_symbol_for_priority(existing if isinstance(existing, Mapping) else {})
+        existing_priority, existing_bucket = self._tick_priority(existing_symbol)
+        if not removed and existing_priority > priority:
+            removed = True
+            removed_bucket = existing_bucket
+            removed_reason = "drop_lower_priority"
+            continue
+        if not removed and existing_symbol == symbol and existing_priority >= priority:
+            removed = True
+            removed_bucket = existing_bucket
+            removed_reason = "coalesce_same_symbol"
+            continue
+        retained.append(existing)
+
+    for item in retained:
+        try:
+            q.put_nowait(item)
+        except queue.Full:
+            self._tick_queue_priority_drops[str(item.get("_mdm_priority_bucket") or "unknown")] += 1
+            break
+
+    if removed:
+        if removed_reason == "coalesce_same_symbol":
+            self._tick_queue_priority_coalesced[removed_bucket] += 1
+        else:
+            self._tick_queue_priority_drops[removed_bucket] += 1
+    elif priority >= 1:
+        self._tick_queue_priority_drops[bucket] += 1
+        return False
+    else:
+        try:
+            dropped = q.get_nowait()
+            _safe_queue_task_done(q)
+            dropped_symbol = self._resolve_tick_symbol_for_priority(dropped if isinstance(dropped, Mapping) else {})
+            self._tick_queue_priority_drops["open_position"] += 1
+            self._logger.critical(
+                "MDM_OPEN_POSITION_TICK_FORCED_DROP dropped_symbol=%s incoming_symbol=%s",
+                dropped_symbol,
+                symbol,
+                extra={
+                    "event": "MDM_OPEN_POSITION_TICK_FORCED_DROP",
+                    "dropped_symbol": dropped_symbol,
+                    "incoming_symbol": symbol,
+                },
+            )
+        except queue.Empty:
+            pass
+
+    try:
+        q.put_nowait(tick_payload)
+        self._bus_priority_counts[bucket] += 1
+        return True
+    except queue.Full:
+        self._tick_queue_priority_drops[bucket] += 1
+        return False
+
+
+def _tick_worker_loop_thread_queue(self: Any) -> None:
+    """Fallback serial tick worker used only before the asyncio loop is wired."""
+    q: queue.Queue[dict[str, Any]] = self._fallback_tick_queue
+    while not self._tick_worker_stop.is_set():
+        try:
+            raw = q.get(timeout=0.25)
+        except queue.Empty:
+            continue
+        try:
+            self._process_queued_tick(raw)
+            self._tick_processed_total += 1
+        except Exception as exc:  # noqa: BLE001
+            self._record_tick_drop(str(raw.get("_mdm_priority_bucket") or "unknown"), "fallback_process_error")
+            self._logger.error(
+                "MDM_FALLBACK_TICK_WORKER_ERROR error=%r",
+                exc,
+                exc_info=True,
+                extra={"event": "MDM_FALLBACK_TICK_WORKER_ERROR", "error": repr(exc)},
+            )
+        finally:
+            _safe_queue_task_done(q)
+
+
+def _stop_fallback_tick_worker(self: Any) -> None:
+    thread = getattr(self, "_tick_worker_thread", None)
+    if thread is None:
+        return
+    self._tick_worker_stop.set()
+    if thread.is_alive():
+        thread.join(timeout=2.0)
+    self._tick_worker_thread = None
+    self._tick_worker_stop.clear()
+
+
+def _ensure_candle_flush_task(self: Any, *, reason: str) -> None:
+    """Start a loop task that finalizes idle one-minute candles."""
+    loop = getattr(self, "_main_loop", None)
+    if loop is None or not loop.is_running():
+        return
+    task = getattr(self, "_candle_flush_task", None)
+    if task is not None and not task.done():
+        return
+
+    async def _runner() -> None:
+        interval = max(float(getattr(self, "_candle_flush_interval_s", 1.0) or 1.0), 0.25)
+        try:
+            while True:
+                await asyncio.sleep(interval)
+                self.flush_due_candles()
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:  # pragma: no cover - defensive task guard
+            self._logger.error(
+                "MDM_CANDLE_FLUSH_TASK_STOPPED error=%r",
+                exc,
+                exc_info=True,
+                extra={"event": "MDM_CANDLE_FLUSH_TASK_STOPPED", "error": repr(exc)},
+            )
+
+    def _start() -> None:
+        task_inner = getattr(self, "_candle_flush_task", None)
+        if task_inner is None or task_inner.done():
+            self._candle_flush_task = loop.create_task(_runner())
+            self._logger.info(
+                "MDM_CANDLE_FLUSH_TASK_STARTED reason=%s",
+                reason,
+                extra={"event": "MDM_CANDLE_FLUSH_TASK_STARTED", "reason": reason},
+            )
+
+    try:
+        running_loop = asyncio.get_running_loop()
+    except RuntimeError:
+        running_loop = None
+    if running_loop is loop:
+        _start()
+    else:
+        loop.call_soon_threadsafe(_start)
+
+
+def _stop_candle_flush_task(self: Any) -> None:
+    task = getattr(self, "_candle_flush_task", None)
+    if task is None or task.done():
+        self._candle_flush_task = None
+        return
+    loop = getattr(self, "_main_loop", None)
+    try:
+        if loop is not None and loop.is_running():
+            loop.call_soon_threadsafe(task.cancel)
+        else:
+            task.cancel()
+    except Exception as exc:  # noqa: BLE001
+        self._logger.debug("candle flush task cancel skipped: %s", exc)
+    self._candle_flush_task = None
+
+
+def _coerce_ist_timestamp(value: Any) -> pd.Timestamp | None:
+    try:
+        ts = pd.Timestamp(value)
+    except Exception:
+        return None
+    if pd.isna(ts):
+        return None
+    if ts.tzinfo is None:
+        return ts.tz_localize(_IST_TZ)
+    return ts.tz_convert(_IST_TZ)
+
+
+def _flush_due_candles(self: Any, *, now: Any | None = None, grace_seconds: float | None = None) -> int:
+    """Finalize candles whose minute has ended even if no next tick arrives."""
+    grace = (
+        max(float(grace_seconds), 0.0)
+        if grace_seconds is not None
+        else max(float(getattr(self, "_candle_flush_grace_s", 1.5) or 1.5), 0.0)
+    )
+    now_ts = _coerce_ist_timestamp(now) if now is not None else pd.Timestamp.now(tz=_IST_TZ)
+    if now_ts is None:
+        return 0
+
+    engines = list(getattr(self, "_engines", {}).items())
+    flushed = 0
+    for symbol, engine in engines:
+        current = getattr(engine, "current_candle", None)
+        if not isinstance(current, Mapping):
+            continue
+        candle_minute = _coerce_ist_timestamp(current.get("timestamp"))
+        if candle_minute is None:
+            continue
+        due_after = candle_minute + pd.Timedelta(minutes=1, seconds=grace)
+        if now_ts < due_after:
+            continue
+        try:
+            candle = engine.flush()
+        except Exception as exc:  # noqa: BLE001
+            self._logger.error(
+                "MDM_CANDLE_CLOCK_FLUSH_FAILED symbol=%s error=%r",
+                symbol,
+                exc,
+                exc_info=True,
+                extra={"event": "MDM_CANDLE_CLOCK_FLUSH_FAILED", "symbol": symbol, "error": repr(exc)},
+            )
+            continue
+        if not candle:
+            continue
+        bar = {
+            "symbol": symbol,
+            "timestamp": candle["timestamp"] if isinstance(candle, dict) else candle.timestamp,
+            "open": float(candle["open"] if isinstance(candle, dict) else candle.open),
+            "high": float(candle["high"] if isinstance(candle, dict) else candle.high),
+            "low": float(candle["low"] if isinstance(candle, dict) else candle.low),
+            "close": float(candle["close"] if isinstance(candle, dict) else candle.close),
+            "volume": int(float((candle.get("volume", 0) if isinstance(candle, dict) else getattr(candle, "volume", 0)) or 0)),
+            "source": "clock_flush_candle",
+        }
+        with self._lock:
+            self._ohlc[symbol].append(bar)
+        publisher = getattr(self, "_publish_closed_bar", None)
+        if callable(publisher):
+            try:
+                publisher(bar)
+            except Exception as exc:  # noqa: BLE001
+                self._logger.debug("clock-flush bar publish skipped: %s", exc)
+        flushed += 1
+        now_mono = time.monotonic()
+        if now_mono - float(getattr(self, "_last_candle_flush_log_mono", 0.0) or 0.0) >= 10.0:
+            self._last_candle_flush_log_mono = now_mono
+            self._logger.info(
+                "MDM_CANDLE_CLOCK_FLUSHED symbol=%s close=%s",
+                symbol,
+                bar["close"],
+                extra={"event": "MDM_CANDLE_CLOCK_FLUSHED", "symbol": symbol, "source": "clock_flush_candle"},
+            )
+    return flushed

--- a/src/nifty_scalper_bot/streaming/market_data_hardening.py
+++ b/src/nifty_scalper_bot/streaming/market_data_hardening.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from datetime import datetime
 import time
 from typing import Any
 
@@ -10,6 +11,7 @@ from nifty_scalper_bot.streaming.websocket_manager import ConnectionState
 
 _INSTALLED_ATTR = "_market_data_hardening_installed"
 _ORIGINAL_BUILD_ATTR = "_market_data_hardening_original_build_ticker"
+_ORIGINAL_TRADING_WINDOW_ATTR = "_market_data_hardening_original_is_within_trading_window"
 
 
 def install_websocket_market_data_hardening(manager_cls: type[Any]) -> None:
@@ -27,6 +29,11 @@ def install_websocket_market_data_hardening(manager_cls: type[Any]) -> None:
             return ticker
 
         setattr(manager_cls, "_build_ticker", _build_ticker_with_safe_close)
+
+    original_window = getattr(manager_cls, "_is_within_trading_window", None)
+    if callable(original_window):
+        setattr(manager_cls, _ORIGINAL_TRADING_WINDOW_ATTR, original_window)
+        setattr(manager_cls, "_is_within_trading_window", _is_within_trading_window_hardened)
 
     setattr(manager_cls, "_on_ticks", _hardened_on_ticks)
     setattr(manager_cls, _INSTALLED_ATTR, True)
@@ -59,6 +66,28 @@ def _wrap_ticker_close(manager: Any, ticker: Any) -> None:
         logger = getattr(manager, "_logger", None)
         if logger is not None:
             logger.debug("WS safe-close wrapper skipped: %s", exc)
+
+
+def _is_within_trading_window_hardened(self: Any) -> bool:
+    """Use the configured trading timezone instead of a hard-coded IST object."""
+    if not self._trading_window_enabled:
+        return True
+
+    now = datetime.now(self._trading_tz)
+    if now.weekday() >= 5:
+        return False
+
+    now_time = now.time().replace(tzinfo=None)
+    allowed = self._trading_start <= now_time <= self._trading_end
+    if not allowed:
+        self._logger.debug(
+            "WS window blocked | now=%s | start=%s | end=%s | tz=%s",
+            now_time,
+            self._trading_start,
+            self._trading_end,
+            self._trading_tz,
+        )
+    return allowed
 
 
 def _hardened_on_ticks(self: Any, ws: Any, ticks: Any) -> None:

--- a/tests/data/test_market_data_hardening.py
+++ b/tests/data/test_market_data_hardening.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+import queue
 import time
+
+import pandas as pd
 
 from nifty_scalper_bot.data.market_data_hardening import (
     install_market_data_manager_hardening,
@@ -61,3 +64,48 @@ def test_exchange_timestamp_passes_fresh_ws_ltp() -> None:
         mdm._last_tick_source[SYMBOL] = "ws"
 
     assert mdm.has_fresh_ws_ltp([SYMBOL], max_age_seconds=5.0) is True
+
+
+def test_fallback_ingress_uses_thread_safe_queue() -> None:
+    mdm = _manager()
+
+    assert isinstance(mdm._fallback_tick_queue, queue.Queue)
+
+
+def test_fallback_queue_coalesces_same_symbol_when_full() -> None:
+    mdm = _manager()
+    mdm._fallback_tick_queue = queue.Queue(maxsize=1)
+
+    assert mdm._put_fallback_tick_nowait(
+        {"symbol": SYMBOL, "instrument_token": TOKEN, "last_price": 101.0}
+    ) is True
+    assert mdm._put_fallback_tick_nowait(
+        {"symbol": SYMBOL, "instrument_token": TOKEN, "last_price": 102.0}
+    ) is True
+
+    retained = mdm._fallback_tick_queue.get_nowait()
+    assert retained["last_price"] == 102.0
+
+
+def test_clock_flush_finalizes_idle_candle_without_next_tick() -> None:
+    mdm = _manager()
+    engine = mdm._get_engine(SYMBOL)
+    candle_minute = pd.Timestamp.now(tz="Asia/Kolkata").floor("1min") - pd.Timedelta(minutes=2)
+    engine.current_candle = {
+        "timestamp": candle_minute,
+        "open": 100.0,
+        "high": 103.0,
+        "low": 99.0,
+        "close": 102.0,
+        "volume": 10.0,
+    }
+
+    flushed = mdm.flush_due_candles(
+        now=candle_minute + pd.Timedelta(minutes=2),
+        grace_seconds=0.0,
+    )
+
+    assert flushed == 1
+    assert engine.current_candle is None
+    assert len(mdm._ohlc[SYMBOL]) == 1
+    assert mdm._ohlc[SYMBOL][0]["source"] == "clock_flush_candle"

--- a/tests/streaming/test_market_data_hardening.py
+++ b/tests/streaming/test_market_data_hardening.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+from datetime import datetime, time as dtime
 import logging
+from zoneinfo import ZoneInfo
 
 from nifty_scalper_bot.streaming.market_data_hardening import (
     install_websocket_market_data_hardening,
@@ -71,3 +73,19 @@ def test_ticker_close_error_is_suppressed() -> None:
     ticker = DummyManager()._build_ticker()
 
     assert ticker.close() is None
+
+
+def test_trading_window_uses_configured_timezone_object() -> None:
+    install_websocket_market_data_hardening(WebSocketManager)
+    manager = WebSocketManager(
+        "api_key",
+        "access_token",
+        trading_window_enabled=True,
+        trading_window_tz="Asia/Kolkata",
+        trading_start=dtime(0, 0),
+        trading_end=dtime(23, 59),
+    )
+
+    assert str(manager._trading_tz) == str(ZoneInfo("Asia/Kolkata"))
+    if datetime.now(ZoneInfo("Asia/Kolkata")).weekday() < 5:
+        assert manager._is_within_trading_window() is True


### PR DESCRIPTION
## Summary

Completes the pending market-data hardening items after PR #790.

Changes:
- Replaces no-loop fallback tick ingestion with a queue.Queue backed worker.
- Adds priority-aware fallback queue coalescing and drop behavior.
- Adds clock-based candle flushing so idle one-minute candles close without waiting for the next tick.
- Uses the configured WebSocket trading timezone.
- Updates PRD/TDD and validation checklist.
- Extends regression tests for fallback queue behavior, candle clock flush, and trading timezone.

## Validation

Connector compare completed: branch is ahead of main by 6 commits, behind by 0, with 6 changed files.

Local pytest was not run in this environment. Run locally:

python -m compileall -q src tests
python -m pytest -q tests/streaming/test_market_data_hardening.py tests/data/test_market_data_hardening.py
python -m pytest -q

## Operational note

Use paper or live-small mode for one full market session before increasing size.