### PR TITLE
Market data: skip in-progress partial minute in backfill; diagnosable integrity logs

### DIFF
--- a/src/nifty_scalper_bot/data/candle_engine.py
+++ b/src/nifty_scalper_bot/data/candle_engine.py
@@ -284,11 +284,11 @@ def repair_with_backfill(
 ) -> pd.DataFrame:
     """Merge deterministic recent candles only without synthetic fills."""
     LOGGER.info(
-        "data_integrity_error",
+        "repair_with_backfill_deprecated symbol=%s",
+        symbol,
         extra={
-            "event": "data_integrity_error",
+            "event": "repair_with_backfill_deprecated",
             "symbol": symbol,
-            "reason": "repair_with_backfill_deprecated",
         },
     )
     recent = sanitize(fetch_recent_rest(symbol))
@@ -310,7 +310,9 @@ def fetch_historical_safe(
         if validate_dataframe(frame, min_required=min_required):
             return frame
         LOGGER.warning(
-            "data_integrity_error",
+            "data_integrity_error symbol=%s reason=historical_validation_failed attempt=%d",
+            symbol,
+            attempt,
             extra={
                 "event": "data_integrity_error",
                 "symbol": symbol,
@@ -379,11 +381,14 @@ def ensure_valid_data(
     )
     if hydrated is None:
         LOGGER.error(
-            "data_integrity_error",
+            "data_integrity_error symbol=%s reason=insufficient_historical min_required=%d",
+            symbol,
+            min_required,
             extra={
                 "event": "data_integrity_error",
                 "symbol": symbol,
                 "reason": "insufficient_historical",
+                "min_required": min_required,
             },
         )
         return None

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -4238,7 +4238,15 @@ class StrategyRunner:
                 end=end_ts,
             )
 
-            # 3. Ingest
+            # 3. Ingest — but never the in-progress minute. Zerodha's minute
+            # history includes the current PARTIAL candle; ingesting it
+            # advances last_bar_ts to the live minute, so the builder's
+            # correct closed bar is then dropped as out-of-order and the
+            # indicators keep the partial OHLC (seen as the every-minute
+            # "Dropping out-of-order candle" warnings on 2026-07-06).
+            # The live builder owns the current minute.
+            if end_ts > datetime.now(timezone.utc):
+                return
             symbol = canonical(str(data["symbol"]))
             self._ingest_bar(symbol, bar, is_backfill=True)
 
@@ -5081,10 +5089,17 @@ class StrategyRunner:
 
         # Use the public .timestamp property (wraps .start)
         if not is_backfill and last_ts and bar.timestamp <= last_ts:
-            self._logger.warning(
-                "Dropping out-of-order candle",
-                extra={"symbol": symbol, "bar_ts": bar.timestamp, "last_ts": last_ts},
-            )
+            duplicate = bar.timestamp == last_ts
+            if self._should_log_throttled(f"bar_ooo:{symbol}", 60.0):
+                self._logger.log(
+                    logging.DEBUG if duplicate else logging.WARNING,
+                    "Dropping out-of-order candle symbol=%s bar_ts=%s last_ts=%s duplicate=%s",
+                    symbol,
+                    bar.timestamp,
+                    last_ts,
+                    duplicate,
+                    extra={"symbol": symbol, "bar_ts": bar.timestamp, "last_ts": last_ts},
+                )
             return
 
         # 2. STATE: Update High-Water Mark

--- a/tests/strategies/test_runner_gap_repair.py
+++ b/tests/strategies/test_runner_gap_repair.py
@@ -53,3 +53,48 @@ def test_gap_repair_does_not_create_synthetic_option_bars() -> None:
     incoming = _bar(datetime(2026, 1, 1, 9, 20, tzinfo=timezone.utc), 101.0)
     repaired = runner._repair_candle_gap('NFO:NIFTY26JAN25000CE', prev_bar, incoming)
     assert repaired == []
+
+
+def test_backfill_skips_in_progress_partial_minute_and_dedupes() -> None:
+    """Zerodha minute history includes the current PARTIAL candle. Backfill
+    must skip it (the live builder owns the current minute) or the correct
+    closed bar is later dropped as out-of-order and indicators keep the
+    partial OHLC (observed all-day in the 2026-07-06 Railway logs)."""
+    import logging
+    from datetime import datetime, timedelta, timezone
+
+    from nifty_scalper_bot.strategies.runner import OneMinuteBar, StrategyRunner
+
+    r = StrategyRunner.__new__(StrategyRunner)
+    r._logger = logging.getLogger("test")
+    r._last_bar_ts = {}
+    r._symbol_history = {}
+    r._should_log_throttled = lambda _k, _s: True
+
+    now_min = datetime.now(timezone.utc).replace(second=0, microsecond=0)
+
+    # Monotonic gate: equal-ts duplicate and older bar are both dropped.
+    r._last_bar_ts["X"] = now_min
+    dup = OneMinuteBar(open=1, high=1, low=1, close=1, volume=0,
+                       start=now_min, end=now_min + timedelta(minutes=1))
+    r._ingest_bar("X", dup)
+    older = OneMinuteBar(open=1, high=1, low=1, close=1, volume=0,
+                         start=now_min - timedelta(minutes=2),
+                         end=now_min - timedelta(minutes=1))
+    r._ingest_bar("X", older)
+    assert r._last_bar_ts["X"] == now_min
+
+    # Backfill ingest: current (partial) minute skipped, closed minute kept.
+    seen: list = []
+    r._ingest_bar = lambda _s, bar, is_backfill=False: seen.append(bar.start)
+    r._ingest_historical_bar_unlocked(
+        {"symbol": "X", "timestamp": now_min, "open": 1, "high": 1,
+         "low": 1, "close": 1, "volume": 0}
+    )
+    assert seen == [], "partial current-minute bar must not be ingested"
+    closed_ts = now_min - timedelta(minutes=1)
+    r._ingest_historical_bar_unlocked(
+        {"symbol": "X", "timestamp": closed_ts, "open": 1, "high": 1,
+         "low": 1, "close": 1, "volume": 0}
+    )
+    assert seen == [closed_ts]


### PR DESCRIPTION
Log-driven fix (4 Railway CSVs from 2026-07-06 reviewed): the bot was armed and healthy all day, but every history sync ingested Zerodha's in-progress PARTIAL minute candle as backfill, so the live builder's correct closed bar was dropped as out-of-order every minute and indicators kept the partial OHLC. One guard at the backfill ingest choke point: skip bars whose end is in the future - the live builder owns the current minute.

Also: drop log throttled + diagnosable (symbol/timestamps in message text; equal-ts duplicate at DEBUG, older at WARNING); all three candle_engine data_integrity_error logs now carry symbol+reason in the message (Railway shows message only - the ERROR entries in the logs were bare and undiagnosable); deprecated repair shim no longer mislabels its event.

Regression test in existing test_runner_gap_repair.py. Full suite green, compileall clean, no behavior change for closed bars.