### PR TITLE
Fix SMC liquidity sweep semantics

### DIFF
--- a/src/nifty_scalper_bot/strategies/elite_strategies/smc_liquidity.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/smc_liquidity.py
@@ -203,10 +203,33 @@ class SMCStrategy(EliteStrategy):
 
             body = abs(close - open_price)
             displacement_score = body / atr
-            prior_swing_low = float(indicators.get('prior_swing_low') or low)
-            prior_swing_high = float(indicators.get('prior_swing_high') or high)
-            bullish_sweep = bool(indicators.get('liquidity_sweep_confirmed')) or (low <= prior_swing_low and close > open_price)
-            bearish_sweep = bool(indicators.get('liquidity_sweep_confirmed_bear')) or (high >= prior_swing_high and close < open_price)
+            raw_swing_low = indicators.get("prior_swing_low")
+            if raw_swing_low is None:
+                raw_swing_low = indicators.get("swing_low")
+            raw_swing_high = indicators.get("prior_swing_high")
+            if raw_swing_high is None:
+                raw_swing_high = indicators.get("swing_high")
+
+            prior_swing_low = (
+                float(raw_swing_low) if raw_swing_low is not None else None
+            )
+            prior_swing_high = (
+                float(raw_swing_high) if raw_swing_high is not None else None
+            )
+            bullish_sweep = bool(
+                indicators.get("liquidity_sweep_confirmed")
+            ) or (
+                prior_swing_low is not None
+                and low < prior_swing_low
+                and close > prior_swing_low
+            )
+            bearish_sweep = bool(
+                indicators.get("liquidity_sweep_confirmed_bear")
+            ) or (
+                prior_swing_high is not None
+                and high > prior_swing_high
+                and close < prior_swing_high
+            )
             if not bullish_sweep and not bearish_sweep:
                 self._no_vote('no_liquidity_sweep')
                 LOGGER.debug('STRATEGY_NO_VOTE strategy=SMC reason=no_sweep')

--- a/tests/strategies/test_smc_liquidity.py
+++ b/tests/strategies/test_smc_liquidity.py
@@ -112,3 +112,140 @@ def test_real_smc_generate_signal_skips_cold_history_before_evaluate(
         "STRATEGY_SKIPPED_HISTORY_COLD" in record.getMessage()
         for record in caplog.records
     )
+
+def _ready_smc_indicators(**overrides):
+    indicators = {
+        "high": 101.0,
+        "low": 99.0,
+        "close": 100.5,
+        "open": 99.5,
+        "atr": 1.0,
+        "direction_bias": "CE",
+        "underlying_direction_bias": "CE",
+        "premium_reclaim": True,
+        "bullish_reversal": True,
+        "choch_confirmed": True,
+        "bos_confirmed": True,
+        "retest_confirmed": True,
+    }
+    indicators.update(overrides)
+    return indicators
+
+
+def test_green_candle_without_swing_is_not_a_liquidity_sweep(monkeypatch):
+    monkeypatch.setenv("EXECUTION_MODE", "SHADOW")
+    strategy = SMCStrategy(SMCStrategyConfig(), indicator_engine=None)
+
+    assert (
+        strategy._evaluate_signal(
+            "NFO:NIFTY26JUN25000CE", _ready_smc_indicators(), 100.0
+        )
+        is None
+    )
+    assert strategy.last_no_vote_reason == "no_liquidity_sweep"
+
+
+def test_red_candle_without_swing_is_not_a_liquidity_sweep(monkeypatch):
+    monkeypatch.setenv("EXECUTION_MODE", "SHADOW")
+    strategy = SMCStrategy(SMCStrategyConfig(), indicator_engine=None)
+    indicators = _ready_smc_indicators(
+        open=100.5,
+        close=99.5,
+        direction_bias="PE",
+        underlying_direction_bias="PE",
+    )
+
+    assert (
+        strategy._evaluate_signal("NFO:NIFTY26JUN25000PE", indicators, 100.0)
+        is None
+    )
+    assert strategy.last_no_vote_reason == "no_liquidity_sweep"
+
+
+def test_bullish_swing_breach_without_reclaim_is_not_a_sweep(monkeypatch):
+    monkeypatch.setenv("EXECUTION_MODE", "SHADOW")
+    strategy = SMCStrategy(SMCStrategyConfig(), indicator_engine=None)
+    indicators = _ready_smc_indicators(
+        high=99.0,
+        low=97.0,
+        open=98.5,
+        close=97.5,
+        prior_swing_low=98.0,
+        prior_swing_high=101.0,
+    )
+
+    assert (
+        strategy._evaluate_signal("NFO:NIFTY26JUN25000CE", indicators, 100.0)
+        is None
+    )
+    assert strategy.last_no_vote_reason == "no_liquidity_sweep"
+
+
+def test_bullish_swing_breach_and_reclaim_is_a_valid_sweep(monkeypatch):
+    monkeypatch.setenv("EXECUTION_MODE", "SHADOW")
+    strategy = SMCStrategy(SMCStrategyConfig(), indicator_engine=None)
+    indicators = _ready_smc_indicators(
+        low=98.0,
+        prior_swing_low=99.0,
+        prior_swing_high=102.0,
+    )
+
+    signal = strategy._evaluate_signal(
+        "NFO:NIFTY26JUN25000CE", indicators, 100.0
+    )
+
+    assert signal is not None
+    assert signal.signal == "CE"
+
+
+def test_bearish_swing_breach_and_rejection_is_a_valid_sweep(monkeypatch):
+    monkeypatch.setenv("EXECUTION_MODE", "SHADOW")
+    strategy = SMCStrategy(SMCStrategyConfig(), indicator_engine=None)
+    indicators = _ready_smc_indicators(
+        high=102.5,
+        low=100.0,
+        open=101.5,
+        close=100.5,
+        prior_swing_low=99.0,
+        prior_swing_high=102.0,
+        direction_bias="PE",
+        underlying_direction_bias="PE",
+    )
+
+    signal = strategy._evaluate_signal(
+        "NFO:NIFTY26JUN25000PE", indicators, 100.0
+    )
+
+    assert signal is not None
+    assert signal.signal == "PE"
+
+
+def test_explicit_liquidity_sweep_confirmation_remains_supported(monkeypatch):
+    monkeypatch.setenv("EXECUTION_MODE", "SHADOW")
+    strategy = SMCStrategy(SMCStrategyConfig(), indicator_engine=None)
+    indicators = _ready_smc_indicators(liquidity_sweep_confirmed=True)
+
+    signal = strategy._evaluate_signal(
+        "NFO:NIFTY26JUN25000CE", indicators, 100.0
+    )
+
+    assert signal is not None
+    assert signal.signal == "CE"
+
+
+def test_manager_swing_low_alias_is_accepted(monkeypatch):
+    monkeypatch.setenv("EXECUTION_MODE", "SHADOW")
+    strategy = SMCStrategy(SMCStrategyConfig(), indicator_engine=None)
+    indicators = _ready_smc_indicators(
+        low=98.0,
+        swing_low=99.0,
+        swing_high=102.0,
+    )
+
+    signal = strategy._evaluate_signal(
+        "NFO:NIFTY26JUN25000CE", indicators, 100.0
+    )
+
+    assert signal is not None
+    assert signal.signal == "CE"
+

--- a/tests/strategies/test_smc_liquidity.py
+++ b/tests/strategies/test_smc_liquidity.py
@@ -113,6 +113,7 @@ def test_real_smc_generate_signal_skips_cold_history_before_evaluate(
         for record in caplog.records
     )
 
+
 def _ready_smc_indicators(**overrides):
     indicators = {
         "high": 101.0,
@@ -155,10 +156,7 @@ def test_red_candle_without_swing_is_not_a_liquidity_sweep(monkeypatch):
         underlying_direction_bias="PE",
     )
 
-    assert (
-        strategy._evaluate_signal("NFO:NIFTY26JUN25000PE", indicators, 100.0)
-        is None
-    )
+    assert strategy._evaluate_signal("NFO:NIFTY26JUN25000PE", indicators, 100.0) is None
     assert strategy.last_no_vote_reason == "no_liquidity_sweep"
 
 
@@ -174,10 +172,7 @@ def test_bullish_swing_breach_without_reclaim_is_not_a_sweep(monkeypatch):
         prior_swing_high=101.0,
     )
 
-    assert (
-        strategy._evaluate_signal("NFO:NIFTY26JUN25000CE", indicators, 100.0)
-        is None
-    )
+    assert strategy._evaluate_signal("NFO:NIFTY26JUN25000CE", indicators, 100.0) is None
     assert strategy.last_no_vote_reason == "no_liquidity_sweep"
 
 
@@ -190,12 +185,11 @@ def test_bullish_swing_breach_and_reclaim_is_a_valid_sweep(monkeypatch):
         prior_swing_high=102.0,
     )
 
-    signal = strategy._evaluate_signal(
-        "NFO:NIFTY26JUN25000CE", indicators, 100.0
-    )
+    signal = strategy._evaluate_signal("NFO:NIFTY26JUN25000CE", indicators, 100.0)
 
     assert signal is not None
-    assert signal.signal == "CE"
+    assert signal.signal == "BUY"
+    assert signal.metadata["trade_side"] == "CE"
 
 
 def test_bearish_swing_breach_and_rejection_is_a_valid_sweep(monkeypatch):
@@ -212,12 +206,11 @@ def test_bearish_swing_breach_and_rejection_is_a_valid_sweep(monkeypatch):
         underlying_direction_bias="PE",
     )
 
-    signal = strategy._evaluate_signal(
-        "NFO:NIFTY26JUN25000PE", indicators, 100.0
-    )
+    signal = strategy._evaluate_signal("NFO:NIFTY26JUN25000PE", indicators, 100.0)
 
     assert signal is not None
-    assert signal.signal == "PE"
+    assert signal.signal == "BUY"
+    assert signal.metadata["trade_side"] == "PE"
 
 
 def test_explicit_liquidity_sweep_confirmation_remains_supported(monkeypatch):
@@ -225,12 +218,11 @@ def test_explicit_liquidity_sweep_confirmation_remains_supported(monkeypatch):
     strategy = SMCStrategy(SMCStrategyConfig(), indicator_engine=None)
     indicators = _ready_smc_indicators(liquidity_sweep_confirmed=True)
 
-    signal = strategy._evaluate_signal(
-        "NFO:NIFTY26JUN25000CE", indicators, 100.0
-    )
+    signal = strategy._evaluate_signal("NFO:NIFTY26JUN25000CE", indicators, 100.0)
 
     assert signal is not None
-    assert signal.signal == "CE"
+    assert signal.signal == "BUY"
+    assert signal.metadata["trade_side"] == "CE"
 
 
 def test_manager_swing_low_alias_is_accepted(monkeypatch):
@@ -242,10 +234,8 @@ def test_manager_swing_low_alias_is_accepted(monkeypatch):
         swing_high=102.0,
     )
 
-    signal = strategy._evaluate_signal(
-        "NFO:NIFTY26JUN25000CE", indicators, 100.0
-    )
+    signal = strategy._evaluate_signal("NFO:NIFTY26JUN25000CE", indicators, 100.0)
 
     assert signal is not None
-    assert signal.signal == "CE"
-
+    assert signal.signal == "BUY"
+    assert signal.metadata["trade_side"] == "CE"


### PR DESCRIPTION
## What changed

- accept the manager-provided `swing_low` / `swing_high` fields as aliases for prior swing levels
- fail closed when no prior swing exists
- require a strict swing breach and close back across the swept level
- preserve explicit liquidity-sweep confirmations
- add seven focused bullish, bearish, missing-data, reclaim, and alias regression tests

## Root cause

The strategy substituted the current candle low/high when prior swing fields were absent. That made `low <= low` or `high >= high` automatically true, so ordinary green/red candles could be classified as liquidity sweeps.

## Validation

GitHub Actions must pass before merge. No local test result is claimed because this workspace has no checkout or `gh` client.