### PR TITLE
Fix trade-path order state and recovery

### DIFF
--- a/src/nifty_scalper_bot/data/rest/zerodha_client.py
+++ b/src/nifty_scalper_bot/data/rest/zerodha_client.py
@@ -1321,8 +1321,8 @@ class ZerodhaKiteClient(BaseBrokerClient):
         self._acquire_bucket(self._GENERAL_BUCKET)
         response = self._ensure_json(self._make_request("GET", f"/orders/{order_id}"))
         orders = cast(list[dict], response.get("data", []))
-        for order in orders:
-            if order.get("order_id") == order_id:
+        for order in reversed(orders):
+            if str(order.get("order_id")) == str(order_id):
                 return order
         return {}
 

--- a/src/nifty_scalper_bot/execution/order_manager_core.py
+++ b/src/nifty_scalper_bot/execution/order_manager_core.py
@@ -3611,12 +3611,14 @@ class OrderManager:
                             normalized_symbol,
                         )
 
-                    # ✅ WORLD-CLASS: Fast fill confirmation & bracket activation
-                    # This replaces the old 0.5s sleep
-                    # BUG 5 FIX: 2000ms poll added 0-2s latency to every entry on the
-                    # broker submission thread. 300ms catches most sub-200ms MARKET fills
-                    # during market hours. Pre-activation below handles the rest.
-                    fill_confirmed = self._confirm_fill_fast(order_id, timeout_ms=300)
+                    # Keep the short entry confirmation used to activate protection.
+                    # System exits are confirmed by the order monitor/reconciliation;
+                    # polling here would block the synchronous protection callback.
+                    fill_confirmed = (
+                        False
+                        if is_system_exit
+                        else self._confirm_fill_fast(order_id, timeout_ms=300)
+                    )
                     if fill_confirmed and self._bracket_manager:
                         bracket = self._bracket_manager.get_bracket(order_id)
                         if bracket:

--- a/src/nifty_scalper_bot/execution/position_manager.py
+++ b/src/nifty_scalper_bot/execution/position_manager.py
@@ -1881,6 +1881,11 @@ class PositionManager:
                 self._broker_realized_pnl = value
                 self._refresh_realized_pnl_locked()
                 return False
+            if self._pnl_trading_date != session_date:
+                self._local_realized_pnl = 0.0
+                self._local_provisional_realized_pnl = 0.0
+                for position in self._positions.values():
+                    position.realized_pnl = 0.0
             self._session_opening_realized_baseline = value
             self._pnl_trading_date = session_date
             self._pnl_account_fingerprint = account_fingerprint
@@ -3394,9 +3399,14 @@ class PositionManager:
     def reset_daily_pnl(self) -> None:
         """Reset realized profit and loss at the start of a new session."""
 
-        self._daily_realized_pnl = 0.0
-        for position in self._positions.values():
-            position.realized_pnl = 0.0
+        with self._lock:
+            self._local_realized_pnl = 0.0
+            self._local_provisional_realized_pnl = 0.0
+            self._pnl_trading_date = self._trading_date_ist()
+            self._session_opening_realized_baseline = self._broker_realized_pnl
+            for position in self._positions.values():
+                position.realized_pnl = 0.0
+            self._refresh_realized_pnl_locked()
         self.save_state()
 
     # Internal helpers -------------------------------------------------

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -1319,7 +1319,7 @@ class StrategyRunner:
             )
 
     def _on_bracket_exit_complete(self, symbol: str, *args: Any, **kwargs: Any) -> None:
-        """Callback from BracketManager after virtual bracket exit completes; clears runner state only."""
+        """Clear runner state and release entry guards after a bracket exit."""
         del args, kwargs
         try:
             if not symbol:
@@ -1359,7 +1359,11 @@ class StrategyRunner:
                 base = symbol
             self._notify_orchestrator_exit(base)
             self._clear_order_in_flight(symbol)
-            self._reset_execution_state(base)
+            self._release_entry_guards(
+                base,
+                start_cooldown=True,
+                reason="bracket_exit_complete",
+            )
 
         except Exception:
             logger = getattr(self, "_logger", LOGGER)
@@ -13531,6 +13535,41 @@ class StrategyRunner:
 
         return True
 
+    def _refresh_risk_halt_state(self, symbol: str) -> bool:
+        """Mirror the authoritative circuit-breaker state into the runner."""
+        if self._risk_manager is None:
+            return self._risk_halt_active
+        try:
+            tripped, reason = self._risk_manager.is_circuit_breaker_tripped()
+        except Exception as exc:
+            self._logger.debug(
+                "Failure in global breaker check: %s",
+                exc,
+                extra={"event": "risk_halt_check_error", "symbol": symbol},
+            )
+            return self._risk_halt_active
+
+        was_halted = self._risk_halt_active
+        self._risk_halt_active = bool(tripped)
+        if self._risk_halt_active and not self._risk_halt_logged:
+            self._risk_halt_logged = True
+            self._logger.error(
+                "Condition met: global risk halt latched",
+                extra={
+                    "event": "risk_halt_latched",
+                    "symbol": symbol,
+                    "reason": reason,
+                },
+            )
+        elif was_halted and not self._risk_halt_active:
+            self._risk_halt_logged = False
+            self._logger.info(
+                "RISK_HALT_CLEARED symbol=%s",
+                symbol,
+                extra={"event": "RISK_HALT_CLEARED", "symbol": symbol},
+            )
+        return self._risk_halt_active
+
     def _on_tick(self, symbol: str, tick: Mapping[str, Any]) -> None:
         """Handle incoming tick. Args: symbol, tick. Returns: None. Raises: Exception."""
         self._logger.debug(
@@ -13852,32 +13891,9 @@ class StrategyRunner:
             # Keep a single forward per tick so protective handlers do not churn
             # duplicate state transitions during stressed periods.
 
-            # Global breaker latch: once tripped, keep running only protective paths
-            # (brackets + position reconciliation) and skip strategy/indicator work.
-            if not self._risk_halt_active and self._risk_manager is not None:
-                try:
-                    tripped, _reason = self._risk_manager.is_circuit_breaker_tripped()
-                except Exception as exc:
-                    self._logger.debug(
-                        "Failure in global breaker check: %s",
-                        exc,
-                        extra={"event": "risk_halt_check_error", "symbol": symbol},
-                    )
-                    tripped = False
-                    _reason = ""
-                if tripped:
-                    self._risk_halt_active = True
-                    if not self._risk_halt_logged:
-                        self._risk_halt_logged = True
-                        self._logger.error(
-                            "Condition met: global risk halt latched",
-                            extra={
-                                "event": "risk_halt_latched",
-                                "symbol": symbol,
-                                "reason": _reason,
-                            },
-                        )
-            if self._risk_halt_active:
+            # Mirror the authoritative breaker on every tick so an operator reset
+            # can resume strategy evaluation while protective paths keep running.
+            if self._refresh_risk_halt_state(symbol):
                 if hasattr(self._position_manager, "update_position_price"):
                     try:
                         self._position_manager.update_position_price(symbol, price)

--- a/tests/data/test_zerodha_client_canonical.py
+++ b/tests/data/test_zerodha_client_canonical.py
@@ -52,3 +52,31 @@ def test_get_quote_bulk_short_circuits_all_canonical(
     assert "NSE:NIFTY" in out
     assert out["NSE:NIFTY"]["instrument_token"] == 256265
     client.close()
+
+
+def test_get_order_status_returns_latest_history_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = ZerodhaKiteClient(api_key="k", access_token="t")
+    monkeypatch.setattr(client, "_acquire_bucket", lambda _bucket: None)
+    monkeypatch.setattr(
+        client,
+        "_make_request",
+        lambda *_args, **_kwargs: {
+            "data": [
+                {"order_id": "123", "status": "OPEN PENDING"},
+                {"order_id": "123", "status": "OPEN"},
+                {
+                    "order_id": "123",
+                    "status": "COMPLETE",
+                    "average_price": 113.45,
+                },
+            ]
+        },
+    )
+
+    status = client.get_order_status("123")
+
+    assert status["status"] == "COMPLETE"
+    assert status["average_price"] == 113.45
+    client.close()

--- a/tests/execution/test_execution_safety_audit_fixes.py
+++ b/tests/execution/test_execution_safety_audit_fixes.py
@@ -609,6 +609,9 @@ def test_session_pnl_baseline_survives_restart_and_resets_by_ist_day(tmp_path) -
     assert restarted.pnl_reconciliation_snapshot()[
         "session_opening_realized_baseline"
     ] == pytest.approx(-1000.0)
+    restarted._local_realized_pnl = -4000.0
+    with restarted._lock:
+        restarted._refresh_realized_pnl_locked()
 
     new_day = restarted.establish_pnl_session_baseline(
         -1200.0,
@@ -618,6 +621,41 @@ def test_session_pnl_baseline_survives_restart_and_resets_by_ist_day(tmp_path) -
     assert restarted.pnl_reconciliation_snapshot()[
         "session_opening_realized_baseline"
     ] == pytest.approx(-1200.0)
+    assert restarted.pnl_reconciliation_snapshot()[
+        "local_confirmed_realized"
+    ] == pytest.approx(0.0)
+    assert restarted.get_realized_pnl() == pytest.approx(0.0)
+
+
+def test_manual_daily_pnl_reset_clears_local_ledger_and_preserves_zero_baseline(
+    tmp_path,
+) -> None:
+    manager = PositionManager(state_file=str(tmp_path / "positions.json"))
+    manager._broker_realized_pnl = -1000.0
+    manager._local_realized_pnl = -4000.0
+    with manager._lock:
+        manager._refresh_realized_pnl_locked()
+
+    manager.reset_daily_pnl()
+
+    snapshot = manager.pnl_reconciliation_snapshot()
+    assert snapshot["local_confirmed_realized"] == pytest.approx(0.0)
+    assert snapshot["broker_session_realized"] == pytest.approx(0.0)
+    assert manager.get_realized_pnl() == pytest.approx(0.0)
+
+
+def test_late_same_day_broker_baseline_preserves_local_fills(tmp_path) -> None:
+    manager = PositionManager(state_file=str(tmp_path / "positions.json"))
+    trading_date = "2026-07-03"
+    manager._pnl_trading_date = trading_date
+    manager._local_realized_pnl = -50.0
+
+    manager.establish_pnl_session_baseline(
+        -1000.0,
+        trading_date=trading_date,
+    )
+
+    assert manager.get_realized_pnl() == pytest.approx(-50.0)
 
 
 def test_exit_order_id_cannot_register_entry_bracket(tmp_path, monkeypatch) -> None:
@@ -1266,6 +1304,51 @@ def test_live_entry_registers_pending_order_with_position_manager(
         assert bracket is not None and bracket.entry_confirmed is False
     finally:
         bm._running = False
+
+
+def test_system_exit_does_not_poll_for_fill_on_protection_path(
+    monkeypatch, tmp_path
+) -> None:
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    from nifty_scalper_bot.execution.order_manager import OrderManager, OrderType
+
+    class _Broker:
+        def place_order(self, **_kwargs):
+            return {"order_id": "SYSTEM-EXIT-1"}
+
+        def get_orders(self):
+            return []
+
+        def get_positions(self):
+            return []
+
+    class _Positions:
+        def add_pending_order(self, **_kwargs):
+            return None
+
+        def get_position(self, _symbol):
+            return SimpleNamespace(quantity=65, side="LONG")
+
+    manager = OrderManager(_Broker(), _Positions(), object())
+    monkeypatch.setattr(
+        manager,
+        "_confirm_fill_fast",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("system exit must not synchronously poll")
+        ),
+    )
+
+    order_id = manager.place_order(
+        symbol="NFO:NIFTY2671424100CE",
+        side="SELL",
+        quantity=65,
+        order_type=OrderType.MARKET,
+        intent="EXIT",
+        tag="stop_exit",
+        check_risk=False,
+    )
+
+    assert order_id == "SYSTEM-EXIT-1"
 
 
 def test_non_incremental_fill_warning_dedupes_per_snapshot(tmp_path) -> None:

--- a/tests/strategies/test_runner_live_suppression_regressions.py
+++ b/tests/strategies/test_runner_live_suppression_regressions.py
@@ -171,6 +171,74 @@ def test_confirmed_flat_symbol_converges_bracket_and_entry_guards() -> None:
     assert releases == [("NFO:NIFTY2670724100PE", True)]
 
 
+def test_bracket_completion_releases_entry_guards_with_cooldown() -> None:
+    symbol = "NFO:NIFTY2670724100PE"
+    releases = []
+    runner = object.__new__(StrategyRunner)
+    runner._logger = type(
+        "Log",
+        (),
+        {"info": lambda *a, **k: None, "exception": lambda *a, **k: None},
+    )()
+    runner._normalize_symbol = lambda value: value
+    runner._notify_orchestrator_exit = lambda _symbol: None
+    runner._clear_order_in_flight = lambda _symbol: None
+    runner._release_entry_guards = (
+        lambda released_symbol, *, start_cooldown, reason: releases.append(
+            (released_symbol, start_cooldown, reason)
+        )
+    )
+
+    runner._on_bracket_exit_complete(symbol)
+
+    assert releases == [(symbol, True, "bracket_exit_complete")]
+
+
+def test_runner_risk_halt_clears_after_authoritative_breaker_reset() -> None:
+    states = iter([(True, "daily loss"), (False, "")])
+    events = []
+    runner = object.__new__(StrategyRunner)
+    runner._risk_manager = type(
+        "Risk",
+        (),
+        {"is_circuit_breaker_tripped": lambda self: next(states)},
+    )()
+    runner._risk_halt_active = False
+    runner._risk_halt_logged = False
+    runner._logger = type(
+        "Log",
+        (),
+        {
+            "debug": lambda *a, **k: None,
+            "error": lambda self, *a, **k: events.append(k["extra"]["event"]),
+            "info": lambda self, *a, **k: events.append(k["extra"]["event"]),
+        },
+    )()
+
+    assert runner._refresh_risk_halt_state("NFO:NIFTY2670724100PE") is True
+    assert runner._refresh_risk_halt_state("NFO:NIFTY2670724100PE") is False
+    assert events == ["risk_halt_latched", "RISK_HALT_CLEARED"]
+    assert runner._risk_halt_logged is False
+
+
+def test_runner_risk_halt_stays_fail_closed_when_recheck_fails() -> None:
+    runner = object.__new__(StrategyRunner)
+    runner._risk_manager = type(
+        "Risk",
+        (),
+        {
+            "is_circuit_breaker_tripped": lambda self: (_ for _ in ()).throw(
+                RuntimeError("unavailable")
+            )
+        },
+    )()
+    runner._risk_halt_active = True
+    runner._risk_halt_logged = True
+    runner._logger = type("Log", (), {"debug": lambda *a, **k: None})()
+
+    assert runner._refresh_risk_halt_state("NFO:NIFTY2670724100PE") is True
+
+
 def test_order_failure_cooldown_rejection_uses_dedup_rollback_path() -> None:
     source = Path("src/nifty_scalper_bot/strategies/runner.py").read_text()
     assert 'reason="order_failure_cooldown_active")' in source


### PR DESCRIPTION
## What changed

- select the latest Zerodha order-history state so completed exits cannot remain falsely pending
- mirror the authoritative circuit breaker on every tick so an operator reset clears the runner halt while failed checks stay fail-closed
- release entry reservations through the existing bracket-completion cleanup and retain the configured cooldown
- reset local realised P&L only on an IST trading-day transition while preserving same-day fills and broker baselines
- skip synchronous fast-fill polling for system exits; the existing monitor and reconciliation remain authoritative

## Root cause and impact

The live incident combined stale broker order history, a one-way runner halt latch, incomplete bracket cleanup, cross-day local P&L carry-over, and broker polling inside the protection callback. The result was incorrect exit accounting, blocked re-entry, non-recovering strategy evaluation, and avoidable tick-path latency.

## Validation

- `python -m compileall -q src`
- focused data, runner, execution-safety, and risk suite: 114 passed
- complete repository suite: 2,187 collected nodes, passed with one expected skip
- `git diff --check`

No safety limit, execution mode, lot sizing, signal threshold, or same-trigger idempotency rule was weakened.