### PR TITLE
Fix VWAP invalidation domain metadata

### DIFF
--- a/src/nifty_scalper_bot/strategies/elite_strategies/vwap_pro.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/vwap_pro.py
@@ -400,9 +400,9 @@ class VWAPProStrategy(EliteStrategy):
                 'continuation_confirmed': continuation_confirmed,
                 'early_trend_pullback': early_trend_pullback,
                 'setup_invalidation_premium': current_price - atr_safe,
+                'invalidation_level_domain': 'option_premium',
                 'premium_stop_distance': atr_safe,
                 'premium_target_rr': 2.0,
-                'underlying_invalidation_level': (vwap - atr_safe) if contract_side == 'CE' else (vwap + atr_safe),
                 'no_vote_conflict_mode': 'hard' if hard_conflict else 'soft',
             }
             LOGGER.info('STRATEGY_VOTE strategy=VWAPPro side=%s score=%.2f', contract_side, strategy_score)

--- a/tests/strategies/test_vwap_pro_context_boost.py
+++ b/tests/strategies/test_vwap_pro_context_boost.py
@@ -1,10 +1,14 @@
-from nifty_scalper_bot.strategies.elite_strategies.config_models import VWAPProStrategyConfig
+from nifty_scalper_bot.strategies.elite_strategies.config_models import (
+    VWAPProStrategyConfig,
+)
 from nifty_scalper_bot.strategies.elite_strategies.vwap_pro import VWAPProStrategy
 
 
 def test_vwap_pro_trend_context_boost_avoids_weak_score(monkeypatch):
     monkeypatch.setenv("EXECUTION_MODE", "LIVE")
-    strategy = VWAPProStrategy(VWAPProStrategyConfig(enabled=True, quantity=1), indicator_engine=None)
+    strategy = VWAPProStrategy(
+        VWAPProStrategyConfig(enabled=True, quantity=1), indicator_engine=None
+    )
     indicators = {
         "vwap": 100.0,
         "open": 108.9,
@@ -21,8 +25,14 @@ def test_vwap_pro_trend_context_boost_avoids_weak_score(monkeypatch):
         "spread_pct": 0.29,
     }
 
-    signal = strategy._evaluate_signal("NFO:NIFTY26MAY24000CE", indicators, current_price=109.0)
+    signal = strategy._evaluate_signal(
+        "NFO:NIFTY26MAY24000CE", indicators, current_price=109.0
+    )
 
     assert signal is not None
     assert "trend_context_boost" in signal.metadata["score_reasons"]
     assert signal.metadata["strategy_score"] >= 5.5
+    assert signal.metadata["vwap_domain"] == "option_premium"
+    assert signal.metadata["invalidation_level_domain"] == "option_premium"
+    assert signal.metadata["setup_invalidation_premium"] == 107.0
+    assert "underlying_invalidation_level" not in signal.metadata


### PR DESCRIPTION
## Summary
- remove the false underlying invalidation level derived from option-premium VWAP/ATR
- label the actual setup invalidation as `option_premium`
- add focused metadata regression coverage

## Validation
- focused VWAP tests: 7 passed
- complete strategy test suite: passed
- full suite excluding one known order-sensitive timing test: passed
- excluded timing test: passed independently
- Ruff, Black, compilation, and diff checks: passed