### PR TITLE
fix: delegate assess freshness to datahub

### DIFF
--- a/src/nifty_scalper_bot/data/assess_data.py
+++ b/src/nifty_scalper_bot/data/assess_data.py
@@ -64,6 +64,17 @@ def assess_datahub_fresh(
         if freshness_ms is None:
             raise TypeError("freshness_ms is required for single-symbol mode")
 
+        is_fresh = getattr(hub, "is_fresh", None)
+        if callable(is_fresh):
+            ok, meta = is_fresh(symbols, threshold_ms=float(freshness_ms))
+            payload = dict(meta or {})
+            payload.setdefault("symbol", symbols)
+            payload.setdefault("limit_ms", freshness_ms)
+            if "age_ms" not in payload and "effective_ms" in payload:
+                payload["age_ms"] = payload.get("effective_ms")
+            detail = str(payload.get("reason") or "ok")
+            return bool(ok), detail, payload
+
         quote = hub.get_quote(symbols, allow_pull=False)
         if not quote:
             return False, "no_quote", {"symbol": symbols}

--- a/tests/data/test_assess_data_freshness.py
+++ b/tests/data/test_assess_data_freshness.py
@@ -1,0 +1,31 @@
+from nifty_scalper_bot.data.assess_data import assess_datahub_fresh
+
+
+class _CanonicalHub:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, float]] = []
+
+    def is_fresh(self, symbol: str, *, threshold_ms: float):
+        self.calls.append((symbol, threshold_ms))
+        return False, {
+            "symbol": symbol,
+            "reason": "stale",
+            "effective_ms": threshold_ms + 1.0,
+            "threshold_ms": threshold_ms,
+            "source": "historical",
+        }
+
+    def get_quote(self, *_args, **_kwargs):
+        raise AssertionError("canonical is_fresh should own freshness")
+
+
+def test_assess_datahub_fresh_delegates_single_symbol_to_datahub_is_fresh() -> None:
+    hub = _CanonicalHub()
+
+    ok, detail, meta = assess_datahub_fresh(hub, "NSE:NIFTY", 60_000)
+
+    assert ok is False
+    assert detail == "stale"
+    assert hub.calls == [("NSE:NIFTY", 60_000.0)]
+    assert meta["source"] == "historical"
+    assert meta["age_ms"] == 60_001.0


### PR DESCRIPTION
﻿## Root cause

`assess_datahub_fresh` in `src/nifty_scalper_bot/data/assess_data.py` kept its own single-symbol timestamp parsing and age decision even when the object was a `DataHub` with canonical `is_fresh`. Telegram/selftest callers could therefore see freshness diagnostics that were not using the same source/age semantics as the runtime data layer.

## What changed

- `src/nifty_scalper_bot/data/assess_data.py`
  - Single-symbol compatibility mode now delegates to `hub.is_fresh(symbol, threshold_ms=...)` when available.
  - Preserves `age_ms` as an alias for `effective_ms` for existing Telegram/selftest display callers.
  - Keeps the old manual timestamp fallback for objects without `is_fresh`.
- `tests/data/test_assess_data_freshness.py`
  - Added a regression test proving `assess_datahub_fresh` uses `DataHub.is_fresh` and does not read `get_quote` directly when canonical freshness is available.

## What did not change

- No DataHub freshness rules changed.
- No MDM history/hydration path changed.
- No contract selection, strategy scoring, risk, execution, broker, or Telegram command behavior changed beyond using canonical freshness metadata.

## Validation

Commands run:

- `python -m pytest -q tests\data\test_assess_data_freshness.py tests\data\test_data_hub_freshness_sources.py`
- `python -m pytest -q tests\data\test_assess_data_freshness.py tests\data\test_data_hub_freshness_sources.py tests\core\test_runtime_self_checker_freshness.py`
- `python -m compileall -q src\nifty_scalper_bot\data\assess_data.py tests\data\test_assess_data_freshness.py`
- `git diff --check`

Results:

```text
focused data freshness tests: passed
runtime freshness compatibility tests: passed
compileall touched files: passed
git diff --check: passed
```

## Runtime impact

- startup: unchanged
- market data: compatibility assessments now share DataHub freshness SSOT where available
- option hydration: unchanged
- strategy evaluation: unchanged
- risk: unchanged
- execution: unchanged
- Telegram/selftest diagnostics: freshness detail now reflects DataHub canonical metadata

## Regression risk

Low. The fallback path remains for non-DataHub objects, and existing callers still receive `age_ms` when DataHub reports `effective_ms`.
