### PR TITLE
Fix UNKNOWN-mode context block, Telegram shutdown order, fallback churn; behavior gate tests

### DIFF
--- a/src/nifty_scalper_bot/core/history_readiness.py
+++ b/src/nifty_scalper_bot/core/history_readiness.py
@@ -629,7 +629,15 @@ def resolve_history_policy(
         required = max(option_min, 1)
         target = max(required, generic_required)
         priority = 1
-    market_closed_context = role == "option_context" and get_runtime_market_mode() != "OPEN" and phase != "recovery"
+    # Only explicit closed sessions block option-context broker fetch.
+    # A transient UNKNOWN mode (startup, clock lag, calendar hiccup near open)
+    # must NOT keep context strategies cold: UNKNOWN != "OPEN" previously
+    # evaluated as closed and suppressed SMC/context votes.
+    market_closed_context = (
+        role == "option_context"
+        and get_runtime_market_mode() in {"PRE_MARKET", "POST_MARKET", "HOLIDAY"}
+        and phase != "recovery"
+    )
     _role_caps = {
         "selected_option": int(os.getenv("HYDRATION_CAP_SELECTED_OPTION", "75") or 75),
         "option_context": int(os.getenv("HYDRATION_CAP_OPTION_CONTEXT", "50") or 50),

--- a/src/nifty_scalper_bot/core/polling_failover_runtime.py
+++ b/src/nifty_scalper_bot/core/polling_failover_runtime.py
@@ -108,13 +108,16 @@ async def _stop_fallback_safely(fallback: Any, *, reason: str) -> None:
     try:
         running_fn = getattr(fallback, "is_running", None)
         running = bool(running_fn()) if callable(running_fn) else bool(getattr(fallback, "_running", False))
+        if not running:
+            # Already stopped: repeating set_websocket_mode(True) every healthy
+            # supervisor iteration is redundant async churn / noisy telemetry.
+            return
         mode_fn = getattr(fallback, "set_websocket_mode", None)
         if callable(mode_fn):
             await _maybe_await(mode_fn(True))
-        if running:
-            stop_fn = getattr(fallback, "stop", None)
-            if callable(stop_fn):
-                await _maybe_await(stop_fn())
+        stop_fn = getattr(fallback, "stop", None)
+        if callable(stop_fn):
+            await _maybe_await(stop_fn())
     except Exception as exc:  # noqa: BLE001 - supervisor must remain non-fatal
         LOGGER.warning(
             "POLLING_FALLBACK_STOP_FAILED reason=%s error_type=%s error=%s",

--- a/src/nifty_scalper_bot/notifications/telegram_controller.py
+++ b/src/nifty_scalper_bot/notifications/telegram_controller.py
@@ -774,6 +774,12 @@ class TelegramBot:
                 self._heartbeat_task = None
             self._bg_task_started = False
 
+            # 1. Drain pending alerts and stop internal workers FIRST — the
+            # final alert flush sends via application.bot, which needs PTB's
+            # HTTPX layer still initialized ("HTTPXRequest is not initialized"
+            # shutdown errors came from draining after application.shutdown()).
+            await self.shutdown()
+
             if self.application.updater is not None:
                 with suppress(Exception):
                     await self.application.updater.stop()
@@ -781,9 +787,7 @@ class TelegramBot:
                 await self.application.stop()
             with suppress(Exception):
                 await self.application.shutdown()
-            
-            # 2. Call internal shutdown for other tasks (loops, workers)
-            await self.shutdown()
+
             release_polling_owner(token=self.deps.token, owner=type(self).__name__)
             self._started = False
             log.info("✅ Telegram Bot: Shutdown complete.")

--- a/tests/core/test_option_context_fetch_market_mode.py
+++ b/tests/core/test_option_context_fetch_market_mode.py
@@ -19,3 +19,45 @@ async def test_closed_modes_block_open_and_unknown_allow() -> None:
     closed = {"PRE_MARKET", "POST_MARKET", "HOLIDAY"}
     assert all(m in closed for m in ("PRE_MARKET", "POST_MARKET", "HOLIDAY"))
     assert "OPEN" not in closed and "UNKNOWN" not in closed
+
+
+import pytest
+from types import SimpleNamespace
+
+from nifty_scalper_bot.core import history_readiness
+
+
+@pytest.mark.parametrize(
+    "mode,expected_allow",
+    [
+        ("OPEN", True),
+        ("UNKNOWN", True),   # transient UNKNOWN near open must not keep SMC cold
+        ("PRE_MARKET", False),
+        ("POST_MARKET", False),
+        ("HOLIDAY", False),
+    ],
+)
+async def test_option_context_fetch_gate_behavior(mode, expected_allow, monkeypatch):
+    """Behavior test of the ACTUAL policy layer (history_readiness), replacing
+    the string assertion against app.py which guarded the wrong file."""
+    monkeypatch.setattr(history_readiness, "get_runtime_market_mode", lambda: mode)
+    policy = history_readiness.resolve_history_policy(
+        SimpleNamespace(strategy_runner=None),
+        "NFO:NIFTY2671424000CE",
+        role="option_context",
+        phase="dynamic_update",
+        reason="test",
+    )
+    assert bool(policy.allow_broker_fetch) is expected_allow
+
+
+async def test_option_context_fetch_allowed_in_recovery_even_when_closed(monkeypatch):
+    monkeypatch.setattr(history_readiness, "get_runtime_market_mode", lambda: "POST_MARKET")
+    policy = history_readiness.resolve_history_policy(
+        SimpleNamespace(strategy_runner=None),
+        "NFO:NIFTY2671424000CE",
+        role="option_context",
+        phase="recovery",
+        reason="test",
+    )
+    assert bool(policy.allow_broker_fetch) is True


### PR DESCRIPTION
Audit items implemented (each claim verified in code first): P1 UNKNOWN market mode no longer blocks option-context history fetch (explicit closed-mode set; recovery unaffected); P1 Telegram shutdown drains/flushes alerts BEFORE PTB application shutdown (kills the HTTPXRequest-not-initialized class); P2 fallback stop path returns early when already stopped (no per-iteration mode toggling after recovery); P3 behavior-based parametrized tests now drive the real policy layer (resolve_history_policy) instead of asserting strings in the wrong file.

Validated on an integration branch together with PRs #834 and #835 (both merged just before this): full suite green, compileall clean. PR #830 deliberately NOT merged: GitHub reports it conflicted (mergeable=false/dirty, +410/-113); blind conflict-resolution of a foreign live-safety gate is riskier than deferring - needs a rebase by its author or a dedicated review slice.