### PR TITLE
Fix post-merge SSOT guard regressions

### DIFF
--- a/src/nifty_scalper_bot/execution/broker_exposure_quarantine_extension.py
+++ b/src/nifty_scalper_bot/execution/broker_exposure_quarantine_extension.py
@@ -82,6 +82,7 @@ def _is_manual_reduction_order(manager: Any, order: Any) -> bool:
     if existing is None:
         return False
     existing_side = str(getattr(existing, "side", "") or "").strip().upper()
+    existing_qty = 0
     with suppress(Exception):
         existing_qty = abs(int(float(getattr(existing, "quantity", 0) or 0)))
     if existing_qty <= 0 or qty > existing_qty:

--- a/src/nifty_scalper_bot/risk/entry_guard_patch.py
+++ b/src/nifty_scalper_bot/risk/entry_guard_patch.py
@@ -12,6 +12,7 @@ from typing import Any
 
 _PATCH_APPLIED = False
 _ORIGINAL_CHECK_ORDER: Any = None
+_REDUCING_INTENTS = {"EXIT", "REDUCE", "FLATTEN", "SQUARE_OFF", "SQUAREOFF"}
 
 
 def _call_count(owner: Any, *names: str) -> int:
@@ -39,6 +40,58 @@ def _open_position_count(position_manager: Any) -> int:
         with suppress(Exception):
             return len(value)
     return 0
+
+
+def _position_symbol(position: Any) -> str:
+    return str(getattr(position, "symbol", "") or getattr(position, "tradingsymbol", "") or "").strip()
+
+
+def _signal_symbol(signal: Any) -> str:
+    return str(getattr(signal, "symbol", "") or getattr(signal, "tradingsymbol", "") or "").strip()
+
+
+def _position_quantity(position: Any) -> int:
+    with suppress(Exception):
+        return abs(int(float(getattr(position, "quantity", 0) or 0)))
+    return 0
+
+
+def _iter_open_positions(position_manager: Any) -> list[Any]:
+    positions = getattr(position_manager, "_positions", None)
+    if isinstance(positions, dict):
+        return list(positions.values())
+    getter = getattr(position_manager, "get_open_positions", None)
+    if callable(getter):
+        with suppress(Exception):
+            return list(getter() or [])
+    value = getattr(position_manager, "open_positions", None)
+    if callable(value):
+        with suppress(Exception):
+            return list(value() or [])
+    if value is not None and not isinstance(value, str):
+        with suppress(Exception):
+            return list(value)
+    return []
+
+
+def _is_reducing_order(position_manager: Any, signal: Any) -> bool:
+    intent = str(getattr(signal, "intent", "") or "").strip().upper()
+    reduce_only = bool(getattr(signal, "reduce_only", False))
+    side = str(getattr(signal, "side", "") or getattr(signal, "transaction_type", "") or "").strip().upper()
+    symbol = _signal_symbol(signal)
+    if intent in _REDUCING_INTENTS or reduce_only:
+        return True
+    if not symbol or side not in {"BUY", "SELL"}:
+        return False
+    for position in _iter_open_positions(position_manager):
+        if _position_symbol(position) != symbol or _position_quantity(position) <= 0:
+            continue
+        existing_side = str(getattr(position, "side", "") or "").strip().upper()
+        if existing_side == "LONG" and side == "SELL":
+            return True
+        if existing_side == "SHORT" and side == "BUY":
+            return True
+    return False
 
 
 def _daily_limit_block_reason(manager: Any) -> tuple[str, str] | None:
@@ -75,7 +128,12 @@ def _daily_limit_block_reason(manager: Any) -> tuple[str, str] | None:
 def _patched_check_order(self: Any, signal: Any, live_enabled: bool) -> tuple[bool, str]:
     # Preserve the original priority for non-live calls and pre-existing breakers.
     # The added SSOT limits are production-entry guards, not replacements for the
-    # existing live-disabled/breaker semantics.
+    # existing live-disabled/breaker semantics. Protective exits/reductions must
+    # never be blocked by entry-only daily trade/open-position limits.
+    position_manager = getattr(self, "position_manager", None)
+    if position_manager is not None and _is_reducing_order(position_manager, signal):
+        return _ORIGINAL_CHECK_ORDER(self, signal, live_enabled)
+
     if live_enabled and not bool(getattr(self, "_breaker_tripped", False)):
         blocker = _daily_limit_block_reason(self)
         if blocker is not None:
@@ -119,4 +177,4 @@ def apply_patches() -> None:
     _PATCH_APPLIED = True
 
 
-__all__ = ["apply_patches", "_daily_limit_block_reason"]
+__all__ = ["apply_patches", "_daily_limit_block_reason", "_is_reducing_order"]

--- a/tests/execution/test_manual_exit_classification.py
+++ b/tests/execution/test_manual_exit_classification.py
@@ -3,6 +3,11 @@ from types import SimpleNamespace
 from nifty_scalper_bot.execution.broker_exposure_quarantine_extension import _is_manual_reduction_order
 
 
+class _BadQuantity:
+    def __float__(self):
+        raise TypeError("bad quantity")
+
+
 def test_manual_sell_against_existing_long_is_classified_as_manual_reduce():
     manager = SimpleNamespace(
         _positions={
@@ -58,6 +63,26 @@ def test_oversized_manual_order_is_not_treated_as_managed_reduction():
         side="SELL",
         filled_quantity=150,
         quantity=150,
+    )
+
+    assert _is_manual_reduction_order(manager, order) is False
+
+
+def test_bad_existing_position_quantity_is_not_reduction_and_does_not_raise():
+    manager = SimpleNamespace(
+        _positions={
+            "NFO:NIFTY24JUL24000CE": SimpleNamespace(
+                symbol="NFO:NIFTY24JUL24000CE",
+                side="LONG",
+                quantity=_BadQuantity(),
+            )
+        }
+    )
+    order = SimpleNamespace(
+        symbol="NFO:NIFTY24JUL24000CE",
+        side="SELL",
+        filled_quantity=75,
+        quantity=75,
     )
 
     assert _is_manual_reduction_order(manager, order) is False

--- a/tests/risk/test_risk_check_order_daily_limits.py
+++ b/tests/risk/test_risk_check_order_daily_limits.py
@@ -1,6 +1,7 @@
 from types import SimpleNamespace
 
 from nifty_scalper_bot.risk import OrderSignal, RiskManager
+from nifty_scalper_bot.risk import entry_guard_patch
 
 
 def test_check_order_enforces_max_trades_per_day_at_final_gate(monkeypatch):
@@ -59,3 +60,35 @@ def test_check_order_enforces_max_open_positions_at_final_gate(monkeypatch):
     assert reason == "max_open_positions breached: 2/1"
     assert manager._last_rejection == "MAX_OPEN:2/1"
     assert trips == ["max_open_positions breached: 2/1"]
+
+
+def test_final_daily_limits_do_not_block_reducing_orders(monkeypatch):
+    symbol = "NFO:NIFTY24JUL24000CE"
+    manager = RiskManager.__new__(RiskManager)
+    manager.settings = SimpleNamespace(max_trades_per_day=3, max_open_positions=1)
+    manager.position_manager = SimpleNamespace(
+        _positions={symbol: SimpleNamespace(symbol=symbol, side="LONG", quantity=75)},
+        trades_today=lambda: 3,
+        get_open_positions=lambda: [SimpleNamespace(symbol=symbol, side="LONG", quantity=75)],
+    )
+    manager._last_rejection = None
+    trips = []
+    monkeypatch.setattr(RiskManager, "_trip_breaker", lambda self, reason: trips.append(reason))
+    monkeypatch.setattr(entry_guard_patch, "_ORIGINAL_CHECK_ORDER", lambda self, signal, live_enabled: (True, "original_ok"))
+
+    allowed, reason = manager.check_order(
+        OrderSignal(
+            symbol=symbol,
+            side="SELL",
+            quantity=75,
+            price=100.0,
+            stop_loss=None,
+            take_profit=None,
+        ),
+        live_enabled=True,
+    )
+
+    assert allowed is True
+    assert reason == "original_ok"
+    assert manager._last_rejection is None
+    assert trips == []


### PR DESCRIPTION
## Summary

Post-merge check found PR #811 was merged, but two safety issues remained:

1. Final daily-trade/max-open-position limits could also block protective exits/reducing orders.
2. Manual reduction classification had an unbound `existing_qty` path if malformed position quantity parsing failed.

## Changes

- Add `_is_reducing_order(...)` to the final risk guard patch.
- Bypass entry-only daily/max-open failsafes for protective exits/reductions and delegate them to the original risk path.
- Initialize `existing_qty = 0` before parsing existing position quantity in manual reduction classification.
- Add regression tests for reducing-order bypass and malformed quantity handling.

## Validation target

Focused suites:

```bash
python -m pytest -q tests/risk/test_risk_check_order_daily_limits.py tests/execution/test_manual_exit_classification.py
```

Safety stance:
- Entry orders still fail closed on daily/max-open caps.
- Protective exits and reductions are not blocked by entry-only caps.
- Unknown/manual entries remain quarantined.
