### PR TITLE
Disable unwired BB Squeeze context

### DIFF
--- a/src/nifty_scalper_bot/strategies/elite_strategies/builder.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/builder.py
@@ -30,6 +30,7 @@ LOGGER = get_logger(__name__)
 
 _PRIMARY_DIRECTIONAL = {'smc', 'vwap', 'orb'}
 _CONTEXT_ONLY = {'oi_max_pain', 'order_flow', 'bb_squeeze'}
+_UNWIRED_DIRECTIONAL_CONTEXT = {'bb_squeeze'}
 _DISABLED_UNTIL_FEATURE_COMPLETE = {'cpr', 'rsi_div'}
 _EXPIRY_ONLY = {'gamma_scalping', 'tuesday_gamma_buyer'}
 _THETA_ONLY = {'straddle'}
@@ -101,6 +102,9 @@ def build_elite_strategies(
 
             if strategy_mode == 'directional_scalp':
                 if field_name in _EXPIRY_ONLY or field_name in _THETA_ONLY:
+                    disabled_names.append(strategy_cls.__name__.replace('Strategy', ''))
+                    continue
+                if field_name in _UNWIRED_DIRECTIONAL_CONTEXT:
                     disabled_names.append(strategy_cls.__name__.replace('Strategy', ''))
                     continue
                 if field_name not in _PRIMARY_DIRECTIONAL and field_name not in _CONTEXT_ONLY:

--- a/tests/strategies/test_elite_builder_mode.py
+++ b/tests/strategies/test_elite_builder_mode.py
@@ -22,7 +22,8 @@ def test_directional_mode_disables_gamma_theta_and_context(monkeypatch) -> None:
     assert "EliteTuesdayGammaBuyer" not in names
     assert "StraddleTheta" not in names
     assert "OIMaxPain" not in names
-    assert {"SMC", "VWAPPro", "OrderFlow", "BBSqueeze", "ORBPro"}.issubset(names)
+    assert "BBSqueeze" not in names
+    assert {"SMC", "VWAPPro", "OrderFlow", "ORBPro"}.issubset(names)
     assert "CPRBreakout" not in names
 
 


### PR DESCRIPTION
## Summary
- stop loading BB Squeeze in `directional_scalp`, where context-symbol evaluation returns before strategies and option-symbol evaluation explicitly skips it
- keep the implementation available for future properly wired modes
- update the production-set regression expectation

## Validation
- focused builder tests: 2 passed
- complete strategy test suite: passed
- full suite excluding one known order-sensitive timing test: passed
- excluded timing test: passed independently
- test Ruff/Black, compilation, and diff checks: passed