### PR TITLE
Enforce historical contract availability in replay

### DIFF
--- a/src/nifty_scalper_bot/backtest/parity.py
+++ b/src/nifty_scalper_bot/backtest/parity.py
@@ -9,7 +9,11 @@ from typing import Any, Callable
 
 import pandas as pd
 
-from nifty_scalper_bot.backtest.replay import ReplayHarness, ReplayResult
+from nifty_scalper_bot.backtest.replay import (
+    HistoricalContractCatalog,
+    ReplayHarness,
+    ReplayResult,
+)
 from nifty_scalper_bot.execution.paper_fill_engine import PaperFillEngine
 from nifty_scalper_bot.utils.logging import get_logger
 
@@ -36,6 +40,7 @@ class SinglePipelineParity:
         paper_factory: Callable[[], PaperFillEngine],
         option_symbol: str,
         index_symbol: str | None = None,
+        contract_catalog: HistoricalContractCatalog | None = None,
     ) -> None:
         """Initialise the parity harness using shared factories.
 
@@ -57,6 +62,7 @@ class SinglePipelineParity:
         self._paper_factory = paper_factory
         self._option_symbol = option_symbol
         self._index_symbol = index_symbol
+        self._contract_catalog = contract_catalog
         self._logger = LOGGER
 
     def run_frame(self, frame: pd.DataFrame) -> PipelineParityResult:
@@ -89,6 +95,7 @@ class SinglePipelineParity:
                 live_paper,
                 option_symbol=self._option_symbol,
                 index_symbol=self._index_symbol,
+                contract_catalog=self._contract_catalog,
             )
             live_result = live_harness.run_dataframe(frame)
 
@@ -99,6 +106,7 @@ class SinglePipelineParity:
                 back_paper,
                 option_symbol=self._option_symbol,
                 index_symbol=self._index_symbol,
+                contract_catalog=self._contract_catalog,
             )
             back_result = back_harness.run_dataframe(frame)
         except Exception as exc:

--- a/src/nifty_scalper_bot/backtest/replay.py
+++ b/src/nifty_scalper_bot/backtest/replay.py
@@ -2,14 +2,18 @@
 
 from __future__ import annotations
 
+from bisect import bisect_right
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import date, datetime
 from pathlib import Path
-from typing import Any, Mapping, Protocol
+from typing import Any, Mapping, Protocol, Sequence
+from zoneinfo import ZoneInfo
 
 import pandas as pd
 
 from nifty_scalper_bot.execution.paper_fill_engine import PaperFillEngine
+
+_IST = ZoneInfo("Asia/Kolkata")
 
 
 class ReplayClock(Protocol):
@@ -42,6 +46,48 @@ class ReplayResult:
         )
 
 
+@dataclass(frozen=True, slots=True)
+class ReplayContractSnapshot:
+    """Historical active basket recorded from ``available_from`` onward."""
+
+    available_from: datetime
+    basket: Mapping[str, Any]
+
+
+class HistoricalContractCatalog:
+    """Resolve the latest time-available basket without future-data look-ahead."""
+
+    def __init__(self, snapshots: Sequence[ReplayContractSnapshot]) -> None:
+        if not snapshots:
+            raise ValueError("historical contract catalog requires snapshots")
+        ordered = sorted(snapshots, key=lambda item: _as_utc(item.available_from))
+        timestamps = [_as_utc(item.available_from) for item in ordered]
+        if len(set(timestamps)) != len(timestamps):
+            raise ValueError("historical contract snapshots require unique timestamps")
+        self._snapshots = tuple(ordered)
+        self._timestamps = tuple(timestamps)
+
+    def resolve(self, timestamp: datetime) -> Mapping[str, Any]:
+        """Return the basket known at ``timestamp`` or fail closed."""
+
+        target = _as_utc(timestamp)
+        index = bisect_right(self._timestamps, target) - 1
+        if index < 0:
+            raise LookupError(
+                f"no contract basket available at {timestamp.isoformat()}"
+            )
+        basket = self._snapshots[index].basket
+        expiry = _parse_contract_expiry(basket.get("option_expiry"))
+        if expiry is None:
+            raise ValueError("historical contract basket requires option_expiry")
+        trading_day = target.astimezone(_IST).date()
+        if expiry < trading_day:
+            raise LookupError(
+                f"historical contract basket expired on {expiry.isoformat()}"
+            )
+        return basket
+
+
 class ReplayHarness:
     """Feed historical minute bars through :class:`StrategyRunner`."""
 
@@ -53,12 +99,15 @@ class ReplayHarness:
         option_symbol: str,
         index_symbol: str | None = None,
         clock: ReplayClock | None = None,
+        contract_catalog: HistoricalContractCatalog | None = None,
     ) -> None:
         self._runner = runner
         self._paper = paper_engine
         self._option_symbol = option_symbol
         self._index_symbol = index_symbol
         self._clock = clock
+        self._contract_catalog = contract_catalog
+        self._active_basket_key: tuple[Any, ...] | None = None
         clock_time = getattr(clock, "time", None)
         set_clock = getattr(paper_engine, "set_clock", None)
         if callable(clock_time) and callable(set_clock):
@@ -79,13 +128,19 @@ class ReplayHarness:
             tick_time = timestamp.to_pydatetime()
             if self._clock is not None:
                 self._clock.advance_to(tick_time)
+            option_symbol = self._option_symbol
+            if self._contract_catalog is not None:
+                basket = self._contract_catalog.resolve(tick_time)
+                self._install_contract_basket(basket)
+                option_symbol = _row_option_symbol(row, option_symbol)
+                _require_available_option(option_symbol, basket, tick_time)
             if self._index_symbol:
                 index_tick = _build_tick(row, tick_time, prefix="index_")
                 if index_tick:
                     self._publish_and_dispatch(self._index_symbol, index_tick)
             option_tick = _build_tick(row, tick_time, prefix="option_")
             if option_tick:
-                self._publish_and_dispatch(self._option_symbol, option_tick)
+                self._publish_and_dispatch(option_symbol, option_tick)
             bars += 1
         trades = _collect_trade_history(self._runner)
         orders = self._paper.get_orders() if hasattr(self._paper, "get_orders") else []
@@ -139,6 +194,34 @@ class ReplayHarness:
             "StrategyRunner does not expose the production tick ingestion surface"
         )
 
+    def _install_contract_basket(self, basket: Mapping[str, Any]) -> None:
+        key = (
+            basket.get("basket_version"),
+            basket.get("selected_ce"),
+            basket.get("selected_ce_token"),
+            basket.get("selected_pe"),
+            basket.get("selected_pe_token"),
+            basket.get("option_expiry"),
+            tuple(basket.get("option_symbols") or ()),
+            tuple(basket.get("option_tokens") or ()),
+        )
+        if key == self._active_basket_key:
+            return
+        set_runner_basket = getattr(self._runner, "set_active_trading_universe", None)
+        if not callable(set_runner_basket):
+            raise AttributeError(
+                "StrategyRunner cannot install historical active contract basket"
+            )
+        set_runner_basket(basket)
+        hub = getattr(self._paper, "hub", None)
+        set_hub_basket = getattr(hub, "set_active_contract_basket", None)
+        if not callable(set_hub_basket):
+            raise AttributeError(
+                "PaperFillEngine quote hub cannot install historical contract basket"
+            )
+        set_hub_basket(basket)
+        self._active_basket_key = key
+
 
 def _build_tick(row: pd.Series, timestamp: datetime, *, prefix: str) -> dict[str, Any]:
     columns = {col for col in row.index if col.startswith(prefix)}
@@ -162,6 +245,53 @@ def _build_tick(row: pd.Series, timestamp: datetime, *, prefix: str) -> dict[str
         if value is not None and not pd.isna(value):
             tick[name] = float(value) if name != "instrument_token" else int(value)
     return tick
+
+
+def _as_utc(value: datetime) -> datetime:
+    timestamp = value if value.tzinfo is not None else value.replace(tzinfo=_IST)
+    return timestamp.astimezone(ZoneInfo("UTC"))
+
+
+def _parse_contract_expiry(value: Any) -> date | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, date):
+        return value
+    parsed = pd.to_datetime(value, errors="coerce")
+    if pd.isna(parsed):
+        return None
+    return parsed.date()
+
+
+def _row_option_symbol(row: pd.Series, default: str) -> str:
+    value = row.get("option_symbol")
+    if value is None or pd.isna(value):
+        return default
+    symbol = str(value).strip()
+    return symbol or default
+
+
+def _require_available_option(
+    symbol: str,
+    basket: Mapping[str, Any],
+    timestamp: datetime,
+) -> None:
+    available = {
+        str(item).strip().upper()
+        for item in (
+            basket.get("option_symbols")
+            or (basket.get("selected_ce"), basket.get("selected_pe"))
+        )
+        if item
+    }
+    normalized = str(symbol).strip().upper()
+    if normalized not in available:
+        raise ValueError(
+            f"option {symbol} not present in historical basket at "
+            f"{timestamp.isoformat()}"
+        )
 
 
 def _load_frame(path: Path) -> pd.DataFrame:
@@ -224,4 +354,10 @@ def _collect_trade_history(runner: Any) -> list[dict[str, Any]]:
     return trades
 
 
-__all__ = ["ReplayClock", "ReplayHarness", "ReplayResult"]
+__all__ = [
+    "HistoricalContractCatalog",
+    "ReplayClock",
+    "ReplayContractSnapshot",
+    "ReplayHarness",
+    "ReplayResult",
+]

--- a/tests/backtest/test_replay.py
+++ b/tests/backtest/test_replay.py
@@ -4,20 +4,29 @@ from datetime import datetime
 from pathlib import Path
 
 import pandas as pd
+import pytest
 
-from nifty_scalper_bot.backtest.replay import ReplayHarness
+from nifty_scalper_bot.backtest.replay import (
+    HistoricalContractCatalog,
+    ReplayContractSnapshot,
+    ReplayHarness,
+)
 from nifty_scalper_bot.execution.paper_fill_engine import PaperFillEngine
 
 
 class _DummyDataHub:
     def __init__(self) -> None:
         self.quotes: dict[str, dict[str, float]] = {}
+        self.baskets: list[dict[str, object]] = []
 
     def get_quote(self, symbol: str, allow_pull: bool = False) -> dict[str, float]:
         return self.quotes.setdefault(symbol, {"ltp": 100.0})
 
     def store_quote(self, symbol: str, quote: dict[str, float], *, source: str) -> None:
         self.quotes[symbol] = dict(quote)
+
+    def set_active_contract_basket(self, basket: dict[str, object]) -> None:
+        self.baskets.append(dict(basket))
 
 
 class _DummyResolver:
@@ -36,12 +45,16 @@ class _TradeRecord:
 class _DummyRunner:
     def __init__(self) -> None:
         self.ticks: list[tuple[str, dict[str, float]]] = []
+        self.baskets: list[dict[str, object]] = []
 
     def on_tick_event(self, tick: dict[str, float]) -> None:
         self.ticks.append((str(tick["symbol"]), tick))
 
     def on_replay_tick(self, symbol: str, tick: dict[str, float]) -> None:
         raise AssertionError("replay must use the production tick ingress")
+
+    def set_active_trading_universe(self, basket: dict[str, object]) -> None:
+        self.baskets.append(dict(basket))
 
     def get_status(self) -> dict[str, dict[str, list[_TradeRecord]]]:
         return {"symbols": {"OPT": {"trade_history": [_TradeRecord("BUY")]}}}
@@ -135,3 +148,129 @@ def test_replay_advances_clock_once_per_synchronised_timestamp() -> None:
         }
     )
     assert order["timestamp"] == frame.index[-1].to_pydatetime().timestamp()
+
+
+def test_replay_rotates_only_time_available_historical_contracts() -> None:
+    timestamps = pd.date_range(datetime(2024, 1, 1, 9, 30), periods=2, freq="T")
+    frame = _sample_frame().iloc[:2].copy()
+    frame.index = timestamps
+    frame["option_symbol"] = ["NFO:NIFTY24JAN19500CE", "NFO:NIFTY24JAN19550CE"]
+    first = {
+        "selected_ce": "NFO:NIFTY24JAN19500CE",
+        "selected_pe": "NFO:NIFTY24JAN19500PE",
+        "option_symbols": (
+            "NFO:NIFTY24JAN19500CE",
+            "NFO:NIFTY24JAN19500PE",
+        ),
+        "option_expiry": "2024-01-04",
+    }
+    second = {
+        "selected_ce": "NFO:NIFTY24JAN19550CE",
+        "selected_pe": "NFO:NIFTY24JAN19550PE",
+        "option_symbols": (
+            "NFO:NIFTY24JAN19550CE",
+            "NFO:NIFTY24JAN19550PE",
+        ),
+        "option_expiry": "2024-01-04",
+    }
+    catalog = HistoricalContractCatalog(
+        [
+            ReplayContractSnapshot(timestamps[0].to_pydatetime(), first),
+            ReplayContractSnapshot(timestamps[1].to_pydatetime(), second),
+        ]
+    )
+    hub = _DummyDataHub()
+    runner = _DummyRunner()
+    harness = ReplayHarness(
+        runner,
+        PaperFillEngine(hub, _DummyResolver()),
+        option_symbol="legacy-option",
+        index_symbol="IDX",
+        contract_catalog=catalog,
+    )
+
+    harness.run_dataframe(frame)
+
+    assert [symbol for symbol, _ in runner.ticks if symbol != "IDX"] == [
+        "NFO:NIFTY24JAN19500CE",
+        "NFO:NIFTY24JAN19550CE",
+    ]
+    assert [basket["selected_ce"] for basket in runner.baskets] == [
+        first["selected_ce"],
+        second["selected_ce"],
+    ]
+    assert hub.baskets == runner.baskets
+
+
+def test_replay_rejects_contract_not_available_in_historical_basket() -> None:
+    timestamp = datetime(2024, 1, 1, 9, 30)
+    frame = _sample_frame().iloc[:1].copy()
+    frame.index = pd.DatetimeIndex([timestamp])
+    frame["option_symbol"] = ["NFO:NIFTY24JAN19600CE"]
+    catalog = HistoricalContractCatalog(
+        [
+            ReplayContractSnapshot(
+                timestamp,
+                {
+                    "selected_ce": "NFO:NIFTY24JAN19500CE",
+                    "selected_pe": "NFO:NIFTY24JAN19500PE",
+                    "option_symbols": (
+                        "NFO:NIFTY24JAN19500CE",
+                        "NFO:NIFTY24JAN19500PE",
+                    ),
+                    "option_expiry": "2024-01-04",
+                },
+            )
+        ]
+    )
+    harness = ReplayHarness(
+        _DummyRunner(),
+        PaperFillEngine(_DummyDataHub(), _DummyResolver()),
+        option_symbol="legacy-option",
+        contract_catalog=catalog,
+    )
+
+    with pytest.raises(ValueError, match="not present in historical basket"):
+        harness.run_dataframe(frame)
+
+
+def test_historical_contract_catalog_rejects_lookahead_and_expired_baskets() -> None:
+    catalog = HistoricalContractCatalog(
+        [
+            ReplayContractSnapshot(
+                datetime(2024, 1, 2, 9, 30),
+                {
+                    "selected_ce": "NFO:NIFTY24JAN19500CE",
+                    "selected_pe": "NFO:NIFTY24JAN19500PE",
+                    "option_symbols": (
+                        "NFO:NIFTY24JAN19500CE",
+                        "NFO:NIFTY24JAN19500PE",
+                    ),
+                    "option_expiry": "2024-01-04",
+                },
+            )
+        ]
+    )
+
+    with pytest.raises(LookupError, match="no contract basket"):
+        catalog.resolve(datetime(2024, 1, 2, 9, 29))
+    with pytest.raises(LookupError, match="expired"):
+        catalog.resolve(datetime(2024, 1, 5, 9, 30))
+
+    missing_expiry = HistoricalContractCatalog(
+        [
+            ReplayContractSnapshot(
+                datetime(2024, 1, 2, 9, 30),
+                {
+                    "selected_ce": "NFO:NIFTY24JAN19500CE",
+                    "selected_pe": "NFO:NIFTY24JAN19500PE",
+                    "option_symbols": (
+                        "NFO:NIFTY24JAN19500CE",
+                        "NFO:NIFTY24JAN19500PE",
+                    ),
+                },
+            )
+        ]
+    )
+    with pytest.raises(ValueError, match="requires option_expiry"):
+        missing_expiry.resolve(datetime(2024, 1, 2, 9, 30))


### PR DESCRIPTION
## What changed

- Add a time-indexed historical contract catalog for live-path replay.
- Resolve only baskets that were available at the replay timestamp, treating naïve timestamps as IST.
- Reject look-ahead, expired, missing-expiry, and out-of-basket option contracts.
- Rotate row-level option symbols and install the same historical basket into the runner and quote hub before evaluation.
- Pass the catalog through the independent parity harness while preserving existing fixed-symbol replay behavior.

## Scope

This is offline replay infrastructure only. It does not alter live contract selection, strategy thresholds, risk, order routing, or exits.

## Validation

- Complete `tests/backtest` and `tests/backtests` suites
- Full repository suite except one known timing-sensitive logging test, which passed independently; all remaining tests passed with one expected skip
- Ruff, Black, isolated mypy, compilation, and whitespace checks