### PR TITLE
fix: scope history continuity checks to current session

### DIFF
--- a/src/nifty_scalper_bot/core/history_readiness.py
+++ b/src/nifty_scalper_bot/core/history_readiness.py
@@ -297,21 +297,20 @@ def _evaluate_recent_history_quality(
         and expected is not None
         and last >= expected - timedelta(minutes=max_lag_minutes)
     )
-    window_size = max(required_bars, continuity_window_bars)
-    window = ordered[-window_size:] if window_size > 0 else ordered
+    latest_session_date = ordered[-1].astimezone(IST).date() if ordered else None
+    session_bars = [
+        ts
+        for ts in ordered
+        if latest_session_date is not None
+        and ts.astimezone(IST).date() == latest_session_date
+        and time(9, 15) <= ts.astimezone(IST).time() <= time(15, 29)
+    ]
+    window_size = max(int(continuity_window_bars), 2)
+    window = session_bars[-window_size:]
     missing = 0
     largest_gap = 0
     for left, right in zip(window, window[1:]):
-        l_ist = left.astimezone(IST)
-        r_ist = right.astimezone(IST)
-        if l_ist.date() != r_ist.date() or not is_nse_trading_day(l_ist.date()):
-            continue
-        if not (
-            time(9, 15) <= l_ist.time() <= time(15, 29)
-            and time(9, 15) <= r_ist.time() <= time(15, 29)
-        ):
-            continue
-        gap = int((r_ist - l_ist).total_seconds() // 60)
+        gap = int((right - left).total_seconds() // 60)
         if gap > 1:
             missing += gap - 1
             largest_gap = max(largest_gap, gap)

--- a/tests/core/test_history_quality.py
+++ b/tests/core/test_history_quality.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import date, datetime, timezone
+from datetime import date, datetime, timedelta, timezone
 from types import SimpleNamespace
 from zoneinfo import ZoneInfo
 
@@ -14,6 +14,11 @@ from nifty_scalper_bot.core.history_readiness import (
 )
 
 IST = ZoneInfo("Asia/Kolkata")
+
+
+def bar(day: date, hour: int, minute: int) -> dict[str, datetime]:
+    start = datetime(day.year, day.month, day.day, hour, 0, tzinfo=IST)
+    return {"timestamp": start + timedelta(minutes=minute)}
 
 
 def trading(day: date) -> bool:
@@ -237,3 +242,90 @@ def test_option_context_gap_is_diagnostic_not_role_specific_execution_blocker() 
     assert result.recent_window_contiguous is False
     assert "selected_ce_history_gap_detected" not in result.blockers
     assert "option_context_history_gap_detected" in result.blockers
+
+
+def test_previous_session_gap_does_not_block_current_session_history() -> None:
+    previous = date(2026, 1, 1)
+    current = date(2026, 1, 2)
+    bars = [
+        bar(previous, 9, 15),
+        bar(previous, 9, 17),
+        bar(current, 9, 15),
+        bar(current, 9, 16),
+        bar(current, 9, 17),
+        bar(current, 9, 18),
+    ]
+
+    quality = _evaluate_recent_history_quality(
+        bars,
+        role="selected_ce",
+        required_bars=3,
+        now_utc=datetime(2026, 1, 2, 9, 19, tzinfo=IST).astimezone(timezone.utc),
+        max_lag_minutes=2,
+        publication_grace_seconds=0,
+        allowed_missing_minutes=0,
+        continuity_window_bars=10,
+        provider_error=None,
+    )
+
+    assert quality.recent_window_contiguous is True
+    assert quality.missing_minute_count == 0
+    assert "selected_ce_history_gap_detected" not in quality.blockers
+
+
+def test_current_session_gap_still_blocks_history() -> None:
+    current = date(2026, 1, 2)
+    bars = [
+        bar(current, 9, 15),
+        bar(current, 9, 16),
+        bar(current, 9, 18),
+    ]
+
+    quality = _evaluate_recent_history_quality(
+        bars,
+        role="selected_ce",
+        required_bars=3,
+        now_utc=datetime(2026, 1, 2, 9, 19, tzinfo=IST).astimezone(timezone.utc),
+        max_lag_minutes=2,
+        publication_grace_seconds=0,
+        allowed_missing_minutes=0,
+        continuity_window_bars=10,
+        provider_error=None,
+    )
+
+    assert quality.recent_window_contiguous is False
+    assert quality.missing_minute_count == 1
+    assert "selected_ce_history_gap_detected" in quality.blockers
+
+
+def test_required_historical_depth_does_not_enlarge_continuity_window() -> None:
+    previous = date(2026, 1, 1)
+    current = date(2026, 1, 2)
+    previous_bars = [
+        bar(previous, 9 + (idx // 60), 15 + (idx % 60))
+        for idx in range(50)
+        if idx != 12
+    ]
+    current_bars = [
+        bar(current, 9, 15),
+        bar(current, 9, 16),
+        bar(current, 9, 17),
+        bar(current, 9, 18),
+        bar(current, 9, 19),
+    ]
+
+    quality = _evaluate_recent_history_quality(
+        [*previous_bars, *current_bars],
+        role="selected_ce",
+        required_bars=50,
+        now_utc=datetime(2026, 1, 2, 9, 20, tzinfo=IST).astimezone(timezone.utc),
+        max_lag_minutes=2,
+        publication_grace_seconds=0,
+        allowed_missing_minutes=0,
+        continuity_window_bars=5,
+        provider_error=None,
+    )
+
+    assert quality.recent_window_contiguous is True
+    assert quality.missing_minute_count == 0
+    assert "selected_ce_history_gap_detected" not in quality.blockers


### PR DESCRIPTION
### Motivation
- Recent readiness logic mixed long-term `required_bars` with the short-term `continuity_window_bars`, causing gaps in previous trading sessions to be treated as current-session continuity failures and incorrectly blocking live readiness at market open.
- The change keeps CandleEngine as the canonical owner and preserves latest-bar freshness, allowed-missing thresholds, and blocker semantics while preventing false positives from yesterday's missing minutes.

### Description
- Restrict `_evaluate_recent_history_quality()` continuity checks to bars from the latest IST trading session only and build the continuity window from those session bars. (`src/nifty_scalper_bot/core/history_readiness.py`)
- Size the continuity window using only `continuity_window_bars` (minimum 2) and stop using `required_bars` to enlarge the recent-gap lookback.
- Simplified the gap loop to compute minute gaps directly between adjacent session bars; preserved `latest_fresh`, `expected_latest_ts_utc`, invalid-timestamp handling, provider-error behavior, and blocker naming.
- Added regression tests that (1) ensure a previous-session gap does not block current-session readiness, (2) ensure a current-session gap still blocks, and (3) verify large `required_bars` does not expand the continuity window. (`tests/core/test_history_quality.py`)

### Testing
- Ran focused unit tests: `python -m pytest -q tests/core/test_history_quality.py` — passed.
- Ran affected readiness and hydration suites: `python -m pytest -q tests/core/test_runtime_readiness.py tests/core/test_runtime_history_orchestration.py tests/core/test_selected_option_exec_min_regression.py tests/core/test_hydration_status_propagation.py` — passed.
- Ran architecture ownership test: `python -m pytest -q tests/architecture/test_history_ownership.py` — passed.
- Executed live-simulation smoke: `ALLOW_NETWORK=false ALLOW_REAL_BROKER=false BROKER_SIMULATION=true EXECUTION_MODE=LIVE_SIMULATION python -m pytest -q -m live_runtime_e2e tests/e2e/live_sim` — passed.
- Static and formatter checks: `python -m compileall -q src tests`, `python -m ruff check src/nifty_scalper_bot/core/history_readiness.py tests/core/test_history_quality.py`, and `python -m black --check src/nifty_scalper_bot/core/history_readiness.py tests/core/test_history_quality.py` — all passed.
- Full test run: `python -m pytest -q` completed with `PYTEST_EXIT_CODE=0`.

Files changed: `src/nifty_scalper_bot/core/history_readiness.py`, `tests/core/test_history_quality.py`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5ef4bd7d4c8324ae6678e38e83e4bc)