### PR TITLE
fix: repair evaluation-stall recovery and stop it blocking the tick thread

### DIFF
--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -8713,15 +8713,82 @@ class StrategyRunner:
                     try:
                         loop = asyncio.get_running_loop()
                     except RuntimeError:
-                        asyncio.run(result)
+                        # This runs inside _health_watchdog -> _on_tick_safe,
+                        # i.e. on the market-data tick thread. asyncio.run()
+                        # here executed the readiness recompute synchronously
+                        # and blocked tick ingestion for its full duration --
+                        # the same defect fixed for Telegram dispatch. Submit
+                        # to the attached runtime loop instead; never block.
+                        runtime_loop = self._main_loop
+                        if runtime_loop is not None and not runtime_loop.is_closed():
+                            asyncio.run_coroutine_threadsafe(result, runtime_loop)
+                        else:
+                            result.close()
+                            self._logger.warning(
+                                "STRATEGY_EVAL_STALL_RECOMPUTE_SKIPPED reason=no_runtime_loop",
+                                extra={
+                                    "event": "STRATEGY_EVAL_STALL_RECOMPUTE_SKIPPED",
+                                    "reason": "no_runtime_loop",
+                                },
+                            )
                     else:
                         loop.create_task(result)
             except Exception:
                 self._logger.exception("STRATEGY_EVAL_STALL_READINESS_RECOMPUTE_FAILED")
+        # Evaluation-worker state, captured BEFORE any recovery action so the
+        # log shows why evaluation stalled rather than only that it did.
+        with self._eval_gate_lock:
+            worker_state = {
+                "pending_entry_eval": sorted(self._pending_entry_eval_symbols),
+                "drain_scheduled": self._entry_eval_drain_scheduled,
+                "drain_active": self._entry_eval_active,
+                "drain_count": self._entry_eval_drain_count,
+                "runtime_loop_attached": self._runtime_loop_attached,
+                "shutdown": self._entry_eval_shutdown,
+            }
+        executor = getattr(self, "_entry_eval_executor", None)
+        worker_state["executor_alive"] = bool(
+            executor is not None and not getattr(executor, "_shutdown", False)
+        )
+        was_running = bool(self._running)
+
         try:
             self.start()
         except Exception:
             self._logger.exception("STRATEGY_EVAL_STALL_LOOP_RESTART_FAILED")
+
+        # start() is a no-op while the runner is already running, so on its own
+        # it cannot recover a stalled evaluation loop -- the recovery advertised
+        # "restart_loop" but performed nothing. Post-#918 the real evaluation
+        # mechanism is the coalesced entry-eval drain, so nudge that instead of
+        # relying on a restart that never happens.
+        drain_rescheduled = False
+        if not self._entry_eval_shutdown:
+            with self._eval_gate_lock:
+                needs_drain = (
+                    bool(self._pending_entry_eval_symbols)
+                    and not self._entry_eval_active
+                    and not self._entry_eval_drain_scheduled
+                )
+                if needs_drain:
+                    self._entry_eval_drain_scheduled = True
+            if needs_drain:
+                drain_rescheduled = self._schedule_entry_eval_drain()
+                if not drain_rescheduled:
+                    with self._eval_gate_lock:
+                        self._entry_eval_drain_scheduled = False
+        self._logger.warning(
+            "STRATEGY_EVAL_STALL_WORKER_STATE start_was_noop=%s drain_rescheduled=%s state=%s",
+            was_running,
+            drain_rescheduled,
+            worker_state,
+            extra={
+                "event": "STRATEGY_EVAL_STALL_WORKER_STATE",
+                "start_was_noop": was_running,
+                "drain_rescheduled": drain_rescheduled,
+                **worker_state,
+            },
+        )
         # Reset per-symbol eval throttles once so the next flowing tick can
         # enter _on_tick instead of being held behind stale same-bar state.
         self._last_eval_ts.clear()

--- a/tests/strategies/test_eval_stall_recovery.py
+++ b/tests/strategies/test_eval_stall_recovery.py
@@ -1,0 +1,125 @@
+"""Evaluation-stall recovery must actually recover, and never block ticks.
+
+Post-#943 audit, P0/P1. _recover_strategy_eval_stall_once() had two defects:
+
+1. It logged action=recompute_readiness_and_restart_loop and called
+   self.start(), but start() is a no-op while the runner is already running --
+   which it always is when a stall is detected. The advertised restart never
+   happened, and because the recovery was marked attempted, escalation was
+   suppressed.
+
+2. Its readiness-recompute fallback called asyncio.run(result) when no loop was
+   running on the calling thread. This function runs inside _health_watchdog ->
+   _on_tick_safe, i.e. on the market-data tick thread, so it blocked tick
+   ingestion for the full recompute -- the same defect fixed for Telegram.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import threading
+import time
+from unittest.mock import MagicMock
+
+from nifty_scalper_bot.strategies.runner import StrategyRunner
+
+
+def _source() -> str:
+    return inspect.getsource(StrategyRunner._recover_strategy_eval_stall_once)
+
+
+def test_recovery_does_not_block_the_tick_thread_with_asyncio_run() -> None:
+    """THE BLOCKING FIX: no synchronous asyncio.run on the tick path."""
+    src = _source()
+    assert "asyncio.run(result)" not in src, (
+        "recovery runs on the market-data tick thread; asyncio.run() there "
+        "blocks tick ingestion for the whole recompute"
+    )
+    assert "run_coroutine_threadsafe" in src
+
+
+def test_recovery_reports_when_start_was_a_noop() -> None:
+    """Operators must see that the advertised restart did nothing."""
+    src = _source()
+    assert "start_was_noop" in src
+    assert "STRATEGY_EVAL_STALL_WORKER_STATE" in src
+
+
+def test_recovery_nudges_the_real_evaluation_mechanism() -> None:
+    """Post-#918 the evaluation mechanism is the coalesced entry-eval drain."""
+    src = _source()
+    assert "_schedule_entry_eval_drain" in src
+
+
+def test_recovery_captures_evaluation_worker_state() -> None:
+    """Stall logs must explain WHY evaluation stalled, not only that it did."""
+    src = _source()
+    for field in (
+        "pending_entry_eval",
+        "drain_scheduled",
+        "drain_active",
+        "runtime_loop_attached",
+        "executor_alive",
+    ):
+        assert field in src, f"missing worker-state field: {field}"
+
+
+def test_recovery_reschedules_a_stranded_pending_drain() -> None:
+    """A pending symbol with no drain scheduled must be re-nudged."""
+    runner = StrategyRunner.__new__(StrategyRunner)
+    runner._logger = MagicMock()
+    runner._eval_gate_lock = threading.Lock()
+    runner._last_global_eval_ts = time.monotonic() - 120.0
+    runner._running = True
+    runner._entry_eval_shutdown = False
+    runner._entry_eval_active = False
+    runner._entry_eval_drain_scheduled = False
+    runner._entry_eval_drain_count = 3
+    runner._runtime_loop_attached = True
+    runner._pending_entry_eval_symbols = {"NFO:NIFTY26JUN24000CE"}
+    runner._entry_eval_executor = None
+    runner._runtime_readiness_recompute_callback = None
+    runner._last_eval_ts = {}
+    runner._last_periodic_eval_at_by_symbol = {}
+    runner.start = lambda: None
+
+    scheduled: list[bool] = []
+    runner._schedule_entry_eval_drain = lambda: (scheduled.append(True), True)[1]
+
+    runner._recover_strategy_eval_stall_once(time.monotonic())
+
+    assert scheduled == [True], "stranded pending drain was not rescheduled"
+    payload = runner._logger.warning.call_args[1]["extra"]
+    assert payload["event"] == "STRATEGY_EVAL_STALL_WORKER_STATE"
+    assert payload["start_was_noop"] is True
+    assert payload["drain_rescheduled"] is True
+    assert payload["pending_entry_eval"] == ["NFO:NIFTY26JUN24000CE"]
+
+
+def test_recovery_does_not_reschedule_when_a_drain_is_already_active() -> None:
+    """No duplicate drain when one is already running."""
+    runner = StrategyRunner.__new__(StrategyRunner)
+    runner._logger = MagicMock()
+    runner._eval_gate_lock = threading.Lock()
+    runner._last_global_eval_ts = time.monotonic() - 120.0
+    runner._running = True
+    runner._entry_eval_shutdown = False
+    runner._entry_eval_active = True          # already draining
+    runner._entry_eval_drain_scheduled = False
+    runner._entry_eval_drain_count = 1
+    runner._runtime_loop_attached = True
+    runner._pending_entry_eval_symbols = {"NFO:NIFTY26JUN24000CE"}
+    runner._entry_eval_executor = None
+    runner._runtime_readiness_recompute_callback = None
+    runner._last_eval_ts = {}
+    runner._last_periodic_eval_at_by_symbol = {}
+    runner.start = lambda: None
+
+    scheduled: list[bool] = []
+    runner._schedule_entry_eval_drain = lambda: (scheduled.append(True), True)[1]
+
+    runner._recover_strategy_eval_stall_once(time.monotonic())
+
+    assert scheduled == []
+    assert runner._logger.warning.call_args[1]["extra"]["drain_rescheduled"] is False


### PR DESCRIPTION
**Audit P0/P1.** Draft — merge after clean CI.

## Defect 1 — the advertised restart never happened
Recovery logged `action=recompute_readiness_and_restart_loop` and called `self.start()`. **`start()` returns early while the runner is already running** — which it always is when a stall is detected. So the restart was a no-op.

Worse: the caller sets `_eval_stall_recovery_attempted=True` *before* invoking it, so the ineffective attempt **suppressed further recovery** for that stall episode. A recovery path that advertises a restart but performs none is worse than none, because it silences escalation.

Post-#918 the real evaluation mechanism is the coalesced entry-eval drain, not the runner loop. Recovery now nudges that — if symbols are pending with no drain active or scheduled, it reschedules one via the existing `_schedule_entry_eval_drain()`. `start()` is retained and its no-op outcome is now visible as `start_was_noop`.

## Defect 2 — blocking recovery work on the tick thread
The readiness-recompute fallback called `asyncio.run(result)` when no loop was running on the calling thread. This function runs inside `_health_watchdog` → `_on_tick_safe`, **i.e. on the market-data tick thread** — so it executed the recompute synchronously and blocked tick ingestion for its full duration. Same defect as the Telegram dispatch fixed in #928.

Now submits via `asyncio.run_coroutine_threadsafe()`; with no usable loop the coroutine is closed and `STRATEGY_EVAL_STALL_RECOMPUTE_SKIPPED reason=no_runtime_loop` is emitted. Tick thread never blocked, no coroutine left un-awaited.

## Instrumentation
`STRATEGY_EVAL_STALL_WORKER_STATE` captures worker state **before** any recovery action, so logs explain *why* evaluation stalled: `pending_entry_eval`, `drain_scheduled`, `drain_active`, `drain_count`, `runtime_loop_attached`, `executor_alive`, `shutdown`, plus `start_was_noop` and `drain_rescheduled`.

No stall threshold, throttle, readiness rule or safety gate changed.

## Tests (+6)
No `asyncio.run` on the recovery path; `start_was_noop` reported; real drain mechanism nudged; all worker-state fields captured; stranded pending drain rescheduled with expected telemetry; no duplicate drain when one is active.

## Validation (local, all exit 0)
`compileall -q src` · `git diff --check` clean · `tests/strategies` + `tests/core` + `tests/data` · `-m live_runtime_e2e` **3/3 clean** · **full suite 2156 passed**.

Production LOC: **+71 / −6**, one file.

## Still open from the audit
Broader watchdog/backfill inside the synchronous tick callback (`_hydrate_missing_bars`, history repair, stale-symbol recovery) is **not** moved here — only the recovery path's blocking recompute. Order-rejection `reason`/`trace_id`/`broker_attempted` and `event_loop_thread` telemetry remain untouched.