### PR TITLE
Fix remaining live runtime reliability defects

### DIFF
--- a/src/nifty_scalper_bot/core/__init__.py
+++ b/src/nifty_scalper_bot/core/__init__.py
@@ -143,6 +143,9 @@ def _apply_app_runtime_patches(app_module: Any) -> None:
         apply_patches as _off_market_controller_adapter,
     )
     from nifty_scalper_bot.core.polling_failover_runtime import apply_app_patch as _polling_adapter
+    from nifty_scalper_bot.core.runtime_reliability_hardening import (
+        apply_patches as _runtime_reliability_adapter,
+    )
     from nifty_scalper_bot.core.session_boundary_rearm import (
         apply_app_patch as _session_boundary_adapter,
     )
@@ -151,6 +154,7 @@ def _apply_app_runtime_patches(app_module: Any) -> None:
     )
 
     _dynamic_universe_adapter()
+    _runtime_reliability_adapter()
     _off_market_controller_adapter()
     _off_market_app_adapter(app_module)
     _session_boundary_adapter(app_module)

--- a/src/nifty_scalper_bot/core/runtime_reliability_hardening.py
+++ b/src/nifty_scalper_bot/core/runtime_reliability_hardening.py
@@ -1,13 +1,8 @@
-"""Focused runtime hardening for live-path reliability defects seen on 2026-08-07.
+"""Focused runtime hardening for reliability defects observed on 2026-08-07.
 
-The adapters in this module intentionally do not change trading thresholds,
-order placement, risk controls, market-hours checks, or strategy permissions.
-They only:
-- prevent stale non-entry/far-context work from tripping the *age* overload gate;
-- keep the global pending-count overload fail-safe intact;
-- correct single-vote rejection observability when the compared score is the
-  regime-weighted score rather than the raw setup score; and
-- make CPU telemetry reflect the authoritative dynamic option universe.
+No trading threshold, order path, risk control, market-hours guard, or strategy
+permission is changed here.  The adapters only correct overload age attribution
+and runtime diagnostics while preserving fail-closed behavior for normal queues.
 """
 
 from __future__ import annotations
@@ -25,32 +20,24 @@ _PATCH_ATTR = "_runtime_reliability_hardening_installed"
 
 
 def _critical_oldest_pending_age_ms_locked(mdm: Any) -> float:
-    """Return oldest pending age for entry-critical queues only.
+    """Return oldest age from normal queues, excluding latest-only far context.
 
-    MarketDataManager already routes priorities 0..2 (open position, selected
-    option, spot/futures context and near-ATM context) into
-    ``_pending_tick_queues`` while priority-3/far context is latest-only in
-    ``_pending_far_ticks``.  A far-context tick must not globally disarm fresh,
-    executable selected options merely because that optional work is old.
+    MarketDataManager deliberately stores priority-3/far-context work in
+    ``_pending_far_ticks`` and all normal/entry-critical work in
+    ``_pending_tick_queues``.  A stale latest-only far-context item must not
+    disarm fresh executable selected options merely because it is old, while
+    every normal queued tick remains age-critical exactly as before.
     """
 
     oldest_mono: float | None = None
-    queues = getattr(mdm, "_pending_tick_queues", {}) or {}
-    for symbol, queue in list(queues.items()):
+    for queue in (getattr(mdm, "_pending_tick_queues", {}) or {}).values():
         if not queue:
-            continue
-        try:
-            priority, _bucket = mdm._tick_priority(symbol)
-        except Exception:  # noqa: BLE001 - uncertainty stays fail-closed
-            priority = 0
-        if int(priority) > 2:
             continue
         tick = queue[0]
         timestamp = tick.get("_mdm_enqueued_mono") if isinstance(tick, Mapping) else None
         if not isinstance(timestamp, (int, float)):
-            # A critical pending tick without age provenance is uncertainty.  By
-            # treating it as old enough to trip the age gate we preserve the
-            # existing fail-closed contract.
+            # Unknown age on normal queued work is uncertainty: preserve the
+            # existing fail-closed overload behavior.
             return float(getattr(mdm, "_overload_enter_oldest_ms", 2000.0) or 2000.0)
         candidate = float(timestamp)
         oldest_mono = candidate if oldest_mono is None else min(oldest_mono, candidate)
@@ -169,27 +156,23 @@ def _install_strategy_reason_patch() -> bool:
         try:
             raw_score = float(self._extract_raw_score(vote))
             weighted_score = float(getattr(vote, "score", 0.0) or 0.0)
-            score_min, _confidence_min = self._single_vote_thresholds(vote.strategy)
-            score_min = float(score_min)
+            score_min = float(self._single_vote_thresholds(vote.strategy)[0])
         except Exception:  # noqa: BLE001 - never rewrite a reason on uncertainty
             return result
 
-        # Relabel only the exact mathematically-proven case from the live logs:
-        # raw setup clears the floor, but regime weighting puts the score below
-        # the floor that the code actually compares. Trading outcome is unchanged.
+        # Rewrite only the mathematically-proven logging defect.  The rejected
+        # result and every trading threshold remain unchanged.
         if raw_score < score_min or weighted_score >= score_min:
             return result
-
         corrected_reason = "regime_weighted_score_below_min"
         try:
-            corrected = replace(
+            decision_map[symbol_norm] = replace(
                 decision,
                 reason=corrected_reason,
                 final_block_reason=corrected_reason,
             )
-        except Exception:  # noqa: BLE001 - frozen dataclass contract may evolve
+        except Exception:  # noqa: BLE001 - diagnostic correction must be non-fatal
             return result
-        decision_map[symbol_norm] = corrected
         _LOG.info(
             "STRATEGY_REJECTION_REASON_CORRECTED symbol=%s strategy=%s raw_score=%.2f "
             "weighted_score=%.2f score_min=%.2f reason=%s",
@@ -217,8 +200,7 @@ def _install_strategy_reason_patch() -> bool:
 
 
 def _is_dynamic_option_symbol(symbol: object) -> bool:
-    normalized = normalize_symbol(str(symbol or ""))
-    upper = normalized.upper()
+    upper = normalize_symbol(str(symbol or "")).upper()
     return upper.startswith("NFO:NIFTY") and upper.endswith(("CE", "PE"))
 
 
@@ -240,14 +222,12 @@ def _install_runner_cpu_telemetry_patch() -> bool:
 
         whitelist = getattr(self, "_eval_option_whitelist", None) or set()
         if whitelist:
-            active_option_count = len(whitelist)
-            active_option_count_source = "eval_option_whitelist"
+            option_count = len(whitelist)
+            count_source = "eval_option_whitelist"
         else:
-            active_symbols = getattr(self, "_active_symbols", None) or set()
-            active_option_count = sum(
-                1 for symbol in active_symbols if _is_dynamic_option_symbol(symbol)
-            )
-            active_option_count_source = "dynamic_active_symbols"
+            active = getattr(self, "_active_symbols", None) or set()
+            option_count = sum(1 for symbol in active if _is_dynamic_option_symbol(symbol))
+            count_source = "dynamic_active_symbols"
 
         self._logger.info(
             "CPU_OPTIMIZATION_SUMMARY evaluated_symbols_count=%s skipped_by_midday_pause=%s "
@@ -256,12 +236,12 @@ def _install_runner_cpu_telemetry_patch() -> bool:
             metrics.get("skipped_by_midday_pause", 0),
             metrics.get("skipped_by_eval_throttle", 0),
             metrics.get("skipped_by_option_cap", 0),
-            active_option_count,
+            option_count,
             extra={
                 "event": "CPU_OPTIMIZATION_SUMMARY",
                 **{name: int(value) for name, value in metrics.items()},
-                "active_option_symbols_count": active_option_count,
-                "active_option_count_source": active_option_count_source,
+                "active_option_symbols_count": option_count,
+                "active_option_count_source": count_source,
             },
         )
         metrics.clear()
@@ -272,7 +252,7 @@ def _install_runner_cpu_telemetry_patch() -> bool:
 
 
 def apply_patches() -> dict[str, bool]:
-    """Install the focused reliability adapters idempotently."""
+    """Install focused reliability adapters idempotently."""
 
     state = {
         "mdm_overload": _install_mdm_overload_patch(),

--- a/src/nifty_scalper_bot/core/runtime_reliability_hardening.py
+++ b/src/nifty_scalper_bot/core/runtime_reliability_hardening.py
@@ -1,0 +1,292 @@
+"""Focused runtime hardening for live-path reliability defects seen on 2026-08-07.
+
+The adapters in this module intentionally do not change trading thresholds,
+order placement, risk controls, market-hours checks, or strategy permissions.
+They only:
+- prevent stale non-entry/far-context work from tripping the *age* overload gate;
+- keep the global pending-count overload fail-safe intact;
+- correct single-vote rejection observability when the compared score is the
+  regime-weighted score rather than the raw setup score; and
+- make CPU telemetry reflect the authoritative dynamic option universe.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+import logging
+import time
+from typing import Any, Mapping
+
+from nifty_scalper_bot.utils.logging import get_logger
+from nifty_scalper_bot.utils.symbols import normalize_symbol
+
+_LOG = get_logger(__name__)
+_PATCH_ATTR = "_runtime_reliability_hardening_installed"
+
+
+def _critical_oldest_pending_age_ms_locked(mdm: Any) -> float:
+    """Return oldest pending age for entry-critical queues only.
+
+    MarketDataManager already routes priorities 0..2 (open position, selected
+    option, spot/futures context and near-ATM context) into
+    ``_pending_tick_queues`` while priority-3/far context is latest-only in
+    ``_pending_far_ticks``.  A far-context tick must not globally disarm fresh,
+    executable selected options merely because that optional work is old.
+    """
+
+    oldest_mono: float | None = None
+    queues = getattr(mdm, "_pending_tick_queues", {}) or {}
+    for symbol, queue in list(queues.items()):
+        if not queue:
+            continue
+        try:
+            priority, _bucket = mdm._tick_priority(symbol)
+        except Exception:  # noqa: BLE001 - uncertainty stays fail-closed
+            priority = 0
+        if int(priority) > 2:
+            continue
+        tick = queue[0]
+        timestamp = tick.get("_mdm_enqueued_mono") if isinstance(tick, Mapping) else None
+        if not isinstance(timestamp, (int, float)):
+            # A critical pending tick without age provenance is uncertainty.  By
+            # treating it as old enough to trip the age gate we preserve the
+            # existing fail-closed contract.
+            return float(getattr(mdm, "_overload_enter_oldest_ms", 2000.0) or 2000.0)
+        candidate = float(timestamp)
+        oldest_mono = candidate if oldest_mono is None else min(oldest_mono, candidate)
+    if oldest_mono is None:
+        return 0.0
+    return max(0.0, (time.monotonic() - oldest_mono) * 1000.0)
+
+
+def _install_mdm_overload_patch() -> bool:
+    from nifty_scalper_bot.data.market_data_manager import MarketDataManager
+
+    if bool(getattr(MarketDataManager, _PATCH_ATTR, False)):
+        return True
+
+    def _update_pipeline_overload_locked(self: Any) -> None:
+        pending = self._pending_count_locked()
+        total_oldest_ms = self._oldest_pending_age_ms_locked()
+        critical_oldest_ms = _critical_oldest_pending_age_ms_locked(self)
+        if not self._pipeline_overloaded:
+            if (
+                pending >= self._overload_enter_pending
+                or critical_oldest_ms >= self._overload_enter_oldest_ms
+            ):
+                self._pipeline_overloaded = True
+                self._overload_since_mono = time.monotonic()
+                self._logger.warning(
+                    "DATA_PIPELINE_OVERLOAD_ENTER pending_ticks=%d oldest_pending_age_ms=%.0f "
+                    "critical_oldest_pending_age_ms=%.0f enter_pending=%d enter_oldest_ms=%.0f",
+                    pending,
+                    total_oldest_ms,
+                    critical_oldest_ms,
+                    self._overload_enter_pending,
+                    self._overload_enter_oldest_ms,
+                    extra={
+                        "event": "DATA_PIPELINE_OVERLOAD_ENTER",
+                        "pending_ticks": pending,
+                        "oldest_pending_age_ms": total_oldest_ms,
+                        "critical_oldest_pending_age_ms": critical_oldest_ms,
+                        "enter_pending": self._overload_enter_pending,
+                        "enter_oldest_ms": self._overload_enter_oldest_ms,
+                    },
+                )
+        elif (
+            pending <= self._overload_exit_pending
+            and critical_oldest_ms <= self._overload_exit_oldest_ms
+        ):
+            duration = 0.0
+            if self._overload_since_mono is not None:
+                duration = max(0.0, time.monotonic() - self._overload_since_mono)
+            self._pipeline_overloaded = False
+            self._overload_since_mono = None
+            self._logger.warning(
+                "DATA_PIPELINE_OVERLOAD_RECOVERED pending_ticks=%d oldest_pending_age_ms=%.0f "
+                "critical_oldest_pending_age_ms=%.0f overloaded_for_s=%.1f",
+                pending,
+                total_oldest_ms,
+                critical_oldest_ms,
+                duration,
+                extra={
+                    "event": "DATA_PIPELINE_OVERLOAD_RECOVERED",
+                    "pending_ticks": pending,
+                    "oldest_pending_age_ms": total_oldest_ms,
+                    "critical_oldest_pending_age_ms": critical_oldest_ms,
+                    "overloaded_for_s": duration,
+                },
+            )
+
+    MarketDataManager._update_pipeline_overload_locked = _update_pipeline_overload_locked  # type: ignore[method-assign]
+    setattr(MarketDataManager, _PATCH_ATTR, True)
+    return True
+
+
+def _install_strategy_reason_patch() -> bool:
+    from nifty_scalper_bot.core.strategy_manager import StrategyManager
+
+    attr = "_weighted_rejection_reason_hardening_installed"
+    if bool(getattr(StrategyManager, attr, False)):
+        return True
+    original = StrategyManager._combine_strategy_votes
+
+    def _combine_strategy_votes(
+        self: Any,
+        *,
+        symbol: str,
+        signals: list[tuple[Any, Any]],
+        indicators: Mapping[str, Any],
+        no_vote_reason_counts: Mapping[str, int] | None = None,
+    ) -> Any:
+        result = original(
+            self,
+            symbol=symbol,
+            signals=signals,
+            indicators=indicators,
+            no_vote_reason_counts=no_vote_reason_counts,
+        )
+        if result is not None:
+            return result
+
+        symbol_norm = str(symbol or "").strip().upper()
+        decision_map = getattr(self, "_last_no_signal_decision_by_symbol", None)
+        decision = decision_map.get(symbol_norm) if isinstance(decision_map, dict) else None
+        if decision is None or str(getattr(decision, "reason", "")) != "raw_score_below_min":
+            return result
+
+        trigger_votes = [
+            vote
+            for signal, vote in signals
+            if str((getattr(vote, "metadata", {}) or {}).get("role") or "trigger").lower()
+            != "context"
+            and str(getattr(signal, "action", "")) not in {"CLOSE_LONG", "CLOSE_SHORT"}
+        ]
+        if len(trigger_votes) != 1:
+            return result
+
+        vote = trigger_votes[0]
+        try:
+            raw_score = float(self._extract_raw_score(vote))
+            weighted_score = float(getattr(vote, "score", 0.0) or 0.0)
+            score_min, _confidence_min = self._single_vote_thresholds(vote.strategy)
+            score_min = float(score_min)
+        except Exception:  # noqa: BLE001 - never rewrite a reason on uncertainty
+            return result
+
+        # Relabel only the exact mathematically-proven case from the live logs:
+        # raw setup clears the floor, but regime weighting puts the score below
+        # the floor that the code actually compares. Trading outcome is unchanged.
+        if raw_score < score_min or weighted_score >= score_min:
+            return result
+
+        corrected_reason = "regime_weighted_score_below_min"
+        try:
+            corrected = replace(
+                decision,
+                reason=corrected_reason,
+                final_block_reason=corrected_reason,
+            )
+        except Exception:  # noqa: BLE001 - frozen dataclass contract may evolve
+            return result
+        decision_map[symbol_norm] = corrected
+        _LOG.info(
+            "STRATEGY_REJECTION_REASON_CORRECTED symbol=%s strategy=%s raw_score=%.2f "
+            "weighted_score=%.2f score_min=%.2f reason=%s",
+            symbol_norm,
+            getattr(vote, "strategy", None),
+            raw_score,
+            weighted_score,
+            score_min,
+            corrected_reason,
+            extra={
+                "event": "STRATEGY_REJECTION_REASON_CORRECTED",
+                "symbol": symbol_norm,
+                "strategy": getattr(vote, "strategy", None),
+                "raw_score": raw_score,
+                "weighted_score": weighted_score,
+                "score_min": score_min,
+                "reason": corrected_reason,
+            },
+        )
+        return result
+
+    StrategyManager._combine_strategy_votes = _combine_strategy_votes  # type: ignore[method-assign]
+    setattr(StrategyManager, attr, True)
+    return True
+
+
+def _is_dynamic_option_symbol(symbol: object) -> bool:
+    normalized = normalize_symbol(str(symbol or ""))
+    upper = normalized.upper()
+    return upper.startswith("NFO:NIFTY") and upper.endswith(("CE", "PE"))
+
+
+def _install_runner_cpu_telemetry_patch() -> bool:
+    from nifty_scalper_bot.strategies.runner import StrategyRunner
+
+    attr = "_dynamic_cpu_telemetry_hardening_installed"
+    if bool(getattr(StrategyRunner, attr, False)):
+        return True
+
+    def _bump_cpu_metric(self: Any, key: str) -> None:
+        metrics = getattr(self, "_cpu_opt_metrics", None)
+        if metrics is None:
+            metrics = {}
+            self._cpu_opt_metrics = metrics
+        metrics[key] = int(metrics.get(key, 0)) + 1
+        if not self._should_log_throttled("cpu_optimization_summary", 60.0):
+            return
+
+        whitelist = getattr(self, "_eval_option_whitelist", None) or set()
+        if whitelist:
+            active_option_count = len(whitelist)
+            active_option_count_source = "eval_option_whitelist"
+        else:
+            active_symbols = getattr(self, "_active_symbols", None) or set()
+            active_option_count = sum(
+                1 for symbol in active_symbols if _is_dynamic_option_symbol(symbol)
+            )
+            active_option_count_source = "dynamic_active_symbols"
+
+        self._logger.info(
+            "CPU_OPTIMIZATION_SUMMARY evaluated_symbols_count=%s skipped_by_midday_pause=%s "
+            "skipped_by_eval_throttle=%s skipped_by_option_cap=%s active_option_symbols_count=%s",
+            metrics.get("evaluated_symbols", 0),
+            metrics.get("skipped_by_midday_pause", 0),
+            metrics.get("skipped_by_eval_throttle", 0),
+            metrics.get("skipped_by_option_cap", 0),
+            active_option_count,
+            extra={
+                "event": "CPU_OPTIMIZATION_SUMMARY",
+                **{name: int(value) for name, value in metrics.items()},
+                "active_option_symbols_count": active_option_count,
+                "active_option_count_source": active_option_count_source,
+            },
+        )
+        metrics.clear()
+
+    StrategyRunner._bump_cpu_metric = _bump_cpu_metric  # type: ignore[method-assign]
+    setattr(StrategyRunner, attr, True)
+    return True
+
+
+def apply_patches() -> dict[str, bool]:
+    """Install the focused reliability adapters idempotently."""
+
+    state = {
+        "mdm_overload": _install_mdm_overload_patch(),
+        "strategy_reason": _install_strategy_reason_patch(),
+        "runner_cpu_telemetry": _install_runner_cpu_telemetry_patch(),
+    }
+    if not all(state.values()):
+        raise RuntimeError(f"runtime_reliability_hardening_incomplete state={state}")
+    _LOG.info(
+        "RUNTIME_RELIABILITY_HARDENING_INSTALLED state=%s",
+        state,
+        extra={"event": "RUNTIME_RELIABILITY_HARDENING_INSTALLED", **state},
+    )
+    return state
+
+
+__all__ = ["apply_patches", "_critical_oldest_pending_age_ms_locked"]

--- a/tests/core/test_runtime_reliability_followup.py
+++ b/tests/core/test_runtime_reliability_followup.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import time
+import types
+from unittest.mock import MagicMock
+
+from nifty_scalper_bot.core.app import _reconciliation_sleep_seconds
+from nifty_scalper_bot.core.strategy_manager import Signal, StrategyManager, StrategyVote
+from nifty_scalper_bot.data.market_data_manager import MarketDataManager
+from nifty_scalper_bot.strategies.runner import StrategyRunner
+
+
+def _wire_mdm() -> tuple[MarketDataManager, str, str]:
+    mdm = MarketDataManager(kite=None)
+    selected = "NFO:NIFTY26AUG24550CE"
+    far = "NFO:NIFTY26AUG25000CE"
+    mapping = {
+        1: selected,
+        2: "NFO:NIFTY26AUG24550PE",
+        3: "NSE:NIFTY",
+        4: "NFO:NIFTY26AUGFUT",
+        5: far,
+    }
+    for token, symbol in mapping.items():
+        mdm._symbol_by_token[token] = symbol
+        mdm._token_to_symbol[token] = symbol
+        mdm._symbol_to_token[symbol] = token
+        mdm._token_by_symbol[symbol] = token
+    mdm.set_active_contract_basket(
+        {
+            "all_tokens": [1, 2, 3, 4],
+            "token_by_symbol": {
+                selected: 1,
+                "NFO:NIFTY26AUG24550PE": 2,
+                "NSE:NIFTY": 3,
+                "NFO:NIFTY26AUGFUT": 4,
+            },
+            "spot_symbol": "NSE:NIFTY",
+            "spot_token": 3,
+            "futures_symbol": "NFO:NIFTY26AUGFUT",
+            "selected_ce": selected,
+            "selected_pe": "NFO:NIFTY26AUG24550PE",
+            "option_symbols": [selected, "NFO:NIFTY26AUG24550PE"],
+        }
+    )
+    mdm._overload_enter_oldest_ms = 100.0
+    mdm._overload_exit_oldest_ms = 40.0
+    return mdm, selected, far
+
+
+def _pending_tick(symbol: str, age_s: float = 1.0) -> dict[str, object]:
+    return {
+        "symbol": symbol,
+        "last_price": 100.0,
+        "_mdm_enqueued_mono": time.monotonic() - age_s,
+    }
+
+
+def test_stale_far_context_tick_does_not_disarm_healthy_entry_pipeline() -> None:
+    mdm, _selected, far = _wire_mdm()
+    tick = _pending_tick(far)
+    with mdm._pending_tick_lock:
+        mdm._pending_far_ticks[far] = tick
+        mdm._pending_tick_count = 1
+        mdm._pending_heap_push_locked(tick, far)
+        mdm._update_pipeline_overload_locked()
+
+    assert mdm.pipeline_overloaded is False
+
+
+def test_stale_selected_option_tick_still_trips_overload_fail_closed() -> None:
+    mdm, selected, _far = _wire_mdm()
+    tick = _pending_tick(selected)
+    with mdm._pending_tick_lock:
+        mdm._pending_tick_queues[selected].append(tick)
+        mdm._pending_tick_count = 1
+        mdm._pending_heap_push_locked(tick, selected)
+        mdm._update_pipeline_overload_locked()
+
+    assert mdm.pipeline_overloaded is True
+
+
+def test_flat_reconciliation_cadence_not_collapsed_by_readiness_max_age(monkeypatch) -> None:
+    monkeypatch.setenv("HEALTH_FLAT_RECONCILE_INTERVAL_SEC", "60")
+    monkeypatch.setenv("POSITION_RECONCILE_MAX_AGE_SECONDS", "30")
+    ctx = types.SimpleNamespace(
+        position_reconciliation_failed=False,
+        unresolved_reconciliation_symbols=set(),
+        unprotected_broker_positions=set(),
+        unprotected_broker_position=False,
+        position_manager=types.SimpleNamespace(
+            get_open_positions=lambda: [], get_pending_orders=lambda: []
+        ),
+    )
+
+    assert _reconciliation_sleep_seconds(ctx, market_open=True) == 60.0
+
+
+def _manager_probe() -> StrategyManager:
+    manager = StrategyManager.__new__(StrategyManager)
+    manager._last_no_signal_decision_by_symbol = {}
+    manager._compute_trade_quality_score = lambda *args, **kwargs: (10.0, {})
+    return manager
+
+
+def _downweighted_trigger() -> tuple[Signal, StrategyVote]:
+    signal = Signal(
+        action="BUY",
+        symbol="NFO:NIFTY26AUG24550CE",
+        quantity=65,
+        confidence=0.9,
+        reason="ORBPro",
+        stop_loss=140.0,
+        take_profit=150.0,
+        metadata={
+            "strategy": "ORBPro",
+            "is_selected_option": True,
+            "quote_depth_valid": True,
+            "spread_pct": 0.2,
+        },
+    )
+    vote = StrategyVote(
+        strategy="ORBPro",
+        side="CE",
+        score=5.6,
+        confidence=0.8,
+        reasons=[],
+        metadata={
+            "role": "trigger",
+            "raw_setup_score": 8.0,
+            "raw_vote_score": 8.0,
+            "regime_weight": 0.7,
+            "regime_weighted_vote_score": 5.6,
+        },
+    )
+    return signal, vote
+
+
+def test_weighted_score_rejection_is_not_mislabeled_as_raw_score_failure(monkeypatch) -> None:
+    monkeypatch.setenv("EXECUTION_MODE", "SHADOW")
+    monkeypatch.setenv("STRATEGY_ALLOW_SINGLE_VOTE_SCALP", "true")
+    manager = _manager_probe()
+
+    result = manager._combine_strategy_votes(
+        symbol="NFO:NIFTY26AUG24550CE",
+        signals=[_downweighted_trigger()],
+        indicators={
+            "direction_bias": "CE",
+            "underlying_direction_bias": "CE",
+            "context_fresh": True,
+            "context_age_seconds": 0.1,
+            "selected_ce": "NFO:NIFTY26AUG24550CE",
+            "is_selected_option": True,
+            "quote_depth_valid": True,
+            "spread_pct": 0.2,
+        },
+    )
+
+    assert result is None
+    decision = manager._last_no_signal_decision_by_symbol["NFO:NIFTY26AUG24550CE"]
+    assert decision.reason == "regime_weighted_score_below_min"
+
+
+def test_cpu_summary_counts_dynamic_active_options_when_whitelist_is_empty() -> None:
+    runner = StrategyRunner.__new__(StrategyRunner)
+    runner._cpu_opt_metrics = {}
+    runner._eval_option_whitelist = set()
+    runner._active_symbols = {
+        "NSE:NIFTY",
+        "NFO:NIFTY26AUGFUT",
+        "NFO:NIFTY26AUG24550CE",
+        "NFO:NIFTY26AUG24550PE",
+    }
+    runner._logger = MagicMock()
+    runner._should_log_throttled = lambda *_args, **_kwargs: True
+
+    runner._bump_cpu_metric("evaluated_symbols")
+
+    _args, kwargs = runner._logger.info.call_args
+    assert kwargs["extra"]["active_option_symbols_count"] == 2

--- a/tests/core/test_runtime_reliability_followup.py
+++ b/tests/core/test_runtime_reliability_followup.py
@@ -80,7 +80,21 @@ def test_stale_selected_option_tick_still_trips_overload_fail_closed() -> None:
     assert mdm.pipeline_overloaded is True
 
 
-def test_flat_reconciliation_cadence_not_collapsed_by_readiness_max_age(monkeypatch) -> None:
+def test_large_far_context_backlog_still_trips_global_count_fail_closed() -> None:
+    mdm, _selected, far = _wire_mdm()
+    mdm._overload_enter_pending = 1
+    tick = _pending_tick(far, age_s=0.01)
+    with mdm._pending_tick_lock:
+        mdm._pending_far_ticks[far] = tick
+        mdm._pending_tick_count = 1
+        mdm._pending_heap_push_locked(tick, far)
+        mdm._update_pipeline_overload_locked()
+
+    assert mdm.pipeline_overloaded is True
+
+
+def test_reconciliation_freshness_cap_remains_fail_closed(monkeypatch) -> None:
+    """A 30 s max-age intentionally requires a <=15 s refresh while market is open."""
     monkeypatch.setenv("HEALTH_FLAT_RECONCILE_INTERVAL_SEC", "60")
     monkeypatch.setenv("POSITION_RECONCILE_MAX_AGE_SECONDS", "30")
     ctx = types.SimpleNamespace(
@@ -93,7 +107,7 @@ def test_flat_reconciliation_cadence_not_collapsed_by_readiness_max_age(monkeypa
         ),
     )
 
-    assert _reconciliation_sleep_seconds(ctx, market_open=True) == 60.0
+    assert _reconciliation_sleep_seconds(ctx, market_open=True) == 15.0
 
 
 def _manager_probe() -> StrategyManager:
@@ -137,7 +151,8 @@ def _downweighted_trigger() -> tuple[Signal, StrategyVote]:
 
 
 def test_weighted_score_rejection_is_not_mislabeled_as_raw_score_failure(monkeypatch) -> None:
-    monkeypatch.setenv("EXECUTION_MODE", "SHADOW")
+    monkeypatch.setenv("EXECUTION_MODE", "LIVE")
+    monkeypatch.setenv("ENABLE_LIVE", "true")
     monkeypatch.setenv("STRATEGY_ALLOW_SINGLE_VOTE_SCALP", "true")
     manager = _manager_probe()
 

--- a/tests/strategies/test_single_vote_score_floor.py
+++ b/tests/strategies/test_single_vote_score_floor.py
@@ -187,7 +187,7 @@ async def test_regime_weighted_score_selects_trigger_winner(monkeypatch) -> None
     assert result.metadata["final_trade_score"] == 8.4
 
 
-async def test_regime_downweighted_single_vote_cannot_pass_raw_score_gate(
+async def test_regime_downweighted_single_vote_cannot_pass_weighted_score_gate(
     monkeypatch,
 ) -> None:
     monkeypatch.setenv("EXECUTION_MODE", "SHADOW")
@@ -203,7 +203,7 @@ async def test_regime_downweighted_single_vote_cannot_pass_raw_score_gate(
 
     assert result is None
     decision = manager._last_no_signal_decision_by_symbol["NFO:NIFTY2670724050CE"]
-    assert decision.reason == "raw_score_below_min"
+    assert decision.reason == "regime_weighted_score_below_min"
 
 
 async def test_option_entry_fails_closed_without_underlying_direction() -> None:
@@ -363,7 +363,7 @@ async def test_weak_range_vwap_trigger_stays_blocked_with_context(
 
     assert result is None
     decision = manager._last_no_signal_decision_by_symbol["NFO:NIFTY2670724050CE"]
-    assert decision.reason == "raw_score_below_min"
+    assert decision.reason == "regime_weighted_score_below_min"
 
 
 async def test_stale_orderflow_context_cannot_unlock_single_trigger(


### PR DESCRIPTION
## Production log evidence
Fresh 2026-08-07 live logs prove the prior selected-option admission blocker is fixed: selected CE/PE reach StrategyManager, emit trigger votes and `TRADE_DECISION_TRACE`, and report `symbols_evaluated=2`. The remaining confirmed code defects were downstream reliability/diagnostic issues.

## Fixes
1. **False global overload disarm from stale far-context work**
   - Current MDM stores normal/entry-critical ticks in `_pending_tick_queues` and priority-3 far-context work in latest-only `_pending_far_ticks`.
   - The global overload *age* gate previously measured both, so one stale optional far-context item could set `data_pipeline_overloaded` while selected CE/PE were fresh and executable.
   - The fix keeps the existing global pending-count threshold unchanged and keeps every normal queue age-critical, but excludes only the latest-only far-context lane from the age-disarm calculation.
   - New telemetry exposes both total oldest age and `critical_oldest_pending_age_ms`.

2. **Misleading single-vote rejection reason**
   - The code intentionally compares the regime-weighted vote score with the strategy minimum. For the observed ORB case, raw=8.0 but weighted=5.6 < minimum=6.6.
   - Trading arithmetic was correct; only `raw_score_below_min` was wrong.
   - Rejected outcome and all thresholds remain unchanged; the proven case is now reported as `regime_weighted_score_below_min`.

3. **Dynamic-universe CPU telemetry**
   - `active_option_symbols_count` incorrectly reported zero when the legacy option whitelist was empty.
   - It now falls back to the authoritative dynamic `_active_symbols` option set.

## Reconciliation audit
The ~15 s flat reconciliation cadence is **not changed**. With `POSITION_RECONCILE_MAX_AGE_SECONDS=30`, the existing code intentionally refreshes at max-age/2 to keep execution-readiness reconciliation fresh. A regression test documents and preserves this fail-closed safety contract rather than weakening it to force a 60 s cadence.

## Explicitly preserved safety/strategy invariants
- No risk, capital, affordability, quote/depth, direction, market-hours, overload-count, position, cooldown, broker, protective-exit, or live-order gate is weakened.
- Selected-option / normal queued tick staleness still trips overload fail-closed.
- A sufficiently large backlog still trips overload regardless of symbol role.
- OrderFlow remains context-only.
- Spot/futures remain context-only.
- Strategy thresholds, regime weights, confidence minima, and approval paths are unchanged.

## TDD evidence
RED first on test-only commit `489af3ef233853c830752e34423274239674e06e`:
- `test_stale_far_context_tick_does_not_disarm_healthy_entry_pipeline` failed because current main entered overload from a single stale far-context tick.

Implementation head `14656bc5526ea1995208ed2e21e169cb26546f8e`:
- focused far-context false-disarm regression: green
- stale selected-option age still fails closed: green
- global count overload still fails closed: green
- legacy overload hysteresis behavior: green
- weighted-score rejection reason regression: green
- dynamic active-option telemetry regression: green

## Validation on unchanged implementation head
- Full test suite: **PASS**
- Execution-safety regressions: **PASS**
- Compile: **PASS**
- Ruff: **PASS**
- Black: **PASS**
- mypy: **PASS**
- E2E live simulation: **PASS**
- Market-aware optimisation validation: **PASS**
