### PR TITLE
Persist completed-trade execution loss

### DIFF
--- a/src/nifty_scalper_bot/execution/bracket_core.py
+++ b/src/nifty_scalper_bot/execution/bracket_core.py
@@ -301,6 +301,13 @@ class BracketState:
     entry_fill_ts: float | None = None
     exit_reason: str | None = None
     exit_triggered_at: float | None = None
+    exit_submitted_at: float | None = None
+    exit_arrival_price: float | None = None
+    exit_quote_bid: float | None = None
+    exit_quote_ask: float | None = None
+    exit_order_type: str | None = None
+    exit_market_fallback: bool = False
+    exit_rejected_attempts: int = 0
     exit_attempt_count: int = 0
     last_exit_attempt_at: float | None = None
     last_exit_error: str | None = None
@@ -421,6 +428,13 @@ class BracketState:
             "entry_fill_price": self.entry_fill_price,
             "exit_reason": self.exit_reason,
             "exit_triggered_at": self.exit_triggered_at,
+            "exit_submitted_at": self.exit_submitted_at,
+            "exit_arrival_price": self.exit_arrival_price,
+            "exit_quote_bid": self.exit_quote_bid,
+            "exit_quote_ask": self.exit_quote_ask,
+            "exit_order_type": self.exit_order_type,
+            "exit_market_fallback": self.exit_market_fallback,
+            "exit_rejected_attempts": self.exit_rejected_attempts,
             "exit_attempt_count": self.exit_attempt_count,
             "last_exit_attempt_at": self.last_exit_attempt_at,
             "last_exit_error": self.last_exit_error,
@@ -3344,6 +3358,16 @@ class BracketManager:
             preferred_order_type=preferred_order_type,
             qty=qty,
         )
+        if bracket is not None:
+            bid = pricing_meta.get("bid")
+            ask = pricing_meta.get("ask")
+            ltp = pricing_meta.get("ltp")
+            executable = bid if side == "SELL" else ask
+            bracket.exit_arrival_price = float(executable or ltp or 0.0) or None
+            bracket.exit_quote_bid = float(bid or 0.0) or None
+            bracket.exit_quote_ask = float(ask or 0.0) or None
+            bracket.exit_order_type = str(order_type or "").upper() or None
+            bracket.exit_market_fallback = bool(pricing_meta.get("fallback"))
         if pricing_meta.get("quote_missing"):
             LOGGER.warning(
                 "EXIT_ORDER_PRICING_DECISION bracket_id=%s reason=%s mode=aggressive_limit side=%s qty=%s bid=%s ask=%s ltp=%s price=%s fallback=%s",
@@ -3857,9 +3881,11 @@ class BracketManager:
                 bracket.pending_exit_order_id = result.order_id
                 bracket.exit_attempt_count += 1
                 bracket.last_exit_attempt_at = time.time()
+                bracket.exit_submitted_at = bracket.last_exit_attempt_at
                 bracket.exit_state = BracketExitLifecycle.EXIT_ORDER_SUBMITTED.value
                 submitted = True
             else:
+                bracket.exit_rejected_attempts += 1
                 bracket.last_exit_error = result.error_message or result.status
                 bracket.exit_state = (
                     BracketExitLifecycle.EXIT_REJECTED_RETRYABLE.value
@@ -4491,6 +4517,15 @@ class BracketManager:
             entry_fill_price=payload.get("entry_fill_price"),
             exit_reason=payload.get("exit_reason"),
             exit_triggered_at=payload.get("exit_triggered_at"),
+            exit_submitted_at=payload.get("exit_submitted_at"),
+            exit_arrival_price=payload.get("exit_arrival_price"),
+            exit_quote_bid=payload.get("exit_quote_bid"),
+            exit_quote_ask=payload.get("exit_quote_ask"),
+            exit_order_type=payload.get("exit_order_type"),
+            exit_market_fallback=bool(payload.get("exit_market_fallback", False)),
+            exit_rejected_attempts=int(
+                payload.get("exit_rejected_attempts", 0) or 0
+            ),
             exit_attempt_count=int(payload.get("exit_attempt_count", 0) or 0),
             last_exit_attempt_at=payload.get("last_exit_attempt_at"),
             last_exit_error=payload.get("last_exit_error"),

--- a/src/nifty_scalper_bot/execution/ledger_bracket_manager.py
+++ b/src/nifty_scalper_bot/execution/ledger_bracket_manager.py
@@ -8,6 +8,7 @@ re-arming until fill history and broker-flat state are reconciled.
 from __future__ import annotations
 
 import json
+import math
 import os
 import sqlite3
 import time
@@ -427,6 +428,106 @@ class LedgerBracketManager(CanonicalBracketManager):
             or closed_at
         )
         provenance = dict(getattr(bracket, "trade_provenance", {}) or {})
+
+        def _finite(value: Any) -> float | None:
+            try:
+                number = float(value)
+            except (TypeError, ValueError):
+                return None
+            return number if math.isfinite(number) and number > 0 else None
+
+        def _elapsed(start: Any, end: Any) -> float | None:
+            start_value = _finite(start)
+            end_value = _finite(end)
+            if start_value is None or end_value is None:
+                return None
+            return round(max(0.0, end_value - start_value), 3)
+
+        entry_arrival = _finite(provenance.get("entry_arrival_price"))
+        entry_bid = _finite(provenance.get("entry_quote_bid"))
+        entry_ask = _finite(provenance.get("entry_quote_ask"))
+        exit_arrival = _finite(getattr(bracket, "exit_arrival_price", None))
+        exit_bid = _finite(getattr(bracket, "exit_quote_bid", None))
+        exit_ask = _finite(getattr(bracket, "exit_quote_ask", None))
+        entry_slippage = None
+        exit_slippage = None
+        if entry_arrival is not None and entry_price is not None:
+            entry_slippage = (
+                float(entry_price) - entry_arrival
+                if side == "BUY"
+                else entry_arrival - float(entry_price)
+            )
+        if exit_arrival is not None and resolved_exit is not None:
+            exit_slippage = (
+                exit_arrival - float(resolved_exit)
+                if side == "BUY"
+                else float(resolved_exit) - exit_arrival
+            )
+        execution_quality = {
+            "entry_arrival_price": entry_arrival,
+            "entry_quote_bid": entry_bid,
+            "entry_quote_ask": entry_ask,
+            "entry_spread_points": (
+                round(entry_ask - entry_bid, 4)
+                if entry_bid is not None and entry_ask is not None
+                else None
+            ),
+            "entry_slippage_points": (
+                round(entry_slippage, 4) if entry_slippage is not None else None
+            ),
+            "entry_slippage_bps": (
+                round(entry_slippage / entry_arrival * 10000.0, 3)
+                if entry_slippage is not None and entry_arrival
+                else None
+            ),
+            "entry_slippage_cost": (
+                round(entry_slippage * quantity, 2)
+                if entry_slippage is not None
+                else None
+            ),
+            "decision_to_entry_fill_seconds": _elapsed(
+                provenance.get("decision_ts"),
+                getattr(bracket, "entry_fill_ts", None),
+            ),
+            "entry_submit_to_fill_seconds": _elapsed(
+                provenance.get("entry_submit_ts"),
+                getattr(bracket, "entry_fill_ts", None),
+            ),
+            "exit_arrival_price": exit_arrival,
+            "exit_quote_bid": exit_bid,
+            "exit_quote_ask": exit_ask,
+            "exit_spread_points": (
+                round(exit_ask - exit_bid, 4)
+                if exit_bid is not None and exit_ask is not None
+                else None
+            ),
+            "exit_slippage_points": (
+                round(exit_slippage, 4) if exit_slippage is not None else None
+            ),
+            "exit_slippage_bps": (
+                round(exit_slippage / exit_arrival * 10000.0, 3)
+                if exit_slippage is not None and exit_arrival
+                else None
+            ),
+            "exit_slippage_cost": (
+                round(exit_slippage * quantity, 2)
+                if exit_slippage is not None
+                else None
+            ),
+            "exit_trigger_to_fill_seconds": _elapsed(
+                getattr(bracket, "exit_triggered_at", None), closed_at
+            ),
+            "exit_submit_to_fill_seconds": _elapsed(
+                getattr(bracket, "exit_submitted_at", None), closed_at
+            ),
+            "exit_order_type": getattr(bracket, "exit_order_type", None),
+            "exit_market_fallback": bool(
+                getattr(bracket, "exit_market_fallback", False)
+            ),
+            "exit_rejected_attempts": int(
+                getattr(bracket, "exit_rejected_attempts", 0) or 0
+            ),
+        }
         return {
             **provenance,
             "bracket_id": str(bracket.bracket_id),
@@ -445,6 +546,7 @@ class LedgerBracketManager(CanonicalBracketManager):
             "mfe_pnl": round(mfe_points * quantity, 2),
             "mae_pnl": round(mae_points * quantity, 2),
             "holding_seconds": round(max(0.0, closed_at - opened_at), 3),
+            "execution_quality": execution_quality,
             "exit_reason": str(
                 getattr(bracket, "exit_reason", None) or bracket.close_source or ""
             ),

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -19906,6 +19906,7 @@ class StrategyRunner:
             _client_order_id = f"nfo:{_identity_digest}"
             _trade_lifecycle_id = f"tl:{_identity_digest}"
             _broker_tag = f"r{_identity_digest[:12]}"
+            _entry_submit_ts = time.time()
             # Request-normalization telemetry: strategy lots -> dynamic
             # lot-size resolution -> REQUESTED broker units. Nothing here is
             # final by name or by value.
@@ -19996,6 +19997,11 @@ class StrategyRunner:
                         "strategy_profile_version", "unknown"
                     ),
                     "final_score": metadata.get("final_score"),
+                    "entry_arrival_price": price,
+                    "entry_quote_bid": selected_snapshot.get("bid"),
+                    "entry_quote_ask": selected_snapshot.get("ask"),
+                    "decision_ts": now_epoch,
+                    "entry_submit_ts": _entry_submit_ts,
                 },
             )
             self._logger.info(

--- a/tests/execution/test_ledger_bracket_runtime.py
+++ b/tests/execution/test_ledger_bracket_runtime.py
@@ -197,6 +197,74 @@ def test_completed_trade_outcome_preserves_provenance_and_net_costs(
     assert restored.trade_provenance == bracket.trade_provenance
 
 
+def test_completed_trade_outcome_preserves_execution_loss(
+    monkeypatch, tmp_path
+) -> None:
+    manager, _order_manager, broker = _manager(monkeypatch, tmp_path)
+    bracket = manager.get_bracket("entry-1")
+    assert bracket is not None
+    manager.attach_trade_provenance(
+        "entry-1",
+        {
+            "entry_arrival_price": 99.5,
+            "entry_quote_bid": 99.0,
+            "entry_quote_ask": 100.0,
+            "decision_ts": 1000.0,
+            "entry_submit_ts": 1001.0,
+        },
+    )
+    manager.confirm_entry_fill("entry-1", 100.0)
+    bracket.entry_fill_ts = 1002.0
+    bracket = _mark_filled_exit(
+        manager,
+        broker,
+        order_id="execution-loss-outcome",
+        reason="HARD_TP_BREACH",
+        price=110.0,
+        residual=0,
+    )
+    bracket.exit_arrival_price = 110.2
+    bracket.exit_quote_bid = 110.0
+    bracket.exit_quote_ask = 110.4
+    bracket.exit_triggered_at = 1008.0
+    bracket.exit_submitted_at = 1009.0
+    bracket.exit_order_type = "MARKET"
+    bracket.exit_market_fallback = True
+    bracket.exit_rejected_attempts = 1
+    monkeypatch.setattr(
+        "nifty_scalper_bot.execution.ledger_bracket_manager.time.time",
+        lambda: 1010.0,
+    )
+
+    manager._close_bracket(bracket, close_source="broker_fill", exit_price=110.0)
+
+    outcome = manager.get_completed_trade_outcome(SYMBOL)
+    assert outcome is not None
+    quality = outcome["execution_quality"]
+    assert quality["entry_slippage_points"] == 0.5
+    assert quality["entry_slippage_cost"] == 65.0
+    assert quality["entry_spread_points"] == 1.0
+    assert quality["decision_to_entry_fill_seconds"] == 2.0
+    assert quality["entry_submit_to_fill_seconds"] == 1.0
+    assert quality["exit_slippage_points"] == 0.2
+    assert quality["exit_slippage_cost"] == 26.0
+    assert quality["exit_spread_points"] == 0.4
+    assert quality["exit_trigger_to_fill_seconds"] == 2.0
+    assert quality["exit_submit_to_fill_seconds"] == 1.0
+    assert quality["exit_order_type"] == "MARKET"
+    assert quality["exit_market_fallback"] is True
+    assert quality["exit_rejected_attempts"] == 1
+
+    restored = manager._decode_restored_bracket(
+        bracket.entry_order_id, bracket.to_dict()
+    )
+    assert restored.exit_arrival_price == bracket.exit_arrival_price
+    assert restored.exit_quote_bid == bracket.exit_quote_bid
+    assert restored.exit_quote_ask == bracket.exit_quote_ask
+    assert restored.exit_submitted_at == bracket.exit_submitted_at
+    assert restored.exit_rejected_attempts == 1
+
+
 def test_duplicate_entry_callback_is_idempotent(monkeypatch, tmp_path) -> None:
     manager, _order_manager, _broker = _manager(monkeypatch, tmp_path)
     manager.confirm_entry_fill("entry-1", 100.0)


### PR DESCRIPTION
## What changed
- stamp entry arrival price, bid/ask, decision time, and submit time into durable trade provenance
- persist exit arrival quote, order type, fallback mode, submit time, and rejected attempts in bracket state
- add confirmed entry/exit adverse slippage, spread, cost, and latency to the existing completed-trade outcome
- preserve all new fields across restart recovery

## Why
Net P&L alone cannot calibrate historical replay or identify execution drag. This keeps confirmed fill VWAP authoritative while measuring the gap from the quote available when the bot decided and submitted.

## Validation
- focused execution-loss TDD regression
- 86 adjacent ledger/exit/order/runner/persistence tests
- complete execution and strategy suites
- complete repository suite passed with 1 expected skip
- compileall and whitespace checks passed

No signal thresholds, risk limits, order modes, or exit policies changed.