### PR TITLE
Clarify signal event semantics

### DIFF
--- a/src/nifty_scalper_bot/core/strategy_manager.py
+++ b/src/nifty_scalper_bot/core/strategy_manager.py
@@ -4688,6 +4688,27 @@ class StrategyManager(_BaseStrategyManager):
         metadata["approval_path"] = approval_path
         metadata["is_approved"] = True
         log.info("TRADE_DECISION_TRACE approval_path=%s symbol=%s strategy=%s", approval_path, symbol_norm, best_vote.strategy)
+        log.info(
+            "SIGNAL_APPROVED symbol=%s strategy=%s side=%s approval_path=%s "
+            "final_score=%.2f trade_quality_score=%.2f",
+            symbol_norm,
+            best_vote.strategy,
+            best_vote.side,
+            approval_path,
+            final_score,
+            quality_score,
+            extra={
+                "event": "SIGNAL_APPROVED",
+                "symbol": symbol_norm,
+                "strategy": best_vote.strategy,
+                "side": best_vote.side,
+                "approval_path": approval_path,
+                "final_score": final_score,
+                "trade_quality_score": quality_score,
+                "trigger_vote_count": len(trigger_votes),
+                "context_vote_count": len(context_votes),
+            },
+        )
         record_strategy_evaluation(strategy=str(best_vote.strategy), symbol=symbol_norm, accepted=True, reason=str(approval_path), score=final_score)
         maybe_emit_strategy_rejection_summary(log, interval_seconds=300.0)
         self._last_no_signal_decision_by_symbol.pop(symbol_norm, None)

--- a/src/nifty_scalper_bot/strategies/signal_identity_patch.py
+++ b/src/nifty_scalper_bot/strategies/signal_identity_patch.py
@@ -171,10 +171,15 @@ def _install_elite_signal_observability() -> None:
         if raw_score is None:
             raw_score = metadata.get("strategy_score") or metadata.get("context_score")
         role = str(metadata.get("role") or "trigger").lower()
+        vote_event = (
+            "STRATEGY_CONTEXT_VOTE"
+            if role == "context"
+            else "STRATEGY_TRIGGER_VOTE"
+        )
         LOGGER.log(
             logging.DEBUG if role == "context" else logging.INFO,
             (
-                "ELITE_SIGNAL_GENERATED strategy=%s symbol=%s side=%s "
+                f"{vote_event} strategy=%s symbol=%s side=%s "
                 "raw_setup_score=%s confidence=%s setup_id=%s setup_anchor=%s "
                 "quote_update_version=%s evaluation_snapshot_id=%s"
             ),
@@ -188,7 +193,7 @@ def _install_elite_signal_observability() -> None:
             metadata.get("quote_update_version"),
             metadata.get("evaluation_snapshot_id"),
             extra={
-                "event": "ELITE_SIGNAL_GENERATED",
+                "event": vote_event,
                 "strategy": strategy,
                 "symbol": getattr(signal, "symbol", symbol),
                 "side": side or None,

--- a/tests/strategies/test_signal_observability_contract.py
+++ b/tests/strategies/test_signal_observability_contract.py
@@ -91,7 +91,7 @@ def test_elite_signal_log_contains_structural_identity(caplog) -> None:
     records = [
         record
         for record in caplog.records
-        if getattr(record, "event", None) == "ELITE_SIGNAL_GENERATED"
+        if getattr(record, "event", None) == "STRATEGY_TRIGGER_VOTE"
     ]
     assert len(records) == 1
     record = records[0]
@@ -106,6 +106,10 @@ def test_elite_signal_log_contains_structural_identity(caplog) -> None:
     )
     assert record.setup_signal_id == signal.deterministic_id
     assert record.evaluation_snapshot_id == signal.metadata["evaluation_snapshot_id"]
+    assert not any(
+        getattr(record, "event", None) == "ELITE_SIGNAL_GENERATED"
+        for record in caplog.records
+    )
 
 
 def test_elite_evaluation_snapshot_identity_tracks_quote_version() -> None:

--- a/tests/strategies/test_single_vote_score_floor.py
+++ b/tests/strategies/test_single_vote_score_floor.py
@@ -7,6 +7,7 @@ combined score clears the same conservative floor.
 
 from __future__ import annotations
 
+import logging
 import os
 
 
@@ -306,8 +307,10 @@ async def test_selected_smc_trigger_uses_fresh_same_side_orderflow_confirmation(
 
 async def test_range_vwap_trigger_uses_separate_context_confirmed_floor(
     monkeypatch,
+    caplog,
 ) -> None:
     """A valid context-confirmed trigger must not reuse the unconfirmed 9.0 floor."""
+    caplog.set_level(logging.INFO)
     monkeypatch.setenv("EXECUTION_MODE", "LIVE")
     monkeypatch.setenv("ENABLE_LIVE", "true")
     monkeypatch.delenv("STRATEGY_ALLOW_SINGLE_VOTE_SCALP", raising=False)
@@ -330,6 +333,14 @@ async def test_range_vwap_trigger_uses_separate_context_confirmed_floor(
     assert result.metadata["approval_path"] == "single_trigger_context_confirmed"
     assert result.metadata["context_confirmation_score_min"] == 7.0
     assert result.metadata["final_trade_score"] == 7.5
+    approvals = [
+        record
+        for record in caplog.records
+        if getattr(record, "event", None) == "SIGNAL_APPROVED"
+    ]
+    assert len(approvals) == 1
+    assert approvals[0].symbol == "NFO:NIFTY2670724050CE"
+    assert approvals[0].approval_path == "single_trigger_context_confirmed"
 
 
 async def test_weak_range_vwap_trigger_stays_blocked_with_context(


### PR DESCRIPTION
## Root cause
The elite-strategy wrapper labeled every preliminary trigger/context vote as `ELITE_SIGNAL_GENERATED`, while manager-approved candidates had no universal structured approval event. Runtime exports therefore counted many repeated setup evaluations as trade signals even when the manager correctly rejected them before risk or order handling.

## Change
- Rename preliminary events to `STRATEGY_TRIGGER_VOTE` or `STRATEGY_CONTEXT_VOTE` according to the existing role.
- Emit one structured `SIGNAL_APPROVED` event only after strategy combination and trade-quality approval, including approval path, final score, quality score, and vote counts.
- Preserve stable setup/evaluation identities and all trading behavior.

## Validation
- Focused trigger-vote and approval-event regressions: passed
- `pytest -q tests/strategies`: 435 passed
- `pytest -q`: passed to 100%, 1 expected skip
- `python -m compileall -q src`: passed
- `git diff --check`: passed