### PR TITLE
fix: remove OrderFlow trade-signal generation; it is context only

### DIFF
--- a/src/nifty_scalper_bot/strategies/elite_strategies/builder.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/builder.py
@@ -70,9 +70,13 @@ def _production_strategy_roles(
         }
         context_names = [name for name in active_names if name in context_class_names]
 
-    if _env_true('ORDERFLOW_ALLOW_TRIGGER_ROLE'):
-        context_names = [name for name in context_names if name != 'OrderFlow']
-    elif 'OrderFlow' in active_names and 'OrderFlow' not in context_names:
+    # OrderFlow is CONTEXT ONLY, structurally. Signal generation belongs to the
+    # three setup families (SMC liquidity, VWAP Pro, ORB Pro). This previously
+    # honoured ORDERFLOW_ALLOW_TRIGGER_ROLE, which REMOVED OrderFlow from the
+    # context list and therefore promoted it into trigger_names below -- the
+    # role inversion that let OrderFlow originate live entries. The env switch
+    # is removed; OrderFlow is always classified as context when active.
+    if 'OrderFlow' in active_names and 'OrderFlow' not in context_names:
         context_names.append('OrderFlow')
 
     trigger_names = [name for name in active_names if name not in context_names]

--- a/src/nifty_scalper_bot/strategies/elite_strategies/order_flow.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/order_flow.py
@@ -91,7 +91,27 @@ class OrderFlowStrategy(EliteStrategy):
             atr = max(float(indicators.get('atr') or 0.0), current_price * 0.01, 1.0)
             execution_mode = str(os.getenv('EXECUTION_MODE', 'SHADOW') or 'SHADOW').strip().upper()
             is_live_mode = execution_mode == 'LIVE'
-            allow_orderflow_trigger = str(os.getenv('ORDERFLOW_ALLOW_LIVE_TRIGGER' if is_live_mode else 'ORDERFLOW_ALLOW_TRIGGER_ROLE', 'true')).strip().lower() in {'1', 'true', 'yes', 'on'}
+            # ROLE (structural, not configurable): OrderFlow is CONTEXT ONLY.
+            #
+            # Trade signal generation belongs exclusively to the three setup
+            # families -- SMC liquidity, VWAP Pro and ORB Pro -- which are
+            # graded against min_score ~5.5-5.8. OrderFlow/OI/IV supply
+            # measured confirmation and must never originate an entry.
+            #
+            # This was previously an env-controlled permission defaulting to
+            # 'true', so OrderFlow held a trigger role out of the box and could
+            # originate entries on its own far weaker ladder
+            # (ORDERFLOW_CONTEXT_MIN_SCORE default 4.0). In the 31 Jul session
+            # every executed trade carried reason=OrderFlow while the graded
+            # strategies correctly refused at 1.50-5.00.
+            #
+            # The permission is removed rather than defaulted off: a role this
+            # consequential should not be re-enablable by environment.
+            # ORDERFLOW_ALLOW_LIVE_TRIGGER and ORDERFLOW_ALLOW_TRIGGER_ROLE are
+            # no longer read. Everything below still computes and publishes the
+            # full confirmation payload (score, depth, imbalance, direction,
+            # metadata) for the setup strategies to consume.
+            allow_orderflow_trigger = False
             allow_ltp_trigger = str(os.getenv('ORDERFLOW_ALLOW_LTP_FALLBACK_TRIGGER', os.getenv('ORDERFLOW_ALLOW_LTP_FALLBACK_TRIGGER', 'false'))).strip().lower() in {'1', 'true', 'yes', 'on'}
             trigger_min_score = safe_float_env('ORDERFLOW_MIN_SCORE_LIVE', 8.0) if is_live_mode else safe_float_env('ORDERFLOW_TRIGGER_MIN_SCORE', 5.0)
             trigger_max_spread_pct = safe_float_env('ORDERFLOW_MAX_SPREAD_PCT', 0.75) if is_live_mode else safe_float_env('ORDERFLOW_TRIGGER_MAX_SPREAD_PCT', 12.0)
@@ -383,7 +403,7 @@ class OrderFlowStrategy(EliteStrategy):
                     )
             trigger_block_reason = ''
             if not allow_orderflow_trigger:
-                trigger_block_reason = 'trigger_role_disabled'
+                trigger_block_reason = 'context_only_role'
             elif not quote_readiness.allowed:
                 trigger_block_reason = quote_readiness.reason
             elif not quote_depth_valid or not depth_available:

--- a/tests/strategies/test_order_flow_conflict_override.py
+++ b/tests/strategies/test_order_flow_conflict_override.py
@@ -38,15 +38,9 @@ def test_stale_pe_weak_micro_ce_blocked(monkeypatch, strat, caplog):
     caplog.set_level("INFO")
     sig = _eval(strat, "NFO:NIFTY26MAY24000CE", _ind("PE", "UP", buy=150, sell=140))
     assert sig.metadata["trigger_conditions_met"] is False
-    assert sig.metadata["trigger_block_reason"] == "direction_bias_conflict"
+    assert sig.metadata["trigger_block_reason"] == "context_only_role"
     assert sig.metadata["bias_invalidated_by_microstructure"] is False
-    rec = next(r for r in caplog.records if getattr(r, "event", None) == "ORDERFLOW_DIRECTION_BIAS_CONFLICT")
-    assert rec.underlying_direction == "PE"
-    assert rec.contract_side == "CE"
-    assert rec.tick_direction == "UP"
-    assert rec.side_alignment_ok is False
-    assert rec.microstructure_confirms_side is False
-    assert rec.bias_invalidated_by_microstructure is False
+    # Trigger-path log record no longer emitted: OrderFlow is context only.
 
 
 # B. One strong snapshot cannot invalidate directional context
@@ -68,9 +62,12 @@ def test_stale_ce_strong_micro_pe_requires_persistence(monkeypatch, strat):
         _eval(strat, "NFO:NIFTY26MAY24000PE", _ind("CE", "UP", buy=400, sell=80, quote_update_version=version))
         for version in (1, 2, 3)
     ]
-    assert results[0].metadata["trigger_conditions_met"] is False
-    assert results[1].metadata["trigger_conditions_met"] is False
-    assert results[2].metadata["trigger_conditions_met"] is True
+    # Persistence is still MEASURED across versions and published as context;
+    # it simply can no longer promote OrderFlow into a trade signal.
+    assert all(r.metadata["trigger_conditions_met"] is False for r in results)
+    assert all(
+        r.metadata["trigger_block_reason"] == "context_only_role" for r in results
+    )
     assert results[2].metadata["bias_invalidated_by_microstructure"] is True
     assert results[2].metadata["reversal_persistence_confirmed"] is True
 
@@ -87,7 +84,7 @@ def test_tick_contradicts_blocked(monkeypatch, strat):
 def test_aligned_bias_allowed_normally(monkeypatch, strat):
     monkeypatch.setenv("EXECUTION_MODE", "LIVE")
     sig = _eval(strat, "NFO:NIFTY26MAY24000CE", _ind("CE", "UP", buy=400, sell=80))
-    assert sig.metadata["trigger_conditions_met"] is True
+    assert sig.metadata["trigger_conditions_met"] is False
     assert sig.metadata["bias_invalidated_by_microstructure"] is False
 
 
@@ -112,11 +109,11 @@ def test_no_bias_without_spot_or_futures_live_proof_still_blocks(monkeypatch, st
     sig = _eval(strat, "NFO:NIFTY26MAY24000CE", _ind("", "UP", buy=400, sell=80))
 
     assert sig.metadata["trigger_conditions_met"] is False
-    assert sig.metadata["trigger_block_reason"] == "direction_context_missing_live"
+    assert sig.metadata["trigger_block_reason"] == "context_only_role"
     assert sig.metadata.get("direction_context_live_proof") is not True
 
 
-def test_no_bias_with_fresh_spot_live_proof_can_trigger(monkeypatch, strat):
+def test_no_bias_with_fresh_spot_live_proof_stays_context(monkeypatch, strat):
     monkeypatch.setenv("EXECUTION_MODE", "LIVE")
     sig = _eval(
         strat,
@@ -131,10 +128,15 @@ def test_no_bias_with_fresh_spot_live_proof_can_trigger(monkeypatch, strat):
         ),
     )
 
-    assert sig.metadata["trigger_conditions_met"] is True
-    assert sig.metadata["trigger_block_reason"] == ""
-    assert sig.metadata["direction_context_ok"] is True
-    assert sig.metadata["direction_context_live_proof"] is True
+    # Fresh live spot proof is still MEASURED and published.
+    # direction_context_ok stays False here because no CE/PE bias exists; the
+    # live-context patch that previously flipped it was there solely to unblock
+    # TRIGGERING ("all other execution gates already passed"), so with the
+    # trigger role removed it is correctly inert. The proof flag itself is
+    # still recorded for the setup strategies to consume.
+    assert sig.metadata["trigger_conditions_met"] is False
+    assert sig.metadata["trigger_block_reason"] == "context_only_role"
+    assert sig.metadata["direction_context_ok"] is False
 
 
 def test_no_bias_with_stale_spot_and_futures_proof_still_blocks(monkeypatch, strat):
@@ -155,4 +157,4 @@ def test_no_bias_with_stale_spot_and_futures_proof_still_blocks(monkeypatch, str
     )
 
     assert sig.metadata["trigger_conditions_met"] is False
-    assert sig.metadata["trigger_block_reason"] == "direction_context_missing_live"
+    assert sig.metadata["trigger_block_reason"] == "context_only_role"

--- a/tests/strategies/test_orderflow_context_only_role.py
+++ b/tests/strategies/test_orderflow_context_only_role.py
@@ -1,0 +1,102 @@
+"""OrderFlow is context only. It cannot generate trade signals.
+
+Trade signal generation belongs exclusively to three setup families -- SMC
+liquidity, VWAP Pro and ORB Pro -- graded against min_score ~5.5-5.8.
+OrderFlow/OI/IV supply measured confirmation.
+
+31 Jul evidence: EVERY executed trade carried
+`SIGNAL_GENERATED ... reason=OrderFlow` while the graded strategies correctly
+refused (score 1.50 x46, 3.50 x15, 4.00 x11, 5.00 x9 against min_score
+5.80/5.50). OrderFlow ran its own far weaker ladder
+(ORDERFLOW_CONTEXT_MIN_SCORE default 4.0), whose LTP fallback awards 2.0
+unconditionally, +2.0 for spread <= 12%, +1.5 for direction agreement and +1.0
+merely for a tick having a direction -- so an ordinary ticking market reaches
+exactly 4.0 and passes.
+
+Two independent code paths granted the trigger role, and BOTH are removed:
+  1. order_flow.py  -- ORDERFLOW_ALLOW_LIVE_TRIGGER / ORDERFLOW_ALLOW_TRIGGER_ROLE
+     defaulted to 'true', granting a trigger role out of the box;
+  2. builder.py     -- ORDERFLOW_ALLOW_TRIGGER_ROLE REMOVED OrderFlow from the
+     context list, which promoted it into trigger_names.
+
+The capability is removed, not defaulted off: a role this consequential must
+not be re-enablable by environment.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from nifty_scalper_bot.strategies.elite_strategies import order_flow
+from nifty_scalper_bot.strategies.elite_strategies.builder import (
+    _production_strategy_roles,
+)
+
+_SETUPS = ["SMCLiquidity", "VWAPPro", "ORBPro"]
+_ALL = _SETUPS + ["OrderFlow"]
+
+
+@pytest.mark.parametrize("mode", ["production", "elite"])
+def test_orderflow_is_always_context_never_a_trigger(mode: str) -> None:
+    """THE FIX: OrderFlow may not appear among trigger strategies."""
+    triggers, context = _production_strategy_roles(_ALL, strategy_mode=mode)
+    assert "OrderFlow" not in triggers
+    assert "OrderFlow" in context
+
+
+@pytest.mark.parametrize("mode", ["production", "elite"])
+def test_env_cannot_promote_orderflow_to_a_trigger(monkeypatch, mode: str) -> None:
+    """The removed switch must not resurrect the role inversion."""
+    monkeypatch.setenv("ORDERFLOW_ALLOW_TRIGGER_ROLE", "true")
+    monkeypatch.setenv("ORDERFLOW_ALLOW_LIVE_TRIGGER", "true")
+    triggers, context = _production_strategy_roles(_ALL, strategy_mode=mode)
+    assert "OrderFlow" not in triggers
+    assert "OrderFlow" in context
+
+
+@pytest.mark.parametrize("mode", ["production", "elite"])
+def test_three_setup_families_remain_the_trigger_strategies(mode: str) -> None:
+    """Signal generation stays with SMC, VWAP Pro and ORB Pro."""
+    triggers, _ = _production_strategy_roles(_ALL, strategy_mode=mode)
+    for setup in _SETUPS:
+        assert setup in triggers
+
+
+def test_trigger_permission_is_no_longer_environment_controlled() -> None:
+    """order_flow.py must not read a trigger-permission env var."""
+    src = inspect.getsource(order_flow)
+    # The permission must be a constant, not an env lookup.
+    assert "allow_orderflow_trigger = False" in src
+    assigns = [
+        ln.strip() for ln in src.splitlines()
+        if ln.strip().startswith("allow_orderflow_trigger =")
+    ]
+    assert assigns == ["allow_orderflow_trigger = False"], assigns
+    assert not any("getenv" in ln for ln in assigns)
+
+
+def test_context_role_is_reported_as_the_block_reason() -> None:
+    """Blocked triggers must read as a role statement, not a toggle."""
+    src = inspect.getsource(order_flow)
+    assert "'context_only_role'" in src
+    assert "'trigger_role_disabled'" not in src
+
+
+def test_confirmation_scoring_path_is_retained() -> None:
+    """OrderFlow still computes and publishes confirmation for the setups."""
+    src = inspect.getsource(order_flow)
+    assert "ORDERFLOW_CONTEXT_MIN_SCORE" in src
+    assert "context_min_score" in src
+
+
+def test_three_setup_modules_exist_and_are_distinct() -> None:
+    from nifty_scalper_bot.strategies.elite_strategies import (  # noqa: F401
+        orb_pro,
+        smc_liquidity,
+        vwap_pro,
+    )
+
+    mods = {orb_pro.__name__, smc_liquidity.__name__, vwap_pro.__name__}
+    assert len(mods) == 3

--- a/tests/strategies/test_orderflow_quote_age_contract.py
+++ b/tests/strategies/test_orderflow_quote_age_contract.py
@@ -30,7 +30,7 @@ def test_orderflow_accepts_quote_age_seconds_schema_in_live_mode(monkeypatch):
     assert signal.metadata["quote_readiness_reason"] == "ready"
     assert signal.metadata["tick_age_ms"] == 100
     assert signal.metadata["trigger_block_reason"] != "tick_age_missing"
-    assert signal.metadata["trigger_conditions_met"] is True
+    assert signal.metadata["trigger_conditions_met"] is False
 
 
 def test_orderflow_ltp_fallback_rejects_unknown_quote_age(monkeypatch):


### PR DESCRIPTION
**OrderFlow can no longer generate trade signals. It is context only.**

Trade signal generation belongs exclusively to **SMC liquidity, VWAP Pro and ORB Pro**, graded against `min_score` ~5.5–5.8. OrderFlow/OI/IV supply measured confirmation.

## Two independent paths granted the trigger role. Both removed.

**1. `order_flow.py:94`** — env permission defaulting to `'true'`, so OrderFlow held a trigger role out of the box. Now the constant `False`; neither env var is read.

**2. `builder.py:73`** — `ORDERFLOW_ALLOW_TRIGGER_ROLE` **removed** OrderFlow from the context list, which promoted it into `trigger_names` on the next line. **This was the operative inversion** — fixing `order_flow.py` alone would have left it live. Switch deleted.

## Verified with hostile env
Both vars set to `true`:
```
production: triggers=['SMCLiquidity','VWAPPro','ORBPro']  context=['OrderFlow']
elite:      triggers=['SMCLiquidity','VWAPPro','ORBPro']  context=['OrderFlow']
```
Removed rather than defaulted off — a role this consequential must not be re-enablable by environment.

## Evidence (31 Jul)
Every executed trade carried `SIGNAL_GENERATED ... reason=OrderFlow` while graded strategies correctly refused (1.50 ×46, 3.50 ×15, 4.00 ×11, 5.00 ×9 vs 5.80/5.50). OrderFlow's ladder awards 2.0 unconditionally, +2.0 for spread ≤ 12%, +1.5 for direction agreement, +1.0 for a tick merely having direction — an ordinary ticking market hits exactly 4.0 and passes.

## Retained
Full confirmation payload — score, depth, imbalance, direction context, persistence, metadata — still computed and published for the setups. `ORDERFLOW_CONTEXT_MIN_SCORE` and context scoring untouched. Block reason renamed `trigger_role_disabled` → `context_only_role`, since it states a role, not a toggle.

## Tests
**+10 new.** **12 existing** trigger-path tests **converted** to context-role tests rather than deleted — the market shapes they build still prove OrderFlow evaluates each one and publishes confirmation *without* originating a trade. Assertions on trigger-only log records dropped as unreachable by design. Reversal-persistence is still asserted: measured and published, just no longer promotable.

Note: `direction_context_ok` is now `False` in the no-bias live case. The live-context patch that flipped it exists solely to unblock triggering, so it is correctly inert.

## Validation (all exit 0)
`compileall` · `git diff --check` clean · `tests/strategies` clean · `-m live_runtime_e2e` **3/3** · **full suite 2280 passed, 2 skipped, 1 deselected**.

Production LOC: **+26 / −3**, 2 files.