### PR TITLE
fix: clear broker-flat stale exit blocker

### DIFF
--- a/src/nifty_scalper_bot/execution/runtime_order_manager.py
+++ b/src/nifty_scalper_bot/execution/runtime_order_manager.py
@@ -63,6 +63,10 @@ class RuntimeOrderManager(_core.OrderManager):
 
     def set_unresolved_exit_provider(self, provider: Any | None) -> None:
         configure_provider(self, provider)
+        # The provider is the canonical runtime bracket owner. Reconciliation
+        # already reads ``order_manager._bracket_manager``; keep both references
+        # aligned so a broker-flat snapshot can clear a completed exit lifecycle.
+        self._bracket_manager = provider
 
     def current_entry_blocker(self) -> Mapping[str, Any] | None:
         return _current_entry_blocker(self)

--- a/tests/execution/test_runtime_order_facade.py
+++ b/tests/execution/test_runtime_order_facade.py
@@ -103,6 +103,21 @@ def test_native_gate_allows_protective_exit_but_blocks_normal_order() -> None:
     assert normal is None
 
 
+def test_unresolved_exit_provider_is_canonical_reconciliation_owner() -> None:
+    manager = _manager(None)
+    provider = _Provider(True)
+
+    manager.set_unresolved_exit_provider(provider)
+
+    assert manager._unresolved_exit_provider is provider
+    assert manager._bracket_manager is provider
+
+    manager.set_unresolved_exit_provider(None)
+
+    assert manager._unresolved_exit_provider is None
+    assert manager._bracket_manager is None
+
+
 def test_managed_order_preserves_approved_strategy_name(monkeypatch) -> None:
     manager = _manager(None)
     captured: dict[str, Any] = {}


### PR DESCRIPTION
Exact production-log correction for `unresolved_exit_position` persisting after repeated successful broker-flat reconciliations.

Root cause:
- `_reconcile_flat_exit_brackets()` reads the canonical bracket owner from `order_manager._bracket_manager`.
- Runtime binding registered that same owner only as `_unresolved_exit_provider`.
- The native entry gate could therefore see and block on bracket `2081608290672238592`, while reconciliation could not see the owner to clear it—even after `POSITION_SYNC_COMMITTED total=0`.

Minimal correction:
- When `RuntimeOrderManager.set_unresolved_exit_provider()` binds or clears the canonical provider, keep `_bracket_manager` aligned to the same object.
- Existing reconciliation logic, broker FLAT/ABSENT checks, local-position-zero checks, fail-closed UNKNOWN/NONZERO behavior, and read-only entry gate remain unchanged.
- Added focused regression coverage in the existing runtime facade test file.

No broker calls, strategy logic, cooldowns, sizing, stops, targets, or exit execution behavior changed. No new files.