### PR TITLE
Harden market timestamp contract and candle forensics

### DIFF
--- a/src/nifty_scalper_bot/data/candle_engine.py
+++ b/src/nifty_scalper_bot/data/candle_engine.py
@@ -8,41 +8,32 @@ import time
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any, Callable, Mapping
-from zoneinfo import ZoneInfo
 
 import pandas as pd
 
 from nifty_scalper_bot.data.source import DataIntegrityError
+from nifty_scalper_bot.data.time_contract import (
+    IST,
+    coerce_market_timestamp,
+    future_delta_seconds,
+    is_future_market_timestamp,
+    normalize_market_tick_timestamp,
+    normalized_symbol,
+)
 from nifty_scalper_bot.data.validator import Tick, validate_tick
 from nifty_scalper_bot.utils.logging import log_throttled
 
 LOGGER = logging.getLogger(__name__)
 FetchHistoricalFn = Callable[[str], pd.DataFrame | None]
 FetchRecentFn = Callable[[str], pd.DataFrame | None]
-IST = ZoneInfo("Asia/Kolkata")
 _OHLC_COLUMNS = ("timestamp", "open", "high", "low", "close", "volume")
 
 
 def _to_ist_timestamp(value: Any) -> pd.Timestamp:
     try:
-        if isinstance(value, (int, float)) and not isinstance(value, bool):
-            raw = float(value)
-            if raw > 1e12:
-                ts = pd.to_datetime(raw, unit="ms", utc=True, errors="coerce")
-            elif raw > 946684800:
-                ts = pd.to_datetime(raw, unit="s", utc=True, errors="coerce")
-            else:
-                ts = pd.NaT
-        else:
-            ts = pd.Timestamp(value)
-    except Exception:
+        return coerce_market_timestamp(value)
+    except ValueError:
         return pd.NaT
-    if pd.isna(ts):
-        return pd.NaT
-    ts = pd.Timestamp(ts)
-    if ts.tzinfo is None:
-        return ts.tz_localize(IST)
-    return ts.tz_convert(IST)
 
 
 def _future_grace_seconds() -> float:
@@ -52,10 +43,11 @@ def _future_grace_seconds() -> float:
         return 120.0
 
 
-def _is_future_timestamp(ts: pd.Timestamp) -> bool:
+def _is_future_timestamp(ts: pd.Timestamp, *, now: pd.Timestamp | None = None) -> bool:
     if pd.isna(ts):
         return False
-    return bool(ts > pd.Timestamp.now(tz=IST) + pd.Timedelta(seconds=_future_grace_seconds()))
+    now_ts = now or pd.Timestamp.now(tz=IST)
+    return is_future_market_timestamp(ts, now=now_ts, grace_seconds=_future_grace_seconds())
 
 
 def _series_to_ist(values: Any) -> pd.Series:
@@ -90,6 +82,24 @@ def sanitize(df: pd.DataFrame | None) -> pd.DataFrame:
     return cleaned[list(_OHLC_COLUMNS)]
 
 
+def _tick_value(tick: Mapping[str, Any] | Tick, key: str, default: Any = None) -> Any:
+    if isinstance(tick, Mapping):
+        return tick.get(key, default)
+    return getattr(tick, key, default)
+
+
+def _tick_symbol(tick: Mapping[str, Any] | Tick, engine_symbol: str | None) -> str:
+    value = _tick_value(tick, "symbol") or _tick_value(tick, "trading_symbol") or engine_symbol
+    return normalized_symbol(value)
+
+
+def _tick_timestamp(tick: Mapping[str, Any] | Tick) -> tuple[pd.Timestamp, str, Any]:
+    if isinstance(tick, Mapping):
+        normalized_ts = normalize_market_tick_timestamp(tick)
+        return normalized_ts.timestamp, normalized_ts.source, normalized_ts.raw_value
+    return coerce_market_timestamp(tick.timestamp), getattr(tick, "timestamp_source", "tick.timestamp"), tick.timestamp
+
+
 @dataclass(slots=True)
 class CandleEngine:
     """Build deterministic 1-minute candles from validated ticks."""
@@ -100,27 +110,76 @@ class CandleEngine:
     current_candle: dict[str, Any] | None = None
     last_candle_close: datetime | None = None
     _last_tick_ts: pd.Timestamp | None = None
+    symbol: str | None = None
 
     def on_tick(self, tick: Mapping[str, Any]) -> dict[str, Any] | None:
         if self.interval != "1min":
             raise ValueError(f"Unsupported interval: {self.interval}")
-        raw_ts = tick.get("timestamp") if isinstance(tick, dict) else getattr(tick, "timestamp", None)
-        timestamp = _to_ist_timestamp(raw_ts)
-        if pd.isna(timestamp) or getattr(timestamp, "year", 1970) < 2020:
-            log_throttled(LOGGER, "candle_tick_bad_timestamp", "CANDLE_TICK_DROPPED reason=bad_timestamp", interval_sec=10.0, level=logging.WARNING)
-            return None
-        if _is_future_timestamp(timestamp):
+        try:
+            symbol = _tick_symbol(tick, self.symbol)
+        except ValueError:
             log_throttled(
                 LOGGER,
-                f"candle_tick_future:{getattr(self, 'symbol', 'unknown')}",
-                "CANDLE_TICK_DROPPED reason=future_timestamp symbol=%s tick_ts=%s" % (getattr(self, "symbol", "unknown"), timestamp.isoformat()),
+                "candle_tick_missing_symbol",
+                "CANDLE_TICK_DROPPED reason=missing_symbol",
+                interval_sec=10.0,
+                level=logging.WARNING,
+                extra={"event": "candle_tick_dropped", "reason": "missing_symbol"},
+            )
+            return None
+        self.symbol = symbol
+        try:
+            timestamp, timestamp_source, raw_ts = _tick_timestamp(tick)
+        except ValueError:
+            log_throttled(
+                LOGGER,
+                f"candle_tick_bad_timestamp:{symbol}",
+                f"CANDLE_TICK_DROPPED reason=bad_timestamp symbol={symbol}",
+                interval_sec=10.0,
+                level=logging.WARNING,
+                extra={"event": "candle_tick_dropped", "symbol": symbol, "reason": "bad_timestamp"},
+            )
+            return None
+        if pd.isna(timestamp) or getattr(timestamp, "year", 1970) < 2020:
+            log_throttled(
+                LOGGER,
+                f"candle_tick_bad_timestamp:{symbol}",
+                f"CANDLE_TICK_DROPPED reason=bad_timestamp symbol={symbol}",
+                interval_sec=10.0,
+                level=logging.WARNING,
+                extra={"event": "candle_tick_dropped", "symbol": symbol, "reason": "bad_timestamp"},
+            )
+            return None
+        now_ist = pd.Timestamp.now(tz=IST)
+        if _is_future_timestamp(timestamp, now=now_ist):
+            future_by_sec = future_delta_seconds(timestamp, now=now_ist)
+            log_throttled(
+                LOGGER,
+                f"candle_tick_future:{symbol}",
+                (
+                    "CANDLE_TICK_DROPPED reason=future_timestamp symbol=%s raw_ts=%r "
+                    "tick_ts_ist=%s now_ist=%s future_by_sec=%.3f timestamp_source=%s"
+                )
+                % (symbol, raw_ts, timestamp.isoformat(), now_ist.isoformat(), future_by_sec, timestamp_source),
                 interval_sec=30.0,
                 level=logging.WARNING,
+                extra={
+                    "event": "candle_tick_dropped",
+                    "reason": "future_timestamp",
+                    "symbol": symbol,
+                    "raw_ts": repr(raw_ts),
+                    "tick_ts_ist": timestamp.isoformat(),
+                    "now_ist": now_ist.isoformat(),
+                    "future_by_sec": float(future_by_sec),
+                    "timestamp_source": timestamp_source,
+                },
             )
             return None
         validated = tick if isinstance(tick, Tick) else validate_tick(dict(tick))
         payload = validated.to_dict()
-        timestamp = _to_ist_timestamp(payload["timestamp"])
+        payload["symbol"] = symbol
+        payload["timestamp"] = timestamp
+        payload["timestamp_source"] = timestamp_source
         minute = timestamp.floor("1min")
 
         if self._last_tick_ts is not None:
@@ -128,8 +187,8 @@ class CandleEngine:
             if not pd.isna(last_ts) and timestamp < last_ts:
                 log_throttled(
                     LOGGER,
-                    f"tick_out_of_order_{getattr(self, 'symbol', 'unknown')}",
-                    "tick_out_of_order symbol=%s tick_ts=%s last_ts=%s" % (getattr(self, "symbol", "unknown"), timestamp.isoformat(), last_ts.isoformat()),
+                    f"tick_out_of_order_{symbol}",
+                    "tick_out_of_order symbol=%s tick_ts=%s last_ts=%s" % (symbol, timestamp.isoformat(), last_ts.isoformat()),
                     interval_sec=10.0,
                     level=logging.DEBUG,
                 )
@@ -138,14 +197,14 @@ class CandleEngine:
         finalized: dict[str, Any] | None = None
         if self.current_candle is None:
             self.current_candle = self._start_candle(payload, minute)
-            LOGGER.debug("candle_created", extra={"event": "candle_created", "minute": minute.isoformat()})
+            LOGGER.debug("candle_created", extra={"event": "candle_created", "symbol": symbol, "minute": minute.isoformat()})
         else:
             current_minute = _to_ist_timestamp(self.current_candle["timestamp"])
             if minute < current_minute:
                 log_throttled(
                     LOGGER,
-                    f"tick_out_of_order_minute_{getattr(self, 'symbol', 'unknown')}",
-                    "tick_out_of_order symbol=%s tick_minute=%s current_minute=%s" % (getattr(self, "symbol", "unknown"), minute.isoformat(), current_minute.isoformat()),
+                    f"tick_out_of_order_minute_{symbol}",
+                    "tick_out_of_order symbol=%s tick_minute=%s current_minute=%s" % (symbol, minute.isoformat(), current_minute.isoformat()),
                     interval_sec=10.0,
                     level=logging.DEBUG,
                 )
@@ -153,7 +212,7 @@ class CandleEngine:
             if minute > current_minute:
                 finalized = self._finalize_current_candle()
                 self.current_candle = self._start_candle(payload, minute)
-                LOGGER.debug("candle_created", extra={"event": "candle_created", "minute": minute.isoformat()})
+                LOGGER.debug("candle_created", extra={"event": "candle_created", "symbol": symbol, "minute": minute.isoformat()})
             else:
                 self._update_candle(payload)
         self._last_tick_ts = timestamp
@@ -180,14 +239,28 @@ class CandleEngine:
         incoming_ts = _to_ist_timestamp(candle.get("timestamp"))
         if pd.isna(incoming_ts):
             raise DataIntegrityError("candle timestamp is invalid")
-        if _is_future_timestamp(incoming_ts):
+        now_ist = pd.Timestamp.now(tz=IST)
+        symbol = self.symbol or "symbol_unset"
+        if _is_future_timestamp(incoming_ts, now=now_ist):
+            future_by_sec = future_delta_seconds(incoming_ts, now=now_ist)
             log_throttled(
                 LOGGER,
-                f"candle_future_{getattr(self, 'symbol', 'unknown')}",
-                "future_candle_rejected symbol=%s incoming_ts=%s source=candle_engine" % (getattr(self, "symbol", "unknown"), incoming_ts.isoformat()),
+                f"candle_future_{symbol}",
+                (
+                    "future_candle_rejected symbol=%s incoming_ts=%s now_ist=%s "
+                    "future_by_sec=%.3f source=candle_engine"
+                )
+                % (symbol, incoming_ts.isoformat(), now_ist.isoformat(), future_by_sec),
                 interval_sec=30.0,
                 level=logging.WARNING,
-                extra={"event": "future_candle_rejected", "symbol": getattr(self, "symbol", "unknown"), "incoming_ts": incoming_ts.isoformat(), "source": "candle_engine"},
+                extra={
+                    "event": "future_candle_rejected",
+                    "symbol": symbol,
+                    "incoming_ts": incoming_ts.isoformat(),
+                    "now_ist": now_ist.isoformat(),
+                    "future_by_sec": float(future_by_sec),
+                    "source": "candle_engine",
+                },
             )
             self.current_candle = None
             return None
@@ -198,11 +271,11 @@ class CandleEngine:
                 if incoming_ts < last_ts:
                     log_throttled(
                         LOGGER,
-                        f"candle_out_of_order_{getattr(self, 'symbol', 'unknown')}",
-                        "candle_out_of_order symbol=%s incoming_ts=%s last_ts=%s source=candle_engine" % (getattr(self, "symbol", "unknown"), incoming_ts.isoformat(), last_ts.isoformat()),
+                        f"candle_out_of_order_{symbol}",
+                        "candle_out_of_order symbol=%s incoming_ts=%s last_ts=%s source=candle_engine" % (symbol, incoming_ts.isoformat(), last_ts.isoformat()),
                         interval_sec=30.0,
                         level=logging.WARNING,
-                        extra={"event": "candle_out_of_order", "symbol": getattr(self, "symbol", "unknown"), "incoming_ts": incoming_ts.isoformat(), "last_ts": last_ts.isoformat(), "source": "candle_engine"},
+                        extra={"event": "candle_out_of_order", "symbol": symbol, "incoming_ts": incoming_ts.isoformat(), "last_ts": last_ts.isoformat(), "source": "candle_engine"},
                     )
                     raise DataIntegrityError("candle timestamps must be monotonic")
                 if incoming_ts == last_ts:
@@ -220,7 +293,7 @@ class CandleEngine:
             raise DataIntegrityError("candle timestamps must be monotonic")
         self.df = frame
         self.last_candle_close = incoming_ts.to_pydatetime()
-        LOGGER.debug("candle_finalized", extra={"event": "candle_finalized", "timestamp": incoming_ts.isoformat()})
+        LOGGER.debug("candle_finalized", extra={"event": "candle_finalized", "symbol": symbol, "timestamp": incoming_ts.isoformat()})
         return candle
 
     def flush(self) -> dict[str, Any] | None:

--- a/src/nifty_scalper_bot/data/pipeline.py
+++ b/src/nifty_scalper_bot/data/pipeline.py
@@ -8,15 +8,21 @@ import threading
 from collections import deque
 from dataclasses import dataclass
 from typing import Any, Dict, Mapping, Optional
-from zoneinfo import ZoneInfo
 
 import pandas as pd
 
 from nifty_scalper_bot.data.source import DataIntegrityError
+from nifty_scalper_bot.data.time_contract import (
+    IST,
+    coerce_market_timestamp,
+    future_delta_seconds,
+    is_future_market_timestamp,
+    normalize_market_tick_timestamp,
+    normalized_symbol,
+)
 from nifty_scalper_bot.utils.logging import log_throttled
 
 LOGGER = logging.getLogger(__name__)
-IST = ZoneInfo("Asia/Kolkata")
 MIN_REQUIRED_CANDLES: int = 50
 
 
@@ -41,24 +47,9 @@ _DROPPED_CANDLES = _Counter()
 
 def _to_ist_timestamp(value: Any) -> pd.Timestamp:
     try:
-        if isinstance(value, (int, float)) and not isinstance(value, bool):
-            raw = float(value)
-            if raw > 1e12:
-                ts = pd.to_datetime(raw, unit="ms", utc=True, errors="coerce")
-            elif raw > 946684800:
-                ts = pd.to_datetime(raw, unit="s", utc=True, errors="coerce")
-            else:
-                ts = pd.NaT
-        else:
-            ts = pd.Timestamp(value)
-    except Exception as exc:  # noqa: BLE001
+        return coerce_market_timestamp(value)
+    except ValueError as exc:
         raise DataIntegrityError(f"unparseable timestamp: {value!r}") from exc
-    if pd.isna(ts):
-        raise DataIntegrityError(f"unparseable timestamp: {value!r}")
-    ts = pd.Timestamp(ts)
-    if ts.tzinfo is None:
-        return ts.tz_localize(IST)
-    return ts.tz_convert(IST)
 
 
 def _future_grace_seconds() -> float:
@@ -77,21 +68,29 @@ def _overlap_seconds() -> float:
 
 def _is_future_timestamp(ts: pd.Timestamp, *, now: pd.Timestamp | None = None) -> bool:
     now_ts = now or pd.Timestamp.now(tz=IST)
-    return bool(ts > now_ts + pd.Timedelta(seconds=_future_grace_seconds()))
+    return is_future_market_timestamp(ts, now=now_ts, grace_seconds=_future_grace_seconds())
 
 
 def _log_future_rejected(symbol: str, ts: pd.Timestamp, source: str) -> None:
     _DROPPED_CANDLES.increment()
+    now_ist = pd.Timestamp.now(tz=IST)
+    future_by_sec = future_delta_seconds(ts, now=now_ist)
     log_throttled(
         LOGGER,
         f"future_candle_rejected:{symbol}:{source}",
-        f"future_candle_rejected symbol={symbol} incoming_ts={ts.isoformat()} source={source}",
+        (
+            "future_candle_rejected symbol=%s incoming_ts=%s now_ist=%s "
+            "future_by_sec=%.3f source=%s"
+        )
+        % (symbol, ts.isoformat(), now_ist.isoformat(), future_by_sec, source),
         interval_sec=30.0,
         level=logging.WARNING,
         extra={
             "event": "future_candle_rejected",
             "symbol": symbol,
             "incoming_ts": ts.isoformat(),
+            "now_ist": now_ist.isoformat(),
+            "future_by_sec": float(future_by_sec),
             "source": source,
             "total_dropped": _DROPPED_CANDLES.value,
         },
@@ -194,6 +193,8 @@ class ValidatedTick:
     timestamp: pd.Timestamp
     ltp: float
     volume: float = 0.0
+    timestamp_source: str = "unknown"
+    raw_timestamp: Any = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -221,25 +222,39 @@ class Candle:
 class TickValidator:
     def validate(self, raw: Mapping[str, Any]) -> Optional[ValidatedTick]:
         try:
-            symbol_raw = raw.get("symbol") or raw.get("trading_symbol")
-            if not symbol_raw or str(symbol_raw).strip() == "":
-                raise DataIntegrityError("missing symbol")
-            ts_raw = raw.get("exchange_timestamp") or raw.get("timestamp") or raw.get("ts")
-            if ts_raw is None:
-                raise DataIntegrityError("missing timestamp")
-            ts = _to_ist_timestamp(ts_raw)
-            if _is_future_timestamp(ts):
+            symbol = normalized_symbol(raw.get("symbol") or raw.get("trading_symbol"))
+            normalized_ts = normalize_market_tick_timestamp(raw)
+            ts = normalized_ts.timestamp
+            now_ist = pd.Timestamp.now(tz=IST)
+            if _is_future_timestamp(ts, now=now_ist):
                 _DROPPED_TICKS.increment()
+                future_by_sec = future_delta_seconds(ts, now=now_ist)
                 log_throttled(
                     LOGGER,
-                    f"future_tick_rejected:{symbol_raw}",
-                    f"future_tick_rejected symbol={symbol_raw} tick_ts={ts.isoformat()}",
+                    f"future_tick_rejected:{symbol}",
+                    (
+                        "future_tick_rejected symbol=%s raw_ts=%r tick_ts_ist=%s now_ist=%s "
+                        "future_by_sec=%.3f timestamp_source=%s"
+                    )
+                    % (
+                        symbol,
+                        normalized_ts.raw_value,
+                        ts.isoformat(),
+                        now_ist.isoformat(),
+                        future_by_sec,
+                        normalized_ts.source,
+                    ),
                     interval_sec=30.0,
                     level=logging.WARNING,
                     extra={
                         "event": "future_tick_rejected",
-                        "symbol": str(symbol_raw).strip().upper(),
+                        "symbol": symbol,
+                        "raw_ts": repr(normalized_ts.raw_value),
                         "tick_ts": ts.isoformat(),
+                        "tick_ts_ist": ts.isoformat(),
+                        "now_ist": now_ist.isoformat(),
+                        "future_by_sec": float(future_by_sec),
+                        "timestamp_source": normalized_ts.source,
                         "source": str(raw.get("source") or "tick_validator"),
                         "total_dropped": _DROPPED_TICKS.value,
                     },
@@ -263,12 +278,25 @@ class TickValidator:
                 volume = float(volume_raw if volume_raw is not None else 0.0)
             except (TypeError, ValueError):
                 volume = 0.0
-            return ValidatedTick(symbol=str(symbol_raw).strip().upper(), timestamp=ts, ltp=ltp, volume=volume)
+            return ValidatedTick(
+                symbol=symbol,
+                timestamp=ts,
+                ltp=ltp,
+                volume=volume,
+                timestamp_source=normalized_ts.source,
+                raw_timestamp=normalized_ts.raw_value,
+            )
         except (DataIntegrityError, ValueError, TypeError) as exc:
             _DROPPED_TICKS.increment()
             LOGGER.error(
                 "tick_rejected",
-                extra={"event": "tick_rejected", "reason": str(exc), "total_dropped": _DROPPED_TICKS.value},
+                extra={
+                    "event": "tick_rejected",
+                    "reason": str(exc),
+                    "symbol": str(raw.get("symbol") or raw.get("trading_symbol") or "").strip().upper() or None,
+                    "timestamp_source": "missing_or_invalid",
+                    "total_dropped": _DROPPED_TICKS.value,
+                },
             )
             return None
 

--- a/src/nifty_scalper_bot/data/time_contract.py
+++ b/src/nifty_scalper_bot/data/time_contract.py
@@ -1,0 +1,126 @@
+"""Canonical market timestamp normalization for NSE/NIFTY data.
+
+Market-data timestamps are normalized to Asia/Kolkata because exchange
+sessions, candle bucketing, and operator diagnostics are NSE-local. Internal
+runtime/lifecycle code may still use UTC; this module is only for market ticks
+and OHLC candles.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+from zoneinfo import ZoneInfo
+
+import pandas as pd
+
+IST = ZoneInfo("Asia/Kolkata")
+UTC_EPOCH_SECONDS_FLOOR = 946684800  # 2000-01-01T00:00:00Z
+
+_EXCHANGE_TIMESTAMP_FIELDS: tuple[str, ...] = (
+    "exchange_timestamp",
+    "last_trade_time",
+    "last_traded_time",
+    "last_trade_timestamp",
+    "exchange_update_time",
+    "last_price_time",
+)
+_BROKER_TIMESTAMP_FIELDS: tuple[str, ...] = ("timestamp", "ts", "date", "datetime")
+_RECEIVED_AT_FIELDS: tuple[str, ...] = ("received_at", "received_ts", "received_time")
+
+
+@dataclass(frozen=True, slots=True)
+class MarketTimestamp:
+    """Normalized market timestamp plus provenance for forensic logging."""
+
+    timestamp: pd.Timestamp
+    source: str
+    raw_value: Any
+
+    @property
+    def isoformat(self) -> str:
+        return self.timestamp.isoformat()
+
+
+def coerce_market_timestamp(value: Any, *, naive_policy: str = "ist") -> pd.Timestamp:
+    """Return an IST-aware timestamp.
+
+    Numeric values are interpreted as UTC epoch seconds/milliseconds. Naive
+    broker/exchange datetimes are interpreted as IST because NSE market feeds
+    commonly send local exchange timestamps without a timezone. Timezone-aware
+    values are converted to IST.
+    """
+
+    try:
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            raw = float(value)
+            if raw > 1e12:
+                ts = pd.to_datetime(raw, unit="ms", utc=True, errors="coerce")
+            elif raw > UTC_EPOCH_SECONDS_FLOOR:
+                ts = pd.to_datetime(raw, unit="s", utc=True, errors="coerce")
+            else:
+                ts = pd.NaT
+        else:
+            ts = pd.Timestamp(value)
+    except Exception as exc:  # noqa: BLE001
+        raise ValueError(f"unparseable timestamp: {value!r}") from exc
+
+    if pd.isna(ts):
+        raise ValueError(f"unparseable timestamp: {value!r}")
+
+    ts = pd.Timestamp(ts)
+    if ts.tzinfo is None:
+        if naive_policy != "ist":
+            raise ValueError(f"naive timestamp rejected: {value!r}")
+        return ts.tz_localize(IST)
+    return ts.tz_convert(IST)
+
+
+def _first_present(payload: Mapping[str, Any], fields: tuple[str, ...]) -> tuple[str, Any] | None:
+    for field in fields:
+        value = payload.get(field)
+        if value is not None and value != "":
+            return field, value
+    return None
+
+
+def normalize_market_tick_timestamp(payload: Mapping[str, Any]) -> MarketTimestamp:
+    """Normalize a live market tick timestamp with explicit source priority.
+
+    Priority is exchange/broker event time first. ``received_at`` is allowed
+    only as an explicit fallback and is labelled as such; this prevents a
+    generated wall-clock timestamp from silently masquerading as exchange time.
+    """
+
+    for fields, label in (
+        (_EXCHANGE_TIMESTAMP_FIELDS, "exchange_timestamp"),
+        (_BROKER_TIMESTAMP_FIELDS, "broker_timestamp"),
+        (_RECEIVED_AT_FIELDS, "received_at_fallback"),
+    ):
+        candidate = _first_present(payload, fields)
+        if candidate is None:
+            continue
+        field, value = candidate
+        return MarketTimestamp(
+            timestamp=coerce_market_timestamp(value),
+            source=field if label != "exchange_timestamp" else field,
+            raw_value=value,
+        )
+    raise ValueError("missing market timestamp")
+
+
+def future_delta_seconds(ts: pd.Timestamp, *, now: pd.Timestamp) -> float:
+    """Positive seconds when ``ts`` is ahead of ``now``; otherwise 0."""
+
+    return max((ts - now).total_seconds(), 0.0)
+
+
+def is_future_market_timestamp(ts: pd.Timestamp, *, now: pd.Timestamp, grace_seconds: float) -> bool:
+    return bool(ts > now + pd.Timedelta(seconds=max(float(grace_seconds), 0.0)))
+
+
+def normalized_symbol(value: Any) -> str:
+    text = str(value or "").strip().upper()
+    if not text:
+        raise ValueError("missing symbol")
+    return text

--- a/src/nifty_scalper_bot/data/validator.py
+++ b/src/nifty_scalper_bot/data/validator.py
@@ -2,16 +2,18 @@
 
 from __future__ import annotations
 
-import datetime as _dt
 from dataclasses import dataclass
 from typing import Any, Mapping
-from zoneinfo import ZoneInfo
 
 import pandas as pd
 
 from nifty_scalper_bot.data.source import DataIntegrityError
-
-IST = ZoneInfo("Asia/Kolkata")
+from nifty_scalper_bot.data.time_contract import (
+    IST,
+    coerce_market_timestamp,
+    normalize_market_tick_timestamp,
+    normalized_symbol,
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -20,6 +22,7 @@ class Tick:
     timestamp: pd.Timestamp
     ltp: float
     volume: float = 0.0
+    timestamp_source: str = "unknown"
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -27,30 +30,28 @@ class Tick:
             "timestamp": self.timestamp,
             "ltp": self.ltp,
             "volume": self.volume,
+            "timestamp_source": self.timestamp_source,
         }
 
 
 def _to_ist(value: Any) -> pd.Timestamp:
     try:
-        ts = pd.Timestamp(value)
-    except Exception as exc:  # noqa: BLE001
+        return coerce_market_timestamp(value)
+    except ValueError as exc:
         raise DataIntegrityError("Invalid timestamp") from exc
-    if pd.isna(ts):
-        raise DataIntegrityError("Invalid timestamp")
-    if ts.tzinfo is None:
-        return ts.tz_localize(IST)
-    return ts.tz_convert(IST)
 
 
 def validate_tick(raw_tick: Mapping[str, Any]) -> Tick:
-    symbol_raw = raw_tick.get("symbol")
-    if symbol_raw is None or str(symbol_raw).strip() == "":
-        raise DataIntegrityError("Missing symbol")
+    try:
+        symbol = normalized_symbol(raw_tick.get("symbol") or raw_tick.get("trading_symbol"))
+    except ValueError as exc:
+        raise DataIntegrityError("Missing symbol") from exc
 
-    timestamp_raw = raw_tick.get("timestamp") or raw_tick.get("exchange_timestamp")
-    if timestamp_raw is None:
-        timestamp_raw = _dt.datetime.now(IST)
-    timestamp = _to_ist(timestamp_raw)
+    try:
+        normalized_ts = normalize_market_tick_timestamp(raw_tick)
+    except ValueError as exc:
+        raise DataIntegrityError("Missing or invalid timestamp") from exc
+    timestamp = normalized_ts.timestamp
 
     ltp_raw = raw_tick.get("ltp") or raw_tick.get("last_price")
     if ltp_raw is None:
@@ -75,8 +76,9 @@ def validate_tick(raw_tick: Mapping[str, Any]) -> Tick:
         volume = 0.0
 
     return Tick(
-        symbol=str(symbol_raw),
+        symbol=symbol,
         timestamp=timestamp,
         ltp=ltp,
         volume=volume,
+        timestamp_source=normalized_ts.source,
     )

--- a/src/nifty_scalper_bot/data/validator.py
+++ b/src/nifty_scalper_bot/data/validator.py
@@ -9,7 +9,6 @@ import pandas as pd
 
 from nifty_scalper_bot.data.source import DataIntegrityError
 from nifty_scalper_bot.data.time_contract import (
-    IST,
     coerce_market_timestamp,
     normalize_market_tick_timestamp,
     normalized_symbol,

--- a/tests/data/test_market_timestamp_contract.py
+++ b/tests/data/test_market_timestamp_contract.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
+
+import pandas as pd
+import pytest
+
+from nifty_scalper_bot.data.candle_engine import CandleEngine
+from nifty_scalper_bot.data.pipeline import MarketDataPipeline, TickValidator
+from nifty_scalper_bot.data.source import DataIntegrityError
+from nifty_scalper_bot.data.time_contract import normalize_market_tick_timestamp
+from nifty_scalper_bot.data.validator import validate_tick
+
+IST = ZoneInfo("Asia/Kolkata")
+
+
+def test_numeric_epoch_ms_converts_utc_to_ist() -> None:
+    raw = int(pd.Timestamp("2026-01-02T09:15:00Z").timestamp() * 1000)
+
+    normalized = normalize_market_tick_timestamp({"symbol": "NFO:TEST", "exchange_timestamp": raw})
+
+    assert normalized.timestamp.isoformat() == "2026-01-02T14:45:00+05:30"
+    assert normalized.source == "exchange_timestamp"
+
+
+def test_naive_broker_timestamp_is_interpreted_as_ist() -> None:
+    normalized = normalize_market_tick_timestamp({"symbol": "NFO:TEST", "timestamp": "2026-01-02 09:15:00"})
+
+    assert normalized.timestamp.isoformat() == "2026-01-02T09:15:00+05:30"
+    assert normalized.source == "timestamp"
+
+
+def test_tick_validator_prefers_exchange_time_over_received_at() -> None:
+    tick = TickValidator().validate(
+        {
+            "symbol": "nfo:test",
+            "exchange_timestamp": "2026-01-02 09:15:00",
+            "received_at": "2026-01-02 09:20:00",
+            "ltp": 100,
+        }
+    )
+
+    assert tick is not None
+    assert tick.symbol == "NFO:TEST"
+    assert tick.timestamp.isoformat() == "2026-01-02T09:15:00+05:30"
+    assert tick.timestamp_source == "exchange_timestamp"
+
+
+def test_validate_tick_rejects_missing_timestamp_instead_of_using_now() -> None:
+    with pytest.raises(DataIntegrityError):
+        validate_tick({"symbol": "NFO:TEST", "ltp": 100})
+
+
+def test_received_at_fallback_is_explicit_not_exchange_time() -> None:
+    tick = TickValidator().validate(
+        {
+            "symbol": "NFO:TEST",
+            "received_at": "2026-01-02T09:15:00Z",
+            "ltp": 100,
+        }
+    )
+
+    assert tick is not None
+    assert tick.timestamp.isoformat() == "2026-01-02T14:45:00+05:30"
+    assert tick.timestamp_source == "received_at"
+
+
+def test_pipeline_rejects_future_received_at_fallback(caplog: pytest.LogCaptureFixture) -> None:
+    pipeline = MarketDataPipeline()
+    future = datetime.now(IST) + timedelta(minutes=10)
+
+    with caplog.at_level(logging.WARNING, logger="nifty_scalper_bot.data.pipeline"):
+        out = pipeline.on_tick({"symbol": "NFO:TEST", "received_at": future, "ltp": 100})
+
+    assert out is None
+    record = next(rec for rec in caplog.records if getattr(rec, "event", "") == "future_tick_rejected")
+    assert record.symbol == "NFO:TEST"
+    assert record.timestamp_source == "received_at"
+    assert record.future_by_sec > 0
+    assert record.now_ist.endswith("+05:30")
+
+
+def test_candle_engine_future_drop_has_forensic_fields(caplog: pytest.LogCaptureFixture) -> None:
+    engine = CandleEngine()
+    future = datetime.now(IST) + timedelta(minutes=10)
+
+    with caplog.at_level(logging.WARNING, logger="nifty_scalper_bot.data.candle_engine"):
+        out = engine.on_tick({"symbol": "NFO:TESTCE", "timestamp": future, "ltp": 100, "volume": 1})
+
+    assert out is None
+    record = next(rec for rec in caplog.records if getattr(rec, "reason", "") == "future_timestamp")
+    assert record.symbol == "NFO:TESTCE"
+    assert record.timestamp_source == "timestamp"
+    assert record.tick_ts_ist.endswith("+05:30")
+    assert record.now_ist.endswith("+05:30")
+    assert record.future_by_sec > 0
+
+
+def test_candle_engine_missing_symbol_is_dropped_not_unknown(caplog: pytest.LogCaptureFixture) -> None:
+    engine = CandleEngine()
+    ts = datetime(2026, 1, 2, 9, 15, tzinfo=timezone.utc)
+
+    with caplog.at_level(logging.WARNING, logger="nifty_scalper_bot.data.candle_engine"):
+        out = engine.on_tick({"timestamp": ts, "ltp": 100, "volume": 1})
+
+    assert out is None
+    record = next(rec for rec in caplog.records if getattr(rec, "reason", "") == "missing_symbol")
+    assert getattr(record, "symbol", None) is None


### PR DESCRIPTION
## Summary
- Add canonical market timestamp contract for NSE/IST handling.
- Stop silent `datetime.now(IST)` fallback when tick timestamps are missing.
- Preserve explicit timestamp provenance (`exchange_timestamp`, broker timestamp, received-at fallback).
- Add symbol-bound candle forensics instead of `symbol=unknown`.
- Keep future timestamp rejection active, with `raw_ts`, `tick_ts_ist`, `now_ist`, `future_by_sec`, and `timestamp_source` fields.
- Apply the same contract to the deterministic market data pipeline.
- Add regression tests for UTC epoch, naive IST, exchange-vs-received priority, missing timestamp rejection, future fallback rejection, and missing-symbol drops.

## Validation target
- `python -m compileall -q src`
- `python -m pytest -q tests/data/test_candle_engine.py`
- `python -m pytest -q tests/data/test_future_candle_guard.py`
- `python -m pytest -q tests/data/test_market_timestamp_contract.py`
- full CI workflows