### PR TITLE
Skip redundant option history prewarm

### DIFF
--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -2517,6 +2517,10 @@ class StrategyRunner:
             symbol_required = max(
                 required, int(self._required_bars_for_symbol(option_symbol) or 0)
             )
+            if self._option_context_history_ready(
+                option_symbol, required_bars=symbol_required
+            ):
+                continue
             before = self._sync_history_from_mdm_cache(
                 option_symbol,
                 required_bars=symbol_required,
@@ -2530,6 +2534,15 @@ class StrategyRunner:
                     required_bars=symbol_required,
                     trace_id=trace_id,
                 )
+
+    def _option_context_history_ready(
+        self, symbol: str, *, required_bars: int
+    ) -> bool:
+        """Return whether Runner and Indicator histories both meet the target."""
+        runner_history = getattr(self, "_symbol_history", {}) or {}
+        runner_bars = len(runner_history.get(symbol, []) or [])
+        indicator_bars = self._history_count_for_symbol(symbol)
+        return min(runner_bars, indicator_bars) >= int(required_bars)
 
     def _should_log_throttled(self, key: str, interval_s: float = 30.0) -> bool:
         """Decide whether a throttled log should emit. Args: key/interval_s. Returns: bool. Raises: None."""
@@ -3720,6 +3733,27 @@ class StrategyRunner:
         switching = (selected_ce_norm and selected_ce_norm != prev_ce) or (
             selected_pe_norm and selected_pe_norm != prev_pe
         )
+        unchanged_active_context = bool(
+            pair_requested
+            and selected_ce_norm == prev_ce
+            and selected_pe_norm == prev_pe
+            and atm_value == getattr(self, "_active_atm_strike", None)
+            and candidate_symbols
+            == set(getattr(self, "_active_option_symbols", set()) or set())
+            and not getattr(self, "_pending_selected_ce", None)
+            and not getattr(self, "_pending_selected_pe", None)
+        )
+        if unchanged_active_context and all(
+            self._option_context_history_ready(
+                symbol,
+                required_bars=max(
+                    self._option_required_bars,
+                    int(self._required_bars_for_symbol(symbol) or 0),
+                ),
+            )
+            for symbol in candidate_symbols
+        ):
+            return
 
         if pair_requested and switching and not pair_ready:
             self._pending_selected_ce = selected_ce_norm

--- a/tests/strategies/test_runner_active_basket_pending.py
+++ b/tests/strategies/test_runner_active_basket_pending.py
@@ -63,3 +63,56 @@ def test_pending_basket_promotes_only_after_both_legs_have_required_bars() -> No
     assert runner._active_selected_pe == "NFO:NIFTY26MAY23300PE"
     assert runner._pending_selected_ce is None
     assert runner._pending_selected_pe is None
+
+
+def test_unchanged_warm_active_context_skips_history_prewarm() -> None:
+    ce = "NFO:NIFTY26MAY23300CE"
+    pe = "NFO:NIFTY26MAY23300PE"
+    runner = _runner({ce: 30, pe: 30})
+    runner._active_selected_ce = ce
+    runner._active_selected_pe = pe
+    runner._active_atm_strike = 23300
+    runner._active_option_symbols = {ce, pe}
+    runner._symbol_history = {ce: list(range(30)), pe: list(range(30))}
+    prewarm_calls = []
+    runner._prewarm_active_option_history = lambda **kwargs: prewarm_calls.append(
+        kwargs
+    )
+
+    runner.set_active_option_context(
+        selected_ce=ce,
+        selected_pe=pe,
+        atm_strike=23300,
+        option_symbols=[ce, pe],
+    )
+
+    assert prewarm_calls == []
+
+
+def test_option_prewarm_syncs_only_cold_symbols() -> None:
+    ce = "NFO:NIFTY26MAY23300CE"
+    pe = "NFO:NIFTY26MAY23300PE"
+    cold = "NFO:NIFTY26MAY23350CE"
+    runner = _runner({ce: 30, pe: 30, cold: 1})
+    runner._active_selected_ce = ce
+    runner._active_selected_pe = pe
+    runner._active_option_symbols = {ce, pe, cold}
+    runner._symbol_history = {
+        ce: list(range(30)),
+        pe: list(range(30)),
+        cold: [1],
+    }
+    runner._required_bars_for_symbol = lambda _symbol: 30
+    synced = []
+    requested = []
+    runner._sync_history_from_mdm_cache = lambda symbol, **_kwargs: (
+        synced.append(symbol) or 1
+    )
+    runner._request_selected_option_history_prewarm = (
+        lambda symbol, **_kwargs: requested.append(symbol)
+    )
+
+    StrategyRunner._prewarm_active_option_history(runner, source="test")
+
+    assert synced == [cold]
+    assert requested == [cold]


### PR DESCRIPTION
## Root cause
Every readiness recomputation reapplied the same active option context. Even when Runner and Indicator histories were already warm, that call reprojected MDM history for every active option, blocking the event loop on each 30-second rearm.

## Change
- Treat an unchanged active CE/PE/ATM/option set as a no-op when both Runner and Indicator histories meet each symbol's requirement.
- When prewarm is still needed, skip warm symbols and process only cold ones.
- Preserve initial hydration, pending-basket promotion, changed-basket handling, and readiness flag updates.

## Validation
- Focused unchanged-context and cold-only prewarm regressions pass.
- Full strategy and readiness-core suites pass.
- `python -m compileall -q src` passes.
- Complete suite: 2238 passed, 2 skipped, 1 deselected.

One commit, two files, based on current `main` `8e502377`.