### PR TITLE
Fix ORB restart and option-side safety

### DIFF
--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -13580,7 +13580,45 @@ class MarketDataManager:
                     min_rows=requested_bars,
                 )
                 fetched_rows = len(rows or [])
-                rows = list(rows or [])[-requested_bars:]
+                rows = list(rows or [])
+                recent_rows = rows[-requested_bars:]
+                # A mid-session tail cannot reconstruct the 09:15-09:45 range.
+                # Retain that small anchor alongside the normal recent window.
+                if (
+                    normalized.endswith(("CE", "PE"))
+                    and normalized_interval == "minute"
+                    and str(os.getenv("ORB_ENABLED", "true")).strip().lower()
+                    in {"1", "true", "yes", "on"}
+                    and rows
+                ):
+                    timestamped_rows = [
+                        (parsed[0], row)
+                        for row in rows
+                        if isinstance(row, Mapping)
+                        and (parsed := self._normalize_bar_timestamp(row)) is not None
+                    ]
+                    if timestamped_rows:
+                        latest_local = pd.Timestamp(timestamped_rows[-1][0]).tz_convert(
+                            "Asia/Kolkata"
+                        )
+                        session_open = latest_local.normalize() + pd.Timedelta(
+                            hours=9, minutes=15
+                        )
+                        cutoff = session_open + pd.Timedelta(minutes=30)
+                        opening_rows = [
+                            (timestamp, row)
+                            for timestamp, row in timestamped_rows
+                            if session_open
+                            <= pd.Timestamp(timestamp).tz_convert("Asia/Kolkata")
+                            <= cutoff
+                        ]
+                        recent_timestamped = timestamped_rows[-requested_bars:]
+                        retained = dict([*opening_rows, *recent_timestamped])
+                        rows = [retained[key] for key in sorted(retained)]
+                    else:
+                        rows = recent_rows
+                else:
+                    rows = recent_rows
                 import_reason: HistoryImportReason = (
                     "startup_bootstrap" if reason == "startup" else "hydration"
                 )

--- a/src/nifty_scalper_bot/strategies/elite_strategies/orb_pro.py
+++ b/src/nifty_scalper_bot/strategies/elite_strategies/orb_pro.py
@@ -11,7 +11,7 @@ LOGGER = get_logger(__name__)
 
 
 class ORBProStrategy(EliteStrategy):
-    """Opening range breakout strategy returning scored vote metadata."""
+    """Option-premium opening-range breakout returning scored vote metadata."""
 
     MIN_BARS_REQUIRED = 5
 
@@ -74,10 +74,18 @@ class ORBProStrategy(EliteStrategy):
                 LOGGER.debug('STRATEGY_NO_VOTE strategy=ORBPro reason=choppy_regime')
                 return None
 
-            breakout_side = 'CE' if close > orb_high else 'PE' if close < orb_low else 'UNKNOWN'
-            if breakout_side == 'UNKNOWN':
+            contract_side = (
+                'CE'
+                if symbol.upper().endswith('CE')
+                else 'PE' if symbol.upper().endswith('PE') else ''
+            )
+            if not contract_side:
+                self._no_vote('invalid_option_contract_side')
+                return None
+            if close <= orb_high:
                 self._no_vote('no_breakout')
                 return None
+            breakout_side = contract_side
 
             candle_range = max(abs(float(indicators.get('high') or close) - float(indicators.get('low') or close)), 1e-9)
             breakout_body_pct = abs(close - open_price) / candle_range
@@ -88,7 +96,7 @@ class ORBProStrategy(EliteStrategy):
 
             retest_confirmed = bool(indicators.get('retest_confirmed'))
             if not retest_confirmed:
-                retest_confirmed = abs(close - (orb_high if breakout_side == 'CE' else orb_low)) <= 0.35 * atr
+                retest_confirmed = abs(close - orb_high) <= 0.35 * atr
 
             score = 1.0 + 2.0
             reasons = ['opening_range_complete', 'breakout_close_beyond_range']
@@ -102,7 +110,7 @@ class ORBProStrategy(EliteStrategy):
             if vol_tick:
                 score += 1.0
                 reasons.append('volume_or_tick_confirmation')
-            stop_level = orb_low if breakout_side == 'CE' else orb_high
+            stop_level = orb_low
             risk = abs(close - stop_level)
             rr = (2.0 * atr) / risk if risk > 1e-9 else 0.0
             if rr >= 1.8:

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -1870,6 +1870,12 @@ class StrategyRunner:
 
     def _get_mdm_bars(self, symbol: str, limit: int) -> list[dict[str, Any]]:
         """Fetch cached bars from MDM/DataHub only. Args: symbol, limit. Returns: rows. Raises: None."""
+        # MDM retains only the opening-range anchor beyond the recent tail.
+        # Keep it when ORB is enabled so IndicatorEngine can restore ORB state.
+        retain_orb_anchor = bool(
+            normalize_symbol(symbol).endswith(("CE", "PE"))
+            and _env_bool("ORB_ENABLED", True)
+        )
         for source in (self._market_data, self._data_hub):
             if source is None:
                 continue
@@ -1879,11 +1885,18 @@ class StrategyRunner:
                     continue
                 try:
                     try:
-                        bars = fn(symbol, limit=limit)
+                        bars = (
+                            fn(symbol)
+                            if retain_orb_anchor
+                            else fn(symbol, limit=limit)
+                        )
                     except TypeError:
                         bars = fn(symbol)
                     if bars:
-                        return [dict(row) for row in list(bars)[-limit:]]
+                        selected = (
+                            list(bars) if retain_orb_anchor else list(bars)[-limit:]
+                        )
+                        return [dict(row) for row in selected]
                 except Exception:
                     continue
         return []

--- a/tests/data/test_canonical_history_hydration.py
+++ b/tests/data/test_canonical_history_hydration.py
@@ -108,6 +108,45 @@ async def test_minimum_met_but_target_cold_fetches_target() -> None:
 
 
 @pytest.mark.asyncio
+async def test_option_hydration_retains_opening_range_after_mid_session_restart(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("ORB_ENABLED", "true")
+    mdm = _mdm([])
+    session_open = datetime(2026, 8, 6, 3, 45, tzinfo=timezone.utc)
+    rows = [
+        {
+            "timestamp": session_open + timedelta(minutes=i),
+            "open": 100.0,
+            "high": 101.0 + i,
+            "low": 99.0,
+            "close": 100.5,
+            "volume": 10,
+        }
+        for i in range(321)
+    ]
+    async def fetch(*_a, **_k):
+        return rows
+
+    mdm.fetch_history = fetch
+
+    result = await mdm.ensure_history(
+        "NFO:NIFTY2680624500CE",
+        required_bars=50,
+        target_bars=75,
+        reason="mid_session_restart",
+    )
+    retained = mdm._test_store["rows"]
+
+    assert result.minimum_ready is True
+    assert retained[0]["timestamp"] == session_open
+    assert any(
+        row["timestamp"] == session_open + timedelta(minutes=30) for row in retained
+    )
+    assert retained[-1]["timestamp"] == rows[-1]["timestamp"]
+
+
+@pytest.mark.asyncio
 async def test_minimum_only_skips_when_minimum_met() -> None:
     mdm = _mdm(_rows(30))
 

--- a/tests/strategies/test_canonical_runner_history_sync.py
+++ b/tests/strategies/test_canonical_runner_history_sync.py
@@ -510,6 +510,38 @@ async def test_selected_option_with_canonical_source_warm_indicator_short_reseed
     assert result.indicator_bars >= 30
 
 
+async def test_option_sync_carries_retained_opening_range_into_indicators(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("ORB_ENABLED", "true")
+    rows = _bars(106)
+    session_open = datetime(2026, 8, 6, 3, 45, tzinfo=timezone.utc)
+    for index, row in enumerate(rows):
+        row["timestamp"] = session_open + timedelta(minutes=index)
+    r = _runner(rows)
+    r._market_data = SimpleNamespace(
+        get_ohlc_bars=lambda _symbol, **_kwargs: list(rows)
+    )
+    r._data_hub = None
+    r._get_mdm_bars = StrategyRunner._get_mdm_bars.__get__(r, StrategyRunner)
+
+    result = r.sync_history_from_mdm(
+        "NFO:NIFTY26JUN24000CE",
+        required_bars=75,
+        reason="mid_session_restart",
+        role="selected_option",
+        request_if_short=False,
+    )
+
+    assert result.success is True
+    assert result.mdm_bars == 106
+    assert result.indicator_bars == 106
+    indicators = r._indicator_engine.get_indicators(
+        "NFO:NIFTY26JUN24000CE", {"orb_ready", "orb_high", "orb_low"}
+    )
+    assert indicators["orb_ready"] is True
+
+
 async def test_indicator_equal_to_short_source_remains_not_ready_without_false_success() -> (
     None
 ):

--- a/tests/strategies/test_elite_builder_mode.py
+++ b/tests/strategies/test_elite_builder_mode.py
@@ -88,6 +88,60 @@ def test_orb_setup_identity_is_runner_owned_and_stable(
     assert first.metadata["liquidity_score"] == 2.0
 
 
+def test_orb_pe_premium_breakout_uses_contract_side() -> None:
+    strategy = ORBProStrategy(
+        ORBProStrategyConfig(min_confidence=0.0), indicator_engine=None
+    )
+    indicators = {
+        "orb_ready": True,
+        "orb_high": 105.0,
+        "orb_low": 95.0,
+        "open": 104.0,
+        "high": 111.0,
+        "low": 103.0,
+        "close": 110.0,
+        "atr": 5.0,
+        "volume": 1000.0,
+        "avg_volume": 900.0,
+        "underlying_direction_bias": "PE",
+        "regime": "TREND_DOWN",
+        "latest_bar_ts": 1_785_000_000.0,
+        "session_date": "2026-08-03",
+    }
+
+    signal = strategy.generate_signal("NFO:NIFTY2680724500PE", indicators, 110.0)
+
+    assert signal is not None
+    assert signal.metadata["contract_side"] == "PE"
+    assert signal.metadata["breakout_side"] == "PE"
+    assert signal.stop_loss == 95.0
+
+
+def test_orb_option_premium_breakdown_does_not_create_buy_vote() -> None:
+    strategy = ORBProStrategy(
+        ORBProStrategyConfig(min_confidence=0.0), indicator_engine=None
+    )
+    indicators = {
+        "orb_ready": True,
+        "orb_high": 105.0,
+        "orb_low": 95.0,
+        "open": 96.0,
+        "high": 97.0,
+        "low": 89.0,
+        "close": 90.0,
+        "atr": 5.0,
+        "volume": 1000.0,
+        "avg_volume": 900.0,
+        "underlying_direction_bias": "PE",
+        "regime": "TREND_DOWN",
+        "latest_bar_ts": 1_785_000_000.0,
+    }
+
+    signal = strategy.generate_signal("NFO:NIFTY2680724500PE", indicators, 90.0)
+
+    assert signal is None
+
+
 def test_production_profile_is_stable_and_changes_with_material_settings(
     monkeypatch,
 ) -> None:


### PR DESCRIPTION
## Root causes

1. Mid-session hydration fetched the opening-session bars but discarded them with a recent-tail slice. Runner history projection independently requested that same tail, leaving `orb_ready=False` for the rest of the session after restart.
2. ORB evaluated option premiums but mapped `close > orb_high` to CE and `close < orb_low` to PE. A rising PE premium was therefore mislabeled CE, while a falling PE premium could incorrectly create a BUY-PE vote.

## Change

- retain the current session's 09:15–09:45 anchor alongside the existing recent option-history window when ORB is enabled
- propagate that bounded retained history through the existing MDM → runner → IndicatorEngine path
- derive ORB vote side from the actual CE/PE contract
- permit only upward option-premium range breakouts; premium breakdowns remain no-vote
- keep the long-option stop anchored below entry at the option opening-range low
- preserve malformed-history rejection, recent-history readiness, and all downstream side/risk/execution gates

## Validation

- pre-fix tests reproduced all three failures: missing restart anchor, rising PE mislabeled CE, falling PE generating a BUY vote
- mid-session hydration now produces `orb_ready=True` in IndicatorEngine
- malformed/duplicate historical rows remain safely handled
- focused history/ORB regressions passed
- adjacent history ownership, runtime orchestration, strategy observability, and context tests passed
- data, strategy, core, execution, and risk suites passed
- complete repository suite passed to 100% with one expected skip
- production compilation and diff-integrity checks passed

No score thresholds, risk limits, candidate selection, lot sizing, margin rules, or broker logic changed.