### PR TITLE
Fix operator execution none display

### DIFF
--- a/src/nifty_scalper_bot/notifications/__init__.py
+++ b/src/nifty_scalper_bot/notifications/__init__.py
@@ -68,7 +68,7 @@ def _install_operator_execution_hygiene() -> None:
         def _patched_execution_items(snap: Mapping[str, Any]) -> dict[str, Any]:
             items = dict(original(snap))
             raw_execution_reason = snap.get("execution_block_reason")
-            items["execution_block_reason"] = "None" if raw_execution_reason is None else raw_execution_reason
+            items["execution_block_reason"] = "none" if raw_execution_reason is None else raw_execution_reason
             last_order_rejection = snap.get("last_order_rejection")
             has_current_blocker = bool(
                 snap.get("live_block_reason")


### PR DESCRIPTION
### Summary
- Fixes the failing operator stale test by normalizing absent `execution_block_reason` to lowercase `none` in the notification package execution hygiene patch.
- Root cause: `operator_telegram._execution_items()` already emitted `none`, but `notifications.__init__._install_operator_execution_hygiene()` overrode it to string `"None"`.

### Validation target
- `python -m pytest -q tests/notifications/test_operator_telegram.py -k 'stale'`
- `python -m pytest -q`

This is a one-line post-merge hotfix after PR #812.