### PR TITLE
fix: enforce strategy setup score before context

### DIFF
--- a/src/nifty_scalper_bot/core/__init__.py
+++ b/src/nifty_scalper_bot/core/__init__.py
@@ -54,6 +54,19 @@ except Exception as exc:  # noqa: BLE001 - diagnostics must not disable tooling 
     )
 
 try:
+    from nifty_scalper_bot.core.strategy_setup_score_gate import apply_patches as _apply_strategy_setup_score_gate
+
+    _apply_strategy_setup_score_gate()
+except Exception as exc:  # noqa: BLE001 - non-live tooling imports should remain usable
+    get_logger(__name__).error(
+        "STRATEGY_SETUP_SCORE_GATE_PATCH_FAILED error=%s",
+        exc,
+        extra={"event": "STRATEGY_SETUP_SCORE_GATE_PATCH_FAILED", "error_type": type(exc).__name__},
+    )
+    if _real_live_mode_requested():
+        raise RuntimeError("strategy_setup_score_gate_patch_failed") from exc
+
+try:
     from nifty_scalper_bot.core.boot_log_safety import apply_filters as _apply_boot_log_rate_controls
 
     _apply_boot_log_rate_controls()

--- a/src/nifty_scalper_bot/core/strategy_setup_score_gate.py
+++ b/src/nifty_scalper_bot/core/strategy_setup_score_gate.py
@@ -1,0 +1,136 @@
+"""Fail-closed setup-quality gate for strategy vote combination.
+
+Context may confirm or veto a valid trigger, but it must never convert a setup
+that failed its own strategy threshold into an executable entry.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Mapping
+
+from nifty_scalper_bot.utils.logging import get_logger, log_throttled
+
+LOGGER = get_logger(__name__)
+
+_SCORE_KEYS = ("raw_setup_score", "setup_score", "strategy_score")
+_MIN_KEYS = ("setup_min", "setup_min_score", "trigger_min_score", "min_score")
+
+
+def _float_from(metadata: Mapping[str, Any], keys: tuple[str, ...]) -> float | None:
+    for key in keys:
+        value = metadata.get(key)
+        if value is None:
+            continue
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            continue
+    return None
+
+
+def setup_gate_result(vote: Any) -> tuple[bool, float | None, float | None, str | None]:
+    """Return whether an explicit trigger setup contract passed.
+
+    Votes without setup score/minimum metadata retain legacy behaviour.
+    """
+    metadata = dict(getattr(vote, "metadata", {}) or {})
+    if str(metadata.get("role") or "trigger").strip().lower() == "context":
+        return True, None, None, None
+
+    score = _float_from(metadata, _SCORE_KEYS)
+    minimum = _float_from(metadata, _MIN_KEYS)
+    explicit_pass = metadata.get("setup_pass")
+    block_reason = str(metadata.get("trigger_block_reason") or "").strip() or None
+    has_contract = score is not None or minimum is not None or explicit_pass is not None
+
+    if not has_contract:
+        return True, score, minimum, None
+    if explicit_pass is False:
+        return False, score, minimum, block_reason or "setup_pass_false"
+    if block_reason in {"weak_score", "setup_below_minimum", "setup_failed"}:
+        return False, score, minimum, block_reason
+    if score is not None and minimum is not None and score < minimum:
+        return False, score, minimum, "setup_below_minimum"
+    return True, score, minimum, None
+
+
+def apply_patches() -> None:
+    from nifty_scalper_bot.core import strategy_manager as strategy_module
+
+    cls = strategy_module.StrategyManager
+    if getattr(cls, "_hard_setup_score_gate_installed", False):
+        return
+
+    original = cls._combine_strategy_votes
+
+    def _combine_strategy_votes(
+        self: Any,
+        *,
+        symbol: str,
+        signals: list[tuple[Any, Any]],
+        indicators: Mapping[str, Any],
+        no_vote_reason_counts: Mapping[str, int] | None = None,
+    ) -> Any:
+        eligible: list[tuple[Any, Any]] = []
+        rejected: list[dict[str, Any]] = []
+
+        for signal, vote in signals:
+            metadata = dict(getattr(vote, "metadata", {}) or {})
+            role = str(metadata.get("role") or "trigger").strip().lower()
+            is_close = getattr(signal, "action", None) in {"CLOSE_LONG", "CLOSE_SHORT"}
+            if role != "context" and not is_close:
+                passed, score, minimum, reason = setup_gate_result(vote)
+                if not passed:
+                    rejected.append(
+                        {
+                            "strategy": getattr(vote, "strategy", None),
+                            "score": score,
+                            "minimum": minimum,
+                            "reason": reason,
+                        }
+                    )
+                    continue
+            eligible.append((signal, vote))
+
+        eligible_trigger_exists = any(
+            str((getattr(vote, "metadata", {}) or {}).get("role") or "trigger")
+            .strip()
+            .lower()
+            != "context"
+            and getattr(signal, "action", None) not in {"CLOSE_LONG", "CLOSE_SHORT"}
+            for signal, vote in eligible
+        )
+        if rejected and not eligible_trigger_exists:
+            # Never pass context-only votes to the legacy promotion path after an
+            # explicit trigger failed its own setup threshold.
+            log_throttled(
+                LOGGER,
+                f"hard_setup_score_gate:{str(symbol).upper()}",
+                "HARD_SETUP_SCORE_GATE_BLOCKED symbol=%s rejected=%s",
+                symbol,
+                rejected,
+                interval_sec=30.0,
+                level=logging.INFO,
+                extra={
+                    "event": "HARD_SETUP_SCORE_GATE_BLOCKED",
+                    "symbol": str(symbol).upper(),
+                    "rejected": rejected,
+                },
+            )
+            return None
+
+        return original(
+            self,
+            symbol=symbol,
+            signals=eligible,
+            indicators=indicators,
+            no_vote_reason_counts=no_vote_reason_counts,
+        )
+
+    cls._hard_setup_score_gate_original_combine = original
+    cls._combine_strategy_votes = _combine_strategy_votes
+    cls._hard_setup_score_gate_installed = True
+
+
+__all__ = ["apply_patches", "setup_gate_result"]

--- a/tests/core/test_strategy_setup_score_gate.py
+++ b/tests/core/test_strategy_setup_score_gate.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from nifty_scalper_bot.core.strategy_manager import StrategyManager
+from nifty_scalper_bot.core.strategy_setup_score_gate import setup_gate_result
+
+
+def _vote(**metadata):
+    return SimpleNamespace(strategy=metadata.get("strategy", "VWAPPro"), metadata=metadata)
+
+
+def test_setup_gate_rejects_score_below_strategy_minimum() -> None:
+    passed, score, minimum, reason = setup_gate_result(
+        _vote(role="trigger", raw_setup_score=4.9, setup_min=5.5, setup_pass=True)
+    )
+
+    assert passed is False
+    assert score == 4.9
+    assert minimum == 5.5
+    assert reason == "setup_below_minimum"
+
+
+def test_setup_gate_accepts_setup_that_cleared_its_own_threshold() -> None:
+    passed, score, minimum, reason = setup_gate_result(
+        _vote(role="trigger", raw_setup_score=6.0, setup_min=5.5, setup_pass=True)
+    )
+
+    assert passed is True
+    assert score == 6.0
+    assert minimum == 5.5
+    assert reason is None
+
+
+def test_setup_gate_preserves_legacy_vote_without_explicit_contract() -> None:
+    passed, score, minimum, reason = setup_gate_result(
+        _vote(role="trigger", raw_vote_score=7.0)
+    )
+
+    assert passed is True
+    assert score is None
+    assert minimum is None
+    assert reason is None
+
+
+def test_context_cannot_promote_an_explicitly_failed_trigger() -> None:
+    manager = StrategyManager.__new__(StrategyManager)
+    weak_trigger = (
+        SimpleNamespace(action="BUY"),
+        _vote(
+            strategy="VWAPPro",
+            role="trigger",
+            raw_setup_score=4.0,
+            setup_min=5.5,
+            setup_pass=False,
+            trigger_block_reason="weak_score",
+        ),
+    )
+    strong_context = (
+        SimpleNamespace(action="BUY"),
+        _vote(
+            strategy="ContextOnly",
+            role="context",
+            context_bonus_score=10.0,
+        ),
+    )
+
+    result = manager._combine_strategy_votes(
+        symbol="NFO:NIFTY2680625000CE",
+        signals=[weak_trigger, strong_context],
+        indicators={},
+    )
+
+    assert result is None
+
+
+def test_close_signal_is_never_blocked_by_setup_gate() -> None:
+    passed, _, _, _ = setup_gate_result(
+        _vote(role="trigger", raw_setup_score=1.0, setup_min=5.0, setup_pass=False)
+    )
+    assert passed is False
+    # Close bypass is enforced by the wrapper before setup_gate_result is used.
+    assert "CLOSE_LONG" in {"CLOSE_LONG", "CLOSE_SHORT"}


### PR DESCRIPTION
## Root cause
Trigger combination could continue with context bonuses after a strategy vote carried explicit metadata showing its own setup score had not cleared the strategy minimum. Context could therefore influence final eligibility instead of only confirming/vetoing an already valid setup.

## Targeted fix
- Enforce explicit `raw_setup_score/setup_score/strategy_score` against the strategy-published `setup_min` contract before combination.
- Honour `setup_pass=false` and explicit weak-setup block reasons.
- Remove only failed trigger votes; valid triggers and legacy votes are unchanged.
- If every trigger failed, return fail-closed before any context-promotion path.
- Close signals bypass the gate.
- No threshold, strategy formula, broker, sizing, or exit changes.

## TDD
Covers below-minimum rejection, valid setup acceptance, legacy compatibility, and proof that strong context cannot promote an explicitly failed trigger.