### PR TITLE
fix(lifecycle): reconcile bracket quantity to the confirmed entry fill

### DIFF
--- a/src/nifty_scalper_bot/execution/bracket_core.py
+++ b/src/nifty_scalper_bot/execution/bracket_core.py
@@ -1406,12 +1406,62 @@ class BracketManager:
             self.save_state()
             self._sync_active_bracket_symbols_to_mdm()
 
-    def confirm_entry_fill(self, order_id: str, fill_price: float) -> None:
+    def _reconcile_entry_fill_quantity(
+        self, bracket: BracketState, filled_qty: int | None
+    ) -> None:
+        """Shrink a bracket to the quantity the broker actually filled.
+
+        Exits must never be sized above the held position: an oversized exit is
+        either rejected (leaving the position unprotected while it retries) or
+        fills into a naked opposite exposure. Only shrinking is permitted -- a
+        reported quantity above the registered size is a data fault, not an
+        instruction to trade more.
+        """
+        if filled_qty is None:
+            return
+        try:
+            filled = int(filled_qty)
+        except (TypeError, ValueError):
+            return
+        registered = int(bracket.quantity or 0)
+        if filled <= 0 or registered <= 0 or filled >= registered:
+            return
+        bracket.quantity = filled
+        bracket.remaining_quantity = filled
+        # A partial-target slice at or above the whole position is no longer a
+        # scale-out; drop it rather than exit the entire position at TP1.
+        bracket.tp_levels = [
+            level
+            for level in bracket.tp_levels
+            if level.executed or int(level.quantity) < filled
+        ]
+        LOGGER.warning(
+            "BRACKET_QTY_RECONCILED order_id=%s symbol=%s requested=%s filled=%s",
+            bracket.entry_order_id,
+            bracket.symbol,
+            registered,
+            filled,
+            extra={
+                "event": "BRACKET_QTY_RECONCILED",
+                "order_id": bracket.entry_order_id,
+                "symbol": bracket.symbol,
+                "requested_qty": registered,
+                "filled_qty": filled,
+            },
+        )
+
+    def confirm_entry_fill(
+        self, order_id: str, fill_price: float, filled_qty: int | None = None
+    ) -> None:
         """Activate a bracket once entry fill is confirmed.
 
         Args:
             order_id: Entry order identifier for the bracket.
             fill_price: Confirmed fill price from the broker.
+            filled_qty: Confirmed filled quantity. Brackets are pre-registered
+                with the *requested* size, so a partial entry fill (whose
+                remainder is then cancelled) would otherwise leave protective
+                exits sized larger than the position actually held.
 
         Returns:
             None.
@@ -1441,6 +1491,8 @@ class BracketManager:
                     },
                 )
                 return
+
+            self._reconcile_entry_fill_quantity(bracket, filled_qty)
 
             # Update entry price with actual fill
             if fill_price and fill_price > 0:

--- a/src/nifty_scalper_bot/execution/bracket_manager.py
+++ b/src/nifty_scalper_bot/execution/bracket_manager.py
@@ -56,7 +56,7 @@ tick_exchange_epoch = _tick_exchange_epoch_with_receipt
 _original_confirm_entry_fill = BoundBracketManager.confirm_entry_fill
 
 
-def _confirm_entry_fill_once(self, order_id, fill_price):
+def _confirm_entry_fill_once(self, order_id, fill_price, filled_qty=None):
     """Ignore an identical repeated COMPLETE callback without resetting protection."""
     bracket = self.get_bracket(order_id)
     try:
@@ -84,7 +84,7 @@ def _confirm_entry_fill_once(self, order_id, fill_price):
             },
         )
         return True
-    return _original_confirm_entry_fill(self, order_id, fill_price)
+    return _original_confirm_entry_fill(self, order_id, fill_price, filled_qty)
 
 
 BoundBracketManager.confirm_entry_fill = _confirm_entry_fill_once

--- a/src/nifty_scalper_bot/execution/canonical_bracket_manager.py
+++ b/src/nifty_scalper_bot/execution/canonical_bracket_manager.py
@@ -64,7 +64,9 @@ class CanonicalBracketManager(HardenedBracketManager):
         )
         super().__init__(*args, **kwargs)
 
-    def confirm_entry_fill(self, order_id: str, fill_price: float) -> None:
+    def confirm_entry_fill(
+        self, order_id: str, fill_price: float, filled_qty: int | None = None
+    ) -> None:
         """Activate a confirmed entry and re-anchor every outstanding target.
 
         The legacy implementation already re-anchors SL and the final TP. This
@@ -82,7 +84,7 @@ class CanonicalBracketManager(HardenedBracketManager):
                     float(target.price or 0.0) for target in before.tp_levels
                 ]
 
-        super().confirm_entry_fill(order_id, fill_price)
+        super().confirm_entry_fill(order_id, fill_price, filled_qty)
 
         bracket = self.get_bracket(order_id)
         if bracket is None:

--- a/src/nifty_scalper_bot/execution/hardened_bracket_manager.py
+++ b/src/nifty_scalper_bot/execution/hardened_bracket_manager.py
@@ -194,8 +194,12 @@ class HardenedBracketManager(_LegacyBracketManager):
                 bracket.last_exit_error = None
                 bracket.next_exit_attempt_at = None
 
-    def confirm_entry_fill(self, order_id: str, fill_price: float) -> None:
-        _LegacyBracketManager.confirm_entry_fill(self, order_id, fill_price)
+    def confirm_entry_fill(
+        self, order_id: str, fill_price: float, filled_qty: int | None = None
+    ) -> None:
+        _LegacyBracketManager.confirm_entry_fill(
+            self, order_id, fill_price, filled_qty
+        )
         bracket = self.get_bracket(order_id)
         if bracket is None:
             return

--- a/src/nifty_scalper_bot/execution/ledger_bracket_manager.py
+++ b/src/nifty_scalper_bot/execution/ledger_bracket_manager.py
@@ -260,7 +260,9 @@ class LedgerBracketManager(CanonicalBracketManager):
             )
         )
 
-    def confirm_entry_fill(self, order_id: str, fill_price: float) -> None:
+    def confirm_entry_fill(
+        self, order_id: str, fill_price: float, filled_qty: int | None = None
+    ) -> None:
         bracket = self.get_bracket(order_id)
         ledger_ok = True
         if bracket is not None:
@@ -268,7 +270,7 @@ class LedgerBracketManager(CanonicalBracketManager):
                 getattr(bracket, "entry_order_intent", "ENTRY") or "ENTRY"
             ).upper()
             if entry_intent not in {"ENTRY", "SCALE_IN", "REVERSAL"}:
-                super().confirm_entry_fill(order_id, fill_price)
+                super().confirm_entry_fill(order_id, fill_price, filled_qty)
                 return
             try:
                 self._record_entry_fill(bracket, float(fill_price))
@@ -280,7 +282,7 @@ class LedgerBracketManager(CanonicalBracketManager):
                     reason="entry_fill_persist_failed",
                     payload={"order_id": order_id, "error": str(exc)},
                 )
-        super().confirm_entry_fill(order_id, fill_price)
+        super().confirm_entry_fill(order_id, fill_price, filled_qty)
         bracket = self.get_bracket(order_id)
         if bracket is not None and ledger_ok:
             self._clear_ledger_release(bracket)

--- a/src/nifty_scalper_bot/execution/order_manager_core.py
+++ b/src/nifty_scalper_bot/execution/order_manager_core.py
@@ -6122,7 +6122,9 @@ class OrderManager:
                 bracket_exists = self._bracket_manager.get_bracket(order.order_id)
                 if bracket_exists is None:
                     raise RuntimeError("entry bracket registration was not confirmed")
-            self._bracket_manager.confirm_entry_fill(order.order_id, entry_price)
+            self._bracket_manager.confirm_entry_fill(
+                order.order_id, entry_price, int(order.filled_quantity or 0) or None
+            )
             verified = self._bracket_manager.get_bracket(order.order_id)
             if (
                 verified is None

--- a/tests/execution/test_bracket_manager_reliability.py
+++ b/tests/execution/test_bracket_manager_reliability.py
@@ -775,3 +775,72 @@ def test_watchdog_payload_records_the_trigger_source() -> None:
     exec_px, exec_src = manager._executable_exit_price(bracket, 100.50)
     assert exec_px == 98.50
     assert exec_src == "bid"
+
+
+def _pending_bracket(manager, order_id, symbol, qty, **kw):
+    manager.register_virtual_bracket(
+        order_id, symbol, "BUY", qty, 100.0, 95.0, 110.0,
+        activate_immediately=False, **kw,
+    )
+    bracket = manager.get_bracket(order_id)
+    assert bracket is not None
+    return bracket
+
+
+def test_partial_entry_fill_shrinks_the_bracket_to_the_held_position() -> None:
+    """Brackets are pre-registered at the requested size. A partial fill whose
+    remainder is cancelled would otherwise leave exits sized above the position,
+    which is either rejected (leaving it unprotected) or fills into a naked short."""
+    manager = BracketManager(order_manager=Mock())
+    bracket = _pending_bracket(manager, "pf-1", "NFO:NIFTYPF1CE", 130)
+
+    manager.confirm_entry_fill("pf-1", 100.0, 65)
+
+    assert bracket.quantity == 65
+    assert bracket.remaining_quantity == 65
+    assert bracket.active is True
+
+
+def test_full_entry_fill_leaves_quantity_untouched() -> None:
+    manager = BracketManager(order_manager=Mock())
+    bracket = _pending_bracket(manager, "pf-2", "NFO:NIFTYPF2CE", 130)
+
+    manager.confirm_entry_fill("pf-2", 100.0, 130)
+
+    assert bracket.quantity == 130
+    assert bracket.remaining_quantity == 130
+
+
+def test_unreported_fill_quantity_preserves_existing_behaviour() -> None:
+    manager = BracketManager(order_manager=Mock())
+    bracket = _pending_bracket(manager, "pf-3", "NFO:NIFTYPF3CE", 130)
+
+    manager.confirm_entry_fill("pf-3", 100.0)
+
+    assert bracket.quantity == 130
+    assert bracket.remaining_quantity == 130
+
+
+def test_overreported_fill_quantity_never_grows_the_bracket() -> None:
+    """A reported quantity above the registered size is a data fault, not an
+    instruction to trade more."""
+    manager = BracketManager(order_manager=Mock())
+    bracket = _pending_bracket(manager, "pf-4", "NFO:NIFTYPF4CE", 65)
+
+    manager.confirm_entry_fill("pf-4", 100.0, 260)
+
+    assert bracket.quantity == 65
+    assert bracket.remaining_quantity == 65
+
+
+def test_partial_fill_drops_a_now_oversized_scale_out_level() -> None:
+    manager = BracketManager(order_manager=Mock())
+    from nifty_scalper_bot.execution.bracket_core import TargetLevel
+
+    bracket = _pending_bracket(manager, "pf-5", "NFO:NIFTYPF5CE", 150)
+    bracket.tp_levels = [TargetLevel(price=105.0, quantity=75, name="TP1")]
+
+    manager.confirm_entry_fill("pf-5", 100.0, 75)
+
+    assert bracket.quantity == 75
+    assert [lvl for lvl in bracket.tp_levels if not lvl.executed] == []

--- a/tests/execution/test_execution_safety_audit_fixes.py
+++ b/tests/execution/test_execution_safety_audit_fixes.py
@@ -1527,7 +1527,7 @@ def test_bracket_registration_is_idempotent_when_fill_replayed_after_position_fa
                 sl_trigger_price=kwargs["sl"],
             )
 
-        def confirm_entry_fill(self, order_id, _entry_price):
+        def confirm_entry_fill(self, order_id, _entry_price, _filled_qty=None):
             assert self.bracket is not None and self.bracket.order_id == order_id
             self.confirm_calls += 1
             self.bracket.quantity = 130

--- a/tests/execution/test_trading_incident_regressions.py
+++ b/tests/execution/test_trading_incident_regressions.py
@@ -108,7 +108,9 @@ class _ExactPendingBracketManager:
     def has_active_bracket(self, _symbol: str) -> bool:
         raise AssertionError("exact entry bracket must be checked before symbol guard")
 
-    def confirm_entry_fill(self, order_id: str, _price: float) -> None:
+    def confirm_entry_fill(
+        self, order_id: str, _price: float, _filled_qty: int | None = None
+    ) -> None:
         assert order_id == ENTRY_ID
         self.bracket.entry_confirmed = True
         self.bracket.active = True


### PR DESCRIPTION
Lifecycle audit finding: protective exits could be sized larger than the position actually held.

## The gap

The entry lifecycle pre-registers the bracket at submit time with the **requested** quantity (`order_manager_core.py:5806`, `activate_immediately=False`), then activates it on fill via `confirm_entry_fill(order_id, fill_price)` — which had no quantity parameter and never reconciled size.

Partial entry fills are a real path here, not a hypothetical: `_await_entry_fill` explicitly handles `entry partially filled; cancelling remainder` (`order_manager_core.py:5908`). So after a partial fill the broker position is smaller than the bracket, and every subsequent exit — SL, TP, trailing, watchdog, EOD flatten — is sized for the full requested quantity.

On a 2-lot order filled 1 lot, the SL exit is for 130 against a 65 position. Either the broker rejects it (the position sits **unprotected** while the exit path retries) or, under MIS, it fills and opens a naked short in the opposite direction. Both are worse than the loss the stop was there to cap. The R-multiple and P&L telemetry from #1003 are also computed on the wrong quantity, so the mis-sizing is invisible afterwards.

## The fix

`confirm_entry_fill()` takes an optional `filled_qty` and delegates to one new `_reconcile_entry_fill_quantity()` helper in `bracket_core`:

- **Shrink only.** A reported quantity above the registered size is a data fault, not an instruction to trade more, so it is ignored.
- `filled_qty=None` is unchanged behaviour, so every existing caller and the restore path keep working.
- A scale-out level whose slice is now at or above the whole position is dropped — otherwise TP1 would exit the entire position and orphan the bracket.
- Emits `BRACKET_QTY_RECONCILED` with requested vs filled.

The parameter is threaded through the execution chain (`Bound -> Runtime -> Ledger -> Canonical -> Hardened -> bracket_core`) as an optional argument, and `order_manager_core.py:6125` now passes `order.filled_quantity`.

## Tests

6 added: partial fill shrinks quantity and remaining_quantity; full fill untouched; unreported quantity preserves existing behaviour; over-reported quantity never grows the bracket; an oversized scale-out level is dropped; the bracket still activates.

`compileall` clean. Full suite **2424 passed, 2 skipped**.