### PR TITLE
Rearm live readiness at the exact market-open boundary

### DIFF
--- a/src/nifty_scalper_bot/core/__init__.py
+++ b/src/nifty_scalper_bot/core/__init__.py
@@ -143,6 +143,9 @@ def _apply_app_runtime_patches(app_module: Any) -> None:
         apply_patches as _off_market_controller_adapter,
     )
     from nifty_scalper_bot.core.polling_failover_runtime import apply_app_patch as _polling_adapter
+    from nifty_scalper_bot.core.session_boundary_rearm import (
+        apply_app_patch as _session_boundary_adapter,
+    )
     from nifty_scalper_bot.core.strategy_runner_dynamic_universe_safety import (
         apply_patches as _dynamic_universe_adapter,
     )
@@ -150,6 +153,7 @@ def _apply_app_runtime_patches(app_module: Any) -> None:
     _dynamic_universe_adapter()
     _off_market_controller_adapter()
     _off_market_app_adapter(app_module)
+    _session_boundary_adapter(app_module)
     _ready_adapter(app_module)
     _polling_adapter(app_module)
 

--- a/src/nifty_scalper_bot/core/session_boundary_rearm.py
+++ b/src/nifty_scalper_bot/core/session_boundary_rearm.py
@@ -1,0 +1,76 @@
+"""Wake live-readiness exactly at the NSE session-open boundary."""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import suppress
+from datetime import datetime
+from functools import wraps
+from typing import Any
+from zoneinfo import ZoneInfo
+
+from nifty_scalper_bot.utils.logging import get_logger
+from nifty_scalper_bot.utils.market_hours import MarketState
+
+LOGGER = get_logger(__name__)
+_IST = ZoneInfo("Asia/Kolkata")
+
+
+async def _market_open_boundary_worker(app_module: Any, ctx: Any) -> None:
+    """Perform one idempotent readiness refresh at each trading-day open."""
+    last_rearmed_date = None
+    while True:
+        state = app_module.get_market_state()
+        now_ist = datetime.now(_IST)
+        if state == MarketState.OPEN:
+            if last_rearmed_date != now_ist.date():
+                await app_module._ensure_strategy_runner_started(
+                    ctx, reason="market_open_boundary"
+                )
+                await app_module._recompute_and_push_runtime_readiness(
+                    ctx, reason="market_open_boundary"
+                )
+                last_rearmed_date = now_ist.date()
+                LOGGER.info(
+                    "MARKET_OPEN_BOUNDARY_REARM_COMPLETE date=%s",
+                    now_ist.date().isoformat(),
+                    extra={
+                        "event": "MARKET_OPEN_BOUNDARY_REARM_COMPLETE",
+                        "date": now_ist.date().isoformat(),
+                    },
+                )
+            await asyncio.sleep(60.0)
+            continue
+
+        next_open = app_module._next_nse_open_after(now_ist)
+        delay = max(0.0, (next_open - now_ist).total_seconds())
+        await asyncio.sleep(min(30.0, delay) if delay > 0 else 0.0)
+
+
+def apply_app_patch(app_module: Any) -> None:
+    """Run the exact-boundary worker beside the existing periodic rearm loop."""
+    if getattr(app_module, "_session_boundary_rearm_installed", False):
+        return
+    original = getattr(app_module, "_live_readiness_rearm_loop", None)
+    if not callable(original):
+        raise RuntimeError("live readiness rearm loop unavailable")
+
+    @wraps(original)
+    async def rearm_loop(ctx: Any) -> None:
+        boundary_task = asyncio.create_task(
+            _market_open_boundary_worker(app_module, ctx),
+            name="market_open_boundary_rearm",
+        )
+        try:
+            await original(ctx)
+        finally:
+            boundary_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await boundary_task
+
+    app_module._session_boundary_rearm_original = original
+    app_module._live_readiness_rearm_loop = rearm_loop
+    app_module._session_boundary_rearm_installed = True
+
+
+__all__ = ["apply_app_patch"]

--- a/tests/core/test_session_boundary_rearm.py
+++ b/tests/core/test_session_boundary_rearm.py
@@ -1,0 +1,67 @@
+"""Regression coverage for exact market-open readiness rearming."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from nifty_scalper_bot.core.session_boundary_rearm import apply_app_patch
+from nifty_scalper_bot.utils.market_hours import MarketState
+
+
+@pytest.mark.asyncio
+async def test_periodic_rearm_gets_an_exact_market_open_boundary_wake() -> None:
+    completed = asyncio.Event()
+    calls: list[tuple[str, str]] = []
+    state_calls = 0
+
+    async def original_loop(_ctx) -> None:
+        await completed.wait()
+
+    def market_state() -> MarketState:
+        nonlocal state_calls
+        state_calls += 1
+        return MarketState.CLOSED if state_calls == 1 else MarketState.OPEN
+
+    async def ensure_started(_ctx, *, reason: str) -> None:
+        calls.append(("runner", reason))
+
+    async def recompute(_ctx, *, reason: str) -> None:
+        calls.append(("readiness", reason))
+        completed.set()
+
+    app_module = SimpleNamespace(
+        _live_readiness_rearm_loop=original_loop,
+        get_market_state=market_state,
+        _next_nse_open_after=lambda now: now,
+        _ensure_strategy_runner_started=ensure_started,
+        _recompute_and_push_runtime_readiness=recompute,
+    )
+    apply_app_patch(app_module)
+
+    await asyncio.wait_for(app_module._live_readiness_rearm_loop(object()), timeout=1.0)
+
+    assert calls == [
+        ("runner", "market_open_boundary"),
+        ("readiness", "market_open_boundary"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_boundary_patch_preserves_original_loop_failure() -> None:
+    async def original_loop(_ctx) -> None:
+        raise RuntimeError("original failure")
+
+    app_module = SimpleNamespace(
+        _live_readiness_rearm_loop=original_loop,
+        get_market_state=lambda: MarketState.CLOSED,
+        _next_nse_open_after=lambda now: now,
+        _ensure_strategy_runner_started=lambda *_args, **_kwargs: None,
+        _recompute_and_push_runtime_readiness=lambda *_args, **_kwargs: None,
+    )
+    apply_app_patch(app_module)
+
+    with pytest.raises(RuntimeError, match="original failure"):
+        await app_module._live_readiness_rearm_loop(object())


### PR DESCRIPTION
## Problem

The existing readiness loop slept on a fixed periodic cadence. On 2026-08-07 it crossed the 09:15 session boundary and did not arm until 09:15:54, losing the opening minute despite executable selected options.

## Correction

Run a lightweight exact-boundary worker beside the existing periodic loop. It uses the existing trading-day/open-time resolver, performs one idempotent runner/readiness refresh per open date, and leaves the original periodic recovery loop unchanged.

## Safety

No market-hours, history, quote, affordability, risk, broker, overload or protective-exit gate is bypassed. The boundary wake only requests the same canonical readiness recomputation earlier.

## Validation

- full repository tests: passed
- compile/lint/format/typecheck: passed
- execution-safety regressions: passed
- live-runtime E2E: passed
- simulation component tests: passed
- market-aware validation: passed

The wrapper also preserves and propagates failures from the original rearm loop.