### PR TITLE
fix(observability): isolate throttles and label context votes

### DIFF
--- a/src/nifty_scalper_bot/core/boot_log_safety.py
+++ b/src/nifty_scalper_bot/core/boot_log_safety.py
@@ -38,7 +38,13 @@ ORDERFLOW_EVENTS = {
 }
 
 
-THROTTLED_EVENTS = CONTRACT_EVENTS | RUNNER_EVENTS | BOOTSTRAP_EVENTS | READINESS_EVENTS | ORDERFLOW_EVENTS
+THROTTLED_EVENTS = (
+    CONTRACT_EVENTS
+    | RUNNER_EVENTS
+    | BOOTSTRAP_EVENTS
+    | READINESS_EVENTS
+    | ORDERFLOW_EVENTS
+)
 
 
 def _event(record: logging.LogRecord) -> str:
@@ -46,6 +52,49 @@ def _event(record: logging.LogRecord) -> str:
     if value:
         return str(value)
     return str(record.getMessage() or "").split(" ", 1)[0]
+
+
+def _normalize_role_telemetry(record: logging.LogRecord) -> None:
+    """Make OrderFlow's permanent context-only role explicit in log records."""
+    event = _event(record)
+    strategy = str(getattr(record, "strategy", "") or "").strip().casefold()
+
+    if event == "elite_strategy_signal" and strategy == "orderflow":
+        record.event = "elite_strategy_context_vote"
+        record.msg = "Condition met: elite context vote generated"
+        record.args = ()
+        record.role = "context"
+        record.can_trigger = False
+        record.context_only = True
+        return
+
+    if event in ORDERFLOW_EVENTS:
+        record.role = "context"
+        record.can_trigger = False
+        record.context_only = True
+        if not getattr(record, "contract_side", None):
+            record.contract_side = getattr(record, "side", None)
+
+
+def _entity(record: logging.LogRecord) -> tuple[Any, ...]:
+    """Return the stable entity whose unchanged state is being throttled."""
+    symbol = getattr(record, "symbol", None)
+    if symbol not in (None, ""):
+        return ("symbol", str(symbol))
+
+    selected_ce = getattr(record, "selected_ce", None)
+    selected_pe = getattr(record, "selected_pe", None)
+    futures_symbol = getattr(record, "futures_symbol", None)
+    if any(
+        value not in (None, "")
+        for value in (selected_ce, selected_pe, futures_symbol)
+    ):
+        return ("basket", selected_ce, selected_pe, futures_symbol)
+
+    strategy = getattr(record, "strategy", None)
+    if strategy not in (None, ""):
+        return ("strategy", str(strategy))
+    return ("global",)
 
 
 def _fingerprint(record: logging.LogRecord) -> tuple[Any, ...]:
@@ -76,6 +125,10 @@ def _fingerprint(record: logging.LogRecord) -> tuple[Any, ...]:
         getattr(record, "trigger_conditions_met", None),
         getattr(record, "side", None),
         getattr(record, "contract_side", None),
+        getattr(record, "strategy", None),
+        getattr(record, "role", None),
+        getattr(record, "can_trigger", None),
+        getattr(record, "context_only", None),
     )
 
 
@@ -85,17 +138,21 @@ class BootLogRateControl(logging.Filter):
     def __init__(self, interval_seconds: float = 300.0) -> None:
         super().__init__()
         self.interval_seconds = max(30.0, float(interval_seconds))
-        self._last: dict[str, tuple[tuple[Any, ...], float]] = {}
+        self._last: dict[
+            tuple[str, tuple[Any, ...]], tuple[tuple[Any, ...], float]
+        ] = {}
 
     def filter(self, record: logging.LogRecord) -> bool:
+        _normalize_role_telemetry(record)
         event = _event(record)
         if event not in THROTTLED_EVENTS:
             return True
         fp = _fingerprint(record)
         now = time.monotonic()
-        last = self._last.get(event)
+        key = (event, _entity(record))
+        last = self._last.get(key)
         if last is None or last[0] != fp or now - last[1] >= self.interval_seconds:
-            self._last[event] = (fp, now)
+            self._last[key] = (fp, now)
             return True
         return False
 
@@ -112,6 +169,7 @@ def apply_filters() -> None:
         "nifty_scalper_bot.core.app",
         "nifty_scalper_bot.execution.readiness",
         "nifty_scalper_bot.strategies.runner",
+        "nifty_scalper_bot.strategies.elite_strategies.base_elite",
         "nifty_scalper_bot.strategies.elite_strategies.order_flow",
     ):
         logger = logging.getLogger(name)

--- a/tests/core/test_boot_log_role_telemetry.py
+++ b/tests/core/test_boot_log_role_telemetry.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import logging
+
+from nifty_scalper_bot.core.boot_log_safety import BootLogRateControl
+
+
+def _record(
+    event: str,
+    *,
+    logger_name: str = "nifty_scalper_bot.strategies.elite_strategies.order_flow",
+    message: str | None = None,
+    **extra: object,
+) -> logging.LogRecord:
+    record = logging.LogRecord(
+        name=logger_name,
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg=message or event,
+        args=(),
+        exc_info=None,
+    )
+    record.event = event
+    for key, value in extra.items():
+        setattr(record, key, value)
+    return record
+
+
+def test_alternating_option_symbols_are_throttled_independently() -> None:
+    control = BootLogRateControl(interval_seconds=30.0)
+    ce = _record(
+        "ORDERFLOW_TRIGGER_DECISION",
+        symbol="NFO:NIFTY26JUL24000CE",
+        side="CE",
+        trigger_conditions_met=False,
+        trigger_block_reason="direction_context_missing_live",
+    )
+    pe = _record(
+        "ORDERFLOW_TRIGGER_DECISION",
+        symbol="NFO:NIFTY26JUL24000PE",
+        side="PE",
+        trigger_conditions_met=False,
+        trigger_block_reason="direction_context_missing_live",
+    )
+
+    assert control.filter(ce) is True
+    assert control.filter(pe) is True
+    assert control.filter(ce) is False
+    assert control.filter(pe) is False
+
+
+def test_option_state_change_is_visible_after_other_symbol() -> None:
+    control = BootLogRateControl(interval_seconds=30.0)
+    ce_blocked = _record(
+        "ORDERFLOW_TRIGGER_DECISION",
+        symbol="NFO:NIFTY26JUL24000CE",
+        side="CE",
+        trigger_conditions_met=False,
+        trigger_block_reason="direction_context_missing_live",
+    )
+    pe_blocked = _record(
+        "ORDERFLOW_TRIGGER_DECISION",
+        symbol="NFO:NIFTY26JUL24000PE",
+        side="PE",
+        trigger_conditions_met=False,
+        trigger_block_reason="direction_context_missing_live",
+    )
+    ce_changed = _record(
+        "ORDERFLOW_TRIGGER_DECISION",
+        symbol="NFO:NIFTY26JUL24000CE",
+        side="CE",
+        trigger_conditions_met=True,
+        trigger_block_reason="",
+    )
+
+    assert control.filter(ce_blocked) is True
+    assert control.filter(pe_blocked) is True
+    assert control.filter(ce_changed) is True
+
+
+def test_orderflow_elite_result_is_relabelled_as_context_vote() -> None:
+    control = BootLogRateControl(interval_seconds=30.0)
+    record = _record(
+        "elite_strategy_signal",
+        logger_name="nifty_scalper_bot.strategies.elite_strategies.base_elite",
+        message="Condition met: elite signal generated",
+        strategy="OrderFlow",
+    )
+
+    assert control.filter(record) is True
+    assert record.event == "elite_strategy_context_vote"
+    assert record.getMessage() == "Condition met: elite context vote generated"
+    assert record.role == "context"
+    assert record.can_trigger is False
+    assert record.context_only is True
+
+
+def test_trigger_strategy_signal_label_is_preserved() -> None:
+    control = BootLogRateControl(interval_seconds=30.0)
+    record = _record(
+        "elite_strategy_signal",
+        logger_name="nifty_scalper_bot.strategies.elite_strategies.base_elite",
+        message="Condition met: elite signal generated",
+        strategy="VWAPPro",
+    )
+
+    assert control.filter(record) is True
+    assert record.event == "elite_strategy_signal"
+    assert record.getMessage() == "Condition met: elite signal generated"
+    assert not hasattr(record, "context_only")
+
+
+def test_orderflow_decision_explicitly_publishes_context_only_role() -> None:
+    control = BootLogRateControl(interval_seconds=30.0)
+    record = _record(
+        "ORDERFLOW_TRIGGER_DECISION",
+        symbol="NFO:NIFTY26JUL24000CE",
+        side="CE",
+        trigger_conditions_met=True,
+        trigger_block_reason="",
+    )
+
+    assert control.filter(record) is True
+    assert record.role == "context"
+    assert record.can_trigger is False
+    assert record.context_only is True
+    assert record.contract_side == "CE"
+
+
+def test_global_readiness_throttle_remains_global() -> None:
+    control = BootLogRateControl(interval_seconds=30.0)
+    first = _record(
+        "LIVE_READINESS_COMPUTED",
+        logger_name="nifty_scalper_bot.execution.readiness",
+        ready=False,
+        primary_blocker="history_cold",
+    )
+    same = _record(
+        "LIVE_READINESS_COMPUTED",
+        logger_name="nifty_scalper_bot.execution.readiness",
+        ready=False,
+        primary_blocker="history_cold",
+    )
+    changed = _record(
+        "LIVE_READINESS_COMPUTED",
+        logger_name="nifty_scalper_bot.execution.readiness",
+        ready=True,
+        primary_blocker=None,
+    )
+
+    assert control.filter(first) is True
+    assert control.filter(same) is False
+    assert control.filter(changed) is True


### PR DESCRIPTION
## Confirmed defects

1. Diagnostic throttling stored one previous state per event name, so alternating CE and PE records replaced one another and escaped suppression.
2. OrderFlow is permanently context-only, but generic elite logging described its output as an executable strategy signal.

## Narrow correction

- Keep unchanged-state throttle history separately by `(event, entity)`, where the entity is a symbol, basket, strategy, or global scope.
- Normalize OrderFlow log records in the logging layer before handlers receive them.
- Relabel generic OrderFlow results from `elite_strategy_signal` to `elite_strategy_context_vote`.
- Explicitly publish `role=context`, `can_trigger=false`, and `context_only=true` on OrderFlow decision records.
- Leave genuine trigger-strategy records unchanged.

## Scope

Exactly two files:

- `src/nifty_scalper_bot/core/boot_log_safety.py`
- `tests/core/test_boot_log_role_telemetry.py`

No strategy implementation, returned signals, scores, entry logic, readiness, risk, sizing, subscriptions, broker execution, stops, targets, or exits are changed.