### PR TITLE
refactor: centralize quote age resolution

### DIFF
--- a/src/nifty_scalper_bot/execution/quote_readiness.py
+++ b/src/nifty_scalper_bot/execution/quote_readiness.py
@@ -7,6 +7,7 @@ from typing import Any, Mapping
 from nifty_scalper_bot.execution.readiness import (
     quote_timestamp_quality_allows_hard_readiness,
     resolve_quote_bid_ask_spread,
+    resolve_quote_age_seconds,
 )
 
 
@@ -33,13 +34,8 @@ def _float(payload: Mapping[str, Any] | object | None, *keys: str) -> float | No
 
 
 def resolve_tick_age_ms(payload: Mapping[str, Any] | object | None) -> float | None:
-    age_ms = _float(payload, "tick_age_ms", "quote_age_ms", "last_tick_age_ms", "market_data_age_ms")
-    if age_ms is not None:
-        return max(0.0, age_ms)
-    age_s = _float(payload, "tick_age_s", "quote_age_s", "data_age_seconds", "age_s", "age_seconds", "last_tick_age_s", "market_data_age_s")
-    if age_s is not None:
-        return max(0.0, age_s * 1000.0)
-    return None
+    age_s = resolve_quote_age_seconds(payload)
+    return None if age_s is None else age_s * 1000.0
 
 
 def resolve_tick_age_seconds(payload: Mapping[str, Any] | object | None) -> float | None:

--- a/src/nifty_scalper_bot/execution/readiness.py
+++ b/src/nifty_scalper_bot/execution/readiness.py
@@ -414,7 +414,7 @@ def _quote_float(payload: dict | object, *keys: str) -> float | None:
     return None
 
 
-def _quote_age_seconds(payload: dict | object) -> float | None:
+def resolve_quote_age_seconds(payload: dict | object) -> float | None:
     age_ms = _quote_float(
         payload,
         "tick_age_ms",
@@ -550,7 +550,7 @@ def evaluate_quote_readiness(
     else:
         reason = "ready"
     if reason == "ready" and require_fresh:
-        age = _quote_age_seconds(quote)
+        age = resolve_quote_age_seconds(quote)
         if age is None:
             ts = _quote_float(quote, "timestamp_ms", "last_tick_ts_ms")
             if ts and ts > 10_000_000_000:


### PR DESCRIPTION
## Root cause
`execution/readiness.py` and `execution/quote_readiness.py` independently implemented the same quote-age field precedence and normalization.

## What changed
- Added the canonical `resolve_quote_age_seconds` in `execution/readiness.py`.
- Updated runtime quote readiness to use it.
- Updated `resolve_tick_age_ms` to delegate while preserving its public API and units.

## What did not change
- Quote thresholds, missing-age blockers, depth checks, timestamp-quality rules, risk, and execution behavior are unchanged.

## Validation
Commands run:
- `python -m pytest -q tests/execution/test_quote_readiness.py tests/execution/test_live_readiness_blocker_recovery.py`
- `python -m compileall -q src/nifty_scalper_bot/execution/readiness.py src/nifty_scalper_bot/execution/quote_readiness.py`
- `git diff --check`

Results:
- 15 passed
- compile and diff checks passed

## Runtime impact
All quote-age consumers now share one field precedence and normalization path; millisecond callers receive the same values as before.

## Regression risk
Low. This PR is dependent on PR #865 and changes only age-resolution ownership.