### PR TITLE
Complete CandleEngine single-source-of-truth migration

### DIFF
--- a/src/nifty_scalper_bot/data/candle_clock_flush_hardening.py
+++ b/src/nifty_scalper_bot/data/candle_clock_flush_hardening.py
@@ -144,8 +144,10 @@ def install_candle_clock_flush_hardening(manager_cls: type[Any]) -> None:
                 ),
                 "source": "clock_flush_candle",
             }
+            refresher = getattr(self, "_refresh_candle_projection", None)
+            if callable(refresher):
+                refresher(symbol, source="clock_flush_candle")
             with self._lock:
-                self._ohlc[symbol].append(bar)
                 published[symbol] = timestamp
 
             publisher = getattr(self, "_publish_closed_bar", None)

--- a/src/nifty_scalper_bot/data/candle_engine.py
+++ b/src/nifty_scalper_bot/data/candle_engine.py
@@ -1166,6 +1166,17 @@ def normalize_ohlc_timezone(df: pd.DataFrame) -> pd.DataFrame:
     return normalized.set_index("timestamp")
 
 
+def import_candle_history(
+    engine: CandleEngine,
+    frame: pd.DataFrame | None,
+    *,
+    mode: str = "incremental",
+    source: str | None = None,
+) -> pd.DataFrame:
+    """Compatibility adapter for non-owner modules to import history safely."""
+    return engine.import_history(frame, mode=mode, source=source)
+
+
 def ensure_valid_data(
     symbol: str,
     engine: CandleEngine,
@@ -1197,5 +1208,9 @@ def ensure_valid_data(
             },
         )
         return None
-    engine.replace_history(hydrated.tail(engine.max_bars).reset_index(drop=True))
+    engine.import_history(
+        hydrated.tail(engine.max_bars).reset_index(drop=True),
+        mode="incremental",
+        source="historical_hydration",
+    )
     return engine.get_df()

--- a/src/nifty_scalper_bot/data/market_data_hardening.py
+++ b/src/nifty_scalper_bot/data/market_data_hardening.py
@@ -523,8 +523,9 @@ def _flush_due_candles(self: Any, *, now: Any | None = None, grace_seconds: floa
             "volume": int(float((candle.get("volume", 0) if isinstance(candle, dict) else getattr(candle, "volume", 0)) or 0)),
             "source": "clock_flush_candle",
         }
-        with self._lock:
-            self._ohlc[symbol].append(bar)
+        refresher = getattr(self, "_refresh_candle_projection", None)
+        if callable(refresher):
+            refresher(symbol, source="clock_flush_candle")
         publisher = getattr(self, "_publish_closed_bar", None)
         if callable(publisher):
             try:

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -2,7 +2,7 @@
 
 Runtime role:
 - Receives broker ticks (WebSocket/REST), maintains the live quote cache, and
-  builds one-minute OHLC bars per symbol.
+  routes accepted ticks/history through CandleEngine for one-minute OHLC bars.
 - Fans ticks out to subscribers via the message bus.
 - Performs broker history fetch/backfill (ensure_history) and is the sole holder
   of the OHLC bar cache used for readiness and indicators.
@@ -12,14 +12,16 @@ Position in the pipeline:
     → data/data_hub.py → strategies/runner.py
 
 Owns / does NOT own:
-- Owns: tick cache, OHLC bar history, broker history fetch, tick fan-out, the
-  committed active-contract basket's futures symbol (read via the basket).
+- Owns: tick cache, read-only CandleEngine OHLC projection, broker history
+  fetch, tick fan-out, the committed active-contract basket's futures symbol
+  (read via the basket).
 - Does NOT own: contract selection (InstrumentManager owns that) and strategy
   logic. MDM returns the active future from the committed basket only.
 
 Safe-edit notes:
-- This is the SSOT for history (PR #562). DataHub is a read facade over MDM and
-  stores no history; never reintroduce a parallel history cache elsewhere.
+- CandleEngine is the SSOT for history and live OHLC. DataHub is a read
+  facade over MDM and stores no history; never reintroduce a parallel history
+  cache elsewhere.
 - get_ohlc_bars normalizes the symbol via _bar_symbol_key; keep symbol
   normalization consistent so bar counts agree across the readiness chain.
 """
@@ -384,10 +386,12 @@ class MarketDataManager:
         self.bus = None
         self._poll_jitter_pct = 0.0
         self._poll_batch_ceiling = 0
+        # Read-only completed-candle projection derived exclusively from CandleEngine.
         self._ohlc: dict[str, Deque[dict[str, Any]]] = defaultdict(
             lambda: deque(maxlen=self._cache_len)
         )
         self._engines: dict[str, CandleEngine] = {}
+        self._candle_metrics: dict[str, float] = defaultdict(float)
         self._last_historical_ts: dict[str, float] = {}
         self._last_tick_ts: dict[str, float] = {}
         self._last_cumulative_volume_by_symbol: dict[str, float] = {}
@@ -975,58 +979,38 @@ class MarketDataManager:
             self._logger.error("Poll candle emit failed: %s", e)
 
     def ingest_historical_bar(self, bar: Mapping[str, Any]) -> None:
-        """Ingest one historical OHLC bar into MDM-owned state.
-
-        Args: bar payload containing symbol/open/high/low/close/volume/timestamp.
-        Returns: None.
-        Raises: None.
-        """
-        try:
-            symbol = normalize_symbol(str(bar.get("symbol") or ""))
-            if not symbol:
-                return
-            ts = bar.get("timestamp")
-            if isinstance(ts, str):
-                ts = datetime.fromisoformat(ts.replace("Z", "+00:00"))
-            if isinstance(ts, (int, float)):
-                ts = datetime.fromtimestamp(float(ts), tz=timezone.utc)
-            if isinstance(ts, datetime) and ts.tzinfo is None:
-                ts = ts.replace(tzinfo=timezone.utc)
-            payload = {
-                "symbol": symbol,
-                "open": float(bar.get("open", 0.0) or 0.0),
-                "high": float(bar.get("high", 0.0) or 0.0),
-                "low": float(bar.get("low", 0.0) or 0.0),
-                "close": float(bar.get("close", 0.0) or 0.0),
-                "volume": int(float(bar.get("volume", 0) or 0)),
-                "timestamp": ts.isoformat(),
-                "source": "historical",
-            }
-            # Historical OHLC belongs only in the canonical candle store.
-            # _raw_tick_history is reserved for raw/live tick payloads.
-            self._ohlc[self._bar_symbol_key(symbol)].append(dict(payload))
-            if isinstance(ts, datetime):
-                self._last_historical_ts[symbol] = ts.timestamp()
-            self.update_hydration_status(
-                symbol, self._ohlc[self._bar_symbol_key(symbol)]
-            )
-        except Exception as exc:  # noqa: BLE001
-            self._logger.error(
-                "Failure in ingest_historical_bar: %s", exc, exc_info=exc
-            )
+        """Import one broker-completed OHLC bar through CandleEngine."""
+        symbol = normalize_symbol(str(bar.get("symbol") or ""))
+        if not symbol:
+            return
+        self.ingest_historical_ohlc(symbol, [bar])
 
     def ingest_historical_ohlc(
         self, symbol: str, bars: Sequence[Mapping[str, Any]]
     ) -> int:
-        """Ingest sorted UTC historical OHLC bars and return newly accepted rows."""
-        accepted = 0
+        """Import sorted historical OHLC bars through CandleEngine.
+
+        MDM fetches/transports history, but CandleEngine is the only writer that
+        validates, reconciles, conflicts, and commits completed candles. The
+        MDM ``_ohlc`` cache is refreshed only after CandleEngine acceptance.
+        """
         normalized_symbol = (
             self._canonical_symbol(symbol)
             if hasattr(self, "_canonical_symbol")
             else str(symbol)
         )
+        if not hasattr(self, "_candle_metrics"):
+            self._candle_metrics = defaultdict(float)
+        if not hasattr(self, "_engines"):
+            self._engines = {}
+        self._candle_metrics["history_hydration_request_total"] += 1
+        before = (
+            self.get_ohlc_bars(normalized_symbol)
+            if hasattr(self, "get_ohlc_bars")
+            else []
+        )
         try:
-            normalized_rows: dict[datetime, dict[str, Any]] = {}
+            normalized_rows: list[dict[str, Any]] = []
             for row in bars or ():
                 normalized = self.normalize_history_row(
                     normalized_symbol, row, source="historical"
@@ -1034,70 +1018,189 @@ class MarketDataManager:
                 if normalized is None:
                     continue
                 ts = normalized.get("timestamp")
-                if not isinstance(ts, datetime):
-                    continue
-                normalized["timestamp"] = ts.astimezone(timezone.utc).replace(
-                    microsecond=0
-                )
-                normalized["symbol"] = normalized_symbol
-                normalized_rows[normalized["timestamp"]] = normalized
-            sorted_rows = [normalized_rows[ts] for ts in sorted(normalized_rows)]
-            key = (
-                self._bar_symbol_key(normalized_symbol)
-                if hasattr(self, "_bar_symbol_key")
-                else normalized_symbol
-            )
-            existing = list(getattr(self, "_ohlc", {}).get(key, []) or [])
-            existing_ts: set[datetime] = set()
-            for existing_row in existing:
-                ts = (
-                    existing_row.get("timestamp")
-                    if isinstance(existing_row, Mapping)
-                    else None
-                )
-                if isinstance(ts, str):
-                    try:
-                        parsed = datetime.fromisoformat(ts.replace("Z", "+00:00"))
-                    except ValueError:
-                        continue
-                    existing_ts.add(
-                        parsed.astimezone(timezone.utc).replace(microsecond=0)
+                if isinstance(ts, datetime):
+                    normalized["timestamp"] = ts.astimezone(timezone.utc).replace(
+                        microsecond=0
                     )
-                elif isinstance(ts, datetime):
-                    existing_ts.add(ts.astimezone(timezone.utc).replace(microsecond=0))
-            for row in sorted_rows:
-                ts = row["timestamp"]
-                if ts in existing_ts:
-                    continue
-                self.ingest_historical_bar(row)
-                existing_ts.add(ts)
-                accepted += 1
-            final_count = (
-                len(self.get_ohlc_bars(normalized_symbol))
-                if hasattr(self, "get_ohlc_bars")
-                else accepted
-            )
+                normalized["symbol"] = normalized_symbol
+                normalized_rows.append(normalized)
+            if normalized_rows:
+                frame = pd.DataFrame(normalized_rows)
+            else:
+                frame = pd.DataFrame(
+                    columns=["timestamp", "open", "high", "low", "close", "volume"]
+                )
+            engine = self._get_engine(normalized_symbol)
+            engine.import_history(frame, mode="incremental", source="historical")
+            after = self._refresh_candle_projection(normalized_symbol)
+            self.update_hydration_status(normalized_symbol, after)
+            latest = engine.latest_finalized_minute()
+            if latest is not None:
+                self._last_historical_ts[normalized_symbol] = latest.timestamp()
+                self._candle_metrics[
+                    "history_hydration_last_success_timestamp"
+                ] = latest.timestamp()
+            before_ts = {
+                normalized[0]
+                for row in before
+                if (normalized := self._normalize_bar_timestamp(row)) is not None
+            }
+            after_ts = {
+                normalized[0]
+                for row in after
+                if (normalized := self._normalize_bar_timestamp(row)) is not None
+            }
+            accepted = len(after_ts - before_ts)
+            if accepted == 0 and normalized_rows:
+                self._candle_metrics["history_hydration_idempotent_total"] += 1
+            self._candle_metrics["history_hydration_success_total"] += 1
+            self._purge_queued_ticks_at_or_before_watermark(normalized_symbol)
             self._logger.info(
                 "HYDRATION_INGEST_RESULT symbol=%s returned_rows=%s accepted_rows=%s final_mdm_bars=%s first_ts=%s last_ts=%s",
                 normalized_symbol,
                 len(bars or ()),
                 accepted,
-                final_count,
-                sorted_rows[0]["timestamp"].isoformat() if sorted_rows else None,
-                sorted_rows[-1]["timestamp"].isoformat() if sorted_rows else None,
+                len(after),
+                normalized_rows[0].get("timestamp") if normalized_rows else None,
+                normalized_rows[-1].get("timestamp") if normalized_rows else None,
                 extra={
                     "event": "HYDRATION_INGEST_RESULT",
                     "symbol": normalized_symbol,
                     "returned_rows": len(bars or ()),
                     "accepted_rows": accepted,
-                    "final_mdm_bars": final_count,
+                    "final_mdm_bars": len(after),
                 },
             )
+            return accepted
         except Exception as exc:  # noqa: BLE001
+            self._candle_metrics["history_hydration_failure_total"] += 1
+            if isinstance(exc, DataIntegrityError):
+                self._candle_metrics["history_hydration_conflict_total"] += 1
             self._logger.error(
                 "Failure in ingest_historical_ohlc: %s", exc, exc_info=exc
             )
-        return accepted
+            return 0
+
+    def _refresh_candle_projection(
+        self, symbol: str, *, source: str | None = None
+    ) -> list[dict[str, Any]]:
+        """Refresh MDM's read-only OHLC projection from CandleEngine."""
+        normalized = (
+            self._canonical_symbol(symbol)
+            if hasattr(self, "_canonical_symbol")
+            else str(symbol)
+        )
+        key = (
+            self._bar_symbol_key(normalized)
+            if hasattr(self, "_bar_symbol_key")
+            else normalized
+        )
+        engine = self._get_engine(normalized)
+        completed = engine.get_completed_bars()
+        projected: Deque[dict[str, Any]] = deque(maxlen=self._cache_len)
+        for row in completed[-self._cache_len :]:
+            bar = dict(row)
+            bar["symbol"] = normalized
+            bar["source"] = source or bar.get("source") or "candle_engine"
+            projected.append(bar)
+        with self._lock:
+            previous = list(self._ohlc.get(key, ()) or ())
+            self._ohlc[key] = projected
+        self._candle_metrics["candle_projection_refresh_total"] += 1
+        self._candle_metrics["candle_projection_last_refresh"] = time.time()
+        self._candle_metrics["candle_projection_size"] = float(len(projected))
+        previous_ts = [
+            normalized_ts[0]
+            for row in previous
+            if (normalized_ts := self._normalize_bar_timestamp(row)) is not None
+        ]
+        projected_ts = [
+            normalized_ts[0]
+            for row in projected
+            if (normalized_ts := self._normalize_bar_timestamp(row)) is not None
+        ]
+        if (
+            len(previous_ts) > len(projected_ts)
+            and previous_ts[: len(projected_ts)] != projected_ts
+        ):
+            self._candle_metrics["candle_projection_divergence_total"] += 1
+            self._logger.warning(
+                "CANDLE_PROJECTION_DIVERGENCE symbol=%s previous=%s projected=%s",
+                normalized,
+                len(previous),
+                len(projected),
+                extra={"event": "CANDLE_PROJECTION_DIVERGENCE", "symbol": normalized},
+            )
+        return [dict(row) for row in projected]
+
+    def _purge_queued_ticks_at_or_before_watermark(self, symbol: str) -> None:
+        """Drop queued ticks for minutes CandleEngine has already finalized."""
+        normalized = (
+            self._canonical_symbol(symbol)
+            if hasattr(self, "_canonical_symbol")
+            else str(symbol)
+        )
+        watermark = self._get_engine(normalized).latest_finalized_minute()
+        if watermark is None:
+            return
+        try:
+            watermark_utc = pd.Timestamp(watermark).tz_convert("UTC").floor("min")
+        except Exception:
+            return
+        retained: list[dict[str, Any]] = []
+        purged = 0
+        while True:
+            try:
+                raw = self._tick_queue.get_nowait()
+            except asyncio.QueueEmpty:
+                break
+            try:
+                raw_symbol = self._canonical_symbol(
+                    str(raw.get("symbol") or raw.get("tradingsymbol") or "")
+                )
+                raw_ts = (
+                    raw.get("timestamp")
+                    or raw.get("exchange_timestamp")
+                    or raw.get("last_trade_time")
+                )
+                tick_minute = pd.to_datetime(
+                    raw_ts, utc=True, errors="coerce"
+                ).floor("min")
+                if (
+                    raw_symbol == normalized
+                    and not pd.isna(tick_minute)
+                    and tick_minute <= watermark_utc
+                ):
+                    purged += 1
+                    try:
+                        self._tick_queue.task_done()
+                    except ValueError:
+                        pass
+                    continue
+            except Exception:
+                pass
+            retained.append(raw)
+        for raw in retained:
+            self._tick_queue.put_nowait(raw)
+        self._candle_metrics["queued_ticks_purged_after_hydration"] += purged
+        self._candle_metrics["queued_ticks_retained_after_hydration"] += len(
+            retained
+        )
+        self._candle_metrics["queue_watermark_timestamp"] = watermark_utc.timestamp()
+        if purged or retained:
+            self._logger.info(
+                "MDM_QUEUE_WATERMARK_PURGE symbol=%s purged=%s retained=%s watermark=%s",
+                normalized,
+                purged,
+                len(retained),
+                watermark_utc.isoformat(),
+                extra={
+                    "event": "MDM_QUEUE_WATERMARK_PURGE",
+                    "symbol": normalized,
+                    "purged": purged,
+                    "retained": len(retained),
+                },
+            )
 
     def subscribe_bars(self, callback: Callable[[dict[str, Any]], None]) -> None:
         """Args: callback. Returns: None. Raises: None."""
@@ -7905,7 +8008,7 @@ class MarketDataManager:
                 ),
                 "source": "ws_candle",
             }
-            self._ohlc[self._bar_symbol_key(symbol)].append(bar)
+            self._refresh_candle_projection(symbol)
             self._publish_closed_bar(bar)
             verbose_candles = str(
                 os.getenv("LOG_VERBOSE_CANDLES", "false")
@@ -7928,8 +8031,10 @@ class MarketDataManager:
 
     def _get_engine(self, symbol: str) -> CandleEngine:
         """Return or create candle engine for symbol."""
+        if not hasattr(self, "_engines"):
+            self._engines = {}
         if symbol not in self._engines:
-            self._engines[symbol] = CandleEngine()
+            self._engines[symbol] = CandleEngine(symbol=symbol)
         return self._engines[symbol]
 
     def _set_symbol_token_mapping(

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -58,7 +58,10 @@ from typing import (
 import pandas as pd
 
 from nifty_scalper_bot.config.settings import get_settings
-from nifty_scalper_bot.data.candle_engine import CandleEngine
+from nifty_scalper_bot.data.candle_engine import (
+    CandleEngine,
+    CandleHistoryConflictError,
+)
 from nifty_scalper_bot.data.market_data_policy import MarketDataPolicy
 from nifty_scalper_bot.data.normalizers import normalize_history_row
 from nifty_scalper_bot.data.time_contract import coerce_market_timestamp
@@ -392,6 +395,8 @@ class MarketDataManager:
         )
         self._engines: dict[str, CandleEngine] = {}
         self._candle_metrics: dict[str, float] = defaultdict(float)
+        self._candle_queue_watermarks: dict[str, pd.Timestamp] = {}
+        self._last_history_import_result: dict[str, Any] | None = None
         self._last_historical_ts: dict[str, float] = {}
         self._last_tick_ts: dict[str, float] = {}
         self._last_cumulative_volume_by_symbol: dict[str, float] = {}
@@ -1003,6 +1008,13 @@ class MarketDataManager:
             self._candle_metrics = defaultdict(float)
         if not hasattr(self, "_engines"):
             self._engines = {}
+        if not hasattr(self, "_candle_queue_watermarks"):
+            self._candle_queue_watermarks = {}
+        self._last_history_import_result = {
+            "symbol": normalized_symbol,
+            "status": "started",
+            "accepted_rows": 0,
+        }
         self._candle_metrics["history_hydration_request_total"] += 1
         before = (
             self.get_ohlc_bars(normalized_symbol)
@@ -1024,6 +1036,8 @@ class MarketDataManager:
                     )
                 normalized["symbol"] = normalized_symbol
                 normalized_rows.append(normalized)
+            if not normalized_rows and bars:
+                raise DataIntegrityError("no valid historical OHLC rows to import")
             if normalized_rows:
                 frame = pd.DataFrame(normalized_rows)
             else:
@@ -1040,21 +1054,29 @@ class MarketDataManager:
                 self._candle_metrics[
                     "history_hydration_last_success_timestamp"
                 ] = latest.timestamp()
-            before_ts = {
-                normalized[0]
-                for row in before
-                if (normalized := self._normalize_bar_timestamp(row)) is not None
-            }
-            after_ts = {
-                normalized[0]
-                for row in after
-                if (normalized := self._normalize_bar_timestamp(row)) is not None
-            }
+            before_ts: set[datetime] = set()
+            for row in before:
+                normalized_ts = self._normalize_bar_timestamp(row)
+                if normalized_ts is not None:
+                    before_ts.add(normalized_ts[0])
+            after_ts: set[datetime] = set()
+            for row in after:
+                normalized_ts = self._normalize_bar_timestamp(row)
+                if normalized_ts is not None:
+                    after_ts.add(normalized_ts[0])
             accepted = len(after_ts - before_ts)
-            if accepted == 0 and normalized_rows:
+            status = "success_new_bars" if accepted > 0 else "success_idempotent"
+            if status == "success_idempotent" and normalized_rows:
                 self._candle_metrics["history_hydration_idempotent_total"] += 1
             self._candle_metrics["history_hydration_success_total"] += 1
-            self._purge_queued_ticks_at_or_before_watermark(normalized_symbol)
+            self._last_history_import_result = {
+                "symbol": normalized_symbol,
+                "status": status,
+                "accepted_rows": accepted,
+                "returned_rows": len(bars or ()),
+                "stored_rows": len(after),
+            }
+            self._record_queue_watermark_after_hydration(normalized_symbol)
             self._logger.info(
                 "HYDRATION_INGEST_RESULT symbol=%s returned_rows=%s accepted_rows=%s final_mdm_bars=%s first_ts=%s last_ts=%s",
                 normalized_symbol,
@@ -1074,8 +1096,17 @@ class MarketDataManager:
             return accepted
         except Exception as exc:  # noqa: BLE001
             self._candle_metrics["history_hydration_failure_total"] += 1
-            if isinstance(exc, DataIntegrityError):
+            status = "finalized_candle_conflict" if isinstance(
+                exc, CandleHistoryConflictError
+            ) else "failed_validation"
+            if isinstance(exc, CandleHistoryConflictError):
                 self._candle_metrics["history_hydration_conflict_total"] += 1
+            self._last_history_import_result = {
+                "symbol": normalized_symbol,
+                "status": status,
+                "accepted_rows": 0,
+                "error": str(exc),
+            }
             self._logger.error(
                 "Failure in ingest_historical_ohlc: %s", exc, exc_info=exc
             )
@@ -1109,20 +1140,9 @@ class MarketDataManager:
         self._candle_metrics["candle_projection_refresh_total"] += 1
         self._candle_metrics["candle_projection_last_refresh"] = time.time()
         self._candle_metrics["candle_projection_size"] = float(len(projected))
-        previous_ts = [
-            normalized_ts[0]
-            for row in previous
-            if (normalized_ts := self._normalize_bar_timestamp(row)) is not None
-        ]
-        projected_ts = [
-            normalized_ts[0]
-            for row in projected
-            if (normalized_ts := self._normalize_bar_timestamp(row)) is not None
-        ]
-        if (
-            len(previous_ts) > len(projected_ts)
-            and previous_ts[: len(projected_ts)] != projected_ts
-        ):
+        previous_fingerprint = self._candle_projection_fingerprint(previous)
+        projected_fingerprint = self._candle_projection_fingerprint(projected)
+        if previous and previous_fingerprint != projected_fingerprint:
             self._candle_metrics["candle_projection_divergence_total"] += 1
             self._logger.warning(
                 "CANDLE_PROJECTION_DIVERGENCE symbol=%s previous=%s projected=%s",
@@ -1133,8 +1153,35 @@ class MarketDataManager:
             )
         return [dict(row) for row in projected]
 
-    def _purge_queued_ticks_at_or_before_watermark(self, symbol: str) -> None:
-        """Drop queued ticks for minutes CandleEngine has already finalized."""
+
+    def _candle_projection_fingerprint(
+        self, rows: Iterable[Mapping[str, Any]]
+    ) -> list[tuple[Any, float, float, float, float, float]]:
+        """Return bounded canonical OHLCV identity for projection comparisons."""
+        fingerprint: list[tuple[Any, float, float, float, float, float]] = []
+        for row in rows:
+            normalized_ts = self._normalize_bar_timestamp(row)
+            if normalized_ts is None:
+                fingerprint.append((None, 0.0, 0.0, 0.0, 0.0, 0.0))
+                continue
+            ts_key, _market_ts = normalized_ts
+            try:
+                fingerprint.append(
+                    (
+                        ts_key,
+                        float(row.get("open", 0.0) or 0.0),
+                        float(row.get("high", 0.0) or 0.0),
+                        float(row.get("low", 0.0) or 0.0),
+                        float(row.get("close", 0.0) or 0.0),
+                        float(row.get("volume", 0.0) or 0.0),
+                    )
+                )
+            except (TypeError, ValueError):
+                fingerprint.append((ts_key, 0.0, 0.0, 0.0, 0.0, 0.0))
+        return fingerprint
+
+    def _record_queue_watermark_after_hydration(self, symbol: str) -> None:
+        """Record consumer-enforced stale-tick watermark after history import."""
         normalized = (
             self._canonical_symbol(symbol)
             if hasattr(self, "_canonical_symbol")
@@ -1147,60 +1194,51 @@ class MarketDataManager:
             watermark_utc = pd.Timestamp(watermark).tz_convert("UTC").floor("min")
         except Exception:
             return
-        retained: list[dict[str, Any]] = []
-        purged = 0
-        while True:
-            try:
-                raw = self._tick_queue.get_nowait()
-            except asyncio.QueueEmpty:
-                break
-            try:
-                raw_symbol = self._canonical_symbol(
-                    str(raw.get("symbol") or raw.get("tradingsymbol") or "")
-                )
-                raw_ts = (
-                    raw.get("timestamp")
-                    or raw.get("exchange_timestamp")
-                    or raw.get("last_trade_time")
-                )
-                tick_minute = pd.to_datetime(
-                    raw_ts, utc=True, errors="coerce"
-                ).floor("min")
-                if (
-                    raw_symbol == normalized
-                    and not pd.isna(tick_minute)
-                    and tick_minute <= watermark_utc
-                ):
-                    purged += 1
-                    try:
-                        self._tick_queue.task_done()
-                    except ValueError:
-                        pass
-                    continue
-            except Exception:
-                pass
-            retained.append(raw)
-        for raw in retained:
-            self._tick_queue.put_nowait(raw)
-        self._candle_metrics["queued_ticks_purged_after_hydration"] += purged
-        self._candle_metrics["queued_ticks_retained_after_hydration"] += len(
-            retained
-        )
+        if not hasattr(self, "_candle_queue_watermarks"):
+            self._candle_queue_watermarks = {}
+        self._candle_queue_watermarks[normalized] = watermark_utc
+        retained = self._tick_queue.qsize() if hasattr(self, "_tick_queue") else 0
+        self._candle_metrics["queued_ticks_retained_after_hydration"] += retained
         self._candle_metrics["queue_watermark_timestamp"] = watermark_utc.timestamp()
-        if purged or retained:
-            self._logger.info(
-                "MDM_QUEUE_WATERMARK_PURGE symbol=%s purged=%s retained=%s watermark=%s",
-                normalized,
-                purged,
-                len(retained),
-                watermark_utc.isoformat(),
-                extra={
-                    "event": "MDM_QUEUE_WATERMARK_PURGE",
-                    "symbol": normalized,
-                    "purged": purged,
-                    "retained": len(retained),
-                },
-            )
+        self._logger.info(
+            "MDM_QUEUE_WATERMARK_ARMED symbol=%s retained=%s watermark=%s",
+            normalized,
+            retained,
+            watermark_utc.isoformat(),
+            extra={
+                "event": "MDM_QUEUE_WATERMARK_ARMED",
+                "symbol": normalized,
+                "purged": 0,
+                "retained": retained,
+                "watermark": watermark_utc.isoformat(),
+            },
+        )
+
+    def _queued_tick_at_or_before_watermark(self, raw: Mapping[str, Any]) -> bool:
+        """Return True when a queued tick is stale under a hydration watermark."""
+        watermarks = getattr(self, "_candle_queue_watermarks", {}) or {}
+        if not watermarks:
+            return False
+        raw_symbol = str(raw.get("symbol") or raw.get("tradingsymbol") or "")
+        if not raw_symbol:
+            return False
+        normalized = (
+            self._canonical_symbol(raw_symbol)
+            if hasattr(self, "_canonical_symbol")
+            else raw_symbol
+        )
+        watermark = watermarks.get(normalized)
+        if watermark is None:
+            return False
+        raw_ts = (
+            raw.get("timestamp")
+            or raw.get("exchange_timestamp")
+            or raw.get("last_trade_time")
+        )
+        tick_minute = pd.to_datetime(raw_ts, utc=True, errors="coerce")
+        if pd.isna(tick_minute):
+            return False
+        return tick_minute.floor("min") <= watermark
 
     def subscribe_bars(self, callback: Callable[[dict[str, Any]], None]) -> None:
         """Args: callback. Returns: None. Raises: None."""
@@ -6997,9 +7035,15 @@ class MarketDataManager:
                     return
                 continue
             try:
+                if self._queued_tick_at_or_before_watermark(raw):
+                    self._candle_metrics["queued_ticks_purged_after_hydration"] += 1
+                    self._candle_metrics["stale_tick_escape_reject_total"] += 1
+                    continue
                 self._process_queued_tick(raw)
             except Exception as exc:  # noqa: BLE001
                 self._logger.debug("tick worker drain error: %s", exc)
+            finally:
+                self._tick_queue.task_done()
 
     def _on_tick(self, tick: dict[str, Any]) -> None:
         """Legacy tick-bus hook routed to queue ingestion."""
@@ -7298,6 +7342,10 @@ class MarketDataManager:
         while True:
             raw = await self._tick_queue.get()
             try:
+                if self._queued_tick_at_or_before_watermark(raw):
+                    self._candle_metrics["queued_ticks_purged_after_hydration"] += 1
+                    self._candle_metrics["stale_tick_escape_reject_total"] += 1
+                    continue
                 self._process_queued_tick(raw)
             except Exception as exc:
                 preview = {}

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -1051,9 +1051,9 @@ class MarketDataManager:
             latest = engine.latest_finalized_minute()
             if latest is not None:
                 self._last_historical_ts[normalized_symbol] = latest.timestamp()
-                self._candle_metrics[
-                    "history_hydration_last_success_timestamp"
-                ] = latest.timestamp()
+                self._candle_metrics["history_hydration_last_success_timestamp"] = (
+                    latest.timestamp()
+                )
             before_ts: set[datetime] = set()
             for row in before:
                 normalized_ts = self._normalize_bar_timestamp(row)
@@ -1096,9 +1096,11 @@ class MarketDataManager:
             return accepted
         except Exception as exc:  # noqa: BLE001
             self._candle_metrics["history_hydration_failure_total"] += 1
-            status = "finalized_candle_conflict" if isinstance(
-                exc, CandleHistoryConflictError
-            ) else "failed_validation"
+            status = (
+                "finalized_candle_conflict"
+                if isinstance(exc, CandleHistoryConflictError)
+                else "failed_validation"
+            )
             if isinstance(exc, CandleHistoryConflictError):
                 self._candle_metrics["history_hydration_conflict_total"] += 1
             self._last_history_import_result = {
@@ -1126,7 +1128,7 @@ class MarketDataManager:
             if hasattr(self, "_bar_symbol_key")
             else normalized
         )
-        engine = self._get_engine(normalized)
+        engine = self.get_candle_engine(normalized)
         completed = engine.get_completed_bars()
         projected: Deque[dict[str, Any]] = deque(maxlen=self._cache_len)
         for row in completed[-self._cache_len :]:
@@ -1141,8 +1143,10 @@ class MarketDataManager:
         self._candle_metrics["candle_projection_last_refresh"] = time.time()
         self._candle_metrics["candle_projection_size"] = float(len(projected))
         previous_fingerprint = self._candle_projection_fingerprint(previous)
-        projected_fingerprint = self._candle_projection_fingerprint(projected)
-        if previous and previous_fingerprint != projected_fingerprint:
+        canonical_fingerprint = self._candle_projection_fingerprint(completed)
+        if previous and not self._projection_matches_canonical_slice(
+            previous_fingerprint, canonical_fingerprint
+        ):
             self._candle_metrics["candle_projection_divergence_total"] += 1
             self._logger.warning(
                 "CANDLE_PROJECTION_DIVERGENCE symbol=%s previous=%s projected=%s",
@@ -1153,6 +1157,21 @@ class MarketDataManager:
             )
         return [dict(row) for row in projected]
 
+    @staticmethod
+    def _projection_matches_canonical_slice(
+        projection: list[tuple[Any, float, float, float, float, float]],
+        canonical: list[tuple[Any, float, float, float, float, float]],
+    ) -> bool:
+        """Return True when projection rows are an ordered contiguous canonical slice."""
+        if not projection:
+            return True
+        if len(projection) > len(canonical):
+            return False
+        width = len(projection)
+        return any(
+            canonical[start : start + width] == projection
+            for start in range(len(canonical) - width + 1)
+        )
 
     def _candle_projection_fingerprint(
         self, rows: Iterable[Mapping[str, Any]]
@@ -2731,7 +2750,9 @@ class MarketDataManager:
             )
             self._desired_tokens.add(token_int)
             if normalized_symbol:
-                missing_generation = normalized_symbol not in self._symbol_subscription_generation
+                missing_generation = (
+                    normalized_symbol not in self._symbol_subscription_generation
+                )
                 material_transition = (
                     (not was_desired)
                     or previous_token != token_int
@@ -3215,9 +3236,15 @@ class MarketDataManager:
             desired = set(getattr(self, "_desired_tokens", set()) or set())
             confirmed = set(getattr(self, "_confirmed_subscriptions", set()) or set())
             dispatched = set(getattr(self, "_dispatched_subscriptions", set()) or set())
-            sub_gen = (getattr(self, "_symbol_subscription_generation", {}) or {}).get(canonical)
-            tick_gen = (getattr(self, "_symbol_first_tick_generation", {}) or {}).get(canonical)
-            tick_mono = (getattr(self, "_last_valid_live_tick_mono", {}) or {}).get(canonical)
+            sub_gen = (getattr(self, "_symbol_subscription_generation", {}) or {}).get(
+                canonical
+            )
+            tick_gen = (getattr(self, "_symbol_first_tick_generation", {}) or {}).get(
+                canonical
+            )
+            tick_mono = (getattr(self, "_last_valid_live_tick_mono", {}) or {}).get(
+                canonical
+            )
             current_token = self._current_symbol_token_locked(canonical)
             tracked = canonical in (getattr(self, "_tracked_symbols", set()) or set())
         subscription_requested = (
@@ -5510,7 +5537,9 @@ class MarketDataManager:
                 stale_required_symbols.append(symbol)
         recovery_active = bool(stale_required_symbols)
         return {
-            "trading_feed_healthy": futures_fresh and options_fresh and not recovery_active,
+            "trading_feed_healthy": futures_fresh
+            and options_fresh
+            and not recovery_active,
             "futures_fresh": futures_fresh,
             "options_fresh": options_fresh,
             "spot_fresh": spot_fresh,
@@ -8077,13 +8106,20 @@ class MarketDataManager:
         # racing paths (MDM consumer + runner), causing out-of-order drops
         # and readiness flapping.
 
+    def get_candle_engine(self, symbol: str) -> CandleEngine:
+        """Return the authoritative CandleEngine for a canonicalized symbol."""
+        normalized = self._bar_symbol_key(self._canonical_symbol(symbol))
+        with self._lock:
+            return self._get_engine(normalized)
+
     def _get_engine(self, symbol: str) -> CandleEngine:
-        """Return or create candle engine for symbol."""
+        """Return or create the authoritative candle engine for symbol."""
+        normalized = self._bar_symbol_key(symbol)
         if not hasattr(self, "_engines"):
             self._engines = {}
-        if symbol not in self._engines:
-            self._engines[symbol] = CandleEngine(symbol=symbol)
-        return self._engines[symbol]
+        if normalized not in self._engines:
+            self._engines[normalized] = CandleEngine(symbol=normalized)
+        return self._engines[normalized]
 
     def _set_symbol_token_mapping(
         self, symbol: str, token: int, *, source: str
@@ -9315,10 +9351,10 @@ class MarketDataManager:
         # WebSocket transport failed. A healthy socket can continue receiving
         # heartbeats while one subscription generation is incomplete. Global
         # reconnects are therefore reserved for explicit transport evidence.
-        transport_failure = bool(stale_or_missing_symbols) and not processing_backlog and (
-            heartbeat_stale
-            or not ws_healthy
-            or subscription_transport_failure
+        transport_failure = (
+            bool(stale_or_missing_symbols)
+            and not processing_backlog
+            and (heartbeat_stale or not ws_healthy or subscription_transport_failure)
         )
         if stale_or_missing_symbols and not transport_failure:
             recovery_last = getattr(self, "_symbol_recovery_last_attempt_mono", None)

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -83,11 +83,8 @@ from nifty_scalper_bot.core.strategy_manager import StrategyManager
 from nifty_scalper_bot.core.trade_manager import TradeManager
 from nifty_scalper_bot.core.universe_controller import UniverseController
 from nifty_scalper_bot.data.candle_engine import (
-    CandleEngine,
-    import_candle_history,
     ensure_valid_data,
     normalize_ohlc_timezone,
-    repair_with_backfill,
     sanitize,
     validate_dataframe,
 )
@@ -1114,14 +1111,9 @@ class StrategyRunner:
         self._last_ws_stale_log_ts_by_symbol: dict[str, float] = defaultdict(float)
         self._last_ws_reconnect_attempt_ts: float = 0.0
         self._last_stall_warn_ts: float = 0.0  # throttle stall warnings to 30s
-        # Runner-LOCAL candle buffers: used ONLY as (a) the symbol registry for
-        # the staleness/backfill supervisor loop and (b) validity seeds for
-        # ensure_valid_data(). NOT a market-data source of truth — the single
-        # runtime OHLC authority is MarketDataManager (pipeline store mirrors
-        # its closed bars). Do not read prices from here for strategy or
-        # execution decisions. Consolidation into MDM reads is the deferred
-        # "runner-candle-consolidation" slice.
-        self._candle_engines: dict[str, CandleEngine] = {}
+        # Compatibility mirror of authoritative MDM CandleEngine objects only.
+        # StrategyRunner must never instantiate or mutate separate engines.
+        self._candle_engines: dict[str, Any] = {}
         # STEP 1/4: Single deterministic pipeline — ticks flow here → closed candles only
         self._pipeline: MarketDataPipeline = get_pipeline(store_maxlen=1500)
         # STEP 5: counter for "invalid data" drops — never silently discarded
@@ -1528,6 +1520,25 @@ class StrategyRunner:
                 exc_info=exc,
             )
 
+    def _mirror_authoritative_candle_engine(self, symbol: str) -> Any | None:
+        """Mirror the MDM-owned CandleEngine object without creating one locally."""
+        getter = getattr(self._market_data, "get_candle_engine", None)
+        if not callable(getter):
+            try:
+                is_live_mode = self._resolve_execution_mode_snapshot().is_live_mode
+            except Exception:
+                is_live_mode = False
+            if is_live_mode:
+                raise RuntimeError(
+                    "MarketDataManager CandleEngine accessor unavailable"
+                )
+            return None
+        normalized = self._normalize_symbol(symbol)
+        engine = getter(normalized)
+        with self._lock:
+            self._candle_engines[normalized] = engine
+        return engine
+
     def add_symbol(self, symbol: str) -> None:
         """Begin tracking a new symbol."""
         normalized = self._normalize_symbol(symbol)
@@ -1539,8 +1550,8 @@ class StrategyRunner:
             and normalized.startswith("NFO:")
             and ("CE" in normalized or "PE" in normalized)
         )
+        self._mirror_authoritative_candle_engine(normalized)
         with self._lock:
-            self._candle_engines.setdefault(normalized, CandleEngine())
             state = self._symbol_state.get(normalized)
             if state is None:
                 state = SymbolRuntimeState(
@@ -2416,22 +2427,22 @@ class StrategyRunner:
                         "volume": float(volumes[i]) if i < len(volumes) else 0.0,
                     }
                 )
-            df = pd.DataFrame(rows)
-            df = df.drop_duplicates(subset="timestamp", keep="last")
-            df = df.sort_values("timestamp").reset_index(drop=True)
-            engine = self._candle_engines.setdefault(symbol, CandleEngine())
-            import_candle_history(
-                engine,
-                df.tail(engine.max_bars).reset_index(drop=True),
-                mode="bootstrap",
-                source="strategy_runner_seed",
-            )
+            ingest = getattr(self._market_data, "ingest_historical_ohlc", None)
+            if not callable(ingest):
+                if self._resolve_execution_mode_snapshot().is_live_mode:
+                    raise RuntimeError("MarketDataManager history import unavailable")
+                return
+            accepted = ingest(symbol, rows)
+            engine = self._mirror_authoritative_candle_engine(symbol)
             self._logger.debug(
                 "candle_engine_seeded",
                 extra={
                     "event": "candle_engine_seeded",
                     "symbol": symbol,
-                    "bars": len(engine.df),
+                    "bars": (
+                        len(engine.get_completed_bars()) if engine is not None else 0
+                    ),
+                    "accepted_rows": accepted,
                 },
             )
         except Exception as exc:
@@ -7583,9 +7594,7 @@ class StrategyRunner:
                         "history_count": history_count,
                     },
                 )
-            engine = self._candle_engines.setdefault(normalized_symbol, CandleEngine())
-            with self._symbol_locks[normalized_symbol]:
-                engine.on_tick(tick)
+            self._mirror_authoritative_candle_engine(normalized_symbol)
             now_mono = time.monotonic()
             self._last_tick_seen_ts = now_mono
 
@@ -7887,7 +7896,11 @@ class StrategyRunner:
             if not ready:
                 _mark_stale(required_symbol, reason)
 
-        for symbol, engine in self._candle_engines.items():
+        watchdog_symbols = set(self._candle_engines)
+        if required_live_symbols is not None:
+            watchdog_symbols.update(required_live_symbols)
+        for symbol in sorted(watchdog_symbols):
+            self._mirror_authoritative_candle_engine(symbol)
             if (
                 required_live_symbols is not None
                 and symbol not in required_live_symbols
@@ -8014,18 +8027,14 @@ class StrategyRunner:
                             continue
 
                         with self._symbol_locks[symbol]:
-                            repaired = repair_with_backfill(
-                                symbol,
-                                sanitize(engine.get_df()),
-                                fetch_recent_rest=lambda _sym: repair_input,
-                                max_bars=engine.max_bars,
+                            ingest = getattr(
+                                self._market_data, "ingest_historical_ohlc", None
                             )
-                            if not repaired.empty:
-                                import_candle_history(
-                                    engine,
-                                    repaired,
-                                    mode="incremental",
-                                    source="strategy_runner_backfill",
+                            if callable(ingest):
+                                ingest(symbol, repair_input.to_dict("records"))
+                            elif self._resolve_execution_mode_snapshot().is_live_mode:
+                                raise RuntimeError(
+                                    "MarketDataManager backfill unavailable"
                                 )
                     except Exception:
                         # 4. Use .exception to capture traceback and stop silent failures

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -84,6 +84,7 @@ from nifty_scalper_bot.core.trade_manager import TradeManager
 from nifty_scalper_bot.core.universe_controller import UniverseController
 from nifty_scalper_bot.data.candle_engine import (
     CandleEngine,
+    import_candle_history,
     ensure_valid_data,
     normalize_ohlc_timezone,
     repair_with_backfill,
@@ -2419,7 +2420,12 @@ class StrategyRunner:
             df = df.drop_duplicates(subset="timestamp", keep="last")
             df = df.sort_values("timestamp").reset_index(drop=True)
             engine = self._candle_engines.setdefault(symbol, CandleEngine())
-            engine.replace_history(df.tail(engine.max_bars).reset_index(drop=True))
+            import_candle_history(
+                engine,
+                df.tail(engine.max_bars).reset_index(drop=True),
+                mode="bootstrap",
+                source="strategy_runner_seed",
+            )
             self._logger.debug(
                 "candle_engine_seeded",
                 extra={
@@ -8015,7 +8021,12 @@ class StrategyRunner:
                                 max_bars=engine.max_bars,
                             )
                             if not repaired.empty:
-                                engine.replace_history(repaired)
+                                import_candle_history(
+                                    engine,
+                                    repaired,
+                                    mode="incremental",
+                                    source="strategy_runner_backfill",
+                                )
                     except Exception:
                         # 4. Use .exception to capture traceback and stop silent failures
                         self._logger.exception(

--- a/tests/data/test_candle_engine_ssot_static_audit.py
+++ b/tests/data/test_candle_engine_ssot_static_audit.py
@@ -42,3 +42,18 @@ def test_market_data_manager_ohlc_projection_is_refreshed_not_appended() -> None
     assert "def _refresh_candle_projection" in text
     assert "_ohlc[self._bar_symbol_key(symbol)].append" not in text
     assert "ingest_historical_bar(row)" not in text
+
+
+def test_production_candle_engine_instantiation_is_limited_to_mdm_owner() -> None:
+    offenders: list[str] = []
+    allowed = {Path("data/market_data_manager.py")}
+    pattern = re.compile(r"\bCandleEngine\s*\(")
+    for path in SRC_ROOT.rglob("*.py"):
+        relative = path.relative_to(SRC_ROOT)
+        if relative in ALLOWED_RELATIVE_FILES or relative in allowed:
+            continue
+        text = path.read_text(encoding="utf-8")
+        for match in pattern.finditer(text):
+            line = text.count("\n", 0, match.start()) + 1
+            offenders.append(f"{relative}:{line}:candle_engine_instantiation")
+    assert offenders == []

--- a/tests/data/test_candle_engine_ssot_static_audit.py
+++ b/tests/data/test_candle_engine_ssot_static_audit.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from pathlib import Path
+import re
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SRC_ROOT = REPO_ROOT / "src" / "nifty_scalper_bot"
+
+
+MUTATION_PATTERNS = {
+    "completed_append": re.compile(r"_completed_candles\s*\.\s*(append|extend)\s*\("),
+    "completed_assign": re.compile(r"_completed_candles\s*="),
+    "current_assign": re.compile(r"current_candle\s*="),
+    "engine_df_assign": re.compile(r"\.df\s*="),
+    "candle_engine_replace_history": re.compile(r"\bengine\.replace_history\s*\("),
+}
+
+ALLOWED_RELATIVE_FILES = {
+    Path("data/candle_engine.py"),
+}
+
+
+def test_production_candle_engine_private_mutation_is_limited_to_candle_engine() -> (
+    None
+):
+    offenders: list[str] = []
+    for path in SRC_ROOT.rglob("*.py"):
+        relative = path.relative_to(SRC_ROOT)
+        if relative in ALLOWED_RELATIVE_FILES:
+            continue
+        text = path.read_text(encoding="utf-8")
+        for name, pattern in MUTATION_PATTERNS.items():
+            for match in pattern.finditer(text):
+                line = text.count("\n", 0, match.start()) + 1
+                offenders.append(f"{relative}:{line}:{name}")
+    assert offenders == []
+
+
+def test_market_data_manager_ohlc_projection_is_refreshed_not_appended() -> None:
+    path = SRC_ROOT / "data" / "market_data_manager.py"
+    text = path.read_text(encoding="utf-8")
+    assert "def _refresh_candle_projection" in text
+    assert "_ohlc[self._bar_symbol_key(symbol)].append" not in text
+    assert "ingest_historical_bar(row)" not in text

--- a/tests/data/test_candle_engine_ssot_static_audit.py
+++ b/tests/data/test_candle_engine_ssot_static_audit.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from pathlib import Path
 import re
+from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SRC_ROOT = REPO_ROOT / "src" / "nifty_scalper_bot"

--- a/tests/data/test_canonical_history_hydration.py
+++ b/tests/data/test_canonical_history_hydration.py
@@ -315,6 +315,8 @@ def _storage_mdm() -> MarketDataManager:
     mdm._engines = {}
     mdm._cache_len = 100
     mdm._candle_metrics = defaultdict(float)
+    mdm._candle_queue_watermarks = {}
+    mdm._last_history_import_result = None
     mdm._last_historical_ts = {}
     import asyncio
     mdm._tick_queue = asyncio.Queue(maxsize=100)

--- a/tests/data/test_canonical_history_hydration.py
+++ b/tests/data/test_canonical_history_hydration.py
@@ -312,7 +312,12 @@ def _storage_mdm() -> MarketDataManager:
     mdm._min_required_bars = 2
     mdm._raw_tick_history = defaultdict(lambda: deque(maxlen=100))
     mdm._ohlc = defaultdict(lambda: deque(maxlen=100))
+    mdm._engines = {}
+    mdm._cache_len = 100
+    mdm._candle_metrics = defaultdict(float)
     mdm._last_historical_ts = {}
+    import asyncio
+    mdm._tick_queue = asyncio.Queue(maxsize=100)
     mdm._bar_symbol_key = lambda s: str(s)
     mdm._canonical_symbol = lambda s: str(s)
     mdm._active_subscribed_symbols = set()
@@ -339,14 +344,29 @@ def _storage_mdm() -> MarketDataManager:
     return mdm
 
 
-def test_historical_bar_writes_only_canonical_ohlc_not_raw_ticks() -> None:
+def test_historical_bar_imports_through_candle_engine_projection_not_raw_ticks() -> None:
     mdm = _storage_mdm()
     bar = {"symbol": "NSE:NIFTY", "timestamp": datetime(2026, 1, 1, tzinfo=timezone.utc), "open": 1, "high": 2, "low": 1, "close": 2, "volume": 10}
     mdm.ingest_historical_bar(bar)
+    engine = mdm._get_engine("NSE:NIFTY")
+    assert len(engine.get_completed_bars()) == 1
     assert len(mdm._ohlc["NSE:NIFTY"]) == 1
     assert len(mdm._raw_tick_history["NSE:NIFTY"]) == 0
+    mdm._ohlc["NSE:NIFTY"][0]["close"] = 999
+    assert engine.get_completed_bars()[0]["close"] == 2.0
     assert mdm.is_ohlc_ready("NSE:NIFTY", required_bars=1) is True
     assert mdm.is_tick_ready("NSE:NIFTY") is False
+
+
+def test_conflicting_rehydration_leaves_projection_unchanged() -> None:
+    mdm = _storage_mdm()
+    first = {"symbol": "NSE:NIFTY", "timestamp": datetime(2026, 1, 1, tzinfo=timezone.utc), "open": 1, "high": 2, "low": 1, "close": 2, "volume": 10}
+    conflict = {**first, "close": 1.5}
+    assert mdm.ingest_historical_ohlc("NSE:NIFTY", [first]) == 1
+    before = mdm.get_ohlc_bars("NSE:NIFTY")
+    assert mdm.ingest_historical_ohlc("NSE:NIFTY", [conflict]) == 0
+    assert mdm.get_ohlc_bars("NSE:NIFTY") == before
+    assert mdm._candle_metrics["history_hydration_conflict_total"] == 1
 
 
 def test_missing_readiness_requirements_fail_closed_even_with_ready_bars() -> None:

--- a/tests/data/test_mdm_history_import_result_contract.py
+++ b/tests/data/test_mdm_history_import_result_contract.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import asyncio
+from collections import defaultdict, deque
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+from nifty_scalper_bot.data.market_data_manager import MarketDataManager
+
+SYMBOL = "NSE:NIFTY"
+
+
+def _mdm() -> MarketDataManager:
+    mdm = MarketDataManager.__new__(MarketDataManager)
+    mdm._logger = SimpleNamespace(
+        info=lambda *a, **k: None,
+        warning=lambda *a, **k: None,
+        error=lambda *a, **k: None,
+        debug=lambda *a, **k: None,
+    )
+    mdm._cache_len = 100
+    mdm._lock = __import__("threading").RLock()
+    mdm._ohlc = defaultdict(lambda: deque(maxlen=100))
+    mdm._engines = {}
+    mdm._candle_metrics = defaultdict(float)
+    mdm._candle_queue_watermarks = {}
+    mdm._last_history_import_result = None
+    mdm._last_historical_ts = {}
+    mdm._tick_queue = asyncio.Queue(maxsize=100)
+    mdm._bar_symbol_key = lambda s: str(s)
+    mdm._canonical_symbol = lambda s: str(s)
+    mdm._min_required_bars = 2
+    mdm.update_hydration_status = lambda *_a, **_k: None
+    return mdm
+
+
+def _bar(close: float = 2.0, *, open_price: float = 1.0) -> dict:
+    return {
+        "symbol": SYMBOL,
+        "timestamp": datetime(2026, 1, 1, tzinfo=timezone.utc),
+        "open": open_price,
+        "high": 2,
+        "low": 1,
+        "close": close,
+        "volume": 10,
+    }
+
+
+def test_invalid_historical_ohlc_failure_is_not_conflict_or_ready() -> None:
+    mdm = _mdm()
+    readiness_calls: list[tuple] = []
+    mdm.update_hydration_status = lambda *args, **kwargs: readiness_calls.append(
+        (args, kwargs)
+    )
+
+    accepted = mdm.ingest_historical_ohlc(SYMBOL, [_bar(open_price=-1)])
+
+    assert accepted == 0
+    assert readiness_calls == []
+    assert mdm._candle_metrics["history_hydration_failure_total"] == 1
+    assert mdm._candle_metrics["history_hydration_conflict_total"] == 0
+    assert mdm._last_history_import_result["status"] == "failed_validation"
+
+
+def test_same_minute_finalized_conflict_counts_failure_and_conflict() -> None:
+    mdm = _mdm()
+
+    assert mdm.ingest_historical_ohlc(SYMBOL, [_bar()]) == 1
+    assert mdm.ingest_historical_ohlc(SYMBOL, [_bar(close=1.5)]) == 0
+
+    assert mdm._candle_metrics["history_hydration_failure_total"] == 1
+    assert mdm._candle_metrics["history_hydration_conflict_total"] == 1
+    assert mdm._last_history_import_result["status"] == "finalized_candle_conflict"
+
+
+def test_idempotent_import_is_distinguishable_from_failure() -> None:
+    mdm = _mdm()
+    row = _bar()
+
+    assert mdm.ingest_historical_ohlc(SYMBOL, [row]) == 1
+    assert mdm.ingest_historical_ohlc(SYMBOL, [row]) == 0
+
+    assert mdm._last_history_import_result["status"] == "success_idempotent"
+    assert mdm._candle_metrics["history_hydration_success_total"] == 2
+    assert mdm._candle_metrics["history_hydration_failure_total"] == 0
+
+
+def test_failed_history_import_leaves_projection_unchanged() -> None:
+    mdm = _mdm()
+
+    assert mdm.ingest_historical_ohlc(SYMBOL, [_bar()]) == 1
+    before = mdm.get_ohlc_bars(SYMBOL)
+    assert mdm.ingest_historical_ohlc(SYMBOL, [_bar(close=1.5)]) == 0
+
+    assert mdm.get_ohlc_bars(SYMBOL) == before
+
+
+def test_projection_divergence_detects_equal_length_ohlcv_mismatch() -> None:
+    mdm = _mdm()
+
+    assert mdm.ingest_historical_ohlc(SYMBOL, [_bar()]) == 1
+    mdm._ohlc[SYMBOL][0]["close"] = 999
+    mdm._refresh_candle_projection(SYMBOL)
+
+    assert mdm._candle_metrics["candle_projection_divergence_total"] == 1

--- a/tests/data/test_mdm_queue_watermark_hydration.py
+++ b/tests/data/test_mdm_queue_watermark_hydration.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import asyncio
+from collections import defaultdict, deque
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pandas as pd
+import pytest
+
+from nifty_scalper_bot.data.market_data_manager import MarketDataManager
+
+SYMBOL = "NSE:NIFTY"
+OTHER_SYMBOL = "NSE:BANKNIFTY"
+
+
+def _tick(identifier: str, symbol: str, minute: int | str) -> dict:
+    timestamp = (
+        minute
+        if isinstance(minute, str)
+        else datetime(2026, 1, 1, 9, minute, tzinfo=timezone.utc)
+    )
+    return {"id": identifier, "symbol": symbol, "timestamp": timestamp}
+
+
+def _storage_mdm() -> MarketDataManager:
+    mdm = MarketDataManager.__new__(MarketDataManager)
+    mdm._logger = SimpleNamespace(
+        info=lambda *a, **k: None,
+        warning=lambda *a, **k: None,
+        error=lambda *a, **k: None,
+        debug=lambda *a, **k: None,
+    )
+    mdm._lock = None
+    mdm._cache_len = 100
+    mdm._ohlc = defaultdict(lambda: deque(maxlen=100))
+    mdm._engines = {}
+    mdm._candle_metrics = defaultdict(float)
+    mdm._candle_queue_watermarks = {}
+    mdm._last_history_import_result = None
+    mdm._last_historical_ts = {}
+    mdm._tick_queue = asyncio.Queue(maxsize=100)
+    mdm._bar_symbol_key = lambda s: str(s)
+    mdm._canonical_symbol = lambda s: str(s)
+    return mdm
+
+
+async def _run_consumer_until_join(mdm: MarketDataManager) -> None:
+    consumer = asyncio.create_task(mdm._consume_ticks())
+    await asyncio.wait_for(mdm._tick_queue.join(), timeout=1.0)
+    consumer.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await consumer
+
+
+@pytest.mark.asyncio
+async def test_consumer_discards_stale_ticks_and_preserves_retained_order() -> None:
+    mdm = _storage_mdm()
+    mdm._candle_queue_watermarks[SYMBOL] = pd.Timestamp(
+        datetime(2026, 1, 1, 9, 16, tzinfo=timezone.utc)
+    )
+    processed: list[str] = []
+    mdm._process_queued_tick = lambda raw: processed.append(raw["id"])
+
+    for tick in [
+        _tick("stale", SYMBOL, 15),
+        _tick("equal", SYMBOL, 16),
+        _tick("newer-1", SYMBOL, 17),
+        _tick("newer-2", SYMBOL, 18),
+    ]:
+        mdm._tick_queue.put_nowait(tick)
+
+    assert mdm._tick_queue._unfinished_tasks == mdm._tick_queue.qsize()
+    await _run_consumer_until_join(mdm)
+
+    assert processed == ["newer-1", "newer-2"]
+    assert mdm._candle_metrics["queued_ticks_purged_after_hydration"] == 2
+    assert mdm._tick_queue._unfinished_tasks == mdm._tick_queue.qsize() == 0
+
+
+@pytest.mark.asyncio
+async def test_queue_join_completes_after_retained_ticks_are_consumed() -> None:
+    mdm = _storage_mdm()
+    mdm._candle_queue_watermarks[SYMBOL] = pd.Timestamp(
+        datetime(2026, 1, 1, 9, 15, tzinfo=timezone.utc)
+    )
+    processed: list[str] = []
+    mdm._process_queued_tick = lambda raw: processed.append(raw["id"])
+
+    for minute in (16, 17, 18):
+        mdm._tick_queue.put_nowait(_tick(f"newer-{minute}", SYMBOL, minute))
+
+    await _run_consumer_until_join(mdm)
+
+    assert processed == ["newer-16", "newer-17", "newer-18"]
+    assert mdm._tick_queue._unfinished_tasks == 0
+
+
+@pytest.mark.asyncio
+async def test_concurrent_producer_has_no_tick_loss_or_reorder() -> None:
+    mdm = _storage_mdm()
+    mdm._candle_queue_watermarks[SYMBOL] = pd.Timestamp(
+        datetime(2026, 1, 1, 9, 15, tzinfo=timezone.utc)
+    )
+    processed: list[str] = []
+    mdm._process_queued_tick = lambda raw: processed.append(raw["id"])
+
+    mdm._tick_queue.put_nowait(_tick("same-symbol-new", SYMBOL, 16))
+    mdm._tick_queue.put_nowait(_tick("other-stale-minute", OTHER_SYMBOL, 14))
+
+    consumer = asyncio.create_task(mdm._consume_ticks())
+    await asyncio.sleep(0)
+    mdm._tick_queue.put_nowait(_tick("producer-new", SYMBOL, 17))
+    await asyncio.wait_for(mdm._tick_queue.join(), timeout=1.0)
+    consumer.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await consumer
+
+    assert processed == ["same-symbol-new", "other-stale-minute", "producer-new"]
+    assert mdm._tick_queue._unfinished_tasks == mdm._tick_queue.qsize() == 0
+
+
+@pytest.mark.asyncio
+async def test_invalid_timestamp_tick_follows_consumer_policy_not_watermark_purge() -> (
+    None
+):
+    mdm = _storage_mdm()
+    mdm._candle_queue_watermarks[SYMBOL] = pd.Timestamp(
+        datetime(2026, 1, 1, 9, 15, tzinfo=timezone.utc)
+    )
+    processed: list[str] = []
+    mdm._process_queued_tick = lambda raw: processed.append(raw["id"])
+    mdm._tick_queue.put_nowait(_tick("invalid-ts", SYMBOL, "not-a-timestamp"))
+
+    await _run_consumer_until_join(mdm)
+
+    assert processed == ["invalid-ts"]
+    assert mdm._candle_metrics["queued_ticks_purged_after_hydration"] == 0

--- a/tests/data/test_mdm_runner_candle_engine_registry.py
+++ b/tests/data/test_mdm_runner_candle_engine_registry.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import threading
+from collections import defaultdict, deque
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from typing import Any
+
+from nifty_scalper_bot.data.market_data_manager import MarketDataManager
+from nifty_scalper_bot.strategies.runner import StrategyRunner
+
+SYMBOL = "NSE:NIFTY"
+
+
+def _logger() -> SimpleNamespace:
+    return SimpleNamespace(
+        info=lambda *a, **k: None,
+        warning=lambda *a, **k: None,
+        error=lambda *a, **k: None,
+        debug=lambda *a, **k: None,
+    )
+
+
+def _mdm() -> MarketDataManager:
+    mdm = MarketDataManager.__new__(MarketDataManager)
+    mdm._logger = _logger()
+    mdm._cache_len = 3
+    mdm._lock = threading.RLock()
+    mdm._ohlc = defaultdict(lambda: deque(maxlen=3))
+    mdm._engines = {}
+    mdm._candle_metrics = defaultdict(float)
+    mdm._candle_queue_watermarks = {}
+    mdm._last_history_import_result = None
+    mdm._last_historical_ts = {}
+    mdm._bar_symbol_key = lambda s: str(s).strip().upper()
+    mdm._canonical_symbol = lambda s: (
+        SYMBOL
+        if str(s).strip().upper() in {"NIFTY", SYMBOL}
+        else str(s).strip().upper()
+    )
+    mdm._min_required_bars = 1
+    mdm.update_hydration_status = lambda *_a, **_k: None
+    return mdm
+
+
+def _runner(mdm: MarketDataManager) -> StrategyRunner:
+    runner = StrategyRunner.__new__(StrategyRunner)
+    runner._market_data = mdm
+    runner._candle_engines = {}
+    runner._lock = threading.RLock()
+    runner._normalize_symbol = lambda s: mdm._canonical_symbol(s)  # type: ignore[method-assign]
+    runner._logger = _logger()
+    return runner
+
+
+def _row(minute: int, close: float = 100.0) -> dict[str, Any]:
+    ts = datetime(2026, 1, 1, 9, 15, tzinfo=timezone.utc) + timedelta(minutes=minute)
+    return {
+        "symbol": SYMBOL,
+        "timestamp": ts,
+        "open": close - 1,
+        "high": close + 1,
+        "low": close - 2,
+        "close": close,
+        "volume": 10,
+    }
+
+
+def test_mdm_candle_engine_accessor_canonicalizes_to_single_object() -> None:
+    mdm = _mdm()
+
+    first = mdm.get_candle_engine("NIFTY")
+    second = mdm.get_candle_engine("nse:nifty")
+
+    assert first is second
+    assert list(mdm._engines) == [SYMBOL]
+
+
+def test_runner_resolves_same_authoritative_engine_as_mdm() -> None:
+    mdm = _mdm()
+    runner = _runner(mdm)
+
+    engine_from_runner = runner._mirror_authoritative_candle_engine("NIFTY")
+
+    assert engine_from_runner is mdm.get_candle_engine(SYMBOL)
+    assert runner._candle_engines[SYMBOL] is engine_from_runner
+
+
+def test_history_imported_through_mdm_is_visible_to_runner_engine() -> None:
+    mdm = _mdm()
+    runner = _runner(mdm)
+
+    assert mdm.ingest_historical_ohlc("NIFTY", [_row(0)]) == 1
+    engine = runner._mirror_authoritative_candle_engine("NIFTY")
+
+    assert engine is mdm.get_candle_engine(SYMBOL)
+    assert engine.get_completed_bars()[-1]["close"] == 100.0
+    assert (
+        engine.latest_finalized_minute()
+        == mdm.get_candle_engine(SYMBOL).latest_finalized_minute()
+    )
+
+
+def test_live_finalization_through_mdm_engine_is_visible_to_runner() -> None:
+    mdm = _mdm()
+    runner = _runner(mdm)
+    engine = mdm.get_candle_engine(SYMBOL)
+    start = datetime(2026, 1, 1, 9, 15, tzinfo=timezone.utc)
+
+    assert engine.on_tick({"symbol": SYMBOL, "timestamp": start, "ltp": 100.0}) is None
+    finalized = engine.on_tick(
+        {"symbol": SYMBOL, "timestamp": start + timedelta(minutes=1), "ltp": 101.0}
+    )
+    mdm._refresh_candle_projection(SYMBOL)
+
+    assert finalized is not None
+    assert runner._mirror_authoritative_candle_engine(SYMBOL) is engine
+    assert runner._candle_engines[SYMBOL].get_completed_bars()[-1]["close"] == 100.0
+    assert mdm.get_latest_closed_bar(SYMBOL) is not None
+
+
+def test_normal_projection_append_and_rolling_maxlen_do_not_count_divergence() -> None:
+    mdm = _mdm()
+
+    assert mdm.ingest_historical_ohlc(SYMBOL, [_row(0, 100.0), _row(1, 101.0)]) == 2
+    assert mdm._candle_metrics["candle_projection_divergence_total"] == 0
+    assert mdm.ingest_historical_ohlc(SYMBOL, [_row(2, 102.0), _row(3, 103.0)]) == 2
+
+    assert len(mdm.get_ohlc_bars(SYMBOL)) == 3
+    assert [bar["close"] for bar in mdm.get_ohlc_bars(SYMBOL)] == [101.0, 102.0, 103.0]
+    assert mdm._candle_metrics["candle_projection_divergence_total"] == 0

--- a/tests/e2e/live_sim/conftest.py
+++ b/tests/e2e/live_sim/conftest.py
@@ -231,7 +231,7 @@ class LiveSimSystem:
             )
             self.runner.sync_history_from_mdm(
                 symbol,
-                required_bars=min(limit, 100),
+                required_bars=limit,
                 reason="live_sim_hydration",
                 role="option" if symbol.endswith(("CE", "PE")) else "context",
             )


### PR DESCRIPTION
### Motivation

- Eliminate competing candle writers: MDM and compatibility layers were appending finalized and historical OHLC directly into `_ohlc`, producing divergent projections and unsafe merge paths.  
- Ensure a single authoritative owner for completed candles and imports so history/backfill/hydration and live finalization are atomic and fail-closed on conflicts.  
- Preserve existing public APIs and downstream compatibility while preventing accidental mutation of CandleEngine private state.

### Description

- Enforce CandleEngine as the sole writer for canonical completed bars by routing all historical ingestion and backfill through `CandleEngine.import_history()` and adding a narrow compatibility adapter `import_candle_history(engine, ...)` for legacy callers.  
- Convert MarketDataManager `_ohlc` into a read-only projection refreshed from CandleEngine via `_refresh_candle_projection(symbol)`, and change live/clock/REST finalized-bar paths to refresh+publish instead of appending.  
- Add queue-watermark purge that drops queued ticks whose minute is <= CandleEngine.latest_finalized_minute() after successful history imports to avoid stale-tick replay.  
- Replace direct `engine.replace_history(...)` usage in legacy runner/backfill seeding with the compatibility adapter and make `ensure_valid_data()` use `import_history()` for hydration.  
- Add structured operational metrics for hydration, projection refresh/divergence, and queue purge (see added metric names in code).  
- Add a static ownership audit test that fails if production modules mutate CandleEngine private state, and extend regression tests to assert projection is CandleEngine-backed and conflicts fail closed.

### Testing

- Ran focused unit/regression suites: `pytest tests/data/test_candle_engine_ssot_static_audit.py tests/data/test_canonical_history_hydration.py tests/data/test_candle_engine_history_import.py tests/data/test_market_data_hardening.py` — all passed.  
- Ran broader focused selection: `pytest tests/data -q` and `pytest -k "candle or hydration or backfill or market_data or polling or queue or datahub or pipeline" -q` — passed.  
- Performed static checks: `python -m compileall src tests` succeeded; repository-wide `black --check` and `ruff` reported pre-existing formatting/style issues (not auto-fixed to avoid unrelated changes).  
- Notes: full local `pytest -q` completed (one skipped test, teardown emitted a benign pending-task log warning) and `git diff --check` returned clean; remote CI/GitHub Actions were not executed from this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5c63a7362c8324bb1354f79bc3719d)