### PR TITLE
Exit fill-latency grace: quiet deferral + rescue skip while broker flat

### DIFF
--- a/src/nifty_scalper_bot/execution/canonical_bracket_manager.py
+++ b/src/nifty_scalper_bot/execution/canonical_bracket_manager.py
@@ -461,6 +461,27 @@ class CanonicalBracketManager(HardenedBracketManager):
     ) -> None:
         """Cancel/replace stale exits without treating a non-flat fill as closure."""
 
+        if self._safe_position_flat(bracket.symbol):
+            _since = getattr(bracket, "_flat_nonterminal_since", None)
+            import time as _t
+
+            if _since is None or (_t.time() - float(_since)) < 10.0:
+                # Broker already FLAT: the exit filled and only the order
+                # status is propagating. Cancel-racing a filled order is pure
+                # churn ('Skipping cancel: Already FILLED', 2026-07-10);
+                # the reconcile loop confirms and closes within the grace.
+                _legacy.LOGGER.info(
+                    "EXIT_RESCUE_SKIPPED_FLAT_LATENCY bracket_id=%s order_id=%s status=%s",
+                    bracket.bracket_id,
+                    order_id,
+                    status,
+                    extra={
+                        "event": "EXIT_RESCUE_SKIPPED_FLAT_LATENCY",
+                        "bracket_id": bracket.bracket_id,
+                        "order_id": order_id,
+                    },
+                )
+                return
         with self._lock:
             if bracket.exit_in_progress:
                 return

--- a/src/nifty_scalper_bot/execution/live_exit_reconciliation_patch.py
+++ b/src/nifty_scalper_bot/execution/live_exit_reconciliation_patch.py
@@ -16,6 +16,11 @@ from contextlib import suppress
 import time
 from typing import Any, Mapping
 
+# Broker-flat + non-terminal exit-order status is expected for a few seconds
+# after a fill (order endpoint propagation lag). Below this age: INFO + no
+# rescue; above: WARNING and normal escalation.
+_FLAT_FILL_CONFIRM_GRACE_SEC = 10.0
+
 from nifty_scalper_bot.execution import bracket_core as _legacy
 from nifty_scalper_bot.utils.symbols import normalize_symbol
 
@@ -228,13 +233,27 @@ def _patched_reconcile_exit_state(self: Any, bracket: Any, *, requested_by: str)
 
     if flat and order_id:
         if order_status in _OPEN_OR_PENDING_STATUSES or order_status not in _TERMINAL_FILLED:
+            _now = time.time()
             with self._lock:
                 bracket.exit_pending = True
                 bracket.exit_state = _legacy.BracketExitLifecycle.EXIT_ORDER_SUBMITTED.value
                 bracket.entry_status = bracket.exit_state
                 bracket.position_flat_confirmed = False
-                bracket.updated_at = time.time()
-            _legacy.LOGGER.warning(
+                bracket.updated_at = _now
+                if getattr(bracket, "_flat_nonterminal_since", None) is None:
+                    bracket._flat_nonterminal_since = _now
+            _flat_age = _now - float(bracket._flat_nonterminal_since)
+            # Broker flat while the order status is still propagating is the
+            # NORMAL fill-latency shape (Kite orders endpoint lags fills by
+            # 1-3s; 2026-07-10 15:00 produced 3 warnings + watchdog + rescue
+            # for an already-FILLED exit). Inside the grace window this is
+            # informational; only a genuinely stuck confirmation escalates.
+            _log = (
+                _legacy.LOGGER.info
+                if _flat_age < _FLAT_FILL_CONFIRM_GRACE_SEC
+                else _legacy.LOGGER.warning
+            )
+            _log(
                 "EXIT_FLAT_BUT_ORDER_NOT_TERMINAL bracket_id=%s symbol=%s order_id=%s order_status=%s fill_price=%s close_deferred=True",
                 bracket.bracket_id,
                 bracket.symbol,

--- a/tests/execution/test_live_exit_hardening.py
+++ b/tests/execution/test_live_exit_hardening.py
@@ -338,3 +338,113 @@ def test_stale_atr_degrades_to_bounded_fallback_instead_of_disabling_trailing() 
     assert controller.trailing_active is True
     assert updates
     assert 80.0 < updates[-1] < 102.0
+
+
+def test_flat_fill_latency_defers_quietly_and_rescue_skips(monkeypatch, tmp_path):
+    """2026-07-10 15:00 lifecycle: broker went FLAT while the exit order status
+    still read OPEN PENDING (normal 1-3s propagation lag). Within the grace
+    window the reconcile must defer at INFO (not WARNING), stamp
+    _flat_nonterminal_since, and the stale-order rescue must SKIP instead of
+    cancel-racing an already-filled order; once the status turns COMPLETE the
+    bracket closes. Exactly one exit order end-to-end."""
+    import logging
+
+    from nifty_scalper_bot.execution.bracket_manager import BracketManager
+
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    status = {"value": "OPEN PENDING", "flat": False}
+    orders: list = []
+
+    class _OM:
+        def place_reduce_only_exit(self, intent):
+            orders.append("exit")
+            return "EXIT-1"
+
+        def place_order(self, **kwargs):
+            orders.append("exit")
+            return "EXIT-1"
+
+        def get_order_status(self, _oid):
+            return {
+                "status": status["value"],
+                "average_price": 102.90 if status["value"] == "COMPLETE" else None,
+            }
+
+    om = _OM()
+
+    class _BrokerStub:
+        def get_positions(self):
+            if status["flat"]:
+                return []
+            return [{"symbol": "NFO:NIFTYLAT24200PE", "quantity": 65}]
+
+        def get_order_status(self, oid):
+            return om.get_order_status(oid)
+
+    om._broker = _BrokerStub()
+    bm = BracketManager(order_manager=om)
+    bm._running = False
+    bm._exit_reconcile_interval_seconds = 0.0
+    bm._filled_position_sync_grace_seconds = 0.0
+    try:
+        bm.register_virtual_bracket(
+            order_id="lat-1", symbol="NFO:NIFTYLAT24200PE", side="BUY", qty=65,
+            price=103.30, sl=97.85, tp=115.45, activate_immediately=False,
+        )
+        bm.confirm_entry_fill("lat-1", 103.75)
+        bracket = bm.get_bracket("lat-1")
+        for px in (104.5, 105.3, 106.15, 102.95):
+            bm.on_tick("NFO:NIFTYLAT24200PE", px)
+        assert bracket.exit_pending is True and orders == ["exit"]
+
+        # Broker flat, order status lagging: force the authoritative flat view
+        # and the strict-live reconcile path (the branch production runs).
+        status["flat"] = True
+        monkeypatch.setattr(
+            type(bm), "_position_flat_for_symbol", lambda self, s: True
+        )
+        from nifty_scalper_bot.execution import live_exit_reconciliation_patch as _lerp
+
+        monkeypatch.setattr(_lerp, "_strict_live", lambda _self: True)
+        records: list = []
+
+        class _Cap(logging.Handler):
+            def emit(self, record):
+                records.append(record)
+
+        from nifty_scalper_bot.execution import bracket_core
+
+        _prev_level = bracket_core.LOGGER.level
+        bracket_core.LOGGER.setLevel(logging.INFO)
+        bracket_core.LOGGER.addHandler(_Cap())
+        try:
+            result = bm._reconcile_exit_state(bracket, requested_by="watchdog")
+        finally:
+            bracket_core.LOGGER.setLevel(_prev_level)
+            bracket_core.LOGGER.handlers = [
+                h for h in bracket_core.LOGGER.handlers if not isinstance(h, _Cap)
+            ]
+        assert result is False
+        assert getattr(bracket, "_flat_nonterminal_since", None) is not None
+        lag_logs = [r for r in records if "EXIT_FLAT_BUT_ORDER_NOT_TERMINAL" in r.getMessage()]
+        assert lag_logs and all(r.levelno == logging.INFO for r in lag_logs), [
+            (r.levelname, r.getMessage()[:60]) for r in lag_logs
+        ]
+
+        # Rescue must skip while flat inside the grace window (no cancel race).
+        bm._rescue_stale_exit_order(
+            bracket, order_id="EXIT-1", qty=65, status="OPEN PENDING"
+        )
+        assert orders == ["exit"]
+        assert bracket.exit_in_progress is False
+
+        # Status propagates -> closure completes with the real fill price.
+        status["value"] = "COMPLETE"
+        closed = bm._reconcile_exit_state(bracket, requested_by="watchdog")
+        if not closed:  # strict-live filled handoff may need one follow-up pass
+            closed = bm._reconcile_exit_state(bracket, requested_by="watchdog")
+        assert closed is True
+        assert bracket.exit_state == "CLOSED"
+        assert orders == ["exit"]
+    finally:
+        bm._running = False


### PR DESCRIPTION
Log-driven (2026-07-10 15:00, complete real trade): trailing SL, single exit authority and the virtual bracket all worked LIVE (SL trailed above entry, one exit order, filled). The closure phase treated normal 1-3s Kite fill-status propagation as an emergency: 3 warnings + 2 watchdog triggers + a rescue cancel-racing an already-FILLED order.

Fixes: strict-live reconcile stamps _flat_nonterminal_since and defers at INFO within a 10s grace (WARNING only beyond it, fail-closed deferral unchanged); stale-order rescue skips while the broker is already flat inside that grace (EXIT_RESCUE_SKIPPED_FLAT_LATENCY), rescuing genuinely stuck exits exactly as before.

New regression drives the strict-live branch through the full cycle: entry -> re-anchor -> trailing ratchet -> single SL exit -> lag deferral (INFO, stamped) -> rescue skip -> COMPLETE -> CLOSED, exactly one exit order. Full suite green, compileall clean, no loss of function.