### PR TITLE
fix: canonicalize polling fallback decision

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -339,18 +339,21 @@ def _polling_fallback_degraded(
     lagging: bool,
     futures_fresh: bool,
     options_fresh: bool,
+    quote_stale_ms: float = 120000.0,
+    feed_health: Mapping[str, Any] | None = None,
+    data_age_ms: float | None = None,
 ) -> bool:
-    """Evaluate fallback degrade state using trading-critical feed health."""
+    """Runtime boolean wrapper around the canonical polling fallback decision."""
 
-    if not ws_ok:
-        return True
-    if lagging:
-        return True
-    if not futures_fresh:
-        return True
-    if not options_fresh:
-        return True
-    return False
+    return decide_polling_fallback(
+        ws_ok=ws_ok,
+        lagging=lagging,
+        futures_fresh=futures_fresh,
+        options_fresh=options_fresh,
+        quote_stale_ms=quote_stale_ms,
+        feed_health=feed_health,
+        data_age_ms=data_age_ms,
+    ).activate
 
 
 
@@ -408,12 +411,31 @@ async def _polling_failover_supervisor_iteration(
 
     ws_ok = bool(_safe_supervisor_call("websocket_manager.is_connected", getattr(getattr(ctx, "websocket_manager", None), "is_connected", None), default=False))
     mdm = getattr(ctx, "market_data_manager", None)
-    feed_health = _safe_supervisor_call(
-        "market_data_manager.trading_feed_health",
-        getattr(mdm, "trading_feed_health", None),
-        max_age_ms=quote_stale_ms,
-        default={},
-    )
+    feed_health_getter = getattr(mdm, "trading_feed_health", None)
+    if callable(feed_health_getter):
+        try:
+            feed_health = feed_health_getter(max_age_ms=quote_stale_ms)
+        except TypeError:
+            try:
+                feed_health = feed_health_getter()
+            except Exception as exc:
+                LOGGER.warning(
+                    "POLLING_FALLBACK_HEALTH_FAILED error_type=%s error=%s",
+                    type(exc).__name__,
+                    exc,
+                    extra={"event": "POLLING_FALLBACK_HEALTH_FAILED", "error_type": type(exc).__name__, "error": str(exc)},
+                )
+                feed_health = {}
+        except Exception as exc:
+            LOGGER.warning(
+                "POLLING_FALLBACK_HEALTH_FAILED error_type=%s error=%s",
+                type(exc).__name__,
+                exc,
+                extra={"event": "POLLING_FALLBACK_HEALTH_FAILED", "error_type": type(exc).__name__, "error": str(exc)},
+            )
+            feed_health = {}
+    else:
+        feed_health = {}
     if not isinstance(feed_health, Mapping):
         feed_health = {}
     futures_fresh = bool(feed_health.get("futures_fresh"))
@@ -421,78 +443,52 @@ async def _polling_failover_supervisor_iteration(
     spot_fresh = bool(feed_health.get("spot_fresh"))
     spot_symbol = str(feed_health.get("spot_symbol") or "NSE:NIFTY")
     spot_age_ms = feed_health.get("spot_age_ms")
-    futures_age_ms = feed_health.get("futures_age_ms")
-    options_age_ms = feed_health.get("options_age_ms")
     auth_tick_age_ms = _safe_supervisor_call("market_data_manager.data_age_ms", getattr(mdm, "data_age_ms", None), default=quote_stale_ms + 1)
     try:
         lagging = float(auth_tick_age_ms) > float(quote_stale_ms)
     except (TypeError, ValueError):
         lagging = True
-    degraded = _polling_fallback_degraded(
+    try:
+        decision_data_age_ms = float(auth_tick_age_ms) if auth_tick_age_ms is not None else None
+    except (TypeError, ValueError):
+        decision_data_age_ms = None
+    decision = decide_polling_fallback(
         ws_ok=ws_ok,
         lagging=lagging,
         futures_fresh=futures_fresh,
         options_fresh=options_fresh,
+        quote_stale_ms=quote_stale_ms,
+        feed_health=feed_health,
+        data_age_ms=decision_data_age_ms,
     )
-    if degraded:
+    if decision.activate:
         recovered_since = None
         degraded_since = degraded_since or now_mono
         running = bool(_safe_supervisor_call("polling_fallback.is_running", getattr(polling_fallback, "is_running", None), default=False))
         if now_mono - degraded_since >= activate_after and not running:
-            stale_age_ms = options_age_ms if not options_fresh else futures_age_ms if not futures_fresh else spot_age_ms
-            try:
-                stale_age_within_threshold = (
-                    stale_age_ms is not None and float(stale_age_ms) < float(quote_stale_ms)
-                )
-            except (TypeError, ValueError):
-                stale_age_within_threshold = False
-            if ws_ok and not lagging and stale_age_within_threshold:
-                _fallback_reason = "futures_stale" if not futures_fresh else "options_stale" if not options_fresh else "within_stale_threshold"
-                log_throttled(
-                    LOGGER,
-                    f"polling_fallback_skipped:{spot_symbol}:{_fallback_reason}:within_threshold",
-                    "POLLING_FALLBACK_SKIPPED reason=%s age_ms=%s threshold_ms=%s ws_ok=%s"
-                    % (_fallback_reason, stale_age_ms, quote_stale_ms, ws_ok),
-                    interval_sec=60.0,
-                    level=logging.INFO,
-                    extra={
-                        "event": "POLLING_FALLBACK_SKIPPED",
-                        "reason": _fallback_reason,
-                        "age_ms": stale_age_ms,
-                        "threshold_ms": quote_stale_ms,
-                        "ws_ok": ws_ok,
-                    },
-                )
-                return degraded_since, recovered_since
-            if (
-                spot_age_ms is not None
-                and float(spot_age_ms) <= float(quote_stale_ms)
-                and ws_ok
-                and spot_fresh
-                and futures_fresh
-                and options_fresh
-                and not lagging
-            ):
-                log_throttled(
-                    LOGGER,
-                    f"polling_fallback_skipped:{spot_symbol}:within_spot_stale_threshold",
-                    "POLLING_FALLBACK_SKIPPED reason=within_spot_stale_threshold age_ms=%s threshold_ms=%s ws_ok=%s" % (spot_age_ms, quote_stale_ms, ws_ok),
-                    interval_sec=60.0,
-                    level=logging.INFO,
-                    extra={"event": "POLLING_FALLBACK_SKIPPED", "reason": "within_spot_stale_threshold", "age_ms": spot_age_ms, "threshold_ms": quote_stale_ms, "ws_ok": ws_ok},
-                )
-                return degraded_since, recovered_since
-            _fallback_reason = "ws_disconnected" if not ws_ok else "tick_lag" if lagging else "futures_stale" if not futures_fresh else "options_stale"
             log_state_change(
                 LOGGER,
                 "POLLING_FALLBACK_ACTIVATE",
-                (_fallback_reason, ws_ok, lagging, futures_fresh, options_fresh),
+                (decision.reason, ws_ok, lagging, futures_fresh, options_fresh),
                 level=logging.WARNING,
-                msg="POLLING_FALLBACK_ACTIVATE reason=%s age_ms=%s threshold_ms=%s ws_ok=%s lagging=%s" % (_fallback_reason, spot_age_ms, quote_stale_ms, ws_ok, lagging),
-                extra={"event": "poll_fallback_activate", "reason": _fallback_reason, "lagging": lagging, "futures_fresh": futures_fresh, "options_fresh": options_fresh, "authoritative_age_ms": auth_tick_age_ms},
+                msg="POLLING_FALLBACK_ACTIVATE reason=%s age_ms=%s threshold_ms=%s ws_ok=%s lagging=%s" % (decision.reason, decision.max_age_ms, quote_stale_ms, ws_ok, lagging),
+                extra={"event": "poll_fallback_activate", "reason": decision.reason, "lagging": lagging, "futures_fresh": futures_fresh, "options_fresh": options_fresh, "authoritative_age_ms": auth_tick_age_ms},
             )
-            _safe_supervisor_call("polling_fallback.set_websocket_mode", getattr(polling_fallback, "set_websocket_mode", None), False)
-            _safe_supervisor_call("polling_fallback.start", getattr(polling_fallback, "start", None))
+            try:
+                mode_fn = getattr(polling_fallback, "set_websocket_mode", None)
+                if callable(mode_fn):
+                    mode_fn(False)
+                start_fn = getattr(polling_fallback, "start", None)
+                if callable(start_fn):
+                    start_fn()
+            except Exception as exc:
+                LOGGER.warning(
+                    "POLLING_FALLBACK_START_FAILED reason=%s error_type=%s error=%s",
+                    decision.reason,
+                    type(exc).__name__,
+                    exc,
+                    extra={"event": "POLLING_FALLBACK_START_FAILED", "reason": decision.reason, "error_type": type(exc).__name__, "error": str(exc)},
+                )
         return degraded_since, recovered_since
 
     if not spot_fresh:
@@ -1199,6 +1195,7 @@ from nifty_scalper_bot.config.settings import Settings, get_settings
 from nifty_scalper_bot.core.market_regime_manager import MarketRegimeManager
 from nifty_scalper_bot.core.message_bus import Message, MessageBus, MessageType
 from nifty_scalper_bot.core.option_universe import OptionUniverseManager
+from nifty_scalper_bot.core.polling_failover import decide_polling_fallback
 from nifty_scalper_bot.core.strategy_manager import StrategyManager
 from nifty_scalper_bot.core.unified_manager import UnifiedManager
 from nifty_scalper_bot.core.universe_controller import UniverseController

--- a/src/nifty_scalper_bot/core/polling_failover_runtime.py
+++ b/src/nifty_scalper_bot/core/polling_failover_runtime.py
@@ -267,6 +267,15 @@ def apply_app_patch(app_module: Any) -> bool:
     _APP_MODULE_REF = app_module
     if bool(getattr(app_module, _PATCH_ATTR, False)):
         return False
+    degraded = getattr(app_module, "_polling_fallback_degraded", None)
+    supervisor = getattr(app_module, "_polling_failover_supervisor_iteration", None)
+    try:
+        degraded_params = inspect.signature(degraded).parameters if callable(degraded) else {}
+    except (TypeError, ValueError):
+        degraded_params = {}
+    if callable(supervisor) and "quote_stale_ms" in degraded_params:
+        setattr(app_module, _PATCH_ATTR, True)
+        return True
 
     async def _installed_polling_failover_supervisor_iteration(
         ctx: Any,

--- a/tests/core/test_import_safety.py
+++ b/tests/core/test_import_safety.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib
+import inspect
 import sys
 
 
@@ -25,6 +26,8 @@ def test_direct_core_app_import_applies_polling_patch_without_lazy_getattr() -> 
 
     assert getattr(app_module, "_polling_failover_runtime_patch_installed", False) is True
     assert callable(getattr(app_module, "_polling_failover_supervisor_iteration", None))
+    assert app_module._polling_fallback_degraded.__module__ == app_module.__name__
+    assert "quote_stale_ms" in inspect.signature(app_module._polling_fallback_degraded).parameters
 
 
 def test_core_lazy_app_resolution_applies_polling_patch() -> None:


### PR DESCRIPTION
﻿## Root cause

Polling fallback readiness had two decision paths:

- `src/nifty_scalper_bot/core/polling_failover.py::decide_polling_fallback` contained the age-gated canonical decision.
- `src/nifty_scalper_bot/core/app.py::_polling_failover_supervisor_iteration` still carried an older boolean degradation path and manual age gate, while `polling_failover_runtime.py` silently replaced app functions at import time.

That made the active behavior depend on an import-time runtime patch instead of the app runtime path itself.

## What changed

- `src/nifty_scalper_bot/core/app.py`
  - `_polling_fallback_degraded` now delegates to `decide_polling_fallback`.
  - `_polling_failover_supervisor_iteration` now uses `decide_polling_fallback` directly for activation reason and age threshold handling.
  - Preserved existing health-call compatibility and failure logs (`POLLING_FALLBACK_HEALTH_FAILED`, `POLLING_FALLBACK_START_FAILED`).
- `src/nifty_scalper_bot/core/polling_failover_runtime.py`
  - Runtime patch now only marks itself installed when app already exposes canonical helpers, instead of replacing app functions.
  - Legacy patch fallback remains for non-canonical app-like objects used by compatibility tests.
- `tests/core/test_import_safety.py`
  - Added assertion that direct app import keeps `_polling_fallback_degraded` owned by `core.app` and accepts `quote_stale_ms`.

## What did not change

- No MDM feed-health calculation changed.
- No WebSocket, polling client, broker, strategy, risk, order placement, or Telegram behavior changed.
- No broad lint/format pass was run.

## Validation

Commands run:

- `python -m pytest -q tests\core\test_polling_failover.py tests\streaming\test_stream_supervisor_fallback.py tests\core\test_import_safety.py tests\test_import_hook_idempotency.py tests\core\test_runtime_install_proof.py`
- `python -m compileall -q src\nifty_scalper_bot\core\app.py src\nifty_scalper_bot\core\polling_failover.py src\nifty_scalper_bot\core\polling_failover_runtime.py tests\core\test_import_safety.py`
- `git diff --check`

Results:

```text
polling fallback/import focused tests: passed, 30 tests
compileall touched files: passed
git diff --check: passed
```

## Runtime impact

- startup: app import still reports polling runtime patch installed for compatibility proof
- market data: unchanged
- WS/polling fallback: activation uses one canonical age-gated decision in `core.polling_failover`
- option hydration: unchanged
- strategy evaluation: avoids false polling fallback activation from duplicate stale-flag logic
- risk: unchanged
- execution: unchanged

## Regression risk

Medium-low. The active decision logic is already covered by existing polling fallback tests; this PR moves app onto that canonical helper and preserves failure logging expected by supervisor tests.
