### PR TITLE
Fix controller trailing dead under degraded ATR; tick-round fill re-anchor

### DIFF
--- a/src/nifty_scalper_bot/execution/bracket_core.py
+++ b/src/nifty_scalper_bot/execution/bracket_core.py
@@ -1093,8 +1093,17 @@ class BracketManager:
                 and AdaptiveTrailingController
             ):
                 try:
+                    # Fallback trail distance must be premium-relative: the old
+                    # absolute 20.0 points is ~13% on a ~150 option premium, so
+                    # with stale/unavailable ATR the controller proposed stops
+                    # far below the current SL and the monotonic guard rejected
+                    # every update — trailing silently dead on the controller
+                    # path while the legacy fallback math trails at ~2-3%.
+                    _fallback_trail = max(
+                        round(max(float(price or 0.0), 1.0) * 0.02, 2), 0.25
+                    )
                     spec = TrailingSpec(
-                        trail_by=20.0, # Fallback
+                        trail_by=_fallback_trail,  # ~2% of entry premium
                         step=0.25,      # Tighter early trailing step
                         activation=0.3 # Earlier activation threshold
                     )
@@ -1203,16 +1212,17 @@ class BracketManager:
                 if old_price > 0 and old_price != fill_price:
                     price_diff_pct = (fill_price - old_price) / old_price
                     
-                    # Adjust SL proportionally
+                    # Adjust SL proportionally (tick-rounded: round(x, 2) put
+                    # SL/TP on the 0.01 grid, e.g. 143.99 — invalid NSE tick)
                     if bracket.sl_trigger_price > 0:
-                        bracket.sl_trigger_price = round(
-                            bracket.sl_trigger_price * (1 + price_diff_pct), 2
+                        bracket.sl_trigger_price = _round_to_tick(
+                            bracket.sl_trigger_price * (1 + price_diff_pct)
                         )
                     
                     # Adjust TP proportionally
                     if bracket.tp_trigger_price > 0:
-                        bracket.tp_trigger_price = round(
-                            bracket.tp_trigger_price * (1 + price_diff_pct), 2
+                        bracket.tp_trigger_price = _round_to_tick(
+                            bracket.tp_trigger_price * (1 + price_diff_pct)
                         )
                     
                     LOGGER.info(

--- a/tests/execution/test_execution_safety_audit_fixes.py
+++ b/tests/execution/test_execution_safety_audit_fixes.py
@@ -1063,3 +1063,62 @@ def test_bracket_tp1_partial_fires_once_on_live_class(monkeypatch, tmp_path) -> 
         assert len(placed) == 1, "TP1 partial must fire exactly one exit order"
     finally:
         bm._running = False
+
+
+def test_fill_reanchor_and_controller_trailing_on_executed_range(
+    monkeypatch, tmp_path
+) -> None:
+    """Signal->executed coordination on the live class: a slipped broker fill
+    must re-anchor entry/SL/TP1 to the executed range (tick-rounded), sync the
+    adaptive controller's anchor, and controller-path trailing must ratchet on
+    a rally even with degraded/unavailable ATR (the old absolute 20.0-point
+    fallback trail distance left trailing silently dead on option premiums)."""
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+
+    class _OM:
+        def place_reduce_only_exit(self, intent):
+            return "X"
+
+        def place_order(self, **kwargs):
+            return "X"
+
+        def get_order_status(self, _oid):
+            return {"status": "COMPLETE"}
+
+    class _IndicatorEngine:  # bare: SafeATRProvider yields degraded ATR
+        pass
+
+    sym = "NFO:NIFTYEXECRANGE24050CE"
+    bm = BracketManager(order_manager=_OM(), indicator_engine=_IndicatorEngine())
+    bm._running = False
+    try:
+        bm.register_virtual_bracket(
+            order_id="ex-1", symbol=sym, side="BUY", qty=65,
+            price=145.15, sl=143.15, tp=160.0,
+            activate_immediately=False, trailing_atr_mult=1.5,
+        )
+        controller = bm._trailing_controllers.get("ex-1")
+        assert controller is not None, "adaptive controller must attach"
+
+        bm.confirm_entry_fill("ex-1", 146.00)  # +0.85 slippage vs signal
+        bracket = bm.get_bracket("ex-1")
+
+        # Re-anchored to broker fill, tick-rounded.
+        assert bracket.entry_price == 146.00
+        assert bracket.entry_fill_price == 146.00
+        assert bracket.sl_trigger_price > 143.15
+        assert round(bracket.sl_trigger_price / 0.05, 6) % 1 == 0
+        # Controller anchor synced to executed range.
+        assert float(controller.entry_price) == 146.00
+        assert float(controller.current_sl) == bracket.sl_trigger_price
+
+        # Controller-path trailing ratchets on a rally despite degraded ATR.
+        sl_path = []
+        for px in (147.0, 149.0, 151.0, 153.0, 151.5, 155.0):
+            bm.on_tick(sym, px)
+            sl_path.append(bracket.sl_trigger_price)
+        assert sl_path[-1] > 146.00, "trailing must lock profit above entry"
+        assert all(b >= a for a, b in zip(sl_path, sl_path[1:]))
+        assert all(round(v / 0.05, 6) % 1 == 0 for v in sl_path)
+    finally:
+        bm._running = False


### PR DESCRIPTION
Execution-harnessing audit (live class, empirical): signal->executed re-anchoring on broker fill VERIFIED working (entry/SL/TP re-anchor + adaptive controller anchor re-sync); broker/internal sync chain verified wired; trailing correctly pauses during pending exits.

Two real defects fixed: (1) controller-path trailing was silently DEAD whenever ATR was stale/unavailable - the absolute 20.0-point fallback trail distance (~13% of an option premium) made every proposed stop monotonic-rejected; now premium-relative (2% of entry). A +6% rally that previously never moved the SL now ratchets 144.00->150.65. (2) fill re-anchor used round(x,2) producing invalid 0.01-grid ticks (143.99); now _round_to_tick, consistent with the canonical TP re-anchor.

Regression test locks in: slipped-fill re-anchor (tick-rounded) + controller anchor sync + degraded-ATR trailing ratchet. Full suite green, compileall clean, no loss of function.