### PR TITLE
fix(execution): preserve premium risk geometry and TP1 lifecycle

### DIFF
--- a/src/nifty_scalper_bot/core/__init__.py
+++ b/src/nifty_scalper_bot/core/__init__.py
@@ -25,12 +25,18 @@ def _core_env_true(name: str) -> bool:
 def _real_live_mode_requested() -> bool:
     mode = str(os.getenv("EXECUTION_MODE", "SHADOW") or "SHADOW").strip().upper()
     live_enabled = _core_env_true("ENABLE_LIVE") or _core_env_true("ENABLE_LIVE_TRADING")
-    paper_shadow = _core_env_true("PAPER_MODE") or _core_env_true("PAPER__ENABLED") or _core_env_true("SHADOW_MODE")
+    paper_shadow = (
+        _core_env_true("PAPER_MODE")
+        or _core_env_true("PAPER__ENABLED")
+        or _core_env_true("SHADOW_MODE")
+    )
     return mode == "LIVE" and live_enabled and not paper_shadow
 
 
 try:
-    from nifty_scalper_bot.core.strategy_live_safety import apply_patches as _apply_strategy_live_safety
+    from nifty_scalper_bot.core.strategy_live_safety import (
+        apply_patches as _apply_strategy_live_safety,
+    )
 
     _apply_strategy_live_safety()
 except Exception as exc:  # noqa: BLE001 - non-live tooling imports should remain usable
@@ -43,18 +49,25 @@ except Exception as exc:  # noqa: BLE001 - non-live tooling imports should remai
         raise RuntimeError("strategy_live_safety_patch_failed") from exc
 
 try:
-    from nifty_scalper_bot.core.strategy_exit_score_diagnostics import apply_patches as _apply_strategy_exit_score_diagnostics
+    from nifty_scalper_bot.core.strategy_exit_score_diagnostics import (
+        apply_patches as _apply_strategy_exit_score_diagnostics,
+    )
 
     _apply_strategy_exit_score_diagnostics()
 except Exception as exc:  # noqa: BLE001 - diagnostics must not disable tooling imports
     get_logger(__name__).error(
         "STRATEGY_EXIT_SCORE_DIAGNOSTIC_PATCH_FAILED error=%s",
         exc,
-        extra={"event": "STRATEGY_EXIT_SCORE_DIAGNOSTIC_PATCH_FAILED", "error_type": type(exc).__name__},
+        extra={
+            "event": "STRATEGY_EXIT_SCORE_DIAGNOSTIC_PATCH_FAILED",
+            "error_type": type(exc).__name__,
+        },
     )
 
 try:
-    from nifty_scalper_bot.core.strategy_setup_score_gate import apply_patches as _apply_strategy_setup_score_gate
+    from nifty_scalper_bot.core.strategy_setup_score_gate import (
+        apply_patches as _apply_strategy_setup_score_gate,
+    )
 
     _apply_strategy_setup_score_gate()
 except Exception as exc:  # noqa: BLE001 - non-live tooling imports should remain usable
@@ -67,7 +80,9 @@ except Exception as exc:  # noqa: BLE001 - non-live tooling imports should remai
         raise RuntimeError("strategy_setup_score_gate_patch_failed") from exc
 
 try:
-    from nifty_scalper_bot.core.boot_log_safety import apply_filters as _apply_boot_log_rate_controls
+    from nifty_scalper_bot.core.boot_log_safety import (
+        apply_filters as _apply_boot_log_rate_controls,
+    )
 
     _apply_boot_log_rate_controls()
 except Exception as exc:  # noqa: BLE001 - core package import must not crash tooling
@@ -116,10 +131,39 @@ def _install_market_data_runtime_hardening() -> dict[str, bool]:
     return state
 
 
+def _install_premium_geometry_runtime_hardening() -> None:
+    """Install option-premium geometry ownership after StrategyRunner imports."""
+
+    try:
+        from nifty_scalper_bot.execution.premium_risk_contract_patch import (
+            install_runner_geometry_hardening,
+        )
+        from nifty_scalper_bot.strategies.runner import StrategyRunner
+
+        install_runner_geometry_hardening(StrategyRunner)
+        _LOGGER.info(
+            "PREMIUM_GEOMETRY_HARDENING_INSTALLED",
+            extra={"event": "PREMIUM_GEOMETRY_HARDENING_INSTALLED"},
+        )
+    except Exception as exc:  # noqa: BLE001
+        _LOGGER.error(
+            "PREMIUM_GEOMETRY_HARDENING_FAILED error=%s",
+            exc,
+            exc_info=True,
+            extra={
+                "event": "PREMIUM_GEOMETRY_HARDENING_FAILED",
+                "error_type": type(exc).__name__,
+            },
+        )
+        if _real_live_mode_requested():
+            raise RuntimeError("premium_geometry_hardening_failed") from exc
+
+
 def _apply_app_runtime_patches(app_module: Any) -> None:
     # The production app import is the single authoritative installation point.
     # Do not require tests or callers to invoke market-data hardening manually.
     _install_market_data_runtime_hardening()
+    _install_premium_geometry_runtime_hardening()
 
     from nifty_scalper_bot.core.boot_readiness_safety import apply_app_patch as _ready_adapter
     from nifty_scalper_bot.core.polling_failover_runtime import apply_app_patch as _polling_adapter

--- a/src/nifty_scalper_bot/core/__init__.py
+++ b/src/nifty_scalper_bot/core/__init__.py
@@ -132,15 +132,18 @@ def _install_market_data_runtime_hardening() -> dict[str, bool]:
 
 
 def _install_premium_geometry_runtime_hardening() -> None:
-    """Install option-premium geometry ownership after StrategyRunner imports."""
+    """Install option-premium geometry ownership after runtime composition."""
 
     try:
+        from nifty_scalper_bot.execution.bracket_manager import BoundBracketManager
         from nifty_scalper_bot.execution.premium_risk_contract_patch import (
+            install_bracket_exit_provenance_hardening,
             install_runner_geometry_hardening,
         )
         from nifty_scalper_bot.strategies.runner import StrategyRunner
 
         install_runner_geometry_hardening(StrategyRunner)
+        install_bracket_exit_provenance_hardening(BoundBracketManager)
         _LOGGER.info(
             "PREMIUM_GEOMETRY_HARDENING_INSTALLED",
             extra={"event": "PREMIUM_GEOMETRY_HARDENING_INSTALLED"},

--- a/src/nifty_scalper_bot/execution/bracket_manager.py
+++ b/src/nifty_scalper_bot/execution/bracket_manager.py
@@ -12,6 +12,9 @@ Operational constraints:
 
 from __future__ import annotations
 
+from contextlib import suppress
+from typing import Any, Mapping
+
 from nifty_scalper_bot.execution import bracket_core as _core
 
 for _name in dir(_core):
@@ -54,6 +57,52 @@ _core.tick_exchange_epoch = _tick_exchange_epoch_with_receipt
 tick_exchange_epoch = _tick_exchange_epoch_with_receipt
 
 _original_confirm_entry_fill = BoundBracketManager.confirm_entry_fill
+_original_register_virtual_bracket = BoundBracketManager.register_virtual_bracket
+
+
+def _positive_number(value: Any) -> float | None:
+    with suppress(TypeError, ValueError):
+        parsed = float(value)
+        if parsed > 0.0:
+            return parsed
+    return None
+
+
+def _enrich_virtual_bracket_kwargs(kwargs: Mapping[str, Any]) -> dict[str, Any]:
+    """Restore optional TP1/trailing fields from durable trade provenance."""
+
+    enriched = dict(kwargs)
+    provenance = enriched.get("trade_provenance")
+    if not isinstance(provenance, Mapping):
+        return enriched
+    exit_plan = provenance.get("exit_plan")
+    source = dict(exit_plan) if isinstance(exit_plan, Mapping) else dict(provenance)
+
+    if _positive_number(enriched.get("tp1_price")) is None:
+        tp1_price = _positive_number(source.get("tp1_price"))
+        if tp1_price is not None:
+            enriched["tp1_price"] = tp1_price
+    if _positive_number(enriched.get("tp1_qty")) is None:
+        tp1_qty = _positive_number(source.get("tp1_qty"))
+        if tp1_qty is not None:
+            enriched["tp1_qty"] = int(tp1_qty)
+    if _positive_number(enriched.get("trailing_atr_mult")) is None:
+        trailing = _positive_number(source.get("trailing_atr_mult"))
+        if trailing is not None:
+            enriched["trailing_atr_mult"] = trailing
+    if _positive_number(enriched.get("resolved_lot_size")) is None:
+        lot_size = _positive_number(source.get("resolved_lot_size"))
+        if lot_size is not None:
+            enriched["resolved_lot_size"] = int(lot_size)
+    return enriched
+
+
+def _register_virtual_bracket_with_provenance(self, *args, **kwargs):
+    return _original_register_virtual_bracket(
+        self,
+        *args,
+        **_enrich_virtual_bracket_kwargs(kwargs),
+    )
 
 
 def _positive_filled_quantity(value):
@@ -166,6 +215,7 @@ def _confirm_entry_fill_once(self, order_id, fill_price, filled_qty=None):
     return _original_confirm_entry_fill(self, order_id, fill_price, filled_qty)
 
 
+BoundBracketManager.register_virtual_bracket = _register_virtual_bracket_with_provenance
 BoundBracketManager.confirm_entry_fill = _confirm_entry_fill_once
 BracketManager = BoundBracketManager
 
@@ -175,5 +225,6 @@ __all__ = sorted(
         "BoundBracketManager",
         "BracketManager",
         "RuntimeBracketManager",
+        "_enrich_virtual_bracket_kwargs",
     }
 )

--- a/src/nifty_scalper_bot/execution/bracket_manager.py
+++ b/src/nifty_scalper_bot/execution/bracket_manager.py
@@ -12,9 +12,6 @@ Operational constraints:
 
 from __future__ import annotations
 
-from contextlib import suppress
-from typing import Any, Mapping
-
 from nifty_scalper_bot.execution import bracket_core as _core
 
 for _name in dir(_core):
@@ -57,52 +54,6 @@ _core.tick_exchange_epoch = _tick_exchange_epoch_with_receipt
 tick_exchange_epoch = _tick_exchange_epoch_with_receipt
 
 _original_confirm_entry_fill = BoundBracketManager.confirm_entry_fill
-_original_register_virtual_bracket = BoundBracketManager.register_virtual_bracket
-
-
-def _positive_number(value: Any) -> float | None:
-    with suppress(TypeError, ValueError):
-        parsed = float(value)
-        if parsed > 0.0:
-            return parsed
-    return None
-
-
-def _enrich_virtual_bracket_kwargs(kwargs: Mapping[str, Any]) -> dict[str, Any]:
-    """Restore optional TP1/trailing fields from durable trade provenance."""
-
-    enriched = dict(kwargs)
-    provenance = enriched.get("trade_provenance")
-    if not isinstance(provenance, Mapping):
-        return enriched
-    exit_plan = provenance.get("exit_plan")
-    source = dict(exit_plan) if isinstance(exit_plan, Mapping) else dict(provenance)
-
-    if _positive_number(enriched.get("tp1_price")) is None:
-        tp1_price = _positive_number(source.get("tp1_price"))
-        if tp1_price is not None:
-            enriched["tp1_price"] = tp1_price
-    if _positive_number(enriched.get("tp1_qty")) is None:
-        tp1_qty = _positive_number(source.get("tp1_qty"))
-        if tp1_qty is not None:
-            enriched["tp1_qty"] = int(tp1_qty)
-    if _positive_number(enriched.get("trailing_atr_mult")) is None:
-        trailing = _positive_number(source.get("trailing_atr_mult"))
-        if trailing is not None:
-            enriched["trailing_atr_mult"] = trailing
-    if _positive_number(enriched.get("resolved_lot_size")) is None:
-        lot_size = _positive_number(source.get("resolved_lot_size"))
-        if lot_size is not None:
-            enriched["resolved_lot_size"] = int(lot_size)
-    return enriched
-
-
-def _register_virtual_bracket_with_provenance(self, *args, **kwargs):
-    return _original_register_virtual_bracket(
-        self,
-        *args,
-        **_enrich_virtual_bracket_kwargs(kwargs),
-    )
 
 
 def _positive_filled_quantity(value):
@@ -215,7 +166,6 @@ def _confirm_entry_fill_once(self, order_id, fill_price, filled_qty=None):
     return _original_confirm_entry_fill(self, order_id, fill_price, filled_qty)
 
 
-BoundBracketManager.register_virtual_bracket = _register_virtual_bracket_with_provenance
 BoundBracketManager.confirm_entry_fill = _confirm_entry_fill_once
 BracketManager = BoundBracketManager
 
@@ -225,6 +175,5 @@ __all__ = sorted(
         "BoundBracketManager",
         "BracketManager",
         "RuntimeBracketManager",
-        "_enrich_virtual_bracket_kwargs",
     }
 )

--- a/src/nifty_scalper_bot/execution/premium_risk_contract_patch.py
+++ b/src/nifty_scalper_bot/execution/premium_risk_contract_patch.py
@@ -3,8 +3,8 @@
 Elite strategies may publish explicit option-premium invalidation metadata.  The
 legacy runner normalisation must not widen those stops or replace their targets
 with an ATR from an ambiguous price domain.  This module keeps the existing
-StrategyManager output patch and installs a small, idempotent StrategyRunner
-geometry hardening hook after the application module is fully imported.
+StrategyManager output patch and installs small, idempotent runtime hooks after
+the application module is fully imported.
 """
 
 from __future__ import annotations
@@ -16,6 +16,7 @@ from typing import Any, Mapping
 _PATCH_APPLIED = False
 _ORIGINAL_GENERATE_SIGNAL: Any = None
 _RUNNER_PATCH_ATTR = "_premium_geometry_hardening_installed"
+_BRACKET_PATCH_ATTR = "_premium_exit_provenance_hardening_installed"
 _TICK_SIZE = 0.05
 
 
@@ -346,6 +347,49 @@ def anchor_option_geometry_to_execution(
     )
 
 
+def _enrich_virtual_bracket_kwargs(kwargs: Mapping[str, Any]) -> dict[str, Any]:
+    """Restore optional TP1/trailing fields from durable trade provenance."""
+
+    enriched = dict(kwargs)
+    provenance = enriched.get("trade_provenance")
+    if not isinstance(provenance, Mapping):
+        return enriched
+    exit_plan = provenance.get("exit_plan")
+    source = dict(exit_plan) if isinstance(exit_plan, Mapping) else dict(provenance)
+
+    if _positive_float(enriched.get("tp1_price")) is None:
+        tp1_price = _positive_float(source.get("tp1_price"))
+        if tp1_price is not None:
+            enriched["tp1_price"] = tp1_price
+    if _positive_float(enriched.get("tp1_qty")) is None:
+        tp1_qty = _positive_float(source.get("tp1_qty"))
+        if tp1_qty is not None:
+            enriched["tp1_qty"] = int(tp1_qty)
+    if _positive_float(enriched.get("trailing_atr_mult")) is None:
+        trailing = _positive_float(source.get("trailing_atr_mult"))
+        if trailing is not None:
+            enriched["trailing_atr_mult"] = trailing
+    if _positive_float(enriched.get("resolved_lot_size")) is None:
+        lot_size = _positive_float(source.get("resolved_lot_size"))
+        if lot_size is not None:
+            enriched["resolved_lot_size"] = int(lot_size)
+    return enriched
+
+
+def install_bracket_exit_provenance_hardening(bracket_cls: type[Any]) -> None:
+    """Wrap the fully composed bracket class without bypassing ownership guards."""
+    if bool(getattr(bracket_cls, _BRACKET_PATCH_ATTR, False)):
+        return
+    original = bracket_cls.register_virtual_bracket
+
+    def register_virtual_bracket(self: Any, *args: Any, **kwargs: Any) -> Any:
+        return original(self, *args, **_enrich_virtual_bracket_kwargs(kwargs))
+
+    bracket_cls._premium_exit_provenance_original_register = original
+    bracket_cls.register_virtual_bracket = register_virtual_bracket
+    setattr(bracket_cls, _BRACKET_PATCH_ATTR, True)
+
+
 def install_runner_geometry_hardening(runner_cls: type[Any]) -> None:
     """Install the domain-safe geometry methods on StrategyRunner once."""
     if bool(getattr(runner_cls, _RUNNER_PATCH_ATTR, False)):
@@ -384,9 +428,11 @@ def apply_patches() -> None:
 
 
 __all__ = [
+    "_enrich_virtual_bracket_kwargs",
     "anchor_option_geometry_to_execution",
     "apply_patches",
     "apply_premium_risk_contract",
+    "install_bracket_exit_provenance_hardening",
     "install_runner_geometry_hardening",
     "validate_option_premium_geometry",
 ]

--- a/src/nifty_scalper_bot/execution/premium_risk_contract_patch.py
+++ b/src/nifty_scalper_bot/execution/premium_risk_contract_patch.py
@@ -1,10 +1,10 @@
-"""Preserve strategy-declared option-premium risk geometry.
+"""Preserve option-premium risk geometry through the live execution boundary.
 
-Elite setup strategies publish ``premium_stop_distance`` in option-premium
-points. The runner's legacy premium helper only consumes ``premium_stop_pct``;
-therefore an otherwise valid absolute invalidation distance can disappear before
-TradePlan construction. Patch the StrategyManager output once, before runner
-normalisation, without changing strategies or bracket ownership.
+Elite strategies may publish explicit option-premium invalidation metadata.  The
+legacy runner normalisation must not widen those stops or replace their targets
+with an ATR from an ambiguous price domain.  This module keeps the existing
+StrategyManager output patch and installs a small, idempotent StrategyRunner
+geometry hardening hook after the application module is fully imported.
 """
 
 from __future__ import annotations
@@ -15,6 +15,8 @@ from typing import Any, Mapping
 
 _PATCH_APPLIED = False
 _ORIGINAL_GENERATE_SIGNAL: Any = None
+_RUNNER_PATCH_ATTR = "_premium_geometry_hardening_installed"
+_TICK_SIZE = 0.05
 
 
 def _positive_float(value: Any) -> float | None:
@@ -23,6 +25,116 @@ def _positive_float(value: Any) -> float | None:
         if parsed > 0.0:
             return parsed
     return None
+
+
+def _metadata(signal: Any) -> dict[str, Any]:
+    value = getattr(signal, "metadata", {})
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _premium_domain(metadata: Mapping[str, Any]) -> bool:
+    domain = str(
+        metadata.get("invalidation_level_domain")
+        or metadata.get("risk_domain")
+        or metadata.get("atr_domain")
+        or ""
+    ).strip().lower()
+    if domain in {"option_premium", "premium", "options"}:
+        return True
+    return bool(
+        metadata.get("computed_from_premium")
+        or metadata.get("premium_risk_contract_applied")
+        or _positive_float(metadata.get("premium_stop_distance"))
+        or _positive_float(metadata.get("premium_stop_pct"))
+        or _positive_float(metadata.get("setup_invalidation_premium"))
+        or _positive_float(metadata.get("premium_stop_price"))
+    )
+
+
+def _spread_distance(metadata: Mapping[str, Any], entry_price: float) -> float:
+    bid = _positive_float(metadata.get("bid") or metadata.get("best_bid"))
+    ask = _positive_float(metadata.get("ask") or metadata.get("best_ask"))
+    if bid is not None and ask is not None and ask >= bid:
+        return ask - bid
+    spread_pct = _positive_float(metadata.get("spread_pct"))
+    if spread_pct is not None:
+        return entry_price * spread_pct / 100.0
+    return 0.0
+
+
+def _side_geometry_valid(side: str, entry: float, stop: float, target: float) -> bool:
+    if side == "BUY":
+        return 0.0 < stop < entry < target
+    return 0.0 < target < entry < stop
+
+
+def _risk_distance(
+    signal: Any,
+    *,
+    entry_price: float,
+    entry_side: str,
+    atr: float,
+) -> tuple[float, float, str, bool]:
+    metadata = _metadata(signal)
+    spread = _spread_distance(metadata, entry_price)
+    trusted = _premium_domain(metadata)
+    stop = _positive_float(getattr(signal, "stop_loss", None))
+    explicit_stop = _positive_float(
+        metadata.get("setup_invalidation_premium")
+        or metadata.get("premium_stop_price")
+    )
+    explicit_distance = _positive_float(metadata.get("premium_stop_distance"))
+    stop_pct = _positive_float(metadata.get("premium_stop_pct"))
+    premium_atr = _positive_float(
+        metadata.get("premium_atr") or metadata.get("option_atr")
+    )
+    if premium_atr is None and trusted:
+        premium_atr = _positive_float(atr)
+
+    source = "premium_percent_fallback"
+    distance: float | None = None
+    if explicit_stop is not None and trusted:
+        candidate = (
+            entry_price - explicit_stop
+            if entry_side == "BUY"
+            else explicit_stop - entry_price
+        )
+        if candidate > 0.0:
+            distance = candidate
+            source = "explicit_premium_stop"
+    if distance is None and explicit_distance is not None:
+        distance = explicit_distance
+        source = "premium_stop_distance"
+        trusted = True
+    if distance is None and stop_pct is not None:
+        normalized_pct = stop_pct / 100.0 if stop_pct > 1.0 else stop_pct
+        if 0.0 < normalized_pct < 1.0:
+            distance = entry_price * normalized_pct
+            source = "premium_stop_pct"
+            trusted = True
+    if distance is None and stop is not None:
+        candidate = entry_price - stop if entry_side == "BUY" else stop - entry_price
+        untrusted_cap = max(entry_price * 0.30, spread * 4.0, 1.0)
+        if candidate > 0.0 and (trusted or candidate <= untrusted_cap):
+            distance = candidate
+            source = "existing_premium_geometry"
+    if distance is None and premium_atr is not None:
+        distance = max(premium_atr * 1.2, entry_price * 0.02, spread * 1.5, 1.0)
+        source = "premium_atr"
+        trusted = True
+    if distance is None:
+        distance = max(entry_price * 0.10, spread * 1.5, 1.0)
+
+    max_distance = max(
+        entry_price * (0.60 if trusted else 0.30),
+        spread * 4.0,
+        1.0,
+    )
+    distance = min(max(distance, _TICK_SIZE), max_distance)
+    if entry_side == "BUY":
+        distance = min(distance, max(entry_price - _TICK_SIZE, _TICK_SIZE))
+    rr = _positive_float(metadata.get("premium_target_rr")) or 2.0
+    return distance, rr, source, trusted
 
 
 def apply_premium_risk_contract(signal: Any, premium: float) -> Any:
@@ -71,7 +183,187 @@ def apply_premium_risk_contract(signal: Any, premium: float) -> Any:
     )
 
 
-def _patched_generate_signal(self: Any, symbol: str, current_price: float, *args: Any, **kwargs: Any) -> Any:
+def validate_option_premium_geometry(
+    self: Any,
+    signal: Any,
+    entry_price: float,
+    entry_side: str,
+    atr: float,
+) -> Any:
+    """Return domain-safe option SL/TP without using underlying-scale distances."""
+    del self
+    entry = float(entry_price or 0.0)
+    side = str(entry_side or "BUY").upper()
+    if entry <= 0.0 or side not in {"BUY", "SELL"}:
+        return signal
+
+    metadata = _metadata(signal)
+    distance, rr, source, trusted = _risk_distance(
+        signal,
+        entry_price=entry,
+        entry_side=side,
+        atr=float(atr or 0.0),
+    )
+    spread = _spread_distance(metadata, entry)
+    existing_stop = _positive_float(getattr(signal, "stop_loss", None))
+    existing_target = _positive_float(getattr(signal, "take_profit", None))
+    explicit_target = _positive_float(
+        metadata.get("setup_target_premium")
+        or metadata.get("premium_target_price")
+    )
+    has_rr_contract = _positive_float(metadata.get("premium_target_rr")) is not None
+
+    if side == "BUY":
+        stop = entry - distance
+        target = entry + distance * rr
+    else:
+        stop = entry + distance
+        target = max(_TICK_SIZE, entry - distance * rr)
+
+    existing_stop_distance = None
+    if existing_stop is not None:
+        existing_stop_distance = (
+            entry - existing_stop if side == "BUY" else existing_stop - entry
+        )
+    max_stop_distance = max(
+        entry * (0.60 if trusted else 0.30), spread * 4.0, 1.0
+    )
+    stop_was_usable = bool(
+        existing_stop_distance is not None
+        and 0.0 < existing_stop_distance <= max_stop_distance
+    )
+    if stop_was_usable and source == "existing_premium_geometry":
+        stop = float(existing_stop)
+        distance = float(existing_stop_distance)
+        if side == "BUY":
+            target = entry + distance * rr
+        else:
+            target = max(_TICK_SIZE, entry - distance * rr)
+
+    max_target_distance = max(entry, distance * max(rr, 3.0), spread * 8.0)
+    if explicit_target is not None:
+        explicit_valid = (
+            entry < explicit_target <= entry + max_target_distance
+            if side == "BUY"
+            else max(_TICK_SIZE, entry - max_target_distance)
+            <= explicit_target
+            < entry
+        )
+        if explicit_valid:
+            target = explicit_target
+    elif not has_rr_contract and existing_target is not None and stop_was_usable:
+        target_distance = (
+            existing_target - entry if side == "BUY" else entry - existing_target
+        )
+        if 0.0 < target_distance <= max_target_distance:
+            target = existing_target
+
+    if not _side_geometry_valid(side, entry, stop, target):
+        if side == "BUY":
+            stop = max(_TICK_SIZE, entry - distance)
+            target = entry + distance * rr
+        else:
+            stop = entry + distance
+            target = max(_TICK_SIZE, entry - distance * rr)
+
+    updated = dict(metadata)
+    updated.update(
+        {
+            "premium_risk_distance": float(distance),
+            "premium_risk_domain": "option_premium",
+            "premium_risk_source": source,
+            "premium_target_rr": float(rr),
+            "premium_geometry_validated": True,
+        }
+    )
+    if source == "premium_atr":
+        updated.setdefault("premium_atr", float(distance) / 1.2)
+
+    return dataclasses.replace(
+        signal,
+        stop_loss=max(_TICK_SIZE, float(stop)),
+        take_profit=max(_TICK_SIZE, float(target)),
+        metadata=updated,
+    )
+
+
+def anchor_option_geometry_to_execution(
+    self: Any,
+    signal: Any,
+    *,
+    signal_price: float,
+    execution_price: float,
+    entry_side: str,
+    atr: float,
+    sl_mult: float = 1.5,
+    tp_mult: float = 3.0,
+) -> Any:
+    """Translate valid distance geometry to execution price; never widen it."""
+    del sl_mult, tp_mult
+    execution = float(execution_price or 0.0)
+    reference = float(signal_price or 0.0)
+    side = str(entry_side or "BUY").upper()
+    if execution <= 0.0 or side not in {"BUY", "SELL"}:
+        return signal
+
+    metadata = _metadata(signal)
+    mode = str(metadata.get("bracket_anchor_mode") or "distance").lower()
+    stop = _positive_float(getattr(signal, "stop_loss", None))
+    target = _positive_float(getattr(signal, "take_profit", None))
+
+    # Absolute technical invalidations are not moved. If fill drift invalidates
+    # them, the downstream order preflight remains the fail-closed authority.
+    if mode == "absolute_level":
+        return signal
+
+    delta = execution - reference
+    if abs(delta) > _TICK_SIZE:
+        if stop is not None:
+            stop += delta
+        if target is not None:
+            target += delta
+
+    if stop is not None and target is not None and _side_geometry_valid(
+        side, execution, stop, target
+    ):
+        return dataclasses.replace(
+            signal,
+            stop_loss=float(stop),
+            take_profit=float(target),
+        )
+
+    candidate = dataclasses.replace(
+        signal,
+        stop_loss=float(stop) if stop is not None else None,
+        take_profit=float(target) if target is not None else None,
+    )
+    return validate_option_premium_geometry(
+        self,
+        candidate,
+        entry_price=execution,
+        entry_side=side,
+        atr=atr,
+    )
+
+
+def install_runner_geometry_hardening(runner_cls: type[Any]) -> None:
+    """Install the domain-safe geometry methods on StrategyRunner once."""
+    if bool(getattr(runner_cls, _RUNNER_PATCH_ATTR, False)):
+        return
+    runner_cls._premium_geometry_original_validate = getattr(
+        runner_cls, "_validate_long_option_geometry", None
+    )
+    runner_cls._premium_geometry_original_anchor = getattr(
+        runner_cls, "_anchor_sl_tp_to_execution", None
+    )
+    runner_cls._validate_long_option_geometry = validate_option_premium_geometry
+    runner_cls._anchor_sl_tp_to_execution = anchor_option_geometry_to_execution
+    setattr(runner_cls, _RUNNER_PATCH_ATTR, True)
+
+
+def _patched_generate_signal(
+    self: Any, symbol: str, current_price: float, *args: Any, **kwargs: Any
+) -> Any:
     signal = _ORIGINAL_GENERATE_SIGNAL(self, symbol, current_price, *args, **kwargs)
     return apply_premium_risk_contract(signal, float(current_price or 0.0))
 
@@ -91,4 +383,10 @@ def apply_patches() -> None:
     _PATCH_APPLIED = True
 
 
-__all__ = ["apply_patches", "apply_premium_risk_contract"]
+__all__ = [
+    "anchor_option_geometry_to_execution",
+    "apply_patches",
+    "apply_premium_risk_contract",
+    "install_runner_geometry_hardening",
+    "validate_option_premium_geometry",
+]

--- a/src/nifty_scalper_bot/execution/runtime_order_manager.py
+++ b/src/nifty_scalper_bot/execution/runtime_order_manager.py
@@ -140,6 +140,12 @@ def _enrich_trade_plan_exit_provenance(plan: Any) -> Any:
     return plan
 
 
+def _submit_core_with_exit_provenance(manager: Any, plan: Any) -> Any:
+    """Enrich every initial or rebuilt recovery plan before core submission."""
+    _enrich_trade_plan_exit_provenance(plan)
+    return _core.OrderManager.submit_trade_plan_result(manager, plan)
+
+
 class RuntimeOrderManager(_core.OrderManager):
     """Production order manager with native recovery and entry gating."""
 
@@ -180,7 +186,7 @@ class RuntimeOrderManager(_core.OrderManager):
         if blocked is not NO_BLOCK:
             return blocked
         return _recover_submit(
-            _core.OrderManager.submit_trade_plan_result,
+            _submit_core_with_exit_provenance,
             self,
             plan,
         )
@@ -254,4 +260,5 @@ __all__ = [
     "RuntimeOrderManager",
     "_enrich_trade_plan_exit_provenance",
     "_strip_exit_identity_kwargs",
+    "_submit_core_with_exit_provenance",
 ]

--- a/src/nifty_scalper_bot/execution/runtime_order_manager.py
+++ b/src/nifty_scalper_bot/execution/runtime_order_manager.py
@@ -13,6 +13,8 @@ Operational constraints:
 
 from __future__ import annotations
 
+import os
+from contextlib import suppress
 from typing import Any, Callable, Mapping
 
 from nifty_scalper_bot.execution import order_manager_core as _core
@@ -52,6 +54,92 @@ def _strip_exit_identity_kwargs(
     return cleaned, identity
 
 
+def _positive_float(value: Any) -> float | None:
+    with suppress(TypeError, ValueError):
+        parsed = float(value)
+        if parsed > 0.0:
+            return parsed
+    return None
+
+
+def _positive_int(value: Any) -> int:
+    with suppress(TypeError, ValueError):
+        parsed = int(float(value))
+        if parsed > 0:
+            return parsed
+    return 0
+
+
+def _enrich_trade_plan_exit_provenance(plan: Any) -> Any:
+    """Persist TP1/trailing inputs inside the existing TradePlan provenance.
+
+    The fill path already carries ``trade_provenance`` into ``OrderDetails`` and
+    then into virtual-bracket registration. Keeping the optional exit plan in
+    that existing durable contract avoids adding a second order model or side
+    registry. TP1 is only created when at least two complete lots are present.
+    """
+
+    if str(getattr(plan, "intent", "ENTRY") or "ENTRY").upper() not in {
+        "ENTRY",
+        "SCALE_IN",
+        "REVERSAL",
+    }:
+        return plan
+
+    provenance = getattr(plan, "trade_provenance", {})
+    enriched = dict(provenance) if isinstance(provenance, Mapping) else {}
+    quantity = _positive_int(getattr(plan, "quantity", 0))
+    lot_size = _positive_int(getattr(plan, "resolved_lot_size", 0))
+    entry = _positive_float(getattr(plan, "entry_price", None))
+    stop = _positive_float(getattr(plan, "stop_loss", None))
+    target = _positive_float(getattr(plan, "take_profit", None))
+    side = str(getattr(plan, "side", "BUY") or "BUY").upper()
+
+    if lot_size > 0:
+        enriched.setdefault("resolved_lot_size", lot_size)
+    if entry is not None and stop is not None and target is not None:
+        risk = entry - stop if side == "BUY" else stop - entry
+        reward = target - entry if side == "BUY" else entry - target
+        if risk > 0.0 and reward > 0.0:
+            enriched.setdefault("initial_risk_points", float(risk))
+            enriched.setdefault("initial_reward_points", float(reward))
+            enriched.setdefault("initial_reward_risk", float(reward / risk))
+
+            tp1_enabled = str(
+                os.getenv("ENABLE_TP1_SCALE_OUT", "true") or "true"
+            ).strip().lower() in {"1", "true", "yes", "on"}
+            total_lots = quantity // lot_size if lot_size > 0 else 0
+            if tp1_enabled and total_lots >= 2:
+                tp1_r = _positive_float(os.getenv("TP1_R_MULT", "1.0")) or 1.0
+                tp1_lots = max(1, total_lots // 2)
+                if tp1_lots < total_lots:
+                    tp1_qty = tp1_lots * lot_size
+                    tp1_price = (
+                        entry + risk * tp1_r
+                        if side == "BUY"
+                        else entry - risk * tp1_r
+                    )
+                    # TP1 must be strictly before the final target. Otherwise a
+                    # single tick could trigger both exits and provide no scale-out.
+                    strictly_before_final = (
+                        entry < tp1_price < target
+                        if side == "BUY"
+                        else target < tp1_price < entry
+                    )
+                    if strictly_before_final:
+                        enriched.setdefault("tp1_price", float(tp1_price))
+                        enriched.setdefault("tp1_qty", int(tp1_qty))
+
+    trailing_mult = _positive_float(enriched.get("trailing_atr_mult"))
+    if trailing_mult is None:
+        trailing_mult = _positive_float(os.getenv("BRACKET_TRAILING_ATR_MULT", "0"))
+    if trailing_mult is not None:
+        enriched["trailing_atr_mult"] = float(trailing_mult)
+
+    setattr(plan, "trade_provenance", enriched)
+    return plan
+
+
 class RuntimeOrderManager(_core.OrderManager):
     """Production order manager with native recovery and entry gating."""
 
@@ -87,6 +175,7 @@ class RuntimeOrderManager(_core.OrderManager):
         )
 
     def submit_trade_plan_result(self, plan: Any) -> Any:
+        _enrich_trade_plan_exit_provenance(plan)
         blocked = self._blocked("submit_trade_plan_result", (plan,), {})
         if blocked is not NO_BLOCK:
             return blocked
@@ -161,4 +250,8 @@ class RuntimeOrderManager(_core.OrderManager):
         return updated
 
 
-__all__ = ["RuntimeOrderManager", "_strip_exit_identity_kwargs"]
+__all__ = [
+    "RuntimeOrderManager",
+    "_enrich_trade_plan_exit_provenance",
+    "_strip_exit_identity_kwargs",
+]

--- a/src/nifty_scalper_bot/risk/net_rr_gate.py
+++ b/src/nifty_scalper_bot/risk/net_rr_gate.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 import os
 from contextlib import suppress
 from dataclasses import dataclass
@@ -81,6 +82,18 @@ def _half_spread(signal: Any, entry: float) -> float:
     return entry * 0.0025
 
 
+def _minimum_net_rr() -> float:
+    """Return a finite non-negative threshold; malformed config never bypasses."""
+    raw = os.getenv("MIN_NET_REWARD_RISK", "1.5")
+    try:
+        parsed = float(raw or 1.5)
+    except (TypeError, ValueError):
+        return 1.5
+    if not math.isfinite(parsed):
+        return 1.5
+    return max(0.0, parsed)
+
+
 def evaluate_final_net_rr(signal: Any) -> NetRRResult | None:
     """Return final BUY-option net RR, or None when the gate is not applicable."""
     symbol = str(getattr(signal, "symbol", "") or "").strip().upper()
@@ -127,24 +140,19 @@ def evaluate_final_net_rr(signal: Any) -> NetRRResult | None:
     net_reward = gross_reward - target_cost
     net_risk = gross_risk + stop_cost
     net_rr = net_reward / net_risk if net_reward > 0.0 and net_risk > 0.0 else 0.0
-    with suppress(TypeError, ValueError):
-        minimum = max(
-            0.0,
-            float(os.getenv("MIN_NET_REWARD_RISK", "1.5") or 1.5),
-        )
-        return NetRRResult(
-            allowed=net_rr >= minimum,
-            net_rr=net_rr,
-            minimum=minimum,
-            gross_reward=gross_reward,
-            gross_risk=gross_risk,
-            net_reward=net_reward,
-            net_risk=net_risk,
-            target_cost=target_cost,
-            stop_cost=stop_cost,
-            half_spread=half_spread,
-        )
-    return None
+    minimum = _minimum_net_rr()
+    return NetRRResult(
+        allowed=net_rr >= minimum,
+        net_rr=net_rr,
+        minimum=minimum,
+        gross_reward=gross_reward,
+        gross_risk=gross_risk,
+        net_reward=net_reward,
+        net_risk=net_risk,
+        target_cost=target_cost,
+        stop_cost=stop_cost,
+        half_spread=half_spread,
+    )
 
 
 __all__ = ["NetRRResult", "evaluate_final_net_rr"]

--- a/tests/execution/test_exit_geometry_provenance.py
+++ b/tests/execution/test_exit_geometry_provenance.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from nifty_scalper_bot.execution.bracket_manager import (
+    _enrich_virtual_bracket_kwargs,
+)
+from nifty_scalper_bot.execution.order_manager import TradePlan
+from nifty_scalper_bot.execution.runtime_order_manager import (
+    _enrich_trade_plan_exit_provenance,
+)
+
+
+def _plan(*, quantity: int = 130, provenance=None) -> TradePlan:
+    return TradePlan(
+        symbol="NFO:NIFTY2680424400CE",
+        side="BUY",
+        quantity=quantity,
+        entry_price=100.0,
+        stop_loss=90.0,
+        take_profit=120.0,
+        requested_lots=quantity // 65,
+        resolved_lot_size=65,
+        trade_provenance=dict(provenance or {}),
+    )
+
+
+def test_multilot_plan_gets_lot_aligned_tp1() -> None:
+    plan = _plan(quantity=130)
+
+    _enrich_trade_plan_exit_provenance(plan)
+
+    assert plan.trade_provenance["resolved_lot_size"] == 65
+    assert plan.trade_provenance["tp1_price"] == 110.0
+    assert plan.trade_provenance["tp1_qty"] == 65
+    assert plan.trade_provenance["initial_reward_risk"] == 2.0
+
+
+def test_single_lot_plan_does_not_create_fractional_tp1() -> None:
+    plan = _plan(quantity=65)
+
+    _enrich_trade_plan_exit_provenance(plan)
+
+    assert "tp1_price" not in plan.trade_provenance
+    assert "tp1_qty" not in plan.trade_provenance
+
+
+def test_existing_exit_provenance_is_preserved() -> None:
+    plan = _plan(
+        quantity=195,
+        provenance={"tp1_price": 108.0, "tp1_qty": 65},
+    )
+
+    _enrich_trade_plan_exit_provenance(plan)
+
+    assert plan.trade_provenance["tp1_price"] == 108.0
+    assert plan.trade_provenance["tp1_qty"] == 65
+
+
+def test_configured_atr_trailing_is_persisted(monkeypatch) -> None:
+    monkeypatch.setenv("BRACKET_TRAILING_ATR_MULT", "1.25")
+    plan = _plan(quantity=130)
+
+    _enrich_trade_plan_exit_provenance(plan)
+
+    assert plan.trade_provenance["trailing_atr_mult"] == 1.25
+
+
+def test_fill_registration_restores_optional_exit_fields_from_provenance() -> None:
+    kwargs = _enrich_virtual_bracket_kwargs(
+        {
+            "order_id": "OID-1",
+            "symbol": "NFO:NIFTY2680424400CE",
+            "side": "BUY",
+            "qty": 130,
+            "price": 100.0,
+            "sl": 90.0,
+            "tp": 120.0,
+            "trade_provenance": {
+                "tp1_price": 110.0,
+                "tp1_qty": 65,
+                "trailing_atr_mult": 1.25,
+                "resolved_lot_size": 65,
+            },
+        }
+    )
+
+    assert kwargs["tp1_price"] == 110.0
+    assert kwargs["tp1_qty"] == 65
+    assert kwargs["trailing_atr_mult"] == 1.25
+    assert kwargs["resolved_lot_size"] == 65
+
+
+def test_explicit_registration_values_override_provenance() -> None:
+    kwargs = _enrich_virtual_bracket_kwargs(
+        {
+            "tp1_price": 109.0,
+            "tp1_qty": 65,
+            "resolved_lot_size": 65,
+            "trade_provenance": {
+                "tp1_price": 110.0,
+                "tp1_qty": 130,
+                "resolved_lot_size": 75,
+            },
+        }
+    )
+
+    assert kwargs["tp1_price"] == 109.0
+    assert kwargs["tp1_qty"] == 65
+    assert kwargs["resolved_lot_size"] == 65

--- a/tests/execution/test_exit_geometry_provenance.py
+++ b/tests/execution/test_exit_geometry_provenance.py
@@ -1,11 +1,16 @@
 from __future__ import annotations
 
-from nifty_scalper_bot.execution.bracket_manager import (
-    _enrich_virtual_bracket_kwargs,
-)
+import types
+
 from nifty_scalper_bot.execution.order_manager import TradePlan
+from nifty_scalper_bot.execution.premium_risk_contract_patch import (
+    _enrich_virtual_bracket_kwargs,
+    install_bracket_exit_provenance_hardening,
+)
+from nifty_scalper_bot.execution import runtime_order_manager as runtime_module
 from nifty_scalper_bot.execution.runtime_order_manager import (
     _enrich_trade_plan_exit_provenance,
+    _submit_core_with_exit_provenance,
 )
 
 
@@ -106,3 +111,59 @@ def test_explicit_registration_values_override_provenance() -> None:
     assert kwargs["tp1_price"] == 109.0
     assert kwargs["tp1_qty"] == 65
     assert kwargs["resolved_lot_size"] == 65
+
+
+def test_bracket_installer_preserves_existing_composed_registration() -> None:
+    calls = []
+
+    class Bracket:
+        def register_virtual_bracket(self, *args, **kwargs):
+            calls.append((args, kwargs))
+            return "registered"
+
+    original = Bracket.register_virtual_bracket
+    install_bracket_exit_provenance_hardening(Bracket)
+    installed = Bracket.register_virtual_bracket
+    install_bracket_exit_provenance_hardening(Bracket)
+
+    result = Bracket().register_virtual_bracket(
+        order_id="OID-2",
+        trade_provenance={
+            "tp1_price": 110.0,
+            "tp1_qty": 65,
+            "resolved_lot_size": 65,
+        },
+    )
+
+    assert result == "registered"
+    assert installed is Bracket.register_virtual_bracket
+    assert installed is not original
+    assert len(calls) == 1
+    assert calls[0][1]["tp1_price"] == 110.0
+    assert calls[0][1]["tp1_qty"] == 65
+    assert calls[0][1]["resolved_lot_size"] == 65
+
+
+def test_recovery_submit_enriches_rebuilt_plan(monkeypatch) -> None:
+    captured = {}
+
+    def fake_submit(manager, plan):
+        captured["manager"] = manager
+        captured["plan"] = plan
+        return types.SimpleNamespace(accepted=True, order_id="OID-3")
+
+    monkeypatch.setattr(
+        runtime_module._core.OrderManager,
+        "submit_trade_plan_result",
+        fake_submit,
+    )
+    manager = object()
+    rebuilt = _plan(quantity=130)
+
+    result = _submit_core_with_exit_provenance(manager, rebuilt)
+
+    assert result.order_id == "OID-3"
+    assert captured["manager"] is manager
+    assert captured["plan"] is rebuilt
+    assert rebuilt.trade_provenance["tp1_price"] == 110.0
+    assert rebuilt.trade_provenance["tp1_qty"] == 65

--- a/tests/execution/test_premium_risk_contract_patch.py
+++ b/tests/execution/test_premium_risk_contract_patch.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 from nifty_scalper_bot.execution.premium_risk_contract_patch import (
+    anchor_option_geometry_to_execution,
     apply_premium_risk_contract,
+    install_runner_geometry_hardening,
+    validate_option_premium_geometry,
 )
 from nifty_scalper_bot.strategies.signal_generator import Signal
 
@@ -87,3 +90,123 @@ def test_sell_geometry_is_symmetric() -> None:
 
     assert result.stop_loss == 105.0
     assert result.take_profit == 92.5
+
+
+def test_untrusted_spot_scale_atr_is_not_used_as_premium_distance() -> None:
+    signal = _signal(stop_loss=82.5, take_profit=195.0)
+
+    result = validate_option_premium_geometry(
+        None,
+        signal,
+        entry_price=120.0,
+        entry_side="BUY",
+        atr=25.0,
+    )
+
+    assert result.stop_loss == 108.0
+    assert result.take_profit == 144.0
+    assert result.metadata["premium_risk_source"] == "premium_percent_fallback"
+    assert result.metadata["premium_risk_domain"] == "option_premium"
+
+
+def test_underlying_scale_target_is_rebuilt_symmetrically() -> None:
+    signal = _signal(stop_loss=110.0, take_profit=24900.0)
+
+    result = validate_option_premium_geometry(
+        None,
+        signal,
+        entry_price=120.0,
+        entry_side="BUY",
+        atr=25.0,
+    )
+
+    assert result.stop_loss == 110.0
+    assert result.take_profit == 140.0
+    assert (result.take_profit - 120.0) / (120.0 - result.stop_loss) == 2.0
+
+
+def test_premium_target_rr_remains_authoritative() -> None:
+    signal = _signal(
+        stop_loss=92.0,
+        take_profit=150.0,
+        premium_stop_distance=8.0,
+        premium_target_rr=1.5,
+        invalidation_level_domain="option_premium",
+    )
+
+    result = validate_option_premium_geometry(
+        None,
+        signal,
+        entry_price=100.0,
+        entry_side="BUY",
+        atr=25.0,
+    )
+
+    assert result.stop_loss == 92.0
+    assert result.take_profit == 112.0
+
+
+def test_execution_anchor_preserves_valid_geometry_instead_of_widening() -> None:
+    signal = _signal(stop_loss=92.0, take_profit=116.0)
+
+    result = anchor_option_geometry_to_execution(
+        None,
+        signal,
+        signal_price=100.0,
+        execution_price=100.0,
+        entry_side="BUY",
+        atr=25.0,
+    )
+
+    assert result.stop_loss == 92.0
+    assert result.take_profit == 116.0
+
+
+def test_execution_anchor_translates_distance_geometry() -> None:
+    signal = _signal(stop_loss=92.0, take_profit=116.0)
+
+    result = anchor_option_geometry_to_execution(
+        None,
+        signal,
+        signal_price=100.0,
+        execution_price=105.0,
+        entry_side="BUY",
+        atr=25.0,
+    )
+
+    assert result.stop_loss == 97.0
+    assert result.take_profit == 121.0
+
+
+def test_absolute_invalidation_is_not_moved_by_anchor() -> None:
+    signal = _signal(
+        stop_loss=92.0,
+        take_profit=116.0,
+        bracket_anchor_mode="absolute_level",
+    )
+
+    result = anchor_option_geometry_to_execution(
+        None,
+        signal,
+        signal_price=100.0,
+        execution_price=105.0,
+        entry_side="BUY",
+        atr=25.0,
+    )
+
+    assert result is signal
+    assert result.stop_loss == 92.0
+    assert result.take_profit == 116.0
+
+
+def test_runner_geometry_installer_is_idempotent() -> None:
+    runner_cls = type("Runner", (), {})
+
+    install_runner_geometry_hardening(runner_cls)
+    first_validate = runner_cls._validate_long_option_geometry
+    first_anchor = runner_cls._anchor_sl_tp_to_execution
+    install_runner_geometry_hardening(runner_cls)
+
+    assert runner_cls._premium_geometry_hardening_installed is True
+    assert runner_cls._validate_long_option_geometry is first_validate
+    assert runner_cls._anchor_sl_tp_to_execution is first_anchor

--- a/tests/risk/test_final_net_rr_gate.py
+++ b/tests/risk/test_final_net_rr_gate.py
@@ -80,6 +80,26 @@ def test_wider_spread_reduces_net_reward_risk(monkeypatch) -> None:
     assert wide.target_cost > tight.target_cost
 
 
+def test_malformed_minimum_uses_safe_default_instead_of_bypassing(monkeypatch) -> None:
+    monkeypatch.setenv("MIN_NET_REWARD_RISK", "not-a-number")
+
+    result = evaluate_final_net_rr(_signal(target=112.0))
+
+    assert result is not None
+    assert result.minimum == 1.5
+    assert result.allowed is False
+
+
+def test_nonfinite_minimum_uses_safe_default(monkeypatch) -> None:
+    monkeypatch.setenv("MIN_NET_REWARD_RISK", "nan")
+
+    result = evaluate_final_net_rr(_signal(target=112.0))
+
+    assert result is not None
+    assert result.minimum == 1.5
+    assert result.allowed is False
+
+
 def test_economic_rejection_is_real_broker_live_only(monkeypatch) -> None:
     for name in ("BROKER_SIMULATION", "PAPER_MODE", "PAPER__ENABLED", "SHADOW_MODE"):
         monkeypatch.delenv(name, raising=False)


### PR DESCRIPTION
## Root causes fixed

- Prevent ambiguous/underlying-scale ATR values from widening option-premium SL/TP geometry.
- Replace the one-way execution anchor with translation-only behaviour that preserves valid strategy geometry and absolute invalidations.
- Add symmetric target-distance validation so underlying-scale targets cannot survive into live brackets.
- Preserve `premium_target_rr` as the target authority when strategies publish it.
- Persist TP1, lot size, initial R and optional ATR-trailing inputs through TradePlan provenance, recovery rebuilds, OrderDetails and fill-time virtual-bracket registration.
- Create TP1 only for two-or-more-lot entries and keep quantities lot-aligned; one-lot entries remain full-position brackets.
- Make malformed/non-finite `MIN_NET_REWARD_RISK` use the safe 1.5 default instead of bypassing the gate.

## Architecture and scope

- Reuses the existing premium-risk contract and trade provenance; no new production registry or second bracket authority.
- Runtime hooks install only after StrategyRunner and the ownership-wrapped BoundBracketManager are fully composed.
- No changes to strategy scoring, signal thresholds, order sizing, entry selection, hard-stop execution, time-stop thresholds, broker placement, STT rates or risk limits.
- The time stop now consumes corrected initial R without changing its policy.

## Regression coverage

- Spot-scale ATR contamination and underlying-scale target correction.
- Premium RR preservation and non-widening execution anchoring.
- Absolute invalidation preservation.
- Multi-lot TP1, single-lot no-partial behaviour and lot alignment.
- Fill-registration provenance, ownership-wrapper composition and recovery-rebuilt plans.
- Malformed and non-finite net-RR configuration.