### PR TITLE
Internalize CandleEngine state invariants

### DIFF
--- a/src/nifty_scalper_bot/data/candle_clock_flush_hardening.py
+++ b/src/nifty_scalper_bot/data/candle_clock_flush_hardening.py
@@ -8,10 +8,7 @@ from typing import Any, Mapping
 
 import pandas as pd
 
-from nifty_scalper_bot.data.candle_state_hardening import (
-    _lock_for,
-    reconcile_stale_current,
-)
+from nifty_scalper_bot.data.candle_state_hardening import reconcile_stale_current
 
 _IST_TZ = "Asia/Kolkata"
 _INSTALLED_ATTR = "_candle_clock_flush_hardening_installed"
@@ -68,38 +65,36 @@ def install_candle_clock_flush_hardening(manager_cls: type[Any]) -> None:
             if now_ts < expected_minute + pd.Timedelta(minutes=1, seconds=grace):
                 continue
 
-            with _lock_for(engine):
-                # Completed history is authoritative. Hydration can race with a
-                # live partial candle and leave current_candle on an already
-                # finalized minute; discard that stale state instead of retrying
-                # the same DataIntegrityError every flush cycle.
-                if reconcile_stale_current(engine, reason="clock_flush"):
-                    continue
-                locked_current = getattr(engine, "current_candle", None)
-                if not isinstance(locked_current, Mapping):
-                    continue
-                locked_minute = _coerce_ist_timestamp(locked_current.get("timestamp"))
-                if locked_minute is None or locked_minute != expected_minute:
-                    # Tick-driven rollover won the race. Never flush the newly
-                    # opened minute based on the stale pre-lock due decision.
-                    continue
-                if now_ts < locked_minute + pd.Timedelta(minutes=1, seconds=grace):
-                    continue
-                try:
-                    candle = engine.flush()
-                except Exception as exc:  # noqa: BLE001
-                    self._logger.error(
-                        "MDM_CANDLE_CLOCK_FLUSH_FAILED symbol=%s error=%r",
-                        symbol,
-                        exc,
-                        exc_info=True,
-                        extra={
-                            "event": "MDM_CANDLE_CLOCK_FLUSH_FAILED",
-                            "symbol": symbol,
-                            "error": repr(exc),
-                        },
-                    )
-                    continue
+            # Completed history is authoritative. Hydration can race with a
+            # live partial candle and leave current_candle on an already
+            # finalized minute; delegate that reconciliation to CandleEngine.
+            if reconcile_stale_current(engine, reason="clock_flush"):
+                continue
+            locked_current = getattr(engine, "current_candle", None)
+            if not isinstance(locked_current, Mapping):
+                continue
+            locked_minute = _coerce_ist_timestamp(locked_current.get("timestamp"))
+            if locked_minute is None or locked_minute != expected_minute:
+                # Tick-driven rollover won the race. Never flush the newly
+                # opened minute based on the stale pre-lock due decision.
+                continue
+            if now_ts < locked_minute + pd.Timedelta(minutes=1, seconds=grace):
+                continue
+            try:
+                candle = engine.flush()
+            except Exception as exc:  # noqa: BLE001
+                self._logger.error(
+                    "MDM_CANDLE_CLOCK_FLUSH_FAILED symbol=%s error=%r",
+                    symbol,
+                    exc,
+                    exc_info=True,
+                    extra={
+                        "event": "MDM_CANDLE_CLOCK_FLUSH_FAILED",
+                        "symbol": symbol,
+                        "error": repr(exc),
+                    },
+                )
+                continue
 
             if not candle:
                 continue
@@ -113,7 +108,10 @@ def install_candle_clock_flush_hardening(manager_cls: type[Any]) -> None:
             previous = published.get(symbol)
             if previous is not None and timestamp <= previous:
                 self._logger.warning(
-                    "MDM_CANDLE_DUPLICATE_PUBLISH_SUPPRESSED symbol=%s timestamp=%s previous=%s",
+                    (
+                        "MDM_CANDLE_DUPLICATE_PUBLISH_SUPPRESSED "
+                        "symbol=%s timestamp=%s previous=%s"
+                    ),
                     symbol,
                     timestamp.isoformat(),
                     previous.isoformat(),
@@ -129,10 +127,16 @@ def install_candle_clock_flush_hardening(manager_cls: type[Any]) -> None:
             bar = {
                 "symbol": symbol,
                 "timestamp": timestamp,
-                "open": float(candle["open"] if isinstance(candle, dict) else candle.open),
-                "high": float(candle["high"] if isinstance(candle, dict) else candle.high),
+                "open": float(
+                    candle["open"] if isinstance(candle, dict) else candle.open
+                ),
+                "high": float(
+                    candle["high"] if isinstance(candle, dict) else candle.high
+                ),
                 "low": float(candle["low"] if isinstance(candle, dict) else candle.low),
-                "close": float(candle["close"] if isinstance(candle, dict) else candle.close),
+                "close": float(
+                    candle["close"] if isinstance(candle, dict) else candle.close
+                ),
                 "volume": int(
                     float(
                         (

--- a/src/nifty_scalper_bot/data/candle_clock_flush_hardening.py
+++ b/src/nifty_scalper_bot/data/candle_clock_flush_hardening.py
@@ -65,23 +65,18 @@ def install_candle_clock_flush_hardening(manager_cls: type[Any]) -> None:
             if now_ts < expected_minute + pd.Timedelta(minutes=1, seconds=grace):
                 continue
 
-            # Completed history is authoritative. Hydration can race with a
-            # live partial candle and leave current_candle on an already
-            # finalized minute; delegate that reconciliation to CandleEngine.
-            if reconcile_stale_current(engine, reason="clock_flush"):
-                continue
-            locked_current = getattr(engine, "current_candle", None)
-            if not isinstance(locked_current, Mapping):
-                continue
-            locked_minute = _coerce_ist_timestamp(locked_current.get("timestamp"))
-            if locked_minute is None or locked_minute != expected_minute:
-                # Tick-driven rollover won the race. Never flush the newly
-                # opened minute based on the stale pre-lock due decision.
-                continue
-            if now_ts < locked_minute + pd.Timedelta(minutes=1, seconds=grace):
-                continue
+            # Completed history is authoritative, and tick-driven rollover can
+            # race this clock path after the due snapshot. Delegate the final
+            # recheck and finalization to CandleEngine under its native lock so
+            # a newer current minute is never flushed using this stale decision.
+            flush_expected = getattr(engine, "flush_if_current_minute", None)
             try:
-                candle = engine.flush()
+                if callable(flush_expected):
+                    candle = flush_expected(expected_minute)
+                else:
+                    if reconcile_stale_current(engine, reason="clock_flush"):
+                        continue
+                    candle = engine.flush()
             except Exception as exc:  # noqa: BLE001
                 self._logger.error(
                     "MDM_CANDLE_CLOCK_FLUSH_FAILED symbol=%s error=%r",

--- a/src/nifty_scalper_bot/data/candle_engine.py
+++ b/src/nifty_scalper_bot/data/candle_engine.py
@@ -226,13 +226,14 @@ class CandleEngine:
         self.import_history(value, mode="bootstrap")
 
     def _cached_df_copy(self) -> pd.DataFrame:
-        if self._df_cache_dirty or self._df_cache is None:
-            self._df_cache = pd.DataFrame(
-                list(self._completed_candles), columns=list(_OHLC_COLUMNS)
-            )
-            self._df_cache_dirty = False
-            self._df_cache_rebuild_total += 1
-        return self._df_cache.copy(deep=True)
+        with self._lock:
+            if self._df_cache_dirty or self._df_cache is None:
+                self._df_cache = pd.DataFrame(
+                    list(self._completed_candles), columns=list(_OHLC_COLUMNS)
+                )
+                self._df_cache_dirty = False
+                self._df_cache_rebuild_total += 1
+            return self._df_cache.copy(deep=True)
 
     def diagnostics(self) -> dict[str, Any]:
         with self._lock:
@@ -276,12 +277,13 @@ class CandleEngine:
 
     def latest_finalized_minute(self) -> pd.Timestamp | None:
         """Return the latest completed candle minute, normalized to market TZ."""
-        if not self._completed_candles:
-            return None
-        ts = _to_ist_timestamp(self._completed_candles[-1].get("timestamp"))
-        if pd.isna(ts):
-            return None
-        return pd.Timestamp(ts)
+        with self._lock:
+            if not self._completed_candles:
+                return None
+            ts = _to_ist_timestamp(self._completed_candles[-1].get("timestamp"))
+            if pd.isna(ts):
+                return None
+            return pd.Timestamp(ts)
 
     def _current_candle_minute(self) -> pd.Timestamp:
         if not isinstance(self.current_candle, Mapping):
@@ -291,39 +293,57 @@ class CandleEngine:
     def is_state_consistent(self) -> bool:
         """Return whether finalized/current candle state satisfies native invariants."""
         with self._lock:
-            previous = pd.NaT
-            seen: set[pd.Timestamp] = set()
-            if len(self._completed_candles) > int(self.max_bars):
+            completed = [dict(row) for row in self._completed_candles]
+            current = (
+                dict(self.current_candle) if self.current_candle is not None else None
+            )
+            return self._candidate_state_consistent(
+                completed,
+                current,
+                self.last_candle_close,
+            )
+
+    def _candidate_state_consistent(
+        self,
+        completed: list[dict[str, Any]],
+        current: dict[str, Any] | None,
+        last_candle_close: datetime | pd.Timestamp | None,
+    ) -> bool:
+        previous = pd.NaT
+        seen: set[pd.Timestamp] = set()
+        if len(completed) > int(self.max_bars):
+            return False
+        for candle in completed:
+            if not isinstance(candle, Mapping):
                 return False
-            for candle in self._completed_candles:
-                if not isinstance(candle, Mapping):
-                    return False
-                ts = _to_ist_timestamp(candle.get("timestamp"))
-                if pd.isna(ts) or ts.tzinfo is None or str(ts.tzinfo) != str(IST):
-                    return False
-                if ts in seen or (not pd.isna(previous) and ts <= previous):
-                    return False
-                seen.add(ts)
-                previous = ts
-            cached_latest = None
-            if self.last_candle_close is not None:
-                cached = _to_ist_timestamp(self.last_candle_close)
-                if pd.isna(cached):
-                    return False
-                cached_latest = cached
-            latest = None if pd.isna(previous) else previous
-            if (
-                cached_latest is not None
-                and latest is not None
-                and cached_latest != latest
-            ):
+            ts = _to_ist_timestamp(candle.get("timestamp"))
+            if pd.isna(ts) or ts.tzinfo is None or str(ts.tzinfo) != str(IST):
                 return False
-            current = self._current_candle_minute()
-            if pd.isna(current):
-                return self.current_candle is None
-            if current.tzinfo is None or str(current.tzinfo) != str(IST):
+            if ts in seen or (not pd.isna(previous) and ts <= previous):
                 return False
-            return latest is None or current > latest
+            seen.add(ts)
+            previous = ts
+
+        latest = None if pd.isna(previous) else previous
+        cached_latest: pd.Timestamp | None = None
+        if last_candle_close is not None:
+            cached = _to_ist_timestamp(last_candle_close)
+            if pd.isna(cached):
+                return False
+            cached_latest = pd.Timestamp(cached)
+        if latest != cached_latest:
+            return False
+
+        if current is None:
+            return True
+        if not isinstance(current, Mapping):
+            return False
+        current_ts = _to_ist_timestamp(current.get("timestamp"))
+        if pd.isna(current_ts):
+            return False
+        if current_ts.tzinfo is None or str(current_ts.tzinfo) != str(IST):
+            return False
+        return latest is None or current_ts > latest
 
     def reconcile_current_with_finalized(self, *, reason: str) -> bool:
         """Discard a current candle only when it duplicates the finalized watermark."""
@@ -369,11 +389,15 @@ class CandleEngine:
 
     def get_completed_bars(self) -> list[dict[str, Any]]:
         """Return defensive copies of canonical finalized OHLCV bars."""
-        return [dict(row) for row in self._completed_candles]
+        with self._lock:
+            return [dict(row) for row in self._completed_candles]
 
     def get_current_candle(self) -> dict[str, Any] | None:
         """Return a defensive copy of the current partial candle, if any."""
-        return dict(self.current_candle) if self.current_candle is not None else None
+        with self._lock:
+            return (
+                dict(self.current_candle) if self.current_candle is not None else None
+            )
 
     def import_history(
         self,
@@ -479,12 +503,40 @@ class CandleEngine:
             )
             raise
 
-        self._completed_candles = deque(
-            [dict(row) for row in bounded], maxlen=int(self.max_bars)
-        )
+        try:
+            bounded_rows = [dict(row) for row in bounded]
+            latest = (
+                _to_ist_timestamp(bounded_rows[-1].get("timestamp"))
+                if bounded_rows
+                else None
+            )
+            if latest is not None and pd.isna(latest):
+                latest = None
+            last_candle_close_after = (
+                latest.to_pydatetime() if latest is not None else None
+            )
+            if not self._candidate_state_consistent(
+                bounded_rows, current_after, last_candle_close_after
+            ):
+                raise DataIntegrityError(
+                    "inconsistent candle state after history import"
+                )
+        except Exception:
+            self._history_import_failure_total += 1
+            LOGGER.exception(
+                "history_import_failed",
+                extra={
+                    "event": "history_import_failed",
+                    "symbol": symbol,
+                    "mode": mode,
+                    "source": source,
+                },
+            )
+            raise
+
+        self._completed_candles = deque(bounded_rows, maxlen=int(self.max_bars))
         self.current_candle = current_after
-        latest = self.latest_finalized_minute()
-        self.last_candle_close = latest.to_pydatetime() if latest is not None else None
+        self.last_candle_close = last_candle_close_after
         if history_reconciled_current:
             self._current_reconcile_total += 1
             self._history_current_reconcile_total += 1
@@ -514,8 +566,6 @@ class CandleEngine:
                         "action": "discarded",
                     },
                 )
-        if not self.is_state_consistent():
-            raise DataIntegrityError("inconsistent candle state after history import")
         self._df_cache_dirty = True
         self._history_import_total += 1
         self._history_import_bar_total += len(incoming)
@@ -865,6 +915,26 @@ class CandleEngine:
             },
         )
         return normalized
+
+    def flush_if_current_minute(
+        self, expected_minute: pd.Timestamp
+    ) -> dict[str, Any] | None:
+        """Atomically flush only when current candle still matches expected minute."""
+        expected = _to_ist_timestamp(expected_minute)
+        if pd.isna(expected):
+            return None
+        with self._lock:
+            if self.reconcile_current_with_finalized(reason="flush"):
+                return None
+            current_minute = self._current_candle_minute()
+            if pd.isna(current_minute) or current_minute != expected:
+                return None
+            finalized = self._finalize_current_candle()
+            if finalized is not None:
+                self.current_candle = None
+            if not self.is_state_consistent():
+                raise DataIntegrityError("inconsistent candle state after flush")
+            return finalized
 
     def flush(self) -> dict[str, Any] | None:
         with self._lock:

--- a/src/nifty_scalper_bot/data/candle_engine.py
+++ b/src/nifty_scalper_bot/data/candle_engine.py
@@ -5,11 +5,12 @@ from __future__ import annotations
 import logging
 import math
 import os
+import threading
 import time
 from collections import deque
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Any, Callable, Mapping
+from typing import Any, Callable, Mapping, cast
 
 import pandas as pd
 
@@ -155,6 +156,11 @@ class CandleEngine:
     _history_import_conflict_total: int = field(default=0, init=False)
     _history_import_failure_total: int = field(default=0, init=False)
     _finalized_minute_tick_reject_total: int = field(default=0, init=False)
+    _history_current_reconcile_total: int = field(default=0, init=False)
+    _current_reconcile_total: int = field(default=0, init=False)
+    _current_reconcile_tick_total: int = field(default=0, init=False)
+    _current_reconcile_flush_total: int = field(default=0, init=False)
+    _lock: threading.RLock = field(init=False, repr=False)
 
     def __init__(
         self,
@@ -171,6 +177,7 @@ class CandleEngine:
         self.last_candle_close = last_candle_close
         self._last_tick_ts = None
         self.symbol = symbol
+        self._lock = threading.RLock()
         self._completed_candles = deque(maxlen=int(self.max_bars))
         self._df_cache = None
         self._df_cache_dirty = True
@@ -184,6 +191,10 @@ class CandleEngine:
         self._history_import_conflict_total = 0
         self._history_import_failure_total = 0
         self._finalized_minute_tick_reject_total = 0
+        self._history_current_reconcile_total = 0
+        self._current_reconcile_total = 0
+        self._current_reconcile_tick_total = 0
+        self._current_reconcile_flush_total = 0
         if df is not None and not df.empty:
             self.replace_history(df)
 
@@ -224,28 +235,44 @@ class CandleEngine:
         return self._df_cache.copy(deep=True)
 
     def diagnostics(self) -> dict[str, Any]:
-        return {
-            "candle_store_size": len(self._completed_candles),
-            "candle_store_maxlen": self._completed_candles.maxlen,
-            "df_cache_dirty": self._df_cache_dirty,
-            "df_cache_rebuild_total": self._df_cache_rebuild_total,
-            "live_append_total": self._live_append_total,
-            "same_minute_idempotent_total": self._same_minute_idempotent_total,
-            "same_minute_conflict_total": self._same_minute_conflict_total,
-            "history_import_total": self._history_import_total,
-            "history_import_bar_total": self._history_import_bar_total,
-            "history_import_idempotent_total": self._history_import_idempotent_total,
-            "history_import_conflict_total": self._history_import_conflict_total,
-            "history_import_failure_total": self._history_import_failure_total,
-            "finalized_minute_tick_reject_total": (
-                self._finalized_minute_tick_reject_total
-            ),
-            "latest_finalized_minute": (
-                self.latest_finalized_minute().isoformat()
-                if self.latest_finalized_minute() is not None
-                else None
-            ),
-        }
+        with self._lock:
+            latest = self.latest_finalized_minute()
+            current = self._current_candle_minute()
+            return {
+                "candle_store_size": len(self._completed_candles),
+                "candle_store_maxlen": self._completed_candles.maxlen,
+                "df_cache_dirty": self._df_cache_dirty,
+                "df_cache_rebuild_total": self._df_cache_rebuild_total,
+                "live_append_total": self._live_append_total,
+                "same_minute_idempotent_total": self._same_minute_idempotent_total,
+                "same_minute_conflict_total": self._same_minute_conflict_total,
+                "history_import_total": self._history_import_total,
+                "history_import_bar_total": self._history_import_bar_total,
+                "history_import_idempotent_total": (
+                    self._history_import_idempotent_total
+                ),
+                "history_import_conflict_total": self._history_import_conflict_total,
+                "history_import_failure_total": self._history_import_failure_total,
+                "finalized_minute_tick_reject_total": (
+                    self._finalized_minute_tick_reject_total
+                ),
+                "history_current_reconcile_total": (
+                    self._history_current_reconcile_total
+                ),
+                "current_reconcile_total": self._current_reconcile_total,
+                "current_reconcile_tick_total": self._current_reconcile_tick_total,
+                "current_reconcile_flush_total": self._current_reconcile_flush_total,
+                "latest_finalized_minute": (
+                    latest.isoformat() if latest is not None else None
+                ),
+                "last_completed_timestamp": (
+                    latest.isoformat() if latest is not None else None
+                ),
+                "current_candle_timestamp": (
+                    None if pd.isna(current) else current.isoformat()
+                ),
+                "state_consistent": self.is_state_consistent(),
+            }
 
     def latest_finalized_minute(self) -> pd.Timestamp | None:
         """Return the latest completed candle minute, normalized to market TZ."""
@@ -255,6 +282,90 @@ class CandleEngine:
         if pd.isna(ts):
             return None
         return pd.Timestamp(ts)
+
+    def _current_candle_minute(self) -> pd.Timestamp:
+        if not isinstance(self.current_candle, Mapping):
+            return pd.NaT
+        return _to_ist_timestamp(self.current_candle.get("timestamp"))
+
+    def is_state_consistent(self) -> bool:
+        """Return whether finalized/current candle state satisfies native invariants."""
+        with self._lock:
+            previous = pd.NaT
+            seen: set[pd.Timestamp] = set()
+            if len(self._completed_candles) > int(self.max_bars):
+                return False
+            for candle in self._completed_candles:
+                if not isinstance(candle, Mapping):
+                    return False
+                ts = _to_ist_timestamp(candle.get("timestamp"))
+                if pd.isna(ts) or ts.tzinfo is None or str(ts.tzinfo) != str(IST):
+                    return False
+                if ts in seen or (not pd.isna(previous) and ts <= previous):
+                    return False
+                seen.add(ts)
+                previous = ts
+            cached_latest = None
+            if self.last_candle_close is not None:
+                cached = _to_ist_timestamp(self.last_candle_close)
+                if pd.isna(cached):
+                    return False
+                cached_latest = cached
+            latest = None if pd.isna(previous) else previous
+            if (
+                cached_latest is not None
+                and latest is not None
+                and cached_latest != latest
+            ):
+                return False
+            current = self._current_candle_minute()
+            if pd.isna(current):
+                return self.current_candle is None
+            if current.tzinfo is None or str(current.tzinfo) != str(IST):
+                return False
+            return latest is None or current > latest
+
+    def reconcile_current_with_finalized(self, *, reason: str) -> bool:
+        """Discard a current candle only when it duplicates the finalized watermark."""
+        with self._lock:
+            latest = self.latest_finalized_minute()
+            current = self._current_candle_minute()
+            if latest is None or pd.isna(current):
+                return False
+            if current > latest:
+                return False
+            if current < latest:
+                raise DataIntegrityError("current candle older than finalized history")
+            self.current_candle = None
+            self._current_reconcile_total += 1
+            if reason in {"history", "bootstrap", "incremental"}:
+                self._history_current_reconcile_total += 1
+            elif reason in {"tick"}:
+                self._current_reconcile_tick_total += 1
+            elif reason in {"flush", "clock_flush"}:
+                self._current_reconcile_flush_total += 1
+                self._same_minute_idempotent_total += 1
+            symbol = self.symbol or "symbol_unset"
+            log_throttled(
+                LOGGER,
+                f"candle_current_reconciled:{symbol}:{reason}:{current.isoformat()}",
+                (
+                    "CANDLE_CURRENT_RECONCILED symbol=%s reason=%s "
+                    "current_minute=%s latest_completed_minute=%s"
+                )
+                % (symbol, reason, current.isoformat(), latest.isoformat()),
+                interval_sec=30.0,
+                level=logging.WARNING,
+                extra={
+                    "event": "CANDLE_CURRENT_RECONCILED",
+                    "symbol": symbol,
+                    "reason": reason,
+                    "current_minute": current.isoformat(),
+                    "latest_completed_minute": latest.isoformat(),
+                    "action": "discarded",
+                },
+            )
+            return True
 
     def get_completed_bars(self) -> list[dict[str, Any]]:
         """Return defensive copies of canonical finalized OHLCV bars."""
@@ -279,6 +390,16 @@ class CandleEngine:
         and fails closed on conflicts. ``source`` is diagnostic metadata only
         and is never part of candle identity.
         """
+        with self._lock:
+            return self._import_history_locked(frame, mode=mode, source=source)
+
+    def _import_history_locked(
+        self,
+        frame: pd.DataFrame | None,
+        *,
+        mode: str = "incremental",
+        source: str | None = None,
+    ) -> pd.DataFrame:
         if mode not in {"bootstrap", "incremental"}:
             raise ValueError(f"Unsupported history import mode: {mode}")
         symbol = self.symbol or "symbol_unset"
@@ -289,6 +410,7 @@ class CandleEngine:
             current_after = (
                 dict(self.current_candle) if self.current_candle is not None else None
             )
+            history_reconciled_current = False
             if mode == "incremental":
                 existing = list(self._completed_candles)
                 merged_by_ts: dict[pd.Timestamp, dict[str, Any]] = {
@@ -321,6 +443,7 @@ class CandleEngine:
                                 symbol, current_ts, imported, normalized_current
                             )
                         current_after = None
+                        history_reconciled_current = True
                         idempotent += 1
                     elif current_ts < latest_imported_ts:
                         raise DataIntegrityError(
@@ -338,6 +461,7 @@ class CandleEngine:
                         )
                     if current_ts == latest_imported_ts:
                         current_after = None
+                        history_reconciled_current = True
 
             bounded = candidate[-int(self.max_bars) :]
         except Exception as exc:
@@ -359,12 +483,43 @@ class CandleEngine:
             [dict(row) for row in bounded], maxlen=int(self.max_bars)
         )
         self.current_candle = current_after
+        latest = self.latest_finalized_minute()
+        self.last_candle_close = latest.to_pydatetime() if latest is not None else None
+        if history_reconciled_current:
+            self._current_reconcile_total += 1
+            self._history_current_reconcile_total += 1
+            reconciled_minute = latest
+            if reconciled_minute is not None:
+                log_throttled(
+                    LOGGER,
+                    f"candle_current_reconciled:{symbol}:history:{reconciled_minute.isoformat()}",
+                    (
+                        "CANDLE_CURRENT_RECONCILED symbol=%s reason=%s "
+                        "current_minute=%s latest_completed_minute=%s"
+                    )
+                    % (
+                        symbol,
+                        "history",
+                        reconciled_minute.isoformat(),
+                        reconciled_minute.isoformat(),
+                    ),
+                    interval_sec=30.0,
+                    level=logging.WARNING,
+                    extra={
+                        "event": "CANDLE_CURRENT_RECONCILED",
+                        "symbol": symbol,
+                        "reason": "history",
+                        "current_minute": reconciled_minute.isoformat(),
+                        "latest_completed_minute": reconciled_minute.isoformat(),
+                        "action": "discarded",
+                    },
+                )
+        if not self.is_state_consistent():
+            raise DataIntegrityError("inconsistent candle state after history import")
         self._df_cache_dirty = True
         self._history_import_total += 1
         self._history_import_bar_total += len(incoming)
         self._history_import_idempotent_total += idempotent
-        latest = self.latest_finalized_minute()
-        self.last_candle_close = latest.to_pydatetime() if latest is not None else None
         LOGGER.info(
             "history_import_completed",
             extra={
@@ -383,6 +538,10 @@ class CandleEngine:
         return self.get_df()
 
     def on_tick(self, tick: Mapping[str, Any]) -> dict[str, Any] | None:
+        with self._lock:
+            return self._on_tick_locked(tick)
+
+    def _on_tick_locked(self, tick: Mapping[str, Any]) -> dict[str, Any] | None:
         if self.interval != "1min":
             raise ValueError(f"Unsupported interval: {self.interval}")
         try:
@@ -482,6 +641,7 @@ class CandleEngine:
         payload["timestamp"] = timestamp
         payload["timestamp_source"] = timestamp_source
         minute = timestamp.floor("1min")
+        self.reconcile_current_with_finalized(reason="tick")
         latest_finalized = self.latest_finalized_minute()
         if latest_finalized is not None and minute <= latest_finalized:
             self._finalized_minute_tick_reject_total += 1
@@ -707,10 +867,15 @@ class CandleEngine:
         return normalized
 
     def flush(self) -> dict[str, Any] | None:
-        finalized = self._finalize_current_candle()
-        if finalized is not None:
-            self.current_candle = None
-        return finalized
+        with self._lock:
+            if self.reconcile_current_with_finalized(reason="flush"):
+                return None
+            finalized = self._finalize_current_candle()
+            if finalized is not None:
+                self.current_candle = None
+            if not self.is_state_consistent():
+                raise DataIntegrityError("inconsistent candle state after flush")
+            return finalized
 
     def get_df(self) -> pd.DataFrame:
         """Return a defensive canonical OHLCV copy."""
@@ -733,7 +898,7 @@ def _normalize_completed_candle(
     out: dict[str, Any] = {"timestamp": incoming_ts}
     for ohlcv_field in ("open", "high", "low", "close"):
         try:
-            value = float(candle.get(ohlcv_field))
+            value = float(cast(float | int | str, candle.get(ohlcv_field)))
         except (TypeError, ValueError):
             return None
         if not math.isfinite(value) or value <= 0.0:
@@ -823,8 +988,8 @@ def _candles_equivalent(left: Mapping[str, Any], right: Mapping[str, Any]) -> bo
     for ohlcv_field in ("open", "high", "low", "close", "volume"):
         try:
             if not math.isclose(
-                float(left.get(ohlcv_field)),
-                float(right.get(ohlcv_field)),
+                float(cast(float | int | str, left.get(ohlcv_field))),
+                float(cast(float | int | str, right.get(ohlcv_field))),
                 rel_tol=1e-12,
                 abs_tol=1e-9,
             ):

--- a/src/nifty_scalper_bot/data/candle_state_hardening.py
+++ b/src/nifty_scalper_bot/data/candle_state_hardening.py
@@ -1,45 +1,20 @@
-"""Runtime hardening for deterministic CandleEngine state transitions."""
+"""Compatibility installer for native CandleEngine state invariants."""
 
 from __future__ import annotations
 
 import logging
-import threading
-from collections import defaultdict
-from typing import Any, Mapping
+from typing import Any, Literal, Mapping
 
 import pandas as pd
 
-from nifty_scalper_bot.data.time_contract import normalize_market_tick_timestamp
-from nifty_scalper_bot.utils.logging import log_throttled
-
 LOGGER = logging.getLogger(__name__)
 _INSTALLED_ATTR = "_candle_state_hardening_installed"
-_REGISTRY_GUARD = threading.RLock()
-_ENGINE_LOCKS: dict[int, threading.RLock] = {}
-_COUNTERS: dict[int, defaultdict[str, int]] = {}
-
-
-def _lock_for(engine: Any) -> threading.RLock:
-    key = id(engine)
-    with _REGISTRY_GUARD:
-        lock = _ENGINE_LOCKS.get(key)
-        if lock is None:
-            lock = threading.RLock()
-            _ENGINE_LOCKS[key] = lock
-        _COUNTERS.setdefault(key, defaultdict(int))
-        return lock
-
-
-def _register_engine(engine: Any) -> None:
-    key = id(engine)
-    with _REGISTRY_GUARD:
-        _ENGINE_LOCKS[key] = threading.RLock()
-        _COUNTERS[key] = defaultdict(int)
-
-
-def _counters_for(engine: Any) -> defaultdict[str, int]:
-    _lock_for(engine)
-    return _COUNTERS[id(engine)]
+_NATIVE_ATTR = "_candle_state_native_invariants_active"
+_REQUIRED_NATIVE_APIS = (
+    "reconcile_current_with_finalized",
+    "is_state_consistent",
+    "latest_finalized_minute",
+)
 
 
 def _coerce_timestamp(value: Any) -> pd.Timestamp:
@@ -55,6 +30,10 @@ def _coerce_timestamp(value: Any) -> pd.Timestamp:
 
 
 def _latest_completed_minute(engine: Any) -> pd.Timestamp:
+    native = getattr(engine, "latest_finalized_minute", None)
+    if callable(native):
+        latest = native()
+        return pd.NaT if latest is None else _coerce_timestamp(latest)
     completed = getattr(engine, "_completed_candles", None)
     if not completed:
         return pd.NaT
@@ -71,219 +50,61 @@ def _current_minute(engine: Any) -> pd.Timestamp:
     return _coerce_timestamp(current.get("timestamp"))
 
 
+def _lock_for(engine: Any) -> Any:
+    """Compatibility alias returning the native per-engine lock when present."""
+    return getattr(engine, "_lock", _NullContext())
+
+
+class _NullContext:
+    def __enter__(self) -> None:
+        return None
+
+    def __exit__(self, *exc: object) -> Literal[False]:
+        return False
+
+
 def reconcile_stale_current(engine: Any, *, reason: str) -> bool:
-    """Discard only a current candle duplicating the finalized watermark."""
-    with _lock_for(engine):
-        latest = _latest_completed_minute(engine)
-        current = _current_minute(engine)
-        if pd.isna(latest) or pd.isna(current) or current != latest:
-            return False
-        engine.current_candle = None
-        counters = _counters_for(engine)
-        counters["current_reconcile_total"] += 1
-        counters[f"current_reconcile_{reason}_total"] += 1
-        symbol = getattr(engine, "symbol", None) or "symbol_unset"
-        log_throttled(
-            LOGGER,
-            f"candle_current_reconciled:{symbol}:{reason}:{current.isoformat()}",
-            "CANDLE_CURRENT_RECONCILED symbol=%s reason=%s current_minute=%s latest_completed_minute=%s"
-            % (symbol, reason, current.isoformat(), latest.isoformat()),
-            interval_sec=30.0,
-            level=logging.WARNING,
-            extra={
-                "event": "CANDLE_CURRENT_RECONCILED",
-                "symbol": symbol,
-                "reason": reason,
-                "current_minute": current.isoformat(),
-                "latest_completed_minute": latest.isoformat(),
-                "action": "discarded",
-            },
-        )
-        return True
+    """Delegate stale-current reconciliation to native CandleEngine logic."""
+    native = getattr(engine, "reconcile_current_with_finalized", None)
+    if not callable(native):
+        raise AttributeError("CandleEngine lacks native reconciliation support")
+    mapped_reason = "flush" if reason == "clock_flush" else reason
+    return bool(native(reason=mapped_reason))
 
 
 def _state_consistent(engine: Any) -> bool:
-    previous = pd.NaT
-    for candle in getattr(engine, "_completed_candles", None) or ():
-        if not isinstance(candle, Mapping):
-            return False
-        timestamp = _coerce_timestamp(candle.get("timestamp"))
-        if pd.isna(timestamp):
-            return False
-        if not pd.isna(previous) and timestamp <= previous:
-            return False
-        previous = timestamp
-    current = _current_minute(engine)
-    if pd.isna(current):
-        return getattr(engine, "current_candle", None) is None
-    return pd.isna(previous) or current > previous
+    native = getattr(engine, "is_state_consistent", None)
+    if callable(native):
+        return bool(native())
+    return False
 
 
 def install_candle_state_hardening(engine_cls: type[Any]) -> None:
+    """Mark native CandleEngine invariants active without monkey-patching methods."""
     if bool(getattr(engine_cls, _INSTALLED_ATTR, False)):
         return
-
-    original_init = engine_cls.__init__
-    original_replace = engine_cls.replace_history
-    original_on_tick = engine_cls.on_tick
-    original_finalize = engine_cls._finalize_current_candle
-    original_flush = engine_cls.flush
-    original_diagnostics = engine_cls.diagnostics
-
-    def hardened_init(self: Any, *args: Any, **kwargs: Any) -> None:
-        original_init(self, *args, **kwargs)
-        _register_engine(self)
-
-    def hardened_replace_history(self: Any, frame: Any) -> None:
-        with _lock_for(self):
-            before_current = _current_minute(self)
-            original_replace(self, frame)
-            reconciled = reconcile_stale_current(self, reason="history")
-            latest_after = _latest_completed_minute(self)
-            current_after = _current_minute(self)
-            if (
-                not reconciled
-                and pd.isna(current_after)
-                and not pd.isna(before_current)
-                and not pd.isna(latest_after)
-                and before_current == latest_after
-            ):
-                counters = _counters_for(self)
-                counters["current_reconcile_total"] += 1
-                counters["current_reconcile_history_total"] += 1
-                reconciled = True
-                symbol = getattr(self, "symbol", None) or "symbol_unset"
-                log_throttled(
-                    LOGGER,
-                    (
-                        "candle_current_reconciled:"
-                        f"{symbol}:history:{before_current.isoformat()}"
-                    ),
-                    (
-                        "CANDLE_CURRENT_RECONCILED symbol=%s reason=%s "
-                        "current_minute=%s latest_completed_minute=%s"
-                    )
-                    % (
-                        symbol,
-                        "history",
-                        before_current.isoformat(),
-                        latest_after.isoformat(),
-                    ),
-                    interval_sec=30.0,
-                    level=logging.WARNING,
-                    extra={
-                        "event": "CANDLE_CURRENT_RECONCILED",
-                        "symbol": symbol,
-                        "reason": "history",
-                        "current_minute": before_current.isoformat(),
-                        "latest_completed_minute": latest_after.isoformat(),
-                        "action": "discarded",
-                    },
-                )
-            if reconciled:
-                _counters_for(self)["history_current_reconcile_total"] += 1
-            if not _state_consistent(self):
-                from nifty_scalper_bot.data.source import DataIntegrityError
-
-                raise DataIntegrityError(
-                    "inconsistent candle state after history replacement"
-                )
-
-    def hardened_on_tick(self: Any, tick: Mapping[str, Any]) -> Any:
-        with _lock_for(self):
-            try:
-                normalized = normalize_market_tick_timestamp(tick)
-                tick_timestamp = normalized.timestamp
-                tick_minute = tick_timestamp.floor("1min")
-                timestamp_source = normalized.source
-            except Exception:
-                return original_on_tick(self, tick)
-            reconcile_stale_current(self, reason="tick")
-            latest = _latest_completed_minute(self)
-            if not pd.isna(latest) and tick_minute <= latest:
-                _counters_for(self)["finalized_minute_tick_reject_total"] += 1
-                symbol = (
-                    tick.get("symbol")
-                    or tick.get("trading_symbol")
-                    or getattr(self, "symbol", None)
-                    or "symbol_unset"
-                )
-                log_throttled(
-                    LOGGER,
-                    f"candle_tick_finalized_minute:{symbol}:{tick_minute.isoformat()}",
-                    "CANDLE_TICK_REJECTED_FINALIZED_MINUTE symbol=%s tick_minute=%s latest_completed_minute=%s"
-                    % (symbol, tick_minute.isoformat(), latest.isoformat()),
-                    interval_sec=30.0,
-                    level=logging.WARNING,
-                    extra={
-                        "event": "CANDLE_TICK_REJECTED_FINALIZED_MINUTE",
-                        "symbol": symbol,
-                        "tick_timestamp": tick_timestamp.isoformat(),
-                        "tick_minute": tick_minute.isoformat(),
-                        "latest_completed_minute": latest.isoformat(),
-                        "timestamp_source": timestamp_source,
-                    },
-                )
-                return None
-            return original_on_tick(self, tick)
-
-    def hardened_finalize(self: Any) -> Any:
-        with _lock_for(self):
-            try:
-                return original_finalize(self)
-            finally:
-                self.current_candle = None
-
-    def hardened_flush(self: Any) -> Any:
-        with _lock_for(self):
-            if reconcile_stale_current(self, reason="flush"):
-                return None
-            return original_flush(self)
-
-    def hardened_diagnostics(self: Any) -> dict[str, Any]:
-        with _lock_for(self):
-            diagnostics = dict(original_diagnostics(self))
-            counters = _counters_for(self)
-            latest = _latest_completed_minute(self)
-            current = _current_minute(self)
-            diagnostics.update(
-                {
-                    "finalized_minute_tick_reject_total": counters[
-                        "finalized_minute_tick_reject_total"
-                    ],
-                    "history_current_reconcile_total": counters[
-                        "history_current_reconcile_total"
-                    ],
-                    "current_reconcile_total": counters["current_reconcile_total"],
-                    "current_reconcile_tick_total": counters[
-                        "current_reconcile_tick_total"
-                    ],
-                    "current_reconcile_flush_total": counters[
-                        "current_reconcile_flush_total"
-                    ],
-                    "last_completed_timestamp": (
-                        None if pd.isna(latest) else latest.isoformat()
-                    ),
-                    "current_candle_timestamp": (
-                        None if pd.isna(current) else current.isoformat()
-                    ),
-                    "state_consistent": _state_consistent(self),
-                }
-            )
-            return diagnostics
-
-    def is_state_consistent(self: Any) -> bool:
-        with _lock_for(self):
-            return _state_consistent(self)
-
-    engine_cls.__init__ = hardened_init
-    engine_cls.replace_history = hardened_replace_history
-    engine_cls.on_tick = hardened_on_tick
-    engine_cls._finalize_current_candle = hardened_finalize
-    engine_cls.flush = hardened_flush
-    engine_cls.diagnostics = hardened_diagnostics
-    engine_cls.is_state_consistent = is_state_consistent
+    missing = [
+        name
+        for name in _REQUIRED_NATIVE_APIS
+        if not callable(getattr(engine_cls, name, None))
+    ]
+    if missing:
+        raise AttributeError(
+            "CandleEngine lacks native state hardening APIs: " + ", ".join(missing)
+        )
+    setattr(engine_cls, _NATIVE_ATTR, True)
     setattr(engine_cls, _INSTALLED_ATTR, True)
+    LOGGER.info(
+        "candle_state_hardening_native_active",
+        extra={"event": "candle_state_hardening_native_active"},
+    )
 
 
-__all__ = ["install_candle_state_hardening", "reconcile_stale_current"]
+__all__ = [
+    "install_candle_state_hardening",
+    "reconcile_stale_current",
+    "_current_minute",
+    "_latest_completed_minute",
+    "_lock_for",
+    "_state_consistent",
+]

--- a/tests/data/test_candle_state_hardening.py
+++ b/tests/data/test_candle_state_hardening.py
@@ -253,3 +253,118 @@ def test_replayed_old_ticks_after_reconciliation_do_not_recreate_conflict() -> N
     assert engine.current_candle is None
     assert engine.diagnostics()["finalized_minute_tick_reject_total"] == 4
     assert engine.is_state_consistent() is True
+
+
+def test_state_hardening_installer_is_native_idempotent() -> None:
+    on_tick = CandleEngine.on_tick
+    replace_history = CandleEngine.replace_history
+    flush = CandleEngine.flush
+
+    install_candle_state_hardening(CandleEngine)
+    install_candle_state_hardening(CandleEngine)
+
+    assert CandleEngine.on_tick is on_tick
+    assert CandleEngine.replace_history is replace_history
+    assert CandleEngine.flush is flush
+
+    minute = _minute()
+    engine = CandleEngine(symbol="NFO:NIFTY26JULFUT")
+    engine.replace_history(pd.DataFrame([_history_row(minute)]))
+    engine.on_tick(_tick(minute + pd.Timedelta(seconds=5), 101.0))
+    assert engine.diagnostics()["finalized_minute_tick_reject_total"] == 1
+
+
+def test_native_reconciliation_raises_for_current_older_than_finalized() -> None:
+    from nifty_scalper_bot.data.source import DataIntegrityError
+
+    minute = _minute()
+    engine = CandleEngine(symbol="NFO:NIFTY26JULFUT")
+    engine.replace_history(pd.DataFrame([_history_row(minute)]))
+    engine.current_candle = _history_row(minute - pd.Timedelta(minutes=1))
+
+    before = engine.get_current_candle()
+    try:
+        engine.reconcile_current_with_finalized(reason="flush")
+    except DataIntegrityError:
+        pass
+    else:
+        raise AssertionError("older current must fail closed")
+
+    assert engine.get_current_candle() == before
+    assert engine.is_state_consistent() is False
+
+
+def test_state_consistency_detects_duplicate_and_non_monotonic_completed_history() -> (
+    None
+):
+    from collections import deque
+
+    minute = _minute()
+    engine = CandleEngine(symbol="NFO:NIFTY26JULFUT")
+    engine._completed_candles = deque(
+        [_history_row(minute), _history_row(minute)], maxlen=engine.max_bars
+    )
+    assert engine.is_state_consistent() is False
+
+    engine._completed_candles = deque(
+        [_history_row(minute), _history_row(minute - pd.Timedelta(minutes=1))],
+        maxlen=engine.max_bars,
+    )
+    assert engine.is_state_consistent() is False
+
+
+def test_bounded_concurrent_native_state_transitions_do_not_corrupt_state() -> None:
+    minute = _minute()
+    engine = CandleEngine(symbol="NFO:NIFTY26JULFUT")
+    engine.on_tick(_tick(minute + pd.Timedelta(seconds=1), 100.0))
+    barrier = threading.Barrier(4)
+    errors: list[BaseException] = []
+
+    def run(action):
+        try:
+            barrier.wait(timeout=5)
+            action()
+        except BaseException as exc:  # pragma: no cover - failure captured below
+            errors.append(exc)
+
+    threads = [
+        threading.Thread(
+            target=run,
+            args=(
+                lambda: engine.on_tick(
+                    _tick(minute + pd.Timedelta(minutes=1, seconds=1), 101.0)
+                ),
+            ),
+        ),
+        threading.Thread(
+            target=run,
+            args=(
+                lambda: engine.import_history(
+                    pd.DataFrame(
+                        [
+                            {
+                                "timestamp": minute,
+                                "open": 100.0,
+                                "high": 100.0,
+                                "low": 100.0,
+                                "close": 100.0,
+                                "volume": 1.0,
+                            }
+                        ]
+                    )
+                ),
+            ),
+        ),
+        threading.Thread(target=run, args=(engine.flush,)),
+        threading.Thread(target=run, args=(engine.diagnostics,)),
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=5)
+
+    assert all(not thread.is_alive() for thread in threads)
+    assert errors == []
+    timestamps = [row["timestamp"] for row in engine.get_completed_bars()]
+    assert len(timestamps) == len(set(timestamps))
+    assert engine.is_state_consistent() is True

--- a/tests/data/test_candle_state_hardening.py
+++ b/tests/data/test_candle_state_hardening.py
@@ -368,3 +368,123 @@ def test_bounded_concurrent_native_state_transitions_do_not_corrupt_state() -> N
     timestamps = [row["timestamp"] for row in engine.get_completed_bars()]
     assert len(timestamps) == len(set(timestamps))
     assert engine.is_state_consistent() is True
+
+
+def test_clock_flush_atomic_api_does_not_flush_new_minute_after_rollover(
+    monkeypatch,
+) -> None:
+    minute = _minute()
+    next_minute = minute + pd.Timedelta(minutes=1)
+    engine = CandleEngine(symbol="NFO:NIFTY26JULFUT")
+    engine.on_tick(_tick(minute + pd.Timedelta(seconds=1), 100.0))
+    manager = _manager_for(engine)
+    observed_due = threading.Event()
+    allow_flush = threading.Event()
+    original_flush_if_current_minute = CandleEngine.flush_if_current_minute
+
+    def delayed_flush_if_current_minute(
+        self: CandleEngine, expected_minute: pd.Timestamp
+    ):
+        if self is engine:
+            observed_due.set()
+            assert allow_flush.wait(timeout=5)
+        return original_flush_if_current_minute(self, expected_minute)
+
+    monkeypatch.setattr(
+        CandleEngine, "flush_if_current_minute", delayed_flush_if_current_minute
+    )
+    result: list[int] = []
+
+    thread = threading.Thread(
+        target=lambda: result.append(
+            manager.flush_due_candles(
+                now=minute + pd.Timedelta(minutes=1, seconds=2),
+                grace_seconds=1.5,
+            )
+        )
+    )
+    thread.start()
+    assert observed_due.wait(timeout=5)
+
+    engine.on_tick(_tick(next_minute + pd.Timedelta(seconds=1), 101.0))
+    allow_flush.set()
+    thread.join(timeout=5)
+
+    assert not thread.is_alive()
+    assert result == [0]
+    assert manager._ohlc["NFO:NIFTY26JULFUT"] == []
+    assert engine.current_candle is not None
+    assert pd.Timestamp(engine.current_candle["timestamp"]) == next_minute
+    assert len(engine.get_completed_bars()) == 1
+    assert engine.is_state_consistent() is True
+
+
+def test_import_history_validation_failure_preserves_previous_state(
+    monkeypatch,
+) -> None:
+    minute = _minute()
+    current_minute = minute + pd.Timedelta(minutes=1)
+    engine = CandleEngine(symbol="NFO:NIFTY26JULFUT")
+    engine.replace_history(pd.DataFrame([_history_row(minute)]))
+    engine.current_candle = _history_row(current_minute, close=101.0)
+    before_completed = engine.get_completed_bars()
+    before_current = engine.get_current_candle()
+    before_last_close = engine.last_candle_close
+    before_df = engine.get_df()
+    before_dirty = engine._df_cache_dirty
+    before_diagnostics = engine.diagnostics()
+
+    original_candidate_state_consistent = CandleEngine._candidate_state_consistent
+
+    def fail_candidate_for_engine(self: CandleEngine, *args):
+        if self is engine:
+            return False
+        return original_candidate_state_consistent(self, *args)
+
+    monkeypatch.setattr(
+        CandleEngine, "_candidate_state_consistent", fail_candidate_for_engine
+    )
+
+    from nifty_scalper_bot.data.source import DataIntegrityError
+
+    try:
+        engine.import_history(
+            pd.DataFrame([_history_row(minute), _history_row(current_minute)])
+        )
+    except DataIntegrityError:
+        pass
+    else:
+        raise AssertionError("candidate validation failure must fail closed")
+
+    assert engine.get_completed_bars() == before_completed
+    assert engine.get_current_candle() == before_current
+    assert engine.last_candle_close == before_last_close
+    pd.testing.assert_frame_equal(engine.get_df(), before_df)
+    assert engine._df_cache_dirty is before_dirty
+    after_diagnostics = engine.diagnostics()
+    for key in (
+        "history_import_total",
+        "history_import_bar_total",
+        "history_import_idempotent_total",
+        "history_current_reconcile_total",
+        "current_reconcile_total",
+    ):
+        assert after_diagnostics[key] == before_diagnostics[key]
+    assert after_diagnostics["history_import_failure_total"] == (
+        before_diagnostics["history_import_failure_total"] + 1
+    )
+
+
+def test_state_consistency_detects_last_close_mismatch_cases() -> None:
+    minute = _minute()
+    engine = CandleEngine(symbol="NFO:NIFTY26JULFUT")
+    engine.last_candle_close = minute.to_pydatetime()
+    assert engine.is_state_consistent() is False
+
+    engine = CandleEngine(symbol="NFO:NIFTY26JULFUT")
+    engine.replace_history(pd.DataFrame([_history_row(minute)]))
+    engine.last_candle_close = None
+    assert engine.is_state_consistent() is False
+
+    engine.last_candle_close = (minute - pd.Timedelta(minutes=1)).to_pydatetime()
+    assert engine.is_state_consistent() is False


### PR DESCRIPTION
### Motivation
- Consolidate CandleEngine state safety so the engine itself owns finalized-minute rejection, current-vs-finalized reconciliation, state-consistency checks, and per-engine diagnostics instead of a monkey-patched wrapper. 
- Remove duplicate locking, duplicate counters, and duplicate rejection/reconciliation paths introduced by the Phase 1 compatibility hardening while preserving backwards-compatible installer hooks. 
- Preserve external behaviour and operational event names while making the invariants single-source-of-truth and thread-safe per engine. 

### Description
- Added native per-instance locking and diagnostics counters to `CandleEngine`, and implemented `is_state_consistent()` and `reconcile_current_with_finalized(reason=...)` so the engine validates chronology, detects duplicates/non-monotonic history, and reconciles equal-minute stale current candles (failing closed for older current). 
- Internalized finalized-minute tick guard into `CandleEngine.on_tick()` so it is the single effective rejection path and increments a per-engine `finalized_minute_tick_reject_total`; `import_history()`/`replace_history()` and `flush()` now use native reconciliation semantics and account reconciliation counters per engine. 
- Converted `candle_state_hardening.py` into a compatibility installer/delegator that no longer monkey-patches engine methods, does not own locks or counters, verifies native APIs are present, and exposes thin helpers (e.g. `reconcile_stale_current`, `_latest_completed_minute`, `_current_minute`, `_lock_for`, `_state_consistent`) that delegate to native APIs. 
- Updated clock-flush hardening to delegate stale-current reconciliation to native CandleEngine and removed the extra wrapper lock and duplicate reconciliation/diagnostic overlays. 
- Files changed: `src/nifty_scalper_bot/data/candle_engine.py` (native APIs, per-engine lock, counters, reconciliation, history/flush adaptations), `src/nifty_scalper_bot/data/candle_state_hardening.py` (compatibility/delegation rewrite), `src/nifty_scalper_bot/data/candle_clock_flush_hardening.py` (delegate-only adjustments), and `tests/data/test_candle_state_hardening.py` (added/updated regression tests for idempotency, native reconciliation, state consistency, and deterministic concurrency). 

### Testing
- Ran static/format/type checks and focused lint: `python -m compileall` and `ruff` and `black --check` on the touched files and relevant tests, and `mypy` with `--follow-imports=skip` for the changed modules; these passed for the scoped files. 
- Ran focused unit suites: `pytest tests/data/test_candle_engine.py tests/data/test_candle_engine_incremental_finalize.py tests/data/test_candle_engine_history_import.py tests/data/test_candle_state_hardening.py -q` and related hardening/bootstrap tests; all ran green locally. 
- Ran wider CI-equivalent validations (selected safety suites, notification tests, e2e live-sim markers and other scoped execution safety tests) as described in the repo guidance; these completed successfully in this environment. 
- Known limitation: running `mypy` without `--follow-imports=skip` surfaces pre-existing repo-wide type debt outside the scope of this change; the touched candle modules pass type checks when run with `--follow-imports=skip`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5c539e56f4832499c3195503affaab)