### PR TITLE
fix: canonicalize runtime quote age readiness

### DIFF
--- a/src/nifty_scalper_bot/execution/readiness.py
+++ b/src/nifty_scalper_bot/execution/readiness.py
@@ -414,6 +414,31 @@ def _quote_float(payload: dict | object, *keys: str) -> float | None:
     return None
 
 
+def _quote_age_seconds(payload: dict | object) -> float | None:
+    age_ms = _quote_float(
+        payload,
+        "tick_age_ms",
+        "quote_age_ms",
+        "last_tick_age_ms",
+        "market_data_age_ms",
+    )
+    if age_ms is not None:
+        return max(0.0, age_ms / 1000.0)
+    age_s = _quote_float(
+        payload,
+        "tick_age_s",
+        "quote_age_s",
+        "data_age_seconds",
+        "age_s",
+        "age_seconds",
+        "last_tick_age_s",
+        "market_data_age_s",
+    )
+    if age_s is not None:
+        return max(0.0, age_s)
+    return None
+
+
 def resolve_quote_bid_ask_spread(quote: dict | object) -> tuple[float | None, float | None, float | None, str]:
     """Resolve bid/ask/spread from top-level fields or Zerodha depth.
 
@@ -525,7 +550,7 @@ def evaluate_quote_readiness(
     else:
         reason = "ready"
     if reason == "ready" and require_fresh:
-        age = _quote_float(quote, "tick_age_s", "age_s")
+        age = _quote_age_seconds(quote)
         if age is None:
             ts = _quote_float(quote, "timestamp_ms", "last_tick_ts_ms")
             if ts and ts > 10_000_000_000:

--- a/tests/execution/test_quote_readiness.py
+++ b/tests/execution/test_quote_readiness.py
@@ -5,7 +5,10 @@ from nifty_scalper_bot.execution.quote_readiness import (
     resolve_real_tick_count,
     resolve_tick_age_ms,
 )
-from nifty_scalper_bot.execution.readiness import resolve_quote_bid_ask_spread
+from nifty_scalper_bot.execution.readiness import (
+    evaluate_quote_readiness,
+    resolve_quote_bid_ask_spread,
+)
 
 
 def test_missing_age_never_becomes_fresh_in_live_mode():
@@ -48,6 +51,26 @@ def test_quote_age_seconds_allows_live_orderflow_quote():
     assert result.allowed is True
     assert result.reason == "ready"
     assert result.tick_age_ms == 100
+
+
+def test_quote_age_seconds_allows_runtime_quote_readiness():
+    result = evaluate_quote_readiness(
+        "NFO:NIFTY26JUN24000CE",
+        {
+            "ltp": 100.0,
+            "bid": 99.9,
+            "ask": 100.1,
+            "quote_age_s": 0.10,
+            "depth_available": True,
+            "tradable_quote": True,
+        },
+        require_fresh=True,
+        max_age_s=2.5,
+        max_spread_pct=0.75,
+    )
+
+    assert result.tradable_quote_ready is True
+    assert result.reason == "ready"
 
 
 def test_synthetic_timestamp_quality_blocks_live_quote_readiness():


### PR DESCRIPTION
## Root cause

`execution.readiness.evaluate_quote_readiness()` only recognized `tick_age_s` and `age_s` when enforcing runtime quote freshness. Other canonical quote-age fields already used elsewhere (`quote_age_s`, `quote_age_ms`, `tick_age_ms`, `last_tick_age_ms`, `market_data_age_ms`, etc.) were treated as missing, producing `quote_age_unknown` and blocking otherwise valid quotes in MDM/DataHub readiness paths.

## What changed

- `src/nifty_scalper_bot/execution/readiness.py`
  - Adds `_quote_age_seconds()` to normalize the accepted quote-age schema for runtime quote readiness.
  - `evaluate_quote_readiness()` now uses that helper before falling back to timestamp fields.
  - Missing age still fails closed with `quote_age_unknown`.
- `tests/execution/test_quote_readiness.py`
  - Adds regression proving `quote_age_s` satisfies runtime quote readiness freshness.

## What did not change

- No market-data subscription changes.
- No history/hydration ownership changes.
- No strategy scoring changes.
- No order placement changes.
- No risk, broker, Telegram, or WebSocket restart behavior changes.
- No new dependencies.

## Validation

Commands run:

- `python -m pytest -q tests\\execution\\test_quote_readiness.py tests\\data\\test_datahub_synthetic_timestamp_guard.py tests\\execution\\test_live_readiness_blocker_recovery.py`
- `python -m compileall -q src\\nifty_scalper_bot\\execution\\readiness.py tests\\execution\\test_quote_readiness.py`
- `git diff --check`

Results:

```text
19 passed
compileall passed
git diff --check passed
```

## Runtime impact

- startup: unchanged.
- market data: selected option quote readiness accepts the canonical age schema.
- option hydration: unchanged.
- strategy evaluation: fewer false readiness blocks when quotes carry `quote_age_*` fields instead of `tick_age_s`.
- risk: unchanged.
- execution: unchanged; missing age still fails closed.
- Telegram diagnostics: readiness reason remains explicit.

## Regression risk

Low. This only broadens accepted age field names for runtime quote freshness and keeps stale/missing age behavior unchanged. Focused readiness, synthetic timestamp, and live blocker tests passed.