### PR TITLE
Fix approved replacement preflight

### DIFF
--- a/src/nifty_scalper_bot/core/active_basket.py
+++ b/src/nifty_scalper_bot/core/active_basket.py
@@ -30,6 +30,7 @@ class ActiveContractSelection:
     option_symbols: tuple[str, ...] = ()
     token_by_symbol: Mapping[str, int] | None = None
     basket_version: str | None = None
+    expiry: str | None = None
     selected_at: str | None = None
     source: str = "active_contract_basket"
 
@@ -85,6 +86,12 @@ def active_contract_selection_from_basket(
         option_symbols=option_symbols,
         token_by_symbol=token_by_symbol,
         basket_version=str(_basket_get(basket, "basket_version", None) or _basket_get(basket, "version", None) or "") or None,
+        expiry=str(
+            _basket_get(basket, "expiry", None)
+            or _basket_get(basket, "contract_expiry", None)
+            or ""
+        )
+        or None,
         selected_at=str(_basket_get(basket, "selected_at", None) or _basket_get(basket, "committed_at", None) or "") or None,
         source="active_contract_basket",
     )

--- a/src/nifty_scalper_bot/execution/order_manager_core.py
+++ b/src/nifty_scalper_bot/execution/order_manager_core.py
@@ -4317,6 +4317,14 @@ class OrderManager:
 
     def _active_contract_for_trade_plan(self, plan: TradePlan) -> dict[str, Any] | None:
         symbol = normalize_symbol(plan.symbol)
+        provenance = (
+            plan.trade_provenance
+            if isinstance(plan.trade_provenance, Mapping)
+            else {}
+        )
+        approved_replacement = normalize_symbol(
+            str(provenance.get("runner_approved_replacement_symbol") or "")
+        )
         sources = (
             getattr(self, "_active_contract_basket", None),
             getattr(getattr(self, "_data_hub", None), "_active_contract_basket", None),
@@ -4339,7 +4347,13 @@ class OrderManager:
                         str(getattr(selection_obj, "selected_pe", "") or "")
                     ),
                 }
-                if symbol not in selected:
+                option_symbols = {
+                    normalize_symbol(str(item))
+                    for item in (getattr(selection_obj, "option_symbols", ()) or ())
+                }
+                if symbol not in selected and not (
+                    symbol == approved_replacement and symbol in option_symbols
+                ):
                     continue
                 token_by_symbol = getattr(selection_obj, "token_by_symbol", None) or {}
                 token = None
@@ -4365,11 +4379,18 @@ class OrderManager:
             if not isinstance(source, Mapping):
                 continue
             token_map = dict(source.get("token_by_symbol") or {})
-            selected = [source.get("selected_ce"), source.get("selected_pe")]
-            symbols = list(source.get("option_symbols") or source.get("symbols") or [])
-            if symbol not in {
-                normalize_symbol(str(x)) for x in [*selected, *symbols] if x
-            }:
+            selected = {
+                normalize_symbol(str(item))
+                for item in (source.get("selected_ce"), source.get("selected_pe"))
+                if item
+            }
+            option_symbols = {
+                normalize_symbol(str(item))
+                for item in (source.get("option_symbols") or source.get("symbols") or [])
+            }
+            if symbol not in selected and not (
+                symbol == approved_replacement and symbol in option_symbols
+            ):
                 continue
             token = token_map.get(symbol) or token_map.get(symbol.split(":", 1)[-1])
             if symbol == normalize_symbol(str(source.get("selected_ce") or "")):

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -20231,6 +20231,15 @@ class StrategyRunner:
                     "entry_quote_ask": selected_snapshot.get("ask"),
                     "decision_ts": now_epoch,
                     "entry_submit_ts": _entry_submit_ts,
+                    **(
+                        {
+                            "runner_approved_replacement_symbol": metadata[
+                                "_runner_approved_replacement_symbol"
+                            ]
+                        }
+                        if metadata.get("_runner_approved_replacement_symbol")
+                        else {}
+                    ),
                 },
             )
             self._logger.info(

--- a/tests/execution/test_trade_plan_identity_guard.py
+++ b/tests/execution/test_trade_plan_identity_guard.py
@@ -6,6 +6,7 @@ import nifty_scalper_bot.execution  # noqa: F401 - applies runtime safety patche
 from nifty_scalper_bot.execution import order_manager_core as core
 
 GOOD_SYMBOL = "NFO:NIFTY2670724250PE"
+ALTERNATIVE_SYMBOL = "NFO:NIFTY2670724200PE"
 BAD_SYMBOL = "NFO:NIFTY2670724300PE"
 
 
@@ -199,6 +200,86 @@ def test_live_trade_plan_requires_active_basket_before_broker_attempt(
     assert result.allowed is False
     assert result.reason == "active_contract_unavailable"
     assert result.details["broker_attempted"] is False
+
+
+def test_live_trade_plan_allows_runner_approved_active_basket_replacement() -> None:
+    manager = _Manager(
+        {"tradingsymbol": "NIFTY2670724200PE"},
+        active_basket={
+            "selected_pe": "NIFTY2670724250PE",
+            "option_symbols": [GOOD_SYMBOL, ALTERNATIVE_SYMBOL],
+            "basket_version": "7",
+            "expiry": "2026-07-30",
+            "token_by_symbol": {GOOD_SYMBOL: 12345, ALTERNATIVE_SYMBOL: 54321},
+        },
+    )
+    plan = _plan(ALTERNATIVE_SYMBOL)
+    plan.instrument_token = 54321
+    plan.trade_provenance["runner_approved_replacement_symbol"] = ALTERNATIVE_SYMBOL
+
+    result = core.OrderManager._validate_trade_plan(manager, plan)
+
+    assert result.allowed is True
+
+
+def test_live_trade_plan_rejects_unapproved_active_basket_replacement() -> None:
+    manager = _Manager(
+        {"tradingsymbol": "NIFTY2670724200PE"},
+        active_basket={
+            "selected_pe": "NIFTY2670724250PE",
+            "option_symbols": [GOOD_SYMBOL, ALTERNATIVE_SYMBOL],
+            "basket_version": "7",
+            "expiry": "2026-07-30",
+            "token_by_symbol": {GOOD_SYMBOL: 12345, ALTERNATIVE_SYMBOL: 54321},
+        },
+    )
+    plan = _plan(ALTERNATIVE_SYMBOL)
+    plan.instrument_token = 54321
+
+    result = core.OrderManager._validate_trade_plan(manager, plan)
+
+    assert result.allowed is False
+    assert result.reason == "active_contract_unavailable"
+
+
+def test_approved_replacement_reaches_order_adapter() -> None:
+    manager = _Manager(
+        {"tradingsymbol": "NIFTY2670724200PE"},
+        active_basket={
+            "selected_pe": "NIFTY2670724250PE",
+            "option_symbols": [GOOD_SYMBOL, ALTERNATIVE_SYMBOL],
+            "basket_version": "7",
+            "expiry": "2026-07-30",
+            "token_by_symbol": {GOOD_SYMBOL: 12345, ALTERNATIVE_SYMBOL: 54321},
+        },
+    )
+    manager.is_kill_switch_active = lambda: False  # type: ignore[attr-defined]
+    manager._validate_trade_plan = lambda plan: core.OrderManager._validate_trade_plan(  # type: ignore[attr-defined]
+        manager, plan
+    )
+    manager._protected_limit_price = lambda _plan: 88.25  # type: ignore[attr-defined]
+    manager._reanchor_bracket_to_price = lambda plan, _price: plan  # type: ignore[attr-defined]
+    captured: dict[str, Any] = {}
+    manager.place_managed_order = lambda **_kwargs: None  # type: ignore[attr-defined]
+    manager.place_managed_order_result = lambda **kwargs: (  # type: ignore[attr-defined]
+        captured.update(kwargs)
+        or core.ManagedOrderResult(
+            accepted=True,
+            order_id="OID-REPLACEMENT",
+            reason="accepted",
+            broker_attempted=True,
+        )
+    )
+    plan = _plan(ALTERNATIVE_SYMBOL)
+    plan.instrument_token = 54321
+    plan.trade_provenance["runner_approved_replacement_symbol"] = ALTERNATIVE_SYMBOL
+
+    result = core.OrderManager.submit_trade_plan_result(manager, plan)
+
+    assert result.accepted is True
+    assert result.order_id == "OID-REPLACEMENT"
+    assert captured["symbol"] == ALTERNATIVE_SYMBOL
+    assert captured["instrument_token"] == 54321
 
 
 def test_live_trade_plan_rejects_more_than_one_lot_when_runtime_max_is_one(


### PR DESCRIPTION
## Root cause

PR #1041 correctly selected an affordable same-side contract, but order-manager preflight rebuilt `ActiveContractSelection` and authorized only `selected_ce`/`selected_pe`. The normalized selection also dropped expiry, so the runner and execution layer had contradictory contract authority.

## Change

- carry the runner's strictly validated replacement symbol into `TradePlan.trade_provenance` after untrusted signal metadata has been removed
- authorize that exact symbol only when it is still in the active basket
- retain token, basket-version, expiry, lot-size, quote-identity, margin, and broker gates
- preserve canonical selected-contract behavior
- retain expiry in `ActiveContractSelection`

## Validation

- regression proved current `main` rejected the approved replacement as `active_contract_unavailable`
- focused identity and candidate-readiness tests passed
- approved replacement reaches the managed-order adapter
- identical unapproved basket member remains rejected
- core, execution, risk, and strategy suites passed
- complete repository suite passed to 100% with one expected skip
- production compilation and diff-integrity checks passed

No strategy thresholds, risk limits, lot sizing, margin policy, or broker placement logic changed.