### PR TITLE
Preserve bot position ownership after broker reconciliation

### DIFF
--- a/src/nifty_scalper_bot/execution/position_identity_extension.py
+++ b/src/nifty_scalper_bot/execution/position_identity_extension.py
@@ -25,6 +25,14 @@ _SYMBOL_FIELDS = ("symbol", "tradingsymbol", "trading_symbol")
 _AVG_PRICE_FIELDS = ("average_price", "avg_price", "buy_price", "price")
 _QTY_FIELDS = ("quantity", "net_qty", "net_quantity", "netQuantity", "net")
 _QUARANTINE_INTENTS = {"", "UNKNOWN", "BROKER_IMPORTED_ORDER", "MANUAL_ORDER_QUARANTINED"}
+_LOCAL_LIFECYCLE_FIELDS = (
+    "entry_time",
+    "order_id",
+    "stop_loss",
+    "take_profit",
+    "trailing_stop_distance",
+    "state",
+)
 
 
 def _canonical_key(symbol: object) -> str:
@@ -118,6 +126,71 @@ def _prepare_broker_positions(manager: Any, broker_positions: Any) -> tuple[Any,
                 unresolved.add(symbol)
         prepared.append(cloned)
     return prepared, unresolved
+
+
+def _snapshot_owned_position_lifecycle(manager: Any) -> dict[str, dict[str, Any]]:
+    """Capture local-only lifecycle identity for positions already owned by the bot."""
+
+    positions = getattr(manager, "_positions", None)
+    if not isinstance(positions, dict):
+        return {}
+    snapshot: dict[str, dict[str, Any]] = {}
+    for raw_key, position in list(positions.items()):
+        order_id = str(getattr(position, "order_id", "") or "").strip()
+        if not order_id:
+            continue
+        symbol = _canonical_key(getattr(position, "symbol", raw_key))
+        if not symbol:
+            continue
+        values = {field: getattr(position, field, None) for field in _LOCAL_LIFECYCLE_FIELDS}
+        values["side"] = str(getattr(position, "side", "") or "").strip().upper()
+        snapshot[symbol] = values
+    return snapshot
+
+
+def _restore_owned_position_lifecycle(
+    manager: Any,
+    snapshot: dict[str, dict[str, Any]],
+) -> int:
+    """Restore local lifecycle fields only when broker truth still shows the same side."""
+
+    if not snapshot:
+        return 0
+    positions = getattr(manager, "_positions", None)
+    if not isinstance(positions, dict):
+        return 0
+    restored = 0
+    for symbol, values in snapshot.items():
+        position = positions.get(symbol)
+        if position is None:
+            continue
+        saved_side = str(values.get("side") or "").strip().upper()
+        current_side = str(getattr(position, "side", "") or "").strip().upper()
+        if saved_side and current_side and saved_side != current_side:
+            continue
+        try:
+            if int(getattr(position, "quantity", 0) or 0) == 0:
+                continue
+        except (TypeError, ValueError):
+            continue
+        for field in _LOCAL_LIFECYCLE_FIELDS:
+            with suppress(Exception):
+                setattr(position, field, values.get(field))
+        restored += 1
+    return restored
+
+
+def _install_position_ownership_property() -> None:
+    """Expose durable bot ownership to existing orphan/capital diagnostics."""
+
+    position_cls = getattr(_position_manager, "Position", None)
+    if position_cls is None or hasattr(position_cls, "strategy_name"):
+        return
+
+    def strategy_name(position: Any) -> str:
+        return "BotManaged" if str(getattr(position, "order_id", "") or "").strip() else ""
+
+    position_cls.strategy_name = property(strategy_name)
 
 
 def _canonicalize_position_store(manager: Any) -> None:
@@ -218,6 +291,7 @@ def apply_patches() -> None:
     global _PATCH_APPLIED
     if _PATCH_APPLIED:
         return
+    _install_position_ownership_property()
     cls = getattr(_position_manager, "PositionManager", None)
     if cls is None or getattr(cls, "_canonical_position_ingress_patch", False):
         _PATCH_APPLIED = True
@@ -295,6 +369,7 @@ def apply_patches() -> None:
         )
 
     def synchronize_with_broker(self: Any, broker_positions: Any) -> Any:
+        lifecycle_snapshot = _snapshot_owned_position_lifecycle(self)
         prepared, unresolved = _prepare_broker_positions(self, broker_positions)
         self._cost_basis_unresolved_symbols = set(unresolved)
         if unresolved and isinstance(prepared, list):
@@ -304,6 +379,11 @@ def apply_patches() -> None:
             prepared,
         )
         _canonicalize_position_store(self)
+        restored = _restore_owned_position_lifecycle(self, lifecycle_snapshot)
+        if restored:
+            save_state = getattr(self, "save_state", None)
+            if callable(save_state):
+                save_state()
         return result
 
     def apply_broker_order_update(

--- a/tests/execution/test_reconciliation_ownership_guards.py
+++ b/tests/execution/test_reconciliation_ownership_guards.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from types import SimpleNamespace
 
 from nifty_scalper_bot.execution import bracket_ownership_extension as bracket_owner
 from nifty_scalper_bot.execution import position_identity_extension as position_owner
+from nifty_scalper_bot.execution import position_manager as position_module
 
 
 def test_broker_sync_missing_average_price_is_unresolved_not_ltp_cost_basis():
@@ -48,6 +50,116 @@ def test_broker_sync_uses_existing_local_entry_when_average_price_missing():
 
     assert unresolved == set()
     assert prepared[0]["average_price"] == 75.0
+
+
+def test_same_side_broker_rebuild_preserves_bot_owned_lifecycle_identity():
+    symbol = "NFO:NIFTY2681124500CE"
+    opened_at = datetime(2026, 8, 10, 9, 22, 13, tzinfo=timezone.utc)
+    owned = SimpleNamespace(
+        symbol=symbol,
+        side="LONG",
+        quantity=65,
+        entry_price=133.50,
+        current_price=134.00,
+        entry_time=opened_at,
+        order_id="2086744920689139712",
+        stop_loss=122.80,
+        take_profit=154.85,
+        trailing_stop_distance=2.5,
+        state="OPEN_ACTIVE",
+    )
+    manager = SimpleNamespace(_positions={symbol: owned})
+    snapshot = position_owner._snapshot_owned_position_lifecycle(manager)
+
+    rebuilt = SimpleNamespace(
+        symbol=symbol,
+        side="LONG",
+        quantity=50,
+        entry_price=134.25,
+        current_price=135.00,
+        entry_time=datetime(2026, 8, 10, 9, 23, tzinfo=timezone.utc),
+        order_id=None,
+        stop_loss=None,
+        take_profit=None,
+        trailing_stop_distance=None,
+        state=None,
+    )
+    manager._positions = {symbol: rebuilt}
+
+    restored = position_owner._restore_owned_position_lifecycle(manager, snapshot)
+
+    assert restored == 1
+    assert rebuilt.quantity == 50
+    assert rebuilt.entry_price == 134.25
+    assert rebuilt.current_price == 135.00
+    assert rebuilt.entry_time == opened_at
+    assert rebuilt.order_id == "2086744920689139712"
+    assert rebuilt.stop_loss == 122.80
+    assert rebuilt.take_profit == 154.85
+    assert rebuilt.trailing_stop_distance == 2.5
+    assert rebuilt.state == "OPEN_ACTIVE"
+
+
+def test_reversed_broker_position_does_not_inherit_prior_entry_identity():
+    symbol = "NFO:NIFTY2681124500CE"
+    manager = SimpleNamespace(
+        _positions={
+            symbol: SimpleNamespace(
+                symbol=symbol,
+                side="LONG",
+                quantity=65,
+                order_id="ENTRY-1",
+                entry_time=datetime.now(timezone.utc),
+                stop_loss=120.0,
+                take_profit=150.0,
+                trailing_stop_distance=2.0,
+                state="OPEN_ACTIVE",
+            )
+        }
+    )
+    snapshot = position_owner._snapshot_owned_position_lifecycle(manager)
+    reversed_position = SimpleNamespace(
+        symbol=symbol,
+        side="SHORT",
+        quantity=65,
+        order_id=None,
+        entry_time=datetime.now(timezone.utc),
+        stop_loss=None,
+        take_profit=None,
+        trailing_stop_distance=None,
+        state=None,
+    )
+    manager._positions = {symbol: reversed_position}
+
+    restored = position_owner._restore_owned_position_lifecycle(manager, snapshot)
+
+    assert restored == 0
+    assert reversed_position.order_id is None
+
+
+def test_position_order_identity_exposes_bot_managed_ownership_to_orchestrator():
+    opened_at = datetime(2026, 8, 10, 9, 22, 13, tzinfo=timezone.utc)
+    managed = position_module.Position(
+        symbol="NFO:NIFTY2681124500CE",
+        side="LONG",
+        quantity=65,
+        entry_price=133.50,
+        entry_time=opened_at,
+        current_price=134.00,
+        order_id="ENTRY-1",
+    )
+    broker_only = position_module.Position(
+        symbol="NFO:NIFTY2681124550PE",
+        side="LONG",
+        quantity=65,
+        entry_price=60.0,
+        entry_time=opened_at,
+        current_price=61.0,
+        order_id=None,
+    )
+
+    assert managed.strategy_name == "BotManaged"
+    assert broker_only.strategy_name == ""
 
 
 def test_existing_nonterminal_bracket_owns_canonical_symbol():

--- a/tests/execution/test_reconciliation_ownership_guards.py
+++ b/tests/execution/test_reconciliation_ownership_guards.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 from nifty_scalper_bot.execution import bracket_ownership_extension as bracket_owner
 from nifty_scalper_bot.execution import position_identity_extension as position_owner
 from nifty_scalper_bot.execution import position_manager as position_module
+from nifty_scalper_bot.strategies.orchestrator import StrategyAllocation, StrategyOrchestrator
 
 
 def test_broker_sync_missing_average_price_is_unresolved_not_ltp_cost_basis():
@@ -137,29 +138,35 @@ def test_reversed_broker_position_does_not_inherit_prior_entry_identity():
     assert reversed_position.order_id is None
 
 
-def test_position_order_identity_exposes_bot_managed_ownership_to_orchestrator():
-    opened_at = datetime(2026, 8, 10, 9, 22, 13, tzinfo=timezone.utc)
-    managed = position_module.Position(
+def _position(*, order_id: str | None) -> position_module.Position:
+    return position_module.Position(
         symbol="NFO:NIFTY2681124500CE",
         side="LONG",
         quantity=65,
         entry_price=133.50,
-        entry_time=opened_at,
-        current_price=134.00,
-        order_id="ENTRY-1",
-    )
-    broker_only = position_module.Position(
-        symbol="NFO:NIFTY2681124550PE",
-        side="LONG",
-        quantity=65,
-        entry_price=60.0,
-        entry_time=opened_at,
-        current_price=61.0,
-        order_id=None,
+        entry_time=datetime(2026, 8, 10, 9, 22, 13, tzinfo=timezone.utc),
+        current_price=133.50,
+        order_id=order_id,
     )
 
-    assert managed.strategy_name == "BotManaged"
-    assert broker_only.strategy_name == ""
+
+def test_position_order_identity_exposes_bot_managed_ownership_to_orchestrator():
+    assert _position(order_id="ENTRY-1").strategy_name == "BotManaged"
+    assert _position(order_id=None).strategy_name == ""
+
+
+def test_bot_managed_position_counts_toward_strategy_capital_headroom():
+    orchestrator = StrategyOrchestrator(
+        risk_manager=SimpleNamespace(current_balance=11381.0),
+    )
+    allocation = StrategyAllocation(capital_fraction=0.15, tags=())
+    managed = _position(order_id="ENTRY-1")
+    position_manager = SimpleNamespace(get_all_positions=lambda: [managed])
+
+    assert orchestrator._has_capital_headroom(allocation, position_manager) is False
+
+    managed.order_id = None
+    assert orchestrator._has_capital_headroom(allocation, position_manager) is True
 
 
 def test_existing_nonterminal_bracket_owns_canonical_symbol():


### PR DESCRIPTION
## Live evidence
A real SMC signal on 2026-08-10 progressed through candidate replacement, broker submission, fill and active bracket. The next periodic broker reconciliation reconstructed the bot-owned `NFO:NIFTY2681124500CE` position as `Manual/Unknown`, causing the orchestrator to report `tracked=0`, `orphan=8677.50`, `orphan_pos=1`, and `ALLOW`.

## Root cause
`PositionManager.synchronize_with_broker()` rebuilds `Position` from broker truth. Broker rows correctly own quantity/side/cost basis/mark, but do not carry bot-local lifecycle identity such as `order_id`, stop/target/trailing state or original entry timestamp. The current ownership adapter canonicalizes the rebuilt store but did not restore those local-only fields. `StrategyOrchestrator` classifies positions without a strategy marker as orphan, so a bot-created position became orphan after reconciliation.

## Fix
- Snapshot lifecycle identity only for positions with a local `order_id`.
- After broker reconciliation, restore those local-only fields only when the same canonical symbol remains open on the same side.
- Preserve broker authority for quantity, side, average price, mark and realized P&L.
- Expose `Position.strategy_name = BotManaged` only when durable local order identity exists so existing capital/correlation orphan logic recognizes bot-owned exposure.
- Persist the corrected position state after restoration.
- Manual/broker-only positions without local order identity remain orphan; side reversals never inherit prior ownership.

## Tests
Adds regression coverage for same-side identity restoration, broker-side field authority, reversal non-inheritance, and bot-managed ownership exposure. Existing reconciliation ownership tests remain intact.

No strategy trigger, net-RR threshold, readiness, sizing, cooldown, kill-switch, broker, bracket, or exit safety gate is weakened.