### PR TITLE
Fix market tick timestamp fallback handling

### DIFF
--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -64,7 +64,10 @@ from nifty_scalper_bot.data.candle_engine import (
 from nifty_scalper_bot.data.market_data_policy import MarketDataPolicy
 from nifty_scalper_bot.data.normalizers import normalize_history_row
 from nifty_scalper_bot.data.source import DataIntegrityError
-from nifty_scalper_bot.data.time_contract import coerce_market_timestamp
+from nifty_scalper_bot.data.time_contract import (
+    coerce_market_timestamp,
+    normalize_market_tick_timestamp,
+)
 from nifty_scalper_bot.data.validator import validate_tick
 from nifty_scalper_bot.execution.readiness import (
     evaluate_quote_readiness,
@@ -7850,13 +7853,28 @@ class MarketDataManager:
         )
         source_timestamp_valid = timestamp_source is not None and ts is not None
         if not source_timestamp_valid:
+            present_timestamp_fields = self._present_market_timestamp_fields(raw)
+            timestamp_reason = (
+                "missing_all" if not present_timestamp_fields else "all_present_invalid"
+            )
             if not hasattr(self, "_candle_metrics"):
                 self._candle_metrics = defaultdict(float)
             self._candle_metrics["invalid_candle_timestamp_total"] += 1
             log_throttled(
                 self._logger,
                 f"mdm_invalid_candle_timestamp_{token or symbol}",
-                "MDM_TICK_DROPPED reason=invalid_candle_timestamp token=%s" % token,
+                (
+                    "MDM_TICK_DROPPED reason=invalid_candle_timestamp "
+                    "timestamp_reason=%s token=%s symbol=%s source=%s present_timestamp_fields=%s"
+                )
+                % (
+                    timestamp_reason,
+                    token,
+                    symbol,
+                    raw.get("source")
+                    or ("rest_poll" if approved_rest_fallback else "ws"),
+                    present_timestamp_fields,
+                ),
                 interval_sec=30.0,
                 level=logging.WARNING,
             )
@@ -7883,12 +7901,55 @@ class MarketDataManager:
                 and not approved_rest_fallback
                 else (raw.get("source") or "ws")
             ),
-            "received_at": float(raw.get("received_at") or time.time()),
+            "received_at": self._tick_received_at_epoch(raw),
         }
+
+    @staticmethod
+    def _tick_received_at_epoch(raw: Mapping[str, Any]) -> float:
+        value = raw.get("received_at")
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            return float(value)
+        return time.time()
+
+    @staticmethod
+    def _present_market_timestamp_fields(raw: Mapping[str, Any]) -> list[str]:
+        timestamp_fields = (
+            "exchange_timestamp",
+            "last_trade_time",
+            "last_traded_time",
+            "last_trade_timestamp",
+            "exchange_update_time",
+            "last_price_time",
+            "timestamp",
+            "ts",
+            "date",
+            "datetime",
+            "received_at",
+            "received_ts",
+            "received_time",
+        )
+        return [
+            field
+            for field in timestamp_fields
+            if raw.get(field) is not None and raw.get(field) != ""
+        ]
 
     def _resolve_candle_tick_timestamp(
         self, raw: Mapping[str, Any], *, rest_fallback: bool
     ) -> tuple[str | None, pd.Timestamp | None]:
+        if not rest_fallback:
+            try:
+                normalized = normalize_market_tick_timestamp(raw)
+            except (TypeError, ValueError, OverflowError):
+                return None, None
+            ts = pd.to_datetime(normalized.raw_value, utc=True, errors="coerce")
+            if pd.isna(ts):
+                return None, None
+            ts = pd.Timestamp(ts)
+            if ts.year >= 2020:
+                return normalized.source, ts
+            return None, None
+
         if rest_fallback:
             candidates = (
                 ("rest_poll", raw.get("timestamp")),
@@ -13661,15 +13722,25 @@ class MarketDataManager:
                     }.values()
                 )
                 deduped.sort(key=lambda item: item["timestamp"])
-                if min_rows > 0 and len(deduped) < min_rows and attempt_name != attempt_specs[-1][0]:
+                if (
+                    min_rows > 0
+                    and len(deduped) < min_rows
+                    and attempt_name != attempt_specs[-1][0]
+                ):
                     if len(deduped) > len(best_so_far):
                         best_so_far = deduped
                         best_attempt_meta = (
-                            attempt_name, from_date, to_date, len(rows)
+                            attempt_name,
+                            from_date,
+                            to_date,
+                            len(rows),
                         )
                     self._logger.info(
                         "HYDRATION_ATTEMPT_INSUFFICIENT_WIDENING symbol=%s attempt=%s returned_rows=%s min_rows=%s",
-                        symbol, attempt_name, len(deduped), min_rows,
+                        symbol,
+                        attempt_name,
+                        len(deduped),
+                        min_rows,
                         extra={
                             "event": "HYDRATION_ATTEMPT_INSUFFICIENT_WIDENING",
                             "symbol": symbol,

--- a/src/nifty_scalper_bot/data/time_contract.py
+++ b/src/nifty_scalper_bot/data/time_contract.py
@@ -76,7 +76,9 @@ def coerce_market_timestamp(value: Any, *, naive_policy: str = "ist") -> pd.Time
     return ts.tz_convert(IST)
 
 
-def _first_present(payload: Mapping[str, Any], fields: tuple[str, ...]) -> tuple[str, Any] | None:
+def _first_present(
+    payload: Mapping[str, Any], fields: tuple[str, ...]
+) -> tuple[str, Any] | None:
     for field in fields:
         value = payload.get(field)
         if value is not None and value != "":
@@ -90,23 +92,31 @@ def normalize_market_tick_timestamp(payload: Mapping[str, Any]) -> MarketTimesta
     Priority is exchange/broker event time first. ``received_at`` is allowed
     only as an explicit fallback and is labelled as such; this prevents a
     generated wall-clock timestamp from silently masquerading as exchange time.
+    A malformed higher-priority field does not hide a later valid timestamp.
     """
 
-    for fields, label in (
-        (_EXCHANGE_TIMESTAMP_FIELDS, "exchange_timestamp"),
-        (_BROKER_TIMESTAMP_FIELDS, "broker_timestamp"),
-        (_RECEIVED_AT_FIELDS, "received_at_fallback"),
+    present = False
+    last_error: Exception | None = None
+    for fields in (
+        _EXCHANGE_TIMESTAMP_FIELDS,
+        _BROKER_TIMESTAMP_FIELDS,
+        _RECEIVED_AT_FIELDS,
     ):
-        candidate = _first_present(payload, fields)
-        if candidate is None:
-            continue
-        field, value = candidate
-        return MarketTimestamp(
-            timestamp=coerce_market_timestamp(value),
-            source=field if label != "exchange_timestamp" else field,
-            raw_value=value,
-        )
-    raise ValueError("missing market timestamp")
+        for field in fields:
+            value = payload.get(field)
+            if value is None or value == "":
+                continue
+            present = True
+            try:
+                timestamp = coerce_market_timestamp(value)
+            except (TypeError, ValueError, OverflowError) as exc:
+                last_error = exc
+                continue
+            return MarketTimestamp(timestamp=timestamp, source=field, raw_value=value)
+
+    if not present:
+        raise ValueError("missing market timestamp")
+    raise ValueError("all present market timestamps are invalid") from last_error
 
 
 def future_delta_seconds(ts: pd.Timestamp, *, now: pd.Timestamp) -> float:
@@ -115,7 +125,9 @@ def future_delta_seconds(ts: pd.Timestamp, *, now: pd.Timestamp) -> float:
     return max((ts - now).total_seconds(), 0.0)
 
 
-def is_future_market_timestamp(ts: pd.Timestamp, *, now: pd.Timestamp, grace_seconds: float) -> bool:
+def is_future_market_timestamp(
+    ts: pd.Timestamp, *, now: pd.Timestamp, grace_seconds: float
+) -> bool:
     return bool(ts > now + pd.Timedelta(seconds=max(float(grace_seconds), 0.0)))
 
 

--- a/tests/data/test_market_timestamp_contract.py
+++ b/tests/data/test_market_timestamp_contract.py
@@ -19,17 +19,71 @@ IST = ZoneInfo("Asia/Kolkata")
 def test_numeric_epoch_ms_converts_utc_to_ist() -> None:
     raw = int(pd.Timestamp("2026-01-02T09:15:00Z").timestamp() * 1000)
 
-    normalized = normalize_market_tick_timestamp({"symbol": "NFO:TEST", "exchange_timestamp": raw})
+    normalized = normalize_market_tick_timestamp(
+        {"symbol": "NFO:TEST", "exchange_timestamp": raw}
+    )
 
     assert normalized.timestamp.isoformat() == "2026-01-02T14:45:00+05:30"
     assert normalized.source == "exchange_timestamp"
 
 
 def test_naive_broker_timestamp_is_interpreted_as_ist() -> None:
-    normalized = normalize_market_tick_timestamp({"symbol": "NFO:TEST", "timestamp": "2026-01-02 09:15:00"})
+    normalized = normalize_market_tick_timestamp(
+        {"symbol": "NFO:TEST", "timestamp": "2026-01-02 09:15:00"}
+    )
 
     assert normalized.timestamp.isoformat() == "2026-01-02T09:15:00+05:30"
     assert normalized.source == "timestamp"
+
+
+def test_bad_first_exchange_field_falls_back_to_valid_last_trade_time() -> None:
+    normalized = normalize_market_tick_timestamp(
+        {
+            "exchange_timestamp": "bad",
+            "last_trade_time": "2026-07-23T09:30:01+05:30",
+        }
+    )
+
+    assert normalized.timestamp.isoformat() == "2026-07-23T09:30:01+05:30"
+    assert normalized.source == "last_trade_time"
+    assert normalized.raw_value == "2026-07-23T09:30:01+05:30"
+
+
+def test_bad_exchange_fields_fall_back_to_valid_broker_timestamp() -> None:
+    normalized = normalize_market_tick_timestamp(
+        {
+            "exchange_timestamp": "bad",
+            "last_trade_time": "also-bad",
+            "timestamp": "2026-07-23T09:30:02+05:30",
+        }
+    )
+
+    assert normalized.timestamp.isoformat() == "2026-07-23T09:30:02+05:30"
+    assert normalized.source == "timestamp"
+
+
+def test_bad_broker_timestamp_falls_back_to_valid_received_at() -> None:
+    normalized = normalize_market_tick_timestamp(
+        {
+            "timestamp": "bad",
+            "received_at": "2026-07-23T09:30:03+05:30",
+        }
+    )
+
+    assert normalized.timestamp.isoformat() == "2026-07-23T09:30:03+05:30"
+    assert normalized.source == "received_at"
+
+
+def test_all_present_market_timestamp_fields_invalid_raises_final_value_error() -> None:
+    with pytest.raises(ValueError, match="all present market timestamps are invalid"):
+        normalize_market_tick_timestamp(
+            {
+                "exchange_timestamp": "bad",
+                "last_trade_time": "also-bad",
+                "timestamp": "still-bad",
+                "received_at": "bad-too",
+            }
+        )
 
 
 def test_tick_validator_prefers_exchange_time_over_received_at() -> None:
@@ -67,30 +121,48 @@ def test_received_at_fallback_is_explicit_not_exchange_time() -> None:
     assert tick.timestamp_source == "received_at"
 
 
-def test_pipeline_rejects_future_received_at_fallback(caplog: pytest.LogCaptureFixture) -> None:
+def test_pipeline_rejects_future_received_at_fallback(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     pipeline = MarketDataPipeline()
     future = datetime.now(IST) + timedelta(minutes=10)
 
     with caplog.at_level(logging.WARNING, logger="nifty_scalper_bot.data.pipeline"):
-        out = pipeline.on_tick({"symbol": "NFO:TEST", "received_at": future, "ltp": 100})
+        out = pipeline.on_tick(
+            {"symbol": "NFO:TEST", "received_at": future, "ltp": 100}
+        )
 
     assert out is None
-    record = next(rec for rec in caplog.records if getattr(rec, "event", "") == "future_tick_rejected")
+    record = next(
+        rec
+        for rec in caplog.records
+        if getattr(rec, "event", "") == "future_tick_rejected"
+    )
     assert record.symbol == "NFO:TEST"
     assert record.timestamp_source == "received_at"
     assert record.future_by_sec > 0
     assert record.now_ist.endswith("+05:30")
 
 
-def test_candle_engine_future_drop_has_forensic_fields(caplog: pytest.LogCaptureFixture) -> None:
+def test_candle_engine_future_drop_has_forensic_fields(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     engine = CandleEngine()
     future = datetime.now(IST) + timedelta(minutes=10)
 
-    with caplog.at_level(logging.WARNING, logger="nifty_scalper_bot.data.candle_engine"):
-        out = engine.on_tick({"symbol": "NFO:TESTCE", "timestamp": future, "ltp": 100, "volume": 1})
+    with caplog.at_level(
+        logging.WARNING, logger="nifty_scalper_bot.data.candle_engine"
+    ):
+        out = engine.on_tick(
+            {"symbol": "NFO:TESTCE", "timestamp": future, "ltp": 100, "volume": 1}
+        )
 
     assert out is None
-    record = next(rec for rec in caplog.records if getattr(rec, "reason", "") == "future_timestamp")
+    record = next(
+        rec
+        for rec in caplog.records
+        if getattr(rec, "reason", "") == "future_timestamp"
+    )
     assert record.symbol == "NFO:TESTCE"
     assert record.timestamp_source == "timestamp"
     assert record.tick_ts_ist.endswith("+05:30")
@@ -98,13 +170,19 @@ def test_candle_engine_future_drop_has_forensic_fields(caplog: pytest.LogCapture
     assert record.future_by_sec > 0
 
 
-def test_candle_engine_missing_symbol_is_dropped_not_unknown(caplog: pytest.LogCaptureFixture) -> None:
+def test_candle_engine_missing_symbol_is_dropped_not_unknown(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     engine = CandleEngine()
     ts = datetime(2026, 1, 2, 9, 15, tzinfo=timezone.utc)
 
-    with caplog.at_level(logging.WARNING, logger="nifty_scalper_bot.data.candle_engine"):
+    with caplog.at_level(
+        logging.WARNING, logger="nifty_scalper_bot.data.candle_engine"
+    ):
         out = engine.on_tick({"timestamp": ts, "ltp": 100, "volume": 1})
 
     assert out is None
-    record = next(rec for rec in caplog.records if getattr(rec, "reason", "") == "missing_symbol")
+    record = next(
+        rec for rec in caplog.records if getattr(rec, "reason", "") == "missing_symbol"
+    )
     assert getattr(record, "symbol", None) is None

--- a/tests/data/test_mdm_invalid_candle_timestamp.py
+++ b/tests/data/test_mdm_invalid_candle_timestamp.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import threading
 from collections import defaultdict
 from datetime import datetime, timezone
@@ -122,3 +123,57 @@ def test_invalid_timestamp_does_not_mutate_candle_engine() -> None:
     mdm._process_queued_tick(_tick(exchange_timestamp="bad"))
     assert engine.current_candle is None
     assert engine.get_completed_bars() == []
+
+
+def test_missing_timestamp_logs_missing_all_reason(caplog) -> None:
+    mdm = _mdm()
+    mdm._logger = logging.getLogger("test_mdm_timestamp_reason")
+    mdm._symbol_by_token[2] = "NFO:Y"
+    mdm._token_to_symbol[2] = "NFO:Y"
+    with caplog.at_level("WARNING", logger="test_mdm_timestamp_reason"):
+        assert (
+            mdm._normalize_ws_tick({"instrument_token": 2, "last_price": 10.0}) is None
+        )
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert any("timestamp_reason=missing_all" in message for message in messages)
+
+
+def test_invalid_tick_does_not_stop_later_valid_tick_processing() -> None:
+    mdm = MarketDataManager(kite=None)
+    mdm._symbol_by_token[1] = "NFO:X"
+    mdm._token_to_symbol[1] = "NFO:X"
+    mdm._symbol_to_token["NFO:X"] = 1
+    mdm._token_by_symbol["NFO:X"] = 1
+
+    mdm._process_queued_tick(_tick(exchange_timestamp="bad"))
+    mdm._process_queued_tick(
+        _tick(exchange_timestamp="2026-07-23T09:30:04+05:30", last_price=11.0)
+    )
+
+    assert "NFO:X" in mdm._latest_ticks
+    assert mdm._latest_ticks["NFO:X"]["last_price"] == 11.0
+    assert mdm.get_candle_engine("NFO:X").current_candle is not None
+
+
+def test_nifty_spot_invalid_exchange_timestamp_uses_valid_received_at_fallback() -> (
+    None
+):
+    mdm = MarketDataManager(kite=None)
+    mdm._symbol_by_token[256265] = "NSE:NIFTY"
+    mdm._token_to_symbol[256265] = "NSE:NIFTY"
+    mdm._symbol_to_token["NSE:NIFTY"] = 256265
+    mdm._token_by_symbol["NSE:NIFTY"] = 256265
+
+    normalized = mdm._normalize_ws_tick(
+        {
+            "instrument_token": 256265,
+            "last_price": 24500.0,
+            "exchange_timestamp": "bad",
+            "received_at": "2026-07-23T09:30:05+05:30",
+        }
+    )
+
+    assert normalized is not None
+    assert normalized["symbol"] == "NSE:NIFTY"
+    assert normalized["timestamp_source"] == "received_at"


### PR DESCRIPTION
### Motivation
- Prevent a single malformed timestamp field from causing a tick to be dropped when another valid timestamp exists and ensure one bad tick cannot kill the consumer loop. 
- Preserve exact provenance (`source` and `raw_value`) for the accepted timestamp and keep `received_at` explicitly labelled as a fallback. 
- Improve MDM diagnostics so dropped ticks report why (missing vs all-invalid) and which timestamp fields were present without logging entire payloads.

### Description
- Change `normalize_market_tick_timestamp()` in `src/nifty_scalper_bot/data/time_contract.py` to iterate through timestamp groups in priority order and attempt parsing each non-empty field until the first valid one is found, skipping fields whose parsing raises `TypeError`, `ValueError`, or `OverflowError`, and raising a deterministic `ValueError` only when no timestamp fields are present or all present fields fail. 
- Preserve provenance by returning `MarketTimestamp.source` and `MarketTimestamp.raw_value` tied to the actual accepted field. 
- Wire MDM non-REST resolution to use the canonical normalizer (`normalize_market_tick_timestamp`) while retaining existing UTC->IST and ancient/future filters by converting the accepted `raw_value` back to a `pd.Timestamp` for MDM checks. 
- Add helper methods in `src/nifty_scalper_bot/data/market_data_manager.py` for safe `received_at` epoch extraction and for enumerating which timestamp fields are present for better diagnostic messages. 
- Improve MDM rejection logging to include `timestamp_reason` (`missing_all` or `all_present_invalid`), `token`, resolved `symbol`, `source` (ws/rest), and the `present_timestamp_fields` list, without printing full payloads. 
- Add focused regression tests in `tests/data/test_market_timestamp_contract.py` and `tests/data/test_mdm_invalid_candle_timestamp.py` to cover malformed-first-field fallback, broker->received_at fallbacks, all-invalid final error, missing-all diagnostics, invalid tick isolation, and NIFTY spot received_at fallback behavior.

### Testing
- Ran `python -m pytest -q tests/data/test_mdm_invalid_candle_timestamp.py` and it passed. 
- Ran `python -m pytest -q tests/data/test_mdm_tick_timestamp_fallback.py` and it passed. 
- Ran `python -m pytest -q tests/data/test_market_data_hardening.py` and it passed. 
- Ran `python -m pytest -q tests/data/test_mdm_tick_coalescing.py` and it passed. 
- Ran `python -m compileall -q src` and it passed. 
- Ran the full suite (`python -m pytest -q`) and the focused timestamp/data-path suites passed, but an unrelated end-to-end test failed: `tests/e2e/live_sim/test_live_runtime_startup_contract.py::test_live_runtime_bullish_spot_future_selects_ce_and_exits_target` reported `execution_not_armed:futures_live_tick_stale`, so repository-wide green is not claimed while focused tests are green.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6197b7688883249694e183459625a6)