### PR TITLE
Fix trade-path state integrity and latency blockers

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -9892,11 +9892,30 @@ def _commit_active_dynamic_basket(
         candidates.sort(key=lambda item: (item[0], item[1]))
         return candidates[0][1]
 
-    if not (selected_ce and selected_ce.endswith("CE") and selected_ce in active_set):
+    def _selected_matches_atm(symbol: str | None, side: str) -> bool:
+        if not (symbol and symbol.endswith(side) and symbol in active_set):
+            return False
+        if atm_strike is None:
+            return True
+        from nifty_scalper_bot.core.active_basket import extract_symbol_strike
+
+        selected_strike = extract_symbol_strike(symbol)
+        return (
+            selected_strike is not None
+            and float(selected_strike) == float(atm_strike)
+        )
+
+    if not _selected_matches_atm(selected_ce, "CE"):
         repaired_ce = _nearest_for_side("CE")
+        if (
+            repaired_ce
+            and atm_strike is not None
+            and not _selected_matches_atm(repaired_ce, "CE")
+        ):
+            repaired_ce = None
         if selected_ce and repaired_ce and selected_ce != repaired_ce:
             LOGGER.warning(
-                "BASKET_SELECTED_PAIR_REPAIRED side=CE previous_selected=%s repaired_selected=%s atm_strike=%s reason=selected_pair_not_in_option_symbols",
+                "BASKET_SELECTED_PAIR_REPAIRED side=CE previous_selected=%s repaired_selected=%s atm_strike=%s reason=selected_pair_not_atm",
                 selected_ce,
                 repaired_ce,
                 atm_strike,
@@ -9906,15 +9925,21 @@ def _commit_active_dynamic_basket(
                     "previous_selected": selected_ce,
                     "repaired_selected": repaired_ce,
                     "atm_strike": atm_strike,
-                    "reason": "selected_pair_not_in_option_symbols",
+                    "reason": "selected_pair_not_atm",
                 },
             )
         selected_ce = repaired_ce
-    if not (selected_pe and selected_pe.endswith("PE") and selected_pe in active_set):
+    if not _selected_matches_atm(selected_pe, "PE"):
         repaired_pe = _nearest_for_side("PE")
+        if (
+            repaired_pe
+            and atm_strike is not None
+            and not _selected_matches_atm(repaired_pe, "PE")
+        ):
+            repaired_pe = None
         if selected_pe and repaired_pe and selected_pe != repaired_pe:
             LOGGER.warning(
-                "BASKET_SELECTED_PAIR_REPAIRED side=PE previous_selected=%s repaired_selected=%s atm_strike=%s reason=selected_pair_not_in_option_symbols",
+                "BASKET_SELECTED_PAIR_REPAIRED side=PE previous_selected=%s repaired_selected=%s atm_strike=%s reason=selected_pair_not_atm",
                 selected_pe,
                 repaired_pe,
                 atm_strike,
@@ -9924,15 +9949,25 @@ def _commit_active_dynamic_basket(
                     "previous_selected": selected_pe,
                     "repaired_selected": repaired_pe,
                     "atm_strike": atm_strike,
-                    "reason": "selected_pair_not_in_option_symbols",
+                    "reason": "selected_pair_not_atm",
                 },
             )
         selected_pe = repaired_pe
     old_ce = getattr(ctx, "selected_ce", None)
     old_pe = getattr(ctx, "selected_pe", None)
-    if not selected_ce and old_ce in active_set and str(old_ce).endswith("CE"):
+    if (
+        atm_strike is None
+        and not selected_ce
+        and old_ce in active_set
+        and str(old_ce).endswith("CE")
+    ):
         selected_ce = old_ce
-    if not selected_pe and old_pe in active_set and str(old_pe).endswith("PE"):
+    if (
+        atm_strike is None
+        and not selected_pe
+        and old_pe in active_set
+        and str(old_pe).endswith("PE")
+    ):
         selected_pe = old_pe
     if current_options and (not selected_ce or not selected_pe):
         LOGGER.warning(
@@ -12809,22 +12844,24 @@ async def startup_sequence(ctx: BotContext) -> None:
 
                         # --- Objective 7: Auto ATM Resubscription via InstrumentManager ---
                         _im = ctx.instrument_manager
+                        fresh_dynamic_basket: dict[str, object] | None = None
                         if spot and spot > 0 and _im and _im.is_loaded():
-                            target_tokens = _im.select_tokens_for_universe(
-                                base="NIFTY",
-                                spot_price=float(spot),
-                                strikes_around_atm=3,
-                                strike_step=ctx.settings.option_universe.strike_step,
+                            fresh_dynamic_basket = asdict(
+                                _im.get_active_nifty_contracts(
+                                    float(spot),
+                                    strikes_around_atm=3,
+                                    strike_step=ctx.settings.option_universe.strike_step,
+                                    include_future=True,
+                                )
                             )
-                            latest_symbols = set()
-                            for t in target_tokens:
-                                s = _im.get_symbol(t)
-                                if s:
-                                    qualified = (
-                                        f"NFO:{s}" if not s.startswith("NFO:") else s
-                                    )
-                                    if qualified.startswith("NFO:NIFTY"):
-                                        latest_symbols.add(qualified)
+                            latest_symbols = {
+                                str(symbol)
+                                for symbol in fresh_dynamic_basket.get(
+                                    "option_symbols", ()
+                                )
+                                if str(symbol).startswith("NFO:NIFTY")
+                                and str(symbol).endswith(("CE", "PE"))
+                            }
                         else:
                             latest_symbols = set(
                                 ctx.option_universe.get_current_universe()
@@ -13083,31 +13120,31 @@ async def startup_sequence(ctx: BotContext) -> None:
                         # where each option sits in the live lifecycle.
                         if add_symbols or drop_symbols:
                             try:
+                                commit_basket = fresh_dynamic_basket or cast(
+                                    dict[str, object],
+                                    getattr(ctx, "active_trading_universe", {}) or {},
+                                )
                                 basket_symbols = [
                                     str(sym)
                                     for sym in dict.fromkeys(
-                                        ["NSE:NIFTY", *sorted(latest_symbols)]
+                                        commit_basket.get("all_symbols")
+                                        or [
+                                            "NSE:NIFTY",
+                                            *sorted(latest_symbols),
+                                        ]
                                     )
                                 ]
+                                commit_atm_strike = cast(
+                                    int | float | str | None,
+                                    commit_basket.get("atm_strike"),
+                                )
                                 committed_ce, committed_pe = (
                                     _commit_active_dynamic_basket(
                                         ctx,
-                                        basket=cast(
-                                            Mapping[str, object],
-                                            getattr(ctx, "active_trading_universe", {})
-                                            or {},
-                                        ),
+                                        basket=commit_basket,
                                         option_symbols=sorted(latest_symbols),
                                         symbols=basket_symbols,
-                                        atm_strike=cast(
-                                            int | float | str | None,
-                                            (
-                                                getattr(
-                                                    ctx, "active_trading_universe", {}
-                                                )
-                                                or {}
-                                            ).get("atm_strike"),
-                                        ),
+                                        atm_strike=commit_atm_strike,
                                     )
                                 )
                                 for _sym in add_symbols:

--- a/src/nifty_scalper_bot/data/candle_engine.py
+++ b/src/nifty_scalper_bot/data/candle_engine.py
@@ -443,6 +443,28 @@ class CandleEngine:
         symbol = self.symbol or "symbol_unset"
         try:
             incoming = _normalize_history_frame(frame, symbol=symbol)
+            if incoming and source in _HISTORY_RECONCILABLE_SOURCES:
+                current_exchange_minute = pd.Timestamp.now(tz=IST).floor("min")
+                completed_incoming = [
+                    row
+                    for row in incoming
+                    if _to_ist_timestamp(row["timestamp"]) < current_exchange_minute
+                ]
+                deferred_count = len(incoming) - len(completed_incoming)
+                if deferred_count:
+                    LOGGER.info(
+                        "HISTORY_CURRENT_MINUTE_DEFERRED",
+                        extra={
+                            "event": "HISTORY_CURRENT_MINUTE_DEFERRED",
+                            "symbol": symbol,
+                            "source": source,
+                            "current_exchange_minute": (
+                                current_exchange_minute.isoformat()
+                            ),
+                            "deferred_rows": deferred_count,
+                        },
+                    )
+                incoming = completed_incoming
             candidate = list(incoming)
             idempotent = 0
             reconciled = 0

--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -464,6 +464,9 @@ class MarketDataManager:
         self._volume_baseline_by_identity: dict[
             tuple[str, int | None, int, int], dict[str, Any]
         ] = {}
+        self._volume_rebaseline_candidate_by_identity: dict[
+            tuple[str, int | None, int, int], dict[str, Any]
+        ] = {}
         self._volume_delta_clamp_stats: dict[str, dict[str, float]] = {}
         self._last_volume_delta_clamp_summary_ts: dict[str, float] = {}
         self._last_tick_snapshot: dict[str, dict[str, Any]] = {}
@@ -8337,6 +8340,7 @@ class MarketDataManager:
                 "timestamp": incoming_ts,
                 "sequence": incoming_sequence,
             }
+            self._volume_rebaseline_candidate_by_identity.pop(identity, None)
         elif (
             incoming_sequence is not None
             and previous_sequence is not None
@@ -8373,6 +8377,7 @@ class MarketDataManager:
                     "timestamp": incoming_ts,
                     "sequence": incoming_sequence,
                 }
+                self._volume_rebaseline_candidate_by_identity.pop(identity, None)
             trusted = False
             transition["rollback_amount"] = rollback_abs
         else:
@@ -8387,6 +8392,59 @@ class MarketDataManager:
                 trusted = False
                 accepted = False
                 effective_delta = 0.0
+                rebaseline_candidates = getattr(
+                    self, "_volume_rebaseline_candidate_by_identity", None
+                )
+                if rebaseline_candidates is None:
+                    rebaseline_candidates = {}
+                    self._volume_rebaseline_candidate_by_identity = (
+                        rebaseline_candidates
+                    )
+                candidate = rebaseline_candidates.get(identity)
+                candidate_cumulative = (
+                    None
+                    if candidate is None
+                    else float(candidate.get("cumulative", 0.0))
+                )
+                candidate_ts = None if candidate is None else candidate.get("timestamp")
+                candidate_sequence = (
+                    None if candidate is None else candidate.get("sequence")
+                )
+                timestamp_confirms = (
+                    incoming_ts is None
+                    or candidate_ts is None
+                    or incoming_ts > candidate_ts
+                )
+                sequence_confirms = (
+                    incoming_sequence is None
+                    or candidate_sequence is None
+                    or int(incoming_sequence) > int(candidate_sequence)
+                )
+                candidate_delta = (
+                    None
+                    if candidate_cumulative is None
+                    else cumulative - candidate_cumulative
+                )
+                if (
+                    candidate_delta is not None
+                    and 0.0 <= candidate_delta <= max_delta
+                    and timestamp_confirms
+                    and sequence_confirms
+                ):
+                    self._volume_baseline_by_identity[identity] = {
+                        "cumulative": cumulative,
+                        "timestamp": incoming_ts,
+                        "sequence": incoming_sequence,
+                    }
+                    rebaseline_candidates.pop(identity, None)
+                    state = "suspicious_jump_rebased"
+                    reason = "monotonic_confirmation_without_jump_credit"
+                else:
+                    rebaseline_candidates[identity] = {
+                        "cumulative": cumulative,
+                        "timestamp": incoming_ts,
+                        "sequence": incoming_sequence,
+                    }
                 stats = self._volume_delta_clamp_stats.setdefault(
                     canonical, {"interval_count": 0.0, "interval_max_delta": 0.0}
                 )
@@ -8417,7 +8475,9 @@ class MarketDataManager:
                     )
                     stats["interval_count"] = 0.0
                     stats["interval_max_delta"] = 0.0
-                # Do not update baseline: the suspicious cumulative value is quarantined.
+                # The first suspicious value is quarantined. A later monotonic
+                # observation may establish a new baseline, but neither tick
+                # contributes the jump to candle volume.
             else:
                 effective_delta = max(0.0, raw_delta)
                 accepted = True
@@ -8432,6 +8492,9 @@ class MarketDataManager:
                     "timestamp": incoming_ts,
                     "sequence": incoming_sequence,
                 }
+                getattr(
+                    self, "_volume_rebaseline_candidate_by_identity", {}
+                ).pop(identity, None)
         self._last_cumulative_volume_by_symbol[canonical] = float(
             self._volume_baseline_by_identity.get(identity, {"cumulative": cumulative})[
                 "cumulative"

--- a/src/nifty_scalper_bot/execution/order_manager_core.py
+++ b/src/nifty_scalper_bot/execution/order_manager_core.py
@@ -915,7 +915,14 @@ class OrderManager:
         self._execution_policy: ExecutionPolicy | None = None
         self._options_policy = OptionsExecutionPolicy()
         self._risk_manager: RiskManager | None = None
-        self._signal_arbitrator = SignalArbitrator()
+        # Runner/risk owns the trading re-entry cooldown.  OrderManager keeps
+        # only the short submission/concurrency reservation; a second default
+        # 300-second cooldown here previously blocked otherwise eligible NIFTY
+        # entries after a position closed.
+        self._signal_arbitrator = SignalArbitrator(
+            cooldown_seconds=3.0,
+            reentry_cooldown_seconds=3.0,
+        )
         self._client_order_index: dict[str, str] = {}
         self._last_skip_reason: str | None = None
         self._margin_block_events: deque[float] = deque()

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -8365,7 +8365,7 @@ class StrategyRunner:
         self._on_tick(symbol, tick_payload)
 
     def _run_health_watchdog_on_cadence(self) -> None:
-        """Run the health watchdog at most once per interval, not per tick.
+        """Dispatch the health watchdog off-thread at most once per interval.
 
         _health_watchdog() was invoked for EVERY accepted tick from inside
         _on_tick_safe, i.e. synchronously on the market-data tick thread. It
@@ -8375,14 +8375,10 @@ class StrategyRunner:
         budget cannot pre-empt that: it is only checked BETWEEN processed ticks,
         never inside one callback.
 
-        Gating by cadence makes health scanning independent of tick frequency,
-        so one scan happens per interval instead of one per tick. Overlap is
-        prevented so a long scan cannot re-enter from a subsequent tick.
-
-        SCOPE: this reduces how OFTEN the scan runs; it does not yet move the
-        scan off the tick thread. Relocating the blocking history/hydration work
-        to the asynchronous control path is the remaining part of that
-        correction and is deliberately not attempted here.
+        Gating by cadence makes health scanning independent of tick frequency.
+        The accepted scan runs in the runtime executor so history/hydration
+        work cannot block either the synchronous tick callback or the event
+        loop that drains queued ticks. Overlap remains prohibited.
         Args: none. Returns: none. Raises: none.
         """
         now = time.monotonic()
@@ -8396,29 +8392,58 @@ class StrategyRunner:
                 return
             self._health_watchdog_running = True
             self._health_watchdog_last_run = now
+
+        def _run() -> None:
+            try:
+                self._health_watchdog()
+            except Exception:
+                self._logger.exception("HEALTH_WATCHDOG_FAILED")
+            finally:
+                duration_ms = (time.monotonic() - now) * 1000.0
+                with self._health_watchdog_lock:
+                    self._health_watchdog_running = False
+                    skipped = self._health_watchdog_skipped
+                    self._health_watchdog_skipped = 0
+                if duration_ms >= 100.0:
+                    log_throttled(
+                        self._logger,
+                        "health_watchdog_slow",
+                        "HEALTH_WATCHDOG_SLOW duration_ms=%.1f ticks_skipped=%d interval_s=%.1f"
+                        % (duration_ms, skipped, interval),
+                        interval_sec=60.0,
+                        level=logging.WARNING,
+                        extra={
+                            "event": "HEALTH_WATCHDOG_SLOW",
+                            "duration_ms": round(duration_ms, 1),
+                            "ticks_skipped": skipped,
+                            "interval_s": interval,
+                        },
+                    )
+
+        runtime_loop = self._main_loop
+        if (
+            runtime_loop is not None
+            and runtime_loop.is_running()
+            and not runtime_loop.is_closed()
+        ):
+            watchdog_coro = asyncio.to_thread(_run)
+            try:
+                asyncio.run_coroutine_threadsafe(
+                    watchdog_coro, runtime_loop
+                )
+                return
+            except RuntimeError:
+                watchdog_coro.close()
         try:
-            self._health_watchdog()
-        finally:
-            duration_ms = (time.monotonic() - now) * 1000.0
+            threading.Thread(
+                target=_run,
+                name="strategy-health-watchdog",
+                daemon=True,
+            ).start()
+        except Exception:
             with self._health_watchdog_lock:
                 self._health_watchdog_running = False
-                skipped = self._health_watchdog_skipped
-                self._health_watchdog_skipped = 0
-            if duration_ms >= 100.0:
-                log_throttled(
-                    self._logger,
-                    "health_watchdog_slow",
-                    "HEALTH_WATCHDOG_SLOW duration_ms=%.1f ticks_skipped=%d interval_s=%.1f"
-                    % (duration_ms, skipped, interval),
-                    interval_sec=60.0,
-                    level=logging.WARNING,
-                    extra={
-                        "event": "HEALTH_WATCHDOG_SLOW",
-                        "duration_ms": round(duration_ms, 1),
-                        "ticks_skipped": skipped,
-                        "interval_s": interval,
-                    },
-                )
+            self._logger.exception("HEALTH_WATCHDOG_DISPATCH_FAILED")
 
     def _health_watchdog(self) -> None:
         """Args: none; Returns: none; Raises: none."""

--- a/tests/data/test_candle_engine_history_import.py
+++ b/tests/data/test_candle_engine_history_import.py
@@ -289,3 +289,29 @@ def test_malformed_and_future_rows_still_rejected_during_reconcilable_import() -
             pd.DataFrame([_row(0, close=100.5), _row(0, close=100.9)]),
             source="historical",
         )
+
+
+def test_historical_import_does_not_finalize_current_exchange_minute() -> None:
+    engine = CandleEngine(symbol="NFO:T")
+    current_minute = pd.Timestamp.now(tz=IST).floor("min")
+    previous_minute = current_minute - pd.Timedelta(minutes=1)
+    rows = pd.DataFrame(
+        [
+            {**_row(0), "timestamp": previous_minute},
+            {**_row(1), "timestamp": current_minute},
+        ]
+    )
+
+    engine.import_history(rows, source="historical")
+
+    assert engine.latest_finalized_minute() == previous_minute
+    result = engine.on_tick(
+        {
+            "symbol": "NFO:T",
+            "timestamp": current_minute + pd.Timedelta(seconds=30),
+            "last_price": 101.0,
+            "volume": 1.0,
+        }
+    )
+    assert result is None
+    assert engine.get_current_candle()["timestamp"] == current_minute

--- a/tests/data/test_mdm_option_volume_semantics.py
+++ b/tests/data/test_mdm_option_volume_semantics.py
@@ -65,6 +65,23 @@ def test_option_volume_rollback_and_suspicious_jump_do_not_poison_candle_volume(
     assert after["volume"] == 50
 
 
+def test_option_volume_rebaselines_after_monotonic_confirmation_without_crediting_jump() -> None:
+    mdm = _mdm()
+    symbol = "NFO:NIFTY26JUN24000CE"
+    mdm._normalise_tick_volume_delta(symbol, _raw(1_000))
+
+    suspicious = mdm._normalise_tick_volume_delta(symbol, _raw(2_000_000, ts=2))
+    confirmed = mdm._normalise_tick_volume_delta(symbol, _raw(2_000_025, ts=3))
+    resumed = mdm._normalise_tick_volume_delta(symbol, _raw(2_000_050, ts=4))
+
+    assert suspicious["volume_transition"]["state"] == "suspicious_jump"
+    assert confirmed["volume_transition"]["state"] == "suspicious_jump_rebased"
+    assert confirmed["volume"] == 0
+    assert confirmed["volume_delta_untrusted"] is True
+    assert resumed["volume_transition"]["state"] == "accepted"
+    assert resumed["volume"] == 25
+
+
 def test_raw_cumulative_never_becomes_completed_candle_volume() -> None:
     mdm = _mdm()
     processed = [

--- a/tests/execution/test_order_manager_preflight.py
+++ b/tests/execution/test_order_manager_preflight.py
@@ -1,4 +1,5 @@
 from nifty_scalper_bot.execution.order_manager import OrderManager
+from nifty_scalper_bot.core import signal_arbitrator as arbitrator_module
 
 
 class _Broker: pass
@@ -14,3 +15,23 @@ def test_extract_quote_diagnostics_handles_malformed_fields():
     assert out['ask'] == 0.0
     assert out['ltp'] == 12.5
     assert out['bid_qty'] == 0
+
+
+def test_order_manager_arbitrator_does_not_add_five_minute_reentry_cooldown(
+    monkeypatch, tmp_path
+):
+    now = [1000.0]
+    monkeypatch.setattr(arbitrator_module.time, "time", lambda: now[0])
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    om = OrderManager(_Broker(), _Pos(), _Limiter())
+    ce = "NFO:NIFTY26AUG24250CE"
+    pe = "NFO:NIFTY26AUG24250PE"
+
+    assert om._signal_arbitrator.allow(ce, "BUY") is True
+    om._signal_arbitrator.register(ce, "BUY")
+    assert om._signal_arbitrator.allow(pe, "BUY") is False
+
+    om._signal_arbitrator.release(ce)
+    now[0] += 3.0
+
+    assert om._signal_arbitrator.allow(pe, "BUY") is True

--- a/tests/strategies/test_health_watchdog_cadence.py
+++ b/tests/strategies/test_health_watchdog_cadence.py
@@ -32,6 +32,7 @@ def _runner(interval: float = 5.0) -> StrategyRunner:
     r._health_watchdog_running = False
     r._health_watchdog_skipped = 0
     r._health_watchdog_interval_s = interval
+    r._main_loop = None
     return r
 
 
@@ -39,11 +40,18 @@ def test_many_ticks_in_one_interval_produce_one_scan() -> None:
     """AUDIT TDD CASE 2: many ticks must not cause many full scans."""
     r = _runner(interval=60.0)
     calls: list[int] = []
-    r._health_watchdog = lambda: calls.append(1)
+    done = threading.Event()
+
+    def _scan() -> None:
+        calls.append(1)
+        done.set()
+
+    r._health_watchdog = _scan
 
     for _ in range(50):
         r._run_health_watchdog_on_cadence()
 
+    assert done.wait(timeout=2.0)
     assert len(calls) == 1, f"expected one scan per interval, got {len(calls)}"
 
 
@@ -51,12 +59,21 @@ def test_scan_runs_again_after_the_interval_elapses() -> None:
     """Cadence must not become a permanent suppression."""
     r = _runner(interval=0.05)
     calls: list[int] = []
-    r._health_watchdog = lambda: calls.append(1)
+    done = threading.Event()
+
+    def _scan() -> None:
+        calls.append(1)
+        done.set()
+
+    r._health_watchdog = _scan
 
     r._run_health_watchdog_on_cadence()
+    assert done.wait(timeout=2.0)
     time.sleep(0.06)
+    done.clear()
     r._run_health_watchdog_on_cadence()
 
+    assert done.wait(timeout=2.0)
     assert len(calls) == 2
 
 
@@ -74,8 +91,7 @@ def test_overlapping_invocation_is_refused() -> None:
 
     r._health_watchdog = _slow
 
-    t = threading.Thread(target=r._run_health_watchdog_on_cadence)
-    t.start()
+    r._run_health_watchdog_on_cadence()
     assert entered.wait(timeout=2.0)
 
     # A second tick arrives while the first scan is still running.
@@ -83,7 +99,9 @@ def test_overlapping_invocation_is_refused() -> None:
     assert len(calls) == 1, "overlapping scan was not refused"
 
     release.set()
-    t.join(timeout=2.0)
+    deadline = time.time() + 2.0
+    while r._health_watchdog_running and time.time() < deadline:
+        time.sleep(0.01)
 
 
 def test_running_flag_is_cleared_even_when_the_scan_raises() -> None:
@@ -95,16 +113,23 @@ def test_running_flag_is_cleared_even_when_the_scan_raises() -> None:
 
     r._health_watchdog = _boom
 
-    try:
-        r._run_health_watchdog_on_cadence()
-    except RuntimeError:
-        pass
+    r._run_health_watchdog_on_cadence()
+    deadline = time.time() + 2.0
+    while r._health_watchdog_running and time.time() < deadline:
+        time.sleep(0.01)
 
     assert r._health_watchdog_running is False
 
     calls: list[int] = []
-    r._health_watchdog = lambda: calls.append(1)
+    done = threading.Event()
+
+    def _scan() -> None:
+        calls.append(1)
+        done.set()
+
+    r._health_watchdog = _scan
     r._run_health_watchdog_on_cadence()
+    assert done.wait(timeout=2.0)
     assert calls == [1]
 
 
@@ -120,6 +145,9 @@ def test_skipped_tick_count_is_reported_for_slow_scans(caplog) -> None:
     r._health_watchdog = _slow
     with caplog.at_level(logging.WARNING):
         r._run_health_watchdog_on_cadence()
+        deadline = time.time() + 2.0
+        while r._health_watchdog_running and time.time() < deadline:
+            time.sleep(0.01)
 
     recs = [
         rec for rec in caplog.records
@@ -128,6 +156,34 @@ def test_skipped_tick_count_is_reported_for_slow_scans(caplog) -> None:
     assert recs, "slow scan was not reported"
     assert recs[-1].duration_ms >= 100.0
     assert hasattr(recs[-1], "ticks_skipped")
+
+
+def test_slow_scan_does_not_block_tick_caller() -> None:
+    r = _runner(interval=0.0)
+    started = threading.Event()
+    release = threading.Event()
+    caller_thread = threading.get_ident()
+    scan_thread: list[int] = []
+
+    def _slow() -> None:
+        scan_thread.append(threading.get_ident())
+        started.set()
+        release.wait(timeout=2.0)
+
+    r._health_watchdog = _slow
+    started_at = time.perf_counter()
+    r._run_health_watchdog_on_cadence()
+    elapsed = time.perf_counter() - started_at
+
+    try:
+        assert elapsed < 0.1
+        assert started.wait(timeout=2.0)
+        assert scan_thread[0] != caller_thread
+    finally:
+        release.set()
+        deadline = time.time() + 2.0
+        while r._health_watchdog_running and time.time() < deadline:
+            time.sleep(0.01)
 
 
 def test_tick_path_calls_the_cadence_wrapper_not_the_scan_directly() -> None:

--- a/tests/test_live_basket_hydration.py
+++ b/tests/test_live_basket_hydration.py
@@ -57,3 +57,32 @@ def test_commit_active_dynamic_basket_persists_context_fields() -> None:
     assert "spot_symbol" in committed and "futures_symbol" in committed
     assert "NSE:NIFTY" in committed["symbols"]
     assert "NFO:NIFTY26MAYFUT" in committed["symbols"]
+
+
+def test_commit_active_dynamic_basket_repairs_stale_selected_pair_after_atm_shift() -> None:
+    old_ce = "NFO:NIFTY26AUG24250CE"
+    old_pe = "NFO:NIFTY26AUG24250PE"
+    new_ce = "NFO:NIFTY26AUG24300CE"
+    new_pe = "NFO:NIFTY26AUG24300PE"
+    option_symbols = [old_ce, old_pe, new_ce, new_pe]
+    ctx = SimpleNamespace(
+        active_trading_universe={
+            "selected_ce": old_ce,
+            "selected_pe": old_pe,
+            "atm_strike": 24250,
+        },
+        selected_ce=old_ce,
+        selected_pe=old_pe,
+        strategy_runner=None,
+    )
+
+    committed_ce, committed_pe = app._commit_active_dynamic_basket(
+        ctx,
+        basket=ctx.active_trading_universe,
+        option_symbols=option_symbols,
+        symbols=option_symbols,
+        atm_strike=24300,
+    )
+
+    assert (committed_ce, committed_pe) == (new_ce, new_pe)
+    assert ctx.active_trading_universe["atm_strike"] == 24300


### PR DESCRIPTION
## What changed

- commit the fresh InstrumentManager ATM basket during dynamic rotation and enforce selected-strike/ATM consistency at the commit boundary
- remove OrderManager's redundant 300-second post-exit cooldown while retaining its underlying-wide concurrency reservation
- prevent REST hydration from finalizing the current exchange minute
- re-baseline quarantined option cumulative volume only after monotonic same-generation confirmation, without crediting the jump
- execute the cadence-limited health watchdog off both the tick callback and the event loop

## Root causes

The dynamic refresh passed a new option set into an old basket snapshot; OrderManager independently applied SignalArbitrator's default five-minute re-entry policy; history imports accepted the current partial minute as completed; suspicious volume never advanced its baseline; and the health watchdog still performed history/recovery work synchronously.

## Validation

- `python -m compileall -q src`
- 50 focused regression tests passed
- `tests/data tests/strategies tests/execution tests/risk` passed
- full suite: 2,180 tests executed to 100% with one existing skip
- remote diff verified against the local scoped diff (10 existing files; no generated artifacts)