### PR TITLE
Clarify approved candidate counters

### DIFF
--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -5314,7 +5314,7 @@ class StrategyRunner:
                 "runner_state": str(self._runner_state),
                 "active_symbols": sorted(self._active_symbols),
                 "symbols": symbols,
-                "signal_count": getattr(self, "_signal_counter", 0),
+                "approved_candidate_count": getattr(self, "_signal_counter", 0),
                 "tick_count": getattr(self, "_eval_counter", 0),
                 "last_tick_age_sec": (
                     round(time.monotonic() - self._last_tick_seen_ts, 1)
@@ -8152,7 +8152,7 @@ class StrategyRunner:
             self._emit_composite_reports()
             if now - self._last_summary_log >= 60.0:
                 self._logger.info(
-                    "ENGINE_SUMMARY evals=%d signals=%d regime_blocks=%d "
+                    "ENGINE_SUMMARY evals=%d approved_candidates=%d regime_blocks=%d "
                     "capital_blocks=%d runner_state=%s",
                     self._eval_counter,
                     self._signal_counter,
@@ -8161,7 +8161,7 @@ class StrategyRunner:
                     str(self._runner_state),
                     extra={
                         "evals": self._eval_counter,
-                        "signals": self._signal_counter,
+                        "approved_candidates": self._signal_counter,
                         "regime_blocks": self._regime_block_counter,
                         "capital_blocks": self._capital_block_counter,
                         "runner_state": str(self._runner_state),

--- a/tests/strategies/test_signal_observability_contract.py
+++ b/tests/strategies/test_signal_observability_contract.py
@@ -228,3 +228,15 @@ def test_orderflow_prefers_existing_quote_version(monkeypatch) -> None:
 
     assert result.metadata["quote_update_version"] == 42
     assert result.metadata["quote_update_version_source"] == "quote_update_version"
+
+
+def test_runner_candidate_counter_is_not_exposed_as_a_trade_signal_count() -> None:
+    import inspect
+
+    from nifty_scalper_bot.strategies.runner import StrategyRunner
+
+    source = inspect.getsource(StrategyRunner)
+    assert '"approved_candidate_count": getattr(self, "_signal_counter", 0)' in source
+    assert "ENGINE_SUMMARY evals=%d approved_candidates=%d" in source
+    assert '"signal_count": getattr(self, "_signal_counter", 0)' not in source
+    assert '"signals": self._signal_counter' not in source


### PR DESCRIPTION
## Root cause
The runner increments its minute counter when StrategyManager returns an approved candidate, before risk, order-manager, and broker outcomes, but exposed that value as `signal_count` and `ENGINE_SUMMARY ... signals=`. Rejected candidates could therefore look like trades.

## Fix
Rename only the external status and log fields to `approved_candidate_count` and `approved_candidates`. Internal timing, counters, strategy flow, metrics, and lifecycle events are unchanged.

## TDD / validation
- red observability regression reproduced the ambiguous labels
- focused signal and rejection observability tests pass
- complete repository suite passes to 100% with one expected skip
- diff-integrity checks pass

No strategy, risk, order, broker, position, or economic behavior changed.