### PR TITLE
CandleEngine: O(1) deque-backed live candles and candidate option-side readiness gate

### DIFF
--- a/src/nifty_scalper_bot/data/candle_engine.py
+++ b/src/nifty_scalper_bot/data/candle_engine.py
@@ -524,7 +524,7 @@ class CandleEngine:
                 "timestamp": incoming_ts.isoformat(),
             },
         )
-        return dict(normalized)
+        return normalized
 
     def flush(self) -> dict[str, Any] | None:
         finalized = self._finalize_current_candle()

--- a/src/nifty_scalper_bot/data/candle_engine.py
+++ b/src/nifty_scalper_bot/data/candle_engine.py
@@ -122,7 +122,15 @@ def _tick_timestamp(tick: Mapping[str, Any] | Tick) -> tuple[pd.Timestamp, str, 
 
 @dataclass(slots=True, init=False)
 class CandleEngine:
-    """Build deterministic 1-minute candles from validated ticks."""
+    """Build deterministic 1-minute candles from validated ticks.
+
+    ``df`` is a read-only compatibility alias for ``get_df()``. The getter
+    returns a defensive copy; mutating that DataFrame does not mutate this
+    engine. Whole-history replacement remains supported through ``engine.df =``
+    assignment or the explicit ``replace_history()`` method. Arbitrary pandas
+    in-place mutation is intentionally not proxied because the deque is the live
+    candle source of truth.
+    """
 
     interval: str = "1min"
     max_bars: int = 500
@@ -161,15 +169,26 @@ class CandleEngine:
         self._same_minute_idempotent_total = 0
         self._same_minute_conflict_total = 0
         if df is not None and not df.empty:
-            self._replace_completed_candles(df)
+            self.replace_history(df)
 
     @property
     def df(self) -> pd.DataFrame:
-        return self._cached_df_copy()
+        """Read-only compatibility alias for ``get_df()``.
+
+        The returned DataFrame is a defensive copy. Mutating it with ``loc``,
+        ``iloc``, column assignment, or ``inplace=True`` operations does not
+        mutate CandleEngine. Use ``replace_history()`` or ``engine.df = frame``
+        for whole-frame replacement.
+        """
+        return self.get_df()
 
     @df.setter
     def df(self, value: pd.DataFrame | None) -> None:
-        self._replace_completed_candles(value)
+        self.replace_history(value)
+
+    def replace_history(self, frame: pd.DataFrame | None) -> None:
+        """Sanitize and atomically replace the bounded candle store."""
+        self._replace_completed_candles(frame)
 
     def _replace_completed_candles(self, value: pd.DataFrame | None) -> None:
         self._completed_candles.clear()
@@ -514,6 +533,7 @@ class CandleEngine:
         return finalized
 
     def get_df(self) -> pd.DataFrame:
+        """Return a defensive canonical OHLCV copy."""
         return self._cached_df_copy()
 
 
@@ -531,14 +551,14 @@ def _normalize_completed_candle(
     tick_pending=1716 at market open).
     """
     out: dict[str, Any] = {"timestamp": incoming_ts}
-    for field in ("open", "high", "low", "close"):
+    for ohlcv_field in ("open", "high", "low", "close"):
         try:
-            value = float(candle.get(field))
+            value = float(candle.get(ohlcv_field))
         except (TypeError, ValueError):
             return None
         if not math.isfinite(value) or value <= 0.0:
             return None
-        out[field] = value
+        out[ohlcv_field] = value
     try:
         volume = float(candle.get("volume") or 0.0)
     except (TypeError, ValueError):
@@ -560,11 +580,11 @@ def _candles_equivalent(left: Mapping[str, Any], right: Mapping[str, Any]) -> bo
         right.get("timestamp")
     ):
         return False
-    for field in ("open", "high", "low", "close", "volume"):
+    for ohlcv_field in ("open", "high", "low", "close", "volume"):
         try:
             if not math.isclose(
-                float(left.get(field)),
-                float(right.get(field)),
+                float(left.get(ohlcv_field)),
+                float(right.get(ohlcv_field)),
                 rel_tol=1e-12,
                 abs_tol=1e-9,
             ):
@@ -696,5 +716,5 @@ def ensure_valid_data(
             },
         )
         return None
-    engine.df = hydrated.tail(engine.max_bars).reset_index(drop=True)
+    engine.replace_history(hydrated.tail(engine.max_bars).reset_index(drop=True))
     return engine.get_df()

--- a/src/nifty_scalper_bot/data/candle_engine.py
+++ b/src/nifty_scalper_bot/data/candle_engine.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import logging
+import math
 import os
 import time
+from collections import deque
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any, Callable, Mapping
@@ -38,7 +40,9 @@ def _to_ist_timestamp(value: Any) -> pd.Timestamp:
 
 def _future_grace_seconds() -> float:
     try:
-        return max(float(os.getenv("MARKETDATA_MAX_FUTURE_CANDLE_SECONDS", "120") or 120), 0.0)
+        return max(
+            float(os.getenv("MARKETDATA_MAX_FUTURE_CANDLE_SECONDS", "120") or 120), 0.0
+        )
     except (TypeError, ValueError):
         return 120.0
 
@@ -47,7 +51,9 @@ def _is_future_timestamp(ts: pd.Timestamp, *, now: pd.Timestamp | None = None) -
     if pd.isna(ts):
         return False
     now_ts = now or pd.Timestamp.now(tz=IST)
-    return is_future_market_timestamp(ts, now=now_ts, grace_seconds=_future_grace_seconds())
+    return is_future_market_timestamp(
+        ts, now=now_ts, grace_seconds=_future_grace_seconds()
+    )
 
 
 def _series_to_ist(values: Any) -> pd.Series:
@@ -71,14 +77,20 @@ def sanitize(df: pd.DataFrame | None) -> pd.DataFrame:
     if future_dropped:
         LOGGER.warning(
             "future_candle_rejected",
-            extra={"event": "future_candle_rejected", "source": "sanitize", "dropped_rows": future_dropped},
+            extra={
+                "event": "future_candle_rejected",
+                "source": "sanitize",
+                "dropped_rows": future_dropped,
+            },
         )
         cleaned = cleaned.loc[~future_mask]
     cleaned = cleaned.drop_duplicates(subset="timestamp", keep="last")
     cleaned = cleaned.sort_values("timestamp").reset_index(drop=True)
     dropped = before - len(cleaned)
     if dropped > 0:
-        LOGGER.warning("tick_invalid", extra={"event": "tick_invalid", "dropped_rows": dropped})
+        LOGGER.warning(
+            "tick_invalid", extra={"event": "tick_invalid", "dropped_rows": dropped}
+        )
     return cleaned[list(_OHLC_COLUMNS)]
 
 
@@ -89,7 +101,11 @@ def _tick_value(tick: Mapping[str, Any] | Tick, key: str, default: Any = None) -
 
 
 def _tick_symbol(tick: Mapping[str, Any] | Tick, engine_symbol: str | None) -> str:
-    value = _tick_value(tick, "symbol") or _tick_value(tick, "trading_symbol") or engine_symbol
+    value = (
+        _tick_value(tick, "symbol")
+        or _tick_value(tick, "trading_symbol")
+        or engine_symbol
+    )
     return normalized_symbol(value)
 
 
@@ -97,20 +113,101 @@ def _tick_timestamp(tick: Mapping[str, Any] | Tick) -> tuple[pd.Timestamp, str, 
     if isinstance(tick, Mapping):
         normalized_ts = normalize_market_tick_timestamp(tick)
         return normalized_ts.timestamp, normalized_ts.source, normalized_ts.raw_value
-    return coerce_market_timestamp(tick.timestamp), getattr(tick, "timestamp_source", "tick.timestamp"), tick.timestamp
+    return (
+        coerce_market_timestamp(tick.timestamp),
+        getattr(tick, "timestamp_source", "tick.timestamp"),
+        tick.timestamp,
+    )
 
 
-@dataclass(slots=True)
+@dataclass(slots=True, init=False)
 class CandleEngine:
     """Build deterministic 1-minute candles from validated ticks."""
 
     interval: str = "1min"
     max_bars: int = 500
-    df: pd.DataFrame = field(default_factory=lambda: pd.DataFrame(columns=_OHLC_COLUMNS))
     current_candle: dict[str, Any] | None = None
     last_candle_close: datetime | None = None
     _last_tick_ts: pd.Timestamp | None = None
     symbol: str | None = None
+    _completed_candles: deque[dict[str, Any]] = field(init=False, repr=False)
+    _df_cache: pd.DataFrame | None = field(default=None, init=False, repr=False)
+    _df_cache_dirty: bool = field(default=True, init=False, repr=False)
+    _df_cache_rebuild_total: int = field(default=0, init=False)
+    _live_append_total: int = field(default=0, init=False)
+    _same_minute_idempotent_total: int = field(default=0, init=False)
+    _same_minute_conflict_total: int = field(default=0, init=False)
+
+    def __init__(
+        self,
+        interval: str = "1min",
+        max_bars: int = 500,
+        df: pd.DataFrame | None = None,
+        current_candle: dict[str, Any] | None = None,
+        last_candle_close: datetime | None = None,
+        symbol: str | None = None,
+    ) -> None:
+        self.interval = interval
+        self.max_bars = max_bars
+        self.current_candle = current_candle
+        self.last_candle_close = last_candle_close
+        self._last_tick_ts = None
+        self.symbol = symbol
+        self._completed_candles = deque(maxlen=int(self.max_bars))
+        self._df_cache = None
+        self._df_cache_dirty = True
+        self._df_cache_rebuild_total = 0
+        self._live_append_total = 0
+        self._same_minute_idempotent_total = 0
+        self._same_minute_conflict_total = 0
+        if df is not None and not df.empty:
+            self._replace_completed_candles(df)
+
+    @property
+    def df(self) -> pd.DataFrame:
+        return self._cached_df_copy()
+
+    @df.setter
+    def df(self, value: pd.DataFrame | None) -> None:
+        self._replace_completed_candles(value)
+
+    def _replace_completed_candles(self, value: pd.DataFrame | None) -> None:
+        self._completed_candles.clear()
+        clean = (
+            sanitize(value)
+            if value is not None
+            else pd.DataFrame(columns=_OHLC_COLUMNS)
+        )
+        for row in clean.tail(self.max_bars).to_dict(orient="records"):
+            ts = _to_ist_timestamp(row.get("timestamp"))
+            if pd.isna(ts):
+                continue
+            normalized = _normalize_completed_candle(
+                row, symbol=self.symbol or "symbol_unset", incoming_ts=ts
+            )
+            if normalized is not None:
+                self._completed_candles.append(normalized)
+        self._df_cache_dirty = True
+
+    def _cached_df_copy(self) -> pd.DataFrame:
+        if self._df_cache_dirty or self._df_cache is None:
+            self._df_cache = pd.DataFrame(
+                list(self._completed_candles), columns=list(_OHLC_COLUMNS)
+            )
+            self._df_cache_dirty = False
+            self._df_cache_rebuild_total += 1
+        return self._df_cache.copy(deep=True)
+
+    def diagnostics(self) -> dict[str, Any]:
+        return {
+            "candle_store_size": len(self._completed_candles),
+            "candle_store_maxlen": self._completed_candles.maxlen,
+            "df_cache_dirty": self._df_cache_dirty,
+            "df_cache_rebuild_total": self._df_cache_rebuild_total,
+            "live_append_total": self._live_append_total,
+            "same_minute_idempotent_total": self._same_minute_idempotent_total,
+            "same_minute_conflict_total": self._same_minute_conflict_total,
+        }
 
     def on_tick(self, tick: Mapping[str, Any]) -> dict[str, Any] | None:
         if self.interval != "1min":
@@ -183,7 +280,14 @@ class CandleEngine:
                     "CANDLE_TICK_DROPPED reason=future_timestamp symbol=%s raw_ts=%r "
                     "tick_ts_ist=%s now_ist=%s future_by_sec=%.3f timestamp_source=%s"
                 )
-                % (symbol, raw_ts, timestamp.isoformat(), now_ist.isoformat(), future_by_sec, timestamp_source),
+                % (
+                    symbol,
+                    raw_ts,
+                    timestamp.isoformat(),
+                    now_ist.isoformat(),
+                    future_by_sec,
+                    timestamp_source,
+                ),
                 interval_sec=30.0,
                 level=logging.WARNING,
                 extra={
@@ -212,7 +316,8 @@ class CandleEngine:
                 log_throttled(
                     LOGGER,
                     f"tick_out_of_order_{symbol}",
-                    "tick_out_of_order symbol=%s tick_ts=%s last_ts=%s" % (symbol, timestamp.isoformat(), last_ts.isoformat()),
+                    "tick_out_of_order symbol=%s tick_ts=%s last_ts=%s"
+                    % (symbol, timestamp.isoformat(), last_ts.isoformat()),
                     interval_sec=10.0,
                     level=logging.DEBUG,
                 )
@@ -221,14 +326,22 @@ class CandleEngine:
         finalized: dict[str, Any] | None = None
         if self.current_candle is None:
             self.current_candle = self._start_candle(payload, minute)
-            LOGGER.debug("candle_created", extra={"event": "candle_created", "symbol": symbol, "minute": minute.isoformat()})
+            LOGGER.debug(
+                "candle_created",
+                extra={
+                    "event": "candle_created",
+                    "symbol": symbol,
+                    "minute": minute.isoformat(),
+                },
+            )
         else:
             current_minute = _to_ist_timestamp(self.current_candle["timestamp"])
             if minute < current_minute:
                 log_throttled(
                     LOGGER,
                     f"tick_out_of_order_minute_{symbol}",
-                    "tick_out_of_order symbol=%s tick_minute=%s current_minute=%s" % (symbol, minute.isoformat(), current_minute.isoformat()),
+                    "tick_out_of_order symbol=%s tick_minute=%s current_minute=%s"
+                    % (symbol, minute.isoformat(), current_minute.isoformat()),
                     interval_sec=10.0,
                     level=logging.DEBUG,
                 )
@@ -236,15 +349,31 @@ class CandleEngine:
             if minute > current_minute:
                 finalized = self._finalize_current_candle()
                 self.current_candle = self._start_candle(payload, minute)
-                LOGGER.debug("candle_created", extra={"event": "candle_created", "symbol": symbol, "minute": minute.isoformat()})
+                LOGGER.debug(
+                    "candle_created",
+                    extra={
+                        "event": "candle_created",
+                        "symbol": symbol,
+                        "minute": minute.isoformat(),
+                    },
+                )
             else:
                 self._update_candle(payload)
         self._last_tick_ts = timestamp
         return finalized
 
-    def _start_candle(self, tick: Mapping[str, Any], minute: pd.Timestamp) -> dict[str, Any]:
+    def _start_candle(
+        self, tick: Mapping[str, Any], minute: pd.Timestamp
+    ) -> dict[str, Any]:
         price = float(tick["ltp"])
-        return {"timestamp": minute, "open": price, "high": price, "low": price, "close": price, "volume": float(tick.get("volume") or 0.0)}
+        return {
+            "timestamp": minute,
+            "open": price,
+            "high": price,
+            "low": price,
+            "close": price,
+            "volume": float(tick.get("volume") or 0.0),
+        }
 
     def _update_candle(self, tick: Mapping[str, Any]) -> None:
         if self.current_candle is None:
@@ -253,7 +382,9 @@ class CandleEngine:
         self.current_candle["high"] = max(float(self.current_candle["high"]), price)
         self.current_candle["low"] = min(float(self.current_candle["low"]), price)
         self.current_candle["close"] = price
-        self.current_candle["volume"] = float(self.current_candle["volume"]) + float(tick.get("volume") or 0.0)
+        self.current_candle["volume"] = float(self.current_candle["volume"]) + float(
+            tick.get("volume") or 0.0
+        )
 
     def _finalize_current_candle(self) -> dict[str, Any] | None:
         if self.current_candle is None:
@@ -288,23 +419,27 @@ class CandleEngine:
             )
             self.current_candle = None
             return None
-        existing = self.df if self.df is not None else pd.DataFrame(columns=_OHLC_COLUMNS)
-        if not existing.empty:
-            last_ts = _to_ist_timestamp(existing["timestamp"].iloc[-1])
+        if self._completed_candles:
+            last = self._completed_candles[-1]
+            last_ts = _to_ist_timestamp(last.get("timestamp"))
             if not pd.isna(last_ts):
                 if incoming_ts < last_ts:
                     log_throttled(
                         LOGGER,
                         f"candle_out_of_order_{symbol}",
-                        "candle_out_of_order symbol=%s incoming_ts=%s last_ts=%s source=candle_engine" % (symbol, incoming_ts.isoformat(), last_ts.isoformat()),
+                        "candle_out_of_order symbol=%s incoming_ts=%s last_ts=%s source=candle_engine"
+                        % (symbol, incoming_ts.isoformat(), last_ts.isoformat()),
                         interval_sec=30.0,
                         level=logging.WARNING,
-                        extra={"event": "candle_out_of_order", "symbol": symbol, "incoming_ts": incoming_ts.isoformat(), "last_ts": last_ts.isoformat(), "source": "candle_engine"},
+                        extra={
+                            "event": "candle_out_of_order",
+                            "symbol": symbol,
+                            "incoming_ts": incoming_ts.isoformat(),
+                            "last_ts": last_ts.isoformat(),
+                            "source": "candle_engine",
+                        },
                     )
                     raise DataIntegrityError("candle timestamps must be monotonic")
-                if incoming_ts == last_ts:
-                    self.current_candle = None
-                    return None
         candle["timestamp"] = incoming_ts
         normalized = _normalize_completed_candle(
             candle, symbol=symbol, incoming_ts=incoming_ts
@@ -313,26 +448,64 @@ class CandleEngine:
             log_throttled(
                 LOGGER,
                 f"candle_invalid_{symbol}",
-                "invalid_live_candle_rejected symbol=%s ts=%s" % (symbol, incoming_ts.isoformat()),
+                "invalid_live_candle_rejected symbol=%s ts=%s"
+                % (symbol, incoming_ts.isoformat()),
                 interval_sec=30.0,
                 level=logging.WARNING,
                 extra={"event": "invalid_live_candle_rejected", "symbol": symbol},
             )
             self.current_candle = None
             return None
-        # Incremental O(1)-amortized append: monotonicity, dedupe and the
-        # future check were enforced above against the last stored row, so a
-        # full-frame sanitize/sort/dedupe pass is unnecessary and forbidden on
-        # the live path (bootstrap/repair paths still sanitize).
-        if existing.empty:
-            self.df = pd.DataFrame([normalized], columns=list(_OHLC_COLUMNS))
-        else:
-            self.df.loc[len(self.df)] = normalized
-            if len(self.df) > self.max_bars:
-                self.df = self.df.iloc[-self.max_bars :].reset_index(drop=True)
+        if self._completed_candles:
+            last = self._completed_candles[-1]
+            last_ts = _to_ist_timestamp(last.get("timestamp"))
+            if not pd.isna(last_ts) and incoming_ts == last_ts:
+                if _candles_equivalent(last, normalized):
+                    self._same_minute_idempotent_total += 1
+                    self.current_candle = None
+                    return None
+                self._same_minute_conflict_total += 1
+                log_throttled(
+                    LOGGER,
+                    f"finalized_candle_conflict_{symbol}_{incoming_ts.isoformat()}",
+                    "FINALIZED_CANDLE_CONFLICT symbol=%s timestamp=%s"
+                    % (symbol, incoming_ts.isoformat()),
+                    interval_sec=30.0,
+                    level=logging.ERROR,
+                    extra={
+                        "event": "FINALIZED_CANDLE_CONFLICT",
+                        "symbol": symbol,
+                        "timestamp": incoming_ts.isoformat(),
+                        "stored_ohlcv": {
+                            k: last.get(k)
+                            for k in ("open", "high", "low", "close", "volume")
+                        },
+                        "incoming_ohlcv": {
+                            k: normalized.get(k)
+                            for k in ("open", "high", "low", "close", "volume")
+                        },
+                    },
+                )
+                self.current_candle = None
+                raise DataIntegrityError(
+                    f"conflicting finalized candle symbol={symbol} timestamp={incoming_ts}"
+                )
+        # Live completed candles are stored in a bounded row-oriented deque.
+        # Avoid DataFrame row insertion/concat here; pandas frames are rebuilt
+        # lazily only for compatibility readers.
+        self._completed_candles.append(normalized)
+        self._df_cache_dirty = True
+        self._live_append_total += 1
         self.last_candle_close = incoming_ts.to_pydatetime()
-        LOGGER.debug("candle_finalized", extra={"event": "candle_finalized", "symbol": symbol, "timestamp": incoming_ts.isoformat()})
-        return candle
+        LOGGER.debug(
+            "candle_finalized",
+            extra={
+                "event": "candle_finalized",
+                "symbol": symbol,
+                "timestamp": incoming_ts.isoformat(),
+            },
+        )
+        return dict(normalized)
 
     def flush(self) -> dict[str, Any] | None:
         finalized = self._finalize_current_candle()
@@ -341,7 +514,7 @@ class CandleEngine:
         return finalized
 
     def get_df(self) -> pd.DataFrame:
-        return self.df.copy(deep=True)
+        return self._cached_df_copy()
 
 
 def _normalize_completed_candle(
@@ -357,8 +530,6 @@ def _normalize_completed_candle(
     every minute boundary across all active symbols (production: lag_ms=851,
     tick_pending=1716 at market open).
     """
-    import math
-
     out: dict[str, Any] = {"timestamp": incoming_ts}
     for field in ("open", "high", "low", "close"):
         try:
@@ -384,6 +555,25 @@ def _normalize_completed_candle(
     return out
 
 
+def _candles_equivalent(left: Mapping[str, Any], right: Mapping[str, Any]) -> bool:
+    if _to_ist_timestamp(left.get("timestamp")) != _to_ist_timestamp(
+        right.get("timestamp")
+    ):
+        return False
+    for field in ("open", "high", "low", "close", "volume"):
+        try:
+            if not math.isclose(
+                float(left.get(field)),
+                float(right.get(field)),
+                rel_tol=1e-12,
+                abs_tol=1e-9,
+            ):
+                return False
+        except (TypeError, ValueError):
+            return False
+    return True
+
+
 def _validate_ohlc_row(row: Mapping[str, Any]) -> None:
     op = float(row["open"])
     hi = float(row["high"])
@@ -403,14 +593,31 @@ def detect_gap(df: pd.DataFrame) -> bool:
     return bool((diffs != pd.Timedelta(minutes=1)).any())
 
 
-def repair_with_backfill(symbol: str, df: pd.DataFrame, *, fetch_recent_rest: FetchRecentFn, max_bars: int = 500) -> pd.DataFrame:
-    LOGGER.info("repair_with_backfill_deprecated symbol=%s", symbol, extra={"event": "repair_with_backfill_deprecated", "symbol": symbol})
+def repair_with_backfill(
+    symbol: str,
+    df: pd.DataFrame,
+    *,
+    fetch_recent_rest: FetchRecentFn,
+    max_bars: int = 500,
+) -> pd.DataFrame:
+    LOGGER.info(
+        "repair_with_backfill_deprecated symbol=%s",
+        symbol,
+        extra={"event": "repair_with_backfill_deprecated", "symbol": symbol},
+    )
     recent = sanitize(fetch_recent_rest(symbol))
     merged = sanitize(pd.concat([sanitize(df), recent], ignore_index=True))
     return merged.tail(max_bars).reset_index(drop=True)
 
 
-def fetch_historical_safe(symbol: str, *, fetch_historical: FetchHistoricalFn, min_required: int = 50, retries: int = 3, sleep_seconds: float = 0.5) -> pd.DataFrame | None:
+def fetch_historical_safe(
+    symbol: str,
+    *,
+    fetch_historical: FetchHistoricalFn,
+    min_required: int = 50,
+    retries: int = 3,
+    sleep_seconds: float = 0.5,
+) -> pd.DataFrame | None:
     for attempt in range(1, retries + 1):
         frame = sanitize(fetch_historical(symbol))
         if validate_dataframe(frame, min_required=min_required):
@@ -419,7 +626,12 @@ def fetch_historical_safe(symbol: str, *, fetch_historical: FetchHistoricalFn, m
             "data_integrity_error symbol=%s reason=historical_validation_failed attempt=%d",
             symbol,
             attempt,
-            extra={"event": "data_integrity_error", "symbol": symbol, "attempt": attempt, "reason": "historical_validation_failed"},
+            extra={
+                "event": "data_integrity_error",
+                "symbol": symbol,
+                "attempt": attempt,
+                "reason": "historical_validation_failed",
+            },
         )
         if attempt < retries:
             time.sleep(sleep_seconds)
@@ -432,7 +644,10 @@ def validate_dataframe(df: pd.DataFrame | None, min_required: int = 50) -> bool:
     clean = sanitize(df)
     if len(clean) < min_required:
         return False
-    if clean["timestamp"].duplicated().any() or not clean["timestamp"].is_monotonic_increasing:
+    if (
+        clean["timestamp"].duplicated().any()
+        or not clean["timestamp"].is_monotonic_increasing
+    ):
         return False
     if detect_gap(clean):
         return False
@@ -453,18 +668,32 @@ def normalize_ohlc_timezone(df: pd.DataFrame) -> pd.DataFrame:
     return normalized.set_index("timestamp")
 
 
-def ensure_valid_data(symbol: str, engine: CandleEngine, *, fetch_historical: FetchHistoricalFn, fetch_recent_rest: FetchRecentFn, min_required: int = 50) -> pd.DataFrame | None:
+def ensure_valid_data(
+    symbol: str,
+    engine: CandleEngine,
+    *,
+    fetch_historical: FetchHistoricalFn,
+    fetch_recent_rest: FetchRecentFn,
+    min_required: int = 50,
+) -> pd.DataFrame | None:
     del fetch_recent_rest
     frame = sanitize(engine.get_df())
     if validate_dataframe(frame, min_required=min_required):
         return frame
-    hydrated = fetch_historical_safe(symbol, fetch_historical=fetch_historical, min_required=min_required, retries=1)
+    hydrated = fetch_historical_safe(
+        symbol, fetch_historical=fetch_historical, min_required=min_required, retries=1
+    )
     if hydrated is None:
         LOGGER.error(
             "data_integrity_error symbol=%s reason=insufficient_historical min_required=%d",
             symbol,
             min_required,
-            extra={"event": "data_integrity_error", "symbol": symbol, "reason": "insufficient_historical", "min_required": min_required},
+            extra={
+                "event": "data_integrity_error",
+                "symbol": symbol,
+                "reason": "insufficient_historical",
+                "min_required": min_required,
+            },
         )
         return None
     engine.df = hydrated.tail(engine.max_bars).reset_index(drop=True)

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -2398,7 +2398,7 @@ class StrategyRunner:
             df = df.drop_duplicates(subset="timestamp", keep="last")
             df = df.sort_values("timestamp").reset_index(drop=True)
             engine = self._candle_engines.setdefault(symbol, CandleEngine())
-            engine.df = df.tail(engine.max_bars).reset_index(drop=True)
+            engine.replace_history(df.tail(engine.max_bars).reset_index(drop=True))
             self._logger.debug(
                 "candle_engine_seeded",
                 extra={
@@ -7990,7 +7990,7 @@ class StrategyRunner:
                                 max_bars=engine.max_bars,
                             )
                             if not repaired.empty:
-                                engine.df = repaired
+                                engine.replace_history(repaired)
                     except Exception:
                         # 4. Use .exception to capture traceback and stop silent failures
                         self._logger.exception(
@@ -9454,6 +9454,66 @@ class StrategyRunner:
         for readiness in snap.values():
             if readiness.symbol and normalize_symbol(str(readiness.symbol)) == norm:
                 return readiness
+        return None
+
+    def _candidate_contract_mismatch_details(
+        self, candidate_symbol: str | None
+    ) -> dict[str, Any] | None:
+        if not candidate_symbol or not is_nifty_option_symbol(str(candidate_symbol)):
+            return None
+        snap = self._option_side_readiness_snapshot()
+        selected = {"CE": snap["CE"], "PE": snap["PE"]}
+        candidate_norms = self._symbol_match_keys(candidate_symbol)
+        candidate_token = self._candidate_token_for_symbol(candidate_symbol)
+        for readiness in selected.values():
+            if readiness.symbol and candidate_norms & self._symbol_match_keys(
+                readiness.symbol
+            ):
+                return None
+            if (
+                candidate_token is not None
+                and readiness.token is not None
+                and int(candidate_token) == int(readiness.token)
+            ):
+                return None
+        return {
+            "candidate_symbol": candidate_symbol,
+            "selected_ce": selected["CE"].symbol,
+            "selected_pe": selected["PE"].symbol,
+            "candidate_token": candidate_token,
+            "selected_ce_token": selected["CE"].token,
+            "selected_pe_token": selected["PE"].token,
+        }
+
+    def _symbol_match_keys(self, symbol: str | None) -> set[str]:
+        if not symbol:
+            return set()
+        raw = str(symbol).strip()
+        stripped = raw.split(":", 1)[-1]
+        keys = {raw.upper(), stripped.upper()}
+        with suppress(Exception):
+            keys.add(normalize_symbol(raw).upper())
+        with suppress(Exception):
+            keys.add(normalize_symbol(stripped).upper())
+        return {key for key in keys if key}
+
+    def _candidate_token_for_symbol(self, symbol: str | None) -> int | None:
+        if not symbol:
+            return None
+        mdm = getattr(self, "_market_data", None)
+        token_by_symbol = (
+            getattr(mdm, "_token_by_symbol", {}) if mdm is not None else {}
+        )
+        for key in self._symbol_match_keys(symbol):
+            raw = token_by_symbol.get(key)
+            if raw is None:
+                raw = token_by_symbol.get(key.split(":", 1)[-1])
+            try:
+                token = int(raw)
+            except (TypeError, ValueError):
+                continue
+            if token > 0:
+                return token
         return None
 
     def _emit_candidate_execution_readiness(
@@ -18516,6 +18576,23 @@ class StrategyRunner:
                 os.getenv("ALLOW_MARKET_ENTRY", "false")
             ).strip().lower() in {"1", "true", "yes", "on"}
             order_symbol = trade_symbol or signal.symbol or base_symbol
+            contract_mismatch = self._candidate_contract_mismatch_details(order_symbol)
+            if contract_mismatch is not None:
+                self._logger.warning(
+                    "ORDER_BLOCKED selected_contract_mismatch "
+                    "candidate_symbol=%s selected_ce=%s selected_pe=%s",
+                    contract_mismatch.get("candidate_symbol"),
+                    contract_mismatch.get("selected_ce"),
+                    contract_mismatch.get("selected_pe"),
+                    extra={
+                        "event": "ORDER_BLOCKED",
+                        "reason": "selected_contract_mismatch",
+                        **contract_mismatch,
+                    },
+                )
+                return _reject_after_dedup(
+                    reason="selected_contract_mismatch", details=contract_mismatch
+                )
             candidate_readiness = self._readiness_for_candidate_symbol(order_symbol)
             if candidate_readiness is not None:
                 self._emit_candidate_execution_readiness(
@@ -18536,11 +18613,17 @@ class StrategyRunner:
                             "candidate_symbol": candidate_readiness.symbol,
                             "candidate_side": candidate_readiness.side,
                             "candidate_blockers": list(candidate_readiness.blockers),
-                            "candidate_subscription_ready": candidate_readiness.subscribed,
+                            "candidate_subscription_ready": (
+                                candidate_readiness.subscribed
+                            ),
                             "candidate_quote_fresh": candidate_readiness.quote_fresh,
                             "candidate_depth_ready": candidate_readiness.depth_ready,
-                            "candidate_history_count": candidate_readiness.history_count,
-                            "candidate_required_bars": candidate_readiness.required_bars,
+                            "candidate_history_count": (
+                                candidate_readiness.history_count
+                            ),
+                            "candidate_required_bars": (
+                                candidate_readiness.required_bars
+                            ),
                         },
                     )
             _resolved_lot_size = 0

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -8934,7 +8934,7 @@ class StrategyRunner:
         )
         mdm = getattr(self, "_market_data", None)
         token_by_symbol = (
-            getattr(mdm, "_token_by_symbol", {}) if mdm is not None else {}
+            (getattr(mdm, "_token_by_symbol", None) or {}) if mdm is not None else {}
         )
         ce_token = token_by_symbol.get(ce_symbol) if ce_symbol else None
         pe_token = token_by_symbol.get(pe_symbol) if pe_symbol else None
@@ -9327,7 +9327,7 @@ class StrategyRunner:
         )
         mdm = getattr(self, "_market_data", None)
         token_by_symbol = (
-            getattr(mdm, "_token_by_symbol", {}) if mdm is not None else {}
+            (getattr(mdm, "_token_by_symbol", None) or {}) if mdm is not None else {}
         )
         active_subs = set(getattr(mdm, "_active_subscribed_symbols", set()) or set())
         desired_tokens = (
@@ -9381,7 +9381,7 @@ class StrategyRunner:
                 and (quote.get("depth_available") or quote.get("depth"))
             )
             if sym and quote and self._is_option_symbol_tick_fresh(sym, max_age_s=60.0):
-                bid, ask, spread, _source = resolve_quote_bid_ask_spread(dict(quote))
+                bid, ask, spread, _source = resolve_quote_bid_ask_spread(quote)
                 ltp = (
                     _extract_float(quote, "ltp", "last_price", "last_traded_price")
                     or 0.0
@@ -9445,23 +9445,29 @@ class StrategyRunner:
         return {"CE": build("CE", ce_symbol), "PE": build("PE", pe_symbol)}
 
     def _readiness_for_candidate_symbol(
-        self, candidate_symbol: str | None
+        self,
+        candidate_symbol: str | None,
+        *,
+        snapshot: Mapping[str, OptionSideReadiness] | None = None,
     ) -> OptionSideReadiness | None:
         if not candidate_symbol:
             return None
         norm = normalize_symbol(str(candidate_symbol))
-        snap = self._option_side_readiness_snapshot()
+        snap = snapshot or self._option_side_readiness_snapshot()
         for readiness in snap.values():
             if readiness.symbol and normalize_symbol(str(readiness.symbol)) == norm:
                 return readiness
         return None
 
     def _candidate_contract_mismatch_details(
-        self, candidate_symbol: str | None
+        self,
+        candidate_symbol: str | None,
+        *,
+        snapshot: Mapping[str, OptionSideReadiness] | None = None,
     ) -> dict[str, Any] | None:
         if not candidate_symbol or not is_nifty_option_symbol(str(candidate_symbol)):
             return None
-        snap = self._option_side_readiness_snapshot()
+        snap = snapshot or self._option_side_readiness_snapshot()
         selected = {"CE": snap["CE"], "PE": snap["PE"]}
         candidate_norms = self._symbol_match_keys(candidate_symbol)
         candidate_token = self._candidate_token_for_symbol(candidate_symbol)
@@ -9502,7 +9508,7 @@ class StrategyRunner:
             return None
         mdm = getattr(self, "_market_data", None)
         token_by_symbol = (
-            getattr(mdm, "_token_by_symbol", {}) if mdm is not None else {}
+            (getattr(mdm, "_token_by_symbol", None) or {}) if mdm is not None else {}
         )
         for key in self._symbol_match_keys(symbol):
             raw = token_by_symbol.get(key)
@@ -9517,10 +9523,14 @@ class StrategyRunner:
         return None
 
     def _emit_candidate_execution_readiness(
-        self, readiness: OptionSideReadiness, *, live_orders_armed: bool
+        self,
+        readiness: OptionSideReadiness,
+        *,
+        live_orders_armed: bool,
+        snapshot: Mapping[str, OptionSideReadiness] | None = None,
     ) -> None:
         opposite = "PE" if readiness.side == "CE" else "CE"
-        snap = self._option_side_readiness_snapshot()
+        snap = snapshot or self._option_side_readiness_snapshot()
         opposite_ready = bool(snap.get(opposite) and snap[opposite].executable)
         log_on_change(
             self._logger,
@@ -18576,7 +18586,10 @@ class StrategyRunner:
                 os.getenv("ALLOW_MARKET_ENTRY", "false")
             ).strip().lower() in {"1", "true", "yes", "on"}
             order_symbol = trade_symbol or signal.symbol or base_symbol
-            contract_mismatch = self._candidate_contract_mismatch_details(order_symbol)
+            readiness_snapshot = self._option_side_readiness_snapshot()
+            contract_mismatch = self._candidate_contract_mismatch_details(
+                order_symbol, snapshot=readiness_snapshot
+            )
             if contract_mismatch is not None:
                 self._logger.warning(
                     "ORDER_BLOCKED selected_contract_mismatch "
@@ -18593,13 +18606,16 @@ class StrategyRunner:
                 return _reject_after_dedup(
                     reason="selected_contract_mismatch", details=contract_mismatch
                 )
-            candidate_readiness = self._readiness_for_candidate_symbol(order_symbol)
+            candidate_readiness = self._readiness_for_candidate_symbol(
+                order_symbol, snapshot=readiness_snapshot
+            )
             if candidate_readiness is not None:
                 self._emit_candidate_execution_readiness(
                     candidate_readiness,
                     live_orders_armed=bool(
                         getattr(self, "_runtime_live_orders_armed", False)
                     ),
+                    snapshot=readiness_snapshot,
                 )
                 if not candidate_readiness.executable:
                     reject_reason = (

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -462,6 +462,22 @@ class ExecutionReadinessResult:
     details: dict[str, Any] = field(default_factory=dict)
 
 
+@dataclass(frozen=True, slots=True)
+class OptionSideReadiness:
+    side: Literal["CE", "PE"]
+    symbol: str | None
+    token: int | None
+    subscribed: bool
+    quote_fresh: bool
+    depth_ready: bool
+    history_count: int
+    required_bars: int
+    history_ready: bool
+    executable: bool
+    blockers: tuple[str, ...]
+    subscription_requested: bool = False
+
+
 @dataclass(slots=True)
 class StrategyRunnerConfig:
     """Configuration controlling runner level behaviour."""
@@ -7766,9 +7782,7 @@ class StrategyRunner:
                     "CRITICAL: Failure in StrategyRunner._health_watchdog.required_symbols"
                 )
                 required_live_symbols = None
-        live_tick_age = getattr(
-            self._market_data, "time_since_last_live_ws_tick", None
-        )
+        live_tick_age = getattr(self._market_data, "time_since_last_live_ws_tick", None)
         classify_live_tick = getattr(
             self._market_data, "classify_live_tick_readiness", None
         )
@@ -7843,7 +7857,10 @@ class StrategyRunner:
                 _mark_stale(required_symbol, reason)
 
         for symbol, engine in self._candle_engines.items():
-            if required_live_symbols is not None and symbol not in required_live_symbols:
+            if (
+                required_live_symbols is not None
+                and symbol not in required_live_symbols
+            ):
                 if self._should_log_throttled(
                     f"ws_stale_skipped_not_required:{symbol}", 300.0
                 ):
@@ -8987,7 +9004,9 @@ class StrategyRunner:
             else False
         )
 
-        def _sub_state(sym: str | None, token: Any, fresh_tick: bool) -> bool:
+        def _sub_state(
+            sym: str | None, token: Any, fresh_tick: bool
+        ) -> tuple[bool, bool]:
             token_int = None
             try:
                 token_int = int(token) if token is not None else None
@@ -9015,6 +9034,23 @@ class StrategyRunner:
                 token_int is not None and token_int in _int_set(confirmed_tokens)
             )
             active_symbol = bool(sym and sym in active_subs)
+            current_generation_fresh_tick = False
+            if fresh_tick and sym and mdm is not None:
+                sub_gen = (
+                    getattr(mdm, "_symbol_subscription_generation", {}) or {}
+                ).get(sym)
+                tick_gen = (
+                    getattr(mdm, "_symbol_first_tick_generation", {}) or {}
+                ).get(sym)
+                current_generation_fresh_tick = bool(
+                    sub_gen is not None and tick_gen == sub_gen
+                )
+            subscription_ready = bool(
+                active_symbol
+                or subscribed
+                or confirmed
+                or current_generation_fresh_tick
+            )
             selected_pair = (
                 getattr(self, "_active_selected_ce", None),
                 getattr(self, "_active_selected_pe", None),
@@ -9038,8 +9074,8 @@ class StrategyRunner:
                     sym,
                     token_int,
                     desired,
-                    subscribed or active_symbol or confirmed,
-                    fresh_tick,
+                    subscription_ready,
+                    current_generation_fresh_tick,
                     None,
                 ),
                 reminder_seconds=float(
@@ -9051,20 +9087,19 @@ class StrategyRunner:
                     "symbol": sym,
                     "token": token_int,
                     "desired": desired,
-                    "subscribed": subscribed or active_symbol or confirmed,
-                    "fresh_tick": fresh_tick,
+                    "subscribed": subscription_ready,
+                    "subscription_requested": desired,
+                    "fresh_tick": current_generation_fresh_tick,
                     "tick_age_s": None,
                     "selected_ce": selected_pair[0],
                     "selected_pe": selected_pair[1],
                     "market_mode": get_runtime_market_mode(),
                 },
             )
-            return bool(
-                active_symbol or desired or subscribed or confirmed or fresh_tick
-            )
+            return subscription_ready, desired
 
-        ce_sub = _sub_state(ce_symbol, ce_token, ce_quote)
-        pe_sub = _sub_state(pe_symbol, pe_token, pe_quote)
+        ce_sub, ce_requested = _sub_state(ce_symbol, ce_token, ce_quote)
+        pe_sub, pe_requested = _sub_state(pe_symbol, pe_token, pe_quote)
         try:
             fut_token_int = int(fut_token) if fut_token is not None else None
         except (TypeError, ValueError):
@@ -9089,7 +9124,23 @@ class StrategyRunner:
         pe_hist = (
             len(self._indicator_engine.get_history(pe_symbol) or []) if pe_symbol else 0
         )
-        min_bars = int(self._required_bars_for_symbol(ce_symbol or pe_symbol or symbol))
+        readiness_snapshot = self._option_side_readiness_snapshot(
+            ce_symbol=ce_symbol, pe_symbol=pe_symbol
+        )
+        ce_ready_snapshot = readiness_snapshot["CE"]
+        pe_ready_snapshot = readiness_snapshot["PE"]
+        ce_sub = ce_ready_snapshot.subscribed
+        pe_sub = pe_ready_snapshot.subscribed
+        ce_requested = ce_ready_snapshot.subscription_requested
+        pe_requested = pe_ready_snapshot.subscription_requested
+        ce_quote = ce_ready_snapshot.quote_fresh
+        pe_quote = pe_ready_snapshot.quote_fresh
+        ce_depth = ce_ready_snapshot.depth_ready
+        pe_depth = pe_ready_snapshot.depth_ready
+        ce_hist = ce_ready_snapshot.history_count
+        pe_hist = pe_ready_snapshot.history_count
+        ce_required_bars = ce_ready_snapshot.required_bars
+        pe_required_bars = pe_ready_snapshot.required_bars
 
         # ── Per-side readiness (CE and PE decoupled) ────────────────────────
         # A directional candidate must depend only on ITS OWN side. The old
@@ -9101,7 +9152,12 @@ class StrategyRunner:
         _require_depth = _env_bool("REQUIRE_FULL_DEPTH_FOR_EXECUTION", False)
 
         def _side_blockers(
-            sym_present: bool, sub: bool, quote: bool, depth: bool, hist: int
+            sym_present: bool,
+            sub: bool,
+            quote: bool,
+            depth: bool,
+            hist: int,
+            required_bars: int,
         ) -> tuple[str, ...]:
             if not sym_present:
                 return ("symbol_missing",)
@@ -9112,14 +9168,14 @@ class StrategyRunner:
                 blockers.append("quote_missing")
             if _require_depth and not depth:
                 blockers.append("depth_missing")
-            if hist < min_bars:
+            if hist < required_bars:
                 blockers.append("history_cold")
             return tuple(blockers)
 
-        ce_blockers = _side_blockers(bool(ce_symbol), ce_sub, ce_quote, ce_depth, ce_hist)
-        pe_blockers = _side_blockers(bool(pe_symbol), pe_sub, pe_quote, pe_depth, pe_hist)
-        ce_executable = bool(ce_symbol) and not ce_blockers
-        pe_executable = bool(pe_symbol) and not pe_blockers
+        ce_blockers = ce_ready_snapshot.blockers
+        pe_blockers = pe_ready_snapshot.blockers
+        ce_executable = ce_ready_snapshot.executable
+        pe_executable = pe_ready_snapshot.executable
 
         normalized_boot_symbol = normalize_symbol(str(symbol or ""))
         _norm_ce = normalize_symbol(str(ce_symbol or "")) if ce_symbol else None
@@ -9140,8 +9196,12 @@ class StrategyRunner:
             self._logger,
             key="OPTION_SIDE_READINESS",
             state=(
-                ce_symbol, pe_symbol, ce_executable, pe_executable,
-                ce_blockers, pe_blockers,
+                ce_symbol,
+                pe_symbol,
+                ce_executable,
+                pe_executable,
+                ce_blockers,
+                pe_blockers,
             ),
             message=(
                 "OPTION_SIDE_READINESS selected_ce=%s ce_executable=%s ce_blockers=%s "
@@ -9149,9 +9209,14 @@ class StrategyRunner:
                 "at_least_one_side_executable=%s both_sides_executable=%s"
             )
             % (
-                ce_symbol, ce_executable, list(ce_blockers),
-                pe_symbol, pe_executable, list(pe_blockers),
-                ce_executable or pe_executable, ce_executable and pe_executable,
+                ce_symbol,
+                ce_executable,
+                list(ce_blockers),
+                pe_symbol,
+                pe_executable,
+                list(pe_blockers),
+                ce_executable or pe_executable,
+                ce_executable and pe_executable,
             ),
             reminder_seconds=600.0,
             level=logging.INFO,
@@ -9159,13 +9224,21 @@ class StrategyRunner:
                 "event": "OPTION_SIDE_READINESS",
                 "selected_ce": ce_symbol,
                 "selected_pe": pe_symbol,
-                "ce_subscribed": ce_sub, "ce_quote_fresh": ce_quote,
-                "ce_depth_ready": ce_depth, "ce_history_count": ce_hist,
-                "ce_required_bars": min_bars, "ce_executable": ce_executable,
+                "ce_subscribed": ce_sub,
+                "ce_quote_fresh": ce_quote,
+                "ce_depth_ready": ce_depth,
+                "ce_history_count": ce_hist,
+                "ce_required_bars": ce_required_bars,
+                "ce_executable": ce_executable,
+                "ce_subscription_requested": ce_requested,
                 "ce_blockers": list(ce_blockers),
-                "pe_subscribed": pe_sub, "pe_quote_fresh": pe_quote,
-                "pe_depth_ready": pe_depth, "pe_history_count": pe_hist,
-                "pe_required_bars": min_bars, "pe_executable": pe_executable,
+                "pe_subscribed": pe_sub,
+                "pe_quote_fresh": pe_quote,
+                "pe_depth_ready": pe_depth,
+                "pe_history_count": pe_hist,
+                "pe_required_bars": pe_required_bars,
+                "pe_executable": pe_executable,
+                "pe_subscription_requested": pe_requested,
                 "pe_blockers": list(pe_blockers),
                 "at_least_one_side_executable": ce_executable or pe_executable,
                 "both_sides_executable": ce_executable and pe_executable,
@@ -9237,6 +9310,186 @@ class StrategyRunner:
             },
         )
         return ready, reason
+
+    def _option_side_readiness_snapshot(
+        self, *, ce_symbol: str | None = None, pe_symbol: str | None = None
+    ) -> dict[str, OptionSideReadiness]:
+        selection = self._current_active_contract_selection()
+        ce_symbol = (
+            ce_symbol
+            or selection.selected_ce
+            or getattr(self, "_active_selected_ce", None)
+        )
+        pe_symbol = (
+            pe_symbol
+            or selection.selected_pe
+            or getattr(self, "_active_selected_pe", None)
+        )
+        mdm = getattr(self, "_market_data", None)
+        token_by_symbol = (
+            getattr(mdm, "_token_by_symbol", {}) if mdm is not None else {}
+        )
+        active_subs = set(getattr(mdm, "_active_subscribed_symbols", set()) or set())
+        desired_tokens = (
+            {
+                int(v)
+                for v in (getattr(mdm, "_desired_tokens", set()) or set())
+                if str(v).isdigit()
+            }
+            if mdm is not None
+            else set()
+        )
+        subscribed_tokens = (
+            {
+                int(v)
+                for v in (getattr(mdm, "_subscribed_tokens", set()) or set())
+                if str(v).isdigit()
+            }
+            if mdm is not None
+            else set()
+        )
+        ws = getattr(mdm, "_ws", None) if mdm is not None else None
+        subscribed_tokens.update(
+            {
+                int(v)
+                for v in (getattr(ws, "_tokens", set()) or set())
+                if str(v).isdigit()
+            }
+        )
+        confirmed_tokens = (
+            {
+                int(v)
+                for v in (getattr(mdm, "_confirmed_subscriptions", set()) or set())
+                if str(v).isdigit()
+            }
+            if mdm is not None
+            else set()
+        )
+        require_depth = _env_bool("REQUIRE_FULL_DEPTH_FOR_EXECUTION", False)
+        max_boot_spread = float(os.getenv("SPREAD_MAX_PCT", "12.5") or "12.5")
+
+        def build(side: Literal["CE", "PE"], sym: str | None) -> OptionSideReadiness:
+            token_raw = token_by_symbol.get(sym) if sym else None
+            try:
+                token = int(token_raw) if token_raw is not None else None
+            except (TypeError, ValueError):
+                token = None
+            quote = self._get_cached_quote_for_live_entry(sym) if sym else {}
+            quote_fresh = False
+            depth_ready = bool(
+                isinstance(quote, Mapping)
+                and (quote.get("depth_available") or quote.get("depth"))
+            )
+            if sym and quote and self._is_option_symbol_tick_fresh(sym, max_age_s=60.0):
+                bid, ask, spread, _source = resolve_quote_bid_ask_spread(dict(quote))
+                ltp = (
+                    _extract_float(quote, "ltp", "last_price", "last_traded_price")
+                    or 0.0
+                )
+                quote_fresh = bool(
+                    ltp > 0
+                    and bid is not None
+                    and ask is not None
+                    and bid > 0
+                    and ask > bid
+                    and spread is not None
+                    and spread <= max_boot_spread
+                )
+            if require_depth:
+                depth_ready = bool(sym and self._selected_option_has_real_depth(sym))
+            requested = bool(token is not None and token in desired_tokens)
+            current_gen_fresh = False
+            if quote_fresh and sym and mdm is not None:
+                sub_gen = (
+                    getattr(mdm, "_symbol_subscription_generation", {}) or {}
+                ).get(sym)
+                tick_gen = (
+                    getattr(mdm, "_symbol_first_tick_generation", {}) or {}
+                ).get(sym)
+                current_gen_fresh = bool(sub_gen is not None and tick_gen == sub_gen)
+            subscribed = bool(
+                (sym and sym in active_subs)
+                or (token is not None and token in subscribed_tokens)
+                or (token is not None and token in confirmed_tokens)
+                or current_gen_fresh
+            )
+            hist = len(self._indicator_engine.get_history(sym) or []) if sym else 0
+            required = int(self._required_bars_for_symbol(sym)) if sym else 0
+            blockers: list[str] = []
+            if not sym:
+                blockers.append("symbol_missing")
+            if not subscribed:
+                blockers.append("subscription_pending")
+            if not quote_fresh:
+                blockers.append("quote_missing")
+            if require_depth and not depth_ready:
+                blockers.append("depth_missing")
+            history_ready = hist >= required
+            if not history_ready:
+                blockers.append("history_cold")
+            return OptionSideReadiness(
+                side,
+                sym,
+                token,
+                subscribed,
+                quote_fresh,
+                depth_ready,
+                hist,
+                required,
+                history_ready,
+                bool(sym) and not blockers,
+                tuple(blockers),
+                requested,
+            )
+
+        return {"CE": build("CE", ce_symbol), "PE": build("PE", pe_symbol)}
+
+    def _readiness_for_candidate_symbol(
+        self, candidate_symbol: str | None
+    ) -> OptionSideReadiness | None:
+        if not candidate_symbol:
+            return None
+        norm = normalize_symbol(str(candidate_symbol))
+        snap = self._option_side_readiness_snapshot()
+        for readiness in snap.values():
+            if readiness.symbol and normalize_symbol(str(readiness.symbol)) == norm:
+                return readiness
+        return None
+
+    def _emit_candidate_execution_readiness(
+        self, readiness: OptionSideReadiness, *, live_orders_armed: bool
+    ) -> None:
+        opposite = "PE" if readiness.side == "CE" else "CE"
+        snap = self._option_side_readiness_snapshot()
+        opposite_ready = bool(snap.get(opposite) and snap[opposite].executable)
+        log_on_change(
+            self._logger,
+            key=f"CANDIDATE_EXECUTION_READINESS:{readiness.symbol}",
+            state=(
+                readiness.symbol,
+                readiness.executable,
+                readiness.blockers,
+                bool(live_orders_armed),
+            ),
+            message="CANDIDATE_EXECUTION_READINESS candidate_symbol=%s candidate_ready=%s blockers=%s"
+            % (readiness.symbol, readiness.executable, list(readiness.blockers)),
+            reminder_seconds=60.0,
+            level=logging.INFO,
+            extra={
+                "event": "CANDIDATE_EXECUTION_READINESS",
+                "candidate_symbol": readiness.symbol,
+                "candidate_side": readiness.side,
+                "candidate_ready": readiness.executable,
+                "candidate_blockers": list(readiness.blockers),
+                "candidate_subscription_ready": readiness.subscribed,
+                "candidate_quote_fresh": readiness.quote_fresh,
+                "candidate_depth_ready": readiness.depth_ready,
+                "candidate_history_count": readiness.history_count,
+                "candidate_required_bars": readiness.required_bars,
+                "opposite_side_ready": opposite_ready,
+                "live_orders_armed": bool(live_orders_armed),
+            },
+        )
 
     def _selected_option_has_real_depth(self, symbol: str | None) -> bool:
         """Return true only when selected option has real bid/ask/depth proof."""
@@ -11215,17 +11468,13 @@ class StrategyRunner:
                 max_age_s=max_live_tick_age_s,
             )
             details["max_live_tick_age_s"] = max_live_tick_age_s
-            details["live_tick_generation_ready"] = bool(
-                live_tick_check.get("ready")
-            )
+            details["live_tick_generation_ready"] = bool(live_tick_check.get("ready"))
             details["live_tick_generation_reason"] = live_tick_check.get("reason")
             details["subscription_generation"] = live_tick_check.get(
                 "subscription_generation"
             )
             details["tick_generation"] = live_tick_check.get("tick_generation")
-            details["first_tick_received"] = live_tick_check.get(
-                "first_tick_received"
-            )
+            details["first_tick_received"] = live_tick_check.get("first_tick_received")
             details["tick_age_s"] = live_tick_check.get("tick_age_s")
             details["expected_subscription_state"] = live_tick_check.get("expected")
             details["actual_subscription_state"] = live_tick_check.get("subscribed")
@@ -18267,6 +18516,33 @@ class StrategyRunner:
                 os.getenv("ALLOW_MARKET_ENTRY", "false")
             ).strip().lower() in {"1", "true", "yes", "on"}
             order_symbol = trade_symbol or signal.symbol or base_symbol
+            candidate_readiness = self._readiness_for_candidate_symbol(order_symbol)
+            if candidate_readiness is not None:
+                self._emit_candidate_execution_readiness(
+                    candidate_readiness,
+                    live_orders_armed=bool(
+                        getattr(self, "_runtime_live_orders_armed", False)
+                    ),
+                )
+                if not candidate_readiness.executable:
+                    reject_reason = (
+                        "selected_ce_unready"
+                        if candidate_readiness.side == "CE"
+                        else "selected_pe_unready"
+                    )
+                    return _reject_after_dedup(
+                        reason=reject_reason,
+                        details={
+                            "candidate_symbol": candidate_readiness.symbol,
+                            "candidate_side": candidate_readiness.side,
+                            "candidate_blockers": list(candidate_readiness.blockers),
+                            "candidate_subscription_ready": candidate_readiness.subscribed,
+                            "candidate_quote_fresh": candidate_readiness.quote_fresh,
+                            "candidate_depth_ready": candidate_readiness.depth_ready,
+                            "candidate_history_count": candidate_readiness.history_count,
+                            "candidate_required_bars": candidate_readiness.required_bars,
+                        },
+                    )
             _resolved_lot_size = 0
             _requested_lots = 0
             _instrument_token = None

--- a/tests/data/test_candle_engine_incremental_finalize.py
+++ b/tests/data/test_candle_engine_incremental_finalize.py
@@ -1,10 +1,9 @@
 """Live candle finalization must be incremental: no full-frame sanitize."""
+
 from __future__ import annotations
 
 import asyncio
 import time
-from datetime import datetime, timedelta
-
 import pandas as pd
 import pytest
 
@@ -32,8 +31,8 @@ def test_incremental_append_correct_and_bounded(monkeypatch) -> None:
     monkeypatch.setattr(ce_mod, "sanitize", lambda f: calls.append(1) or real(f))
 
     engine = CandleEngine(symbol="NFO:T", max_bars=5)
-    assert _finalize(engine, _mk(_ts(0))) is not None      # first append
-    assert _finalize(engine, _mk(_ts(1))) is not None      # later append
+    assert _finalize(engine, _mk(_ts(0))) is not None  # first append
+    assert _finalize(engine, _mk(_ts(1))) is not None  # later append
     assert calls == [], "live finalize must NOT call full sanitize"
 
     # same-minute duplicate: no duplicate timestamp row
@@ -52,7 +51,10 @@ def test_incremental_append_correct_and_bounded(monkeypatch) -> None:
         pass
     engine.current_candle = None
     # future candle rejected
-    assert _finalize(engine, _mk(pd.Timestamp.now(tz=IST) + pd.Timedelta(minutes=10))) is None
+    assert (
+        _finalize(engine, _mk(pd.Timestamp.now(tz=IST) + pd.Timedelta(minutes=10)))
+        is None
+    )
 
     for minute in range(2, 12):  # bound to max_bars
         _finalize(engine, _mk(_ts(minute)))
@@ -97,3 +99,61 @@ def test_market_open_rollover_burst_keeps_loop_responsive() -> None:
     # Cooperative bound: heartbeat scheduling delay stays far below the
     # 500-850ms production lag this fix targets.
     assert worst < 0.25, worst
+
+
+def test_live_finalize_uses_deque_not_dataframe_append_paths(monkeypatch) -> None:
+    engine = CandleEngine(symbol="NFO:T", max_bars=3)
+    concat_calls = []
+    monkeypatch.setattr(
+        pd,
+        "concat",
+        lambda *a, **k: concat_calls.append(1)
+        or pytest.fail("pd.concat used on live append"),
+    )
+    result = _finalize(engine, _mk(_ts(20)))
+    assert result is not None
+    assert concat_calls == []
+    assert engine.diagnostics()["candle_store_size"] == 1
+    assert engine.diagnostics()["live_append_total"] == 1
+
+
+def test_returned_candle_is_canonical_and_cache_rebuilds_only_when_dirty() -> None:
+    engine = CandleEngine(symbol="NFO:T", max_bars=5)
+    candle = {
+        "timestamp": _ts(30),
+        "open": "100.0",
+        "high": "102.0",
+        "low": "99.0",
+        "close": "101.0",
+        "volume": "2500",
+    }
+    returned = _finalize(engine, candle)
+    stored = engine.get_df().iloc[-1].to_dict()
+    for field in ("open", "high", "low", "close", "volume"):
+        assert isinstance(returned[field], float)
+        assert isinstance(stored[field], float)
+        assert returned[field] == stored[field]
+    assert returned["timestamp"] == stored["timestamp"]
+    diag_after_first_read = engine.diagnostics()
+    engine.get_df()
+    assert (
+        engine.diagnostics()["df_cache_rebuild_total"]
+        == diag_after_first_read["df_cache_rebuild_total"]
+    )
+    _finalize(engine, _mk(_ts(31)))
+    assert engine.diagnostics()["df_cache_dirty"] is True
+    engine.get_df()
+    assert (
+        engine.diagnostics()["df_cache_rebuild_total"]
+        == diag_after_first_read["df_cache_rebuild_total"] + 1
+    )
+
+
+def test_same_minute_identical_ignored_and_conflicting_rejected() -> None:
+    engine = CandleEngine(symbol="NFO:T", max_bars=5)
+    assert _finalize(engine, _mk(_ts(40))) is not None
+    assert _finalize(engine, _mk(_ts(40))) is None
+    assert engine.diagnostics()["same_minute_idempotent_total"] == 1
+    with pytest.raises(DataIntegrityError):
+        _finalize(engine, _mk(_ts(40), c=100.75))
+    assert engine.diagnostics()["same_minute_conflict_total"] == 1

--- a/tests/data/test_candle_engine_incremental_finalize.py
+++ b/tests/data/test_candle_engine_incremental_finalize.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import time
+
 import pandas as pd
 import pytest
 
@@ -157,3 +158,64 @@ def test_same_minute_identical_ignored_and_conflicting_rejected() -> None:
     with pytest.raises(DataIntegrityError):
         _finalize(engine, _mk(_ts(40), c=100.75))
     assert engine.diagnostics()["same_minute_conflict_total"] == 1
+
+
+def test_df_getter_is_defensive_copy_and_replacement_methods_work() -> None:
+    engine = CandleEngine(symbol="NFO:T", max_bars=5)
+    first = pd.DataFrame([_mk(_ts(50), c=100.5)])
+    engine.df = first
+    copy_frame = engine.df
+    copy_frame.loc[0, "close"] = 999.0
+    copy_frame["extra"] = "ignored"
+    stored = engine.get_df()
+    assert float(stored.loc[0, "close"]) == 100.5
+    assert "extra" not in stored.columns
+
+    assigned = pd.DataFrame([_mk(_ts(51), h=103.0, c=101.5)])
+    engine.df = assigned
+    assert float(engine.get_df().loc[0, "close"]) == 101.5
+
+    replaced = pd.DataFrame([_mk(_ts(52), h=104.0, c=102.5)])
+    engine.replace_history(replaced)
+    assert float(engine.get_df().loc[0, "close"]) == 102.5
+
+
+def test_candle_engine_df_callers_do_not_use_in_place_mutation() -> None:
+    import ast
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[2]
+    production = list((root / "src" / "nifty_scalper_bot").rglob("*.py"))
+    offenders: list[str] = []
+    for path in production:
+        source = path.read_text()
+        tree = ast.parse(source, filename=str(path))
+        for node in ast.walk(tree):
+            for child in ast.iter_child_nodes(node):
+                child.parent = node
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Attribute) and node.attr in {"loc", "iloc"}:
+                parent = getattr(node, "parent", None)
+                if (
+                    isinstance(parent, ast.Attribute)
+                    and isinstance(node.value, ast.Attribute)
+                    and node.value.attr == "df"
+                ):
+                    offenders.append(f"{path.relative_to(root)}:{node.lineno}")
+            if (
+                isinstance(node, ast.Subscript)
+                and isinstance(node.value, ast.Attribute)
+                and node.value.attr == "df"
+            ):
+                offenders.append(f"{path.relative_to(root)}:{node.lineno}")
+            if isinstance(node, ast.Call):
+                for kw in node.keywords:
+                    if (
+                        kw.arg == "inplace"
+                        and isinstance(kw.value, ast.Constant)
+                        and kw.value.value is True
+                    ):
+                        text = ast.get_source_segment(source, node) or ""
+                        if ".df" in text:
+                            offenders.append(f"{path.relative_to(root)}:{node.lineno}")
+    assert offenders == []

--- a/tests/strategies/test_candidate_specific_option_readiness.py
+++ b/tests/strategies/test_candidate_specific_option_readiness.py
@@ -278,9 +278,9 @@ def _execution_runner(monkeypatch, *, ce_ok=True, pe_ok=False):
         runner, StrategyRunner
     )
 
-    def wrapped(symbol):
+    def wrapped(symbol, **kwargs):
         calls["gate"] += 1
-        return real(symbol)
+        return real(symbol, **kwargs)
 
     runner._readiness_for_candidate_symbol = wrapped
     return runner, calls
@@ -375,3 +375,60 @@ def test_exit_path_does_not_apply_candidate_entry_gate(monkeypatch):
     assert calls["gate"] == 0
     assert len(submitted) == 1
     assert submitted[0].symbol == "NFO:PE"
+
+
+def test_readiness_snapshot_handles_none_mdm_mappings_fail_closed():
+    runner = _runner()
+    runner._market_data = SimpleNamespace(
+        _token_by_symbol=None,
+        _active_subscribed_symbols=None,
+        _desired_tokens=None,
+        _subscribed_tokens=None,
+        _confirmed_subscriptions=None,
+        _ws=SimpleNamespace(_tokens=None),
+        _symbol_subscription_generation=None,
+        _symbol_first_tick_generation=None,
+    )
+    runner._indicator_engine = SimpleNamespace(get_history=lambda sym: [1] * 50)
+    runner._current_active_contract_selection = lambda: SimpleNamespace(
+        selected_ce="NFO:CE", selected_pe="NFO:PE"
+    )
+    runner._get_cached_quote_for_live_entry = lambda sym: {
+        "ltp": 100,
+        "bid": 99,
+        "ask": 101,
+        "depth_available": True,
+    }
+    runner._is_option_symbol_tick_fresh = lambda sym, max_age_s=60.0: True
+    runner._selected_option_has_real_depth = lambda sym: True
+    runner._required_bars_for_symbol = lambda sym: 50
+    snap = runner._option_side_readiness_snapshot()
+    assert snap["CE"].token is None
+    assert snap["CE"].subscribed is False
+    assert snap["CE"].executable is False
+    assert "subscription_pending" in snap["CE"].blockers
+    assert snap["PE"].subscribed is False
+
+
+def test_entry_path_uses_one_readiness_snapshot_for_candidate_decision(monkeypatch):
+    runner, calls = _execution_runner(monkeypatch, ce_ok=True, pe_ok=False)
+    snapshot = _snap(True, False)
+    snapshot_calls = {"count": 0}
+
+    def snapshot_once(**kwargs):
+        snapshot_calls["count"] += 1
+        return snapshot
+
+    runner._option_side_readiness_snapshot = snapshot_once
+    result = runner._handle_entry_signal_inner(
+        _signal("NFO:CE"),
+        "NSE:NIFTY",
+        "NFO:CE",
+        100.0,
+        datetime.now(timezone.utc),
+        trace_id="t",
+    )
+    assert result.accepted is True
+    assert calls["gate"] == 1
+    assert snapshot_calls["count"] == 1
+    assert len(runner._order_manager.plans) == 1

--- a/tests/strategies/test_candidate_specific_option_readiness.py
+++ b/tests/strategies/test_candidate_specific_option_readiness.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from nifty_scalper_bot.strategies.runner import OptionSideReadiness, StrategyRunner
+
+
+def _runner() -> StrategyRunner:
+    runner = object.__new__(StrategyRunner)
+    runner._active_selected_ce = "NFO:CE"
+    runner._active_selected_pe = "NFO:PE"
+    runner._runtime_live_orders_armed = True
+    runner._logger = SimpleNamespace(info=lambda *a, **k: None)
+    return runner
+
+
+def _snap(ce_ok: bool, pe_ok: bool):
+    return {
+        "CE": OptionSideReadiness(
+            "CE",
+            "NFO:CE",
+            1,
+            ce_ok,
+            ce_ok,
+            True,
+            50 if ce_ok else 49,
+            50,
+            ce_ok,
+            ce_ok,
+            () if ce_ok else ("history_cold",),
+        ),
+        "PE": OptionSideReadiness(
+            "PE",
+            "NFO:PE",
+            2,
+            pe_ok,
+            pe_ok,
+            True,
+            30 if pe_ok else 29,
+            30,
+            pe_ok,
+            pe_ok,
+            () if pe_ok else ("quote_missing",),
+        ),
+    }
+
+
+def test_readiness_for_candidate_symbol_returns_candidate_side(monkeypatch):
+    runner = _runner()
+    monkeypatch.setattr(
+        runner, "_option_side_readiness_snapshot", lambda **_: _snap(True, False)
+    )
+    assert runner._readiness_for_candidate_symbol("NFO:CE").executable is True
+    pe = runner._readiness_for_candidate_symbol("NFO:PE")
+    assert pe is not None
+    assert pe.side == "PE"
+    assert pe.executable is False
+    assert pe.blockers == ("quote_missing",)
+
+
+def test_independent_required_bars_are_preserved_in_snapshot(monkeypatch):
+    runner = _runner()
+    monkeypatch.setattr(
+        runner, "_option_side_readiness_snapshot", lambda **_: _snap(False, True)
+    )
+    ce = runner._readiness_for_candidate_symbol("NFO:CE")
+    pe = runner._readiness_for_candidate_symbol("NFO:PE")
+    assert ce.required_bars == 50 and ce.history_count == 49 and not ce.history_ready
+    assert pe.required_bars == 30 and pe.history_count == 30 and pe.history_ready
+
+
+def test_desired_only_subscription_is_not_ready(monkeypatch):
+    runner = _runner()
+    mdm = SimpleNamespace(
+        _token_by_symbol={"NFO:CE": 1, "NFO:PE": 2},
+        _desired_tokens={1},
+        _subscribed_tokens=set(),
+        _confirmed_subscriptions=set(),
+        _active_subscribed_symbols=set(),
+        _ws=SimpleNamespace(_tokens=set()),
+    )
+    runner._market_data = mdm
+    runner._indicator_engine = SimpleNamespace(get_history=lambda sym: [1] * 50)
+    runner._current_active_contract_selection = lambda: SimpleNamespace(
+        selected_ce="NFO:CE", selected_pe="NFO:PE"
+    )
+    runner._get_cached_quote_for_live_entry = lambda sym: {
+        "ltp": 100,
+        "bid": 99,
+        "ask": 101,
+        "depth_available": True,
+    }
+    runner._is_option_symbol_tick_fresh = lambda sym, max_age_s=60.0: True
+    runner._selected_option_has_real_depth = lambda sym: True
+    runner._required_bars_for_symbol = lambda sym: 50
+    snap = runner._option_side_readiness_snapshot()
+    assert snap["CE"].subscription_requested is True
+    assert snap["CE"].subscribed is False
+
+
+def test_current_generation_fresh_tick_can_prove_subscription(monkeypatch):
+    runner = _runner()
+    mdm = SimpleNamespace(
+        _token_by_symbol={"NFO:CE": 1, "NFO:PE": 2},
+        _desired_tokens=set(),
+        _subscribed_tokens=set(),
+        _confirmed_subscriptions=set(),
+        _active_subscribed_symbols=set(),
+        _ws=SimpleNamespace(_tokens=set()),
+        _symbol_subscription_generation={"NFO:CE": 7},
+        _symbol_first_tick_generation={"NFO:CE": 7},
+    )
+    runner._market_data = mdm
+    runner._indicator_engine = SimpleNamespace(get_history=lambda sym: [1] * 50)
+    runner._current_active_contract_selection = lambda: SimpleNamespace(
+        selected_ce="NFO:CE", selected_pe=None
+    )
+    runner._get_cached_quote_for_live_entry = lambda sym: {
+        "ltp": 100,
+        "bid": 99,
+        "ask": 101,
+        "depth_available": True,
+    }
+    runner._is_option_symbol_tick_fresh = lambda sym, max_age_s=60.0: True
+    runner._selected_option_has_real_depth = lambda sym: True
+    runner._required_bars_for_symbol = lambda sym: 50
+    assert runner._option_side_readiness_snapshot()["CE"].subscribed is True
+    mdm._symbol_first_tick_generation["NFO:CE"] = 6
+    assert runner._option_side_readiness_snapshot()["CE"].subscribed is False

--- a/tests/strategies/test_candidate_specific_option_readiness.py
+++ b/tests/strategies/test_candidate_specific_option_readiness.py
@@ -1,8 +1,18 @@
 from __future__ import annotations
 
+from collections import deque
+from datetime import datetime, timezone
 from types import SimpleNamespace
 
-from nifty_scalper_bot.strategies.runner import OptionSideReadiness, StrategyRunner
+import pytest
+
+from nifty_scalper_bot.strategies.runner import (
+    ExecutionModeSnapshot,
+    OptionSideReadiness,
+    SignalExecutionResult,
+    StrategyRunner,
+)
+from nifty_scalper_bot.strategies.signal_generator import Signal
 
 
 def _runner() -> StrategyRunner:
@@ -127,3 +137,241 @@ def test_current_generation_fresh_tick_can_prove_subscription(monkeypatch):
     assert runner._option_side_readiness_snapshot()["CE"].subscribed is True
     mdm._symbol_first_tick_generation["NFO:CE"] = 6
     assert runner._option_side_readiness_snapshot()["CE"].subscribed is False
+
+
+class _Logger:
+    def debug(self, *args, **kwargs):
+        pass
+
+    def info(self, *args, **kwargs):
+        pass
+
+    def warning(self, *args, **kwargs):
+        pass
+
+    def error(self, *args, **kwargs):
+        pass
+
+    def critical(self, *args, **kwargs):
+        pass
+
+
+class _OrderManager:
+    def __init__(self):
+        self.plans = []
+
+    def resolve_lot_size(self, symbol):
+        return 1
+
+    def _lot_size_for_symbol(self, symbol):
+        return 1
+
+    def submit_trade_plan_result(self, plan):
+        self.plans.append(plan)
+        return SimpleNamespace(
+            accepted=True,
+            order_id="OID-1",
+            broker_attempted=True,
+            reason="accepted",
+            details={},
+        )
+
+
+def _execution_runner(monkeypatch, *, ce_ok=True, pe_ok=False):
+    import nifty_scalper_bot.strategies.runner as runner_mod
+
+    monkeypatch.setattr(
+        runner_mod,
+        "score_signal_quality",
+        lambda **kwargs: SimpleNamespace(
+            allowed=True,
+            final_score=10.0,
+            direction_score=10.0,
+            strategy_score=10.0,
+            option_score=10.0,
+            data_score=10.0,
+            rr_score=10.0,
+            components={"threshold": 0.0},
+            reasons=[],
+        ),
+    )
+    runner = object.__new__(StrategyRunner)
+    runner._logger = _Logger()
+    runner._order_manager = _OrderManager()
+    runner._runtime_live_orders_armed = True
+    runner._order_attempt_window = deque()
+    runner._max_order_attempts_per_minute = 999
+    runner._signal_reject_cooldown_ts = {}
+    runner._execution_reject_cooldown_ts = {}
+    runner._premium_squeeze_last_signal_ts = {}
+    runner._underlying_last_signal_ts = {}
+    runner._reason_last_signal_ts = {}
+    runner._order_failure_cooldown_until = {}
+    runner._submitted_entry_order_context = {}
+    runner._signal_attempt_debounce_state = {}
+    runner._session_date = "2026-07-15"
+    runner._last_regime_by_symbol = {}
+    runner._last_regime_inputs_by_symbol = {}
+    runner._reason_signal_cooldown_seconds = 0.0
+    runner._underlying_signal_cooldown_seconds = 0.0
+    runner._cooldown_log_throttle_seconds = 0.0
+    runner._order_failure_cooldown_seconds = 0.0
+    runner._trade_candidate_selector = SimpleNamespace(_last_rejects={})
+    runner._position_manager = None
+    runner._orchestrator = None
+    runner._active_atm_strike = 25000
+    runner._active_option_symbols = {"NFO:CE", "NFO:PE"}
+    runner._active_basket_all_symbols = {"NFO:CE", "NFO:PE"}
+    runner._active_basket_token_by_symbol = {"NFO:CE": 1, "NFO:PE": 2}
+    runner._active_contract_basket = {
+        "selected_ce": "NFO:CE",
+        "selected_pe": "NFO:PE",
+        "token_by_symbol": {"NFO:CE": 1, "NFO:PE": 2},
+    }
+    runner._market_data = SimpleNamespace(
+        _token_by_symbol={
+            "NFO:CE": 1,
+            "CE": 1,
+            "NFO:PE": 2,
+            "PE": 2,
+            "NFO:OTHERCE": 3,
+            "OTHERCE": 3,
+        }
+    )
+    runner._resolve_execution_mode_snapshot = lambda: ExecutionModeSnapshot(
+        "paper", False, True, False, False, False
+    )
+    runner._is_tradable_symbol = lambda symbol: True
+    runner._extract_underlying = lambda symbol: "NIFTY"
+    runner._reason_order_cooldown_key = lambda **kwargs: "NIFTY:CE:test"
+    runner._execution_reject_cooldown_result = lambda *args, **kwargs: None
+    runner._reset_execution_state = lambda *args, **kwargs: None
+    runner._mark_directional_dedup_failed = lambda **kwargs: None
+    runner._apply_directional_signal_dedup = lambda **kwargs: None
+    runner._ensure_symbol_execution_ready_result = (
+        lambda *args, **kwargs: SimpleNamespace(
+            allowed=True, reason="ready", details={}
+        )
+    )
+    runner._prepare_order_state_for_submission = lambda *args, **kwargs: (
+        True,
+        "ready",
+        {},
+    )
+    runner._strategy_regime_decision = lambda *args, **kwargs: (True, "allowed")
+    runner._record_trade_decision_snapshot = lambda **kwargs: setattr(
+        runner, "_last_decision", kwargs
+    )
+    runner._record_trade = lambda *args, **kwargs: None
+    runner._reject_signal_execution = (
+        lambda *, symbol, trace_id, reason, details=None: SignalExecutionResult(
+            False, reason, details=dict(details or {})
+        )
+    )
+    runner._current_active_contract_selection = lambda: SimpleNamespace(
+        selected_ce="NFO:CE", selected_pe="NFO:PE"
+    )
+    snap = _snap(ce_ok, pe_ok)
+    runner._option_side_readiness_snapshot = lambda **kwargs: snap
+    calls = {"gate": 0}
+    real = StrategyRunner._readiness_for_candidate_symbol.__get__(
+        runner, StrategyRunner
+    )
+
+    def wrapped(symbol):
+        calls["gate"] += 1
+        return real(symbol)
+
+    runner._readiness_for_candidate_symbol = wrapped
+    return runner, calls
+
+
+def _signal(symbol: str) -> Signal:
+    return Signal(
+        "BUY",
+        symbol,
+        1,
+        1.0,
+        "test",
+        90.0,
+        120.0,
+        metadata={"strategy_name": "test", "final_score": 10.0},
+    )
+
+
+@pytest.mark.parametrize("trade_symbol", ["NFO:CE"])
+def test_entry_path_allows_ready_ce_candidate_and_submits_order(
+    monkeypatch, trade_symbol
+):
+    runner, calls = _execution_runner(monkeypatch, ce_ok=True, pe_ok=False)
+    result = runner._handle_entry_signal_inner(
+        _signal(trade_symbol),
+        "NSE:NIFTY",
+        trade_symbol,
+        100.0,
+        datetime.now(timezone.utc),
+        trace_id="t",
+    )
+    assert calls["gate"] == 1
+    assert result.accepted is True
+    assert len(runner._order_manager.plans) == 1
+    assert runner._order_manager.plans[0].symbol == "NFO:CE"
+
+
+def test_entry_path_rejects_stale_pe_candidate_before_order_manager(monkeypatch):
+    runner, calls = _execution_runner(monkeypatch, ce_ok=True, pe_ok=False)
+    result = runner._handle_entry_signal_inner(
+        _signal("NFO:PE"),
+        "NSE:NIFTY",
+        "NFO:PE",
+        100.0,
+        datetime.now(timezone.utc),
+        trace_id="t",
+    )
+    assert calls["gate"] == 1
+    assert result.accepted is False
+    assert result.reason == "selected_pe_unready"
+    assert result.details["candidate_blockers"] == ["quote_missing"]
+    assert runner._order_manager.plans == []
+
+
+def test_entry_path_rejects_unmapped_nifty_option_before_order_manager(monkeypatch):
+    runner, calls = _execution_runner(monkeypatch, ce_ok=True, pe_ok=True)
+    result = runner._handle_entry_signal_inner(
+        _signal("NFO:OTHERCE"),
+        "NSE:NIFTY",
+        "NFO:OTHERCE",
+        100.0,
+        datetime.now(timezone.utc),
+        trace_id="t",
+    )
+    assert calls["gate"] == 0
+    assert result.accepted is False
+    assert result.reason == "selected_contract_mismatch"
+    assert result.details["candidate_symbol"] == "NFO:OTHERCE"
+    assert result.details["selected_ce"] == "NFO:CE"
+    assert runner._order_manager.plans == []
+
+
+def test_exit_path_does_not_apply_candidate_entry_gate(monkeypatch):
+    runner, calls = _execution_runner(monkeypatch, ce_ok=False, pe_ok=False)
+    submitted = []
+    runner._order_manager.place_reduce_only_exit = (
+        lambda intent: submitted.append(intent) or "EXIT-1"
+    )
+    signal = Signal(
+        "CLOSE_LONG",
+        "NFO:PE",
+        1,
+        1.0,
+        "protective_stop",
+        None,
+        None,
+        metadata={},
+    )
+    runner._handle_exit_signal(
+        signal, "NFO:PE", "NFO:PE", 100.0, datetime.now(timezone.utc)
+    )
+    assert calls["gate"] == 0
+    assert len(submitted) == 1
+    assert submitted[0].symbol == "NFO:PE"

--- a/tests/strategies/test_runner_option_side_readiness.py
+++ b/tests/strategies/test_runner_option_side_readiness.py
@@ -1,10 +1,8 @@
 """CE/PE readiness decoupling: a candidate depends only on its own side."""
+
 from __future__ import annotations
 
 import inspect
-import logging
-import types
-
 import pytest
 
 from nifty_scalper_bot.strategies.runner import StrategyRunner
@@ -29,10 +27,10 @@ def test_pair_wide_coupling_removed_and_side_reasons_present() -> None:
 @pytest.mark.parametrize(
     "ce_ok,pe_ok,candidate_is_ce,expected_ready",
     [
-        (True, False, True, True),    # CE ready, PE stale, CE candidate -> allowed
+        (True, False, True, True),  # CE ready, PE stale, CE candidate -> allowed
         (True, False, False, False),  # CE ready, PE stale, PE candidate -> rejected
-        (False, True, False, True),   # PE ready, CE stale, PE candidate -> allowed
-        (False, True, True, False),   # PE ready, CE stale, CE candidate -> rejected
+        (False, True, False, True),  # PE ready, CE stale, PE candidate -> allowed
+        (False, True, True, False),  # PE ready, CE stale, CE candidate -> rejected
         (True, True, True, True),
         (True, True, False, True),
         (False, False, True, False),  # both stale -> nothing executable
@@ -75,8 +73,9 @@ def test_side_blocker_attribution_is_per_side() -> None:
     side (drives the real inner helper via a bound re-implementation check
     against source: subscription/quote/depth/history are per-side inputs)."""
     src = inspect.getsource(StrategyRunner._emit_live_universe_bootstrap_status)
-    assert "_side_blockers(bool(ce_symbol), ce_sub, ce_quote, ce_depth, ce_hist)" in src
-    assert "_side_blockers(bool(pe_symbol), pe_sub, pe_quote, pe_depth, pe_hist)" in src
+    assert "readiness_snapshot = self._option_side_readiness_snapshot" in src
+    assert "ce_required_bars = ce_ready_snapshot.required_bars" in src
+    assert "pe_required_bars = pe_ready_snapshot.required_bars" in src
     # Exit paths never consult side readiness:
     from nifty_scalper_bot.execution import bracket_core
 


### PR DESCRIPTION
### Motivation

- Remove the remaining production stall risk caused by per-minute `DataFrame` row insertion and make live candle append genuinely O(1). 
- Ensure the finalized candle returned to callers is the canonical normalized payload that is actually stored. 
- Add a single canonical, post-candidate side-readiness gate so candidates generated from context are rejected with clear blocker attribution before risk/order submission. 
- Tighten subscription proof and decouple CE/PE required-bar calculations to avoid hidden cross-leg coupling.

### Description

- Replace live `DataFrame` row appends with a bounded `deque` SSOT (`self._completed_candles`) and expose a lazy DataFrame cache (`_df_cache`) rebuilt only when dirty, preserving `get_df()` compatibility and adding `diagnostics()` counters. 
- Finalize path now appends `normalized` into the deque, sets `_df_cache_dirty = True`, and returns `dict(normalized)` so the returned candle exactly matches the stored canonical row. 
- Make same-minute handling explicit: identical finalized duplicates are idempotently ignored and conflicting same-timestamp corrections raise `DataIntegrityError` and emit `FINALIZED_CANDLE_CONFLICT` diagnostics. 
- Add `OptionSideReadiness` dataclass and `_option_side_readiness_snapshot()` resolver that computes per-side: subscription proof (active/confirmed/WS-token/current-generation fresh tick), `quote_fresh`, `depth_ready`, `history_count`, `required_bars`, `history_ready`, `executable` and `blockers`. 
- Call a single canonical candidate readiness gate (resolved with `_readiness_for_candidate_symbol`) immediately after `order_symbol` resolution and before risk validation/`OrderManager` submission; reject with `selected_ce_unready` / `selected_pe_unready` when appropriate. 
- Compute CE and PE required bars independently (no shared `min_bars`), and expose both values in readiness diagnostics; desired-only subscription is kept as `subscription_requested` but does not prove `subscribed`. 
- Add/modify focused tests that exercise the live candle incremental finalize behavior, canonical-return consistency, deque-backed storage performance characteristics, same-minute conflict semantics, and candidate-side readiness rules.

### Testing

- Ran `python -m compileall -q src` with no compile errors. 
- Focused tests: `pytest -q tests/data/test_candle_engine_incremental_finalize.py tests/strategies/test_runner_option_side_readiness.py tests/strategies/test_candidate_specific_option_readiness.py tests/strategies/test_runner_execution_quote_readiness.py tests/strategies/test_runner_live_suppression_regressions.py tests/test_execution_path_contract.py` — result: 36 passed, 0 skipped, 0 failed. 
- Subsuite runs: `pytest -q tests/data` → 239 passed, 0 skipped, 0 failed; `pytest -q tests/strategies` → 215 passed, 0 skipped, 0 failed; `pytest -q tests/execution` → 371 passed, 0 skipped, 0 failed. 
- Full suite: `pytest -q` → 1684 passed, 2 skipped, 0 failed (test run emitted pre-existing asyncio/logging shutdown noise but no failures). 
- Style/format checks: `python -m black --check` passed for changed files; `python -m ruff check <changed files>` reports repository-existing lint/import/line-length findings in large files (not functionally blocking), and were left as style debt to avoid scope creep.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a578d2f9e9883249996a0e9643b2308)