### PR TITLE
fix: isolated stale-symbol subscription signals no longer force a global WS restart

### DIFF
--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -9794,7 +9794,14 @@ class MarketDataManager:
         # A broad set of stale symbols is not, by itself, proof that the
         # WebSocket transport failed. A healthy socket can continue receiving
         # heartbeats while one subscription generation is incomplete. Global
-        # reconnects are therefore reserved for explicit transport evidence.
+        # reconnects are therefore reserved for explicit transport evidence:
+        # heartbeat/socket unhealthy, or classify_transport_backlog's genuine
+        # transport_silent signal (no raw packets at all, distinct from an
+        # isolated stale symbol subscription). subscription_transport_failure
+        # and symbol_recovery_exceeded are dropped from this gate: both can
+        # fire for a single stuck symbol subscription (e.g. one illiquid
+        # option strike) while the transport is demonstrably healthy,
+        # invalidating quotes for the whole restart+re-verification window.
         transport_failure = bool(
             stale_or_missing_symbols
             and not processing_backlog
@@ -9802,8 +9809,6 @@ class MarketDataManager:
                 backlog_classification.get("global_restart_eligible")
                 or heartbeat_stale
                 or not ws_healthy
-                or subscription_transport_failure
-                or symbol_recovery_exceeded
             )
         )
         if stale_or_missing_symbols and not transport_failure:

--- a/tests/data/test_mdm_tick_coalescing.py
+++ b/tests/data/test_mdm_tick_coalescing.py
@@ -647,6 +647,50 @@ def test_required_symbol_without_first_ws_tick_gets_symbol_recovery(monkeypatch)
     assert rest_requests == [(missing, "ws_symbol_stale_recovery")]
 
 
+def test_symbol_recovery_exceeded_alone_does_not_force_global_restart(monkeypatch):
+    """Regression: a single stuck symbol subscription (e.g. the active
+    future repeatedly failing verification) must not escalate to a global
+    WS restart while the transport itself is healthy and heartbeat fresh.
+    Only genuine transport evidence (heartbeat stale / socket unhealthy /
+    classify_transport_backlog transport_silent) may trigger a restart.
+    """
+    from nifty_scalper_bot.utils import market_hours
+
+    mdm = MarketDataManager(kite=None)
+    _wire_symbols(mdm)
+    now = time.monotonic()
+    future = mdm.get_active_nifty_future_symbol_cached()
+    for sym in mdm._required_live_symbols():
+        mdm._last_valid_live_tick_mono[sym] = now
+    mdm._last_valid_live_tick_mono[future] = now - 120.0
+    mdm._zombie_tick_threshold_sec = 60.0
+    mdm._last_hb_mono = now
+    monkeypatch.setattr(market_hours, "is_market_open", lambda: True)
+    monkeypatch.setattr(mdm, "_is_ws_healthy", lambda: True)
+    monkeypatch.setattr(mdm, "_monitor_spot_ws_health", lambda: None)
+    monkeypatch.setattr(mdm, "request_fallback_refresh", lambda symbol, reason: True)
+    monkeypatch.setattr(
+        mdm,
+        "verify_symbol_subscription_recovery",
+        lambda symbol: {
+            "ok": False,
+            "attempts": 5,
+            "attempt_started_mono": now - 120.0,
+        },
+    )
+    monkeypatch.setattr(mdm, "_ws_recovery_timeout_sec", 5.0)
+    monkeypatch.setattr(
+        mdm,
+        "_trigger_zombie_ws_restart",
+        lambda: pytest.fail(
+            "isolated symbol_recovery_exceeded must not force a global restart"
+            " while transport is healthy"
+        ),
+    )
+
+    mdm._check_zombie_ticks()
+
+
 def test_two_stale_options_with_fresh_context_do_not_restart_full_ws(monkeypatch):
     from nifty_scalper_bot.utils import market_hours
 


### PR DESCRIPTION
Follow-up to #907. Narrows the transport-failure gate in _check_zombie_ticks() so isolated per-symbol staleness (subscription_transport_failure / symbol_recovery_exceeded) no longer forces a global WS restart while the transport itself is healthy and heartbeat is fresh -- this was invalidating selected-option quotes (quote_missing -> context_exec_not_ready -> live_orders_armed=False).

Kept: classify_transport_backlog global_restart_eligible (genuine full transport silence), heartbeat_stale, not ws_healthy. Isolated stale symbols still recover via the existing per-symbol path unchanged.

Validation: compileall clean; tests/data/test_mdm_tick_coalescing.py, tests/data/test_mdm_lifecycle_generation.py, live_runtime_e2e marker, and full pytest all exit 0 (1950 passed / 0 failed). New regression test added and verified to fail against pre-fix logic.