### PR TITLE
Preserve bracket intent during entry repricing

### DIFF
--- a/src/nifty_scalper_bot/execution/order_manager_core.py
+++ b/src/nifty_scalper_bot/execution/order_manager_core.py
@@ -271,6 +271,7 @@ class TradePlan:
     entry_price: float | None
     stop_loss: float | None
     take_profit: float | None
+    bracket_anchor_mode: Literal["distance", "absolute_level"] = "distance"
     strategy_name: str = "runner"
     signal_id: str | None = None
     trace_id: str | None = None
@@ -4673,16 +4674,13 @@ class OrderManager:
         )
 
     def _reanchor_bracket_to_price(self, plan: TradePlan, price: float) -> TradePlan:
-        """Re-anchor a stale SL/TP bracket to the live protected ``price``.
+        """Re-anchor a distance-based SL/TP bracket to protected ``price``.
 
         Strategy SL/TP are computed off the option premium at signal time.
-        Premiums can move materially before submission, so the precomputed
-        band can land on the wrong side of the live protected price and the
-        order is rejected (``protected_price_invalidates_bracket``) — a lost
-        but valid entry. When (and only when) the existing band is invalid
-        against ``price``, rebuild it at ``price`` preserving the plan's
-        intended SL/TP distances (so the sized rupee risk is unchanged).
-        Valid brackets pass through untouched.
+        Premiums can move before submission, so distance-derived levels must
+        move with the protected entry even while the old band remains
+        positionally valid. Absolute technical invalidations stay fixed and
+        are left to the final geometry guard when repricing invalidates them.
         """
         entry = plan.entry_price
         sl = plan.stop_loss
@@ -4697,13 +4695,9 @@ class OrderManager:
         ):
             return plan
 
-        if plan.side == "BUY":
-            bracket_valid = sl < price < tp
-        elif plan.side == "SELL":
-            bracket_valid = tp < price < sl
-        else:
+        if plan.side not in {"BUY", "SELL"}:
             return plan
-        if bracket_valid:
+        if plan.bracket_anchor_mode != "distance" or price == entry:
             return plan
 
         # Preserve the strategy's intended absolute distances from its entry.

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -16731,6 +16731,12 @@ class StrategyRunner:
         ) or _to_float(metadata.get("premium_stop_price"))
         plan_source = "existing_signal_levels"
         if (
+            stop_loss is not None
+            and explicit_stop is not None
+            and abs(stop_loss - explicit_stop) < 0.01
+        ):
+            plan_source = "explicit_premium_stop"
+        if (
             stop_loss is None
             or stop_loss <= 0
             or take_profit is None
@@ -16811,6 +16817,11 @@ class StrategyRunner:
         final_md["materialized_trade_plan"] = True
         final_md["option_trade_plan_source"] = final_md.get(
             "option_trade_plan_source", plan_source
+        )
+        final_md["bracket_anchor_mode"] = (
+            "absolute_level"
+            if final_md["option_trade_plan_source"] == "explicit_premium_stop"
+            else "distance"
         )
         self._logger.info(
             "OPTION_TRADE_PLAN_MATERIALIZED symbol=%s entry=%.2f sl=%s tp=%s source=%s",
@@ -19855,6 +19866,11 @@ class StrategyRunner:
                 entry_price=price,
                 stop_loss=stop_loss,
                 take_profit=take_profit,
+                bracket_anchor_mode=(
+                    "absolute_level"
+                    if metadata.get("bracket_anchor_mode") == "absolute_level"
+                    else "distance"
+                ),
                 strategy_name=strategy_name,
                 signal_id=signal.deterministic_id,
                 trace_id=trace_id,

--- a/tests/execution/test_order_manager_trade_plan.py
+++ b/tests/execution/test_order_manager_trade_plan.py
@@ -592,12 +592,9 @@ def test_entry_gate_uses_protected_price_and_reanchored_stop(monkeypatch) -> Non
     assert inputs.price != 100.0
     assert inputs.symbol == "NFO:NIFTY26AUG25000CE"
     assert inputs.lot_size == 65
-    # Sizing sees the plan's FINAL stop, i.e. whatever survived
-    # _reanchor_bracket_to_price (here the bracket stayed valid at the
-    # protected price, so it is unchanged). Re-anchoring itself is covered by
-    # tests/test_bracket_reanchor.py; what matters here is that the gate runs
-    # after that step and never sizes off the stale signal price.
-    assert inputs.stop_loss == 80.0
+    # Sizing sees the final distance-based stop after it moves from the
+    # signal entry (100) to the protected entry (107).
+    assert inputs.stop_loss == 87.0
 
 
 def test_entry_gate_passes_no_atr_when_option_stop_available(monkeypatch) -> None:
@@ -814,7 +811,7 @@ def test_entry_gate_uses_canonical_lowercase_risk_settings(monkeypatch) -> None:
     assert inputs.atr is None
     assert inputs.symbol == "NFO:NIFTY26AUG25000CE"
     assert inputs.price == 107.0
-    assert inputs.stop_loss == 80.0
+    assert inputs.stop_loss == 87.0
 
 
 def test_entry_gate_result_carries_frozen_sizing_details(monkeypatch) -> None:

--- a/tests/test_bracket_reanchor.py
+++ b/tests/test_bracket_reanchor.py
@@ -1,11 +1,9 @@
 """Regression tests: stale SL/TP bracket re-anchored to live protected price.
 
 Strategy SL/TP are computed off the option premium at signal time. When the
-premium moves before submission, the precomputed band can land on the wrong
-side of the live protected price, which previously rejected the order with
-``protected_price_invalidates_bracket`` (a lost but valid entry). The order
-manager now re-anchors an *invalid* band to the live price, preserving the
-plan's intended SL/TP distances, while leaving valid brackets untouched.
+premium moves before submission, distance-derived brackets must move with the
+protected price to preserve risk and reward. Absolute technical invalidations
+must remain fixed and fail closed if repricing makes their geometry invalid.
 """
 
 from __future__ import annotations
@@ -15,9 +13,18 @@ import types
 from typing import Any
 
 from nifty_scalper_bot.execution.order_manager import OrderManager, TradePlan
+from nifty_scalper_bot.strategies.runner import StrategyRunner
+from nifty_scalper_bot.strategies.signal_generator import Signal
 
 
-def _plan(side: str, entry: float, sl: float, tp: float) -> TradePlan:
+def _plan(
+    side: str,
+    entry: float,
+    sl: float,
+    tp: float,
+    *,
+    anchor_mode: str = "distance",
+) -> TradePlan:
     return TradePlan(
         symbol="NFO:NIFTY2662324050CE",
         side=side,  # type: ignore[arg-type]
@@ -25,6 +32,7 @@ def _plan(side: str, entry: float, sl: float, tp: float) -> TradePlan:
         entry_price=entry,
         stop_loss=sl,
         take_profit=tp,
+        bracket_anchor_mode=anchor_mode,  # type: ignore[arg-type]
     )
 
 
@@ -59,9 +67,24 @@ async def test_sell_stale_band_reanchored() -> None:
     assert out.take_profit < 90.00 < out.stop_loss
 
 
-async def test_valid_bracket_passes_through_unchanged() -> None:
+async def test_distance_bracket_reanchors_even_while_old_levels_remain_valid() -> None:
     plan = _plan("BUY", entry=130.0, sl=125.0, tp=140.0)
     out = _reanchor(plan, 131.0)  # 125 < 131 < 140 already valid
+
+    assert out.stop_loss == 126.0
+    assert out.take_profit == 141.0
+
+
+async def test_absolute_invalidation_passes_through_unchanged() -> None:
+    plan = _plan(
+        "BUY",
+        entry=130.0,
+        sl=125.0,
+        tp=140.0,
+        anchor_mode="absolute_level",
+    )
+    out = _reanchor(plan, 131.0)
+
     assert out.stop_loss == 125.0
     assert out.take_profit == 140.0
     assert out is plan  # untouched
@@ -78,6 +101,35 @@ async def test_missing_levels_untouched() -> None:
     )
     out = _reanchor(plan, 138.45)
     assert out is plan
+
+
+def test_materialized_explicit_premium_stop_is_marked_absolute() -> None:
+    runner = types.SimpleNamespace(
+        _logger=logging.getLogger("materialize-test"),
+        _validate_long_option_geometry=lambda **kwargs: kwargs["signal"],
+        _anchor_sl_tp_to_execution=lambda **kwargs: kwargs["signal"],
+    )
+    signal = Signal(
+        action="BUY",
+        symbol="NFO:NIFTY2662324050CE",
+        quantity=65,
+        confidence=0.8,
+        reason="technical_invalidation",
+        stop_loss=97.5,
+        take_profit=105.0,
+        metadata={"setup_invalidation_premium": 97.5},
+    )
+
+    out = StrategyRunner._materialize_option_trade_plan(
+        runner,
+        signal,
+        execution_price=100.0,
+        atr=2.0,
+        entry_side="BUY",
+    )
+
+    assert out.metadata["option_trade_plan_source"] == "explicit_premium_stop"
+    assert out.metadata["bracket_anchor_mode"] == "absolute_level"
 
 
 async def test_submit_reanchors_instead_of_rejecting(monkeypatch: Any) -> None:
@@ -97,13 +149,17 @@ async def test_submit_reanchors_instead_of_rejecting(monkeypatch: Any) -> None:
     def _fake_managed(**kwargs: Any) -> Any:
         captured.update(kwargs)
         return types.SimpleNamespace(
-            accepted=True, order_id="ORD-1", reason="accepted",
-            details={}, broker_attempted=True,
+            accepted=True,
+            order_id="ORD-1",
+            reason="accepted",
+            details={},
+            broker_attempted=True,
         )
 
     monkeypatch.setattr(mgr, "is_kill_switch_active", lambda: False)
     monkeypatch.setattr(
-        mgr, "_validate_trade_plan",
+        mgr,
+        "_validate_trade_plan",
         lambda plan: OrderPreflightResult(True, "ok", {}),
     )
     monkeypatch.setattr(mgr, "_protected_limit_price", lambda plan: 119.00)


### PR DESCRIPTION
## Root cause
The order manager re-anchored SL/TP only when the old bracket crossed the protected entry price. A distance-derived bracket could therefore remain positionally valid while its reward-to-risk degraded below the execution floor. The execution contract also did not distinguish a movable premium-distance stop from an absolute technical invalidation.

## Fix
- Add `bracket_anchor_mode` to `TradePlan`, defaulting to distance semantics for existing callers.
- Re-anchor distance-derived SL/TP whenever protected price differs from signal entry, preserving intended risk and reward distances.
- Keep absolute technical invalidations fixed so the existing final geometry guard can reject economically invalid repricing.
- Propagate stop provenance from runner materialization into the submitted trade plan.
- Keep margin sizing after re-anchoring so it uses the final protected price and final stop.

## Validation
- Focused bracket and order-plan tests: 52 passed.
- Complete execution suite: passed.
- Complete strategy suite: passed.
- Complete repository suite: passed with one repository skip.
- New bracket regression file passes Ruff and Black.
- Production compilation and diff whitespace checks passed.
- All four remote blob hashes match the locally validated commit.