### PR TITLE
Add versioned production strategy profile

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -1482,6 +1482,7 @@ from nifty_scalper_bot.shadow.shadow_paper import ShadowPaperTrader
 from nifty_scalper_bot.storage import HubStore
 from nifty_scalper_bot.strategies.elite_strategies.builder import (
     build_elite_strategies,
+    build_production_strategy_profile,
     get_strategy_tags as elite_strategy_tags,
 )
 from nifty_scalper_bot.strategies.indicators import IndicatorEngine
@@ -6243,6 +6244,21 @@ def initialize_components(settings: Settings | None = None) -> BotContext:
         regime_bias_map=regime_bias_map,
         market_regime_manager=market_regime_manager,
     )
+    strategy_profile = build_production_strategy_profile(
+        settings=settings,
+        strategies=elite_strategies,
+        mode_profile=strategy_manager.get_strategy_mode_profile(),
+        global_min_confidence=_global_min_conf,
+    )
+    LOGGER.info(
+        "PRODUCTION_STRATEGY_PROFILE version=%s profile=%s",
+        strategy_profile["version"],
+        strategy_profile,
+        extra={
+            "event": "PRODUCTION_STRATEGY_PROFILE",
+            "strategy_profile_version": strategy_profile["version"],
+        },
+    )
 
     unified_manager: UnifiedManager | None = None
     try:
@@ -6320,6 +6336,7 @@ def initialize_components(settings: Settings | None = None) -> BotContext:
         strike_selector=strike_selector,
         message_bus=message_bus,
         bracket_manager=bracket_manager,
+        strategy_profile=strategy_profile,
     )
     strategy_runner.attach_persistent_state(persistent_state)
     if hasattr(order_manager, "entry_order_failed_callback"):

--- a/src/nifty_scalper_bot/strategies/elite_strategies/builder.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/builder.py
@@ -5,25 +5,39 @@ Production-Grade: Explicit Registry Mapping for Stability and Fault-Tolerance.
 
 from __future__ import annotations
 
+import hashlib
+import json
 import os
-from typing import Any, List, Dict, Type
+from dataclasses import asdict
+from typing import Any, Dict, List, Mapping, Sequence, Type
 
 from nifty_scalper_bot.strategies.elite_strategies.base_elite import EliteStrategy
-from nifty_scalper_bot.strategies.elite_strategies.config_models import EliteStrategiesSettings
 
 # --- Strategy Class Imports ---
 from nifty_scalper_bot.strategies.elite_strategies.bb_squeeze import BBSqueezeStrategy
-from nifty_scalper_bot.strategies.elite_strategies.cpr_breakout import CPRBreakoutStrategy
-from nifty_scalper_bot.strategies.elite_strategies.gamma_scalping import GammaScalpingStrategy
-from nifty_scalper_bot.strategies.elite_tuesday_gamma_buyer import EliteTuesdayGammaBuyer
+from nifty_scalper_bot.strategies.elite_strategies.config_models import (
+    EliteStrategiesSettings,
+)
+from nifty_scalper_bot.strategies.elite_strategies.cpr_breakout import (
+    CPRBreakoutStrategy,
+)
+from nifty_scalper_bot.strategies.elite_strategies.gamma_scalping import (
+    GammaScalpingStrategy,
+)
 from nifty_scalper_bot.strategies.elite_strategies.oi_max_pain import OIMaxPainStrategy
 from nifty_scalper_bot.strategies.elite_strategies.orb_pro import ORBProStrategy
 from nifty_scalper_bot.strategies.elite_strategies.order_flow import OrderFlowStrategy
-from nifty_scalper_bot.strategies.elite_strategies.rsi_divergence import RSIDivergenceStrategy
+from nifty_scalper_bot.strategies.elite_strategies.rsi_divergence import (
+    RSIDivergenceStrategy,
+)
 from nifty_scalper_bot.strategies.elite_strategies.smc_liquidity import SMCStrategy
-from nifty_scalper_bot.strategies.elite_strategies.straddle_theta import StraddleThetaStrategy
+from nifty_scalper_bot.strategies.elite_strategies.straddle_theta import (
+    StraddleThetaStrategy,
+)
 from nifty_scalper_bot.strategies.elite_strategies.vwap_pro import VWAPProStrategy
-
+from nifty_scalper_bot.strategies.elite_tuesday_gamma_buyer import (
+    EliteTuesdayGammaBuyer,
+)
 from nifty_scalper_bot.utils.logging import get_logger
 
 LOGGER = get_logger(__name__)
@@ -39,6 +53,116 @@ _TRUE_VALUES = {'1', 'true', 'yes', 'on'}
 
 def _env_true(name: str, default: str = 'false') -> bool:
     return str(os.getenv(name, default) or default).strip().lower() in _TRUE_VALUES
+
+
+def _production_strategy_roles(
+    active_names: Sequence[str],
+    *,
+    strategy_mode: str,
+) -> tuple[list[str], list[str]]:
+    """Return the effective trigger and context strategy sets."""
+    context_names: list[str] = []
+    if strategy_mode == 'directional_scalp':
+        context_class_names = {
+            OIMaxPainStrategy.__name__.replace('Strategy', ''),
+            OrderFlowStrategy.__name__.replace('Strategy', ''),
+            BBSqueezeStrategy.__name__.replace('Strategy', ''),
+        }
+        context_names = [name for name in active_names if name in context_class_names]
+
+    if _env_true('ORDERFLOW_ALLOW_TRIGGER_ROLE'):
+        context_names = [name for name in context_names if name != 'OrderFlow']
+    elif 'OrderFlow' in active_names and 'OrderFlow' not in context_names:
+        context_names.append('OrderFlow')
+
+    trigger_names = [name for name in active_names if name not in context_names]
+    return trigger_names, context_names
+
+
+def build_production_strategy_profile(
+    *,
+    settings: Any,
+    strategies: Sequence[EliteStrategy],
+    mode_profile: Mapping[str, Any],
+    global_min_confidence: float,
+) -> dict[str, Any]:
+    """Build a deterministic, observational snapshot of material live settings."""
+    strategy_mode = str(os.getenv('STRATEGY_MODE', 'directional_scalp')).strip().lower()
+    active_names = [str(strategy.name) for strategy in strategies]
+    trigger_names, context_names = _production_strategy_roles(
+        active_names,
+        strategy_mode=strategy_mode,
+    )
+    confidence_thresholds: dict[str, float] = {}
+    for strategy in strategies:
+        config = getattr(strategy, 'config', None)
+        if config is None:
+            continue
+        raw_threshold = (
+            config.get('min_confidence')
+            if isinstance(config, Mapping)
+            else getattr(config, 'min_confidence', None)
+        )
+        if raw_threshold is not None:
+            confidence_thresholds[str(strategy.name)] = float(raw_threshold)
+
+    from nifty_scalper_bot.config import settings as app_settings
+    from nifty_scalper_bot.core.strategy_manager import REGIME_STRATEGY_WEIGHTS
+
+    profile: dict[str, Any] = {
+        'schema_version': 1,
+        'execution_mode': str(mode_profile.get('mode') or settings.execution_mode),
+        'strategies': {
+            'mode': strategy_mode,
+            'active': active_names,
+            'trigger_capable': trigger_names,
+            'context_only': context_names,
+        },
+        'score_thresholds': {
+            'global_min_confidence': float(global_min_confidence),
+            'per_strategy_min_confidence': confidence_thresholds,
+            'mode_gate': dict(mode_profile),
+        },
+        'quote_policy': {
+            'order_max_age_ms': int(settings.orders.max_quote_age_ms),
+            'liquidity_max_spread_pct': float(settings.liquidity.max_spread_pct),
+            'live_entry_max_spread_pct': float(
+                os.getenv('LIVE_MAX_SPREAD_PCT', '0.75') or '0.75'
+            ),
+            'order_max_spread_pct': float(
+                os.getenv(
+                    'ORDER_MAX_SPREAD_PCT',
+                    os.getenv('SPREAD_MAX_PCT', '10.0'),
+                )
+                or '10.0'
+            ),
+        },
+        'risk': {
+            'per_trade_risk_pct': float(settings.risk.per_trade_risk_pct),
+            'per_trade_cap_pct': float(settings.risk.per_trade_cap_pct),
+            'min_lots': int(settings.risk.min_lots_per_trade),
+            'max_lots': int(settings.risk.max_lots_per_trade),
+            'max_open_positions': int(settings.risk.max_open_positions),
+        },
+        'exit_policy': {
+            **asdict(settings.orders.lifecycle),
+            'atr_stop_multiple': float(settings.risk.atr_stop_multiple),
+        },
+        'regime': {
+            'adaptive_enabled': bool(app_settings.USE_REGIME_ADAPTIVE),
+            'sizing_multipliers': {
+                'trend': float(app_settings.REGIME_TREND_SIZING_MULT),
+                'range': float(app_settings.REGIME_RANGE_SIZING_MULT),
+                'volatile': float(app_settings.REGIME_VOLATILE_SIZING_MULT),
+                'event': float(app_settings.REGIME_EVENT_SIZING_MULT),
+            },
+            'strategy_weights': REGIME_STRATEGY_WEIGHTS,
+        },
+    }
+    canonical = json.dumps(profile, sort_keys=True, separators=(',', ':'))
+    digest = hashlib.sha256(canonical.encode()).hexdigest()[:12]
+    profile['version'] = f"production-v1-{digest}"
+    return profile
 
 
 def build_elite_strategies(
@@ -146,12 +270,10 @@ def build_elite_strategies(
     passed = len(strategies)
     total = len(registry)
     LOGGER.info(f"📊 Strategy Build Complete: {passed}/{total} active.")
-    orderflow_trigger = _env_true('ORDERFLOW_ALLOW_TRIGGER_ROLE')
-    if orderflow_trigger and 'OrderFlow' in context_names:
-        context_names.remove('OrderFlow')
-    elif not orderflow_trigger and 'OrderFlow' in active_names and 'OrderFlow' not in context_names:
-        context_names.append('OrderFlow')
-    trigger_capable = [name for name in active_names if name not in (context_names or [])]
+    trigger_capable, context_names = _production_strategy_roles(
+        active_names,
+        strategy_mode=strategy_mode,
+    )
     LOGGER.info(
         "STRATEGY_PRODUCTION_SET active=%s trigger_capable=%s context_only=%s disabled_experimental=%s",
         active_names,
@@ -192,4 +314,8 @@ def get_strategy_tags(settings: EliteStrategiesSettings) -> Dict[str, List[str]]
     return tags
 
 
-__all__ = ["build_elite_strategies", "get_strategy_tags"]
+__all__ = [
+    "build_elite_strategies",
+    "build_production_strategy_profile",
+    "get_strategy_tags",
+]

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -804,10 +804,12 @@ class StrategyRunner:
         data_hub: "DataHub | None" = None,
         strike_selector: StrikeSelector | None = None,
         bracket_manager: Any | None = None,
+        strategy_profile: Mapping[str, Any] | None = None,
     ) -> None:
         self._market_data = market_data_manager
         self._indicator_engine = indicator_engine
         self._strategy_manager = strategy_manager
+        self._strategy_profile = dict(strategy_profile or {})
         self._risk_manager = risk_manager
         self._order_manager = order_manager
         self._position_manager = position_manager
@@ -1309,9 +1311,8 @@ class StrategyRunner:
             "git_branch": os.getenv("GIT_BRANCH", "unknown"),
             "deployment_id": os.getenv("DEPLOYMENT_ID", "unknown"),
             "build_time": os.getenv("BUILD_TIME", "unknown"),
-            "strategy_profile_version": os.getenv(
-                "STRATEGY_PROFILE_VERSION", "unknown"
-            ),
+            "strategy_profile_version": self._strategy_profile.get("version")
+            or os.getenv("STRATEGY_PROFILE_VERSION", "unknown"),
         }
 
         # FIX S10-2: wire bracket-exit callback so direction lock clears on SL/TP

--- a/tests/strategies/test_elite_builder_mode.py
+++ b/tests/strategies/test_elite_builder_mode.py
@@ -1,6 +1,18 @@
 from __future__ import annotations
 
-from nifty_scalper_bot.strategies.elite_strategies.builder import build_elite_strategies
+from dataclasses import replace
+from types import SimpleNamespace
+
+from nifty_scalper_bot.config.settings import (
+    LiquiditySettings,
+    OrderLifecycleSettings,
+    OrderSettings,
+    RiskSettings,
+)
+from nifty_scalper_bot.strategies.elite_strategies.builder import (
+    build_elite_strategies,
+    build_production_strategy_profile,
+)
 from nifty_scalper_bot.strategies.elite_strategies.config_models import (
     EliteStrategiesSettings,
     ORBProStrategyConfig,
@@ -54,3 +66,62 @@ def test_orb_direction_is_consumed_only_after_entry_acceptance(
 
     assert strategy._evaluate_signal("NFO:NIFTYCE", indicators, 110.0) is None
     assert strategy.last_no_vote_reason == "direction_already_traded_today"
+
+
+def test_production_profile_is_stable_and_changes_with_material_settings(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("STRATEGY_MODE", "directional_scalp")
+    monkeypatch.setenv("ORDERFLOW_ALLOW_TRIGGER_ROLE", "false")
+    elite = EliteStrategiesSettings()
+    strategies = build_elite_strategies(elite, indicator_engine=None)
+    runtime = SimpleNamespace(
+        execution_mode="LIVE",
+        orders=OrderSettings(lifecycle=OrderLifecycleSettings()),
+        liquidity=LiquiditySettings(max_spread_pct=30.0),
+        risk=RiskSettings(per_trade_risk_pct=5.0),
+    )
+    mode_profile = {
+        "mode": "LIVE",
+        "allow_context_promotion": False,
+        "allow_single_vote": True,
+        "min_trade_quality": 7.0,
+    }
+
+    first = build_production_strategy_profile(
+        settings=runtime,
+        strategies=strategies,
+        mode_profile=mode_profile,
+        global_min_confidence=0.35,
+    )
+    repeated = build_production_strategy_profile(
+        settings=runtime,
+        strategies=strategies,
+        mode_profile=mode_profile,
+        global_min_confidence=0.35,
+    )
+
+    assert first == repeated
+    assert first["version"].startswith("production-v1-")
+    assert first["execution_mode"] == "LIVE"
+    assert "OrderFlow" in first["strategies"]["context_only"]
+    assert {"SMC", "VWAPPro", "ORBPro"}.issubset(
+        first["strategies"]["trigger_capable"]
+    )
+    assert first["score_thresholds"]["global_min_confidence"] == 0.35
+
+    changed_runtime = SimpleNamespace(
+        **{
+            **runtime.__dict__,
+            "risk": replace(runtime.risk, per_trade_risk_pct=4.0),
+        }
+    )
+    changed = build_production_strategy_profile(
+        settings=changed_runtime,
+        strategies=strategies,
+        mode_profile=mode_profile,
+        global_min_confidence=0.35,
+    )
+
+    assert changed["risk"]["per_trade_risk_pct"] == 4.0
+    assert changed["version"] != first["version"]

--- a/tests/strategies/test_symbol_runtime_state_trade_runtime.py
+++ b/tests/strategies/test_symbol_runtime_state_trade_runtime.py
@@ -42,7 +42,9 @@ class _StubPositionManager:
         return None
 
 
-def _build_runner() -> StrategyRunner:
+def _build_runner(
+    strategy_profile: dict[str, object] | None = None,
+) -> StrategyRunner:
     return StrategyRunner(
         market_data_manager=SimpleNamespace(),
         indicator_engine=SimpleNamespace(),
@@ -52,7 +54,20 @@ def _build_runner() -> StrategyRunner:
         position_manager=_StubPositionManager(),
         message_bus=MessageBus(),
         config=StrategyRunnerConfig(max_trade_history=5),
+        strategy_profile=strategy_profile,
     )
+
+
+def test_runner_uses_derived_strategy_profile_version() -> None:
+    runner = _build_runner(
+        {"schema_version": 1, "version": "production-v1-abc123def456"}
+    )
+
+    assert (
+        runner._build_info["strategy_profile_version"]
+        == "production-v1-abc123def456"
+    )
+    assert runner._strategy_profile["schema_version"] == 1
 
 
 def test_symbol_runtime_state_defaults_without_last_trade_at() -> None:


### PR DESCRIPTION
## What changed

- Build one deterministic production strategy profile from the existing strategy builder, effective score gates, quote policy, risk limits, exit lifecycle, regime weights, and execution mode.
- Derive a content-based `production-v1-…` version and log the complete observational snapshot at startup.
- Pass the derived version through the existing runner provenance path so completed trades no longer depend on an unset `STRATEGY_PROFILE_VERSION`.
- Preserve legacy dictionary-based strategy configs used by live simulation.

## Behavior preserved

This profile is observational only. It does not replace or mutate environment switches, strategy roles, thresholds, risk sizing, quote gates, order routing, or exit behavior.

## Validation

- Focused profile and runner provenance regressions
- Complete `tests/strategies` and `tests/core` suites
- Live-runtime startup contract suite
- Full repository pytest suite (one expected skip)
- `compileall`, targeted Ruff, targeted mypy, and `git diff --check`
