### PR TITLE
Guard active option readiness by subscription/restart generation

### DIFF
--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -552,6 +552,14 @@ class MarketDataManager:
         self._pending_subscriptions: set[int] = set()
         self._dispatched_subscriptions: set[int] = set()
         self._confirmed_subscriptions: set[int] = set()
+        self._subscription_generation = 0
+        self._symbol_subscription_generation: dict[str, int] = {}
+        self._symbol_first_tick_generation: dict[str, int] = {}
+        self._ws_restart_generation = 0
+        self._ws_restart_inflight = False
+        self._ws_restart_lock = threading.Lock()
+        self._ws_restart_started_at: float | None = None
+        self._ws_restart_diagnostics: dict[str, Any] = {}
         self._last_rest_refresh_attempt: dict[str, float] = {}
         self._tick_warn_last: dict[str, float] = (
             {}
@@ -1405,6 +1413,9 @@ class MarketDataManager:
         if not self._started:
             return
         self._started = False
+        with self._ws_restart_lock:
+            self._ws_restart_inflight = False
+            self._ws_restart_started_at = None
         if self._ws is not None:
             try:
                 self._ws.stop()
@@ -1824,6 +1835,9 @@ class MarketDataManager:
         try:
             changed = ws.set_tokens(sorted(self._desired_tokens))
             self._dispatched_subscriptions.update(self._desired_tokens)
+            if changed:
+                with self._lock:
+                    self._subscription_generation += 1
             connected = self._is_ws_connected()
             self._logger.debug(
                 "ws_tokens_reconciled desired=%d changed=%s connected=%s",
@@ -2529,6 +2543,15 @@ class MarketDataManager:
                 self._set_symbol_token_mapping(
                     normalized_symbol, token_int, source="request_token_subscription"
                 )
+                self._subscription_generation += 1
+                self._symbol_subscription_generation[normalized_symbol] = (
+                    self._subscription_generation
+                )
+                self._symbol_first_tick_generation.pop(normalized_symbol, None)
+                self._last_valid_live_tick_mono.pop(normalized_symbol, None)
+                self._last_tick_ts.pop(normalized_symbol, None)
+                self._last_tick_snapshot.pop(normalized_symbol, None)
+                self._last_cumulative_volume_by_symbol.pop(normalized_symbol, None)
         if active_future:
             self.purge_stale_nifty_futures(
                 active_future, reason="request_token_subscription_post"
@@ -2595,6 +2618,8 @@ class MarketDataManager:
             before = len(self._desired_tokens)
             self._desired_tokens.update(accepted)
             added_count = len(self._desired_tokens) - before
+            if added_count:
+                self._subscription_generation += 1
         if active_future:
             self.purge_stale_nifty_futures(
                 active_future, reason="request_token_subscriptions_post"
@@ -2918,6 +2943,70 @@ class MarketDataManager:
         if mono is None:
             return None
         return max(time.monotonic() - float(mono), 0.0)
+
+    def classify_live_tick_readiness(
+        self,
+        symbol: str,
+        token: int | None,
+        *,
+        max_age_s: float,
+    ) -> dict[str, Any]:
+        """Classify current-generation live tick readiness for execution gates."""
+        canonical = self._canonical_symbol(symbol)
+        try:
+            token_int = int(token) if token is not None else None
+        except (TypeError, ValueError):
+            token_int = None
+        with self._lock:
+            desired = set(getattr(self, "_desired_tokens", set()) or set())
+            confirmed = set(getattr(self, "_confirmed_subscriptions", set()) or set())
+            dispatched = set(getattr(self, "_dispatched_subscriptions", set()) or set())
+            sub_gen = self._symbol_subscription_generation.get(canonical)
+            tick_gen = self._symbol_first_tick_generation.get(canonical)
+            tick_mono = self._last_valid_live_tick_mono.get(canonical)
+        expected = token_int in desired if token_int is not None else False
+        subscribed = (
+            (token_int in confirmed or token_int in dispatched)
+            if token_int is not None
+            else False
+        )
+        age_s = (
+            None
+            if tick_mono is None
+            else max(time.monotonic() - float(tick_mono), 0.0)
+        )
+        if token_int is None:
+            reason = "subscription_missing"
+        elif not expected:
+            reason = "symbol_not_expected_live"
+        elif not subscribed:
+            reason = (
+                "subscription_pending"
+                if token_int in desired
+                else "subscription_missing"
+            )
+        elif sub_gen is not None and tick_gen is not None and tick_gen < sub_gen:
+            reason = "subscription_generation_mismatch"
+        elif tick_mono is None:
+            reason = "never_received_tick"
+        elif age_s is None:
+            reason = "tick_timestamp_missing"
+        elif age_s > max_age_s:
+            reason = "tick_stale"
+        else:
+            reason = "ready"
+        return {
+            "ready": reason == "ready",
+            "reason": reason,
+            "symbol": canonical,
+            "token": token_int,
+            "expected": expected,
+            "subscribed": subscribed,
+            "subscription_generation": sub_gen,
+            "tick_generation": tick_gen,
+            "first_tick_received": tick_gen is not None,
+            "tick_age_s": age_s,
+        }
 
     async def _rest_refresh(self, symbol: str) -> None:
         """Args: symbol; Returns: none; Raises: none."""
@@ -7524,6 +7613,11 @@ class MarketDataManager:
             canonical_symbol = self._canonical_symbol(symbol)
             with self._lock:
                 self._last_valid_live_tick_mono[canonical_symbol] = now_mono
+                self._symbol_first_tick_generation[canonical_symbol] = (
+                    self._symbol_subscription_generation.get(
+                        canonical_symbol, self._subscription_generation
+                    )
+                )
             try:
                 token_value = tick.get("instrument_token") or tick.get("token")
                 token_int = int(token_value) if token_value is not None else None
@@ -8318,6 +8412,42 @@ class MarketDataManager:
         ws = self._ws
         if ws is None:
             return
+        with self._ws_restart_lock:
+            if self._ws_restart_inflight:
+                self._logger.info(
+                    "MDM_ZOMBIE_WS_RESTART_COALESCED generation=%s",
+                    self._ws_restart_generation,
+                    extra={
+                        "event": "MDM_ZOMBIE_WS_RESTART_COALESCED",
+                        "restart_generation": self._ws_restart_generation,
+                        "state": "inflight",
+                    },
+                )
+                return
+            self._ws_restart_inflight = True
+            self._ws_restart_generation += 1
+            self._ws_restart_started_at = now
+            self._ws_restart_diagnostics = {
+                "restart_generation": self._ws_restart_generation,
+                "initiator": "mdm_zombie_watchdog",
+                "reason": "transport_failure",
+                "started_at": now,
+                "desired_tokens": sorted(self._desired_tokens),
+            }
+            self._subscription_generation += 1
+            for token in list(self._desired_tokens):
+                sym = self._resolve_symbol_for_token(int(token))
+                if not sym:
+                    continue
+                canonical = self._canonical_symbol(sym)
+                self._symbol_subscription_generation[canonical] = (
+                    self._subscription_generation
+                )
+                self._symbol_first_tick_generation.pop(canonical, None)
+                self._last_valid_live_tick_mono.pop(canonical, None)
+                self._last_tick_ts.pop(canonical, None)
+                self._last_tick_snapshot.pop(canonical, None)
+                self._last_cumulative_volume_by_symbol.pop(canonical, None)
 
         reconnect = getattr(ws, "force_reconnect", None)
         if not callable(reconnect):
@@ -8325,6 +8455,18 @@ class MarketDataManager:
         else:
             try:
                 reconnect()
+                self._reconcile_ws_subscriptions()
+                recovery = self.verify_websocket_recovery()
+                if not recovery.get("ok"):
+                    self._logger.error(
+                        "MDM_ZOMBIE_WS_RECOVERY_FAILED reason=%s generation=%s",
+                        recovery.get("reason"),
+                        self._ws_restart_generation,
+                        extra={
+                            "event": "MDM_ZOMBIE_WS_RECOVERY_FAILED",
+                            **recovery,
+                        },
+                    )
                 self._zombie_restart_failures = 0
                 self._zombie_restart_consecutive += 1
                 self._zombie_restart_attempts.append(now)
@@ -8350,6 +8492,10 @@ class MarketDataManager:
                     extra={"event": "mdm_zombie_ws_restart_error"},
                     exc_info=exc,
                 )
+            finally:
+                with self._ws_restart_lock:
+                    self._ws_restart_inflight = False
+                    self._ws_restart_started_at = None
 
         if len(self._zombie_restart_attempts) > 5:
             self._logger.critical(
@@ -8359,7 +8505,9 @@ class MarketDataManager:
                     "attempts_in_2m": len(self._zombie_restart_attempts),
                 },
             )
-            raise RuntimeError("WebSocket restart circuit breaker exceeded: >5 in 120s")
+            raise RuntimeError(
+                "WebSocket restart circuit breaker exceeded: >5 in 120s"
+            )
 
         if self._zombie_restart_failures > self._zombie_restart_limit:
             self._zombie_breaker_open_until = now + self._zombie_restart_window
@@ -8371,6 +8519,29 @@ class MarketDataManager:
                     "open_seconds": self._zombie_restart_window,
                 },
             )
+
+    def verify_websocket_recovery(self) -> dict[str, Any]:
+        """Verify websocket recovery state without assuming reconnect success."""
+        connected = self._is_ws_connected()
+        with self._lock:
+            desired = set(self._desired_tokens)
+            dispatched = set(self._dispatched_subscriptions)
+            confirmed = set(self._confirmed_subscriptions)
+        represented = desired <= (dispatched | confirmed)
+        reason = "ok"
+        if not connected:
+            reason = "websocket_not_connected"
+        elif not represented:
+            reason = "expected_tokens_not_restored"
+        return {
+            "ok": connected and represented,
+            "reason": reason,
+            "restart_generation": self._ws_restart_generation,
+            "connected": connected,
+            "desired_tokens": sorted(desired),
+            "dispatched_tokens": sorted(dispatched),
+            "confirmed_tokens": sorted(confirmed),
+        }
 
     def _start_rest_poll(self) -> None:
         if self._rest_poll_thread is not None and self._rest_poll_thread.is_alive():

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -555,11 +555,20 @@ class MarketDataManager:
         self._subscription_generation = 0
         self._symbol_subscription_generation: dict[str, int] = {}
         self._symbol_first_tick_generation: dict[str, int] = {}
+        self._symbol_token_generation: dict[str, tuple[int, int]] = {}
         self._ws_restart_generation = 0
         self._ws_restart_inflight = False
+        self._ws_restart_state = "idle"
         self._ws_restart_lock = threading.Lock()
         self._ws_restart_started_at: float | None = None
+        self._ws_restart_deadline_mono: float | None = None
+        self._ws_restart_affected: dict[str, int] = {}
         self._ws_restart_diagnostics: dict[str, Any] = {}
+        self._ws_recovery_timeout_sec = self._parse_float_env(
+            "MDM_WS_RECOVERY_TIMEOUT_SECONDS", default=15.0, minimum=1.0
+        )
+        self._ws_restart_fail_reason: str | None = None
+        self._mismatched_generation_tick_counts: dict[str, int] = defaultdict(int)
         self._last_rest_refresh_attempt: dict[str, float] = {}
         self._tick_warn_last: dict[str, float] = (
             {}
@@ -1415,7 +1424,10 @@ class MarketDataManager:
         self._started = False
         with self._ws_restart_lock:
             self._ws_restart_inflight = False
+            self._ws_restart_state = "failed"
             self._ws_restart_started_at = None
+            self._ws_restart_deadline_mono = None
+            self._ws_restart_fail_reason = "shutdown"
         if self._ws is not None:
             try:
                 self._ws.stop()
@@ -1835,9 +1847,6 @@ class MarketDataManager:
         try:
             changed = ws.set_tokens(sorted(self._desired_tokens))
             self._dispatched_subscriptions.update(self._desired_tokens)
-            if changed:
-                with self._lock:
-                    self._subscription_generation += 1
             connected = self._is_ws_connected()
             self._logger.debug(
                 "ws_tokens_reconciled desired=%d changed=%s connected=%s",
@@ -2538,20 +2547,34 @@ class MarketDataManager:
                 active_future, reason="request_token_subscription_pre"
             )
         with self._lock:
+            was_desired = token_int in self._desired_tokens
+            previous_token = (
+                self._symbol_to_token.get(normalized_symbol)
+                if normalized_symbol
+                else None
+            )
             self._desired_tokens.add(token_int)
             if normalized_symbol:
+                material_transition = (not was_desired) or previous_token != token_int
                 self._set_symbol_token_mapping(
                     normalized_symbol, token_int, source="request_token_subscription"
                 )
-                self._subscription_generation += 1
-                self._symbol_subscription_generation[normalized_symbol] = (
-                    self._subscription_generation
-                )
-                self._symbol_first_tick_generation.pop(normalized_symbol, None)
-                self._last_valid_live_tick_mono.pop(normalized_symbol, None)
-                self._last_tick_ts.pop(normalized_symbol, None)
-                self._last_tick_snapshot.pop(normalized_symbol, None)
-                self._last_cumulative_volume_by_symbol.pop(normalized_symbol, None)
+                if material_transition:
+                    if previous_token not in (None, token_int):
+                        self._desired_tokens.discard(int(previous_token))
+                        self._pending_subscription_tokens.discard(int(previous_token))
+                        self._pending_subscriptions.discard(int(previous_token))
+                        self._dispatched_subscriptions.discard(int(previous_token))
+                        self._confirmed_subscriptions.discard(int(previous_token))
+                    self._begin_subscription_generation_locked(
+                        normalized_symbol,
+                        token_int,
+                        reason=(
+                            "token_changed"
+                            if previous_token not in (None, token_int)
+                            else "new_symbol_token"
+                        ),
+                    )
         if active_future:
             self.purge_stale_nifty_futures(
                 active_future, reason="request_token_subscription_post"
@@ -2944,6 +2967,45 @@ class MarketDataManager:
             return None
         return max(time.monotonic() - float(mono), 0.0)
 
+    def _begin_subscription_generation_locked(
+        self, symbol: str, token: int, *, reason: str
+    ) -> int:
+        """Advance symbol lifecycle generation and invalidate old live state."""
+        canonical = self._canonical_symbol(symbol)
+        token_int = int(token)
+        self._subscription_generation += 1
+        generation = self._subscription_generation
+        self._symbol_subscription_generation[canonical] = generation
+        self._symbol_token_generation[canonical] = (token_int, generation)
+        self._symbol_first_tick_generation.pop(canonical, None)
+        self._last_valid_live_tick_mono.pop(canonical, None)
+        self._last_tick_ts.pop(canonical, None)
+        self._last_tick_snapshot.pop(canonical, None)
+        self._last_cumulative_volume_by_symbol.pop(canonical, None)
+        self._logger.info(
+            "MDM_SUBSCRIPTION_GENERATION_ADVANCED symbol=%s token=%s generation=%s reason=%s",
+            canonical,
+            token_int,
+            generation,
+            reason,
+            extra={
+                "event": "MDM_SUBSCRIPTION_GENERATION_ADVANCED",
+                "symbol": canonical,
+                "token": token_int,
+                "subscription_generation": generation,
+                "reason": reason,
+            },
+        )
+        return generation
+
+    def _current_symbol_token_locked(self, symbol: str) -> int | None:
+        canonical = self._canonical_symbol(symbol)
+        token = self._symbol_to_token.get(canonical) or self._token_by_symbol.get(canonical)
+        try:
+            return int(token) if token is not None else None
+        except (TypeError, ValueError):
+            return None
+
     def classify_live_tick_readiness(
         self,
         symbol: str,
@@ -2964,11 +3026,13 @@ class MarketDataManager:
             sub_gen = self._symbol_subscription_generation.get(canonical)
             tick_gen = self._symbol_first_tick_generation.get(canonical)
             tick_mono = self._last_valid_live_tick_mono.get(canonical)
+            current_token = self._current_symbol_token_locked(canonical)
         expected = token_int in desired if token_int is not None else False
-        subscribed = (
-            (token_int in confirmed or token_int in dispatched)
-            if token_int is not None
-            else False
+        dispatch_attempted = token_int in dispatched if token_int is not None else False
+        confirmed_subscription = token_int in confirmed if token_int is not None else False
+        token_matches = bool(token_int is not None and token_int == current_token)
+        current_generation_tick_received = bool(
+            tick_gen is not None and sub_gen is not None and tick_gen >= sub_gen
         )
         age_s = (
             None
@@ -2977,15 +3041,13 @@ class MarketDataManager:
         )
         if token_int is None:
             reason = "subscription_missing"
+        elif not token_matches:
+            reason = "subscription_token_mismatch"
         elif not expected:
             reason = "symbol_not_expected_live"
-        elif not subscribed:
-            reason = (
-                "subscription_pending"
-                if token_int in desired
-                else "subscription_missing"
-            )
-        elif sub_gen is not None and tick_gen is not None and tick_gen < sub_gen:
+        elif not dispatch_attempted and not confirmed_subscription:
+            reason = "subscription_pending" if token_int in desired else "subscription_missing"
+        elif not current_generation_tick_received and tick_gen is not None:
             reason = "subscription_generation_mismatch"
         elif tick_mono is None:
             reason = "never_received_tick"
@@ -3001,10 +3063,15 @@ class MarketDataManager:
             "symbol": canonical,
             "token": token_int,
             "expected": expected,
-            "subscribed": subscribed,
+            "desired": expected,
+            "dispatch_attempted": dispatch_attempted,
+            "confirmed": confirmed_subscription,
+            "subscribed": confirmed_subscription,
+            "token_matches": token_matches,
+            "current_generation_tick_received": current_generation_tick_received,
             "subscription_generation": sub_gen,
             "tick_generation": tick_gen,
-            "first_tick_received": tick_gen is not None,
+            "first_tick_received": current_generation_tick_received,
             "tick_age_s": age_s,
         }
 
@@ -7606,21 +7673,57 @@ class MarketDataManager:
 
     def _emit_tick(self, symbol: str, tick: dict[str, Any], *, source: str) -> None:
         source = str(source or "unknown").lower()
-        self._store_tick(symbol, tick)
+        accepted_current_generation_tick = False
         if source == "ws":
             now_mono = time.monotonic()
             self._last_ws_tick_mono = now_mono
             canonical_symbol = self._canonical_symbol(symbol)
-            with self._lock:
-                self._last_valid_live_tick_mono[canonical_symbol] = now_mono
-                self._symbol_first_tick_generation[canonical_symbol] = (
-                    self._symbol_subscription_generation.get(
-                        canonical_symbol, self._subscription_generation
-                    )
-                )
+            token_value = tick.get("instrument_token") or tick.get("token")
             try:
-                token_value = tick.get("instrument_token") or tick.get("token")
                 token_int = int(token_value) if token_value is not None else None
+            except (TypeError, ValueError):
+                token_int = None
+            with self._lock:
+                current_token = self._current_symbol_token_locked(canonical_symbol)
+                token_expected = token_int is not None and token_int in self._desired_tokens
+                requires_token_bound_generation = canonical_symbol.startswith(
+                    "NFO:"
+                ) and canonical_symbol.endswith(("CE", "PE"))
+                if requires_token_bound_generation and (
+                    token_int is None or token_int != current_token or not token_expected
+                ):
+                    self._mismatched_generation_tick_counts[canonical_symbol] += 1
+                    log_throttled(
+                        self._logger,
+                        f"ws_generation_tick_rejected:{canonical_symbol}",
+                        "WS_GENERATION_TICK_REJECTED symbol=%s token=%s expected_token=%s",
+                        canonical_symbol,
+                        token_int,
+                        current_token,
+                        interval_sec=60.0,
+                        level=logging.WARNING,
+                        extra={
+                            "event": "WS_GENERATION_TICK_REJECTED",
+                            "symbol": canonical_symbol,
+                            "token": token_int,
+                            "expected_token": current_token,
+                            "desired": token_expected,
+                        },
+                    )
+                    return
+                else:
+                    self._last_valid_live_tick_mono[canonical_symbol] = now_mono
+                    if token_int is not None:
+                        self._symbol_first_tick_generation[canonical_symbol] = (
+                            self._symbol_subscription_generation.get(
+                                canonical_symbol, self._subscription_generation
+                            )
+                        )
+                        self._confirmed_subscriptions.add(token_int)
+                        accepted_current_generation_tick = True
+            if accepted_current_generation_tick:
+                self.verify_websocket_recovery(now_mono=now_mono)
+            try:
                 now = time.monotonic()
                 last_logged = float(self._ws_stored_tick_log_at.get(symbol, 0.0))
                 if last_logged <= 0.0 or (now - last_logged) >= 60.0:
@@ -7654,6 +7757,7 @@ class MarketDataManager:
                     )
             except Exception:
                 pass
+        self._store_tick(symbol, tick)
         callbacks: list[TickCallback]
         tick_payload = to_json_safe(dict(tick))
         ts_payload = pd.to_datetime(
@@ -8391,6 +8495,23 @@ class MarketDataManager:
         now = time.monotonic()
         if now < self._zombie_breaker_open_until:
             return
+        recovery = self.verify_websocket_recovery(now_mono=now)
+        if recovery.get("state") in {
+            "reconnect_requested",
+            "waiting_for_connection",
+            "waiting_for_subscriptions",
+            "waiting_for_first_ticks",
+        }:
+            self._logger.info(
+                "MDM_ZOMBIE_WS_RESTART_COALESCED generation=%s state=%s",
+                recovery.get("restart_generation"),
+                recovery.get("state"),
+                extra={
+                    "event": "MDM_ZOMBIE_WS_RESTART_COALESCED",
+                    **recovery,
+                },
+            )
+            return
 
         # Exponential backoff between consecutive zombie restart
         # triggers.  WebSocketManager itself already does full-jitter
@@ -8425,23 +8546,32 @@ class MarketDataManager:
                 )
                 return
             self._ws_restart_inflight = True
+            self._ws_restart_state = "reconnect_requested"
             self._ws_restart_generation += 1
             self._ws_restart_started_at = now
+            self._ws_restart_deadline_mono = now + self._ws_recovery_timeout_sec
+            affected: dict[str, int] = {}
+            for token in list(self._desired_tokens):
+                sym = self._resolve_symbol_for_token(int(token))
+                if sym:
+                    affected[self._canonical_symbol(sym)] = int(token)
+            self._ws_restart_affected = affected
             self._ws_restart_diagnostics = {
                 "restart_generation": self._ws_restart_generation,
                 "initiator": "mdm_zombie_watchdog",
                 "reason": "transport_failure",
                 "started_at": now,
                 "desired_tokens": sorted(self._desired_tokens),
+                "affected_symbols": sorted(affected),
             }
             self._subscription_generation += 1
-            for token in list(self._desired_tokens):
-                sym = self._resolve_symbol_for_token(int(token))
-                if not sym:
-                    continue
-                canonical = self._canonical_symbol(sym)
+            for canonical, token in affected.items():
                 self._symbol_subscription_generation[canonical] = (
                     self._subscription_generation
+                )
+                self._symbol_token_generation[canonical] = (
+                    int(token),
+                    self._subscription_generation,
                 )
                 self._symbol_first_tick_generation.pop(canonical, None)
                 self._last_valid_live_tick_mono.pop(canonical, None)
@@ -8450,24 +8580,18 @@ class MarketDataManager:
                 self._last_cumulative_volume_by_symbol.pop(canonical, None)
 
         reconnect = getattr(ws, "force_reconnect", None)
-        if not callable(reconnect):
-            self._zombie_restart_failures += 1
-        else:
+        try:
+            if not callable(reconnect):
+                self._fail_ws_recovery("force_reconnect_unavailable")
+                self._zombie_restart_failures += 1
+                return
             try:
                 reconnect()
+                with self._ws_restart_lock:
+                    if self._ws_restart_inflight:
+                        self._ws_restart_state = "waiting_for_subscriptions"
                 self._reconcile_ws_subscriptions()
-                recovery = self.verify_websocket_recovery()
-                if not recovery.get("ok"):
-                    self._logger.error(
-                        "MDM_ZOMBIE_WS_RECOVERY_FAILED reason=%s generation=%s",
-                        recovery.get("reason"),
-                        self._ws_restart_generation,
-                        extra={
-                            "event": "MDM_ZOMBIE_WS_RECOVERY_FAILED",
-                            **recovery,
-                        },
-                    )
-                self._zombie_restart_failures = 0
+                recovery = self.verify_websocket_recovery(now_mono=time.monotonic())
                 self._zombie_restart_consecutive += 1
                 self._zombie_restart_attempts.append(now)
                 while (
@@ -8482,9 +8606,11 @@ class MarketDataManager:
                         "failure_count": self._zombie_restart_failures,
                         "consecutive": self._zombie_restart_consecutive,
                         "cooldown_sec": round(cooldown, 2),
+                        "recovery_state": recovery.get("state"),
                     },
                 )
             except Exception as exc:  # noqa: BLE001
+                self._fail_ws_recovery(type(exc).__name__)
                 self._zombie_restart_failures += 1
                 self._logger.error(
                     "Failure in _trigger_zombie_ws_restart: %s",
@@ -8492,10 +8618,10 @@ class MarketDataManager:
                     extra={"event": "mdm_zombie_ws_restart_error"},
                     exc_info=exc,
                 )
-            finally:
-                with self._ws_restart_lock:
-                    self._ws_restart_inflight = False
-                    self._ws_restart_started_at = None
+        finally:
+            # Successful asynchronous recovery intentionally remains inflight
+            # until verify_websocket_recovery observes current-generation ticks.
+            pass
 
         if len(self._zombie_restart_attempts) > 5:
             self._logger.critical(
@@ -8520,27 +8646,99 @@ class MarketDataManager:
                 },
             )
 
-    def verify_websocket_recovery(self) -> dict[str, Any]:
+    def _fail_ws_recovery(self, reason: str) -> None:
+        with self._ws_restart_lock:
+            self._ws_restart_state = "failed"
+            self._ws_restart_inflight = False
+            self._ws_restart_started_at = None
+            self._ws_restart_deadline_mono = None
+            self._ws_restart_fail_reason = reason
+        self._logger.error(
+            "MDM_ZOMBIE_WS_RECOVERY_FAILED reason=%s generation=%s",
+            reason,
+            self._ws_restart_generation,
+            extra={
+                "event": "MDM_ZOMBIE_WS_RECOVERY_FAILED",
+                "reason": reason,
+                "restart_generation": self._ws_restart_generation,
+            },
+        )
+
+    def verify_websocket_recovery(self, *, now_mono: float | None = None) -> dict[str, Any]:
         """Verify websocket recovery state without assuming reconnect success."""
+        now_value = time.monotonic() if now_mono is None else float(now_mono)
         connected = self._is_ws_connected()
         with self._lock:
             desired = set(self._desired_tokens)
             dispatched = set(self._dispatched_subscriptions)
             confirmed = set(self._confirmed_subscriptions)
-        represented = desired <= (dispatched | confirmed)
+            affected = dict(self._ws_restart_affected)
+            sub_generations = dict(self._symbol_subscription_generation)
+            tick_generations = dict(self._symbol_first_tick_generation)
+            tick_monos = dict(self._last_valid_live_tick_mono)
+            deadline = self._ws_restart_deadline_mono
+            restart_generation = self._ws_restart_generation
+            state = self._ws_restart_state
+            inflight = self._ws_restart_inflight
+        dispatch_attempted = desired <= dispatched if desired else True
+        affected_ready = True
+        missing_ticks: list[str] = []
+        for symbol, token in affected.items():
+            sub_gen = sub_generations.get(symbol)
+            tick_gen = tick_generations.get(symbol)
+            has_tick = (
+                token in desired
+                and token in confirmed
+                and sub_gen is not None
+                and tick_gen is not None
+                and tick_gen >= sub_gen
+                and tick_monos.get(symbol) is not None
+            )
+            if not has_tick:
+                affected_ready = False
+                missing_ticks.append(symbol)
         reason = "ok"
-        if not connected:
+        terminal_state = state
+        if not inflight and state not in {"failed", "recovered"}:
+            terminal_state = state
+        elif not connected:
             reason = "websocket_not_connected"
-        elif not represented:
-            reason = "expected_tokens_not_restored"
+            terminal_state = "waiting_for_connection"
+        elif not dispatch_attempted:
+            reason = "resubscription_not_attempted"
+            terminal_state = "waiting_for_subscriptions"
+        elif not affected_ready:
+            reason = "waiting_for_current_generation_ticks"
+            terminal_state = "waiting_for_first_ticks"
+        if inflight and deadline is not None and now_value >= deadline and reason != "ok":
+            self._fail_ws_recovery(reason)
+            terminal_state = "failed"
+            inflight = False
+        elif inflight and reason == "ok":
+            with self._ws_restart_lock:
+                self._ws_restart_state = "recovered"
+                self._ws_restart_inflight = False
+                self._ws_restart_started_at = None
+                self._ws_restart_deadline_mono = None
+                self._zombie_restart_failures = 0
+            terminal_state = "recovered"
+            inflight = False
+        elif inflight:
+            with self._ws_restart_lock:
+                self._ws_restart_state = terminal_state
         return {
-            "ok": connected and represented,
+            "ok": reason == "ok",
             "reason": reason,
-            "restart_generation": self._ws_restart_generation,
+            "state": terminal_state,
+            "inflight": inflight,
+            "restart_generation": restart_generation,
             "connected": connected,
             "desired_tokens": sorted(desired),
             "dispatched_tokens": sorted(dispatched),
             "confirmed_tokens": sorted(confirmed),
+            "dispatch_attempted": dispatch_attempted,
+            "affected_symbols": sorted(affected),
+            "missing_current_generation_ticks": missing_ticks,
         }
 
     def _start_rest_poll(self) -> None:

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -563,6 +563,7 @@ class MarketDataManager:
         self._ws_restart_started_at: float | None = None
         self._ws_restart_deadline_mono: float | None = None
         self._ws_restart_affected: dict[str, int] = {}
+        self._ws_restart_unresolved_tokens: set[int] = set()
         self._ws_restart_diagnostics: dict[str, Any] = {}
         self._ws_recovery_timeout_sec = self._parse_float_env(
             "MDM_WS_RECOVERY_TIMEOUT_SECONDS", default=15.0, minimum=1.0
@@ -8545,83 +8546,85 @@ class MarketDataManager:
                     },
                 )
                 return
+            with self._lock:
+                desired_snapshot = set(self._desired_tokens)
+                affected: dict[str, int] = {}
+                unresolved: set[int] = set()
+                for token in list(desired_snapshot):
+                    sym = self._resolve_symbol_for_token(int(token))
+                    if sym:
+                        affected[self._canonical_symbol(sym)] = int(token)
+                    else:
+                        unresolved.add(int(token))
+                self._subscription_generation += 1
+                generation = self._subscription_generation
+                for canonical, token in affected.items():
+                    self._symbol_subscription_generation[canonical] = generation
+                    self._symbol_token_generation[canonical] = (
+                        int(token),
+                        generation,
+                    )
+                    self._symbol_first_tick_generation.pop(canonical, None)
+                    self._last_valid_live_tick_mono.pop(canonical, None)
+                    self._last_tick_ts.pop(canonical, None)
+                    self._last_tick_snapshot.pop(canonical, None)
+                    self._last_cumulative_volume_by_symbol.pop(canonical, None)
             self._ws_restart_inflight = True
             self._ws_restart_state = "reconnect_requested"
             self._ws_restart_generation += 1
             self._ws_restart_started_at = now
             self._ws_restart_deadline_mono = now + self._ws_recovery_timeout_sec
-            affected: dict[str, int] = {}
-            for token in list(self._desired_tokens):
-                sym = self._resolve_symbol_for_token(int(token))
-                if sym:
-                    affected[self._canonical_symbol(sym)] = int(token)
             self._ws_restart_affected = affected
+            self._ws_restart_unresolved_tokens = unresolved
+            self._ws_restart_fail_reason = None
             self._ws_restart_diagnostics = {
                 "restart_generation": self._ws_restart_generation,
                 "initiator": "mdm_zombie_watchdog",
                 "reason": "transport_failure",
                 "started_at": now,
-                "desired_tokens": sorted(self._desired_tokens),
+                "desired_tokens": sorted(desired_snapshot),
                 "affected_symbols": sorted(affected),
+                "unresolved_tokens": sorted(unresolved),
             }
-            self._subscription_generation += 1
-            for canonical, token in affected.items():
-                self._symbol_subscription_generation[canonical] = (
-                    self._subscription_generation
-                )
-                self._symbol_token_generation[canonical] = (
-                    int(token),
-                    self._subscription_generation,
-                )
-                self._symbol_first_tick_generation.pop(canonical, None)
-                self._last_valid_live_tick_mono.pop(canonical, None)
-                self._last_tick_ts.pop(canonical, None)
-                self._last_tick_snapshot.pop(canonical, None)
-                self._last_cumulative_volume_by_symbol.pop(canonical, None)
 
         reconnect = getattr(ws, "force_reconnect", None)
+        if not callable(reconnect):
+            self._fail_ws_recovery("force_reconnect_unavailable")
+            self._zombie_restart_failures += 1
+            return
         try:
-            if not callable(reconnect):
-                self._fail_ws_recovery("force_reconnect_unavailable")
-                self._zombie_restart_failures += 1
-                return
-            try:
-                reconnect()
-                with self._ws_restart_lock:
-                    if self._ws_restart_inflight:
-                        self._ws_restart_state = "waiting_for_subscriptions"
-                self._reconcile_ws_subscriptions()
-                recovery = self.verify_websocket_recovery(now_mono=time.monotonic())
-                self._zombie_restart_consecutive += 1
-                self._zombie_restart_attempts.append(now)
-                while (
-                    self._zombie_restart_attempts
-                    and (now - self._zombie_restart_attempts[0]) > 120.0
-                ):
-                    self._zombie_restart_attempts.popleft()
-                self._logger.warning(
-                    "Condition met: mdm_zombie_ws_restart",
-                    extra={
-                        "event": "mdm_zombie_ws_restart",
-                        "failure_count": self._zombie_restart_failures,
-                        "consecutive": self._zombie_restart_consecutive,
-                        "cooldown_sec": round(cooldown, 2),
-                        "recovery_state": recovery.get("state"),
-                    },
-                )
-            except Exception as exc:  # noqa: BLE001
-                self._fail_ws_recovery(type(exc).__name__)
-                self._zombie_restart_failures += 1
-                self._logger.error(
-                    "Failure in _trigger_zombie_ws_restart: %s",
-                    exc,
-                    extra={"event": "mdm_zombie_ws_restart_error"},
-                    exc_info=exc,
-                )
-        finally:
-            # Successful asynchronous recovery intentionally remains inflight
-            # until verify_websocket_recovery observes current-generation ticks.
-            pass
+            reconnect()
+            with self._ws_restart_lock:
+                if self._ws_restart_inflight:
+                    self._ws_restart_state = "waiting_for_subscriptions"
+            self._reconcile_ws_subscriptions()
+            recovery = self.verify_websocket_recovery(now_mono=time.monotonic())
+            self._zombie_restart_consecutive += 1
+            self._zombie_restart_attempts.append(now)
+            while (
+                self._zombie_restart_attempts
+                and (now - self._zombie_restart_attempts[0]) > 120.0
+            ):
+                self._zombie_restart_attempts.popleft()
+            self._logger.warning(
+                "Condition met: mdm_zombie_ws_restart",
+                extra={
+                    "event": "mdm_zombie_ws_restart",
+                    "failure_count": self._zombie_restart_failures,
+                    "consecutive": self._zombie_restart_consecutive,
+                    "cooldown_sec": round(cooldown, 2),
+                    "recovery_state": recovery.get("state"),
+                },
+            )
+        except Exception as exc:  # noqa: BLE001
+            self._fail_ws_recovery(type(exc).__name__)
+            self._zombie_restart_failures += 1
+            self._logger.error(
+                "Failure in _trigger_zombie_ws_restart: %s",
+                exc,
+                extra={"event": "mdm_zombie_ws_restart_error"},
+                exc_info=exc,
+            )
 
         if len(self._zombie_restart_attempts) > 5:
             self._logger.critical(
@@ -8664,22 +8667,43 @@ class MarketDataManager:
             },
         )
 
-    def verify_websocket_recovery(self, *, now_mono: float | None = None) -> dict[str, Any]:
+    def verify_websocket_recovery(
+        self, *, now_mono: float | None = None
+    ) -> dict[str, Any]:
         """Verify websocket recovery state without assuming reconnect success."""
         now_value = time.monotonic() if now_mono is None else float(now_mono)
         connected = self._is_ws_connected()
-        with self._lock:
-            desired = set(self._desired_tokens)
-            dispatched = set(self._dispatched_subscriptions)
-            confirmed = set(self._confirmed_subscriptions)
+        with self._ws_restart_lock:
             affected = dict(self._ws_restart_affected)
-            sub_generations = dict(self._symbol_subscription_generation)
-            tick_generations = dict(self._symbol_first_tick_generation)
-            tick_monos = dict(self._last_valid_live_tick_mono)
+            unresolved = set(self._ws_restart_unresolved_tokens)
             deadline = self._ws_restart_deadline_mono
             restart_generation = self._ws_restart_generation
             state = self._ws_restart_state
             inflight = self._ws_restart_inflight
+            fail_reason = self._ws_restart_fail_reason
+            if state == "failed":
+                return {
+                    "ok": False,
+                    "reason": fail_reason or "recovery_failed",
+                    "state": "failed",
+                    "inflight": False,
+                    "restart_generation": restart_generation,
+                    "connected": connected,
+                    "desired_tokens": [],
+                    "dispatched_tokens": [],
+                    "confirmed_tokens": [],
+                    "dispatch_attempted": False,
+                    "affected_symbols": sorted(affected),
+                    "unresolved_tokens": sorted(unresolved),
+                    "missing_current_generation_ticks": sorted(affected),
+                }
+            with self._lock:
+                desired = set(self._desired_tokens)
+                dispatched = set(self._dispatched_subscriptions)
+                confirmed = set(self._confirmed_subscriptions)
+                sub_generations = dict(self._symbol_subscription_generation)
+                tick_generations = dict(self._symbol_first_tick_generation)
+                tick_monos = dict(self._last_valid_live_tick_mono)
         dispatch_attempted = desired <= dispatched if desired else True
         affected_ready = True
         missing_ticks: list[str] = []
@@ -8704,6 +8728,12 @@ class MarketDataManager:
         elif not connected:
             reason = "websocket_not_connected"
             terminal_state = "waiting_for_connection"
+        elif desired and unresolved:
+            reason = "affected_token_mapping_incomplete"
+            terminal_state = "waiting_for_subscriptions"
+        elif desired and not affected:
+            reason = "affected_token_mapping_incomplete"
+            terminal_state = "waiting_for_subscriptions"
         elif not dispatch_attempted:
             reason = "resubscription_not_attempted"
             terminal_state = "waiting_for_subscriptions"
@@ -8720,6 +8750,7 @@ class MarketDataManager:
                 self._ws_restart_inflight = False
                 self._ws_restart_started_at = None
                 self._ws_restart_deadline_mono = None
+                self._ws_restart_fail_reason = None
                 self._zombie_restart_failures = 0
             terminal_state = "recovered"
             inflight = False
@@ -8738,6 +8769,7 @@ class MarketDataManager:
             "confirmed_tokens": sorted(confirmed),
             "dispatch_attempted": dispatch_attempted,
             "affected_symbols": sorted(affected),
+            "unresolved_tokens": sorted(unresolved),
             "missing_current_generation_ticks": missing_ticks,
         }
 

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -41,6 +41,7 @@ import logging
 import os
 from nifty_scalper_bot.config.defaults import (
     DEFAULT_OPTION_EXEC_MIN_BARS as _DEFAULT_OPT_MIN_BARS,
+    QUOTE_STALE_THRESHOLD_MS,
 )
 from nifty_scalper_bot.config.env_utils import parse_float_env, parse_int_env
 from pathlib import Path
@@ -113,6 +114,7 @@ from nifty_scalper_bot.execution.quote_readiness import (
 )
 from nifty_scalper_bot.execution.readiness import (
     HistoryReadinessPolicy,
+    resolve_max_quote_age_seconds,
     resolve_quote_bid_ask_spread,
 )
 from nifty_scalper_bot.execution.order_state_machine import (
@@ -10995,11 +10997,17 @@ class StrategyRunner:
         mdm = getattr(self, "_market_data", None)
         classifier = getattr(mdm, "classify_live_tick_readiness", None)
         if callable(classifier):
+            max_live_tick_age_s = resolve_max_quote_age_seconds(
+                "HYDRATION_LIVE_TICK_MAX_AGE_SECONDS",
+                "HYDRATION_LIVE_TICK_MAX_AGE_MS",
+                default_seconds=float(QUOTE_STALE_THRESHOLD_MS) / 1000.0,
+            )
             live_tick_check = classifier(
                 symbol_norm,
                 int(candidate_token),
-                max_age_s=60.0,
+                max_age_s=max_live_tick_age_s,
             )
+            details["max_live_tick_age_s"] = max_live_tick_age_s
             details["live_tick_generation_ready"] = bool(
                 live_tick_check.get("ready")
             )

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -10991,6 +10991,31 @@ class StrategyRunner:
             return _finish(False, "option_token_missing")
         if not candidate_orderable:
             return _finish(False, "lot_size_unresolved")
+        live_tick_check = None
+        mdm = getattr(self, "_market_data", None)
+        classifier = getattr(mdm, "classify_live_tick_readiness", None)
+        if callable(classifier):
+            live_tick_check = classifier(
+                symbol_norm,
+                int(candidate_token),
+                max_age_s=60.0,
+            )
+            details["live_tick_generation_ready"] = bool(
+                live_tick_check.get("ready")
+            )
+            details["live_tick_generation_reason"] = live_tick_check.get("reason")
+            details["subscription_generation"] = live_tick_check.get(
+                "subscription_generation"
+            )
+            details["tick_generation"] = live_tick_check.get("tick_generation")
+            details["first_tick_received"] = live_tick_check.get(
+                "first_tick_received"
+            )
+            details["tick_age_s"] = live_tick_check.get("tick_age_s")
+            details["expected_subscription_state"] = live_tick_check.get("expected")
+            details["actual_subscription_state"] = live_tick_check.get("subscribed")
+            if not bool(live_tick_check.get("ready")):
+                return _finish(False, str(live_tick_check.get("reason")))
         if not quote:
             details["tradable_quote"] = False
             details["depth_available"] = False

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -11004,7 +11004,7 @@ class StrategyRunner:
             )
             live_tick_check = classifier(
                 symbol_norm,
-                int(candidate_token),
+                candidate_token,
                 max_age_s=max_live_tick_age_s,
             )
             details["max_live_tick_age_s"] = max_live_tick_age_s

--- a/tests/data/test_mdm_lifecycle_generation.py
+++ b/tests/data/test_mdm_lifecycle_generation.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import time
+
+from nifty_scalper_bot.data.market_data_manager import MarketDataManager
+
+
+class _FakeWebSocket:
+    def __init__(self, *, connected: bool = True) -> None:
+        self.calls = 0
+        self.tokens: list[int] = []
+        self.connected = connected
+
+    def set_tokens(self, tokens):
+        self.tokens = list(tokens)
+        return True
+
+    def is_connected(self) -> bool:
+        return self.connected
+
+    def force_reconnect(self) -> None:
+        self.calls += 1
+
+
+def _subscribe(mdm: MarketDataManager, symbol: str, token: int) -> None:
+    assert mdm.request_token_subscription(token, symbol=symbol)
+    mdm._confirmed_subscriptions.add(token)
+
+
+def test_current_generation_first_tick_required_after_subscription() -> None:
+    mdm = MarketDataManager(kite=None, websocket=_FakeWebSocket())
+    symbol = "NFO:NIFTY26JUN24000CE"
+    token = 24000
+
+    _subscribe(mdm, symbol, token)
+
+    pending = mdm.classify_live_tick_readiness(symbol, token, max_age_s=60.0)
+    assert pending["ready"] is False
+    assert pending["reason"] == "never_received_tick"
+    assert pending["tick_age_s"] is None
+
+    mdm._emit_tick(
+        symbol,
+        {
+            "symbol": symbol,
+            "instrument_token": token,
+            "ltp": 10.0,
+            "timestamp": time.time(),
+        },
+        source="ws",
+    )
+
+    ready = mdm.classify_live_tick_readiness(symbol, token, max_age_s=60.0)
+    assert ready["ready"] is True
+    assert ready["reason"] == "ready"
+    assert ready["first_tick_received"] is True
+
+
+def test_reconnect_generation_invalidates_old_tick_until_new_tick_arrives(monkeypatch) -> None:
+    ws = _FakeWebSocket()
+    mdm = MarketDataManager(kite=None, websocket=ws)
+    symbol = "NFO:NIFTY26JUN24000CE"
+    token = 24000
+    _subscribe(mdm, symbol, token)
+    mdm._emit_tick(
+        symbol,
+        {
+            "symbol": symbol,
+            "instrument_token": token,
+            "ltp": 10.0,
+            "timestamp": time.time(),
+        },
+        source="ws",
+    )
+    assert mdm.classify_live_tick_readiness(symbol, token, max_age_s=60.0)["ready"]
+    monkeypatch.setattr(mdm, "_reconcile_ws_subscriptions", lambda: None)
+
+    mdm._trigger_zombie_ws_restart()
+
+    blocked = mdm.classify_live_tick_readiness(symbol, token, max_age_s=60.0)
+    assert blocked["ready"] is False
+    assert blocked["reason"] == "never_received_tick"
+
+    mdm._emit_tick(
+        symbol,
+        {
+            "symbol": symbol,
+            "instrument_token": token,
+            "ltp": 10.5,
+            "timestamp": time.time(),
+        },
+        source="ws",
+    )
+    assert mdm.classify_live_tick_readiness(symbol, token, max_age_s=60.0)["ready"]
+
+
+def test_zombie_restart_is_single_flight() -> None:
+    ws = _FakeWebSocket()
+    mdm = MarketDataManager(kite=None, websocket=ws)
+    mdm._ws_restart_inflight = True
+    mdm._ws_restart_generation = 7
+
+    mdm._trigger_zombie_ws_restart()
+
+    assert ws.calls == 0
+    assert mdm._ws_restart_generation == 7
+
+
+def test_restart_connection_without_expected_token_is_recovery_failure(monkeypatch) -> None:
+    ws = _FakeWebSocket(connected=True)
+    mdm = MarketDataManager(kite=None, websocket=ws)
+    symbol = "NFO:NIFTY26JUN24000CE"
+    token = 24000
+    _subscribe(mdm, symbol, token)
+    mdm._dispatched_subscriptions.clear()
+    mdm._confirmed_subscriptions.clear()
+    monkeypatch.setattr(mdm, "_reconcile_ws_subscriptions", lambda: None)
+
+    mdm._trigger_zombie_ws_restart()
+
+    assert ws.calls == 1
+    recovery = mdm.verify_websocket_recovery()
+    assert recovery["ok"] is False
+    assert recovery["reason"] == "expected_tokens_not_restored"
+    assert (
+        mdm.classify_live_tick_readiness(symbol, token, max_age_s=60.0)["ready"]
+        is False
+    )
+
+
+def test_volume_baseline_resets_on_subscription_generation() -> None:
+    mdm = MarketDataManager(kite=None, websocket=_FakeWebSocket())
+    symbol = "NFO:NIFTY26JUN24000CE"
+    token = 24000
+    _subscribe(mdm, symbol, token)
+
+    first = mdm._normalise_tick_volume_delta(
+        symbol, {"volume_traded_today": 6_000_000}
+    )
+    second = mdm._normalise_tick_volume_delta(
+        symbol, {"volume_traded_today": 6_000_125}
+    )
+    assert first["volume_delta"] == 0
+    assert second["volume_delta"] == 125
+
+    mdm.request_token_subscription(token, symbol=symbol)
+    after_generation_change = mdm._normalise_tick_volume_delta(
+        symbol, {"volume_traded_today": 29_364_530}
+    )
+    assert after_generation_change["volume_delta"] == 0
+    assert after_generation_change["volume_delta_untrusted"] is False
+
+
+def test_stop_clears_restart_inflight_state() -> None:
+    mdm = MarketDataManager(kite=None, websocket=_FakeWebSocket())
+    mdm._started = True
+    mdm._ws_restart_inflight = True
+    mdm._ws_restart_started_at = time.monotonic()
+
+    mdm.stop()
+
+    assert mdm._ws_restart_inflight is False
+    assert mdm._ws_restart_started_at is None

--- a/tests/data/test_mdm_lifecycle_generation.py
+++ b/tests/data/test_mdm_lifecycle_generation.py
@@ -225,11 +225,155 @@ def test_shutdown_during_recovery_is_terminal_and_late_tick_cannot_recover() -> 
     assert mdm._ws_restart_fail_reason == "shutdown"
 
 
-def test_runner_live_tick_classifier_uses_canonical_freshness_policy() -> None:
-    runner_source = __import__("pathlib").Path(
-        "src/nifty_scalper_bot/strategies/runner.py"
-    ).read_text()
-    classifier_call = runner_source[runner_source.index("live_tick_check = classifier") : runner_source.index("details[\"live_tick_generation_ready\"]")]
-    assert "max_age_s=60.0" not in classifier_call
-    assert "max_live_tick_age_s" in classifier_call
-    assert "resolve_max_quote_age_seconds" in runner_source
+def test_failed_recovery_late_tick_remains_failed() -> None:
+    ws = _FakeWebSocket(raises=True)
+    mdm = MarketDataManager(kite=None, websocket=ws)
+    symbol = "NFO:NIFTY26JUN24000CE"
+    token = 24000
+    _subscribe(mdm, symbol, token)
+
+    mdm._trigger_zombie_ws_restart()
+    _ws_tick(mdm, symbol, token)
+
+    state = mdm.verify_websocket_recovery()
+    assert state["ok"] is False
+    assert state["state"] == "failed"
+    assert state["reason"] == "RuntimeError"
+
+
+def test_timeout_late_tick_remains_failed() -> None:
+    mdm = MarketDataManager(kite=None, websocket=_FakeWebSocket(connected=True))
+    symbol = "NFO:NIFTY26JUN24000CE"
+    token = 24000
+    _subscribe(mdm, symbol, token)
+    mdm._ws_recovery_timeout_sec = 1.0
+
+    mdm._trigger_zombie_ws_restart()
+    failed = mdm.verify_websocket_recovery(
+        now_mono=(mdm._ws_restart_deadline_mono or 0) + 0.1
+    )
+    _ws_tick(mdm, symbol, token)
+
+    state = mdm.verify_websocket_recovery()
+    assert failed["state"] == "failed"
+    assert state["ok"] is False
+    assert state["state"] == "failed"
+    assert state["reason"] == "waiting_for_current_generation_ticks"
+
+
+def test_unresolved_desired_token_mapping_cannot_recover() -> None:
+    mdm = MarketDataManager(kite=None, websocket=_FakeWebSocket(connected=True))
+    with mdm._lock:
+        mdm._desired_tokens.add(999999)
+
+    mdm._trigger_zombie_ws_restart()
+
+    state = mdm.verify_websocket_recovery()
+    assert state["ok"] is False
+    assert state["reason"] == "affected_token_mapping_incomplete"
+    assert state["unresolved_tokens"] == [999999]
+
+
+def test_concurrent_tick_and_restart_state_remains_atomic() -> None:
+    mdm = MarketDataManager(kite=None, websocket=_FakeWebSocket(connected=True))
+    symbol = "NFO:NIFTY26JUN24000CE"
+    token = 24000
+    _subscribe(mdm, symbol, token)
+
+    restart_thread = threading.Thread(target=mdm._trigger_zombie_ws_restart)
+    tick_thread = threading.Thread(target=_ws_tick, args=(mdm, symbol, token))
+    restart_thread.start()
+    tick_thread.start()
+    restart_thread.join()
+    tick_thread.join()
+
+    state = mdm.verify_websocket_recovery()
+    assert state["state"] in {"recovered", "waiting_for_first_ticks"}
+    assert mdm._symbol_subscription_generation[symbol] >= 1
+
+
+def test_successful_new_generation_clears_previous_failure_reason() -> None:
+    mdm = MarketDataManager(kite=None, websocket=_FakeWebSocket(raises=True))
+    symbol = "NFO:NIFTY26JUN24000CE"
+    token = 24000
+    _subscribe(mdm, symbol, token)
+    mdm._trigger_zombie_ws_restart()
+    assert mdm._ws_restart_fail_reason == "RuntimeError"
+
+    mdm._ws = _FakeWebSocket(connected=True)
+    mdm._zombie_last_restart_attempt_at = -10_000.0
+    mdm._trigger_zombie_ws_restart()
+    assert mdm._ws_restart_fail_reason is None
+    _ws_tick(mdm, symbol, token)
+
+    assert mdm.verify_websocket_recovery()["ok"] is True
+    assert mdm._ws_restart_fail_reason is None
+
+
+def test_runner_live_tick_classifier_uses_canonical_freshness_policy(monkeypatch) -> None:
+    from types import SimpleNamespace
+
+    from nifty_scalper_bot.strategies import runner as runner_module
+
+    captured: dict[str, object] = {}
+
+    class _FakeMDM:
+        def classify_live_tick_readiness(self, symbol, token, *, max_age_s):
+            captured["symbol"] = symbol
+            captured["token"] = token
+            captured["max_age_s"] = max_age_s
+            return {"ready": False, "reason": "sentinel_block"}
+
+    class _FakeIndicator:
+        def get_history(self, symbol):
+            return [object()] * 5
+
+    runner = object.__new__(runner_module.StrategyRunner)
+    runner._market_data = _FakeMDM()
+    runner._runtime_indicators = {"NFO:NIFTY26JUN24000CE": {}}
+    runner._resolve_execution_mode_snapshot = lambda: SimpleNamespace(
+        execution_mode="LIVE",
+        is_live_mode=True,
+        env_live_enabled=True,
+        paper_enabled=False,
+        shadow_mode_enabled=False,
+        order_manager_live=True,
+    )
+    runner._order_manager_kill_switch_status_for_entry = lambda: (False, None)
+    runner._get_cached_quote_for_live_entry = lambda symbol: {
+        "bid": 10.0,
+        "ask": 10.1,
+        "tradable_quote": True,
+    }
+    runner._risk_kill_switch_triggered = lambda: False
+    runner._runtime_live_orders_armed = True
+    runner._runtime_readiness_reason = "ready"
+    runner._runtime_data_hard_ready = True
+    runner._runtime_evaluation_ready = True
+    runner._logger = SimpleNamespace(info=lambda *a, **k: None, warning=lambda *a, **k: None)
+    runner._is_tradable_symbol = lambda symbol: True
+    runner._contract_side_from_symbol = lambda symbol: "CE"
+    runner._active_selected_ce = "NFO:NIFTY26JUN24000CE"
+    runner._active_selected_pe = "NFO:NIFTY26JUN24000PE"
+    runner._required_bars_for_symbol = lambda symbol: 1
+    runner._indicator_engine = _FakeIndicator()
+    runner._is_option_symbol_tick_fresh = lambda symbol, max_age_s: True
+    runner._live_entry_candidate_eligibility = lambda symbol, direction_bias: (
+        True,
+        "eligible",
+        {},
+    )
+    runner._active_basket_token_by_symbol = {"NFO:NIFTY26JUN24000CE": "24000"}
+    runner._order_manager = SimpleNamespace(resolve_lot_size=lambda symbol: 75)
+    runner._resolve_order_manager_health_for_entry = lambda: (True, "ok", {"broker_ready": True})
+    monkeypatch.setattr(runner_module, "resolve_max_quote_age_seconds", lambda *a, **k: 3.25)
+
+    ready, reason, _details = runner._symbol_live_entry_ready("NFO:NIFTY26JUN24000CE")
+
+    assert ready is False
+    assert reason == "sentinel_block"
+    assert captured == {
+        "symbol": "NFO:NIFTY26JUN24000CE",
+        "token": "24000",
+        "max_age_s": 3.25,
+    }

--- a/tests/data/test_mdm_lifecycle_generation.py
+++ b/tests/data/test_mdm_lifecycle_generation.py
@@ -1,15 +1,17 @@
 from __future__ import annotations
 
+import threading
 import time
 
 from nifty_scalper_bot.data.market_data_manager import MarketDataManager
 
 
 class _FakeWebSocket:
-    def __init__(self, *, connected: bool = True) -> None:
+    def __init__(self, *, connected: bool = True, raises: bool = False) -> None:
         self.calls = 0
         self.tokens: list[int] = []
         self.connected = connected
+        self.raises = raises
 
     def set_tokens(self, tokens):
         self.tokens = list(tokens)
@@ -20,11 +22,39 @@ class _FakeWebSocket:
 
     def force_reconnect(self) -> None:
         self.calls += 1
+        if self.raises:
+            raise RuntimeError("boom")
+
+
+class _NoReconnectWebSocket:
+    def __init__(self) -> None:
+        self.tokens: list[int] = []
+        self.connected = True
+
+    def set_tokens(self, tokens):
+        self.tokens = list(tokens)
+        return True
+
+    def is_connected(self) -> bool:
+        return self.connected
 
 
 def _subscribe(mdm: MarketDataManager, symbol: str, token: int) -> None:
     assert mdm.request_token_subscription(token, symbol=symbol)
     mdm._confirmed_subscriptions.add(token)
+
+
+def _ws_tick(mdm: MarketDataManager, symbol: str, token: int, ltp: float = 10.0) -> None:
+    mdm._emit_tick(
+        symbol,
+        {
+            "symbol": symbol,
+            "instrument_token": token,
+            "ltp": ltp,
+            "timestamp": time.time(),
+        },
+        source="ws",
+    )
 
 
 def test_current_generation_first_tick_required_after_subscription() -> None:
@@ -39,125 +69,167 @@ def test_current_generation_first_tick_required_after_subscription() -> None:
     assert pending["reason"] == "never_received_tick"
     assert pending["tick_age_s"] is None
 
-    mdm._emit_tick(
-        symbol,
-        {
-            "symbol": symbol,
-            "instrument_token": token,
-            "ltp": 10.0,
-            "timestamp": time.time(),
-        },
-        source="ws",
-    )
+    _ws_tick(mdm, symbol, token)
 
     ready = mdm.classify_live_tick_readiness(symbol, token, max_age_s=60.0)
     assert ready["ready"] is True
     assert ready["reason"] == "ready"
-    assert ready["first_tick_received"] is True
+    assert ready["current_generation_tick_received"] is True
 
 
-def test_reconnect_generation_invalidates_old_tick_until_new_tick_arrives(monkeypatch) -> None:
-    ws = _FakeWebSocket()
-    mdm = MarketDataManager(kite=None, websocket=ws)
+def test_idempotent_subscription_does_not_reset_generation_tick_or_volume() -> None:
+    mdm = MarketDataManager(kite=None, websocket=_FakeWebSocket())
     symbol = "NFO:NIFTY26JUN24000CE"
     token = 24000
     _subscribe(mdm, symbol, token)
-    mdm._emit_tick(
-        symbol,
-        {
-            "symbol": symbol,
-            "instrument_token": token,
-            "ltp": 10.0,
-            "timestamp": time.time(),
-        },
-        source="ws",
-    )
+    _ws_tick(mdm, symbol, token)
+    generation = mdm._symbol_subscription_generation[symbol]
+    first = mdm._normalise_tick_volume_delta(symbol, {"volume_traded_today": 1_000})
+    second = mdm._normalise_tick_volume_delta(symbol, {"volume_traded_today": 1_025})
+    assert first["volume_delta"] == 0
+    assert second["volume_delta"] == 25
+
+    assert mdm.request_token_subscription(token, symbol=symbol)
+
+    assert mdm._symbol_subscription_generation[symbol] == generation
     assert mdm.classify_live_tick_readiness(symbol, token, max_age_s=60.0)["ready"]
-    monkeypatch.setattr(mdm, "_reconcile_ws_subscriptions", lambda: None)
+    third = mdm._normalise_tick_volume_delta(symbol, {"volume_traded_today": 1_050})
+    assert third["volume_delta"] == 25
 
-    mdm._trigger_zombie_ws_restart()
 
-    blocked = mdm.classify_live_tick_readiness(symbol, token, max_age_s=60.0)
+def test_token_change_resets_generation_and_requires_new_matching_tick() -> None:
+    mdm = MarketDataManager(kite=None, websocket=_FakeWebSocket())
+    symbol = "NFO:NIFTY26JUN24000CE"
+    old_token = 24000
+    new_token = 24001
+    _subscribe(mdm, symbol, old_token)
+    _ws_tick(mdm, symbol, old_token)
+    old_generation = mdm._symbol_subscription_generation[symbol]
+    mdm._normalise_tick_volume_delta(symbol, {"volume_traded_today": 2_000})
+
+    assert mdm.request_token_subscription(new_token, symbol=symbol)
+
+    assert mdm._symbol_subscription_generation[symbol] > old_generation
+    assert mdm.classify_live_tick_readiness(symbol, new_token, max_age_s=60.0)["ready"] is False
+    baseline = mdm._normalise_tick_volume_delta(symbol, {"volume_traded_today": 29_364_530})
+    assert baseline["volume_delta"] == 0
+    assert baseline["volume_delta_untrusted"] is False
+
+    _ws_tick(mdm, symbol, old_token, ltp=9.5)
+    blocked = mdm.classify_live_tick_readiness(symbol, new_token, max_age_s=60.0)
     assert blocked["ready"] is False
     assert blocked["reason"] == "never_received_tick"
 
-    mdm._emit_tick(
-        symbol,
-        {
-            "symbol": symbol,
-            "instrument_token": token,
-            "ltp": 10.5,
-            "timestamp": time.time(),
-        },
-        source="ws",
-    )
-    assert mdm.classify_live_tick_readiness(symbol, token, max_age_s=60.0)["ready"]
+    _ws_tick(mdm, symbol, new_token, ltp=10.5)
+    assert mdm.classify_live_tick_readiness(symbol, new_token, max_age_s=60.0)["ready"]
 
 
-def test_zombie_restart_is_single_flight() -> None:
-    ws = _FakeWebSocket()
-    mdm = MarketDataManager(kite=None, websocket=ws)
-    mdm._ws_restart_inflight = True
-    mdm._ws_restart_generation = 7
-
-    mdm._trigger_zombie_ws_restart()
-
-    assert ws.calls == 0
-    assert mdm._ws_restart_generation == 7
-
-
-def test_restart_connection_without_expected_token_is_recovery_failure(monkeypatch) -> None:
+def test_reconnect_remains_inflight_until_current_generation_tick() -> None:
     ws = _FakeWebSocket(connected=True)
     mdm = MarketDataManager(kite=None, websocket=ws)
     symbol = "NFO:NIFTY26JUN24000CE"
     token = 24000
     _subscribe(mdm, symbol, token)
-    mdm._dispatched_subscriptions.clear()
-    mdm._confirmed_subscriptions.clear()
-    monkeypatch.setattr(mdm, "_reconcile_ws_subscriptions", lambda: None)
+    _ws_tick(mdm, symbol, token)
 
     mdm._trigger_zombie_ws_restart()
 
     assert ws.calls == 1
-    recovery = mdm.verify_websocket_recovery()
-    assert recovery["ok"] is False
-    assert recovery["reason"] == "expected_tokens_not_restored"
-    assert (
-        mdm.classify_live_tick_readiness(symbol, token, max_age_s=60.0)["ready"]
-        is False
-    )
+    pending = mdm.verify_websocket_recovery()
+    assert pending["ok"] is False
+    assert pending["state"] == "waiting_for_first_ticks"
+    assert pending["inflight"] is True
+    assert mdm.classify_live_tick_readiness(symbol, token, max_age_s=60.0)["ready"] is False
+
+    _ws_tick(mdm, symbol, token)
+    recovered = mdm.verify_websocket_recovery()
+    assert recovered["ok"] is True
+    assert recovered["state"] == "recovered"
+    assert recovered["inflight"] is False
+    assert mdm.classify_live_tick_readiness(symbol, token, max_age_s=60.0)["ready"]
 
 
-def test_volume_baseline_resets_on_subscription_generation() -> None:
-    mdm = MarketDataManager(kite=None, websocket=_FakeWebSocket())
+def test_concurrent_duplicate_restart_callers_start_one_reconnect() -> None:
+    ws = _FakeWebSocket(connected=True)
+    mdm = MarketDataManager(kite=None, websocket=ws)
+    _subscribe(mdm, "NFO:NIFTY26JUN24000CE", 24000)
+    mdm._zombie_last_restart_attempt_at = -10_000.0
+
+    threads = [threading.Thread(target=mdm._trigger_zombie_ws_restart) for _ in range(2)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert ws.calls == 1
+    assert mdm._ws_restart_inflight is True
+
+
+def test_connected_dispatched_without_tick_is_not_recovered_at_deadline() -> None:
+    ws = _FakeWebSocket(connected=True)
+    mdm = MarketDataManager(kite=None, websocket=ws)
     symbol = "NFO:NIFTY26JUN24000CE"
     token = 24000
     _subscribe(mdm, symbol, token)
+    mdm._ws_recovery_timeout_sec = 1.0
 
-    first = mdm._normalise_tick_volume_delta(
-        symbol, {"volume_traded_today": 6_000_000}
-    )
-    second = mdm._normalise_tick_volume_delta(
-        symbol, {"volume_traded_today": 6_000_125}
-    )
-    assert first["volume_delta"] == 0
-    assert second["volume_delta"] == 125
+    mdm._trigger_zombie_ws_restart()
+    mdm._dispatched_subscriptions.add(token)
+    pending = mdm.verify_websocket_recovery(now_mono=(mdm._ws_restart_deadline_mono or 0) - 0.1)
+    assert pending["ok"] is False
+    assert pending["state"] == "waiting_for_first_ticks"
 
-    mdm.request_token_subscription(token, symbol=symbol)
-    after_generation_change = mdm._normalise_tick_volume_delta(
-        symbol, {"volume_traded_today": 29_364_530}
-    )
-    assert after_generation_change["volume_delta"] == 0
-    assert after_generation_change["volume_delta_untrusted"] is False
+    failed = mdm.verify_websocket_recovery(now_mono=(mdm._ws_restart_deadline_mono or 0) + 0.1)
+    assert failed["ok"] is False
+    assert failed["state"] == "failed"
+    assert mdm._ws_restart_inflight is False
 
 
-def test_stop_clears_restart_inflight_state() -> None:
-    mdm = MarketDataManager(kite=None, websocket=_FakeWebSocket())
-    mdm._started = True
-    mdm._ws_restart_inflight = True
-    mdm._ws_restart_started_at = time.monotonic()
+def test_missing_force_reconnect_records_failure_and_clears_inflight() -> None:
+    mdm = MarketDataManager(kite=None, websocket=_NoReconnectWebSocket())
+    _subscribe(mdm, "NFO:NIFTY26JUN24000CE", 24000)
 
-    mdm.stop()
+    mdm._trigger_zombie_ws_restart()
 
     assert mdm._ws_restart_inflight is False
-    assert mdm._ws_restart_started_at is None
+    assert mdm._ws_restart_state == "failed"
+    assert mdm._ws_restart_fail_reason == "force_reconnect_unavailable"
+
+
+def test_force_reconnect_exception_records_failure_and_clears_inflight() -> None:
+    mdm = MarketDataManager(kite=None, websocket=_FakeWebSocket(raises=True))
+    _subscribe(mdm, "NFO:NIFTY26JUN24000CE", 24000)
+
+    mdm._trigger_zombie_ws_restart()
+
+    assert mdm._ws_restart_inflight is False
+    assert mdm._ws_restart_state == "failed"
+    assert mdm._ws_restart_fail_reason == "RuntimeError"
+
+
+def test_shutdown_during_recovery_is_terminal_and_late_tick_cannot_recover() -> None:
+    ws = _FakeWebSocket(connected=True)
+    mdm = MarketDataManager(kite=None, websocket=ws)
+    symbol = "NFO:NIFTY26JUN24000CE"
+    token = 24000
+    _subscribe(mdm, symbol, token)
+    mdm._started = True
+    mdm._trigger_zombie_ws_restart()
+
+    mdm.stop()
+    _ws_tick(mdm, symbol, token)
+
+    state = mdm.verify_websocket_recovery()
+    assert state["state"] == "failed"
+    assert state["inflight"] is False
+    assert mdm._ws_restart_fail_reason == "shutdown"
+
+
+def test_runner_live_tick_classifier_uses_canonical_freshness_policy() -> None:
+    runner_source = __import__("pathlib").Path(
+        "src/nifty_scalper_bot/strategies/runner.py"
+    ).read_text()
+    classifier_call = runner_source[runner_source.index("live_tick_check = classifier") : runner_source.index("details[\"live_tick_generation_ready\"]")]
+    assert "max_age_s=60.0" not in classifier_call
+    assert "max_live_tick_age_s" in classifier_call
+    assert "resolve_max_quote_age_seconds" in runner_source

--- a/tests/data/test_mdm_tick_coalescing.py
+++ b/tests/data/test_mdm_tick_coalescing.py
@@ -352,8 +352,16 @@ def test_rest_fallback_does_not_mark_ws_tick_freshness():
 def test_valid_ws_tick_updates_canonical_live_timestamp():
     mdm = MarketDataManager(kite=None)
     symbol = "NFO:NIFTY26JUN24000CE"
+    token = 24000
+    assert mdm.request_token_subscription(token, symbol=symbol)
     mdm._ingest_normalized_tick(
-        {"symbol": symbol, "ltp": 10.0, "timestamp": time.time(), "source": "ws"}
+        {
+            "symbol": symbol,
+            "instrument_token": token,
+            "ltp": 10.0,
+            "timestamp": time.time(),
+            "source": "ws",
+        }
     )
 
     assert mdm.time_since_last_live_ws_tick(symbol) is not None


### PR DESCRIPTION
### Motivation
- Fix a production defect where an active-basket contract could be visible to strategies/watchdogs before its history, subscription, and a current-generation first WS tick were coherently established, causing hydration failures, long-stale symbols, repeated zombie restarts, and volume-baseline discontinuities.
- Ensure fail-closed behavior: a contract in a new subscription/restart generation must not be treated as execution-ready until canonical generation-bound readiness is proven.

### Description
- MarketDataManager: added generation state and lifecycle ownership including `_subscription_generation`, per-symbol `_symbol_subscription_generation`, per-symbol `_symbol_first_tick_generation`, `_ws_restart_generation`, `_ws_restart_inflight`, `_ws_restart_lock`, and restart diagnostics; these fields are used to invalidate old tick/history/volume baseline on generation changes and restarts.
- MarketDataManager: implemented `classify_live_tick_readiness(symbol, token, max_age_s=...)` which returns a deterministic readiness taxonomy (`subscription_missing`, `symbol_not_expected_live`, `subscription_pending`, `subscription_generation_mismatch`, `never_received_tick`, `tick_timestamp_missing`, `tick_stale`, `ready`) and exposes generation/timestamp/age details for diagnostics.
- MarketDataManager: stamp first-tick generation on WS ticks, reset `_last_cumulative_volume_by_symbol` and related tick cache on subscription/restart generation changes, and add `verify_websocket_recovery()` to validate post-reconnect token restoration; make zombie WS restarts single-flight using a lock and inflight flag.
- StrategyRunner: call the MDM classifier during live-entry candidate checks and fail-closed when the token is not subscribed/represented or lacks a current-generation fresh WS tick; emitted classifier diagnostics are attached to the existing `details` object so gates remain observable.
- Tests: added deterministic tests in `tests/data/test_mdm_lifecycle_generation.py` exercising first-tick gating, reconnect invalidation, single-flight restart coalescing, failed recovery when expected tokens are not restored, volume-baseline reset on generation change, and restart inflight cleanup at `stop()`.

### Testing
- Added test file `tests/data/test_mdm_lifecycle_generation.py` covering: (1) subscription with no first tick remains blocked, (2) reconnect invalidates old-generation tick until a new tick arrives, (3) duplicate watchdog restart triggers are coalesced, (4) recovery is marked failed when expected tokens are not restored, (5) cumulative-volume baseline resets on subscription generation change, and (6) shutdown clears restart inflight state.
- Commands run and results: `python -m py_compile src` (succeeds), `pytest -q tests/data/test_mdm_lifecycle_generation.py` (passes), `python -m compileall -q src` (passes), `pytest -q` (full test-suite executed; all tests passed in this environment).
- No changes were made to fill polling, order rejection handling, strategy thresholds, or order placement logic in this PR; those alerts were audited and identified as separate follow-ups.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a553530aaa88324b145669cf641b66a)