### PR TITLE
Fix canonical history hydration deadlock blocking live trading

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -10196,6 +10196,30 @@ async def _deferred_basket_hydration_retry(
     if max_attempts is None:
         max_attempts = int(os.getenv("DEFERRED_BASKET_MAX_ATTEMPTS", "160") or "160")
     policy = MarketDataPolicy.from_env()
+
+    def _hydration_fingerprint() -> tuple[int, ...]:
+        # Cheap progress evidence: total MDM closed-bar count across the
+        # currently committed basket's symbols. If this is unchanged between
+        # attempts, the previous attempt's hydration fetch made no progress
+        # and logging a second "FAILED" event for the SAME expected wait
+        # state is misleading noise, not a new failure (2026-07-20 incident:
+        # DEFERRED_BASKET_RETRY_WAITING immediately followed by
+        # DEFERRED_BASKET_RETRY_FAILED for the identical data_not_ready
+        # state, every 15s, 95 times).
+        mdm = getattr(ctx, "market_data_manager", None)
+        basket = getattr(ctx, "active_contract_basket", None) or {}
+        symbols = list(basket.get("symbols") or []) if isinstance(basket, dict) else []
+        if mdm is None or not symbols:
+            return (-1,)
+        counts = []
+        for sym in symbols:
+            try:
+                counts.append(len(mdm.get_ohlc_bars(sym) or []))
+            except Exception:  # noqa: BLE001 - diagnostic fingerprint only
+                counts.append(0)
+        return tuple(counts)
+
+    last_fingerprint: tuple[int, ...] | None = None
     for attempt in range(1, max_attempts + 1):
         market_state = get_market_state()
         if market_state != MarketState.OPEN and delay_seconds >= 15.0:
@@ -10279,17 +10303,23 @@ async def _deferred_basket_hydration_retry(
                         "reason": "data_not_ready",
                     },
                 )
-                LOGGER.info(
-                    "DEFERRED_BASKET_RETRY_FAILED attempt=%d/%d reason=data_not_ready",
-                    attempt,
-                    max_attempts,
-                    extra={
-                        "event": "DEFERRED_BASKET_RETRY_FAILED",
-                        "attempt": attempt,
-                        "max_attempts": max_attempts,
-                        "reason": "data_not_ready",
-                    },
-                )
+                fingerprint = _hydration_fingerprint()
+                if last_fingerprint is not None and fingerprint != last_fingerprint:
+                    LOGGER.info(
+                        "DEFERRED_BASKET_RETRY_PROGRESS attempt=%d/%d reason=data_not_ready",
+                        attempt,
+                        max_attempts,
+                        extra={
+                            "event": "DEFERRED_BASKET_RETRY_PROGRESS",
+                            "attempt": attempt,
+                            "max_attempts": max_attempts,
+                            "reason": "data_not_ready",
+                        },
+                    )
+                # No duplicate "FAILED" event for the same expected wait
+                # state: DEFERRED_BASKET_RETRY_WAITING above already
+                # reported it; data_not_ready is not a hydration failure.
+                last_fingerprint = fingerprint
                 continue
             LOGGER.info(
                 "DEFERRED_BASKET_RETRY_SUCCESS attempt=%d spot_ltp=%.2f",
@@ -11804,8 +11834,14 @@ async def startup_sequence(ctx: BotContext) -> None:
                     )
                 if (
                     runner is not None
-                    and runner_history_count <= 0
-                    and mdm_ohlc_count > 0
+                    # Sync whenever the runner/indicator lags canonical MDM
+                    # history (not merely when it is empty) - a runner left
+                    # holding a STALE, larger count from before a restart or a
+                    # since-shrunk MDM fetch must not silently bypass the
+                    # canonical SSOT via a bigger old number (production
+                    # incident: mdm=41, stale runner/indicator=77, readiness
+                    # incorrectly satisfied by max()).
+                    and mdm_ohlc_count > runner_history_count
                     and callable(getattr(runner, "sync_history_from_mdm", None))
                 ):
                     sync_result = runner.sync_history_from_mdm(
@@ -11828,7 +11864,12 @@ async def startup_sequence(ctx: BotContext) -> None:
                     and (str(sym).endswith("CE") or str(sym).endswith("PE"))
                     else default_required_bars
                 )
-                effective_bar_count = max(runner_history_count, mdm_ohlc_count)
+                # Canonical MDM closed-bar count is the readiness SSOT (see
+                # AGENTS.md: data/market_data_manager.py owns hydration
+                # state). A runner/indicator count is never allowed to
+                # satisfy readiness on its own via max() - it is synced FROM
+                # MDM above, never the other way around.
+                effective_bar_count = mdm_ohlc_count
                 if effective_bar_count >= min_required_bars:
                     ready_symbols.append(sym)
                 else:

--- a/src/nifty_scalper_bot/data/candle_engine.py
+++ b/src/nifty_scalper_bot/data/candle_engine.py
@@ -31,6 +31,14 @@ FetchHistoricalFn = Callable[[str], pd.DataFrame | None]
 FetchRecentFn = Callable[[str], pd.DataFrame | None]
 _OHLC_COLUMNS = ("timestamp", "open", "high", "low", "close", "volume")
 
+# Sources representing an explicit REST historical/backfill fetch. A
+# conflicting overlap from one of these sources against an existing
+# locally-finalized candle (e.g. WS-built) is reconciled deterministically
+# (REST wins, since it is the exchange-finalized aggregate) rather than
+# aborting the whole import batch. Any other/undeclared source keeps the
+# strict fail-closed conflict behavior unchanged.
+_HISTORY_RECONCILABLE_SOURCES = frozenset({"historical", "historical_hydration"})
+
 
 class CandleHistoryConflictError(DataIntegrityError):
     """Historical import conflicts with a finalized candle identity."""
@@ -154,6 +162,7 @@ class CandleEngine:
     _history_import_bar_total: int = field(default=0, init=False)
     _history_import_idempotent_total: int = field(default=0, init=False)
     _history_import_conflict_total: int = field(default=0, init=False)
+    _history_import_reconciled_total: int = field(default=0, init=False)
     _history_import_failure_total: int = field(default=0, init=False)
     _finalized_minute_tick_reject_total: int = field(default=0, init=False)
     _history_current_reconcile_total: int = field(default=0, init=False)
@@ -189,6 +198,7 @@ class CandleEngine:
         self._history_import_bar_total = 0
         self._history_import_idempotent_total = 0
         self._history_import_conflict_total = 0
+        self._history_import_reconciled_total = 0
         self._history_import_failure_total = 0
         self._finalized_minute_tick_reject_total = 0
         self._history_current_reconcile_total = 0
@@ -253,6 +263,7 @@ class CandleEngine:
                     self._history_import_idempotent_total
                 ),
                 "history_import_conflict_total": self._history_import_conflict_total,
+                "history_import_reconciled_total": self._history_import_reconciled_total,
                 "history_import_failure_total": self._history_import_failure_total,
                 "finalized_minute_tick_reject_total": (
                     self._finalized_minute_tick_reject_total
@@ -431,6 +442,7 @@ class CandleEngine:
             incoming = _normalize_history_frame(frame, symbol=symbol)
             candidate = list(incoming)
             idempotent = 0
+            reconciled = 0
             current_after = (
                 dict(self.current_candle) if self.current_candle is not None else None
             )
@@ -445,6 +457,15 @@ class CandleEngine:
                     stored = merged_by_ts.get(ts)
                     if stored is not None:
                         if not _candles_equivalent(stored, row):
+                            if source in _HISTORY_RECONCILABLE_SOURCES:
+                                # REST historical is the exchange-finalized
+                                # aggregate; a locally-built (e.g. WS) candle
+                                # for the same minute may differ slightly on
+                                # early/late ticks. Reconcile deterministically
+                                # instead of aborting the whole batch.
+                                merged_by_ts[ts] = dict(row)
+                                reconciled += 1
+                                continue
                             raise _history_conflict(symbol, ts, stored, row)
                         idempotent += 1
                         continue
@@ -463,9 +484,11 @@ class CandleEngine:
                     if current_ts == latest_imported_ts:
                         imported = incoming[-1]
                         if not _candles_equivalent(normalized_current, imported):
-                            raise _history_conflict(
-                                symbol, current_ts, imported, normalized_current
-                            )
+                            if source not in _HISTORY_RECONCILABLE_SOURCES:
+                                raise _history_conflict(
+                                    symbol, current_ts, imported, normalized_current
+                                )
+                            reconciled += 1
                         current_after = None
                         history_reconciled_current = True
                         idempotent += 1
@@ -488,6 +511,18 @@ class CandleEngine:
                         history_reconciled_current = True
 
             bounded = candidate[-int(self.max_bars) :]
+            if reconciled:
+                self._history_import_reconciled_total += reconciled
+                LOGGER.info(
+                    "HISTORY_OVERLAP_RECONCILED",
+                    extra={
+                        "event": "HISTORY_OVERLAP_RECONCILED",
+                        "symbol": symbol,
+                        "reconciled_count": reconciled,
+                        "existing_source": "ws_or_local",
+                        "incoming_source": source,
+                    },
+                )
         except Exception as exc:
             self._history_import_failure_total += 1
             if isinstance(exc, CandleHistoryConflictError):

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -12842,7 +12842,10 @@ class MarketDataManager:
             failure_reason: str | None = None
             try:
                 rows = await self.fetch_history(
-                    normalized, normalized_interval, lookback_days
+                    normalized,
+                    normalized_interval,
+                    lookback_days,
+                    min_rows=requested_bars,
                 )
                 fetched_rows = len(rows or [])
                 rows = list(rows or [])[-requested_bars:]
@@ -13102,9 +13105,19 @@ class MarketDataManager:
         return rows[-target:]
 
     async def fetch_history(
-        self, symbol: str, interval: str, days: int = 3
+        self, symbol: str, interval: str, days: int = 3, *, min_rows: int = 0
     ) -> list[dict]:
-        """Fetch historical data with token, tradingsymbol, wider-window, and spot fallbacks."""
+        """Fetch historical data with token, tradingsymbol, wider-window, and spot fallbacks.
+
+        ``min_rows`` is the caller's required closed-bar count (e.g. 50). The
+        attempt ladder below only accepts the FIRST non-empty response
+        regardless of size unless min_rows is supplied - at 09:59 IST Monday
+        the 2-calendar-day window never reaches Friday's session (2 days back
+        from Monday is Saturday), so the "token" attempt returned ~41
+        elapsed-session rows and the wider "token_wide" attempt was never
+        tried (production: mdm_after=41, required_bars=50). With min_rows
+        set, a short-but-nonempty response keeps trying wider windows.
+        """
         symbol = (
             self._canonical_symbol(symbol.strip().upper())
             if hasattr(self, "_canonical_symbol")
@@ -13256,8 +13269,17 @@ class MarketDataManager:
         wide_days = max(int(days), 5)
         if wide_days != int(days):
             attempt_specs.append(("token_wide", token_int, wide_days))
+        # Walk further back only when the caller declared a row target that a
+        # single prior session may not satisfy (e.g. a holiday-adjacent long
+        # weekend). Bounded to a modest ceiling to avoid unbounded broker load.
+        if min_rows > 0:
+            widest_days = max(wide_days, 10)
+            if widest_days != wide_days:
+                attempt_specs.append(("token_widest", token_int, widest_days))
 
         last_error: str | None = None
+        best_so_far: list[dict[str, Any]] = []
+        best_attempt_meta: tuple[str, datetime, datetime, int] | None = None
         for attempt_name, instrument_key, lookback_days in attempt_specs:
             to_date = now
             from_date = to_date - timedelta(days=max(1, int(lookback_days)))
@@ -13343,6 +13365,24 @@ class MarketDataManager:
                     }.values()
                 )
                 deduped.sort(key=lambda item: item["timestamp"])
+                if min_rows > 0 and len(deduped) < min_rows and attempt_name != attempt_specs[-1][0]:
+                    if len(deduped) > len(best_so_far):
+                        best_so_far = deduped
+                        best_attempt_meta = (
+                            attempt_name, from_date, to_date, len(rows)
+                        )
+                    self._logger.info(
+                        "HYDRATION_ATTEMPT_INSUFFICIENT_WIDENING symbol=%s attempt=%s returned_rows=%s min_rows=%s",
+                        symbol, attempt_name, len(deduped), min_rows,
+                        extra={
+                            "event": "HYDRATION_ATTEMPT_INSUFFICIENT_WIDENING",
+                            "symbol": symbol,
+                            "attempt": attempt_name,
+                            "returned_rows": len(deduped),
+                            "min_rows": min_rows,
+                        },
+                    )
+                    continue
                 self._logger.info(
                     "HYDRATION_FETCH_RESULT symbol=%s token=%s tradingsymbol=%s exchange=%s interval=%s attempt=%s returned_rows=%s accepted_rows=%s first_ts=%s last_ts=%s exception_type=%s exception_message=%s",
                     symbol,
@@ -13374,7 +13414,10 @@ class MarketDataManager:
                     },
                 )
                 if deduped:
-                    return deduped
+                    if min_rows <= 0 or len(deduped) >= min_rows:
+                        return deduped
+                    if len(deduped) > len(best_so_far):
+                        best_so_far = deduped
             except BrokerAuthenticationError:
                 self._logger.error(
                     "HYDRATION_FETCH_RESULT symbol=%s instrument_token=%s tradingsymbol=%s exchange=%s interval=%s attempt=%s returned_rows=0 accepted_rows=0 failure_category=history_authentication_failed",
@@ -13440,6 +13483,34 @@ class MarketDataManager:
                         "failure_category": failure_category,
                     },
                 )
+        if best_so_far:
+            # Every attempt (including the widest tried) was individually
+            # insufficient for min_rows, but the widest attempt's rows are
+            # still the best available closed-bar evidence - return them so
+            # the caller's sufficiency check (required_bars) reports the true
+            # shortfall instead of a false "returned_rows=0".
+            self._logger.warning(
+                "HYDRATION_FETCH_RESULT symbol=%s token=%s tradingsymbol=%s exchange=%s interval=%s returned_rows=%s accepted_rows=%s failure_category=history_insufficient_after_widening",
+                symbol,
+                token_int,
+                tradingsymbol,
+                exchange,
+                interval,
+                len(best_so_far),
+                len(best_so_far),
+                extra={
+                    "event": "HYDRATION_FETCH_RESULT",
+                    "symbol": symbol,
+                    "instrument_token": token_int,
+                    "tradingsymbol": tradingsymbol,
+                    "exchange": exchange,
+                    "interval": interval,
+                    "returned_rows": len(best_so_far),
+                    "accepted_rows": len(best_so_far),
+                    "failure_category": "history_insufficient_after_widening",
+                },
+            )
+            return best_so_far
         self._logger.error(
             "HYDRATION_FETCH_RESULT symbol=%s token=%s tradingsymbol=%s exchange=%s interval=%s returned_rows=0 accepted_rows=0 exception_message=%s",
             symbol,

--- a/tests/core/test_app_deferred_retry.py
+++ b/tests/core/test_app_deferred_retry.py
@@ -60,3 +60,81 @@ async def test_strategy_runner_start_idempotent() -> None:
     ctx.runner_task = None
     await app._ensure_strategy_runner_started(ctx, reason="test_start")
     assert started == 1
+
+
+@pytest.mark.asyncio
+async def test_deferred_retry_no_duplicate_failed_log_for_unchanged_data_not_ready(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """2026-07-20 incident: every 15s retry logged BOTH
+    DEFERRED_BASKET_RETRY_WAITING and DEFERRED_BASKET_RETRY_FAILED for the
+    identical data_not_ready state (95 times), implying repeated failures
+    when nothing had actually changed. With an unchanged progress
+    fingerprint (MDM bar counts for the committed basket's symbols), only
+    the WAITING event fires and no FAILED/PROGRESS event is emitted; once
+    the fingerprint changes, a PROGRESS event fires instead of FAILED."""
+    from nifty_scalper_bot.utils.market_hours import MarketState
+
+    events: list[str] = []
+
+    class _Logger:
+        def info(self, msg, *a, extra=None, **k):
+            events.append((extra or {}).get("event", msg))
+
+        def warning(self, *a, **k):
+            pass
+
+        def error(self, *a, **k):
+            pass
+
+    monkeypatch.setattr(app, "LOGGER", _Logger())
+    monkeypatch.setattr(app, "get_market_state", lambda: MarketState.OPEN)
+    monkeypatch.setattr(
+        app, "_wait_for_live_spot_or_raise", lambda *a, **k: _coro(24000.0)
+    )
+    monkeypatch.setattr(
+        app, "_build_and_hydrate_live_basket_from_spot", lambda *a, **k: _coro({})
+    )
+    monkeypatch.setattr(
+        app, "_ensure_strategy_runner_started", lambda *a, **k: _coro(None)
+    )
+    monkeypatch.setattr(
+        app, "_recompute_and_push_runtime_readiness", lambda *a, **k: _coro(None)
+    )
+    monkeypatch.setattr(app.asyncio, "sleep", lambda *_a, **_k: _coro(None))
+
+    bar_counts = {"CALL": 41}
+
+    class _MDM:
+        def get_ohlc_bars(self, symbol):
+            return list(range(bar_counts.get(symbol, 0)))
+
+    ctx = SimpleNamespace(
+        trading_ready=False,
+        live_orders_armed=False,
+        data_ready=False,
+        evaluation_ready=False,
+        selected_ce=None,
+        market_data_manager=_MDM(),
+        active_contract_basket={"symbols": ["CALL"]},
+    )
+
+    await app._deferred_basket_hydration_retry(
+        ctx, configured_mode="LIVE", max_attempts=2, delay_seconds=0.0
+    )
+
+    waiting = events.count("DEFERRED_BASKET_RETRY_WAITING")
+    failed = events.count("DEFERRED_BASKET_RETRY_FAILED")
+    progress = events.count("DEFERRED_BASKET_RETRY_PROGRESS")
+    assert failed == 0, "the duplicate FAILED event for an unchanged state must be gone"
+    assert waiting >= 1
+    # Fingerprint unchanged across both attempts (bar_counts static) -> no
+    # PROGRESS event either; only the WAITING evidence is logged.
+    assert progress == 0
+
+
+def _coro(value):
+    async def _inner(*_a, **_k):
+        return value
+
+    return _inner()

--- a/tests/core/test_history_readiness_ssot.py
+++ b/tests/core/test_history_readiness_ssot.py
@@ -127,3 +127,30 @@ async def test_shared_role_resolver_keeps_selected_option_exact() -> None:
         selected_pe="NFO:NIFTY26JUN24000PE",
         spot_symbol="NSE:NIFTY",
     ) == "option_context"
+
+
+def test_startup_sequence_never_uses_max_of_runner_and_mdm_for_readiness() -> None:
+    """Static architecture check (2026-07-20 hydration-deadlock incident):
+    core/app.py's startup readiness loop previously computed
+    `effective_bar_count = max(runner_history_count, mdm_ohlc_count)`, so a
+    STALE runner/indicator count from before a restart (or from before MDM's
+    cache shrank) could satisfy readiness on its own even though canonical
+    MDM history was short (production: mdm=41, stale runner/indicator=77,
+    required=50 -> incorrectly marked ready via max(77,41)=77>=50).
+
+    `startup_sequence` is a large top-level orchestration function unsuitable
+    for direct unit invocation here; this is a deliberate static check (the
+    class of check called for in the incident's own architecture-review
+    step), not a substitute for the full-cycle behavioral tests above.
+    """
+    import inspect
+
+    from nifty_scalper_bot.core import app as app_module
+
+    src = inspect.getsource(app_module.startup_sequence)
+    assert "max(runner_history_count, mdm_ohlc_count)" not in src
+    assert "effective_bar_count = mdm_ohlc_count" in src
+    # The sync-from-MDM trigger must fire whenever the runner LAGS canonical
+    # MDM history, not merely when it is exactly empty - otherwise a stale
+    # nonzero runner count never gets a chance to be corrected.
+    assert "mdm_ohlc_count > runner_history_count" in src

--- a/tests/data/test_candle_engine_history_import.py
+++ b/tests/data/test_candle_engine_history_import.py
@@ -204,3 +204,88 @@ def test_history_import_normalizes_timezone_and_does_not_touch_trading_modules()
                 if isinstance(node, ast.Attribute) and node.attr == "import_history":
                     offenders.append(str(rel))
     assert offenders == []
+
+
+def test_rest_historical_overlap_with_ws_finalized_candle_is_reconciled_not_fatal() -> (
+    None
+):
+    """Production incident (2026-07-20 09:59 IST): a REST historical backfill
+    batch spanning the previous session contained the already-finalized WS
+    candle at 09:19 with a slightly different close/volume (normal — WS may
+    miss early/late ticks; REST is the exchange-finalized aggregate). The old
+    behavior aborted the ENTIRE batch (new_ingested_bars=0), leaving canonical
+    history stuck below the 50-bar requirement forever.
+
+    With source="historical" declared, one reconciled overlap must not abort
+    bars before/after it, and the reconciled bar must take the REST value.
+    """
+    engine = CandleEngine(symbol="NFO:T")
+    # WS-built candle already finalized locally at "09:19" (minute index 0).
+    engine.import_history(
+        pd.DataFrame([_row(0, close=100.5, volume=10.0)]),
+        mode="bootstrap",
+    )
+    before_reconciled = engine.diagnostics()["history_import_reconciled_total"]
+
+    # REST batch: bars before, the SAME minute with a legitimately different
+    # OHLC/volume (exchange-finalized), and valid bars after.
+    rest_batch = pd.DataFrame(
+        [
+            _row(-2), _row(-1),
+            _row(0, close=100.65, volume=11.0),  # overlap: reconciled, not fatal
+            _row(1), _row(2),
+        ]
+    )
+    engine.import_history(rest_batch, source="historical")
+
+    bars = engine.get_completed_bars()
+    timestamps = [b["timestamp"] for b in bars]
+    assert timestamps == sorted(timestamps)
+    assert len(set(timestamps)) == len(timestamps)  # strictly unique
+    # Batch continued: bars before AND after the overlap were both accepted.
+    assert len(bars) == 5
+    # The overlapping minute now holds the REST (incoming) value.
+    reconciled_row = next(b for b in bars if b["timestamp"] == _ts(0))
+    assert reconciled_row["close"] == 100.65
+    assert reconciled_row["volume"] == 11.0
+    assert (
+        engine.diagnostics()["history_import_reconciled_total"]
+        == before_reconciled + 1
+    )
+    # No fatal batch failure was recorded for this reconciled overlap.
+    assert engine.diagnostics()["history_import_conflict_total"] == 0
+
+
+def test_undeclared_source_overlap_still_fails_closed() -> None:
+    """Reconciliation is scoped strictly to declared REST-historical sources.
+    An incremental import with no declared provenance keeps the original
+    strict fail-closed contract (unchanged; see the conflict tests above)."""
+    engine = CandleEngine(symbol="NFO:T")
+    engine.import_history(pd.DataFrame([_row(0, close=100.5)]), mode="bootstrap")
+    with pytest.raises(DataIntegrityError):
+        engine.import_history(pd.DataFrame([_row(0, close=100.75)]))  # source=None
+    assert engine.diagnostics()["history_import_reconciled_total"] == 0
+
+
+def test_malformed_and_future_rows_still_rejected_during_reconcilable_import() -> None:
+    """Reconciliation never weakens the existing integrity/future-candle
+    guards — only the same-timestamp-conflict-vs-existing-store path changes."""
+    engine = CandleEngine(symbol="NFO:T")
+    with pytest.raises(DataIntegrityError):
+        engine.import_history(
+            pd.DataFrame([{**_row(0), "high": 99.0}]), source="historical"
+        )
+    with pytest.raises(DataIntegrityError):
+        engine.import_history(
+            pd.DataFrame([_row(0, volume=-1.0)]), source="historical"
+        )
+    future_row = {**_row(0), "timestamp": pd.Timestamp.now(tz=IST) + pd.Timedelta(days=1)}
+    with pytest.raises(DataIntegrityError):
+        engine.import_history(pd.DataFrame([future_row]), source="historical")
+    # Contradictory duplicate timestamps WITHIN the same incoming REST batch
+    # remain a genuine source-integrity error, not a reconcilable overlap.
+    with pytest.raises(DataIntegrityError):
+        engine.import_history(
+            pd.DataFrame([_row(0, close=100.5), _row(0, close=100.9)]),
+            source="historical",
+        )

--- a/tests/data/test_canonical_history_hydration.py
+++ b/tests/data/test_canonical_history_hydration.py
@@ -360,15 +360,29 @@ def test_historical_bar_imports_through_candle_engine_projection_not_raw_ticks()
     assert mdm.is_tick_ready("NSE:NIFTY") is False
 
 
-def test_conflicting_rehydration_leaves_projection_unchanged() -> None:
+def test_conflicting_rehydration_reconciles_to_the_rest_historical_value() -> None:
+    """Contract corrected (2026-07-20 hydration-deadlock incident fix): a REST
+    historical re-fetch that disagrees with an already-stored bar for the same
+    minute (declared source="historical", the only source ingest_historical_ohlc
+    ever uses) is now RECONCILED - REST is the exchange-finalized aggregate -
+    instead of aborting the whole batch. This test previously asserted the old
+    batch-fatal behavior (accepted=0, storage unchanged, conflict counted);
+    that was the exact incident-causing defect (real REST/WS overlaps at
+    market open aborted the entire hydration batch, e.g. new_ingested_bars=0
+    for the 2026-07-20 09:19 IST candle)."""
     mdm = _storage_mdm()
     first = {"symbol": "NSE:NIFTY", "timestamp": datetime(2026, 1, 1, tzinfo=timezone.utc), "open": 1, "high": 2, "low": 1, "close": 2, "volume": 10}
     conflict = {**first, "close": 1.5}
     assert mdm.ingest_historical_ohlc("NSE:NIFTY", [first]) == 1
-    before = mdm.get_ohlc_bars("NSE:NIFTY")
-    assert mdm.ingest_historical_ohlc("NSE:NIFTY", [conflict]) == 0
-    assert mdm.get_ohlc_bars("NSE:NIFTY") == before
-    assert mdm._candle_metrics["history_hydration_conflict_total"] == 1
+    # accepted_rows counts NEWLY added timestamps; a reconciled overlap
+    # updates an EXISTING timestamp's value, so accepted_rows is 0 here -
+    # the correctness signal is the stored value and the absence of a
+    # recorded conflict, asserted below.
+    mdm.ingest_historical_ohlc("NSE:NIFTY", [conflict])
+    after = mdm.get_ohlc_bars("NSE:NIFTY")
+    assert len(after) == 1
+    assert after[0]["close"] == 1.5
+    assert mdm._candle_metrics["history_hydration_conflict_total"] == 0
 
 
 def test_missing_readiness_requirements_fail_closed_even_with_ready_bars() -> None:
@@ -423,3 +437,111 @@ def test_live_tick_writes_raw_tick_history_without_implying_ohlc_ready() -> None
     assert mdm.is_tick_ready("NSE:NIFTY") is True
     assert mdm.is_ohlc_ready("NSE:NIFTY") is False
     assert mdm.is_market_data_ready("NSE:NIFTY") is False
+
+
+def _fetch_history_mdm(historical_data) -> MarketDataManager:
+    """Minimal MDM wired only for MarketDataManager.fetch_history's real
+    attempt-widening ladder (token/broker/lock plumbing), independent of the
+    lighter-weight `_mdm()` fake used by the ensure_history-level tests above.
+    """
+    mdm = MarketDataManager.__new__(MarketDataManager)
+    mdm._logger = SimpleNamespace(
+        info=lambda *a, **k: None, warning=lambda *a, **k: None, error=lambda *a, **k: None
+    )
+    mdm._canonical_symbol = lambda s: str(s)
+    mdm._token_by_symbol = {"NSE:NIFTY": 256265}
+    mdm._resolver = None
+    mdm._last_history_request_ts = 0.0
+
+    class _Broker:
+        pass
+
+    broker = _Broker()
+    broker.historical_data = historical_data
+    mdm._broker = broker
+    return mdm
+
+
+def _hist_row(minute_offset: int, base: datetime) -> dict:
+    ts = base + timedelta(minutes=minute_offset)
+    return {"timestamp": ts, "open": 100.0, "high": 101.0, "low": 99.0, "close": 100.5, "volume": 10}
+
+
+@pytest.mark.asyncio
+async def test_fetch_history_widens_past_single_session_when_insufficient() -> None:
+    """2026-07-20 09:59 IST incident: a 2-calendar-day window from a Monday
+    morning does not reach Friday's session (2 days back from Monday is
+    Saturday). The first attempt returned only ~41 elapsed-session rows and
+    was accepted merely because it was non-empty. With min_rows declared,
+    fetch_history must keep widening until the target is met."""
+    now = datetime.now(timezone.utc)
+    session_open = now.replace(hour=3, minute=45, second=0, microsecond=0)  # ~09:15 IST in UTC
+    if session_open > now:
+        session_open -= timedelta(days=1)
+    calls: list[tuple] = []
+
+    def historical_data(instrument_key, from_date, to_date, interval):
+        calls.append((instrument_key, from_date, to_date, interval))
+        span_days = (to_date - from_date).days
+        if span_days <= 3:
+            # Narrow window: only today's elapsed 41 minutes (the incident).
+            return _rows(41)
+        # Wider window reaches the prior session: 60 eligible closed bars.
+        return _rows(60)
+
+    mdm = _fetch_history_mdm(historical_data)
+    rows = await mdm.fetch_history("NSE:NIFTY", "minute", days=2, min_rows=50)
+
+    assert len(rows) >= 50
+    assert len(calls) >= 2, "must have widened past the first insufficient attempt"
+
+
+@pytest.mark.asyncio
+async def test_fetch_history_returns_first_attempt_when_already_sufficient() -> None:
+    """No unnecessary widening/broker load when the first attempt already
+    satisfies min_rows."""
+    calls: list[tuple] = []
+
+    def historical_data(instrument_key, from_date, to_date, interval):
+        calls.append(1)
+        return _rows(55)
+
+    mdm = _fetch_history_mdm(historical_data)
+    rows = await mdm.fetch_history("NSE:NIFTY", "minute", days=2, min_rows=50)
+
+    assert len(rows) == 55
+    assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_fetch_history_returns_best_available_when_all_attempts_short() -> None:
+    """Even a broker that never has enough bars (e.g. a young contract) must
+    not come back as an empty list - the caller's own sufficiency check
+    (required_bars) reports the true shortfall using real, if short, data."""
+    def historical_data(instrument_key, from_date, to_date, interval):
+        span_days = (to_date - from_date).days
+        return _rows(min(30, span_days * 5))
+
+    mdm = _fetch_history_mdm(historical_data)
+    rows = await mdm.fetch_history("NSE:NIFTY", "minute", days=2, min_rows=50)
+
+    assert 0 < len(rows) <= 30
+
+
+@pytest.mark.asyncio
+async def test_fetch_history_min_rows_zero_preserves_legacy_first_nonempty_behavior() -> (
+    None
+):
+    """Backward compatibility: existing callers that omit min_rows keep the
+    original "first non-empty attempt wins" behavior unchanged."""
+    calls: list[tuple] = []
+
+    def historical_data(instrument_key, from_date, to_date, interval):
+        calls.append(1)
+        return _rows(5)
+
+    mdm = _fetch_history_mdm(historical_data)
+    rows = await mdm.fetch_history("NSE:NIFTY", "minute", days=2)
+
+    assert len(rows) == 5
+    assert len(calls) == 1

--- a/tests/data/test_mdm_history_import_result_contract.py
+++ b/tests/data/test_mdm_history_import_result_contract.py
@@ -62,15 +62,26 @@ def test_invalid_historical_ohlc_failure_is_not_conflict_or_ready() -> None:
     assert mdm._last_history_import_result["status"] == "failed_validation"
 
 
-def test_same_minute_finalized_conflict_counts_failure_and_conflict() -> None:
+def test_same_minute_rest_overlap_reconciles_instead_of_failing() -> None:
+    """Contract corrected (2026-07-20 hydration-deadlock incident fix):
+    ingest_historical_ohlc always declares source="historical" to
+    CandleEngine.import_history, so a same-minute overlap against an already
+    finalized bar is now a deterministic RECONCILIATION (REST is the
+    exchange-finalized aggregate), not a batch-fatal conflict. This test
+    previously asserted the old behavior (failure_total=1, conflict_total=1,
+    status=finalized_candle_conflict) - that was the incident-causing defect
+    (a single REST/WS overlap aborted the whole hydration batch)."""
     mdm = _mdm()
 
     assert mdm.ingest_historical_ohlc(SYMBOL, [_bar()]) == 1
-    assert mdm.ingest_historical_ohlc(SYMBOL, [_bar(close=1.5)]) == 0
+    mdm.ingest_historical_ohlc(SYMBOL, [_bar(close=1.5)])
 
-    assert mdm._candle_metrics["history_hydration_failure_total"] == 1
-    assert mdm._candle_metrics["history_hydration_conflict_total"] == 1
-    assert mdm._last_history_import_result["status"] == "finalized_candle_conflict"
+    assert mdm._candle_metrics["history_hydration_failure_total"] == 0
+    assert mdm._candle_metrics["history_hydration_conflict_total"] == 0
+    assert mdm._last_history_import_result["status"] in {
+        "success_new_bars", "success_idempotent",
+    }
+    assert mdm.get_ohlc_bars(SYMBOL)[-1]["close"] == 1.5
 
 
 def test_idempotent_import_is_distinguishable_from_failure() -> None:
@@ -85,14 +96,17 @@ def test_idempotent_import_is_distinguishable_from_failure() -> None:
     assert mdm._candle_metrics["history_hydration_failure_total"] == 0
 
 
-def test_failed_history_import_leaves_projection_unchanged() -> None:
+def test_reconciled_history_import_updates_projection_to_rest_value() -> None:
+    """Contract corrected alongside the conflict test above: a reconciled
+    REST overlap DOES change the projection (to the REST/incoming value) -
+    it is no longer treated as a failed import that must leave storage
+    untouched."""
     mdm = _mdm()
 
     assert mdm.ingest_historical_ohlc(SYMBOL, [_bar()]) == 1
-    before = mdm.get_ohlc_bars(SYMBOL)
-    assert mdm.ingest_historical_ohlc(SYMBOL, [_bar(close=1.5)]) == 0
+    mdm.ingest_historical_ohlc(SYMBOL, [_bar(close=1.5)])
 
-    assert mdm.get_ohlc_bars(SYMBOL) == before
+    assert mdm.get_ohlc_bars(SYMBOL)[-1]["close"] == 1.5
 
 
 def test_projection_divergence_detects_equal_length_ohlcv_mismatch() -> None:

--- a/tests/e2e/live_sim/test_live_runtime_startup_contract.py
+++ b/tests/e2e/live_sim/test_live_runtime_startup_contract.py
@@ -591,8 +591,15 @@ def test_live_runtime_bullish_spot_future_selects_ce_and_exits_target(
             basket.selected_pe: _bars(end, 60, 95.0, 0.05),
         }
 
-        async def fetch_history(symbol: str, interval: str, days: int = 3):
-            del interval, days
+        async def fetch_history(
+            symbol: str, interval: str, days: int = 3, *, min_rows: int = 0
+        ):
+            # min_rows: MDM's real fetch_history now accepts a sufficiency
+            # target so it can widen its lookback across prior sessions
+            # (2026-07-20 hydration-deadlock fix); this fake pre-generates a
+            # fixed 60-bar history per symbol regardless, so the parameter is
+            # accepted for signature compatibility and otherwise unused.
+            del interval, days, min_rows
             rows = histories.get(symbol) or histories.get(str(symbol).upper())
             assert rows, f"unexpected history request for {symbol}"
             return list(rows)


### PR DESCRIPTION
## Root cause

At early-session startup, the canonical history request returned only current-session bars (2-calendar-day lookback from a Monday morning lands on Saturday, never reaching Friday), leaving spot/futures MDM history below the 50-bar requirement. A normal REST-vs-WS overlap at an already-finalized candle was treated as batch-fatal (new_ingested_bars=0). A stale, larger runner/indicator count (77, from before a restart) satisfied readiness via `max(runner, mdm)` even though canonical MDM history was short (41). The retry loop double-logged the identical `data_not_ready` state as both WAITING and FAILED.

## Fix

- `data/candle_engine.py`: REST historical overlap against an already-finalized local candle is reconciled (REST wins) instead of aborting the whole batch, scoped strictly to declared historical sources.
- `data/market_data_manager.py`: `fetch_history` gained a `min_rows` sufficiency parameter; the attempt ladder now widens across prior sessions until met, defaulting to the old first-non-empty behavior when omitted.
- `core/app.py` (`startup_sequence`): `effective_bar_count = mdm_ohlc_count` (canonical SSOT only), sync-from-MDM trigger widened to fire whenever the runner lags MDM, not just when empty.
- `core/app.py` (`_deferred_basket_hydration_retry`): duplicate FAILED log removed; a progress fingerprint (MDM bar counts) now gates a PROGRESS event on genuine change only.

## Safety preserved

No reduction of the 50-bar requirement. No runner-only readiness bypass (the opposite bypass - `max()` - is what was removed). No stale-quote/broker/risk/emergency bypass. No future/open candle accepted (unchanged guards). No order, bracket, exit, or reconciliation logic touched. No new env vars.

## Tests

3 pre-existing tests (test_canonical_history_hydration.py, test_mdm_history_import_result_contract.py) encoded the old batch-fatal overlap behavior as intended - each updated with an explicit comment stating the contract correction, never silently bypassed. Added: 3 tests in test_candle_engine_history_import.py (incident reproduction + scope-safety + malformed/future preserved), 4 in test_canonical_history_hydration.py (fetch-widening ladder), 1 in test_app_deferred_retry.py (duplicate-log removal), 1 static architecture check in test_history_readiness_ssot.py (max()-bypass regression guard). Live-sim test stub signature updated for min_rows compatibility (unrelated fake behavior unchanged).

Targeted list: all passed. Subsystems (`tests/data`, `tests/core`, `tests/strategies`, `tests/execution`, `tests/e2e/live_sim`): all passed, zero failures observed. Full `pytest -q`: multiple complete runs showed only `.`/`s` characters (no `F`) across every page of output; the sandbox truncated the final numeric summary line on repeated attempts, so that exact count is not quotable, but no failure was observed in any full or partial run. `compileall -q src`: clean.

## Non-goals

Strategy thresholds, freshness thresholds, risk rules, sizing, order/bracket/exit behavior unchanged. No environment variables added. Diff scope limited to the 3 owning production files + their exact test files (`git status --short` verified clean of unrelated changes).

## Rollback

Revert this PR. No schema or persistent-state migration required.