### PR TITLE
fix: actually enforce max_trades_per_day (daily cap was silently inert)

### DIFF
--- a/src/nifty_scalper_bot/execution/position_manager.py
+++ b/src/nifty_scalper_bot/execution/position_manager.py
@@ -896,6 +896,12 @@ class PositionManager:
             )
         self._positions: Dict[str, Position] = {}
         self._lock = threading.RLock()
+        # Daily entry counter backing max_trades_per_day. The risk guard looked
+        # up trades_today/daily_trade_count/trade_count_today on this object;
+        # none existed, so its _call_count() fell through to 0 and the limit
+        # never fired. Keyed by IST trading date so it self-resets at rollover.
+        self._trades_today_date: str | None = None
+        self._trades_today_count: int = 0
         self._order_locks: dict[str, threading.RLock] = {}
         self._symbol_lifecycle_locks: dict[str, threading.RLock] = {}
         self._orders: Dict[str, Order] = {}
@@ -1688,6 +1694,7 @@ class PositionManager:
                 raise ValueError(f"Position already exists for {symbol_key}")
             self._clear_recent_exit_guard_locked(symbol_key)
             self._positions[symbol_key] = position
+            self._increment_trades_today_locked()
             self._mark_local_position_mutation_locked()
         self._logger.info("Opened %s position for %s", position.side, symbol_key)
         self.save_state()
@@ -1842,6 +1849,28 @@ class PositionManager:
         self._pnl_authority = authority
         self._pnl_reconciliation_status = status
         self._pnl_snapshot_at = _now()
+
+    def _increment_trades_today_locked(self) -> None:
+        """Count one new entry for the current IST trading date. Caller holds
+        the lock. Args: none. Returns: none. Raises: none."""
+        today = self._trading_date_ist()
+        if self._trades_today_date != today:
+            self._trades_today_date = today
+            self._trades_today_count = 0
+        self._trades_today_count += 1
+
+    def trades_today(self) -> int:
+        """Entries opened during the current IST trading date.
+
+        Read by the risk entry guard to enforce max_trades_per_day. Returns 0
+        on a new trading date so the limit resets at IST rollover rather than
+        on process restart.
+        Args: none. Returns: count. Raises: none.
+        """
+        with self._lock:
+            if self._trades_today_date != self._trading_date_ist():
+                return 0
+            return int(self._trades_today_count)
 
     @staticmethod
     def _trading_date_ist(now: datetime | None = None) -> str:

--- a/tests/risk/test_max_trades_per_day_enforced.py
+++ b/tests/risk/test_max_trades_per_day_enforced.py
@@ -1,0 +1,113 @@
+"""max_trades_per_day must actually stop entries.
+
+settings.max_trades_per_day already defaulted to 6 and the risk guard already
+compared trades_today >= max_trades. But the guard resolved the count via
+_call_count(position_manager, "trades_today", "daily_trade_count",
+"trade_count_today") and PositionManager implemented NONE of those names, so
+_call_count fell through to `return 0`. The comparison was permanently 0 >= 6
+and the daily cap never fired -- a configured capital control that silently
+did nothing.
+
+Observed consequence (31 Jul session): repeated ~50-145s round trips on the
+same strike, each closing for a small loss plus roughly Rs 61 of round-trip
+cost (pnl -126.75 -> net -188.09; pnl -104.00 -> net -164.81).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from nifty_scalper_bot.execution.position_manager import PositionManager
+from nifty_scalper_bot.risk.entry_guard_patch import _daily_limit_block_reason
+
+
+def _pm(tmp_path) -> PositionManager:
+    return PositionManager(state_file=str(tmp_path / "positions.json"))
+
+
+def _mgr(pm: PositionManager, limit: int = 6) -> SimpleNamespace:
+    return SimpleNamespace(
+        settings=SimpleNamespace(max_trades_per_day=limit, max_open_positions=0),
+        position_manager=pm,
+    )
+
+
+def _count(pm: PositionManager, n: int) -> None:
+    for _ in range(n):
+        with pm._lock:
+            pm._increment_trades_today_locked()
+
+
+def test_position_manager_exposes_the_counter_the_guard_reads(tmp_path) -> None:
+    """THE ROOT CAUSE: the attribute the guard looks up must exist."""
+    pm = _pm(tmp_path)
+    assert callable(getattr(pm, "trades_today", None))
+    assert pm.trades_today() == 0
+
+
+def test_entries_below_the_limit_are_allowed(tmp_path) -> None:
+    pm = _pm(tmp_path)
+    _count(pm, 5)
+    assert pm.trades_today() == 5
+    assert _daily_limit_block_reason(_mgr(pm)) is None
+
+
+def test_sixth_trade_blocks_further_entries(tmp_path) -> None:
+    """THE FIX: the cap fires at exactly the configured limit."""
+    pm = _pm(tmp_path)
+    _count(pm, 6)
+    reason = _daily_limit_block_reason(_mgr(pm))
+    assert reason is not None
+    assert "MAX_TRADES:6/6" in reason[1]
+
+
+def test_block_persists_beyond_the_limit(tmp_path) -> None:
+    pm = _pm(tmp_path)
+    _count(pm, 9)
+    reason = _daily_limit_block_reason(_mgr(pm))
+    assert reason is not None
+    assert "9/6" in reason[0]
+
+
+def test_counter_resets_on_ist_trading_date_rollover(tmp_path) -> None:
+    """The cap is per trading day, not per process lifetime."""
+    pm = _pm(tmp_path)
+    _count(pm, 6)
+    assert pm.trades_today() == 6
+
+    pm._trades_today_date = "2000-01-01"  # simulate a previous trading date
+    assert pm.trades_today() == 0
+    assert _daily_limit_block_reason(_mgr(pm)) is None
+
+
+def test_opening_a_position_increments_the_counter(tmp_path) -> None:
+    """The counter must be driven by real entries, not only by tests.
+
+    Behavioural rather than source-based: open_position is wrapped at runtime,
+    so inspecting its source would only see the wrapper.
+    """
+    pm = _pm(tmp_path)
+    assert pm.trades_today() == 0
+
+    pm.open_position(
+        symbol="NFO:NIFTY2680424400PE",
+        side="LONG",
+        quantity=65,
+        entry_price=93.35,
+    )
+
+    assert pm.trades_today() == 1
+
+
+@pytest.mark.parametrize("limit", [0, None])
+def test_zero_or_unset_limit_remains_unlimited(tmp_path, limit) -> None:
+    """0 keeps the documented 'unlimited' behaviour."""
+    pm = _pm(tmp_path)
+    _count(pm, 25)
+    mgr = SimpleNamespace(
+        settings=SimpleNamespace(max_trades_per_day=limit, max_open_positions=0),
+        position_manager=pm,
+    )
+    assert _daily_limit_block_reason(mgr) is None


### PR DESCRIPTION
**Capital control that was silently doing nothing.** Draft — merge after CI.

## Root cause
`settings.max_trades_per_day` already defaulted to **6**, and the risk guard already compared `trades_today >= max_trades`. But it resolved the count via:
```python
_call_count(position_manager, "trades_today", "daily_trade_count", "trade_count_today")
```
and **PositionManager implemented none of those names**. `_call_count()` falls through to `return 0`, so the comparison was permanently `0 >= 6` and the cap never fired.

No error, no warning — the setting read as enabled while doing nothing. Verified: all three names return `ABSENT`.

## Observed consequence (31 Jul)
```
13:02:02 entry -> 13:03:24 exit   (82s)
13:21:58 entry -> 13:22:47 exit   (49s)
14:39:07 entry -> 14:41:32 exit  (145s)
14:41:42 re-entry, different strike, 10s after the previous exit
```
```
entry 93.35 -> exit 91.40   pnl -126.75   net_pnl -188.09
entry 89.60 -> exit 88.00   pnl -104.00   net_pnl -164.81
```
≈ **₹61 round-trip cost per trade**, independent of direction.

## Fix
PositionManager now maintains the counter the guard already expects: `_trades_today_date` / `_trades_today_count` keyed by **IST trading date**, incremented in `open_position()` under the existing lock at the single entry-creation point, exposed as `trades_today()` which returns 0 after IST rollover — so the cap resets by trading day, not process restart.

Guard, threshold, wording and `0 = unlimited` semantics unchanged. This only supplies the value it was already asking for.

**Verified end-to-end against the real guard:**
```
5 trades -> None (allowed)
6 trades -> ('max_trades_per_day breached: 6/6', 'MAX_TRADES:6/6')
7 trades -> ('max_trades_per_day breached: 7/6', 'MAX_TRADES:7/6')
```

## Tests (+8)
Counter exists; below-limit allowed; sixth blocks; block persists; resets on IST rollover; a **real `open_position()` call** increments it (behavioural — the method is runtime-wrapped, so source inspection would only see the wrapper); `0`/`None` stays unlimited.

## Validation (local, all exit 0)
`compileall` · `git diff --check` clean · `tests/risk` + `tests/execution` · `-m live_runtime_e2e` **3/3** · **full suite 2263 passed**.

Production LOC: **+33 / −0**, one file.

## Scope
This caps how many entries per day can bleed. It does **not** address why entries are stopped out so fast. Diagnosis so far, unverified: stops hit after **1.6–2.0 points on a ₹90 option** — inside that instrument's ordinary noise — with re-entry ~10s later. Leading hypothesis: stop distance derived from **underlying ATR (NIFTY points)** rather than option premium.