### PR TITLE
Fix Phase-9 selected-leg starvation and readiness flapping

### DIFF
--- a/src/nifty_scalper_bot/core/boot_log_safety.py
+++ b/src/nifty_scalper_bot/core/boot_log_safety.py
@@ -36,6 +36,9 @@ ORDERFLOW_EVENTS = {
     "ORDERFLOW_TRIGGER_DECISION",
     "ORDERFLOW_DIRECTION_BIAS_CONFLICT",
 }
+INDICATOR_EVENTS = {
+    "indicator_engine_history_missing",
+}
 
 
 THROTTLED_EVENTS = (
@@ -44,6 +47,7 @@ THROTTLED_EVENTS = (
     | BOOTSTRAP_EVENTS
     | READINESS_EVENTS
     | ORDERFLOW_EVENTS
+    | INDICATOR_EVENTS
 )
 
 
@@ -169,6 +173,7 @@ def apply_filters() -> None:
         "nifty_scalper_bot.core.app",
         "nifty_scalper_bot.execution.readiness",
         "nifty_scalper_bot.strategies.runner",
+        "nifty_scalper_bot.strategies.indicators",
         "nifty_scalper_bot.strategies.elite_strategies.base_elite",
         "nifty_scalper_bot.strategies.elite_strategies.order_flow",
     ):

--- a/src/nifty_scalper_bot/core/boot_readiness_safety.py
+++ b/src/nifty_scalper_bot/core/boot_readiness_safety.py
@@ -14,19 +14,46 @@ _T = TypeVar("_T")
 def adapt_compute_live_readiness(
     original: Callable[..., tuple[bool, list[str]]],
 ) -> Callable[..., tuple[bool, list[str]]]:
-    """Return an adapter that keeps option quote checks quiet outside session."""
+    """Keep session details quiet and every live refusal diagnostically explicit."""
 
     @wraps(original)
     def wrapped(**kwargs: Any) -> tuple[bool, list[str]]:
-        if bool(kwargs.get("live_mode")) and not bool(kwargs.get("market_open")):
-            min_bars = int(kwargs.get("option_exec_min_bars") or 1)
-            adjusted = dict(kwargs)
+        adjusted = dict(kwargs)
+        if bool(adjusted.get("live_mode")) and not bool(adjusted.get("market_open")):
+            min_bars = int(adjusted.get("option_exec_min_bars") or 1)
             adjusted["ce_quote_ready"] = True
             adjusted["pe_quote_ready"] = True
             adjusted["ce_bars"] = max(int(adjusted.get("ce_bars") or 0), min_bars)
             adjusted["pe_bars"] = max(int(adjusted.get("pe_bars") or 0), min_bars)
-            return original(**adjusted)
-        return original(**kwargs)
+
+        armed, reasons = original(**adjusted)
+        normalized_reasons = list(reasons or [])
+        if bool(adjusted.get("live_mode")) and not armed and not normalized_reasons:
+            minimum = int(adjusted.get("option_exec_min_bars") or 1)
+            if not bool(adjusted.get("hard_ready")):
+                normalized_reasons.append("startup_pipeline_incomplete")
+            elif not bool(adjusted.get("market_open")):
+                normalized_reasons.append("market_closed")
+            elif not bool(adjusted.get("runner_running")):
+                normalized_reasons.append("runner_not_running")
+            elif not adjusted.get("selected_ce") or not adjusted.get("selected_pe"):
+                normalized_reasons.append("selected_options_missing")
+            elif int(adjusted.get("ce_bars") or 0) < minimum:
+                normalized_reasons.append("ce_exec_bars_missing")
+            elif int(adjusted.get("pe_bars") or 0) < minimum:
+                normalized_reasons.append("pe_exec_bars_missing")
+            elif not bool(adjusted.get("ce_quote_ready", True)):
+                normalized_reasons.append("selected_ce_quote_missing")
+            elif not bool(adjusted.get("pe_quote_ready", True)):
+                normalized_reasons.append("selected_pe_quote_missing")
+            elif not (
+                bool(adjusted.get("quote_available"))
+                or bool(adjusted.get("ws_quote_proof"))
+            ):
+                normalized_reasons.append("market_data_proof_unavailable")
+            else:
+                normalized_reasons.append("readiness_inconsistent")
+        return bool(armed), normalized_reasons
 
     return wrapped
 

--- a/src/nifty_scalper_bot/core/boot_readiness_safety.py
+++ b/src/nifty_scalper_bot/core/boot_readiness_safety.py
@@ -205,6 +205,20 @@ def adapt_sync_history_from_mdm(original: Callable[..., _T]) -> Callable[..., _T
     return wrapped
 
 
+def adapt_mdm_pipeline_overload(original: Callable[..., Any]) -> Callable[..., Any]:
+    """Do not report overload recovery while a tick batch is still in flight."""
+
+    @wraps(original)
+    def wrapped(self: Any) -> Any:
+        if bool(getattr(self, "_pipeline_overloaded", False)) and int(
+            getattr(self, "_tick_active_drains", 0) or 0
+        ) > 0:
+            return None
+        return original(self)
+
+    return wrapped
+
+
 def _patch_function(
     target: Any,
     name: str,
@@ -263,9 +277,26 @@ def apply_app_patch(app_module: Any) -> None:
             "_history_role_corrected",
         )
 
+    mdm_cls = getattr(app_module, "MarketDataManager", None)
+    if mdm_cls is None:
+        try:
+            from nifty_scalper_bot.data.market_data_manager import MarketDataManager
+
+            mdm_cls = MarketDataManager
+        except Exception:  # noqa: BLE001 - optional import compatibility
+            mdm_cls = None
+    if mdm_cls is not None:
+        _patch_function(
+            mdm_cls,
+            "_update_pipeline_overload_locked",
+            adapt_mdm_pipeline_overload,
+            "_active_drain_overload_recovery_guarded",
+        )
+
 
 __all__ = [
     "adapt_compute_live_readiness",
+    "adapt_mdm_pipeline_overload",
     "adapt_register_and_subscribe_live_symbol",
     "adapt_replay_latest_mdm_ticks_to_bus",
     "adapt_sync_history_from_mdm",

--- a/src/nifty_scalper_bot/core/strategy_runner_dynamic_universe_safety.py
+++ b/src/nifty_scalper_bot/core/strategy_runner_dynamic_universe_safety.py
@@ -96,7 +96,18 @@ def apply_patches() -> None:
             if item
         }
         live_seen = getattr(self, "_live_bar_seen", set())
-        if normalized in selected and normalized not in live_seen:
+        current_version = int(
+            (getattr(self, "_candle_versions", {}) or {}).get(normalized, 0) or 0
+        )
+        last_version = int(
+            (getattr(self, "_last_strategy_versions", {}) or {}).get(normalized, 0)
+            or 0
+        )
+        if (
+            normalized in selected
+            and normalized not in live_seen
+            and current_version > last_version
+        ):
             state = (getattr(self, "_symbol_state", {}) or {}).get(normalized)
             if state is not None:
                 state._last_eval_bar_ts = None

--- a/src/nifty_scalper_bot/core/strategy_runner_dynamic_universe_safety.py
+++ b/src/nifty_scalper_bot/core/strategy_runner_dynamic_universe_safety.py
@@ -18,6 +18,7 @@ def apply_patches() -> None:
 
     original_validate: Callable[..., bool] = StrategyRunner._validate_symbol_for_cycle
     original_sync = StrategyRunner._sync_active_selection_from_basket
+    original_mark_live = StrategyRunner._mark_live
     original_on_tick = StrategyRunner._on_tick
 
     @wraps(original_validate)
@@ -72,21 +73,48 @@ def apply_patches() -> None:
                 return
         original_sync(self, selection)
 
+    @wraps(original_mark_live)
+    def mark_live(self: Any, symbol: str) -> Any:
+        """Record authoritative live evidence even when phase was already set LIVE."""
+        normalized = normalize_symbol(str(symbol or "")) or symbol
+        result = original_mark_live(self, normalized)
+        live_seen = getattr(self, "_live_bar_seen", None)
+        if isinstance(live_seen, set) and normalized:
+            live_seen.add(normalized)
+        return result
+
     @wraps(original_on_tick)
     def on_tick(self: Any, symbol: str, tick: Mapping[str, Any]) -> Any:
-        """Keep quote/data sequence versions out of the candle-version state machine."""
+        """Keep quote versions and hydration-only bar state out of candle gating."""
+        normalized = normalize_symbol(str(symbol or "")) or symbol
+        selected = {
+            normalize_symbol(str(item or ""))
+            for item in (
+                getattr(self, "_active_selected_ce", None),
+                getattr(self, "_active_selected_pe", None),
+            )
+            if item
+        }
+        live_seen = getattr(self, "_live_bar_seen", set())
+        if normalized in selected and normalized not in live_seen:
+            state = (getattr(self, "_symbol_state", {}) or {}).get(normalized)
+            if state is not None:
+                state._last_eval_bar_ts = None
+
         clean_tick = tick
         if isinstance(tick, Mapping) and ("version" in tick or "data_version" in tick):
             clean_tick = dict(tick)
             clean_tick.pop("version", None)
             clean_tick.pop("data_version", None)
-        return original_on_tick(self, symbol, clean_tick)
+        return original_on_tick(self, normalized, clean_tick)
 
     StrategyRunner._dynamic_universe_safety_original_validate = original_validate
     StrategyRunner._dynamic_universe_safety_original_sync = original_sync
+    StrategyRunner._dynamic_universe_safety_original_mark_live = original_mark_live
     StrategyRunner._dynamic_universe_safety_original_on_tick = original_on_tick
     StrategyRunner._validate_symbol_for_cycle = validate_symbol_for_cycle
     StrategyRunner._sync_active_selection_from_basket = sync_active_selection_from_basket
+    StrategyRunner._mark_live = mark_live
     StrategyRunner._on_tick = on_tick
     StrategyRunner._dynamic_universe_safety_installed = True
 

--- a/src/nifty_scalper_bot/core/strategy_runner_dynamic_universe_safety.py
+++ b/src/nifty_scalper_bot/core/strategy_runner_dynamic_universe_safety.py
@@ -96,9 +96,14 @@ def apply_patches() -> None:
             if item
         }
         live_seen = getattr(self, "_live_bar_seen", set())
-        current_version = int(
+        stored_version = int(
             (getattr(self, "_candle_versions", {}) or {}).get(normalized, 0) or 0
         )
+        try:
+            incoming_version = int(tick.get("candle_version") or 0)
+        except (TypeError, ValueError):
+            incoming_version = 0
+        current_version = max(stored_version, incoming_version)
         last_version = int(
             (getattr(self, "_last_strategy_versions", {}) or {}).get(normalized, 0)
             or 0

--- a/tests/core/test_boot_log_safety.py
+++ b/tests/core/test_boot_log_safety.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 from nifty_scalper_bot.core.boot_log_safety import BootLogRateControl
 from nifty_scalper_bot.core.boot_readiness_safety import (
     adapt_compute_live_readiness,
+    adapt_mdm_pipeline_overload,
     adapt_register_and_subscribe_live_symbol,
     adapt_replay_latest_mdm_ticks_to_bus,
     adapt_sync_history_from_mdm,
@@ -135,6 +136,26 @@ def test_rate_control_covers_live_validation_checklist() -> None:
     assert control.filter(first) is True
     assert control.filter(same) is False
     assert control.filter(changed) is True
+
+
+def test_rate_control_covers_indicator_history_missing_noise() -> None:
+    control = BootLogRateControl(interval_seconds=30.0)
+    first = _record(
+        "indicator_engine_history_missing",
+        symbol="NFO:NIFTY2681124600PE",
+    )
+    same = _record(
+        "indicator_engine_history_missing",
+        symbol="NFO:NIFTY2681124600PE",
+    )
+    other = _record(
+        "indicator_engine_history_missing",
+        symbol="NFO:NIFTY2681124600CE",
+    )
+
+    assert control.filter(first) is True
+    assert control.filter(same) is False
+    assert control.filter(other) is True
 
 
 def test_live_validation_checklist_log_contains_primary_gate(caplog) -> None:
@@ -408,3 +429,23 @@ def test_history_sync_adapter_corrects_futures_role_only() -> None:
         ("NFO:NIFTY26AUGFUT", "futures_context"),
         ("NFO:NIFTY2680424750CE", "selected_option"),
     ]
+
+
+def test_active_tick_drain_keeps_pipeline_overload_fail_closed() -> None:
+    calls: list[str] = []
+
+    def original(state):
+        calls.append("original")
+        state._pipeline_overloaded = False
+
+    adapted = adapt_mdm_pipeline_overload(original)
+    state = SimpleNamespace(_pipeline_overloaded=True, _tick_active_drains=1)
+
+    adapted(state)
+    assert state._pipeline_overloaded is True
+    assert calls == []
+
+    state._tick_active_drains = 0
+    adapted(state)
+    assert state._pipeline_overloaded is False
+    assert calls == ["original"]

--- a/tests/core/test_boot_log_safety.py
+++ b/tests/core/test_boot_log_safety.py
@@ -211,6 +211,29 @@ def test_session_readiness_adapter_removes_option_details_outside_session() -> N
     assert reasons == ["market_closed"]
 
 
+def test_live_readiness_adapter_never_returns_unknown_empty_blocker() -> None:
+    adapted = adapt_compute_live_readiness(lambda **_kwargs: (False, []))
+
+    armed, reasons = adapted(
+        live_mode=True,
+        hard_ready=True,
+        quote_available=True,
+        ws_quote_proof=True,
+        market_open=True,
+        runner_running=True,
+        selected_ce="NFO:NIFTY2681124600CE",
+        selected_pe="NFO:NIFTY2681124600PE",
+        ce_bars=105,
+        pe_bars=105,
+        option_exec_min_bars=30,
+        ce_quote_ready=True,
+        pe_quote_ready=True,
+    )
+
+    assert armed is False
+    assert reasons == ["readiness_inconsistent"]
+
+
 def test_cached_tick_replay_skips_when_message_bus_is_inactive() -> None:
     calls: list[str] = []
 

--- a/tests/strategies/test_selected_option_live_path.py
+++ b/tests/strategies/test_selected_option_live_path.py
@@ -218,3 +218,74 @@ def test_quote_versions_do_not_advance_candle_version_or_starve_same_bar_evaluat
     assert runner._candle_versions.get(selected_ce, 0) == 0
     assert first_tick["version"] == 1
     assert second_tick["data_version"] == 22
+
+
+def test_mark_live_records_authoritative_bar_when_phase_was_already_live(monkeypatch):
+    """A pre-set LIVE phase must not prevent the first real bar from being recorded."""
+    apply_patches()
+    runner, _strategy_manager, _risk_manager, _order_manager, selected_ce = (
+        _build_phase9_runner(monkeypatch)
+    )
+    runner._data_phase[selected_ce] = "LIVE"
+    runner._live_bar_seen.discard(selected_ce)
+
+    runner._mark_live(selected_ce)
+
+    assert selected_ce in runner._live_bar_seen
+    assert runner._data_phase[selected_ce] == "LIVE"
+
+
+def test_hydrated_selected_ce_and_pe_both_reach_strategy_manager_on_new_candle_version(monkeypatch):
+    """Hydration-only bar timestamps must not silently starve either selected leg."""
+    apply_patches()
+    runner, strategy_manager, _risk_manager, _order_manager, selected_ce = (
+        _build_phase9_runner(monkeypatch)
+    )
+    selected_pe = runner._active_selected_pe
+    fixed_bar_ts = datetime.now(timezone.utc)
+    runner._refresh_underlying_context_snapshots = lambda **_kwargs: None
+    runner._get_cached_quote_for_live_entry = lambda _symbol: {
+        "symbol": _symbol,
+        "ltp": 100.0,
+        "last_price": 100.0,
+        "bid": 99.5,
+        "ask": 100.5,
+        "timestamp": time.time(),
+    }
+
+    for symbol in (selected_ce, selected_pe):
+        runner._active_symbols.add(symbol)
+        runner._tracked_symbols.add(symbol)
+        runner._history_ready_by_symbol[symbol] = True
+        runner._data_phase[symbol] = "LIVE"
+        runner._symbol_history[symbol] = [{"timestamp": fixed_bar_ts}]
+        runner._last_bar_ts[symbol] = fixed_bar_ts
+        runner._symbol_state[symbol] = SymbolRuntimeState(symbol, 100)
+        runner._symbol_state[symbol].active = True
+        runner._symbol_state[symbol]._last_eval_bar_ts = fixed_bar_ts
+        runner._symbol_states[symbol] = SymbolState.READY
+        runner._active_basket_token_by_symbol[symbol] = 1
+        runner._symbol_has_completed_strategy_eval.add(symbol)
+        runner._candle_versions[symbol] = 2
+        runner._last_strategy_versions[symbol] = 1
+        runner._live_bar_seen.discard(symbol)
+
+    for index, symbol in enumerate((selected_ce, selected_pe), start=1):
+        strategy_manager.generate_signal.reset_mock()
+        runner._on_tick(
+            symbol,
+            {
+                "symbol": symbol,
+                "last_price": 100.0,
+                "ltp": 100.0,
+                "bid": 99.5,
+                "ask": 100.5,
+                "timestamp": time.time(),
+                "source": "ws",
+                "trace_id": f"selected-leg-{index}",
+            },
+        )
+        assert any(
+            call.args and call.args[0] == symbol
+            for call in strategy_manager.generate_signal.call_args_list
+        )

--- a/tests/strategies/test_selected_option_live_path.py
+++ b/tests/strategies/test_selected_option_live_path.py
@@ -273,6 +273,15 @@ def test_hydrated_selected_ce_and_pe_both_reach_strategy_manager_on_new_candle_v
     runner._candle_versions[selected_pe] = 1
 
     for index, symbol in enumerate((selected_ce, selected_pe), start=1):
+        bias = "CE" if symbol.endswith("CE") else "PE"
+        runner._underlying_context_from_strategy_manager = lambda bias=bias: {
+            "direction_bias": bias,
+            "underlying_direction_bias": bias,
+            "spot_fresh": True,
+            "fut_fresh": True,
+            "context_fresh": True,
+            "underlying_direction_confidence": 0.9,
+        }
         strategy_manager.generate_signal.reset_mock()
         tick = {
             "symbol": symbol,

--- a/tests/strategies/test_selected_option_live_path.py
+++ b/tests/strategies/test_selected_option_live_path.py
@@ -240,6 +240,9 @@ def test_hydrated_selected_ce_and_pe_both_reach_strategy_manager_on_new_candle_v
     )
     selected_pe = runner._active_selected_pe
     fixed_bar_ts = datetime.now(timezone.utc)
+    runner._universe_dynamic_mode = True
+    runner._frozen_universe.update({selected_ce, selected_pe})
+    runner._active_option_symbols.update({selected_ce, selected_pe})
     runner._refresh_underlying_context_snapshots = lambda **_kwargs: None
     runner._get_cached_quote_for_live_entry = lambda _symbol: {
         "symbol": _symbol,

--- a/tests/strategies/test_selected_option_live_path.py
+++ b/tests/strategies/test_selected_option_live_path.py
@@ -51,9 +51,6 @@ def test_live_selected_option_tick_reaches_strategy_manager_after_atm_switch(mon
     selected_ce = "NFO:NIFTY26JUN24100CE"
     selected_pe = "NFO:NIFTY26JUN24100PE"
 
-    # Production starts with a frozen startup snapshot. Dynamic ATM selection
-    # later makes a previously contextual contract active; the startup snapshot
-    # must not veto that authoritative dynamic universe update.
     runner._universe_dynamic_mode = True
     runner._frozen_universe = {"NSE:NIFTY", old_ce, old_pe}
 
@@ -266,25 +263,27 @@ def test_hydrated_selected_ce_and_pe_both_reach_strategy_manager_on_new_candle_v
         runner._symbol_states[symbol] = SymbolState.READY
         runner._active_basket_token_by_symbol[symbol] = 1
         runner._symbol_has_completed_strategy_eval.add(symbol)
-        runner._candle_versions[symbol] = 2
         runner._last_strategy_versions[symbol] = 1
         runner._live_bar_seen.discard(symbol)
 
+    runner._candle_versions[selected_ce] = 2
+    runner._candle_versions[selected_pe] = 1
+
     for index, symbol in enumerate((selected_ce, selected_pe), start=1):
         strategy_manager.generate_signal.reset_mock()
-        runner._on_tick(
-            symbol,
-            {
-                "symbol": symbol,
-                "last_price": 100.0,
-                "ltp": 100.0,
-                "bid": 99.5,
-                "ask": 100.5,
-                "timestamp": time.time(),
-                "source": "ws",
-                "trace_id": f"selected-leg-{index}",
-            },
-        )
+        tick = {
+            "symbol": symbol,
+            "last_price": 100.0,
+            "ltp": 100.0,
+            "bid": 99.5,
+            "ask": 100.5,
+            "timestamp": time.time(),
+            "source": "ws",
+            "trace_id": f"selected-leg-{index}",
+        }
+        if symbol == selected_pe:
+            tick["candle_version"] = 2
+        runner._on_tick(symbol, tick)
         assert any(
             call.args and call.args[0] == symbol
             for call in strategy_manager.generate_signal.call_args_list


### PR DESCRIPTION
## Production defects fixed

1. Selected CE/PE could enter Phase 9 yet return before StrategyManager because hydrated `_symbol_history` was treated as live-bar evidence while `_live_bar_seen` could remain unset if `_data_phase` was already LIVE.
2. The same stale hydrated bar timestamp could suppress a newly advanced candle version for one selected leg, producing the observed CE/PE evaluation asymmetry.
3. Pipeline overload could transiently report recovery while a tick batch was still executing, causing readiness/arming flapping during startup pressure.
4. An unarmed live-readiness result with an empty blocker list was logged as `reason=unknown`, hiding the actual inconsistent state.
5. Repeated `indicator_engine_history_missing` diagnostics produced unnecessary log/CPU churn.

## Targeted corrections

- Preserve the existing runner architecture and runtime hardening layer; no new files.
- Make `_mark_live()` always record authoritative live evidence even when phase is already LIVE.
- For selected CE/PE only, neutralize the stale hydrated evaluation timestamp only when an explicit/stored candle version is newer than the last evaluated version and no live-bar marker exists.
- Preserve generic quote/data-version isolation from #1055; explicit `candle_version` remains authoritative.
- Keep pipeline overload fail-closed until the active tick drain settles, then allow the existing recovery logic to run unchanged.
- Convert empty unarmed live-readiness blocker lists into a deterministic fail-closed diagnostic reason; arming result is not changed.
- Add the indicator-history event to the existing state-aware log throttle; readiness itself is unchanged.

## TDD

Existing test files now prove:
- a pre-set LIVE phase cannot lose the first authoritative live-bar marker;
- historically hydrated selected CE and PE both reach StrategyManager on a true new candle version, covering stored and incoming `candle_version` paths;
- existing quote/data sequence numbers still cannot advance candle identity;
- cold basket promotion still waits for both indicator histories;
- overload does not recover while a drain is active but recovers normally after settlement;
- an unarmed readiness result never degrades to `reason=unknown`;
- duplicate indicator-history diagnostics remain visible once per state/entity and are then throttled.

OrderFlow remains context-only. Strategy thresholds, direction gates, quality floor, risk rules, sizing, order idempotency, exits, and order placement are unchanged.