### PR TITLE
fix: derive ATM strike distance instead of the 999 sentinel

### DIFF
--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -124,7 +124,11 @@ from nifty_scalper_bot.execution.order_state_machine import (
 from nifty_scalper_bot.config.env_utils import resolve_build_sha as _resolve_build_sha
 from nifty_scalper_bot.execution.bracket_manager import tick_exchange_epoch
 from nifty_scalper_bot.execution.position_manager import OrderSide, PositionManager
-from nifty_scalper_bot.options.strike_selector import SelectedContract, StrikeSelector
+from nifty_scalper_bot.options.strike_selector import (
+    SelectedContract,
+    StrikeSelector,
+    _parse_strike_from_symbol,
+)
 from nifty_scalper_bot.risk import RiskManager
 from nifty_scalper_bot.risk.expiry_gate import expiry_theta_block, midday_pause_block
 from nifty_scalper_bot.risk.position_sizing import (
@@ -194,6 +198,43 @@ _IST = ZoneInfo("Asia/Kolkata")
 
 _TRUE_VALUES = {"1", "true", "yes", "y", "on", "enable", "enabled"}
 _FALSE_VALUES = {"0", "false", "no", "n", "off", "disable", "disabled"}
+
+
+def _derive_strike_distance_from_atm(
+    symbol: str,
+    snapshot: Mapping[str, Any] | None,
+    metadata: Mapping[str, Any] | None,
+) -> float | None:
+    """Distance in points between a candidate's strike and the ATM strike.
+
+    Used only when the snapshot carries no explicit distance. Returns None when
+    either strike is unresolvable, so the caller keeps its explicit "unknown"
+    marker instead of inventing a value.
+    Args: symbol, snapshot, metadata. Returns: points or None. Raises: none.
+    """
+    def _num(*values: Any) -> float | None:
+        for value in values:
+            if value in (None, ""):
+                continue
+            try:
+                parsed = float(value)
+            except (TypeError, ValueError):
+                continue
+            if parsed > 0:
+                return parsed
+        return None
+
+    snap = snapshot or {}
+    meta = metadata or {}
+    atm = _num(snap.get("atm_strike"), meta.get("atm_strike"))
+    if atm is None:
+        return None
+    strike = _num(snap.get("strike"), meta.get("strike"))
+    if strike is None:
+        strike = _parse_strike_from_symbol(str(symbol or ""))
+    if strike is None or strike <= 0:
+        return None
+    return abs(strike - atm)
 
 
 class EntryEvaluationRoute(str, Enum):
@@ -17174,6 +17215,16 @@ class StrategyRunner:
             distance_raw = selected_snapshot.get("strike_distance_from_atm")
         if distance_raw is None:
             distance_raw = metadata.get("strike_distance_from_atm")
+        if distance_raw is None:
+            # Derive from strikes rather than falling back to the 999 sentinel:
+            # the snapshot rarely carries an explicit distance, so every
+            # candidate reported distance_from_atm=999.0 in production. Only a
+            # genuinely ATM strike may become 0.
+            distance_raw = _derive_strike_distance_from_atm(
+                selected_symbol, selected_snapshot, metadata
+            )
+        # 999.0 remains the last-resort "unknown" marker when neither an
+        # explicit distance nor both strikes are resolvable.
         distance_atm = abs(float(distance_raw)) if distance_raw is not None else 999.0
         rank_score = (
             score * 10.0

--- a/tests/strategies/test_atm_distance_derivation.py
+++ b/tests/strategies/test_atm_distance_derivation.py
@@ -1,0 +1,68 @@
+"""ATM-distance derivation instead of the blanket 999 sentinel.
+
+Production logs showed `distance_from_atm: 999.0` on every candidate,
+including exact-ATM selections, because the snapshot rarely carries an
+explicit distance and the code fell straight through to the sentinel.
+
+MEASURED SEVERITY (before changing anything): rank_score is NOT the selection
+mechanism -- `selected_symbol` arrives as a parameter, already chosen
+upstream. rank_score feeds exactly one decision, the signal-attempt debounce,
+which compares CURRENT against PREVIOUS rank_score. A uniform sentinel applies
+the same `min(999/100, 10) * 0.5 ~= 5.0` penalty to both sides and cancels in
+the difference. So this was a diagnostics/latent-trap defect, not corrupted
+candidate selection.
+"""
+
+from __future__ import annotations
+
+from nifty_scalper_bot.strategies.runner import _derive_strike_distance_from_atm
+
+
+def test_exact_atm_strike_is_zero_distance() -> None:
+    assert _derive_strike_distance_from_atm(
+        "NFO:NIFTY26JUL24000CE", {"atm_strike": 24000}, {}
+    ) == 0.0
+
+
+def test_off_atm_strike_distance_from_symbol() -> None:
+    assert _derive_strike_distance_from_atm(
+        "NFO:NIFTY26JUL23950CE", {"atm_strike": 24000}, {}
+    ) == 50.0
+    assert _derive_strike_distance_from_atm(
+        "NFO:NIFTY26JUL24050PE", {"atm_strike": 24000}, {}
+    ) == 50.0
+
+
+def test_explicit_strike_on_snapshot_wins_over_symbol_parse() -> None:
+    assert _derive_strike_distance_from_atm(
+        "NFO:NIFTY26JUL23950CE", {"atm_strike": 24000, "strike": 23900}, {}
+    ) == 100.0
+
+
+def test_atm_strike_may_come_from_metadata() -> None:
+    assert _derive_strike_distance_from_atm(
+        "NFO:NIFTY26JUL23900CE", {}, {"atm_strike": 24000}
+    ) == 100.0
+
+
+def test_returns_none_when_atm_unresolvable() -> None:
+    """Caller must keep its explicit unknown marker, not invent a distance."""
+    assert _derive_strike_distance_from_atm(
+        "NFO:NIFTY26JUL23950CE", {}, {}
+    ) is None
+
+
+def test_returns_none_when_strike_unparseable() -> None:
+    assert _derive_strike_distance_from_atm(
+        "NOT-AN-OPTION", {"atm_strike": 24000}, {}
+    ) is None
+
+
+def test_malformed_values_do_not_raise() -> None:
+    assert _derive_strike_distance_from_atm(
+        "NFO:NIFTY26JUL23950CE", {"atm_strike": "abc"}, {}
+    ) is None
+    assert _derive_strike_distance_from_atm(
+        "NFO:NIFTY26JUL23950CE", {"atm_strike": 0}, {}
+    ) is None
+    assert _derive_strike_distance_from_atm("NFO:NIFTY26JUL23950CE", None, None) is None


### PR DESCRIPTION
**#3 of the log review.** Includes the measurement you asked for before modification — which **downgraded** this from P1 to P3.

## Measured severity first
An earlier review (mine) claimed the 999 sentinel corrupted candidate ranking. **That was wrong:**

- `rank_score` is **not** the selection mechanism. `selected_symbol` arrives at `_apply_directional_signal_dedup()` as a parameter, already chosen upstream; this block computes `rank_score` as after-the-fact telemetry.
- `rank_score` feeds exactly **one** decision — the signal-attempt debounce, comparing **current vs previous** rank_score for the same underlying+side.
- The sentinel contributes `min(999/100, 10) x 0.5 ~= 5.0` **uniformly**, so it appears on both sides of that subtraction and **cancels**.

So: a diagnostics defect plus a latent trap (any future use of absolute `rank_score` would inherit a silent ~5-point penalty), not corrupted selection.

## Fix
New `_derive_strike_distance_from_atm(symbol, snapshot, metadata)`, consulted **only after** the existing explicit-distance lookups fail. Resolves ATM strike from snapshot/metadata and candidate strike from snapshot/metadata, falling back to the canonical `_parse_strike_from_symbol()` already used by the strike selector, returning `abs(strike - atm)`.

Returns `None` when either strike is unresolvable, so the caller keeps `999.0` as an explicit **unknown** marker rather than inventing a value. Only a genuinely ATM strike becomes `0.0`. No ranking, selection, debounce or scoring formula otherwise changed.

## Tests (+7)
Exact ATM → `0.0`; ±50 derived from symbol; explicit snapshot strike wins over parsing; `atm_strike` from metadata; `None` when ATM unresolvable; `None` when symbol unparseable; malformed/zero/None inputs don't raise.

## Validation (all exit 0)
`compileall src tests` · `tests/strategies` + `tests/execution` (776 passed) · `-m live_runtime_e2e` **3/3 clean** · **full suite 2116 passed**.

Production LOC: **+38 / −1**, one file.