### PR TITLE
Reject synthetic timestamp quotes from hard readiness

### DIFF
--- a/src/nifty_scalper_bot/execution/quote_readiness.py
+++ b/src/nifty_scalper_bot/execution/quote_readiness.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 from dataclasses import asdict, dataclass
 from typing import Any, Mapping
 
-from nifty_scalper_bot.execution.readiness import resolve_quote_bid_ask_spread
+from nifty_scalper_bot.execution.readiness import (
+    quote_timestamp_quality_allows_hard_readiness,
+    resolve_quote_bid_ask_spread,
+)
 
 
 def _value(payload: Mapping[str, Any] | object | None, key: str) -> Any:
@@ -87,6 +90,7 @@ class ExecutionQuoteReadiness:
 
 
 def evaluate_execution_quote(symbol: str, payload: Mapping[str, Any] | object | None, *, live_mode: bool, max_tick_age_ms: float, max_spread_pct: float, require_depth: bool, min_real_ticks_last_60s: int = 0) -> ExecutionQuoteReadiness:
+    timestamp_quality_ok = quote_timestamp_quality_allows_hard_readiness(payload)
     bid, ask, derived_spread_pct, _bid_ask_source = resolve_quote_bid_ask_spread(payload)
     has_bid_ask = bool(bid is not None and ask is not None and bid > 0 and ask > bid)
     spread_pct = _float(payload, "spread_pct")
@@ -101,7 +105,9 @@ def evaluate_execution_quote(symbol: str, payload: Mapping[str, Any] | object | 
     real_ticks, derived = resolve_real_tick_count(payload, tick_age_ms=tick_age_ms, max_age_ms=max_tick_age_ms, has_bid_ask=has_bid_ask)
 
     reason = "ready"
-    if not has_bid_ask:
+    if live_mode and not timestamp_quality_ok:
+        reason = "timestamp_quality_unusable"
+    elif not has_bid_ask:
         reason = "bid_ask_missing"
     elif live_mode and tick_age_ms is None:
         reason = "tick_age_missing"

--- a/src/nifty_scalper_bot/execution/readiness.py
+++ b/src/nifty_scalper_bot/execution/readiness.py
@@ -13,6 +13,7 @@ from datetime import datetime, timezone
 from typing import Mapping
 
 LOGGER = logging.getLogger(__name__)
+_UNUSABLE_QUOTE_TIMESTAMP_QUALITIES = {"synthetic", "unknown", "invalid"}
 
 
 def _env_int(name: str, default: int, minimum: int = 1) -> int:
@@ -271,9 +272,27 @@ class HistoryReadinessPolicy:
         )
 
 
+def _quote_getter(payload: dict | object):
+    return payload.get if isinstance(payload, dict) else lambda key, default=None: getattr(payload, key, default)
+
+
+def quote_timestamp_quality_allows_hard_readiness(quote: dict | object | None) -> bool:
+    """Return False when a quote explicitly carries synthetic/invalid time proof.
+
+    Missing timestamp_quality remains backward-compatible; explicit unusable
+    quality is treated as hard-negative for bid/ask readiness and live arming.
+    """
+
+    if quote is None:
+        return True
+    getter = _quote_getter(quote)
+    quality = str(getter("timestamp_quality", "") or "").strip().lower()
+    return quality not in _UNUSABLE_QUOTE_TIMESTAMP_QUALITIES
+
+
 def _quote_float(payload: dict | object, *keys: str) -> float | None:
     """Return first positive-compatible float field from a quote-like mapping."""
-    getter = payload.get if isinstance(payload, dict) else lambda key, default=None: getattr(payload, key, default)
+    getter = _quote_getter(payload)
     for key in keys:
         value = getter(key, None)
         if value is None:
@@ -292,10 +311,13 @@ def resolve_quote_bid_ask_spread(quote: dict | object) -> tuple[float | None, fl
 
     Fresh WebSocket FULL quotes are tradable when either top-level bid/ask or
     depth.buy[0]/depth.sell[0] contains a valid crossed-safe best bid/ask.
+    Quotes explicitly tagged synthetic/unknown/invalid cannot prove readiness.
     """
     if quote is None:
         return None, None, None, "missing"
-    getter = quote.get if isinstance(quote, dict) else lambda key, default=None: getattr(quote, key, default)
+    if not quote_timestamp_quality_allows_hard_readiness(quote):
+        return None, None, None, "timestamp_quality_unusable"
+    getter = _quote_getter(quote)
     bid: float | None = None
     ask: float | None = None
     source = "missing"
@@ -357,7 +379,6 @@ class QuoteReadiness:
     def to_dict(self) -> dict[str, object]:
         return asdict(self)
 
-
 def evaluate_quote_readiness(
     symbol: str,
     quote: dict | object | None,
@@ -374,15 +395,18 @@ def evaluate_quote_readiness(
     """
     if quote is None:
         return QuoteReadiness(symbol=symbol, ltp_ready=False, depth_available=False, bid_ask_available=False, tradable_quote_ready=False, reason="quote_missing")
-    getter = quote.get if isinstance(quote, dict) else lambda key, default=None: getattr(quote, key, default)
+    getter = _quote_getter(quote)
     ltp = _quote_float(quote, "ltp", "last_price", "last_traded_price")
     ltp_ready = bool(ltp is not None and ltp > 0)
     depth = getter("depth", None)
     depth_available = bool(getter("depth_available", False) or depth)
     bid, ask, spread_pct, source = resolve_quote_bid_ask_spread(quote)
     bid_ask_available = bool(bid is not None and ask is not None and bid > 0 and ask > bid)
+    timestamp_quality_ok = quote_timestamp_quality_allows_hard_readiness(quote)
     if not ltp_ready:
         reason = "ltp_missing"
+    elif not timestamp_quality_ok:
+        reason = "timestamp_quality_unusable"
     elif not bid_ask_available:
         raw_bid = _quote_float(quote, "bid", "bid_price", "best_bid", "best_bid_price")
         raw_ask = _quote_float(quote, "ask", "ask_price", "best_ask", "best_ask_price")

--- a/src/nifty_scalper_bot/execution/readiness.py
+++ b/src/nifty_scalper_bot/execution/readiness.py
@@ -241,6 +241,17 @@ class HydrationStatus:
     last_bar_ts: datetime | None = None
     live_merge_applied: bool = False
 
+    def __post_init__(self) -> None:
+        if self.role not in {"selected_ce", "selected_pe"} or not self.ready_for_execution:
+            return
+        bid_ask_valid = bool(self.bid is not None and self.ask is not None and self.bid > 0 and self.ask > self.bid)
+        if bid_ask_valid:
+            return
+        self.ready_for_execution = False
+        blocker = f"{self.role}_quote_missing"
+        if blocker not in self.blocker_reasons:
+            self.blocker_reasons.append(blocker)
+
     def to_dict(self) -> dict[str, object]:
         """Return a JSON-friendly hydration snapshot."""
         payload = asdict(self)

--- a/tests/core/test_hydration_status_propagation.py
+++ b/tests/core/test_hydration_status_propagation.py
@@ -135,3 +135,17 @@ def test_readiness_true_when_all_layers_have_bars_and_quote_depth_valid() -> Non
     assert status.ready_for_execution is True
     assert status.tradable_quote is True
     assert status.depth_available is True
+
+
+def test_synthetic_timestamp_quote_does_not_make_selected_option_execution_ready() -> None:
+    quote = {
+        **_quote(),
+        "timestamp_quality": "synthetic",
+    }
+
+    status = app.build_symbol_hydration_status(_ctx(30, 30, 30, 30, quote), SYMBOL, "selected_ce", 30)
+
+    assert status.ready_for_evaluation is True
+    assert status.ready_for_execution is False
+    assert status.tradable_quote is True
+    assert "selected_ce_quote_missing" in status.blocker_reasons

--- a/tests/execution/test_quote_readiness.py
+++ b/tests/execution/test_quote_readiness.py
@@ -5,6 +5,7 @@ from nifty_scalper_bot.execution.quote_readiness import (
     resolve_real_tick_count,
     resolve_tick_age_ms,
 )
+from nifty_scalper_bot.execution.readiness import resolve_quote_bid_ask_spread
 
 
 def test_missing_age_never_becomes_fresh_in_live_mode():
@@ -47,6 +48,31 @@ def test_quote_age_seconds_allows_live_orderflow_quote():
     assert result.allowed is True
     assert result.reason == "ready"
     assert result.tick_age_ms == 100
+
+
+def test_synthetic_timestamp_quality_blocks_live_quote_readiness():
+    payload = {
+        "bid": 99.9,
+        "ask": 100.1,
+        "tick_age_ms": 100,
+        "depth_available": True,
+        "tradable_quote": True,
+        "timestamp_quality": "synthetic",
+    }
+
+    result = evaluate_execution_quote(
+        "NFO:NIFTY26JUN24000CE",
+        payload,
+        live_mode=True,
+        max_tick_age_ms=2500,
+        max_spread_pct=0.75,
+        require_depth=True,
+    )
+    bid, ask, spread, source = resolve_quote_bid_ask_spread(payload)
+
+    assert result.allowed is False
+    assert result.reason == "timestamp_quality_unusable"
+    assert (bid, ask, spread, source) == (None, None, None, "timestamp_quality_unusable")
 
 
 def test_fresh_ms_quote_can_prove_one_recent_update():


### PR DESCRIPTION
## Summary
- Reject quotes explicitly tagged `timestamp_quality=synthetic|unknown|invalid` from bid/ask readiness proof.
- Surface execution quote failures as `timestamp_quality_unusable` in live mode.
- Add a HydrationStatus post-init guard so selected CE/PE cannot remain execution-ready without real bid/ask proof.
- Add regression tests for execution quote readiness and selected-option hydration readiness.

## Rationale
`MarketDataManager.has_fresh_ws_ltp()` already rejects synthetic timestamp quality, but the canonical hydration readiness path could still treat explicit `tradable_quote=True` plus fresh age as enough for selected-option execution. This closes that hard-readiness bypass.

## Testing
- Not run locally in this environment; GitHub source patch only.