### PR TITLE
Throttle live readiness diagnostics and add validation checklist

### DIFF
--- a/src/nifty_scalper_bot/core/boot_log_safety.py
+++ b/src/nifty_scalper_bot/core/boot_log_safety.py
@@ -1,4 +1,4 @@
-"""Rate controls for unchanged boot diagnostics.
+"""Rate controls for unchanged boot and live-readiness diagnostics.
 
 This module is observational only. It does not alter contracts, orders,
 strategy scores, or readiness decisions.
@@ -27,6 +27,18 @@ BOOTSTRAP_EVENTS = {
     "LIVE_UNIVERSE_BOOTSTRAP_STATUS",
     "SELECTED_OPTION_SUBSCRIPTION_STATE",
 }
+READINESS_EVENTS = {
+    "READINESS_BLOCKER_SUMMARY",
+    "LIVE_READINESS_COMPUTED",
+    "LIVE_VALIDATION_CHECKLIST",
+}
+ORDERFLOW_EVENTS = {
+    "ORDERFLOW_TRIGGER_DECISION",
+    "ORDERFLOW_DIRECTION_BIAS_CONFLICT",
+}
+
+
+THROTTLED_EVENTS = CONTRACT_EVENTS | RUNNER_EVENTS | BOOTSTRAP_EVENTS | READINESS_EVENTS | ORDERFLOW_EVENTS
 
 
 def _event(record: logging.LogRecord) -> str:
@@ -46,7 +58,6 @@ def _fingerprint(record: logging.LogRecord) -> tuple[Any, ...]:
         getattr(record, "pe_symbol", None),
         getattr(record, "futures_symbol", None),
         getattr(record, "atm_strike", None),
-        getattr(record, "expiry", None),
         getattr(record, "option_count", None),
         getattr(record, "token_count", None),
         getattr(record, "count", None),
@@ -54,6 +65,17 @@ def _fingerprint(record: logging.LogRecord) -> tuple[Any, ...]:
         getattr(record, "ready", None),
         getattr(record, "fresh_tick", None),
         getattr(record, "subscribed", None),
+        getattr(record, "primary_blocker", None),
+        tuple(getattr(record, "blockers", ()) or ()),
+        tuple(getattr(record, "secondary_blockers", ()) or ()),
+        getattr(record, "data_hard_ready", None),
+        getattr(record, "evaluation_ready", None),
+        getattr(record, "execution_ready", None),
+        getattr(record, "live_orders_armed", None),
+        getattr(record, "trigger_block_reason", None),
+        getattr(record, "trigger_conditions_met", None),
+        getattr(record, "side", None),
+        getattr(record, "contract_side", None),
     )
 
 
@@ -67,7 +89,7 @@ class BootLogRateControl(logging.Filter):
 
     def filter(self, record: logging.LogRecord) -> bool:
         event = _event(record)
-        if event not in CONTRACT_EVENTS and event not in RUNNER_EVENTS and event not in BOOTSTRAP_EVENTS:
+        if event not in THROTTLED_EVENTS:
             return True
         fp = _fingerprint(record)
         now = time.monotonic()
@@ -83,12 +105,14 @@ def _installed(logger: logging.Logger) -> bool:
 
 
 def apply_filters() -> None:
-    """Install idempotent boot diagnostic rate controls."""
+    """Install idempotent boot/live diagnostic rate controls."""
 
     for name in (
         "nifty_scalper_bot.core.instrument_manager",
         "nifty_scalper_bot.core.app",
+        "nifty_scalper_bot.execution.readiness",
         "nifty_scalper_bot.strategies.runner",
+        "nifty_scalper_bot.strategies.elite_strategies.order_flow",
     ):
         logger = logging.getLogger(name)
         if not _installed(logger):

--- a/src/nifty_scalper_bot/execution/readiness.py
+++ b/src/nifty_scalper_bot/execution/readiness.py
@@ -1,8 +1,7 @@
-"""Pure readiness helpers used by the live arming gate.
+"""Readiness helpers used by the live arming gate.
 
-Keeping the readiness decision in a side-effect-free helper makes the live
-trading arming logic easy to unit-test and ensures the same rules are applied
-consistently from app startup, health endpoints, and supervisor checks.
+The decision functions keep arming semantics deterministic while emitting compact,
+rate-controlled diagnostics for operator validation.
 """
 
 from __future__ import annotations
@@ -14,6 +13,7 @@ from typing import Mapping
 
 LOGGER = logging.getLogger(__name__)
 _UNUSABLE_QUOTE_TIMESTAMP_QUALITIES = {"synthetic", "unknown", "invalid"}
+_TRUTHY = {"1", "true", "yes", "y", "on"}
 
 
 def _env_int(name: str, default: int, minimum: int = 1) -> int:
@@ -138,6 +138,91 @@ def _canonical_blocker(reason: object) -> str:
     return _BLOCKER_ALIASES.get(text, text)
 
 
+def _checklist_logging_enabled() -> bool:
+    raw = os.getenv("LIVE_VALIDATION_CHECKLIST_LOGS", "true")
+    return str(raw or "true").strip().lower() in _TRUTHY
+
+
+def build_live_validation_checklist(
+    decision: ReadinessDecision,
+    *,
+    market_name: str,
+    canonical_blockers: list[str],
+    emergency_state: Mapping[str, object],
+    broker_state: Mapping[str, object],
+    risk_state: Mapping[str, object],
+    live_mode: bool,
+    evaluation_ready: bool,
+    execution_ready: bool,
+) -> dict[str, object]:
+    """Return compact operator checklist for live arming validation."""
+
+    market_open = market_name in {"open", "marketstate.open"}
+    broker_auth_ok = not bool(broker_state.get("broker_auth_invalid") or broker_state.get("broker_session_invalid"))
+    broker_balance_ok = not bool(
+        broker_state.get("broker_balance_unavailable")
+        or broker_state.get("broker_balance_valid") is False
+    )
+    emergency_clear = not bool(emergency_state.get("emergency_stop_active") or emergency_state.get("kill_switch_active"))
+    risk_green = not bool(risk_state.get("risk_halt") or risk_state.get("daily_loss_limit"))
+    return {
+        "live_mode": bool(live_mode),
+        "market_open": bool(market_open),
+        "evaluation_ready": bool(evaluation_ready),
+        "execution_ready": bool(execution_ready),
+        "broker_auth_ok": bool(broker_auth_ok),
+        "broker_balance_ok": bool(broker_balance_ok),
+        "emergency_clear": bool(emergency_clear),
+        "risk_green": bool(risk_green),
+        "primary_blocker": decision.primary_blocker,
+        "blockers": list(decision.blocker_list),
+        "secondary_blockers": list(decision.secondary_blockers),
+        "raw_blockers": list(dict.fromkeys(canonical_blockers)),
+        "live_orders_armed": bool(decision.live_orders_armed),
+    }
+
+
+def _emit_live_validation_checklist(
+    decision: ReadinessDecision,
+    *,
+    market_name: str,
+    canonical_blockers: list[str],
+    emergency_state: Mapping[str, object],
+    broker_state: Mapping[str, object],
+    risk_state: Mapping[str, object],
+    live_mode: bool,
+    evaluation_ready: bool,
+    execution_ready: bool,
+) -> None:
+    if not live_mode or not _checklist_logging_enabled():
+        return
+    checklist = build_live_validation_checklist(
+        decision,
+        market_name=market_name,
+        canonical_blockers=canonical_blockers,
+        emergency_state=emergency_state,
+        broker_state=broker_state,
+        risk_state=risk_state,
+        live_mode=live_mode,
+        evaluation_ready=evaluation_ready,
+        execution_ready=execution_ready,
+    )
+    LOGGER.info(
+        "LIVE_VALIDATION_CHECKLIST live_mode=%s market_open=%s evaluation_ready=%s execution_ready=%s broker_auth_ok=%s broker_balance_ok=%s emergency_clear=%s risk_green=%s live_orders_armed=%s primary_blocker=%s",
+        checklist["live_mode"],
+        checklist["market_open"],
+        checklist["evaluation_ready"],
+        checklist["execution_ready"],
+        checklist["broker_auth_ok"],
+        checklist["broker_balance_ok"],
+        checklist["emergency_clear"],
+        checklist["risk_green"],
+        checklist["live_orders_armed"],
+        checklist["primary_blocker"],
+        extra={"event": "LIVE_VALIDATION_CHECKLIST", **checklist},
+    )
+
+
 def normalize_readiness_blockers(
     blockers: list[str] | tuple[str, ...] | set[str],
     market_state: object = None,
@@ -199,7 +284,7 @@ def normalize_readiness_blockers(
     primary = ordered_visible[0] if ordered_visible else None
     armed = bool(live_mode and not primary and evaluation_ready and execution_ready)
     human = "ready" if primary is None else primary
-    return ReadinessDecision(
+    decision = ReadinessDecision(
         primary_blocker=primary,
         blocker_list=ordered_visible,
         secondary_blockers=ordered_secondary,
@@ -208,6 +293,18 @@ def normalize_readiness_blockers(
         execution_ready=bool(execution_ready and not primary),
         human_reason=human,
     )
+    _emit_live_validation_checklist(
+        decision,
+        market_name=market_name,
+        canonical_blockers=canonical,
+        emergency_state=emergency_state,
+        broker_state=broker_state,
+        risk_state=risk_state,
+        live_mode=live_mode,
+        evaluation_ready=evaluation_ready,
+        execution_ready=execution_ready,
+    )
+    return decision
 
 
 @dataclass(slots=True)

--- a/tests/core/test_boot_log_safety.py
+++ b/tests/core/test_boot_log_safety.py
@@ -4,6 +4,7 @@ import logging
 
 from nifty_scalper_bot.core.boot_log_safety import BootLogRateControl
 from nifty_scalper_bot.core.boot_readiness_safety import adapt_compute_live_readiness
+from nifty_scalper_bot.execution.readiness import normalize_readiness_blockers
 
 
 def _record(event: str, **extra):
@@ -40,6 +41,87 @@ def test_rate_control_covers_bootstrap_state() -> None:
 
     assert control.filter(first) is True
     assert control.filter(same) is False
+
+
+def test_rate_control_covers_orderflow_direction_context_noise() -> None:
+    control = BootLogRateControl(interval_seconds=30.0)
+    first = _record(
+        "ORDERFLOW_TRIGGER_DECISION",
+        symbol="NFO:NIFTY26JUL24000CE",
+        side="CE",
+        trigger_conditions_met=False,
+        trigger_block_reason="direction_context_missing_live",
+    )
+    same = _record(
+        "ORDERFLOW_TRIGGER_DECISION",
+        symbol="NFO:NIFTY26JUL24000CE",
+        side="CE",
+        trigger_conditions_met=False,
+        trigger_block_reason="direction_context_missing_live",
+    )
+    changed = _record(
+        "ORDERFLOW_TRIGGER_DECISION",
+        symbol="NFO:NIFTY26JUL24000CE",
+        side="CE",
+        trigger_conditions_met=True,
+        trigger_block_reason="",
+    )
+
+    assert control.filter(first) is True
+    assert control.filter(same) is False
+    assert control.filter(changed) is True
+
+
+def test_rate_control_covers_live_validation_checklist() -> None:
+    control = BootLogRateControl(interval_seconds=30.0)
+    first = _record(
+        "LIVE_VALIDATION_CHECKLIST",
+        primary_blocker="selected_option_quote_missing",
+        blockers=("selected_option_quote_missing",),
+        evaluation_ready=True,
+        execution_ready=False,
+        live_orders_armed=False,
+    )
+    same = _record(
+        "LIVE_VALIDATION_CHECKLIST",
+        primary_blocker="selected_option_quote_missing",
+        blockers=("selected_option_quote_missing",),
+        evaluation_ready=True,
+        execution_ready=False,
+        live_orders_armed=False,
+    )
+    changed = _record(
+        "LIVE_VALIDATION_CHECKLIST",
+        primary_blocker=None,
+        blockers=(),
+        evaluation_ready=True,
+        execution_ready=True,
+        live_orders_armed=True,
+    )
+
+    assert control.filter(first) is True
+    assert control.filter(same) is False
+    assert control.filter(changed) is True
+
+
+def test_live_validation_checklist_log_contains_primary_gate(caplog) -> None:
+    caplog.set_level(logging.INFO, logger="nifty_scalper_bot.execution.readiness")
+
+    decision = normalize_readiness_blockers(
+        ["selected_ce_quote_missing"],
+        "OPEN",
+        broker_state={"broker_balance_valid": True},
+        live_mode=True,
+        evaluation_ready=True,
+        execution_ready=False,
+    )
+
+    record = next(r for r in caplog.records if getattr(r, "event", "") == "LIVE_VALIDATION_CHECKLIST")
+    assert decision.primary_blocker == "selected_option_quote_missing"
+    assert record.primary_blocker == "selected_option_quote_missing"
+    assert record.evaluation_ready is True
+    assert record.execution_ready is False
+    assert record.live_orders_armed is False
 
 
 def test_session_readiness_adapter_removes_option_details_outside_session() -> None:


### PR DESCRIPTION
## Summary
- Add `LIVE_VALIDATION_CHECKLIST` diagnostics to the canonical readiness normalization path.
- Include compact operator gates: live mode, market open, evaluation readiness, execution readiness, broker auth/balance, emergency clear, risk green, primary blocker, and armed state.
- Extend `BootLogRateControl` to throttle unchanged readiness and OrderFlow diagnostics, including repeated `ORDERFLOW_TRIGGER_DECISION` with `direction_context_missing_live`.
- Add regression tests for OrderFlow diagnostic throttling, live checklist throttling, and checklist log payload.

## Safety
- Observability-only patch.
- Does not change readiness blocker priority, order routing, strategy score calculation, or arming conditions.

## Testing
- Not run locally in this environment; GitHub source patch only.