### PR TITLE
Consolidate background health work

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -15974,18 +15974,6 @@ class NiftyScalperApp:
                         )
                         await asyncio.sleep(5.0)
                     try:
-                        if _should_reconcile_now(self._ctx):
-                            await _reconcile_state(self._ctx, source="manual")
-                    except Exception as exc:  # noqa: BLE001
-                        LOGGER.warning(
-                            "Periodic state reconciliation failed",
-                            extra={
-                                "event": "state_reconcile_failed_periodic",
-                                "error": str(exc),
-                            },
-                            exc_info=True,
-                        )
-                    try:
                         _alert_overnight_exposure(self._ctx)
                     except Exception as exc:  # noqa: BLE001
                         LOGGER.warning(

--- a/src/nifty_scalper_bot/core/polling_failover_runtime.py
+++ b/src/nifty_scalper_bot/core/polling_failover_runtime.py
@@ -14,6 +14,7 @@ import time
 from typing import Any, Mapping
 
 from nifty_scalper_bot.core.polling_failover import decide_polling_fallback
+from nifty_scalper_bot.utils.log_throttle import log_on_change
 
 _PATCH_ATTR = "_polling_failover_runtime_patch_installed"
 _APP_MODULE_NAME = "nifty_scalper_bot.core.app"
@@ -79,7 +80,11 @@ def _safe_feed_health(mdm: Any) -> Mapping[str, Any]:
             "POLLING_FALLBACK_HEALTH_FAILED error_type=%s error=%s",
             type(exc).__name__,
             exc,
-            extra={"event": "POLLING_FALLBACK_HEALTH_FAILED", "error_type": type(exc).__name__, "error": str(exc)},
+            extra={
+                "event": "POLLING_FALLBACK_HEALTH_FAILED",
+                "error_type": type(exc).__name__,
+                "error": str(exc),
+            },
         )
         return {}
     return value if isinstance(value, Mapping) else {}
@@ -99,7 +104,11 @@ def _safe_data_age_ms(mdm: Any) -> float | None:
             "POLLING_FALLBACK_AGE_FAILED error_type=%s error=%s",
             type(exc).__name__,
             exc,
-            extra={"event": "POLLING_FALLBACK_AGE_FAILED", "error_type": type(exc).__name__, "error": str(exc)},
+            extra={
+                "event": "POLLING_FALLBACK_AGE_FAILED",
+                "error_type": type(exc).__name__,
+                "error": str(exc),
+            },
         )
         return None
 
@@ -107,7 +116,11 @@ def _safe_data_age_ms(mdm: Any) -> float | None:
 async def _stop_fallback_safely(fallback: Any, *, reason: str) -> None:
     try:
         running_fn = getattr(fallback, "is_running", None)
-        running = bool(running_fn()) if callable(running_fn) else bool(getattr(fallback, "_running", False))
+        running = (
+            bool(running_fn())
+            if callable(running_fn)
+            else bool(getattr(fallback, "_running", False))
+        )
         if not running:
             # Already stopped: repeating set_websocket_mode(True) every healthy
             # supervisor iteration is redundant async churn / noisy telemetry.
@@ -124,7 +137,12 @@ async def _stop_fallback_safely(fallback: Any, *, reason: str) -> None:
             reason,
             type(exc).__name__,
             exc,
-            extra={"event": "POLLING_FALLBACK_STOP_FAILED", "reason": reason, "error_type": type(exc).__name__, "error": str(exc)},
+            extra={
+                "event": "POLLING_FALLBACK_STOP_FAILED",
+                "reason": reason,
+                "error_type": type(exc).__name__,
+                "error": str(exc),
+            },
         )
 
 
@@ -134,7 +152,11 @@ async def _start_fallback_safely(fallback: Any, *, decision_reason: str | None) 
         if callable(mode_fn):
             await _maybe_await(mode_fn(False))
         running_fn = getattr(fallback, "is_running", None)
-        running = bool(running_fn()) if callable(running_fn) else bool(getattr(fallback, "_running", False))
+        running = (
+            bool(running_fn())
+            if callable(running_fn)
+            else bool(getattr(fallback, "_running", False))
+        )
         if not running:
             start_fn = getattr(fallback, "start", None)
             if callable(start_fn):
@@ -145,7 +167,12 @@ async def _start_fallback_safely(fallback: Any, *, decision_reason: str | None) 
             decision_reason,
             type(exc).__name__,
             exc,
-            extra={"event": "POLLING_FALLBACK_START_FAILED", "reason": decision_reason, "error_type": type(exc).__name__, "error": str(exc)},
+            extra={
+                "event": "POLLING_FALLBACK_START_FAILED",
+                "reason": decision_reason,
+                "error_type": type(exc).__name__,
+                "error": str(exc),
+            },
         )
 
 
@@ -232,16 +259,30 @@ async def _polling_failover_supervisor_iteration(
         feed_health=feed_health,
         data_age_ms=data_age_ms,
     )
-    LOGGER.info(
-        "POLLING_FALLBACK_DECISION activate=%s reason=%s ws_ok=%s lagging=%s futures_fresh=%s options_fresh=%s max_age_ms=%s threshold_ms=%s",
-        decision.activate,
-        decision.reason,
-        decision.ws_ok,
-        decision.lagging,
-        decision.futures_fresh,
-        decision.options_fresh,
-        decision.max_age_ms,
-        decision.threshold_ms,
+    log_on_change(
+        LOGGER,
+        key="polling_fallback_decision",
+        state=(
+            decision.activate,
+            decision.reason,
+            decision.ws_ok,
+            decision.lagging,
+            decision.futures_fresh,
+            decision.options_fresh,
+            decision.required_symbol_recovery_active,
+            decision.stale_required_symbols,
+        ),
+        message=(
+            "POLLING_FALLBACK_DECISION "
+            f"activate={decision.activate} reason={decision.reason} "
+            f"ws_ok={decision.ws_ok} lagging={decision.lagging} "
+            f"futures_fresh={decision.futures_fresh} "
+            f"options_fresh={decision.options_fresh} "
+            f"max_age_ms={decision.max_age_ms} "
+            f"threshold_ms={decision.threshold_ms}"
+        ),
+        reminder_seconds=60.0,
+        level=logging.INFO,
         extra=decision.as_log_extra(),
     )
     now = time.monotonic()
@@ -268,9 +309,10 @@ def apply_app_patch(app_module: Any) -> bool:
     if bool(getattr(app_module, _PATCH_ATTR, False)):
         return False
     supervisor = getattr(app_module, "_polling_failover_supervisor_iteration", None)
-    if callable(supervisor) and getattr(
-        supervisor, "_nifty_polling_supervisor_version", None
-    ) == 2:
+    if (
+        callable(supervisor)
+        and getattr(supervisor, "_nifty_polling_supervisor_version", None) == 2
+    ):
         setattr(app_module, _PATCH_ATTR, True)
         return False
 

--- a/tests/core/test_polling_failover_runtime_installation.py
+++ b/tests/core/test_polling_failover_runtime_installation.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import asyncio
 from types import SimpleNamespace
 
+from nifty_scalper_bot.core import polling_failover_runtime as runtime
 from nifty_scalper_bot.core.polling_failover_runtime import apply_app_patch
 
 
@@ -34,3 +36,43 @@ def test_apply_app_patch_is_idempotent_for_versioned_supervisor():
 
     assert apply_app_patch(module) is False
     assert module._polling_failover_supervisor_iteration is installed_supervisor
+
+
+def test_healthy_decision_uses_state_change_logging(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        runtime,
+        "log_on_change",
+        lambda *args, **kwargs: calls.append(kwargs),
+    )
+    ctx = SimpleNamespace(
+        is_market_open_now=lambda: True,
+        websocket_manager=SimpleNamespace(is_connected=lambda: True),
+        market_data_manager=SimpleNamespace(
+            trading_feed_health=lambda: {
+                "lagging": False,
+                "futures_fresh": True,
+                "options_fresh": True,
+            },
+            data_age_ms=lambda: 100.0,
+        ),
+    )
+    fallback = SimpleNamespace(is_running=lambda: False)
+
+    asyncio.run(
+        runtime._polling_failover_supervisor_iteration(
+            ctx,
+            fallback,
+            quote_stale_ms=2_000,
+            degraded_since=None,
+            recovered_since=None,
+            activate_after=5,
+            recover_cooldown=10,
+        )
+    )
+
+    assert len(calls) == 1
+    assert calls[0]["key"] == "polling_fallback_decision"
+    assert calls[0]["state"][0] is False
+    assert calls[0]["reminder_seconds"] == 60.0
+    assert "activate=False" in calls[0]["message"]

--- a/tests/core/test_reconcile_readiness_lifecycle.py
+++ b/tests/core/test_reconcile_readiness_lifecycle.py
@@ -3,7 +3,7 @@
 Regression for the 2026-07-27 production logs: `_reconcile_state` cleared
 `position_reconciliation_completed` at the START of every run, and readiness
 converted that into the hard blocker `position_reconciliation_incomplete`.
-With refreshes every ~15-20s each taking 2.5-7.2s (periodic_health AND manual
+With refreshes every ~15-20s each taking 2.5-7.2s (two scheduled owners
 overlapping), the 30s readiness check repeatedly landed inside a run and
 live_orders_armed flapped False/True, blocking entries roughly half the time:
 
@@ -18,10 +18,7 @@ not "no refresh is running".
 
 from __future__ import annotations
 
-import os
 from datetime import datetime, timedelta, timezone
-
-import pytest
 
 from nifty_scalper_bot.core.app import _reconciliation_max_age_seconds
 
@@ -129,3 +126,16 @@ def test_reconcile_state_coalesces_overlapping_runs(monkeypatch) -> None:
 
     # Coalesced: no new run id registered, and the in-flight one is untouched.
     assert ctx.position_reconciliation_active_run_ids == started_before
+
+
+def test_health_loop_is_not_a_second_reconciliation_scheduler() -> None:
+    """Only the dedicated sync loop may own scheduled reconciliation."""
+    import inspect
+
+    from nifty_scalper_bot.core import app as app_module
+
+    health_loop_source = inspect.getsource(app_module.NiftyScalperApp._health_loop)
+    app_source = inspect.getsource(app_module)
+
+    assert "_reconcile_state" not in health_loop_source
+    assert 'await _reconcile_state(ctx, source="periodic_health")' in app_source


### PR DESCRIPTION
## Root causes

- Position reconciliation had two scheduled owners: the dedicated 15-second sync loop and the 30-second health loop. The second owner also mislabeled scheduled work as `source="manual"`, causing redundant broker round-trips despite the single-flight guard.
- Polling fallback decisions were logged unconditionally every supervisor iteration, including unchanged healthy state.

## Corrections

- Keep the dedicated sync loop as the sole scheduled reconciliation owner.
- Preserve health checks, overnight exposure checks, startup reconciliation, and genuine manual reconciliation paths.
- Route polling decisions through the existing thread-safe `log_on_change` utility.
- Log immediately on meaningful decision-state changes and emit an unchanged-state reminder every 60 seconds.
- Exclude quote ages from the comparison state so naturally changing ages do not defeat throttling; retain ages in each emitted log record.

## Validation

- 24 focused and adjacent reconciliation/fallback tests passed.
- Ruff and Black passed for changed scoped files.
- Mypy passed for the polling runtime adapter.
- Production sources compile.
- Full repository suite passed with one order-sensitive exit test deselected; that test passed independently.
- Remote blob hashes exactly match the locally validated files.
