### PR TITLE
fix: preserve canonical live context and avoid redundant history propagation

### DIFF
--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -1975,6 +1975,54 @@ class StrategyRunner:
             },
         )
 
+    @staticmethod
+    def _history_row_timestamp(row: Any) -> datetime | None:
+        """Return a comparable UTC timestamp for a cached history row."""
+        value = None
+        if isinstance(row, Mapping):
+            value = (
+                row.get("timestamp")
+                or row.get("start")
+                or row.get("date")
+                or row.get("time")
+            )
+        else:
+            value = getattr(row, "start", None) or getattr(row, "timestamp", None)
+        if value is None:
+            return None
+        try:
+            if isinstance(value, datetime):
+                ts = value
+            elif isinstance(value, (int, float)):
+                raw = float(value)
+                ts = datetime.fromtimestamp(
+                    raw / 1000.0 if raw > 1e12 else raw, tz=timezone.utc
+                )
+            elif isinstance(value, str):
+                ts = datetime.fromisoformat(value.replace("Z", "+00:00"))
+            else:
+                return None
+        except (TypeError, ValueError, OSError, OverflowError):
+            return None
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=timezone.utc)
+        return ts.astimezone(timezone.utc).replace(microsecond=0)
+
+    def _runner_history_last_timestamp(self, symbol: str) -> datetime | None:
+        rows = getattr(self, "_symbol_history", {}).get(symbol, []) or []
+        return self._history_row_timestamp(rows[-1]) if rows else None
+
+    def _indicator_history_last_timestamp(self, symbol: str) -> datetime | None:
+        engine = getattr(self, "_indicator_engine", None)
+        getter = getattr(engine, "get_history", None)
+        if not callable(getter):
+            return None
+        try:
+            rows = getter(symbol, count=1, field="bars")
+        except Exception:
+            return None
+        return self._history_row_timestamp(rows[-1]) if rows else None
+
     def sync_history_from_mdm(
         self,
         symbol: str,
@@ -2011,9 +2059,24 @@ class StrategyRunner:
         source_ready = source_count >= required_count
         indicator_ready = indicator_count >= required_count
         runner_ready = runner_before >= required_count
+        mdm_last_ts = self._history_row_timestamp(rows[-1]) if rows else None
+        runner_last_ts = self._runner_history_last_timestamp(normalized)
+        indicator_last_ts = self._indicator_history_last_timestamp(normalized)
+        runner_current = (
+            runner_ready
+            and runner_last_ts is not None
+            and mdm_last_ts is not None
+            and runner_last_ts >= mdm_last_ts
+        )
+        indicator_current = (
+            indicator_ready
+            and indicator_last_ts is not None
+            and mdm_last_ts is not None
+            and indicator_last_ts >= mdm_last_ts
+        )
         needs_seed = bool(
             rows
-            and (not indicator_ready or not runner_ready)
+            and (not indicator_current or not runner_current)
             and (source_count > min(indicator_count, runner_before) or source_ready)
         )
         if needs_seed:

--- a/src/nifty_scalper_bot/strategies/runtime_context_contract.py
+++ b/src/nifty_scalper_bot/strategies/runtime_context_contract.py
@@ -7,7 +7,6 @@ import os
 import time
 from typing import Any, Mapping
 
-
 _LIVE_DIRECTION_CONTEXT_KEYS = frozenset(
     {
         "direction_bias",
@@ -60,7 +59,12 @@ _TRUTHY = {"1", "true", "yes", "y", "on"}
 
 def _runtime_context_max_age_seconds(default: float = 5.0) -> float:
     try:
-        return max(float(os.getenv("ORDERFLOW_MAX_CONTEXT_AGE_SECONDS", str(default)) or default), 0.0)
+        return max(
+            float(
+                os.getenv("ORDERFLOW_MAX_CONTEXT_AGE_SECONDS", str(default)) or default
+            ),
+            0.0,
+        )
     except (TypeError, ValueError):
         return default
 
@@ -95,9 +99,15 @@ def _coerce_age_seconds(value: Any) -> float | None:
     return age
 
 
-def resolve_context_age_seconds(context: Mapping[str, Any], default: float = 999.0) -> float:
+def resolve_context_age_seconds(
+    context: Mapping[str, Any], default: float = 999.0
+) -> float:
     """Return normalized context age, failing closed for missing/invalid values."""
-    age = _coerce_age_seconds(context.get("context_age_seconds")) if isinstance(context, Mapping) else None
+    age = (
+        _coerce_age_seconds(context.get("context_age_seconds"))
+        if isinstance(context, Mapping)
+        else None
+    )
     return age if age is not None else float(default)
 
 
@@ -109,7 +119,9 @@ def _coerce_timestamp(value: Any) -> datetime | None:
     elif isinstance(value, (int, float)):
         try:
             raw = float(value)
-            ts = datetime.fromtimestamp(raw / 1000.0 if raw > 1e12 else raw, tz=timezone.utc)
+            ts = datetime.fromtimestamp(
+                raw / 1000.0 if raw > 1e12 else raw, tz=timezone.utc
+            )
         except (OSError, OverflowError, ValueError):
             return None
     elif isinstance(value, str):
@@ -124,7 +136,9 @@ def _coerce_timestamp(value: Any) -> datetime | None:
     return ts.astimezone(timezone.utc)
 
 
-def _derive_freshness_from_age(context: Mapping[str, Any], *keys: str, max_age_seconds: float) -> bool | None:
+def _derive_freshness_from_age(
+    context: Mapping[str, Any], *keys: str, max_age_seconds: float
+) -> bool | None:
     for key in keys:
         age = _coerce_age_seconds(context.get(key))
         if age is not None:
@@ -132,7 +146,9 @@ def _derive_freshness_from_age(context: Mapping[str, Any], *keys: str, max_age_s
     return None
 
 
-def live_direction_context_has_proof(context: Mapping[str, Any], *, max_age_seconds: float | None = None) -> bool:
+def live_direction_context_has_proof(
+    context: Mapping[str, Any], *, max_age_seconds: float | None = None
+) -> bool:
     """Return True if live spot/futures context has explicit fresh proof.
 
     This does not invent a CE/PE direction. It only confirms that the missing
@@ -142,14 +158,22 @@ def live_direction_context_has_proof(context: Mapping[str, Any], *, max_age_seco
 
     if not isinstance(context, Mapping):
         return False
-    max_age = _runtime_context_max_age_seconds() if max_age_seconds is None else max(float(max_age_seconds), 0.0)
+    max_age = (
+        _runtime_context_max_age_seconds()
+        if max_age_seconds is None
+        else max(float(max_age_seconds), 0.0)
+    )
     spot_fresh = _coerce_bool(context.get("spot_fresh"))
     fut_fresh = _coerce_bool(context.get("fut_fresh"))
     futures_fresh = _coerce_bool(context.get("futures_fresh"))
     if fut_fresh is None:
         fut_fresh = futures_fresh
-    derived_spot = _derive_freshness_from_age(context, "spot_age_seconds", "spot_tick_age_s", max_age_seconds=max_age)
-    derived_fut = _derive_freshness_from_age(context, "futures_age_seconds", "futures_tick_age_s", max_age_seconds=max_age)
+    derived_spot = _derive_freshness_from_age(
+        context, "spot_age_seconds", "spot_tick_age_s", max_age_seconds=max_age
+    )
+    derived_fut = _derive_freshness_from_age(
+        context, "futures_age_seconds", "futures_tick_age_s", max_age_seconds=max_age
+    )
     if spot_fresh is None:
         spot_fresh = derived_spot
     if fut_fresh is None:
@@ -163,7 +187,9 @@ def normalise_live_direction_context(context: Mapping[str, Any]) -> dict[str, An
     if not isinstance(context, Mapping):
         return {}
 
-    preserved = {key: context[key] for key in _LIVE_DIRECTION_CONTEXT_KEYS if key in context}
+    preserved = {
+        key: context[key] for key in _LIVE_DIRECTION_CONTEXT_KEYS if key in context
+    }
     max_age = _runtime_context_max_age_seconds()
 
     if "direction_bias" not in preserved:
@@ -177,12 +203,20 @@ def normalise_live_direction_context(context: Mapping[str, Any]) -> dict[str, An
         if direction is not None:
             preserved["direction_bias"] = direction
 
-    derived_spot = _derive_freshness_from_age(context, "spot_age_seconds", "spot_tick_age_s", max_age_seconds=max_age)
-    derived_fut = _derive_freshness_from_age(context, "futures_age_seconds", "futures_tick_age_s", max_age_seconds=max_age)
-    if "spot_fresh" not in preserved and derived_spot is not None:
+    derived_spot = _derive_freshness_from_age(
+        context, "spot_age_seconds", "spot_tick_age_s", max_age_seconds=max_age
+    )
+    derived_fut = _derive_freshness_from_age(
+        context, "futures_age_seconds", "futures_tick_age_s", max_age_seconds=max_age
+    )
+    # Tick ages are objective freshness proof from the current canonical
+    # snapshot. When present, replace cached boolean freshness as the matching
+    # age/boolean group so stale merge=False values cannot outlive fresh ticks.
+    if derived_spot is not None:
         preserved["spot_fresh"] = derived_spot
-    if "fut_fresh" not in preserved and derived_fut is not None:
+    if derived_fut is not None:
         preserved["fut_fresh"] = derived_fut
+        preserved["futures_fresh"] = derived_fut
     if "futures_fresh" in preserved and "fut_fresh" not in preserved:
         preserved["fut_fresh"] = bool(preserved["futures_fresh"])
     if "fut_fresh" in preserved and "futures_fresh" not in preserved:
@@ -192,12 +226,20 @@ def normalise_live_direction_context(context: Mapping[str, Any]) -> dict[str, An
     if age is not None:
         preserved["context_age_seconds"] = age
     else:
-        for key in ("context_timestamp", "direction_context_timestamp", "direction_updated_at"):
+        for key in (
+            "context_timestamp",
+            "direction_context_timestamp",
+            "direction_updated_at",
+        ):
             ts = _coerce_timestamp(context.get(key))
             if ts is not None:
-                preserved["context_age_seconds"] = max(0.0, time.time() - ts.timestamp())
+                preserved["context_age_seconds"] = max(
+                    0.0, time.time() - ts.timestamp()
+                )
                 break
-    preserved["live_direction_context_proof"] = live_direction_context_has_proof(preserved, max_age_seconds=max_age)
+    preserved["live_direction_context_proof"] = live_direction_context_has_proof(
+        preserved, max_age_seconds=max_age
+    )
 
     return preserved
 
@@ -214,21 +256,36 @@ def install_indicator_runtime_context_contract() -> bool:
 
     original = current
 
-    def set_runtime_context(self: Any, symbol: str, context: Mapping[str, Any], *, merge: bool = True) -> None:
+    def set_runtime_context(
+        self: Any, symbol: str, context: Mapping[str, Any], *, merge: bool = True
+    ) -> None:
         original(self, symbol, context, merge=merge)
         extras = normalise_live_direction_context(context or {})
         if not symbol or not extras:
             return
         try:
             with self._lock:
-                existing = self._runtime_context.setdefault(symbol, {}) if merge else dict(self._runtime_context.get(symbol, {}) or {})
+                existing = (
+                    self._runtime_context.setdefault(symbol, {})
+                    if merge
+                    else dict(self._runtime_context.get(symbol, {}) or {})
+                )
                 existing.update(extras)
                 self._runtime_context[symbol] = existing
                 self._cache.pop(symbol, None)
         except Exception as exc:
             logger = getattr(self, "_logger", None)
             if logger is not None:
-                logger.error("LIVE_DIRECTION_CONTEXT_PRESERVE_FAILED symbol=%s error=%s", symbol, exc, extra={"event": "LIVE_DIRECTION_CONTEXT_PRESERVE_FAILED", "symbol": symbol, "error": str(exc)})
+                logger.error(
+                    "LIVE_DIRECTION_CONTEXT_PRESERVE_FAILED symbol=%s error=%s",
+                    symbol,
+                    exc,
+                    extra={
+                        "event": "LIVE_DIRECTION_CONTEXT_PRESERVE_FAILED",
+                        "symbol": symbol,
+                        "error": str(exc),
+                    },
+                )
             raise
 
     set_runtime_context.__name__ = getattr(original, "__name__", "set_runtime_context")

--- a/tests/strategies/test_canonical_runner_history_sync.py
+++ b/tests/strategies/test_canonical_runner_history_sync.py
@@ -9,7 +9,17 @@ from nifty_scalper_bot.strategies.runner import StrategyRunner
 
 def _bars(count: int) -> list[dict]:
     base = datetime(2026, 1, 1, 9, 15, tzinfo=timezone.utc)
-    return [{"timestamp": base + timedelta(minutes=i), "open": 1+i, "high": 2+i, "low": 1+i, "close": 2+i, "volume": i} for i in range(count)]
+    return [
+        {
+            "timestamp": base + timedelta(minutes=i),
+            "open": 1 + i,
+            "high": 2 + i,
+            "low": 1 + i,
+            "close": 2 + i,
+            "volume": i,
+        }
+        for i in range(count)
+    ]
 
 
 def _runner(rows: list[dict] | None = None) -> StrategyRunner:
@@ -22,14 +32,20 @@ def _runner(rows: list[dict] | None = None) -> StrategyRunner:
     r._set_symbol_hydration_state = lambda *_a, **_k: None
     r._seed_pipeline_store = lambda *_a, **_k: None
     r._seed_candle_engine_from_history = lambda *_a, **_k: None
-    r._active_symbols = set(); r._tracked_symbols = set(); r._data_phase = {}; r._last_bar_ts = {}
+    r._active_symbols = set()
+    r._tracked_symbols = set()
+    r._data_phase = {}
+    r._last_bar_ts = {}
     r._runtime_history_ensure_inflight = {}
     r._runtime_history_ensure_roles = {}
     r._hydration_attempted_symbols = set()
     r._last_hydration_reason_by_symbol = {}
     r._history_role_for_symbol = lambda _s: "spot_context"
     # sync must not start a broker fetch when request_if_short=False
-    r._schedule_runtime_history_ensure = lambda *_a, **_k: (_ for _ in ()).throw(AssertionError("no scheduling from sync when request_if_short=False"))
+    r._schedule_runtime_history_ensure = lambda *_a, **_k: (_ for _ in ()).throw(
+        AssertionError("no scheduling from sync when request_if_short=False")
+    )
+
     def _reseed(symbol, bars, *, source="", min_bars=0):
         rows_list = list(bars or [])
         r._symbol_history[symbol] = list(rows_list)
@@ -39,13 +55,20 @@ def _runner(rows: list[dict] | None = None) -> StrategyRunner:
             except Exception:
                 pass
         return len(rows_list)
+
     r.reseed_history_from_bars = _reseed
     return r
 
 
 async def test_mdm_warm_runner_and_indicator_cold_sync_only() -> None:
     r = _runner(_bars(30))
-    result = r.sync_history_from_mdm("NSE:NIFTY", required_bars=30, reason="test", role="spot_context", request_if_short=False)
+    result = r.sync_history_from_mdm(
+        "NSE:NIFTY",
+        required_bars=30,
+        reason="test",
+        role="spot_context",
+        request_if_short=False,
+    )
     assert result.success
     assert result.runner_bars >= 30
     assert result.indicator_bars >= 30
@@ -54,30 +77,52 @@ async def test_mdm_warm_runner_and_indicator_cold_sync_only() -> None:
 async def test_mdm_warm_indicator_cold_reseeds_without_fetch() -> None:
     r = _runner(_bars(30))
     r._symbol_history["NSE:NIFTY"] = [object()] * 30
-    result = r.sync_history_from_mdm("NSE:NIFTY", required_bars=30, reason="test", role="spot_context", request_if_short=False)
+    result = r.sync_history_from_mdm(
+        "NSE:NIFTY",
+        required_bars=30,
+        reason="test",
+        role="spot_context",
+        request_if_short=False,
+    )
     assert result.success
     assert result.failure_reason is None
 
 
 async def test_reseed_failure_returns_failed_result() -> None:
     r = _runner(_bars(30))
+
     def bad_reseed(*_a, **_k):
         raise ValueError("bad rows")
+
     r.reseed_history_from_bars = bad_reseed  # type: ignore[method-assign]
-    result = r.sync_history_from_mdm("NSE:NIFTY", required_bars=30, reason="test", role="spot_context", request_if_short=False)
+    result = r.sync_history_from_mdm(
+        "NSE:NIFTY",
+        required_bars=30,
+        reason="test",
+        role="spot_context",
+        request_if_short=False,
+    )
     assert not result.success
-    assert result.failure_reason and result.failure_reason.startswith("runner_reseed_failed")
+    assert result.failure_reason and result.failure_reason.startswith(
+        "runner_reseed_failed"
+    )
 
 
 async def test_selected_option_classification_exact_and_unknown_false() -> None:
     r = _runner([])
     r._active_selected_ce = "NFO:NIFTY26JUN23600CE"
     r._active_selected_pe = "NFO:NIFTY26JUN23600PE"
-    r._selected_ce_symbol = None; r._selected_pe_symbol = None; r._pending_selected_ce = None; r._pending_selected_pe = None
-    r._active_contract_basket = None; r._data_hub = None; r._market_data = None
+    r._selected_ce_symbol = None
+    r._selected_pe_symbol = None
+    r._pending_selected_ce = None
+    r._pending_selected_pe = None
+    r._active_contract_basket = None
+    r._data_hub = None
+    r._market_data = None
     assert r._is_selected_option_symbol("NFO:NIFTY26JUN23600CE")
     assert not r._is_selected_option_symbol("NFO:NIFTY26JUN23500CE")
-    r._active_selected_ce = None; r._active_selected_pe = None
+    r._active_selected_ce = None
+    r._active_selected_pe = None
     assert not r._is_selected_option_symbol("NFO:NIFTY26JUN23600CE")
 
 
@@ -85,14 +130,24 @@ async def test_compat_wrapper_delegates_to_canonical_sync() -> None:
     r = _runner(_bars(5))
     r._required_bars_for_symbol = lambda _s: 5
     r._symbol_role_for_runner = lambda _s: "spot_context"
-    assert r._sync_history_from_mdm_cache("NSE:NIFTY", required_bars=5, request_if_short=False) >= 5
+    assert (
+        r._sync_history_from_mdm_cache(
+            "NSE:NIFTY", required_bars=5, request_if_short=False
+        )
+        >= 5
+    )
 
 
 # ---- Canonical scheduling on short history (spec §1/§9) ----
 
+
 def _runner_for_scheduling():
     r = StrategyRunner.__new__(StrategyRunner)
-    r._logger = SimpleNamespace(info=lambda *a, **k: None, warning=lambda *a, **k: None, debug=lambda *a, **k: None)
+    r._logger = SimpleNamespace(
+        info=lambda *a, **k: None,
+        warning=lambda *a, **k: None,
+        debug=lambda *a, **k: None,
+    )
     r._normalize_symbol = lambda s: str(s)
     r._symbol_history = {}
     r._indicator_engine = IndicatorEngine()
@@ -106,18 +161,39 @@ def _runner_for_scheduling():
     return r
 
 
-async def test_short_history_schedules_canonical_ensurer_not_request_hydration() -> None:
+async def test_short_history_schedules_canonical_ensurer_not_request_hydration() -> (
+    None
+):
     r = _runner_for_scheduling()
     calls = []
-    async def _ensurer(symbol, *, role, phase, reason, required_bars=None, target_bars=None):
+
+    async def _ensurer(
+        symbol, *, role, phase, reason, required_bars=None, target_bars=None
+    ):
         calls.append((symbol, role, phase, reason, required_bars))
+
     r.set_runtime_history_ensurer(_ensurer)
     # DataHub/MDM request_hydration must never be touched.
-    r._data_hub = SimpleNamespace(request_hydration=lambda *a, **k: (_ for _ in ()).throw(AssertionError("DataHub request_hydration must not be called")))
-    r._market_data = SimpleNamespace(request_hydration=lambda *a, **k: (_ for _ in ()).throw(AssertionError("MDM request_hydration must not be called")))
-    result = r.sync_history_from_mdm("NFO:NIFTY26JUN24000CE", required_bars=30, reason="t", role="selected_option", request_if_short=True)
+    r._data_hub = SimpleNamespace(
+        request_hydration=lambda *a, **k: (_ for _ in ()).throw(
+            AssertionError("DataHub request_hydration must not be called")
+        )
+    )
+    r._market_data = SimpleNamespace(
+        request_hydration=lambda *a, **k: (_ for _ in ()).throw(
+            AssertionError("MDM request_hydration must not be called")
+        )
+    )
+    result = r.sync_history_from_mdm(
+        "NFO:NIFTY26JUN24000CE",
+        required_bars=30,
+        reason="t",
+        role="selected_option",
+        request_if_short=True,
+    )
     assert result.success is False
     import asyncio as _asyncio
+
     for _ in range(5):
         await _asyncio.sleep(0)
         if calls:
@@ -133,23 +209,45 @@ async def test_short_history_schedules_canonical_ensurer_not_request_hydration()
 async def test_missing_ensurer_fails_safe_no_request_hydration() -> None:
     r = _runner_for_scheduling()
     r._runtime_history_ensurer = None
-    r._data_hub = SimpleNamespace(request_hydration=lambda *a, **k: (_ for _ in ()).throw(AssertionError("must not fall back")))
-    r._market_data = SimpleNamespace(request_hydration=lambda *a, **k: (_ for _ in ()).throw(AssertionError("must not fall back")))
+    r._data_hub = SimpleNamespace(
+        request_hydration=lambda *a, **k: (_ for _ in ()).throw(
+            AssertionError("must not fall back")
+        )
+    )
+    r._market_data = SimpleNamespace(
+        request_hydration=lambda *a, **k: (_ for _ in ()).throw(
+            AssertionError("must not fall back")
+        )
+    )
     # must not raise
-    result = r.sync_history_from_mdm("NFO:NIFTY26JUN24000CE", required_bars=30, reason="t", role="selected_option", request_if_short=True)
+    result = r.sync_history_from_mdm(
+        "NFO:NIFTY26JUN24000CE",
+        required_bars=30,
+        reason="t",
+        role="selected_option",
+        request_if_short=True,
+    )
     assert result.success is False
 
 
 async def test_duplicate_scheduling_suppressed() -> None:
     r = _runner_for_scheduling()
     n = {"count": 0}
+
     async def _ensurer(symbol, **kw):
         n["count"] += 1
+
     r.set_runtime_history_ensurer(_ensurer)
     # pre-mark inflight to simulate an active request
     r._runtime_history_ensure_inflight["NFO:NIFTY26JUN24000CE"] = 30
     r._runtime_history_ensure_roles["NFO:NIFTY26JUN24000CE"] = "selected_option"
-    scheduled = r._schedule_runtime_history_ensure("NFO:NIFTY26JUN24000CE", role="selected_option", phase="runner_sync", reason="t", required_bars=30)
+    scheduled = r._schedule_runtime_history_ensure(
+        "NFO:NIFTY26JUN24000CE",
+        role="selected_option",
+        phase="runner_sync",
+        reason="t",
+        required_bars=30,
+    )
     assert scheduled is True  # already inflight counts as scheduled
     assert n["count"] == 0  # callback not invoked again
 
@@ -157,11 +255,19 @@ async def test_duplicate_scheduling_suppressed() -> None:
 async def test_reseed_runtime_error_returns_structured_failure() -> None:
     r = _runner_for_scheduling()
     r._get_mdm_bars = lambda _s, limit: _bars(30)
+
     def _boom(*_a, **_k):
         raise RuntimeError("kaboom")
+
     r.reseed_history_from_bars = _boom
     r._schedule_runtime_history_ensure = lambda *a, **k: True
-    result = r.sync_history_from_mdm("NSE:NIFTY", required_bars=30, reason="t", role="spot_context", request_if_short=False)
+    result = r.sync_history_from_mdm(
+        "NSE:NIFTY",
+        required_bars=30,
+        reason="t",
+        role="spot_context",
+        request_if_short=False,
+    )
     assert result.success is False
     assert "runner_reseed_failed:RuntimeError" in (result.failure_reason or "")
 
@@ -169,15 +275,24 @@ async def test_reseed_runtime_error_returns_structured_failure() -> None:
 async def test_same_target_stronger_role_schedules_upgrade_selected_option() -> None:
     r = _runner_for_scheduling()
     calls = []
+
     async def _ensurer(symbol, **kw):
         calls.append((symbol, kw))
+
     r.set_runtime_history_ensurer(_ensurer)
     r._runtime_history_ensure_inflight["NFO:NIFTY26JUN24000CE"] = 30
     r._runtime_history_ensure_roles["NFO:NIFTY26JUN24000CE"] = "option_context"
 
-    assert r._schedule_runtime_history_ensure("NFO:NIFTY26JUN24000CE", role="selected_option", phase="runner_sync", reason="upgrade", required_bars=30)
+    assert r._schedule_runtime_history_ensure(
+        "NFO:NIFTY26JUN24000CE",
+        role="selected_option",
+        phase="runner_sync",
+        reason="upgrade",
+        required_bars=30,
+    )
 
     import asyncio as _asyncio
+
     for _ in range(5):
         await _asyncio.sleep(0)
         if calls:
@@ -189,14 +304,23 @@ async def test_same_target_stronger_role_schedules_upgrade_selected_option() -> 
 async def test_same_target_weaker_role_suppresses_existing_selected_option() -> None:
     r = _runner_for_scheduling()
     calls = []
+
     async def _ensurer(symbol, **kw):
         calls.append((symbol, kw))
+
     r.set_runtime_history_ensurer(_ensurer)
     r._runtime_history_ensure_inflight["NFO:NIFTY26JUN24000CE"] = 30
     r._runtime_history_ensure_roles["NFO:NIFTY26JUN24000CE"] = "selected_option"
 
-    assert r._schedule_runtime_history_ensure("NFO:NIFTY26JUN24000CE", role="option_context", phase="runner_sync", reason="weaker", required_bars=30)
+    assert r._schedule_runtime_history_ensure(
+        "NFO:NIFTY26JUN24000CE",
+        role="option_context",
+        phase="runner_sync",
+        reason="weaker",
+        required_bars=30,
+    )
     import asyncio as _asyncio
+
     await _asyncio.sleep(0)
     assert calls == []
 
@@ -204,14 +328,23 @@ async def test_same_target_weaker_role_suppresses_existing_selected_option() -> 
 async def test_same_target_recovery_role_schedules_upgrade() -> None:
     r = _runner_for_scheduling()
     calls = []
+
     async def _ensurer(symbol, **kw):
         calls.append((symbol, kw))
+
     r.set_runtime_history_ensurer(_ensurer)
     r._runtime_history_ensure_inflight["NFO:NIFTY26JUN24000CE"] = 30
     r._runtime_history_ensure_roles["NFO:NIFTY26JUN24000CE"] = "option_context"
 
-    assert r._schedule_runtime_history_ensure("NFO:NIFTY26JUN24000CE", role="recovery_or_open_position", phase="runner_sync", reason="recovery", required_bars=30)
+    assert r._schedule_runtime_history_ensure(
+        "NFO:NIFTY26JUN24000CE",
+        role="recovery_or_open_position",
+        phase="runner_sync",
+        reason="recovery",
+        required_bars=30,
+    )
     import asyncio as _asyncio
+
     for _ in range(5):
         await _asyncio.sleep(0)
         if calls:
@@ -222,14 +355,23 @@ async def test_same_target_recovery_role_schedules_upgrade() -> None:
 async def test_smaller_target_weaker_role_suppresses_larger_selected_option() -> None:
     r = _runner_for_scheduling()
     calls = []
+
     async def _ensurer(symbol, **kw):
         calls.append((symbol, kw))
+
     r.set_runtime_history_ensurer(_ensurer)
     r._runtime_history_ensure_inflight["NFO:NIFTY26JUN24000CE"] = 75
     r._runtime_history_ensure_roles["NFO:NIFTY26JUN24000CE"] = "selected_option"
 
-    assert r._schedule_runtime_history_ensure("NFO:NIFTY26JUN24000CE", role="option_context", phase="runner_sync", reason="smaller", required_bars=30)
+    assert r._schedule_runtime_history_ensure(
+        "NFO:NIFTY26JUN24000CE",
+        role="option_context",
+        phase="runner_sync",
+        reason="smaller",
+        required_bars=30,
+    )
     import asyncio as _asyncio
+
     await _asyncio.sleep(0)
     assert calls == []
 
@@ -237,14 +379,24 @@ async def test_smaller_target_weaker_role_suppresses_larger_selected_option() ->
 async def test_larger_target_and_stronger_role_preserves_both_upgrades() -> None:
     r = _runner_for_scheduling()
     calls = []
+
     async def _ensurer(symbol, **kw):
         calls.append((symbol, kw))
+
     r.set_runtime_history_ensurer(_ensurer)
     r._runtime_history_ensure_inflight["NFO:NIFTY26JUN24000CE"] = 30
     r._runtime_history_ensure_roles["NFO:NIFTY26JUN24000CE"] = "option_context"
 
-    assert r._schedule_runtime_history_ensure("NFO:NIFTY26JUN24000CE", role="selected_option", phase="runner_sync", reason="both", required_bars=30, target_bars=75)
+    assert r._schedule_runtime_history_ensure(
+        "NFO:NIFTY26JUN24000CE",
+        role="selected_option",
+        phase="runner_sync",
+        reason="both",
+        required_bars=30,
+        target_bars=75,
+    )
     import asyncio as _asyncio
+
     for _ in range(5):
         await _asyncio.sleep(0)
         if calls:
@@ -253,10 +405,14 @@ async def test_larger_target_and_stronger_role_preserves_both_upgrades() -> None
     assert calls[0][1]["target_bars"] == 75
 
 
-async def test_create_task_failure_closes_coroutine_and_does_not_overwrite_newer_upgrade(monkeypatch, recwarn) -> None:
+async def test_create_task_failure_closes_coroutine_and_does_not_overwrite_newer_upgrade(
+    monkeypatch, recwarn
+) -> None:
     r = _runner_for_scheduling()
+
     async def _ensurer(symbol, **kw):
         raise AssertionError("callback must not run when scheduling fails")
+
     r.set_runtime_history_ensurer(_ensurer)
     r._runtime_history_ensure_inflight["NFO:NIFTY26JUN24000CE"] = 30
     r._runtime_history_ensure_roles["NFO:NIFTY26JUN24000CE"] = "option_context"
@@ -266,18 +422,34 @@ async def test_create_task_failure_closes_coroutine_and_does_not_overwrite_newer
             # Simulate a concurrent stronger same-target upgrade that wins before
             # rollback executes; rollback must not overwrite this role marker.
             r._runtime_history_ensure_inflight["NFO:NIFTY26JUN24000CE"] = 30
-            r._runtime_history_ensure_roles["NFO:NIFTY26JUN24000CE"] = "recovery_or_open_position"
+            r._runtime_history_ensure_roles["NFO:NIFTY26JUN24000CE"] = (
+                "recovery_or_open_position"
+            )
             raise RuntimeError("create_task boom")
 
-    monkeypatch.setattr("nifty_scalper_bot.strategies.runner.asyncio.get_running_loop", lambda: _Loop())
-    scheduled = r._schedule_runtime_history_ensure("NFO:NIFTY26JUN24000CE", role="selected_option", phase="runner_sync", reason="fail", required_bars=30)
+    monkeypatch.setattr(
+        "nifty_scalper_bot.strategies.runner.asyncio.get_running_loop", lambda: _Loop()
+    )
+    scheduled = r._schedule_runtime_history_ensure(
+        "NFO:NIFTY26JUN24000CE",
+        role="selected_option",
+        phase="runner_sync",
+        reason="fail",
+        required_bars=30,
+    )
 
     assert scheduled is False
     assert r._runtime_history_ensure_inflight["NFO:NIFTY26JUN24000CE"] == 30
-    assert r._runtime_history_ensure_roles["NFO:NIFTY26JUN24000CE"] == "recovery_or_open_position"
+    assert (
+        r._runtime_history_ensure_roles["NFO:NIFTY26JUN24000CE"]
+        == "recovery_or_open_position"
+    )
     assert [w for w in recwarn if "was never awaited" in str(w.message)] == []
 
-async def test_selected_option_with_canonical_source_warm_indicator_short_reseeds_immediately() -> None:
+
+async def test_selected_option_with_canonical_source_warm_indicator_short_reseeds_immediately() -> (
+    None
+):
     r = _runner(_bars(50))
     symbol = "NFO:NIFTY26JUN24000CE"
     r._symbol_history[symbol] = _bars(15)
@@ -298,7 +470,9 @@ async def test_selected_option_with_canonical_source_warm_indicator_short_reseed
     assert result.indicator_bars >= 30
 
 
-async def test_indicator_equal_to_short_source_remains_not_ready_without_false_success() -> None:
+async def test_indicator_equal_to_short_source_remains_not_ready_without_false_success() -> (
+    None
+):
     r = _runner(_bars(15))
     symbol = "NFO:NIFTY26JUN24000CE"
     r._symbol_history[symbol] = _bars(15)
@@ -319,7 +493,9 @@ async def test_indicator_equal_to_short_source_remains_not_ready_without_false_s
     assert result.failure_reason == "source_history_short"
 
 
-async def test_partial_source_availability_seeds_useful_bars_but_remains_fail_closed() -> None:
+async def test_partial_source_availability_seeds_useful_bars_but_remains_fail_closed() -> (
+    None
+):
     r = _runner(_bars(20))
     symbol = "NFO:NIFTY26JUN24000CE"
     for bar in _bars(15):
@@ -425,3 +601,69 @@ async def test_short_source_repairs_short_runner_but_remains_fail_closed() -> No
     assert result.mdm_bars == 20
     assert result.runner_bars == 20
     assert result.failure_reason == "source_history_short"
+
+
+async def test_repeated_sync_skips_reseed_when_runner_and_indicator_match_mdm_latest_timestamp() -> (
+    None
+):
+    r = _runner(_bars(50))
+    symbol = "NFO:NIFTY26JUN24000CE"
+    calls = []
+    original = r.reseed_history_from_bars
+
+    def _counting_reseed(*args, **kwargs):
+        calls.append(args[0])
+        return original(*args, **kwargs)
+
+    r.reseed_history_from_bars = _counting_reseed
+    first = r.sync_history_from_mdm(
+        symbol,
+        required_bars=30,
+        reason="selected_option_hydration",
+        role="selected_option",
+        request_if_short=False,
+    )
+    second = r.sync_history_from_mdm(
+        symbol,
+        required_bars=30,
+        reason="selected_option_hydration",
+        role="selected_option",
+        request_if_short=False,
+    )
+
+    assert first.success is True
+    assert second.success is True
+    assert calls == [symbol]
+
+
+async def test_equal_counts_with_newer_mdm_timestamp_reseeds() -> None:
+    initial = _bars(30)
+    newer = _bars(31)[1:]
+    r = _runner(initial)
+    symbol = "NFO:NIFTY26JUN24000CE"
+    r.sync_history_from_mdm(
+        symbol,
+        required_bars=30,
+        reason="selected_option_hydration",
+        role="selected_option",
+        request_if_short=False,
+    )
+    r._get_mdm_bars = lambda _s, limit: list(newer)[-limit:]
+    calls = []
+    original = r.reseed_history_from_bars
+
+    def _counting_reseed(*args, **kwargs):
+        calls.append(args[0])
+        return original(*args, **kwargs)
+
+    r.reseed_history_from_bars = _counting_reseed
+    result = r.sync_history_from_mdm(
+        symbol,
+        required_bars=30,
+        reason="selected_option_hydration",
+        role="selected_option",
+        request_if_short=False,
+    )
+
+    assert result.success is True
+    assert calls == [symbol]

--- a/tests/strategies/test_runtime_context_contract.py
+++ b/tests/strategies/test_runtime_context_contract.py
@@ -23,7 +23,9 @@ def test_runtime_context_preserves_live_direction_contract_keys() -> None:
         },
     )
 
-    indicators = engine.get_indicators(symbol, names={"direction_bias", "context_age_seconds"})
+    indicators = engine.get_indicators(
+        symbol, names={"direction_bias", "context_age_seconds"}
+    )
     assert indicators["direction_bias"] == "CE"
     assert indicators["context_age_seconds"] == 0.42
     assert indicators["spot_fresh"] is True
@@ -48,7 +50,9 @@ def test_runtime_context_preserves_live_quote_age_contract_keys() -> None:
         },
     )
 
-    indicators = engine.get_indicators(symbol, names={"quote_age_s", "tick_age_ms", "quote_update_version"})
+    indicators = engine.get_indicators(
+        symbol, names={"quote_age_s", "tick_age_ms", "quote_update_version"}
+    )
     assert indicators["quote_age_s"] == 0.12
     assert indicators["tick_age_ms"] == 120
     assert indicators["quote_update_version"] == 42
@@ -73,7 +77,9 @@ def test_runtime_context_derives_direction_bias_from_alias() -> None:
     assert preserved["live_direction_context_proof"] is True
 
 
-def test_live_direction_context_proof_derives_freshness_from_spot_or_futures_age() -> None:
+def test_live_direction_context_proof_derives_freshness_from_spot_or_futures_age() -> (
+    None
+):
     spot = normalise_live_direction_context(
         {
             "spot_tick_age_s": 0.25,
@@ -108,3 +114,68 @@ def test_resolve_context_age_seconds_uses_canonical_safe_default() -> None:
     assert resolve_context_age_seconds({"context_age_seconds": "1.5"}) == 1.5
     assert resolve_context_age_seconds({"context_age_seconds": "invalid"}) == 999.0
     assert resolve_context_age_seconds({}) == 999.0
+
+
+def test_normalise_current_age_overrides_stale_cached_false_freshness() -> None:
+    preserved = normalise_live_direction_context(
+        {
+            "spot_fresh": False,
+            "fut_fresh": False,
+            "futures_fresh": False,
+            "spot_tick_age_s": 0.25,
+            "futures_tick_age_s": 0.5,
+            "context_age_seconds": 0.5,
+        }
+    )
+
+    assert preserved["spot_fresh"] is True
+    assert preserved["fut_fresh"] is True
+    assert preserved["futures_fresh"] is True
+    assert preserved["live_direction_context_proof"] is True
+
+
+def test_normalise_missing_current_age_keeps_explicit_stale_false_fail_closed() -> None:
+    preserved = normalise_live_direction_context(
+        {
+            "spot_fresh": False,
+            "fut_fresh": False,
+            "futures_fresh": False,
+            "context_age_seconds": 0.5,
+        }
+    )
+
+    assert preserved["spot_fresh"] is False
+    assert preserved["fut_fresh"] is False
+    assert preserved["futures_fresh"] is False
+    assert preserved["live_direction_context_proof"] is False
+
+
+def test_runtime_context_current_age_replaces_cached_false_atomically() -> None:
+    engine = IndicatorEngine()
+    symbol = "NFO:NIFTY2670724400CE"
+
+    engine.set_runtime_context(
+        symbol,
+        {
+            "spot_fresh": False,
+            "fut_fresh": False,
+            "futures_fresh": False,
+            "context_age_seconds": 0.5,
+        },
+    )
+    engine.set_runtime_context(
+        symbol,
+        {
+            "spot_tick_age_s": 0.25,
+            "futures_tick_age_s": 0.5,
+            "context_age_seconds": 0.5,
+        },
+    )
+
+    indicators = engine.get_indicators(
+        symbol, names={"spot_fresh", "fut_fresh", "futures_fresh"}
+    )
+    assert indicators["spot_fresh"] is True
+    assert indicators["fut_fresh"] is True
+    assert indicators["futures_fresh"] is True
+    assert indicators["live_direction_context_proof"] is True


### PR DESCRIPTION
### Motivation
- Prevent fresh MDM tick ages from being overridden by stale cached boolean freshness in the runtime context which caused `direction_context_missing_live` and `live_underlying_context_freshness_unknown` while MDM reported fresh ticks.
- Avoid unnecessary runner/indicator reseeds on every rearm by ensuring the runner only reseeds when MDM is actually ahead (timestamp-aware), reducing CPU/log noise and preventing redundant history propagation.

### Description
- Normalization change: `normalise_live_direction_context()` now treats canonical tick ages as authoritative proof and, when present, atomically replaces the matching freshness boolean group (`spot_fresh`, `fut_fresh`, `futures_fresh`) so stale cached False values cannot outlive fresh age evidence (file: `src/nifty_scalper_bot/strategies/runtime_context_contract.py`).
- Runner timestamp guards: `StrategyRunner.sync_history_from_mdm()` gained row/tail timestamp extraction helpers and checks MDM vs runner vs indicator last-timestamps so reseed occurs only when MDM is ahead or local histories are genuinely short (file: `src/nifty_scalper_bot/strategies/runner.py`).
- Tests added/updated to cover the defect: freshness-override and atomic replacement tests and history-sync idempotence / equal-count-newer-mdm behaviors (files: `tests/strategies/test_runtime_context_contract.py`, `tests/strategies/test_canonical_runner_history_sync.py`).
- Call graph (producer → consumer): WebSocket tick → MarketDataManager / CandleEngine (canonical) → Runner assembles runtime context → `IndicatorEngine.set_runtime_context()` (wrapped) → `normalise_live_direction_context()` → strategy/OrderFlow live-safety consumers (via `live_direction_context_has_proof()`).
- Files changed: `src/nifty_scalper_bot/strategies/runtime_context_contract.py`, `src/nifty_scalper_bot/strategies/runner.py`, `tests/strategies/test_runtime_context_contract.py`, `tests/strategies/test_canonical_runner_history_sync.py`.

### Testing
- Ran focused strategy/history suites: `pytest -q tests/strategies/test_runtime_context_contract.py tests/strategies/test_orderflow_live_context_age.py tests/strategies/test_runner_symbol_role_gate.py tests/strategies/test_canonical_runner_history_sync.py tests/core/test_runtime_history_orchestration.py` — all passed.
- Ran broader core suites: `pytest -q tests/core/test_runtime_readiness.py tests/core/test_selected_option_exec_min_regression.py tests/core/test_hydration_status_propagation.py tests/architecture/test_history_ownership.py` — all passed.
- Live-simulation: `ALLOW_NETWORK=false ALLOW_REAL_BROKER=false BROKER_SIMULATION=true EXECUTION_MODE=LIVE_SIMULATION pytest -q -m live_runtime_e2e tests/e2e/live_sim` — the suite reached the repaired path but a date/session-dependent scenario caused one live-sim test (`test_live_runtime_bullish_spot_future_selects_ce_and_exits_target`) to fail due to an unrelated expiry-day risk block (`expiry_day_after_13:30_ist`), not the freshness or history logic.
- Static checks: `python -m compileall -q src tests` and `black --check` on changed files passed; `ruff check` notes pre-existing repository-style findings unrelated to this behavioral fix.
- Full test run exit: `PYTEST_EXIT_CODE=1` due to the single live-sim expiry/risk blocking test; focused regression coverage for the defect is green.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5f2d92c4008324a8731f3adb585f52)