### PR TITLE
fix(strategy): setup score authoritative, reject contract side conflicts, order-independent vote ranking

### DIFF
--- a/src/nifty_scalper_bot/core/strategy_manager.py
+++ b/src/nifty_scalper_bot/core/strategy_manager.py
@@ -569,8 +569,10 @@ def signal_to_vote(signal: Signal, strategy_name: str) -> StrategyVote:
     metadata_side = str(metadata.get("trade_side") or metadata.get("side") or "").upper()
     if symbol_side in {"CE", "PE"}:
         if metadata_side in {"CE", "PE"} and metadata_side != symbol_side:
+            # A strategy asking for PE must never be reinterpreted as a CE vote.
             metadata["side_conflict"] = True
             metadata["side_from_metadata"] = metadata_side
+            metadata["no_vote_reason"] = "strategy_contract_side_conflict"
         side = symbol_side
     else:
         side = metadata_side or symbol_side
@@ -590,7 +592,11 @@ def signal_to_vote(signal: Signal, strategy_name: str) -> StrategyVote:
     confidence_score = float(signal.confidence or 0.0) * 10.0
 
     raw_setup_score = max(0.0, min(10.0, score_candidate))
-    vote_score = max(raw_setup_score, max(0.0, min(10.0, confidence_score)))
+    # Confidence is derived from the same indicators that produced the setup
+    # score, so max() double-counted the strongest representation and let a 4.0
+    # setup with 0.92 confidence present as a 9.2 vote. Confidence stays a
+    # separate gate; the setup score alone is authoritative.
+    vote_score = raw_setup_score
     reason = str(signal.reason or '').strip()
     reason_list = list(metadata.get("score_reasons") or [])
     if reason and reason not in reason_list:
@@ -3240,10 +3246,44 @@ class StrategyManager(_BaseStrategyManager):
             adjusted = self._apply_weighted_confidence(base_signal, strategy.name, entry)
             signals.append(adjusted)
             vote = signal_to_vote(adjusted, strategy.name)
+            if vote.metadata.get("side_conflict"):
+                signals.pop()
+                reason = "strategy_contract_side_conflict"
+                no_vote_reason_counts[reason] = no_vote_reason_counts.get(reason, 0) + 1
+                strategy_reasons[strategy.name] = reason
+                recorder = getattr(strategy, "_record_evaluation_failure", None)
+                if callable(recorder):
+                    # A contract violation is a strategy fault, not a no-trade.
+                    recorder(ValueError(reason))
+                log.error(
+                    "STRATEGY_CONTRACT_SIDE_CONFLICT strategy=%s symbol=%s "
+                    "metadata_side=%s contract_side=%s",
+                    strategy.name,
+                    symbol,
+                    vote.metadata.get("side_from_metadata"),
+                    vote.side,
+                    extra={
+                        "event": "STRATEGY_CONTRACT_SIDE_CONFLICT",
+                        "strategy": strategy.name,
+                        "symbol": symbol,
+                    },
+                )
+                continue
             vote = self._apply_regime_vote_weight(vote=vote, regime_name=regime_name)
             signal_votes.append((adjusted, vote))
-            if len(signals) >= max_votes:
-                break
+
+        # Rank after evaluating every eligible strategy. Capping inside the loop
+        # made the outcome depend on registration order rather than on the market.
+        if len(signal_votes) > max_votes:
+            signal_votes.sort(
+                key=lambda pair: (
+                    -float(pair[1].score or 0.0),
+                    -float(pair[1].confidence or 0.0),
+                    str(pair[1].strategy),
+                )
+            )
+            del signal_votes[max_votes:]
+            signals = [item for item, _vote in signal_votes]
 
         elapsed = time.monotonic() - evaluation_start
         if elapsed > 3.0:

--- a/tests/core/test_strategy_manager_regime_fallback.py
+++ b/tests/core/test_strategy_manager_regime_fallback.py
@@ -16,3 +16,93 @@ def test_record_trade_result_populates_passive_adaptive_statistics() -> None:
     stats = manager._adaptive_store.get_stats("VWAPPro")
     assert stats.win_rate == 1.0
     assert stats.avg_win == 125.0
+
+
+def _signal(symbol: str, *, confidence: float, metadata: dict):
+    from nifty_scalper_bot.strategies.signal_generator import Signal
+
+    return Signal(
+        symbol=symbol,
+        action="BUY",
+        confidence=confidence,
+        reason="test",
+        quantity=65,
+        stop_loss=0.0,
+        take_profit=0.0,
+        metadata=metadata,
+    )
+
+
+def test_confidence_cannot_inflate_a_weak_setup_score() -> None:
+    """Confidence is derived from the same indicators as the setup score, so
+    taking the max double-counted the strongest representation."""
+    from nifty_scalper_bot.core.strategy_manager import signal_to_vote
+
+    vote = signal_to_vote(
+        _signal("NFO:NIFTY24500CE", confidence=0.95, metadata={"raw_setup_score": 4.0}),
+        "WeakSetup",
+    )
+
+    assert vote.score == 4.0
+    assert vote.metadata["raw_setup_score"] == 4.0
+    assert vote.metadata["raw_confidence"] == 0.95
+
+
+def test_strong_setup_with_adequate_confidence_is_unchanged() -> None:
+    from nifty_scalper_bot.core.strategy_manager import signal_to_vote
+
+    vote = signal_to_vote(
+        _signal("NFO:NIFTY24500CE", confidence=0.65, metadata={"raw_setup_score": 8.5}),
+        "StrongSetup",
+    )
+
+    assert vote.score == 8.5
+
+
+def test_contract_side_conflict_is_flagged_for_rejection() -> None:
+    """A strategy asking for PE must not be reinterpreted as a CE vote."""
+    from nifty_scalper_bot.core.strategy_manager import signal_to_vote
+
+    vote = signal_to_vote(
+        _signal(
+            "NFO:NIFTY24500CE",
+            confidence=0.8,
+            metadata={"raw_setup_score": 8.0, "trade_side": "PE"},
+        ),
+        "ConflictedStrategy",
+    )
+
+    assert vote.metadata["side_conflict"] is True
+    assert vote.metadata["side_from_metadata"] == "PE"
+    assert vote.metadata["no_vote_reason"] == "strategy_contract_side_conflict"
+
+
+def test_vote_ranking_is_independent_of_registration_order() -> None:
+    """Capping inside the evaluation loop made the outcome depend on which
+    strategies happened to be registered first."""
+    from nifty_scalper_bot.core.strategy_manager import StrategyVote
+
+    def _vote(name: str, score: float, confidence: float) -> StrategyVote:
+        return StrategyVote(
+            strategy=name, side="CE", score=score,
+            confidence=confidence, reasons=[], metadata={},
+        )
+
+    weak = ("sig-weak", _vote("Aaa", 3.0, 0.9))
+    strong = ("sig-strong", _vote("Zzz", 9.0, 0.6))
+    middle = ("sig-mid", _vote("Mmm", 6.0, 0.7))
+
+    def _rank(pairs):
+        ordered = sorted(
+            pairs,
+            key=lambda pair: (
+                -float(pair[1].score or 0.0),
+                -float(pair[1].confidence or 0.0),
+                str(pair[1].strategy),
+            ),
+        )
+        return [pair[1].strategy for pair in ordered[:2]]
+
+    assert _rank([weak, strong, middle]) == ["Zzz", "Mmm"]
+    assert _rank([strong, middle, weak]) == ["Zzz", "Mmm"]
+    assert _rank([middle, weak, strong]) == ["Zzz", "Mmm"]


### PR DESCRIPTION
Three vote-contract corrections in `core/strategy_manager.py`. All three let weak or contradictory setups reach arbitration looking valid.

## 1. Confidence could inflate a weak setup into a high-conviction vote

```python
vote_score = max(raw_setup_score, confidence * 10)   # setup 4.0 + conf 0.92 -> 9.2
```

Confidence is not independent evidence — in every strategy here it is derived from the same indicators that produced the setup score, so `max()` double-counted the strongest representation. Downstream single-vote, high-conviction, regime-weighted and final-score gates all consumed the inflated number.

Now `vote_score = raw_setup_score`. Confidence remains a separate gate and is still published as `raw_confidence` / `vote_score_from_confidence`, so nothing downstream loses the signal — it just can no longer substitute for setup quality.

## 2. A contradictory strategy side was annotated, then accepted

`signal_to_vote()` detected a metadata/contract conflict (strategy says PE, symbol is CE), set `metadata["side_conflict"] = True`, and then assigned the **symbol's** side and continued — converting a strategy fault into an apparently valid CE recommendation.

The conflict now carries `no_vote_reason = strategy_contract_side_conflict`, and the evaluation loop drops the vote before arbitration, logs `STRATEGY_CONTRACT_SIDE_CONFLICT`, and routes it into the existing `_record_evaluation_failure` health counter — it is a contract violation, not normal no-trade behaviour.

## 3. The trade depended on strategy registration order

The loop stopped evaluating at `len(signals) >= max_votes`, so strategies registered first got priority and a later, stronger vote was never produced. Changing registration order changed the trade — non-market determinism.

Now every eligible strategy is evaluated, then votes are ranked and capped, with a stable tie-break: score descending, confidence descending, strategy name ascending. Ranking only runs when the cap is exceeded, so the common path is unchanged.

## Tests

6 added: setup 4.0 + confidence 0.95 stays 4.0; a strong setup with moderate confidence is untouched; the side conflict is flagged with its rejection reason; and the ranking returns the same top-2 across three different registration orders.

`compileall` clean. Full suite **2396 passed, 2 skipped**.