### PR TITLE
Fix post-merge trade approval and context overload attribution

### DIFF
--- a/src/nifty_scalper_bot/core/runtime_reliability_hardening.py
+++ b/src/nifty_scalper_bot/core/runtime_reliability_hardening.py
@@ -1,8 +1,9 @@
 """Focused runtime hardening for reliability defects observed on 2026-08-07.
 
 No trading threshold, order path, risk control, market-hours guard, or strategy
-permission is changed here.  The adapters only correct overload age attribution
-and runtime diagnostics while preserving fail-closed behavior for normal queues.
+permission is changed here. The adapters correct overload age attribution,
+bounded consensus-quality evidence, and runtime diagnostics while preserving
+fail-closed behavior for entry-critical queues.
 """
 
 from __future__ import annotations
@@ -20,13 +21,14 @@ _PATCH_ATTR = "_runtime_reliability_hardening_installed"
 
 
 def _critical_oldest_pending_age_ms_locked(mdm: Any) -> float:
-    """Return oldest age from normal queues, excluding latest-only far context.
+    """Return oldest entry-critical queue age.
 
-    MarketDataManager deliberately stores priority-3/far-context work in
-    ``_pending_far_ticks`` and all normal/entry-critical work in
-    ``_pending_tick_queues``.  A stale latest-only far-context item must not
-    disarm fresh executable selected options merely because it is old, while
-    every normal queued tick remains age-critical exactly as before.
+    Non-selected active-basket ``near_atm`` options remain in normal FIFO
+    queues so every tick still reaches CandleEngine/OHLC processing. Their age
+    is optional strategy context, however, and must not by itself disarm fresh
+    selected CE/PE execution. Selected options, spot/future context, open
+    positions, and any unclassified normal queue remain age-critical. Global
+    pending-count overload remains unchanged and still covers every lane.
     """
 
     oldest_mono: float | None = None
@@ -34,13 +36,24 @@ def _critical_oldest_pending_age_ms_locked(mdm: Any) -> float:
         if not queue:
             continue
         tick = queue[0]
-        timestamp = tick.get("_mdm_enqueued_mono") if isinstance(tick, Mapping) else None
+        if not isinstance(tick, Mapping):
+            return float(
+                getattr(mdm, "_overload_enter_oldest_ms", 2000.0) or 2000.0
+            )
+        bucket = str(tick.get("_mdm_priority_bucket") or "").strip().lower()
+        if bucket == "near_atm":
+            continue
+        timestamp = tick.get("_mdm_enqueued_mono")
         if not isinstance(timestamp, (int, float)):
-            # Unknown age on normal queued work is uncertainty: preserve the
-            # existing fail-closed overload behavior.
-            return float(getattr(mdm, "_overload_enter_oldest_ms", 2000.0) or 2000.0)
+            # Unknown age/role on normal queued work is uncertainty: preserve
+            # fail-closed behavior rather than silently treating it as context.
+            return float(
+                getattr(mdm, "_overload_enter_oldest_ms", 2000.0) or 2000.0
+            )
         candidate = float(timestamp)
-        oldest_mono = candidate if oldest_mono is None else min(oldest_mono, candidate)
+        oldest_mono = (
+            candidate if oldest_mono is None else min(oldest_mono, candidate)
+        )
     if oldest_mono is None:
         return 0.0
     return max(0.0, (time.monotonic() - oldest_mono) * 1000.0)
@@ -105,8 +118,97 @@ def _install_mdm_overload_patch() -> bool:
                 },
             )
 
-    MarketDataManager._update_pipeline_overload_locked = _update_pipeline_overload_locked  # type: ignore[method-assign]
+    MarketDataManager._update_pipeline_overload_locked = (  # type: ignore[method-assign]
+        _update_pipeline_overload_locked
+    )
     setattr(MarketDataManager, _PATCH_ATTR, True)
+    return True
+
+
+def _trigger_confirmation_details(
+    signals: list[tuple[Any, Any]],
+) -> tuple[bool, list[str]]:
+    """Return bounded independent same-side trigger confirmation evidence."""
+
+    trigger_votes = [
+        vote
+        for signal, vote in signals
+        if str((getattr(vote, "metadata", {}) or {}).get("role") or "trigger").lower()
+        != "context"
+        and str(getattr(signal, "action", "")) not in {"CLOSE_LONG", "CLOSE_SHORT"}
+    ]
+    if len(trigger_votes) < 2:
+        return False, []
+    try:
+        best = max(trigger_votes, key=lambda vote: float(getattr(vote, "score", 0.0) or 0.0))
+    except Exception:  # noqa: BLE001 - uncertainty never creates confirmation
+        return False, []
+    best_side = str(getattr(best, "side", "") or "").upper()
+    best_strategy = str(getattr(best, "strategy", "") or "").strip().lower()
+    if best_side not in {"CE", "PE"} or not best_strategy:
+        return False, []
+    confirming = sorted(
+        {
+            str(getattr(vote, "strategy", "") or "").strip()
+            for vote in trigger_votes
+            if str(getattr(vote, "side", "") or "").upper() == best_side
+            and str(getattr(vote, "strategy", "") or "").strip().lower()
+            not in {"", best_strategy}
+        }
+    )
+    return bool(confirming), confirming
+
+
+def _install_trade_quality_patch() -> bool:
+    """Credit one bounded independent trigger before the unchanged quality gate."""
+
+    from nifty_scalper_bot.core.strategy_manager import StrategyManager
+
+    attr = "_independent_trigger_quality_hardening_installed"
+    if bool(getattr(StrategyManager, attr, False)):
+        return True
+    original = StrategyManager._compute_trade_quality_score
+
+    def _compute_trade_quality_score(
+        self: Any,
+        vote: Any,
+        indicators: Mapping[str, Any],
+        *,
+        symbol: str,
+        selected_ok: bool,
+        near_atm_ok: bool,
+        context_votes: list[Any],
+    ) -> tuple[float, dict[str, Any]]:
+        score, metadata = original(
+            self,
+            vote,
+            indicators,
+            symbol=symbol,
+            selected_ok=selected_ok,
+            near_atm_ok=near_atm_ok,
+            context_votes=context_votes,
+        )
+        details = dict(metadata or {})
+        components = dict(details.get("trade_quality_components") or {})
+        confirmation = bool(indicators.get("independent_trigger_confirmation"))
+        already_blocked = bool(details.get("already_blocked_by_strategy"))
+        # Exactly one capped 0.5-point contribution. Multiple trigger votes do
+        # not stack, and an already-invalid best trigger receives no rescue.
+        bonus = 0.5 if confirmation and not already_blocked else 0.0
+        components["independent_trigger_confirmation"] = bonus
+        adjusted = max(0.0, min(10.0, float(score) + bonus))
+        details["trade_quality_components"] = components
+        details["trade_quality_score"] = round(adjusted, 3)
+        details["independent_trigger_confirmation"] = bool(bonus)
+        details["independent_trigger_confirmation_strategies"] = list(
+            indicators.get("independent_trigger_confirmation_strategies") or []
+        )
+        return adjusted, details
+
+    StrategyManager._compute_trade_quality_score = (  # type: ignore[method-assign]
+        _compute_trade_quality_score
+    )
+    setattr(StrategyManager, attr, True)
     return True
 
 
@@ -126,11 +228,18 @@ def _install_strategy_reason_patch() -> bool:
         indicators: Mapping[str, Any],
         no_vote_reason_counts: Mapping[str, int] | None = None,
     ) -> Any:
+        confirmation, confirmation_strategies = _trigger_confirmation_details(signals)
+        effective_indicators = dict(indicators or {})
+        if confirmation:
+            effective_indicators["independent_trigger_confirmation"] = True
+            effective_indicators["independent_trigger_confirmation_strategies"] = (
+                confirmation_strategies
+            )
         result = original(
             self,
             symbol=symbol,
             signals=signals,
-            indicators=indicators,
+            indicators=effective_indicators,
             no_vote_reason_counts=no_vote_reason_counts,
         )
         if result is not None:
@@ -160,7 +269,7 @@ def _install_strategy_reason_patch() -> bool:
         except Exception:  # noqa: BLE001 - never rewrite a reason on uncertainty
             return result
 
-        # Rewrite only the mathematically-proven logging defect.  The rejected
+        # Rewrite only the mathematically-proven logging defect. The rejected
         # result and every trading threshold remain unchanged.
         if raw_score < score_min or weighted_score >= score_min:
             return result
@@ -226,7 +335,9 @@ def _install_runner_cpu_telemetry_patch() -> bool:
             count_source = "eval_option_whitelist"
         else:
             active = getattr(self, "_active_symbols", None) or set()
-            option_count = sum(1 for symbol in active if _is_dynamic_option_symbol(symbol))
+            option_count = sum(
+                1 for symbol in active if _is_dynamic_option_symbol(symbol)
+            )
             count_source = "dynamic_active_symbols"
 
         self._logger.info(
@@ -256,6 +367,7 @@ def apply_patches() -> dict[str, bool]:
 
     state = {
         "mdm_overload": _install_mdm_overload_patch(),
+        "trade_quality": _install_trade_quality_patch(),
         "strategy_reason": _install_strategy_reason_patch(),
         "runner_cpu_telemetry": _install_runner_cpu_telemetry_patch(),
     }
@@ -269,4 +381,8 @@ def apply_patches() -> dict[str, bool]:
     return state
 
 
-__all__ = ["apply_patches", "_critical_oldest_pending_age_ms_locked"]
+__all__ = [
+    "apply_patches",
+    "_critical_oldest_pending_age_ms_locked",
+    "_trigger_confirmation_details",
+]

--- a/tests/core/test_postmerge_trade_path.py
+++ b/tests/core/test_postmerge_trade_path.py
@@ -1,0 +1,234 @@
+from __future__ import annotations
+
+import time
+
+from nifty_scalper_bot.core.strategy_manager import Signal, StrategyManager, StrategyVote
+from nifty_scalper_bot.data.market_data_manager import MarketDataManager
+
+
+_SYMBOL = "NFO:NIFTY2670724050CE"
+
+
+def _signal_vote(
+    strategy: str,
+    *,
+    side: str = "CE",
+    raw_score: float,
+    weighted_score: float,
+    confidence: float,
+    role: str = "trigger",
+) -> tuple[Signal, StrategyVote]:
+    signal = Signal(
+        action="BUY",
+        symbol=_SYMBOL,
+        quantity=65,
+        confidence=confidence,
+        reason=strategy,
+        stop_loss=100.0,
+        take_profit=130.0,
+        metadata={
+            "strategy": strategy,
+            "is_selected_option": True,
+            "quote_depth_valid": True,
+            "tradable_quote": True,
+            "spread_pct": 0.2,
+        },
+    )
+    metadata = {
+        "role": role,
+        "raw_setup_score": raw_score,
+        "raw_vote_score": raw_score,
+        "regime_weight": weighted_score / raw_score,
+        "regime_weighted_vote_score": weighted_score,
+        "quote_depth_valid": True,
+        "tradable_quote": True,
+        "spread_pct": 0.2,
+    }
+    if role == "trigger" and strategy == "VWAPPro":
+        # Reproduce the 14:20 live-quality shape: 6.83 before independent
+        # trigger confirmation (2.833 setup + 2 direction + 1 freshness +
+        # 1 same-side context).
+        metadata["direction_alignment_score"] = 2.0
+    if role == "context":
+        metadata.update(
+            {
+                "context_bonus_score": 2.0,
+                "vote_timestamp": time.time(),
+                "trigger_conditions_met": False,
+                "trigger_block_reason": "context_only_role",
+            }
+        )
+    vote = StrategyVote(
+        strategy=strategy,
+        side=side,
+        score=weighted_score,
+        confidence=confidence,
+        reasons=[],
+        metadata=metadata,
+    )
+    return signal, vote
+
+
+def _live_indicators() -> dict[str, object]:
+    return {
+        "direction_bias": "CE",
+        "underlying_direction_bias": "CE",
+        "underlying_direction_confidence": 0.70,
+        "context_fresh": True,
+        "context_age_seconds": 0.1,
+        "selected_ce": _SYMBOL,
+        "is_selected_option": True,
+        "quote_depth_valid": True,
+        "tradable_quote": True,
+        "spread_pct": 0.2,
+        "stale_data_used": False,
+    }
+
+
+def test_aligned_independent_trigger_can_clear_unchanged_live_quality_floor(monkeypatch) -> None:
+    """A second independent trigger is bounded quality evidence, not a lower floor."""
+    monkeypatch.setenv("EXECUTION_MODE", "LIVE")
+    monkeypatch.setenv("ENABLE_LIVE", "true")
+    manager = StrategyManager.__new__(StrategyManager)
+    manager._last_no_signal_decision_by_symbol = {}
+
+    vwap = _signal_vote(
+        "VWAPPro", raw_score=8.5, weighted_score=6.8, confidence=0.85
+    )
+    orb = _signal_vote(
+        "ORBPro", raw_score=7.0, weighted_score=5.6, confidence=0.70
+    )
+    orderflow = _signal_vote(
+        "OrderFlow",
+        raw_score=8.0,
+        weighted_score=8.0,
+        confidence=0.80,
+        role="context",
+    )
+
+    result = manager._combine_strategy_votes(
+        symbol=_SYMBOL,
+        signals=[vwap, orb, orderflow],
+        indicators=_live_indicators(),
+    )
+
+    assert result is not None
+    assert result.metadata["quality_min_required"] == 7.0
+    assert result.metadata["trade_quality_components"]["independent_trigger_confirmation"] == 0.5
+    assert result.metadata["trade_quality_score"] >= 7.0
+    assert result.metadata["approval_path"] == "aligned_two_trigger_consensus"
+
+
+def test_opposite_trigger_does_not_receive_quality_confirmation(monkeypatch) -> None:
+    monkeypatch.setenv("EXECUTION_MODE", "LIVE")
+    monkeypatch.setenv("ENABLE_LIVE", "true")
+    manager = StrategyManager.__new__(StrategyManager)
+    manager._last_no_signal_decision_by_symbol = {}
+
+    vwap = _signal_vote(
+        "VWAPPro", raw_score=8.5, weighted_score=6.8, confidence=0.85
+    )
+    opposite_orb = _signal_vote(
+        "ORBPro", side="PE", raw_score=7.0, weighted_score=5.6, confidence=0.70
+    )
+    orderflow = _signal_vote(
+        "OrderFlow",
+        raw_score=8.0,
+        weighted_score=8.0,
+        confidence=0.80,
+        role="context",
+    )
+
+    result = manager._combine_strategy_votes(
+        symbol=_SYMBOL,
+        signals=[vwap, opposite_orb, orderflow],
+        indicators=_live_indicators(),
+    )
+
+    assert result is None
+    decision = manager._last_no_signal_decision_by_symbol[_SYMBOL]
+    assert decision.blocked_at == "trade_quality_gate"
+
+
+def _wired_mdm() -> tuple[MarketDataManager, str, str]:
+    mdm = MarketDataManager(kite=None)
+    selected = "NFO:NIFTY26AUG24550CE"
+    selected_pe = "NFO:NIFTY26AUG24550PE"
+    near_context = "NFO:NIFTY26AUG24600CE"
+    mapping = {
+        1: selected,
+        2: selected_pe,
+        3: "NSE:NIFTY",
+        4: "NFO:NIFTY26AUGFUT",
+        5: near_context,
+    }
+    for token, symbol in mapping.items():
+        mdm._symbol_by_token[token] = symbol
+        mdm._token_to_symbol[token] = symbol
+        mdm._symbol_to_token[symbol] = token
+        mdm._token_by_symbol[symbol] = token
+    mdm.set_active_contract_basket(
+        {
+            "all_tokens": list(mapping),
+            "token_by_symbol": {symbol: token for token, symbol in mapping.items()},
+            "spot_symbol": "NSE:NIFTY",
+            "futures_symbol": "NFO:NIFTY26AUGFUT",
+            "selected_ce": selected,
+            "selected_pe": selected_pe,
+            "option_symbols": [selected, selected_pe, near_context],
+        }
+    )
+    mdm._overload_enter_oldest_ms = 100.0
+    mdm._overload_exit_oldest_ms = 40.0
+    return mdm, selected, near_context
+
+
+def _stale_pending(symbol: str, bucket: str) -> dict[str, object]:
+    return {
+        "symbol": symbol,
+        "last_price": 100.0,
+        "_mdm_priority_bucket": bucket,
+        "_mdm_enqueued_mono": time.monotonic() - 1.0,
+    }
+
+
+def test_stale_nonselected_near_atm_context_does_not_disarm_entry() -> None:
+    """Optional context keeps full ticks/OHLC but its age alone cannot block entry."""
+    mdm, _selected, near_context = _wired_mdm()
+    tick = _stale_pending(near_context, "near_atm")
+    with mdm._pending_tick_lock:
+        mdm._pending_tick_queues[near_context].append(tick)
+        mdm._pending_tick_count = 1
+        mdm._pending_heap_push_locked(tick, near_context)
+        mdm._update_pipeline_overload_locked()
+
+    assert mdm.pipeline_overloaded is False
+
+
+def test_stale_selected_option_remains_age_critical() -> None:
+    mdm, selected, _near_context = _wired_mdm()
+    tick = _stale_pending(selected, "selected_option")
+    with mdm._pending_tick_lock:
+        mdm._pending_tick_queues[selected].append(tick)
+        mdm._pending_tick_count = 1
+        mdm._pending_heap_push_locked(tick, selected)
+        mdm._update_pipeline_overload_locked()
+
+    assert mdm.pipeline_overloaded is True
+
+
+def test_unknown_normal_queue_remains_fail_closed() -> None:
+    mdm, _selected, _near_context = _wired_mdm()
+    unknown = "NFO:NIFTY26AUG24700CE"
+    tick = {
+        "symbol": unknown,
+        "last_price": 100.0,
+        "_mdm_enqueued_mono": time.monotonic() - 1.0,
+    }
+    with mdm._pending_tick_lock:
+        mdm._pending_tick_queues[unknown].append(tick)
+        mdm._pending_tick_count = 1
+        mdm._pending_heap_push_locked(tick, unknown)
+        mdm._update_pipeline_overload_locked()
+
+    assert mdm.pipeline_overloaded is True


### PR DESCRIPTION
## Scope
Two remaining production defects from 2026-08-07 live logs:

1. A strong aligned multi-trigger setup (VWAPPro 8.5 + ORBPro 7.0, same PE side) can be rejected at the trade-quality gate because independent trigger confirmation is not represented in quality until after that gate.
2. Non-selected active-basket near-ATM context ticks retain full normal-queue history (correct), but their queue age is treated as entry-critical and can briefly disarm live entries even while selected CE/PE are fresh.

## Safety constraints
- Keep LIVE trade-quality floor at 7.0.
- No risk, broker, affordability, market-hours, direction, position, cooldown, protective-exit, or order-path bypass.
- Do not promote OrderFlow to trigger.
- Preserve full tick/OHLC processing for non-selected active options.
- Selected CE/PE, spot/future context, open positions and uncertain normal queues remain age fail-closed.
- Global pending-count overload remains global.

## TDD state
Test-only RED commit: `ff6d6e0c7f9d40841742b6cabb166fde07fadd6b`.
The new regressions require bounded same-side independent-trigger quality evidence and require stale non-selected near-ATM context age alone not to disarm entries. Current main does not satisfy those invariants.