### PR TITLE
fix: enforce whole-lot entry sizing and margin step-down

### DIFF
--- a/src/nifty_scalper_bot/execution/margin_engine.py
+++ b/src/nifty_scalper_bot/execution/margin_engine.py
@@ -148,12 +148,16 @@ class MarginEngine:
             },
         )
         fallback_balance = max(0.0, float(inputs.balance))
-        if int(inputs.requested_qty) <= 0:
-            # Fail closed before any minimum-lot clamping: a zero/negative
-            # request must never be promoted into live exposure.
+        requested_qty = int(inputs.requested_qty)
+        raw_lot = max(1, int(inputs.lot_size))
+        if requested_qty <= 0 or requested_qty % raw_lot != 0:
             return MarginDecision(
                 ok=False,
-                reason="invalid_requested_quantity",
+                reason=(
+                    "invalid_requested_quantity"
+                    if requested_qty <= 0
+                    else "invalid_lot_quantity"
+                ),
                 order_type=(inputs.product or "NRML") or "NRML",
                 quantity=0,
                 est_required=0.0,
@@ -169,15 +173,14 @@ class MarginEngine:
             effective_inputs.ist_now, effective_inputs.product
         )
         max_units = self._max_qty_from_risk(effective_inputs)
-        raw_lot = max(1, int(inputs.lot_size))
         min_lot_qty = raw_lot * max(1, int(inputs.min_lots_per_trade))
         max_lot_qty = raw_lot * max(int(inputs.max_lots_per_trade), 0)
         if 0 < max_lot_qty < min_lot_qty:
             min_lot_qty = max_lot_qty
         if max_lot_qty > 0:
             max_units = min(max_units, max_lot_qty)
-        qty = max(0, min(inputs.requested_qty, max_units))
-        qty = self._snap_lot(qty, inputs.lot_size)
+        qty = max(0, min(requested_qty, max_units))
+        qty = self._snap_lot(qty, raw_lot)
         if max_lot_qty > 0:
             qty = min(qty, max_lot_qty)
         if qty <= 0:
@@ -187,7 +190,7 @@ class MarginEngine:
                     "event": "margin_sizing_zero_qty",
                     "symbol": inputs.symbol,
                     "side": inputs.side,
-                    "requested_qty": inputs.requested_qty,
+                    "requested_qty": requested_qty,
                     "max_units": max_units,
                     "available_margin": round(float(available_margin), 2),
                     "effective_balance": round(float(effective_balance), 2),
@@ -200,7 +203,7 @@ class MarginEngine:
         if qty <= 0:
             min_lots = max(1, int(app_settings.MIN_LOTS_PER_TRADE))
             min_lots = max(min_lots, int(inputs.min_lots_per_trade))
-            lot_units = max(1, int(inputs.lot_size))
+            lot_units = raw_lot
             min_qty = min_lots * lot_units
             if max_units < min_qty:
                 sizing = SizingResult(
@@ -343,7 +346,19 @@ class MarginEngine:
                 sizing=sizing,
             )
 
-        if available_margin * inputs.margin_buffer < needed:
+        buffer = inputs.margin_buffer if inputs.margin_buffer > 0 else 1.0
+        while qty > min_lot_qty and available_margin * buffer < needed:
+            qty -= raw_lot
+            needed = self._estimate_required(
+                symbol=inputs.symbol,
+                side=inputs.side,
+                quantity=qty,
+                order_type=order_type,
+                inputs=inputs,
+            )
+        sizing.qty = qty
+        sizing.needed = needed
+        if available_margin * buffer < needed:
             reason_text = f"MARGIN needed={needed:.2f}"
             self._logger.info(
                 "margin_plan_block_balance",
@@ -355,7 +370,7 @@ class MarginEngine:
                     "quantity": qty,
                     "needed": needed,
                     "available": available_margin,
-                    "buffer": inputs.margin_buffer,
+                    "buffer": buffer,
                 },
             )
             return MarginDecision(
@@ -614,7 +629,7 @@ class MarginEngine:
 
         balance = max(0.0, float(inputs.balance))
         price = max(inputs.price, 0.0)
-        cap_pct = max(inputs.per_trade_cap_pct, inputs.per_trade_risk_pct)
+        cap_pct = max(inputs.per_trade_cap_pct, 0.0)
         cap_from_pct = balance * (cap_pct / 100.0)
         risk_pct = max(inputs.per_trade_risk_pct, 0.0) / 100.0
 
@@ -646,7 +661,7 @@ class MarginEngine:
         # anywhere in this repo (no adapter defines it), so its quantity
         # convention cannot be verified: passing `lot_size` as quantity is
         # only correct if a future adapter treats quantity as broker units --
-        # if one instead treated it as lots, this would silently request
+        # if one instead treated quantity as lots, this would silently request
         # margin for `lot_size` lots. Removed rather than guessed. Sizing
         # here relies only on the two deterministic sources below; broker
         # required-margin validation still happens in _estimate_required()
@@ -748,9 +763,7 @@ class MarginEngine:
         # `contract_multiplier` IS the lot size, so applying it here would
         # square the contract size (e.g. 100 x 65 x 65 = 422500 instead of
         # 6500). Contract size is counted exactly once, inside `quantity`.
-        estimate = (
-            premium * max(quantity, 0) * max(inputs.margin_factor, 1.0)
-        )
+        estimate = premium * max(quantity, 0) * max(inputs.margin_factor, 1.0)
         return estimate
 
     def _session_reason(self, now_ist: datetime, order_type: str) -> str | None:

--- a/tests/execution/test_margin_engine.py
+++ b/tests/execution/test_margin_engine.py
@@ -7,15 +7,22 @@ from nifty_scalper_bot.execution.margin_engine import MarginEngine, MarginInputs
 
 
 class DummyBroker:
-    def __init__(self, required: float | None = None) -> None:
+    def __init__(self, required: float | dict[int, float] | None = None) -> None:
         self.required = required
+        self.quantities: list[int] = []
 
     def get_required_margin(
         self, *, symbol: str, side: str, quantity: int, product: str
     ) -> dict[str, float]:
+        self.quantities.append(quantity)
         if self.required is None:
             raise RuntimeError("not implemented")
-        return {"required": self.required}
+        required = (
+            self.required.get(quantity, 0.0)
+            if isinstance(self.required, dict)
+            else self.required
+        )
+        return {"required": required}
 
 
 def _inputs(**overrides: float | int | str | None) -> MarginInputs:
@@ -68,7 +75,7 @@ def test_plan_downgrades_mis_after_cutoff() -> None:
     assert decision.reason == "MIS_WINDOW_CLOSED"
 
 
-def test_plan_sizes_by_risk_and_caps() -> None:
+def test_plan_honours_tighter_cap_independently() -> None:
     engine = MarginEngine(
         broker=object(), data_hub=None, lot_size_resolver=None, clock=lambda: 0.0
     )
@@ -82,8 +89,8 @@ def test_plan_sizes_by_risk_and_caps() -> None:
         per_trade_cap_pct=0.5,
     )
     decision = engine.plan(inputs)
-    assert decision.ok
-    assert decision.quantity == 5
+    assert not decision.ok
+    assert decision.quantity == 0
 
 
 def test_plan_uses_broker_margin_when_available() -> None:
@@ -100,41 +107,40 @@ def test_plan_uses_broker_margin_when_available() -> None:
     assert decision.available == pytest.approx(1_000.0)
 
 
-def test_plan_clamps_min_lot_when_margin_permits() -> None:
+def test_plan_steps_down_by_whole_lots_until_broker_margin_fits() -> None:
+    broker = DummyBroker(required={15: 1_500.0, 10: 900.0})
     engine = MarginEngine(
-        broker=object(), data_hub=None, lot_size_resolver=None, clock=lambda: 0.0
+        broker=broker, data_hub=None, lot_size_resolver=None, clock=lambda: 0.0
     )
-    inputs = _inputs(requested_qty=1, lot_size=25, balance=10_000.0)
-    decision = engine.plan(inputs)
+    decision = engine.plan(
+        _inputs(
+            price=10.0,
+            stop_loss=9.0,
+            requested_qty=15,
+            lot_size=5,
+            balance=1_000.0,
+            per_trade_risk_pct=100.0,
+            per_trade_cap_pct=100.0,
+        )
+    )
     assert decision.ok
-    assert decision.quantity == 25
-    assert decision.sizing is not None
-    assert decision.sizing.reason == "clamped_min_lot"
+    assert decision.quantity == 10
+    assert decision.est_required == pytest.approx(900.0)
+    assert broker.quantities == [15, 10]
 
 
-def test_plan_reports_insufficient_margin_for_min_lot() -> None:
+def test_plan_rejects_positive_non_lot_request() -> None:
     engine = MarginEngine(
         broker=object(), data_hub=None, lot_size_resolver=None, clock=lambda: 0.0
     )
-    inputs = _inputs(requested_qty=1, lot_size=25, balance=1_000.0, price=120.0)
-    decision = engine.plan(inputs)
+    decision = engine.plan(_inputs(requested_qty=1, lot_size=25))
     assert not decision.ok
-    assert decision.reason == "margin_no_qty"
     assert decision.quantity == 0
-    assert decision.sizing is not None
-    assert decision.sizing.reason == "margin_no_qty"
-    assert decision.sizing.needed is not None and decision.sizing.needed > 0
+    assert decision.reason == "invalid_lot_quantity"
 
 
 def test_plan_rejects_zero_requested_quantity_without_min_lot_promotion() -> None:
-    """A zero request must never become live exposure.
-
-    Previously this asserted zero was clamped UP to one minimum lot
-    (`clamped_min_lot`). That is unsafe for a live entry-sizing authority:
-    minimum-lot logic may decide whether a POSITIVE request has at least one
-    tradable lot of capacity, but it must never manufacture a position from a
-    zero or negative request.
-    """
+    """A zero request must never become live exposure."""
     engine = MarginEngine(
         broker=object(), data_hub=None, lot_size_resolver=None, clock=lambda: 0.0
     )
@@ -157,7 +163,6 @@ def test_plan_rejects_zero_requested_quantity_without_min_lot_promotion() -> Non
 
 @pytest.mark.parametrize("requested_qty", [0, -1, -65])
 def test_plan_rejects_non_positive_requested_quantity(requested_qty: int) -> None:
-    """Test 4: zero and negative requests fail closed with a specific reason."""
     engine = MarginEngine(
         broker=object(), data_hub=None, lot_size_resolver=None, clock=lambda: 0.0
     )
@@ -169,9 +174,7 @@ def test_plan_rejects_non_positive_requested_quantity(requested_qty: int) -> Non
 
 # ===================== OPTION LOT-SIZING REGRESSION =====================
 # NIFTY option sizing must reason in COMPLETE LOTS and convert to broker
-# units exactly once. Regression for the unit/lot mixing that rejected every
-# affordable trade with `no_qty_after_risk`, and for the contract-size double
-# count that inflated est_required by lot_size.
+# units exactly once.
 
 
 def _opt_inputs(**overrides):
@@ -190,7 +193,6 @@ def _opt_inputs(**overrides):
         "per_trade_cap_pct": 100.0,
         "margin_factor": 1.0,
         "margin_buffer": 1.0,
-        # Production sets this to the lot size; sizing must NOT count it again.
         "contract_multiplier": float(lot),
         "ist_now": datetime(2024, 1, 1, 9, 30, tzinfo=ZoneInfo("Asia/Kolkata")),
         "min_lots_per_trade": 1,
@@ -208,14 +210,12 @@ def _opt_engine() -> MarginEngine:
 
 
 def test_option_one_lot_accepted_as_broker_units() -> None:
-    """Test A: one lot with lot_size=65 becomes broker quantity 65."""
     decision = _opt_engine().plan(_opt_inputs())
     assert decision.ok
     assert decision.quantity == 65
 
 
 def test_option_two_lots_accepted() -> None:
-    """Test B: two affordable lots become broker quantity 130."""
     decision = _opt_engine().plan(
         _opt_inputs(requested_qty=130, balance=2_000_000.0)
     )
@@ -224,21 +224,18 @@ def test_option_two_lots_accepted() -> None:
 
 
 def test_option_partial_lot_capacity_is_rejected_not_rounded_up() -> None:
-    """Test C: capacity below one complete lot rejects; never rounds up."""
     decision = _opt_engine().plan(_opt_inputs(balance=1_000.0))
     assert not decision.ok
     assert decision.quantity == 0
 
 
 def test_option_capital_permits_one_of_two_requested_lots() -> None:
-    """Test D: request 2, capital/risk supports 1 -> exactly one lot."""
     decision = _opt_engine().plan(_opt_inputs(requested_qty=130))
     assert decision.ok
     assert decision.quantity == 65
 
 
 def test_option_stop_risk_permits_one_of_two_lots() -> None:
-    """Test E: capital allows two lots, stop-risk budget allows one."""
     decision = _opt_engine().plan(
         _opt_inputs(
             requested_qty=130, balance=2_000_000.0, per_trade_risk_pct=0.1
@@ -250,7 +247,6 @@ def test_option_stop_risk_permits_one_of_two_lots() -> None:
 
 @pytest.mark.parametrize("lot_size", [50, 65, 75])
 def test_option_broker_quantity_uses_resolved_lot_size(lot_size: int) -> None:
-    """Test G: lot size is taken from the contract, never hard-coded."""
     decision = _opt_engine().plan(_opt_inputs(lot_size=lot_size))
     assert decision.ok
     assert decision.quantity == lot_size
@@ -258,7 +254,6 @@ def test_option_broker_quantity_uses_resolved_lot_size(lot_size: int) -> None:
 
 
 def test_option_premium_cost_is_not_double_counted_by_contract_size() -> None:
-    """Test H: one lot at premium 100, lot_size 65 costs ~6500, not 422500."""
     decision = _opt_engine().plan(_opt_inputs())
     assert decision.quantity == 65
     assert decision.est_required == pytest.approx(6_500.0)
@@ -266,9 +261,7 @@ def test_option_premium_cost_is_not_double_counted_by_contract_size() -> None:
 
 
 def test_option_affordability_uses_selected_premium_not_underlying() -> None:
-    """Test I: affordability uses the option premium (120), not spot (25000)."""
     decision = _opt_engine().plan(_opt_inputs(price=120.0, stop_loss=100.0))
     assert decision.ok
     assert decision.quantity == 65
-    # 120 * 65 = 7800, nowhere near a spot-driven 25000 * 65.
     assert decision.est_required == pytest.approx(7_800.0)

--- a/tests/execution/test_margin_engine.py
+++ b/tests/execution/test_margin_engine.py
@@ -50,14 +50,14 @@ def _inputs(**overrides: float | int | str | None) -> MarginInputs:
     return MarginInputs(**base)  # type: ignore[arg-type]
 
 
-def test_plan_blocks_when_needed_gt_available() -> None:
+def test_plan_steps_down_fallback_margin_to_affordable_quantity() -> None:
     engine = MarginEngine(
         broker=object(), data_hub=None, lot_size_resolver=None, clock=lambda: 0.0
     )
-    inputs = _inputs(balance=500.0)
-    decision = engine.plan(inputs)
-    assert not decision.ok
-    assert decision.reason is not None and "MARGIN" in decision.reason
+    decision = engine.plan(_inputs(balance=500.0))
+    assert decision.ok
+    assert decision.quantity == 5
+    assert decision.est_required == pytest.approx(500.0)
 
 
 def test_plan_downgrades_mis_after_cutoff() -> None:


### PR DESCRIPTION
Minimal follow-up to merged PR #920.

- Reject non-positive or non-lot-multiple entry quantities at MarginEngine.
- Never widen a tighter per-trade capital cap to the risk percentage.
- When broker-required margin rejects the selected size, step down one whole lot at a time until affordable or minimum size is reached.
- No new files; only the existing margin engine is changed.

The branch must remain unmerged until all CI checks pass.