### PR TITLE
fix(exit): tier-4 R comparison, canonical net-profit floor, executable-side stop trigger

### DIFF
--- a/src/nifty_scalper_bot/execution/bracket_core.py
+++ b/src/nifty_scalper_bot/execution/bracket_core.py
@@ -66,6 +66,8 @@ from nifty_scalper_bot.execution.position_snapshot import (
     decode_position_snapshot,
 )
 
+from nifty_scalper_bot.execution.readiness import resolve_quote_bid_ask_spread
+
 try:
     from nifty_scalper_bot.risk.cost_model import estimate_round_trip_cost
 except ImportError:  # pragma: no cover - cost model is always present in prod
@@ -542,6 +544,12 @@ class BracketManager:
         if SafeATRProvider and indicator_engine:
             self._atr_provider = SafeATRProvider(indicator_engine, max_cache_age=60.0)
         self._recent_ticks: Dict[str, deque] = {}
+        # symbol -> (bid, ask, captured_at). Stop breach must be judged on the
+        # side the position is actually liquidated into, not on LTP.
+        self._exit_quotes: Dict[str, tuple[float, float, float]] = {}
+        self._exit_quote_max_age = max(
+            0.0, parse_float_env(os.getenv("EXIT_QUOTE_MAX_AGE_SEC"), 3.0)
+        )
         self._max_tick_history = 20
         self._orphan_retry_count: Dict[str, int] = {}
         self._orphan_retry_last_attempt: Dict[str, float] = {}
@@ -1904,6 +1912,37 @@ class BracketManager:
             )
             self._fire_exits_batch(exits_to_fire)
 
+    def _capture_exit_quote(self, symbol: str, tick: Mapping[str, Any]) -> None:
+        """Cache the executable bid/ask for a symbol from a full tick."""
+        try:
+            bid, ask, _spread, source = resolve_quote_bid_ask_spread(tick)
+        except Exception:  # noqa: BLE001 - a malformed tick must not stop exits
+            return
+        if source == "missing" or not bid or not ask or bid <= 0 or ask < bid:
+            return
+        self._exit_quotes[symbol] = (float(bid), float(ask), time.time())
+
+    def _executable_exit_price(
+        self, bracket: BracketState, ltp: float
+    ) -> tuple[float, str]:
+        """Return the price this position would actually be liquidated at.
+
+        A long option is sold into the bid, a short is bought back at the ask.
+        When LTP still reads above the stop but the bid has already crossed it,
+        the position is executable below the stop and protection must fire.
+        LTP remains the fallback while depth is momentarily absent.
+        """
+        quote = self._exit_quotes.get(bracket.symbol)
+        if quote is None:
+            return float(ltp), "ltp"
+        bid, ask, captured_at = quote
+        if (time.time() - captured_at) > self._exit_quote_max_age:
+            return float(ltp), "ltp_stale_quote"
+        price = bid if bracket.side == "BUY" else ask
+        if price <= 0:
+            return float(ltp), "ltp"
+        return float(price), "bid" if bracket.side == "BUY" else "ask"
+
     def _sl_crossed(self, bracket: BracketState, ltp: float) -> bool:
         """Return True when a tick crosses stop-loss. Args: bracket, ltp; Returns: bool; Raises: none."""
         prev_ltp = float(bracket.previous_ltp or bracket.last_ltp or ltp)
@@ -1933,14 +1972,15 @@ class BracketManager:
         # current-tick trailing calculation.
         if sl_to_check > 0:
             prev_ltp = float(bracket.previous_ltp or bracket.entry_price or ltp)
+            exit_px, exit_src = self._executable_exit_price(bracket, ltp)
             triggered = False
             if bracket.side == "BUY":
-                crossed = prev_ltp > sl_to_check and ltp <= sl_to_check
-                breached = ltp <= sl_to_check
+                crossed = prev_ltp > sl_to_check and exit_px <= sl_to_check
+                breached = exit_px <= sl_to_check
                 triggered = crossed or breached
             elif bracket.side == "SELL":
-                crossed = prev_ltp < sl_to_check and ltp >= sl_to_check
-                breached = ltp >= sl_to_check
+                crossed = prev_ltp < sl_to_check and exit_px >= sl_to_check
+                breached = exit_px >= sl_to_check
                 triggered = crossed or breached
 
             if triggered:
@@ -1951,7 +1991,11 @@ class BracketManager:
                     "qty": bracket.remaining_quantity,
                     "old_sl": sl_to_check,
                     "new_sl": bracket.sl_trigger_price,
-                    "reason": f"HARD_SL_BREACH prev={prev_ltp:.2f} curr={ltp:.2f} sl={sl_to_check:.2f}",
+                    "trigger_price_source": exit_src,
+                    "reason": (
+                        f"HARD_SL_BREACH prev={prev_ltp:.2f} curr={exit_px:.2f} "
+                        f"src={exit_src} sl={sl_to_check:.2f}"
+                    ),
                 }
 
         # Check partial targets (TP1, TP2, etc.)
@@ -2663,6 +2707,7 @@ class BracketManager:
             if not symbol or not isinstance(ltp, (int, float)):
                 return
             exchange_ts = tick_exchange_epoch(tick)
+            self._capture_exit_quote(normalize_symbol(symbol), tick)
             self.on_tick(symbol, float(ltp), exchange_ts)
         except Exception as e:
             LOGGER.error("Failure in BracketManager.on_tick_event: %s", e)
@@ -2762,6 +2807,10 @@ class BracketManager:
             atr=atr,
         )
 
+        if new_sl is None:
+            return False
+
+        new_sl = self._apply_min_profit_floor(bracket, new_sl, ltp)
         if new_sl is None:
             return False
 
@@ -2900,6 +2949,50 @@ class BracketManager:
             ),
         }
 
+    def _min_locked_profit_r(self) -> float:
+        """Post-activation net-profit floor, in units of initial risk."""
+        cached = getattr(self, "_trail_min_locked_profit_r", None)
+        if cached is None:
+            cached = max(
+                0.0, parse_float_env(os.getenv("TRAIL_MIN_LOCKED_PROFIT_R"), 0.10)
+            )
+            self._trail_min_locked_profit_r = cached
+        return float(cached)
+
+    def _apply_min_profit_floor(
+        self, bracket: BracketState, candidate: float, ltp: float
+    ) -> float | None:
+        """Raise a trail candidate to clear costs plus a minimum locked profit.
+
+        Once the trade has earned its activation progress, a stop that merely
+        scratches is not worth holding: the floor is round-trip costs plus
+        TRAIL_MIN_LOCKED_PROFIT_R of initial risk. Returns None when the floor
+        cannot be placed with room below price (it would be a hair-trigger).
+        """
+        entry = float(bracket.entry_price or 0.0)
+        initial_sl = float(
+            bracket.initial_sl_trigger_price or bracket.sl_trigger_price or 0.0
+        )
+        initial_risk = abs(entry - initial_sl)
+        if entry <= 0 or initial_risk <= 0:
+            return candidate
+        profit_points = (ltp - entry) if bracket.side == "BUY" else (entry - ltp)
+        tier_metric = profit_points / initial_risk
+        if tier_metric < self._trail_activation_r(bracket):
+            return candidate
+        cost = self._breakeven_cost_per_unit(bracket)
+        # The positive-profit component starts only after real progress (0.75R);
+        # before that only costs are cleared, so an early cost-adjusted breakeven
+        # is not converted into a noise-sensitive profit stop.
+        locked_r = self._min_locked_profit_r() if tier_metric >= 0.75 else 0.0
+        locked = cost + (initial_risk * locked_r)
+        room = max(cost, 0.05)
+        if bracket.side == "BUY":
+            proposed = max(float(candidate), entry + locked)
+            return None if proposed >= (ltp - room) else proposed
+        proposed = min(float(candidate), entry - locked)
+        return None if proposed <= (ltp + room) else proposed
+
     def _calculate_tiered_trailing_sl(
         self,
         bracket: BracketState,
@@ -3033,7 +3126,7 @@ class BracketManager:
         # ═══════════════════════════════════════════════════════════
         # TIER 4: EXCELLENT PROFIT (> 6%) - PROTECT 60% + TIGHT TRAIL
         # ═══════════════════════════════════════════════════════════
-        if profit_pct >= tier4_threshold:
+        if tier_metric >= tier4_threshold:
             protection_pct = 0.60
 
             # Tighter ATR multiplier for big winners

--- a/src/nifty_scalper_bot/execution/runtime_bracket_manager.py
+++ b/src/nifty_scalper_bot/execution/runtime_bracket_manager.py
@@ -7,7 +7,6 @@ lose functionality when broker fill identity is intentionally absent.
 
 from __future__ import annotations
 
-import math
 import os
 import time
 from contextlib import suppress
@@ -19,112 +18,6 @@ from nifty_scalper_bot.execution.ledger_bracket_manager import LedgerBracketMana
 
 class RuntimeBracketManager(LedgerBracketManager):
     """Final runtime export for the staged lifecycle implementation."""
-
-    def _minimum_locked_profit_r(self) -> float:
-        """Return the cached post-activation net-profit floor in initial-risk units."""
-        cached = getattr(self, "_trail_min_locked_profit_r", None)
-        if cached is not None:
-            return float(cached)
-        try:
-            value = float(os.getenv("TRAIL_MIN_LOCKED_PROFIT_R", "0.10"))
-        except (TypeError, ValueError):
-            value = 0.10
-        value = value if math.isfinite(value) else 0.10
-        self._trail_min_locked_profit_r = max(0.0, value)
-        return self._trail_min_locked_profit_r
-
-    def _calculate_tiered_trailing_sl(
-        self,
-        bracket: Any,
-        ltp: float,
-        profit_pct: float,
-        high_water: float,
-        atr: float,
-    ) -> float | None:
-        """Delegate to the canonical ladder, then enforce one net-profit invariant.
-
-        The inherited core ladder is the only tier implementation. This override
-        corrects its Tier-4 dimensional comparison by supplying the canonical
-        R-metric only for that legacy percentage check, then floors the single
-        returned candidate at round-trip costs plus ``TRAIL_MIN_LOCKED_PROFIT_R``.
-        """
-        entry = float(getattr(bracket, "entry_price", 0.0) or 0.0)
-        current_sl = float(getattr(bracket, "sl_trigger_price", 0.0) or 0.0)
-        initial_sl = float(
-            getattr(bracket, "initial_sl_trigger_price", 0.0) or current_sl
-        )
-        initial_risk = abs(entry - initial_sl)
-        side = str(getattr(bracket, "side", "") or "").upper()
-        profit_points = (ltp - entry) if side == "BUY" else (entry - ltp)
-        tier_metric = (profit_points / initial_risk) if initial_risk > 0 else None
-
-        corrected_profit_pct = float(profit_pct)
-        if tier_metric is not None and tier_metric >= float(self._trail_tier4_r):
-            # bracket_core's final legacy guard compares profit_pct with an R
-            # threshold. Supplying the already-computed R value fixes only that
-            # dimensional mismatch; all tier calculations still live in super().
-            corrected_profit_pct = max(corrected_profit_pct, tier_metric)
-
-        candidate = super()._calculate_tiered_trailing_sl(
-            bracket=bracket,
-            ltp=ltp,
-            profit_pct=corrected_profit_pct,
-            high_water=high_water,
-            atr=atr,
-        )
-        if candidate is None or initial_risk <= 0 or tier_metric is None:
-            return candidate
-
-        activation_r = float(self._trail_activation_r(bracket))
-        if tier_metric < activation_r:
-            return candidate
-
-        cost_points = max(0.0, float(self._breakeven_cost_per_unit(bracket)))
-        # The positive-profit floor starts only after the canonical 0.75R
-        # progress threshold. Strategies that deliberately arm cost-adjusted
-        # breakeven earlier retain that established behaviour without installing
-        # a noise-sensitive positive-profit stop before meaningful progress.
-        locked_r = self._minimum_locked_profit_r() if tier_metric >= 0.75 else 0.0
-        locked_points = cost_points + (initial_risk * locked_r)
-        room = max(cost_points, 0.05)
-
-        if side == "BUY":
-            floor = entry + locked_points
-            proposed = max(float(candidate), floor)
-            if proposed >= (float(ltp) - room):
-                return None
-        else:
-            floor = entry - locked_points
-            proposed = min(float(candidate), floor)
-            if proposed <= (float(ltp) + room):
-                return None
-
-        if proposed != float(candidate):
-            _legacy.LOGGER.info(
-                "TRAIL_MIN_PROFIT_FLOOR_APPLIED symbol=%s side=%s tier_metric_r=%.3f locked_r=%.3f cost_points=%.3f candidate_sl=%.2f floored_sl=%.2f ltp=%.2f",
-                getattr(bracket, "symbol", ""),
-                side,
-                tier_metric,
-                locked_r,
-                cost_points,
-                float(candidate),
-                proposed,
-                float(ltp),
-                extra={
-                    "event": "TRAIL_MIN_PROFIT_FLOOR_APPLIED",
-                    "symbol": getattr(bracket, "symbol", ""),
-                    "side": side,
-                    "initial_risk_points": initial_risk,
-                    "tier_metric_r": tier_metric,
-                    "minimum_locked_profit_r": locked_r,
-                    "minimum_locked_profit_points": initial_risk * locked_r,
-                    "estimated_cost_points": cost_points,
-                    "candidate_sl": float(candidate),
-                    "applied_sl": proposed,
-                    "ltp": float(ltp),
-                },
-            )
-        return proposed
 
     def _block_ledger_release(
         self,

--- a/tests/execution/test_bracket_manager_reliability.py
+++ b/tests/execution/test_bracket_manager_reliability.py
@@ -621,3 +621,100 @@ def test_completed_trade_outcome_reports_r_normalised_excursions() -> None:
     assert outcome["mae_r"] == 0.5
     assert outcome["r_multiple"] is not None
     assert outcome["r_multiple"] < 2.0  # net of costs
+
+
+def _quote_tick(symbol: str, ltp: float, bid: float, ask: float) -> dict:
+    return {
+        "symbol": symbol,
+        "last_price": ltp,
+        "depth": {"buy": [{"price": bid, "quantity": 500}],
+                  "sell": [{"price": ask, "quantity": 500}]},
+        "exchange_timestamp": None,
+    }
+
+
+def test_long_stop_fires_when_bid_crosses_though_ltp_has_not() -> None:
+    """A long option is sold into the bid. If the bid is already below the stop
+    the position is executable below it, and waiting for LTP is late protection."""
+    order_manager = Mock()
+    order_manager.place_order.return_value = "exit-bid"
+    manager = BracketManager(order_manager=order_manager)
+    manager.register_virtual_bracket(
+        "bid-1", "NFO:NIFTYBIDCE", "BUY", 65, 100.0, 99.0, 120.0,
+        activate_immediately=True,
+    )
+    bracket = manager.get_bracket("bid-1")
+    assert bracket is not None
+
+    manager.on_tick_event(_quote_tick("NFO:NIFTYBIDCE", 100.50, 98.50, 101.50))
+
+    assert "SL" in str(bracket.exit_reason or "").upper()
+    assert "src=bid" in str(bracket.exit_reason or "")
+    assert order_manager.place_order.call_count >= 1
+
+
+def test_short_stop_fires_when_ask_crosses_though_ltp_has_not() -> None:
+    order_manager = Mock()
+    order_manager.place_order.return_value = "exit-ask"
+    manager = BracketManager(order_manager=order_manager)
+    manager.register_virtual_bracket(
+        "ask-1", "NFO:NIFTYASKCE", "SELL", 65, 100.0, 101.0, 80.0,
+        activate_immediately=True,
+    )
+    bracket = manager.get_bracket("ask-1")
+    assert bracket is not None
+
+    manager.on_tick_event(_quote_tick("NFO:NIFTYASKCE", 99.50, 98.50, 101.50))
+
+    assert "src=ask" in str(bracket.exit_reason or "")
+    assert order_manager.place_order.call_count >= 1
+
+
+def test_stop_holds_when_executable_side_has_not_crossed() -> None:
+    manager = BracketManager(order_manager=Mock())
+    manager.register_virtual_bracket(
+        "hold-1", "NFO:NIFTYHOLDCE", "BUY", 65, 100.0, 97.0, 120.0,
+        activate_immediately=True,
+    )
+    bracket = manager.get_bracket("hold-1")
+    assert bracket is not None
+
+    manager.on_tick_event(_quote_tick("NFO:NIFTYHOLDCE", 99.00, 98.50, 99.50))
+
+    assert bracket.exit_pending is False
+
+
+def test_stale_quote_falls_back_to_ltp_and_cannot_suppress_protection() -> None:
+    manager = BracketManager(order_manager=Mock())
+    manager.register_virtual_bracket(
+        "stale-1", "NFO:NIFTYSTALECE", "BUY", 65, 100.0, 99.0, 120.0,
+        activate_immediately=True,
+    )
+    bracket = manager.get_bracket("stale-1")
+    assert bracket is not None
+    # A generous bid captured long ago must not keep a breached position alive.
+    manager._exit_quotes["NFO:NIFTYSTALECE"] = (105.0, 106.0, time.time() - 600.0)
+
+    price, source = manager._executable_exit_price(bracket, 98.0)
+    assert price == 98.0
+    assert source == "ltp_stale_quote"
+
+
+def test_tier4_uses_r_not_premium_percent() -> None:
+    """A tight-stop trade at >3R but only ~2% premium profit must still trail;
+    the Tier-4 guard previously compared premium-percent to an R threshold and
+    returned no stop at all for the largest winners."""
+    manager = BracketManager(order_manager=Mock())
+    manager.register_virtual_bracket(
+        "t4-1", "NFO:NIFTYT4CE", "BUY", 65, 100.0, 99.0, 130.0,
+        activate_immediately=True,
+    )
+    bracket = manager.get_bracket("t4-1")
+    assert bracket is not None
+    bracket.highest_ltp = 104.0  # 4R on a 1.0-point stop, only +4% premium
+
+    new_sl = manager._calculate_tiered_trailing_sl(
+        bracket=bracket, ltp=104.0, profit_pct=4.0, high_water=104.0, atr=0.0
+    )
+    assert new_sl is not None, "Tier 4 must engage on R, not premium percent"
+    assert new_sl > 100.0

--- a/tests/execution/test_runtime_trailing_profit_floor.py
+++ b/tests/execution/test_runtime_trailing_profit_floor.py
@@ -20,7 +20,19 @@ def _manager(monkeypatch, *, cost_points: float = 1.0) -> RuntimeBracketManager:
     manager._calculate_momentum = lambda _symbol: 0.0
     manager._breakeven_cost_per_unit = lambda _bracket: cost_points
     manager._trail_activation_r = lambda _bracket: 0.75
+    manager._min_locked_profit_r = lambda: 0.10
     return manager
+
+
+def _trail(manager, bracket, *, ltp, profit_pct, high_water, atr=0.0):
+    """Canonical trail decision: tier ladder, then the net-profit floor."""
+    candidate = manager._calculate_tiered_trailing_sl(
+        bracket=bracket, ltp=ltp, profit_pct=profit_pct,
+        high_water=high_water, atr=atr,
+    )
+    if candidate is None:
+        return None
+    return manager._apply_min_profit_floor(bracket, candidate, ltp)
 
 
 def _bracket(*, side: str, entry: float, sl: float, high: float, low: float):
@@ -41,12 +53,9 @@ def test_buy_tier1_locks_cost_plus_point_one_r(monkeypatch) -> None:
     manager = _manager(monkeypatch, cost_points=1.0)
     bracket = _bracket(side="BUY", entry=100.0, sl=90.0, high=108.0, low=100.0)
 
-    candidate = manager._calculate_tiered_trailing_sl(
-        bracket=bracket,
-        ltp=108.0,
-        profit_pct=8.0,
-        high_water=108.0,
-        atr=0.0,
+    candidate = _trail(
+        manager, bracket, ltp=108.0, profit_pct=8.0,
+        high_water=108.0, atr=0.0,
     )
 
     assert candidate == pytest.approx(102.0)
@@ -56,12 +65,9 @@ def test_sell_tier1_locks_cost_plus_point_one_r(monkeypatch) -> None:
     manager = _manager(monkeypatch, cost_points=1.0)
     bracket = _bracket(side="SELL", entry=100.0, sl=110.0, high=100.0, low=92.0)
 
-    candidate = manager._calculate_tiered_trailing_sl(
-        bracket=bracket,
-        ltp=92.0,
-        profit_pct=8.0,
-        high_water=92.0,
-        atr=0.0,
+    candidate = _trail(
+        manager, bracket, ltp=92.0, profit_pct=8.0,
+        high_water=92.0, atr=0.0,
     )
 
     assert candidate == pytest.approx(98.0)
@@ -77,12 +83,9 @@ def test_tier4_uses_r_metric_not_premium_percentage(monkeypatch) -> None:
         low=1000.0,
     )
 
-    candidate = manager._calculate_tiered_trailing_sl(
-        bracket=bracket,
-        ltp=1015.0,
-        profit_pct=1.5,
-        high_water=1015.0,
-        atr=0.0,
+    candidate = _trail(
+        manager, bracket, ltp=1015.0, profit_pct=1.5,
+        high_water=1015.0, atr=0.0,
     )
 
     assert candidate == pytest.approx(1009.0)
@@ -92,12 +95,9 @@ def test_floor_is_not_installed_before_activation(monkeypatch) -> None:
     manager = _manager(monkeypatch, cost_points=1.0)
     bracket = _bracket(side="BUY", entry=100.0, sl=90.0, high=107.0, low=100.0)
 
-    candidate = manager._calculate_tiered_trailing_sl(
-        bracket=bracket,
-        ltp=107.0,
-        profit_pct=7.0,
-        high_water=107.0,
-        atr=0.0,
+    candidate = _trail(
+        manager, bracket, ltp=107.0, profit_pct=7.0,
+        high_water=107.0, atr=0.0,
     )
 
     assert candidate is None
@@ -107,12 +107,9 @@ def test_floor_is_rejected_when_execution_room_is_insufficient(monkeypatch) -> N
     manager = _manager(monkeypatch, cost_points=4.0)
     bracket = _bracket(side="BUY", entry=100.0, sl=90.0, high=108.0, low=100.0)
 
-    candidate = manager._calculate_tiered_trailing_sl(
-        bracket=bracket,
-        ltp=108.0,
-        profit_pct=8.0,
-        high_water=108.0,
-        atr=0.0,
+    candidate = _trail(
+        manager, bracket, ltp=108.0, profit_pct=8.0,
+        high_water=108.0, atr=0.0,
     )
 
     assert candidate is None


### PR DESCRIPTION
Three exit-path corrections, all in the canonical layer.

## 1. Tier-4 dimensional bug (regression from #1003)

`bracket_core` Tier 4 still read `if profit_pct >= tier4_threshold` while tiers 0-3 had moved to the R metric — premium-percent compared against an R threshold of 3.0. Tier 4 is only reached at `tier_metric >= 3.0R`, so a tight-stop trade at 3R but only +2% premium failed the guard and the ladder returned `None`: **no trailing at all on the largest winners.** Fixed at the root (`profit_pct` -> `tier_metric`).

## 2. Removed the subclass override that papered over it

`runtime_bracket_manager.py` had gained a 107-line override of `_calculate_tiered_trailing_sl` that recomputed `initial_risk`/`tier_metric` itself and then called `super()` with a deliberately falsified argument (`corrected_profit_pct = max(profit_pct, tier_metric)`) to work around the bug above. That is a duplicate tier implementation in the MRO — the pattern #1003 removed. It had also silently gained the ability to return `None` where the canonical ladder returned a valid stop, suppressing legitimate trail updates.

The net-profit floor it introduced is a good idea and is **kept**, moved to `bracket_core._apply_min_profit_floor()` and applied once to the single returned candidate: costs + `TRAIL_MIN_LOCKED_PROFIT_R` (0.10R), with the positive component deferred until 0.75R of progress so an early cost-adjusted breakeven does not become a noise-sensitive profit stop. Its tests are retained, retargeted at the canonical composition.

## 3. Stop breach now uses the executable side

A long option is liquidated into the bid. With LTP 100.50 / bid 98.50 / SL 99.00 the position was already executable below the stop, but `_evaluate_exit_fast` compared LTP and kept holding — late protection plus the spread paid on the way out.

`_capture_exit_quote()` caches best bid/ask per symbol from full ticks via the existing canonical `resolve_quote_bid_ask_spread`; `_executable_exit_price()` returns bid for BUY, ask for SELL, falling back to LTP when depth is absent or older than `EXIT_QUOTE_MAX_AGE_SEC` (3s) with an explicit `ltp_stale_quote` source. Only SL breach detection changed — TP, partials and trailing watermarks still use LTP, and the source is recorded in the exit reason and a new `trigger_price_source` field.

## Tests

5 added: long fires on bid cross with LTP above; short fires on ask cross; no exit when the executable side has not crossed; a stale favourable quote cannot suppress protection; Tier 4 engages on R rather than premium percent.

`compileall` clean. Full suite **2392 passed, 2 skipped**. Net -107 lines in `runtime_bracket_manager.py`.