### PR TITLE
Add chronological walk-forward evaluation

### DIFF
--- a/src/nifty_scalper_bot/core/adaptive_calibration.py
+++ b/src/nifty_scalper_bot/core/adaptive_calibration.py
@@ -3,10 +3,180 @@
 from __future__ import annotations
 
 from collections import deque
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, field
 from math import sqrt
 from statistics import mean, pstdev
-from typing import Deque
+from typing import Any, Deque
+
+WalkForwardEvaluator = Callable[
+    [Sequence[Mapping[str, Any]], Sequence[Mapping[str, Any]]],
+    Sequence[float],
+]
+
+
+@dataclass(frozen=True, slots=True)
+class PerformanceSummary:
+    """Net performance for one untouched walk-forward window."""
+
+    trade_count: int
+    total_net_pnl: float
+    expectancy: float
+    win_rate: float
+    profit_factor: float | None
+    max_drawdown: float
+
+    @classmethod
+    def from_pnl(cls, pnl: Sequence[float]) -> "PerformanceSummary":
+        values = [float(value) for value in pnl]
+        wins = [value for value in values if value > 0]
+        losses = [value for value in values if value < 0]
+        equity = 0.0
+        peak = 0.0
+        max_drawdown = 0.0
+        for value in values:
+            equity += value
+            peak = max(peak, equity)
+            max_drawdown = max(max_drawdown, peak - equity)
+        gross_profit = sum(wins)
+        gross_loss = abs(sum(losses))
+        return cls(
+            trade_count=len(values),
+            total_net_pnl=round(sum(values), 2),
+            expectancy=round(mean(values), 4) if values else 0.0,
+            win_rate=round(len(wins) / len(values), 4) if values else 0.0,
+            profit_factor=(
+                round(gross_profit / gross_loss, 4) if gross_loss > 0 else None
+            ),
+            max_drawdown=round(max_drawdown, 2),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class WalkForwardFold:
+    """One ordered train/validation/test comparison."""
+
+    fold: int
+    train_start: Any
+    train_end: Any
+    validation_start: Any
+    validation_end: Any
+    test_start: Any
+    test_end: Any
+    selected_candidate: str
+    selected_validation: PerformanceSummary
+    baseline_test: PerformanceSummary
+    candidate_test: PerformanceSummary
+
+
+@dataclass(frozen=True, slots=True)
+class WalkForwardResult:
+    """All untouched fold comparisons and their aggregate evidence."""
+
+    folds: tuple[WalkForwardFold, ...]
+    aggregate_baseline: PerformanceSummary
+    aggregate_candidate: PerformanceSummary
+
+
+@dataclass(frozen=True, slots=True)
+class ChronologicalWalkForward:
+    """Evaluate candidates without random splits or test-window look-ahead."""
+
+    train_size: int
+    validation_size: int
+    test_size: int
+    step_size: int | None = None
+    timestamp_field: str = "timestamp"
+
+    def __post_init__(self) -> None:
+        for name in ("train_size", "validation_size", "test_size"):
+            if int(getattr(self, name)) <= 0:
+                raise ValueError(f"{name} must be positive")
+        if self.step_size is not None and int(self.step_size) <= 0:
+            raise ValueError("step_size must be positive")
+
+    def evaluate(
+        self,
+        records: Sequence[Mapping[str, Any]],
+        *,
+        baseline: WalkForwardEvaluator,
+        candidates: Mapping[str, WalkForwardEvaluator],
+    ) -> WalkForwardResult:
+        """Select on validation and compare only on the following test slice."""
+
+        observations = list(records)
+        if not candidates:
+            raise ValueError("at least one candidate is required")
+        timestamps: list[Any] = []
+        for record in observations:
+            timestamp = record.get(self.timestamp_field)
+            if timestamp is None:
+                raise ValueError(f"every record requires {self.timestamp_field}")
+            timestamps.append(timestamp)
+        if any(
+            current >= following
+            for current, following in zip(timestamps, timestamps[1:])
+        ):
+            raise ValueError("records must be in strict chronological order")
+
+        fold_results: list[WalkForwardFold] = []
+        aggregate_baseline: list[float] = []
+        aggregate_candidate: list[float] = []
+        start = 0
+        step = int(self.step_size or self.test_size)
+        required = self.train_size + self.validation_size + self.test_size
+        while start + required <= len(observations):
+            train_end = start + self.train_size
+            validation_end = train_end + self.validation_size
+            test_end = validation_end + self.test_size
+            train = observations[start:train_end]
+            validation = observations[train_end:validation_end]
+            test = observations[validation_end:test_end]
+
+            validation_results = {
+                name: (
+                    PerformanceSummary.from_pnl(evaluator(train, validation)),
+                    evaluator,
+                )
+                for name, evaluator in sorted(candidates.items())
+            }
+            selected_name, (selected_validation, selected_evaluator) = max(
+                validation_results.items(),
+                key=lambda item: (
+                    item[1][0].expectancy,
+                    item[1][0].total_net_pnl,
+                    item[0],
+                ),
+            )
+            fit_for_test = [*train, *validation]
+            baseline_test_pnl = list(baseline(fit_for_test, test))
+            candidate_test_pnl = list(selected_evaluator(fit_for_test, test))
+            aggregate_baseline.extend(float(value) for value in baseline_test_pnl)
+            aggregate_candidate.extend(float(value) for value in candidate_test_pnl)
+            fold_results.append(
+                WalkForwardFold(
+                    fold=len(fold_results) + 1,
+                    train_start=timestamps[start],
+                    train_end=timestamps[train_end - 1],
+                    validation_start=timestamps[train_end],
+                    validation_end=timestamps[validation_end - 1],
+                    test_start=timestamps[validation_end],
+                    test_end=timestamps[test_end - 1],
+                    selected_candidate=selected_name,
+                    selected_validation=selected_validation,
+                    baseline_test=PerformanceSummary.from_pnl(baseline_test_pnl),
+                    candidate_test=PerformanceSummary.from_pnl(candidate_test_pnl),
+                )
+            )
+            start += step
+
+        if not fold_results:
+            raise ValueError("insufficient records for one walk-forward fold")
+        return WalkForwardResult(
+            folds=tuple(fold_results),
+            aggregate_baseline=PerformanceSummary.from_pnl(aggregate_baseline),
+            aggregate_candidate=PerformanceSummary.from_pnl(aggregate_candidate),
+        )
 
 
 @dataclass(slots=True)

--- a/tests/core/test_adaptive_calibration.py
+++ b/tests/core/test_adaptive_calibration.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import pytest
+
 from nifty_scalper_bot.core.adaptive_calibration import (
     AdaptiveParameterStore,
+    ChronologicalWalkForward,
     WalkForwardOptimizer,
 )
 
@@ -73,3 +76,60 @@ def test_negative_strategy_does_not_freeze_other_research_strategy() -> None:
     assert "loser" in opt._frozen_strategies
     assert "winner" not in opt._frozen_strategies
     assert tuned != current
+
+
+def test_chronological_walk_forward_keeps_test_untouched() -> None:
+    records = [
+        {
+            "timestamp": float(index),
+            "baseline": 1.0,
+            "stable": 2.0,
+            "overfit": 3.0 if index < 6 else -5.0,
+        }
+        for index in range(10)
+    ]
+    seen: list[tuple[str, float, float]] = []
+
+    def evaluator(name: str):
+        def _evaluate(fit, evaluation):
+            seen.append((name, fit[-1]["timestamp"], evaluation[0]["timestamp"]))
+            return [row[name] for row in evaluation]
+
+        return _evaluate
+
+    result = ChronologicalWalkForward(
+        train_size=4,
+        validation_size=2,
+        test_size=2,
+    ).evaluate(
+        records,
+        baseline=evaluator("baseline"),
+        candidates={
+            "stable": evaluator("stable"),
+            "overfit": evaluator("overfit"),
+        },
+    )
+
+    assert len(result.folds) == 2
+    assert result.folds[0].selected_candidate == "overfit"
+    assert result.folds[0].candidate_test.total_net_pnl == -10.0
+    assert result.folds[0].baseline_test.total_net_pnl == 2.0
+    assert result.folds[1].selected_candidate == "stable"
+    assert result.folds[1].candidate_test.total_net_pnl == 4.0
+    assert result.aggregate_candidate.total_net_pnl == -6.0
+    assert result.aggregate_baseline.total_net_pnl == 4.0
+    assert all(fit_end < evaluation_start for _, fit_end, evaluation_start in seen)
+
+
+def test_chronological_walk_forward_rejects_unsorted_records() -> None:
+    records = [{"timestamp": 2.0}, {"timestamp": 1.0}]
+
+    def evaluator(_fit, evaluation):
+        return [0.0 for _ in evaluation]
+
+    with pytest.raises(ValueError, match="chronological"):
+        ChronologicalWalkForward(1, 1, 1).evaluate(
+            records,
+            baseline=evaluator,
+            candidates={"candidate": evaluator},
+        )


### PR DESCRIPTION
## What changed
- add deterministic rolling train → validation → untouched-test folds
- select candidates only on validation data
- evaluate the locked candidate on the subsequent test slice against an unchanged baseline
- report net P&L, expectancy, win rate, profit factor, drawdown, and trade count per fold and in aggregate
- reject unsorted data and insufficient windows instead of silently randomizing or looking ahead

## Why
The existing adaptive tuner is research-only but was not a genuine walk-forward evaluator. This adds the evidence boundary needed before any parameter or strategy-profile promotion.

## Validation
- focused TDD includes an overfit candidate that wins validation and loses untouched test
- complete core and backtesting suites passed
- complete repository suite passed with 1 expected skip
- Ruff, Black, mypy, compileall, and whitespace checks passed

Automatic live parameter updates remain disabled.