### PR TITLE
Ensure market data hardening is installed during startup

### DIFF
--- a/src/nifty_scalper_bot/core/__init__.py
+++ b/src/nifty_scalper_bot/core/__init__.py
@@ -58,6 +58,24 @@ except Exception as exc:  # noqa: BLE001 - core package import must not crash to
         extra={"event": "BOOT_LOG_RATE_CONTROL_FAILED", "error_type": type(exc).__name__},
     )
 
+try:
+    from nifty_scalper_bot.core.market_data_hardening_bootstrap import (
+        install_market_data_hardening_or_raise as _install_market_data_hardening,
+    )
+
+    _install_market_data_hardening(get_logger(__name__))
+except Exception as exc:  # noqa: BLE001 - fail closed only for real live mode
+    get_logger(__name__).error(
+        "MARKET_DATA_HARDENING_BOOTSTRAP_FAILED error=%s",
+        exc,
+        extra={
+            "event": "MARKET_DATA_HARDENING_BOOTSTRAP_FAILED",
+            "error_type": type(exc).__name__,
+        },
+    )
+    if _real_live_mode_requested():
+        raise RuntimeError("market_data_hardening_bootstrap_failed") from exc
+
 __all__ = ["NiftyScalperApp", "canonical_price_source"]
 
 _LOGGER = get_logger(__name__)

--- a/src/nifty_scalper_bot/core/market_data_hardening_bootstrap.py
+++ b/src/nifty_scalper_bot/core/market_data_hardening_bootstrap.py
@@ -1,0 +1,67 @@
+"""Deterministic market-data hardening bootstrap.
+
+This module is intentionally narrow: it verifies that the live market-data
+classes expose their runtime hardening hooks before the trading app is built.
+The class definition files still own the actual hook installation; this layer
+makes startup visibility explicit and fails loudly in real live mode if the
+hooks cannot be confirmed.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+_MDM_HARDENING_ATTR = "_freshness_hardening_installed"
+_WS_HARDENING_ATTR = "_market_data_hardening_installed"
+
+
+def install_market_data_hardening_or_raise(logger: Any | None = None) -> dict[str, bool]:
+    """Install and verify MDM/WebSocket market-data hardening.
+
+    Args:
+        logger: Optional structured logger used for the startup confirmation.
+
+    Returns:
+        Mapping with ``mdm`` and ``websocket`` installation states.
+
+    Raises:
+        RuntimeError: If either hardening layer is unavailable after explicit
+            idempotent installation.
+    """
+
+    from nifty_scalper_bot.data.market_data_hardening import (
+        install_market_data_manager_hardening,
+    )
+    from nifty_scalper_bot.data.market_data_manager import MarketDataManager
+    from nifty_scalper_bot.streaming.market_data_hardening import (
+        install_websocket_market_data_hardening,
+    )
+    from nifty_scalper_bot.streaming.websocket_manager import WebSocketManager
+
+    install_market_data_manager_hardening(MarketDataManager)
+    install_websocket_market_data_hardening(WebSocketManager)
+
+    state = {
+        "mdm": bool(getattr(MarketDataManager, _MDM_HARDENING_ATTR, False)),
+        "websocket": bool(getattr(WebSocketManager, _WS_HARDENING_ATTR, False)),
+    }
+
+    if logger is not None:
+        logger.info(
+            "MARKET_DATA_HARDENING_INSTALLED mdm=%s websocket=%s",
+            state["mdm"],
+            state["websocket"],
+            extra={
+                "event": "MARKET_DATA_HARDENING_INSTALLED",
+                "mdm": state["mdm"],
+                "websocket": state["websocket"],
+            },
+        )
+
+    if not all(state.values()):
+        raise RuntimeError(f"market_data_hardening_not_installed state={state}")
+
+    return state
+
+
+__all__ = ["install_market_data_hardening_or_raise"]

--- a/tests/core/test_market_data_hardening_bootstrap.py
+++ b/tests/core/test_market_data_hardening_bootstrap.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import logging
+
+from nifty_scalper_bot.core.market_data_hardening_bootstrap import (
+    install_market_data_hardening_or_raise,
+)
+from nifty_scalper_bot.data.market_data_manager import MarketDataManager
+from nifty_scalper_bot.streaming.websocket_manager import WebSocketManager
+
+
+def test_market_data_hardening_bootstrap_confirms_mdm_and_websocket_hooks(caplog) -> None:
+    caplog.set_level(logging.INFO)
+
+    state = install_market_data_hardening_or_raise(logging.getLogger("test.market_data_hardening"))
+
+    assert state == {"mdm": True, "websocket": True}
+    assert getattr(MarketDataManager, "_freshness_hardening_installed", False) is True
+    assert getattr(WebSocketManager, "_market_data_hardening_installed", False) is True
+    assert "MARKET_DATA_HARDENING_INSTALLED mdm=True websocket=True" in caplog.text


### PR DESCRIPTION
## Summary
- Add an explicit market-data hardening bootstrap verifier for MarketDataManager and WebSocketManager.
- Run the verifier from core package bootstrap so production startup logs `MARKET_DATA_HARDENING_INSTALLED mdm=True websocket=True`.
- Fail closed only when real LIVE mode is requested; keep non-live tooling imports usable.
- Add a regression test that confirms both hardening hooks remain installed.

## Notes
- Current class definition files already install the hardening hooks at definition-site.
- This PR makes that state visible and enforceable at startup, reducing the risk of silent un-hardened live runtime.

## Testing
- Not run locally in this environment; GitHub source patch only.