### PR TITLE
Harden readiness quote-age handling and CI quality tooling

### DIFF
--- a/.github/workflows/live-exit-safety-ci.yml
+++ b/.github/workflows/live-exit-safety-ci.yml
@@ -39,21 +39,21 @@ jobs:
         run: python -m compileall -q src dashboard scripts
       - name: Scoped ruff lint
         run: |
-          ruff check \
+          python -m ruff check \
             src/nifty_scalper_bot/execution/broker_position_evidence.py \
             src/nifty_scalper_bot/execution/order_state.py \
             tests/core/test_eod_flatten_schedule.py \
             tests/execution/test_broker_position_and_order_state.py
       - name: Scoped black format check
         run: |
-          black --check \
+          python -m black --check \
             src/nifty_scalper_bot/execution/broker_position_evidence.py \
             src/nifty_scalper_bot/execution/order_state.py \
             tests/core/test_eod_flatten_schedule.py \
             tests/execution/test_broker_position_and_order_state.py
       - name: Scoped mypy typecheck
         run: |
-          mypy --follow-imports=skip \
+          python -m mypy --follow-imports=skip \
             src/nifty_scalper_bot/execution/broker_position_evidence.py \
             src/nifty_scalper_bot/execution/order_state.py \
             src/nifty_scalper_bot/execution/canonical_bracket_manager.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ include = ["nifty_scalper_bot*"]
 [project.optional-dependencies]
 dev = [
     "black>=24.3.0",
+    "ruff>=0.5.0",
     "mypy>=1.9.0",
     "pytest>=7.4",
 ]

--- a/src/nifty_scalper_bot/core/history_readiness.py
+++ b/src/nifty_scalper_bot/core/history_readiness.py
@@ -35,24 +35,25 @@ Safe-edit notes:
 from __future__ import annotations
 
 import os
-from nifty_scalper_bot.config.defaults import DEFAULT_OPTION_EXEC_MIN_BARS as _DEFAULT_OPT_MIN_BARS
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Any, Mapping
+from typing import TYPE_CHECKING, Any, Mapping
 
+from nifty_scalper_bot.config.defaults import (
+    DEFAULT_OPTION_EXEC_MIN_BARS as _DEFAULT_OPT_MIN_BARS,
+)
+from nifty_scalper_bot.config.env_utils import parse_float_env
 from nifty_scalper_bot.core.active_basket import pick_atm_option_symbols_from_basket
 from nifty_scalper_bot.core.history_roles import (
     resolve_symbol_history_role as _shared_resolve_symbol_history_role,
 )
 from nifty_scalper_bot.execution.readiness import (
-    HistoryReadinessPolicy,
     HydrationStatus,
     evaluate_quote_readiness,
+    resolve_max_quote_age_seconds,
 )
-from nifty_scalper_bot.utils.market_hours import get_runtime_market_mode
 from nifty_scalper_bot.utils.logging import get_logger
-
-from typing import TYPE_CHECKING
+from nifty_scalper_bot.utils.market_hours import get_runtime_market_mode
 
 if TYPE_CHECKING:
     from nifty_scalper_bot.core.app import BotContext
@@ -78,7 +79,9 @@ def _count_bars_from_provider(provider: Any, symbol: str, *, limit: int = 500) -
         return 0
 
 
-def _get_bars_from_provider(provider: Any, symbol: str, *, limit: int = 500) -> list[Any]:
+def _get_bars_from_provider(
+    provider: Any, symbol: str, *, limit: int = 500
+) -> list[Any]:
     """Read cached OHLC bars from a provider without triggering historical fetch."""
     if provider is None or not symbol:
         return []
@@ -100,7 +103,12 @@ def _bar_timestamp(row: Any) -> datetime | None:
     """Extract a UTC timestamp from a cached bar-like object."""
     value = None
     if isinstance(row, Mapping):
-        value = row.get("timestamp") or row.get("start") or row.get("date") or row.get("time")
+        value = (
+            row.get("timestamp")
+            or row.get("start")
+            or row.get("date")
+            or row.get("time")
+        )
     else:
         value = getattr(row, "timestamp", None) or getattr(row, "start", None)
     try:
@@ -109,7 +117,9 @@ def _bar_timestamp(row: Any) -> datetime | None:
         if isinstance(value, (int, float)):
             return datetime.fromtimestamp(float(value), tz=timezone.utc)
         if value:
-            return datetime.fromisoformat(str(value).replace("Z", "+00:00")).astimezone(timezone.utc)
+            return datetime.fromisoformat(str(value).replace("Z", "+00:00")).astimezone(
+                timezone.utc
+            )
     except (TypeError, ValueError):
         return None
     return None
@@ -172,15 +182,35 @@ def _basket_get(basket: Any, key: str, default: Any = None) -> Any:
 
 
 def _basket_option_symbols(basket: Any) -> list[str]:
-    raw = _basket_get(basket, "option_symbols", None) or _basket_get(basket, "symbols", ()) or ()
+    raw = (
+        _basket_get(basket, "option_symbols", None)
+        or _basket_get(basket, "symbols", ())
+        or ()
+    )
     return [str(sym) for sym in raw if str(sym).endswith(("CE", "PE"))]
 
 
 def _active_selection_symbols(ctx: "BotContext") -> tuple[str | None, str | None]:
     """Read selected CE/PE directly from active basket without mutating context."""
-    basket = getattr(ctx, "active_contract_basket", None) or getattr(ctx, "active_trading_universe", None)
-    ce = str(_basket_get(basket, "selected_ce", None) or _basket_get(basket, "atm_ce", None) or "") or None
-    pe = str(_basket_get(basket, "selected_pe", None) or _basket_get(basket, "atm_pe", None) or "") or None
+    basket = getattr(ctx, "active_contract_basket", None) or getattr(
+        ctx, "active_trading_universe", None
+    )
+    ce = (
+        str(
+            _basket_get(basket, "selected_ce", None)
+            or _basket_get(basket, "atm_ce", None)
+            or ""
+        )
+        or None
+    )
+    pe = (
+        str(
+            _basket_get(basket, "selected_pe", None)
+            or _basket_get(basket, "atm_pe", None)
+            or ""
+        )
+        or None
+    )
     return ce, pe
 
 
@@ -228,7 +258,11 @@ def build_symbol_hydration_status(
                     token = None
 
     mdm_bars = _count_bars_from_provider(mdm, normalized)
-    datahub_bars = _count_bars_from_provider(datahub, normalized) if datahub is not None else mdm_bars
+    datahub_bars = (
+        _count_bars_from_provider(datahub, normalized)
+        if datahub is not None
+        else mdm_bars
+    )
     runner_bars = 0
     indicator_bars = 0
     if runner is not None:
@@ -244,11 +278,21 @@ def build_symbol_hydration_status(
                 indicator_bars = 0
         if runner_bars == 0 and indicator_bars > 0:
             runner_bars = indicator_bars
-    bars_for_ts = _get_bars_from_provider(mdm, normalized) or _get_bars_from_provider(datahub, normalized)
-    timestamps = [ts for ts in (_bar_timestamp(row) for row in bars_for_ts) if ts is not None]
+    bars_for_ts = _get_bars_from_provider(mdm, normalized) or _get_bars_from_provider(
+        datahub, normalized
+    )
+    timestamps = [
+        ts for ts in (_bar_timestamp(row) for row in bars_for_ts) if ts is not None
+    ]
     quote = _get_cached_quote(ctx, normalized)
-    max_quote_age_s = float(os.getenv("HYDRATION_LIVE_TICK_MAX_AGE_MS", "60000") or 60000) / 1000.0
-    max_spread = float(os.getenv("HYDRATION_MAX_SPREAD_PCT", os.getenv("MAX_OPTION_SPREAD_PCT", "12")) or 12)
+    max_quote_age_s = resolve_max_quote_age_seconds(
+        "HYDRATION_LIVE_TICK_MAX_AGE_SECONDS",
+        "HYDRATION_LIVE_TICK_MAX_AGE_MS",
+        default_seconds=60.0,
+    )
+    max_spread = parse_float_env(
+        os.getenv("HYDRATION_MAX_SPREAD_PCT", os.getenv("MAX_OPTION_SPREAD_PCT")), 12.0
+    )
     quote_ready = evaluate_quote_readiness(
         normalized,
         dict(quote) if isinstance(quote, Mapping) else quote,
@@ -263,30 +307,46 @@ def build_symbol_hydration_status(
     # do not require a separate depth flag unless final order preflight does so.
     depth_available = bool(quote_ready.depth_available or quote_ready.bid_ask_available)
     tradable_quote = bool(quote_ready.tradable_quote_ready)
-    live_tick_fresh = quote_ready.reason not in {"quote_age_unknown", "quote_stale", "timestamp_quality_unusable", "quote_missing"}
+    live_tick_fresh = quote_ready.reason not in {
+        "quote_age_unknown",
+        "quote_stale",
+        "timestamp_quality_unusable",
+        "quote_missing",
+    }
     exchange = normalized.split(":", 1)[0] if ":" in normalized else None
-    tradingsymbol = normalized.split(":", 1)[1] if ":" in normalized else normalized or None
+    tradingsymbol = (
+        normalized.split(":", 1)[1] if ":" in normalized else normalized or None
+    )
     gating_counts = [mdm_bars, runner_bars, indicator_bars]
     blockers: list[str] = []
     if not normalized:
         blockers.append(f"{role}_symbol_missing")
-    if token is None and role in {"selected_ce", "selected_pe", "option_context", "futures_context"}:
-        blockers.append("option_token_missing" if role.startswith("selected_") or role == "option_context" else "futures_token_missing")
+    if token is None and role in {
+        "selected_ce",
+        "selected_pe",
+        "option_context",
+        "futures_context",
+    }:
+        blockers.append(
+            "option_token_missing"
+            if role.startswith("selected_") or role == "option_context"
+            else "futures_token_missing"
+        )
     if required > 0 and any(count < required for count in gating_counts):
         blockers.append(f"{role}_history_cold")
     selected_role = role in {"selected_ce", "selected_pe"}
     if selected_role and quote_ready.reason != "ready":
         blockers.append(quote_ready.reason)
-    ready_for_evaluation = bool(normalized and required >= 0 and all(count >= required for count in gating_counts))
+    ready_for_evaluation = bool(
+        normalized
+        and required >= 0
+        and all(count >= required for count in gating_counts)
+    )
     ready_for_execution = bool(
         ready_for_evaluation
         and (
             not selected_role
-            or (
-                token is not None
-                and tradable_quote
-                and quote_ready.reason == "ready"
-            )
+            or (token is not None and tradable_quote and quote_ready.reason == "ready")
         )
     )
     status = HydrationStatus(
@@ -313,7 +373,9 @@ def build_symbol_hydration_status(
         blocker_reasons=list(dict.fromkeys(blockers)),
         first_bar_ts=min(timestamps) if timestamps else None,
         last_bar_ts=max(timestamps) if timestamps else None,
-        live_merge_applied=bool(mdm_bars and datahub_bars and (mdm_bars == datahub_bars)),
+        live_merge_applied=bool(
+            mdm_bars and datahub_bars and (mdm_bars == datahub_bars)
+        ),
     )
     LOGGER.debug(
         "HYDRATION_PROPAGATION_RESULT symbol=%s role=%s required_bars=%s mdm_bars=%s datahub_bars=%s runner_bars=%s indicator_bars=%s tradable_quote=%s depth_available=%s ready_for_evaluation=%s ready_for_execution=%s blockers=%s",
@@ -334,7 +396,9 @@ def build_symbol_hydration_status(
     return status
 
 
-def _hydration_status_map(ctx: "BotContext", *, required_option_bars: int, required_context_bars: int) -> dict[str, HydrationStatus]:
+def _hydration_status_map(
+    ctx: "BotContext", *, required_option_bars: int, required_context_bars: int
+) -> dict[str, HydrationStatus]:
     """Build hydration statuses using ActiveContractBasket as selected-symbol SSOT.
 
     Production safety invariant: a newly selected active basket must beat stale
@@ -342,22 +406,59 @@ def _hydration_status_map(ctx: "BotContext", *, required_option_bars: int, requi
     24350 to 24400, readiness must immediately evaluate 24400 and block until
     24400 has enough bars/quote/depth; it must never arm stale 24350.
     """
-    from nifty_scalper_bot.core.app import ensure_bot_context_runtime_fields, get_active_contract_selection
+    from nifty_scalper_bot.core.app import (
+        ensure_bot_context_runtime_fields,
+        get_active_contract_selection,
+    )
 
     ensure_bot_context_runtime_fields(ctx)
     runner = getattr(ctx, "strategy_runner", None)
-    basket_obj = getattr(ctx, "active_contract_basket", None) or getattr(ctx, "active_trading_universe", None) or {}
+    basket_obj = (
+        getattr(ctx, "active_contract_basket", None)
+        or getattr(ctx, "active_trading_universe", None)
+        or {}
+    )
     selection = get_active_contract_selection(ctx)
 
-    selected_ce = str(selection.selected_ce or _basket_get(basket_obj, "selected_ce", None) or _basket_get(basket_obj, "atm_ce", None) or getattr(runner, "_pending_selected_ce", None) or getattr(ctx, "selected_ce", None) or "")
-    selected_pe = str(selection.selected_pe or _basket_get(basket_obj, "selected_pe", None) or _basket_get(basket_obj, "atm_pe", None) or getattr(runner, "_pending_selected_pe", None) or getattr(ctx, "selected_pe", None) or "")
-    futures_symbol = str(selection.futures_symbol or _basket_get(basket_obj, "futures_symbol", None) or _basket_get(basket_obj, "future_symbol", None) or getattr(ctx, "active_futures_symbol", None) or "")
-    spot_symbol = str(_basket_get(basket_obj, "spot_symbol", None) or getattr(ctx, "nifty_symbol", None) or "NSE:NIFTY")
-    option_symbols = list(selection.option_symbols or _basket_option_symbols(basket_obj))
+    selected_ce = str(
+        selection.selected_ce
+        or _basket_get(basket_obj, "selected_ce", None)
+        or _basket_get(basket_obj, "atm_ce", None)
+        or getattr(runner, "_pending_selected_ce", None)
+        or getattr(ctx, "selected_ce", None)
+        or ""
+    )
+    selected_pe = str(
+        selection.selected_pe
+        or _basket_get(basket_obj, "selected_pe", None)
+        or _basket_get(basket_obj, "atm_pe", None)
+        or getattr(runner, "_pending_selected_pe", None)
+        or getattr(ctx, "selected_pe", None)
+        or ""
+    )
+    futures_symbol = str(
+        selection.futures_symbol
+        or _basket_get(basket_obj, "futures_symbol", None)
+        or _basket_get(basket_obj, "future_symbol", None)
+        or getattr(ctx, "active_futures_symbol", None)
+        or ""
+    )
+    spot_symbol = str(
+        _basket_get(basket_obj, "spot_symbol", None)
+        or getattr(ctx, "nifty_symbol", None)
+        or "NSE:NIFTY"
+    )
+    option_symbols = list(
+        selection.option_symbols or _basket_option_symbols(basket_obj)
+    )
 
     old_ce = getattr(ctx, "selected_ce", None)
     old_pe = getattr(ctx, "selected_pe", None)
-    if (selection.selected_ce and old_ce and str(old_ce) != str(selection.selected_ce)) or (selection.selected_pe and old_pe and str(old_pe) != str(selection.selected_pe)):
+    if (
+        selection.selected_ce and old_ce and str(old_ce) != str(selection.selected_ce)
+    ) or (
+        selection.selected_pe and old_pe and str(old_pe) != str(selection.selected_pe)
+    ):
         LOGGER.warning(
             "ACTIVE_SELECTION_DRIFT_BLOCKED old_ce=%s old_pe=%s new_ce=%s new_pe=%s source=history_readiness",
             old_ce,
@@ -387,14 +488,22 @@ def _hydration_status_map(ctx: "BotContext", *, required_option_bars: int, requi
     for sym, role in role_by_symbol.items():
         if not sym:
             continue
-        required = required_context_bars if role in {"spot", "futures_context"} else required_option_bars
+        required = (
+            required_context_bars
+            if role in {"spot", "futures_context"}
+            else required_option_bars
+        )
         statuses[sym] = build_symbol_hydration_status(ctx, sym, role, required)
-    ctx.hydration_status_by_symbol = {sym: status.to_dict() for sym, status in statuses.items()}
+    ctx.hydration_status_by_symbol = {
+        sym: status.to_dict() for sym, status in statuses.items()
+    }
     ctx.last_hydration_status_at = datetime.now(timezone.utc)
     return statuses
 
 
-def _status_for_role(statuses: Mapping[str, HydrationStatus], role: str) -> HydrationStatus | None:
+def _status_for_role(
+    statuses: Mapping[str, HydrationStatus], role: str
+) -> HydrationStatus | None:
     for status in statuses.values():
         if status.role == role:
             return status
@@ -411,7 +520,9 @@ def _count_symbol_bars(ctx: "BotContext", symbol: str | None) -> int:
         return 0
 
 
-def _pick_atm_option_symbols_from_basket(basket: dict[str, object]) -> tuple[str | None, str | None]:
+def _pick_atm_option_symbols_from_basket(
+    basket: dict[str, object],
+) -> tuple[str | None, str | None]:
     """Compatibility wrapper for basket symbol selection. Args: basket. Returns: ce/pe. Raises: none."""
     return pick_atm_option_symbols_from_basket(basket)
 
@@ -487,8 +598,20 @@ def compute_history_readiness(
     indicator_bars: int,
 ) -> HistoryReadiness:
     """Compute current-state history readiness without mutation."""
-    minimum_ready = bool(mdm_bars >= required_bars and runner_bars >= required_bars and indicator_bars >= required_bars)
-    return HistoryReadiness(symbol, role, required_bars, mdm_bars, runner_bars, indicator_bars, minimum_ready)
+    minimum_ready = bool(
+        mdm_bars >= required_bars
+        and runner_bars >= required_bars
+        and indicator_bars >= required_bars
+    )
+    return HistoryReadiness(
+        symbol,
+        role,
+        required_bars,
+        mdm_bars,
+        runner_bars,
+        indicator_bars,
+        minimum_ready,
+    )
 
 
 def resolve_symbol_history_role(ctx: "BotContext", symbol: str) -> str:
@@ -505,19 +628,30 @@ def resolve_symbol_history_role(ctx: "BotContext", symbol: str) -> str:
             return obj.get(name)
         return getattr(obj, name, None)
 
-    manager = getattr(ctx, "position_manager", None) or getattr(runner, "_position_manager", None)
+    manager = getattr(ctx, "position_manager", None) or getattr(
+        runner, "_position_manager", None
+    )
     open_symbols: list[str] = []
     try:
-        if manager is not None and callable(getattr(manager, "get_open_positions", None)):
-            open_symbols = [str(getattr(p, "symbol", p)) for p in manager.get_open_positions()]
+        if manager is not None and callable(
+            getattr(manager, "get_open_positions", None)
+        ):
+            open_symbols = [
+                str(getattr(p, "symbol", p)) for p in manager.get_open_positions()
+            ]
     except Exception:
         open_symbols = []
     return _shared_resolve_symbol_history_role(
         symbol=symbol,
-        selected_ce=_attr(basket, "selected_ce") or getattr(runner, "_active_selected_ce", None),
-        selected_pe=_attr(basket, "selected_pe") or getattr(runner, "_active_selected_pe", None),
-        spot_symbol=getattr(ctx, "spot_symbol", None) or getattr(runner, "_spot_symbol", None) or "NSE:NIFTY",
-        futures_symbol=getattr(runner, "_active_futures_symbol", None) or getattr(ctx, "active_futures_symbol", None),
+        selected_ce=_attr(basket, "selected_ce")
+        or getattr(runner, "_active_selected_ce", None),
+        selected_pe=_attr(basket, "selected_pe")
+        or getattr(runner, "_active_selected_pe", None),
+        spot_symbol=getattr(ctx, "spot_symbol", None)
+        or getattr(runner, "_spot_symbol", None)
+        or "NSE:NIFTY",
+        futures_symbol=getattr(runner, "_active_futures_symbol", None)
+        or getattr(ctx, "active_futures_symbol", None),
         open_position_symbols=open_symbols,
     )
 
@@ -534,7 +668,11 @@ def compute_selected_option_history_readiness(
     none.
     """
     active_ce, active_pe = _active_selection_symbols(ctx)
-    if active_ce and active_pe and (selected_ce != active_ce or selected_pe != active_pe):
+    if (
+        active_ce
+        and active_pe
+        and (selected_ce != active_ce or selected_pe != active_pe)
+    ):
         LOGGER.warning(
             "SELECTED_OPTION_HISTORY_DRIFT_CORRECTED old_ce=%s old_pe=%s new_ce=%s new_pe=%s source=active_contract_basket",
             selected_ce,
@@ -554,7 +692,13 @@ def compute_selected_option_history_readiness(
 
     mdm = getattr(ctx, "market_data_manager", None)
     runner = getattr(ctx, "strategy_runner", None)
-    option_min = int(os.getenv("READINESS_OPTION_EXEC_MIN_BARS", os.getenv("OPTION_EXECUTION_MIN_BARS", str(_DEFAULT_OPT_MIN_BARS))) or _DEFAULT_OPT_MIN_BARS)
+    option_min = int(
+        os.getenv(
+            "READINESS_OPTION_EXEC_MIN_BARS",
+            os.getenv("OPTION_EXECUTION_MIN_BARS", str(_DEFAULT_OPT_MIN_BARS)),
+        )
+        or _DEFAULT_OPT_MIN_BARS
+    )
     required = max(option_min, int(getattr(runner, "_option_required_bars", 0) or 0))
 
     def _readiness(sym: str | None) -> HistoryReadiness | None:
@@ -564,14 +708,30 @@ def compute_selected_option_history_readiness(
             mdm_bars = len(mdm.get_ohlc_bars(sym) or []) if mdm is not None else 0
         except Exception:
             mdm_bars = 0
-        runner_bars = int(runner.runner_history_count(sym)) if runner is not None and callable(getattr(runner, "runner_history_count", None)) else 0
-        if runner is not None and callable(getattr(runner, "indicator_history_count", None)):
+        runner_bars = (
+            int(runner.runner_history_count(sym))
+            if runner is not None
+            and callable(getattr(runner, "runner_history_count", None))
+            else 0
+        )
+        if runner is not None and callable(
+            getattr(runner, "indicator_history_count", None)
+        ):
             indicator_bars = int(runner.indicator_history_count(sym))
-        elif runner is not None and callable(getattr(runner, "_history_count_for_symbol", None)):
+        elif runner is not None and callable(
+            getattr(runner, "_history_count_for_symbol", None)
+        ):
             indicator_bars = int(runner._history_count_for_symbol(sym))
         else:
             indicator_bars = 0
-        return compute_history_readiness(symbol=sym, role="selected_option", required_bars=required, mdm_bars=mdm_bars, runner_bars=runner_bars, indicator_bars=indicator_bars)
+        return compute_history_readiness(
+            symbol=sym,
+            role="selected_option",
+            required_bars=required,
+            mdm_bars=mdm_bars,
+            runner_bars=runner_bars,
+            indicator_bars=indicator_bars,
+        )
 
     ce = _readiness(selected_ce)
     pe = _readiness(selected_pe)
@@ -589,7 +749,9 @@ def compute_selected_option_history_readiness(
                 blocker = "selected_option_history_cold"
         else:
             blocker = "selected_option_not_set"
-    return SelectedOptionHistoryReadiness(selected_ce, selected_pe, ce, pe, both_ready, blocker)
+    return SelectedOptionHistoryReadiness(
+        selected_ce, selected_pe, ce, pe, both_ready, blocker
+    )
 
 
 def resolve_history_policy(
@@ -604,14 +766,29 @@ def resolve_history_policy(
     runner = getattr(ctx, "strategy_runner", None)
     role = str(role or "option_context")
     phase = str(phase or "dynamic_update")
-    option_min = int(os.getenv("READINESS_OPTION_EXEC_MIN_BARS", os.getenv("OPTION_EXECUTION_MIN_BARS", str(_DEFAULT_OPT_MIN_BARS))) or _DEFAULT_OPT_MIN_BARS)
-    context_env = int(os.getenv("READINESS_CONTEXT_MIN_BARS", os.getenv("CONTEXT_EXECUTION_MIN_BARS", "20")) or 20)
-    context_min = max(context_env, int(getattr(runner, "_context_required_bars", 0) or 0))
+    option_min = int(
+        os.getenv(
+            "READINESS_OPTION_EXEC_MIN_BARS",
+            os.getenv("OPTION_EXECUTION_MIN_BARS", str(_DEFAULT_OPT_MIN_BARS)),
+        )
+        or _DEFAULT_OPT_MIN_BARS
+    )
+    context_env = int(
+        os.getenv(
+            "READINESS_CONTEXT_MIN_BARS", os.getenv("CONTEXT_EXECUTION_MIN_BARS", "20")
+        )
+        or 20
+    )
+    context_min = max(
+        context_env, int(getattr(runner, "_context_required_bars", 0) or 0)
+    )
     from nifty_scalper_bot.core.app import _symbol_history_requirement
 
     generic_required = _symbol_history_requirement(ctx)
     if role == "selected_option":
-        required = max(option_min, int(getattr(runner, "_option_required_bars", 0) or 0))
+        required = max(
+            option_min, int(getattr(runner, "_option_required_bars", 0) or 0)
+        )
         target = max(required, generic_required)
         priority = 10
     elif role in {"spot_context", "futures_context"}:
@@ -639,16 +816,28 @@ def resolve_history_policy(
         "selected_option": int(os.getenv("HYDRATION_CAP_SELECTED_OPTION", "75") or 75),
         "option_context": int(os.getenv("HYDRATION_CAP_OPTION_CONTEXT", "50") or 50),
         "spot_context": int(os.getenv("HYDRATION_CAP_SPOT_CONTEXT", "100") or 100),
-        "futures_context": int(os.getenv("HYDRATION_CAP_FUTURES_CONTEXT", "100") or 100),
-        "recovery_or_open_position": int(os.getenv("HYDRATION_CAP_RECOVERY", "100") or 100),
+        "futures_context": int(
+            os.getenv("HYDRATION_CAP_FUTURES_CONTEXT", "100") or 100
+        ),
+        "recovery_or_open_position": int(
+            os.getenv("HYDRATION_CAP_RECOVERY", "100") or 100
+        ),
     }
     role_cap = _role_caps.get(role, int(os.getenv("HYDRATION_CAP_DEFAULT", "75") or 75))
     _deep_caps = {
-        "selected_option": int(os.getenv("HYDRATION_DEEP_SELECTED_OPTION", "300") or 300),
-        "option_context": int(os.getenv("HYDRATION_DEEP_OPTION_CONTEXT", str(role_cap)) or role_cap),
+        "selected_option": int(
+            os.getenv("HYDRATION_DEEP_SELECTED_OPTION", "300") or 300
+        ),
+        "option_context": int(
+            os.getenv("HYDRATION_DEEP_OPTION_CONTEXT", str(role_cap)) or role_cap
+        ),
         "spot_context": int(os.getenv("HYDRATION_DEEP_SPOT_CONTEXT", "300") or 300),
-        "futures_context": int(os.getenv("HYDRATION_DEEP_FUTURES_CONTEXT", "300") or 300),
-        "recovery_or_open_position": int(os.getenv("HYDRATION_DEEP_RECOVERY", "300") or 300),
+        "futures_context": int(
+            os.getenv("HYDRATION_DEEP_FUTURES_CONTEXT", "300") or 300
+        ),
+        "recovery_or_open_position": int(
+            os.getenv("HYDRATION_DEEP_RECOVERY", "300") or 300
+        ),
     }
     deep_cap = max(role_cap, _deep_caps.get(role, role_cap))
     safety_max = int(os.getenv("HYDRATION_MAX_BARS", "0") or 0)

--- a/src/nifty_scalper_bot/core/history_readiness.py
+++ b/src/nifty_scalper_bot/core/history_readiness.py
@@ -290,8 +290,12 @@ def build_symbol_hydration_status(
         "HYDRATION_LIVE_TICK_MAX_AGE_MS",
         default_seconds=60.0,
     )
-    max_spread = parse_float_env(
-        os.getenv("HYDRATION_MAX_SPREAD_PCT", os.getenv("MAX_OPTION_SPREAD_PCT")), 12.0
+    raw_spread = os.getenv("HYDRATION_MAX_SPREAD_PCT")
+    if raw_spread is None or not raw_spread.strip():
+        raw_spread = os.getenv("MAX_OPTION_SPREAD_PCT")
+    max_spread = max(
+        0.0,
+        parse_float_env(raw_spread, 12.0),
     )
     quote_ready = evaluate_quote_readiness(
         normalized,
@@ -378,7 +382,10 @@ def build_symbol_hydration_status(
         ),
     )
     LOGGER.debug(
-        "HYDRATION_PROPAGATION_RESULT symbol=%s role=%s required_bars=%s mdm_bars=%s datahub_bars=%s runner_bars=%s indicator_bars=%s tradable_quote=%s depth_available=%s ready_for_evaluation=%s ready_for_execution=%s blockers=%s",
+        "HYDRATION_PROPAGATION_RESULT symbol=%s role=%s required_bars=%s "
+        "mdm_bars=%s datahub_bars=%s runner_bars=%s indicator_bars=%s "
+        "tradable_quote=%s depth_available=%s ready_for_evaluation=%s "
+        "ready_for_execution=%s blockers=%s",
         status.symbol,
         status.role,
         status.required_bars,
@@ -460,7 +467,8 @@ def _hydration_status_map(
         selection.selected_pe and old_pe and str(old_pe) != str(selection.selected_pe)
     ):
         LOGGER.warning(
-            "ACTIVE_SELECTION_DRIFT_BLOCKED old_ce=%s old_pe=%s new_ce=%s new_pe=%s source=history_readiness",
+            "ACTIVE_SELECTION_DRIFT_BLOCKED old_ce=%s old_pe=%s new_ce=%s "
+            "new_pe=%s source=history_readiness",
             old_ce,
             old_pe,
             selection.selected_ce,
@@ -511,7 +519,7 @@ def _status_for_role(
 
 
 def _count_symbol_bars(ctx: "BotContext", symbol: str | None) -> int:
-    """Count hydrated bars for symbol. Args: ctx/symbol. Returns: bars count. Raises: none."""
+    """Count hydrated bars for symbol."""
     if not symbol or ctx.market_data_manager is None:
         return 0
     try:
@@ -523,7 +531,7 @@ def _count_symbol_bars(ctx: "BotContext", symbol: str | None) -> int:
 def _pick_atm_option_symbols_from_basket(
     basket: dict[str, object],
 ) -> tuple[str | None, str | None]:
-    """Compatibility wrapper for basket symbol selection. Args: basket. Returns: ce/pe. Raises: none."""
+    """Compatibility wrapper for basket symbol selection."""
     return pick_atm_option_symbols_from_basket(basket)
 
 
@@ -674,7 +682,8 @@ def compute_selected_option_history_readiness(
         and (selected_ce != active_ce or selected_pe != active_pe)
     ):
         LOGGER.warning(
-            "SELECTED_OPTION_HISTORY_DRIFT_CORRECTED old_ce=%s old_pe=%s new_ce=%s new_pe=%s source=active_contract_basket",
+            "SELECTED_OPTION_HISTORY_DRIFT_CORRECTED old_ce=%s old_pe=%s "
+            "new_ce=%s new_pe=%s source=active_contract_basket",
             selected_ce,
             selected_pe,
             active_ce,

--- a/src/nifty_scalper_bot/execution/readiness.py
+++ b/src/nifty_scalper_bot/execution/readiness.py
@@ -5,11 +5,14 @@ rate-controlled diagnostics for operator validation.
 """
 
 from __future__ import annotations
-from dataclasses import dataclass, field, asdict
-import os
+
 import logging
+import os
+from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from typing import Mapping
+
+from nifty_scalper_bot.config.env_utils import parse_float_env
 
 LOGGER = logging.getLogger(__name__)
 _UNUSABLE_QUOTE_TIMESTAMP_QUALITIES = {"synthetic", "unknown", "invalid"}
@@ -28,7 +31,12 @@ def _env_int(name: str, default: int, minimum: int = 1) -> int:
             name,
             raw,
             default,
-            extra={"event": "INVALID_HISTORY_POLICY_ENV", "env_name": name, "value": raw, "default": default},
+            extra={
+                "event": "INVALID_HISTORY_POLICY_ENV",
+                "env_name": name,
+                "value": raw,
+                "default": default,
+            },
         )
         return max(default, minimum)
 
@@ -158,13 +166,21 @@ def build_live_validation_checklist(
     """Return compact operator checklist for live arming validation."""
 
     market_open = market_name in {"open", "marketstate.open"}
-    broker_auth_ok = not bool(broker_state.get("broker_auth_invalid") or broker_state.get("broker_session_invalid"))
+    broker_auth_ok = not bool(
+        broker_state.get("broker_auth_invalid")
+        or broker_state.get("broker_session_invalid")
+    )
     broker_balance_ok = not bool(
         broker_state.get("broker_balance_unavailable")
         or broker_state.get("broker_balance_valid") is False
     )
-    emergency_clear = not bool(emergency_state.get("emergency_stop_active") or emergency_state.get("kill_switch_active"))
-    risk_green = not bool(risk_state.get("risk_halt") or risk_state.get("daily_loss_limit"))
+    emergency_clear = not bool(
+        emergency_state.get("emergency_stop_active")
+        or emergency_state.get("kill_switch_active")
+    )
+    risk_green = not bool(
+        risk_state.get("risk_halt") or risk_state.get("daily_loss_limit")
+    )
     return {
         "live_mode": bool(live_mode),
         "market_open": bool(market_open),
@@ -249,7 +265,10 @@ def normalize_readiness_blockers(
         canonical.append("broker_auth_invalid")
     if broker_state.get("broker_session_invalid"):
         canonical.append("broker_session_invalid")
-    if broker_state.get("broker_balance_unavailable") or broker_state.get("broker_balance_valid") is False:
+    if (
+        broker_state.get("broker_balance_unavailable")
+        or broker_state.get("broker_balance_valid") is False
+    ):
         canonical.append("broker_balance_unavailable")
     if risk_state.get("risk_halt"):
         canonical.append("risk_halt")
@@ -264,9 +283,27 @@ def normalize_readiness_blockers(
             canonical.append("market_closed")
     canonical = list(dict.fromkeys(canonical))
 
-    high_priority = {"emergency_stop_active", "kill_switch_active", "broker_auth_invalid", "broker_session_invalid", "broker_balance_unavailable", "position_reconciliation_failed", "position_reconciliation_incomplete", "unresolved_exit_position", "unprotected_broker_position"}
+    high_priority = {
+        "emergency_stop_active",
+        "kill_switch_active",
+        "broker_auth_invalid",
+        "broker_session_invalid",
+        "broker_balance_unavailable",
+        "position_reconciliation_failed",
+        "position_reconciliation_incomplete",
+        "unresolved_exit_position",
+        "unprotected_broker_position",
+    }
     has_high_priority = any(item in canonical for item in high_priority)
-    market_blocker = "exchange_holiday" if "exchange_holiday" in canonical else "outside_session" if "outside_session" in canonical else "market_closed" if "market_closed" in canonical else None
+    market_blocker = (
+        "exchange_holiday"
+        if "exchange_holiday" in canonical
+        else (
+            "outside_session"
+            if "outside_session" in canonical
+            else "market_closed" if "market_closed" in canonical else None
+        )
+    )
     secondary: list[str] = []
     visible = canonical
     if market_blocker and not has_high_priority:
@@ -339,9 +376,17 @@ class HydrationStatus:
     live_merge_applied: bool = False
 
     def __post_init__(self) -> None:
-        if self.role not in {"selected_ce", "selected_pe"} or not self.ready_for_execution:
+        if (
+            self.role not in {"selected_ce", "selected_pe"}
+            or not self.ready_for_execution
+        ):
             return
-        bid_ask_valid = bool(self.bid is not None and self.ask is not None and self.bid > 0 and self.ask > self.bid)
+        bid_ask_valid = bool(
+            self.bid is not None
+            and self.ask is not None
+            and self.bid > 0
+            and self.ask > self.bid
+        )
         if bid_ask_valid:
             return
         self.ready_for_execution = False
@@ -376,12 +421,19 @@ class HistoryReadinessPolicy:
             smc_min_bars=_env_int("SMC_MIN_BARS_REQUIRED", 30),
             allow_synthetic_option_bars_for_eval=str(
                 os.getenv("ALLOW_SYNTHETIC_OPTION_BARS_FOR_EVAL", "false")
-            ).strip().lower() in {"1", "true", "yes", "on"},
+            )
+            .strip()
+            .lower()
+            in {"1", "true", "yes", "on"},
         )
 
 
 def _quote_getter(payload: dict | object):
-    return payload.get if isinstance(payload, dict) else lambda key, default=None: getattr(payload, key, default)
+    return (
+        payload.get
+        if isinstance(payload, dict)
+        else lambda key, default=None: getattr(payload, key, default)
+    )
 
 
 def quote_timestamp_quality_allows_hard_readiness(quote: dict | object | None) -> bool:
@@ -414,6 +466,25 @@ def _quote_float(payload: dict | object, *keys: str) -> float | None:
     return None
 
 
+def resolve_max_quote_age_seconds(
+    seconds_env: str,
+    legacy_ms_env: str,
+    *,
+    default_seconds: float,
+) -> float:
+    """Resolve quote max-age config once into canonical seconds.
+
+    Prefer the seconds setting. Fall back to a legacy millisecond setting for
+    deployment compatibility. Malformed/commented values safely use defaults.
+    """
+    raw_seconds = os.getenv(seconds_env)
+    if raw_seconds not in (None, ""):
+        return max(0.0, parse_float_env(raw_seconds, default_seconds))
+    legacy_default_ms = default_seconds * 1000.0
+    legacy_ms = parse_float_env(os.getenv(legacy_ms_env), legacy_default_ms)
+    return max(0.0, legacy_ms / 1000.0)
+
+
 def resolve_quote_age_seconds(payload: dict | object) -> float | None:
     age_ms = _quote_float(
         payload,
@@ -439,7 +510,9 @@ def resolve_quote_age_seconds(payload: dict | object) -> float | None:
     return None
 
 
-def resolve_quote_bid_ask_spread(quote: dict | object) -> tuple[float | None, float | None, float | None, str]:
+def resolve_quote_bid_ask_spread(
+    quote: dict | object,
+) -> tuple[float | None, float | None, float | None, str]:
     """Resolve bid/ask/spread from top-level fields or Zerodha depth.
 
     Fresh WebSocket FULL quotes are tradable when either top-level bid/ask or
@@ -457,13 +530,23 @@ def resolve_quote_bid_ask_spread(quote: dict | object) -> tuple[float | None, fl
 
     raw_bid = _quote_float(quote, "bid", "bid_price")
     raw_ask = _quote_float(quote, "ask", "ask_price")
-    if raw_bid is not None and raw_bid > 0 and raw_ask is not None and raw_ask > raw_bid:
+    if (
+        raw_bid is not None
+        and raw_bid > 0
+        and raw_ask is not None
+        and raw_ask > raw_bid
+    ):
         bid, ask, source = raw_bid, raw_ask, "top_level"
 
     if bid is None:
         raw_bid = _quote_float(quote, "best_bid", "best_bid_price")
         raw_ask = _quote_float(quote, "best_ask", "best_ask_price")
-        if raw_bid is not None and raw_bid > 0 and raw_ask is not None and raw_ask > raw_bid:
+        if (
+            raw_bid is not None
+            and raw_bid > 0
+            and raw_ask is not None
+            and raw_ask > raw_bid
+        ):
             bid, ask, source = raw_bid, raw_ask, "best_bid_ask"
 
     if bid is None:
@@ -473,10 +556,19 @@ def resolve_quote_bid_ask_spread(quote: dict | object) -> tuple[float | None, fl
             buy_levels = depth.get("buy") or []
             sell_levels = depth.get("sell") or []
         buy_top = buy_levels[0] if isinstance(buy_levels, list) and buy_levels else {}
-        sell_top = sell_levels[0] if isinstance(sell_levels, list) and sell_levels else {}
+        sell_top = (
+            sell_levels[0] if isinstance(sell_levels, list) and sell_levels else {}
+        )
         raw_bid = _quote_float(buy_top, "price") if isinstance(buy_top, dict) else None
-        raw_ask = _quote_float(sell_top, "price") if isinstance(sell_top, dict) else None
-        if raw_bid is not None and raw_bid > 0 and raw_ask is not None and raw_ask > raw_bid:
+        raw_ask = (
+            _quote_float(sell_top, "price") if isinstance(sell_top, dict) else None
+        )
+        if (
+            raw_bid is not None
+            and raw_bid > 0
+            and raw_ask is not None
+            and raw_ask > raw_bid
+        ):
             bid, ask, source = raw_bid, raw_ask, "depth"
 
     spread_pct: float | None = None
@@ -485,13 +577,16 @@ def resolve_quote_bid_ask_spread(quote: dict | object) -> tuple[float | None, fl
         spread_pct = ((ask - bid) / mid) * 100.0
     else:
         precomputed = _quote_float(quote, "spread_pct")
-        has_quote_proof = bool(getter("tradable_quote", False) or getter("depth_available", False) or getter("depth", None))
+        has_quote_proof = bool(
+            getter("tradable_quote", False)
+            or getter("depth_available", False)
+            or getter("depth", None)
+        )
         if precomputed is not None and precomputed > 0 and has_quote_proof:
             spread_pct = precomputed
             if source == "missing":
                 source = "derived_only"
     return bid, ask, spread_pct, source
-
 
 
 @dataclass(frozen=True, slots=True)
@@ -512,6 +607,7 @@ class QuoteReadiness:
     def to_dict(self) -> dict[str, object]:
         return asdict(self)
 
+
 def evaluate_quote_readiness(
     symbol: str,
     quote: dict | object | None,
@@ -520,21 +616,30 @@ def evaluate_quote_readiness(
     require_fresh: bool = True,
     max_age_s: float | None = None,
 ) -> QuoteReadiness:
-    """Return canonical quote readiness for startup, runtime, execution, Telegram, and health.
+    """Return canonical quote readiness for runtime, execution, and health.
 
     Tradable quote readiness is stricter than LTP readiness: bid and ask must be
     present, positive, non-crossed, fresh when age is known, and within the
     configured spread limit.
     """
     if quote is None:
-        return QuoteReadiness(symbol=symbol, ltp_ready=False, depth_available=False, bid_ask_available=False, tradable_quote_ready=False, reason="quote_missing")
+        return QuoteReadiness(
+            symbol=symbol,
+            ltp_ready=False,
+            depth_available=False,
+            bid_ask_available=False,
+            tradable_quote_ready=False,
+            reason="quote_missing",
+        )
     getter = _quote_getter(quote)
     ltp = _quote_float(quote, "ltp", "last_price", "last_traded_price")
     ltp_ready = bool(ltp is not None and ltp > 0)
     depth = getter("depth", None)
     depth_available = bool(getter("depth_available", False) or depth)
     bid, ask, spread_pct, source = resolve_quote_bid_ask_spread(quote)
-    bid_ask_available = bool(bid is not None and ask is not None and bid > 0 and ask > bid)
+    bid_ask_available = bool(
+        bid is not None and ask is not None and bid > 0 and ask > bid
+    )
     timestamp_quality_ok = quote_timestamp_quality_allows_hard_readiness(quote)
     if not ltp_ready:
         reason = "ltp_missing"
@@ -543,7 +648,13 @@ def evaluate_quote_readiness(
     elif not bid_ask_available:
         raw_bid = _quote_float(quote, "bid", "bid_price", "best_bid", "best_bid_price")
         raw_ask = _quote_float(quote, "ask", "ask_price", "best_ask", "best_ask_price")
-        if raw_bid is not None and raw_ask is not None and raw_bid > 0 and raw_ask > 0 and raw_ask <= raw_bid:
+        if (
+            raw_bid is not None
+            and raw_ask is not None
+            and raw_bid > 0
+            and raw_ask > 0
+            and raw_ask <= raw_bid
+        ):
             reason = "bid_ask_crossed"
         else:
             reason = "bid_ask_missing"
@@ -559,7 +670,12 @@ def evaluate_quote_readiness(
             reason = "quote_age_unknown"
         elif max_age_s is not None and age > max_age_s:
             reason = "quote_stale"
-    if reason == "ready" and max_spread_pct is not None and spread_pct is not None and spread_pct > max_spread_pct:
+    if (
+        reason == "ready"
+        and max_spread_pct is not None
+        and spread_pct is not None
+        and spread_pct > max_spread_pct
+    ):
         reason = "spread_too_wide"
     return QuoteReadiness(
         symbol=symbol,
@@ -573,6 +689,7 @@ def evaluate_quote_readiness(
         spread_pct=spread_pct,
         source=source,
     )
+
 
 def quote_has_tradable_bid_ask(quote: dict | object) -> bool:
     """Return True when quote has valid top-level/depth bid-ask proof."""

--- a/src/nifty_scalper_bot/execution/readiness.py
+++ b/src/nifty_scalper_bot/execution/readiness.py
@@ -44,7 +44,7 @@ def _env_int(name: str, default: int, minimum: int = 1) -> int:
 def _safe_positive_int(value: object, fallback: int) -> int:
     fallback_value = max(int(fallback), 1)
     try:
-        parsed = int(float(value))
+        parsed = int(float(str(value)))
     except (TypeError, ValueError):
         return fallback_value
     if parsed <= 0:
@@ -54,7 +54,7 @@ def _safe_positive_int(value: object, fallback: int) -> int:
 
 def _safe_non_negative_int(value: object, fallback: int = 0) -> int:
     try:
-        parsed = int(float(value))
+        parsed = int(float(str(value)))
     except (TypeError, ValueError):
         return max(int(fallback), 0)
     return max(parsed, 0)
@@ -224,7 +224,10 @@ def _emit_live_validation_checklist(
         execution_ready=execution_ready,
     )
     LOGGER.info(
-        "LIVE_VALIDATION_CHECKLIST live_mode=%s market_open=%s evaluation_ready=%s execution_ready=%s broker_auth_ok=%s broker_balance_ok=%s emergency_clear=%s risk_green=%s live_orders_armed=%s primary_blocker=%s",
+        "LIVE_VALIDATION_CHECKLIST live_mode=%s market_open=%s "
+        "evaluation_ready=%s execution_ready=%s broker_auth_ok=%s "
+        "broker_balance_ok=%s emergency_clear=%s risk_green=%s "
+        "live_orders_armed=%s primary_blocker=%s",
         checklist["live_mode"],
         checklist["market_open"],
         checklist["evaluation_ready"],
@@ -478,10 +481,16 @@ def resolve_max_quote_age_seconds(
     deployment compatibility. Malformed/commented values safely use defaults.
     """
     raw_seconds = os.getenv(seconds_env)
-    if raw_seconds not in (None, ""):
-        return max(0.0, parse_float_env(raw_seconds, default_seconds))
+    if raw_seconds is not None and raw_seconds.strip():
+        return max(
+            0.0,
+            parse_float_env(raw_seconds, default_seconds),
+        )
     legacy_default_ms = default_seconds * 1000.0
-    legacy_ms = parse_float_env(os.getenv(legacy_ms_env), legacy_default_ms)
+    legacy_ms = parse_float_env(
+        os.getenv(legacy_ms_env),
+        legacy_default_ms,
+    )
     return max(0.0, legacy_ms / 1000.0)
 
 
@@ -551,10 +560,11 @@ def resolve_quote_bid_ask_spread(
 
     if bid is None:
         depth = getter("depth", None)
-        buy_levels = sell_levels = []
+        buy_levels: list[object] = []
+        sell_levels: list[object] = []
         if isinstance(depth, dict):
-            buy_levels = depth.get("buy") or []
-            sell_levels = depth.get("sell") or []
+            buy_levels = list(depth.get("buy") or [])
+            sell_levels = list(depth.get("sell") or [])
         buy_top = buy_levels[0] if isinstance(buy_levels, list) and buy_levels else {}
         sell_top = (
             sell_levels[0] if isinstance(sell_levels, list) and sell_levels else {}

--- a/tests/core/test_hydration_status_propagation.py
+++ b/tests/core/test_hydration_status_propagation.py
@@ -279,3 +279,53 @@ def test_malformed_hydration_age_env_falls_back_without_crashing(monkeypatch) ->
     )
 
     assert status.ready_for_execution is True
+
+
+def test_whitespace_spread_env_falls_back_to_legacy_spread(monkeypatch) -> None:
+    monkeypatch.setenv("HYDRATION_MAX_SPREAD_PCT", "   ")
+    monkeypatch.setenv("MAX_OPTION_SPREAD_PCT", "1.5")
+    quote = {**_quote(), "bid": 100.0, "ask": 103.0}
+
+    status = app.build_symbol_hydration_status(
+        _ctx(30, 30, 30, 30, quote), SYMBOL, "selected_ce", 30
+    )
+
+    assert status.ready_for_execution is False
+    assert "spread_too_wide" in status.blocker_reasons
+
+
+def test_empty_spread_env_falls_back_to_legacy_spread(monkeypatch) -> None:
+    monkeypatch.setenv("HYDRATION_MAX_SPREAD_PCT", "")
+    monkeypatch.setenv("MAX_OPTION_SPREAD_PCT", "1.5")
+    quote = {**_quote(), "bid": 100.0, "ask": 103.0}
+
+    status = app.build_symbol_hydration_status(
+        _ctx(30, 30, 30, 30, quote), SYMBOL, "selected_ce", 30
+    )
+
+    assert status.ready_for_execution is False
+    assert "spread_too_wide" in status.blocker_reasons
+
+
+def test_canonical_spread_env_takes_precedence(monkeypatch) -> None:
+    monkeypatch.setenv("HYDRATION_MAX_SPREAD_PCT", "5")
+    monkeypatch.setenv("MAX_OPTION_SPREAD_PCT", "1.5")
+    quote = {**_quote(), "bid": 100.0, "ask": 103.0}
+
+    status = app.build_symbol_hydration_status(
+        _ctx(30, 30, 30, 30, quote), SYMBOL, "selected_ce", 30
+    )
+
+    assert status.ready_for_execution is True
+
+
+def test_malformed_spread_env_uses_default_without_crashing(monkeypatch) -> None:
+    monkeypatch.setenv("HYDRATION_MAX_SPREAD_PCT", "bad # comment")
+    monkeypatch.setenv("MAX_OPTION_SPREAD_PCT", "1.5")
+    quote = {**_quote(), "bid": 100.0, "ask": 111.0}
+
+    status = app.build_symbol_hydration_status(
+        _ctx(30, 30, 30, 30, quote), SYMBOL, "selected_ce", 30
+    )
+
+    assert status.ready_for_execution is True

--- a/tests/core/test_hydration_status_propagation.py
+++ b/tests/core/test_hydration_status_propagation.py
@@ -5,7 +5,6 @@ from types import SimpleNamespace
 
 from nifty_scalper_bot.core import app
 
-
 SYMBOL = "NFO:NIFTY26MAY23300CE"
 
 
@@ -26,7 +25,11 @@ def _bars(count: int) -> list[dict[str, object]]:
 
 
 class _Provider:
-    def __init__(self, bars_by_symbol: dict[str, list[dict[str, object]]], quote: dict[str, object] | None = None) -> None:
+    def __init__(
+        self,
+        bars_by_symbol: dict[str, list[dict[str, object]]],
+        quote: dict[str, object] | None = None,
+    ) -> None:
         self._bars = bars_by_symbol
         self._quote = quote or {}
         self._token_by_symbol = {SYMBOL: 12345}
@@ -54,11 +57,15 @@ class _Indicator:
 
 
 class _Runner:
-    def __init__(self, rows: list[dict[str, object]], indicator_rows: list[dict[str, object]]) -> None:
+    def __init__(
+        self, rows: list[dict[str, object]], indicator_rows: list[dict[str, object]]
+    ) -> None:
         self._symbol_history = {SYMBOL: list(rows)}
         self._indicator_engine = _Indicator(indicator_rows)
 
-    def reseed_history_from_bars(self, symbol: str, rows, source: str = "test", min_bars: int = 1) -> int:
+    def reseed_history_from_bars(
+        self, symbol: str, rows, source: str = "test", min_bars: int = 1
+    ) -> int:
         self._symbol_history[symbol] = list(rows)
         self._indicator_engine.rows = list(rows)
         return len(list(rows))
@@ -76,7 +83,13 @@ def _quote() -> dict[str, object]:
     }
 
 
-def _ctx(mdm_rows: int, datahub_rows: int, runner_rows: int, indicator_rows: int, quote: dict[str, object] | None = None):
+def _ctx(
+    mdm_rows: int,
+    datahub_rows: int,
+    runner_rows: int,
+    indicator_rows: int,
+    quote: dict[str, object] | None = None,
+):
     return SimpleNamespace(
         market_data_manager=_Provider({SYMBOL: _bars(mdm_rows)}, quote),
         data_hub=_Provider({SYMBOL: _bars(datahub_rows)}, quote),
@@ -86,7 +99,9 @@ def _ctx(mdm_rows: int, datahub_rows: int, runner_rows: int, indicator_rows: int
 
 
 def test_mdm_30_bars_propagate_to_datahub_30_bars() -> None:
-    status = app.build_symbol_hydration_status(_ctx(30, 30, 30, 30, _quote()), SYMBOL, "selected_ce", 30)
+    status = app.build_symbol_hydration_status(
+        _ctx(30, 30, 30, 30, _quote()), SYMBOL, "selected_ce", 30
+    )
 
     assert status.mdm_bars == 30
     assert status.datahub_bars == 30
@@ -105,7 +120,9 @@ def test_datahub_30_bars_propagate_to_runner_30_bars() -> None:
 
 def test_runner_30_bars_propagate_to_indicator_30_bars() -> None:
     ctx = _ctx(30, 30, 0, 0, _quote())
-    ctx.strategy_runner.reseed_history_from_bars(SYMBOL, ctx.data_hub.get_ohlc_bars(SYMBOL), min_bars=30)
+    ctx.strategy_runner.reseed_history_from_bars(
+        SYMBOL, ctx.data_hub.get_ohlc_bars(SYMBOL), min_bars=30
+    )
 
     status = app.build_symbol_hydration_status(ctx, SYMBOL, "selected_ce", 30)
 
@@ -114,9 +131,16 @@ def test_runner_30_bars_propagate_to_indicator_30_bars() -> None:
 
 
 def test_hydration_status_consistent_counts_across_all_layers() -> None:
-    status = app.build_symbol_hydration_status(_ctx(30, 30, 30, 30, _quote()), SYMBOL, "selected_ce", 30)
+    status = app.build_symbol_hydration_status(
+        _ctx(30, 30, 30, 30, _quote()), SYMBOL, "selected_ce", 30
+    )
 
-    assert (status.mdm_bars, status.datahub_bars, status.runner_bars, status.indicator_bars) == (30, 30, 30, 30)
+    assert (
+        status.mdm_bars,
+        status.datahub_bars,
+        status.runner_bars,
+        status.indicator_bars,
+    ) == (30, 30, 30, 30)
     assert status.ready_for_evaluation is True
 
 
@@ -130,7 +154,9 @@ def test_datahub_bars_do_not_gate_readiness() -> None:
 
 
 def test_readiness_true_when_all_layers_have_bars_and_quote_depth_valid() -> None:
-    status = app.build_symbol_hydration_status(_ctx(30, 30, 30, 30, _quote()), SYMBOL, "selected_ce", 30)
+    status = app.build_symbol_hydration_status(
+        _ctx(30, 30, 30, 30, _quote()), SYMBOL, "selected_ce", 30
+    )
 
     assert status.ready_for_evaluation is True
     assert status.ready_for_execution is True
@@ -138,13 +164,17 @@ def test_readiness_true_when_all_layers_have_bars_and_quote_depth_valid() -> Non
     assert status.depth_available is True
 
 
-def test_synthetic_timestamp_quote_does_not_make_selected_option_execution_ready() -> None:
+def test_synthetic_timestamp_quote_does_not_make_selected_option_execution_ready() -> (
+    None
+):
     quote = {
         **_quote(),
         "timestamp_quality": "synthetic",
     }
 
-    status = app.build_symbol_hydration_status(_ctx(30, 30, 30, 30, quote), SYMBOL, "selected_ce", 30)
+    status = app.build_symbol_hydration_status(
+        _ctx(30, 30, 30, 30, quote), SYMBOL, "selected_ce", 30
+    )
 
     assert status.ready_for_evaluation is True
     assert status.ready_for_execution is False
@@ -152,10 +182,12 @@ def test_synthetic_timestamp_quote_does_not_make_selected_option_execution_ready
     assert "timestamp_quality_unusable" in status.blocker_reasons
 
 
-def test_selected_option_execution_ready_with_top_level_bid_ask_without_depth_flag() -> None:
+def test_top_level_bid_ask_without_depth_flag_is_execution_ready() -> None:
     quote = {"ltp": 100.5, "bid": 100.0, "ask": 101.0, "tick_age_s": 1.0}
 
-    status = app.build_symbol_hydration_status(_ctx(30, 30, 30, 30, quote), SYMBOL, "selected_ce", 30)
+    status = app.build_symbol_hydration_status(
+        _ctx(30, 30, 30, 30, quote), SYMBOL, "selected_ce", 30
+    )
 
     assert status.ready_for_execution is True
     assert status.tradable_quote is True
@@ -169,7 +201,9 @@ def test_selected_option_execution_ready_with_depth_top_of_book() -> None:
         "tick_age_s": 1.0,
     }
 
-    status = app.build_symbol_hydration_status(_ctx(30, 30, 30, 30, quote), SYMBOL, "selected_ce", 30)
+    status = app.build_symbol_hydration_status(
+        _ctx(30, 30, 30, 30, quote), SYMBOL, "selected_ce", 30
+    )
 
     assert status.ready_for_execution is True
     assert status.bid == 100.0
@@ -179,7 +213,9 @@ def test_selected_option_execution_ready_with_depth_top_of_book() -> None:
 def test_stale_quote_does_not_make_selected_option_execution_ready() -> None:
     quote = {**_quote(), "tick_age_s": 120.0}
 
-    status = app.build_symbol_hydration_status(_ctx(30, 30, 30, 30, quote), SYMBOL, "selected_ce", 30)
+    status = app.build_symbol_hydration_status(
+        _ctx(30, 30, 30, 30, quote), SYMBOL, "selected_ce", 30
+    )
 
     assert status.ready_for_execution is False
     assert "quote_stale" in status.blocker_reasons
@@ -189,7 +225,9 @@ def test_unknown_quote_age_does_not_make_selected_option_execution_ready() -> No
     quote = dict(_quote())
     quote.pop("tick_age_s")
 
-    status = app.build_symbol_hydration_status(_ctx(30, 30, 30, 30, quote), SYMBOL, "selected_ce", 30)
+    status = app.build_symbol_hydration_status(
+        _ctx(30, 30, 30, 30, quote), SYMBOL, "selected_ce", 30
+    )
 
     assert status.ready_for_execution is False
     assert "quote_age_unknown" in status.blocker_reasons
@@ -198,7 +236,46 @@ def test_unknown_quote_age_does_not_make_selected_option_execution_ready() -> No
 def test_wide_spread_does_not_make_selected_option_execution_ready() -> None:
     quote = {**_quote(), "bid": 100.0, "ask": 130.0}
 
-    status = app.build_symbol_hydration_status(_ctx(30, 30, 30, 30, quote), SYMBOL, "selected_ce", 30)
+    status = app.build_symbol_hydration_status(
+        _ctx(30, 30, 30, 30, quote), SYMBOL, "selected_ce", 30
+    )
 
     assert status.ready_for_execution is False
     assert "spread_too_wide" in status.blocker_reasons
+
+
+def test_hydration_live_tick_max_age_legacy_ms_env_still_applies(monkeypatch) -> None:
+    monkeypatch.delenv("HYDRATION_LIVE_TICK_MAX_AGE_SECONDS", raising=False)
+    monkeypatch.setenv("HYDRATION_LIVE_TICK_MAX_AGE_MS", "2500")
+    quote = {**_quote(), "tick_age_s": 3.0}
+
+    status = app.build_symbol_hydration_status(
+        _ctx(30, 30, 30, 30, quote), SYMBOL, "selected_ce", 30
+    )
+
+    assert status.ready_for_execution is False
+    assert "quote_stale" in status.blocker_reasons
+
+
+def test_hydration_live_tick_max_age_seconds_env_takes_precedence(monkeypatch) -> None:
+    monkeypatch.setenv("HYDRATION_LIVE_TICK_MAX_AGE_SECONDS", "5")
+    monkeypatch.setenv("HYDRATION_LIVE_TICK_MAX_AGE_MS", "2500")
+    quote = {**_quote(), "tick_age_s": 3.0}
+
+    status = app.build_symbol_hydration_status(
+        _ctx(30, 30, 30, 30, quote), SYMBOL, "selected_ce", 30
+    )
+
+    assert status.ready_for_execution is True
+
+
+def test_malformed_hydration_age_env_falls_back_without_crashing(monkeypatch) -> None:
+    monkeypatch.setenv("HYDRATION_LIVE_TICK_MAX_AGE_SECONDS", "bad # comment")
+    monkeypatch.setenv("HYDRATION_MAX_SPREAD_PCT", "bad # comment")
+    quote = {**_quote(), "tick_age_s": 59.0, "bid": 100.0, "ask": 101.0}
+
+    status = app.build_symbol_hydration_status(
+        _ctx(30, 30, 30, 30, quote), SYMBOL, "selected_ce", 30
+    )
+
+    assert status.ready_for_execution is True

--- a/tests/execution/test_quote_readiness.py
+++ b/tests/execution/test_quote_readiness.py
@@ -135,3 +135,59 @@ def test_canonical_quote_age_keeps_seconds_unchanged():
     from nifty_scalper_bot.execution.readiness import resolve_quote_age_seconds
 
     assert resolve_quote_age_seconds({"quote_age_s": 2.5}) == 2.5
+
+
+def test_max_quote_age_seconds_blank_env_uses_legacy_ms(monkeypatch):
+    from nifty_scalper_bot.execution.readiness import resolve_max_quote_age_seconds
+
+    monkeypatch.setenv("TEST_MAX_AGE_SECONDS", "   ")
+    monkeypatch.setenv("TEST_MAX_AGE_MS", "2500")
+
+    assert (
+        resolve_max_quote_age_seconds(
+            "TEST_MAX_AGE_SECONDS", "TEST_MAX_AGE_MS", default_seconds=60.0
+        )
+        == 2.5
+    )
+
+
+def test_max_quote_age_seconds_empty_env_uses_legacy_ms(monkeypatch):
+    from nifty_scalper_bot.execution.readiness import resolve_max_quote_age_seconds
+
+    monkeypatch.setenv("TEST_MAX_AGE_SECONDS", "")
+    monkeypatch.setenv("TEST_MAX_AGE_MS", "2500")
+
+    assert (
+        resolve_max_quote_age_seconds(
+            "TEST_MAX_AGE_SECONDS", "TEST_MAX_AGE_MS", default_seconds=60.0
+        )
+        == 2.5
+    )
+
+
+def test_max_quote_age_seconds_valid_env_takes_precedence(monkeypatch):
+    from nifty_scalper_bot.execution.readiness import resolve_max_quote_age_seconds
+
+    monkeypatch.setenv("TEST_MAX_AGE_SECONDS", "5")
+    monkeypatch.setenv("TEST_MAX_AGE_MS", "2500")
+
+    assert (
+        resolve_max_quote_age_seconds(
+            "TEST_MAX_AGE_SECONDS", "TEST_MAX_AGE_MS", default_seconds=60.0
+        )
+        == 5.0
+    )
+
+
+def test_max_quote_age_seconds_invalid_non_empty_uses_default(monkeypatch):
+    from nifty_scalper_bot.execution.readiness import resolve_max_quote_age_seconds
+
+    monkeypatch.setenv("TEST_MAX_AGE_SECONDS", "bad # comment")
+    monkeypatch.setenv("TEST_MAX_AGE_MS", "2500")
+
+    assert (
+        resolve_max_quote_age_seconds(
+            "TEST_MAX_AGE_SECONDS", "TEST_MAX_AGE_MS", default_seconds=60.0
+        )
+        == 60.0
+    )

--- a/tests/execution/test_quote_readiness.py
+++ b/tests/execution/test_quote_readiness.py
@@ -95,7 +95,12 @@ def test_synthetic_timestamp_quality_blocks_live_quote_readiness():
 
     assert result.allowed is False
     assert result.reason == "timestamp_quality_unusable"
-    assert (bid, ask, spread, source) == (None, None, None, "timestamp_quality_unusable")
+    assert (bid, ask, spread, source) == (
+        None,
+        None,
+        None,
+        "timestamp_quality_unusable",
+    )
 
 
 def test_fresh_ms_quote_can_prove_one_recent_update():
@@ -118,3 +123,15 @@ def test_quote_age_seconds_does_not_invent_tick_count():
     )
     assert ticks == 0
     assert derived is False
+
+
+def test_canonical_quote_age_converts_milliseconds_to_seconds():
+    from nifty_scalper_bot.execution.readiness import resolve_quote_age_seconds
+
+    assert resolve_quote_age_seconds({"quote_age_ms": 2500}) == 2.5
+
+
+def test_canonical_quote_age_keeps_seconds_unchanged():
+    from nifty_scalper_bot.execution.readiness import resolve_quote_age_seconds
+
+    assert resolve_quote_age_seconds({"quote_age_s": 2.5}) == 2.5


### PR DESCRIPTION
### Motivation

- Prevent hydration/readiness crashes and inconsistent semantics caused by mixed millisecond/second env handling and unsafe `float(os.getenv(...))` parsing, and make CI quality checks runnable and reliable within the GitHub Actions Python environment. 
- Preserve the canonical readiness SSOT (MDM/runner/indicator) and keep DataHub strictly diagnostic/non-gating while improving quote-age semantics and CI invocations.

### Description

- Invoke quality tools via Python modules in CI by changing `.github/workflows/live-exit-safety-ci.yml` to run `python -m ruff`, `python -m black`, and `python -m mypy` so they execute reliably in the action environment. 
- Add `ruff` to the `dev` optional dependencies in `pyproject.toml` so CI installs the same tool the workflow invokes. 
- Introduce `resolve_max_quote_age_seconds(...)` in `src/nifty_scalper_bot/execution/readiness.py` to centralize seconds-vs-milliseconds resolution: prefer `HYDRATION_LIVE_TICK_MAX_AGE_SECONDS`, fall back to legacy ms env, and safely parse malformed/commented values using `parse_float_env`. 
- Update `src/nifty_scalper_bot/core/history_readiness.py` to consume canonical seconds via the new resolver and to use `parse_float_env` for spread config; keep `datahub_bars` as diagnostic only and retain gating on MDM/runner/indicator bar counts. 
- Add/adjust unit tests to assert canonical behavior: millisecond→seconds conversion, second-based env precedence, legacy-ms compatibility, and malformed env fallback; also touched/formatting cleanup for related readiness/quote tests.

### Testing

- Ran focused test suites: `pytest -q tests/execution/test_quote_readiness.py tests/core/test_hydration_status_propagation.py tests/core/test_hydration_datahub_not_gating.py tests/core/test_readiness_live_tick_proof.py tests/architecture/test_history_ownership.py`; all passed. 
- Ran broader readiness/usage grep-driven suites and lifecycle-focused test collections via `pytest` (tests referencing `resolve_quote_age_seconds`, `evaluate_quote_readiness`, `build_symbol_hydration_status`, `datahub_bars`, `ready_for_execution`, `live_orders_armed`), and the lifecycle/regression suites; all passed. 
- Quality checks executed as CI will: `python -m ruff check ...`, `python -m black --check ...`, and `python -m mypy --follow-imports=skip ...` on the scoped files; all passed. 
- Repository validation: `python -m compileall -q src`, full `pytest -q`, and `git diff --check` were run and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a536f043c448324ac9f6e071bd522f5)