### PR TITLE
Fix exit identity kwargs

### DIFF
--- a/src/nifty_scalper_bot/execution/runtime_order_manager.py
+++ b/src/nifty_scalper_bot/execution/runtime_order_manager.py
@@ -26,6 +26,28 @@ from nifty_scalper_bot.execution.native_entry_gate import (
     configure_provider,
 )
 
+_EXIT_IDENTITY_KWARGS = {"linked_entry_order_id", "trade_lifecycle_id", "bracket_id"}
+
+
+def _strip_exit_identity_kwargs(kwargs: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Remove exit identity metadata unsupported by core.place_order.
+
+    The live bracket safety layer attaches immutable exit metadata to protective
+    order requests. The native entry gate needs to see the original kwargs to
+    classify the request as protective, but the base OrderManager.place_order
+    currently does not accept these metadata-only fields. Strip them only at the
+    delegation boundary so exits cannot fail with a TypeError before reaching the
+    broker.
+    """
+
+    cleaned = dict(kwargs)
+    identity = {
+        key: cleaned.pop(key)
+        for key in list(_EXIT_IDENTITY_KWARGS)
+        if key in cleaned
+    }
+    return cleaned, identity
+
 
 class RuntimeOrderManager(_core.OrderManager):
     """Production order manager with native recovery and entry gating."""
@@ -86,7 +108,10 @@ class RuntimeOrderManager(_core.OrderManager):
         blocked = self._blocked("place_order", args, kwargs)
         if blocked is not NO_BLOCK:
             return blocked
-        return super().place_order(*args, **kwargs)
+        cleaned_kwargs, identity = _strip_exit_identity_kwargs(kwargs)
+        if identity:
+            self._last_exit_identity_kwargs = dict(identity)
+        return super().place_order(*args, **cleaned_kwargs)
 
     def _update_from_response(
         self,
@@ -113,4 +138,4 @@ class RuntimeOrderManager(_core.OrderManager):
         return updated
 
 
-__all__ = ["RuntimeOrderManager"]
+__all__ = ["RuntimeOrderManager", "_strip_exit_identity_kwargs"]

--- a/tests/execution/test_runtime_order_exit_identity_kwargs.py
+++ b/tests/execution/test_runtime_order_exit_identity_kwargs.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from typing import Any
+
+from nifty_scalper_bot.execution import order_manager_core as core
+from nifty_scalper_bot.execution.native_entry_gate import NO_BLOCK
+from nifty_scalper_bot.execution.runtime_order_manager import (
+    RuntimeOrderManager,
+    _strip_exit_identity_kwargs,
+)
+
+
+def test_strip_exit_identity_kwargs_preserves_core_order_kwargs() -> None:
+    cleaned, identity = _strip_exit_identity_kwargs(
+        {
+            "symbol": "NFO:NIFTY2671424250PE",
+            "side": "SELL",
+            "quantity": 65,
+            "intent": "EXIT",
+            "linked_entry_order_id": "2074702520085045248",
+            "trade_lifecycle_id": "2074702520085045248",
+            "bracket_id": "2074702520085045248",
+        }
+    )
+
+    assert cleaned == {
+        "symbol": "NFO:NIFTY2671424250PE",
+        "side": "SELL",
+        "quantity": 65,
+        "intent": "EXIT",
+    }
+    assert identity == {
+        "linked_entry_order_id": "2074702520085045248",
+        "trade_lifecycle_id": "2074702520085045248",
+        "bracket_id": "2074702520085045248",
+    }
+
+
+def test_runtime_place_order_strips_exit_identity_only_after_native_gate(monkeypatch) -> None:
+    manager = object.__new__(RuntimeOrderManager)
+    blocked_kwargs: dict[str, Any] = {}
+    core_kwargs: dict[str, Any] = {}
+
+    def fake_blocked(self: RuntimeOrderManager, method_name: str, args: tuple[Any, ...], kwargs: dict[str, Any]) -> Any:
+        blocked_kwargs.update(kwargs)
+        return NO_BLOCK
+
+    def fake_core_place_order(self: RuntimeOrderManager, *args: Any, **kwargs: Any) -> str:
+        core_kwargs.update(kwargs)
+        return "exit_order_1"
+
+    monkeypatch.setattr(RuntimeOrderManager, "_blocked", fake_blocked)
+    monkeypatch.setattr(core.OrderManager, "place_order", fake_core_place_order)
+
+    order_id = RuntimeOrderManager.place_order(
+        manager,
+        symbol="NFO:NIFTY2671424250PE",
+        side="SELL",
+        quantity=65,
+        order_type="MARKET",
+        product="MIS",
+        tag="exit_sl_20747025",
+        check_risk=False,
+        intent="EXIT",
+        linked_entry_order_id="2074702520085045248",
+        trade_lifecycle_id="2074702520085045248",
+        bracket_id="2074702520085045248",
+    )
+
+    assert order_id == "exit_order_1"
+    assert blocked_kwargs["intent"] == "EXIT"
+    assert blocked_kwargs["linked_entry_order_id"] == "2074702520085045248"
+    assert core_kwargs["intent"] == "EXIT"
+    assert "linked_entry_order_id" not in core_kwargs
+    assert "trade_lifecycle_id" not in core_kwargs
+    assert "bracket_id" not in core_kwargs
+    assert manager._last_exit_identity_kwargs["bracket_id"] == "2074702520085045248"


### PR DESCRIPTION
Fixes live exit failures where protective exit paths passed metadata-only fields into RuntimeOrderManager.place_order and the core OrderManager rejected them as unexpected keyword arguments. The native entry gate still sees the original protective EXIT kwargs; the metadata is stripped only before delegating to the core order manager. Adds focused regression tests. No strategy or entry logic changed.