### PR TITLE
fix(runtime): preserve frozen signals and sync rotated basket ingress

### DIFF
--- a/src/nifty_scalper_bot/core/market_data_hardening_bootstrap.py
+++ b/src/nifty_scalper_bot/core/market_data_hardening_bootstrap.py
@@ -1,7 +1,7 @@
 """Deterministic market-data hardening bootstrap.
 
-This module verifies that candle, manager, and WebSocket hardening hooks are
-installed before the trading application is built.
+This module verifies that candle, manager, DataHub, and WebSocket hardening hooks
+are installed before the trading application is built.
 """
 
 from __future__ import annotations
@@ -9,6 +9,7 @@ from __future__ import annotations
 from typing import Any
 
 _MDM_HARDENING_ATTR = "_freshness_hardening_installed"
+_DATAHUB_HARDENING_ATTR = "_active_basket_subscription_hardening_installed"
 _WS_HARDENING_ATTR = "_market_data_hardening_installed"
 _CANDLE_HARDENING_ATTR = "_candle_state_hardening_installed"
 _CLOCK_FLUSH_HARDENING_ATTR = "_candle_clock_flush_hardening_installed"
@@ -24,6 +25,10 @@ def install_market_data_hardening_or_raise(logger: Any | None = None) -> dict[st
     from nifty_scalper_bot.data.candle_state_hardening import (
         install_candle_state_hardening,
     )
+    from nifty_scalper_bot.data.data_hub import DataHub
+    from nifty_scalper_bot.data.data_hub_subscription_hardening import (
+        install_data_hub_subscription_hardening,
+    )
     from nifty_scalper_bot.data.market_data_hardening import (
         install_market_data_manager_hardening,
     )
@@ -36,6 +41,7 @@ def install_market_data_hardening_or_raise(logger: Any | None = None) -> dict[st
     install_candle_state_hardening(CandleEngine)
     install_market_data_manager_hardening(MarketDataManager)
     install_candle_clock_flush_hardening(MarketDataManager)
+    install_data_hub_subscription_hardening(DataHub)
     install_websocket_market_data_hardening(WebSocketManager)
 
     full_state = {
@@ -43,6 +49,7 @@ def install_market_data_hardening_or_raise(logger: Any | None = None) -> dict[st
         "clock_flush": bool(
             getattr(MarketDataManager, _CLOCK_FLUSH_HARDENING_ATTR, False)
         ),
+        "datahub": bool(getattr(DataHub, _DATAHUB_HARDENING_ATTR, False)),
         "mdm": bool(getattr(MarketDataManager, _MDM_HARDENING_ATTR, False)),
         "websocket": bool(getattr(WebSocketManager, _WS_HARDENING_ATTR, False)),
     }
@@ -51,11 +58,12 @@ def install_market_data_hardening_or_raise(logger: Any | None = None) -> dict[st
 
     if logger is not None:
         logger.info(
-            "MARKET_DATA_HARDENING_INSTALLED mdm=%s websocket=%s candle=%s clock_flush=%s",
+            "MARKET_DATA_HARDENING_INSTALLED mdm=%s websocket=%s candle=%s clock_flush=%s datahub=%s",
             full_state["mdm"],
             full_state["websocket"],
             full_state["candle"],
             full_state["clock_flush"],
+            full_state["datahub"],
             extra={"event": "MARKET_DATA_HARDENING_INSTALLED", **full_state},
         )
 

--- a/src/nifty_scalper_bot/core/strategy_setup_score_gate.py
+++ b/src/nifty_scalper_bot/core/strategy_setup_score_gate.py
@@ -7,6 +7,7 @@ only and cannot be promoted into a trigger.
 
 from __future__ import annotations
 
+import dataclasses
 import logging
 from typing import Any, Mapping
 
@@ -54,14 +55,15 @@ def setup_gate_result(vote: Any) -> tuple[bool, float | None, float | None, str 
     return True, score, minimum, None
 
 
-def enforce_context_only_role(signal: Any, vote: Any) -> bool:
-    """Force permanent context strategies back to their declared role."""
+def enforce_context_only_role(signal: Any, vote: Any) -> tuple[Any, bool]:
+    """Return a signal/vote pair with permanent context roles enforced safely."""
     strategy = str(getattr(vote, "strategy", "") or "").strip().lower()
     if strategy not in _CONTEXT_ONLY or getattr(signal, "action", None) in {
         "CLOSE_LONG",
         "CLOSE_SHORT",
     }:
-        return False
+        return signal, False
+
     enforced = {
         "role": "context",
         "can_trigger": False,
@@ -73,12 +75,24 @@ def enforce_context_only_role(signal: Any, vote: Any) -> bool:
     }
     vote_metadata = dict(getattr(vote, "metadata", {}) or {})
     signal_metadata = dict(getattr(signal, "metadata", {}) or {})
-    changed = any(vote_metadata.get(key) != value for key, value in enforced.items())
+    changed = any(
+        vote_metadata.get(key) != value or signal_metadata.get(key) != value
+        for key, value in enforced.items()
+    )
     vote_metadata.update(enforced)
     signal_metadata.update(enforced)
     vote.metadata = vote_metadata
-    signal.metadata = signal_metadata
-    return changed
+
+    # Signal is a frozen dataclass in production. Never assign signal.metadata;
+    # preserve immutability and return a replacement instead.
+    with_metadata = getattr(signal, "with_metadata", None)
+    if callable(with_metadata):
+        signal = with_metadata(**enforced)
+    elif dataclasses.is_dataclass(signal):
+        signal = dataclasses.replace(signal, metadata=signal_metadata)
+    else:
+        signal.metadata = signal_metadata
+    return signal, changed
 
 
 def filter_context_promotions(
@@ -116,7 +130,8 @@ def apply_patches() -> None:
             rejected: list[dict[str, Any]] = []
             corrected: list[str] = []
             for signal, vote in signals:
-                if enforce_context_only_role(signal, vote):
+                signal, role_changed = enforce_context_only_role(signal, vote)
+                if role_changed:
                     corrected.append(str(getattr(vote, "strategy", "unknown")))
                 metadata = dict(getattr(vote, "metadata", {}) or {})
                 role = str(metadata.get("role") or "trigger").strip().lower()

--- a/src/nifty_scalper_bot/data/data_hub_subscription_hardening.py
+++ b/src/nifty_scalper_bot/data/data_hub_subscription_hardening.py
@@ -1,0 +1,93 @@
+"""Keep DataHub's direct MDM ingress aligned with the active basket."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Mapping
+
+_INSTALLED_ATTR = "_active_basket_subscription_hardening_installed"
+_ORIGINAL_ATTR = "_active_basket_subscription_hardening_original_set_basket"
+
+
+def _basket_get(basket: Any, key: str, default: Any = None) -> Any:
+    if isinstance(basket, Mapping):
+        return basket.get(key, default)
+    return getattr(basket, key, default)
+
+
+def _basket_symbols(basket: Any) -> list[str]:
+    values: list[Any] = []
+    values.extend(_basket_get(basket, "all_symbols", ()) or ())
+    values.extend(_basket_get(basket, "symbols", ()) or ())
+    values.extend(_basket_get(basket, "option_symbols", ()) or ())
+    values.extend(
+        [
+            _basket_get(basket, "spot_symbol"),
+            _basket_get(basket, "futures_symbol"),
+            _basket_get(basket, "selected_ce"),
+            _basket_get(basket, "selected_pe"),
+            _basket_get(basket, "atm_ce"),
+            _basket_get(basket, "atm_pe"),
+        ]
+    )
+    return [str(value) for value in dict.fromkeys(values) if value]
+
+
+def install_data_hub_subscription_hardening(data_hub_cls: type[Any]) -> None:
+    """Subscribe every active-basket symbol through DataHub's direct MDM path."""
+    if bool(getattr(data_hub_cls, _INSTALLED_ATTR, False)):
+        return
+
+    original = getattr(data_hub_cls, "set_active_contract_basket")
+    setattr(data_hub_cls, _ORIGINAL_ATTR, original)
+
+    def _set_active_contract_basket(self: Any, basket: Any) -> None:
+        original(self, basket)
+        token_by_symbol = dict(_basket_get(basket, "token_by_symbol", {}) or {})
+        deferred = bool(getattr(self, "_defer_live_symbol_subscriptions", True))
+        subscribe_ticks = getattr(self, "subscribe_ticks", None)
+        if not callable(subscribe_ticks):
+            return
+
+        failed: list[str] = []
+        subscribed: list[str] = []
+        for symbol in _basket_symbols(basket):
+            token = token_by_symbol.get(symbol)
+            try:
+                subscribe_ticks(
+                    symbol,
+                    token=int(token) if token is not None else None,
+                    force_live=not deferred,
+                )
+                subscribed.append(symbol)
+            except Exception as exc:  # noqa: BLE001 - one symbol must not abort basket commit
+                failed.append(symbol)
+                logging.getLogger(__name__).error(
+                    "DATAHUB_BASKET_SUBSCRIPTION_FAILED symbol=%s error=%r",
+                    symbol,
+                    exc,
+                    exc_info=True,
+                    extra={
+                        "event": "DATAHUB_BASKET_SUBSCRIPTION_FAILED",
+                        "symbol": symbol,
+                        "error_type": type(exc).__name__,
+                    },
+                )
+        logging.getLogger(__name__).info(
+            "DATAHUB_BASKET_SUBSCRIPTIONS_SYNCED symbols=%d failed=%d deferred=%s",
+            len(subscribed),
+            len(failed),
+            deferred,
+            extra={
+                "event": "DATAHUB_BASKET_SUBSCRIPTIONS_SYNCED",
+                "symbols": subscribed,
+                "failed_symbols": failed,
+                "deferred": deferred,
+            },
+        )
+
+    setattr(data_hub_cls, "set_active_contract_basket", _set_active_contract_basket)
+    setattr(data_hub_cls, _INSTALLED_ATTR, True)
+
+
+__all__ = ["install_data_hub_subscription_hardening"]

--- a/tests/core/test_market_data_hardening_production_import.py
+++ b/tests/core/test_market_data_hardening_production_import.py
@@ -9,6 +9,7 @@ def test_production_app_import_installs_all_market_data_hardening() -> None:
     assert app_module is not None
 
     from nifty_scalper_bot.data.candle_engine import CandleEngine
+    from nifty_scalper_bot.data.data_hub import DataHub
     from nifty_scalper_bot.data.market_data_manager import MarketDataManager
     from nifty_scalper_bot.streaming.websocket_manager import WebSocketManager
 
@@ -16,6 +17,10 @@ def test_production_app_import_installs_all_market_data_hardening() -> None:
     assert getattr(MarketDataManager, "_freshness_hardening_installed", False) is True
     assert (
         getattr(MarketDataManager, "_candle_clock_flush_hardening_installed", False)
+        is True
+    )
+    assert (
+        getattr(DataHub, "_active_basket_subscription_hardening_installed", False)
         is True
     )
     assert getattr(WebSocketManager, "_market_data_hardening_installed", False) is True
@@ -31,10 +36,15 @@ def test_production_app_import_is_idempotent() -> None:
     assert id(reloaded) == before["app"]
 
     from nifty_scalper_bot.data.candle_engine import CandleEngine
+    from nifty_scalper_bot.data.data_hub import DataHub
     from nifty_scalper_bot.data.market_data_manager import MarketDataManager
 
     assert getattr(CandleEngine, "_candle_state_hardening_installed", False) is True
     assert (
         getattr(MarketDataManager, "_candle_clock_flush_hardening_installed", False)
+        is True
+    )
+    assert (
+        getattr(DataHub, "_active_basket_subscription_hardening_installed", False)
         is True
     )

--- a/tests/core/test_strategy_setup_score_gate.py
+++ b/tests/core/test_strategy_setup_score_gate.py
@@ -8,6 +8,7 @@ from nifty_scalper_bot.core.strategy_setup_score_gate import (
     filter_context_promotions,
     setup_gate_result,
 )
+from nifty_scalper_bot.strategies.signal_generator import Signal
 
 
 def _vote(**metadata):
@@ -95,15 +96,38 @@ def test_malformed_orderflow_trigger_is_normalized_to_context() -> None:
         trigger_conditions_met=True,
     )
 
-    changed = enforce_context_only_role(signal, vote)
+    updated_signal, changed = enforce_context_only_role(signal, vote)
 
     assert changed is True
-    for metadata in (signal.metadata, vote.metadata):
+    for metadata in (updated_signal.metadata, vote.metadata):
         assert metadata["role"] == "context"
         assert metadata["can_trigger"] is False
         assert metadata["trigger_conditions_met"] is False
         assert metadata["trigger_eligible"] is False
         assert metadata["trigger_block_reason"] == "context_only_role"
+
+
+def test_frozen_signal_is_replaced_not_mutated() -> None:
+    signal = Signal(
+        action="BUY",
+        symbol="NFO:NIFTY2680424600PE",
+        quantity=65,
+        confidence=0.8,
+        reason="OrderFlow",
+        stop_loss=None,
+        take_profit=None,
+        metadata={"strategy": "OrderFlow", "role": "trigger"},
+    )
+    vote = _vote(strategy="OrderFlow", role="trigger", can_trigger=True)
+
+    updated_signal, changed = enforce_context_only_role(signal, vote)
+
+    assert changed is True
+    assert updated_signal is not signal
+    assert signal.metadata["role"] == "trigger"
+    assert updated_signal.metadata["role"] == "context"
+    assert updated_signal.metadata["can_trigger"] is False
+    assert vote.metadata["role"] == "context"
 
 
 def test_orderflow_is_removed_from_context_promotion_candidates() -> None:

--- a/tests/data/test_datahub_basket_subscription_hardening.py
+++ b/tests/data/test_datahub_basket_subscription_hardening.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from typing import Any
+
+from nifty_scalper_bot.data.data_hub import DataHub
+from nifty_scalper_bot.data.data_hub_subscription_hardening import (
+    install_data_hub_subscription_hardening,
+)
+
+
+class _FakeMDM:
+    def __init__(self) -> None:
+        self.subscriptions: list[tuple[str, Any]] = []
+        self.unsubscriptions: list[tuple[str, Any]] = []
+
+    def attach_tick_bus(self, _bus: Any) -> None:
+        return None
+
+    def subscribe(self, symbol: str, callback: Any) -> None:
+        self.subscriptions.append((symbol, callback))
+
+    def unsubscribe(self, symbol: str, callback: Any) -> None:
+        self.unsubscriptions.append((symbol, callback))
+
+
+def _basket(strike: int) -> dict[str, Any]:
+    ce = f"NFO:NIFTY26804{strike}CE"
+    pe = f"NFO:NIFTY26804{strike}PE"
+    symbols = ["NSE:NIFTY", "NFO:NIFTY26AUGFUT", ce, pe]
+    return {
+        "all_symbols": symbols,
+        "option_symbols": [ce, pe],
+        "spot_symbol": "NSE:NIFTY",
+        "futures_symbol": "NFO:NIFTY26AUGFUT",
+        "selected_ce": ce,
+        "selected_pe": pe,
+        "token_by_symbol": {symbol: index + 1 for index, symbol in enumerate(symbols)},
+    }
+
+
+def test_live_basket_rotation_registers_new_direct_mdm_ingress_once() -> None:
+    install_data_hub_subscription_hardening(DataHub)
+    mdm = _FakeMDM()
+    hub = DataHub(mdm, defer_live_symbol_subscriptions=False)
+    try:
+        first = _basket(24600)
+        second = _basket(24650)
+
+        hub.set_active_contract_basket(first)
+        hub.set_active_contract_basket(second)
+        hub.set_active_contract_basket(second)
+
+        symbols = [symbol for symbol, _callback in mdm.subscriptions]
+        assert symbols.count(first["selected_ce"]) == 1
+        assert symbols.count(first["selected_pe"]) == 1
+        assert symbols.count(second["selected_ce"]) == 1
+        assert symbols.count(second["selected_pe"]) == 1
+        assert symbols.count("NSE:NIFTY") == 1
+        assert symbols.count("NFO:NIFTY26AUGFUT") == 1
+        assert all(callback == hub.ingest_tick_sync for _symbol, callback in mdm.subscriptions)
+    finally:
+        hub.close()
+
+
+def test_startup_basket_remains_deferred_until_explicit_flush() -> None:
+    install_data_hub_subscription_hardening(DataHub)
+    mdm = _FakeMDM()
+    hub = DataHub(mdm, defer_live_symbol_subscriptions=True)
+    try:
+        basket = _basket(24600)
+
+        hub.set_active_contract_basket(basket)
+
+        assert mdm.subscriptions == []
+        assert set(basket["all_symbols"]).issubset(hub._pending_live_symbols)
+
+        flushed = hub.flush_pending_live_subscriptions()
+
+        assert flushed == len(set(basket["all_symbols"]))
+        assert {symbol for symbol, _callback in mdm.subscriptions} == set(
+            basket["all_symbols"]
+        )
+    finally:
+        hub.close()
+
+
+def test_installer_is_idempotent() -> None:
+    install_data_hub_subscription_hardening(DataHub)
+    wrapped = DataHub.set_active_contract_basket
+
+    install_data_hub_subscription_hardening(DataHub)
+
+    assert DataHub.set_active_contract_basket is wrapped


### PR DESCRIPTION
## Confirmed production failures

1. `Signal` is a frozen dataclass, but the OrderFlow context-only gate assigned `signal.metadata = ...`. Every phase-9 evaluation therefore failed with `FrozenInstanceError`, including valid VWAPPro setups.
2. `DataHub.set_active_contract_basket()` refreshed basket/token aliases but did not establish DataHub's direct MDM ingress for newly rotated contracts. A rotated selected option could receive MDM ticks with no direct subscriber while the MessageBus fallback was unavailable.

## Focused corrections

- Return an immutable `Signal.with_metadata(...)` replacement from the context-only gate and pass that replacement into the existing combiner.
- Keep OrderFlow permanently context-only without mutating frozen signals.
- Install a narrow, idempotent DataHub basket-subscription hook:
  - startup subscriptions remain deferred until the existing flush;
  - runtime basket rotations subscribe newly active symbols immediately;
  - existing `_mdm_subscribed_symbols` prevents duplicate callbacks.
- Preserve the established direct-MDM-only DataHub ingress and all strategy/execution logic.

## TDD

- Real frozen `Signal` is replaced, not mutated.
- OrderFlow trigger metadata is normalized to context.
- OrderFlow remains excluded from promotion.
- Basket rotation `24600 -> 24650` attaches each direct MDM ingress exactly once.
- Startup basket remains deferred and flushes through the existing path.
- Production app import installs the DataHub hardening idempotently.

No changes to strategy scores, thresholds, sizing, stop-loss/target geometry, broker placement, bracket protection, or tick-drain scheduling.