### PR TITLE
Calibrate replay fills and report entry funnel

### DIFF
--- a/scripts/reporting/generate_daily_report.py
+++ b/scripts/reporting/generate_daily_report.py
@@ -70,6 +70,101 @@ def load_completed_trades(
     return list(outcomes.values())
 
 
+def load_entry_funnel(
+    db_path: Path,
+    *,
+    report_date: str,
+    timezone_name: str,
+) -> dict[str, int]:
+    """Load a date-scoped entry funnel from the existing trade journal."""
+
+    resolved = db_path.expanduser().resolve()
+    if not resolved.exists():
+        raise FileNotFoundError(f"Trade journal not found: {resolved}")
+    local_zone = ZoneInfo(timezone_name)
+    local_day = date.fromisoformat(report_date)
+    start = datetime.combine(local_day, time.min, tzinfo=local_zone)
+    end = start + timedelta(days=1)
+    decision_ids: set[str] = set()
+    selected_ids: set[str] = set()
+    blocked_ids: set[str] = set()
+    attempts: set[str] = set()
+    submitted: set[str] = set()
+    filled: set[str] = set()
+    broker_rejected: set[str] = set()
+    completed: set[str] = set()
+    candidate_total = 0
+    uri = f"{resolved.as_uri()}?mode=ro"
+    with sqlite3.connect(uri, uri=True) as connection:
+        columns = {
+            str(row[1]) for row in connection.execute("PRAGMA table_info(trade_events)")
+        }
+        order_expression = "order_id" if "order_id" in columns else "NULL"
+        rows = connection.execute(
+            f"""
+            SELECT id, event_type, {order_expression}, meta_json
+            FROM trade_events
+            WHERE timestamp >= ?
+              AND timestamp < ?
+            ORDER BY timestamp, id
+            """,
+            (start.timestamp(), end.timestamp()),
+        )
+        for event_id, event_type, order_id, meta_json in rows:
+            try:
+                meta = json.loads(meta_json or "{}")
+            except (TypeError, ValueError, json.JSONDecodeError):
+                meta = {}
+            if not isinstance(meta, Mapping):
+                meta = {}
+            event = str(event_type or "").strip().upper()
+            trace_id = str(meta.get("trace_id") or "").strip()
+            trade_id = str(meta.get("trade_id") or "").strip()
+            event_key = (
+                trace_id
+                or trade_id
+                or str(order_id or "").strip()
+                or f"event:{event_id}"
+            )
+            if event == "TRADE_DECISION":
+                decision_ids.add(event_key)
+                count = _number(meta.get("candidate_count"))
+                if count is not None and count > 0:
+                    candidate_total += int(count)
+                if meta.get("selected_candidate"):
+                    selected_ids.add(event_key)
+                if meta.get("order_submitted") is not True:
+                    blocked_ids.add(event_key)
+            elif event == "ORDER_SUBMIT_ATTEMPT":
+                attempts.add(event_key)
+            elif event == "ORDER_SUBMITTED":
+                submitted.add(str(order_id or event_key))
+            elif event == "ORDER_FILL_CONFIRMED":
+                filled.add(str(order_id or event_key))
+            elif event.startswith("ORDER_REJECTED"):
+                broker_rejected.add(event_key)
+            elif event == "BRACKET_CLOSED":
+                completed_trade = meta.get("completed_trade")
+                bracket_id = (
+                    str(completed_trade.get("bracket_id") or "").strip()
+                    if isinstance(completed_trade, Mapping)
+                    else ""
+                )
+                completed.add(bracket_id or event_key)
+    return {
+        "decision_events": len(decision_ids),
+        "candidate_count": candidate_total,
+        "selected_decisions": len(selected_ids),
+        "pre_order_blocked": len(blocked_ids),
+        "submit_attempts": len(attempts),
+        "orders_submitted": len(submitted),
+        "broker_rejected": len(broker_rejected),
+        "fill_confirmed": len(filled),
+        "submitted_without_fill_confirmation": len(submitted - filled),
+        "completed_trades": len(completed),
+    }
+
+
 def _number(value: Any) -> float | None:
     if isinstance(value, bool) or not isinstance(value, (int, float)):
         return None
@@ -238,6 +333,8 @@ def _exit_summary(measured: list[dict[str, Any]]) -> dict[str, Any]:
 
 def summarise_completed_trades(
     trades: list[dict[str, Any]],
+    *,
+    entry_funnel: Mapping[str, int] | None = None,
 ) -> dict[str, Any]:
     """Aggregate completed outcomes without converting incomplete trades to losses."""
 
@@ -348,7 +445,7 @@ def summarise_completed_trades(
 
     measured = _measured_trades(trades)
     score_buckets, score_coverage = _score_summary(measured)
-    return {
+    summary = {
         "groups": groups,
         "totals": {
             "closed_trades": len(trades),
@@ -363,6 +460,9 @@ def summarise_completed_trades(
         "execution_quality": _execution_summary(measured),
         "exit_quality": _exit_summary(measured),
     }
+    if entry_funnel is not None:
+        summary["entry_funnel"] = dict(entry_funnel)
+    return summary
 
 
 def _display(value: Any, *, suffix: str = "") -> str:
@@ -475,6 +575,33 @@ def _append_observational_sections(
         lines.append(
             f"| {safe_reason} | {int(reason.get('trades', 0))} | "
             f"{float(reason.get('net_pnl', 0.0)):+.2f} |"
+        )
+
+    funnel = summary.get("entry_funnel")
+    if isinstance(funnel, Mapping):
+        lines.extend(
+            [
+                "",
+                "## Entry Attempt Funnel (observational)",
+                "",
+                "| Stage | Count |",
+                "|---|---:|",
+                f"| Candidate decisions | {int(funnel.get('decision_events', 0))} |",
+                f"| Candidates evaluated | {int(funnel.get('candidate_count', 0))} |",
+                f"| Candidate selected | {int(funnel.get('selected_decisions', 0))} |",
+                "| Blocked before submission | "
+                f"{int(funnel.get('pre_order_blocked', 0))} |",
+                f"| Order submit attempts | {int(funnel.get('submit_attempts', 0))} |",
+                f"| Orders submitted | {int(funnel.get('orders_submitted', 0))} |",
+                f"| Broker rejected | {int(funnel.get('broker_rejected', 0))} |",
+                f"| Fill confirmed | {int(funnel.get('fill_confirmed', 0))} |",
+                "| Submitted without fill confirmation | "
+                f"{int(funnel.get('submitted_without_fill_confirmation', 0))} |",
+                f"| Completed trades | {int(funnel.get('completed_trades', 0))} |",
+                "",
+                "A missing fill confirmation is reported as missing coverage, "
+                "not assumed to be an unfilled or losing trade.",
+            ]
         )
 
 
@@ -798,7 +925,12 @@ def main(argv: list[str] | None = None) -> int:
                 report_date=local_day,
                 timezone_name=args.timezone,
             )
-            summary = summarise_completed_trades(trades)
+            funnel = load_entry_funnel(
+                args.trades_db,
+                report_date=local_day,
+                timezone_name=args.timezone,
+            )
+            summary = summarise_completed_trades(trades, entry_funnel=funnel)
             report = build_trade_outcome_report(
                 summary,
                 report_date=local_day,
@@ -826,6 +958,7 @@ __all__ = [
     "build_daily_report",
     "build_trade_outcome_report",
     "load_completed_trades",
+    "load_entry_funnel",
     "load_summary",
     "main",
     "summarise_completed_trades",

--- a/src/nifty_scalper_bot/backtest/replay.py
+++ b/src/nifty_scalper_bot/backtest/replay.py
@@ -31,6 +31,7 @@ class ReplayResult:
     end: datetime | None
     trades: list[dict[str, Any]]
     orders: list[dict[str, Any]]
+    fill_calibration: Mapping[str, float | int | None] | None = None
 
     def format_summary(self) -> str:
         """Return a human-readable summary suitable for Telegram."""
@@ -100,6 +101,7 @@ class ReplayHarness:
         index_symbol: str | None = None,
         clock: ReplayClock | None = None,
         contract_catalog: HistoricalContractCatalog | None = None,
+        calibration_outcomes: Sequence[Mapping[str, Any]] | None = None,
     ) -> None:
         self._runner = runner
         self._paper = paper_engine
@@ -108,6 +110,10 @@ class ReplayHarness:
         self._clock = clock
         self._contract_catalog = contract_catalog
         self._active_basket_key: tuple[Any, ...] | None = None
+        self._fill_calibration = None
+        calibrate = getattr(paper_engine, "calibrate_from_completed_trades", None)
+        if calibration_outcomes is not None and callable(calibrate):
+            self._fill_calibration = calibrate(list(calibration_outcomes))
         clock_time = getattr(clock, "time", None)
         set_clock = getattr(paper_engine, "set_clock", None)
         if callable(clock_time) and callable(set_clock):
@@ -117,7 +123,9 @@ class ReplayHarness:
         """Replay the provided dataframe and return a :class:`ReplayResult`."""
 
         if data.empty:
-            return ReplayResult(0, None, None, [], [])
+            return ReplayResult(
+                0, None, None, [], [], fill_calibration=self._fill_calibration
+            )
         frame = data.copy()
         if not isinstance(frame.index, pd.DatetimeIndex):
             frame.index = pd.to_datetime(frame.index)
@@ -144,7 +152,14 @@ class ReplayHarness:
             bars += 1
         trades = _collect_trade_history(self._runner)
         orders = self._paper.get_orders() if hasattr(self._paper, "get_orders") else []
-        return ReplayResult(bars, start_ts, end_ts, trades, orders)
+        return ReplayResult(
+            bars,
+            start_ts,
+            end_ts,
+            trades,
+            orders,
+            fill_calibration=self._fill_calibration,
+        )
 
     def run_file(self, path: Path) -> ReplayResult:
         """Load ``path`` as CSV/Parquet and run :meth:`run_dataframe`."""
@@ -168,6 +183,9 @@ class ReplayHarness:
             "trace_id": f"replay:{tick['timestamp'].isoformat()}:{symbol}",
         }
         self._publish_quote(symbol, payload)
+        process_quote = getattr(self._paper, "process_quote", None)
+        if callable(process_quote):
+            process_quote(symbol)
         self._dispatch_tick(symbol, payload)
 
     def _publish_quote(self, symbol: str, tick: Mapping[str, Any]) -> None:
@@ -240,10 +258,23 @@ def _build_tick(row: pd.Series, timestamp: datetime, *, prefix: str) -> dict[str
         "volume": _pick("volume"),
         "oi": _pick("oi"),
     }
-    for name in ("bid", "ask", "instrument_token"):
+    for name in (
+        "bid",
+        "ask",
+        "bid_quantity",
+        "ask_quantity",
+        "instrument_token",
+        "replay_reject_reason",
+        "tradable_quote",
+    ):
         value = row.get(f"{prefix}{name}")
         if value is not None and not pd.isna(value):
-            tick[name] = float(value) if name != "instrument_token" else int(value)
+            if name == "instrument_token":
+                tick[name] = int(value)
+            elif name in {"replay_reject_reason", "tradable_quote"}:
+                tick[name] = value
+            else:
+                tick[name] = float(value)
     return tick
 
 

--- a/src/nifty_scalper_bot/execution/order_manager_core.py
+++ b/src/nifty_scalper_bot/execution/order_manager_core.py
@@ -1194,6 +1194,26 @@ class OrderManager:
         except Exception as exc:  # noqa: BLE001
             self._logger.error("Failure in _log_trade_event: %s", exc)
 
+    def record_trade_decision(
+        self,
+        snapshot: Mapping[str, object],
+        *,
+        trace_id: str | None = None,
+    ) -> None:
+        """Persist one runner decision in the existing trade journal."""
+
+        payload = dict(snapshot)
+        if trace_id:
+            payload["trace_id"] = trace_id
+        self._log_trade_event(
+            "TRADE_DECISION",
+            symbol=str(payload.get("symbol") or ""),
+            side=str(payload.get("direction") or ""),
+            qty=0,
+            price=0.0,
+            meta=payload,
+        )
+
     def _ensure_quote_refresh(
         self,
         mdm: "MarketDataManager",

--- a/src/nifty_scalper_bot/execution/paper_fill_engine.py
+++ b/src/nifty_scalper_bot/execution/paper_fill_engine.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import math
 import os
+import statistics
 import time
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -36,6 +38,10 @@ class _QuoteMetrics:
     mid: float
     spread: float
     momentum: float
+    bid_quantity: int | None
+    ask_quantity: int | None
+    reject_reason: str | None
+    tradable: bool | None
 
 
 class PaperFillEngine:
@@ -53,6 +59,8 @@ class PaperFillEngine:
             os.getenv("PAPER__RESPECT_LOTSIZE", "true")
         )
         self._slip_bps = max(0.0, _safe_float(os.getenv("PAPER__SLIPPAGE_BPS"), 0.0))
+        self._calibrated_slippage_bps: float | None = None
+        self._calibrated_fill_latency_s: float | None = None
         self._slippage_model = SlippageModel()
 
     # ------------------------------------------------------------------
@@ -60,6 +68,53 @@ class PaperFillEngine:
         """Use a caller-owned clock for deterministic paper-order timestamps."""
 
         self._clock = clock
+
+    def calibrate_from_completed_trades(
+        self, outcomes: list[Mapping[str, Any]]
+    ) -> dict[str, float | int | None]:
+        """Calibrate replay drag from measured completed-trade telemetry."""
+
+        slippage: list[float] = []
+        latency: list[float] = []
+        for outcome in outcomes:
+            quality = outcome.get("execution_quality")
+            if not isinstance(quality, Mapping):
+                continue
+            for key in ("entry_slippage_bps", "exit_slippage_bps"):
+                value = _finite_non_negative(quality.get(key))
+                if value is not None:
+                    slippage.append(value)
+            for key in (
+                "entry_submit_to_fill_seconds",
+                "exit_submit_to_fill_seconds",
+            ):
+                value = _finite_non_negative(quality.get(key))
+                if value is not None:
+                    latency.append(value)
+        self._calibrated_slippage_bps = (
+            float(statistics.median(slippage)) if slippage else None
+        )
+        self._calibrated_fill_latency_s = (
+            float(statistics.median(latency)) if latency else None
+        )
+        return {
+            "slippage_samples": len(slippage),
+            "latency_samples": len(latency),
+            "slippage_bps_p50": self._calibrated_slippage_bps,
+            "fill_latency_seconds_p50": self._calibrated_fill_latency_s,
+        }
+
+    def process_quote(self, symbol: str) -> None:
+        """Advance open orders for ``symbol`` against the latest quote."""
+
+        normalized = DataHub.normalize(symbol)
+        metrics = self._quote_metrics(
+            self.hub.get_quote(normalized, allow_pull=False) or {}
+        )
+        for order in self.orders.values():
+            if order.get("symbol") != normalized or order.get("status") != "open":
+                continue
+            self._apply_fill(order, metrics)
 
     def place_order(self, payload: dict[str, Any]) -> dict[str, Any]:
         """Simulate order placement returning a broker-like response."""
@@ -184,6 +239,28 @@ class PaperFillEngine:
         if quantity <= 0:
             order.update({"status": "rejected", "message": "Quantity must be positive"})
             return
+        if metrics.reject_reason:
+            order.update(
+                {
+                    "status": "rejected",
+                    "message": metrics.reject_reason,
+                    "remaining_quantity": max(
+                        quantity - int(order.get("filled_quantity", 0)), 0
+                    ),
+                }
+            )
+            return
+        if metrics.tradable is False:
+            order.update(
+                {
+                    "status": "rejected",
+                    "message": "historical_quote_not_tradable",
+                    "remaining_quantity": max(
+                        quantity - int(order.get("filled_quantity", 0)), 0
+                    ),
+                }
+            )
+            return
 
         if order_type == "MARKET":
             self._fill_market(order, metrics)
@@ -238,18 +315,53 @@ class PaperFillEngine:
     def _fill_market(self, order: dict[str, Any], metrics: _QuoteMetrics) -> None:
         side = str(order.get("transaction_type") or "").upper()
         quantity = int(order.get("quantity") or 0)
+        if not _valid_market_quote(metrics):
+            order.update(
+                {
+                    "status": "rejected",
+                    "message": "market_quote_unavailable",
+                    "remaining_quantity": max(
+                        quantity - int(order.get("filled_quantity", 0)), 0
+                    ),
+                }
+            )
+            return
+        previous_fill = int(order.get("filled_quantity", 0))
+        remaining = max(quantity - previous_fill, 0)
+        if remaining <= 0:
+            order["status"] = "complete"
+            order["remaining_quantity"] = 0
+            return
+        best_quantity = metrics.ask_quantity if side == "BUY" else metrics.bid_quantity
+        fill_quantity = (
+            remaining
+            if best_quantity is None
+            else min(remaining, max(best_quantity, 0))
+        )
+        if fill_quantity <= 0:
+            order["status"] = "open"
+            order["remaining_quantity"] = remaining
+            return
         base_price = metrics.mid or metrics.ltp
         if base_price <= 0:
             base_price = metrics.bid if side == "BUY" else metrics.ask
-        spread_component = metrics.spread * (1.0 + abs(metrics.momentum))
-        slip_component = self._slip_bps / 10000.0 * base_price
-        model_adjustment = self._slippage_model.estimate(
-            symbol=str(order.get("symbol") or ""),
-            side=side,
-            quantity=quantity,
-            base_price=base_price,
-        )
-        total_adjustment = max(spread_component, slip_component) + abs(model_adjustment)
+        if self._calibrated_slippage_bps is not None:
+            total_adjustment = max(
+                metrics.spread / 2.0,
+                self._calibrated_slippage_bps / 10000.0 * base_price,
+            )
+        else:
+            spread_component = metrics.spread * (1.0 + abs(metrics.momentum))
+            slip_component = self._slip_bps / 10000.0 * base_price
+            model_adjustment = self._slippage_model.estimate(
+                symbol=str(order.get("symbol") or ""),
+                side=side,
+                quantity=fill_quantity,
+                base_price=base_price,
+            )
+            total_adjustment = max(spread_component, slip_component) + abs(
+                model_adjustment
+            )
         LOGGER.debug(
             "paper_fill_market_slippage",
             extra={
@@ -265,10 +377,18 @@ class PaperFillEngine:
             fill_price = base_price + total_adjustment
         else:
             fill_price = max(0.05, base_price - total_adjustment)
-        order["filled_quantity"] = quantity
-        order["average_price"] = fill_price
-        order["remaining_quantity"] = 0
-        order["status"] = "complete"
+        new_total = previous_fill + fill_quantity
+        previous_average = _safe_float(order.get("average_price"), fill_price)
+        order["average_price"] = (
+            previous_average * previous_fill + fill_price * fill_quantity
+        ) / new_total
+        order["filled_quantity"] = new_total
+        order["remaining_quantity"] = max(quantity - new_total, 0)
+        order["status"] = "complete" if new_total >= quantity else "open"
+        latency = self._calibrated_fill_latency_s or 0.0
+        order.setdefault("first_fill_timestamp", self._clock() + latency)
+        order["last_fill_timestamp"] = self._clock() + latency
+        order["fill_latency_seconds"] = latency
 
     # Helpers ------------------------------------------------------------
     def _next_id(self) -> str:
@@ -357,9 +477,59 @@ class PaperFillEngine:
         momentum = 0.0
         if close > 0:
             momentum = (ltp - close) / close
-        return _QuoteMetrics(
-            ltp=ltp, bid=bid, ask=ask, mid=mid, spread=spread, momentum=momentum
+        reject_reason_raw = quote.get("replay_reject_reason")
+        reject_reason = (
+            str(reject_reason_raw).strip() if reject_reason_raw is not None else ""
         )
+        tradable_raw = quote.get("tradable_quote")
+        tradable = self._coerce_bool(tradable_raw) if tradable_raw is not None else None
+        return _QuoteMetrics(
+            ltp=ltp,
+            bid=bid,
+            ask=ask,
+            mid=mid,
+            spread=spread,
+            momentum=momentum,
+            bid_quantity=_quote_quantity(quote, "bid"),
+            ask_quantity=_quote_quantity(quote, "ask"),
+            reject_reason=reject_reason or None,
+            tradable=tradable,
+        )
+
+
+def _finite_non_negative(value: object) -> float | None:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    resolved = float(value)
+    if not math.isfinite(resolved) or resolved < 0:
+        return None
+    return resolved
+
+
+def _quote_quantity(quote: Mapping[str, Any], side: str) -> int | None:
+    keys = (
+        f"{side}_quantity",
+        f"best_{side}_quantity",
+        f"{side}_qty",
+        f"best_{side}_qty",
+    )
+    for key in keys:
+        if key in quote:
+            return PaperFillEngine._coerce_int(quote.get(key))
+    depth = quote.get("depth")
+    if isinstance(depth, Mapping):
+        book_side = "buy" if side == "bid" else "sell"
+        levels = depth.get(book_side)
+        if isinstance(levels, list) and levels and isinstance(levels[0], Mapping):
+            if "quantity" in levels[0]:
+                return PaperFillEngine._coerce_int(levels[0].get("quantity"))
+    return None
+
+
+def _valid_market_quote(metrics: _QuoteMetrics) -> bool:
+    if metrics.bid > 0 and metrics.ask > 0:
+        return metrics.ask > metrics.bid
+    return metrics.ltp > 0 or metrics.bid > 0 or metrics.ask > 0
 
 
 __all__ = ["PaperFillEngine", "SlippageModel"]

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -4662,8 +4662,9 @@ class StrategyRunner:
         strategy_allowed: bool | None = None,
         risk_allowed: bool | None = None,
         order_submitted: bool = False,
+        trace_id: str | None = None,
     ) -> None:
-        """Update the diagnostic-only latest trade decision snapshot."""
+        """Update diagnostics and persist the decision in the existing journal."""
         try:
             snapshot = TradeDecisionSnapshot(
                 timestamp=datetime.now(timezone.utc).isoformat(),
@@ -4680,6 +4681,9 @@ class StrategyRunner:
             )
             self._last_trade_decision = snapshot
             globals()["LAST_TRADE_DECISION_SNAPSHOT"] = snapshot
+            recorder = getattr(self._order_manager, "record_trade_decision", None)
+            if callable(recorder):
+                recorder(dataclasses.asdict(snapshot), trace_id=trace_id)
         except Exception as exc:  # noqa: BLE001 - diagnostics must never block trading
             self._logger.debug(
                 "TRADE_DECISION_SNAPSHOT_UPDATE_FAILED error_type=%s",
@@ -4738,6 +4742,7 @@ class StrategyRunner:
             strategy_allowed=False,
             risk_allowed=None,
             order_submitted=False,
+            trace_id=trace_id,
         )
         if reason == "candidate_refresh_pending" and not bool(
             payload.get("event_loop_active", False)
@@ -20210,6 +20215,7 @@ class StrategyRunner:
                     strategy_allowed=True,
                     risk_allowed=True,
                     order_submitted=True,
+                    trace_id=trace_id,
                 )
                 return SignalExecutionResult(
                     True,
@@ -20324,6 +20330,7 @@ class StrategyRunner:
                     strategy_allowed=True,
                     risk_allowed=False,
                     order_submitted=False,
+                    trace_id=trace_id,
                 )
                 return SignalExecutionResult(
                     False, submit_reason, details=submit_details

--- a/tests/backtest/test_replay.py
+++ b/tests/backtest/test_replay.py
@@ -150,6 +150,143 @@ def test_replay_advances_clock_once_per_synchronised_timestamp() -> None:
     assert order["timestamp"] == frame.index[-1].to_pydatetime().timestamp()
 
 
+def test_replay_market_order_consumes_historical_depth_across_ticks() -> None:
+    hub = _DummyDataHub()
+    paper = PaperFillEngine(hub, _DummyResolver())
+
+    class _OrderRunner(_DummyRunner):
+        def __init__(self) -> None:
+            super().__init__()
+            self.order: dict[str, object] | None = None
+
+        def on_tick_event(self, tick: dict[str, float]) -> None:
+            super().on_tick_event(tick)
+            if tick["symbol"] == "OPT" and self.order is None:
+                self.order = paper.place_order(
+                    {
+                        "symbol": "OPT",
+                        "transaction_type": "BUY",
+                        "quantity": 10,
+                        "order_type": "MARKET",
+                    }
+                )
+
+    runner = _OrderRunner()
+    frame = _sample_frame().iloc[:2].copy()
+    frame["option_ask_quantity"] = [4, 6]
+    frame["option_bid_quantity"] = [10, 10]
+
+    result = ReplayHarness(runner, paper, option_symbol="OPT").run_dataframe(frame)
+
+    assert runner.order is not None
+    order = result.orders[0]
+    assert order["status"] == "complete"
+    assert order["filled_quantity"] == 10
+    assert order["remaining_quantity"] == 0
+    assert order["first_fill_timestamp"] < order["last_fill_timestamp"]
+
+
+def test_paper_market_fill_fails_closed_without_a_usable_quote() -> None:
+    hub = _DummyDataHub()
+    hub.quotes["NSE:OPT"] = {"ltp": 0.0}
+    paper = PaperFillEngine(hub, _DummyResolver())
+
+    order = paper.place_order(
+        {
+            "symbol": "OPT",
+            "transaction_type": "BUY",
+            "quantity": 10,
+            "order_type": "MARKET",
+        }
+    )
+
+    assert order["status"] == "rejected"
+    assert order["message"] == "market_quote_unavailable"
+    assert order["filled_quantity"] == 0
+
+
+def test_paper_market_fill_respects_historical_rejection_marker() -> None:
+    hub = _DummyDataHub()
+    hub.quotes["NSE:OPT"] = {
+        "ltp": 100.0,
+        "bid": 99.9,
+        "ask": 100.1,
+        "replay_reject_reason": "historical_exchange_reject",
+    }
+    order = PaperFillEngine(hub, _DummyResolver()).place_order(
+        {
+            "symbol": "OPT",
+            "transaction_type": "BUY",
+            "quantity": 10,
+            "order_type": "MARKET",
+        }
+    )
+
+    assert order["status"] == "rejected"
+    assert order["message"] == "historical_exchange_reject"
+
+
+def test_paper_fill_uses_measured_execution_calibration() -> None:
+    hub = _DummyDataHub()
+    hub.quotes["NSE:OPT"] = {"ltp": 100.0, "bid": 99.9, "ask": 100.1}
+    paper = PaperFillEngine(hub, _DummyResolver())
+    now = 1_000.0
+    paper.set_clock(lambda: now)
+
+    calibration = paper.calibrate_from_completed_trades(
+        [
+            {
+                "execution_quality": {
+                    "entry_slippage_bps": 8.0,
+                    "exit_slippage_bps": 12.0,
+                    "entry_submit_to_fill_seconds": 0.4,
+                    "exit_submit_to_fill_seconds": 0.8,
+                }
+            }
+        ]
+    )
+    order = paper.place_order(
+        {
+            "symbol": "OPT",
+            "transaction_type": "BUY",
+            "quantity": 10,
+            "order_type": "MARKET",
+        }
+    )
+
+    assert calibration["slippage_bps_p50"] == 10.0
+    assert calibration["fill_latency_seconds_p50"] == pytest.approx(0.6)
+    assert order["average_price"] == pytest.approx(100.1)
+    assert order["fill_latency_seconds"] == pytest.approx(0.6)
+    assert order["first_fill_timestamp"] == pytest.approx(1_000.6)
+
+
+def test_replay_harness_applies_completed_outcome_fill_calibration() -> None:
+    paper = PaperFillEngine(_DummyDataHub(), _DummyResolver())
+    result = ReplayHarness(
+        _DummyRunner(),
+        paper,
+        option_symbol="OPT",
+        calibration_outcomes=[
+            {
+                "execution_quality": {
+                    "entry_slippage_bps": 4.0,
+                    "exit_slippage_bps": 8.0,
+                    "entry_submit_to_fill_seconds": 0.2,
+                    "exit_submit_to_fill_seconds": 0.6,
+                }
+            }
+        ],
+    ).run_dataframe(_sample_frame().iloc[:1])
+
+    assert result.fill_calibration == {
+        "slippage_samples": 2,
+        "latency_samples": 2,
+        "slippage_bps_p50": 6.0,
+        "fill_latency_seconds_p50": pytest.approx(0.4),
+    }
+
+
 def test_replay_rotates_only_time_available_historical_contracts() -> None:
     timestamps = pd.date_range(datetime(2024, 1, 1, 9, 30), periods=2, freq="T")
     frame = _sample_frame().iloc[:2].copy()

--- a/tests/backtests/test_replay_parity.py
+++ b/tests/backtests/test_replay_parity.py
@@ -561,3 +561,88 @@ def test_daily_report_trade_db_cli_writes_date_scoped_report(tmp_path: Path) -> 
     assert exit_code == 0
     assert output_path.exists()
     assert "Closed trades: **0**" in output_path.read_text(encoding="utf-8")
+
+
+def test_daily_report_builds_entry_attempt_funnel_without_assuming_fills(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "trades.db"
+    timestamp = datetime.fromisoformat("2026-07-31T04:00:00+00:00").timestamp()
+    with sqlite3.connect(db_path) as connection:
+        connection.execute("""
+            CREATE TABLE trade_events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                timestamp REAL NOT NULL,
+                event_type TEXT NOT NULL,
+                order_id TEXT,
+                meta_json TEXT
+            )
+            """)
+        events = [
+            (
+                "TRADE_DECISION",
+                None,
+                {
+                    "trace_id": "blocked",
+                    "candidate_count": 3,
+                    "selected_candidate": None,
+                    "order_submitted": False,
+                },
+            ),
+            (
+                "TRADE_DECISION",
+                None,
+                {
+                    "trace_id": "accepted",
+                    "candidate_count": 2,
+                    "selected_candidate": "NFO:NIFTYCE",
+                    "order_submitted": True,
+                },
+            ),
+            ("ORDER_SUBMIT_ATTEMPT", None, {"trade_id": "trade-1"}),
+            ("ORDER_SUBMITTED", "order-1", {"trade_id": "trade-1"}),
+            ("ORDER_FILL_CONFIRMED", "order-1", {"trade_id": "trade-1"}),
+            ("ORDER_SUBMIT_ATTEMPT", None, {"trade_id": "trade-2"}),
+            ("ORDER_SUBMITTED", "order-2", {"trade_id": "trade-2"}),
+            ("ORDER_REJECTED_FATAL", None, {"trade_id": "trade-3"}),
+        ]
+        connection.executemany(
+            """
+            INSERT INTO trade_events (timestamp, event_type, order_id, meta_json)
+            VALUES (?, ?, ?, ?)
+            """,
+            [
+                (timestamp, event, order_id, json.dumps(meta))
+                for event, order_id, meta in events
+            ],
+        )
+
+    module = _load_daily_report_module()
+    funnel = module.load_entry_funnel(
+        db_path,
+        report_date="2026-07-31",
+        timezone_name="Asia/Kolkata",
+    )
+    summary = module.summarise_completed_trades([], entry_funnel=funnel)
+    report = module.build_trade_outcome_report(
+        summary,
+        report_date="2026-07-31",
+        timezone_name="Asia/Kolkata",
+    )
+
+    assert funnel == {
+        "decision_events": 2,
+        "candidate_count": 5,
+        "selected_decisions": 1,
+        "pre_order_blocked": 1,
+        "submit_attempts": 2,
+        "orders_submitted": 2,
+        "broker_rejected": 1,
+        "fill_confirmed": 1,
+        "submitted_without_fill_confirmation": 1,
+        "completed_trades": 0,
+    }
+    assert "## Entry Attempt Funnel (observational)" in report
+    assert "| Candidates evaluated | 5 |" in report
+    assert "| Submitted without fill confirmation | 1 |" in report
+    assert "not assumed to be an unfilled or losing trade" in report

--- a/tests/strategies/test_order_rejected_observability.py
+++ b/tests/strategies/test_order_rejected_observability.py
@@ -13,6 +13,7 @@ in scope at the emit site; they were simply discarded.
 from __future__ import annotations
 
 import inspect
+from types import SimpleNamespace
 
 from nifty_scalper_bot.strategies.runner import StrategyRunner
 
@@ -61,3 +62,34 @@ def test_order_rejected_still_identifies_both_symbols() -> None:
     region = _emit_region()
     assert '"symbol": base_symbol' in region
     assert '"order_symbol": order_symbol' in region
+
+
+def test_trade_decision_snapshot_is_persisted_to_existing_journal() -> None:
+    captured: list[tuple[dict[str, object], str | None]] = []
+    runner = SimpleNamespace(
+        _runtime_live_orders_armed=True,
+        _last_trade_decision=None,
+        _order_manager=SimpleNamespace(
+            record_trade_decision=lambda snapshot, trace_id=None: captured.append(
+                (snapshot, trace_id)
+            )
+        ),
+        _logger=SimpleNamespace(debug=lambda *_args, **_kwargs: None),
+    )
+
+    StrategyRunner._record_trade_decision_snapshot(
+        runner,
+        symbol="NFO:NIFTYCE",
+        direction="CE",
+        final_reason="order_submitted",
+        candidate_count=2,
+        selected_candidate="NFO:NIFTYCE",
+        strategy_allowed=True,
+        risk_allowed=True,
+        order_submitted=True,
+        trace_id="trace-1",
+    )
+
+    assert captured[0][0]["candidate_count"] == 2
+    assert captured[0][0]["order_submitted"] is True
+    assert captured[0][1] == "trace-1"


### PR DESCRIPTION
## What changed
- fail closed on unusable paper/replay market quotes
- consume historical best-level depth across ticks for partial and unfilled orders
- support explicit historical rejection markers
- calibrate replay adverse slippage and fill-latency telemetry from completed outcomes
- persist runner trade decisions in the existing trade journal
- add a date-scoped entry-attempt funnel to the existing daily outcome report

## Why
Historical contract availability is now time-safe, but replay fills still assumed immediate full execution and the daily report could not quantify where opportunities were blocked or lost before completion.

## Safety
Live strategy thresholds, risk gates, broker execution, and exits are unchanged. Missing fill confirmation is reported as missing coverage, not classified as an unfilled or losing trade.

## Validation
- focused replay, backtest, execution, strategy and reporting suites passed
- complete execution/strategy/backtest suites passed
- full repository suite passed with one expected skip
- compileall, Ruff, Black, mypy and whitespace checks passed