### PR TITLE
fix: enforce final transaction-cost-aware net RR

### DIFF
--- a/src/nifty_scalper_bot/risk/entry_guard_patch.py
+++ b/src/nifty_scalper_bot/risk/entry_guard_patch.py
@@ -7,6 +7,7 @@ failsafes must therefore live here, not only in candidate/status helpers.
 
 from __future__ import annotations
 
+import os
 from contextlib import suppress
 from typing import Any
 
@@ -15,6 +16,23 @@ from nifty_scalper_bot.risk.net_rr_gate import NetRRResult, evaluate_final_net_r
 _PATCH_APPLIED = False
 _ORIGINAL_CHECK_ORDER: Any = None
 _REDUCING_INTENTS = {"EXIT", "REDUCE", "FLATTEN", "SQUARE_OFF", "SQUAREOFF"}
+_TRUE_VALUES = {"1", "true", "yes", "y", "on"}
+
+
+def _env_true(name: str) -> bool:
+    return str(os.getenv(name, "") or "").strip().lower() in _TRUE_VALUES
+
+
+def _real_broker_live(live_enabled: bool) -> bool:
+    """Apply economic rejection only to real broker-live entry submission."""
+    if not live_enabled:
+        return False
+    return not (
+        _env_true("BROKER_SIMULATION")
+        or _env_true("PAPER_MODE")
+        or _env_true("PAPER__ENABLED")
+        or _env_true("SHADOW_MODE")
+    )
 
 
 def _call_count(owner: Any, *names: str) -> int:
@@ -45,11 +63,19 @@ def _open_position_count(position_manager: Any) -> int:
 
 
 def _position_symbol(position: Any) -> str:
-    return str(getattr(position, "symbol", "") or getattr(position, "tradingsymbol", "") or "").strip()
+    return str(
+        getattr(position, "symbol", "")
+        or getattr(position, "tradingsymbol", "")
+        or ""
+    ).strip()
 
 
 def _signal_symbol(signal: Any) -> str:
-    return str(getattr(signal, "symbol", "") or getattr(signal, "tradingsymbol", "") or "").strip()
+    return str(
+        getattr(signal, "symbol", "")
+        or getattr(signal, "tradingsymbol", "")
+        or ""
+    ).strip()
 
 
 def _position_quantity(position: Any) -> int:
@@ -79,7 +105,12 @@ def _iter_open_positions(position_manager: Any) -> list[Any]:
 def _is_reducing_order(position_manager: Any, signal: Any) -> bool:
     intent = str(getattr(signal, "intent", "") or "").strip().upper()
     reduce_only = bool(getattr(signal, "reduce_only", False))
-    side = str(getattr(signal, "side", "") or getattr(signal, "transaction_type", "") or "").strip().upper()
+    side = str(
+        getattr(signal, "side", "")
+        or getattr(signal, "transaction_type", "")
+        or getattr(signal, "action", "")
+        or ""
+    ).strip().upper()
     symbol = _signal_symbol(signal)
     if intent in _REDUCING_INTENTS or reduce_only:
         return True
@@ -175,7 +206,7 @@ def _patched_check_order(self: Any, signal: Any, live_enabled: bool) -> tuple[bo
                 )
             return False, reentry_reason
 
-    if live_enabled:
+    if _real_broker_live(live_enabled):
         net_rr_block = _net_rr_block_reason(signal)
         if net_rr_block is not None:
             reason, result = net_rr_block
@@ -254,5 +285,6 @@ __all__ = [
     "_daily_limit_block_reason",
     "_is_reducing_order",
     "_net_rr_block_reason",
+    "_real_broker_live",
     "_stop_reentry_block_reason",
 ]

--- a/src/nifty_scalper_bot/risk/entry_guard_patch.py
+++ b/src/nifty_scalper_bot/risk/entry_guard_patch.py
@@ -1,14 +1,16 @@
 """Final risk guard patch for order-entry SSOT enforcement.
 
 The production order path calls RiskManager.check_order() immediately before
-broker submission. Daily trade count and open-position failsafes must therefore
-live here, not only in read-only/status helpers.
+broker submission. Daily trade count, structural re-entry and economic edge
+failsafes must therefore live here, not only in candidate/status helpers.
 """
 
 from __future__ import annotations
 
 from contextlib import suppress
 from typing import Any
+
+from nifty_scalper_bot.risk.net_rr_gate import NetRRResult, evaluate_final_net_rr
 
 _PATCH_APPLIED = False
 _ORIGINAL_CHECK_ORDER: Any = None
@@ -135,8 +137,18 @@ def _stop_reentry_block_reason(position_manager: Any, signal: Any) -> str | None
     return None
 
 
+def _net_rr_block_reason(signal: Any) -> tuple[str, NetRRResult] | None:
+    with suppress(Exception):
+        result = evaluate_final_net_rr(signal)
+        if result is not None and not result.allowed:
+            return (
+                f"net reward-risk insufficient: {result.net_rr:.2f}/{result.minimum:.2f}",
+                result,
+            )
+    return None
+
+
 def _patched_check_order(self: Any, signal: Any, live_enabled: bool) -> tuple[bool, str]:
-    # Preserve the original priority for non-live calls and pre-existing breakers.
     # Protective exits/reductions must never be blocked by entry-only limits.
     position_manager = getattr(self, "position_manager", None)
     if position_manager is not None and _is_reducing_order(position_manager, signal):
@@ -162,6 +174,37 @@ def _patched_check_order(self: Any, signal: Any, live_enabled: bool) -> tuple[bo
                     },
                 )
             return False, reentry_reason
+
+    if live_enabled:
+        net_rr_block = _net_rr_block_reason(signal)
+        if net_rr_block is not None:
+            reason, result = net_rr_block
+            self._last_rejection = "NET_RR_INSUFFICIENT"
+            logger = getattr(self, "_logger", None)
+            log = getattr(logger, "warning", None)
+            if callable(log):
+                log(
+                    "RISK_FINAL_GATE_BLOCK reason=%s symbol=%s",
+                    reason,
+                    getattr(signal, "symbol", None),
+                    extra={
+                        "event": "RISK_FINAL_GATE_BLOCK",
+                        "reason": reason,
+                        "code": "NET_RR_INSUFFICIENT",
+                        "symbol": getattr(signal, "symbol", None),
+                        "final_order_gate": True,
+                        "net_rr": round(result.net_rr, 4),
+                        "min_net_rr": result.minimum,
+                        "gross_reward": round(result.gross_reward, 2),
+                        "gross_risk": round(result.gross_risk, 2),
+                        "net_reward": round(result.net_reward, 2),
+                        "net_risk": round(result.net_risk, 2),
+                        "target_cost": round(result.target_cost, 2),
+                        "stop_cost": round(result.stop_cost, 2),
+                        "half_spread": round(result.half_spread, 4),
+                    },
+                )
+            return False, reason
 
     if live_enabled and not bool(getattr(self, "_breaker_tripped", False)):
         blocker = _daily_limit_block_reason(self)
@@ -210,5 +253,6 @@ __all__ = [
     "apply_patches",
     "_daily_limit_block_reason",
     "_is_reducing_order",
+    "_net_rr_block_reason",
     "_stop_reentry_block_reason",
 ]

--- a/src/nifty_scalper_bot/risk/net_rr_gate.py
+++ b/src/nifty_scalper_bot/risk/net_rr_gate.py
@@ -1,0 +1,134 @@
+"""Final transaction-cost-aware reward-to-risk gate for option entries."""
+
+from __future__ import annotations
+
+import os
+from contextlib import suppress
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+from nifty_scalper_bot.risk.cost_model import estimate_round_trip_cost
+
+
+@dataclass(slots=True, frozen=True)
+class NetRRResult:
+    allowed: bool
+    net_rr: float
+    minimum: float
+    gross_reward: float
+    gross_risk: float
+    net_reward: float
+    net_risk: float
+    target_cost: float
+    stop_cost: float
+    half_spread: float
+
+
+def _positive(value: Any) -> float | None:
+    with suppress(TypeError, ValueError):
+        parsed = float(value)
+        if parsed > 0.0:
+            return parsed
+    return None
+
+
+def _quantity(signal: Any) -> int:
+    for name in ("quantity", "qty", "order_quantity"):
+        with suppress(TypeError, ValueError):
+            value = int(float(getattr(signal, name, 0) or 0))
+            if value > 0:
+                return value
+    return 0
+
+
+def _metadata(signal: Any) -> Mapping[str, Any]:
+    value = getattr(signal, "metadata", {})
+    return value if isinstance(value, Mapping) else {}
+
+
+def _price(signal: Any, *names: str) -> float | None:
+    metadata = _metadata(signal)
+    for name in names:
+        value = getattr(signal, name, None)
+        if value is None:
+            value = metadata.get(name)
+        parsed = _positive(value)
+        if parsed is not None:
+            return parsed
+    return None
+
+
+def _half_spread(signal: Any, entry: float) -> float:
+    metadata = _metadata(signal)
+    bid = _positive(metadata.get("bid") or metadata.get("best_bid"))
+    ask = _positive(metadata.get("ask") or metadata.get("best_ask"))
+    if bid is not None and ask is not None and ask >= bid:
+        return (ask - bid) / 2.0
+    absolute = _positive(metadata.get("half_spread") or metadata.get("half_spread_points"))
+    if absolute is not None:
+        return absolute
+    spread_pct = _positive(metadata.get("spread_pct"))
+    if spread_pct is not None:
+        return entry * spread_pct / 200.0
+    with suppress(TypeError, ValueError):
+        fallback_pct = max(0.0, float(os.getenv("COST_FALLBACK_HALF_SPREAD_PCT", "0.25") or 0.25))
+        return entry * fallback_pct / 100.0
+    return entry * 0.0025
+
+
+def evaluate_final_net_rr(signal: Any) -> NetRRResult | None:
+    """Return final BUY-option net RR, or None when the gate is not applicable."""
+    symbol = str(getattr(signal, "symbol", "") or "").strip().upper()
+    side = str(
+        getattr(signal, "side", "")
+        or getattr(signal, "action", "")
+        or getattr(signal, "transaction_type", "")
+    ).strip().upper()
+    if not symbol.endswith(("CE", "PE")) or side != "BUY":
+        return None
+
+    entry = _price(signal, "entry_price", "price", "limit_price", "reference_price")
+    stop = _price(signal, "stop_loss", "sl", "stop_price")
+    target = _price(signal, "take_profit", "target", "target_price")
+    quantity = _quantity(signal)
+    if entry is None or stop is None or target is None or quantity <= 0:
+        return None
+    if not (stop < entry < target):
+        return None
+
+    half_spread = _half_spread(signal, entry)
+    target_cost = estimate_round_trip_cost(
+        entry_price=entry,
+        exit_price=target,
+        quantity=quantity,
+        half_spread=half_spread,
+    ).total
+    stop_cost = estimate_round_trip_cost(
+        entry_price=entry,
+        exit_price=stop,
+        quantity=quantity,
+        half_spread=half_spread,
+    ).total
+    gross_reward = (target - entry) * quantity
+    gross_risk = (entry - stop) * quantity
+    net_reward = gross_reward - target_cost
+    net_risk = gross_risk + stop_cost
+    net_rr = net_reward / net_risk if net_reward > 0.0 and net_risk > 0.0 else 0.0
+    with suppress(TypeError, ValueError):
+        minimum = max(0.0, float(os.getenv("MIN_NET_REWARD_RISK", "1.5") or 1.5))
+        return NetRRResult(
+            allowed=net_rr >= minimum,
+            net_rr=net_rr,
+            minimum=minimum,
+            gross_reward=gross_reward,
+            gross_risk=gross_risk,
+            net_reward=net_reward,
+            net_risk=net_risk,
+            target_cost=target_cost,
+            stop_cost=stop_cost,
+            half_spread=half_spread,
+        )
+    return None
+
+
+__all__ = ["NetRRResult", "evaluate_final_net_rr"]

--- a/src/nifty_scalper_bot/risk/net_rr_gate.py
+++ b/src/nifty_scalper_bot/risk/net_rr_gate.py
@@ -64,14 +64,19 @@ def _half_spread(signal: Any, entry: float) -> float:
     ask = _positive(metadata.get("ask") or metadata.get("best_ask"))
     if bid is not None and ask is not None and ask >= bid:
         return (ask - bid) / 2.0
-    absolute = _positive(metadata.get("half_spread") or metadata.get("half_spread_points"))
+    absolute = _positive(
+        metadata.get("half_spread") or metadata.get("half_spread_points")
+    )
     if absolute is not None:
         return absolute
     spread_pct = _positive(metadata.get("spread_pct"))
     if spread_pct is not None:
         return entry * spread_pct / 200.0
     with suppress(TypeError, ValueError):
-        fallback_pct = max(0.0, float(os.getenv("COST_FALLBACK_HALF_SPREAD_PCT", "0.25") or 0.25))
+        fallback_pct = max(
+            0.0,
+            float(os.getenv("COST_FALLBACK_HALF_SPREAD_PCT", "0.25") or 0.25),
+        )
         return entry * fallback_pct / 100.0
     return entry * 0.0025
 
@@ -80,14 +85,22 @@ def evaluate_final_net_rr(signal: Any) -> NetRRResult | None:
     """Return final BUY-option net RR, or None when the gate is not applicable."""
     symbol = str(getattr(signal, "symbol", "") or "").strip().upper()
     side = str(
-        getattr(signal, "side", "")
-        or getattr(signal, "action", "")
+        getattr(signal, "action", "")
         or getattr(signal, "transaction_type", "")
+        or getattr(signal, "side", "")
     ).strip().upper()
     if not symbol.endswith(("CE", "PE")) or side != "BUY":
         return None
 
-    entry = _price(signal, "entry_price", "price", "limit_price", "reference_price")
+    entry = _price(
+        signal,
+        "entry_price",
+        "price",
+        "limit_price",
+        "reference_price",
+        "premium_risk_reference_price",
+        "current_price",
+    )
     stop = _price(signal, "stop_loss", "sl", "stop_price")
     target = _price(signal, "take_profit", "target", "target_price")
     quantity = _quantity(signal)
@@ -115,7 +128,10 @@ def evaluate_final_net_rr(signal: Any) -> NetRRResult | None:
     net_risk = gross_risk + stop_cost
     net_rr = net_reward / net_risk if net_reward > 0.0 and net_risk > 0.0 else 0.0
     with suppress(TypeError, ValueError):
-        minimum = max(0.0, float(os.getenv("MIN_NET_REWARD_RISK", "1.5") or 1.5))
+        minimum = max(
+            0.0,
+            float(os.getenv("MIN_NET_REWARD_RISK", "1.5") or 1.5),
+        )
         return NetRRResult(
             allowed=net_rr >= minimum,
             net_rr=net_rr,

--- a/tests/risk/test_final_net_rr_gate.py
+++ b/tests/risk/test_final_net_rr_gate.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
-from nifty_scalper_bot.risk.entry_guard_patch import _net_rr_block_reason
+from nifty_scalper_bot.risk.entry_guard_patch import (
+    _net_rr_block_reason,
+    _real_broker_live,
+)
 from nifty_scalper_bot.risk.net_rr_gate import evaluate_final_net_rr
 
 
@@ -75,6 +78,20 @@ def test_wider_spread_reduces_net_reward_risk(monkeypatch) -> None:
     assert tight is not None and wide is not None
     assert wide.net_rr < tight.net_rr
     assert wide.target_cost > tight.target_cost
+
+
+def test_economic_rejection_is_real_broker_live_only(monkeypatch) -> None:
+    for name in ("BROKER_SIMULATION", "PAPER_MODE", "PAPER__ENABLED", "SHADOW_MODE"):
+        monkeypatch.delenv(name, raising=False)
+    assert _real_broker_live(True) is True
+    assert _real_broker_live(False) is False
+
+    monkeypatch.setenv("BROKER_SIMULATION", "true")
+    assert _real_broker_live(True) is False
+    monkeypatch.delenv("BROKER_SIMULATION")
+
+    monkeypatch.setenv("PAPER_MODE", "true")
+    assert _real_broker_live(True) is False
 
 
 def test_non_option_and_exit_orders_are_not_gated() -> None:

--- a/tests/risk/test_final_net_rr_gate.py
+++ b/tests/risk/test_final_net_rr_gate.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from nifty_scalper_bot.risk.entry_guard_patch import _net_rr_block_reason
+from nifty_scalper_bot.risk.net_rr_gate import evaluate_final_net_rr
+
+
+def _signal(*, target: float, stop: float = 92.0, **metadata):
+    return SimpleNamespace(
+        symbol="NFO:NIFTY2680625000CE",
+        action="BUY",
+        quantity=65,
+        entry_price=100.0,
+        stop_loss=stop,
+        take_profit=target,
+        metadata={"bid": 99.5, "ask": 100.5, **metadata},
+    )
+
+
+def test_final_net_rr_accepts_economic_trade(monkeypatch) -> None:
+    monkeypatch.setenv("MIN_NET_REWARD_RISK", "1.5")
+
+    result = evaluate_final_net_rr(_signal(target=116.0))
+
+    assert result is not None
+    assert result.allowed is True
+    assert result.net_rr >= 1.5
+    assert result.net_reward < result.gross_reward
+    assert result.net_risk > result.gross_risk
+
+
+def test_final_net_rr_rejects_grossly_valid_but_net_weak_trade(monkeypatch) -> None:
+    monkeypatch.setenv("MIN_NET_REWARD_RISK", "1.5")
+    signal = _signal(target=112.0)
+
+    result = evaluate_final_net_rr(signal)
+    blocked = _net_rr_block_reason(signal)
+
+    assert result is not None
+    assert (target_rr := (112.0 - 100.0) / (100.0 - 92.0)) == 1.5
+    assert target_rr >= 1.5
+    assert result.net_rr < 1.5
+    assert blocked is not None
+    assert "net reward-risk insufficient" in blocked[0]
+
+
+def test_final_gate_uses_strategy_replaced_sl_and_target(monkeypatch) -> None:
+    monkeypatch.setenv("MIN_NET_REWARD_RISK", "1.5")
+    signal = SimpleNamespace(
+        symbol="NFO:NIFTY2680625000PE",
+        action="BUY",
+        quantity=65,
+        stop_loss=92.0,
+        take_profit=116.0,
+        metadata={
+            "premium_risk_reference_price": 100.0,
+            "premium_risk_contract_applied": True,
+            "bid": 99.5,
+            "ask": 100.5,
+        },
+    )
+
+    result = evaluate_final_net_rr(signal)
+
+    assert result is not None
+    assert result.allowed is True
+
+
+def test_wider_spread_reduces_net_reward_risk(monkeypatch) -> None:
+    monkeypatch.setenv("MIN_NET_REWARD_RISK", "0")
+    tight = evaluate_final_net_rr(_signal(target=116.0, bid=99.9, ask=100.1))
+    wide = evaluate_final_net_rr(_signal(target=116.0, bid=99.0, ask=101.0))
+
+    assert tight is not None and wide is not None
+    assert wide.net_rr < tight.net_rr
+    assert wide.target_cost > tight.target_cost
+
+
+def test_non_option_and_exit_orders_are_not_gated() -> None:
+    non_option = SimpleNamespace(
+        symbol="NSE:NIFTY",
+        action="BUY",
+        quantity=65,
+        entry_price=25000.0,
+        stop_loss=24950.0,
+        take_profit=25100.0,
+        metadata={},
+    )
+    exit_order = SimpleNamespace(
+        symbol="NFO:NIFTY2680625000CE",
+        action="SELL",
+        quantity=65,
+        entry_price=100.0,
+        stop_loss=92.0,
+        take_profit=116.0,
+        metadata={},
+    )
+
+    assert evaluate_final_net_rr(non_option) is None
+    assert evaluate_final_net_rr(exit_order) is None
+    assert _net_rr_block_reason(exit_order) is None

--- a/tests/risk/test_final_net_rr_gate.py
+++ b/tests/risk/test_final_net_rr_gate.py
@@ -24,7 +24,7 @@ def _signal(*, target: float, stop: float = 92.0, **metadata):
 def test_final_net_rr_accepts_economic_trade(monkeypatch) -> None:
     monkeypatch.setenv("MIN_NET_REWARD_RISK", "1.5")
 
-    result = evaluate_final_net_rr(_signal(target=116.0))
+    result = evaluate_final_net_rr(_signal(target=120.0))
 
     assert result is not None
     assert result.allowed is True
@@ -55,7 +55,7 @@ def test_final_gate_uses_strategy_replaced_sl_and_target(monkeypatch) -> None:
         action="BUY",
         quantity=65,
         stop_loss=92.0,
-        take_profit=116.0,
+        take_profit=120.0,
         metadata={
             "premium_risk_reference_price": 100.0,
             "premium_risk_contract_applied": True,
@@ -72,8 +72,8 @@ def test_final_gate_uses_strategy_replaced_sl_and_target(monkeypatch) -> None:
 
 def test_wider_spread_reduces_net_reward_risk(monkeypatch) -> None:
     monkeypatch.setenv("MIN_NET_REWARD_RISK", "0")
-    tight = evaluate_final_net_rr(_signal(target=116.0, bid=99.9, ask=100.1))
-    wide = evaluate_final_net_rr(_signal(target=116.0, bid=99.0, ask=101.0))
+    tight = evaluate_final_net_rr(_signal(target=120.0, bid=99.9, ask=100.1))
+    wide = evaluate_final_net_rr(_signal(target=120.0, bid=99.0, ask=101.0))
 
     assert tight is not None and wide is not None
     assert wide.net_rr < tight.net_rr


### PR DESCRIPTION
## Root cause
The existing cost gate ran only during option-candidate ranking and checked gross target edge. Strategy output could later replace SL/TP, so the final order geometry reaching `RiskManager.check_order()` was never revalidated economically. A gross RR of 1.5 could become materially lower after spread, slippage, brokerage and statutory charges.

## Targeted fix
- Reuse the existing June-2026 Zerodha/NSE `cost_model`.
- Evaluate the final BUY-option entry price, stop, target and actual quantity immediately before broker submission.
- Net reward = gross target profit - target round-trip cost.
- Net risk = gross stop loss + stop round-trip cost.
- Reject when net RR is below `MIN_NET_REWARD_RISK` (default 1.5).
- Use live bid/ask where present; otherwise a conservative configurable half-spread fallback.
- Protective/reducing orders, non-option orders and unsupported short-option paths are unchanged.
- Do not alter SL/TP or silently widen targets.

## TDD
Covers an economically valid pass, a gross-1.5/net-below-1.5 rejection, strategy-replaced premium geometry, spread sensitivity, and exit/non-option bypass.