### PR TITLE
Defer basket rotation until the safe-entry window

### DIFF
--- a/src/nifty_scalper_bot/core/off_market_basket_safety.py
+++ b/src/nifty_scalper_bot/core/off_market_basket_safety.py
@@ -1,4 +1,4 @@
-"""Prevent active option-basket mutations outside the open NSE session."""
+"""Prevent active option-basket mutations outside the safe entry window."""
 
 from __future__ import annotations
 
@@ -7,13 +7,23 @@ from typing import Any, Callable, Iterable
 
 from nifty_scalper_bot.core.active_basket import active_contract_selection_from_basket
 from nifty_scalper_bot.utils.logging import get_logger
-from nifty_scalper_bot.utils.market_hours import MarketState, get_market_state
+from nifty_scalper_bot.utils.market_hours import (
+    MarketState,
+    get_market_state,
+    is_safe_entry_window,
+)
 
 LOGGER = get_logger(__name__)
 
 
+def _rotation_allowed() -> tuple[bool, MarketState]:
+    """Return whether active basket mutation is allowed right now."""
+    state = get_market_state()
+    return state == MarketState.OPEN and is_safe_entry_window(), state
+
+
 def apply_patches() -> None:
-    """Freeze existing universe membership off-market; allow initial seeding."""
+    """Freeze existing membership outside entry hours; allow initial seeding."""
     from nifty_scalper_bot.core.universe_controller import UniverseController
 
     if getattr(UniverseController, "_off_market_basket_safety_installed", False):
@@ -26,17 +36,18 @@ def apply_patches() -> None:
         requested = {
             str(symbol) for symbol in new_universe if str(symbol or "").strip()
         }
-        state = get_market_state()
+        rotation_allowed, state = _rotation_allowed()
         current = set(getattr(self, "current_universe", set()) or set())
-        if current and requested != current and state != MarketState.OPEN:
+        if current and requested != current and not rotation_allowed:
             LOGGER.info(
-                "UNIVERSE_REFRESH_DEFERRED_OFF_MARKET state=%s added=%s removed=%s",
+                "UNIVERSE_REFRESH_DEFERRED_OUTSIDE_ENTRY_WINDOW state=%s added=%s removed=%s",
                 state.value,
                 sorted(requested - current),
                 sorted(current - requested),
                 extra={
-                    "event": "UNIVERSE_REFRESH_DEFERRED_OFF_MARKET",
+                    "event": "UNIVERSE_REFRESH_DEFERRED_OUTSIDE_ENTRY_WINDOW",
                     "market_state": state.value,
+                    "safe_entry_window": False,
                     "added": sorted(requested - current),
                     "removed": sorted(current - requested),
                 },
@@ -50,7 +61,7 @@ def apply_patches() -> None:
 
 
 def apply_app_patch(app_module: Any) -> None:
-    """Preserve the committed selected pair off-market once a basket exists."""
+    """Preserve the selected pair outside entry hours once a basket exists."""
     if getattr(app_module, "_off_market_basket_commit_safety_installed", False):
         return
     original = getattr(app_module, "_commit_active_dynamic_basket", None)
@@ -62,21 +73,22 @@ def apply_app_patch(app_module: Any) -> None:
         existing = getattr(ctx, "active_contract_basket", None) or getattr(
             ctx, "active_trading_universe", None
         )
-        state = get_market_state()
-        if existing and state != MarketState.OPEN:
+        rotation_allowed, state = _rotation_allowed()
+        if existing and not rotation_allowed:
             selection = active_contract_selection_from_basket(existing)
             selected_ce = selection.selected_ce or getattr(ctx, "selected_ce", None)
             selected_pe = selection.selected_pe or getattr(ctx, "selected_pe", None)
             if selected_ce and selected_pe:
                 LOGGER.info(
-                    "ACTIVE_BASKET_COMMIT_DEFERRED_OFF_MARKET selected_ce=%s selected_pe=%s",
+                    "ACTIVE_BASKET_COMMIT_DEFERRED_OUTSIDE_ENTRY_WINDOW selected_ce=%s selected_pe=%s",
                     selected_ce,
                     selected_pe,
                     extra={
-                        "event": "ACTIVE_BASKET_COMMIT_DEFERRED_OFF_MARKET",
+                        "event": "ACTIVE_BASKET_COMMIT_DEFERRED_OUTSIDE_ENTRY_WINDOW",
                         "selected_ce": selected_ce,
                         "selected_pe": selected_pe,
                         "market_state": state.value,
+                        "safe_entry_window": False,
                     },
                 )
                 return str(selected_ce), str(selected_pe)

--- a/tests/core/test_off_market_basket_safety.py
+++ b/tests/core/test_off_market_basket_safety.py
@@ -12,6 +12,7 @@ from nifty_scalper_bot.utils.market_hours import MarketState
 def test_existing_universe_does_not_mutate_while_market_is_closed(monkeypatch) -> None:
     safety.apply_patches()
     monkeypatch.setattr(safety, "get_market_state", lambda: MarketState.CLOSED, raising=False)
+    monkeypatch.setattr(safety, "is_safe_entry_window", lambda: False, raising=False)
     controller = UniverseController()
 
     controller.update(["OLD_CE", "OLD_PE"])
@@ -23,10 +24,25 @@ def test_existing_universe_does_not_mutate_while_market_is_closed(monkeypatch) -
     assert controller.previous_universe == set()
 
 
-def test_existing_universe_can_change_when_market_opens(monkeypatch) -> None:
+def test_existing_universe_stays_warmed_during_opening_buffer(monkeypatch) -> None:
+    safety.apply_patches()
+    monkeypatch.setattr(safety, "get_market_state", lambda: MarketState.OPEN, raising=False)
+    monkeypatch.setattr(safety, "is_safe_entry_window", lambda: False, raising=False)
+    controller = UniverseController()
+
+    controller.update(["OLD_CE", "OLD_PE"])
+    added, removed = controller.update(["NEW_CE", "NEW_PE"])
+
+    assert added == set()
+    assert removed == set()
+    assert controller.current_universe == {"OLD_CE", "OLD_PE"}
+
+
+def test_existing_universe_can_change_in_safe_entry_window(monkeypatch) -> None:
     safety.apply_patches()
     states = iter([MarketState.CLOSED, MarketState.OPEN])
     monkeypatch.setattr(safety, "get_market_state", lambda: next(states), raising=False)
+    monkeypatch.setattr(safety, "is_safe_entry_window", lambda: True, raising=False)
     controller = UniverseController()
 
     controller.update(["OLD_CE", "OLD_PE"])
@@ -47,6 +63,7 @@ def test_existing_basket_selection_commit_is_preserved_off_market(monkeypatch) -
     app_module = SimpleNamespace(_commit_active_dynamic_basket=original_commit)
     safety.apply_app_patch(app_module)
     monkeypatch.setattr(safety, "get_market_state", lambda: MarketState.PREOPEN, raising=False)
+    monkeypatch.setattr(safety, "is_safe_entry_window", lambda: False, raising=False)
     ctx = SimpleNamespace(
         active_contract_basket={
             "selected_ce": "OLD_CE",
@@ -71,6 +88,36 @@ def test_existing_basket_selection_commit_is_preserved_off_market(monkeypatch) -
     assert ctx.selected_pe == "OLD_PE"
 
 
+def test_existing_basket_selection_is_preserved_during_opening_buffer(monkeypatch) -> None:
+    calls: list[dict[str, object]] = []
+
+    def original_commit(ctx, **kwargs):
+        calls.append(dict(kwargs))
+        return kwargs["basket"]["selected_ce"], kwargs["basket"]["selected_pe"]
+
+    app_module = SimpleNamespace(_commit_active_dynamic_basket=original_commit)
+    safety.apply_app_patch(app_module)
+    monkeypatch.setattr(safety, "get_market_state", lambda: MarketState.OPEN, raising=False)
+    monkeypatch.setattr(safety, "is_safe_entry_window", lambda: False, raising=False)
+    ctx = SimpleNamespace(
+        active_contract_basket={"selected_ce": "OLD_CE", "selected_pe": "OLD_PE"},
+        active_trading_universe={},
+        selected_ce="OLD_CE",
+        selected_pe="OLD_PE",
+    )
+
+    selected = app_module._commit_active_dynamic_basket(
+        ctx,
+        basket={"selected_ce": "NEW_CE", "selected_pe": "NEW_PE"},
+        option_symbols=["NEW_CE", "NEW_PE"],
+        symbols=["NEW_CE", "NEW_PE"],
+        atm_strike=25000,
+    )
+
+    assert selected == ("OLD_CE", "OLD_PE")
+    assert calls == []
+
+
 def test_initial_basket_commit_is_allowed_off_market(monkeypatch) -> None:
     calls: list[dict[str, object]] = []
 
@@ -81,6 +128,7 @@ def test_initial_basket_commit_is_allowed_off_market(monkeypatch) -> None:
     app_module = SimpleNamespace(_commit_active_dynamic_basket=original_commit)
     safety.apply_app_patch(app_module)
     monkeypatch.setattr(safety, "get_market_state", lambda: MarketState.CLOSED, raising=False)
+    monkeypatch.setattr(safety, "is_safe_entry_window", lambda: False, raising=False)
     ctx = SimpleNamespace(
         active_contract_basket=None,
         active_trading_universe={},


### PR DESCRIPTION
## Problem

At 09:15:58 the live ATM rotation hydrated and rewired several contracts during the opening tick burst, producing 4–5 second backlog, overload disarming and finalized-minute tick drops. The repository already defines an opening-volatility buffer in which new entries are not allowed.

## Root cause

The dynamic basket guard allowed mutation whenever `MarketState.OPEN`, even when the canonical `is_safe_entry_window()` gate was still false. Heavy history hydration and subscription changes therefore ran during the opening burst despite entries being intentionally blocked.

## Correction

- Preserve an existing warmed universe and selected CE/PE outside the canonical safe-entry window.
- Continue allowing initial startup basket seeding.
- Resume normal ATM/expiry rotation when `is_safe_entry_window()` becomes true.
- Use the existing market-hours policy rather than adding hard-coded times.

## TDD evidence

RED:
- the new opening-buffer regression failed because `NEW_CE` and `NEW_PE` were added while `MarketState.OPEN` but `is_safe_entry_window()` was false.

GREEN:
- full repository tests: passed
- compile/lint/format/typecheck: passed
- execution-safety regressions: passed
- live-runtime E2E: passed
- simulation component tests: passed
- market-aware validation: passed

## Scope control

No strategy threshold, quote, history, affordability, risk, broker, overload or protective-exit gate was weakened. This only postpones heavy basket mutation to the same period in which entries are already permitted.