### PR TITLE
Fix remaining post-1056 trading-path inconsistencies

### DIFF
--- a/src/nifty_scalper_bot/core/boot_log_safety.py
+++ b/src/nifty_scalper_bot/core/boot_log_safety.py
@@ -31,6 +31,7 @@ READINESS_EVENTS = {
     "READINESS_BLOCKER_SUMMARY",
     "LIVE_READINESS_COMPUTED",
     "LIVE_VALIDATION_CHECKLIST",
+    "LIVE_ORDER_ARM_BLOCKED",
 }
 ORDERFLOW_EVENTS = {
     "ORDERFLOW_TRIGGER_DECISION",
@@ -78,6 +79,33 @@ def _normalize_role_telemetry(record: logging.LogRecord) -> None:
         record.context_only = True
         if not getattr(record, "contract_side", None):
             record.contract_side = getattr(record, "side", None)
+
+
+def _normalize_readiness_telemetry(record: logging.LogRecord) -> None:
+    """Replace legacy unknown arm telemetry with the visible orchestration blocker."""
+    if _event(record) != "LIVE_ORDER_ARM_BLOCKED":
+        return
+    args = record.args if isinstance(record.args, tuple) else ()
+    if len(args) < 6 or str(args[0] or "").strip().lower() != "unknown":
+        return
+    try:
+        ce_bars, pe_bars, required = int(args[1]), int(args[2]), int(args[3])
+    except (TypeError, ValueError):
+        ce_bars = pe_bars = required = 0
+    indicators_ready = bool(args[4])
+    quote_ready = bool(args[5])
+    if not indicators_ready:
+        reason = "evaluation_not_ready"
+    elif not quote_ready:
+        reason = "selected_option_quote_not_ready"
+    elif ce_bars < required or pe_bars < required:
+        reason = "selected_option_history_not_ready"
+    else:
+        reason = "startup_orchestration_guard"
+    normalized_args = list(args)
+    normalized_args[0] = reason
+    record.args = tuple(normalized_args)
+    record.reason = reason
 
 
 def _entity(record: logging.LogRecord) -> tuple[Any, ...]:
@@ -148,6 +176,7 @@ class BootLogRateControl(logging.Filter):
 
     def filter(self, record: logging.LogRecord) -> bool:
         _normalize_role_telemetry(record)
+        _normalize_readiness_telemetry(record)
         event = _event(record)
         if event not in THROTTLED_EVENTS:
             return True

--- a/src/nifty_scalper_bot/core/boot_readiness_safety.py
+++ b/src/nifty_scalper_bot/core/boot_readiness_safety.py
@@ -7,8 +7,19 @@ from collections.abc import Mapping
 from functools import wraps
 from typing import Any, Awaitable, Callable, TypeVar
 
+from nifty_scalper_bot.utils.logging import log_throttled
+
 _LOGGER = logging.getLogger("nifty_scalper_bot.core.app")
 _T = TypeVar("_T")
+_OPTION_DIRECTION_CONTEXT_KEYS = {
+    "direction_bias",
+    "underlying_direction_bias",
+    "underlying_direction_confidence",
+    "context_age_seconds",
+    "context_fresh",
+    "direction_context_source",
+    "direction_context_reasons",
+}
 
 
 def adapt_compute_live_readiness(
@@ -246,6 +257,79 @@ def adapt_mdm_pipeline_overload(original: Callable[..., Any]) -> Callable[..., A
     return wrapped
 
 
+def adapt_indicator_get_history(original: Callable[..., list[Any]]) -> Callable[..., list[Any]]:
+    """Short-circuit missing histories before duplicate INFO instrumentation runs."""
+
+    @wraps(original)
+    def wrapped(self: Any, symbol: str, *args: Any, **kwargs: Any) -> list[Any]:
+        histories = getattr(self, "_histories", None)
+        lock = getattr(self, "_lock", None)
+        if not isinstance(histories, dict):
+            return original(self, symbol, *args, **kwargs)
+        if lock is not None:
+            with lock:
+                missing = symbol not in histories
+        else:
+            missing = symbol not in histories
+        if not missing:
+            return original(self, symbol, *args, **kwargs)
+
+        market_open = True
+        try:
+            from nifty_scalper_bot.utils.market_hours import is_market_open_now
+
+            market_open = bool(is_market_open_now())
+        except Exception:  # noqa: BLE001 - diagnostics must not affect data access
+            pass
+        logger = getattr(
+            self,
+            "_logger",
+            logging.getLogger("nifty_scalper_bot.strategies.indicators"),
+        )
+        log_throttled(
+            logger,
+            (
+                f"indicator_history_missing:{symbol}"
+                if market_open
+                else f"indicator_history_missing_offmarket:{symbol}"
+            ),
+            (
+                "Condition met: indicator_history_missing"
+                if market_open
+                else "Condition met: indicator_history_missing (market_closed)"
+            ),
+            interval_sec=60.0 if market_open else 900.0,
+            level=logging.INFO if market_open else logging.DEBUG,
+            extra={
+                "event": "indicator_engine_history_missing",
+                "symbol": symbol,
+                "market_session_state": "open" if market_open else "closed",
+            },
+        )
+        return []
+
+    return wrapped
+
+
+def adapt_option_indicator_direction_context(
+    original: Callable[..., Any],
+) -> Callable[..., Any]:
+    """Keep option indicators free of inherited direction; context snapshots own it."""
+
+    @wraps(original)
+    def wrapped(self: Any, symbol: str, *args: Any, **kwargs: Any) -> Any:
+        result = original(self, symbol, *args, **kwargs)
+        normalized = str(symbol or "").strip().upper().replace(" ", "")
+        if not normalized.endswith(("CE", "PE")) or not isinstance(result, Mapping):
+            return result
+        cleaned = dict(result)
+        for key in _OPTION_DIRECTION_CONTEXT_KEYS:
+            cleaned.pop(key, None)
+        return cleaned
+
+    return wrapped
+
+
 def _patch_function(
     target: Any,
     name: str,
@@ -320,10 +404,34 @@ def apply_app_patch(app_module: Any) -> None:
             "_active_drain_overload_recovery_guarded",
         )
 
+    indicator_cls = getattr(app_module, "IndicatorEngine", None)
+    if indicator_cls is None:
+        try:
+            from nifty_scalper_bot.strategies.indicators import IndicatorEngine
+
+            indicator_cls = IndicatorEngine
+        except Exception:  # noqa: BLE001 - optional import compatibility
+            indicator_cls = None
+    if indicator_cls is not None:
+        _patch_function(
+            indicator_cls,
+            "get_history",
+            adapt_indicator_get_history,
+            "_missing_history_single_log_adapted",
+        )
+        _patch_function(
+            indicator_cls,
+            "get_indicators",
+            adapt_option_indicator_direction_context,
+            "_option_direction_context_authority_adapted",
+        )
+
 
 __all__ = [
     "adapt_compute_live_readiness",
+    "adapt_indicator_get_history",
     "adapt_mdm_pipeline_overload",
+    "adapt_option_indicator_direction_context",
     "adapt_register_and_subscribe_live_symbol",
     "adapt_replay_latest_mdm_ticks_to_bus",
     "adapt_sync_history_from_mdm",

--- a/tests/core/test_boot_log_safety.py
+++ b/tests/core/test_boot_log_safety.py
@@ -2,12 +2,15 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import threading
 from types import SimpleNamespace
 
 from nifty_scalper_bot.core.boot_log_safety import BootLogRateControl
 from nifty_scalper_bot.core.boot_readiness_safety import (
     adapt_compute_live_readiness,
+    adapt_indicator_get_history,
     adapt_mdm_pipeline_overload,
+    adapt_option_indicator_direction_context,
     adapt_register_and_subscribe_live_symbol,
     adapt_replay_latest_mdm_ticks_to_bus,
     adapt_sync_history_from_mdm,
@@ -156,6 +159,72 @@ def test_rate_control_covers_indicator_history_missing_noise() -> None:
     assert control.filter(first) is True
     assert control.filter(same) is False
     assert control.filter(other) is True
+
+
+def test_live_order_arm_unknown_is_replaced_by_visible_orchestration_reason() -> None:
+    record = logging.LogRecord(
+        name="nifty_scalper_bot.core.app",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg=(
+            "LIVE_ORDER_ARM_BLOCKED reason=%s ce_bars=%s pe_bars=%s required=%s "
+            "indicators_ready=%s quote_ready=%s"
+        ),
+        args=("unknown", 105, 105, 30, True, True),
+        exc_info=None,
+    )
+
+    assert BootLogRateControl(interval_seconds=30.0).filter(record) is True
+    assert record.reason == "startup_orchestration_guard"
+    assert "reason=startup_orchestration_guard" in record.getMessage()
+    assert "reason=unknown" not in record.getMessage()
+
+
+def test_missing_indicator_history_short_circuits_duplicate_instrumentation() -> None:
+    calls: list[str] = []
+    symbol = "NFO:NIFTY2681124600PE"
+
+    def original(_self, resolved_symbol: str, *args, **kwargs):
+        del args, kwargs
+        calls.append(resolved_symbol)
+        return [1.0]
+
+    state = SimpleNamespace(
+        _histories={},
+        _lock=threading.RLock(),
+        _logger=logging.getLogger("nifty_scalper_bot.strategies.indicators"),
+    )
+    adapted = adapt_indicator_get_history(original)
+
+    assert adapted(state, symbol) == []
+    assert calls == []
+
+    state._histories[symbol] = object()
+    assert adapted(state, symbol) == [1.0]
+    assert calls == [symbol]
+
+
+def test_option_indicator_direction_is_rederived_from_underlying_context() -> None:
+    def original(_self, _symbol: str, *args, **kwargs):
+        del args, kwargs
+        return {
+            "close": 85.0,
+            "direction_bias": "CE",
+            "underlying_direction_bias": "CE",
+            "underlying_direction_confidence": 0.95,
+            "context_age_seconds": 0.01,
+            "context_fresh": True,
+            "direction_context_source": "stale_option_payload",
+        }
+
+    adapted = adapt_option_indicator_direction_context(original)
+    option_payload = adapted(object(), "NFO:NIFTY2681124600PE")
+    spot_payload = adapted(object(), "NSE:NIFTY")
+
+    assert option_payload == {"close": 85.0}
+    assert spot_payload["direction_bias"] == "CE"
+    assert spot_payload["context_fresh"] is True
 
 
 def test_live_validation_checklist_log_contains_primary_gate(caplog) -> None:


### PR DESCRIPTION
Targeted follow-up to post-#1056 live logs.

Fixes:
- removes inherited option-side direction context before StrategyManager so fresh spot/futures snapshots remain the direction authority;
- short-circuits missing IndicatorEngine history lookups before duplicate INFO instrumentation executes;
- replaces legacy LIVE_ORDER_ARM_BLOCKED reason=unknown with an explicit visible orchestration/readiness reason;
- preserves existing overload fail-closed behavior, OrderFlow context-only semantics, strategy thresholds, direction gates, risk, sizing, exits and order safety.

TDD added in the existing boot/readiness test module. No new files.