### PR TITLE
fix(startup): restore readiness ownership and direct tick replay

### DIFF
--- a/src/nifty_scalper_bot/core/boot_readiness_safety.py
+++ b/src/nifty_scalper_bot/core/boot_readiness_safety.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from functools import wraps
 import logging
 from typing import Any, Awaitable, Callable, TypeVar
@@ -33,24 +34,55 @@ def adapt_compute_live_readiness(
 def adapt_replay_latest_mdm_ticks_to_bus(
     original: Callable[..., Awaitable[int]],
 ) -> Callable[..., Awaitable[int]]:
-    """Skip cached-tick replay when the optional MessageBus is inactive."""
+    """Replay cached ticks through the active authoritative ingress."""
 
     @wraps(original)
     async def wrapped(ctx: Any, *, reason: str) -> int:
+        if bool(getattr(ctx, "data_observation_ready", False)):
+            return int(await original(ctx, reason=reason))
+
         bus = getattr(ctx, "message_bus", None)
-        if bus is None or not bool(getattr(bus, "running", False)):
+        if bus is not None and bool(getattr(bus, "running", False)):
+            return int(await original(ctx, reason=reason))
+
+        mdm = getattr(ctx, "market_data_manager", None)
+        hub = getattr(ctx, "data_hub", None)
+        ingest = getattr(hub, "ingest_tick_sync", None)
+        latest_ticks = getattr(mdm, "_latest_ticks", {}) if mdm is not None else {}
+        if callable(ingest) and isinstance(latest_ticks, Mapping):
+            replayed = 0
+            for symbol, tick in list(latest_ticks.items()):
+                if not isinstance(tick, Mapping):
+                    continue
+                payload = dict(tick)
+                payload["symbol"] = str(symbol)
+                payload["source"] = "mdm_replay"
+                ingest(payload)
+                replayed += 1
             _LOGGER.info(
-                "MDM_CACHED_TICKS_REPLAY_SKIPPED "
-                "reason=message_bus_not_running requested_reason=%s",
+                "MDM_CACHED_TICKS_REPLAYED count=%d reason=%s path=direct_datahub",
+                replayed,
                 reason,
                 extra={
-                    "event": "MDM_CACHED_TICKS_REPLAY_SKIPPED",
-                    "reason": "message_bus_not_running",
-                    "requested_reason": reason,
+                    "event": "MDM_CACHED_TICKS_REPLAYED",
+                    "count": replayed,
+                    "reason": reason,
+                    "path": "direct_datahub",
                 },
             )
-            return 0
-        return int(await original(ctx, reason=reason))
+            return replayed
+
+        _LOGGER.info(
+            "MDM_CACHED_TICKS_REPLAY_SKIPPED "
+            "reason=message_bus_not_running requested_reason=%s",
+            reason,
+            extra={
+                "event": "MDM_CACHED_TICKS_REPLAY_SKIPPED",
+                "reason": "message_bus_not_running",
+                "requested_reason": reason,
+            },
+        )
+        return 0
 
     return wrapped
 

--- a/src/nifty_scalper_bot/core/boot_readiness_safety.py
+++ b/src/nifty_scalper_bot/core/boot_readiness_safety.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Mapping
 from functools import wraps
-import logging
 from typing import Any, Awaitable, Callable, TypeVar
 
 _LOGGER = logging.getLogger("nifty_scalper_bot.core.app")
@@ -116,12 +116,20 @@ class _DeferredDataHubView:
 class _WiringContextView:
     """Read-through context with startup-safe runner/DataHub views."""
 
-    def __init__(self, ctx: Any, *, defer_datahub: bool) -> None:
+    def __init__(
+        self,
+        ctx: Any,
+        *,
+        defer_datahub: bool,
+        withhold_runner_activation: bool,
+    ) -> None:
         self._ctx = ctx
         runner = getattr(ctx, "strategy_runner", None)
         hub = getattr(ctx, "data_hub", None)
         self.strategy_runner = (
-            _RunnerWiringView(runner) if runner is not None else None
+            _RunnerWiringView(runner)
+            if withhold_runner_activation and runner is not None
+            else runner
         )
         self.data_hub = (
             _DeferredDataHubView(hub) if defer_datahub and hub is not None else hub
@@ -144,9 +152,11 @@ def adapt_register_and_subscribe_live_symbol(
         reason: str,
         role: str = "tradable_option",
     ) -> bool:
+        startup_wiring = reason == "basket_commit_live_startup"
         view = _WiringContextView(
             ctx,
-            defer_datahub=reason == "basket_commit_live_startup",
+            defer_datahub=startup_wiring,
+            withhold_runner_activation=startup_wiring,
         )
         return bool(original(view, symbol, token, reason, role))
 

--- a/src/nifty_scalper_bot/core/boot_readiness_safety.py
+++ b/src/nifty_scalper_bot/core/boot_readiness_safety.py
@@ -1,13 +1,21 @@
-"""Session readiness adapter for startup diagnostics."""
+"""Session readiness and startup-orchestration adapters."""
 
 from __future__ import annotations
 
-from typing import Any, Callable
+from functools import wraps
+import logging
+from typing import Any, Awaitable, Callable, TypeVar
+
+_LOGGER = logging.getLogger("nifty_scalper_bot.core.app")
+_T = TypeVar("_T")
 
 
-def adapt_compute_live_readiness(original: Callable[..., tuple[bool, list[str]]]) -> Callable[..., tuple[bool, list[str]]]:
+def adapt_compute_live_readiness(
+    original: Callable[..., tuple[bool, list[str]]],
+) -> Callable[..., tuple[bool, list[str]]]:
     """Return an adapter that keeps option quote checks quiet outside session."""
 
+    @wraps(original)
     def wrapped(**kwargs: Any) -> tuple[bool, list[str]]:
         if bool(kwargs.get("live_mode")) and not bool(kwargs.get("market_open")):
             min_bars = int(kwargs.get("option_exec_min_bars") or 1)
@@ -22,15 +30,203 @@ def adapt_compute_live_readiness(original: Callable[..., tuple[bool, list[str]]]
     return wrapped
 
 
-def apply_app_patch(app_module: Any) -> None:
-    """Install the adapter on a loaded app module."""
+def adapt_replay_latest_mdm_ticks_to_bus(
+    original: Callable[..., Awaitable[int]],
+) -> Callable[..., Awaitable[int]]:
+    """Skip cached-tick replay when the optional MessageBus is inactive."""
 
-    current = getattr(app_module, "compute_live_readiness", None)
-    if not callable(current) or getattr(current, "_session_readiness_adapted", False):
+    @wraps(original)
+    async def wrapped(ctx: Any, *, reason: str) -> int:
+        bus = getattr(ctx, "message_bus", None)
+        if bus is None or not bool(getattr(bus, "running", False)):
+            _LOGGER.info(
+                "MDM_CACHED_TICKS_REPLAY_SKIPPED "
+                "reason=message_bus_not_running requested_reason=%s",
+                reason,
+                extra={
+                    "event": "MDM_CACHED_TICKS_REPLAY_SKIPPED",
+                    "reason": "message_bus_not_running",
+                    "requested_reason": reason,
+                },
+            )
+            return 0
+        return int(await original(ctx, reason=reason))
+
+    return wrapped
+
+
+class _RunnerWiringView:
+    """Expose runner callbacks while withholding activation authority."""
+
+    def __init__(self, runner: Any) -> None:
+        self._runner = runner
+
+    def __getattr__(self, name: str) -> Any:
+        if name == "add_symbol":
+            raise AttributeError(name)
+        return getattr(self._runner, name)
+
+
+class _DeferredDataHubView:
+    """Keep startup subscriptions deferred until the canonical readiness flush."""
+
+    def __init__(self, hub: Any) -> None:
+        self._hub = hub
+
+    def subscribe_ticks(self, *args: Any, **kwargs: Any) -> Any:
+        kwargs["force_live"] = False
+        return self._hub.subscribe_ticks(*args, **kwargs)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._hub, name)
+
+
+class _WiringContextView:
+    """Read-through context with startup-safe runner/DataHub views."""
+
+    def __init__(self, ctx: Any, *, defer_datahub: bool) -> None:
+        self._ctx = ctx
+        runner = getattr(ctx, "strategy_runner", None)
+        hub = getattr(ctx, "data_hub", None)
+        self.strategy_runner = (
+            _RunnerWiringView(runner) if runner is not None else None
+        )
+        self.data_hub = (
+            _DeferredDataHubView(hub) if defer_datahub and hub is not None else hub
+        )
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._ctx, name)
+
+
+def adapt_register_and_subscribe_live_symbol(
+    original: Callable[..., bool],
+) -> Callable[..., bool]:
+    """Wire market data without bypassing the canonical runner-readiness gate."""
+
+    @wraps(original)
+    def wrapped(
+        ctx: Any,
+        symbol: str | None,
+        token: int | None,
+        reason: str,
+        role: str = "tradable_option",
+    ) -> bool:
+        view = _WiringContextView(
+            ctx,
+            defer_datahub=reason == "basket_commit_live_startup",
+        )
+        return bool(original(view, symbol, token, reason, role))
+
+    return wrapped
+
+
+def adapt_wire_and_start_message_bus(
+    original: Callable[..., bool],
+) -> Callable[..., bool]:
+    """Detach an inactive, subscriber-less bus from direct MDM tick ingress."""
+
+    @wraps(original)
+    def wrapped(ctx: Any) -> bool:
+        started = bool(original(ctx))
+        bus = getattr(ctx, "message_bus", None)
+        mdm = getattr(ctx, "market_data_manager", None)
+        subscribers = getattr(bus, "subscribers", {}) if bus is not None else {}
+        has_subscribers = bool(
+            isinstance(subscribers, dict)
+            and any(bool(items) for items in subscribers.values())
+        )
+        if not started and not has_subscribers and mdm is not None:
+            if getattr(mdm, "bus", None) is bus:
+                mdm.bus = None
+        return started
+
+    return wrapped
+
+
+def adapt_sync_history_from_mdm(original: Callable[..., _T]) -> Callable[..., _T]:
+    """Correct unambiguous spot/futures history-role mismatches at the SSOT."""
+
+    @wraps(original)
+    def wrapped(self: Any, symbol: str, *args: Any, **kwargs: Any) -> _T:
+        normalized = str(symbol or "").strip().upper().replace(" ", "")
+        role = str(kwargs.get("role") or "").strip().lower()
+        if normalized.endswith("FUT") and role != "futures_context":
+            kwargs["role"] = "futures_context"
+        elif (
+            normalized in {"NIFTY", "NIFTY50", "NSE:NIFTY", "NSE:NIFTY50"}
+            and role != "spot_context"
+        ):
+            kwargs["role"] = "spot_context"
+        return original(self, symbol, *args, **kwargs)
+
+    return wrapped
+
+
+def _patch_function(
+    target: Any,
+    name: str,
+    adapter: Callable[[Any], Any],
+    marker: str,
+) -> None:
+    current = getattr(target, name, None)
+    if not callable(current) or bool(getattr(current, marker, False)):
         return
-    wrapped = adapt_compute_live_readiness(current)
-    setattr(wrapped, "_session_readiness_adapted", True)
-    setattr(app_module, "compute_live_readiness", wrapped)
+    wrapped = adapter(current)
+    setattr(wrapped, marker, True)
+    setattr(target, name, wrapped)
 
 
-__all__ = ["adapt_compute_live_readiness", "apply_app_patch"]
+def apply_app_patch(app_module: Any) -> None:
+    """Install startup/readiness adapters on a loaded app module."""
+
+    _patch_function(
+        app_module,
+        "compute_live_readiness",
+        adapt_compute_live_readiness,
+        "_session_readiness_adapted",
+    )
+    _patch_function(
+        app_module,
+        "_replay_latest_mdm_ticks_to_bus",
+        adapt_replay_latest_mdm_ticks_to_bus,
+        "_inactive_bus_replay_guarded",
+    )
+    _patch_function(
+        app_module,
+        "_register_and_subscribe_live_symbol",
+        adapt_register_and_subscribe_live_symbol,
+        "_runner_activation_gated",
+    )
+    _patch_function(
+        app_module,
+        "_wire_and_start_message_bus",
+        adapt_wire_and_start_message_bus,
+        "_direct_mdm_bus_detach_adapted",
+    )
+
+    runner_cls = getattr(app_module, "StrategyRunner", None)
+    if runner_cls is None:
+        try:
+            from nifty_scalper_bot.strategies.runner import StrategyRunner
+
+            runner_cls = StrategyRunner
+        except Exception:  # noqa: BLE001 - optional import compatibility
+            runner_cls = None
+    if runner_cls is not None:
+        _patch_function(
+            runner_cls,
+            "sync_history_from_mdm",
+            adapt_sync_history_from_mdm,
+            "_history_role_corrected",
+        )
+
+
+__all__ = [
+    "adapt_compute_live_readiness",
+    "adapt_register_and_subscribe_live_symbol",
+    "adapt_replay_latest_mdm_ticks_to_bus",
+    "adapt_sync_history_from_mdm",
+    "adapt_wire_and_start_message_bus",
+    "apply_app_patch",
+]

--- a/tests/core/test_boot_log_safety.py
+++ b/tests/core/test_boot_log_safety.py
@@ -1,9 +1,17 @@
 from __future__ import annotations
 
+import asyncio
 import logging
+from types import SimpleNamespace
 
 from nifty_scalper_bot.core.boot_log_safety import BootLogRateControl
-from nifty_scalper_bot.core.boot_readiness_safety import adapt_compute_live_readiness
+from nifty_scalper_bot.core.boot_readiness_safety import (
+    adapt_compute_live_readiness,
+    adapt_register_and_subscribe_live_symbol,
+    adapt_replay_latest_mdm_ticks_to_bus,
+    adapt_sync_history_from_mdm,
+    adapt_wire_and_start_message_bus,
+)
 from nifty_scalper_bot.execution.readiness import normalize_readiness_blockers
 
 
@@ -25,9 +33,24 @@ def _record(event: str, **extra):
 
 def test_rate_control_allows_changed_basket_state() -> None:
     control = BootLogRateControl(interval_seconds=30.0)
-    first = _record("CONTRACT_SSOT_BASKET_SELECTED", selected_ce="CE1", selected_pe="PE1", atm_strike=24250)
-    same = _record("CONTRACT_SSOT_BASKET_SELECTED", selected_ce="CE1", selected_pe="PE1", atm_strike=24250)
-    changed = _record("CONTRACT_SSOT_BASKET_SELECTED", selected_ce="CE2", selected_pe="PE2", atm_strike=24300)
+    first = _record(
+        "CONTRACT_SSOT_BASKET_SELECTED",
+        selected_ce="CE1",
+        selected_pe="PE1",
+        atm_strike=24250,
+    )
+    same = _record(
+        "CONTRACT_SSOT_BASKET_SELECTED",
+        selected_ce="CE1",
+        selected_pe="PE1",
+        atm_strike=24250,
+    )
+    changed = _record(
+        "CONTRACT_SSOT_BASKET_SELECTED",
+        selected_ce="CE2",
+        selected_pe="PE2",
+        atm_strike=24300,
+    )
 
     assert control.filter(first) is True
     assert control.filter(same) is False
@@ -36,8 +59,18 @@ def test_rate_control_allows_changed_basket_state() -> None:
 
 def test_rate_control_covers_bootstrap_state() -> None:
     control = BootLogRateControl(interval_seconds=30.0)
-    first = _record("LIVE_UNIVERSE_BOOTSTRAP_STATUS", symbol="NSE:NIFTY", ready=False, reason="waiting")
-    same = _record("LIVE_UNIVERSE_BOOTSTRAP_STATUS", symbol="NSE:NIFTY", ready=False, reason="waiting")
+    first = _record(
+        "LIVE_UNIVERSE_BOOTSTRAP_STATUS",
+        symbol="NSE:NIFTY",
+        ready=False,
+        reason="waiting",
+    )
+    same = _record(
+        "LIVE_UNIVERSE_BOOTSTRAP_STATUS",
+        symbol="NSE:NIFTY",
+        ready=False,
+        reason="waiting",
+    )
 
     assert control.filter(first) is True
     assert control.filter(same) is False
@@ -116,7 +149,11 @@ def test_live_validation_checklist_log_contains_primary_gate(caplog) -> None:
         execution_ready=False,
     )
 
-    record = next(r for r in caplog.records if getattr(r, "event", "") == "LIVE_VALIDATION_CHECKLIST")
+    record = next(
+        r
+        for r in caplog.records
+        if getattr(r, "event", "") == "LIVE_VALIDATION_CHECKLIST"
+    )
     assert decision.primary_blocker == "selected_option_quote_missing"
     assert record.primary_blocker == "selected_option_quote_missing"
     assert record.evaluation_ready is True
@@ -151,3 +188,190 @@ def test_session_readiness_adapter_removes_option_details_outside_session() -> N
     )
 
     assert reasons == ["market_closed"]
+
+
+def test_cached_tick_replay_skips_when_message_bus_is_inactive() -> None:
+    calls: list[str] = []
+
+    async def original(ctx, *, reason: str) -> int:
+        calls.append(reason)
+        return 10
+
+    adapted = adapt_replay_latest_mdm_ticks_to_bus(original)
+    ctx = SimpleNamespace(message_bus=SimpleNamespace(running=False))
+
+    assert asyncio.run(adapted(ctx, reason="post_runner_start")) == 0
+    assert calls == []
+
+
+def test_cached_tick_replay_preserved_when_message_bus_is_running() -> None:
+    calls: list[str] = []
+
+    async def original(ctx, *, reason: str) -> int:
+        calls.append(reason)
+        return 3
+
+    adapted = adapt_replay_latest_mdm_ticks_to_bus(original)
+    ctx = SimpleNamespace(message_bus=SimpleNamespace(running=True))
+
+    assert asyncio.run(adapted(ctx, reason="post_runner_start")) == 3
+    assert calls == ["post_runner_start"]
+
+
+def test_startup_symbol_wiring_does_not_activate_runner_early() -> None:
+    class Runner:
+        def __init__(self) -> None:
+            self.added: list[str] = []
+
+        def add_symbol(self, symbol: str) -> None:
+            self.added.append(symbol)
+
+        def on_datahub_tick(self, tick) -> None:
+            del tick
+
+    class Hub:
+        def __init__(self) -> None:
+            self.calls: list[dict] = []
+
+        def subscribe_ticks(self, symbol, callback, **kwargs):
+            self.calls.append(
+                {
+                    "symbol": symbol,
+                    "callback": callback,
+                    **kwargs,
+                }
+            )
+            return True
+
+    def original(ctx, symbol, token, reason, role="tradable_option") -> bool:
+        del reason, role
+        if hasattr(ctx.strategy_runner, "add_symbol"):
+            ctx.strategy_runner.add_symbol(symbol)
+        ctx.data_hub.subscribe_ticks(
+            symbol,
+            ctx.strategy_runner.on_datahub_tick,
+            token=token,
+            force_live=True,
+        )
+        return True
+
+    runner = Runner()
+    hub = Hub()
+    ctx = SimpleNamespace(strategy_runner=runner, data_hub=hub)
+    adapted = adapt_register_and_subscribe_live_symbol(original)
+
+    assert (
+        adapted(
+            ctx,
+            "NFO:NIFTY2680424750CE",
+            16868098,
+            "basket_commit_live_startup",
+        )
+        is True
+    )
+    assert runner.added == []
+    assert hub.calls[0]["force_live"] is False
+
+
+def test_runtime_symbol_wiring_keeps_immediate_data_subscription() -> None:
+    class Runner:
+        def add_symbol(self, symbol: str) -> None:
+            raise AssertionError(f"unexpected activation: {symbol}")
+
+        def on_datahub_tick(self, tick) -> None:
+            del tick
+
+    class Hub:
+        def __init__(self) -> None:
+            self.force_live: bool | None = None
+
+        def subscribe_ticks(self, symbol, callback, **kwargs):
+            del symbol, callback
+            self.force_live = bool(kwargs["force_live"])
+            return True
+
+    def original(ctx, symbol, token, reason, role="tradable_option") -> bool:
+        del reason, role
+        if hasattr(ctx.strategy_runner, "add_symbol"):
+            ctx.strategy_runner.add_symbol(symbol)
+        ctx.data_hub.subscribe_ticks(
+            symbol,
+            ctx.strategy_runner.on_datahub_tick,
+            token=token,
+            force_live=True,
+        )
+        return True
+
+    runner = Runner()
+    hub = Hub()
+    ctx = SimpleNamespace(strategy_runner=runner, data_hub=hub)
+    adapted = adapt_register_and_subscribe_live_symbol(original)
+
+    assert adapted(ctx, "NFO:NIFTY2680424800PE", 16869634, "runtime_rotation")
+    assert hub.force_live is True
+
+
+def test_inactive_subscriberless_bus_is_detached_from_direct_mdm() -> None:
+    bus = SimpleNamespace(
+        running=False,
+        subscribers={"tick": [], "signal": []},
+    )
+    mdm = SimpleNamespace(bus=bus)
+    ctx = SimpleNamespace(message_bus=bus, market_data_manager=mdm)
+
+    def original(input_ctx) -> bool:
+        assert input_ctx is ctx
+        return False
+
+    adapted = adapt_wire_and_start_message_bus(original)
+
+    assert adapted(ctx) is False
+    assert mdm.bus is None
+
+
+def test_message_bus_attachment_is_preserved_for_real_subscribers() -> None:
+    bus = SimpleNamespace(
+        running=False,
+        subscribers={"tick": [object()]},
+    )
+    mdm = SimpleNamespace(bus=bus)
+    ctx = SimpleNamespace(message_bus=bus, market_data_manager=mdm)
+
+    adapted = adapt_wire_and_start_message_bus(lambda _ctx: False)
+
+    assert adapted(ctx) is False
+    assert mdm.bus is bus
+
+
+def test_history_sync_adapter_corrects_futures_role_only() -> None:
+    calls: list[tuple[str, str]] = []
+
+    def original(self, symbol: str, *args, **kwargs):
+        del self, args
+        calls.append((symbol, kwargs["role"]))
+        return kwargs["role"]
+
+    adapted = adapt_sync_history_from_mdm(original)
+
+    assert (
+        adapted(
+            object(),
+            "NFO:NIFTY26AUGFUT",
+            required_bars=20,
+            role="spot_context",
+        )
+        == "futures_context"
+    )
+    assert (
+        adapted(
+            object(),
+            "NFO:NIFTY2680424750CE",
+            required_bars=20,
+            role="selected_option",
+        )
+        == "selected_option"
+    )
+    assert calls == [
+        ("NFO:NIFTY26AUGFUT", "futures_context"),
+        ("NFO:NIFTY2680424750CE", "selected_option"),
+    ]

--- a/tests/core/test_boot_log_safety.py
+++ b/tests/core/test_boot_log_safety.py
@@ -204,6 +204,35 @@ def test_cached_tick_replay_skips_when_message_bus_is_inactive() -> None:
     assert calls == []
 
 
+def test_cached_tick_replay_uses_direct_datahub_when_bus_is_inactive() -> None:
+    replayed: list[dict] = []
+
+    async def original(ctx, *, reason: str) -> int:
+        raise AssertionError(f"unexpected bus replay: {reason}")
+
+    adapted = adapt_replay_latest_mdm_ticks_to_bus(original)
+    ctx = SimpleNamespace(
+        message_bus=SimpleNamespace(running=False),
+        market_data_manager=SimpleNamespace(
+            _latest_ticks={
+                "NSE:NIFTY": {"last_price": 24775.0},
+                "NFO:NIFTY26AUGFUT": {"last_price": 24665.0},
+            }
+        ),
+        data_hub=SimpleNamespace(
+            ingest_tick_sync=lambda tick: replayed.append(dict(tick))
+        ),
+        data_observation_ready=False,
+    )
+
+    assert asyncio.run(adapted(ctx, reason="post_runner_start")) == 2
+    assert [tick["symbol"] for tick in replayed] == [
+        "NSE:NIFTY",
+        "NFO:NIFTY26AUGFUT",
+    ]
+    assert all(tick["source"] == "mdm_replay" for tick in replayed)
+
+
 def test_cached_tick_replay_preserved_when_message_bus_is_running() -> None:
     calls: list[str] = []
 

--- a/tests/core/test_boot_log_safety.py
+++ b/tests/core/test_boot_log_safety.py
@@ -302,10 +302,13 @@ def test_startup_symbol_wiring_does_not_activate_runner_early() -> None:
     assert hub.calls[0]["force_live"] is False
 
 
-def test_runtime_symbol_wiring_keeps_immediate_data_subscription() -> None:
+def test_runtime_symbol_wiring_preserves_activation_and_live_subscription() -> None:
     class Runner:
+        def __init__(self) -> None:
+            self.added: list[str] = []
+
         def add_symbol(self, symbol: str) -> None:
-            raise AssertionError(f"unexpected activation: {symbol}")
+            self.added.append(symbol)
 
         def on_datahub_tick(self, tick) -> None:
             del tick
@@ -337,6 +340,7 @@ def test_runtime_symbol_wiring_keeps_immediate_data_subscription() -> None:
     adapted = adapt_register_and_subscribe_live_symbol(original)
 
     assert adapted(ctx, "NFO:NIFTY2680424800PE", 16869634, "runtime_rotation")
+    assert runner.added == ["NFO:NIFTY2680424800PE"]
     assert hub.force_live is True
 
 


### PR DESCRIPTION
## Root causes fixed

- Prevent cached MDM replay from publishing into a stopped, subscriber-less MessageBus.
- Replay cached startup ticks through the authoritative direct DataHub ingress when the bus is intentionally inactive.
- Prevent `_register_and_subscribe_live_symbol` from bypassing the canonical runner hydration/readiness gate.
- Keep initial DataHub subscriptions deferred until the existing readiness flush, reducing synchronous startup work and tick backlog.
- Detach the optional MessageBus from MDM when it has no subscribers, eliminating false bus-publication warnings while preserving future real subscribers.
- Correct unambiguous NIFTY futures history-role misclassification from `spot_context` to `futures_context`.

## Scope

No signal scoring, thresholds, order sizing, entry/exit logic, bracket protection, risk controls, or runtime rotation immediacy were changed.

## Tests

Focused regression coverage for inactive/active bus replay, direct DataHub replay, startup runner activation ownership, startup-vs-runtime subscription behavior, optional bus detachment, and futures role correction.