### PR TITLE
Fix false unresolved_exit_position blocker using broker exposure + reconcile flat brackets

### DIFF
--- a/src/nifty_scalper_bot/execution/bracket_core.py
+++ b/src/nifty_scalper_bot/execution/bracket_core.py
@@ -2161,8 +2161,12 @@ class BracketManager:
                 bracket.exit_correlation_id = None
                 bracket.last_exit_error = exc_message
                 bracket.exit_state = BracketExitLifecycle.EXIT_REJECTED_RETRYABLE.value
-                bracket.entry_status = BracketExitLifecycle.EXIT_REJECTED_RETRYABLE.value
-                bracket.next_exit_attempt_at = time.time() + self._retry_delay_for_attempt(attempt)
+                bracket.entry_status = (
+                    BracketExitLifecycle.EXIT_REJECTED_RETRYABLE.value
+                )
+                bracket.next_exit_attempt_at = (
+                    time.time() + self._retry_delay_for_attempt(attempt)
+                )
             LOGGER.error(
                 "EXIT_PROVISIONAL_REGISTRATION_FAILED bracket_id=%s symbol=%s correlation_id=%s attempt=%s exception_type=%s exception_message=%s",
                 bracket.bracket_id,
@@ -2186,7 +2190,8 @@ class BracketManager:
             registrar(
                 correlation_id,
                 symbol,
-                bracket.expected_exit_side or ("SELL" if bracket.side == "BUY" else "BUY"),
+                bracket.expected_exit_side
+                or ("SELL" if bracket.side == "BUY" else "BUY"),
                 qty,
                 float(bracket.last_ltp or bracket.entry_price or 0.0),
                 "LIMIT",
@@ -2203,8 +2208,12 @@ class BracketManager:
                 bracket.exit_correlation_id = None
                 bracket.last_exit_error = str(exc)
                 bracket.exit_state = BracketExitLifecycle.EXIT_REJECTED_RETRYABLE.value
-                bracket.entry_status = BracketExitLifecycle.EXIT_REJECTED_RETRYABLE.value
-                bracket.next_exit_attempt_at = time.time() + self._retry_delay_for_attempt(attempt)
+                bracket.entry_status = (
+                    BracketExitLifecycle.EXIT_REJECTED_RETRYABLE.value
+                )
+                bracket.next_exit_attempt_at = (
+                    time.time() + self._retry_delay_for_attempt(attempt)
+                )
             LOGGER.error(
                 "EXIT_PROVISIONAL_REGISTRATION_FAILED bracket_id=%s symbol=%s correlation_id=%s attempt=%s exception_type=%s exception_message=%s",
                 bracket.bracket_id,
@@ -2258,7 +2267,9 @@ class BracketManager:
                 if callable(binder) and bracket.exit_correlation_id:
                     try:
                         binder(bracket.exit_correlation_id, returned_order_id)
-                    except Exception as exc:  # noqa: BLE001 - broker order exists; fail closed
+                    except (
+                        Exception
+                    ) as exc:  # noqa: BLE001 - broker order exists; fail closed
                         bind_failed = True
                         bracket.last_exit_attempt_at = time.time()
                         bracket.last_exit_error = f"exit_order_id_bind_failed: {exc}"
@@ -2283,7 +2294,9 @@ class BracketManager:
                 elif bracket.exit_correlation_id:
                     bind_failed = True
                     bracket.last_exit_attempt_at = time.time()
-                    bracket.last_exit_error = "exit_order_id_bind_failed: binder_unavailable"
+                    bracket.last_exit_error = (
+                        "exit_order_id_bind_failed: binder_unavailable"
+                    )
                     LOGGER.error(
                         "EXIT_ORDER_ID_BIND_FAILED bracket_id=%s symbol=%s correlation_id=%s returned_order_id=%s exception_type=%s exception_message=%s",
                         bracket.bracket_id,
@@ -4085,9 +4098,14 @@ class BracketManager:
                     protected_quantity += max(qty, 0)
                 entry_order_id = str(getattr(bracket, "entry_order_id", "") or "")
                 tag = str(getattr(bracket, "tag", "") or "")
-                is_orphan = entry_order_id.startswith("orphan_") or tag == "orphan_recovery"
+                is_orphan = (
+                    entry_order_id.startswith("orphan_") or tag == "orphan_recovery"
+                )
                 orphan_origin = orphan_origin or is_orphan
-                if not bool(getattr(bracket, "entry_confirmed", False)) and not is_orphan:
+                if (
+                    not bool(getattr(bracket, "entry_confirmed", False))
+                    and not is_orphan
+                ):
                     pending_entry = True
                 stop_value = getattr(bracket, "stop_loss", None)
                 if stop_value is None:
@@ -4112,7 +4130,6 @@ class BracketManager:
             "all_closed": all_closed,
         }
 
-
     def is_exit_converging(self, symbol: str) -> bool:
         """Return True while a managed exit for ``symbol`` is not fully converged."""
 
@@ -4131,11 +4148,19 @@ class BracketManager:
                 bracket = self._brackets.get(entry_id)
                 if bracket is None:
                     continue
-                if (
-                    bracket.exit_state == BracketExitLifecycle.CLOSED.value
-                    and bracket.remaining_quantity <= 0
-                    and bracket.position_flat_confirmed
-                ):
+                terminal_flat = (
+                    str(bracket.exit_state or "").upper()
+                    in {
+                        BracketExitLifecycle.CLOSED.value,
+                        BracketExitLifecycle.EXIT_FILLED.value,
+                        BracketExitLifecycle.EXIT_RECONCILED_FLAT.value,
+                    }
+                    and bool(bracket.position_flat_confirmed)
+                    and int(bracket.remaining_quantity or 0) <= 0
+                    and not bool(getattr(bracket, "exit_submission_inflight", False))
+                    and getattr(bracket, "pending_exit_order_id", None) is None
+                )
+                if terminal_flat:
                     continue
                 if getattr(bracket, "exit_submission_inflight", False):
                     return True
@@ -4166,22 +4191,53 @@ class BracketManager:
         23950CE orphan re-adopted thousands of times). Returns count removed.
         """
         symbol = normalize_symbol(symbol)
+        reconciled = 0
         with self._lock:
             entry_ids = list(self._symbol_map.get(symbol, []))
-        removed = 0
-        for eid in entry_ids:
-            try:
-                self.unregister_bracket(eid)
-                removed += 1
-            except Exception:  # noqa: BLE001
-                continue
-        if removed:
+            for eid in entry_ids:
+                bracket = self._brackets.get(eid)
+                if bracket is None:
+                    continue
+                already_terminal_flat = (
+                    bool(getattr(bracket, "position_flat_confirmed", False))
+                    and int(getattr(bracket, "remaining_quantity", 0) or 0) <= 0
+                )
+                if not already_terminal_flat:
+                    self._brackets.pop(eid, None)
+                    ids = self._symbol_map.get(symbol)
+                    if ids and eid in ids:
+                        ids.remove(eid)
+                        if not ids:
+                            self._symbol_map.pop(symbol, None)
+                    reconciled += 1
+                    continue
+                bracket.remaining_quantity = 0
+                bracket.exit_executed = True
+                bracket.exit_pending = False
+                bracket.exit_in_progress = False
+                bracket.active = False
+                bracket.position_flat_confirmed = True
+                bracket.flat_nonterminal_since_monotonic = None
+                bracket.flat_nonterminal_since_utc = None
+                bracket.exit_submission_inflight = False
+                bracket.exit_intent = None
+                bracket.expected_exit_side = None
+                bracket.expected_exit_qty = 0
+                bracket.exit_correlation_id = None
+                bracket.pending_exit_order_id = None
+                bracket.exit_state = BracketExitLifecycle.CLOSED.value
+                bracket.entry_status = "CLOSED"
+                bracket.close_source = bracket.close_source or "broker_position_closed"
+                bracket.closed_at = bracket.closed_at or time.time()
+                bracket.updated_at = time.time()
+                reconciled += 1
+        if reconciled:
             LOGGER.info(
-                "BRACKET_RECONCILED_FLAT symbol=%s removed=%s reason=broker_position_closed",
+                "BRACKET_RECONCILED_FLAT symbol=%s reconciled=%s reason=broker_position_closed",
                 symbol,
-                removed,
+                reconciled,
             )
-        return removed
+        return reconciled
 
     def unregister_bracket(self, entry_id: str) -> None:
         """Remove a bracket from memory and indices."""

--- a/src/nifty_scalper_bot/execution/ownership.py
+++ b/src/nifty_scalper_bot/execution/ownership.py
@@ -19,6 +19,7 @@ from contextlib import suppress
 import os
 from typing import Any, Mapping, Sequence
 
+from nifty_scalper_bot.execution.position_snapshot import BrokerExposureState
 from nifty_scalper_bot.execution.runtime_bracket_manager import RuntimeBracketManager
 from nifty_scalper_bot.utils.symbols import normalize_symbol
 
@@ -159,6 +160,111 @@ class BoundBracketManager(RuntimeBracketManager):
             return
         super()._install_unresolved_exit_entry_guard()
 
+    def _unresolved_exit_entry_blocker(
+        self, position_manager: Any | None
+    ) -> Mapping[str, Any] | None:
+        bracket_id = None
+        getter = getattr(self, "get_first_unresolved_exit_bracket_id", None)
+        if callable(getter):
+            with suppress(Exception):
+                bracket_id = getter()
+        symbol = None
+        if bracket_id:
+            bracket_getter = getattr(self, "get_bracket", None)
+            if callable(bracket_getter):
+                with suppress(Exception):
+                    bracket = bracket_getter(bracket_id)
+                    symbol = getattr(bracket, "symbol", None)
+        if not symbol:
+            return _block(
+                "unresolved_exit_position",
+                source="bracket_manager",
+                bracket_id=bracket_id,
+            )
+        return self._unresolved_exit_entry_blocker_for_symbol(
+            position_manager, str(symbol), bracket_id=bracket_id
+        )
+
+    def _unresolved_exit_entry_blocker_for_symbol(
+        self,
+        position_manager: Any | None,
+        symbol: str,
+        *,
+        bracket_id: str | None = None,
+    ) -> Mapping[str, Any] | None:
+        symbol = normalize_symbol(str(symbol))
+        unresolved = lambda **details: _block(
+            "unresolved_exit_position",
+            source="bracket_manager",
+            bracket_id=bracket_id,
+            symbol=symbol,
+            **details,
+        )
+        if position_manager is None:
+            return unresolved(broker_exposure_state=BrokerExposureState.UNKNOWN.value)
+        exposure_getter = getattr(position_manager, "broker_exposure_state", None)
+        if not callable(exposure_getter):
+            return unresolved(broker_exposure_state=BrokerExposureState.UNKNOWN.value)
+        try:
+            exposure = exposure_getter(symbol)
+        except (
+            Exception
+        ) as exc:  # noqa: BLE001 - fail closed on broker truth uncertainty
+            return unresolved(
+                broker_exposure_state=BrokerExposureState.UNKNOWN.value,
+                broker_exposure_error=f"{type(exc).__name__}: {exc}",
+            )
+        snapshot_details: dict[str, Any] = {
+            "broker_exposure_state": getattr(exposure, "value", str(exposure))
+        }
+        snapshot_getter = getattr(position_manager, "broker_exposure_snapshot", None)
+        if callable(snapshot_getter):
+            with suppress(Exception):
+                snapshot = snapshot_getter()
+                if isinstance(snapshot, Mapping):
+                    snapshot_details.update(
+                        broker_snapshot_fresh=snapshot.get("fresh"),
+                        broker_snapshot_age_seconds=snapshot.get("age_seconds"),
+                    )
+        if exposure in (BrokerExposureState.NONZERO, BrokerExposureState.UNKNOWN):
+            return unresolved(**snapshot_details)
+        if exposure not in (BrokerExposureState.FLAT, BrokerExposureState.ABSENT):
+            return unresolved(**snapshot_details)
+        local_getter = getattr(position_manager, "get_position", None)
+        if not callable(local_getter):
+            return unresolved(**snapshot_details)
+        try:
+            local_position = local_getter(symbol)
+            local_qty = (
+                int(getattr(local_position, "quantity", 0) or 0)
+                if local_position is not None
+                else 0
+            )
+        except Exception as exc:  # noqa: BLE001 - local truth uncertainty fails closed
+            return unresolved(
+                local_position_error=f"{type(exc).__name__}: {exc}", **snapshot_details
+            )
+        if local_qty != 0:
+            return unresolved(local_position_quantity=local_qty, **snapshot_details)
+        reconcile_flat = getattr(self, "reconcile_symbol_flat", None)
+        if callable(reconcile_flat):
+            try:
+                reconcile_flat(symbol)
+            except Exception as exc:  # noqa: BLE001 - cleanup failure fails closed
+                return unresolved(
+                    reconcile_error=f"{type(exc).__name__}: {exc}", **snapshot_details
+                )
+        converging = getattr(self, "is_exit_converging", None)
+        if callable(converging):
+            try:
+                if not bool(converging(symbol)):
+                    return None
+            except Exception as exc:  # noqa: BLE001
+                return unresolved(
+                    recheck_error=f"{type(exc).__name__}: {exc}", **snapshot_details
+                )
+        return unresolved(**snapshot_details)
+
     def current_entry_blocker(self) -> Mapping[str, Any] | None:
         """Return the first live-safety blocker for new entries.
 
@@ -169,19 +275,14 @@ class BoundBracketManager(RuntimeBracketManager):
         broker-synced positions that do not yet have local order ownership.
         """
 
+        position_manager = _order_manager_position_manager(
+            getattr(self, "order_manager", None)
+        )
+
         checker = getattr(self, "has_unresolved_exit", None)
         try:
             if callable(checker) and bool(checker()):
-                bracket_id = None
-                getter = getattr(self, "get_first_unresolved_exit_bracket_id", None)
-                if callable(getter):
-                    with suppress(Exception):
-                        bracket_id = getter()
-                return _block(
-                    "unresolved_exit_position",
-                    source="bracket_manager",
-                    bracket_id=bracket_id,
-                )
+                return self._unresolved_exit_entry_blocker(position_manager)
         except Exception as exc:  # noqa: BLE001 - fail closed
             return _block(
                 "entry_blocker_provider_error",
@@ -189,9 +290,32 @@ class BoundBracketManager(RuntimeBracketManager):
                 provider_error=f"{type(exc).__name__}: {exc}",
             )
 
-        position_manager = _order_manager_position_manager(getattr(self, "order_manager", None))
         if position_manager is None:
             return None
+
+        converging = getattr(self, "is_exit_converging", None)
+        if callable(converging):
+            symbol_map = getattr(self, "_symbol_map", {})
+            try:
+                symbols = list(symbol_map.keys())
+            except Exception:
+                symbols = []
+            for candidate_symbol in symbols:
+                try:
+                    if bool(converging(candidate_symbol)):
+                        blocker = self._unresolved_exit_entry_blocker_for_symbol(
+                            position_manager,
+                            candidate_symbol,
+                        )
+                        if blocker is not None:
+                            return blocker
+                except Exception as exc:  # noqa: BLE001 - fail closed
+                    return _block(
+                        "unresolved_exit_position",
+                        source="bracket_manager",
+                        symbol=normalize_symbol(str(candidate_symbol)),
+                        convergence_error=f"{type(exc).__name__}: {exc}",
+                    )
 
         for method_name in (
             "current_entry_protection_blocker",
@@ -221,7 +345,6 @@ class BoundBracketManager(RuntimeBracketManager):
 
 __all__ = ["BoundBracketManager"]
 from enum import Enum
-from nifty_scalper_bot.execution.position_snapshot import BrokerExposureState
 
 
 class SymbolLifecycleClassification(str, Enum):
@@ -283,4 +406,8 @@ def classify_symbol_lifecycle(
     return SymbolLifecycleClassification.UNRESOLVED
 
 
-__all__ = ["BoundBracketManager", "SymbolLifecycleClassification", "classify_symbol_lifecycle"]
+__all__ = [
+    "BoundBracketManager",
+    "SymbolLifecycleClassification",
+    "classify_symbol_lifecycle",
+]

--- a/tests/execution/test_exit_reconciliation_race.py
+++ b/tests/execution/test_exit_reconciliation_race.py
@@ -424,7 +424,9 @@ def _runner_for(pm: PositionManager, bm: BracketManager) -> StrategyRunner:
     return runner
 
 
-def test_orphan_scan_skips_stale_positive_position_during_exit_convergence(tmp_path) -> None:
+def test_orphan_scan_skips_stale_positive_position_during_exit_convergence(
+    tmp_path,
+) -> None:
     pm = _position_manager(tmp_path)
     bm = _bracket_manager()
     bm.order_manager._positions = pm
@@ -554,7 +556,9 @@ def test_provisional_registration_failure_prevents_broker_submission(
     assert "EXIT_PROVISIONAL_REGISTRATION_FAILED" in caplog.text
 
 
-def test_missing_provisional_registrar_prevents_broker_submission(tmp_path, caplog) -> None:
+def test_missing_provisional_registrar_prevents_broker_submission(
+    tmp_path, caplog
+) -> None:
     pm = PositionManager(str(tmp_path / "positions.json"))
     pm.open_position(SYMBOL, "LONG", QTY, 100.0, order_id="entry-missing")
     om = _RecordingExitOrderManager(None)
@@ -593,14 +597,19 @@ def test_final_id_binding_failure_stays_converging_and_blocks_orphan(
     assert bracket.pending_exit_order_id == "exit-final-1"
     assert bracket.exit_correlation_id is not None
     assert bracket.exit_intent == "EXIT"
-    assert bracket.last_exit_error and "exit_order_id_bind_failed" in bracket.last_exit_error
+    assert (
+        bracket.last_exit_error
+        and "exit_order_id_bind_failed" in bracket.last_exit_error
+    )
     assert bm.is_exit_converging(SYMBOL) is True
     _runner_for(pm, bm)._adopt_orphan_positions()
     assert adopt_calls == []
     assert "EXIT_ORDER_ID_BIND_FAILED" in caplog.text
 
 
-def test_binding_failure_recovers_when_tagged_terminal_update_reconciles(tmp_path) -> None:
+def test_binding_failure_recovers_when_tagged_terminal_update_reconciles(
+    tmp_path,
+) -> None:
     pm = _BindFailPositionManager(str(tmp_path / "positions.json"))
     pm.open_position(SYMBOL, "LONG", QTY, 100.0, order_id="entry-bindrecover")
     om = _RecordingExitOrderManager(pm)
@@ -699,6 +708,7 @@ def test_registration_failure_can_retry_without_duplicate_broker_exit(tmp_path) 
     assert len(om.calls) == 1
     assert bracket.exit_order_id == "exit-final-1"
 
+
 class _ExplodingBroker:
     def get_positions(self):
         raise AssertionError("runner must not call broker positions")
@@ -707,7 +717,9 @@ class _ExplodingBroker:
         raise AssertionError("runner must not call broker positions")
 
 
-def test_runner_orphan_scan_uses_position_manager_snapshot_not_broker_io(tmp_path) -> None:
+def test_runner_orphan_scan_uses_position_manager_snapshot_not_broker_io(
+    tmp_path,
+) -> None:
     pm = PositionManager(str(tmp_path / "positions.json"))
     pm.open_position(SYMBOL, "LONG", QTY, 100.0, order_id="manual")
     pm.synchronize_with_broker([_broker_row(0)])
@@ -735,12 +747,17 @@ def test_runner_unknown_broker_exposure_defers_without_adoption(tmp_path) -> Non
         runner._adopt_orphan_positions()
 
         assert adopt_calls == []
-        assert any("ORPHAN_ADOPTION_DEFERRED_BROKER_UNKNOWN" in str(args[0]) for args, _kwargs in warnings)
+        assert any(
+            "ORPHAN_ADOPTION_DEFERRED_BROKER_UNKNOWN" in str(args[0])
+            for args, _kwargs in warnings
+        )
     finally:
         _stop_bracket_manager(bm)
 
 
-def test_runner_stale_flat_snapshot_defers_without_orphan_adoption(tmp_path, monkeypatch) -> None:
+def test_runner_stale_flat_snapshot_defers_without_orphan_adoption(
+    tmp_path, monkeypatch
+) -> None:
     from nifty_scalper_bot.execution import position_manager as pm_module
     from nifty_scalper_bot.execution.position_snapshot import BrokerExposureState
 
@@ -772,12 +789,17 @@ def test_runner_stale_flat_snapshot_defers_without_orphan_adoption(tmp_path, mon
         runner._adopt_orphan_positions()
 
         assert adopt_calls == []
-        assert any("ORPHAN_ADOPTION_DEFERRED_BROKER_UNKNOWN" in str(args[0]) for args, _kwargs in warnings)
+        assert any(
+            "ORPHAN_ADOPTION_DEFERRED_BROKER_UNKNOWN" in str(args[0])
+            for args, _kwargs in warnings
+        )
     finally:
         _stop_bracket_manager(bm)
 
 
-def test_runner_local_generation_invalidates_absent_snapshot_before_adoption(tmp_path, monkeypatch) -> None:
+def test_runner_local_generation_invalidates_absent_snapshot_before_adoption(
+    tmp_path, monkeypatch
+) -> None:
     from nifty_scalper_bot.execution import position_manager as pm_module
     from nifty_scalper_bot.execution.position_snapshot import BrokerExposureState
 
@@ -801,3 +823,52 @@ def test_runner_local_generation_invalidates_absent_snapshot_before_adoption(tmp
 
     pm.synchronize_with_broker([_broker_row()])
     assert pm.broker_exposure_state(SYMBOL) is BrokerExposureState.NONZERO
+
+
+def test_terminal_flat_bracket_with_historical_exit_id_is_not_converging(
+    tmp_path,
+) -> None:
+    pm = PositionManager(str(tmp_path / "positions.json"))
+    bm = _bracket_with_pm(pm, _RecordingExitOrderManager(pm))
+    bracket = bm.get_bracket("entry-fail")
+    assert bracket is not None
+    bracket.exit_state = "CLOSED"
+    bracket.entry_status = "CLOSED"
+    bracket.position_flat_confirmed = True
+    bracket.remaining_quantity = 0
+    bracket.exit_submission_inflight = False
+    bracket.pending_exit_order_id = None
+    bracket.exit_order_id = "historical-exit-1"
+
+    assert bm.is_exit_converging(SYMBOL) is False
+
+
+def test_reconcile_symbol_flat_is_idempotent_and_terminal(tmp_path) -> None:
+    pm = PositionManager(str(tmp_path / "positions.json"))
+    bm = _bracket_with_pm(pm, _RecordingExitOrderManager(pm))
+    bracket = bm.get_bracket("entry-fail")
+    assert bracket is not None
+    bracket.exit_state = "EXIT_RECONCILED_FLAT"
+    bracket.position_flat_confirmed = True
+    bracket.remaining_quantity = 0
+    bracket.exit_submission_inflight = True
+    bracket.pending_exit_order_id = "exit-pending"
+    bracket.exit_order_id = "historical-exit-1"
+    before_ids = set(bm._brackets)
+
+    bm.reconcile_symbol_flat(SYMBOL)
+    first_state = (bracket.exit_state, bracket.entry_status, bracket.close_source)
+    bm.reconcile_symbol_flat(SYMBOL)
+
+    assert set(bm._brackets) == before_ids
+    assert bm.get_bracket("orphan_" + SYMBOL) is None
+    assert (
+        bracket.exit_state,
+        bracket.entry_status,
+        bracket.close_source,
+    ) == first_state
+    assert bracket.position_flat_confirmed is True
+    assert bracket.remaining_quantity == 0
+    assert bracket.exit_submission_inflight is False
+    assert bracket.pending_exit_order_id is None
+    assert bm.is_exit_converging(SYMBOL) is False

--- a/tests/execution/test_lifecycle_entry_guards.py
+++ b/tests/execution/test_lifecycle_entry_guards.py
@@ -7,8 +7,156 @@ from nifty_scalper_bot.execution import native_entry_gate
 from nifty_scalper_bot.execution.ownership import BoundBracketManager
 
 
+import pytest
+
+from nifty_scalper_bot.execution.bracket_manager import BracketManager
+from nifty_scalper_bot.execution.position_manager import PositionManager
+from nifty_scalper_bot.execution.position_snapshot import BrokerExposureState
+
+_SYMBOL = "NFO:NIFTY2662324050PE"
+_QTY = 65
+
+
+class _NoBrokerCalls:
+    def get_positions(self):
+        raise AssertionError("entry blocker must not call broker positions")
+
+    def positions(self):
+        raise AssertionError("entry blocker must not call broker positions")
+
+
+class _OrderManagerForEntryGuard:
+    def __init__(self, pm: PositionManager) -> None:
+        self._position_manager = pm
+        self._positions = pm
+        self._broker = _NoBrokerCalls()
+
+
+def _broker_row(quantity: int) -> dict[str, Any]:
+    return {
+        "symbol": _SYMBOL,
+        "quantity": quantity,
+        "average_price": 100.0,
+        "product": "MIS",
+    }
+
+
+def _real_bound_bracket_manager(pm: PositionManager) -> BracketManager:
+    bm = BracketManager(order_manager=_OrderManagerForEntryGuard(pm))
+    bm.register_virtual_bracket(
+        order_id="entry-stale-exit",
+        symbol=_SYMBOL,
+        side="BUY",
+        qty=_QTY,
+        price=100.0,
+        sl=90.0,
+        tp=120.0,
+    )
+    bm.confirm_entry_fill("entry-stale-exit", 100.0)
+    bracket = bm.get_bracket("entry-stale-exit")
+    assert bracket is not None
+    bracket.remaining_quantity = 0
+    bracket.position_flat_confirmed = True
+    bracket.exit_submission_inflight = False
+    bracket.pending_exit_order_id = None
+    bracket.exit_order_id = "historical-exit-1"
+    return bm
+
+
+@pytest.mark.parametrize(
+    "exposure", [BrokerExposureState.FLAT, BrokerExposureState.ABSENT]
+)
+def test_fresh_broker_flat_clears_false_unresolved_exit_blocker(
+    tmp_path, exposure
+) -> None:
+    pm = PositionManager(str(tmp_path / "positions.json"))
+    if exposure is BrokerExposureState.FLAT:
+        pm.synchronize_with_broker([_broker_row(0)])
+    else:
+        pm.synchronize_with_broker([])
+    bm = _real_bound_bracket_manager(pm)
+
+    assert pm.get_position(_SYMBOL) is None
+    assert pm.broker_exposure_state(_SYMBOL) is exposure
+    assert bm.is_exit_converging(_SYMBOL) is True
+
+    blocker = bm.current_entry_blocker()
+
+    assert blocker is None
+    assert bm.is_exit_converging(_SYMBOL) is False
+    assert bm.get_bracket("orphan_" + _SYMBOL) is None
+
+
+def test_unknown_broker_exposure_keeps_unresolved_exit_blocker(tmp_path) -> None:
+    pm = PositionManager(str(tmp_path / "positions.json"))
+    bm = _real_bound_bracket_manager(pm)
+
+    blocker = bm.current_entry_blocker()
+
+    assert blocker is not None
+    assert blocker["block_reason"] == "unresolved_exit_position"
+    assert blocker["broker_exposure_state"] == BrokerExposureState.UNKNOWN.value
+    assert bm.is_exit_converging(_SYMBOL) is True
+
+
+def test_nonzero_broker_exposure_keeps_unresolved_exit_blocker(tmp_path) -> None:
+    pm = PositionManager(str(tmp_path / "positions.json"))
+    pm.synchronize_with_broker([_broker_row(_QTY)])
+    bm = _real_bound_bracket_manager(pm)
+
+    blocker = bm.current_entry_blocker()
+
+    assert blocker is not None
+    assert blocker["block_reason"] == "unresolved_exit_position"
+    assert blocker["broker_exposure_state"] == BrokerExposureState.NONZERO.value
+    assert bm.is_exit_converging(_SYMBOL) is True
+
+
+@pytest.mark.parametrize(
+    "exposure", [BrokerExposureState.FLAT, BrokerExposureState.ABSENT]
+)
+def test_broker_flat_with_local_position_keeps_unresolved_exit_blocker(
+    tmp_path, exposure
+) -> None:
+    real_pm = PositionManager(str(tmp_path / "positions.json"))
+
+    class _DisagreeingPositionManager:
+        def broker_exposure_state(self, _symbol: str) -> BrokerExposureState:
+            return exposure
+
+        def broker_exposure_snapshot(self) -> dict[str, Any]:
+            return {"fresh": True, "age_seconds": 0.1}
+
+        def get_position(self, _symbol: str) -> Any:
+            return SimpleNamespace(quantity=_QTY)
+
+        def get_open_positions(self) -> list[Any]:
+            return []
+
+        def unresolved_terminal_summary(self) -> dict[str, Any]:
+            return {"count": 0}
+
+    bm = _real_bound_bracket_manager(real_pm)
+    bm.order_manager._position_manager = _DisagreeingPositionManager()
+    bm.order_manager._positions = bm.order_manager._position_manager
+
+    blocker = bm.current_entry_blocker()
+
+    assert blocker is not None
+    assert blocker["block_reason"] == "unresolved_exit_position"
+    assert bm.is_exit_converging(_SYMBOL) is True
+
+
 class _Result:
-    def __init__(self, *, accepted: bool, order_id: str | None, reason: str, details: dict[str, Any], broker_attempted: bool) -> None:
+    def __init__(
+        self,
+        *,
+        accepted: bool,
+        order_id: str | None,
+        reason: str,
+        details: dict[str, Any],
+        broker_attempted: bool,
+    ) -> None:
         self.accepted = accepted
         self.order_id = order_id
         self.reason = reason
@@ -35,7 +183,9 @@ class _Manager:
         return True
 
 
-def _base_place_order(_manager: Any, *, intent: str | None = None, tag: str | None = None) -> None:
+def _base_place_order(
+    _manager: Any, *, intent: str | None = None, tag: str | None = None
+) -> None:
     return None
 
 
@@ -48,7 +198,9 @@ def _bound_manager(position_manager: Any) -> BoundBracketManager:
 
 
 def test_native_entry_gate_blocks_generic_provider_reason() -> None:
-    provider = SimpleNamespace(current_entry_blocker=lambda: "pnl_reconciliation_mismatch")
+    provider = SimpleNamespace(
+        current_entry_blocker=lambda: "pnl_reconciliation_mismatch"
+    )
     manager = _Manager(provider)
 
     result = native_entry_gate.block_result(
@@ -90,7 +242,9 @@ def test_native_entry_gate_fails_closed_when_provider_raises() -> None:
 
 
 def test_protective_order_is_not_stopped_by_entry_blocker() -> None:
-    provider = SimpleNamespace(current_entry_blocker=lambda: "unresolved_terminal_order")
+    provider = SimpleNamespace(
+        current_entry_blocker=lambda: "unresolved_terminal_order"
+    )
     manager = _Manager(provider)
 
     result = native_entry_gate.block_result(
@@ -149,7 +303,9 @@ def test_bound_bracket_manager_blocks_unmanaged_broker_synced_positions() -> Non
         current_orphan_position_blocker=lambda: None,
         current_exit_lifecycle_blocker=lambda: None,
         unresolved_terminal_summary=lambda: {"count": 0},
-        get_open_positions=lambda: [SimpleNamespace(symbol="NFO:NIFTY2662324050PE", order_id=None)],
+        get_open_positions=lambda: [
+            SimpleNamespace(symbol="NFO:NIFTY2662324050PE", order_id=None)
+        ],
     )
     manager = _bound_manager(position_manager)
 
@@ -180,7 +336,9 @@ def test_bound_bracket_manager_blocks_unhealthy_reconciliation_state() -> None:
 
 
 def test_bound_bracket_manager_keeps_unresolved_bracket_priority() -> None:
-    position_manager = SimpleNamespace(current_pnl_reconciliation_blocker=lambda: "pnl_reconciliation_mismatch")
+    position_manager = SimpleNamespace(
+        current_pnl_reconciliation_blocker=lambda: "pnl_reconciliation_mismatch"
+    )
     order_manager = SimpleNamespace(_position_manager=position_manager)
     manager = BoundBracketManager.__new__(BoundBracketManager)
     manager.order_manager = order_manager


### PR DESCRIPTION
### Motivation
- A stale terminal bracket could keep `is_exit_converging()` true because historical exit metadata (e.g. `exit_order_id`/correlation) was still treated as active, causing `unresolved_exit_position` to persist even when canonical broker truth was fresh FLAT/ABSENT and there was no local position.
- The intent is to make the PositionManager broker snapshot authoritative for clearing false unresolved-exit blockers while preserving the fail-closed safety contract (NONZERO / UNKNOWN must keep blocking).
- This must be done without adding broker IO to the signal path or broad refactors, and while keeping reconciliation ownership with BracketManager/PositionManager.

### Description
- BoundBracketManager.current_entry_blocker now consults `PositionManager.broker_exposure_state()` and applies the exact decision table: NONZERO/UNKNOWN -> keep blocking; FLAT/ABSENT -> verify `get_position()` shows no local quantity, call `reconcile_symbol_flat()` and re-check `is_exit_converging()` before clearing the blocker; missing/getter errors fail closed. (Functions changed: `BoundBracketManager.current_entry_blocker`, `_unresolved_exit_entry_blocker`, `_unresolved_exit_entry_blocker_for_symbol` in `src/nifty_scalper_bot/execution/ownership.py`.)
- BracketManager reconciliation and convergence logic updated so terminal-flat brackets are normalized to a closed terminal lifecycle without treating historical audit-only fields as active convergence drivers; `is_exit_converging()` now treats a bracket as non-converging when it is terminal, `position_flat_confirmed` is True, `remaining_quantity <= 0`, `exit_submission_inflight` is False, and `pending_exit_order_id` is None. (Functions changed: `reconcile_symbol_flat`, `is_exit_converging` in `src/nifty_scalper_bot/execution/bracket_core.py`.)
- Tests added to lock the behavior and regressions: lifecycle entry guard tests for FLAT/ABSENT clearing, UNKNOWN and NONZERO protection, and local-position disagreement; BracketManager tests proving a terminal-flat bracket with historical `exit_order_id` is not converging and that `reconcile_symbol_flat()` is idempotent. (Files changed: `tests/execution/test_lifecycle_entry_guards.py`, `tests/execution/test_exit_reconciliation_race.py`.)
- Small housekeeping: preserved historical `exit_order_id` only as audit metadata when it does not imply active convergence; reconciled terminal fields cleared consistently under the existing BracketManager lock and lifecycle semantics.

### Testing
- Compilation: `python -m compileall -q src tests` exited 0.  
- Focused pytest runs: `python -m pytest -q tests/execution/test_lifecycle_entry_guards.py tests/execution/test_exit_reconciliation_race.py tests/execution/test_canonical_execution_recovery.py tests/execution/test_readiness_execution_safety_blockers.py` exited 0, and `python -m pytest -q tests/execution` exited 0.  
- Live-sim E2E: `python -m pytest -q -m live_runtime_e2e tests/e2e/live_sim` exited 0 when run standalone.  
- Full suite: `python -m pytest -q` returned non-zero (exit 1) due to an order-dependent pre-existing `live_runtime_e2e` readiness failure (`execution_not_armed:futures_live_tick_stale`) that appears unrelated to the ownership/bracket changes and which reproduces only when the full suite runs in that order.  

Additional QA notes:  
- Commands and notable exit codes recorded above demonstrate the focused suites and E2E passed (exit 0) while the full-run failure (exit 1) is an order-dependent readiness/flakiness symptom; remediation of that flaky readiness ordering is out of scope for this PR.  

Files changed and production LOC delta:  
- `src/nifty_scalper_bot/execution/ownership.py`: modified (added ~140 lines, removed ~13 lines).  
- `src/nifty_scalper_bot/execution/bracket_core.py`: modified (added ~82 lines, removed ~26 lines).  
- Tests: `tests/execution/test_lifecycle_entry_guards.py`, `tests/execution/test_exit_reconciliation_race.py` updated/extended.  

Safety/Scope confirmation:  
- No broker network calls added to StrategyRunner, native_entry_gate, or per-signal path.  
- No changes to strategies, risk, sizing, order placement, WebSocket, candle, queue, or freshness logic.  
- Behavior change is restricted to reconciliation/entry-gating when canonical broker snapshot and local PM state permit safe reconciliation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a62ed113cd4832498e7d82936332162)