### PR TITLE
Build deterministic live-path replay foundation

### DIFF
--- a/src/nifty_scalper_bot/backtest/parity.py
+++ b/src/nifty_scalper_bot/backtest/parity.py
@@ -32,6 +32,7 @@ class SinglePipelineParity:
         self,
         *,
         runner_factory: Callable[[], Any],
+        reference_runner_factory: Callable[[], Any] | None = None,
         paper_factory: Callable[[], PaperFillEngine],
         option_symbol: str,
         index_symbol: str | None = None,
@@ -52,6 +53,7 @@ class SinglePipelineParity:
         """
 
         self._runner_factory = runner_factory
+        self._reference_runner_factory = reference_runner_factory
         self._paper_factory = paper_factory
         self._option_symbol = option_symbol
         self._index_symbol = index_symbol
@@ -74,6 +76,11 @@ class SinglePipelineParity:
             "Entered SinglePipelineParity.run_frame",
             extra={"event": "single_pipeline_parity_run_enter"},
         )
+        if self._reference_runner_factory is None:
+            raise ValueError(
+                "reference_runner_factory is required; comparing one replay "
+                "pipeline with itself does not prove parity"
+            )
         try:
             live_runner = self._runner_factory()
             live_paper = self._paper_factory()
@@ -85,7 +92,7 @@ class SinglePipelineParity:
             )
             live_result = live_harness.run_dataframe(frame)
 
-            back_runner = self._runner_factory()
+            back_runner = self._reference_runner_factory()
             back_paper = self._paper_factory()
             back_harness = ReplayHarness(
                 back_runner,

--- a/src/nifty_scalper_bot/backtest/replay.py
+++ b/src/nifty_scalper_bot/backtest/replay.py
@@ -5,11 +5,17 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Mapping
+from typing import Any, Mapping, Protocol
 
 import pandas as pd
 
 from nifty_scalper_bot.execution.paper_fill_engine import PaperFillEngine
+
+
+class ReplayClock(Protocol):
+    """Clock surface used by deterministic historical replay."""
+
+    def advance_to(self, timestamp: datetime) -> None: ...
 
 
 @dataclass(slots=True)
@@ -46,11 +52,17 @@ class ReplayHarness:
         *,
         option_symbol: str,
         index_symbol: str | None = None,
+        clock: ReplayClock | None = None,
     ) -> None:
         self._runner = runner
         self._paper = paper_engine
         self._option_symbol = option_symbol
         self._index_symbol = index_symbol
+        self._clock = clock
+        clock_time = getattr(clock, "time", None)
+        set_clock = getattr(paper_engine, "set_clock", None)
+        if callable(clock_time) and callable(set_clock):
+            set_clock(clock_time)
 
     def run_dataframe(self, data: pd.DataFrame) -> ReplayResult:
         """Replay the provided dataframe and return a :class:`ReplayResult`."""
@@ -65,13 +77,15 @@ class ReplayHarness:
         bars = 0
         for timestamp, row in frame.iterrows():
             tick_time = timestamp.to_pydatetime()
-            option_tick = _build_tick(row, tick_time, prefix="option_")
-            if option_tick:
-                self._dispatch_tick(self._option_symbol, option_tick)
+            if self._clock is not None:
+                self._clock.advance_to(tick_time)
             if self._index_symbol:
                 index_tick = _build_tick(row, tick_time, prefix="index_")
                 if index_tick:
-                    self._dispatch_tick(self._index_symbol, index_tick)
+                    self._publish_and_dispatch(self._index_symbol, index_tick)
+            option_tick = _build_tick(row, tick_time, prefix="option_")
+            if option_tick:
+                self._publish_and_dispatch(self._option_symbol, option_tick)
             bars += 1
         trades = _collect_trade_history(self._runner)
         orders = self._paper.get_orders() if hasattr(self._paper, "get_orders") else []
@@ -89,15 +103,41 @@ class ReplayHarness:
         day_path = _resolve_day_path(directory, day)
         return self.run_file(day_path)
 
+    def _publish_and_dispatch(self, symbol: str, tick: Mapping[str, Any]) -> None:
+        payload = {
+            **dict(tick),
+            "symbol": symbol,
+            "last_price": float(tick["close"]),
+            "ltp": float(tick["close"]),
+            "source": "historical_replay",
+            "trace_id": f"replay:{tick['timestamp'].isoformat()}:{symbol}",
+        }
+        self._publish_quote(symbol, payload)
+        self._dispatch_tick(symbol, payload)
+
+    def _publish_quote(self, symbol: str, tick: Mapping[str, Any]) -> None:
+        hub = getattr(self._paper, "hub", None)
+        store_quote = getattr(hub, "store_quote", None)
+        if callable(store_quote):
+            store_quote(symbol, dict(tick), source="historical_replay")
+            return
+        quotes = getattr(hub, "quotes", None)
+        if isinstance(quotes, dict):
+            quotes[symbol] = dict(tick)
+
     def _dispatch_tick(self, symbol: str, tick: Mapping[str, Any]) -> None:
-        handler: Any
-        for attr in ("on_replay_tick", "process_tick", "on_tick", "_on_tick"):
+        for attr in ("on_tick_event", "on_datahub_tick", "_on_tick_safe"):
             handler = getattr(self._runner, attr, None)
-            if handler is None:
-                continue
+            if callable(handler):
+                handler(dict(tick))
+                return
+        handler = getattr(self._runner, "_on_tick", None)
+        if callable(handler):
             handler(symbol, tick)
             return
-        raise AttributeError("StrategyRunner does not expose a tick ingestion surface")
+        raise AttributeError(
+            "StrategyRunner does not expose the production tick ingestion surface"
+        )
 
 
 def _build_tick(row: pd.Series, timestamp: datetime, *, prefix: str) -> dict[str, Any]:
@@ -108,7 +148,7 @@ def _build_tick(row: pd.Series, timestamp: datetime, *, prefix: str) -> dict[str
     def _pick(name: str, default: float = 0.0) -> float:
         return float(row.get(f"{prefix}{name}", default))
 
-    return {
+    tick = {
         "timestamp": timestamp,
         "open": _pick("open"),
         "high": _pick("high"),
@@ -117,6 +157,11 @@ def _build_tick(row: pd.Series, timestamp: datetime, *, prefix: str) -> dict[str
         "volume": _pick("volume"),
         "oi": _pick("oi"),
     }
+    for name in ("bid", "ask", "instrument_token"):
+        value = row.get(f"{prefix}{name}")
+        if value is not None and not pd.isna(value):
+            tick[name] = float(value) if name != "instrument_token" else int(value)
+    return tick
 
 
 def _load_frame(path: Path) -> pd.DataFrame:
@@ -179,4 +224,4 @@ def _collect_trade_history(runner: Any) -> list[dict[str, Any]]:
     return trades
 
 
-__all__ = ["ReplayHarness", "ReplayResult"]
+__all__ = ["ReplayClock", "ReplayHarness", "ReplayResult"]

--- a/src/nifty_scalper_bot/execution/paper_fill_engine.py
+++ b/src/nifty_scalper_bot/execution/paper_fill_engine.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import time
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any, Dict, Mapping, cast
 
@@ -55,6 +56,11 @@ class PaperFillEngine:
         self._slippage_model = SlippageModel()
 
     # ------------------------------------------------------------------
+    def set_clock(self, clock: Callable[[], float]) -> None:
+        """Use a caller-owned clock for deterministic paper-order timestamps."""
+
+        self._clock = clock
+
     def place_order(self, payload: dict[str, Any]) -> dict[str, Any]:
         """Simulate order placement returning a broker-like response."""
 

--- a/tests/backtest/test_pipeline_parity.py
+++ b/tests/backtest/test_pipeline_parity.py
@@ -27,7 +27,8 @@ class _ParityRunner:
         self.ticks: list[tuple[str, float]] = []
         self._trades: list[dict[str, Any]] = []
 
-    def on_replay_tick(self, symbol: str, tick: dict[str, Any]) -> None:
+    def on_tick_event(self, tick: dict[str, Any]) -> None:
+        symbol = str(tick["symbol"])
         self.ticks.append((symbol, float(tick.get("close", 0.0))))
         if symbol == "OPT" and float(tick.get("close", 0.0)) > 101.0:
             self._trades.append({"symbol": symbol, "close": float(tick["close"])})
@@ -62,6 +63,7 @@ def test_single_pipeline_parity_matches() -> None:
     frame = _sample_frame()
     parity = SinglePipelineParity(
         runner_factory=_runner_factory,
+        reference_runner_factory=_runner_factory,
         paper_factory=_paper_factory,
         option_symbol="OPT",
     )
@@ -71,3 +73,18 @@ def test_single_pipeline_parity_matches() -> None:
     assert result.diff == ""
     assert result.live.trades == result.backtest.trades
     assert result.live.orders == result.backtest.orders
+
+
+def test_single_pipeline_parity_requires_independent_reference() -> None:
+    parity = SinglePipelineParity(
+        runner_factory=_runner_factory,
+        paper_factory=_paper_factory,
+        option_symbol="OPT",
+    )
+
+    try:
+        parity.run_frame(_sample_frame())
+    except ValueError as exc:
+        assert "reference_runner_factory" in str(exc)
+    else:  # pragma: no cover - explicit contract failure
+        raise AssertionError("parity must not compare a pipeline with itself")

--- a/tests/backtest/test_replay.py
+++ b/tests/backtest/test_replay.py
@@ -16,6 +16,9 @@ class _DummyDataHub:
     def get_quote(self, symbol: str, allow_pull: bool = False) -> dict[str, float]:
         return self.quotes.setdefault(symbol, {"ltp": 100.0})
 
+    def store_quote(self, symbol: str, quote: dict[str, float], *, source: str) -> None:
+        self.quotes[symbol] = dict(quote)
+
 
 class _DummyResolver:
     def lot_size_for_symbol(self, symbol: str) -> int:  # pragma: no cover - not used
@@ -34,8 +37,11 @@ class _DummyRunner:
     def __init__(self) -> None:
         self.ticks: list[tuple[str, dict[str, float]]] = []
 
-    def _on_tick(self, symbol: str, tick: dict[str, float]) -> None:
-        self.ticks.append((symbol, tick))
+    def on_tick_event(self, tick: dict[str, float]) -> None:
+        self.ticks.append((str(tick["symbol"]), tick))
+
+    def on_replay_tick(self, symbol: str, tick: dict[str, float]) -> None:
+        raise AssertionError("replay must use the production tick ingress")
 
     def get_status(self) -> dict[str, dict[str, list[_TradeRecord]]]:
         return {"symbols": {"OPT": {"trade_history": [_TradeRecord("BUY")]}}}
@@ -50,6 +56,8 @@ def _sample_frame() -> pd.DataFrame:
             "option_low": [99.5, 100.5, 101.5],
             "option_close": [100.5, 101.5, 102.5],
             "option_volume": [1000, 1100, 1200],
+            "option_bid": [100.4, 101.4, 102.4],
+            "option_ask": [100.6, 101.6, 102.6],
             "index_open": [19500.0, 19510.0, 19520.0],
             "index_high": [19520.0, 19530.0, 19540.0],
             "index_low": [19480.0, 19490.0, 19500.0],
@@ -72,6 +80,12 @@ def test_replay_harness_dispatches_ticks(tmp_path: Path) -> None:
 
     assert result.bars_processed == len(frame)
     assert len(runner.ticks) == len(frame) * 2
+    assert [symbol for symbol, _ in runner.ticks[:2]] == ["IDX", "OPT"]
+    assert runner.ticks[1][1]["last_price"] == 100.5
+    assert runner.ticks[1][1]["bid"] == 100.4
+    assert runner.ticks[1][1]["ask"] == 100.6
+    assert runner.ticks[1][1]["source"] == "historical_replay"
+    assert paper.hub.get_quote("OPT", allow_pull=False)["ltp"] == 102.5
     assert result.trades == [{"action": "BUY"}]
     assert result.orders == []
 
@@ -79,3 +93,45 @@ def test_replay_harness_dispatches_ticks(tmp_path: Path) -> None:
     frame.to_csv(csv_path)
     result_from_file = harness.run_day(tmp_path, "20240101")
     assert result_from_file.bars_processed == len(frame)
+
+
+class _ReplayClock:
+    def __init__(self) -> None:
+        self.timestamps: list[datetime] = []
+        self.current: datetime | None = None
+
+    def advance_to(self, timestamp: datetime) -> None:
+        self.timestamps.append(timestamp)
+        self.current = timestamp
+
+    def time(self) -> float:
+        assert self.current is not None
+        return self.current.timestamp()
+
+
+def test_replay_advances_clock_once_per_synchronised_timestamp() -> None:
+    hub = _DummyDataHub()
+    paper = PaperFillEngine(hub, _DummyResolver())
+    runner = _DummyRunner()
+    clock = _ReplayClock()
+    harness = ReplayHarness(
+        runner,
+        paper,
+        option_symbol="OPT",
+        index_symbol="IDX",
+        clock=clock,
+    )
+
+    frame = _sample_frame()
+    harness.run_dataframe(frame)
+
+    assert clock.timestamps == [timestamp.to_pydatetime() for timestamp in frame.index]
+    order = paper.place_order(
+        {
+            "symbol": "OPT",
+            "transaction_type": "BUY",
+            "quantity": 1,
+            "order_type": "MARKET",
+        }
+    )
+    assert order["timestamp"] == frame.index[-1].to_pydatetime().timestamp()

--- a/tests/backtests/test_replay_parity.py
+++ b/tests/backtests/test_replay_parity.py
@@ -57,7 +57,8 @@ class _ParityRunner:
         self._trades: list[dict[str, Any]] = []
         self._threshold = threshold
 
-    def on_replay_tick(self, symbol: str, tick: dict[str, Any]) -> None:
+    def on_tick_event(self, tick: dict[str, Any]) -> None:
+        symbol = str(tick["symbol"])
         close_price = float(tick.get("close", 0.0))
         self.ticks.append((symbol, close_price))
         if symbol == "OPT" and close_price >= self._threshold:
@@ -131,6 +132,7 @@ def test_backtest_pipeline_parity_generates_identical_trade_logs(
     engine = BacktestEngine(data, strategy, config)
     parity = SinglePipelineParity(
         runner_factory=_runner_factory,
+        reference_runner_factory=_runner_factory,
         paper_factory=_paper_factory,
         option_symbol="OPT",
     )
@@ -176,6 +178,7 @@ def test_backtest_pipeline_parity_detects_mismatched_trade_logs(
 
     parity = SinglePipelineParity(
         runner_factory=mismatch_factory,
+        reference_runner_factory=mismatch_factory,
         paper_factory=_paper_factory,
         option_symbol="OPT",
     )


### PR DESCRIPTION
## What changed
- route historical ticks through the production `on_tick_event` ingress
- advance a caller-owned replay clock once per synchronized timestamp
- publish underlying quotes before option evaluation and feed historical bid/ask/LTP into paper fills
- make paper-order timestamps deterministic under replay
- require an explicit reference runner before reporting pipeline parity

## Why
The prior replay preferred a test-only hook, evaluated the option before its underlying context, disconnected paper fills from historical quotes, and compared the same harness with itself. That could report false parity and unrealistic fills.

## Validation
- focused and adjacent replay/backtesting suites: 23 passed
- complete repository suite: passed with 1 expected skip
- Ruff, Black, changed-source mypy, compileall, and whitespace checks passed