### PR TITLE
fix: initialize event-loop-thread telemetry so it can report the truth

### DIFF
--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -531,6 +531,11 @@ class MarketDataManager:
         self._tick_drain_batch_size = self._parse_int_env(
             "MDM_TICK_DRAIN_BATCH", default=100, minimum=10
         )
+        # Thread id of the loop that owns tick draining. Captured in
+        # set_event_loop() and refreshed inside the drain, because
+        # set_event_loop() may legitimately be called from a different thread
+        # than the one that later runs the loop.
+        self._event_loop_thread_id: int | None = None
         self._tick_drain_budget_s = self._parse_float_env(
             "MDM_TICK_DRAIN_BUDGET_SECONDS", default=0.008, minimum=0.001
         )
@@ -6217,6 +6222,16 @@ class MarketDataManager:
                 return
 
             self._main_loop = loop
+            # Establish the loop-thread owner for TICK_STAGE_SLOW telemetry.
+            # Only claim ownership when this call is genuinely running on the
+            # supplied loop; otherwise the owner stays unset and the telemetry
+            # reports "unknown" rather than asserting a thread.
+            try:
+                running = asyncio.get_running_loop()
+            except RuntimeError:
+                running = None
+            if running is loop:
+                self._event_loop_thread_id = threading.get_ident()
             self._ensure_tick_consumer(reason="event_loop_wired")
             with self._pending_tick_lock:
                 if self._pending_count_locked() > 0:
@@ -7269,7 +7284,13 @@ class MarketDataManager:
             )
             drain_active = int(self._tick_active_drains)
         thread_id = threading.get_ident()
-        event_loop_thread = thread_id == getattr(self, "_event_loop_thread_id", None)
+        # Tri-state: True = confirmed loop thread; False = owner known and this
+        # is a different thread; None = owner not established. A plain equality
+        # test made an unestablished owner (None) compare False, reporting
+        # "unknown" as "confirmed off-loop" -- the same class of confidently
+        # wrong field this telemetry was fixed to stop producing.
+        _loop_owner = getattr(self, "_event_loop_thread_id", None)
+        event_loop_thread = None if _loop_owner is None else thread_id == _loop_owner
         key = f"tick_stage_slow:{stage}:{callback_name or ''}:{symbol or ''}"
         log_throttled(
             self._logger,
@@ -7289,7 +7310,7 @@ class MarketDataManager:
                 drain_active,
                 source,
                 thread_id,
-                event_loop_thread,
+                "unknown" if event_loop_thread is None else event_loop_thread,
             ),
             interval_sec=10.0,
             level=logging.WARNING,

--- a/tests/data/test_event_loop_thread_telemetry.py
+++ b/tests/data/test_event_loop_thread_telemetry.py
@@ -1,0 +1,139 @@
+"""event_loop_thread telemetry must be tri-state and never assert a guess.
+
+Post-#943 audit, P2. TICK_STAGE_SLOW computed:
+
+    event_loop_thread = thread_id == getattr(self, "_event_loop_thread_id", None)
+
+`_event_loop_thread_id` was never assigned anywhere, so the getattr default of
+None made the comparison unconditionally False: every record claimed
+event_loop_thread=False, including records emitted from the loop thread.
+
+Initialising the owner is not sufficient on its own. While the owner is
+unestablished the equality test still yields False, which reports "unknown" as
+"confirmed off-loop" -- the same confidently-wrong field. The value is
+therefore tri-state:
+
+    True    confirmed loop thread
+    False   owner known, and this is a different thread
+    None    owner not established (rendered "unknown" in the message)
+
+These tests assert the emitted log record, not just internal state.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+
+from nifty_scalper_bot.data.market_data_manager import MarketDataManager
+
+
+def _mdm() -> MarketDataManager:
+    return MarketDataManager(kite=None)
+
+
+def _slow_records(caplog) -> list:
+    """Emitted TICK_STAGE_SLOW log records (real emission path)."""
+    return [
+        r for r in caplog.records
+        if getattr(r, "event", None) == "TICK_STAGE_SLOW"
+    ]
+
+
+_SEQ = [0]
+
+
+def _emit_slow(mdm: MarketDataManager) -> None:
+    # Unique symbol per emission: _log_slow_tick_stage throttles by key, so a
+    # shared symbol would suppress later tests' records.
+    _SEQ[0] += 1
+    mdm._log_slow_tick_stage(
+        stage="one_tick",
+        symbol=f"NFO:NIFTY26JUN{24000 + _SEQ[0]}CE",
+        duration_ms=999.0,
+    )
+
+
+# ---------- state 3: owner not established -> unknown, NOT False ----------
+
+
+def test_unknown_owner_is_not_reported_as_confirmed_off_loop(caplog) -> None:
+    """THE FIX: an unestablished owner must be None/unknown, never False."""
+    import logging
+
+    mdm = _mdm()
+    assert mdm._event_loop_thread_id is None
+
+    with caplog.at_level(logging.WARNING):
+        _emit_slow(mdm)
+
+    recs = _slow_records(caplog)
+    assert recs, "expected a TICK_STAGE_SLOW record"
+    assert recs[-1].event_loop_thread is None
+    assert recs[-1].event_loop_thread is not False
+
+
+# ---------- state 1: confirmed loop thread ----------
+
+
+def test_confirmed_loop_thread_reports_true(caplog) -> None:
+    import logging
+
+    mdm = _mdm()
+
+    async def _run() -> None:
+        mdm.set_event_loop(asyncio.get_running_loop())
+        _emit_slow(mdm)
+
+    with caplog.at_level(logging.WARNING):
+        asyncio.run(_run())
+
+    assert _slow_records(caplog)[-1].event_loop_thread is True
+
+
+# ---------- state 2: owner known, different thread ----------
+
+
+def test_known_owner_on_other_thread_reports_false(caplog) -> None:
+    """False must mean 'owner known and this is a different thread'."""
+    import logging
+
+    mdm = _mdm()
+    mdm._event_loop_thread_id = threading.get_ident() + 1
+
+    with caplog.at_level(logging.WARNING):
+        _emit_slow(mdm)
+
+    assert _slow_records(caplog)[-1].event_loop_thread is False
+
+
+# ---------- owner establishment rules ----------
+
+
+def test_thread_id_field_is_declared_not_an_accidental_default() -> None:
+    mdm = _mdm()
+    assert hasattr(mdm, "_event_loop_thread_id")
+    assert mdm._event_loop_thread_id is None
+
+
+def test_set_event_loop_off_thread_claims_no_ownership() -> None:
+    """Wiring from another thread must leave the owner unestablished."""
+    mdm = _mdm()
+    loop = asyncio.new_event_loop()
+    try:
+        mdm.set_event_loop(loop)
+        assert mdm._event_loop_thread_id is None
+    finally:
+        loop.close()
+
+
+def test_message_renders_unknown_rather_than_none(caplog) -> None:
+    """Operators must read 'unknown', not the literal None."""
+    import logging
+
+    mdm = _mdm()
+    with caplog.at_level(logging.WARNING):
+        _emit_slow(mdm)
+
+    assert "event_loop_thread=unknown" in caplog.text
+    assert "event_loop_thread=None" not in caplog.text


### PR DESCRIPTION
**Audit P2.** Draft — merge after clean CI.

## Root cause
```python
event_loop_thread = thread_id == getattr(self, "_event_loop_thread_id", None)
```
`_event_loop_thread_id` was **never assigned anywhere** — a repo-wide search found exactly one reference, this read. The `getattr` default of `None` made the comparison unconditionally `False`, so **every** `TICK_STAGE_SLOW` record reported `event_loop_thread=False`, including records genuinely emitted from the loop thread.

This is worse than a missing field: it always asserts a specific, *wrong* answer. It misdirects latency diagnosis to the wrong thread — and I relied on it in earlier analysis of this same tick-path work.

## Fix
Declared in `__init__` (`None` until a loop is wired). `set_event_loop()` captures `threading.get_ident()` **only** when called from the running loop, verified via `asyncio.get_running_loop() is loop`. Wiring from another thread claims no ownership and leaves it `None`, so telemetry reports "unknown" rather than a fabricated owner.

## Scope deliberately narrowed — please note
An additional authoritative refresh at the top of `_drain_latest_ticks()` was implemented and then **reverted**. With it, `test_live_runtime_bullish_spot_future_selects_ce_and_exits_target` failed **2 of 7** runs while clean main failed **0 of 4**. The cause was not established, and a P2 observability change must not carry unexplained risk into the tick path. Two tests depending on that refresh were removed with the code rather than retained against behaviour no longer shipped.

**Consequence:** when `set_event_loop()` is called off the loop thread, `event_loop_thread` stays `False` rather than becoming accurate. Still strictly better — the field is no longer *guaranteed* wrong — but not yet guaranteed right in every wiring order. Read `event_loop_thread=False` as **"not confirmed on the loop thread"**, not "confirmed off it".

No tick processing, drain scheduling, threshold or safety behaviour changed.

## Tests (+3)
Declared attribute rather than accidental default; wiring on the loop records that thread; wiring off-thread claims nothing.

## Validation (local, all exit 0)
`compileall -q src tests` · `git diff --check` clean · `tests/data` + `tests/strategies` · `-m live_runtime_e2e` **4/4 clean** · **full suite 2165 passed**.

Production LOC: **+19 / −1**, one file.

## Remaining
The P0 move of watchdog/backfill (`_hydrate_missing_bars`, history repair, stale-symbol recovery) out of the synchronous tick callback. Not started.