### PR TITLE
fix: canonicalize runner candidate age freshness

### DIFF
--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -95,7 +95,10 @@ from nifty_scalper_bot.data.source import (
 )
 # Signals route directly through OrderManager submit/place APIs; no execution hub layer.
 from nifty_scalper_bot.execution.order_manager import OrderType, TradePlan
-from nifty_scalper_bot.execution.quote_readiness import evaluate_execution_quote
+from nifty_scalper_bot.execution.quote_readiness import (
+    evaluate_execution_quote,
+    resolve_tick_age_ms,
+)
 from nifty_scalper_bot.execution.readiness import HistoryReadinessPolicy, resolve_quote_bid_ask_spread
 from nifty_scalper_bot.execution.order_state_machine import (
     ExecutionState,
@@ -13707,9 +13710,13 @@ class StrategyRunner:
                     else:
                         strike_distance = float(distance_raw or 999.0)
                     is_selected = bool(lone.get("is_selected_option")) or lone_symbol == selected_symbol
-                    tick_age_raw = lone.get("tick_age_s")
-                    tick_age_s = float(tick_age_raw) if tick_age_raw is not None else 999.0
-                    is_fresh = tick_age_s <= (float(os.getenv("ORDER_MAX_QUOTE_AGE_MS", "60000") or "60000") / 1000.0)
+                    tick_age_ms = resolve_tick_age_ms(lone)
+                    tick_age_s = None if tick_age_ms is None else tick_age_ms / 1000.0
+                    max_quote_age_s = (
+                        float(os.getenv("ORDER_MAX_QUOTE_AGE_MS", "60000") or "60000")
+                        / 1000.0
+                    )
+                    is_fresh = bool(tick_age_s is not None and tick_age_s <= max_quote_age_s)
                     ltp = float(lone.get("ltp") or 0.0)
                     bid = float(lone.get("bid") or 0.0)
                     ask = float(lone.get("ask") or 0.0)

--- a/tests/strategies/test_runner_candidate_age_readiness.py
+++ b/tests/strategies/test_runner_candidate_age_readiness.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_single_candidate_screen_uses_canonical_tick_age_resolver() -> None:
+    source = Path("src/nifty_scalper_bot/strategies/runner.py").read_text(
+        encoding="utf-8"
+    )
+    marker = "EXECUTION_SINGLE_CANDIDATE_SCREEN"
+    block_start = source.index(marker)
+    block_end = source.index("ranked_candidates =", block_start)
+    block = source[block_start:block_end]
+
+    assert "resolve_tick_age_ms(" in block
+    assert "lone.get(\"tick_age_s\")" not in block


### PR DESCRIPTION
## Root cause

The live single-candidate screen in `StrategyRunner` only read `tick_age_s` and manually compared it to `ORDER_MAX_QUOTE_AGE_MS`. Candidates carrying the canonical age schema (`tick_age_ms`, `quote_age_ms`, `quote_age_s`, `market_data_age_ms`, etc.) could be treated as missing/stale even though `execution.quote_readiness.resolve_tick_age_ms()` already defines the accepted schema.

## What changed

- `src/nifty_scalper_bot/strategies/runner.py`
  - Imports and uses `resolve_tick_age_ms()` in the single-candidate execution screen.
  - Preserves the existing threshold and rejection behavior, but accepts all canonical age fields.
  - Missing age remains not fresh; no false freshness is introduced.
- `tests/strategies/test_runner_candidate_age_readiness.py`
  - Adds a regression proving this block uses the canonical tick-age resolver instead of direct `tick_age_s` lookup.

## What did not change

- No market-data subscription changes.
- No history/hydration ownership changes.
- No strategy scoring changes.
- No order placement changes.
- No risk, broker, Telegram, or WebSocket restart behavior changes.
- No new dependencies.

## Validation

Commands run:

- `python -m pytest -q tests\\strategies\\test_runner_candidate_age_readiness.py tests\\execution\\test_quote_readiness.py tests\\strategies\\test_runner_single_candidate_selected_context.py`
- `python -m compileall -q src\\nifty_scalper_bot\\strategies\\runner.py tests\\strategies\\test_runner_candidate_age_readiness.py`
- `git diff --check`

Results:

```text
8 passed
compileall passed
git diff --check passed
```

## Runtime impact

- startup: unchanged.
- market data: unchanged.
- option hydration: unchanged.
- strategy evaluation: single-candidate fallback no longer falsely rejects fresh candidates that use canonical age fields other than `tick_age_s`.
- risk: unchanged.
- execution: candidate freshness screen aligns with canonical quote-age schema.
- Telegram diagnostics: unchanged.

## Regression risk

Low. This only changes age-field parsing in a fallback candidate screen and keeps missing age as not fresh. Focused resolver and runner tests passed.