### PR TITLE
fix: bound tick-drain invocation so it cannot monopolise the event loop

### DIFF
--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -534,6 +534,18 @@ class MarketDataManager:
         self._tick_drain_budget_s = self._parse_float_env(
             "MDM_TICK_DRAIN_BUDGET_SECONDS", default=0.008, minimum=0.001
         )
+        # Total wall-clock budget for ONE drain invocation. The per-batch
+        # budget above only yields with `await asyncio.sleep(0)`, which
+        # re-queues this task immediately; under continuous tick inflow the
+        # batch is never empty, so the task would never return and would
+        # monopolise the event-loop ready queue, starving timers (observed as
+        # EVENT_LOOP_LAG_HIGH up to ~2.3s with a drain active). Returning lets
+        # the loop take a clean pass; the `finally` block below reschedules
+        # immediately when ticks remain, so no tick is lost or delayed beyond
+        # one loop iteration.
+        self._tick_drain_invocation_budget_s = self._parse_float_env(
+            "MDM_TICK_DRAIN_INVOCATION_BUDGET_SECONDS", default=0.05, minimum=0.005
+        )
         self._tick_drain_callbacks_scheduled = 0
         self._tick_drain_callbacks_completed = 0
         self._tick_drain_callbacks_cancelled = 0
@@ -7326,6 +7338,13 @@ class MarketDataManager:
                     if time.monotonic() - start >= self._tick_drain_budget_s:
                         self._requeue_unprocessed_ticks(batch[index + 1 :])
                         break
+                if (
+                    time.monotonic() - drain_started
+                    >= self._tick_drain_invocation_budget_s
+                ):
+                    # Yield the loop entirely; `finally` reschedules when work
+                    # remains, so draining continues on the next iteration.
+                    return
                 await asyncio.sleep(0)
         except asyncio.CancelledError:
             with self._pending_tick_lock:

--- a/tests/data/test_mdm_tick_coalescing.py
+++ b/tests/data/test_mdm_tick_coalescing.py
@@ -2002,3 +2002,50 @@ def test_slow_closed_bar_subscriber_that_raises_is_identified(caplog):
         and getattr(record, "duration_ms", 0.0) >= 50.0
         for record in slow_records
     )
+
+
+def test_drain_invocation_returns_within_budget_under_continuous_inflow() -> None:
+    """Regression: one drain invocation must not monopolise the event loop.
+
+    The per-batch budget only yields with `await asyncio.sleep(0)`, which
+    re-queues the drain immediately. Under continuous inflow the pending queue
+    is never empty, so without a total-invocation budget the task never
+    returns and starves timer-driven loop work (observed in production as
+    EVENT_LOOP_LAG_HIGH up to ~2.3s while a drain was active).
+    """
+    mdm = _make_mdm()
+    mdm._tick_drain_invocation_budget_s = 0.02
+    mdm._tick_drain_budget_s = 0.001
+
+    processed = {"n": 0}
+
+    def _slow_tick(raw):
+        processed["n"] += 1
+        time.sleep(0.002)
+
+    mdm._process_queued_tick = _slow_tick
+
+    # Refill the queue on every pop so the batch is never empty -- exactly the
+    # continuous-inflow condition that previously made the drain run forever.
+    real_pop = mdm._pop_pending_tick_batch
+
+    def _always_more():
+        batch = real_pop()
+        if not batch:
+            return [
+                {"symbol": "NFO:NIFTY26JUN24000CE", "last_price": 1.0} for _ in range(5)
+            ]
+        return batch
+
+    mdm._pop_pending_tick_batch = _always_more
+
+    async def _run():
+        started = time.monotonic()
+        await mdm._drain_latest_ticks()
+        return time.monotonic() - started
+
+    elapsed = asyncio.run(_run())
+
+    # It returned at all (no infinite loop) and respected the budget.
+    assert processed["n"] > 0
+    assert elapsed < 0.5, f"drain monopolised the loop for {elapsed:.3f}s"


### PR DESCRIPTION
Fixes the production event-loop lag chain seen in the 2026-07-27 logs.

## Root cause (proven, not inferred)
`_drain_latest_ticks()` ran `while True` with **no total-invocation bound**. The existing per-batch budget (`MDM_TICK_DRAIN_BUDGET_SECONDS`, 8ms) only yields with `await asyncio.sleep(0)`, which re-queues the drain task immediately. Under continuous tick inflow the pending queue is never empty, so the task **never returned** — it cycled `8ms work -> sleep(0)` forever, permanently occupying the event-loop ready queue and starving timer-driven work.

**Proof:** the new regression test **times out (pytest exit 124 — infinite loop)** against the previous code, and completes in `<0.5s` after the fix.

## Log chain this explains
```
EVENT_LOOP_LAG_HIGH 527..2345ms, drain_state={'scheduled': True, 'active': 1}, tick_pending up to 43
  -> ticks sit queued past their own minute boundary
  -> CANDLE_TICK_DROPPED reason=finalized_minute   (tick_minute == latest_finalized, candle_engine.py:739)
  -> candle gaps
  -> STRATEGY_LIVE_SAFETY_BLOCK reason=live_latest_closed_bar_stale
  -> entries blocked
```
`DATA_PIPELINE_OVERLOAD_ENTER oldest_pending_age_ms=2295` (>2000) corroborates. `TICK_STAGE_SLOW stage=drain_invocation duration_ms=191` is the same effect — that log fires at >=100ms, so invocations routinely overran. No **per-stage** `TICK_STAGE_SLOW` was emitted (50ms threshold), confirming the lag was cumulative monopolisation rather than a single slow call.

## Fix
`MDM_TICK_DRAIN_INVOCATION_BUDGET_SECONDS` (default 0.05s, min 0.005s). When one invocation exceeds it, the coroutine returns. The existing `finally` block already reschedules whenever pending ticks remain, so draining continues on the next loop iteration — **no tick dropped, requeued incorrectly, or delayed beyond one iteration**. Per-batch budget, coalescing, ordering, priority buckets and overload detection are unchanged.

## Not changed (working as designed in the same logs)
`RISK BLOCK [COOLDOWN]` after a realized −221 loss, and `signal_arbitrator_blocked` — both guards behaving correctly.

## Validation (all exit 0)
`compileall src tests` · `tests/data` + `tests/strategies` (642 passed) · `-m live_runtime_e2e tests/e2e/live_sim` (3/3 clean) · **full suite 2100 passed, 2 skipped, 1 deselected, 0 failed**.

Production LOC: **+19 / −0**, one file.