### PR TITLE
fix: ignore stale context options for freshness

### DIFF
--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -4620,7 +4620,13 @@ class MarketDataManager:
     def _active_option_symbols(self) -> list[str]:
         """Return currently active option symbols used for hard feed checks."""
         requirements = dict(self._readiness_requirements)
-        symbols = [str(s) for s in requirements.get("options") or [] if s]
+        selected = [
+            str(requirements.get("atm_ce") or ""),
+            str(requirements.get("atm_pe") or ""),
+        ]
+        symbols = [s for s in selected if s and s.endswith(("CE", "PE"))]
+        if not symbols:
+            symbols = [str(s) for s in requirements.get("options") or [] if s]
         if not symbols:
             with self._lock:
                 symbols = [

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -136,6 +136,7 @@ from nifty_scalper_bot.utils.market_hours import (
     post_market_suppress_candle_gap_warnings,
     is_market_hours_cached,
     is_market_open_now,
+    is_nifty_option_symbol,
     stale_threshold_for_symbol,
 )
 from nifty_scalper_bot.utils.metrics import Counter, signals_generated_total
@@ -6804,6 +6805,11 @@ class StrategyRunner:
         now_wall = time.time()
         stale_count = 0
         stale_symbols: list[str] = []
+        active_option_symbols = {
+            normalize_symbol(str(sym))
+            for sym in (getattr(self, "_active_option_symbols", set()) or set())
+            if sym
+        }
 
         for symbol, engine in self._candle_engines.items():
             if symbol not in self._active_symbols:
@@ -6825,6 +6831,22 @@ class StrategyRunner:
                             extra={"event": "BACKFILL_SKIPPED_REMOVED_SYMBOL", "symbol": symbol},
                         )
                     continue
+            if (
+                is_nifty_option_symbol(symbol)
+                and symbol not in active_option_symbols
+                and not self._is_selected_option_symbol(symbol)
+            ):
+                if self._should_log_throttled(f"ws_stale_skipped_inactive_option:{symbol}", 300.0):
+                    self._logger.debug(
+                        "WS_STALE_SKIPPED symbol=%s reason=outside_active_option_basket",
+                        symbol,
+                        extra={
+                            "event": "WS_STALE_SKIPPED",
+                            "symbol": symbol,
+                            "reason": "outside_active_option_basket",
+                        },
+                    )
+                continue
             # 1. Use .get() to prevent KeyError on newly subscribed symbols
             stale_for = now_wall - self._last_tick_time_by_symbol.get(symbol, now_wall)
 

--- a/tests/data/test_canonical_history_hydration.py
+++ b/tests/data/test_canonical_history_hydration.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import time
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 
@@ -346,6 +347,37 @@ def test_historical_bar_writes_only_canonical_ohlc_not_raw_ticks() -> None:
     assert len(mdm._raw_tick_history["NSE:NIFTY"]) == 0
     assert mdm.is_ohlc_ready("NSE:NIFTY", required_bars=1) is True
     assert mdm.is_tick_ready("NSE:NIFTY") is False
+
+
+def test_feed_health_uses_selected_options_not_context_option_staleness() -> None:
+    mdm = _storage_mdm()
+    now = time.time()
+    selected_ce = "NFO:NIFTY2671423950CE"
+    selected_pe = "NFO:NIFTY2671423950PE"
+    stale_context = "NFO:NIFTY2671424100PE"
+    mdm._tick_stale_threshold_ms = 60_000
+    mdm._resolve_symbol_key_safe = lambda symbol: str(symbol)
+    mdm._active_subscribed_symbols = {selected_ce, selected_pe, stale_context}
+    mdm._last_tick_wallclock = {
+        "NSE:NIFTY": now,
+        "NFO:NIFTY26JULFUT": now,
+        selected_ce: now,
+        selected_pe: now,
+        stale_context: now - 3600,
+    }
+    mdm._last_tick_time = dict(mdm._last_tick_wallclock)
+    mdm.set_readiness_requirements(
+        spot_symbol="NSE:NIFTY",
+        futures_symbol="NFO:NIFTY26JULFUT",
+        atm_ce_symbol=selected_ce,
+        atm_pe_symbol=selected_pe,
+        option_symbols=[selected_ce, selected_pe, stale_context],
+    )
+
+    health = mdm.trading_feed_health(max_age_ms=60_000)
+
+    assert health["options_fresh"] is True
+    assert health["option_symbols"] == [selected_ce, selected_pe]
 
 
 def test_live_tick_writes_raw_tick_history_without_implying_ohlc_ready() -> None:

--- a/tests/strategies/test_runner_market_closed_watchdog.py
+++ b/tests/strategies/test_runner_market_closed_watchdog.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import logging
 import re
+import time
 
 import pytest
 
@@ -39,7 +40,7 @@ def test_runner_uses_central_stale_threshold():
     assert "stale_threshold_for_symbol(symbol, market_open_now)" in source
     assert "is_market_open_now()" in source
     # Ensure the legacy hardcoded 10.0 NIFTY threshold is gone.
-    assert "else (30.0 if source in (\"rest\", \"polling\") else 10.0)" not in source
+    assert 'else (30.0 if source in ("rest", "polling") else 10.0)' not in source
 
 
 def test_runner_strategy_stall_check_skipped_when_market_closed():
@@ -64,6 +65,67 @@ def test_runner_zombie_ws_restart_skipped_when_market_closed():
     assert block is not None, "zombie WS restart must be gated by market_open"
 
 
+def test_runner_skips_inactive_option_stale_restart_count():
+    """Args: none. Returns: None. Raises: AssertionError."""
+    source = _read_runner_source()
+    assert "outside_active_option_basket" in source
+    assert "is_nifty_option_symbol(symbol)" in source
+    assert "self._is_selected_option_symbol(symbol)" in source
+    skip_index = source.index("outside_active_option_basket")
+    stale_count_index = source.index("stale_count += 1", skip_index)
+    assert skip_index < stale_count_index
+
+
+def test_runner_watchdog_does_not_restart_for_inactive_option(monkeypatch):
+    """Args: monkeypatch. Returns: None. Raises: AssertionError."""
+    import nifty_scalper_bot.strategies.runner as runner_module
+    from nifty_scalper_bot.strategies.runner import StrategyRunner
+
+    class _MarketData:
+        def __init__(self) -> None:
+            self.restart_count = 0
+
+        def _trigger_zombie_ws_restart(self) -> None:
+            self.restart_count += 1
+
+    old_symbol = "NFO:NIFTY2671424100PE"
+    selected_ce = "NFO:NIFTY2671423950CE"
+    selected_pe = "NFO:NIFTY2671423950PE"
+    market_data = _MarketData()
+    now_mono = time.monotonic()
+    now_wall = time.time()
+
+    runner = StrategyRunner.__new__(StrategyRunner)
+    runner.ready = False
+    runner._last_tick_seen_ts = now_mono
+    runner._last_global_eval_ts = now_mono
+    runner._eval_stall_recovery_attempted = False
+    runner._candle_engines = {old_symbol: object()}
+    runner._active_symbols = {old_symbol}
+    runner._tracked_symbols = {old_symbol}
+    runner._last_tick_time_by_symbol = {old_symbol: now_wall - 4000.0}
+    runner._active_option_symbols = {selected_ce, selected_pe}
+    runner._active_selected_ce = selected_ce
+    runner._active_selected_pe = selected_pe
+    runner._selected_ce_symbol = None
+    runner._selected_pe_symbol = None
+    runner._pending_selected_ce = None
+    runner._pending_selected_pe = None
+    runner._active_contract_basket = None
+    runner._data_hub = None
+    runner._last_ws_stale_log_ts_by_symbol = {}
+    runner._last_ws_reconnect_attempt_ts = 0.0
+    runner._market_data = market_data
+    runner._log_throttle_state = {}
+    runner._logger = logging.getLogger("test.runner.watchdog")
+
+    monkeypatch.setattr(runner_module, "is_market_open_now", lambda: True)
+
+    runner._health_watchdog()
+
+    assert market_data.restart_count == 0
+
+
 def test_runner_stale_tick_offmarket_uses_central_threshold():
     """Args: none. Returns: None. Raises: AssertionError."""
     source = _read_runner_source()
@@ -77,5 +139,7 @@ def test_runner_offmarket_nifty_stale_threshold_gte_3600():
     """Args: none. Returns: None. Raises: AssertionError."""
     threshold = market_hours.stale_threshold_for_symbol("NSE:NIFTY", market_open=False)
     assert threshold >= 3600.0
-    threshold_open = market_hours.stale_threshold_for_symbol("NSE:NIFTY", market_open=True)
+    threshold_open = market_hours.stale_threshold_for_symbol(
+        "NSE:NIFTY", market_open=True
+    )
     assert threshold_open == 120.0


### PR DESCRIPTION
## Root cause

`MarketDataManager._active_option_symbols()` used the whole readiness option list for hard option feed freshness. That list can include non-selected context strikes, so a stale old/context option could make `options_fresh=False` even while selected CE/PE were fresh. Separately, `StrategyRunner._health_watchdog()` counted stale inactive option symbols toward zombie WS restart/backfill decisions.

## What changed

- `src/nifty_scalper_bot/data/market_data_manager.py`: hard option feed freshness now uses selected ATM CE/PE from readiness requirements first, falling back to the broader option list only when selected symbols are unavailable.
- `src/nifty_scalper_bot/strategies/runner.py`: runner watchdog skips stale option symbols outside the active option basket and current selected CE/PE, logging `WS_STALE_SKIPPED reason=outside_active_option_basket`.
- `tests/data/test_canonical_history_hydration.py`: regression test proving stale context options do not make selected-option feed health false.
- `tests/strategies/test_runner_market_closed_watchdog.py`: regression coverage for inactive option stale symbols not triggering zombie WS restart.

## What did not change

- No contract selection changes.
- No order execution, risk, SL/TP, broker reconciliation, or Telegram behavior changed.
- Selected CE/PE, futures, and spot freshness checks remain active.

## Validation

Commands run:

- `python -m pytest -q tests\data\test_canonical_history_hydration.py tests\strategies\test_runner_market_closed_watchdog.py --basetemp .pytest-tmp-feed-watchdog`
- `python -m compileall -q src`
- `git diff --check`

Results:

```text
26 passed
compileall passed
diff check passed
```

## Runtime impact

- Startup: no startup ordering change.
- Market data: selected option freshness is no longer vetoed by stale non-selected/context option symbols.
- Option hydration: unchanged; history remains MDM-owned.
- Strategy evaluation: inactive stale option candles no longer trigger runner watchdog backfill/restart.
- Risk/execution/Telegram: unchanged.

## Regression risk

Low. The change narrows hard freshness/restart decisions to selected active options while retaining fallback behavior when selected symbols are unavailable.