### PR TITLE
fix(strategy): unify live quality and setup lifecycle authority

### DIFF
--- a/src/nifty_scalper_bot/strategies/elite_strategies/base_elite.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/base_elite.py
@@ -7,7 +7,8 @@ Fixed: 'Signal' object has no attribute 'strategy_name' crash.
 from __future__ import annotations
 
 import inspect
-from dataclasses import dataclass, field, asdict
+import os
+from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from typing import Any, Dict, Mapping
 
@@ -15,6 +16,7 @@ from nifty_scalper_bot.strategies.elite_strategies.config_models import (
     EliteStrategyConfig,
 )
 from nifty_scalper_bot.strategies.signal_generator import Signal, Strategy
+from nifty_scalper_bot.strategies.signal_quality import build_trade_quality_evidence
 from nifty_scalper_bot.utils.logging import get_logger
 
 LOGGER = get_logger(__name__)
@@ -105,7 +107,6 @@ class EliteStrategy(Strategy):
         self._last_signal_at: datetime | None = None
         self._signals_generated = 0
         self._last_signal: EliteSignal | None = None
-        self._accepted_setup_by_symbol: dict[str, tuple[str, str, str]] = {}
         self._consecutive_evaluation_failures = 0
         self._last_evaluation_error: str | None = None
 
@@ -229,6 +230,16 @@ class EliteStrategy(Strategy):
             self._consecutive_evaluation_failures = 0
             if elite_signal:
                 self._stamp_setup_anchor(elite_signal, indicators_payload)
+                self._stamp_structural_setup_id(elite_signal, indicators_payload)
+                quality = self._stamp_quality_evidence(elite_signal, indicators_payload)
+                if (
+                    str(os.getenv("EXECUTION_MODE", "SHADOW")).strip().upper()
+                    == "LIVE"
+                    and bool(quality.get("quality_spread_observed"))
+                    and not bool(quality.get("quality_spread_pass"))
+                ):
+                    self._no_vote("wide_spread")
+                    return None
                 min_conf = _as_confidence_fraction(self._config.min_confidence)
                 if float(elite_signal.confidence) < min_conf:
                     self._no_vote("below_strategy_min_confidence")
@@ -237,20 +248,6 @@ class EliteStrategy(Strategy):
                         extra={
                             "event": "elite_strategy_below_min_conf",
                             "strategy": self.name,
-                        },
-                    )
-                    return None
-                if self._is_duplicate_setup_vote(elite_signal):
-                    self._no_vote("setup_anchor_already_consumed")
-                    LOGGER.debug(
-                        "STRATEGY_NO_VOTE strategy=%s symbol=%s reason=setup_anchor_already_consumed",
-                        self.name,
-                        elite_signal.symbol,
-                        extra={
-                            "event": "STRATEGY_NO_VOTE",
-                            "strategy": self.name,
-                            "symbol": elite_signal.symbol,
-                            "reason": "setup_anchor_already_consumed",
                         },
                     )
                     return None
@@ -415,14 +412,7 @@ class EliteStrategy(Strategy):
     def _stamp_setup_anchor(
         cls, elite_signal: EliteSignal, indicators: Mapping[str, Any]
     ) -> None:
-        """Stamp the evaluation bar identity onto the signal metadata.
-
-        Without this, only SMCLiquidity carried a setup anchor. Every other
-        strategy produced metadata with no bar identity, so the deterministic
-        signal id degraded to a wall-clock minute bucket (the same setup earned
-        a fresh id every 60s, defeating duplicate suppression) and the
-        structural stop-rearm gate could never observe a newer setup candle.
-        """
+        """Stamp the evaluation bar identity onto the signal metadata."""
         metadata = elite_signal.metadata
         anchor = None
         for key in cls._SETUP_ANCHOR_SOURCES:
@@ -447,6 +437,73 @@ class EliteStrategy(Strategy):
         metadata.setdefault("latest_bar_ts", anchor)
         metadata.setdefault("setup_candle_timestamp", anchor)
         metadata.setdefault("bar_timestamp", anchor)
+
+    @staticmethod
+    def _stamp_structural_setup_id(
+        elite_signal: EliteSignal, indicators: Mapping[str, Any]
+    ) -> None:
+        """Use market structure, not process memory, as the reusable setup key."""
+        metadata = elite_signal.metadata
+        if metadata.get("setup_id") not in (None, ""):
+            return
+        if str(metadata.get("role") or "trigger").lower() == "context":
+            return
+        strategy = str(
+            elite_signal.strategy_name or metadata.get("strategy") or ""
+        ).lower()
+        side = str(
+            metadata.get("contract_side")
+            or metadata.get("trade_side")
+            or metadata.get("side")
+            or ""
+        ).upper()
+        if "orb" in strategy:
+            session = str(
+                indicators.get("session_date")
+                or str(metadata.get("latest_bar_ts") or "")[:10]
+                or datetime.now(timezone.utc).date().isoformat()
+            )
+            high = metadata.get("opening_range_high")
+            low = metadata.get("opening_range_low")
+            if high is not None and low is not None:
+                metadata["setup_id"] = f"orb:{session}:{side}:{high}:{low}"
+        elif "smc" in strategy:
+            reference = (
+                indicators.get("prior_swing_low")
+                if side == "CE"
+                else indicators.get("prior_swing_high")
+                if side == "PE"
+                else None
+            )
+            if reference is None:
+                reference = metadata.get("sweep_level")
+            if reference is not None:
+                metadata["setup_id"] = f"smc:{side}:{reference}"
+
+    @staticmethod
+    def _stamp_quality_evidence(
+        elite_signal: EliteSignal, indicators: Mapping[str, Any]
+    ) -> dict[str, object]:
+        """Attach the canonical quality contract to every elite trigger vote."""
+        metadata = elite_signal.metadata
+        side = str(
+            metadata.get("contract_side")
+            or metadata.get("trade_side")
+            or metadata.get("side")
+            or ""
+        ).upper()
+        evidence = build_trade_quality_evidence(indicators, side=side)
+        for key, value in evidence.items():
+            metadata.setdefault(key, value)
+        for key in (
+            "spread_pct",
+            "quote_depth_valid",
+            "tradable_quote",
+            "stale_data_used",
+        ):
+            if metadata.get(key) is None and indicators.get(key) is not None:
+                metadata[key] = indicators.get(key)
+        return evidence
 
     def _setup_vote_key(
         self, elite_signal: EliteSignal
@@ -474,33 +531,13 @@ class EliteStrategy(Strategy):
         return symbol_key, (str(anchor), str(elite_signal.signal), side)
 
     def _is_duplicate_setup_vote(self, elite_signal: EliteSignal) -> bool:
-        """Return whether this finalized trigger setup already entered.
-
-        A setup is consumed only after the existing order-accepted callback.
-        Failed quote/risk/arbitration attempts can therefore retry safely while
-        an accepted setup cannot keep firing after an exit or tick retry.
-        """
-        resolved = self._setup_vote_key(elite_signal)
-        if resolved is None:
-            return False
-        symbol_key, vote_key = resolved
-        return self._accepted_setup_by_symbol.get(symbol_key) == vote_key
+        """Compatibility shim; runner deterministic identity owns deduplication."""
+        del elite_signal
+        return False
 
     def notify_entry_accepted(self, side: str) -> None:
-        """Consume the last emitted trigger setup after order acceptance."""
-        signal = self._last_signal
-        if signal is None:
-            return
-        resolved = self._setup_vote_key(signal)
-        if resolved is None:
-            return
-        symbol_key, vote_key = resolved
-        accepted_side = str(side or "").strip().upper()
-        vote_side = vote_key[2]
-        if accepted_side in {"CE", "PE"} and vote_side in {"CE", "PE"}:
-            if accepted_side != vote_side:
-                return
-        self._accepted_setup_by_symbol[symbol_key] = vote_key
+        """Compatibility hook; order lifecycle is owned by the runner."""
+        del side
 
     def _no_vote(self, reason: str) -> None:
         """Record a single no-vote reason. Args: reason. Returns: None. Raises: none."""

--- a/src/nifty_scalper_bot/strategies/elite_strategies/orb_pro.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/orb_pro.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import os
-from datetime import datetime, timedelta, timezone
 from typing import Any
 
 from nifty_scalper_bot.strategies.elite_strategies.base_elite import EliteSignal, EliteStrategy
@@ -20,24 +19,27 @@ class ORBProStrategy(EliteStrategy):
         """Args: config, indicator_engine. Returns: None. Raises: Exception."""
         super().__init__(config=config, indicator_engine=indicator_engine)
         self._cfg = config
-        # One breakout trade per direction per day: {(iso_date, 'CE'|'PE')}
-        self._fired_today: set[tuple[str, str]] = set()
 
     def get_required_indicators(self) -> set[str]:
         """Args: none. Returns: indicators set. Raises: Exception."""
-        return {'orb_high', 'orb_low', 'orb_ready', 'close', 'open', 'volume', 'avg_volume', 'atr', 'direction_bias', 'regime'}
-
-    def notify_entry_accepted(self, side: str) -> None:
-        """Consume today's ORB direction only after order acceptance."""
-        accepted_side = str(side or "").strip().upper()
-        if accepted_side not in {"CE", "PE"}:
-            return
-        today = datetime.now(
-            timezone(timedelta(hours=5, minutes=30))
-        ).date().isoformat()
-        self._fired_today.add((today, accepted_side))
-        self._fired_today = {
-            key for key in self._fired_today if key[0] == today
+        return {
+            'orb_high',
+            'orb_low',
+            'orb_ready',
+            'close',
+            'open',
+            'high',
+            'low',
+            'volume',
+            'avg_volume',
+            'atr',
+            'direction_bias',
+            'underlying_direction_bias',
+            'regime',
+            'spread_pct',
+            'quote_depth_valid',
+            'tradable_quote',
+            'stale_data_used',
         }
 
     def _evaluate_signal(self, symbol: str, indicators: dict[str, Any], current_price: float, position: Any | None = None) -> EliteSignal | None:
@@ -55,7 +57,11 @@ class ORBProStrategy(EliteStrategy):
             atr = max(float(indicators.get('atr') or 0.0), current_price * 0.01, 1.0)
             vol = float(indicators.get('volume') or 0.0)
             avg_vol = float(indicators.get('avg_volume') or 0.0)
-            direction = str(indicators.get('direction_bias') or '').upper()
+            direction = str(
+                indicators.get('underlying_direction_bias')
+                or indicators.get('direction_bias')
+                or ''
+            ).upper()
             regime = str(indicators.get('regime') or '').upper()
 
             if not or_complete:
@@ -73,12 +79,6 @@ class ORBProStrategy(EliteStrategy):
             breakout_side = 'CE' if close > orb_high else 'PE' if close < orb_low else 'UNKNOWN'
             if breakout_side == 'UNKNOWN':
                 self._no_vote('no_breakout')
-                return None
-
-            day_key = (datetime.now(timezone(timedelta(hours=5, minutes=30))).date().isoformat(), breakout_side)
-            if day_key in self._fired_today:
-                self._no_vote('direction_already_traded_today')
-                LOGGER.debug('STRATEGY_NO_VOTE strategy=ORBPro reason=direction_already_traded_today side=%s', breakout_side)
                 return None
 
             candle_range = max(abs(float(indicators.get('high') or close) - float(indicators.get('low') or close)), 1e-9)
@@ -120,8 +120,13 @@ class ORBProStrategy(EliteStrategy):
             strategy_score = max(0.0, min(10.0, score))
             metadata = {
                 'strategy': 'ORBPro',
+                'strategy_name': 'ORBPro',
+                'role': 'trigger',
+                'trade_side': breakout_side,
                 'side': breakout_side,
+                'contract_side': breakout_side,
                 'direction_bias': breakout_side,
+                'raw_setup_score': strategy_score,
                 'strategy_score': strategy_score,
                 'score_reasons': reasons,
                 'setup_type': 'opening_range_breakout',
@@ -137,7 +142,7 @@ class ORBProStrategy(EliteStrategy):
                 'retest_confirmed': retest_confirmed,
                 'breakout_body_pct': round(breakout_body_pct, 3),
                 'volume_or_tick_confirmation': vol_tick,
-                'invalidation_level': orb_low if breakout_side == 'CE' else orb_high,
+                'invalidation_level': stop_level,
             }
             LOGGER.info('STRATEGY_VOTE strategy=ORBPro side=%s score=%.2f', breakout_side, strategy_score)
             return EliteSignal(

--- a/src/nifty_scalper_bot/strategies/elite_strategies/orb_pro.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/orb_pro.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+from datetime import datetime, timezone
 from typing import Any
 
 from nifty_scalper_bot.strategies.elite_strategies.base_elite import EliteSignal, EliteStrategy
@@ -104,7 +105,6 @@ class ORBProStrategy(EliteStrategy):
             if vol_tick:
                 score += 1.0
                 reasons.append('volume_or_tick_confirmation')
-            # Real RR from the actual stop (range invalidation) and target (2*ATR)
             stop_level = orb_low if breakout_side == 'CE' else orb_high
             risk = abs(close - stop_level)
             rr = (2.0 * atr) / risk if risk > 1e-9 else 0.0
@@ -118,6 +118,10 @@ class ORBProStrategy(EliteStrategy):
                 reasons.append(f'rr_thin_{rr:.1f}')
 
             strategy_score = max(0.0, min(10.0, score))
+            session_date = str(
+                indicators.get('session_date')
+                or datetime.now(timezone.utc).date().isoformat()
+            )
             metadata = {
                 'strategy': 'ORBPro',
                 'strategy_name': 'ORBPro',
@@ -125,6 +129,7 @@ class ORBProStrategy(EliteStrategy):
                 'trade_side': breakout_side,
                 'side': breakout_side,
                 'contract_side': breakout_side,
+                'setup_id': f'orb:{session_date}:{breakout_side}:{orb_high}:{orb_low}',
                 'direction_bias': breakout_side,
                 'raw_setup_score': strategy_score,
                 'strategy_score': strategy_score,

--- a/src/nifty_scalper_bot/strategies/elite_strategies/vwap_pro.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/vwap_pro.py
@@ -5,7 +5,10 @@ from typing import Any
 
 from nifty_scalper_bot.strategies.elite_strategies.base_elite import EliteSignal, EliteStrategy
 from nifty_scalper_bot.strategies.elite_strategies.config_models import VWAPProStrategyConfig
-from nifty_scalper_bot.strategies.signal_quality import resolve_signal_domain
+from nifty_scalper_bot.strategies.signal_quality import (
+    canonical_max_spread_pct,
+    resolve_signal_domain,
+)
 from nifty_scalper_bot.strategies.runtime_context_contract import resolve_context_age_seconds
 from nifty_scalper_bot.utils.logging import get_logger
 
@@ -13,16 +16,7 @@ LOGGER = get_logger(__name__)
 
 
 def _fmt_optional(value: float | None, digits: int) -> str:
-    """Format an optional metric for logging without crashing on None.
-
-    futures_vwap_slope / futures_volume_ratio are legitimately None when the
-    futures context is unavailable (they are no longer conflated with 0.0).
-    Feeding None to a %.4f/%.2f specifier raised
-    "TypeError: must be real number, not NoneType" inside the STRATEGY_NO_VOTE
-    log call, which the broad handler swallowed as a strategy failure -- so
-    VWAPPro silently produced no vote on every evaluation.
-    Args: value, digits. Returns: formatted str or "unavailable". Raises: none.
-    """
+    """Format an optional metric for logging without crashing on None."""
     if value is None:
         return "unavailable"
     try:
@@ -50,7 +44,10 @@ class VWAPProStrategy(EliteStrategy):
             0.0,
             float(os.getenv("VWAP_MIN_PENETRATION_ATR_MULT", "0.15") or 0.15),
         )
-        self._accepted_thesis_sides: set[str] = set()
+        # The last finalized below-VWAP/reclaim anchor defines the thesis.
+        # It is structural, not an order-state latch; the runner persists the
+        # resulting setup_id and owns accepted/failed order lifecycle.
+        self._thesis_anchor_by_side: dict[str, str] = {}
         self._futures_slope_neutral_eps = float(os.getenv("VWAP_FUTURES_SLOPE_NEUTRAL_EPS", "0.00005") or 0.00005)
         self._allow_early_trend_pullback = str(
             os.getenv("VWAP_PRO_ALLOW_EARLY_TREND_PULLBACK_LIVE", "false")
@@ -59,12 +56,6 @@ class VWAPProStrategy(EliteStrategy):
         ).strip().lower() in {"1", "true", "yes", "on"}
         self._early_trend_min_context_conf = float(os.getenv("VWAP_EARLY_TREND_MIN_CONTEXT_CONF", "0.90") or 0.90)
         self._early_trend_max_context_age = float(os.getenv("VWAP_EARLY_TREND_MAX_CONTEXT_AGE", "2.0") or 2.0)
-
-    def notify_entry_accepted(self, side: str) -> None:
-        """Disarm an accepted VWAP thesis until premium closes below VWAP."""
-        resolved = str(side or "").strip().upper()
-        if resolved in {"CE", "PE"}:
-            self._accepted_thesis_sides.add(resolved)
 
     def get_required_indicators(self) -> set[str]:
         """Args: none. Returns: indicators set. Raises: Exception."""
@@ -86,6 +77,8 @@ class VWAPProStrategy(EliteStrategy):
             "futures_vwap_slope",
             "futures_volume_ratio",
             "spread_pct",
+            "quote_depth_valid",
+            "tradable_quote",
             "spot_context",
             "futures_context",
             "stale_data_used",
@@ -97,10 +90,6 @@ class VWAPProStrategy(EliteStrategy):
         del position
         try:
             self._no_vote("stale_or_invalid_data")
-            # Reference priority: the broker's day VWAP, then our session-anchored
-            # VWAP, then the rolling `period`-bar mean. Previously the rolling
-            # proxy won unconditionally because it is almost never falsy, so the
-            # true VWAP sat unused in the same payload.
             vwap = float(
                 indicators.get('exchange_vwap')
                 or indicators.get('session_vwap')
@@ -133,6 +122,7 @@ class VWAPProStrategy(EliteStrategy):
                 or fut_ctx.get("direction_bias")
                 or ""
             ).upper()
+
             def _optional_float(value: Any) -> float | None:
                 try:
                     return None if value is None else float(value)
@@ -160,8 +150,7 @@ class VWAPProStrategy(EliteStrategy):
                 self._no_vote('stale_data')
                 LOGGER.debug('STRATEGY_NO_VOTE strategy=VWAPPro reason=stale_data')
                 return None
-            max_spread_pct = 12.0 if str(os.getenv('EXECUTION_MODE','SHADOW')).strip().upper() == 'LIVE' else 28.0
-
+            max_spread_pct = canonical_max_spread_pct()
             if spread_pct > max_spread_pct:
                 self._no_vote('wide_spread')
                 LOGGER.debug('STRATEGY_NO_VOTE strategy=VWAPPro reason=wide_spread')
@@ -195,15 +184,28 @@ class VWAPProStrategy(EliteStrategy):
                 self._no_vote('invalid_price_domain')
                 return None
 
-            # An accepted VWAP trade owns this side's thesis until a finalized
-            # premium candle closes below VWAP. The reset candle only rearms;
-            # it cannot immediately originate the next trade.
-            if contract_side in self._accepted_thesis_sides:
-                if close < vwap:
-                    self._accepted_thesis_sides.discard(contract_side)
-                    self._no_vote('vwap_thesis_reset')
-                else:
-                    self._no_vote('vwap_thesis_not_reset')
+            bar_anchor = next(
+                (
+                    indicators.get(key)
+                    for key in (
+                        "latest_bar_ts",
+                        "bar_timestamp",
+                        "setup_candle_timestamp",
+                    )
+                    if indicators.get(key) not in (None, "")
+                ),
+                None,
+            )
+            if close < vwap:
+                if bar_anchor is not None:
+                    self._thesis_anchor_by_side[contract_side] = str(bar_anchor)
+                self._no_vote('vwap_thesis_reset')
+                return None
+            if (open_price < vwap or low < vwap) and bar_anchor is not None:
+                self._thesis_anchor_by_side[contract_side] = str(bar_anchor)
+            thesis_anchor = self._thesis_anchor_by_side.get(contract_side)
+            if not thesis_anchor:
+                self._no_vote('vwap_thesis_not_armed')
                 return None
 
             premium_above_vwap = close >= vwap
@@ -305,7 +307,10 @@ class VWAPProStrategy(EliteStrategy):
                 and not premium_above_vwap
                 and not pullback_flag
                 and distance_pct <= min(self._max_distance_pct * 0.15, 0.03)
-                and spread_pct <= float(os.getenv("VWAP_EARLY_TREND_MAX_SPREAD_PCT", "8.0") or 8.0)
+                and spread_pct <= min(
+                    canonical_max_spread_pct(),
+                    float(os.getenv("VWAP_EARLY_TREND_MAX_SPREAD_PCT", "8.0") or 8.0),
+                )
             )
             if early_trend_pullback:
                 score += 1.2
@@ -314,7 +319,10 @@ class VWAPProStrategy(EliteStrategy):
                 trend_alignment
                 and context_fresh
                 and underlying_direction_confidence >= float(os.getenv("VWAP_CONTEXT_BOOST_MIN_CONFIDENCE", "0.90") or "0.90")
-                and spread_pct <= float(os.getenv("LIVE_MAX_SPREAD_PCT", "0.75") or "0.75")
+                and spread_pct <= min(
+                    canonical_max_spread_pct(),
+                    float(os.getenv("VWAP_CONTEXT_BOOST_MAX_SPREAD_PCT", "0.75") or "0.75"),
+                )
                 and premium_above_vwap
             ):
                 boost = float(os.getenv("VWAP_PRO_TREND_CONTEXT_BOOST", "0.5") or "0.5")
@@ -422,6 +430,7 @@ class VWAPProStrategy(EliteStrategy):
                 'trade_side': contract_side,
                 'side': contract_side,
                 'contract_side': contract_side,
+                'setup_id': f"vwap:{contract_side}:{thesis_anchor}",
                 'premium_above_vwap': premium_above_vwap,
                 'direction_bias': direction if direction in {'CE', 'PE'} else None,
                 "underlying_direction_bias": underlying_direction if underlying_direction in {"CE", "PE"} else None,

--- a/src/nifty_scalper_bot/strategies/signal_quality.py
+++ b/src/nifty_scalper_bot/strategies/signal_quality.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass, field
+from typing import Mapping
 
 REQUIRED_SCORE_COMPONENTS: tuple[str, ...] = (
     'direction_score',
@@ -34,6 +35,84 @@ def resolve_signal_domain(symbol: str, metadata: dict[str, object] | None = None
     option_premium_domain = bool(option_symbol and not source_symbol)
     underlying_domain = bool(source_symbol)
     return contract_side, option_premium_domain, underlying_domain
+
+
+def canonical_max_spread_pct() -> float:
+    """Return the single live entry spread limit used by strategy and execution."""
+    for name in ("ORDER_MAX_SPREAD_PCT", "SPREAD_MAX_PCT"):
+        raw = os.getenv(name)
+        if raw is None:
+            continue
+        try:
+            value = float(raw)
+        except (TypeError, ValueError):
+            continue
+        if value > 0:
+            return value
+    return 10.0
+
+
+def build_trade_quality_evidence(
+    indicators: Mapping[str, object] | None,
+    *,
+    side: str,
+) -> dict[str, object]:
+    """Derive canonical quality fields from evidence already owned by the engine."""
+    payload = dict(indicators or {})
+    resolved_side = str(side or "").strip().upper()
+    direction = str(
+        payload.get("underlying_direction_bias")
+        or payload.get("direction_bias")
+        or ""
+    ).strip().upper()
+
+    bid = ask = 0.0
+    try:
+        bid = float(payload.get("bid") or 0.0)
+        ask = float(payload.get("ask") or 0.0)
+    except (TypeError, ValueError):
+        pass
+    bid_ask_valid = bid > 0.0 and ask >= bid
+
+    spread_observed = payload.get("spread_pct") is not None
+    try:
+        spread_pct = float(payload.get("spread_pct")) if spread_observed else 999.0
+    except (TypeError, ValueError):
+        spread_pct = 999.0
+    if not spread_observed and bid_ask_valid:
+        midpoint = (bid + ask) / 2.0
+        if midpoint > 0:
+            spread_pct = ((ask - bid) / midpoint) * 100.0
+            spread_observed = True
+
+    spread_limit = canonical_max_spread_pct()
+    spread_pass = bool(not spread_observed or spread_pct <= spread_limit)
+    depth_valid = bool(payload.get("quote_depth_valid"))
+    tradable_quote = bool(payload.get("tradable_quote"))
+    quote_valid = bool(bid_ask_valid or tradable_quote)
+    if depth_valid and quote_valid and spread_pass:
+        liquidity_score = 2.0
+    elif quote_valid and spread_pass:
+        liquidity_score = 1.0
+    else:
+        liquidity_score = 0.0
+
+    regime = str(payload.get("regime") or payload.get("market_regime") or "").upper()
+    regime_score = 1.0 if regime and regime != "CHOPPY" else 0.0
+
+    return {
+        "direction_alignment_score": (
+            2.0
+            if resolved_side in {"CE", "PE"} and direction == resolved_side
+            else 0.0
+        ),
+        "liquidity_score": liquidity_score,
+        "regime_time_suitability_score": regime_score,
+        "quality_spread_observed": spread_observed,
+        "quality_spread_pass": spread_pass,
+        "quality_spread_pct": spread_pct if spread_observed else None,
+        "quality_spread_limit_pct": spread_limit,
+    }
 
 
 @dataclass(slots=True)

--- a/tests/strategies/test_elite_builder_mode.py
+++ b/tests/strategies/test_elite_builder_mode.py
@@ -39,11 +39,14 @@ def test_directional_mode_disables_gamma_theta_and_context(monkeypatch) -> None:
     assert "CPRBreakout" not in names
 
 
-def test_orb_direction_is_consumed_only_after_entry_acceptance(
+def test_orb_setup_identity_is_runner_owned_and_stable(
     monkeypatch,
 ) -> None:
     monkeypatch.setenv("ENABLE_ORB_STRATEGY", "true")
-    strategy = ORBProStrategy(ORBProStrategyConfig(), indicator_engine=None)
+    strategy = ORBProStrategy(
+        ORBProStrategyConfig(min_confidence=0.0),
+        indicator_engine=None,
+    )
     indicators = {
         "orb_ready": True,
         "orb_high": 105.0,
@@ -56,16 +59,31 @@ def test_orb_direction_is_consumed_only_after_entry_acceptance(
         "volume": 1000.0,
         "avg_volume": 900.0,
         "direction_bias": "CE",
+        "underlying_direction_bias": "CE",
         "regime": "TREND_UP",
+        "spread_pct": 0.5,
+        "bid": 109.5,
+        "ask": 110.0,
+        "quote_depth_valid": True,
+        "tradable_quote": True,
+        "stale_data_used": False,
+        "latest_bar_ts": 1_785_000_000.0,
+        "session_date": "2026-08-03",
     }
 
-    assert strategy._evaluate_signal("NFO:NIFTYCE", indicators, 110.0) is not None
-    assert strategy._evaluate_signal("NFO:NIFTYCE", indicators, 110.0) is not None
-
+    first = strategy.generate_signal("NFO:NIFTYCE", indicators, 110.0)
+    assert first is not None
     strategy.notify_entry_accepted("CE")
+    repeated = strategy.generate_signal(
+        "NFO:NIFTYCE",
+        {**indicators, "latest_bar_ts": 1_785_000_060.0},
+        110.0,
+    )
 
-    assert strategy._evaluate_signal("NFO:NIFTYCE", indicators, 110.0) is None
-    assert strategy.last_no_vote_reason == "direction_already_traded_today"
+    assert repeated is not None
+    assert first.metadata["setup_id"] == repeated.metadata["setup_id"]
+    assert first.metadata["direction_alignment_score"] == 2.0
+    assert first.metadata["liquidity_score"] == 2.0
 
 
 def test_production_profile_is_stable_and_changes_with_material_settings(

--- a/tests/strategies/test_setup_anchor_identity.py
+++ b/tests/strategies/test_setup_anchor_identity.py
@@ -16,6 +16,7 @@ from nifty_scalper_bot.strategies.signal_identity_patch import (
     _deterministic_id,
     has_setup_anchor,
 )
+from nifty_scalper_bot.strategies.signal_quality import build_trade_quality_evidence
 
 BAR_TS = 1_785_000_000.0
 
@@ -58,6 +59,7 @@ class _RepeatingStrategy(EliteStrategy):
             {
                 "role": self._role,
                 "contract_side": "CE",
+                "raw_setup_score": 9.0,
             }
         )
         return signal
@@ -150,26 +152,28 @@ def test_existing_signal_anchor_is_not_overwritten() -> None:
     assert signal.metadata["setup_candle_timestamp"] == BAR_TS
 
 
-def test_trigger_retry_is_allowed_until_entry_is_accepted() -> None:
+def test_strategy_hook_does_not_own_order_lifecycle() -> None:
     strategy = _RepeatingStrategy(role="trigger")
-    indicators = {"latest_bar_ts": BAR_TS}
+    indicators = {
+        "latest_bar_ts": BAR_TS,
+        "direction_bias": "CE",
+        "bid": 99.5,
+        "ask": 100.0,
+        "spread_pct": 0.5,
+        "quote_depth_valid": True,
+        "tradable_quote": True,
+        "regime": "TREND_UP",
+        "stale_data_used": False,
+    }
     symbol = _elite_signal().symbol
 
     first = strategy.generate_signal(symbol, indicators, 100.0)
-    retry_before_acceptance = strategy.generate_signal(symbol, indicators, 100.5)
     strategy.notify_entry_accepted("CE")
-    repeated_after_acceptance = strategy.generate_signal(symbol, indicators, 101.0)
-    next_bar = strategy.generate_signal(
-        symbol,
-        {"latest_bar_ts": BAR_TS + 60.0},
-        101.5,
-    )
+    repeated = strategy.generate_signal(symbol, indicators, 100.5)
 
     assert first is not None
-    assert retry_before_acceptance is not None
-    assert repeated_after_acceptance is None
-    assert strategy.last_no_vote_reason == "setup_anchor_already_consumed"
-    assert next_bar is not None
+    assert repeated is not None
+    assert _deterministic_id(first) == _deterministic_id(repeated)
 
 
 def test_context_vote_remains_tick_responsive_on_same_anchor() -> None:
@@ -179,3 +183,80 @@ def test_context_vote_remains_tick_responsive_on_same_anchor() -> None:
     assert strategy.generate_signal(_elite_signal().symbol, indicators, 100.0) is not None
     strategy.notify_entry_accepted("CE")
     assert strategy.generate_signal(_elite_signal().symbol, indicators, 100.5) is not None
+
+
+def test_orb_and_smc_structural_ids_ignore_new_bar_noise() -> None:
+    orb_first = EliteSignal(
+        symbol="NFO:NIFTY2680424400CE",
+        signal="BUY",
+        confidence=0.8,
+        entry_price=100.0,
+        stop_loss=90.0,
+        target=120.0,
+        strategy_name="ORBPro",
+        metadata={
+            "role": "trigger",
+            "contract_side": "CE",
+            "opening_range_high": 105.0,
+            "opening_range_low": 95.0,
+        },
+    )
+    orb_second = _elite_signal()
+    orb_second.strategy_name = "ORBPro"
+    orb_second.metadata.update(orb_first.metadata)
+    for signal, bar_ts in ((orb_first, BAR_TS), (orb_second, BAR_TS + 60.0)):
+        EliteStrategy._stamp_setup_anchor(signal, {"latest_bar_ts": bar_ts})
+        EliteStrategy._stamp_structural_setup_id(
+            signal,
+            {"latest_bar_ts": bar_ts, "session_date": "2026-08-03"},
+        )
+    assert orb_first.metadata["setup_id"] == orb_second.metadata["setup_id"]
+
+    smc_first = _elite_signal()
+    smc_second = _elite_signal()
+    for signal, bar_ts in ((smc_first, BAR_TS), (smc_second, BAR_TS + 60.0)):
+        signal.strategy_name = "SMC"
+        signal.metadata.update(
+            {"strategy": "SMC", "role": "trigger", "contract_side": "CE"}
+        )
+        EliteStrategy._stamp_setup_anchor(signal, {"latest_bar_ts": bar_ts})
+        EliteStrategy._stamp_structural_setup_id(
+            signal,
+            {"latest_bar_ts": bar_ts, "prior_swing_low": 98.0},
+        )
+    assert smc_first.metadata["setup_id"] == smc_second.metadata["setup_id"]
+
+
+def test_quality_evidence_uses_order_spread_policy(monkeypatch) -> None:
+    monkeypatch.setenv("ORDER_MAX_SPREAD_PCT", "1.0")
+    good = build_trade_quality_evidence(
+        {
+            "direction_bias": "CE",
+            "bid": 99.5,
+            "ask": 100.0,
+            "spread_pct": 0.5,
+            "quote_depth_valid": True,
+            "tradable_quote": True,
+            "regime": "TREND_UP",
+        },
+        side="CE",
+    )
+    wide = build_trade_quality_evidence(
+        {
+            "direction_bias": "CE",
+            "bid": 98.0,
+            "ask": 100.0,
+            "spread_pct": 2.0,
+            "quote_depth_valid": True,
+            "tradable_quote": True,
+            "regime": "TREND_UP",
+        },
+        side="CE",
+    )
+
+    assert good["direction_alignment_score"] == 2.0
+    assert good["liquidity_score"] == 2.0
+    assert good["regime_time_suitability_score"] == 1.0
+    assert good["quality_spread_pass"] is True
+    assert wide["liquidity_score"] == 0.0
+    assert wide["quality_spread_pass"] is False

--- a/tests/strategies/test_vwap_metadata_contract_side.py
+++ b/tests/strategies/test_vwap_metadata_contract_side.py
@@ -1,9 +1,16 @@
+from nifty_scalper_bot.core.strategy_manager import (
+    StrategyManager,
+    signal_to_vote,
+)
 from nifty_scalper_bot.strategies.elite_strategies.config_models import VWAPProStrategyConfig
 from nifty_scalper_bot.strategies.elite_strategies.vwap_pro import VWAPProStrategy
 
 
 class _DummyEngine:
     pass
+
+
+BAR_TS = 1_785_000_000.0
 
 
 def _indicators(**updates):
@@ -17,9 +24,18 @@ def _indicators(**updates):
         'volume': 1000.0,
         'avg_volume': 900.0,
         'spread_pct': 0.5,
+        'bid': 102.5,
+        'ask': 103.0,
+        'quote_depth_valid': True,
+        'tradable_quote': True,
         'direction_bias': 'CE',
+        'underlying_direction_bias': 'CE',
         'underlying_direction_confidence': 0.95,
         'context_age_seconds': 0.0,
+        'context_fresh': True,
+        'regime': 'TREND_UP',
+        'stale_data_used': False,
+        'latest_bar_ts': BAR_TS,
     }
     payload.update(updates)
     return payload
@@ -29,7 +45,7 @@ def test_vwap_metadata_contract_side_and_setup_scores_present():
     strategy = VWAPProStrategy(VWAPProStrategyConfig(), _DummyEngine())
     signal = strategy._evaluate_signal(
         'NFO:NIFTY26FEB22500CE',
-        _indicators(direction_bias='UNKNOWN'),
+        _indicators(direction_bias='UNKNOWN', underlying_direction_bias='UNKNOWN'),
         101.0,
     )
     assert signal is not None
@@ -38,6 +54,7 @@ def test_vwap_metadata_contract_side_and_setup_scores_present():
     assert metadata['direction_bias'] is None
     assert metadata['raw_setup_score'] is not None
     assert metadata['setup_score'] is not None
+    assert metadata['setup_id'].startswith('vwap:CE:')
 
 
 def test_live_vwap_rejects_threshold_pass_from_small_noise(monkeypatch):
@@ -50,7 +67,7 @@ def test_live_vwap_rejects_threshold_pass_from_small_noise(monkeypatch):
             close=100.05,
             open=100.04,
             high=100.10,
-            low=100.02,
+            low=99.90,
             volume=0.0,
             avg_volume=0.0,
         ),
@@ -69,9 +86,9 @@ def test_live_vwap_accepts_meaningful_atr_penetration(monkeypatch):
         'NFO:NIFTY26FEB22500CE',
         _indicators(
             close=100.80,
-            open=100.75,
+            open=99.80,
             high=100.85,
-            low=100.70,
+            low=99.50,
             volume=0.0,
             avg_volume=0.0,
         ),
@@ -83,22 +100,87 @@ def test_live_vwap_accepts_meaningful_atr_penetration(monkeypatch):
     assert signal.metadata['vwap_event_confirmed'] is True
 
 
-def test_accepted_vwap_thesis_requires_closed_candle_reset(monkeypatch):
+def test_vwap_thesis_uses_stable_structural_id_until_closed_candle_reset(monkeypatch):
     monkeypatch.setenv('EXECUTION_MODE', 'LIVE')
     strategy = VWAPProStrategy(VWAPProStrategyConfig(), _DummyEngine())
     symbol = 'NFO:NIFTY26FEB22500CE'
 
-    assert strategy._evaluate_signal(symbol, _indicators(), 103.0) is not None
+    first = strategy._evaluate_signal(symbol, _indicators(), 103.0)
+    assert first is not None
     strategy.notify_entry_accepted('CE')
 
-    assert strategy._evaluate_signal(symbol, _indicators(close=104.0), 104.0) is None
-    assert strategy.last_no_vote_reason == 'vwap_thesis_not_reset'
+    same_thesis = strategy._evaluate_signal(
+        symbol,
+        _indicators(
+            latest_bar_ts=BAR_TS + 60.0,
+            close=104.0,
+            open=103.8,
+            high=104.2,
+            low=103.5,
+        ),
+        104.0,
+    )
+    assert same_thesis is not None
+    assert same_thesis.metadata['setup_id'] == first.metadata['setup_id']
 
     assert strategy._evaluate_signal(
         symbol,
-        _indicators(close=99.5, open=100.0, high=100.2, low=99.2),
+        _indicators(
+            latest_bar_ts=BAR_TS + 120.0,
+            close=99.5,
+            open=100.0,
+            high=100.2,
+            low=99.2,
+        ),
         99.5,
     ) is None
     assert strategy.last_no_vote_reason == 'vwap_thesis_reset'
 
-    assert strategy._evaluate_signal(symbol, _indicators(), 103.0) is not None
+    next_thesis = strategy._evaluate_signal(
+        symbol,
+        _indicators(
+            latest_bar_ts=BAR_TS + 180.0,
+            close=103.0,
+            open=100.5,
+            high=103.2,
+            low=100.2,
+        ),
+        103.0,
+    )
+    assert next_thesis is not None
+    assert next_thesis.metadata['setup_id'] != first.metadata['setup_id']
+
+
+def test_real_vwap_vote_clears_default_live_quality_gate(monkeypatch):
+    monkeypatch.setenv('EXECUTION_MODE', 'LIVE')
+    monkeypatch.setenv('ENABLE_LIVE', 'true')
+    monkeypatch.setenv('ORDER_MAX_SPREAD_PCT', '1.0')
+    strategy = VWAPProStrategy(
+        VWAPProStrategyConfig(min_confidence=0.0),
+        _DummyEngine(),
+    )
+    indicators = _indicators()
+
+    signal = strategy.generate_signal(
+        'NFO:NIFTY26FEB22500CE',
+        indicators,
+        103.0,
+    )
+
+    assert signal is not None
+    vote = signal_to_vote(signal, 'VWAPPro')
+    manager = object.__new__(StrategyManager)
+    quality_score, quality_meta = manager._compute_trade_quality_score(
+        vote,
+        indicators,
+        symbol=signal.symbol,
+        selected_ok=True,
+        near_atm_ok=True,
+        context_votes=[],
+    )
+
+    assert quality_score >= 7.0
+    assert quality_meta['quality_evidence_complete'] is True
+    assert signal.metadata['direction_alignment_score'] == 2.0
+    assert signal.metadata['liquidity_score'] == 2.0
+    assert signal.metadata['regime_time_suitability_score'] == 1.0

--- a/tests/strategies/test_vwap_pro_context_boost.py
+++ b/tests/strategies/test_vwap_pro_context_boost.py
@@ -9,6 +9,31 @@ def test_vwap_pro_trend_context_boost_avoids_weak_score(monkeypatch):
     strategy = VWAPProStrategy(
         VWAPProStrategyConfig(enabled=True, quantity=1), indicator_engine=None
     )
+    symbol = "NFO:NIFTY26MAY24000CE"
+
+    # A live VWAP thesis is edge-triggered. Establish the finalized reset first
+    # rather than manufacturing a mid-session entry from an already-extended
+    # above-VWAP state.
+    assert (
+        strategy._evaluate_signal(
+            symbol,
+            {
+                "vwap": 100.0,
+                "open": 100.2,
+                "high": 100.4,
+                "low": 99.0,
+                "close": 99.5,
+                "atr": 2.0,
+                "direction_bias": "CE",
+                "underlying_direction_bias": "CE",
+                "latest_bar_ts": 1_785_000_000.0,
+            },
+            current_price=99.5,
+        )
+        is None
+    )
+    assert strategy.last_no_vote_reason == "vwap_thesis_reset"
+
     indicators = {
         "vwap": 100.0,
         "open": 108.9,
@@ -23,11 +48,10 @@ def test_vwap_pro_trend_context_boost_avoids_weak_score(monkeypatch):
         "underlying_direction_confidence": 0.95,
         "context_age_seconds": 1.0,
         "spread_pct": 0.29,
+        "latest_bar_ts": 1_785_000_060.0,
     }
 
-    signal = strategy._evaluate_signal(
-        "NFO:NIFTY26MAY24000CE", indicators, current_price=109.0
-    )
+    signal = strategy._evaluate_signal(symbol, indicators, current_price=109.0)
 
     assert signal is not None
     assert "trend_context_boost" in signal.metadata["score_reasons"]


### PR DESCRIPTION
## Root causes

1. The LIVE quality gate required canonical direction/liquidity/regime evidence, while real SMC/VWAP/ORB strategies emitted equivalent facts under different names. Valid triggers therefore could not reach the default 7.0 quality floor.
2. Strategy-local accepted-entry latches duplicated runner/order lifecycle state. A broker-acknowledged order that later failed could remain consumed locally, while restart lost those latches.
3. Strategy and execution spread thresholds were independently configured.

## Focused corrections

- Derive the canonical quality fields once in the elite base from authoritative direction, quote/depth, freshness and regime evidence.
- Use the existing order spread setting as the single live spread limit; OrderManager remains the final fail-closed authority.
- Remove strategy-local order-state ownership. The runner/OrderManager deterministic signal ledger remains the single persisted deduplication authority.
- Emit structural setup IDs:
  - VWAP: side + last finalized below-VWAP/reclaim anchor;
  - SMC: side + sweep/swing reference;
  - ORB: trading session + side + opening range.
- VWAP remains fail-closed after restart until a real reset/reclaim arms a thesis.

## TDD

- Actual VWAPPro output clears the unchanged LIVE 7.0 quality floor only with complete direction/liquidity/freshness/regime evidence.
- Wide spread uses the same policy as order execution and is rejected.
- Failed-order compatibility hooks do not consume strategy state.
- Repeated VWAP/SMC/ORB states retain the same deterministic setup identity across new candles; structural reset creates a new identity.
- Existing consumed-signal persistence remains the restart authority.

No order-placement, position-sizing, risk, exit, bracket or broker code changed.