### PR TITLE
fix: bound market data backlog and clean token rollover

### DIFF
--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -2942,6 +2942,7 @@ class MarketDataManager:
             return False
         active_future = self.get_active_nifty_future_symbol_cached()
         normalized_symbol: str | None = None
+        previous_token: int | None = None
         if symbol:
             normalized_symbol = self._canonical_symbol(symbol)
             if self._is_stale_nifty_future_subscription(
@@ -2963,6 +2964,8 @@ class MarketDataManager:
                     active_future, reason="stale_future_subscription_rejected"
                 )
                 return False
+            with self._lock:
+                previous_token = self._symbol_to_token.get(normalized_symbol)
             self.register_symbol(normalized_symbol, token_int)
             if normalized_symbol.endswith(("CE", "PE")):
                 self._logger.info(
@@ -2977,11 +2980,6 @@ class MarketDataManager:
             )
         with self._lock:
             was_desired = token_int in self._desired_tokens
-            previous_token = (
-                self._symbol_to_token.get(normalized_symbol)
-                if normalized_symbol
-                else None
-            )
             self._desired_tokens.add(token_int)
             if normalized_symbol:
                 missing_generation = (
@@ -7120,6 +7118,24 @@ class MarketDataManager:
                     str(dropped.get("_mdm_priority_bucket") or "context_or_far"),
                     "pending_limit_far",
                 )
+                pending = self._pending_count_locked()
+            while pending > self._tick_queue_maxsize:
+                candidates = [
+                    (int(queue[-1].get("_mdm_priority", 99)), queue)
+                    for queue in self._pending_tick_queues.values()
+                    if len(queue) > 1 and int(queue[-1].get("_mdm_priority", 99)) > 0
+                ]
+                if not candidates:
+                    break
+                _priority, queue = max(candidates, key=lambda item: item[0])
+                latest = queue.pop()
+                dropped = queue.pop()
+                queue.append(latest)
+                self._pending_decrement_locked(1)
+                bucket = str(dropped.get("_mdm_priority_bucket") or "protected")
+                self._tick_coalesced_total += 1
+                self._tick_coalesced_by_priority[bucket] += 1
+                self._tick_queue_priority_coalesced[bucket] += 1
                 pending = self._pending_count_locked()
             self._update_pipeline_overload_locked()
             self._schedule_tick_drain_locked(loop)

--- a/tests/data/test_mdm_history_import_result_contract.py
+++ b/tests/data/test_mdm_history_import_result_contract.py
@@ -81,7 +81,8 @@ def test_same_minute_rest_overlap_reconciles_instead_of_failing() -> None:
     assert mdm._candle_metrics["history_hydration_failure_total"] == 0
     assert mdm._candle_metrics["history_hydration_conflict_total"] == 0
     assert mdm._last_history_import_result["status"] in {
-        "success_new_bars", "success_idempotent",
+        "success_new_bars",
+        "success_idempotent",
     }
     assert mdm.get_ohlc_bars(SYMBOL)[-1]["close"] == 1.5
 
@@ -247,14 +248,14 @@ def test_import_result_counts_malformed_without_confusing_later_failure() -> Non
     assert result.imported_at.tzinfo is not None
 
 
-def test_conflict_reports_one_conflicting_row_not_validation_rejection() -> None:
+def test_reconciled_rest_overlap_reports_idempotent_success() -> None:
     mdm = _mdm()
     assert mdm.import_historical_ohlc(SYMBOL, [_bar()]).success
-    conflict = mdm.import_historical_ohlc(SYMBOL, [_bar(close=1.25)])
-    assert conflict.status == "finalized_candle_conflict"
-    assert conflict.error == "finalized_candle_conflict"
-    assert conflict.conflicting_rows == 1
-    assert conflict.validation_rejected_rows == 0
+    reconciled = mdm.import_historical_ohlc(SYMBOL, [_bar(close=1.25)])
+    assert reconciled.status == "success_idempotent"
+    assert reconciled.conflicting_rows == 0
+    assert reconciled.validation_rejected_rows == 0
+    assert mdm.get_ohlc_bars(SYMBOL)[-1]["close"] == 1.25
 
 
 def test_malformed_rows_are_counted_on_validation_failure() -> None:

--- a/tests/data/test_mdm_lifecycle_generation.py
+++ b/tests/data/test_mdm_lifecycle_generation.py
@@ -111,6 +111,8 @@ def test_token_change_resets_generation_and_requires_new_matching_tick() -> None
 
     assert mdm.request_token_subscription(new_token, symbol=symbol)
 
+    assert mdm.desired_tokens_snapshot() == [new_token]
+    assert mdm._ws.tokens == [new_token]
     assert mdm._symbol_subscription_generation[symbol] > old_generation
     assert (
         mdm.classify_live_tick_readiness(symbol, new_token, max_age_s=60.0)["ready"]

--- a/tests/data/test_mdm_tick_coalescing.py
+++ b/tests/data/test_mdm_tick_coalescing.py
@@ -112,6 +112,28 @@ async def test_selected_ticks_span_multiple_budget_batches_without_loss(monkeypa
     await _stop_mdm(mdm)
 
 
+@pytest.mark.parametrize("token", [1, 3, 4])
+def test_required_tick_backlog_is_bounded_and_keeps_latest_tick(token: int) -> None:
+    mdm = MarketDataManager(kite=None)
+    _wire_symbols(mdm)
+    mdm._tick_queue_maxsize = 5
+    loop = asyncio.new_event_loop()
+    try:
+        for second in range(20):
+            mdm._enqueue_latest_tick_for_drain(
+                _ws_tick(token, 100 + second, second), loop
+            )
+
+        stats = mdm.get_tick_pressure_stats()
+        pending = mdm._pop_pending_tick_batch()
+
+        assert stats["pending_tick_count"] <= mdm._tick_queue_maxsize
+        assert pending[-1]["last_price"] == 119
+        assert stats["unexplained_loss"] == 0
+    finally:
+        loop.close()
+
+
 @pytest.mark.asyncio
 async def test_direct_push_tick_uses_bounded_drain(monkeypatch):
     mdm = _make_mdm()


### PR DESCRIPTION
## Root cause

- `MarketDataManager._enqueue_latest_tick_for_drain` retained every priority 1/2 tick but enforced the configured limit only against priority-3 ticks, allowing selected-option and spot/futures backlogs to grow without bound.
- `MarketDataManager.request_token_subscription` read the previous token after `register_symbol` had already overwritten the mapping, so stale token intent was not removed on rollover.
- One history-import result test still asserted the superseded conflict behavior even though the production contract and dedicated tests require REST history to reconcile WS-built overlaps.

## What changed

- Coalesce only non-position protected backlog after the configured pending limit, retaining the newest tick and preserving all priority-0 open-position ticks.
- Capture the previous token before remapping so desired and WebSocket subscription state contains only the replacement token.
- Correct the contradictory history-result regression test and add focused bounded-backlog and token-rollover coverage in existing test files.

## What did not change

- No strategy, risk, execution, order, position, readiness threshold, freshness threshold, queue-size configuration, or CandleEngine behavior changed.
- Normal-load FIFO behavior and open-position tick protection remain unchanged.

## Validation

- `python -m compileall -q src tests` — passed
- Focused rollover/backlog/history tests — passed
- `python -m pytest -q tests/data --basetemp=...` — passed
- `python -m pytest -q tests/core --basetemp=...` — passed
- `python -m pytest -q tests/streaming` — passed
- `python -m pytest -q tests/execution --basetemp=...` — passed
- `python -m pytest -q --basetemp=...` — passed, `PYTEST_EXIT_CODE=0`
- Changed-line Black and critical Ruff checks — passed

The Windows live-simulation run reached entry and target exit but reproduced an existing execution-reconciliation timing race after the simulated fill. This diff does not touch that path; the Linux E2E CI check remains the merge gate.

## Runtime impact

- Startup: unchanged.
- Market data: required-symbol backlog is bounded under overload; stale token intent is removed during rollover.
- Option hydration and strategy evaluation: unchanged under normal load; new entries remain blocked by the existing overload guard.
- Risk and execution: unchanged; open-position ticks remain fully protected.
- Telegram diagnostics: unchanged.

## Regression risk

- Under overload, intermediate non-position selected/context ticks may be coalesced. The latest tick is retained, open-position ticks are never coalesced, and the existing overload guard prevents new entries until recovery.
