### PR TITLE
Wire polling fallback age gate into runtime supervisor

### DIFF
--- a/src/nifty_scalper_bot/core/__init__.py
+++ b/src/nifty_scalper_bot/core/__init__.py
@@ -76,6 +76,20 @@ except Exception as exc:  # noqa: BLE001 - fail closed only for real live mode
     if _real_live_mode_requested():
         raise RuntimeError("market_data_hardening_bootstrap_failed") from exc
 
+try:
+    from . import app as _app_module
+    from nifty_scalper_bot.core.polling_failover_runtime import apply_app_patch as _apply_polling_failover_runtime
+
+    _apply_polling_failover_runtime(_app_module)
+except Exception as exc:  # noqa: BLE001 - fail closed only for real live mode
+    get_logger(__name__).error(
+        "POLLING_FAILOVER_RUNTIME_PATCH_FAILED error=%s",
+        exc,
+        extra={"event": "POLLING_FAILOVER_RUNTIME_PATCH_FAILED", "error_type": type(exc).__name__},
+    )
+    if _real_live_mode_requested():
+        raise RuntimeError("polling_failover_runtime_patch_failed") from exc
+
 __all__ = ["NiftyScalperApp", "canonical_price_source"]
 
 _LOGGER = get_logger(__name__)
@@ -102,8 +116,10 @@ def __getattr__(name: str) -> Any:
         try:
             from . import app as _app_module
             from nifty_scalper_bot.core.boot_readiness_safety import apply_app_patch as _ready_adapter
+            from nifty_scalper_bot.core.polling_failover_runtime import apply_app_patch as _polling_adapter
 
             _ready_adapter(_app_module)
+            _polling_adapter(_app_module)
             _App = _app_module.NiftyScalperApp
         except Exception as exc:  # noqa: BLE001
             _LOGGER.error(

--- a/src/nifty_scalper_bot/core/polling_failover_runtime.py
+++ b/src/nifty_scalper_bot/core/polling_failover_runtime.py
@@ -9,12 +9,14 @@ from __future__ import annotations
 
 import inspect
 import logging
+import sys
 import time
 from typing import Any, Mapping
 
 from nifty_scalper_bot.core.polling_failover import decide_polling_fallback
 
 _PATCH_ATTR = "_polling_failover_runtime_patch_installed"
+_APP_MODULE_NAME = "nifty_scalper_bot.core.app"
 LOGGER = logging.getLogger("nifty_scalper_bot.core.app")
 
 
@@ -162,6 +164,14 @@ def _polling_fallback_degraded(
     ).activate
 
 
+def _resolve_market_open_callable(ctx: Any) -> Any:
+    ctx_hook = getattr(ctx, "is_market_open_now", None)
+    if ctx_hook is not None:
+        return ctx_hook
+    app_module = sys.modules.get(_APP_MODULE_NAME)
+    return getattr(app_module, "is_market_open_now", None)
+
+
 async def _polling_failover_supervisor_iteration(
     ctx: Any,
     fallback: Any,
@@ -176,10 +186,7 @@ async def _polling_failover_supervisor_iteration(
     Returns the updated ``(degraded_since, recovered_since)`` state.
     """
 
-    market_open_fn = getattr(ctx, "is_market_open_now", None)
-    if market_open_fn is None:
-        market_open_fn = globals().get("is_market_open_now")
-    _called, market_open = _safe_callable(market_open_fn, name="is_market_open_now", default=False)
+    _called, market_open = _safe_callable(_resolve_market_open_callable(ctx), name="is_market_open_now", default=False)
     if not bool(market_open):
         await _stop_fallback_safely(fallback, reason="market_closed")
         return None, time.monotonic()

--- a/src/nifty_scalper_bot/core/polling_failover_runtime.py
+++ b/src/nifty_scalper_bot/core/polling_failover_runtime.py
@@ -1,0 +1,243 @@
+"""Runtime adapter for polling fallback supervision.
+
+The polling path is a recovery path.  It must not activate only because a broad
+``options_fresh=False`` flag was produced while the selected option quote age is
+well below the configured stale threshold.
+"""
+
+from __future__ import annotations
+
+import inspect
+import logging
+import time
+from typing import Any, Mapping
+
+from nifty_scalper_bot.core.polling_failover import decide_polling_fallback
+
+_PATCH_ATTR = "_polling_failover_runtime_patch_installed"
+LOGGER = logging.getLogger("nifty_scalper_bot.core.app")
+
+
+async def _maybe_await(value: Any) -> Any:
+    if inspect.isawaitable(value):
+        return await value
+    return value
+
+
+def _safe_callable(value: Any, *, name: str, default: Any = None) -> tuple[bool, Any]:
+    if callable(value):
+        try:
+            return True, value()
+        except Exception as exc:  # noqa: BLE001 - supervisor must stay alive
+            LOGGER.warning(
+                "POLLING_SUPERVISOR_CALL_FAILED name=%s error_type=%s error=%s",
+                name,
+                type(exc).__name__,
+                exc,
+                extra={
+                    "event": "POLLING_SUPERVISOR_CALL_FAILED",
+                    "name": name,
+                    "error_type": type(exc).__name__,
+                    "error": str(exc),
+                },
+            )
+            return False, default
+    if value is not None and not isinstance(value, (bool, int, float, str)):
+        LOGGER.warning(
+            "POLLING_SUPERVISOR_NONCALLABLE name=%s value_type=%s",
+            name,
+            type(value).__name__,
+            extra={"event": "POLLING_SUPERVISOR_NONCALLABLE", "name": name, "value_type": type(value).__name__},
+        )
+    return False, value if isinstance(value, bool) else default
+
+
+def _bool(payload: Mapping[str, Any], key: str, default: bool = True) -> bool:
+    value = payload.get(key, default)
+    if isinstance(value, bool):
+        return value
+    return str(value or "").strip().lower() in {"1", "true", "yes", "y", "on"}
+
+
+def _safe_feed_health(mdm: Any) -> Mapping[str, Any]:
+    if mdm is None:
+        return {}
+    getter = getattr(mdm, "trading_feed_health", None)
+    if not callable(getter):
+        return {}
+    try:
+        value = getter()
+    except Exception as exc:  # noqa: BLE001 - fallback decision must not crash WS path
+        LOGGER.warning(
+            "POLLING_FALLBACK_HEALTH_FAILED error_type=%s error=%s",
+            type(exc).__name__,
+            exc,
+            extra={"event": "POLLING_FALLBACK_HEALTH_FAILED", "error_type": type(exc).__name__, "error": str(exc)},
+        )
+        return {}
+    return value if isinstance(value, Mapping) else {}
+
+
+def _safe_data_age_ms(mdm: Any) -> float | None:
+    if mdm is None:
+        return None
+    getter = getattr(mdm, "data_age_ms", None)
+    if not callable(getter):
+        return None
+    try:
+        value = getter()
+        return float(value) if value is not None else None
+    except Exception as exc:  # noqa: BLE001 - fallback decision must not crash WS path
+        LOGGER.warning(
+            "POLLING_FALLBACK_AGE_FAILED error_type=%s error=%s",
+            type(exc).__name__,
+            exc,
+            extra={"event": "POLLING_FALLBACK_AGE_FAILED", "error_type": type(exc).__name__, "error": str(exc)},
+        )
+        return None
+
+
+async def _stop_fallback_safely(fallback: Any, *, reason: str) -> None:
+    try:
+        running_fn = getattr(fallback, "is_running", None)
+        running = bool(running_fn()) if callable(running_fn) else bool(getattr(fallback, "_running", False))
+        mode_fn = getattr(fallback, "set_websocket_mode", None)
+        if callable(mode_fn):
+            await _maybe_await(mode_fn(True))
+        if running:
+            stop_fn = getattr(fallback, "stop", None)
+            if callable(stop_fn):
+                await _maybe_await(stop_fn())
+    except Exception as exc:  # noqa: BLE001 - supervisor must remain non-fatal
+        LOGGER.warning(
+            "POLLING_FALLBACK_STOP_FAILED reason=%s error_type=%s error=%s",
+            reason,
+            type(exc).__name__,
+            exc,
+            extra={"event": "POLLING_FALLBACK_STOP_FAILED", "reason": reason, "error_type": type(exc).__name__, "error": str(exc)},
+        )
+
+
+async def _start_fallback_safely(fallback: Any, *, decision_reason: str | None) -> None:
+    try:
+        mode_fn = getattr(fallback, "set_websocket_mode", None)
+        if callable(mode_fn):
+            await _maybe_await(mode_fn(False))
+        running_fn = getattr(fallback, "is_running", None)
+        running = bool(running_fn()) if callable(running_fn) else bool(getattr(fallback, "_running", False))
+        if not running:
+            start_fn = getattr(fallback, "start", None)
+            if callable(start_fn):
+                await _maybe_await(start_fn())
+    except Exception as exc:  # noqa: BLE001 - never destabilize WS path
+        LOGGER.warning(
+            "POLLING_FALLBACK_START_FAILED reason=%s error_type=%s error=%s",
+            decision_reason,
+            type(exc).__name__,
+            exc,
+            extra={"event": "POLLING_FALLBACK_START_FAILED", "reason": decision_reason, "error_type": type(exc).__name__, "error": str(exc)},
+        )
+
+
+def _polling_fallback_degraded(
+    *,
+    ws_ok: bool,
+    lagging: bool,
+    futures_fresh: bool,
+    options_fresh: bool,
+    quote_stale_ms: float = 120000.0,
+    feed_health: Mapping[str, Any] | None = None,
+    data_age_ms: float | None = None,
+) -> bool:
+    """Runtime boolean wrapper around the age-gated fallback decision."""
+
+    return decide_polling_fallback(
+        ws_ok=ws_ok,
+        lagging=lagging,
+        futures_fresh=futures_fresh,
+        options_fresh=options_fresh,
+        quote_stale_ms=quote_stale_ms,
+        feed_health=feed_health,
+        data_age_ms=data_age_ms,
+    ).activate
+
+
+async def _polling_failover_supervisor_iteration(
+    ctx: Any,
+    fallback: Any,
+    *,
+    quote_stale_ms: float,
+    degraded_since: float | None,
+    recovered_since: float | None,
+    activate_after: float,
+) -> tuple[float | None, float | None]:
+    """One non-fatal polling failover supervisor iteration.
+
+    Returns the updated ``(degraded_since, recovered_since)`` state.
+    """
+
+    market_open_fn = getattr(ctx, "is_market_open_now", None)
+    if market_open_fn is None:
+        market_open_fn = globals().get("is_market_open_now")
+    _called, market_open = _safe_callable(market_open_fn, name="is_market_open_now", default=False)
+    if not bool(market_open):
+        await _stop_fallback_safely(fallback, reason="market_closed")
+        return None, time.monotonic()
+
+    ws_mgr = getattr(ctx, "websocket_manager", None)
+    is_connected = getattr(ws_mgr, "is_connected", None)
+    _called_ws, ws_state = _safe_callable(is_connected, name="websocket_manager.is_connected", default=False)
+    ws_ok = bool(ws_state)
+    mdm = getattr(ctx, "market_data_manager", None)
+    feed_health = _safe_feed_health(mdm)
+    data_age_ms = _safe_data_age_ms(mdm)
+    lagging = bool(feed_health.get("lagging") or feed_health.get("event_loop_lagging") or getattr(ctx, "event_loop_lagging", False))
+    futures_fresh = _bool(feed_health, "futures_fresh", True)
+    options_fresh = _bool(feed_health, "options_fresh", True)
+    decision = decide_polling_fallback(
+        ws_ok=ws_ok,
+        lagging=lagging,
+        futures_fresh=futures_fresh,
+        options_fresh=options_fresh,
+        quote_stale_ms=quote_stale_ms,
+        feed_health=feed_health,
+        data_age_ms=data_age_ms,
+    )
+    LOGGER.info(
+        "POLLING_FALLBACK_DECISION activate=%s reason=%s ws_ok=%s lagging=%s futures_fresh=%s options_fresh=%s max_age_ms=%s threshold_ms=%s",
+        decision.activate,
+        decision.reason,
+        decision.ws_ok,
+        decision.lagging,
+        decision.futures_fresh,
+        decision.options_fresh,
+        decision.max_age_ms,
+        decision.threshold_ms,
+        extra=decision.as_log_extra(),
+    )
+    now = time.monotonic()
+    if not decision.activate:
+        await _stop_fallback_safely(fallback, reason="feed_recovered")
+        return None, recovered_since or now
+    degraded_since = degraded_since or now
+    if now - degraded_since >= max(0.0, float(activate_after or 0.0)):
+        await _start_fallback_safely(fallback, decision_reason=decision.reason)
+    return degraded_since, None
+
+
+def apply_app_patch(app_module: Any) -> bool:
+    """Install runtime polling fallback helpers on ``core.app``."""
+
+    if bool(getattr(app_module, _PATCH_ATTR, False)):
+        return False
+    setattr(app_module, "_polling_fallback_degraded", _polling_fallback_degraded)
+    setattr(app_module, "_polling_failover_supervisor_iteration", _polling_failover_supervisor_iteration)
+    setattr(app_module, _PATCH_ATTR, True)
+    return True
+
+
+__all__ = [
+    "apply_app_patch",
+    "_polling_fallback_degraded",
+    "_polling_failover_supervisor_iteration",
+]

--- a/tests/streaming/test_stream_supervisor_fallback.py
+++ b/tests/streaming/test_stream_supervisor_fallback.py
@@ -17,30 +17,63 @@ def test_spot_stale_only_does_not_activate_poll_fallback() -> None:
             lagging=False,
             futures_fresh=True,
             options_fresh=True,
+            quote_stale_ms=120000,
+            feed_health={"spot_age_ms": 10**9},
+            data_age_ms=10**9,
         )
         is False
     )
 
 
-def test_futures_stale_activates_poll_fallback() -> None:
+def test_futures_stale_requires_age_threshold_when_websocket_healthy() -> None:
     assert (
         _polling_fallback_degraded(
             ws_ok=True,
             lagging=False,
             futures_fresh=False,
             options_fresh=True,
+            quote_stale_ms=120000,
+            feed_health={"futures_age_ms": 70},
+            data_age_ms=70,
+        )
+        is False
+    )
+    assert (
+        _polling_fallback_degraded(
+            ws_ok=True,
+            lagging=False,
+            futures_fresh=False,
+            options_fresh=True,
+            quote_stale_ms=120000,
+            feed_health={"futures_age_ms": 120000},
+            data_age_ms=120000,
         )
         is True
     )
 
 
-def test_options_stale_activates_poll_fallback() -> None:
+def test_options_stale_requires_selected_age_threshold_when_websocket_healthy() -> None:
     assert (
         _polling_fallback_degraded(
             ws_ok=True,
             lagging=False,
             futures_fresh=True,
             options_fresh=False,
+            quote_stale_ms=120000,
+            feed_health={"selected_ce_age_ms": 70, "selected_pe_age_ms": 60},
+            data_age_ms=70,
+        )
+        is False
+    )
+    assert (
+        _polling_fallback_degraded(
+            ws_ok=True,
+            lagging=False,
+            futures_fresh=True,
+            options_fresh=False,
+            quote_stale_ms=120000,
+            feed_health={"selected_ce_age_ms": 120000, "selected_pe_age_ms": 60},
+            data_age_ms=120000,
         )
         is True
     )
@@ -53,6 +86,8 @@ def test_ws_disconnected_activates_poll_fallback() -> None:
             lagging=False,
             futures_fresh=True,
             options_fresh=True,
+            quote_stale_ms=120000,
+            data_age_ms=10,
         )
         is True
     )
@@ -65,6 +100,8 @@ def test_lagging_event_loop_activates_poll_fallback() -> None:
             lagging=True,
             futures_fresh=True,
             options_fresh=True,
+            quote_stale_ms=120000,
+            data_age_ms=10,
         )
         is True
     )
@@ -136,9 +173,10 @@ async def test_stale_futures_activates_polling_fallback(
     monkeypatch.setattr(app, "is_market_open_now", lambda: True)
     ctx = _supervisor_ctx(
         is_connected=lambda: True,
-        data_age_ms=100,
+        data_age_ms=120000,
         feed_health={
             "futures_fresh": False,
+            "futures_age_ms": 120000,
             "options_fresh": True,
             "spot_fresh": True,
             "spot_symbol": "NSE:NIFTY",
@@ -276,3 +314,50 @@ async def test_missing_quote_or_websocket_failure_allows_fallback(monkeypatch: p
     )
 
     fallback.start.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_fallback_health_exception_logs_without_raising(
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(app, "is_market_open_now", lambda: True)
+
+    def bad_health() -> dict[str, object]:
+        raise RuntimeError("health boom")
+
+    ctx = SimpleNamespace(
+        websocket_manager=SimpleNamespace(is_connected=MagicMock(return_value=True)),
+        market_data_manager=SimpleNamespace(
+            trading_feed_health=bad_health,
+            data_age_ms=MagicMock(return_value=70),
+        ),
+    )
+    fallback = _Fallback(running=False)
+
+    with caplog.at_level(logging.WARNING, logger="nifty_scalper_bot.core.app"):
+        await app._polling_failover_supervisor_iteration(
+            ctx, fallback, quote_stale_ms=120000, degraded_since=0.0, recovered_since=None, activate_after=0.0
+        )
+
+    assert "POLLING_FALLBACK_HEALTH_FAILED" in caplog.text
+    fallback.start.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_fallback_start_exception_is_nonfatal(
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(app, "is_market_open_now", lambda: True)
+    ctx = _supervisor_ctx(is_connected=MagicMock(return_value=False), data_age_ms=10)
+    fallback = _Fallback(running=False)
+    fallback.start.side_effect = RuntimeError("start boom")
+
+    with caplog.at_level(logging.WARNING, logger="nifty_scalper_bot.core.app"):
+        await app._polling_failover_supervisor_iteration(
+            ctx, fallback, quote_stale_ms=120000, degraded_since=0.0, recovered_since=None, activate_after=0.0
+        )
+
+    assert "POLLING_FALLBACK_START_FAILED" in caplog.text
+    assert "start boom" in caplog.text


### PR DESCRIPTION
## Summary
- Add a runtime polling failover adapter that installs `_polling_fallback_degraded()` and `_polling_failover_supervisor_iteration()` onto `core.app`.
- Wire the supervisor iteration through `decide_polling_fallback()` so stale option/futures flags require actual selected quote age to cross threshold while WebSocket is healthy.
- Log structured `POLLING_FALLBACK_DECISION` fields including reason, threshold, max age, selected CE/PE age, and futures age.
- Catch feed-health, age, start, and stop exceptions so polling fallback failure does not destabilize the WebSocket path.
- Update stream-supervisor regression tests to assert the production runtime path, including the `options_age_ms=70 threshold_ms=120000` non-activation case.

## Safety
- WebSocket disconnected and event-loop lagging still activate fallback immediately.
- Healthy WebSocket + stale boolean alone no longer activates fallback unless selected option/futures age crosses threshold.
- Start/stop failures are logged as warnings and do not raise out of the supervisor iteration.

## Testing
- Not run locally in this environment; GitHub source patch only.