### PR TITLE
Install candle hardening in the real production startup path

### DIFF
--- a/src/nifty_scalper_bot/core/__init__.py
+++ b/src/nifty_scalper_bot/core/__init__.py
@@ -64,17 +64,50 @@ except Exception as exc:  # noqa: BLE001 - core package import must not crash to
         extra={"event": "BOOT_LOG_RATE_CONTROL_FAILED", "error_type": type(exc).__name__},
     )
 
-# Market-data hardening verification moved to initialize_components (app.py):
-# running it at package-import time re-introduced the hidden-hook pattern
-# removed in #792 and could fire during a partially-initialized settings
-# import (circular), silently skipping verification outside live mode.
-
 __all__ = ["NiftyScalperApp", "canonical_price_source"]
 
 _LOGGER = get_logger(__name__)
 
 
+def _install_market_data_runtime_hardening() -> dict[str, bool]:
+    """Install candle/manager/WebSocket hardening in the real app import path.
+
+    This is deliberately called after ``core.app`` has completed importing, so
+    settings and production classes are fully initialized. Live startup fails
+    closed if any required market-data layer cannot be installed.
+    """
+    from nifty_scalper_bot.core.market_data_hardening_bootstrap import (
+        install_market_data_hardening_or_raise,
+    )
+
+    try:
+        state = install_market_data_hardening_or_raise(_LOGGER)
+    except Exception as exc:  # noqa: BLE001
+        _LOGGER.error(
+            "MARKET_DATA_RUNTIME_HARDENING_FAILED error=%s",
+            exc,
+            exc_info=True,
+            extra={
+                "event": "MARKET_DATA_RUNTIME_HARDENING_FAILED",
+                "error_type": type(exc).__name__,
+            },
+        )
+        if _real_live_mode_requested():
+            raise RuntimeError("market_data_runtime_hardening_failed") from exc
+        return {
+            "candle": False,
+            "clock_flush": False,
+            "mdm": False,
+            "websocket": False,
+        }
+    return state
+
+
 def _apply_app_runtime_patches(app_module: Any) -> None:
+    # The production app import is the single authoritative installation point.
+    # Do not require tests or callers to invoke market-data hardening manually.
+    _install_market_data_runtime_hardening()
+
     from nifty_scalper_bot.core.boot_readiness_safety import apply_app_patch as _ready_adapter
     from nifty_scalper_bot.core.polling_failover_runtime import apply_app_patch as _polling_adapter
 
@@ -133,18 +166,7 @@ _install_core_app_patch_import_hook()
 
 
 def __getattr__(name: str) -> Any:
-    """Return lazily imported core entry points.
-
-    Args:
-        name: Attribute requested from the package.
-
-    Returns:
-        Any: Resolved attribute when exported by the package.
-
-    Raises:
-        AttributeError: If the requested attribute is not available.
-    """
-
+    """Return lazily imported core entry points."""
     _LOGGER.debug(
         "Entered core.__getattr__",
         extra={"event": "core_init_getattr_enter", "attribute": name},

--- a/tests/core/test_market_data_hardening_production_import.py
+++ b/tests/core/test_market_data_hardening_production_import.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import importlib
+
+
+def test_production_app_import_installs_all_market_data_hardening() -> None:
+    """The real core.app import must install hardening without manual calls."""
+    app_module = importlib.import_module("nifty_scalper_bot.core.app")
+    assert app_module is not None
+
+    from nifty_scalper_bot.data.candle_engine import CandleEngine
+    from nifty_scalper_bot.data.market_data_manager import MarketDataManager
+    from nifty_scalper_bot.streaming.websocket_manager import WebSocketManager
+
+    assert getattr(CandleEngine, "_candle_state_hardening_installed", False) is True
+    assert getattr(MarketDataManager, "_freshness_hardening_installed", False) is True
+    assert (
+        getattr(MarketDataManager, "_candle_clock_flush_hardening_installed", False)
+        is True
+    )
+    assert getattr(WebSocketManager, "_market_data_hardening_installed", False) is True
+
+
+def test_production_app_import_is_idempotent() -> None:
+    import nifty_scalper_bot.core.app as app_module
+
+    before = {
+        "app": id(app_module),
+    }
+    reloaded = importlib.reload(app_module)
+    assert id(reloaded) == before["app"]
+
+    from nifty_scalper_bot.data.candle_engine import CandleEngine
+    from nifty_scalper_bot.data.market_data_manager import MarketDataManager
+
+    assert getattr(CandleEngine, "_candle_state_hardening_installed", False) is True
+    assert (
+        getattr(MarketDataManager, "_candle_clock_flush_hardening_installed", False)
+        is True
+    )

--- a/tests/data/test_candle_replay_production_bootstrap.py
+++ b/tests/data/test_candle_replay_production_bootstrap.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import importlib
+
+import pandas as pd
+
+
+def _row(timestamp: pd.Timestamp, close: float = 100.5) -> dict[str, object]:
+    return {
+        "timestamp": timestamp,
+        "open": 100.0,
+        "high": max(101.0, close),
+        "low": 99.0,
+        "close": close,
+        "volume": 10.0,
+    }
+
+
+def _tick(timestamp: pd.Timestamp, price: float = 101.0) -> dict[str, object]:
+    return {
+        "symbol": "NFO:NIFTY26JULFUT",
+        "timestamp": timestamp,
+        "ltp": price,
+        "volume": 1.0,
+    }
+
+
+def test_production_bootstrap_replay_cannot_reopen_finalized_minute() -> None:
+    # This import is the production installation path. The test deliberately does
+    # not call any hardening installer directly.
+    importlib.import_module("nifty_scalper_bot.core.app")
+
+    from nifty_scalper_bot.data.candle_engine import CandleEngine, IST
+
+    minute = pd.Timestamp.now(tz=IST).floor("min") - pd.Timedelta(minutes=5)
+    engine = CandleEngine(symbol="NFO:NIFTY26JULFUT")
+    engine.replace_history(pd.DataFrame([_row(minute)]))
+
+    for second in (5, 15, 30, 45):
+        assert engine.on_tick(_tick(minute + pd.Timedelta(seconds=second))) is None
+
+    assert engine.current_candle is None
+    assert len(engine.get_df()) == 1
+    diagnostics = engine.diagnostics()
+    assert diagnostics["finalized_minute_tick_reject_total"] == 4
+    assert diagnostics["state_consistent"] is True
+
+
+def test_production_bootstrap_reconciles_history_over_live_partial() -> None:
+    importlib.import_module("nifty_scalper_bot.core.app")
+
+    from nifty_scalper_bot.data.candle_engine import CandleEngine, IST
+
+    minute = pd.Timestamp.now(tz=IST).floor("min") - pd.Timedelta(minutes=5)
+    engine = CandleEngine(symbol="NFO:NIFTY26JULFUT")
+    engine.current_candle = {
+        "timestamp": minute,
+        "open": 100.0,
+        "high": 102.0,
+        "low": 99.0,
+        "close": 101.5,
+        "volume": 4.0,
+    }
+
+    engine.replace_history(pd.DataFrame([_row(minute, close=100.5)]))
+
+    assert engine.current_candle is None
+    assert float(engine.get_df().iloc[-1]["close"]) == 100.5
+    diagnostics = engine.diagnostics()
+    assert diagnostics["history_current_reconcile_total"] == 1
+    assert diagnostics["state_consistent"] is True


### PR DESCRIPTION
## Root cause

PR #887 added candle reconciliation and race hardening, but the installer was never invoked by the actual production startup path. Tests called the installer manually, so CI was green while Lightsail continued running the unprotected classes.

## Correction

- Install all candle, clock-flush, MDM, and WebSocket hardening from the existing `core.app` import hook after the production app module is fully initialized.
- Fail closed in real live mode when installation fails.
- Keep non-live tooling imports usable while emitting a structured installation failure.
- Add production-bootstrap tests that import `nifty_scalper_bot.core.app` and verify all class markers without manually invoking any installer.
- Replay the delayed-tick/finalized-minute and history/current overlap failures through the production bootstrap path.

## Safety

No strategy thresholds, signal logic, order execution logic, or live safety gates are weakened. This change makes the already-reviewed reconciliation code actually active in production and verifies the deployment path directly.

## Deployment validation

After merge and redeploy, startup must emit `MARKET_DATA_HARDENING_INSTALLED candle=True clock_flush=True mdm=True websocket=True`. Run order-disabled validation first and verify zero recurring `FINALIZED_CANDLE_CONFLICT`, `MDM_CANDLE_CLOCK_FLUSH_FAILED`, and candle-related `MDM_TICK_DRAIN_ERROR`.