### PR TITLE
Fix selected-option live evaluation after ATM basket change

### DIFF
--- a/src/nifty_scalper_bot/core/__init__.py
+++ b/src/nifty_scalper_bot/core/__init__.py
@@ -24,7 +24,9 @@ def _core_env_true(name: str) -> bool:
 
 def _real_live_mode_requested() -> bool:
     mode = str(os.getenv("EXECUTION_MODE", "SHADOW") or "SHADOW").strip().upper()
-    live_enabled = _core_env_true("ENABLE_LIVE") or _core_env_true("ENABLE_LIVE_TRADING")
+    live_enabled = _core_env_true("ENABLE_LIVE") or _core_env_true(
+        "ENABLE_LIVE_TRADING"
+    )
     paper_shadow = (
         _core_env_true("PAPER_MODE")
         or _core_env_true("PAPER__ENABLED")
@@ -43,7 +45,10 @@ except Exception as exc:  # noqa: BLE001 - non-live tooling imports should remai
     get_logger(__name__).error(
         "STRATEGY_LIVE_SAFETY_PATCH_FAILED error=%s",
         exc,
-        extra={"event": "STRATEGY_LIVE_SAFETY_PATCH_FAILED", "error_type": type(exc).__name__},
+        extra={
+            "event": "STRATEGY_LIVE_SAFETY_PATCH_FAILED",
+            "error_type": type(exc).__name__,
+        },
     )
     if _real_live_mode_requested():
         raise RuntimeError("strategy_live_safety_patch_failed") from exc
@@ -74,7 +79,10 @@ except Exception as exc:  # noqa: BLE001 - non-live tooling imports should remai
     get_logger(__name__).error(
         "STRATEGY_SETUP_SCORE_GATE_PATCH_FAILED error=%s",
         exc,
-        extra={"event": "STRATEGY_SETUP_SCORE_GATE_PATCH_FAILED", "error_type": type(exc).__name__},
+        extra={
+            "event": "STRATEGY_SETUP_SCORE_GATE_PATCH_FAILED",
+            "error_type": type(exc).__name__,
+        },
     )
     if _real_live_mode_requested():
         raise RuntimeError("strategy_setup_score_gate_patch_failed") from exc
@@ -89,7 +97,10 @@ except Exception as exc:  # noqa: BLE001 - core package import must not crash to
     get_logger(__name__).error(
         "BOOT_LOG_RATE_CONTROL_FAILED error=%s",
         exc,
-        extra={"event": "BOOT_LOG_RATE_CONTROL_FAILED", "error_type": type(exc).__name__},
+        extra={
+            "event": "BOOT_LOG_RATE_CONTROL_FAILED",
+            "error_type": type(exc).__name__,
+        },
     )
 
 __all__ = ["NiftyScalperApp", "canonical_price_source"]
@@ -131,15 +142,22 @@ def _install_market_data_runtime_hardening() -> dict[str, bool]:
     return state
 
 
-
 def _apply_app_runtime_patches(app_module: Any) -> None:
     # The production app import is the single authoritative installation point.
     # Do not require tests or callers to invoke market-data hardening manually.
     _install_market_data_runtime_hardening()
 
-    from nifty_scalper_bot.core.boot_readiness_safety import apply_app_patch as _ready_adapter
-    from nifty_scalper_bot.core.polling_failover_runtime import apply_app_patch as _polling_adapter
+    from nifty_scalper_bot.core.boot_readiness_safety import (
+        apply_app_patch as _ready_adapter,
+    )
+    from nifty_scalper_bot.core.polling_failover_runtime import (
+        apply_app_patch as _polling_adapter,
+    )
+    from nifty_scalper_bot.core.strategy_runner_dynamic_universe_safety import (
+        apply_patches as _dynamic_universe_adapter,
+    )
 
+    _dynamic_universe_adapter()
     _ready_adapter(app_module)
     _polling_adapter(app_module)
 
@@ -177,14 +195,18 @@ class _CoreAppPatchFinder(importlib.abc.MetaPathFinder):
         if fullname != _APP_MODULE_NAME:
             return None
         spec = importlib.machinery.PathFinder.find_spec(fullname, path)
-        if spec is None or spec.loader is None or isinstance(spec.loader, _CoreAppPatchLoader):
+        if spec is None or spec.loader is None or isinstance(
+            spec.loader, _CoreAppPatchLoader
+        ):
             return spec
         spec.loader = _CoreAppPatchLoader(spec.loader)
         return spec
 
 
 def _install_core_app_patch_import_hook() -> None:
-    if any(getattr(finder, _APP_IMPORT_HOOK_ATTR, False) for finder in sys.meta_path):
+    if any(
+        getattr(finder, _APP_IMPORT_HOOK_ATTR, False) for finder in sys.meta_path
+    ):
         return
     finder = _CoreAppPatchFinder()
     setattr(finder, _APP_IMPORT_HOOK_ATTR, True)

--- a/src/nifty_scalper_bot/core/__init__.py
+++ b/src/nifty_scalper_bot/core/__init__.py
@@ -24,9 +24,7 @@ def _core_env_true(name: str) -> bool:
 
 def _real_live_mode_requested() -> bool:
     mode = str(os.getenv("EXECUTION_MODE", "SHADOW") or "SHADOW").strip().upper()
-    live_enabled = _core_env_true("ENABLE_LIVE") or _core_env_true(
-        "ENABLE_LIVE_TRADING"
-    )
+    live_enabled = _core_env_true("ENABLE_LIVE") or _core_env_true("ENABLE_LIVE_TRADING")
     paper_shadow = (
         _core_env_true("PAPER_MODE")
         or _core_env_true("PAPER__ENABLED")
@@ -45,10 +43,7 @@ except Exception as exc:  # noqa: BLE001 - non-live tooling imports should remai
     get_logger(__name__).error(
         "STRATEGY_LIVE_SAFETY_PATCH_FAILED error=%s",
         exc,
-        extra={
-            "event": "STRATEGY_LIVE_SAFETY_PATCH_FAILED",
-            "error_type": type(exc).__name__,
-        },
+        extra={"event": "STRATEGY_LIVE_SAFETY_PATCH_FAILED", "error_type": type(exc).__name__},
     )
     if _real_live_mode_requested():
         raise RuntimeError("strategy_live_safety_patch_failed") from exc
@@ -79,10 +74,7 @@ except Exception as exc:  # noqa: BLE001 - non-live tooling imports should remai
     get_logger(__name__).error(
         "STRATEGY_SETUP_SCORE_GATE_PATCH_FAILED error=%s",
         exc,
-        extra={
-            "event": "STRATEGY_SETUP_SCORE_GATE_PATCH_FAILED",
-            "error_type": type(exc).__name__,
-        },
+        extra={"event": "STRATEGY_SETUP_SCORE_GATE_PATCH_FAILED", "error_type": type(exc).__name__},
     )
     if _real_live_mode_requested():
         raise RuntimeError("strategy_setup_score_gate_patch_failed") from exc
@@ -97,10 +89,7 @@ except Exception as exc:  # noqa: BLE001 - core package import must not crash to
     get_logger(__name__).error(
         "BOOT_LOG_RATE_CONTROL_FAILED error=%s",
         exc,
-        extra={
-            "event": "BOOT_LOG_RATE_CONTROL_FAILED",
-            "error_type": type(exc).__name__,
-        },
+        extra={"event": "BOOT_LOG_RATE_CONTROL_FAILED", "error_type": type(exc).__name__},
     )
 
 __all__ = ["NiftyScalperApp", "canonical_price_source"]
@@ -142,17 +131,14 @@ def _install_market_data_runtime_hardening() -> dict[str, bool]:
     return state
 
 
+
 def _apply_app_runtime_patches(app_module: Any) -> None:
     # The production app import is the single authoritative installation point.
     # Do not require tests or callers to invoke market-data hardening manually.
     _install_market_data_runtime_hardening()
 
-    from nifty_scalper_bot.core.boot_readiness_safety import (
-        apply_app_patch as _ready_adapter,
-    )
-    from nifty_scalper_bot.core.polling_failover_runtime import (
-        apply_app_patch as _polling_adapter,
-    )
+    from nifty_scalper_bot.core.boot_readiness_safety import apply_app_patch as _ready_adapter
+    from nifty_scalper_bot.core.polling_failover_runtime import apply_app_patch as _polling_adapter
     from nifty_scalper_bot.core.strategy_runner_dynamic_universe_safety import (
         apply_patches as _dynamic_universe_adapter,
     )
@@ -195,18 +181,14 @@ class _CoreAppPatchFinder(importlib.abc.MetaPathFinder):
         if fullname != _APP_MODULE_NAME:
             return None
         spec = importlib.machinery.PathFinder.find_spec(fullname, path)
-        if spec is None or spec.loader is None or isinstance(
-            spec.loader, _CoreAppPatchLoader
-        ):
+        if spec is None or spec.loader is None or isinstance(spec.loader, _CoreAppPatchLoader):
             return spec
         spec.loader = _CoreAppPatchLoader(spec.loader)
         return spec
 
 
 def _install_core_app_patch_import_hook() -> None:
-    if any(
-        getattr(finder, _APP_IMPORT_HOOK_ATTR, False) for finder in sys.meta_path
-    ):
+    if any(getattr(finder, _APP_IMPORT_HOOK_ATTR, False) for finder in sys.meta_path):
         return
     finder = _CoreAppPatchFinder()
     setattr(finder, _APP_IMPORT_HOOK_ATTR, True)

--- a/src/nifty_scalper_bot/core/strategy_runner_dynamic_universe_safety.py
+++ b/src/nifty_scalper_bot/core/strategy_runner_dynamic_universe_safety.py
@@ -1,0 +1,50 @@
+"""Keep StrategyRunner's frozen gate aligned with its dynamic active universe."""
+
+from __future__ import annotations
+
+from functools import wraps
+from typing import Any, Callable
+
+from nifty_scalper_bot.utils.symbols import normalize_symbol
+
+
+def apply_patches() -> None:
+    """Install the dynamic-universe admission fix once."""
+    from nifty_scalper_bot.strategies.runner import StrategyRunner
+
+    if getattr(StrategyRunner, "_dynamic_universe_safety_installed", False):
+        return
+
+    original: Callable[..., bool] = StrategyRunner._validate_symbol_for_cycle
+
+    @wraps(original)
+    def validate_symbol_for_cycle(self: Any, symbol: str) -> bool:
+        normalized = normalize_symbol(str(symbol or ""))
+        admitted = False
+        if normalized and bool(getattr(self, "_universe_dynamic_mode", False)):
+            lock = getattr(self, "_lock", None)
+            if lock is not None:
+                with lock:
+                    active = normalized in getattr(self, "_active_symbols", set())
+                    frozen = getattr(self, "_frozen_universe", None)
+                    if active and isinstance(frozen, set) and normalized not in frozen:
+                        frozen.add(normalized)
+                        admitted = True
+        if admitted:
+            self._logger.info(
+                "DYNAMIC_ACTIVE_SYMBOL_ADMITTED symbol=%s reason=active_universe_authority",
+                normalized,
+                extra={
+                    "event": "DYNAMIC_ACTIVE_SYMBOL_ADMITTED",
+                    "symbol": normalized,
+                    "reason": "active_universe_authority",
+                },
+            )
+        return original(self, normalized or symbol)
+
+    StrategyRunner._dynamic_universe_safety_original_validate = original
+    StrategyRunner._validate_symbol_for_cycle = validate_symbol_for_cycle
+    StrategyRunner._dynamic_universe_safety_installed = True
+
+
+__all__ = ["apply_patches"]

--- a/tests/strategies/test_selected_option_live_path.py
+++ b/tests/strategies/test_selected_option_live_path.py
@@ -38,13 +38,19 @@ def _wait_until(predicate, *, timeout=3.0):
 
 
 def test_live_selected_option_tick_reaches_strategy_manager_after_atm_switch(monkeypatch):
-    """A ready option promoted from context to selected must remain evaluable."""
+    """A dynamically selected option must not be blocked by the startup snapshot."""
     runner, strategy_manager, risk_manager, order_manager, old_ce = (
         _build_phase9_runner(monkeypatch)
     )
     old_pe = "NFO:NIFTY26JUN24000PE"
     selected_ce = "NFO:NIFTY26JUN24100CE"
     selected_pe = "NFO:NIFTY26JUN24100PE"
+
+    # Production starts with a frozen startup snapshot. Dynamic ATM selection
+    # later makes a previously contextual contract active; the startup snapshot
+    # must not veto that authoritative dynamic universe update.
+    runner._universe_dynamic_mode = True
+    runner._frozen_universe = {"NSE:NIFTY", old_ce, old_pe}
 
     for symbol in (old_pe, selected_ce, selected_pe):
         runner._active_symbols.add(symbol)

--- a/tests/strategies/test_selected_option_live_path.py
+++ b/tests/strategies/test_selected_option_live_path.py
@@ -7,6 +7,9 @@ import threading
 import time
 from datetime import datetime, timezone
 
+from nifty_scalper_bot.core.strategy_runner_dynamic_universe_safety import (
+    apply_patches,
+)
 from nifty_scalper_bot.strategies.runner import (
     EntryEvaluationRoute,
     SymbolRuntimeState,
@@ -39,6 +42,7 @@ def _wait_until(predicate, *, timeout=3.0):
 
 def test_live_selected_option_tick_reaches_strategy_manager_after_atm_switch(monkeypatch):
     """A dynamically selected option must not be blocked by the startup snapshot."""
+    apply_patches()
     runner, strategy_manager, risk_manager, order_manager, old_ce = (
         _build_phase9_runner(monkeypatch)
     )

--- a/tests/strategies/test_selected_option_live_path.py
+++ b/tests/strategies/test_selected_option_live_path.py
@@ -1,0 +1,104 @@
+"""Regression coverage for the live selected-option evaluation path."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+from datetime import datetime, timezone
+
+from nifty_scalper_bot.strategies.runner import (
+    EntryEvaluationRoute,
+    SymbolRuntimeState,
+    SymbolState,
+)
+from tests.strategies.test_runner_symbol_role_gate import _build_phase9_runner
+
+
+def _run_loop_in_thread():
+    loop = asyncio.new_event_loop()
+    thread = threading.Thread(target=loop.run_forever, daemon=True)
+    thread.start()
+    return loop, thread
+
+
+def _stop_loop(loop, thread):
+    loop.call_soon_threadsafe(loop.stop)
+    thread.join(timeout=2.0)
+    loop.close()
+
+
+def _wait_until(predicate, *, timeout=3.0):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.01)
+    return predicate()
+
+
+def test_live_selected_option_tick_reaches_strategy_manager_after_atm_switch(monkeypatch):
+    """A ready option promoted from context to selected must remain evaluable."""
+    runner, strategy_manager, risk_manager, order_manager, old_ce = (
+        _build_phase9_runner(monkeypatch)
+    )
+    old_pe = "NFO:NIFTY26JUN24000PE"
+    selected_ce = "NFO:NIFTY26JUN24100CE"
+    selected_pe = "NFO:NIFTY26JUN24100PE"
+
+    for symbol in (old_pe, selected_ce, selected_pe):
+        runner._active_symbols.add(symbol)
+        runner._tracked_symbols.add(symbol)
+        runner._history_ready_by_symbol[symbol] = True
+        runner._data_phase[symbol] = "LIVE"
+        runner._symbol_history[symbol] = [{"timestamp": time.time()}]
+        runner._last_bar_ts[symbol] = datetime.now(timezone.utc)
+        runner._symbol_state[symbol] = SymbolRuntimeState(symbol, 100)
+        runner._symbol_state[symbol].active = True
+        runner._symbol_states[symbol] = SymbolState.READY
+        runner._active_basket_token_by_symbol[symbol] = 1
+
+    runner.set_active_option_context(
+        selected_ce=selected_ce,
+        selected_pe=selected_pe,
+        atm_strike=24100,
+        option_symbols=[old_ce, old_pe, selected_ce, selected_pe],
+    )
+    runner._refresh_underlying_context_snapshots = lambda **_kwargs: None
+    runner._get_cached_quote_for_live_entry = lambda _symbol: {
+        "symbol": _symbol,
+        "ltp": 100.0,
+        "last_price": 100.0,
+        "bid": 99.5,
+        "ask": 100.5,
+        "timestamp": time.time(),
+    }
+
+    assert runner._entry_evaluation_route(selected_ce) == EntryEvaluationRoute.OPTION_CANDIDATE
+
+    loop, thread = _run_loop_in_thread()
+    runner.attach_runtime_loop(loop)
+    try:
+        runner._on_tick_safe(
+            {
+                "symbol": selected_ce,
+                "last_price": 100.0,
+                "ltp": 100.0,
+                "bid": 99.5,
+                "ask": 100.5,
+                "timestamp": time.time(),
+                "source": "ws",
+                "trace_id": "selected-option-live-path",
+            }
+        )
+
+        assert _wait_until(
+            lambda: any(
+                call.args and call.args[0] == selected_ce
+                for call in strategy_manager.generate_signal.call_args_list
+            )
+        )
+        risk_manager.validate.assert_called()
+        order_manager.submit.assert_called()
+    finally:
+        _stop_loop(loop, thread)


### PR DESCRIPTION
## Problem

Production logs on 2026-08-07 showed the runner fully live-ready with fresh, history-ready, executable selected CE/PE contracts, while `STRATEGY_STATUS_REPORT` remained `symbols_evaluated=0` and no signal reached the order path.

## Root cause

`StrategyRunner` correctly updated the authoritative dynamic `_active_symbols` and selected ATM basket, but `_validate_symbol_for_cycle()` still enforced the startup `_frozen_universe` snapshot. A newly selected ATM contract could therefore be silently rejected before phase 9 and before `StrategyManager.generate_signal()`.

## Correction

- Admit a symbol into the frozen validation snapshot only when dynamic-universe mode is enabled and that symbol is already present in the authoritative active universe.
- Preserve the original validation path afterward, including quarantine, symbol cap, active-universe, history, quote, risk, broker, overload, market-hours and protective-exit checks.
- Install the correction through the repository's existing runtime-patch bootstrap.
- Add a production-path regression covering ATM selection change → WS tick → coalesced worker → StrategyManager → risk → order submission.

## TDD evidence

RED:
- `test_live_selected_option_tick_reaches_strategy_manager_after_atm_switch` failed because the selected option never called `StrategyManager.generate_signal()`.

GREEN:
- full repository test suite: passed
- changed-code compile/lint/format/typecheck: passed
- execution-safety regressions: passed
- live-runtime E2E: passed
- simulation component rerun: passed
- market-aware validation workflow: passed

## Scope control

No strategy threshold, profitability parameter, market-hours gate, data-overload gate, quote-freshness gate, affordability rule, risk rule, broker safety check or protective-exit behavior was relaxed.