### PR TITLE
fix(strategy): make trigger signals edge-driven and noise resistant

### DIFF
--- a/src/nifty_scalper_bot/strategies/elite_strategies/base_elite.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/base_elite.py
@@ -105,6 +105,7 @@ class EliteStrategy(Strategy):
         self._last_signal_at: datetime | None = None
         self._signals_generated = 0
         self._last_signal: EliteSignal | None = None
+        self._last_emitted_setup_by_symbol: dict[str, tuple[str, str, str]] = {}
         self._consecutive_evaluation_failures = 0
         self._last_evaluation_error: str | None = None
 
@@ -236,6 +237,20 @@ class EliteStrategy(Strategy):
                         extra={
                             "event": "elite_strategy_below_min_conf",
                             "strategy": self.name,
+                        },
+                    )
+                    return None
+                if self._is_duplicate_setup_vote(elite_signal):
+                    self._no_vote("setup_anchor_already_emitted")
+                    LOGGER.debug(
+                        "STRATEGY_NO_VOTE strategy=%s symbol=%s reason=setup_anchor_already_emitted",
+                        self.name,
+                        elite_signal.symbol,
+                        extra={
+                            "event": "STRATEGY_NO_VOTE",
+                            "strategy": self.name,
+                            "symbol": elite_signal.symbol,
+                            "reason": "setup_anchor_already_emitted",
                         },
                     )
                     return None
@@ -389,6 +404,12 @@ class EliteStrategy(Strategy):
         "setup_candle_timestamp",
         "signal_timestamp",
     )
+    _SETUP_VOTE_ID_SOURCES = (
+        "setup_id",
+        "setup_structure_id",
+        "structure_id",
+        *_SETUP_ANCHOR_SOURCES,
+    )
 
     @classmethod
     def _stamp_setup_anchor(
@@ -426,6 +447,40 @@ class EliteStrategy(Strategy):
         metadata.setdefault("latest_bar_ts", anchor)
         metadata.setdefault("setup_candle_timestamp", anchor)
         metadata.setdefault("bar_timestamp", anchor)
+
+    def _is_duplicate_setup_vote(self, elite_signal: EliteSignal) -> bool:
+        """Consume one trigger vote per symbol/setup anchor.
+
+        Push evaluation runs on live ticks, but trigger setups are defined by a
+        finalized candle/structure anchor. Re-emitting the same trigger vote on
+        every tick only repeats arbitration and plan construction. Context
+        strategies remain tick-responsive and are deliberately excluded.
+        """
+        metadata = elite_signal.metadata
+        if str(metadata.get("role") or "trigger").strip().lower() == "context":
+            return False
+        anchor = next(
+            (
+                metadata.get(key)
+                for key in self._SETUP_VOTE_ID_SOURCES
+                if metadata.get(key) not in (None, "")
+            ),
+            None,
+        )
+        if anchor is None:
+            return False
+        symbol_key = str(elite_signal.symbol or "").strip().upper()
+        side = str(
+            metadata.get("contract_side")
+            or metadata.get("trade_side")
+            or metadata.get("side")
+            or ""
+        ).strip().upper()
+        vote_key = (str(anchor), str(elite_signal.signal), side)
+        if self._last_emitted_setup_by_symbol.get(symbol_key) == vote_key:
+            return True
+        self._last_emitted_setup_by_symbol[symbol_key] = vote_key
+        return False
 
     def _no_vote(self, reason: str) -> None:
         """Record a single no-vote reason. Args: reason. Returns: None. Raises: none."""

--- a/src/nifty_scalper_bot/strategies/elite_strategies/base_elite.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/base_elite.py
@@ -105,7 +105,7 @@ class EliteStrategy(Strategy):
         self._last_signal_at: datetime | None = None
         self._signals_generated = 0
         self._last_signal: EliteSignal | None = None
-        self._last_emitted_setup_by_symbol: dict[str, tuple[str, str, str]] = {}
+        self._accepted_setup_by_symbol: dict[str, tuple[str, str, str]] = {}
         self._consecutive_evaluation_failures = 0
         self._last_evaluation_error: str | None = None
 
@@ -241,16 +241,16 @@ class EliteStrategy(Strategy):
                     )
                     return None
                 if self._is_duplicate_setup_vote(elite_signal):
-                    self._no_vote("setup_anchor_already_emitted")
+                    self._no_vote("setup_anchor_already_consumed")
                     LOGGER.debug(
-                        "STRATEGY_NO_VOTE strategy=%s symbol=%s reason=setup_anchor_already_emitted",
+                        "STRATEGY_NO_VOTE strategy=%s symbol=%s reason=setup_anchor_already_consumed",
                         self.name,
                         elite_signal.symbol,
                         extra={
                             "event": "STRATEGY_NO_VOTE",
                             "strategy": self.name,
                             "symbol": elite_signal.symbol,
-                            "reason": "setup_anchor_already_emitted",
+                            "reason": "setup_anchor_already_consumed",
                         },
                     )
                     return None
@@ -448,17 +448,12 @@ class EliteStrategy(Strategy):
         metadata.setdefault("setup_candle_timestamp", anchor)
         metadata.setdefault("bar_timestamp", anchor)
 
-    def _is_duplicate_setup_vote(self, elite_signal: EliteSignal) -> bool:
-        """Consume one trigger vote per symbol/setup anchor.
-
-        Push evaluation runs on live ticks, but trigger setups are defined by a
-        finalized candle/structure anchor. Re-emitting the same trigger vote on
-        every tick only repeats arbitration and plan construction. Context
-        strategies remain tick-responsive and are deliberately excluded.
-        """
+    def _setup_vote_key(
+        self, elite_signal: EliteSignal
+    ) -> tuple[str, tuple[str, str, str]] | None:
         metadata = elite_signal.metadata
         if str(metadata.get("role") or "trigger").strip().lower() == "context":
-            return False
+            return None
         anchor = next(
             (
                 metadata.get(key)
@@ -468,7 +463,7 @@ class EliteStrategy(Strategy):
             None,
         )
         if anchor is None:
-            return False
+            return None
         symbol_key = str(elite_signal.symbol or "").strip().upper()
         side = str(
             metadata.get("contract_side")
@@ -476,11 +471,36 @@ class EliteStrategy(Strategy):
             or metadata.get("side")
             or ""
         ).strip().upper()
-        vote_key = (str(anchor), str(elite_signal.signal), side)
-        if self._last_emitted_setup_by_symbol.get(symbol_key) == vote_key:
-            return True
-        self._last_emitted_setup_by_symbol[symbol_key] = vote_key
-        return False
+        return symbol_key, (str(anchor), str(elite_signal.signal), side)
+
+    def _is_duplicate_setup_vote(self, elite_signal: EliteSignal) -> bool:
+        """Return whether this finalized trigger setup already entered.
+
+        A setup is consumed only after the existing order-accepted callback.
+        Failed quote/risk/arbitration attempts can therefore retry safely while
+        an accepted setup cannot keep firing after an exit or tick retry.
+        """
+        resolved = self._setup_vote_key(elite_signal)
+        if resolved is None:
+            return False
+        symbol_key, vote_key = resolved
+        return self._accepted_setup_by_symbol.get(symbol_key) == vote_key
+
+    def notify_entry_accepted(self, side: str) -> None:
+        """Consume the last emitted trigger setup after order acceptance."""
+        signal = self._last_signal
+        if signal is None:
+            return
+        resolved = self._setup_vote_key(signal)
+        if resolved is None:
+            return
+        symbol_key, vote_key = resolved
+        accepted_side = str(side or "").strip().upper()
+        vote_side = vote_key[2]
+        if accepted_side in {"CE", "PE"} and vote_side in {"CE", "PE"}:
+            if accepted_side != vote_side:
+                return
+        self._accepted_setup_by_symbol[symbol_key] = vote_key
 
     def _no_vote(self, reason: str) -> None:
         """Record a single no-vote reason. Args: reason. Returns: None. Raises: none."""

--- a/src/nifty_scalper_bot/strategies/elite_strategies/order_flow.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/order_flow.py
@@ -29,6 +29,20 @@ def safe_float_env(name: str, default: float) -> float:
     return parse_float_env(os.getenv(name), default)
 
 
+def _context_confirmation_score(
+    strategy_score: float, context_min_score: float
+) -> tuple[float, float]:
+    """Return directional evidence and its bounded confirmation contribution.
+
+    The first context points pay only for quote availability/freshness and must
+    not reinforce a trigger. Only score above the context admission floor is
+    directional evidence; half of that evidence is published so the manager's
+    existing 0.45 multiplier remains gradual instead of saturating immediately.
+    """
+    evidence = max(0.0, min(10.0, float(strategy_score)) - max(0.0, float(context_min_score)))
+    return evidence, 0.5 * evidence
+
+
 class OrderFlowStrategy(EliteStrategy):
     """Order-flow vote using spread, depth imbalance and tick direction."""
 
@@ -244,7 +258,17 @@ class OrderFlowStrategy(EliteStrategy):
                     'quote_update_version': quote_update_version,
                 }
                 side_aligns = direction in {'CE', 'PE'} and direction == side
-                metadata.update({'context_role': 'confirmation', 'vote_timestamp': time.time(), 'context_bonus_score': strategy_score if side_aligns else 0.0, 'context_veto_score': strategy_score if (direction in {'CE', 'PE'} and direction != side) else 0.0, 'tick_supports_direction': tick_supports})
+                context_evidence_score, context_confirmation_score = (
+                    _context_confirmation_score(strategy_score, context_min_score)
+                )
+                metadata.update({
+                    'context_role': 'confirmation',
+                    'vote_timestamp': time.time(),
+                    'context_evidence_score': context_evidence_score,
+                    'context_bonus_score': context_confirmation_score if side_aligns else 0.0,
+                    'context_veto_score': strategy_score if (direction in {'CE', 'PE'} and direction != side) else 0.0,
+                    'tick_supports_direction': tick_supports,
+                })
                 return EliteSignal(symbol=symbol, signal='BUY', confidence=max(0.1, min(0.55, strategy_score / 10.0)), entry_price=current_price, stop_loss=None, target=None, quantity=self._cfg.quantity or 1, strategy_name='OrderFlow', metadata=metadata)
 
             depth_imbalance = (total_bid - total_ask) / max(total_bid + total_ask, 1.0)
@@ -451,6 +475,9 @@ class OrderFlowStrategy(EliteStrategy):
             elif not tick_supports:
                 trigger_block_reason = 'negative_premium_flow'
 
+            context_evidence_score, context_confirmation_score = (
+                _context_confirmation_score(strategy_score, context_min_score)
+            )
             metadata = {
                 'strategy': 'OrderFlow', 'strategy_name': 'OrderFlow', 'role': 'trigger' if trigger_conditions_met else 'context',
                 'source_domain': 'market_microstructure', 'context_score': strategy_score, 'side': side, 'trade_side': side,
@@ -478,11 +505,11 @@ class OrderFlowStrategy(EliteStrategy):
                 'negative_premium_flow_mode': 'hard' if clear_adverse_flow else 'soft',
                 'tick_age_ms': tick_age_ms,
                 'quote_update_version': quote_update_version,
-                 'quote_readiness_allowed': quote_readiness.allowed,
-                 'quote_readiness_reason': quote_readiness.reason,
-                 'real_ticks_last_60s': quote_readiness.real_ticks_last_60s,
-                 'real_tick_count_derived': quote_readiness.real_tick_count_derived,
-                 'reversal_persistence_confirmed': reversal_persistence_confirmed,
+                'quote_readiness_allowed': quote_readiness.allowed,
+                'quote_readiness_reason': quote_readiness.reason,
+                'real_ticks_last_60s': quote_readiness.real_ticks_last_60s,
+                'real_tick_count_derived': quote_readiness.real_tick_count_derived,
+                'reversal_persistence_confirmed': reversal_persistence_confirmed,
                 'selected_or_near_atm': selected_or_near_atm,
                 'bias_invalidated_by_microstructure': bias_invalidated_by_microstructure,
                 'microstructure_confirms_side': microstructure_confirms_side,
@@ -491,10 +518,16 @@ class OrderFlowStrategy(EliteStrategy):
                 'orderflow_conflict_override_applied': conflict_override_applied,
                 'orderflow_conflict_override': conflict_override_applied,
                 'conflict_override_reason': 'high_conviction_depth_spread_tick_near_atm' if conflict_override_applied else '',
+                'context_evidence_score': context_evidence_score,
             }
             if trigger_conditions_met:
                 metadata['approval_candidate'] = 'orderflow_live_depth_trigger'
-            metadata.update({'context_role': 'confirmation', 'vote_timestamp': time.time(), 'context_bonus_score': strategy_score if side_aligns else 0.0, 'context_veto_score': strategy_score if (direction in {'CE', 'PE'} and direction != side) else 0.0})
+            metadata.update({
+                'context_role': 'confirmation',
+                'vote_timestamp': time.time(),
+                'context_bonus_score': context_confirmation_score if side_aligns else 0.0,
+                'context_veto_score': strategy_score if (direction in {'CE', 'PE'} and direction != side) else 0.0,
+            })
             LOGGER.info(
                 'ORDERFLOW_TRIGGER_DECISION symbol=%s side=%s trigger_conditions_met=%s trigger_block_reason=%s score=%.2f spread_pct=%.2f context_age_seconds=%s',
                 symbol,

--- a/src/nifty_scalper_bot/strategies/elite_strategies/vwap_pro.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/vwap_pro.py
@@ -46,6 +46,11 @@ class VWAPProStrategy(EliteStrategy):
         self._slack_atr_mult = float(os.getenv('VWAP_SLACK_ATR_MULT', '1.5') or 1.5)
         self._max_distance_pct = float(os.getenv('VWAP_MAX_OPTION_DISTANCE_PCT', '0.18') or 0.18)
         self._max_atr_distance_mult = float(os.getenv('VWAP_MAX_ATR_DISTANCE_MULT', '1.5') or 1.5)
+        self._min_penetration_atr = max(
+            0.0,
+            float(os.getenv("VWAP_MIN_PENETRATION_ATR_MULT", "0.15") or 0.15),
+        )
+        self._accepted_thesis_sides: set[str] = set()
         self._futures_slope_neutral_eps = float(os.getenv("VWAP_FUTURES_SLOPE_NEUTRAL_EPS", "0.00005") or 0.00005)
         self._allow_early_trend_pullback = str(
             os.getenv("VWAP_PRO_ALLOW_EARLY_TREND_PULLBACK_LIVE", "false")
@@ -54,6 +59,12 @@ class VWAPProStrategy(EliteStrategy):
         ).strip().lower() in {"1", "true", "yes", "on"}
         self._early_trend_min_context_conf = float(os.getenv("VWAP_EARLY_TREND_MIN_CONTEXT_CONF", "0.90") or 0.90)
         self._early_trend_max_context_age = float(os.getenv("VWAP_EARLY_TREND_MAX_CONTEXT_AGE", "2.0") or 2.0)
+
+    def notify_entry_accepted(self, side: str) -> None:
+        """Disarm an accepted VWAP thesis until premium closes below VWAP."""
+        resolved = str(side or "").strip().upper()
+        if resolved in {"CE", "PE"}:
+            self._accepted_thesis_sides.add(resolved)
 
     def get_required_indicators(self) -> set[str]:
         """Args: none. Returns: indicators set. Raises: Exception."""
@@ -183,14 +194,28 @@ class VWAPProStrategy(EliteStrategy):
             if not option_premium_domain:
                 self._no_vote('invalid_price_domain')
                 return None
-            premium_above_vwap = current_price >= vwap
+
+            # An accepted VWAP trade owns this side's thesis until a finalized
+            # premium candle closes below VWAP. The reset candle only rearms;
+            # it cannot immediately originate the next trade.
+            if contract_side in self._accepted_thesis_sides:
+                if close < vwap:
+                    self._accepted_thesis_sides.discard(contract_side)
+                    self._no_vote('vwap_thesis_reset')
+                else:
+                    self._no_vote('vwap_thesis_not_reset')
+                return None
+
+            premium_above_vwap = close >= vwap
             if premium_above_vwap:
                 score += 2.0
                 reasons.append('premium_above_vwap')
 
             candle_body = abs(close - open_price)
             atr_safe = max(atr, current_price * 0.01, 1.0)
-            continuation_confirmed = candle_body >= (0.35 * atr_safe)
+            continuation_confirmed = bool(
+                close > open_price and candle_body >= (0.35 * atr_safe)
+            )
             if continuation_confirmed:
                 score += 1.5
                 reasons.append('premium_continuation')
@@ -200,6 +225,14 @@ class VWAPProStrategy(EliteStrategy):
                 pullback_flag = True
                 score += 1.5
                 reasons.append('premium_reclaim_vwap')
+
+            penetration_atr = max(0.0, close - vwap) / atr_safe
+            penetration_confirmed = bool(
+                premium_above_vwap
+                and penetration_atr >= self._min_penetration_atr
+            )
+            if penetration_confirmed:
+                reasons.append('premium_vwap_penetration')
 
             if distance_pct <= self._max_distance_pct * 0.7:
                 score += 1.0
@@ -287,6 +320,32 @@ class VWAPProStrategy(EliteStrategy):
                 boost = float(os.getenv("VWAP_PRO_TREND_CONTEXT_BOOST", "0.5") or "0.5")
                 score = min(10.0, score + boost)
                 reasons.append("trend_context_boost")
+
+            event_confirmed = bool(
+                continuation_confirmed
+                or pullback_flag
+                or penetration_confirmed
+                or early_trend_pullback
+            )
+            if is_live and not event_confirmed:
+                self._no_vote('vwap_event_unconfirmed')
+                LOGGER.info(
+                    "STRATEGY_NO_VOTE strategy=VWAPPro symbol=%s reason=vwap_event_unconfirmed close=%.2f vwap=%.2f penetration_atr=%.3f",
+                    symbol,
+                    close,
+                    vwap,
+                    penetration_atr,
+                    extra={
+                        "event": "STRATEGY_NO_VOTE",
+                        "strategy": "VWAPPro",
+                        "symbol": symbol,
+                        "reason": "vwap_event_unconfirmed",
+                        "close": close,
+                        "vwap": vwap,
+                        "penetration_atr": penetration_atr,
+                    },
+                )
+                return None
             threshold_source = 'trend_aligned' if trend_alignment else 'base'
 
             if score < min_score:
@@ -408,6 +467,9 @@ class VWAPProStrategy(EliteStrategy):
                 'futures_volume_ratio': futures_volume_ratio,
                 'trigger_block_reason': '' if strategy_score >= min_score else 'weak_score',
                 'continuation_confirmed': continuation_confirmed,
+                'penetration_confirmed': penetration_confirmed,
+                'vwap_penetration_atr': round(penetration_atr, 4),
+                'vwap_event_confirmed': event_confirmed,
                 'early_trend_pullback': early_trend_pullback,
                 'setup_invalidation_premium': current_price - atr_safe,
                 'invalidation_level_domain': 'option_premium',

--- a/tests/strategies/test_orderflow_depth_context.py
+++ b/tests/strategies/test_orderflow_depth_context.py
@@ -1,5 +1,8 @@
 from nifty_scalper_bot.strategies.elite_strategies.config_models import OrderFlowStrategyConfig
-from nifty_scalper_bot.strategies.elite_strategies.order_flow import OrderFlowStrategy
+from nifty_scalper_bot.strategies.elite_strategies.order_flow import (
+    OrderFlowStrategy,
+    _context_confirmation_score,
+)
 
 
 def test_orderflow_no_missing_depth_when_bid_ask_and_depth_exist() -> None:
@@ -17,6 +20,15 @@ def test_orderflow_no_missing_depth_when_bid_ask_and_depth_exist() -> None:
     signal = strategy._evaluate_signal('NFO:NIFTY26MAY24000CE', indicators, current_price=100.5)
     assert signal is not None
     assert getattr(strategy, 'last_no_vote_reason', None) != 'missing_depth'
+    assert signal.metadata['context_evidence_score'] == 6.0
+    assert signal.metadata['context_bonus_score'] == 3.0
+
+
+def test_orderflow_context_floor_does_not_reinforce_a_trigger() -> None:
+    assert _context_confirmation_score(4.0, 4.0) == (0.0, 0.0)
+    assert _context_confirmation_score(6.0, 4.0) == (2.0, 1.0)
+    assert _context_confirmation_score(10.0, 4.0) == (6.0, 3.0)
+
 
 from nifty_scalper_bot.strategies.indicators import IndicatorEngine
 

--- a/tests/strategies/test_setup_anchor_identity.py
+++ b/tests/strategies/test_setup_anchor_identity.py
@@ -9,6 +9,9 @@ from nifty_scalper_bot.strategies.elite_strategies.base_elite import (
     EliteSignal,
     EliteStrategy,
 )
+from nifty_scalper_bot.strategies.elite_strategies.config_models import (
+    EliteStrategyConfig,
+)
 from nifty_scalper_bot.strategies.signal_identity_patch import (
     _deterministic_id,
     has_setup_anchor,
@@ -28,6 +31,36 @@ def _elite_signal(symbol: str = "NFO:NIFTY2680424400CE") -> EliteSignal:
         strategy_name="VWAPPro",
         metadata={"strategy": "VWAPPro"},
     )
+
+
+class _RepeatingStrategy(EliteStrategy):
+    def __init__(self, role: str = "trigger") -> None:
+        self._role = role
+        super().__init__(
+            config=EliteStrategyConfig(min_confidence=0.0),
+            indicator_engine=SimpleNamespace(),
+        )
+
+    def get_required_indicators(self) -> list[str]:
+        return []
+
+    def _evaluate_signal(
+        self,
+        symbol: str,
+        indicators: dict[str, object],
+        current_price: float,
+        position: object | None = None,
+    ) -> EliteSignal:
+        del indicators, position
+        signal = _elite_signal(symbol)
+        signal.entry_price = current_price
+        signal.metadata.update(
+            {
+                "role": self._role,
+                "contract_side": "CE",
+            }
+        )
+        return signal
 
 
 def test_anchor_is_stamped_from_indicator_context() -> None:
@@ -115,3 +148,29 @@ def test_existing_signal_anchor_is_not_overwritten() -> None:
     EliteStrategy._stamp_setup_anchor(signal, {"latest_bar_ts": BAR_TS + 300.0})
 
     assert signal.metadata["setup_candle_timestamp"] == BAR_TS
+
+
+def test_push_trigger_emits_once_per_setup_anchor() -> None:
+    strategy = _RepeatingStrategy(role="trigger")
+    indicators = {"latest_bar_ts": BAR_TS}
+
+    first = strategy.generate_signal(_elite_signal().symbol, indicators, 100.0)
+    repeated = strategy.generate_signal(_elite_signal().symbol, indicators, 100.5)
+    next_bar = strategy.generate_signal(
+        _elite_signal().symbol,
+        {"latest_bar_ts": BAR_TS + 60.0},
+        101.0,
+    )
+
+    assert first is not None
+    assert repeated is None
+    assert strategy.last_no_vote_reason == "setup_anchor_already_emitted"
+    assert next_bar is not None
+
+
+def test_context_vote_remains_tick_responsive_on_same_anchor() -> None:
+    strategy = _RepeatingStrategy(role="context")
+    indicators = {"latest_bar_ts": BAR_TS}
+
+    assert strategy.generate_signal(_elite_signal().symbol, indicators, 100.0) is not None
+    assert strategy.generate_signal(_elite_signal().symbol, indicators, 100.5) is not None

--- a/tests/strategies/test_setup_anchor_identity.py
+++ b/tests/strategies/test_setup_anchor_identity.py
@@ -150,21 +150,25 @@ def test_existing_signal_anchor_is_not_overwritten() -> None:
     assert signal.metadata["setup_candle_timestamp"] == BAR_TS
 
 
-def test_push_trigger_emits_once_per_setup_anchor() -> None:
+def test_trigger_retry_is_allowed_until_entry_is_accepted() -> None:
     strategy = _RepeatingStrategy(role="trigger")
     indicators = {"latest_bar_ts": BAR_TS}
+    symbol = _elite_signal().symbol
 
-    first = strategy.generate_signal(_elite_signal().symbol, indicators, 100.0)
-    repeated = strategy.generate_signal(_elite_signal().symbol, indicators, 100.5)
+    first = strategy.generate_signal(symbol, indicators, 100.0)
+    retry_before_acceptance = strategy.generate_signal(symbol, indicators, 100.5)
+    strategy.notify_entry_accepted("CE")
+    repeated_after_acceptance = strategy.generate_signal(symbol, indicators, 101.0)
     next_bar = strategy.generate_signal(
-        _elite_signal().symbol,
+        symbol,
         {"latest_bar_ts": BAR_TS + 60.0},
-        101.0,
+        101.5,
     )
 
     assert first is not None
-    assert repeated is None
-    assert strategy.last_no_vote_reason == "setup_anchor_already_emitted"
+    assert retry_before_acceptance is not None
+    assert repeated_after_acceptance is None
+    assert strategy.last_no_vote_reason == "setup_anchor_already_consumed"
     assert next_bar is not None
 
 
@@ -173,4 +177,5 @@ def test_context_vote_remains_tick_responsive_on_same_anchor() -> None:
     indicators = {"latest_bar_ts": BAR_TS}
 
     assert strategy.generate_signal(_elite_signal().symbol, indicators, 100.0) is not None
+    strategy.notify_entry_accepted("CE")
     assert strategy.generate_signal(_elite_signal().symbol, indicators, 100.5) is not None

--- a/tests/strategies/test_vwap_metadata_contract_side.py
+++ b/tests/strategies/test_vwap_metadata_contract_side.py
@@ -6,12 +6,99 @@ class _DummyEngine:
     pass
 
 
+def _indicators(**updates):
+    payload = {
+        'vwap': 100.0,
+        'atr': 5.0,
+        'close': 103.0,
+        'open': 100.0,
+        'high': 104.0,
+        'low': 99.0,
+        'volume': 1000.0,
+        'avg_volume': 900.0,
+        'spread_pct': 0.5,
+        'direction_bias': 'CE',
+        'underlying_direction_confidence': 0.95,
+        'context_age_seconds': 0.0,
+    }
+    payload.update(updates)
+    return payload
+
+
 def test_vwap_metadata_contract_side_and_setup_scores_present():
     strategy = VWAPProStrategy(VWAPProStrategyConfig(), _DummyEngine())
-    signal = strategy._evaluate_signal('NFO:NIFTY26FEB22500CE', {'vwap': 100.0, 'atr': 5.0, 'close': 103.0, 'open': 100.0, 'high': 104.0, 'low': 99.0, 'volume': 1000.0, 'avg_volume': 900.0, 'spread_pct': 2.0, 'direction_bias': 'UNKNOWN'}, 101.0)
+    signal = strategy._evaluate_signal(
+        'NFO:NIFTY26FEB22500CE',
+        _indicators(direction_bias='UNKNOWN'),
+        101.0,
+    )
     assert signal is not None
     metadata = signal.metadata
     assert metadata['contract_side'] == 'CE'
     assert metadata['direction_bias'] is None
     assert metadata['raw_setup_score'] is not None
     assert metadata['setup_score'] is not None
+
+
+def test_live_vwap_rejects_threshold_pass_from_small_noise(monkeypatch):
+    monkeypatch.setenv('EXECUTION_MODE', 'LIVE')
+    strategy = VWAPProStrategy(VWAPProStrategyConfig(), _DummyEngine())
+
+    signal = strategy._evaluate_signal(
+        'NFO:NIFTY26FEB22500CE',
+        _indicators(
+            close=100.05,
+            open=100.04,
+            high=100.10,
+            low=100.02,
+            volume=0.0,
+            avg_volume=0.0,
+        ),
+        100.05,
+    )
+
+    assert signal is None
+    assert strategy.last_no_vote_reason == 'vwap_event_unconfirmed'
+
+
+def test_live_vwap_accepts_meaningful_atr_penetration(monkeypatch):
+    monkeypatch.setenv('EXECUTION_MODE', 'LIVE')
+    strategy = VWAPProStrategy(VWAPProStrategyConfig(), _DummyEngine())
+
+    signal = strategy._evaluate_signal(
+        'NFO:NIFTY26FEB22500CE',
+        _indicators(
+            close=100.80,
+            open=100.75,
+            high=100.85,
+            low=100.70,
+            volume=0.0,
+            avg_volume=0.0,
+        ),
+        100.80,
+    )
+
+    assert signal is not None
+    assert signal.metadata['penetration_confirmed'] is True
+    assert signal.metadata['vwap_event_confirmed'] is True
+
+
+def test_accepted_vwap_thesis_requires_closed_candle_reset(monkeypatch):
+    monkeypatch.setenv('EXECUTION_MODE', 'LIVE')
+    strategy = VWAPProStrategy(VWAPProStrategyConfig(), _DummyEngine())
+    symbol = 'NFO:NIFTY26FEB22500CE'
+
+    assert strategy._evaluate_signal(symbol, _indicators(), 103.0) is not None
+    strategy.notify_entry_accepted('CE')
+
+    assert strategy._evaluate_signal(symbol, _indicators(close=104.0), 104.0) is None
+    assert strategy.last_no_vote_reason == 'vwap_thesis_not_reset'
+
+    assert strategy._evaluate_signal(
+        symbol,
+        _indicators(close=99.5, open=100.0, high=100.2, low=99.2),
+        99.5,
+    ) is None
+    assert strategy.last_no_vote_reason == 'vwap_thesis_reset'
+
+    assert strategy._evaluate_signal(symbol, _indicators(), 103.0) is not None


### PR DESCRIPTION
## Problem

The execution layer suppresses duplicate orders, but accepted trigger setups could still be regenerated after an exit, VWAPPro could pass its live floor from a marginal move around VWAP, and baseline OrderFlow points saturated context reinforcement.

## Focused corrections

1. **Consume accepted trigger setup anchors**
   - Trigger setups remain retryable while quote, arbitration or risk gates reject them.
   - The existing `order_accepted` callback consumes the finalized setup anchor only after a real entry is accepted.
   - The same accepted strategy/symbol/setup anchor cannot fire again; a newer setup anchor can.
   - Context strategies remain tick-responsive.

2. **VWAP requires a discrete event in LIVE**
   - Premium-above-VWAP uses the finalized close rather than oscillating LTP.
   - Continuation must be bullish and at least 0.35 ATR.
   - A live vote requires continuation, reclaim, early pullback, or at least 0.15 ATR VWAP penetration.

3. **Accepted VWAP thesis must reset**
   - The existing `notify_entry_accepted` hook disarms the accepted CE/PE VWAP thesis.
   - Same-side VWAP entries remain blocked until a finalized premium candle closes below VWAP.
   - The reset candle only rearms; it cannot immediately originate the next entry.

4. **OrderFlow reinforcement is evidence-proportional**
   - Quote/freshness admission points no longer reinforce a trigger.
   - `context_evidence_score = max(0, score - context_min_score)`.
   - Half of that evidence is passed into the existing manager multiplier, preventing immediate bonus saturation.
   - Opposite-side veto strength is unchanged.

## TDD

- Trigger retries remain possible before acceptance; accepted same-anchor setups are blocked; newer anchors pass; context remains tick-responsive.
- Marginal live VWAP noise is rejected; meaningful ATR penetration is accepted.
- Accepted VWAP thesis blocks until a closed-candle reset and then rearms.
- OrderFlow floor gives zero confirmation and stronger evidence scales proportionally.

No execution, risk, order-placement or exit code changed.