### PR TITLE
Guard DataHub synthetic timestamps from live readiness

### DIFF
--- a/src/nifty_scalper_bot/data/__init__.py
+++ b/src/nifty_scalper_bot/data/__init__.py
@@ -2,11 +2,14 @@
 
 Hardening note: MarketDataManager hardening is installed explicitly in
 ``market_data_manager.py`` and the IST time adapter in ``source.py`` — at
-their definition sites, failing loudly. This package import has no hidden
-side effects.
+their definition sites. DataHub quote timestamp-quality guarding is installed
+when this package is imported so direct ``data_hub`` imports get the same live
+readiness safety.
 """
 
 from __future__ import annotations
+
+import logging
 
 from nifty_scalper_bot.brokers.instrument_lookup import Instrument
 from nifty_scalper_bot.data.instrument_resolver import InstrumentResolver
@@ -20,6 +23,20 @@ from nifty_scalper_bot.data.instrument_loader import (
     upsert_instruments,
     write_instrument_rows_to_csv,
 )
+
+try:
+    from nifty_scalper_bot.data.data_hub import DataHub as _DataHub
+    from nifty_scalper_bot.data.data_hub_synthetic_guard import (
+        install_datahub_synthetic_timestamp_guard as _install_datahub_synthetic_guard,
+    )
+
+    _install_datahub_synthetic_guard(_DataHub)
+except Exception as exc:  # noqa: BLE001 - data package imports must remain usable
+    logging.getLogger(__name__).error(
+        "DATAHUB_SYNTHETIC_TIMESTAMP_GUARD_FAILED error=%s",
+        exc,
+        extra={"event": "DATAHUB_SYNTHETIC_TIMESTAMP_GUARD_FAILED", "error_type": type(exc).__name__},
+    )
 
 __all__ = [
     "Instrument",

--- a/src/nifty_scalper_bot/data/data_hub_synthetic_guard.py
+++ b/src/nifty_scalper_bot/data/data_hub_synthetic_guard.py
@@ -1,0 +1,169 @@
+"""Synthetic timestamp guard for DataHub quotes.
+
+DataHub is a read facade. It may retain quotes with missing or malformed broker
+timestamps for display and diagnostics, but those quotes must not become hard
+live-readiness proof simply because the facade synthesized ``now()``.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from datetime import datetime, timezone
+from typing import Any, Mapping
+
+import pandas as pd
+
+_PATCH_ATTR = "_synthetic_timestamp_guard_installed"
+_ORIGINALS_ATTR = "_synthetic_timestamp_guard_originals"
+_UNUSABLE_TIMESTAMP_QUALITIES = {"synthetic", "unknown", "invalid"}
+_WS_SOURCES = {"ws", "websocket", "stream"}
+LOGGER = logging.getLogger(__name__)
+
+
+def _valid_timestamp_ms(value: Any) -> float | None:
+    if value is None or value == "":
+        return None
+    try:
+        if isinstance(value, datetime):
+            ts = pd.Timestamp(value)
+        elif isinstance(value, (int, float)):
+            raw = float(value)
+            if raw <= 0:
+                return None
+            seconds = raw / 1000.0 if raw > 1e11 else raw
+            ts = pd.Timestamp(datetime.fromtimestamp(seconds, tz=timezone.utc))
+        else:
+            ts = pd.to_datetime(value, utc=True, errors="coerce")
+        if pd.isna(ts) or getattr(ts, "year", 1970) < 2020:
+            return None
+        return float(pd.Timestamp(ts).timestamp() * 1000.0)
+    except Exception:
+        return None
+
+
+def _timestamp_quality(payload: Mapping[str, Any]) -> str:
+    explicit = str(payload.get("timestamp_quality") or "").strip().lower()
+    if explicit:
+        return explicit
+    if _valid_timestamp_ms(payload.get("exchange_timestamp")) is not None:
+        return "exchange"
+    if _valid_timestamp_ms(payload.get("timestamp")) is not None:
+        return "broker"
+    if _valid_timestamp_ms(payload.get("received_at")) is not None:
+        return "received_at"
+    if any(key in payload for key in ("exchange_timestamp", "timestamp", "received_at")):
+        return "invalid"
+    return "synthetic"
+
+
+def _quote_getter(payload: Mapping[str, Any], key: str, default: Any = None) -> Any:
+    try:
+        return payload.get(key, default)
+    except AttributeError:
+        return default
+
+
+def _quote_timestamp_ms(payload: Mapping[str, Any]) -> float | None:
+    for key in ("timestamp_ms", "exchange_timestamp", "timestamp", "received_at"):
+        value = _quote_getter(payload, key)
+        if key == "timestamp_ms":
+            try:
+                parsed = float(value)
+            except (TypeError, ValueError):
+                parsed = None
+            if parsed is not None and parsed > 0:
+                return parsed if parsed > 1e11 else parsed * 1000.0
+        parsed = _valid_timestamp_ms(value)
+        if parsed is not None:
+            return parsed
+    return None
+
+
+def _tick_price(tick: Mapping[str, Any]) -> float | None:
+    for key in ("ltp", "last_price", "price", "close"):
+        value = tick.get(key)
+        try:
+            if value is not None:
+                parsed = float(value)
+                if parsed > 0:
+                    return parsed
+        except (TypeError, ValueError):
+            continue
+    return None
+
+
+def install_datahub_synthetic_timestamp_guard(datahub_cls: type[Any]) -> bool:
+    """Install DataHub timestamp-quality wrappers once."""
+
+    if bool(getattr(datahub_cls, _PATCH_ATTR, False)):
+        return False
+    originals = {
+        "store_quote": getattr(datahub_cls, "store_quote"),
+        "_canonicalize_tick_payload": getattr(datahub_cls, "_canonicalize_tick_payload"),
+        "get_cached_ltp": getattr(datahub_cls, "get_cached_ltp"),
+    }
+
+    def store_quote(self: Any, symbol: str, quote_data: dict[str, Any], source: str = "ws", seed: bool = False) -> None:
+        payload = dict(quote_data or {})
+        if not any(payload.get(key) not in (None, "") for key in ("exchange_timestamp", "timestamp", "received_at", "timestamp_quality")):
+            payload["timestamp_quality"] = "synthetic"
+            payload["synthetic_timestamp"] = True
+        return originals["store_quote"](self, symbol, payload, source=source, seed=seed)
+
+    def _canonicalize_tick_payload(self: Any, payload: Mapping[str, Any]) -> dict[str, Any] | None:
+        input_payload = dict(payload or {})
+        quality = _timestamp_quality(input_payload)
+        tick = originals["_canonicalize_tick_payload"](self, input_payload)
+        if tick is None:
+            return None
+        tick["timestamp_quality"] = quality
+        if quality in _UNUSABLE_TIMESTAMP_QUALITIES:
+            tick["synthetic_timestamp"] = True
+            tick["hard_readiness_eligible"] = False
+            tick["tradable_quote"] = False
+        else:
+            tick.setdefault("hard_readiness_eligible", True)
+        return tick
+
+    def get_cached_ltp(
+        self: Any,
+        symbol: str,
+        *,
+        max_age_seconds: float | None = None,
+        require_ws: bool = False,
+    ) -> float | None:
+        mdm_cached = getattr(getattr(self, "_mdm", None), "get_cached_ltp", None)
+        if callable(mdm_cached):
+            return mdm_cached(symbol, max_age_seconds=max_age_seconds, require_ws=require_ws)
+        quote = self.get_quote(symbol, allow_pull=False)
+        if not quote:
+            return None
+        quality = str(quote.get("timestamp_quality") or "").strip().lower()
+        guarded = bool(require_ws or max_age_seconds is not None)
+        if guarded and quality in _UNUSABLE_TIMESTAMP_QUALITIES:
+            return None
+        if require_ws and str(quote.get("source") or "").strip().lower() not in _WS_SOURCES:
+            return None
+        if max_age_seconds is not None:
+            ts_ms = _quote_timestamp_ms(quote)
+            if ts_ms is None:
+                return None
+            age_s = max(0.0, time.time() - (ts_ms / 1000.0))
+            if age_s > max(0.0, float(max_age_seconds)):
+                return None
+        return _tick_price(quote)
+
+    setattr(datahub_cls, "store_quote", store_quote)
+    setattr(datahub_cls, "_canonicalize_tick_payload", _canonicalize_tick_payload)
+    setattr(datahub_cls, "get_cached_ltp", get_cached_ltp)
+    setattr(datahub_cls, _ORIGINALS_ATTR, originals)
+    setattr(datahub_cls, _PATCH_ATTR, True)
+    LOGGER.info(
+        "DATAHUB_SYNTHETIC_TIMESTAMP_GUARD_INSTALLED",
+        extra={"event": "DATAHUB_SYNTHETIC_TIMESTAMP_GUARD_INSTALLED"},
+    )
+    return True
+
+
+__all__ = ["install_datahub_synthetic_timestamp_guard"]

--- a/tests/data/test_datahub_synthetic_timestamp_guard.py
+++ b/tests/data/test_datahub_synthetic_timestamp_guard.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import pandas as pd
+
+from nifty_scalper_bot.data.data_hub import DataHub
+from nifty_scalper_bot.execution.readiness import evaluate_quote_readiness
+
+
+class _MdmNoop:
+    def attach_tick_bus(self, _tick_bus) -> None:
+        return None
+
+
+def _quote_payload(**overrides):
+    payload = {
+        "instrument_token": 12345,
+        "ltp": 100.0,
+        "bid": 99.5,
+        "ask": 100.5,
+        "depth_available": True,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_store_quote_without_timestamp_is_tagged_synthetic_and_not_hard_ready() -> None:
+    hub = DataHub(_MdmNoop())
+    symbol = "NFO:NIFTY26JUL24000CE"
+
+    hub.store_quote(symbol, _quote_payload(), source="ws")
+    quote = hub.get_quote(symbol, allow_pull=False)
+    readiness = evaluate_quote_readiness(symbol, quote, require_fresh=True, max_age_s=2.0)
+
+    assert quote is not None
+    assert quote["timestamp_quality"] == "synthetic"
+    assert quote["synthetic_timestamp"] is True
+    assert quote["hard_readiness_eligible"] is False
+    assert quote["tradable_quote"] is False
+    assert readiness.tradable_quote_ready is False
+    assert readiness.reason == "timestamp_quality_unusable"
+    assert hub.get_cached_ltp(symbol, max_age_seconds=2.0) is None
+
+
+def test_invalid_timestamp_is_tagged_invalid_and_rejected_for_guarded_cached_ltp() -> None:
+    hub = DataHub(_MdmNoop())
+    symbol = "NFO:NIFTY26JUL24000PE"
+
+    hub.ingest_tick_sync(_quote_payload(symbol=symbol, timestamp="not-a-date", source="ws"))
+    quote = hub.get_quote(symbol, allow_pull=False)
+
+    assert quote is not None
+    assert quote["timestamp_quality"] == "invalid"
+    assert quote["hard_readiness_eligible"] is False
+    assert hub.get_cached_ltp(symbol, max_age_seconds=2.0) is None
+    assert hub.get_cached_ltp(symbol) == 100.0
+
+
+def test_valid_broker_timestamp_can_satisfy_guarded_cached_ltp() -> None:
+    hub = DataHub(_MdmNoop())
+    symbol = "NSE:NIFTY"
+    now = pd.Timestamp.utcnow().isoformat()
+
+    hub.ingest_tick_sync(_quote_payload(symbol=symbol, timestamp=now, source="ws"))
+    quote = hub.get_quote(symbol, allow_pull=False)
+
+    assert quote is not None
+    assert quote["timestamp_quality"] == "broker"
+    assert quote["hard_readiness_eligible"] is True
+    assert hub.get_cached_ltp(symbol, max_age_seconds=2.0, require_ws=True) == 100.0
+
+
+def test_received_at_quality_preserved_when_it_is_the_only_valid_time_proof() -> None:
+    hub = DataHub(_MdmNoop())
+    symbol = "NSE:NIFTY"
+
+    hub.ingest_tick_sync(_quote_payload(symbol=symbol, received_at=pd.Timestamp.utcnow().timestamp(), source="ws"))
+    quote = hub.get_quote(symbol, allow_pull=False)
+
+    assert quote is not None
+    assert quote["timestamp_quality"] == "received_at"
+    assert quote["hard_readiness_eligible"] is True


### PR DESCRIPTION
## Summary
- Add a DataHub synthetic timestamp guard that tags missing/malformed quote timestamps as `timestamp_quality=synthetic` or `invalid`.
- Keep synthetic quotes visible for UI/diagnostics, but mark them `hard_readiness_eligible=False` and `tradable_quote=False`.
- Guard `DataHub.get_cached_ltp(..., max_age_seconds=...)` / `require_ws=True` so synthetic timestamps cannot satisfy freshness checks.
- Preserve valid broker/exchange/received_at timestamp quality when real time proof exists.
- Add regression tests for missing timestamp, invalid timestamp, valid broker timestamp, and received_at-only timestamp proof.

## Safety
- Does not delete quotes or break display-only use.
- Only guarded/freshness-sensitive paths reject synthetic timestamps.
- Continues to delegate to MarketDataManager `get_cached_ltp()` when available, preserving existing MDM hardening behavior.

## Testing
- Not run locally in this environment; GitHub source patch only.