### PR TITLE
Centralize hardening hooks explicitly; make MDM the single pipeline candle source

### DIFF
--- a/src/nifty_scalper_bot/data/__init__.py
+++ b/src/nifty_scalper_bot/data/__init__.py
@@ -1,8 +1,12 @@
-"""Data layer exports used across the runtime."""
+"""Data layer exports used across the runtime.
+
+Hardening note: MarketDataManager hardening is installed explicitly in
+``market_data_manager.py`` and the IST time adapter in ``source.py`` — at
+their definition sites, failing loudly. This package import has no hidden
+side effects.
+"""
 
 from __future__ import annotations
-
-import importlib
 
 from nifty_scalper_bot.brokers.instrument_lookup import Instrument
 from nifty_scalper_bot.data.instrument_resolver import InstrumentResolver
@@ -16,22 +20,6 @@ from nifty_scalper_bot.data.instrument_loader import (
     upsert_instruments,
     write_instrument_rows_to_csv,
 )
-from nifty_scalper_bot.utils.time_apply import apply as _apply_time_adapter
-
-try:
-    _apply_time_adapter(importlib.import_module("nifty_scalper_bot.data." + "source"))
-except Exception:
-    pass
-
-try:
-    from nifty_scalper_bot.data.market_data_manager import MarketDataManager
-    from nifty_scalper_bot.data.market_data_hardening import (
-        install_market_data_manager_hardening,
-    )
-
-    install_market_data_manager_hardening(MarketDataManager)
-except Exception:
-    pass
 
 __all__ = [
     "Instrument",

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -980,8 +980,40 @@ class MarketDataManager:
         if callback not in self._bar_subscribers:
             self._bar_subscribers.append(callback)
 
+    def _push_bar_to_pipeline(self, bar: dict[str, Any]) -> None:
+        """Sync one CLOSED MDM bar into the deterministic pipeline store.
+
+        MDM is the single runtime candle builder; the pipeline store is a
+        validated view of MDM's closed bars (store.push dedupes equal-minute
+        bars and rejects out-of-order ones). Errors never break publishing.
+        """
+        try:
+            from nifty_scalper_bot.data.pipeline import Candle, get_pipeline  # noqa: PLC0415
+
+            get_pipeline().store.push(
+                Candle(
+                    symbol=str(bar.get("symbol") or ""),
+                    timestamp=bar.get("timestamp") or bar.get("date"),
+                    open=float(bar.get("open") or bar.get("close") or 0.0),
+                    high=float(bar.get("high") or bar.get("close") or 0.0),
+                    low=float(bar.get("low") or bar.get("close") or 0.0),
+                    close=float(bar.get("close") or 0.0),
+                    volume=float(bar.get("volume") or 0.0),
+                )
+            )
+        except Exception as exc:  # noqa: BLE001 - pipeline sync must not break bar publish
+            log_throttled(
+                self._logger,
+                f"pipeline_bar_sync_failed:{bar.get('symbol')}",
+                "PIPELINE_BAR_SYNC_FAILED symbol=%s error=%s" % (bar.get("symbol"), exc),
+                interval_sec=60,
+                level=logging.WARNING,
+                extra={"event": "PIPELINE_BAR_SYNC_FAILED", "symbol": str(bar.get("symbol") or "")},
+            )
+
     def _publish_closed_bar(self, bar: dict[str, Any]) -> None:
         """Args: bar. Returns: None. Raises: None."""
+        self._push_bar_to_pipeline(bar)
         for cb in list(self._bar_subscribers):
             try:
                 cb(dict(bar))
@@ -6249,25 +6281,14 @@ class MarketDataManager:
                 bar["close"],
             )
 
-        # ── PIPELINE FEED ─────────────────────────────────────────────────────
-        # Feed the deterministic MarketDataPipeline so pipeline.candles_ready()
-        # and pipeline.get_candles() reflect live data.  Lazy import avoids
-        # circular dependency.  Errors are caught so MDM consumer loop never dies.
-        try:
-            from nifty_scalper_bot.data.pipeline import get_pipeline  # noqa: PLC0415
-            _pipeline_candle = get_pipeline().on_tick(raw)
-            if _pipeline_candle is not None:
-                self._logger.debug(
-                    "CANDLE_FORMED symbol=%s ts=%s open=%.2f high=%.2f low=%.2f close=%.2f",
-                    _pipeline_candle.symbol,
-                    _pipeline_candle.timestamp,
-                    _pipeline_candle.open,
-                    _pipeline_candle.high,
-                    _pipeline_candle.low,
-                    _pipeline_candle.close,
-                )
-        except Exception as _pipe_exc:  # pragma: no cover
-            self._logger.debug("pipeline.on_tick feed failed: %s", _pipe_exc)
+        # ── PIPELINE SYNC (closed bars only) ─────────────────────────────────
+        # MDM is the single runtime candle builder. The deterministic pipeline
+        # store is populated from MDM's CLOSED bars via _publish_closed_bar →
+        # _push_bar_to_pipeline, so pipeline.candles_ready()/get_candles()
+        # reflect exactly the same candles as MDM. The former per-tick feed
+        # here made the pipeline a second live candle builder fed from two
+        # racing paths (MDM consumer + runner), causing out-of-order drops
+        # and readiness flapping.
 
     def _get_engine(self, symbol: str) -> CandleEngine:
         """Return or create candle engine for symbol."""
@@ -10499,3 +10520,14 @@ def _select_expiry(
 
 
 __all__ = ["MarketDataManager"]
+
+
+# ── Explicit hardening integration (definition site, fails loudly) ──────────
+# Previously installed by a hidden try/except-pass hook in data/__init__.py,
+# which could silently leave live trading without freshness guards. The class
+# is never exposed un-hardened: any import of this module hardens it here.
+from nifty_scalper_bot.data.market_data_hardening import (  # noqa: E402
+    install_market_data_manager_hardening as _install_mdm_hardening,
+)
+
+_install_mdm_hardening(MarketDataManager)

--- a/src/nifty_scalper_bot/data/source.py
+++ b/src/nifty_scalper_bot/data/source.py
@@ -278,3 +278,12 @@ class MarketDataSource:
         raise DataIntegrityError(
             "Historical OHLC fetch is owned by MarketDataManager.ensure_history"
         )
+
+
+# ── Explicit IST time-adapter integration (definition site, fails loudly) ───
+# Previously applied by a hidden try/except-pass hook in data/__init__.py.
+import sys as _sys  # noqa: E402
+
+from nifty_scalper_bot.utils.time_apply import apply as _apply_ist_time_adapter  # noqa: E402
+
+_apply_ist_time_adapter(_sys.modules[__name__])

--- a/src/nifty_scalper_bot/strategies/__init__.py
+++ b/src/nifty_scalper_bot/strategies/__init__.py
@@ -2,12 +2,8 @@
 
 from .elite_strategies import *  # noqa: F401,F403
 
-# Keep the runtime context contract active for direct imports such as
-# ``nifty_scalper_bot.strategies.indicators``.  This preserves live direction
-# fields required by OrderFlowStrategy without admitting arbitrary context keys.
-from .runtime_context_contract import install_indicator_runtime_context_contract
-
-install_indicator_runtime_context_contract()
+# The indicator runtime-context contract is installed explicitly at the end
+# of ``strategies/indicators.py`` (its definition site) — no hidden hook here.
 
 # explicit __all__ comes from elite_strategies.__init__
 try:

--- a/src/nifty_scalper_bot/strategies/indicators.py
+++ b/src/nifty_scalper_bot/strategies/indicators.py
@@ -1870,3 +1870,13 @@ class IndicatorEngine:
     def supports_feature(self, feature_name: str) -> bool:
         """Args: feature_name. Returns: support flag. Raises: none."""
         return supports_feature(feature_name)
+
+
+# ── Explicit runtime-context contract integration (definition site) ─────────
+# Previously installed from strategies/__init__.py; centralized here so
+# IndicatorEngine always carries the contract regardless of import path.
+from nifty_scalper_bot.strategies.runtime_context_contract import (  # noqa: E402
+    install_indicator_runtime_context_contract as _install_ctx_contract,
+)
+
+_install_ctx_contract()

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -6581,28 +6581,16 @@ class StrategyRunner:
             now_mono = time.monotonic()
             self._last_tick_seen_ts = now_mono
 
-            # ── PIPELINE FEED + OBSERVABILITY ────────────────────────────────
-            # Feed deterministic pipeline so candles_ready() stays current.
-            # Also log TICK_RECEIVED (debug) and CANDLE_FORMED (info) events.
-            try:
-                _pl_candle = self._pipeline.on_tick(dict(tick))
-                self._logger.debug(
-                    "TICK_RECEIVED symbol=%s ltp=%s",
-                    normalized_symbol,
-                    tick.get("ltp") or tick.get("last_price", "?"),
-                )
-                if _pl_candle is not None:
-                    _pl_count = len(self._pipeline.store.get(normalized_symbol))
-                    self._logger.debug(
-                        "CANDLE_FORMED symbol=%s ts=%s close=%.2f candles=%d ready=%s",
-                        normalized_symbol,
-                        _pl_candle.timestamp,
-                        _pl_candle.close,
-                        _pl_count,
-                        _pl_count >= 50,
-                    )
-            except Exception as _pl_exc:
-                self._logger.debug("Runner pipeline feed failed: %s", _pl_exc)
+            # ── OBSERVABILITY ────────────────────────────────────────────────
+            # Pipeline candles are populated exclusively by MDM's closed bars
+            # (MarketDataManager._publish_closed_bar → _push_bar_to_pipeline).
+            # The former pipeline.on_tick feed here was a second live candle
+            # builder racing MDM's feed, causing out-of-order candle drops.
+            self._logger.debug(
+                "TICK_RECEIVED symbol=%s ltp=%s",
+                normalized_symbol,
+                tick.get("ltp") or tick.get("last_price", "?"),
+            )
             # ✅ FIX: Throttle stall warning to 30s — same-bar-skip causes expected
             # gaps between _last_global_eval_ts updates (one eval per bar ≈ 60s cycle).
             # ✅ FIX D: Raise stall threshold to 120s. Options tick once per ~13min;

--- a/src/nifty_scalper_bot/streaming/__init__.py
+++ b/src/nifty_scalper_bot/streaming/__init__.py
@@ -6,21 +6,15 @@ Architecture:
     - StreamSupervisor: lifecycle/autostart/health manager for the active streamer.
 
 All streamers feed MarketDataManager, which re-emits into DataHub (SSOT).
+
+Hardening note: the WebSocket calendar guard and market-data hardening are
+installed explicitly in ``websocket_manager.py`` at the class definition
+site — this package import has no side effects.
 """
 
 from .polling_streamer import PollingStreamer
 from .stream_supervisor import StreamHealth, StreamSupervisor
 from .websocket_manager import WebSocketManager
-from .market_data_hardening import install_websocket_market_data_hardening
-from nifty_scalper_bot.utils.runtime_session_guards import (
-    install_websocket_market_calendar_guard,
-)
-
-# Direct and package imports both execute this module before exposing the
-# transport class, so every runtime instance receives the canonical holiday
-# gate without making the top-level package import side-effectful.
-install_websocket_market_calendar_guard()
-install_websocket_market_data_hardening(WebSocketManager)
 
 __all__ = [
     "PollingStreamer",

--- a/src/nifty_scalper_bot/streaming/websocket_manager.py
+++ b/src/nifty_scalper_bot/streaming/websocket_manager.py
@@ -1082,3 +1082,18 @@ class WebSocketManager:
             await task
         except asyncio.CancelledError:
             return
+
+
+# ── Explicit hardening integration (definition site, fails loudly) ──────────
+# Previously installed from streaming/__init__.py; centralized here so the
+# transport class is never exposed without the NSE calendar guard and
+# market-data hardening, regardless of import path.
+from nifty_scalper_bot.streaming.market_data_hardening import (  # noqa: E402
+    install_websocket_market_data_hardening as _install_ws_hardening,
+)
+from nifty_scalper_bot.utils.runtime_session_guards import (  # noqa: E402
+    install_websocket_market_calendar_guard as _install_ws_calendar_guard,
+)
+
+_install_ws_calendar_guard()
+_install_ws_hardening(WebSocketManager)

--- a/tests/test_market_data_ownership.py
+++ b/tests/test_market_data_ownership.py
@@ -14,3 +14,35 @@ def test_app_does_not_thread_async_mdm_fetch_history() -> None:
     text = APP.read_text(encoding='utf-8')
     assert 'asyncio.to_thread(\n                    ctx.market_data_manager.fetch_history' not in text
     assert 'asyncio.to_thread(ctx.market_data_manager.fetch_history' not in text
+
+
+def test_mdm_closed_bar_is_single_pipeline_source() -> None:
+    """MDM is the single runtime candle builder: its closed bars populate the
+    pipeline store via _publish_closed_bar, duplicates dedupe, and neither MDM
+    nor the runner feeds pipeline.on_tick live anymore."""
+    import inspect
+    import logging
+    from datetime import datetime, timezone
+
+    from nifty_scalper_bot.data.market_data_manager import MarketDataManager
+    from nifty_scalper_bot.data.pipeline import get_pipeline
+
+    mdm = MarketDataManager.__new__(MarketDataManager)
+    mdm._logger = logging.getLogger("test")
+    mdm._bar_subscribers = []
+    sym = "NFO:NIFTYTESTPIPE24050CE"
+    bar = {
+        "symbol": sym,
+        "timestamp": datetime(2026, 7, 7, 9, 16, tzinfo=timezone.utc),
+        "open": 100.0, "high": 101.0, "low": 99.5, "close": 100.5, "volume": 10,
+    }
+    mdm._publish_closed_bar(bar)
+    mdm._publish_closed_bar(bar)  # duplicate minute dedupes
+    assert len(get_pipeline().store.get(sym)) == 1
+
+    # No live per-tick pipeline feed remains in MDM's consumer or the runner.
+    import nifty_scalper_bot.strategies.runner as runner_mod
+    mdm_src = inspect.getsource(MarketDataManager)
+    assert "get_pipeline().on_tick" not in mdm_src
+    runner_src = inspect.getsource(runner_mod.StrategyRunner)
+    assert "_pipeline.on_tick" not in runner_src


### PR DESCRIPTION
Two trading-path blockers fixed with minimal anchored diffs:

1. Hidden package-level hardening hooks removed and centralized. data/__init__, streaming/__init__ and strategies/__init__ installed class patches at package import, some inside try/except-pass - a failed install silently left live trading without freshness guards. Each install now lives explicitly at its class's definition site (market_data_manager.py, source.py, websocket_manager.py, indicators.py) and fails loudly. Verified installed on direct module import.

2. MDM is now the single runtime OHLC/candle source. data.pipeline was a second live candle builder fed from two racing per-tick paths (MDM consumer + runner), so the losing feed's candles were dropped as out-of-order/duplicate and candles_ready()/readiness flapped - blocking trading. Both per-tick feeds removed; MDM._publish_closed_bar now pushes each CLOSED bar into the pipeline store via new _push_bar_to_pipeline (dedup + monotonic validation preserved, errors throttled, publish never breaks). Runner pipeline reads unchanged.

Regression test in existing tests/test_market_data_ownership.py. No new files except none; no renames. Full suite green, compileall clean. Prior slices' protections untouched.