### PR TITLE
Show install proof in admin dashboard

### DIFF
--- a/dashboard/superlite_console.py
+++ b/dashboard/superlite_console.py
@@ -14,6 +14,7 @@ from zoneinfo import ZoneInfo
 import streamlit as st
 
 from dashboard.superlite_events import csv_bytes, deduplicate_events, filter_events, parse_event
+from nifty_scalper_bot.admin_install_proof_display import install_proof_display
 
 IST = ZoneInfo("Asia/Kolkata")
 ADMIN_API = os.getenv("BOT_ADMIN_API_URL", "http://127.0.0.1:8081").rstrip("/")
@@ -122,6 +123,20 @@ def engine_display_status(status: dict) -> str:
     return "ENGINE UP, TRADING BLOCKED"
 
 
+def hook_count_label(proof_display: dict) -> str:
+    counts = proof_display.get("hook_counts") if isinstance(proof_display, dict) else {}
+    if not isinstance(counts, dict) or not counts:
+        return "—"
+    return f"core:{counts.get('core_app', '—')} data:{counts.get('datahub', '—')}"
+
+
+def missing_hardening_label(proof_display: dict) -> str:
+    missing = proof_display.get("missing") if isinstance(proof_display, dict) else []
+    if not missing:
+        return "NONE"
+    return ", ".join(str(item) for item in missing[:3]) + ("…" if len(missing) > 3 else "")
+
+
 def feed_html(rows: list[dict[str, str]]) -> str:
     if not rows:
         return '<div class="feed"><div class="row"><span></span><span></span><span class="muted">No matching actionable events.</span></div></div>'
@@ -184,6 +199,8 @@ def render() -> None:
     recon = status.get("reconciliation") or {}
     selected = status.get("selected") or {}
     memory = status.get("host_memory") or {}
+    proof = status.get("install_proof") or {}
+    proof_status = status.get("install_proof_display") or install_proof_display(proof)
     pnl_total, closed = pnl_summary(rows_all)
     primary = status.get("primary_blocker") or next((b for b in status.get("blockers", []) if b), "—")
     engine_status = engine_display_status(status)
@@ -193,29 +210,38 @@ def render() -> None:
     recon_label = reconciliation_display_label(recon_state, recon)
     mem_pct = memory.get("mem_used_pct")
     mem_css = "bad" if isinstance(mem_pct, (int, float)) and mem_pct >= 90 else "warn" if isinstance(mem_pct, (int, float)) and mem_pct >= 75 else "ok"
+    hardening_css = str(proof_status.get("css") or "warn")
     st.markdown(
         '<div class="cards">'
         + card("Engine", engine_status, "ok" if status.get("operational_ready") else "warn")
         + card("Primary blocker", primary, "warn" if primary != "—" else "ok")
-        + card("Memory", f"{mem_pct if mem_pct is not None else '—'}%", mem_css)
+        + card("Hardening", proof_status.get("label") or "UNKNOWN", hardening_css)
         + card("Broker", broker_label, "ok" if broker_label.startswith("YES") else "warn")
         + card("Reconciled", recon_label, "ok" if recon_label.startswith("YES") else "warn")
+        + '</div><div class="cards">'
+        + card("Hook counts", hook_count_label(proof_status), hardening_css)
+        + card("Missing hardening", missing_hardening_label(proof_status), "ok" if not proof_status.get("missing") else "bad")
+        + card("Memory", f"{mem_pct if mem_pct is not None else '—'}%", mem_css)
+        + card("Error events", sum(row.get("type") == "ERROR" for row in rows), "bad" if any(row.get("type") == "ERROR" for row in rows) else "")
+        + card("Log realised P&L", f"₹{pnl_total:,.2f} · {closed} closed", "ok" if pnl_total >= 0 else "bad")
         + '</div><div class="cards">'
         + card("Visible events", len(rows))
         + card("Trade events", sum(row.get("type") == "TRADE" for row in rows))
         + card("Signal events", sum(row.get("type") == "SIGNAL" for row in rows))
-        + card("Error events", sum(row.get("type") == "ERROR" for row in rows), "bad" if any(row.get("type") == "ERROR" for row in rows) else "")
-        + card("Log realised P&L", f"₹{pnl_total:,.2f} · {closed} closed", "ok" if pnl_total >= 0 else "bad")
+        + card("Running", status.get("running") or "—")
+        + card("Remote", status.get("remote") or "—", "warn" if status.get("stale") else "")
         + '</div><div class="cards">'
         + card("ATM", selected.get("atm") or "—")
         + card("Selected CE", selected.get("ce") or "—")
         + card("Selected PE", selected.get("pe") or "—")
-        + card("Running", status.get("running") or "—")
-        + card("Remote", status.get("remote") or "—", "warn" if status.get("stale") else "")
+        + card("Mode", status.get("mode") or status.get("execution_mode") or "—")
+        + card("Selected source", status.get("selected_source") or "—")
         + "</div>" + feed_html(rows),
         unsafe_allow_html=True,
     )
     st.download_button("Download current filtered events", csv_bytes(rows), file_name=f"niftybot-events-{datetime.now(IST):%Y%m%d-%H%M}.csv", mime="text/csv", width="stretch")
+    with st.expander("Hardening install proof", expanded=False):
+        st.json({"display": proof_status, "install_proof": proof})
     with st.expander("Technical status", expanded=False):
         st.json(status)
 

--- a/src/nifty_scalper_bot/admin_install_proof_display.py
+++ b/src/nifty_scalper_bot/admin_install_proof_display.py
@@ -1,0 +1,49 @@
+"""Display helpers for runtime install-proof status."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+_REQUIRED_FLAGS = (
+    ("market_data_manager_hardened", "MDM"),
+    ("websocket_hardened", "WebSocket"),
+    ("datahub_synthetic_guard_installed", "DataHub synthetic guard"),
+    ("polling_failover_runtime_patch_installed", "Polling failover"),
+    ("core_app_import_hook_installed", "core.app hook"),
+    ("datahub_import_hook_installed", "DataHub hook"),
+)
+
+
+def install_proof_display(proof: Mapping[str, Any] | None) -> dict[str, Any]:
+    """Return a compact UI-ready summary for install proof."""
+
+    if not isinstance(proof, Mapping) or not proof:
+        return {
+            "label": "UNKNOWN",
+            "css": "warn",
+            "all_installed": None,
+            "missing": [],
+            "hook_counts": {},
+        }
+    missing = [label for key, label in _REQUIRED_FLAGS if not bool(proof.get(key))]
+    hook_counts = dict(proof.get("import_hook_counts") or {}) if isinstance(proof.get("import_hook_counts"), Mapping) else {}
+    all_installed = bool(proof.get("all_required_installed")) and not missing
+    if all_installed:
+        label = "ALL HARDENING INSTALLED"
+        css = "ok"
+    elif missing:
+        label = "HARDENING INCOMPLETE"
+        css = "bad"
+    else:
+        label = "CHECK HARDENING"
+        css = "warn"
+    return {
+        "label": label,
+        "css": css,
+        "all_installed": all_installed,
+        "missing": missing,
+        "hook_counts": hook_counts,
+    }
+
+
+__all__ = ["install_proof_display"]

--- a/src/nifty_scalper_bot/superlite_admin.py
+++ b/src/nifty_scalper_bot/superlite_admin.py
@@ -10,10 +10,12 @@ from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse, RedirectResponse
 
 from nifty_scalper_bot import admin_dashboard as dashboard
+from nifty_scalper_bot.admin_install_proof_display import install_proof_display
 from nifty_scalper_bot.ops.service_control import memory_snapshot
 from nifty_scalper_bot.superlite_admin_core import (
     APP_DIR,
     ENGINE_SERVICE,
+    _http_json,
     bounded_logs,
     read_env,
     restart,
@@ -91,6 +93,15 @@ def _logs(
     return bounded_logs(lines, contains)
 
 
+def _engine_install_proof() -> dict:
+    for path in ("/health/trading", "/trading/status", "/livez"):
+        payload = _http_json(path)
+        proof = payload.get("install_proof") if isinstance(payload, dict) else None
+        if isinstance(proof, dict):
+            return dict(proof)
+    return {}
+
+
 # Keep the familiar dashboard and forms, but run them outside the engine and
 # replace blocking helpers with bounded control-plane implementations.
 dashboard._check_auth = _guard
@@ -120,5 +131,9 @@ def healthz() -> dict[str, str]:
 @app.get("/admin/api/status")
 def status() -> JSONResponse:
     data = status_snapshot()
+    proof = data.get("install_proof") if isinstance(data.get("install_proof"), dict) else _engine_install_proof()
+    data["install_proof"] = proof
+    data["install_proof_display"] = install_proof_display(proof)
+    data["hardening_all_installed"] = data["install_proof_display"].get("all_installed")
     data["host_memory"] = memory_snapshot()
     return JSONResponse(data, headers={"Cache-Control": "no-store"})

--- a/tests/dashboard/test_install_proof_display.py
+++ b/tests/dashboard/test_install_proof_display.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from nifty_scalper_bot.admin_install_proof_display import install_proof_display
+
+
+def test_install_proof_display_reports_all_installed() -> None:
+    proof = {
+        "market_data_manager_hardened": True,
+        "websocket_hardened": True,
+        "datahub_synthetic_guard_installed": True,
+        "polling_failover_runtime_patch_installed": True,
+        "core_app_import_hook_installed": True,
+        "datahub_import_hook_installed": True,
+        "all_required_installed": True,
+        "import_hook_counts": {"core_app": 1, "datahub": 1},
+    }
+
+    display = install_proof_display(proof)
+
+    assert display["label"] == "ALL HARDENING INSTALLED"
+    assert display["css"] == "ok"
+    assert display["all_installed"] is True
+    assert display["missing"] == []
+    assert display["hook_counts"] == {"core_app": 1, "datahub": 1}
+
+
+def test_install_proof_display_lists_missing_items() -> None:
+    proof = {
+        "market_data_manager_hardened": True,
+        "websocket_hardened": False,
+        "datahub_synthetic_guard_installed": True,
+        "polling_failover_runtime_patch_installed": False,
+        "core_app_import_hook_installed": True,
+        "datahub_import_hook_installed": False,
+        "all_required_installed": False,
+        "import_hook_counts": {"core_app": 1, "datahub": 2},
+    }
+
+    display = install_proof_display(proof)
+
+    assert display["label"] == "HARDENING INCOMPLETE"
+    assert display["css"] == "bad"
+    assert display["all_installed"] is False
+    assert display["missing"] == ["WebSocket", "Polling failover", "DataHub hook"]
+
+
+def test_install_proof_display_unknown_when_missing() -> None:
+    display = install_proof_display(None)
+
+    assert display["label"] == "UNKNOWN"
+    assert display["css"] == "warn"
+    assert display["all_installed"] is None


### PR DESCRIPTION
## Summary
- Add a small `install_proof_display()` helper that converts raw runtime install proof into UI-ready label/css/missing fields.
- Enrich `/admin/api/status` with `install_proof_display` and `hardening_all_installed`, pulling install proof from engine status endpoints if the cached status snapshot does not already contain it.
- Show hardening state in the Streamlit review console with visible cards for `Hardening`, `Hook counts`, and `Missing hardening`.
- Add a dedicated `Hardening install proof` expander with raw proof JSON.
- Add unit tests for the display helper.

## Safety
- UI/observability-only patch.
- No trading, order routing, risk, strategy, readiness, market-data age, fallback, or broker-auth semantics changed.

## Testing
- Not run locally in this environment; GitHub source patch only.