### PR TITLE
Harden LIVE_SIMULATION adapter safety and route golden live-sim through simulated websocket

### DIFF
--- a/.github/workflows/e2e-live-sim.yml
+++ b/.github/workflows/e2e-live-sim.yml
@@ -18,8 +18,13 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - run: python -m pip install -r requirements.txt
-      - run: pytest -q -m simulation_component tests/e2e/live_sim
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
+          python -m pip install pytest
+      - name: Run simulation component tests
+        run: python -m pytest -q -m simulation_component tests/e2e/live_sim
       - name: Upload component artifacts on failure
         if: failure()
         uses: actions/upload-artifact@v4
@@ -45,8 +50,13 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - run: python -m pip install -r requirements.txt
-      - run: pytest -q -m live_runtime_e2e tests/e2e/live_sim
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
+          python -m pip install pytest
+      - name: Run live runtime E2E tests
+        run: python -m pytest -q -m live_runtime_e2e tests/e2e/live_sim
       - name: Upload runtime artifacts on failure
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/e2e-live-sim.yml
+++ b/.github/workflows/e2e-live-sim.yml
@@ -13,7 +13,6 @@ jobs:
       ALLOW_NETWORK: "false"
       ALLOW_REAL_BROKER: "false"
       BROKER_SIMULATION: "true"
-      EXECUTION_MODE: LIVE_SIMULATION
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -7519,22 +7519,38 @@ def _is_live_simulation_mode(configured_mode: str | None = None) -> bool:
     return mode_name == "LIVE_SIMULATION"
 
 
+def _is_explicit_simulated_adapter(adapter: Any) -> bool:
+    if adapter is None:
+        return False
+
+    if bool(getattr(adapter, "is_simulated_adapter", False)):
+        return True
+
+    wrapped = getattr(adapter, "client", None)
+    if wrapped is not None and bool(
+        getattr(wrapped, "is_simulated_adapter", False)
+    ):
+        return True
+
+    wrapped = getattr(adapter, "_broker", None)
+    if wrapped is not None and bool(
+        getattr(wrapped, "is_simulated_adapter", False)
+    ):
+        return True
+
+    return False
+
+
 def _assert_live_simulation_adapter_safe(adapter: Any, *, component: str) -> None:
     """Fail fast if LIVE_SIMULATION is wired to a real external adapter."""
 
     if not _is_live_simulation_mode():
         return
-    cls = adapter.__class__
-    module = str(getattr(cls, "__module__", ""))
-    name = str(getattr(cls, "__name__", ""))
-    real_markers = (
-        "nifty_scalper_bot.data.rest",
-        "nifty_scalper_bot.streaming.websocket_manager",
-    )
-    if name in {"ZerodhaKiteClient", "WebSocketManager"} or module.startswith(
-        real_markers
-    ):
-        raise RuntimeError(f"LIVE_SIMULATION requires simulated {component} adapter")
+
+    if not _is_explicit_simulated_adapter(adapter):
+        raise RuntimeError(
+            f"LIVE_SIMULATION requires an explicitly simulated {component} adapter"
+        )
 
 
 def _is_live_execution_mode(configured_mode: str | None = None) -> bool:

--- a/src/nifty_scalper_bot/execution/order_manager_core.py
+++ b/src/nifty_scalper_bot/execution/order_manager_core.py
@@ -2285,12 +2285,44 @@ class OrderManager:
         )
         return any(marker in text for marker in signature_markers)
 
+    def _validate_execution_adapter(self) -> None:
+        mode = self._execution_mode_env()
+
+        if mode != "LIVE_SIMULATION":
+            return
+
+        broker = getattr(self, "broker", None)
+        if broker is None:
+            broker = getattr(self, "_broker", None)
+        if broker is None:
+            broker = getattr(self, "broker_client", None)
+
+        is_simulated = bool(getattr(broker, "is_simulated_adapter", False))
+
+        wrapped = getattr(broker, "client", None)
+        if wrapped is not None:
+            is_simulated = is_simulated or bool(
+                getattr(wrapped, "is_simulated_adapter", False)
+            )
+
+        wrapped = getattr(broker, "_broker", None)
+        if wrapped is not None:
+            is_simulated = is_simulated or bool(
+                getattr(wrapped, "is_simulated_adapter", False)
+            )
+
+        if not is_simulated:
+            raise RuntimeError(
+                "LIVE_SIMULATION cannot submit orders through a non-simulated broker"
+            )
+
     def _submit_broker_order(
         self,
         payload: dict[str, object],
         *,
         legacy_payload: dict[str, object] | None = None,
     ) -> dict[str, object]:
+        self._validate_execution_adapter()
         try:
             response = self._broker.place_order(**payload)
         except TypeError as exc:
@@ -6990,6 +7022,7 @@ class OrderManager:
     def cancel_order(self, order_id: str) -> bool:
         """Cancel an order. Intercepts Virtual Brackets for clean shutdown."""
 
+        self._validate_execution_adapter()
         # 1. Intercept Virtual Bracket Cancellation
         if self._bracket_manager:
             # If strategy tries to cancel the Entry ID, it implies "Abort Trade"
@@ -7307,6 +7340,7 @@ class OrderManager:
                 )
 
             # 3. Execute Modification
+            self._validate_execution_adapter()
             self._broker.modify_order(
                 order_id=order_id,
                 price=price,
@@ -10899,6 +10933,7 @@ class OrderManager:
         return payload
 
     def _submit_order_with_retry(self, payload: dict[str, Any]) -> dict[str, Any]:
+        self._validate_execution_adapter()
         last_error: Exception | None = None
         client_order_id = str(payload.get("client_order_id") or "").strip()
         if client_order_id:

--- a/tests/e2e/live_sim/simulated_broker.py
+++ b/tests/e2e/live_sim/simulated_broker.py
@@ -65,6 +65,7 @@ class SimulatedTrade:
 
 
 class SimulatedBroker:
+    is_simulated_adapter = True
     """Deterministic broker/matcher.
 
     Long protective stops trigger on bid or LTP <= stop.

--- a/tests/e2e/live_sim/simulated_history_provider.py
+++ b/tests/e2e/live_sim/simulated_history_provider.py
@@ -17,6 +17,7 @@ class HistoryRequest:
 
 
 class SimulatedHistoryProvider:
+    is_simulated_adapter = True
     def __init__(self, clock, recorder=None) -> None:
         self.clock = clock
         self.recorder = recorder

--- a/tests/e2e/live_sim/simulated_websocket.py
+++ b/tests/e2e/live_sim/simulated_websocket.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import asyncio
+import inspect
 import time
 from dataclasses import dataclass
 from typing import Any
@@ -14,12 +16,57 @@ class SubscriptionProof:
 
 
 class SimulatedWebSocket:
+    is_simulated_adapter = True
     """Production-stream seam for deterministic subscription lifecycle tests."""
 
     def __init__(self, market_data: Any, recorder: Any | None = None) -> None:
         self.market_data = market_data
         self.recorder = recorder
         self.transitions: list[SubscriptionProof] = []
+        self._callbacks: dict[str, Any] = {}
+        self.connected = False
+
+
+    def set_callbacks(self, **callbacks: Any) -> None:
+        existing = getattr(self, "_callbacks", {})
+        existing.update(callbacks)
+        self._callbacks = existing
+
+    def connect(self) -> None:
+        self.connected = True
+
+        callback = (
+            self._callbacks.get("on_connect")
+            or self._callbacks.get("on_open")
+        )
+
+        if callback is not None:
+            result = callback()
+            if inspect.isawaitable(result):
+                asyncio.get_event_loop().run_until_complete(result)
+
+    def publish_tick(self, tick: dict[str, Any]) -> None:
+        if not self.connected:
+            raise RuntimeError("simulated websocket is not connected")
+
+        callback = (
+            self._callbacks.get("on_ticks")
+            or self._callbacks.get("on_tick")
+        )
+
+        if callback is None:
+            raise RuntimeError(
+                "production websocket tick callback was not registered"
+            )
+
+        try:
+            result = callback([tick])
+        except TypeError:
+            result = callback(tick)
+
+        if inspect.isawaitable(result):
+            loop = asyncio.get_event_loop()
+            loop.run_until_complete(result)
 
     def request(self, symbol: str, token: int) -> SubscriptionProof:
         self.market_data.register_symbol(symbol, token)

--- a/tests/e2e/live_sim/test_live_runtime_startup_contract.py
+++ b/tests/e2e/live_sim/test_live_runtime_startup_contract.py
@@ -4,7 +4,6 @@ import asyncio
 import inspect
 from dataclasses import asdict
 from datetime import date, timedelta
-import time
 from typing import Any
 
 import pandas as pd
@@ -368,8 +367,14 @@ async def _initialize_runtime() -> BotContext:
     return initialize_components()
 
 
-def _publish_tick(ctx: BotContext, symbol: str, token: int, price: float) -> None:
-    now = pd.Timestamp.now(tz="UTC")
+def _publish_tick(
+    ctx: BotContext,
+    symbol: str,
+    token: int,
+    price: float,
+    *,
+    timestamp: pd.Timestamp,
+) -> None:
     tick = {
         "instrument_token": int(token),
         "symbol": symbol,
@@ -382,13 +387,69 @@ def _publish_tick(ctx: BotContext, symbol: str, token: int, price: float) -> Non
             "sell": [{"price": float(price) + 0.05, "quantity": 1000}],
         },
         "volume": 10000,
-        "timestamp": now.to_pydatetime(),
-        "exchange_timestamp": now.to_pydatetime(),
-        "timestamp_ms": float(now.timestamp() * 1000.0),
+        "timestamp": timestamp.to_pydatetime(),
+        "exchange_timestamp": timestamp.to_pydatetime(),
+        "timestamp_ms": float(timestamp.timestamp() * 1000.0),
         "source": "websocket",
     }
     assert ctx.websocket_manager is not None
     ctx.websocket_manager.publish_tick(tick)
+
+
+def _pump_runtime(
+    loop: asyncio.AbstractEventLoop,
+    ctx: BotContext,
+    *,
+    iterations: int = 100,
+) -> None:
+    for _ in range(iterations):
+        ctx.market_data_manager._drain_tick_queue_sync()  # noqa: SLF001 - drain production queue
+        loop.run_until_complete(asyncio.sleep(0.01))
+
+
+def _wait_until(
+    loop: asyncio.AbstractEventLoop,
+    ctx: BotContext,
+    predicate,
+    *,
+    iterations: int = 200,
+    failure_message: str,
+) -> None:
+    for _ in range(iterations):
+        ctx.market_data_manager._drain_tick_queue_sync()  # noqa: SLF001 - drain production queue
+        loop.run_until_complete(asyncio.sleep(0.01))
+        if predicate():
+            return
+    raise AssertionError(failure_message)
+
+
+def _quote_ltp(ctx: BotContext, symbol: str) -> float:
+    quote = ctx.data_hub.get_quote(symbol, allow_pull=False) if ctx.data_hub else None
+    if quote is None and ctx.market_data_manager is not None:
+        quote = ctx.market_data_manager.get_quote(symbol)
+    if isinstance(quote, dict):
+        value = quote.get("ltp") or quote.get("last_price")
+    else:
+        value = getattr(quote, "ltp", 0.0)
+    try:
+        return float(value or 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _broker_symbol_qty(broker: Any, symbol: str) -> int:
+    return sum(
+        int(p.get("quantity", 0))
+        for p in broker.get_positions()
+        if p.get("symbol") == symbol
+    )
+
+
+def _position_manager_qty(ctx: BotContext, symbol: str) -> int:
+    position = ctx.position_manager.get_position(symbol)
+    if position is None:
+        return 0
+    return int(getattr(position, "quantity", 0) or 0)
 
 
 @pytest.mark.simulation_component
@@ -590,12 +651,21 @@ def test_live_runtime_bullish_spot_future_selects_ce_and_exits_target(
             ctx.order_manager.apply_broker_order_update
         )
 
-        for sym, tok, price in (
-            ("NSE:NIFTY", basket.spot_token, 25000.0),
-            (basket.futures_symbol, basket.futures_token, 25020.0),
-            (basket.selected_ce, basket.selected_ce_token, 112.0),
-            (basket.selected_pe, basket.selected_pe_token, 96.0),
-        ):
+        fixed_base_tick_time = pd.Timestamp(
+            "2026-07-16 10:00:00",
+            tz="Asia/Kolkata",
+        ).tz_convert("UTC")
+        fresh_base_tick_time = pd.Timestamp.now(tz="UTC").floor("s") - pd.Timedelta(
+            seconds=31
+        )
+        base_tick_time = max(fixed_base_tick_time, fresh_base_tick_time)
+        startup_ticks = (
+            ("NSE:NIFTY", basket.spot_token, 25000.0, 1),
+            (basket.futures_symbol, basket.futures_token, 25020.0, 2),
+            (basket.selected_ce, basket.selected_ce_token, 112.0, 3),
+            (basket.selected_pe, basket.selected_pe_token, 96.0, 4),
+        )
+        for sym, tok, price, offset_seconds in startup_ticks:
             assert core_app._register_and_subscribe_live_symbol(  # noqa: SLF001 - production app subscribe helper
                 ctx,
                 sym,
@@ -603,7 +673,20 @@ def test_live_runtime_bullish_spot_future_selects_ce_and_exits_target(
                 "live_sim",
                 role="tradable_option" if sym.endswith(("CE", "PE")) else "context",
             )
-            _publish_tick(ctx, sym, int(tok), price)
+            _publish_tick(
+                ctx,
+                sym,
+                int(tok),
+                price,
+                timestamp=base_tick_time + pd.Timedelta(seconds=offset_seconds),
+            )
+            _wait_until(
+                loop,
+                ctx,
+                lambda sym=sym, price=price: _quote_ltp(ctx, sym) == float(price),
+                failure_message=f"startup tick did not reach DataHub for {sym}",
+            )
+        _pump_runtime(loop, ctx, iterations=20)
 
         assert ctx.live_orders_armed is False
         loop.run_until_complete(
@@ -612,89 +695,117 @@ def test_live_runtime_bullish_spot_future_selects_ce_and_exits_target(
         assert ctx.live_orders_armed is True, ctx.live_block_reason
 
         submitted_before = len(broker.get_orders())
-        ctx.strategy_runner._last_same_bar_eval_ts_by_symbol.pop(  # noqa: SLF001 - test-only throttle reset
+        _publish_tick(
+            ctx,
             basket.selected_ce,
-            None,
+            basket.selected_ce_token,
+            116.0,
+            timestamp=base_tick_time + pd.Timedelta(seconds=15),
         )
-        ctx.strategy_runner._last_periodic_eval_at_by_symbol.pop(  # noqa: SLF001 - test-only throttle reset
-            basket.selected_ce,
-            None,
+        _wait_until(
+            loop,
+            ctx,
+            lambda: _quote_ltp(ctx, basket.selected_ce) == 116.0,
+            failure_message="CE trigger tick did not reach DataHub",
         )
-        _publish_tick(ctx, basket.selected_ce, basket.selected_ce_token, 116.0)
+        _wait_until(
+            loop,
+            ctx,
+            lambda: len(broker.get_orders()) == submitted_before + 1,
+            failure_message=str(
+                {
+                    "orders": broker.get_orders(),
+                    "no_signal": ctx.strategy_manager.get_last_no_signal_decision(
+                        basket.selected_ce
+                    ),
+                    "tick_ready": ctx.market_data_manager.classify_live_tick_readiness(
+                        basket.selected_ce,
+                        basket.selected_ce_token,
+                        max_age_s=20.0,
+                    ),
+                }
+            ),
+        )
         orders = broker.get_orders()
-        for _ in range(100):
-            if len(orders) == submitted_before + 1:
-                break
-            ctx.market_data_manager._drain_tick_queue_sync()  # noqa: SLF001 - drain production queue
-            time.sleep(0.01)
-            orders = broker.get_orders()
-        assert len(orders) == submitted_before + 1, {
-            "orders": orders,
-            "no_signal": ctx.strategy_manager.get_last_no_signal_decision(
-                basket.selected_ce
-            ),
-            "mdm_tracked": ctx.market_data_manager.is_symbol_tracked(
-                basket.selected_ce
-            ),
-            "tick_ready": ctx.market_data_manager.classify_live_tick_readiness(
-                basket.selected_ce, basket.selected_ce_token, max_age_s=5.0
-            ),
-        }
         entry = orders[-1]
         assert entry["symbol"] == basket.selected_ce
         assert entry["transaction_type"] == "BUY"
-        for _ in range(50):
-            if entry["order_id"] in getattr(ctx.position_manager, "_orders", {}):
-                break
-            time.sleep(0.01)
-        assert entry["order_id"] in getattr(ctx.position_manager, "_orders", {})
+        _wait_until(
+            loop,
+            ctx,
+            lambda: entry["order_id"] in getattr(ctx.position_manager, "_orders", {}),
+            failure_message="entry order was not tracked internally",
+        )
 
         broker.fill_order(
             entry["order_id"], average_price=float(entry["price"] or 116.0)
         )
-        position = ctx.position_manager.get_position(basket.selected_ce)
-        assert position is not None
-        assert int(getattr(position, "quantity", 0)) > 0
-        assert ctx.bracket_manager.is_symbol_managed(basket.selected_ce)
+        _wait_until(
+            loop,
+            ctx,
+            lambda: _position_manager_qty(ctx, basket.selected_ce) > 0,
+            failure_message="entry fill did not update PositionManager",
+        )
+        _wait_until(
+            loop,
+            ctx,
+            lambda: ctx.bracket_manager.is_symbol_managed(basket.selected_ce),
+            failure_message="entry fill did not activate bracket management",
+        )
 
         # Let production bracket logic see the target-side market move through the
         # normal MDM/DataHub path, then fill the resulting simulated exit order.
-        _publish_tick(ctx, basket.selected_ce, basket.selected_ce_token, 200.0)
-        target_orders: list[dict[str, Any]] = []
-        for _ in range(50):
-            target_orders = [
-                order
-                for order in broker.get_orders()
-                if order["order_id"] != entry["order_id"]
+        _publish_tick(
+            ctx,
+            basket.selected_ce,
+            basket.selected_ce_token,
+            200.0,
+            timestamp=base_tick_time + pd.Timedelta(seconds=30),
+        )
+        _wait_until(
+            loop,
+            ctx,
+            lambda: _quote_ltp(ctx, basket.selected_ce) == 200.0,
+            failure_message="CE target tick did not reach DataHub",
+        )
+        _wait_until(
+            loop,
+            ctx,
+            lambda: any(
+                order["order_id"] != entry["order_id"]
                 and order.get("transaction_type") == "SELL"
-            ]
-            if target_orders:
-                break
-            ctx.market_data_manager._drain_tick_queue_sync()  # noqa: SLF001 - drain production queue
-            time.sleep(0.01)
-        assert target_orders, broker.get_orders()
+                for order in broker.get_orders()
+            ),
+            failure_message=f"target SELL order did not appear: {broker.get_orders()}",
+        )
+        target_orders = [
+            order
+            for order in broker.get_orders()
+            if order["order_id"] != entry["order_id"]
+            and order.get("transaction_type") == "SELL"
+        ]
         target_id = target_orders[-1]["order_id"]
-        for _ in range(50):
-            if target_id in getattr(ctx.order_manager, "_orders", {}):
-                break
-            time.sleep(0.01)
-        assert target_id in getattr(ctx.order_manager, "_orders", {})
+        _wait_until(
+            loop,
+            ctx,
+            lambda: target_id in getattr(ctx.order_manager, "_orders", {}),
+            failure_message="target order was not tracked internally",
+        )
         broker.fill_order(target_id, average_price=200.0)
+        _pump_runtime(loop, ctx)
         loop.run_until_complete(core_app._reconcile_state(ctx))  # noqa: SLF001
         assert ctx.position_reconciliation_completed is True
 
-        final_qty = sum(
-            int(p.get("quantity", 0))
-            for p in broker.get_positions()
-            if p.get("symbol") == basket.selected_ce
+        _wait_until(
+            loop,
+            ctx,
+            lambda: _broker_symbol_qty(broker, basket.selected_ce) == 0
+            and _position_manager_qty(ctx, basket.selected_ce) == 0
+            and not ctx.bracket_manager.is_symbol_managed(basket.selected_ce),
+            failure_message="exit fill did not flatten broker/internal state and clear bracket",
         )
-        assert final_qty == 0
-        final_position = ctx.position_manager.get_position(basket.selected_ce)
-        assert (
-            final_position is None or int(getattr(final_position, "quantity", 0)) == 0
-        )
-        if ctx.bracket_manager.is_symbol_managed(basket.selected_ce):
-            ctx.bracket_manager.reconcile_symbol_flat(basket.selected_ce)
+        assert _broker_symbol_qty(broker, basket.selected_ce) == 0
+        assert _position_manager_qty(ctx, basket.selected_ce) == 0
         assert not ctx.bracket_manager.is_symbol_managed(basket.selected_ce)
     finally:
         pending = [task for task in asyncio.all_tasks(loop) if not task.done()]

--- a/tests/e2e/live_sim/test_live_runtime_startup_contract.py
+++ b/tests/e2e/live_sim/test_live_runtime_startup_contract.py
@@ -612,9 +612,17 @@ def test_live_runtime_bullish_spot_future_selects_ce_and_exits_target(
         assert ctx.live_orders_armed is True, ctx.live_block_reason
 
         submitted_before = len(broker.get_orders())
+        ctx.strategy_runner._last_same_bar_eval_ts_by_symbol.pop(  # noqa: SLF001 - test-only throttle reset
+            basket.selected_ce,
+            None,
+        )
+        ctx.strategy_runner._last_periodic_eval_at_by_symbol.pop(  # noqa: SLF001 - test-only throttle reset
+            basket.selected_ce,
+            None,
+        )
         _publish_tick(ctx, basket.selected_ce, basket.selected_ce_token, 116.0)
         orders = broker.get_orders()
-        for _ in range(50):
+        for _ in range(100):
             if len(orders) == submitted_before + 1:
                 break
             ctx.market_data_manager._drain_tick_queue_sync()  # noqa: SLF001 - drain production queue

--- a/tests/e2e/live_sim/test_live_runtime_startup_contract.py
+++ b/tests/e2e/live_sim/test_live_runtime_startup_contract.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
 from dataclasses import asdict
-from datetime import date, datetime, timedelta, timezone
+from datetime import date, timedelta
 import time
 from typing import Any
 
@@ -23,10 +24,11 @@ from nifty_scalper_bot.risk.risk_manager import RiskManager
 from nifty_scalper_bot.strategies.indicators import IndicatorEngine
 from nifty_scalper_bot.strategies.runner import StrategyRunner
 
-pytestmark = [pytest.mark.e2e_live_sim, pytest.mark.live_runtime_e2e]
+pytestmark = pytest.mark.e2e_live_sim
 
 
 class _NoNetworkBroker:
+    is_simulated_adapter = True
     """Broker stand-in for production composition startup only.
 
     It implements the broker methods that app.initialize_components wires into
@@ -171,6 +173,7 @@ class _NoNetworkBroker:
 
 
 class _NoNetworkWebSocketManager:
+    is_simulated_adapter = True
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         self._callbacks: dict[str, Any] = {}
         self._subscribed_tokens: set[int] = set()
@@ -179,6 +182,35 @@ class _NoNetworkWebSocketManager:
 
     def set_callbacks(self, **callbacks: Any) -> None:
         self._callbacks.update(callbacks)
+
+    def connect(self) -> None:
+        self.connected = True
+        callback = self._callbacks.get("on_connect") or self._callbacks.get("on_open")
+        if callback is not None:
+            result = callback()
+            if inspect.isawaitable(result):
+                asyncio.get_event_loop().run_until_complete(result)
+
+    def publish_tick(self, tick: dict[str, Any]) -> None:
+        if not self.connected:
+            raise RuntimeError("simulated websocket is not connected")
+        callback = self._callbacks.get("on_ticks") or self._callbacks.get("on_tick")
+        if callback is None:
+            # Production WebSocketManager routes through its injected MDM reference.
+            mdm = getattr(self, "_market_data_manager", None)
+            if mdm is None:
+                raise RuntimeError("production websocket tick callback was not registered")
+            mdm.process_ticks([tick])
+            drain = getattr(mdm, "_drain_tick_queue_sync", None)
+            if callable(drain):
+                drain()
+            return
+        try:
+            result = callback([tick])
+        except TypeError:
+            result = callback(tick)
+        if inspect.isawaitable(result):
+            asyncio.get_event_loop().run_until_complete(result)
 
     def set_fallback_callbacks(self, **callbacks: Any) -> None:
         self._fallback_callbacks = callbacks
@@ -199,6 +231,7 @@ class _NoNetworkWebSocketManager:
 
 
 class _NoNetworkRobustProvider:
+    is_simulated_adapter = True
     def __init__(self, broker_client: Any, *args: Any, **kwargs: Any) -> None:
         self.client = broker_client
         self._broker = broker_client
@@ -354,22 +387,24 @@ def _publish_tick(ctx: BotContext, symbol: str, token: int, price: float) -> Non
         "timestamp_ms": float(now.timestamp() * 1000.0),
         "source": "websocket",
     }
-    ctx.market_data_manager.process_ticks([tick])
-    ctx.market_data_manager._drain_tick_queue_sync()  # noqa: SLF001 - drain production queue
+    assert ctx.websocket_manager is not None
+    ctx.websocket_manager.publish_tick(tick)
 
 
-def test_live_simulation_blocks_real_broker_adapter(monkeypatch):
+@pytest.mark.simulation_component
+def test_live_simulation_rejects_unmarked_broker(monkeypatch):
     monkeypatch.setenv("EXECUTION_MODE", "LIVE_SIMULATION")
 
-    class ZerodhaKiteClient:
+    class Broker:
         pass
 
     with pytest.raises(RuntimeError, match="simulated broker"):
         core_app._assert_live_simulation_adapter_safe(  # noqa: SLF001 - focused safety hook
-            ZerodhaKiteClient(), component="broker"
+            Broker(), component="broker"
         )
 
 
+@pytest.mark.simulation_component
 def test_live_simulation_blocks_real_websocket_adapter(monkeypatch):
     monkeypatch.setenv("EXECUTION_MODE", "LIVE_SIMULATION")
 
@@ -382,16 +417,18 @@ def test_live_simulation_blocks_real_websocket_adapter(monkeypatch):
         )
 
 
-def test_live_simulation_allows_simulated_adapters(monkeypatch):
+@pytest.mark.simulation_component
+def test_live_simulation_accepts_marked_broker(monkeypatch):
     monkeypatch.setenv("EXECUTION_MODE", "LIVE_SIMULATION")
+    class Broker:
+        is_simulated_adapter = True
+
     core_app._assert_live_simulation_adapter_safe(  # noqa: SLF001 - focused safety hook
-        _NoNetworkBroker(), component="broker"
-    )
-    core_app._assert_live_simulation_adapter_safe(  # noqa: SLF001 - focused safety hook
-        _NoNetworkWebSocketManager(), component="websocket"
+        Broker(), component="broker"
     )
 
 
+@pytest.mark.live_runtime_e2e
 def test_live_runtime_starts_from_production_composition_with_simulated_adapters(
     monkeypatch, tmp_path
 ):
@@ -446,6 +483,7 @@ def test_live_runtime_starts_from_production_composition_with_simulated_adapters
     assert ctx.live_orders_armed is False
 
 
+@pytest.mark.live_runtime_e2e
 def test_live_runtime_bullish_spot_future_selects_ce_and_exits_target(
     monkeypatch, tmp_path
 ):
@@ -541,8 +579,11 @@ def test_live_runtime_bullish_spot_future_selects_ce_and_exits_target(
             assert len(ctx.market_data_manager.get_ohlc_bars(sym) or []) >= 20
             assert len(ctx.indicator_engine.get_history(sym) or []) >= 20
 
-        ctx.broker_balance_valid = True
-        ctx.position_reconciliation_completed = True
+        assert ctx.broker_balance_valid is True
+        loop.run_until_complete(core_app._reconcile_state(ctx))  # noqa: SLF001
+        assert ctx.position_reconciliation_completed is True
+        assert ctx.websocket_manager is not None
+        ctx.websocket_manager.connect()
         ctx.strategy_runner.start()
         broker = ctx.broker_client.client
         broker.register_order_update_callback(
@@ -571,19 +612,14 @@ def test_live_runtime_bullish_spot_future_selects_ce_and_exits_target(
         assert ctx.live_orders_armed is True, ctx.live_block_reason
 
         submitted_before = len(broker.get_orders())
-        ctx.strategy_runner.on_datahub_tick(
-            {
-                "symbol": basket.selected_ce,
-                "instrument_token": basket.selected_ce_token,
-                "last_price": 116.0,
-                "ltp": 116.0,
-                "bid": 115.95,
-                "ask": 116.05,
-                "timestamp": datetime.now(timezone.utc),
-                "source": "websocket",
-            }
-        )
+        _publish_tick(ctx, basket.selected_ce, basket.selected_ce_token, 116.0)
         orders = broker.get_orders()
+        for _ in range(50):
+            if len(orders) == submitted_before + 1:
+                break
+            ctx.market_data_manager._drain_tick_queue_sync()  # noqa: SLF001 - drain production queue
+            time.sleep(0.01)
+            orders = broker.get_orders()
         assert len(orders) == submitted_before + 1, {
             "orders": orders,
             "no_signal": ctx.strategy_manager.get_last_no_signal_decision(
@@ -599,6 +635,11 @@ def test_live_runtime_bullish_spot_future_selects_ce_and_exits_target(
         entry = orders[-1]
         assert entry["symbol"] == basket.selected_ce
         assert entry["transaction_type"] == "BUY"
+        for _ in range(50):
+            if entry["order_id"] in getattr(ctx.position_manager, "_orders", {}):
+                break
+            time.sleep(0.01)
+        assert entry["order_id"] in getattr(ctx.position_manager, "_orders", {})
 
         broker.fill_order(
             entry["order_id"], average_price=float(entry["price"] or 116.0)
@@ -624,8 +665,15 @@ def test_live_runtime_bullish_spot_future_selects_ce_and_exits_target(
             ctx.market_data_manager._drain_tick_queue_sync()  # noqa: SLF001 - drain production queue
             time.sleep(0.01)
         assert target_orders, broker.get_orders()
-        broker.fill_order(target_orders[-1]["order_id"], average_price=200.0)
-        assert ctx.position_manager.reconcile_now() is True
+        target_id = target_orders[-1]["order_id"]
+        for _ in range(50):
+            if target_id in getattr(ctx.order_manager, "_orders", {}):
+                break
+            time.sleep(0.01)
+        assert target_id in getattr(ctx.order_manager, "_orders", {})
+        broker.fill_order(target_id, average_price=200.0)
+        loop.run_until_complete(core_app._reconcile_state(ctx))  # noqa: SLF001
+        assert ctx.position_reconciliation_completed is True
 
         final_qty = sum(
             int(p.get("quantity", 0))
@@ -637,6 +685,9 @@ def test_live_runtime_bullish_spot_future_selects_ce_and_exits_target(
         assert (
             final_position is None or int(getattr(final_position, "quantity", 0)) == 0
         )
+        if ctx.bracket_manager.is_symbol_managed(basket.selected_ce):
+            ctx.bracket_manager.reconcile_symbol_flat(basket.selected_ce)
+        assert not ctx.bracket_manager.is_symbol_managed(basket.selected_ce)
     finally:
         pending = [task for task in asyncio.all_tasks(loop) if not task.done()]
         for task in pending:

--- a/tests/execution/test_order_manager_execution_mode_regression.py
+++ b/tests/execution/test_order_manager_execution_mode_regression.py
@@ -52,3 +52,57 @@ def test_live_mode_requires_live_flag(monkeypatch, tmp_path):
             position_manager=DummyPositionManager(),
             rate_limiter=DummyRateLimiter(),
         )
+
+
+class _SubmittingBroker:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def place_order(self, **kwargs):
+        self.calls += 1
+        return {"order_id": "SIM-1", "status": "success"}
+
+
+class _MarkedSubmittingBroker(_SubmittingBroker):
+    is_simulated_adapter = True
+
+
+def _live_sim_order_manager(tmp_path, broker):
+    from nifty_scalper_bot.execution.position_manager import PositionManager
+    from nifty_scalper_bot.utils.rate_limiter import RateLimiter
+
+    return OrderManager(
+        broker_client=broker,
+        position_manager=PositionManager(str(tmp_path / "positions.json")),
+        rate_limiter=RateLimiter(),
+    )
+
+
+def test_live_simulation_order_submission_rejects_unmarked_broker(monkeypatch, tmp_path):
+    monkeypatch.setenv("EXECUTION_MODE", "LIVE_SIMULATION")
+    monkeypatch.setenv("ENABLE_LIVE", "true")
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    broker = _SubmittingBroker()
+    manager = _live_sim_order_manager(tmp_path, broker)
+
+    with pytest.raises(RuntimeError, match="non-simulated broker"):
+        manager._submit_order_with_retry(  # noqa: SLF001 - canonical broker submission guard
+            {"symbol": "NFO:NIFTY26AUG25000CE", "side": "BUY", "quantity": 75}
+        )
+
+    assert broker.calls == 0
+
+
+def test_live_simulation_order_submission_allows_marked_broker(monkeypatch, tmp_path):
+    monkeypatch.setenv("EXECUTION_MODE", "LIVE_SIMULATION")
+    monkeypatch.setenv("ENABLE_LIVE", "true")
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    broker = _MarkedSubmittingBroker()
+    manager = _live_sim_order_manager(tmp_path, broker)
+
+    response = manager._submit_order_with_retry(  # noqa: SLF001 - canonical broker submission guard
+        {"symbol": "NFO:NIFTY26AUG25000CE", "side": "BUY", "quantity": 75}
+    )
+
+    assert response["order_id"] == "SIM-1"
+    assert broker.calls == 1


### PR DESCRIPTION
### Motivation

- Ensure the `LIVE_SIMULATION` runtime cannot be accidentally wired to real adapters by relying on explicit adapter capability markers rather than class/module name heuristics. 
- Add a second, per-submission safety guard so order submissions in `LIVE_SIMULATION` are double-checked before reaching a broker.
- Make the golden end-to-end live-sim test exercise the real websocket → MDM → DataHub → StrategyRunner path (production wiring) instead of calling the runner directly.
- Keep production readiness and reconciliation flow intact so the single CE-entry → simulated fill → bracket exit scenario runs reliably.

### Description

- Replace class-name/module-path checks in `_assert_live_simulation_adapter_safe` with an explicit capability probe that recognizes `is_simulated_adapter` on the adapter or wrapped clients (`.client` / `._broker`). (file: `src/nifty_scalper_bot/core/app.py`)
- Add `is_simulated_adapter = True` to the simulated adapters used by tests: `SimulatedBroker`, `SimulatedWebSocket`, and `SimulatedHistoryProvider`. (files: `tests/e2e/live_sim/simulated_broker.py`, `tests/e2e/live_sim/simulated_websocket.py`, `tests/e2e/live_sim/simulated_history_provider.py`)
- Implement `_validate_execution_adapter` in `OrderManager` and call it immediately before canonical broker submission paths (place, retry-backed submit, modify, cancel) to reject non-simulated brokers under `LIVE_SIMULATION`. (file: `src/nifty_scalper_bot/execution/order_manager_core.py`)
- Extend the simulated websocket with `set_callbacks`, `connect`, and `publish_tick` methods so tests can publish ticks through the production websocket callbacks and the MDM/DataHub pipeline. (file: `tests/e2e/live_sim/simulated_websocket.py`)
- Update the golden runtime test to: publish ticks through `ctx.websocket_manager.publish_tick(...)`, call the existing reconciliation/startup helpers instead of forcing flags, recompute production readiness, wait for production order objects to be tracked, and assert the full CE entry → fill → target exit lifecycle including final broker and internal position reconciliation and no remaining bracket. (file: `tests/e2e/live_sim/test_live_runtime_startup_contract.py`)
- Split pytest markers so component/adapter tests use `@pytest.mark.simulation_component` and runtime scenarios use `@pytest.mark.live_runtime_e2e`, and adjust the CI workflow environment for the simulation components job to remove `EXECUTION_MODE: LIVE_SIMULATION`. (files: `tests/e2e/live_sim/test_live_runtime_startup_contract.py`, `.github/workflows/e2e-live-sim.yml`)
- Add focused safety/regression tests for the new adapter checks and OrderManager guard to ensure `LIVE_SIMULATION` rejects unmarked brokers and allows marked simulated brokers. (file: `tests/execution/test_order_manager_execution_mode_regression.py`)

### Testing

- Ran a byte-compile: `python -m compileall -q src tests` which succeeded.
- Ran simulation component tests: `pytest -q -m simulation_component tests/e2e/live_sim` — 23 passed (all simulation-component tests green).
- Ran live-runtime e2e tests: `pytest -q -m live_runtime_e2e tests/e2e/live_sim` — 2 passed (golden runtime scenarios passed).
- Ran focused execution/core/data/strategies suites: `pytest -q tests/execution` (373 passed), `pytest -q tests/core` (227 passed), `pytest -q tests/data` (241 passed), `pytest -q tests/strategies` (240 passed).
- Ran the full test suite: `pytest -q` — 1746 passed, 1 skipped (1747 collected); overall test run succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a590817be588324b7dd0b6e22af96a5)