### PR TITLE
Avoid eager DataHub import while preserving synthetic timestamp guard

### DIFF
--- a/src/nifty_scalper_bot/data/__init__.py
+++ b/src/nifty_scalper_bot/data/__init__.py
@@ -3,13 +3,16 @@
 Hardening note: MarketDataManager hardening is installed explicitly in
 ``market_data_manager.py`` and the IST time adapter in ``source.py`` — at
 their definition sites. DataHub quote timestamp-quality guarding is installed
-when this package is imported so direct ``data_hub`` imports get the same live
-readiness safety.
+by a narrow import hook for ``nifty_scalper_bot.data.data_hub`` so the package
+import does not eagerly load DataHub.
 """
 
 from __future__ import annotations
 
-import logging
+import importlib.abc
+import importlib.machinery
+import sys
+from types import ModuleType
 
 from nifty_scalper_bot.brokers.instrument_lookup import Instrument
 from nifty_scalper_bot.data.instrument_resolver import InstrumentResolver
@@ -24,19 +27,71 @@ from nifty_scalper_bot.data.instrument_loader import (
     write_instrument_rows_to_csv,
 )
 
-try:
-    from nifty_scalper_bot.data.data_hub import DataHub as _DataHub
-    from nifty_scalper_bot.data.data_hub_synthetic_guard import (
-        install_datahub_synthetic_timestamp_guard as _install_datahub_synthetic_guard,
-    )
+_DATAHUB_MODULE_NAME = "nifty_scalper_bot.data.data_hub"
+_DATAHUB_IMPORT_HOOK_ATTR = "_nifty_scalper_datahub_synthetic_guard_hook"
 
-    _install_datahub_synthetic_guard(_DataHub)
-except Exception as exc:  # noqa: BLE001 - data package imports must remain usable
-    logging.getLogger(__name__).error(
-        "DATAHUB_SYNTHETIC_TIMESTAMP_GUARD_FAILED error=%s",
-        exc,
-        extra={"event": "DATAHUB_SYNTHETIC_TIMESTAMP_GUARD_FAILED", "error_type": type(exc).__name__},
-    )
+
+def _install_datahub_guard(module: ModuleType) -> None:
+    datahub_cls = getattr(module, "DataHub", None)
+    if datahub_cls is None:
+        return
+    from nifty_scalper_bot.data.data_hub_synthetic_guard import install_datahub_synthetic_timestamp_guard
+
+    install_datahub_synthetic_timestamp_guard(datahub_cls)
+
+
+class _DataHubGuardLoader(importlib.abc.Loader):
+    def __init__(self, wrapped: importlib.abc.Loader) -> None:
+        self._wrapped = wrapped
+
+    def create_module(self, spec: importlib.machinery.ModuleSpec) -> ModuleType | None:
+        create = getattr(self._wrapped, "create_module", None)
+        if callable(create):
+            return create(spec)
+        return None
+
+    def exec_module(self, module: ModuleType) -> None:
+        exec_module = getattr(self._wrapped, "exec_module", None)
+        if callable(exec_module):
+            exec_module(module)
+        else:
+            load_module = getattr(self._wrapped, "load_module", None)
+            if callable(load_module):
+                loaded = load_module(module.__name__)  # pragma: no cover - legacy loader path
+                if loaded is not module:
+                    module.__dict__.update(getattr(loaded, "__dict__", {}))
+        _install_datahub_guard(module)
+
+
+class _DataHubGuardFinder(importlib.abc.MetaPathFinder):
+    def find_spec(
+        self,
+        fullname: str,
+        path: list[str] | None,
+        target: ModuleType | None = None,
+    ) -> importlib.machinery.ModuleSpec | None:
+        if fullname != _DATAHUB_MODULE_NAME:
+            return None
+        spec = importlib.machinery.PathFinder.find_spec(fullname, path)
+        if spec is None or spec.loader is None or isinstance(spec.loader, _DataHubGuardLoader):
+            return spec
+        spec.loader = _DataHubGuardLoader(spec.loader)
+        return spec
+
+
+def _install_datahub_guard_import_hook() -> None:
+    module = sys.modules.get(_DATAHUB_MODULE_NAME)
+    if isinstance(module, ModuleType):
+        _install_datahub_guard(module)
+        return
+    if any(getattr(finder, _DATAHUB_IMPORT_HOOK_ATTR, False) for finder in sys.meta_path):
+        return
+    finder = _DataHubGuardFinder()
+    setattr(finder, _DATAHUB_IMPORT_HOOK_ATTR, True)
+    sys.meta_path.insert(0, finder)
+
+
+_install_datahub_guard_import_hook()
 
 __all__ = [
     "Instrument",

--- a/tests/data/test_datahub_import_safety.py
+++ b/tests/data/test_datahub_import_safety.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import importlib
+import sys
+
+
+def _reset_data_modules() -> None:
+    for name in list(sys.modules):
+        if name == "nifty_scalper_bot.data" or name.startswith("nifty_scalper_bot.data.data_hub"):
+            sys.modules.pop(name, None)
+
+
+def test_data_package_import_does_not_eagerly_import_datahub() -> None:
+    _reset_data_modules()
+
+    importlib.import_module("nifty_scalper_bot.data")
+
+    assert "nifty_scalper_bot.data.data_hub" not in sys.modules
+
+
+def test_direct_datahub_import_installs_synthetic_timestamp_guard() -> None:
+    _reset_data_modules()
+
+    module = importlib.import_module("nifty_scalper_bot.data.data_hub")
+
+    assert getattr(module.DataHub, "_synthetic_timestamp_guard_installed", False) is True
+
+
+def test_direct_datahub_import_synthetic_quote_is_guarded() -> None:
+    _reset_data_modules()
+    module = importlib.import_module("nifty_scalper_bot.data.data_hub")
+
+    class _MdmNoop:
+        def attach_tick_bus(self, _tick_bus) -> None:
+            return None
+
+    hub = module.DataHub(_MdmNoop())
+    symbol = "NFO:NIFTY26JUL24000CE"
+    hub.store_quote(
+        symbol,
+        {
+            "instrument_token": 12345,
+            "ltp": 100.0,
+            "bid": 99.5,
+            "ask": 100.5,
+            "depth_available": True,
+        },
+        source="ws",
+    )
+    quote = hub.get_quote(symbol, allow_pull=False)
+
+    assert quote is not None
+    assert quote["timestamp_quality"] == "synthetic"
+    assert quote["hard_readiness_eligible"] is False
+    assert hub.get_cached_ltp(symbol, max_age_seconds=2.0) is None


### PR DESCRIPTION
## Summary
- Remove the eager `DataHub` import from `nifty_scalper_bot.data.__init__`.
- Replace package-level guard installation with a scoped import hook for `nifty_scalper_bot.data.data_hub`.
- Direct `data_hub` imports still receive `install_datahub_synthetic_timestamp_guard()` after module load.
- Add regression tests proving `import nifty_scalper_bot.data` does not load `data_hub`, while direct `data_hub` import is guarded.
- Add direct-import synthetic quote regression: missing timestamp remains visible but is rejected by guarded freshness paths.

## Safety
- Import-safety cleanup only.
- DataHub synthetic timestamp semantics from PR #826 are preserved.
- No trading, order, risk, strategy, or market-data decision semantics changed.

## Testing
- Not run locally in this environment; GitHub source patch only.