### PR TITLE
fix: preserve candle drop diagnostics

### DIFF
--- a/src/nifty_scalper_bot/data/candle_engine.py
+++ b/src/nifty_scalper_bot/data/candle_engine.py
@@ -118,36 +118,59 @@ class CandleEngine:
         try:
             symbol = _tick_symbol(tick, self.symbol)
         except ValueError:
+            raw_ts_for_key = _tick_value(tick, "timestamp") or _tick_value(
+                tick, "exchange_timestamp"
+            )
             log_throttled(
                 LOGGER,
-                "candle_tick_missing_symbol",
+                f"candle_tick_missing_symbol:{raw_ts_for_key!r}",
                 "CANDLE_TICK_DROPPED reason=missing_symbol",
                 interval_sec=10.0,
                 level=logging.WARNING,
-                extra={"event": "candle_tick_dropped", "reason": "missing_symbol"},
+                extra={
+                    "event": "candle_tick_dropped",
+                    "reason": "missing_symbol",
+                    "raw_ts": repr(raw_ts_for_key),
+                    "bypass_filters": True,
+                },
             )
             return None
         self.symbol = symbol
         try:
             timestamp, timestamp_source, raw_ts = _tick_timestamp(tick)
         except ValueError:
+            raw_ts_for_key = _tick_value(tick, "timestamp") or _tick_value(
+                tick, "exchange_timestamp"
+            )
             log_throttled(
                 LOGGER,
-                f"candle_tick_bad_timestamp:{symbol}",
+                f"candle_tick_bad_timestamp:{symbol}:{raw_ts_for_key!r}",
                 f"CANDLE_TICK_DROPPED reason=bad_timestamp symbol={symbol}",
                 interval_sec=10.0,
                 level=logging.WARNING,
-                extra={"event": "candle_tick_dropped", "symbol": symbol, "reason": "bad_timestamp"},
+                extra={
+                    "event": "candle_tick_dropped",
+                    "symbol": symbol,
+                    "reason": "bad_timestamp",
+                    "raw_ts": repr(raw_ts_for_key),
+                    "bypass_filters": True,
+                },
             )
             return None
         if pd.isna(timestamp) or getattr(timestamp, "year", 1970) < 2020:
             log_throttled(
                 LOGGER,
-                f"candle_tick_bad_timestamp:{symbol}",
+                f"candle_tick_bad_timestamp:{symbol}:{raw_ts!r}",
                 f"CANDLE_TICK_DROPPED reason=bad_timestamp symbol={symbol}",
                 interval_sec=10.0,
                 level=logging.WARNING,
-                extra={"event": "candle_tick_dropped", "symbol": symbol, "reason": "bad_timestamp"},
+                extra={
+                    "event": "candle_tick_dropped",
+                    "symbol": symbol,
+                    "reason": "bad_timestamp",
+                    "raw_ts": repr(raw_ts),
+                    "bypass_filters": True,
+                },
             )
             return None
         now_ist = pd.Timestamp.now(tz=IST)
@@ -155,7 +178,7 @@ class CandleEngine:
             future_by_sec = future_delta_seconds(timestamp, now=now_ist)
             log_throttled(
                 LOGGER,
-                f"candle_tick_future:{symbol}",
+                f"candle_tick_future:{symbol}:{timestamp.isoformat()}",
                 (
                     "CANDLE_TICK_DROPPED reason=future_timestamp symbol=%s raw_ts=%r "
                     "tick_ts_ist=%s now_ist=%s future_by_sec=%.3f timestamp_source=%s"
@@ -172,6 +195,7 @@ class CandleEngine:
                     "now_ist": now_ist.isoformat(),
                     "future_by_sec": float(future_by_sec),
                     "timestamp_source": timestamp_source,
+                    "bypass_filters": True,
                 },
             )
             return None

--- a/src/nifty_scalper_bot/data/pipeline.py
+++ b/src/nifty_scalper_bot/data/pipeline.py
@@ -153,7 +153,10 @@ def _log_candle_store_out_of_order(
 def _log_pipeline_store_rejected(candle: "Candle", exc: DataIntegrityError, *, source: str) -> None:
     log_throttled(
         LOGGER,
-        f"pipeline_candle_store_rejected:{candle.symbol}:{source}",
+        (
+            f"pipeline_candle_store_rejected:{candle.symbol}:"
+            f"{source}:{candle.timestamp.isoformat()}"
+        ),
         (
             "pipeline_candle_store_rejected symbol=%s incoming_ts=%s "
             "error_type=%s reason=%s source=%s"
@@ -176,6 +179,7 @@ def _log_pipeline_store_rejected(candle: "Candle", exc: DataIntegrityError, *, s
             "error_type": type(exc).__name__,
             "reason": str(exc),
             "source": source,
+            "bypass_filters": True,
         },
     )
 
@@ -232,7 +236,7 @@ class TickValidator:
                 future_by_sec = future_delta_seconds(ts, now=now_ist)
                 log_throttled(
                     LOGGER,
-                    f"future_tick_rejected:{symbol}",
+                    f"future_tick_rejected:{symbol}:{ts.isoformat()}",
                     (
                         "future_tick_rejected symbol=%s raw_ts=%r tick_ts_ist=%s now_ist=%s "
                         "future_by_sec=%.3f timestamp_source=%s"
@@ -258,6 +262,7 @@ class TickValidator:
                         "timestamp_source": normalized_ts.source,
                         "source": str(raw.get("source") or "tick_validator"),
                         "total_dropped": _DROPPED_TICKS.value,
+                        "bypass_filters": True,
                     },
                 )
                 return None


### PR DESCRIPTION
## Root cause

Focused timestamp/candle validation exposed that rejection diagnostics for dropped ticks/candles could be throttled away when the same symbol/source had already emitted a similar event. This made live failures such as `CANDLE_TICK_DROPPED reason=future_timestamp` and pipeline store rejections harder to audit, even though the drop decisions themselves were correct.

## What changed

- `src/nifty_scalper_bot/data/pipeline.py`
  - Include the rejected tick/candle timestamp in throttle keys for `future_tick_rejected` and `pipeline_candle_store_rejected`.
  - Mark those rejection diagnostics with `bypass_filters=True`.
- `src/nifty_scalper_bot/data/candle_engine.py`
  - Include raw or normalized timestamp evidence in throttle keys for missing-symbol, bad-timestamp, and future-timestamp candle drops.
  - Add raw timestamp metadata to missing/bad timestamp diagnostics and mark rejection diagnostics with `bypass_filters=True`.

## What did not change

- Tick/candle accept or reject decisions did not change.
- No history ownership change.
- No DataHub state change.
- No strategy, risk, execution, order placement, SL/TP, or broker logic changed.
- No `.env` or configuration keys changed.

## Validation

Commands run:

- `python -m compileall -q src`
- `python -m pytest -q tests\data\test_market_data_pipeline.py tests\data\test_future_candle_guard.py tests\data\test_market_timestamp_contract.py tests\data\test_candle_engine.py --basetemp .pytest-tmp-timestamp`
- `python -m pytest -q tests\data\test_market_data_manager_volume_pipeline.py tests\data\test_volume_zero_preservation.py tests\data\test_option_volume_sanity.py tests\strategies\test_runner_volume_rejects_cumulative.py tests\strategies\test_runner_volume_semantics.py --basetemp .pytest-tmp-volume`
- `python -m pytest -q --disable-warnings --ignore=tests/test_live_mode.py --ignore=tests/test_health_server.py --basetemp .pytest-tmp-full`
- `git diff --check`

Results:

```text
compileall: passed
focused timestamp/candle tests: 29 passed
focused volume tests: 12 passed
broad pytest gate: passed, 1 skipped
whitespace check: passed
```

## Runtime impact

- Startup: unchanged.
- Market data: dropped tick/candle diagnostics are now deterministic and include timestamp evidence.
- Option hydration: unchanged.
- Strategy evaluation: unchanged.
- Risk: unchanged.
- Execution: unchanged.
- Telegram diagnostics: unchanged.

## Regression risk

Low. The change is observability-only around rejection logging keys/metadata. It does not alter candle construction, storage, readiness, strategy, or execution behavior.