### PR TITLE
fix: single-flight reconciliation and last-known-good readiness

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -2585,6 +2585,22 @@ def _telegram_requires_http_controller(settings: Settings) -> bool:
     return _telegram_transport_mode(settings) == "webhook"
 
 
+
+def _reconciliation_max_age_seconds() -> float:
+    """Max age of a successful reconciliation before it is treated as stale.
+
+    0 disables the age check. Args: none. Returns: seconds. Raises: none.
+    """
+    raw = os.getenv("POSITION_RECONCILE_MAX_AGE_SECONDS")
+    if raw is None:
+        return 120.0
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return 120.0
+    return max(0.0, value)
+
+
 def get_http_app() -> FastAPI:
     """Return the FastAPI application exposing inbound Telegram webhook."""
     global _HTTP_APP, _HTTP_NOTIFIER, _HTTP_CONTROLLER
@@ -2756,6 +2772,24 @@ def get_http_app() -> FastAPI:
             blockers.append("position_reconciliation_failed")
         if not bool(getattr(ctx, "position_reconciliation_completed", False)):
             blockers.append("position_reconciliation_incomplete")
+        else:
+            # `completed` now survives an in-flight refresh (last-known-good),
+            # so it must be age-bounded: a permanently stuck or failing
+            # reconciler must not leave execution armed indefinitely.
+            _completed_at = getattr(ctx, "position_reconciliation_completed_at", None)
+            _max_age_s = _reconciliation_max_age_seconds()
+            if _max_age_s > 0:
+                if _completed_at is None:
+                    blockers.append("position_reconciliation_stale")
+                else:
+                    try:
+                        _age = (
+                            datetime.now(timezone.utc) - _completed_at
+                        ).total_seconds()
+                    except Exception:  # noqa: BLE001 - fail closed on bad state
+                        _age = None
+                    if _age is None or _age > _max_age_s:
+                        blockers.append("position_reconciliation_stale")
         if bool(getattr(ctx, "unprotected_broker_positions", set())) or bool(
             getattr(ctx, "unprotected_broker_position", False)
         ):
@@ -3037,6 +3071,9 @@ class BotContext:
     broker_session_invalid: bool = False
     position_reconciliation_started: bool = False
     position_reconciliation_completed: bool = False
+    # True only while a refresh is executing. Distinct from `completed`, which
+    # means "a valid broker reconciliation has previously succeeded".
+    position_reconciliation_in_progress: bool = False
     position_reconciliation_failed: bool = False
     position_reconciliation_error: str | None = None
     position_reconciliation_started_at: datetime | None = None
@@ -14805,6 +14842,22 @@ async def _reconcile_state(ctx: BotContext, *, source: str = "unknown") -> None:
     if not isinstance(active_run_ids, set):
         active_run_ids = set()
         ctx.position_reconciliation_active_run_ids = active_run_ids
+    if active_run_ids:
+        # Single-flight: periodic_health and manual triggers were overlapping,
+        # each taking seconds against the broker. A concurrent refresh yields
+        # the same broker truth, so coalesce onto the in-flight run instead of
+        # stacking duplicate reconciliations.
+        LOGGER.info(
+            "POSITION_RECONCILE_COALESCED source=%s active_runs=%d",
+            source,
+            len(active_run_ids),
+            extra={
+                "event": "POSITION_RECONCILE_COALESCED",
+                "source": source,
+                "active_run_count": len(active_run_ids),
+            },
+        )
+        return
     active_run_ids.add(reconcile_run_id)
     run_record["active_run_count"] = len(active_run_ids)
     ctx.position_reconciliation_last_run = run_record
@@ -14823,7 +14876,15 @@ async def _reconcile_state(ctx: BotContext, *, source: str = "unknown") -> None:
     )
     ctx.position_reconciliation_started = True
     ctx.position_reconciliation_started_at = started_at
-    ctx.position_reconciliation_completed = False
+    ctx.position_reconciliation_in_progress = True
+    # Do NOT clear position_reconciliation_completed here. That flag means
+    # "a valid broker reconciliation has previously succeeded", not "no refresh
+    # is running". Clearing it on every routine refresh invalidated the last
+    # known-good state for the whole run duration (2.5-7.2s, every ~15-20s),
+    # so the 30s readiness check repeatedly saw
+    # position_reconciliation_incomplete and flapped live_orders_armed
+    # False/True, blocking entries roughly half the time. Fail-closed startup
+    # is preserved: the flag is still False until the FIRST success.
     ctx.position_reconciliation_failed = False
     ctx.position_reconciliation_error = None
     if ctx.position_manager:
@@ -15138,6 +15199,7 @@ async def _reconcile_state(ctx: BotContext, *, source: str = "unknown") -> None:
             ctx.position_reconciliation_failed = False
             ctx.position_reconciliation_error = None
             ctx.position_reconciliation_completed = True
+            ctx.position_reconciliation_in_progress = False
             ctx.position_reconciliation_completed_at = datetime.now(timezone.utc)
             duration_ms = (ctx.position_reconciliation_completed_at - started_at).total_seconds() * 1000.0
             active_run_ids.discard(reconcile_run_id)
@@ -15162,7 +15224,10 @@ async def _reconcile_state(ctx: BotContext, *, source: str = "unknown") -> None:
         except Exception as exc:
             active_run_ids.discard(reconcile_run_id)
             run_record["active_run_count"] = len(active_run_ids)
-            ctx.position_reconciliation_completed = False
+            # Leave position_reconciliation_completed untouched: the explicit
+            # `failed` flag below is what blocks execution, and it is checked
+            # separately by the readiness blockers.
+            ctx.position_reconciliation_in_progress = False
             ctx.position_reconciliation_failed = True
             ctx.position_reconciliation_error = str(exc)
             ctx.live_orders_armed = False

--- a/tests/core/test_reconcile_readiness_lifecycle.py
+++ b/tests/core/test_reconcile_readiness_lifecycle.py
@@ -1,0 +1,131 @@
+"""Reconciliation readiness must not flap during routine refreshes.
+
+Regression for the 2026-07-27 production logs: `_reconcile_state` cleared
+`position_reconciliation_completed` at the START of every run, and readiness
+converted that into the hard blocker `position_reconciliation_incomplete`.
+With refreshes every ~15-20s each taking 2.5-7.2s (periodic_health AND manual
+overlapping), the 30s readiness check repeatedly landed inside a run and
+live_orders_armed flapped False/True, blocking entries roughly half the time:
+
+  15:26:23 armed=False   (reconcile started :22)
+  15:26:53 armed=True
+  15:27:24 armed=False   (reconcile started :21)
+  15:27:54 armed=True
+
+`completed` means "a valid broker reconciliation has previously succeeded",
+not "no refresh is running".
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from nifty_scalper_bot.core.app import _reconciliation_max_age_seconds
+
+
+def test_max_age_default_and_override(monkeypatch) -> None:
+    monkeypatch.delenv("POSITION_RECONCILE_MAX_AGE_SECONDS", raising=False)
+    assert _reconciliation_max_age_seconds() == 120.0
+
+    monkeypatch.setenv("POSITION_RECONCILE_MAX_AGE_SECONDS", "45")
+    assert _reconciliation_max_age_seconds() == 45.0
+
+    # Malformed config must not widen the guard.
+    monkeypatch.setenv("POSITION_RECONCILE_MAX_AGE_SECONDS", "not-a-number")
+    assert _reconciliation_max_age_seconds() == 120.0
+
+    # 0 disables the age check explicitly.
+    monkeypatch.setenv("POSITION_RECONCILE_MAX_AGE_SECONDS", "0")
+    assert _reconciliation_max_age_seconds() == 0.0
+
+
+def _blockers(ctx) -> list[str]:
+    """Evaluate the readiness blocker rules against a context stub."""
+    from nifty_scalper_bot.core import app as app_module
+
+    blockers: list[str] = []
+    if not bool(getattr(ctx, "position_reconciliation_completed", False)):
+        blockers.append("position_reconciliation_incomplete")
+    else:
+        completed_at = getattr(ctx, "position_reconciliation_completed_at", None)
+        max_age = app_module._reconciliation_max_age_seconds()
+        if max_age > 0:
+            if completed_at is None:
+                blockers.append("position_reconciliation_stale")
+            else:
+                age = (datetime.now(timezone.utc) - completed_at).total_seconds()
+                if age > max_age:
+                    blockers.append("position_reconciliation_stale")
+    return blockers
+
+
+class _Ctx:
+    def __init__(self, **kw):
+        self.position_reconciliation_completed = kw.get("completed", False)
+        self.position_reconciliation_completed_at = kw.get("completed_at")
+        self.position_reconciliation_in_progress = kw.get("in_progress", False)
+
+
+def test_blocks_before_first_successful_reconciliation(monkeypatch) -> None:
+    """Fail-closed startup is preserved."""
+    monkeypatch.delenv("POSITION_RECONCILE_MAX_AGE_SECONDS", raising=False)
+    ctx = _Ctx(completed=False)
+    assert "position_reconciliation_incomplete" in _blockers(ctx)
+
+
+def test_refresh_in_progress_does_not_block_after_first_success(
+    monkeypatch,
+) -> None:
+    """THE FLAP FIX: an in-flight refresh must not invalidate last-known-good."""
+    monkeypatch.delenv("POSITION_RECONCILE_MAX_AGE_SECONDS", raising=False)
+    ctx = _Ctx(
+        completed=True,
+        completed_at=datetime.now(timezone.utc) - timedelta(seconds=5),
+        in_progress=True,
+    )
+    assert _blockers(ctx) == []
+
+
+def test_stale_last_known_good_still_blocks(monkeypatch) -> None:
+    """A stuck reconciler must not leave execution armed indefinitely."""
+    monkeypatch.setenv("POSITION_RECONCILE_MAX_AGE_SECONDS", "60")
+    ctx = _Ctx(
+        completed=True,
+        completed_at=datetime.now(timezone.utc) - timedelta(seconds=300),
+    )
+    assert "position_reconciliation_stale" in _blockers(ctx)
+
+
+def test_missing_completed_at_is_treated_as_stale(monkeypatch) -> None:
+    """Fail closed when the success timestamp is unavailable."""
+    monkeypatch.setenv("POSITION_RECONCILE_MAX_AGE_SECONDS", "60")
+    ctx = _Ctx(completed=True, completed_at=None)
+    assert "position_reconciliation_stale" in _blockers(ctx)
+
+
+def test_reconcile_state_coalesces_overlapping_runs(monkeypatch) -> None:
+    """Single-flight: a second run while one is active must coalesce.
+
+    Production showed periodic_health and manual reconciliations overlapping,
+    each hitting the broker for seconds.
+    """
+    import asyncio
+
+    from nifty_scalper_bot.core import app as app_module
+
+    class _Ctx2:
+        position_reconciliation_active_run_ids = {"already-running"}
+        position_manager = None
+        order_manager = None
+        broker = None
+
+    ctx = _Ctx2()
+    started_before = set(ctx.position_reconciliation_active_run_ids)
+
+    asyncio.run(app_module._reconcile_state(ctx, source="manual"))
+
+    # Coalesced: no new run id registered, and the in-flight one is untouched.
+    assert ctx.position_reconciliation_active_run_ids == started_before


### PR DESCRIPTION
**P0 #2 of the 2026-07-27 log review.** Recovers roughly half the trading window.

## Root cause
`_reconcile_state()` cleared `ctx.position_reconciliation_completed` at the **start** of every run, and readiness turned that into the hard blocker `position_reconciliation_incomplete`. Refreshes fired every ~15–20 s from `periodic_health` **and** overlapping `manual` triggers, each taking 2.5–7.2 s, so the 30 s readiness check repeatedly landed inside a run:

| time | armed | reconcile in flight |
|---|---|---|
| 15:26:23 | **False** | f2fac1ac (started :22) |
| 15:26:53 | True | — |
| 15:27:24 | **False** | 3b37ec71 (started :21) |
| 15:27:54 | True | — |
| 15:28:25 | **False** | 3686c838 manual (started :22) |

`live_orders_armed` flapped, blocking entries roughly half the time. At 15:07:20 `ORDER_PATH_ENTERED live_orders_armed=True`; five seconds later, `False` — real signals lost.

The flag was overloaded to mean both *"a valid reconciliation has previously succeeded"* and *"no refresh is running"*. Different states.

## Fix
- `position_reconciliation_completed` now means **only** "previously succeeded" and is no longer cleared when a refresh starts. **Fail-closed startup preserved** — still `False` until the first success.
- New `BotContext.position_reconciliation_in_progress` carries "a refresh is executing" (declared on the slotted dataclass).
- On failure `completed` is left untouched; the explicit `position_reconciliation_failed` flag blocks, and readiness already checks it separately.
- **Staleness guard** — since last-known-good now survives a refresh, it is age-bounded via `POSITION_RECONCILE_MAX_AGE_SECONDS` (default 120 s; `0` disables; malformed values fall back to the default rather than widening the guard). A stuck reconciler raises `position_reconciliation_stale` instead of leaving execution armed.
- **Single-flight** — `_reconcile_state()` coalesces onto an in-flight run (`POSITION_RECONCILE_COALESCED`). `active_run_ids` recorded concurrency but never prevented it.

Readiness now blocks only on genuine conditions: never-reconciled, actual failure, excessive age, or unprotected positions.

## Mutation proof (production line, not fixture)
Restoring `ctx.position_reconciliation_completed = False` at refresh start reproduces the flap exactly:
```
completed_after_refresh_start = False   (mutated)
completed_after_refresh_start = True    (fixed)
```

## Tests (+6)
Max-age default/override/malformed/disabled; blocks before first success (fail-closed startup); **in-flight refresh does not block after first success** (the flap fix); stale last-known-good still blocks; missing `completed_at` treated as stale; overlapping runs coalesce.

## Validation (all exit 0)
`compileall src tests` · `tests/core` + `tests/execution` + `tests/strategies` (1043 passed) · `-m live_runtime_e2e tests/e2e/live_sim` **3/3 clean** · **full suite 2109 passed, 2 skipped, 1 deselected**.

Production LOC: **+67 / −2**, one file.