### PR TITLE
fix: keep signal identity stable across strike rotation

### DIFF
--- a/src/nifty_scalper_bot/strategies/__init__.py
+++ b/src/nifty_scalper_bot/strategies/__init__.py
@@ -1,6 +1,13 @@
 from .elite_strategies import *  # noqa: F401,F403
 
 try:
+    from .signal_identity_patch import apply_patches as _apply_signal_identity_patches
+
+    _apply_signal_identity_patches()
+except Exception:
+    pass
+
+try:
     from .runtime_context_contract import install_indicator_runtime_context_contract
 
     install_indicator_runtime_context_contract()

--- a/src/nifty_scalper_bot/strategies/signal_identity_patch.py
+++ b/src/nifty_scalper_bot/strategies/signal_identity_patch.py
@@ -1,0 +1,78 @@
+"""Make live signal identity stable across option strike rotation and tick retries."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import hashlib
+import re
+from typing import Any, Mapping
+
+_PATCHED = False
+_OPTION_SUFFIX = re.compile(r"(CE|PE)$")
+_FIRST_DIGIT = re.compile(r"\d")
+_ANCHOR_KEYS = (
+    "setup_id",
+    "setup_structure_id",
+    "structure_id",
+    "setup_candle_timestamp",
+    "bar_timestamp",
+    "latest_bar_ts",
+    "signal_timestamp",
+    "timestamp",
+)
+
+
+def _option_thesis(symbol: object, metadata: Mapping[str, Any]) -> tuple[str, str]:
+    side = str(metadata.get("option_side") or metadata.get("contract_side") or "").upper()
+    text = str(symbol or "").strip().upper().split(":")[-1]
+    suffix = _OPTION_SUFFIX.search(text)
+    if side not in {"CE", "PE"} and suffix is not None:
+        side = suffix.group(1)
+    underlying = str(metadata.get("underlying") or metadata.get("base_symbol") or "").upper()
+    if not underlying:
+        body = _OPTION_SUFFIX.sub("", text)
+        digit = _FIRST_DIGIT.search(body)
+        underlying = body[: digit.start()] if digit is not None else body
+    return underlying or text, side
+
+
+def _anchor(metadata: Mapping[str, Any]) -> str:
+    for key in _ANCHOR_KEYS:
+        value = metadata.get(key)
+        if value in (None, ""):
+            continue
+        if isinstance(value, datetime):
+            dt = value if value.tzinfo is not None else value.replace(tzinfo=timezone.utc)
+            return dt.isoformat()
+        if isinstance(value, (int, float)):
+            return str(int(float(value)))
+        return str(value).strip()
+    # Legacy fallback retained only for signals that provide no setup/bar identity.
+    return datetime.now(timezone.utc).strftime("%Y%m%d%H%M")
+
+
+def _deterministic_id(signal: Any) -> str:
+    metadata = dict(getattr(signal, "metadata", {}) or {})
+    strategy = str(metadata.get("strategy_name") or metadata.get("strategy") or "manual")
+    underlying, option_side = _option_thesis(getattr(signal, "symbol", ""), metadata)
+    setup_anchor = _anchor(metadata)
+    action = str(getattr(signal, "action", ""))
+    raw = f"{strategy}:{underlying}:{option_side}:{action}:{setup_anchor}"
+    return hashlib.md5(raw.encode()).hexdigest()[:16]
+
+
+def apply_patches() -> None:
+    global _PATCHED
+    if _PATCHED:
+        return
+    from nifty_scalper_bot.strategies.signal_generator import Signal
+
+    if getattr(Signal, "_stable_setup_identity_patch", False):
+        _PATCHED = True
+        return
+    Signal.deterministic_id = property(_deterministic_id)
+    Signal._stable_setup_identity_patch = True
+    _PATCHED = True
+
+
+__all__ = ["apply_patches", "_deterministic_id", "_option_thesis"]

--- a/tests/strategies/test_signal_identity_patch.py
+++ b/tests/strategies/test_signal_identity_patch.py
@@ -1,0 +1,78 @@
+from nifty_scalper_bot.strategies.signal_generator import Signal
+
+
+def _signal(symbol: str, **metadata):
+    return Signal(
+        action="BUY",
+        symbol=symbol,
+        quantity=75,
+        confidence=0.9,
+        reason="setup",
+        stop_loss=90.0,
+        take_profit=120.0,
+        metadata={"strategy": "VWAPPro", **metadata},
+    )
+
+
+def test_same_setup_is_stable_across_strike_rotation():
+    first = _signal(
+        "NFO:NIFTY2680624500CE",
+        setup_candle_timestamp="2026-07-31T09:22:00+05:30",
+    )
+    rotated = _signal(
+        "NFO:NIFTY2680624550CE",
+        setup_candle_timestamp="2026-07-31T09:22:00+05:30",
+    )
+
+    assert first.deterministic_id == rotated.deterministic_id
+
+
+def test_setup_side_remains_part_of_identity():
+    ce = _signal(
+        "NFO:NIFTY2680624500CE",
+        setup_candle_timestamp="2026-07-31T09:22:00+05:30",
+    )
+    pe = _signal(
+        "NFO:NIFTY2680624500PE",
+        setup_candle_timestamp="2026-07-31T09:22:00+05:30",
+    )
+
+    assert ce.deterministic_id != pe.deterministic_id
+
+
+def test_new_setup_candle_gets_new_identity():
+    first = _signal(
+        "NFO:NIFTY2680624500CE",
+        setup_candle_timestamp="2026-07-31T09:22:00+05:30",
+    )
+    next_setup = _signal(
+        "NFO:NIFTY2680624500CE",
+        setup_candle_timestamp="2026-07-31T09:23:00+05:30",
+    )
+
+    assert first.deterministic_id != next_setup.deterministic_id
+
+
+def test_explicit_setup_id_has_priority_over_tick_timestamp():
+    first = _signal(
+        "NFO:NIFTY2680624500CE",
+        setup_id="vwap-reclaim-17",
+        timestamp="2026-07-31T09:22:01+05:30",
+    )
+    retry = _signal(
+        "NFO:NIFTY2680624550CE",
+        setup_id="vwap-reclaim-17",
+        timestamp="2026-07-31T09:24:59+05:30",
+    )
+
+    assert first.deterministic_id == retry.deterministic_id
+
+
+def test_strategy_remains_part_of_identity():
+    vwap = _signal(
+        "NFO:NIFTY2680624500CE",
+        setup_candle_timestamp="2026-07-31T09:22:00+05:30",
+    )
+    smc = vwap.with_metadata(strategy="SMCLiquidity")
+
+    assert vwap.deterministic_id != smc.deterministic_id


### PR DESCRIPTION
## Root cause
`Signal.deterministic_id` included the exact option symbol and could fall back to the current wall-clock minute. The same underlying setup therefore acquired a new id after strike rotation or minute rollover, allowing repeated execution attempts.

## Targeted fix
- Identity now uses strategy + underlying + CE/PE side + action + setup/bar anchor.
- Explicit setup identifiers take priority over tick timestamps.
- Different strategies, sides and setup candles remain distinct.
- Legacy minute fallback is retained only when no setup/bar identity exists.
- No execution, threshold, cooldown or broker changes.

## TDD
Covers strike rotation stability, CE/PE separation, new-candle identity, explicit setup-id precedence, and strategy separation.