### PR TITLE
fix: bind broker position sync for reconciliation

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -1851,6 +1851,10 @@ def _hydrate_positions(
     jitter_fraction: float,
     total_timeout_sec: float,
 ) -> list[Mapping[str, object]] | None:
+    set_broker_client = getattr(position_manager, "set_broker_client", None)
+    if callable(set_broker_client):
+        set_broker_client(broker_client)
+
     persisted_positions = persistent_state.load_positions()
     broker_positions: list[Mapping[str, object]] | None
     try:

--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -1975,7 +1975,10 @@ class TradingSessionGuard:
 
     def evaluate(self) -> TradingSessionStatus:
         now = datetime.now(timezone.utc)
-        base_guard = build_session_guard(
+        guard_builder = getattr(
+            import_module(__name__), "build_session_guard", build_session_guard
+        )
+        base_guard = guard_builder(
             now=now,
             override=self._allow_out_of_hours,
             market_open=self._market_open,
@@ -2168,7 +2171,10 @@ class TradingSessionGuard:
         return payload
 
     def _is_market_open(self, now_utc: datetime) -> bool:
-        guard = build_session_guard(
+        guard_builder = getattr(
+            import_module(__name__), "build_session_guard", build_session_guard
+        )
+        guard = guard_builder(
             now=now_utc,
             override=self._allow_out_of_hours,
             market_open=self._market_open,

--- a/src/nifty_scalper_bot/core/polling_failover_runtime.py
+++ b/src/nifty_scalper_bot/core/polling_failover_runtime.py
@@ -17,6 +17,7 @@ from nifty_scalper_bot.core.polling_failover import decide_polling_fallback
 
 _PATCH_ATTR = "_polling_failover_runtime_patch_installed"
 _APP_MODULE_NAME = "nifty_scalper_bot.core.app"
+_APP_MODULE_REF: Any | None = None
 LOGGER = logging.getLogger("nifty_scalper_bot.core.app")
 
 
@@ -38,7 +39,7 @@ def _safe_callable(value: Any, *, name: str, default: Any = None) -> tuple[bool,
                 exc,
                 extra={
                     "event": "POLLING_SUPERVISOR_CALL_FAILED",
-                    "name": name,
+                    "dependency": name,
                     "error_type": type(exc).__name__,
                     "error": str(exc),
                 },
@@ -49,7 +50,11 @@ def _safe_callable(value: Any, *, name: str, default: Any = None) -> tuple[bool,
             "POLLING_SUPERVISOR_NONCALLABLE name=%s value_type=%s",
             name,
             type(value).__name__,
-            extra={"event": "POLLING_SUPERVISOR_NONCALLABLE", "name": name, "value_type": type(value).__name__},
+            extra={
+                "event": "POLLING_SUPERVISOR_NONCALLABLE",
+                "dependency": name,
+                "value_type": type(value).__name__,
+            },
         )
     return False, value if isinstance(value, bool) else default
 
@@ -164,12 +169,12 @@ def _polling_fallback_degraded(
     ).activate
 
 
-def _resolve_market_open_callable(ctx: Any) -> Any:
+def _resolve_market_open_callable(ctx: Any, app_module: Any | None = None) -> Any:
     ctx_hook = getattr(ctx, "is_market_open_now", None)
     if ctx_hook is not None:
         return ctx_hook
-    app_module = sys.modules.get(_APP_MODULE_NAME)
-    return getattr(app_module, "is_market_open_now", None)
+    module = app_module or _APP_MODULE_REF or sys.modules.get(_APP_MODULE_NAME)
+    return getattr(module, "is_market_open_now", None)
 
 
 async def _polling_failover_supervisor_iteration(
@@ -180,25 +185,38 @@ async def _polling_failover_supervisor_iteration(
     degraded_since: float | None,
     recovered_since: float | None,
     activate_after: float,
+    _app_module: Any | None = None,
 ) -> tuple[float | None, float | None]:
     """One non-fatal polling failover supervisor iteration.
 
     Returns the updated ``(degraded_since, recovered_since)`` state.
     """
 
-    _called, market_open = _safe_callable(_resolve_market_open_callable(ctx), name="is_market_open_now", default=False)
+    _called, market_open = _safe_callable(
+        _resolve_market_open_callable(ctx, _app_module),
+        name="is_market_open_now",
+        default=False,
+    )
     if not bool(market_open):
         await _stop_fallback_safely(fallback, reason="market_closed")
         return None, time.monotonic()
 
     ws_mgr = getattr(ctx, "websocket_manager", None)
     is_connected = getattr(ws_mgr, "is_connected", None)
-    _called_ws, ws_state = _safe_callable(is_connected, name="websocket_manager.is_connected", default=False)
+    _called_ws, ws_state = _safe_callable(
+        is_connected,
+        name="websocket_manager.is_connected",
+        default=False,
+    )
     ws_ok = bool(ws_state)
     mdm = getattr(ctx, "market_data_manager", None)
     feed_health = _safe_feed_health(mdm)
     data_age_ms = _safe_data_age_ms(mdm)
-    lagging = bool(feed_health.get("lagging") or feed_health.get("event_loop_lagging") or getattr(ctx, "event_loop_lagging", False))
+    lagging = bool(
+        feed_health.get("lagging")
+        or feed_health.get("event_loop_lagging")
+        or getattr(ctx, "event_loop_lagging", False)
+    )
     futures_fresh = _bool(feed_health, "futures_fresh", True)
     options_fresh = _bool(feed_health, "options_fresh", True)
     decision = decide_polling_fallback(
@@ -235,10 +253,36 @@ async def _polling_failover_supervisor_iteration(
 def apply_app_patch(app_module: Any) -> bool:
     """Install runtime polling fallback helpers on ``core.app``."""
 
+    global _APP_MODULE_REF
+    _APP_MODULE_REF = app_module
     if bool(getattr(app_module, _PATCH_ATTR, False)):
         return False
+
+    async def _installed_polling_failover_supervisor_iteration(
+        ctx: Any,
+        fallback: Any,
+        *,
+        quote_stale_ms: float,
+        degraded_since: float | None,
+        recovered_since: float | None,
+        activate_after: float,
+    ) -> tuple[float | None, float | None]:
+        return await _polling_failover_supervisor_iteration(
+            ctx,
+            fallback,
+            quote_stale_ms=quote_stale_ms,
+            degraded_since=degraded_since,
+            recovered_since=recovered_since,
+            activate_after=activate_after,
+            _app_module=app_module,
+        )
+
     setattr(app_module, "_polling_fallback_degraded", _polling_fallback_degraded)
-    setattr(app_module, "_polling_failover_supervisor_iteration", _polling_failover_supervisor_iteration)
+    setattr(
+        app_module,
+        "_polling_failover_supervisor_iteration",
+        _installed_polling_failover_supervisor_iteration,
+    )
     setattr(app_module, _PATCH_ATTR, True)
     return True
 

--- a/src/nifty_scalper_bot/core/runtime_install_proof.py
+++ b/src/nifty_scalper_bot/core/runtime_install_proof.py
@@ -54,30 +54,32 @@ def build_runtime_install_proof(ctx: Any | None = None) -> dict[str, Any]:
     core_hook_count = _hook_count(_CORE_APP_HOOK_ATTR)
     datahub_hook_count = _hook_count(_DATAHUB_HOOK_ATTR)
 
-    market_data_manager_hardened = bool(
-        getattr(mdm_cls, "_freshness_hardening_installed", False)
-        or _class_attr(
+    if ctx is not None:
+        market_data_manager_hardened = bool(
+            getattr(mdm_cls, "_freshness_hardening_installed", False)
+        )
+        websocket_hardened = bool(
+            getattr(ws_cls, "_market_data_hardening_installed", False)
+        )
+        datahub_guarded = bool(
+            getattr(datahub_cls, "_synthetic_timestamp_guard_installed", False)
+        )
+    else:
+        market_data_manager_hardened = _class_attr(
             "nifty_scalper_bot.data.market_data_manager",
             "MarketDataManager",
             "_freshness_hardening_installed",
         )
-    )
-    websocket_hardened = bool(
-        getattr(ws_cls, "_market_data_hardening_installed", False)
-        or _class_attr(
+        websocket_hardened = _class_attr(
             "nifty_scalper_bot.streaming.websocket_manager",
             "WebSocketManager",
             "_market_data_hardening_installed",
         )
-    )
-    datahub_guarded = bool(
-        getattr(datahub_cls, "_synthetic_timestamp_guard_installed", False)
-        or _class_attr(
+        datahub_guarded = _class_attr(
             "nifty_scalper_bot.data.data_hub",
             "DataHub",
             "_synthetic_timestamp_guard_installed",
         )
-    )
     polling_failover_patched = bool(
         _module_attr("nifty_scalper_bot.core.app", "_polling_failover_runtime_patch_installed")
     )

--- a/src/nifty_scalper_bot/data/__init__.py
+++ b/src/nifty_scalper_bot/data/__init__.py
@@ -9,6 +9,7 @@ import does not eagerly load DataHub.
 
 from __future__ import annotations
 
+import importlib
 import importlib.abc
 import importlib.machinery
 import sys
@@ -92,6 +93,15 @@ def _install_datahub_guard_import_hook() -> None:
 
 
 _install_datahub_guard_import_hook()
+
+
+def __getattr__(name: str) -> ModuleType:
+    if name == "rest":
+        module = importlib.import_module("nifty_scalper_bot.data.rest")
+        setattr(sys.modules[__name__], name, module)
+        return module
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 __all__ = [
     "Instrument",

--- a/src/nifty_scalper_bot/data/pipeline.py
+++ b/src/nifty_scalper_bot/data/pipeline.py
@@ -125,10 +125,11 @@ def _log_candle_store_out_of_order(
         "source": source,
         "reason": "incoming_before_last_store_ts",
         "total_dropped": _DROPPED_CANDLES.value,
+        "bypass_filters": True,
     }
     log_throttled(
         LOGGER,
-        f"candle_store_out_of_order:{symbol}",
+        f"candle_store_out_of_order:{symbol}:{incoming_ts.isoformat()}:{last_ts.isoformat()}",
         (
             "candle_store_out_of_order symbol=%s incoming_ts=%s last_ts=%s "
             "age_delta_s=%.1f incoming_close=%s last_close=%s store_size=%d source=%s"

--- a/src/nifty_scalper_bot/data/robust_provider.py
+++ b/src/nifty_scalper_bot/data/robust_provider.py
@@ -2,20 +2,23 @@
 
 import asyncio
 import logging
+import sys
+from dataclasses import dataclass
 from datetime import datetime, timedelta
 from enum import Enum
 from typing import Any, Callable, TypeVar
-from dataclasses import dataclass
 
 try:
     from tenacity import (
+        before_sleep_log,
         retry,
+        retry_if_exception_type,
         stop_after_attempt,
         wait_exponential,
-        retry_if_exception_type,
-        before_sleep_log,
     )
-except ImportError:  # dependency-free fallback for clean envs
+except Exception:  # dependency-free fallback for clean/partially-initialized envs
+    sys.modules.pop("tenacity", None)
+    sys.modules.pop("tenacity.asyncio", None)
     import asyncio
     import time
 

--- a/src/nifty_scalper_bot/utils/log_throttle.py
+++ b/src/nifty_scalper_bot/utils/log_throttle.py
@@ -177,7 +177,13 @@ class LogThrottle:
             "LOG_THROTTLE_SUMMARY total_suppressed=%s top_keys=%s",
             total_suppressed,
             keys,
-            extra={"event": "LOG_THROTTLE_SUMMARY", "total_suppressed": total_suppressed, "top_keys": keys, "keys_count": len(top)},
+            extra={
+                "event": "LOG_THROTTLE_SUMMARY",
+                "reason": "throttle_summary",
+                "total_suppressed": total_suppressed,
+                "top_keys": keys,
+                "keys_count": len(top),
+            },
         )
 
     def log_on_change(self, logger: logging.Logger, *, key: str, state: Any, message: str, reminder_seconds: float = 600, level: int = logging.INFO, extra: dict[str, Any] | None = None) -> bool:

--- a/tests/core/test_position_hydration.py
+++ b/tests/core/test_position_hydration.py
@@ -53,9 +53,7 @@ class _DataHub:
         self.rows = list(rows)
 
 
-def test_hydrate_positions_prefers_broker_snapshot(
-    monkeypatch,
-) -> None:
+def test_hydrate_positions_prefers_broker_snapshot() -> None:
     persisted = [
         SimpleNamespace(
             symbol="PERSISTED",
@@ -73,12 +71,8 @@ def test_hydrate_positions_prefers_broker_snapshot(
     ]
     manager = _PositionManager()
     data_hub = _DataHub()
-    monkeypatch.setattr(
-        "nifty_scalper_bot.core.app._fetch_positions_with_retry",
-        lambda *args, **kwargs: broker_positions,
-    )
 
-    broker_client = object()
+    broker_client = SimpleNamespace(get_positions=lambda: broker_positions)
 
     result = _hydrate_positions(
         position_manager=manager,

--- a/tests/core/test_position_hydration.py
+++ b/tests/core/test_position_hydration.py
@@ -19,6 +19,10 @@ class _PositionManager:
         self.restored: list[Any] | None = None
         self.synced: list[dict[str, Any]] | None = None
         self._positions: list[Any] = []
+        self.broker_client: Any | None = None
+
+    def set_broker_client(self, broker_client: Any | None) -> None:
+        self.broker_client = broker_client
 
     def restore_positions(self, positions: list[Any]) -> None:
         self.restored = list(positions)
@@ -74,10 +78,12 @@ def test_hydrate_positions_prefers_broker_snapshot(
         lambda *args, **kwargs: broker_positions,
     )
 
+    broker_client = object()
+
     result = _hydrate_positions(
         position_manager=manager,
         persistent_state=_PersistentState(persisted),
-        broker_client=object(),
+        broker_client=broker_client,
         data_hub=data_hub,
         max_attempts=1,
         backoff_min=0.1,
@@ -88,6 +94,7 @@ def test_hydrate_positions_prefers_broker_snapshot(
     )
 
     assert result == broker_positions
+    assert manager.broker_client is broker_client
     assert manager.restored is None
     assert manager.synced == broker_positions
     assert data_hub.rows == [


### PR DESCRIPTION
## Root cause

Uploaded runtime evidence showed broker/internal position reconciliation could not verify unknown orders because `PositionManager` had no broker fetcher bound during startup hydration (`core/app.py::_hydrate_positions`). Full-suite validation also exposed import-hook/runtime patch instability where duplicated module state caused supervisor/session tests to consult stale globals, and logging diagnostics could crash when `extra` used reserved `LogRecord` keys.

## What changed

- `src/nifty_scalper_bot/core/app.py`: bind the broker client into `PositionManager` during `_hydrate_positions`; resolve `build_session_guard` through the live app module so monkeypatched/runtime guards use current state.
- `src/nifty_scalper_bot/data/pipeline.py`: make out-of-order candle rejection logs forensic and bypass filtered throttling without changing candle accept/reject behavior.
- `src/nifty_scalper_bot/core/polling_failover_runtime.py`: install a wrapper tied to the patched app module so off-market fallback stops before reading websocket/feed state; replace reserved logging `extra.name` with `dependency`.
- `src/nifty_scalper_bot/core/runtime_install_proof.py`: when a context is supplied, report hardening from that context's actual runtime instances rather than class-level fallbacks.
- `src/nifty_scalper_bot/data/robust_provider.py`: tolerate partially initialized `tenacity` imports by using the existing dependency-free fallback.
- `src/nifty_scalper_bot/data/__init__.py`: lazily expose the `data.rest` package attribute for stable dotted import/monkeypatch resolution.
- `src/nifty_scalper_bot/utils/log_throttle.py`: add neutral `reason=throttle_summary` metadata to throttle summaries so captured health logs remain schema-stable.
- `tests/core/test_position_hydration.py`: use the real broker `get_positions` seam to validate broker snapshot hydration and broker binding.

## What did not change

- No order placement logic was bypassed.
- No risk checks, SL/TP logic, margin checks, or cooldowns were weakened.
- No contract selection ownership was moved.
- No strategy scoring/profit optimization was changed.
- No `.env` or secret/config keys were modified.

## Validation

Commands run:

- `python -m compileall -q src`
- `python -m pytest -q --disable-warnings --ignore=tests/test_live_mode.py --ignore=tests/test_health_server.py --basetemp .pytest-tmp-full`
- `python -m pytest -q tests\core\test_position_hydration.py tests\core\test_runtime_install_proof.py tests\infra\test_session_guard.py tests\streaming\test_stream_supervisor_fallback.py tests\test_logging_extra_reserved_keys.py tests\websocket\test_ws_adapter.py tests\test_health_check_paper_mode.py tests\test_import_hook_idempotency.py tests\core\test_import_safety.py --basetemp .pytest-tmp-final-focused`
- `git diff --check`

Results:

```text
compileall: passed
focused regression tests: 42 passed
broad pytest gate: passed, 1 skipped
whitespace check: passed
```

Repo-wide required checks still fail on existing baseline debt:

```text
python -m black --check .  -> fails; 478 files would be reformatted
python -m isort --check-only . -> fails; broad existing import-order debt
python -m ruff check . -> fails; 6603 existing lint findings in latest run
python -m mypy src -> fails; 679 existing type findings in latest run
```

## Runtime impact

- Startup: broker client is now bound before broker snapshot hydration/reconciliation.
- Market data: candle rejection behavior unchanged; diagnostics for dropped/out-of-order candles are more reliable.
- Option hydration: no ownership change.
- Strategy evaluation: no scoring change; session guard now resolves current runtime guard state.
- Risk: unchanged.
- Execution: unknown-order verification can use broker positions instead of reporting missing fetcher.
- Telegram diagnostics: unchanged.

## Regression risk

Risk: low-to-medium because `core/app.py`, runtime patching, and logging helpers are high-impact surfaces. Mitigation: focused tests plus broad pytest gate passed; changes are narrow and avoid execution/risk bypasses.