### PR TITLE
Verify broker truth before quarantining unknown orders

### DIFF
--- a/src/nifty_scalper_bot/execution/broker_exposure_quarantine_extension.py
+++ b/src/nifty_scalper_bot/execution/broker_exposure_quarantine_extension.py
@@ -82,7 +82,6 @@ def _is_manual_reduction_order(manager: Any, order: Any) -> bool:
     if existing is None:
         return False
     existing_side = str(getattr(existing, "side", "") or "").strip().upper()
-    existing_qty = 0
     with suppress(Exception):
         existing_qty = abs(int(float(getattr(existing, "quantity", 0) or 0)))
     if existing_qty <= 0 or qty > existing_qty:
@@ -140,8 +139,8 @@ def _manual_order_exposure(order: Any, intent: str) -> dict[str, Any] | None:
         "side": _order_side(order),
         "product": str(getattr(order, "product", "MIS") or "MIS").upper(),
         "average_price": price,
-        "status": "MANUAL_ORDER_QUARANTINED",
-        "reason": "manual_order_quarantined",
+        "status": "BROKER_POSITION_QUARANTINED",
+        "reason": "broker_position_unowned_or_cost_basis_unresolved",
         "intent": intent,
         "order_id": str(getattr(order, "order_id", "") or ""),
         "managed_position": False,
@@ -192,8 +191,16 @@ def apply_patches() -> None:
 
     def current_entry_protection_blocker(self: Any, symbol: str | None = None) -> str | None:
         exposures = dict(getattr(self, "_quarantined_broker_exposures", {}) or {})
-        if exposures and (symbol is None or _canonical(symbol) in exposures):
-            return "broker_exposure_quarantined"
+        if exposures:
+            if symbol is None:
+                exposure = next(iter(exposures.values()))
+            else:
+                exposure = exposures.get(_canonical(symbol))
+            if exposure is not None:
+                reason = str(exposure.get("reason") or "")
+                if reason == "broker_state_unverified":
+                    return "broker_state_unverified"
+                return "broker_exposure_quarantined"
         original = _ORIGINALS.get("PositionManager.current_entry_protection_blocker")
         if callable(original):
             return original(self, symbol)
@@ -245,9 +252,21 @@ def apply_patches() -> None:
 
         result = original(self, order)
         if intent in _MANUAL_INTENTS:
+            symbol = _order_symbol(order)
+            result_reason = str(getattr(result, "reason", "") or "")
+            exposures = dict(getattr(self, "_quarantined_broker_exposures", {}) or {})
+            if result_reason == "broker_flat_confirmed_unknown_order":
+                exposures.pop(symbol, None)
+                self._quarantined_broker_exposures = exposures
+                return result
             exposure = _manual_order_exposure(order, intent)
             if exposure is not None:
-                exposures = dict(getattr(self, "_quarantined_broker_exposures", {}) or {})
+                if result_reason == "broker_state_unverified":
+                    exposure["status"] = "BROKER_STATE_UNVERIFIED"
+                    exposure["reason"] = "broker_state_unverified"
+                    exposure["requires_history_recovery"] = False
+                elif result_reason:
+                    exposure["reason"] = result_reason
                 exposures[exposure["symbol"]] = exposure
                 self._quarantined_broker_exposures = exposures
         return result

--- a/src/nifty_scalper_bot/execution/broker_exposure_quarantine_extension.py
+++ b/src/nifty_scalper_bot/execution/broker_exposure_quarantine_extension.py
@@ -82,6 +82,7 @@ def _is_manual_reduction_order(manager: Any, order: Any) -> bool:
     if existing is None:
         return False
     existing_side = str(getattr(existing, "side", "") or "").strip().upper()
+    existing_qty = 0
     with suppress(Exception):
         existing_qty = abs(int(float(getattr(existing, "quantity", 0) or 0)))
     if existing_qty <= 0 or qty > existing_qty:
@@ -190,15 +191,21 @@ def apply_patches() -> None:
         return _ORIGINALS["PositionManager.synchronize_with_broker"](self, broker_positions)
 
     def current_entry_protection_blocker(self: Any, symbol: str | None = None) -> str | None:
-        exposures = dict(getattr(self, "_quarantined_broker_exposures", {}) or {})
-        if exposures:
-            if symbol is None:
-                exposure = next(iter(exposures.values()))
-            else:
+        exposures = getattr(self, "_quarantined_broker_exposures", {}) or {}
+        if isinstance(exposures, dict) and exposures:
+            if symbol is not None:
                 exposure = exposures.get(_canonical(symbol))
-            if exposure is not None:
-                reason = str(exposure.get("reason") or "")
-                if reason == "broker_state_unverified":
+                if exposure is not None:
+                    reason = str(exposure.get("reason") or "")
+                    if reason == "broker_state_unverified":
+                        return "broker_state_unverified"
+                    return "broker_exposure_quarantined"
+            else:
+                if any(
+                    str(exposure.get("reason") or "") == "broker_state_unverified"
+                    for exposure in exposures.values()
+                    if isinstance(exposure, dict)
+                ):
                     return "broker_state_unverified"
                 return "broker_exposure_quarantined"
         original = _ORIGINALS.get("PositionManager.current_entry_protection_blocker")

--- a/src/nifty_scalper_bot/execution/position_identity_extension.py
+++ b/src/nifty_scalper_bot/execution/position_identity_extension.py
@@ -7,11 +7,16 @@ by the loaded runtime guards in this module.
 from __future__ import annotations
 
 from contextlib import suppress
+import inspect
 import threading
 from typing import Any
 
 from nifty_scalper_bot.execution import live_safety_identity as _live_safety_identity
 from nifty_scalper_bot.execution import position_manager as _position_manager
+from nifty_scalper_bot.execution.position_snapshot import (
+    PositionSnapshotError,
+    decode_position_snapshot,
+)
 from nifty_scalper_bot.utils.symbols import normalize_symbol
 
 _PATCH_APPLIED = False
@@ -134,6 +139,66 @@ def _restore_persistent_state_methods(cls: Any) -> None:
             setattr(cls, name, original)
 
 
+def _resolve_broker_position_fetcher(manager: Any) -> Any | None:
+    resolver = getattr(manager, "_resolve_broker_position_fetcher", None)
+    if callable(resolver):
+        with suppress(Exception):
+            fetcher = resolver()
+            if callable(fetcher):
+                return fetcher
+    broker = (
+        getattr(manager, "_broker_client", None)
+        or getattr(manager, "broker_client", None)
+        or getattr(manager, "broker", None)
+    )
+    if broker is None:
+        return None
+    for name in ("get_positions", "list_positions", "positions", "fetch_positions"):
+        fetcher = getattr(broker, name, None)
+        if callable(fetcher):
+            return fetcher
+    return None
+
+
+def _broker_position_quantity(manager: Any, symbol: str) -> tuple[str, int, str | None]:
+    """Return broker truth for *symbol*: flat, open, or unverified.
+
+    Broker position snapshot is the only authority allowed to prove that an
+    unknown/replayed order has no live exposure. Missing or failed broker access
+    deliberately fails closed as ``unverified``.
+    """
+
+    fetcher = _resolve_broker_position_fetcher(manager)
+    if fetcher is None:
+        return "unverified", 0, "broker_position_fetcher_missing"
+    try:
+        payload = fetcher()
+        if inspect.isawaitable(payload):
+            with suppress(Exception):
+                close = getattr(payload, "close", None)
+                if callable(close):
+                    close()
+            return "unverified", 0, "async_broker_position_fetcher_unsupported"
+        snapshot = decode_position_snapshot(payload)
+        qty = int(snapshot.quantity_for(symbol))
+    except PositionSnapshotError as exc:
+        return "unverified", 0, f"position_snapshot_invalid:{exc}"
+    except Exception as exc:  # noqa: BLE001 - broker boundary must fail closed
+        return "unverified", 0, f"broker_position_fetch_failed:{type(exc).__name__}:{exc}"
+    return ("flat", 0, None) if qty == 0 else ("open", qty, None)
+
+
+def _clear_symbol_quarantine(manager: Any, symbol: str) -> None:
+    exposures = getattr(manager, "_quarantined_broker_exposures", None)
+    if isinstance(exposures, dict):
+        exposures.pop(symbol, None)
+        with suppress(Exception):
+            manager._quarantined_broker_exposures = exposures
+    unresolved = getattr(manager, "_cost_basis_unresolved_symbols", None)
+    if isinstance(unresolved, set):
+        unresolved.discard(symbol)
+
+
 def apply_patches() -> None:
     global _PATCH_APPLIED
     if _PATCH_APPLIED:
@@ -249,23 +314,72 @@ def apply_patches() -> None:
     def _handle_filled_order(self: Any, order: Any) -> Any:
         intent = str(getattr(order, "intent", "UNKNOWN") or "UNKNOWN").strip().upper()
         if intent in _QUARANTINE_INTENTS:
+            symbol = _canonical_key(getattr(order, "symbol", None))
+            state, broker_qty, broker_error = _broker_position_quantity(self, symbol)
             logger = getattr(self, "_logger", None)
-            log = getattr(logger, "warning", None)
-            if callable(log):
-                log(
-                    "MANUAL_ORDER_QUARANTINED order_id=%s symbol=%s side=%s",
+            log_warning = getattr(logger, "warning", None)
+            log_info = getattr(logger, "info", None)
+
+            if state == "flat":
+                _clear_symbol_quarantine(self, symbol)
+                if callable(log_info):
+                    log_info(
+                        "BROKER_FLAT_CONFIRMED_FOR_UNKNOWN_ORDER order_id=%s symbol=%s side=%s",
+                        getattr(order, "order_id", None),
+                        symbol,
+                        getattr(order, "side", None),
+                        extra={
+                            "event": "BROKER_FLAT_CONFIRMED_FOR_UNKNOWN_ORDER",
+                            "order_id": getattr(order, "order_id", None),
+                            "symbol": symbol,
+                            "side": getattr(order, "side", None),
+                            "intent": intent,
+                        },
+                    )
+                return _position_manager.FillApplicationResult(
+                    accounting_finalized=True,
+                    lifecycle_resolved=True,
+                    reason="broker_flat_confirmed_unknown_order",
+                )
+
+            if state == "unverified":
+                if callable(log_warning):
+                    log_warning(
+                        "BROKER_STATE_UNVERIFIED_FOR_UNKNOWN_ORDER order_id=%s symbol=%s side=%s reason=%s",
+                        getattr(order, "order_id", None),
+                        symbol,
+                        getattr(order, "side", None),
+                        broker_error,
+                        extra={
+                            "event": "BROKER_STATE_UNVERIFIED_FOR_UNKNOWN_ORDER",
+                            "order_id": getattr(order, "order_id", None),
+                            "symbol": symbol,
+                            "side": getattr(order, "side", None),
+                            "intent": intent,
+                            "reason": broker_error,
+                        },
+                    )
+                return _position_manager.FillApplicationResult(reason="broker_state_unverified")
+
+            if callable(log_warning):
+                log_warning(
+                    "BROKER_POSITION_QUARANTINED_FOR_UNKNOWN_ORDER order_id=%s symbol=%s side=%s broker_qty=%s",
                     getattr(order, "order_id", None),
-                    getattr(order, "symbol", None),
+                    symbol,
                     getattr(order, "side", None),
+                    broker_qty,
                     extra={
-                        "event": "MANUAL_ORDER_QUARANTINED",
+                        "event": "BROKER_POSITION_QUARANTINED_FOR_UNKNOWN_ORDER",
                         "order_id": getattr(order, "order_id", None),
-                        "symbol": getattr(order, "symbol", None),
+                        "symbol": symbol,
                         "side": getattr(order, "side", None),
                         "intent": intent,
+                        "broker_qty": broker_qty,
                     },
                 )
-            return _position_manager.FillApplicationResult(reason="manual_order_quarantined")
+            return _position_manager.FillApplicationResult(
+                reason="broker_position_unowned_or_cost_basis_unresolved"
+            )
         return _ORIGINALS["PositionManager._handle_filled_order"](self, order)
 
     if "PositionManager.__init__" in _ORIGINALS:

--- a/tests/execution/test_manual_order_quarantine.py
+++ b/tests/execution/test_manual_order_quarantine.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 from nifty_scalper_bot.execution import position_identity_extension as identity_ext
 from nifty_scalper_bot.execution.position_manager import Order, PositionManager
 
@@ -7,11 +9,22 @@ from nifty_scalper_bot.execution.position_manager import Order, PositionManager
 SYMBOL = "NFO:NIFTY2670724250PE"
 
 
-def test_unknown_buy_fill_does_not_scale_existing_long_position(tmp_path):
-    manager = PositionManager(state_file=str(tmp_path / "positions.json"))
-    manager.open_position(SYMBOL, "LONG", 65, 75.0, order_id="entry-1")
-    order = Order(
-        order_id="manual-buy",
+class BrokerPositions:
+    def __init__(self, payload=None, exc: Exception | None = None) -> None:
+        self.payload = {"net": []} if payload is None else payload
+        self.exc = exc
+        self.calls = 0
+
+    def get_positions(self):
+        self.calls += 1
+        if self.exc is not None:
+            raise self.exc
+        return self.payload
+
+
+def _unknown_buy(order_id: str = "manual-buy") -> Order:
+    return Order(
+        order_id=order_id,
         symbol=SYMBOL,
         side="BUY",
         order_type="MARKET",
@@ -22,6 +35,25 @@ def test_unknown_buy_fill_does_not_scale_existing_long_position(tmp_path):
         fill_price=80.0,
         intent="UNKNOWN",
     )
+
+
+def test_unknown_buy_fill_with_broker_open_does_not_scale_existing_long_position(tmp_path):
+    manager = PositionManager(state_file=str(tmp_path / "positions.json"))
+    manager.set_broker_client(
+        BrokerPositions(
+            {
+                "net": [
+                    {
+                        "tradingsymbol": "NIFTY2670724250PE",
+                        "quantity": 130,
+                        "average_price": 80.0,
+                    }
+                ]
+            }
+        )
+    )
+    manager.open_position(SYMBOL, "LONG", 65, 75.0, order_id="entry-1")
+    order = _unknown_buy()
     manager._orders[order.order_id] = order
 
     manager.update_order_status(order.order_id, "COMPLETE", fill_price=80.0)
@@ -35,9 +67,63 @@ def test_unknown_buy_fill_does_not_scale_existing_long_position(tmp_path):
     assert terminal.lifecycle_applied is False
     assert terminal.lifecycle_resolved is False
     exposures = manager.get_quarantined_broker_exposures()
-    assert exposures[SYMBOL]["status"] == "MANUAL_ORDER_QUARANTINED"
+    assert exposures[SYMBOL]["status"] == "BROKER_POSITION_QUARANTINED"
     assert exposures[SYMBOL]["order_id"] == "manual-buy"
-    assert exposures[SYMBOL]["reason"] == "manual_order_quarantined"
+    assert exposures[SYMBOL]["reason"] == "broker_position_unowned_or_cost_basis_unresolved"
+
+
+def test_unknown_buy_fill_with_broker_flat_is_resolved_without_quarantine(tmp_path, caplog):
+    manager = PositionManager(state_file=str(tmp_path / "positions.json"))
+    broker = BrokerPositions({"net": []})
+    manager.set_broker_client(broker)
+    order = _unknown_buy("replayed-buy")
+    manager._orders[order.order_id] = order
+
+    with caplog.at_level("INFO"):
+        manager.update_order_status(order.order_id, "COMPLETE", fill_price=80.0)
+
+    assert broker.calls == 1
+    assert manager.get_position(SYMBOL) is None
+    assert manager.get_quarantined_broker_exposures() == {}
+    terminal = manager._terminal_orders[order.order_id]
+    assert terminal.lifecycle_applied is False
+    assert terminal.accounting_finalized is True
+    assert terminal.lifecycle_resolved is True
+    assert order.order_id not in manager._unresolved_terminal_orders
+    assert "BROKER_FLAT_CONFIRMED_FOR_UNKNOWN_ORDER" in caplog.text
+    assert "MANUAL_ORDER_QUARANTINED" not in caplog.text
+
+
+def test_unknown_buy_fill_with_broker_fetch_failure_fails_closed(tmp_path):
+    manager = PositionManager(state_file=str(tmp_path / "positions.json"))
+    manager.set_broker_client(BrokerPositions(exc=RuntimeError("kite down")))
+    order = _unknown_buy("unverified-buy")
+    manager._orders[order.order_id] = order
+
+    manager.update_order_status(order.order_id, "COMPLETE", fill_price=80.0)
+
+    assert manager.get_position(SYMBOL) is None
+    terminal = manager._terminal_orders[order.order_id]
+    assert terminal.lifecycle_resolved is False
+    assert order.order_id in manager._unresolved_terminal_orders
+    exposures = manager.get_quarantined_broker_exposures()
+    assert exposures[SYMBOL]["status"] == "BROKER_STATE_UNVERIFIED"
+    assert exposures[SYMBOL]["reason"] == "broker_state_unverified"
+    assert manager.current_entry_protection_blocker(SYMBOL) == "broker_state_unverified"
+
+
+def test_unknown_buy_fill_without_broker_fetcher_fails_closed(tmp_path):
+    manager = PositionManager(state_file=str(tmp_path / "positions.json"))
+    order = _unknown_buy("no-fetcher-buy")
+    manager._orders[order.order_id] = order
+
+    manager.update_order_status(order.order_id, "COMPLETE", fill_price=80.0)
+
+    assert manager.get_position(SYMBOL) is None
+    exposures = manager.get_quarantined_broker_exposures()
+    assert exposures[SYMBOL]["status"] == "BROKER_STATE_UNVERIFIED"
+    assert exposures[SYMBOL]["reason"] == "broker_state_unverified"
+    assert manager.current_entry_protection_blocker(SYMBOL) == "broker_state_unverified"
 
 
 def test_unknown_sell_fill_is_recognized_as_manual_exit_for_existing_long_position(tmp_path):


### PR DESCRIPTION
### Summary
- Change UNKNOWN/blank/BROKER_IMPORTED_ORDER fill handling so the bot checks live broker positions before quarantining.
- If broker proves the symbol is flat, clear quarantine and resolve the terminal order as ignored/no-accounting.
- If broker has open exposure, record `BROKER_POSITION_QUARANTINED` instead of blindly treating it as a manual order.
- If broker position state cannot be fetched, fail closed with `BROKER_STATE_UNVERIFIED` and block entries for that symbol.
- Preserve manual exit recognition for UNKNOWN sells reducing an existing local long.

### Why
A stale/replayed filled BUY order was logging `MANUAL_ORDER_QUARANTINED` even when Kite showed no open broker position. Broker position truth must override stale local assumptions, while broker fetch failures must remain fail-closed.

### Validation target
- `python -m compileall -q src`
- `python -m pytest -q tests/execution/test_manual_order_quarantine.py`
- `python -m pytest -q tests/execution/test_post_fill_monitor_reconcile.py`
- `python -m pytest -q tests/execution/test_post_fill_monitor_sync_positions.py`
- `python -m pytest -q`