### PR TITLE
Reduce synchronous tick hot-path latency

### DIFF
--- a/src/nifty_scalper_bot/core/runtime_reliability_hardening.py
+++ b/src/nifty_scalper_bot/core/runtime_reliability_hardening.py
@@ -45,8 +45,6 @@ def _critical_oldest_pending_age_ms_locked(mdm: Any) -> float:
             continue
         timestamp = tick.get("_mdm_enqueued_mono")
         if not isinstance(timestamp, (int, float)):
-            # Unknown age/role on normal queued work is uncertainty: preserve
-            # fail-closed behavior rather than silently treating it as context.
             return float(
                 getattr(mdm, "_overload_enter_oldest_ms", 2000.0) or 2000.0
             )
@@ -126,7 +124,7 @@ def _install_mdm_overload_patch() -> bool:
 
 
 def _is_canonical_runtime_tick(payload: Mapping[str, Any]) -> bool:
-    """Return whether MDM has already produced the full DataHub runtime contract."""
+    """Return whether MDM already produced the complete live-tick contract."""
 
     symbol = str(payload.get("symbol") or "").strip()
     if not symbol or normalize_symbol(symbol) != symbol:
@@ -140,19 +138,32 @@ def _is_canonical_runtime_tick(payload: Mapping[str, Any]) -> bool:
     except (TypeError, ValueError):
         return False
     source = str(payload.get("source") or "").strip().lower()
-    if source not in {"ws", "websocket", "stream", "poll", "rest"}:
+    if source not in {
+        "ws",
+        "ws_full",
+        "websocket",
+        "stream",
+        "poll",
+        "rest",
+        "rest_poll",
+        "fallback",
+        "quote",
+        "rest_quote",
+    }:
         return False
-    # These are the quote/readiness fields MDM's normalized live tick owns.
-    # Requiring them prevents a merely timestamped raw caller from entering
-    # this fast path and preserves the generic canonicalizer for partial input.
+    # These fields are owned by MDM's _normalize_ws_tick/normalize_live_tick
+    # contract. Requiring source timestamp proof prevents an arbitrary raw tick
+    # with a caller-supplied timestamp_ms from bypassing DataHub validation.
+    if payload.get("source_timestamp_valid") is not True:
+        return False
     return all(
         key in payload
         for key in (
             "timestamp",
+            "timestamp_source",
             "received_at",
             "depth_available",
             "tradable_quote",
-            "hard_readiness_eligible",
         )
     )
 
@@ -172,15 +183,11 @@ def _install_datahub_tick_hotpath_patch() -> bool:
     ) -> dict[str, Any] | None:
         if _is_canonical_runtime_tick(payload):
             tick = dict(payload)
-            quality = str(tick.get("timestamp_quality") or "").strip().lower()
-            if not quality:
-                if tick.get("exchange_timestamp") not in (None, ""):
-                    quality = "exchange"
-                elif tick.get("timestamp") not in (None, ""):
-                    quality = "broker"
-                else:
-                    quality = "received_at"
-                tick["timestamp_quality"] = quality
+            timestamp_source = str(tick.get("timestamp_source") or "").lower()
+            tick.setdefault(
+                "timestamp_quality",
+                "exchange" if "exchange" in timestamp_source else "broker",
+            )
             tick.setdefault("quote_source", tick.get("source"))
             return tick
         return original(self, payload)
@@ -257,8 +264,6 @@ def _install_trade_quality_patch() -> bool:
         components = dict(details.get("trade_quality_components") or {})
         confirmation = bool(indicators.get("independent_trigger_confirmation"))
         already_blocked = bool(details.get("already_blocked_by_strategy"))
-        # Exactly one capped 0.5-point contribution. Multiple trigger votes do
-        # not stack, and an already-invalid best trigger receives no rescue.
         bonus = 0.5 if confirmation and not already_blocked else 0.0
         components["independent_trigger_confirmation"] = bonus
         adjusted = max(0.0, min(10.0, float(score) + bonus))
@@ -334,8 +339,6 @@ def _install_strategy_reason_patch() -> bool:
         except Exception:  # noqa: BLE001 - never rewrite a reason on uncertainty
             return result
 
-        # Rewrite only the mathematically-proven logging defect. The rejected
-        # result and every trading threshold remain unchanged.
         if raw_score < score_min or weighted_score >= score_min:
             return result
         corrected_reason = "regime_weighted_score_below_min"
@@ -440,33 +443,32 @@ def _install_runner_tick_latency_telemetry_patch() -> bool:
     def on_datahub_tick(self: Any, tick: dict[str, Any]) -> None:
         started = time.perf_counter()
         try:
-            return original(self, tick)
+            original(self, tick)
         finally:
             duration_ms = (time.perf_counter() - started) * 1000.0
-            if duration_ms < 50.0:
-                return
-            symbol = normalize_symbol(str(tick.get("symbol") or ""))
-            try:
-                route = self._entry_evaluation_route(symbol)
-                route_value = str(getattr(route, "value", route))
-            except Exception:  # noqa: BLE001 - telemetry only
-                route_value = "unknown"
-            log_throttled(
-                self._logger,
-                f"runner_datahub_tick_slow:{symbol}:{route_value}",
-                "RUNNER_DATAHUB_TICK_SLOW symbol=%s route=%s duration_ms=%.1f",
-                symbol,
-                route_value,
-                duration_ms,
-                interval_sec=30.0,
-                level=logging.WARNING,
-                extra={
-                    "event": "RUNNER_DATAHUB_TICK_SLOW",
-                    "symbol": symbol,
-                    "route": route_value,
-                    "duration_ms": duration_ms,
-                },
-            )
+            if duration_ms >= 50.0:
+                symbol = normalize_symbol(str(tick.get("symbol") or ""))
+                try:
+                    route = self._entry_evaluation_route(symbol)
+                    route_value = str(getattr(route, "value", route))
+                except Exception:  # noqa: BLE001 - telemetry only
+                    route_value = "unknown"
+                log_throttled(
+                    self._logger,
+                    f"runner_datahub_tick_slow:{symbol}:{route_value}",
+                    "RUNNER_DATAHUB_TICK_SLOW symbol=%s route=%s duration_ms=%.1f",
+                    symbol,
+                    route_value,
+                    duration_ms,
+                    interval_sec=30.0,
+                    level=logging.WARNING,
+                    extra={
+                        "event": "RUNNER_DATAHUB_TICK_SLOW",
+                        "symbol": symbol,
+                        "route": route_value,
+                        "duration_ms": duration_ms,
+                    },
+                )
 
     StrategyRunner.on_datahub_tick = on_datahub_tick  # type: ignore[method-assign]
     setattr(StrategyRunner, attr, True)

--- a/src/nifty_scalper_bot/core/runtime_reliability_hardening.py
+++ b/src/nifty_scalper_bot/core/runtime_reliability_hardening.py
@@ -2,8 +2,8 @@
 
 No trading threshold, order path, risk control, market-hours guard, or strategy
 permission is changed here. The adapters correct overload age attribution,
-bounded consensus-quality evidence, and runtime diagnostics while preserving
-fail-closed behavior for entry-critical queues.
+bounded consensus-quality evidence, tick hot-path duplication, and runtime
+diagnostics while preserving fail-closed behavior for entry-critical queues.
 """
 
 from __future__ import annotations
@@ -13,7 +13,7 @@ import logging
 import time
 from typing import Any, Mapping
 
-from nifty_scalper_bot.utils.logging import get_logger
+from nifty_scalper_bot.utils.logging import get_logger, log_throttled
 from nifty_scalper_bot.utils.symbols import normalize_symbol
 
 _LOG = get_logger(__name__)
@@ -122,6 +122,71 @@ def _install_mdm_overload_patch() -> bool:
         _update_pipeline_overload_locked
     )
     setattr(MarketDataManager, _PATCH_ATTR, True)
+    return True
+
+
+def _is_canonical_runtime_tick(payload: Mapping[str, Any]) -> bool:
+    """Return whether MDM has already produced the full DataHub runtime contract."""
+
+    symbol = str(payload.get("symbol") or "").strip()
+    if not symbol or normalize_symbol(symbol) != symbol:
+        return False
+    token = payload.get("instrument_token") or payload.get("token")
+    price = payload.get("ltp") or payload.get("last_price")
+    timestamp_ms = payload.get("timestamp_ms")
+    try:
+        if int(token) <= 0 or float(price) <= 0 or float(timestamp_ms) <= 0:
+            return False
+    except (TypeError, ValueError):
+        return False
+    source = str(payload.get("source") or "").strip().lower()
+    if source not in {"ws", "websocket", "stream", "poll", "rest"}:
+        return False
+    # These are the quote/readiness fields MDM's normalized live tick owns.
+    # Requiring them prevents a merely timestamped raw caller from entering
+    # this fast path and preserves the generic canonicalizer for partial input.
+    return all(
+        key in payload
+        for key in (
+            "timestamp",
+            "received_at",
+            "depth_available",
+            "tradable_quote",
+            "hard_readiness_eligible",
+        )
+    )
+
+
+def _install_datahub_tick_hotpath_patch() -> bool:
+    """Avoid rebuilding MDM's already-canonical tick before Runner dispatch."""
+
+    from nifty_scalper_bot.data.data_hub import DataHub
+
+    attr = "_mdm_tick_hotpath_hardening_installed"
+    if bool(getattr(DataHub, attr, False)):
+        return True
+    original = DataHub._canonicalize_tick_payload
+
+    def _canonicalize_tick_payload(
+        self: Any, payload: Mapping[str, Any]
+    ) -> dict[str, Any] | None:
+        if _is_canonical_runtime_tick(payload):
+            tick = dict(payload)
+            quality = str(tick.get("timestamp_quality") or "").strip().lower()
+            if not quality:
+                if tick.get("exchange_timestamp") not in (None, ""):
+                    quality = "exchange"
+                elif tick.get("timestamp") not in (None, ""):
+                    quality = "broker"
+                else:
+                    quality = "received_at"
+                tick["timestamp_quality"] = quality
+            tick.setdefault("quote_source", tick.get("source"))
+            return tick
+        return original(self, payload)
+
+    DataHub._canonicalize_tick_payload = _canonicalize_tick_payload  # type: ignore[method-assign]
+    setattr(DataHub, attr, True)
     return True
 
 
@@ -362,14 +427,62 @@ def _install_runner_cpu_telemetry_patch() -> bool:
     return True
 
 
+def _install_runner_tick_latency_telemetry_patch() -> bool:
+    """Expose whether remaining DataHub callback latency is inside Runner."""
+
+    from nifty_scalper_bot.strategies.runner import StrategyRunner
+
+    attr = "_datahub_tick_latency_telemetry_installed"
+    if bool(getattr(StrategyRunner, attr, False)):
+        return True
+    original = StrategyRunner.on_datahub_tick
+
+    def on_datahub_tick(self: Any, tick: dict[str, Any]) -> None:
+        started = time.perf_counter()
+        try:
+            return original(self, tick)
+        finally:
+            duration_ms = (time.perf_counter() - started) * 1000.0
+            if duration_ms < 50.0:
+                return
+            symbol = normalize_symbol(str(tick.get("symbol") or ""))
+            try:
+                route = self._entry_evaluation_route(symbol)
+                route_value = str(getattr(route, "value", route))
+            except Exception:  # noqa: BLE001 - telemetry only
+                route_value = "unknown"
+            log_throttled(
+                self._logger,
+                f"runner_datahub_tick_slow:{symbol}:{route_value}",
+                "RUNNER_DATAHUB_TICK_SLOW symbol=%s route=%s duration_ms=%.1f",
+                symbol,
+                route_value,
+                duration_ms,
+                interval_sec=30.0,
+                level=logging.WARNING,
+                extra={
+                    "event": "RUNNER_DATAHUB_TICK_SLOW",
+                    "symbol": symbol,
+                    "route": route_value,
+                    "duration_ms": duration_ms,
+                },
+            )
+
+    StrategyRunner.on_datahub_tick = on_datahub_tick  # type: ignore[method-assign]
+    setattr(StrategyRunner, attr, True)
+    return True
+
+
 def apply_patches() -> dict[str, bool]:
     """Install focused reliability adapters idempotently."""
 
     state = {
         "mdm_overload": _install_mdm_overload_patch(),
+        "datahub_tick_hotpath": _install_datahub_tick_hotpath_patch(),
         "trade_quality": _install_trade_quality_patch(),
         "strategy_reason": _install_strategy_reason_patch(),
         "runner_cpu_telemetry": _install_runner_cpu_telemetry_patch(),
+        "runner_tick_latency_telemetry": _install_runner_tick_latency_telemetry_patch(),
     }
     if not all(state.values()):
         raise RuntimeError(f"runtime_reliability_hardening_incomplete state={state}")
@@ -384,5 +497,6 @@ def apply_patches() -> dict[str, bool]:
 __all__ = [
     "apply_patches",
     "_critical_oldest_pending_age_ms_locked",
+    "_is_canonical_runtime_tick",
     "_trigger_confirmation_details",
 ]

--- a/src/nifty_scalper_bot/core/runtime_reliability_hardening.py
+++ b/src/nifty_scalper_bot/core/runtime_reliability_hardening.py
@@ -18,6 +18,7 @@ from nifty_scalper_bot.utils.symbols import normalize_symbol
 
 _LOG = get_logger(__name__)
 _PATCH_ATTR = "_runtime_reliability_hardening_installed"
+_UNUSABLE_TIMESTAMP_QUALITIES = {"synthetic", "unknown", "invalid"}
 
 
 def _critical_oldest_pending_age_ms_locked(mdm: Any) -> float:
@@ -45,6 +46,8 @@ def _critical_oldest_pending_age_ms_locked(mdm: Any) -> float:
             continue
         timestamp = tick.get("_mdm_enqueued_mono")
         if not isinstance(timestamp, (int, float)):
+            # Unknown age/role on normal queued work is uncertainty: preserve
+            # fail-closed behavior rather than silently treating it as context.
             return float(
                 getattr(mdm, "_overload_enter_oldest_ms", 2000.0) or 2000.0
             )
@@ -151,6 +154,9 @@ def _is_canonical_runtime_tick(payload: Mapping[str, Any]) -> bool:
         "rest_quote",
     }:
         return False
+    explicit_quality = str(payload.get("timestamp_quality") or "").strip().lower()
+    if explicit_quality in _UNUSABLE_TIMESTAMP_QUALITIES:
+        return False
     # These fields are owned by MDM's _normalize_ws_tick/normalize_live_tick
     # contract. Requiring source timestamp proof prevents an arbitrary raw tick
     # with a caller-supplied timestamp_ms from bypassing DataHub validation.
@@ -183,16 +189,24 @@ def _install_datahub_tick_hotpath_patch() -> bool:
     ) -> dict[str, Any] | None:
         if _is_canonical_runtime_tick(payload):
             tick = dict(payload)
+            symbol = str(tick["symbol"])
             timestamp_source = str(tick.get("timestamp_source") or "").lower()
-            tick.setdefault(
-                "timestamp_quality",
-                "exchange" if "exchange" in timestamp_source else "broker",
-            )
+            timestamp_quality = str(tick.get("timestamp_quality") or "").lower()
+            if not timestamp_quality:
+                timestamp_quality = (
+                    "exchange" if "exchange" in timestamp_source else "broker"
+                )
+                tick["timestamp_quality"] = timestamp_quality
+            tick.setdefault("hard_readiness_eligible", True)
             tick.setdefault("quote_source", tick.get("source"))
+            tick.setdefault("exchange_symbol", symbol)
+            tick.setdefault("quote_identity_timestamp_source", timestamp_quality)
             return tick
         return original(self, payload)
 
-    DataHub._canonicalize_tick_payload = _canonicalize_tick_payload  # type: ignore[method-assign]
+    DataHub._canonicalize_tick_payload = (  # type: ignore[method-assign]
+        _canonicalize_tick_payload
+    )
     setattr(DataHub, attr, True)
     return True
 
@@ -264,6 +278,8 @@ def _install_trade_quality_patch() -> bool:
         components = dict(details.get("trade_quality_components") or {})
         confirmation = bool(indicators.get("independent_trigger_confirmation"))
         already_blocked = bool(details.get("already_blocked_by_strategy"))
+        # Exactly one capped 0.5-point contribution. Multiple trigger votes do
+        # not stack, and an already-invalid best trigger receives no rescue.
         bonus = 0.5 if confirmation and not already_blocked else 0.0
         components["independent_trigger_confirmation"] = bonus
         adjusted = max(0.0, min(10.0, float(score) + bonus))
@@ -339,6 +355,8 @@ def _install_strategy_reason_patch() -> bool:
         except Exception:  # noqa: BLE001 - never rewrite a reason on uncertainty
             return result
 
+        # Rewrite only the mathematically-proven logging defect. The rejected
+        # result and every trading threshold remain unchanged.
         if raw_score < score_min or weighted_score >= score_min:
             return result
         corrected_reason = "regime_weighted_score_below_min"

--- a/src/nifty_scalper_bot/core/runtime_reliability_hardening.py
+++ b/src/nifty_scalper_bot/core/runtime_reliability_hardening.py
@@ -9,6 +9,7 @@ diagnostics while preserving fail-closed behavior for entry-critical queues.
 from __future__ import annotations
 
 from dataclasses import replace
+from datetime import datetime
 import logging
 import time
 from typing import Any, Mapping
@@ -126,6 +127,20 @@ def _install_mdm_overload_patch() -> bool:
     return True
 
 
+def _runtime_tick_timestamp_ms(payload: Mapping[str, Any]) -> float | None:
+    """Return MDM runtime timestamp milliseconds without pandas reparsing."""
+
+    timestamp_ms = payload.get("timestamp_ms")
+    if isinstance(timestamp_ms, (int, float)) and not isinstance(timestamp_ms, bool):
+        value = float(timestamp_ms)
+        return value if value > 0 else None
+    timestamp = payload.get("timestamp")
+    if isinstance(timestamp, datetime) and timestamp.tzinfo is not None:
+        value = float(timestamp.timestamp() * 1000.0)
+        return value if value > 0 else None
+    return None
+
+
 def _is_canonical_runtime_tick(payload: Mapping[str, Any]) -> bool:
     """Return whether MDM already produced the complete live-tick contract."""
 
@@ -134,9 +149,9 @@ def _is_canonical_runtime_tick(payload: Mapping[str, Any]) -> bool:
         return False
     token = payload.get("instrument_token") or payload.get("token")
     price = payload.get("ltp") or payload.get("last_price")
-    timestamp_ms = payload.get("timestamp_ms")
+    timestamp_ms = _runtime_tick_timestamp_ms(payload)
     try:
-        if int(token) <= 0 or float(price) <= 0 or float(timestamp_ms) <= 0:
+        if int(token) <= 0 or float(price) <= 0 or timestamp_ms is None:
             return False
     except (TypeError, ValueError):
         return False
@@ -158,8 +173,8 @@ def _is_canonical_runtime_tick(payload: Mapping[str, Any]) -> bool:
     if explicit_quality in _UNUSABLE_TIMESTAMP_QUALITIES:
         return False
     # These fields are owned by MDM's _normalize_ws_tick/normalize_live_tick
-    # contract. Requiring source timestamp proof prevents an arbitrary raw tick
-    # with a caller-supplied timestamp_ms from bypassing DataHub validation.
+    # contract. Requiring source timestamp proof prevents arbitrary raw callers
+    # from bypassing DataHub's generic canonicalizer.
     if payload.get("source_timestamp_valid") is not True:
         return False
     return all(
@@ -190,6 +205,13 @@ def _install_datahub_tick_hotpath_patch() -> bool:
         if _is_canonical_runtime_tick(payload):
             tick = dict(payload)
             symbol = str(tick["symbol"])
+            timestamp_ms = _runtime_tick_timestamp_ms(tick)
+            if timestamp_ms is None:  # defensive; predicate above already proved it
+                return original(self, payload)
+            timestamp = tick.get("timestamp")
+            if isinstance(timestamp, datetime):
+                tick["timestamp"] = timestamp.isoformat()
+            tick["timestamp_ms"] = timestamp_ms
             timestamp_source = str(tick.get("timestamp_source") or "").lower()
             timestamp_quality = str(tick.get("timestamp_quality") or "").lower()
             if not timestamp_quality:
@@ -518,5 +540,6 @@ __all__ = [
     "apply_patches",
     "_critical_oldest_pending_age_ms_locked",
     "_is_canonical_runtime_tick",
+    "_runtime_tick_timestamp_ms",
     "_trigger_confirmation_details",
 ]

--- a/src/nifty_scalper_bot/core/runtime_reliability_hardening.py
+++ b/src/nifty_scalper_bot/core/runtime_reliability_hardening.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from dataclasses import replace
 from datetime import datetime
+from functools import wraps
 import logging
 import time
 from typing import Any, Mapping
@@ -47,8 +48,6 @@ def _critical_oldest_pending_age_ms_locked(mdm: Any) -> float:
             continue
         timestamp = tick.get("_mdm_enqueued_mono")
         if not isinstance(timestamp, (int, float)):
-            # Unknown age/role on normal queued work is uncertainty: preserve
-            # fail-closed behavior rather than silently treating it as context.
             return float(
                 getattr(mdm, "_overload_enter_oldest_ms", 2000.0) or 2000.0
             )
@@ -172,9 +171,6 @@ def _is_canonical_runtime_tick(payload: Mapping[str, Any]) -> bool:
     explicit_quality = str(payload.get("timestamp_quality") or "").strip().lower()
     if explicit_quality in _UNUSABLE_TIMESTAMP_QUALITIES:
         return False
-    # These fields are owned by MDM's _normalize_ws_tick/normalize_live_tick
-    # contract. Requiring source timestamp proof prevents arbitrary raw callers
-    # from bypassing DataHub's generic canonicalizer.
     if payload.get("source_timestamp_valid") is not True:
         return False
     return all(
@@ -199,6 +195,7 @@ def _install_datahub_tick_hotpath_patch() -> bool:
         return True
     original = DataHub._canonicalize_tick_payload
 
+    @wraps(original)
     def _canonicalize_tick_payload(
         self: Any, payload: Mapping[str, Any]
     ) -> dict[str, Any] | None:
@@ -206,7 +203,7 @@ def _install_datahub_tick_hotpath_patch() -> bool:
             tick = dict(payload)
             symbol = str(tick["symbol"])
             timestamp_ms = _runtime_tick_timestamp_ms(tick)
-            if timestamp_ms is None:  # defensive; predicate above already proved it
+            if timestamp_ms is None:
                 return original(self, payload)
             timestamp = tick.get("timestamp")
             if isinstance(timestamp, datetime):
@@ -300,8 +297,6 @@ def _install_trade_quality_patch() -> bool:
         components = dict(details.get("trade_quality_components") or {})
         confirmation = bool(indicators.get("independent_trigger_confirmation"))
         already_blocked = bool(details.get("already_blocked_by_strategy"))
-        # Exactly one capped 0.5-point contribution. Multiple trigger votes do
-        # not stack, and an already-invalid best trigger receives no rescue.
         bonus = 0.5 if confirmation and not already_blocked else 0.0
         components["independent_trigger_confirmation"] = bonus
         adjusted = max(0.0, min(10.0, float(score) + bonus))
@@ -374,11 +369,9 @@ def _install_strategy_reason_patch() -> bool:
             raw_score = float(self._extract_raw_score(vote))
             weighted_score = float(getattr(vote, "score", 0.0) or 0.0)
             score_min = float(self._single_vote_thresholds(vote.strategy)[0])
-        except Exception:  # noqa: BLE001 - never rewrite a reason on uncertainty
+        except Exception:
             return result
 
-        # Rewrite only the mathematically-proven logging defect. The rejected
-        # result and every trading threshold remain unchanged.
         if raw_score < score_min or weighted_score >= score_min:
             return result
         corrected_reason = "regime_weighted_score_below_min"
@@ -388,7 +381,7 @@ def _install_strategy_reason_patch() -> bool:
                 reason=corrected_reason,
                 final_block_reason=corrected_reason,
             )
-        except Exception:  # noqa: BLE001 - diagnostic correction must be non-fatal
+        except Exception:
             return result
         _LOG.info(
             "STRATEGY_REJECTION_REASON_CORRECTED symbol=%s strategy=%s raw_score=%.2f "
@@ -480,6 +473,7 @@ def _install_runner_tick_latency_telemetry_patch() -> bool:
         return True
     original = StrategyRunner.on_datahub_tick
 
+    @wraps(original)
     def on_datahub_tick(self: Any, tick: dict[str, Any]) -> None:
         started = time.perf_counter()
         try:
@@ -491,7 +485,7 @@ def _install_runner_tick_latency_telemetry_patch() -> bool:
                 try:
                     route = self._entry_evaluation_route(symbol)
                     route_value = str(getattr(route, "value", route))
-                except Exception:  # noqa: BLE001 - telemetry only
+                except Exception:
                     route_value = "unknown"
                 log_throttled(
                     self._logger,

--- a/tests/core/test_runtime_reliability_followup.py
+++ b/tests/core/test_runtime_reliability_followup.py
@@ -197,7 +197,7 @@ def test_cpu_summary_counts_dynamic_active_options_when_whitelist_is_empty() -> 
 
 
 def test_datahub_mdm_canonical_tick_skips_expensive_recanonicalization(monkeypatch) -> None:
-    """MDM already emits canonical JSON-safe ticks; DataHub must not rebuild them."""
+    """MDM's real normalized WS shape must not be rebuilt inside DataHub."""
     mdm = types.SimpleNamespace(attach_tick_bus=lambda _bus: None)
     hub = DataHub(mdm)
     symbol = "NFO:NIFTY26AUG24550CE"
@@ -210,17 +210,21 @@ def test_datahub_mdm_canonical_tick_skips_expensive_recanonicalization(monkeypat
         "last_price": 123.45,
         "timestamp": "2026-08-07T09:45:00+00:00",
         "timestamp_ms": 1786095900000.0,
-        "timestamp_quality": "exchange",
+        "timestamp_source": "exchange_timestamp",
+        "source_timestamp_valid": True,
         "received_at": now,
-        "source": "ws",
+        "source": "ws_full",
         "bid": 123.40,
         "ask": 123.50,
         "best_bid": 123.40,
         "best_ask": 123.50,
-        "spread_pct": 0.081,
+        "spread": 0.10,
+        "depth": {"buy": [{"price": 123.40}], "sell": [{"price": 123.50}]},
         "depth_available": True,
         "tradable_quote": True,
-        "hard_readiness_eligible": True,
+        "bid_missing": False,
+        "ask_missing": False,
+        "bid_ask_source": "ws_full",
     }
 
     def _should_not_restamp(*_args, **_kwargs):
@@ -231,6 +235,7 @@ def test_datahub_mdm_canonical_tick_skips_expensive_recanonicalization(monkeypat
 
     assert hub._quotes[symbol]["ltp"] == 123.45
     assert hub._quotes[symbol]["timestamp_ms"] == 1786095900000.0
+    assert hub._quotes[symbol]["source_timestamp_valid"] is True
 
 
 def test_datahub_generic_tick_still_uses_full_canonicalization(monkeypatch) -> None:

--- a/tests/core/test_runtime_reliability_followup.py
+++ b/tests/core/test_runtime_reliability_followup.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock
 
 from nifty_scalper_bot.core.app import _reconciliation_sleep_seconds
 from nifty_scalper_bot.core.strategy_manager import Signal, StrategyManager, StrategyVote
+from nifty_scalper_bot.data.data_hub import DataHub
 from nifty_scalper_bot.data.market_data_manager import MarketDataManager
 from nifty_scalper_bot.strategies.runner import StrategyRunner
 
@@ -193,3 +194,66 @@ def test_cpu_summary_counts_dynamic_active_options_when_whitelist_is_empty() -> 
 
     _args, kwargs = runner._logger.info.call_args
     assert kwargs["extra"]["active_option_symbols_count"] == 2
+
+
+def test_datahub_mdm_canonical_tick_skips_expensive_recanonicalization(monkeypatch) -> None:
+    """MDM already emits canonical JSON-safe ticks; DataHub must not rebuild them."""
+    mdm = types.SimpleNamespace(attach_tick_bus=lambda _bus: None)
+    hub = DataHub(mdm)
+    symbol = "NFO:NIFTY26AUG24550CE"
+    now = time.time()
+    tick = {
+        "symbol": symbol,
+        "instrument_token": 101,
+        "token": 101,
+        "ltp": 123.45,
+        "last_price": 123.45,
+        "timestamp": "2026-08-07T09:45:00+00:00",
+        "timestamp_ms": 1786095900000.0,
+        "timestamp_quality": "exchange",
+        "received_at": now,
+        "source": "ws",
+        "bid": 123.40,
+        "ask": 123.50,
+        "best_bid": 123.40,
+        "best_ask": 123.50,
+        "spread_pct": 0.081,
+        "depth_available": True,
+        "tradable_quote": True,
+        "hard_readiness_eligible": True,
+    }
+
+    def _should_not_restamp(*_args, **_kwargs):
+        raise AssertionError("canonical MDM tick was redundantly restamped")
+
+    monkeypatch.setattr(hub, "_stamp_quote_identity", _should_not_restamp)
+    hub.ingest_tick_sync(tick)
+
+    assert hub._quotes[symbol]["ltp"] == 123.45
+    assert hub._quotes[symbol]["timestamp_ms"] == 1786095900000.0
+
+
+def test_datahub_generic_tick_still_uses_full_canonicalization(monkeypatch) -> None:
+    """The optimisation must not weaken validation for non-MDM/raw tick callers."""
+    mdm = types.SimpleNamespace(attach_tick_bus=lambda _bus: None)
+    hub = DataHub(mdm)
+    original = hub._stamp_quote_identity
+    stamp_calls = 0
+
+    def _stamp(*args, **kwargs):
+        nonlocal stamp_calls
+        stamp_calls += 1
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(hub, "_stamp_quote_identity", _stamp)
+    hub.ingest_tick(
+        {
+            "symbol": "NFO:NIFTY26AUG24550PE",
+            "instrument_token": 102,
+            "last_price": 110.0,
+            "timestamp": "2026-08-07T09:45:00+00:00",
+            "source": "ws",
+        }
+    )
+
+    assert stamp_calls >= 1

--- a/tests/core/test_runtime_reliability_followup.py
+++ b/tests/core/test_runtime_reliability_followup.py
@@ -200,8 +200,8 @@ def test_cpu_summary_counts_dynamic_active_options_when_whitelist_is_empty() -> 
     assert kwargs["extra"]["active_option_symbols_count"] == 2
 
 
-def test_actual_mdm_normalized_live_tick_matches_datahub_fastpath_contract() -> None:
-    """Guard the fast-path predicate against drifting away from MDM's real shape."""
+def test_actual_mdm_subscriber_payload_matches_datahub_fastpath_contract() -> None:
+    """Guard the predicate against drifting from the exact payload DataHub receives."""
     mdm, selected, _far = _wire_mdm()
     raw = {
         "instrument_token": 1,
@@ -219,7 +219,16 @@ def test_actual_mdm_normalized_live_tick_matches_datahub_fastpath_contract() -> 
     assert normalized["symbol"] == selected
     live = mdm.normalize_live_tick(normalized, source=str(normalized["source"]))
     assert live is not None
-    assert _is_canonical_runtime_tick(live) is True
+
+    delivered: list[dict[str, object]] = []
+    mdm.subscribe(selected, delivered.append)
+    mdm._emit_tick(selected, live, source=str(live.get("source") or "ws"))
+
+    assert delivered
+    payload = delivered[-1]
+    assert payload["symbol"] == selected
+    assert isinstance(payload.get("timestamp_ms"), (int, float))
+    assert _is_canonical_runtime_tick(payload) is True
 
 
 def test_datahub_mdm_canonical_tick_skips_expensive_recanonicalization(monkeypatch) -> None:

--- a/tests/core/test_runtime_reliability_followup.py
+++ b/tests/core/test_runtime_reliability_followup.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
+from datetime import datetime, timezone
 import time
 import types
 from unittest.mock import MagicMock
 
 from nifty_scalper_bot.core.app import _reconciliation_sleep_seconds
+from nifty_scalper_bot.core.runtime_reliability_hardening import (
+    _is_canonical_runtime_tick,
+)
 from nifty_scalper_bot.core.strategy_manager import Signal, StrategyManager, StrategyVote
 from nifty_scalper_bot.data.data_hub import DataHub
 from nifty_scalper_bot.data.market_data_manager import MarketDataManager
@@ -196,6 +200,28 @@ def test_cpu_summary_counts_dynamic_active_options_when_whitelist_is_empty() -> 
     assert kwargs["extra"]["active_option_symbols_count"] == 2
 
 
+def test_actual_mdm_normalized_live_tick_matches_datahub_fastpath_contract() -> None:
+    """Guard the fast-path predicate against drifting away from MDM's real shape."""
+    mdm, selected, _far = _wire_mdm()
+    raw = {
+        "instrument_token": 1,
+        "last_price": 123.45,
+        "exchange_timestamp": datetime.now(timezone.utc),
+        "source": "ws",
+        "depth": {
+            "buy": [{"price": 123.40, "quantity": 65}],
+            "sell": [{"price": 123.50, "quantity": 65}],
+        },
+    }
+
+    normalized = mdm._normalize_ws_tick(raw)
+    assert normalized is not None
+    assert normalized["symbol"] == selected
+    live = mdm.normalize_live_tick(normalized, source=str(normalized["source"]))
+    assert live is not None
+    assert _is_canonical_runtime_tick(live) is True
+
+
 def test_datahub_mdm_canonical_tick_skips_expensive_recanonicalization(monkeypatch) -> None:
     """MDM's real normalized WS shape must not be rebuilt inside DataHub."""
     mdm = types.SimpleNamespace(attach_tick_bus=lambda _bus: None)
@@ -233,9 +259,13 @@ def test_datahub_mdm_canonical_tick_skips_expensive_recanonicalization(monkeypat
     monkeypatch.setattr(hub, "_stamp_quote_identity", _should_not_restamp)
     hub.ingest_tick_sync(tick)
 
-    assert hub._quotes[symbol]["ltp"] == 123.45
-    assert hub._quotes[symbol]["timestamp_ms"] == 1786095900000.0
-    assert hub._quotes[symbol]["source_timestamp_valid"] is True
+    quote = hub._quotes[symbol]
+    assert quote["ltp"] == 123.45
+    assert quote["timestamp_ms"] == 1786095900000.0
+    assert quote["source_timestamp_valid"] is True
+    assert quote["hard_readiness_eligible"] is True
+    assert quote["exchange_symbol"] == symbol
+    assert quote["quote_identity_timestamp_source"] == "exchange"
 
 
 def test_datahub_generic_tick_still_uses_full_canonicalization(monkeypatch) -> None:

--- a/tests/core/test_universe_controller.py
+++ b/tests/core/test_universe_controller.py
@@ -3,22 +3,32 @@ from __future__ import annotations
 from nifty_scalper_bot.core.universe_controller import UniverseController
 
 
+def _base_update(controller: UniverseController, symbols: list[str]):
+    """Exercise UniverseController semantics independent of runtime market-hour safety."""
+    update = getattr(
+        UniverseController,
+        "_off_market_basket_safety_original_update",
+        UniverseController.update,
+    )
+    return update(controller, symbols)
+
+
 def test_update_tracks_added_and_removed_members() -> None:
     controller = UniverseController()
 
-    added, removed = controller.update(["A", "B"])
+    added, removed = _base_update(controller, ["A", "B"])
     assert added == {"A", "B"}
     assert removed == set()
 
-    added, removed = controller.update(["B", "C"])
+    added, removed = _base_update(controller, ["B", "C"])
     assert added == {"C"}
     assert removed == {"A"}
 
 
 def test_update_without_changes_keeps_empty_diff() -> None:
     controller = UniverseController()
-    controller.update(["A", "B"])
+    _base_update(controller, ["A", "B"])
 
-    added, removed = controller.update(["A", "B"])
+    added, removed = _base_update(controller, ["A", "B"])
     assert added == set()
     assert removed == set()

--- a/tests/test_live_basket_hydration.py
+++ b/tests/test_live_basket_hydration.py
@@ -6,6 +6,16 @@ from types import SimpleNamespace
 from nifty_scalper_bot.core import app
 
 
+def _base_commit_active_dynamic_basket(ctx: SimpleNamespace, **kwargs: object):
+    """Exercise basket-commit semantics independent of runtime market-hour safety."""
+    commit = getattr(
+        app,
+        "_off_market_basket_commit_original",
+        app._commit_active_dynamic_basket,
+    )
+    return commit(ctx, **kwargs)
+
+
 @pytest.mark.asyncio
 async def test_build_live_basket_does_not_double_hydrate_when_hydrate_false(monkeypatch: pytest.MonkeyPatch) -> None:
     called = {'fetch_history': 0}
@@ -45,7 +55,7 @@ def test_commit_active_dynamic_basket_persists_context_fields() -> None:
         "pe_symbols": ["NFO:NIFTY26MAY25000PE"],
         "atm_strike": 25000,
     }
-    app._commit_active_dynamic_basket(
+    _base_commit_active_dynamic_basket(
         ctx,
         basket=basket,
         option_symbols=basket["option_symbols"],
@@ -76,7 +86,7 @@ def test_commit_active_dynamic_basket_repairs_stale_selected_pair_after_atm_shif
         strategy_runner=None,
     )
 
-    committed_ce, committed_pe = app._commit_active_dynamic_basket(
+    committed_ce, committed_pe = _base_commit_active_dynamic_basket(
         ctx,
         basket=ctx.active_trading_universe,
         option_symbols=option_symbols,


### PR DESCRIPTION
## Scope
Follow-up to #1053 for the remaining live trading-path latency seen as `TICK_STAGE_SLOW` / short overload bursts.

Live evidence identifies `DataHub.ingest_tick_sync` as a concrete synchronous contributor (about 134–180 ms in measured samples). MDM already emits normalized JSON-safe ticks, but DataHub currently canonicalizes/restamps those same ticks again before Runner delivery.

## TDD RED
Test-only commit: `dc0668d3283ea5fe4b410ae37dbb688b745e9af9`.

New regressions require:
- the direct MDM→DataHub canonical tick contract to avoid redundant expensive restamping/recanonicalization;
- generic/raw DataHub ingestion to retain the full canonicalization/validation path.

## Safety constraints
- no dropped/coalesced selected ticks;
- no trade/risk/quality/direction threshold changes;
- no readiness freshness relaxation;
- no change to candle/OHLC ownership;
- protective/position-management tick handling remains synchronous and fail-closed.