### PR TITLE
Unify ORB enablement authority

### DIFF
--- a/src/nifty_scalper_bot/strategies/elite_strategies/orb_pro.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/orb_pro.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 from datetime import datetime, timezone
 from typing import Any
 
@@ -46,9 +45,6 @@ class ORBProStrategy(EliteStrategy):
     def _evaluate_signal(self, symbol: str, indicators: dict[str, Any], current_price: float, position: Any | None = None) -> EliteSignal | None:
         """Args: symbol, indicators, current_price, position. Returns: EliteSignal|None. Raises: Exception."""
         del position
-        if str(os.getenv('ENABLE_ORB_STRATEGY', 'false')).strip().lower() not in {'1','true','yes','on'}:
-            self._no_vote('strategy_disabled_by_env')
-            return None
         try:
             self._no_vote("stale_or_invalid_data")
             or_complete = bool(indicators.get('orb_ready'))

--- a/tests/strategies/test_elite_builder_mode.py
+++ b/tests/strategies/test_elite_builder_mode.py
@@ -42,7 +42,9 @@ def test_directional_mode_disables_gamma_theta_and_context(monkeypatch) -> None:
 def test_orb_setup_identity_is_runner_owned_and_stable(
     monkeypatch,
 ) -> None:
-    monkeypatch.setenv("ENABLE_ORB_STRATEGY", "true")
+    # ORB_ENABLED is resolved into config by settings; a legacy second env
+    # switch must not silently disable an already-enabled strategy instance.
+    monkeypatch.setenv("ENABLE_ORB_STRATEGY", "false")
     strategy = ORBProStrategy(
         ORBProStrategyConfig(min_confidence=0.0),
         indicator_engine=None,

--- a/tests/strategies/test_signal_observability_contract.py
+++ b/tests/strategies/test_signal_observability_contract.py
@@ -55,10 +55,10 @@ class _ObservableStrategy(EliteStrategy):
         )
 
 
-def test_disabled_orb_has_explicit_no_vote_reason(monkeypatch) -> None:
-    monkeypatch.setenv("ENABLE_ORB_STRATEGY", "false")
+def test_disabled_orb_config_stays_disabled(monkeypatch) -> None:
+    monkeypatch.setenv("ENABLE_ORB_STRATEGY", "true")
     strategy = ORBProStrategy(
-        ORBProStrategyConfig(enabled=True, quantity=1), indicator_engine=None
+        ORBProStrategyConfig(enabled=False, quantity=1), indicator_engine=None
     )
 
     signal = strategy.generate_signal(
@@ -68,7 +68,6 @@ def test_disabled_orb_has_explicit_no_vote_reason(monkeypatch) -> None:
     )
 
     assert signal is None
-    assert strategy.last_no_vote_reason == "strategy_disabled_by_env"
 
 
 def test_elite_signal_log_contains_structural_identity(caplog) -> None:


### PR DESCRIPTION
## Root cause
Settings constructed ORBPro as enabled from `ORB_ENABLED=true`, but ORBPro then applied a second independent `ENABLE_ORB_STRATEGY=false` gate on every evaluation. A strategy that was loaded and advertised as enabled therefore returned `strategy_disabled_by_env` indefinitely.

## Change
- Remove the duplicate per-evaluation environment gate from ORBPro.
- Keep the existing `ORBProStrategyConfig.enabled` check in `EliteStrategy.generate_signal` as the sole runtime authority.
- Add regressions proving a configured-enabled strategy is not disabled by the legacy variable and a configured-disabled strategy remains disabled.

## Preserved behavior
ORB readiness, history, regime, breakout, retest, volume, direction, RR, score/confidence, consensus, quality, risk, and execution gates are unchanged.

## Validation
- ORB focused regressions: passed
- `pytest -q tests/strategies`: 435 passed
- `pytest -q`: passed to 100%, 1 expected skip
- `python -m compileall -q src`: passed
- `git diff --check`: passed