### PR TITLE
fix: preserve strategy premium stop distance

### DIFF
--- a/src/nifty_scalper_bot/execution/__init__.py
+++ b/src/nifty_scalper_bot/execution/__init__.py
@@ -21,6 +21,7 @@ from nifty_scalper_bot.execution.operator_control_patch import apply_patches as 
 from nifty_scalper_bot.execution.protective_order_intent_patch import apply_patches as _apply_protective_order_intent_patches
 from nifty_scalper_bot.execution.order_entry_guard_patch import apply_patches as _apply_order_entry_guard_patches
 from nifty_scalper_bot.execution.position_risk_state_patch import apply_patches as _apply_position_risk_state_patches
+from nifty_scalper_bot.execution.premium_risk_contract_patch import apply_patches as _apply_premium_risk_contract_patches
 import nifty_scalper_bot.data.quote_identity_extension as _quote_identity_extension
 import nifty_scalper_bot.execution.bracket_ownership_extension as _bracket_ownership_extension
 import nifty_scalper_bot.execution.broker_exposure_quarantine_extension as _broker_exposure_quarantine_extension
@@ -33,6 +34,7 @@ _apply_operator_control_patches()
 _apply_protective_order_intent_patches()
 _apply_order_entry_guard_patches()
 _apply_position_risk_state_patches()
+_apply_premium_risk_contract_patches()
 _quote_identity_extension.apply_patches()
 _broker_exposure_quarantine_extension.apply_patches()
 _broker_order_ledger_patch.apply_patches()

--- a/src/nifty_scalper_bot/execution/premium_risk_contract_patch.py
+++ b/src/nifty_scalper_bot/execution/premium_risk_contract_patch.py
@@ -1,0 +1,94 @@
+"""Preserve strategy-declared option-premium risk geometry.
+
+Elite setup strategies publish ``premium_stop_distance`` in option-premium
+points. The runner's legacy premium helper only consumes ``premium_stop_pct``;
+therefore an otherwise valid absolute invalidation distance can disappear before
+TradePlan construction. Patch the StrategyManager output once, before runner
+normalisation, without changing strategies or bracket ownership.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from contextlib import suppress
+from typing import Any, Mapping
+
+_PATCH_APPLIED = False
+_ORIGINAL_GENERATE_SIGNAL: Any = None
+
+
+def _positive_float(value: Any) -> float | None:
+    with suppress(TypeError, ValueError):
+        parsed = float(value)
+        if parsed > 0.0:
+            return parsed
+    return None
+
+
+def apply_premium_risk_contract(signal: Any, premium: float) -> Any:
+    """Fill missing option-premium SL/TP from explicit strategy distance."""
+    if signal is None or premium <= 0.0:
+        return signal
+    action = str(getattr(signal, "action", "") or "").upper()
+    symbol = str(getattr(signal, "symbol", "") or "").upper()
+    if action not in {"BUY", "SELL"} or not symbol.endswith(("CE", "PE")):
+        return signal
+
+    metadata = getattr(signal, "metadata", {})
+    if not isinstance(metadata, Mapping):
+        return signal
+    distance = _positive_float(metadata.get("premium_stop_distance"))
+    if distance is None:
+        return signal
+    domain = str(metadata.get("invalidation_level_domain") or "option_premium").lower()
+    if domain != "option_premium":
+        return signal
+
+    existing_sl = _positive_float(getattr(signal, "stop_loss", None))
+    existing_tp = _positive_float(getattr(signal, "take_profit", None))
+    rr = _positive_float(metadata.get("premium_target_rr")) or 2.0
+
+    if action == "BUY":
+        stop_loss = existing_sl or max(0.05, premium - distance)
+        take_profit = existing_tp or premium + distance * rr
+        valid = stop_loss < premium < take_profit
+    else:
+        stop_loss = existing_sl or premium + distance
+        take_profit = existing_tp or max(0.05, premium - distance * rr)
+        valid = take_profit < premium < stop_loss
+    if not valid:
+        return signal
+
+    updated_metadata = dict(metadata)
+    updated_metadata.setdefault("premium_risk_contract_applied", True)
+    updated_metadata.setdefault("premium_risk_source", "premium_stop_distance")
+    updated_metadata.setdefault("premium_risk_reference_price", float(premium))
+    return dataclasses.replace(
+        signal,
+        stop_loss=float(stop_loss),
+        take_profit=float(take_profit),
+        metadata=updated_metadata,
+    )
+
+
+def _patched_generate_signal(self: Any, symbol: str, current_price: float, *args: Any, **kwargs: Any) -> Any:
+    signal = _ORIGINAL_GENERATE_SIGNAL(self, symbol, current_price, *args, **kwargs)
+    return apply_premium_risk_contract(signal, float(current_price or 0.0))
+
+
+def apply_patches() -> None:
+    global _PATCH_APPLIED, _ORIGINAL_GENERATE_SIGNAL
+    if _PATCH_APPLIED:
+        return
+    from nifty_scalper_bot.core.strategy_manager import StrategyManager
+
+    if getattr(StrategyManager, "_premium_risk_contract_patch", False):
+        _PATCH_APPLIED = True
+        return
+    _ORIGINAL_GENERATE_SIGNAL = StrategyManager.generate_signal
+    StrategyManager.generate_signal = _patched_generate_signal
+    StrategyManager._premium_risk_contract_patch = True
+    _PATCH_APPLIED = True
+
+
+__all__ = ["apply_patches", "apply_premium_risk_contract"]

--- a/tests/execution/test_premium_risk_contract_patch.py
+++ b/tests/execution/test_premium_risk_contract_patch.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from nifty_scalper_bot.execution.premium_risk_contract_patch import (
+    apply_premium_risk_contract,
+)
+from nifty_scalper_bot.strategies.signal_generator import Signal
+
+
+def _signal(*, action: str = "BUY", stop_loss=None, take_profit=None, **metadata):
+    return Signal(
+        action=action,
+        symbol="NFO:NIFTY2680424400PE",
+        quantity=65,
+        confidence=0.8,
+        reason="setup",
+        stop_loss=stop_loss,
+        take_profit=take_profit,
+        metadata=metadata,
+    )
+
+
+def test_absolute_premium_distance_builds_buy_geometry() -> None:
+    signal = _signal(
+        premium_stop_distance=8.0,
+        premium_target_rr=2.0,
+        invalidation_level_domain="option_premium",
+    )
+
+    result = apply_premium_risk_contract(signal, 100.0)
+
+    assert result.stop_loss == 92.0
+    assert result.take_profit == 116.0
+    assert result.metadata["premium_risk_source"] == "premium_stop_distance"
+
+
+def test_absolute_distance_is_not_replaced_by_legacy_percentage() -> None:
+    signal = _signal(
+        premium_stop_distance=8.0,
+        premium_stop_pct=0.02,
+        premium_target_rr=2.0,
+        invalidation_level_domain="option_premium",
+    )
+
+    result = apply_premium_risk_contract(signal, 100.0)
+
+    assert result.stop_loss == 92.0
+    assert result.take_profit == 116.0
+
+
+def test_existing_valid_strategy_levels_are_preserved() -> None:
+    signal = _signal(
+        stop_loss=90.0,
+        take_profit=125.0,
+        premium_stop_distance=8.0,
+        premium_target_rr=2.0,
+        invalidation_level_domain="option_premium",
+    )
+
+    result = apply_premium_risk_contract(signal, 100.0)
+
+    assert result.stop_loss == 90.0
+    assert result.take_profit == 125.0
+
+
+def test_non_premium_domain_is_not_modified() -> None:
+    signal = _signal(
+        premium_stop_distance=8.0,
+        premium_target_rr=2.0,
+        invalidation_level_domain="underlying",
+    )
+
+    result = apply_premium_risk_contract(signal, 100.0)
+
+    assert result is signal
+    assert result.stop_loss is None
+
+
+def test_sell_geometry_is_symmetric() -> None:
+    signal = _signal(
+        action="SELL",
+        premium_stop_distance=5.0,
+        premium_target_rr=1.5,
+        invalidation_level_domain="option_premium",
+    )
+
+    result = apply_premium_risk_contract(signal, 100.0)
+
+    assert result.stop_loss == 105.0
+    assert result.take_profit == 92.5


### PR DESCRIPTION
## Root cause
Elite setup strategies publish `premium_stop_distance` in option-premium points, but the runner's legacy premium helper only consumes `premium_stop_pct`. The explicit strategy invalidation distance could therefore disappear before `TradePlan` construction.

## Targeted fix
- Apply the absolute option-premium distance once at the StrategyManager output boundary.
- Fill only missing SL/TP; preserve valid strategy-provided levels.
- Require an option symbol and `invalidation_level_domain=option_premium`.
- Preserve all strategy, runner, bracket and broker ownership paths.
- No threshold or multiplier changes.

## TDD
Covers BUY and SELL geometry, absolute-distance precedence over legacy percentage, preservation of existing levels, and rejection of non-premium domains.