### PR TITLE
Allow OrderFlow trigger with fresh live direction-context proof

### DIFF
--- a/src/nifty_scalper_bot/strategies/elite_strategies/__init__.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/__init__.py
@@ -9,10 +9,13 @@ from ..elite_tuesday_gamma_buyer import EliteTuesdayGammaBuyer
 from .oi_max_pain import OIMaxPainStrategy
 from .orb_pro import ORBProStrategy
 from .order_flow import OrderFlowStrategy
+from .order_flow_live_context_patch import apply_orderflow_live_context_patch
 from .rsi_divergence import RSIDivergenceStrategy
 from .smc_liquidity import SMCStrategy
 from .straddle_theta import StraddleThetaStrategy
 from .vwap_pro import VWAPProStrategy
+
+apply_orderflow_live_context_patch(OrderFlowStrategy)
 
 __all__ = [
     "BBSqueezeStrategy",

--- a/src/nifty_scalper_bot/strategies/elite_strategies/order_flow_live_context_patch.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/order_flow_live_context_patch.py
@@ -1,0 +1,111 @@
+"""Live direction-context proof adapter for OrderFlow.
+
+This patch is deliberately narrow.  It does not invent an underlying CE/PE bias.
+It only prevents a live OrderFlow candidate from being blocked solely because
+``direction_bias`` is absent when fresh spot/futures context proof is present and
+all other execution gates already passed.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Mapping
+
+from nifty_scalper_bot.strategies.runtime_context_contract import live_direction_context_has_proof
+
+_PATCH_ATTR = "_live_direction_context_proof_patch_installed"
+_ORIGINAL_ATTR = "_live_direction_context_proof_original_evaluate_signal"
+_TRUTHY = {"1", "true", "yes", "y", "on"}
+
+
+def _env_live() -> bool:
+    return str(os.getenv("EXECUTION_MODE", "SHADOW") or "SHADOW").strip().upper() == "LIVE"
+
+
+def _boolish(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    return str(value or "").strip().lower() in _TRUTHY
+
+
+def _safe_float(value: Any) -> float | None:
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    return number if number == number else None
+
+
+def _can_upgrade_direction_context_block(metadata: Mapping[str, Any], indicators: Mapping[str, Any]) -> bool:
+    if str(metadata.get("trigger_block_reason") or "") != "direction_context_missing_live":
+        return False
+    if metadata.get("raw_direction_bias") in {"CE", "PE"} or metadata.get("direction_bias") in {"CE", "PE"}:
+        return False
+    context = dict(indicators or {})
+    context.update(dict(metadata or {}))
+    if not live_direction_context_has_proof(context):
+        return False
+    score = _safe_float(metadata.get("strategy_score") or metadata.get("setup_quality"))
+    min_score = _safe_float(metadata.get("trigger_min_score"))
+    spread = _safe_float(metadata.get("spread_pct"))
+    max_spread = _safe_float(metadata.get("trigger_max_spread_pct"))
+    tick_age_ms = _safe_float(metadata.get("tick_age_ms"))
+    max_tick_age_ms = _safe_float(os.getenv("LIVE_MAX_TICK_AGE_MS", "2500") or 2500)
+    if score is None or min_score is None or score < min_score:
+        return False
+    if spread is None or max_spread is None or spread > max_spread:
+        return False
+    if tick_age_ms is None or max_tick_age_ms is None or tick_age_ms > max_tick_age_ms:
+        return False
+    if _boolish(metadata.get("tick_direction_missing")):
+        return False
+    if not _boolish(metadata.get("quote_readiness_allowed")):
+        return False
+    if not _boolish(metadata.get("quote_depth_valid")) or not _boolish(metadata.get("depth_available")):
+        return False
+    if not _boolish(metadata.get("tradable_quote")):
+        return False
+    if not _boolish(metadata.get("selected_or_near_atm")):
+        return False
+    return True
+
+
+def apply_orderflow_live_context_patch(orderflow_cls: type[Any]) -> bool:
+    """Patch OrderFlowStrategy once. Returns True when installed."""
+
+    if bool(getattr(orderflow_cls, _PATCH_ATTR, False)):
+        return False
+    original = getattr(orderflow_cls, "_evaluate_signal", None)
+    if not callable(original):
+        return False
+
+    def _evaluate_signal_with_live_context_proof(self: Any, symbol: str, indicators: dict[str, Any], current_price: float, position: Any | None = None) -> Any:
+        signal = original(self, symbol, indicators, current_price, position)
+        if signal is None or not _env_live():
+            return signal
+        metadata = dict(getattr(signal, "metadata", {}) or {})
+        if not _can_upgrade_direction_context_block(metadata, indicators or {}):
+            return signal
+        metadata.update(
+            {
+                "role": "trigger",
+                "can_trigger": True,
+                "trigger_conditions_met": True,
+                "trigger_eligible": True,
+                "trigger_block_reason": "",
+                "trigger_disqualified_by": None,
+                "direction_context_ok": True,
+                "direction_context_live_proof": True,
+                "approval_candidate": "orderflow_live_depth_trigger",
+            }
+        )
+        signal.metadata = metadata
+        return signal
+
+    setattr(_evaluate_signal_with_live_context_proof, _ORIGINAL_ATTR, original)
+    setattr(orderflow_cls, "_evaluate_signal", _evaluate_signal_with_live_context_proof)
+    setattr(orderflow_cls, _PATCH_ATTR, True)
+    return True
+
+
+__all__ = ["apply_orderflow_live_context_patch"]

--- a/src/nifty_scalper_bot/strategies/runtime_context_contract.py
+++ b/src/nifty_scalper_bot/strategies/runtime_context_contract.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+import os
 import time
 from typing import Any, Mapping
 
@@ -54,6 +55,25 @@ _DIRECTION_ALIAS_KEYS = (
     "underlying_direction",
     "direction_context",
 )
+_TRUTHY = {"1", "true", "yes", "y", "on"}
+
+
+def _runtime_context_max_age_seconds(default: float = 5.0) -> float:
+    try:
+        return max(float(os.getenv("ORDERFLOW_MAX_CONTEXT_AGE_SECONDS", str(default)) or default), 0.0)
+    except (TypeError, ValueError):
+        return default
+
+
+def _coerce_bool(value: Any) -> bool | None:
+    if isinstance(value, bool):
+        return value
+    text = str(value or "").strip().lower()
+    if text in _TRUTHY:
+        return True
+    if text in {"0", "false", "no", "n", "off"}:
+        return False
+    return None
 
 
 def _coerce_direction(value: Any) -> str | None:
@@ -98,11 +118,47 @@ def _coerce_timestamp(value: Any) -> datetime | None:
     return ts.astimezone(timezone.utc)
 
 
+def _derive_freshness_from_age(context: Mapping[str, Any], *keys: str, max_age_seconds: float) -> bool | None:
+    for key in keys:
+        age = _coerce_age_seconds(context.get(key))
+        if age is not None:
+            return age <= max_age_seconds
+    return None
+
+
+def live_direction_context_has_proof(context: Mapping[str, Any], *, max_age_seconds: float | None = None) -> bool:
+    """Return True if live spot/futures context has explicit fresh proof.
+
+    This does not invent a CE/PE direction. It only confirms that the missing
+    direction is not due to absent/stale underlying context. Live trigger logic
+    can then decide whether its own microstructure evidence is strong enough.
+    """
+
+    if not isinstance(context, Mapping):
+        return False
+    max_age = _runtime_context_max_age_seconds() if max_age_seconds is None else max(float(max_age_seconds), 0.0)
+    spot_fresh = _coerce_bool(context.get("spot_fresh"))
+    fut_fresh = _coerce_bool(context.get("fut_fresh"))
+    futures_fresh = _coerce_bool(context.get("futures_fresh"))
+    if fut_fresh is None:
+        fut_fresh = futures_fresh
+    derived_spot = _derive_freshness_from_age(context, "spot_age_seconds", "spot_tick_age_s", max_age_seconds=max_age)
+    derived_fut = _derive_freshness_from_age(context, "futures_age_seconds", "futures_tick_age_s", max_age_seconds=max_age)
+    if spot_fresh is None:
+        spot_fresh = derived_spot
+    if fut_fresh is None:
+        fut_fresh = derived_fut
+    context_age = _coerce_age_seconds(context.get("context_age_seconds"))
+    context_age_ok = context_age is None or context_age <= max_age
+    return bool(context_age_ok and (spot_fresh or fut_fresh))
+
+
 def normalise_live_direction_context(context: Mapping[str, Any]) -> dict[str, Any]:
     if not isinstance(context, Mapping):
         return {}
 
     preserved = {key: context[key] for key in _LIVE_DIRECTION_CONTEXT_KEYS if key in context}
+    max_age = _runtime_context_max_age_seconds()
 
     if "direction_bias" not in preserved:
         for key in _DIRECTION_ALIAS_KEYS:
@@ -115,6 +171,12 @@ def normalise_live_direction_context(context: Mapping[str, Any]) -> dict[str, An
         if direction is not None:
             preserved["direction_bias"] = direction
 
+    derived_spot = _derive_freshness_from_age(context, "spot_age_seconds", "spot_tick_age_s", max_age_seconds=max_age)
+    derived_fut = _derive_freshness_from_age(context, "futures_age_seconds", "futures_tick_age_s", max_age_seconds=max_age)
+    if "spot_fresh" not in preserved and derived_spot is not None:
+        preserved["spot_fresh"] = derived_spot
+    if "fut_fresh" not in preserved and derived_fut is not None:
+        preserved["fut_fresh"] = derived_fut
     if "futures_fresh" in preserved and "fut_fresh" not in preserved:
         preserved["fut_fresh"] = bool(preserved["futures_fresh"])
     if "fut_fresh" in preserved and "futures_fresh" not in preserved:
@@ -129,6 +191,7 @@ def normalise_live_direction_context(context: Mapping[str, Any]) -> dict[str, An
             if ts is not None:
                 preserved["context_age_seconds"] = max(0.0, time.time() - ts.timestamp())
                 break
+    preserved["live_direction_context_proof"] = live_direction_context_has_proof(preserved, max_age_seconds=max_age)
 
     return preserved
 

--- a/tests/strategies/test_order_flow_conflict_override.py
+++ b/tests/strategies/test_order_flow_conflict_override.py
@@ -105,3 +105,54 @@ def test_no_bias_not_conflict_gated(monkeypatch, strat):
     monkeypatch.setenv("EXECUTION_MODE", "LIVE")
     sig = _eval(strat, "NFO:NIFTY26MAY24000CE", _ind("", "UP", buy=400, sell=80))
     assert sig.metadata["trigger_block_reason"] != "direction_bias_conflict"
+
+
+def test_no_bias_without_spot_or_futures_live_proof_still_blocks(monkeypatch, strat):
+    monkeypatch.setenv("EXECUTION_MODE", "LIVE")
+    sig = _eval(strat, "NFO:NIFTY26MAY24000CE", _ind("", "UP", buy=400, sell=80))
+
+    assert sig.metadata["trigger_conditions_met"] is False
+    assert sig.metadata["trigger_block_reason"] == "direction_context_missing_live"
+    assert sig.metadata.get("direction_context_live_proof") is not True
+
+
+def test_no_bias_with_fresh_spot_live_proof_can_trigger(monkeypatch, strat):
+    monkeypatch.setenv("EXECUTION_MODE", "LIVE")
+    sig = _eval(
+        strat,
+        "NFO:NIFTY26MAY24000CE",
+        _ind(
+            "",
+            "UP",
+            buy=400,
+            sell=80,
+            spot_fresh=True,
+            spot_tick_age_s=0.25,
+        ),
+    )
+
+    assert sig.metadata["trigger_conditions_met"] is True
+    assert sig.metadata["trigger_block_reason"] == ""
+    assert sig.metadata["direction_context_ok"] is True
+    assert sig.metadata["direction_context_live_proof"] is True
+
+
+def test_no_bias_with_stale_spot_and_futures_proof_still_blocks(monkeypatch, strat):
+    monkeypatch.setenv("EXECUTION_MODE", "LIVE")
+    sig = _eval(
+        strat,
+        "NFO:NIFTY26MAY24000CE",
+        _ind(
+            "",
+            "UP",
+            buy=400,
+            sell=80,
+            spot_fresh=False,
+            fut_fresh=False,
+            spot_tick_age_s=30.0,
+            futures_tick_age_s=30.0,
+        ),
+    )
+
+    assert sig.metadata["trigger_conditions_met"] is False
+    assert sig.metadata["trigger_block_reason"] == "direction_context_missing_live"

--- a/tests/strategies/test_runtime_context_contract.py
+++ b/tests/strategies/test_runtime_context_contract.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 from nifty_scalper_bot.strategies.indicators import IndicatorEngine
-from nifty_scalper_bot.strategies.runtime_context_contract import normalise_live_direction_context
+from nifty_scalper_bot.strategies.runtime_context_contract import (
+    live_direction_context_has_proof,
+    normalise_live_direction_context,
+)
 
 
 def test_runtime_context_preserves_live_direction_contract_keys() -> None:
@@ -24,6 +27,7 @@ def test_runtime_context_preserves_live_direction_contract_keys() -> None:
     assert indicators["context_age_seconds"] == 0.42
     assert indicators["spot_fresh"] is True
     assert indicators["fut_fresh"] is True
+    assert indicators["live_direction_context_proof"] is True
     assert "ignored_payload_key" not in indicators
 
 
@@ -65,3 +69,35 @@ def test_runtime_context_derives_direction_bias_from_alias() -> None:
     assert preserved["fut_fresh"] is True
     assert preserved["futures_fresh"] is True
     assert preserved["context_age_seconds"] == 1.5
+    assert preserved["live_direction_context_proof"] is True
+
+
+def test_live_direction_context_proof_derives_freshness_from_spot_or_futures_age() -> None:
+    spot = normalise_live_direction_context(
+        {
+            "spot_tick_age_s": 0.25,
+            "context_age_seconds": 0.5,
+        }
+    )
+    futures = normalise_live_direction_context(
+        {
+            "futures_age_seconds": 0.25,
+            "context_age_seconds": 0.5,
+        }
+    )
+    stale = normalise_live_direction_context(
+        {
+            "spot_tick_age_s": 30.0,
+            "futures_age_seconds": 30.0,
+            "context_age_seconds": 30.0,
+        }
+    )
+
+    assert spot["spot_fresh"] is True
+    assert spot["live_direction_context_proof"] is True
+    assert futures["fut_fresh"] is True
+    assert futures["futures_fresh"] is True
+    assert futures["live_direction_context_proof"] is True
+    assert stale["spot_fresh"] is False
+    assert stale["fut_fresh"] is False
+    assert live_direction_context_has_proof(stale) is False


### PR DESCRIPTION
## Summary
- Derive `spot_fresh` / `fut_fresh` from spot/futures age fields in the runtime context contract.
- Add `live_direction_context_has_proof()` so live strategies can distinguish missing direction bias from missing/stale underlying context.
- Add a narrow OrderFlow adapter that upgrades only the specific `direction_context_missing_live` block when fresh live spot/futures proof exists and all other live execution gates already pass.
- Keep the block in place when both spot and futures proof are absent or stale.
- Add regression tests for the context contract and OrderFlow live gate.

## Rationale
Runtime logs previously showed OrderFlow blocked by `direction_context_missing_live` with `spot_fresh=False fut_fresh=False`. The contract now derives those freshness flags from age fields and OrderFlow can proceed only when live context proof is present.

## Testing
- Not run locally in this environment; GitHub source patch only.