### PR TITLE
fix: scope runtime freshness to selected basket

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -3093,6 +3093,37 @@ class RuntimeSelfChecker:
                     return 30000.0
                 return float(adaptive_ms)
 
+            def _basket_value(basket: object, key: str) -> object:
+                if isinstance(basket, Mapping):
+                    return basket.get(key)
+                return getattr(basket, key, None)
+
+            def _critical_symbols() -> set[str]:
+                basket = getattr(self._context, "active_contract_basket", None)
+                if basket is None:
+                    get_basket = getattr(hub, "get_active_contract_basket", None)
+                    if callable(get_basket):
+                        try:
+                            basket = get_basket()
+                        except Exception:
+                            basket = None
+                universe = getattr(self._context, "active_trading_universe", None)
+                selected: set[str] = set()
+                for source in (basket, universe):
+                    if source is None:
+                        continue
+                    for key in (
+                        "spot_symbol",
+                        "futures_symbol",
+                        "selected_ce",
+                        "selected_pe",
+                    ):
+                        value = _basket_value(source, key)
+                        if value:
+                            selected.add(canonical(str(value)))
+                selected.add("NSE:NIFTY")
+                return {sym for sym in selected if sym}
+
             per_symbol: list[tuple[str, bool, dict[str, object], float]] = []
             for s in symbols:
                 threshold_ms = _threshold_for_symbol(s)
@@ -3101,10 +3132,11 @@ class RuntimeSelfChecker:
 
             fresh = [item for item in per_symbol if item[1]]
             stale = [item for item in per_symbol if not item[1]]
+            selected_critical = _critical_symbols()
             critical = [
                 item
                 for item in per_symbol
-                if str(item[0]).upper().startswith("NFO:") or str(item[0]).upper() == "NSE:NIFTY"
+                if canonical(str(item[0])) in selected_critical
             ] or per_symbol
             all_critical_stale = not any(item[1] for item in critical)
             if hard_ready and symbols and stale and not all_critical_stale:
@@ -3112,6 +3144,7 @@ class RuntimeSelfChecker:
                     "fresh_symbols": len(fresh),
                     "stale_symbols": len(stale),
                     "live_symbols": len(symbols),
+                    "critical_symbols": len(critical),
                 }
 
             symbol, ok, meta, symbol_threshold_ms = fresh[0] if fresh else per_symbol[0]

--- a/tests/core/test_runtime_self_checker_freshness.py
+++ b/tests/core/test_runtime_self_checker_freshness.py
@@ -1,0 +1,57 @@
+from types import SimpleNamespace
+
+from nifty_scalper_bot.core import app
+
+
+class _Hub:
+    def __init__(self) -> None:
+        self._quotes = {
+            "NSE:NIFTY": {},
+            "NFO:NIFTY26JUL24000CE": {},
+            "NFO:NIFTY26JUL24000PE": {},
+            "NFO:NIFTY26JUL24500CE": {},
+        }
+        self._fresh = {
+            "NSE:NIFTY",
+            "NFO:NIFTY26JUL24000CE",
+            "NFO:NIFTY26JUL24000PE",
+        }
+
+    def is_fresh(self, symbol: str, *, threshold_ms: float | None = None):
+        ok = symbol in self._fresh
+        return ok, {
+            "reason": None if ok else "stale",
+            "symbol": symbol,
+            "threshold_ms": threshold_ms,
+        }
+
+    def get_active_contract_basket(self):
+        return {
+            "spot_symbol": "NSE:NIFTY",
+            "selected_ce": "NFO:NIFTY26JUL24000CE",
+            "selected_pe": "NFO:NIFTY26JUL24000PE",
+            "option_symbols": list(self._quotes),
+        }
+
+
+def test_runtime_self_checker_ignores_stale_non_selected_option(monkeypatch) -> None:
+    monkeypatch.setattr(app, "get_market_state", lambda: app.MarketState.OPEN)
+    runner = SimpleNamespace(set_data_freshness_backoff=lambda *args, **kwargs: None)
+    ctx = SimpleNamespace(
+        data_hub=_Hub(),
+        streamer=SimpleNamespace(_interval_s=0.7),
+        market_data_manager=SimpleNamespace(hard_ready=lambda: True),
+        strategy_runner=runner,
+        active_contract_basket={
+            "spot_symbol": "NSE:NIFTY",
+            "selected_ce": "NFO:NIFTY26JUL24000CE",
+            "selected_pe": "NFO:NIFTY26JUL24000PE",
+        },
+    )
+
+    ok, detail, meta = app.RuntimeSelfChecker(ctx)._check_data_freshness()
+
+    assert ok is True
+    assert detail == "partial_stale_ignored"
+    assert meta["stale_symbols"] == 1
+    assert meta["critical_symbols"] == 3


### PR DESCRIPTION
## Root cause

`RuntimeSelfChecker._check_data_freshness` in `src/nifty_scalper_bot/core/app.py` classified every tracked `NFO:` quote as critical. After active-basket selection, DataHub may still hold stale non-selected/context option quotes, so runtime self-check could treat stale old/context strikes as equivalent to selected CE/PE freshness.

## What changed

- `src/nifty_scalper_bot/core/app.py`
  - Added a local critical-symbol resolver inside `_check_data_freshness`.
  - Critical freshness is now scoped to active basket / active universe `spot_symbol`, `futures_symbol`, `selected_ce`, and `selected_pe`.
  - Stale non-selected option quotes are still counted in diagnostics but do not make the self-check choose them as the critical probe when selected symbols are healthy.
- `tests/core/test_runtime_self_checker_freshness.py`
  - Added a regression test where selected CE/PE and spot are fresh while a non-selected option is stale; expected result remains `partial_stale_ignored`.

## What did not change

- No market-data ownership change.
- No history hydration fetch path change.
- No DataHub history cache or broker-history access added.
- No strategy scoring, risk, execution, order placement, or broker behavior changed.

## Validation

Commands run:

- `python -m pytest -q tests\core\test_runtime_self_checker_freshness.py`
- `python -m pytest -q tests\architecture\test_history_ownership.py tests\data\test_data_hub_freshness_sources.py tests\core\test_runtime_self_checker_freshness.py`
- `python -m compileall -q src\nifty_scalper_bot\core\app.py tests\core\test_runtime_self_checker_freshness.py`
- `python -m ruff check tests\core\test_runtime_self_checker_freshness.py`
- `git diff --check`

Results:

```text
focused pytest: passed
architecture/data/runtime freshness pytest: passed, 36 tests
touched-file compileall: passed
new test ruff: passed
git diff --check: passed
```

Repo-wide `ruff check src\nifty_scalper_bot\core\app.py` and `black --check src\nifty_scalper_bot\core\app.py` were not used as pass/fail gates because `app.py` has existing baseline formatting/lint debt unrelated to this change.

## Runtime impact

- startup: no startup ordering change
- market data: runtime self-check freshness criticality now follows selected basket instead of all cached options
- option hydration: unchanged
- strategy evaluation: reduces false freshness backoff from stale non-selected option quotes
- risk: unchanged
- execution: unchanged
- Telegram diagnostics: unchanged

## Regression risk

Low. The change is local to runtime self-check diagnostics/backoff selection and preserves the previous fallback to all tracked symbols when no selected critical symbols are present.