### PR TITLE
Fix orderflow quote age contract

### DIFF
--- a/src/nifty_scalper_bot/execution/quote_readiness.py
+++ b/src/nifty_scalper_bot/execution/quote_readiness.py
@@ -30,11 +30,10 @@ def _float(payload: Mapping[str, Any] | object | None, *keys: str) -> float | No
 
 
 def resolve_tick_age_ms(payload: Mapping[str, Any] | object | None) -> float | None:
-    """Resolve quote age without converting missing metadata into a fresh quote."""
-    age_ms = _float(payload, "tick_age_ms", "quote_age_ms")
+    age_ms = _float(payload, "tick_age_ms", "quote_age_ms", "last_tick_age_ms", "market_data_age_ms")
     if age_ms is not None:
         return max(0.0, age_ms)
-    age_s = _float(payload, "tick_age_s", "data_age_seconds", "age_s")
+    age_s = _float(payload, "tick_age_s", "quote_age_s", "data_age_seconds", "age_s", "age_seconds", "last_tick_age_s", "market_data_age_s")
     if age_s is not None:
         return max(0.0, age_s * 1000.0)
     return None
@@ -46,34 +45,14 @@ def resolve_tick_age_seconds(payload: Mapping[str, Any] | object | None) -> floa
 
 
 def resolve_quote_version(payload: Mapping[str, Any] | object | None) -> object | None:
-    for key in (
-        "quote_update_version",
-        "update_version",
-        "tick_version",
-        "last_tick_ts_ms",
-        "timestamp_ms",
-        "last_tick_timestamp",
-        "timestamp",
-    ):
+    for key in ("quote_update_version", "update_version", "tick_version", "last_tick_ts_ms", "timestamp_ms", "last_tick_timestamp", "timestamp"):
         value = _value(payload, key)
         if value not in (None, "", 0, 0.0):
             return value
     return None
 
 
-def resolve_real_tick_count(
-    payload: Mapping[str, Any] | object | None,
-    *,
-    tick_age_ms: float | None,
-    max_age_ms: float,
-    has_bid_ask: bool,
-) -> tuple[int, bool]:
-    """Resolve rolling ticks and conservatively derive one fresh real update.
-
-    A derived count is allowed only when the producer supplied an explicit
-    millisecond quote age. This fixes schema drift without treating a completely
-    unversioned snapshot as liquid.
-    """
+def resolve_real_tick_count(payload: Mapping[str, Any] | object | None, *, tick_age_ms: float | None, max_age_ms: float, has_bid_ask: bool) -> tuple[int, bool]:
     for key in ("real_ticks_last_60s", "tick_count_60s", "recent_real_tick_count"):
         raw = _value(payload, key)
         if raw is None:
@@ -82,16 +61,8 @@ def resolve_real_tick_count(
             return max(0, int(raw)), False
         except (TypeError, ValueError):
             return 0, False
-    explicit_ms = (
-        _value(payload, "tick_age_ms") is not None
-        or _value(payload, "quote_age_ms") is not None
-    )
-    if (
-        explicit_ms
-        and tick_age_ms is not None
-        and tick_age_ms <= max_age_ms
-        and has_bid_ask
-    ):
+    explicit_ms = any(_value(payload, key) is not None for key in ("tick_age_ms", "quote_age_ms", "last_tick_age_ms", "market_data_age_ms"))
+    if explicit_ms and tick_age_ms is not None and tick_age_ms <= max_age_ms and has_bid_ask:
         return 1, True
     return 0, False
 
@@ -115,53 +86,19 @@ class ExecutionQuoteReadiness:
         return asdict(self)
 
 
-def evaluate_execution_quote(
-    symbol: str,
-    payload: Mapping[str, Any] | object | None,
-    *,
-    live_mode: bool,
-    max_tick_age_ms: float,
-    max_spread_pct: float,
-    require_depth: bool,
-    min_real_ticks_last_60s: int = 0,
-) -> ExecutionQuoteReadiness:
-    """Return one canonical fail-closed quote verdict.
-
-    FULL Kite ticks commonly carry best prices only inside
-    ``depth.buy[0]``/``depth.sell[0]``.  Resolve those through the canonical
-    depth-aware helper before applying the execution gates.  This preserves
-    fail-closed behaviour: an absent, crossed, stale, wide, or one-sided book
-    remains non-tradable.
-    """
-    bid, ask, derived_spread_pct, _bid_ask_source = resolve_quote_bid_ask_spread(
-        payload
-    )
-    has_bid_ask = bool(
-        bid is not None and ask is not None and bid > 0 and ask > bid
-    )
+def evaluate_execution_quote(symbol: str, payload: Mapping[str, Any] | object | None, *, live_mode: bool, max_tick_age_ms: float, max_spread_pct: float, require_depth: bool, min_real_ticks_last_60s: int = 0) -> ExecutionQuoteReadiness:
+    bid, ask, derived_spread_pct, _bid_ask_source = resolve_quote_bid_ask_spread(payload)
+    has_bid_ask = bool(bid is not None and ask is not None and bid > 0 and ask > bid)
     spread_pct = _float(payload, "spread_pct")
     if spread_pct is None:
         spread_pct = derived_spread_pct
     tick_age_ms = resolve_tick_age_ms(payload)
     quote_version = resolve_quote_version(payload)
     depth = _value(payload, "depth")
-    depth_available = bool(
-        _value(payload, "depth_available") is True
-        or _value(payload, "quote_depth_valid") is True
-        or (
-            isinstance(depth, Mapping)
-            and bool(depth.get("buy"))
-            and bool(depth.get("sell"))
-        )
-    )
+    depth_available = bool(_value(payload, "depth_available") is True or _value(payload, "quote_depth_valid") is True or (isinstance(depth, Mapping) and bool(depth.get("buy")) and bool(depth.get("sell"))))
     explicit_tradable = _value(payload, "tradable_quote")
     tradable_quote = bool(has_bid_ask and explicit_tradable is not False)
-    real_ticks, derived = resolve_real_tick_count(
-        payload,
-        tick_age_ms=tick_age_ms,
-        max_age_ms=max_tick_age_ms,
-        has_bid_ask=has_bid_ask,
-    )
+    real_ticks, derived = resolve_real_tick_count(payload, tick_age_ms=tick_age_ms, max_age_ms=max_tick_age_ms, has_bid_ask=has_bid_ask)
 
     reason = "ready"
     if not has_bid_ask:
@@ -181,27 +118,7 @@ def evaluate_execution_quote(
     elif real_ticks < max(0, int(min_real_ticks_last_60s)):
         reason = "insufficient_real_ticks"
 
-    return ExecutionQuoteReadiness(
-        symbol=symbol,
-        allowed=reason == "ready",
-        reason=reason,
-        bid=bid,
-        ask=ask,
-        spread_pct=spread_pct,
-        tick_age_ms=tick_age_ms,
-        quote_update_version=quote_version,
-        real_ticks_last_60s=real_ticks,
-        real_tick_count_derived=derived,
-        depth_available=depth_available,
-        tradable_quote=tradable_quote,
-    )
+    return ExecutionQuoteReadiness(symbol=symbol, allowed=reason == "ready", reason=reason, bid=bid, ask=ask, spread_pct=spread_pct, tick_age_ms=tick_age_ms, quote_update_version=quote_version, real_ticks_last_60s=real_ticks, real_tick_count_derived=derived, depth_available=depth_available, tradable_quote=tradable_quote)
 
 
-__all__ = [
-    "ExecutionQuoteReadiness",
-    "evaluate_execution_quote",
-    "resolve_quote_version",
-    "resolve_real_tick_count",
-    "resolve_tick_age_ms",
-    "resolve_tick_age_seconds",
-]
+__all__ = ["ExecutionQuoteReadiness", "evaluate_execution_quote", "resolve_quote_version", "resolve_real_tick_count", "resolve_tick_age_ms", "resolve_tick_age_seconds"]

--- a/src/nifty_scalper_bot/strategies/runtime_context_contract.py
+++ b/src/nifty_scalper_bot/strategies/runtime_context_contract.py
@@ -1,10 +1,4 @@
-"""Runtime context contract for live directional strategy gates.
-
-This module deliberately keeps the existing IndicatorEngine allow-list model, but
-adds the missing live-direction keys that are required by OrderFlowStrategy in
-LIVE mode.  The installer is idempotent and only preserves explicitly approved
-context fields; arbitrary user/provider payload keys remain filtered out.
-"""
+"""Runtime context contract for live directional and quote-age strategy gates."""
 
 from __future__ import annotations
 
@@ -32,6 +26,26 @@ _LIVE_DIRECTION_CONTEXT_KEYS = frozenset(
         "spot_tick_age_s",
         "futures_tick_age_s",
         "underlying_symbol",
+        "tick_age_ms",
+        "tick_age_s",
+        "quote_age_ms",
+        "quote_age_s",
+        "last_tick_age_ms",
+        "last_tick_age_s",
+        "market_data_age_ms",
+        "market_data_age_s",
+        "quote_update_version",
+        "update_version",
+        "tick_version",
+        "last_tick_ts_ms",
+        "timestamp_ms",
+        "last_tick_timestamp",
+        "real_ticks_last_60s",
+        "tick_count_60s",
+        "recent_real_tick_count",
+        "quote_depth_valid",
+        "quote_readiness_allowed",
+        "quote_readiness_reason",
     }
 )
 
@@ -85,15 +99,10 @@ def _coerce_timestamp(value: Any) -> datetime | None:
 
 
 def normalise_live_direction_context(context: Mapping[str, Any]) -> dict[str, Any]:
-    """Return approved live-direction fields from a runtime context payload."""
     if not isinstance(context, Mapping):
         return {}
 
-    preserved = {
-        key: context[key]
-        for key in _LIVE_DIRECTION_CONTEXT_KEYS
-        if key in context
-    }
+    preserved = {key: context[key] for key in _LIVE_DIRECTION_CONTEXT_KEYS if key in context}
 
     if "direction_bias" not in preserved:
         for key in _DIRECTION_ALIAS_KEYS:
@@ -125,12 +134,6 @@ def normalise_live_direction_context(context: Mapping[str, Any]) -> dict[str, An
 
 
 def install_indicator_runtime_context_contract() -> bool:
-    """Patch IndicatorEngine.set_runtime_context once, preserving live context keys.
-
-    Returns True when the installer changed the class, False when it was already
-    installed or the class could not be imported.  Import failures are intentionally
-    swallowed so package import remains safe in tooling contexts.
-    """
     try:
         from nifty_scalper_bot.strategies.indicators import IndicatorEngine
     except Exception:
@@ -149,21 +152,14 @@ def install_indicator_runtime_context_contract() -> bool:
             return
         try:
             with self._lock:
-                existing = self._runtime_context.setdefault(symbol, {}) if merge else dict(
-                    self._runtime_context.get(symbol, {}) or {}
-                )
+                existing = self._runtime_context.setdefault(symbol, {}) if merge else dict(self._runtime_context.get(symbol, {}) or {})
                 existing.update(extras)
                 self._runtime_context[symbol] = existing
                 self._cache.pop(symbol, None)
         except Exception as exc:
             logger = getattr(self, "_logger", None)
             if logger is not None:
-                logger.error(
-                    "LIVE_DIRECTION_CONTEXT_PRESERVE_FAILED symbol=%s error=%s",
-                    symbol,
-                    exc,
-                    extra={"event": "LIVE_DIRECTION_CONTEXT_PRESERVE_FAILED", "symbol": symbol, "error": str(exc)},
-                )
+                logger.error("LIVE_DIRECTION_CONTEXT_PRESERVE_FAILED symbol=%s error=%s", symbol, exc, extra={"event": "LIVE_DIRECTION_CONTEXT_PRESERVE_FAILED", "symbol": symbol, "error": str(exc)})
             raise
 
     set_runtime_context.__name__ = getattr(original, "__name__", "set_runtime_context")

--- a/tests/execution/test_quote_readiness.py
+++ b/tests/execution/test_quote_readiness.py
@@ -23,6 +23,30 @@ def test_missing_age_never_becomes_fresh_in_live_mode():
 def test_tick_age_schema_is_canonical():
     assert resolve_tick_age_ms({"tick_age_ms": 125}) == 125
     assert resolve_tick_age_ms({"tick_age_s": 0.25}) == 250
+    assert resolve_tick_age_ms({"quote_age_s": 0.25}) == 250
+    assert resolve_tick_age_ms({"quote_age_ms": 125}) == 125
+    assert resolve_tick_age_ms({"last_tick_age_s": 0.25}) == 250
+    assert resolve_tick_age_ms({"market_data_age_ms": 125}) == 125
+
+
+def test_quote_age_seconds_allows_live_orderflow_quote():
+    result = evaluate_execution_quote(
+        "NFO:NIFTY26JUN24000CE",
+        {
+            "bid": 99.9,
+            "ask": 100.1,
+            "quote_age_s": 0.10,
+            "depth_available": True,
+            "tradable_quote": True,
+        },
+        live_mode=True,
+        max_tick_age_ms=2500,
+        max_spread_pct=0.75,
+        require_depth=True,
+    )
+    assert result.allowed is True
+    assert result.reason == "ready"
+    assert result.tick_age_ms == 100
 
 
 def test_fresh_ms_quote_can_prove_one_recent_update():
@@ -36,9 +60,9 @@ def test_fresh_ms_quote_can_prove_one_recent_update():
     assert derived is True
 
 
-def test_seconds_only_age_does_not_invent_tick_count():
+def test_quote_age_seconds_does_not_invent_tick_count():
     ticks, derived = resolve_real_tick_count(
-        {"tick_age_s": 0.1},
+        {"quote_age_s": 0.1},
         tick_age_ms=100,
         max_age_ms=2500,
         has_bid_ask=True,

--- a/tests/strategies/test_orderflow_quote_age_contract.py
+++ b/tests/strategies/test_orderflow_quote_age_contract.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from nifty_scalper_bot.strategies.elite_strategies.config_models import OrderFlowStrategyConfig
+from nifty_scalper_bot.strategies.elite_strategies.order_flow import OrderFlowStrategy
+
+
+def test_orderflow_accepts_quote_age_seconds_schema_in_live_mode(monkeypatch):
+    monkeypatch.setenv("EXECUTION_MODE", "LIVE")
+    strategy = OrderFlowStrategy(OrderFlowStrategyConfig(enabled=True, quantity=1), indicator_engine=None)
+    indicators = {
+        "bid": 100.0,
+        "ask": 100.25,
+        "spread_pct": 0.24,
+        "depth": {"buy": [{"quantity": 400}], "sell": [{"quantity": 80}]},
+        "tick_direction": "UP",
+        "direction_bias": "CE",
+        "atr": 2.0,
+        "quote_age_s": 0.10,
+        "context_age_seconds": 0.10,
+        "quote_depth_valid": True,
+        "tradable_quote": True,
+        "is_selected_option": True,
+        "strike_distance_from_atm": 0,
+        "quote_update_version": 1,
+    }
+
+    signal = strategy._evaluate_signal("NFO:NIFTY26MAY24000CE", indicators, current_price=100.1)
+
+    assert signal is not None
+    assert signal.metadata["quote_readiness_reason"] == "ready"
+    assert signal.metadata["tick_age_ms"] == 100
+    assert signal.metadata["trigger_block_reason"] != "tick_age_missing"
+    assert signal.metadata["trigger_conditions_met"] is True

--- a/tests/strategies/test_runtime_context_contract.py
+++ b/tests/strategies/test_runtime_context_contract.py
@@ -27,6 +27,31 @@ def test_runtime_context_preserves_live_direction_contract_keys() -> None:
     assert "ignored_payload_key" not in indicators
 
 
+def test_runtime_context_preserves_live_quote_age_contract_keys() -> None:
+    engine = IndicatorEngine()
+    symbol = "NFO:NIFTY2670724400CE"
+
+    engine.set_runtime_context(
+        symbol,
+        {
+            "quote_age_s": 0.12,
+            "tick_age_ms": 120,
+            "quote_update_version": 42,
+            "real_ticks_last_60s": 3,
+            "quote_depth_valid": True,
+            "ignored_payload_key": "must_not_leak",
+        },
+    )
+
+    indicators = engine.get_indicators(symbol, names={"quote_age_s", "tick_age_ms", "quote_update_version"})
+    assert indicators["quote_age_s"] == 0.12
+    assert indicators["tick_age_ms"] == 120
+    assert indicators["quote_update_version"] == 42
+    assert indicators["real_ticks_last_60s"] == 3
+    assert indicators["quote_depth_valid"] is True
+    assert "ignored_payload_key" not in indicators
+
+
 def test_runtime_context_derives_direction_bias_from_alias() -> None:
     preserved = normalise_live_direction_context(
         {


### PR DESCRIPTION
Production incident fix for the 13:50-13:51 IST log slice.

Root cause:
OrderFlow was failing closed with trigger_block_reason=tick_age_missing on every decision even though selected option readiness showed fresh ticks. The age metadata contract drifted: runtime context may provide quote_age_s, tick age variants, quote update version, and real tick counts, while the live quote gate and indicator runtime-context preservation only accepted a narrower schema.

Fix:
- Accept quote_age_s, last_tick_age_*, and market_data_age_* in canonical quote readiness.
- Keep missing age fail-closed in live mode.
- Do not derive real tick count from seconds-only age.
- Preserve quote age, quote version, depth-valid, and real-tick metadata through runtime context.
- Add regression tests for quote readiness, runtime context preservation, and OrderFlow live evaluation using quote_age_s.

Validation targets:
python -m compileall -q src tests
python -m pytest -q tests/execution/test_quote_readiness.py tests/strategies/test_runtime_context_contract.py tests/strategies/test_orderflow_quote_age_contract.py tests/strategies/test_order_flow_conflict_override.py