### PR TITLE
Fix time-shadow reconcile crash, unarmed order-path entry, candle storm, fill-warn flood

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -3275,7 +3275,7 @@ class RuntimeSelfChecker:
         last_tick_ts = getattr(streamer, "last_tick_ts", None)
         if last_tick_ts is not None:
             with suppress(Exception):
-                recent_tick_age = max(0.0, time.time() - float(last_tick_ts))
+                recent_tick_age = max(0.0, time_module.time() - float(last_tick_ts))
             if recent_tick_age > 10.0:
                 connected = False
                 detail = "no_recent_ticks"
@@ -4748,9 +4748,9 @@ def initialize_components(settings: Settings | None = None) -> BotContext:
                 last_tick = getattr(market_data_manager, "last_tick_time", 0)
 
                 # If we have received data before (>0) but it's now stale (>180s)
-                if last_tick > 0 and (time.time() - last_tick > 180):
+                if last_tick > 0 and (time_module.time() - last_tick > 180):
                     logger.critical(
-                        f"🚨 FATAL: No data for {int(time.time() - last_tick)}s. Zombie Mode detected. Exiting."
+                        f"🚨 FATAL: No data for {int(time_module.time() - last_tick)}s. Zombie Mode detected. Exiting."
                     )
                     os._exit(
                         1
@@ -12563,7 +12563,7 @@ async def _reconcile_state(ctx: BotContext) -> None:
                     # 3. Identify Ghosts (Managed but no Position)
                     ghosts = managed_symbols - real_positions
 
-                    _ghost_now = time.time()
+                    _ghost_now = time_module.time()
                     for ghost_sym in ghosts:
                         # Double check if it actually has active brackets inside
                         if bm.is_symbol_managed(ghost_sym):

--- a/src/nifty_scalper_bot/execution/position_manager.py
+++ b/src/nifty_scalper_bot/execution/position_manager.py
@@ -3158,9 +3158,21 @@ class PositionManager:
             return FillApplicationResult(reason="cumulative_quantity_exceeds_order")
         qty = cumulative_qty - previous_qty
         if qty <= 0:
-            self._logger.warning(
-                "Ignoring non-incremental fill for order %s", order.order_id
-            )
+            # Correct idempotency drop — but the same terminal fill can be
+            # replayed by every reconcile cycle; warn once per (order,
+            # cumulative snapshot) instead of flooding logs and Telegram.
+            _dedupe_key = (str(order.order_id), int(cumulative_qty))
+            _seen = getattr(self, "_non_incremental_fill_warned", None)
+            if _seen is None:
+                _seen = set()
+                self._non_incremental_fill_warned = _seen
+            if _dedupe_key not in _seen:
+                _seen.add(_dedupe_key)
+                self._logger.warning(
+                    "Ignoring non-incremental fill for order %s (cumulative=%s; further replays suppressed)",
+                    order.order_id,
+                    cumulative_qty,
+                )
             return FillApplicationResult(reason="non_incremental_cumulative_quantity")
 
         cumulative_avg = order.fill_price

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -6734,12 +6734,28 @@ class StrategyRunner:
                 with self._eval_gate_lock:
                     self._eval_in_progress_symbols.discard(normalized_symbol)
         except Exception as exc:
-            LOGGER.error(
-                "Critical error in _on_tick for %s: %s",
-                symbol,
-                exc,
-                exc_info=True,
-            )
+            from nifty_scalper_bot.data.source import DataIntegrityError as _DIErr
+
+            if isinstance(exc, _DIErr):
+                # Stale/out-of-order candle contaminating the live stream is
+                # quarantined by the engine's monotonic guard; treat it as a
+                # dropped candle (throttled warning), not a repeating CRITICAL
+                # storm per tick (2026-07-10: hundreds of _on_tick criticals
+                # from one 09:39 candle arriving after 11:16).
+                if self._should_log_throttled(f"candle_ooo:{symbol}", 60.0):
+                    self._logger.warning(
+                        "candle_out_of_order symbol=%s dropped=%s",
+                        symbol,
+                        exc,
+                        extra={"event": "candle_out_of_order", "symbol": symbol},
+                    )
+            else:
+                LOGGER.error(
+                    "Critical error in _on_tick for %s: %s",
+                    symbol,
+                    exc,
+                    exc_info=True,
+                )
         finally:
             now = time.monotonic()
             self._emit_composite_reports()
@@ -12024,6 +12040,36 @@ class StrategyRunner:
                         "trace_id": trace_id,
                     },
                 )
+                # Global execution arming dominates symbol readiness: while
+                # live orders are not armed, stop BEFORE the order path
+                # (materializing plans + order requests just to be rejected by
+                # the native gate wastes the event loop and floods logs —
+                # 2026-07-10 RCA: ORDER_PATH_ENTERED live_orders_armed=False).
+                if (
+                    getattr(self, "_live_mode", False)
+                    and not getattr(self, "_runtime_live_orders_armed", True)
+                ):
+                    if self._should_log_throttled(
+                        f"signal_prep_unarmed:{symbol}", 30.0
+                    ):
+                        self._logger.warning(
+                            "RUNNER_SIGNAL_PREP_BLOCKED_UNARMED symbol=%s "
+                            "trace_id=%s broker_attempted=False",
+                            symbol,
+                            trace_id,
+                            extra={
+                                "event": "RUNNER_SIGNAL_PREP_BLOCKED_UNARMED",
+                                "symbol": symbol,
+                                "trace_id": trace_id,
+                            },
+                        )
+                    self._emit_runner_eval_decision(
+                        symbol=symbol,
+                        stage="phase10_execute",
+                        reason="live_orders_not_armed",
+                        allowed=False,
+                    )
+                    return
                 scheduled, prepare_reason = self._schedule_signal_preparation(
                     signal, price, now, trace_id
                 )

--- a/tests/execution/test_execution_safety_audit_fixes.py
+++ b/tests/execution/test_execution_safety_audit_fixes.py
@@ -1181,3 +1181,40 @@ def test_live_entry_registers_pending_order_with_position_manager(
         assert bracket is not None and bracket.entry_confirmed is False
     finally:
         bm._running = False
+
+
+def test_non_incremental_fill_warning_dedupes_per_snapshot(tmp_path) -> None:
+    """2026-07-10 RCA: the same terminal fill replayed by every reconcile
+    cycle flooded logs/Telegram with identical warnings. The idempotency drop
+    stays; the warning fires once per (order, cumulative snapshot)."""
+    import logging
+
+    from nifty_scalper_bot.execution.position_manager import PositionManager
+
+    manager = PositionManager(state_file=str(tmp_path / "positions.json"))
+    manager.add_pending_order(
+        "OID-1", "NFO:NIFTY2671424100CE", "BUY", 65, 160.45, "LIMIT", intent="ENTRY"
+    )
+    manager.apply_broker_order_update(
+        "OID-1", {"status": "COMPLETE", "filled_quantity": 65, "average_price": 160.45}
+    )
+
+    records: list = []
+
+    class _Capture(logging.Handler):
+        def emit(self, record):
+            records.append(record.getMessage())
+
+    handler = _Capture()
+    manager._logger.addHandler(handler)
+    try:
+        for _ in range(5):  # replayed terminal fill, five reconcile cycles
+            manager.apply_broker_order_update(
+                "OID-1",
+                {"status": "COMPLETE", "filled_quantity": 65, "average_price": 160.45},
+            )
+    finally:
+        manager._logger.removeHandler(handler)
+    warnings = [m for m in records if "non-incremental" in m]
+    assert len(warnings) == 1, warnings
+    assert manager.get_position("NFO:NIFTY2671424100CE").quantity == 65


### PR DESCRIPTION
RCA implemented with expert modification. P0 time-shadow crash (datetime.time imported as 'time'; 4 call sites incl. #843's ghost-sweep timestamp) fixed at source with time_module.time() - this was the root blocker keeping live_orders_armed=False and the unresolved bracket un-clearable; the native unresolved_exit gate behaved correctly and is untouched. P1 runner unarmed guard: global arming now dominates symbol readiness (RUNNER_SIGNAL_PREP_BLOCKED_UNARMED before any plan materialization). P1 candle monotonic storm: DataIntegrityError at the _on_tick boundary is a quarantined drop with one throttled candle_out_of_order warning, engine guard stays authoritative. P1 non-incremental fill warning: once per (order, cumulative) snapshot; idempotency unchanged.

PR #844 superseded: same outcomes, but implemented at the owning functions instead of its runtime monkeypatch layer (silent package-root hook + import-hook time proxy) - the hidden-hook pattern already removed twice (#792/#838) and the machinery class behind the #839 signature drift.

Regression test: 5 replayed terminal fills -> 1 warning, accounting intact. Full suite green, compileall clean.