### PR TITLE
Harden post-exit reconciliation and candle diagnostics

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -7527,15 +7527,11 @@ def _is_explicit_simulated_adapter(adapter: Any) -> bool:
         return True
 
     wrapped = getattr(adapter, "client", None)
-    if wrapped is not None and bool(
-        getattr(wrapped, "is_simulated_adapter", False)
-    ):
+    if wrapped is not None and bool(getattr(wrapped, "is_simulated_adapter", False)):
         return True
 
     wrapped = getattr(adapter, "_broker", None)
-    if wrapped is not None and bool(
-        getattr(wrapped, "is_simulated_adapter", False)
-    ):
+    if wrapped is not None and bool(getattr(wrapped, "is_simulated_adapter", False)):
         return True
 
     return False
@@ -9399,9 +9395,11 @@ async def _recompute_and_push_runtime_readiness(
     )
     runner_running = _runner_is_running(getattr(ctx, "strategy_runner", None))
     evaluation_ready = bool(data_hard_ready and runner_running)
-    configured_mode = str(
-        getattr(getattr(ctx, "settings", None), "execution_mode", "") or ""
-    ).strip().upper()
+    configured_mode = (
+        str(getattr(getattr(ctx, "settings", None), "execution_mode", "") or "")
+        .strip()
+        .upper()
+    )
     live_mode = _is_live_execution_mode(configured_mode) or _is_live_execution_mode()
     market_open = get_market_state() == MarketState.OPEN
     broker_ready = bool(
@@ -14447,7 +14445,9 @@ async def shutdown_sequence(ctx: BotContext, *, reason: str = "shutdown") -> Non
     )
     await _call_component("streamer", streamer, ("stop", "shutdown", "close"))
     await _call_component(
-        "market_data_manager", market_data_manager, ("stop", "shutdown", "close")
+        "market_data_manager",
+        market_data_manager,
+        ("async_stop", "stop", "shutdown", "close"),
     )
     await _call_component("message_bus", message_bus, ("stop", "shutdown", "close"))
     try:

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -701,10 +701,7 @@ class MarketDataManager:
             configured_poll_max if self._rest_poll_enabled else 0
         )
         self._fallback_enabled = self._rest_poll_enabled
-        # Deprecated diagnostics only: REST fallback quotes are ticks,
-        # not candle writers.
-        self._poll_bar_state: dict[str, dict[str, float | None | int]] = {}
-        self._last_poll_bucket: dict[str, int] = {}
+        # REST fallback quotes are ticks only; CandleEngine owns candle formation.
         self._rest_poll_stop = threading.Event()
         self._rest_poll_thread: threading.Thread | None = None
         self._health_monitor_stop = threading.Event()
@@ -933,23 +930,6 @@ class MarketDataManager:
         except Exception as exc:  # noqa: BLE001
             self._logger.debug("ingest_rest_quote failed for %s: %s", symbol, exc)
 
-    def _process_poll_quote(self, symbol: str, quote: Mapping[str, Any]) -> None:
-        """Deprecated: REST fallback quotes must not fabricate completed candles."""
-        self._candle_metrics["fallback_quote_tick_reject_total"] += 1
-        self._logger.debug(
-            "POLL_CANDLE_BUILDER_DISABLED symbol=%s reason=rest_quotes_are_ticks",
-            symbol,
-        )
-
-    def _emit_poll_candle(self, candle: Mapping[str, Any]) -> None:
-        """Deprecated: poll-built candles are not authoritative production input."""
-        symbol = str(candle.get("symbol") or "") if isinstance(candle, Mapping) else ""
-        self._candle_metrics["fallback_quote_tick_reject_total"] += 1
-        self._logger.debug(
-            "POLL_CANDLE_EMIT_DISABLED symbol=%s reason=use_broker_historical_gap_fill",
-            symbol,
-        )
-
     def ingest_historical_bar(self, bar: Mapping[str, Any]) -> None:
         """Import one broker-completed OHLC bar through CandleEngine."""
         symbol = normalize_symbol(str(bar.get("symbol") or ""))
@@ -1176,36 +1156,68 @@ class MarketDataManager:
         lag_after_seconds, lag_after_bars = self._projection_lag(
             completed, canonical_latest_ts, refreshed_latest
         )
+        refreshed_at = time.time()
+        canonical_latest_value = (
+            canonical_latest_ts.timestamp() if canonical_latest_ts is not None else None
+        )
+        previous_latest_value = (
+            previous_latest.timestamp() if previous_latest is not None else None
+        )
+        refreshed_latest_value = (
+            refreshed_latest.timestamp() if refreshed_latest is not None else None
+        )
         with self._lock:
             self._ohlc[key] = projected
-
-        self._candle_metrics["candle_projection_refresh_total"] += 1
-        self._candle_metrics["candle_projection_last_refresh"] = time.time()
-        self._candle_metrics["candle_projection_size"] = float(len(projected))
-        if canonical_latest_ts is not None:
-            self._candle_metrics["candle_engine_latest_finalized_timestamp"] = (
-                canonical_latest_ts.timestamp()
+            self._candle_metrics["candle_projection_refresh_total"] += 1
+            self._candle_metrics["candle_projection_last_refresh"] = refreshed_at
+            self._candle_metrics["candle_projection_size"] = float(len(projected))
+            if canonical_latest_value is not None:
+                self._candle_metrics["candle_engine_latest_finalized_timestamp"] = (
+                    canonical_latest_value
+                )
+            if refreshed_latest_value is not None:
+                self._candle_metrics["candle_projection_latest_timestamp"] = (
+                    refreshed_latest_value
+                )
+            self._candle_metrics["candle_projection_lag_before_refresh_seconds"] = (
+                lag_before_seconds
             )
-        if refreshed_latest is not None:
-            self._candle_metrics["candle_projection_latest_timestamp"] = (
-                refreshed_latest.timestamp()
+            self._candle_metrics["candle_projection_lag_before_refresh_bars"] = (
+                lag_before_bars
             )
-        self._candle_metrics["candle_projection_lag_before_refresh_seconds"] = (
-            lag_before_seconds
-        )
-        self._candle_metrics["candle_projection_lag_before_refresh_bars"] = (
-            lag_before_bars
-        )
-        self._candle_metrics["candle_projection_lag_after_refresh_seconds"] = (
-            lag_after_seconds
-        )
-        self._candle_metrics["candle_projection_lag_after_refresh_bars"] = (
-            lag_after_bars
-        )
-        self._candle_metrics["candle_projection_lag_seconds"] = lag_after_seconds
-        self._candle_metrics["candle_projection_lag_bars"] = lag_after_bars
+            self._candle_metrics["candle_projection_lag_after_refresh_seconds"] = (
+                lag_after_seconds
+            )
+            self._candle_metrics["candle_projection_lag_after_refresh_bars"] = (
+                lag_after_bars
+            )
+            self._candle_metrics["candle_projection_lag_seconds"] = lag_after_seconds
+            self._candle_metrics["candle_projection_lag_bars"] = lag_after_bars
+            if divergence:
+                self._candle_metrics["candle_projection_divergence_total"] += 1
+            if not hasattr(self, "_candle_projection_diagnostics"):
+                self._candle_projection_diagnostics = {}
+            previous_divergence_total = float(
+                (self._candle_projection_diagnostics.get(normalized, {}) or {}).get(
+                    "divergence_total", 0.0
+                )
+                or 0.0
+            )
+            diagnostics = {
+                "canonical_latest_timestamp": canonical_latest_value,
+                "previous_projection_latest_timestamp": previous_latest_value,
+                "refreshed_projection_latest_timestamp": refreshed_latest_value,
+                "lag_before_refresh_seconds": lag_before_seconds,
+                "lag_before_refresh_bars": lag_before_bars,
+                "lag_after_refresh_seconds": lag_after_seconds,
+                "lag_after_refresh_bars": lag_after_bars,
+                "projection_size": len(projected),
+                "refreshed_at": refreshed_at,
+                "divergence_total": previous_divergence_total
+                + (1.0 if divergence else 0.0),
+            }
+            self._candle_projection_diagnostics[normalized] = diagnostics
         if divergence:
-            self._candle_metrics["candle_projection_divergence_total"] += 1
             self._logger.warning(
                 "CANDLE_PROJECTION_DIVERGENCE symbol=%s previous=%s projected=%s",
                 normalized,
@@ -1213,36 +1225,6 @@ class MarketDataManager:
                 len(projected),
                 extra={"event": "CANDLE_PROJECTION_DIVERGENCE", "symbol": normalized},
             )
-        divergence_total = float(
-            (getattr(self, "_candle_projection_diagnostics", {}) or {})
-            .get(normalized, {})
-            .get("divergence_total", 0.0)
-            or 0.0
-        ) + (1.0 if divergence else 0.0)
-        diagnostics = {
-            "canonical_latest_timestamp": (
-                canonical_latest_ts.timestamp()
-                if canonical_latest_ts is not None
-                else None
-            ),
-            "previous_projection_latest_timestamp": (
-                previous_latest.timestamp() if previous_latest is not None else None
-            ),
-            "refreshed_projection_latest_timestamp": (
-                refreshed_latest.timestamp() if refreshed_latest is not None else None
-            ),
-            "lag_before_refresh_seconds": lag_before_seconds,
-            "lag_before_refresh_bars": lag_before_bars,
-            "lag_after_refresh_seconds": lag_after_seconds,
-            "lag_after_refresh_bars": lag_after_bars,
-            "projection_size": len(projected),
-            "refreshed_at": time.time(),
-            "divergence_total": divergence_total,
-        }
-        if not hasattr(self, "_candle_projection_diagnostics"):
-            self._candle_projection_diagnostics = {}
-        with self._lock:
-            self._candle_projection_diagnostics[normalized] = diagnostics
         return [dict(row) for row in projected]
 
     def _latest_projection_timestamp(
@@ -1335,12 +1317,15 @@ class MarketDataManager:
             watermark_utc = pd.Timestamp(watermark).tz_convert("UTC").floor("min")
         except Exception:
             return
-        if not hasattr(self, "_candle_queue_watermarks"):
-            self._candle_queue_watermarks = {}
-        self._candle_queue_watermarks[normalized] = watermark_utc
         retained = self._tick_queue.qsize() if hasattr(self, "_tick_queue") else 0
-        self._candle_metrics["queued_ticks_retained_after_hydration"] += retained
-        self._candle_metrics["queue_watermark_timestamp"] = watermark_utc.timestamp()
+        with self._lock:
+            if not hasattr(self, "_candle_queue_watermarks"):
+                self._candle_queue_watermarks = {}
+            self._candle_queue_watermarks[normalized] = watermark_utc
+            self._candle_metrics["queued_ticks_retained_after_hydration"] += retained
+            self._candle_metrics["queue_watermark_timestamp"] = (
+                watermark_utc.timestamp()
+            )
         self._logger.info(
             "MDM_QUEUE_WATERMARK_ARMED symbol=%s retained=%s watermark=%s",
             normalized,
@@ -1357,9 +1342,6 @@ class MarketDataManager:
 
     def _queued_tick_at_or_before_watermark(self, raw: Mapping[str, Any]) -> bool:
         """Return True when a queued tick is stale under a hydration watermark."""
-        watermarks = getattr(self, "_candle_queue_watermarks", {}) or {}
-        if not watermarks:
-            return False
         raw_symbol = str(raw.get("symbol") or raw.get("tradingsymbol") or "")
         if not raw_symbol:
             return False
@@ -1368,7 +1350,10 @@ class MarketDataManager:
             if hasattr(self, "_canonical_symbol")
             else raw_symbol
         )
-        watermark = watermarks.get(normalized)
+        with self._lock:
+            watermark = (getattr(self, "_candle_queue_watermarks", {}) or {}).get(
+                normalized
+            )
         if watermark is None:
             return False
         raw_ts = (
@@ -1728,6 +1713,32 @@ class MarketDataManager:
             self._ws_start_requested = False
             self._logger.exception("Failure in ws.start")
 
+    def _settle_cancelled_tick_task(
+        self, task: asyncio.Task[Any] | None, *, name: str
+    ) -> None:
+        if task is None:
+            return
+        if task.done():
+            with suppress(asyncio.CancelledError, Exception):
+                task.result()
+            return
+        try:
+            task.cancel()
+        except Exception as exc:  # noqa: BLE001
+            self._logger.debug("%s cancel raised: %s", name, exc)
+            return
+        loop = task.get_loop()
+        if loop.is_running():
+
+            def _consume_terminal_result(done: asyncio.Task[Any]) -> None:
+                with suppress(asyncio.CancelledError, Exception):
+                    done.result()
+
+            task.add_done_callback(_consume_terminal_result)
+            return
+        with suppress(asyncio.CancelledError, Exception):
+            loop.run_until_complete(asyncio.gather(task, return_exceptions=True))
+
     def stop(self) -> None:
         if not self._started:
             return
@@ -1744,18 +1755,12 @@ class MarketDataManager:
             except Exception as exc:  # noqa: BLE001
                 self._logger.debug("ws.stop() raised: %s", exc)
         self._tick_drain_stopping = True
-        if self._tick_drain_task is not None:
-            try:
-                self._tick_drain_task.cancel()
-            except Exception as exc:  # noqa: BLE001
-                self._logger.debug("tick drain cancel raised: %s", exc)
-            self._tick_drain_task = None
-        if self._tick_consumer_task is not None:
-            try:
-                self._tick_consumer_task.cancel()
-            except Exception as exc:  # noqa: BLE001
-                self._logger.debug("tick consumer cancel raised: %s", exc)
-            self._tick_consumer_task = None
+        tick_drain_task = self._tick_drain_task
+        tick_consumer_task = self._tick_consumer_task
+        self._tick_drain_task = None
+        self._tick_consumer_task = None
+        self._settle_cancelled_tick_task(tick_drain_task, name="tick drain")
+        self._settle_cancelled_tick_task(tick_consumer_task, name="tick consumer")
         # Deprecated tick worker removed: only the owning asyncio loop drains ticks.
         if self._rest_poll_thread is not None:
             self._rest_poll_stop.set()
@@ -10720,8 +10725,6 @@ class MarketDataManager:
                 "_tick_cache",
                 "_last_tick_snapshot",
                 "_history",
-                "_poll_bar_state",
-                "_last_poll_bucket",
             ):
                 cache = getattr(self, cache_name, {})
                 if isinstance(cache, dict):
@@ -10753,8 +10756,6 @@ class MarketDataManager:
                 self._last_tick_snapshot.pop(symbol, None)
                 self._raw_tick_history.pop(symbol, None)
                 self._ohlc.pop(self._bar_symbol_key(symbol), None)
-                self._poll_bar_state.pop(symbol, None)
-                self._last_poll_bucket.pop(symbol, None)
                 self._last_tick_time.pop(symbol, None)
                 self._last_tick_ts.pop(symbol, None)
                 self._last_tick_wallclock.pop(symbol, None)

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -1713,35 +1713,28 @@ class MarketDataManager:
             self._ws_start_requested = False
             self._logger.exception("Failure in ws.start")
 
-    def _settle_cancelled_tick_task(
-        self, task: asyncio.Task[Any] | None, *, name: str
-    ) -> None:
-        if task is None:
-            return
-        if task.done():
-            with suppress(asyncio.CancelledError, Exception):
-                task.result()
-            return
-        try:
-            task.cancel()
-        except Exception as exc:  # noqa: BLE001
-            self._logger.debug("%s cancel raised: %s", name, exc)
-            return
-        loop = task.get_loop()
-        if loop.is_running():
+    def _capture_tick_shutdown_tasks(
+        self,
+    ) -> tuple[asyncio.Task[Any] | None, asyncio.Task[Any] | None]:
+        self._tick_drain_stopping = True
+        return self._tick_drain_task, self._tick_consumer_task
 
-            def _consume_terminal_result(done: asyncio.Task[Any]) -> None:
-                with suppress(asyncio.CancelledError, Exception):
-                    done.result()
+    def _stop_worker_threads_for_shutdown(self) -> None:
+        # Deprecated tick worker removed: only the owning asyncio loop drains ticks.
+        if self._rest_poll_thread is not None:
+            self._rest_poll_stop.set()
+            self._rest_poll_thread.join(timeout=2.0)
+            self._rest_poll_thread = None
+            self._rest_poll_stop.clear()
+        if self._health_monitor_thread is not None:
+            self._health_monitor_stop.set()
+            self._health_monitor_thread.join(timeout=2.0)
+            self._health_monitor_thread = None
+            self._health_monitor_stop.clear()
 
-            task.add_done_callback(_consume_terminal_result)
-            return
-        with suppress(asyncio.CancelledError, Exception):
-            loop.run_until_complete(asyncio.gather(task, return_exceptions=True))
-
-    def stop(self) -> None:
+    def _prepare_stop_state(self) -> bool:
         if not self._started:
-            return
+            return False
         self._started = False
         with self._ws_restart_lock:
             self._ws_restart_inflight = False
@@ -1754,24 +1747,102 @@ class MarketDataManager:
                 self._ws.stop()
             except Exception as exc:  # noqa: BLE001
                 self._logger.debug("ws.stop() raised: %s", exc)
-        self._tick_drain_stopping = True
-        tick_drain_task = self._tick_drain_task
-        tick_consumer_task = self._tick_consumer_task
+        return True
+
+    async def async_stop(self) -> None:
+        """Stop MDM and await owned asyncio tick tasks to terminal state."""
+        should_stop = self._prepare_stop_state()
+        tick_drain_task, tick_consumer_task = self._capture_tick_shutdown_tasks()
+        candle_flush_task = getattr(self, "_candle_flush_task", None)
+        tasks = [
+            task
+            for task in (tick_drain_task, tick_consumer_task, candle_flush_task)
+            if task is not None and not task.done()
+        ]
+        for task in tasks:
+            task.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+        for task in (tick_drain_task, tick_consumer_task, candle_flush_task):
+            if task is not None and task.done():
+                with suppress(asyncio.CancelledError, Exception):
+                    task.result()
         self._tick_drain_task = None
         self._tick_consumer_task = None
-        self._settle_cancelled_tick_task(tick_drain_task, name="tick drain")
-        self._settle_cancelled_tick_task(tick_consumer_task, name="tick consumer")
-        # Deprecated tick worker removed: only the owning asyncio loop drains ticks.
-        if self._rest_poll_thread is not None:
-            self._rest_poll_stop.set()
-            self._rest_poll_thread.join(timeout=2.0)
-            self._rest_poll_thread = None
-            self._rest_poll_stop.clear()
-        if self._health_monitor_thread is not None:
-            self._health_monitor_stop.set()
-            self._health_monitor_thread.join(timeout=2.0)
-            self._health_monitor_thread = None
-            self._health_monitor_stop.clear()
+        if hasattr(self, "_candle_flush_task"):
+            self._candle_flush_task = None
+        stop_fallback_worker = getattr(self, "_stop_fallback_tick_worker", None)
+        if callable(stop_fallback_worker):
+            stop_fallback_worker()
+        if should_stop:
+            self._stop_worker_threads_for_shutdown()
+
+    def _settle_cancelled_tick_task(
+        self, task: asyncio.Task[Any] | None, *, name: str
+    ) -> bool:
+        if task is None:
+            return True
+        if task.done():
+            with suppress(asyncio.CancelledError, Exception):
+                task.result()
+            return True
+        try:
+            task.cancel()
+        except Exception as exc:  # noqa: BLE001
+            self._logger.debug("%s cancel raised: %s", name, exc)
+            return False
+        loop = task.get_loop()
+        if loop.is_closed():
+            self._logger.warning(
+                "MDM_TICK_TASK_UNSETTLED_ON_CLOSED_LOOP name=%s",
+                name,
+                extra={"event": "MDM_TICK_TASK_UNSETTLED_ON_CLOSED_LOOP", "task": name},
+            )
+            return False
+        if loop.is_running():
+
+            def _consume_terminal_result(done: asyncio.Task[Any]) -> None:
+                with suppress(asyncio.CancelledError, Exception):
+                    done.result()
+
+            task.add_done_callback(_consume_terminal_result)
+            self._logger.warning(
+                "MDM_TICK_TASK_CANCEL_DEFERRED_RUNNING_LOOP name=%s",
+                name,
+                extra={
+                    "event": "MDM_TICK_TASK_CANCEL_DEFERRED_RUNNING_LOOP",
+                    "task": name,
+                },
+            )
+            return False
+        with suppress(asyncio.CancelledError, Exception):
+            loop.run_until_complete(asyncio.gather(task, return_exceptions=True))
+        return task.done()
+
+    def stop(self) -> None:
+        should_stop = self._prepare_stop_state()
+        tick_drain_task, tick_consumer_task = self._capture_tick_shutdown_tasks()
+        drain_settled = self._settle_cancelled_tick_task(
+            tick_drain_task, name="tick drain"
+        )
+        consumer_settled = self._settle_cancelled_tick_task(
+            tick_consumer_task, name="tick consumer"
+        )
+        if not drain_settled or not consumer_settled:
+            self._logger.warning(
+                "MDM_TICK_TASK_SHUTDOWN_UNSETTLED drain_settled=%s consumer_settled=%s",
+                drain_settled,
+                consumer_settled,
+                extra={
+                    "event": "MDM_TICK_TASK_SHUTDOWN_UNSETTLED",
+                    "drain_settled": drain_settled,
+                    "consumer_settled": consumer_settled,
+                },
+            )
+        self._tick_drain_task = None
+        self._tick_consumer_task = None
+        if should_stop:
+            self._stop_worker_threads_for_shutdown()
 
     def set_ws_connected(self, connected: bool) -> None:
         """Record WebSocket connectivity state for health reporting."""

--- a/src/nifty_scalper_bot/execution/position_manager.py
+++ b/src/nifty_scalper_bot/execution/position_manager.py
@@ -60,6 +60,25 @@ OrderStatus = Literal[
 ]
 
 _MIN_RECONCILE_DELAY_S = 0.5
+_EXIT_RECONCILIATION_GRACE_DEFAULT_S = 2.0
+_EXIT_RECONCILIATION_GRACE_MIN_S = 0.25
+_EXIT_RECONCILIATION_GRACE_MAX_S = 5.0
+
+
+def _resolve_exit_reconciliation_grace_seconds() -> float:
+    raw = os.getenv("EXIT_RECONCILIATION_SETTLEMENT_GRACE_SECONDS")
+    if raw is None or str(raw).strip() == "":
+        return _EXIT_RECONCILIATION_GRACE_DEFAULT_S
+    try:
+        value = float(str(raw).strip())
+    except (TypeError, ValueError):
+        return _EXIT_RECONCILIATION_GRACE_DEFAULT_S
+    if not math.isfinite(value):
+        return _EXIT_RECONCILIATION_GRACE_DEFAULT_S
+    return min(
+        _EXIT_RECONCILIATION_GRACE_MAX_S,
+        max(_EXIT_RECONCILIATION_GRACE_MIN_S, value),
+    )
 
 
 _POSITION_RECONCILE_EVENTS = Counter(
@@ -131,6 +150,7 @@ def _normalize_intent(value: object | None) -> OrderIntent:
         return cast(OrderIntent, normalized)
     return "UNKNOWN"
 
+
 def _to_int(value: object) -> int:
     """Robust integer conversion handling None and strings."""
     if value is None:
@@ -184,7 +204,7 @@ def _atomic_write_json(path: Path, payload: Mapping[str, Any]) -> None:
 
     Raises:
         None.
-        
+
     ✅ PRODUCTION FIX: Added Enum, datetime, Decimal serialization support.
     """
     import json
@@ -199,14 +219,14 @@ def _atomic_write_json(path: Path, payload: Mapping[str, Any]) -> None:
     class EnhancedJSONEncoder(json.JSONEncoder):
         def default(self, obj):
             if isinstance(obj, Enum):
-                return obj.value if hasattr(obj, 'value') else obj.name
+                return obj.value if hasattr(obj, "value") else obj.name
             if isinstance(obj, (datetime, date)):
                 return obj.isoformat()
             if isinstance(obj, Decimal):
                 return float(obj)
-            if hasattr(obj, 'to_dict'):
+            if hasattr(obj, "to_dict"):
                 return obj.to_dict()
-            if hasattr(obj, '__dict__') and not isinstance(obj, type):
+            if hasattr(obj, "__dict__") and not isinstance(obj, type):
                 return obj.__dict__
             return super().default(obj)
 
@@ -218,14 +238,14 @@ def _atomic_write_json(path: Path, payload: Mapping[str, Any]) -> None:
         elif isinstance(obj, (list, tuple)):
             return [_sanitize(item) for item in obj]
         elif isinstance(obj, Enum):
-            return obj.value if hasattr(obj, 'value') else obj.name
+            return obj.value if hasattr(obj, "value") else obj.name
         elif isinstance(obj, (datetime, date)):
             return obj.isoformat()
         elif isinstance(obj, Decimal):
             return float(obj)
-        elif hasattr(obj, 'to_dict'):
+        elif hasattr(obj, "to_dict"):
             return _sanitize(obj.to_dict())
-        elif hasattr(obj, '__dict__') and not isinstance(obj, type):
+        elif hasattr(obj, "__dict__") and not isinstance(obj, type):
             return _sanitize(vars(obj))
         return obj
 
@@ -240,8 +260,14 @@ def _atomic_write_json(path: Path, payload: Mapping[str, Any]) -> None:
 
         # Write to unique temp file with custom encoder + default=str fallback
         with open(temp_path, "w", encoding="utf-8") as f:
-            json.dump(sanitized_payload, f, indent=2, sort_keys=True, 
-                      cls=EnhancedJSONEncoder, default=str)
+            json.dump(
+                sanitized_payload,
+                f,
+                indent=2,
+                sort_keys=True,
+                cls=EnhancedJSONEncoder,
+                default=str,
+            )
             f.flush()
             os.fsync(f.fileno())  # Force flush to disk for durability
 
@@ -253,10 +279,9 @@ def _atomic_write_json(path: Path, payload: Mapping[str, Any]) -> None:
         with suppress(OSError):
             if temp_path.exists():
                 os.remove(temp_path)
-        
+
         get_logger(__name__).error("Failure in _atomic_write_json: %s", exc)
         raise
-
 
 
 @dataclass(slots=True)
@@ -289,12 +314,12 @@ class Position:
 
         # Direction logic is correct
         direction = 1 if self.side == "LONG" else -1
-        
+
         # FIX: Guard against division by zero
         notional = abs(self.entry_price * self.quantity)
         if notional == 0:
             return 0.0
-            
+
         return (self.unrealized_pnl / notional) * 100.0
 
     @property
@@ -343,8 +368,19 @@ class Position:
                 else None
             ),
             realized_pnl=float(payload.get("realized_pnl", 0.0)),
-            state=str(payload.get("state")) if payload.get("state") is not None else None,
+            state=(
+                str(payload.get("state")) if payload.get("state") is not None else None
+            ),
         )
+
+
+@dataclass(slots=True)
+class ExitSettlementGuard:
+    completed_exit_at_monotonic: float
+    grace_until_monotonic: float
+    stale_snapshot_count: int = 0
+    last_stale_quantity: int = 0
+    last_log_monotonic: float = 0.0
 
 
 @dataclass(slots=True)
@@ -506,9 +542,13 @@ class ExitLifecycleRecord:
             "expected_exit_quantity": self.expected_exit_quantity,
             "state": self.state,
             "submitted_at": self.submitted_at.isoformat(),
-            "broker_flat_at": self.broker_flat_at.isoformat() if self.broker_flat_at else None,
+            "broker_flat_at": (
+                self.broker_flat_at.isoformat() if self.broker_flat_at else None
+            ),
             "final_fill_price": self.final_fill_price,
-            "finalized_at": self.finalized_at.isoformat() if self.finalized_at else None,
+            "finalized_at": (
+                self.finalized_at.isoformat() if self.finalized_at else None
+            ),
         }
 
     @staticmethod
@@ -531,7 +571,9 @@ class ExitLifecycleRecord:
                 if payload.get("bracket_id") is not None
                 else None
             ),
-            expected_exit_side=_normalize_order_side(str(payload["expected_exit_side"])),
+            expected_exit_side=_normalize_order_side(
+                str(payload["expected_exit_side"])
+            ),
             expected_exit_quantity=_to_int(payload.get("expected_exit_quantity", 0)),
             state=str(payload.get("state") or "EXIT_PENDING"),
             submitted_at=datetime.fromisoformat(str(payload["submitted_at"])),
@@ -685,7 +727,9 @@ class Order:
                 if payload.get("linked_entry_order_id") is not None
                 else None
             ),
-            pre_order_entry_price=_to_optional_float(payload.get("pre_order_entry_price")),
+            pre_order_entry_price=_to_optional_float(
+                payload.get("pre_order_entry_price")
+            ),
             protected_quantity=_to_int(payload.get("protected_quantity", 0)),
             protection_confirmed=bool(payload.get("protection_confirmed", False)),
             protection_confirmed_at=(
@@ -866,7 +910,10 @@ class PositionManager:
         )
         self._last_reconciled_state: Dict[str, Position] = {}
         self._recently_flat_exit_until_monotonic: dict[str, float] = {}
-        self._recently_flat_exit_grace_seconds: float = 30.0
+        self._recently_flat_exit_metadata: dict[str, ExitSettlementGuard] = {}
+        self._recently_flat_exit_grace_seconds: float = (
+            _resolve_exit_reconciliation_grace_seconds()
+        )
         self._last_reconcile_attempt: datetime | None = None
         self._last_reconcile_success_at: datetime | None = None
         self._last_reconcile_error: str | None = None
@@ -1247,7 +1294,9 @@ class PositionManager:
             snapshot = decode_position_snapshot(response)
         except Exception as exc:  # noqa: BLE001
             reason = canonical(
-                "payload_invalid" if isinstance(exc, PositionSnapshotError) else "fetch_error"
+                "payload_invalid"
+                if isinstance(exc, PositionSnapshotError)
+                else "fetch_error"
             )
             self._logger.warning(
                 "Position reconciliation snapshot failed: %s",
@@ -1541,6 +1590,7 @@ class PositionManager:
         with self._lock:
             if symbol_key in self._positions:
                 raise ValueError(f"Position already exists for {symbol_key}")
+            self._clear_recent_exit_guard_locked(symbol_key)
             self._positions[symbol_key] = position
         self._logger.info("Opened %s position for %s", position.side, symbol_key)
         self.save_state()
@@ -1752,6 +1802,7 @@ class PositionManager:
             return float(self._broker_realized_pnl) - float(
                 self._session_opening_realized_baseline
             )
+
     def get_realized_pnl(self) -> float:
         """Return conservative realised P&L used by capital-protection gates."""
         with self._lock:
@@ -1837,8 +1888,7 @@ class PositionManager:
                     continue
                 if (
                     not metadata.protection_confirmed
-                    or metadata.protected_quantity
-                    < metadata.cumulative_filled_quantity
+                    or metadata.protected_quantity < metadata.cumulative_filled_quantity
                 ):
                     return "entry_protection_incomplete"
         return None
@@ -1857,13 +1907,13 @@ class PositionManager:
         signal_fingerprint: str | None = None,
     ) -> None:
         """Track a newly submitted order.
-        
+
         ✅ PRODUCTION FIX: Skip orders that have already been fully processed.
         This prevents the infinite loop where historical filled orders are
         re-added and re-processed every reconciliation cycle.
         """
         order_id = str(order_id).strip()
-        
+
         # ✅ FIX 1: Don't re-add orders that were already processed
         if (
             hasattr(self, "_terminal_orders")
@@ -1872,15 +1922,15 @@ class PositionManager:
         ):
             self._logger.debug(
                 f"Skipping add_pending_order for already-processed: {order_id}",
-                extra={"event": "order_add_skip_processed", "order_id": order_id}
+                extra={"event": "order_add_skip_processed", "order_id": order_id},
             )
             return
-        
+
         # ✅ FIX 2: Don't re-add orders that are already being tracked
         if order_id in self._orders:
             self._logger.debug(
                 f"Order already tracked, skipping: {order_id}",
-                extra={"event": "order_add_skip_existing", "order_id": order_id}
+                extra={"event": "order_add_skip_existing", "order_id": order_id},
             )
             return
 
@@ -1916,7 +1966,8 @@ class PositionManager:
             trade_lifecycle_id=bracket_id or signal_id or order_id,
             linked_entry_order_id=(
                 existing_position.order_id
-                if existing_position is not None and normalized_intent in ("EXIT", "REDUCE")
+                if existing_position is not None
+                and normalized_intent in ("EXIT", "REDUCE")
                 else None
             ),
             pre_order_entry_price=(
@@ -1944,27 +1995,27 @@ class PositionManager:
         fill_price: float | None = None,
     ) -> None:
         """Update the status of a tracked order and react to fills.
-        
+
         ✅ PRODUCTION FIX: Added guard against re-processing completed orders.
         This prevents the position thrashing loop where the same filled orders
         are processed over and over again, causing:
-        - "Opened LONG position" 
+        - "Opened LONG position"
         - "Position fully closed via order"
         to repeat infinitely.
         """
         order_id = str(order_id).strip()
-        
+
         # ✅ FIX: Initialize _processed_order_ids if not exists (backward compat)
         if not hasattr(self, "_terminal_orders"):
             self._terminal_orders = {}
             self._max_terminal_orders = 5000
-        
+
         # ✅ FIX: Skip if this order was already fully processed
         terminal_record = self._terminal_orders.get(order_id)
         if terminal_record is not None and terminal_record.lifecycle_resolved:
             self._logger.debug(
                 f"Skipping already-processed order: {order_id}",
-                extra={"event": "order_already_processed", "order_id": order_id}
+                extra={"event": "order_already_processed", "order_id": order_id},
             )
             return
         incoming_status = normalize_broker_order_status(status)
@@ -1986,13 +2037,13 @@ class PositionManager:
                 },
             )
             return
-        
+
         order = self._orders.get(order_id)
         if order is None:
             # ✅ FIX: Also skip unknown orders that might be historical
             self._logger.debug(
                 f"Attempted to update unknown order {order_id} - may be historical",
-                extra={"event": "order_update_skip_unknown", "order_id": order_id}
+                extra={"event": "order_update_skip_unknown", "order_id": order_id},
             )
             return
 
@@ -2008,7 +2059,10 @@ class PositionManager:
             order.fill_price = float(fill_price)
 
         fill_result = FillApplicationResult()
-        if order.status in ("PARTIALLY_FILLED", "FILLED") and order.fill_price is not None:
+        if (
+            order.status in ("PARTIALLY_FILLED", "FILLED")
+            and order.fill_price is not None
+        ):
             if order.filled_quantity <= 0:
                 order.filled_quantity = order.quantity
             fill_result = self._handle_filled_order(order)
@@ -2046,7 +2100,9 @@ class PositionManager:
                 protection_failure_reason=order.protection_failure_reason,
             )
             if not self._terminal_orders[order_id].lifecycle_resolved:
-                self._unresolved_terminal_orders[order_id] = self._terminal_orders[order_id]
+                self._unresolved_terminal_orders[order_id] = self._terminal_orders[
+                    order_id
+                ]
             else:
                 self._unresolved_terminal_orders.pop(order_id, None)
             self._logger.debug(
@@ -2054,8 +2110,9 @@ class PositionManager:
                 extra={
                     "event": "order_terminal_recorded",
                     "order_id": order_id,
-                    "lifecycle_applied": fill_result.position_applied or fill_result.pnl_applied,
-                }
+                    "lifecycle_applied": fill_result.position_applied
+                    or fill_result.pnl_applied,
+                },
             )
             self._evict_old_terminal_orders()
 
@@ -2091,9 +2148,9 @@ class PositionManager:
                     or broker_payload.get("fill_price")
                     or broker_payload.get("price")
                 )
-                filled_qty = broker_payload.get("filled_quantity") or broker_payload.get(
-                    "filled"
-                )
+                filled_qty = broker_payload.get(
+                    "filled_quantity"
+                ) or broker_payload.get("filled")
                 if order is not None and filled_qty is not None:
                     with suppress(Exception):
                         order.filled_quantity = int(float(filled_qty))
@@ -2187,7 +2244,9 @@ class PositionManager:
         """Persist one coherent positions/orders snapshot to disk."""
         with self._lock:
             state = {
-                "positions": [position.to_dict() for position in self._positions.values()],
+                "positions": [
+                    position.to_dict() for position in self._positions.values()
+                ],
                 "orders": [order.to_dict() for order in self._orders.values()],
                 "terminal_orders": {
                     order_id: metadata.to_dict()
@@ -2557,11 +2616,12 @@ class PositionManager:
             try:
                 return int(float(value))
             except (TypeError, ValueError) as exc:
-                raise ValueError(f"invalid broker quantity field {key}={value!r}") from exc
+                raise ValueError(
+                    f"invalid broker quantity field {key}={value!r}"
+                ) from exc
         if not found:
             raise ValueError("broker position quantity field missing")
         raise ValueError("broker position quantity is null or invalid")
-    
 
     def synchronize_with_broker(
         self, broker_positions: Sequence[Mapping[str, object]]
@@ -2599,7 +2659,7 @@ class PositionManager:
             snapshot_symbols = {row.symbol for row in snapshot.rows}
             for recent_symbol in list(self._recently_flat_exit_until_monotonic):
                 if recent_symbol not in snapshot_symbols:
-                    self._recently_flat_exit_until_monotonic.pop(recent_symbol, None)
+                    self._clear_recent_exit_guard_locked(recent_symbol)
             for row in snapshot.rows:
                 record = row.raw
                 symbol = row.symbol
@@ -2614,26 +2674,16 @@ class PositionManager:
                         )
                     continue
                 quantity = row.quantity
-                realized_pnl = get_float(
-                    record, ("realised", "realized"), default=0.0
-                )
+                realized_pnl = get_float(record, ("realised", "realized"), default=0.0)
                 if "realised" in record or "realized" in record:
                     snapshot_realized_seen = True
                     snapshot_realized_pnl += realized_pnl
                 if quantity == 0:
-                    self._recently_flat_exit_until_monotonic.pop(symbol, None)
+                    self._clear_recent_exit_guard_locked(symbol)
                     continue
-                if self._should_ignore_recent_exit_stale_snapshot_locked(symbol):
-                    self._logger.info(
-                        "POSITION_SYNC_STALE_AFTER_EXIT_IGNORED symbol=%s qty=%s",
-                        symbol,
-                        quantity,
-                        extra={
-                            "event": "POSITION_SYNC_STALE_AFTER_EXIT_IGNORED",
-                            "symbol": symbol,
-                            "broker_quantity": quantity,
-                        },
-                    )
+                if self._should_ignore_recent_exit_stale_snapshot_locked(
+                    symbol, quantity
+                ):
                     continue
                 side: Side = "LONG" if quantity > 0 else "SHORT"
                 abs_quantity = abs(quantity)
@@ -3196,12 +3246,20 @@ class PositionManager:
             return FillApplicationResult(reason="non_incremental_cumulative_quantity")
 
         cumulative_avg = order.fill_price
-        if cumulative_avg is None or not math.isfinite(float(cumulative_avg)) or float(cumulative_avg) <= 0:
-            self._logger.warning("Missing/invalid cumulative fill price for order %s", order.order_id)
+        if (
+            cumulative_avg is None
+            or not math.isfinite(float(cumulative_avg))
+            or float(cumulative_avg) <= 0
+        ):
+            self._logger.warning(
+                "Missing/invalid cumulative fill price for order %s", order.order_id
+            )
             return FillApplicationResult(reason="invalid_cumulative_average_price")
 
         new_cumulative_notional = cumulative_qty * float(cumulative_avg)
-        delta_notional = new_cumulative_notional - float(order.applied_cumulative_notional or 0.0)
+        delta_notional = new_cumulative_notional - float(
+            order.applied_cumulative_notional or 0.0
+        )
         if delta_notional <= 0 or not math.isfinite(delta_notional):
             self._logger.warning(
                 "Ignoring invalid cumulative notional for order %s", order.order_id
@@ -3209,7 +3267,9 @@ class PositionManager:
             return FillApplicationResult(reason="invalid_cumulative_notional")
         fill_price = delta_notional / qty
         if not math.isfinite(fill_price) or fill_price <= 0:
-            self._logger.warning("Invalid delta fill price for order %s", order.order_id)
+            self._logger.warning(
+                "Invalid delta fill price for order %s", order.order_id
+            )
             return FillApplicationResult(reason="invalid_delta_fill_price")
 
         side = order.side
@@ -3264,7 +3324,9 @@ class PositionManager:
                 lifecycle = self._exit_lifecycles.get(order.order_id)
                 if lifecycle is not None:
                     lifecycle.final_fill_price = float(cumulative_avg)
-                    lifecycle.state = "EXIT_FINALIZED" if is_terminal else "EXIT_PARTIALLY_FILLED"
+                    lifecycle.state = (
+                        "EXIT_FINALIZED" if is_terminal else "EXIT_PARTIALLY_FILLED"
+                    )
                     if is_terminal:
                         lifecycle.finalized_at = _now()
                 mark_applied()
@@ -3277,7 +3339,11 @@ class PositionManager:
                     lifecycle_resolved=is_terminal,
                     quantity_delta=qty,
                     delta_fill_price=fill_price,
-                    reason="exit_fill_finalized_after_broker_flat" if is_terminal else "exit_partial_after_broker_flat",
+                    reason=(
+                        "exit_fill_finalized_after_broker_flat"
+                        if is_terminal
+                        else "exit_partial_after_broker_flat"
+                    ),
                 )
 
             if intent not in ("ENTRY", "SCALE_IN", "REVERSAL"):
@@ -3354,7 +3420,9 @@ class PositionManager:
                     lifecycle_resolved=True,
                 )
                 paired_qty = min(qty, abs(int(paired_exit.cumulative_filled_quantity)))
-                realized = (float(paired_exit.average_fill_price) - fill_price) * paired_qty
+                realized = (
+                    float(paired_exit.average_fill_price) - fill_price
+                ) * paired_qty
                 self._local_realized_pnl += realized
                 with self._lock:
                     self._refresh_realized_pnl_locked()
@@ -3411,9 +3479,8 @@ class PositionManager:
             )
 
         position = self._positions[symbol_key]
-        entry_side_matches = (
-            (position.side == "LONG" and side == "BUY")
-            or (position.side == "SHORT" and side == "SELL")
+        entry_side_matches = (position.side == "LONG" and side == "BUY") or (
+            position.side == "SHORT" and side == "SELL"
         )
         if intent in ("ENTRY", "SCALE_IN", "REVERSAL") and entry_side_matches:
             expected_post_fill_qty = int(order.pre_order_quantity or 0) + cumulative_qty
@@ -3481,7 +3548,9 @@ class PositionManager:
             lifecycle = self._exit_lifecycles.get(order.order_id)
             if lifecycle is not None:
                 lifecycle.final_fill_price = float(cumulative_avg)
-                lifecycle.state = "EXIT_FINALIZED" if is_terminal else "EXIT_PARTIALLY_FILLED"
+                lifecycle.state = (
+                    "EXIT_FINALIZED" if is_terminal else "EXIT_PARTIALLY_FILLED"
+                )
                 if is_terminal:
                     lifecycle.finalized_at = _now()
             mark_applied()
@@ -3579,27 +3648,78 @@ class PositionManager:
             )
 
     def _mark_recent_exit_flat_locked(self, symbol: str) -> None:
-        """Remember symbols just flattened by exit fill."""
+        """Remember symbols just flattened by exit fill with a fixed deadline."""
         if not hasattr(self, "_recently_flat_exit_until_monotonic"):
             self._recently_flat_exit_until_monotonic = {}
-        grace = float(getattr(self, "_recently_flat_exit_grace_seconds", 30.0) or 30.0)
-        self._recently_flat_exit_until_monotonic[symbol.upper()] = (
-            time.monotonic() + grace
+        if not hasattr(self, "_recently_flat_exit_metadata"):
+            self._recently_flat_exit_metadata = {}
+        key = symbol.upper()
+        now = time.monotonic()
+        grace = float(
+            getattr(
+                self,
+                "_recently_flat_exit_grace_seconds",
+                _EXIT_RECONCILIATION_GRACE_DEFAULT_S,
+            )
+            or _EXIT_RECONCILIATION_GRACE_DEFAULT_S
+        )
+        until = now + grace
+        self._recently_flat_exit_until_monotonic[key] = until
+        self._recently_flat_exit_metadata[key] = ExitSettlementGuard(
+            completed_exit_at_monotonic=now,
+            grace_until_monotonic=until,
         )
 
-    def _should_ignore_recent_exit_stale_snapshot_locked(self, symbol: str) -> bool:
+    def _clear_recent_exit_guard_locked(self, symbol: str) -> None:
+        key = symbol.upper()
+        if hasattr(self, "_recently_flat_exit_until_monotonic"):
+            self._recently_flat_exit_until_monotonic.pop(key, None)
+        if hasattr(self, "_recently_flat_exit_metadata"):
+            self._recently_flat_exit_metadata.pop(key, None)
+
+    def _should_ignore_recent_exit_stale_snapshot_locked(
+        self, symbol: str, quantity: int
+    ) -> bool:
         """Return true for a non-zero broker row that conflicts with a recent exit."""
         if symbol.upper() in self._positions:
             return False
         if not hasattr(self, "_recently_flat_exit_until_monotonic"):
             self._recently_flat_exit_until_monotonic = {}
+        if not hasattr(self, "_recently_flat_exit_metadata"):
+            self._recently_flat_exit_metadata = {}
         key = symbol.upper()
         until = self._recently_flat_exit_until_monotonic.get(key)
         if until is None:
             return False
-        if time.monotonic() > float(until):
-            self._recently_flat_exit_until_monotonic.pop(key, None)
+        now = time.monotonic()
+        if now > float(until):
+            self._clear_recent_exit_guard_locked(key)
             return False
+        guard = self._recently_flat_exit_metadata.get(key)
+        if guard is None:
+            guard = ExitSettlementGuard(
+                completed_exit_at_monotonic=now, grace_until_monotonic=float(until)
+            )
+            self._recently_flat_exit_metadata[key] = guard
+        guard.stale_snapshot_count += 1
+        guard.last_stale_quantity = int(quantity)
+        grace_remaining = max(0.0, float(until) - now)
+        if guard.last_log_monotonic <= 0.0 or now - guard.last_log_monotonic >= 1.0:
+            guard.last_log_monotonic = now
+            self._logger.info(
+                "POSITION_SYNC_DEFERRED_AFTER_EXIT symbol=%s qty=%s remaining=%.3f stale_count=%s",
+                key,
+                quantity,
+                grace_remaining,
+                guard.stale_snapshot_count,
+                extra={
+                    "event": "POSITION_SYNC_DEFERRED_AFTER_EXIT",
+                    "symbol": key,
+                    "broker_quantity": quantity,
+                    "grace_remaining_s": grace_remaining,
+                    "stale_snapshot_count": guard.stale_snapshot_count,
+                },
+            )
         return True
 
     @staticmethod

--- a/src/nifty_scalper_bot/execution/position_manager.py
+++ b/src/nifty_scalper_bot/execution/position_manager.py
@@ -3707,7 +3707,8 @@ class PositionManager:
         if guard.last_log_monotonic <= 0.0 or now - guard.last_log_monotonic >= 1.0:
             guard.last_log_monotonic = now
             self._logger.info(
-                "POSITION_SYNC_DEFERRED_AFTER_EXIT symbol=%s qty=%s remaining=%.3f stale_count=%s",
+                "POSITION_SYNC_DEFERRED_AFTER_EXIT symbol=%s qty=%s "
+                "remaining=%.3f stale_count=%s",
                 key,
                 quantity,
                 grace_remaining,

--- a/tests/architecture/test_history_ownership.py
+++ b/tests/architecture/test_history_ownership.py
@@ -490,10 +490,10 @@ async def test_mdm_readiness_requires_tradable_quote_and_canonical_bars() -> Non
 
 
 async def test_mdm_poll_quote_does_not_fabricate_completed_candles() -> None:
-    src = _func_source(SRC / "data" / "market_data_manager.py", "_process_poll_quote")
-    assert (
-        "Deprecated: REST fallback quotes must not fabricate completed candles" in src
-    )
+    text = _read_text(SRC / "data" / "market_data_manager.py")
+    src = _func_source(SRC / "data" / "market_data_manager.py", "ingest_rest_quote")
+    assert "_process_poll_quote" not in text
+    assert "_emit_poll_candle" not in text
     assert "_last_cumulative_volume_by_symbol" not in src
     assert "ingest_historical_ohlc" not in src
 

--- a/tests/core/test_shutdown_sequence_safe.py
+++ b/tests/core/test_shutdown_sequence_safe.py
@@ -14,7 +14,7 @@ class Ctx:
     market_data_manager = Dummy()
     position_manager = Dummy()
     persistent_state = Dummy()
-    config = type('Cfg', (), {'close_positions_on_shutdown': False})()
+    config = type("Cfg", (), {"close_positions_on_shutdown": False})()
     streamer = Dummy()
 
 
@@ -22,3 +22,22 @@ class Ctx:
 async def test_shutdown_sequence_no_proc():
     ctx = Ctx()
     await shutdown_sequence(ctx)
+
+
+@pytest.mark.asyncio
+async def test_shutdown_sequence_awaits_market_data_manager_async_stop_first():
+    calls = []
+
+    class MDM:
+        async def async_stop(self):
+            calls.append("async_stop")
+
+        def stop(self):
+            calls.append("stop")
+
+    ctx = Ctx()
+    ctx.market_data_manager = MDM()
+
+    await shutdown_sequence(ctx)
+
+    assert calls == ["async_stop"]

--- a/tests/data/test_candle_engine_ssot_static_audit.py
+++ b/tests/data/test_candle_engine_ssot_static_audit.py
@@ -61,12 +61,13 @@ def test_production_candle_engine_instantiation_is_limited_to_mdm_owner() -> Non
 
 def test_rest_poll_path_does_not_construct_completed_ohlc_candle() -> None:
     text = (SRC_ROOT / "data" / "market_data_manager.py").read_text(encoding="utf-8")
-    process_body = re.search(
-        r"def _process_poll_quote\(.*?\n    def _emit_poll_candle", text, re.S
+    ingest_body = re.search(
+        r"def ingest_rest_quote\(.*?\n    def ingest_historical_bar", text, re.S
     )
-    assert process_body is not None
-    assert "open" not in process_body.group(0)
-    assert "ingest_historical_ohlc" not in process_body.group(0)
+    assert ingest_body is not None
+    assert "_process_poll_quote" not in text
+    assert "_emit_poll_candle" not in text
+    assert "ingest_historical_ohlc" not in ingest_body.group(0)
     assert "POLL CANDLE EMITTED" not in text
 
 

--- a/tests/data/test_mdm_queue_watermark_hydration.py
+++ b/tests/data/test_mdm_queue_watermark_hydration.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import threading
 from collections import defaultdict, deque
 from datetime import datetime, timezone
 from types import SimpleNamespace
@@ -31,7 +32,7 @@ def _storage_mdm() -> MarketDataManager:
         error=lambda *a, **k: None,
         debug=lambda *a, **k: None,
     )
-    mdm._lock = None
+    mdm._lock = threading.RLock()
     mdm._cache_len = 100
     mdm._ohlc = defaultdict(lambda: deque(maxlen=100))
     mdm._engines = {}
@@ -170,3 +171,64 @@ def test_sync_drain_task_done_runs_when_processing_raises() -> None:
     with pytest.raises(RuntimeError):
         mdm._drain_tick_queue_sync()
     assert mdm._tick_queue._unfinished_tasks == 0
+
+
+def test_watermark_updates_metrics_under_lock_without_lost_retained_count() -> None:
+    mdm = _storage_mdm()
+    engine = mdm.get_candle_engine(SYMBOL)
+    engine.import_history(
+        pd.DataFrame(
+            [
+                {
+                    "timestamp": datetime(2026, 1, 1, 9, 15, tzinfo=timezone.utc),
+                    "open": 1.0,
+                    "high": 1.0,
+                    "low": 1.0,
+                    "close": 1.0,
+                    "volume": 1,
+                }
+            ]
+        )
+    )
+    mdm._tick_queue.put_nowait(_tick("queued", SYMBOL, 16))
+
+    mdm._record_queue_watermark_after_hydration(SYMBOL)
+    mdm._record_queue_watermark_after_hydration(SYMBOL)
+
+    assert mdm._candle_queue_watermarks[SYMBOL] == pd.Timestamp(
+        datetime(2026, 1, 1, 9, 15, tzinfo=timezone.utc)
+    )
+    assert mdm._candle_metrics["queued_ticks_retained_after_hydration"] == 2
+
+
+def test_watermark_read_is_symbol_specific_and_canonicalized() -> None:
+    mdm = _storage_mdm()
+    mdm._canonical_symbol = lambda s: s.upper()
+    mdm._candle_queue_watermarks[SYMBOL] = pd.Timestamp(
+        datetime(2026, 1, 1, 9, 16, tzinfo=timezone.utc)
+    )
+    mdm._candle_queue_watermarks[OTHER_SYMBOL] = pd.Timestamp(
+        datetime(2026, 1, 1, 9, 10, tzinfo=timezone.utc)
+    )
+
+    assert mdm._queued_tick_at_or_before_watermark(_tick("a", SYMBOL.lower(), 16))
+    assert not mdm._queued_tick_at_or_before_watermark(_tick("b", OTHER_SYMBOL, 16))
+
+
+@pytest.mark.asyncio
+async def test_stop_settles_running_tick_tasks_without_pending_task_warning() -> None:
+    mdm = MarketDataManager(broker=None, websocket=None, settings={})
+    loop = asyncio.get_running_loop()
+    mdm._started = True
+
+    async def wait_forever() -> None:
+        await asyncio.Event().wait()
+
+    mdm._tick_drain_task = loop.create_task(wait_forever())
+    mdm._tick_consumer_task = loop.create_task(wait_forever())
+
+    mdm.stop()
+    await asyncio.sleep(0)
+
+    assert mdm._tick_drain_task is None
+    assert mdm._tick_consumer_task is None

--- a/tests/data/test_mdm_queue_watermark_hydration.py
+++ b/tests/data/test_mdm_queue_watermark_hydration.py
@@ -50,8 +50,7 @@ async def _run_consumer_until_join(mdm: MarketDataManager) -> None:
     consumer = asyncio.create_task(mdm._consume_ticks())
     await asyncio.wait_for(mdm._tick_queue.join(), timeout=1.0)
     consumer.cancel()
-    with pytest.raises(asyncio.CancelledError):
-        await consumer
+    await asyncio.gather(consumer, return_exceptions=True)
 
 
 @pytest.mark.asyncio
@@ -114,8 +113,7 @@ async def test_concurrent_producer_has_no_tick_loss_or_reorder() -> None:
     mdm._tick_queue.put_nowait(_tick("producer-new", SYMBOL, 17))
     await asyncio.wait_for(mdm._tick_queue.join(), timeout=1.0)
     consumer.cancel()
-    with pytest.raises(asyncio.CancelledError):
-        await consumer
+    await asyncio.gather(consumer, return_exceptions=True)
 
     assert processed == ["same-symbol-new", "other-stale-minute", "producer-new"]
     assert mdm._tick_queue._unfinished_tasks == mdm._tick_queue.qsize() == 0
@@ -232,3 +230,101 @@ async def test_stop_settles_running_tick_tasks_without_pending_task_warning() ->
 
     assert mdm._tick_drain_task is None
     assert mdm._tick_consumer_task is None
+
+
+@pytest.mark.asyncio
+async def test_async_stop_awaits_tick_tasks_and_clears_references() -> None:
+    mdm = MarketDataManager(broker=None, websocket=None, settings={})
+    loop = asyncio.get_running_loop()
+    mdm._started = True
+    task_exits: list[str] = []
+
+    async def wait_forever(name: str) -> None:
+        try:
+            await asyncio.Event().wait()
+        finally:
+            task_exits.append(name)
+
+    drain_task = loop.create_task(wait_forever("drain"))
+    consumer_task = loop.create_task(wait_forever("consumer"))
+    mdm._tick_drain_task = drain_task
+    mdm._tick_consumer_task = consumer_task
+    await asyncio.sleep(0)
+
+    await mdm.async_stop()
+
+    assert sorted(task_exits) == ["consumer", "drain"]
+    assert drain_task.done()
+    assert consumer_task.done()
+    assert mdm._tick_drain_task is None
+    assert mdm._tick_consumer_task is None
+
+
+@pytest.mark.asyncio
+async def test_async_stop_is_idempotent_and_leaves_no_pending_mdm_task() -> None:
+    mdm = MarketDataManager(broker=None, websocket=None, settings={})
+    loop = asyncio.get_running_loop()
+    mdm._started = True
+
+    async def wait_forever() -> None:
+        await asyncio.Event().wait()
+
+    drain_task = loop.create_task(wait_forever())
+    consumer_task = loop.create_task(wait_forever())
+    mdm._tick_drain_task = drain_task
+    mdm._tick_consumer_task = consumer_task
+
+    await mdm.async_stop()
+    await mdm.async_stop()
+    await asyncio.sleep(0)
+
+    assert drain_task.done()
+    assert consumer_task.done()
+    assert not [task for task in (drain_task, consumer_task) if not task.done()]
+
+
+@pytest.mark.asyncio
+async def test_async_stop_does_not_block_or_close_running_loop() -> None:
+    mdm = MarketDataManager(broker=None, websocket=None, settings={})
+    loop = asyncio.get_running_loop()
+    mdm._started = True
+
+    async def wait_forever() -> None:
+        await asyncio.Event().wait()
+
+    mdm._tick_drain_task = loop.create_task(wait_forever())
+    mdm._tick_consumer_task = loop.create_task(wait_forever())
+
+    await asyncio.wait_for(mdm.async_stop(), timeout=1.0)
+
+    assert loop.is_running()
+    assert not loop.is_closed()
+
+
+@pytest.mark.asyncio
+async def test_async_stop_produces_no_mdm_task_destroyed_pending_warning() -> None:
+    mdm = MarketDataManager(broker=None, websocket=None, settings={})
+    loop = asyncio.get_running_loop()
+    mdm._started = True
+    contexts: list[dict] = []
+    previous_handler = loop.get_exception_handler()
+    loop.set_exception_handler(lambda _loop, context: contexts.append(context))
+
+    async def wait_forever() -> None:
+        await asyncio.Event().wait()
+
+    mdm._tick_drain_task = loop.create_task(wait_forever())
+    mdm._tick_consumer_task = loop.create_task(wait_forever())
+    mdm._candle_flush_task = loop.create_task(wait_forever())
+    try:
+        await mdm.async_stop()
+        await asyncio.sleep(0)
+    finally:
+        loop.set_exception_handler(previous_handler)
+
+    assert mdm._candle_flush_task is None
+    assert not [
+        context
+        for context in contexts
+        if "Task was destroyed but it is pending" in str(context.get("message"))
+    ]

--- a/tests/data/test_mdm_rest_fallback_tick_path.py
+++ b/tests/data/test_mdm_rest_fallback_tick_path.py
@@ -19,9 +19,7 @@ def _manager(*, token: bool = True) -> MarketDataManager:
 def test_ingest_rest_quote_without_token_enters_candle_engine_once() -> None:
     mdm = _manager(token=False)
     engine = mdm.get_candle_engine(SYMBOL)
-    mdm._process_poll_quote = lambda *_a, **_k: (_ for _ in ()).throw(  # type: ignore[method-assign]
-        AssertionError("poll candle fabrication path must not be called")
-    )
+    assert not hasattr(mdm, "_process_poll_quote")
     mdm._enqueue_tick_threadsafe = lambda tick: mdm._process_queued_tick(tick)  # type: ignore[method-assign]
 
     mdm.ingest_rest_quote(SYMBOL, {"last_price": 100.0, "timestamp": TS})

--- a/tests/execution/test_exit_reconciliation_race.py
+++ b/tests/execution/test_exit_reconciliation_race.py
@@ -174,3 +174,118 @@ def test_terminal_exit_order_not_pending_for_bracket_ghost_or_orphan(tmp_path) -
     assert bm.is_symbol_managed(SYMBOL) is False
     assert bm.get_bracket("entry-1") is None
     assert bm.get_bracket(f"orphan_{SYMBOL}") is None
+
+
+def test_exit_reconciliation_grace_configuration(monkeypatch) -> None:
+    from nifty_scalper_bot.execution import position_manager as module
+
+    monkeypatch.delenv("EXIT_RECONCILIATION_SETTLEMENT_GRACE_SECONDS", raising=False)
+    assert module._resolve_exit_reconciliation_grace_seconds() == 2.0
+    monkeypatch.setenv("EXIT_RECONCILIATION_SETTLEMENT_GRACE_SECONDS", "bad")
+    assert module._resolve_exit_reconciliation_grace_seconds() == 2.0
+    monkeypatch.setenv("EXIT_RECONCILIATION_SETTLEMENT_GRACE_SECONDS", "nan")
+    assert module._resolve_exit_reconciliation_grace_seconds() == 2.0
+    monkeypatch.setenv("EXIT_RECONCILIATION_SETTLEMENT_GRACE_SECONDS", "0.1")
+    assert module._resolve_exit_reconciliation_grace_seconds() == 0.25
+    monkeypatch.setenv("EXIT_RECONCILIATION_SETTLEMENT_GRACE_SECONDS", "10")
+    assert module._resolve_exit_reconciliation_grace_seconds() == 5.0
+
+
+def _broker_row(quantity: int = QTY) -> dict[str, Any]:
+    return {
+        "symbol": SYMBOL,
+        "quantity": quantity,
+        "average_price": 100.0,
+        "last_price": 120.0,
+        "product": "MIS",
+    }
+
+
+def test_repeated_stale_snapshots_do_not_extend_fixed_exit_deadline(tmp_path) -> None:
+    pm = _position_manager(tmp_path)
+    pm._recently_flat_exit_grace_seconds = 1.0
+    pm.update_order_status("exit-1", "FILLED", 120.0)
+    first_deadline = pm._recently_flat_exit_until_monotonic[SYMBOL]
+
+    pm.synchronize_with_broker([_broker_row()])
+    pm.synchronize_with_broker([_broker_row()])
+
+    assert pm.get_position(SYMBOL) is None
+    assert pm._recently_flat_exit_until_monotonic[SYMBOL] == first_deadline
+    guard = pm._recently_flat_exit_metadata[SYMBOL]
+    assert guard.stale_snapshot_count == 2
+    assert guard.last_stale_quantity == QTY
+
+
+def test_zero_or_missing_snapshot_clears_exit_guard(tmp_path) -> None:
+    pm = _position_manager(tmp_path)
+    pm.update_order_status("exit-1", "FILLED", 120.0)
+
+    pm.synchronize_with_broker([_broker_row(0)])
+    assert SYMBOL not in pm._recently_flat_exit_until_monotonic
+    assert SYMBOL not in pm._recently_flat_exit_metadata
+
+    pm = _position_manager(tmp_path / "second")
+    pm.update_order_status("exit-1", "FILLED", 120.0)
+    pm.synchronize_with_broker([])
+    assert SYMBOL not in pm._recently_flat_exit_until_monotonic
+    assert SYMBOL not in pm._recently_flat_exit_metadata
+
+
+def test_persistent_non_zero_position_is_restored_after_exit_grace_expiry(
+    tmp_path,
+) -> None:
+    pm = _position_manager(tmp_path)
+    pm._recently_flat_exit_grace_seconds = 0.25
+    pm.update_order_status("exit-1", "FILLED", 120.0)
+    pm._recently_flat_exit_until_monotonic[SYMBOL] = 0.0
+    pm._recently_flat_exit_metadata[SYMBOL].grace_until_monotonic = 0.0
+
+    pm.synchronize_with_broker([_broker_row()])
+
+    restored = pm.get_position(SYMBOL)
+    assert restored is not None
+    assert restored.quantity == QTY
+    assert SYMBOL not in pm._recently_flat_exit_until_monotonic
+
+
+def test_new_entry_clears_old_exit_guard(tmp_path) -> None:
+    pm = _position_manager(tmp_path)
+    pm.update_order_status("exit-1", "FILLED", 120.0)
+
+    pm.open_position(SYMBOL, "LONG", QTY, 121.0, order_id="entry-2")
+
+    assert SYMBOL not in pm._recently_flat_exit_until_monotonic
+    assert SYMBOL not in pm._recently_flat_exit_metadata
+    assert pm.get_position(SYMBOL) is not None
+
+
+def test_partial_exit_does_not_create_flat_guard(tmp_path) -> None:
+    pm = PositionManager(str(tmp_path / "positions.json"))
+    pm.open_position(SYMBOL, "LONG", QTY * 2, 100.0, order_id="entry-1")
+    pm.add_pending_order(
+        "exit-partial",
+        SYMBOL,
+        "SELL",
+        QTY,
+        120.0,
+        "MARKET",
+        intent="REDUCE",
+        bracket_id="entry-1",
+    )
+
+    pm.update_order_status("exit-partial", "FILLED", 120.0)
+
+    assert pm.get_position(SYMBOL) is not None
+    assert SYMBOL not in pm._recently_flat_exit_until_monotonic
+
+
+def test_duplicate_terminal_callbacks_remain_idempotent(tmp_path) -> None:
+    pm = _position_manager(tmp_path)
+
+    pm.update_order_status("exit-1", "FILLED", 120.0)
+    pm.update_order_status("exit-1", "FILLED", 120.0)
+
+    assert pm.get_position(SYMBOL) is None
+    assert pm.unresolved_terminal_summary()["count"] == 0
+    assert pm._terminal_orders["exit-1"].lifecycle_applied is True

--- a/tests/execution/test_exit_reconciliation_race.py
+++ b/tests/execution/test_exit_reconciliation_race.py
@@ -289,3 +289,41 @@ def test_duplicate_terminal_callbacks_remain_idempotent(tmp_path) -> None:
     assert pm.get_position(SYMBOL) is None
     assert pm.unresolved_terminal_summary()["count"] == 0
     assert pm._terminal_orders["exit-1"].lifecycle_applied is True
+
+
+def test_persistent_position_after_grace_gets_orphan_protection(tmp_path) -> None:
+    pm = _position_manager(tmp_path)
+    bm = _bracket_manager()
+    pm._recently_flat_exit_grace_seconds = 0.25
+
+    pm.update_order_status("exit-1", "FILLED", 120.0)
+    bm.reconcile_symbol_flat(SYMBOL)
+    pm.synchronize_with_broker([_broker_row()])
+    assert pm.get_position(SYMBOL) is None
+    assert bm.is_symbol_managed(SYMBOL) is False
+
+    pm._recently_flat_exit_until_monotonic[SYMBOL] = 0.0
+    pm._recently_flat_exit_metadata[SYMBOL].grace_until_monotonic = 0.0
+    pm.synchronize_with_broker([_broker_row()])
+    restored = pm.get_position(SYMBOL)
+    assert restored is not None
+    assert restored.quantity == QTY
+
+    runner = StrategyRunner.__new__(StrategyRunner)
+    runner._position_manager = pm
+    runner._bracket_manager = bm
+    runner._active_orphan_guards = set()
+    runner._orphan_retry_count = {}
+    runner._orphan_retry_last_attempt = {}
+    runner._logger = SimpleNamespace(
+        debug=lambda *a, **k: None,
+        info=lambda *a, **k: None,
+        warning=lambda *a, **k: None,
+        error=lambda *a, **k: None,
+        exception=lambda *a, **k: None,
+    )
+
+    runner._adopt_orphan_positions()
+
+    assert bm.is_symbol_managed(SYMBOL) is True
+    assert bm.get_bracket(f"orphan_{SYMBOL}") is not None

--- a/tests/test_mdm_event_loop_consumer.py
+++ b/tests/test_mdm_event_loop_consumer.py
@@ -23,13 +23,12 @@ def test_set_event_loop_starts_consumer_after_started_flag() -> None:
         time.sleep(0.05)
         mdm.set_event_loop(loop)
         time.sleep(0.2)
-        task = getattr(mdm, '_tick_consumer_task', None)
+        task = getattr(mdm, "_tick_consumer_task", None)
         assert task is not None
         assert not task.done()
     finally:
-        task = getattr(mdm, '_tick_consumer_task', None)
-        if task is not None:
-            loop.call_soon_threadsafe(task.cancel)
+        future = asyncio.run_coroutine_threadsafe(mdm.async_stop(), loop)
+        future.result(timeout=1.0)
         loop.call_soon_threadsafe(loop.stop)
         thread.join(timeout=1.0)
         loop.close()


### PR DESCRIPTION
### Motivation
- Prevent stale broker snapshots from reopening flat positions by introducing a validated, short exit-settlement grace and per-symbol settlement guards so reconciliation remains deterministic and cannot be extended by repeated stale snapshots.
- Make MDM projection and watermark updates atomic and canonicalized to avoid lost metrics, incorrect stale-tick purges, and subtle divergence accounting races between threads and async consumers.
- Ensure safe shutdown of asynchronous MDM tick tasks to avoid pending/destroyed-task warnings and avoid closing externally owned event loops while preserving production single-threaded event-loop ownership.

### Description
- Replace the hardcoded exit-grace with a validated resolver `_resolve_exit_reconciliation_grace_seconds()` and constants (`_EXIT_RECONCILIATION_GRACE_DEFAULT_S = 2.0`, `_EXIT_RECONCILIATION_GRACE_MIN_S = 0.25`, `_EXIT_RECONCILIATION_GRACE_MAX_S = 5.0`) and add `ExitSettlementGuard` per-symbol metadata; update `PositionManager` reconciliation and lifecycle logic to establish a fixed deadline on a completed exit, increment stale-snapshot counters without renewing the deadline, clear the guard on zero/missing snapshots, and clear old guards when a new entry is opened (changes in src/nifty_scalper_bot/execution/position_manager.py).
- Remove obsolete REST poll candle production state and deprecated methods (`_poll_bar_state`, `_last_poll_bucket`, `_process_poll_quote`, `_emit_poll_candle`) and keep REST fallback quote path as tick-only while preserving CandleEngine ownership (changes in src/nifty_scalper_bot/data/market_data_manager.py and updated static checks/tests).
- Harden MDM watermark locking by sampling queue size outside the lock and updating `_candle_queue_watermarks` and associated metrics together under `self._lock`, and make `_queued_tick_at_or_before_watermark()` canonicalize the symbol and read the specific watermark inside the lock only; also compute projection fingerprints, lag and projection rows outside the lock then atomically update `_ohlc`, projection metrics and per-symbol diagnostics in one short locked section (changes in src/nifty_scalper_bot/data/market_data_manager.py).
- Implement safe cancellation settlement for `_tick_drain_task` and `_tick_consumer_task` in `MarketDataManager.stop()` via `_settle_cancelled_tick_task()` that cancels captured tasks and either settles them by running `gather` on non-running loops or attaches a done-callback when the loop is running; add focused tests and test updates to reflect removed/deprecated code and new behavior (tests modified/added under tests/execution and tests/data).
- Files touched: src/nifty_scalper_bot/execution/position_manager.py, src/nifty_scalper_bot/data/market_data_manager.py, tests/execution/test_exit_reconciliation_race.py, tests/data/test_mdm_queue_watermark_hydration.py, tests/data/test_mdm_rest_fallback_tick_path.py, tests/data/test_candle_engine_ssot_static_audit.py, tests/architecture/test_history_ownership.py.
- Base SHA: 5a4d0f52edb044a0be36fe397e38ba21b7238897; Branch head SHA: 59a11442f9cbc49f7b4016afa1431d276071977a.

### Testing
- `python -m compileall -q src dashboard tests` completed successfully and `black --check` on changed files passed.  
- `ruff check` against the touched files reported pre-existing file-level lint debt (E501/F841/I001) in large modules; the new edits were formatted with `black` but repository-wide ruff issues remain (reported).  
- Focused pytest runs: `pytest tests/execution/test_exit_reconciliation_race.py -q` passed, `pytest tests/data/test_mdm_queue_watermark_hydration.py -q` passed, `pytest tests/data/test_mdm_history_import_result_contract.py -q` passed, `pytest tests/data/test_mdm_rest_fallback_tick_path.py -q` passed, and `pytest tests/data/test_candle_engine_ssot_static_audit.py -q` passed.  
- Live E2E / runtime checks: the required repeated single E2E run showed flakiness (10-run loop: iteration 1 passed, iteration 2 failed due to an unrelated strategy signal/score rejection path), `python -m pytest -q -m live_runtime_e2e tests/e2e/live_sim` passed in a subsequent run, and a broader filtered suite (`pytest tests -k "candle or hydration or exit or orphan or reconciliation or shutdown"`) experienced the same intermittent live-runtime E2E failure during exit flatten/bracket cleanup in one run; full test suite (`pytest -q`) completed locally (with teardown logging warnings observed from background task teardown).  
- Automated validations and the focused unit/behavior tests exercising the new guards, watermark locking, projection diagnostics atomicity, poll-fallback behavior, and shutdown settlement succeeded; remaining risks are the pre-existing lint debt and intermittent live-runtime E2E flakiness which must be validated by CI workflows and the repository pre-merge trading-safety review before merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5cc0544bf483248276c02952d705b5)