### PR TITLE
Add strategy-by-regime outcome reporting

### DIFF
--- a/scripts/reporting/generate_daily_report.py
+++ b/scripts/reporting/generate_daily_report.py
@@ -4,9 +4,15 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
+import sqlite3
 import sys
+from collections import defaultdict
+from collections.abc import Mapping
+from datetime import date, datetime, time, timedelta
 from pathlib import Path
 from typing import Any, Dict
+from zoneinfo import ZoneInfo
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 SRC_PATH = PROJECT_ROOT / "src"
@@ -16,6 +22,249 @@ if str(SRC_PATH) not in sys.path:
 from nifty_scalper_bot.utils.logging import get_logger  # noqa: E402
 
 LOGGER = get_logger(__name__)
+
+
+def load_completed_trades(
+    db_path: Path,
+    *,
+    report_date: str,
+    timezone_name: str,
+) -> list[dict[str, Any]]:
+    """Load one local trading day's authoritative completed outcomes."""
+
+    resolved = db_path.expanduser().resolve()
+    if not resolved.exists():
+        raise FileNotFoundError(f"Trade journal not found: {resolved}")
+    local_zone = ZoneInfo(timezone_name)
+    local_day = date.fromisoformat(report_date)
+    start = datetime.combine(local_day, time.min, tzinfo=local_zone)
+    end = start + timedelta(days=1)
+    outcomes: dict[str, dict[str, Any]] = {}
+    uri = f"{resolved.as_uri()}?mode=ro"
+    with sqlite3.connect(uri, uri=True) as connection:
+        rows = connection.execute(
+            """
+            SELECT id, timestamp, meta_json
+            FROM trade_events
+            WHERE event_type = ?
+              AND timestamp >= ?
+              AND timestamp < ?
+            ORDER BY timestamp, id
+            """,
+            ("BRACKET_CLOSED", start.timestamp(), end.timestamp()),
+        )
+        for event_id, timestamp, meta_json in rows:
+            try:
+                meta = json.loads(meta_json or "{}")
+                if not isinstance(meta, Mapping):
+                    continue
+                outcome = meta.get("completed_trade")
+                if not isinstance(outcome, Mapping):
+                    continue
+                completed = dict(outcome)
+                completed["closed_timestamp"] = float(timestamp)
+                bracket_id = str(completed.get("bracket_id") or "").strip()
+                outcomes[bracket_id or f"event:{event_id}"] = completed
+            except (TypeError, ValueError, json.JSONDecodeError):
+                continue
+    return list(outcomes.values())
+
+
+def _number(value: Any) -> float | None:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    resolved = float(value)
+    return resolved if math.isfinite(resolved) else None
+
+
+def summarise_completed_trades(
+    trades: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Aggregate completed outcomes without converting incomplete trades to losses."""
+
+    grouped: dict[tuple[str, str], list[dict[str, Any]]] = defaultdict(list)
+    for trade in trades:
+        strategy = str(trade.get("strategy_name") or "UNKNOWN").strip() or "UNKNOWN"
+        regime = str(trade.get("regime") or "UNKNOWN").strip() or "UNKNOWN"
+        grouped[(strategy, regime)].append(trade)
+
+    groups: list[dict[str, Any]] = []
+    total_measured = 0
+    total_gross = 0.0
+    total_costs = 0.0
+    total_net = 0.0
+    for (strategy, regime), outcomes in sorted(grouped.items()):
+        measured = [
+            outcome
+            for outcome in outcomes
+            if outcome.get("ledger_complete") is True
+            and _number(outcome.get("net_pnl")) is not None
+        ]
+        net_values = [_number(outcome.get("net_pnl")) or 0.0 for outcome in measured]
+        gross_values = [
+            _number(outcome.get("gross_pnl")) or 0.0 for outcome in measured
+        ]
+        cost_values = []
+        for outcome in measured:
+            costs = outcome.get("estimated_costs")
+            cost_values.append(
+                _number(costs.get("total")) or 0.0
+                if isinstance(costs, Mapping)
+                else 0.0
+            )
+        wins = [value for value in net_values if value > 0]
+        losses = [value for value in net_values if value < 0]
+        mfe_values = [
+            value
+            for outcome in measured
+            if (value := _number(outcome.get("mfe_pnl"))) is not None
+        ]
+        mae_values = [
+            value
+            for outcome in measured
+            if (value := _number(outcome.get("mae_pnl"))) is not None
+        ]
+        holding_values = [
+            value
+            for outcome in measured
+            if (value := _number(outcome.get("holding_seconds"))) is not None
+        ]
+        measured_count = len(measured)
+        positive_pnl = sum(wins)
+        negative_pnl = abs(sum(losses))
+        gross_pnl = round(sum(gross_values), 2)
+        estimated_costs = round(sum(cost_values), 2)
+        net_pnl = round(sum(net_values), 2)
+        groups.append(
+            {
+                "strategy": strategy,
+                "regime": regime,
+                "setups": sorted(
+                    {
+                        str(
+                            outcome.get("setup_name") or outcome.get("setup_type")
+                        ).strip()
+                        for outcome in outcomes
+                        if str(
+                            outcome.get("setup_name") or outcome.get("setup_type") or ""
+                        ).strip()
+                    }
+                ),
+                "closed_trades": len(outcomes),
+                "measured_trades": measured_count,
+                "wins": len(wins),
+                "losses": len(losses),
+                "win_rate_pct": (
+                    round(len(wins) / measured_count * 100.0, 1)
+                    if measured_count
+                    else None
+                ),
+                "gross_pnl": gross_pnl,
+                "estimated_costs": estimated_costs,
+                "net_pnl": net_pnl,
+                "average_net_pnl": (
+                    round(net_pnl / measured_count, 2) if measured_count else None
+                ),
+                "profit_factor": (
+                    round(positive_pnl / negative_pnl, 4) if negative_pnl > 0 else None
+                ),
+                "average_mfe_pnl": (
+                    round(sum(mfe_values) / len(mfe_values), 2) if mfe_values else None
+                ),
+                "average_mae_pnl": (
+                    round(sum(mae_values) / len(mae_values), 2) if mae_values else None
+                ),
+                "average_holding_seconds": (
+                    round(sum(holding_values) / len(holding_values), 2)
+                    if holding_values
+                    else None
+                ),
+                "incomplete_trades": len(outcomes) - measured_count,
+            }
+        )
+        total_measured += measured_count
+        total_gross += gross_pnl
+        total_costs += estimated_costs
+        total_net += net_pnl
+
+    return {
+        "groups": groups,
+        "totals": {
+            "closed_trades": len(trades),
+            "measured_trades": total_measured,
+            "incomplete_trades": len(trades) - total_measured,
+            "gross_pnl": round(total_gross, 2),
+            "estimated_costs": round(total_costs, 2),
+            "net_pnl": round(total_net, 2),
+        },
+    }
+
+
+def _display(value: Any, *, suffix: str = "") -> str:
+    return "N/A" if value is None else f"{value}{suffix}"
+
+
+def build_trade_outcome_report(
+    summary: Mapping[str, Any],
+    *,
+    report_date: str,
+    timezone_name: str,
+) -> str:
+    """Build an observational strategy-by-regime Markdown report."""
+
+    totals = summary.get("totals", {})
+    groups = summary.get("groups", [])
+    lines = [
+        "# Daily Strategy-by-Regime Outcome Report",
+        "",
+        f"Trading date: **{report_date}** ({timezone_name})",
+        "",
+        f"Closed trades: **{int(totals.get('closed_trades', 0))}**  ",
+        f"Measured outcomes: **{int(totals.get('measured_trades', 0))}**  ",
+        f"Incomplete outcomes: **{int(totals.get('incomplete_trades', 0))}**  ",
+        f"Gross P&L: **{float(totals.get('gross_pnl', 0.0)):+.2f}**  ",
+        f"Estimated costs: **{float(totals.get('estimated_costs', 0.0)):.2f}**  ",
+        f"Net P&L: **{float(totals.get('net_pnl', 0.0)):+.2f}**",
+        "",
+        "| Strategy | Regime | Setup | Closed | Measured | Win rate | Net P&L | "
+        "Avg net | Profit factor | Avg MFE | Avg MAE | Avg hold (s) | Incomplete |",
+        "|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|",
+    ]
+    for group in groups:
+        setups = ", ".join(group.get("setups", [])) or "UNKNOWN"
+        safe_text = [
+            str(group.get("strategy", "UNKNOWN")).replace("|", "/"),
+            str(group.get("regime", "UNKNOWN")).replace("|", "/"),
+            setups.replace("|", "/"),
+        ]
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    *safe_text,
+                    str(group.get("closed_trades", 0)),
+                    str(group.get("measured_trades", 0)),
+                    _display(group.get("win_rate_pct"), suffix="%"),
+                    f"{float(group.get('net_pnl', 0.0)):+.2f}",
+                    _display(group.get("average_net_pnl")),
+                    _display(group.get("profit_factor")),
+                    _display(group.get("average_mfe_pnl")),
+                    _display(group.get("average_mae_pnl")),
+                    _display(group.get("average_holding_seconds")),
+                    str(group.get("incomplete_trades", 0)),
+                ]
+            )
+            + " |"
+        )
+    lines.extend(
+        [
+            "",
+            "This report is observational and does not change live strategy "
+            "parameters.",
+            "Incomplete outcomes are excluded from win rate and expectancy metrics.",
+        ]
+    )
+    return "\n".join(lines)
 
 
 def load_summary(path: Path) -> Dict[str, Any]:
@@ -238,11 +487,25 @@ def main(argv: list[str] | None = None) -> int:
         extra={"event": "daily_report_main_enter"},
     )
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument(
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument(
         "--summary",
-        required=True,
         type=Path,
         help="Path to a PnL JSON summary emitted by the backtest engine.",
+    )
+    source.add_argument(
+        "--trades-db",
+        type=Path,
+        help="Path to the live trades.db journal containing BRACKET_CLOSED outcomes.",
+    )
+    parser.add_argument(
+        "--date",
+        help="Local trading date for --trades-db in YYYY-MM-DD format.",
+    )
+    parser.add_argument(
+        "--timezone",
+        default="Asia/Kolkata",
+        help="IANA timezone used to bound --date (default: Asia/Kolkata).",
     )
     parser.add_argument(
         "--output",
@@ -251,9 +514,28 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
     try:
-        summary = load_summary(args.summary)
-        report = build_daily_report(summary)
-        output_path = args.output or _build_default_output(args.summary)
+        if args.trades_db is not None:
+            local_day = (
+                args.date or datetime.now(ZoneInfo(args.timezone)).date().isoformat()
+            )
+            trades = load_completed_trades(
+                args.trades_db,
+                report_date=local_day,
+                timezone_name=args.timezone,
+            )
+            summary = summarise_completed_trades(trades)
+            report = build_trade_outcome_report(
+                summary,
+                report_date=local_day,
+                timezone_name=args.timezone,
+            )
+            output_path = args.output or args.trades_db.with_name(
+                f"daily_strategy_outcomes_{local_day}.md"
+            )
+        else:
+            summary = load_summary(args.summary)
+            report = build_daily_report(summary)
+            output_path = args.output or _build_default_output(args.summary)
         write_report(output_path, report)
         return 0
     except Exception as exc:
@@ -267,8 +549,11 @@ def main(argv: list[str] | None = None) -> int:
 
 __all__ = [
     "build_daily_report",
+    "build_trade_outcome_report",
+    "load_completed_trades",
     "load_summary",
     "main",
+    "summarise_completed_trades",
     "write_report",
 ]
 

--- a/tests/backtests/test_replay_parity.py
+++ b/tests/backtests/test_replay_parity.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import sqlite3
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -311,3 +312,179 @@ def test_generate_daily_report_builds_markdown(tmp_path: Path) -> None:
     assert "Daily Strategy Performance Report" in content
     assert "2024-01-01" in content and "2024-01-02" in content
     assert "Maximum Drawdown" in content
+
+
+def test_daily_report_aggregates_completed_trades_by_strategy_and_regime(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "trades.db"
+    with sqlite3.connect(db_path) as connection:
+        connection.execute("""
+            CREATE TABLE trade_events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                timestamp REAL NOT NULL,
+                event_type TEXT NOT NULL,
+                meta_json TEXT
+            )
+            """)
+        outcomes = [
+            (
+                datetime.fromisoformat("2026-07-31T03:50:00+00:00").timestamp(),
+                {
+                    "strategy_name": "VWAPPro",
+                    "regime": "TREND",
+                    "setup_name": "continuation_pullback",
+                    "bracket_id": "bracket-1",
+                    "gross_pnl": 500.0,
+                    "estimated_costs": {"total": 25.0},
+                    "net_pnl": 475.0,
+                    "mfe_pnl": 650.0,
+                    "mae_pnl": 100.0,
+                    "holding_seconds": 180.0,
+                    "ledger_complete": True,
+                },
+            ),
+            (
+                datetime.fromisoformat("2026-07-31T04:30:00+00:00").timestamp(),
+                {
+                    "strategy_name": "VWAPPro",
+                    "regime": "TREND",
+                    "setup_name": "continuation_pullback",
+                    "bracket_id": "bracket-2",
+                    "gross_pnl": -200.0,
+                    "estimated_costs": {"total": 20.0},
+                    "net_pnl": -220.0,
+                    "mfe_pnl": 40.0,
+                    "mae_pnl": 240.0,
+                    "holding_seconds": 90.0,
+                    "ledger_complete": True,
+                },
+            ),
+            (
+                datetime.fromisoformat("2026-07-31T05:00:00+00:00").timestamp(),
+                {
+                    "strategy_name": "SMC",
+                    "regime": "RANGE",
+                    "setup_name": "liquidity_sweep_retest",
+                    "bracket_id": "bracket-3",
+                    "gross_pnl": None,
+                    "net_pnl": None,
+                    "ledger_complete": False,
+                },
+            ),
+        ]
+        for timestamp, outcome in outcomes:
+            connection.execute(
+                """
+                INSERT INTO trade_events (timestamp, event_type, meta_json)
+                VALUES (?, 'BRACKET_CLOSED', ?)
+                """,
+                (timestamp, json.dumps({"completed_trade": outcome})),
+            )
+        # A duplicate close event must not double-count the same bracket.
+        connection.execute(
+            """
+            INSERT INTO trade_events (timestamp, event_type, meta_json)
+            VALUES (?, 'BRACKET_CLOSED', ?)
+            """,
+            (
+                datetime.fromisoformat("2026-07-31T05:01:00+00:00").timestamp(),
+                json.dumps({"completed_trade": outcomes[-1][1]}),
+            ),
+        )
+        # This is 31 July UTC, but 1 August in Asia/Kolkata and must be excluded.
+        connection.execute(
+            """
+            INSERT INTO trade_events (timestamp, event_type, meta_json)
+            VALUES (?, 'BRACKET_CLOSED', ?)
+            """,
+            (
+                datetime.fromisoformat("2026-07-31T19:00:00+00:00").timestamp(),
+                json.dumps(
+                    {
+                        "completed_trade": {
+                            **outcomes[0][1],
+                            "bracket_id": "bracket-next-day",
+                        }
+                    }
+                ),
+            ),
+        )
+
+    module = _load_daily_report_module()
+    trades = module.load_completed_trades(
+        db_path,
+        report_date="2026-07-31",
+        timezone_name="Asia/Kolkata",
+    )
+    summary = module.summarise_completed_trades(trades)
+    report = module.build_trade_outcome_report(
+        summary,
+        report_date="2026-07-31",
+        timezone_name="Asia/Kolkata",
+    )
+
+    assert len(trades) == 3
+    assert summary["totals"]["closed_trades"] == 3
+    assert summary["totals"]["measured_trades"] == 2
+    assert summary["totals"]["incomplete_trades"] == 1
+    assert summary["totals"]["net_pnl"] == 255.0
+    assert summary["groups"][0] == {
+        "strategy": "SMC",
+        "regime": "RANGE",
+        "setups": ["liquidity_sweep_retest"],
+        "closed_trades": 1,
+        "measured_trades": 0,
+        "wins": 0,
+        "losses": 0,
+        "win_rate_pct": None,
+        "gross_pnl": 0.0,
+        "estimated_costs": 0.0,
+        "net_pnl": 0.0,
+        "average_net_pnl": None,
+        "profit_factor": None,
+        "average_mfe_pnl": None,
+        "average_mae_pnl": None,
+        "average_holding_seconds": None,
+        "incomplete_trades": 1,
+    }
+    assert summary["groups"][1]["strategy"] == "VWAPPro"
+    assert summary["groups"][1]["win_rate_pct"] == 50.0
+    assert summary["groups"][1]["net_pnl"] == 255.0
+    assert summary["groups"][1]["profit_factor"] == 2.1591
+    assert "Daily Strategy-by-Regime Outcome Report" in report
+    assert "| VWAPPro | TREND | continuation_pullback | 2 | 2 | 50.0% |" in report
+    assert "Incomplete outcomes: **1**" in report
+    assert "does not change live strategy parameters" in report
+
+
+def test_daily_report_trade_db_cli_writes_date_scoped_report(tmp_path: Path) -> None:
+    db_path = tmp_path / "trades.db"
+    with sqlite3.connect(db_path) as connection:
+        connection.execute("""
+            CREATE TABLE trade_events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                timestamp REAL NOT NULL,
+                event_type TEXT NOT NULL,
+                meta_json TEXT
+            )
+            """)
+    output_path = tmp_path / "strategy_report.md"
+
+    module = _load_daily_report_module()
+    exit_code = module.main(
+        [
+            "--trades-db",
+            str(db_path),
+            "--date",
+            "2026-07-31",
+            "--timezone",
+            "Asia/Kolkata",
+            "--output",
+            str(output_path),
+        ]
+    )
+
+    assert exit_code == 0
+    assert output_path.exists()
+    assert "Closed trades: **0**" in output_path.read_text(encoding="utf-8")


### PR DESCRIPTION
## What changed
- Extend the existing daily report to read authoritative `BRACKET_CLOSED` outcomes from `trades.db`.
- Aggregate measured net expectancy by strategy and regime, including win rate, profit factor, costs, MAE/MFE, and holding time.
- Deduplicate bracket closures and report incomplete ledger outcomes separately.
- Preserve the existing backtest-summary report mode.

## Why
Completed-trade attribution is now available, but it needs a compact observational report before strategy or regime decisions can be calibrated from evidence.

## Safety
This is an offline reporting-only change. It does not alter signal generation, trade admission, execution, risk controls, or bracket behavior.

## Validation
- Focused and adjacent report/ledger/feedback tests
- Full repository suite
- Ruff, Black, mypy, compilation, and whitespace checks