### PR TITLE
Instrument slow tick pipeline stages

### DIFF
--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -8417,316 +8417,312 @@ class MarketDataManager:
         tick_started = time.perf_counter()
         symbol_for_timing = str(raw.get("symbol") or "") or None
         source_for_timing = str(raw.get("source") or "ws")
-        stage_started = time.perf_counter()
-        raw = self._normalize_ws_tick(raw)
-        duration_ms = (time.perf_counter() - stage_started) * 1000.0
-        if duration_ms >= 50.0:
-            self._log_slow_tick_stage(
-                stage="normalize",
-                symbol=symbol_for_timing,
-                duration_ms=duration_ms,
-                source=source_for_timing,
-            )
-        if raw is None:
-            return
-        volume_delta_normalized = False
-        enqueued_mono = raw.get("_enqueued_monotonic")
-        if isinstance(enqueued_mono, (int, float)):
-            self._event_loop_lag_seconds = max(
-                0.0, time.monotonic() - float(enqueued_mono)
-            )
-        if not raw.get("symbol"):
-            token = raw.get("instrument_token")
-            if token is None:
-                return
-
-            token_int = int(token)
-            with self._lock:
-                symbol_from_map = self._symbol_by_token.get(token_int)
-
-            if not symbol_from_map:
-                log_throttled(
-                    self._logger,
-                    f"unmapped_token_{token_int}",
-                    "Unmapped token %s — tick dropped" % token_int,
-                    interval_sec=30.0,
-                    level=logging.WARNING,
-                )
-                return
-            raw = {**raw, "symbol": symbol_from_map}
-            raw = self._normalise_tick_volume_delta(
-                symbol_from_map or raw.get("symbol", ""), raw
-            )
-            volume_delta_normalized = True
-
-        symbol = str(raw.get("symbol") or "")
-        if symbol and not volume_delta_normalized:
-            raw = self._normalise_tick_volume_delta(symbol, raw)
-
         try:
-            tick = validate_tick(raw)
-        except DataIntegrityError as exc:
-            self._logger.debug("Tick validation failed: %s — dropped", exc)
-            return
-
-        symbol = tick.symbol
-        tick_ts = pd.to_datetime(tick.timestamp, utc=True, errors="coerce")
-        if pd.isna(tick_ts):
-            return
-
-        last_ts = self._last_tick_ts.get(symbol)
-        if last_ts is not None:
-            last_ts = pd.to_datetime(last_ts, utc=True, errors="coerce")
-            if not pd.isna(last_ts) and tick_ts < last_ts:
-                self._logger.debug(
-                    "MDM_TICK_DROPPED reason=older_timestamp symbol=%s ts=%s last=%s",
-                    symbol,
-                    tick_ts,
-                    last_ts,
-                )
-                return
-
-            if not pd.isna(last_ts) and tick_ts == last_ts:
-                last_snapshot = self._last_tick_snapshot.get(symbol, {})
-                same_price = float(last_snapshot.get("ltp", -1)) == float(tick.ltp)
-                same_volume = last_snapshot.get("volume") == raw.get(
-                    "volume_traded_today"
-                )
-
-                if same_price and same_volume:
-                    self._logger.debug(
-                        "MDM_TICK_DROPPED reason=duplicate_tick symbol=%s ts=%s",
-                        symbol,
-                        tick_ts,
-                    )
-                    return
-
-        stage_started = time.perf_counter()
-        self._last_tick_snapshot[symbol] = {
-            "ltp": tick.ltp,
-            "volume": raw.get("volume_traded_today") or raw.get("volume_traded"),
-        }
-        self._last_tick_ts[symbol] = tick_ts
-        duration_ms = (time.perf_counter() - stage_started) * 1000.0
-        if duration_ms >= 50.0:
-            self._log_slow_tick_stage(
-                stage="cache_update",
-                symbol=symbol,
-                duration_ms=duration_ms,
-                source=source_for_timing,
-            )
-        engine = self.get_candle_engine(symbol)
-        stage_started = time.perf_counter()
-        candle = engine.on_tick(tick)
-        duration_ms = (time.perf_counter() - stage_started) * 1000.0
-        if duration_ms >= 50.0:
-            self._log_slow_tick_stage(
-                stage="candle_engine_on_tick",
-                symbol=symbol,
-                duration_ms=duration_ms,
-                source=source_for_timing,
-            )
-        # ── EMIT TICK: replaces bare _store_tick call ─────────────────────────
-        # _emit_tick calls _store_tick internally AND dispatches to _subscribers.
-        # Before this fix: DataHub.subscribe_ticks() callbacks (including
-        # StrategyRunner's per-symbol callbacks) were registered in _subscribers
-        # but NEVER called from the WS path — _store_tick only cached the tick.
-        # _emit_tick is the correct call; it was defined but never invoked.
-        quote_fields = self._extract_depth_quote_fields(raw)
-        raw_safe = to_json_safe(dict(raw))
-        tick_safe = tick.to_dict()
-        tick_dict = {**raw_safe, **tick_safe, **quote_fields}
-        if "volume_delta" in raw_safe:
-            tick_dict["volume_delta"] = raw_safe.get("volume_delta")
-            tick_dict["volume"] = raw_safe.get("volume_delta")
-        elif "volume" in raw_safe:
-            tick_dict["volume"] = raw_safe.get("volume")
-            tick_dict["volume_delta"] = raw_safe.get("volume")
-        else:
-            tick_dict["volume"] = tick_safe.get("volume", 0)
-            tick_dict["volume_delta"] = tick_safe.get("volume", 0)
-        if "volume_cumulative" in raw_safe:
-            tick_dict["volume_cumulative"] = raw_safe.get("volume_cumulative")
-        elif "volume_traded_today" in raw_safe:
-            tick_dict["volume_cumulative"] = raw_safe.get("volume_traded_today")
-        elif "volume_traded" in raw_safe:
-            tick_dict["volume_cumulative"] = raw_safe.get("volume_traded")
-        tick_dict["symbol"] = symbol
-        tick_dict["timestamp"] = pd.to_datetime(
-            tick_dict["timestamp"], utc=True, errors="coerce"
-        ).isoformat()
-        token_value = raw.get("instrument_token") or raw.get("token")
-        if token_value is not None:
-            tick_dict["instrument_token"] = token_value
-        price_value = raw.get("last_price") or raw.get("ltp") or tick.ltp
-        tick_dict["last_price"] = price_value
-        tick_dict["ltp"] = tick.ltp
-        tick_dict["source"] = raw.get("source") or "ws"
-        tick_dict["timestamp_source"] = raw.get(
-            "timestamp_source", tick_dict.get("timestamp_source")
-        )
-        tick_dict["source_timestamp_valid"] = raw.get(
-            "source_timestamp_valid", tick_dict.get("source_timestamp_valid")
-        )
-        tick_dict["received_at"] = raw.get("received_at", time.time())
-        if raw.get("exchange_timestamp") is not None:
-            tick_dict["exchange_timestamp"] = raw.get("exchange_timestamp")
-        if raw.get("depth") is not None:
-            tick_dict["depth"] = raw.get("depth")
-
-        # Structured Logging for tick received (Objective 6)
-        try:
-            self._logger.debug(
-                "TICK_RECEIVED",
-                extra={
-                    "event": "tick_received",
-                    "symbol": symbol,
-                    "price": tick.ltp,
-                    "source": "ws",
-                    "token": token_value,
-                },
-            )
-        except Exception:
-            pass
-
-        normalized_live = self.normalize_live_tick(
-            tick_dict, source=str(tick_dict.get("source") or "ws")
-        )
-        if normalized_live is None:
-            return
-        stage_started = time.perf_counter()
-        self._ingest_normalized_tick(normalized_live)
-        duration_ms = (time.perf_counter() - stage_started) * 1000.0
-        if duration_ms >= 50.0:
-            self._log_slow_tick_stage(
-                stage="tick_publication",
-                symbol=symbol,
-                duration_ms=duration_ms,
-                source=str(normalized_live.get("source") or source_for_timing),
-            )
-        if bool(normalized_live.get("tradable_quote")):
-            # Log only on first quote, state transitions, or periodic debug interval.
-            # Routine per-tick proof logs are suppressed to avoid high-frequency spam.
-            _proof_state = getattr(self, "_ws_quote_proof_state", None)
-            if _proof_state is None:
-                self._ws_quote_proof_state: dict[str, dict] = {}
-                _proof_state = self._ws_quote_proof_state
-            _prev = _proof_state.get(symbol, {})
-            _cur_tradable = bool(normalized_live.get("tradable_quote"))
-            _cur_depth = bool(normalized_live.get("depth_available"))
-            _is_first = not _prev
-            _tradable_transition = _cur_tradable and not _prev.get(
-                "tradable_quote", False
-            )
-            _depth_transition = _cur_depth and not _prev.get("depth_available", False)
-            _proof_state[symbol] = {
-                "tradable_quote": _cur_tradable,
-                "depth_available": _cur_depth,
-            }
-            _should_emit_proof = _is_first or _tradable_transition or _depth_transition
-            if not _should_emit_proof and str(
-                os.getenv("LOG_QUOTE_PROOF_DEBUG", "false")
-            ).lower() in {"1", "true", "yes"}:
-                _proof_interval = float(
-                    os.getenv("LOG_QUOTE_PROOF_EVERY_SECONDS", "60") or "60"
-                )
-                _proof_throttle = getattr(self, "_ws_proof_throttle", None)
-                if _proof_throttle is None:
-                    self._ws_proof_throttle: dict[str, float] = {}
-                    _proof_throttle = self._ws_proof_throttle
-                import time as _t
-
-                _now_mono = _t.monotonic()
-                _last_proof = float(_proof_throttle.get(symbol, 0.0))
-                if _now_mono - _last_proof >= _proof_interval:
-                    _proof_throttle[symbol] = _now_mono
-                    _should_emit_proof = True
-            if _should_emit_proof:
-                log_throttled_live(
-                    self._logger,
-                    logging.INFO,
-                    "WS_FULL_QUOTE_PROOF",
-                    f"WS_FULL_QUOTE_PROOF:{symbol}",
-                    float(os.getenv("LOG_THROTTLE_WS_PROOF_SECONDS", "60") or "60"),
-                    "WS_FULL_QUOTE_PROOF symbol=%s token=%s ltp=%s bid=%s ask=%s spread=%s depth_available=%s tradable_quote=%s",
-                    symbol,
-                    token_value,
-                    normalized_live.get("ltp"),
-                    normalized_live.get("bid"),
-                    normalized_live.get("ask"),
-                    normalized_live.get("spread"),
-                    normalized_live.get("depth_available"),
-                    normalized_live.get("tradable_quote"),
-                    extra={"event": "WS_FULL_QUOTE_PROOF", "symbol": symbol},
-                )
-        if candle:
-            bar = {
-                "symbol": symbol,
-                "timestamp": (
-                    candle["timestamp"]
-                    if isinstance(candle, dict)
-                    else candle.timestamp
-                ),
-                "open": float(
-                    candle["open"] if isinstance(candle, dict) else candle.open
-                ),
-                "high": float(
-                    candle["high"] if isinstance(candle, dict) else candle.high
-                ),
-                "low": float(candle["low"] if isinstance(candle, dict) else candle.low),
-                "close": float(
-                    candle["close"] if isinstance(candle, dict) else candle.close
-                ),
-                "volume": int(
-                    float(
-                        (
-                            candle.get("volume", 0)
-                            if isinstance(candle, dict)
-                            else getattr(candle, "volume", 0)
-                        )
-                        or 0
-                    )
-                ),
-                "source": "ws_candle",
-            }
-            self._refresh_candle_projection(symbol)
             stage_started = time.perf_counter()
-            self._publish_closed_bar(bar)
+            raw = self._normalize_ws_tick(raw)
             duration_ms = (time.perf_counter() - stage_started) * 1000.0
             if duration_ms >= 50.0:
                 self._log_slow_tick_stage(
-                    stage="closed_bar_publication",
+                    stage="normalize",
+                    symbol=symbol_for_timing,
+                    duration_ms=duration_ms,
+                    source=source_for_timing,
+                )
+            if raw is None:
+                return
+            volume_delta_normalized = False
+            enqueued_mono = raw.get("_enqueued_monotonic")
+            if isinstance(enqueued_mono, (int, float)):
+                self._event_loop_lag_seconds = max(
+                    0.0, time.monotonic() - float(enqueued_mono)
+                )
+            if not raw.get("symbol"):
+                token = raw.get("instrument_token")
+                if token is None:
+                    return
+
+                token_int = int(token)
+                with self._lock:
+                    symbol_from_map = self._symbol_by_token.get(token_int)
+
+                if not symbol_from_map:
+                    log_throttled(
+                        self._logger,
+                        f"unmapped_token_{token_int}",
+                        "Unmapped token %s — tick dropped" % token_int,
+                        interval_sec=30.0,
+                        level=logging.WARNING,
+                    )
+                    return
+                raw = {**raw, "symbol": symbol_from_map}
+                raw = self._normalise_tick_volume_delta(
+                    symbol_from_map or raw.get("symbol", ""), raw
+                )
+                volume_delta_normalized = True
+
+            symbol = str(raw.get("symbol") or "")
+            if symbol:
+                symbol_for_timing = symbol
+            if symbol and not volume_delta_normalized:
+                raw = self._normalise_tick_volume_delta(symbol, raw)
+
+            try:
+                tick = validate_tick(raw)
+            except DataIntegrityError as exc:
+                self._logger.debug("Tick validation failed: %s — dropped", exc)
+                return
+
+            symbol = tick.symbol
+            symbol_for_timing = symbol
+            tick_ts = pd.to_datetime(tick.timestamp, utc=True, errors="coerce")
+            if pd.isna(tick_ts):
+                return
+
+            last_ts = self._last_tick_ts.get(symbol)
+            if last_ts is not None:
+                last_ts = pd.to_datetime(last_ts, utc=True, errors="coerce")
+                if not pd.isna(last_ts) and tick_ts < last_ts:
+                    self._logger.debug(
+                        "MDM_TICK_DROPPED reason=older_timestamp symbol=%s ts=%s last=%s",
+                        symbol,
+                        tick_ts,
+                        last_ts,
+                    )
+                    return
+
+                if not pd.isna(last_ts) and tick_ts == last_ts:
+                    last_snapshot = self._last_tick_snapshot.get(symbol, {})
+                    same_price = float(last_snapshot.get("ltp", -1)) == float(tick.ltp)
+                    same_volume = last_snapshot.get("volume") == raw.get(
+                        "volume_traded_today"
+                    )
+
+                    if same_price and same_volume:
+                        self._logger.debug(
+                            "MDM_TICK_DROPPED reason=duplicate_tick symbol=%s ts=%s",
+                            symbol,
+                            tick_ts,
+                        )
+                        return
+
+            stage_started = time.perf_counter()
+            self._last_tick_snapshot[symbol] = {
+                "ltp": tick.ltp,
+                "volume": raw.get("volume_traded_today") or raw.get("volume_traded"),
+            }
+            self._last_tick_ts[symbol] = tick_ts
+            duration_ms = (time.perf_counter() - stage_started) * 1000.0
+            if duration_ms >= 50.0:
+                self._log_slow_tick_stage(
+                    stage="cache_update",
                     symbol=symbol,
                     duration_ms=duration_ms,
                     source=source_for_timing,
                 )
-            verbose_candles = str(
-                os.getenv("LOG_VERBOSE_CANDLES", "false")
-            ).strip().lower() in {"1", "true", "yes", "y", "on"}
-            self._logger.log(
-                logging.INFO if verbose_candles else logging.DEBUG,
-                "LIVE_CANDLE_CLOSED symbol=%s source=ws_candle close=%s",
-                symbol,
-                bar["close"],
+            engine = self.get_candle_engine(symbol)
+            stage_started = time.perf_counter()
+            candle = engine.on_tick(tick)
+            duration_ms = (time.perf_counter() - stage_started) * 1000.0
+            if duration_ms >= 50.0:
+                self._log_slow_tick_stage(
+                    stage="candle_engine_on_tick",
+                    symbol=symbol,
+                    duration_ms=duration_ms,
+                    source=source_for_timing,
+                )
+            # ── EMIT TICK: replaces bare _store_tick call ─────────────────────────
+            # _emit_tick calls _store_tick internally AND dispatches to _subscribers.
+            # Before this fix: DataHub.subscribe_ticks() callbacks (including
+            # StrategyRunner's per-symbol callbacks) were registered in _subscribers
+            # but NEVER called from the WS path — _store_tick only cached the tick.
+            # _emit_tick is the correct call; it was defined but never invoked.
+            quote_fields = self._extract_depth_quote_fields(raw)
+            raw_safe = to_json_safe(dict(raw))
+            tick_safe = tick.to_dict()
+            tick_dict = {**raw_safe, **tick_safe, **quote_fields}
+            if "volume_delta" in raw_safe:
+                tick_dict["volume_delta"] = raw_safe.get("volume_delta")
+                tick_dict["volume"] = raw_safe.get("volume_delta")
+            elif "volume" in raw_safe:
+                tick_dict["volume"] = raw_safe.get("volume")
+                tick_dict["volume_delta"] = raw_safe.get("volume")
+            else:
+                tick_dict["volume"] = tick_safe.get("volume", 0)
+                tick_dict["volume_delta"] = tick_safe.get("volume", 0)
+            if "volume_cumulative" in raw_safe:
+                tick_dict["volume_cumulative"] = raw_safe.get("volume_cumulative")
+            elif "volume_traded_today" in raw_safe:
+                tick_dict["volume_cumulative"] = raw_safe.get("volume_traded_today")
+            elif "volume_traded" in raw_safe:
+                tick_dict["volume_cumulative"] = raw_safe.get("volume_traded")
+            tick_dict["symbol"] = symbol
+            tick_dict["timestamp"] = pd.to_datetime(
+                tick_dict["timestamp"], utc=True, errors="coerce"
+            ).isoformat()
+            token_value = raw.get("instrument_token") or raw.get("token")
+            if token_value is not None:
+                tick_dict["instrument_token"] = token_value
+            price_value = raw.get("last_price") or raw.get("ltp") or tick.ltp
+            tick_dict["last_price"] = price_value
+            tick_dict["ltp"] = tick.ltp
+            tick_dict["source"] = raw.get("source") or "ws"
+            tick_dict["timestamp_source"] = raw.get(
+                "timestamp_source", tick_dict.get("timestamp_source")
             )
-
-        tick_duration_ms = (time.perf_counter() - tick_started) * 1000.0
-        if tick_duration_ms >= 100.0:
-            self._log_slow_tick_stage(
-                stage="one_tick",
-                symbol=symbol,
-                duration_ms=tick_duration_ms,
-                source=source_for_timing,
+            tick_dict["source_timestamp_valid"] = raw.get(
+                "source_timestamp_valid", tick_dict.get("source_timestamp_valid")
             )
+            tick_dict["received_at"] = raw.get("received_at", time.time())
+            if raw.get("exchange_timestamp") is not None:
+                tick_dict["exchange_timestamp"] = raw.get("exchange_timestamp")
+            if raw.get("depth") is not None:
+                tick_dict["depth"] = raw.get("depth")
 
-        # ── PIPELINE SYNC (closed bars only) ─────────────────────────────────
-        # MDM is the single runtime candle builder. The deterministic pipeline
-        # store is populated from MDM's CLOSED bars via _publish_closed_bar →
-        # _push_bar_to_pipeline, so pipeline.candles_ready()/get_candles()
-        # reflect exactly the same candles as MDM. The former per-tick feed
-        # here made the pipeline a second live candle builder fed from two
-        # racing paths (MDM consumer + runner), causing out-of-order drops
-        # and readiness flapping.
+            # Structured Logging for tick received (Objective 6)
+            try:
+                self._logger.debug(
+                    "TICK_RECEIVED",
+                    extra={
+                        "event": "tick_received",
+                        "symbol": symbol,
+                        "price": tick.ltp,
+                        "source": "ws",
+                        "token": token_value,
+                    },
+                )
+            except Exception:
+                pass
+
+            normalized_live = self.normalize_live_tick(
+                tick_dict, source=str(tick_dict.get("source") or "ws")
+            )
+            if normalized_live is None:
+                return
+            stage_started = time.perf_counter()
+            self._ingest_normalized_tick(normalized_live)
+            duration_ms = (time.perf_counter() - stage_started) * 1000.0
+            if duration_ms >= 50.0:
+                self._log_slow_tick_stage(
+                    stage="tick_publication",
+                    symbol=symbol,
+                    duration_ms=duration_ms,
+                    source=str(normalized_live.get("source") or source_for_timing),
+                )
+            if bool(normalized_live.get("tradable_quote")):
+                # Log only on first quote, state transitions, or periodic debug interval.
+                # Routine per-tick proof logs are suppressed to avoid high-frequency spam.
+                _proof_state = getattr(self, "_ws_quote_proof_state", None)
+                if _proof_state is None:
+                    self._ws_quote_proof_state: dict[str, dict] = {}
+                    _proof_state = self._ws_quote_proof_state
+                _prev = _proof_state.get(symbol, {})
+                _cur_tradable = bool(normalized_live.get("tradable_quote"))
+                _cur_depth = bool(normalized_live.get("depth_available"))
+                _is_first = not _prev
+                _tradable_transition = _cur_tradable and not _prev.get(
+                    "tradable_quote", False
+                )
+                _depth_transition = _cur_depth and not _prev.get("depth_available", False)
+                _proof_state[symbol] = {
+                    "tradable_quote": _cur_tradable,
+                    "depth_available": _cur_depth,
+                }
+                _should_emit_proof = _is_first or _tradable_transition or _depth_transition
+                if not _should_emit_proof and str(
+                    os.getenv("LOG_QUOTE_PROOF_DEBUG", "false")
+                ).lower() in {"1", "true", "yes"}:
+                    _proof_interval = float(
+                        os.getenv("LOG_QUOTE_PROOF_EVERY_SECONDS", "60") or "60"
+                    )
+                    _proof_throttle = getattr(self, "_ws_proof_throttle", None)
+                    if _proof_throttle is None:
+                        self._ws_proof_throttle: dict[str, float] = {}
+                        _proof_throttle = self._ws_proof_throttle
+                    import time as _t
+
+                    _now_mono = _t.monotonic()
+                    _last_proof = float(_proof_throttle.get(symbol, 0.0))
+                    if _now_mono - _last_proof >= _proof_interval:
+                        _proof_throttle[symbol] = _now_mono
+                        _should_emit_proof = True
+                if _should_emit_proof:
+                    log_throttled_live(
+                        self._logger,
+                        logging.INFO,
+                        "WS_FULL_QUOTE_PROOF",
+                        f"WS_FULL_QUOTE_PROOF:{symbol}",
+                        float(os.getenv("LOG_THROTTLE_WS_PROOF_SECONDS", "60") or "60"),
+                        "WS_FULL_QUOTE_PROOF symbol=%s token=%s ltp=%s bid=%s ask=%s spread=%s depth_available=%s tradable_quote=%s",
+                        symbol,
+                        token_value,
+                        normalized_live.get("ltp"),
+                        normalized_live.get("bid"),
+                        normalized_live.get("ask"),
+                        normalized_live.get("spread"),
+                        normalized_live.get("depth_available"),
+                        normalized_live.get("tradable_quote"),
+                        extra={"event": "WS_FULL_QUOTE_PROOF", "symbol": symbol},
+                    )
+            if candle:
+                bar = {
+                    "symbol": symbol,
+                    "timestamp": (
+                        candle["timestamp"]
+                        if isinstance(candle, dict)
+                        else candle.timestamp
+                    ),
+                    "open": float(
+                        candle["open"] if isinstance(candle, dict) else candle.open
+                    ),
+                    "high": float(
+                        candle["high"] if isinstance(candle, dict) else candle.high
+                    ),
+                    "low": float(candle["low"] if isinstance(candle, dict) else candle.low),
+                    "close": float(
+                        candle["close"] if isinstance(candle, dict) else candle.close
+                    ),
+                    "volume": int(
+                        float(
+                            (
+                                candle.get("volume", 0)
+                                if isinstance(candle, dict)
+                                else getattr(candle, "volume", 0)
+                            )
+                            or 0
+                        )
+                    ),
+                    "source": "ws_candle",
+                }
+                self._refresh_candle_projection(symbol)
+                self._publish_closed_bar(bar)
+                verbose_candles = str(
+                    os.getenv("LOG_VERBOSE_CANDLES", "false")
+                ).strip().lower() in {"1", "true", "yes", "y", "on"}
+                self._logger.log(
+                    logging.INFO if verbose_candles else logging.DEBUG,
+                    "LIVE_CANDLE_CLOSED symbol=%s source=ws_candle close=%s",
+                    symbol,
+                    bar["close"],
+                )
+
+            # ── PIPELINE SYNC (closed bars only) ─────────────────────────────────
+            # MDM is the single runtime candle builder. The deterministic pipeline
+            # store is populated from MDM's CLOSED bars via _publish_closed_bar →
+            # _push_bar_to_pipeline, so pipeline.candles_ready()/get_candles()
+            # reflect exactly the same candles as MDM. The former per-tick feed
+            # here made the pipeline a second live candle builder fed from two
+            # racing paths (MDM consumer + runner), causing out-of-order drops
+            # and readiness flapping.
+
+        finally:
+            tick_duration_ms = (time.perf_counter() - tick_started) * 1000.0
+            if tick_duration_ms >= 100.0:
+                self._log_slow_tick_stage(
+                    stage="one_tick",
+                    symbol=symbol_for_timing,
+                    duration_ms=tick_duration_ms,
+                    source=source_for_timing,
+                )
 
     def get_candle_engine(self, symbol: str) -> CandleEngine:
         """Return the authoritative CandleEngine for a canonicalized symbol."""
@@ -13186,8 +13182,7 @@ class MarketDataManager:
         observed_at = payload.pop("_local_timestamp", None)
         received_at = (
             float(observed_at)
-            if isinstance(observed_at, (int, float))
-            and not isinstance(observed_at, bool)
+            if isinstance(observed_at, (int, float)) and not isinstance(observed_at, bool)
             else time.time()
         )
         payload["source"] = source
@@ -13929,25 +13924,15 @@ class MarketDataManager:
                     }.values()
                 )
                 deduped.sort(key=lambda item: item["timestamp"])
-                if (
-                    min_rows > 0
-                    and len(deduped) < min_rows
-                    and attempt_name != attempt_specs[-1][0]
-                ):
+                if min_rows > 0 and len(deduped) < min_rows and attempt_name != attempt_specs[-1][0]:
                     if len(deduped) > len(best_so_far):
                         best_so_far = deduped
                         best_attempt_meta = (
-                            attempt_name,
-                            from_date,
-                            to_date,
-                            len(rows),
+                            attempt_name, from_date, to_date, len(rows)
                         )
                     self._logger.info(
                         "HYDRATION_ATTEMPT_INSUFFICIENT_WIDENING symbol=%s attempt=%s returned_rows=%s min_rows=%s",
-                        symbol,
-                        attempt_name,
-                        len(deduped),
-                        min_rows,
+                        symbol, attempt_name, len(deduped), min_rows,
                         extra={
                             "event": "HYDRATION_ATTEMPT_INSUFFICIENT_WIDENING",
                             "symbol": symbol,

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -1452,16 +1452,18 @@ class MarketDataManager:
         for cb in list(self._bar_subscribers):
             try:
                 stage_started = time.perf_counter()
-                cb(dict(bar))
-                duration_ms = (time.perf_counter() - stage_started) * 1000.0
-                if duration_ms >= 50.0:
-                    self._log_slow_tick_stage(
-                        stage="closed_bar_subscriber_callback",
-                        symbol=symbol,
-                        duration_ms=duration_ms,
-                        source=str(bar.get("source") or "ws_candle"),
-                        callback=cb,
-                    )
+                try:
+                    cb(dict(bar))
+                finally:
+                    duration_ms = (time.perf_counter() - stage_started) * 1000.0
+                    if duration_ms >= 50.0:
+                        self._log_slow_tick_stage(
+                            stage="closed_bar_subscriber_callback",
+                            symbol=symbol,
+                            duration_ms=duration_ms,
+                            source=str(bar.get("source") or "ws_candle"),
+                            callback=cb,
+                        )
             except Exception as exc:
                 callback_name = getattr(cb, "__qualname__", repr(cb))
                 log_throttled(
@@ -9713,16 +9715,18 @@ class MarketDataManager:
                         )
                 else:
                     stage_started = time.perf_counter()
-                    result = callback(dict(tick_payload))
-                    duration_ms = (time.perf_counter() - stage_started) * 1000.0
-                    if duration_ms >= 50.0:
-                        self._log_slow_tick_stage(
-                            stage="tick_subscriber_callback",
-                            symbol=symbol,
-                            duration_ms=duration_ms,
-                            source=source,
-                            callback=callback,
-                        )
+                    try:
+                        result = callback(dict(tick_payload))
+                    finally:
+                        duration_ms = (time.perf_counter() - stage_started) * 1000.0
+                        if duration_ms >= 50.0:
+                            self._log_slow_tick_stage(
+                                stage="tick_subscriber_callback",
+                                symbol=symbol,
+                                duration_ms=duration_ms,
+                                source=source,
+                                callback=callback,
+                            )
                     self._dispatch_awaitable_callback_result(
                         result,
                         symbol=symbol,

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -1438,12 +1438,31 @@ class MarketDataManager:
 
     def _publish_closed_bar(self, bar: dict[str, Any]) -> None:
         """Args: bar. Returns: None. Raises: None."""
+        symbol = str(bar.get("symbol") or "")
+        stage_started = time.perf_counter()
         self._push_bar_to_pipeline(bar)
+        duration_ms = (time.perf_counter() - stage_started) * 1000.0
+        if duration_ms >= 50.0:
+            self._log_slow_tick_stage(
+                stage="closed_bar_pipeline_push",
+                symbol=symbol,
+                duration_ms=duration_ms,
+                source=str(bar.get("source") or "ws_candle"),
+            )
         for cb in list(self._bar_subscribers):
             try:
+                stage_started = time.perf_counter()
                 cb(dict(bar))
+                duration_ms = (time.perf_counter() - stage_started) * 1000.0
+                if duration_ms >= 50.0:
+                    self._log_slow_tick_stage(
+                        stage="closed_bar_subscriber_callback",
+                        symbol=symbol,
+                        duration_ms=duration_ms,
+                        source=str(bar.get("source") or "ws_candle"),
+                        callback=cb,
+                    )
             except Exception as exc:
-                symbol = str(bar.get("symbol") or "")
                 callback_name = getattr(cb, "__qualname__", repr(cb))
                 log_throttled(
                     self._logger,
@@ -7196,6 +7215,84 @@ class MarketDataManager:
                     self._pending_far_ticks[key] = raw
                     self._pending_increment_locked(raw, key)
 
+    @staticmethod
+    def _tick_callback_identity(callback: Callable[..., Any]) -> str:
+        bound_self = getattr(callback, "__self__", None)
+        module = getattr(callback, "__module__", type(callback).__module__)
+        name = getattr(
+            callback,
+            "__qualname__",
+            getattr(callback, "__name__", type(callback).__name__),
+        )
+        if bound_self is not None and not isinstance(bound_self, type):
+            cls_name = type(bound_self).__name__
+            leaf = getattr(callback, "__name__", name.rsplit(".", 1)[-1])
+            return f"{module}.{cls_name}.{leaf}"
+        return f"{module}.{name}"
+
+    def _log_slow_tick_stage(
+        self,
+        *,
+        stage: str,
+        symbol: str | None,
+        duration_ms: float,
+        source: str | None = None,
+        callback: Callable[..., Any] | str | None = None,
+    ) -> None:
+        callback_name = (
+            self._tick_callback_identity(callback)
+            if callable(callback)
+            else (str(callback) if callback else None)
+        )
+        pending_ticks = 0
+        oldest_pending_age_ms = None
+        drain_active = 0
+        with self._pending_tick_lock:
+            pending_ticks = self._pending_count_locked()
+            oldest_pending_age_ms = (
+                self._oldest_pending_age_ms_locked() if pending_ticks else None
+            )
+            drain_active = int(self._tick_active_drains)
+        thread_id = threading.get_ident()
+        event_loop_thread = thread_id == getattr(self, "_event_loop_thread_id", None)
+        key = f"tick_stage_slow:{stage}:{callback_name or ''}:{symbol or ''}"
+        log_throttled(
+            self._logger,
+            key,
+            "TICK_STAGE_SLOW stage=%s callback=%s symbol=%s duration_ms=%.3f pending_ticks=%d oldest_pending_age_ms=%s drain_active=%d source=%s thread_id=%s event_loop_thread=%s"
+            % (
+                stage,
+                callback_name,
+                symbol,
+                duration_ms,
+                pending_ticks,
+                (
+                    None
+                    if oldest_pending_age_ms is None
+                    else round(oldest_pending_age_ms, 3)
+                ),
+                drain_active,
+                source,
+                thread_id,
+                event_loop_thread,
+            ),
+            interval_sec=10.0,
+            level=logging.WARNING,
+            extra={
+                "event": "TICK_STAGE_SLOW",
+                "stage": stage,
+                "callback": callback_name,
+                "symbol": symbol,
+                "duration_ms": duration_ms,
+                "pending_ticks": pending_ticks,
+                "oldest_pending_age_ms": oldest_pending_age_ms,
+                "drain_active": drain_active,
+                "source": source,
+                "thread_id": thread_id,
+                "event_loop_thread": event_loop_thread,
+            },
+        )
+
     async def _drain_latest_ticks(self) -> None:
         drain_started = time.monotonic()
         with self._pending_tick_lock:
@@ -7237,6 +7334,7 @@ class MarketDataManager:
                 self._last_drain_duration_ms = max(
                     0.0, (time.monotonic() - drain_started) * 1000.0
                 )
+                drain_duration_ms = self._last_drain_duration_ms
                 self._tick_active_drains = max(0, self._tick_active_drains - 1)
                 self._update_pipeline_overload_locked()
                 has_more = self._pending_count_locked() > 0
@@ -7250,6 +7348,13 @@ class MarketDataManager:
                     and loop.is_running()
                 ):
                     self._schedule_tick_drain_locked(loop)
+            if drain_duration_ms >= 100.0:
+                self._log_slow_tick_stage(
+                    stage="drain_invocation",
+                    symbol=None,
+                    duration_ms=drain_duration_ms,
+                    source=None,
+                )
 
     async def drain_pending_ticks(self, *, timeout: float = 5.0) -> None:
         deadline = time.monotonic() + max(0.0, timeout)
@@ -8309,7 +8414,19 @@ class MarketDataManager:
         return payload
 
     def _process_queued_tick(self, raw: dict[str, Any]) -> None:
+        tick_started = time.perf_counter()
+        symbol_for_timing = str(raw.get("symbol") or "") or None
+        source_for_timing = str(raw.get("source") or "ws")
+        stage_started = time.perf_counter()
         raw = self._normalize_ws_tick(raw)
+        duration_ms = (time.perf_counter() - stage_started) * 1000.0
+        if duration_ms >= 50.0:
+            self._log_slow_tick_stage(
+                stage="normalize",
+                symbol=symbol_for_timing,
+                duration_ms=duration_ms,
+                source=source_for_timing,
+            )
         if raw is None:
             return
         volume_delta_normalized = False
@@ -8384,13 +8501,31 @@ class MarketDataManager:
                     )
                     return
 
+        stage_started = time.perf_counter()
         self._last_tick_snapshot[symbol] = {
             "ltp": tick.ltp,
             "volume": raw.get("volume_traded_today") or raw.get("volume_traded"),
         }
         self._last_tick_ts[symbol] = tick_ts
+        duration_ms = (time.perf_counter() - stage_started) * 1000.0
+        if duration_ms >= 50.0:
+            self._log_slow_tick_stage(
+                stage="cache_update",
+                symbol=symbol,
+                duration_ms=duration_ms,
+                source=source_for_timing,
+            )
         engine = self.get_candle_engine(symbol)
+        stage_started = time.perf_counter()
         candle = engine.on_tick(tick)
+        duration_ms = (time.perf_counter() - stage_started) * 1000.0
+        if duration_ms >= 50.0:
+            self._log_slow_tick_stage(
+                stage="candle_engine_on_tick",
+                symbol=symbol,
+                duration_ms=duration_ms,
+                source=source_for_timing,
+            )
         # ── EMIT TICK: replaces bare _store_tick call ─────────────────────────
         # _emit_tick calls _store_tick internally AND dispatches to _subscribers.
         # Before this fix: DataHub.subscribe_ticks() callbacks (including
@@ -8459,7 +8594,16 @@ class MarketDataManager:
         )
         if normalized_live is None:
             return
+        stage_started = time.perf_counter()
         self._ingest_normalized_tick(normalized_live)
+        duration_ms = (time.perf_counter() - stage_started) * 1000.0
+        if duration_ms >= 50.0:
+            self._log_slow_tick_stage(
+                stage="tick_publication",
+                symbol=symbol,
+                duration_ms=duration_ms,
+                source=str(normalized_live.get("source") or source_for_timing),
+            )
         if bool(normalized_live.get("tradable_quote")):
             # Log only on first quote, state transitions, or periodic debug interval.
             # Routine per-tick proof logs are suppressed to avoid high-frequency spam.
@@ -8546,7 +8690,16 @@ class MarketDataManager:
                 "source": "ws_candle",
             }
             self._refresh_candle_projection(symbol)
+            stage_started = time.perf_counter()
             self._publish_closed_bar(bar)
+            duration_ms = (time.perf_counter() - stage_started) * 1000.0
+            if duration_ms >= 50.0:
+                self._log_slow_tick_stage(
+                    stage="closed_bar_publication",
+                    symbol=symbol,
+                    duration_ms=duration_ms,
+                    source=source_for_timing,
+                )
             verbose_candles = str(
                 os.getenv("LOG_VERBOSE_CANDLES", "false")
             ).strip().lower() in {"1", "true", "yes", "y", "on"}
@@ -8555,6 +8708,15 @@ class MarketDataManager:
                 "LIVE_CANDLE_CLOSED symbol=%s source=ws_candle close=%s",
                 symbol,
                 bar["close"],
+            )
+
+        tick_duration_ms = (time.perf_counter() - tick_started) * 1000.0
+        if tick_duration_ms >= 100.0:
+            self._log_slow_tick_stage(
+                stage="one_tick",
+                symbol=symbol,
+                duration_ms=tick_duration_ms,
+                source=source_for_timing,
             )
 
         # ── PIPELINE SYNC (closed bars only) ─────────────────────────────────
@@ -9554,7 +9716,17 @@ class MarketDataManager:
                             },
                         )
                 else:
+                    stage_started = time.perf_counter()
                     result = callback(dict(tick_payload))
+                    duration_ms = (time.perf_counter() - stage_started) * 1000.0
+                    if duration_ms >= 50.0:
+                        self._log_slow_tick_stage(
+                            stage="tick_subscriber_callback",
+                            symbol=symbol,
+                            duration_ms=duration_ms,
+                            source=source,
+                            callback=callback,
+                        )
                     self._dispatch_awaitable_callback_result(
                         result,
                         symbol=symbol,
@@ -13014,7 +13186,8 @@ class MarketDataManager:
         observed_at = payload.pop("_local_timestamp", None)
         received_at = (
             float(observed_at)
-            if isinstance(observed_at, (int, float)) and not isinstance(observed_at, bool)
+            if isinstance(observed_at, (int, float))
+            and not isinstance(observed_at, bool)
             else time.time()
         )
         payload["source"] = source
@@ -13756,15 +13929,25 @@ class MarketDataManager:
                     }.values()
                 )
                 deduped.sort(key=lambda item: item["timestamp"])
-                if min_rows > 0 and len(deduped) < min_rows and attempt_name != attempt_specs[-1][0]:
+                if (
+                    min_rows > 0
+                    and len(deduped) < min_rows
+                    and attempt_name != attempt_specs[-1][0]
+                ):
                     if len(deduped) > len(best_so_far):
                         best_so_far = deduped
                         best_attempt_meta = (
-                            attempt_name, from_date, to_date, len(rows)
+                            attempt_name,
+                            from_date,
+                            to_date,
+                            len(rows),
                         )
                     self._logger.info(
                         "HYDRATION_ATTEMPT_INSUFFICIENT_WIDENING symbol=%s attempt=%s returned_rows=%s min_rows=%s",
-                        symbol, attempt_name, len(deduped), min_rows,
+                        symbol,
+                        attempt_name,
+                        len(deduped),
+                        min_rows,
                         extra={
                             "event": "HYDRATION_ATTEMPT_INSUFFICIENT_WIDENING",
                             "symbol": symbol,

--- a/tests/data/test_mdm_tick_coalescing.py
+++ b/tests/data/test_mdm_tick_coalescing.py
@@ -1856,3 +1856,79 @@ def test_dynamic_basket_old_ticks_do_not_churn_generation_during_grace(monkeypat
         )["ready"]
         is False
     )
+
+
+def test_slow_tick_subscriber_is_identified_without_tick_accounting_loss(caplog):
+    mdm = _make_mdm()
+    symbol = "NFO:NIFTY26JUN24000CE"
+    mdm._desired_tokens.add(1)
+    mdm._active_subscribed_symbols.add(symbol)
+    mdm._symbol_subscription_generation[symbol] = mdm._subscription_generation
+    mdm._event_loop_thread_id = threading.get_ident()
+    calls: list[dict] = []
+
+    class SlowSubscriber:
+        def on_tick(self, tick: dict) -> None:
+            time.sleep(0.15)
+            calls.append(tick)
+
+    subscriber = SlowSubscriber()
+    mdm.subscribe(symbol, subscriber.on_tick)
+
+    with caplog.at_level("WARNING"):
+        mdm._process_queued_tick(_ws_tick(1, 100.0, 1, volume=10, bid=99.5, ask=100.5))
+
+    assert len(calls) == 1
+    assert mdm.get_tick_pressure_stats()["max_active_drains"] == 0
+    records = [
+        r for r in caplog.records if getattr(r, "event", "") == "TICK_STAGE_SLOW"
+    ]
+    assert any(
+        getattr(r, "stage", None) == "tick_subscriber_callback"
+        and getattr(r, "callback", "").endswith("SlowSubscriber.on_tick")
+        and getattr(r, "duration_ms", 0.0) >= 100.0
+        for r in records
+    )
+    assert any(getattr(r, "stage", None) == "one_tick" for r in records)
+
+
+@pytest.mark.asyncio
+async def test_slow_subscriber_exception_isolated_and_drain_continues(caplog):
+    mdm = _make_mdm()
+    symbol = "NFO:NIFTY26JUN24000CE"
+    mdm._desired_tokens.add(1)
+    mdm._active_subscribed_symbols.add(symbol)
+    mdm._symbol_subscription_generation[symbol] = mdm._subscription_generation
+    mdm._cached_selected_option_symbols = {symbol}
+    mdm._priority_context_cached_at = time.monotonic()
+    mdm.set_event_loop(asyncio.get_running_loop())
+    seen: list[float] = []
+
+    def delayed_failure(_tick: dict) -> None:
+        time.sleep(0.06)
+        raise RuntimeError("subscriber boom")
+
+    def observer(tick: dict) -> None:
+        seen.append(float(tick["last_price"]))
+
+    mdm.subscribe(symbol, delayed_failure)
+    mdm.subscribe(symbol, observer)
+
+    with caplog.at_level("WARNING"):
+        mdm._enqueue_latest_tick_for_drain(
+            _ws_tick(1, 100.0, 1, volume=10, bid=99.5, ask=100.5),
+            asyncio.get_running_loop(),
+        )
+        mdm._enqueue_latest_tick_for_drain(
+            _ws_tick(1, 101.0, 2, volume=11, bid=100.5, ask=101.5),
+            asyncio.get_running_loop(),
+        )
+        await mdm.drain_pending_ticks(timeout=2.0)
+
+    assert seen == [100.0, 101.0]
+    stats = mdm.get_tick_pressure_stats()
+    assert stats["pending_tick_count"] == 0
+    assert stats["max_active_drains"] == 1
+    assert any("Tick callback failed" in r.getMessage() for r in caplog.records)
+    assert any(getattr(r, "event", "") == "TICK_STAGE_SLOW" for r in caplog.records)
+    await _stop_mdm(mdm)

--- a/tests/data/test_mdm_tick_coalescing.py
+++ b/tests/data/test_mdm_tick_coalescing.py
@@ -1932,3 +1932,26 @@ async def test_slow_subscriber_exception_isolated_and_drain_continues(caplog):
     assert any("Tick callback failed" in r.getMessage() for r in caplog.records)
     assert any(getattr(r, "event", "") == "TICK_STAGE_SLOW" for r in caplog.records)
     await _stop_mdm(mdm)
+
+
+def test_full_one_tick_timing_covers_early_normalization_return(monkeypatch, caplog):
+    mdm = _make_mdm()
+    mdm._event_loop_thread_id = threading.get_ident()
+
+    def slow_drop(_raw: dict):
+        time.sleep(0.11)
+        return None
+
+    monkeypatch.setattr(mdm, "_normalize_ws_tick", slow_drop)
+
+    symbol = "NFO:NIFTY26JUN24100PE"
+
+    with caplog.at_level("WARNING"):
+        mdm._process_queued_tick({"symbol": symbol, "source": "ws"})
+
+    assert any(
+        getattr(r, "event", "") == "TICK_STAGE_SLOW"
+        and getattr(r, "stage", None) == "one_tick"
+        and getattr(r, "symbol", None) == symbol
+        for r in caplog.records
+    )

--- a/tests/data/test_mdm_tick_coalescing.py
+++ b/tests/data/test_mdm_tick_coalescing.py
@@ -1930,7 +1930,17 @@ async def test_slow_subscriber_exception_isolated_and_drain_continues(caplog):
     assert stats["pending_tick_count"] == 0
     assert stats["max_active_drains"] == 1
     assert any("Tick callback failed" in r.getMessage() for r in caplog.records)
-    assert any(getattr(r, "event", "") == "TICK_STAGE_SLOW" for r in caplog.records)
+    slow_records = [
+        record
+        for record in caplog.records
+        if getattr(record, "event", "") == "TICK_STAGE_SLOW"
+        and getattr(record, "stage", None) == "tick_subscriber_callback"
+    ]
+    assert any(
+        getattr(record, "callback", "").endswith("delayed_failure")
+        and getattr(record, "duration_ms", 0.0) >= 50.0
+        for record in slow_records
+    )
     await _stop_mdm(mdm)
 
 
@@ -1954,4 +1964,41 @@ def test_full_one_tick_timing_covers_early_normalization_return(monkeypatch, cap
         and getattr(r, "stage", None) == "one_tick"
         and getattr(r, "symbol", None) == symbol
         for r in caplog.records
+    )
+
+
+def test_slow_closed_bar_subscriber_that_raises_is_identified(caplog):
+    mdm = _make_mdm()
+    symbol = "NFO:NIFTY26JUN24000CE"
+
+    def delayed_bar_failure(_bar: dict) -> None:
+        time.sleep(0.06)
+        raise RuntimeError("bar subscriber boom")
+
+    mdm.subscribe_bars(delayed_bar_failure)
+    bar = {
+        "symbol": symbol,
+        "timestamp": "2026-06-30T09:16:00+00:00",
+        "open": 100.0,
+        "high": 101.0,
+        "low": 99.0,
+        "close": 100.5,
+        "volume": 10,
+        "source": "ws_candle",
+    }
+
+    with caplog.at_level("WARNING"):
+        mdm._publish_closed_bar(bar)
+
+    assert any("BAR_SUBSCRIBER_FAILED" in r.getMessage() for r in caplog.records)
+    slow_records = [
+        record
+        for record in caplog.records
+        if getattr(record, "event", "") == "TICK_STAGE_SLOW"
+        and getattr(record, "stage", None) == "closed_bar_subscriber_callback"
+    ]
+    assert any(
+        getattr(record, "callback", "").endswith("delayed_bar_failure")
+        and getattr(record, "duration_ms", 0.0) >= 50.0
+        for record in slow_records
     )


### PR DESCRIPTION
### Motivation
- Production observed EVENT_LOOP_LAG_HIGH and stale ticks caused by a single dequeued tick running an unbounded synchronous downstream callback chain that blocks the drain rescheduling; add minimal, cheap timing to identify the blocking stage before changing runtime behavior. 
- Keep all safety, candle semantics, strategy/risk/execution invariants unchanged while obtaining deterministic evidence and test coverage for the structural defect.

### Description
- Added a small private helper `_log_slow_tick_stage(...)` and `_tick_callback_identity(...)` in `MarketDataManager` to emit structured `TICK_STAGE_SLOW` telemetry when a stage exceeds thresholds. 
- Instrumented only the major existing stages in `src/nifty_scalper_bot/data/market_data_manager.py`: tick normalization, canonical/latest-tick cache update, `CandleEngine.on_tick`, tick publication (`_ingest_normalized_tick`), per-subscriber synchronous callback execution, closed-bar pipeline push and closed-bar subscriber callbacks, full one-tick duration, and full drain invocation duration; logs only when stage >= 50 ms or tick/drain thresholds are exceeded. 
- Observability includes stable callback identity (module.class.func or Class.method), symbol, duration_ms, pending tick pressure, oldest pending age, drain active count, source, thread id and an event-loop-thread boolean, and reuses existing `log_throttled` to avoid spam. 
- Preserved invariants and constraints: no new modules, no worker pools, no parallel candle processing, no strategy/risk/execution changes, and no change to queue/coalescing/overload semantics. 
- Added focused tests in `tests/data/test_mdm_tick_coalescing.py` that (1) simulate a slow synchronous subscriber and assert `TICK_STAGE_SLOW` records the callback identity and one-tick duration, and (2) simulate a delayed subscriber exception and assert exception isolation, drain continuation and accounting.

### Testing
- Ran compilation: `python -m compileall -q src tests` which completed successfully. 
- Ran focused tests: `python -m pytest -q tests/data/test_mdm_tick_coalescing.py tests/data/test_market_data_hardening.py tests/test_no_history_fetch_in_tick_path.py` which passed. 
- Ran broader suites individually: `python -m pytest -q tests/data`, `python -m pytest -q tests/strategies`, and `python -m pytest -q tests/execution` all passed; an initial chained invocation hit a transient `OSError: Too many open files` during pytest tmpdir cleanup, after which the suites were re-run individually and passed. 
- Ran live-sim markers: `python -m pytest -q -m live_runtime_e2e tests/e2e/live_sim` passed. 
- Performed a 50,000-tick synthetic burst harness (via `PYTHONPATH=src python - <<'PY' ...`): observed max_active_drains == 1, unexplained tick loss == 0, and metrics: submitted=50000, processed=15909, coalesced=34091, dropped=0, pending=0, max_pending_ticks=3196, max_oldest_pending_age_ms≈439.5, max_event_loop_heartbeat_delay_ms≈475.9; runner evaluations per symbol were recorded and duplicate-signal/order counts were 0. 
- New tests added pass and prove the telemetry identifies a slow synchronous subscriber and that subscriber exceptions are isolated while draining continues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a62ef8c00648324b9e0d8f569d57366)