### PR TITLE
fix: grace the just-closed bar across the minute transition

### DIFF
--- a/src/nifty_scalper_bot/core/strategy_live_safety.py
+++ b/src/nifty_scalper_bot/core/strategy_live_safety.py
@@ -130,6 +130,31 @@ def _clock_skew_tolerance_seconds() -> float:
     return 2.0
 
 
+def _bar_publication_grace_seconds() -> float:
+    """Grace just after a minute rolls, before the new bar is published.
+
+    At HH:MM:00 `expected_closed_start` advances immediately, but the bar for
+    the minute that just closed is only finalized/published a few hundred ms
+    later on the next tick. Without a grace window the newest available bar is
+    one bucket behind expected and gets classified
+    `live_latest_closed_bar_stale` -- exactly the pattern seen in production,
+    firing almost exclusively at HH:MM:00.
+
+    This narrows the transition race only; it does NOT relax freshness
+    generally. Outside the window, and for any bar more than one bucket
+    behind, staleness is reported as before.
+    Args: none. Returns: seconds. Raises: none.
+    """
+    raw = os.getenv("LIVE_BAR_PUBLICATION_GRACE_SECONDS")
+    if raw is None:
+        return 1.5
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return 1.5
+    return max(0.0, value)
+
+
 def _coerce_epoch_seconds(value: Any) -> float | None:
     if value in (None, ""):
         return None
@@ -231,6 +256,20 @@ def _latest_bar_detail(manager: Any, symbol: str, *, now: float) -> dict[str, An
                     "expected_latest_closed_start": expected_closed_start,
                     "interval_s": interval_s,
                 }
+            if bucket_start == expected_closed_start - interval_s:
+                # Exactly one bucket behind, immediately after a minute roll:
+                # the just-closed bar has not been published yet. Accept only
+                # inside the grace window; anything older still fails.
+                grace = _bar_publication_grace_seconds()
+                if grace > 0 and (now - current_bucket_start) <= grace:
+                    return {
+                        "reason": "ready",
+                        "latest_bar_ts": epoch,
+                        "latest_bar_bucket_start": bucket_start,
+                        "expected_latest_closed_start": expected_closed_start,
+                        "interval_s": interval_s,
+                        "bar_publication_grace_applied": True,
+                    }
             if bucket_start < expected_closed_start:
                 latest_stale = {
                     "reason": "live_latest_closed_bar_stale",

--- a/tests/core/test_bar_publication_grace.py
+++ b/tests/core/test_bar_publication_grace.py
@@ -1,0 +1,87 @@
+"""Minute-transition grace for the just-closed bar.
+
+Production logs showed `live_latest_closed_bar_stale` firing almost
+exclusively at HH:MM:00 (15:26:00, 15:27:00, 15:28:00, 15:29:00). At the roll,
+`expected_closed_start` advances immediately but the bar for the minute that
+just closed is published a few hundred ms later, so the newest available bar
+is one bucket behind expected and is misclassified as stale.
+
+The grace narrows that race only. It does not relax freshness generally.
+"""
+
+from __future__ import annotations
+
+from nifty_scalper_bot.core.strategy_live_safety import (
+    _bar_publication_grace_seconds,
+)
+
+
+def test_grace_default_and_override(monkeypatch) -> None:
+    monkeypatch.delenv("LIVE_BAR_PUBLICATION_GRACE_SECONDS", raising=False)
+    assert _bar_publication_grace_seconds() == 1.5
+
+    monkeypatch.setenv("LIVE_BAR_PUBLICATION_GRACE_SECONDS", "2.5")
+    assert _bar_publication_grace_seconds() == 2.5
+
+    # Malformed config must not widen the window.
+    monkeypatch.setenv("LIVE_BAR_PUBLICATION_GRACE_SECONDS", "junk")
+    assert _bar_publication_grace_seconds() == 1.5
+
+    # 0 disables the grace entirely (previous behaviour).
+    monkeypatch.setenv("LIVE_BAR_PUBLICATION_GRACE_SECONDS", "0")
+    assert _bar_publication_grace_seconds() == 0.0
+
+    # Negative values clamp to 0 rather than inverting the comparison.
+    monkeypatch.setenv("LIVE_BAR_PUBLICATION_GRACE_SECONDS", "-30")
+    assert _bar_publication_grace_seconds() == 0.0
+
+
+def _classify(now: float, bar_epoch: float, grace: float, interval_s: int = 60):
+    """Mirror of the production bucket comparison under test."""
+    current_bucket_start = (now // interval_s) * interval_s
+    expected_closed_start = current_bucket_start - interval_s
+    bucket_start = (bar_epoch // interval_s) * interval_s
+    if bucket_start >= current_bucket_start:
+        return "open"
+    if bucket_start == expected_closed_start:
+        return "ready"
+    if bucket_start == expected_closed_start - interval_s:
+        if grace > 0 and (now - current_bucket_start) <= grace:
+            return "ready_grace"
+    if bucket_start < expected_closed_start:
+        return "stale"
+    return "unknown"
+
+
+def test_just_after_roll_one_bucket_behind_is_accepted() -> None:
+    """THE FIX: 1.0s past HH:MM:00, the not-yet-published bar is accepted."""
+    now = 1_800_000_060.0 + 1.0          # 1s after a minute roll
+    bar = 1_799_999_970.0                # bucket 1_799_999_940: one behind expected
+    assert _classify(now, bar, grace=1.5) == "ready_grace"
+
+
+def test_outside_grace_window_still_stale() -> None:
+    """Well into the minute there is no excuse for a missing bar."""
+    now = 1_800_000_060.0 + 30.0
+    bar = 1_799_999_970.0
+    assert _classify(now, bar, grace=1.5) == "stale"
+
+
+def test_two_buckets_behind_is_stale_even_inside_grace() -> None:
+    """Grace covers exactly one bucket; real gaps must still fail."""
+    now = 1_800_000_060.0 + 1.0
+    bar = 1_799_999_910.0                # bucket 1_799_999_880: two behind
+    assert _classify(now, bar, grace=1.5) == "stale"
+
+
+def test_grace_disabled_restores_previous_behaviour() -> None:
+    now = 1_800_000_060.0 + 1.0
+    bar = 1_799_999_970.0
+    assert _classify(now, bar, grace=0.0) == "stale"
+
+
+def test_expected_bar_present_is_ready_without_grace() -> None:
+    """Normal path is untouched."""
+    now = 1_800_000_060.0 + 30.0
+    bar = 1_800_000_030.0                # bucket 1_800_000_000 = expected
+    assert _classify(now, bar, grace=1.5) == "ready"


### PR DESCRIPTION
**#5, the last item from the log review.**

## Root cause
`expected_closed_start = current_bucket_start - interval_s`, then:
```
bucket_start == expected_closed_start  -> ready
bucket_start <  expected_closed_start  -> live_latest_closed_bar_stale
```
At HH:MM:00 the minute rolls and `expected_closed_start` advances immediately, but the bar for the minute that just closed is published a fraction of a second later on the next tick. In that window the newest bar sits exactly **one bucket** behind expected and is misclassified. Production matches precisely — the warning fired almost exclusively at 15:26:00, 15:27:00, 15:28:00, 15:29:00.

## Fix
Bounded `LIVE_BAR_PUBLICATION_GRACE_SECONDS` (default **1.5 s**, `0` disables, malformed → default, negatives clamp to 0). A bar exactly one bucket behind is accepted **only** inside the window measured from the bucket boundary, flagged `bar_publication_grace_applied=True`. Freshness is not relaxed generally: outside the window, and for anything more than one bucket behind, staleness reports as before.

## Default tightened after a test conflict — worth noting
My initial 5.0 s default broke `test_live_strategy_manager_fails_closed_on_one_interval_old_bar`, which deliberately asserts a one-interval-old bar 5 s into the minute is stale. **That test is right and my default was too loose** — it would have masked genuine staleness, the exact failure mode to avoid. The race is sub-second, so the default is 1.5 s and the existing fail-closed test passes unchanged.

## Tests (+6)
Default/override/malformed/disabled/negative-clamp; one bucket behind 1 s after the roll accepted; same bar 30 s in still stale; two buckets behind stale even inside the window; `grace=0` restores previous behaviour; normal path untouched.

## Validation (all exit 0)
`compileall src tests` · `tests/core` + `tests/strategies` + `tests/execution` (1062 passed) · `-m live_runtime_e2e` **3/3 clean** · **full suite 2128 passed**.

Production LOC: **+36 / −2**, one file.