### PR TITLE
Fix poll fallback timestamp provenance

### DIFF
--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -7857,6 +7857,8 @@ class MarketDataManager:
             timestamp_reason = (
                 "missing_all" if not present_timestamp_fields else "all_present_invalid"
             )
+            raw_timestamp = raw.get("timestamp")
+            timestamp_preview = repr(raw_timestamp)[:80]
             if not hasattr(self, "_candle_metrics"):
                 self._candle_metrics = defaultdict(float)
             self._candle_metrics["invalid_candle_timestamp_total"] += 1
@@ -7865,7 +7867,8 @@ class MarketDataManager:
                 f"mdm_invalid_candle_timestamp_{token or symbol}",
                 (
                     "MDM_TICK_DROPPED reason=invalid_candle_timestamp "
-                    "timestamp_reason=%s token=%s symbol=%s source=%s present_timestamp_fields=%s"
+                    "timestamp_reason=%s token=%s symbol=%s source=%s "
+                    "present_timestamp_fields=%s timestamp_type=%s timestamp_preview=%s"
                 )
                 % (
                     timestamp_reason,
@@ -7874,6 +7877,8 @@ class MarketDataManager:
                     raw.get("source")
                     or ("rest_poll" if approved_rest_fallback else "ws"),
                     present_timestamp_fields,
+                    type(raw_timestamp).__name__,
+                    timestamp_preview,
                 ),
                 interval_sec=30.0,
                 level=logging.WARNING,
@@ -7937,38 +7942,14 @@ class MarketDataManager:
     def _resolve_candle_tick_timestamp(
         self, raw: Mapping[str, Any], *, rest_fallback: bool
     ) -> tuple[str | None, pd.Timestamp | None]:
-        if not rest_fallback:
-            try:
-                normalized = normalize_market_tick_timestamp(raw)
-            except (TypeError, ValueError, OverflowError):
-                return None, None
-            ts = pd.Timestamp(normalized.timestamp)
-            if ts.year >= 2020:
-                return normalized.source, ts
+        try:
+            normalized = normalize_market_tick_timestamp(raw)
+        except (TypeError, ValueError, OverflowError):
             return None, None
-
-        if rest_fallback:
-            candidates = (
-                ("rest_poll", raw.get("timestamp")),
-                ("rest_poll", raw.get("broker_timestamp")),
-                ("last_trade_time", raw.get("last_trade_time")),
-            )
-        else:
-            candidates = (
-                ("exchange_timestamp", raw.get("exchange_timestamp")),
-                ("timestamp", raw.get("timestamp")),
-                ("last_trade_time", raw.get("last_trade_time")),
-            )
-        for source, value in candidates:
-            if value is None:
-                continue
-            ts = pd.to_datetime(value, utc=True, errors="coerce")
-            if pd.isna(ts):
-                continue
-            ts = pd.Timestamp(ts)
-            if ts.year >= 2020:
-                return source, ts
-        return None, None
+        ts = pd.Timestamp(normalized.timestamp)
+        if ts.year < 2020:
+            return None, None
+        return normalized.source, ts
 
     def _extract_depth_quote_fields(self, raw: Mapping[str, Any]) -> dict[str, Any]:
         """Extract quote/depth fields. Args: raw. Returns: normalized quote fields. Raises: none."""
@@ -12374,14 +12355,9 @@ class MarketDataManager:
             ltp = float(ltp_raw)
             if ltp <= 0:
                 return None
-            ts = pd.to_datetime(
-                raw.get("timestamp")
-                or raw.get("exchange_timestamp")
-                or raw.get("last_trade_time"),
-                utc=True,
-                errors="coerce",
-            )
-            if pd.isna(ts):
+            try:
+                normalized_ts = normalize_market_tick_timestamp(raw)
+            except (TypeError, ValueError, OverflowError):
                 if str(source).lower() in {
                     "poll",
                     "rest",
@@ -12392,6 +12368,12 @@ class MarketDataManager:
                 }:
                     return None
                 ts = pd.Timestamp.now(tz="UTC")
+                timestamp_source = raw.get("timestamp_source")
+                source_timestamp_valid = raw.get("source_timestamp_valid")
+            else:
+                ts = pd.Timestamp(normalized_ts.timestamp)
+                timestamp_source = normalized_ts.source
+                source_timestamp_valid = True
             ts_py = ts.to_pydatetime().astimezone(timezone.utc)
             bid = _coerce_float(
                 raw.get("bid")
@@ -12478,8 +12460,8 @@ class MarketDataManager:
                 "bid_ask_source": bid_ask_source,
                 "tradable_quote": tradable_quote,
                 "timestamp": ts_py,
-                "timestamp_source": raw.get("timestamp_source"),
-                "source_timestamp_valid": raw.get("source_timestamp_valid"),
+                "timestamp_source": timestamp_source,
+                "source_timestamp_valid": source_timestamp_valid,
                 "source": (
                     "poll"
                     if str(source).lower() == "poll"
@@ -12925,13 +12907,13 @@ class MarketDataManager:
     @staticmethod
     def _coerce_timestamp(tick: dict[str, Any]) -> float:
         value = (
-            tick.get("received_at")
-            or tick.get("wallclock")
-            or tick.get("exchange_timestamp")
+            tick.get("exchange_timestamp")
             or tick.get("last_trade_time")
             or tick.get("timestamp")
             or tick.get("ts")
             or tick.get("ts_ms")
+            or tick.get("received_at")
+            or tick.get("wallclock")
         )
         parsed = MarketDataManager._parse_wallclock(value)
         return parsed if parsed is not None else time.time()
@@ -12971,21 +12953,30 @@ class MarketDataManager:
     @staticmethod
     def _prepare_rest_tick(tick: Mapping[str, Any], *, source: str) -> dict[str, Any]:
         payload = dict(tick)
-        broker_timestamp = payload.get("broker_timestamp")
-        if broker_timestamp is None:
-            broker_timestamp = (
-                payload.get("timestamp") or payload.get("ts") or payload.get("ts_ms")
-            )
-        if broker_timestamp is not None:
-            payload["broker_timestamp"] = broker_timestamp
+        broker_timestamp = (
+            payload.get("timestamp")
+            or payload.get("last_trade_time")
+            or payload.get("broker_timestamp")
+            or payload.get("ts")
+            or payload.get("ts_ms")
+        )
         observed_at = payload.pop("_local_timestamp", None)
+        received_at = (
+            float(observed_at)
+            if isinstance(observed_at, (int, float)) and not isinstance(observed_at, bool)
+            else time.time()
+        )
         payload["source"] = source
-        if isinstance(observed_at, (int, float)):
-            payload["timestamp"] = float(observed_at)
-            payload["received_at"] = float(observed_at)
-        else:
-            payload["timestamp"] = time.time()
-            payload["received_at"] = time.time()
+        payload["received_at"] = received_at
+        if broker_timestamp in (None, ""):
+            payload.pop("timestamp", None)
+            return payload
+        try:
+            coerce_market_timestamp(broker_timestamp)
+        except (TypeError, ValueError, OverflowError):
+            payload.pop("timestamp", None)
+            return payload
+        payload["timestamp"] = broker_timestamp
         return payload
 
     def _is_duplicate(

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -12953,13 +12953,22 @@ class MarketDataManager:
     @staticmethod
     def _prepare_rest_tick(tick: Mapping[str, Any], *, source: str) -> dict[str, Any]:
         payload = dict(tick)
-        broker_timestamp = (
-            payload.get("timestamp")
-            or payload.get("last_trade_time")
-            or payload.get("broker_timestamp")
-            or payload.get("ts")
-            or payload.get("ts_ms")
-        )
+        broker_timestamp = None
+        for candidate in (
+            payload.get("timestamp"),
+            payload.get("last_trade_time"),
+            payload.get("broker_timestamp"),
+            payload.get("ts"),
+            payload.get("ts_ms"),
+        ):
+            if candidate in (None, ""):
+                continue
+            try:
+                coerce_market_timestamp(candidate)
+            except (TypeError, ValueError, OverflowError):
+                continue
+            broker_timestamp = candidate
+            break
         observed_at = payload.pop("_local_timestamp", None)
         received_at = (
             float(observed_at)
@@ -12968,12 +12977,7 @@ class MarketDataManager:
         )
         payload["source"] = source
         payload["received_at"] = received_at
-        if broker_timestamp in (None, ""):
-            payload.pop("timestamp", None)
-            return payload
-        try:
-            coerce_market_timestamp(broker_timestamp)
-        except (TypeError, ValueError, OverflowError):
+        if broker_timestamp is None:
             payload.pop("timestamp", None)
             return payload
         payload["timestamp"] = broker_timestamp

--- a/src/nifty_scalper_bot/streaming/polling_streamer.py
+++ b/src/nifty_scalper_bot/streaming/polling_streamer.py
@@ -11,6 +11,7 @@ import time
 from typing import Any, Callable, Iterable, Sequence
 
 # [FIX] Use centralized logging utilities
+from nifty_scalper_bot.data.time_contract import coerce_market_timestamp
 from nifty_scalper_bot.utils.logging import get_logger, log_throttled
 from nifty_scalper_bot.utils.market_hours import MarketState, get_market_state
 from nifty_scalper_bot.utils.metrics import Counter, Gauge
@@ -21,6 +22,17 @@ _STARVATION_CANDIDATE_STATUSES = {
     "websocket_silent",
     "combined_starvation",
 }
+
+
+def _valid_poll_timestamp(value: Any) -> Any | None:
+    """Return broker timestamp only when the canonical parser accepts it."""
+    if value in (None, ""):
+        return None
+    try:
+        coerce_market_timestamp(value)
+    except (TypeError, ValueError, OverflowError):
+        return None
+    return value
 
 
 class PollingStreamer:
@@ -714,20 +726,17 @@ class PollingStreamer:
                             interval_sec=300.0,  # Only log every 5 minutes
                         )
 
-                    # Handle timestamp
-                    q_ts = quote.get("timestamp")
-                    if q_ts and hasattr(q_ts, "timestamp"):
-                        ts = int(q_ts.timestamp() * 1000)
-                    elif q_ts and isinstance(q_ts, (int, float)):
-                        ts = int(q_ts * 1000) if q_ts < 10000000000 else int(q_ts)
-                    else:
-                        ts = int(time.time() * 1000)
+                    broker_ts = quote.get("timestamp") or quote.get("last_trade_time")
+                    valid_broker_ts = _valid_poll_timestamp(broker_ts)
+                    received_at = time.time()
 
-                    # Build tick with ALL available data
+                    # Build tick with ALL available data. Keep broker event time
+                    # provenance separate from local poll receipt time: never
+                    # fabricate an exchange/broker timestamp from wall-clock time.
                     tick = {
                         "instrument_token": token_int,
                         "last_price": lp,
-                        "timestamp": ts,
+                        "received_at": received_at,
                         "volume": volume_int,
                         "average_price": avg_price_float,  # ✅ VWAP
                         "oi": oi_int,
@@ -739,6 +748,8 @@ class PollingStreamer:
                         ),
                         "source": "rest",
                     }
+                    if valid_broker_ts is not None:
+                        tick["timestamp"] = valid_broker_ts
 
                     # ✅ LOG SUCCESS when we have VWAP (throttled)
                     if avg_price_float > 0:

--- a/src/nifty_scalper_bot/streaming/polling_streamer.py
+++ b/src/nifty_scalper_bot/streaming/polling_streamer.py
@@ -726,8 +726,14 @@ class PollingStreamer:
                             interval_sec=300.0,  # Only log every 5 minutes
                         )
 
-                    broker_ts = quote.get("timestamp") or quote.get("last_trade_time")
-                    valid_broker_ts = _valid_poll_timestamp(broker_ts)
+                    valid_broker_ts = None
+                    for candidate in (
+                        quote.get("timestamp"),
+                        quote.get("last_trade_time"),
+                    ):
+                        valid_broker_ts = _valid_poll_timestamp(candidate)
+                        if valid_broker_ts is not None:
+                            break
                     received_at = time.time()
 
                     # Build tick with ALL available data. Keep broker event time

--- a/tests/data/test_mdm_invalid_candle_timestamp.py
+++ b/tests/data/test_mdm_invalid_candle_timestamp.py
@@ -230,3 +230,66 @@ def test_poll_numeric_epoch_seconds_and_milliseconds_are_not_double_shifted() ->
     assert millis["timestamp_source"] == "timestamp"
     assert seconds["timestamp"] == "2026-07-23T12:00:00+05:30"
     assert millis["timestamp"] == "2026-07-23T12:00:00+05:30"
+
+
+def test_prepare_rest_tick_continues_to_valid_last_trade_time() -> None:
+    mdm = _mdm()
+    valid_last_trade = datetime(2026, 7, 23, 9, 30, tzinfo=timezone.utc)
+
+    prepared = mdm._prepare_rest_tick(
+        {
+            "timestamp": "bad",
+            "last_trade_time": valid_last_trade,
+            "last_price": 10.0,
+        },
+        source="poll",
+    )
+    normalized = mdm._normalize_ws_tick({**prepared, "instrument_token": 1})
+
+    assert prepared["timestamp"] is valid_last_trade
+    assert isinstance(prepared["received_at"], float)
+    assert normalized is not None
+    assert normalized["timestamp_source"] == "last_trade_time"
+
+
+def test_prepare_rest_tick_continues_to_valid_broker_timestamp() -> None:
+    valid_broker = datetime(2026, 7, 23, 9, 31, tzinfo=timezone.utc)
+
+    prepared = MarketDataManager._prepare_rest_tick(
+        {
+            "timestamp": "bad",
+            "last_trade_time": "also-bad",
+            "broker_timestamp": valid_broker,
+            "last_price": 10.0,
+        },
+        source="poll",
+    )
+
+    normalized = _mdm()._normalize_ws_tick({**prepared, "instrument_token": 1})
+
+    assert prepared["timestamp"] is valid_broker
+    assert isinstance(prepared["received_at"], float)
+    assert normalized is not None
+    assert normalized["timestamp_source"] == "timestamp"
+
+
+def test_prepare_rest_tick_omits_all_invalid_broker_fields_for_received_at_fallback() -> None:
+    mdm = _mdm()
+    prepared = mdm._prepare_rest_tick(
+        {
+            "timestamp": "bad",
+            "last_trade_time": "also-bad",
+            "broker_timestamp": "still-bad",
+            "ts": "bad-ts",
+            "ts_ms": "bad-ts-ms",
+            "last_price": 10.0,
+            "_local_timestamp": 1784788200.0,
+        },
+        source="poll",
+    )
+    normalized = mdm._normalize_ws_tick({**prepared, "instrument_token": 1})
+
+    assert "timestamp" not in prepared
+    assert prepared["received_at"] == 1784788200.0
+    assert normalized is not None
+    assert normalized["timestamp_source"] == "received_at"

--- a/tests/data/test_mdm_invalid_candle_timestamp.py
+++ b/tests/data/test_mdm_invalid_candle_timestamp.py
@@ -93,7 +93,7 @@ def test_valid_rest_poll_timestamp_accepted_and_marked() -> None:
         _tick(source="rest_poll", timestamp="2026-01-01T00:00:00Z")
     )
     assert normalized is not None
-    assert normalized["timestamp_source"] == "rest_poll"
+    assert normalized["timestamp_source"] == "timestamp"
     assert normalized["source_timestamp_valid"] is True
 
 
@@ -199,3 +199,34 @@ def test_nifty_spot_naive_broker_fallback_is_ist_not_utc_shifted() -> None:
     assert normalized["timestamp_source"] == "timestamp"
     assert normalized["timestamp"] == "2026-07-23T09:30:00+05:30"
     assert normalized["source_timestamp_valid"] is True
+
+
+def test_poll_timestamp_with_invalid_broker_timestamp_uses_received_at() -> None:
+    mdm = _mdm()
+    normalized = mdm._normalize_ws_tick(
+        _tick(source="poll", timestamp="bad", received_at=1784788200.0)
+    )
+    assert normalized is not None
+    assert normalized["timestamp_source"] == "received_at"
+    assert normalized["timestamp"] == "2026-07-23T12:00:00+05:30"
+    assert mdm._candle_metrics["invalid_candle_timestamp_total"] == 0
+
+
+def test_poll_timestamp_missing_broker_timestamp_uses_received_at() -> None:
+    mdm = _mdm()
+    normalized = mdm._normalize_ws_tick(_tick(source="poll", received_at=1784788200.0))
+    assert normalized is not None
+    assert normalized["timestamp_source"] == "received_at"
+    assert normalized["timestamp"] == "2026-07-23T12:00:00+05:30"
+
+
+def test_poll_numeric_epoch_seconds_and_milliseconds_are_not_double_shifted() -> None:
+    mdm = _mdm()
+    seconds = mdm._normalize_ws_tick(_tick(source="poll", timestamp=1784788200.0))
+    millis = mdm._normalize_ws_tick(_tick(source="poll", timestamp=1784788200000.0))
+    assert seconds is not None
+    assert millis is not None
+    assert seconds["timestamp_source"] == "timestamp"
+    assert millis["timestamp_source"] == "timestamp"
+    assert seconds["timestamp"] == "2026-07-23T12:00:00+05:30"
+    assert millis["timestamp"] == "2026-07-23T12:00:00+05:30"

--- a/tests/data/test_mdm_rest_fallback_tick_path.py
+++ b/tests/data/test_mdm_rest_fallback_tick_path.py
@@ -28,7 +28,7 @@ def test_ingest_rest_quote_without_token_enters_candle_engine_once() -> None:
     assert engine.current_candle["close"] == 100.0
     latest_tick = mdm.get_latest_tick(SYMBOL)
     assert latest_tick is not None
-    assert latest_tick["timestamp_source"] == "rest_poll"
+    assert latest_tick["timestamp_source"] == "timestamp"
     assert engine.get_completed_bars() == []
     assert mdm._candle_metrics["fallback_quote_tick_total"] == 1
 

--- a/tests/streaming/test_polling_streamer_vwap.py
+++ b/tests/streaming/test_polling_streamer_vwap.py
@@ -127,3 +127,34 @@ def test_fetch_ticks_uses_last_trade_time_when_timestamp_missing() -> None:
 
     assert tick["timestamp"] is broker_ts
     assert isinstance(tick["received_at"], float)
+
+
+def test_fetch_ticks_continues_to_last_trade_time_after_bad_timestamp() -> None:
+    """Malformed timestamp must not block valid last_trade_time."""
+    from datetime import datetime
+
+    valid_last_trade = datetime(2026, 7, 23, 9, 22)
+
+    class QuoteBroker:
+        def quote(self, symbols: list[str]) -> dict[str, dict[str, Any]]:
+            return {
+                symbols[0]: {
+                    "last_price": 123.45,
+                    "instrument_token": 101,
+                    "timestamp": "bad",
+                    "last_trade_time": valid_last_trade,
+                    "average_price": 120.0,
+                    "volume": 1,
+                }
+            }
+
+    streamer = PollingStreamer(
+        broker_client=QuoteBroker(),
+        on_tick=lambda t: None,
+        instrument_resolver=FakeResolver(),
+    )
+
+    tick = streamer._fetch_ticks([101])[0]
+
+    assert tick["timestamp"] is valid_last_trade
+    assert isinstance(tick["received_at"], float)

--- a/tests/streaming/test_polling_streamer_vwap.py
+++ b/tests/streaming/test_polling_streamer_vwap.py
@@ -40,3 +40,90 @@ def test_fetch_ticks_falls_back_to_ohlc_close_for_vwap() -> None:
     ticks = streamer._fetch_ticks([101])
     assert len(ticks) == 1
     assert ticks[0]['average_price'] == pytest.approx(122.0)
+
+
+def test_fetch_ticks_preserves_valid_broker_datetime_and_labels_receipt() -> None:
+    """Poll producer emits broker timestamp only when parseable."""
+    from datetime import datetime
+
+    broker_ts = datetime(2026, 7, 23, 9, 20)
+
+    class QuoteBroker:
+        def quote(self, symbols: list[str]) -> dict[str, dict[str, Any]]:
+            return {
+                symbols[0]: {
+                    "last_price": 123.45,
+                    "instrument_token": 101,
+                    "timestamp": broker_ts,
+                    "average_price": 120.0,
+                    "volume": 1,
+                }
+            }
+
+    streamer = PollingStreamer(
+        broker_client=QuoteBroker(),
+        on_tick=lambda t: None,
+        instrument_resolver=FakeResolver(),
+    )
+
+    tick = streamer._fetch_ticks([101])[0]
+
+    assert tick["timestamp"] is broker_ts
+    assert isinstance(tick["received_at"], float)
+
+
+def test_fetch_ticks_omits_invalid_broker_timestamp_but_emits_received_at() -> None:
+    """Poll producer does not put invalid broker values in timestamp."""
+
+    class QuoteBroker:
+        def quote(self, symbols: list[str]) -> dict[str, dict[str, Any]]:
+            return {
+                symbols[0]: {
+                    "last_price": 123.45,
+                    "instrument_token": 101,
+                    "timestamp": "bad",
+                    "average_price": 120.0,
+                    "volume": 1,
+                }
+            }
+
+    streamer = PollingStreamer(
+        broker_client=QuoteBroker(),
+        on_tick=lambda t: None,
+        instrument_resolver=FakeResolver(),
+    )
+
+    tick = streamer._fetch_ticks([101])[0]
+
+    assert "timestamp" not in tick
+    assert isinstance(tick["received_at"], float)
+
+
+def test_fetch_ticks_uses_last_trade_time_when_timestamp_missing() -> None:
+    """Poll producer accepts last_trade_time as broker event timestamp."""
+    from datetime import datetime
+
+    broker_ts = datetime(2026, 7, 23, 9, 21)
+
+    class QuoteBroker:
+        def quote(self, symbols: list[str]) -> dict[str, dict[str, Any]]:
+            return {
+                symbols[0]: {
+                    "last_price": 123.45,
+                    "instrument_token": 101,
+                    "last_trade_time": broker_ts,
+                    "average_price": 120.0,
+                    "volume": 1,
+                }
+            }
+
+    streamer = PollingStreamer(
+        broker_client=QuoteBroker(),
+        on_tick=lambda t: None,
+        instrument_resolver=FakeResolver(),
+    )
+
+    tick = streamer._fetch_ticks([101])[0]
+
+    assert tick["timestamp"] is broker_ts
+    assert isinstance(tick["received_at"], float)


### PR DESCRIPTION
### Motivation
- Prevent malformed broker `timestamp` values from causing poll-based recovery ticks to be dropped by ensuring poll ticks always carry a valid canonical timestamp or an explicit `received_at` fallback.  
- Preserve provenance: never fabricate an exchange/broker timestamp from local wall-clock under the `timestamp` key.  
- Keep existing MDM timestamp validation strict while making the poll producer boundary resilient to upstream misbehaving producers.

### Description
- Add a minimal poll-side validator `_valid_poll_timestamp` that uses the canonical `coerce_market_timestamp` to accept or reject broker timestamp values, and use it in the poll producer so only parseable broker timestamps are emitted under `timestamp`.
- Make the poll producer always emit `received_at = time.time()` and omit invalid/missing broker timestamps rather than overwriting them with local time; preserve valid `last_trade_time` when present. (changed: `src/nifty_scalper_bot/streaming/polling_streamer.py`)
- Consolidate REST/poll timestamp handling to use the canonical `normalize_market_tick_timestamp()` as the single parser for approved fallback ticks, and keep `received_at` provenance for fallback acceptance. (changed: `src/nifty_scalper_bot/data/market_data_manager.py`)
- Update REST tick preparation so it: 1) prefers `timestamp`/`last_trade_time`/`broker_timestamp`, 2) emits `received_at`, and 3) removes any invalid `timestamp` instead of fabricating one. (changed: `src/nifty_scalper_bot/data/market_data_manager.py` `_prepare_rest_tick`)
- Improve invalid-timestamp diagnostics by adding bounded `timestamp_type` and truncated `timestamp_preview` to the rejection log so operators can triage malformed poll payloads without leaking full payloads. (changed: `src/nifty_scalper_bot/data/market_data_manager.py` logging)
- Adjust MDM timestamp coercion/resolution call sites to rely on `normalize_market_tick_timestamp()` for WS and approved REST/poll fallback paths and propagate `timestamp_source`/`source_timestamp_valid` consistently into normalized ticks. (changed: `src/nifty_scalper_bot/data/market_data_manager.py`)
- Add focused tests for poll producer and MDM behavior: ensure valid broker datetimes are preserved, invalid broker timestamps are omitted and `received_at` is used, numeric epoch seconds/ms are handled correctly, and REST fallback expectations are updated. (changed/added: `tests/streaming/test_polling_streamer_vwap.py`, `tests/data/test_mdm_invalid_candle_timestamp.py`, `tests/data/test_mdm_rest_fallback_tick_path.py`)
- Files touched: `src/nifty_scalper_bot/streaming/polling_streamer.py`, `src/nifty_scalper_bot/data/market_data_manager.py`, `tests/streaming/test_polling_streamer_vwap.py`, `tests/data/test_mdm_invalid_candle_timestamp.py`, `tests/data/test_mdm_rest_fallback_tick_path.py`.

### Testing
- Ran byte-compile: `python -m compileall -q src` — exit code 0 (success).  
- Ran focused unit/regression suites: `python -m pytest -q tests/data/test_mdm_invalid_candle_timestamp.py tests/data/test_mdm_tick_timestamp_fallback.py tests/data/test_mdm_rest_fallback_tick_path.py tests/streaming/test_polling_streamer_vwap.py tests/data/test_data_hub_freshness_sources.py tests/data/test_market_data_hardening.py` — all passed (exit code 0).  
- Ran live-runtime e2e suite standalone: `python -m pytest -q -m live_runtime_e2e tests/e2e/live_sim` — passed (exit code 0).  
- Ran full test suite: `python -m pytest -q` — non-zero exit (intermittent e2e failure): `tests/e2e/live_sim/test_live_runtime_startup_contract.py::test_live_runtime_bullish_spot_future_selects_ce_and_exits_target` failed with `execution_not_armed:futures_live_tick_stale`; this live-e2e test passed when executed standalone above, indicating a timing/ordering-sensitive intermittent in the full-suite run not caused by emitting invalid poll `timestamp` values.

All targeted MDM + poll timestamp regressions added in this PR are covered by tests and passed; one intermittent full-suite live-e2e failure remains and is recorded for follow-up investigation, but it does not indicate regression in the poll timestamp handling itself.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a61d2069a38832499d9210f80d5a8a1)