### PR TITLE
fix: make final bracket closure sequentially and concurrently idempotent

### DIFF
--- a/src/nifty_scalper_bot/execution/ledger_bracket_manager.py
+++ b/src/nifty_scalper_bot/execution/ledger_bracket_manager.py
@@ -362,6 +362,43 @@ class LedgerBracketManager(CanonicalBracketManager):
         close_source: str,
         exit_price: float | None = None,
     ) -> None:
+        # Idempotency + single-flight for FINAL accounting.
+        #
+        # A second closure of an already-accounted bracket re-entered the
+        # accounting block with remaining_quantity already 0, raised
+        # "final exit identity, quantity or fill price unavailable", and
+        # latched ledger_blocked=True with
+        # fill_ledger_degraded:final_exit_accounting_failed. That latch does
+        # not self-heal: _retry_ledger_block() sees a pending exit marker with
+        # quantity 0 and returns before reaching its closed-and-complete
+        # recovery, so entries stayed blocked with
+        # ENTRY_BLOCKED_NATIVE_GATE reason=unresolved_exit_position even after
+        # position reconciliation succeeded.
+        #
+        # Both orderings must be covered: a sequential re-close, and two
+        # callers (watchdog / tick processing / reconciliation) beginning
+        # final accounting concurrently.
+        with self._lock:
+            already_accounted = bool(
+                getattr(bracket, "exit_executed", False)
+                and int(getattr(bracket, "remaining_quantity", 0) or 0) <= 0
+            )
+            if already_accounted or getattr(bracket, "_final_close_in_progress", False):
+                _legacy.LOGGER.info(
+                    "BRACKET_CLOSE_ALREADY_ACCOUNTED bracket_id=%s close_source=%s",
+                    getattr(bracket, "bracket_id", None),
+                    close_source,
+                    extra={
+                        "event": "BRACKET_CLOSE_ALREADY_ACCOUNTED",
+                        "bracket_id": str(getattr(bracket, "bracket_id", "") or ""),
+                        "symbol": getattr(bracket, "symbol", None),
+                        "close_source": close_source,
+                        "concurrent": not already_accounted,
+                    },
+                )
+                return
+            setattr(bracket, "_final_close_in_progress", True)
+
         order_id = str(bracket.exit_order_id or bracket.pending_exit_order_id or "")
         closing_quantity = int(bracket.remaining_quantity or 0)
         resolved_price = self._resolved_exit_price(bracket, exit_price)
@@ -398,6 +435,7 @@ class LedgerBracketManager(CanonicalBracketManager):
             )
 
         with self._lock:
+            setattr(bracket, "_final_close_in_progress", False)
             bracket.remaining_quantity = 0
             bracket.exit_executed = True
             bracket.exit_pending = False

--- a/tests/execution/test_ledger_bracket_runtime.py
+++ b/tests/execution/test_ledger_bracket_runtime.py
@@ -232,3 +232,87 @@ def test_release_block_survives_manager_restart(monkeypatch, tmp_path) -> None:
     second._watchdog_thread.join(timeout=1.0)
     assert bracket.bracket_id in second._ledger_blocked
     assert second.has_unresolved_exit() is True
+
+
+def test_duplicate_final_close_does_not_latch_ledger_block(monkeypatch, tmp_path) -> None:
+    """P0: closing an already-accounted bracket twice must be a no-op.
+
+    Production symptom: a second _close_bracket() on a successfully accounted
+    bracket re-entered final accounting with remaining_quantity already 0,
+    raised "final exit identity, quantity or fill price unavailable", and
+    latched ledger_blocked=True with
+    fill_ledger_degraded:final_exit_accounting_failed.
+
+    That latch does not self-heal -- _retry_ledger_block() sees a pending exit
+    marker with quantity 0 and returns early -- so entries stayed blocked with
+    ENTRY_BLOCKED_NATIVE_GATE reason=unresolved_exit_position even after
+    position reconciliation succeeded.
+    """
+    manager, _order_manager, broker = _manager(monkeypatch, tmp_path)
+    manager.confirm_entry_fill("entry-1", 100.0)
+    bracket = _mark_filled_exit(
+        manager,
+        broker,
+        order_id="final-1",
+        reason="SL Hit (95.00)",
+        price=95.0,
+        residual=0,
+    )
+
+    manager._close_bracket(bracket, close_source="first")
+    assert bracket.exit_executed is True
+    assert bracket.remaining_quantity == 0
+    assert bracket.bracket_id not in manager._ledger_blocked
+
+    # Second closure: previously latched the block.
+    manager._close_bracket(bracket, close_source="duplicate")
+
+    assert bracket.bracket_id not in manager._ledger_blocked
+    assert bracket.remaining_quantity == 0
+    assert bracket.exit_executed is True
+    assert manager.has_unresolved_exit() is False
+
+    # Exactly one entry and one exit fill -- accounting was not repeated.
+    assert manager._fill_ledger is not None
+    fills = manager._fill_ledger.load_fills(bracket.bracket_id)
+    assert len([f for f in fills if f.fill_id.startswith("ENTRY:")]) == 1
+
+
+def test_concurrent_final_close_accounts_once(monkeypatch, tmp_path) -> None:
+    """Two callers beginning final accounting at once must not double-account.
+
+    Watchdog, tick processing and reconciliation can all reach closure; an
+    idempotency check alone does not stop two threads entering together.
+    """
+    import threading
+
+    manager, _order_manager, broker = _manager(monkeypatch, tmp_path)
+    manager.confirm_entry_fill("entry-1", 100.0)
+    bracket = _mark_filled_exit(
+        manager,
+        broker,
+        order_id="final-1",
+        reason="SL Hit (95.00)",
+        price=95.0,
+        residual=0,
+    )
+
+    barrier = threading.Barrier(2)
+
+    def _close(tag: str) -> None:
+        barrier.wait(timeout=5.0)
+        manager._close_bracket(bracket, close_source=tag)
+
+    threads = [
+        threading.Thread(target=_close, args=("concurrent-a",)),
+        threading.Thread(target=_close, args=("concurrent-b",)),
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=5.0)
+
+    assert bracket.bracket_id not in manager._ledger_blocked
+    assert bracket.exit_executed is True
+    assert bracket.remaining_quantity == 0
+    assert manager.has_unresolved_exit() is False


### PR DESCRIPTION
**P0.** A duplicate final closure permanently latched the ledger block and stopped all further entries.

## Root cause (reproduced)
`_close_bracket()` had no already-closed guard. A second closure of an already-accounted bracket re-entered final accounting with `remaining_quantity` already 0, so this fired:
```python
if not order_id or closing_quantity <= 0 or resolved_price is None:
    raise FillValidationError("final exit identity, quantity or fill price unavailable")
```
latching `ledger_blocked=True` / `fill_ledger_degraded:final_exit_accounting_failed`.

**The latch does not self-heal.** `_retry_ledger_block()` sees a pending exit marker with quantity 0 and returns before reaching its closed-and-complete recovery, so entries stayed blocked with `ENTRY_BLOCKED_NATIVE_GATE reason=unresolved_exit_position` even after `POSITION_RECONCILE_SUCCESS` — reconciliation completing does **not** clear the independent ledger latch.

Reproduced pre-fix:
```
after_first:  state=CLOSED remaining=0 ledger_blocked=False
after_second: state=CLOSED remaining=0 ledger_blocked=True
              last_exit_error=fill_ledger_degraded:final_exit_accounting_failed
```
with only one entry and one exit fill in the ledger — accounting had already completed successfully.

## Fix
Under the existing lock, `_close_bracket()` returns early when the bracket is already accounted (`exit_executed` and `remaining_quantity <= 0`) or when another caller is mid-accounting, emitting `BRACKET_CLOSE_ALREADY_ACCOUNTED`. A `_final_close_in_progress` marker set inside the same lock gives single-flight so two callers cannot both begin final accounting.

An idempotency check alone is insufficient — watchdog, tick processing and reconciliation can all reach closure — so **both orderings are covered**. No accounting, ledger, PnL, exit-geometry or gate logic otherwise changed.

## Tests (+2)
Sequential duplicate closure (no latch, exactly one ENTRY fill, accounting not repeated) and concurrent closure via `threading.Barrier`.

Verified against pre-fix code, which fails with:
```
assert 'entry-1' not in {'entry-1': {'reason': 'final_exit_accounting_failed', ...}}
```

## Validation (all exit 0)
`compileall src tests` · `tests/execution` (505 passed) · `-m live_runtime_e2e` **3/3 clean** · **full suite 2137 passed**.

**Not addressed here:** the production caller that closes twice is not identified from the available excerpts. This change makes the outcome safe regardless of which path re-enters.

Production LOC: **+37 / −1**, one file.