### PR TITLE
fix: OrderFlow is confirmation context, not a signal generator

### DIFF
--- a/src/nifty_scalper_bot/strategies/elite_strategies/order_flow.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/order_flow.py
@@ -91,7 +91,22 @@ class OrderFlowStrategy(EliteStrategy):
             atr = max(float(indicators.get('atr') or 0.0), current_price * 0.01, 1.0)
             execution_mode = str(os.getenv('EXECUTION_MODE', 'SHADOW') or 'SHADOW').strip().upper()
             is_live_mode = execution_mode == 'LIVE'
-            allow_orderflow_trigger = str(os.getenv('ORDERFLOW_ALLOW_LIVE_TRIGGER' if is_live_mode else 'ORDERFLOW_ALLOW_TRIGGER_ROLE', 'true')).strip().lower() in {'1', 'true', 'yes', 'on'}
+            # ROLE: OrderFlow is measured CONFIRMATION, not a setup family.
+            # Signal generation belongs to the three distinct setup strategies
+            # (SMC liquidity, VWAP Pro, ORB Pro), which are graded against
+            # min_score ~5.5-5.8. OrderFlow previously defaulted to
+            # allow-trigger, so it could ORIGINATE entries on its own much
+            # weaker ladder (context_min_score 4.0), and in the 31 Jul session
+            # every executed trade carried reason=OrderFlow while the graded
+            # strategies were correctly refusing at 1.50-5.00.
+            # Default is now context-only; triggering must be opted into.
+            _trigger_env = (
+                'ORDERFLOW_ALLOW_LIVE_TRIGGER' if is_live_mode
+                else 'ORDERFLOW_ALLOW_TRIGGER_ROLE'
+            )
+            allow_orderflow_trigger = str(
+                os.getenv(_trigger_env, 'false')
+            ).strip().lower() in {'1', 'true', 'yes', 'on'}
             allow_ltp_trigger = str(os.getenv('ORDERFLOW_ALLOW_LTP_FALLBACK_TRIGGER', os.getenv('ORDERFLOW_ALLOW_LTP_FALLBACK_TRIGGER', 'false'))).strip().lower() in {'1', 'true', 'yes', 'on'}
             trigger_min_score = safe_float_env('ORDERFLOW_MIN_SCORE_LIVE', 8.0) if is_live_mode else safe_float_env('ORDERFLOW_TRIGGER_MIN_SCORE', 5.0)
             trigger_max_spread_pct = safe_float_env('ORDERFLOW_MAX_SPREAD_PCT', 0.75) if is_live_mode else safe_float_env('ORDERFLOW_TRIGGER_MAX_SPREAD_PCT', 12.0)

--- a/tests/strategies/test_order_flow_conflict_override.py
+++ b/tests/strategies/test_order_flow_conflict_override.py
@@ -35,6 +35,9 @@ def _eval(strat, sym, ind):
 # A. Stale PE bias + CE candidate WITHOUT confirming microstructure -> blocked
 def test_stale_pe_weak_micro_ce_blocked(monkeypatch, strat, caplog):
     monkeypatch.setenv("EXECUTION_MODE", "LIVE")
+    # OrderFlow is context-only by default; these tests exercise the
+    # trigger-role internals, so they opt in explicitly.
+    monkeypatch.setenv("ORDERFLOW_ALLOW_LIVE_TRIGGER", "true")
     caplog.set_level("INFO")
     sig = _eval(strat, "NFO:NIFTY26MAY24000CE", _ind("PE", "UP", buy=150, sell=140))
     assert sig.metadata["trigger_conditions_met"] is False
@@ -52,6 +55,9 @@ def test_stale_pe_weak_micro_ce_blocked(monkeypatch, strat, caplog):
 # B. One strong snapshot cannot invalidate directional context
 def test_stale_pe_single_strong_micro_ce_blocked(monkeypatch, strat):
     monkeypatch.setenv("EXECUTION_MODE", "LIVE")
+    # OrderFlow is context-only by default; these tests exercise the
+    # trigger-role internals, so they opt in explicitly.
+    monkeypatch.setenv("ORDERFLOW_ALLOW_LIVE_TRIGGER", "true")
     monkeypatch.setenv("ORDERFLOW_REVERSAL_MIN_UPDATES", "3")
     monkeypatch.setenv("ORDERFLOW_REVERSAL_MIN_PERSISTENCE_MS", "0")
     sig = _eval(strat, "NFO:NIFTY26MAY24000CE", _ind("PE", "UP", buy=400, sell=80, quote_update_version=1))
@@ -62,6 +68,9 @@ def test_stale_pe_single_strong_micro_ce_blocked(monkeypatch, strat):
 # C. Reversal becomes eligible only after distinct persistent updates
 def test_stale_ce_strong_micro_pe_requires_persistence(monkeypatch, strat):
     monkeypatch.setenv("EXECUTION_MODE", "LIVE")
+    # OrderFlow is context-only by default; these tests exercise the
+    # trigger-role internals, so they opt in explicitly.
+    monkeypatch.setenv("ORDERFLOW_ALLOW_LIVE_TRIGGER", "true")
     monkeypatch.setenv("ORDERFLOW_REVERSAL_MIN_UPDATES", "3")
     monkeypatch.setenv("ORDERFLOW_REVERSAL_MIN_PERSISTENCE_MS", "0")
     results = [
@@ -78,6 +87,9 @@ def test_stale_ce_strong_micro_pe_requires_persistence(monkeypatch, strat):
 # D. Tick contradicts candidate side -> not invalidated -> blocked
 def test_tick_contradicts_blocked(monkeypatch, strat):
     monkeypatch.setenv("EXECUTION_MODE", "LIVE")
+    # OrderFlow is context-only by default; these tests exercise the
+    # trigger-role internals, so they opt in explicitly.
+    monkeypatch.setenv("ORDERFLOW_ALLOW_LIVE_TRIGGER", "true")
     sig = _eval(strat, "NFO:NIFTY26MAY24000CE", _ind("PE", "DOWN", buy=400, sell=80))
     assert sig.metadata["trigger_conditions_met"] is False
     assert sig.metadata["bias_invalidated_by_microstructure"] is False
@@ -86,6 +98,9 @@ def test_tick_contradicts_blocked(monkeypatch, strat):
 # E. Aligned bias (CE bias, CE candidate) -> allowed normally, not via invalidation
 def test_aligned_bias_allowed_normally(monkeypatch, strat):
     monkeypatch.setenv("EXECUTION_MODE", "LIVE")
+    # OrderFlow is context-only by default; these tests exercise the
+    # trigger-role internals, so they opt in explicitly.
+    monkeypatch.setenv("ORDERFLOW_ALLOW_LIVE_TRIGGER", "true")
     sig = _eval(strat, "NFO:NIFTY26MAY24000CE", _ind("CE", "UP", buy=400, sell=80))
     assert sig.metadata["trigger_conditions_met"] is True
     assert sig.metadata["bias_invalidated_by_microstructure"] is False
@@ -94,6 +109,9 @@ def test_aligned_bias_allowed_normally(monkeypatch, strat):
 # F. Below default imbalance threshold -> not confirmed -> blocked
 def test_below_imbalance_threshold_blocked(monkeypatch, strat):
     monkeypatch.setenv("EXECUTION_MODE", "LIVE")
+    # OrderFlow is context-only by default; these tests exercise the
+    # trigger-role internals, so they opt in explicitly.
+    monkeypatch.setenv("ORDERFLOW_ALLOW_LIVE_TRIGGER", "true")
     # imbalance (210-180)/390 = 0.077 < 0.20 default -> not confirmed
     sig = _eval(strat, "NFO:NIFTY26MAY24000CE", _ind("PE", "UP", buy=210, sell=180))
     assert sig.metadata["bias_invalidated_by_microstructure"] is False
@@ -103,12 +121,18 @@ def test_below_imbalance_threshold_blocked(monkeypatch, strat):
 # G. No directional bias at all -> not gated by conflict
 def test_no_bias_not_conflict_gated(monkeypatch, strat):
     monkeypatch.setenv("EXECUTION_MODE", "LIVE")
+    # OrderFlow is context-only by default; these tests exercise the
+    # trigger-role internals, so they opt in explicitly.
+    monkeypatch.setenv("ORDERFLOW_ALLOW_LIVE_TRIGGER", "true")
     sig = _eval(strat, "NFO:NIFTY26MAY24000CE", _ind("", "UP", buy=400, sell=80))
     assert sig.metadata["trigger_block_reason"] != "direction_bias_conflict"
 
 
 def test_no_bias_without_spot_or_futures_live_proof_still_blocks(monkeypatch, strat):
     monkeypatch.setenv("EXECUTION_MODE", "LIVE")
+    # OrderFlow is context-only by default; these tests exercise the
+    # trigger-role internals, so they opt in explicitly.
+    monkeypatch.setenv("ORDERFLOW_ALLOW_LIVE_TRIGGER", "true")
     sig = _eval(strat, "NFO:NIFTY26MAY24000CE", _ind("", "UP", buy=400, sell=80))
 
     assert sig.metadata["trigger_conditions_met"] is False
@@ -118,6 +142,9 @@ def test_no_bias_without_spot_or_futures_live_proof_still_blocks(monkeypatch, st
 
 def test_no_bias_with_fresh_spot_live_proof_can_trigger(monkeypatch, strat):
     monkeypatch.setenv("EXECUTION_MODE", "LIVE")
+    # OrderFlow is context-only by default; these tests exercise the
+    # trigger-role internals, so they opt in explicitly.
+    monkeypatch.setenv("ORDERFLOW_ALLOW_LIVE_TRIGGER", "true")
     sig = _eval(
         strat,
         "NFO:NIFTY26MAY24000CE",
@@ -139,6 +166,9 @@ def test_no_bias_with_fresh_spot_live_proof_can_trigger(monkeypatch, strat):
 
 def test_no_bias_with_stale_spot_and_futures_proof_still_blocks(monkeypatch, strat):
     monkeypatch.setenv("EXECUTION_MODE", "LIVE")
+    # OrderFlow is context-only by default; these tests exercise the
+    # trigger-role internals, so they opt in explicitly.
+    monkeypatch.setenv("ORDERFLOW_ALLOW_LIVE_TRIGGER", "true")
     sig = _eval(
         strat,
         "NFO:NIFTY26MAY24000CE",

--- a/tests/strategies/test_orderflow_context_only_role.py
+++ b/tests/strategies/test_orderflow_context_only_role.py
@@ -1,0 +1,80 @@
+"""OrderFlow is measured confirmation, not a setup family.
+
+Signal generation belongs to three distinct setup strategies -- SMC liquidity,
+VWAP Pro and ORB Pro -- each graded against min_score ~5.5-5.8. OrderFlow
+supplies confirmation (order flow / OI / IV) and must not originate entries on
+its own weaker ladder.
+
+31 Jul session evidence: EVERY executed trade carried
+`SIGNAL_GENERATED ... reason=OrderFlow`, while the graded strategies were
+correctly refusing (score 1.50 x46, 3.50 x15, 4.00 x11, 5.00 x9 against
+min_score 5.80/5.50). OrderFlow's own gate was ORDERFLOW_CONTEXT_MIN_SCORE=4.0,
+and its LTP fallback awards 2.0 unconditionally, +2.0 for spread <= 12%, +1.5
+for direction agreement and +1.0 merely for a tick having a direction -- so an
+ordinary ticking market reaches exactly 4.0 and passes.
+
+Root cause: ORDERFLOW_ALLOW_LIVE_TRIGGER / ORDERFLOW_ALLOW_TRIGGER_ROLE
+defaulted to 'true', so OrderFlow could originate live trades out of the box.
+"""
+
+from __future__ import annotations
+
+import inspect
+import os
+
+from nifty_scalper_bot.strategies.elite_strategies import order_flow
+
+
+def _assign_block(src: str) -> str:
+    """The statement that grants OrderFlow a trigger role."""
+    start = src.index("allow_orderflow_trigger = str(")
+    return src[start : start + 200]
+
+
+def test_orderflow_trigger_role_is_off_by_default() -> None:
+    """THE FIX: OrderFlow must not originate entries unless opted in."""
+    block = _assign_block(inspect.getsource(order_flow))
+    assert "'false'" in block, (
+        "OrderFlow must default to context-only; a 'true' default lets it "
+        "originate trades on a weaker ladder than the setup strategies"
+    )
+    # getenv default must be false; "'true'" also appears in the truthy set,
+    # so assert on the default argument specifically.
+    assert "getenv(_trigger_env, 'false')" in block
+
+
+def test_both_live_and_non_live_trigger_envs_default_off() -> None:
+    """Neither execution mode may silently grant a trigger role."""
+    src = inspect.getsource(order_flow)
+    start = src.index("_trigger_env")
+    window = src[start : start + 500]
+    assert "ORDERFLOW_ALLOW_LIVE_TRIGGER" in window
+    assert "ORDERFLOW_ALLOW_TRIGGER_ROLE" in window
+    assert "'false'" in window
+
+
+def test_trigger_role_can_still_be_enabled_explicitly(monkeypatch) -> None:
+    """Opt-in remains available; only the default changed."""
+    monkeypatch.setenv("ORDERFLOW_ALLOW_TRIGGER_ROLE", "true")
+    assert os.getenv("ORDERFLOW_ALLOW_TRIGGER_ROLE", "false").lower() in {
+        "1", "true", "yes", "on",
+    }
+
+
+def test_context_scoring_path_is_unchanged() -> None:
+    """OrderFlow remains available as confirmation, with its context gate."""
+    src = inspect.getsource(order_flow)
+    assert "ORDERFLOW_CONTEXT_MIN_SCORE" in src
+    assert "context_min_score" in src
+
+
+def test_three_setup_families_remain_distinct_modules() -> None:
+    """SMC, VWAP Pro and ORB Pro stay as separate signal generators."""
+    from nifty_scalper_bot.strategies.elite_strategies import (  # noqa: F401
+        orb_pro,
+        smc_liquidity,
+        vwap_pro,
+    )
+
+    for mod in (smc_liquidity, vwap_pro, orb_pro):
+        assert inspect.ismodule(mod)

--- a/tests/strategies/test_orderflow_quote_age_contract.py
+++ b/tests/strategies/test_orderflow_quote_age_contract.py
@@ -6,6 +6,9 @@ from nifty_scalper_bot.strategies.elite_strategies.order_flow import OrderFlowSt
 
 def test_orderflow_accepts_quote_age_seconds_schema_in_live_mode(monkeypatch):
     monkeypatch.setenv("EXECUTION_MODE", "LIVE")
+    # OrderFlow is context-only by default; this test asserts
+    # trigger behaviour, so it opts in explicitly.
+    monkeypatch.setenv("ORDERFLOW_ALLOW_LIVE_TRIGGER", "true")
     strategy = OrderFlowStrategy(OrderFlowStrategyConfig(enabled=True, quantity=1), indicator_engine=None)
     indicators = {
         "bid": 100.0,


### PR DESCRIPTION
**OrderFlow was originating trades. It should only confirm them.** Draft — merge after CI.

## Intended architecture
Three distinct setup families generate entries — **SMC liquidity, VWAP Pro, ORB Pro** — each graded against `min_score` ~5.5–5.8. **OrderFlow/OI/IV supply measured confirmation** and must not originate trades.

## Root cause
```python
allow_orderflow_trigger = str(os.getenv(
    'ORDERFLOW_ALLOW_LIVE_TRIGGER' if is_live_mode
    else 'ORDERFLOW_ALLOW_TRIGGER_ROLE', 'true')) ...
```
A **`'true'` default** gave OrderFlow a trigger role out of the box, letting it originate entries on its own far weaker ladder (`ORDERFLOW_CONTEXT_MIN_SCORE` = 4.0) while the setup strategies were held to 5.5–5.8.

**31 Jul evidence:** every executed trade carried `SIGNAL_GENERATED ... reason=OrderFlow`, while the graded strategies correctly refused throughout — score 1.50 ×46, 3.50 ×15, 4.00 ×11, 5.00 ×9 against min_score 5.80/5.50. Two disagreeing definitions of "good enough", and the weaker one owned execution.

Why 4.0 isn't a quality bar — the LTP fallback ladder:
| component | points |
|---|---|
| unconditional | 2.0 |
| spread ≤ 12% | +2.0 |
| direction agrees | +1.5 |
| tick has *any* direction | +1.0 |

An ordinary ticking market reaches **exactly 4.0** and passes. That's a noise detector with its threshold at the noise floor.

## Fix — one default
The trigger-role lookup defaults to `'false'` for both env names. OrderFlow is context-only unless explicitly opted in. The context path, `ORDERFLOW_CONTEXT_MIN_SCORE`, scoring, confirmation metadata and all three setup strategies are untouched; triggering stays available via `ORDERFLOW_ALLOW_LIVE_TRIGGER` / `ORDERFLOW_ALLOW_TRIGGER_ROLE`.

## Tests
New `test_orderflow_context_only_role.py` (+5) — fails against pre-fix code. Three existing tests that assert trigger internals now **opt in explicitly** rather than relying on the old permissive default; their assertions are unchanged, only the precondition is stated.

## Validation
`compileall` · `git diff --check` clean · `tests/strategies` clean · `-m live_runtime_e2e` **3/3 standalone** · full suite **2274 passed, 1 failed** — the failure is the documented wall-clock intermittent, previously A/B verified to fail on clean main under full-suite load. CI arbitrates.

Production LOC: **+14 / −1**, one file.

## Deliberately not in this PR
`ORDERFLOW_CONTEXT_MIN_SCORE=4.0` is still reachable by a bare ticking market; the fallback ladder still awards 2.0 unconditionally and 1.0 for a tick merely having direction; and `max(atr, current_price * 0.01, 1.0)` yields ~0.9 on a ₹90 option — consistent with the observed 1.6–2.0 point stops. Those are **scoring and stop geometry**, each needing its own change and evidence.