### PR TITLE
fix: stop non-gating history gaps from blocking live loop

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -8927,8 +8927,13 @@ async def _ensure_active_basket_history(
         mdm_short = int(status.mdm_bars or 0) < required
         runner_short = int(status.runner_bars or 0) < required
         indicator_short = int(status.indicator_bars or 0) < required
-        stale = required > 0 and not bool(status.latest_bar_fresh)
-        gap = required > 0 and not bool(status.recent_window_contiguous)
+        quality_gating = bool(spec["gating"])
+        stale = quality_gating and required > 0 and not bool(status.latest_bar_fresh)
+        gap = (
+            quality_gating
+            and required > 0
+            and not bool(status.recent_window_contiguous)
+        )
         ensure_reason = (
             "history_short"
             if mdm_short

--- a/src/nifty_scalper_bot/core/history_readiness.py
+++ b/src/nifty_scalper_bot/core/history_readiness.py
@@ -528,9 +528,7 @@ def build_symbol_hydration_status(
     evaluated_at_utc = evaluated_at_utc.astimezone(timezone.utc)
     grace = float(_clamped_int_env("HISTORY_PUBLICATION_GRACE_SECONDS", 90, 0, 300))
     max_lag = _clamped_int_env("HISTORY_LATEST_BAR_MAX_LAG_MINUTES", 2, 0, 5)
-    continuity_window = _clamped_int_env(
-        "HISTORY_CONTINUITY_WINDOW_BARS", 50, required, 500
-    )
+    continuity_window = _clamped_int_env("HISTORY_CONTINUITY_WINDOW_BARS", 5, 2, 500)
     allowed_missing = _clamped_int_env(
         "HISTORY_ALLOWED_RECENT_MISSING_MINUTES", 0, 0, 5
     )

--- a/tests/core/test_history_quality.py
+++ b/tests/core/test_history_quality.py
@@ -329,3 +329,49 @@ def test_required_historical_depth_does_not_enlarge_continuity_window() -> None:
     assert quality.recent_window_contiguous is True
     assert quality.missing_minute_count == 0
     assert "selected_ce_history_gap_detected" not in quality.blockers
+
+
+def test_build_symbol_hydration_status_defaults_to_five_bar_continuity_window(
+    monkeypatch,
+) -> None:
+    monkeypatch.delenv("HISTORY_CONTINUITY_WINDOW_BARS", raising=False)
+    monkeypatch.setenv("HISTORY_PUBLICATION_GRACE_SECONDS", "0")
+    current = date(2026, 1, 2)
+
+    def make_bars_without(missing_idx: int) -> list[dict[str, datetime]]:
+        return [
+            bar(current, 9 + (idx // 60), 15 + (idx % 60))
+            for idx in range(52)
+            if idx != missing_idx
+        ]
+
+    ctx = SimpleNamespace(
+        market_data_manager=SimpleNamespace(
+            get_ohlc_bars=lambda *_a, **_k: make_bars_without(10)
+        ),
+        data_hub=None,
+        strategy_runner=None,
+    )
+
+    quality = build_symbol_hydration_status(
+        ctx,
+        "NSE:NIFTY",
+        "spot",
+        50,
+        now_utc=datetime(2026, 1, 2, 10, 7, tzinfo=IST).astimezone(timezone.utc),
+    )
+
+    assert quality.recent_window_contiguous is True
+    assert "spot_history_gap_detected" not in quality.blocker_reasons
+
+    ctx.market_data_manager.get_ohlc_bars = lambda *_a, **_k: make_bars_without(49)
+    quality = build_symbol_hydration_status(
+        ctx,
+        "NSE:NIFTY",
+        "spot",
+        50,
+        now_utc=datetime(2026, 1, 2, 10, 7, tzinfo=IST).astimezone(timezone.utc),
+    )
+
+    assert quality.recent_window_contiguous is False
+    assert "spot_history_gap_detected" in quality.blocker_reasons

--- a/tests/core/test_runtime_history_orchestration.py
+++ b/tests/core/test_runtime_history_orchestration.py
@@ -753,3 +753,107 @@ async def test_active_basket_cooldown_bypassed_by_change_or_requirement(
         phase="runtime",
     )
     assert len(mdm.calls) > first * 2
+
+
+@pytest.mark.asyncio
+async def test_non_gating_option_context_gap_does_not_fetch_or_sync(
+    monkeypatch,
+) -> None:
+    mdm = _ActiveMDM()
+    runner = _ActiveRunner()
+    c = _active_ctx(mdm, runner)
+    context_symbol = "NFO:NIFTY2661623100CE"
+
+    def fake_status(_ctx, symbol, _role, _required):
+        if symbol == context_symbol:
+            return _status(
+                bars=40,
+                runner_bars=40,
+                indicator_bars=40,
+                fresh=False,
+                contiguous=False,
+            )
+        return _status(bars=40, runner_bars=40, indicator_bars=40)
+
+    monkeypatch.setattr(app, "build_symbol_hydration_status", fake_status)
+
+    result = await app._ensure_active_basket_history(
+        c,
+        option_required_bars=30,
+        context_required_bars=20,
+        reason="readiness",
+        phase="runtime",
+    )
+
+    assert [call for call in mdm.calls if call[0] == context_symbol] == []
+    assert [call for call in runner.calls if call[0] == context_symbol] == []
+    assert result[context_symbol]["reason"] in {"ready", "skipped", "non_gating"}
+
+
+@pytest.mark.asyncio
+async def test_selected_option_gap_still_fetches_recovery_gap_fill(monkeypatch) -> None:
+    mdm = _ActiveMDM()
+    runner = _ActiveRunner()
+    c = _active_ctx(mdm, runner)
+    selected_symbol = "NFO:NIFTY2661623000CE"
+
+    def fake_status(_ctx, symbol, _role, _required):
+        if symbol == selected_symbol:
+            return _status(
+                bars=40,
+                runner_bars=40,
+                indicator_bars=40,
+                fresh=True,
+                contiguous=False,
+            )
+        return _status(bars=40, runner_bars=40, indicator_bars=40)
+
+    monkeypatch.setattr(app, "build_symbol_hydration_status", fake_status)
+
+    result = await app._ensure_active_basket_history(
+        c,
+        option_required_bars=30,
+        context_required_bars=20,
+        reason="readiness",
+        phase="runtime",
+    )
+
+    selected_calls = [call for call in mdm.calls if call[0] == selected_symbol]
+    assert selected_calls
+    assert selected_calls[0][1]["reason"] == "recovery_gap_fill"
+    assert result[selected_symbol].symbol == selected_symbol
+
+
+@pytest.mark.asyncio
+async def test_non_gating_option_context_short_history_still_hydrates(
+    monkeypatch,
+) -> None:
+    mdm = _ActiveMDM()
+    runner = _ActiveRunner()
+    c = _active_ctx(mdm, runner)
+    context_symbol = "NFO:NIFTY2661623100CE"
+
+    def fake_status(_ctx, symbol, _role, _required):
+        if symbol == context_symbol:
+            return _status(
+                bars=10,
+                runner_bars=40,
+                indicator_bars=40,
+                fresh=True,
+                contiguous=True,
+            )
+        return _status(bars=40, runner_bars=40, indicator_bars=40)
+
+    monkeypatch.setattr(app, "build_symbol_hydration_status", fake_status)
+
+    await app._ensure_active_basket_history(
+        c,
+        option_required_bars=30,
+        context_required_bars=20,
+        reason="readiness",
+        phase="runtime",
+    )
+
+    context_calls = [call for call in mdm.calls if call[0] == context_symbol]
+    assert context_calls
+    assert context_calls[0][1]["reason"] == "history_short"


### PR DESCRIPTION
### Motivation

- Live runtime occasionally becomes blocked by historical gaps that are older than the intended recent continuity check, because `HISTORY_CONTINUITY_WINDOW_BARS` was clamped to `required_bars`.  
- Non-gating option-context symbols (background strikes) were triggering full recovery work when only a recent continuity proof or latest-bar freshness check failed, causing repeated `recovery_gap_fill` cycles and event-loop pressure.  
- Make the smallest safe production change to separate recent continuity proof from total historical depth and to restrict gap/stale recovery to hard-gating market symbols while preserving fail-closed behavior and background hydration for genuinely short non-gating symbols.

### Description

- In `src/nifty_scalper_bot/core/history_readiness.py` changed the continuity window env clamp from `50, required, 500` to `5, 2, 500`, so `HISTORY_CONTINUITY_WINDOW_BARS` defaults to `5` and no longer grows with `required_bars`.  
- In `src/nifty_scalper_bot/core/app.py` updated `_ensure_active_basket_history()` to gate `stale` and `gap` checks behind the per-symbol `spec["gating"]` flag (introduced `quality_gating = bool(spec["gating"])`) so only hard-gating symbols (spot, futures, selected CE/PE) trigger `history_stale` / `recovery_gap_fill` fetches.  
- Added focused regression tests in `tests/core/test_history_quality.py` and `tests/core/test_runtime_history_orchestration.py` to verify five-bar continuity default, that gaps older than the continuity window do not block, that gaps inside the window do block, that non-gating context gaps do not trigger fetch/sync, that selected-option gaps still use `recovery_gap_fill`, and that non-gating short history still hydrates.  
- No new production files were added and ownership of `CandleEngine` / `MarketDataManager` / runner / indicators / execution/risk behaviour was preserved.

### Testing

- Ran focused tests: `python -m pytest -q tests/core/test_history_quality.py tests/core/test_runtime_history_orchestration.py` and they passed.  
- Ran broader suites and checks including `tests/core/test_runtime_readiness.py`, `tests/core/test_selected_option_exec_min_regression.py`, `tests/core/test_hydration_status_propagation.py`, `tests/architecture/test_history_ownership.py`, `tests/strategies`, `tests/data`, and the live-simulation e2e (`ALLOW_NETWORK=false ... python -m pytest -q -m live_runtime_e2e tests/e2e/live_sim`), all of which completed successfully in the validation run.  
- Ran `python -m compileall -q src tests` and `python -m black --check` against the modified files; `black` reformatted/checked the edited files and checks passed.  
- Ran `python -m ruff check` scoped to the touched readiness and test files and they passed, while a full repository `ruff` run still reports pre-existing lint debt in `src/nifty_scalper_bot/core/app.py` outside this minimal change (no production behaviour impacted).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5f14dc731c8324bc4ac9c7daa98085)