### PR TITLE
Fix false global WebSocket restart during symbol subscription activation

### DIFF
--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -9717,6 +9717,7 @@ class MarketDataManager:
             return
         self._monitor_spot_ws_health()
         ws_healthy = self._is_ws_healthy()
+        connected = self._is_ws_connected()
 
         with self._lock:
             required = self._required_live_symbols()
@@ -9733,12 +9734,19 @@ class MarketDataManager:
         stale_symbols: list[str] = []
         missing_symbols: list[str] = []
         fresh_symbols: list[str] = []
+        required_grace_symbols: list[str] = []
         for sym in candidate_symbols:
+            required_since = since_by_symbol.get(sym)
+            within_required_grace = (
+                required_since is not None
+                and now_mono - required_since < self._required_symbol_missing_grace_sec
+            )
+            if within_required_grace:
+                required_grace_symbols.append(sym)
+                continue
             age = self.time_since_last_live_ws_tick(sym)
             if age is None:
-                required_since = since_by_symbol.get(sym) or now_mono
-                if now_mono - required_since >= self._required_symbol_missing_grace_sec:
-                    missing_symbols.append(sym)
+                missing_symbols.append(sym)
                 continue
             if age > self._zombie_tick_threshold_sec:
                 stale_symbols.append(sym)
@@ -9763,6 +9771,7 @@ class MarketDataManager:
                 "threshold_seconds": self._zombie_tick_threshold_sec,
                 "required_symbols": len(required),
                 "heartbeat_age_s": heartbeat_age,
+                "required_grace_symbols": required_grace_symbols,
             },
         )
         spot_stale = "NSE:NIFTY" in stale_or_missing_symbols
@@ -9805,13 +9814,13 @@ class MarketDataManager:
             and (heartbeat_stale or not ws_healthy)
         )
         backlog_classification = self.classify_transport_backlog()
-        processing_backlog = (
-            backlog_classification.get("transport_classification")
-            == "processing_backlog"
+        transport_classification = backlog_classification.get(
+            "transport_classification"
         )
+        processing_backlog = transport_classification == "processing_backlog"
+        raw_transport_silent = transport_classification == "transport_silent"
         symbol_subscription_stale = (
-            backlog_classification.get("transport_classification")
-            == "symbol_subscription_stale"
+            transport_classification == "symbol_subscription_stale"
         )
         active_future = self.get_active_nifty_future_symbol_cached()
         symbol_recovery_exceeded = False
@@ -9841,15 +9850,34 @@ class MarketDataManager:
         # fire for a single stuck symbol subscription (e.g. one illiquid
         # option strike) while the transport is demonstrably healthy,
         # invalidating quotes for the whole restart+re-verification window.
+        global_restart_eligible = bool(
+            backlog_classification.get("global_restart_eligible")
+            and raw_transport_silent
+        )
         transport_failure = bool(
             stale_or_missing_symbols
             and not processing_backlog
-            and (
-                backlog_classification.get("global_restart_eligible")
-                or heartbeat_stale
-                or not ws_healthy
-            )
+            and (not connected or heartbeat_stale or raw_transport_silent)
         )
+        restart_diagnostics = {
+            "connected": connected,
+            "ws_healthy": ws_healthy,
+            "heartbeat_stale": heartbeat_stale,
+            "heartbeat_age_s": heartbeat_age,
+            "last_raw_ws_packet_age_s": backlog_classification.get("raw_receive_age_s"),
+            "last_accepted_ws_tick_age_s": backlog_classification.get(
+                "processed_tick_age_s"
+            ),
+            "event_loop_lag_s": max(
+                0.0, float(getattr(self, "_event_loop_lag_seconds", 0.0) or 0.0)
+            ),
+            "processing_backlog": processing_backlog,
+            "transport_classification": transport_classification,
+            "global_restart_eligible": global_restart_eligible,
+            "subscription_divergence": subscription_divergence,
+            "stale_ratio": round(stale_ratio, 3),
+            "required_grace_symbols": required_grace_symbols,
+        }
         if stale_or_missing_symbols and not transport_failure:
             recovery_last = getattr(self, "_symbol_recovery_last_attempt_mono", None)
             if not isinstance(recovery_last, dict):
@@ -9905,6 +9933,18 @@ class MarketDataManager:
                         "stale_age_s": age,
                         "heartbeat_age_s": heartbeat_age,
                         "ws_healthy": ws_healthy,
+                        "connected": connected,
+                        "heartbeat_stale": heartbeat_stale,
+                        "last_raw_ws_packet_age_s": restart_diagnostics[
+                            "last_raw_ws_packet_age_s"
+                        ],
+                        "last_accepted_ws_tick_age_s": restart_diagnostics[
+                            "last_accepted_ws_tick_age_s"
+                        ],
+                        "event_loop_lag_s": restart_diagnostics["event_loop_lag_s"],
+                        "processing_backlog": processing_backlog,
+                        "transport_classification": transport_classification,
+                        "global_restart_eligible": global_restart_eligible,
                         "subscription_divergence": subscription_divergence,
                         "subscription_divergence_age_s": divergence_age,
                         "reason": recovery_reason,
@@ -9922,6 +9962,7 @@ class MarketDataManager:
                     "stale_symbols": stale_symbols,
                     "missing_symbols": missing_symbols,
                     "recovery_dispatched_symbols": dispatched_symbols,
+                    **restart_diagnostics,
                     "heartbeat_age_s": heartbeat_age,
                     "ws_healthy": ws_healthy,
                     "subscription_divergence": subscription_divergence,
@@ -9973,6 +10014,7 @@ class MarketDataManager:
                 "event": "WS_GLOBAL_RESTART_TRIGGERED",
                 "symbols": stale_symbols,
                 "missing_symbols": missing_symbols,
+                **restart_diagnostics,
                 "heartbeat_age_s": heartbeat_age,
                 "ws_healthy": ws_healthy,
                 "subscription_divergence": subscription_divergence,

--- a/tests/data/test_mdm_tick_coalescing.py
+++ b/tests/data/test_mdm_tick_coalescing.py
@@ -328,11 +328,13 @@ def test_one_stale_noncritical_option_does_not_restart_full_ws(monkeypatch):
     for sym in mdm._required_live_symbols():
         mdm._last_valid_live_tick_mono[sym] = now
     mdm._last_valid_live_tick_mono[stale] = now - 120.0
+    mdm._required_symbol_since_mono[stale] = now - 120.0
     mdm._zombie_tick_threshold_sec = 60.0
     mdm._last_hb_mono = now
     rest_requests = []
     monkeypatch.setattr(market_hours, "is_market_open", lambda: True)
     monkeypatch.setattr(mdm, "_is_ws_healthy", lambda: True)
+    monkeypatch.setattr(mdm, "_is_ws_connected", lambda: True)
     monkeypatch.setattr(mdm, "_monitor_spot_ws_health", lambda: None)
     monkeypatch.setattr(
         mdm,
@@ -362,12 +364,15 @@ def test_spot_and_futures_stale_use_symbol_recovery_when_transport_healthy(monke
         mdm._last_valid_live_tick_mono[sym] = now
     mdm._last_valid_live_tick_mono["NSE:NIFTY"] = now - 120.0
     mdm._last_valid_live_tick_mono["NFO:NIFTY26JUNFUT"] = now - 120.0
+    mdm._required_symbol_since_mono["NSE:NIFTY"] = now - 120.0
+    mdm._required_symbol_since_mono["NFO:NIFTY26JUNFUT"] = now - 120.0
     mdm._zombie_tick_threshold_sec = 60.0
     mdm._last_hb_mono = now
     rest_requests: list[tuple[str, str]] = []
     resubscribed: list[bool] = []
     monkeypatch.setattr(market_hours, "is_market_open", lambda: True)
     monkeypatch.setattr(mdm, "_is_ws_healthy", lambda: True)
+    monkeypatch.setattr(mdm, "_is_ws_connected", lambda: True)
     monkeypatch.setattr(mdm, "_monitor_spot_ws_health", lambda: None)
     monkeypatch.setattr(
         mdm,
@@ -399,11 +404,13 @@ def test_heartbeat_stale_triggers_single_global_restart(monkeypatch):
     mdm._symbols_with_tick.update(required)
     for sym in required:
         mdm._last_valid_live_tick_mono[sym] = now - 120.0
+        mdm._required_symbol_since_mono[sym] = now - 120.0
     mdm._zombie_tick_threshold_sec = 60.0
     mdm._last_hb_mono = now - 120.0
     restarted: list[bool] = []
     monkeypatch.setattr(market_hours, "is_market_open", lambda: True)
     monkeypatch.setattr(mdm, "_is_ws_healthy", lambda: False)
+    monkeypatch.setattr(mdm, "_is_ws_connected", lambda: True)
     monkeypatch.setattr(mdm, "_monitor_spot_ws_health", lambda: None)
     monkeypatch.setattr(
         mdm, "_trigger_zombie_ws_restart", lambda: restarted.append(True)
@@ -469,6 +476,7 @@ def test_required_symbol_without_current_generation_tick_is_not_fresh(monkeypatc
     rest_requests = []
     monkeypatch.setattr(market_hours, "is_market_open", lambda: True)
     monkeypatch.setattr(mdm, "_is_ws_healthy", lambda: True)
+    monkeypatch.setattr(mdm, "_is_ws_connected", lambda: True)
     monkeypatch.setattr(mdm, "_monitor_spot_ws_health", lambda: None)
     monkeypatch.setattr(
         mdm,
@@ -630,6 +638,7 @@ def test_required_symbol_without_first_ws_tick_gets_symbol_recovery(monkeypatch)
     rest_requests = []
     monkeypatch.setattr(market_hours, "is_market_open", lambda: True)
     monkeypatch.setattr(mdm, "_is_ws_healthy", lambda: True)
+    monkeypatch.setattr(mdm, "_is_ws_connected", lambda: True)
     monkeypatch.setattr(mdm, "_monitor_spot_ws_health", lambda: None)
     monkeypatch.setattr(
         mdm,
@@ -663,10 +672,12 @@ def test_symbol_recovery_exceeded_alone_does_not_force_global_restart(monkeypatc
     for sym in mdm._required_live_symbols():
         mdm._last_valid_live_tick_mono[sym] = now
     mdm._last_valid_live_tick_mono[future] = now - 120.0
+    mdm._required_symbol_since_mono[future] = now - 120.0
     mdm._zombie_tick_threshold_sec = 60.0
     mdm._last_hb_mono = now
     monkeypatch.setattr(market_hours, "is_market_open", lambda: True)
     monkeypatch.setattr(mdm, "_is_ws_healthy", lambda: True)
+    monkeypatch.setattr(mdm, "_is_ws_connected", lambda: True)
     monkeypatch.setattr(mdm, "_monitor_spot_ws_health", lambda: None)
     monkeypatch.setattr(mdm, "request_fallback_refresh", lambda symbol, reason: True)
     monkeypatch.setattr(
@@ -701,12 +712,15 @@ def test_two_stale_options_with_fresh_context_do_not_restart_full_ws(monkeypatch
     for sym in required:
         mdm._last_valid_live_tick_mono[sym] = now
     mdm._last_valid_live_tick_mono["NFO:NIFTY26JUN24000CE"] = now - 120.0
+    mdm._required_symbol_since_mono["NFO:NIFTY26JUN24000CE"] = now - 120.0
     mdm._last_valid_live_tick_mono["NFO:NIFTY26JUN24000PE"] = now - 120.0
+    mdm._required_symbol_since_mono["NFO:NIFTY26JUN24000PE"] = now - 120.0
     mdm._zombie_tick_threshold_sec = 60.0
     mdm._last_hb_mono = now
     rest_requests = []
     monkeypatch.setattr(market_hours, "is_market_open", lambda: True)
     monkeypatch.setattr(mdm, "_is_ws_healthy", lambda: True)
+    monkeypatch.setattr(mdm, "_is_ws_connected", lambda: True)
     monkeypatch.setattr(mdm, "_monitor_spot_ws_health", lambda: None)
     monkeypatch.setattr(
         mdm,
@@ -753,7 +767,7 @@ def test_active_bracket_symbol_remains_required_before_position_reconcile():
     assert bracket_symbol in mdm._required_live_symbols()
 
 
-def test_unhealthy_ws_still_diagnoses_and_restarts_for_stale_context(monkeypatch):
+def test_disconnected_ws_still_diagnoses_and_restarts_for_stale_context(monkeypatch):
     from nifty_scalper_bot.utils import market_hours
 
     mdm = MarketDataManager(kite=None)
@@ -764,11 +778,14 @@ def test_unhealthy_ws_still_diagnoses_and_restarts_for_stale_context(monkeypatch
         mdm._last_valid_live_tick_mono[sym] = now
     mdm._last_valid_live_tick_mono["NSE:NIFTY"] = now - 120.0
     mdm._last_valid_live_tick_mono["NFO:NIFTY26JUNFUT"] = now - 120.0
+    mdm._required_symbol_since_mono["NSE:NIFTY"] = now - 120.0
+    mdm._required_symbol_since_mono["NFO:NIFTY26JUNFUT"] = now - 120.0
     mdm._zombie_tick_threshold_sec = 60.0
     mdm._last_hb_mono = now
     restarted = []
     monkeypatch.setattr(market_hours, "is_market_open", lambda: True)
     monkeypatch.setattr(mdm, "_is_ws_healthy", lambda: False)
+    monkeypatch.setattr(mdm, "_is_ws_connected", lambda: False)
     monkeypatch.setattr(mdm, "_monitor_spot_ws_health", lambda: None)
     monkeypatch.setattr(
         mdm, "_trigger_zombie_ws_restart", lambda: restarted.append(True)
@@ -790,6 +807,7 @@ def test_subscription_divergence_needs_grace_and_symbol_recovery(monkeypatch):
         mdm._last_valid_live_tick_mono[sym] = now
     stale = "NFO:NIFTY26JUN24000CE"
     mdm._last_valid_live_tick_mono[stale] = now - 120.0
+    mdm._required_symbol_since_mono[stale] = now - 120.0
     mdm._desired_tokens = {1, 2, 3, 4}
     mdm._confirmed_subscriptions = {2, 3, 4}
     mdm._subscription_divergence_since_mono = now - 120.0
@@ -800,6 +818,7 @@ def test_subscription_divergence_needs_grace_and_symbol_recovery(monkeypatch):
     restarted = []
     monkeypatch.setattr(market_hours, "is_market_open", lambda: True)
     monkeypatch.setattr(mdm, "_is_ws_healthy", lambda: True)
+    monkeypatch.setattr(mdm, "_is_ws_connected", lambda: True)
     monkeypatch.setattr(mdm, "_monitor_spot_ws_health", lambda: None)
     monkeypatch.setattr(
         mdm,
@@ -816,6 +835,7 @@ def test_subscription_divergence_needs_grace_and_symbol_recovery(monkeypatch):
     assert restarted == []
 
     mdm._last_valid_live_tick_mono[stale] = now - 120.0
+    mdm._required_symbol_since_mono[stale] = now - 120.0
     mdm._last_symbol_level_recovery_mono = now
     mdm._check_zombie_ticks()
 
@@ -852,6 +872,7 @@ def test_one_stale_active_future_uses_symbol_recovery_not_global_restart(monkeyp
         mdm._last_valid_live_tick_mono[sym] = now
     stale_future = "NFO:NIFTY26JUNFUT"
     mdm._last_valid_live_tick_mono[stale_future] = now - 120.0
+    mdm._required_symbol_since_mono[stale_future] = now - 120.0
     mdm._desired_tokens = set(mapping)
     mdm._dispatched_subscriptions = set(mapping)
     mdm._confirmed_subscriptions = set(mapping)
@@ -868,6 +889,7 @@ def test_one_stale_active_future_uses_symbol_recovery_not_global_restart(monkeyp
     restarted = []
     monkeypatch.setattr(market_hours, "is_market_open", lambda: True)
     monkeypatch.setattr(mdm, "_is_ws_healthy", lambda: True)
+    monkeypatch.setattr(mdm, "_is_ws_connected", lambda: True)
     monkeypatch.setattr(mdm, "_monitor_spot_ws_health", lambda: None)
     monkeypatch.setattr(
         mdm, "_trigger_zombie_ws_restart", lambda: restarted.append(True)
@@ -930,11 +952,13 @@ def test_stale_entire_universe_triggers_global_recovery(monkeypatch):
     now = time.monotonic()
     for sym in mdm._required_live_symbols():
         mdm._last_valid_live_tick_mono[sym] = now - 120.0
+        mdm._required_symbol_since_mono[sym] = now - 120.0
     mdm._zombie_tick_threshold_sec = 60.0
     mdm._last_hb_mono = now - 120.0
     restarted = []
     monkeypatch.setattr(market_hours, "is_market_open", lambda: True)
     monkeypatch.setattr(mdm, "_is_ws_healthy", lambda: False)
+    monkeypatch.setattr(mdm, "_is_ws_connected", lambda: True)
     monkeypatch.setattr(mdm, "_monitor_spot_ws_health", lambda: None)
     monkeypatch.setattr(
         mdm, "_trigger_zombie_ws_restart", lambda: restarted.append(True)
@@ -955,6 +979,7 @@ def test_fresh_heartbeat_does_not_mask_complete_market_data_silence(monkeypatch)
     now = time.monotonic()
     for sym in mdm._required_live_symbols():
         mdm._last_valid_live_tick_mono[sym] = now - 120.0
+        mdm._required_symbol_since_mono[sym] = now - 120.0
     mdm._desired_tokens = {1, 2, 3, 4}
     mdm._dispatched_subscriptions = {1, 2, 3, 4}
     mdm._confirmed_subscriptions = {1, 2, 3, 4}
@@ -964,6 +989,7 @@ def test_fresh_heartbeat_does_not_mask_complete_market_data_silence(monkeypatch)
     restart_calls = []
     monkeypatch.setattr(market_hours, "is_market_open", lambda: True)
     monkeypatch.setattr(mdm, "_is_ws_healthy", lambda: True)
+    monkeypatch.setattr(mdm, "_is_ws_connected", lambda: True)
     monkeypatch.setattr(mdm, "_monitor_spot_ws_health", lambda: None)
     monkeypatch.setattr(
         mdm, "_trigger_zombie_ws_restart", lambda: restart_calls.append(True)
@@ -1499,12 +1525,14 @@ def test_symbol_recovery_attempts_are_cooldown_bounded(monkeypatch):
     for sym in required:
         mdm._last_valid_live_tick_mono[sym] = now
     mdm._last_valid_live_tick_mono[stale] = now - 120.0
+    mdm._required_symbol_since_mono[stale] = now - 120.0
     mdm._zombie_tick_threshold_sec = 60.0
     mdm._last_hb_mono = now
     mdm._symbol_recovery_cooldown_s = 30.0
     requests: list[str] = []
     monkeypatch.setattr(market_hours, "is_market_open", lambda: True)
     monkeypatch.setattr(mdm, "_is_ws_healthy", lambda: True)
+    monkeypatch.setattr(mdm, "_is_ws_connected", lambda: True)
     monkeypatch.setattr(mdm, "_monitor_spot_ws_health", lambda: None)
     monkeypatch.setattr(
         mdm,
@@ -1542,3 +1570,289 @@ def test_trading_feed_health_exposes_required_symbol_recovery():
     assert health["required_symbol_recovery_active"] is True
     assert set(health["stale_required_symbols"]) == mdm._required_live_symbols()
     assert health["trading_feed_healthy"] is False
+
+
+def test_fresh_heartbeat_with_event_loop_lag_uses_symbol_recovery(monkeypatch, caplog):
+    from nifty_scalper_bot.utils import market_hours
+
+    mdm = MarketDataManager(kite=None)
+    _wire_symbols(mdm)
+    now = time.monotonic()
+    stale = "NFO:NIFTY26JUN24000CE"
+    for sym in mdm._required_live_symbols():
+        mdm._last_valid_live_tick_mono[sym] = now
+    mdm._last_valid_live_tick_mono[stale] = now - 120.0
+    mdm._required_symbol_since_mono[stale] = now - 120.0
+    mdm._zombie_tick_threshold_sec = 60.0
+    mdm._last_hb_mono = now
+    mdm._last_raw_ws_receive_mono = now
+    mdm._last_ws_tick_mono = now
+    mdm._event_loop_lag_seconds = 0.75
+    rest_requests = []
+    monkeypatch.setattr(market_hours, "is_market_open", lambda: True)
+    monkeypatch.setattr(mdm, "_monitor_spot_ws_health", lambda: None)
+    monkeypatch.setattr(mdm, "_is_ws_connected", lambda: True)
+    monkeypatch.setattr(
+        mdm,
+        "request_fallback_refresh",
+        lambda symbol, reason: rest_requests.append((symbol, reason)) or True,
+    )
+    monkeypatch.setattr(
+        mdm,
+        "_trigger_zombie_ws_restart",
+        lambda: pytest.fail("event-loop lag alone must not restart WS globally"),
+    )
+
+    with caplog.at_level("WARNING"):
+        mdm._check_zombie_ticks()
+
+    assert rest_requests == [(stale, "ws_symbol_stale_recovery")]
+    recoveries = [
+        record
+        for record in caplog.records
+        if getattr(record, "event", None) == "WS_SYMBOL_STALE_RECOVERY"
+    ]
+    assert recoveries
+    assert recoveries[-1].connected is True
+    assert recoveries[-1].ws_healthy is False
+    assert recoveries[-1].heartbeat_stale is False
+    assert recoveries[-1].processing_backlog is False
+
+
+def test_fresh_heartbeat_with_accepted_tick_gap_uses_symbol_recovery(monkeypatch):
+    from nifty_scalper_bot.utils import market_hours
+
+    mdm = MarketDataManager(kite=None)
+    _wire_symbols(mdm)
+    now = time.monotonic()
+    stale = "NFO:NIFTY26JUN24000CE"
+    for sym in mdm._required_live_symbols():
+        mdm._last_valid_live_tick_mono[sym] = now
+    mdm._last_valid_live_tick_mono[stale] = now - 120.0
+    mdm._required_symbol_since_mono[stale] = now - 120.0
+    mdm._zombie_tick_threshold_sec = 60.0
+    mdm._last_hb_mono = now
+    mdm._last_raw_ws_receive_mono = now
+    mdm._last_ws_tick_mono = now - 3.0
+    rest_requests = []
+    monkeypatch.setattr(market_hours, "is_market_open", lambda: True)
+    monkeypatch.setattr(mdm, "_monitor_spot_ws_health", lambda: None)
+    monkeypatch.setattr(mdm, "_is_ws_connected", lambda: True)
+    monkeypatch.setattr(
+        mdm,
+        "request_fallback_refresh",
+        lambda symbol, reason: rest_requests.append((symbol, reason)) or True,
+    )
+    monkeypatch.setattr(
+        mdm,
+        "_trigger_zombie_ws_restart",
+        lambda: pytest.fail("accepted tick gap alone must not restart globally"),
+    )
+
+    assert mdm._is_ws_healthy() is False
+    mdm._check_zombie_ticks()
+
+    assert rest_requests == [(stale, "ws_symbol_stale_recovery")]
+
+
+def test_newly_required_old_generation_tick_receives_activation_grace(
+    monkeypatch, caplog
+):
+    from nifty_scalper_bot.utils import market_hours
+
+    mdm = MarketDataManager(kite=None)
+    _wire_symbols(mdm)
+    now = time.monotonic()
+    stale = "NFO:NIFTY26JUN24000CE"
+    for sym in mdm._required_live_symbols():
+        mdm._last_valid_live_tick_mono[sym] = now
+        mdm._required_symbol_since_mono[sym] = now - 120.0
+    mdm._last_valid_live_tick_mono[stale] = now - 120.0
+    mdm._required_symbol_since_mono[stale] = now
+    mdm._required_symbol_missing_grace_sec = 5.0
+    mdm._zombie_tick_threshold_sec = 60.0
+    mdm._last_hb_mono = now
+    mdm._last_raw_ws_receive_mono = now
+    rest_requests = []
+    monkeypatch.setattr(market_hours, "is_market_open", lambda: True)
+    monkeypatch.setattr(mdm, "_monitor_spot_ws_health", lambda: None)
+    monkeypatch.setattr(mdm, "_is_ws_connected", lambda: True)
+    monkeypatch.setattr(
+        mdm,
+        "request_fallback_refresh",
+        lambda symbol, reason: rest_requests.append(symbol) or True,
+    )
+    monkeypatch.setattr(
+        mdm,
+        "_trigger_zombie_ws_restart",
+        lambda: pytest.fail("activation grace must not globally restart"),
+    )
+
+    with caplog.at_level("CRITICAL"):
+        mdm._check_zombie_ticks()
+
+    assert rest_requests == []
+    assert stale not in [
+        sym
+        for record in caplog.records
+        if getattr(record, "event", None) == "mdm_zombie_tick_detected"
+        for sym in getattr(record, "symbols", [])
+    ]
+
+
+def test_newly_required_old_generation_tick_recovers_after_grace(monkeypatch):
+    from nifty_scalper_bot.utils import market_hours
+
+    mdm = MarketDataManager(kite=None)
+    _wire_symbols(mdm)
+    now = time.monotonic()
+    stale = "NFO:NIFTY26JUN24000CE"
+    for sym in mdm._required_live_symbols():
+        mdm._last_valid_live_tick_mono[sym] = now
+        mdm._required_symbol_since_mono[sym] = now - 120.0
+    mdm._last_valid_live_tick_mono[stale] = now - 120.0
+    mdm._required_symbol_since_mono[stale] = now - 2.0
+    mdm._required_symbol_missing_grace_sec = 1.0
+    mdm._zombie_tick_threshold_sec = 60.0
+    mdm._last_hb_mono = now
+    mdm._last_raw_ws_receive_mono = now
+    rest_requests = []
+    monkeypatch.setattr(market_hours, "is_market_open", lambda: True)
+    monkeypatch.setattr(mdm, "_monitor_spot_ws_health", lambda: None)
+    monkeypatch.setattr(mdm, "_is_ws_connected", lambda: True)
+    monkeypatch.setattr(
+        mdm,
+        "request_fallback_refresh",
+        lambda symbol, reason: rest_requests.append((symbol, reason)) or True,
+    )
+    monkeypatch.setattr(
+        mdm,
+        "_trigger_zombie_ws_restart",
+        lambda: pytest.fail("healthy transport should recover symbol after grace"),
+    )
+
+    mdm._check_zombie_ticks()
+
+    assert rest_requests == [(stale, "ws_symbol_stale_recovery")]
+
+
+def test_processing_backlog_classification_never_global_restarts(monkeypatch):
+    from nifty_scalper_bot.utils import market_hours
+
+    mdm = MarketDataManager(kite=None)
+    _wire_symbols(mdm)
+    now = time.monotonic()
+    stale = "NFO:NIFTY26JUN24000CE"
+    for sym in mdm._required_live_symbols():
+        mdm._last_valid_live_tick_mono[sym] = now
+    mdm._last_valid_live_tick_mono[stale] = now - 120.0
+    mdm._required_symbol_since_mono[stale] = now - 120.0
+    mdm._zombie_tick_threshold_sec = 60.0
+    mdm._last_hb_mono = now
+    monkeypatch.setattr(market_hours, "is_market_open", lambda: True)
+    monkeypatch.setattr(mdm, "_monitor_spot_ws_health", lambda: None)
+    monkeypatch.setattr(mdm, "_is_ws_connected", lambda: True)
+    monkeypatch.setattr(
+        mdm,
+        "classify_transport_backlog",
+        lambda: {
+            "transport_classification": "processing_backlog",
+            "global_restart_eligible": False,
+            "raw_receive_age_s": 0.01,
+            "processed_tick_age_s": 120.0,
+        },
+    )
+    monkeypatch.setattr(
+        mdm,
+        "_trigger_zombie_ws_restart",
+        lambda: pytest.fail("processing backlog must not restart globally"),
+    )
+
+    mdm._check_zombie_ticks()
+
+
+def test_dynamic_basket_old_ticks_do_not_churn_generation_during_grace(monkeypatch):
+    from nifty_scalper_bot.utils import market_hours
+
+    mdm = MarketDataManager(kite=None)
+    _wire_symbols(mdm)
+    option_symbols = [f"NFO:NIFTY26JUN{24000 + i * 50}CE" for i in range(8)]
+    token_by_symbol = {symbol: 100 + i for i, symbol in enumerate(option_symbols)}
+    token_by_symbol.update({"NSE:NIFTY": 3, "NFO:NIFTY26JUNFUT": 4})
+    for symbol, token in token_by_symbol.items():
+        mdm._symbol_by_token[token] = symbol
+        mdm._token_to_symbol[token] = symbol
+        mdm._symbol_to_token[symbol] = token
+        mdm._token_by_symbol[symbol] = token
+    now = time.monotonic()
+    mdm.set_active_contract_basket(
+        {
+            "all_tokens": list(token_by_symbol.values()),
+            "token_by_symbol": token_by_symbol,
+            "spot_symbol": "NSE:NIFTY",
+            "spot_token": 3,
+            "futures_symbol": "NFO:NIFTY26JUNFUT",
+            "selected_ce": option_symbols[0],
+            "selected_pe": option_symbols[1],
+            "option_symbols": option_symbols,
+        }
+    )
+    for symbol in option_symbols:
+        token = token_by_symbol[symbol]
+        mdm._symbol_to_token[symbol] = token
+        mdm._token_by_symbol[symbol] = token
+        mdm._begin_subscription_generation_locked(
+            symbol, token, reason="test_dynamic_basket_activation"
+        )
+        mdm._desired_tokens.add(token)
+        mdm._dispatched_subscriptions.add(token)
+        mdm._last_valid_live_tick_mono[symbol] = now - 120.0
+        mdm._required_symbol_since_mono[symbol] = now
+    mdm._last_valid_live_tick_mono["NSE:NIFTY"] = now
+    mdm._last_valid_live_tick_mono["NFO:NIFTY26JUNFUT"] = now
+    mdm._required_symbol_missing_grace_sec = 5.0
+    mdm._zombie_tick_threshold_sec = 60.0
+    mdm._last_hb_mono = now
+    mdm._last_raw_ws_receive_mono = now
+    generation_before = mdm._subscription_generation
+    monkeypatch.setattr(market_hours, "is_market_open", lambda: True)
+    monkeypatch.setattr(mdm, "_monitor_spot_ws_health", lambda: None)
+    monkeypatch.setattr(mdm, "_is_ws_connected", lambda: True)
+    monkeypatch.setattr(
+        mdm,
+        "request_fallback_refresh",
+        lambda symbol, reason: pytest.fail(
+            "new basket should remain in activation grace"
+        ),
+    )
+    monkeypatch.setattr(
+        mdm,
+        "_trigger_zombie_ws_restart",
+        lambda: pytest.fail("dynamic activation grace must not restart globally"),
+    )
+
+    mdm._check_zombie_ticks()
+    for symbol in option_symbols[:3]:
+        mdm._ingest_normalized_tick(
+            {
+                "symbol": symbol,
+                "instrument_token": token_by_symbol[symbol],
+                "ltp": 10.0,
+                "timestamp": time.time(),
+                "source": "ws",
+            }
+        )
+
+    assert mdm._subscription_generation == generation_before
+    assert (
+        mdm.classify_live_tick_readiness(
+            option_symbols[0], token_by_symbol[option_symbols[0]], max_age_s=60.0
+        )["ready"]
+        is True
+    )
+    assert (
+        mdm.classify_live_tick_readiness(
+            option_symbols[-1], token_by_symbol[option_symbols[-1]], max_age_s=60.0
+        )["ready"]
+        is False
+    )


### PR DESCRIPTION
### Motivation
- Prevent dynamic-basket activation, accepted-tick delay, or event-loop lag from being misclassified as a global WebSocket transport failure and triggering a full restart while leaving stale-data trading safeguards intact. 
- Preserve current-generation validation and symbol-level recovery while ensuring global restart is only authorized by direct transport evidence. 

### Description
- In `MarketDataManager._check_zombie_ticks()` use the existing pure connectivity helper `_is_ws_connected()` (instead of the compound `_is_ws_healthy()`) when deciding whether direct transport evidence exists for a global restart. 
- Apply the required-symbol activation grace before both missing and stale classification so newly-required symbols with old prior-generation ticks are kept in activation grace rather than immediately escalated. 
- Derive transport evidence explicitly from `connected`, `heartbeat_stale`, and `classify_transport_backlog()` (including `transport_silent`), and only permit a global restart when stale/missing symbols coincide with direct transport failure and not while processing backlog or isolated symbol staleness exists. 
- Preserve symbol-level recovery, REST fallback, recovery cooldown/throttling, restart cooldown/backoff, and first-current-generation verification; add `restart_diagnostics` (connection, ws health, heartbeat, raw/accepted tick ages, event-loop lag, backlog, transport classification, stale ratio, required-grace symbols, etc.) and include it in suppressed and triggered restart logs for exact diagnostics. 
- Add focused regression tests and small test adjustments in `tests/data/test_mdm_tick_coalescing.py` that exercise event-loop lag, accepted-tick gaps, activation grace, post-grace symbol recovery, processing-backlog suppression, and dynamic basket activation stability. 

### Testing
- Ran compilation and focused test suites: `python -m compileall -q src` and `pytest -q tests/data/test_mdm_tick_coalescing.py tests/data/test_mdm_lifecycle_generation.py` and both completed successfully. 
- Ran broader validation suites: `pytest -q tests/data/test_market_data_hardening.py`, `pytest -q tests/data/test_data_hub_freshness_sources.py`, `pytest -q -m live_runtime_e2e tests/e2e/live_sim`, and a full `pytest -q`; all exited with code 0. 
- Tests confirm that fresh heartbeat with event-loop lag or accepted-tick gap no longer trigger a global restart, newly-required symbols receive activation grace, symbol-level recovery runs when transport is healthy, and genuine heartbeat/socket/raw-silence conditions still permit global restart.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a61ea63d36083249ce6252045ddb740)