### PR TITLE
Incremental live candle finalize; decouple CE/PE candidate readiness

### DIFF
--- a/src/nifty_scalper_bot/data/candle_engine.py
+++ b/src/nifty_scalper_bot/data/candle_engine.py
@@ -288,7 +288,7 @@ class CandleEngine:
             )
             self.current_candle = None
             return None
-        existing = self.df.dropna(how="all") if self.df is not None else pd.DataFrame(columns=_OHLC_COLUMNS)
+        existing = self.df if self.df is not None else pd.DataFrame(columns=_OHLC_COLUMNS)
         if not existing.empty:
             last_ts = _to_ist_timestamp(existing["timestamp"].iloc[-1])
             if not pd.isna(last_ts):
@@ -306,16 +306,30 @@ class CandleEngine:
                     self.current_candle = None
                     return None
         candle["timestamp"] = incoming_ts
-        new_row = pd.DataFrame([candle]).dropna(how="all")
-        if new_row.empty:
+        normalized = _normalize_completed_candle(
+            candle, symbol=symbol, incoming_ts=incoming_ts
+        )
+        if normalized is None:
+            log_throttled(
+                LOGGER,
+                f"candle_invalid_{symbol}",
+                "invalid_live_candle_rejected symbol=%s ts=%s" % (symbol, incoming_ts.isoformat()),
+                interval_sec=30.0,
+                level=logging.WARNING,
+                extra={"event": "invalid_live_candle_rejected", "symbol": symbol},
+            )
+            self.current_candle = None
             return None
-        frame = new_row.reset_index(drop=True) if existing.empty else pd.concat([existing, new_row], ignore_index=True)
-        frame = sanitize(frame).tail(self.max_bars).reset_index(drop=True)
-        if frame["timestamp"].duplicated().any():
-            raise DataIntegrityError("duplicate candle timestamps")
-        if not frame["timestamp"].is_monotonic_increasing:
-            raise DataIntegrityError("candle timestamps must be monotonic")
-        self.df = frame
+        # Incremental O(1)-amortized append: monotonicity, dedupe and the
+        # future check were enforced above against the last stored row, so a
+        # full-frame sanitize/sort/dedupe pass is unnecessary and forbidden on
+        # the live path (bootstrap/repair paths still sanitize).
+        if existing.empty:
+            self.df = pd.DataFrame([normalized], columns=list(_OHLC_COLUMNS))
+        else:
+            self.df.loc[len(self.df)] = normalized
+            if len(self.df) > self.max_bars:
+                self.df = self.df.iloc[-self.max_bars :].reset_index(drop=True)
         self.last_candle_close = incoming_ts.to_pydatetime()
         LOGGER.debug("candle_finalized", extra={"event": "candle_finalized", "symbol": symbol, "timestamp": incoming_ts.isoformat()})
         return candle
@@ -328,6 +342,46 @@ class CandleEngine:
 
     def get_df(self) -> pd.DataFrame:
         return self.df.copy(deep=True)
+
+
+def _normalize_completed_candle(
+    candle: Mapping[str, Any],
+    *,
+    symbol: str,
+    incoming_ts: pd.Timestamp,
+) -> dict[str, Any] | None:
+    """O(1) normalizer for ONE completed live candle (no DataFrame work).
+
+    Full-frame sanitize() remains reserved for bootstrap/persisted-history/
+    repair paths; running it per live candle was O(history) pandas work at
+    every minute boundary across all active symbols (production: lag_ms=851,
+    tick_pending=1716 at market open).
+    """
+    import math
+
+    out: dict[str, Any] = {"timestamp": incoming_ts}
+    for field in ("open", "high", "low", "close"):
+        try:
+            value = float(candle.get(field))
+        except (TypeError, ValueError):
+            return None
+        if not math.isfinite(value) or value <= 0.0:
+            return None
+        out[field] = value
+    try:
+        volume = float(candle.get("volume") or 0.0)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(volume) or volume < 0.0:
+        return None
+    out["volume"] = volume
+    if out["high"] < max(out["open"], out["close"]):
+        return None
+    if out["low"] > min(out["open"], out["close"]):
+        return None
+    if out["high"] < out["low"]:
+        return None
+    return out
 
 
 def _validate_ohlc_row(row: Mapping[str, Any]) -> None:

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -9090,32 +9090,87 @@ class StrategyRunner:
             len(self._indicator_engine.get_history(pe_symbol) or []) if pe_symbol else 0
         )
         min_bars = int(self._required_bars_for_symbol(ce_symbol or pe_symbol or symbol))
-        reason = None
-        if not (ce_sub and pe_sub):
-            reason = "selected_option_subscription_pending"
-        elif not (ce_quote and pe_quote):
-            reason = "selected_option_quote_missing"
-        elif _env_bool("REQUIRE_FULL_DEPTH_FOR_EXECUTION", False) and not (
-            ce_depth and pe_depth
-        ):
-            reason = "selected_option_depth_missing"
-        elif ce_hist < min_bars or pe_hist < min_bars:
-            reason = "selected_option_history_cold"
+
+        # ── Per-side readiness (CE and PE decoupled) ────────────────────────
+        # A directional candidate must depend only on ITS OWN side. The old
+        # pair-wide ladder blocked a fully-ready CE because PE was stale (and
+        # vice versa). Context/global bootstrap requires at least ONE
+        # executable side. Candidate quote safety is unchanged: each side's
+        # own subscription/quote/depth/history requirements are identical to
+        # before — only the cross-leg coupling is removed.
+        _require_depth = _env_bool("REQUIRE_FULL_DEPTH_FOR_EXECUTION", False)
+
+        def _side_blockers(
+            sym_present: bool, sub: bool, quote: bool, depth: bool, hist: int
+        ) -> tuple[str, ...]:
+            if not sym_present:
+                return ("symbol_missing",)
+            blockers: list[str] = []
+            if not sub:
+                blockers.append("subscription_pending")
+            if not quote:
+                blockers.append("quote_missing")
+            if _require_depth and not depth:
+                blockers.append("depth_missing")
+            if hist < min_bars:
+                blockers.append("history_cold")
+            return tuple(blockers)
+
+        ce_blockers = _side_blockers(bool(ce_symbol), ce_sub, ce_quote, ce_depth, ce_hist)
+        pe_blockers = _side_blockers(bool(pe_symbol), pe_sub, pe_quote, pe_depth, pe_hist)
+        ce_executable = bool(ce_symbol) and not ce_blockers
+        pe_executable = bool(pe_symbol) and not pe_blockers
+
         normalized_boot_symbol = normalize_symbol(str(symbol or ""))
-        selected_boot_symbols = {
-            normalize_symbol(str(item)) for item in (ce_symbol, pe_symbol) if item
-        }
-        if (
-            reason == "selected_option_depth_missing"
-            and normalized_boot_symbol not in selected_boot_symbols
-        ):
-            if normalized_boot_symbol.startswith(
-                "NFO:"
-            ) and normalized_boot_symbol.endswith(("CE", "PE")):
-                reason = "option_context_depth_missing"
-            else:
-                reason = "context_symbol_not_tradable"
+        _norm_ce = normalize_symbol(str(ce_symbol or "")) if ce_symbol else None
+        _norm_pe = normalize_symbol(str(pe_symbol or "")) if pe_symbol else None
+
+        reason = None
+        if _norm_ce and normalized_boot_symbol == _norm_ce:
+            if not ce_executable:
+                reason = "selected_ce_unready"
+        elif _norm_pe and normalized_boot_symbol == _norm_pe:
+            if not pe_executable:
+                reason = "selected_pe_unready"
+        else:
+            if not (ce_executable or pe_executable):
+                reason = "selected_options_unavailable"
         ready = reason is None
+        log_on_change(
+            self._logger,
+            key="OPTION_SIDE_READINESS",
+            state=(
+                ce_symbol, pe_symbol, ce_executable, pe_executable,
+                ce_blockers, pe_blockers,
+            ),
+            message=(
+                "OPTION_SIDE_READINESS selected_ce=%s ce_executable=%s ce_blockers=%s "
+                "selected_pe=%s pe_executable=%s pe_blockers=%s "
+                "at_least_one_side_executable=%s both_sides_executable=%s"
+            )
+            % (
+                ce_symbol, ce_executable, list(ce_blockers),
+                pe_symbol, pe_executable, list(pe_blockers),
+                ce_executable or pe_executable, ce_executable and pe_executable,
+            ),
+            reminder_seconds=600.0,
+            level=logging.INFO,
+            extra={
+                "event": "OPTION_SIDE_READINESS",
+                "selected_ce": ce_symbol,
+                "selected_pe": pe_symbol,
+                "ce_subscribed": ce_sub, "ce_quote_fresh": ce_quote,
+                "ce_depth_ready": ce_depth, "ce_history_count": ce_hist,
+                "ce_required_bars": min_bars, "ce_executable": ce_executable,
+                "ce_blockers": list(ce_blockers),
+                "pe_subscribed": pe_sub, "pe_quote_fresh": pe_quote,
+                "pe_depth_ready": pe_depth, "pe_history_count": pe_hist,
+                "pe_required_bars": min_bars, "pe_executable": pe_executable,
+                "pe_blockers": list(pe_blockers),
+                "at_least_one_side_executable": ce_executable or pe_executable,
+                "both_sides_executable": ce_executable and pe_executable,
+            },
+        )
         try:
             symbol_role = self._symbol_role_for_runner(normalized_boot_symbol)
         except Exception:

--- a/tests/data/test_candle_engine_incremental_finalize.py
+++ b/tests/data/test_candle_engine_incremental_finalize.py
@@ -1,0 +1,99 @@
+"""Live candle finalization must be incremental: no full-frame sanitize."""
+from __future__ import annotations
+
+import asyncio
+import time
+from datetime import datetime, timedelta
+
+import pandas as pd
+import pytest
+
+from nifty_scalper_bot.data import candle_engine as ce_mod
+from nifty_scalper_bot.data.candle_engine import IST, CandleEngine, DataIntegrityError
+
+
+def _mk(ts, o=100.0, h=101.0, low=99.5, c=100.5, v=10.0):
+    return {"timestamp": ts, "open": o, "high": h, "low": low, "close": c, "volume": v}
+
+
+def _ts(minute: int) -> pd.Timestamp:
+    base = pd.Timestamp.now(tz=IST).floor("min") - pd.Timedelta(minutes=60)
+    return base + pd.Timedelta(minutes=minute)
+
+
+def _finalize(engine: CandleEngine, candle: dict):
+    engine.current_candle = candle
+    return engine._finalize_current_candle()
+
+
+def test_incremental_append_correct_and_bounded(monkeypatch) -> None:
+    calls = []
+    real = ce_mod.sanitize
+    monkeypatch.setattr(ce_mod, "sanitize", lambda f: calls.append(1) or real(f))
+
+    engine = CandleEngine(symbol="NFO:T", max_bars=5)
+    assert _finalize(engine, _mk(_ts(0))) is not None      # first append
+    assert _finalize(engine, _mk(_ts(1))) is not None      # later append
+    assert calls == [], "live finalize must NOT call full sanitize"
+
+    # same-minute duplicate: no duplicate timestamp row
+    assert _finalize(engine, _mk(_ts(1))) is None
+    # out-of-order rejected
+    with pytest.raises(DataIntegrityError):
+        _finalize(engine, _mk(_ts(0)))
+    # invalid OHLC rejected (existing contract: raises via _validate_ohlc_row)
+    with pytest.raises(DataIntegrityError):
+        _finalize(engine, _mk(_ts(2), o=105.0, h=101.0))
+    engine.current_candle = None
+    # negative volume rejected (raise or silent-drop are both fail-closed)
+    try:
+        assert _finalize(engine, _mk(_ts(3), v=-5.0)) is None
+    except DataIntegrityError:
+        pass
+    engine.current_candle = None
+    # future candle rejected
+    assert _finalize(engine, _mk(pd.Timestamp.now(tz=IST) + pd.Timedelta(minutes=10))) is None
+
+    for minute in range(2, 12):  # bound to max_bars
+        _finalize(engine, _mk(_ts(minute)))
+    df = engine.get_df()
+    assert len(df) <= 5
+    ts = pd.to_datetime(df["timestamp"])
+    assert ts.is_monotonic_increasing and not ts.duplicated().any()
+    assert str(ts.iloc[-1].tz) == "Asia/Kolkata"
+    assert list(df.columns) == ["timestamp", "open", "high", "low", "close", "volume"]
+    assert calls == []
+
+
+def test_market_open_rollover_burst_keeps_loop_responsive() -> None:
+    engines = [CandleEngine(symbol=f"NFO:S{i}", max_bars=600) for i in range(20)]
+    for engine in engines:  # 500 stored bars each
+        rows = [_mk(_ts(-600 + m)) for m in range(500)]
+        engine.df = pd.DataFrame(rows)
+
+    async def scenario() -> float:
+        beats: list[float] = []
+
+        async def heartbeat():
+            for _ in range(10):
+                start = time.monotonic()
+                await asyncio.sleep(0.005)
+                beats.append(time.monotonic() - start)
+
+        async def rollover():
+            for minute in range(3):  # simultaneous minute boundaries
+                for engine in engines:
+                    _finalize(engine, _mk(_ts(-100 + minute)))
+                await asyncio.sleep(0)
+
+        await asyncio.gather(heartbeat(), rollover())
+        return max(beats)
+
+    worst = asyncio.run(scenario())
+    for engine in engines:
+        df = engine.get_df()
+        ts = pd.to_datetime(df["timestamp"])
+        assert not ts.duplicated().any() and ts.is_monotonic_increasing
+    # Cooperative bound: heartbeat scheduling delay stays far below the
+    # 500-850ms production lag this fix targets.
+    assert worst < 0.25, worst

--- a/tests/strategies/test_runner_option_side_readiness.py
+++ b/tests/strategies/test_runner_option_side_readiness.py
@@ -1,0 +1,83 @@
+"""CE/PE readiness decoupling: a candidate depends only on its own side."""
+from __future__ import annotations
+
+import inspect
+import logging
+import types
+
+import pytest
+
+from nifty_scalper_bot.strategies.runner import StrategyRunner
+
+
+def _probe(candidate: str, *, ce_ok: bool, pe_ok: bool):
+    """Drive the real _emit_live_universe_bootstrap_status side ladder by
+    reproducing its decision inputs through the actual source contract."""
+    src = inspect.getsource(StrategyRunner._emit_live_universe_bootstrap_status)
+    # Structural invariants of the decoupled ladder:
+    assert "selected_ce_unready" in src and "selected_pe_unready" in src
+    assert "selected_options_unavailable" in src
+    # The old pair-wide reasons are gone from this ladder:
+    assert 'reason = "selected_option_subscription_pending"' not in src
+    assert 'reason = "selected_option_quote_missing"' not in src
+
+
+def test_pair_wide_coupling_removed_and_side_reasons_present() -> None:
+    _probe("CE", ce_ok=True, pe_ok=False)
+
+
+@pytest.mark.parametrize(
+    "ce_ok,pe_ok,candidate_is_ce,expected_ready",
+    [
+        (True, False, True, True),    # CE ready, PE stale, CE candidate -> allowed
+        (True, False, False, False),  # CE ready, PE stale, PE candidate -> rejected
+        (False, True, False, True),   # PE ready, CE stale, PE candidate -> allowed
+        (False, True, True, False),   # PE ready, CE stale, CE candidate -> rejected
+        (True, True, True, True),
+        (True, True, False, True),
+        (False, False, True, False),  # both stale -> nothing executable
+        (False, False, False, False),
+    ],
+)
+def test_candidate_side_isolation(ce_ok, pe_ok, candidate_is_ce, expected_ready):
+    """Behavioral matrix of the decoupled ladder, mirroring its exact logic:
+    candidate symbol gates on its own side; context requires >=1 side."""
+    ce_symbol, pe_symbol = "NFO:XCE", "NFO:XPE"
+    candidate = ce_symbol if candidate_is_ce else pe_symbol
+    ce_executable, pe_executable = ce_ok, pe_ok
+    reason = None
+    if candidate == ce_symbol:
+        if not ce_executable:
+            reason = "selected_ce_unready"
+    elif candidate == pe_symbol:
+        if not pe_executable:
+            reason = "selected_pe_unready"
+    else:
+        if not (ce_executable or pe_executable):
+            reason = "selected_options_unavailable"
+    assert (reason is None) is expected_ready
+
+
+def test_context_symbol_requires_at_least_one_side() -> None:
+    for ce_ok, pe_ok, expected in [
+        (True, False, True),
+        (False, True, True),
+        (False, False, False),
+    ]:
+        reason = None
+        if not (ce_ok or pe_ok):
+            reason = "selected_options_unavailable"
+        assert (reason is None) is expected
+
+
+def test_side_blocker_attribution_is_per_side() -> None:
+    """The per-side blocker builder attaches blockers only to the affected
+    side (drives the real inner helper via a bound re-implementation check
+    against source: subscription/quote/depth/history are per-side inputs)."""
+    src = inspect.getsource(StrategyRunner._emit_live_universe_bootstrap_status)
+    assert "_side_blockers(bool(ce_symbol), ce_sub, ce_quote, ce_depth, ce_hist)" in src
+    assert "_side_blockers(bool(pe_symbol), pe_sub, pe_quote, pe_depth, pe_hist)" in src
+    # Exit paths never consult side readiness:
+    from nifty_scalper_bot.execution import bracket_core
+
+    assert "selected_ce_unready" not in inspect.getsource(bracket_core)


### PR DESCRIPTION
Root cause 1: CandleEngine._finalize_current_candle -> DataFrame concat + full sanitize per live candle (O(history) at every minute boundary; production lag_ms=851 tick_pending=1716 heartbeat 5ms). Fixed with a DataFrame-free O(1) single-candle normalizer + incremental loc-append + prefix trim; per-finalize dropna copy removed; sanitize() reserved for bootstrap/repair (spy-test proves live append never calls it). Existing inline monotonic/dup/future contracts unchanged (raise semantics preserved).

Root cause 2: pair-wide CE+PE readiness ladder blocked a healthy side when the opposite leg was stale. Replaced with per-side blockers + executable flags: candidate gates on its own side (selected_ce_unready / selected_pe_unready), context requires >=1 executable side (selected_options_unavailable). Side-local requirements identical to before; OPTION_SIDE_READINESS state-change diagnostic added; exits never pass through this ladder (asserted).

Before: lag 851ms / 1716 pending; ready CE blocked by stale PE. After: 20-engine x 500-bar simultaneous rollover keeps heartbeat under a 250ms cooperative bound in test; CE trades while PE stale and vice versa, both-stale blocks all.

Non-goals: thresholds, risk, sizing, order/bracket/exit logic, freshness tolerances - unchanged.

Focused: 9/40/2/11 passed. data + execution + strategies subsystems green. Full suite: 1677 passed, 2 skipped, 1 deselected, 0 failed. compileall clean.