### PR TITLE
refactor: canonicalize strategy manager context age

### DIFF
--- a/src/nifty_scalper_bot/core/strategy_manager.py
+++ b/src/nifty_scalper_bot/core/strategy_manager.py
@@ -41,6 +41,7 @@ from nifty_scalper_bot.utils.log_throttle import maybe_emit_strategy_rejection_s
 from nifty_scalper_bot.utils.logging import get_logger, log_state_change, log_throttled
 from nifty_scalper_bot.utils.symbols import normalize_symbol
 from nifty_scalper_bot.execution.readiness import HistoryReadinessPolicy
+from nifty_scalper_bot.execution.quote_readiness import resolve_tick_age_seconds
 
 log = get_logger(__name__)
 
@@ -2313,14 +2314,7 @@ class StrategyManager(_BaseStrategyManager):
 
     @staticmethod
     def _context_tick_age_seconds(ctx: t.Mapping[str, t.Any]) -> float | None:
-        raw = ctx.get("tick_age_ms")
-        if raw is None:
-            return None
-        try:
-            age_ms = float(raw)
-        except (TypeError, ValueError):
-            return None
-        return age_ms / 1000.0 if age_ms >= 0 else None
+        return resolve_tick_age_seconds(ctx)
 
     def _strategy_required_indicator_union(self) -> set[str]:
         required = set(getattr(self, "_required_indicators", set()) or set())

--- a/tests/core/test_strategy_manager_context_age.py
+++ b/tests/core/test_strategy_manager_context_age.py
@@ -1,0 +1,7 @@
+from nifty_scalper_bot.core.strategy_manager import StrategyManager
+
+
+def test_strategy_manager_context_age_uses_canonical_quote_age_schema() -> None:
+    assert StrategyManager._context_tick_age_seconds({"quote_age_s": 0.25}) == 0.25
+    assert StrategyManager._context_tick_age_seconds({"tick_age_ms": 250}) == 0.25
+    assert StrategyManager._context_tick_age_seconds({"tick_age_ms": "invalid"}) is None


### PR DESCRIPTION
## Root cause
`StrategyManager._context_tick_age_seconds` duplicated quote-age parsing and only accepted `tick_age_ms`, while the canonical resolver supports all runtime quote-age fields.

## What changed
- Delegated `_context_tick_age_seconds` to `resolve_tick_age_seconds`.
- Added coverage for `quote_age_s`, `tick_age_ms`, and invalid age input.

## What did not change
- Context thresholds, direction selection, strategy scoring, risk, and execution behavior are unchanged.

## Validation
Commands run:
- `python -m pytest -q tests/core/test_strategy_manager_context_age.py tests/core/test_strategy_live_safety.py tests/core/test_strategy_manager_regime_fallback.py`
- `python -m compileall -q src/nifty_scalper_bot/core/strategy_manager.py`
- `git diff --check`

Results:
- 6 passed
- compile and diff checks passed

## Runtime impact
Strategy manager now accepts the same normalized context age schema as the execution quote contract. Existing millisecond behavior is preserved.

## Regression risk
Low. This PR is dependent on PR #860 and changes only one parser helper.