### PR TITLE
Verify orphan protection and centralize broker-position truth

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -3042,6 +3042,7 @@ class BotContext:
     position_reconciliation_started_at: datetime | None = None
     position_reconciliation_completed_at: datetime | None = None
     position_reconciliation_last_run: dict[str, Any] = field(default_factory=dict)
+    position_reconciliation_active_run_ids: set[str] = field(default_factory=set)
     unresolved_reconciliation_symbols: set[str] = field(default_factory=set)
     unprotected_broker_positions: set[str] = field(default_factory=set)
     unprotected_broker_position: bool = False
@@ -10592,6 +10593,7 @@ async def _build_and_hydrate_live_basket_from_spot(
                     "symbol_count": len(list(dict.fromkeys(basket.get("symbols", [])))),
                     "hydrated": bool(hydrate),
                     "duration_ms": duration_ms,
+                    "active_run_count": len(active_run_ids),
                 },
             )
             LOGGER.info(
@@ -14720,12 +14722,19 @@ async def _reconcile_state(ctx: BotContext, *, source: str = "unknown") -> None:
     reconcile_run_id = uuid.uuid4().hex
     requested_at = datetime.now(timezone.utc)
     started_at = requested_at
-    ctx.position_reconciliation_last_run = {
+    run_record = {
         "reconcile_run_id": reconcile_run_id,
         "source": source,
         "requested_at": requested_at.isoformat(),
         "started_at": started_at.isoformat(),
     }
+    active_run_ids = getattr(ctx, "position_reconciliation_active_run_ids", None)
+    if not isinstance(active_run_ids, set):
+        active_run_ids = set()
+        ctx.position_reconciliation_active_run_ids = active_run_ids
+    active_run_ids.add(reconcile_run_id)
+    run_record["active_run_count"] = len(active_run_ids)
+    ctx.position_reconciliation_last_run = run_record
     LOGGER.info(
         "POSITION_RECONCILE_STARTED run_id=%s source=%s",
         reconcile_run_id,
@@ -14736,6 +14745,7 @@ async def _reconcile_state(ctx: BotContext, *, source: str = "unknown") -> None:
             "source": source,
             "requested_at": requested_at.isoformat(),
             "started_at": started_at.isoformat(),
+            "active_run_count": len(active_run_ids),
         },
     )
     ctx.position_reconciliation_started = True
@@ -14746,10 +14756,10 @@ async def _reconcile_state(ctx: BotContext, *, source: str = "unknown") -> None:
     if ctx.position_manager:
         try:
             sync_started_at = datetime.now(timezone.utc)
-            ctx.position_reconciliation_last_run["sync_started_at"] = sync_started_at.isoformat()
+            run_record["sync_started_at"] = sync_started_at.isoformat()
             broker_positions = await asyncio.to_thread(safe_sync_fetch)
             sync_completed_at = datetime.now(timezone.utc)
-            ctx.position_reconciliation_last_run["sync_completed_at"] = sync_completed_at.isoformat()
+            run_record["sync_completed_at"] = sync_completed_at.isoformat()
             if hasattr(ctx, "unresolved_reconciliation_symbols"):
                 ctx.unresolved_reconciliation_symbols.clear()
             if hasattr(ctx, "unprotected_broker_positions"):
@@ -14834,28 +14844,51 @@ async def _reconcile_state(ctx: BotContext, *, source: str = "unknown") -> None:
                             continue
 
                         bracket_id = guard_result if isinstance(guard_result, str) else None
-                        bracket = bm.get_bracket(bracket_id) if bracket_id and hasattr(bm, "get_bracket") else None
-                        bracket_managed = bool(bm.is_symbol_managed(norm_symbol))
+                        lifecycle_getter = getattr(bm, "get_symbol_lifecycle_snapshot", None)
+                        lifecycle_snapshot = (
+                            lifecycle_getter(norm_symbol)
+                            if callable(lifecycle_getter)
+                            else {}
+                        )
+                        bracket_managed = bool(
+                            lifecycle_snapshot.get("managed")
+                            if isinstance(lifecycle_snapshot, Mapping) and lifecycle_snapshot
+                            else bm.is_symbol_managed(norm_symbol)
+                        )
                         verification_reason = None
-                        if not guard_result:
-                            verification_reason = "guard_returned_falsey"
-                        elif not bracket_managed:
+                        if not bracket_managed:
                             verification_reason = "symbol_not_managed"
-                        elif bracket_id and bracket is None:
-                            verification_reason = "returned_bracket_missing"
-                        elif bracket is not None:
-                            bracket_symbol = normalize_symbol(getattr(bracket, "symbol", "")) or getattr(bracket, "symbol", "")
-                            bracket_status = str(getattr(bracket, "status", "") or "").upper()
-                            bracket_qty = int(getattr(bracket, "quantity", getattr(bracket, "qty", 0)) or 0)
-                            stop_value = getattr(bracket, "stop_loss", getattr(bracket, "sl", None))
-                            if bracket_symbol != norm_symbol:
-                                verification_reason = "bracket_symbol_mismatch"
-                            elif bracket_status == "CLOSED":
-                                verification_reason = "bracket_closed"
-                            elif bracket_qty <= 0:
+                        elif isinstance(lifecycle_snapshot, Mapping) and lifecycle_snapshot:
+                            active_ids = set(lifecycle_snapshot.get("active_bracket_ids") or ())
+                            if not active_ids:
+                                verification_reason = "no_active_bracket"
+                            elif bracket_id and bracket_id not in active_ids:
+                                verification_reason = "returned_bracket_not_active"
+                            elif int(lifecycle_snapshot.get("protected_quantity") or 0) <= 0:
                                 verification_reason = "bracket_quantity_not_positive"
-                            elif stop_value is None:
+                            elif not bool(lifecycle_snapshot.get("has_valid_stop")):
                                 verification_reason = "bracket_stop_missing"
+                            elif bool(lifecycle_snapshot.get("pending_entry")) and not bool(
+                                lifecycle_snapshot.get("orphan_origin")
+                            ):
+                                verification_reason = "pending_entry_not_orphan_protection"
+                        elif bracket_id:
+                            bracket = bm.get_bracket(bracket_id) if hasattr(bm, "get_bracket") else None
+                            if bracket is None:
+                                verification_reason = "returned_bracket_missing"
+                            else:
+                                bracket_symbol = normalize_symbol(getattr(bracket, "symbol", "")) or getattr(bracket, "symbol", "")
+                                bracket_status = str(getattr(bracket, "status", "") or "").upper()
+                                bracket_qty = int(getattr(bracket, "quantity", getattr(bracket, "qty", 0)) or 0)
+                                stop_value = getattr(bracket, "stop_loss", getattr(bracket, "sl", None))
+                                if bracket_symbol != norm_symbol:
+                                    verification_reason = "bracket_symbol_mismatch"
+                                elif bracket_status == "CLOSED":
+                                    verification_reason = "bracket_closed"
+                                elif bracket_qty <= 0:
+                                    verification_reason = "bracket_quantity_not_positive"
+                                elif stop_value is None:
+                                    verification_reason = "bracket_stop_missing"
 
                         if verification_reason is None:
                             if hasattr(ctx, "unprotected_broker_positions"):
@@ -14965,23 +14998,39 @@ async def _reconcile_state(ctx: BotContext, *, source: str = "unknown") -> None:
                                 if callable(exposure_getter)
                                 else BrokerExposureState.UNKNOWN
                             )
+                            snapshot_getter = getattr(
+                                ctx.position_manager, "broker_exposure_snapshot", None
+                            )
+                            exposure_snapshot = (
+                                snapshot_getter() if callable(snapshot_getter) else {}
+                            )
                             lifecycle = classify_symbol_lifecycle(
                                 ghost_sym,
                                 bracket_manager=bm,
                                 local_position_present=False,
                                 broker_exposure_state=exposure,
                             )
-                            if exposure == BrokerExposureState.UNKNOWN or lifecycle == SymbolLifecycleClassification.UNRESOLVED:
+                            if (
+                                exposure not in (BrokerExposureState.FLAT, BrokerExposureState.ABSENT)
+                                or lifecycle != SymbolLifecycleClassification.GHOST_FLAT
+                                or not bool(exposure_snapshot.get("fresh", False))
+                            ):
                                 LOGGER.warning(
-                                    "GHOST_SWEEP_DEFERRED_BROKER_UNKNOWN symbol=%s",
+                                    "GHOST_SWEEP_DEFERRED_BROKER_UNKNOWN symbol=%s exposure_state=%s snapshot_age_seconds=%s snapshot_fresh=%s lifecycle=%s",
                                     ghost_sym,
+                                    getattr(exposure, "value", str(exposure)),
+                                    exposure_snapshot.get("age_seconds"),
+                                    exposure_snapshot.get("fresh"),
+                                    getattr(lifecycle, "value", str(lifecycle)),
                                     extra={
                                         "event": "GHOST_SWEEP_DEFERRED_BROKER_UNKNOWN",
                                         "symbol": ghost_sym,
+                                        "exposure_state": getattr(exposure, "value", str(exposure)),
+                                        "snapshot_age_seconds": exposure_snapshot.get("age_seconds"),
+                                        "snapshot_fresh": exposure_snapshot.get("fresh"),
+                                        "lifecycle": getattr(lifecycle, "value", str(lifecycle)),
                                     },
                                 )
-                                continue
-                            if exposure == BrokerExposureState.NONZERO:
                                 continue
                             LOGGER.warning(
                                 f"👻 GHOST BRACKET DETECTED: {ghost_sym} has protection but no Open Position. "
@@ -15004,9 +15053,11 @@ async def _reconcile_state(ctx: BotContext, *, source: str = "unknown") -> None:
             ctx.position_reconciliation_completed = True
             ctx.position_reconciliation_completed_at = datetime.now(timezone.utc)
             duration_ms = (ctx.position_reconciliation_completed_at - started_at).total_seconds() * 1000.0
-            ctx.position_reconciliation_last_run.update({
+            active_run_ids.discard(reconcile_run_id)
+            run_record.update({
                 "completed_at": ctx.position_reconciliation_completed_at.isoformat(),
                 "duration_ms": duration_ms,
+                "active_run_count": len(active_run_ids),
             })
             LOGGER.info(
                 "POSITION_RECONCILE_SUCCESS run_id=%s source=%s duration_ms=%.3f",
@@ -15022,6 +15073,8 @@ async def _reconcile_state(ctx: BotContext, *, source: str = "unknown") -> None:
             )
 
         except Exception as exc:
+            active_run_ids.discard(reconcile_run_id)
+            run_record["active_run_count"] = len(active_run_ids)
             ctx.position_reconciliation_completed = False
             ctx.position_reconciliation_failed = True
             ctx.position_reconciliation_error = str(exc)

--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -10593,7 +10593,6 @@ async def _build_and_hydrate_live_basket_from_spot(
                     "symbol_count": len(list(dict.fromkeys(basket.get("symbols", [])))),
                     "hydrated": bool(hydrate),
                     "duration_ms": duration_ms,
-                    "active_run_count": len(active_run_ids),
                 },
             )
             LOGGER.info(

--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -54,6 +54,7 @@ import random
 import sqlite3
 import threading
 import time as time_module
+import uuid
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -1521,6 +1522,14 @@ from nifty_scalper_bot.utils.market_hours import (
     get_market_state,
     is_market_open_session,
     is_market_open_now,
+)
+from nifty_scalper_bot.execution.ownership import (
+    SymbolLifecycleClassification,
+    classify_symbol_lifecycle,
+)
+from nifty_scalper_bot.execution.position_snapshot import (
+    BrokerExposureState,
+    decode_position_snapshot,
 )
 from nifty_scalper_bot.utils.metrics import ensure_multiproc_dir
 from nifty_scalper_bot.utils.rate_limiter import RateLimiter
@@ -3032,6 +3041,7 @@ class BotContext:
     position_reconciliation_error: str | None = None
     position_reconciliation_started_at: datetime | None = None
     position_reconciliation_completed_at: datetime | None = None
+    position_reconciliation_last_run: dict[str, Any] = field(default_factory=dict)
     unresolved_reconciliation_symbols: set[str] = field(default_factory=set)
     unprotected_broker_positions: set[str] = field(default_factory=set)
     unprotected_broker_position: bool = False
@@ -11221,7 +11231,7 @@ async def startup_sequence(ctx: BotContext) -> None:
             if guard:
                 guard.mark_session_valid()
             try:
-                await _reconcile_state(ctx)
+                await _reconcile_state(ctx, source="startup")
                 LOGGER.info("startup_position_reconciliation_complete")
             except Exception as reconcile_exc:
                 LOGGER.error(
@@ -14229,7 +14239,7 @@ async def startup_sequence(ctx: BotContext) -> None:
                 while True:
                     try:
                         if is_market_open():
-                            await _reconcile_state(ctx)
+                            await _reconcile_state(ctx, source="periodic_health")
                         else:
                             _inner = getattr(
                                 ctx.broker_client,
@@ -14647,7 +14657,7 @@ def _should_reconcile_now(ctx: BotContext) -> bool:
         return True
 
 
-async def _reconcile_state(ctx: BotContext) -> None:
+async def _reconcile_state(ctx: BotContext, *, source: str = "unknown") -> None:
     """
     Syncs local state with Broker (Orders & Positions).
     Features: Non-Blocking Execution, Position Sync, and Auto-Guarding of Orphans.
@@ -14698,15 +14708,8 @@ async def _reconcile_state(ctx: BotContext) -> None:
                 raise RuntimeError(
                     f"broker_position_fetch_failed:{_pos_err}"
                 ) from _pos_err
-            broker_positions: list[Mapping[str, Any]] = []
-            if isinstance(raw, list):
-                broker_positions = [p for p in raw if isinstance(p, Mapping)]
-            elif isinstance(raw, Mapping):
-                src = raw.get("net", raw)
-                if isinstance(src, list):
-                    broker_positions = [p for p in src if isinstance(p, Mapping)]
-                elif isinstance(src, Mapping):
-                    broker_positions = [src]
+            snapshot = decode_position_snapshot(raw)
+            broker_positions = snapshot.raw_rows()
             if ctx.position_manager:
                 ctx.position_manager.synchronize_with_broker(broker_positions)
             return broker_positions
@@ -14714,17 +14717,39 @@ async def _reconcile_state(ctx: BotContext) -> None:
         return cast(list[Mapping[str, Any]], _run_sync_locked(_sync_operation))
 
     # 1/2. SYNC ORDERS + POSITIONS & AUTO-GUARD ORPHANS
+    reconcile_run_id = uuid.uuid4().hex
+    requested_at = datetime.now(timezone.utc)
+    started_at = requested_at
+    ctx.position_reconciliation_last_run = {
+        "reconcile_run_id": reconcile_run_id,
+        "source": source,
+        "requested_at": requested_at.isoformat(),
+        "started_at": started_at.isoformat(),
+    }
     LOGGER.info(
-        "POSITION_RECONCILE_STARTED", extra={"event": "POSITION_RECONCILE_STARTED"}
+        "POSITION_RECONCILE_STARTED run_id=%s source=%s",
+        reconcile_run_id,
+        source,
+        extra={
+            "event": "POSITION_RECONCILE_STARTED",
+            "reconcile_run_id": reconcile_run_id,
+            "source": source,
+            "requested_at": requested_at.isoformat(),
+            "started_at": started_at.isoformat(),
+        },
     )
     ctx.position_reconciliation_started = True
-    ctx.position_reconciliation_started_at = datetime.now(timezone.utc)
+    ctx.position_reconciliation_started_at = started_at
     ctx.position_reconciliation_completed = False
     ctx.position_reconciliation_failed = False
     ctx.position_reconciliation_error = None
     if ctx.position_manager:
         try:
+            sync_started_at = datetime.now(timezone.utc)
+            ctx.position_reconciliation_last_run["sync_started_at"] = sync_started_at.isoformat()
             broker_positions = await asyncio.to_thread(safe_sync_fetch)
+            sync_completed_at = datetime.now(timezone.utc)
+            ctx.position_reconciliation_last_run["sync_completed_at"] = sync_completed_at.isoformat()
             if hasattr(ctx, "unresolved_reconciliation_symbols"):
                 ctx.unresolved_reconciliation_symbols.clear()
             if hasattr(ctx, "unprotected_broker_positions"):
@@ -14777,25 +14802,97 @@ async def _reconcile_state(ctx: BotContext) -> None:
                         signed_qty = (
                             pos.quantity if pos.side == "LONG" else -pos.quantity
                         )
-                        om.guard_orphan_position(
-                            symbol=norm_symbol,
-                            quantity=signed_qty,  # ✅ Now negative for SHORT
-                            average_price=avg_price,
-                            position_side=pos.side,
-                        )
-                        ctx.unprotected_broker_position = False
-                        if hasattr(ctx, "unprotected_broker_positions"):
-                            ctx.unprotected_broker_positions.discard(str(norm_symbol))
-                        LOGGER.info(
-                            "POSITION_ADOPTED_TO_BRACKET symbol=%s quantity=%s",
-                            norm_symbol,
-                            pos.quantity,
-                            extra={
-                                "event": "POSITION_ADOPTED_TO_BRACKET",
-                                "symbol": norm_symbol,
-                                "quantity": pos.quantity,
-                            },
-                        )
+                        guard_result = None
+                        guard_failed_reason = None
+                        try:
+                            guard_result = om.guard_orphan_position(
+                                symbol=norm_symbol,
+                                quantity=signed_qty,  # ✅ Now negative for SHORT
+                                average_price=avg_price,
+                                position_side=pos.side,
+                            )
+                        except Exception as guard_exc:  # noqa: BLE001 - keep other symbols blocked independently
+                            guard_failed_reason = f"{type(guard_exc).__name__}: {guard_exc}"
+                            LOGGER.exception(
+                                "POSITION_ORPHAN_GUARD_FAILED symbol=%s quantity=%s position_side=%s guard_result=%r bracket_managed=%s reason=%s",
+                                norm_symbol,
+                                pos.quantity,
+                                pos.side,
+                                guard_result,
+                                bm.is_symbol_managed(norm_symbol),
+                                guard_failed_reason,
+                                extra={
+                                    "event": "POSITION_ORPHAN_GUARD_FAILED",
+                                    "symbol": norm_symbol,
+                                    "quantity": pos.quantity,
+                                    "position_side": pos.side,
+                                    "guard_result": guard_result,
+                                    "bracket_managed": bm.is_symbol_managed(norm_symbol),
+                                    "reason": guard_failed_reason,
+                                },
+                            )
+                            continue
+
+                        bracket_id = guard_result if isinstance(guard_result, str) else None
+                        bracket = bm.get_bracket(bracket_id) if bracket_id and hasattr(bm, "get_bracket") else None
+                        bracket_managed = bool(bm.is_symbol_managed(norm_symbol))
+                        verification_reason = None
+                        if not guard_result:
+                            verification_reason = "guard_returned_falsey"
+                        elif not bracket_managed:
+                            verification_reason = "symbol_not_managed"
+                        elif bracket_id and bracket is None:
+                            verification_reason = "returned_bracket_missing"
+                        elif bracket is not None:
+                            bracket_symbol = normalize_symbol(getattr(bracket, "symbol", "")) or getattr(bracket, "symbol", "")
+                            bracket_status = str(getattr(bracket, "status", "") or "").upper()
+                            bracket_qty = int(getattr(bracket, "quantity", getattr(bracket, "qty", 0)) or 0)
+                            stop_value = getattr(bracket, "stop_loss", getattr(bracket, "sl", None))
+                            if bracket_symbol != norm_symbol:
+                                verification_reason = "bracket_symbol_mismatch"
+                            elif bracket_status == "CLOSED":
+                                verification_reason = "bracket_closed"
+                            elif bracket_qty <= 0:
+                                verification_reason = "bracket_quantity_not_positive"
+                            elif stop_value is None:
+                                verification_reason = "bracket_stop_missing"
+
+                        if verification_reason is None:
+                            if hasattr(ctx, "unprotected_broker_positions"):
+                                ctx.unprotected_broker_positions.discard(str(norm_symbol))
+                            LOGGER.info(
+                                "POSITION_ADOPTED_TO_BRACKET symbol=%s quantity=%s",
+                                norm_symbol,
+                                pos.quantity,
+                                extra={
+                                    "event": "POSITION_ADOPTED_TO_BRACKET",
+                                    "symbol": norm_symbol,
+                                    "quantity": pos.quantity,
+                                    "guard_result": guard_result,
+                                },
+                            )
+                        else:
+                            LOGGER.error(
+                                "POSITION_ORPHAN_GUARD_FAILED symbol=%s quantity=%s position_side=%s guard_result=%r bracket_managed=%s reason=%s",
+                                norm_symbol,
+                                pos.quantity,
+                                pos.side,
+                                guard_result,
+                                bracket_managed,
+                                verification_reason,
+                                extra={
+                                    "event": "POSITION_ORPHAN_GUARD_FAILED",
+                                    "symbol": norm_symbol,
+                                    "quantity": pos.quantity,
+                                    "position_side": pos.side,
+                                    "guard_result": guard_result,
+                                    "bracket_managed": bracket_managed,
+                                    "reason": verification_reason,
+                                },
+                            )
+
+                if hasattr(ctx, "unprotected_broker_positions"):
+                    ctx.unprotected_broker_position = bool(ctx.unprotected_broker_positions)
 
             # =================================================================
             # ✅ D. CLEANUP GHOST BRACKETS (Safety Cleanup)
@@ -14862,6 +14959,30 @@ async def _reconcile_state(ctx: BotContext) -> None:
                                     },
                                 )
                                 continue
+                            exposure_getter = getattr(ctx.position_manager, "broker_exposure_state", None)
+                            exposure = (
+                                exposure_getter(ghost_sym)
+                                if callable(exposure_getter)
+                                else BrokerExposureState.UNKNOWN
+                            )
+                            lifecycle = classify_symbol_lifecycle(
+                                ghost_sym,
+                                bracket_manager=bm,
+                                local_position_present=False,
+                                broker_exposure_state=exposure,
+                            )
+                            if exposure == BrokerExposureState.UNKNOWN or lifecycle == SymbolLifecycleClassification.UNRESOLVED:
+                                LOGGER.warning(
+                                    "GHOST_SWEEP_DEFERRED_BROKER_UNKNOWN symbol=%s",
+                                    ghost_sym,
+                                    extra={
+                                        "event": "GHOST_SWEEP_DEFERRED_BROKER_UNKNOWN",
+                                        "symbol": ghost_sym,
+                                    },
+                                )
+                                continue
+                            if exposure == BrokerExposureState.NONZERO:
+                                continue
                             LOGGER.warning(
                                 f"👻 GHOST BRACKET DETECTED: {ghost_sym} has protection but no Open Position. "
                                 "Performing Safety Cleanup..."
@@ -14882,9 +15003,22 @@ async def _reconcile_state(ctx: BotContext) -> None:
             ctx.position_reconciliation_error = None
             ctx.position_reconciliation_completed = True
             ctx.position_reconciliation_completed_at = datetime.now(timezone.utc)
+            duration_ms = (ctx.position_reconciliation_completed_at - started_at).total_seconds() * 1000.0
+            ctx.position_reconciliation_last_run.update({
+                "completed_at": ctx.position_reconciliation_completed_at.isoformat(),
+                "duration_ms": duration_ms,
+            })
             LOGGER.info(
-                "POSITION_RECONCILE_SUCCESS",
-                extra={"event": "POSITION_RECONCILE_SUCCESS"},
+                "POSITION_RECONCILE_SUCCESS run_id=%s source=%s duration_ms=%.3f",
+                reconcile_run_id,
+                source,
+                duration_ms,
+                extra={
+                    "event": "POSITION_RECONCILE_SUCCESS",
+                    "reconcile_run_id": reconcile_run_id,
+                    "source": source,
+                    "duration_ms": duration_ms,
+                },
             )
 
         except Exception as exc:
@@ -15585,7 +15719,7 @@ class NiftyScalperApp:
                         await asyncio.sleep(5.0)
                     try:
                         if _should_reconcile_now(self._ctx):
-                            await _reconcile_state(self._ctx)
+                            await _reconcile_state(self._ctx, source="manual")
                     except Exception as exc:  # noqa: BLE001
                         LOGGER.warning(
                             "Periodic state reconciliation failed",

--- a/src/nifty_scalper_bot/execution/bracket_core.py
+++ b/src/nifty_scalper_bot/execution/bracket_core.py
@@ -4043,6 +4043,75 @@ class BracketManager:
                 return True
         return False
 
+    def get_symbol_lifecycle_snapshot(self, symbol: str) -> dict[str, object]:
+        """Return read-only bracket lifecycle facts for reconciliation callers."""
+
+        symbol_key = normalize_symbol(symbol)
+        terminal_states = {
+            BracketExitLifecycle.CLOSED.value,
+            BracketExitLifecycle.EXIT_FILLED.value,
+            BracketExitLifecycle.EXIT_RECONCILED_FLAT.value,
+        }
+        bracket_ids: list[str] = []
+        active_bracket_ids: list[str] = []
+        pending_entry = False
+        orphan_origin = False
+        protected_quantity = 0
+        has_valid_stop = False
+        all_closed = True
+        with self._lock:
+            for entry_id in list(self._symbol_map.get(symbol_key, [])):
+                bracket = self._brackets.get(entry_id)
+                if bracket is None:
+                    continue
+                bracket_ids.append(entry_id)
+                bracket_symbol = normalize_symbol(getattr(bracket, "symbol", ""))
+                if bracket_symbol != symbol_key:
+                    continue
+                remaining = int(getattr(bracket, "remaining_quantity", 0) or 0)
+                quantity = int(getattr(bracket, "quantity", 0) or 0)
+                qty = remaining if remaining > 0 else quantity
+                status = str(getattr(bracket, "status", "") or "").upper()
+                exit_state = str(getattr(bracket, "exit_state", "") or "").upper()
+                closed = (
+                    status == "CLOSED"
+                    or exit_state in terminal_states
+                    or bool(getattr(bracket, "position_flat_confirmed", False))
+                    or qty <= 0
+                )
+                if not closed:
+                    all_closed = False
+                    active_bracket_ids.append(entry_id)
+                    protected_quantity += max(qty, 0)
+                entry_order_id = str(getattr(bracket, "entry_order_id", "") or "")
+                tag = str(getattr(bracket, "tag", "") or "")
+                is_orphan = entry_order_id.startswith("orphan_") or tag == "orphan_recovery"
+                orphan_origin = orphan_origin or is_orphan
+                if not bool(getattr(bracket, "entry_confirmed", False)) and not is_orphan:
+                    pending_entry = True
+                stop_value = getattr(bracket, "stop_loss", None)
+                if stop_value is None:
+                    stop_value = getattr(bracket, "sl", None)
+                if stop_value is None:
+                    stop_value = getattr(bracket, "sl_trigger_price", None)
+                try:
+                    has_valid_stop = has_valid_stop or float(stop_value) > 0.0
+                except (TypeError, ValueError):
+                    pass
+        managed = bool(active_bracket_ids)
+        return {
+            "normalized_symbol": symbol_key,
+            "managed": managed,
+            "bracket_ids": tuple(bracket_ids),
+            "active_bracket_ids": tuple(active_bracket_ids),
+            "pending_entry": pending_entry,
+            "exit_converging": self.is_exit_converging(symbol_key),
+            "orphan_origin": orphan_origin,
+            "protected_quantity": protected_quantity,
+            "has_valid_stop": has_valid_stop,
+            "all_closed": all_closed,
+        }
+
 
     def is_exit_converging(self, symbol: str) -> bool:
         """Return True while a managed exit for ``symbol`` is not fully converged."""

--- a/src/nifty_scalper_bot/execution/ownership.py
+++ b/src/nifty_scalper_bot/execution/ownership.py
@@ -20,6 +20,7 @@ import os
 from typing import Any, Mapping, Sequence
 
 from nifty_scalper_bot.execution.runtime_bracket_manager import RuntimeBracketManager
+from nifty_scalper_bot.utils.symbols import normalize_symbol
 
 _TRUTHY = {"1", "true", "yes", "y", "on", "live"}
 
@@ -241,41 +242,40 @@ def classify_symbol_lifecycle(
     local_position_present: bool,
     broker_exposure_state: BrokerExposureState,
 ) -> SymbolLifecycleClassification:
-    """Classify current symbol ownership without mutating brackets or orders.
+    """Classify current symbol ownership without mutating brackets or orders."""
 
-    This centralizes the narrow orphan/ghost questions used by app and runner so
-    future execution corrections do not add another broker-position parser.
-    """
-
-    pending_entry = False
-    exit_converging = False
-    managed = False
-    try:
-        managed = bool(bracket_manager.is_symbol_managed(symbol))
-    except Exception:
-        return SymbolLifecycleClassification.UNRESOLVED
-    checker = getattr(bracket_manager, "is_exit_converging", None)
-    if callable(checker):
+    normalized = normalize_symbol(symbol) or str(symbol or "").strip().upper()
+    snapshot_getter = getattr(bracket_manager, "get_symbol_lifecycle_snapshot", None)
+    if callable(snapshot_getter):
         try:
-            exit_converging = bool(checker(symbol))
+            snapshot = snapshot_getter(normalized)
         except Exception:
             return SymbolLifecycleClassification.UNRESOLVED
-    if exit_converging:
-        return SymbolLifecycleClassification.EXIT_CONVERGING
-    for bracket_id in list((getattr(bracket_manager, "_symbol_map", {}) or {}).get(symbol) or []):
-        bracket = (getattr(bracket_manager, "_brackets", {}) or {}).get(bracket_id)
-        if bracket is not None and not getattr(bracket, "entry_confirmed", False):
-            entry_order_id = str(getattr(bracket, "entry_order_id", "") or "")
-            tag = str(getattr(bracket, "tag", "") or "")
-            if not entry_order_id.startswith("orphan_") and tag != "orphan_recovery":
-                pending_entry = True
-                break
-    if pending_entry:
-        return SymbolLifecycleClassification.PENDING_ENTRY
+        if bool(snapshot.get("exit_converging")):
+            return SymbolLifecycleClassification.EXIT_CONVERGING
+        if bool(snapshot.get("pending_entry")):
+            return SymbolLifecycleClassification.PENDING_ENTRY
+        managed = bool(snapshot.get("managed"))
+    else:
+        try:
+            managed = bool(bracket_manager.is_symbol_managed(normalized))
+        except Exception:
+            return SymbolLifecycleClassification.UNRESOLVED
+        checker = getattr(bracket_manager, "is_exit_converging", None)
+        if callable(checker):
+            try:
+                if bool(checker(normalized)):
+                    return SymbolLifecycleClassification.EXIT_CONVERGING
+            except Exception:
+                return SymbolLifecycleClassification.UNRESOLVED
+
     if managed and local_position_present:
         return SymbolLifecycleClassification.PROTECTED_OPEN
     if managed and not local_position_present:
-        if broker_exposure_state in (BrokerExposureState.FLAT, BrokerExposureState.ABSENT):
+        if broker_exposure_state in (
+            BrokerExposureState.FLAT,
+            BrokerExposureState.ABSENT,
+        ):
             return SymbolLifecycleClassification.GHOST_FLAT
         return SymbolLifecycleClassification.UNRESOLVED
     if local_position_present and broker_exposure_state == BrokerExposureState.NONZERO:

--- a/src/nifty_scalper_bot/execution/ownership.py
+++ b/src/nifty_scalper_bot/execution/ownership.py
@@ -219,3 +219,68 @@ class BoundBracketManager(RuntimeBracketManager):
 
 
 __all__ = ["BoundBracketManager"]
+from enum import Enum
+from nifty_scalper_bot.execution.position_snapshot import BrokerExposureState
+
+
+class SymbolLifecycleClassification(str, Enum):
+    """Read-only symbol lifecycle classification for reconciliation callers."""
+
+    PROTECTED_OPEN = "protected_open"
+    PENDING_ENTRY = "pending_entry"
+    EXIT_CONVERGING = "exit_converging"
+    TRUE_ORPHAN = "true_orphan"
+    GHOST_FLAT = "ghost_flat"
+    UNRESOLVED = "unresolved"
+
+
+def classify_symbol_lifecycle(
+    symbol: str,
+    *,
+    bracket_manager: Any,
+    local_position_present: bool,
+    broker_exposure_state: BrokerExposureState,
+) -> SymbolLifecycleClassification:
+    """Classify current symbol ownership without mutating brackets or orders.
+
+    This centralizes the narrow orphan/ghost questions used by app and runner so
+    future execution corrections do not add another broker-position parser.
+    """
+
+    pending_entry = False
+    exit_converging = False
+    managed = False
+    try:
+        managed = bool(bracket_manager.is_symbol_managed(symbol))
+    except Exception:
+        return SymbolLifecycleClassification.UNRESOLVED
+    checker = getattr(bracket_manager, "is_exit_converging", None)
+    if callable(checker):
+        try:
+            exit_converging = bool(checker(symbol))
+        except Exception:
+            return SymbolLifecycleClassification.UNRESOLVED
+    if exit_converging:
+        return SymbolLifecycleClassification.EXIT_CONVERGING
+    for bracket_id in list((getattr(bracket_manager, "_symbol_map", {}) or {}).get(symbol) or []):
+        bracket = (getattr(bracket_manager, "_brackets", {}) or {}).get(bracket_id)
+        if bracket is not None and not getattr(bracket, "entry_confirmed", False):
+            entry_order_id = str(getattr(bracket, "entry_order_id", "") or "")
+            tag = str(getattr(bracket, "tag", "") or "")
+            if not entry_order_id.startswith("orphan_") and tag != "orphan_recovery":
+                pending_entry = True
+                break
+    if pending_entry:
+        return SymbolLifecycleClassification.PENDING_ENTRY
+    if managed and local_position_present:
+        return SymbolLifecycleClassification.PROTECTED_OPEN
+    if managed and not local_position_present:
+        if broker_exposure_state in (BrokerExposureState.FLAT, BrokerExposureState.ABSENT):
+            return SymbolLifecycleClassification.GHOST_FLAT
+        return SymbolLifecycleClassification.UNRESOLVED
+    if local_position_present and broker_exposure_state == BrokerExposureState.NONZERO:
+        return SymbolLifecycleClassification.TRUE_ORPHAN
+    return SymbolLifecycleClassification.UNRESOLVED
+
+
+__all__ = ["BoundBracketManager", "SymbolLifecycleClassification", "classify_symbol_lifecycle"]

--- a/src/nifty_scalper_bot/execution/position_identity_extension.py
+++ b/src/nifty_scalper_bot/execution/position_identity_extension.py
@@ -46,6 +46,15 @@ def _canonicalize_broker_positions(broker_positions: Any) -> Any:
     if broker_positions is None:
         return None
     if isinstance(broker_positions, dict):
+        # Preserve canonical complete broker snapshot mappings such as Zerodha
+        # {"net": [...], "day": [...]} instead of wrapping them as one row.
+        if "net" in broker_positions or "positions" in broker_positions:
+            cloned = dict(broker_positions)
+            for key in ("net", "positions"):
+                value = cloned.get(key)
+                if isinstance(value, list):
+                    cloned[key] = [_canonicalize_payload_symbol(row) for row in value]
+            return cloned
         return [_canonicalize_payload_symbol(broker_positions)]
     try:
         return [_canonicalize_payload_symbol(position) for position in broker_positions]
@@ -79,6 +88,12 @@ def _prepared_row_symbol(row: Any) -> str:
 
 def _prepare_broker_positions(manager: Any, broker_positions: Any) -> tuple[Any, set[str]]:
     canonicalized = _canonicalize_broker_positions(broker_positions)
+    if isinstance(canonicalized, dict):
+        try:
+            snapshot = decode_position_snapshot(canonicalized)
+        except PositionSnapshotError:
+            return canonicalized, set()
+        canonicalized = snapshot.raw_rows()
     if not isinstance(canonicalized, list):
         return canonicalized, set()
     positions = getattr(manager, "_positions", {})

--- a/src/nifty_scalper_bot/execution/position_manager.py
+++ b/src/nifty_scalper_bot/execution/position_manager.py
@@ -64,6 +64,25 @@ _MIN_RECONCILE_DELAY_S = 0.5
 _EXIT_RECONCILIATION_GRACE_DEFAULT_S = 2.0
 _EXIT_RECONCILIATION_GRACE_MIN_S = 0.25
 _EXIT_RECONCILIATION_GRACE_MAX_S = 5.0
+_BROKER_POSITION_SNAPSHOT_MAX_AGE_DEFAULT_S = 20.0
+_BROKER_POSITION_SNAPSHOT_MAX_AGE_MIN_S = 1.0
+_BROKER_POSITION_SNAPSHOT_MAX_AGE_MAX_S = 300.0
+
+
+def _resolve_broker_position_snapshot_max_age_seconds() -> float:
+    raw = os.getenv("BROKER_POSITION_SNAPSHOT_MAX_AGE_SECONDS")
+    if raw is None or str(raw).strip() == "":
+        return _BROKER_POSITION_SNAPSHOT_MAX_AGE_DEFAULT_S
+    try:
+        value = float(str(raw).strip())
+    except (TypeError, ValueError):
+        return _BROKER_POSITION_SNAPSHOT_MAX_AGE_DEFAULT_S
+    if not math.isfinite(value):
+        return _BROKER_POSITION_SNAPSHOT_MAX_AGE_DEFAULT_S
+    return min(
+        _BROKER_POSITION_SNAPSHOT_MAX_AGE_MAX_S,
+        max(_BROKER_POSITION_SNAPSHOT_MAX_AGE_MIN_S, value),
+    )
 
 
 def _resolve_exit_reconciliation_grace_seconds() -> float:
@@ -911,11 +930,17 @@ class PositionManager:
         )
         self._last_reconciled_state: Dict[str, Position] = {}
         self._last_broker_position_snapshot_at: float | None = None
+        self._last_broker_position_snapshot_mono: float | None = None
         self._last_broker_position_snapshot_valid: bool = False
         self._last_broker_quantities_by_symbol: dict[str, int] = {}
         self._last_broker_position_snapshot_source: str | None = None
         self._last_broker_position_snapshot_failure_at: float | None = None
         self._last_broker_position_snapshot_failure_reason: str | None = None
+        self._broker_position_snapshot_max_age_seconds = (
+            _resolve_broker_position_snapshot_max_age_seconds()
+        )
+        self._local_position_generation: int = 0
+        self._broker_snapshot_local_generation: int = -1
         self._recently_flat_exit_until_monotonic: dict[str, float] = {}
         self._recently_flat_exit_metadata: dict[str, ExitSettlementGuard] = {}
         self._recently_flat_exit_grace_seconds: float = (
@@ -1545,6 +1570,25 @@ class PositionManager:
                 exc,
             )
 
+    def _mark_local_position_mutation_locked(self) -> None:
+        """Invalidate broker snapshot authority after local exposure changes."""
+
+        self._local_position_generation += 1
+
+    def _broker_snapshot_age_locked(self) -> float | None:
+        if self._last_broker_position_snapshot_mono is None:
+            return None
+        return time.monotonic() - self._last_broker_position_snapshot_mono
+
+    def _broker_snapshot_fresh_locked(self) -> tuple[bool, float | None]:
+        age = self._broker_snapshot_age_locked()
+        max_age = float(self._broker_position_snapshot_max_age_seconds)
+        if age is None or age < 0 or age > max_age:
+            return False, age
+        if self._broker_snapshot_local_generation != self._local_position_generation:
+            return False, age
+        return True, age
+
     def is_flat(self, symbol: str) -> bool:
         """Return ``True`` when local state proves no open position.
 
@@ -1579,27 +1623,35 @@ class PositionManager:
         """Return a detached copy of the last validated complete broker snapshot."""
 
         with self._lock:
+            fresh, age = self._broker_snapshot_fresh_locked()
             return {
                 "valid": self._last_broker_position_snapshot_valid,
+                "fresh": bool(self._last_broker_position_snapshot_valid and fresh),
+                "age_seconds": age,
+                "max_age_seconds": self._broker_position_snapshot_max_age_seconds,
                 "fetched_at": self._last_broker_position_snapshot_at,
                 "source": self._last_broker_position_snapshot_source,
                 "quantities_by_symbol": dict(self._last_broker_quantities_by_symbol),
                 "failure_at": self._last_broker_position_snapshot_failure_at,
                 "failure_reason": self._last_broker_position_snapshot_failure_reason,
+                "local_position_generation": self._local_position_generation,
+                "snapshot_local_generation": self._broker_snapshot_local_generation,
             }
 
     def broker_exposure_state(self, symbol: str) -> BrokerExposureState:
         """Return broker-authoritative exposure state for ``symbol``.
 
-        UNKNOWN means no complete validated snapshot has been committed and must
-        not be treated as flat. ABSENT means the latest complete net snapshot was
-        valid but had no row for the symbol, which is broker-flat for Zerodha net
-        snapshots.
+        UNKNOWN means the latest complete snapshot is missing, stale, invalid, or
+        predates a local exposure mutation. UNKNOWN is never flat and never a
+        true orphan. ABSENT means a fresh complete net snapshot had no symbol row.
         """
 
         lookup = normalize_symbol(symbol) or symbol.strip().upper()
         with self._lock:
             if not self._last_broker_position_snapshot_valid:
+                return BrokerExposureState.UNKNOWN
+            fresh, _age = self._broker_snapshot_fresh_locked()
+            if not fresh:
                 return BrokerExposureState.UNKNOWN
             if lookup not in self._last_broker_quantities_by_symbol:
                 return BrokerExposureState.ABSENT
@@ -1636,6 +1688,7 @@ class PositionManager:
                 raise ValueError(f"Position already exists for {symbol_key}")
             self._clear_recent_exit_guard_locked(symbol_key)
             self._positions[symbol_key] = position
+            self._mark_local_position_mutation_locked()
         self._logger.info("Opened %s position for %s", position.side, symbol_key)
         self.save_state()
         return position
@@ -1663,6 +1716,7 @@ class PositionManager:
             position.current_price = float(exit_price)
             position.quantity = 0
             del self._positions[symbol_key]
+            self._mark_local_position_mutation_locked()
             self._mark_recent_exit_flat_locked(symbol_key)
         closed_at = close_time or _now()
         self._logger.info(
@@ -2871,12 +2925,20 @@ class PositionManager:
                         self._exit_lifecycles[order.order_id] = lifecycle
                     lifecycle.state = "BROKER_FLAT_AWAITING_FILL"
                     lifecycle.broker_flat_at = now
+            if set(self._positions) != set(reconciled) or any(
+                int(getattr(self._positions.get(symbol), "quantity", 0) or 0)
+                != int(getattr(position, "quantity", 0) or 0)
+                for symbol, position in reconciled.items()
+            ):
+                self._mark_local_position_mutation_locked()
             self._positions = reconciled
             self._last_broker_quantities_by_symbol = {
                 row.symbol: int(row.quantity) for row in snapshot.rows
             }
             self._last_broker_position_snapshot_at = snapshot.fetched_at
+            self._last_broker_position_snapshot_mono = time.monotonic()
             self._last_broker_position_snapshot_valid = True
+            self._broker_snapshot_local_generation = self._local_position_generation
             self._last_broker_position_snapshot_source = snapshot.source
             self._last_broker_position_snapshot_failure_reason = None
             if snapshot_realized_seen:
@@ -3745,6 +3807,8 @@ class PositionManager:
         ) / new_qty
         position.quantity = new_qty
         position.current_price = fill_price
+        with self._lock:
+            self._mark_local_position_mutation_locked()
         self._logger.info(
             "Scaled position %s to quantity %s", position.symbol, position.quantity
         )
@@ -3762,6 +3826,8 @@ class PositionManager:
         with self._lock:
             self._refresh_realized_pnl_locked()
         position.current_price = fill_price
+        with self._lock:
+            self._mark_local_position_mutation_locked()
         if position.quantity == 0:
             self._logger.info("Position %s fully closed via order", position.symbol)
             del self._positions[position.symbol]

--- a/src/nifty_scalper_bot/execution/position_manager.py
+++ b/src/nifty_scalper_bot/execution/position_manager.py
@@ -27,6 +27,7 @@ from zoneinfo import ZoneInfo
 
 from nifty_scalper_bot.infra.metrics import METRICS
 from nifty_scalper_bot.execution.position_snapshot import (
+    BrokerExposureState,
     PositionSnapshotError,
     decode_position_snapshot,
 )
@@ -34,7 +35,7 @@ from nifty_scalper_bot.options.strike_selector import SelectedContract
 from nifty_scalper_bot.utils.logging import get_logger
 from nifty_scalper_bot.utils.metrics import Counter
 from nifty_scalper_bot.utils.reasons import canonical
-from nifty_scalper_bot.utils.symbols import is_strategy_instrument
+from nifty_scalper_bot.utils.symbols import is_strategy_instrument, normalize_symbol
 
 if TYPE_CHECKING:
     from nifty_scalper_bot.data.persistent_state import PersistentStateManager
@@ -909,6 +910,12 @@ class PositionManager:
             []
         )
         self._last_reconciled_state: Dict[str, Position] = {}
+        self._last_broker_position_snapshot_at: float | None = None
+        self._last_broker_position_snapshot_valid: bool = False
+        self._last_broker_quantities_by_symbol: dict[str, int] = {}
+        self._last_broker_position_snapshot_source: str | None = None
+        self._last_broker_position_snapshot_failure_at: float | None = None
+        self._last_broker_position_snapshot_failure_reason: str | None = None
         self._recently_flat_exit_until_monotonic: dict[str, float] = {}
         self._recently_flat_exit_metadata: dict[str, ExitSettlementGuard] = {}
         self._recently_flat_exit_grace_seconds: float = (
@@ -1539,16 +1546,10 @@ class PositionManager:
             )
 
     def is_flat(self, symbol: str) -> bool:
-        """Return ``True`` when *symbol* has no open position.
+        """Return ``True`` when local state proves no open position.
 
-        Args:
-            symbol: Option contract identifier.
-
-        Returns:
-            ``True`` if quantity is zero or position missing.
-
-        Raises:
-            None.
+        Unexpected lookup failures are unknown state and therefore fail closed.
+        Broker-authoritative callers must use ``broker_exposure_state`` instead.
         """
 
         lookup = symbol.strip().upper()
@@ -1556,11 +1557,54 @@ class PositionManager:
             "Entered is_flat", extra={"event": "is_flat", "symbol": lookup}
         )
         try:
-            position = self._positions.get(lookup)
+            with self._lock:
+                position = self._positions.get(lookup)
         except Exception as exc:  # noqa: BLE001 - defensive guard
-            self._logger.error("Failure in is_flat: %s", exc)
-            return True
+            self._logger.error(
+                "POSITION_FLAT_CHECK_FAILED symbol=%s error=%s",
+                lookup,
+                exc,
+                extra={
+                    "event": "POSITION_FLAT_CHECK_FAILED",
+                    "symbol": lookup,
+                    "error_type": type(exc).__name__,
+                    "error_message": str(exc),
+                },
+                exc_info=True,
+            )
+            return False
         return position is None or position.quantity <= 0
+
+    def broker_exposure_snapshot(self) -> dict[str, object]:
+        """Return a detached copy of the last validated complete broker snapshot."""
+
+        with self._lock:
+            return {
+                "valid": self._last_broker_position_snapshot_valid,
+                "fetched_at": self._last_broker_position_snapshot_at,
+                "source": self._last_broker_position_snapshot_source,
+                "quantities_by_symbol": dict(self._last_broker_quantities_by_symbol),
+                "failure_at": self._last_broker_position_snapshot_failure_at,
+                "failure_reason": self._last_broker_position_snapshot_failure_reason,
+            }
+
+    def broker_exposure_state(self, symbol: str) -> BrokerExposureState:
+        """Return broker-authoritative exposure state for ``symbol``.
+
+        UNKNOWN means no complete validated snapshot has been committed and must
+        not be treated as flat. ABSENT means the latest complete net snapshot was
+        valid but had no row for the symbol, which is broker-flat for Zerodha net
+        snapshots.
+        """
+
+        lookup = normalize_symbol(symbol) or symbol.strip().upper()
+        with self._lock:
+            if not self._last_broker_position_snapshot_valid:
+                return BrokerExposureState.UNKNOWN
+            if lookup not in self._last_broker_quantities_by_symbol:
+                return BrokerExposureState.ABSENT
+            qty = self._last_broker_quantities_by_symbol[lookup]
+        return BrokerExposureState.FLAT if qty == 0 else BrokerExposureState.NONZERO
 
     def open_position(
         self,
@@ -1662,22 +1706,26 @@ class PositionManager:
     def get_position(self, symbol: str) -> Position | None:
         """Return the :class:`Position` for ``symbol`` if it exists."""
 
-        return self._positions.get(symbol.upper())
+        with self._lock:
+            return self._positions.get(symbol.upper())
 
     def get_all_positions(self) -> list[Position]:
         """Return all currently open positions."""
 
-        return list(self._positions.values())
+        with self._lock:
+            return list(self._positions.values())
 
     def get_open_positions(self) -> list[Position]:
         """Alias for :meth:`get_all_positions` for compatibility with protocols."""
 
-        return list(self._positions.values())
+        with self._lock:
+            return list(self._positions.values())
 
     def has_position(self, symbol: str) -> bool:
         """Return ``True`` if a position exists for ``symbol``."""
 
-        return symbol.upper() in self._positions
+        with self._lock:
+            return symbol.upper() in self._positions
 
     def has_open_position(self, symbol: str) -> bool:
         """Return whether an open position exists. Args: symbol. Returns: bool. Raises: None."""
@@ -2694,7 +2742,13 @@ class PositionManager:
         self, broker_positions: Sequence[Mapping[str, object]]
     ) -> None:
         """Validate and atomically replace managed positions from broker truth."""
-        snapshot = decode_position_snapshot(broker_positions)
+        try:
+            snapshot = decode_position_snapshot(broker_positions)
+        except Exception as exc:
+            with self._lock:
+                self._last_broker_position_snapshot_failure_at = time.time()
+                self._last_broker_position_snapshot_failure_reason = str(exc)
+            raise
 
         def get_float(
             record: Mapping[str, object],
@@ -2818,6 +2872,13 @@ class PositionManager:
                     lifecycle.state = "BROKER_FLAT_AWAITING_FILL"
                     lifecycle.broker_flat_at = now
             self._positions = reconciled
+            self._last_broker_quantities_by_symbol = {
+                row.symbol: int(row.quantity) for row in snapshot.rows
+            }
+            self._last_broker_position_snapshot_at = snapshot.fetched_at
+            self._last_broker_position_snapshot_valid = True
+            self._last_broker_position_snapshot_source = snapshot.source
+            self._last_broker_position_snapshot_failure_reason = None
             if snapshot_realized_seen:
                 self._broker_realized_pnl = float(snapshot_realized_pnl)
                 self._refresh_realized_pnl_locked()

--- a/src/nifty_scalper_bot/execution/position_snapshot.py
+++ b/src/nifty_scalper_bot/execution/position_snapshot.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 from dataclasses import dataclass
+from enum import Enum
 import math
 import time
 from typing import Any, Mapping
@@ -25,6 +26,20 @@ from nifty_scalper_bot.utils.symbols import normalize_symbol
 
 class PositionSnapshotError(ValueError):
     """Raised when broker exposure cannot be interpreted authoritatively."""
+
+
+class BrokerExposureState(str, Enum):
+    """Authoritative broker exposure state for one symbol.
+
+    UNKNOWN is fail-closed: it means no complete validated broker snapshot is
+    currently available and must not be interpreted as flat. ABSENT means a
+    complete broker net snapshot was valid and did not include the symbol.
+    """
+
+    FLAT = "flat"
+    NONZERO = "nonzero"
+    ABSENT = "absent"
+    UNKNOWN = "unknown"
 
 
 @dataclass(frozen=True, slots=True)
@@ -45,12 +60,25 @@ class PositionSnapshot:
     fetched_at: float
 
     def quantity_for(self, symbol: str) -> int:
-        """Return signed net quantity for ``symbol``."""
+        """Return signed net quantity for ``symbol``; absent complete rows are zero."""
         target = normalize_symbol(symbol)
         for row in self.rows:
             if row.symbol == target:
                 return row.quantity
         return 0
+
+    def exposure_state_for(self, symbol: str) -> BrokerExposureState:
+        """Return symbol exposure while distinguishing explicit flat from absent."""
+        target = normalize_symbol(symbol)
+        for row in self.rows:
+            if row.symbol != target:
+                continue
+            return (
+                BrokerExposureState.FLAT
+                if row.quantity == 0
+                else BrokerExposureState.NONZERO
+            )
+        return BrokerExposureState.ABSENT
 
     @property
     def all_flat(self) -> bool:
@@ -154,6 +182,7 @@ def decode_position_snapshot(payload: object) -> PositionSnapshot:
 
 
 __all__ = [
+    "BrokerExposureState",
     "PositionSnapshot",
     "PositionSnapshotError",
     "PositionSnapshotRow",

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -162,6 +162,11 @@ from nifty_scalper_bot.utils.market_hours import (
     stale_threshold_for_symbol,
 )
 from nifty_scalper_bot.utils.metrics import Counter, signals_generated_total
+from nifty_scalper_bot.execution.ownership import (
+    SymbolLifecycleClassification,
+    classify_symbol_lifecycle,
+)
+from nifty_scalper_bot.execution.position_snapshot import BrokerExposureState
 from nifty_scalper_bot.utils.symbols import (
     canonical,
     enforce_canonical,
@@ -16280,40 +16285,16 @@ class StrategyRunner:
 
 
     def _broker_reports_symbol_flat(self, symbol: str) -> bool:
-        """Return True when broker positions explicitly report no exposure."""
+        """Return True only when the validated PositionManager snapshot proves flat."""
 
-        broker = getattr(getattr(self._bracket_manager, "order_manager", None), "_broker", None)
-        fetcher = getattr(broker, "get_positions", None) or getattr(broker, "positions", None)
-        if not callable(fetcher):
+        exposure_getter = getattr(self._position_manager, "broker_exposure_state", None)
+        if not callable(exposure_getter):
             return False
         try:
-            rows = fetcher()
+            exposure = exposure_getter(symbol)
         except Exception:
             return False
-        wanted = str(symbol or "").upper()
-        saw_symbol = False
-        for row in rows or []:
-            raw_symbol = str(
-                getattr(row, "symbol", "")
-                or getattr(row, "tradingsymbol", "")
-                or (row.get("symbol") if isinstance(row, dict) else "")
-                or (row.get("tradingsymbol") if isinstance(row, dict) else "")
-                or ""
-            ).upper()
-            if raw_symbol != wanted and not wanted.endswith(raw_symbol):
-                continue
-            saw_symbol = True
-            raw_qty = (
-                getattr(row, "quantity", None)
-                if not isinstance(row, dict)
-                else row.get("quantity")
-            )
-            try:
-                if abs(int(float(raw_qty or 0))) > 0:
-                    return False
-            except Exception:
-                return False
-        return saw_symbol
+        return exposure in (BrokerExposureState.FLAT, BrokerExposureState.ABSENT)
 
     def _adopt_orphan_positions(self) -> None:
         """
@@ -16367,19 +16348,30 @@ class StrategyRunner:
                 if qty <= 0 or entry <= 0:
                     continue
 
-                exit_converging = getattr(
-                    self._bracket_manager, "is_exit_converging", None
+                exposure_getter = getattr(self._position_manager, "broker_exposure_state", None)
+                try:
+                    exposure = (
+                        exposure_getter(symbol)
+                        if callable(exposure_getter)
+                        else BrokerExposureState.UNKNOWN
+                    )
+                except Exception:
+                    exposure = BrokerExposureState.UNKNOWN
+                lifecycle = classify_symbol_lifecycle(
+                    symbol,
+                    bracket_manager=self._bracket_manager,
+                    local_position_present=True,
+                    broker_exposure_state=exposure,
                 )
-                if callable(exit_converging) and exit_converging(symbol):
+                if lifecycle in (
+                    SymbolLifecycleClassification.EXIT_CONVERGING,
+                    SymbolLifecycleClassification.PENDING_ENTRY,
+                    SymbolLifecycleClassification.PROTECTED_OPEN,
+                    SymbolLifecycleClassification.GHOST_FLAT,
+                ):
                     continue
-
-                broker_flat = getattr(self, "_broker_reports_symbol_flat", None)
-                if callable(broker_flat) and broker_flat(symbol):
+                if exposure in (BrokerExposureState.FLAT, BrokerExposureState.ABSENT):
                     continue
-
-                # ═══════════════════════════════════════════════════════════════
-                # ✅ FIX #1: Use is_symbol_managed() instead of get_bracket()
-                # ═══════════════════════════════════════════════════════════════
                 if self._bracket_manager.is_symbol_managed(symbol):
                     continue  # Existing pending/active lifecycle owns the position.
 

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -16372,6 +16372,37 @@ class StrategyRunner:
                     continue
                 if exposure in (BrokerExposureState.FLAT, BrokerExposureState.ABSENT):
                     continue
+                if (
+                    exposure == BrokerExposureState.UNKNOWN
+                    or lifecycle == SymbolLifecycleClassification.UNRESOLVED
+                ):
+                    snapshot_getter = getattr(
+                        self._position_manager, "broker_exposure_snapshot", None
+                    )
+                    snapshot = snapshot_getter() if callable(snapshot_getter) else {}
+                    self._logger.warning(
+                        "ORPHAN_ADOPTION_DEFERRED_BROKER_UNKNOWN symbol=%s exposure_state=%s lifecycle=%s snapshot_age_seconds=%s snapshot_fresh=%s",
+                        symbol,
+                        getattr(exposure, "value", str(exposure)),
+                        getattr(lifecycle, "value", str(lifecycle)),
+                        snapshot.get("age_seconds") if isinstance(snapshot, dict) else None,
+                        snapshot.get("fresh") if isinstance(snapshot, dict) else None,
+                        extra={
+                            "event": "ORPHAN_ADOPTION_DEFERRED_BROKER_UNKNOWN",
+                            "symbol": symbol,
+                            "exposure_state": getattr(exposure, "value", str(exposure)),
+                            "lifecycle": getattr(lifecycle, "value", str(lifecycle)),
+                            "snapshot_age_seconds": (
+                                snapshot.get("age_seconds")
+                                if isinstance(snapshot, dict)
+                                else None
+                            ),
+                            "snapshot_fresh": (
+                                snapshot.get("fresh") if isinstance(snapshot, dict) else None
+                            ),
+                        },
+                    )
+                    continue
                 if self._bracket_manager.is_symbol_managed(symbol):
                     continue  # Existing pending/active lifecycle owns the position.
 

--- a/tests/execution/test_canonical_execution_recovery.py
+++ b/tests/execution/test_canonical_execution_recovery.py
@@ -288,3 +288,63 @@ def test_broker_exposure_states_distinguish_flat_absent_nonzero_and_unknown(tmp_
 def test_malformed_broker_exposure_never_decodes_as_flat(payload):
     with pytest.raises(PositionSnapshotError):
         decode_position_snapshot(payload)
+
+
+def test_broker_exposure_snapshot_expires_to_unknown(tmp_path, monkeypatch):
+    from nifty_scalper_bot.execution import position_manager as pm_module
+    from nifty_scalper_bot.execution.position_snapshot import BrokerExposureState
+
+    now = {"value": 100.0}
+    monkeypatch.setattr(pm_module.time, "monotonic", lambda: now["value"])
+    monkeypatch.setenv("BROKER_POSITION_SNAPSHOT_MAX_AGE_SECONDS", "20")
+    pm = PositionManager(str(tmp_path / "positions.json"))
+    pm.synchronize_with_broker([{"symbol": SYMBOL, "quantity": 0, "product": "MIS"}])
+
+    assert pm.broker_exposure_state(SYMBOL) is BrokerExposureState.FLAT
+    snapshot = pm.broker_exposure_snapshot()
+    assert snapshot["fresh"] is True
+    assert snapshot["max_age_seconds"] == 20.0
+
+    now["value"] = 121.0
+    assert pm.broker_exposure_state(SYMBOL) is BrokerExposureState.UNKNOWN
+    assert pm.broker_exposure_snapshot()["fresh"] is False
+
+
+def test_absent_snapshot_expires_and_local_generation_invalidates(tmp_path, monkeypatch):
+    from nifty_scalper_bot.execution import position_manager as pm_module
+    from nifty_scalper_bot.execution.position_snapshot import BrokerExposureState
+
+    now = {"value": 200.0}
+    monkeypatch.setattr(pm_module.time, "monotonic", lambda: now["value"])
+    monkeypatch.setenv("BROKER_POSITION_SNAPSHOT_MAX_AGE_SECONDS", "20")
+    pm = PositionManager(str(tmp_path / "positions.json"))
+    pm.synchronize_with_broker([])
+    assert pm.broker_exposure_state(SYMBOL) is BrokerExposureState.ABSENT
+
+    pm.open_position(SYMBOL, "LONG", 65, 100.0, order_id="manual")
+    assert pm.broker_exposure_state(SYMBOL) is BrokerExposureState.UNKNOWN
+
+    pm.synchronize_with_broker([{"symbol": SYMBOL, "quantity": 65, "average_price": 100.0, "last_price": 100.0, "product": "MIS"}])
+    assert pm.broker_exposure_state(SYMBOL) is BrokerExposureState.NONZERO
+    pm.update_position_price(SYMBOL, 101.0)
+    assert pm.broker_exposure_state(SYMBOL) is BrokerExposureState.NONZERO
+
+    now["value"] = 221.0
+    assert pm.broker_exposure_state(SYMBOL) is BrokerExposureState.UNKNOWN
+
+
+def test_position_manager_is_flat_fails_closed_on_lookup_exception(tmp_path, caplog):
+    class RaisingPositions(dict):
+        def get(self, _key, _default=None):
+            raise RuntimeError("lookup failed")
+
+    errors = []
+    pm = PositionManager(str(tmp_path / "positions.json"))
+    pm._positions = RaisingPositions()
+    pm._logger = SimpleNamespace(
+        debug=lambda *a, **k: None,
+        error=lambda *args, **kwargs: errors.append((args, kwargs)),
+    )
+
+    assert pm.is_flat(SYMBOL) is False
+    assert any("POSITION_FLAT_CHECK_FAILED" in str(args[0]) for args, _kwargs in errors)

--- a/tests/execution/test_canonical_execution_recovery.py
+++ b/tests/execution/test_canonical_execution_recovery.py
@@ -257,3 +257,34 @@ def test_restart_with_already_protected_position_no_duplicate_bracket(
     assert len(brackets) == 1
     assert brackets[0].remaining_quantity == 65
     assert brackets[0].active and brackets[0].entry_confirmed
+
+
+def test_broker_exposure_states_distinguish_flat_absent_nonzero_and_unknown(tmp_path):
+    from nifty_scalper_bot.execution.position_snapshot import BrokerExposureState
+
+    pm = PositionManager(str(tmp_path / "positions.json"))
+    assert pm.broker_exposure_state(SYMBOL) is BrokerExposureState.UNKNOWN
+
+    pm.synchronize_with_broker({"net": [{"tradingsymbol": SYMBOL.replace("NFO:", ""), "quantity": 0, "product": "MIS"}], "day": []})
+    assert pm.broker_exposure_state(SYMBOL) is BrokerExposureState.FLAT
+    assert pm.broker_exposure_state(OTHER) is BrokerExposureState.ABSENT
+
+    pm.synchronize_with_broker([{"symbol": SYMBOL, "quantity": 65, "average_price": 100.0, "last_price": 100.0, "product": "MIS"}])
+    assert pm.broker_exposure_state(SYMBOL) is BrokerExposureState.NONZERO
+
+    with pytest.raises(PositionSnapshotError):
+        pm.synchronize_with_broker([{"symbol": SYMBOL, "product": "MIS"}])
+    assert pm.broker_exposure_state(SYMBOL) is BrokerExposureState.NONZERO
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        [{"symbol": SYMBOL, "quantity": "bad"}],
+        [{"symbol": SYMBOL}],
+        [{"symbol": SYMBOL, "quantity": 1}, {"tradingsymbol": SYMBOL.replace("NFO:", ""), "quantity": 0}],
+    ],
+)
+def test_malformed_broker_exposure_never_decodes_as_flat(payload):
+    with pytest.raises(PositionSnapshotError):
+        decode_position_snapshot(payload)

--- a/tests/execution/test_exit_reconciliation_race.py
+++ b/tests/execution/test_exit_reconciliation_race.py
@@ -686,3 +686,35 @@ def test_registration_failure_can_retry_without_duplicate_broker_exit(tmp_path) 
 
     assert len(om.calls) == 1
     assert bracket.exit_order_id == "exit-final-1"
+
+class _ExplodingBroker:
+    def get_positions(self):
+        raise AssertionError("runner must not call broker positions")
+
+    def positions(self):
+        raise AssertionError("runner must not call broker positions")
+
+
+def test_runner_orphan_scan_uses_position_manager_snapshot_not_broker_io(tmp_path) -> None:
+    pm = PositionManager(str(tmp_path / "positions.json"))
+    pm.open_position(SYMBOL, "LONG", QTY, 100.0, order_id="manual")
+    pm.synchronize_with_broker([_broker_row(0)])
+    bm = BracketManager(order_manager=_OrderManager(_ExplodingBroker()))
+    adopt_calls: list[dict[str, Any]] = []
+    bm.attach_orphan_position = lambda **kwargs: adopt_calls.append(kwargs) or "orphan"  # type: ignore[method-assign]
+
+    _runner_for(pm, bm)._adopt_orphan_positions()
+
+    assert adopt_calls == []
+
+
+def test_runner_unknown_broker_exposure_does_not_claim_flat(tmp_path) -> None:
+    pm = PositionManager(str(tmp_path / "positions.json"))
+    pm.open_position(SYMBOL, "LONG", QTY, 100.0, order_id="manual")
+    bm = BracketManager(order_manager=_OrderManager(_ExplodingBroker()))
+    adopt_calls: list[dict[str, Any]] = []
+    bm.attach_orphan_position = lambda **kwargs: adopt_calls.append(kwargs) or "orphan"  # type: ignore[method-assign]
+
+    _runner_for(pm, bm)._adopt_orphan_positions()
+
+    assert adopt_calls == [{"symbol": SYMBOL, "side": "LONG", "qty": QTY, "entry_price": 100.0}]

--- a/tests/execution/test_exit_reconciliation_race.py
+++ b/tests/execution/test_exit_reconciliation_race.py
@@ -77,6 +77,15 @@ def _bracket_manager() -> BracketManager:
     return bm
 
 
+def _stop_bracket_manager(bm: BracketManager) -> None:
+    shutdown = getattr(bm, "shutdown", None)
+    if callable(shutdown):
+        shutdown()
+    watchdog = getattr(bm, "_watchdog_thread", None)
+    if watchdog is not None:
+        watchdog.join(timeout=1.0)
+
+
 def test_exit_fill_reconciliation_flat_does_not_leave_orphan_bracket(tmp_path) -> None:
     """Terminal SELL fill makes broker, PM and bracket ownership flat immediately."""
     pm = _position_manager(tmp_path)
@@ -434,9 +443,12 @@ def test_orphan_scan_skips_stale_positive_position_during_exit_convergence(tmp_p
         order_id="stale-local",
     )
 
-    _runner_for(pm, bm)._adopt_orphan_positions()
+    try:
+        _runner_for(pm, bm)._adopt_orphan_positions()
 
-    assert adopt_calls == []
+        assert adopt_calls == []
+    finally:
+        _stop_bracket_manager(bm)
     assert bm.get_bracket(f"orphan_{SYMBOL}") is None
 
 
@@ -708,13 +720,84 @@ def test_runner_orphan_scan_uses_position_manager_snapshot_not_broker_io(tmp_pat
     assert adopt_calls == []
 
 
-def test_runner_unknown_broker_exposure_does_not_claim_flat(tmp_path) -> None:
+def test_runner_unknown_broker_exposure_defers_without_adoption(tmp_path) -> None:
     pm = PositionManager(str(tmp_path / "positions.json"))
     pm.open_position(SYMBOL, "LONG", QTY, 100.0, order_id="manual")
     bm = BracketManager(order_manager=_OrderManager(_ExplodingBroker()))
     adopt_calls: list[dict[str, Any]] = []
     bm.attach_orphan_position = lambda **kwargs: adopt_calls.append(kwargs) or "orphan"  # type: ignore[method-assign]
 
-    _runner_for(pm, bm)._adopt_orphan_positions()
+    warnings = []
+    runner = _runner_for(pm, bm)
+    runner._logger.warning = lambda *args, **kwargs: warnings.append((args, kwargs))
 
-    assert adopt_calls == [{"symbol": SYMBOL, "side": "LONG", "qty": QTY, "entry_price": 100.0}]
+    try:
+        runner._adopt_orphan_positions()
+
+        assert adopt_calls == []
+        assert any("ORPHAN_ADOPTION_DEFERRED_BROKER_UNKNOWN" in str(args[0]) for args, _kwargs in warnings)
+    finally:
+        _stop_bracket_manager(bm)
+
+
+def test_runner_stale_flat_snapshot_defers_without_orphan_adoption(tmp_path, monkeypatch) -> None:
+    from nifty_scalper_bot.execution import position_manager as pm_module
+    from nifty_scalper_bot.execution.position_snapshot import BrokerExposureState
+
+    now = {"value": 100.0}
+    monkeypatch.setattr(pm_module.time, "monotonic", lambda: now["value"])
+    monkeypatch.setenv("BROKER_POSITION_SNAPSHOT_MAX_AGE_SECONDS", "20")
+    pm = PositionManager(str(tmp_path / "positions.json"))
+    pm.synchronize_with_broker([_broker_row(0)])
+    now["value"] = 121.0
+    assert pm.broker_exposure_state(SYMBOL) is BrokerExposureState.UNKNOWN
+
+    pm._positions[SYMBOL] = Position(
+        symbol=SYMBOL,
+        side="LONG",
+        quantity=QTY,
+        entry_price=100.0,
+        entry_time=datetime.now(timezone.utc),
+        current_price=100.0,
+        order_id="manual",
+    )
+    bm = BracketManager(order_manager=_OrderManager(_ExplodingBroker()))
+    adopt_calls: list[dict[str, Any]] = []
+    bm.attach_orphan_position = lambda **kwargs: adopt_calls.append(kwargs) or "orphan"  # type: ignore[method-assign]
+    warnings = []
+    runner = _runner_for(pm, bm)
+    runner._logger.warning = lambda *args, **kwargs: warnings.append((args, kwargs))
+
+    try:
+        runner._adopt_orphan_positions()
+
+        assert adopt_calls == []
+        assert any("ORPHAN_ADOPTION_DEFERRED_BROKER_UNKNOWN" in str(args[0]) for args, _kwargs in warnings)
+    finally:
+        _stop_bracket_manager(bm)
+
+
+def test_runner_local_generation_invalidates_absent_snapshot_before_adoption(tmp_path, monkeypatch) -> None:
+    from nifty_scalper_bot.execution import position_manager as pm_module
+    from nifty_scalper_bot.execution.position_snapshot import BrokerExposureState
+
+    monkeypatch.setattr(pm_module.time, "monotonic", lambda: 100.0)
+    monkeypatch.setenv("BROKER_POSITION_SNAPSHOT_MAX_AGE_SECONDS", "20")
+    pm = PositionManager(str(tmp_path / "positions.json"))
+    pm.synchronize_with_broker([])
+    assert pm.broker_exposure_state(SYMBOL) is BrokerExposureState.ABSENT
+    pm.open_position(SYMBOL, "LONG", QTY, 100.0, order_id="manual")
+    assert pm.broker_exposure_state(SYMBOL) is BrokerExposureState.UNKNOWN
+
+    bm = BracketManager(order_manager=_OrderManager(_ExplodingBroker()))
+    adopt_calls: list[dict[str, Any]] = []
+    bm.attach_orphan_position = lambda **kwargs: adopt_calls.append(kwargs) or "orphan"  # type: ignore[method-assign]
+    try:
+        _runner_for(pm, bm)._adopt_orphan_positions()
+
+        assert adopt_calls == []
+    finally:
+        _stop_bracket_manager(bm)
+
+    pm.synchronize_with_broker([_broker_row()])
+    assert pm.broker_exposure_state(SYMBOL) is BrokerExposureState.NONZERO

--- a/tests/execution/test_readiness_execution_safety_blockers.py
+++ b/tests/execution/test_readiness_execution_safety_blockers.py
@@ -93,3 +93,127 @@ async def test_successful_flat_reconcile_clears_previous_unprotected_blocker():
         execution_ready=True,
     )
     assert decision.live_orders_armed is True
+
+class _BrokerWithPositions:
+    def __init__(self, positions):
+        self._positions = positions
+
+    def get_positions(self):
+        return list(self._positions)
+
+
+class _BrokerSyncedPositionManager(_PositionManager):
+    def __init__(self):
+        super().__init__()
+        self._open = []
+
+    def synchronize_with_broker(self, positions):
+        self.synced = list(positions)
+        self._open = [
+            SimpleNamespace(
+                symbol=p["symbol"],
+                quantity=abs(int(p["quantity"])),
+                side="LONG" if int(p["quantity"]) > 0 else "SHORT",
+                average_price=p.get("average_price", 100.0),
+                last_price=p.get("last_price", 100.0),
+            )
+            for p in self.synced
+            if int(p.get("quantity", 0)) != 0
+        ]
+
+    def get_open_positions(self):
+        return list(self._open)
+
+    def broker_exposure_state(self, _symbol):
+        from nifty_scalper_bot.execution.position_snapshot import BrokerExposureState
+
+        return BrokerExposureState.NONZERO
+
+
+class _BracketManagerFake:
+    def __init__(self):
+        self._managed = set()
+        self._brackets = {}
+        self._symbol_map = {}
+
+    def is_symbol_managed(self, symbol):
+        return symbol in self._managed
+
+    def get_bracket(self, bracket_id):
+        return self._brackets.get(bracket_id)
+
+    def manage(self, symbol, bracket_id="guard-1"):
+        self._managed.add(symbol)
+        self._symbol_map.setdefault(symbol, set()).add(bracket_id)
+        self._brackets[bracket_id] = SimpleNamespace(
+            symbol=symbol,
+            status="ACTIVE",
+            quantity=65,
+            stop_loss=90.0,
+        )
+        return bracket_id
+
+
+class _GuardOrderManager(_OrderManager):
+    def __init__(self, bm, result=None, raises=False):
+        super().__init__()
+        self._bracket_manager = bm
+        self.result = result
+        self.raises = raises
+        self.calls = []
+
+    def guard_orphan_position(self, **kwargs):
+        self.calls.append(kwargs)
+        if self.raises:
+            raise RuntimeError("guard failed")
+        if self.result == "manage":
+            return self._bracket_manager.manage(kwargs["symbol"])
+        return self.result
+
+
+@pytest.mark.asyncio
+async def test_reconcile_retains_unprotected_blocker_when_guard_returns_none(caplog):
+    symbol = "NFO:NIFTY2660923100CE"
+    bm = _BracketManagerFake()
+    ctx = SimpleNamespace(
+        broker_client=SimpleNamespace(client=_BrokerWithPositions([{"symbol": symbol, "quantity": 65, "average_price": 100.0, "last_price": 100.0, "product": "MIS"}])),
+        order_manager=_GuardOrderManager(bm, result=None),
+        position_manager=_BrokerSyncedPositionManager(),
+        data_hub=None,
+        unprotected_broker_position=False,
+        unprotected_broker_positions=set(),
+        position_reconciliation_failed=False,
+        live_orders_armed=False,
+    )
+
+    await _reconcile_state(ctx, source="test")
+
+    assert ctx.position_reconciliation_failed is False
+    assert ctx.unprotected_broker_position is True
+    assert symbol in ctx.unprotected_broker_positions
+    assert "POSITION_ORPHAN_GUARD_FAILED" in caplog.text
+    assert "POSITION_ADOPTED_TO_BRACKET" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_reconcile_clears_only_verified_orphan_protection(caplog):
+    symbol = "NFO:NIFTY2660923100CE"
+    bm = _BracketManagerFake()
+    ctx = SimpleNamespace(
+        broker_client=SimpleNamespace(client=_BrokerWithPositions([{"symbol": symbol, "quantity": 65, "average_price": 100.0, "last_price": 100.0, "product": "MIS"}])),
+        order_manager=_GuardOrderManager(bm, result="manage"),
+        position_manager=_BrokerSyncedPositionManager(),
+        data_hub=None,
+        unprotected_broker_position=False,
+        unprotected_broker_positions=set(),
+        position_reconciliation_failed=False,
+        live_orders_armed=False,
+    )
+
+    await _reconcile_state(ctx, source="test")
+
+    assert ctx.unprotected_broker_position is False
+    assert ctx.unprotected_broker_positions == set()
+    assert "POSITION_ADOPTED_TO_BRACKET" in caplog.text
+    assert ctx.position_reconciliation_last_run["source"] == "test"
+    assert ctx.position_reconciliation_last_run["reconcile_run_id"]

--- a/tests/execution/test_readiness_execution_safety_blockers.py
+++ b/tests/execution/test_readiness_execution_safety_blockers.py
@@ -217,3 +217,162 @@ async def test_reconcile_clears_only_verified_orphan_protection(caplog):
     assert "POSITION_ADOPTED_TO_BRACKET" in caplog.text
     assert ctx.position_reconciliation_last_run["source"] == "test"
     assert ctx.position_reconciliation_last_run["reconcile_run_id"]
+
+class _SideEffectGuardOrderManager(_GuardOrderManager):
+    def guard_orphan_position(self, **kwargs):
+        self.calls.append(kwargs)
+        self._bracket_manager.manage(kwargs["symbol"])
+        return None
+
+
+@pytest.mark.asyncio
+async def test_reconcile_clears_when_guard_returns_none_but_bracket_is_managed():
+    symbol = "NFO:NIFTY2660923100CE"
+    bm = _BracketManagerFake()
+    ctx = SimpleNamespace(
+        broker_client=SimpleNamespace(client=_BrokerWithPositions([{"symbol": symbol, "quantity": 65, "average_price": 100.0, "last_price": 100.0, "product": "MIS"}])),
+        order_manager=_SideEffectGuardOrderManager(bm),
+        position_manager=_BrokerSyncedPositionManager(),
+        data_hub=None,
+        unprotected_broker_position=False,
+        unprotected_broker_positions=set(),
+        position_reconciliation_failed=False,
+        live_orders_armed=False,
+    )
+
+    await _reconcile_state(ctx, source="test")
+
+    assert ctx.unprotected_broker_position is False
+    assert ctx.unprotected_broker_positions == set()
+
+
+@pytest.mark.asyncio
+async def test_reconcile_retains_blocker_when_guard_returns_invalid_bracket_id():
+    symbol = "NFO:NIFTY2660923100CE"
+    bm = _BracketManagerFake()
+    ctx = SimpleNamespace(
+        broker_client=SimpleNamespace(client=_BrokerWithPositions([{"symbol": symbol, "quantity": 65, "average_price": 100.0, "last_price": 100.0, "product": "MIS"}])),
+        order_manager=_GuardOrderManager(bm, result="missing-bracket"),
+        position_manager=_BrokerSyncedPositionManager(),
+        data_hub=None,
+        unprotected_broker_position=False,
+        unprotected_broker_positions=set(),
+        position_reconciliation_failed=False,
+        live_orders_armed=False,
+    )
+
+    await _reconcile_state(ctx, source="test")
+
+    assert ctx.unprotected_broker_position is True
+    assert symbol in ctx.unprotected_broker_positions
+
+
+@pytest.mark.asyncio
+async def test_reconcile_mixed_orphan_success_and_failure_keeps_failed_symbol_blocked():
+    ok = "NFO:NIFTY2660923100CE"
+    bad = "NFO:NIFTY2660923200CE"
+    bm = _BracketManagerFake()
+
+    class MixedGuard(_GuardOrderManager):
+        def guard_orphan_position(self, **kwargs):
+            self.calls.append(kwargs)
+            if kwargs["symbol"] == ok:
+                return self._bracket_manager.manage(ok, "ok-bracket")
+            return None
+
+    ctx = SimpleNamespace(
+        broker_client=SimpleNamespace(client=_BrokerWithPositions([
+            {"symbol": ok, "quantity": 65, "average_price": 100.0, "last_price": 100.0, "product": "MIS"},
+            {"symbol": bad, "quantity": 65, "average_price": 100.0, "last_price": 100.0, "product": "MIS"},
+        ])),
+        order_manager=MixedGuard(bm),
+        position_manager=_BrokerSyncedPositionManager(),
+        data_hub=None,
+        unprotected_broker_position=False,
+        unprotected_broker_positions=set(),
+        position_reconciliation_failed=False,
+        live_orders_armed=False,
+    )
+
+    await _reconcile_state(ctx, source="test")
+
+    assert ctx.unprotected_broker_position is True
+    assert ctx.unprotected_broker_positions == {bad}
+
+
+@pytest.mark.asyncio
+async def test_reconciliation_telemetry_records_are_run_local():
+    ctx = SimpleNamespace(
+        broker_client=SimpleNamespace(client=_FlatBroker()),
+        order_manager=_OrderManager(),
+        position_manager=_PositionManager(),
+        data_hub=None,
+        unprotected_broker_position=False,
+        unprotected_broker_positions=set(),
+        position_reconciliation_failed=False,
+        live_orders_armed=False,
+    )
+
+    await _reconcile_state(ctx, source="one")
+    first_record = ctx.position_reconciliation_last_run
+    await _reconcile_state(ctx, source="two")
+    second_record = ctx.position_reconciliation_last_run
+
+    assert first_record is not second_record
+    assert first_record["source"] == "one"
+    assert second_record["source"] == "two"
+    assert first_record["reconcile_run_id"] != second_record["reconcile_run_id"]
+    assert "completed_at" in first_record
+    assert "completed_at" in second_record
+
+@pytest.mark.asyncio
+async def test_ghost_cleanup_retains_bracket_when_broker_snapshot_stale():
+    symbol = "NFO:NIFTY2660923100CE"
+
+    class StaleFlatPositionManager(_PositionManager):
+        def broker_exposure_state(self, _symbol):
+            from nifty_scalper_bot.execution.position_snapshot import BrokerExposureState
+
+            return BrokerExposureState.UNKNOWN
+
+        def broker_exposure_snapshot(self):
+            return {"fresh": False, "age_seconds": 21.0}
+
+    class GhostBracketManager(_BracketManagerFake):
+        def __init__(self):
+            super().__init__()
+            self.manage(symbol)
+            self.closed = []
+
+        def get_symbol_lifecycle_snapshot(self, _symbol):
+            return {
+                "normalized_symbol": symbol,
+                "managed": True,
+                "active_bracket_ids": ("guard-1",),
+                "pending_entry": False,
+                "exit_converging": False,
+                "orphan_origin": True,
+                "protected_quantity": 65,
+                "has_valid_stop": True,
+                "all_closed": False,
+            }
+
+        def manual_override_close(self, ghost_sym, reason):
+            self.closed.append((ghost_sym, reason))
+
+    bm = GhostBracketManager()
+    ctx = SimpleNamespace(
+        broker_client=SimpleNamespace(client=_FlatBroker()),
+        order_manager=_OrderManager(),
+        position_manager=StaleFlatPositionManager(),
+        data_hub=None,
+        unprotected_broker_position=False,
+        unprotected_broker_positions=set(),
+        position_reconciliation_failed=False,
+        live_orders_armed=False,
+    )
+    ctx.order_manager._bracket_manager = bm
+
+    await _reconcile_state(ctx, source="test")
+
+    assert bm.closed == []


### PR DESCRIPTION
### Motivation
- Fix unsafe orphan adoption where `_reconcile_state()` called `guard_orphan_position()` then cleared `unprotected_broker_position` without verifying that protection was actually established.
- Stop divergent, synchronous broker parsing inside the runner and centralize broker-position semantics so all callers use a single canonical decoder and snapshot (preventing mapping-iteration bugs for Zerodha-style `{ "net": [...] }` responses).
- Make local flat checks and broker flatness fail-closed so UNKNOWN state is never treated as FLAT and invalid broker payloads do not overwrite the last-good snapshot.
- Add observability for reconciliation runs (run id / source / timing) and a small read-only lifecycle classifier to avoid duplicating orphan/ghost classification logic across modules. 

### Description
- Verify orphan protection before clearing blockers: `_reconcile_state()` now marks symbols as unprotected, calls `guard_orphan_position()`, and only clears `ctx.unprotected_broker_positions` after authoritative verification using `BracketManager.is_symbol_managed()` and (when available) `get_bracket()` checks; failures log `POSITION_ORPHAN_GUARD_FAILED` and retain blockers. (edited: `src/nifty_scalper_bot/core/app.py`)
- Centralized broker exposure snapshot and enum: introduced `BrokerExposureState` (`FLAT`, `NONZERO`, `ABSENT`, `UNKNOWN`) and `PositionSnapshot` semantics in `execution/position_snapshot.py`, and preserved the last validated snapshot in `PositionManager` with read-only APIs `broker_exposure_snapshot()` and `broker_exposure_state()`. (`src/nifty_scalper_bot/execution/position_snapshot.py`, `src/nifty_scalper_bot/execution/position_manager.py`)
- Runner no longer performs direct broker I/O or ad-hoc parsing: `StrategyRunner._broker_reports_symbol_flat()` now consumes `PositionManager.broker_exposure_state()` and the runner uses the shared `classify_symbol_lifecycle()` helper for orphan adoption decisions. (`src/nifty_scalper_bot/strategies/runner.py`, `src/nifty_scalper_bot/execution/ownership.py`)
- Preserve broker snapshot truth on failures: `PositionManager.synchronize_with_broker()` only updates the last-good snapshot on successful decode; decode failures record failure metadata and do not replace valid snapshots. (`src/nifty_scalper_bot/execution/position_manager.py`)
- Make `PositionManager.is_flat()` fail-closed on unexpected exceptions and add lock-protected read getters (`get_position`, `get_all_positions`, `get_open_positions`, `has_position`) to reduce races. (`src/nifty_scalper_bot/execution/position_manager.py`)
- Ghost cleanup tightened: `core.app` ghost sweep defers cleanup when broker exposure is `UNKNOWN` and consults the shared lifecycle classifier so brackets are removed only when broker and local state prove flatness or absent as appropriate. (`src/nifty_scalper_bot/core/app.py`, `src/nifty_scalper_bot/execution/ownership.py`)
- Ingress normalization and extensions: preserve map-shaped broker payloads (e.g. Zerodha `{ "net": [...] }`) in `position_identity_extension` so canonical `decode_position_snapshot()` sees them correctly. (`src/nifty_scalper_bot/execution/position_identity_extension.py`)
- Tests and small helpers: added focused tests for orphan-guard verification, canonical broker snapshot parsing and states, and runner behavior to ensure no direct broker I/O from the runner. (tests updated under `tests/execution/*`)

Files changed: `src/nifty_scalper_bot/core/app.py`, `src/nifty_scalper_bot/strategies/runner.py`, `src/nifty_scalper_bot/execution/position_snapshot.py`, `src/nifty_scalper_bot/execution/position_manager.py`, `src/nifty_scalper_bot/execution/position_identity_extension.py`, `src/nifty_scalper_bot/execution/ownership.py`, plus test updates in `tests/execution/`.

### Testing
- Unit & integration: ran `python -m compileall -q src` and `python -m pytest -q` plus focused suites; all tests executed in this branch passed (exit code 0). The focused execution suites ran and passed: `tests/execution/*` and related E2E live-sim tests. (commands and passes reported in CI log run recorded in PR metadata)
- Focused verifications: `tests/execution/test_exit_reconciliation_race.py`, `tests/execution/test_readiness_execution_safety_blockers.py`, and `tests/execution/test_canonical_execution_recovery.py` were executed and passed after the changes; new tests exercise: orphan guard returns (None/ID/raise), runner not calling broker I/O, malformed snapshots not decoding as FLAT, and `broker_exposure_state()` behavior.
- E2E: repeated the existing exit-fill/orphan lifecycle E2E `tests/e2e/live_sim/test_live_runtime_startup_contract.py::test_live_runtime_bullish_spot_future_selects_ce_and_exits_target` 10x and observed all runs succeed.
- Concurrency/overlap: added reconciliation run id / source / timing observability but did not add a single-flight coalescing change because inspection and tests did not prove unsafe overlap in production call sites; this is documented in the PR rationale and telemetry enables a follow-up if overlap is later demonstrated.

If any additional focused proof-of-overlap or a single-flight coalescing change is required, that can be implemented in a small follow-up once telemetry confirms concurrent overlap in production call graphs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a622d8b95288324a98e8286b13a8ebf)