### PR TITLE
Defer derived option analytics from tick ingestion

### DIFF
--- a/src/nifty_scalper_bot/data/data_hub.py
+++ b/src/nifty_scalper_bot/data/data_hub.py
@@ -1121,7 +1121,9 @@ class DataHub:
             exc,
         )
 
-    def _capture_option_metrics(self, symbol: str, tick: Tick) -> None:
+    def _capture_option_metrics(
+        self, symbol: str, tick: Tick, *, derive_missing: bool = True
+    ) -> None:
         iv_raw = tick.get("implied_volatility") or tick.get("iv")
         if iv_raw is not None:
             try:
@@ -1144,6 +1146,8 @@ class DataHub:
                 self._oi_cache[symbol] = float(oi)
             except (TypeError, ValueError):
                 pass
+        if not derive_missing:
+            return
         if symbol in self._iv_cache and symbol in self._greeks_cache:
             return
         parsed = self._parse_option_symbol(symbol)
@@ -1312,7 +1316,7 @@ class DataHub:
                 },
             )
 
-        self._capture_option_metrics(symbol, canonical_tick)
+        self._capture_option_metrics(symbol, canonical_tick, derive_missing=False)
 
         for callback in subscribers:
             try:

--- a/tests/data/test_mdm_callback_dispatch.py
+++ b/tests/data/test_mdm_callback_dispatch.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import asyncio
+from datetime import datetime, timezone
 from typing import Any
 
+import nifty_scalper_bot.data.data_hub as data_hub_module
 from nifty_scalper_bot.data.data_hub import DataHub
 from nifty_scalper_bot.data.market_data_manager import MarketDataManager
 
@@ -19,8 +21,10 @@ def test_sync_callback_none_no_error() -> None:
         seen.append(tick)
         return None
 
-    mdm.subscribe('NSE:NIFTY', callback)
-    mdm._emit_tick('NSE:NIFTY', {'symbol': 'NSE:NIFTY', 'ltp': 10.0}, source='ws')  # noqa: SLF001
+    mdm.subscribe("NSE:NIFTY", callback)
+    mdm._emit_tick(
+        "NSE:NIFTY", {"symbol": "NSE:NIFTY", "ltp": 10.0}, source="ws"
+    )  # noqa: SLF001
     assert len(seen) == 1
 
 
@@ -36,29 +40,93 @@ def test_sync_callback_custom_awaitable_no_type_error() -> None:
     def callback(_tick: dict[str, Any]) -> CustomAwaitable:
         return CustomAwaitable()
 
-    mdm.subscribe('NSE:NIFTY', callback)
-    mdm._emit_tick('NSE:NIFTY', {'symbol': 'NSE:NIFTY', 'ltp': 10.0}, source='ws')  # noqa: SLF001
+    mdm.subscribe("NSE:NIFTY", callback)
+    mdm._emit_tick(
+        "NSE:NIFTY", {"symbol": "NSE:NIFTY", "ltp": 10.0}, source="ws"
+    )  # noqa: SLF001
 
 
 def test_async_callback_scheduled_on_main_loop() -> None:
     mdm = MarketDataManager(DummyBroker(), websocket=None)
-    ran = {'ok': False}
+    ran = {"ok": False}
 
     async def callback(_tick: dict[str, Any]) -> None:
-        ran['ok'] = True
+        ran["ok"] = True
 
     async def runner() -> None:
         mdm.set_event_loop(asyncio.get_running_loop())
-        mdm.subscribe('NSE:NIFTY', callback)
-        mdm._emit_tick('NSE:NIFTY', {'symbol': 'NSE:NIFTY', 'ltp': 11.0}, source='ws')  # noqa: SLF001
+        mdm.subscribe("NSE:NIFTY", callback)
+        mdm._emit_tick(
+            "NSE:NIFTY", {"symbol": "NSE:NIFTY", "ltp": 11.0}, source="ws"
+        )  # noqa: SLF001
         await asyncio.sleep(0.01)
 
     asyncio.run(runner())
-    assert ran['ok'] is True
+    assert ran["ok"] is True
 
 
 def test_datahub_ingest_tick_sync_returns_none() -> None:
     mdm = MarketDataManager(DummyBroker(), websocket=None)
     hub = DataHub(mdm)
-    result = hub.ingest_tick_sync({'symbol': 'NSE:NIFTY', 'ltp': 1.0})
+    result = hub.ingest_tick_sync({"symbol": "NSE:NIFTY", "ltp": 1.0})
     assert result is None
+
+
+def test_tick_ingestion_defers_missing_option_analytics(monkeypatch) -> None:
+    hub = DataHub(MarketDataManager(DummyBroker(), websocket=None))
+    symbol = "NFO:NIFTY26AUG25000CE"
+    calls: list[float] = []
+    monkeypatch.setattr(hub, "get_latest_price", lambda _symbol: 25_000.0)
+    monkeypatch.setattr(
+        data_hub_module,
+        "implied_volatility",
+        lambda **_kwargs: calls.append(1.0) or 0.2,
+    )
+    monkeypatch.setattr(
+        data_hub_module,
+        "black_scholes_greeks",
+        lambda **_kwargs: {"delta": 0.5},
+    )
+
+    hub.ingest_tick_sync(
+        {
+            "symbol": symbol,
+            "instrument_token": 123,
+            "ltp": 100.0,
+            "source": "ws",
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
+    )
+
+    assert calls == []
+    monkeypatch.setattr(hub, "get_quote", lambda _symbol: hub._quotes[symbol])
+    assert hub.get_iv(symbol) == 0.2
+    assert calls == [1.0]
+    assert hub.get_greeks(symbol) == {"delta": 0.5}
+
+
+def test_tick_ingestion_still_caches_broker_option_metrics(monkeypatch) -> None:
+    hub = DataHub(MarketDataManager(DummyBroker(), websocket=None))
+    symbol = "NFO:NIFTY26AUG25000CE"
+    monkeypatch.setattr(
+        data_hub_module,
+        "implied_volatility",
+        lambda **_kwargs: (_ for _ in ()).throw(AssertionError("must not derive")),
+    )
+
+    hub.ingest_tick_sync(
+        {
+            "symbol": symbol,
+            "instrument_token": 123,
+            "ltp": 100.0,
+            "iv": 0.25,
+            "greeks": {"delta": 0.6},
+            "oi": 12_345,
+            "source": "ws",
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
+    )
+
+    assert hub.get_iv(symbol) == 0.25
+    assert hub.get_greeks(symbol) == {"delta": 0.6}
+    assert hub.get_oi(symbol) == 12_345


### PR DESCRIPTION
## Root cause
`DataHub._ingest_tick_impl()` called `_capture_option_metrics()` synchronously for every tick. When an option tick lacked broker IV/Greeks, that helper ran iterative implied-volatility solving and Black-Scholes Greeks before subscribers were notified, adding optional analytics work to the quote and stop-protection path.

## Fix
- Add a `derive_missing` switch to the existing metric-capture owner.
- During tick ingestion, cache broker-supplied IV/Greeks/OI but skip fallback derivation.
- Preserve existing on-demand derivation through `get_iv()` and `get_greeks()`.
- Do not add threads, queues, dependencies, or a competing analytics cache.

## Validation
- Focused DataHub callback/metric tests: 6 passed.
- Complete DataHub/data suite passed apart from one unrelated timing-sensitive live-runtime test.
- That timing test passed independently.
- Every remaining repository test passed with only that test deselected; one repository skip remained.
- Changed test Ruff/Black, production compilation, and diff whitespace checks passed.
- Both remote blobs match the locally validated commit.