### PR TITLE
Stop quarantining own fills; ghost sweep respects fill-latency window

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -12563,9 +12563,42 @@ async def _reconcile_state(ctx: BotContext) -> None:
                     # 3. Identify Ghosts (Managed but no Position)
                     ghosts = managed_symbols - real_positions
 
+                    _ghost_now = time.time()
                     for ghost_sym in ghosts:
                         # Double check if it actually has active brackets inside
                         if bm.is_symbol_managed(ghost_sym):
+                            # NEVER kill a bracket that is awaiting its entry
+                            # fill or was activated moments ago. Broker fill
+                            # latency means the local position lags the bracket
+                            # by seconds: on 2026-07-10 this sweeper deleted the
+                            # pending bracket of a REAL in-flight order one
+                            # second after submit; the fill then arrived
+                            # orphaned -> own-order quarantine -> new entries
+                            # blocked and the position left on a wide guard SL.
+                            _in_fill_window = False
+                            for _bid in list(
+                                (getattr(bm, "_symbol_map", {}) or {}).get(ghost_sym) or []
+                            ):
+                                _b = (getattr(bm, "_brackets", {}) or {}).get(_bid)
+                                if _b is None:
+                                    continue
+                                if not getattr(_b, "entry_confirmed", False):
+                                    _in_fill_window = True
+                                    break
+                                _fill_ts = getattr(_b, "entry_fill_ts", None)
+                                if _fill_ts and _ghost_now - float(_fill_ts) < 120.0:
+                                    _in_fill_window = True
+                                    break
+                            if _in_fill_window:
+                                LOGGER.info(
+                                    "GHOST_SWEEP_SKIPPED_PENDING_ENTRY symbol=%s",
+                                    ghost_sym,
+                                    extra={
+                                        "event": "GHOST_SWEEP_SKIPPED_PENDING_ENTRY",
+                                        "symbol": ghost_sym,
+                                    },
+                                )
+                                continue
                             LOGGER.warning(
                                 f"👻 GHOST BRACKET DETECTED: {ghost_sym} has protection but no Open Position. "
                                 "Performing Safety Cleanup..."

--- a/src/nifty_scalper_bot/execution/order_manager_core.py
+++ b/src/nifty_scalper_bot/execution/order_manager_core.py
@@ -3196,6 +3196,38 @@ class OrderManager:
                         signal_id=signal_id,
                     )
                     self._register_order(details)
+                    # Sync PositionManager's pending-order registry so the
+                    # incoming broker fill is attributed to OUR order (intent
+                    # preserved), not synthesized as an unknown order and
+                    # quarantined. 2026-07-10: this sync existed only on the
+                    # reconcile path, so a live entry's own fill arrived as
+                    # intent=UNKNOWN -> BROKER_POSITION_QUARANTINED_FOR_
+                    # UNKNOWN_ORDER every sync -> all new entries blocked and
+                    # the position left on a wide guard bracket.
+                    if hasattr(self._positions, "add_pending_order"):
+                        try:
+                            self._positions.add_pending_order(
+                                order_id=details.order_id,
+                                symbol=details.symbol,
+                                side=details.side,
+                                qty=details.quantity,
+                                price=details.price,
+                                order_type=details.order_type,
+                                intent=details.intent,
+                                bracket_id=details.bracket_id,
+                                signal_id=details.signal_id,
+                                signal_fingerprint=details.signal_fingerprint,
+                            )
+                        except Exception as _pm_sync_exc:  # noqa: BLE001
+                            self._logger.error(
+                                "POSITION_MANAGER_PENDING_SYNC_FAILED order_id=%s error=%s",
+                                details.order_id,
+                                _pm_sync_exc,
+                                extra={
+                                    "event": "POSITION_MANAGER_PENDING_SYNC_FAILED",
+                                    "order_id": details.order_id,
+                                },
+                            )
                     # Local order record now owns the symbol — release the
                     # single-position gate's in-flight reservation.
                     with self._lock:

--- a/tests/execution/test_execution_safety_audit_fixes.py
+++ b/tests/execution/test_execution_safety_audit_fixes.py
@@ -1122,3 +1122,62 @@ def test_fill_reanchor_and_controller_trailing_on_executed_range(
         assert all(round(v / 0.05, 6) % 1 == 0 for v in sl_path)
     finally:
         bm._running = False
+
+
+def test_live_entry_registers_pending_order_with_position_manager(
+    monkeypatch, tmp_path
+) -> None:
+    """2026-07-10 incident: place_order registered the order locally and with
+    the bracket manager but NOT with the PositionManager, so the broker fill
+    for the bot's OWN live entry arrived as an unknown order (intent=UNKNOWN),
+    was quarantined every sync, blocked all new entries, and left the position
+    on a wide guard bracket. The pending-order sync must happen at submit."""
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    from nifty_scalper_bot.execution.order_manager import OrderManager, OrderType
+
+    class _Broker:
+        def place_order(self, **_k):
+            return {"order_id": "LIVE-ENTRY-1"}
+
+        def get_orders(self):
+            return []
+
+        def get_positions(self):
+            return []
+
+    class _Positions:
+        def __init__(self):
+            self.pending: dict = {}
+
+        def has_open_position(self, _s):
+            return False
+
+        def get_open_positions(self):
+            return []
+
+        def add_pending_order(self, **kwargs):
+            self.pending[kwargs["order_id"]] = kwargs
+
+    om = OrderManager(_Broker(), _Positions(), object())
+    monkeypatch.setattr(om, "_lot_size_for_symbol", lambda _s: 65)
+    bm = BracketManager(order_manager=om)
+    bm._running = False
+    om.set_bracket_manager(bm)
+    try:
+        oid = om.place_order(
+            symbol="NFO:NIFTY2671424100CE", side="BUY", quantity=65,
+            order_type=OrderType.LIMIT, price=160.45,
+            stop_loss=151.20, take_profit=177.10,
+            intent="ENTRY", check_risk=False, signal_id="sig-0710",
+        )
+        assert oid
+        pending = om._positions.pending.get(oid)
+        assert pending is not None, "pending order must reach PositionManager"
+        assert str(pending["intent"]).upper() == "ENTRY"
+        assert pending["qty"] == 65
+        # The freshly registered bracket is pending entry — the ghost sweeper's
+        # skip condition (entry_confirmed False) must hold for it.
+        bracket = bm.get_bracket(oid)
+        assert bracket is not None and bracket.entry_confirmed is False
+    finally:
+        bm._running = False


### PR DESCRIPTION
Log-driven (2026-07-10 morning, real live entry): the bot placed a live BUY, then (1) the ghost-bracket sweeper deleted the pending bracket one second after submit (fill latency window), and (2) the fill arrived for an order the PositionManager never learned about (pending-order sync existed only on the reconcile path, not in place_order) -> own fill quarantined as unknown every sync, all new entries arbitrator-blocked, valid 200CE signal rejected, state machine stuck ORDER_PENDING, position left on a wide 10% guard SL instead of the planned bracket.

Fixes at the owning functions: place_order now syncs add_pending_order (full intent/bracket/signal identity) immediately after local registration; the ghost sweep skips brackets awaiting entry confirmation or filled <120s ago (manual-exit ghosts still swept). Regression test locks both in. Full suite green, compileall clean, no loss of function.