### PR TITLE
Prevent off-market dynamic basket mutation

### DIFF
--- a/src/nifty_scalper_bot/core/__init__.py
+++ b/src/nifty_scalper_bot/core/__init__.py
@@ -138,12 +138,18 @@ def _apply_app_runtime_patches(app_module: Any) -> None:
     _install_market_data_runtime_hardening()
 
     from nifty_scalper_bot.core.boot_readiness_safety import apply_app_patch as _ready_adapter
+    from nifty_scalper_bot.core.off_market_basket_safety import (
+        apply_app_patch as _off_market_app_adapter,
+        apply_patches as _off_market_controller_adapter,
+    )
     from nifty_scalper_bot.core.polling_failover_runtime import apply_app_patch as _polling_adapter
     from nifty_scalper_bot.core.strategy_runner_dynamic_universe_safety import (
         apply_patches as _dynamic_universe_adapter,
     )
 
     _dynamic_universe_adapter()
+    _off_market_controller_adapter()
+    _off_market_app_adapter(app_module)
     _ready_adapter(app_module)
     _polling_adapter(app_module)
 

--- a/src/nifty_scalper_bot/core/off_market_basket_safety.py
+++ b/src/nifty_scalper_bot/core/off_market_basket_safety.py
@@ -1,0 +1,16 @@
+"""Off-market active-basket mutation guards."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def apply_patches() -> None:
+    """Install universe-controller guards. Implemented by the production fix."""
+
+
+def apply_app_patch(app_module: Any) -> None:
+    """Install app basket-commit guards. Implemented by the production fix."""
+
+
+__all__ = ["apply_app_patch", "apply_patches"]

--- a/src/nifty_scalper_bot/core/off_market_basket_safety.py
+++ b/src/nifty_scalper_bot/core/off_market_basket_safety.py
@@ -1,16 +1,91 @@
-"""Off-market active-basket mutation guards."""
+"""Prevent active option-basket mutations outside the open NSE session."""
 
 from __future__ import annotations
 
-from typing import Any
+from functools import wraps
+from typing import Any, Callable, Iterable
+
+from nifty_scalper_bot.core.active_basket import active_contract_selection_from_basket
+from nifty_scalper_bot.utils.logging import get_logger
+from nifty_scalper_bot.utils.market_hours import MarketState, get_market_state
+
+LOGGER = get_logger(__name__)
 
 
 def apply_patches() -> None:
-    """Install universe-controller guards. Implemented by the production fix."""
+    """Freeze existing universe membership off-market; allow initial seeding."""
+    from nifty_scalper_bot.core.universe_controller import UniverseController
+
+    if getattr(UniverseController, "_off_market_basket_safety_installed", False):
+        return
+
+    original: Callable[..., tuple[set[str], set[str]]] = UniverseController.update
+
+    @wraps(original)
+    def update(self: Any, new_universe: Iterable[str]) -> tuple[set[str], set[str]]:
+        requested = {
+            str(symbol) for symbol in new_universe if str(symbol or "").strip()
+        }
+        state = get_market_state()
+        current = set(getattr(self, "current_universe", set()) or set())
+        if current and requested != current and state != MarketState.OPEN:
+            LOGGER.info(
+                "UNIVERSE_REFRESH_DEFERRED_OFF_MARKET state=%s added=%s removed=%s",
+                state.value,
+                sorted(requested - current),
+                sorted(current - requested),
+                extra={
+                    "event": "UNIVERSE_REFRESH_DEFERRED_OFF_MARKET",
+                    "market_state": state.value,
+                    "added": sorted(requested - current),
+                    "removed": sorted(current - requested),
+                },
+            )
+            return set(), set()
+        return original(self, requested)
+
+    UniverseController._off_market_basket_safety_original_update = original
+    UniverseController.update = update
+    UniverseController._off_market_basket_safety_installed = True
 
 
 def apply_app_patch(app_module: Any) -> None:
-    """Install app basket-commit guards. Implemented by the production fix."""
+    """Preserve the committed selected pair off-market once a basket exists."""
+    if getattr(app_module, "_off_market_basket_commit_safety_installed", False):
+        return
+    original = getattr(app_module, "_commit_active_dynamic_basket", None)
+    if not callable(original):
+        raise RuntimeError("active basket commit function unavailable")
+
+    @wraps(original)
+    def commit(ctx: Any, **kwargs: Any) -> tuple[str | None, str | None]:
+        existing = getattr(ctx, "active_contract_basket", None) or getattr(
+            ctx, "active_trading_universe", None
+        )
+        state = get_market_state()
+        if existing and state != MarketState.OPEN:
+            selection = active_contract_selection_from_basket(existing)
+            selected_ce = selection.selected_ce or getattr(ctx, "selected_ce", None)
+            selected_pe = selection.selected_pe or getattr(ctx, "selected_pe", None)
+            if selected_ce and selected_pe:
+                LOGGER.info(
+                    "ACTIVE_BASKET_COMMIT_DEFERRED_OFF_MARKET selected_ce=%s selected_pe=%s",
+                    selected_ce,
+                    selected_pe,
+                    extra={
+                        "event": "ACTIVE_BASKET_COMMIT_DEFERRED_OFF_MARKET",
+                        "selected_ce": selected_ce,
+                        "selected_pe": selected_pe,
+                        "market_state": state.value,
+                    },
+                )
+                return str(selected_ce), str(selected_pe)
+        return original(ctx, **kwargs)
+
+    app_module._off_market_basket_commit_original = original
+    app_module._commit_active_dynamic_basket = commit
+    app_module._off_market_basket_commit_safety_installed = True
+    apply_patches()
 
 
 __all__ = ["apply_app_patch", "apply_patches"]

--- a/tests/core/test_off_market_basket_safety.py
+++ b/tests/core/test_off_market_basket_safety.py
@@ -1,0 +1,100 @@
+"""Regression tests for off-market dynamic basket mutation safety."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import nifty_scalper_bot.core.off_market_basket_safety as safety
+from nifty_scalper_bot.core.universe_controller import UniverseController
+from nifty_scalper_bot.utils.market_hours import MarketState
+
+
+def test_existing_universe_does_not_mutate_while_market_is_closed(monkeypatch) -> None:
+    safety.apply_patches()
+    monkeypatch.setattr(safety, "get_market_state", lambda: MarketState.CLOSED, raising=False)
+    controller = UniverseController()
+
+    controller.update(["OLD_CE", "OLD_PE"])
+    added, removed = controller.update(["NEW_CE", "NEW_PE"])
+
+    assert added == set()
+    assert removed == set()
+    assert controller.current_universe == {"OLD_CE", "OLD_PE"}
+    assert controller.previous_universe == set()
+
+
+def test_existing_universe_can_change_when_market_opens(monkeypatch) -> None:
+    safety.apply_patches()
+    states = iter([MarketState.CLOSED, MarketState.OPEN])
+    monkeypatch.setattr(safety, "get_market_state", lambda: next(states), raising=False)
+    controller = UniverseController()
+
+    controller.update(["OLD_CE", "OLD_PE"])
+    added, removed = controller.update(["NEW_CE", "NEW_PE"])
+
+    assert added == {"NEW_CE", "NEW_PE"}
+    assert removed == {"OLD_CE", "OLD_PE"}
+    assert controller.current_universe == {"NEW_CE", "NEW_PE"}
+
+
+def test_existing_basket_selection_commit_is_preserved_off_market(monkeypatch) -> None:
+    calls: list[dict[str, object]] = []
+
+    def original_commit(ctx, **kwargs):
+        calls.append(dict(kwargs))
+        return kwargs["basket"]["selected_ce"], kwargs["basket"]["selected_pe"]
+
+    app_module = SimpleNamespace(_commit_active_dynamic_basket=original_commit)
+    safety.apply_app_patch(app_module)
+    monkeypatch.setattr(safety, "get_market_state", lambda: MarketState.PREOPEN, raising=False)
+    ctx = SimpleNamespace(
+        active_contract_basket={
+            "selected_ce": "OLD_CE",
+            "selected_pe": "OLD_PE",
+        },
+        active_trading_universe={},
+        selected_ce="OLD_CE",
+        selected_pe="OLD_PE",
+    )
+
+    selected = app_module._commit_active_dynamic_basket(
+        ctx,
+        basket={"selected_ce": "NEW_CE", "selected_pe": "NEW_PE"},
+        option_symbols=["NEW_CE", "NEW_PE"],
+        symbols=["NEW_CE", "NEW_PE"],
+        atm_strike=25000,
+    )
+
+    assert selected == ("OLD_CE", "OLD_PE")
+    assert calls == []
+    assert ctx.selected_ce == "OLD_CE"
+    assert ctx.selected_pe == "OLD_PE"
+
+
+def test_initial_basket_commit_is_allowed_off_market(monkeypatch) -> None:
+    calls: list[dict[str, object]] = []
+
+    def original_commit(ctx, **kwargs):
+        calls.append(dict(kwargs))
+        return kwargs["basket"]["selected_ce"], kwargs["basket"]["selected_pe"]
+
+    app_module = SimpleNamespace(_commit_active_dynamic_basket=original_commit)
+    safety.apply_app_patch(app_module)
+    monkeypatch.setattr(safety, "get_market_state", lambda: MarketState.CLOSED, raising=False)
+    ctx = SimpleNamespace(
+        active_contract_basket=None,
+        active_trading_universe={},
+        selected_ce=None,
+        selected_pe=None,
+    )
+
+    selected = app_module._commit_active_dynamic_basket(
+        ctx,
+        basket={"selected_ce": "NEW_CE", "selected_pe": "NEW_PE"},
+        option_symbols=["NEW_CE", "NEW_PE"],
+        symbols=["NEW_CE", "NEW_PE"],
+        atm_strike=25000,
+    )
+
+    assert selected == ("NEW_CE", "NEW_PE")
+    assert len(calls) == 1


### PR DESCRIPTION
## Problem

The option-universe loop mutated its controller before checking market state, then suppressed only removals. During pre-market this allowed new contracts to be hydrated, wired and selected despite logging that the refresh was skipped, causing startup overload and stale subscription accumulation.

## Root cause

Two independent state changes were permitted outside the open session:

1. `UniverseController.update()` committed new membership before the app checked market state.
2. `_commit_active_dynamic_basket()` could replace the selected CE/PE pair even when membership changes were suppressed.

## Correction

- Allow initial basket/universe seeding off-market.
- Once an active universe exists, defer both additions and removals until `MarketState.OPEN`.
- Once an active basket exists, preserve its selected CE/PE pair outside the open session.
- Resume normal universe and basket transitions at market open.
- Install through the existing app runtime-patch bootstrap.

## TDD evidence

RED:
- the no-op implementation failed because `NEW_CE` and `NEW_PE` were added while the market was closed.

GREEN:
- full repository tests: passed
- code compile/lint/format/typecheck: passed
- execution-safety regressions: passed
- live-runtime E2E: passed
- simulation component tests: passed
- market-aware validation: passed

## Scope control

This does not change initial startup basket creation, live-session ATM reselection, strategy rules, risk controls, quote requirements, overload protection, broker safety or protective exits.