### PR TITLE
fix: validate historical quote freshness

### DIFF
--- a/src/nifty_scalper_bot/data/data_hub.py
+++ b/src/nifty_scalper_bot/data/data_hub.py
@@ -1941,8 +1941,6 @@ class DataHub:
         if not quote:
             return False, {"reason": "no_tick", "symbol": sym, "threshold_ms": threshold}
         source = str(quote.get("source") or "ws").lower()
-        if source == "historical":
-            return True, {"source": source, "threshold_ms": threshold, "reason": None}
         now_ms = self._now() * 1000.0
         ts_ms = self._timestamp_ms(quote.get("timestamp"))
         effective_ms = max(0.0, now_ms - ts_ms)

--- a/tests/data/test_data_hub_freshness_sources.py
+++ b/tests/data/test_data_hub_freshness_sources.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import time
+
 from nifty_scalper_bot.data.data_hub import DataHub
 
 
@@ -25,3 +27,21 @@ def test_poll_source_does_not_update_ws_arrival_but_stream_does() -> None:
     stream_tick['source'] = 'stream'
     hub.ingest_tick_sync(stream_tick)
     assert hub._last_ws_arrival.get('NSE:NIFTY', 0.0) > 0.0
+
+
+def test_historical_source_quote_still_uses_age_for_freshness() -> None:
+    now = time.time()
+    hub = DataHub(market_data_manager=_Mdm(), clock=lambda: now)
+    hub._quotes["NSE:NIFTY"] = {
+        "symbol": "NSE:NIFTY",
+        "ltp": 24000.0,
+        "timestamp": now - 120.0,
+        "source": "historical",
+    }
+    hub._start_mono = hub._monotonic() - hub._warmup_grace_s - 1.0
+
+    fresh, meta = hub.is_fresh("NSE:NIFTY", threshold_ms=60_000)
+
+    assert fresh is False
+    assert meta["source"] == "historical"
+    assert meta["reason"] == "stale"


### PR DESCRIPTION
## Root cause

`DataHub.is_fresh()` treated cached quotes with `source == historical` as fresh without checking quote age. That creates a second freshness rule and can hide stale restored/historical quote state from runtime self-checks, risk checks, order diagnostics, and Telegram diagnostics.

## What changed

- `src/nifty_scalper_bot/data/data_hub.py`: removed the historical-source freshness bypass so all cached quotes use the same timestamp/age threshold logic.
- `tests/data/test_data_hub_freshness_sources.py`: added a regression proving old historical-source cached quotes are stale outside startup warmup.

## What did not change

- No MDM history ownership or broker fetch behavior changed.
- No subscription, strategy, risk, order execution, or Telegram behavior changed.
- DataHub startup warmup grace remains intact.

## Validation

Commands run:

- `python -m pytest -q tests\data\test_data_hub_freshness_sources.py --basetemp .pytest-tmp-datahub-freshness`
- `python -m compileall -q src`
- `git diff --check`

Results:

```text
2 passed
compileall passed
diff check passed
```

## Runtime impact

- Startup: unchanged; warmup grace still applies.
- Market data: stale historical/restored quote cache no longer reports fresh only because of source label.
- History/hydration: unchanged; MDM remains the owner.
- Strategy/risk/execution/Telegram diagnostics: receive stricter freshness truth from DataHub.

## Regression risk

Low. The change removes a source-specific bypass and uses the existing age-based freshness calculation for every quote source.