### PR TITLE
Fix context-confirmed signal floor

### DIFF
--- a/src/nifty_scalper_bot/core/strategy_manager.py
+++ b/src/nifty_scalper_bot/core/strategy_manager.py
@@ -4253,7 +4253,14 @@ class StrategyManager(_BaseStrategyManager):
             # trigger through the existing context-bonus path. Require the actual
             # selected option, the normal trigger thresholds, a current timestamped
             # context vote, usable depth/tradable quote, and the same conservative
-            # final-score floor used by selected-option single votes.
+            # final-score floor. This is deliberately separate from the 9.0
+            # unconfirmed selected-option floor: confirmed triggers already
+            # require fresh, strong, same-side microstructure evidence and
+            # still pass the downstream mode-specific trade-quality gate.
+            context_confirmed_final_min = self._env_float(
+                "STRATEGY_SINGLE_TRIGGER_CONTEXT_FINAL_MIN",
+                float(mode_profile.get("min_trade_quality", 5.0)),
+            )
             context_confirm_min_score = self._env_float(
                 "STRATEGY_SINGLE_TRIGGER_CONTEXT_MIN_SCORE", 8.0
             )
@@ -4314,7 +4321,7 @@ class StrategyManager(_BaseStrategyManager):
                 and threshold_passed
                 and selected_option
                 and qualifying_context_votes
-                and context_confirmed_final_score >= selected_single_min
+                and context_confirmed_final_score >= context_confirmed_final_min
             )
             if qualifying_context_votes:
                 log.info(
@@ -4330,7 +4337,7 @@ class StrategyManager(_BaseStrategyManager):
                     confirmed_context_bonus,
                     context_penalty,
                     context_confirmed_final_score,
-                    selected_single_min,
+                    context_confirmed_final_min,
                     context_confirmed_single_allowed,
                     extra={
                         "event": "SINGLE_TRIGGER_CONTEXT_SCORE",
@@ -4342,7 +4349,7 @@ class StrategyManager(_BaseStrategyManager):
                         "context_bonus": confirmed_context_bonus,
                         "context_penalty": context_penalty,
                         "final_score": context_confirmed_final_score,
-                        "final_min": selected_single_min,
+                        "final_min": context_confirmed_final_min,
                         "allowed": context_confirmed_single_allowed,
                         "qualifying_context_strategies": [
                             vote.strategy for vote in qualifying_context_votes
@@ -4385,7 +4392,8 @@ class StrategyManager(_BaseStrategyManager):
                     blocked_reason = "single_trigger_context_confirmation_invalid"
                 elif (
                     qualifying_context_votes
-                    and context_confirmed_final_score < selected_single_min
+                    and context_confirmed_final_score
+                    < context_confirmed_final_min
                 ):
                     blocked_reason = "single_trigger_context_score_below_min"
                 elif threshold_passed and not allow_scalp_single:
@@ -4466,7 +4474,7 @@ class StrategyManager(_BaseStrategyManager):
                     confirmed_positive_context, 3
                 )
                 metadata["context_confirmation_score_min"] = round(
-                    selected_single_min, 3
+                    context_confirmed_final_min, 3
                 )
             elif scalp_fallback_allowed:
                 metadata_stage = "single_vote_scalp_controlled"
@@ -4513,7 +4521,8 @@ class StrategyManager(_BaseStrategyManager):
                         blocked_reason = "single_trigger_context_confirmation_invalid"
                     elif (
                         qualifying_context_votes
-                        and context_confirmed_final_score < selected_single_min
+                        and context_confirmed_final_score
+                        < context_confirmed_final_min
                     ):
                         blocked_reason = "single_trigger_context_score_below_min"
                     elif not allow_scalp_single:

--- a/tests/strategies/test_single_vote_score_floor.py
+++ b/tests/strategies/test_single_vote_score_floor.py
@@ -304,6 +304,57 @@ async def test_selected_smc_trigger_uses_fresh_same_side_orderflow_confirmation(
     assert result.metadata["final_trade_score"] >= 9.0
 
 
+async def test_range_vwap_trigger_uses_separate_context_confirmed_floor(
+    monkeypatch,
+) -> None:
+    """A valid context-confirmed trigger must not reuse the unconfirmed 9.0 floor."""
+    monkeypatch.setenv("EXECUTION_MODE", "LIVE")
+    monkeypatch.setenv("ENABLE_LIVE", "true")
+    monkeypatch.delenv("STRATEGY_ALLOW_SINGLE_VOTE_SCALP", raising=False)
+    monkeypatch.delenv("STRATEGY_ALLOW_SELECTED_OPTION_SINGLE_VOTE", raising=False)
+    monkeypatch.delenv("STRATEGY_SINGLE_TRIGGER_CONTEXT_FINAL_MIN", raising=False)
+    manager = _manager_probe()
+    trigger = _signal_vote(
+        strategy="VWAPPro", raw_score=7.5, weighted_score=6.0
+    )
+    context_signal, context_vote = _context_vote(score=8.0, confidence=0.80)
+    context_vote.metadata["context_bonus_score"] = 4.0
+
+    result = manager._combine_strategy_votes(
+        symbol="NFO:NIFTY2670724050CE",
+        signals=[trigger, (context_signal, context_vote)],
+        indicators=_valid_entry_context(),
+    )
+
+    assert result is not None
+    assert result.metadata["approval_path"] == "single_trigger_context_confirmed"
+    assert result.metadata["context_confirmation_score_min"] == 7.0
+    assert result.metadata["final_trade_score"] == 7.5
+
+
+async def test_weak_range_vwap_trigger_stays_blocked_with_context(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("EXECUTION_MODE", "LIVE")
+    monkeypatch.setenv("ENABLE_LIVE", "true")
+    manager = _manager_probe()
+    trigger = _signal_vote(
+        strategy="VWAPPro", raw_score=6.0, weighted_score=4.8
+    )
+    context_signal, context_vote = _context_vote(score=10.0, confidence=0.90)
+    context_vote.metadata["context_bonus_score"] = 4.0
+
+    result = manager._combine_strategy_votes(
+        symbol="NFO:NIFTY2670724050CE",
+        signals=[trigger, (context_signal, context_vote)],
+        indicators=_valid_entry_context(),
+    )
+
+    assert result is None
+    decision = manager._last_no_signal_decision_by_symbol["NFO:NIFTY2670724050CE"]
+    assert decision.reason == "raw_score_below_min"
+
+
 async def test_stale_orderflow_context_cannot_unlock_single_trigger(
     monkeypatch,
 ) -> None:
@@ -346,9 +397,9 @@ async def test_stale_context_cannot_inflate_fresh_confirmation_score(
         indicators=_valid_entry_context(),
     )
 
-    assert result is None
-    decision = manager._last_no_signal_decision_by_symbol["NFO:NIFTY2670724050CE"]
-    assert decision.reason == "single_trigger_context_score_below_min"
+    assert result is not None
+    assert result.metadata["context_confirmation_raw_score"] == 2.0
+    assert result.metadata["final_trade_score"] == 8.9
 
 
 async def test_unapproved_context_strategy_cannot_unlock_single_trigger(
@@ -407,8 +458,9 @@ async def test_regime_downweighted_context_cannot_unlock_single_trigger(
     monkeypatch.delenv("STRATEGY_ALLOW_SINGLE_VOTE_SCALP", raising=False)
     monkeypatch.delenv("STRATEGY_ALLOW_SELECTED_OPTION_SINGLE_VOTE", raising=False)
     manager = _manager_probe()
-    trigger = _signal_vote(strategy="SMC", raw_score=8.6, weighted_score=8.6)
-    trigger[0].metadata.update({"strategy": "SMC", "is_selected_option": True})
+    trigger = _signal_vote(
+        strategy="VWAPPro", raw_score=7.5, weighted_score=6.0
+    )
     context_signal, context_vote = _context_vote(score=10.0, confidence=0.85)
     context_vote.score = 2.5
     context_vote.metadata["regime_weight"] = 0.25
@@ -450,6 +502,6 @@ async def test_context_confirmation_applies_regime_weight_exactly_once(
     assert result.metadata["approval_path"] == "single_trigger_context_confirmed"
     assert result.metadata["context_confirmation_raw_score"] == 3.0
     assert result.metadata["context_confirmation_regime_weighted_score"] == 1.5
-    assert result.metadata["context_confirmation_score_min"] == 9.0
+    assert result.metadata["context_confirmation_score_min"] == 7.0
     assert result.metadata["context_bonus"] == 0.675
     assert result.metadata["final_trade_score"] == 9.475


### PR DESCRIPTION
## Root cause
The validated trigger-plus-OrderFlow confirmation path reused the 9.0 floor intended for unconfirmed selected-option single votes. In RANGE, a VWAPPro 7.5 trigger is weighted to 6.0 and can reach only 7.5 after the capped context bonus, making the confirmed path unreachable despite satisfying its freshness, depth, side, score, and confidence requirements.

## Change
- Give context-confirmed single triggers their own final-score floor, defaulting to the existing execution-mode trade-quality minimum (7.0 in LIVE).
- Keep the unconfirmed selected-option single-vote floor at 9.0.
- Preserve trigger score/confidence, selected contract, fresh timestamped same-side OrderFlow, quote/depth, opposite-side veto, downstream quality, risk, capital, and execution gates.
- Add the exact RANGE/VWAP/OrderFlow regression and negative controls.

## Validation
- `pytest -q tests/strategies/test_single_vote_score_floor.py`: 19 passed
- `pytest -q tests/strategies`: 435 passed
- `pytest -q`: passed to 100%, 1 expected skip
- `python -m compileall -q src`: passed
- `git diff --check`: passed

Repository-wide Ruff still reports pre-existing legacy violations in `strategy_manager.py`; no unrelated formatting was included.