### PR TITLE
fix: WS restart trigger gating + post-restart quote re-prime + history gap tolerance

### DIFF
--- a/src/nifty_scalper_bot/core/history_readiness.py
+++ b/src/nifty_scalper_bot/core/history_readiness.py
@@ -529,8 +529,12 @@ def build_symbol_hydration_status(
     grace = float(_clamped_int_env("HISTORY_PUBLICATION_GRACE_SECONDS", 90, 0, 300))
     max_lag = _clamped_int_env("HISTORY_LATEST_BAR_MAX_LAG_MINUTES", 2, 0, 5)
     continuity_window = _clamped_int_env("HISTORY_CONTINUITY_WINDOW_BARS", 5, 2, 500)
+    # Default 2 (was 0): Kite minute candles legitimately omit minutes with
+    # zero trades (common for options), so a zero-tolerance continuity check
+    # permanently raised *_history_gap_detected blockers on healthy data.
+    # Staleness of the latest bar is still enforced separately above.
     allowed_missing = _clamped_int_env(
-        "HISTORY_ALLOWED_RECENT_MISSING_MINUTES", 0, 0, 5
+        "HISTORY_ALLOWED_RECENT_MISSING_MINUTES", 2, 0, 5
     )
     quality = _evaluate_recent_history_quality(
         mdm_read.bars,

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -9914,6 +9914,13 @@ class MarketDataManager:
             self._log_global_restart_suppressed(suppression, now_mono)
             return
 
+        # Dispatch first; the trigger has its own backoff/coalesce gates.
+        # Logging TRIGGERED only when a restart actually dispatched prevents
+        # duplicate TRIGGERED log storms when the trigger early-returns.
+        dispatched = self._trigger_zombie_ws_restart()
+        if not dispatched:
+            self._log_global_restart_suppressed("trigger_backoff", now_mono)
+            return
         self._logger.critical(
             "WS_GLOBAL_RESTART_TRIGGERED stale_symbols=%d heartbeat_age_s=%s reason=transport_failure",
             len(stale_or_missing_symbols),
@@ -9929,7 +9936,6 @@ class MarketDataManager:
                 "reason": "transport_failure",
             },
         )
-        self._trigger_zombie_ws_restart()
 
     def _global_restart_suppression_reason(self, now: float) -> str | None:
         if getattr(self, "_ws_restart_inflight", False):
@@ -9960,12 +9966,12 @@ class MarketDataManager:
             extra={"event": "WS_GLOBAL_RESTART_SUPPRESSED", "reason": reason},
         )
 
-    def _trigger_zombie_ws_restart(self) -> None:
-        """Args: none; Returns: none; Raises: none."""
+    def _trigger_zombie_ws_restart(self) -> bool:
+        """Args: none; Returns: True when a restart was dispatched; Raises: none."""
 
         now = time.monotonic()
         if now < self._zombie_breaker_open_until:
-            return
+            return False
         recovery = self.verify_websocket_recovery(now_mono=now)
         if recovery.get("state") in {
             "reconnect_requested",
@@ -9982,7 +9988,7 @@ class MarketDataManager:
                     **recovery,
                 },
             )
-            return
+            return False
 
         # Exponential backoff between consecutive zombie restart
         # triggers.  WebSocketManager itself already does full-jitter
@@ -9998,12 +10004,12 @@ class MarketDataManager:
 
         since_last = now - self._zombie_last_restart_attempt_at
         if since_last < cooldown:
-            return
+            return False
         self._zombie_last_restart_attempt_at = now
 
         ws = self._ws
         if ws is None:
-            return
+            return False
         with self._ws_restart_lock:
             if self._ws_restart_inflight:
                 self._logger.info(
@@ -10015,7 +10021,7 @@ class MarketDataManager:
                         "state": "inflight",
                     },
                 )
-                return
+                return False
             with self._lock:
                 desired_snapshot = set(self._desired_tokens)
                 affected: dict[str, int] = {}
@@ -10061,13 +10067,25 @@ class MarketDataManager:
         if not callable(reconnect):
             self._fail_ws_recovery("force_reconnect_unavailable")
             self._zombie_restart_failures += 1
-            return
+            return False
+        dispatched = False
         try:
             reconnect()
+            dispatched = True
             with self._ws_restart_lock:
                 if self._ws_restart_inflight:
                     self._ws_restart_state = "waiting_for_subscriptions"
             self._reconcile_ws_subscriptions()
+            # Re-prime quotes for affected symbols via the canonical fallback
+            # path so tradable quotes recover even before the first post-restart
+            # WS tick arrives (restart intentionally clears last-tick state).
+            for _sym in sorted(affected):
+                try:
+                    self.request_fallback_refresh(
+                        _sym, reason="ws_restart_quote_reprime"
+                    )
+                except Exception:  # noqa: BLE001 - best-effort re-prime
+                    pass
             recovery = self.verify_websocket_recovery(now_mono=time.monotonic())
             self._zombie_restart_consecutive += 1
             self._zombie_restart_attempts.append(now)
@@ -10116,6 +10134,7 @@ class MarketDataManager:
                     "open_seconds": self._zombie_restart_window,
                 },
             )
+        return dispatched
 
     def _fail_ws_recovery(self, reason: str) -> None:
         with self._ws_restart_lock:

--- a/tests/core/test_history_quality.py
+++ b/tests/core/test_history_quality.py
@@ -336,6 +336,10 @@ def test_build_symbol_hydration_status_defaults_to_five_bar_continuity_window(
 ) -> None:
     monkeypatch.delenv("HISTORY_CONTINUITY_WINDOW_BARS", raising=False)
     monkeypatch.setenv("HISTORY_PUBLICATION_GRACE_SECONDS", "0")
+    # This test exercises the window size; pin tolerance to zero because the
+    # default HISTORY_ALLOWED_RECENT_MISSING_MINUTES is now 2 (zero-trade
+    # minute candles are legitimately absent from Kite history).
+    monkeypatch.setenv("HISTORY_ALLOWED_RECENT_MISSING_MINUTES", "0")
     current = date(2026, 1, 2)
 
     def make_bars_without(missing_idx: int) -> list[dict[str, datetime]]:

--- a/tests/data/test_mdm_lifecycle_generation.py
+++ b/tests/data/test_mdm_lifecycle_generation.py
@@ -422,3 +422,24 @@ def test_runner_live_tick_classifier_uses_canonical_freshness_policy(
         "token": "24000",
         "max_age_s": 3.25,
     }
+
+
+def test_trigger_zombie_ws_restart_returns_dispatch_flag_and_backoff() -> None:
+    """Regression: TRIGGERED must only be logged when a restart dispatches.
+
+    First call dispatches (returns True); an immediate second call is gated
+    by the coalesce/backoff paths (returns False) so the caller does not emit
+    a duplicate WS_GLOBAL_RESTART_TRIGGERED log storm.
+    """
+    ws = _FakeWebSocket(connected=True)
+    mdm = MarketDataManager(kite=None, websocket=ws)
+    symbol = "NFO:NIFTY26JUN24000CE"
+    token = 24000
+    _subscribe(mdm, symbol, token)
+    _ws_tick(mdm, symbol, token)
+
+    assert mdm._trigger_zombie_ws_restart() is True
+    assert ws.calls == 1
+    # Immediate re-trigger: inflight/backoff must gate it.
+    assert mdm._trigger_zombie_ws_restart() is False
+    assert ws.calls == 1


### PR DESCRIPTION
Fixes three trading-path blockers seen in the 2026-07-22 live log (double WS_GLOBAL_RESTART_TRIGGERED 1s apart, quote_missing stuck after WS restart, spot/CE/PE history_gap_detected despite RUNNER_HISTORY_SYNC_RESULT success=True).

1. TRIGGERED log now fires only when a restart actually dispatches (_trigger_zombie_ws_restart returns bool; suppressed paths log WS_GLOBAL_RESTART_SUPPRESSED reason=trigger_backoff).
2. After reconnect+resubscribe, affected symbols get quote re-priming via existing request_fallback_refresh (reason=ws_restart_quote_reprime).
3. HISTORY_ALLOWED_RECENT_MISSING_MINUTES default 0->2 (Kite omits zero-trade minute candles; staleness check unchanged).

Validation: compileall clean; full pytest 1948 passed / 0 failed; regression test added in tests/data/test_mdm_lifecycle_generation.py.