### PR TITLE
Fix capital-aware option entry path

### DIFF
--- a/src/nifty_scalper_bot/execution/affordability.py
+++ b/src/nifty_scalper_bot/execution/affordability.py
@@ -1,7 +1,8 @@
 """Minimum executable-lot affordability for live readiness.
 
-This module deliberately evaluates only the already-selected contract. It must
-never choose a cheaper strike or bypass the strategy/liquidity selection policy.
+This module evaluates one supplied contract and never chooses a strike. Callers
+may use the result only after strategy, side, expiry and liquidity ranking; the
+authoritative order-manager margin gate still runs immediately before submission.
 """
 
 from __future__ import annotations
@@ -80,7 +81,7 @@ def evaluate_minimum_lot_affordability(
     data_hub: Any | None = None,
     fallback_balance: Any | None = None,
 ) -> MinimumLotAffordability:
-    """Evaluate whether one selected BUY option lot is executable.
+    """Evaluate whether one supplied BUY option lot is executable.
 
     The estimate mirrors the MarginEngine fallback path: ask premium × lot size ×
     margin factor, while the configured margin buffer reserves cash by reducing

--- a/src/nifty_scalper_bot/execution/order_manager_core.py
+++ b/src/nifty_scalper_bot/execution/order_manager_core.py
@@ -4979,8 +4979,9 @@ class OrderManager:
             new_sl = round(price + sl_dist, 2)
             new_tp = max(0.05, round(price - tp_dist, 2))
 
-        self._logger.warning(
-            "BRACKET_REANCHORED symbol=%s side=%s entry=%.2f price=%.2f "
+        self._logger.info(
+            "TRADE_PLAN_BRACKET_REANCHORED stage=pre_submit "
+            "broker_attempted=False symbol=%s side=%s entry=%.2f price=%.2f "
             "sl=%.2f->%.2f tp=%.2f->%.2f trace_id=%s",
             plan.symbol,
             plan.side,
@@ -4991,6 +4992,13 @@ class OrderManager:
             tp,
             new_tp,
             plan.trace_id,
+            extra={
+                "event": "TRADE_PLAN_BRACKET_REANCHORED",
+                "stage": "pre_submit",
+                "broker_attempted": False,
+                "symbol": plan.symbol,
+                "trace_id": plan.trace_id,
+            },
         )
         return replace(plan, stop_loss=new_sl, take_profit=new_tp)
 

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -107,6 +107,9 @@ from nifty_scalper_bot.data.source import (
 )
 
 # Signals route directly through OrderManager submit/place APIs; no execution hub layer.
+from nifty_scalper_bot.execution.affordability import (
+    evaluate_minimum_lot_affordability,
+)
 from nifty_scalper_bot.execution.order_manager import OrderType, TradePlan
 from nifty_scalper_bot.execution.quote_readiness import (
     evaluate_execution_quote,
@@ -4443,6 +4446,89 @@ class StrategyRunner:
         reject_key = f"{normalize_symbol(symbol)}:{reason_key}:{reject_reason}"
         self._execution_reject_cooldown_ts[reject_key] = now_epoch
         return reject_reason
+
+    def _select_capital_eligible_candidate(
+        self,
+        *,
+        ranked_candidates: Sequence[Any],
+        candidate_snapshots: Sequence[Mapping[str, Any]],
+        is_live_mode: bool,
+        trace_id: str | None,
+    ) -> tuple[Any | None, dict[str, dict[str, object]]]:
+        """Return the first ranked, ready candidate that can fund one live lot."""
+        snapshots_by_symbol = {
+            normalize_symbol(str(snapshot.get("symbol") or "")): snapshot
+            for snapshot in candidate_snapshots
+            if snapshot.get("symbol")
+        }
+        decisions: dict[str, dict[str, object]] = {}
+        fallback_balance = getattr(
+            getattr(self, "_risk_manager", None), "available_balance", None
+        )
+        for ranked in ranked_candidates:
+            ranked_symbol = normalize_symbol(str(ranked.symbol))
+            ready_before = self._is_symbol_execution_ready(ranked_symbol)
+            ready_after = bool(
+                ready_before
+                or (
+                    is_live_mode
+                    and self._ensure_symbol_execution_ready_for_order(
+                        ranked_symbol, trace_id=trace_id
+                    )
+                )
+            )
+            if not ready_after:
+                decisions[ranked_symbol] = {
+                    "symbol": ranked_symbol,
+                    "reason": "execution_not_ready",
+                    "execution_ready_before": bool(ready_before),
+                    "execution_ready_after": False,
+                }
+                continue
+            if not is_live_mode:
+                decisions[ranked_symbol] = {
+                    "symbol": ranked_symbol,
+                    "reason": "capacity_not_required",
+                    "execution_ready_before": bool(ready_before),
+                    "execution_ready_after": True,
+                }
+                return ranked, decisions
+
+            capacity = evaluate_minimum_lot_affordability(
+                symbol=ranked_symbol,
+                quote=snapshots_by_symbol.get(ranked_symbol),
+                order_manager=getattr(self, "_order_manager", None),
+                data_hub=getattr(self, "_data_hub", None),
+                fallback_balance=fallback_balance,
+            )
+            capacity_details = capacity.to_dict()
+            capacity_details.update(
+                {
+                    "execution_ready_before": bool(ready_before),
+                    "execution_ready_after": True,
+                    "trace_id": trace_id,
+                }
+            )
+            decisions[ranked_symbol] = capacity_details
+            self._logger.info(
+                "CANDIDATE_CAPACITY_DECISION symbol=%s affordable=%s "
+                "determinate=%s reason=%s required=%s executable_capacity=%s "
+                "trace_id=%s",
+                ranked_symbol,
+                capacity.affordable,
+                capacity.determinate,
+                capacity.reason,
+                capacity.required,
+                capacity.executable_capacity,
+                trace_id,
+                extra={
+                    "event": "CANDIDATE_CAPACITY_DECISION",
+                    **capacity_details,
+                },
+            )
+            if capacity.determinate and capacity.affordable:
+                return ranked, decisions
+        return None, decisions
 
     def get_runtime_readiness_snapshot(self) -> dict[str, object]:
         """Return runtime readiness snapshot. Args: none. Returns: readiness map. Raises: none."""
@@ -10405,8 +10491,13 @@ class StrategyRunner:
         candidate_symbol: str | None,
         *,
         snapshot: Mapping[str, OptionSideReadiness] | None = None,
+        approved_replacement_symbol: str | None = None,
     ) -> dict[str, Any] | None:
         if not candidate_symbol or not is_nifty_option_symbol(str(candidate_symbol)):
+            return None
+        if approved_replacement_symbol and self._symbol_match_keys(
+            candidate_symbol
+        ) & self._symbol_match_keys(approved_replacement_symbol):
             return None
         snap = snapshot or self._option_side_readiness_snapshot()
         selected = {"CE": snap["CE"], "PE": snap["PE"]}
@@ -18185,6 +18276,9 @@ class StrategyRunner:
                 self._reset_execution_state(base_symbol)
                 return SignalExecutionResult(False, "max_order_attempts_per_minute")
             metadata = dict(signal.metadata or {})
+            # Signal metadata is external to the runner; only this invocation may
+            # stamp a replacement after every strict replacement guard passes.
+            metadata.pop("_runner_approved_replacement_symbol", None)
             quality = None
             reject_cooldown_result = self._execution_reject_cooldown_result(
                 base_symbol, reason_key, now_epoch, trace_id
@@ -18712,27 +18806,25 @@ class StrategyRunner:
                             snapshots=valid_snapshots,
                         )
                     )
-                    candidate = None
-                    for ranked in ranked_candidates:
-                        ranked_symbol = normalize_symbol(ranked.symbol)
-                        selected_candidate_trace = ranked_symbol
-                        candidate_ready_before = self._is_symbol_execution_ready(
-                            ranked_symbol
+                    candidate, candidate_capacity_decisions = (
+                        self._select_capital_eligible_candidate(
+                            ranked_candidates=ranked_candidates,
+                            candidate_snapshots=valid_snapshots,
+                            is_live_mode=is_live_mode,
+                            trace_id=trace_id,
                         )
-                        if candidate_ready_before:
-                            candidate_ready_after = True
-                            candidate = ranked
-                            break
-                        if (
-                            is_live_mode
-                            and self._ensure_symbol_execution_ready_for_order(
-                                ranked_symbol, trace_id=trace_id
-                            )
-                        ):
-                            candidate_ready_after = True
-                            candidate = ranked
-                            break
-                        candidate_ready_after = False
+                    )
+                    if candidate is not None:
+                        selected_candidate_trace = normalize_symbol(candidate.symbol)
+                        selected_decision = candidate_capacity_decisions.get(
+                            selected_candidate_trace, {}
+                        )
+                        candidate_ready_before = selected_decision.get(
+                            "execution_ready_before"
+                        )
+                        candidate_ready_after = selected_decision.get(
+                            "execution_ready_after"
+                        )
                 except Exception as exc:  # noqa: BLE001
                     self._logger.error(
                         "Failure in trade candidate selection: %s",
@@ -18759,11 +18851,25 @@ class StrategyRunner:
                         },
                     )
                 if candidate is None:
+                    capacity_blocked = any(
+                        decision.get("reason")
+                        in {
+                            "minimum_lot_unaffordable",
+                            "available_balance_unavailable",
+                            "executable_quote_unavailable",
+                            "lot_size_unresolved",
+                        }
+                        for decision in candidate_capacity_decisions.values()
+                    )
                     self._reset_execution_state(base_symbol)
                     return self._reject_signal_execution(
                         symbol=base_symbol,
                         trace_id=trace_id,
-                        reason="no_execution_ready_candidate",
+                        reason=(
+                            "no_affordable_execution_candidate"
+                            if capacity_blocked
+                            else "no_execution_ready_candidate"
+                        ),
                         details={
                             "candidate_total": len(valid_snapshots),
                             "candidate_ranked": len(ranked_candidates),
@@ -18772,8 +18878,15 @@ class StrategyRunner:
                             ),
                             "direction": option_side,
                             "atm": atm_strike,
-                            "min_option_premium": self._trade_candidate_selector.min_option_premium,
-                            "max_option_premium": self._trade_candidate_selector.max_option_premium,
+                            "min_option_premium": (
+                                self._trade_candidate_selector.min_option_premium
+                            ),
+                            "max_option_premium": (
+                                self._trade_candidate_selector.max_option_premium
+                            ),
+                            "candidate_capacity_decisions": (
+                                candidate_capacity_decisions
+                            ),
                         },
                     )
                 selected_symbol = normalize_symbol(candidate.symbol)
@@ -18782,7 +18895,7 @@ class StrategyRunner:
                 replacement_blocked_reason: str | None = None
                 if selected_symbol != original_symbol:
                     allow_replace = _env_flag(
-                        "ALLOW_CANDIDATE_REPLACEMENT", default=False
+                        "ALLOW_CANDIDATE_REPLACEMENT", default=True
                     )
                     strict_replace = _env_flag(
                         "STRICT_CANDIDATE_REPLACEMENT", default=True
@@ -18818,9 +18931,17 @@ class StrategyRunner:
                         replacement_blocked_reason = "side_mismatch"
 
                     def _expiry_key(sym: str) -> str | None:
+                        normalized = normalize_symbol(sym).split(":", 1)[-1]
+                        side = self._contract_side_from_symbol(normalized)
+                        strike = self._extract_strike_from_symbol(normalized)
+                        if side in {"CE", "PE"} and strike is not None:
+                            strike_text = str(int(strike))
+                            suffix = f"{strike_text}{side}"
+                            if normalized.endswith(suffix):
+                                return normalized[: -len(suffix)]
                         match = re.search(
                             r"NIFTY(\d{1,2}[A-Z]{3})\d{4,5}(CE|PE)$",
-                            normalize_symbol(sym),
+                            normalized,
                         )
                         return match.group(1) if match else None
 
@@ -18908,6 +19029,10 @@ class StrategyRunner:
                             },
                         )
                         selected_symbol = original_symbol
+                    else:
+                        metadata["_runner_approved_replacement_symbol"] = (
+                            selected_symbol
+                        )
 
                 # The final order symbol, candidate, quote snapshot and premium plan
                 # are one atomic decision. A rejected replacement must never leak
@@ -19867,7 +19992,11 @@ class StrategyRunner:
             order_symbol = trade_symbol or signal.symbol or base_symbol
             readiness_snapshot = self._option_side_readiness_snapshot()
             contract_mismatch = self._candidate_contract_mismatch_details(
-                order_symbol, snapshot=readiness_snapshot
+                order_symbol,
+                snapshot=readiness_snapshot,
+                approved_replacement_symbol=metadata.get(
+                    "_runner_approved_replacement_symbol"
+                ),
             )
             if contract_mismatch is not None:
                 self._logger.warning(

--- a/tests/strategies/test_candidate_specific_option_readiness.py
+++ b/tests/strategies/test_candidate_specific_option_readiness.py
@@ -464,3 +464,119 @@ def test_entry_path_uses_one_readiness_snapshot_for_candidate_decision(monkeypat
     assert calls["gate"] == 1
     assert snapshot_calls["count"] == 1
     assert len(runner._order_manager.plans) == 1
+
+
+def test_live_candidate_selection_skips_unaffordable_ranked_contract() -> None:
+    """A valid cheaper same-side candidate must survive the capital screen."""
+    runner = object.__new__(StrategyRunner)
+    runner._logger = _Logger()
+    runner._order_manager = SimpleNamespace(
+        _margin_factor=1.1,
+        _margin_buffer=0.9,
+        resolve_lot_size=lambda _symbol: 65,
+    )
+    runner._data_hub = SimpleNamespace(
+        get_available_balance=lambda force=False: 11_381.0
+    )
+    runner._risk_manager = SimpleNamespace(available_balance=11_381.0)
+    runner._is_symbol_execution_ready = lambda _symbol: False
+    runner._ensure_symbol_execution_ready_for_order = (
+        lambda _symbol, trace_id=None: True
+    )
+    expensive = SimpleNamespace(symbol="NFO:NIFTY2681124650CE")
+    affordable = SimpleNamespace(symbol="NFO:NIFTY2681124700CE")
+    snapshots = [
+        {
+            "symbol": expensive.symbol,
+            "bid": 146.75,
+            "ask": 147.10,
+            "ltp": 147.00,
+        },
+        {
+            "symbol": affordable.symbol,
+            "bid": 120.80,
+            "ask": 121.10,
+            "ltp": 121.00,
+        },
+    ]
+
+    selected, decisions = runner._select_capital_eligible_candidate(
+        ranked_candidates=[expensive, affordable],
+        candidate_snapshots=snapshots,
+        is_live_mode=True,
+        trace_id="trace-capital",
+    )
+
+    assert selected is affordable
+    assert decisions[expensive.symbol]["reason"] == "minimum_lot_unaffordable"
+    assert decisions[expensive.symbol]["affordable"] is False
+    assert decisions[affordable.symbol]["affordable"] is True
+
+
+def test_live_candidate_selection_fails_closed_when_capacity_is_unknown() -> None:
+    runner = object.__new__(StrategyRunner)
+    runner._logger = _Logger()
+    runner._order_manager = SimpleNamespace(
+        _margin_factor=1.1,
+        _margin_buffer=0.9,
+        resolve_lot_size=lambda _symbol: 65,
+    )
+    runner._data_hub = None
+    runner._risk_manager = SimpleNamespace(available_balance=None)
+    runner._is_symbol_execution_ready = lambda _symbol: True
+    runner._ensure_symbol_execution_ready_for_order = (
+        lambda _symbol, trace_id=None: True
+    )
+    candidate = SimpleNamespace(symbol="NFO:NIFTY2681124700CE")
+
+    selected, decisions = runner._select_capital_eligible_candidate(
+        ranked_candidates=[candidate],
+        candidate_snapshots=[
+            {"symbol": candidate.symbol, "bid": 120.80, "ask": 121.10}
+        ],
+        is_live_mode=True,
+        trace_id="trace-unknown-capital",
+    )
+
+    assert selected is None
+    assert decisions[candidate.symbol]["reason"] == "available_balance_unavailable"
+    assert decisions[candidate.symbol]["determinate"] is False
+
+
+def test_final_contract_gate_accepts_only_runner_approved_replacement() -> None:
+    runner = object.__new__(StrategyRunner)
+    selected_ce = "NFO:NIFTY2681124650CE"
+    selected_pe = "NFO:NIFTY2681124650PE"
+    replacement = "NFO:NIFTY2681124700CE"
+    runner._market_data = SimpleNamespace(
+        _token_by_symbol={selected_ce: 1, selected_pe: 2, replacement: 3}
+    )
+    snapshot = {
+        "CE": OptionSideReadiness(
+            "CE", selected_ce, 1, True, True, True, 50, 50, True, True, ()
+        ),
+        "PE": OptionSideReadiness(
+            "PE", selected_pe, 2, True, True, True, 50, 50, True, True, ()
+        ),
+    }
+
+    assert (
+        runner._candidate_contract_mismatch_details(replacement, snapshot=snapshot)
+        is not None
+    )
+    assert (
+        runner._candidate_contract_mismatch_details(
+            replacement,
+            snapshot=snapshot,
+            approved_replacement_symbol=replacement,
+        )
+        is None
+    )
+    assert (
+        runner._candidate_contract_mismatch_details(
+            "NFO:NIFTY2681124750CE",
+            snapshot=snapshot,
+            approved_replacement_symbol=replacement,
+        )
+        is not None
+    )

--- a/tests/test_bracket_reanchor.py
+++ b/tests/test_bracket_reanchor.py
@@ -75,6 +75,22 @@ async def test_distance_bracket_reanchors_even_while_old_levels_remain_valid() -
     assert out.take_profit == 141.0
 
 
+async def test_reanchor_is_labelled_as_pre_submit_plan_adjustment(caplog) -> None:
+    plan = _plan("BUY", entry=130.0, sl=125.0, tp=140.0)
+
+    with caplog.at_level(logging.INFO, logger="reanchor-test"):
+        _reanchor(plan, 131.0)
+
+    record = next(
+        item
+        for item in caplog.records
+        if "TRADE_PLAN_BRACKET_REANCHORED" in item.getMessage()
+    )
+    assert record.levelno == logging.INFO
+    assert "stage=pre_submit" in record.getMessage()
+    assert "broker_attempted=False" in record.getMessage()
+
+
 async def test_absolute_invalidation_passes_through_unchanged() -> None:
     plan = _plan(
         "BUY",


### PR DESCRIPTION
## Root cause

The 6 Aug production trace reached valid CE entry planning but selected the unaffordable 24650 CE (₹10,521 required) and stopped at the correct pre-broker margin gate, even though the already-ranked, fresh, same-expiry 24700 CE required only about ₹8,659. Candidate ranking did not apply the canonical minimum-lot affordability calculation, candidate replacement was disabled by default, and the final selected-contract gate could not recognize a replacement that had passed the runner's strict guards.

`BRACKET_REANCHORED` was also a misleading WARNING emitted while repricing a proposed trade plan before margin approval or broker submission; it did not represent a local or broker position.

## Fix

- Apply the existing minimum-lot affordability calculation to live ranked candidates, preserving ranking and failing closed when capital is indeterminate.
- Allow only runner-validated replacements by default, retaining same-side, same-expiry, active-basket, quote, ≤50-point strike and ≤35% premium-deviation guards.
- Stamp the exact approved replacement only after those checks; strip any incoming untrusted stamp and keep the final contract-integrity gate authoritative.
- Keep the order-manager margin check unchanged as the final pre-submit authority.
- Relabel plan repricing as `TRADE_PLAN_BRACKET_REANCHORED`, `stage=pre_submit`, `broker_attempted=False` at INFO.

## TDD / validation

- Exact observed capital regression: unaffordable 24650 CE is skipped for affordable same-side 24700 CE.
- Unknown capital fails closed.
- Arbitrary or forged replacement symbols fail the final contract gate.
- Pre-submit reanchor telemetry has the correct event, stage and severity.
- Focused and broad strategy/execution/risk suites passed.
- Live E2E coverage passed.
- Complete repository suite passed to 100% (one expected skip).
- Compile and diff-integrity checks passed.

No strategy-quality, risk, sizing, broker-position, or final margin safety rule is weakened.