### PR TITLE
Fix canonical option-history visibility and runner reseeding

### DIFF
--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -58,6 +58,7 @@ from nifty_scalper_bot.config.settings import get_settings
 from nifty_scalper_bot.data.candle_engine import CandleEngine
 from nifty_scalper_bot.data.market_data_policy import MarketDataPolicy
 from nifty_scalper_bot.data.normalizers import normalize_history_row
+from nifty_scalper_bot.data.time_contract import coerce_market_timestamp
 from nifty_scalper_bot.data.validator import validate_tick
 from nifty_scalper_bot.data.source import DataIntegrityError
 from nifty_scalper_bot.instruments.active_contracts import (
@@ -10077,25 +10078,21 @@ class MarketDataManager:
 
     @staticmethod
     def _bar_timestamp_key(row: Mapping[str, Any]) -> datetime | None:
-        """Return the UTC minute timestamp used to merge completed OHLC bars."""
+        """Return UTC minute key using the canonical market timestamp policy."""
 
         ts = row.get("timestamp") if isinstance(row, Mapping) else None
         if ts is None and isinstance(row, Mapping):
             ts = row.get("date")
         try:
-            if isinstance(ts, datetime):
-                parsed = ts
-            elif isinstance(ts, (int, float)):
-                parsed = datetime.fromtimestamp(float(ts), tz=timezone.utc)
-            elif isinstance(ts, str):
-                parsed = datetime.fromisoformat(ts.replace("Z", "+00:00"))
-            else:
-                return None
+            market_ts = coerce_market_timestamp(ts)
         except (TypeError, ValueError, OSError):
             return None
-        if parsed.tzinfo is None:
-            parsed = parsed.replace(tzinfo=timezone.utc)
-        return parsed.astimezone(timezone.utc).replace(second=0, microsecond=0)
+        return (
+            market_ts.tz_convert(timezone.utc)
+            .floor("min")
+            .to_pydatetime()
+            .replace(second=0, microsecond=0)
+        )
 
     @staticmethod
     def _completed_bar_precedence(row: Mapping[str, Any]) -> int:

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -10119,7 +10119,13 @@ class MarketDataManager:
         """
 
         bar_symbol = self._bar_symbol_key(symbol)
-        candidate_keys = {bar_symbol, str(symbol or "").strip()}
+        raw_symbol = str(symbol or "").strip()
+        # Canonical-key storage is authoritative. Reading the raw symbol key is
+        # temporary backward compatibility for rows written before canonical live
+        # candle storage was enforced; no new writes may target the raw key.
+        candidate_keys = [bar_symbol]
+        if raw_symbol and raw_symbol != bar_symbol:
+            candidate_keys.append(raw_symbol)
         merged: dict[datetime, tuple[int, int, dict[str, Any]]] = {}
         sequence = 0
         with self._lock:
@@ -10139,7 +10145,7 @@ class MarketDataManager:
             row.setdefault("symbol", bar_symbol)
             precedence = self._completed_bar_precedence(row)
             existing = merged.get(ts_key)
-            if existing is None or (precedence, sequence) >= (existing[0], existing[1]):
+            if existing is None or precedence > existing[0]:
                 merged[ts_key] = (precedence, sequence, row)
         bars = [entry[2] for _, entry in sorted(merged.items(), key=lambda item: item[0])]
         if limit is not None and limit >= 0:

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -7167,7 +7167,7 @@ class MarketDataManager:
                 ),
                 "source": "ws_candle",
             }
-            self._ohlc[symbol].append(bar)
+            self._ohlc[self._bar_symbol_key(symbol)].append(bar)
             self._publish_closed_bar(bar)
             verbose_candles = str(
                 os.getenv("LOG_VERBOSE_CANDLES", "false")
@@ -10075,14 +10075,76 @@ class MarketDataManager:
         }
         return snapshot
 
+    @staticmethod
+    def _bar_timestamp_key(row: Mapping[str, Any]) -> datetime | None:
+        """Return the UTC minute timestamp used to merge completed OHLC bars."""
+
+        ts = row.get("timestamp") if isinstance(row, Mapping) else None
+        if ts is None and isinstance(row, Mapping):
+            ts = row.get("date")
+        try:
+            if isinstance(ts, datetime):
+                parsed = ts
+            elif isinstance(ts, (int, float)):
+                parsed = datetime.fromtimestamp(float(ts), tz=timezone.utc)
+            elif isinstance(ts, str):
+                parsed = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+            else:
+                return None
+        except (TypeError, ValueError, OSError):
+            return None
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc).replace(second=0, microsecond=0)
+
+    @staticmethod
+    def _completed_bar_precedence(row: Mapping[str, Any]) -> int:
+        """Return deterministic precedence for duplicate completed candle timestamps."""
+
+        if bool(row.get("provisional")):
+            return -1
+        source = str(row.get("source") or "").lower()
+        if source in {"ws_candle", "live", "websocket", "ws"}:
+            return 30
+        if source in {"historical", "broker", "broker_history"}:
+            return 20
+        return 10
+
     def get_ohlc_bars(
         self, symbol: str, *, limit: int | None = None
     ) -> list[dict[str, Any]]:
-        """Return trailing one-minute OHLC bars for *symbol*."""
+        """Return canonical completed one-minute OHLC bars for *symbol*.
+
+        The canonical view is a pure read: it merges accepted broker-history rows
+        with completed live-built candles for the normalized bar key, deduplicates
+        by candle timestamp, prefers completed live candles over broker history on
+        identical timestamps, and never exposes provisional current candles.
+        """
 
         bar_symbol = self._bar_symbol_key(symbol)
+        candidate_keys = {bar_symbol, str(symbol or "").strip()}
+        merged: dict[datetime, tuple[int, int, dict[str, Any]]] = {}
+        sequence = 0
         with self._lock:
-            bars = list(self._ohlc.get(bar_symbol, ()))
+            rows: list[dict[str, Any]] = []
+            for key in candidate_keys:
+                if not key:
+                    continue
+                rows.extend(dict(row) for row in self._ohlc.get(key, ()) or ())
+        for row in rows:
+            sequence += 1
+            if bool(row.get("provisional")):
+                continue
+            ts_key = self._bar_timestamp_key(row)
+            if ts_key is None:
+                continue
+            row["timestamp"] = ts_key
+            row.setdefault("symbol", bar_symbol)
+            precedence = self._completed_bar_precedence(row)
+            existing = merged.get(ts_key)
+            if existing is None or (precedence, sequence) >= (existing[0], existing[1]):
+                merged[ts_key] = (precedence, sequence, row)
+        bars = [entry[2] for _, entry in sorted(merged.items(), key=lambda item: item[0])]
         if limit is not None and limit >= 0:
             bars = bars[-limit:]
         return bars

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -1953,17 +1953,24 @@ class StrategyRunner:
         except (AttributeError, TypeError, ValueError) as exc:
             rows = []
             failure_reason = f"mdm_history_read_failed:{type(exc).__name__}"
-        mdm_bars = len(rows)
+        source_count = len(rows)
+        required_count = target
+        target_count = target
         runner_before = len(
             getattr(self, "_symbol_history", {}).get(normalized, []) or []
         )
-        if rows and (
-            runner_before < min(target, mdm_bars)
-            or indicator_before < min(target, mdm_bars)
-        ):
+        indicator_count = indicator_before
+        source_ready = source_count >= required_count
+        indicator_ready = indicator_count >= required_count
+        needs_seed = bool(
+            rows
+            and not indicator_ready
+            and (source_count > indicator_count or source_ready)
+        )
+        if needs_seed:
             try:
                 self.reseed_history_from_bars(
-                    normalized, rows, source=reason, min_bars=target
+                    normalized, rows, source=reason, min_bars=required_count
                 )
             except (
                 Exception
@@ -1986,6 +1993,8 @@ class StrategyRunner:
                         "failure_reason": failure_reason,
                     },
                 )
+        elif not source_ready and not indicator_ready and failure_reason is None:
+            failure_reason = "source_history_short"
         runner_after = len(
             getattr(self, "_symbol_history", {}).get(normalized, []) or []
         )
@@ -1998,7 +2007,7 @@ class StrategyRunner:
             )
         success = (
             failure_reason is None
-            and mdm_bars >= target
+            and source_count >= target
             and runner_after >= target
             and indicator_after >= target
         )
@@ -2015,7 +2024,7 @@ class StrategyRunner:
         # memory-tight host. Throttle the healthy/steady case per symbol+state
         # (60s); failures and state changes still log immediately. Same pattern as
         # LIVE_TRADING_READINESS_SNAPSHOT / LIVE_UNIVERSE_BOOTSTRAP_STATUS.
-        _sync_key = f"hist_sync:{normalized}:{role}:{success}:{reason}:{mdm_bars}:{runner_after}:{indicator_after}"
+        _sync_key = f"hist_sync:{normalized}:{role}:{success}:{reason}:{source_count}:{runner_after}:{indicator_after}"
         _sync_interval = float(
             os.getenv("RUNNER_HISTORY_SYNC_LOG_INTERVAL_SECONDS", "60") or "60"
         )
@@ -2026,7 +2035,7 @@ class StrategyRunner:
                 role,
                 reason,
                 target,
-                mdm_bars,
+                source_count,
                 runner_after,
                 indicator_after,
                 success,
@@ -2037,7 +2046,7 @@ class StrategyRunner:
                     "role": role,
                     "reason": reason,
                     "required_bars": target,
-                    "mdm_after": mdm_bars,
+                    "mdm_after": source_count,
                     "runner_after": runner_after,
                     "indicator_after": indicator_after,
                     "success": success,
@@ -2058,7 +2067,7 @@ class StrategyRunner:
             role,
             reason,
             target,
-            mdm_bars,
+            source_count,
             runner_after,
             indicator_after,
             success,

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -1961,10 +1961,11 @@ class StrategyRunner:
         indicator_count = indicator_before
         source_ready = source_count >= required_count
         indicator_ready = indicator_count >= required_count
+        runner_ready = runner_before >= required_count
         needs_seed = bool(
             rows
-            and not indicator_ready
-            and (source_count > indicator_count or source_ready)
+            and (not indicator_ready or not runner_ready)
+            and (source_count > min(indicator_count, runner_before) or source_ready)
         )
         if needs_seed:
             try:
@@ -1992,7 +1993,7 @@ class StrategyRunner:
                         "failure_reason": failure_reason,
                     },
                 )
-        elif not source_ready and not indicator_ready and failure_reason is None:
+        if not source_ready and failure_reason is None:
             failure_reason = "source_history_short"
         runner_after = len(
             getattr(self, "_symbol_history", {}).get(normalized, []) or []

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -1955,7 +1955,6 @@ class StrategyRunner:
             failure_reason = f"mdm_history_read_failed:{type(exc).__name__}"
         source_count = len(rows)
         required_count = target
-        target_count = target
         runner_before = len(
             getattr(self, "_symbol_history", {}).get(normalized, []) or []
         )

--- a/tests/data/test_mdm_canonical_ohlc_merge.py
+++ b/tests/data/test_mdm_canonical_ohlc_merge.py
@@ -249,3 +249,74 @@ def test_invalid_timestamp_is_rejected_deterministically() -> None:
     assert len(bars) == 1
     assert bars[0]["source"] == "ws_candle"
     assert bars[0]["timestamp_quality"] == "exchange_timestamp"
+
+
+def test_canonical_and_raw_key_merge_order_is_deterministic_and_canonical_authoritative() -> (
+    None
+):
+    mdm = _mdm()
+    symbol = "NFO:NIFTY26JUN24000CE"
+    raw_symbol = "  NFO:NIFTY26JUN24000CE  "
+    canonical_key = mdm._bar_symbol_key(symbol)
+    mdm._ohlc[canonical_key].append(
+        _custom_bar(
+            datetime(2026, 1, 1, 9, 15),
+            source="historical",
+            close=111.0,
+            synthetic=False,
+            timestamp_quality="canonical_history",
+        )
+    )
+    mdm._ohlc[raw_symbol].append(
+        _custom_bar(
+            datetime(2026, 1, 1, 9, 15),
+            source="historical",
+            close=999.0,
+            synthetic=True,
+            timestamp_quality="legacy_raw_history",
+        )
+    )
+
+    first = mdm.get_ohlc_bars(raw_symbol)
+    second = mdm.get_ohlc_bars(raw_symbol)
+
+    assert first == second
+    assert len(first) == 1
+    assert first[0]["close"] == 111.0
+    assert first[0]["timestamp_quality"] == "canonical_history"
+    assert first[0]["synthetic"] is False
+
+
+def test_repeated_canonical_getter_calls_keep_same_live_winner_metadata() -> None:
+    mdm = _mdm()
+    symbol = "NFO:NIFTY26JUN24000CE"
+    key = mdm._bar_symbol_key(symbol)
+    mdm._ohlc[key].append(
+        _custom_bar(
+            datetime(2026, 1, 1, 9, 15),
+            source="historical",
+            close=111.0,
+            synthetic=False,
+            timestamp_quality="broker_history",
+        )
+    )
+    mdm._ohlc[key].append(
+        _custom_bar(
+            datetime(2026, 1, 1, 9, 15, 30),
+            source="ws_candle",
+            close=222.0,
+            synthetic=True,
+            timestamp_quality="exchange_timestamp",
+            provisional=False,
+        )
+    )
+
+    first = mdm.get_ohlc_bars(symbol)
+    second = mdm.get_ohlc_bars(symbol)
+
+    assert first == second
+    assert len(first) == 1
+    assert first[0]["source"] == "ws_candle"
+    assert first[0]["synthetic"] is True
+    assert first[0]["timestamp_quality"] == "exchange_timestamp"
+    assert first[0]["provisional"] is False

--- a/tests/data/test_mdm_canonical_ohlc_merge.py
+++ b/tests/data/test_mdm_canonical_ohlc_merge.py
@@ -57,14 +57,14 @@ def test_canonical_getter_merges_history_and_live_dedupes_overlaps() -> None:
     assert bars[-1]["close"] == 1049.0
 
 
-def test_canonical_getter_does_not_let_provisional_current_candle_overwrite_history() -> None:
+def test_canonical_getter_does_not_let_provisional_current_candle_overwrite_history() -> (
+    None
+):
     mdm = _mdm()
     symbol = "NFO:NIFTY26JUN24000CE"
     key = mdm._bar_symbol_key(symbol)
     mdm._ohlc[key].append(_bar(1, source="historical", close=101.0))
-    mdm._ohlc[key].append(
-        _bar(1, source="ws_candle", provisional=True, close=999.0)
-    )
+    mdm._ohlc[key].append(_bar(1, source="ws_candle", provisional=True, close=999.0))
 
     bars = mdm.get_ohlc_bars(symbol)
 
@@ -87,7 +87,9 @@ def test_completed_live_candle_precedes_historical_on_same_timestamp() -> None:
     assert bars[0]["source"] == "ws_candle"
 
 
-def test_canonical_getter_applies_limit_after_merge_and_does_not_mutate_storage() -> None:
+def test_canonical_getter_applies_limit_after_merge_and_does_not_mutate_storage() -> (
+    None
+):
     mdm = _mdm()
     symbol = "NFO:NIFTY26JUN24000CE"
     key = mdm._bar_symbol_key(symbol)
@@ -103,3 +105,147 @@ def test_canonical_getter_applies_limit_after_merge_and_does_not_mutate_storage(
         before[-1]["timestamp"],
     ]
     assert list(mdm._ohlc[key]) == before
+
+
+def _custom_bar(
+    timestamp: object,
+    *,
+    source: str,
+    close: float,
+    provisional: bool = False,
+    synthetic: bool = False,
+    timestamp_quality: str = "broker",
+) -> dict:
+    return {
+        "symbol": "NFO:NIFTY26JUN24000CE",
+        "timestamp": timestamp,
+        "open": close,
+        "high": close + 1,
+        "low": close - 1,
+        "close": close,
+        "volume": 1,
+        "source": source,
+        "provisional": provisional,
+        "synthetic": synthetic,
+        "timestamp_quality": timestamp_quality,
+    }
+
+
+def _assert_single_live_winner(mdm: MarketDataManager, symbol: str) -> None:
+    bars = mdm.get_ohlc_bars(symbol)
+    assert len(bars) == 1
+    assert bars[0]["source"] == "ws_candle"
+    assert bars[0]["synthetic"] is True
+    assert bars[0]["timestamp_quality"] == "exchange_timestamp"
+    assert bars[0]["provisional"] is False
+    assert bars[0]["close"] == 222.0
+
+
+def test_naive_ist_history_and_aware_ist_live_timestamp_dedupe_with_metadata() -> None:
+    from zoneinfo import ZoneInfo
+
+    mdm = _mdm()
+    symbol = "NFO:NIFTY26JUN24000CE"
+    key = mdm._bar_symbol_key(symbol)
+    mdm._ohlc[key].append(
+        _custom_bar(
+            datetime(2026, 1, 1, 9, 15),
+            source="historical",
+            close=111.0,
+            timestamp_quality="broker_naive",
+        )
+    )
+    mdm._ohlc[key].append(
+        _custom_bar(
+            datetime(2026, 1, 1, 9, 15, 30, tzinfo=ZoneInfo("Asia/Kolkata")),
+            source="ws_candle",
+            close=222.0,
+            synthetic=True,
+            timestamp_quality="exchange_timestamp",
+        )
+    )
+
+    _assert_single_live_winner(mdm, symbol)
+
+
+def test_naive_ist_history_and_equivalent_utc_live_timestamp_dedupe() -> None:
+    mdm = _mdm()
+    symbol = "NFO:NIFTY26JUN24000CE"
+    key = mdm._bar_symbol_key(symbol)
+    mdm._ohlc[key].append(
+        _custom_bar(datetime(2026, 1, 1, 9, 15), source="historical", close=111.0)
+    )
+    mdm._ohlc[key].append(
+        _custom_bar(
+            datetime(2026, 1, 1, 3, 45, 45, tzinfo=timezone.utc),
+            source="ws_candle",
+            close=222.0,
+            synthetic=True,
+            timestamp_quality="exchange_timestamp",
+        )
+    )
+
+    _assert_single_live_winner(mdm, symbol)
+
+
+def test_iso_timestamp_with_ist_offset_dedupes_to_same_minute() -> None:
+    mdm = _mdm()
+    symbol = "NFO:NIFTY26JUN24000CE"
+    key = mdm._bar_symbol_key(symbol)
+    mdm._ohlc[key].append(
+        _custom_bar("2026-01-01T09:15:00+05:30", source="historical", close=111.0)
+    )
+    mdm._ohlc[key].append(
+        _custom_bar(
+            "2026-01-01T03:45:40Z",
+            source="ws_candle",
+            close=222.0,
+            synthetic=True,
+            timestamp_quality="exchange_timestamp",
+        )
+    )
+
+    _assert_single_live_winner(mdm, symbol)
+
+
+def test_unix_epoch_timestamp_dedupes_to_same_minute() -> None:
+    mdm = _mdm()
+    symbol = "NFO:NIFTY26JUN24000CE"
+    key = mdm._bar_symbol_key(symbol)
+    epoch = datetime(2026, 1, 1, 3, 45, 10, tzinfo=timezone.utc).timestamp()
+    mdm._ohlc[key].append(_custom_bar(epoch, source="historical", close=111.0))
+    mdm._ohlc[key].append(
+        _custom_bar(
+            datetime(2026, 1, 1, 9, 15, 55),
+            source="ws_candle",
+            close=222.0,
+            synthetic=True,
+            timestamp_quality="exchange_timestamp",
+        )
+    )
+
+    _assert_single_live_winner(mdm, symbol)
+
+
+def test_invalid_timestamp_is_rejected_deterministically() -> None:
+    mdm = _mdm()
+    symbol = "NFO:NIFTY26JUN24000CE"
+    key = mdm._bar_symbol_key(symbol)
+    mdm._ohlc[key].append(
+        _custom_bar("not-a-timestamp", source="historical", close=111.0)
+    )
+    mdm._ohlc[key].append(
+        _custom_bar(
+            datetime(2026, 1, 1, 9, 15),
+            source="ws_candle",
+            close=222.0,
+            synthetic=True,
+            timestamp_quality="exchange_timestamp",
+        )
+    )
+
+    bars = mdm.get_ohlc_bars(symbol)
+
+    assert len(bars) == 1
+    assert bars[0]["source"] == "ws_candle"
+    assert bars[0]["timestamp_quality"] == "exchange_timestamp"

--- a/tests/data/test_mdm_canonical_ohlc_merge.py
+++ b/tests/data/test_mdm_canonical_ohlc_merge.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from collections import defaultdict, deque
+from datetime import datetime, timedelta, timezone
+import threading
+
+from nifty_scalper_bot.data.market_data_manager import MarketDataManager
+
+
+def _mdm() -> MarketDataManager:
+    mdm = MarketDataManager.__new__(MarketDataManager)
+    mdm._lock = threading.RLock()
+    mdm._cache_len = 250
+    mdm._ohlc = defaultdict(lambda: deque(maxlen=mdm._cache_len))
+    return mdm
+
+
+def _bar(
+    i: int,
+    *,
+    source: str = "historical",
+    provisional: bool = False,
+    close: float | None = None,
+) -> dict:
+    ts = datetime(2026, 1, 1, 9, 15, tzinfo=timezone.utc) + timedelta(minutes=i)
+    return {
+        "symbol": "NFO:NIFTY26JUN24000CE",
+        "timestamp": ts,
+        "open": 100 + i,
+        "high": 101 + i,
+        "low": 99 + i,
+        "close": float(close if close is not None else 100 + i),
+        "volume": i,
+        "source": source,
+        "provisional": provisional,
+        "synthetic": False,
+        "timestamp_quality": "broker",
+    }
+
+
+def test_canonical_getter_merges_history_and_live_dedupes_overlaps() -> None:
+    mdm = _mdm()
+    symbol = "NFO:NIFTY26JUN24000CE"
+    key = mdm._bar_symbol_key(symbol)
+    for i in range(50):
+        mdm._ohlc[key].append(_bar(i, source="historical"))
+    for i in range(35, 50):
+        mdm._ohlc[symbol].append(_bar(i, source="ws_candle", close=1000 + i))
+
+    bars = mdm.get_ohlc_bars(symbol)
+
+    assert len(bars) == 50
+    assert [bar["timestamp"] for bar in bars] == sorted(
+        bar["timestamp"] for bar in bars
+    )
+    assert len({bar["timestamp"] for bar in bars}) == 50
+    assert bars[-1]["close"] == 1049.0
+
+
+def test_canonical_getter_does_not_let_provisional_current_candle_overwrite_history() -> None:
+    mdm = _mdm()
+    symbol = "NFO:NIFTY26JUN24000CE"
+    key = mdm._bar_symbol_key(symbol)
+    mdm._ohlc[key].append(_bar(1, source="historical", close=101.0))
+    mdm._ohlc[key].append(
+        _bar(1, source="ws_candle", provisional=True, close=999.0)
+    )
+
+    bars = mdm.get_ohlc_bars(symbol)
+
+    assert len(bars) == 1
+    assert bars[0]["close"] == 101.0
+    assert bars[0]["source"] == "historical"
+
+
+def test_completed_live_candle_precedes_historical_on_same_timestamp() -> None:
+    mdm = _mdm()
+    symbol = "NFO:NIFTY26JUN24000CE"
+    key = mdm._bar_symbol_key(symbol)
+    mdm._ohlc[key].append(_bar(2, source="historical", close=102.0))
+    mdm._ohlc[key].append(_bar(2, source="ws_candle", close=202.0))
+
+    bars = mdm.get_ohlc_bars(symbol)
+
+    assert len(bars) == 1
+    assert bars[0]["close"] == 202.0
+    assert bars[0]["source"] == "ws_candle"
+
+
+def test_canonical_getter_applies_limit_after_merge_and_does_not_mutate_storage() -> None:
+    mdm = _mdm()
+    symbol = "NFO:NIFTY26JUN24000CE"
+    key = mdm._bar_symbol_key(symbol)
+    for i in range(10):
+        mdm._ohlc[key].append(_bar(i, source="historical"))
+    before = list(mdm._ohlc[key])
+
+    bars = mdm.get_ohlc_bars(symbol, limit=3)
+
+    assert [bar["timestamp"] for bar in bars] == [
+        before[-3]["timestamp"],
+        before[-2]["timestamp"],
+        before[-1]["timestamp"],
+    ]
+    assert list(mdm._ohlc[key]) == before

--- a/tests/strategies/test_canonical_runner_history_sync.py
+++ b/tests/strategies/test_canonical_runner_history_sync.py
@@ -276,3 +276,89 @@ async def test_create_task_failure_closes_coroutine_and_does_not_overwrite_newer
     assert r._runtime_history_ensure_inflight["NFO:NIFTY26JUN24000CE"] == 30
     assert r._runtime_history_ensure_roles["NFO:NIFTY26JUN24000CE"] == "recovery_or_open_position"
     assert [w for w in recwarn if "was never awaited" in str(w.message)] == []
+
+async def test_selected_option_with_canonical_source_warm_indicator_short_reseeds_immediately() -> None:
+    r = _runner(_bars(50))
+    symbol = "NFO:NIFTY26JUN24000CE"
+    r._symbol_history[symbol] = _bars(15)
+    for bar in _bars(15):
+        r._indicator_engine.ingest_historical_bar(symbol, bar)
+
+    result = r.sync_history_from_mdm(
+        symbol,
+        required_bars=30,
+        reason="selected_option_hydration",
+        role="selected_option",
+        request_if_short=False,
+    )
+
+    assert result.success is True
+    assert result.mdm_bars == 30
+    assert result.runner_bars >= 30
+    assert result.indicator_bars >= 30
+
+
+async def test_indicator_equal_to_short_source_remains_not_ready_without_false_success() -> None:
+    r = _runner(_bars(15))
+    symbol = "NFO:NIFTY26JUN24000CE"
+    r._symbol_history[symbol] = _bars(15)
+    for bar in _bars(15):
+        r._indicator_engine.ingest_historical_bar(symbol, bar)
+
+    result = r.sync_history_from_mdm(
+        symbol,
+        required_bars=30,
+        reason="selected_option_hydration",
+        role="selected_option",
+        request_if_short=False,
+    )
+
+    assert result.success is False
+    assert result.mdm_bars == 15
+    assert result.indicator_bars == 15
+    assert result.failure_reason == "source_history_short"
+
+
+async def test_partial_source_availability_seeds_useful_bars_but_remains_fail_closed() -> None:
+    r = _runner(_bars(20))
+    symbol = "NFO:NIFTY26JUN24000CE"
+    for bar in _bars(15):
+        r._indicator_engine.ingest_historical_bar(symbol, bar)
+
+    result = r.sync_history_from_mdm(
+        symbol,
+        required_bars=30,
+        reason="selected_option_hydration",
+        role="selected_option",
+        request_if_short=False,
+    )
+
+    assert result.success is False
+    assert result.mdm_bars == 20
+    assert result.runner_bars == 20
+    assert result.indicator_bars == 20
+
+
+async def test_repeated_sync_is_idempotent_for_same_canonical_bars() -> None:
+    r = _runner(_bars(50))
+    symbol = "NFO:NIFTY26JUN24000CE"
+
+    first = r.sync_history_from_mdm(
+        symbol,
+        required_bars=30,
+        reason="selected_option_hydration",
+        role="selected_option",
+        request_if_short=False,
+    )
+    second = r.sync_history_from_mdm(
+        symbol,
+        required_bars=30,
+        reason="selected_option_hydration",
+        role="selected_option",
+        request_if_short=False,
+    )
+
+    assert first.success is True
+    assert second.success is True
+    assert second.runner_bars == first.runner_bars == 30
+    assert second.indicator_bars == first.indicator_bars == 30

--- a/tests/strategies/test_canonical_runner_history_sync.py
+++ b/tests/strategies/test_canonical_runner_history_sync.py
@@ -362,3 +362,66 @@ async def test_repeated_sync_is_idempotent_for_same_canonical_bars() -> None:
     assert second.success is True
     assert second.runner_bars == first.runner_bars == 30
     assert second.indicator_bars == first.indicator_bars == 30
+
+
+async def test_runner_short_indicator_ready_source_warm_reseeds_and_succeeds() -> None:
+    r = _runner(_bars(50))
+    symbol = "NFO:NIFTY26JUN24000CE"
+    r._symbol_history[symbol] = _bars(15)
+    for bar in _bars(30):
+        r._indicator_engine.ingest_historical_bar(symbol, bar)
+
+    result = r.sync_history_from_mdm(
+        symbol,
+        required_bars=30,
+        reason="selected_option_hydration",
+        role="selected_option",
+        request_if_short=False,
+    )
+
+    assert result.success is True
+    assert result.runner_bars >= 30
+    assert result.indicator_bars >= 30
+
+
+async def test_short_source_fails_even_when_runner_and_indicator_are_warm() -> None:
+    r = _runner(_bars(15))
+    symbol = "NFO:NIFTY26JUN24000CE"
+    r._symbol_history[symbol] = _bars(30)
+    for bar in _bars(30):
+        r._indicator_engine.ingest_historical_bar(symbol, bar)
+
+    result = r.sync_history_from_mdm(
+        symbol,
+        required_bars=30,
+        reason="selected_option_hydration",
+        role="selected_option",
+        request_if_short=False,
+    )
+
+    assert result.success is False
+    assert result.mdm_bars == 15
+    assert result.runner_bars == 30
+    assert result.indicator_bars == 30
+    assert result.failure_reason == "source_history_short"
+
+
+async def test_short_source_repairs_short_runner_but_remains_fail_closed() -> None:
+    r = _runner(_bars(20))
+    symbol = "NFO:NIFTY26JUN24000CE"
+    r._symbol_history[symbol] = _bars(15)
+    for bar in _bars(30):
+        r._indicator_engine.ingest_historical_bar(symbol, bar)
+
+    result = r.sync_history_from_mdm(
+        symbol,
+        required_bars=30,
+        reason="selected_option_hydration",
+        role="selected_option",
+        request_if_short=False,
+    )
+
+    assert result.success is False
+    assert result.mdm_bars == 20
+    assert result.runner_bars == 20
+    assert result.failure_reason == "source_history_short"


### PR DESCRIPTION
### Motivation

- Selected-option hydration reported MDM having many historical bars while Runner/Indicator saw a much shorter live series, causing persistent SELECTED_OPTION_HYDRATION_NOT_READY despite broker-fetched history being present.
- Investigation showed MDM stored completed live bars under a non-normalized key while the canonical getter read only the normalized deque, and Runner used an implicit reseed condition that treated `indicator_count == source_count < required` as not needing action.
- The goal is a minimal, deterministic fix so MDM remains the single history owner and Runner reseeding uses an explicit, fail-closed readiness model.

### Description

- MarketDataManager: ensure completed live candles are appended using the canonical bar key and implement a pure read-time canonical getter that merges accepted broker-history rows and completed live-built candles, deduplicates by minute timestamp, sorts chronologically, excludes provisional current candles, preserves metadata, and applies `limit` after merge without mutating storage (`src/nifty_scalper_bot/data/market_data_manager.py`).
- Precedence and normalization: add `_bar_timestamp_key()` and `_completed_bar_precedence()` helpers to deterministically resolve timestamp collisions and prefer authoritative completed live candles over historical rows when timestamps coincide.
- StrategyRunner: replace the implicit reseed gating with explicit variables (`source_count`, `indicator_count`, `required_count`, `source_ready`, `indicator_ready`, `needs_seed`) and implement fail-closed behavior by setting `failure_reason = "source_history_short"` when source==indicator<required; reseed immediately when source supplies the required/seedable bars (`src/nifty_scalper_bot/strategies/runner.py`).
- Tests: add focused regression tests for canonical MDM merge/dedup/precedence/provisional/limit and Runner reseeding cases (new `tests/data/test_mdm_canonical_ohlc_merge.py` and extended `tests/strategies/test_canonical_runner_history_sync.py`).

### Testing

- Type-check/compile: `python -m compileall -q src` — succeeded.
- Focused unit tests: `pytest -q tests/data/test_mdm_canonical_ohlc_merge.py tests/strategies/test_canonical_runner_history_sync.py` — passed (all tests in those files green).
- Expanded validation: `pytest -q tests/core/test_history_readiness_ssot.py tests/core/test_runtime_history_orchestration.py tests/core/test_selected_option_exec_min_regression.py tests/test_selected_option_runner_sync.py tests/core/test_hydration_status_propagation.py tests/core/test_hydration_datahub_not_gating.py` — passed (all tests green).
- Full-suite smoke: `pytest -q tests/core`, `pytest -q tests/strategies`, and `pytest -q` — executed and passed (one existing skipped test in the upstream suite).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a55f75f69d4832494e3c27467bb9fbc)