### PR TITLE
fix: give DataHub exactly one tick ingress route

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -8211,12 +8211,26 @@ def _wire_and_start_message_bus(ctx: BotContext) -> bool:
         mdm.bus = bus
     if not ctx.message_bus_tick_subscribed:
         if data_hub is not None:
-            bus.subscribe_once(
-                MessageType.TICK,
-                data_hub.ingest_tick_from_bus,
-                subscriber_id="data_hub.ingest_tick_from_bus",
+            # EXACTLY-ONCE DATAHUB INGRESS.
+            #
+            # DataHub is already registered as a DIRECT MarketDataManager
+            # subscriber (DataHub.subscribe_ticks -> mdm.subscribe(symbol,
+            # self.ingest_tick_sync)). Also subscribing it to MessageBus TICK
+            # gave one accepted market tick two ingress routes, so a single
+            # market event could bump the quote version twice, run every
+            # DataHub subscriber twice, and repeat runner ingress and
+            # position-protection work. The equal-market-timestamp check is
+            # not an event identity and does not reliably reject the second
+            # delivery.
+            #
+            # The direct path is retained because it preserves deterministic
+            # ordering for position protection. MessageBus TICK publication
+            # continues for independent observers; DataHub simply no longer
+            # re-injects from it. DataHub is the single owner of normalized
+            # tick state.
+            LOGGER.info(
+                "MESSAGE_BUS_TICK_OWNER owner=data_hub ingress=direct_mdm_only"
             )
-            LOGGER.info("MESSAGE_BUS_TICK_OWNER owner=data_hub")
         elif runner is not None:
             bus.subscribe_once(
                 MessageType.TICK,

--- a/tests/data/test_datahub_single_tick_ingress.py
+++ b/tests/data/test_datahub_single_tick_ingress.py
@@ -1,0 +1,69 @@
+"""DataHub must have exactly one tick ingress route.
+
+Post-#943 audit, P0: DataHub was registered BOTH as a direct
+MarketDataManager subscriber (DataHub.subscribe_ticks ->
+mdm.subscribe(symbol, self.ingest_tick_sync)) AND as a MessageBus TICK
+consumer (app.py: bus.subscribe_once(MessageType.TICK,
+data_hub.ingest_tick_from_bus)).
+
+One accepted market tick therefore had two ingress routes: the quote version
+could increment twice, every DataHub subscriber could run twice, and runner
+ingress plus position-protection work could repeat. The equal-market-timestamp
+check is not an event identity and does not reliably reject the second
+delivery, because wall-clock arrival differs.
+
+The direct path is kept (deterministic ordering for position protection);
+MessageBus TICK publication continues for independent observers.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+from nifty_scalper_bot.core import app as app_module
+
+
+def _bus_start_source() -> str:
+    """Source of the function that wires MessageBus TICK subscribers."""
+    src = inspect.getsource(app_module)
+    marker = "MESSAGE_BUS_TICK_OWNER"
+    assert marker in src, "tick-owner wiring not found"
+    start = src.index("if not ctx.message_bus_tick_subscribed:")
+    return src[start : start + 2000]
+
+
+def test_datahub_is_not_registered_as_a_messagebus_tick_consumer() -> None:
+    """THE FIX: no second ingress route back into DataHub."""
+    region = _bus_start_source()
+    assert "data_hub.ingest_tick_from_bus" not in region, (
+        "DataHub must not consume MessageBus TICK: it is already a direct "
+        "MarketDataManager subscriber, so this creates duplicate ingress."
+    )
+
+
+def test_datahub_remains_the_declared_tick_owner() -> None:
+    """Ownership telemetry is preserved and states the ingress route."""
+    region = _bus_start_source()
+    assert "MESSAGE_BUS_TICK_OWNER owner=data_hub" in region
+    assert "ingress=direct_mdm_only" in region
+
+
+def test_runner_fallback_subscription_is_retained() -> None:
+    """When DataHub is absent the runner must still receive bus ticks."""
+    region = _bus_start_source()
+    assert "strategy_runner.on_data.fallback" in region
+
+
+def test_direct_mdm_subscription_is_still_the_ingress_path() -> None:
+    """DataHub keeps its direct, ordered MDM subscription."""
+    from nifty_scalper_bot.data import data_hub as dh_module
+
+    src = inspect.getsource(dh_module)
+    assert "mdm_sub(symbol, self.ingest_tick_sync)" in src
+
+
+def test_ingest_tick_from_bus_remains_available_for_other_wiring() -> None:
+    """The method is not deleted -- only this duplicate registration is."""
+    from nifty_scalper_bot.data.data_hub import DataHub
+
+    assert callable(getattr(DataHub, "ingest_tick_from_bus", None))


### PR DESCRIPTION
**P0 #1 from the post-#943 audit.** Draft — merge only after clean CI.

## Root cause
DataHub was registered on **both** ingress paths at once:
1. direct MDM subscriber — `data_hub.py:1446` `mdm_sub(symbol, self.ingest_tick_sync)`
2. MessageBus TICK consumer — `app.py:8216` `bus.subscribe_once(MessageType.TICK, data_hub.ingest_tick_from_bus)`

One accepted market tick therefore had two routes into DataHub. The equal-market-timestamp check is **not an event identity** and doesn't reliably reject the second delivery, since wall-clock arrival differs. A single market event could increment the quote version twice, invoke every DataHub subscriber twice, repeat runner ingress and position-protection work, and duplicate checkpoint/metrics/coalescing contention.

That duplication is a **latency multiplier on the synchronous hot path**, matching the observed profile: `DataHub.ingest_tick_sync` at 1,088 ms, event-loop lag to 2,746 ms, up to 51 pending ticks — feeding late candle arrival and stale-bar blocks.

## Fix — remove the duplicate route, not add a dedup cache
DataHub no longer subscribes to MessageBus TICK. The direct MDM path is retained because it preserves **deterministic ordering for position protection**, and DataHub is documented as the single owner of normalized tick state. MessageBus TICK publication continues for independent observers; the runner fallback (data_hub-absent) is untouched; `ingest_tick_from_bus` is retained for other wiring.

A dedup cache was deliberately **not** used as the primary fix — it would keep duplicate transport and scheduling cost and add eviction/identity complexity while leaving two owners of the same event.

No stale-data, overload, generation or safety check is weakened. Those gates are responding correctly to degraded input.

## Tests (+5)
Not a bus consumer; ownership telemetry retained with `ingress=direct_mdm_only`; runner fallback retained; direct MDM subscription retained; `ingest_tick_from_bus` not deleted.

Pre-fix failure: `DataHub must not consume MessageBus TICK`.

## Validation (local, all exit 0)
`compileall -q src` · `git diff --check` clean · `tests/data` + `tests/core` + `tests/execution` · `-m live_runtime_e2e` **3/3 clean** · **full suite 2150 passed**.

Production LOC: **+17 / −6**, one file.

## Remaining from the audit (separate PRs)
P0 blocking watchdog/recovery inside the synchronous tick callback; P0/P1 stall recovery calling `start()` which is a no-op while running; P1 order-rejection warning discarding reason/correlation; P2 `event_loop_thread` telemetry never initialized.