### PR TITLE
refactor: canonicalize runner option age

### DIFF
--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -8579,9 +8579,9 @@ class StrategyRunner:
         limit = float(max_age_s or os.getenv("OPTION_TICK_FRESH_MAX_AGE_S", "60") or 60.0)
         quote = self._get_cached_quote_for_live_entry(symbol)
         if isinstance(quote, Mapping):
-            age = _extract_float(quote, "tick_age_s", "age_s")
-            if age is not None:
-                return age <= limit
+            age_ms = resolve_tick_age_ms(quote)
+            if age_ms is not None:
+                return age_ms <= limit * 1000.0
         for source in (self._market_data, self._data_hub):
             if source is None:
                 continue

--- a/tests/strategies/test_runner_tick_age_contract.py
+++ b/tests/strategies/test_runner_tick_age_contract.py
@@ -1,0 +1,15 @@
+from nifty_scalper_bot.strategies.runner import StrategyRunner
+
+
+def test_runner_option_freshness_uses_canonical_quote_age_schema(monkeypatch) -> None:
+    runner = object.__new__(StrategyRunner)
+    runner._market_data = None
+    runner._data_hub = None
+    monkeypatch.setattr(runner, "_is_tradable_symbol", lambda symbol: True)
+    monkeypatch.setattr(
+        runner,
+        "_get_cached_quote_for_live_entry",
+        lambda symbol: {"quote_age_s": 0.5},
+    )
+
+    assert runner._is_option_symbol_tick_fresh("NFO:NIFTY26MAY24000CE", max_age_s=1.0)


### PR DESCRIPTION
## Root cause
`StrategyRunner._is_option_symbol_tick_fresh` used a second, incomplete quote-age parser and ignored `quote_age_s`, millisecond age fields, and other canonical schemas.

## What changed
- Delegated option freshness age resolution to `resolve_tick_age_ms`.
- Converted the configured seconds limit to milliseconds for comparison.
- Added a regression test for `quote_age_s`.

## What did not change
- Freshness threshold, broker fallback, subscription logic, risk, and execution behavior are unchanged.

## Validation
Commands run:
- `python -m pytest -q tests/strategies/test_runner_tick_age_contract.py tests/strategies/test_runner_execution_quote_readiness.py tests/strategies/test_runner_candidate_age_readiness.py`
- `python -m compileall -q src/nifty_scalper_bot/strategies/runner.py`
- `git diff --check`

Results:
- 3 passed
- compile and diff checks passed

## Runtime impact
Runner option freshness now follows the existing canonical quote-age contract and preserves the configured seconds limit.

## Regression risk
Low. This PR is dependent on PR #861 and changes one freshness parser plus focused coverage.