### PR TITLE
fix: clear final live-entry blockers

### DIFF
--- a/src/nifty_scalper_bot/config/env_utils.py
+++ b/src/nifty_scalper_bot/config/env_utils.py
@@ -6,6 +6,7 @@ import logging
 import os
 
 LOGGER = logging.getLogger(__name__)
+LIVE_PER_TRADE_RISK_PCT = "7.0"
 
 
 def _strip_inline_comment(text: str) -> str:
@@ -124,6 +125,12 @@ def normalise_live_env_defaults() -> None:
 
     for key, value in defaults.items():
         setdefault_env(key, value)
+
+    if live_requested:
+        # One canonical live risk value. Keep both accepted aliases aligned so
+        # an older private deployment value cannot silently retain the 4% cap.
+        os.environ['RISK__PER_TRADE_RISK_PCT'] = LIVE_PER_TRADE_RISK_PCT
+        os.environ['RISK_PER_TRADE_PCT'] = LIVE_PER_TRADE_RISK_PCT
 
 
 def resolve_build_sha() -> str:

--- a/src/nifty_scalper_bot/core/signal_arbitrator.py
+++ b/src/nifty_scalper_bot/core/signal_arbitrator.py
@@ -45,8 +45,15 @@ class TradeDecision:
 
 
 class SignalArbitrator:
-    def __init__(self, cooldown_seconds: float = 3.0) -> None:
+    def __init__(
+        self,
+        cooldown_seconds: float = 3.0,
+        stale_active_seconds: float = 120.0,
+    ) -> None:
         self._cooldown_seconds = max(float(cooldown_seconds), 0.0)
+        self._stale_active_seconds = max(
+            float(stale_active_seconds), self._cooldown_seconds
+        )
         self._active_symbols: set[str] = set()
         self._state: dict[str, _SymbolState] = {}
         self._lock = threading.RLock()
@@ -63,10 +70,21 @@ class SignalArbitrator:
         direction = self._direction(normalized_action)
         now = time.time()
         with self._lock:
-            if symbol in self._active_symbols:
-                return False
             prev = self._state.get(symbol)
+            if symbol in self._active_symbols:
+                if (
+                    prev is not None
+                    and now - prev.last_ts >= self._stale_active_seconds
+                ):
+                    self._active_symbols.discard(symbol)
+                    self._state.pop(symbol, None)
+                    prev = None
+                else:
+                    return False
             if prev is None:
+                return True
+            if now - prev.last_ts >= self._stale_active_seconds:
+                self._state.pop(symbol, None)
                 return True
             if direction and prev.direction == direction:
                 return False

--- a/src/nifty_scalper_bot/execution/order_state_machine.py
+++ b/src/nifty_scalper_bot/execution/order_state_machine.py
@@ -22,6 +22,7 @@ class ExecutionState(str, Enum):
 class OrderStateMachine:
     """Track and validate order lifecycle transitions per symbol."""
 
+    _STALE_ORDER_PENDING_SECONDS = 120.0
     _VALID_TRANSITIONS: dict[ExecutionState, set[ExecutionState]] = {
         ExecutionState.IDLE: {ExecutionState.READY, ExecutionState.SIGNAL_RECEIVED},
         ExecutionState.READY: {ExecutionState.SIGNAL_RECEIVED, ExecutionState.IDLE},
@@ -74,18 +75,37 @@ class OrderStateMachine:
         """Apply validated transition. Args: new_state and optional order_id/
         reason/trace_id metadata. Returns: bool. Raises: none."""
         with self._lock:
+            now = datetime.now(timezone.utc)
+            state_age = max(0.0, (now - self._entered_at).total_seconds())
+            stale_pending_retry = (
+                self._state is ExecutionState.ORDER_PENDING
+                and new_state is ExecutionState.ORDER_PENDING
+                and bool(trace_id)
+                and trace_id != self._trace_id
+                and state_age >= self._STALE_ORDER_PENDING_SECONDS
+            )
+            if stale_pending_retry:
+                self._state = ExecutionState.ORDER_PENDING
+                self._last_transition_ts = now.isoformat()
+                self._entered_at = now
+                self._order_id = order_id
+                self._reason = reason
+                self._trace_id = trace_id
+                self._last_reject = None
+                return True
+
             allowed = self._VALID_TRANSITIONS.get(self._state, set())
             if new_state not in allowed:
                 self._last_reject = {
                     "from": self._state.value,
                     "to": new_state.value,
                     "allowed_next": sorted(state.value for state in allowed),
-                    "ts": datetime.now(timezone.utc).isoformat(),
+                    "ts": now.isoformat(),
                 }
                 return False
             self._state = new_state
-            self._last_transition_ts = datetime.now(timezone.utc).isoformat()
-            self._entered_at = datetime.now(timezone.utc)
+            self._last_transition_ts = now.isoformat()
+            self._entered_at = now
             if order_id is not None:
                 self._order_id = order_id
             if reason is not None:

--- a/src/nifty_scalper_bot/execution/runtime_order_manager.py
+++ b/src/nifty_scalper_bot/execution/runtime_order_manager.py
@@ -102,7 +102,15 @@ class RuntimeOrderManager(_core.OrderManager):
         blocked = self._blocked("place_managed_order_result", args, kwargs)
         if blocked is not NO_BLOCK:
             return blocked
-        return super().place_managed_order_result(*args, **kwargs)
+        previous = getattr(self, "_managed_strategy_name", None)
+        self._managed_strategy_name = str(kwargs.get("strategy_name") or "runner")
+        try:
+            return super().place_managed_order_result(*args, **kwargs)
+        finally:
+            if previous is None:
+                self.__dict__.pop("_managed_strategy_name", None)
+            else:
+                self._managed_strategy_name = previous
 
     def place_managed_order(self, *args: Any, **kwargs: Any) -> Any:
         blocked = self._blocked("place_managed_order", args, kwargs)
@@ -111,10 +119,15 @@ class RuntimeOrderManager(_core.OrderManager):
         return super().place_managed_order(*args, **kwargs)
 
     def place_order(self, *args: Any, **kwargs: Any) -> Any:
-        blocked = self._blocked("place_order", args, kwargs)
+        effective_kwargs = dict(kwargs)
+        managed_strategy = getattr(self, "_managed_strategy_name", None)
+        current_strategy = str(effective_kwargs.get("strategy_name") or "").strip().lower()
+        if managed_strategy and current_strategy in {"", "manual"}:
+            effective_kwargs["strategy_name"] = managed_strategy
+        blocked = self._blocked("place_order", args, effective_kwargs)
         if blocked is not NO_BLOCK:
             return blocked
-        cleaned_kwargs, identity = _strip_exit_identity_kwargs(kwargs)
+        cleaned_kwargs, identity = _strip_exit_identity_kwargs(effective_kwargs)
         if identity:
             self._last_exit_identity_kwargs = dict(identity)
         return super().place_order(*args, **cleaned_kwargs)

--- a/tests/execution/test_runtime_order_facade.py
+++ b/tests/execution/test_runtime_order_facade.py
@@ -103,6 +103,63 @@ def test_native_gate_allows_protective_exit_but_blocks_normal_order() -> None:
     assert normal is None
 
 
+def test_managed_order_preserves_approved_strategy_name(monkeypatch) -> None:
+    manager = _manager(None)
+    captured: dict[str, Any] = {}
+
+    def core_place_order(self: Any, *args: Any, **kwargs: Any) -> str:
+        captured.update(kwargs)
+        return "OID-1"
+
+    def core_managed(self: Any, *args: Any, **kwargs: Any) -> Any:
+        order_id = self.place_order(
+            symbol=kwargs["symbol"],
+            side=kwargs["side"],
+            quantity=kwargs["quantity"],
+            signal_id=kwargs.get("signal_id"),
+            intent="ENTRY",
+        )
+        return SimpleNamespace(
+            accepted=bool(order_id),
+            order_id=order_id,
+            reason="accepted",
+            details={},
+            broker_attempted=True,
+        )
+
+    monkeypatch.setattr(order_manager_core.OrderManager, "place_order", core_place_order)
+    monkeypatch.setattr(
+        order_manager_core.OrderManager,
+        "place_managed_order_result",
+        core_managed,
+    )
+
+    result = manager.place_managed_order_result(
+        symbol="NFO:NIFTY26JUL23950PE",
+        side="BUY",
+        quantity=65,
+        strategy_name="OrderFlow",
+        signal_id="sig-1",
+    )
+
+    assert result.accepted is True
+    assert captured["strategy_name"] == "OrderFlow"
+
+
+def test_live_env_normalizes_per_trade_risk_to_seven_percent(monkeypatch) -> None:
+    from nifty_scalper_bot.config.env_utils import normalise_live_env_defaults
+
+    monkeypatch.setenv("ENABLE_LIVE", "true")
+    monkeypatch.setenv("EXECUTION_MODE", "LIVE")
+    monkeypatch.setenv("RISK__PER_TRADE_RISK_PCT", "4.0")
+    monkeypatch.setenv("RISK_PER_TRADE_PCT", "4.0")
+
+    normalise_live_env_defaults()
+
+    assert os.environ["RISK__PER_TRADE_RISK_PCT"] == "7.0"
+    assert os.environ["RISK_PER_TRADE_PCT"] == "7.0"
+
+
 def test_order_module_is_safe_when_imported_before_package() -> None:
     code = r'''
 import importlib

--- a/tests/test_execution_path_contract.py
+++ b/tests/test_execution_path_contract.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
 import ast
+from datetime import timedelta
 from pathlib import Path
 
+from nifty_scalper_bot.core.signal_arbitrator import SignalArbitrator
 from nifty_scalper_bot.execution.bracket_manager import BracketManager
 from nifty_scalper_bot.execution.order_manager import OrderManager
+from nifty_scalper_bot.execution.order_state_machine import ExecutionState, OrderStateMachine
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -117,3 +120,40 @@ def test_runner_execute_order_does_not_bypass_canonical_entry_api() -> None:
             assert "execute_market_order" not in calls
             return
     raise AssertionError("StrategyRunner._execute_order not found")
+
+
+def test_stale_signal_arbitration_reservation_expires() -> None:
+    arbitrator = SignalArbitrator(stale_active_seconds=120.0)
+    symbol = "NFO:NIFTY26JUL23950PE"
+    arbitrator.register(symbol, "BUY")
+    arbitrator._state[symbol].last_ts -= 121.0
+
+    assert arbitrator.allow(symbol, "BUY") is True
+    assert symbol not in arbitrator._active_symbols
+
+
+def test_stale_order_pending_accepts_new_trace_but_fresh_duplicate_does_not() -> None:
+    machine = OrderStateMachine()
+    assert machine.transition(ExecutionState.SIGNAL_RECEIVED, trace_id="old-trace")
+    assert machine.transition(
+        ExecutionState.ORDER_PENDING,
+        order_id="old-order",
+        reason="order_submit",
+        trace_id="old-trace",
+    )
+    assert not machine.transition(
+        ExecutionState.ORDER_PENDING,
+        reason="order_submit",
+        trace_id="new-trace",
+    )
+
+    machine._entered_at -= timedelta(seconds=121)
+    assert machine.transition(
+        ExecutionState.ORDER_PENDING,
+        reason="order_submit",
+        trace_id="new-trace",
+    )
+    details = machine.current_state_details()
+    assert details["state"] == ExecutionState.ORDER_PENDING.value
+    assert details["order_id"] is None
+    assert details["trace_id"] == "new-trace"


### PR DESCRIPTION
Log-driven minimal live-path corrections; no new files.

- Set canonical live per-trade stop risk to 7% and align both accepted env aliases.
- Preserve the StrategyManager-approved strategy name through managed placement so OrderFlow does not become `manual` before SignalArbitrator.
- Expire stale SignalArbitrator active reservations after 120 seconds.
- Permit a new trace to recover a stale `ORDER_PENDING` state after 120 seconds while fresh duplicate submissions remain blocked.
- Add focused regression coverage in existing test files.

No strategy thresholds, candidate filters, broker APIs, bracket geometry, or exit protections were weakened.