### PR TITLE
Gate live strategy dispatch on fresh data

### DIFF
--- a/src/nifty_scalper_bot/core/strategy_live_safety.py
+++ b/src/nifty_scalper_bot/core/strategy_live_safety.py
@@ -14,7 +14,10 @@ from contextlib import suppress
 from datetime import datetime, timezone
 from typing import Any
 
-from nifty_scalper_bot.execution.readiness import HistoryReadinessPolicy
+from nifty_scalper_bot.execution.readiness import (
+    HistoryReadinessPolicy,
+    resolve_max_quote_age_seconds,
+)
 from nifty_scalper_bot.strategies.signal_generator import Signal
 from nifty_scalper_bot.utils.logging import get_logger, log_throttled
 from nifty_scalper_bot.utils.symbols import normalize_symbol
@@ -73,10 +76,27 @@ def _required_bars(manager: Any) -> int:
     return max(1, int(policy.option_eval_min_bars))
 
 
-def _max_age_seconds(name: str, default: float) -> float:
-    with suppress(Exception):
-        return max(0.0, float(os.getenv(name, str(default)) or default))
-    return default
+def _live_tick_max_age_seconds() -> float:
+    return resolve_max_quote_age_seconds(
+        "HYDRATION_LIVE_TICK_MAX_AGE_SECONDS",
+        "HYDRATION_LIVE_TICK_MAX_AGE_MS",
+        default_seconds=60.0,
+    )
+
+
+def _context_max_age_seconds() -> float:
+    return _live_tick_max_age_seconds()
+
+
+def _bar_max_age_seconds(manager: Any) -> float:
+    interval = getattr(manager, "_bar_interval_seconds", None)
+    if interval in (None, ""):
+        interval = getattr(manager, "bar_interval_seconds", None)
+    try:
+        interval_s = float(interval)
+    except (TypeError, ValueError):
+        interval_s = 60.0
+    return max(1.0, interval_s * 1.25)
 
 
 def _coerce_epoch_seconds(value: Any) -> float | None:
@@ -103,33 +123,70 @@ def _coerce_epoch_seconds(value: Any) -> float | None:
     return None
 
 
-def _latest_bar_epoch(manager: Any, symbol: str) -> float | None:
+def _bar_get(row: Any, key: str, default: Any = None) -> Any:
+    if isinstance(row, dict):
+        return row.get(key, default)
+    return getattr(row, key, default)
+
+
+def _boolish_false(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value is False
+    return str(value or "").strip().lower() in {
+        "0",
+        "false",
+        "no",
+        "n",
+        "open",
+        "forming",
+    }
+
+
+def _latest_bar_detail(manager: Any, symbol: str) -> dict[str, Any]:
     getter = getattr(getattr(manager, "_indicator_engine", None), "get_history", None)
     if not callable(getter):
-        return None
-    with suppress(Exception):
+        return {"reason": "live_latest_closed_bar_unavailable"}
+    history: list[Any] = []
+    try:
         history = list(getter(symbol) or [])
+    except Exception as exc:  # noqa: BLE001 - safety gate must fail closed, not crash
+        return {
+            "reason": "live_latest_closed_bar_unavailable",
+            "error_type": type(exc).__name__,
+        }
     if not history:
-        return None
+        return {"reason": "live_latest_closed_bar_missing"}
     latest = history[-1]
-    if isinstance(latest, dict):
-        for key in ("timestamp", "timestamp_ms", "ts", "date", "time"):
-            epoch = _coerce_epoch_seconds(latest.get(key))
-            if epoch is not None:
-                return epoch
+    for key in ("closed", "is_closed", "complete", "is_complete", "final"):
+        value = _bar_get(latest, key, None)
+        if _boolish_false(value):
+            return {"reason": "live_latest_closed_bar_open", "closed_field": key}
+    epoch = None
     for key in ("timestamp", "timestamp_ms", "ts", "date", "time"):
-        epoch = _coerce_epoch_seconds(getattr(latest, key, None))
+        epoch = _coerce_epoch_seconds(_bar_get(latest, key, None))
         if epoch is not None:
-            return epoch
-    return None
+            break
+    if epoch is None:
+        return {"reason": "live_latest_closed_bar_missing"}
+    return {"reason": "ready", "latest_bar_ts": epoch}
 
 
 def _latest_bar_fresh_block(manager: Any, symbol: str) -> dict[str, Any] | None:
-    max_age = _max_age_seconds("STRATEGY_LATEST_BAR_MAX_AGE_SECONDS", 180.0)
-    epoch = _latest_bar_epoch(manager, symbol)
-    if epoch is None:
-        return {"reason": "live_latest_closed_bar_missing", "max_bar_age_s": max_age}
-    age = max(0.0, time.time() - epoch)
+    max_age = _bar_max_age_seconds(manager)
+    detail = _latest_bar_detail(manager, symbol)
+    if detail.get("reason") != "ready":
+        detail["max_bar_age_s"] = max_age
+        return detail
+    epoch = float(detail["latest_bar_ts"])
+    age = time.time() - epoch
+    if age < -1.0:
+        return {
+            "reason": "live_latest_closed_bar_future_timestamp",
+            "latest_bar_ts": epoch,
+            "bar_age_s": age,
+            "max_bar_age_s": max_age,
+        }
+    age = max(0.0, age)
     if age > max_age:
         return {
             "reason": "live_latest_closed_bar_stale",
@@ -140,99 +197,161 @@ def _latest_bar_fresh_block(manager: Any, symbol: str) -> dict[str, Any] | None:
     return None
 
 
+def _market_data_manager(manager: Any) -> Any | None:
+    direct = getattr(manager, "_market_data_manager", None)
+    if direct is not None:
+        return direct
+    hub = getattr(manager, "_data_hub", None)
+    return getattr(hub, "_mdm", None)
+
+
 def _live_option_tick_block(manager: Any, symbol: str) -> dict[str, Any] | None:
-    max_age = _max_age_seconds("STRATEGY_LIVE_TICK_MAX_AGE_SECONDS", 5.0)
-    mdm = getattr(manager, "_market_data_manager", None) or getattr(
-        getattr(manager, "_data_hub", None), "_mdm", None
-    )
-    age_fn = getattr(mdm, "time_since_last_live_ws_tick", None)
-    if not callable(age_fn):
-        return None
-    with suppress(Exception):
-        age = age_fn(symbol)
-        if age is not None and float(age) <= max_age:
-            return None
-        if callable(getattr(mdm, "request_fallback_refresh", None)):
-            with suppress(Exception):
-                mdm.request_fallback_refresh(
-                    symbol, reason="strategy_live_option_tick_stale"
-                )
+    max_age = _live_tick_max_age_seconds()
+    mdm = _market_data_manager(manager)
+    if mdm is None:
         return {
-            "reason": "live_option_tick_stale",
-            "live_tick_age_s": age,
+            "reason": "live_market_data_manager_missing",
             "max_live_tick_age_s": max_age,
         }
-    return {
-        "reason": "live_option_tick_freshness_unknown",
-        "max_live_tick_age_s": max_age,
-    }
+    age_fn = getattr(mdm, "time_since_last_live_ws_tick", None)
+    if not callable(age_fn):
+        return {
+            "reason": "live_option_tick_freshness_unavailable",
+            "max_live_tick_age_s": max_age,
+        }
+    try:
+        age = age_fn(symbol)
+    except Exception as exc:  # noqa: BLE001
+        return {
+            "reason": "live_option_tick_freshness_unavailable",
+            "error_type": type(exc).__name__,
+            "max_live_tick_age_s": max_age,
+        }
+    if age is not None and float(age) <= max_age:
+        return None
+    if callable(getattr(mdm, "request_fallback_refresh", None)):
+        with suppress(Exception):
+            mdm.request_fallback_refresh(
+                symbol, reason="strategy_live_option_tick_stale"
+            )
+    reason = "live_option_tick_missing" if age is None else "live_option_tick_stale"
+    return {"reason": reason, "live_tick_age_s": age, "max_live_tick_age_s": max_age}
+
+
+def _num(value: Any) -> float | None:
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    return number if number == number else None
+
+
+def _snapshot_age_seconds(snapshot: dict[str, Any]) -> float | None:
+    for key in ("tick_age_s", "age_seconds", "context_age_seconds"):
+        age = _num(snapshot.get(key))
+        if age is not None:
+            return max(0.0, age)
+    for key in ("tick_age_ms", "quote_age_ms"):
+        age_ms = _num(snapshot.get(key))
+        if age_ms is not None:
+            return max(0.0, age_ms / 1000.0)
+    for key in ("context_timestamp_epoch", "timestamp"):
+        epoch = _coerce_epoch_seconds(snapshot.get(key))
+        if epoch is not None:
+            return max(0.0, time.time() - epoch)
+    return None
 
 
 def _context_fresh_block(manager: Any, symbol: str) -> dict[str, Any] | None:
     required = getattr(manager, "_strategy_required_context", None)
     if required is False:
         return None
-    indicators = getattr(manager, "_strategy_live_safety_last_indicators", {})
-    if not isinstance(indicators, dict):
-        indicators = {}
-    if indicators.get("context_fresh") is False:
-        return {"reason": "live_underlying_context_stale", "context_fresh": False}
-    max_age = _max_age_seconds("STRATEGY_CONTEXT_MAX_AGE_SECONDS", 120.0)
-    ages = {
-        k: indicators.get(k)
-        for k in (
-            "spot_age_seconds",
-            "spot_tick_age_s",
-            "futures_age_seconds",
-            "futures_tick_age_s",
-        )
-    }
-    present = [float(v) for v in ages.values() if isinstance(v, (int, float))]
-    if present and min(present) > max_age:
-        return {
-            "reason": "live_underlying_context_stale",
-            "context_age_seconds": min(present),
-            "max_context_age_s": max_age,
-        }
-    if (
-        indicators.get("spot_fresh") is False
-        and indicators.get("fut_fresh") is False
-        and indicators.get("futures_fresh") is False
-    ):
-        return {
-            "reason": "live_underlying_context_stale",
-            "spot_fresh": False,
-            "fut_fresh": False,
-        }
+    snapshots = getattr(manager, "_latest_context_snapshots", None)
+    if not isinstance(snapshots, dict):
+        return {"reason": "live_underlying_context_freshness_unknown"}
+    max_age = _context_max_age_seconds()
+    details: dict[str, Any] = {"max_context_age_s": max_age}
+    for role, label in (("spot_context", "spot"), ("futures_context", "futures")):
+        snap = snapshots.get(role)
+        if not isinstance(snap, dict) or not snap:
+            return {"reason": f"live_{label}_context_missing", **details}
+        fresh_key = "spot_fresh" if label == "spot" else "fut_fresh"
+        explicit = snap.get(fresh_key)
+        if explicit is False or snap.get("context_fresh") is False:
+            return {
+                "reason": f"live_{label}_context_stale",
+                fresh_key: False,
+                **details,
+            }
+        age = _snapshot_age_seconds(snap)
+        details[f"{label}_context_age_s"] = age
+        if age is None:
+            return {"reason": f"live_{label}_context_freshness_unknown", **details}
+        if age > max_age:
+            return {"reason": f"live_{label}_context_stale", **details}
     return None
 
 
+def _basket_get(basket: Any, key: str, default: Any = None) -> Any:
+    if isinstance(basket, dict):
+        return basket.get(key, default)
+    return getattr(basket, key, default)
+
+
+def _active_basket(manager: Any) -> Any | None:
+    hub = getattr(manager, "_data_hub", None)
+    getter = getattr(hub, "get_active_contract_basket", None)
+    if callable(getter):
+        with suppress(Exception):
+            basket = getter()
+            if basket is not None:
+                return basket
+    mdm = _market_data_manager(manager)
+    getter = getattr(mdm, "get_active_contract_basket", None)
+    if callable(getter):
+        with suppress(Exception):
+            basket = getter()
+            if basket is not None:
+                return basket
+    return getattr(manager, "active_contract_basket", None) or getattr(
+        manager, "_active_contract_basket", None
+    )
+
+
 def _selected_contract_block(manager: Any, symbol: str) -> dict[str, Any] | None:
-    indicators = getattr(manager, "_strategy_live_safety_last_indicators", {})
-    if not isinstance(indicators, dict):
-        return None
+    basket = _active_basket(manager)
+    if basket is None:
+        return {"reason": "live_active_basket_missing"}
     selected = {
-        normalize_symbol(indicators.get("selected_ce")),
-        normalize_symbol(indicators.get("selected_pe")),
+        normalize_symbol(
+            _basket_get(basket, "selected_ce") or _basket_get(basket, "atm_ce")
+        ),
+        normalize_symbol(
+            _basket_get(basket, "selected_pe") or _basket_get(basket, "atm_pe")
+        ),
     }
     selected.discard("")
-    if selected and normalize_symbol(symbol) not in selected:
+    if not selected:
+        return {"reason": "live_selected_contract_missing"}
+    if normalize_symbol(symbol) not in selected:
         return {
             "reason": "live_selected_contract_mismatch",
             "selected_symbols": sorted(selected),
         }
-    local_version = indicators.get("selected_contract_version") or indicators.get(
-        "active_basket_version"
+    basket_version = (
+        _basket_get(basket, "basket_version")
+        or _basket_get(basket, "active_basket_version")
+        or _basket_get(basket, "version")
     )
     owner_version = getattr(manager, "_active_basket_version", None)
     if (
-        local_version not in (None, "")
+        basket_version not in (None, "")
         and owner_version not in (None, "")
-        and str(local_version) != str(owner_version)
+        and str(basket_version) != str(owner_version)
     ):
         return {
             "reason": "live_selected_contract_version_stale",
-            "selected_contract_version": local_version,
+            "selected_contract_version": basket_version,
             "active_basket_version": owner_version,
         }
     return None
@@ -292,24 +411,6 @@ def _record(
         level=30,
         extra={"event": "STRATEGY_LIVE_SAFETY_BLOCK", "symbol": symbol, **payload},
     )
-
-
-def _prime_indicator_snapshot(manager: Any, symbol: str) -> None:
-    engine = getattr(manager, "_indicator_engine", None)
-    getter = getattr(engine, "get_indicators", None)
-    if not callable(getter):
-        return
-    required = set()
-    union = getattr(manager, "_strategy_required_indicator_union", None)
-    if callable(union):
-        with suppress(Exception):
-            required = set(union() or set())
-    with suppress(Exception):
-        raw = getter(symbol, required)
-        if isinstance(raw, dict):
-            manager._strategy_live_safety_last_indicators = dict(raw)
-        elif hasattr(raw, "items"):
-            manager._strategy_live_safety_last_indicators = dict(raw)
 
 
 def _readiness_block(manager: Any, symbol: str) -> dict[str, Any] | None:
@@ -482,7 +583,6 @@ def apply_patches() -> None:
         trace_id: str | None = None,
     ) -> Signal | None:
         symbol_norm = normalize_symbol(symbol)
-        _prime_indicator_snapshot(self, symbol_norm)
         block = _readiness_block(self, symbol_norm)
         if block is not None:
             _record(

--- a/src/nifty_scalper_bot/core/strategy_live_safety.py
+++ b/src/nifty_scalper_bot/core/strategy_live_safety.py
@@ -14,6 +14,7 @@ from contextlib import suppress
 from datetime import datetime, timezone
 from typing import Any
 
+from nifty_scalper_bot.config.defaults import QUOTE_STALE_THRESHOLD_MS
 from nifty_scalper_bot.execution.readiness import (
     HistoryReadinessPolicy,
     resolve_max_quote_age_seconds,
@@ -80,7 +81,7 @@ def _live_tick_max_age_seconds() -> float:
     return resolve_max_quote_age_seconds(
         "HYDRATION_LIVE_TICK_MAX_AGE_SECONDS",
         "HYDRATION_LIVE_TICK_MAX_AGE_MS",
-        default_seconds=60.0,
+        default_seconds=float(QUOTE_STALE_THRESHOLD_MS) / 1000.0,
     )
 
 
@@ -88,7 +89,7 @@ def _context_max_age_seconds() -> float:
     return _live_tick_max_age_seconds()
 
 
-def _bar_max_age_seconds(manager: Any) -> float:
+def _bar_interval_seconds(manager: Any) -> float:
     interval = getattr(manager, "_bar_interval_seconds", None)
     if interval in (None, ""):
         interval = getattr(manager, "bar_interval_seconds", None)
@@ -96,7 +97,11 @@ def _bar_max_age_seconds(manager: Any) -> float:
         interval_s = float(interval)
     except (TypeError, ValueError):
         interval_s = 60.0
-    return max(1.0, interval_s * 1.25)
+    return max(1.0, interval_s)
+
+
+def _clock_skew_tolerance_seconds() -> float:
+    return 2.0
 
 
 def _coerce_epoch_seconds(value: Any) -> float | None:
@@ -142,7 +147,7 @@ def _boolish_false(value: Any) -> bool:
     }
 
 
-def _latest_bar_detail(manager: Any, symbol: str) -> dict[str, Any]:
+def _latest_bar_detail(manager: Any, symbol: str, *, now: float) -> dict[str, Any]:
     getter = getattr(getattr(manager, "_indicator_engine", None), "get_history", None)
     if not callable(getter):
         return {"reason": "live_latest_closed_bar_unavailable"}
@@ -156,44 +161,64 @@ def _latest_bar_detail(manager: Any, symbol: str) -> dict[str, Any]:
         }
     if not history:
         return {"reason": "live_latest_closed_bar_missing"}
-    latest = history[-1]
-    for key in ("closed", "is_closed", "complete", "is_complete", "final"):
-        value = _bar_get(latest, key, None)
-        if _boolish_false(value):
-            return {"reason": "live_latest_closed_bar_open", "closed_field": key}
-    epoch = None
-    for key in ("timestamp", "timestamp_ms", "ts", "date", "time"):
-        epoch = _coerce_epoch_seconds(_bar_get(latest, key, None))
-        if epoch is not None:
-            break
-    if epoch is None:
-        return {"reason": "live_latest_closed_bar_missing"}
-    return {"reason": "ready", "latest_bar_ts": epoch}
+    interval_s = _bar_interval_seconds(manager)
+    current_bucket_start = (now // interval_s) * interval_s
+    expected_closed_start = current_bucket_start - interval_s
+    latest_stale: dict[str, Any] | None = None
+    for row in reversed(history):
+        for key in ("closed", "is_closed", "complete", "is_complete", "final"):
+            value = _bar_get(row, key, None)
+            if _boolish_false(value):
+                latest_stale = {
+                    "reason": "live_latest_closed_bar_open",
+                    "closed_field": key,
+                }
+                break
+        else:
+            epoch = None
+            for key in ("timestamp", "timestamp_ms", "ts", "date", "time"):
+                epoch = _coerce_epoch_seconds(_bar_get(row, key, None))
+                if epoch is not None:
+                    break
+            if epoch is None:
+                latest_stale = {"reason": "live_latest_closed_bar_missing"}
+                continue
+            if epoch > now + _clock_skew_tolerance_seconds():
+                return {
+                    "reason": "live_latest_closed_bar_future_timestamp",
+                    "latest_bar_ts": epoch,
+                }
+            bucket_start = (epoch // interval_s) * interval_s
+            if bucket_start >= current_bucket_start:
+                latest_stale = {
+                    "reason": "live_latest_closed_bar_open",
+                    "latest_bar_ts": epoch,
+                }
+                continue
+            if bucket_start == expected_closed_start:
+                return {
+                    "reason": "ready",
+                    "latest_bar_ts": epoch,
+                    "latest_bar_bucket_start": bucket_start,
+                    "expected_latest_closed_start": expected_closed_start,
+                    "interval_s": interval_s,
+                }
+            if bucket_start < expected_closed_start:
+                latest_stale = {
+                    "reason": "live_latest_closed_bar_stale",
+                    "latest_bar_ts": epoch,
+                    "latest_bar_bucket_start": bucket_start,
+                    "expected_latest_closed_start": expected_closed_start,
+                    "interval_s": interval_s,
+                }
+                break
+    return latest_stale or {"reason": "live_latest_closed_bar_missing"}
 
 
 def _latest_bar_fresh_block(manager: Any, symbol: str) -> dict[str, Any] | None:
-    max_age = _bar_max_age_seconds(manager)
-    detail = _latest_bar_detail(manager, symbol)
+    detail = _latest_bar_detail(manager, symbol, now=time.time())
     if detail.get("reason") != "ready":
-        detail["max_bar_age_s"] = max_age
         return detail
-    epoch = float(detail["latest_bar_ts"])
-    age = time.time() - epoch
-    if age < -1.0:
-        return {
-            "reason": "live_latest_closed_bar_future_timestamp",
-            "latest_bar_ts": epoch,
-            "bar_age_s": age,
-            "max_bar_age_s": max_age,
-        }
-    age = max(0.0, age)
-    if age > max_age:
-        return {
-            "reason": "live_latest_closed_bar_stale",
-            "latest_bar_ts": epoch,
-            "bar_age_s": age,
-            "max_bar_age_s": max_age,
-        }
     return None
 
 
@@ -250,15 +275,15 @@ def _snapshot_age_seconds(snapshot: dict[str, Any]) -> float | None:
     for key in ("tick_age_s", "age_seconds", "context_age_seconds"):
         age = _num(snapshot.get(key))
         if age is not None:
-            return max(0.0, age)
+            return age
     for key in ("tick_age_ms", "quote_age_ms"):
         age_ms = _num(snapshot.get(key))
         if age_ms is not None:
-            return max(0.0, age_ms / 1000.0)
+            return age_ms / 1000.0
     for key in ("context_timestamp_epoch", "timestamp"):
         epoch = _coerce_epoch_seconds(snapshot.get(key))
         if epoch is not None:
-            return max(0.0, time.time() - epoch)
+            return time.time() - epoch
     return None
 
 
@@ -287,6 +312,8 @@ def _context_fresh_block(manager: Any, symbol: str) -> dict[str, Any] | None:
         details[f"{label}_context_age_s"] = age
         if age is None:
             return {"reason": f"live_{label}_context_freshness_unknown", **details}
+        if age < -_clock_skew_tolerance_seconds():
+            return {"reason": f"live_{label}_context_future_timestamp", **details}
         if age > max_age:
             return {"reason": f"live_{label}_context_stale", **details}
     return None

--- a/src/nifty_scalper_bot/core/strategy_live_safety.py
+++ b/src/nifty_scalper_bot/core/strategy_live_safety.py
@@ -8,8 +8,10 @@ approved signals are idempotent without depending on every strategy to stamp it.
 
 from __future__ import annotations
 
-from contextlib import suppress
 import os
+import time
+from contextlib import suppress
+from datetime import datetime, timezone
 from typing import Any
 
 from nifty_scalper_bot.execution.readiness import HistoryReadinessPolicy
@@ -40,7 +42,11 @@ def _is_live(manager: Any) -> bool:
             return bool(checker())
     mode = str(os.getenv("EXECUTION_MODE", "SHADOW") or "SHADOW").strip().upper()
     live = _env_true("ENABLE_LIVE") or _env_true("ENABLE_LIVE_TRADING")
-    paper_shadow = _env_true("PAPER_MODE") or _env_true("PAPER__ENABLED") or _env_true("SHADOW_MODE")
+    paper_shadow = (
+        _env_true("PAPER_MODE")
+        or _env_true("PAPER__ENABLED")
+        or _env_true("SHADOW_MODE")
+    )
     return mode == "LIVE" and live and not paper_shadow
 
 
@@ -65,6 +71,171 @@ def _required_bars(manager: Any) -> int:
     with suppress(Exception):
         return max(1, int(raw or policy.option_eval_min_bars))
     return max(1, int(policy.option_eval_min_bars))
+
+
+def _max_age_seconds(name: str, default: float) -> float:
+    with suppress(Exception):
+        return max(0.0, float(os.getenv(name, str(default)) or default))
+    return default
+
+
+def _coerce_epoch_seconds(value: Any) -> float | None:
+    if value in (None, ""):
+        return None
+    if isinstance(value, (int, float)):
+        raw = float(value)
+        if raw > 1_000_000_000_000:
+            return raw / 1000.0
+        return raw
+    if isinstance(value, datetime):
+        dt = value if value.tzinfo is not None else value.replace(tzinfo=timezone.utc)
+        return dt.timestamp()
+    text = str(value).strip()
+    if not text:
+        return None
+    with suppress(Exception):
+        return _coerce_epoch_seconds(float(text))
+    with suppress(Exception):
+        dt = datetime.fromisoformat(text.replace("Z", "+00:00"))
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt.timestamp()
+    return None
+
+
+def _latest_bar_epoch(manager: Any, symbol: str) -> float | None:
+    getter = getattr(getattr(manager, "_indicator_engine", None), "get_history", None)
+    if not callable(getter):
+        return None
+    with suppress(Exception):
+        history = list(getter(symbol) or [])
+    if not history:
+        return None
+    latest = history[-1]
+    if isinstance(latest, dict):
+        for key in ("timestamp", "timestamp_ms", "ts", "date", "time"):
+            epoch = _coerce_epoch_seconds(latest.get(key))
+            if epoch is not None:
+                return epoch
+    for key in ("timestamp", "timestamp_ms", "ts", "date", "time"):
+        epoch = _coerce_epoch_seconds(getattr(latest, key, None))
+        if epoch is not None:
+            return epoch
+    return None
+
+
+def _latest_bar_fresh_block(manager: Any, symbol: str) -> dict[str, Any] | None:
+    max_age = _max_age_seconds("STRATEGY_LATEST_BAR_MAX_AGE_SECONDS", 180.0)
+    epoch = _latest_bar_epoch(manager, symbol)
+    if epoch is None:
+        return {"reason": "live_latest_closed_bar_missing", "max_bar_age_s": max_age}
+    age = max(0.0, time.time() - epoch)
+    if age > max_age:
+        return {
+            "reason": "live_latest_closed_bar_stale",
+            "latest_bar_ts": epoch,
+            "bar_age_s": age,
+            "max_bar_age_s": max_age,
+        }
+    return None
+
+
+def _live_option_tick_block(manager: Any, symbol: str) -> dict[str, Any] | None:
+    max_age = _max_age_seconds("STRATEGY_LIVE_TICK_MAX_AGE_SECONDS", 5.0)
+    mdm = getattr(manager, "_market_data_manager", None) or getattr(
+        getattr(manager, "_data_hub", None), "_mdm", None
+    )
+    age_fn = getattr(mdm, "time_since_last_live_ws_tick", None)
+    if not callable(age_fn):
+        return None
+    with suppress(Exception):
+        age = age_fn(symbol)
+        if age is not None and float(age) <= max_age:
+            return None
+        if callable(getattr(mdm, "request_fallback_refresh", None)):
+            with suppress(Exception):
+                mdm.request_fallback_refresh(
+                    symbol, reason="strategy_live_option_tick_stale"
+                )
+        return {
+            "reason": "live_option_tick_stale",
+            "live_tick_age_s": age,
+            "max_live_tick_age_s": max_age,
+        }
+    return {
+        "reason": "live_option_tick_freshness_unknown",
+        "max_live_tick_age_s": max_age,
+    }
+
+
+def _context_fresh_block(manager: Any, symbol: str) -> dict[str, Any] | None:
+    required = getattr(manager, "_strategy_required_context", None)
+    if required is False:
+        return None
+    indicators = getattr(manager, "_strategy_live_safety_last_indicators", {})
+    if not isinstance(indicators, dict):
+        indicators = {}
+    if indicators.get("context_fresh") is False:
+        return {"reason": "live_underlying_context_stale", "context_fresh": False}
+    max_age = _max_age_seconds("STRATEGY_CONTEXT_MAX_AGE_SECONDS", 120.0)
+    ages = {
+        k: indicators.get(k)
+        for k in (
+            "spot_age_seconds",
+            "spot_tick_age_s",
+            "futures_age_seconds",
+            "futures_tick_age_s",
+        )
+    }
+    present = [float(v) for v in ages.values() if isinstance(v, (int, float))]
+    if present and min(present) > max_age:
+        return {
+            "reason": "live_underlying_context_stale",
+            "context_age_seconds": min(present),
+            "max_context_age_s": max_age,
+        }
+    if (
+        indicators.get("spot_fresh") is False
+        and indicators.get("fut_fresh") is False
+        and indicators.get("futures_fresh") is False
+    ):
+        return {
+            "reason": "live_underlying_context_stale",
+            "spot_fresh": False,
+            "fut_fresh": False,
+        }
+    return None
+
+
+def _selected_contract_block(manager: Any, symbol: str) -> dict[str, Any] | None:
+    indicators = getattr(manager, "_strategy_live_safety_last_indicators", {})
+    if not isinstance(indicators, dict):
+        return None
+    selected = {
+        normalize_symbol(indicators.get("selected_ce")),
+        normalize_symbol(indicators.get("selected_pe")),
+    }
+    selected.discard("")
+    if selected and normalize_symbol(symbol) not in selected:
+        return {
+            "reason": "live_selected_contract_mismatch",
+            "selected_symbols": sorted(selected),
+        }
+    local_version = indicators.get("selected_contract_version") or indicators.get(
+        "active_basket_version"
+    )
+    owner_version = getattr(manager, "_active_basket_version", None)
+    if (
+        local_version not in (None, "")
+        and owner_version not in (None, "")
+        and str(local_version) != str(owner_version)
+    ):
+        return {
+            "reason": "live_selected_contract_version_stale",
+            "selected_contract_version": local_version,
+            "active_basket_version": owner_version,
+        }
+    return None
 
 
 def _hub_ready(manager: Any) -> bool | None:
@@ -123,6 +294,24 @@ def _record(
     )
 
 
+def _prime_indicator_snapshot(manager: Any, symbol: str) -> None:
+    engine = getattr(manager, "_indicator_engine", None)
+    getter = getattr(engine, "get_indicators", None)
+    if not callable(getter):
+        return
+    required = set()
+    union = getattr(manager, "_strategy_required_indicator_union", None)
+    if callable(union):
+        with suppress(Exception):
+            required = set(union() or set())
+    with suppress(Exception):
+        raw = getter(symbol, required)
+        if isinstance(raw, dict):
+            manager._strategy_live_safety_last_indicators = dict(raw)
+        elif hasattr(raw, "items"):
+            manager._strategy_live_safety_last_indicators = dict(raw)
+
+
 def _readiness_block(manager: Any, symbol: str) -> dict[str, Any] | None:
     if not _is_live(manager):
         return None
@@ -140,6 +329,17 @@ def _readiness_block(manager: Any, symbol: str) -> dict[str, Any] | None:
             "bars_available": available,
             "required_bars": required,
         }
+    for checker in (
+        _latest_bar_fresh_block,
+        _live_option_tick_block,
+        _context_fresh_block,
+        _selected_contract_block,
+    ):
+        block = checker(manager, symbol)
+        if block is not None:
+            block.setdefault("bars_available", available)
+            block.setdefault("required_bars", required)
+            return block
     return None
 
 
@@ -156,7 +356,9 @@ def _add_identity(signal: Signal) -> Signal:
             if candidate not in (None, ""):
                 metadata["timestamp"] = candidate
                 break
-    deterministic = str(metadata.get("deterministic_signal_id") or signal.deterministic_id)
+    deterministic = str(
+        metadata.get("deterministic_signal_id") or signal.deterministic_id
+    )
     metadata.setdefault("deterministic_signal_id", deterministic)
     metadata.setdefault("signal_id", deterministic)
     metadata.setdefault("idempotency_key", deterministic)
@@ -255,8 +457,12 @@ def _install_canonical_history_builder(strategy_module: Any) -> None:
     )
     from nifty_scalper_bot.strategies import signal_generator as signal_generator_module
 
-    strategy_module.build_strategy_history_context = canonical_build_strategy_history_context
-    signal_generator_module.build_strategy_history_context = canonical_build_strategy_history_context
+    strategy_module.build_strategy_history_context = (
+        canonical_build_strategy_history_context
+    )
+    signal_generator_module.build_strategy_history_context = (
+        canonical_build_strategy_history_context
+    )
 
 
 def apply_patches() -> None:
@@ -276,6 +482,7 @@ def apply_patches() -> None:
         trace_id: str | None = None,
     ) -> Signal | None:
         symbol_norm = normalize_symbol(symbol)
+        _prime_indicator_snapshot(self, symbol_norm)
         block = _readiness_block(self, symbol_norm)
         if block is not None:
             _record(
@@ -302,7 +509,10 @@ def apply_patches() -> None:
             _record(
                 self,
                 signal.symbol,
-                str(orderflow_block.get("reason") or "live_orderflow_selected_option_required"),
+                str(
+                    orderflow_block.get("reason")
+                    or "live_orderflow_selected_option_required"
+                ),
                 trace_id,
                 orderflow_block,
             )

--- a/tests/core/test_strategy_live_safety.py
+++ b/tests/core/test_strategy_live_safety.py
@@ -17,17 +17,21 @@ class _Engine:
         indicators: dict | None = None,
         raises: bool = False,
         latest_extra: dict | None = None,
+        rows: list[dict] | None = None,
     ) -> None:
         self.bars = bars
         self.latest_age_s = latest_age_s
         self.indicators = dict(indicators or {})
         self.raises = raises
         self.latest_extra = dict(latest_extra or {})
+        self.rows = [dict(row) for row in rows] if rows is not None else None
         self.indicator_calls = 0
 
     def get_history(self, _symbol: str):
         if self.raises:
             raise RuntimeError("history unavailable")
+        if self.rows is not None:
+            return [dict(row) for row in self.rows]
         ts = time.time() - self.latest_age_s
         row = {"timestamp": ts, "open": 1, "high": 1, "low": 1, "close": 1}
         row.update(self.latest_extra)
@@ -50,6 +54,31 @@ def _live_env(monkeypatch) -> None:
     monkeypatch.setenv("PAPER_MODE", "false")
     monkeypatch.setenv("PAPER__ENABLED", "false")
     monkeypatch.setenv("SHADOW_MODE", "false")
+
+
+def _shadow_env(monkeypatch) -> None:
+    monkeypatch.setenv("EXECUTION_MODE", "SHADOW")
+    monkeypatch.setenv("ENABLE_LIVE", "false")
+    monkeypatch.setenv("ENABLE_LIVE_TRADING", "false")
+    monkeypatch.setenv("SHADOW_MODE", "true")
+
+
+def _set_now(monkeypatch, epoch: float) -> None:
+    monkeypatch.setattr(guard.time, "time", lambda: epoch)
+
+
+def _bars(*timestamps: float, extra: dict | None = None) -> list[dict]:
+    extra = dict(extra or {})
+    return [
+        dict({"timestamp": ts, "open": 1, "high": 1, "low": 1, "close": 1}, **extra)
+        for ts in timestamps
+    ]
+
+
+def _history_at(
+    timestamp: float, *, count: int = 5, extra: dict | None = None
+) -> list[dict]:
+    return _bars(*([timestamp] * count), extra=extra)
 
 
 def _signal(**metadata) -> Signal:
@@ -192,6 +221,9 @@ def _manager_with_strategy(
     engine: _Engine, strategy: _CallingStrategy | None = None
 ) -> tuple[StrategyManager, _CallingStrategy]:
     strategy = strategy or _CallingStrategy()
+    if engine.rows is None and not engine.raises:
+        now = guard.time.time()
+        engine.rows = _history_at((now // 60.0) * 60.0 - 60.0)
     manager = StrategyManager([strategy], engine, _Positions())
     manager._required_candles = 2
     manager._bar_interval_seconds = 60.0
@@ -201,10 +233,51 @@ def _manager_with_strategy(
     return manager, strategy
 
 
-def test_live_strategy_manager_fails_closed_on_stale_latest_bar(monkeypatch) -> None:
+def test_live_strategy_manager_accepts_expected_closed_bucket_early_next_minute(
+    monkeypatch,
+) -> None:
     _live_env(monkeypatch)
-    manager, strategy = _manager_with_strategy(_Engine(5, latest_age_s=60.0))
-    manager._bar_interval_seconds = 8.0
+    now = 11 * 3600 + 31 * 60 + 5
+    _set_now(monkeypatch, float(now))
+    manager, strategy = _manager_with_strategy(
+        _Engine(5, rows=_history_at(11 * 3600 + 30 * 60))
+    )
+
+    result = manager.generate_signal(
+        "NFO:NIFTY2662324050CE", 100.0, trace_id="fresh-bar-early"
+    )
+
+    assert result is None
+    assert strategy.calls == 1
+
+
+def test_live_strategy_manager_accepts_expected_closed_bucket_late_next_minute(
+    monkeypatch,
+) -> None:
+    _live_env(monkeypatch)
+    now = 11 * 3600 + 31 * 60 + 50
+    _set_now(monkeypatch, float(now))
+    manager, strategy = _manager_with_strategy(
+        _Engine(5, rows=_history_at(11 * 3600 + 30 * 60))
+    )
+
+    result = manager.generate_signal(
+        "NFO:NIFTY2662324050CE", 100.0, trace_id="fresh-bar-late"
+    )
+
+    assert result is None
+    assert strategy.calls == 1
+
+
+def test_live_strategy_manager_fails_closed_on_one_interval_old_bar(
+    monkeypatch,
+) -> None:
+    _live_env(monkeypatch)
+    now = 11 * 3600 + 32 * 60 + 5
+    _set_now(monkeypatch, float(now))
+    manager, strategy = _manager_with_strategy(
+        _Engine(5, rows=_history_at(11 * 3600 + 30 * 60))
+    )
 
     result = manager.generate_signal(
         "NFO:NIFTY2662324050CE", 100.0, trace_id="stale-bar"
@@ -215,6 +288,26 @@ def test_live_strategy_manager_fails_closed_on_stale_latest_bar(monkeypatch) -> 
     assert (
         manager.get_last_no_signal_decision("NFO:NIFTY2662324050CE").reason
         == "live_latest_closed_bar_stale"
+    )
+
+
+def test_live_strategy_manager_ignores_current_forming_bucket_as_closed(
+    monkeypatch,
+) -> None:
+    _live_env(monkeypatch)
+    now = 11 * 3600 + 31 * 60 + 5
+    _set_now(monkeypatch, float(now))
+    manager, strategy = _manager_with_strategy(
+        _Engine(5, rows=_history_at(11 * 3600 + 31 * 60))
+    )
+
+    result = manager.generate_signal("NFO:NIFTY2662324050CE", 100.0)
+
+    assert result is None
+    assert strategy.calls == 0
+    assert (
+        manager.get_last_no_signal_decision("NFO:NIFTY2662324050CE").reason
+        == "live_latest_closed_bar_open"
     )
 
 
@@ -454,8 +547,10 @@ def test_live_strategy_manager_does_not_prime_indicators_before_dispatch(
 
 def test_live_strategy_manager_blocks_latest_open_candle(monkeypatch) -> None:
     _live_env(monkeypatch)
+    now = 11 * 3600 + 31 * 60 + 5
+    _set_now(monkeypatch, float(now))
     manager, strategy = _manager_with_strategy(
-        _Engine(5, latest_extra={"is_closed": False})
+        _Engine(5, rows=_history_at(11 * 3600 + 30 * 60, extra={"is_closed": False}))
     )
 
     result = manager.generate_signal("NFO:NIFTY2662324050CE", 100.0)
@@ -470,7 +565,9 @@ def test_live_strategy_manager_blocks_latest_open_candle(monkeypatch) -> None:
 
 def test_live_strategy_manager_blocks_future_bar_timestamp(monkeypatch) -> None:
     _live_env(monkeypatch)
-    manager, strategy = _manager_with_strategy(_Engine(5, latest_age_s=-30.0))
+    now = 11 * 3600 + 31 * 60 + 5
+    _set_now(monkeypatch, float(now))
+    manager, strategy = _manager_with_strategy(_Engine(5, rows=_history_at(now + 30)))
 
     result = manager.generate_signal("NFO:NIFTY2662324050CE", 100.0)
 
@@ -480,3 +577,87 @@ def test_live_strategy_manager_blocks_future_bar_timestamp(monkeypatch) -> None:
         manager.get_last_no_signal_decision("NFO:NIFTY2662324050CE").reason
         == "live_latest_closed_bar_future_timestamp"
     )
+
+
+def test_live_strategy_manager_blocks_future_spot_context_timestamp(
+    monkeypatch,
+) -> None:
+    _live_env(monkeypatch)
+    now = 11 * 3600 + 31 * 60 + 5
+    _set_now(monkeypatch, float(now))
+    manager, strategy = _manager_with_strategy(
+        _Engine(5, rows=_history_at(11 * 3600 + 30 * 60))
+    )
+    manager._latest_context_snapshots = {
+        "spot_context": {"timestamp": now + 30},
+        "futures_context": {"timestamp": now - 1},
+    }
+
+    result = manager.generate_signal("NFO:NIFTY2662324050CE", 100.0)
+
+    assert result is None
+    assert strategy.calls == 0
+    assert (
+        manager.get_last_no_signal_decision("NFO:NIFTY2662324050CE").reason
+        == "live_spot_context_future_timestamp"
+    )
+
+
+def test_live_strategy_manager_blocks_future_futures_context_timestamp(
+    monkeypatch,
+) -> None:
+    _live_env(monkeypatch)
+    now = 11 * 3600 + 31 * 60 + 5
+    _set_now(monkeypatch, float(now))
+    manager, strategy = _manager_with_strategy(
+        _Engine(5, rows=_history_at(11 * 3600 + 30 * 60))
+    )
+    manager._latest_context_snapshots = {
+        "spot_context": {"timestamp": now - 1},
+        "futures_context": {"timestamp": now + 30},
+    }
+
+    result = manager.generate_signal("NFO:NIFTY2662324050CE", 100.0)
+
+    assert result is None
+    assert strategy.calls == 0
+    assert (
+        manager.get_last_no_signal_decision("NFO:NIFTY2662324050CE").reason
+        == "live_futures_context_future_timestamp"
+    )
+
+
+def test_live_strategy_manager_production_wired_fresh_runtime_invokes_once(
+    monkeypatch,
+) -> None:
+    _shadow_env(monkeypatch)
+    now = 11 * 3600 + 31 * 60 + 5
+    _set_now(monkeypatch, float(now))
+    strategy = _CallingStrategy()
+    engine = _Engine(
+        5,
+        rows=_history_at(11 * 3600 + 30 * 60),
+        indicators={"ltp": 100.0, "close": 100.0},
+    )
+    if engine.rows is None and not engine.raises:
+        now = guard.time.time()
+        engine.rows = _history_at((now // 60.0) * 60.0 - 60.0)
+    manager = StrategyManager([strategy], engine, _Positions())
+    manager._required_candles = 2
+    manager._bar_interval_seconds = 60.0
+    mdm = _TickMDM(age=1.0)
+    manager._market_data_manager = mdm
+    manager._active_basket_version = "v1"
+
+    manager.generate_signal("NSE:NIFTY", 100.0, trace_id="publish-spot")
+    manager.generate_signal("NFO:NIFTY26JUN25000FUT", 100.0, trace_id="publish-futures")
+
+    _live_env(monkeypatch)
+    result = manager.generate_signal(
+        "NFO:NIFTY2662324050CE", 100.0, trace_id="live-option"
+    )
+
+    assert result is None
+    assert strategy.calls == 1
+    assert mdm.get_active_contract_basket()["selected_ce"] == "NFO:NIFTY2662324050CE"
+    assert set(manager._latest_context_snapshots) >= {"spot_context", "futures_context"}

--- a/tests/core/test_strategy_live_safety.py
+++ b/tests/core/test_strategy_live_safety.py
@@ -10,20 +10,31 @@ from nifty_scalper_bot.strategies.signal_generator import Signal
 
 class _Engine:
     def __init__(
-        self, bars: int, *, latest_age_s: float = 1.0, indicators: dict | None = None
+        self,
+        bars: int,
+        *,
+        latest_age_s: float = 1.0,
+        indicators: dict | None = None,
+        raises: bool = False,
+        latest_extra: dict | None = None,
     ) -> None:
         self.bars = bars
         self.latest_age_s = latest_age_s
         self.indicators = dict(indicators or {})
+        self.raises = raises
+        self.latest_extra = dict(latest_extra or {})
+        self.indicator_calls = 0
 
     def get_history(self, _symbol: str):
+        if self.raises:
+            raise RuntimeError("history unavailable")
         ts = time.time() - self.latest_age_s
-        return [
-            {"timestamp": ts, "open": 1, "high": 1, "low": 1, "close": 1}
-            for _ in range(self.bars)
-        ]
+        row = {"timestamp": ts, "open": 1, "high": 1, "low": 1, "close": 1}
+        row.update(self.latest_extra)
+        return [dict(row) for _ in range(self.bars)]
 
     def get_indicators(self, _symbol: str, _names):
+        self.indicator_calls += 1
         return dict(self.indicators)
 
 
@@ -126,8 +137,13 @@ def test_live_signal_identity_is_generated_and_enriched() -> None:
 
 
 class _TickMDM:
-    def __init__(self, age: float | None) -> None:
+    def __init__(self, age: float | None, *, basket: dict | None = None) -> None:
         self.age = age
+        self.basket = basket or {
+            "selected_ce": "NFO:NIFTY2662324050CE",
+            "selected_pe": "NFO:NIFTY2662324050PE",
+            "basket_version": "v1",
+        }
         self.recovery_requests: list[tuple[str, str]] = []
 
     def time_since_last_live_ws_tick(self, symbol: str):
@@ -136,6 +152,17 @@ class _TickMDM:
     def request_fallback_refresh(self, symbol: str, *, reason: str) -> bool:
         self.recovery_requests.append((symbol, reason))
         return True
+
+    def get_active_contract_basket(self):
+        return self.basket
+
+
+class _NoFreshnessMDM:
+    def get_active_contract_basket(self):
+        return {
+            "selected_ce": "NFO:NIFTY2662324050CE",
+            "selected_pe": "NFO:NIFTY2662324050PE",
+        }
 
 
 class _CallingStrategy:
@@ -153,19 +180,31 @@ class _CallingStrategy:
         return None
 
 
+def _fresh_context(*, spot_age: float = 1.0, futures_age: float = 1.0) -> dict:
+    now = time.time()
+    return {
+        "spot_context": {"timestamp": now - spot_age},
+        "futures_context": {"timestamp": now - futures_age},
+    }
+
+
 def _manager_with_strategy(
     engine: _Engine, strategy: _CallingStrategy | None = None
 ) -> tuple[StrategyManager, _CallingStrategy]:
     strategy = strategy or _CallingStrategy()
     manager = StrategyManager([strategy], engine, _Positions())
     manager._required_candles = 2
+    manager._bar_interval_seconds = 60.0
+    manager._market_data_manager = _TickMDM(age=1.0)
+    manager._latest_context_snapshots = _fresh_context()
+    manager._active_basket_version = "v1"
     return manager, strategy
 
 
 def test_live_strategy_manager_fails_closed_on_stale_latest_bar(monkeypatch) -> None:
     _live_env(monkeypatch)
-    monkeypatch.setenv("STRATEGY_LATEST_BAR_MAX_AGE_SECONDS", "10")
     manager, strategy = _manager_with_strategy(_Engine(5, latest_age_s=60.0))
+    manager._bar_interval_seconds = 8.0
 
     result = manager.generate_signal(
         "NFO:NIFTY2662324050CE", 100.0, trace_id="stale-bar"
@@ -183,7 +222,7 @@ def test_live_strategy_manager_blocks_stale_option_tick_and_requests_recovery(
     monkeypatch,
 ) -> None:
     _live_env(monkeypatch)
-    monkeypatch.setenv("STRATEGY_LIVE_TICK_MAX_AGE_SECONDS", "5")
+    monkeypatch.setenv("HYDRATION_LIVE_TICK_MAX_AGE_SECONDS", "5")
     manager, strategy = _manager_with_strategy(_Engine(5))
     mdm = _TickMDM(age=30.0)
     manager._market_data_manager = mdm
@@ -207,8 +246,9 @@ def test_live_strategy_manager_fails_closed_on_stale_underlying_context(
     monkeypatch,
 ) -> None:
     _live_env(monkeypatch)
-    engine = _Engine(5, indicators={"context_fresh": False})
+    engine = _Engine(5)
     manager, strategy = _manager_with_strategy(engine)
+    manager._latest_context_snapshots = _fresh_context(spot_age=1.0, futures_age=300.0)
 
     result = manager.generate_signal(
         "NFO:NIFTY2662324050CE", 100.0, trace_id="stale-context"
@@ -218,7 +258,7 @@ def test_live_strategy_manager_fails_closed_on_stale_underlying_context(
     assert strategy.calls == 0
     assert (
         manager.get_last_no_signal_decision("NFO:NIFTY2662324050CE").reason
-        == "live_underlying_context_stale"
+        == "live_futures_context_stale"
     )
 
 
@@ -226,13 +266,7 @@ def test_live_strategy_manager_fails_closed_on_selected_contract_mismatch(
     monkeypatch,
 ) -> None:
     _live_env(monkeypatch)
-    engine = _Engine(
-        5,
-        indicators={
-            "selected_ce": "NFO:NIFTY2662324050CE",
-            "selected_pe": "NFO:NIFTY2662324050PE",
-        },
-    )
+    engine = _Engine(5)
     manager, strategy = _manager_with_strategy(engine)
 
     result = manager.generate_signal(
@@ -251,11 +285,8 @@ def test_live_strategy_manager_invokes_strategy_when_canonical_freshness_gate_pa
     monkeypatch,
 ) -> None:
     _live_env(monkeypatch)
-    engine = _Engine(
-        5, indicators={"context_fresh": True, "selected_ce": "NFO:NIFTY2662324050CE"}
-    )
+    engine = _Engine(5)
     manager, strategy = _manager_with_strategy(engine)
-    manager._market_data_manager = _TickMDM(age=1.0)
 
     result = manager.generate_signal(
         "NFO:NIFTY2662324050CE", 100.0, trace_id="fresh-pass"
@@ -265,3 +296,187 @@ def test_live_strategy_manager_invokes_strategy_when_canonical_freshness_gate_pa
     assert strategy.calls == 1
     decision = manager.get_last_no_signal_decision("NFO:NIFTY2662324050CE")
     assert decision is None or decision.blocked_at != "strategy_live_safety"
+
+
+def test_live_strategy_manager_fails_closed_when_mdm_missing(monkeypatch) -> None:
+    _live_env(monkeypatch)
+    manager, strategy = _manager_with_strategy(_Engine(5))
+    manager._market_data_manager = None
+    manager._data_hub = None
+
+    result = manager.generate_signal("NFO:NIFTY2662324050CE", 100.0)
+
+    assert result is None
+    assert strategy.calls == 0
+    assert (
+        manager.get_last_no_signal_decision("NFO:NIFTY2662324050CE").reason
+        == "live_market_data_manager_missing"
+    )
+
+
+def test_live_strategy_manager_fails_closed_when_tick_freshness_api_missing(
+    monkeypatch,
+) -> None:
+    _live_env(monkeypatch)
+    manager, strategy = _manager_with_strategy(_Engine(5))
+    manager._market_data_manager = _NoFreshnessMDM()
+
+    result = manager.generate_signal("NFO:NIFTY2662324050CE", 100.0)
+
+    assert result is None
+    assert strategy.calls == 0
+    assert (
+        manager.get_last_no_signal_decision("NFO:NIFTY2662324050CE").reason
+        == "live_option_tick_freshness_unavailable"
+    )
+
+
+def test_live_strategy_manager_fails_closed_when_first_ws_tick_missing(
+    monkeypatch,
+) -> None:
+    _live_env(monkeypatch)
+    manager, strategy = _manager_with_strategy(_Engine(5))
+    manager._market_data_manager = _TickMDM(age=None)
+
+    result = manager.generate_signal("NFO:NIFTY2662324050CE", 100.0)
+
+    assert result is None
+    assert strategy.calls == 0
+    assert (
+        manager.get_last_no_signal_decision("NFO:NIFTY2662324050CE").reason
+        == "live_option_tick_missing"
+    )
+
+
+def test_live_strategy_manager_history_exception_fails_closed_without_crash(
+    monkeypatch,
+) -> None:
+    _live_env(monkeypatch)
+    manager, strategy = _manager_with_strategy(_Engine(5, raises=True))
+
+    result = manager.generate_signal("NFO:NIFTY2662324050CE", 100.0)
+
+    assert result is None
+    assert strategy.calls == 0
+    assert (
+        manager.get_last_no_signal_decision("NFO:NIFTY2662324050CE").reason
+        == "live_indicators_not_ready"
+    )
+
+
+def test_live_strategy_manager_blocks_when_spot_stale_even_if_future_fresh(
+    monkeypatch,
+) -> None:
+    _live_env(monkeypatch)
+    manager, strategy = _manager_with_strategy(_Engine(5))
+    manager._latest_context_snapshots = _fresh_context(spot_age=300.0, futures_age=1.0)
+
+    result = manager.generate_signal("NFO:NIFTY2662324050CE", 100.0)
+
+    assert result is None
+    assert strategy.calls == 0
+    assert (
+        manager.get_last_no_signal_decision("NFO:NIFTY2662324050CE").reason
+        == "live_spot_context_stale"
+    )
+
+
+def test_live_strategy_manager_blocks_when_context_freshness_unknown(
+    monkeypatch,
+) -> None:
+    _live_env(monkeypatch)
+    manager, strategy = _manager_with_strategy(_Engine(5))
+    manager._latest_context_snapshots = {}
+
+    result = manager.generate_signal("NFO:NIFTY2662324050CE", 100.0)
+
+    assert result is None
+    assert strategy.calls == 0
+    assert (
+        manager.get_last_no_signal_decision("NFO:NIFTY2662324050CE").reason
+        == "live_spot_context_missing"
+    )
+
+
+def test_live_strategy_manager_blocks_when_active_basket_missing(monkeypatch) -> None:
+    _live_env(monkeypatch)
+    manager, strategy = _manager_with_strategy(_Engine(5))
+    manager._market_data_manager = _TickMDM(age=1.0, basket=None)
+    manager._market_data_manager.basket = None
+
+    result = manager.generate_signal("NFO:NIFTY2662324050CE", 100.0)
+
+    assert result is None
+    assert strategy.calls == 0
+    assert (
+        manager.get_last_no_signal_decision("NFO:NIFTY2662324050CE").reason
+        == "live_active_basket_missing"
+    )
+
+
+def test_live_strategy_manager_blocks_canonical_basket_version_mismatch(
+    monkeypatch,
+) -> None:
+    _live_env(monkeypatch)
+    manager, strategy = _manager_with_strategy(_Engine(5))
+    manager._market_data_manager = _TickMDM(
+        age=1.0,
+        basket={
+            "selected_ce": "NFO:NIFTY2662324050CE",
+            "selected_pe": "NFO:NIFTY2662324050PE",
+            "basket_version": "v2",
+        },
+    )
+
+    result = manager.generate_signal("NFO:NIFTY2662324050CE", 100.0)
+
+    assert result is None
+    assert strategy.calls == 0
+    assert (
+        manager.get_last_no_signal_decision("NFO:NIFTY2662324050CE").reason
+        == "live_selected_contract_version_stale"
+    )
+
+
+def test_live_strategy_manager_does_not_prime_indicators_before_dispatch(
+    monkeypatch,
+) -> None:
+    _live_env(monkeypatch)
+    engine = _Engine(5)
+    manager, strategy = _manager_with_strategy(engine)
+
+    result = manager.generate_signal("NFO:NIFTY2662324050CE", 100.0)
+
+    assert result is None
+    assert strategy.calls == 1
+    assert engine.indicator_calls == 1
+
+
+def test_live_strategy_manager_blocks_latest_open_candle(monkeypatch) -> None:
+    _live_env(monkeypatch)
+    manager, strategy = _manager_with_strategy(
+        _Engine(5, latest_extra={"is_closed": False})
+    )
+
+    result = manager.generate_signal("NFO:NIFTY2662324050CE", 100.0)
+
+    assert result is None
+    assert strategy.calls == 0
+    assert (
+        manager.get_last_no_signal_decision("NFO:NIFTY2662324050CE").reason
+        == "live_latest_closed_bar_open"
+    )
+
+
+def test_live_strategy_manager_blocks_future_bar_timestamp(monkeypatch) -> None:
+    _live_env(monkeypatch)
+    manager, strategy = _manager_with_strategy(_Engine(5, latest_age_s=-30.0))
+
+    result = manager.generate_signal("NFO:NIFTY2662324050CE", 100.0)
+
+    assert result is None
+    assert strategy.calls == 0
+    assert (
+        manager.get_last_no_signal_decision("NFO:NIFTY2662324050CE").reason
+        == "live_latest_closed_bar_future_timestamp"
+    )

--- a/tests/core/test_strategy_live_safety.py
+++ b/tests/core/test_strategy_live_safety.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import time
 from types import SimpleNamespace
 
 from nifty_scalper_bot.core import strategy_live_safety as guard
@@ -8,14 +9,22 @@ from nifty_scalper_bot.strategies.signal_generator import Signal
 
 
 class _Engine:
-    def __init__(self, bars: int) -> None:
+    def __init__(
+        self, bars: int, *, latest_age_s: float = 1.0, indicators: dict | None = None
+    ) -> None:
         self.bars = bars
+        self.latest_age_s = latest_age_s
+        self.indicators = dict(indicators or {})
 
     def get_history(self, _symbol: str):
-        return [{} for _ in range(self.bars)]
+        ts = time.time() - self.latest_age_s
+        return [
+            {"timestamp": ts, "open": 1, "high": 1, "low": 1, "close": 1}
+            for _ in range(self.bars)
+        ]
 
     def get_indicators(self, _symbol: str, _names):
-        return {}
+        return dict(self.indicators)
 
 
 class _Positions:
@@ -51,7 +60,9 @@ def test_live_strategy_manager_fails_closed_on_cold_history(monkeypatch) -> None
     manager = StrategyManager([], _Engine(0), _Positions())
     manager._required_candles = 10
 
-    result = manager.generate_signal("NFO:NIFTY2662324050CE", 100.0, trace_id="cold-history")
+    result = manager.generate_signal(
+        "NFO:NIFTY2662324050CE", 100.0, trace_id="cold-history"
+    )
 
     assert result is None
     decision = manager.get_last_no_signal_decision("NFO:NIFTY2662324050CE")
@@ -67,7 +78,9 @@ def test_live_strategy_manager_fails_closed_when_hub_not_ready(monkeypatch) -> N
     manager._required_candles = 2
     manager._data_hub = SimpleNamespace(indicators_ready=False)
 
-    result = manager.generate_signal("NFO:NIFTY2662324050CE", 100.0, trace_id="hub-not-ready")
+    result = manager.generate_signal(
+        "NFO:NIFTY2662324050CE", 100.0, trace_id="hub-not-ready"
+    )
 
     assert result is None
     decision = manager.get_last_no_signal_decision("NFO:NIFTY2662324050CE")
@@ -84,7 +97,9 @@ def test_live_approved_signal_must_pass_final_filter(monkeypatch) -> None:
         _last_no_signal_decision_by_symbol={},
     )
 
-    result = guard._final_filter(manager, _signal(is_approved=True, timestamp="2026-07-05T09:20:00"), "approved")
+    result = guard._final_filter(
+        manager, _signal(is_approved=True, timestamp="2026-07-05T09:20:00"), "approved"
+    )
 
     assert result is None
     decision = manager._last_no_signal_decision_by_symbol["NFO:NIFTY2662324050CE"]
@@ -99,8 +114,154 @@ def test_live_signal_identity_is_generated_and_enriched() -> None:
     assert guard._has_identity(present) is True
     enriched_missing = guard._add_identity(missing)
     assert guard._has_identity(enriched_missing) is True
-    assert enriched_missing.metadata["deterministic_signal_id"] == missing.deterministic_id
+    assert (
+        enriched_missing.metadata["deterministic_signal_id"] == missing.deterministic_id
+    )
     assert enriched_missing.metadata["signal_id"] == missing.deterministic_id
     assert enriched_missing.metadata["idempotency_key"] == missing.deterministic_id
     enriched_present = guard._add_identity(present)
-    assert enriched_present.metadata["deterministic_signal_id"] == present.deterministic_id
+    assert (
+        enriched_present.metadata["deterministic_signal_id"] == present.deterministic_id
+    )
+
+
+class _TickMDM:
+    def __init__(self, age: float | None) -> None:
+        self.age = age
+        self.recovery_requests: list[tuple[str, str]] = []
+
+    def time_since_last_live_ws_tick(self, symbol: str):
+        return self.age
+
+    def request_fallback_refresh(self, symbol: str, *, reason: str) -> bool:
+        self.recovery_requests.append((symbol, reason))
+        return True
+
+
+class _CallingStrategy:
+    name = "SMC"
+    config = {}
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def get_required_indicators(self):
+        return []
+
+    def generate_signal(self, symbol, indicators, current_price, position=None):
+        self.calls += 1
+        return None
+
+
+def _manager_with_strategy(
+    engine: _Engine, strategy: _CallingStrategy | None = None
+) -> tuple[StrategyManager, _CallingStrategy]:
+    strategy = strategy or _CallingStrategy()
+    manager = StrategyManager([strategy], engine, _Positions())
+    manager._required_candles = 2
+    return manager, strategy
+
+
+def test_live_strategy_manager_fails_closed_on_stale_latest_bar(monkeypatch) -> None:
+    _live_env(monkeypatch)
+    monkeypatch.setenv("STRATEGY_LATEST_BAR_MAX_AGE_SECONDS", "10")
+    manager, strategy = _manager_with_strategy(_Engine(5, latest_age_s=60.0))
+
+    result = manager.generate_signal(
+        "NFO:NIFTY2662324050CE", 100.0, trace_id="stale-bar"
+    )
+
+    assert result is None
+    assert strategy.calls == 0
+    assert (
+        manager.get_last_no_signal_decision("NFO:NIFTY2662324050CE").reason
+        == "live_latest_closed_bar_stale"
+    )
+
+
+def test_live_strategy_manager_blocks_stale_option_tick_and_requests_recovery(
+    monkeypatch,
+) -> None:
+    _live_env(monkeypatch)
+    monkeypatch.setenv("STRATEGY_LIVE_TICK_MAX_AGE_SECONDS", "5")
+    manager, strategy = _manager_with_strategy(_Engine(5))
+    mdm = _TickMDM(age=30.0)
+    manager._market_data_manager = mdm
+
+    result = manager.generate_signal(
+        "NFO:NIFTY2662324050CE", 100.0, trace_id="stale-tick"
+    )
+
+    assert result is None
+    assert strategy.calls == 0
+    assert mdm.recovery_requests == [
+        ("NFO:NIFTY2662324050CE", "strategy_live_option_tick_stale")
+    ]
+    assert (
+        manager.get_last_no_signal_decision("NFO:NIFTY2662324050CE").reason
+        == "live_option_tick_stale"
+    )
+
+
+def test_live_strategy_manager_fails_closed_on_stale_underlying_context(
+    monkeypatch,
+) -> None:
+    _live_env(monkeypatch)
+    engine = _Engine(5, indicators={"context_fresh": False})
+    manager, strategy = _manager_with_strategy(engine)
+
+    result = manager.generate_signal(
+        "NFO:NIFTY2662324050CE", 100.0, trace_id="stale-context"
+    )
+
+    assert result is None
+    assert strategy.calls == 0
+    assert (
+        manager.get_last_no_signal_decision("NFO:NIFTY2662324050CE").reason
+        == "live_underlying_context_stale"
+    )
+
+
+def test_live_strategy_manager_fails_closed_on_selected_contract_mismatch(
+    monkeypatch,
+) -> None:
+    _live_env(monkeypatch)
+    engine = _Engine(
+        5,
+        indicators={
+            "selected_ce": "NFO:NIFTY2662324050CE",
+            "selected_pe": "NFO:NIFTY2662324050PE",
+        },
+    )
+    manager, strategy = _manager_with_strategy(engine)
+
+    result = manager.generate_signal(
+        "NFO:NIFTY2662324100CE", 100.0, trace_id="contract-mismatch"
+    )
+
+    assert result is None
+    assert strategy.calls == 0
+    assert (
+        manager.get_last_no_signal_decision("NFO:NIFTY2662324100CE").reason
+        == "live_selected_contract_mismatch"
+    )
+
+
+def test_live_strategy_manager_invokes_strategy_when_canonical_freshness_gate_passes(
+    monkeypatch,
+) -> None:
+    _live_env(monkeypatch)
+    engine = _Engine(
+        5, indicators={"context_fresh": True, "selected_ce": "NFO:NIFTY2662324050CE"}
+    )
+    manager, strategy = _manager_with_strategy(engine)
+    manager._market_data_manager = _TickMDM(age=1.0)
+
+    result = manager.generate_signal(
+        "NFO:NIFTY2662324050CE", 100.0, trace_id="fresh-pass"
+    )
+
+    assert result is None
+    assert strategy.calls == 1
+    decision = manager.get_last_no_signal_decision("NFO:NIFTY2662324050CE")
+    assert decision is None or decision.blocked_at != "strategy_live_safety"


### PR DESCRIPTION
### Motivation
- Prevent strategy execution on stale or mismatched runtime inputs by introducing a single canonical manager-level LIVE pre-dispatch freshness gate. 
- Existing live-safety previously failed closed for cold history and DataHub unreadiness but left other freshness checks to downstream code or strategy-local guards, risking stale-data evaluations.
- The gate must be minimal, fail-closed for safety, and reuse existing recovery mechanisms rather than inventing new ones.

### Description
- Add manager-level freshness checks in `core/strategy_live_safety.py`: `latest closed bar` freshness, `live option WS tick` freshness (and request MDM fallback refresh when stale), `underlying spot/futures context` freshness, and `selected contract identity/version` consistency. 
- Implement utility helpers: `_max_age_seconds`, `_coerce_epoch_seconds`, `_latest_bar_epoch`, `_latest_bar_fresh_block`, `_live_option_tick_block`, `_context_fresh_block`, `_selected_contract_block`, and `_prime_indicator_snapshot` to produce structured blocks. 
- Run the canonical checks from `_readiness_block` before any strategy is invoked; on failure create a structured live-safety `no-signal` decision and return `None` without calling strategies. 
- Preserve previous protections and defenses-in-depth: strategy-local checks remain unchanged and the patch only introduces a manager-level pre-dispatch gate. 
- Tests: extend `tests/core/test_strategy_live_safety.py` with focused regression cases that assert strategies are not called when each freshness component fails and that strategies are invoked unchanged when the gate passes.

### Testing
- Unit tests run: `pytest -q tests/core/test_strategy_live_safety.py` — passed. 
- Subsystem tests run: `pytest -q tests/core` — passed. 
- Full test run: `pytest -q` — passed (1 skipped unrelated test); a non-fatal async shutdown logging warning about pending tasks was observed but did not affect test outcomes. 
- Static/format checks: `python -m compileall -q src` succeeded, `black` and `ruff` checks on changed files passed, and `git diff --check` produced no issues. 
- Files changed: `src/nifty_scalper_bot/core/strategy_live_safety.py` (production) and `tests/core/test_strategy_live_safety.py` (tests). All new tests demonstrate the canonical gate blocks strategy invocation on stale latest bar, stale option tick (and requests MDM fallback), stale underlying context, and selected-contract mismatch, and allow invocation when all checks pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a54fdaefa488324aff054ff62794c18)