### PR TITLE
fix(exit): watchdog stop uses the executable side, matching the tick evaluator

### DIFF
--- a/src/nifty_scalper_bot/execution/bracket_core.py
+++ b/src/nifty_scalper_bot/execution/bracket_core.py
@@ -888,19 +888,12 @@ class BracketManager:
                                 bracket.symbol,
                             )
                             continue
-                        if bracket.side == "BUY" and self._sl_crossed(bracket, ltp):
-                            pending.append(
-                                (
-                                    bracket,
-                                    {
-                                        "type": "SL",
-                                        "price": ltp,
-                                        "qty": bracket.remaining_quantity,
-                                        "reason": "WATCHDOG_HARD_SL",
-                                    },
-                                )
+                        if bracket.side not in {"BUY", "SELL"}:
+                            continue
+                        if self._sl_crossed(bracket, ltp):
+                            exec_px, exec_src = self._executable_exit_price(
+                                bracket, ltp
                             )
-                        elif bracket.side == "SELL" and self._sl_crossed(bracket, ltp):
                             pending.append(
                                 (
                                     bracket,
@@ -908,7 +901,12 @@ class BracketManager:
                                         "type": "SL",
                                         "price": ltp,
                                         "qty": bracket.remaining_quantity,
-                                        "reason": "WATCHDOG_HARD_SL",
+                                        "trigger_price": exec_px,
+                                        "trigger_price_source": exec_src,
+                                        "reason": (
+                                            f"WATCHDOG_HARD_SL trigger={exec_px:.2f} "
+                                            f"src={exec_src}"
+                                        ),
                                     },
                                 )
                             )
@@ -1944,13 +1942,23 @@ class BracketManager:
         return float(price), "bid" if bracket.side == "BUY" else "ask"
 
     def _sl_crossed(self, bracket: BracketState, ltp: float) -> bool:
-        """Return True when a tick crosses stop-loss. Args: bracket, ltp; Returns: bool; Raises: none."""
+        """Return True when the stop is breached on the executable side.
+
+        The watchdog is the independent protection path used when normal tick
+        evaluation is delayed or blocked, so it must not carry weaker stop
+        semantics than `_evaluate_exit_fast`. A long is sold into the bid and a
+        short bought back at the ask; an already-breached executable price is
+        sufficient, since requiring a freshly observed crossing would let a
+        position that is already liquidatable below its stop keep running.
+        """
+        exit_px, _source = self._executable_exit_price(bracket, ltp)
+        stop = float(bracket.sl_trigger_price or 0.0)
+        if stop <= 0:
+            return False
         prev_ltp = float(bracket.previous_ltp or bracket.last_ltp or ltp)
         if bracket.side == "BUY":
-            return (
-                prev_ltp > bracket.sl_trigger_price and ltp <= bracket.sl_trigger_price
-            )
-        return prev_ltp < bracket.sl_trigger_price and ltp >= bracket.sl_trigger_price
+            return exit_px <= stop or (prev_ltp > stop and exit_px <= stop)
+        return exit_px >= stop or (prev_ltp < stop and exit_px >= stop)
 
     def _evaluate_exit_fast(
         self,

--- a/tests/execution/test_bracket_manager_reliability.py
+++ b/tests/execution/test_bracket_manager_reliability.py
@@ -718,3 +718,60 @@ def test_tier4_uses_r_not_premium_percent() -> None:
     )
     assert new_sl is not None, "Tier 4 must engage on R, not premium percent"
     assert new_sl > 100.0
+
+
+def _watchdog_bracket(manager, order_id, symbol, side, sl):
+    manager.register_virtual_bracket(
+        order_id, symbol, side, 65, 100.0, sl,
+        120.0 if side == "BUY" else 80.0, activate_immediately=True,
+    )
+    bracket = manager.get_bracket(order_id)
+    assert bracket is not None
+    return bracket
+
+
+def test_watchdog_stop_uses_bid_for_a_long_position() -> None:
+    """The watchdog is the independent protection path; it must not carry
+    weaker stop semantics than the normal tick evaluator."""
+    manager = BracketManager(order_manager=Mock())
+    bracket = _watchdog_bracket(manager, "wd-1", "NFO:NIFTYWD1CE", "BUY", 99.0)
+    manager._exit_quotes["NFO:NIFTYWD1CE"] = (98.50, 101.50, time.time())
+
+    assert manager._sl_crossed(bracket, 100.50) is True
+
+
+def test_watchdog_stop_uses_ask_for_a_short_position() -> None:
+    manager = BracketManager(order_manager=Mock())
+    bracket = _watchdog_bracket(manager, "wd-2", "NFO:NIFTYWD2CE", "SELL", 101.0)
+    manager._exit_quotes["NFO:NIFTYWD2CE"] = (98.50, 101.50, time.time())
+
+    assert manager._sl_crossed(bracket, 99.50) is True
+
+
+def test_watchdog_holds_when_executable_side_has_not_breached() -> None:
+    manager = BracketManager(order_manager=Mock())
+    bracket = _watchdog_bracket(manager, "wd-3", "NFO:NIFTYWD3CE", "BUY", 97.0)
+    manager._exit_quotes["NFO:NIFTYWD3CE"] = (98.50, 99.50, time.time())
+
+    assert manager._sl_crossed(bracket, 99.00) is False
+
+
+def test_watchdog_falls_back_to_ltp_on_a_stale_quote() -> None:
+    manager = BracketManager(order_manager=Mock())
+    bracket = _watchdog_bracket(manager, "wd-4", "NFO:NIFTYWD4CE", "BUY", 99.0)
+    # A generous but stale bid must not suppress the watchdog.
+    manager._exit_quotes["NFO:NIFTYWD4CE"] = (105.0, 106.0, time.time() - 600.0)
+
+    price, source = manager._executable_exit_price(bracket, 98.0)
+    assert (price, source) == (98.0, "ltp_stale_quote")
+    assert manager._sl_crossed(bracket, 98.0) is True
+
+
+def test_watchdog_payload_records_the_trigger_source() -> None:
+    manager = BracketManager(order_manager=Mock())
+    bracket = _watchdog_bracket(manager, "wd-5", "NFO:NIFTYWD5CE", "BUY", 99.0)
+    manager._exit_quotes["NFO:NIFTYWD5CE"] = (98.50, 101.50, time.time())
+
+    exec_px, exec_src = manager._executable_exit_price(bracket, 100.50)
+    assert exec_px == 98.50
+    assert exec_src == "bid"


### PR DESCRIPTION
Closes the residual gap left by #1007.

#1007 moved stop breach detection onto the executable side in `_evaluate_exit_fast()`, but the independent bracket watchdog still called `_sl_crossed()`, which compared LTP alone. The watchdog is precisely the path that runs when normal tick evaluation is delayed, blocked or failing, so it must not carry weaker stop semantics than the primary path.

```
Long option   SL 99.00   LTP 100.50   Bid 98.50
tick evaluator -> exits
watchdog       -> did not recognise the breach
```

## Changes (one file)

- `_sl_crossed()` now resolves through `_executable_exit_price()` — bid for a long, ask for a short — with the same stale-quote LTP fallback.
- An already-breached executable price is sufficient. Requiring a freshly observed crossing would let a position that is *already* liquidatable below its stop keep running simply because the crossing tick was missed — the exact failure the watchdog exists to catch.
- Zero/absent stop returns False explicitly rather than relying on comparison against 0.0.
- The duplicated BUY/SELL watchdog branches collapse into one call, with a non-directional side guarded by `continue`.
- The watchdog exit payload carries `trigger_price` and `trigger_price_source`, and the reason string records both, matching the tick path.

`exit_pending` single-flight behaviour, `_fire_exits_batch` and the skip conditions are untouched.

## Tests

5 added: long exits on a bid breach with LTP above; short exits on an ask breach with LTP below; no exit when a fresh executable quote has not crossed; a stale favourable quote falls back to LTP and cannot suppress protection; the payload records `src=bid`.

`compileall` clean. Full suite **2410 passed, 2 skipped**.