### PR TITLE
fix(exit): enforce canonical net-profit trailing floor

### DIFF
--- a/src/nifty_scalper_bot/execution/runtime_bracket_manager.py
+++ b/src/nifty_scalper_bot/execution/runtime_bracket_manager.py
@@ -7,6 +7,7 @@ lose functionality when broker fill identity is intentionally absent.
 
 from __future__ import annotations
 
+import math
 import os
 import time
 from contextlib import suppress
@@ -18,6 +19,108 @@ from nifty_scalper_bot.execution.ledger_bracket_manager import LedgerBracketMana
 
 class RuntimeBracketManager(LedgerBracketManager):
     """Final runtime export for the staged lifecycle implementation."""
+
+    def _minimum_locked_profit_r(self) -> float:
+        """Return the cached post-activation net-profit floor in initial-risk units."""
+        cached = getattr(self, "_trail_min_locked_profit_r", None)
+        if cached is not None:
+            return float(cached)
+        try:
+            value = float(os.getenv("TRAIL_MIN_LOCKED_PROFIT_R", "0.10"))
+        except (TypeError, ValueError):
+            value = 0.10
+        value = value if math.isfinite(value) else 0.10
+        self._trail_min_locked_profit_r = max(0.0, value)
+        return self._trail_min_locked_profit_r
+
+    def _calculate_tiered_trailing_sl(
+        self,
+        bracket: Any,
+        ltp: float,
+        profit_pct: float,
+        high_water: float,
+        atr: float,
+    ) -> float | None:
+        """Delegate to the canonical ladder, then enforce one net-profit invariant.
+
+        The inherited core ladder is the only tier implementation. This override
+        corrects its Tier-4 dimensional comparison by supplying the canonical
+        R-metric only for that legacy percentage check, then floors the single
+        returned candidate at round-trip costs plus ``TRAIL_MIN_LOCKED_PROFIT_R``.
+        """
+        entry = float(getattr(bracket, "entry_price", 0.0) or 0.0)
+        current_sl = float(getattr(bracket, "sl_trigger_price", 0.0) or 0.0)
+        initial_sl = float(
+            getattr(bracket, "initial_sl_trigger_price", 0.0) or current_sl
+        )
+        initial_risk = abs(entry - initial_sl)
+        side = str(getattr(bracket, "side", "") or "").upper()
+        profit_points = (ltp - entry) if side == "BUY" else (entry - ltp)
+        tier_metric = (profit_points / initial_risk) if initial_risk > 0 else None
+
+        corrected_profit_pct = float(profit_pct)
+        if tier_metric is not None and tier_metric >= float(self._trail_tier4_r):
+            # bracket_core's final legacy guard compares profit_pct with an R
+            # threshold. Supplying the already-computed R value fixes only that
+            # dimensional mismatch; all tier calculations still live in super().
+            corrected_profit_pct = max(corrected_profit_pct, tier_metric)
+
+        candidate = super()._calculate_tiered_trailing_sl(
+            bracket=bracket,
+            ltp=ltp,
+            profit_pct=corrected_profit_pct,
+            high_water=high_water,
+            atr=atr,
+        )
+        if candidate is None or initial_risk <= 0 or tier_metric is None:
+            return candidate
+
+        activation_r = float(self._trail_activation_r(bracket))
+        if tier_metric < activation_r:
+            return candidate
+
+        cost_points = max(0.0, float(self._breakeven_cost_per_unit(bracket)))
+        locked_r = self._minimum_locked_profit_r()
+        locked_points = cost_points + (initial_risk * locked_r)
+        room = max(cost_points, 0.05)
+
+        if side == "BUY":
+            floor = entry + locked_points
+            proposed = max(float(candidate), floor)
+            if proposed >= (float(ltp) - room):
+                return None
+        else:
+            floor = entry - locked_points
+            proposed = min(float(candidate), floor)
+            if proposed <= (float(ltp) + room):
+                return None
+
+        if proposed != float(candidate):
+            _legacy.LOGGER.info(
+                "TRAIL_MIN_PROFIT_FLOOR_APPLIED symbol=%s side=%s tier_metric_r=%.3f locked_r=%.3f cost_points=%.3f candidate_sl=%.2f floored_sl=%.2f ltp=%.2f",
+                getattr(bracket, "symbol", ""),
+                side,
+                tier_metric,
+                locked_r,
+                cost_points,
+                float(candidate),
+                proposed,
+                float(ltp),
+                extra={
+                    "event": "TRAIL_MIN_PROFIT_FLOOR_APPLIED",
+                    "symbol": getattr(bracket, "symbol", ""),
+                    "side": side,
+                    "initial_risk_points": initial_risk,
+                    "tier_metric_r": tier_metric,
+                    "minimum_locked_profit_r": locked_r,
+                    "minimum_locked_profit_points": initial_risk * locked_r,
+                    "estimated_cost_points": cost_points,
+                    "candidate_sl": float(candidate),
+                    "applied_sl": proposed,
+                    "ltp": float(ltp),
+                },
+            )
+        return proposed
 
     def _block_ledger_release(
         self,

--- a/src/nifty_scalper_bot/execution/runtime_bracket_manager.py
+++ b/src/nifty_scalper_bot/execution/runtime_bracket_manager.py
@@ -80,7 +80,11 @@ class RuntimeBracketManager(LedgerBracketManager):
             return candidate
 
         cost_points = max(0.0, float(self._breakeven_cost_per_unit(bracket)))
-        locked_r = self._minimum_locked_profit_r()
+        # The positive-profit floor starts only after the canonical 0.75R
+        # progress threshold. Strategies that deliberately arm cost-adjusted
+        # breakeven earlier retain that established behaviour without installing
+        # a noise-sensitive positive-profit stop before meaningful progress.
+        locked_r = self._minimum_locked_profit_r() if tier_metric >= 0.75 else 0.0
         locked_points = cost_points + (initial_risk * locked_r)
         room = max(cost_points, 0.05)
 

--- a/tests/execution/test_runtime_trailing_profit_floor.py
+++ b/tests/execution/test_runtime_trailing_profit_floor.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from nifty_scalper_bot.execution.runtime_bracket_manager import RuntimeBracketManager
+
+
+def _manager(monkeypatch, *, cost_points: float = 1.0) -> RuntimeBracketManager:
+    monkeypatch.setenv("TRAIL_MIN_LOCKED_PROFIT_R", "0.10")
+    manager = object.__new__(RuntimeBracketManager)
+    manager._trail_tier1_pct = 1.0
+    manager._trail_tier2_pct = 2.0
+    manager._trail_tier3_pct = 4.0
+    manager._trail_tier4_pct = 6.0
+    manager._trail_tier2_r = 1.0
+    manager._trail_tier3_r = 2.0
+    manager._trail_tier4_r = 3.0
+    manager._calculate_momentum = lambda _symbol: 0.0
+    manager._breakeven_cost_per_unit = lambda _bracket: cost_points
+    manager._trail_activation_r = lambda _bracket: 0.75
+    return manager
+
+
+def _bracket(*, side: str, entry: float, sl: float, high: float, low: float):
+    return SimpleNamespace(
+        symbol="NFO:NIFTYTEST",
+        side=side,
+        entry_price=entry,
+        sl_trigger_price=sl,
+        initial_sl_trigger_price=sl,
+        highest_ltp=high,
+        lowest_ltp=low,
+        trailing_config={},
+        quantity=65,
+    )
+
+
+def test_buy_tier1_locks_cost_plus_point_one_r(monkeypatch) -> None:
+    manager = _manager(monkeypatch, cost_points=1.0)
+    bracket = _bracket(side="BUY", entry=100.0, sl=90.0, high=108.0, low=100.0)
+
+    candidate = manager._calculate_tiered_trailing_sl(
+        bracket=bracket,
+        ltp=108.0,
+        profit_pct=8.0,
+        high_water=108.0,
+        atr=0.0,
+    )
+
+    assert candidate == pytest.approx(102.0)
+
+
+def test_sell_tier1_locks_cost_plus_point_one_r(monkeypatch) -> None:
+    manager = _manager(monkeypatch, cost_points=1.0)
+    bracket = _bracket(side="SELL", entry=100.0, sl=110.0, high=100.0, low=92.0)
+
+    candidate = manager._calculate_tiered_trailing_sl(
+        bracket=bracket,
+        ltp=92.0,
+        profit_pct=8.0,
+        high_water=92.0,
+        atr=0.0,
+    )
+
+    assert candidate == pytest.approx(98.0)
+
+
+def test_tier4_uses_r_metric_not_premium_percentage(monkeypatch) -> None:
+    manager = _manager(monkeypatch, cost_points=0.0)
+    bracket = _bracket(
+        side="BUY",
+        entry=1000.0,
+        sl=995.0,
+        high=1015.0,
+        low=1000.0,
+    )
+
+    candidate = manager._calculate_tiered_trailing_sl(
+        bracket=bracket,
+        ltp=1015.0,
+        profit_pct=1.5,
+        high_water=1015.0,
+        atr=0.0,
+    )
+
+    assert candidate == pytest.approx(1009.0)
+
+
+def test_floor_is_not_installed_before_activation(monkeypatch) -> None:
+    manager = _manager(monkeypatch, cost_points=1.0)
+    bracket = _bracket(side="BUY", entry=100.0, sl=90.0, high=107.0, low=100.0)
+
+    candidate = manager._calculate_tiered_trailing_sl(
+        bracket=bracket,
+        ltp=107.0,
+        profit_pct=7.0,
+        high_water=107.0,
+        atr=0.0,
+    )
+
+    assert candidate is None
+
+
+def test_floor_is_rejected_when_execution_room_is_insufficient(monkeypatch) -> None:
+    manager = _manager(monkeypatch, cost_points=4.0)
+    bracket = _bracket(side="BUY", entry=100.0, sl=90.0, high=108.0, low=100.0)
+
+    candidate = manager._calculate_tiered_trailing_sl(
+        bracket=bracket,
+        ltp=108.0,
+        profit_pct=8.0,
+        high_water=108.0,
+        atr=0.0,
+    )
+
+    assert candidate is None


### PR DESCRIPTION
Focused runtime correction for the single exported bracket authority.

- Delegate to the inherited canonical trailing ladder; no copied ladder or second controller.
- Correct the Tier-4 dimensional mismatch by using R only for the legacy final guard.
- Enforce one configurable `TRAIL_MIN_LOCKED_PROFIT_R` floor (default 0.10R) after activation.
- Add estimated round-trip cost separately to the locked-profit floor.
- Reject a floor when insufficient executable-price room remains.
- Preserve initial-risk-unavailable percentage fallback and monotonic stop validation.
- Add focused BUY, SELL, Tier-4, pre-activation, and insufficient-room regressions.

Do not merge until CI is green and the two-file diff is reviewed.