### PR TITLE
fix: size NIFTY options in whole lots, convert to broker units exactly once

### DIFF
--- a/src/nifty_scalper_bot/execution/margin_engine.py
+++ b/src/nifty_scalper_bot/execution/margin_engine.py
@@ -617,39 +617,51 @@ class MarginEngine:
             )
             risk_per_unit = price * fallback_move_pct
 
-        unit_risk_value = risk_per_unit * max(inputs.contract_multiplier, 1.0)
-        if unit_risk_value <= 0:
+        lot_size = max(1, int(inputs.lot_size))
+        # Per-lot economics derived from lot_size ALONE. contract_multiplier is
+        # deliberately not applied here: production sets it to the lot size, so
+        # using both would count contract size twice. Contract size is counted
+        # exactly once, via lot_size, and converted to broker units once at the
+        # end of this method.
+        one_lot_risk = risk_per_unit * lot_size
+        if one_lot_risk <= 0:
             return 0
-        qty_by_risk = int((balance * risk_pct) // unit_risk_value)
-        price_denominator = price * max(inputs.contract_multiplier, 1.0)
-        qty_by_cap = (
-            int(cap_from_pct // price_denominator) if price_denominator > 0 else 0
-        )
-        qty_by_margin = 0
+        lots_by_risk = int((balance * risk_pct) // one_lot_risk)
+        one_lot_cost = price * lot_size
+        lots_by_cap = int(cap_from_pct // one_lot_cost) if one_lot_cost > 0 else 0
+        lots_by_margin = 0
         margin_estimator = getattr(self._broker, "estimate_margin", None)
         if callable(margin_estimator) and price > 0:
             try:
+                # Broker margin is quoted per unit; scale to a per-lot cost so
+                # it is comparable with the lot counts above.
                 margin_per_unit = float(margin_estimator(inputs.symbol, 1, price))
-                if margin_per_unit > 0:
-                    qty_by_margin = int(balance // margin_per_unit)
+                margin_per_lot = margin_per_unit * lot_size
+                if margin_per_lot > 0:
+                    lots_by_margin = int(balance // margin_per_lot)
             except Exception as exc:  # noqa: BLE001
                 self._logger.debug(
                     "margin_plan_estimate_margin_error",
                     extra={"event": "margin_plan_estimate_margin_error", "error": str(exc)},
                 )
-        max_units = max(0, min(qty_by_risk, qty_by_cap, qty_by_margin or qty_by_cap))
-        lot_size = max(1, int(inputs.lot_size))
-        max_lot_units = lot_size * max(int(inputs.max_lots_per_trade), 0)
-        if max_lot_units > 0:
-            max_units = min(max_units, max_lot_units)
+        max_lots = max(
+            0, min(lots_by_risk, lots_by_cap, lots_by_margin or lots_by_cap)
+        )
+        configured_max_lots = max(int(inputs.max_lots_per_trade), 0)
+        if configured_max_lots > 0:
+            max_lots = min(max_lots, configured_max_lots)
+        # Single conversion point: complete lots -> broker units.
+        max_units = max_lots * lot_size
         self._logger.debug(
             "margin_plan_qty",
             extra={
                 "event": "margin_plan_qty",
                 "symbol": inputs.symbol,
-                "qty_by_risk": qty_by_risk,
-                "qty_by_cap": qty_by_cap,
-                "max_lot_units": max_lot_units,
+                "lots_by_risk": lots_by_risk,
+                "lots_by_cap": lots_by_cap,
+                "lots_by_margin": lots_by_margin,
+                "max_lots": max_lots,
+                "lot_size": lot_size,
                 "max_units": max_units,
             },
         )
@@ -728,11 +740,12 @@ class MarginEngine:
                     extra={"event": "margin_plan_required_fallback", "error": str(exc)},
                 )
         premium = max(inputs.price, 0.0)
+        # `quantity` is already broker units (lots x lot_size), and
+        # `contract_multiplier` IS the lot size, so applying it here would
+        # square the contract size (e.g. 100 x 65 x 65 = 422500 instead of
+        # 6500). Contract size is counted exactly once, inside `quantity`.
         estimate = (
-            premium
-            * max(quantity, 0)
-            * max(inputs.contract_multiplier, 1.0)
-            * max(inputs.margin_factor, 1.0)
+            premium * max(quantity, 0) * max(inputs.margin_factor, 1.0)
         )
         return estimate
 

--- a/src/nifty_scalper_bot/execution/margin_engine.py
+++ b/src/nifty_scalper_bot/execution/margin_engine.py
@@ -629,33 +629,17 @@ class MarginEngine:
         lots_by_risk = int((balance * risk_pct) // one_lot_risk)
         one_lot_cost = price * lot_size
         lots_by_cap = int(cap_from_pct // one_lot_cost) if one_lot_cost > 0 else 0
-        lots_by_margin = 0
-        margin_estimator = getattr(self._broker, "estimate_margin", None)
-        if callable(margin_estimator) and price > 0:
-            try:
-                # QUANTITY CONTRACT: `estimate_margin(symbol, quantity, price)`
-                # is an OPTIONAL broker capability -- no adapter in this repo
-                # implements it today (it is probed via getattr), so its
-                # quantity convention is not established by any concrete
-                # implementation. We therefore ask for the margin of ONE WHOLE
-                # LOT directly by passing `lot_size` as the quantity, rather
-                # than estimating one unit and scaling by lot_size. If the
-                # broker interprets quantity as broker units this is exactly
-                # one lot; the result is used as-is and never multiplied by
-                # lot_size again, so no convention mismatch can inflate it.
-                margin_for_one_lot = float(
-                    margin_estimator(inputs.symbol, lot_size, price)
-                )
-                if margin_for_one_lot > 0:
-                    lots_by_margin = int(balance // margin_for_one_lot)
-            except Exception as exc:  # noqa: BLE001
-                self._logger.debug(
-                    "margin_plan_estimate_margin_error",
-                    extra={"event": "margin_plan_estimate_margin_error", "error": str(exc)},
-                )
-        max_lots = max(
-            0, min(lots_by_risk, lots_by_cap, lots_by_margin or lots_by_cap)
-        )
+        # NOTE: an optional broker `estimate_margin(symbol, quantity, price)`
+        # probe previously ran here. It has no concrete implementation
+        # anywhere in this repo (no adapter defines it), so its quantity
+        # convention cannot be verified: passing `lot_size` as quantity is
+        # only correct if a future adapter treats quantity as broker units --
+        # if one instead treated it as lots, this would silently request
+        # margin for `lot_size` lots. Removed rather than guessed. Sizing
+        # here relies only on the two deterministic sources below; broker
+        # required-margin validation still happens in _estimate_required()
+        # via get_required_margin when the broker supports it.
+        max_lots = max(0, min(lots_by_risk, lots_by_cap))
         configured_max_lots = max(int(inputs.max_lots_per_trade), 0)
         if configured_max_lots > 0:
             max_lots = min(max_lots, configured_max_lots)
@@ -668,7 +652,6 @@ class MarginEngine:
                 "symbol": inputs.symbol,
                 "lots_by_risk": lots_by_risk,
                 "lots_by_cap": lots_by_cap,
-                "lots_by_margin": lots_by_margin,
                 "max_lots": max_lots,
                 "lot_size": lot_size,
                 "max_units": max_units,

--- a/src/nifty_scalper_bot/execution/margin_engine.py
+++ b/src/nifty_scalper_bot/execution/margin_engine.py
@@ -633,12 +633,21 @@ class MarginEngine:
         margin_estimator = getattr(self._broker, "estimate_margin", None)
         if callable(margin_estimator) and price > 0:
             try:
-                # Broker margin is quoted per unit; scale to a per-lot cost so
-                # it is comparable with the lot counts above.
-                margin_per_unit = float(margin_estimator(inputs.symbol, 1, price))
-                margin_per_lot = margin_per_unit * lot_size
-                if margin_per_lot > 0:
-                    lots_by_margin = int(balance // margin_per_lot)
+                # QUANTITY CONTRACT: `estimate_margin(symbol, quantity, price)`
+                # is an OPTIONAL broker capability -- no adapter in this repo
+                # implements it today (it is probed via getattr), so its
+                # quantity convention is not established by any concrete
+                # implementation. We therefore ask for the margin of ONE WHOLE
+                # LOT directly by passing `lot_size` as the quantity, rather
+                # than estimating one unit and scaling by lot_size. If the
+                # broker interprets quantity as broker units this is exactly
+                # one lot; the result is used as-is and never multiplied by
+                # lot_size again, so no convention mismatch can inflate it.
+                margin_for_one_lot = float(
+                    margin_estimator(inputs.symbol, lot_size, price)
+                )
+                if margin_for_one_lot > 0:
+                    lots_by_margin = int(balance // margin_for_one_lot)
             except Exception as exc:  # noqa: BLE001
                 self._logger.debug(
                     "margin_plan_estimate_margin_error",

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -19216,13 +19216,45 @@ class StrategyRunner:
             lot_size = 1
             final_qty = qty
             try:
-                qty_lots = max(int(signal.quantity or 1), 1)
+                # One lot is the MINIMUM VALID TRADE, never a fallback for
+                # invalid input. None/0/negative requested lots is a strategy
+                # contract violation and must fail closed rather than silently
+                # becoming a live one-lot order.
+                requested_lots = int(signal.quantity or 0)
+                if requested_lots <= 0:
+                    self._logger.warning(
+                        "ORDER_BLOCKED: invalid_requested_lots symbol=%s "
+                        "requested_lots=%s trace_id=%s",
+                        trade_symbol or base_symbol,
+                        signal.quantity,
+                        trace_id,
+                        extra={
+                            "event": "ORDER_BLOCKED",
+                            "reason": "invalid_requested_lots",
+                            "symbol": trade_symbol or base_symbol,
+                            "requested_lots": signal.quantity,
+                            "trace_id": trace_id,
+                        },
+                    )
+                    self._mark_directional_dedup_failed(
+                        underlying=underlying,
+                        option_side=option_side,
+                        reason=reason_key,
+                    )
+                    self._reset_execution_state(base_symbol)
+                    return self._reject_signal_execution(
+                        symbol=base_symbol,
+                        trace_id=trace_id,
+                        reason="invalid_requested_lots",
+                    )
+                qty_lots = requested_lots
                 if hasattr(self._order_manager, "resolve_lot_size"):
                     lot_size = int(
                         self._order_manager.resolve_lot_size(
                             trade_symbol or base_symbol
                         )
                     )
+                # Single conversion point: complete lots -> broker units.
                 final_qty = qty_lots * lot_size
                 self._logger.info(
                     "ORDER_QTY_NORMALIZED symbol=%s input_qty_lots=%s lot_size=%s final_qty=%s trace_id=%s",
@@ -19468,11 +19500,13 @@ class StrategyRunner:
                 _resolved_lot_size = int(
                     self._order_manager._lot_size_for_symbol(order_symbol) or 0
                 )
-                _requested_lots = (
-                    1
-                    if _resolved_lot_size > 0 and int(qty) == _resolved_lot_size
-                    else 0
-                )
+                # Derive lots by exact division. The previous form only ever
+                # produced 1 (when qty == lot_size) or 0, so every multi-lot
+                # trade recorded requested_lots=0 in the TradePlan.
+                if _resolved_lot_size > 0 and int(qty) % _resolved_lot_size == 0:
+                    _requested_lots = int(qty) // _resolved_lot_size
+                else:
+                    _requested_lots = 0
             except Exception:
                 _resolved_lot_size = 0
             _basket = getattr(self, "_active_contract_basket", None) or {}
@@ -19529,6 +19563,36 @@ class StrategyRunner:
             _client_order_id = f"nfo:{_identity_digest}"
             _trade_lifecycle_id = f"tl:{_identity_digest}"
             _broker_tag = f"r{_identity_digest[:12]}"
+            # 1E: one lot-sizing trace, for the FINAL selected contract only.
+            # `qty` is broker units; requested/final lots are whole lots.
+            self._logger.info(
+                "OPTION_LOT_SIZING_DECISION symbol=%s requested_lots=%s "
+                "final_lots=%s resolved_lot_size=%s broker_quantity=%s "
+                "option_entry_price=%s option_stop_loss=%s trace_id=%s",
+                order_symbol,
+                requested_lots,
+                _requested_lots,
+                _resolved_lot_size,
+                qty,
+                price,
+                stop_loss,
+                trace_id,
+                extra={
+                    "event": "OPTION_LOT_SIZING_DECISION",
+                    "symbol": order_symbol,
+                    "requested_lots": requested_lots,
+                    "final_lots": _requested_lots,
+                    "configured_max_lots": getattr(
+                        getattr(self, "_settings", None), "MAX_LOTS_PER_TRADE", None
+                    ),
+                    "resolved_lot_size": _resolved_lot_size,
+                    "broker_quantity": qty,
+                    "option_entry_price": price,
+                    "option_stop_loss": stop_loss,
+                    "sizing_reason": "runner_lot_conversion",
+                    "trace_id": trace_id,
+                },
+            )
             plan = TradePlan(
                 symbol=order_symbol,
                 side=signal.action,

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -19563,33 +19563,38 @@ class StrategyRunner:
             _client_order_id = f"nfo:{_identity_digest}"
             _trade_lifecycle_id = f"tl:{_identity_digest}"
             _broker_tag = f"r{_identity_digest[:12]}"
-            # 1E: one lot-sizing trace, for the FINAL selected contract only.
-            # `qty` is broker units; requested/final lots are whole lots.
+            # Request-normalization telemetry: strategy lots -> dynamic
+            # lot-size resolution -> REQUESTED broker units. Nothing here is
+            # final by name or by value.
+            #
+            # NOTE ON SCOPE: there is currently no live entry-sizing boundary
+            # downstream of this point. MarginEngine.plan() is reached only via
+            # _execute_market_order (emergency-exit path); _precheck_margin is
+            # dead code and discards decision.quantity; and
+            # submit_trade_plan_result forwards plan.quantity unchanged to
+            # place_managed_order*/place_order. So for live entries today this
+            # requested quantity is also what is submitted. Deliberately not
+            # labelled "final" here: if entry-side margin gating is wired in
+            # later, the authoritative event belongs at that boundary, not here.
             self._logger.info(
-                "OPTION_LOT_SIZING_DECISION symbol=%s requested_lots=%s "
-                "final_lots=%s resolved_lot_size=%s broker_quantity=%s "
+                "OPTION_LOT_REQUEST_NORMALIZED symbol=%s requested_lots=%s "
+                "resolved_lot_size=%s requested_broker_quantity=%s "
                 "option_entry_price=%s option_stop_loss=%s trace_id=%s",
                 order_symbol,
                 requested_lots,
-                _requested_lots,
                 _resolved_lot_size,
                 qty,
                 price,
                 stop_loss,
                 trace_id,
                 extra={
-                    "event": "OPTION_LOT_SIZING_DECISION",
+                    "event": "OPTION_LOT_REQUEST_NORMALIZED",
                     "symbol": order_symbol,
                     "requested_lots": requested_lots,
-                    "final_lots": _requested_lots,
-                    "configured_max_lots": getattr(
-                        getattr(self, "_settings", None), "MAX_LOTS_PER_TRADE", None
-                    ),
                     "resolved_lot_size": _resolved_lot_size,
-                    "broker_quantity": qty,
+                    "requested_broker_quantity": qty,
                     "option_entry_price": price,
                     "option_stop_loss": stop_loss,
-                    "sizing_reason": "runner_lot_conversion",
                     "trace_id": trace_id,
                 },
             )

--- a/tests/execution/test_margin_engine.py
+++ b/tests/execution/test_margin_engine.py
@@ -146,3 +146,110 @@ def test_plan_clamps_zero_requested_with_atr_margin() -> None:
     assert decision.quantity == 75
     assert decision.sizing is not None
     assert decision.sizing.reason == "clamped_min_lot"
+
+
+# ===================== OPTION LOT-SIZING REGRESSION =====================
+# NIFTY option sizing must reason in COMPLETE LOTS and convert to broker
+# units exactly once. Regression for the unit/lot mixing that rejected every
+# affordable trade with `no_qty_after_risk`, and for the contract-size double
+# count that inflated est_required by lot_size.
+
+
+def _opt_inputs(**overrides):
+    lot = overrides.pop("lot_size", 65)
+    base = {
+        "symbol": "NFO:NIFTY26AUG25000CE",
+        "side": "BUY",
+        "price": 100.0,
+        "stop_loss": 80.0,
+        "atr": None,
+        "requested_qty": lot,
+        "product": "NRML",
+        "lot_size": lot,
+        "balance": 200_000.0,
+        "per_trade_risk_pct": 1.0,
+        "per_trade_cap_pct": 100.0,
+        "margin_factor": 1.0,
+        "margin_buffer": 1.0,
+        # Production sets this to the lot size; sizing must NOT count it again.
+        "contract_multiplier": float(lot),
+        "ist_now": datetime(2024, 1, 1, 9, 30, tzinfo=ZoneInfo("Asia/Kolkata")),
+        "min_lots_per_trade": 1,
+        "max_lots_per_trade": 10,
+        "atr_multiple": 1.5,
+    }
+    base.update(overrides)
+    return MarginInputs(**base)  # type: ignore[arg-type]
+
+
+def _opt_engine() -> MarginEngine:
+    return MarginEngine(
+        broker=object(), data_hub=None, lot_size_resolver=None, clock=lambda: 0.0
+    )
+
+
+def test_option_one_lot_accepted_as_broker_units() -> None:
+    """Test A: one lot with lot_size=65 becomes broker quantity 65."""
+    decision = _opt_engine().plan(_opt_inputs())
+    assert decision.ok
+    assert decision.quantity == 65
+
+
+def test_option_two_lots_accepted() -> None:
+    """Test B: two affordable lots become broker quantity 130."""
+    decision = _opt_engine().plan(
+        _opt_inputs(requested_qty=130, balance=2_000_000.0)
+    )
+    assert decision.ok
+    assert decision.quantity == 130
+
+
+def test_option_partial_lot_capacity_is_rejected_not_rounded_up() -> None:
+    """Test C: capacity below one complete lot rejects; never rounds up."""
+    decision = _opt_engine().plan(_opt_inputs(balance=1_000.0))
+    assert not decision.ok
+    assert decision.quantity == 0
+
+
+def test_option_capital_permits_one_of_two_requested_lots() -> None:
+    """Test D: request 2, capital/risk supports 1 -> exactly one lot."""
+    decision = _opt_engine().plan(_opt_inputs(requested_qty=130))
+    assert decision.ok
+    assert decision.quantity == 65
+
+
+def test_option_stop_risk_permits_one_of_two_lots() -> None:
+    """Test E: capital allows two lots, stop-risk budget allows one."""
+    decision = _opt_engine().plan(
+        _opt_inputs(
+            requested_qty=130, balance=2_000_000.0, per_trade_risk_pct=0.1
+        )
+    )
+    assert decision.ok
+    assert decision.quantity == 65
+
+
+@pytest.mark.parametrize("lot_size", [50, 65, 75])
+def test_option_broker_quantity_uses_resolved_lot_size(lot_size: int) -> None:
+    """Test G: lot size is taken from the contract, never hard-coded."""
+    decision = _opt_engine().plan(_opt_inputs(lot_size=lot_size))
+    assert decision.ok
+    assert decision.quantity == lot_size
+    assert decision.quantity % lot_size == 0
+
+
+def test_option_premium_cost_is_not_double_counted_by_contract_size() -> None:
+    """Test H: one lot at premium 100, lot_size 65 costs ~6500, not 422500."""
+    decision = _opt_engine().plan(_opt_inputs())
+    assert decision.quantity == 65
+    assert decision.est_required == pytest.approx(6_500.0)
+    assert decision.est_required != pytest.approx(422_500.0)
+
+
+def test_option_affordability_uses_selected_premium_not_underlying() -> None:
+    """Test I: affordability uses the option premium (120), not spot (25000)."""
+    decision = _opt_engine().plan(_opt_inputs(price=120.0, stop_loss=100.0))
+    assert decision.ok
+    assert decision.quantity == 65
+    # 120 * 65 = 7800, nowhere near a spot-driven 25000 * 65.
+    assert decision.est_required == pytest.approx(7_800.0)


### PR DESCRIPTION
Makes NIFTY option sizing reason in **whole lots**, fixes a broken arithmetic path in `MarginEngine`, and hardens the runner's lot handling.

## Scope correction (important — read first)

An earlier revision of this description claimed MarginEngine was "the live sizing authority via `OrderManager._pre_trade_decision`". **That is wrong for entries.** Verified by exhaustive trace:

- `_pre_trade_decision` has exactly two callers: `_precheck_margin` and `_execute_market_order`.
- **`_precheck_margin` is dead code** — zero callers in `src/` or `tests/` — and it discards `decision.quantity` entirely, returning only `(ok, reason, meta)`.
- `_execute_market_order` *does* correctly rebind `quantity = effective_quantity`, but its only call site is `_handle_failed_bracket_entry` — the **emergency-exit** path.
- The entry path is `submit_trade_plan_result` -> `place_managed_order_result` / `place_managed_order` / `place_order`, all forwarding `plan.quantity` unchanged. None contains `_pre_trade_decision`, `margin_engine` or `effective_quantity`.

**Current live entries therefore submit the strategy-requested lots after exactly one lot-size conversion, with no risk/affordability clamp applied.** The MarginEngine arithmetic fix below remains valid and necessary for its existing caller (emergency exit) and for any future entry wiring, but it does **not** gate entry sizing today. Wiring MarginEngine into the entry path is a deliberate design change and is intentionally **not** part of this PR. No authoritative final-sizing telemetry is added, because there is no live entry-sizing boundary to attach it to.

## MarginEngine arithmetic fix

`_max_qty_from_risk` divided rupee budgets by **per-lot** denominators (`contract_multiplier` is set by the caller to `float(max(lot_size, 1))` — it *is* the lot size), producing a count of **complete lots** that was then returned and compared as if it were **broker units**:

```python
qty = max(0, min(inputs.requested_qty, max_units))   # units vs lots
qty = self._snap_lot(qty, inputs.lot_size)           # -> 0
```

Reproduced directly — premium 100, stop 80, lot_size 65, balance 200000, risk 1%. One-lot risk = 20x65 = 1300 against a 2000 budget, so one lot is clearly affordable. The engine returned `ok=False, quantity=0, reason='no_qty_after_risk'`: `min(65 units, 1 lot) = 1` -> snap -> `0`.

**Fix:** per-lot economics derived from `lot_size` alone, sizing in complete lots throughout, single conversion to broker units at the end. `contract_multiplier` is no longer used in any calculation, so contract size cannot be double-counted regardless of how a caller sets it.

If production logs show `no_qty_after_risk` or `margin_sizing_zero_qty`, this arithmetic is a likely contributor on the paths that do reach MarginEngine. It is **not** established that this caused all historical zero fills — entries do not currently pass through this code.

## Contract-size double count fixed
`est_required` applied `contract_multiplier` to a quantity already in broker units, squaring contract size: **100 x 65 x 65 = 422500** instead of **6500**.

## `estimate_margin` ambiguous probe removed (final correction)
`estimate_margin` has **no concrete implementation anywhere in the repository** — no adapter in `brokers/` defines it, and no test mocks it. An earlier revision called `estimate_margin(symbol, lot_size, price)` and claimed this was "correct under either possible quantity convention" — that claim was false: it is only correct if quantity means broker units. If a future adapter treated quantity as lots, this would silently request margin for `lot_size` lots instead of one. Rather than guess at an unverifiable contract, **the branch is removed entirely**.

`_max_qty_from_risk()` now computes `max_lots` from only the two deterministic sources:
```python
max_lots = min(lots_by_risk, lots_by_cap)
```
then applies the configured max-lots cap and converts to broker units exactly once, unchanged from before.

`_estimate_required()` is untouched — it already attempts the concrete `get_required_margin` broker operation and falls back to `option_premium x broker_quantity x margin_factor`. Broker required-margin validation continues there, not in the removed branch.

## Runner changes
- `max(int(signal.quantity or 1), 1)` silently promoted `None`/`0`/negative to a live one-lot order. Now fails closed with `invalid_requested_lots`. One lot is the minimum valid trade, not a fallback for invalid input.
- `TradePlan.requested_lots` was back-derived as `1 if qty == lot_size else 0`, so every multi-lot trade recorded `0`. Now exact division.
- New **`OPTION_LOT_REQUEST_NORMALIZED`** telemetry — deliberately named as *request normalization*, not a sizing decision. Fields: `symbol`, `requested_lots`, `resolved_lot_size`, `requested_broker_quantity`, `option_entry_price`, `option_stop_loss`, `trace_id`. No field implies finality.

## Verified engine behaviour (re-verified identical after the final correction — the removed branch was always inert since no adapter implements it)
| case | result |
|---|---|
| 1 lot, lot_size 65 | qty **65**, est_required **6500** |
| 2 lots affordable | qty **130** |
| request 2, capital/risk supports 1 | qty **65** |
| capacity below one lot | qty **0**, rejected (never rounded up) |
| lot_size 50 / 75 | qty **50** / **75** (nothing hard-coded) |
| premium 120 vs spot 25000 | affordability uses 120x65 = **7800** |

## Phase-0 audit (verified, unchanged)
`Signal.quantity` means lots. `RiskManager.suggest_position_size()` has no production caller (Telegram diagnostic only) — left untouched, so no second live sizing formula. `TradePlan.quantity` is broker units. `StrategyRunner._execute_order` (which force-promotes zero to one lot) has no production caller — dead in the live path, not refactored.

## Tests
**+8** in the existing `tests/execution/test_margin_engine.py` (no new module), all verified to **fail against the pre-fix engine**. Covers: one lot -> 65; two lots -> 130; sub-lot capacity rejected; capital permits 1 of 2; stop-risk permits 1 of 2; lot size parametrized 50/65/75; est_required ~6500 not 422500; affordability uses option premium not spot. No test anywhere mocked the removed `estimate_margin` probe, so none needed updating.

**Not covered** (explicitly not claimed): candidate-replacement price provenance, broker-conversion instrumentation, and live-sim order-path assertions.

## Validation (all exit 0)
`compileall src tests` - focused margin/order tests (`test_margin_engine`, `test_margin_clamp`, `test_execution_safety_audit_fixes`, `test_order_manager_trade_plan`, `test_execution_path_contract`) - `tests/execution` - `tests/strategies` - `-m live_runtime_e2e tests/e2e/live_sim` - **full suite 2054 passed, 2 skipped, 1 deselected, 0 failed**.

**Known pre-existing flake (A/B measured):** `test_live_runtime_bullish_spot_future_selects_ce_and_exits_target` fails intermittently under full-suite load at the same rate on clean main as on this branch, and passes standalone. Rejection reason is `score_below_threshold` (strategy scoring), unrelated to lot sizing; not touched here.

Production LOC (cumulative across all commits on this branch): **+148 / -74** across 2 files. No new production files, no broker calls added, no changes to option selection, strike/expiry choice, direction logic, stop/target formulas, bracket lifecycle or order idempotency. No entry-side margin gating wired in.