### PR TITLE
Integrate OrderFlow live context proof

### DIFF
--- a/src/nifty_scalper_bot/strategies/elite_strategies/__init__.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/__init__.py
@@ -2,20 +2,17 @@
 
 from __future__ import annotations
 
+from ..elite_tuesday_gamma_buyer import EliteTuesdayGammaBuyer
 from .bb_squeeze import BBSqueezeStrategy
 from .cpr_breakout import CPRBreakoutStrategy
 from .gamma_scalping import GammaScalpingStrategy
-from ..elite_tuesday_gamma_buyer import EliteTuesdayGammaBuyer
 from .oi_max_pain import OIMaxPainStrategy
 from .orb_pro import ORBProStrategy
 from .order_flow import OrderFlowStrategy
-from .order_flow_live_context_patch import apply_orderflow_live_context_patch
 from .rsi_divergence import RSIDivergenceStrategy
 from .smc_liquidity import SMCStrategy
 from .straddle_theta import StraddleThetaStrategy
 from .vwap_pro import VWAPProStrategy
-
-apply_orderflow_live_context_patch(OrderFlowStrategy)
 
 __all__ = [
     "BBSqueezeStrategy",

--- a/src/nifty_scalper_bot/strategies/elite_strategies/order_flow.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/order_flow.py
@@ -5,10 +5,20 @@ import time
 from typing import Any
 
 from nifty_scalper_bot.execution.quote_readiness import evaluate_execution_quote
-from nifty_scalper_bot.strategies.elite_strategies.base_elite import EliteSignal, EliteStrategy
-from nifty_scalper_bot.strategies.elite_strategies.config_models import OrderFlowStrategyConfig
+from nifty_scalper_bot.strategies.elite_strategies.base_elite import (
+    EliteSignal,
+    EliteStrategy,
+)
+from nifty_scalper_bot.strategies.elite_strategies.config_models import (
+    OrderFlowStrategyConfig,
+)
+from nifty_scalper_bot.strategies.elite_strategies.order_flow_live_context_patch import (
+    apply_orderflow_live_context_proof,
+)
+from nifty_scalper_bot.strategies.runtime_context_contract import (
+    resolve_context_age_seconds,
+)
 from nifty_scalper_bot.strategies.signal_quality import resolve_signal_domain
-from nifty_scalper_bot.strategies.runtime_context_contract import resolve_context_age_seconds
 from nifty_scalper_bot.utils.logging import get_logger
 
 LOGGER = get_logger(__name__)
@@ -465,7 +475,35 @@ class OrderFlowStrategy(EliteStrategy):
             if trigger_conditions_met:
                 metadata['approval_candidate'] = 'orderflow_live_depth_trigger'
             metadata.update({'context_role': 'confirmation', 'context_bonus_score': strategy_score if side_aligns else 0.0, 'context_veto_score': strategy_score if (direction in {'CE', 'PE'} and direction != side) else 0.0})
-            LOGGER.info('ORDERFLOW_TRIGGER_DECISION symbol=%s side=%s trigger_conditions_met=%s trigger_block_reason=%s score=%.2f spread_pct=%.2f context_age_seconds=%s', symbol, side, trigger_conditions_met, trigger_block_reason, strategy_score, spread_pct, indicators.get('context_age_seconds'), extra={'event':'ORDERFLOW_TRIGGER_DECISION','symbol':symbol,'side':side,'trigger_conditions_met':trigger_conditions_met,'trigger_block_reason':trigger_block_reason}); return EliteSignal(symbol=symbol, signal='BUY', confidence=max(0.1, min(0.85, strategy_score / 10.0)), entry_price=current_price, stop_loss=None, target=None, quantity=self._cfg.quantity or 1, strategy_name='OrderFlow', metadata=metadata)
+            LOGGER.info(
+                'ORDERFLOW_TRIGGER_DECISION symbol=%s side=%s trigger_conditions_met=%s trigger_block_reason=%s score=%.2f spread_pct=%.2f context_age_seconds=%s',
+                symbol,
+                side,
+                trigger_conditions_met,
+                trigger_block_reason,
+                strategy_score,
+                spread_pct,
+                indicators.get('context_age_seconds'),
+                extra={
+                    'event': 'ORDERFLOW_TRIGGER_DECISION',
+                    'symbol': symbol,
+                    'side': side,
+                    'trigger_conditions_met': trigger_conditions_met,
+                    'trigger_block_reason': trigger_block_reason,
+                },
+            )
+            signal = EliteSignal(
+                symbol=symbol,
+                signal='BUY',
+                confidence=max(0.1, min(0.85, strategy_score / 10.0)),
+                entry_price=current_price,
+                stop_loss=None,
+                target=None,
+                quantity=self._cfg.quantity or 1,
+                strategy_name='OrderFlow',
+                metadata=metadata,
+            )
+            return apply_orderflow_live_context_proof(signal, indicators)
         except Exception as e:
             LOGGER.error('Failure in OrderFlowStrategy._evaluate_signal: %s', e, exc_info=e)
             return None

--- a/src/nifty_scalper_bot/strategies/elite_strategies/order_flow_live_context_patch.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/order_flow_live_context_patch.py
@@ -1,6 +1,6 @@
-"""Live direction-context proof adapter for OrderFlow.
+"""Live direction-context proof for OrderFlow.
 
-This patch is deliberately narrow.  It does not invent an underlying CE/PE bias.
+This helper is deliberately narrow.  It does not invent an underlying CE/PE bias.
 It only prevents a live OrderFlow candidate from being blocked solely because
 ``direction_bias`` is absent when fresh spot/futures context proof is present and
 all other execution gates already passed.
@@ -12,15 +12,17 @@ import os
 from typing import Any, Mapping
 
 from nifty_scalper_bot.execution.quote_readiness import resolve_tick_age_ms
-from nifty_scalper_bot.strategies.runtime_context_contract import live_direction_context_has_proof
+from nifty_scalper_bot.strategies.runtime_context_contract import (
+    live_direction_context_has_proof,
+)
 
-_PATCH_ATTR = "_live_direction_context_proof_patch_installed"
-_ORIGINAL_ATTR = "_live_direction_context_proof_original_evaluate_signal"
 _TRUTHY = {"1", "true", "yes", "y", "on"}
 
 
 def _env_live() -> bool:
-    return str(os.getenv("EXECUTION_MODE", "SHADOW") or "SHADOW").strip().upper() == "LIVE"
+    return (
+        str(os.getenv("EXECUTION_MODE", "SHADOW") or "SHADOW").strip().upper() == "LIVE"
+    )
 
 
 def _boolish(value: Any) -> bool:
@@ -37,10 +39,17 @@ def _safe_float(value: Any) -> float | None:
     return number if number == number else None
 
 
-def _can_upgrade_direction_context_block(metadata: Mapping[str, Any], indicators: Mapping[str, Any]) -> bool:
-    if str(metadata.get("trigger_block_reason") or "") != "direction_context_missing_live":
+def _can_upgrade_direction_context_block(
+    metadata: Mapping[str, Any], indicators: Mapping[str, Any]
+) -> bool:
+    if (
+        str(metadata.get("trigger_block_reason") or "")
+        != "direction_context_missing_live"
+    ):
         return False
-    if metadata.get("raw_direction_bias") in {"CE", "PE"} or metadata.get("direction_bias") in {"CE", "PE"}:
+    if metadata.get("raw_direction_bias") in {"CE", "PE"} or metadata.get(
+        "direction_bias"
+    ) in {"CE", "PE"}:
         return False
     context = dict(indicators or {})
     context.update(dict(metadata or {}))
@@ -62,7 +71,9 @@ def _can_upgrade_direction_context_block(metadata: Mapping[str, Any], indicators
         return False
     if not _boolish(metadata.get("quote_readiness_allowed")):
         return False
-    if not _boolish(metadata.get("quote_depth_valid")) or not _boolish(metadata.get("depth_available")):
+    if not _boolish(metadata.get("quote_depth_valid")) or not _boolish(
+        metadata.get("depth_available")
+    ):
         return False
     if not _boolish(metadata.get("tradable_quote")):
         return False
@@ -71,42 +82,32 @@ def _can_upgrade_direction_context_block(metadata: Mapping[str, Any], indicators
     return True
 
 
-def apply_orderflow_live_context_patch(orderflow_cls: type[Any]) -> bool:
-    """Patch OrderFlowStrategy once. Returns True when installed."""
+def apply_orderflow_live_context_proof(
+    signal: Any,
+    indicators: Mapping[str, Any],
+) -> Any:
+    """Upgrade an otherwise valid live OrderFlow signal using fresh context proof."""
 
-    if bool(getattr(orderflow_cls, _PATCH_ATTR, False)):
-        return False
-    original = getattr(orderflow_cls, "_evaluate_signal", None)
-    if not callable(original):
-        return False
-
-    def _evaluate_signal_with_live_context_proof(self: Any, symbol: str, indicators: dict[str, Any], current_price: float, position: Any | None = None) -> Any:
-        signal = original(self, symbol, indicators, current_price, position)
-        if signal is None or not _env_live():
-            return signal
-        metadata = dict(getattr(signal, "metadata", {}) or {})
-        if not _can_upgrade_direction_context_block(metadata, indicators or {}):
-            return signal
-        metadata.update(
-            {
-                "role": "trigger",
-                "can_trigger": True,
-                "trigger_conditions_met": True,
-                "trigger_eligible": True,
-                "trigger_block_reason": "",
-                "trigger_disqualified_by": None,
-                "direction_context_ok": True,
-                "direction_context_live_proof": True,
-                "approval_candidate": "orderflow_live_depth_trigger",
-            }
-        )
-        signal.metadata = metadata
+    if signal is None or not _env_live():
         return signal
+    metadata = dict(getattr(signal, "metadata", {}) or {})
+    if not _can_upgrade_direction_context_block(metadata, indicators or {}):
+        return signal
+    metadata.update(
+        {
+            "role": "trigger",
+            "can_trigger": True,
+            "trigger_conditions_met": True,
+            "trigger_eligible": True,
+            "trigger_block_reason": "",
+            "trigger_disqualified_by": None,
+            "direction_context_ok": True,
+            "direction_context_live_proof": True,
+            "approval_candidate": "orderflow_live_depth_trigger",
+        }
+    )
+    signal.metadata = metadata
+    return signal
 
-    setattr(_evaluate_signal_with_live_context_proof, _ORIGINAL_ATTR, original)
-    setattr(orderflow_cls, "_evaluate_signal", _evaluate_signal_with_live_context_proof)
-    setattr(orderflow_cls, _PATCH_ATTR, True)
-    return True
 
-
-__all__ = ["apply_orderflow_live_context_patch"]
+__all__ = ["apply_orderflow_live_context_proof"]

--- a/tests/strategies/test_orderflow_live_context_age.py
+++ b/tests/strategies/test_orderflow_live_context_age.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-from nifty_scalper_bot.strategies.elite_strategies.order_flow_live_context_patch import (
-    _can_upgrade_direction_context_block,
+from nifty_scalper_bot.strategies.elite_strategies import (
+    order_flow_live_context_patch as live_context,
 )
+from nifty_scalper_bot.strategies.elite_strategies.order_flow import OrderFlowStrategy
 
 
 def _metadata(**overrides: object) -> dict[str, object]:
@@ -32,7 +33,15 @@ def test_live_context_upgrade_accepts_canonical_quote_age_seconds(
         "futures_fresh": True,
     }
 
-    assert _can_upgrade_direction_context_block(
+    assert live_context._can_upgrade_direction_context_block(
         _metadata(quote_age_s=0.10),
         indicators,
+    )
+
+
+def test_orderflow_evaluation_is_not_replaced_at_package_import() -> None:
+    assert OrderFlowStrategy._evaluate_signal.__module__.endswith(".order_flow")
+    assert not hasattr(
+        OrderFlowStrategy,
+        "_live_direction_context_proof_patch_installed",
     )


### PR DESCRIPTION
## Summary
- replace the OrderFlow import-time class monkey patch with an explicit pure helper call
- preserve every existing live-context proof gate and metadata upgrade
- add a regression proving package import no longer replaces `_evaluate_signal`

## Validation
- focused OrderFlow tests: 16 passed
- complete strategy test suite: passed
- full suite excluding one known order-sensitive timing test: passed
- excluded timing test: passed independently
- helper/package/test Ruff and Black checks: passed
- compilation and diff checks: passed