### PR TITLE
fix: fail closed without readiness requirements

### DIFF
--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -4420,7 +4420,6 @@ class MarketDataManager:
     ) -> dict[str, Any]:
         """Classify readiness into hard-trading and soft-spot states."""
         if not requirements:
-            any_ready = any(count >= min_bars for count in bars.values())
             spot_fresh = False
             try:
                 spot_fresh = bool(
@@ -4428,13 +4427,11 @@ class MarketDataManager:
                 )
             except Exception:
                 spot_fresh = False
-            missing: list[str] = []
-            if not any_ready:
-                missing.append("readiness_requirements_missing")
+            missing: list[str] = ["readiness_requirements_missing"]
             if not spot_fresh:
                 missing.append("fresh_spot_tick_missing")
             return {
-                "hard_ready": bool(any_ready),
+                "hard_ready": False,
                 "spot_ready": bool(spot_fresh),
                 "missing_hard": missing,
             }

--- a/tests/data/test_canonical_history_hydration.py
+++ b/tests/data/test_canonical_history_hydration.py
@@ -349,6 +349,18 @@ def test_historical_bar_writes_only_canonical_ohlc_not_raw_ticks() -> None:
     assert mdm.is_tick_ready("NSE:NIFTY") is False
 
 
+def test_missing_readiness_requirements_fail_closed_even_with_ready_bars() -> None:
+    mdm = _storage_mdm()
+    mdm._tick_stale_threshold_ms = 60_000
+    mdm._is_symbol_fresh = lambda *_a, **_k: True
+
+    state = mdm._readiness_state({"NFO:NIFTY26JUL24000CE": 5}, 2, {})
+
+    assert state["hard_ready"] is False
+    assert state["spot_ready"] is True
+    assert state["missing_hard"] == ["readiness_requirements_missing"]
+
+
 def test_feed_health_uses_selected_options_not_context_option_staleness() -> None:
     mdm = _storage_mdm()
     now = time.time()


### PR DESCRIPTION
﻿## Root cause

`MarketDataManager._readiness_state` in `src/nifty_scalper_bot/data/market_data_manager.py` had a fallback path for missing readiness requirements that could return `hard_ready=True` when any subscribed symbol had enough raw tick history. That duplicated the canonical selected CE/PE readiness decision and could make the data pipeline appear trading-ready without explicit spot/selected-option requirements.

## What changed

- `src/nifty_scalper_bot/data/market_data_manager.py`
  - Missing readiness requirements now fail closed with `hard_ready=False`.
  - `readiness_requirements_missing` is always reported in `missing_hard` for that fallback path.
  - Spot freshness is preserved as diagnostic `spot_ready` only.
- `tests/data/test_canonical_history_hydration.py`
  - Added a regression test proving ready bars cannot make MDM hard-ready when canonical requirements are absent.

## What did not change

- No contract selection logic changed.
- No history ownership or hydration fetch path changed.
- No DataHub behavior changed.
- No strategy scoring, risk, execution, broker, or Telegram behavior changed.

## Validation

Commands run:

- `python -m pytest -q tests\data\test_canonical_history_hydration.py -k missing_readiness_requirements`
  - pre-fix: failed as expected with `assert True is False`
- `python -m pytest -q tests\data\test_canonical_history_hydration.py -k "missing_readiness_requirements or feed_health_uses_selected_options"`
- `python -m pytest -q tests\data\test_canonical_history_hydration.py tests\architecture\test_history_ownership.py tests\data\test_data_hub_freshness_sources.py`
- `python -m compileall -q src\nifty_scalper_bot\data\market_data_manager.py tests\data\test_canonical_history_hydration.py`
- `git diff --check`

Results:

```text
focused regression: passed
focused data/history suites: passed
compileall touched files: passed
git diff --check: passed
```

## Runtime impact

- startup: missing readiness setup remains blocked instead of falling through to hard-ready
- market data: readiness now requires canonical requirements before hard-ready can be true
- option hydration: unchanged
- strategy evaluation: avoids false green data readiness when selected option requirements were never installed
- risk: unchanged
- execution: unchanged
- Telegram diagnostics: unchanged

## Regression risk

Low to medium. This is intentionally stricter when requirements are missing. It should only affect miswired startup/readiness states that were previously capable of appearing hard-ready without selected CE/PE requirements.
