### PR TITLE
Fix entry state reconciliation

### DIFF
--- a/ARCHITECTURE_TRADING_PATH.md
+++ b/ARCHITECTURE_TRADING_PATH.md
@@ -35,6 +35,7 @@
    - Responsibilities:
      - preflight, spread, margin and risk validation;
      - broker submission and acknowledgement reconciliation;
+     - terminal failed-entry propagation to runner and arbitrator guards;
      - bounded broker-rejection recovery;
      - partial-entry remainder cancellation;
      - actual fill quantity/VWAP hand-off to the bracket authority;
@@ -84,6 +85,9 @@ TradePlan
 ```
 
 At every ambiguous broker state, new entries remain blocked until orders, fills and positions are reconciled.
+Rejected, cancelled or expired entries re-arm only after broker-confirmed absence of
+exposure. Broker-confirmed flat positions re-arm the runner while preserving the
+configured post-exit cooldown.
 
 ## Compatibility-only modules
 

--- a/src/nifty_scalper_bot/core/signal_arbitrator.py
+++ b/src/nifty_scalper_bot/core/signal_arbitrator.py
@@ -82,7 +82,6 @@ class SignalArbitrator:
             if key in self._active_symbols:
                 if prev is not None and now - prev.last_ts >= self._stale_active_seconds:
                     self._active_symbols.discard(key)
-                    prev.last_ts = now
                 else:
                     return False
             if prev is None:
@@ -111,6 +110,15 @@ class SignalArbitrator:
             state = self._state.get(key)
             if state is not None:
                 state.last_ts = time.time()
+
+    def clear(self, symbol: str) -> None:
+        """Drop a reservation for an entry that never created exposure."""
+        key = self._reservation_key(symbol)
+        if not key:
+            return
+        with self._lock:
+            self._active_symbols.discard(key)
+            self._state.pop(key, None)
 
     def decide(self, *, underlying: str, votes: list[StrategyVote], option_candidates: list[dict[str, Any]], market_context: dict[str, Any], trace_id: str) -> TradeDecision:
         mode = str(market_context.get("quality_mode") or "normal").lower()

--- a/src/nifty_scalper_bot/execution/order_manager_core.py
+++ b/src/nifty_scalper_bot/execution/order_manager_core.py
@@ -7217,26 +7217,7 @@ class OrderManager:
                 self._confirm_position_protection_for_fill(order)
                 order.applied_filled_quantity = broker_filled_quantity
 
-            is_failed_entry_terminal = (
-                status_raw in {"REJECTED", "CANCELLED", "CANCELED", "FAILED", "EXPIRED"}
-                and old_status != new_status
-                and str(getattr(order, "intent", "") or "").upper()
-                in {"ENTRY", "UNKNOWN", ""}
-            )
-            if is_failed_entry_terminal and callable(self.entry_order_failed_callback):
-                try:
-                    self.entry_order_failed_callback(
-                        order_id=str(order_id),
-                        symbol=str(order.symbol),
-                        reason=status_raw.lower(),
-                    )
-                except Exception:
-                    self._logger.exception(
-                        "ENTRY_ORDER_FAILED_CALLBACK_ERROR order_id=%s symbol=%s status=%s",
-                        order_id,
-                        order.symbol,
-                        status_raw,
-                    )
+            self._notify_failed_entry_terminal(order, old_status, status_raw)
 
             # ── FIX (BUG 3): CANCELLED exit orders — reactivate bracket.
             # _check_zombie_orders cancels stuck PENDING orders after 45s via
@@ -7665,6 +7646,48 @@ class OrderManager:
 
         self._signal_arbitrator.release(symbol)
         return exit_id
+
+    def release_entry_reservation(
+        self, symbol: str, *, start_cooldown: bool = True
+    ) -> None:
+        """Converge the entry arbitrator after broker-confirmed terminal state."""
+        if start_cooldown:
+            self._signal_arbitrator.release(symbol)
+        else:
+            self._signal_arbitrator.clear(symbol)
+
+    def _notify_failed_entry_terminal(
+        self,
+        order: OrderDetails,
+        old_status: OrderStatus,
+        raw_status: str,
+    ) -> None:
+        """Converge entry guards once any broker ingress proves terminal failure."""
+        failed = {
+            OrderStatus.CANCELLED,
+            OrderStatus.REJECTED,
+            OrderStatus.EXPIRED,
+        }
+        if (
+            order.status not in failed
+            or old_status == order.status
+            or str(order.intent or "").upper() not in {"ENTRY", "UNKNOWN", ""}
+            or not callable(self.entry_order_failed_callback)
+        ):
+            return
+        try:
+            self.entry_order_failed_callback(
+                order_id=str(order.order_id),
+                symbol=str(order.symbol),
+                reason=str(raw_status or order.status.name).lower(),
+            )
+        except Exception:
+            self._logger.exception(
+                "ENTRY_ORDER_FAILED_CALLBACK_ERROR order_id=%s symbol=%s status=%s",
+                order.order_id,
+                order.symbol,
+                raw_status,
+            )
 
     def modify_order(
         self,
@@ -11874,6 +11897,9 @@ class OrderManager:
             and previous_status != OrderStatus.REJECTED
         ):
             self._handle_order_rejected(order)
+        self._notify_failed_entry_terminal(
+            order, previous_status, str(payload.get("status") or "")
+        )
         self._handle_bracket_update(order, previous_status, payload)
         self._handle_guard_order_update(order, previous_status)
         return order
@@ -12949,6 +12975,9 @@ class OrderManager:
                         and old_status != OrderStatus.REJECTED
                     ):
                         self._handle_order_rejected(local_order)
+                    self._notify_failed_entry_terminal(
+                        local_order, old_status, raw_status
+                    )
 
         except Exception as e:
             self._logger.error(f"Reconcile failed: {e}", exc_info=True)

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -848,23 +848,10 @@ class StrategyRunner:
         # When broker sync prunes externally-closed positions (manual square-off /
         # auto-square-off), drop their brackets so they are not re-adopted forever.
         try:
-            if (
-                self._position_manager is not None
-                and self._bracket_manager is not None
-                and hasattr(self._position_manager, "set_on_symbols_flat")
+            if self._position_manager is not None and hasattr(
+                self._position_manager, "set_on_symbols_flat"
             ):
-
-                def _on_symbols_flat(symbols: list[str]) -> None:
-                    bm = self._bracket_manager
-                    if bm is None:
-                        return
-                    for _sym in symbols or []:
-                        try:
-                            bm.reconcile_symbol_flat(_sym)
-                        except Exception:  # noqa: BLE001
-                            continue
-
-                self._position_manager.set_on_symbols_flat(_on_symbols_flat)
+                self._position_manager.set_on_symbols_flat(self._on_symbols_flat)
         except Exception:  # noqa: BLE001
             pass
         self._symbol_source: MarketDataManager | None = None
@@ -7451,6 +7438,52 @@ class StrategyRunner:
         """Reset execution state to IDLE. Args: symbol. Returns: none. Raises: none."""
         machine = self._get_execution_state_machine(symbol)
         machine.force_idle()
+
+    def _release_entry_guards(
+        self, symbol: str, *, start_cooldown: bool, reason: str
+    ) -> None:
+        """Converge runner and order-manager guards from canonical lifecycle state."""
+        self._reset_execution_state(symbol)
+        releaser = getattr(self._order_manager, "release_entry_reservation", None)
+        if callable(releaser):
+            releaser(symbol, start_cooldown=start_cooldown)
+        self._logger.info(
+            "ENTRY_GUARDS_RELEASED symbol=%s reason=%s start_cooldown=%s",
+            symbol,
+            reason,
+            start_cooldown,
+            extra={
+                "event": "ENTRY_GUARDS_RELEASED",
+                "symbol": symbol,
+                "reason": reason,
+                "start_cooldown": start_cooldown,
+            },
+        )
+
+    def _on_symbols_flat(self, symbols: list[str]) -> None:
+        """Apply broker-confirmed flat state to brackets and entry guards."""
+        for symbol in symbols or []:
+            if self._bracket_manager is not None:
+                try:
+                    self._bracket_manager.reconcile_symbol_flat(symbol)
+                except Exception as exc:  # noqa: BLE001
+                    self._logger.warning(
+                        "FLAT_SYMBOL_BRACKET_RECONCILE_FAILED symbol=%s error=%s",
+                        symbol,
+                        exc,
+                    )
+            try:
+                self._release_entry_guards(
+                    symbol,
+                    start_cooldown=True,
+                    reason="broker_position_flat",
+                )
+            except Exception as exc:  # noqa: BLE001 - keep other symbols converging
+                self._logger.warning(
+                    "FLAT_SYMBOL_GUARD_RECONCILE_FAILED symbol=%s error=%s",
+                    symbol,
+                    exc,
+                )
 
     # Cooldown logic moved to ExecutionEngine
 
@@ -20001,8 +20034,15 @@ class StrategyRunner:
             try:
                 has_position = bool(self._position_manager.has_open_position(symbol))
             except Exception:
-                has_position = False
+                has_position = True
         if not has_position:
+            resolved_symbol = str(symbol or context.get("symbol") or "")
+            if resolved_symbol:
+                self._release_entry_guards(
+                    resolved_symbol,
+                    start_cooldown=False,
+                    reason=f"entry_order_{reason}",
+                )
             orchestrator = getattr(self, "_orchestrator", None)
             if orchestrator is not None and hasattr(
                 orchestrator, "clear_direction_lock"

--- a/tests/core/test_signal_arbitrator_decision.py
+++ b/tests/core/test_signal_arbitrator_decision.py
@@ -70,7 +70,7 @@ def test_nifty_ce_and_pe_share_one_entry_reservation(monkeypatch):
     assert arb.allow(pe, 'BUY') is True
 
 
-def test_stale_active_reservation_fails_closed_for_reentry_window(monkeypatch):
+def test_stale_active_reservation_does_not_restart_reentry_window(monkeypatch):
     now = [3000.0]
     monkeypatch.setattr(arbitrator_module.time, 'time', lambda: now[0])
     arb = SignalArbitrator(
@@ -82,5 +82,18 @@ def test_stale_active_reservation_fails_closed_for_reentry_window(monkeypatch):
     arb.register(symbol, 'BUY')
     now[0] += 121.0
     assert arb.allow(symbol, 'BUY') is False
-    now[0] += 300.0
+    now[0] += 178.0
+    assert arb.allow(symbol, 'BUY') is False
+    now[0] += 1.0
+    assert arb.allow(symbol, 'BUY') is True
+
+
+def test_clear_removes_failed_entry_without_reentry_cooldown(monkeypatch):
+    monkeypatch.setattr(arbitrator_module.time, 'time', lambda: 4000.0)
+    arb = SignalArbitrator(reentry_cooldown_seconds=300.0)
+    symbol = 'NFO:NIFTY26JUL23950CE'
+
+    arb.register(symbol, 'BUY')
+    arb.clear(symbol)
+
     assert arb.allow(symbol, 'BUY') is True

--- a/tests/execution/test_canonical_entry_recovery.py
+++ b/tests/execution/test_canonical_entry_recovery.py
@@ -18,6 +18,10 @@ from nifty_scalper_bot.execution.entry_recovery import (
     quantity_to_exact_lots,
 )
 from nifty_scalper_bot.execution.order_manager import TradePlan, TradePlanSubmitResult
+from nifty_scalper_bot.execution.order_manager_core import (
+    OrderManager,
+    OrderStatus,
+)
 
 
 class _Logger:
@@ -501,3 +505,31 @@ def test_core_submit_explicit_rejection_does_not_second_post(tmp_path):
         )
 
     assert broker.calls == 1
+
+
+def test_failed_entry_terminal_callback_is_transition_scoped() -> None:
+    callbacks = []
+    manager = object.__new__(OrderManager)
+    manager.entry_order_failed_callback = lambda **payload: callbacks.append(payload)
+    manager._logger = _Logger()
+    order = SimpleNamespace(
+        order_id="OID-1",
+        symbol="NFO:NIFTY2671423950CE",
+        intent="ENTRY",
+        status=OrderStatus.REJECTED,
+    )
+
+    manager._notify_failed_entry_terminal(
+        order, OrderStatus.SUBMITTED, "REJECTED"
+    )
+    manager._notify_failed_entry_terminal(
+        order, OrderStatus.REJECTED, "REJECTED"
+    )
+
+    assert callbacks == [
+        {
+            "order_id": "OID-1",
+            "symbol": "NFO:NIFTY2671423950CE",
+            "reason": "rejected",
+        }
+    ]

--- a/tests/strategies/test_runner_live_suppression_regressions.py
+++ b/tests/strategies/test_runner_live_suppression_regressions.py
@@ -1,8 +1,56 @@
 from __future__ import annotations
 
+import threading
 from pathlib import Path
 
+from nifty_scalper_bot.execution.order_state_machine import (
+    ExecutionState,
+    OrderStateMachine,
+)
 from nifty_scalper_bot.strategies.runner import StrategyRunner
+
+
+def _pending_runner(
+    *, has_position: bool
+) -> tuple[StrategyRunner, OrderStateMachine, list]:
+    symbol = "NFO:NIFTY2670724100PE"
+    releases = []
+    runner = object.__new__(StrategyRunner)
+    runner._submitted_entry_order_context = {
+        "OID1": {
+            "symbol": symbol,
+            "underlying": "NIFTY",
+            "underlying_reason_key": "NIFTY:PE:OrderFlow",
+        }
+    }
+    runner._underlying_last_signal_ts = {"NIFTY": 1000.0}
+    runner._reason_last_signal_ts = {"NIFTY:PE:OrderFlow": 1000.0}
+    runner._position_manager = type(
+        "PM", (), {"has_open_position": lambda self, _symbol: has_position}
+    )()
+    runner._order_manager = type(
+        "OM",
+        (),
+        {
+            "release_entry_reservation": (
+                lambda self, released_symbol, *, start_cooldown: releases.append(
+                    (released_symbol, start_cooldown)
+                )
+            )
+        },
+    )()
+    runner._execution_state_lock = threading.RLock()
+    machine = OrderStateMachine()
+    machine.transition(ExecutionState.SIGNAL_RECEIVED)
+    machine.transition(ExecutionState.ORDER_PENDING, order_id="OID1")
+    runner._execution_state_by_symbol = {symbol: machine}
+    runner._orchestrator = None
+    runner._logger = type(
+        "Log",
+        (),
+        {"info": lambda *a, **k: None, "warning": lambda *a, **k: None},
+    )()
+    return runner, machine, releases
 
 
 def test_option_reason_cooldown_key_is_side_aware() -> None:
@@ -55,45 +103,72 @@ def test_live_scalping_cooldown_defaults_match_operator_comments(monkeypatch) ->
 
 
 def test_failed_entry_order_clears_submission_cooldowns_without_position() -> None:
-    runner = object.__new__(StrategyRunner)
-    runner._submitted_entry_order_context = {
-        "OID1": {
-            "symbol": "NFO:NIFTY2670724100PE",
-            "underlying": "NIFTY",
-            "underlying_reason_key": "NIFTY:PE:OrderFlow",
-        }
-    }
-    runner._underlying_last_signal_ts = {"NIFTY": 1000.0}
-    runner._reason_last_signal_ts = {"NIFTY:PE:OrderFlow": 1000.0}
-    runner._position_manager = type("PM", (), {"has_open_position": lambda self, symbol: False})()
-    runner._orchestrator = None
-    runner._logger = type("Log", (), {"info": lambda *a, **k: None})()
+    runner, machine, releases = _pending_runner(has_position=False)
 
-    runner.notify_entry_order_failed(order_id="OID1", symbol="NFO:NIFTY2670724100PE", reason="rejected")
+    runner.notify_entry_order_failed(
+        order_id="OID1",
+        symbol="NFO:NIFTY2670724100PE",
+        reason="rejected",
+    )
 
     assert runner._underlying_last_signal_ts == {}
     assert runner._reason_last_signal_ts == {}
+    assert machine.state == ExecutionState.IDLE
+    assert releases == [("NFO:NIFTY2670724100PE", False)]
 
 
 def test_failed_entry_order_keeps_cooldowns_when_position_exists() -> None:
-    runner = object.__new__(StrategyRunner)
-    runner._submitted_entry_order_context = {
-        "OID1": {
-            "symbol": "NFO:NIFTY2670724100PE",
-            "underlying": "NIFTY",
-            "underlying_reason_key": "NIFTY:PE:OrderFlow",
-        }
-    }
-    runner._underlying_last_signal_ts = {"NIFTY": 1000.0}
-    runner._reason_last_signal_ts = {"NIFTY:PE:OrderFlow": 1000.0}
-    runner._position_manager = type("PM", (), {"has_open_position": lambda self, symbol: True})()
-    runner._orchestrator = None
-    runner._logger = type("Log", (), {"info": lambda *a, **k: None})()
+    runner, machine, releases = _pending_runner(has_position=True)
 
-    runner.notify_entry_order_failed(order_id="OID1", symbol="NFO:NIFTY2670724100PE", reason="rejected")
+    runner.notify_entry_order_failed(
+        order_id="OID1",
+        symbol="NFO:NIFTY2670724100PE",
+        reason="rejected",
+    )
 
     assert runner._underlying_last_signal_ts == {"NIFTY": 1000.0}
     assert runner._reason_last_signal_ts == {"NIFTY:PE:OrderFlow": 1000.0}
+    assert machine.state == ExecutionState.ORDER_PENDING
+    assert releases == []
+
+
+def test_failed_entry_order_keeps_guards_when_position_state_is_unknown() -> None:
+    runner, machine, releases = _pending_runner(has_position=False)
+    runner._position_manager = type(
+        "PM",
+        (),
+        {
+            "has_open_position": lambda self, _symbol: (_ for _ in ()).throw(
+                RuntimeError("position sync unavailable")
+            )
+        },
+    )()
+
+    runner.notify_entry_order_failed(
+        order_id="OID1",
+        symbol="NFO:NIFTY2670724100PE",
+        reason="rejected",
+    )
+
+    assert runner._underlying_last_signal_ts == {"NIFTY": 1000.0}
+    assert machine.state == ExecutionState.ORDER_PENDING
+    assert releases == []
+
+
+def test_confirmed_flat_symbol_converges_bracket_and_entry_guards() -> None:
+    runner, machine, releases = _pending_runner(has_position=False)
+    reconciled = []
+    runner._bracket_manager = type(
+        "BM",
+        (),
+        {"reconcile_symbol_flat": lambda self, symbol: reconciled.append(symbol)},
+    )()
+
+    runner._on_symbols_flat(["NFO:NIFTY2670724100PE"])
+
+    assert reconciled == ["NFO:NIFTY2670724100PE"]
+    assert machine.state == ExecutionState.IDLE
+    assert releases == [("NFO:NIFTY2670724100PE", True)]
 
 
 def test_order_failure_cooldown_rejection_uses_dedup_rollback_path() -> None:


### PR DESCRIPTION
## What changed
- converge runner `ORDER_PENDING` and order-manager arbitration state on rejected, cancelled, expired, and broker-confirmed-flat lifecycles
- preserve fail-closed behavior while position state is unknown or exposure remains open
- stop stale active arbitration from restarting the configured re-entry cooldown
- add focused regression coverage across websocket, polling/refresh, failed-entry, flat-position, and cooldown behavior

## Root cause
Terminal order and flat-position reconciliation did not consistently release both entry guards. The arbitrator stale fallback also reset its timestamp, extending a 300-second re-entry cooldown to roughly 420 seconds.

## Validation
- `python -m compileall -q src`
- focused lifecycle suite: passed
- execution + strategy suites: passed
- full `pytest -q`: passed to 100% (one pre-existing skipped test)
- `git diff --check`: passed