### PR TITLE
fix: keep quote identity native to datahub

### DIFF
--- a/src/nifty_scalper_bot/data/data_hub.py
+++ b/src/nifty_scalper_bot/data/data_hub.py
@@ -55,6 +55,13 @@ TickListener = Callable[[Tick], None]
 OrderListener = Callable[[dict[str, Any]], None]
 _UNUSABLE_TIMESTAMP_QUALITIES = {"synthetic", "unknown", "invalid"}
 _WS_SOURCES = {"ws", "websocket", "stream"}
+_QUOTE_IDENTITY_KEYS = (
+    "symbol",
+    "tradingsymbol",
+    "trading_symbol",
+    "instrument_symbol",
+    "exchange_symbol",
+)
 
 
 def _valid_timestamp_ms(value: Any) -> float | None:
@@ -110,6 +117,26 @@ def _quote_timestamp_ms(payload: Mapping[str, Any]) -> float | None:
         if parsed is not None:
             return parsed
     return None
+
+
+def _quote_symbol_hint(quote: Mapping[str, Any]) -> str:
+    for key in _QUOTE_IDENTITY_KEYS:
+        value = quote.get(key)
+        if isinstance(value, str) and value.strip():
+            return value
+    instrument = quote.get("instrument")
+    if isinstance(instrument, Mapping):
+        for key in _QUOTE_IDENTITY_KEYS:
+            value = instrument.get(key)
+            if isinstance(value, str) and value.strip():
+                return value
+    meta = quote.get("meta") or quote.get("metadata")
+    if isinstance(meta, Mapping):
+        for key in _QUOTE_IDENTITY_KEYS:
+            value = meta.get(key)
+            if isinstance(value, str) and value.strip():
+                return value
+    return ""
 
 
 class SubscriptionState(str, Enum):
@@ -656,6 +683,51 @@ class DataHub:
                     return int(self._quote_update_versions[mapped_symbol])
         return None
 
+    def _stamp_quote_identity(self, requested_symbol: object, quote: Any) -> Any:
+        if not isinstance(quote, Mapping):
+            return quote
+        stamped = dict(quote)
+        symbol = self._canonical_quote_symbol(
+            requested_symbol
+        ) or self._canonical_quote_symbol(
+            _quote_symbol_hint(stamped)
+        )
+        if not symbol:
+            return stamped
+        stamped["quote_identity_source"] = (
+            stamped.get("quote_identity_source") or "datahub_quote_contract"
+        )
+        stamped["symbol"] = symbol
+        stamped["tradingsymbol"] = symbol
+        stamped["trading_symbol"] = symbol
+        stamped["instrument_symbol"] = symbol
+        stamped["exchange_symbol"] = symbol
+        token = self._token_from_symbol(symbol)
+        if token is not None:
+            stamped["instrument_token"] = token
+            stamped["token"] = token
+        version = self.quote_update_version(symbol)
+        if version is not None:
+            stamped["quote_update_version"] = int(version)
+        quality = str(stamped.get("timestamp_quality") or "").strip().lower()
+        stamped["quote_identity_timestamp_source"] = quality or "unknown"
+        if quality in _UNUSABLE_TIMESTAMP_QUALITIES:
+            stamped["quote_identity_timestamp_rejected"] = True
+            return stamped
+        ts_ms = _quote_timestamp_ms(stamped)
+        if ts_ms is None:
+            stamped["quote_identity_timestamp_rejected"] = True
+            return stamped
+        stamped["last_tick_ts_ms"] = ts_ms
+        age_ms = max(0.0, self._now() * 1000.0 - ts_ms)
+        stamped["tick_age_ms"] = age_ms
+        stamped["quote_age_ms"] = age_ms
+        stamped["last_tick_age_ms"] = age_ms
+        stamped["market_data_age_ms"] = age_ms
+        stamped["quote_age_s"] = age_ms / 1000.0
+        stamped["last_tick_age_s"] = age_ms / 1000.0
+        stamped["market_data_age_s"] = age_ms / 1000.0
+        return stamped
 
     def _token_from_symbol(self, symbol: str) -> int | None:
         """Resolve instrument token from symbol aliases. Args: symbol. Returns: token. Raises: none."""
@@ -978,7 +1050,7 @@ class DataHub:
                 "received_at": received_at,
             }
         )
-        return to_json_safe(tick)
+        return to_json_safe(self._stamp_quote_identity(symbol, tick))
 
     def _tick_price(self, tick: dict[str, Any]) -> float | None:
         for key in ("ltp", "last_price", "price", "close"):
@@ -1293,19 +1365,19 @@ class DataHub:
                 tok = int(str(symbol).strip())
                 tick = self._ticks.get(tok) or self._token_quotes.get(tok)
                 if tick is not None:
-                    return dict(tick)
+                    return self._stamp_quote_identity(symbol, tick)
             token = self._token_by_symbol.get(lookup)
             if token is not None:
                 tick = self._ticks.get(token) or self._token_quotes.get(token)
                 if tick is not None:
-                    return dict(tick)
+                    return self._stamp_quote_identity(symbol, tick)
             tick = self._quotes.get(lookup)
             if tick is not None:
-                return dict(tick)
+                return self._stamp_quote_identity(symbol, tick)
             for alias in self._symbol_aliases.get(lookup, set()):
                 t = self._quotes.get(alias)
                 if t is not None:
-                    return dict(t)
+                    return self._stamp_quote_identity(symbol, t)
         if allow_pull:
             pulled = self.pull_quote(symbol) or None
             if pulled is not None:
@@ -1316,7 +1388,8 @@ class DataHub:
     def get_tick_by_token(self, token: int) -> Optional[Tick]:
         with self._lock:
             tick = self._ticks.get(token)
-            return dict(tick) if tick else None
+            symbol = self._symbol_by_token.get(int(token))
+            return self._stamp_quote_identity(symbol or token, tick) if tick else None
 
     def subscribe(self, symbol: str, callback: Optional[TickListener] = None):
         return self.subscribe_ticks(symbol, callback)

--- a/src/nifty_scalper_bot/data/quote_identity_extension.py
+++ b/src/nifty_scalper_bot/data/quote_identity_extension.py
@@ -116,15 +116,25 @@ def _now_ms(hub: Any) -> float:
     return time.time() * 1000.0
 
 
-def _received_at_ms(hub: Any, quote: Mapping[str, Any], *, now_ms: float) -> float | None:
-    for key in ("received_at", "arrival_time", "ingested_at", "updated_at", "last_update_time"):
+def _received_at_ms(
+    hub: Any, quote: Mapping[str, Any], *, now_ms: float
+) -> float | None:
+    for key in (
+        "received_at",
+        "arrival_time",
+        "ingested_at",
+        "updated_at",
+        "last_update_time",
+    ):
         value = _coerce_arrival_ms(quote.get(key))
         if value is not None and value <= now_ms + _future_grace_ms():
             return value
     return None
 
 
-def _resolve_quote_timestamp_ms(hub: Any, quote: Mapping[str, Any]) -> tuple[float | None, str]:
+def _resolve_quote_timestamp_ms(
+    hub: Any, quote: Mapping[str, Any]
+) -> tuple[float | None, str]:
     now_ms = _now_ms(hub)
     received_ms = _received_at_ms(hub, quote, now_ms=now_ms)
     candidates = (
@@ -151,8 +161,14 @@ def _resolve_quote_timestamp_ms(hub: Any, quote: Mapping[str, Any]) -> tuple[flo
 def stamp_quote_identity(hub: Any, requested_symbol: object, quote: Any) -> Any:
     if not isinstance(quote, Mapping):
         return quote
+    native = getattr(hub, "_stamp_quote_identity", None)
+    if callable(native):
+        with suppress(Exception):
+            return native(requested_symbol, quote)
     stamped = dict(quote)
-    symbol = _canonical(hub, requested_symbol) or _canonical(hub, _quote_symbol_hint(stamped))
+    symbol = _canonical(hub, requested_symbol) or _canonical(
+        hub, _quote_symbol_hint(stamped)
+    )
     if not symbol:
         return stamped
     stamped["symbol"] = symbol
@@ -170,6 +186,14 @@ def stamp_quote_identity(hub: Any, requested_symbol: object, quote: Any) -> Any:
             version = version_getter(symbol)
             if version is not None:
                 stamped["quote_update_version"] = int(version)
+    quality = str(stamped.get("timestamp_quality") or "").strip().lower()
+    if quality in {"synthetic", "unknown", "invalid"}:
+        stamped["quote_identity_timestamp_source"] = quality
+        stamped["quote_identity_timestamp_rejected"] = True
+        stamped["quote_identity_source"] = (
+            stamped.get("quote_identity_source") or "datahub_quote_contract"
+        )
+        return stamped
     ts_ms, ts_source = _resolve_quote_timestamp_ms(hub, stamped)
     stamped["quote_identity_timestamp_source"] = ts_source
     if ts_ms is not None:
@@ -184,7 +208,9 @@ def stamp_quote_identity(hub: Any, requested_symbol: object, quote: Any) -> Any:
         stamped["market_data_age_s"] = age_ms / 1000.0
     else:
         stamped["quote_identity_timestamp_rejected"] = True
-    stamped["quote_identity_source"] = stamped.get("quote_identity_source") or "datahub_quote_contract"
+    stamped["quote_identity_source"] = (
+        stamped.get("quote_identity_source") or "datahub_quote_contract"
+    )
     return stamped
 
 
@@ -196,11 +222,17 @@ def apply_patches() -> None:
     if cls is None or getattr(cls, "_quote_identity_contract_patch", False):
         _PATCH_APPLIED = True
         return
+    if callable(getattr(cls, "_stamp_quote_identity", None)):
+        cls._quote_identity_contract_patch = True
+        _PATCH_APPLIED = True
+        return
     _ORIGINALS["DataHub._canonicalize_tick_payload"] = cls._canonicalize_tick_payload
     _ORIGINALS["DataHub.get_quote"] = cls.get_quote
     _ORIGINALS["DataHub.get_tick_by_token"] = cls.get_tick_by_token
 
-    def _canonicalize_tick_payload(self: Any, payload: Mapping[str, Any]) -> dict[str, Any] | None:
+    def _canonicalize_tick_payload(
+        self: Any, payload: Mapping[str, Any]
+    ) -> dict[str, Any] | None:
         tick = _ORIGINALS["DataHub._canonicalize_tick_payload"](self, payload)
         if tick is None:
             return None

--- a/tests/data/test_quote_contract.py
+++ b/tests/data/test_quote_contract.py
@@ -16,6 +16,11 @@ class DummyMDM:
 def test_quote_contract_adds_identity_and_tick_age():
     hub = DataHub(DummyMDM(), clock=lambda: 1000.0)
     try:
+        assert DataHub.get_quote.__module__ == "nifty_scalper_bot.data.data_hub"
+        assert (
+            DataHub._canonicalize_tick_payload.__module__
+            == "nifty_scalper_bot.data.data_hub"
+        )
         hub.ingest_tick(
             {
                 "symbol": "NIFTY24JAN100CE",
@@ -30,12 +35,10 @@ def test_quote_contract_adds_identity_and_tick_age():
         assert quote["tradingsymbol"] == "NFO:NIFTY24JAN100CE"
         assert quote["instrument_token"] == 12345
         assert quote["quote_update_version"] == 1
-        assert quote["quote_identity_timestamp_source"] in {
-            "hub_clock_fallback",
-            "hub_clock_for_timestamp_future_guard",
-        }
-        assert quote["tick_age_ms"] == 0.0
-        assert quote["quote_age_s"] == 0.0
+        assert quote["timestamp_quality"] == "synthetic"
+        assert quote["quote_identity_timestamp_source"] == "synthetic"
+        assert "tick_age_ms" not in quote
+        assert "quote_age_s" not in quote
     finally:
         hub.close()
 
@@ -44,7 +47,9 @@ def test_quote_identity_falls_back_to_arrival_when_timestamp_is_future():
     now_epoch = 1_783_415_880.0  # 2026-07-07 14:48 IST
     hub = SimpleNamespace(
         _now=lambda: now_epoch,
-        _canonical_quote_symbol=lambda symbol: f"NFO:{symbol}" if ":" not in str(symbol) else str(symbol),
+        _canonical_quote_symbol=lambda symbol: (
+            f"NFO:{symbol}" if ":" not in str(symbol) else str(symbol)
+        ),
         quote_update_version=lambda _symbol: 7,
     )
     quote = {
@@ -58,6 +63,9 @@ def test_quote_identity_falls_back_to_arrival_when_timestamp_is_future():
     stamped = stamp_quote_identity(hub, "NIFTY24JAN100CE", quote)
 
     assert stamped["quote_update_version"] == 7
-    assert stamped["quote_identity_timestamp_source"] == "received_at_for_timestamp_future_guard"
+    assert (
+        stamped["quote_identity_timestamp_source"]
+        == "received_at_for_timestamp_future_guard"
+    )
     assert stamped["tick_age_ms"] == 0.0
     assert stamped["quote_age_s"] == 0.0


### PR DESCRIPTION
## Root cause

`src/nifty_scalper_bot/data/quote_identity_extension.py` patched `DataHub._canonicalize_tick_payload`, `DataHub.get_quote`, and `DataHub.get_tick_by_token` at import time to add symbol identity and quote age fields. That duplicated quote/freshness ownership outside `data_hub.py` and allowed synthetic or invalid timestamp quotes to receive hub-clock fallback age fields such as `tick_age_ms=0`, which could make diagnostics/strategy context see false freshness.

## What changed

- `src/nifty_scalper_bot/data/data_hub.py`
  - Adds native quote identity stamping for cached quotes and token reads.
  - Keeps identity fields (`symbol`, `tradingsymbol`, `instrument_token`, `quote_update_version`) in the owning DataHub path.
  - Adds age fields only when timestamp quality is usable and a real timestamp is available.
  - Marks synthetic/unknown/invalid timestamp quotes as timestamp rejected instead of assigning fresh hub-clock age.
- `src/nifty_scalper_bot/data/quote_identity_extension.py`
  - Delegates to native `DataHub._stamp_quote_identity()` when present.
  - Stops patching native `DataHub` methods when native support exists.
  - Keeps compatibility fallback for non-native DataHub-like objects.
- `tests/data/test_quote_contract.py`
  - Adds regression proving `DataHub.get_quote` and `_canonicalize_tick_payload` remain native methods.
  - Updates the synthetic timestamp contract so identity is preserved but false-fresh age fields are absent.

## What did not change

- No contract selection changes.
- No MDM history/hydration owner changes.
- No strategy scoring changes.
- No risk, execution, broker, Telegram, or WebSocket restart behavior changes.
- No new dependencies.

## Validation

Commands run:

- `python -m pytest -q tests\\data\\test_quote_contract.py tests\\data\\test_datahub_import_safety.py tests\\data\\test_datahub_synthetic_timestamp_guard.py tests\\execution\\test_quote_readiness.py tests\\strategies\\test_runtime_context_contract.py tests\\strategies\\test_runtime_context_contract_autoinstall.py`
- `python -m compileall -q src\\nifty_scalper_bot\\data\\data_hub.py src\\nifty_scalper_bot\\data\\quote_identity_extension.py tests\\data\\test_quote_contract.py`
- `python -m black --check src\\nifty_scalper_bot\\data\\quote_identity_extension.py tests\\data\\test_quote_contract.py`
- `git diff --check`

Results:

```text
20 passed
compileall passed
black compatibility/test files passed
git diff --check passed
```

Note: `ruff` on `quote_identity_extension.py` / `test_quote_contract.py` still reports pre-existing import-order/E402 and line-length style debt in that legacy extension/test shape. I did not broad-clean unrelated lint debt.

## Runtime impact

- startup: importing the legacy quote identity extension no longer replaces native DataHub methods.
- market data: DataHub remains the quote identity and quote-age owner.
- option hydration: unchanged; history/hydration still delegates to MDM.
- strategy evaluation: synthetic/invalid timestamp quotes no longer get false-fresh tick-age fields.
- risk: unchanged.
- execution: unchanged.
- Telegram diagnostics: unchanged.

## Regression risk

Medium. The change touches DataHub quote metadata returned to strategy context, but it is intentionally constrained to identity/age stamping. Focused quote contract, DataHub import safety, synthetic timestamp guard, execution quote readiness, and runtime context contract tests passed.