### PR TITLE
Throttle deterministic pre-broker entry rejections

### DIFF
--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -935,6 +935,9 @@ class StrategyRunner:
             1.0,
             float(os.getenv("EXEC_REJECT_COOLDOWN_INVALID_LOT_SECONDS", "300") or 300),
         )
+        self._exec_reject_rr_seconds = 5.0
+        self._exec_reject_margin_seconds = 30.0
+        self._exec_reject_position_seconds = 15.0
         self._order_attempt_window: Deque[float] = deque()
         self._signal_attempt_debounce_seconds = max(
             0.5, float(os.getenv("SIGNAL_ATTEMPT_DEBOUNCE_SECONDS", "2") or 2)
@@ -4208,6 +4211,9 @@ class StrategyRunner:
         reject_reason_cooldown = {
             "runtime_symbol_execution_not_ready": self._exec_reject_runtime_not_ready_seconds,
             "invalid_lot_quantity": self._exec_reject_invalid_lot_seconds,
+            "entry_rr_below_floor": self._exec_reject_rr_seconds,
+            "risk_capacity_unavailable": self._exec_reject_margin_seconds,
+            "position_conflict": self._exec_reject_position_seconds,
         }
         normalized_reject_symbol = normalize_symbol(symbol)
         for reject_reason, seconds in reject_reason_cooldown.items():
@@ -4230,6 +4236,45 @@ class StrategyRunner:
                 )
                 return SignalExecutionResult(False, f"{reject_reason}_reject_cooldown")
         return None
+
+    @staticmethod
+    def _deterministic_execution_reject_reason(reason: object) -> str | None:
+        normalized = str(reason or "").strip().lower()
+        if "entry_rr_below_floor" in normalized:
+            return "entry_rr_below_floor"
+        if any(
+            marker in normalized
+            for marker in (
+                "no_qty_after_risk",
+                "insufficient_margin",
+                "available_balance_unavailable",
+            )
+        ):
+            return "risk_capacity_unavailable"
+        if any(
+            marker in normalized
+            for marker in ("single_position_gate", "open_position_exists")
+        ):
+            return "position_conflict"
+        return None
+
+    def _mark_deterministic_execution_reject_cooldown(
+        self,
+        *,
+        symbol: str,
+        reason_key: str,
+        reason: object,
+        now_epoch: float,
+        broker_attempted: bool,
+    ) -> str | None:
+        if broker_attempted:
+            return None
+        reject_reason = self._deterministic_execution_reject_reason(reason)
+        if reject_reason is None:
+            return None
+        reject_key = f"{normalize_symbol(symbol)}:{reason_key}:{reject_reason}"
+        self._execution_reject_cooldown_ts[reject_key] = now_epoch
+        return reject_reason
 
     def get_runtime_readiness_snapshot(self) -> dict[str, object]:
         """Return runtime readiness snapshot. Args: none. Returns: readiness map. Raises: none."""
@@ -19933,6 +19978,13 @@ class StrategyRunner:
                         **dict(getattr(submit_result, "details", {}) or {}),
                         "trace_id": trace_id,
                     }
+                    self._mark_deterministic_execution_reject_cooldown(
+                        symbol=order_symbol,
+                        reason_key=reason_key,
+                        reason=submit_result.reason,
+                        now_epoch=now_epoch,
+                        broker_attempted=broker_attempted,
+                    )
                     if submit_result.reason == "kill_switch_active" and hasattr(
                         self._order_manager, "get_kill_switch_status"
                     ):

--- a/tests/strategies/test_runner_cooldowns.py
+++ b/tests/strategies/test_runner_cooldowns.py
@@ -2,30 +2,92 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
+from nifty_scalper_bot.strategies.runner import StrategyRunner
+
 
 def test_on_tick_error_phase_updates_for_premium_squeeze() -> None:
-    source = Path('src/nifty_scalper_bot/strategies/runner.py').read_text(encoding='utf-8')
+    source = Path("src/nifty_scalper_bot/strategies/runner.py").read_text(
+        encoding="utf-8"
+    )
     assert 'phase = "phase8_premium_squeeze"' in source
 
 
 def test_active_option_selection_uses_atm_strike_key() -> None:
-    source = Path('src/nifty_scalper_bot/core/app.py').read_text(encoding='utf-8')
+    source = Path("src/nifty_scalper_bot/core/app.py").read_text(encoding="utf-8")
     assert 'atm=basket.get("atm_strike")' in source
 
 
 def test_cooldown_first_trade_no_epoch_age() -> None:
-    source = Path('src/nifty_scalper_bot/strategies/runner.py').read_text(encoding='utf-8')
-    assert 'first_trade_for_key' in source
-    assert 'age_seconds=None' not in source or 'age_seconds=%s' in source
+    source = Path("src/nifty_scalper_bot/strategies/runner.py").read_text(
+        encoding="utf-8"
+    )
+    assert "first_trade_for_key" in source
+    assert "age_seconds=None" not in source or "age_seconds=%s" in source
 
 
 def test_rejected_signal_cooldown_prevents_spam() -> None:
-    source = Path('src/nifty_scalper_bot/strategies/runner.py').read_text(encoding='utf-8')
-    assert 'SIGNAL_REJECT_COOLDOWN_ACTIVE' in source
-    assert '_signal_reject_cooldown_ts' in source
+    source = Path("src/nifty_scalper_bot/strategies/runner.py").read_text(
+        encoding="utf-8"
+    )
+    assert "SIGNAL_REJECT_COOLDOWN_ACTIVE" in source
+    assert "_signal_reject_cooldown_ts" in source
 
 
 def test_candidate_enrichment_raises_rr_and_option_score() -> None:
-    source = Path('src/nifty_scalper_bot/strategies/runner.py').read_text(encoding='utf-8')
+    source = Path("src/nifty_scalper_bot/strategies/runner.py").read_text(
+        encoding="utf-8"
+    )
     assert 'metadata["rr_score"] = max(' in source
     assert 'metadata["option_score"] = max(' in source
+
+
+@pytest.mark.parametrize(
+    ("reason", "expected"),
+    [
+        ("entry_rr_below_floor", "entry_rr_below_floor"),
+        ("MARGIN no_qty_after_risk", "risk_capacity_unavailable"),
+        ("insufficient_margin", "risk_capacity_unavailable"),
+        ("available_balance_unavailable", "risk_capacity_unavailable"),
+        ("single_position_gate", "position_conflict"),
+        ("open_position_exists", "position_conflict"),
+        ("quote_stale", None),
+    ],
+)
+def test_deterministic_execution_reject_reason_families(reason, expected) -> None:
+    assert StrategyRunner._deterministic_execution_reject_reason(reason) == expected
+
+
+def test_deterministic_reject_cooldown_requires_no_broker_attempt() -> None:
+    runner = object.__new__(StrategyRunner)
+    runner._execution_reject_cooldown_ts = {}
+
+    marked = runner._mark_deterministic_execution_reject_cooldown(
+        symbol="NFO:NIFTY26AUG25000CE",
+        reason_key="orderflow",
+        reason="MARGIN no_qty_after_risk",
+        now_epoch=100.0,
+        broker_attempted=True,
+    )
+
+    assert marked is None
+    assert runner._execution_reject_cooldown_ts == {}
+
+
+def test_deterministic_local_reject_stamps_existing_cooldown_cache() -> None:
+    runner = object.__new__(StrategyRunner)
+    runner._execution_reject_cooldown_ts = {}
+
+    marked = runner._mark_deterministic_execution_reject_cooldown(
+        symbol="NFO:NIFTY26AUG25000CE",
+        reason_key="orderflow",
+        reason="MARGIN no_qty_after_risk",
+        now_epoch=100.0,
+        broker_attempted=False,
+    )
+
+    assert marked == "risk_capacity_unavailable"
+    assert runner._execution_reject_cooldown_ts == {
+        "NFO:NIFTY26AUG25000CE:orderflow:risk_capacity_unavailable": 100.0
+    }


### PR DESCRIPTION
## Root cause
After a deterministic local entry rejection, runner rolled back the directional reservation immediately but did not stamp the existing execution-rejection cache. The unchanged setup could therefore rebuild and traverse the full execution path again within seconds, even though margin/risk capacity or an open-position conflict could not plausibly change that quickly.

## Fix
- Reuse the existing execution-rejection cooldown cache and pre-attempt gate.
- Normalize only three deterministic reason families: RR geometry (5 s), risk/margin capacity (30 s), and position conflict (15 s).
- Stamp cooldowns only when the order manager confirms `broker_attempted=False`.
- Leave quote recovery cadence, broker-attempted failures, successful order cooldowns, and protective exits unchanged.

## Validation
- Focused cooldown tests: 14 passed.
- Complete strategy suite: passed.
- Complete repository suite: passed with one repository skip.
- Changed test Ruff/Black checks passed.
- Runner compilation and diff whitespace checks passed.
- Both remote blobs match the locally validated commit.