### PR TITLE
fix: preserve ORDER_REJECTED cause, trace ID and broker_attempted

### DIFF
--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -20034,13 +20034,34 @@ class StrategyRunner:
                         "reason": "no_order_submitted",
                     },
                 )
+                # Preserve the causal fields. This warning previously carried
+                # only the symbol, so a rejection could not be attributed to a
+                # safety gate, local validation, margin/sizing or an actual
+                # broker failure -- and could not be correlated with the
+                # matching RUNNER_ORDER_MANAGER_REJECTED record. All of
+                # submit_reason, submit_details, broker_attempted and trace_id
+                # are already in scope here; they were simply discarded.
+                # broker_attempted is the key discriminator: False means the
+                # order never reached the broker.
+                _reject_details = dict(submit_details or {})
                 log_throttled(
                     self._logger,
-                    f"runner_order_rejected_{base_symbol}",
-                    "ORDER_REJECTED by order_manager",
+                    f"runner_order_rejected_{base_symbol}_{submit_reason}",
+                    "ORDER_REJECTED by order_manager symbol=%s reason=%s "
+                    "broker_attempted=%s trace_id=%s"
+                    % (base_symbol, submit_reason, broker_attempted, trace_id),
                     interval_sec=300.0,
                     level=logging.WARNING,
-                    extra={"event": "ORDER_REJECTED", "symbol": base_symbol},
+                    extra={
+                        "event": "ORDER_REJECTED",
+                        "symbol": base_symbol,
+                        "order_symbol": order_symbol,
+                        "reason": submit_reason,
+                        "broker_attempted": broker_attempted,
+                        "trace_id": trace_id,
+                        "signal_id": getattr(signal, "signal_id", None),
+                        "details": _reject_details,
+                    },
                 )
                 self._reset_execution_state(base_symbol)
                 self._record_trade_decision_snapshot(

--- a/tests/strategies/test_order_rejected_observability.py
+++ b/tests/strategies/test_order_rejected_observability.py
@@ -1,0 +1,63 @@
+"""ORDER_REJECTED must preserve its causal fields.
+
+Post-#943 audit, P1. The warning carried only {"event", "symbol"}, so a
+rejection could not be attributed to a safety gate, local validation,
+margin/sizing or an actual broker failure, and could not be correlated with
+the matching RUNNER_ORDER_MANAGER_REJECTED record. Three ORDER_REJECTED
+events appeared in the 29 July session with no recoverable cause.
+
+submit_reason, submit_details, broker_attempted and trace_id were all already
+in scope at the emit site; they were simply discarded.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+from nifty_scalper_bot.strategies.runner import StrategyRunner
+
+
+def _emit_region() -> str:
+    """Source around the ORDER_REJECTED emit site."""
+    src = inspect.getsource(StrategyRunner)
+    marker = '"ORDER_REJECTED by order_manager'
+    assert marker in src, "ORDER_REJECTED emit site not found"
+    start = src.index(marker)
+    return src[start - 700 : start + 1400]
+
+
+def test_order_rejected_carries_reason() -> None:
+    """Without the reason a rejection class cannot be identified."""
+    region = _emit_region()
+    assert '"reason": submit_reason' in region
+
+
+def test_order_rejected_carries_broker_attempted() -> None:
+    """THE KEY DISCRIMINATOR: False means it never reached the broker."""
+    region = _emit_region()
+    assert '"broker_attempted": broker_attempted' in region
+
+
+def test_order_rejected_carries_trace_id_for_correlation() -> None:
+    """Needed to join with RUNNER_ORDER_MANAGER_REJECTED."""
+    region = _emit_region()
+    assert '"trace_id": trace_id' in region
+
+
+def test_order_rejected_carries_structured_details() -> None:
+    """Margin/sizing and kill-switch payloads must survive."""
+    region = _emit_region()
+    assert '"details": _reject_details' in region
+
+
+def test_order_rejected_throttle_key_is_reason_scoped() -> None:
+    """A 300s throttle keyed only on symbol hid distinct later causes."""
+    region = _emit_region()
+    assert 'f"runner_order_rejected_{base_symbol}_{submit_reason}"' in region
+
+
+def test_order_rejected_still_identifies_both_symbols() -> None:
+    """Underlying and the actual order symbol are both retained."""
+    region = _emit_region()
+    assert '"symbol": base_symbol' in region
+    assert '"order_symbol": order_symbol' in region


### PR DESCRIPTION
**Audit P1.** Draft — merge after clean CI.

## Root cause
The warning carried only `{"event", "symbol"}`:
```python
extra={"event": "ORDER_REJECTED", "symbol": base_symbol}
```
So a rejection couldn't be attributed to a safety gate, local validation, margin/sizing or a genuine broker failure — and couldn't be correlated with the matching `RUNNER_ORDER_MANAGER_REJECTED` record. Three `ORDER_REJECTED` events in the 29 July session had **no recoverable cause**.

`submit_reason`, `submit_details`, `broker_attempted` and `trace_id` were **all already in scope** at the emit site. They were simply discarded.

## A second defect found while fixing it
The throttle key was `f"runner_order_rejected_{base_symbol}"`. With a 300 s interval, the **first** rejection cause for a symbol suppressed every later rejection of that symbol *regardless of a different cause* — so distinct failure modes were hidden behind an unrelated earlier one. That likely means the three logged rejections under-count what actually happened.

## Fix (observability only)
Now carries `reason`, `broker_attempted`, `trace_id`, `signal_id`, `order_symbol` and the structured `details` payload, with reason/broker_attempted/trace_id in the message line too. **`broker_attempted` is the key discriminator** — `False` means the order never reached the broker, separating local/safety rejections from real broker failures.

Throttle key is now scoped by reason as well as symbol; the 300 s interval is unchanged.

No gating, sizing, ordering, retry or safety behaviour changed — this only stops discarding already-computed fields.

## Tests (+6)
All four causal fields carried; throttle key reason-scoped; both symbols retained. Fails against pre-fix code.

## Validation (local, all exit 0)
`compileall -q src` · `git diff --check` clean · `tests/strategies` + `tests/execution` · `-m live_runtime_e2e` **3/3 clean** · **full suite 2162 passed**.

Production LOC: **+26 / −7**, one file.

## Remaining from the audit
Broader watchdog/backfill inside the synchronous tick callback (`_hydrate_missing_bars`, history repair, stale-symbol recovery), and `event_loop_thread` telemetry initialization.