### PR TITLE
Record completed strategy trade outcomes

### DIFF
--- a/src/nifty_scalper_bot/core/strategy_manager.py
+++ b/src/nifty_scalper_bot/core/strategy_manager.py
@@ -1420,6 +1420,7 @@ class StrategyManager(_BaseStrategyManager):
         if regime_label is None:
             regime_label = self._regime_state.regime
         perf.record(pnl, regime=regime_label)
+        self._adaptive_store.record_trade(strategy_name, pnl)
         if metadata:
             log.info(
                 "Condition met: strategy_trade_recorded",

--- a/src/nifty_scalper_bot/execution/bracket_core.py
+++ b/src/nifty_scalper_bot/execution/bracket_core.py
@@ -271,6 +271,7 @@ class BracketState:
 
     # Metadata
     tag: str | None = None
+    trade_provenance: Dict[str, Any] = field(default_factory=dict)
     entry_order_intent: str = "ENTRY"
     trade_lifecycle_id: str | None = None
     linked_exit_order_ids: list[str] = field(default_factory=list)
@@ -404,6 +405,7 @@ class BracketState:
             "lowest_ltp": self.lowest_ltp,
             "last_ltp": self.last_ltp,
             "tag": self.tag,
+            "trade_provenance": dict(self.trade_provenance),
             "created_at": self.created_at,
             "updated_at": self.updated_at,
             "exit_executed": self.exit_executed,
@@ -526,7 +528,7 @@ class BracketManager:
         self._orphan_retry_last_attempt: Dict[str, float] = {}
         self._exit_executor: Callable[[str, int], Any] | None = None
         self._trailing_controller_factory: Callable[[BracketState], Any] | None = None
-        self._on_exit_complete_hook: Callable[[str], None] | None = None
+        self._on_exit_complete_hook: Callable[..., None] | None = None
         self._on_position_open_priority_hook: Callable[[str], None] | None = None
         self._on_position_closed_priority_hook: Callable[[str], None] | None = None
         self._active_bracket_symbols_hook: Callable[[Iterable[str]], None] | None = None
@@ -676,9 +678,44 @@ class BracketManager:
         """Attach an external market-exit executor. Args: executor; Returns: None; Raises: None."""
         self._exit_executor = executor
 
-    def attach_on_exit_complete(self, hook: Callable[[str], None] | None) -> None:
+    def attach_on_exit_complete(self, hook: Callable[..., None] | None) -> None:
         """Attach callback fired with symbol when bracket fully closes. Lets runner clear orchestrator direction lock."""
         self._on_exit_complete_hook = hook
+
+    def attach_trade_provenance(
+        self, order_id: str, provenance: Mapping[str, Any]
+    ) -> bool:
+        """Persist strategy/setup identity on the bracket owned by *order_id*."""
+        with self._lock:
+            bracket = self._brackets.get(str(order_id))
+            if bracket is None:
+                return False
+            bracket.trade_provenance.update(dict(provenance or {}))
+            bracket.updated_at = time.time()
+        self.save_state()
+        return True
+
+    def get_completed_trade_outcome(self, symbol: str) -> dict[str, Any] | None:
+        """Return the latest completed outcome for *symbol*, when available."""
+        normalized = normalize_symbol(symbol)
+        with self._lock:
+            matches = [
+                bracket
+                for bracket in self._brackets.values()
+                if bracket.symbol == normalized
+                and isinstance(
+                    getattr(bracket, "_completed_trade_outcome", None), Mapping
+                )
+            ]
+            if not matches:
+                return None
+            latest = max(
+                matches,
+                key=lambda bracket: float(
+                    getattr(bracket, "closed_at", 0.0) or 0.0
+                ),
+            )
+            return dict(getattr(latest, "_completed_trade_outcome"))
 
     def attach_open_position_priority_hooks(
         self,
@@ -1092,6 +1129,7 @@ class BracketManager:
         activate_immediately: bool = False,
         intent: str | None = None,
         resolved_lot_size: int | None = None,
+        trade_provenance: Mapping[str, Any] | None = None,
     ) -> None:
         """Register a position for virtual bracket monitoring.
 
@@ -1154,6 +1192,7 @@ class BracketManager:
                 existing.remaining_quantity = abs(qty)
                 existing.exit_state = BracketExitLifecycle.OPEN_PENDING_FILL.value
                 existing.exit_pending = False
+                existing.trade_provenance.update(dict(trade_provenance or {}))
                 self.save_state()  # Persist updates
                 self._sync_active_bracket_symbols_to_mdm()
                 return
@@ -1221,6 +1260,7 @@ class BracketManager:
                 ),
                 entry_fill_price=price if activate_immediately else None,
                 tag=tag,
+                trade_provenance=dict(trade_provenance or {}),
                 entry_order_intent=normalized_intent or "ENTRY",
                 trade_lifecycle_id=order_id,
                 trailing_config=t_config,
@@ -4419,6 +4459,7 @@ class BracketManager:
                 payload.get("previous_ltp", payload.get("last_ltp", entry_price)),
             ),
             tag=payload.get("tag"),
+            trade_provenance=dict(payload.get("trade_provenance") or {}),
             created_at=finite_float(
                 "created at", payload.get("created_at", time.time())
             ),

--- a/src/nifty_scalper_bot/execution/ledger_bracket_manager.py
+++ b/src/nifty_scalper_bot/execution/ledger_bracket_manager.py
@@ -7,12 +7,13 @@ re-arming until fill history and broker-flat state are reconciled.
 
 from __future__ import annotations
 
-from contextlib import suppress
 import json
 import os
-from pathlib import Path
 import sqlite3
 import time
+from contextlib import suppress
+from dataclasses import asdict
+from pathlib import Path
 from typing import Any, Mapping
 
 from nifty_scalper_bot.execution import bracket_manager as _legacy
@@ -25,6 +26,7 @@ from nifty_scalper_bot.execution.fill_ledger import (
     FillLeg,
     FillValidationError,
 )
+from nifty_scalper_bot.risk.cost_model import estimate_round_trip_cost
 
 
 class _LedgerReleaseStore:
@@ -355,6 +357,101 @@ class LedgerBracketManager(CanonicalBracketManager):
             )
         return None
 
+    def _completed_trade_outcome(
+        self,
+        bracket: Any,
+        *,
+        ledger_pnl: Any | None,
+        gross_pnl: float | None,
+        exit_price: float | None,
+        ledger_complete: bool,
+    ) -> dict[str, Any]:
+        """Build the strategy-facing outcome from confirmed bracket economics."""
+        entry_price = (
+            ledger_pnl.entry_vwap
+            if ledger_pnl is not None
+            else getattr(bracket, "entry_fill_price", None)
+            or getattr(bracket, "entry_price", None)
+        )
+        resolved_exit = (
+            ledger_pnl.exit_vwap
+            if ledger_pnl is not None and ledger_pnl.exit_vwap is not None
+            else exit_price
+        )
+        quantity = int(
+            getattr(ledger_pnl, "entry_quantity", 0)
+            or getattr(bracket, "quantity", 0)
+            or 0
+        )
+        executed_orders = 2
+        if self._fill_ledger is not None:
+            with suppress(Exception):
+                executed_orders = max(
+                    2,
+                    len(self._fill_ledger.load_fills(str(bracket.bracket_id))),
+                )
+        costs = None
+        net_pnl = gross_pnl
+        if (
+            gross_pnl is not None
+            and entry_price is not None
+            and resolved_exit is not None
+            and quantity > 0
+        ):
+            costs = estimate_round_trip_cost(
+                entry_price=float(entry_price),
+                exit_price=float(resolved_exit),
+                quantity=quantity,
+                executed_orders=executed_orders,
+            )
+            net_pnl = round(float(gross_pnl) - costs.total, 2)
+
+        side = str(getattr(bracket, "side", "BUY") or "BUY").upper()
+        high = float(
+            getattr(bracket, "highest_ltp", entry_price) or entry_price or 0.0
+        )
+        low = float(
+            getattr(bracket, "lowest_ltp", entry_price) or entry_price or 0.0
+        )
+        entry = float(entry_price or 0.0)
+        if side == "SELL":
+            mfe_points = max(0.0, entry - low)
+            mae_points = max(0.0, high - entry)
+        else:
+            mfe_points = max(0.0, high - entry)
+            mae_points = max(0.0, entry - low)
+        closed_at = float(getattr(bracket, "closed_at", None) or time.time())
+        opened_at = float(
+            getattr(bracket, "entry_fill_ts", None)
+            or getattr(bracket, "created_at", closed_at)
+            or closed_at
+        )
+        provenance = dict(getattr(bracket, "trade_provenance", {}) or {})
+        return {
+            **provenance,
+            "bracket_id": str(bracket.bracket_id),
+            "symbol": str(bracket.symbol),
+            "side": side,
+            "quantity": quantity,
+            "entry_price": float(entry_price) if entry_price is not None else None,
+            "exit_price": (
+                float(resolved_exit) if resolved_exit is not None else None
+            ),
+            "gross_pnl": gross_pnl,
+            "estimated_costs": asdict(costs) if costs is not None else None,
+            "net_pnl": net_pnl,
+            "mfe_points": round(mfe_points, 4),
+            "mae_points": round(mae_points, 4),
+            "mfe_pnl": round(mfe_points * quantity, 2),
+            "mae_pnl": round(mae_points * quantity, 2),
+            "holding_seconds": round(max(0.0, closed_at - opened_at), 3),
+            "exit_reason": str(
+                getattr(bracket, "exit_reason", None) or bracket.close_source or ""
+            ),
+            "close_source": str(bracket.close_source or ""),
+            "ledger_complete": bool(ledger_complete),
+        }
+
     def _close_bracket(
         self,
         bracket: Any,
@@ -490,11 +587,21 @@ class LedgerBracketManager(CanonicalBracketManager):
         net_pnl = ledger_pnl.net_pnl if ledger_pnl is not None else None
         if gross_pnl is None and resolved_price is not None:
             entry_price = getattr(bracket, "entry_fill_price", None) or getattr(bracket, "entry_price", None)
-            try:
-                side_mult = -1.0 if str(getattr(bracket, "side", "BUY")).upper() == "SELL" else 1.0
-                gross_pnl = round((float(resolved_price) - float(entry_price)) * int(bracket.quantity or 0) * side_mult, 2)
-            except (TypeError, ValueError):
-                gross_pnl = None
+            if entry_price is not None:
+                try:
+                    side_mult = -1.0 if str(getattr(bracket, "side", "BUY")).upper() == "SELL" else 1.0
+                    gross_pnl = round((float(resolved_price) - float(entry_price)) * int(bracket.quantity or 0) * side_mult, 2)
+                except (TypeError, ValueError):
+                    gross_pnl = None
+        outcome = self._completed_trade_outcome(
+            bracket,
+            ledger_pnl=ledger_pnl,
+            gross_pnl=gross_pnl,
+            exit_price=resolved_price,
+            ledger_complete=ledger_complete,
+        )
+        setattr(bracket, "_completed_trade_outcome", outcome)
+        net_pnl = outcome["net_pnl"]
         _legacy.LOGGER.info(
             "BRACKET_CLOSED bracket_id=%s symbol=%s close_source=%s side=%s qty=%s entry=%s exit=%s pnl=%s net_pnl=%s ledger_complete=%s",
             bracket.bracket_id,
@@ -517,6 +624,7 @@ class LedgerBracketManager(CanonicalBracketManager):
                 "gross_pnl": gross_pnl,
                 "net_pnl": net_pnl,
                 "ledger_complete": ledger_complete,
+                "completed_trade": outcome,
             },
         )
         self._notify_open_position_priority("close", bracket.symbol)
@@ -530,6 +638,7 @@ class LedgerBracketManager(CanonicalBracketManager):
                     "net_pnl": net_pnl,
                     "ledger_complete": ledger_complete,
                     "close_source": close_source,
+                    "completed_trade": outcome,
                 },
             )
 
@@ -603,6 +712,17 @@ class LedgerBracketManager(CanonicalBracketManager):
                 if hook is not None and not getattr(
                     bracket, "_ledger_release_hook_fired", False
                 ):
+                    setattr(
+                        bracket,
+                        "_completed_trade_outcome",
+                        self._completed_trade_outcome(
+                            bracket,
+                            ledger_pnl=pnl,
+                            gross_pnl=pnl.gross_pnl,
+                            exit_price=pnl.exit_vwap,
+                            ledger_complete=True,
+                        ),
+                    )
                     hook(bracket.symbol)
                     setattr(bracket, "_ledger_release_hook_fired", True)
             self._clear_ledger_release(bracket)

--- a/src/nifty_scalper_bot/execution/order_manager_core.py
+++ b/src/nifty_scalper_bot/execution/order_manager_core.py
@@ -230,6 +230,7 @@ class OrderDetails:
     requested_lots: int = 0
     resolved_lot_size: int = 0
     entry_lifecycle_state: dict[str, Any] | None = None
+    trade_provenance: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass(slots=True)
@@ -292,6 +293,7 @@ class TradePlan:
     selection_timestamp: float | None = None
     requested_lots: int = 0
     resolved_lot_size: int = 0
+    trade_provenance: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass(slots=True)
@@ -2394,6 +2396,7 @@ class OrderManager:
         contract_expiry: str | None = None,
         requested_lots: int = 0,
         resolved_lot_size: int = 0,
+        trade_provenance: Mapping[str, Any] | None = None,
     ) -> str | None:
         """
         Execute order with Idempotency, Safe Trading Window, Risk Gating, and Auto-Recovery.
@@ -3549,6 +3552,7 @@ class OrderManager:
                         contract_expiry=contract_expiry,
                         requested_lots=requested_lots,
                         resolved_lot_size=resolved_lot_size,
+                        trade_provenance=dict(trade_provenance or {}),
                     )
                     self._register_order(details)
                     # Sync PositionManager's pending-order registry so the
@@ -3614,6 +3618,7 @@ class OrderManager:
                             tag=tag or "auto",
                             intent=normalized_intent,
                             activate_immediately=False,
+                            trade_provenance=trade_provenance,
                         )
                         self._logger.info(f"🛡️ Auto-bracket registered for {order_id}")
                         self._logger.info(
@@ -5018,6 +5023,7 @@ class OrderManager:
                         contract_expiry=plan.contract_expiry,
                         requested_lots=int(plan.requested_lots or 0),
                         resolved_lot_size=int(plan.resolved_lot_size or 0),
+                        trade_provenance=plan.trade_provenance,
                     )
                 except Exception as exc:  # noqa: BLE001
                     err = self._sanitize_broker_error(exc)
@@ -5066,6 +5072,7 @@ class OrderManager:
                     allow_market_entry=plan.allow_market_entry,
                     intent=plan.intent,
                     intended_position_side=plan.intended_position_side,
+                    trade_provenance=plan.trade_provenance,
                 )
             except Exception as exc:  # noqa: BLE001
                 err = self._sanitize_broker_error(exc)
@@ -5112,8 +5119,10 @@ class OrderManager:
                 tag=plan.tag,
                 check_risk=True,
                 product=plan.product,
+                strategy_name=plan.strategy_name,
                 intent=plan.intent,
                 intended_position_side=plan.intended_position_side,
+                trade_provenance=plan.trade_provenance,
             )
         except Exception as exc:  # noqa: BLE001
             err = self._sanitize_broker_error(exc)
@@ -5171,6 +5180,7 @@ class OrderManager:
         basket_version: int | str | None = None,
         instrument_token: int | None = None,
         contract_expiry: str | None = None,
+        trade_provenance: Mapping[str, Any] | None = None,
     ) -> str | None:
         result = self.place_managed_order_result(
             symbol=symbol,
@@ -5193,6 +5203,7 @@ class OrderManager:
             basket_version=basket_version,
             instrument_token=instrument_token,
             contract_expiry=contract_expiry,
+            trade_provenance=trade_provenance,
         )
         return result.order_id if result.accepted else None
 
@@ -5220,6 +5231,7 @@ class OrderManager:
         contract_expiry: str | None = None,
         requested_lots: int = 0,
         resolved_lot_size: int = 0,
+        trade_provenance: Mapping[str, Any] | None = None,
     ) -> ManagedOrderResult:
         """Convert a TradePlan-style entry into broker/paper placement plus bracket registration."""
         # BUG 6 FIX: lot size was hardcoded to 65 — NIFTY options lot size fallback for resiliency.
@@ -5278,6 +5290,7 @@ class OrderManager:
             stop_loss=stop_loss,  # ✅ Critical: Passing this satisfies the Safety Guard
             take_profit=take_profit,
             signal_id=signal_id,
+            strategy_name=strategy_name,
             trace_id=trace_id,
             tag=tag,
             product=product,
@@ -5290,6 +5303,7 @@ class OrderManager:
             contract_expiry=contract_expiry,
             requested_lots=requested_lots,
             resolved_lot_size=resolved_lot_size,
+            trade_provenance=trade_provenance,
         )
 
         if order_id:
@@ -5872,6 +5886,7 @@ class OrderManager:
                     tp=tp_price,
                     tag=order.tag or source,
                     intent=str(getattr(order, "intent", "ENTRY") or "ENTRY"),
+                    trade_provenance=order.trade_provenance,
                 )
                 bracket_exists = self._bracket_manager.get_bracket(order.order_id)
                 if bracket_exists is None:

--- a/src/nifty_scalper_bot/execution/runtime_bracket_manager.py
+++ b/src/nifty_scalper_bot/execution/runtime_bracket_manager.py
@@ -7,9 +7,9 @@ lose functionality when broker fill identity is intentionally absent.
 
 from __future__ import annotations
 
-from contextlib import suppress
 import os
 import time
+from contextlib import suppress
 from typing import Any, Mapping
 
 from nifty_scalper_bot.execution import bracket_manager as _legacy
@@ -334,6 +334,14 @@ class RuntimeBracketManager(LedgerBracketManager):
                 exc,
             )
 
+        outcome = self._completed_trade_outcome(
+            bracket,
+            ledger_pnl=ledger_pnl,
+            gross_pnl=realized_pnl,
+            exit_price=final_exit_px,
+            ledger_complete=bool(ledger_pnl and ledger_pnl.complete),
+        )
+        setattr(bracket, "_completed_trade_outcome", outcome)
         _legacy.LOGGER.info(
             "BRACKET_CLOSED bracket_id=%s symbol=%s close_source=%s side=%s qty=%s entry=%s exit=%s pnl=%s",
             bracket.bracket_id,
@@ -356,7 +364,9 @@ class RuntimeBracketManager(LedgerBracketManager):
                 "entry": entry_px,
                 "exit": final_exit_px,
                 "pnl": realized_pnl,
+                "net_pnl": outcome["net_pnl"],
                 "ledger_complete": bool(ledger_pnl and ledger_pnl.complete),
+                "completed_trade": outcome,
             },
         )
         self._notify_open_position_priority("close", bracket.symbol)
@@ -367,8 +377,10 @@ class RuntimeBracketManager(LedgerBracketManager):
                     "symbol": bracket.symbol,
                     "quantity": filled_qty,
                     "gross_pnl": realized_pnl,
+                    "net_pnl": outcome["net_pnl"],
                     "ledger_complete": bool(ledger_pnl and ledger_pnl.complete),
                     "close_source": close_source,
+                    "completed_trade": outcome,
                 },
             )
         self._clear_ledger_release(bracket)

--- a/src/nifty_scalper_bot/risk/cost_model.py
+++ b/src/nifty_scalper_bot/risk/cost_model.py
@@ -3,7 +3,7 @@
 Rates current as of June 2026 (post Budget 2026-27, effective 1 Apr 2026):
 - Brokerage: flat Rs 20 per executed order (buy + sell = Rs 40 round trip)
 - STT: 0.15% of premium, sell side only
-- NSE exchange transaction charge: 0.035% of premium, both sides
+- NSE exchange transaction charge: 0.03553% of premium, both sides
 - SEBI charges: Rs 10 per crore (0.0001%), both sides
 - GST: 18% on (brokerage + exchange txn charge + SEBI charges)
 - Stamp duty: 0.003% of premium, buy side only
@@ -46,6 +46,7 @@ def estimate_round_trip_cost(
     exit_price: float,
     quantity: int,
     half_spread: float = 0.0,
+    executed_orders: int = 2,
 ) -> CostBreakdown:
     """Args: entry/exit premium per unit, total quantity, half-spread per unit.
     Returns: full round-trip cost breakdown in rupees. Raises: none.
@@ -57,9 +58,9 @@ def estimate_round_trip_cost(
     buy_value = max(0.0, float(entry_price)) * qty
     sell_value = max(0.0, float(exit_price)) * qty
 
-    brokerage = 2.0 * _rate("COST_BROKERAGE_PER_ORDER", 20.0)
+    brokerage = max(2, int(executed_orders)) * _rate("COST_BROKERAGE_PER_ORDER", 20.0)
     stt = sell_value * _rate("COST_STT_SELL_PCT", 0.0015)
-    exchange_txn = (buy_value + sell_value) * _rate("COST_EXCH_TXN_PCT", 0.00035)
+    exchange_txn = (buy_value + sell_value) * _rate("COST_EXCH_TXN_PCT", 0.0003553)
     sebi = (buy_value + sell_value) * _rate("COST_SEBI_PCT", 0.000001)
     gst = (brokerage + exchange_txn + sebi) * _rate("COST_GST_PCT", 0.18)
     stamp_duty = buy_value * _rate("COST_STAMP_BUY_PCT", 0.00003)

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -1324,13 +1324,50 @@ class StrategyRunner:
 
     def _on_bracket_exit_complete(self, symbol: str, *args: Any, **kwargs: Any) -> None:
         """Clear runner state and release entry guards after a bracket exit."""
-        del args, kwargs
         try:
             if not symbol:
                 return
 
             logger = getattr(self, "_logger", LOGGER)
             logger.info("BRACKET_EXIT_COMPLETE symbol=%s", symbol)
+            outcome = kwargs.get("outcome")
+            if outcome is None and args:
+                outcome = args[0]
+            if outcome is None:
+                getter = getattr(
+                    getattr(self, "_bracket_manager", None),
+                    "get_completed_trade_outcome",
+                    None,
+                )
+                if callable(getter):
+                    outcome = getter(symbol)
+            if isinstance(outcome, Mapping):
+                strategy_name = str(outcome.get("strategy_name") or "").strip()
+                net_pnl = outcome.get("net_pnl")
+                recorder = getattr(
+                    getattr(self, "_strategy_manager", None),
+                    "record_trade_result",
+                    None,
+                )
+                if strategy_name and callable(recorder) and net_pnl is not None:
+                    try:
+                        recorder(
+                            strategy_name,
+                            float(net_pnl),
+                            metadata={
+                                key: value
+                                for key, value in outcome.items()
+                                if key != "strategy_name"
+                            },
+                        )
+                    except Exception as exc:  # noqa: BLE001 - release must continue
+                        logger.error(
+                            "STRATEGY_TRADE_FEEDBACK_FAILED symbol=%s strategy=%s error=%s",
+                            symbol,
+                            strategy_name,
+                            exc,
+                            exc_info=exc,
+                        )
 
             for attr in (
                 "active_trades",
@@ -19942,6 +19979,24 @@ class StrategyRunner:
                 ),
                 requested_lots=_requested_lots,
                 resolved_lot_size=_resolved_lot_size,
+                trade_provenance={
+                    "strategy_name": strategy_name,
+                    "setup_name": str(
+                        metadata.get("setup_type")
+                        or metadata.get("feature")
+                        or signal.reason
+                        or strategy_name
+                    ),
+                    "regime": str(metadata.get("runtime_regime") or "UNKNOWN"),
+                    "signal_id": signal.deterministic_id,
+                    "trace_id": trace_id,
+                    "strategy_profile_version": getattr(
+                        self, "_build_info", {}
+                    ).get(
+                        "strategy_profile_version", "unknown"
+                    ),
+                    "final_score": metadata.get("final_score"),
+                },
             )
             self._logger.info(
                 "ENTRY_EXECUTION_MODE_RESOLVED symbol=%s trace_id=%s is_live_mode=%s execution_mode=%s env_live_enabled=%s paper_enabled=%s shadow_mode_enabled=%s",

--- a/tests/core/test_strategy_manager_regime_fallback.py
+++ b/tests/core/test_strategy_manager_regime_fallback.py
@@ -6,3 +6,13 @@ from nifty_scalper_bot.core.strategy_manager import StrategyManager
 def test_extract_regime_scale_honours_default() -> None:
     manager = StrategyManager([], None, None)
     assert manager._extract_regime_scale({}) == 1.0
+
+
+def test_record_trade_result_populates_passive_adaptive_statistics() -> None:
+    manager = StrategyManager([], None, None)
+
+    manager.record_trade_result("VWAPPro", 125.0, metadata={"regime": "trend"})
+
+    stats = manager._adaptive_store.get_stats("VWAPPro")
+    assert stats.win_rate == 1.0
+    assert stats.avg_win == 125.0

--- a/tests/execution/test_ledger_bracket_runtime.py
+++ b/tests/execution/test_ledger_bracket_runtime.py
@@ -143,6 +143,60 @@ def test_scaled_fills_persist_and_close_uses_exact_weighted_pnl(
     assert manager.has_unresolved_exit() is False
 
 
+def test_completed_trade_outcome_preserves_provenance_and_net_costs(
+    monkeypatch, tmp_path
+) -> None:
+    manager, _order_manager, broker = _manager(monkeypatch, tmp_path)
+    bracket = manager.get_bracket("entry-1")
+    assert bracket is not None
+    manager.attach_trade_provenance(
+        "entry-1",
+        {
+            "strategy_name": "VWAPPro",
+            "setup_name": "continuation_pullback",
+            "regime": "TREND",
+            "signal_id": "sig-1",
+            "trace_id": "trace-1",
+            "strategy_profile_version": "2026-07-30",
+        },
+    )
+    manager.confirm_entry_fill("entry-1", 100.0)
+    bracket.highest_ltp = 112.0
+    bracket.lowest_ltp = 96.0
+    bracket = _mark_filled_exit(
+        manager,
+        broker,
+        order_id="final-outcome",
+        reason="HARD_TP_BREACH",
+        price=110.0,
+        residual=0,
+    )
+    completed: list[str] = []
+    manager.attach_on_exit_complete(completed.append)
+
+    manager._close_bracket(bracket, close_source="broker_fill", exit_price=110.0)
+
+    assert len(completed) == 1
+    assert completed[0] == SYMBOL
+    outcome = manager.get_completed_trade_outcome(SYMBOL)
+    assert outcome is not None
+    assert outcome["strategy_name"] == "VWAPPro"
+    assert outcome["setup_name"] == "continuation_pullback"
+    assert outcome["regime"] == "TREND"
+    assert outcome["gross_pnl"] == 1300.0
+    assert outcome["estimated_costs"]["total"] > 0
+    assert outcome["net_pnl"] < outcome["gross_pnl"]
+    assert outcome["mfe_pnl"] == 1560.0
+    assert outcome["mae_pnl"] == 520.0
+    assert outcome["exit_reason"] == "HARD_TP_BREACH"
+    assert outcome["ledger_complete"] is True
+
+    restored = manager._decode_restored_bracket(
+        bracket.entry_order_id, bracket.to_dict()
+    )
+    assert restored.trade_provenance == bracket.trade_provenance
+
+
 def test_duplicate_entry_callback_is_idempotent(monkeypatch, tmp_path) -> None:
     manager, _order_manager, _broker = _manager(monkeypatch, tmp_path)
     manager.confirm_entry_fill("entry-1", 100.0)

--- a/tests/execution/test_order_manager_trade_plan.py
+++ b/tests/execution/test_order_manager_trade_plan.py
@@ -86,6 +86,40 @@ def test_managed_order_uses_last_decision_for_broker_attempted_none() -> None:
     assert out.broker_attempted is True
 
 
+def test_trade_plan_provenance_reaches_order_and_bracket_registration() -> None:
+    m = _manager_stub()
+    m._validate_trade_plan = lambda p: OrderPreflightResult(True)
+    m._protected_limit_price = lambda p: 100.0
+    m._lot_size_for_symbol = lambda _s: 75
+    captured = {}
+
+    def _place_order(**kwargs):
+        captured.update(kwargs)
+        return "OID1"
+
+    m.place_order = _place_order
+    plan = TradePlan(
+        symbol="NFO:NIFTY",
+        side="BUY",
+        quantity=75,
+        entry_price=100.0,
+        stop_loss=90.0,
+        take_profit=110.0,
+        strategy_name="VWAPPro",
+        trade_provenance={
+            "strategy_name": "VWAPPro",
+            "setup_name": "continuation_pullback",
+            "regime": "TREND",
+        },
+    )
+
+    out = OrderManager.submit_trade_plan_result(m, plan)
+
+    assert out.accepted is True
+    assert captured["strategy_name"] == "VWAPPro"
+    assert captured["trade_provenance"] == plan.trade_provenance
+
+
 def test_stale_last_order_decision_does_not_leak() -> None:
     m = _manager_stub()
     m._lot_size_for_symbol = lambda s: 75

--- a/tests/risk/test_cost_model.py
+++ b/tests/risk/test_cost_model.py
@@ -18,6 +18,23 @@ def test_cost_breakdown_components_positive() -> None:
     assert abs(c.cost_per_unit - c.total / 65) < 1e-9
 
 
+def test_round_trip_cost_counts_each_partial_exit_order() -> None:
+    two_orders = estimate_round_trip_cost(
+        entry_price=100.0,
+        exit_price=110.0,
+        quantity=130,
+        executed_orders=2,
+    )
+    three_orders = estimate_round_trip_cost(
+        entry_price=100.0,
+        exit_price=110.0,
+        quantity=130,
+        executed_orders=3,
+    )
+    assert three_orders.brokerage - two_orders.brokerage == 20.0
+    assert three_orders.total > two_orders.total
+
+
 def test_gate_blocks_thin_target() -> None:
     ok, edge, _ = passes_cost_edge_gate(
         entry_price=120, target_price=122, quantity=65, half_spread=0.5

--- a/tests/strategies/test_runner_live_suppression_regressions.py
+++ b/tests/strategies/test_runner_live_suppression_regressions.py
@@ -194,6 +194,112 @@ def test_bracket_completion_releases_entry_guards_with_cooldown() -> None:
     assert releases == [(symbol, True, "bracket_exit_complete")]
 
 
+def test_bracket_completion_records_strategy_net_outcome_before_release() -> None:
+    symbol = "NFO:NIFTY2670724100PE"
+    releases = []
+    recorded = []
+    runner = object.__new__(StrategyRunner)
+    runner._logger = type(
+        "Log",
+        (),
+        {
+            "info": lambda *a, **k: None,
+            "error": lambda *a, **k: None,
+            "exception": lambda *a, **k: None,
+        },
+    )()
+    runner._strategy_manager = type(
+        "SM",
+        (),
+        {
+            "record_trade_result": (
+                lambda self, strategy, pnl, *, metadata: recorded.append(
+                    (strategy, pnl, metadata)
+                )
+            )
+        },
+    )()
+    runner._normalize_symbol = lambda value: value
+    runner._notify_orchestrator_exit = lambda _symbol: None
+    runner._clear_order_in_flight = lambda _symbol: None
+    runner._release_entry_guards = (
+        lambda released_symbol, *, start_cooldown, reason: releases.append(
+            (released_symbol, start_cooldown, reason)
+        )
+    )
+    outcome = {
+        "strategy_name": "VWAPPro",
+        "setup_name": "continuation_pullback",
+        "regime": "TREND",
+        "gross_pnl": 650.0,
+        "net_pnl": 575.0,
+        "exit_reason": "HARD_TP_BREACH",
+    }
+    runner._bracket_manager = type(
+        "BM",
+        (),
+        {"get_completed_trade_outcome": lambda self, _symbol: outcome},
+    )()
+
+    runner._on_bracket_exit_complete(symbol)
+
+    assert recorded == [
+        (
+            "VWAPPro",
+            575.0,
+            {
+                "setup_name": "continuation_pullback",
+                "regime": "TREND",
+                "gross_pnl": 650.0,
+                "net_pnl": 575.0,
+                "exit_reason": "HARD_TP_BREACH",
+            },
+        )
+    ]
+    assert releases == [(symbol, True, "bracket_exit_complete")]
+
+
+def test_strategy_feedback_failure_never_blocks_bracket_guard_release() -> None:
+    symbol = "NFO:NIFTY2670724100PE"
+    releases = []
+    runner = object.__new__(StrategyRunner)
+    runner._logger = type(
+        "Log",
+        (),
+        {
+            "info": lambda *a, **k: None,
+            "error": lambda *a, **k: None,
+            "exception": lambda *a, **k: None,
+        },
+    )()
+    runner._strategy_manager = type(
+        "SM",
+        (),
+        {
+            "record_trade_result": (
+                lambda *_a, **_k: (_ for _ in ()).throw(
+                    RuntimeError("analytics down")
+                )
+            )
+        },
+    )()
+    runner._normalize_symbol = lambda value: value
+    runner._notify_orchestrator_exit = lambda _symbol: None
+    runner._clear_order_in_flight = lambda _symbol: None
+    runner._release_entry_guards = (
+        lambda released_symbol, *, start_cooldown, reason: releases.append(
+            (released_symbol, start_cooldown, reason)
+        )
+    )
+
+    runner._on_bracket_exit_complete(
+        symbol,
+        {"strategy_name": "VWAPPro", "net_pnl": -100.0, "regime": "RANGE"},
+    )
+
+    assert releases == [(symbol, True, "bracket_exit_complete")]
+
+
 def test_runner_risk_halt_clears_after_authoritative_breaker_reset() -> None:
     states = iter([(True, "daily loss"), (False, "")])
     events = []


### PR DESCRIPTION
## Root cause

The originating strategy, setup, regime, trace and profile identity were dropped when a live trade became a durable bracket. Final bracket closure released runner guards but did not provide the completed trade outcome to `StrategyManager`, leaving adaptive performance statistics without production observations.

## What changed

- carry immutable strategy/setup/regime/signal/trace/profile provenance from `TradePlan` into durable `BracketState`
- make the fill ledger the authoritative final-outcome owner
- calculate weighted entry/exit fills, gross and estimated net P&L, costs, MAE/MFE, holding duration and exit reason at final closure
- include that outcome in the existing `BRACKET_CLOSED` journal event
- let the runner retrieve the authoritative outcome and feed net performance into the existing `StrategyManager.record_trade_result()`
- preserve the legacy one-argument close callback and ensure analytics failure cannot prevent guard release
- keep adaptive calibration passive; this PR does not enable live parameter optimization

## Preserved behavior

- option-only execution, risk gates, bracket protection and reconciliation are unchanged
- the existing async trade journal remains the sole journal
- restart compatibility is preserved through optional/default provenance fields
- no runtime artifacts or generated files are included

## Validation

- six new focused regressions passed
- 99 focused/adjacent bracket, order-plan, runner, cost and StrategyManager tests passed
- complete execution, strategy, core and risk suites passed
- complete repository suite passed; one independently passing order-sensitive coalescing test was deselected only in the confirming remainder run after its suite-race reproduction
- scoped mypy, Black, import ordering, compilation and whitespace checks passed
- remote branch is exactly one commit ahead of `02f8514`; all twelve blob SHAs and the complete tree SHA match the locally validated commit