### PR TITLE
Mark ORB fired after order acceptance

### DIFF
--- a/src/nifty_scalper_bot/core/strategy_manager.py
+++ b/src/nifty_scalper_bot/core/strategy_manager.py
@@ -1432,6 +1432,32 @@ class StrategyManager(_BaseStrategyManager):
             )
         self._score_cache.pop(strategy_name, None)
 
+    def notify_entry_accepted(self, strategy_name: str, side: str) -> None:
+        """Notify the originating strategy after an entry order is accepted."""
+        resolved_name = str(strategy_name or "").strip()
+        if not resolved_name:
+            return
+        for strategy in self._strategies:
+            if str(getattr(strategy, "name", "") or "") != resolved_name:
+                continue
+            hook = getattr(strategy, "notify_entry_accepted", None)
+            if not callable(hook):
+                return
+            try:
+                hook(side)
+            except Exception as exc:  # noqa: BLE001 - order is already accepted
+                log.error(
+                    "Failure in strategy entry-accepted hook: %s",
+                    exc,
+                    exc_info=exc,
+                    extra={
+                        "event": "strategy_entry_accepted_hook_error",
+                        "strategy": resolved_name,
+                        "side": side,
+                    },
+                )
+            return
+
     def get_strategy_scores(self, limit: int | None = None) -> list[StrategyScore]:
         """Return ordered strategy scores for observability.
 

--- a/src/nifty_scalper_bot/strategies/elite_strategies/orb_pro.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/orb_pro.py
@@ -27,6 +27,19 @@ class ORBProStrategy(EliteStrategy):
         """Args: none. Returns: indicators set. Raises: Exception."""
         return {'orb_high', 'orb_low', 'orb_ready', 'close', 'open', 'volume', 'avg_volume', 'atr', 'direction_bias', 'regime'}
 
+    def notify_entry_accepted(self, side: str) -> None:
+        """Consume today's ORB direction only after order acceptance."""
+        accepted_side = str(side or "").strip().upper()
+        if accepted_side not in {"CE", "PE"}:
+            return
+        today = datetime.now(
+            timezone(timedelta(hours=5, minutes=30))
+        ).date().isoformat()
+        self._fired_today.add((today, accepted_side))
+        self._fired_today = {
+            key for key in self._fired_today if key[0] == today
+        }
+
     def _evaluate_signal(self, symbol: str, indicators: dict[str, Any], current_price: float, position: Any | None = None) -> EliteSignal | None:
         """Args: symbol, indicators, current_price, position. Returns: EliteSignal|None. Raises: Exception."""
         del position
@@ -127,10 +140,6 @@ class ORBProStrategy(EliteStrategy):
                 'invalidation_level': orb_low if breakout_side == 'CE' else orb_high,
             }
             LOGGER.info('STRATEGY_VOTE strategy=ORBPro side=%s score=%.2f', breakout_side, strategy_score)
-            self._fired_today.add(day_key)
-            if len(self._fired_today) > 8:
-                today = day_key[0]
-                self._fired_today = {k for k in self._fired_today if k[0] == today}
             return EliteSignal(
                 symbol=symbol,
                 signal='BUY',

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -19987,6 +19987,23 @@ class StrategyRunner:
                 orchestrator = getattr(self, "_orchestrator", None)
                 if orchestrator is not None and hasattr(orchestrator, "notify_entry"):
                     orchestrator.notify_entry(signal.symbol, reason="order_accepted")
+                strategy_manager = getattr(self, "_strategy_manager", None)
+                notify_entry_accepted = getattr(
+                    strategy_manager, "notify_entry_accepted", None
+                )
+                if callable(notify_entry_accepted):
+                    try:
+                        notify_entry_accepted(strategy_name, option_side)
+                    except Exception as exc:  # noqa: BLE001 - order is accepted
+                        self._logger.error(
+                            "STRATEGY_ENTRY_ACCEPTED_HOOK_FAILED "
+                            "strategy=%s side=%s order_id=%s error=%s",
+                            strategy_name,
+                            option_side,
+                            order_id,
+                            exc,
+                            exc_info=exc,
+                        )
                 # Stamp the order id onto the execution state machine so stale-state
                 # reconciliation can tell a real pending order from a wedged one.
                 try:

--- a/tests/strategies/test_candidate_specific_option_readiness.py
+++ b/tests/strategies/test_candidate_specific_option_readiness.py
@@ -219,6 +219,13 @@ def _execution_runner(monkeypatch, *, ce_ok=True, pe_ok=False):
     runner._trade_candidate_selector = SimpleNamespace(_last_rejects={})
     runner._position_manager = None
     runner._orchestrator = None
+    accepted_notifications = []
+    runner._strategy_manager = SimpleNamespace(
+        notify_entry_accepted=lambda strategy, side: accepted_notifications.append(
+            (strategy, side)
+        )
+    )
+    runner._accepted_strategy_notifications = accepted_notifications
     runner._active_atm_strike = 25000
     runner._active_option_symbols = {"NFO:CE", "NFO:PE"}
     runner._active_basket_all_symbols = {"NFO:CE", "NFO:PE"}
@@ -316,6 +323,30 @@ def test_entry_path_allows_ready_ce_candidate_and_submits_order(
     assert result.accepted is True
     assert len(runner._order_manager.plans) == 1
     assert runner._order_manager.plans[0].symbol == "NFO:CE"
+    assert runner._accepted_strategy_notifications == [("test", "CE")]
+
+
+def test_entry_remains_accepted_when_strategy_notification_fails(
+    monkeypatch,
+) -> None:
+    runner, _ = _execution_runner(monkeypatch, ce_ok=True, pe_ok=False)
+
+    def fail_notification(*_args):
+        raise RuntimeError("notification failed")
+
+    runner._strategy_manager.notify_entry_accepted = fail_notification
+
+    result = runner._handle_entry_signal_inner(
+        _signal("NFO:CE"),
+        "NSE:NIFTY",
+        "NFO:CE",
+        100.0,
+        datetime.now(timezone.utc),
+        trace_id="t",
+    )
+
+    assert result.accepted is True
+    assert len(runner._order_manager.plans) == 1
 
 
 def test_entry_path_rejects_stale_pe_candidate_before_order_manager(monkeypatch):
@@ -333,6 +364,7 @@ def test_entry_path_rejects_stale_pe_candidate_before_order_manager(monkeypatch)
     assert result.reason == "selected_pe_unready"
     assert result.details["candidate_blockers"] == ["quote_missing"]
     assert runner._order_manager.plans == []
+    assert runner._accepted_strategy_notifications == []
 
 
 def test_entry_path_rejects_unmapped_nifty_option_before_order_manager(monkeypatch):

--- a/tests/strategies/test_elite_builder_mode.py
+++ b/tests/strategies/test_elite_builder_mode.py
@@ -3,12 +3,14 @@ from __future__ import annotations
 from nifty_scalper_bot.strategies.elite_strategies.builder import build_elite_strategies
 from nifty_scalper_bot.strategies.elite_strategies.config_models import (
     EliteStrategiesSettings,
+    ORBProStrategyConfig,
 )
+from nifty_scalper_bot.strategies.elite_strategies.orb_pro import ORBProStrategy
 
 
 def test_directional_mode_disables_gamma_theta_and_context(monkeypatch) -> None:
-    monkeypatch.setenv('STRATEGY_MODE', 'directional_scalp')
-    monkeypatch.setenv('ALLOW_EXPIRY_GAMMA_STRATEGIES', 'false')
+    monkeypatch.setenv("STRATEGY_MODE", "directional_scalp")
+    monkeypatch.setenv("ALLOW_EXPIRY_GAMMA_STRATEGIES", "false")
 
     strategies = build_elite_strategies(
         settings=EliteStrategiesSettings(),
@@ -16,9 +18,38 @@ def test_directional_mode_disables_gamma_theta_and_context(monkeypatch) -> None:
     )
     names = {strategy.name for strategy in strategies}
 
-    assert 'GammaScalping' not in names
-    assert 'EliteTuesdayGammaBuyer' not in names
-    assert 'StraddleTheta' not in names
-    assert 'OIMaxPain' not in names
-    assert {'SMC', 'VWAPPro', 'OrderFlow', 'BBSqueeze', 'ORBPro'}.issubset(names)
-    assert 'CPRBreakout' not in names
+    assert "GammaScalping" not in names
+    assert "EliteTuesdayGammaBuyer" not in names
+    assert "StraddleTheta" not in names
+    assert "OIMaxPain" not in names
+    assert {"SMC", "VWAPPro", "OrderFlow", "BBSqueeze", "ORBPro"}.issubset(names)
+    assert "CPRBreakout" not in names
+
+
+def test_orb_direction_is_consumed_only_after_entry_acceptance(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("ENABLE_ORB_STRATEGY", "true")
+    strategy = ORBProStrategy(ORBProStrategyConfig(), indicator_engine=None)
+    indicators = {
+        "orb_ready": True,
+        "orb_high": 105.0,
+        "orb_low": 95.0,
+        "open": 104.0,
+        "high": 111.0,
+        "low": 103.0,
+        "close": 110.0,
+        "atr": 5.0,
+        "volume": 1000.0,
+        "avg_volume": 900.0,
+        "direction_bias": "CE",
+        "regime": "TREND_UP",
+    }
+
+    assert strategy._evaluate_signal("NFO:NIFTYCE", indicators, 110.0) is not None
+    assert strategy._evaluate_signal("NFO:NIFTYCE", indicators, 110.0) is not None
+
+    strategy.notify_entry_accepted("CE")
+
+    assert strategy._evaluate_signal("NFO:NIFTYCE", indicators, 110.0) is None
+    assert strategy.last_no_vote_reason == "direction_already_traded_today"


### PR DESCRIPTION
## What changed
- stop consuming an ORB direction when the strategy merely emits a vote
- add a strategy-manager acceptance notification hook
- notify ORB only after the order manager returns an accepted order ID
- isolate notification failures so an accepted order remains accepted
- add focused ORB and runner regression tests

## Root cause
ORB added its daily fired key during signal evaluation. Any later rejection by consensus, risk, readiness, or execution incorrectly consumed that direction for the day.

## Validation
- focused ORB/runner tests: 13 passed
- full strategy suite: passed
- complete suite passed with the known timing-sensitive heap-age test deselected; that test passed independently
- source compilation and diff checks passed

Runtime state and pytest artifacts are excluded.