### PR TITLE
Auth latch self-heal with periodic re-probe; throttle auth quote-error flood

### DIFF
--- a/src/nifty_scalper_bot/data/rest/zerodha_client.py
+++ b/src/nifty_scalper_bot/data/rest/zerodha_client.py
@@ -60,7 +60,7 @@ from nifty_scalper_bot.utils.errors import (
     OrderPlacementError,
     WebSocketError,
 )
-from nifty_scalper_bot.utils.logging import get_logger
+from nifty_scalper_bot.utils.logging import get_logger, log_throttled
 from nifty_scalper_bot.utils.rate_limiter import RateLimiter, RateLimitError
 from nifty_scalper_bot.utils.retry import (
     RetryableError,
@@ -278,6 +278,11 @@ class ZerodhaKiteClient(BaseBrokerClient):
         self._auth_invalid = False
         self._auth_invalid_reason: str | None = None
         self._auth_invalid_at: float | None = None
+        # Auth latch self-heal: while latched, one request per interval is
+        # allowed through as a re-probe so recovery is automatic once the
+        # operator fixes the Kite console allowlist/token (no restart needed).
+        self._auth_reprobe_interval: float = 60.0
+        self._auth_reprobe_next: float = 0.0
         self._auth_failure_generation = 0
         self._auth_failure_alerted_generation = -1
         self._auth_failure_callback: Callable[[dict[str, Any]], None] | None = None
@@ -379,10 +384,17 @@ class ZerodhaKiteClient(BaseBrokerClient):
         )
 
     def _raise_if_authentication_latched(self) -> None:
-        if self._auth_invalid:
-            raise BrokerAuthenticationError(
-                f"Zerodha authentication invalid: {self._auth_invalid_reason}"
-            )
+        if not self._auth_invalid:
+            return
+        now = self._log_time_fn()
+        if now >= self._auth_reprobe_next:
+            # Let exactly one request through per interval as a re-probe;
+            # a success clears the latch via _reset_transient_state.
+            self._auth_reprobe_next = now + self._auth_reprobe_interval
+            return
+        raise BrokerAuthenticationError(
+            f"Zerodha authentication invalid: {self._auth_invalid_reason}"
+        )
 
     def quote_api_available(self) -> bool:
         """Return quote API capability flag."""
@@ -1133,6 +1145,21 @@ class ZerodhaKiteClient(BaseBrokerClient):
                     exc,
                     extra={
                         "event": "quote_bulk_access_denied",
+                        "symbols_count": len(symbols),
+                    },
+                )
+            elif isinstance(exc, BrokerAuthenticationError):
+                # Terminal auth failures repeat at poll cadence (233 ERROR
+                # lines in 4 minutes on 2026-07-07); throttle to one per
+                # minute — ZERODHA_AUTH_INVALIDATED already fired loudly once.
+                log_throttled(
+                    LOGGER,
+                    "quote_bulk_auth_invalid",
+                    "Quote bulk blocked by invalid auth (throttled): %s" % exc,
+                    interval_sec=60,
+                    level=logging.ERROR,
+                    extra={
+                        "event": "quote_bulk_request_error",
                         "symbols_count": len(symbols),
                     },
                 )
@@ -2979,6 +3006,21 @@ class ZerodhaKiteClient(BaseBrokerClient):
         with self._resilience_lock:
             self._transient_error_streak = 0
             self._breaker_open_until = 0.0
+        if self._auth_invalid:
+            # An authenticated request just succeeded: the console/token was
+            # fixed. Clear the latch so trading re-arms without a restart.
+            self._auth_invalid = False
+            self._auth_invalid_reason = None
+            self._auth_invalid_at = None
+            self._auth_reprobe_next = 0.0
+            LOGGER.warning(
+                "ZERODHA_AUTH_RESTORED generation=%s",
+                self._auth_failure_generation,
+                extra={
+                    "event": "ZERODHA_AUTH_RESTORED",
+                    "generation": self._auth_failure_generation,
+                },
+            )
 
     def _create_http_client(self, base_url: str) -> httpx.Client:
         # Force outbound connections over IPv4. Zerodha's developer console

--- a/tests/data/test_zerodha_balance_logging.py
+++ b/tests/data/test_zerodha_balance_logging.py
@@ -159,3 +159,40 @@ def test_simulated_balance_requires_explicit_capital(monkeypatch) -> None:
     monkeypatch.setenv("BACKTEST__CAPITAL", "12345")
     assert client._resolve_simulated_balance() == 12345.0
     client._client.close()
+
+
+def test_auth_latch_reprobes_and_self_heals_on_success() -> None:
+    """2026-07-07 incident: IP-allowlist auth failure latched _auth_invalid
+    forever (only cleared in __init__), so even after fixing the Kite console
+    the bot stayed blocked until restart, while the quote poller logged one
+    ERROR per second. The latch must let one re-probe through per interval
+    and clear itself on the first successful authenticated request."""
+    import threading
+
+    from nifty_scalper_bot.data.rest.zerodha_client import (
+        BrokerAuthenticationError,
+        ZerodhaKiteClient,
+    )
+
+    client = ZerodhaKiteClient.__new__(ZerodhaKiteClient)
+    client._auth_invalid = True
+    client._auth_invalid_reason = "ip blocked"
+    client._auth_invalid_at = 1.0
+    client._auth_reprobe_interval = 60.0
+    client._auth_reprobe_next = 0.0
+    clock = {"now": 1000.0}
+    client._log_time_fn = lambda: clock["now"]
+
+    client._raise_if_authentication_latched()  # re-probe allowed
+    with pytest.raises(BrokerAuthenticationError):
+        client._raise_if_authentication_latched()  # inside window: blocked
+    clock["now"] = 1061.0
+    client._raise_if_authentication_latched()  # next window: re-probe again
+
+    client._resilience_lock = threading.Lock()
+    client._transient_error_streak = 3
+    client._breaker_open_until = 9.0
+    client._auth_failure_generation = 1
+    client._reset_transient_state()  # success path
+    assert client._auth_invalid is False
+    client._raise_if_authentication_latched()  # gate open again


### PR DESCRIPTION
Log-driven incident fix for broker authentication recovery and quote-error throttling. The change lets the auth latch re-probe periodically after the operator fixes Kite console allowlist or token settings, and throttles repeated quote auth errors while keeping the invalid-auth alert visible. Regression test added; full suite and compileall were reported green for that PR.