### PR TITLE
Retire terminal pending entry brackets

### DIFF
--- a/src/nifty_scalper_bot/execution/bracket_core.py
+++ b/src/nifty_scalper_bot/execution/bracket_core.py
@@ -581,6 +581,12 @@ class BracketManager:
                 os.getenv("BRACKET_PENDING_ENTRY_RECONCILE_AFTER_SEC"), 5.0
             ),
         )
+        self._pending_entry_stale_after_sec = max(
+            120.0,
+            parse_float_env(
+                os.getenv("BRACKET_PENDING_ENTRY_STALE_AFTER_SEC"), 120.0
+            ),
+        )
         self._stale_cleanup_age = 86400
         self._trail_tier1_pct = parse_float_env(os.getenv("TRAIL_TIER1_PCT"), 1.0)
         self._trail_tier2_pct = parse_float_env(os.getenv("TRAIL_TIER2_PCT"), 2.0)
@@ -903,10 +909,13 @@ class BracketManager:
                 LOGGER.error("Failure in _watchdog_exit_loop: %s", e)
                 time.sleep(0.25)
 
-    def _broker_order_filled(self, order_id: str) -> tuple[bool, float | None]:
+    def _broker_entry_order_status(
+        self, order_id: str
+    ) -> tuple[Mapping[str, Any], bool]:
+        """Return entry-order status and whether broker lookup was authoritative."""
         broker = getattr(self.order_manager, "_broker", None)
         if broker is None:
-            return False, None
+            return {}, False
         for attr in ("get_order_status", "order_status"):
             fn = getattr(broker, attr, None)
             if callable(fn):
@@ -914,18 +923,10 @@ class BracketManager:
                     status = fn(order_id)
                 except Exception:
                     continue
-                if isinstance(status, Mapping):
-                    status_text = str(status.get("status") or "").upper()
-                    if status_text in _FILLED_STATUSES:
-                        avg_price = (
-                            status.get("average_price")
-                            or status.get("avg_price")
-                            or status.get("price")
-                        )
-                        try:
-                            return True, float(avg_price) if avg_price else None
-                        except (TypeError, ValueError):
-                            return True, None
+                if isinstance(status, Mapping) and str(
+                    status.get("status") or ""
+                ).strip():
+                    return status, True
         get_orders = getattr(broker, "get_orders", None)
         if not callable(get_orders):
             get_orders = getattr(broker, "orders", None)
@@ -933,24 +934,30 @@ class BracketManager:
             try:
                 orders = get_orders() or []
             except Exception:
-                orders = []
+                return {}, False
             for order in orders:
                 if not isinstance(order, Mapping):
                     continue
                 if str(order.get("order_id") or "") != str(order_id):
                     continue
-                status_text = str(order.get("status") or "").upper()
-                if status_text in _FILLED_STATUSES:
-                    avg_price = (
-                        order.get("average_price")
-                        or order.get("avg_price")
-                        or order.get("price")
-                    )
-                    try:
-                        return True, float(avg_price) if avg_price else None
-                    except (TypeError, ValueError):
-                        return True, None
-        return False, None
+                return order, True
+            return {}, True
+        return {}, False
+
+    def _broker_order_filled(self, order_id: str) -> tuple[bool, float | None]:
+        status, _known = self._broker_entry_order_status(order_id)
+        status_text = str(status.get("status") or "").upper()
+        if status_text not in _FILLED_STATUSES:
+            return False, None
+        avg_price = (
+            status.get("average_price")
+            or status.get("avg_price")
+            or status.get("price")
+        )
+        try:
+            return True, float(avg_price) if avg_price else None
+        except (TypeError, ValueError):
+            return True, None
 
     def _reconcile_pending_entry(self, bracket: BracketState) -> None:
         if bracket.entry_confirmed or bracket.monitoring_only:
@@ -958,11 +965,41 @@ class BracketManager:
         age = time.time() - float(bracket.created_at or 0.0)
         if age < self._pending_entry_reconcile_after_sec:
             return
-        filled, fill_price = self._broker_order_filled(bracket.entry_order_id)
-        if filled:
+        status, status_known = self._broker_entry_order_status(
+            bracket.entry_order_id
+        )
+        status_text = str(status.get("status") or "").upper()
+        if status_text in _FILLED_STATUSES:
+            fill_price = self._extract_status_price(status)
             self.confirm_entry_fill(
                 bracket.entry_order_id, fill_price or bracket.entry_price
             )
+            return
+        terminal_unfilled = status_text in _CANCELLED_STATUSES
+        authoritatively_absent = (
+            status_known
+            and not status_text
+            and age >= self._pending_entry_stale_after_sec
+        )
+        if not (terminal_unfilled or authoritatively_absent):
+            return
+        if not self._position_flat_for_symbol(bracket.symbol):
+            return
+        LOGGER.warning(
+            "PENDING_ENTRY_RECONCILED_FLAT entry_order_id=%s symbol=%s order_status=%s age_s=%.1f",
+            bracket.entry_order_id,
+            bracket.symbol,
+            status_text or "ABSENT",
+            age,
+            extra={
+                "event": "PENDING_ENTRY_RECONCILED_FLAT",
+                "entry_order_id": bracket.entry_order_id,
+                "symbol": bracket.symbol,
+                "order_status": status_text or "ABSENT",
+                "age_seconds": age,
+            },
+        )
+        self.unregister_bracket(bracket.entry_order_id)
 
     def _log_throttled(
         self,

--- a/tests/execution/test_bracket_manager_state.py
+++ b/tests/execution/test_bracket_manager_state.py
@@ -14,8 +14,30 @@ def test_exit_execution_result_instantiation_safe() -> None:
 def _mk_bm_with_broker(broker):
     om = SimpleNamespace(_broker=broker)
     bm = BracketManager(om)
+    bm.shutdown()
+    bm._watchdog_thread.join(timeout=1.0)
     bm._pending_entry_reconcile_after_sec = 0.0
     return bm
+
+
+def _add_pending(bm, bracket):
+    bm._brackets[bracket.entry_order_id] = bracket
+    bm._symbol_map[bracket.symbol] = [bracket.entry_order_id]
+
+
+def _pending(order_id, *, age=10):
+    return BracketState(
+        order_id,
+        "NFO:NIFTYCE",
+        "BUY",
+        1,
+        100.0,
+        95.0,
+        110.0,
+        created_at=time.time() - age,
+        active=False,
+        entry_confirmed=False,
+    )
 
 
 def test_pending_bracket_reconciles_filled_order_from_get_order_status():
@@ -54,3 +76,98 @@ def test_pending_bracket_not_reconciled_before_threshold():
     bm._brackets["E3"] = bracket
     bm._reconcile_pending_entry(bracket)
     assert bracket.entry_confirmed is False
+
+
+def test_terminal_unfilled_pending_entry_closes_only_when_broker_flat():
+    class _Broker:
+        def get_order_status(self, oid):
+            return {"order_id": oid, "status": "REJECTED"}
+
+        def get_positions(self):
+            return []
+
+    bm = _mk_bm_with_broker(_Broker())
+    bracket = _pending("E4")
+    _add_pending(bm, bracket)
+
+    bm._reconcile_pending_entry(bracket)
+
+    assert bm.get_bracket("E4") is None
+    assert not bm.is_symbol_managed("NFO:NIFTYCE")
+
+
+def test_terminal_pending_entry_is_preserved_when_position_state_unknown():
+    class _Broker:
+        def get_order_status(self, oid):
+            return {"order_id": oid, "status": "CANCELLED"}
+
+        def get_positions(self):
+            raise RuntimeError("broker unavailable")
+
+    bm = _mk_bm_with_broker(_Broker())
+    bracket = _pending("E5")
+    _add_pending(bm, bracket)
+
+    bm._reconcile_pending_entry(bracket)
+
+    assert bm.get_bracket("E5") is bracket
+
+
+def test_live_or_exposed_pending_entry_is_preserved():
+    class _Broker:
+        status = "OPEN"
+        positions = []
+
+        def get_order_status(self, oid):
+            return {"order_id": oid, "status": self.status}
+
+        def get_positions(self):
+            return list(self.positions)
+
+    broker = _Broker()
+    bm = _mk_bm_with_broker(broker)
+    bracket = _pending("E7", age=300)
+    _add_pending(bm, bracket)
+
+    bm._reconcile_pending_entry(bracket)
+    assert bm.get_bracket("E7") is bracket
+
+    broker.status = "REJECTED"
+    broker.positions = [{"symbol": "NFO:NIFTYCE", "quantity": 1}]
+    bm._reconcile_pending_entry(bracket)
+    assert bm.get_bracket("E7") is bracket
+
+
+def test_old_absent_entry_closes_after_authoritative_order_and_position_checks():
+    class _Broker:
+        def get_orders(self):
+            return []
+
+        def get_positions(self):
+            return []
+
+    bm = _mk_bm_with_broker(_Broker())
+    bm._pending_entry_stale_after_sec = 120.0
+    bracket = _pending("E6", age=121)
+    _add_pending(bm, bracket)
+
+    bm._reconcile_pending_entry(bracket)
+
+    assert bm.get_bracket("E6") is None
+
+
+def test_recent_absent_entry_is_preserved_during_fill_grace():
+    class _Broker:
+        def get_orders(self):
+            return []
+
+        def get_positions(self):
+            return []
+
+    bm = _mk_bm_with_broker(_Broker())
+    bracket = _pending("E8", age=30)
+    _add_pending(bm, bracket)
+
+    bm._reconcile_pending_entry(bracket)
+
+    assert bm.get_bracket("E8") is bracket


### PR DESCRIPTION
## Root cause
Pending-entry reconciliation only handled fills. A rejected, cancelled, or definitively absent entry could therefore remain registered forever, even when an authoritative broker position snapshot proved the symbol was flat.

## Change
- Resolve entry fill/terminal/absence from one broker status lookup.
- Confirm filled entries as before.
- Remove only terminal-unfilled entries with broker-flat proof.
- Remove old (>120 s) entries absent from an authoritative broker order list only with broker-flat proof.
- Preserve OPEN/PENDING entries, recent absence, nonzero exposure, and every unknown/error state.

## Validation
- Nine focused pending-entry lifecycle tests pass.
- All execution tests pass.
- `python -m compileall -q src` passes.
- Complete repository suite passes with one expected skip.

This branch is one commit ahead of current `main` `9828b685` and changes only the bracket owner plus its focused test file.