### PR TITLE
fix: require new setup after stop loss

### DIFF
--- a/src/nifty_scalper_bot/execution/__init__.py
+++ b/src/nifty_scalper_bot/execution/__init__.py
@@ -21,6 +21,7 @@ from nifty_scalper_bot.execution.operator_control_patch import apply_patches as 
 from nifty_scalper_bot.execution.protective_order_intent_patch import apply_patches as _apply_protective_order_intent_patches
 from nifty_scalper_bot.execution.order_entry_guard_patch import apply_patches as _apply_order_entry_guard_patches
 from nifty_scalper_bot.execution.position_risk_state_patch import apply_patches as _apply_position_risk_state_patches
+from nifty_scalper_bot.execution.stop_rearm_contract_patch import apply_patches as _apply_stop_rearm_contract_patches
 from nifty_scalper_bot.execution.premium_risk_contract_patch import apply_patches as _apply_premium_risk_contract_patches
 import nifty_scalper_bot.data.quote_identity_extension as _quote_identity_extension
 import nifty_scalper_bot.execution.bracket_ownership_extension as _bracket_ownership_extension
@@ -34,6 +35,7 @@ _apply_operator_control_patches()
 _apply_protective_order_intent_patches()
 _apply_order_entry_guard_patches()
 _apply_position_risk_state_patches()
+_apply_stop_rearm_contract_patches()
 _apply_premium_risk_contract_patches()
 _quote_identity_extension.apply_patches()
 _broker_exposure_quarantine_extension.apply_patches()

--- a/src/nifty_scalper_bot/execution/stop_rearm_contract_patch.py
+++ b/src/nifty_scalper_bot/execution/stop_rearm_contract_patch.py
@@ -1,0 +1,169 @@
+"""Require a genuinely newer setup after a stop-loss before same-side re-entry.
+
+The existing stop-loss thesis guard enforces a minimum cooldown. This patch keeps
+that protection but prevents time alone from revalidating the stopped thesis:
+a same-underlying/same-option-side entry must carry a setup/bar timestamp newer
+than the stop event. Opposite-side entries and non-stop exits are unchanged.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from contextlib import suppress
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping
+
+from nifty_scalper_bot.execution.position_risk_state_patch import (
+    _cooldown_seconds,
+    _is_stop_reason,
+    _option_thesis,
+)
+
+_PATCHED = False
+_ORIGINAL_INIT: Any = None
+_ORIGINAL_CLOSE: Any = None
+_ANCHOR_KEYS = (
+    "setup_candle_timestamp",
+    "bar_timestamp",
+    "latest_bar_ts",
+    "signal_timestamp",
+    "timestamp",
+)
+_RISK_KEY = "_risk_runtime"
+
+
+def _to_epoch(value: Any) -> float | None:
+    if value in (None, ""):
+        return None
+    if isinstance(value, (int, float)):
+        parsed = float(value)
+        return parsed / 1000.0 if parsed > 10_000_000_000 else parsed
+    if isinstance(value, datetime):
+        dt = value if value.tzinfo is not None else value.replace(tzinfo=timezone.utc)
+        return dt.timestamp()
+    text = str(value).strip()
+    if not text:
+        return None
+    with suppress(ValueError):
+        parsed = float(text)
+        return parsed / 1000.0 if parsed > 10_000_000_000 else parsed
+    with suppress(ValueError):
+        return datetime.fromisoformat(text.replace("Z", "+00:00")).timestamp()
+    return None
+
+
+def _signal_setup_epoch(signal: Any) -> float | None:
+    metadata = getattr(signal, "metadata", {})
+    if not isinstance(metadata, Mapping):
+        return None
+    for key in _ANCHOR_KEYS:
+        anchor = _to_epoch(metadata.get(key))
+        if anchor is not None:
+            return anchor
+    return None
+
+
+def _load_persisted_stop(owner: Any) -> dict[str, Any] | None:
+    path = Path(getattr(owner, "_state_path", ""))
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError, TypeError):
+        return None
+    risk = payload.get(_RISK_KEY, {}) if isinstance(payload, dict) else {}
+    stopped = risk.get("recent_stop_thesis") if isinstance(risk, dict) else None
+    return dict(stopped) if isinstance(stopped, dict) else None
+
+
+def _same_trading_day(owner: Any, stopped: Mapping[str, Any]) -> bool:
+    stored_date = str(stopped.get("trading_date") or "")
+    return not stored_date or stored_date == owner._trading_date_ist()
+
+
+def _patched_init(self: Any, *args: Any, **kwargs: Any) -> None:
+    _ORIGINAL_INIT(self, *args, **kwargs)
+    persisted = _load_persisted_stop(self)
+    if persisted and _same_trading_day(self, persisted):
+        stopped_at = _to_epoch(persisted.get("stopped_at_epoch"))
+        if stopped_at is None:
+            expires = _to_epoch(persisted.get("expires_epoch"))
+            if expires is not None:
+                persisted["stopped_at_epoch"] = expires - _cooldown_seconds()
+        self._recent_stop_thesis = persisted
+
+
+def _patched_close_position(
+    self: Any,
+    symbol: str,
+    exit_price: float,
+    reason: str,
+    close_time: Any = None,
+) -> Any:
+    result = _ORIGINAL_CLOSE(
+        self, symbol, exit_price, reason, close_time=close_time
+    )
+    if _is_stop_reason(reason):
+        with getattr(self, "_lock"):
+            stopped = getattr(self, "_recent_stop_thesis", None)
+            if isinstance(stopped, dict):
+                stopped["stopped_at_epoch"] = time.time()
+                stopped["trading_date"] = self._trading_date_ist()
+                stopped["rearm_required"] = True
+        self.save_state()
+    return result
+
+
+def stop_reentry_block_reason(self: Any, signal: Any) -> str | None:
+    thesis = _option_thesis(getattr(signal, "symbol", None))
+    if thesis is None:
+        return None
+    with getattr(self, "_lock"):
+        stopped = getattr(self, "_recent_stop_thesis", None)
+        if not isinstance(stopped, dict):
+            return None
+        if not _same_trading_day(self, stopped):
+            self._recent_stop_thesis = None
+            return None
+        stopped_thesis = (
+            str(stopped.get("underlying", "")),
+            str(stopped.get("option_side", "")),
+        )
+        if thesis != stopped_thesis:
+            return None
+        now = time.time()
+        minimum_until = float(stopped.get("expires_epoch", 0.0) or 0.0)
+        if now < minimum_until:
+            return f"stop-loss thesis cooldown active: {int(minimum_until - now + 0.999)}s"
+        stopped_at = _to_epoch(stopped.get("stopped_at_epoch"))
+        if stopped_at is None:
+            stopped_at = minimum_until - _cooldown_seconds()
+        setup_epoch = _signal_setup_epoch(signal)
+        if setup_epoch is None:
+            return "stop-loss thesis awaiting newer setup candle"
+        if setup_epoch <= stopped_at:
+            return "stop-loss thesis setup not rearmed"
+        self._recent_stop_thesis = None
+    self.save_state()
+    return None
+
+
+def apply_patches() -> None:
+    global _PATCHED, _ORIGINAL_INIT, _ORIGINAL_CLOSE
+    if _PATCHED:
+        return
+    from nifty_scalper_bot.execution.position_manager import PositionManager
+
+    if getattr(PositionManager, "_structural_stop_rearm_patch", False):
+        _PATCHED = True
+        return
+    _ORIGINAL_INIT = PositionManager.__init__
+    _ORIGINAL_CLOSE = PositionManager.close_position
+    PositionManager.__init__ = _patched_init
+    PositionManager.close_position = _patched_close_position
+    PositionManager.stop_reentry_block_reason = stop_reentry_block_reason
+    PositionManager._structural_stop_rearm_patch = True
+    _PATCHED = True
+
+
+__all__ = ["apply_patches", "stop_reentry_block_reason", "_signal_setup_epoch"]

--- a/tests/risk/test_structural_stop_rearm.py
+++ b/tests/risk/test_structural_stop_rearm.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+
+from nifty_scalper_bot.execution.position_manager import PositionManager
+
+
+def _signal(symbol: str, **metadata):
+    return SimpleNamespace(symbol=symbol, metadata=metadata)
+
+
+def _stopped_manager(monkeypatch, tmp_path) -> PositionManager:
+    monkeypatch.setenv("STOP_LOSS_REENTRY_COOLDOWN_SECONDS", "1")
+    pm = PositionManager(state_file=str(tmp_path / "positions.json"))
+    pm.open_position(
+        symbol="NFO:NIFTY2680424400PE",
+        side="LONG",
+        quantity=65,
+        entry_price=93.35,
+    )
+    pm.close_position(
+        "NFO:NIFTY2680424400PE",
+        exit_price=91.40,
+        reason="STOP_LOSS",
+    )
+    return pm
+
+
+def test_time_alone_does_not_rearm_stopped_thesis(monkeypatch, tmp_path) -> None:
+    pm = _stopped_manager(monkeypatch, tmp_path)
+    pm._recent_stop_thesis["expires_epoch"] = time.time() - 1
+
+    reason = pm.stop_reentry_block_reason(
+        _signal("NFO:NIFTY2680424350PE")
+    )
+
+    assert reason == "stop-loss thesis awaiting newer setup candle"
+
+
+def test_reused_setup_anchor_remains_blocked(monkeypatch, tmp_path) -> None:
+    pm = _stopped_manager(monkeypatch, tmp_path)
+    stopped_at = float(pm._recent_stop_thesis["stopped_at_epoch"])
+    pm._recent_stop_thesis["expires_epoch"] = time.time() - 1
+
+    reason = pm.stop_reentry_block_reason(
+        _signal(
+            "NFO:NIFTY2680424350PE",
+            setup_candle_timestamp=stopped_at - 60,
+        )
+    )
+
+    assert reason == "stop-loss thesis setup not rearmed"
+
+
+def test_newer_setup_candle_rearms_after_minimum_cooldown(monkeypatch, tmp_path) -> None:
+    pm = _stopped_manager(monkeypatch, tmp_path)
+    stopped_at = float(pm._recent_stop_thesis["stopped_at_epoch"])
+    pm._recent_stop_thesis["expires_epoch"] = time.time() - 1
+
+    reason = pm.stop_reentry_block_reason(
+        _signal(
+            "NFO:NIFTY2680424350PE",
+            setup_candle_timestamp=stopped_at + 60,
+        )
+    )
+
+    assert reason is None
+    assert pm._recent_stop_thesis is None
+
+
+def test_new_setup_cannot_bypass_minimum_cooldown(monkeypatch, tmp_path) -> None:
+    pm = _stopped_manager(monkeypatch, tmp_path)
+    stopped_at = float(pm._recent_stop_thesis["stopped_at_epoch"])
+
+    reason = pm.stop_reentry_block_reason(
+        _signal(
+            "NFO:NIFTY2680424350PE",
+            setup_candle_timestamp=stopped_at + 60,
+        )
+    )
+
+    assert "stop-loss thesis cooldown active" in reason
+
+
+def test_opposite_option_side_is_not_blocked(monkeypatch, tmp_path) -> None:
+    pm = _stopped_manager(monkeypatch, tmp_path)
+
+    assert (
+        pm.stop_reentry_block_reason(
+            _signal("NFO:NIFTY2680424400CE")
+        )
+        is None
+    )
+
+
+def test_structural_lock_survives_restart_after_timer(monkeypatch, tmp_path) -> None:
+    pm = _stopped_manager(monkeypatch, tmp_path)
+    pm._recent_stop_thesis["expires_epoch"] = time.time() - 1
+    pm.save_state()
+
+    restarted = PositionManager(state_file=str(tmp_path / "positions.json"))
+
+    assert restarted._recent_stop_thesis is not None
+    assert restarted.stop_reentry_block_reason(
+        _signal("NFO:NIFTY2680424350PE")
+    ) == "stop-loss thesis awaiting newer setup candle"


### PR DESCRIPTION
## Root cause
The persisted stop-loss thesis lock expired solely on time. After the cooldown, the same failed setup could be evaluated again and re-entered without any new setup candle or structural evidence.

## Targeted fix
- Keep the existing minimum cooldown unchanged.
- After cooldown, require a setup/bar timestamp newer than the stop event for the same underlying + CE/PE thesis.
- Missing or reused setup anchors remain blocked.
- Opposite-side entries remain allowed.
- Non-stop exits remain unchanged.
- Persist the structural lock through restart for the same IST trading day.
- Clear it immediately when a genuinely newer setup arrives.

No strategy thresholds, broker path, sizing, SL/TP, or exit protection changed.

## TDD
Covers timer-only rejection, reused-anchor rejection, newer-candle rearm, minimum-cooldown precedence, opposite-side allowance, and restart survival.