### PR TITLE
Apply regime-weighted trigger scores

### DIFF
--- a/src/nifty_scalper_bot/core/strategy_manager.py
+++ b/src/nifty_scalper_bot/core/strategy_manager.py
@@ -3951,7 +3951,9 @@ class StrategyManager(_BaseStrategyManager):
                 _record_no_signal("strategy_partial_no_consensus", "no_trigger_vote", "no_trigger_vote", trigger_vote_count=0, context_vote_count=len(context_votes), final_block_reason="partial")
                 return None
         else:
-            best_signal, best_vote = max(trigger_votes, key=lambda pair: self._extract_raw_score(pair[1]))
+            best_signal, best_vote = max(
+                trigger_votes, key=lambda pair: _weighted_score(pair[1])
+            )
         metadata = dict(best_signal.metadata or {})
         threshold = float(os.getenv("STRATEGY_TRIGGER_MIN_SCORE", "4.5") or "4.5")
         single_high = float(os.getenv("STRATEGY_SINGLE_VOTE_HIGH_CONVICTION", "8.8") or "8.8")
@@ -3965,7 +3967,7 @@ class StrategyManager(_BaseStrategyManager):
         negative_context = sum(self._extract_context_veto_score(v) for v in opposite_context)
         context_bonus = min(1.5, 0.45 * positive_context)
         context_penalty = min(1.5, 0.60 * negative_context)
-        final_score = raw_trigger_score + context_bonus - context_penalty
+        final_score = weighted_trigger_score + context_bonus - context_penalty
         final_score = max(0.0, min(10.0, final_score))
         context_confidence_floor = float(os.getenv("STRATEGY_CONTEXT_HARD_VETO_MIN_CONFIDENCE", "0.80") or "0.80")
         context_freshness_max_age_s = float(os.getenv("STRATEGY_CONTEXT_HARD_VETO_MAX_AGE_SECONDS", "120") or "120")
@@ -4024,7 +4026,7 @@ class StrategyManager(_BaseStrategyManager):
                 near_atm = strike_distance_from_atm <= near_atm_threshold
             score_min, conf_min = self._single_vote_thresholds(best_vote.strategy)
             regime_weight = _regime_weight(best_vote)
-            score_ok = raw_trigger_score >= score_min
+            score_ok = weighted_trigger_score >= score_min
             conf_ok = best_vote.confidence >= conf_min
             selected_ok = selected_option or near_atm
             selected_ok_reason = "selected_option" if selected_option else "near_atm" if near_atm else "not_selected_or_near_atm"
@@ -4033,7 +4035,12 @@ class StrategyManager(_BaseStrategyManager):
             metadata["strike_distance_from_atm"] = strike_distance_from_atm
             metadata["is_selected_option"] = selected_option
             metadata["selected_ok_reason"] = selected_ok_reason
-            threshold_passed = bool(raw_trigger_score >= score_min and best_vote.confidence >= conf_min and selected_ok and not vetoed)
+            threshold_passed = bool(
+                weighted_trigger_score >= score_min
+                and best_vote.confidence >= conf_min
+                and selected_ok
+                and not vetoed
+            )
             # STRATEGY_ALLOW_SINGLE_VOTE_SCALP=false is the master default block.
             # Single-vote high-conviction/selected-option paths require explicit,
             # narrower operator overrides to avoid accidental lone-vote approvals.
@@ -4045,7 +4052,12 @@ class StrategyManager(_BaseStrategyManager):
                 "STRATEGY_ALLOW_SELECTED_OPTION_SINGLE_VOTE",
                 self._env_bool("STRATEGY_ALLOW_SINGLE_VOTE_SELECTED_OPTION", False),
             )
-            high_conviction_allowed = bool(raw_trigger_score >= single_high and selected_ok and not vetoed and allow_high_conviction)
+            high_conviction_allowed = bool(
+                weighted_trigger_score >= single_high
+                and selected_ok
+                and not vetoed
+                and allow_high_conviction
+            )
             # A single trigger on the actually-SELECTED ATM option that already
             # cleared score/confidence/veto gates is the core scalp this platform
             # exists to take. Allow it without the global scalp flag, since
@@ -4055,7 +4067,10 @@ class StrategyManager(_BaseStrategyManager):
             # must clear a high score floor (default 9.0) on top of the normal gates.
             # This keeps single-vote trades to only the strongest signals.
             selected_single_min = self._env_float("STRATEGY_SELECTED_OPTION_SINGLE_VOTE_MIN_SCORE", 9.0)
-            if selected_option_scalp_allowed and raw_trigger_score < selected_single_min:
+            if (
+                selected_option_scalp_allowed
+                and weighted_trigger_score < selected_single_min
+            ):
                 selected_option_scalp_allowed = False
             scalp_fallback_allowed = bool((allow_scalp_single and threshold_passed) or selected_option_scalp_allowed)
             final_allowed = bool(high_conviction_allowed or scalp_fallback_allowed)
@@ -4144,7 +4159,7 @@ class StrategyManager(_BaseStrategyManager):
                 switch_allowed = (
                     allow_candidate_switch
                     and (strike_distance_from_atm is not None)
-                    and raw_trigger_score >= switch_min_score
+                    and weighted_trigger_score >= switch_min_score
                     and quote_depth_valid
                     and switch_spread_pct <= self._env_float("LIVE_MAX_SPREAD_PCT", 0.75)
                     and strike_distance_from_atm <= max_candidate_switch_distance
@@ -4321,7 +4336,9 @@ class StrategyManager(_BaseStrategyManager):
             metadata.pop("direction_bias", None)
         metadata["confidence"] = float(best_vote.confidence)
         metadata["consensus_stage"] = metadata_stage
-        metadata["manager_score_source"] = "strategy_score_plus_context_arbitration"
+        metadata["manager_score_source"] = (
+            "regime_weighted_strategy_score_plus_context_arbitration"
+        )
         metadata["approval_path"] = approval_path
         metadata["is_approved"] = True
         log.info("TRADE_DECISION_TRACE approval_path=%s symbol=%s strategy=%s", approval_path, symbol_norm, best_vote.strategy)

--- a/tests/strategies/test_single_vote_score_floor.py
+++ b/tests/strategies/test_single_vote_score_floor.py
@@ -2,16 +2,24 @@
 
 A lone vote (no consensus) is riskier, so only the strongest signals should pass.
 """
+
 from __future__ import annotations
 
 import os
 
 
-def _selected_option_allowed(raw_trigger_score: float, *, threshold_passed=True,
-                             selected_option=True, allow_selected_option=True) -> bool:
+def _selected_option_allowed(
+    raw_trigger_score: float,
+    *,
+    threshold_passed=True,
+    selected_option=True,
+    allow_selected_option=True,
+) -> bool:
     # Mirrors the gate in strategy_manager: base allow AND score >= floor.
     allowed = bool(threshold_passed and selected_option and allow_selected_option)
-    floor = float(os.getenv("STRATEGY_SELECTED_OPTION_SINGLE_VOTE_MIN_SCORE", "9.0") or "9.0")
+    floor = float(
+        os.getenv("STRATEGY_SELECTED_OPTION_SINGLE_VOTE_MIN_SCORE", "9.0") or "9.0"
+    )
     if allowed and raw_trigger_score < floor:
         allowed = False
     return allowed
@@ -19,7 +27,7 @@ def _selected_option_allowed(raw_trigger_score: float, *, threshold_passed=True,
 
 async def test_single_vote_blocked_below_nine(monkeypatch) -> None:
     monkeypatch.delenv("STRATEGY_SELECTED_OPTION_SINGLE_VOTE_MIN_SCORE", raising=False)
-    assert _selected_option_allowed(8.0) is False   # was allowed before; now blocked
+    assert _selected_option_allowed(8.0) is False  # was allowed before; now blocked
     assert _selected_option_allowed(8.9) is False
 
 
@@ -40,9 +48,15 @@ async def test_smc_option_context_fetch_allowed_at_open() -> None:
     # closed (PRE/POST/HOLIDAY), not for OPEN or transient UNKNOWN — otherwise SMC
     # stays history-cold and can't vote.
     import pathlib
+
     src = pathlib.Path("src/nifty_scalper_bot/core/app.py").read_text()
-    assert '_market_closed_for_fetch = _market_mode in {"PRE_MARKET", "POST_MARKET", "HOLIDAY"}' in src
-    assert 'get_runtime_market_mode() != "OPEN"' not in src  # old over-broad gate removed
+    assert (
+        '_market_closed_for_fetch = _market_mode in {"PRE_MARKET", '
+        '"POST_MARKET", "HOLIDAY"}' in src
+    )
+    assert (
+        'get_runtime_market_mode() != "OPEN"' not in src
+    )  # old over-broad gate removed
     # behavior: only the three closed modes block
     for mode in ("PRE_MARKET", "POST_MARKET", "HOLIDAY"):
         assert mode in {"PRE_MARKET", "POST_MARKET", "HOLIDAY"}
@@ -54,6 +68,7 @@ async def test_malformed_score_env_does_not_crash() -> None:
     # #13: a malformed STRATEGY_SELECTED_OPTION_SINGLE_VOTE_MIN_SCORE must fall back
     # to the default, not raise ValueError inside signal combination.
     from nifty_scalper_bot.config.env_utils import parse_float_env
+
     assert parse_float_env("high", 9.0) == 9.0
     assert parse_float_env("", 9.0) == 9.0
     assert parse_float_env("9.5", 9.0) == 9.5
@@ -70,18 +85,122 @@ def _gate_probe(symbol: str, indicators: dict):
     mgr = StrategyManager.__new__(StrategyManager)
     mgr._last_no_signal_decision_by_symbol = {}
     sig = Signal(
-        action="BUY", symbol=symbol, quantity=65, confidence=0.9,
-        reason="t", stop_loss=140.0, take_profit=150.0, metadata={},
+        action="BUY",
+        symbol=symbol,
+        quantity=65,
+        confidence=0.9,
+        reason="t",
+        stop_loss=140.0,
+        take_profit=150.0,
+        metadata={},
     )
     vote = StrategyVote(
-        strategy="VWAPPro", side="CE", score=9.9, confidence=0.9,
-        reasons=[], metadata={"role": "trigger"},
+        strategy="VWAPPro",
+        side="CE",
+        score=9.9,
+        confidence=0.9,
+        reasons=[],
+        metadata={"role": "trigger"},
     )
     result = mgr._combine_strategy_votes(
         symbol=symbol, signals=[(sig, vote)], indicators=indicators
     )
     decision = mgr._last_no_signal_decision_by_symbol.get(symbol.upper())
     return result, decision
+
+
+def _manager_probe():
+    from nifty_scalper_bot.core.strategy_manager import StrategyManager
+
+    manager = StrategyManager.__new__(StrategyManager)
+    manager._last_no_signal_decision_by_symbol = {}
+    manager._compute_trade_quality_score = lambda *args, **kwargs: (10.0, {})
+    return manager
+
+
+def _signal_vote(*, strategy: str, raw_score: float, weighted_score: float):
+    from nifty_scalper_bot.core.strategy_manager import Signal, StrategyVote
+
+    signal = Signal(
+        action="BUY",
+        symbol="NFO:NIFTY2670724050CE",
+        quantity=65,
+        confidence=0.9,
+        reason=strategy,
+        stop_loss=140.0,
+        take_profit=150.0,
+        metadata={
+            "strategy": strategy,
+            "is_selected_option": True,
+            "quote_depth_valid": True,
+            "spread_pct": 0.2,
+        },
+    )
+    vote = StrategyVote(
+        strategy=strategy,
+        side="CE",
+        score=weighted_score,
+        confidence=0.9,
+        reasons=[],
+        metadata={
+            "role": "trigger",
+            "raw_setup_score": raw_score,
+            "raw_vote_score": raw_score,
+            "regime_weight": weighted_score / raw_score,
+            "regime_weighted_vote_score": weighted_score,
+        },
+    )
+    return signal, vote
+
+
+def _valid_entry_context() -> dict:
+    return {
+        "direction_bias": "CE",
+        "context_fresh": True,
+        "context_age_seconds": 0.1,
+        "selected_ce": "NFO:NIFTY2670724050CE",
+        "is_selected_option": True,
+        "quote_depth_valid": True,
+        "spread_pct": 0.2,
+    }
+
+
+async def test_regime_weighted_score_selects_trigger_winner(monkeypatch) -> None:
+    monkeypatch.setenv("EXECUTION_MODE", "SHADOW")
+    manager = _manager_probe()
+    high_raw = _signal_vote(strategy="SMC", raw_score=9.0, weighted_score=1.8)
+    regime_fit = _signal_vote(strategy="VWAPPro", raw_score=7.0, weighted_score=8.4)
+
+    result = manager._combine_strategy_votes(
+        symbol="NFO:NIFTY2670724050CE",
+        signals=[high_raw, regime_fit],
+        indicators=_valid_entry_context(),
+    )
+
+    assert result is not None
+    assert result.reason == "VWAPPro"
+    assert result.metadata["raw_setup_score"] == 7.0
+    assert result.metadata["regime_weighted_score"] == 8.4
+    assert result.metadata["final_trade_score"] == 8.4
+
+
+async def test_regime_downweighted_single_vote_cannot_pass_raw_score_gate(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("EXECUTION_MODE", "SHADOW")
+    monkeypatch.setenv("STRATEGY_ALLOW_SINGLE_VOTE_SCALP", "true")
+    manager = _manager_probe()
+    vote = _signal_vote(strategy="SMC", raw_score=9.0, weighted_score=1.8)
+
+    result = manager._combine_strategy_votes(
+        symbol="NFO:NIFTY2670724050CE",
+        signals=[vote],
+        indicators=_valid_entry_context(),
+    )
+
+    assert result is None
+    decision = manager._last_no_signal_decision_by_symbol["NFO:NIFTY2670724050CE"]
+    assert decision.reason == "raw_score_below_min"
 
 
 async def test_option_entry_fails_closed_without_underlying_direction() -> None:


### PR DESCRIPTION
## What changed
- rank trigger votes by the already-computed regime-weighted score
- use that weighted score once for single-vote, high-conviction, candidate-switch, and final admission gates
- preserve raw scores in metadata for auditability
- add focused regression coverage for winner selection and down-weighted single-vote rejection

## Root cause
The manager calculated regime-adjusted vote scores but selected and admitted trades using raw setup scores, making regime suitability largely descriptive.

## Validation
- 14 focused strategy-manager tests passed
- focused test module: 10 passed
- full suite passed with one timing-sensitive market-data test deselected; that test passed independently
- `python -m compileall -q src`
- Black and Ruff on the edited test file
- `git diff --check`

No runtime state files or unrelated artifacts are included.