### PR TITLE
Refactor CandleEngine as the single candle source of truth

### DIFF
--- a/src/nifty_scalper_bot/data/candle_engine.py
+++ b/src/nifty_scalper_bot/data/candle_engine.py
@@ -145,6 +145,11 @@ class CandleEngine:
     _live_append_total: int = field(default=0, init=False)
     _same_minute_idempotent_total: int = field(default=0, init=False)
     _same_minute_conflict_total: int = field(default=0, init=False)
+    _history_import_total: int = field(default=0, init=False)
+    _history_import_bar_total: int = field(default=0, init=False)
+    _history_import_idempotent_total: int = field(default=0, init=False)
+    _history_import_conflict_total: int = field(default=0, init=False)
+    _finalized_minute_tick_reject_total: int = field(default=0, init=False)
 
     def __init__(
         self,
@@ -168,6 +173,11 @@ class CandleEngine:
         self._live_append_total = 0
         self._same_minute_idempotent_total = 0
         self._same_minute_conflict_total = 0
+        self._history_import_total = 0
+        self._history_import_bar_total = 0
+        self._history_import_idempotent_total = 0
+        self._history_import_conflict_total = 0
+        self._finalized_minute_tick_reject_total = 0
         if df is not None and not df.empty:
             self.replace_history(df)
 
@@ -187,26 +197,16 @@ class CandleEngine:
         self.replace_history(value)
 
     def replace_history(self, frame: pd.DataFrame | None) -> None:
-        """Sanitize and atomically replace the bounded candle store."""
-        self._replace_completed_candles(frame)
+        """Bootstrap/legacy whole-history replacement.
+
+        Prefer ``import_history(..., mode="incremental")`` during live
+        operation so historical hydration cannot silently overwrite
+        CandleEngine-owned finalized candles or a live current candle.
+        """
+        self.import_history(frame, mode="bootstrap")
 
     def _replace_completed_candles(self, value: pd.DataFrame | None) -> None:
-        self._completed_candles.clear()
-        clean = (
-            sanitize(value)
-            if value is not None
-            else pd.DataFrame(columns=_OHLC_COLUMNS)
-        )
-        for row in clean.tail(self.max_bars).to_dict(orient="records"):
-            ts = _to_ist_timestamp(row.get("timestamp"))
-            if pd.isna(ts):
-                continue
-            normalized = _normalize_completed_candle(
-                row, symbol=self.symbol or "symbol_unset", incoming_ts=ts
-            )
-            if normalized is not None:
-                self._completed_candles.append(normalized)
-        self._df_cache_dirty = True
+        self.import_history(value, mode="bootstrap")
 
     def _cached_df_copy(self) -> pd.DataFrame:
         if self._df_cache_dirty or self._df_cache is None:
@@ -226,7 +226,142 @@ class CandleEngine:
             "live_append_total": self._live_append_total,
             "same_minute_idempotent_total": self._same_minute_idempotent_total,
             "same_minute_conflict_total": self._same_minute_conflict_total,
+            "history_import_total": self._history_import_total,
+            "history_import_bar_total": self._history_import_bar_total,
+            "history_import_idempotent_total": self._history_import_idempotent_total,
+            "history_import_conflict_total": self._history_import_conflict_total,
+            "finalized_minute_tick_reject_total": (
+                self._finalized_minute_tick_reject_total
+            ),
+            "latest_finalized_minute": (
+                self.latest_finalized_minute().isoformat()
+                if self.latest_finalized_minute() is not None
+                else None
+            ),
         }
+
+    def latest_finalized_minute(self) -> pd.Timestamp | None:
+        """Return the latest completed candle minute, normalized to market TZ."""
+        if not self._completed_candles:
+            return None
+        ts = _to_ist_timestamp(self._completed_candles[-1].get("timestamp"))
+        if pd.isna(ts):
+            return None
+        return pd.Timestamp(ts)
+
+    def get_completed_bars(self) -> list[dict[str, Any]]:
+        """Return defensive copies of canonical finalized OHLCV bars."""
+        return [dict(row) for row in self._completed_candles]
+
+    def get_current_candle(self) -> dict[str, Any] | None:
+        """Return a defensive copy of the current partial candle, if any."""
+        return dict(self.current_candle) if self.current_candle is not None else None
+
+    def import_history(
+        self,
+        frame: pd.DataFrame | None,
+        *,
+        mode: str = "incremental",
+        source: str | None = None,
+    ) -> pd.DataFrame:
+        """Atomically import broker-completed historical candles.
+
+        ``mode="bootstrap"`` replaces completed history and is intended for
+        startup/legacy compatibility before live ticks are accepted.
+        ``mode="incremental"`` merges only idempotent or newer completed bars
+        and fails closed on conflicts. ``source`` is diagnostic metadata only
+        and is never part of candle identity.
+        """
+        if mode not in {"bootstrap", "incremental"}:
+            raise ValueError(f"Unsupported history import mode: {mode}")
+        symbol = self.symbol or "symbol_unset"
+        try:
+            incoming = _normalize_history_frame(frame, symbol=symbol)
+            candidate = list(incoming)
+            idempotent = 0
+            current_after = (
+                dict(self.current_candle) if self.current_candle is not None else None
+            )
+            if mode == "incremental":
+                existing = list(self._completed_candles)
+                merged_by_ts: dict[pd.Timestamp, dict[str, Any]] = {
+                    _to_ist_timestamp(row["timestamp"]): dict(row) for row in existing
+                }
+                for row in incoming:
+                    ts = _to_ist_timestamp(row["timestamp"])
+                    stored = merged_by_ts.get(ts)
+                    if stored is not None:
+                        if not _candles_equivalent(stored, row):
+                            raise _history_conflict(symbol, ts, stored, row)
+                        idempotent += 1
+                        continue
+                    merged_by_ts[ts] = dict(row)
+                candidate = [merged_by_ts[ts] for ts in sorted(merged_by_ts)]
+                if current_after is not None and incoming:
+                    latest_imported_ts = _to_ist_timestamp(incoming[-1]["timestamp"])
+                    current_ts = _to_ist_timestamp(current_after.get("timestamp"))
+                    if pd.isna(current_ts):
+                        raise DataIntegrityError("current candle timestamp is invalid")
+                    normalized_current = _normalize_completed_candle(
+                        current_after, symbol=symbol, incoming_ts=current_ts
+                    )
+                    if normalized_current is None:
+                        raise DataIntegrityError("current candle is invalid")
+                    if current_ts == latest_imported_ts:
+                        imported = incoming[-1]
+                        if not _candles_equivalent(normalized_current, imported):
+                            raise _history_conflict(
+                                symbol, current_ts, imported, normalized_current
+                            )
+                        current_after = None
+                        idempotent += 1
+                    elif current_ts < latest_imported_ts:
+                        raise DataIntegrityError(
+                            "current candle older than imported finalized history"
+                        )
+            else:
+                current_after = None
+
+            bounded = candidate[-int(self.max_bars) :]
+        except Exception:
+            self._history_import_conflict_total += 1
+            LOGGER.exception(
+                "history_import_failed",
+                extra={
+                    "event": "history_import_failed",
+                    "symbol": symbol,
+                    "mode": mode,
+                    "source": source,
+                },
+            )
+            raise
+
+        self._completed_candles = deque(
+            [dict(row) for row in bounded], maxlen=int(self.max_bars)
+        )
+        self.current_candle = current_after
+        self._df_cache_dirty = True
+        self._history_import_total += 1
+        self._history_import_bar_total += len(incoming)
+        self._history_import_idempotent_total += idempotent
+        latest = self.latest_finalized_minute()
+        self.last_candle_close = latest.to_pydatetime() if latest is not None else None
+        LOGGER.info(
+            "history_import_completed",
+            extra={
+                "event": "history_import_completed",
+                "symbol": symbol,
+                "mode": mode,
+                "source": source,
+                "incoming_bars": len(incoming),
+                "stored_bars": len(self._completed_candles),
+                "idempotent_bars": idempotent,
+                "latest_finalized_minute": (
+                    latest.isoformat() if latest is not None else None
+                ),
+            },
+        )
+        return self.get_df()
 
     def on_tick(self, tick: Mapping[str, Any]) -> dict[str, Any] | None:
         if self.interval != "1min":
@@ -328,6 +463,28 @@ class CandleEngine:
         payload["timestamp"] = timestamp
         payload["timestamp_source"] = timestamp_source
         minute = timestamp.floor("1min")
+        latest_finalized = self.latest_finalized_minute()
+        if latest_finalized is not None and minute <= latest_finalized:
+            self._finalized_minute_tick_reject_total += 1
+            log_throttled(
+                LOGGER,
+                f"finalized_minute_tick_rejected_{symbol}",
+                (
+                    "CANDLE_TICK_DROPPED reason=finalized_minute symbol=%s "
+                    "tick_minute=%s latest_finalized=%s"
+                )
+                % (symbol, minute.isoformat(), latest_finalized.isoformat()),
+                interval_sec=10.0,
+                level=logging.WARNING,
+                extra={
+                    "event": "candle_tick_dropped",
+                    "reason": "finalized_minute",
+                    "symbol": symbol,
+                    "tick_minute": minute.isoformat(),
+                    "latest_finalized_minute": latest_finalized.isoformat(),
+                },
+            )
+            return None
 
         if self._last_tick_ts is not None:
             last_ts = _to_ist_timestamp(self._last_tick_ts)
@@ -446,7 +603,10 @@ class CandleEngine:
                     log_throttled(
                         LOGGER,
                         f"candle_out_of_order_{symbol}",
-                        "candle_out_of_order symbol=%s incoming_ts=%s last_ts=%s source=candle_engine"
+                        (
+                            "candle_out_of_order symbol=%s incoming_ts=%s "
+                            "last_ts=%s source=candle_engine"
+                        )
                         % (symbol, incoming_ts.isoformat(), last_ts.isoformat()),
                         interval_sec=30.0,
                         level=logging.WARNING,
@@ -507,7 +667,8 @@ class CandleEngine:
                 )
                 self.current_candle = None
                 raise DataIntegrityError(
-                    f"conflicting finalized candle symbol={symbol} timestamp={incoming_ts}"
+                    "conflicting finalized candle "
+                    f"symbol={symbol} timestamp={incoming_ts}"
                 )
         # Live completed candles are stored in a bounded row-oriented deque.
         # Avoid DataFrame row insertion/concat here; pandas frames are rebuilt
@@ -573,6 +734,66 @@ def _normalize_completed_candle(
     if out["high"] < out["low"]:
         return None
     return out
+
+
+def _normalize_history_frame(
+    frame: pd.DataFrame | None, *, symbol: str
+) -> list[dict[str, Any]]:
+    if frame is None or frame.empty:
+        return []
+    if "timestamp" not in frame.columns:
+        raise DataIntegrityError("historical candle timestamp is required")
+    normalized_rows: list[dict[str, Any]] = []
+    for index, row in frame.copy().iterrows():
+        ts = _to_ist_timestamp(row.get("timestamp"))
+        if pd.isna(ts):
+            raise DataIntegrityError(
+                f"historical candle timestamp is invalid row={index}"
+            )
+        if _is_future_timestamp(ts):
+            raise DataIntegrityError(
+                f"historical candle timestamp is in the future row={index}"
+            )
+        normalized = _normalize_completed_candle(row, symbol=symbol, incoming_ts=ts)
+        if normalized is None:
+            raise DataIntegrityError(f"invalid historical OHLCV row={index}")
+        normalized_rows.append(normalized)
+
+    by_ts: dict[pd.Timestamp, dict[str, Any]] = {}
+    for row in normalized_rows:
+        ts = _to_ist_timestamp(row["timestamp"])
+        existing = by_ts.get(ts)
+        if existing is not None:
+            if not _candles_equivalent(existing, row):
+                raise _history_conflict(symbol, ts, existing, row)
+            continue
+        by_ts[ts] = row
+    return [by_ts[ts] for ts in sorted(by_ts)]
+
+
+def _history_conflict(
+    symbol: str,
+    ts: pd.Timestamp,
+    stored: Mapping[str, Any],
+    incoming: Mapping[str, Any],
+) -> DataIntegrityError:
+    LOGGER.error(
+        "FINALIZED_CANDLE_CONFLICT",
+        extra={
+            "event": "FINALIZED_CANDLE_CONFLICT",
+            "symbol": symbol,
+            "timestamp": ts.isoformat(),
+            "stored_ohlcv": {
+                k: stored.get(k) for k in ("open", "high", "low", "close", "volume")
+            },
+            "incoming_ohlcv": {
+                k: incoming.get(k) for k in ("open", "high", "low", "close", "volume")
+            },
+        },
+    )
+    return DataIntegrityError(
+        f"conflicting finalized candle symbol={symbol} timestamp={ts}"
+    )
 
 
 def _candles_equivalent(left: Mapping[str, Any], right: Mapping[str, Any]) -> bool:
@@ -643,7 +864,10 @@ def fetch_historical_safe(
         if validate_dataframe(frame, min_required=min_required):
             return frame
         LOGGER.warning(
-            "data_integrity_error symbol=%s reason=historical_validation_failed attempt=%d",
+            (
+                "data_integrity_error symbol=%s "
+                "reason=historical_validation_failed attempt=%d"
+            ),
             symbol,
             attempt,
             extra={
@@ -705,7 +929,10 @@ def ensure_valid_data(
     )
     if hydrated is None:
         LOGGER.error(
-            "data_integrity_error symbol=%s reason=insufficient_historical min_required=%d",
+            (
+                "data_integrity_error symbol=%s "
+                "reason=insufficient_historical min_required=%d"
+            ),
             symbol,
             min_required,
             extra={

--- a/src/nifty_scalper_bot/data/candle_engine.py
+++ b/src/nifty_scalper_bot/data/candle_engine.py
@@ -31,6 +31,10 @@ FetchRecentFn = Callable[[str], pd.DataFrame | None]
 _OHLC_COLUMNS = ("timestamp", "open", "high", "low", "close", "volume")
 
 
+class CandleHistoryConflictError(DataIntegrityError):
+    """Historical import conflicts with a finalized candle identity."""
+
+
 def _to_ist_timestamp(value: Any) -> pd.Timestamp:
     try:
         return coerce_market_timestamp(value)
@@ -149,6 +153,7 @@ class CandleEngine:
     _history_import_bar_total: int = field(default=0, init=False)
     _history_import_idempotent_total: int = field(default=0, init=False)
     _history_import_conflict_total: int = field(default=0, init=False)
+    _history_import_failure_total: int = field(default=0, init=False)
     _finalized_minute_tick_reject_total: int = field(default=0, init=False)
 
     def __init__(
@@ -177,6 +182,7 @@ class CandleEngine:
         self._history_import_bar_total = 0
         self._history_import_idempotent_total = 0
         self._history_import_conflict_total = 0
+        self._history_import_failure_total = 0
         self._finalized_minute_tick_reject_total = 0
         if df is not None and not df.empty:
             self.replace_history(df)
@@ -230,6 +236,7 @@ class CandleEngine:
             "history_import_bar_total": self._history_import_bar_total,
             "history_import_idempotent_total": self._history_import_idempotent_total,
             "history_import_conflict_total": self._history_import_conflict_total,
+            "history_import_failure_total": self._history_import_failure_total,
             "finalized_minute_tick_reject_total": (
                 self._finalized_minute_tick_reject_total
             ),
@@ -320,11 +327,23 @@ class CandleEngine:
                             "current candle older than imported finalized history"
                         )
             else:
-                current_after = None
+                if current_after is not None and incoming:
+                    latest_imported_ts = _to_ist_timestamp(incoming[-1]["timestamp"])
+                    current_ts = _to_ist_timestamp(current_after.get("timestamp"))
+                    if pd.isna(current_ts):
+                        raise DataIntegrityError("current candle timestamp is invalid")
+                    if current_ts < latest_imported_ts:
+                        raise DataIntegrityError(
+                            "current candle older than imported finalized history"
+                        )
+                    if current_ts == latest_imported_ts:
+                        current_after = None
 
             bounded = candidate[-int(self.max_bars) :]
-        except Exception:
-            self._history_import_conflict_total += 1
+        except Exception as exc:
+            self._history_import_failure_total += 1
+            if isinstance(exc, CandleHistoryConflictError):
+                self._history_import_conflict_total += 1
             LOGGER.exception(
                 "history_import_failed",
                 extra={
@@ -776,7 +795,7 @@ def _history_conflict(
     ts: pd.Timestamp,
     stored: Mapping[str, Any],
     incoming: Mapping[str, Any],
-) -> DataIntegrityError:
+) -> CandleHistoryConflictError:
     LOGGER.error(
         "FINALIZED_CANDLE_CONFLICT",
         extra={
@@ -791,7 +810,7 @@ def _history_conflict(
             },
         },
     )
-    return DataIntegrityError(
+    return CandleHistoryConflictError(
         f"conflicting finalized candle symbol={symbol} timestamp={ts}"
     )
 

--- a/src/nifty_scalper_bot/data/candle_state_hardening.py
+++ b/src/nifty_scalper_bot/data/candle_state_hardening.py
@@ -136,12 +136,58 @@ def install_candle_state_hardening(engine_cls: type[Any]) -> None:
 
     def hardened_replace_history(self: Any, frame: Any) -> None:
         with _lock_for(self):
+            before_current = _current_minute(self)
             original_replace(self, frame)
-            if reconcile_stale_current(self, reason="history"):
+            reconciled = reconcile_stale_current(self, reason="history")
+            latest_after = _latest_completed_minute(self)
+            current_after = _current_minute(self)
+            if (
+                not reconciled
+                and pd.isna(current_after)
+                and not pd.isna(before_current)
+                and not pd.isna(latest_after)
+                and before_current == latest_after
+            ):
+                counters = _counters_for(self)
+                counters["current_reconcile_total"] += 1
+                counters["current_reconcile_history_total"] += 1
+                reconciled = True
+                symbol = getattr(self, "symbol", None) or "symbol_unset"
+                log_throttled(
+                    LOGGER,
+                    (
+                        "candle_current_reconciled:"
+                        f"{symbol}:history:{before_current.isoformat()}"
+                    ),
+                    (
+                        "CANDLE_CURRENT_RECONCILED symbol=%s reason=%s "
+                        "current_minute=%s latest_completed_minute=%s"
+                    )
+                    % (
+                        symbol,
+                        "history",
+                        before_current.isoformat(),
+                        latest_after.isoformat(),
+                    ),
+                    interval_sec=30.0,
+                    level=logging.WARNING,
+                    extra={
+                        "event": "CANDLE_CURRENT_RECONCILED",
+                        "symbol": symbol,
+                        "reason": "history",
+                        "current_minute": before_current.isoformat(),
+                        "latest_completed_minute": latest_after.isoformat(),
+                        "action": "discarded",
+                    },
+                )
+            if reconciled:
                 _counters_for(self)["history_current_reconcile_total"] += 1
             if not _state_consistent(self):
                 from nifty_scalper_bot.data.source import DataIntegrityError
-                raise DataIntegrityError("inconsistent candle state after history replacement")
+
+                raise DataIntegrityError(
+                    "inconsistent candle state after history replacement"
+                )
 
     def hardened_on_tick(self: Any, tick: Mapping[str, Any]) -> Any:
         with _lock_for(self):
@@ -156,7 +202,12 @@ def install_candle_state_hardening(engine_cls: type[Any]) -> None:
             latest = _latest_completed_minute(self)
             if not pd.isna(latest) and tick_minute <= latest:
                 _counters_for(self)["finalized_minute_tick_reject_total"] += 1
-                symbol = tick.get("symbol") or tick.get("trading_symbol") or getattr(self, "symbol", None) or "symbol_unset"
+                symbol = (
+                    tick.get("symbol")
+                    or tick.get("trading_symbol")
+                    or getattr(self, "symbol", None)
+                    or "symbol_unset"
+                )
                 log_throttled(
                     LOGGER,
                     f"candle_tick_finalized_minute:{symbol}:{tick_minute.isoformat()}",
@@ -195,16 +246,30 @@ def install_candle_state_hardening(engine_cls: type[Any]) -> None:
             counters = _counters_for(self)
             latest = _latest_completed_minute(self)
             current = _current_minute(self)
-            diagnostics.update({
-                "finalized_minute_tick_reject_total": counters["finalized_minute_tick_reject_total"],
-                "history_current_reconcile_total": counters["history_current_reconcile_total"],
-                "current_reconcile_total": counters["current_reconcile_total"],
-                "current_reconcile_tick_total": counters["current_reconcile_tick_total"],
-                "current_reconcile_flush_total": counters["current_reconcile_flush_total"],
-                "last_completed_timestamp": None if pd.isna(latest) else latest.isoformat(),
-                "current_candle_timestamp": None if pd.isna(current) else current.isoformat(),
-                "state_consistent": _state_consistent(self),
-            })
+            diagnostics.update(
+                {
+                    "finalized_minute_tick_reject_total": counters[
+                        "finalized_minute_tick_reject_total"
+                    ],
+                    "history_current_reconcile_total": counters[
+                        "history_current_reconcile_total"
+                    ],
+                    "current_reconcile_total": counters["current_reconcile_total"],
+                    "current_reconcile_tick_total": counters[
+                        "current_reconcile_tick_total"
+                    ],
+                    "current_reconcile_flush_total": counters[
+                        "current_reconcile_flush_total"
+                    ],
+                    "last_completed_timestamp": (
+                        None if pd.isna(latest) else latest.isoformat()
+                    ),
+                    "current_candle_timestamp": (
+                        None if pd.isna(current) else current.isoformat()
+                    ),
+                    "state_consistent": _state_consistent(self),
+                }
+            )
             return diagnostics
 
     def is_state_consistent(self: Any) -> bool:

--- a/tests/data/test_candle_engine_history_import.py
+++ b/tests/data/test_candle_engine_history_import.py
@@ -92,6 +92,71 @@ def test_current_candle_overlap_rules_are_atomic() -> None:
         engine.import_history(pd.DataFrame([_row(5)]))
 
 
+def test_bootstrap_import_preserves_newer_current_candle() -> None:
+    engine = CandleEngine(symbol="NFO:T")
+    engine.current_candle = _row(2)
+
+    engine.import_history(pd.DataFrame([_row(0), _row(1)]), mode="bootstrap")
+
+    assert engine.get_current_candle() == _row(2)
+    assert len(engine.get_completed_bars()) == 2
+
+
+def test_bootstrap_equal_minute_overlap_uses_history_authoritative_compatibility() -> (
+    None
+):
+    engine = CandleEngine(symbol="NFO:T")
+    engine.current_candle = _row(1, close=100.75)
+
+    engine.import_history(pd.DataFrame([_row(0), _row(1)]), mode="bootstrap")
+
+    assert engine.get_current_candle() is None
+    assert float(engine.get_df().iloc[-1]["close"]) == 100.5
+
+
+def test_bootstrap_rejects_older_current_candle_atomically() -> None:
+    engine = CandleEngine(symbol="NFO:T")
+    engine.import_history(pd.DataFrame([_row(0)]), mode="bootstrap")
+    engine.current_candle = _row(1)
+    before = engine.get_df()
+
+    with pytest.raises(DataIntegrityError):
+        engine.import_history(
+            pd.DataFrame([_row(0), _row(1), _row(2)]), mode="bootstrap"
+        )
+
+    pd.testing.assert_frame_equal(engine.get_df(), before)
+    assert engine.get_current_candle() == _row(1)
+
+
+def test_empty_bootstrap_import_preserves_current_candle() -> None:
+    engine = CandleEngine(symbol="NFO:T")
+    engine.import_history(pd.DataFrame([_row(0)]), mode="bootstrap")
+    engine.current_candle = _row(1)
+
+    engine.import_history(pd.DataFrame(), mode="bootstrap")
+
+    assert engine.get_completed_bars() == []
+    assert engine.get_current_candle() == _row(1)
+
+
+def test_history_import_failure_and_conflict_counters_are_distinct() -> None:
+    engine = CandleEngine(symbol="NFO:T")
+    engine.import_history(pd.DataFrame([_row(0)]), mode="bootstrap")
+
+    with pytest.raises(DataIntegrityError):
+        engine.import_history(pd.DataFrame([{**_row(1), "high": 99.0}]))
+    diagnostics = engine.diagnostics()
+    assert diagnostics["history_import_failure_total"] == 1
+    assert diagnostics["history_import_conflict_total"] == 0
+
+    with pytest.raises(DataIntegrityError):
+        engine.import_history(pd.DataFrame([_row(0, close=100.75)]))
+    diagnostics = engine.diagnostics()
+    assert diagnostics["history_import_failure_total"] == 2
+    assert diagnostics["history_import_conflict_total"] == 1
+
+
 def test_max_bars_and_defensive_readers_are_enforced() -> None:
     engine = CandleEngine(symbol="NFO:T", max_bars=3)
     engine.import_history(pd.DataFrame([_row(i) for i in range(5)]), mode="bootstrap")

--- a/tests/data/test_candle_engine_history_import.py
+++ b/tests/data/test_candle_engine_history_import.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from nifty_scalper_bot.data.candle_engine import IST, CandleEngine, DataIntegrityError
+
+
+def _ts(minute: int) -> pd.Timestamp:
+    return pd.Timestamp("2026-01-02T09:15:00Z") + pd.Timedelta(minutes=minute)
+
+
+def _row(minute: int, *, close: float = 100.5, volume: float = 10.0) -> dict:
+    return {
+        "timestamp": _ts(minute),
+        "open": 100.0,
+        "high": max(101.0, close),
+        "low": min(99.0, close),
+        "close": close,
+        "volume": volume,
+    }
+
+
+def test_empty_engine_returns_no_finalized_watermark() -> None:
+    engine = CandleEngine(symbol="NFO:T")
+    assert engine.latest_finalized_minute() is None
+
+
+def test_bootstrap_and_incremental_history_import_populate_canonical_history() -> None:
+    engine = CandleEngine(symbol="NFO:T", max_bars=5)
+    engine.import_history(pd.DataFrame([_row(0), _row(1)]), mode="bootstrap")
+    engine.import_history(pd.DataFrame([_row(2)]))
+
+    bars = engine.get_completed_bars()
+    assert len(bars) == 3
+    assert bars[-1]["timestamp"].isoformat() == "2026-01-02T14:47:00+05:30"
+    assert engine.latest_finalized_minute() == bars[-1]["timestamp"]
+
+
+def test_identical_finalized_import_is_idempotent_and_conflict_is_atomic() -> None:
+    engine = CandleEngine(symbol="NFO:T")
+    engine.import_history(pd.DataFrame([_row(0), _row(1)]), mode="bootstrap")
+    before = engine.get_df()
+
+    engine.import_history(pd.DataFrame([_row(1)]))
+    assert len(engine.get_df()) == 2
+    assert engine.diagnostics()["history_import_idempotent_total"] == 1
+
+    with pytest.raises(DataIntegrityError):
+        engine.import_history(pd.DataFrame([_row(1, close=100.75)]))
+    pd.testing.assert_frame_equal(engine.get_df(), before)
+    assert engine.diagnostics()["history_import_conflict_total"] >= 1
+
+
+def test_invalid_ohlc_negative_volume_and_conflicting_duplicates_rejected() -> None:
+    engine = CandleEngine(symbol="NFO:T")
+
+    with pytest.raises(DataIntegrityError):
+        engine.import_history(pd.DataFrame([{**_row(0), "high": 99.0}]))
+    with pytest.raises(DataIntegrityError):
+        engine.import_history(pd.DataFrame([_row(0, volume=-1.0)]))
+    with pytest.raises(DataIntegrityError):
+        engine.import_history(pd.DataFrame([_row(0), _row(0, close=100.75)]))
+
+
+def test_identical_duplicate_timestamp_is_accepted_once() -> None:
+    engine = CandleEngine(symbol="NFO:T")
+    engine.import_history(pd.DataFrame([_row(0), _row(0)]))
+    assert len(engine.get_completed_bars()) == 1
+
+
+def test_current_candle_overlap_rules_are_atomic() -> None:
+    engine = CandleEngine(symbol="NFO:T")
+    engine.current_candle = _row(2)
+    engine.import_history(pd.DataFrame([_row(0), _row(1)]))
+    assert engine.get_current_candle() is not None
+
+    engine.import_history(pd.DataFrame([_row(2)]))
+    assert engine.get_current_candle() is None
+
+    engine.current_candle = _row(4, close=100.5)
+    before = engine.get_df()
+    with pytest.raises(DataIntegrityError):
+        engine.import_history(pd.DataFrame([_row(3), _row(4, close=100.75)]))
+    pd.testing.assert_frame_equal(engine.get_df(), before)
+    assert engine.get_current_candle() is not None
+
+    with pytest.raises(DataIntegrityError):
+        engine.import_history(pd.DataFrame([_row(5)]))
+
+
+def test_max_bars_and_defensive_readers_are_enforced() -> None:
+    engine = CandleEngine(symbol="NFO:T", max_bars=3)
+    engine.import_history(pd.DataFrame([_row(i) for i in range(5)]), mode="bootstrap")
+    assert len(engine.get_completed_bars()) == 3
+
+    bars = engine.get_completed_bars()
+    bars[-1]["close"] = 999.0
+    assert engine.get_completed_bars()[-1]["close"] != 999.0
+
+    frame = engine.get_df()
+    frame.loc[frame.index[-1], "close"] = 999.0
+    assert float(engine.get_df().iloc[-1]["close"]) != 999.0
+
+    engine.current_candle = _row(6)
+    current = engine.get_current_candle()
+    assert current is not None
+    current["close"] = 999.0
+    assert engine.get_current_candle()["close"] != 999.0  # type: ignore[index]
+
+
+def test_late_tick_at_finalized_watermark_rejected_after_hydration() -> None:
+    engine = CandleEngine(symbol="NFO:T")
+    engine.import_history(pd.DataFrame([_row(0)]), mode="bootstrap")
+    assert (
+        engine.on_tick({"symbol": "NFO:T", "timestamp": _ts(0), "ltp": 101.0}) is None
+    )
+    assert engine.diagnostics()["finalized_minute_tick_reject_total"] == 1
+
+
+def test_history_import_normalizes_timezone_and_does_not_touch_trading_modules() -> (
+    None
+):
+    engine = CandleEngine(symbol="NFO:T")
+    engine.import_history(pd.DataFrame([_row(0)]), mode="bootstrap")
+    assert str(engine.get_df().iloc[0]["timestamp"].tz) == str(IST)
+
+    root = Path(__file__).resolve().parents[2]
+    forbidden_roots = ("strategies", "execution", "risk")
+    offenders: list[str] = []
+    for path in (root / "src" / "nifty_scalper_bot").rglob("*.py"):
+        rel = path.relative_to(root / "src" / "nifty_scalper_bot")
+        if rel.parts and rel.parts[0] in forbidden_roots:
+            tree = ast.parse(path.read_text(), filename=str(path))
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Attribute) and node.attr == "import_history":
+                    offenders.append(str(rel))
+    assert offenders == []

--- a/tests/data/test_candle_state_hardening.py
+++ b/tests/data/test_candle_state_hardening.py
@@ -9,7 +9,7 @@ import pandas as pd
 from nifty_scalper_bot.data.candle_clock_flush_hardening import (
     install_candle_clock_flush_hardening,
 )
-from nifty_scalper_bot.data.candle_engine import CandleEngine, IST
+from nifty_scalper_bot.data.candle_engine import IST, CandleEngine
 from nifty_scalper_bot.data.candle_state_hardening import install_candle_state_hardening
 
 install_candle_state_hardening(CandleEngine)
@@ -89,7 +89,9 @@ def test_new_engine_does_not_inherit_hardening_diagnostics() -> None:
     first = CandleEngine(symbol="NFO:NIFTY26JULFUT")
     first.replace_history(pd.DataFrame([_history_row(minute)]))
     for second in (5, 15, 30):
-        assert first.on_tick(_tick(minute + pd.Timedelta(seconds=second), 101.0)) is None
+        assert (
+            first.on_tick(_tick(minute + pd.Timedelta(seconds=second), 101.0)) is None
+        )
     assert first.diagnostics()["finalized_minute_tick_reject_total"] == 3
 
     second = CandleEngine(symbol="NFO:NIFTY26JULFUT")
@@ -244,7 +246,9 @@ def test_replayed_old_ticks_after_reconciliation_do_not_recreate_conflict() -> N
     engine.replace_history(pd.DataFrame([_history_row(minute)]))
 
     for second in (5, 15, 30, 45):
-        assert engine.on_tick(_tick(minute + pd.Timedelta(seconds=second), 101.0)) is None
+        assert (
+            engine.on_tick(_tick(minute + pd.Timedelta(seconds=second), 101.0)) is None
+        )
 
     assert engine.current_candle is None
     assert engine.diagnostics()["finalized_minute_tick_reject_total"] == 4


### PR DESCRIPTION
### Motivation

- There are multiple competing candle writers and hydration paths which created split state, history/live races, and the risk that queued or imported data could reopen or conflict with finalized minutes, so CandleEngine must offer a clear authoritative API for candle lifecycle and history imports (Phase 1 of the SSOT plan). 
- This change implements a safe, staged refactor that preserves existing live aggregation semantics while introducing an explicit, atomic historical import API so other components can stop mutating CandleEngine private state.

### Description

- Added public CandleEngine APIs: `latest_finalized_minute()`, `get_completed_bars()`, `get_current_candle()`, and `import_history(..., mode="bootstrap"|"incremental")`, and made `replace_history` delegate to bootstrap import semantics for compatibility. 
- Implemented strict historical normalization and validation (`_normalize_history_frame`) with timestamp timezone normalization, per-row OHLCV validation, deduplication by canonical timestamp, idempotency counting, and atomic conflict detection that raises `DataIntegrityError` on conflicting finalized bars (no last-write-wins). 
- Kept per-tick hot path O(1) and unchanged live aggregation semantics, and added late-tick safety by rejecting ticks at-or-before the finalized watermark in `on_tick` while recording diagnostics; added import and reject counters to diagnostics. 
- Added focused tests `tests/data/test_candle_engine_history_import.py` that exercise bootstrap vs incremental import, idempotency, conflicts, validation failures, current/history overlap rules, `max_bars`, defensive-copy guarantees, and late-tick rejection after hydration; no strategy/execution logic was changed.

### Testing

- Ran focused validations and unit tests for the modified module and new tests: 
  - `python -m compileall src/nifty_scalper_bot/data/candle_engine.py` — success. 
  - `ruff check src/nifty_scalper_bot/data/candle_engine.py tests/data/test_candle_engine_history_import.py` — success for the changed files. 
  - `black --check src/nifty_scalper_bot/data/candle_engine.py tests/data/test_candle_engine_history_import.py` — success for the changed files. 
  - `pytest tests/data/test_candle_engine.py tests/data/test_candle_engine_incremental_finalize.py tests/data/test_candle_engine_history_import.py -q` — focused suites passed (the new history-import tests exercised the required Phase 1 behaviors). 
- Broader repo-wide checks: `mypy` and full `black --check src tests` surfaced many pre-existing/type/formatting issues across unrelated files (these are repository-wide pre-existing failures and not caused by the Phase 1 changes), so full-suite static typing/format checks were not completed for the entire repo in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5c224fc01083248726c31334e59b37)