### PR TITLE
fix: coalesce new-entry strategy evaluation off the MDM tick-ingestion call stack

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -10771,6 +10771,16 @@ async def startup_sequence(ctx: BotContext) -> None:
     ):
         ctx.market_data_manager.set_event_loop(loop)
 
+    # Hand the Runner the authoritative running application loop. Ticks are
+    # delivered on background websocket/drain threads that have no loop of
+    # their own, so entry-evaluation drains can only be scheduled onto a loop
+    # explicitly attached here. This MUST happen before market data starts,
+    # otherwise early ticks would be marked pending with no scheduler.
+    if ctx.strategy_runner is not None and hasattr(
+        ctx.strategy_runner, "attach_runtime_loop"
+    ):
+        ctx.strategy_runner.attach_runtime_loop(loop)
+
     _set_startup_phase(ctx, "create_strategy_layer")
     _set_startup_phase(ctx, "wire_message_bus")
     _wire_and_start_message_bus(ctx)

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -29,8 +29,10 @@ from __future__ import annotations
 import asyncio
 import calendar
 from collections import defaultdict, deque
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import suppress
 import dataclasses
+import functools
 from dataclasses import dataclass, field
 from datetime import datetime, time as dt_time, timedelta, timezone
 from enum import Enum
@@ -199,6 +201,21 @@ class EntryEvaluationRoute(str, Enum):
     OPTION_CANDIDATE = "option_candidate"
     POSITION_MANAGEMENT = "position_management"
     CONTEXT_ONLY = "context_only"
+
+
+# Routes whose heavy evaluation is coalesced onto the dedicated entry-eval
+# worker. POSITION_MANAGEMENT is deliberately absent: protective/bracket work
+# always runs synchronously on the ingestion path and is never deferred.
+# CONTEXT_ONLY is included because its heavy body (indicator/context snapshot
+# refresh through the full _on_tick) previously ran inline on the MDM/main
+# event loop; it is still evaluated, just coalesced to latest state.
+_ENTRY_EVAL_COALESCED_ROUTES = frozenset(
+    {
+        EntryEvaluationRoute.OPTION_CANDIDATE,
+        EntryEvaluationRoute.UNDERLYING,
+        EntryEvaluationRoute.CONTEXT_ONLY,
+    }
+)
 
 
 def _env_flag(name: str, default: bool = False) -> bool:
@@ -1166,10 +1183,31 @@ class StrategyRunner:
         self._pending_entry_eval_symbols: set[str] = set()
         self._entry_eval_generation_by_symbol: dict[str, int] = defaultdict(int)
         self._entry_eval_drained_generation: dict[str, int] = {}
+        self._entry_eval_trace_id_by_symbol: dict[str, str] = {}
         self._entry_eval_drain_scheduled: bool = False
         self._entry_eval_active: bool = False
         self._entry_eval_drain_count: int = 0
         self._entry_eval_reschedule_count: int = 0
+        self._entry_eval_shutdown: bool = False
+        # Exactly one dedicated worker. The heavy phase9 _on_tick body runs
+        # here instead of on the MDM/main event loop, so tick draining,
+        # candle construction, heartbeat and context freshness keep running
+        # while a strategy evaluation is in flight. max_workers=1 preserves
+        # the existing serial entry-evaluation semantics (no concurrent
+        # mutation of Runner state, no duplicate concurrent evaluations).
+        # Never the default shared executor: this path is stateful.
+        self._entry_eval_executor = ThreadPoolExecutor(
+            max_workers=1,
+            thread_name_prefix="nifty-entry-eval",
+        )
+        # Latch the runtime loop early. Ticks are delivered on background
+        # (websocket/drain) threads that have no event loop of their own, so
+        # the drain can only ever be scheduled onto a loop captured from a
+        # thread that has one. Runner construction happens on the runtime
+        # thread that owns the loop, making this the reliable capture point.
+        # Later attachments (start paths) still overwrite this.
+        if getattr(self, "_main_loop", None) is None:
+            self._main_loop = self._discover_runtime_loop()
         self._eval_counter = 0
         self._signal_counter = 0
         self._regime_block_counter = 0
@@ -1503,7 +1541,36 @@ class StrategyRunner:
                 self._market_data.unsubscribe(symbol, callback)
 
         self._market_data.stop()
+        self._shutdown_entry_eval_worker()
         self._logger.info("Strategy runner stopped")
+
+    def _shutdown_entry_eval_worker(self) -> None:
+        """Stop the dedicated entry-eval worker without leaking threads.
+
+        Marks shutdown state first so _notify_entry_eval_pending stops
+        accepting work, no further drain is scheduled, and no evaluation
+        begins after shutdown. Args: none. Returns: none. Raises: none.
+        """
+        with self._eval_gate_lock:
+            self._entry_eval_shutdown = True
+            self._pending_entry_eval_symbols.clear()
+            self._entry_eval_drain_scheduled = False
+        executor = getattr(self, "_entry_eval_executor", None)
+        if executor is None:
+            return
+        try:
+            executor.shutdown(wait=True, cancel_futures=True)
+        except TypeError:  # pragma: no cover - Python < 3.9 compatibility
+            executor.shutdown(wait=True)
+        except Exception as exc:  # noqa: BLE001 - shutdown must never raise
+            self._logger.warning(
+                "ENTRY_EVAL_EXECUTOR_SHUTDOWN_FAILED error_type=%s",
+                type(exc).__name__,
+                extra={
+                    "event": "ENTRY_EVAL_EXECUTOR_SHUTDOWN_FAILED",
+                    "error_type": type(exc).__name__,
+                },
+            )
 
     def pause_trading(self) -> None:
         """Temporarily prevent order placement while keeping data flowing."""
@@ -7770,19 +7837,31 @@ class StrategyRunner:
             # backfills. Ticks will now flow directly into Phase 0/1/4 so the
             # OneMinuteBarBuilder can construct live candles autonomously.
 
-            # Category-1 tick/strategy separation: new-entry candidate routes
-            # (a selected/trigger-candidate option, or an underlying trigger)
-            # are coalesced into a bounded async drain instead of running the
-            # heavy phase9 body inline here. POSITION_MANAGEMENT (open
-            # positions -- protective/bracket handling already ran above at
-            # PHASE -1 inside _on_tick for the synchronous routes) and
-            # CONTEXT_ONLY both keep calling _on_tick synchronously,
-            # unchanged, exactly as before this fix.
+            # Category-1 tick/strategy separation.
+            #
+            # POSITION_MANAGEMENT: protection ONLY, synchronously, right here.
+            # Stop-loss / take-profit / trailing must never wait behind a busy
+            # entry evaluation, so this route no longer runs the full heavy
+            # _on_tick body at all -- just the extracted protective phase.
+            #
+            # OPTION_CANDIDATE / UNDERLYING / CONTEXT_ONLY: the heavy body is
+            # coalesced to latest state and executed on the dedicated
+            # single-worker executor, off the MDM/main event loop.
             route = self._entry_evaluation_route(normalized_symbol)
-            if route in (
-                EntryEvaluationRoute.OPTION_CANDIDATE,
-                EntryEvaluationRoute.UNDERLYING,
-            ):
+            if route == EntryEvaluationRoute.POSITION_MANAGEMENT:
+                self._handle_position_tick_protection(
+                    normalized_symbol,
+                    {**dict(tick), "trace_id": trace_id},
+                )
+                return
+            if route in _ENTRY_EVAL_COALESCED_ROUTES:
+                # Protection still runs immediately for every tick, on this
+                # thread, before the heavy evaluation is deferred -- the
+                # bracket manager must see every tick regardless of route.
+                self._handle_position_tick_protection(
+                    normalized_symbol,
+                    {**dict(tick), "trace_id": trace_id},
+                )
                 self._notify_entry_eval_pending(normalized_symbol, trace_id=trace_id)
                 return
 
@@ -7865,6 +7944,102 @@ class StrategyRunner:
     # entirely unaffected -- this only changes *when* the existing heavy
     # phase9 body runs for new-entry candidates, never *what* it does.
 
+    def _handle_position_tick_protection(
+        self, symbol: str, tick: Mapping[str, Any]
+    ) -> None:
+        """Protective/open-position lifecycle handling only (former PHASE -1).
+
+        Forwards the tick to the bracket manager, which monitors SL/TP/
+        trailing for ALL active positions and MUST receive every tick
+        regardless of market hours, stale-tick status, or any other
+        condition -- without this, stop losses and take profits never fire.
+
+        This runs synchronously on the ingestion path and is NEVER routed to
+        the entry-evaluation worker. Extracted mechanically from _on_tick:
+        stop/target/trailing rules, exit quantity, exit idempotency, bracket
+        transitions, broker calls and exception semantics are all unchanged.
+        Args: symbol, tick. Returns: none. Raises: none.
+        """
+        if self._bracket_manager:
+            try:
+                _ltp_raw = (
+                    tick.get("ltp") or tick.get("last_price") or tick.get("price") or 0.0
+                )
+                _ltp = float(_ltp_raw)
+                if _ltp > 0:
+                    self._bracket_manager.on_tick(
+                        symbol, _ltp, tick_exchange_epoch(tick)
+                    )
+                    tick_err_map = getattr(
+                        self._bracket_manager, "_tick_error_logged", None
+                    )
+                    if isinstance(tick_err_map, dict):
+                        tick_err_map[symbol] = False
+            except Exception as _bm_err:
+                tick_err_map = getattr(self._bracket_manager, "_tick_error_logged", None)
+                already_logged = bool(
+                    isinstance(tick_err_map, dict) and tick_err_map.get(symbol)
+                )
+                if not already_logged:
+                    self._logger.error(
+                        "Bracket tick handler error",
+                        extra={
+                            "event": "bracket_tick_handler_error",
+                            "symbol": symbol,
+                            "error": str(_bm_err),
+                        },
+                    )
+                    if isinstance(tick_err_map, dict):
+                        tick_err_map[symbol] = True
+
+    def _schedule_entry_eval_drain(self) -> bool:
+        """Schedule exactly one entry-eval drain on the main loop.
+
+        Returns True when a drain was scheduled, False when no running loop
+        is reachable. NEVER runs evaluation inline and never raises.
+        Args: none. Returns: bool. Raises: none.
+        """
+        loop = self._main_loop
+        if loop is None or loop.is_closed():
+            # _main_loop may never have been attached (some runtimes drive the
+            # loop in slices and never start the Runner under it). Latch the
+            # thread's current loop once so pending work is scheduled rather
+            # than stranded. This never runs evaluation inline.
+            loop = self._discover_runtime_loop()
+            if loop is None:
+                return False
+            self._main_loop = loop
+        try:
+            # call_soon_threadsafe is valid on an open loop that is not
+            # currently running: the callback is queued and executes the next
+            # time the loop is driven. This keeps entry evaluation off the
+            # ingestion path (never inline) while ensuring pending work is
+            # not stranded in runtimes that pump the loop in slices.
+            loop.call_soon_threadsafe(
+                lambda: safe_task(self._drain_pending_entry_evaluations())
+            )
+            return True
+        except RuntimeError:
+            # Loop closed between the check and the submission.
+            return False
+
+    @staticmethod
+    def _discover_runtime_loop() -> asyncio.AbstractEventLoop | None:
+        """Best-effort lookup of this thread's event loop. Args: none.
+        Returns: an open loop or None. Raises: none.
+        """
+        try:
+            return asyncio.get_running_loop()
+        except RuntimeError:
+            pass
+        try:
+            loop = asyncio.get_event_loop_policy().get_event_loop()
+        except Exception:  # noqa: BLE001 - no usable loop on this thread
+            return None
+        if loop is None or loop.is_closed():
+            return None
+        return loop
+
     def _notify_entry_eval_pending(
         self, symbol: str, *, trace_id: str | None = None
     ) -> None:
@@ -7874,12 +8049,15 @@ class StrategyRunner:
         logging and leaving the symbol pending on any scheduling error).
         """
         try:
-            loop = self._main_loop
             with self._eval_gate_lock:
+                if self._entry_eval_shutdown:
+                    return
                 self._entry_eval_generation_by_symbol[symbol] += 1
                 generation = self._entry_eval_generation_by_symbol[symbol]
                 already_pending = symbol in self._pending_entry_eval_symbols
                 self._pending_entry_eval_symbols.add(symbol)
+                if trace_id:
+                    self._entry_eval_trace_id_by_symbol[symbol] = trace_id
                 should_schedule = (
                     not self._entry_eval_drain_scheduled
                     and not self._entry_eval_active
@@ -7899,20 +8077,30 @@ class StrategyRunner:
                     "trace_id": trace_id,
                 },
             )
-            if should_schedule:
-                if loop is not None and loop.is_running():
-                    loop.call_soon_threadsafe(
-                        lambda: safe_task(self._drain_pending_entry_evaluations())
-                    )
-                else:
-                    # No running loop reachable from this thread (e.g. a
-                    # focused unit test invoking the callback directly).
-                    # Run the drain inline rather than dropping the pending
-                    # evaluation -- still bounded to the pending set, never
-                    # replays intermediate ticks.
-                    with self._eval_gate_lock:
-                        self._entry_eval_drain_scheduled = False
-                    asyncio.run(self._drain_pending_entry_evaluations())
+            if should_schedule and not self._schedule_entry_eval_drain():
+                # No running loop reachable. The symbol STAYS pending and is
+                # retried by a later tick or an explicit scheduler recovery.
+                # Never run heavy evaluation inline on the ingestion path,
+                # and never asyncio.run() here.
+                loop = self._main_loop
+                with self._eval_gate_lock:
+                    self._entry_eval_drain_scheduled = False
+                log_throttled(
+                    self._logger,
+                    "entry_eval_scheduler_unavailable",
+                    "ENTRY_EVAL_SCHEDULER_UNAVAILABLE symbol=%s generation=%d"
+                    % (symbol, generation),
+                    interval_sec=30.0,
+                    extra={
+                        "event": "ENTRY_EVAL_SCHEDULER_UNAVAILABLE",
+                        "symbol": symbol,
+                        "generation": generation,
+                        "loop_present": loop is not None,
+                        "loop_running": bool(loop is not None and loop.is_running()),
+                        "shutdown_state": self._entry_eval_shutdown,
+                        "trace_id": trace_id,
+                    },
+                )
         except Exception as exc:  # noqa: BLE001 - must never crash MDM ingestion
             with self._eval_gate_lock:
                 self._entry_eval_drain_scheduled = False
@@ -7935,66 +8123,76 @@ class StrategyRunner:
         Raises: none (isolates one symbol's failure from the rest).
         """
         with self._eval_gate_lock:
-            if self._entry_eval_active:
+            if self._entry_eval_active or self._entry_eval_shutdown:
                 return
             self._entry_eval_active = True
             self._entry_eval_drain_scheduled = False
+            # ONE bounded batch per invocation: snapshot and clear. Symbols
+            # that receive newer ticks during this batch are re-added below
+            # and handled by exactly one follow-up drain, so a continuously
+            # busy symbol can never monopolise the drain (no `while True`).
+            pending = tuple(sorted(self._pending_entry_eval_symbols))
+            self._pending_entry_eval_symbols.clear()
+            captured = {
+                sym: self._entry_eval_generation_by_symbol[sym] for sym in pending
+            }
+            captured_trace = {
+                sym: self._entry_eval_trace_id_by_symbol.get(sym) for sym in pending
+            }
         drain_started = time.monotonic()
         processed = 0
         rescheduled = 0
+        loop = asyncio.get_running_loop()
         try:
-            while True:
-                with self._eval_gate_lock:
-                    pending = sorted(self._pending_entry_eval_symbols)
-                    self._pending_entry_eval_symbols.clear()
-                    captured_generations = {
-                        sym: self._entry_eval_generation_by_symbol[sym]
-                        for sym in pending
-                    }
-                if not pending:
+            for symbol in pending:
+                if self._entry_eval_shutdown:
                     break
-                for symbol in pending:
-                    try:
-                        self._evaluate_entry_from_latest_state(symbol)
-                    except Exception as exc:  # noqa: BLE001 - isolate one symbol
-                        self._logger.error(
-                            "SIGNAL_EVALUATION_FAILURE symbol=%s error_type=%s",
+                try:
+                    # Heavy phase9 body runs on the dedicated single worker,
+                    # NOT on this event loop -- tick drain, candle updates and
+                    # heartbeat keep running while it executes. One symbol at
+                    # a time (max_workers=1 plus the single-flight drain), so
+                    # no concurrent evaluation of the same or another symbol.
+                    await loop.run_in_executor(
+                        self._entry_eval_executor,
+                        functools.partial(
+                            self._evaluate_entry_from_latest_state,
                             symbol,
-                            type(exc).__name__,
-                            extra={
-                                "event": "SIGNAL_EVALUATION_FAILURE",
-                                "symbol": symbol,
-                                "error_type": type(exc).__name__,
-                            },
-                        )
-                    finally:
-                        with self._eval_gate_lock:
-                            self._entry_eval_drained_generation[symbol] = (
-                                captured_generations[symbol]
-                            )
+                            trace_id=captured_trace.get(symbol),
+                        ),
+                    )
+                except Exception as exc:  # noqa: BLE001 - isolate one symbol
+                    self._logger.error(
+                        "SIGNAL_EVALUATION_FAILURE symbol=%s error_type=%s",
+                        symbol,
+                        type(exc).__name__,
+                        extra={
+                            "event": "SIGNAL_EVALUATION_FAILURE",
+                            "symbol": symbol,
+                            "error_type": type(exc).__name__,
+                        },
+                    )
+                finally:
                     processed += 1
-                    await asyncio.sleep(0)
-                with self._eval_gate_lock:
-                    newer = {
-                        sym
-                        for sym in pending
-                        if self._entry_eval_generation_by_symbol[sym]
-                        != self._entry_eval_drained_generation.get(sym)
-                    }
-                    if newer:
-                        self._pending_entry_eval_symbols.update(newer)
-                        rescheduled += len(newer)
-                    else:
-                        break
+                    with self._eval_gate_lock:
+                        self._entry_eval_drained_generation[symbol] = captured[symbol]
+                        if (
+                            self._entry_eval_generation_by_symbol[symbol]
+                            != captured[symbol]
+                            and not self._entry_eval_shutdown
+                        ):
+                            self._pending_entry_eval_symbols.add(symbol)
+                            rescheduled += 1
         finally:
             with self._eval_gate_lock:
                 self._entry_eval_active = False
-                pending_remaining = bool(self._pending_entry_eval_symbols)
-                if pending_remaining and not self._entry_eval_drain_scheduled:
+                needs_next = bool(self._pending_entry_eval_symbols) and not (
+                    self._entry_eval_shutdown
+                )
+                if needs_next and not self._entry_eval_drain_scheduled:
                     self._entry_eval_drain_scheduled = True
-                    reschedule_needed = True
                 else:
-                    reschedule_needed = False
+                    needs_next = False
                 self._entry_eval_drain_count += 1
                 self._entry_eval_reschedule_count += rescheduled
             duration_ms = (time.monotonic() - drain_started) * 1000.0
@@ -8014,15 +8212,9 @@ class StrategyRunner:
                     "active_basket_size": len(getattr(self, "_active_symbols", ())),
                 },
             )
-            if reschedule_needed:
-                loop = self._main_loop
-                if loop is not None and loop.is_running():
-                    loop.call_soon_threadsafe(
-                        lambda: safe_task(self._drain_pending_entry_evaluations())
-                    )
-                else:
-                    with self._eval_gate_lock:
-                        self._entry_eval_drain_scheduled = False
+            if needs_next and not self._schedule_entry_eval_drain():
+                with self._eval_gate_lock:
+                    self._entry_eval_drain_scheduled = False
 
     def _evaluate_entry_from_latest_state(
         self,
@@ -8036,16 +8228,41 @@ class StrategyRunner:
         strategy/risk/order behaviour changes here. Args: symbol, trace_id.
         Returns: none. Raises: propagates to the drain's per-symbol isolation.
         """
+        if self._entry_eval_shutdown:
+            return
         latest_tick = self._last_tick.get(symbol)
         if not latest_tick:
             # No canonical tick observed yet for this symbol; nothing to
             # evaluate against. Same "missing state" outcome _on_tick already
             # produces when it cannot resolve a price.
             return
+        # Re-assert canonical symbol authority on the worker: between the tick
+        # that marked this symbol pending and this evaluation, the basket may
+        # have rolled to a new subscription generation / a different selected
+        # contract. _entry_evaluation_route is the existing single authority
+        # (role, active basket, selected-candidate status) -- if the symbol is
+        # no longer an entry candidate, skip rather than trade a stale one.
+        route = self._entry_evaluation_route(symbol)
+        if route not in _ENTRY_EVAL_COALESCED_ROUTES:
+            self._logger.debug(
+                "ENTRY_EVAL_SKIPPED_SUPERSEDED symbol=%s route=%s",
+                symbol,
+                getattr(route, "value", route),
+                extra={
+                    "event": "ENTRY_EVAL_SKIPPED_SUPERSEDED",
+                    "symbol": symbol,
+                    "route": getattr(route, "value", str(route)),
+                    "trace_id": trace_id,
+                },
+            )
+            return
         tick_payload = dict(latest_tick)
         tick_payload["trace_id"] = (
             trace_id or tick_payload.get("trace_id") or f"{symbol}-drain"
         )
+        # Protection already ran synchronously in _on_tick_safe when this tick
+        # was ingested, so _on_tick must not run it a second time.
+        tick_payload["_protection_already_handled"] = True
         self._on_tick(symbol, tick_payload)
 
     def _health_watchdog(self) -> None:
@@ -13088,46 +13305,14 @@ class StrategyRunner:
             # =================================================================
             # PHASE -1: BRACKET MANAGER TICK FORWARDING (MUST be before ANY return)
             # =================================================================
-            # CRITICAL: The bracket manager monitors SL/TP/trailing for ALL
-            # active positions. It MUST receive every tick regardless of
-            # market hours, stale-tick status, or any other condition.
-            # Without this, stop losses and take profits NEVER fire.
-            if self._bracket_manager:
-                try:
-                    _ltp_raw = (
-                        tick.get("ltp")
-                        or tick.get("last_price")
-                        or tick.get("price")
-                        or 0.0
-                    )
-                    _ltp = float(_ltp_raw)
-                    if _ltp > 0:
-                        self._bracket_manager.on_tick(
-                            symbol, _ltp, tick_exchange_epoch(tick)
-                        )
-                        tick_err_map = getattr(
-                            self._bracket_manager, "_tick_error_logged", None
-                        )
-                        if isinstance(tick_err_map, dict):
-                            tick_err_map[symbol] = False
-                except Exception as _bm_err:
-                    tick_err_map = getattr(
-                        self._bracket_manager, "_tick_error_logged", None
-                    )
-                    already_logged = bool(
-                        isinstance(tick_err_map, dict) and tick_err_map.get(symbol)
-                    )
-                    if not already_logged:
-                        self._logger.error(
-                            "Bracket tick handler error",
-                            extra={
-                                "event": "bracket_tick_handler_error",
-                                "symbol": symbol,
-                                "error": str(_bm_err),
-                            },
-                        )
-                        if isinstance(tick_err_map, dict):
-                            tick_err_map[symbol] = True
+            # Extracted verbatim into _handle_position_tick_protection so the
+            # POSITION_MANAGEMENT route can run protection-only, synchronously,
+            # without dragging the whole heavy entry-evaluation body with it.
+            # `_protection_already_handled` is set by _on_tick_safe when it has
+            # already run protection for this exact tick, so one tick never
+            # produces two protective lifecycle updates.
+            if not bool(tick.get("_protection_already_handled")):
+                self._handle_position_tick_protection(symbol, tick)
 
             # =================================================================
             # PHASE 0: EARLY EXIT CHECKS (Fast path for non-trading scenarios)

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -143,6 +143,7 @@ from nifty_scalper_bot.strategies.signal_quality import (
 )
 from nifty_scalper_bot.strategies.trade_selector import TradeCandidateSelector
 from nifty_scalper_bot.utils import metrics
+from nifty_scalper_bot.utils.async_helpers import safe_task
 from nifty_scalper_bot.utils.errors import OrderPlacementError
 from nifty_scalper_bot.utils.log_throttle import (
     log_on_change,
@@ -1155,6 +1156,20 @@ class StrategyRunner:
         self._eval_queue_peak = 0
         self._eval_queue_lock = threading.Lock()
         self._eval_in_progress_symbols: set[str] = set()
+        # Bounded new-entry evaluation coalescing (protected by
+        # _eval_gate_lock, reused rather than a new lock). Ticks routed to
+        # OPTION_CANDIDATE/UNDERLYING mark the symbol pending here and
+        # schedule at most one drain task instead of running the heavy
+        # phase9 body inline on the MDM/DataHub tick-ingestion call stack.
+        # POSITION_MANAGEMENT and CONTEXT_ONLY routes are unaffected and
+        # continue to call _on_tick synchronously exactly as before.
+        self._pending_entry_eval_symbols: set[str] = set()
+        self._entry_eval_generation_by_symbol: dict[str, int] = defaultdict(int)
+        self._entry_eval_drained_generation: dict[str, int] = {}
+        self._entry_eval_drain_scheduled: bool = False
+        self._entry_eval_active: bool = False
+        self._entry_eval_drain_count: int = 0
+        self._entry_eval_reschedule_count: int = 0
         self._eval_counter = 0
         self._signal_counter = 0
         self._regime_block_counter = 0
@@ -7755,6 +7770,22 @@ class StrategyRunner:
             # backfills. Ticks will now flow directly into Phase 0/1/4 so the
             # OneMinuteBarBuilder can construct live candles autonomously.
 
+            # Category-1 tick/strategy separation: new-entry candidate routes
+            # (a selected/trigger-candidate option, or an underlying trigger)
+            # are coalesced into a bounded async drain instead of running the
+            # heavy phase9 body inline here. POSITION_MANAGEMENT (open
+            # positions -- protective/bracket handling already ran above at
+            # PHASE -1 inside _on_tick for the synchronous routes) and
+            # CONTEXT_ONLY both keep calling _on_tick synchronously,
+            # unchanged, exactly as before this fix.
+            route = self._entry_evaluation_route(normalized_symbol)
+            if route in (
+                EntryEvaluationRoute.OPTION_CANDIDATE,
+                EntryEvaluationRoute.UNDERLYING,
+            ):
+                self._notify_entry_eval_pending(normalized_symbol, trace_id=trace_id)
+                return
+
             with self._eval_gate_lock:
                 if normalized_symbol in self._eval_in_progress_symbols:
                     return
@@ -7825,6 +7856,197 @@ class StrategyRunner:
                 self._regime_block_counter = 0
                 self._capital_block_counter = 0
                 self._last_summary_log = now
+
+    # ==================== ENTRY-EVAL COALESCING (Category 1) ====================
+    # Applies only to new-entry strategy evaluation (OPTION_CANDIDATE/
+    # UNDERLYING routes). MDM/DataHub tick ingestion, CandleEngine updates,
+    # and protective/bracket handling (POSITION_MANAGEMENT route, and Phase -1
+    # bracket forwarding inside _on_tick for whichever route runs) are
+    # entirely unaffected -- this only changes *when* the existing heavy
+    # phase9 body runs for new-entry candidates, never *what* it does.
+
+    def _notify_entry_eval_pending(
+        self, symbol: str, *, trace_id: str | None = None
+    ) -> None:
+        """Mark a new-entry candidate pending and schedule at most one bounded
+        drain. Must stay cheap: no strategy evaluation happens here.
+        Args: symbol, trace_id. Returns: none. Raises: none (fails closed by
+        logging and leaving the symbol pending on any scheduling error).
+        """
+        try:
+            loop = self._main_loop
+            with self._eval_gate_lock:
+                self._entry_eval_generation_by_symbol[symbol] += 1
+                generation = self._entry_eval_generation_by_symbol[symbol]
+                already_pending = symbol in self._pending_entry_eval_symbols
+                self._pending_entry_eval_symbols.add(symbol)
+                should_schedule = (
+                    not self._entry_eval_drain_scheduled
+                    and not self._entry_eval_active
+                )
+                if should_schedule:
+                    self._entry_eval_drain_scheduled = True
+            self._logger.debug(
+                "ENTRY_EVAL_COALESCED symbol=%s generation=%d already_pending=%s",
+                symbol,
+                generation,
+                already_pending,
+                extra={
+                    "event": "ENTRY_EVAL_COALESCED",
+                    "symbol": symbol,
+                    "generation": generation,
+                    "already_pending": already_pending,
+                    "trace_id": trace_id,
+                },
+            )
+            if should_schedule:
+                if loop is not None and loop.is_running():
+                    loop.call_soon_threadsafe(
+                        lambda: safe_task(self._drain_pending_entry_evaluations())
+                    )
+                else:
+                    # No running loop reachable from this thread (e.g. a
+                    # focused unit test invoking the callback directly).
+                    # Run the drain inline rather than dropping the pending
+                    # evaluation -- still bounded to the pending set, never
+                    # replays intermediate ticks.
+                    with self._eval_gate_lock:
+                        self._entry_eval_drain_scheduled = False
+                    asyncio.run(self._drain_pending_entry_evaluations())
+        except Exception as exc:  # noqa: BLE001 - must never crash MDM ingestion
+            with self._eval_gate_lock:
+                self._entry_eval_drain_scheduled = False
+            self._logger.error(
+                "ENTRY_EVAL_SCHEDULE_FAILED symbol=%s error_type=%s",
+                symbol,
+                type(exc).__name__,
+                extra={
+                    "event": "ENTRY_EVAL_SCHEDULE_FAILED",
+                    "symbol": symbol,
+                    "error_type": type(exc).__name__,
+                    "trace_id": trace_id,
+                },
+            )
+
+    async def _drain_pending_entry_evaluations(self) -> None:
+        """Single-flight bounded drain of pending new-entry candidates.
+        Reads the latest canonical tick per symbol (never the stale payload
+        captured at notification time). Args: none. Returns: none.
+        Raises: none (isolates one symbol's failure from the rest).
+        """
+        with self._eval_gate_lock:
+            if self._entry_eval_active:
+                return
+            self._entry_eval_active = True
+            self._entry_eval_drain_scheduled = False
+        drain_started = time.monotonic()
+        processed = 0
+        rescheduled = 0
+        try:
+            while True:
+                with self._eval_gate_lock:
+                    pending = sorted(self._pending_entry_eval_symbols)
+                    self._pending_entry_eval_symbols.clear()
+                    captured_generations = {
+                        sym: self._entry_eval_generation_by_symbol[sym]
+                        for sym in pending
+                    }
+                if not pending:
+                    break
+                for symbol in pending:
+                    try:
+                        self._evaluate_entry_from_latest_state(symbol)
+                    except Exception as exc:  # noqa: BLE001 - isolate one symbol
+                        self._logger.error(
+                            "SIGNAL_EVALUATION_FAILURE symbol=%s error_type=%s",
+                            symbol,
+                            type(exc).__name__,
+                            extra={
+                                "event": "SIGNAL_EVALUATION_FAILURE",
+                                "symbol": symbol,
+                                "error_type": type(exc).__name__,
+                            },
+                        )
+                    finally:
+                        with self._eval_gate_lock:
+                            self._entry_eval_drained_generation[symbol] = (
+                                captured_generations[symbol]
+                            )
+                    processed += 1
+                    await asyncio.sleep(0)
+                with self._eval_gate_lock:
+                    newer = {
+                        sym
+                        for sym in pending
+                        if self._entry_eval_generation_by_symbol[sym]
+                        != self._entry_eval_drained_generation.get(sym)
+                    }
+                    if newer:
+                        self._pending_entry_eval_symbols.update(newer)
+                        rescheduled += len(newer)
+                    else:
+                        break
+        finally:
+            with self._eval_gate_lock:
+                self._entry_eval_active = False
+                pending_remaining = bool(self._pending_entry_eval_symbols)
+                if pending_remaining and not self._entry_eval_drain_scheduled:
+                    self._entry_eval_drain_scheduled = True
+                    reschedule_needed = True
+                else:
+                    reschedule_needed = False
+                self._entry_eval_drain_count += 1
+                self._entry_eval_reschedule_count += rescheduled
+            duration_ms = (time.monotonic() - drain_started) * 1000.0
+            self._logger.debug(
+                "ENTRY_EVAL_DRAIN pending_count=%d processed_count=%d "
+                "rescheduled_count=%d duration_ms=%.1f",
+                len(pending),
+                processed,
+                rescheduled,
+                duration_ms,
+                extra={
+                    "event": "ENTRY_EVAL_DRAIN",
+                    "pending_count": len(pending),
+                    "processed_count": processed,
+                    "rescheduled_count": rescheduled,
+                    "duration_ms": round(duration_ms, 1),
+                    "active_basket_size": len(getattr(self, "_active_symbols", ())),
+                },
+            )
+            if reschedule_needed:
+                loop = self._main_loop
+                if loop is not None and loop.is_running():
+                    loop.call_soon_threadsafe(
+                        lambda: safe_task(self._drain_pending_entry_evaluations())
+                    )
+                else:
+                    with self._eval_gate_lock:
+                        self._entry_eval_drain_scheduled = False
+
+    def _evaluate_entry_from_latest_state(
+        self,
+        symbol: str,
+        *,
+        trace_id: str | None = None,
+    ) -> None:
+        """Evaluate one coalesced new-entry candidate using the latest
+        canonical tick (not a stale payload captured at notification time).
+        Delegates to the existing, unmodified heavy _on_tick body -- no
+        strategy/risk/order behaviour changes here. Args: symbol, trace_id.
+        Returns: none. Raises: propagates to the drain's per-symbol isolation.
+        """
+        latest_tick = self._last_tick.get(symbol)
+        if not latest_tick:
+            # No canonical tick observed yet for this symbol; nothing to
+            # evaluate against. Same "missing state" outcome _on_tick already
+            # produces when it cannot resolve a price.
+            return
+        tick_payload = dict(latest_tick)
+        tick_payload["trace_id"] = (
+            trace_id or tick_payload.get("trace_id") or f"{symbol}-drain"
+        )
+        self._on_tick(symbol, tick_payload)
 
     def _health_watchdog(self) -> None:
         """Args: none; Returns: none; Raises: none."""

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -1189,6 +1189,9 @@ class StrategyRunner:
         self._entry_eval_drain_count: int = 0
         self._entry_eval_reschedule_count: int = 0
         self._entry_eval_shutdown: bool = False
+        # True only once canonical startup has handed over the authoritative
+        # running application loop via attach_runtime_loop().
+        self._runtime_loop_attached: bool = False
         # Exactly one dedicated worker. The heavy phase9 _on_tick body runs
         # here instead of on the MDM/main event loop, so tick draining,
         # candle construction, heartbeat and context freshness keep running
@@ -1200,14 +1203,6 @@ class StrategyRunner:
             max_workers=1,
             thread_name_prefix="nifty-entry-eval",
         )
-        # Latch the runtime loop early. Ticks are delivered on background
-        # (websocket/drain) threads that have no event loop of their own, so
-        # the drain can only ever be scheduled onto a loop captured from a
-        # thread that has one. Runner construction happens on the runtime
-        # thread that owns the loop, making this the reliable capture point.
-        # Later attachments (start paths) still overwrite this.
-        if getattr(self, "_main_loop", None) is None:
-            self._main_loop = self._discover_runtime_loop()
         self._eval_counter = 0
         self._signal_counter = 0
         self._regime_block_counter = 0
@@ -7937,12 +7932,16 @@ class StrategyRunner:
                 self._last_summary_log = now
 
     # ==================== ENTRY-EVAL COALESCING (Category 1) ====================
-    # Applies only to new-entry strategy evaluation (OPTION_CANDIDATE/
-    # UNDERLYING routes). MDM/DataHub tick ingestion, CandleEngine updates,
-    # and protective/bracket handling (POSITION_MANAGEMENT route, and Phase -1
-    # bracket forwarding inside _on_tick for whichever route runs) are
-    # entirely unaffected -- this only changes *when* the existing heavy
-    # phase9 body runs for new-entry candidates, never *what* it does.
+    # Routing:
+    #   POSITION_MANAGEMENT
+    #       -> protection-only, synchronous on the ingestion path. Never runs
+    #          the heavy _on_tick body and never enters the coalescer.
+    #   OPTION_CANDIDATE / UNDERLYING / CONTEXT_ONLY
+    #       -> heavy evaluation coalesced to latest state and executed on the
+    #          dedicated single-worker executor, off the MDM/main event loop.
+    # MDM/DataHub tick ingestion, CandleEngine updates and protective/bracket
+    # handling all remain synchronous and ordered -- this changes *when* and
+    # *on which thread* the heavy phase9 body runs, never *what* it does.
 
     def _handle_position_tick_protection(
         self, symbol: str, tick: Mapping[str, Any]
@@ -7992,29 +7991,57 @@ class StrategyRunner:
                     if isinstance(tick_err_map, dict):
                         tick_err_map[symbol] = True
 
-    def _schedule_entry_eval_drain(self) -> bool:
-        """Schedule exactly one entry-eval drain on the main loop.
+    def attach_runtime_loop(self, loop: asyncio.AbstractEventLoop) -> None:
+        """Attach the authoritative application event loop used for entry drains.
 
-        Returns True when a drain was scheduled, False when no running loop
-        is reachable. NEVER runs evaluation inline and never raises.
+        Called once by canonical async startup, on the running application
+        loop, before live tick subscriptions can deliver ticks. Ticks arrive
+        on background websocket/drain threads that have no loop of their own,
+        so the drain can only be scheduled onto a loop explicitly handed over
+        here -- the Runner never infers or creates one.
+        Args: loop. Returns: none. Raises: RuntimeError on a closed or
+        non-running loop.
+        """
+        if loop.is_closed():
+            raise RuntimeError("cannot attach closed runtime loop")
+        if not loop.is_running():
+            raise RuntimeError("runtime loop must be running")
+        self._main_loop = loop
+        self._runtime_loop_attached = True
+        # Recover any work that was marked pending before the loop existed.
+        with self._eval_gate_lock:
+            should_recover = (
+                bool(self._pending_entry_eval_symbols)
+                and not self._entry_eval_active
+                and not self._entry_eval_drain_scheduled
+                and not self._entry_eval_shutdown
+            )
+            if should_recover:
+                self._entry_eval_drain_scheduled = True
+        if should_recover and not self._schedule_entry_eval_drain():
+            with self._eval_gate_lock:
+                self._entry_eval_drain_scheduled = False
+
+    def _schedule_entry_eval_drain(self) -> bool:
+        """Schedule exactly one entry-eval drain on the attached runtime loop.
+
+        Only ever schedules onto the explicitly attached live loop: it does
+        not discover, create or replace a loop, and never runs evaluation
+        inline. Returns True when a drain was scheduled.
         Args: none. Returns: bool. Raises: none.
         """
         loop = self._main_loop
         if loop is None or loop.is_closed():
-            # _main_loop may never have been attached (some runtimes drive the
-            # loop in slices and never start the Runner under it). Latch the
-            # thread's current loop once so pending work is scheduled rather
-            # than stranded. This never runs evaluation inline.
-            loop = self._discover_runtime_loop()
-            if loop is None:
-                return False
-            self._main_loop = loop
+            return False
+        if not loop.is_running() and not self._runtime_loop_attached:
+            # A loop that was never handed over by attach_runtime_loop() and
+            # is not currently running may be a dormant/inferred loop -- never
+            # schedule onto it. The attached loop is authoritative (attach
+            # itself requires a running loop), so it may be queued onto with
+            # call_soon_threadsafe even between pump slices; the callback runs
+            # the next time the loop is driven. Evaluation is never inline.
+            return False
         try:
-            # call_soon_threadsafe is valid on an open loop that is not
-            # currently running: the callback is queued and executes the next
-            # time the loop is driven. This keeps entry evaluation off the
-            # ingestion path (never inline) while ensuring pending work is
-            # not stranded in runtimes that pump the loop in slices.
             loop.call_soon_threadsafe(
                 lambda: safe_task(self._drain_pending_entry_evaluations())
             )
@@ -8022,23 +8049,6 @@ class StrategyRunner:
         except RuntimeError:
             # Loop closed between the check and the submission.
             return False
-
-    @staticmethod
-    def _discover_runtime_loop() -> asyncio.AbstractEventLoop | None:
-        """Best-effort lookup of this thread's event loop. Args: none.
-        Returns: an open loop or None. Raises: none.
-        """
-        try:
-            return asyncio.get_running_loop()
-        except RuntimeError:
-            pass
-        try:
-            loop = asyncio.get_event_loop_policy().get_event_loop()
-        except Exception:  # noqa: BLE001 - no usable loop on this thread
-            return None
-        if loop is None or loop.is_closed():
-            return None
-        return loop
 
     def _notify_entry_eval_pending(
         self, symbol: str, *, trace_id: str | None = None
@@ -8096,7 +8106,13 @@ class StrategyRunner:
                         "symbol": symbol,
                         "generation": generation,
                         "loop_present": loop is not None,
-                        "loop_running": bool(loop is not None and loop.is_running()),
+                        "loop_closed": bool(loop is not None and loop.is_closed()),
+                        "loop_running": bool(
+                            loop is not None
+                            and not loop.is_closed()
+                            and loop.is_running()
+                        ),
+                        "runtime_loop_attached": loop is not None,
                         "shutdown_state": self._entry_eval_shutdown,
                         "trace_id": trace_id,
                     },

--- a/tests/e2e/live_sim/test_live_runtime_startup_contract.py
+++ b/tests/e2e/live_sim/test_live_runtime_startup_contract.py
@@ -604,6 +604,16 @@ def test_live_runtime_bullish_spot_future_selects_ce_and_exits_target(
     try:
         asyncio.set_event_loop(loop)
         ctx = loop.run_until_complete(_initialize_runtime())
+
+        async def _attach_runtime_loop() -> None:
+            running = asyncio.get_running_loop()
+            ctx.strategy_runner.attach_runtime_loop(running)
+            # The Runner must hold the authoritative *running* application
+            # loop before any background tick thread can deliver ticks.
+            assert ctx.strategy_runner._main_loop is running  # noqa: SLF001
+            assert ctx.strategy_runner._main_loop.is_running()  # noqa: SLF001
+
+        loop.run_until_complete(_attach_runtime_loop())
         ctx.instrument_manager.load()
         basket = ctx.instrument_manager.get_active_nifty_contracts(25000.0)
         basket_dict = {

--- a/tests/strategies/test_entry_eval_coalescing.py
+++ b/tests/strategies/test_entry_eval_coalescing.py
@@ -1,0 +1,497 @@
+"""Regression tests for bounded new-entry evaluation coalescing.
+
+Verifies StrategyRunner._on_tick_safe no longer runs the heavy phase9
+_on_tick body inline for OPTION_CANDIDATE/UNDERLYING routes, and that the
+bounded async drain (_drain_pending_entry_evaluations) preserves latest-state
+evaluation, fairness across symbols, mid-evaluation reschedule, exception
+isolation, and never delays protective/position-management routes.
+
+The underlying-trigger route (NSE:NIFTY registered in
+_trigger_candidate_symbols) is used as the "real evaluation reaches
+strategy_manager.generate_signal" fixture, since it is the one already
+proven to work end-to-end by test_nifty_underlying_reaches_strategy_manager
+in test_runner_symbol_role_gate.py. Tests that only need to verify the
+coalescing contract itself (fairness, reschedule-once, exception isolation)
+spy on _evaluate_entry_from_latest_state directly instead of depending on
+deeper phase9 gating internals, which are out of scope for this PR.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+from unittest.mock import Mock
+
+from nifty_scalper_bot.strategies.runner import EntryEvaluationRoute
+from nifty_scalper_bot.strategies.signal_generator import Signal
+from tests.strategies.test_runner_symbol_role_gate import _build_phase9_runner
+
+UNDERLYING_SYMBOL = "NSE:NIFTY"
+
+
+def _run_loop_in_thread():
+    loop = asyncio.new_event_loop()
+    thread = threading.Thread(target=loop.run_forever, daemon=True)
+    thread.start()
+    return loop, thread
+
+
+def _stop_loop(loop, thread):
+    loop.call_soon_threadsafe(loop.stop)
+    thread.join(timeout=2.0)
+    loop.close()
+
+
+def _wait_until(predicate, *, timeout=2.0):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.005)
+    return predicate()
+
+
+def _underlying_runner(monkeypatch):
+    runner_obj, strategy_manager, risk_manager, order_manager, selected_ce = (
+        _build_phase9_runner(monkeypatch)
+    )
+    runner_obj._trigger_candidate_symbols = {UNDERLYING_SYMBOL}
+    assert (
+        runner_obj._entry_evaluation_route(UNDERLYING_SYMBOL)
+        == EntryEvaluationRoute.UNDERLYING
+    )
+    return runner_obj, strategy_manager, risk_manager, order_manager, selected_ce
+
+
+def test_runner_tick_notification_does_not_run_strategy_inline(monkeypatch):
+    """Test A: the tick callback (_on_tick_safe) must return quickly for an
+    UNDERLYING-routed candidate and must not run the heavy evaluator inline."""
+    runner_obj, strategy_manager, _risk, _order, selected_ce = _underlying_runner(
+        monkeypatch
+    )
+    started = threading.Event()
+    finished = threading.Event()
+
+    def _slow_generate_signal(symbol, price, trace_id=None):
+        started.set()
+        time.sleep(0.12)
+        finished.set()
+        return Signal(
+            "BUY", selected_ce, 75, 0.9, "slow_signal", 90.0, 120.0, metadata={}
+        )
+
+    strategy_manager.generate_signal = Mock(side_effect=_slow_generate_signal)
+
+    loop, thread = _run_loop_in_thread()
+    runner_obj._main_loop = loop
+    try:
+        callback_start = time.perf_counter()
+        runner_obj._on_tick_safe(
+            {
+                "symbol": UNDERLYING_SYMBOL,
+                "last_price": 24000.0,
+                "timestamp": time.time(),
+            }
+        )
+        callback_duration_ms = (time.perf_counter() - callback_start) * 1000.0
+
+        assert callback_duration_ms < 40.0
+        assert not finished.is_set()
+
+        assert _wait_until(lambda: started.is_set())
+        assert _wait_until(lambda: finished.is_set())
+    finally:
+        _stop_loop(loop, thread)
+
+
+def test_multiple_ticks_coalesce_to_one_latest_entry_evaluation(monkeypatch):
+    """Test B: a burst of ticks for the same evaluation key must not queue
+    one evaluation per tick -- pending stays bounded and the drain reads the
+    latest generation rather than replaying every intermediate tick."""
+    runner_obj, _strategy_manager, _risk, _order, _selected_ce = _underlying_runner(
+        monkeypatch
+    )
+    seen_generations: list[int] = []
+    original_eval = runner_obj._evaluate_entry_from_latest_state
+    release = threading.Event()
+
+    def _capture(symbol, *, trace_id=None):
+        with runner_obj._eval_gate_lock:
+            seen_generations.append(
+                runner_obj._entry_eval_generation_by_symbol[symbol]
+            )
+        release.wait(timeout=2.0)
+        return None
+
+    runner_obj._evaluate_entry_from_latest_state = _capture
+
+    loop, thread = _run_loop_in_thread()
+    runner_obj._main_loop = loop
+    try:
+        for i in range(30):
+            runner_obj._last_eval_ts[UNDERLYING_SYMBOL] = 0.0
+            runner_obj._on_tick_safe(
+                {
+                    "symbol": UNDERLYING_SYMBOL,
+                    "last_price": 24000.0 + i,
+                    "timestamp": time.time(),
+                }
+            )
+        assert _wait_until(lambda: len(seen_generations) >= 1)
+        with runner_obj._eval_gate_lock:
+            pending_count = len(runner_obj._pending_entry_eval_symbols)
+            latest_generation = runner_obj._entry_eval_generation_by_symbol[
+                UNDERLYING_SYMBOL
+            ]
+        # 30 ticks must not produce 30 queued evaluations.
+        assert pending_count <= 1
+        assert latest_generation == 30
+        release.set()
+        # The drain may run once (burst fully coalesced before it started) or
+        # a small bounded number of times (if it started mid-burst and had to
+        # pick up newer generations) -- both are correct. What must hold
+        # regardless of this scheduling race: nowhere near 30 replayed
+        # evaluations, and the final evaluation reflects the latest state.
+        assert _wait_until(
+            lambda: len(seen_generations) >= 1
+            and seen_generations[-1] == 30,
+            timeout=2.0,
+        )
+        assert len(seen_generations) <= 5
+    finally:
+        runner_obj._evaluate_entry_from_latest_state = original_eval
+        _stop_loop(loop, thread)
+
+
+def test_coalesced_entry_drain_processes_each_pending_symbol_once(monkeypatch):
+    """Test C: two independent pending evaluation keys are each evaluated
+    exactly once by the drain; one busy key does not starve the other."""
+    runner_obj, _strategy_manager, _risk, _order, _selected_ce = _underlying_runner(
+        monkeypatch
+    )
+    other_symbol = "NFO:NIFTY26JUNFUT"
+    runner_obj._trigger_candidate_symbols.add(other_symbol)
+    assert (
+        runner_obj._entry_evaluation_route(other_symbol)
+        == EntryEvaluationRoute.UNDERLYING
+    )
+    runner_obj._last_tick[other_symbol] = {
+        "symbol": other_symbol,
+        "last_price": 24010.0,
+        "timestamp": time.time(),
+    }
+
+    seen: list[str] = []
+
+    def _capture(symbol, *, trace_id=None):
+        seen.append(symbol)
+        return None
+
+    runner_obj._evaluate_entry_from_latest_state = _capture
+
+    loop, thread = _run_loop_in_thread()
+    runner_obj._main_loop = loop
+    try:
+        runner_obj._on_tick_safe(
+            {
+                "symbol": UNDERLYING_SYMBOL,
+                "last_price": 24000.0,
+                "timestamp": time.time(),
+            }
+        )
+        runner_obj._on_tick_safe(
+            {"symbol": other_symbol, "last_price": 24010.0, "timestamp": time.time()}
+        )
+        assert _wait_until(lambda: len(seen) >= 2, timeout=2.0)
+        assert seen.count(UNDERLYING_SYMBOL) == 1
+        assert seen.count(other_symbol) == 1
+    finally:
+        _stop_loop(loop, thread)
+
+
+def test_new_generation_during_evaluation_reschedules_once(monkeypatch):
+    """Test D: a newer tick arriving mid-evaluation must be evaluated once
+    more after the in-flight evaluation completes -- no unbounded recursion,
+    and the pending set drains to empty."""
+    runner_obj, _strategy_manager, _risk, _order, _selected_ce = _underlying_runner(
+        monkeypatch
+    )
+    call_count = {"n": 0}
+    in_first_call = threading.Event()
+    release_first_call = threading.Event()
+
+    def _capture(symbol, *, trace_id=None):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            in_first_call.set()
+            release_first_call.wait(timeout=2.0)
+        return None
+
+    runner_obj._evaluate_entry_from_latest_state = _capture
+
+    loop, thread = _run_loop_in_thread()
+    runner_obj._main_loop = loop
+    try:
+        runner_obj._on_tick_safe(
+            {
+                "symbol": UNDERLYING_SYMBOL,
+                "last_price": 24000.0,
+                "timestamp": time.time(),
+            }
+        )
+        assert _wait_until(lambda: in_first_call.is_set())
+        # Inject a newer tick while the first evaluation is still in flight.
+        runner_obj._last_eval_ts[UNDERLYING_SYMBOL] = 0.0
+        runner_obj._on_tick_safe(
+            {
+                "symbol": UNDERLYING_SYMBOL,
+                "last_price": 24001.0,
+                "timestamp": time.time(),
+            }
+        )
+        release_first_call.set()
+        assert _wait_until(lambda: call_count["n"] >= 2, timeout=2.0)
+        assert call_count["n"] == 2
+        assert _wait_until(
+            lambda: not runner_obj._pending_entry_eval_symbols, timeout=2.0
+        )
+        with runner_obj._eval_gate_lock:
+            assert not runner_obj._entry_eval_active
+    finally:
+        _stop_loop(loop, thread)
+
+
+def test_protective_exit_not_blocked_by_busy_entry_evaluation(monkeypatch):
+    """Test F: a POSITION_MANAGEMENT-routed symbol (open position) must run
+    synchronously via _on_tick_safe even while an UNDERLYING evaluation is
+    busy in the coalesced drain -- exits are never routed through the
+    entry-eval queue."""
+    runner_obj, strategy_manager, _risk, _order, _selected_ce = _underlying_runner(
+        monkeypatch
+    )
+    busy = threading.Event()
+    release_busy = threading.Event()
+
+    def _slow_generate_signal(symbol, price, trace_id=None):
+        busy.set()
+        release_busy.wait(timeout=2.0)
+        return None
+
+    strategy_manager.generate_signal = Mock(side_effect=_slow_generate_signal)
+
+    open_symbol = "NFO:NIFTY26JUN24100CE"
+    runner_obj._position_manager.has_open_position = lambda s: s == open_symbol
+    assert (
+        runner_obj._entry_evaluation_route(open_symbol)
+        == EntryEvaluationRoute.POSITION_MANAGEMENT
+    )
+
+    on_tick_calls: list[str] = []
+    original_on_tick = runner_obj._on_tick
+
+    def _spy_on_tick(symbol, tick):
+        on_tick_calls.append(symbol)
+        return original_on_tick(symbol, tick)
+
+    runner_obj._on_tick = _spy_on_tick
+
+    loop, thread = _run_loop_in_thread()
+    runner_obj._main_loop = loop
+    try:
+        runner_obj._on_tick_safe(
+            {
+                "symbol": UNDERLYING_SYMBOL,
+                "last_price": 24000.0,
+                "timestamp": time.time(),
+            }
+        )
+        assert _wait_until(lambda: busy.is_set())
+
+        exit_start = time.perf_counter()
+        runner_obj._on_tick_safe(
+            {"symbol": open_symbol, "last_price": 50.0, "timestamp": time.time()}
+        )
+        exit_duration_ms = (time.perf_counter() - exit_start) * 1000.0
+
+        # The protective/position-management route must have run inline,
+        # immediately, regardless of the busy entry-eval drain.
+        assert exit_duration_ms < 100.0
+        assert open_symbol in on_tick_calls
+        release_busy.set()
+    finally:
+        _stop_loop(loop, thread)
+
+
+def test_entry_evaluation_exception_does_not_stop_future_drains(monkeypatch):
+    """Test G: one symbol's evaluation raising must not stop other pending
+    keys, and must not leave the drain permanently active/stuck."""
+    runner_obj, _strategy_manager, _risk, _order, _selected_ce = _underlying_runner(
+        monkeypatch
+    )
+    other_symbol = "NFO:NIFTY26JUNFUT"
+    runner_obj._trigger_candidate_symbols.add(other_symbol)
+    runner_obj._last_tick[other_symbol] = {
+        "symbol": other_symbol,
+        "last_price": 24010.0,
+        "timestamp": time.time(),
+    }
+
+    seen: list[str] = []
+
+    def _capture(symbol, *, trace_id=None):
+        seen.append(symbol)
+        if symbol == UNDERLYING_SYMBOL:
+            raise RuntimeError("boom")
+        return None
+
+    runner_obj._evaluate_entry_from_latest_state = _capture
+
+    loop, thread = _run_loop_in_thread()
+    runner_obj._main_loop = loop
+    try:
+        runner_obj._on_tick_safe(
+            {
+                "symbol": UNDERLYING_SYMBOL,
+                "last_price": 24000.0,
+                "timestamp": time.time(),
+            }
+        )
+        runner_obj._on_tick_safe(
+            {"symbol": other_symbol, "last_price": 24010.0, "timestamp": time.time()}
+        )
+        assert _wait_until(lambda: other_symbol in seen, timeout=2.0)
+        assert UNDERLYING_SYMBOL in seen
+
+        with runner_obj._eval_gate_lock:
+            assert not runner_obj._entry_eval_active
+
+        # A later tick for the failed symbol must still be evaluable.
+        seen.clear()
+
+        def _capture_ok(symbol, *, trace_id=None):
+            seen.append(symbol)
+            return None
+
+        runner_obj._evaluate_entry_from_latest_state = _capture_ok
+        runner_obj._last_eval_ts[UNDERLYING_SYMBOL] = 0.0
+        runner_obj._on_tick_safe(
+            {
+                "symbol": UNDERLYING_SYMBOL,
+                "last_price": 24005.0,
+                "timestamp": time.time(),
+            }
+        )
+        assert _wait_until(lambda: UNDERLYING_SYMBOL in seen, timeout=2.0)
+    finally:
+        _stop_loop(loop, thread)
+
+
+def test_entry_eval_burst_invariants_bounded_and_no_duplicates(monkeypatch):
+    """Test J (CI-sized burst harness): a large burst of ticks for one
+    evaluation key must produce materially fewer evaluations than ticks,
+    drain to an empty pending set, and never run two drains concurrently.
+    """
+    runner_obj, strategy_manager, _risk, _order, _selected_ce = _underlying_runner(
+        monkeypatch
+    )
+    n_ticks = 2000
+    evaluation_count = {"n": 0}
+    max_concurrent = {"n": 0}
+    concurrent_now = {"n": 0}
+    concurrency_lock = threading.Lock()
+
+    def _capture(symbol, *, trace_id=None):
+        with concurrency_lock:
+            concurrent_now["n"] += 1
+            max_concurrent["n"] = max(max_concurrent["n"], concurrent_now["n"])
+        evaluation_count["n"] += 1
+        time.sleep(0.001)
+        with concurrency_lock:
+            concurrent_now["n"] -= 1
+
+    runner_obj._evaluate_entry_from_latest_state = _capture
+
+    loop, thread = _run_loop_in_thread()
+    runner_obj._main_loop = loop
+    try:
+        start = time.perf_counter()
+        for i in range(n_ticks):
+            runner_obj._last_eval_ts[UNDERLYING_SYMBOL] = 0.0
+            runner_obj._on_tick_safe(
+                {
+                    "symbol": UNDERLYING_SYMBOL,
+                    "last_price": 24000.0 + (i % 7),
+                    "timestamp": time.time(),
+                }
+            )
+        ingest_duration_s = time.perf_counter() - start
+
+        assert _wait_until(
+            lambda: not runner_obj._pending_entry_eval_symbols, timeout=5.0
+        )
+        with runner_obj._eval_gate_lock:
+            assert not runner_obj._entry_eval_active
+
+        # Materially fewer evaluations than ticks submitted (coalescing did
+        # its job), never concurrent (single-flight drain), and pending
+        # drains to empty (no unbounded backlog).
+        assert evaluation_count["n"] < n_ticks // 10
+        assert max_concurrent["n"] == 1
+        assert ingest_duration_s < 2.0
+    finally:
+        _stop_loop(loop, thread)
+
+
+def test_subscribe_symbol_registers_single_lightweight_callback(monkeypatch):
+    """Wiring test: production subscribe path registers exactly one
+    tick-notification callback per symbol (on_datahub_tick), and it is not
+    the heavy evaluator (_on_tick) registered directly."""
+    runner_obj, _strategy_manager, _risk, _order, _selected_ce = _underlying_runner(
+        monkeypatch
+    )
+
+    class _FakeDataHub:
+        def __init__(self):
+            self.subscriptions: list[tuple[str, object]] = []
+
+        def subscribe_ticks(self, symbol, callback):
+            self.subscriptions.append((symbol, callback))
+
+    fake_hub = _FakeDataHub()
+    runner_obj._data_hub = fake_hub
+    runner_obj._datahub_registered_symbols = set()
+
+    runner_obj._subscribe_symbol(UNDERLYING_SYMBOL)
+    runner_obj._subscribe_symbol(UNDERLYING_SYMBOL)  # idempotent re-subscribe
+
+    matching = [
+        (sym, cb) for sym, cb in fake_hub.subscriptions if sym == UNDERLYING_SYMBOL
+    ]
+    assert len(matching) == 1
+    registered_symbol, registered_callback = matching[0]
+    assert registered_callback == runner_obj.on_datahub_tick
+    assert registered_callback != runner_obj._on_tick
+
+
+def test_entry_eval_schedule_failure_falls_back_inline(monkeypatch):
+    """A scheduling error (e.g. no running loop reachable) must not crash
+    ingestion and must not silently drop the pending evaluation -- it runs
+    inline as a bounded fallback instead."""
+    runner_obj, _strategy_manager, _risk, _order, _selected_ce = _underlying_runner(
+        monkeypatch
+    )
+    seen: list[str] = []
+    runner_obj._evaluate_entry_from_latest_state = lambda symbol, **_kw: seen.append(
+        symbol
+    )
+    runner_obj._main_loop = None
+
+    runner_obj._on_tick_safe(
+        {"symbol": UNDERLYING_SYMBOL, "last_price": 24000.0, "timestamp": time.time()}
+    )
+
+    assert UNDERLYING_SYMBOL in seen
+    with runner_obj._eval_gate_lock:
+        assert not runner_obj._entry_eval_active
+        assert not runner_obj._entry_eval_drain_scheduled

--- a/tests/strategies/test_entry_eval_coalescing.py
+++ b/tests/strategies/test_entry_eval_coalescing.py
@@ -24,6 +24,8 @@ import time
 from types import SimpleNamespace
 from unittest.mock import Mock
 
+import pytest
+
 from nifty_scalper_bot.strategies.runner import EntryEvaluationRoute
 from nifty_scalper_bot.strategies.signal_generator import Signal
 from tests.strategies.test_runner_symbol_role_gate import _build_phase9_runner
@@ -793,9 +795,6 @@ def test_entry_eval_scheduler_unavailable_never_runs_inline(monkeypatch):
         AssertionError("heavy _on_tick must not run inline without a loop")
     )
     runner_obj._main_loop = None
-    # Also block loop discovery, so this genuinely exercises the
-    # "no scheduler reachable at all" path.
-    runner_obj._discover_runtime_loop = staticmethod(lambda: None)
     with runner_obj._eval_gate_lock:
         runner_obj._entry_eval_active = False
         runner_obj._entry_eval_drain_scheduled = False
@@ -841,3 +840,149 @@ def test_entry_eval_worker_skips_symbol_that_became_position_managed(monkeypatch
     runner_obj._evaluate_entry_from_latest_state(selected_ce)
 
     assert on_tick_calls == []
+
+
+# ==================== EXPLICIT RUNTIME-LOOP ATTACHMENT ====================
+
+
+def test_background_tick_uses_explicit_runtime_loop(monkeypatch):
+    """Test 1: a tick delivered from a background thread must be drained on
+    the explicitly attached live loop B, never on a dormant loop A."""
+    runner_obj, _sm, _r, _o, _ce = _underlying_runner(monkeypatch)
+
+    dormant_loop = asyncio.new_event_loop()
+    dormant_calls: list[object] = []
+    dormant_loop.call_soon_threadsafe = lambda cb, *a: dormant_calls.append(cb)
+    runner_obj._main_loop = dormant_loop
+
+    loop_b, thread_b = _run_loop_in_thread()
+    drain_loops: list[object] = []
+    eval_threads: list[str] = []
+
+    def _capture(symbol, *, trace_id=None):
+        drain_loops.append(asyncio.get_event_loop_policy())
+        eval_threads.append(threading.current_thread().name)
+
+    runner_obj._evaluate_entry_from_latest_state = _capture
+
+    try:
+        fut = asyncio.run_coroutine_threadsafe(
+            _attach_from_loop(runner_obj), loop_b
+        )
+        fut.result(timeout=2.0)
+        assert runner_obj._main_loop is loop_b
+
+        # Deliver the tick from a separate background thread.
+        feeder = threading.Thread(
+            target=runner_obj._on_tick_safe,
+            args=(
+                {
+                    "symbol": UNDERLYING_SYMBOL,
+                    "last_price": 24000.0,
+                    "timestamp": time.time(),
+                },
+            ),
+        )
+        feeder.start()
+        feeder.join(timeout=2.0)
+
+        assert _wait_until(lambda: len(eval_threads) >= 1, timeout=3.0)
+        assert _wait_until(
+            lambda: not runner_obj._pending_entry_eval_symbols, timeout=3.0
+        )
+        assert len(eval_threads) == 1
+        assert eval_threads[0].startswith("nifty-entry-eval")
+        assert dormant_calls == []
+        assert runner_obj._main_loop is loop_b
+    finally:
+        _stop_loop(loop_b, thread_b)
+        dormant_loop.close()
+
+
+async def _attach_from_loop(runner_obj) -> None:
+    runner_obj.attach_runtime_loop(asyncio.get_running_loop())
+
+
+def test_nonrunning_runtime_loop_cannot_be_attached(monkeypatch):
+    """Test 2: an open but dormant loop must be rejected."""
+    runner_obj, _sm, _r, _o, _ce = _underlying_runner(monkeypatch)
+    previous = runner_obj._main_loop
+    dormant = asyncio.new_event_loop()
+    try:
+        with pytest.raises(RuntimeError, match="running"):
+            runner_obj.attach_runtime_loop(dormant)
+        assert runner_obj._main_loop is previous
+        assert not runner_obj._runtime_loop_attached
+    finally:
+        dormant.close()
+
+
+def test_closed_runtime_loop_cannot_be_attached(monkeypatch):
+    """Test 3: a closed loop must be rejected."""
+    runner_obj, _sm, _r, _o, _ce = _underlying_runner(monkeypatch)
+    previous = runner_obj._main_loop
+    closed = asyncio.new_event_loop()
+    closed.close()
+    with pytest.raises(RuntimeError, match="closed"):
+        runner_obj.attach_runtime_loop(closed)
+    assert runner_obj._main_loop is previous
+    assert not runner_obj._runtime_loop_attached
+
+
+def test_schedule_entry_eval_drain_returns_false_for_nonrunning_loop(monkeypatch):
+    """Test 4: a directly-assigned (never attached) dormant loop must not be
+    scheduled onto, and pending work must survive."""
+    runner_obj, _sm, _r, _o, _ce = _underlying_runner(monkeypatch)
+
+    def _must_not_run(symbol, **_kw):
+        raise AssertionError("evaluator must not run for a dormant loop")
+
+    runner_obj._evaluate_entry_from_latest_state = _must_not_run
+
+    dormant = asyncio.new_event_loop()
+    queued: list[object] = []
+    dormant.call_soon_threadsafe = lambda cb, *a: queued.append(cb)
+    runner_obj._main_loop = dormant
+    runner_obj._runtime_loop_attached = False
+    with runner_obj._eval_gate_lock:
+        runner_obj._pending_entry_eval_symbols.add(UNDERLYING_SYMBOL)
+    try:
+        assert runner_obj._schedule_entry_eval_drain() is False
+        assert queued == []
+        with runner_obj._eval_gate_lock:
+            assert UNDERLYING_SYMBOL in runner_obj._pending_entry_eval_symbols
+    finally:
+        dormant.close()
+
+
+def test_attach_runtime_loop_recovers_existing_pending_entry_eval(monkeypatch):
+    """Test 5: work marked pending before any loop existed must be recovered
+    exactly once when the authoritative loop is attached."""
+    runner_obj, _sm, _r, _o, _ce = _underlying_runner(monkeypatch)
+    seen: list[str] = []
+    runner_obj._evaluate_entry_from_latest_state = lambda symbol, **_kw: seen.append(
+        symbol
+    )
+    runner_obj._main_loop = None
+    runner_obj._runtime_loop_attached = False
+
+    runner_obj._on_tick_safe(
+        {"symbol": UNDERLYING_SYMBOL, "last_price": 24000.0, "timestamp": time.time()}
+    )
+    with runner_obj._eval_gate_lock:
+        assert UNDERLYING_SYMBOL in runner_obj._pending_entry_eval_symbols
+    assert seen == []
+
+    loop_b, thread_b = _run_loop_in_thread()
+    try:
+        fut = asyncio.run_coroutine_threadsafe(
+            _attach_from_loop(runner_obj), loop_b
+        )
+        fut.result(timeout=2.0)
+        assert _wait_until(lambda: seen == [UNDERLYING_SYMBOL], timeout=3.0)
+        assert _wait_until(
+            lambda: not runner_obj._pending_entry_eval_symbols, timeout=3.0
+        )
+        assert seen == [UNDERLYING_SYMBOL]
+    finally:
+        _stop_loop(loop_b, thread_b)

--- a/tests/strategies/test_entry_eval_coalescing.py
+++ b/tests/strategies/test_entry_eval_coalescing.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import asyncio
 import threading
 import time
+from types import SimpleNamespace
 from unittest.mock import Mock
 
 from nifty_scalper_bot.strategies.runner import EntryEvaluationRoute
@@ -262,11 +263,11 @@ def test_new_generation_during_evaluation_reschedules_once(monkeypatch):
         _stop_loop(loop, thread)
 
 
-def test_protective_exit_not_blocked_by_busy_entry_evaluation(monkeypatch):
+def test_position_management_route_runs_only_protection_inline(monkeypatch):
     """Test F: a POSITION_MANAGEMENT-routed symbol (open position) must run
-    synchronously via _on_tick_safe even while an UNDERLYING evaluation is
-    busy in the coalesced drain -- exits are never routed through the
-    entry-eval queue."""
+    ONLY the extracted protection helper, synchronously and immediately, even
+    while an entry evaluation is busy on the worker. The full heavy _on_tick
+    must not be invoked, and no entry-eval work may be scheduled for it."""
     runner_obj, strategy_manager, _risk, _order, _selected_ce = _underlying_runner(
         monkeypatch
     )
@@ -287,14 +288,12 @@ def test_protective_exit_not_blocked_by_busy_entry_evaluation(monkeypatch):
         == EntryEvaluationRoute.POSITION_MANAGEMENT
     )
 
-    on_tick_calls: list[str] = []
-    original_on_tick = runner_obj._on_tick
+    protection_calls: list[str] = []
 
-    def _spy_on_tick(symbol, tick):
-        on_tick_calls.append(symbol)
-        return original_on_tick(symbol, tick)
-
-    runner_obj._on_tick = _spy_on_tick
+    def _must_not_run(symbol, tick):
+        raise AssertionError(
+            f"heavy _on_tick must not run inline for position route: {symbol}"
+        )
 
     loop, thread = _run_loop_in_thread()
     runner_obj._main_loop = loop
@@ -308,19 +307,323 @@ def test_protective_exit_not_blocked_by_busy_entry_evaluation(monkeypatch):
         )
         assert _wait_until(lambda: busy.is_set())
 
+        # Only now forbid the heavy body and start recording protection, so
+        # the underlying evaluation above (already on the worker) is
+        # unaffected and we isolate the position-route call.
+        runner_obj._on_tick = _must_not_run
+        runner_obj._handle_position_tick_protection = (
+            lambda symbol, tick: protection_calls.append(symbol)
+        )
+        pending_before = set(runner_obj._pending_entry_eval_symbols)
+
         exit_start = time.perf_counter()
         runner_obj._on_tick_safe(
             {"symbol": open_symbol, "last_price": 50.0, "timestamp": time.time()}
         )
         exit_duration_ms = (time.perf_counter() - exit_start) * 1000.0
 
-        # The protective/position-management route must have run inline,
-        # immediately, regardless of the busy entry-eval drain.
+        # Protection ran inline, immediately, despite the busy worker.
+        assert protection_calls == [open_symbol]
         assert exit_duration_ms < 100.0
-        assert open_symbol in on_tick_calls
+        # The position route must not enqueue any entry-evaluation work.
+        with runner_obj._eval_gate_lock:
+            assert open_symbol not in runner_obj._pending_entry_eval_symbols
+            assert set(runner_obj._pending_entry_eval_symbols) == pending_before
         release_busy.set()
     finally:
+        release_busy.set()
         _stop_loop(loop, thread)
+
+
+def test_position_tick_protection_not_executed_twice(monkeypatch):
+    """Test G: one tick must produce exactly one protective lifecycle update,
+    even though protection runs at ingestion and the heavy body later runs on
+    the worker for the same tick."""
+    runner_obj, _strategy_manager, _risk, _order, _selected_ce = _underlying_runner(
+        monkeypatch
+    )
+    bracket_ticks: list[tuple[str, float]] = []
+    runner_obj._bracket_manager = SimpleNamespace(
+        on_tick=lambda sym, ltp, ts: bracket_ticks.append((sym, ltp))
+    )
+
+    loop, thread = _run_loop_in_thread()
+    runner_obj._main_loop = loop
+    try:
+        runner_obj._on_tick_safe(
+            {
+                "symbol": UNDERLYING_SYMBOL,
+                "last_price": 24000.0,
+                "timestamp": time.time(),
+            }
+        )
+        # Let the deferred heavy evaluation complete on the worker.
+        assert _wait_until(
+            lambda: not runner_obj._pending_entry_eval_symbols
+            and not runner_obj._entry_eval_active,
+            timeout=3.0,
+        )
+        time.sleep(0.05)
+        assert len(bracket_ticks) == 1
+        assert bracket_ticks[0][0] == UNDERLYING_SYMBOL
+    finally:
+        _stop_loop(loop, thread)
+
+
+def test_slow_entry_evaluation_does_not_block_main_event_loop(monkeypatch):
+    """Test A (decisive): while the heavy evaluation is running, the main
+    event loop must keep making progress, and the evaluation must execute on
+    a dedicated worker thread -- not the loop thread."""
+    runner_obj, _strategy_manager, _risk, _order, _selected_ce = _underlying_runner(
+        monkeypatch
+    )
+    eval_thread_names: list[str] = []
+    eval_started = threading.Event()
+    eval_done = threading.Event()
+
+    def _slow_eval(symbol, *, trace_id=None):
+        eval_thread_names.append(threading.current_thread().name)
+        eval_started.set()
+        time.sleep(0.2)
+        eval_done.set()
+
+    runner_obj._evaluate_entry_from_latest_state = _slow_eval
+
+    loop, thread = _run_loop_in_thread()
+    runner_obj._main_loop = loop
+    loop_thread_name = None
+    heartbeat = {"n": 0}
+
+    async def _heartbeat():
+        nonlocal loop_thread_name
+        loop_thread_name = threading.current_thread().name
+        while not eval_done.is_set():
+            heartbeat["n"] += 1
+            await asyncio.sleep(0.01)
+
+    try:
+        asyncio.run_coroutine_threadsafe(_heartbeat(), loop)
+        runner_obj._on_tick_safe(
+            {
+                "symbol": UNDERLYING_SYMBOL,
+                "last_price": 24000.0,
+                "timestamp": time.time(),
+            }
+        )
+        assert _wait_until(lambda: eval_started.is_set(), timeout=2.0)
+        beats_at_start = heartbeat["n"]
+        assert _wait_until(lambda: eval_done.is_set(), timeout=3.0)
+
+        # The loop kept running throughout the 200 ms evaluation.
+        assert heartbeat["n"] - beats_at_start >= 5
+
+        # And the evaluation ran on the dedicated worker, not the loop thread.
+        assert eval_thread_names
+        assert all(n.startswith("nifty-entry-eval") for n in eval_thread_names)
+        assert loop_thread_name not in eval_thread_names
+        # Exactly one worker thread was used.
+        assert len(set(eval_thread_names)) == 1
+    finally:
+        eval_done.set()
+        _stop_loop(loop, thread)
+
+
+def test_entry_eval_drain_processes_one_snapshot_per_invocation(monkeypatch):
+    """Test C: each drain invocation handles exactly one captured batch. A
+    newer generation arriving mid-batch is handled by a second drain, not by
+    an unbounded `while True` inside the first."""
+    runner_obj, _strategy_manager, _risk, _order, _selected_ce = _underlying_runner(
+        monkeypatch
+    )
+    in_first = threading.Event()
+    release_first = threading.Event()
+    calls = {"n": 0}
+
+    def _capture(symbol, *, trace_id=None):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            in_first.set()
+            release_first.wait(timeout=2.0)
+
+    runner_obj._evaluate_entry_from_latest_state = _capture
+
+    loop, thread = _run_loop_in_thread()
+    runner_obj._main_loop = loop
+    try:
+        drains_before = runner_obj._entry_eval_drain_count
+        runner_obj._on_tick_safe(
+            {
+                "symbol": UNDERLYING_SYMBOL,
+                "last_price": 24000.0,
+                "timestamp": time.time(),
+            }
+        )
+        assert _wait_until(lambda: in_first.is_set(), timeout=2.0)
+        runner_obj._last_eval_ts[UNDERLYING_SYMBOL] = 0.0
+        runner_obj._on_tick_safe(
+            {
+                "symbol": UNDERLYING_SYMBOL,
+                "last_price": 24001.0,
+                "timestamp": time.time(),
+            }
+        )
+        release_first.set()
+        assert _wait_until(lambda: calls["n"] >= 2, timeout=3.0)
+        assert _wait_until(
+            lambda: not runner_obj._pending_entry_eval_symbols
+            and not runner_obj._entry_eval_active,
+            timeout=3.0,
+        )
+        # Exactly two bounded drain invocations, not one monopolising loop.
+        assert runner_obj._entry_eval_drain_count - drains_before == 2
+        assert calls["n"] == 2
+    finally:
+        release_first.set()
+        _stop_loop(loop, thread)
+
+
+def test_continuous_busy_symbol_does_not_starve_other_pending_symbol(monkeypatch):
+    """Test D: a continuously-ticking symbol must not starve another pending
+    symbol -- B is evaluated within a bounded number of drain batches."""
+    runner_obj, _strategy_manager, _risk, _order, _selected_ce = _underlying_runner(
+        monkeypatch
+    )
+    busy_symbol = UNDERLYING_SYMBOL
+    other_symbol = "NFO:NIFTY26JUNFUT"
+    runner_obj._trigger_candidate_symbols.add(other_symbol)
+    runner_obj._last_tick[other_symbol] = {
+        "symbol": other_symbol,
+        "last_price": 24010.0,
+        "timestamp": time.time(),
+    }
+    seen: list[str] = []
+    stop_feeding = threading.Event()
+
+    def _capture(symbol, *, trace_id=None):
+        seen.append(symbol)
+        time.sleep(0.002)
+
+    runner_obj._evaluate_entry_from_latest_state = _capture
+
+    loop, thread = _run_loop_in_thread()
+    runner_obj._main_loop = loop
+    try:
+        runner_obj._on_tick_safe(
+            {"symbol": other_symbol, "last_price": 24010.0, "timestamp": time.time()}
+        )
+        deadline = time.time() + 1.5
+        while time.time() < deadline and not stop_feeding.is_set():
+            runner_obj._last_eval_ts[busy_symbol] = 0.0
+            runner_obj._on_tick_safe(
+                {
+                    "symbol": busy_symbol,
+                    "last_price": 24000.0,
+                    "timestamp": time.time(),
+                }
+            )
+            if other_symbol in seen:
+                stop_feeding.set()
+            time.sleep(0.002)
+
+        assert other_symbol in seen, "continuously busy symbol starved the other"
+        # The busy symbol stayed coalesced: far fewer evaluations than ticks.
+        assert seen.count(busy_symbol) < 200
+    finally:
+        _stop_loop(loop, thread)
+
+
+def test_context_only_tick_does_not_run_heavy_on_tick_inline(monkeypatch):
+    """Test E: a CONTEXT_ONLY symbol must not run the heavy _on_tick body
+    inline on the ingestion path -- it is coalesced onto the worker."""
+    runner_obj, _strategy_manager, _risk, _order, _selected_ce = _underlying_runner(
+        monkeypatch
+    )
+    context_symbol = "NFO:NIFTY26JUN24100CE"
+    assert (
+        runner_obj._entry_evaluation_route(context_symbol)
+        == EntryEvaluationRoute.CONTEXT_ONLY
+    )
+    runner_obj._last_tick[context_symbol] = {
+        "symbol": context_symbol,
+        "last_price": 55.0,
+        "timestamp": time.time(),
+    }
+    ingress_thread = threading.current_thread().name
+    eval_threads: list[str] = []
+
+    def _capture(symbol, *, trace_id=None):
+        eval_threads.append(threading.current_thread().name)
+
+    runner_obj._evaluate_entry_from_latest_state = _capture
+
+    def _must_not_run_inline(symbol, tick):
+        raise AssertionError("heavy _on_tick ran inline for CONTEXT_ONLY")
+
+    runner_obj._on_tick = _must_not_run_inline
+
+    loop, thread = _run_loop_in_thread()
+    runner_obj._main_loop = loop
+    try:
+        start = time.perf_counter()
+        runner_obj._on_tick_safe(
+            {"symbol": context_symbol, "last_price": 55.0, "timestamp": time.time()}
+        )
+        duration_ms = (time.perf_counter() - start) * 1000.0
+        assert duration_ms < 40.0
+        assert _wait_until(lambda: bool(eval_threads), timeout=2.0)
+        assert all(n.startswith("nifty-entry-eval") for n in eval_threads)
+        assert ingress_thread not in eval_threads
+    finally:
+        _stop_loop(loop, thread)
+
+
+def test_runner_shutdown_stops_entry_eval_executor(monkeypatch):
+    """Test I: shutdown terminates the worker, clears pending work, and no
+    evaluation runs afterwards. No leaked nifty-entry-eval thread."""
+    runner_obj, _strategy_manager, _risk, _order, _selected_ce = _underlying_runner(
+        monkeypatch
+    )
+    calls: list[str] = []
+    runner_obj._evaluate_entry_from_latest_state = lambda symbol, **_kw: calls.append(
+        symbol
+    )
+
+    loop, thread = _run_loop_in_thread()
+    runner_obj._main_loop = loop
+    try:
+        runner_obj._on_tick_safe(
+            {
+                "symbol": UNDERLYING_SYMBOL,
+                "last_price": 24000.0,
+                "timestamp": time.time(),
+            }
+        )
+        assert _wait_until(lambda: bool(calls), timeout=2.0)
+
+        runner_obj._shutdown_entry_eval_worker()
+        calls.clear()
+
+        # No new work may be accepted or evaluated after shutdown.
+        runner_obj._last_eval_ts[UNDERLYING_SYMBOL] = 0.0
+        runner_obj._on_tick_safe(
+            {
+                "symbol": UNDERLYING_SYMBOL,
+                "last_price": 24002.0,
+                "timestamp": time.time(),
+            }
+        )
+        time.sleep(0.15)
+        assert calls == []
+        with runner_obj._eval_gate_lock:
+            assert not runner_obj._pending_entry_eval_symbols
+            assert not runner_obj._entry_eval_active
+    finally:
+        _stop_loop(loop, thread)
+
+    # This runner's own worker thread(s) terminated -- no leak from shutdown.
+    for worker in getattr(runner_obj._entry_eval_executor, "_threads", ()):
+        worker.join(timeout=2.0)
+        assert not worker.is_alive()
 
 
 def test_entry_evaluation_exception_does_not_stop_future_drains(monkeypatch):
@@ -474,24 +777,67 @@ def test_subscribe_symbol_registers_single_lightweight_callback(monkeypatch):
     assert registered_callback != runner_obj._on_tick
 
 
-def test_entry_eval_schedule_failure_falls_back_inline(monkeypatch):
-    """A scheduling error (e.g. no running loop reachable) must not crash
-    ingestion and must not silently drop the pending evaluation -- it runs
-    inline as a bounded fallback instead."""
+def test_entry_eval_scheduler_unavailable_never_runs_inline(monkeypatch):
+    """With no running loop the callback must still return immediately, must
+    NOT run the evaluation inline (no asyncio.run fallback), and must keep the
+    symbol pending so a later tick retries scheduling."""
     runner_obj, _strategy_manager, _risk, _order, _selected_ce = _underlying_runner(
         monkeypatch
     )
-    seen: list[str] = []
-    runner_obj._evaluate_entry_from_latest_state = lambda symbol, **_kw: seen.append(
-        symbol
+
+    def _must_not_run(symbol, **_kw):
+        raise AssertionError("evaluation must not run inline without a loop")
+
+    runner_obj._evaluate_entry_from_latest_state = _must_not_run
+    runner_obj._on_tick = lambda symbol, tick: (_ for _ in ()).throw(
+        AssertionError("heavy _on_tick must not run inline without a loop")
     )
     runner_obj._main_loop = None
+    # Also block loop discovery, so this genuinely exercises the
+    # "no scheduler reachable at all" path.
+    runner_obj._discover_runtime_loop = staticmethod(lambda: None)
+    with runner_obj._eval_gate_lock:
+        runner_obj._entry_eval_active = False
+        runner_obj._entry_eval_drain_scheduled = False
+        runner_obj._pending_entry_eval_symbols.clear()
 
+    start = time.perf_counter()
     runner_obj._on_tick_safe(
         {"symbol": UNDERLYING_SYMBOL, "last_price": 24000.0, "timestamp": time.time()}
     )
+    duration_ms = (time.perf_counter() - start) * 1000.0
 
-    assert UNDERLYING_SYMBOL in seen
+    assert duration_ms < 40.0
     with runner_obj._eval_gate_lock:
+        # Pending state preserved for a later retry; nothing left active.
+        assert UNDERLYING_SYMBOL in runner_obj._pending_entry_eval_symbols
         assert not runner_obj._entry_eval_active
         assert not runner_obj._entry_eval_drain_scheduled
+
+
+def test_entry_eval_worker_skips_symbol_that_became_position_managed(monkeypatch):
+    """1H: if a symbol acquires an open position between being marked pending
+    and the worker reaching it, entry evaluation must be skipped -- protection
+    owns that symbol, and an entry must never race an open position."""
+    runner_obj, _strategy_manager, _risk, _order, selected_ce = _underlying_runner(
+        monkeypatch
+    )
+    runner_obj._last_tick[selected_ce] = {
+        "symbol": selected_ce,
+        "last_price": 100.0,
+        "timestamp": time.time(),
+    }
+    on_tick_calls: list[str] = []
+    runner_obj._on_tick = lambda symbol, tick: on_tick_calls.append(symbol)
+
+    # Sanity: it would normally be evaluated as an entry candidate.
+    assert (
+        runner_obj._entry_evaluation_route(selected_ce)
+        == EntryEvaluationRoute.OPTION_CANDIDATE
+    )
+
+    # A position opens before the worker gets to it.
+    runner_obj._position_manager.has_open_position = lambda s: s == selected_ce
+    runner_obj._evaluate_entry_from_latest_state(selected_ce)
+
+    assert on_tick_calls == []


### PR DESCRIPTION
Category-1 lag correction: heavy new-entry strategy evaluation no longer runs on the MDM/main asyncio event loop.

## What changed
- **Dedicated worker.** The heavy `_on_tick()` body runs on one `ThreadPoolExecutor(max_workers=1, thread_name_prefix="nifty-entry-eval")` per Runner via `run_in_executor`, so the main event loop stays responsive. `max_workers=1` preserves serial entry-evaluation semantics.
- **Coalescing.** Repeated ticks collapse to latest state; one bounded batch per drain invocation (no `while True`), with exactly one follow-up drain when newer generations arrive.
- **Routing.** `POSITION_MANAGEMENT` -> protection-only, synchronous (extracted `_handle_position_tick_protection`, former PHASE -1); it never runs the full heavy body. `OPTION_CANDIDATE` / `UNDERLYING` / **`CONTEXT_ONLY`** -> coalesced heavy evaluation on the dedicated worker. `_protection_already_handled` ensures one tick = one protective lifecycle update.
- **No inline fallback.** The `asyncio.run()` fallback is gone. When no scheduler is reachable the symbol stays pending and a throttled `ENTRY_EVAL_SCHEDULER_UNAVAILABLE` is logged; evaluation never runs inline on the ingestion path.
- **Explicit runtime-loop attachment.** Ticks arrive on background websocket/drain threads with no event loop, so the Runner never infers or creates one. `attach_runtime_loop(loop)` is the single authority (rejects closed and non-running loops) and is called once from canonical async startup in `core/app.py::startup_sequence`, after the loop is running and before market data can deliver ticks. Policy-based loop discovery was removed entirely.
- **Shutdown.** `stop()` marks shutdown first (no new drains, no evaluation after shutdown), clears pending, then `shutdown(wait=True, cancel_futures=True)`. No leaked threads.

## A/B timing (500 ticks, 50 ms evaluation, same machine)
| | before | after |
|---|---|---|
| worst main-loop delay | **95.57 ms** | **0.43 ms** (~222x) |
| evaluation thread | `Thread-1 (run_forever)` (the loop thread) | `nifty-entry-eval_0` |
| runner callback max | 0.24 ms | 0.55 ms |
| evaluations / 500 ticks | 2 | 2 |
| max concurrent evaluations | 1 | 1 |
| pending remaining | 0 | 0 |

`test_slow_entry_evaluation_does_not_block_main_event_loop` fails against the pre-correction code (heartbeat advanced 0 times during a 200 ms evaluation) and passes after.

## Production bug found
With the `asyncio.run()` fallback removed, entry evaluations were scheduled nowhere, because `_main_loop` was never reliably attached and ticks arrive on threads without a loop. The fallback had been masking this by spinning up a throwaway event loop per tick on the ingestion thread. Caught by `test_live_runtime_bullish_spot_future_selects_ce_and_exits_target` regressing to `orders: []`; fixed by the explicit attachment above.

## Scope
No changes to strategy logic, indicators, risk, sizing, order submission, freshness thresholds, symbol selection, PositionManager, BracketManager or MarketDataManager. No new production files.

Production diff: `runner.py` + `core/app.py`.

## Validation (all exit 0)
`compileall src tests` - `tests/strategies/test_entry_eval_coalescing.py` (21) - `tests/e2e/live_sim/test_live_runtime_startup_contract.py` (6) - `tests/strategies` - `-m live_runtime_e2e tests/e2e/live_sim` (3) - **full suite 2044 passed, 2 skipped, 1 deselected, 0 failed** (clean-main baseline 2023).

Known flake: `test_live_runtime_bullish_spot_future_selects_ce_and_exits_target` failed in 1 of 3 full-suite runs under load and passed in all targeted runs; historically timing-fragile.