### PR TITLE
Fix polling-failover supervisor signature drift; restore anti-flap cooldown

### DIFF
--- a/src/nifty_scalper_bot/core/polling_failover_runtime.py
+++ b/src/nifty_scalper_bot/core/polling_failover_runtime.py
@@ -185,6 +185,7 @@ async def _polling_failover_supervisor_iteration(
     degraded_since: float | None,
     recovered_since: float | None,
     activate_after: float,
+    recover_cooldown: float = 10.0,
     _app_module: Any | None = None,
 ) -> tuple[float | None, float | None]:
     """One non-fatal polling failover supervisor iteration.
@@ -242,8 +243,14 @@ async def _polling_failover_supervisor_iteration(
     )
     now = time.monotonic()
     if not decision.activate:
-        await _stop_fallback_safely(fallback, reason="feed_recovered")
-        return None, recovered_since or now
+        # Anti-flap hysteresis (mirrors core.app:_polling_failover_supervisor_
+        # iteration): only stop the fallback after recover_cooldown seconds of
+        # continuous recovery, so a briefly healthy feed cannot bounce the
+        # REST poller on/off.
+        recovered_since = recovered_since or now
+        if now - recovered_since >= max(0.0, float(recover_cooldown or 0.0)):
+            await _stop_fallback_safely(fallback, reason="feed_recovered")
+        return None, recovered_since
     degraded_since = degraded_since or now
     if now - degraded_since >= max(0.0, float(activate_after or 0.0)):
         await _start_fallback_safely(fallback, decision_reason=decision.reason)
@@ -266,6 +273,7 @@ def apply_app_patch(app_module: Any) -> bool:
         degraded_since: float | None,
         recovered_since: float | None,
         activate_after: float,
+        recover_cooldown: float = 10.0,
     ) -> tuple[float | None, float | None]:
         return await _polling_failover_supervisor_iteration(
             ctx,
@@ -274,6 +282,7 @@ def apply_app_patch(app_module: Any) -> bool:
             degraded_since=degraded_since,
             recovered_since=recovered_since,
             activate_after=activate_after,
+            recover_cooldown=recover_cooldown,
             _app_module=app_module,
         )
 

--- a/tests/core/test_import_safety.py
+++ b/tests/core/test_import_safety.py
@@ -42,3 +42,45 @@ def test_nifty_scalper_app_lazy_resolution_applies_app_patches() -> None:
 
     assert app_cls is getattr(app_module, "NiftyScalperApp")
     assert getattr(app_module, "_polling_failover_runtime_patch_installed", False) is True
+
+
+def test_installed_polling_failover_iteration_accepts_recover_cooldown() -> None:
+    """2026-07-09 incident: the runtime patch replaced core.app's supervisor
+    iteration with a wrapper that rejected recover_cooldown, so every
+    supervisor loop iteration raised TypeError (213x in one session) and the
+    WS->REST polling failover safety net was dead. The installed wrapper must
+    accept the exact call shape used by core.app's supervisor loop and honor
+    the anti-flap recover cooldown."""
+    import asyncio
+    import types
+
+    from nifty_scalper_bot.core import polling_failover_runtime as pfr
+
+    app_module = types.SimpleNamespace()
+    pfr.apply_app_patch(app_module)
+    installed = app_module._polling_failover_supervisor_iteration
+
+    stops: list = []
+
+    class _Fallback:
+        def is_running(self) -> bool:
+            return True
+
+        async def stop(self) -> None:
+            stops.append(True)
+
+    ctx = types.SimpleNamespace(
+        websocket_manager=None, market_data_manager=None, event_loop_lagging=False
+    )
+    result = asyncio.run(
+        installed(
+            ctx,
+            _Fallback(),
+            quote_stale_ms=5000.0,
+            degraded_since=None,
+            recovered_since=None,
+            activate_after=5.0,
+            recover_cooldown=10.0,
+        )
+    )
+    assert isinstance(result, tuple) and len(result) == 2


### PR DESCRIPTION
Log-driven (2026-07-09 16:15+): 213x TypeError per supervisor iteration - the WS->REST polling failover safety net was dead all session. Root cause: signature drift between core.app's supervisor loop (passes recover_cooldown) and the runtime patch's installed replacement wrapper (rejected it); the runtime duplicate had also dropped the anti-flap recover-cooldown hysteresis present in the canonical app implementation.

Fix in polling_failover_runtime.py: wrapper accepts/forwards recover_cooldown (defaulted - older call shapes unaffected); runtime implementation restores the cooldown gate mirroring core.app:515 so recovery cannot bounce the poller. Regression test drives the installed wrapper with the exact production call shape. Full suite green, compileall clean.