### PR TITLE
fix: canonicalize runner ranking tick age

### DIFF
--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -163,6 +163,7 @@ RELAX_REGIME_FILTER = (
     os.getenv("RELAX_REGIME_FILTER", "true").lower() != "false"
 )  # default True: regime starts with no snapshot
 MIN_EVAL_INTERVAL_SECONDS = 5.0
+_CANDIDATE_RANK_MISSING_TICK_AGE_MS = 999000.0
 _IST = ZoneInfo("Asia/Kolkata")
 
 _TRUE_VALUES = {"1", "true", "yes", "y", "on", "enable", "enabled"}
@@ -13093,16 +13094,22 @@ class StrategyRunner:
         if spread_pct_raw is None:
             spread_pct_raw = metadata.get("spread_pct")
         spread_pct = float(spread_pct_raw) if spread_pct_raw is not None else 999.0
-        tick_age_ms_raw = metadata.get("candidate_tick_age_ms")
-        if tick_age_ms_raw is None:
-            tick_age_ms_raw = metadata.get("tick_age_ms")
-        if tick_age_ms_raw is not None:
-            tick_age_ms = float(tick_age_ms_raw)
-        else:
-            tick_age_s_raw = metadata.get("candidate_tick_age_s")
-            if tick_age_s_raw is None:
-                tick_age_s_raw = metadata.get("tick_age_s")
-            tick_age_ms = float(tick_age_s_raw) * 1000.0 if tick_age_s_raw is not None else 999000.0
+        tick_age_ms = resolve_tick_age_ms(
+            {
+                "tick_age_ms": metadata.get("candidate_tick_age_ms")
+                if metadata.get("candidate_tick_age_ms") is not None
+                else metadata.get("tick_age_ms"),
+                "tick_age_s": metadata.get("candidate_tick_age_s")
+                if metadata.get("candidate_tick_age_s") is not None
+                else metadata.get("tick_age_s"),
+                "quote_age_ms": metadata.get("quote_age_ms"),
+                "quote_age_s": metadata.get("quote_age_s"),
+                "last_tick_age_ms": metadata.get("last_tick_age_ms"),
+                "market_data_age_ms": metadata.get("market_data_age_ms"),
+            }
+        )
+        if tick_age_ms is None:
+            tick_age_ms = _CANDIDATE_RANK_MISSING_TICK_AGE_MS
         depth_available = bool(
             selected_snapshot.get("depth_available") or selected_snapshot.get("depth")
         )

--- a/tests/strategies/test_runner_candidate_rank_age_readiness.py
+++ b/tests/strategies/test_runner_candidate_rank_age_readiness.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_execution_candidate_ranking_uses_canonical_tick_age_resolver() -> None:
+    source = Path("src/nifty_scalper_bot/strategies/runner.py").read_text(
+        encoding="utf-8"
+    )
+    start = source.index('score_raw = metadata.get("candidate_score")')
+    end = source.index("depth_available = bool(", start)
+    block = source[start:end]
+
+    assert "resolve_tick_age_ms(" in block
+    assert "999000.0" not in block


### PR DESCRIPTION
## Root cause

The runner execution-candidate ranking block manually parsed `candidate_tick_age_ms`, `tick_age_ms`, `candidate_tick_age_s`, and `tick_age_s`, then used a local magic stale penalty. This duplicated the canonical age schema owned by `execution.quote_readiness.resolve_tick_age_ms()` and ignored valid fields such as `quote_age_ms`, `quote_age_s`, `last_tick_age_ms`, and `market_data_age_ms`.

## What changed

- `src/nifty_scalper_bot/strategies/runner.py`
  - Candidate ranking now uses `resolve_tick_age_ms()` for age normalization.
  - Missing age still receives a stale ranking penalty via a named constant.
  - Ranking behavior is preserved while accepting the full canonical age schema.
- `tests/strategies/test_runner_candidate_rank_age_readiness.py`
  - Adds a regression proving the ranking block uses the canonical resolver and does not carry the old local magic fallback in the block.

## What did not change

- No market-data subscription changes.
- No history/hydration ownership changes.
- No strategy scoring thresholds changed.
- No order placement changes.
- No risk, broker, Telegram, or WebSocket restart behavior changes.
- No new dependencies.

## Validation

Commands run:

- `python -m pytest -q tests\\strategies\\test_runner_candidate_rank_age_readiness.py tests\\strategies\\test_runner_candidate_age_readiness.py tests\\execution\\test_quote_readiness.py`
- `python -m compileall -q src\\nifty_scalper_bot\\strategies\\runner.py tests\\strategies\\test_runner_candidate_rank_age_readiness.py`
- `git diff --check`

Results:

```text
8 passed
compileall passed
git diff --check passed
```

## Runtime impact

- startup: unchanged.
- market data: unchanged.
- option hydration: unchanged.
- strategy evaluation: execution-candidate ranking now honors all canonical quote-age fields.
- risk: unchanged.
- execution: ranking freshness semantics align with existing execution quote readiness schema.
- Telegram diagnostics: unchanged.

## Regression risk

Low. This affects only candidate ranking age normalization and keeps missing age penalized. Focused runner and quote-readiness tests passed.