### PR TITLE
Fix flat exit bracket reconciliation

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -14658,6 +14658,58 @@ def _should_reconcile_now(ctx: BotContext) -> bool:
         return True
 
 
+def _reconcile_flat_exit_brackets(ctx: BotContext) -> int:
+    """Clear exit-converging bracket lifecycles only after PM proves flat/absent."""
+
+    pm = getattr(ctx, "position_manager", None)
+    om = getattr(ctx, "order_manager", None)
+    bm = getattr(om, "_bracket_manager", None)
+    if pm is None or bm is None:
+        return 0
+
+    symbol_getter = getattr(bm, "managed_symbols", None)
+    if not callable(symbol_getter):
+        return 0
+
+    try:
+        symbols = tuple(symbol_getter())
+    except Exception:  # noqa: BLE001 - reconciliation must not fail the run
+        return 0
+
+    reconciled = 0
+    flat_states = {BrokerExposureState.FLAT, BrokerExposureState.ABSENT}
+    for symbol in symbols:
+        try:
+            exposure = pm.broker_exposure_state(symbol)
+        except Exception:  # noqa: BLE001 - keep other symbols fail-closed
+            continue
+        if exposure not in flat_states:
+            continue
+
+        try:
+            position = pm.get_position(symbol)
+            local_qty = int(getattr(position, "quantity", 0) or 0)
+        except Exception:  # noqa: BLE001 - disagreement/unknown stays blocked
+            continue
+        if local_qty != 0:
+            continue
+
+        try:
+            if not bm.is_exit_converging(symbol):
+                continue
+            reconciled += int(bm.reconcile_symbol_flat(symbol) or 0)
+        except Exception:
+            LOGGER.exception(
+                "FLAT_EXIT_BRACKET_RECONCILE_FAILED symbol=%s",
+                symbol,
+                extra={
+                    "event": "FLAT_EXIT_BRACKET_RECONCILE_FAILED",
+                    "symbol": symbol,
+                },
+            )
+    return reconciled
+
+
 async def _reconcile_state(ctx: BotContext, *, source: str = "unknown") -> None:
     """
     Syncs local state with Broker (Orders & Positions).
@@ -14757,6 +14809,20 @@ async def _reconcile_state(ctx: BotContext, *, source: str = "unknown") -> None:
             sync_started_at = datetime.now(timezone.utc)
             run_record["sync_started_at"] = sync_started_at.isoformat()
             broker_positions = await asyncio.to_thread(safe_sync_fetch)
+            reconciled_flat_exits = _reconcile_flat_exit_brackets(ctx)
+            if reconciled_flat_exits > 0:
+                LOGGER.info(
+                    "FLAT_EXIT_BRACKETS_RECONCILED count=%s run_id=%s source=%s",
+                    reconciled_flat_exits,
+                    reconcile_run_id,
+                    source,
+                    extra={
+                        "event": "FLAT_EXIT_BRACKETS_RECONCILED",
+                        "count": reconciled_flat_exits,
+                        "reconcile_run_id": reconcile_run_id,
+                        "source": source,
+                    },
+                )
             sync_completed_at = datetime.now(timezone.utc)
             run_record["sync_completed_at"] = sync_completed_at.isoformat()
             if hasattr(ctx, "unresolved_reconciliation_symbols"):

--- a/src/nifty_scalper_bot/execution/bracket_core.py
+++ b/src/nifty_scalper_bot/execution/bracket_core.py
@@ -667,6 +667,11 @@ class BracketManager:
                         return bracket.bracket_id
         return None
 
+    def managed_symbols(self) -> tuple[str, ...]:
+        """Return normalized symbols currently indexed by BracketManager."""
+        with self._lock:
+            return tuple(self._symbol_map.keys())
+
     def attach_exit_executor(self, executor: Callable[[str, int], Any] | None) -> None:
         """Attach an external market-exit executor. Args: executor; Returns: None; Raises: None."""
         self._exit_executor = executor

--- a/tests/execution/test_exit_reconciliation_race.py
+++ b/tests/execution/test_exit_reconciliation_race.py
@@ -9,6 +9,7 @@ from typing import Any
 import pytest
 
 from nifty_scalper_bot.execution.bracket_manager import BracketManager
+from nifty_scalper_bot.execution.ownership import BoundBracketManager
 from nifty_scalper_bot.execution.position_manager import Position, PositionManager
 from nifty_scalper_bot.strategies.runner import StrategyRunner
 
@@ -801,3 +802,189 @@ def test_runner_local_generation_invalidates_absent_snapshot_before_adoption(tmp
 
     pm.synchronize_with_broker([_broker_row()])
     assert pm.broker_exposure_state(SYMBOL) is BrokerExposureState.NONZERO
+
+class _ReconBroker:
+    def __init__(self, positions: list[dict[str, Any]]) -> None:
+        self.positions = positions
+        self.get_positions_calls = 0
+
+    def get_positions(self) -> list[dict[str, Any]]:
+        self.get_positions_calls += 1
+        return list(self.positions)
+
+
+class _ReconOrderManager:
+    def __init__(self, bracket_manager: Any, broker: _ReconBroker) -> None:
+        self._bracket_manager = bracket_manager
+        self._broker = broker
+        self.reconcile_calls = 0
+        self.guard_calls: list[dict[str, Any]] = []
+
+    def reconcile_open_orders_with_broker(self) -> None:
+        self.reconcile_calls += 1
+
+    def guard_orphan_position(self, **kwargs: Any) -> str:
+        self.guard_calls.append(kwargs)
+        return "guarded"
+
+    def _log_status_report(self) -> None:
+        return None
+
+
+class _ReconBrokerClient:
+    def __init__(self, broker: _ReconBroker) -> None:
+        self.client = broker
+
+
+class _ExitConvergingBracket:
+    def __init__(self, symbol: str, *, converging: bool = True) -> None:
+        self.symbol = symbol
+        self.converging = converging
+        self.reconcile_calls: list[str] = []
+        self.broker_calls = 0
+        self._managed = True
+
+    def managed_symbols(self) -> tuple[str, ...]:
+        return (self.symbol,) if self._managed else ()
+
+    def is_exit_converging(self, symbol: str) -> bool:
+        return self.converging and self._managed and symbol == self.symbol
+
+    def reconcile_symbol_flat(self, symbol: str) -> int:
+        self.reconcile_calls.append(symbol)
+        if self._managed:
+            self._managed = False
+            return 1
+        return 0
+
+    def has_unresolved_exit(self) -> bool:
+        return bool(self._managed and self.converging)
+
+    def get_first_unresolved_exit_bracket_id(self) -> str | None:
+        return "entry-1" if self.has_unresolved_exit() else None
+
+    def is_symbol_managed(self, symbol: str) -> bool:
+        return self._managed and symbol == self.symbol
+
+    def manual_override_close(self, *_args: Any, **_kwargs: Any) -> None:
+        raise AssertionError("generic ghost cleanup must remain the owner for non-exit brackets")
+
+
+def _entry_blocker_for(bm: Any) -> dict[str, Any] | None:
+    manager = BoundBracketManager.__new__(BoundBracketManager)
+    manager.order_manager = SimpleNamespace(_position_manager=None)
+    manager.has_unresolved_exit = bm.has_unresolved_exit
+    manager.get_first_unresolved_exit_bracket_id = bm.get_first_unresolved_exit_bracket_id
+    return manager.current_entry_blocker()
+
+
+def _reconcile_ctx(tmp_path, broker_positions: list[dict[str, Any]], bm: Any) -> tuple[Any, PositionManager, _ReconBroker]:
+    broker = _ReconBroker(broker_positions)
+    pm = PositionManager(str(tmp_path / "reconcile_positions.json"))
+    om = _ReconOrderManager(bm, broker)
+    ctx = SimpleNamespace()
+    ctx.position_manager = pm
+    ctx.order_manager = om
+    ctx.broker_client = _ReconBrokerClient(broker)
+    ctx.unresolved_reconciliation_symbols = set()
+    ctx.unprotected_broker_positions = set()
+    ctx.unprotected_broker_position = False
+    return ctx, pm, broker
+
+
+@pytest.mark.asyncio
+async def test_reconcile_state_clears_stale_exit_when_broker_flat(tmp_path) -> None:
+    from nifty_scalper_bot.core.app import _reconcile_state
+
+    bm = _ExitConvergingBracket(SYMBOL)
+    ctx, _pm, broker = _reconcile_ctx(tmp_path, [_broker_row(0)], bm)
+
+    await _reconcile_state(ctx, source="test")
+
+    assert bm.reconcile_calls == [SYMBOL]
+    assert _entry_blocker_for(bm) is None
+    assert broker.get_positions_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_reconcile_state_clears_stale_exit_when_symbol_absent_from_broker_snapshot(tmp_path) -> None:
+    from nifty_scalper_bot.core.app import _reconcile_state
+
+    bm = _ExitConvergingBracket(SYMBOL)
+    ctx, _pm, _broker = _reconcile_ctx(tmp_path, [], bm)
+
+    await _reconcile_state(ctx, source="test")
+
+    assert bm.reconcile_calls == [SYMBOL]
+    assert _entry_blocker_for(bm) is None
+
+
+@pytest.mark.asyncio
+async def test_reconcile_state_does_not_clear_when_broker_exposure_unknown(tmp_path, monkeypatch) -> None:
+    from nifty_scalper_bot.core.app import _reconcile_state
+    from nifty_scalper_bot.execution.position_snapshot import BrokerExposureState
+
+    bm = _ExitConvergingBracket(SYMBOL)
+    ctx, pm, _broker = _reconcile_ctx(tmp_path, [_broker_row(0)], bm)
+    monkeypatch.setattr(pm, "broker_exposure_state", lambda _symbol: BrokerExposureState.UNKNOWN)
+
+    await _reconcile_state(ctx, source="test")
+
+    assert bm.reconcile_calls == []
+    assert _entry_blocker_for(bm)["block_reason"] == "unresolved_exit_position"
+
+
+@pytest.mark.asyncio
+async def test_reconcile_state_does_not_clear_when_broker_position_nonzero(tmp_path) -> None:
+    from nifty_scalper_bot.core.app import _reconcile_state
+
+    bm = _ExitConvergingBracket(SYMBOL)
+    ctx, _pm, _broker = _reconcile_ctx(tmp_path, [_broker_row(QTY)], bm)
+
+    await _reconcile_state(ctx, source="test")
+
+    assert bm.reconcile_calls == []
+    assert _entry_blocker_for(bm)["block_reason"] == "unresolved_exit_position"
+
+
+@pytest.mark.asyncio
+async def test_reconcile_state_does_not_clear_on_local_position_disagreement(tmp_path, monkeypatch) -> None:
+    from nifty_scalper_bot.core.app import _reconcile_state
+
+    bm = _ExitConvergingBracket(SYMBOL)
+    ctx, pm, _broker = _reconcile_ctx(tmp_path, [_broker_row(0)], bm)
+    disagreement = SimpleNamespace(quantity=QTY)
+    monkeypatch.setattr(pm, "get_position", lambda _symbol: disagreement)
+
+    await _reconcile_state(ctx, source="test")
+
+    assert bm.reconcile_calls == []
+    assert _entry_blocker_for(bm)["block_reason"] == "unresolved_exit_position"
+
+
+@pytest.mark.asyncio
+async def test_flat_exit_reconciliation_is_idempotent_across_reconcile_runs(tmp_path) -> None:
+    from nifty_scalper_bot.core.app import _reconcile_state
+
+    bm = _ExitConvergingBracket(SYMBOL)
+    ctx, _pm, _broker = _reconcile_ctx(tmp_path, [_broker_row(0)], bm)
+
+    await _reconcile_state(ctx, source="test")
+    await _reconcile_state(ctx, source="test")
+
+    assert bm.reconcile_calls == [SYMBOL]
+    assert bm.managed_symbols() == ()
+    assert _entry_blocker_for(bm) is None
+
+
+@pytest.mark.asyncio
+async def test_non_exit_ghost_bracket_not_changed_by_flat_exit_helper(tmp_path) -> None:
+    from nifty_scalper_bot.core.app import _reconcile_state
+
+    bm = _ExitConvergingBracket(SYMBOL, converging=False)
+    ctx, _pm, _broker = _reconcile_ctx(tmp_path, [_broker_row(0)], bm)
+
+    await _reconcile_state(ctx, source="test")
+
+    assert bm.reconcile_calls == []
+    assert bm.managed_symbols() == (SYMBOL,)

--- a/tests/execution/test_exit_reconciliation_race.py
+++ b/tests/execution/test_exit_reconciliation_race.py
@@ -8,7 +8,7 @@ from typing import Any
 
 import pytest
 
-from nifty_scalper_bot.execution.bracket_manager import BracketManager
+from nifty_scalper_bot.execution.bracket_manager import BracketExitLifecycle, BracketManager
 from nifty_scalper_bot.execution.ownership import BoundBracketManager
 from nifty_scalper_bot.execution.position_manager import Position, PositionManager
 from nifty_scalper_bot.strategies.runner import StrategyRunner
@@ -841,7 +841,6 @@ class _ExitConvergingBracket:
         self.symbol = symbol
         self.converging = converging
         self.reconcile_calls: list[str] = []
-        self.broker_calls = 0
         self._managed = True
 
     def managed_symbols(self) -> tuple[str, ...]:
@@ -890,6 +889,83 @@ def _reconcile_ctx(tmp_path, broker_positions: list[dict[str, Any]], bm: Any) ->
     ctx.unprotected_broker_positions = set()
     ctx.unprotected_broker_position = False
     return ctx, pm, broker
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("broker_rows", "expected_exposure"),
+    [
+        ([_broker_row(0)], "FLAT"),
+        ([], "ABSENT"),
+    ],
+)
+async def test_real_bracket_manager_flat_reconcile_clears_unresolved_entry_blocker(
+    tmp_path,
+    broker_rows: list[dict[str, Any]],
+    expected_exposure: str,
+) -> None:
+    from nifty_scalper_bot.core.app import _reconcile_state
+    from nifty_scalper_bot.execution.position_snapshot import BrokerExposureState
+
+    broker = _ReconBroker(broker_rows)
+    pm = PositionManager(str(tmp_path / "positions.json"))
+    order_manager = _ReconOrderManager(None, broker)
+    order_manager._position_manager = pm
+    order_manager._positions = pm
+    bm = BracketManager(order_manager=order_manager)
+    order_manager._bracket_manager = bm
+
+    try:
+        bm.register_virtual_bracket(
+            order_id="entry-stale-exit",
+            symbol=SYMBOL,
+            side="BUY",
+            qty=QTY,
+            price=100.0,
+            sl=90.0,
+            tp=120.0,
+        )
+        bm.confirm_entry_fill("entry-stale-exit", 100.0)
+        bracket = bm.get_bracket("entry-stale-exit")
+        assert bracket is not None
+        bracket.exit_pending = True
+        bracket.exit_state = BracketExitLifecycle.EXIT_ORDER_SUBMITTED.value
+        bracket.pending_exit_order_id = "exit-stale"
+
+        assert bm.is_exit_converging(SYMBOL) is True
+        blocker_before = bm.current_entry_blocker()
+        assert blocker_before is not None
+        assert blocker_before["block_reason"] == "unresolved_exit_position"
+
+        ctx = SimpleNamespace()
+        ctx.position_manager = pm
+        ctx.order_manager = order_manager
+        ctx.broker_client = _ReconBrokerClient(broker)
+        ctx.unresolved_reconciliation_symbols = set()
+        ctx.unprotected_broker_positions = set()
+        ctx.unprotected_broker_position = False
+
+        await _reconcile_state(ctx, source="test")
+
+        assert pm.broker_exposure_state(SYMBOL) is getattr(
+            BrokerExposureState, expected_exposure
+        )
+        assert bm.is_exit_converging(SYMBOL) is False
+        assert bm.current_entry_blocker() is None
+        assert (
+            bm.get_bracket("entry-stale-exit") is None
+            or SYMBOL not in bm.managed_symbols()
+        )
+
+        await _reconcile_state(ctx, source="test")
+
+        assert bm.is_exit_converging(SYMBOL) is False
+        assert bm.current_entry_blocker() is None
+        assert bm.get_bracket("orphan_" + SYMBOL) is None
+        assert list(bm.managed_symbols()).count(SYMBOL) <= 1
+        assert broker.get_positions_calls == 2
+    finally:
+        _stop_bracket_manager(bm)
 
 
 @pytest.mark.asyncio

--- a/tests/execution/test_lifecycle_entry_guards.py
+++ b/tests/execution/test_lifecycle_entry_guards.py
@@ -202,11 +202,22 @@ def test_current_entry_blocker_is_read_only() -> None:
     state = {"managed": True, "unresolved": True}
     manager.has_unresolved_exit = lambda: state["unresolved"]
     manager.get_first_unresolved_exit_bracket_id = lambda: "entry-1"
-    manager.reconcile_symbol_flat = lambda _symbol: (_ for _ in ()).throw(AssertionError("reconcile called"))
+    reconcile_calls = 0
 
-    before = dict(state)
+    def forbidden_reconcile(_symbol: str) -> None:
+        nonlocal reconcile_calls
+        reconcile_calls += 1
+        raise AssertionError("reconcile called")
+
+    manager.reconcile_symbol_flat = forbidden_reconcile
+
+    before = {
+        "unresolved": state["unresolved"],
+        "managed": state["managed"],
+    }
     blocker = manager.current_entry_blocker()
 
     assert blocker is not None
     assert blocker["block_reason"] == "unresolved_exit_position"
+    assert reconcile_calls == 0
     assert state == before

--- a/tests/execution/test_lifecycle_entry_guards.py
+++ b/tests/execution/test_lifecycle_entry_guards.py
@@ -192,3 +192,21 @@ def test_bound_bracket_manager_keeps_unresolved_bracket_priority() -> None:
     assert blocker is not None
     assert blocker["block_reason"] == "unresolved_exit_position"
     assert blocker["bracket_id"] == "bracket-1"
+
+
+def test_current_entry_blocker_is_read_only() -> None:
+    broker = SimpleNamespace(get_positions=lambda: (_ for _ in ()).throw(AssertionError("broker called")))
+    order_manager = SimpleNamespace(_position_manager=None, _broker=broker)
+    manager = BoundBracketManager.__new__(BoundBracketManager)
+    manager.order_manager = order_manager
+    state = {"managed": True, "unresolved": True}
+    manager.has_unresolved_exit = lambda: state["unresolved"]
+    manager.get_first_unresolved_exit_bracket_id = lambda: "entry-1"
+    manager.reconcile_symbol_flat = lambda _symbol: (_ for _ in ()).throw(AssertionError("reconcile called"))
+
+    before = dict(state)
+    blocker = manager.current_entry_blocker()
+
+    assert blocker is not None
+    assert blocker["block_reason"] == "unresolved_exit_position"
+    assert state == before


### PR DESCRIPTION
### Motivation

- A stale BracketManager exit lifecycle could remain after a successful broker reconciliation and PositionManager proving a symbol is FLAT/ABSENT, causing the native entry gate to continue reporting `unresolved_exit_position` incorrectly. 
- The change implements a minimal, safe reconciliation-time cleanup that preserves PositionManager as the sole source of broker-position truth and keeps BracketManager as the lifecycle owner. 

### Description

- Add `_reconcile_flat_exit_brackets(ctx: BotContext) -> int` in `src/nifty_scalper_bot/core/app.py` that iterates BracketManager symbols via a read-only accessor, consults `PositionManager.broker_exposure_state()` and `get_position()` and calls `BracketManager.reconcile_symbol_flat()` only when broker exposure is `FLAT`/`ABSENT`, local position quantity is zero, and `is_exit_converging(symbol)` is true. 
- Call the helper once immediately after `ctx.position_manager.synchronize_with_broker(...)` during `_reconcile_state()` and emit one structured summary log when reconciliations > 0. 
- Add a small read-only `BracketManager.managed_symbols()` accessor in `src/nifty_scalper_bot/execution/bracket_core.py` that returns a detached tuple of normalized symbols under the existing lock. 
- Add focused tests covering broker FLAT/ABSENT, UNKNOWN, NONZERO, local-position disagreement, idempotency, non-exit ghost separation, and a read-only `current_entry_blocker()` regression in `tests/execution/*` without mutating `current_entry_blocker()` behavior. 

### Testing

- Ran `python -m compileall -q src tests` and it completed successfully (exit 0). 
- Ran focused suites `pytest -q tests/execution/test_lifecycle_entry_guards.py tests/execution/test_exit_reconciliation_race.py tests/execution/test_readiness_execution_safety_blockers.py tests/execution/test_canonical_execution_recovery.py` and they passed (exit 0). 
- An intermediate run of `pytest -q tests/execution` encountered an environment `OSError: [Errno 24] Too many open files` during pytest tmpdir cleanup, which is an ephemeral test-run resource limit and not a behavioral regression. 
- Re-ran CI-style checks including `pytest -q -m live_runtime_e2e tests/e2e/live_sim` and a full `pytest -q`, which completed successfully in this environment. 

Files changed: 4 (production: `src/nifty_scalper_bot/core/app.py`, `src/nifty_scalper_bot/execution/bracket_core.py`; tests: `tests/execution/test_exit_reconciliation_race.py`, `tests/execution/test_lifecycle_entry_guards.py`). Production LOC added: ~71 lines (helper + call site + small accessor), tests + fixtures added for coverage.

Static safety confirmation: no new direct calls to `get_positions()`/`positions()` were added in `bracket_core.py`, `ownership.py`, `strategies/runner.py` or `native_entry_gate.py`; `current_entry_blocker()` remains read-only and BracketManager does not call broker APIs as part of the entry gate logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6376424c588324bd74c4b9c38a1317)