### PR TITLE
PR-1: Fix tick-drain starvation exposure - canonical pipeline-overload entry gate

### DIFF
--- a/src/nifty_scalper_bot/data/data_hub.py
+++ b/src/nifty_scalper_bot/data/data_hub.py
@@ -1975,6 +1975,10 @@ class DataHub:
                 LOGGER.debug("probe_quote delegate failed for %s: %s", symbol, exc)
         return self.get_quote(symbol) or {}
 
+    @property
+    def pipeline_overloaded(self) -> bool:
+        return bool(getattr(self._mdm, "pipeline_overloaded", False))
+
     def get_ohlc_bars(self, symbol: str, *, limit: Optional[int] = None) -> list:
         mdm_fn = getattr(self._mdm, "get_ohlc_bars", None)
         if callable(mdm_fn):

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -466,6 +466,20 @@ class MarketDataManager:
         self._tick_dropped_by_priority: dict[str, int] = defaultdict(int)
         self._tick_max_active_drains = 0
         self._tick_active_drains = 0
+        # Canonical data-pipeline overload state (evidence: pending backlog +
+        # oldest pending tick age). While overloaded, NEW ENTRIES are blocked
+        # via the runner guard; protective exits, bracket monitoring and
+        # reconciliation are untouched.
+        self._overload_enter_pending = self._parse_int_env(
+            "MDM_TICK_OVERLOAD_PENDING", default=1000, minimum=50
+        )
+        self._overload_exit_pending = max(10, int(self._overload_enter_pending * 0.5))
+        self._overload_enter_oldest_ms = self._parse_float_env(
+            "MDM_TICK_OVERLOAD_OLDEST_MS", default=2000.0, minimum=100.0
+        )
+        self._overload_exit_oldest_ms = max(50.0, self._overload_enter_oldest_ms * 0.4)
+        self._pipeline_overloaded = False
+        self._overload_since_mono: float | None = None
         # Fallback worker thread for when no asyncio loop is registered
         # (e.g. early boot, polling-only mode).  Isolates the WS thread
         # from any processing work — the WS callback must only enqueue.
@@ -6129,6 +6143,7 @@ class MarketDataManager:
                 return
             tick["_mdm_priority"] = priority
             tick["_mdm_priority_bucket"] = bucket
+            tick.setdefault("_mdm_enqueued_mono", time.monotonic())
             if priority <= 2:
                 self._pending_tick_queues[key].append(tick)
                 self._bus_priority_counts[bucket] += 1
@@ -6154,6 +6169,7 @@ class MarketDataManager:
                     "pending_limit_far",
                 )
                 pending = self._pending_count_locked()
+            self._update_pipeline_overload_locked()
             self._schedule_tick_drain_locked(loop)
 
     def _pop_pending_tick_batch(self) -> list[dict[str, Any]]:
@@ -6245,6 +6261,7 @@ class MarketDataManager:
                     0.0, (time.monotonic() - drain_started) * 1000.0
                 )
                 self._tick_active_drains = max(0, self._tick_active_drains - 1)
+                self._update_pipeline_overload_locked()
                 has_more = self._pending_count_locked() > 0
                 self._tick_drain_scheduled = False
                 self._tick_drain_callbacks_completed += 1
@@ -6289,6 +6306,64 @@ class MarketDataManager:
                 with suppress(asyncio.CancelledError):
                     await task
         self._tick_drain_task = None
+
+    def _oldest_pending_age_ms_locked(self) -> float:
+        now = time.monotonic()
+        oldest: float | None = None
+        for queue in self._pending_tick_queues.values():
+            if queue:
+                ts = queue[0].get("_mdm_enqueued_mono")
+                if isinstance(ts, (int, float)) and (oldest is None or ts < oldest):
+                    oldest = float(ts)
+        for tick in self._pending_far_ticks.values():
+            ts = tick.get("_mdm_enqueued_mono")
+            if isinstance(ts, (int, float)) and (oldest is None or ts < oldest):
+                oldest = float(ts)
+        if oldest is None:
+            return 0.0
+        return max(0.0, (now - oldest) * 1000.0)
+
+    def _update_pipeline_overload_locked(self) -> None:
+        pending = self._pending_count_locked()
+        oldest_ms = self._oldest_pending_age_ms_locked()
+        if not self._pipeline_overloaded:
+            if (
+                pending >= self._overload_enter_pending
+                or oldest_ms >= self._overload_enter_oldest_ms
+            ):
+                self._pipeline_overloaded = True
+                self._overload_since_mono = time.monotonic()
+                self._logger.warning(
+                    "DATA_PIPELINE_OVERLOAD_ENTER pending_ticks=%d oldest_pending_age_ms=%.0f enter_pending=%d enter_oldest_ms=%.0f",
+                    pending, oldest_ms,
+                    self._overload_enter_pending, self._overload_enter_oldest_ms,
+                    extra={"event": "DATA_PIPELINE_OVERLOAD_ENTER",
+                           "pending_ticks": pending,
+                           "oldest_pending_age_ms": oldest_ms},
+                )
+        else:
+            # Hysteresis: recover only when BOTH signals are below exit bounds.
+            if (
+                pending <= self._overload_exit_pending
+                and oldest_ms <= self._overload_exit_oldest_ms
+            ):
+                duration = 0.0
+                if self._overload_since_mono is not None:
+                    duration = max(0.0, time.monotonic() - self._overload_since_mono)
+                self._pipeline_overloaded = False
+                self._overload_since_mono = None
+                self._logger.warning(
+                    "DATA_PIPELINE_OVERLOAD_RECOVERED pending_ticks=%d oldest_pending_age_ms=%.0f overloaded_for_s=%.1f",
+                    pending, oldest_ms, duration,
+                    extra={"event": "DATA_PIPELINE_OVERLOAD_RECOVERED",
+                           "pending_ticks": pending,
+                           "oldest_pending_age_ms": oldest_ms},
+                )
+
+    @property
+    def pipeline_overloaded(self) -> bool:
+        # True while the tick pipeline backlog exceeds safe bounds.
+        return bool(self._pipeline_overloaded)
 
     def get_tick_pressure_stats(self) -> dict[str, Any]:
         with self._pending_tick_lock:

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -14825,6 +14825,35 @@ class StrategyRunner:
                 # (materializing plans + order requests just to be rejected by
                 # the native gate wastes the event loop and floods logs —
                 # 2026-07-10 RCA: ORDER_PATH_ENTERED live_orders_armed=False).
+                _pipeline_overloaded = bool(
+                    getattr(self._market_data, "pipeline_overloaded", False)
+                    or getattr(self._data_hub, "pipeline_overloaded", False)
+                )
+                if _pipeline_overloaded:
+                    # DATA_PIPELINE_OVERLOAD: backlog/lag beyond safe bounds.
+                    # New entries stop here; protective exits, bracket
+                    # monitoring and reconciliation are untouched (they do
+                    # not pass through signal preparation).
+                    if self._should_log_throttled(
+                        f"signal_prep_overload:{symbol}", 30.0
+                    ):
+                        self._logger.warning(
+                            "RUNNER_SIGNAL_PREP_BLOCKED_OVERLOAD symbol=%s trace_id=%s broker_attempted=False",
+                            symbol,
+                            trace_id,
+                            extra={
+                                "event": "RUNNER_SIGNAL_PREP_BLOCKED_OVERLOAD",
+                                "symbol": symbol,
+                                "trace_id": trace_id,
+                            },
+                        )
+                    self._emit_runner_eval_decision(
+                        symbol=symbol,
+                        stage="phase10_execute",
+                        reason="data_pipeline_overloaded",
+                        allowed=False,
+                    )
+                    return
                 if getattr(self, "_live_mode", False) and not getattr(
                     self, "_runtime_live_orders_armed", True
                 ):

--- a/tests/data/test_mdm_tick_coalescing.py
+++ b/tests/data/test_mdm_tick_coalescing.py
@@ -712,3 +712,78 @@ def test_subscription_divergence_needs_grace_and_symbol_recovery(monkeypatch):
     mdm._check_zombie_ticks()
 
     assert restarted == [True]
+
+
+def test_pipeline_overload_enters_recovers_with_hysteresis() -> None:
+    """PR-1 item E: canonical overload state. Enters on pending backlog OR
+    oldest-pending age; recovers only when BOTH are below exit thresholds
+    (hysteresis). New entries consult MarketDataManager.pipeline_overloaded
+    via the runner signal-prep guard; exits never pass through that guard."""
+    import collections
+    import logging
+    import threading
+    import time as time_mod
+
+    from nifty_scalper_bot.data.market_data_manager import MarketDataManager
+
+    mdm = MarketDataManager.__new__(MarketDataManager)
+    mdm._logger = logging.getLogger("test")
+    mdm._pending_tick_lock = threading.Lock()
+    mdm._pending_tick_queues = collections.defaultdict(collections.deque)
+    mdm._pending_far_ticks = {}
+    mdm._overload_enter_pending = 5
+    mdm._overload_exit_pending = 2
+    mdm._overload_enter_oldest_ms = 2000.0
+    mdm._overload_exit_oldest_ms = 800.0
+    mdm._pipeline_overloaded = False
+    mdm._overload_since_mono = None
+    mdm._pending_count_locked = lambda: (
+        sum(len(q) for q in mdm._pending_tick_queues.values())
+        + len(mdm._pending_far_ticks)
+    )
+
+    now = time_mod.monotonic()
+    for i in range(6):
+        mdm._pending_tick_queues[f"s{i}"].append({"_mdm_enqueued_mono": now})
+    with mdm._pending_tick_lock:
+        mdm._update_pipeline_overload_locked()
+    assert mdm.pipeline_overloaded is True
+
+    for i in range(3):  # partially drained: still above exit bound
+        mdm._pending_tick_queues.pop(f"s{i}")
+    with mdm._pending_tick_lock:
+        mdm._update_pipeline_overload_locked()
+    assert mdm.pipeline_overloaded is True, "hysteresis must hold"
+
+    for i in range(3, 5):
+        mdm._pending_tick_queues.pop(f"s{i}")
+    with mdm._pending_tick_lock:
+        mdm._update_pipeline_overload_locked()
+    assert mdm.pipeline_overloaded is False
+
+    # Oldest-age evidence alone triggers even with tiny backlog.
+    mdm._pending_tick_queues["x"].append(
+        {"_mdm_enqueued_mono": time_mod.monotonic() - 3.0}
+    )
+    with mdm._pending_tick_lock:
+        mdm._update_pipeline_overload_locked()
+    assert mdm.pipeline_overloaded is True
+
+
+def test_runner_signal_prep_blocks_on_overload_before_unarmed_guard() -> None:
+    """The overload guard sits at the same choke point as the unarmed guard,
+    BEFORE _schedule_signal_preparation, and exits (bracket paths) never
+    reference it."""
+    import inspect
+
+    from nifty_scalper_bot.strategies.runner import StrategyRunner
+    from nifty_scalper_bot.execution import bracket_core
+
+    src = inspect.getsource(StrategyRunner)
+    i_over = src.index("RUNNER_SIGNAL_PREP_BLOCKED_OVERLOAD")
+    i_unarmed = src.index("RUNNER_SIGNAL_PREP_BLOCKED_UNARMED")
+    i_sched = src.index(
+        "scheduled, prepare_reason = self._schedule_signal_preparation"
+    )
+    assert i_over < i_unarmed < i_sched
+    assert "pipeline_overloaded" not in inspect.getsource(bracket_core)


### PR DESCRIPTION
PR 1 of the serial work order. Audit finding: the bounded-drain design (#874-#879) already implements priority batching, 8ms time slices, single-drain, coalescing and backpressure - not duplicated. The genuinely missing invariant was item E: sustained backlog never became a trading decision.

Added: canonical MDM overload state (pending backlog OR oldest-pending age to enter; BOTH below hysteresis bounds to recover; structured ENTER/RECOVERED events; env-tunable via safe parsing), DataHub proxy, and an entry guard at the existing runner signal-prep choke point (RUNNER_SIGNAL_PREP_BLOCKED_OVERLOAD) evaluated before the unarmed guard. Exits/bracket/reconciliation untouched (test-asserted: bracket_core has no overload reference).

Behavior before: tick_pending=2552 with lag 500-576ms while entry evaluation continued on stale context. After: same backlog blocks new entries with a structured reason until backlog AND age recover below hysteresis bounds.

Tests: state machine (enter/hold/recover/oldest-age), guard ordering, exit-isolation. tests/data + tests/strategies + full suite green, compileall clean. Non-goals: PRs 2-5 follow serially.