### PR TITLE
refactor: canonicalize strategy context age

### DIFF
--- a/src/nifty_scalper_bot/strategies/elite_strategies/smc_liquidity.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/smc_liquidity.py
@@ -7,6 +7,7 @@ from nifty_scalper_bot.execution.readiness import HistoryReadinessPolicy
 from nifty_scalper_bot.strategies.elite_strategies.base_elite import EliteSignal, EliteStrategy
 from nifty_scalper_bot.strategies.elite_strategies.config_models import SMCStrategyConfig
 from nifty_scalper_bot.strategies.signal_quality import resolve_signal_domain
+from nifty_scalper_bot.strategies.runtime_context_contract import resolve_context_age_seconds
 from nifty_scalper_bot.utils.logging import get_logger, log_throttled
 
 LOGGER = get_logger(__name__)
@@ -58,10 +59,7 @@ class SMCStrategy(EliteStrategy):
             atr = max(float(indicators.get('atr') or 0.0), current_price * 0.01, 1.0)
             direction = str(indicators.get("direction_bias") or "").upper()
             stale_data = bool(indicators.get('stale_data_used')) or float(indicators.get('data_age_seconds') or 0.0) > 120.0
-            try:
-                context_age_seconds = float(indicators.get("context_age_seconds") or 999.0)
-            except (TypeError, ValueError):
-                context_age_seconds = 999.0
+            context_age_seconds = resolve_context_age_seconds(indicators)
             underlying_direction = str(indicators.get("underlying_direction_bias") or "").upper()
             effective_direction = underlying_direction or direction
             if str(os.getenv('EXECUTION_MODE', 'SHADOW') or 'SHADOW').strip().upper() == 'LIVE' and not effective_direction:

--- a/src/nifty_scalper_bot/strategies/elite_strategies/vwap_pro.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/vwap_pro.py
@@ -6,6 +6,7 @@ from typing import Any
 from nifty_scalper_bot.strategies.elite_strategies.base_elite import EliteSignal, EliteStrategy
 from nifty_scalper_bot.strategies.elite_strategies.config_models import VWAPProStrategyConfig
 from nifty_scalper_bot.strategies.signal_quality import resolve_signal_domain
+from nifty_scalper_bot.strategies.runtime_context_contract import resolve_context_age_seconds
 from nifty_scalper_bot.utils.logging import get_logger
 
 LOGGER = get_logger(__name__)
@@ -209,10 +210,7 @@ class VWAPProStrategy(EliteStrategy):
             min_score_default = '5.8' if is_live else '5.0'
             min_trend_score_default = '5.5' if is_live else '4.5'
             min_score = float(os.getenv('VWAP_PRO_MIN_TREND_ALIGNED_SCORE', min_trend_score_default) if trend_alignment else os.getenv('VWAP_PRO_MIN_SCORE', min_score_default))
-            try:
-                context_age_seconds = float(indicators.get("context_age_seconds") or 999.0)
-            except (TypeError, ValueError):
-                context_age_seconds = 999.0
+            context_age_seconds = resolve_context_age_seconds(indicators)
             try:
                 underlying_direction_confidence = float(
                     indicators.get("underlying_direction_confidence")

--- a/src/nifty_scalper_bot/strategies/runtime_context_contract.py
+++ b/src/nifty_scalper_bot/strategies/runtime_context_contract.py
@@ -95,6 +95,12 @@ def _coerce_age_seconds(value: Any) -> float | None:
     return age
 
 
+def resolve_context_age_seconds(context: Mapping[str, Any], default: float = 999.0) -> float:
+    """Return normalized context age, failing closed for missing/invalid values."""
+    age = _coerce_age_seconds(context.get("context_age_seconds")) if isinstance(context, Mapping) else None
+    return age if age is not None else float(default)
+
+
 def _coerce_timestamp(value: Any) -> datetime | None:
     if value is None:
         return None

--- a/tests/strategies/test_runtime_context_contract.py
+++ b/tests/strategies/test_runtime_context_contract.py
@@ -4,6 +4,7 @@ from nifty_scalper_bot.strategies.indicators import IndicatorEngine
 from nifty_scalper_bot.strategies.runtime_context_contract import (
     live_direction_context_has_proof,
     normalise_live_direction_context,
+    resolve_context_age_seconds,
 )
 
 
@@ -101,3 +102,9 @@ def test_live_direction_context_proof_derives_freshness_from_spot_or_futures_age
     assert stale["spot_fresh"] is False
     assert stale["fut_fresh"] is False
     assert live_direction_context_has_proof(stale) is False
+
+
+def test_resolve_context_age_seconds_uses_canonical_safe_default() -> None:
+    assert resolve_context_age_seconds({"context_age_seconds": "1.5"}) == 1.5
+    assert resolve_context_age_seconds({"context_age_seconds": "invalid"}) == 999.0
+    assert resolve_context_age_seconds({}) == 999.0


### PR DESCRIPTION
## Root cause
VWAP Pro and SMC independently parsed `context_age_seconds`, duplicating the runtime context freshness contract and risking inconsistent invalid-value behavior.

## What changed
- Added `resolve_context_age_seconds` to `strategies/runtime_context_contract.py`.
- Updated VWAP Pro and SMC to use the shared resolver.
- Added regression coverage for valid, missing, and invalid context ages.

## What did not change
- No thresholds, scoring, signal rules, history ownership, quote readiness, risk, or execution behavior changed.

## Validation
Commands run:
- `python -m pytest -q tests/strategies/test_runtime_context_contract.py tests/strategies/test_vwap_pro_context_boost.py tests/strategies/test_vwap_metadata_contract_side.py tests/strategies/test_orderflow_live_context_age.py`
- `python -m compileall -q src/nifty_scalper_bot/strategies/runtime_context_contract.py src/nifty_scalper_bot/strategies/elite_strategies/vwap_pro.py src/nifty_scalper_bot/strategies/elite_strategies/smc_liquidity.py`
- `git diff --check`

Results:
- 8 passed
- compile and diff checks passed

## Runtime impact
Startup, market data, hydration, strategy scoring thresholds, risk, execution, and Telegram behavior are unchanged. Only context-age parsing is centralized.

## Regression risk
Low. The shared resolver preserves the prior `999.0` fallback and uses the existing normalized age coercion.