### PR TITLE
Relax proven-flat reconciliation cadence

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -14730,7 +14730,9 @@ async def startup_sequence(ctx: BotContext) -> None:
                         is_market_open as _imo,
                     )
 
-                    await asyncio.sleep(15 if _imo() else 120)
+                    await asyncio.sleep(
+                        _reconciliation_sleep_seconds(ctx, market_open=_imo())
+                    )
 
             asyncio.create_task(_sync_loop())
             asyncio.create_task(_live_readiness_rearm_loop(ctx))
@@ -15127,6 +15129,35 @@ def _should_reconcile_now(ctx: BotContext) -> bool:
         return False
     except Exception:  # noqa: BLE001 - never let the guard break the loop
         return True
+
+
+def _reconciliation_sleep_seconds(ctx: BotContext, *, market_open: bool) -> float:
+    """Use a relaxed cadence only for a proven flat, settled live state."""
+    if not market_open:
+        return 120.0
+    if (
+        bool(getattr(ctx, "position_reconciliation_failed", False))
+        or bool(getattr(ctx, "unresolved_reconciliation_symbols", set()))
+        or bool(getattr(ctx, "unprotected_broker_positions", set()))
+        or bool(getattr(ctx, "unprotected_broker_position", False))
+    ):
+        return 15.0
+    try:
+        manager = ctx.position_manager
+        if manager is None or list(manager.get_open_positions()):
+            return 15.0
+        pending_getter = getattr(manager, "get_pending_orders", None)
+        if not callable(pending_getter) or list(pending_getter()):
+            return 15.0
+    except Exception:  # noqa: BLE001 - uncertainty retains the safety cadence
+        return 15.0
+    try:
+        configured = float(os.getenv("HEALTH_FLAT_RECONCILE_INTERVAL_SEC", "60"))
+    except (TypeError, ValueError):
+        configured = 60.0
+    max_age = _reconciliation_max_age_seconds()
+    freshness_cap = max_age / 2.0 if max_age > 0 else 60.0
+    return max(15.0, min(configured, freshness_cap))
 
 
 def _reconcile_flat_exit_brackets(ctx: BotContext) -> int:

--- a/tests/core/test_should_reconcile_now.py
+++ b/tests/core/test_should_reconcile_now.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 import types
 from unittest.mock import patch
 
-from nifty_scalper_bot.core.app import _should_reconcile_now
+from nifty_scalper_bot.core.app import (
+    _reconciliation_sleep_seconds,
+    _should_reconcile_now,
+)
 
 
 def _ctx(open_positions):
@@ -34,3 +37,42 @@ async def test_disabled_always_reconciles(monkeypatch):
     monkeypatch.setenv("HEALTH_RECONCILE_SKIP_WHEN_CLOSED", "false")
     with patch("nifty_scalper_bot.risk.session_gate._is_market_open", return_value=False):
         assert _should_reconcile_now(_ctx([])) is True
+
+
+def test_flat_market_open_reconciliation_uses_relaxed_cadence(monkeypatch):
+    monkeypatch.delenv("HEALTH_FLAT_RECONCILE_INTERVAL_SEC", raising=False)
+    ctx = types.SimpleNamespace(
+        position_reconciliation_failed=False,
+        unresolved_reconciliation_symbols=set(),
+        unprotected_broker_positions=set(),
+        unprotected_broker_position=False,
+        position_manager=types.SimpleNamespace(
+            get_open_positions=lambda: [], get_pending_orders=lambda: []
+        ),
+    )
+
+    assert _reconciliation_sleep_seconds(ctx, market_open=True) == 60.0
+
+
+def test_reconciliation_stays_rapid_for_exposure_pending_orders_or_uncertainty():
+    def _ctx_for(*, positions=(), pending=(), failed=False):
+        return types.SimpleNamespace(
+            position_reconciliation_failed=failed,
+            unresolved_reconciliation_symbols=set(),
+            unprotected_broker_positions=set(),
+            unprotected_broker_position=False,
+            position_manager=types.SimpleNamespace(
+                get_open_positions=lambda: list(positions),
+                get_pending_orders=lambda: list(pending),
+            ),
+        )
+
+    assert _reconciliation_sleep_seconds(
+        _ctx_for(positions=({"symbol": "NFO:NIFTYCE"},)), market_open=True
+    ) == 15.0
+    assert _reconciliation_sleep_seconds(
+        _ctx_for(pending=({"order_id": "1"},)), market_open=True
+    ) == 15.0
+    assert _reconciliation_sleep_seconds(
+        _ctx_for(failed=True), market_open=True
+    ) == 15.0


### PR DESCRIPTION
## Root cause
The dedicated broker order/position sync loop used a hard-coded 15-second sleep for every market-open cycle. Production remained flat and settled yet performed 42 reconciliations in about 10.6 minutes, each consuming 68–367 ms.

## Fix
- retain the 15-second cadence for open positions, pending orders, failed reconciliation, unresolved symbols, unprotected exposure, or any state-read error
- use a configurable 60-second default only after the refreshed state proves flat and has no pending order
- cap the relaxed interval at half the reconciliation freshness limit
- preserve the existing 120-second post-close cadence

## TDD / validation
- red tests confirmed there was no state-aware reconciliation scheduler
- focused cadence and reconciliation lifecycle tests pass
- all core, execution, and risk tests pass
- complete repository suite passes to 100% with one expected skip
- compilation and diff-integrity checks pass

No order, position, entry/exit safety, strategy, risk, or broker-state semantics changed.