### PR TITLE
fix: run the health watchdog on cadence instead of once per tick

### DIFF
--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -1162,6 +1162,15 @@ class StrategyRunner:
         self._last_ws_stale_log_ts_by_symbol: dict[str, float] = defaultdict(float)
         self._last_ws_reconnect_attempt_ts: float = 0.0
         self._last_stall_warn_ts: float = 0.0  # throttle stall warnings to 30s
+        # Health-watchdog cadence: the scan was previously executed for every
+        # accepted tick on the tick thread.
+        self._health_watchdog_lock = threading.Lock()
+        self._health_watchdog_last_run: float = 0.0
+        self._health_watchdog_running: bool = False
+        self._health_watchdog_skipped: int = 0
+        self._health_watchdog_interval_s: float = parse_float_env(
+            "HEALTH_WATCHDOG_INTERVAL_SECONDS", 5.0
+        )
         # Compatibility mirror of authoritative MDM CandleEngine objects only.
         # StrategyRunner must never instantiate or mutate separate engines.
         self._candle_engines: dict[str, Any] = {}
@@ -7858,7 +7867,7 @@ class StrategyRunner:
                             "stall_sec": round(now_mono - self._last_global_eval_ts, 1),
                         },
                     )
-            self._health_watchdog()
+            self._run_health_watchdog_on_cadence()
             self._logger.debug(
                 "PIPELINE_OK",
                 extra={"symbol": normalized_symbol, "state": str(self._runner_state)},
@@ -8354,6 +8363,62 @@ class StrategyRunner:
         # was ingested, so _on_tick must not run it a second time.
         tick_payload["_protection_already_handled"] = True
         self._on_tick(symbol, tick_payload)
+
+    def _run_health_watchdog_on_cadence(self) -> None:
+        """Run the health watchdog at most once per interval, not per tick.
+
+        _health_watchdog() was invoked for EVERY accepted tick from inside
+        _on_tick_safe, i.e. synchronously on the market-data tick thread. It
+        scans all active symbols and can perform bar hydration, historical
+        repair, MDM history ingestion and stale-symbol recovery assessment,
+        which produced indivisible 176-1,088 ms tick callbacks. The tick drain
+        budget cannot pre-empt that: it is only checked BETWEEN processed ticks,
+        never inside one callback.
+
+        Gating by cadence makes health scanning independent of tick frequency,
+        so one scan happens per interval instead of one per tick. Overlap is
+        prevented so a long scan cannot re-enter from a subsequent tick.
+
+        SCOPE: this reduces how OFTEN the scan runs; it does not yet move the
+        scan off the tick thread. Relocating the blocking history/hydration work
+        to the asynchronous control path is the remaining part of that
+        correction and is deliberately not attempted here.
+        Args: none. Returns: none. Raises: none.
+        """
+        now = time.monotonic()
+        interval = self._health_watchdog_interval_s
+        with self._health_watchdog_lock:
+            if self._health_watchdog_running:
+                self._health_watchdog_skipped += 1
+                return
+            if (now - self._health_watchdog_last_run) < interval:
+                self._health_watchdog_skipped += 1
+                return
+            self._health_watchdog_running = True
+            self._health_watchdog_last_run = now
+        try:
+            self._health_watchdog()
+        finally:
+            duration_ms = (time.monotonic() - now) * 1000.0
+            with self._health_watchdog_lock:
+                self._health_watchdog_running = False
+                skipped = self._health_watchdog_skipped
+                self._health_watchdog_skipped = 0
+            if duration_ms >= 100.0:
+                log_throttled(
+                    self._logger,
+                    "health_watchdog_slow",
+                    "HEALTH_WATCHDOG_SLOW duration_ms=%.1f ticks_skipped=%d interval_s=%.1f"
+                    % (duration_ms, skipped, interval),
+                    interval_sec=60.0,
+                    level=logging.WARNING,
+                    extra={
+                        "event": "HEALTH_WATCHDOG_SLOW",
+                        "duration_ms": round(duration_ms, 1),
+                        "ticks_skipped": skipped,
+                        "interval_s": interval,
+                    },
+                )
 
     def _health_watchdog(self) -> None:
         """Args: none; Returns: none; Raises: none."""

--- a/tests/strategies/test_health_watchdog_cadence.py
+++ b/tests/strategies/test_health_watchdog_cadence.py
@@ -1,0 +1,139 @@
+"""Health scans must run on cadence, not once per tick.
+
+Post-#943 audit, section 4.2. _health_watchdog() was invoked for EVERY accepted
+tick from inside _on_tick_safe, i.e. synchronously on the market-data tick
+thread. It scans all active symbols and can perform bar hydration, historical
+repair, MDM history ingestion and stale-symbol recovery assessment, producing
+indivisible 176-1,088 ms tick callbacks.
+
+The tick drain budget cannot pre-empt that: it is only checked BETWEEN
+processed ticks, never inside a single callback.
+
+Audit acceptance criterion covered here: "Health scans occur on configured
+cadence, independent of tick frequency." Relocating the blocking history work
+to the asynchronous control path is the remaining part of that correction and
+is NOT covered by these tests.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from unittest.mock import MagicMock
+
+from nifty_scalper_bot.strategies.runner import StrategyRunner
+
+
+def _runner(interval: float = 5.0) -> StrategyRunner:
+    r = StrategyRunner.__new__(StrategyRunner)
+    r._logger = MagicMock()
+    r._health_watchdog_lock = threading.Lock()
+    r._health_watchdog_last_run = 0.0
+    r._health_watchdog_running = False
+    r._health_watchdog_skipped = 0
+    r._health_watchdog_interval_s = interval
+    return r
+
+
+def test_many_ticks_in_one_interval_produce_one_scan() -> None:
+    """AUDIT TDD CASE 2: many ticks must not cause many full scans."""
+    r = _runner(interval=60.0)
+    calls: list[int] = []
+    r._health_watchdog = lambda: calls.append(1)
+
+    for _ in range(50):
+        r._run_health_watchdog_on_cadence()
+
+    assert len(calls) == 1, f"expected one scan per interval, got {len(calls)}"
+
+
+def test_scan_runs_again_after_the_interval_elapses() -> None:
+    """Cadence must not become a permanent suppression."""
+    r = _runner(interval=0.05)
+    calls: list[int] = []
+    r._health_watchdog = lambda: calls.append(1)
+
+    r._run_health_watchdog_on_cadence()
+    time.sleep(0.06)
+    r._run_health_watchdog_on_cadence()
+
+    assert len(calls) == 2
+
+
+def test_overlapping_invocation_is_refused() -> None:
+    """A long scan must not be re-entered by a subsequent tick."""
+    r = _runner(interval=0.0)
+    entered = threading.Event()
+    release = threading.Event()
+    calls: list[int] = []
+
+    def _slow() -> None:
+        calls.append(1)
+        entered.set()
+        release.wait(timeout=2.0)
+
+    r._health_watchdog = _slow
+
+    t = threading.Thread(target=r._run_health_watchdog_on_cadence)
+    t.start()
+    assert entered.wait(timeout=2.0)
+
+    # A second tick arrives while the first scan is still running.
+    r._run_health_watchdog_on_cadence()
+    assert len(calls) == 1, "overlapping scan was not refused"
+
+    release.set()
+    t.join(timeout=2.0)
+
+
+def test_running_flag_is_cleared_even_when_the_scan_raises() -> None:
+    """A failed scan must not permanently wedge health scanning."""
+    r = _runner(interval=0.0)
+
+    def _boom() -> None:
+        raise RuntimeError("scan failed")
+
+    r._health_watchdog = _boom
+
+    try:
+        r._run_health_watchdog_on_cadence()
+    except RuntimeError:
+        pass
+
+    assert r._health_watchdog_running is False
+
+    calls: list[int] = []
+    r._health_watchdog = lambda: calls.append(1)
+    r._run_health_watchdog_on_cadence()
+    assert calls == [1]
+
+
+def test_skipped_tick_count_is_reported_for_slow_scans(caplog) -> None:
+    """Operators need to see how many ticks a slow scan displaced."""
+    import logging
+
+    r = _runner(interval=0.0)
+
+    def _slow() -> None:
+        time.sleep(0.12)
+
+    r._health_watchdog = _slow
+    with caplog.at_level(logging.WARNING):
+        r._run_health_watchdog_on_cadence()
+
+    recs = [
+        rec for rec in caplog.records
+        if getattr(rec, "event", None) == "HEALTH_WATCHDOG_SLOW"
+    ]
+    assert recs, "slow scan was not reported"
+    assert recs[-1].duration_ms >= 100.0
+    assert hasattr(recs[-1], "ticks_skipped")
+
+
+def test_tick_path_calls_the_cadence_wrapper_not_the_scan_directly() -> None:
+    """_on_tick_safe must not invoke the full scan per tick."""
+    import inspect
+
+    src = inspect.getsource(StrategyRunner._on_tick_safe)
+    assert "_run_health_watchdog_on_cadence()" in src
+    assert "self._health_watchdog()" not in src


### PR DESCRIPTION
**Audit section 4.2, items 1 and 2.** Draft — merge after clean CI. **Partial by design; scope stated below.**

## Root cause
`_health_watchdog()` ran for **every accepted tick**, synchronously on the market-data tick thread:
```
tick drain -> MDM._emit_tick -> DataHub.ingest_tick_sync
  -> runner subscriber -> _on_tick_safe -> _health_watchdog()
```
It scans all active symbols and can perform bar hydration, historical repair, MDM history ingestion and stale-symbol recovery — producing indivisible **176–1,088 ms** tick callbacks. The drain budget cannot pre-empt them: it's checked **between** ticks, never inside one callback. That's precisely why #927's budget fix couldn't touch this class.

## Fix
`_run_health_watchdog_on_cadence()` replaces the per-tick call:
- at most one scan per `HEALTH_WATCHDOG_INTERVAL_SECONDS` (default 5.0) — health scanning now independent of tick frequency
- refuses overlapping entry, so a long scan can't be re-entered by a later tick
- clears its running flag in `finally`, so a raising scan can't permanently wedge scanning
- `HEALTH_WATCHDOG_SLOW` reports `duration_ms` and how many ticks' scans were skipped

At realistic option tick rates this turns hundreds of full scans per minute into roughly twelve, removing most stall opportunities without changing what the scan does.

## Scope — partial, deliberately
Implements items **1 and 2**. It reduces how *often* the blocking work runs; it does **not** move that work off the tick thread. Still outstanding from 4.2:

3. prohibit synchronous broker history calls / bar hydration from DataHub subscribers
4. route missing-bar repair through the async canonical history-ensure mechanism
5. coalesce recovery by symbol **and generation**
7. time each DataHub subscriber independently

Item 6 (ordered lightweight position protection in the sync path) is already satisfied and unchanged.

So the acceptance criteria *"no synchronous history/backfill/recovery I/O from DataHub subscribers"* and *"a slow recovery call does not increase tick callback duration"* are **not yet met** — a scan that does run still runs inline. The criterion met here is *"health scans occur on configured cadence, independent of tick frequency."*

No watchdog logic, threshold, readiness rule, safety gate, protection ordering or trading behaviour changed.

## Tests (+6)
Audit TDD case 2 (50 ticks → exactly one scan); resumes after the interval; overlap refused; running flag cleared when the scan raises and scanning recovers; slow scans report duration and skipped count; `_on_tick_safe` no longer calls the scan directly.

## Validation (local, all exit 0)
`compileall -q src tests` · `git diff --check` clean · `tests/strategies` + `tests/data` + `tests/execution` · `-m live_runtime_e2e` **5/5 clean** · **full suite 2174 passed**.

Production LOC: **+62 / −1**, one file.