### PR TITLE
Fix pre-broker entry reservation leak and replacement geometry

### DIFF
--- a/src/nifty_scalper_bot/execution/order_entry_guard_patch.py
+++ b/src/nifty_scalper_bot/execution/order_entry_guard_patch.py
@@ -8,6 +8,7 @@ import os
 from typing import Any, Mapping
 
 from nifty_scalper_bot.execution import order_manager_core as _core
+from nifty_scalper_bot.utils.symbols import normalize_symbol
 
 _PATCH_APPLIED = False
 _ORIGINAL_PLACE_ORDER: Any = None
@@ -133,6 +134,29 @@ def _live_mode(self: Any) -> bool:
     return str(os.getenv("EXECUTION_MODE", "")).strip().upper() == "LIVE"
 
 
+def _release_prebroker_entry_reservation(self: Any, values: Mapping[str, Any]) -> bool:
+    """Release only an explicitly rejected entry that never reached the broker."""
+    intent = getattr(values.get("intent"), "value", values.get("intent"))
+    if str(intent or "").strip().upper() not in _ENTRY_INTENTS:
+        return False
+    decision = getattr(self, "_last_order_decision", None)
+    if not isinstance(decision, Mapping) or decision.get("allowed") is not False:
+        return False
+    if bool(decision.get("broker_attempted")):
+        return False
+    symbol = normalize_symbol(str(values.get("symbol") or ""))
+    reservations = getattr(self, "_entries_in_flight", None)
+    if not symbol or not isinstance(reservations, dict) or symbol not in reservations:
+        return False
+    lock = getattr(self, "_lock", None)
+    if lock is None:
+        reservations.pop(symbol, None)
+    else:
+        with lock:
+            reservations.pop(symbol, None)
+    return True
+
+
 def _patched_place_order(self: Any, *args: Any, **kwargs: Any) -> Any:
     if not _live_mode(self):
         return _ORIGINAL_PLACE_ORDER(self, *args, **kwargs)
@@ -173,7 +197,10 @@ def _patched_place_order(self: Any, *args: Any, **kwargs: Any) -> Any:
                 extra={"event": "ENTRY_GEOMETRY_BLOCKED", **reason},
             )
         return None
-    return _ORIGINAL_PLACE_ORDER(self, *args, **kwargs)
+    result = _ORIGINAL_PLACE_ORDER(self, *args, **kwargs)
+    if result is None:
+        _release_prebroker_entry_reservation(self, values)
+    return result
 
 
 def apply_patches() -> None:
@@ -191,4 +218,8 @@ def apply_patches() -> None:
     _PATCH_APPLIED = True
 
 
-__all__ = ["apply_patches", "_entry_geometry_block_reason"]
+__all__ = [
+    "apply_patches",
+    "_entry_geometry_block_reason",
+    "_release_prebroker_entry_reservation",
+]

--- a/src/nifty_scalper_bot/strategies/premium_risk_geometry.py
+++ b/src/nifty_scalper_bot/strategies/premium_risk_geometry.py
@@ -63,6 +63,10 @@ def _side_geometry_valid(side: str, entry: float, stop: float, target: float) ->
     return 0.0 < target < entry < stop
 
 
+def _same_price(left: float | None, right: float | None) -> bool:
+    return left is not None and right is not None and abs(left - right) <= _TICK_SIZE
+
+
 def _risk_distance(
     signal: Any,
     *,
@@ -74,6 +78,18 @@ def _risk_distance(
     spread = _spread_distance(metadata, entry_price)
     trusted = _premium_domain(metadata)
     stop = _positive_float(getattr(signal, "stop_loss", None))
+    target = _positive_float(getattr(signal, "take_profit", None))
+    candidate_stop = _positive_float(metadata.get("candidate_stop_loss"))
+    candidate_target = _positive_float(metadata.get("candidate_target"))
+    candidate_symbol = str(metadata.get("candidate_symbol") or "").strip().upper()
+    signal_symbol = str(getattr(signal, "symbol", "") or "").strip().upper()
+    copied_candidate_geometry = bool(
+        metadata.get("candidate_selected")
+        and candidate_symbol
+        and candidate_symbol == signal_symbol
+        and _same_price(stop, candidate_stop)
+        and _same_price(target, candidate_target)
+    )
     explicit_stop = _positive_float(
         metadata.get("setup_invalidation_premium")
         or metadata.get("premium_stop_price")
@@ -88,7 +104,17 @@ def _risk_distance(
 
     source = "premium_percent_fallback"
     distance: float | None = None
-    if explicit_stop is not None and trusted:
+    if copied_candidate_geometry and candidate_stop is not None:
+        candidate = (
+            entry_price - candidate_stop
+            if entry_side == "BUY"
+            else candidate_stop - entry_price
+        )
+        if candidate > 0.0:
+            distance = candidate
+            source = "selected_candidate_geometry"
+            trusted = True
+    if distance is None and explicit_stop is not None and trusted:
         candidate = (
             entry_price - explicit_stop
             if entry_side == "BUY"

--- a/tests/execution/test_entry_geometry_guard.py
+++ b/tests/execution/test_entry_geometry_guard.py
@@ -1,6 +1,9 @@
+from threading import RLock
 from types import SimpleNamespace
 
+from nifty_scalper_bot.execution import order_entry_guard_patch as guard_patch
 from nifty_scalper_bot.execution.order_entry_guard_patch import _entry_geometry_block_reason
+from nifty_scalper_bot.utils.symbols import normalize_symbol
 
 
 def test_entry_geometry_blocks_low_reward_to_risk():
@@ -45,3 +48,56 @@ def test_entry_geometry_does_not_block_protective_exit():
     )
 
     assert reason is None
+
+
+def test_explicit_prebroker_rejection_releases_entry_reservation(monkeypatch):
+    symbol = "NFO:NIFTY2681124600CE"
+    normalized = normalize_symbol(symbol)
+    manager = SimpleNamespace(
+        is_live_mode=lambda: True,
+        _lock=RLock(),
+        _entries_in_flight={normalized: 1.0},
+        _last_order_decision={"allowed": False, "broker_attempted": False},
+    )
+    monkeypatch.setattr(
+        guard_patch,
+        "_ORIGINAL_PLACE_ORDER",
+        lambda _self, *args, **kwargs: None,
+    )
+
+    result = guard_patch._patched_place_order(
+        manager,
+        symbol=symbol,
+        side="BUY",
+        quantity=65,
+        intent="ENTRY",
+    )
+
+    assert result is None
+    assert normalized not in manager._entries_in_flight
+
+
+def test_broker_attempted_rejection_keeps_entry_reservation(monkeypatch):
+    symbol = "NFO:NIFTY2681124600CE"
+    normalized = normalize_symbol(symbol)
+    manager = SimpleNamespace(
+        is_live_mode=lambda: True,
+        _lock=RLock(),
+        _entries_in_flight={normalized: 1.0},
+        _last_order_decision={"allowed": False, "broker_attempted": True},
+    )
+    monkeypatch.setattr(
+        guard_patch,
+        "_ORIGINAL_PLACE_ORDER",
+        lambda _self, *args, **kwargs: None,
+    )
+
+    guard_patch._patched_place_order(
+        manager,
+        symbol=symbol,
+        side="BUY",
+        quantity=65,
+        intent="ENTRY",
+    )
+
+    assert normalized in manager._entries_in_flight

--- a/tests/strategies/test_premium_risk_geometry.py
+++ b/tests/strategies/test_premium_risk_geometry.py
@@ -149,6 +149,61 @@ def test_premium_target_rr_remains_authoritative() -> None:
     assert result.take_profit == 112.0
 
 
+def test_replacement_candidate_geometry_beats_stale_original_distance() -> None:
+    signal = _signal(
+        stop_loss=112.746,
+        take_profit=138.2364,
+        candidate_selected=True,
+        candidate_symbol="NFO:NIFTY2680424400PE",
+        candidate_entry_price=122.55,
+        candidate_stop_loss=112.746,
+        candidate_target=138.2364,
+        premium_stop_distance=2.8457142857,
+        premium_target_rr=2.0,
+        premium_risk_reference_price=92.65,
+        invalidation_level_domain="option_premium",
+    )
+
+    result = validate_option_premium_geometry(
+        None,
+        signal,
+        entry_price=122.55,
+        entry_side="BUY",
+        atr=25.0,
+    )
+
+    assert result.stop_loss == 112.746
+    assert result.take_profit == 142.158
+    assert result.metadata["premium_risk_source"] == "selected_candidate_geometry"
+    assert (result.take_profit - 122.55) / (122.55 - result.stop_loss) == 2.0
+
+
+def test_candidate_metadata_does_not_override_uncopied_strategy_geometry() -> None:
+    signal = _signal(
+        stop_loss=119.7042857143,
+        take_profit=128.2414285714,
+        candidate_selected=True,
+        candidate_symbol="NFO:NIFTY2680424400PE",
+        candidate_entry_price=122.55,
+        candidate_stop_loss=112.746,
+        candidate_target=138.2364,
+        premium_stop_distance=2.8457142857,
+        premium_target_rr=2.0,
+        invalidation_level_domain="option_premium",
+    )
+
+    result = validate_option_premium_geometry(
+        None,
+        signal,
+        entry_price=122.55,
+        entry_side="BUY",
+        atr=25.0,
+    )
+
+    assert result.stop_loss == 122.55 - 2.8457142857
+    assert result.metadata["premium_risk_source"] == "premium_stop_distance"
+
+
 def test_execution_anchor_preserves_valid_geometry_instead_of_widening() -> None:
     signal = _signal(stop_loss=92.0, take_profit=116.0)
 
@@ -200,7 +255,6 @@ def test_absolute_invalidation_is_not_moved_by_anchor() -> None:
     assert result is signal
     assert result.stop_loss == 92.0
     assert result.take_profit == 116.0
-
 
 
 def test_runner_geometry_is_owned_at_definition_site() -> None:

--- a/tests/strategies/test_premium_risk_geometry.py
+++ b/tests/strategies/test_premium_risk_geometry.py
@@ -4,6 +4,8 @@ import inspect
 import subprocess
 import sys
 
+import pytest
+
 from nifty_scalper_bot.strategies.premium_risk_geometry import (
     anchor_option_geometry_to_execution,
     apply_premium_risk_contract,
@@ -172,10 +174,11 @@ def test_replacement_candidate_geometry_beats_stale_original_distance() -> None:
         atr=25.0,
     )
 
-    assert result.stop_loss == 112.746
-    assert result.take_profit == 142.158
+    assert result.stop_loss == pytest.approx(112.746)
+    assert result.take_profit == pytest.approx(142.158)
     assert result.metadata["premium_risk_source"] == "selected_candidate_geometry"
-    assert (result.take_profit - 122.55) / (122.55 - result.stop_loss) == 2.0
+    rr = (result.take_profit - 122.55) / (122.55 - result.stop_loss)
+    assert rr == pytest.approx(2.0)
 
 
 def test_candidate_metadata_does_not_override_uncopied_strategy_geometry() -> None:
@@ -200,7 +203,7 @@ def test_candidate_metadata_does_not_override_uncopied_strategy_geometry() -> No
         atr=25.0,
     )
 
-    assert result.stop_loss == 122.55 - 2.8457142857
+    assert result.stop_loss == pytest.approx(122.55 - 2.8457142857)
     assert result.metadata["premium_risk_source"] == "premium_stop_distance"
 
 


### PR DESCRIPTION
Post-#1057 live-log correction from the 14:07-14:08 IST trading window.

Fixes two confirmed execution defects without relaxing any trading or risk gate:
- release the single-position in-flight reservation only after an explicit ENTRY rejection with broker_attempted=False, so a risk-rejected contract cannot block later valid candidates for the 30s TTL;
- preserve the selected replacement contract's copied premium stop geometry ahead of stale premium_stop_distance metadata from the original contract, while retaining the strategy's premium_target_rr contract and the existing final transaction-cost-aware net-RR gate.

No changes to OrderFlow context-only semantics, strategy thresholds, MIN_NET_REWARD_RISK, quote/spread/readiness gates, risk limits, sizing, broker submission, exits, or kill switches. Four existing files only; no new files. TDD added for both failure modes.