### PR TITLE
feat: /sessionlogs Telegram command for full-day (09:00-15:30 IST) logs

### DIFF
--- a/src/nifty_scalper_bot/notifications/operator_telegram.py
+++ b/src/nifty_scalper_bot/notifications/operator_telegram.py
@@ -14,6 +14,7 @@ from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import asdict, dataclass, is_dataclass
 import inspect
 import logging
+import os
 import secrets
 import time
 from typing import Any
@@ -736,6 +737,82 @@ async def cmd_dumplogs(update: Update, _: ContextTypes.DEFAULT_TYPE, service: An
     await sender(InputFile(bio))
 
 
+def _session_window_ist(now: "datetime | None" = None) -> "tuple[str, str]":
+    """Inclusive HH:MM bounds of the NSE trading session in IST."""
+    start = os.getenv("SESSION_LOG_START_IST", "09:00")
+    end = os.getenv("SESSION_LOG_END_IST", "15:30")
+    return start, end
+
+
+def _filter_session_lines(lines: "list[str]", start: str, end: str) -> "list[str]":
+    """Keep lines whose leading HH:MM:SS falls inside the session window.
+
+    Log lines begin with an IST wall-clock timestamp. Lines without a parseable
+    leading timestamp (tracebacks, continuations) are RETAINED so multi-line
+    records are not silently broken apart.
+    Args: lines, start, end. Returns: filtered lines. Raises: none.
+    """
+    kept: list[str] = []
+    inside = False
+    for line in lines:
+        stamp = line[:5]
+        if len(line) >= 8 and line[2] == ":" and line[5] == ":" and stamp[:2].isdigit():
+            inside = start <= stamp <= end
+            if inside:
+                kept.append(line)
+            continue
+        # Continuation line: follow the state of the record it belongs to.
+        if inside:
+            kept.append(line)
+    return kept
+
+
+async def cmd_sessionlogs(update: Update, _: ContextTypes.DEFAULT_TYPE, service: Any) -> None:
+    """Full trading-session logs (09:00-15:30 IST) as a downloadable file."""
+    del service
+    import gzip
+    import io
+    import time as _time
+
+    start, end = _session_window_ist()
+    ring_lines = await asyncio.to_thread(lambda: _log_ring_tail(200_000))
+    session_lines = await asyncio.to_thread(
+        _filter_session_lines, ring_lines, start, end
+    )
+    if not session_lines:
+        await safe_reply(
+            update,
+            f"No buffered logs inside {start}-{end} IST yet. "
+            f"({len(ring_lines)} lines buffered overall.)",
+        )
+        return
+
+    text = "\n".join(session_lines)
+    stamp = _time.strftime("%Y%m%d")
+    raw = text.encode("utf-8")
+
+    chat = getattr(update, "effective_chat", None)
+    sender = getattr(chat, "send_document", None) if chat is not None else None
+    if sender is None:
+        await safe_reply(update, "Cannot send a document to this chat.")
+        return
+
+    # Telegram caps uploads; gzip keeps a full session comfortably inside it.
+    if len(raw) > 4_000_000:
+        payload = io.BytesIO(gzip.compress(raw))
+        payload.name = f"niftybot-session-{stamp}.txt.gz"
+    else:
+        payload = io.BytesIO(raw)
+        payload.name = f"niftybot-session-{stamp}.txt"
+
+    await sender(InputFile(payload))
+    await safe_reply(
+        update,
+        f"Session {start}-{end} IST: {len(session_lines)} lines "
+        f"({len(raw) // 1024} KB uncompressed).",
+    )
+
+
 async def cmd_stderror(update: Update, _: ContextTypes.DEFAULT_TYPE, service: Any) -> None:
     err = _first_attr(_context(service), ("last_exception", "last_error", "runtime_exception"))
     await safe_reply(update, str(err) if err else "No runtime exception captured.")
@@ -881,6 +958,12 @@ OPERATOR_COMMANDS: list[CommandSpec] = [
     CommandSpec("version", "app version, build and git SHA", cmd_version, "Diagnostics"),
     CommandSpec("errors", "recent error log summary", cmd_errors, "Logs"),
     CommandSpec("logs", "recent log lines inline (/logs [N])", cmd_logs, "Logs"),
+    CommandSpec(
+        "sessionlogs",
+        "full trading session 09:00-15:30 IST as a file",
+        cmd_sessionlogs,
+        "Logs",
+    ),
     CommandSpec("dumplogs", "download recent logs as a .txt file (/dumplogs [N])", cmd_dumplogs, "Logs"),
     CommandSpec("stderror", "last runtime exception/error details", cmd_stderror, "Logs"),
     CommandSpec("selftest", "run non-invasive system self-test", cmd_selftest, "Diagnostics"),

--- a/src/nifty_scalper_bot/notifications/telegram_controller.py
+++ b/src/nifty_scalper_bot/notifications/telegram_controller.py
@@ -362,9 +362,28 @@ log = get_logger(__name__)
 # -----------------------------
 # In-memory ring buffer logging
 # -----------------------------
+def _ring_capacity() -> int:
+    """Lines retained for Telegram log retrieval.
+
+    The previous fixed 2000 lines held only ~15-90 minutes at live tick-log
+    rates, so /dumplogs could never return a full trading session (09:00-15:30
+    IST) and post-session diagnosis was working from a truncated window.
+    Roughly 200 bytes/line, so the 50k default is ~10 MB resident.
+    Args: none. Returns: line capacity. Raises: none.
+    """
+    raw = os.getenv("TELEGRAM_LOG_RING_LINES")
+    if raw is None:
+        return 50_000
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return 50_000
+    return max(2_000, min(value, 200_000))
+
+
 class _Ring:
-    def __init__(self, maxlen: int = 2000) -> None:
-        self.buf: deque[str] = deque(maxlen=maxlen)
+    def __init__(self, maxlen: int | None = None) -> None:
+        self.buf: deque[str] = deque(maxlen=maxlen or _ring_capacity())
 
     def add(self, line: str) -> None:
         # NOTE: all inputs already stringified; keep compact

--- a/tests/notifications/test_operator_telegram.py
+++ b/tests/notifications/test_operator_telegram.py
@@ -235,6 +235,7 @@ EXPECTED_OPERATOR_COMMANDS = (
     "version",
     "errors",
     "logs",
+    "sessionlogs",
     "dumplogs",
     "stderror",
     "selftest",

--- a/tests/notifications/test_session_logs_command.py
+++ b/tests/notifications/test_session_logs_command.py
@@ -1,0 +1,84 @@
+"""/sessionlogs must return the whole trading session, not a truncated tail.
+
+The Telegram log ring was fixed at 2000 lines. At live tick-log rates that
+holds roughly 15-90 minutes, so /dumplogs could never return a full trading
+session and post-session diagnosis worked from a truncated window -- observed
+directly: uploaded 31 Jul logs covered only 13:00-14:42 of a 09:00-15:30 day,
+showing 3 closed trades out of a reported 36.
+"""
+
+from __future__ import annotations
+
+from nifty_scalper_bot.notifications.operator_telegram import (
+    OPERATOR_COMMANDS,
+    _filter_session_lines,
+    _session_window_ist,
+)
+from nifty_scalper_bot.notifications.telegram_controller import _Ring, _ring_capacity
+
+
+def test_command_is_registered() -> None:
+    names = [c.name for c in OPERATOR_COMMANDS]
+    assert "sessionlogs" in names
+    # Existing commands are preserved.
+    assert "logs" in names and "dumplogs" in names
+
+
+def test_default_window_is_the_nse_session() -> None:
+    assert _session_window_ist() == ("09:00", "15:30")
+
+
+def test_window_is_configurable(monkeypatch) -> None:
+    monkeypatch.setenv("SESSION_LOG_START_IST", "09:15")
+    monkeypatch.setenv("SESSION_LOG_END_IST", "15:29")
+    assert _session_window_ist() == ("09:15", "15:29")
+
+
+def test_pre_open_and_post_close_lines_are_excluded() -> None:
+    lines = [
+        "08:59:59 [INFO] pre-open",
+        "09:00:00 [INFO] open",
+        "12:30:00 [INFO] midday",
+        "15:30:00 [INFO] close",
+        "15:31:00 [INFO] post-close",
+    ]
+    kept = _filter_session_lines(lines, "09:00", "15:30")
+    assert "08:59:59 [INFO] pre-open" not in kept
+    assert "15:31:00 [INFO] post-close" not in kept
+    assert len(kept) == 3
+
+
+def test_multiline_records_are_not_broken_apart() -> None:
+    """Tracebacks have no leading timestamp and must follow their record."""
+    lines = [
+        "12:00:00 [ERROR] boom",
+        "Traceback (most recent call last):",
+        "  File 'x.py', line 1",
+        "15:31:00 [INFO] post-close",
+        "  orphaned continuation after the window",
+    ]
+    kept = _filter_session_lines(lines, "09:00", "15:30")
+    assert "Traceback (most recent call last):" in kept
+    assert "  File 'x.py', line 1" in kept
+    # A continuation belonging to an excluded record stays excluded.
+    assert "  orphaned continuation after the window" not in kept
+
+
+def test_ring_capacity_holds_a_full_session_by_default() -> None:
+    """2000 lines could not span 09:00-15:30 at live log rates."""
+    assert _ring_capacity() == 50_000
+    assert _Ring().buf.maxlen == 50_000
+
+
+def test_ring_capacity_is_bounded_and_configurable(monkeypatch) -> None:
+    monkeypatch.setenv("TELEGRAM_LOG_RING_LINES", "80000")
+    assert _ring_capacity() == 80_000
+    # Floor protects the existing /logs and /dumplogs behaviour.
+    monkeypatch.setenv("TELEGRAM_LOG_RING_LINES", "10")
+    assert _ring_capacity() == 2_000
+    # Ceiling bounds memory (~200 bytes/line).
+    monkeypatch.setenv("TELEGRAM_LOG_RING_LINES", "999999")
+    assert _ring_capacity() == 200_000
+    # Malformed config must not shrink the buffer.
+    monkeypatch.setenv("TELEGRAM_LOG_RING_LINES", "abc")
+    assert _ring_capacity() == 50_000


### PR DESCRIPTION
Adds `/sessionlogs` for full trading-day log retrieval. Draft — merge after CI.

## Why
The Telegram log ring was fixed at **2000 lines**. At live tick-log rates that holds roughly 15–90 minutes, so `/dumplogs` could never return a full session.

Observed directly: the uploaded 31 Jul logs covered only **13:00–14:42** of a 09:00–15:30 day and contained **3 closed trades out of a reported 36** — which made per-trade cost and win/loss distribution impossible to establish.

## Changes
**1. Ring capacity** → `TELEGRAM_LOG_RING_LINES`, default **50,000 lines** (~10 MB at ~200 bytes/line), floored at 2,000 so `/logs` and `/dumplogs` cannot regress, ceilinged at 200,000 to bound memory. Malformed values fall back to the default rather than shrinking the buffer.

**2. New `/sessionlogs`** —
- filters to the IST trading window, configurable via `SESSION_LOG_START_IST` / `SESSION_LOG_END_IST` (defaults `09:00` / `15:30`)
- lines with no parseable leading timestamp (tracebacks, continuations) **follow the record they belong to**, so multi-line records are neither split nor leaked past the boundary
- sends a document, **gzipping above 4 MB** to stay inside Telegram's upload limit
- replies with line count and uncompressed size
- when the window is empty, reports how many lines *are* buffered instead of failing silently

Existing commands untouched. The pinned command-set test was updated **deliberately** to include the new name rather than relaxed.

No trading, risk, execution or data-path code touched.

## Tests (+7)
Registered alongside `logs`/`dumplogs`; default window is the NSE session; window configurable; pre-open and post-close excluded; multi-line records intact with out-of-window continuations excluded; default ring spans a full session; capacity floor, ceiling and malformed handling.

## Validation (local, all exit 0)
`compileall` · `git diff --check` clean · `tests/notifications` + `tests/risk` · `-m live_runtime_e2e` 3/3 clean on re-run · **full suite 2270 passed**.

Production LOC: **+95 / −2**, 2 files.