### PR TITLE
Reject bearish SMC option-premium sweeps

### DIFF
--- a/src/nifty_scalper_bot/strategies/elite_strategies/smc_liquidity.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/smc_liquidity.py
@@ -236,6 +236,15 @@ class SMCStrategy(EliteStrategy):
                 return None
 
             contract_side, option_premium_domain, _ = resolve_signal_domain(symbol, indicators)
+            if option_premium_domain and bearish_sweep:
+                self._no_vote("premium_not_reversing_up")
+                LOGGER.info(
+                    "STRATEGY_NO_VOTE strategy=SMC symbol=%s "
+                    "reason=premium_not_reversing_up bearish_sweep=%s",
+                    symbol,
+                    bearish_sweep,
+                )
+                return None
             required_features = ("premium_reclaim", "bullish_reversal", "choch_confirmed", "bos_confirmed", "retest_confirmed")
             present_features = [name for name in required_features if indicators.get(name) is not None]
             feature_completeness = float(len(present_features)) / float(len(required_features))

--- a/tests/strategies/test_smc_liquidity.py
+++ b/tests/strategies/test_smc_liquidity.py
@@ -192,7 +192,7 @@ def test_bullish_swing_breach_and_reclaim_is_a_valid_sweep(monkeypatch):
     assert signal.metadata["trade_side"] == "CE"
 
 
-def test_bearish_swing_breach_and_rejection_is_a_valid_sweep(monkeypatch):
+def test_bearish_option_premium_sweep_is_rejected_before_buy(monkeypatch):
     monkeypatch.setenv("EXECUTION_MODE", "SHADOW")
     strategy = SMCStrategy(SMCStrategyConfig(), indicator_engine=None)
     indicators = _ready_smc_indicators(
@@ -206,11 +206,31 @@ def test_bearish_swing_breach_and_rejection_is_a_valid_sweep(monkeypatch):
         underlying_direction_bias="PE",
     )
 
+    assert strategy._evaluate_signal("NFO:NIFTY26JUN25000PE", indicators, 100.0) is None
+    assert strategy.last_no_vote_reason == "premium_not_reversing_up"
+
+
+def test_bearish_underlying_sweep_can_still_select_pe(monkeypatch):
+    monkeypatch.setenv("EXECUTION_MODE", "SHADOW")
+    strategy = SMCStrategy(SMCStrategyConfig(), indicator_engine=None)
+    indicators = _ready_smc_indicators(
+        high=102.5,
+        low=100.0,
+        open=101.5,
+        close=100.5,
+        prior_swing_low=99.0,
+        prior_swing_high=102.0,
+        direction_bias="PE",
+        underlying_direction_bias="PE",
+        source_symbol="NSE:NIFTY 50",
+    )
+
     signal = strategy._evaluate_signal("NFO:NIFTY26JUN25000PE", indicators, 100.0)
 
     assert signal is not None
     assert signal.signal == "BUY"
     assert signal.metadata["trade_side"] == "PE"
+    assert signal.metadata["source_domain"] == "underlying_price"
 
 
 def test_explicit_liquidity_sweep_confirmation_remains_supported(monkeypatch):


### PR DESCRIPTION
## What changed

- reject a bearish liquidity sweep when SMC is evaluating an option-premium price domain
- reuse the existing `premium_not_reversing_up` no-vote reason
- preserve bearish underlying-domain sweeps that correctly select a PE contract
- add focused regression coverage for both paths

## Root cause

A bearish high sweep in the option premium could still earn the base liquidity-sweep score and reach a BUY vote when structure confirmation or `premium_reclaim` satisfied later gates. That treats bearish price action in the purchased instrument as supporting evidence.

## Validation

- focused SMC module: 11/11 passed locally
- full local suite: 2,194 tests passed
- test file Ruff and Black checks passed
- strategy module compiled successfully

GitHub Actions must pass before merge.