### PR TITLE
fix: canonicalize runner quote revalidation

### DIFF
--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -95,6 +95,7 @@ from nifty_scalper_bot.data.source import (
 )
 # Signals route directly through OrderManager submit/place APIs; no execution hub layer.
 from nifty_scalper_bot.execution.order_manager import OrderType, TradePlan
+from nifty_scalper_bot.execution.quote_readiness import evaluate_execution_quote
 from nifty_scalper_bot.execution.readiness import HistoryReadinessPolicy, resolve_quote_bid_ask_spread
 from nifty_scalper_bot.execution.order_state_machine import (
     ExecutionState,
@@ -3187,7 +3188,10 @@ class StrategyRunner:
         reason = "runtime_not_marked_ready"
         tick_age_ms = None
         bid = ask = None
+        spread_pct = None
         tradable_quote = False
+        depth_available = False
+        ltp = 0.0
         lot_size_resolved = False
         lot_size = 0
         max_quote_age_ms = int(os.getenv("ORDER_MAX_QUOTE_AGE_MS", "60000") or "60000")
@@ -3228,13 +3232,34 @@ class StrategyRunner:
                     "depth": getattr(snap, "depth", None),
                     "depth_available": getattr(snap, "depth_available", False),
                     "tradable_quote": getattr(snap, "tradable_quote", False),
+                    "spread_pct": getattr(snap, "spread_pct", None),
+                    "tick_age_ms": getattr(snap, "tick_age_ms", None),
                     "tick_age_s": getattr(snap, "tick_age_s", None),
+                    "real_ticks_last_60s": getattr(snap, "real_ticks_last_60s", None),
                     "source": getattr(snap, "source", None),
                 }
-                bid, ask, spread_pct, quote_source = resolve_quote_bid_ask_spread(quote)
+                max_spread_pct = float(os.getenv("SPREAD_MAX_PCT", "12.5") or "12.5")
+                quote_readiness = evaluate_execution_quote(
+                    normalized,
+                    quote,
+                    live_mode=True,
+                    max_tick_age_ms=float(max_quote_age_ms),
+                    max_spread_pct=max_spread_pct,
+                    require_depth=False,
+                    min_real_ticks_last_60s=0,
+                )
+                bid = quote_readiness.bid
+                ask = quote_readiness.ask
+                spread_pct = quote_readiness.spread_pct
+                quote_source = getattr(snap, "source", None)
                 ltp = _extract_float(quote, "ltp", "last_price") or 0.0
-                tradable_quote = bool(ltp > 0 and bid is not None and ask is not None and bid > 0 and ask > bid and spread_pct is not None)
-                tick_age_ms = int(max(0.0, float(getattr(snap, "tick_age_s", 9999.0) or 9999.0) * 1000.0))
+                tradable_quote = bool(quote_readiness.tradable_quote and ltp > 0)
+                tick_age_ms = (
+                    int(quote_readiness.tick_age_ms)
+                    if quote_readiness.tick_age_ms is not None
+                    else None
+                )
+                depth_available = quote_readiness.depth_available
             else:
                 reason = "quote_missing"
         lot_size_key_used: str | None = None
@@ -3266,23 +3291,14 @@ class StrategyRunner:
                 history_count = int(getattr(snap, "real_ticks_last_60s", 0) or 0)
             except (TypeError, ValueError):
                 history_count = 0
-            spread_ok = bool(spread_pct is not None and spread_pct <= float(os.getenv("SPREAD_MAX_PCT", "12.5") or "12.5"))
-        else:
-            spread_ok = False
         min_history = int(os.getenv("RUNNER_MIN_REAL_TICKS_60S", "1") or "1")
         allow_fresh_without_tick_count = _env_flag("RUNNER_ALLOW_FRESH_QUOTE_WITHOUT_TICK_COUNT", default=True)
         if snap is None:
             reason = "quote_missing"
-        elif (locals().get("ltp") or 0.0) <= 0:
+        elif ltp <= 0:
             reason = "ltp_missing"
-        elif bid is None or ask is None or bid <= 0 or ask <= 0:
-            reason = "bid_ask_missing"
-        elif ask <= bid:
-            reason = "bid_ask_crossed"
-        elif tick_age_ms is None or tick_age_ms > max_quote_age_ms:
-            reason = "quote_stale"
-        elif not spread_ok:
-            reason = "spread_too_wide"
+        elif not quote_readiness.allowed:
+            reason = quote_readiness.reason
         elif not lot_size_resolved or lot_size <= 0:
             reason = "lot_size_unresolved"
         elif history_count < min_history and not allow_fresh_without_tick_count:
@@ -3299,7 +3315,11 @@ class StrategyRunner:
             self._runtime_execution_ready_by_symbol[runtime_key] = True
             self._runtime_symbol_last_ready_at[runtime_key] = time.time()
             self._logger.info("EXECUTION_READY_DYNAMIC_MARK symbol=%s runtime_key=%s reason=%s tick_age_ms=%s bid=%s ask=%s lot_size=%s history_count=%s trace_id=%s", normalized, runtime_key, reason, tick_age_ms, bid, ask, lot_size, history_count, trace_id)
-        depth_available = bool(getattr(snap, "depth_available", False) or getattr(snap, "depth", None)) if snap is not None else False
+        depth_available = (
+            bool(depth_available or getattr(snap, "depth_available", False) or getattr(snap, "depth", None))
+            if snap is not None
+            else False
+        )
         self._logger.info("ORDER_READINESS_REVALIDATION symbol=%s runtime_key=%s trace_id=%s was_ready=%s refreshed=%s final_ready=%s reason=%s startup_marked_ready=%s dynamic_revalidation_attempted=%s dynamic_revalidation_passed=%s quote_source=%s history_count=%s history_fallback=%s lot_size=%s final_reason=%s tick_age_ms=%s max_quote_age_ms=%s snapshot_key_used=%s lot_size_key_used=%s bid=%s ask=%s spread_pct=%s tradable_quote=%s depth_available=%s lot_size_resolved=%s", normalized, runtime_key, trace_id, was_ready, True, final_ready, reason, startup_marked_ready, dynamic_revalidation_attempted, dynamic_revalidation_passed, quote_source, history_count, history_fallback, lot_size, reason, tick_age_ms, max_quote_age_ms, snapshot_key_used, lot_size_key_used, bid, ask, spread_pct, tradable_quote, depth_available, lot_size_resolved)
         return ExecutionReadinessResult(final_ready, reason, {"symbol": normalized, "runtime_key": runtime_key, "tick_age_ms": tick_age_ms, "bid": bid, "ask": ask, "spread_pct": spread_pct, "quote_source": quote_source, "snapshot_key_used": snapshot_key_used, "tradable_quote": tradable_quote, "depth_available": depth_available, "lot_size_resolved": lot_size_resolved})
 

--- a/tests/strategies/test_runner_execution_quote_readiness.py
+++ b/tests/strategies/test_runner_execution_quote_readiness.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_runner_order_readiness_uses_canonical_execution_quote_readiness() -> None:
+    source = Path("src/nifty_scalper_bot/strategies/runner.py").read_text(
+        encoding="utf-8"
+    )
+    function_start = source.index("def _ensure_symbol_execution_ready_result")
+    function_end = source.index("def _execution_reject_cooldown_result", function_start)
+    body = source[function_start:function_end]
+
+    assert "evaluate_execution_quote(" in body


### PR DESCRIPTION
## Root cause

`StrategyRunner._ensure_symbol_execution_ready_result()` manually recalculated live execution quote readiness: bid/ask availability, spread, tick age, stale reason, and tradable quote status. The same contract already exists in `execution.quote_readiness.evaluate_execution_quote()`, so runner revalidation could drift from the canonical live execution gate.

## What changed

- `src/nifty_scalper_bot/strategies/runner.py`
  - Uses `evaluate_execution_quote()` for runner-side dynamic order readiness revalidation.
  - Preserves runner-owned lot-size resolution and history fallback behavior.
  - Keeps existing logging fields: bid, ask, spread, tick age, tradable quote, depth, lot-size, and final reason.
- `tests/strategies/test_runner_execution_quote_readiness.py`
  - Adds a narrow regression proving the runner revalidation function calls the canonical execution quote readiness evaluator.

## What did not change

- No market-data subscription changes.
- No DataHub/MDM history or hydration owner changes.
- No strategy scoring changes.
- No order placement behavior changes.
- No risk, broker, Telegram, or WebSocket restart behavior changes.
- No new dependencies.

## Validation

Commands run:

- `python -m pytest -q tests\\strategies\\test_runner_execution_quote_readiness.py tests\\execution\\test_quote_readiness.py tests\\execution\\test_live_readiness_blocker_recovery.py`
- `python -m pytest -q tests\\strategies\\test_runner_execution_quote_readiness.py tests\\strategies\\test_orderflow_quote_age_contract.py tests\\strategies\\test_runner_single_candidate_selected_context.py`
- `python -m compileall -q src\\nifty_scalper_bot\\strategies\\runner.py tests\\strategies\\test_runner_execution_quote_readiness.py`
- `git diff --check`

Results:

```text
15 passed
3 passed
compileall passed
git diff --check passed
```

## Runtime impact

- startup: unchanged.
- market data: unchanged.
- option hydration: unchanged.
- strategy evaluation: runner execution revalidation now shares canonical execution quote freshness/tradability semantics.
- risk: unchanged.
- execution: readiness reason mapping is more consistent with `execution.quote_readiness`.
- Telegram diagnostics: unchanged.

## Regression risk

Medium. This touches the runner order-readiness path, but keeps the existing lot-size and history fallback decisions intact and delegates only quote readiness to the existing canonical evaluator. Focused quote readiness and runner-adjacent tests passed.