### PR TITLE
fix(lifecycle): reconcile partial fills and make signal decisions auditable

### DIFF
--- a/src/nifty_scalper_bot/execution/bracket_manager.py
+++ b/src/nifty_scalper_bot/execution/bracket_manager.py
@@ -56,9 +56,80 @@ tick_exchange_epoch = _tick_exchange_epoch_with_receipt
 _original_confirm_entry_fill = BoundBracketManager.confirm_entry_fill
 
 
+def _positive_filled_quantity(value):
+    try:
+        quantity = int(value or 0)
+    except (TypeError, ValueError):
+        return None
+    return quantity if quantity > 0 else None
+
+
+def _reconcile_confirmed_entry_quantity(self, order_id, bracket, filled_qty):
+    """Shrink bracket and durable entry fill to a later authoritative quantity."""
+    reported = _positive_filled_quantity(filled_qty)
+    if bracket is None or reported is None:
+        return False
+    intent = str(getattr(bracket, "entry_order_intent", "ENTRY") or "ENTRY").upper()
+    if intent not in {"ENTRY", "SCALE_IN", "REVERSAL"}:
+        return False
+    try:
+        registered = int(getattr(bracket, "quantity", 0) or 0)
+    except (TypeError, ValueError):
+        return False
+    if registered <= 0 or reported >= registered:
+        return False
+
+    reconciler = getattr(self, "_reconcile_entry_fill_quantity", None)
+    if not callable(reconciler):
+        return False
+    reconciler(bracket, reported)
+
+    # On the first callback the ledger has not been written yet; pre-shrinking
+    # makes the existing ledger layer record the actual quantity. On a later
+    # duplicate callback, explicitly shrink the already-persisted ENTRY row.
+    if bool(getattr(bracket, "entry_confirmed", False)):
+        ledger = getattr(self, "_fill_ledger", None)
+        ledger_reconcile = getattr(ledger, "reconcile_entry_quantity", None)
+        fill_id_builder = getattr(self, "_entry_fill_id", None)
+        if callable(ledger_reconcile) and callable(fill_id_builder):
+            try:
+                ledger_reconcile(fill_id_builder(str(order_id)), reported)
+            except Exception as exc:  # noqa: BLE001 - block release on accounting drift
+                blocker = getattr(self, "_block_ledger_release", None)
+                if callable(blocker):
+                    blocker(
+                        bracket,
+                        reason="entry_fill_quantity_reconcile_failed",
+                        payload={
+                            "order_id": str(order_id),
+                            "filled_qty": reported,
+                            "error": str(exc),
+                        },
+                    )
+                raise
+        _core.LOGGER.warning(
+            "FILL_LEDGER_ENTRY_QTY_RECONCILED order_id=%s symbol=%s requested=%s filled=%s",
+            order_id,
+            bracket.symbol,
+            registered,
+            reported,
+            extra={
+                "event": "FILL_LEDGER_ENTRY_QTY_RECONCILED",
+                "order_id": str(order_id),
+                "symbol": bracket.symbol,
+                "requested_qty": registered,
+                "filled_qty": reported,
+            },
+        )
+    return True
+
+
 def _confirm_entry_fill_once(self, order_id, fill_price, filled_qty=None):
-    """Ignore an identical repeated COMPLETE callback without resetting protection."""
+    """Keep repeated COMPLETE callbacks idempotent while accepting smaller fills."""
     bracket = self.get_bracket(order_id)
+    quantity_reconciled = _reconcile_confirmed_entry_quantity(
+        self, order_id, bracket, filled_qty
+    )
     try:
         price = float(fill_price)
         prior = float(bracket.entry_fill_price) if bracket is not None else None
@@ -71,16 +142,24 @@ def _confirm_entry_fill_once(self, order_id, fill_price, filled_qty=None):
         and price is not None
         and abs(prior - price) < 1e-9
     ):
+        event = (
+            "BRACKET_DUPLICATE_FILL_QTY_RECONCILED"
+            if quantity_reconciled
+            else "BRACKET_ACTIVATION_DUPLICATE_IGNORED"
+        )
         _core.LOGGER.info(
-            "BRACKET_ACTIVATION_DUPLICATE_IGNORED order_id=%s symbol=%s fill_price=%.2f",
+            "%s order_id=%s symbol=%s fill_price=%.2f filled_qty=%s",
+            event,
             order_id,
             bracket.symbol,
             price,
+            _positive_filled_quantity(filled_qty),
             extra={
-                "event": "BRACKET_ACTIVATION_DUPLICATE_IGNORED",
+                "event": event,
                 "order_id": str(order_id),
                 "symbol": bracket.symbol,
                 "fill_price": price,
+                "filled_qty": _positive_filled_quantity(filled_qty),
             },
         )
         return True

--- a/src/nifty_scalper_bot/execution/fill_ledger.py
+++ b/src/nifty_scalper_bot/execution/fill_ledger.py
@@ -272,6 +272,45 @@ class BracketFillLedgerStore:
             raise FillLedgerError(f"unable to persist fill {leg.fill_id}: {exc}") from exc
         return True
 
+    def reconcile_entry_quantity(self, fill_id: str, filled_qty: int) -> bool:
+        """Shrink an existing ENTRY fill to a later authoritative broker quantity.
+
+        Fill rows stay immutable except for this explicit partial-fill correction.
+        The method can never grow exposure or alter price, side, fees, or identity.
+        """
+        quantity = int(filled_qty or 0)
+        if quantity <= 0:
+            raise FillValidationError("reconciled entry quantity must be positive")
+        key = str(fill_id or "").strip()
+        existing = self.get_fill(key)
+        if existing is None:
+            return False
+        if existing.kind != "ENTRY":
+            raise FillConflictError(f"fill_id {key!r} is not an entry fill")
+        if quantity >= existing.quantity:
+            return False
+        try:
+            with self._connect() as connection:
+                cursor = connection.execute(
+                    """
+                    UPDATE bracket_fill_legs
+                    SET quantity = ?
+                    WHERE fill_id = ? AND kind = 'ENTRY' AND quantity > ?
+                    """,
+                    (quantity, key, quantity),
+                )
+                changed = cursor.rowcount > 0
+        except sqlite3.Error as exc:
+            raise FillLedgerError(
+                f"unable to reconcile entry fill {key}: {exc}"
+            ) from exc
+        current = self.get_fill(key)
+        if current is None or current.kind != "ENTRY" or current.quantity > quantity:
+            raise FillConflictError(
+                f"entry fill {key!r} quantity reconciliation was not durable"
+            )
+        return changed
+
     def load_fills(self, bracket_id: str) -> list[FillLeg]:
         try:
             with self._connect() as connection:

--- a/src/nifty_scalper_bot/strategies/elite_strategies/orb_pro.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/orb_pro.py
@@ -47,6 +47,7 @@ class ORBProStrategy(EliteStrategy):
         """Args: symbol, indicators, current_price, position. Returns: EliteSignal|None. Raises: Exception."""
         del position
         if str(os.getenv('ENABLE_ORB_STRATEGY', 'false')).strip().lower() not in {'1','true','yes','on'}:
+            self._no_vote('strategy_disabled_by_env')
             return None
         try:
             self._no_vote("stale_or_invalid_data")
@@ -161,9 +162,10 @@ class ORBProStrategy(EliteStrategy):
                 strategy_name='ORBPro',
                 metadata=metadata,
             )
-        except Exception as e:
-            LOGGER.error('Failure in ORBProStrategy._evaluate_signal: %s', e, exc_info=e)
-            return None
+        except Exception:
+            # The base wrapper records evaluation failures distinctly from
+            # legitimate no-votes; do not convert an ORB crash into reason=none.
+            raise
 
 
 __all__ = ['ORBProStrategy']

--- a/src/nifty_scalper_bot/strategies/elite_strategies/order_flow_live_context_patch.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/order_flow_live_context_patch.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 from typing import Any, Mapping
+import zlib
 
 from nifty_scalper_bot.execution.quote_readiness import resolve_tick_age_ms
 from nifty_scalper_bot.strategies.runtime_context_contract import (
@@ -33,10 +34,20 @@ def _safe_float(value: Any) -> float | None:
     return number if number == number else None
 
 
+def _stable_version(value: Any) -> int:
+    try:
+        numeric = int(float(value))
+    except (TypeError, ValueError):
+        numeric = 0
+    if numeric > 0:
+        return numeric
+    return int(zlib.crc32(str(value).encode("utf-8")) & 0x7FFFFFFF) or 1
+
+
 def _stamp_quote_update_identity(
     metadata: dict[str, Any], indicators: Mapping[str, Any]
 ) -> None:
-    """Preserve the real version, or a stable observed-quote fingerprint."""
+    """Preserve the real version, or a stable integer quote fingerprint."""
     for source in (metadata, indicators):
         for key in (
             "quote_update_version",
@@ -48,7 +59,7 @@ def _stamp_quote_update_identity(
         ):
             value = source.get(key)
             if value not in (None, "", 0, 0.0):
-                metadata["quote_update_version"] = value
+                metadata["quote_update_version"] = _stable_version(value)
                 metadata.setdefault("quote_update_version_source", key)
                 return
 
@@ -62,11 +73,12 @@ def _stamp_quote_update_identity(
     ).upper()
     if bid is None and ask is None and imbalance is None and not tick_direction:
         return
-    metadata["quote_update_version"] = (
-        f"micro:{bid if bid is not None else 'na'}:"
+    raw = (
+        f"{bid if bid is not None else 'na'}:"
         f"{ask if ask is not None else 'na'}:"
         f"{imbalance if imbalance is not None else 'na'}:{tick_direction or 'na'}"
     )
+    metadata["quote_update_version"] = _stable_version(raw)
     metadata["quote_update_version_source"] = "microstructure_fingerprint"
 
 

--- a/src/nifty_scalper_bot/strategies/elite_strategies/order_flow_live_context_patch.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/order_flow_live_context_patch.py
@@ -1,10 +1,4 @@
-"""Live direction-context proof for OrderFlow.
-
-This helper is deliberately narrow.  It does not invent an underlying CE/PE bias.
-It only prevents a live OrderFlow candidate from being blocked solely because
-``direction_bias`` is absent when fresh spot/futures context proof is present and
-all other execution gates already passed.
-"""
+"""Live direction-context proof and quote identity for OrderFlow."""
 
 from __future__ import annotations
 
@@ -37,6 +31,43 @@ def _safe_float(value: Any) -> float | None:
     except (TypeError, ValueError):
         return None
     return number if number == number else None
+
+
+def _stamp_quote_update_identity(
+    metadata: dict[str, Any], indicators: Mapping[str, Any]
+) -> None:
+    """Preserve the real version, or a stable observed-quote fingerprint."""
+    for source in (metadata, indicators):
+        for key in (
+            "quote_update_version",
+            "update_version",
+            "tick_version",
+            "last_tick_ts_ms",
+            "timestamp_ms",
+            "last_tick_timestamp",
+        ):
+            value = source.get(key)
+            if value not in (None, "", 0, 0.0):
+                metadata["quote_update_version"] = value
+                metadata.setdefault("quote_update_version_source", key)
+                return
+
+    bid = _safe_float(metadata.get("bid") or indicators.get("bid"))
+    ask = _safe_float(metadata.get("ask") or indicators.get("ask"))
+    imbalance = _safe_float(
+        metadata.get("depth_imbalance") or indicators.get("depth_imbalance")
+    )
+    tick_direction = str(
+        metadata.get("tick_direction") or indicators.get("tick_direction") or ""
+    ).upper()
+    if bid is None and ask is None and imbalance is None and not tick_direction:
+        return
+    metadata["quote_update_version"] = (
+        f"micro:{bid if bid is not None else 'na'}:"
+        f"{ask if ask is not None else 'na'}:"
+        f"{imbalance if imbalance is not None else 'na'}:{tick_direction or 'na'}"
+    )
+    metadata["quote_update_version_source"] = "microstructure_fingerprint"
 
 
 def _can_upgrade_direction_context_block(
@@ -86,12 +117,16 @@ def apply_orderflow_live_context_proof(
     signal: Any,
     indicators: Mapping[str, Any],
 ) -> Any:
-    """Upgrade an otherwise valid live OrderFlow signal using fresh context proof."""
+    """Preserve quote identity and upgrade only fully proven live context."""
 
-    if signal is None or not _env_live():
+    if signal is None:
         return signal
     metadata = dict(getattr(signal, "metadata", {}) or {})
-    if not _can_upgrade_direction_context_block(metadata, indicators or {}):
+    _stamp_quote_update_identity(metadata, indicators or {})
+    signal.metadata = metadata
+    if not _env_live() or not _can_upgrade_direction_context_block(
+        metadata, indicators or {}
+    ):
         return signal
     metadata.update(
         {

--- a/src/nifty_scalper_bot/strategies/signal_identity_patch.py
+++ b/src/nifty_scalper_bot/strategies/signal_identity_patch.py
@@ -1,4 +1,4 @@
-"""Make live signal identity stable across option strike rotation and tick retries."""
+"""Make live signal identity stable and observable across tick retries."""
 
 from __future__ import annotations
 
@@ -47,7 +47,7 @@ def has_setup_anchor(metadata: Mapping[str, Any] | None) -> bool:
     return any(payload.get(key) not in (None, "") for key in _ANCHOR_KEYS)
 
 
-def _anchor(metadata: Mapping[str, Any]) -> str:
+def _anchor_value(metadata: Mapping[str, Any]) -> str | None:
     for key in _ANCHOR_KEYS:
         value = metadata.get(key)
         if value in (None, ""):
@@ -58,6 +58,13 @@ def _anchor(metadata: Mapping[str, Any]) -> str:
         if isinstance(value, (int, float)):
             return str(int(float(value)))
         return str(value).strip()
+    return None
+
+
+def _anchor(metadata: Mapping[str, Any]) -> str:
+    value = _anchor_value(metadata)
+    if value is not None:
+        return value
     # Never mint a new identity from wall-clock time. A stable sentinel keeps
     # malformed retries idempotent; the real-live preparation gate rejects
     # anchorless strategy entries before they can reach the broker.
@@ -84,17 +91,77 @@ def _deterministic_id(signal: Any) -> str:
     return hashlib.md5(raw.encode()).hexdigest()[:16]
 
 
+def _install_elite_signal_observability() -> None:
+    from nifty_scalper_bot.strategies.elite_strategies.base_elite import EliteStrategy
+
+    current = EliteStrategy.generate_signal
+    if getattr(current, "_elite_signal_observability_patch", False):
+        return
+
+    def generate_signal(
+        self: Any,
+        symbol: str,
+        indicators: Mapping[str, Any],
+        current_price: float,
+        position: Any | None = None,
+    ) -> Any:
+        signal = current(self, symbol, indicators, current_price, position)
+        if signal is None:
+            return None
+        metadata = dict(getattr(signal, "metadata", {}) or {})
+        strategy = str(
+            metadata.get("strategy_name")
+            or metadata.get("strategy")
+            or getattr(self, "name", "unknown")
+        )
+        _, side = _option_thesis(getattr(signal, "symbol", symbol), metadata)
+        setup_anchor = _anchor_value(metadata)
+        setup_id = metadata.get("setup_id") or metadata.get("setup_structure_id")
+        raw_score = metadata.get("raw_setup_score")
+        if raw_score is None:
+            raw_score = metadata.get("strategy_score") or metadata.get("context_score")
+        LOGGER.info(
+            "ELITE_SIGNAL_GENERATED strategy=%s symbol=%s side=%s raw_setup_score=%s confidence=%s setup_id=%s setup_anchor=%s quote_update_version=%s",
+            strategy,
+            getattr(signal, "symbol", symbol),
+            side or None,
+            raw_score,
+            getattr(signal, "confidence", None),
+            setup_id,
+            setup_anchor,
+            metadata.get("quote_update_version"),
+            extra={
+                "event": "ELITE_SIGNAL_GENERATED",
+                "strategy": strategy,
+                "symbol": getattr(signal, "symbol", symbol),
+                "side": side or None,
+                "raw_setup_score": raw_score,
+                "confidence": getattr(signal, "confidence", None),
+                "setup_id": setup_id,
+                "setup_anchor": setup_anchor,
+                "quote_update_version": metadata.get("quote_update_version"),
+                "role": metadata.get("role"),
+            },
+        )
+        return signal
+
+    generate_signal.__name__ = getattr(current, "__name__", "generate_signal")
+    generate_signal.__doc__ = getattr(current, "__doc__", None)
+    setattr(generate_signal, "_elite_signal_observability_patch", True)
+    setattr(generate_signal, "_original", current)
+    EliteStrategy.generate_signal = generate_signal  # type: ignore[assignment]
+
+
 def apply_patches() -> None:
     global _PATCHED
     if _PATCHED:
         return
     from nifty_scalper_bot.strategies.signal_generator import Signal
 
-    if getattr(Signal, "_stable_setup_identity_patch", False):
-        _PATCHED = True
-        return
-    Signal.deterministic_id = property(_deterministic_id)
-    Signal._stable_setup_identity_patch = True
+    if not getattr(Signal, "_stable_setup_identity_patch", False):
+        Signal.deterministic_id = property(_deterministic_id)
+        Signal._stable_setup_identity_patch = True
+    _install_elite_signal_observability()
     _PATCHED = True
 
 

--- a/src/nifty_scalper_bot/strategies/signal_identity_patch.py
+++ b/src/nifty_scalper_bot/strategies/signal_identity_patch.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 import hashlib
+import logging
 import re
 from typing import Any, Mapping
 
@@ -120,7 +121,9 @@ def _install_elite_signal_observability() -> None:
         raw_score = metadata.get("raw_setup_score")
         if raw_score is None:
             raw_score = metadata.get("strategy_score") or metadata.get("context_score")
-        LOGGER.info(
+        role = str(metadata.get("role") or "trigger").lower()
+        LOGGER.log(
+            logging.DEBUG if role == "context" else logging.INFO,
             "ELITE_SIGNAL_GENERATED strategy=%s symbol=%s side=%s raw_setup_score=%s confidence=%s setup_id=%s setup_anchor=%s quote_update_version=%s",
             strategy,
             getattr(signal, "symbol", symbol),
@@ -140,7 +143,7 @@ def _install_elite_signal_observability() -> None:
                 "setup_id": setup_id,
                 "setup_anchor": setup_anchor,
                 "quote_update_version": metadata.get("quote_update_version"),
-                "role": metadata.get("role"),
+                "role": role,
             },
         )
         return signal

--- a/tests/execution/test_entry_fill_quantity_reconciliation.py
+++ b/tests/execution/test_entry_fill_quantity_reconciliation.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+from nifty_scalper_bot.execution.bracket_manager import BracketManager
+
+SYMBOL = "NFO:NIFTY2680724500CE"
+
+
+def _manager(monkeypatch, tmp_path) -> BracketManager:
+    monkeypatch.setenv("BRACKET_FILL_LEDGER_PATH", str(tmp_path / "fills.db"))
+    manager = BracketManager(order_manager=Mock())
+    manager._running = False
+    manager._watchdog_thread.join(timeout=1.0)
+    manager.register_virtual_bracket(
+        "entry-partial",
+        SYMBOL,
+        "BUY",
+        130,
+        100.0,
+        95.0,
+        110.0,
+        activate_immediately=False,
+    )
+    return manager
+
+
+def _entry_fill(manager: BracketManager):
+    bracket = manager.get_bracket("entry-partial")
+    assert bracket is not None
+    assert manager._fill_ledger is not None
+    fills = manager._fill_ledger.load_fills(bracket.bracket_id)
+    entries = [fill for fill in fills if fill.kind == "ENTRY"]
+    assert len(entries) == 1
+    return bracket, entries[0]
+
+
+def test_partial_fill_reconciles_bracket_and_entry_ledger(monkeypatch, tmp_path) -> None:
+    manager = _manager(monkeypatch, tmp_path)
+
+    manager.confirm_entry_fill("entry-partial", 100.0, 65)
+
+    bracket, entry = _entry_fill(manager)
+    assert bracket.quantity == 65
+    assert bracket.remaining_quantity == 65
+    assert bracket.active is True
+    assert entry.quantity == 65
+
+
+def test_late_same_price_callback_reconciles_smaller_quantity(monkeypatch, tmp_path) -> None:
+    manager = _manager(monkeypatch, tmp_path)
+    manager.confirm_entry_fill("entry-partial", 100.0)
+    before, entry_before = _entry_fill(manager)
+    assert before.quantity == 130
+    assert entry_before.quantity == 130
+
+    manager.confirm_entry_fill("entry-partial", 100.0, 65)
+
+    bracket, entry = _entry_fill(manager)
+    assert bracket.quantity == 65
+    assert bracket.remaining_quantity == 65
+    assert entry.quantity == 65
+
+
+def test_identical_duplicate_callback_remains_idempotent(monkeypatch, tmp_path) -> None:
+    manager = _manager(monkeypatch, tmp_path)
+    manager.confirm_entry_fill("entry-partial", 100.0, 65)
+
+    manager.confirm_entry_fill("entry-partial", 100.0, 65)
+
+    bracket, entry = _entry_fill(manager)
+    assert bracket.quantity == 65
+    assert entry.quantity == 65
+
+
+def test_overreported_quantity_never_grows_bracket_or_ledger(monkeypatch, tmp_path) -> None:
+    manager = _manager(monkeypatch, tmp_path)
+    manager.confirm_entry_fill("entry-partial", 100.0, 260)
+
+    bracket, entry = _entry_fill(manager)
+    assert bracket.quantity == 130
+    assert bracket.remaining_quantity == 130
+    assert entry.quantity == 130

--- a/tests/strategies/test_signal_observability_contract.py
+++ b/tests/strategies/test_signal_observability_contract.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+
+from nifty_scalper_bot.strategies.elite_strategies.base_elite import (
+    EliteSignal,
+    EliteStrategy,
+)
+from nifty_scalper_bot.strategies.elite_strategies.config_models import (
+    EliteStrategyConfig,
+    ORBProStrategyConfig,
+)
+from nifty_scalper_bot.strategies.elite_strategies.orb_pro import ORBProStrategy
+from nifty_scalper_bot.strategies.elite_strategies.order_flow_live_context_patch import (
+    apply_orderflow_live_context_proof,
+)
+
+
+class _ObservableStrategy(EliteStrategy):
+    def __init__(self) -> None:
+        super().__init__(EliteStrategyConfig(min_confidence=0.0), SimpleNamespace())
+
+    def get_required_indicators(self) -> list[str]:
+        return []
+
+    def _evaluate_signal(
+        self,
+        symbol: str,
+        indicators: dict[str, object],
+        current_price: float,
+        position: object | None = None,
+    ) -> EliteSignal:
+        del position
+        return EliteSignal(
+            symbol=symbol,
+            signal="BUY",
+            confidence=0.8,
+            entry_price=current_price,
+            stop_loss=current_price - 5.0,
+            target=current_price + 10.0,
+            strategy_name="Observable",
+            metadata={
+                "strategy": "Observable",
+                "strategy_name": "Observable",
+                "role": "trigger",
+                "contract_side": "CE",
+                "raw_setup_score": 8.0,
+                "setup_id": "observable:ce:1",
+                "latest_bar_ts": indicators["latest_bar_ts"],
+                "quote_update_version": 7,
+            },
+        )
+
+
+def test_disabled_orb_has_explicit_no_vote_reason(monkeypatch) -> None:
+    monkeypatch.setenv("ENABLE_ORB_STRATEGY", "false")
+    strategy = ORBProStrategy(
+        ORBProStrategyConfig(enabled=True, quantity=1), indicator_engine=None
+    )
+
+    signal = strategy.generate_signal(
+        "NFO:NIFTY2680724500CE",
+        {"history_resolved_count": 5, "latest_bar_ts": 1_785_000_000.0},
+        100.0,
+    )
+
+    assert signal is None
+    assert strategy.last_no_vote_reason == "strategy_disabled_by_env"
+
+
+def test_elite_signal_log_contains_structural_identity(caplog) -> None:
+    caplog.set_level(logging.INFO)
+    strategy = _ObservableStrategy()
+
+    signal = strategy.generate_signal(
+        "NFO:NIFTY2680724500CE",
+        {"latest_bar_ts": 1_785_000_000.0},
+        100.0,
+    )
+
+    assert signal is not None
+    records = [
+        record
+        for record in caplog.records
+        if getattr(record, "event", None) == "ELITE_SIGNAL_GENERATED"
+    ]
+    assert len(records) == 1
+    record = records[0]
+    assert record.strategy == "Observable"
+    assert record.symbol == "NFO:NIFTY2680724500CE"
+    assert record.side == "CE"
+    assert record.raw_setup_score == 8.0
+    assert record.setup_id == "observable:ce:1"
+    assert record.quote_update_version == 7
+
+
+def _orderflow_signal(*, bid: float = 99.5) -> SimpleNamespace:
+    return SimpleNamespace(
+        metadata={
+            "strategy": "OrderFlow",
+            "role": "context",
+            "bid": bid,
+            "ask": 100.0,
+            "depth_imbalance": 0.25,
+            "tick_direction": "UP",
+        }
+    )
+
+
+def test_orderflow_quote_fingerprint_is_stable_and_changes_with_quote(monkeypatch) -> None:
+    monkeypatch.setenv("EXECUTION_MODE", "SHADOW")
+    first = apply_orderflow_live_context_proof(_orderflow_signal(), {})
+    repeated = apply_orderflow_live_context_proof(_orderflow_signal(), {})
+    changed = apply_orderflow_live_context_proof(_orderflow_signal(bid=99.6), {})
+
+    first_version = first.metadata["quote_update_version"]
+    assert first.metadata["quote_update_version_source"] == "microstructure_fingerprint"
+    assert first_version == repeated.metadata["quote_update_version"]
+    assert first_version != changed.metadata["quote_update_version"]
+
+
+def test_orderflow_prefers_existing_quote_version(monkeypatch) -> None:
+    monkeypatch.setenv("EXECUTION_MODE", "SHADOW")
+    signal = _orderflow_signal()
+
+    result = apply_orderflow_live_context_proof(
+        signal, {"quote_update_version": 42}
+    )
+
+    assert result.metadata["quote_update_version"] == 42
+    assert result.metadata["quote_update_version_source"] == "quote_update_version"


### PR DESCRIPTION
## Problems confirmed from the 09:43/09:44 event exports

1. PR #1013 shrank the active bracket after a partial fill, but the ledger layer recorded the ENTRY before that reconciliation and could retain the requested quantity.
2. An identical-price duplicate fill callback was ignored even when it later supplied a smaller authoritative `filled_qty`.
3. Disabled ORB evaluations returned without a no-vote reason, producing the misleading `none` bucket; ORB exceptions were also converted into normal no-votes.
4. Elite signal events did not expose strategy, side, score, setup identity or quote identity.
5. OrderFlow sometimes reached diagnostics without an explicit quote update version even though the observed microstructure was available.

## Focused corrections

- Pre-shrink the bracket before first ledger persistence, so bracket, ledger, P&L and risk accounting use the same confirmed quantity.
- Add one explicit shrink-only ledger reconciliation operation for a later broker quantity correction. It cannot grow exposure or alter price/side/fees/identity.
- Allow a same-price duplicate callback to reconcile a newly reported smaller quantity; otherwise retain the existing idempotent no-op.
- Set `strategy_disabled_by_env` for disabled ORB and route real ORB exceptions through the base evaluation-failure path.
- Emit structured `ELITE_SIGNAL_GENERATED` events with strategy, symbol, side, raw setup score, confidence, setup ID/anchor and quote version.
- Preserve the existing DataHub quote version when available; otherwise publish a stable observed-microstructure fingerprint for diagnostics only.

## Startup/readiness finding

Code and event ordering were re-traced. Startup reconciliation completes before the LIVE_READY transition in this capture, and the final symbol-readiness path already blocks hard runtime/broker/evaluation states. No redundant startup flag or readiness subsystem was added.

## TDD

- requested 130 / filled 65 -> bracket quantity 65, remaining 65, ledger ENTRY 65;
- late identical-price callback with newly reported 65 shrinks both existing bracket and ledger;
- identical duplicate remains one ledger row;
- over-reported quantity cannot grow bracket or ledger;
- disabled ORB has an explicit reason;
- structured elite-signal identity is logged;
- quote fingerprint is stable for an unchanged quote, changes with microstructure, and never replaces an explicit version.

No strategy thresholds, position sizing, stop/target geometry, broker placement or exit policy changed.