### PR TITLE
Block duplicate normal entries for open positions

### DIFF
--- a/src/nifty_scalper_bot/execution/order_manager_core.py
+++ b/src/nifty_scalper_bot/execution/order_manager_core.py
@@ -2714,6 +2714,16 @@ class OrderManager:
                 and o.status in [OrderStatus.PENDING, OrderStatus.SUBMITTED]
                 for o in self._orders.values()
             )
+            if normalized_intent == "ENTRY" and has_open_local:
+                self._logger.warning(
+                    "ORDER_BLOCKED: open_position_exists symbol=%s side=%s",
+                    symbol,
+                    side,
+                )
+                _log_order_decision(
+                    allowed=False, block_reason="open_position_exists"
+                )
+                return None
             if has_open_local and has_pending_entry:
                 self._logger.warning(
                     "ORDER_BLOCKED: duplicate_entry_prevented symbol=%s side=%s",

--- a/tests/execution/test_order_manager_execution_mode_regression.py
+++ b/tests/execution/test_order_manager_execution_mode_regression.py
@@ -196,6 +196,63 @@ def test_nifty_option_entry_uses_unit_quantity_at_broker_boundary(
     assert broker.payloads[-1]["quantity"] == quantity
 
 
+def test_normal_entry_is_blocked_when_same_symbol_position_is_open(
+    monkeypatch, tmp_path
+):
+    from nifty_scalper_bot.execution.order_manager import OrderType
+
+    monkeypatch.setenv("EXECUTION_MODE", "SHADOW")
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    broker = _MarkedSubmittingBroker()
+    manager = _live_sim_order_manager(tmp_path, broker)
+    monkeypatch.setattr(manager._positions, "has_open_position", lambda _symbol: True)
+    monkeypatch.setattr(manager, "_lot_size_for_symbol", lambda _symbol: 65)
+
+    order_id = manager.place_order(
+        symbol="NFO:NIFTY2671423950CE",
+        side="BUY",
+        quantity=65,
+        order_type=OrderType.LIMIT,
+        price=100.0,
+        stop_loss=95.0,
+        take_profit=110.0,
+        check_risk=False,
+        intent="ENTRY",
+        signal_id="duplicate-filled-position",
+    )
+
+    assert order_id is None
+    assert broker.calls == 0
+    assert manager._last_order_decision["block_reason"] == "open_position_exists"
+
+
+def test_explicit_scale_in_is_not_blocked_as_normal_entry(monkeypatch, tmp_path):
+    from nifty_scalper_bot.execution.order_manager import OrderType
+
+    monkeypatch.setenv("EXECUTION_MODE", "SHADOW")
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    broker = _MarkedSubmittingBroker()
+    manager = _live_sim_order_manager(tmp_path, broker)
+    monkeypatch.setattr(manager._positions, "has_open_position", lambda _symbol: True)
+    monkeypatch.setattr(manager, "_lot_size_for_symbol", lambda _symbol: 65)
+
+    order_id = manager.place_order(
+        symbol="NFO:NIFTY2671423950CE",
+        side="BUY",
+        quantity=65,
+        order_type=OrderType.LIMIT,
+        price=100.0,
+        stop_loss=95.0,
+        take_profit=110.0,
+        check_risk=False,
+        intent="SCALE_IN",
+        signal_id="explicit-scale-in",
+    )
+
+    assert order_id is not None
+    assert broker.calls == 1
+
+
 @pytest.mark.parametrize("quantity", [1, 50, 75, 129])
 def test_nifty_option_entry_rejects_invalid_unit_quantities_before_broker(
     monkeypatch, tmp_path, quantity


### PR DESCRIPTION
## Root cause
The final order-submission duplicate guard required both an existing local position and a pending entry. A fully filled position normally has no pending entry, so a second ordinary `ENTRY` for the same option could reach the broker.

## Fix
- Reject `ENTRY` when the same symbol already has an open local position.
- Preserve the existing dedicated behavior for explicit `SCALE_IN`, `REVERSAL`, and exits.
- Emit the explicit `open_position_exists` order decision reason.

## Validation
- Focused order-manager module: 31 passed.
- Complete execution suite: passed.
- Complete repository suite: passed (one repository skip).
- Source compilation and diff whitespace checks passed.
- Broker-boundary regressions prove no broker call for duplicate `ENTRY` and continued explicit `SCALE_IN` behavior.