### PR TITLE
fix: canonicalize datahub timestamp quality

### DIFF
--- a/src/nifty_scalper_bot/data/data_hub.py
+++ b/src/nifty_scalper_bot/data/data_hub.py
@@ -53,6 +53,63 @@ LOGGER = logging.getLogger(__name__)
 Tick = Dict[str, Any]
 TickListener = Callable[[Tick], None]
 OrderListener = Callable[[dict[str, Any]], None]
+_UNUSABLE_TIMESTAMP_QUALITIES = {"synthetic", "unknown", "invalid"}
+_WS_SOURCES = {"ws", "websocket", "stream"}
+
+
+def _valid_timestamp_ms(value: Any) -> float | None:
+    if value is None or value == "":
+        return None
+    try:
+        if isinstance(value, datetime):
+            ts = pd.Timestamp(value)
+        elif isinstance(value, (int, float)):
+            raw = float(value)
+            if raw <= 0:
+                return None
+            seconds = raw / 1000.0 if raw > 1e11 else raw
+            ts = pd.Timestamp(datetime.fromtimestamp(seconds, tz=timezone.utc))
+        else:
+            ts = pd.to_datetime(value, utc=True, errors="coerce")
+        if pd.isna(ts) or getattr(ts, "year", 1970) < 2020:
+            return None
+        return float(pd.Timestamp(ts).timestamp() * 1000.0)
+    except Exception:
+        return None
+
+
+def _timestamp_quality(payload: Mapping[str, Any]) -> str:
+    explicit = str(payload.get("timestamp_quality") or "").strip().lower()
+    if explicit:
+        return explicit
+    if _valid_timestamp_ms(payload.get("exchange_timestamp")) is not None:
+        return "exchange"
+    if _valid_timestamp_ms(payload.get("timestamp")) is not None:
+        return "broker"
+    if _valid_timestamp_ms(payload.get("received_at")) is not None:
+        return "received_at"
+    if any(
+        key in payload
+        for key in ("exchange_timestamp", "timestamp", "received_at")
+    ):
+        return "invalid"
+    return "synthetic"
+
+
+def _quote_timestamp_ms(payload: Mapping[str, Any]) -> float | None:
+    for key in ("timestamp_ms", "exchange_timestamp", "timestamp", "received_at"):
+        value = payload.get(key)
+        if key == "timestamp_ms":
+            try:
+                parsed = float(value)
+            except (TypeError, ValueError):
+                parsed = None
+            if parsed is not None and parsed > 0:
+                return parsed if parsed > 1e11 else parsed * 1000.0
+        parsed = _valid_timestamp_ms(value)
+        if parsed is not None:
+            return parsed
+    return None
 
 
 class SubscriptionState(str, Enum):
@@ -823,8 +880,6 @@ class DataHub:
         payload["source"] = source
         if seed:
             payload["seed"] = True
-        if "timestamp" not in payload:
-            payload["timestamp"] = pd.Timestamp.utcnow().isoformat()
         self._ingest_tick_impl(payload)
 
     def _normalize_tick_symbol(self, tick: Tick) -> str:
@@ -866,6 +921,7 @@ class DataHub:
     def _canonicalize_tick_payload(self, payload: Mapping[str, Any]) -> dict[str, Any] | None:
         """Args: payload. Returns: canonicalized tick or None. Raises: None."""
         tick = dict(payload)
+        timestamp_quality = _timestamp_quality(tick)
         symbol = str(tick.get("symbol") or "").strip()
         token_raw = tick.get("instrument_token") or tick.get("token")
         price_raw = tick.get("ltp") or tick.get("last_price") or tick.get("price")
@@ -902,6 +958,12 @@ class DataHub:
             tick["tradable_quote"] = True
         else:
             tick.setdefault("tradable_quote", False)
+        if timestamp_quality in _UNUSABLE_TIMESTAMP_QUALITIES:
+            tick["synthetic_timestamp"] = True
+            tick["hard_readiness_eligible"] = False
+            tick["tradable_quote"] = False
+        else:
+            tick.setdefault("hard_readiness_eligible", True)
         tick.setdefault("quote_source", tick.get("source"))
         tick.update(
             {
@@ -912,6 +974,7 @@ class DataHub:
                 "last_price": price,
                 "timestamp": ts_iso,
                 "timestamp_ms": ts_ms,
+                "timestamp_quality": timestamp_quality,
                 "received_at": received_at,
             }
         )
@@ -1695,6 +1758,20 @@ class DataHub:
         quote = self.get_quote(symbol, allow_pull=False)
         if not quote:
             return None
+        quality = str(quote.get("timestamp_quality") or "").strip().lower()
+        guarded = bool(require_ws or max_age_seconds is not None)
+        if guarded and quality in _UNUSABLE_TIMESTAMP_QUALITIES:
+            return None
+        quote_source = str(quote.get("source") or "").strip().lower()
+        if require_ws and quote_source not in _WS_SOURCES:
+            return None
+        if max_age_seconds is not None:
+            ts_ms = _quote_timestamp_ms(quote)
+            if ts_ms is None:
+                return None
+            age_s = max(0.0, time.time() - (ts_ms / 1000.0))
+            if age_s > max(0.0, float(max_age_seconds)):
+                return None
         return self._tick_price(quote)
 
 

--- a/src/nifty_scalper_bot/data/data_hub_synthetic_guard.py
+++ b/src/nifty_scalper_bot/data/data_hub_synthetic_guard.py
@@ -52,7 +52,9 @@ def _timestamp_quality(payload: Mapping[str, Any]) -> str:
         return "broker"
     if _valid_timestamp_ms(payload.get("received_at")) is not None:
         return "received_at"
-    if any(key in payload for key in ("exchange_timestamp", "timestamp", "received_at")):
+    if any(
+        key in payload for key in ("exchange_timestamp", "timestamp", "received_at")
+    ):
         return "invalid"
     return "synthetic"
 
@@ -98,20 +100,53 @@ def install_datahub_synthetic_timestamp_guard(datahub_cls: type[Any]) -> bool:
 
     if bool(getattr(datahub_cls, _PATCH_ATTR, False)):
         return False
+    native_module = "nifty_scalper_bot.data.data_hub"
+    store_quote_module = getattr(
+        getattr(datahub_cls, "store_quote", None), "__module__", ""
+    )
+    canonicalize_module = getattr(
+        getattr(datahub_cls, "_canonicalize_tick_payload", None), "__module__", ""
+    )
+    cached_ltp_module = getattr(
+        getattr(datahub_cls, "get_cached_ltp", None), "__module__", ""
+    )
+    if (
+        store_quote_module == native_module
+        and canonicalize_module == native_module
+        and cached_ltp_module == native_module
+    ):
+        setattr(datahub_cls, _PATCH_ATTR, True)
+        return False
     originals = {
         "store_quote": getattr(datahub_cls, "store_quote"),
-        "_canonicalize_tick_payload": getattr(datahub_cls, "_canonicalize_tick_payload"),
+        "_canonicalize_tick_payload": getattr(
+            datahub_cls, "_canonicalize_tick_payload"
+        ),
         "get_cached_ltp": getattr(datahub_cls, "get_cached_ltp"),
     }
 
-    def store_quote(self: Any, symbol: str, quote_data: dict[str, Any], source: str = "ws", seed: bool = False) -> None:
+    def store_quote(
+        self: Any,
+        symbol: str,
+        quote_data: dict[str, Any],
+        source: str = "ws",
+        seed: bool = False,
+    ) -> None:
         payload = dict(quote_data or {})
-        if not any(payload.get(key) not in (None, "") for key in ("exchange_timestamp", "timestamp", "received_at", "timestamp_quality")):
+        time_keys = (
+            "exchange_timestamp",
+            "timestamp",
+            "received_at",
+            "timestamp_quality",
+        )
+        if not any(payload.get(key) not in (None, "") for key in time_keys):
             payload["timestamp_quality"] = "synthetic"
             payload["synthetic_timestamp"] = True
         return originals["store_quote"](self, symbol, payload, source=source, seed=seed)
 
-    def _canonicalize_tick_payload(self: Any, payload: Mapping[str, Any]) -> dict[str, Any] | None:
+    def _canonicalize_tick_payload(
+        self: Any, payload: Mapping[str, Any]
+    ) -> dict[str, Any] | None:
         input_payload = dict(payload or {})
         quality = _timestamp_quality(input_payload)
         tick = originals["_canonicalize_tick_payload"](self, input_payload)
@@ -135,7 +170,9 @@ def install_datahub_synthetic_timestamp_guard(datahub_cls: type[Any]) -> bool:
     ) -> float | None:
         mdm_cached = getattr(getattr(self, "_mdm", None), "get_cached_ltp", None)
         if callable(mdm_cached):
-            return mdm_cached(symbol, max_age_seconds=max_age_seconds, require_ws=require_ws)
+            return mdm_cached(
+                symbol, max_age_seconds=max_age_seconds, require_ws=require_ws
+            )
         quote = self.get_quote(symbol, allow_pull=False)
         if not quote:
             return None
@@ -143,7 +180,8 @@ def install_datahub_synthetic_timestamp_guard(datahub_cls: type[Any]) -> bool:
         guarded = bool(require_ws or max_age_seconds is not None)
         if guarded and quality in _UNUSABLE_TIMESTAMP_QUALITIES:
             return None
-        if require_ws and str(quote.get("source") or "").strip().lower() not in _WS_SOURCES:
+        quote_source = str(quote.get("source") or "").strip().lower()
+        if require_ws and quote_source not in _WS_SOURCES:
             return None
         if max_age_seconds is not None:
             ts_ms = _quote_timestamp_ms(quote)

--- a/tests/data/test_datahub_import_safety.py
+++ b/tests/data/test_datahub_import_safety.py
@@ -6,7 +6,9 @@ import sys
 
 def _reset_data_modules() -> None:
     for name in list(sys.modules):
-        if name == "nifty_scalper_bot.data" or name.startswith("nifty_scalper_bot.data.data_hub"):
+        if name == "nifty_scalper_bot.data" or name.startswith(
+            "nifty_scalper_bot.data.data_hub"
+        ):
             sys.modules.pop(name, None)
 
 
@@ -23,7 +25,15 @@ def test_direct_datahub_import_installs_synthetic_timestamp_guard() -> None:
 
     module = importlib.import_module("nifty_scalper_bot.data.data_hub")
 
-    assert getattr(module.DataHub, "_synthetic_timestamp_guard_installed", False) is True
+    assert (
+        getattr(module.DataHub, "_synthetic_timestamp_guard_installed", False) is True
+    )
+    assert module.DataHub.store_quote.__module__ == "nifty_scalper_bot.data.data_hub"
+    assert (
+        module.DataHub._canonicalize_tick_payload.__module__
+        == "nifty_scalper_bot.data.data_hub"
+    )
+    assert module.DataHub.get_cached_ltp.__module__ == "nifty_scalper_bot.data.data_hub"
 
 
 def test_direct_datahub_import_synthetic_quote_is_guarded() -> None:


### PR DESCRIPTION
## Root cause

`DataHub.store_quote`, `DataHub._canonicalize_tick_payload`, and `DataHub.get_cached_ltp` depended on `data_hub_synthetic_guard.install_datahub_synthetic_timestamp_guard()` to wrap class methods after import. That left timestamp-quality readiness behavior outside the owning `data_hub.py` quote normalization path, while missing/invalid broker timestamps were still converted to current time before the wrapper marked them unusable.

## What changed

- `src/nifty_scalper_bot/data/data_hub.py`
  - Classifies quote timestamp quality natively as `exchange`, `broker`, `received_at`, `invalid`, or `synthetic`.
  - Stops `store_quote()` from pre-filling missing timestamps as fresh broker time.
  - Marks synthetic/invalid/unknown timestamp quotes as not hard-readiness eligible and not tradable.
  - Applies the same timestamp-quality/source/age guard in `get_cached_ltp()` when `max_age_seconds` or `require_ws` is requested.
- `src/nifty_scalper_bot/data/data_hub_synthetic_guard.py`
  - Keeps backward-compatible wrapper fallback for noncanonical DataHub-like classes.
  - For native `DataHub`, only marks the guard as installed instead of replacing methods.
- `tests/data/test_datahub_import_safety.py`
  - Adds a regression proving direct `DataHub` import retains native method ownership while still guarding synthetic quotes.

## What did not change

- No contract selection changes.
- No MDM history owner changes.
- No strategy, risk, execution, Telegram, broker, or WebSocket restart behavior changes.
- No new dependencies.

## Validation

Commands run:

- `python -m pytest -q tests\\data\\test_datahub_synthetic_timestamp_guard.py tests\\data\\test_datahub_import_safety.py tests\\data\\test_market_data_hardening.py tests\\test_import_hook_idempotency.py tests\\core\\test_runtime_install_proof.py`
- `python -m compileall -q src\\nifty_scalper_bot\\data\\data_hub.py src\\nifty_scalper_bot\\data\\data_hub_synthetic_guard.py tests\\data\\test_datahub_import_safety.py`
- `python -m ruff check src\\nifty_scalper_bot\\data\\data_hub_synthetic_guard.py tests\\data\\test_datahub_import_safety.py`
- `python -m black --check src\\nifty_scalper_bot\\data\\data_hub_synthetic_guard.py tests\\data\\test_datahub_import_safety.py`
- `git diff --check`

Results:

```text
20 passed
compileall passed
ruff changed compatibility/test files passed
black compatibility/test files passed
git diff --check passed
```

Note: `python -m ruff check src\\nifty_scalper_bot\\data\\data_hub.py ...` reports pre-existing repo-wide/data_hub line-length/import-format debt outside this patch, so validation was kept to focused tests plus diff/compile and ruff/black on the small touched compatibility/test files.

## Runtime impact

- startup: direct DataHub import still reports synthetic timestamp guard installed.
- market data: missing/invalid quote timestamps are retained for diagnostics but cannot masquerade as fresh hard-readiness proof.
- option hydration: unchanged; DataHub still delegates history/hydration ownership to MDM.
- strategy evaluation: unchanged except guarded cached LTP will reject synthetic/invalid timestamp quotes when freshness is requested.
- risk: unchanged.
- execution: unchanged.
- Telegram diagnostics: unchanged.

## Regression risk

Low to medium. The changed behavior is limited to timestamp-quality metadata and guarded cached-LTP reads. Existing synthetic timestamp, import safety, market data hardening, import hook idempotency, and runtime proof tests cover the intended path.