### PR TITLE
fix: canonicalize orderflow live context age

### DIFF
--- a/src/nifty_scalper_bot/strategies/elite_strategies/order_flow_live_context_patch.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/order_flow_live_context_patch.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import os
 from typing import Any, Mapping
 
+from nifty_scalper_bot.execution.quote_readiness import resolve_tick_age_ms
 from nifty_scalper_bot.strategies.runtime_context_contract import live_direction_context_has_proof
 
 _PATCH_ATTR = "_live_direction_context_proof_patch_installed"
@@ -49,7 +50,7 @@ def _can_upgrade_direction_context_block(metadata: Mapping[str, Any], indicators
     min_score = _safe_float(metadata.get("trigger_min_score"))
     spread = _safe_float(metadata.get("spread_pct"))
     max_spread = _safe_float(metadata.get("trigger_max_spread_pct"))
-    tick_age_ms = _safe_float(metadata.get("tick_age_ms"))
+    tick_age_ms = resolve_tick_age_ms(metadata)
     max_tick_age_ms = _safe_float(os.getenv("LIVE_MAX_TICK_AGE_MS", "2500") or 2500)
     if score is None or min_score is None or score < min_score:
         return False

--- a/tests/strategies/test_orderflow_live_context_age.py
+++ b/tests/strategies/test_orderflow_live_context_age.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from nifty_scalper_bot.strategies.elite_strategies.order_flow_live_context_patch import (
+    _can_upgrade_direction_context_block,
+)
+
+
+def _metadata(**overrides: object) -> dict[str, object]:
+    metadata: dict[str, object] = {
+        "trigger_block_reason": "direction_context_missing_live",
+        "strategy_score": 8.5,
+        "trigger_min_score": 8.0,
+        "spread_pct": 0.2,
+        "trigger_max_spread_pct": 0.75,
+        "quote_readiness_allowed": True,
+        "quote_depth_valid": True,
+        "depth_available": True,
+        "tradable_quote": True,
+        "selected_or_near_atm": True,
+    }
+    metadata.update(overrides)
+    return metadata
+
+
+def test_live_context_upgrade_accepts_canonical_quote_age_seconds(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("LIVE_MAX_TICK_AGE_MS", "2500")
+    indicators = {
+        "context_fresh": True,
+        "spot_fresh": True,
+        "futures_fresh": True,
+    }
+
+    assert _can_upgrade_direction_context_block(
+        _metadata(quote_age_s=0.10),
+        indicators,
+    )


### PR DESCRIPTION
## Root cause

`order_flow_live_context_patch._can_upgrade_direction_context_block()` only checked `metadata[tick_age_ms]` before upgrading a live direction-context block. The rest of the live execution path already accepts the canonical quote-age schema through `execution.quote_readiness.resolve_tick_age_ms()`, including `quote_age_s`, `quote_age_ms`, `last_tick_age_ms`, and `market_data_age_ms`.

## What changed

- `src/nifty_scalper_bot/strategies/elite_strategies/order_flow_live_context_patch.py`
  - Uses `resolve_tick_age_ms(metadata)` for live context age validation.
  - Preserves the same `LIVE_MAX_TICK_AGE_MS` threshold and fail-closed behavior when age is missing.
- `tests/strategies/test_orderflow_live_context_age.py`
  - Adds a regression proving a fresh canonical `quote_age_s` value can satisfy the live context proof age gate.

## What did not change

- No market-data subscription changes.
- No history/hydration changes.
- No strategy scoring threshold changes.
- No order placement changes.
- No risk, broker, Telegram, or WebSocket restart behavior changes.
- No new dependencies.

## Validation

Commands run:

- `python -m pytest -q tests\\strategies\\test_orderflow_live_context_age.py tests\\strategies\\test_orderflow_quote_age_contract.py tests\\execution\\test_quote_readiness.py`
- `python -m compileall -q src\\nifty_scalper_bot\\strategies\\elite_strategies\\order_flow_live_context_patch.py tests\\strategies\\test_orderflow_live_context_age.py`
- `git diff --check`

Results:

```text
8 passed
compileall passed
git diff --check passed
```

## Runtime impact

- startup: unchanged.
- market data: unchanged.
- option hydration: unchanged.
- strategy evaluation: OrderFlow live context proof now accepts all canonical quote-age fields.
- risk: unchanged.
- execution: fail-closed age threshold remains unchanged.
- Telegram diagnostics: unchanged.

## Regression risk

Low. This changes only age-field parsing in a narrow OrderFlow unblock adapter and preserves the existing threshold and missing-age rejection.