### PR TITLE
fix: never run Telegram dispatch synchronously on the tick/order thread

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -10781,6 +10781,18 @@ async def startup_sequence(ctx: BotContext) -> None:
     ):
         ctx.strategy_runner.attach_runtime_loop(loop)
 
+    # Same authoritative loop for the notifier: send_alert() is reached from
+    # the order/bracket path on the tick thread, and must never run its retry
+    # chain synchronously there.
+    _notifier = getattr(ctx, "telegram_notifier", None) or getattr(
+        ctx, "notifier", None
+    )
+    if _notifier is not None and hasattr(_notifier, "attach_runtime_loop"):
+        try:
+            _notifier.attach_runtime_loop(loop)
+        except Exception:  # noqa: BLE001 - notifications must not break startup
+            pass
+
     _set_startup_phase(ctx, "create_strategy_layer")
     _set_startup_phase(ctx, "wire_message_bus")
     _wire_and_start_message_bus(ctx)

--- a/src/nifty_scalper_bot/notifications/telegram_webhook_enhanced.py
+++ b/src/nifty_scalper_bot/notifications/telegram_webhook_enhanced.py
@@ -158,6 +158,12 @@ class TelegramEnhancedNotifier:
     _telegram_backoff_until: float = field(init=False, repr=False, default=0.0)
     _consecutive_failures: int = field(init=False, repr=False, default=0)
     _last_success_ts: float = field(init=False, repr=False, default=0.0)
+    # Authoritative application loop, latched by attach_runtime_loop(). Alerts
+    # raised from non-loop threads (market-data / order paths) are submitted
+    # here instead of being run synchronously on the calling thread.
+    _runtime_loop: "asyncio.AbstractEventLoop | None" = field(
+        init=False, repr=False, default=None
+    )
     _last_error_type: str | None = field(init=False, repr=False, default=None)
 
     def __post_init__(self) -> None:
@@ -230,6 +236,16 @@ class TelegramEnhancedNotifier:
             )
         return results
 
+    def attach_runtime_loop(self, loop: "asyncio.AbstractEventLoop") -> None:
+        """Latch the authoritative application loop for off-thread alerts.
+
+        Called once by canonical startup while the loop is running. Alerts
+        raised from market-data / order threads are submitted here with
+        run_coroutine_threadsafe instead of blocking the caller.
+        Args: loop. Returns: none. Raises: none.
+        """
+        self._runtime_loop = loop
+
     def send_alert(self, message: str) -> None:
         """Send alert synchronously with proper event loop handling.
 
@@ -276,22 +292,65 @@ class TelegramEnhancedNotifier:
                 )
             return results
 
+        def _report_failure(done: Any) -> None:
+            with suppress(asyncio.CancelledError):
+                exc = done.exception()
+                if exc is not None:
+                    self._logger.error(
+                        "NOTIFICATION_DISPATCH_FAILED",
+                        extra={
+                            "alert_id": alert_id,
+                            "provider": "telegram",
+                            "event_type": "alert",
+                            "error_type": type(exc).__name__,
+                            "error": str(exc),
+                        },
+                    )
+
         try:
-            # Check if we're already in an event loop
+            # NEVER run dispatch synchronously. _dispatch() performs rate-limit
+            # waits, network I/O and a retry chain whose backoff is
+            # min(2**attempt, 30) -- up to ~35s. send_alert() is called from
+            # the order/bracket path, which executes on the market-data tick
+            # thread, so a synchronous asyncio.run() here froze tick ingestion
+            # for the whole retry window (observed: one tick callback blocked
+            # 34.3s, 548 pending ticks, event-loop lag 34s).
             try:
-                loop = asyncio.get_running_loop()
-                # We're in a running loop - schedule as task
+                asyncio.get_running_loop()
+                on_loop = True
+            except RuntimeError:
+                on_loop = False
+
+            if on_loop:
                 task = safe_task(_dispatch())
                 self._logger.info("NOTIFICATION_DISPATCH_QUEUED", extra={"status": "queued", "alert_id": alert_id, "provider": "telegram", "event_type": "alert"})
-                def _on_done(done_task: asyncio.Task[list[NotificationDispatchResult]]) -> None:
-                    with suppress(asyncio.CancelledError):
-                        exc = done_task.exception()
-                        if exc is not None:
-                            self._logger.error("NOTIFICATION_DISPATCH_FAILED", extra={"alert_id": alert_id, "provider": "telegram", "event_type": "alert", "error_type": type(exc).__name__, "error": str(exc)})
-                task.add_done_callback(_on_done)
-            except RuntimeError:
-                # No running loop - create one
-                asyncio.run(_dispatch())
+                task.add_done_callback(_report_failure)
+                return
+
+            runtime_loop = self._runtime_loop
+            if runtime_loop is not None and not runtime_loop.is_closed():
+                try:
+                    future = asyncio.run_coroutine_threadsafe(
+                        _dispatch(), runtime_loop
+                    )
+                except RuntimeError:
+                    runtime_loop = None
+                else:
+                    self._logger.info("NOTIFICATION_DISPATCH_QUEUED", extra={"status": "queued_threadsafe", "alert_id": alert_id, "provider": "telegram", "event_type": "alert"})
+                    future.add_done_callback(_report_failure)
+                    return
+
+            # No usable runtime loop (not yet attached, or shutting down).
+            # Drop the alert rather than block a trading thread.
+            self._logger.warning(
+                "NOTIFICATION_DISPATCH_DROPPED_NO_LOOP",
+                extra={
+                    "event": "NOTIFICATION_DISPATCH_DROPPED_NO_LOOP",
+                    "alert_id": alert_id,
+                    "provider": "telegram",
+                    "event_type": "alert",
+                },
+            )
         except Exception as exc:
             self._logger.error(
                 f"Alert send failed: {exc}",

--- a/tests/notifications/test_telegram_non_blocking_dispatch.py
+++ b/tests/notifications/test_telegram_non_blocking_dispatch.py
@@ -1,0 +1,112 @@
+"""send_alert() must never block a trading thread.
+
+Regression for the 2026-07-27 production incident: send_alert() is reached
+from the order/bracket path, which runs on the market-data tick thread. The
+previous implementation fell back to `asyncio.run(_dispatch())` whenever no
+loop was running on the calling thread, executing the full retry chain
+(backoff min(2**attempt, 30) -> ~35s) synchronously. One tick callback
+blocked for 34.3s with 548 pending ticks and 34s of event-loop lag.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+from types import SimpleNamespace
+
+from nifty_scalper_bot.notifications.telegram_webhook_enhanced import (
+    TelegramEnhancedNotifier,
+)
+
+
+class _SlowNotifier(TelegramEnhancedNotifier):
+    """Real send_alert(); only the network leaf is slowed."""
+
+    dispatch_seconds = 1.0
+
+    async def _send_single(self, chat_id, text, *, alert_id, event_type):
+        await asyncio.sleep(self.dispatch_seconds)
+        return SimpleNamespace(alert_id=alert_id)
+
+    async def _acquire_token(self) -> None:
+        return None
+
+    def _log_provider_health(self) -> None:
+        return None
+
+
+def _notifier(monkeypatch, *, dispatch_seconds: float):
+    """Notifier whose single-send path is deliberately slow."""
+    n = _SlowNotifier.__new__(_SlowNotifier)
+    object.__setattr__(
+        n,
+        "_logger",
+        SimpleNamespace(
+            debug=lambda *a, **k: None,
+            info=lambda *a, **k: None,
+            warning=lambda *a, **k: None,
+            error=lambda *a, **k: None,
+        ),
+    )
+    object.__setattr__(n, "_chat_whitelist", {123})
+    object.__setattr__(n, "_runtime_loop", None)
+    object.__setattr__(n, "_telegram_degraded", False)
+    object.__setattr__(n, "_telegram_degraded_until", 0.0)
+    object.__setattr__(n, "dispatch_seconds", dispatch_seconds)
+    return n
+
+
+def _run_loop_in_thread():
+    loop = asyncio.new_event_loop()
+    t = threading.Thread(target=loop.run_forever, daemon=True)
+    t.start()
+    return loop, t
+
+
+def _stop_loop(loop, thread):
+    loop.call_soon_threadsafe(loop.stop)
+    thread.join(timeout=2.0)
+    loop.close()
+
+
+def test_send_alert_from_worker_thread_does_not_block(monkeypatch) -> None:
+    """With a runtime loop attached, a slow dispatch must not block the caller."""
+    n = _notifier(monkeypatch, dispatch_seconds=1.0)
+    loop, thread = _run_loop_in_thread()
+    n.attach_runtime_loop(loop)
+    try:
+        started = time.perf_counter()
+        n.send_alert("order filled")
+        elapsed = time.perf_counter() - started
+
+        # Caller returns immediately; the 1s dispatch continues on the loop.
+        assert elapsed < 0.2, f"send_alert blocked caller for {elapsed:.3f}s"
+    finally:
+        _stop_loop(loop, thread)
+
+
+def test_send_alert_without_runtime_loop_drops_instead_of_blocking() -> None:
+    """No usable loop -> drop the alert rather than freeze a trading thread."""
+    n = _notifier(None, dispatch_seconds=1.0)
+    n._runtime_loop = None
+
+    started = time.perf_counter()
+    n.send_alert("order filled")
+    elapsed = time.perf_counter() - started
+
+    assert elapsed < 0.2, f"send_alert blocked caller for {elapsed:.3f}s"
+
+
+def test_send_alert_on_loop_thread_still_schedules_task() -> None:
+    """Existing behaviour on the loop thread is preserved (fire-and-forget)."""
+    n = _notifier(None, dispatch_seconds=0.05)
+
+    async def _main():
+        started = time.perf_counter()
+        n.send_alert("order filled")
+        elapsed = time.perf_counter() - started
+        assert elapsed < 0.2
+        await asyncio.sleep(0.1)
+
+    asyncio.run(_main())


### PR DESCRIPTION
**P0 #1 of the 2026-07-27 log review.** Removes a 34-second stall from the market-data path.

## Root cause
`send_alert()` ended with:
```python
try:
    loop = asyncio.get_running_loop()
    task = safe_task(_dispatch())      # non-blocking
except RuntimeError:
    asyncio.run(_dispatch())           # blocks the calling thread
```
`send_alert()` is reached from the order/bracket path, which runs on the **market-data tick thread** (every `TICK_STAGE_SLOW` record shows `event_loop_thread=False`). So `get_running_loop()` raised `RuntimeError` and the fallback ran the whole dispatch synchronously there. `_dispatch()` does token-bucket waits, network I/O and a retry chain with backoff `min(2**attempt, 30.0)` — 2+4+8+16 ≈ **35 s**.

Observed:
```
15:08:58 ORDER_SENT -> NOTIFICATION_DISPATCH_ATTEMPT
15:08:59/09:02/09:07/09:16  telegram_network_retry
15:09:33 telegram_network_error
15:09:33 TICK_STAGE_SLOW ingest_tick_sync duration_ms=34281 pending_ticks=548
15:09:33 EVENT_LOOP_LAG_HIGH lag_ms=33952 tick_pending=553
```
The log shows `NOTIFICATION_DISPATCH_ATTEMPT`, **not** `NOTIFICATION_DISPATCH_QUEUED` — confirming the blocking branch.

**Distinct from PR #927.** That bounds repeated drain *batches*; it cannot interrupt a single `_process_queued_tick` blocked inside notification dispatch. Two different lag classes.

## Fix
- New `attach_runtime_loop(loop)` latches the authoritative application loop, called once from canonical startup (`startup_sequence`) alongside the existing Runner attachment, while the loop is running.
- `send_alert()` now: on-loop → `safe_task` (unchanged); off-thread with a known loop → `asyncio.run_coroutine_threadsafe`; no usable loop → drop with `NOTIFICATION_DISPATCH_DROPPED_NO_LOOP`. Returns immediately in all three cases.
- `asyncio.run()` is gone from this path. **No per-alert thread is created**, so no uncontrolled thread/retry system is introduced.

Notification delivery is best-effort and must never gate market-data or order processing — dropping an alert beats freezing tick ingestion for tens of seconds.

## Tests (+3)
Worker thread with loop attached → caller returns `<0.2s` while a 1 s dispatch continues on the loop; no loop → dropped, still `<0.2s`; on-loop → fire-and-forget preserved.

**Verified against pre-fix code:** the drop test fails with **`send_alert blocked caller for 1.002s`** — the exact defect at 1/35th scale.

## Validation (all exit 0)
`compileall src tests` · `tests/notifications` + `tests/execution` (542 passed) · `-m live_runtime_e2e tests/e2e/live_sim` (0 failures) · **full suite 2103 passed, 2 skipped, 1 deselected**.

Production LOC: **+83 / −12**, 2 files.