### PR TITLE
readiness: reuse canonical quote evaluator

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -8407,9 +8407,20 @@ async def _recompute_and_push_runtime_readiness(ctx: BotContext, *, reason: str)
             context_only_blockers,
             extra={"event": "CONTEXT_SYMBOL_BLOCKERS_NON_GATING", "blockers": context_only_blockers},
         )
+    quote_quality_blockers = {
+        "quote_missing",
+        "ltp_missing",
+        "quote_age_unknown",
+        "quote_stale",
+        "timestamp_quality_unusable",
+        "bid_ask_missing",
+        "bid_ask_crossed",
+        "spread_too_wide",
+        "quote_not_tradable",
+    }
     hydration_hard_blockers = [
         blocker for blocker in status_blockers
-        if not (blocker.endswith("_quote_missing") or blocker.endswith("_depth_missing") or blocker == "spread_too_wide" or blocker.endswith("_token_missing") or blocker == "option_token_missing")
+        if not (blocker.endswith("_quote_missing") or blocker.endswith("_depth_missing") or blocker in quote_quality_blockers or blocker.endswith("_token_missing") or blocker == "option_token_missing")
     ]
     if hydration_hard_blockers:
         basket_hard_ready = False
@@ -8434,6 +8445,8 @@ async def _recompute_and_push_runtime_readiness(ctx: BotContext, *, reason: str)
     )
     selected_history_blockers = {
         "selected_option_history_cold",
+        "selected_ce_history_cold",
+        "selected_pe_history_cold",
         "selected_ce_history_missing",
         "selected_pe_history_missing",
         "ce_eval_bars_missing",

--- a/src/nifty_scalper_bot/core/history_readiness.py
+++ b/src/nifty_scalper_bot/core/history_readiness.py
@@ -47,7 +47,7 @@ from nifty_scalper_bot.core.history_roles import (
 from nifty_scalper_bot.execution.readiness import (
     HistoryReadinessPolicy,
     HydrationStatus,
-    resolve_quote_bid_ask_spread,
+    evaluate_quote_readiness,
 )
 from nifty_scalper_bot.utils.market_hours import get_runtime_market_mode
 from nifty_scalper_bot.utils.logging import get_logger
@@ -247,23 +247,23 @@ def build_symbol_hydration_status(
     bars_for_ts = _get_bars_from_provider(mdm, normalized) or _get_bars_from_provider(datahub, normalized)
     timestamps = [ts for ts in (_bar_timestamp(row) for row in bars_for_ts) if ts is not None]
     quote = _get_cached_quote(ctx, normalized)
-    bid, ask, spread_pct, _source = resolve_quote_bid_ask_spread(dict(quote))
-    depth = quote.get("depth") if isinstance(quote, Mapping) else None
-    depth_available = bool(quote.get("depth_available") or depth)
-    tradable_quote = bool(quote.get("tradable_quote") or (bid is not None and ask is not None and ask > bid))
-    live_tick_fresh = False
-    age_ms_fn = getattr(mdm, "symbol_data_age_ms", None)
-    if callable(age_ms_fn):
-        try:
-            live_tick_fresh = float(age_ms_fn(normalized)) <= float(os.getenv("HYDRATION_LIVE_TICK_MAX_AGE_MS", "60000"))
-        except (TypeError, ValueError):
-            live_tick_fresh = False
-    if not live_tick_fresh and isinstance(quote, Mapping):
-        try:
-            age_s = quote.get("tick_age_s") or quote.get("age_s")
-            live_tick_fresh = age_s is not None and float(age_s) <= 60.0
-        except (TypeError, ValueError):
-            live_tick_fresh = False
+    max_quote_age_s = float(os.getenv("HYDRATION_LIVE_TICK_MAX_AGE_MS", "60000") or 60000) / 1000.0
+    max_spread = float(os.getenv("HYDRATION_MAX_SPREAD_PCT", os.getenv("MAX_OPTION_SPREAD_PCT", "12")) or 12)
+    quote_ready = evaluate_quote_readiness(
+        normalized,
+        dict(quote) if isinstance(quote, Mapping) else quote,
+        max_spread_pct=max_spread,
+        require_fresh=True,
+        max_age_s=max_quote_age_s,
+    )
+    bid = quote_ready.bid
+    ask = quote_ready.ask
+    spread_pct = quote_ready.spread_pct
+    # Top-level bid/ask and depth top-of-book are both canonical quote proof;
+    # do not require a separate depth flag unless final order preflight does so.
+    depth_available = bool(quote_ready.depth_available or quote_ready.bid_ask_available)
+    tradable_quote = bool(quote_ready.tradable_quote_ready)
+    live_tick_fresh = quote_ready.reason not in {"quote_age_unknown", "quote_stale", "timestamp_quality_unusable", "quote_missing"}
     exchange = normalized.split(":", 1)[0] if ":" in normalized else None
     tradingsymbol = normalized.split(":", 1)[1] if ":" in normalized else normalized or None
     gating_counts = [mdm_bars, runner_bars, indicator_bars]
@@ -273,25 +273,22 @@ def build_symbol_hydration_status(
     if token is None and role in {"selected_ce", "selected_pe", "option_context", "futures_context"}:
         blockers.append("option_token_missing" if role.startswith("selected_") or role == "option_context" else "futures_token_missing")
     if required > 0 and any(count < required for count in gating_counts):
-        blockers.append(f"{role}_history_missing")
-        blockers.append("insufficient_bars")
-        if mdm_bars < required:
-            blockers.append("mdm_bars_missing")
-        if runner_bars < required:
-            blockers.append("runner_bars_missing")
-        if indicator_bars < required:
-            blockers.append("indicator_bars_missing")
+        blockers.append(f"{role}_history_cold")
     selected_role = role in {"selected_ce", "selected_pe"}
-    if selected_role:
-        if not tradable_quote:
-            blockers.append(f"{role}_quote_missing")
-        if not depth_available:
-            blockers.append(f"{role}_depth_missing")
-        max_spread = float(os.getenv("HYDRATION_MAX_SPREAD_PCT", os.getenv("MAX_OPTION_SPREAD_PCT", "12")) or 12)
-        if spread_pct is not None and spread_pct > max_spread:
-            blockers.append("spread_too_wide")
+    if selected_role and quote_ready.reason != "ready":
+        blockers.append(quote_ready.reason)
     ready_for_evaluation = bool(normalized and required >= 0 and all(count >= required for count in gating_counts))
-    ready_for_execution = bool(ready_for_evaluation and (not selected_role or (tradable_quote and depth_available and "spread_too_wide" not in blockers)))
+    ready_for_execution = bool(
+        ready_for_evaluation
+        and (
+            not selected_role
+            or (
+                token is not None
+                and tradable_quote
+                and quote_ready.reason == "ready"
+            )
+        )
+    )
     status = HydrationStatus(
         symbol=normalized,
         role=role,

--- a/tests/core/test_hydration_datahub_not_gating.py
+++ b/tests/core/test_hydration_datahub_not_gating.py
@@ -66,5 +66,4 @@ async def test_genuine_history_shortfall_still_blocks() -> None:
     ctx = _ctx(mdm_n=51, datahub_n=51, runner_n=10, indicator_n=46, sym=SYM)
     status = build_symbol_hydration_status(ctx, SYM, "selected_ce", 30)
     assert status.ready_for_evaluation is False
-    assert "insufficient_bars" in status.blocker_reasons
-    assert "runner_bars_missing" in status.blocker_reasons
+    assert "selected_ce_history_cold" in status.blocker_reasons

--- a/tests/core/test_hydration_status_propagation.py
+++ b/tests/core/test_hydration_status_propagation.py
@@ -66,6 +66,7 @@ class _Runner:
 
 def _quote() -> dict[str, object]:
     return {
+        "ltp": 100.5,
         "bid": 100.0,
         "ask": 101.0,
         "tradable_quote": True,
@@ -147,5 +148,57 @@ def test_synthetic_timestamp_quote_does_not_make_selected_option_execution_ready
 
     assert status.ready_for_evaluation is True
     assert status.ready_for_execution is False
+    assert status.tradable_quote is False
+    assert "timestamp_quality_unusable" in status.blocker_reasons
+
+
+def test_selected_option_execution_ready_with_top_level_bid_ask_without_depth_flag() -> None:
+    quote = {"ltp": 100.5, "bid": 100.0, "ask": 101.0, "tick_age_s": 1.0}
+
+    status = app.build_symbol_hydration_status(_ctx(30, 30, 30, 30, quote), SYMBOL, "selected_ce", 30)
+
+    assert status.ready_for_execution is True
     assert status.tradable_quote is True
-    assert "selected_ce_quote_missing" in status.blocker_reasons
+    assert status.depth_available is True
+
+
+def test_selected_option_execution_ready_with_depth_top_of_book() -> None:
+    quote = {
+        "ltp": 100.5,
+        "depth": {"buy": [{"price": 100.0}], "sell": [{"price": 101.0}]},
+        "tick_age_s": 1.0,
+    }
+
+    status = app.build_symbol_hydration_status(_ctx(30, 30, 30, 30, quote), SYMBOL, "selected_ce", 30)
+
+    assert status.ready_for_execution is True
+    assert status.bid == 100.0
+    assert status.ask == 101.0
+
+
+def test_stale_quote_does_not_make_selected_option_execution_ready() -> None:
+    quote = {**_quote(), "tick_age_s": 120.0}
+
+    status = app.build_symbol_hydration_status(_ctx(30, 30, 30, 30, quote), SYMBOL, "selected_ce", 30)
+
+    assert status.ready_for_execution is False
+    assert "quote_stale" in status.blocker_reasons
+
+
+def test_unknown_quote_age_does_not_make_selected_option_execution_ready() -> None:
+    quote = dict(_quote())
+    quote.pop("tick_age_s")
+
+    status = app.build_symbol_hydration_status(_ctx(30, 30, 30, 30, quote), SYMBOL, "selected_ce", 30)
+
+    assert status.ready_for_execution is False
+    assert "quote_age_unknown" in status.blocker_reasons
+
+
+def test_wide_spread_does_not_make_selected_option_execution_ready() -> None:
+    quote = {**_quote(), "bid": 100.0, "ask": 130.0}
+
+    status = app.build_symbol_hydration_status(_ctx(30, 30, 30, 30, quote), SYMBOL, "selected_ce", 30)
+
+    assert status.ready_for_execution is False
+    assert "spread_too_wide" in status.blocker_reasons


### PR DESCRIPTION
### Motivation

- Remove duplicated quote/freshness/depth logic in `build_symbol_hydration_status()` and reuse the canonical evaluator to avoid inconsistent readiness semantics.  
- Ensure selected CE/PE execution readiness is fail-closed for stale/unknown/invalid timestamp quotes and respects canonical spread and bid/ask rules.  
- Simplify depth/tradable-quote handling so valid top-level bid/ask or depth top-of-book both prove a tradable quote without an extra redundant depth flag.

### Description

- Replaced ad-hoc bid/ask/age/depth/spread logic in `src/nifty_scalper_bot/core/history_readiness.py` with the canonical `evaluate_quote_readiness(...)` results and used its returned fields for `bid`, `ask`, `spread_pct`, `depth_available`, `tradable_quote`, and quote blocker reason.  
- Tightened execution semantics: selected CE/PE `ready_for_execution` now requires history readiness, a resolved token, and `evaluate_quote_readiness` to report `ready` (fresh, non-crossed, within-spread tradable quote).  
- Simplified depth handling: treat valid top-level bid/ask OR depth top-of-book as quote proof and set `depth_available` accordingly; do not require a separate hard `depth_available=True` when bid/ask prove tradability.  
- Consolidated symbol history blockers to a single canonical `{role}_history_cold` while preserving `mdm_bars`, `runner_bars`, and `indicator_bars` in `HydrationStatus` for diagnostics.  
- Adjusted app-level hydration logic in `src/nifty_scalper_bot/core/app.py` so quote-quality blockers remain execution blockers rather than forcing history hard-failure, and added the canonical selected CE/PE history-cold blockers to the stale-history-clear set.  
- Updated and added focused tests in `tests/core/*` to cover: top-level bid/ask readiness without separate depth flag, depth top-of-book readiness, stale quote, unknown-age quote, synthetic timestamp quality, wide-spread blocking, and DataHub-not-gating behavior.  
- Files changed: `src/nifty_scalper_bot/core/history_readiness.py`, `src/nifty_scalper_bot/core/app.py`, `tests/core/test_hydration_status_propagation.py`, `tests/core/test_hydration_datahub_not_gating.py`.

### Testing

- Commands run: `python -m compileall -q src` and `pytest -q` plus focused test runs for readiness and lifecycle slices such as `tests/execution/test_quote_readiness.py`, `tests/core/test_hydration_status_propagation.py`, `tests/core/test_hydration_datahub_not_gating.py`, `tests/core/test_readiness_live_tick_proof.py`, and several execution/strategy lifecycle suites.  
- Targeted readiness tests and lifecycle regression suites passed (see CI output).  
- Full test suite summary: `1518 collected, 1516 passed, 2 skipped`.  
- Additional checks: compile (`python -m compileall -q src`) passed and `git diff --check` returned no problems.

Branch: `readiness-canonical-quote` (commit message: `readiness: reuse canonical quote evaluator`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5304f246f48324b7538970b3e6530b)