### PR TITLE
fix(strategy): make OrderFlow permanently context-only

### DIFF
--- a/src/nifty_scalper_bot/core/strategy_setup_score_gate.py
+++ b/src/nifty_scalper_bot/core/strategy_setup_score_gate.py
@@ -57,6 +57,37 @@ def setup_gate_result(vote: Any) -> tuple[bool, float | None, float | None, str 
     return True, score, minimum, None
 
 
+def _enforce_permanent_context_only_role(signal: Any, vote: Any) -> bool:
+    """Normalize permanent context strategies before the combiner sees them."""
+    strategy = str(getattr(vote, "strategy", "") or "").strip()
+    if strategy.lower() not in _PERMANENT_CONTEXT_ONLY_STRATEGIES:
+        return False
+    if getattr(signal, "action", None) in {"CLOSE_LONG", "CLOSE_SHORT"}:
+        return False
+
+    metadata = dict(getattr(vote, "metadata", {}) or {})
+    signal_metadata = dict(getattr(signal, "metadata", {}) or {})
+    changed = bool(
+        str(metadata.get("role") or "trigger").strip().lower() != "context"
+        or metadata.get("can_trigger") is not False
+        or metadata.get("trigger_conditions_met") is not False
+    )
+    enforced = {
+        "role": "context",
+        "can_trigger": False,
+        "trigger_conditions_met": False,
+        "trigger_eligible": False,
+        "trigger_block_reason": "context_only_role",
+        "trigger_disqualified_by": "context_only_role",
+        "context_role": "confirmation",
+    }
+    metadata.update(enforced)
+    signal_metadata.update(enforced)
+    setattr(vote, "metadata", metadata)
+    setattr(signal, "metadata", signal_metadata)
+    return changed
+
+
 def _remove_permanent_context_only_promotions(
     context_votes: list[tuple[Any, Any]],
 ) -> tuple[list[tuple[Any, Any]], list[str]]:
@@ -90,8 +121,13 @@ def apply_patches() -> None:
         ) -> Any:
             eligible: list[tuple[Any, Any]] = []
             rejected: list[dict[str, Any]] = []
+            role_corrections: list[str] = []
 
             for signal, vote in signals:
+                if _enforce_permanent_context_only_role(signal, vote):
+                    role_corrections.append(
+                        str(getattr(vote, "strategy", "unknown") or "unknown")
+                    )
                 metadata = dict(getattr(vote, "metadata", {}) or {})
                 role = str(metadata.get("role") or "trigger").strip().lower()
                 is_close = getattr(signal, "action", None) in {
@@ -111,6 +147,22 @@ def apply_patches() -> None:
                         )
                         continue
                 eligible.append((signal, vote))
+
+            if role_corrections:
+                log_throttled(
+                    LOGGER,
+                    f"permanent_context_role:{str(symbol).upper()}",
+                    "PERMANENT_CONTEXT_ONLY_ROLE_ENFORCED symbol=%s strategies=%s",
+                    symbol,
+                    role_corrections,
+                    interval_sec=30.0,
+                    level=logging.WARNING,
+                    extra={
+                        "event": "PERMANENT_CONTEXT_ONLY_ROLE_ENFORCED",
+                        "symbol": str(symbol).upper(),
+                        "strategies": role_corrections,
+                    },
+                )
 
             eligible_trigger_exists = any(
                 str((getattr(vote, "metadata", {}) or {}).get("role") or "trigger")
@@ -198,5 +250,6 @@ def apply_patches() -> None:
 __all__ = [
     "apply_patches",
     "setup_gate_result",
+    "_enforce_permanent_context_only_role",
     "_remove_permanent_context_only_promotions",
 ]

--- a/src/nifty_scalper_bot/core/strategy_setup_score_gate.py
+++ b/src/nifty_scalper_bot/core/strategy_setup_score_gate.py
@@ -1,7 +1,8 @@
-"""Fail-closed setup-quality gate for strategy vote combination.
+"""Fail-closed setup-quality and context-role gates for strategy combination.
 
 Context may confirm or veto a valid trigger, but it must never convert a setup
-that failed its own strategy threshold into an executable entry.
+that failed its own strategy threshold into an executable entry. OrderFlow is a
+permanent confirmation-only strategy and cannot be promoted into a trigger.
 """
 
 from __future__ import annotations
@@ -15,6 +16,7 @@ LOGGER = get_logger(__name__)
 
 _SCORE_KEYS = ("raw_setup_score", "setup_score", "strategy_score")
 _MIN_KEYS = ("setup_min", "setup_min_score", "trigger_min_score", "min_score")
+_PERMANENT_CONTEXT_ONLY_STRATEGIES = frozenset({"orderflow"})
 
 
 def _float_from(metadata: Mapping[str, Any], keys: tuple[str, ...]) -> float | None:
@@ -55,82 +57,146 @@ def setup_gate_result(vote: Any) -> tuple[bool, float | None, float | None, str 
     return True, score, minimum, None
 
 
+def _remove_permanent_context_only_promotions(
+    context_votes: list[tuple[Any, Any]],
+) -> tuple[list[tuple[Any, Any]], list[str]]:
+    """Remove strategies that are never allowed to originate an entry."""
+    eligible: list[tuple[Any, Any]] = []
+    blocked: list[str] = []
+    for signal, vote in context_votes:
+        strategy = str(getattr(vote, "strategy", "") or "").strip()
+        if strategy.lower() in _PERMANENT_CONTEXT_ONLY_STRATEGIES:
+            blocked.append(strategy or "unknown")
+            continue
+        eligible.append((signal, vote))
+    return eligible, blocked
+
+
 def apply_patches() -> None:
     from nifty_scalper_bot.core import strategy_manager as strategy_module
 
     cls = strategy_module.StrategyManager
-    if getattr(cls, "_hard_setup_score_gate_installed", False):
-        return
 
-    original = cls._combine_strategy_votes
+    if not getattr(cls, "_hard_setup_score_gate_installed", False):
+        original = cls._combine_strategy_votes
 
-    def _combine_strategy_votes(
-        self: Any,
-        *,
-        symbol: str,
-        signals: list[tuple[Any, Any]],
-        indicators: Mapping[str, Any],
-        no_vote_reason_counts: Mapping[str, int] | None = None,
-    ) -> Any:
-        eligible: list[tuple[Any, Any]] = []
-        rejected: list[dict[str, Any]] = []
+        def _combine_strategy_votes(
+            self: Any,
+            *,
+            symbol: str,
+            signals: list[tuple[Any, Any]],
+            indicators: Mapping[str, Any],
+            no_vote_reason_counts: Mapping[str, int] | None = None,
+        ) -> Any:
+            eligible: list[tuple[Any, Any]] = []
+            rejected: list[dict[str, Any]] = []
 
-        for signal, vote in signals:
-            metadata = dict(getattr(vote, "metadata", {}) or {})
-            role = str(metadata.get("role") or "trigger").strip().lower()
-            is_close = getattr(signal, "action", None) in {"CLOSE_LONG", "CLOSE_SHORT"}
-            if role != "context" and not is_close:
-                passed, score, minimum, reason = setup_gate_result(vote)
-                if not passed:
-                    rejected.append(
-                        {
-                            "strategy": getattr(vote, "strategy", None),
-                            "score": score,
-                            "minimum": minimum,
-                            "reason": reason,
-                        }
-                    )
-                    continue
-            eligible.append((signal, vote))
+            for signal, vote in signals:
+                metadata = dict(getattr(vote, "metadata", {}) or {})
+                role = str(metadata.get("role") or "trigger").strip().lower()
+                is_close = getattr(signal, "action", None) in {
+                    "CLOSE_LONG",
+                    "CLOSE_SHORT",
+                }
+                if role != "context" and not is_close:
+                    passed, score, minimum, reason = setup_gate_result(vote)
+                    if not passed:
+                        rejected.append(
+                            {
+                                "strategy": getattr(vote, "strategy", None),
+                                "score": score,
+                                "minimum": minimum,
+                                "reason": reason,
+                            }
+                        )
+                        continue
+                eligible.append((signal, vote))
 
-        eligible_trigger_exists = any(
-            str((getattr(vote, "metadata", {}) or {}).get("role") or "trigger")
-            .strip()
-            .lower()
-            != "context"
-            and getattr(signal, "action", None) not in {"CLOSE_LONG", "CLOSE_SHORT"}
-            for signal, vote in eligible
-        )
-        if rejected and not eligible_trigger_exists:
-            # Never pass context-only votes to the legacy promotion path after an
-            # explicit trigger failed its own setup threshold.
-            log_throttled(
-                LOGGER,
-                f"hard_setup_score_gate:{str(symbol).upper()}",
-                "HARD_SETUP_SCORE_GATE_BLOCKED symbol=%s rejected=%s",
-                symbol,
-                rejected,
-                interval_sec=30.0,
-                level=logging.INFO,
-                extra={
-                    "event": "HARD_SETUP_SCORE_GATE_BLOCKED",
-                    "symbol": str(symbol).upper(),
-                    "rejected": rejected,
-                },
+            eligible_trigger_exists = any(
+                str((getattr(vote, "metadata", {}) or {}).get("role") or "trigger")
+                .strip()
+                .lower()
+                != "context"
+                and getattr(signal, "action", None)
+                not in {"CLOSE_LONG", "CLOSE_SHORT"}
+                for signal, vote in eligible
             )
-            return None
+            if rejected and not eligible_trigger_exists:
+                # Never pass context-only votes to the legacy promotion path after an
+                # explicit trigger failed its own setup threshold.
+                log_throttled(
+                    LOGGER,
+                    f"hard_setup_score_gate:{str(symbol).upper()}",
+                    "HARD_SETUP_SCORE_GATE_BLOCKED symbol=%s rejected=%s",
+                    symbol,
+                    rejected,
+                    interval_sec=30.0,
+                    level=logging.INFO,
+                    extra={
+                        "event": "HARD_SETUP_SCORE_GATE_BLOCKED",
+                        "symbol": str(symbol).upper(),
+                        "rejected": rejected,
+                    },
+                )
+                return None
 
-        return original(
-            self,
-            symbol=symbol,
-            signals=eligible,
-            indicators=indicators,
-            no_vote_reason_counts=no_vote_reason_counts,
-        )
+            return original(
+                self,
+                symbol=symbol,
+                signals=eligible,
+                indicators=indicators,
+                no_vote_reason_counts=no_vote_reason_counts,
+            )
 
-    cls._hard_setup_score_gate_original_combine = original
-    cls._combine_strategy_votes = _combine_strategy_votes
-    cls._hard_setup_score_gate_installed = True
+        cls._hard_setup_score_gate_original_combine = original
+        cls._combine_strategy_votes = _combine_strategy_votes
+        cls._hard_setup_score_gate_installed = True
+
+    if not getattr(cls, "_permanent_context_only_gate_installed", False):
+        original_promotion = cls._try_context_promotion
+
+        def _try_context_promotion(
+            self: Any,
+            symbol: str,
+            context_votes: list[tuple[Any, Any]],
+            indicators: Mapping[str, Any],
+            mode_profile: dict[str, Any],
+        ) -> Any:
+            eligible, blocked = _remove_permanent_context_only_promotions(
+                context_votes
+            )
+            if blocked:
+                log_throttled(
+                    LOGGER,
+                    f"permanent_context_only:{str(symbol).upper()}",
+                    "PERMANENT_CONTEXT_ONLY_PROMOTION_BLOCKED symbol=%s strategies=%s",
+                    symbol,
+                    blocked,
+                    interval_sec=30.0,
+                    level=logging.INFO,
+                    extra={
+                        "event": "PERMANENT_CONTEXT_ONLY_PROMOTION_BLOCKED",
+                        "symbol": str(symbol).upper(),
+                        "strategies": blocked,
+                    },
+                )
+            if not eligible:
+                return None
+            return original_promotion(
+                self,
+                symbol,
+                eligible,
+                indicators,
+                mode_profile,
+            )
+
+        cls._permanent_context_only_original_promotion = original_promotion
+        cls._try_context_promotion = _try_context_promotion
+        cls._permanent_context_only_gate_installed = True
 
 
-__all__ = ["apply_patches", "setup_gate_result"]
+__all__ = [
+    "apply_patches",
+    "setup_gate_result",
+    "_remove_permanent_context_only_promotions",
+]

--- a/src/nifty_scalper_bot/core/strategy_setup_score_gate.py
+++ b/src/nifty_scalper_bot/core/strategy_setup_score_gate.py
@@ -1,8 +1,8 @@
 """Fail-closed setup-quality and context-role gates for strategy combination.
 
 Context may confirm or veto a valid trigger, but it must never convert a setup
-that failed its own strategy threshold into an executable entry. OrderFlow is a
-permanent confirmation-only strategy and cannot be promoted into a trigger.
+that failed its own threshold into an entry. OrderFlow is permanently context
+only and cannot be promoted into a trigger.
 """
 
 from __future__ import annotations
@@ -16,7 +16,7 @@ LOGGER = get_logger(__name__)
 
 _SCORE_KEYS = ("raw_setup_score", "setup_score", "strategy_score")
 _MIN_KEYS = ("setup_min", "setup_min_score", "trigger_min_score", "min_score")
-_PERMANENT_CONTEXT_ONLY_STRATEGIES = frozenset({"orderflow"})
+_CONTEXT_ONLY = frozenset({"orderflow"})
 
 
 def _float_from(metadata: Mapping[str, Any], keys: tuple[str, ...]) -> float | None:
@@ -32,10 +32,7 @@ def _float_from(metadata: Mapping[str, Any], keys: tuple[str, ...]) -> float | N
 
 
 def setup_gate_result(vote: Any) -> tuple[bool, float | None, float | None, str | None]:
-    """Return whether an explicit trigger setup contract passed.
-
-    Votes without setup score/minimum metadata retain legacy behaviour.
-    """
+    """Return whether an explicit trigger setup contract passed."""
     metadata = dict(getattr(vote, "metadata", {}) or {})
     if str(metadata.get("role") or "trigger").strip().lower() == "context":
         return True, None, None, None
@@ -57,21 +54,14 @@ def setup_gate_result(vote: Any) -> tuple[bool, float | None, float | None, str 
     return True, score, minimum, None
 
 
-def _enforce_permanent_context_only_role(signal: Any, vote: Any) -> bool:
-    """Normalize permanent context strategies before the combiner sees them."""
-    strategy = str(getattr(vote, "strategy", "") or "").strip()
-    if strategy.lower() not in _PERMANENT_CONTEXT_ONLY_STRATEGIES:
+def enforce_context_only_role(signal: Any, vote: Any) -> bool:
+    """Force permanent context strategies back to their declared role."""
+    strategy = str(getattr(vote, "strategy", "") or "").strip().lower()
+    if strategy not in _CONTEXT_ONLY or getattr(signal, "action", None) in {
+        "CLOSE_LONG",
+        "CLOSE_SHORT",
+    }:
         return False
-    if getattr(signal, "action", None) in {"CLOSE_LONG", "CLOSE_SHORT"}:
-        return False
-
-    metadata = dict(getattr(vote, "metadata", {}) or {})
-    signal_metadata = dict(getattr(signal, "metadata", {}) or {})
-    changed = bool(
-        str(metadata.get("role") or "trigger").strip().lower() != "context"
-        or metadata.get("can_trigger") is not False
-        or metadata.get("trigger_conditions_met") is not False
-    )
     enforced = {
         "role": "context",
         "can_trigger": False,
@@ -81,25 +71,28 @@ def _enforce_permanent_context_only_role(signal: Any, vote: Any) -> bool:
         "trigger_disqualified_by": "context_only_role",
         "context_role": "confirmation",
     }
-    metadata.update(enforced)
+    vote_metadata = dict(getattr(vote, "metadata", {}) or {})
+    signal_metadata = dict(getattr(signal, "metadata", {}) or {})
+    changed = any(vote_metadata.get(key) != value for key, value in enforced.items())
+    vote_metadata.update(enforced)
     signal_metadata.update(enforced)
-    setattr(vote, "metadata", metadata)
-    setattr(signal, "metadata", signal_metadata)
+    vote.metadata = vote_metadata
+    signal.metadata = signal_metadata
     return changed
 
 
-def _remove_permanent_context_only_promotions(
+def filter_context_promotions(
     context_votes: list[tuple[Any, Any]],
 ) -> tuple[list[tuple[Any, Any]], list[str]]:
-    """Remove strategies that are never allowed to originate an entry."""
+    """Remove permanent context-only strategies from promotion candidates."""
     eligible: list[tuple[Any, Any]] = []
     blocked: list[str] = []
     for signal, vote in context_votes:
         strategy = str(getattr(vote, "strategy", "") or "").strip()
-        if strategy.lower() in _PERMANENT_CONTEXT_ONLY_STRATEGIES:
+        if strategy.lower() in _CONTEXT_ONLY:
             blocked.append(strategy or "unknown")
-            continue
-        eligible.append((signal, vote))
+        else:
+            eligible.append((signal, vote))
     return eligible, blocked
 
 
@@ -109,7 +102,7 @@ def apply_patches() -> None:
     cls = strategy_module.StrategyManager
 
     if not getattr(cls, "_hard_setup_score_gate_installed", False):
-        original = cls._combine_strategy_votes
+        original_combine = cls._combine_strategy_votes
 
         def _combine_strategy_votes(
             self: Any,
@@ -121,13 +114,10 @@ def apply_patches() -> None:
         ) -> Any:
             eligible: list[tuple[Any, Any]] = []
             rejected: list[dict[str, Any]] = []
-            role_corrections: list[str] = []
-
+            corrected: list[str] = []
             for signal, vote in signals:
-                if _enforce_permanent_context_only_role(signal, vote):
-                    role_corrections.append(
-                        str(getattr(vote, "strategy", "unknown") or "unknown")
-                    )
+                if enforce_context_only_role(signal, vote):
+                    corrected.append(str(getattr(vote, "strategy", "unknown")))
                 metadata = dict(getattr(vote, "metadata", {}) or {})
                 role = str(metadata.get("role") or "trigger").strip().lower()
                 is_close = getattr(signal, "action", None) in {
@@ -148,23 +138,23 @@ def apply_patches() -> None:
                         continue
                 eligible.append((signal, vote))
 
-            if role_corrections:
+            if corrected:
                 log_throttled(
                     LOGGER,
-                    f"permanent_context_role:{str(symbol).upper()}",
+                    f"context_role_enforced:{str(symbol).upper()}",
                     "PERMANENT_CONTEXT_ONLY_ROLE_ENFORCED symbol=%s strategies=%s",
                     symbol,
-                    role_corrections,
+                    corrected,
                     interval_sec=30.0,
                     level=logging.WARNING,
                     extra={
                         "event": "PERMANENT_CONTEXT_ONLY_ROLE_ENFORCED",
                         "symbol": str(symbol).upper(),
-                        "strategies": role_corrections,
+                        "strategies": corrected,
                     },
                 )
 
-            eligible_trigger_exists = any(
+            trigger_exists = any(
                 str((getattr(vote, "metadata", {}) or {}).get("role") or "trigger")
                 .strip()
                 .lower()
@@ -173,9 +163,7 @@ def apply_patches() -> None:
                 not in {"CLOSE_LONG", "CLOSE_SHORT"}
                 for signal, vote in eligible
             )
-            if rejected and not eligible_trigger_exists:
-                # Never pass context-only votes to the legacy promotion path after an
-                # explicit trigger failed its own setup threshold.
+            if rejected and not trigger_exists:
                 log_throttled(
                     LOGGER,
                     f"hard_setup_score_gate:{str(symbol).upper()}",
@@ -191,8 +179,7 @@ def apply_patches() -> None:
                     },
                 )
                 return None
-
-            return original(
+            return original_combine(
                 self,
                 symbol=symbol,
                 signals=eligible,
@@ -200,7 +187,7 @@ def apply_patches() -> None:
                 no_vote_reason_counts=no_vote_reason_counts,
             )
 
-        cls._hard_setup_score_gate_original_combine = original
+        cls._hard_setup_score_gate_original_combine = original_combine
         cls._combine_strategy_votes = _combine_strategy_votes
         cls._hard_setup_score_gate_installed = True
 
@@ -214,13 +201,11 @@ def apply_patches() -> None:
             indicators: Mapping[str, Any],
             mode_profile: dict[str, Any],
         ) -> Any:
-            eligible, blocked = _remove_permanent_context_only_promotions(
-                context_votes
-            )
+            eligible, blocked = filter_context_promotions(context_votes)
             if blocked:
                 log_throttled(
                     LOGGER,
-                    f"permanent_context_only:{str(symbol).upper()}",
+                    f"context_promotion_blocked:{str(symbol).upper()}",
                     "PERMANENT_CONTEXT_ONLY_PROMOTION_BLOCKED symbol=%s strategies=%s",
                     symbol,
                     blocked,
@@ -235,11 +220,7 @@ def apply_patches() -> None:
             if not eligible:
                 return None
             return original_promotion(
-                self,
-                symbol,
-                eligible,
-                indicators,
-                mode_profile,
+                self, symbol, eligible, indicators, mode_profile
             )
 
         cls._permanent_context_only_original_promotion = original_promotion
@@ -249,7 +230,7 @@ def apply_patches() -> None:
 
 __all__ = [
     "apply_patches",
+    "enforce_context_only_role",
+    "filter_context_promotions",
     "setup_gate_result",
-    "_enforce_permanent_context_only_role",
-    "_remove_permanent_context_only_promotions",
 ]

--- a/tests/core/test_strategy_setup_score_gate.py
+++ b/tests/core/test_strategy_setup_score_gate.py
@@ -4,8 +4,8 @@ from types import SimpleNamespace
 
 from nifty_scalper_bot.core.strategy_manager import StrategyManager
 from nifty_scalper_bot.core.strategy_setup_score_gate import (
-    _enforce_permanent_context_only_role,
-    _remove_permanent_context_only_promotions,
+    enforce_context_only_role,
+    filter_context_promotions,
     setup_gate_result,
 )
 
@@ -95,7 +95,7 @@ def test_malformed_orderflow_trigger_is_normalized_to_context() -> None:
         trigger_conditions_met=True,
     )
 
-    changed = _enforce_permanent_context_only_role(signal, vote)
+    changed = enforce_context_only_role(signal, vote)
 
     assert changed is True
     for metadata in (signal.metadata, vote.metadata):
@@ -116,9 +116,7 @@ def test_orderflow_is_removed_from_context_promotion_candidates() -> None:
         _vote(strategy="VWAPPro", role="context", raw_setup_score=9.0),
     )
 
-    eligible, blocked = _remove_permanent_context_only_promotions(
-        [orderflow, vwap_context]
-    )
+    eligible, blocked = filter_context_promotions([orderflow, vwap_context])
 
     assert eligible == [vwap_context]
     assert blocked == ["OrderFlow"]

--- a/tests/core/test_strategy_setup_score_gate.py
+++ b/tests/core/test_strategy_setup_score_gate.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 
 from nifty_scalper_bot.core.strategy_manager import StrategyManager
 from nifty_scalper_bot.core.strategy_setup_score_gate import (
+    _enforce_permanent_context_only_role,
     _remove_permanent_context_only_promotions,
     setup_gate_result,
 )
@@ -75,6 +76,34 @@ def test_context_cannot_promote_an_explicitly_failed_trigger() -> None:
     )
 
     assert result is None
+
+
+def test_malformed_orderflow_trigger_is_normalized_to_context() -> None:
+    signal = SimpleNamespace(
+        action="BUY",
+        metadata={
+            "strategy": "OrderFlow",
+            "role": "trigger",
+            "can_trigger": True,
+            "trigger_conditions_met": True,
+        },
+    )
+    vote = _vote(
+        strategy="OrderFlow",
+        role="trigger",
+        can_trigger=True,
+        trigger_conditions_met=True,
+    )
+
+    changed = _enforce_permanent_context_only_role(signal, vote)
+
+    assert changed is True
+    for metadata in (signal.metadata, vote.metadata):
+        assert metadata["role"] == "context"
+        assert metadata["can_trigger"] is False
+        assert metadata["trigger_conditions_met"] is False
+        assert metadata["trigger_eligible"] is False
+        assert metadata["trigger_block_reason"] == "context_only_role"
 
 
 def test_orderflow_is_removed_from_context_promotion_candidates() -> None:

--- a/tests/core/test_strategy_setup_score_gate.py
+++ b/tests/core/test_strategy_setup_score_gate.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 from nifty_scalper_bot.core.strategy_manager import StrategyManager
-from nifty_scalper_bot.core.strategy_setup_score_gate import setup_gate_result
+from nifty_scalper_bot.core.strategy_setup_score_gate import (
+    _remove_permanent_context_only_promotions,
+    setup_gate_result,
+)
 
 
 def _vote(**metadata):
@@ -69,6 +72,67 @@ def test_context_cannot_promote_an_explicitly_failed_trigger() -> None:
         symbol="NFO:NIFTY2680625000CE",
         signals=[weak_trigger, strong_context],
         indicators={},
+    )
+
+    assert result is None
+
+
+def test_orderflow_is_removed_from_context_promotion_candidates() -> None:
+    orderflow = (
+        SimpleNamespace(action="BUY"),
+        _vote(strategy="OrderFlow", role="context", raw_setup_score=10.0),
+    )
+    vwap_context = (
+        SimpleNamespace(action="BUY"),
+        _vote(strategy="VWAPPro", role="context", raw_setup_score=9.0),
+    )
+
+    eligible, blocked = _remove_permanent_context_only_promotions(
+        [orderflow, vwap_context]
+    )
+
+    assert eligible == [vwap_context]
+    assert blocked == ["OrderFlow"]
+
+
+def test_orderflow_cannot_promote_even_when_every_promotion_flag_is_enabled(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("EXECUTION_MODE", "LIVE")
+    monkeypatch.setenv("ENABLE_LIVE", "true")
+    monkeypatch.setenv("STRATEGY_CONTEXT_PROMOTION_LIVE_ALLOWED", "true")
+    monkeypatch.setenv(
+        "STRATEGY_CONTEXT_PROMOTION_ALLOWED_STRATEGIES", "OrderFlow,VWAPPro"
+    )
+    manager = StrategyManager.__new__(StrategyManager)
+    orderflow = (
+        SimpleNamespace(action="BUY"),
+        _vote(
+            strategy="OrderFlow",
+            role="context",
+            raw_setup_score=10.0,
+            context_score=10.0,
+        ),
+    )
+
+    result = manager._try_context_promotion(
+        "NFO:NIFTY2680625000CE",
+        [orderflow],
+        {
+            "direction_bias": "CE",
+            "context_fresh": True,
+            "context_age_seconds": 0.1,
+            "is_selected_option": True,
+            "bid": 99.5,
+            "ask": 100.0,
+            "quote_depth_valid": True,
+        },
+        {
+            "mode": "LIVE",
+            "allow_context_promotion": True,
+            "allow_single_vote": True,
+            "min_trade_quality": 7.0,
+        },
     )
 
     assert result is None


### PR DESCRIPTION
## Root cause

OrderFlow's evaluator already sets `allow_orderflow_trigger = False`, but the central StrategyManager retained a context-promotion path that explicitly allowed `OrderFlow`. Therefore a strong OrderFlow context vote could become an executable trigger in PAPER/SHADOW by default, or in LIVE when `STRATEGY_CONTEXT_PROMOTION_LIVE_ALLOWED=true`.

The existing `ORDERFLOW_TRIGGER_DECISION` diagnostic also continues to appear for context evaluations, which can look like an entry firing even when `trigger_conditions_met=false` and `trigger_block_reason=context_only_role`.

## Focused correction

- Enforce the declared production role at the combiner boundary: any OrderFlow vote marked as trigger is normalized to context with `can_trigger=false`.
- Remove OrderFlow from context-promotion candidates, independent of environment flags and score.
- Preserve OrderFlow as confirmation/veto context when a genuine SMC, VWAPPro, or ORBPro trigger exists.
- Keep close signals untouched.

## TDD

- malformed `OrderFlow role=trigger` is normalized to context;
- OrderFlow is removed while another context candidate remains eligible;
- OrderFlow cannot promote even with every LIVE promotion flag enabled;
- existing failed-trigger and close-signal contracts remain covered.

No changes to signal scores, strategy conditions, position sizing, stops, targets, broker execution, or exit policy.