### PR TITLE
Expose runtime install proof in health status

### DIFF
--- a/src/nifty_scalper_bot/core/runtime_install_proof.py
+++ b/src/nifty_scalper_bot/core/runtime_install_proof.py
@@ -1,0 +1,107 @@
+"""Runtime install-proof snapshot for market-data hardening patches.
+
+This module is observability only. It reports whether the runtime process has the
+expected hardening/adapter hooks installed without mutating trading state.
+"""
+
+from __future__ import annotations
+
+import sys
+from types import ModuleType
+from typing import Any
+
+_CORE_APP_HOOK_ATTR = "_nifty_scalper_core_app_patch_hook"
+_DATAHUB_HOOK_ATTR = "_nifty_scalper_datahub_synthetic_guard_hook"
+
+
+def _hook_count(attr: str) -> int:
+    return sum(1 for finder in sys.meta_path if bool(getattr(finder, attr, False)))
+
+
+def _module(name: str) -> ModuleType | None:
+    value = sys.modules.get(name)
+    return value if isinstance(value, ModuleType) else None
+
+
+def _class_attr(module_name: str, class_name: str, attr: str) -> bool:
+    module = _module(module_name)
+    cls = getattr(module, class_name, None) if module is not None else None
+    return bool(getattr(cls, attr, False))
+
+
+def _module_attr(module_name: str, attr: str) -> bool:
+    module = _module(module_name)
+    return bool(getattr(module, attr, False)) if module is not None else False
+
+
+def build_runtime_install_proof(ctx: Any | None = None) -> dict[str, Any]:
+    """Return compact runtime install-proof status.
+
+    Args:
+        ctx: Optional live bot context. When supplied, instance-level references
+            are inspected in addition to class/module-level patch markers.
+
+    Returns:
+        dict[str, Any]: JSON-safe install proof snapshot.
+    """
+
+    mdm = getattr(ctx, "market_data_manager", None) if ctx is not None else None
+    datahub = getattr(ctx, "data_hub", None) if ctx is not None else None
+    ws_manager = getattr(ctx, "websocket_manager", None) if ctx is not None else None
+    mdm_cls = type(mdm) if mdm is not None else None
+    datahub_cls = type(datahub) if datahub is not None else None
+    ws_cls = type(ws_manager) if ws_manager is not None else None
+    core_hook_count = _hook_count(_CORE_APP_HOOK_ATTR)
+    datahub_hook_count = _hook_count(_DATAHUB_HOOK_ATTR)
+
+    market_data_manager_hardened = bool(
+        getattr(mdm_cls, "_freshness_hardening_installed", False)
+        or _class_attr(
+            "nifty_scalper_bot.data.market_data_manager",
+            "MarketDataManager",
+            "_freshness_hardening_installed",
+        )
+    )
+    websocket_hardened = bool(
+        getattr(ws_cls, "_market_data_hardening_installed", False)
+        or _class_attr(
+            "nifty_scalper_bot.streaming.websocket_manager",
+            "WebSocketManager",
+            "_market_data_hardening_installed",
+        )
+    )
+    datahub_guarded = bool(
+        getattr(datahub_cls, "_synthetic_timestamp_guard_installed", False)
+        or _class_attr(
+            "nifty_scalper_bot.data.data_hub",
+            "DataHub",
+            "_synthetic_timestamp_guard_installed",
+        )
+    )
+    polling_failover_patched = bool(
+        _module_attr("nifty_scalper_bot.core.app", "_polling_failover_runtime_patch_installed")
+    )
+
+    return {
+        "market_data_manager_hardened": market_data_manager_hardened,
+        "websocket_hardened": websocket_hardened,
+        "datahub_synthetic_guard_installed": datahub_guarded,
+        "polling_failover_runtime_patch_installed": polling_failover_patched,
+        "core_app_import_hook_installed": core_hook_count == 1,
+        "datahub_import_hook_installed": datahub_hook_count == 1,
+        "import_hook_counts": {
+            "core_app": core_hook_count,
+            "datahub": datahub_hook_count,
+        },
+        "all_required_installed": bool(
+            market_data_manager_hardened
+            and websocket_hardened
+            and datahub_guarded
+            and polling_failover_patched
+            and core_hook_count == 1
+            and datahub_hook_count == 1
+        ),
+    }
+
+
+__all__ = ["build_runtime_install_proof"]

--- a/src/nifty_scalper_bot/main.py
+++ b/src/nifty_scalper_bot/main.py
@@ -24,6 +24,7 @@ from fastapi.responses import JSONResponse, PlainTextResponse
 
 from nifty_scalper_bot.config.env_utils import normalise_live_env_defaults
 from nifty_scalper_bot.config.paths import get_data_dir
+from nifty_scalper_bot.core.runtime_install_proof import build_runtime_install_proof
 from nifty_scalper_bot.utils.async_helpers import safe_task
 from nifty_scalper_bot.utils.metrics import ensure_multiproc_dir
 
@@ -323,6 +324,7 @@ def livez():
         "bot_loaded": app.state.bot is not None,
         "engine_http_responsive": True,
         "event_loop_lag_ms": round(float(_EVENT_LOOP_LAG_MS), 3),
+        "install_proof": build_runtime_install_proof(_latest_context()),
     }
 
 
@@ -422,6 +424,7 @@ def _structured_runtime_status(ctx):  # noqa: ANN001
         "broker_authentication": auth_state,
         "event_loop_lag_ms": round(float(_EVENT_LOOP_LAG_MS), 3),
         "tick_pressure": tick_pressure,
+        "install_proof": build_runtime_install_proof(ctx),
         "build_sha": STARTUP_BUILD_SHA,
     }
 
@@ -509,6 +512,7 @@ def health_trading():
                 "live_orders_armed": False,
                 "primary_blocker": "startup_incomplete",
                 "blockers": ["startup_incomplete"],
+                "install_proof": build_runtime_install_proof(None),
             },
         )
     decision = getattr(ctx, "readiness_decision", None)
@@ -622,7 +626,7 @@ def trading_status():
     exec_mode = os.getenv("EXECUTION_MODE", "SHADOW")
 
     ctx = _latest_context()
-    structured = _structured_runtime_status(ctx) if ctx is not None else {}
+    structured = _structured_runtime_status(ctx) if ctx is not None else {"install_proof": build_runtime_install_proof(None)}
     return {
         "enable_live": enable_live,
         "execution_mode": exec_mode,

--- a/tests/core/test_runtime_install_proof.py
+++ b/tests/core/test_runtime_install_proof.py
@@ -14,6 +14,10 @@ class _DataHubHook:
     _nifty_scalper_datahub_synthetic_guard_hook = True
 
 
+class _PlainFinder:
+    pass
+
+
 class _Mdm:
     _freshness_hardening_installed = True
 
@@ -27,7 +31,7 @@ class _DataHub:
 
 
 def test_runtime_install_proof_uses_context_instances(monkeypatch) -> None:
-    monkeypatch.setattr(sys, "meta_path", [_CoreHook(), _DataHubHook(), *sys.meta_path])
+    monkeypatch.setattr(sys, "meta_path", [_CoreHook(), _DataHubHook(), _PlainFinder()])
     ctx = SimpleNamespace(
         market_data_manager=_Mdm(),
         websocket_manager=_Ws(),
@@ -45,7 +49,7 @@ def test_runtime_install_proof_uses_context_instances(monkeypatch) -> None:
 
 
 def test_runtime_install_proof_reports_duplicate_import_hooks(monkeypatch) -> None:
-    monkeypatch.setattr(sys, "meta_path", [_CoreHook(), _CoreHook(), _DataHubHook(), *sys.meta_path])
+    monkeypatch.setattr(sys, "meta_path", [_CoreHook(), _CoreHook(), _DataHubHook()])
 
     proof = build_runtime_install_proof(None)
 
@@ -55,7 +59,7 @@ def test_runtime_install_proof_reports_duplicate_import_hooks(monkeypatch) -> No
 
 
 def test_runtime_install_proof_all_required_requires_every_marker(monkeypatch) -> None:
-    monkeypatch.setattr(sys, "meta_path", [_CoreHook(), _DataHubHook(), *sys.meta_path])
+    monkeypatch.setattr(sys, "meta_path", [_CoreHook(), _DataHubHook()])
     partial_ctx = SimpleNamespace(
         market_data_manager=_Mdm(),
         websocket_manager=None,

--- a/tests/core/test_runtime_install_proof.py
+++ b/tests/core/test_runtime_install_proof.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+
+from nifty_scalper_bot.core.runtime_install_proof import build_runtime_install_proof
+
+
+class _CoreHook:
+    _nifty_scalper_core_app_patch_hook = True
+
+
+class _DataHubHook:
+    _nifty_scalper_datahub_synthetic_guard_hook = True
+
+
+class _Mdm:
+    _freshness_hardening_installed = True
+
+
+class _Ws:
+    _market_data_hardening_installed = True
+
+
+class _DataHub:
+    _synthetic_timestamp_guard_installed = True
+
+
+def test_runtime_install_proof_uses_context_instances(monkeypatch) -> None:
+    monkeypatch.setattr(sys, "meta_path", [_CoreHook(), _DataHubHook(), *sys.meta_path])
+    ctx = SimpleNamespace(
+        market_data_manager=_Mdm(),
+        websocket_manager=_Ws(),
+        data_hub=_DataHub(),
+    )
+
+    proof = build_runtime_install_proof(ctx)
+
+    assert proof["market_data_manager_hardened"] is True
+    assert proof["websocket_hardened"] is True
+    assert proof["datahub_synthetic_guard_installed"] is True
+    assert proof["core_app_import_hook_installed"] is True
+    assert proof["datahub_import_hook_installed"] is True
+    assert proof["import_hook_counts"] == {"core_app": 1, "datahub": 1}
+
+
+def test_runtime_install_proof_reports_duplicate_import_hooks(monkeypatch) -> None:
+    monkeypatch.setattr(sys, "meta_path", [_CoreHook(), _CoreHook(), _DataHubHook(), *sys.meta_path])
+
+    proof = build_runtime_install_proof(None)
+
+    assert proof["core_app_import_hook_installed"] is False
+    assert proof["datahub_import_hook_installed"] is True
+    assert proof["import_hook_counts"]["core_app"] == 2
+
+
+def test_runtime_install_proof_all_required_requires_every_marker(monkeypatch) -> None:
+    monkeypatch.setattr(sys, "meta_path", [_CoreHook(), _DataHubHook(), *sys.meta_path])
+    partial_ctx = SimpleNamespace(
+        market_data_manager=_Mdm(),
+        websocket_manager=None,
+        data_hub=_DataHub(),
+    )
+
+    proof = build_runtime_install_proof(partial_ctx)
+
+    assert proof["market_data_manager_hardened"] is True
+    assert proof["websocket_hardened"] is False
+    assert proof["all_required_installed"] is False


### PR DESCRIPTION
## Summary
- Add `build_runtime_install_proof()` to report install status for market-data hardening, WebSocket hardening, DataHub synthetic timestamp guard, polling failover app patch, and scoped import hooks.
- Expose `install_proof` in `/livez`, `/health/trading`, and `/trading/status`.
- Include install proof during startup/incomplete states so the runtime can show which hardening pieces are installed before the bot context is available.
- Add focused tests for context-based proof, duplicate import-hook detection, and missing-marker handling.

## Safety
- Observability-only patch.
- No trading, order routing, risk, strategy, readiness, market-data age, or fallback activation semantics changed.

## Testing
- Not run locally in this environment; GitHub source patch only.