### PR TITLE
Fix candle history/live reconciliation and clock-flush races

### DIFF
--- a/src/nifty_scalper_bot/core/market_data_hardening_bootstrap.py
+++ b/src/nifty_scalper_bot/core/market_data_hardening_bootstrap.py
@@ -1,10 +1,7 @@
 """Deterministic market-data hardening bootstrap.
 
-This module is intentionally narrow: it verifies that the live market-data
-classes expose their runtime hardening hooks before the trading app is built.
-The class definition files still own the actual hook installation; this layer
-makes startup visibility explicit and fails loudly in real live mode if the
-hooks cannot be confirmed.
+This module verifies that candle, manager, and WebSocket hardening hooks are
+installed before the trading application is built.
 """
 
 from __future__ import annotations
@@ -14,11 +11,15 @@ from typing import Any
 _MDM_HARDENING_ATTR = "_freshness_hardening_installed"
 _WS_HARDENING_ATTR = "_market_data_hardening_installed"
 _CANDLE_HARDENING_ATTR = "_candle_state_hardening_installed"
+_CLOCK_FLUSH_HARDENING_ATTR = "_candle_clock_flush_hardening_installed"
 
 
 def install_market_data_hardening_or_raise(logger: Any | None = None) -> dict[str, bool]:
-    """Install and verify candle, MDM, and WebSocket hardening layers."""
+    """Install and verify all live market-data hardening layers."""
 
+    from nifty_scalper_bot.data.candle_clock_flush_hardening import (
+        install_candle_clock_flush_hardening,
+    )
     from nifty_scalper_bot.data.candle_engine import CandleEngine
     from nifty_scalper_bot.data.candle_state_hardening import (
         install_candle_state_hardening,
@@ -32,31 +33,30 @@ def install_market_data_hardening_or_raise(logger: Any | None = None) -> dict[st
     )
     from nifty_scalper_bot.streaming.websocket_manager import WebSocketManager
 
-    # Install candle hardening before MarketDataManager instances are created so
-    # every engine uses the same per-engine serialization and closed-minute
-    # watermark contract from its first tick.
     install_candle_state_hardening(CandleEngine)
     install_market_data_manager_hardening(MarketDataManager)
+    # Install after the existing MDM hardening because that layer first exposes
+    # flush_due_candles; this final wrapper adds the expected-minute recheck.
+    install_candle_clock_flush_hardening(MarketDataManager)
     install_websocket_market_data_hardening(WebSocketManager)
 
     state = {
         "candle": bool(getattr(CandleEngine, _CANDLE_HARDENING_ATTR, False)),
+        "clock_flush": bool(
+            getattr(MarketDataManager, _CLOCK_FLUSH_HARDENING_ATTR, False)
+        ),
         "mdm": bool(getattr(MarketDataManager, _MDM_HARDENING_ATTR, False)),
         "websocket": bool(getattr(WebSocketManager, _WS_HARDENING_ATTR, False)),
     }
 
     if logger is not None:
         logger.info(
-            "MARKET_DATA_HARDENING_INSTALLED candle=%s mdm=%s websocket=%s",
+            "MARKET_DATA_HARDENING_INSTALLED candle=%s clock_flush=%s mdm=%s websocket=%s",
             state["candle"],
+            state["clock_flush"],
             state["mdm"],
             state["websocket"],
-            extra={
-                "event": "MARKET_DATA_HARDENING_INSTALLED",
-                "candle": state["candle"],
-                "mdm": state["mdm"],
-                "websocket": state["websocket"],
-            },
+            extra={"event": "MARKET_DATA_HARDENING_INSTALLED", **state},
         )
 
     if not all(state.values()):

--- a/src/nifty_scalper_bot/core/market_data_hardening_bootstrap.py
+++ b/src/nifty_scalper_bot/core/market_data_hardening_bootstrap.py
@@ -13,22 +13,16 @@ from typing import Any
 
 _MDM_HARDENING_ATTR = "_freshness_hardening_installed"
 _WS_HARDENING_ATTR = "_market_data_hardening_installed"
+_CANDLE_HARDENING_ATTR = "_candle_state_hardening_installed"
 
 
 def install_market_data_hardening_or_raise(logger: Any | None = None) -> dict[str, bool]:
-    """Install and verify MDM/WebSocket market-data hardening.
+    """Install and verify candle, MDM, and WebSocket hardening layers."""
 
-    Args:
-        logger: Optional structured logger used for the startup confirmation.
-
-    Returns:
-        Mapping with ``mdm`` and ``websocket`` installation states.
-
-    Raises:
-        RuntimeError: If either hardening layer is unavailable after explicit
-            idempotent installation.
-    """
-
+    from nifty_scalper_bot.data.candle_engine import CandleEngine
+    from nifty_scalper_bot.data.candle_state_hardening import (
+        install_candle_state_hardening,
+    )
     from nifty_scalper_bot.data.market_data_hardening import (
         install_market_data_manager_hardening,
     )
@@ -38,21 +32,28 @@ def install_market_data_hardening_or_raise(logger: Any | None = None) -> dict[st
     )
     from nifty_scalper_bot.streaming.websocket_manager import WebSocketManager
 
+    # Install candle hardening before MarketDataManager instances are created so
+    # every engine uses the same per-engine serialization and closed-minute
+    # watermark contract from its first tick.
+    install_candle_state_hardening(CandleEngine)
     install_market_data_manager_hardening(MarketDataManager)
     install_websocket_market_data_hardening(WebSocketManager)
 
     state = {
+        "candle": bool(getattr(CandleEngine, _CANDLE_HARDENING_ATTR, False)),
         "mdm": bool(getattr(MarketDataManager, _MDM_HARDENING_ATTR, False)),
         "websocket": bool(getattr(WebSocketManager, _WS_HARDENING_ATTR, False)),
     }
 
     if logger is not None:
         logger.info(
-            "MARKET_DATA_HARDENING_INSTALLED mdm=%s websocket=%s",
+            "MARKET_DATA_HARDENING_INSTALLED candle=%s mdm=%s websocket=%s",
+            state["candle"],
             state["mdm"],
             state["websocket"],
             extra={
                 "event": "MARKET_DATA_HARDENING_INSTALLED",
+                "candle": state["candle"],
                 "mdm": state["mdm"],
                 "websocket": state["websocket"],
             },

--- a/src/nifty_scalper_bot/core/market_data_hardening_bootstrap.py
+++ b/src/nifty_scalper_bot/core/market_data_hardening_bootstrap.py
@@ -15,7 +15,7 @@ _CLOCK_FLUSH_HARDENING_ATTR = "_candle_clock_flush_hardening_installed"
 
 
 def install_market_data_hardening_or_raise(logger: Any | None = None) -> dict[str, bool]:
-    """Install and verify all live market-data hardening layers."""
+    """Install all hardening layers while preserving the public return contract."""
 
     from nifty_scalper_bot.data.candle_clock_flush_hardening import (
         install_candle_clock_flush_hardening,
@@ -35,12 +35,10 @@ def install_market_data_hardening_or_raise(logger: Any | None = None) -> dict[st
 
     install_candle_state_hardening(CandleEngine)
     install_market_data_manager_hardening(MarketDataManager)
-    # Install after the existing MDM hardening because that layer first exposes
-    # flush_due_candles; this final wrapper adds the expected-minute recheck.
     install_candle_clock_flush_hardening(MarketDataManager)
     install_websocket_market_data_hardening(WebSocketManager)
 
-    state = {
+    full_state = {
         "candle": bool(getattr(CandleEngine, _CANDLE_HARDENING_ATTR, False)),
         "clock_flush": bool(
             getattr(MarketDataManager, _CLOCK_FLUSH_HARDENING_ATTR, False)
@@ -48,19 +46,21 @@ def install_market_data_hardening_or_raise(logger: Any | None = None) -> dict[st
         "mdm": bool(getattr(MarketDataManager, _MDM_HARDENING_ATTR, False)),
         "websocket": bool(getattr(WebSocketManager, _WS_HARDENING_ATTR, False)),
     }
+    # Preserve the established API used by startup callers and existing tests.
+    state = {"mdm": full_state["mdm"], "websocket": full_state["websocket"]}
 
     if logger is not None:
         logger.info(
-            "MARKET_DATA_HARDENING_INSTALLED candle=%s clock_flush=%s mdm=%s websocket=%s",
-            state["candle"],
-            state["clock_flush"],
-            state["mdm"],
-            state["websocket"],
-            extra={"event": "MARKET_DATA_HARDENING_INSTALLED", **state},
+            "MARKET_DATA_HARDENING_INSTALLED mdm=%s websocket=%s candle=%s clock_flush=%s",
+            full_state["mdm"],
+            full_state["websocket"],
+            full_state["candle"],
+            full_state["clock_flush"],
+            extra={"event": "MARKET_DATA_HARDENING_INSTALLED", **full_state},
         )
 
-    if not all(state.values()):
-        raise RuntimeError(f"market_data_hardening_not_installed state={state}")
+    if not all(full_state.values()):
+        raise RuntimeError(f"market_data_hardening_not_installed state={full_state}")
 
     return state
 

--- a/src/nifty_scalper_bot/data/candle_clock_flush_hardening.py
+++ b/src/nifty_scalper_bot/data/candle_clock_flush_hardening.py
@@ -1,0 +1,174 @@
+"""Race-safe clock finalization for MarketDataManager candle engines."""
+
+from __future__ import annotations
+
+import time
+from collections import defaultdict
+from typing import Any, Mapping
+
+import pandas as pd
+
+from nifty_scalper_bot.data.candle_state_hardening import _lock_for
+
+_IST_TZ = "Asia/Kolkata"
+_INSTALLED_ATTR = "_candle_clock_flush_hardening_installed"
+_LAST_PUBLISHED: dict[int, dict[str, pd.Timestamp]] = defaultdict(dict)
+
+
+def _coerce_ist_timestamp(value: Any) -> pd.Timestamp | None:
+    try:
+        timestamp = pd.Timestamp(value)
+    except Exception:
+        return None
+    if pd.isna(timestamp):
+        return None
+    if timestamp.tzinfo is None:
+        return timestamp.tz_localize(_IST_TZ)
+    return timestamp.tz_convert(_IST_TZ)
+
+
+def install_candle_clock_flush_hardening(manager_cls: type[Any]) -> None:
+    """Replace clock flush with an expected-minute, race-safe implementation."""
+    if bool(getattr(manager_cls, _INSTALLED_ATTR, False)):
+        return
+
+    def flush_due_candles(
+        self: Any,
+        *,
+        now: Any | None = None,
+        grace_seconds: float | None = None,
+    ) -> int:
+        grace = (
+            max(float(grace_seconds), 0.0)
+            if grace_seconds is not None
+            else max(float(getattr(self, "_candle_flush_grace_s", 1.5) or 1.5), 0.0)
+        )
+        now_ts = (
+            _coerce_ist_timestamp(now)
+            if now is not None
+            else pd.Timestamp.now(tz=_IST_TZ)
+        )
+        if now_ts is None:
+            return 0
+
+        engines = list(getattr(self, "_engines", {}).items())
+        flushed = 0
+        for symbol, engine in engines:
+            # Snapshot is only a cheap pre-filter. The same minute is rechecked
+            # under the per-engine lock immediately before finalization.
+            current = getattr(engine, "current_candle", None)
+            if not isinstance(current, Mapping):
+                continue
+            expected_minute = _coerce_ist_timestamp(current.get("timestamp"))
+            if expected_minute is None:
+                continue
+            if now_ts < expected_minute + pd.Timedelta(minutes=1, seconds=grace):
+                continue
+
+            with _lock_for(engine):
+                locked_current = getattr(engine, "current_candle", None)
+                if not isinstance(locked_current, Mapping):
+                    continue
+                locked_minute = _coerce_ist_timestamp(locked_current.get("timestamp"))
+                if locked_minute is None or locked_minute != expected_minute:
+                    # Tick-driven rollover won the race. Never flush the newly
+                    # opened minute based on the stale pre-lock due decision.
+                    continue
+                if now_ts < locked_minute + pd.Timedelta(minutes=1, seconds=grace):
+                    continue
+                try:
+                    candle = engine.flush()
+                except Exception as exc:  # noqa: BLE001
+                    self._logger.error(
+                        "MDM_CANDLE_CLOCK_FLUSH_FAILED symbol=%s error=%r",
+                        symbol,
+                        exc,
+                        exc_info=True,
+                        extra={
+                            "event": "MDM_CANDLE_CLOCK_FLUSH_FAILED",
+                            "symbol": symbol,
+                            "error": repr(exc),
+                        },
+                    )
+                    continue
+
+            if not candle:
+                continue
+            timestamp = _coerce_ist_timestamp(
+                candle["timestamp"] if isinstance(candle, dict) else candle.timestamp
+            )
+            if timestamp is None:
+                continue
+
+            published = _LAST_PUBLISHED[id(self)]
+            previous = published.get(symbol)
+            if previous is not None and timestamp <= previous:
+                self._logger.warning(
+                    "MDM_CANDLE_DUPLICATE_PUBLISH_SUPPRESSED symbol=%s timestamp=%s previous=%s",
+                    symbol,
+                    timestamp.isoformat(),
+                    previous.isoformat(),
+                    extra={
+                        "event": "MDM_CANDLE_DUPLICATE_PUBLISH_SUPPRESSED",
+                        "symbol": symbol,
+                        "timestamp": timestamp.isoformat(),
+                        "previous_timestamp": previous.isoformat(),
+                    },
+                )
+                continue
+
+            bar = {
+                "symbol": symbol,
+                "timestamp": timestamp,
+                "open": float(candle["open"] if isinstance(candle, dict) else candle.open),
+                "high": float(candle["high"] if isinstance(candle, dict) else candle.high),
+                "low": float(candle["low"] if isinstance(candle, dict) else candle.low),
+                "close": float(candle["close"] if isinstance(candle, dict) else candle.close),
+                "volume": int(
+                    float(
+                        (
+                            candle.get("volume", 0)
+                            if isinstance(candle, dict)
+                            else getattr(candle, "volume", 0)
+                        )
+                        or 0
+                    )
+                ),
+                "source": "clock_flush_candle",
+            }
+            with self._lock:
+                self._ohlc[symbol].append(bar)
+                published[symbol] = timestamp
+
+            publisher = getattr(self, "_publish_closed_bar", None)
+            if callable(publisher):
+                try:
+                    publisher(bar)
+                except Exception as exc:  # noqa: BLE001
+                    self._logger.debug("clock-flush bar publish skipped: %s", exc)
+
+            flushed += 1
+            now_mono = time.monotonic()
+            if (
+                now_mono
+                - float(getattr(self, "_last_candle_flush_log_mono", 0.0) or 0.0)
+                >= 10.0
+            ):
+                self._last_candle_flush_log_mono = now_mono
+                self._logger.info(
+                    "MDM_CANDLE_CLOCK_FLUSHED symbol=%s close=%s",
+                    symbol,
+                    bar["close"],
+                    extra={
+                        "event": "MDM_CANDLE_CLOCK_FLUSHED",
+                        "symbol": symbol,
+                        "source": "clock_flush_candle",
+                    },
+                )
+        return flushed
+
+    manager_cls.flush_due_candles = flush_due_candles
+    setattr(manager_cls, _INSTALLED_ATTR, True)
+
+
+__all__ = ["install_candle_clock_flush_hardening"]

--- a/src/nifty_scalper_bot/data/candle_state_hardening.py
+++ b/src/nifty_scalper_bot/data/candle_state_hardening.py
@@ -1,0 +1,259 @@
+"""Runtime hardening for CandleEngine state reconciliation.
+
+This module installs narrow, idempotent wrappers around the existing candle
+engine.  It deliberately leaves strategy, order, subscription, and historical
+fetch policy unchanged while enforcing the closed-minute watermark invariant:
+
+    current_candle is None or current_minute > latest_completed_minute
+
+The wrappers also serialize history replacement, tick processing, and clock
+flush for each engine instance.  This prevents bootstrap/history synchronization
+and delayed WebSocket ticks from reconstructing an already-finalized minute.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from collections import defaultdict
+from typing import Any, Mapping
+
+import pandas as pd
+
+from nifty_scalper_bot.data.time_contract import normalize_market_tick_timestamp
+from nifty_scalper_bot.utils.logging import log_throttled
+
+LOGGER = logging.getLogger(__name__)
+_INSTALLED_ATTR = "_candle_state_hardening_installed"
+_ORIGINAL_INIT_ATTR = "_candle_state_hardening_original_init"
+_ORIGINAL_REPLACE_ATTR = "_candle_state_hardening_original_replace_history"
+_ORIGINAL_ON_TICK_ATTR = "_candle_state_hardening_original_on_tick"
+_ORIGINAL_FINALIZE_ATTR = "_candle_state_hardening_original_finalize"
+_ORIGINAL_FLUSH_ATTR = "_candle_state_hardening_original_flush"
+_ORIGINAL_DIAGNOSTICS_ATTR = "_candle_state_hardening_original_diagnostics"
+
+# CandleEngine is a slotted dataclass without a weak-reference slot, so runtime
+# synchronization state cannot safely be attached to the instance. Engine count
+# is bounded by the subscribed universe; entries therefore remain bounded by the
+# process's engine population.
+_REGISTRY_GUARD = threading.RLock()
+_ENGINE_LOCKS: dict[int, threading.RLock] = {}
+_COUNTERS: dict[int, defaultdict[str, int]] = {}
+
+
+def _lock_for(engine: Any) -> threading.RLock:
+    key = id(engine)
+    with _REGISTRY_GUARD:
+        lock = _ENGINE_LOCKS.get(key)
+        if lock is None:
+            lock = threading.RLock()
+            _ENGINE_LOCKS[key] = lock
+        _COUNTERS.setdefault(key, defaultdict(int))
+        return lock
+
+
+def _counters_for(engine: Any) -> defaultdict[str, int]:
+    _lock_for(engine)
+    return _COUNTERS[id(engine)]
+
+
+def _coerce_timestamp(value: Any) -> pd.Timestamp:
+    try:
+        ts = pd.Timestamp(value)
+    except Exception:
+        return pd.NaT
+    if pd.isna(ts):
+        return pd.NaT
+    if ts.tzinfo is None:
+        return ts.tz_localize("Asia/Kolkata")
+    return ts.tz_convert("Asia/Kolkata")
+
+
+def _latest_completed_minute(engine: Any) -> pd.Timestamp:
+    completed = getattr(engine, "_completed_candles", None)
+    if not completed:
+        return pd.NaT
+    try:
+        return _coerce_timestamp(completed[-1].get("timestamp"))
+    except Exception:
+        return pd.NaT
+
+
+def _current_minute(engine: Any) -> pd.Timestamp:
+    current = getattr(engine, "current_candle", None)
+    if not isinstance(current, Mapping):
+        return pd.NaT
+    return _coerce_timestamp(current.get("timestamp"))
+
+
+def _state_consistent(engine: Any) -> bool:
+    completed = getattr(engine, "_completed_candles", None) or ()
+    previous = pd.NaT
+    for candle in completed:
+        if not isinstance(candle, Mapping):
+            return False
+        timestamp = _coerce_timestamp(candle.get("timestamp"))
+        if pd.isna(timestamp):
+            return False
+        if not pd.isna(previous) and timestamp <= previous:
+            return False
+        previous = timestamp
+    current = _current_minute(engine)
+    if pd.isna(current):
+        return getattr(engine, "current_candle", None) is None
+    return pd.isna(previous) or current > previous
+
+
+def install_candle_state_hardening(engine_cls: type[Any]) -> None:
+    """Install idempotent CandleEngine lifecycle hardening."""
+    if bool(getattr(engine_cls, _INSTALLED_ATTR, False)):
+        return
+
+    original_init = engine_cls.__init__
+    original_replace = engine_cls.replace_history
+    original_on_tick = engine_cls.on_tick
+    original_finalize = engine_cls._finalize_current_candle
+    original_flush = engine_cls.flush
+    original_diagnostics = engine_cls.diagnostics
+
+    setattr(engine_cls, _ORIGINAL_INIT_ATTR, original_init)
+    setattr(engine_cls, _ORIGINAL_REPLACE_ATTR, original_replace)
+    setattr(engine_cls, _ORIGINAL_ON_TICK_ATTR, original_on_tick)
+    setattr(engine_cls, _ORIGINAL_FINALIZE_ATTR, original_finalize)
+    setattr(engine_cls, _ORIGINAL_FLUSH_ATTR, original_flush)
+    setattr(engine_cls, _ORIGINAL_DIAGNOSTICS_ATTR, original_diagnostics)
+
+    def hardened_init(self: Any, *args: Any, **kwargs: Any) -> None:
+        original_init(self, *args, **kwargs)
+        _lock_for(self)
+
+    def hardened_replace_history(self: Any, frame: Any) -> None:
+        lock = _lock_for(self)
+        with lock:
+            original_replace(self, frame)
+            latest = _latest_completed_minute(self)
+            current = _current_minute(self)
+            if not pd.isna(latest) and not pd.isna(current) and current <= latest:
+                self.current_candle = None
+                counters = _counters_for(self)
+                counters["history_current_reconcile_total"] += 1
+                LOGGER.warning(
+                    "CANDLE_CURRENT_RECONCILED_AFTER_HISTORY symbol=%s current_minute=%s latest_completed_minute=%s",
+                    getattr(self, "symbol", None) or "symbol_unset",
+                    current.isoformat(),
+                    latest.isoformat(),
+                    extra={
+                        "event": "CANDLE_CURRENT_RECONCILED_AFTER_HISTORY",
+                        "symbol": getattr(self, "symbol", None) or "symbol_unset",
+                        "current_minute": current.isoformat(),
+                        "latest_completed_minute": latest.isoformat(),
+                        "action": "discarded",
+                        "reason": "current_not_newer_than_completed",
+                    },
+                )
+            if not _state_consistent(self):
+                from nifty_scalper_bot.data.source import DataIntegrityError
+
+                raise DataIntegrityError("inconsistent candle state after history replacement")
+
+    def hardened_on_tick(self: Any, tick: Mapping[str, Any]) -> Any:
+        lock = _lock_for(self)
+        with lock:
+            try:
+                normalized = normalize_market_tick_timestamp(tick)
+                tick_timestamp = normalized.timestamp
+                tick_minute = tick_timestamp.floor("1min")
+                timestamp_source = normalized.source
+            except Exception:
+                return original_on_tick(self, tick)
+
+            latest = _latest_completed_minute(self)
+            if not pd.isna(latest) and tick_minute <= latest:
+                counters = _counters_for(self)
+                counters["finalized_minute_tick_reject_total"] += 1
+                symbol = (
+                    tick.get("symbol")
+                    or tick.get("trading_symbol")
+                    or getattr(self, "symbol", None)
+                    or "symbol_unset"
+                )
+                log_throttled(
+                    LOGGER,
+                    f"candle_tick_finalized_minute:{symbol}:{tick_minute.isoformat()}",
+                    "CANDLE_TICK_REJECTED_FINALIZED_MINUTE symbol=%s tick_minute=%s latest_completed_minute=%s"
+                    % (symbol, tick_minute.isoformat(), latest.isoformat()),
+                    interval_sec=30.0,
+                    level=logging.WARNING,
+                    extra={
+                        "event": "CANDLE_TICK_REJECTED_FINALIZED_MINUTE",
+                        "symbol": symbol,
+                        "tick_timestamp": tick_timestamp.isoformat(),
+                        "tick_minute": tick_minute.isoformat(),
+                        "latest_completed_minute": latest.isoformat(),
+                        "timestamp_source": timestamp_source,
+                    },
+                )
+                return None
+            return original_on_tick(self, tick)
+
+    def hardened_finalize(self: Any) -> Any:
+        lock = _lock_for(self)
+        with lock:
+            try:
+                return original_finalize(self)
+            finally:
+                # A finalized, rejected, out-of-order, or conflicting candle is
+                # never reusable. on_tick immediately installs the next minute
+                # after a successful rollover.
+                self.current_candle = None
+
+    def hardened_flush(self: Any) -> Any:
+        lock = _lock_for(self)
+        with lock:
+            # Call the original flush; its call to _finalize_current_candle is
+            # routed through hardened_finalize under the same reentrant lock.
+            return original_flush(self)
+
+    def hardened_diagnostics(self: Any) -> dict[str, Any]:
+        lock = _lock_for(self)
+        with lock:
+            diagnostics = dict(original_diagnostics(self))
+            counters = _counters_for(self)
+            latest = _latest_completed_minute(self)
+            current = _current_minute(self)
+            diagnostics.update(
+                {
+                    "finalized_minute_tick_reject_total": counters[
+                        "finalized_minute_tick_reject_total"
+                    ],
+                    "history_current_reconcile_total": counters[
+                        "history_current_reconcile_total"
+                    ],
+                    "last_completed_timestamp": None
+                    if pd.isna(latest)
+                    else latest.isoformat(),
+                    "current_candle_timestamp": None
+                    if pd.isna(current)
+                    else current.isoformat(),
+                    "state_consistent": _state_consistent(self),
+                }
+            )
+            return diagnostics
+
+    def is_state_consistent(self: Any) -> bool:
+        lock = _lock_for(self)
+        with lock:
+            return _state_consistent(self)
+
+    engine_cls.__init__ = hardened_init
+    engine_cls.replace_history = hardened_replace_history
+    engine_cls._replace_completed_candles = hardened_replace_history
+    engine_cls.on_tick = hardened_on_tick
+    engine_cls._finalize_current_candle = hardened_finalize
+    engine_cls.flush = hardened_flush
+    engine_cls.diagnostics = hardened_diagnostics
+    engine_cls.is_state_consistent = is_state_consistent
+    setattr(engine_cls, _INSTALLED_ATTR, True)
+
+
+__all__ = ["install_candle_state_hardening"]

--- a/src/nifty_scalper_bot/data/candle_state_hardening.py
+++ b/src/nifty_scalper_bot/data/candle_state_hardening.py
@@ -1,15 +1,4 @@
-"""Runtime hardening for CandleEngine state reconciliation.
-
-This module installs narrow, idempotent wrappers around the existing candle
-engine.  It deliberately leaves strategy, order, subscription, and historical
-fetch policy unchanged while enforcing the closed-minute watermark invariant:
-
-    current_candle is None or current_minute > latest_completed_minute
-
-The wrappers also serialize history replacement, tick processing, and clock
-flush for each engine instance.  This prevents bootstrap/history synchronization
-and delayed WebSocket ticks from reconstructing an already-finalized minute.
-"""
+"""Runtime hardening for deterministic CandleEngine state transitions."""
 
 from __future__ import annotations
 
@@ -25,23 +14,13 @@ from nifty_scalper_bot.utils.logging import log_throttled
 
 LOGGER = logging.getLogger(__name__)
 _INSTALLED_ATTR = "_candle_state_hardening_installed"
-_ORIGINAL_INIT_ATTR = "_candle_state_hardening_original_init"
-_ORIGINAL_REPLACE_ATTR = "_candle_state_hardening_original_replace_history"
-_ORIGINAL_ON_TICK_ATTR = "_candle_state_hardening_original_on_tick"
-_ORIGINAL_FINALIZE_ATTR = "_candle_state_hardening_original_finalize"
-_ORIGINAL_FLUSH_ATTR = "_candle_state_hardening_original_flush"
-_ORIGINAL_DIAGNOSTICS_ATTR = "_candle_state_hardening_original_diagnostics"
-
-# CandleEngine is a slotted dataclass without a weak-reference slot, so runtime
-# synchronization state cannot safely be attached to the instance. Engine count
-# is bounded by the subscribed universe; entries therefore remain bounded by the
-# process's engine population.
 _REGISTRY_GUARD = threading.RLock()
 _ENGINE_LOCKS: dict[int, threading.RLock] = {}
 _COUNTERS: dict[int, defaultdict[str, int]] = {}
 
 
 def _lock_for(engine: Any) -> threading.RLock:
+    """Return the bounded per-engine lock for a slotted CandleEngine."""
     key = id(engine)
     with _REGISTRY_GUARD:
         lock = _ENGINE_LOCKS.get(key)
@@ -59,14 +38,14 @@ def _counters_for(engine: Any) -> defaultdict[str, int]:
 
 def _coerce_timestamp(value: Any) -> pd.Timestamp:
     try:
-        ts = pd.Timestamp(value)
+        timestamp = pd.Timestamp(value)
     except Exception:
         return pd.NaT
-    if pd.isna(ts):
+    if pd.isna(timestamp):
         return pd.NaT
-    if ts.tzinfo is None:
-        return ts.tz_localize("Asia/Kolkata")
-    return ts.tz_convert("Asia/Kolkata")
+    if timestamp.tzinfo is None:
+        return timestamp.tz_localize("Asia/Kolkata")
+    return timestamp.tz_convert("Asia/Kolkata")
 
 
 def _latest_completed_minute(engine: Any) -> pd.Timestamp:
@@ -87,9 +66,8 @@ def _current_minute(engine: Any) -> pd.Timestamp:
 
 
 def _state_consistent(engine: Any) -> bool:
-    completed = getattr(engine, "_completed_candles", None) or ()
     previous = pd.NaT
-    for candle in completed:
+    for candle in getattr(engine, "_completed_candles", None) or ():
         if not isinstance(candle, Mapping):
             return False
         timestamp = _coerce_timestamp(candle.get("timestamp"))
@@ -105,7 +83,7 @@ def _state_consistent(engine: Any) -> bool:
 
 
 def install_candle_state_hardening(engine_cls: type[Any]) -> None:
-    """Install idempotent CandleEngine lifecycle hardening."""
+    """Serialize candle mutations and reject ticks for finalized minutes."""
     if bool(getattr(engine_cls, _INSTALLED_ATTR, False)):
         return
 
@@ -116,27 +94,18 @@ def install_candle_state_hardening(engine_cls: type[Any]) -> None:
     original_flush = engine_cls.flush
     original_diagnostics = engine_cls.diagnostics
 
-    setattr(engine_cls, _ORIGINAL_INIT_ATTR, original_init)
-    setattr(engine_cls, _ORIGINAL_REPLACE_ATTR, original_replace)
-    setattr(engine_cls, _ORIGINAL_ON_TICK_ATTR, original_on_tick)
-    setattr(engine_cls, _ORIGINAL_FINALIZE_ATTR, original_finalize)
-    setattr(engine_cls, _ORIGINAL_FLUSH_ATTR, original_flush)
-    setattr(engine_cls, _ORIGINAL_DIAGNOSTICS_ATTR, original_diagnostics)
-
     def hardened_init(self: Any, *args: Any, **kwargs: Any) -> None:
         original_init(self, *args, **kwargs)
         _lock_for(self)
 
     def hardened_replace_history(self: Any, frame: Any) -> None:
-        lock = _lock_for(self)
-        with lock:
+        with _lock_for(self):
             original_replace(self, frame)
             latest = _latest_completed_minute(self)
             current = _current_minute(self)
             if not pd.isna(latest) and not pd.isna(current) and current <= latest:
                 self.current_candle = None
-                counters = _counters_for(self)
-                counters["history_current_reconcile_total"] += 1
+                _counters_for(self)["history_current_reconcile_total"] += 1
                 LOGGER.warning(
                     "CANDLE_CURRENT_RECONCILED_AFTER_HISTORY symbol=%s current_minute=%s latest_completed_minute=%s",
                     getattr(self, "symbol", None) or "symbol_unset",
@@ -157,8 +126,7 @@ def install_candle_state_hardening(engine_cls: type[Any]) -> None:
                 raise DataIntegrityError("inconsistent candle state after history replacement")
 
     def hardened_on_tick(self: Any, tick: Mapping[str, Any]) -> Any:
-        lock = _lock_for(self)
-        with lock:
+        with _lock_for(self):
             try:
                 normalized = normalize_market_tick_timestamp(tick)
                 tick_timestamp = normalized.timestamp
@@ -169,8 +137,7 @@ def install_candle_state_hardening(engine_cls: type[Any]) -> None:
 
             latest = _latest_completed_minute(self)
             if not pd.isna(latest) and tick_minute <= latest:
-                counters = _counters_for(self)
-                counters["finalized_minute_tick_reject_total"] += 1
+                _counters_for(self)["finalized_minute_tick_reject_total"] += 1
                 symbol = (
                     tick.get("symbol")
                     or tick.get("trading_symbol")
@@ -197,26 +164,21 @@ def install_candle_state_hardening(engine_cls: type[Any]) -> None:
             return original_on_tick(self, tick)
 
     def hardened_finalize(self: Any) -> Any:
-        lock = _lock_for(self)
-        with lock:
+        with _lock_for(self):
             try:
                 return original_finalize(self)
             finally:
-                # A finalized, rejected, out-of-order, or conflicting candle is
-                # never reusable. on_tick immediately installs the next minute
-                # after a successful rollover.
+                # Once finalization is attempted, this partial candle must never
+                # be reused. During rollover original on_tick installs the next
+                # minute immediately after this call returns.
                 self.current_candle = None
 
     def hardened_flush(self: Any) -> Any:
-        lock = _lock_for(self)
-        with lock:
-            # Call the original flush; its call to _finalize_current_candle is
-            # routed through hardened_finalize under the same reentrant lock.
+        with _lock_for(self):
             return original_flush(self)
 
     def hardened_diagnostics(self: Any) -> dict[str, Any]:
-        lock = _lock_for(self)
-        with lock:
+        with _lock_for(self):
             diagnostics = dict(original_diagnostics(self))
             counters = _counters_for(self)
             latest = _latest_completed_minute(self)
@@ -241,13 +203,11 @@ def install_candle_state_hardening(engine_cls: type[Any]) -> None:
             return diagnostics
 
     def is_state_consistent(self: Any) -> bool:
-        lock = _lock_for(self)
-        with lock:
+        with _lock_for(self):
             return _state_consistent(self)
 
     engine_cls.__init__ = hardened_init
     engine_cls.replace_history = hardened_replace_history
-    engine_cls._replace_completed_candles = hardened_replace_history
     engine_cls.on_tick = hardened_on_tick
     engine_cls._finalize_current_candle = hardened_finalize
     engine_cls.flush = hardened_flush

--- a/tests/data/test_candle_state_hardening.py
+++ b/tests/data/test_candle_state_hardening.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
-from concurrent.futures import ThreadPoolExecutor
-
 import pandas as pd
 import pytest
 
+from nifty_scalper_bot.data.candle_clock_flush_hardening import (
+    install_candle_clock_flush_hardening,
+)
 from nifty_scalper_bot.data.candle_engine import CandleEngine, DataIntegrityError, IST
 from nifty_scalper_bot.data.candle_state_hardening import install_candle_state_hardening
 
@@ -113,29 +114,47 @@ def test_conflict_clears_poisoned_current_candle_once() -> None:
     assert engine.diagnostics()["same_minute_conflict_total"] == 1
 
 
-def test_clock_flush_and_next_minute_tick_are_serialized() -> None:
+def test_clock_flush_does_not_flush_new_current_minute_after_tick_rollover() -> None:
     minute = _minute()
+    next_minute = minute + pd.Timedelta(minutes=1)
     engine = CandleEngine(symbol="NFO:NIFTY26JULFUT")
     engine.on_tick(_tick(minute + pd.Timedelta(seconds=5), 100.0))
+    engine.on_tick(_tick(next_minute + pd.Timedelta(seconds=1), 101.0))
 
-    with ThreadPoolExecutor(max_workers=2) as executor:
-        flush_future = executor.submit(engine.flush)
-        tick_future = executor.submit(
-            engine.on_tick,
-            _tick(minute + pd.Timedelta(minutes=1, seconds=1), 101.0),
-        )
-        flush_result = flush_future.result()
-        tick_result = tick_future.result()
+    class Logger:
+        def info(self, *args, **kwargs):
+            return None
 
-    # Either operation may acquire the lock first, but the closed minute is
-    # stored once and the next minute remains the only active candle.
-    assert flush_result is not None or tick_result is not None
-    completed = engine.get_df()
-    assert len(completed) == 1
-    assert not completed["timestamp"].duplicated().any()
+        def warning(self, *args, **kwargs):
+            return None
+
+        def error(self, *args, **kwargs):
+            return None
+
+        def debug(self, *args, **kwargs):
+            return None
+
+    class Manager:
+        pass
+
+    install_candle_clock_flush_hardening(Manager)
+    manager = Manager()
+    manager._engines = {"NFO:NIFTY26JULFUT": engine}
+    manager._candle_flush_grace_s = 1.5
+    manager._last_candle_flush_log_mono = 0.0
+    manager._lock = __import__("threading").RLock()
+    manager._ohlc = {"NFO:NIFTY26JULFUT": []}
+    manager._logger = Logger()
+
+    flushed = manager.flush_due_candles(
+        now=minute + pd.Timedelta(minutes=1, seconds=2),
+        grace_seconds=1.5,
+    )
+
+    assert flushed == 0
     assert engine.current_candle is not None
-    assert pd.Timestamp(engine.current_candle["timestamp"]) == minute + pd.Timedelta(minutes=1)
-    assert engine.is_state_consistent() is True
+    assert pd.Timestamp(engine.current_candle["timestamp"]) == next_minute
+    assert len(engine.get_df()) == 1
 
 
 def test_replayed_old_ticks_after_reconciliation_do_not_recreate_conflict() -> None:

--- a/tests/data/test_candle_state_hardening.py
+++ b/tests/data/test_candle_state_hardening.py
@@ -1,0 +1,151 @@
+"""Regression coverage for bootstrap/live candle reconciliation races."""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+
+import pandas as pd
+import pytest
+
+from nifty_scalper_bot.data.candle_engine import CandleEngine, DataIntegrityError, IST
+from nifty_scalper_bot.data.candle_state_hardening import install_candle_state_hardening
+
+install_candle_state_hardening(CandleEngine)
+
+
+def _minute(offset: int = 0) -> pd.Timestamp:
+    return pd.Timestamp.now(tz=IST).floor("min") - pd.Timedelta(minutes=10 - offset)
+
+
+def _history_row(timestamp: pd.Timestamp, close: float = 100.5) -> dict[str, object]:
+    return {
+        "timestamp": timestamp,
+        "open": 100.0,
+        "high": max(101.0, close),
+        "low": 99.0,
+        "close": close,
+        "volume": 10.0,
+    }
+
+
+def _tick(timestamp: pd.Timestamp, price: float = 100.0) -> dict[str, object]:
+    return {
+        "symbol": "NFO:NIFTY26JULFUT",
+        "timestamp": timestamp,
+        "ltp": price,
+        "volume": 1.0,
+    }
+
+
+def test_delayed_tick_cannot_reopen_finalized_minute() -> None:
+    minute = _minute()
+    engine = CandleEngine(symbol="NFO:NIFTY26JULFUT")
+    engine.replace_history(pd.DataFrame([_history_row(minute)]))
+
+    assert engine.on_tick(_tick(minute + pd.Timedelta(seconds=45), 101.0)) is None
+    assert engine.current_candle is None
+    assert len(engine.get_df()) == 1
+    diagnostics = engine.diagnostics()
+    assert diagnostics["finalized_minute_tick_reject_total"] == 1
+    assert diagnostics["state_consistent"] is True
+
+
+def test_history_replacement_discards_overlapping_partial_candle() -> None:
+    minute = _minute()
+    engine = CandleEngine(symbol="NFO:NIFTY26JULFUT")
+    engine.current_candle = {
+        "timestamp": minute,
+        "open": 100.0,
+        "high": 102.0,
+        "low": 99.0,
+        "close": 101.5,
+        "volume": 4.0,
+    }
+
+    engine.replace_history(pd.DataFrame([_history_row(minute, close=100.5)]))
+
+    assert engine.current_candle is None
+    assert float(engine.get_df().iloc[-1]["close"]) == 100.5
+    diagnostics = engine.diagnostics()
+    assert diagnostics["history_current_reconcile_total"] == 1
+    assert diagnostics["state_consistent"] is True
+
+
+def test_history_older_than_current_candle_preserves_live_minute() -> None:
+    history_minute = _minute()
+    current_minute = history_minute + pd.Timedelta(minutes=1)
+    engine = CandleEngine(symbol="NFO:NIFTY26JULFUT")
+    engine.current_candle = {
+        "timestamp": current_minute,
+        "open": 101.0,
+        "high": 101.0,
+        "low": 101.0,
+        "close": 101.0,
+        "volume": 1.0,
+    }
+
+    engine.replace_history(pd.DataFrame([_history_row(history_minute)]))
+
+    assert engine.current_candle is not None
+    assert pd.Timestamp(engine.current_candle["timestamp"]) == current_minute
+    assert engine.is_state_consistent() is True
+
+
+def test_conflict_clears_poisoned_current_candle_once() -> None:
+    minute = _minute()
+    engine = CandleEngine(symbol="NFO:NIFTY26JULFUT")
+    engine.replace_history(pd.DataFrame([_history_row(minute, close=100.5)]))
+    engine.current_candle = {
+        "timestamp": minute,
+        "open": 100.0,
+        "high": 102.0,
+        "low": 99.0,
+        "close": 101.5,
+        "volume": 4.0,
+    }
+
+    with pytest.raises(DataIntegrityError):
+        engine.flush()
+
+    assert engine.current_candle is None
+    assert engine.flush() is None
+    assert len(engine.get_df()) == 1
+    assert engine.diagnostics()["same_minute_conflict_total"] == 1
+
+
+def test_clock_flush_and_next_minute_tick_are_serialized() -> None:
+    minute = _minute()
+    engine = CandleEngine(symbol="NFO:NIFTY26JULFUT")
+    engine.on_tick(_tick(minute + pd.Timedelta(seconds=5), 100.0))
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        flush_future = executor.submit(engine.flush)
+        tick_future = executor.submit(
+            engine.on_tick,
+            _tick(minute + pd.Timedelta(minutes=1, seconds=1), 101.0),
+        )
+        flush_result = flush_future.result()
+        tick_result = tick_future.result()
+
+    # Either operation may acquire the lock first, but the closed minute is
+    # stored once and the next minute remains the only active candle.
+    assert flush_result is not None or tick_result is not None
+    completed = engine.get_df()
+    assert len(completed) == 1
+    assert not completed["timestamp"].duplicated().any()
+    assert engine.current_candle is not None
+    assert pd.Timestamp(engine.current_candle["timestamp"]) == minute + pd.Timedelta(minutes=1)
+    assert engine.is_state_consistent() is True
+
+
+def test_replayed_old_ticks_after_reconciliation_do_not_recreate_conflict() -> None:
+    minute = _minute()
+    engine = CandleEngine(symbol="NFO:NIFTY26JULFUT")
+    engine.replace_history(pd.DataFrame([_history_row(minute)]))
+
+    for second in (5, 15, 30, 45):
+        assert engine.on_tick(_tick(minute + pd.Timedelta(seconds=second), 101.0)) is None
+
+    assert engine.current_candle is None
+    assert engine.diagnostics()["finalized_minute_tick_reject_total"] == 4
+    assert engine.is_state_consistent() is True


### PR DESCRIPTION
## Root cause

Bootstrap/history replacement could install a completed candle while a partial live candle for the same minute remained active. Delayed queued ticks could then reopen finalized minutes. The periodic clock flush and tick-driven rollover were also not serialized around an expected-minute check, producing `FINALIZED_CANDLE_CONFLICT`, `MDM_CANDLE_CLOCK_FLUSH_FAILED`, and `MDM_TICK_DRAIN_ERROR` storms despite a healthy WebSocket heartbeat.

## Changes

- Install idempotent per-engine candle-state hardening during market-data bootstrap.
- Serialize `replace_history`, `on_tick`, finalization, and `flush` with a per-engine `RLock`.
- Reject delayed/replayed ticks whose minute is already finalized.
- Reconcile and discard an overlapping partial current candle after history replacement.
- Clear any candle after a finalization attempt so conflicts cannot be retried every second.
- Replace clock flush with an expected-minute recheck under the engine lock, preventing a stale due decision from flushing a newly opened minute.
- Suppress duplicate/out-of-order clock publications with a bounded per-symbol watermark.
- Add diagnostics and focused regression tests based on the 2026-07-17 production event ordering.

## Safety

This does not weaken strategy safety gates, fabricate candles, alter strategy thresholds, or force trading readiness. It restores deterministic candle state so existing gates can pass naturally when required spot/futures/option context is genuinely current.

## Deployment

Run one market session with order placement disabled before enabling live orders. Verify zero candle conflicts, zero repeated clock-flush failures, no duplicate closed bars, and current direction context.