### PR TITLE
refactor: canonicalize app option age

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -11621,7 +11621,8 @@ async def startup_sequence(ctx: BotContext) -> None:
                                             datahub_bars[sym] = 0
                                     try:
                                         snap = ctx.market_data_manager.get_symbol_snapshot(sym)
-                                        if float(getattr(snap, "ltp", 0.0) or 0.0) > 0 and float(getattr(snap, "tick_age_s", 9999.0) or 9999.0) <= 60.0:
+                                        age = resolve_tick_age_seconds(snap)
+                                        if float(getattr(snap, "ltp", 0.0) or 0.0) > 0 and age is not None and age <= 60.0:
                                             fresh_quote_symbols.append(sym)
                                     except Exception:
                                         pass

--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -89,6 +89,7 @@ from nifty_scalper_bot.data.robust_provider import (
 )
 from nifty_scalper_bot.infra.watchdog import start_watchdog
 from nifty_scalper_bot.instruments.active_contracts import canonical_nifty_future_symbol
+from nifty_scalper_bot.execution.quote_readiness import resolve_tick_age_seconds
 from nifty_scalper_bot.execution.readiness import evaluate_quote_readiness, normalize_readiness_blockers
 from nifty_scalper_bot.utils.market_hours import (
     get_runtime_market_mode,
@@ -7879,8 +7880,8 @@ def _best_fresh_option(
         try:
             snap = ctx.market_data_manager.get_symbol_snapshot(sym) if ctx.market_data_manager is not None else None
             ltp = float(getattr(snap, "ltp", 0.0) or 0.0)
-            age = float(getattr(snap, "tick_age_s", 9999.0) or 9999.0)
-            quote_fresh = ltp > 0 and age <= max_age_s
+            age = resolve_tick_age_seconds(snap)
+            quote_fresh = ltp > 0 and age is not None and age <= max_age_s
         except Exception:
             quote_fresh = False
         score = 3 if quote_fresh else 0
@@ -7948,10 +7949,10 @@ def _fresh_option_quote(
     try:
         snap = ctx.market_data_manager.get_symbol_snapshot(symbol)
         ltp = float(getattr(snap, "ltp", 0.0) or 0.0)
-        age = float(getattr(snap, "tick_age_s", 9999.0) or 9999.0)
+        age = resolve_tick_age_seconds(snap)
     except Exception:
         return None
-    return symbol if ltp > 0 and age <= max_age_s else None
+    return symbol if ltp > 0 and age is not None and age <= max_age_s else None
 
 
 
@@ -8267,7 +8268,7 @@ async def _recompute_and_push_runtime_readiness(ctx: BotContext, *, reason: str)
         if snap is None: return False
         age_limit=max_age_s or _tick_age_threshold()
         ltp=float(getattr(snap,'ltp',0.0) or 0.0)
-        age=getattr(snap,'tick_age_s',None)
+        age=resolve_tick_age_seconds(snap)
         if ltp<=0: return False
         if age is not None:
             return float(age)<=age_limit

--- a/src/nifty_scalper_bot/core/strategy_manager.py
+++ b/src/nifty_scalper_bot/core/strategy_manager.py
@@ -4484,10 +4484,9 @@ class StrategyManager(_BaseStrategyManager):
                 spread_pct = float(md0.get("spread_pct") or indicators.get("spread_pct") or 999.0)
             except (TypeError, ValueError):
                 spread_pct = 999.0
-            try:
-                context_age = float(md0.get("context_age_seconds") or indicators.get("context_age_seconds") or 999.0)
-            except (TypeError, ValueError):
-                context_age = 999.0
+            context_age = resolve_context_age_seconds(
+                md0 if md0.get("context_age_seconds") is not None else indicators
+            )
             try:
                 bid = float(md0.get("bid") or indicators.get("bid") or 0.0)
             except (TypeError, ValueError):

--- a/src/nifty_scalper_bot/core/strategy_manager.py
+++ b/src/nifty_scalper_bot/core/strategy_manager.py
@@ -2896,6 +2896,9 @@ class StrategyManager(_BaseStrategyManager):
             max_context_age = self._live_context_max_age_seconds()
             now_ts = time.time()
             def _fresh(ctx: t.Mapping[str, t.Any]) -> bool:
+                age_seconds = resolve_tick_age_seconds(ctx)
+                if age_seconds is not None:
+                    return age_seconds <= max_context_age
                 try:
                     ts = float(ctx.get("timestamp") or ctx.get("context_timestamp_epoch") or 0.0)
                     return ts > 0 and (now_ts - ts) <= max_context_age

--- a/src/nifty_scalper_bot/core/strategy_manager.py
+++ b/src/nifty_scalper_bot/core/strategy_manager.py
@@ -42,6 +42,7 @@ from nifty_scalper_bot.utils.logging import get_logger, log_state_change, log_th
 from nifty_scalper_bot.utils.symbols import normalize_symbol
 from nifty_scalper_bot.execution.readiness import HistoryReadinessPolicy
 from nifty_scalper_bot.execution.quote_readiness import resolve_tick_age_seconds
+from nifty_scalper_bot.strategies.runtime_context_contract import resolve_context_age_seconds
 
 log = get_logger(__name__)
 
@@ -4287,10 +4288,7 @@ class StrategyManager(_BaseStrategyManager):
 
         direction_bias = str(indicator_map.get("direction_bias") or indicator_map.get("underlying_direction_bias") or "").upper()
         max_context_age = self._live_context_max_age_seconds()
-        try:
-            context_age_seconds = float(indicator_map.get("context_age_seconds"))
-        except (TypeError, ValueError):
-            context_age_seconds = 999.0
+        context_age_seconds = resolve_context_age_seconds(indicator_map)
         spread_pct = float(metadata.get("spread_pct") or indicator_map.get("spread_pct") or 999.0)
         selected_ok_combined = bool(selected_ok or near_atm)
         quote_depth_ok = bool(metadata.get("quote_depth_valid") or indicator_map.get("quote_depth_valid") or metadata.get("tradable_quote") or indicator_map.get("tradable_quote"))
@@ -4567,13 +4565,9 @@ class StrategyManager(_BaseStrategyManager):
             or ""
         ).upper()
         direction_aligned = direction_bias in {"CE", "PE"} and direction_bias == str(best_vote.side).upper()
-        age_raw = md0.get("context_age_seconds")
-        if age_raw is None:
-            age_raw = indicators.get("context_age_seconds")
-        try:
-            context_age_seconds = float(age_raw) if age_raw is not None else 999.0
-        except (TypeError, ValueError):
-            context_age_seconds = 999.0
+        context_age_seconds = resolve_context_age_seconds(
+            md0 if md0.get("context_age_seconds") is not None else indicators
+        )
         context_fresh = bool(
             md0.get("context_fresh")
             if md0.get("context_fresh") is not None

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -7827,9 +7827,9 @@ class StrategyRunner:
         """Return whether an existing quote/tick for symbol is fresh enough for live gates."""
         limit = float(os.getenv("OPTION_TICK_FRESH_MAX_AGE_S", "60") or 60.0)
         if quote is not None:
-            age = _extract_float(quote, "tick_age_s", "quote_age_s", "data_age_seconds", "age_s")
-            if age is not None:
-                return age <= limit
+            age_ms = resolve_tick_age_ms(quote)
+            if age_ms is not None:
+                return age_ms <= limit * 1000.0
             ts_raw = quote.get("timestamp") or quote.get("received_at") or quote.get("exchange_timestamp")
             if ts_raw is not None:
                 try:

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -98,6 +98,7 @@ from nifty_scalper_bot.execution.order_manager import OrderType, TradePlan
 from nifty_scalper_bot.execution.quote_readiness import (
     evaluate_execution_quote,
     resolve_tick_age_ms,
+    resolve_tick_age_seconds,
 )
 from nifty_scalper_bot.execution.readiness import HistoryReadinessPolicy, resolve_quote_bid_ask_spread
 from nifty_scalper_bot.execution.order_state_machine import (
@@ -3544,9 +3545,7 @@ class StrategyRunner:
                 or (strike_distance is not None and strike_distance <= near_threshold)
             )
             spread_pct = ((ask - bid) / ltp * 100.0) if has_bid_ask and ltp > 0 else None
-            tick_age_raw = getattr(snapshot, "tick_age_s", None)
-            tick_age_s = float(tick_age_raw) if tick_age_raw is not None else 0.0
-            tick_age_s = max(0.0, tick_age_s)
+            tick_age_s = resolve_tick_age_seconds(snapshot) or 0.0
             real_ticks_raw = getattr(snapshot, "real_ticks_last_60s", None)
             real_ticks_last_60s = int(real_ticks_raw) if real_ticks_raw is not None else 0
             if ltp > 0 and real_ticks_last_60s < 1:
@@ -5828,7 +5827,7 @@ class StrategyRunner:
         if self._market_data and hasattr(self._market_data, "get_symbol_snapshot"):
             snap = self._market_data.get_symbol_snapshot("NSE:NIFTY")
             if snap and getattr(snap, "ltp", None):
-                tick_age = float(getattr(snap, "tick_age_s", 0.0) or 0.0)
+                tick_age = resolve_tick_age_seconds(snap) or 0.0
                 return {
                     "symbol": "NSE:NIFTY",
                     "ltp": float(getattr(snap, "ltp")),

--- a/tests/strategies/test_runner_tick_age_contract.py
+++ b/tests/strategies/test_runner_tick_age_contract.py
@@ -11,5 +11,9 @@ def test_runner_option_freshness_uses_canonical_quote_age_schema(monkeypatch) ->
         "_get_cached_quote_for_live_entry",
         lambda symbol: {"quote_age_s": 0.5},
     )
+    monkeypatch.setattr(runner, "get_quote", lambda symbol: {"quote_age_s": 0.5})
 
     assert runner._is_option_symbol_tick_fresh("NFO:NIFTY26MAY24000CE", max_age_s=1.0)
+    assert runner._quote_fresh_for_symbol(
+        "NFO:NIFTY26MAY24000CE", {"quote_age_s": 0.5}
+    )


### PR DESCRIPTION
## Root cause
Three app-side option freshness checks independently read `tick_age_s`, duplicating the canonical quote-age contract and making schema handling inconsistent.

## What changed
- Reused `resolve_tick_age_seconds` in `_best_fresh_option`, `_fresh_option_quote`, and nested `_fresh_ltp`.
- Preserved LTP-positive checks and the existing timestamp fallback in `_fresh_ltp`.

## What did not change
- Readiness thresholds, bid/ask/depth gates, history hydration, risk, and execution behavior are unchanged.

## Validation
Commands run:
- `python -m pytest -q tests/core/test_readiness_live_tick_proof.py tests/core/test_strategy_live_safety.py`
- `python -m compileall -q src/nifty_scalper_bot/core/app.py`
- `git diff --check`

Results:
- 10 passed
- compile and diff checks passed

## Runtime impact
App option freshness now accepts the same normalized quote-age schema as other runtime paths. Missing age remains fail-closed except for the existing timestamp fallback in `_fresh_ltp`.

## Regression risk
Low. This PR is dependent on PR #862 and changes only age parsing in existing helpers.