### PR TITLE
Settings fail-soft on malformed env; NIFTY spot alias; hardening verify at startup

### DIFF
--- a/src/nifty_scalper_bot/config/settings.py
+++ b/src/nifty_scalper_bot/config/settings.py
@@ -231,16 +231,25 @@ def _env_float(*names: str, default: float, minimum: float | None = None) -> flo
                 continue
             try:
                 value = float(candidate)
-            except ValueError as exc:  # pragma: no cover - defensive
-                raise ConfigurationError(
-                    f"Invalid float for {name!s}: {raw_value!r}"
-                ) from exc
+            except ValueError:
+                # Fail-soft: a typo'd tuning variable must not kill the whole
+                # settings import (a partial module then surfaces as cryptic
+                # AttributeErrors elsewhere and bricks startup - 2026-07-09).
+                LOGGER.error(
+                    "SETTINGS_ENV_INVALID name=%s raw=%r using_default=%r",
+                    name, raw_value, default,
+                    extra={"event": "SETTINGS_ENV_INVALID", "env_name": name},
+                )
+                value = float(default)
             source_name = name
             break
         if minimum is not None and value < minimum:
-            raise ConfigurationError(
-                f"Invalid float for {source_name!s}: {value!r} < minimum {minimum!r}"
+            LOGGER.error(
+                "SETTINGS_ENV_BELOW_MINIMUM name=%s value=%r minimum=%r using_default=%r",
+                source_name, value, minimum, default,
+                extra={"event": "SETTINGS_ENV_INVALID", "env_name": source_name},
             )
+            value = float(default) if float(default) >= minimum else float(minimum)
         LOGGER.debug(
             "Condition met: settings_env_float_resolved",
             extra={
@@ -303,16 +312,24 @@ def _env_int(*names: str, default: int, minimum: int | None = None) -> int:
                 continue
             try:
                 value = int(candidate)
-            except ValueError as exc:  # pragma: no cover - defensive
-                raise ConfigurationError(
-                    f"Invalid integer for {name!s}: {raw_value!r}"
-                ) from exc
+            except ValueError:
+                # Fail-soft (see _env_float): never kill the settings import
+                # over a malformed tuning variable.
+                LOGGER.error(
+                    "SETTINGS_ENV_INVALID name=%s raw=%r using_default=%r",
+                    name, raw_value, default,
+                    extra={"event": "SETTINGS_ENV_INVALID", "env_name": name},
+                )
+                value = int(default)
             source_name = name
             break
         if minimum is not None and value < minimum:
-            raise ConfigurationError(
-                f"Invalid integer for {source_name!s}: {value!r} < minimum {minimum!r}"
+            LOGGER.error(
+                "SETTINGS_ENV_BELOW_MINIMUM name=%s value=%r minimum=%r using_default=%r",
+                source_name, value, minimum, default,
+                extra={"event": "SETTINGS_ENV_INVALID", "env_name": source_name},
             )
+            value = int(default) if int(default) >= minimum else int(minimum)
         LOGGER.debug(
             "Condition met: settings_env_int_resolved",
             extra={

--- a/src/nifty_scalper_bot/core/__init__.py
+++ b/src/nifty_scalper_bot/core/__init__.py
@@ -64,23 +64,10 @@ except Exception as exc:  # noqa: BLE001 - core package import must not crash to
         extra={"event": "BOOT_LOG_RATE_CONTROL_FAILED", "error_type": type(exc).__name__},
     )
 
-try:
-    from nifty_scalper_bot.core.market_data_hardening_bootstrap import (
-        install_market_data_hardening_or_raise as _install_market_data_hardening,
-    )
-
-    _install_market_data_hardening(get_logger(__name__))
-except Exception as exc:  # noqa: BLE001 - fail closed only for real live mode
-    get_logger(__name__).error(
-        "MARKET_DATA_HARDENING_BOOTSTRAP_FAILED error=%s",
-        exc,
-        extra={
-            "event": "MARKET_DATA_HARDENING_BOOTSTRAP_FAILED",
-            "error_type": type(exc).__name__,
-        },
-    )
-    if _real_live_mode_requested():
-        raise RuntimeError("market_data_hardening_bootstrap_failed") from exc
+# Market-data hardening verification moved to initialize_components (app.py):
+# running it at package-import time re-introduced the hidden-hook pattern
+# removed in #792 and could fire during a partially-initialized settings
+# import (circular), silently skipping verification outside live mode.
 
 __all__ = ["NiftyScalperApp", "canonical_price_source"]
 

--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -4481,6 +4481,31 @@ def initialize_components(settings: Settings | None = None) -> BotContext:
 
     ensure_multiproc_dir(clear_stale=True)
     settings = settings or get_settings()
+    # Verify market-data hardening at explicit startup (moved from
+    # core/__init__ import time — see #792 canonical-hooks decision).
+    # Definition sites already install; this confirms and fails closed
+    # for real live mode.
+    try:
+        from nifty_scalper_bot.core.market_data_hardening_bootstrap import (
+            install_market_data_hardening_or_raise,
+        )
+
+        install_market_data_hardening_or_raise(LOGGER)
+    except Exception as _hard_exc:  # noqa: BLE001
+        LOGGER.error(
+            "MARKET_DATA_HARDENING_BOOTSTRAP_FAILED error=%s",
+            _hard_exc,
+            extra={
+                "event": "MARKET_DATA_HARDENING_BOOTSTRAP_FAILED",
+                "error_type": type(_hard_exc).__name__,
+            },
+        )
+        from nifty_scalper_bot.core import _real_live_mode_requested
+
+        if _real_live_mode_requested():
+            raise RuntimeError(
+                "market_data_hardening_bootstrap_failed"
+            ) from _hard_exc
     fingerprint = _build_startup_fingerprint()
     LOGGER.info(
         "startup_fingerprint version=%s release=%s",

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -9454,9 +9454,22 @@ class MarketDataManager:
             # which defaulted to NSE, so all NFO instruments silently returned None.
             _suffix = clean_symbol.upper()
             _exchange = "NFO" if any(_suffix.endswith(s) for s in ("FUT", "CE", "PE")) else "NSE"
+            # Zerodha's instrument dump lists index spot instruments under
+            # their full names ("NIFTY 50", "NIFTY BANK"), not the short
+            # aliases used across the bot ("NIFTY") — root cause of the
+            # 2026-07-09 SPOT_TOKEN_RESOLUTION_FAILED for NSE:NIFTY.
+            _aliases = {clean_symbol, _suffix}
+            _index_alias = {
+                "NIFTY": "NIFTY 50",
+                "NIFTY50": "NIFTY 50",
+                "BANKNIFTY": "NIFTY BANK",
+                "FINNIFTY": "NIFTY FIN SERVICE",
+            }.get(_suffix)
+            if _index_alias:
+                _aliases.add(_index_alias)
             instruments = self._broker.instruments(_exchange)
             for ins in instruments:
-                if ins["tradingsymbol"] == clean_symbol:
+                if ins["tradingsymbol"] in _aliases:
                     t = int(ins["instrument_token"])
                     self.register_symbol(symbol, t) # Cache it
                     return t

--- a/tests/data/test_zerodha_balance_logging.py
+++ b/tests/data/test_zerodha_balance_logging.py
@@ -196,3 +196,51 @@ def test_auth_latch_reprobes_and_self_heals_on_success() -> None:
     client._reset_transient_state()  # success path
     assert client._auth_invalid is False
     client._raise_if_authentication_latched()  # gate open again
+
+
+def test_settings_import_survives_malformed_env(monkeypatch) -> None:
+    """2026-07-09 incident: a malformed tuning env var killed the settings
+    module mid-import; the partial module then surfaced as cryptic
+    AttributeErrors (USE_REGIME_ADAPTIVE, REGIME_TREND_SIZING_MULT) and the
+    bot entered degraded mode. Tunables must fail soft to their defaults."""
+    import importlib
+
+    monkeypatch.setenv("REGIME_TREND_SIZING_MULT", "not-a-number")
+    monkeypatch.setenv("MAX_LOTS_PER_TRADE", "banana")
+    monkeypatch.setenv("MIN_LOTS_PER_TRADE", "0")  # below minimum -> clamp
+    import nifty_scalper_bot.config.settings as settings_module
+
+    reloaded = importlib.reload(settings_module)
+    try:
+        assert reloaded.REGIME_TREND_SIZING_MULT == 1.15
+        assert reloaded.MAX_LOTS_PER_TRADE == 2
+        assert reloaded.MIN_LOTS_PER_TRADE == 1
+        assert reloaded.USE_REGIME_ADAPTIVE is True
+    finally:
+        monkeypatch.delenv("REGIME_TREND_SIZING_MULT")
+        monkeypatch.delenv("MAX_LOTS_PER_TRADE")
+        monkeypatch.delenv("MIN_LOTS_PER_TRADE")
+        importlib.reload(settings_module)
+
+
+def test_spot_index_token_resolves_via_zerodha_full_name() -> None:
+    """NSE:NIFTY must resolve although Zerodha lists the index as 'NIFTY 50'."""
+    import logging as _logging
+
+    from nifty_scalper_bot.data.market_data_manager import MarketDataManager
+
+    mdm = MarketDataManager.__new__(MarketDataManager)
+    mdm._logger = _logging.getLogger("test")
+    mdm._token_by_symbol = {}
+    mdm._canonical_symbol = lambda s: s
+    registered: dict = {}
+    mdm.register_symbol = lambda s, t: registered.__setitem__(s, t)
+
+    class _Broker:
+        def instruments(self, exchange):
+            assert exchange == "NSE"
+            return [{"tradingsymbol": "NIFTY 50", "instrument_token": 256265}]
+
+    mdm._broker = _Broker()
+    assert mdm._resolve_token("NSE:NIFTY") == 256265
+    assert registered["NSE:NIFTY"] == 256265


### PR DESCRIPTION
Log-driven (2026-07-09): (1) settings module died mid-import on a malformed tuning env var -> partial module -> cryptic AttributeErrors (USE_REGIME_ADAPTIVE / REGIME_TREND_SIZING_MULT) -> degraded mode. Tunable env parsers now fail soft with loud SETTINGS_ENV_INVALID errors naming the variable and applying the default (min-clamped). (2) NSE:NIFTY spot token: Zerodha lists the index as 'NIFTY 50'; resolver fallback now matches known index aliases (verified -> 256265). (3) core/__init__ ran the hardening bootstrap at import time (hidden hook, circular-import hazard vs partial settings, silent skip outside live) - moved into initialize_components with identical fail-closed live semantics.

2 regression tests in existing file. Full suite green, compileall clean, no loss of function.