### PR TITLE
fix(exit): one canonical trailing authority, R-keyed tiers, cost-adjusted breakeven, time stop

### DIFF
--- a/src/nifty_scalper_bot/execution/bracket_core.py
+++ b/src/nifty_scalper_bot/execution/bracket_core.py
@@ -66,6 +66,11 @@ from nifty_scalper_bot.execution.position_snapshot import (
     decode_position_snapshot,
 )
 
+try:
+    from nifty_scalper_bot.risk.cost_model import estimate_round_trip_cost
+except ImportError:  # pragma: no cover - cost model is always present in prod
+    estimate_round_trip_cost = None  # type: ignore[assignment]
+
 # --- NEW IMPORTS FOR WORLD-CLASS TRAILING ---
 try:
     from nifty_scalper_bot.indicators.atr_provider import SafeATRProvider
@@ -536,13 +541,11 @@ class BracketManager:
         self._atr_provider = None
         if SafeATRProvider and indicator_engine:
             self._atr_provider = SafeATRProvider(indicator_engine, max_cache_age=60.0)
-        self._trailing_controllers: Dict[str, Any] = {}
         self._recent_ticks: Dict[str, deque] = {}
         self._max_tick_history = 20
         self._orphan_retry_count: Dict[str, int] = {}
         self._orphan_retry_last_attempt: Dict[str, float] = {}
         self._exit_executor: Callable[[str, int], Any] | None = None
-        self._trailing_controller_factory: Callable[[BracketState], Any] | None = None
         self._on_exit_complete_hook: Callable[..., None] | None = None
         self._on_position_open_priority_hook: Callable[[str], None] | None = None
         self._on_position_closed_priority_hook: Callable[[str], None] | None = None
@@ -592,6 +595,20 @@ class BracketManager:
         self._trail_tier2_pct = parse_float_env(os.getenv("TRAIL_TIER2_PCT"), 2.0)
         self._trail_tier3_pct = parse_float_env(os.getenv("TRAIL_TIER3_PCT"), 4.0)
         self._trail_tier4_pct = parse_float_env(os.getenv("TRAIL_TIER4_PCT"), 6.0)
+        # Canonical tier metric is the R-multiple of open profit. The premium-%
+        # thresholds above are only the degraded fallback used when the initial
+        # risk distance is unknown: a fixed 2% of premium is 0.2R on a wide stop
+        # and 1.2R on a tight one, so identical protection was applied to very
+        # different risk. Tiers are therefore keyed to R.
+        self._time_stop_seconds = max(
+            0.0, parse_float_env(os.getenv("LIFECYCLE_TIME_STOP_MIN"), 12.0) * 60.0
+        )
+        self._time_stop_min_progress_r = max(
+            0.0, parse_float_env(os.getenv("TIME_STOP_MIN_PROGRESS_R"), 0.5)
+        )
+        self._trail_tier2_r = parse_float_env(os.getenv("TRAIL_TIER2_R"), 1.0)
+        self._trail_tier3_r = parse_float_env(os.getenv("TRAIL_TIER3_R"), 2.0)
+        self._trail_tier4_r = parse_float_env(os.getenv("TRAIL_TIER4_R"), 3.0)
         self._exit_retry_enabled = os.getenv(
             "EXIT_RETRY_ENABLE", "true"
         ).strip().lower() in {"1", "true", "yes", "on"}
@@ -820,12 +837,6 @@ class BracketManager:
                     "error": str(exc),
                 },
             )
-
-    def attach_trailing_controller_factory(
-        self, factory: Callable[[BracketState], Any] | None
-    ) -> None:
-        """Attach a trailing controller factory. Args: factory; Returns: None; Raises: None."""
-        self._trailing_controller_factory = factory
 
     def _watchdog_exit_loop(self) -> None:
         """Run watchdog checks and force exits on hard SL breach. Args: none; Returns: none; Raises: none."""
@@ -1333,12 +1344,6 @@ class BracketManager:
 
             self._brackets[order_id] = state
 
-            if self._trailing_controller_factory:
-                if state.entry_order_id in self._trailing_controllers:
-                    return
-                controller = self._trailing_controller_factory(state)
-                self._trailing_controllers[state.entry_order_id] = controller
-
             # 6. Populate Indices
             self._order_to_entry[order_id] = order_id
             if symbol not in self._symbol_map:
@@ -1354,51 +1359,6 @@ class BracketManager:
                 order_id,
                 symbol,
             )
-
-            # 7. Initialize Adaptive Controller (The "Brain")
-            if (
-                not self._trailing_controller_factory
-                and trailing_atr_mult
-                and self._atr_provider
-                and AdaptiveTrailingController
-            ):
-                try:
-                    # Fallback trail distance must be premium-relative: the old
-                    # absolute 20.0 points is ~13% on a ~150 option premium, so
-                    # with stale/unavailable ATR the controller proposed stops
-                    # far below the current SL and the monotonic guard rejected
-                    # every update — trailing silently dead on the controller
-                    # path while the legacy fallback math trails at ~2-3%.
-                    _fallback_trail = max(
-                        round(max(float(price or 0.0), 1.0) * 0.02, 2), 0.25
-                    )
-                    spec = TrailingSpec(
-                        trail_by=_fallback_trail,  # ~2% of entry premium
-                        step=0.25,  # Tighter early trailing step
-                        activation=0.3,  # Earlier activation threshold
-                    )
-
-                    # We pass a lambda that returns the latest price from the bracket state
-                    ctrl = AdaptiveTrailingController(
-                        symbol=symbol,
-                        side="LONG" if side == "BUY" else "SHORT",
-                        entry=price,
-                        sl_order_id=state.virtual_sl_id,
-                        variety="virtual",
-                        spec=spec,
-                        get_ltp=lambda s: state.last_ltp,
-                        modify_order=self._virtual_modify_sl,
-                        atr_provider=self._atr_provider,
-                        journal=MockJournal(),
-                        atr_multiplier=trailing_atr_mult,
-                    )
-                    self._trailing_controllers[order_id] = ctrl
-                    LOGGER.info(
-                        f"🧠 Adaptive Controller Attached to {symbol} (Mult: {trailing_atr_mult}x)"
-                    )
-
-                except Exception as e:
-                    LOGGER.error(f"Failed to attach Adaptive Controller: {e}")
 
             trail_msg = f"| Trail={t_config.get('mode', 'None')}"
             LOGGER.info(
@@ -1859,22 +1819,9 @@ class BracketManager:
 
             # Check trailing controller (if attached)
             # Wrapped in try/except so trailing failures cannot block SL/TP eval
-            entry_id = bracket.entry_order_id
             trail_updated = False
             try:
-                if entry_id in self._trailing_controllers:
-                    ctrl = self._trailing_controllers[entry_id]
-
-                    # Inject ATR if available
-                    current_atr = self._current_atr.get(symbol)
-                    if current_atr and current_atr > 0 and hasattr(ctrl, "update_atr"):
-                        ctrl.update_atr(current_atr)
-
-                    # Run controller
-                    ctrl.on_tick({"ltp": ltp})
-                else:
-                    # Use built-in adaptive trailing
-                    trail_updated = self._apply_trailing_math(bracket)
+                trail_updated = self._apply_trailing_math(bracket)
             except Exception as _trail_exc:
                 LOGGER.debug(
                     "Trailing logic failed for %s: %s (SL/TP eval continues)",
@@ -2044,6 +1991,10 @@ class BracketManager:
                     "qty": bracket.remaining_quantity,
                     "reason": "HARD_TP_BREACH",
                 }
+
+        time_stop = self._time_stop_action(bracket, ltp)
+        if time_stop is not None:
+            return time_stop
 
         return None
 
@@ -2733,26 +2684,14 @@ class BracketManager:
             if ltp < bracket.lowest_ltp:
                 bracket.lowest_ltp = ltp
 
-        # B. Delegate to World-Class Controller (If attached)
-        if bracket.entry_order_id in self._trailing_controllers:
-            ctrl = self._trailing_controllers[bracket.entry_order_id]
-            # ✅ FIX: Inject dynamic ATR from feed
-            current_atr = self._current_atr.get(bracket.symbol)
-            if current_atr and hasattr(ctrl, "update_atr"):
-                ctrl.update_atr(current_atr)
-            # The controller calculates using ATR and calls _virtual_modify_sl if needed
-            # We updated bracket.last_ltp in on_tick, so controller reads fresh data
-            ctrl.on_tick(None)
-            return
-
-        # C. Fallback Legacy Logic
+        # B. Single trailing authority.
         self._apply_trailing_math(bracket)
 
     def _apply_trailing_math(self, bracket: BracketState) -> bool:
         """Apply adaptive trailing rules for the bracket.
 
         SYNC CONTRACT: this is the FALLBACK trailing path (runs only when the
-        AdaptiveTrailingController could not attach). It must uphold exactly
+        the single trailing authority for virtual brackets. It must uphold
         the invariants of the canonical authority
         HardenedBracketManager._virtual_modify_sl — under-lock compare-and-set,
         monotonic per side (BUY only raises, SELL only lowers), tick rounding,
@@ -2904,6 +2843,63 @@ class BracketManager:
                     return True
         return False
 
+    def _breakeven_cost_per_unit(self, bracket: BracketState) -> float:
+        """Round-trip cost of this position expressed in premium points/unit."""
+        entry = float(bracket.entry_price or 0.0)
+        qty = int(bracket.quantity or 0)
+        if entry <= 0 or qty <= 0 or estimate_round_trip_cost is None:
+            return 0.0
+        try:
+            costs = estimate_round_trip_cost(
+                entry_price=entry, exit_price=entry, quantity=abs(qty)
+            )
+            cost = float(costs.cost_per_unit)
+        except Exception:  # noqa: BLE001 - cost model must never break trailing
+            return 0.0
+        if not math.isfinite(cost) or cost <= 0:
+            return 0.0
+        # Never let an implausible cost estimate swallow the whole stop band.
+        return min(cost, entry * 0.02)
+
+    def _time_stop_action(
+        self, bracket: BracketState, ltp: float
+    ) -> dict[str, Any] | None:
+        """Flatten a stalled position before theta erodes it.
+
+        A long option that reaches neither stop nor target still loses extrinsic
+        value every minute, so "wait and see" is a negative-expectancy default.
+        The trade is closed once it has been held past LIFECYCLE_TIME_STOP_MIN
+        without ever reaching TIME_STOP_MIN_PROGRESS_R of its initial risk.
+        """
+        if self._time_stop_seconds <= 0 or bracket.remaining_quantity <= 0:
+            return None
+        opened_at = float(bracket.entry_fill_ts or 0.0)
+        if opened_at <= 0:
+            return None
+        held = time.time() - opened_at
+        if held < self._time_stop_seconds:
+            return None
+        entry = float(bracket.entry_price or 0.0)
+        initial_sl = float(bracket.initial_sl_trigger_price or bracket.sl_trigger_price or 0.0)
+        initial_risk = abs(entry - initial_sl)
+        if entry <= 0 or initial_risk <= 0:
+            return None
+        if bracket.side == "BUY":
+            mfe = float(bracket.highest_ltp or entry) - entry
+        else:
+            mfe = entry - float(bracket.lowest_ltp or entry)
+        if (mfe / initial_risk) >= self._time_stop_min_progress_r:
+            return None
+        return {
+            "decision": BracketTickDecision.EXIT_STOP.value,
+            "type": "TIME_STOP",
+            "price": ltp,
+            "qty": bracket.remaining_quantity,
+            "reason": (
+                f"TIME_STOP held={int(held)}s progress={mfe / initial_risk:.2f}R"
+            ),
+        }
+
     def _calculate_tiered_trailing_sl(
         self,
         bracket: BracketState,
@@ -2938,38 +2934,51 @@ class BracketManager:
         )
 
         # Use instance-cached thresholds (set at __init__) — not os.getenv on every tick.
-        tier1_threshold = self._trail_tier1_pct
-        tier2_threshold = self._trail_tier2_pct
-        tier3_threshold = self._trail_tier3_pct
-        tier4_threshold = self._trail_tier4_pct
+        # Canonical metric is R (open profit / initial risk); the premium-percent
+        # ladder is the fallback when initial risk is unknown.
+        profit_points = (ltp - entry) if bracket.side == "BUY" else (entry - ltp)
+        if initial_risk > 0:
+            tier_metric = profit_points / initial_risk
+            tier1_threshold = activation_r
+            tier2_threshold = self._trail_tier2_r
+            tier3_threshold = self._trail_tier3_r
+            tier4_threshold = self._trail_tier4_r
+        else:
+            tier_metric = profit_pct
+            tier1_threshold = self._trail_tier1_pct
+            tier2_threshold = self._trail_tier2_pct
+            tier3_threshold = self._trail_tier3_pct
+            tier4_threshold = self._trail_tier4_pct
 
         # ═══════════════════════════════════════════════════════════
         # TIER 0: NO PROFIT (< 1%) - Use original SL
         # ═══════════════════════════════════════════════════════════
-        if profit_pct < tier1_threshold:
+        if tier_metric < tier1_threshold:
             return None  # No change
 
         # ═══════════════════════════════════════════════════════════
         # TIER 1: SMALL PROFIT (1-2%) - BREAKEVEN LOCK
         # ═══════════════════════════════════════════════════════════
-        if tier1_threshold <= profit_pct < tier2_threshold:
-            if initial_risk <= 0 or mfe < (initial_risk * activation_r):
-                return None
-            # Lock at breakeven (entry price)
+        if tier1_threshold <= tier_metric < tier2_threshold:
+            # Lock at TRUE breakeven: exiting at the entry premium is a loss of
+            # the full round-trip cost, so the stop is offset by that cost.
+            cost = self._breakeven_cost_per_unit(bracket)
             if bracket.side == "BUY":
-                if entry > current_sl:
-                    LOGGER.debug(f"🔒 Tier 1: Breakeven lock at {entry:.2f}")
-                    return entry
+                level = entry + cost
+                if level > current_sl and level <= ltp - cost:
+                    LOGGER.debug(f"🔒 Tier 1: Cost-adjusted breakeven at {level:.2f}")
+                    return level
             else:
-                if entry < current_sl:
-                    LOGGER.debug(f"🔒 Tier 1: Breakeven lock at {entry:.2f}")
-                    return entry
+                level = entry - cost
+                if level < current_sl and level >= ltp + cost:
+                    LOGGER.debug(f"🔒 Tier 1: Cost-adjusted breakeven at {level:.2f}")
+                    return level
             return None
 
         # ═══════════════════════════════════════════════════════════
         # TIER 2: MODERATE PROFIT (2-4%) - PROTECT 40%
         # ═══════════════════════════════════════════════════════════
-        if tier2_threshold <= profit_pct < tier3_threshold:
+        if tier2_threshold <= tier_metric < tier3_threshold:
             protection_pct = 0.40
 
             if bracket.side == "BUY":
@@ -2986,7 +2995,7 @@ class BracketManager:
         # ═══════════════════════════════════════════════════════════
         # TIER 3: GOOD PROFIT (4-6%) - PROTECT 50% + ATR TRAIL
         # ═══════════════════════════════════════════════════════════
-        if tier3_threshold <= profit_pct < tier4_threshold:
+        if tier3_threshold <= tier_metric < tier4_threshold:
             protection_pct = 0.50
 
             # Calculate momentum-adjusted ATR multiplier
@@ -4363,10 +4372,6 @@ class BracketManager:
                     if not self._symbol_map[symbol]:
                         del self._symbol_map[symbol]
 
-                # Cleanup Controller
-                if entry_id in self._trailing_controllers:
-                    del self._trailing_controllers[entry_id]
-
                 # ✅ NEW: Cleanup Exit Cooldown
                 if entry_id in self._exit_cooldowns:
                     del self._exit_cooldowns[entry_id]
@@ -4404,7 +4409,6 @@ class BracketManager:
                 "active_brackets": len(self._brackets),
                 "symbols_managed": len(self._symbol_map),
                 "atr_tracked_symbols": len(self._current_atr),
-                "adaptive_controllers": len(self._trailing_controllers),
             }
 
     def _log_bracket_event(
@@ -4799,8 +4803,6 @@ class BracketManager:
             temp_brackets: Dict[str, BracketState] = {}
             temp_order_map: Dict[str, str] = {}
             temp_symbol_map: Dict[str, List[str]] = {}
-            temp_controllers: Dict[str, Any] = {}
-            controller_errors: list[str] = []
             for raw_entry_id, record in records.items():
                 entry_id = str(raw_entry_id).strip()
                 if not entry_id or not isinstance(record, Mapping):
@@ -4809,41 +4811,6 @@ class BracketManager:
                 temp_brackets[entry_id] = bracket
                 temp_order_map[entry_id] = entry_id
                 temp_symbol_map.setdefault(bracket.symbol, []).append(entry_id)
-                if bracket.trailing_enabled:
-                    try:
-                        if self._trailing_controller_factory is not None:
-                            temp_controllers[entry_id] = (
-                                self._trailing_controller_factory(bracket)
-                            )
-                        elif (
-                            bracket.trailing_config.get("mode") == "ATR"
-                            and self._atr_provider
-                            and AdaptiveTrailingController
-                        ):
-                            mult = float(
-                                bracket.trailing_config.get("mult", 1.5) or 1.5
-                            )
-                            spec = TrailingSpec(
-                                trail_by=20.0, step=0.25, activation=0.3
-                            )
-                            temp_controllers[entry_id] = AdaptiveTrailingController(
-                                symbol=bracket.symbol,
-                                side="LONG" if bracket.side == "BUY" else "SHORT",
-                                entry=bracket.entry_price,
-                                sl_order_id=bracket.virtual_sl_id,
-                                variety="virtual",
-                                spec=spec,
-                                get_ltp=lambda _symbol, _b=bracket: _b.last_ltp,
-                                modify_order=self._virtual_modify_sl,
-                                atr_provider=self._atr_provider,
-                                journal=MockJournal(),
-                                atr_multiplier=mult,
-                            )
-                    except Exception as exc:  # noqa: BLE001
-                        controller_errors.append(
-                            f"{entry_id}:{type(exc).__name__}:{exc}"
-                        )
-
             parsed_rescue = {
                 str(key): int(value) for key, value in rescue_attempts.items()
             }
@@ -4854,23 +4821,12 @@ class BracketManager:
                 self._brackets = temp_brackets
                 self._order_to_entry = temp_order_map
                 self._symbol_map = temp_symbol_map
-                self._trailing_controllers = temp_controllers
                 if hasattr(self, "_exit_rescue_attempts"):
                     self._exit_rescue_attempts = parsed_rescue
                 if hasattr(self, "_exit_order_open_since"):
                     self._exit_order_open_since = parsed_open_since
             self._clear_persistence_degraded()
             self._recovery_degraded_reason = None
-            if controller_errors:
-                self._recovery_degraded_reason = "trailing_controller_restore_failed"
-                LOGGER.critical(
-                    "BRACKET_TRAILING_RESTORE_DEGRADED errors=%s",
-                    controller_errors,
-                    extra={
-                        "event": "BRACKET_TRAILING_RESTORE_DEGRADED",
-                        "errors": controller_errors,
-                    },
-                )
             LOGGER.info(
                 "BRACKET_STATE_RESTORED count=%s path=%s",
                 len(temp_brackets),

--- a/src/nifty_scalper_bot/execution/hardened_bracket_manager.py
+++ b/src/nifty_scalper_bot/execution/hardened_bracket_manager.py
@@ -193,12 +193,6 @@ class HardenedBracketManager(_LegacyBracketManager):
                 bracket.escalated_at = None
                 bracket.last_exit_error = None
                 bracket.next_exit_attempt_at = None
-            controller = self._trailing_controllers.get(bracket.entry_order_id)
-            if controller is not None:
-                controller.current_sl = float(bracket.sl_trigger_price)
-                controller.entry_price = float(bracket.entry_price)
-                controller.highest_price = float(bracket.entry_price)
-                controller.lowest_price = float(bracket.entry_price)
 
     def confirm_entry_fill(self, order_id: str, fill_price: float) -> None:
         _LegacyBracketManager.confirm_entry_fill(self, order_id, fill_price)
@@ -206,12 +200,8 @@ class HardenedBracketManager(_LegacyBracketManager):
         if bracket is None:
             return
         with self._lock:
-            controller = self._trailing_controllers.get(order_id)
-            if controller is not None:
-                controller.entry_price = float(bracket.entry_price)
-                controller.current_sl = float(bracket.sl_trigger_price)
-                controller.highest_price = float(bracket.entry_price)
-                controller.lowest_price = float(bracket.entry_price)
+            bracket.highest_ltp = float(bracket.entry_price)
+            bracket.lowest_ltp = float(bracket.entry_price)
 
     def _virtual_modify_sl(self, order_id: str, price: float) -> bool:
         """Apply only finite, market-side, monotonic virtual stop updates."""

--- a/src/nifty_scalper_bot/execution/ledger_bracket_manager.py
+++ b/src/nifty_scalper_bot/execution/ledger_bracket_manager.py
@@ -421,6 +421,15 @@ class LedgerBracketManager(CanonicalBracketManager):
         else:
             mfe_points = max(0.0, high - entry)
             mae_points = max(0.0, entry - low)
+        initial_sl = float(
+            getattr(bracket, "initial_sl_trigger_price", None)
+            or getattr(bracket, "sl_trigger_price", 0.0)
+            or 0.0
+        )
+        # R-multiple normalisation: MAE/MFE in premium points cannot be compared
+        # across trades with different stop distances, so exit tuning needs them
+        # expressed in units of the risk actually taken.
+        initial_risk = abs(entry - initial_sl) if entry > 0 and initial_sl > 0 else 0.0
         closed_at = float(getattr(bracket, "closed_at", None) or time.time())
         opened_at = float(
             getattr(bracket, "entry_fill_ts", None)
@@ -541,6 +550,16 @@ class LedgerBracketManager(CanonicalBracketManager):
             "gross_pnl": gross_pnl,
             "estimated_costs": asdict(costs) if costs is not None else None,
             "net_pnl": net_pnl,
+            "initial_risk_points": (
+                round(initial_risk, 4) if initial_risk > 0 else None
+            ),
+            "r_multiple": (
+                round(float(net_pnl) / (initial_risk * quantity), 4)
+                if initial_risk > 0 and quantity > 0 and net_pnl is not None
+                else None
+            ),
+            "mfe_r": round(mfe_points / initial_risk, 4) if initial_risk > 0 else None,
+            "mae_r": round(mae_points / initial_risk, 4) if initial_risk > 0 else None,
             "mfe_points": round(mfe_points, 4),
             "mae_points": round(mae_points, 4),
             "mfe_pnl": round(mfe_points * quantity, 2),

--- a/tests/execution/test_bracket_manager_reliability.py
+++ b/tests/execution/test_bracket_manager_reliability.py
@@ -173,17 +173,19 @@ def test_trail_update_does_not_exit_same_tick_regression() -> None:
     assert bracket is not None
     bracket.trailing_config["breakeven_activation_r"] = 0.20
 
-    manager.on_tick("NFO:NIFTY24100CE", 71.65, exchange_ts=1_000.0)
+    # Breakeven is cost-adjusted: exiting at the entry premium is a loss of the
+    # full round-trip charge, so the lock sits at entry + cost_per_unit (~0.89).
+    manager.on_tick("NFO:NIFTY24100CE", 72.60, exchange_ts=1_000.0)
 
-    assert bracket.sl_trigger_price == 70.80
+    assert bracket.sl_trigger_price == 71.70
     assert bracket.exit_pending is False
     assert order_manager.place_order.call_count == 0
 
-    manager.on_tick("NFO:NIFTY24100CE", 71.40, exchange_ts=1_001.0)
+    manager.on_tick("NFO:NIFTY24100CE", 72.30, exchange_ts=1_001.0)
     assert bracket.exit_pending is False
     assert order_manager.place_order.call_count == 0
 
-    manager.on_tick("NFO:NIFTY24100CE", 70.75, exchange_ts=1_002.0)
+    manager.on_tick("NFO:NIFTY24100CE", 71.65, exchange_ts=1_002.0)
     assert "SL" in str(bracket.exit_reason or "")
     assert order_manager.place_order.call_count == 1
 
@@ -206,10 +208,10 @@ def test_duplicate_same_tick_has_one_trail_update_and_no_exit() -> None:
     assert bracket is not None
     bracket.trailing_config["breakeven_activation_r"] = 0.20
 
-    manager.on_tick("NFO:NIFTY24100CE", 71.65, exchange_ts=2_000.0)
-    manager.on_tick("NFO:NIFTY24100CE", 71.65, exchange_ts=2_000.0)
+    manager.on_tick("NFO:NIFTY24100CE", 72.60, exchange_ts=2_000.0)
+    manager.on_tick("NFO:NIFTY24100CE", 72.60, exchange_ts=2_000.0)
 
-    assert bracket.sl_trigger_price == 70.80
+    assert bracket.sl_trigger_price == 71.70
     assert bracket.trail_revision == 1
     assert order_manager.place_order.call_count == 0
 
@@ -362,10 +364,10 @@ def test_timestampless_duplicate_callback_has_one_trail_revision_and_notificatio
     assert bracket is not None
     bracket.trailing_config["breakeven_activation_r"] = 0.20
 
-    manager.process_exit_checks("NFO:NIFTYNOTSCE", 71.65)
-    manager.process_exit_checks("NFO:NIFTYNOTSCE", 71.65)
+    manager.process_exit_checks("NFO:NIFTYNOTSCE", 72.60)
+    manager.process_exit_checks("NFO:NIFTYNOTSCE", 72.60)
 
-    assert bracket.sl_trigger_price == 70.80
+    assert bracket.sl_trigger_price == 71.70
     assert bracket.trail_revision == 1
     assert [event for event, _ in notifications].count("BRACKET_TRAIL_UPDATED") <= 1
     assert order_manager.place_order.call_count == 0
@@ -449,3 +451,173 @@ def test_active_selection_drift_path_leaves_open_bracket_untouched(caplog) -> No
     assert bracket.tp_trigger_price == 120.0
     assert bracket.remaining_quantity == 65
     assert order_manager.place_order.call_count == 0
+
+
+def test_time_stop_flattens_a_stalled_position(monkeypatch) -> None:
+    """A long option that reaches neither stop nor target still bleeds theta,
+    so a stalled trade must be flattened once past the time stop."""
+    import time as _time
+
+    order_manager = Mock()
+    order_manager.place_order.return_value = "exit-ts"
+    monkeypatch.setenv("LIFECYCLE_TIME_STOP_MIN", "12")
+    manager = BracketManager(order_manager=order_manager)
+    manager.register_virtual_bracket(
+        "stall-1",
+        "NFO:NIFTYSTALLCE",
+        "BUY",
+        65,
+        100.0,
+        95.0,
+        115.0,
+        activate_immediately=True,
+    )
+    bracket = manager.get_bracket("stall-1")
+    assert bracket is not None
+    bracket.entry_fill_ts = _time.time() - 800.0  # held > 12 min
+
+    action = manager._time_stop_action(bracket, 101.0)
+    assert action is not None
+    assert action["type"] == "TIME_STOP"
+    assert action["qty"] == bracket.remaining_quantity
+
+
+def test_time_stop_spares_a_position_that_made_progress() -> None:
+    import time as _time
+
+    order_manager = Mock()
+    manager = BracketManager(order_manager=order_manager)
+    manager.register_virtual_bracket(
+        "moving-1",
+        "NFO:NIFTYMOVECE",
+        "BUY",
+        65,
+        100.0,
+        95.0,
+        115.0,
+        activate_immediately=True,
+    )
+    bracket = manager.get_bracket("moving-1")
+    assert bracket is not None
+    bracket.entry_fill_ts = _time.time() - 800.0
+    bracket.highest_ltp = 104.0  # 0.8R of progress, above the 0.5R floor
+
+    assert manager._time_stop_action(bracket, 103.0) is None
+
+
+def test_time_stop_is_inert_before_the_holding_window() -> None:
+    import time as _time
+
+    manager = BracketManager(order_manager=Mock())
+    manager.register_virtual_bracket(
+        "fresh-1",
+        "NFO:NIFTYFRESHCE",
+        "BUY",
+        65,
+        100.0,
+        95.0,
+        115.0,
+        activate_immediately=True,
+    )
+    bracket = manager.get_bracket("fresh-1")
+    assert bracket is not None
+    bracket.entry_fill_ts = _time.time() - 10.0
+
+    assert manager._time_stop_action(bracket, 101.0) is None
+
+
+def test_breakeven_lock_clears_round_trip_cost() -> None:
+    """Locking at the raw entry premium books a guaranteed loss of the full
+    round-trip charge; the lock must sit above it."""
+    manager = BracketManager(order_manager=Mock())
+    manager.register_virtual_bracket(
+        "be-1",
+        "NFO:NIFTYBECE",
+        "BUY",
+        65,
+        70.80,
+        66.60,
+        78.25,
+        activate_immediately=True,
+    )
+    bracket = manager.get_bracket("be-1")
+    assert bracket is not None
+    bracket.trailing_config["breakeven_activation_r"] = 0.20
+
+    cost = manager._breakeven_cost_per_unit(bracket)
+    assert cost > 0.0
+
+    manager.on_tick("NFO:NIFTYBECE", 72.60)
+    assert bracket.sl_trigger_price > 70.80
+    assert bracket.sl_trigger_price >= 70.80 + cost - 0.05
+
+
+def test_trailing_tiers_are_keyed_to_r_not_premium_percent() -> None:
+    """Identical premium moves on different stop distances must not receive
+    identical protection — the tier ladder is denominated in R."""
+    manager = BracketManager(order_manager=Mock())
+    manager.register_virtual_bracket(
+        "wide-1", "NFO:NIFTYWIDECE", "BUY", 65, 100.0, 80.0, 160.0,
+        activate_immediately=True,
+    )
+    manager.register_virtual_bracket(
+        "tight-1", "NFO:NIFTYTIGHTCE", "BUY", 65, 100.0, 98.0, 106.0,
+        activate_immediately=True,
+    )
+    wide = manager.get_bracket("wide-1")
+    tight = manager.get_bracket("tight-1")
+    assert wide is not None and tight is not None
+
+    # Same +4% premium move: 0.2R on the wide stop, 2.0R on the tight one.
+    wide.highest_ltp = tight.highest_ltp = 104.0
+    wide_sl = manager._calculate_tiered_trailing_sl(
+        bracket=wide, ltp=104.0, profit_pct=4.0, high_water=104.0, atr=2.0
+    )
+    tight_sl = manager._calculate_tiered_trailing_sl(
+        bracket=tight, ltp=104.0, profit_pct=4.0, high_water=104.0, atr=2.0
+    )
+    assert wide_sl is None, "0.2R must not trigger any protection tier"
+    assert tight_sl is not None and tight_sl > 100.0
+
+
+def test_completed_trade_outcome_reports_r_normalised_excursions() -> None:
+    """Premium-point MAE/MFE cannot be compared across trades with different
+    stop distances, so the outcome record carries R-normalised values."""
+    from types import SimpleNamespace
+
+    manager = BracketManager(order_manager=Mock())
+    bracket = SimpleNamespace(
+        bracket_id="r-1",
+        entry_order_id="r-1",
+        trade_lifecycle_id="r-1",
+        symbol="NFO:NIFTYRCE",
+        side="BUY",
+        quantity=65,
+        entry_price=100.0,
+        entry_fill_price=100.0,
+        initial_sl_trigger_price=96.0,
+        sl_trigger_price=96.0,
+        highest_ltp=108.0,
+        lowest_ltp=98.0,
+        close_source="broker_fill",
+        exit_reason="TP",
+        trade_provenance={},
+        closed_at=None,
+        entry_fill_ts=None,
+        created_at=None,
+        tag="",
+    )
+
+    outcome = manager._completed_trade_outcome(
+        bracket,
+        ledger_pnl=None,
+        gross_pnl=520.0,
+        exit_price=108.0,
+        ledger_complete=True,
+    )
+
+    assert outcome["initial_risk_points"] == 4.0
+    assert outcome["mfe_r"] == 2.0
+    assert outcome["mae_r"] == 0.5
+    assert outcome["r_multiple"] is not None
+    assert outcome["r_multiple"] < 2.0  # net of costs

--- a/tests/execution/test_execution_safety_audit_fixes.py
+++ b/tests/execution/test_execution_safety_audit_fixes.py
@@ -1176,14 +1176,13 @@ def test_bracket_tp1_partial_fires_once_on_live_class(monkeypatch, tmp_path) -> 
         bm._running = False
 
 
-def test_fill_reanchor_and_controller_trailing_on_executed_range(
+def test_fill_reanchor_and_canonical_trailing_on_executed_range(
     monkeypatch, tmp_path
 ) -> None:
     """Signal->executed coordination on the live class: a slipped broker fill
-    must re-anchor entry/SL/TP1 to the executed range (tick-rounded), sync the
-    adaptive controller's anchor, and controller-path trailing must ratchet on
-    a rally even with degraded/unavailable ATR (the old absolute 20.0-point
-    fallback trail distance left trailing silently dead on option premiums)."""
+    must re-anchor entry/SL/TP1 to the executed range (tick-rounded) along with
+    the bracket watermarks, and the single canonical trailing authority must
+    ratchet on a rally even with degraded/unavailable ATR."""
     monkeypatch.setenv("DATA_DIR", str(tmp_path))
 
     class _OM:
@@ -1214,9 +1213,6 @@ def test_fill_reanchor_and_controller_trailing_on_executed_range(
             activate_immediately=False,
             trailing_atr_mult=1.5,
         )
-        controller = bm._trailing_controllers.get("ex-1")
-        assert controller is not None, "adaptive controller must attach"
-
         bm.confirm_entry_fill("ex-1", 146.00)  # +0.85 slippage vs signal
         bracket = bm.get_bracket("ex-1")
 
@@ -1225,11 +1221,10 @@ def test_fill_reanchor_and_controller_trailing_on_executed_range(
         assert bracket.entry_fill_price == 146.00
         assert bracket.sl_trigger_price > 143.15
         assert round(bracket.sl_trigger_price / 0.05, 6) % 1 == 0
-        # Controller anchor synced to executed range.
-        assert float(controller.entry_price) == 146.00
-        assert float(controller.current_sl) == bracket.sl_trigger_price
+        # Watermarks re-anchored to the executed range.
+        assert float(bracket.highest_ltp) == 146.00
 
-        # Controller-path trailing ratchets on a rally despite degraded ATR.
+        # Canonical trailing ratchets on a rally despite degraded ATR.
         sl_path = []
         for px in (147.0, 149.0, 151.0, 153.0, 151.5, 155.0):
             bm.on_tick(sym, px)

--- a/tests/execution/test_live_exit_hardening.py
+++ b/tests/execution/test_live_exit_hardening.py
@@ -107,17 +107,6 @@ class _OrderManager:
         self.last_skip_reason = reason
 
 
-class _DummyController:
-    def __init__(self) -> None:
-        self.entry_price = 0.0
-        self.current_sl = 0.0
-        self.highest_price = 0.0
-        self.lowest_price = 0.0
-
-    def on_tick(self, _tick: Any) -> None:
-        return None
-
-
 def _manager(
     *, cancel_confirms: bool = True
 ) -> tuple[BracketManager, _OrderManager, _Broker]:
@@ -260,14 +249,15 @@ def test_virtual_trailing_stop_is_monotonic_and_stays_below_market_for_long() ->
     assert bracket.sl_trigger_price == 150.05
 
 
-def test_actual_fill_resynchronizes_attached_trailing_controller() -> None:
+def test_actual_fill_resynchronizes_trailing_watermarks() -> None:
+    """Trailing has one authority (the tiered bracket math), so an actual fill
+    must re-anchor the bracket's own watermarks — there is no second controller
+    holding a stale entry anchor."""
     broker = _Broker()
     order_manager = _OrderManager(broker)
     manager = BracketManager(order_manager=order_manager)
     manager._running = False
     manager._watchdog_thread.join(timeout=1.0)
-    controller = _DummyController()
-    manager.attach_trailing_controller_factory(lambda _state: controller)
     manager.register_virtual_bracket(
         order_id="entry-fill",
         symbol=SYMBOL,
@@ -282,10 +272,9 @@ def test_actual_fill_resynchronizes_attached_trailing_controller() -> None:
     manager.confirm_entry_fill("entry-fill", 102.0)
     bracket = manager.get_bracket("entry-fill")
     assert bracket is not None
-    assert controller.entry_price == bracket.entry_price == 102.0
-    assert controller.current_sl == bracket.sl_trigger_price
-    assert controller.highest_price == 102.0
-    assert controller.lowest_price == 102.0
+    assert bracket.entry_price == 102.0
+    assert bracket.highest_ltp == 102.0
+    assert bracket.lowest_ltp == 102.0
 
 
 @dataclass


### PR DESCRIPTION
Single chained concern: make the exit path deterministic and cost-aware. Net -210/+331 lines, ~130 of which are deletions of a duplicate control path.

## 1. Removed the second trailing authority (the core ambiguity)

`_process_trailing_logic()` chose between two structurally different policies depending on whether `trailing_atr_mult and self._atr_provider and AdaptiveTrailingController` all happened to be truthy at registration: an ATR-chandelier trail off the high-water mark, or the tiered MFE-protection ladder. The same setup could exit under either rulebook, which makes measured expectancy unattributable. The state-restore path made it worse — it rebuilt controllers with a hardcoded `trail_by=20.0` (~13% of a Rs 150 premium), so a restored bracket trailed differently from a fresh one.

Excised from the bracket layer: auto-attach block, `attach_trailing_controller_factory` (**zero** production callers — kept alive only by one test), `_trailing_controllers` dict, both delegation sites, cleanup site, stats field, restore-path construction, and the `controller_errors` degraded-recovery branch. Also the two controller-resync blocks in `hardened_bracket_manager.py`, replaced with direct bracket watermark re-anchoring on fill.

The tiered ladder is now the sole authority, and the `_apply_trailing_math` docstring no longer carries a "must be mirrored in the other implementation" maintenance contract. `adaptive_trailing*` is untouched — `order_manager_core.py:1737` still uses it for real broker SL orders, a different context.

## 2. Tiers keyed to R, not premium percent

Tiers fired at 1/2/4/6% of premium while SL distance is ATR-derived, so a 2% move was 0.2R on a wide stop and 1.2R on a tight one — identical protection for very different risk. `tier_metric = profit_points / initial_risk`; percent ladder retained only as fallback when initial risk is unknown. New `TRAIL_TIER2_R/3_R/4_R` (1.0/2.0/3.0). Collapsed a duplicate knob: tier 1's threshold *is* `breakeven_activation_r`, so `TRAIL_TIER1_R` and the redundant inner `mfe >= initial_risk * activation_r` gate are gone.

## 3. Cost-adjusted breakeven

Tier 1 returned raw `entry` — a guaranteed loss of the round-trip charge (Rs 58, or 0.89 premium points at 70.80 x 65). Now `entry +/- cost_per_unit` via the existing `estimate_round_trip_cost`, capped at 2% of entry, and applied only with a further cost-width of room below price so the lock is not a hair-trigger.

## 4. Time stop (was configured but had no consumer)

`LIFECYCLE_TIME_STOP_MIN=12` existed in settings and was validated by `lifecycle_validator`, but the only consumer was the legacy `bot/components.py` path. A long option that reaches neither stop nor target still bleeds theta. `_time_stop_action()` runs last (SL/TP always win) and flattens a position held past the window that never reached `TIME_STOP_MIN_PROGRESS_R` (default 0.5R).

## 5. R-normalised exit telemetry

MAE/MFE/slippage were already captured. Added `initial_risk_points`, `r_multiple`, `mfe_r`, `mae_r` so excursions are comparable across trades with different stop distances — this is what tier and time-stop calibration will be measured against.

## Tests

8 added. Time stop fires / spares a trade with progress / inert before the window; breakeven clears round-trip cost; R-vs-percent tiers (same +4% move, wide vs tight stop, must not get identical protection); R-normalised outcome record. 5 pre-existing tests asserted the old semantics and were rewritten against the new contract rather than the code being weakened.

`compileall` clean. Full suite: **2380 passed, 2 skipped**.

## Deliberately not in this PR

Bid-side SL triggering, Wilder-ATR profile validation, and regime-adaptive RR selection all need a live session measured against the new R telemetry before they can be tuned honestly.