### PR TITLE
fix(entry): fail-closed quote evidence, canonical VWAP authority, evidence-based quality, timestamped context veto

### DIFF
--- a/src/nifty_scalper_bot/core/strategy_manager.py
+++ b/src/nifty_scalper_bot/core/strategy_manager.py
@@ -146,6 +146,23 @@ def _enrich_option_candidate_metadata(symbol: str, indicators: t.Mapping[str, t.
     return enriched
 
 
+def resolve_canonical_vwap(indicators: t.Mapping[str, t.Any] | None) -> float | None:
+    """Single VWAP authority for every strategy-layer consumer.
+
+    Precedence is exchange/session cumulative VWAP first, then the rolling
+    proxy. Direction gating, SMC enrichment and VWAPPro previously resolved in
+    different orders and could classify the same snapshot in opposite
+    directions. Returns None when no VWAP evidence exists — never the current
+    price, which manufactures a reclaim out of nothing.
+    """
+    payload = indicators or {}
+    for key in ("exchange_vwap", "session_vwap", "vwap"):
+        value = _safe_float_value(payload.get(key))
+        if value is not None and value > 0:
+            return value
+    return None
+
+
 def _enrich_smc_pre_strategy(
     symbol: str,
     indicators: t.Mapping[str, t.Any],
@@ -207,15 +224,14 @@ def _enrich_smc_pre_strategy(
     if premium_current <= 0 and fallback_price is not None:
         premium_current = fallback_price
     premium_prev_close = previous["close"]
-    premium_vwap = _safe_float_value(enriched.get("vwap"))
-    if premium_vwap is None:
-        premium_vwap = _safe_float_value(enriched.get("exchange_vwap"))
+    premium_vwap = resolve_canonical_vwap(enriched)
     if premium_vwap is None:
         volume_sum = sum(max(0.0, bar["volume"]) for bar in ohlcv)
         if volume_sum > 0:
             premium_vwap = sum(((bar["high"] + bar["low"] + bar["close"]) / 3.0) * max(0.0, bar["volume"]) for bar in ohlcv) / volume_sum
-        else:
-            premium_vwap = premium_current
+        # No volume-backed VWAP exists. Falling back to the current premium made
+        # prev_close < price read as a VWAP reclaim on zero evidence, so the
+        # feature stays absent instead of being manufactured.
 
     tolerance = max(abs(premium_current) * 0.003, 0.05)
     recent_bars = ohlcv[-5:]
@@ -2189,7 +2205,7 @@ class StrategyManager(_BaseStrategyManager):
         snapshot = {
             "symbol": symbol, "role": role, "context_kind": context_kind, "timestamp": time.time(),
             "ltp": _num("ltp", "close", "price"), "close": _num("close", "ltp", "price"),
-            "vwap": _num("vwap", "exchange_vwap", "session_vwap"),
+            "vwap": _num("exchange_vwap", "session_vwap", "vwap"),
             "ema_fast": _num("ema_fast", "ema_9", "ema9"),
             "ema_slow": _num("ema_slow", "ema_21", "ema21"), "ema_50": _num("ema_50", "ema50"),
             "adx": _num("adx"), "atr": _num("atr"), "volume": _num("volume"),
@@ -2241,7 +2257,7 @@ class StrategyManager(_BaseStrategyManager):
         day_open = _f("open") or _f("day_open") or _f("first_ltp")
         recent_ltp_delta = _f("recent_ltp_delta") or _f("net_change") or _f("price_change_pct")
         tick_slope = _f("tick_slope")
-        vwap = _f("vwap") or _f("exchange_vwap") or _f("session_vwap")
+        vwap = _f("exchange_vwap") or _f("session_vwap") or _f("vwap")
         ema_fast = _f("ema_fast") or _f("ema_9") or _f("ema9")
         ema_slow = _f("ema_slow") or _f("ema_21") or _f("ema21")
         ema_50 = _f("ema_50") or _f("ema50")
@@ -3687,8 +3703,28 @@ class StrategyManager(_BaseStrategyManager):
                 continue
         return max(0.0, self._extract_raw_score(vote))
 
+    def _context_vote_is_timestamped(self, vote: StrategyVote) -> bool:
+        """Return whether a context vote proves it is current.
+
+        A hard veto blocks an otherwise valid trade, so it requires an
+        authoritative, fresh timestamp. Missing or stale provenance downgrades
+        the vote to a soft penalty instead of silently defaulting its age to
+        "now" and letting an undated vote veto at full strength.
+        """
+        raw = (vote.metadata or {}).get("vote_timestamp")
+        try:
+            stamped = float(raw)
+        except (TypeError, ValueError):
+            return False
+        if stamped <= 0:
+            return False
+        max_age = max(0.0, self._env_float("CONTEXT_VOTE_MAX_AGE_SEC", 30.0))
+        return (time.time() - stamped) <= max_age
+
     def _extract_context_veto_score(self, vote: StrategyVote) -> float:
         """Args: vote. Returns: context veto score. Raises: none."""
+        if not self._context_vote_is_timestamped(vote):
+            return 0.0
         payload = dict(vote.metadata or {})
         for key in ("context_veto_score", "context_score", "raw_setup_score", "raw_vote_score", "vote_score"):
             try:
@@ -4708,14 +4744,33 @@ class StrategyManager(_BaseStrategyManager):
     ) -> tuple[float, dict[str, t.Any]]:
         """Args: vote+indicators. Returns: trade quality score and metadata. Raises: none."""
         payload = dict(vote.metadata or {})
+        # Missing evidence must score zero. The previous positive defaults let a
+        # setup accumulate quality points for facts never demonstrated, and
+        # "strategy_score" could carry the adaptive historical performance score
+        # injected by _apply_weighted_confidence rather than this trade's setup.
+        raw_setup = float(payload.get("raw_setup_score", vote.score or 0.0))
+        has_direction = payload.get("direction_alignment_score") is not None
+        has_liquidity = payload.get("liquidity_score") is not None
+        has_freshness = indicators.get("stale_data_used") is not None
         components = {
-            "strategy_score": min(3.0, max(0.0, float(payload.get("strategy_score", vote.score or 0.0)) / 3.0)),
-            "direction_alignment": float(payload.get("direction_alignment_score", 1.0)),
-            "liquidity_spread_quality": min(2.0, max(0.0, float(payload.get("liquidity_score", 1.0)))),
-            "freshness_tick_quality": 1.0 if not bool(indicators.get("stale_data_used")) else 0.0,
+            "strategy_score": min(3.0, max(0.0, raw_setup / 3.0)),
+            "direction_alignment": (
+                float(payload.get("direction_alignment_score")) if has_direction else 0.0
+            ),
+            "liquidity_spread_quality": (
+                min(2.0, max(0.0, float(payload.get("liquidity_score"))))
+                if has_liquidity
+                else 0.0
+            ),
+            "freshness_tick_quality": (
+                1.0 if has_freshness and not bool(indicators.get("stale_data_used")) else 0.0
+            ),
             "same_side_context_confirmation": 1.0 if any(v.side == vote.side for v in context_votes) else 0.0,
-            "market_regime_time_suitability": 1.0,
+            "market_regime_time_suitability": float(
+                payload.get("regime_time_suitability_score") or 0.0
+            ),
         }
+        evidence_complete = bool(has_direction and has_liquidity and has_freshness)
         penalties: dict[str, float] = {}
         score_reasons = {str(r) for r in (payload.get("score_reasons") or [])}
         already_blocked_by_strategy = False
@@ -4731,7 +4786,12 @@ class StrategyManager(_BaseStrategyManager):
         spread_pct = float(payload.get("spread_pct") or indicators.get("spread_pct") or 0.0)
         if spread_pct > float(os.getenv("STRATEGY_MAX_SPREAD_PCT", "28.0")) and not already_blocked_by_strategy:
             penalties["spread_above_max"] = -3.0
-        if any(v.side in {"CE", "PE"} and v.side != vote.side and float((v.metadata or {}).get("context_veto_score", v.score)) >= 8.0 for v in context_votes):
+        if any(
+            v.side in {"CE", "PE"}
+            and v.side != vote.side
+            and self._extract_context_veto_score(v) >= 8.0
+            for v in context_votes
+        ):
             penalties["opposite_context_veto"] = -4.0
         if not selected_ok and not near_atm_ok:
             penalties["non_selected_far_otm"] = -3.0
@@ -4749,6 +4809,7 @@ class StrategyManager(_BaseStrategyManager):
             "trade_quality_components": components,
             "trade_quality_penalties": penalties,
             "quality_block_reason": block_reason,
+            "quality_evidence_complete": evidence_complete,
             "already_blocked_by_strategy": already_blocked_by_strategy,
             "strategy_block_reason": strategy_block_reason or None,
             "trade_quality_symbol": symbol,

--- a/src/nifty_scalper_bot/execution/order_manager_core.py
+++ b/src/nifty_scalper_bot/execution/order_manager_core.py
@@ -4357,6 +4357,55 @@ class OrderManager:
             }
         return None
 
+    def _validate_live_entry_quote(
+        self, plan: TradePlan, qd: dict[str, Any]
+    ) -> OrderPreflightResult | None:
+        """Fail closed on incomplete quote evidence for a live entry.
+
+        The general checks only rejected a wide spread when both sides were
+        already positive, and depth only when a depth field existed, so an
+        LTP-only quote with bid=0/ask=0 and no depth passed straight through to
+        the broker. Returns None when the quote is fully proven.
+        """
+        if qd["bid"] <= 0 or qd["ask"] < qd["bid"]:
+            return OrderPreflightResult(
+                False,
+                "entry_bid_ask_missing",
+                {"bid": qd["bid"], "ask": qd["ask"]},
+            )
+        if qd.get("age_ms") is None:
+            return OrderPreflightResult(
+                False,
+                "entry_quote_timestamp_unusable",
+                {"timestamp_key": qd.get("timestamp_key")},
+            )
+        if qd["spread_pct"] > plan.max_spread_pct:
+            return OrderPreflightResult(
+                False,
+                "entry_spread_too_wide",
+                {"spread_pct": qd["spread_pct"], "limit_pct": plan.max_spread_pct},
+            )
+        # For one-lot option buying the executable side matters, not the
+        # aggregate book: a BUY entry is filled against the ask.
+        executable_qty = qd["ask_qty"] if plan.side == "BUY" else qd["bid_qty"]
+        if executable_qty <= 0:
+            return OrderPreflightResult(
+                False,
+                "entry_executable_depth_missing",
+                {"side": plan.side, "bid_qty": qd["bid_qty"], "ask_qty": qd["ask_qty"]},
+            )
+        if executable_qty < int(plan.quantity):
+            return OrderPreflightResult(
+                False,
+                "entry_executable_depth_insufficient",
+                {
+                    "side": plan.side,
+                    "executable_qty": executable_qty,
+                    "required_qty": int(plan.quantity),
+                },
+            )
+        return None
+
     def _validate_trade_plan(self, plan: TradePlan) -> OrderPreflightResult:
         symbol = normalize_symbol(plan.symbol)
         if not is_strategy_instrument(symbol):
@@ -4558,6 +4607,10 @@ class OrderManager:
                 "spread_too_wide",
                 {"spread_pct": qd["spread_pct"], "limit_pct": plan.max_spread_pct},
             )
+        if live_entry:
+            quote_rejection = OrderManager._validate_live_entry_quote(self, plan, qd)
+            if quote_rejection is not None:
+                return quote_rejection
         if is_entry and plan.max_signal_age_seconds > 0:
             decision_epoch = 0.0
             with suppress(TypeError, ValueError):

--- a/src/nifty_scalper_bot/strategies/elite_strategies/order_flow.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/order_flow.py
@@ -244,7 +244,7 @@ class OrderFlowStrategy(EliteStrategy):
                     'quote_update_version': quote_update_version,
                 }
                 side_aligns = direction in {'CE', 'PE'} and direction == side
-                metadata.update({'context_role': 'confirmation', 'context_bonus_score': strategy_score if side_aligns else 0.0, 'context_veto_score': strategy_score if (direction in {'CE', 'PE'} and direction != side) else 0.0, 'tick_supports_direction': tick_supports})
+                metadata.update({'context_role': 'confirmation', 'vote_timestamp': time.time(), 'context_bonus_score': strategy_score if side_aligns else 0.0, 'context_veto_score': strategy_score if (direction in {'CE', 'PE'} and direction != side) else 0.0, 'tick_supports_direction': tick_supports})
                 return EliteSignal(symbol=symbol, signal='BUY', confidence=max(0.1, min(0.55, strategy_score / 10.0)), entry_price=current_price, stop_loss=None, target=None, quantity=self._cfg.quantity or 1, strategy_name='OrderFlow', metadata=metadata)
 
             depth_imbalance = (total_bid - total_ask) / max(total_bid + total_ask, 1.0)
@@ -494,7 +494,7 @@ class OrderFlowStrategy(EliteStrategy):
             }
             if trigger_conditions_met:
                 metadata['approval_candidate'] = 'orderflow_live_depth_trigger'
-            metadata.update({'context_role': 'confirmation', 'context_bonus_score': strategy_score if side_aligns else 0.0, 'context_veto_score': strategy_score if (direction in {'CE', 'PE'} and direction != side) else 0.0})
+            metadata.update({'context_role': 'confirmation', 'vote_timestamp': time.time(), 'context_bonus_score': strategy_score if side_aligns else 0.0, 'context_veto_score': strategy_score if (direction in {'CE', 'PE'} and direction != side) else 0.0})
             LOGGER.info(
                 'ORDERFLOW_TRIGGER_DECISION symbol=%s side=%s trigger_conditions_met=%s trigger_block_reason=%s score=%.2f spread_pct=%.2f context_age_seconds=%s',
                 symbol,

--- a/tests/core/test_strategy_manager_regime_fallback.py
+++ b/tests/core/test_strategy_manager_regime_fallback.py
@@ -106,3 +106,100 @@ def test_vote_ranking_is_independent_of_registration_order() -> None:
     assert _rank([weak, strong, middle]) == ["Zzz", "Mmm"]
     assert _rank([strong, middle, weak]) == ["Zzz", "Mmm"]
     assert _rank([middle, weak, strong]) == ["Zzz", "Mmm"]
+
+
+def _context_vote(side: str, veto: float, *, stamped: bool = True):
+    import time
+
+    from nifty_scalper_bot.core.strategy_manager import StrategyVote
+
+    metadata = {"context_veto_score": veto}
+    if stamped:
+        metadata["vote_timestamp"] = time.time()
+    return StrategyVote(
+        strategy="OrderFlow", side=side, score=veto,
+        confidence=0.5, reasons=[], metadata=metadata,
+    )
+
+
+def test_undated_context_vote_cannot_hard_veto() -> None:
+    """Defaulting a missing vote timestamp to 'now' let a provenance-free vote
+    block a valid trade at full strength."""
+    manager = StrategyManager([], None, None)
+
+    assert manager._extract_context_veto_score(_context_vote("PE", 9.0)) == 9.0
+    assert (
+        manager._extract_context_veto_score(_context_vote("PE", 9.0, stamped=False))
+        == 0.0
+    )
+
+
+def test_stale_context_vote_cannot_hard_veto() -> None:
+    import time
+
+    manager = StrategyManager([], None, None)
+    vote = _context_vote("PE", 9.0)
+    vote.metadata["vote_timestamp"] = time.time() - 600.0
+
+    assert manager._extract_context_veto_score(vote) == 0.0
+
+
+def test_canonical_vwap_prefers_session_over_rolling_and_never_invents_one() -> None:
+    from nifty_scalper_bot.core.strategy_manager import resolve_canonical_vwap
+
+    assert resolve_canonical_vwap(
+        {"vwap": 102.94, "session_vwap": 103.31, "exchange_vwap": 103.45}
+    ) == 103.45
+    assert resolve_canonical_vwap({"vwap": 102.94, "session_vwap": 103.31}) == 103.31
+    assert resolve_canonical_vwap({"vwap": 102.94}) == 102.94
+    # No VWAP evidence must stay absent, never fall back to the current price.
+    assert resolve_canonical_vwap({"current_price": 103.0, "ltp": 103.0}) is None
+    assert resolve_canonical_vwap({}) is None
+
+
+def test_quality_score_awards_nothing_for_missing_evidence() -> None:
+    from nifty_scalper_bot.core.strategy_manager import StrategyVote
+
+    manager = StrategyManager([], None, None)
+    bare = StrategyVote(
+        strategy="Bare", side="CE", score=6.0, confidence=0.7,
+        reasons=[], metadata={"raw_setup_score": 6.0},
+    )
+
+    _score, meta = manager._compute_trade_quality_score(
+        bare, {}, symbol="NFO:NIFTY24500CE",
+        selected_ok=True, near_atm_ok=True, context_votes=[],
+    )
+    components = meta["trade_quality_components"]
+
+    assert components["direction_alignment"] == 0.0
+    assert components["liquidity_spread_quality"] == 0.0
+    assert components["freshness_tick_quality"] == 0.0
+    assert components["market_regime_time_suitability"] == 0.0
+    assert meta["quality_evidence_complete"] is False
+
+
+def test_quality_score_credits_demonstrated_evidence() -> None:
+    from nifty_scalper_bot.core.strategy_manager import StrategyVote
+
+    manager = StrategyManager([], None, None)
+    proven = StrategyVote(
+        strategy="Proven", side="CE", score=6.0, confidence=0.7, reasons=[],
+        metadata={
+            "raw_setup_score": 6.0,
+            "direction_alignment_score": 1.0,
+            "liquidity_score": 2.0,
+            "regime_time_suitability_score": 1.0,
+        },
+    )
+
+    _score, meta = manager._compute_trade_quality_score(
+        proven, {"stale_data_used": False}, symbol="NFO:NIFTY24500CE",
+        selected_ok=True, near_atm_ok=True, context_votes=[],
+    )
+    components = meta["trade_quality_components"]
+
+    assert components["direction_alignment"] == 1.0
+    assert components["liquidity_spread_quality"] == 2.0
+    assert components["freshness_tick_quality"] == 1.0
+    assert meta["quality_evidence_complete"] is True

--- a/tests/execution/test_order_manager_trade_plan.py
+++ b/tests/execution/test_order_manager_trade_plan.py
@@ -1,3 +1,4 @@
+import time
 import pytest
 import types
 from types import SimpleNamespace
@@ -1064,3 +1065,66 @@ def test_legacy_place_order_without_lot_metadata_keeps_safe_defaults(
     sig = inspect.signature(OrderManager.place_order)
     assert sig.parameters["requested_lots"].default == 0
     assert sig.parameters["resolved_lot_size"].default == 0
+
+
+def _live_entry_manager(quote: dict):
+    """Minimal stub exercising the live-entry quote-evidence gate."""
+    m = _manager_stub()
+    m.is_live_mode = lambda: True
+    m._lot_size_for_symbol = lambda _s: 65
+    m._get_latest_quote_safe = lambda _s: quote
+    m._extract_quote_diagnostics = lambda q: OrderManager._extract_quote_diagnostics(m, q)
+    return m
+
+
+def _live_plan(**overrides):
+    kwargs = dict(
+        symbol="NFO:NIFTY24500CE", side="BUY", quantity=65,
+        entry_price=100.0, stop_loss=95.0, take_profit=110.0,
+        intent="ENTRY", trade_lifecycle_id="lc-1", resolved_lot_size=65,
+        client_order_id="coid-1", signal_id="sig-1",
+    )
+    kwargs.update(overrides)
+    return TradePlan(**kwargs)
+
+
+def _reject_reason(quote: dict) -> str | None:
+    m = _live_entry_manager(quote)
+    qd = m._extract_quote_diagnostics(quote)
+    result = OrderManager._validate_live_entry_quote(m, _live_plan(), qd)
+    return None if result is None else result.reason
+
+
+def test_live_entry_rejects_ltp_only_quote() -> None:
+    """An LTP-only quote with no bid/ask and no depth previously passed the
+    final preflight and reached the broker."""
+    assert _reject_reason(
+        {"ltp": 100.0, "received_at": time.time()}
+    ) == "entry_bid_ask_missing"
+
+
+def test_live_entry_rejects_missing_executable_depth() -> None:
+    assert _reject_reason(
+        {"ltp": 100.0, "bid": 99.5, "ask": 100.5, "received_at": time.time()}
+    ) == "entry_executable_depth_missing"
+
+
+def test_live_entry_rejects_insufficient_executable_depth() -> None:
+    """A BUY is filled against the ask, so ask-side depth is what must cover it."""
+    assert _reject_reason(
+        {
+            "ltp": 100.0, "bid": 99.5, "ask": 100.5,
+            "bid_quantity": 5000, "ask_quantity": 25,
+            "received_at": time.time(),
+        }
+    ) == "entry_executable_depth_insufficient"
+
+
+def test_live_entry_accepts_complete_quote_evidence() -> None:
+    assert _reject_reason(
+        {
+            "ltp": 100.0, "bid": 99.5, "ask": 100.5,
+            "bid_quantity": 5000, "ask_quantity": 500,
+            "received_at": time.time(),
+        }
+    ) is None


### PR DESCRIPTION
Four corrections that all share one theme: **a trade must not earn credit for evidence that was never demonstrated.**

## 1. Live entry preflight failed open on incomplete quotes

`_validate_trade_plan()` rejected a wide spread only when both bid and ask were already positive, and rejected depth only when a depth field existed. An LTP-only quote with `bid=0`, `ask=0` and no depth therefore passed the final gate and reached the broker.

Extracted `_validate_live_entry_quote()` — one named method, called only for `live_entry`, returning precise reasons: `entry_bid_ask_missing`, `entry_quote_timestamp_unusable`, `entry_spread_too_wide`, `entry_executable_depth_missing`, `entry_executable_depth_insufficient`.

Depth is checked on the **executable side** (ask for a BUY, bid for a SELL) rather than in aggregate — for one-lot option buying that is the side that actually has to fill you. Protective exits are untouched and keep their risk bypass.

## 2. VWAP was not a single source of truth

Three components resolved VWAP in three different orders, so direction gating, SMC enrichment and VWAPPro could classify the same snapshot in opposite directions. Worse, SMC fell back to `premium_vwap = premium_current` when no volume-backed VWAP existed — which makes `prev_close < price` read as a VWAP reclaim on **zero evidence**.

`resolve_canonical_vwap()` is now the single authority: exchange -> session -> rolling, returning `None` when no VWAP evidence exists. The current-price fallback is deleted; the feature stays absent rather than being manufactured.

## 3. Trade-quality score rewarded missing evidence

Defaults of `1.0` for direction alignment, liquidity and freshness, and a hard-coded `1.0` for regime/time suitability, let an incomplete setup accumulate points for facts never shown. It also read `strategy_score`, which can carry the adaptive *historical performance* score injected by `_apply_weighted_confidence` rather than this trade's setup.

Missing evidence now scores 0, the setup component reads `raw_setup_score`, and `quality_evidence_complete` is published so the live gate can require proof rather than trusting an aggregate.

## 4. An undated context vote could hard-veto

A missing vote timestamp defaulted to `now`, making a provenance-free or stale vote look perfectly fresh and block a valid trade at full veto strength.

The rule is enforced inside `_extract_context_veto_score()` — the single extractor all four veto call sites already use — so no site can drift. `OrderFlow` now stamps `vote_timestamp` where it sets `context_veto_score`, and an unstamped or stale vote (`CONTEXT_VOTE_MAX_AGE_SEC`, 30s) scores 0 and can only penalise, never veto.

Note: this required wiring the producer first. Requiring the timestamp without stamping it would have silently disabled the opposite-context veto entirely.

## Tests

9 added: LTP-only quote rejected; missing and insufficient executable depth rejected; complete evidence accepted; VWAP precedence and the no-invention guarantee; quality components zero without evidence and credited with it; undated and stale votes cannot veto while a fresh one still can.

`compileall` clean. Full suite **2405 passed, 2 skipped**.