### PR TITLE
fix: preserve REST cumulative-volume semantics end to end

### DIFF
--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -952,6 +952,7 @@ class MarketDataManager:
             else:
                 normalized["source"] = source or "rest_poll"
                 normalized["timestamp_source"] = "rest_poll"
+                normalized["_volume_delta_normalized"] = True
                 self._candle_metrics["fallback_quote_tick_total"] += 1
                 self._enqueue_tick_threadsafe(dict(normalized))
         except Exception as exc:  # noqa: BLE001
@@ -8451,7 +8452,9 @@ class MarketDataManager:
                 )
             if raw is None:
                 return
-            volume_delta_normalized = False
+            volume_delta_normalized = bool(
+                raw.pop("_volume_delta_normalized", False)
+            )
             enqueued_mono = raw.get("_enqueued_monotonic")
             if isinstance(enqueued_mono, (int, float)):
                 self._event_loop_lag_seconds = max(
@@ -9255,6 +9258,7 @@ class MarketDataManager:
 
     def _emit_tick(self, symbol: str, tick: dict[str, Any], *, source: str) -> None:
         source = str(source or "unknown").lower()
+        tick.pop("_volume_delta_normalized", None)
         accepted_current_generation_tick = False
         if source == "ws":
             now_mono = time.monotonic()
@@ -13091,7 +13095,9 @@ class MarketDataManager:
         # `volume_cumulative` alone is NOT sufficient: that key is diagnostic
         # only and the normalizer never consumes it, so the baseline would
         # never advance and every REST tick would publish delta 0.
-        explicit_delta = self._coerce_float(tick, "volume_delta")
+        explicit_delta = self._coerce_float(
+            tick, "volume_delta", "effective_volume_delta"
+        )
         has_cumulative = any(
             tick.get(key) is not None
             for key in (
@@ -13105,6 +13111,7 @@ class MarketDataManager:
         if explicit_delta is not None:
             # A genuine interval delta is preserved verbatim, never relabelled.
             normalized["volume_delta"] = float(explicit_delta)
+            normalized["effective_volume_delta"] = float(explicit_delta)
             normalized["volume"] = float(explicit_delta)
             cumulative_hint = self._coerce_float(
                 tick, "volume_cumulative", "volume_traded_today"

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -13082,20 +13082,56 @@ class MarketDataManager:
             normalized["broker_timestamp"] = broker_timestamp
 
         # 5. Volume Handling
-        volume = self._coerce_float(
-            tick,
-            "volume_traded_today",
-            "volume",
-            "volume_traded",
-            "total_traded_volume",
+        # Volume transport contract.
+        #
+        # Cumulative input is handed to the canonical
+        # _normalise_tick_volume_delta(), which owns the per-symbol/token/
+        # generation baseline, first-observation zero delta, rollback and
+        # out-of-order quarantine and suspicious-jump rejection. Publishing
+        # `volume_cumulative` alone is NOT sufficient: that key is diagnostic
+        # only and the normalizer never consumes it, so the baseline would
+        # never advance and every REST tick would publish delta 0.
+        explicit_delta = self._coerce_float(tick, "volume_delta")
+        has_cumulative = any(
+            tick.get(key) is not None
+            for key in (
+                "volume_traded_today",
+                "volume_traded",
+                "total_traded_volume",
+                "cumulative_volume",
+            )
         )
-        if volume is None and previous:
-            prev_vol = previous.get("volume")
-            if isinstance(prev_vol, (int, float)):
-                volume = float(prev_vol)
 
-        if volume is not None:
-            normalized["volume"] = float(volume)
+        if explicit_delta is not None:
+            # A genuine interval delta is preserved verbatim, never relabelled.
+            normalized["volume_delta"] = float(explicit_delta)
+            normalized["volume"] = float(explicit_delta)
+            cumulative_hint = self._coerce_float(
+                tick, "volume_cumulative", "volume_traded_today"
+            )
+            if cumulative_hint is not None:
+                normalized["volume_cumulative"] = float(cumulative_hint)
+        elif has_cumulative:
+            derived = self._normalise_tick_volume_delta(symbol, tick)
+            for key in (
+                "volume",
+                "volume_delta",
+                "effective_volume_delta",
+                "volume_cumulative",
+                "volume_transition",
+                "volume_delta_untrusted",
+                "volume_baseline_reset",
+            ):
+                if key in derived:
+                    normalized[key] = derived[key]
+        else:
+            plain_volume = self._coerce_float(tick, "volume")
+            if plain_volume is None and previous:
+                prev_vol = previous.get("volume")
+                if isinstance(prev_vol, (int, float)):
+                    plain_volume = float(prev_vol)
+            if plain_volume is not None:
+                normalized["volume"] = float(plain_volume)
 
         instrument_token = tick.get("instrument_token") or tick.get("token")
         if instrument_token is not None:
@@ -13186,6 +13222,20 @@ class MarketDataManager:
     @staticmethod
     def _prepare_rest_tick(tick: Mapping[str, Any], *, source: str) -> dict[str, Any]:
         payload = dict(tick)
+        # Zerodha REST /quote reports `volume` as volume traded TODAY
+        # (cumulative). Generic `volume` on other transports may legitimately
+        # be an interval figure, so the retag happens here at the REST
+        # boundary only, and only when nothing more specific is present.
+        if (
+            payload.get("volume") is not None
+            and payload.get("volume_delta") is None
+            and payload.get("effective_volume_delta") is None
+            and payload.get("volume_traded_today") is None
+            and payload.get("volume_traded") is None
+            and payload.get("total_traded_volume") is None
+            and payload.get("cumulative_volume") is None
+        ):
+            payload["volume_traded_today"] = payload.get("volume")
         broker_timestamp = None
         for candidate in (
             payload.get("timestamp"),

--- a/tests/data/test_mdm_option_volume_semantics.py
+++ b/tests/data/test_mdm_option_volume_semantics.py
@@ -112,3 +112,141 @@ def test_counter_reset_requires_explicit_or_session_evidence() -> None:
     assert reset["volume_transition"]["state"] == "counter_reset"
     assert reset["volume_delta"] == 0
     assert after_reset["volume_delta"] == 25
+
+
+# ============ REST / pull transport volume contract ============
+# Zerodha REST /quote returns `volume` / `volume_traded_today` as volume traded
+# TODAY -- cumulative, not per-interval. _normalize_tick() previously mapped it
+# straight to `volume` with no volume_cumulative / volume_delta /
+# volume_delta_untrusted, so a cached REST quote reaching the runner looked
+# like explicit interval volume (RUNNER_OPTION_VOLUME_CLAMPED volume=28574260).
+
+_SYM = "NFO:NIFTY26JUN24000CE"
+
+
+def test_rest_cumulative_volume_is_not_published_as_interval_volume() -> None:
+    """A REST quote must be labelled cumulative, never interval."""
+    mdm = _mdm()
+    out = mdm._normalize_tick(
+        _SYM,
+        {"last_price": 45.0, "volume_traded_today": 28_574_260,
+         "instrument_token": 1, "source": "rest"},
+    )
+    assert out is not None
+    assert out.get("volume_cumulative") == 28_574_260.0
+    # First observation establishes the baseline: delta 0, never the daily total.
+    assert out.get("volume_delta") == 0.0
+    assert out["volume_transition"]["state"] == "baseline_initialized"
+    assert out.get("volume") != 28_574_260.0
+
+
+def test_untagged_rest_volume_key_is_also_treated_as_cumulative() -> None:
+    """Zerodha's `volume` on this transport is the daily total, not interval."""
+    mdm = _mdm()
+    raw = mdm._prepare_rest_tick(
+        {"last_price": 45.0, "volume": 28_574_260, "instrument_token": 1},
+        source="rest",
+    )
+    out = mdm._normalize_tick(_SYM, raw)
+    assert out is not None
+    assert out.get("volume_cumulative") == 28_574_260.0
+    assert out.get("volume_delta") == 0.0
+    assert out["volume_transition"]["state"] == "baseline_initialized"
+
+
+def test_explicit_interval_delta_is_not_relabelled_as_cumulative() -> None:
+    """REGRESSION TEST 1: a genuine interval delta must pass through intact."""
+    mdm = _mdm()
+    out = mdm._normalize_tick(
+        _SYM,
+        {
+            "last_price": 45.0,
+            "volume_delta": 1_250.0,
+            "volume_cumulative": 28_574_260,
+            "source": "ws",
+        },
+    )
+    assert out is not None
+    assert out.get("volume_delta") == 1_250.0
+    assert out.get("volume") == 1_250.0
+    # Cumulative is retained separately, not conflated with the delta.
+    assert out.get("volume_cumulative") == 28_574_260.0
+    assert out.get("volume_delta_untrusted") is not True
+
+
+def _rest(mdm: MarketDataManager, cumulative: int) -> dict:
+    """Drive the real REST ingress -> normalize path."""
+    raw = mdm._prepare_rest_tick(
+        {"last_price": 45.0, "volume": cumulative, "instrument_token": 1},
+        source="rest",
+    )
+    return mdm._normalize_tick(_SYM, raw) or {}
+
+
+def test_rest_cumulative_produces_real_incremental_delta() -> None:
+    """END-TO-END: first REST observation 0, next a true incremental delta.
+
+    Publishing volume_cumulative alone is NOT enough: that key is diagnostic
+    only and _normalise_tick_volume_delta() never consumes it, so the baseline
+    would never advance and every REST tick would publish delta 0.
+    """
+    mdm = _mdm()
+
+    first = _rest(mdm, 28_574_260)
+    assert first["volume_delta"] == 0.0
+    assert first["volume_transition"]["state"] == "baseline_initialized"
+    assert first["volume_cumulative"] == 28_574_260.0
+
+    second = _rest(mdm, 28_574_325)
+    assert second["volume_delta"] == 65.0
+    assert second["effective_volume_delta"] == 65.0
+    assert second["volume_transition"]["state"] == "accepted"
+    assert second["volume_cumulative"] == 28_574_325.0
+    # REST must not remain permanently untrusted once a baseline exists.
+    assert second.get("volume_delta_untrusted") is not True
+
+
+def test_ws_rest_ws_transition_shares_one_baseline() -> None:
+    """WS -> REST fallback -> WS must share ONE baseline, no double counting."""
+    mdm = _mdm()
+
+    ws1 = mdm._normalize_tick(
+        _SYM, {"last_price": 45.0, "volume_traded_today": 28_574_000,
+               "instrument_token": 1, "source": "ws"}
+    ) or {}
+    assert ws1["volume_delta"] == 0.0            # initial baseline
+
+    rest = _rest(mdm, 28_574_260)
+    assert rest["volume_delta"] == 260.0         # 260 since the WS baseline
+    assert rest["volume_transition"]["state"] == "accepted"
+
+    ws2 = mdm._normalize_tick(
+        _SYM, {"last_price": 45.2, "volume_traded_today": 28_574_560,
+               "instrument_token": 1, "source": "ws"}
+    ) or {}
+    assert ws2["volume_delta"] == 300.0          # 300 since the REST hop
+    assert ws2["volume_transition"]["state"] == "accepted"
+
+    # One shared baseline: increments sum to the total span, no double count.
+    assert (
+        ws1["volume_delta"] + rest["volume_delta"] + ws2["volume_delta"]
+        == 28_574_560 - 28_574_000
+    )
+    # And no delta was ever the cumulative daily total.
+    for tick in (ws1, rest, ws2):
+        assert tick["volume_delta"] != tick["volume_cumulative"]
+
+
+def test_out_of_order_rest_does_not_move_baseline() -> None:
+    """A stale REST quote must not corrupt or rewind the baseline."""
+    mdm = _mdm()
+    _rest(mdm, 28_574_260)
+    _rest(mdm, 28_574_325)
+
+    stale = _rest(mdm, 28_574_100)
+    assert stale["volume_transition"]["state"] != "accepted"
+    assert stale.get("effective_volume_delta") in (0, 0.0, None)
+
+    # Baseline intact: a later legitimate value still measures from 28_574_325.
+    resumed = _rest(mdm, 28_574_400)
+    assert resumed["volume_delta"] == 75.0

--- a/tests/data/test_mdm_option_volume_semantics.py
+++ b/tests/data/test_mdm_option_volume_semantics.py
@@ -174,6 +174,67 @@ def test_explicit_interval_delta_is_not_relabelled_as_cumulative() -> None:
     assert out.get("volume_delta_untrusted") is not True
 
 
+def test_effective_volume_delta_only_remains_interval_volume() -> None:
+    """Compatibility: effective-only interval input must not become cumulative."""
+    mdm = _mdm()
+    prepared = mdm._prepare_rest_tick(
+        {
+            "last_price": 45.0,
+            "volume": 28_574_260,
+            "effective_volume_delta": 65.0,
+            "instrument_token": 1,
+        },
+        source="rest",
+    )
+    out = mdm._normalize_tick(_SYM, prepared)
+
+    assert out is not None
+    assert out["volume"] == 65.0
+    assert out["volume_delta"] == 65.0
+    assert out["effective_volume_delta"] == 65.0
+    assert out.get("volume_cumulative") != 28_574_260.0
+
+
+def test_public_rest_ingress_publishes_incremental_delta() -> None:
+    """REST ingress must preserve its derived delta through queue and storage."""
+    mdm = _mdm()
+    mdm._is_duplicate = lambda *_args, **_kwargs: False  # type: ignore[method-assign]
+
+    def process_immediately(tick: dict) -> None:
+        mdm._process_queued_tick(tick)
+
+    mdm._enqueue_tick_threadsafe = process_immediately  # type: ignore[method-assign]
+
+    mdm.ingest_rest_quote(
+        _SYM,
+        {
+            "last_price": 45.0,
+            "volume": 28_574_260,
+            "instrument_token": 1,
+            "timestamp": datetime(2026, 1, 1, 9, 15, 1, tzinfo=timezone.utc),
+        },
+    )
+    first = mdm.get_latest_tick(_SYM)
+
+    mdm.ingest_rest_quote(
+        _SYM,
+        {
+            "last_price": 45.2,
+            "volume": 28_574_325,
+            "instrument_token": 1,
+            "timestamp": datetime(2026, 1, 1, 9, 15, 2, tzinfo=timezone.utc),
+        },
+    )
+    second = mdm.get_latest_tick(_SYM)
+
+    assert first is not None
+    assert first["volume_delta"] == 0.0
+    assert second is not None
+    assert second["volume"] == 65.0
+    assert second["volume_delta"] == 65.0
+    assert second["volume_cumulative"] == 28_574_325.0
+
+
 def _rest(mdm: MarketDataManager, cumulative: int) -> dict:
     """Drive the real REST ingress -> normalize path."""
     raw = mdm._prepare_rest_tick(


### PR DESCRIPTION
## Root cause
Zerodha REST `/quote` exposes `volume` as cumulative daily traded volume. The REST/pull path flattened that total into interval `volume`, so a value such as `28,574,260` could reach the runner and be clamped, suppressing volume confirmation.

The canonical WebSocket cumulative-to-delta state machine was already correct; the defect was the REST transport handoff.

## Fix
- Retag unqualified Zerodha REST `volume` as cumulative at `_prepare_rest_tick()`.
- Route cumulative REST observations through the existing per-symbol/token/generation volume normalizer.
- Preserve explicit `volume_delta` and `effective_volume_delta` as interval values.
- Mark the REST queue handoff as already normalized so `_process_queued_tick()` does not consume the same cumulative observation twice and replace a valid delta with duplicate-zero.
- Remove the internal handoff marker before publication/storage.
- Leave the one-million safety clamp unchanged.

Expected behavior:

| Observation | Cumulative | Published delta |
|---|---:|---:|
| First REST quote | 28,574,260 | 0 |
| Next REST quote | 28,574,325 | 65 |

## Regression coverage
- First REST cumulative observation establishes a zero baseline.
- Subsequent REST observation publishes the real increment.
- WS → REST → WS shares one baseline without double-counting.
- Out-of-order REST data does not move the baseline.
- Explicit `volume_delta` remains interval volume.
- `effective_volume_delta`-only input remains interval volume.
- Public `ingest_rest_quote → queue processing → emit/store → get_latest_tick` is forced through the non-duplicate queue path and verifies `0 → 65`.

## Validation
- Focused REST/volume and fallback tests: passed.
- `tests/data`: passed.
- `python -m compileall -q src`: passed.
- Complete non-dashboard suite: passed with uppercase and lowercase proxy variables removed.
- Full local collection remains blocked by a pre-existing corrupted Streamlit installation (`FeedbackMixin` missing); fresh GitHub CI is the full-suite merge gate.
- `git diff --check`: clean.
- Exactly two tracked files changed; generated `positions.json` was excluded.

## Post-deploy validation
During one market session, confirm #941–#943 together: VWAPPro votes return, bracket closure does not leave `unresolved_exit_position`, REST volume publishes realistic deltas with cumulative retained separately, and `RUNNER_OPTION_VOLUME_CLAMPED` falls sharply or disappears. Latency optimization is intentionally excluded from this PR.