### PR TITLE
Decouple protective exits from tick ingestion

### DIFF
--- a/src/nifty_scalper_bot/execution/bracket_core.py
+++ b/src/nifty_scalper_bot/execution/bracket_core.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 from collections import deque
 import hashlib
 from contextlib import suppress
+from queue import Queue
 import threading
 from threading import RLock
 import time
@@ -556,6 +557,16 @@ class BracketManager:
         self._throttle_log_at: Dict[str, float] = {}
         self._lock = _RLOCK_CLASS()
         self._reconcile_lock = threading.Lock()
+        self._exit_dispatch_scheduled: set[str] = set()
+        self._exit_dispatch_queue: Queue[
+            tuple[BracketState, Mapping[str, Any]] | None
+        ] = Queue()
+        self._exit_dispatch_thread = threading.Thread(
+            target=self._exit_dispatch_loop,
+            name="bracket-exit",
+            daemon=True,
+        )
+        self._exit_dispatch_thread.start()
         self._running = True
         self._persistence_degraded_reason: str | None = None
         self._recovery_degraded_reason: str | None = None
@@ -972,6 +983,7 @@ class BracketManager:
     def shutdown(self) -> None:
         """Stop watchdog processing. Args: none; Returns: none; Raises: none."""
         self._running = False
+        self._exit_dispatch_queue.put(None)
 
     # --------------------------------------------------------------------------
     # 1. CORE API (Backward Compatible & Enhanced)
@@ -1661,7 +1673,12 @@ class BracketManager:
     # --------------------------------------------------------------------------
 
     def on_tick(
-        self, symbol: str, ltp: float, exchange_ts: float | None = None
+        self,
+        symbol: str,
+        ltp: float,
+        exchange_ts: float | None = None,
+        *,
+        defer_submission: bool = False,
     ) -> None:
         """Process one tick through trailing and hard SL/TP evaluation.
 
@@ -1672,6 +1689,8 @@ class BracketManager:
                 provided, ticks older than a freshly activated bracket's fill
                 time are not evaluated against it — a replayed pre-fill signal
                 tick must not trigger an immediate false exit right after entry.
+            defer_submission: Latch the trigger synchronously, then dispatch
+                broker submission on the dedicated single-worker exit path.
         """
         symbol = normalize_symbol(symbol)
         # ═══════════════════════════════════════════════════════════
@@ -1835,7 +1854,10 @@ class BracketManager:
         # FIRE EXITS: Batch processing (takes lock once)
         # ═══════════════════════════════════════════════════════════
         if exits_to_fire:
-            self._fire_exits_batch(exits_to_fire)
+            self._fire_exits_batch(
+                exits_to_fire,
+                defer_submission=defer_submission,
+            )
 
     def process_exit_checks(self, symbol: str, ltp: float) -> None:
         """Route tick to the single on-tick exit authority. Args: symbol, ltp; Returns: None; Raises: None."""
@@ -1988,13 +2010,20 @@ class BracketManager:
 
         return None
 
-    def _fire_exits_batch(self, exits: list) -> None:
+    def _fire_exits_batch(
+        self,
+        exits: list,
+        *,
+        defer_submission: bool = False,
+    ) -> None:
         """Latch exit triggers and submit at most one controlled exit order per bracket."""
         now = time.time()
         approved: list[tuple[BracketState, dict[str, Any]]] = []
 
         with self._lock:
             for bracket, action in exits:
+                if bracket.bracket_id in self._exit_dispatch_scheduled:
+                    continue
                 if not self._exit_can_submit_or_reconcile_locked(bracket, now):
                     LOGGER.info(
                         "BRACKET_EXIT_SKIPPED_DUPLICATE bracket_id=%s symbol=%s exit_state=%s pending_exit_order_id=%s",
@@ -2106,9 +2135,35 @@ class BracketManager:
                     )
 
                 approved.append((bracket, action))
+                if defer_submission:
+                    self._exit_dispatch_scheduled.add(bracket.bracket_id)
 
         for bracket, action in approved:
-            self._process_exit_state(bracket, action, now=time.time())
+            if not defer_submission:
+                self._process_exit_state(bracket, action, now=time.time())
+                continue
+            self._exit_dispatch_queue.put((bracket, action))
+
+    def _exit_dispatch_loop(self) -> None:
+        """Persist and submit latched exits serially outside tick ingestion."""
+        while True:
+            item = self._exit_dispatch_queue.get()
+            try:
+                if item is None:
+                    return
+                bracket, action = item
+                try:
+                    self.save_state()
+                except Exception as exc:  # noqa: BLE001 - exits remain mandatory
+                    self._mark_persistence_degraded("exit_trigger_persist_failed", exc)
+                self._process_exit_state(bracket, action, now=time.time())
+            finally:
+                if item is not None:
+                    with self._lock:
+                        self._exit_dispatch_scheduled.discard(
+                            item[0].bracket_id
+                        )
+                self._exit_dispatch_queue.task_done()
 
     def _exit_can_submit_or_reconcile_locked(
         self, bracket: BracketState, now: float

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -8132,7 +8132,8 @@ class StrategyRunner:
         This runs synchronously on the ingestion path and is NEVER routed to
         the entry-evaluation worker. Extracted mechanically from _on_tick:
         stop/target/trailing rules, exit quantity, exit idempotency, bracket
-        transitions, broker calls and exception semantics are all unchanged.
+        transitions and exception semantics are unchanged; broker submission
+        runs on the bracket manager's single-worker exit dispatcher.
         Args: symbol, tick. Returns: none. Raises: none.
         """
         if self._bracket_manager:
@@ -8143,7 +8144,10 @@ class StrategyRunner:
                 _ltp = float(_ltp_raw)
                 if _ltp > 0:
                     self._bracket_manager.on_tick(
-                        symbol, _ltp, tick_exchange_epoch(tick)
+                        symbol,
+                        _ltp,
+                        tick_exchange_epoch(tick),
+                        defer_submission=True,
                     )
                     tick_err_map = getattr(
                         self._bracket_manager, "_tick_error_logged", None

--- a/tests/execution/test_bracket_exit_state_machine.py
+++ b/tests/execution/test_bracket_exit_state_machine.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import threading
 import time
 from typing import Any
 
@@ -102,6 +103,51 @@ def test_first_sl_breach_latches_and_submits_once(caplog) -> None:
     assert len(om.calls) == 1
     assert om.calls[0]["side"] == "SELL"
     assert caplog.text.count("EXIT_TRIGGERED") == 1
+
+
+def test_deferred_exit_latches_without_waiting_for_broker() -> None:
+    broker_started = threading.Event()
+    release_broker = threading.Event()
+
+    class _SlowOrderManager(_OrderManager):
+        def place_order(self, **kwargs: Any) -> str | None:
+            self.calls.append(kwargs)
+            broker_started.set()
+            assert release_broker.wait(timeout=2.0)
+            return self.order_id
+
+    om = _SlowOrderManager(broker=_Broker(status="OPEN"), order_id="exit-1")
+    manager = _active_manager(om)
+
+    started = time.monotonic()
+    manager.on_tick(
+        "NFO:NIFTY2660923100CE",
+        157.10,
+        defer_submission=True,
+    )
+    elapsed = time.monotonic() - started
+
+    bracket = manager.get_bracket("entry-1")
+    assert bracket is not None
+    assert elapsed < 0.1
+    assert bracket.exit_pending is True
+    assert bracket.exit_state == BracketExitLifecycle.EXIT_TRIGGERED.value
+    assert broker_started.wait(timeout=1.0)
+
+    # A concurrent watchdog/tick trigger must not submit a second exit.
+    manager.on_tick(
+        "NFO:NIFTY2660923100CE",
+        156.90,
+        defer_submission=True,
+    )
+    release_broker.set()
+    deadline = time.monotonic() + 1.0
+    while bracket.exit_state != BracketExitLifecycle.EXIT_ORDER_SUBMITTED.value:
+        assert time.monotonic() < deadline
+        time.sleep(0.01)
+
+    assert bracket.exit_order_id == "exit-1"
+    assert len(om.calls) == 1
 
 
 def test_exit_fill_closes_bracket_and_unfreezes_entries() -> None:

--- a/tests/strategies/test_entry_eval_coalescing.py
+++ b/tests/strategies/test_entry_eval_coalescing.py
@@ -344,9 +344,11 @@ def test_position_tick_protection_not_executed_twice(monkeypatch):
     runner_obj, _strategy_manager, _risk, _order, _selected_ce = _underlying_runner(
         monkeypatch
     )
-    bracket_ticks: list[tuple[str, float]] = []
+    bracket_ticks: list[tuple[str, float, bool]] = []
     runner_obj._bracket_manager = SimpleNamespace(
-        on_tick=lambda sym, ltp, ts: bracket_ticks.append((sym, ltp))
+        on_tick=lambda sym, ltp, ts, **kwargs: bracket_ticks.append(
+            (sym, ltp, kwargs.get("defer_submission") is True)
+        )
     )
 
     loop, thread = _run_loop_in_thread()
@@ -368,6 +370,7 @@ def test_position_tick_protection_not_executed_twice(monkeypatch):
         time.sleep(0.05)
         assert len(bracket_ticks) == 1
         assert bracket_ticks[0][0] == UNDERLYING_SYMBOL
+        assert bracket_ticks[0][2] is True
     finally:
         _stop_loop(loop, thread)
 


### PR DESCRIPTION
## Root cause
Protective SL/TP ticks called broker reconciliation, order submission, fill polling, persistence, and callbacks synchronously on the market-data ingestion path. A slow broker call therefore blocked all tick processing.

## Change
- Keep SL/TP evaluation and the exit-trigger latch synchronous.
- Dispatch the persisted broker workflow through one daemon exit worker.
- Deduplicate scheduled exits so tick/watchdog races cannot submit twice.
- Preserve synchronous behavior for direct/EOD callers; only the live runner requests deferred submission.

## Validation
- Focused blocked-broker latency/idempotency regression passes.
- Adjacent execution reconciliation, live-exit, and runner coalescing suites pass.
- Execution/risk/strategy suite passes.
- `python -m compileall -q src` passes.
- Complete repository suite passes with one expected skip (proxy variables removed for the no-network Telegram test environment).

The branch is based on current `main` `28c3c219` and changes only four intended files.