### PR TITLE
Patch polling failover on direct core app imports

### DIFF
--- a/src/nifty_scalper_bot/core/__init__.py
+++ b/src/nifty_scalper_bot/core/__init__.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
+import importlib.abc
+import importlib.machinery
 import os
+import sys
+from types import ModuleType
 from typing import Any
 
 from nifty_scalper_bot.utils.logging import get_logger
@@ -10,6 +14,8 @@ from nifty_scalper_bot.utils.logging import get_logger
 from nifty_scalper_bot.utils.pricing import canonical_price_source  # compat
 
 _CORE_TRUTHY = {"1", "true", "yes", "y", "on", "live"}
+_APP_MODULE_NAME = "nifty_scalper_bot.core.app"
+_APP_IMPORT_HOOK_ATTR = "_nifty_scalper_core_app_patch_hook"
 
 
 def _core_env_true(name: str) -> bool:
@@ -87,6 +93,56 @@ def _apply_app_runtime_patches(app_module: Any) -> None:
 
     _ready_adapter(app_module)
     _polling_adapter(app_module)
+
+
+class _CoreAppPatchLoader(importlib.abc.Loader):
+    def __init__(self, wrapped: importlib.abc.Loader) -> None:
+        self._wrapped = wrapped
+
+    def create_module(self, spec: importlib.machinery.ModuleSpec) -> ModuleType | None:
+        create = getattr(self._wrapped, "create_module", None)
+        if callable(create):
+            return create(spec)
+        return None
+
+    def exec_module(self, module: ModuleType) -> None:
+        exec_module = getattr(self._wrapped, "exec_module", None)
+        if callable(exec_module):
+            exec_module(module)
+        else:
+            load_module = getattr(self._wrapped, "load_module", None)
+            if callable(load_module):
+                loaded = load_module(module.__name__)  # pragma: no cover - legacy loader path
+                if loaded is not module:
+                    module.__dict__.update(getattr(loaded, "__dict__", {}))
+        _apply_app_runtime_patches(module)
+
+
+class _CoreAppPatchFinder(importlib.abc.MetaPathFinder):
+    def find_spec(
+        self,
+        fullname: str,
+        path: list[str] | None,
+        target: ModuleType | None = None,
+    ) -> importlib.machinery.ModuleSpec | None:
+        if fullname != _APP_MODULE_NAME:
+            return None
+        spec = importlib.machinery.PathFinder.find_spec(fullname, path)
+        if spec is None or spec.loader is None or isinstance(spec.loader, _CoreAppPatchLoader):
+            return spec
+        spec.loader = _CoreAppPatchLoader(spec.loader)
+        return spec
+
+
+def _install_core_app_patch_import_hook() -> None:
+    if any(getattr(finder, _APP_IMPORT_HOOK_ATTR, False) for finder in sys.meta_path):
+        return
+    finder = _CoreAppPatchFinder()
+    setattr(finder, _APP_IMPORT_HOOK_ATTR, True)
+    sys.meta_path.insert(0, finder)
+
+
+_install_core_app_patch_import_hook()
 
 
 def __getattr__(name: str) -> Any:

--- a/tests/core/test_import_safety.py
+++ b/tests/core/test_import_safety.py
@@ -4,13 +4,27 @@ import importlib
 import sys
 
 
+def _reset_core_modules() -> None:
+    for name in list(sys.modules):
+        if name == "nifty_scalper_bot.core" or name.startswith("nifty_scalper_bot.core.app"):
+            sys.modules.pop(name, None)
+
+
 def test_core_package_import_does_not_eagerly_import_app_module() -> None:
-    sys.modules.pop("nifty_scalper_bot.core", None)
-    sys.modules.pop("nifty_scalper_bot.core.app", None)
+    _reset_core_modules()
 
     importlib.import_module("nifty_scalper_bot.core")
 
     assert "nifty_scalper_bot.core.app" not in sys.modules
+
+
+def test_direct_core_app_import_applies_polling_patch_without_lazy_getattr() -> None:
+    _reset_core_modules()
+
+    app_module = importlib.import_module("nifty_scalper_bot.core.app")
+
+    assert getattr(app_module, "_polling_failover_runtime_patch_installed", False) is True
+    assert callable(getattr(app_module, "_polling_failover_supervisor_iteration", None))
 
 
 def test_core_lazy_app_resolution_applies_polling_patch() -> None:


### PR DESCRIPTION
## Summary
- Add a narrow import hook for `nifty_scalper_bot.core.app` so direct imports receive app runtime patches.
- Keep `import nifty_scalper_bot.core` lightweight: the hook does not import `core.app` eagerly.
- Apply polling failover and boot-readiness app patches after the direct app module import finishes.
- Add regression coverage for `importlib.import_module("nifty_scalper_bot.core.app")` patch installation.

## Safety
- Import-hook is scoped only to `nifty_scalper_bot.core.app`.
- Lazy `core.NiftyScalperApp` and `core.__getattr__("app")` paths remain idempotently patched.
- No trading, readiness, order, risk, or market-data decision semantics changed.

## Testing
- Not run locally in this environment; GitHub source patch only.