### PR TITLE
Fix selected-option evaluation starvation and cold basket promotion

### DIFF
--- a/src/nifty_scalper_bot/core/strategy_runner_dynamic_universe_safety.py
+++ b/src/nifty_scalper_bot/core/strategy_runner_dynamic_universe_safety.py
@@ -50,7 +50,10 @@ def apply_patches() -> None:
         """Do not promote a newly selected CE/PE pair before its indicator history is warm."""
         new_ce = normalize_symbol(str(getattr(selection, "selected_ce", None) or "")) or None
         new_pe = normalize_symbol(str(getattr(selection, "selected_pe", None) or "")) or None
-        if new_ce and new_pe:
+        runtime_ready = hasattr(self, "_option_required_bars") and hasattr(
+            self, "_indicator_engine"
+        )
+        if new_ce and new_pe and runtime_ready:
             required = int(getattr(self, "_option_required_bars", 1) or 1)
             try:
                 pair_ready = all(

--- a/src/nifty_scalper_bot/core/strategy_runner_dynamic_universe_safety.py
+++ b/src/nifty_scalper_bot/core/strategy_runner_dynamic_universe_safety.py
@@ -1,7 +1,8 @@
-"""Keep StrategyRunner's frozen gate aligned with its dynamic active universe."""
+"""Keep StrategyRunner's dynamic universe and live evaluation state safe."""
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from functools import wraps
 from typing import Any, Callable
 
@@ -9,15 +10,17 @@ from nifty_scalper_bot.utils.symbols import normalize_symbol
 
 
 def apply_patches() -> None:
-    """Install the dynamic-universe admission fix once."""
+    """Install the dynamic-universe and selected-option evaluation fixes once."""
     from nifty_scalper_bot.strategies.runner import StrategyRunner
 
     if getattr(StrategyRunner, "_dynamic_universe_safety_installed", False):
         return
 
-    original: Callable[..., bool] = StrategyRunner._validate_symbol_for_cycle
+    original_validate: Callable[..., bool] = StrategyRunner._validate_symbol_for_cycle
+    original_sync = StrategyRunner._sync_active_selection_from_basket
+    original_on_tick = StrategyRunner._on_tick
 
-    @wraps(original)
+    @wraps(original_validate)
     def validate_symbol_for_cycle(self: Any, symbol: str) -> bool:
         normalized = normalize_symbol(str(symbol or ""))
         admitted = False
@@ -40,10 +43,48 @@ def apply_patches() -> None:
                     "reason": "active_universe_authority",
                 },
             )
-        return original(self, normalized or symbol)
+        return original_validate(self, normalized or symbol)
 
-    StrategyRunner._dynamic_universe_safety_original_validate = original
+    @wraps(original_sync)
+    def sync_active_selection_from_basket(self: Any, selection: Any) -> None:
+        """Do not promote a newly selected CE/PE pair before its indicator history is warm."""
+        new_ce = normalize_symbol(str(getattr(selection, "selected_ce", None) or "")) or None
+        new_pe = normalize_symbol(str(getattr(selection, "selected_pe", None) or "")) or None
+        if new_ce and new_pe:
+            required = int(getattr(self, "_option_required_bars", 1) or 1)
+            try:
+                pair_ready = all(
+                    self._history_count_for_symbol(symbol) >= required
+                    for symbol in (new_ce, new_pe)
+                )
+            except Exception:  # noqa: BLE001 - readiness must fail closed
+                pair_ready = False
+            if not pair_ready:
+                self.set_active_option_context(
+                    selected_ce=new_ce,
+                    selected_pe=new_pe,
+                    atm_strike=getattr(selection, "atm_strike", None),
+                    option_symbols=getattr(selection, "option_symbols", None),
+                )
+                return
+        original_sync(self, selection)
+
+    @wraps(original_on_tick)
+    def on_tick(self: Any, symbol: str, tick: Mapping[str, Any]) -> Any:
+        """Keep quote/data sequence versions out of the candle-version state machine."""
+        clean_tick = tick
+        if isinstance(tick, Mapping) and ("version" in tick or "data_version" in tick):
+            clean_tick = dict(tick)
+            clean_tick.pop("version", None)
+            clean_tick.pop("data_version", None)
+        return original_on_tick(self, symbol, clean_tick)
+
+    StrategyRunner._dynamic_universe_safety_original_validate = original_validate
+    StrategyRunner._dynamic_universe_safety_original_sync = original_sync
+    StrategyRunner._dynamic_universe_safety_original_on_tick = original_on_tick
     StrategyRunner._validate_symbol_for_cycle = validate_symbol_for_cycle
+    StrategyRunner._sync_active_selection_from_basket = sync_active_selection_from_basket
+    StrategyRunner._on_tick = on_tick
     StrategyRunner._dynamic_universe_safety_installed = True
 
 

--- a/tests/strategies/test_selected_option_live_path.py
+++ b/tests/strategies/test_selected_option_live_path.py
@@ -6,6 +6,7 @@ import asyncio
 import threading
 import time
 from datetime import datetime, timezone
+from types import SimpleNamespace
 
 from nifty_scalper_bot.core.strategy_runner_dynamic_universe_safety import (
     apply_patches,
@@ -112,3 +113,107 @@ def test_live_selected_option_tick_reaches_strategy_manager_after_atm_switch(mon
         order_manager.submit.assert_called()
     finally:
         _stop_loop(loop, thread)
+
+
+def test_basket_sync_defers_cold_selected_pair_until_indicator_history_is_ready(monkeypatch):
+    """Basket SSOT must not replace the executable pair before both new legs are warm."""
+    apply_patches()
+    runner, _strategy_manager, _risk_manager, _order_manager, old_ce = (
+        _build_phase9_runner(monkeypatch)
+    )
+    old_pe = runner._active_selected_pe
+    new_ce = "NFO:NIFTY26JUN24100CE"
+    new_pe = "NFO:NIFTY26JUN24100PE"
+    histories = {
+        old_ce: [{}] * 100,
+        old_pe: [{}] * 100,
+        new_ce: [],
+        new_pe: [],
+    }
+    runner._indicator_engine.get_history = lambda symbol: histories.get(symbol, [])
+    runner._option_required_bars = 20
+    runner._prewarm_active_option_history = lambda **_kwargs: None
+    selection = SimpleNamespace(
+        selected_ce=new_ce,
+        selected_pe=new_pe,
+        atm_strike=24100,
+        option_symbols=(new_ce, new_pe),
+        basket_version="test-cold-switch",
+        selected_at=time.time(),
+        source="test",
+    )
+
+    runner._sync_active_selection_from_basket(selection)
+
+    assert runner._active_selected_ce == old_ce
+    assert runner._active_selected_pe == old_pe
+    assert runner._pending_selected_ce == new_ce
+    assert runner._pending_selected_pe == new_pe
+
+    histories[new_ce] = [{}] * 20
+    histories[new_pe] = [{}] * 20
+    assert runner._maybe_promote_pending_active_basket(source="test") is True
+    assert runner._active_selected_ce == new_ce
+    assert runner._active_selected_pe == new_pe
+    assert runner._pending_selected_ce is None
+    assert runner._pending_selected_pe is None
+
+
+def test_quote_versions_do_not_advance_candle_version_or_starve_same_bar_evaluation(monkeypatch):
+    """Quote/data sequence counters are not candle identity and must not suppress a leg."""
+    apply_patches()
+    runner, strategy_manager, _risk_manager, _order_manager, selected_ce = (
+        _build_phase9_runner(monkeypatch)
+    )
+    runner._active_symbols.add(selected_ce)
+    runner._tracked_symbols.add(selected_ce)
+    runner._history_ready_by_symbol[selected_ce] = True
+    runner._data_phase[selected_ce] = "LIVE"
+    runner._symbol_history[selected_ce] = [{"timestamp": time.time()}]
+    fixed_bar_ts = datetime.now(timezone.utc)
+    runner._last_bar_ts[selected_ce] = fixed_bar_ts
+    runner._symbol_state[selected_ce] = SymbolRuntimeState(selected_ce, 100)
+    runner._symbol_state[selected_ce].active = True
+    runner._symbol_states[selected_ce] = SymbolState.READY
+    runner._active_basket_token_by_symbol[selected_ce] = 1
+    runner._refresh_underlying_context_snapshots = lambda **_kwargs: None
+    runner._get_cached_quote_for_live_entry = lambda _symbol: {
+        "symbol": _symbol,
+        "ltp": 100.0,
+        "last_price": 100.0,
+        "bid": 99.5,
+        "ask": 100.5,
+        "timestamp": time.time(),
+    }
+
+    first_tick = {
+        "symbol": selected_ce,
+        "last_price": 100.0,
+        "ltp": 100.0,
+        "bid": 99.5,
+        "ask": 100.5,
+        "timestamp": time.time(),
+        "source": "ws",
+        "trace_id": "quote-version-1",
+        "version": 1,
+    }
+    second_tick = {
+        **first_tick,
+        "timestamp": time.time() + 0.1,
+        "trace_id": "quote-version-2",
+        "version": 2,
+        "data_version": 22,
+    }
+
+    runner._on_tick(selected_ce, first_tick)
+    runner._on_tick(selected_ce, second_tick)
+
+    calls = [
+        call
+        for call in strategy_manager.generate_signal.call_args_list
+        if call.args and call.args[0] == selected_ce
+    ]
+    assert len(calls) == 2
+    assert runner._candle_versions.get(selected_ce, 0) == 0
+    assert first_tick["version"] == 1
+    assert second_tick["data_version"] == 22

--- a/tests/strategies/test_selected_option_live_path.py
+++ b/tests/strategies/test_selected_option_live_path.py
@@ -206,6 +206,7 @@ def test_quote_versions_do_not_advance_candle_version_or_starve_same_bar_evaluat
     }
 
     runner._on_tick(selected_ce, first_tick)
+    runner._last_periodic_eval_at_by_symbol[selected_ce] = time.monotonic() - 11.0
     runner._on_tick(selected_ce, second_tick)
 
     calls = [


### PR DESCRIPTION
## Root causes fixed

1. Quote/data sequence `version` fields were allowed to enter StrategyRunner's candle-version state machine. On repeated same-bar ticks this could make a selected leg look like a new candle without a new bar timestamp, causing the later Phase-9 same-bar guard to return before StrategyManager evaluation.
2. `_sync_active_selection_from_basket()` could promote a newly selected CE/PE pair immediately even when the pair had no IndicatorEngine history, bypassing the existing deferred-hydration path in `set_active_option_context()`.

## Targeted correction

- Reuse the existing production StrategyRunner runtime-hardening layer; no new files.
- Strip only generic quote/data sequence versions from the runner evaluation copy; explicit `candle_version` remains untouched.
- Route cold basket SSOT switches through the existing `set_active_option_context()` defer/prewarm/promote mechanism; warm pairs continue through the existing sync implementation unchanged.
- Preserve OrderFlow as context-only and leave strategy thresholds, direction gates, risk gates, sizing, and order submission unchanged.

## Regression coverage

Extended the existing selected-option live-path tests to prove:
- a cold newly selected CE/PE pair cannot replace the currently executable pair until both IndicatorEngine histories meet the existing requirement;
- promotion occurs once both new legs are warm;
- generic `version`/`data_version` cannot advance candle identity or starve repeated same-bar selected-option evaluation;
- caller tick dictionaries are not mutated.

No new production or test files were created.