### PR TITLE
Fix futures VWAP slope context fallback

### DIFF
--- a/src/nifty_scalper_bot/core/strategy_manager.py
+++ b/src/nifty_scalper_bot/core/strategy_manager.py
@@ -2192,6 +2192,30 @@ class StrategyManager(_BaseStrategyManager):
             except (TypeError, ValueError):
                 return None
 
+        def _history_vwap_slope() -> float | None:
+            if role != "futures_context":
+                return None
+            getter = getattr(
+                getattr(self, "_indicator_engine", None),
+                "get_session_vwap_slope",
+                None,
+            )
+            if not callable(getter):
+                return None
+            try:
+                value = getter(symbol, lookback=3)
+            except Exception as exc:  # noqa: BLE001 - context remains fail-closed
+                log.debug(
+                    "FUTURES_CONTEXT_VWAP_SLOPE_FALLBACK_FAILED symbol=%s error=%s",
+                    symbol,
+                    exc,
+                )
+                return None
+            try:
+                return float(value) if value is not None else None
+            except (TypeError, ValueError):
+                return None
+
         context_kind = (
             "price_direction"
             if role == "spot_context"
@@ -2222,6 +2246,10 @@ class StrategyManager(_BaseStrategyManager):
         ema_slow_source = "indicator" if ema_slow is not None else "unavailable"
         ema_50_source = "indicator" if ema_50 is not None else "unavailable"
         if role == "futures_context":
+            if vwap_slope is None:
+                vwap_slope = _history_vwap_slope()
+                if vwap_slope is not None:
+                    vwap_slope_source = "indicator_engine_history"
             if ema_fast is None:
                 ema_fast = _history_ema(9)
                 if ema_fast is not None:

--- a/src/nifty_scalper_bot/strategies/indicators.py
+++ b/src/nifty_scalper_bot/strategies/indicators.py
@@ -995,6 +995,53 @@ class IndicatorEngine:
         except Exception:  # noqa: BLE001 - indicator pipeline must not crash
             return None
 
+    def get_session_vwap_slope(
+        self, symbol: str, *, lookback: int = 3
+    ) -> float | None:
+        """Return percentage change in session VWAP over finalized volume bars."""
+        try:
+            with self._lock:
+                history = self._histories.get(symbol)
+            if history is None or lookback < 1:
+                return None
+            timestamps = history.get_timestamps()
+            if not timestamps:
+                return None
+            session_open, _session_close = self._session_bounds(timestamps[-1])
+            closes = history.get_closes()
+            highs = history.get_highs()
+            lows = history.get_lows()
+            volumes = history.get_volumes()
+            provisional = history.get_provisional_flags()
+            cumulative_vwaps: list[float] = []
+            cum_pv = 0.0
+            cum_vol = 0.0
+            for index, stamp in enumerate(timestamps):
+                if stamp is None or stamp < session_open:
+                    continue
+                if provisional and index < len(provisional) and provisional[index]:
+                    continue
+                if index >= len(volumes) or index >= len(closes):
+                    continue
+                volume = float(volumes[index] or 0.0)
+                if volume <= 0:
+                    continue
+                close = float(closes[index])
+                high = float(highs[index]) if index < len(highs) else close
+                low = float(lows[index]) if index < len(lows) else close
+                cum_pv += ((high + low + close) / 3.0) * volume
+                cum_vol += volume
+                cumulative_vwaps.append(cum_pv / cum_vol)
+            if len(cumulative_vwaps) <= lookback:
+                return None
+            current = cumulative_vwaps[-1]
+            reference = cumulative_vwaps[-(lookback + 1)]
+            if reference <= 0:
+                return None
+            return ((current / reference) - 1.0) * 100.0
+        except Exception:  # noqa: BLE001 - indicator pipeline must not crash
+            return None
+
     def get_atr_trend(self, symbol: str, period: int = 14) -> float | None:
         """Return ATR trend ratio for *symbol*.
 

--- a/tests/core/test_strategy_manager_context_age.py
+++ b/tests/core/test_strategy_manager_context_age.py
@@ -85,3 +85,35 @@ def test_futures_context_uses_hydrated_history_when_ema_aliases_are_absent() -> 
     assert snapshot["ema_50_source"] == "indicator_engine_history"
     assert snapshot["direction_bias"] == "CE"
     assert "ema_fast_above_slow" in snapshot["direction_context_reasons"]
+
+
+def test_futures_context_derives_current_vwap_slope_from_hydrated_history() -> None:
+    from datetime import datetime, timedelta, timezone
+
+    from nifty_scalper_bot.strategies.indicators import IndicatorEngine
+
+    symbol = "NFO:NIFTY26AUGFUT"
+    engine = IndicatorEngine()
+    started_at = datetime(2026, 8, 5, 3, 45, tzinfo=timezone.utc)
+    for index in range(10):
+        price = 25000.0 + float(index)
+        engine.update_price(
+            symbol,
+            {"open": price, "high": price, "low": price, "close": price},
+            volume=100,
+            timestamp=started_at + timedelta(minutes=index),
+        )
+
+    manager = object.__new__(StrategyManager)
+    manager._indicator_engine = engine
+    manager._latest_context_snapshots = {}
+    manager._update_context_snapshot(
+        symbol=symbol,
+        indicators={"ltp": 25009.0, "close": 25009.0},
+        role="futures_context",
+    )
+
+    snapshot = manager._latest_context_snapshots["futures_context"]
+    assert snapshot["vwap_slope"] > 0
+    assert snapshot["vwap_slope_source"] == "indicator_engine_history"
+    assert "vwap_slope_positive" in snapshot["direction_context_reasons"]

--- a/tests/strategies/test_session_vwap.py
+++ b/tests/strategies/test_session_vwap.py
@@ -56,6 +56,22 @@ def test_zero_volume_series_yields_no_vwap() -> None:
     assert engine.get_session_vwap("NFO:NIFTY2680424400CE") is None
 
 
+def test_session_vwap_slope_uses_finalized_positive_volume_bars() -> None:
+    engine = _engine_with_bars([_session_bar(i, 100.0 + i, 100) for i in range(5)])
+
+    # Session VWAP progresses 100.0, 100.5, ..., 102.0.  Three bars back it
+    # was 100.5, so the percentage slope is (102 / 100.5 - 1) * 100.
+    assert engine.get_session_vwap_slope(
+        "NFO:NIFTY2680424400CE", lookback=3
+    ) == pytest.approx((102.0 / 100.5 - 1.0) * 100.0)
+
+
+def test_session_vwap_slope_fails_closed_without_enough_volume_history() -> None:
+    engine = _engine_with_bars([_session_bar(0, 100.0, 100), _session_bar(1, 101.0, 0)])
+
+    assert engine.get_session_vwap_slope("NFO:NIFTY2680424400CE", lookback=1) is None
+
+
 def test_unvolumed_bars_do_not_get_fake_weights() -> None:
     engine = IndicatorEngine()
     # Only the second bar carries volume, so it alone defines VWAP.


### PR DESCRIPTION
## Root cause
Futures context snapshots copied `vwap_slope` only when the incoming evaluation supplied it. Hydrated futures OHLCV was already available, but unlike EMA values there was no history fallback, leaving VWAPPro without futures-slope confirmation after restart.

## Fix
- derive a fresh three-finalized-bar percentage slope from session-anchored VWAP
- use it only for futures context when the current evaluation omits an explicit slope
- retain explicit-indicator precedence and fail closed for short, provisional, or zero-volume history
- preserve final strategy, quality, risk, capital, and order-manager gates

## TDD / validation
- red regressions confirmed the missing indicator API and absent manager fallback
- focused session-VWAP and context tests pass
- all strategy and core tests pass
- complete repository suite passes to 100% with one expected skip
- compilation and diff-integrity checks pass

No strategy threshold, score weight, risk limit, sizing rule, broker path, or order-state behavior changed.