### PR TITLE
fix: VWAPPro crashed on every evaluation when futures context was unavailable

### DIFF
--- a/src/nifty_scalper_bot/strategies/elite_strategies/vwap_pro.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/vwap_pro.py
@@ -12,6 +12,25 @@ from nifty_scalper_bot.utils.logging import get_logger
 LOGGER = get_logger(__name__)
 
 
+def _fmt_optional(value: float | None, digits: int) -> str:
+    """Format an optional metric for logging without crashing on None.
+
+    futures_vwap_slope / futures_volume_ratio are legitimately None when the
+    futures context is unavailable (they are no longer conflated with 0.0).
+    Feeding None to a %.4f/%.2f specifier raised
+    "TypeError: must be real number, not NoneType" inside the STRATEGY_NO_VOTE
+    log call, which the broad handler swallowed as a strategy failure -- so
+    VWAPPro silently produced no vote on every evaluation.
+    Args: value, digits. Returns: formatted str or "unavailable". Raises: none.
+    """
+    if value is None:
+        return "unavailable"
+    try:
+        return f"{float(value):.{digits}f}"
+    except (TypeError, ValueError):
+        return "unavailable"
+
+
 class VWAPProStrategy(EliteStrategy):
     """VWAP continuation/pullback strategy emitting scored strategy votes."""
 
@@ -269,7 +288,7 @@ class VWAPProStrategy(EliteStrategy):
                     "vwap=%.2f distance_pct=%.4f allowed_distance=%.4f atr=%.2f "
                     "volume=%.2f avg_volume=%.2f trend_alignment=%s pullback_flag=%s "
                     "context_age_seconds=%.2f context_fresh=%s context_confidence=%.2f "
-                    "futures_vwap_slope=%.4f futures_volume_ratio=%.2f slope_support=%s "
+                    "futures_vwap_slope=%s futures_volume_ratio=%s slope_support=%s "
                     "premium_above_vwap=%s continuation_confirmed=%s reasons=%s",
                     symbol,
                     score,
@@ -290,8 +309,8 @@ class VWAPProStrategy(EliteStrategy):
                     context_age_seconds,
                     context_fresh,
                     underlying_direction_confidence,
-                    futures_vwap_slope,
-                    futures_volume_ratio,
+                    _fmt_optional(futures_vwap_slope, 4),
+                    _fmt_optional(futures_volume_ratio, 2),
                     slope_support,
                     premium_above_vwap,
                     continuation_confirmed,

--- a/tests/strategies/test_vwap_pro_none_futures_context.py
+++ b/tests/strategies/test_vwap_pro_none_futures_context.py
@@ -1,0 +1,80 @@
+"""VWAPPro must survive an unavailable futures context.
+
+Production 2026-07-29: `Failure in VWAPProStrategy._evaluate_signal: must be
+real number, not NoneType` fired 44 times -- once per evaluation. The strategy
+therefore contributed NO votes all session, and because the failure was caught
+by a broad handler it surfaced only as a silent "no vote".
+
+Root cause: the futures-context correction made futures_vwap_slope and
+futures_volume_ratio legitimately None when unavailable (previously conflated
+with 0.0). The STRATEGY_NO_VOTE log line still formatted them with %.4f/%.2f,
+and the logging call raised TypeError before the strategy could return.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from nifty_scalper_bot.strategies.elite_strategies.vwap_pro import (
+    VWAPProStrategy,
+    _fmt_optional,
+)
+
+
+def _indicators(**over):
+    base = {
+        "vwap": 48.0, "atr": 2.1, "close": 45.0, "open": 45.0,
+        "high": 46.0, "low": 44.0, "volume": 1_300_000.0,
+        "avg_volume": 1_700_000.0, "spread_pct": 0.3,
+        "futures_vwap_slope": None, "futures_volume_ratio": None,
+        "direction": "CE", "underlying_direction": "CE",
+        "contract_side": "PE", "context_age_seconds": 0.06,
+        "underlying_direction_confidence": 0.70,
+    }
+    base.update(over)
+    return base
+
+
+def _strategy():
+    return VWAPProStrategy(config=MagicMock(), indicator_engine=MagicMock())
+
+
+def test_evaluate_signal_survives_none_futures_context() -> None:
+    """THE FIX: a None futures context must not abort the evaluation."""
+    _strategy()._evaluate_signal("NFO:NIFTY2680424200PE", _indicators(), 45.0)
+
+
+def test_evaluate_signal_survives_none_slope_only() -> None:
+    _strategy()._evaluate_signal(
+        "NFO:NIFTY2680424200PE",
+        _indicators(futures_volume_ratio=1.2),
+        45.0,
+    )
+
+
+def test_evaluate_signal_survives_none_volume_ratio_only() -> None:
+    _strategy()._evaluate_signal(
+        "NFO:NIFTY2680424200PE",
+        _indicators(futures_vwap_slope=0.0004),
+        45.0,
+    )
+
+
+def test_fmt_optional_marks_unavailable_rather_than_faking_zero() -> None:
+    """None must be visibly 'unavailable', not silently rendered as 0.0000."""
+    assert _fmt_optional(None, 4) == "unavailable"
+    assert _fmt_optional(None, 2) == "unavailable"
+    # A real zero is still a real value and must be shown as such.
+    assert _fmt_optional(0.0, 4) == "0.0000"
+    assert _fmt_optional(0.0, 2) == "0.00"
+
+
+def test_fmt_optional_formats_normal_values() -> None:
+    assert _fmt_optional(0.00042, 4) == "0.0004"
+    assert _fmt_optional(4.111, 2) == "4.11"
+
+
+def test_fmt_optional_does_not_raise_on_garbage() -> None:
+    assert _fmt_optional("abc", 2) == "unavailable"  # type: ignore[arg-type]


### PR DESCRIPTION
**P0 from the 2026-07-29 logs.** An entire strategy was silently disabled.

## Root cause (reproduced, not inferred)
44 occurrences — **once per evaluation**:
```
[ERROR] vwap_pro: Failure in VWAPProStrategy._evaluate_signal: must be real number, not NoneType
```
VWAPPro contributed **no votes all session**. A broad handler caught it, so it surfaced as a silent "no vote" — the strategy looked merely unconvinced rather than broken. On 2026-07-27 it was voting normally (`STRATEGY_VOTE strategy=VWAPPro side=CE score=6.00`).

Reproduced directly:
```
vwap_pro.py:265 in _evaluate_signal -> LOGGER.info(...)
utils/logging.py:360 -> key = str(msg % args if args else msg)
TypeError: must be real number, not NoneType
```

The `STRATEGY_NO_VOTE` line formats `futures_vwap_slope` with `%.4f` and `futures_volume_ratio` with `%.2f`. The recent futures-context correction made both legitimately `None` when unavailable (previously conflated with `0.0`), so the **logging call** raised before the strategy could return.

**This is a logging defect, not a scoring defect** — the scoring branches consuming those values were already `None`-guarded.

## Fix
`_fmt_optional(value, digits)` → `"unavailable"` for `None` (and unformattable input), otherwise the fixed-point string; the two specifiers become `%s`. A real `0.0` still renders `0.0000`/`0.00`, so the value-vs-unavailable distinction the futures-context work established is preserved rather than silently re-flattened to zero.

No scoring, voting, threshold or gating behaviour changed.

## Tests (+6)
Survives `None` futures context (both values, and each independently); `_fmt_optional` marks `None` unavailable while still rendering genuine `0.0`; normal values format; garbage doesn't raise.

## Validation (all exit 0)
`compileall src tests` · `tests/strategies` + `tests/core` (566 passed) · `-m live_runtime_e2e` **3/3 clean** · **full suite 2134 passed**.

`test_repeated_exit_triggers_are_idempotent_while_pending` appeared once in a full-suite run; it passes **3/3 on this branch and 3/3 on clean main** — the known pre-existing wall-clock flake, unrelated.

Production LOC: **+20 / −2**, one file.