### PR TITLE
Add corrected strategy score diagnostics

### DIFF
--- a/src/nifty_scalper_bot/core/__init__.py
+++ b/src/nifty_scalper_bot/core/__init__.py
@@ -37,6 +37,19 @@ except Exception as exc:  # noqa: BLE001 - non-live tooling imports should remai
         raise RuntimeError("strategy_live_safety_patch_failed") from exc
 
 try:
+    from nifty_scalper_bot.core.strategy_exit_score_diagnostics import apply_patches as _apply_strategy_exit_score_diagnostics
+
+    _apply_strategy_exit_score_diagnostics()
+except Exception as exc:  # noqa: BLE001 - diagnostics must not disable tooling imports
+    get_logger(__name__).error(
+        "STRATEGY_EXIT_SCORE_DIAGNOSTIC_PATCH_FAILED error=%s",
+        exc,
+        extra={"event": "STRATEGY_EXIT_SCORE_DIAGNOSTIC_PATCH_FAILED", "error_type": type(exc).__name__},
+    )
+    if _real_live_mode_requested():
+        raise RuntimeError("strategy_exit_score_diagnostic_patch_failed") from exc
+
+try:
     from nifty_scalper_bot.core.boot_log_safety import apply_filters as _apply_boot_log_rate_controls
 
     _apply_boot_log_rate_controls()

--- a/src/nifty_scalper_bot/core/strategy_exit_score_diagnostics.py
+++ b/src/nifty_scalper_bot/core/strategy_exit_score_diagnostics.py
@@ -1,0 +1,102 @@
+"""Corrected strategy-exit score diagnostics.
+
+StrategyManager's legacy STRATEGY_MANAGER_EXIT log historically used the order
+quantity in the signal_score field. This non-invasive adapter emits a corrected
+post-return diagnostic without changing trade gating or execution behavior.
+"""
+
+from __future__ import annotations
+
+from contextlib import suppress
+from typing import Any
+
+from nifty_scalper_bot.strategies.signal_generator import Signal
+from nifty_scalper_bot.utils.logging import get_logger, log_throttled
+
+LOG = get_logger(__name__)
+_PATCH_INSTALLED = False
+
+_SCORE_KEYS = (
+    "final_trade_score",
+    "consensus_score",
+    "setup_score",
+    "raw_setup_score",
+    "strategy_score",
+)
+
+
+def _extract_signal_score(signal: Signal) -> float | None:
+    metadata = dict(getattr(signal, "metadata", {}) or {})
+    for key in _SCORE_KEYS:
+        raw = metadata.get(key)
+        if raw in (None, ""):
+            continue
+        with suppress(TypeError, ValueError):
+            return float(raw)
+    return None
+
+
+def apply_patches() -> bool:
+    """Install corrected score diagnostic wrapper. Returns True if installed."""
+    global _PATCH_INSTALLED
+    if _PATCH_INSTALLED:
+        return False
+    try:
+        from nifty_scalper_bot.core import strategy_manager as strategy_module
+    except Exception:
+        return False
+
+    cls = strategy_module.StrategyManager
+    if getattr(cls, "_strategy_exit_score_diagnostics_installed", False):
+        _PATCH_INSTALLED = True
+        return False
+
+    original = cls.generate_signal
+
+    def generate_signal(
+        self: Any,
+        symbol: str,
+        current_price: float,
+        *,
+        trace_id: str | None = None,
+    ) -> Signal | None:
+        signal = original(self, symbol, current_price, trace_id=trace_id)
+        if signal is None:
+            return None
+        score = _extract_signal_score(signal)
+        if score is None:
+            return signal
+        metadata = dict(getattr(signal, "metadata", {}) or {})
+        log_throttled(
+            LOG,
+            f"strategy_exit_score_corrected:{getattr(signal, 'symbol', symbol)}:{metadata.get('approval_path')}",
+            "STRATEGY_MANAGER_EXIT_SCORE symbol=%s signal_score=%.3f signal_quantity=%s approval_path=%s",
+            getattr(signal, "symbol", symbol),
+            score,
+            getattr(signal, "quantity", None),
+            metadata.get("approval_path"),
+            interval_sec=10.0,
+            level=20,
+            extra={
+                "event": "STRATEGY_MANAGER_EXIT_SCORE",
+                "symbol": getattr(signal, "symbol", symbol),
+                "signal_score": score,
+                "signal_quantity": getattr(signal, "quantity", None),
+                "approval_path": metadata.get("approval_path"),
+                "setup_score": metadata.get("setup_score"),
+                "raw_setup_score": metadata.get("raw_setup_score"),
+                "final_trade_score": metadata.get("final_trade_score"),
+                "consensus_score": metadata.get("consensus_score"),
+                "trace_id": trace_id,
+            },
+        )
+        return signal
+
+    cls._strategy_exit_score_diagnostics_original_generate_signal = original
+    cls.generate_signal = generate_signal
+    cls._strategy_exit_score_diagnostics_installed = True
+    _PATCH_INSTALLED = True
+    return True
+
+
+__all__ = ["apply_patches", "_extract_signal_score"]

--- a/tests/core/test_strategy_exit_score_diagnostics.py
+++ b/tests/core/test_strategy_exit_score_diagnostics.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import pytest
+
+from nifty_scalper_bot.core.strategy_exit_score_diagnostics import _extract_signal_score
+from nifty_scalper_bot.strategies.signal_generator import Signal
+
+
+def _signal(**metadata) -> Signal:
+    return Signal(
+        action="BUY",
+        symbol="NFO:NIFTY2662324050CE",
+        quantity=3,
+        confidence=0.88,
+        reason="test",
+        stop_loss=95.0,
+        take_profit=110.0,
+        metadata=dict(metadata),
+    )
+
+
+def test_extract_signal_score_prefers_final_trade_score_over_quantity() -> None:
+    signal = _signal(final_trade_score=8.75, setup_score=9.0, raw_setup_score=9.0)
+
+    assert _extract_signal_score(signal) == pytest.approx(8.75)
+    assert signal.quantity == 3
+
+
+def test_extract_signal_score_uses_setup_score_when_final_missing() -> None:
+    signal = _signal(setup_score=9.0, raw_setup_score=8.5)
+
+    assert _extract_signal_score(signal) == pytest.approx(9.0)
+
+
+def test_extract_signal_score_returns_none_without_score_metadata() -> None:
+    signal = _signal()
+
+    assert _extract_signal_score(signal) is None


### PR DESCRIPTION
Fixes the remaining misleading score diagnostic after PR #800.

Problem:
- The core trading gate already uses raw_setup_score/final_trade_score correctly.
- But STRATEGY_MANAGER_EXIT still reports signal_score from quantity in the legacy nested exit logger, which can confuse live-log triage.

Change:
- Add a non-invasive diagnostic wrapper that emits STRATEGY_MANAGER_EXIT_SCORE after an approved signal returns.
- The corrected event reports signal_score from final_trade_score/consensus_score/setup_score/raw_setup_score, and reports signal_quantity separately.
- No trade gating, risk, order placement, or execution behavior is changed.
- Install the diagnostic wrapper at core package load after live-safety patches.
- Add focused tests for score extraction priority.

Validation target:
python -m compileall -q src tests
python -m pytest -q tests/core/test_strategy_exit_score_diagnostics.py tests/core/test_strategy_live_safety.py tests/data/test_quote_contract.py tests/strategies/test_runtime_context_contract.py tests/strategies/test_runtime_context_contract_autoinstall.py tests/strategies/test_orderflow_quote_age_contract.py