### PR TITLE
Make score diagnostics non-fatal for tests

### DIFF
--- a/src/nifty_scalper_bot/core/__init__.py
+++ b/src/nifty_scalper_bot/core/__init__.py
@@ -46,8 +46,6 @@ except Exception as exc:  # noqa: BLE001 - diagnostics must not disable tooling 
         exc,
         extra={"event": "STRATEGY_EXIT_SCORE_DIAGNOSTIC_PATCH_FAILED", "error_type": type(exc).__name__},
     )
-    if _real_live_mode_requested():
-        raise RuntimeError("strategy_exit_score_diagnostic_patch_failed") from exc
 
 try:
     from nifty_scalper_bot.core.boot_log_safety import apply_filters as _apply_boot_log_rate_controls


### PR DESCRIPTION
Repairs the post-PR #801 CI/test-suite risk.

Root issue:
PR #801 added score diagnostics as an observability-only wrapper, but core package import still treated diagnostic patch failure as fatal in live-mode environments. That is too aggressive for tests and workflows because score diagnostics must never block imports or fail the full suite.

Change:
- Keep strategy_live_safety fail-closed as before.
- Make strategy_exit_score_diagnostics strictly non-fatal during import.
- Preserve the corrected STRATEGY_MANAGER_EXIT_SCORE diagnostic when the patch installs successfully.
- No trade gating, order execution, risk controls, quote freshness, timestamp logic, or signal scoring logic is changed.

Validation target:
python -m compileall -q src tests
python -m pytest -q tests/core/test_strategy_exit_score_diagnostics.py tests/core/test_strategy_live_safety.py tests/data/test_quote_contract.py tests/strategies/test_runtime_context_contract.py tests/strategies/test_runtime_context_contract_autoinstall.py tests/strategies/test_orderflow_quote_age_contract.py
python -m pytest -q