### PR TITLE
Make filled exits terminalize canonical brackets deterministically

### DIFF
--- a/src/nifty_scalper_bot/execution/runtime_bracket_manager.py
+++ b/src/nifty_scalper_bot/execution/runtime_bracket_manager.py
@@ -226,6 +226,202 @@ class RuntimeBracketManager(LedgerBracketManager):
             )
         return True
 
+    def _active_brackets_for_exit_symbol(self, symbol: str) -> list[Any]:
+        """Return non-terminal brackets for one canonical symbol."""
+
+        key = _legacy.normalize_symbol(symbol)
+        terminal = {
+            _legacy.BracketExitLifecycle.CLOSED.value,
+            _legacy.BracketExitLifecycle.EXIT_FILLED.value,
+            _legacy.BracketExitLifecycle.EXIT_RECONCILED_FLAT.value,
+        }
+        with self._lock:
+            return [
+                bracket
+                for bracket in self._brackets.values()
+                if _legacy.normalize_symbol(bracket.symbol) == key
+                and int(bracket.remaining_quantity or 0) > 0
+                and str(bracket.exit_state or "") not in terminal
+            ]
+
+    @staticmethod
+    def _exit_side_matches(bracket: Any, order: Any) -> bool:
+        side = str(getattr(order, "side", "") or "").strip().upper()
+        expected = "SELL" if str(bracket.side).upper() == "BUY" else "BUY"
+        return side == expected
+
+    def _resolve_exit_bracket(self, order: Any) -> tuple[Any | None, str]:
+        """Resolve an exit fill to a bracket without guessing across exposures."""
+
+        symbol = _legacy.normalize_symbol(getattr(order, "symbol", ""))
+        identity = [
+            str(getattr(order, name, "") or "").strip()
+            for name in ("bracket_id", "linked_entry_order_id", "trade_lifecycle_id")
+        ]
+        explicit = [value for value in identity if value]
+        for value in explicit:
+            bracket = self._find_bracket_by_id(value)
+            if bracket is None:
+                bracket = self.get_bracket(value)
+            if (
+                bracket is not None
+                and _legacy.normalize_symbol(bracket.symbol) == symbol
+                and self._exit_side_matches(bracket, order)
+            ):
+                return bracket, "managed_identity"
+        if explicit:
+            return None, "identity_mismatch"
+
+        # External/manual broker orders have no lifecycle id.  They can own the
+        # local bracket only after authoritative flat proof and only when there is
+        # exactly one same-symbol bracket, preventing accidental cross-trade binds.
+        residual = self._broker_position_quantity(symbol)
+        if residual != 0:
+            return None, "broker_nonflat_or_unknown"
+        candidates = [
+            bracket
+            for bracket in self._active_brackets_for_exit_symbol(symbol)
+            if self._exit_side_matches(bracket, order)
+        ]
+        if len(candidates) != 1:
+            return None, "external_exit_ambiguous"
+        return candidates[0], "broker_external"
+
+    def reconcile_filled_exit_order(
+        self,
+        order: Any,
+        payload: Mapping[str, Any] | None = None,
+    ) -> bool:
+        """Correlate a confirmed reducing fill and converge its canonical bracket.
+
+        This never closes optimistically.  It only restores order/bracket identity
+        and delegates terminal authority to the existing broker-status, broker-flat
+        and fill-ledger reconciliation state machine.
+        """
+
+        order_id = str(getattr(order, "order_id", "") or "").strip()
+        symbol = _legacy.normalize_symbol(getattr(order, "symbol", ""))
+        if not order_id or not symbol:
+            return False
+        bracket, source = self._resolve_exit_bracket(order)
+        if bracket is None:
+            _legacy.LOGGER.warning(
+                "EXIT_ORDER_CORRELATION_DEFERRED order_id=%s symbol=%s source=%s",
+                order_id,
+                symbol,
+                source,
+                extra={
+                    "event": "EXIT_ORDER_CORRELATION_DEFERRED",
+                    "order_id": order_id,
+                    "symbol": symbol,
+                    "source": source,
+                },
+            )
+            return False
+
+        quantity = int(
+            getattr(order, "filled_quantity", 0)
+            or getattr(order, "quantity", 0)
+            or bracket.remaining_quantity
+            or 0
+        )
+        fill_price = getattr(order, "fill_price", None)
+        if fill_price is None and isinstance(payload, Mapping):
+            fill_price = payload.get("average_price") or payload.get("fill_price")
+        now = time.time()
+        with self._lock:
+            if order_id not in bracket.linked_exit_order_ids:
+                bracket.linked_exit_order_ids.append(order_id)
+            bracket.exit_order_id = order_id
+            bracket.pending_exit_order_id = order_id
+            bracket.exit_intent = "EXIT"
+            bracket.expected_exit_side = str(getattr(order, "side", "") or "").upper()
+            bracket.expected_exit_qty = quantity
+            bracket.exit_pending = True
+            bracket.exit_in_progress = False
+            bracket.exit_submission_inflight = False
+            bracket.exit_state = _legacy.BracketExitLifecycle.EXIT_ORDER_SUBMITTED.value
+            bracket.entry_status = bracket.exit_state
+            bracket.exit_submitted_at = bracket.exit_submitted_at or now
+            bracket.last_exit_attempt_at = bracket.last_exit_attempt_at or now
+            if bracket.exit_reason is None:
+                bracket.exit_reason = (
+                    "BROKER_EXTERNAL" if source == "broker_external" else "BROKER_EXIT"
+                )
+            if fill_price is not None:
+                with suppress(TypeError, ValueError):
+                    bracket.exit_price = float(fill_price)
+            bracket.updated_at = now
+
+        with suppress(Exception):
+            self.save_state()
+        _legacy.LOGGER.info(
+            "EXIT_ORDER_CORRELATED bracket_id=%s order_id=%s symbol=%s source=%s reason=%s qty=%s fill_price=%s",
+            bracket.bracket_id,
+            order_id,
+            symbol,
+            source,
+            bracket.exit_reason,
+            quantity,
+            fill_price,
+            extra={
+                "event": "EXIT_ORDER_CORRELATED",
+                "bracket_id": bracket.bracket_id,
+                "order_id": order_id,
+                "symbol": symbol,
+                "source": source,
+                "exit_reason": bracket.exit_reason,
+                "quantity": quantity,
+                "fill_price": fill_price,
+            },
+        )
+        return bool(
+            self._reconcile_exit_state(
+                bracket,
+                requested_by="order_manager_fill_callback",
+            )
+        )
+
+    def trailing_status_snapshot(self, bracket_or_symbol: Any) -> dict[str, Any] | None:
+        """Return truthful trailing activation state for operator diagnostics."""
+
+        bracket = bracket_or_symbol
+        if not hasattr(bracket, "entry_price"):
+            matches = self._active_brackets_for_exit_symbol(str(bracket_or_symbol))
+            bracket = matches[0] if len(matches) == 1 else None
+        if bracket is None:
+            return None
+        if not bool(getattr(bracket, "trailing_enabled", False)):
+            return {
+                "state": "DISABLED",
+                "mfe_r": 0.0,
+                "activation_r": self._trail_activation_r(bracket),
+            }
+        entry = float(bracket.entry_price or 0.0)
+        initial_sl = float(
+            bracket.initial_sl_trigger_price or bracket.sl_trigger_price or 0.0
+        )
+        initial_risk = abs(entry - initial_sl)
+        if bracket.side == "BUY":
+            mfe = max(0.0, float(bracket.highest_ltp or entry) - entry)
+        else:
+            mfe = max(0.0, entry - float(bracket.lowest_ltp or entry))
+        mfe_r = mfe / initial_risk if initial_risk > 0 else 0.0
+        activation = float(self._trail_activation_r(bracket))
+        moved = int(getattr(bracket, "trail_revision", 0) or 0) > 0
+        state = "TRAILING" if moved else (
+            "ACTIVE" if mfe_r >= activation else "WAITING_ACTIVATION"
+        )
+        return {
+            "state": state,
+            "mfe_r": round(mfe_r, 4),
+            "activation_r": activation,
+            "current_sl": float(bracket.sl_trigger_price or 0.0),
+            "initial_sl": initial_sl,
+            "highest_ltp": float(bracket.highest_ltp or 0.0),
+            "lowest_ltp": float(bracket.lowest_ltp or 0.0),
+        }
+
     def _close_bracket(
         self,
         bracket: Any,

--- a/src/nifty_scalper_bot/execution/runtime_order_manager.py
+++ b/src/nifty_scalper_bot/execution/runtime_order_manager.py
@@ -37,20 +37,15 @@ _EXIT_IDENTITY_KWARGS = {"linked_entry_order_id", "trade_lifecycle_id", "bracket
 def _strip_exit_identity_kwargs(
     kwargs: dict[str, Any],
 ) -> tuple[dict[str, Any], dict[str, Any]]:
-    """Remove exit identity metadata unsupported by core.place_order.
+    """Return core-compatible kwargs while retaining supported exit identity.
 
-    The live bracket safety layer attaches immutable exit metadata to protective
-    order requests. The native entry gate needs to see the original kwargs to
-    classify the request as protective, but the base OrderManager.place_order
-    currently does not accept these metadata-only fields. Strip them only at the
-    delegation boundary so exits cannot fail with a TypeError before reaching the
-    broker.
+    Older core ``place_order`` signatures did not accept these lifecycle fields,
+    so this compatibility helper used to remove them.  The canonical core now
+    accepts and persists them; keep the helper/API but stop discarding identity.
     """
 
     cleaned = dict(kwargs)
-    identity = {
-        key: cleaned.pop(key) for key in list(_EXIT_IDENTITY_KWARGS) if key in cleaned
-    }
+    identity = {key: cleaned[key] for key in _EXIT_IDENTITY_KWARGS if key in cleaned}
     return cleaned, identity
 
 
@@ -276,6 +271,48 @@ class RuntimeOrderManager(_core.OrderManager):
             self._last_exit_identity_kwargs = dict(identity)
         return super().place_order(*args, **cleaned_kwargs)
 
+    def _sync_filled_exit_bracket(
+        self,
+        order: Any,
+        payload: Mapping[str, Any] | None = None,
+    ) -> None:
+        """Ask the canonical bracket owner to converge a confirmed reducing fill."""
+
+        if order is None:
+            return
+        status = getattr(order, "status", None)
+        status_name = str(getattr(status, "name", status) or "").strip().upper()
+        intent = str(getattr(order, "intent", "") or "").strip().upper()
+        if status_name != "FILLED" or intent not in {"EXIT", "REDUCE"}:
+            return
+        bracket_manager = getattr(self, "_bracket_manager", None)
+        reconcile = getattr(bracket_manager, "reconcile_filled_exit_order", None)
+        if not callable(reconcile):
+            return
+        try:
+            reconcile(order, dict(payload or {}))
+        except Exception as exc:  # noqa: BLE001 - fill is already broker truth
+            logger = getattr(self, "_logger", None)
+            log = getattr(logger, "error", None)
+            if callable(log):
+                log(
+                    "EXIT_BRACKET_TERMINAL_RECONCILE_FAILED order_id=%s symbol=%s error=%s",
+                    getattr(order, "order_id", ""),
+                    getattr(order, "symbol", ""),
+                    exc,
+                    extra={
+                        "event": "EXIT_BRACKET_TERMINAL_RECONCILE_FAILED",
+                        "order_id": getattr(order, "order_id", ""),
+                        "symbol": getattr(order, "symbol", ""),
+                        "error_type": type(exc).__name__,
+                    },
+                )
+
+    def _apply_broker_order_update(self, order_update: dict[str, Any]) -> Any:
+        updated = super()._apply_broker_order_update(order_update)
+        self._sync_filled_exit_bracket(updated, order_update)
+        return updated
+
     def _update_from_response(
         self,
         order: Any,
@@ -298,6 +335,7 @@ class RuntimeOrderManager(_core.OrderManager):
                         "error_type": type(exc).__name__,
                     },
                 )
+        self._sync_filled_exit_bracket(updated, payload)
         return updated
 
 

--- a/tests/execution/test_runtime_bracket_facade.py
+++ b/tests/execution/test_runtime_bracket_facade.py
@@ -6,6 +6,7 @@ import json
 import os
 import subprocess
 import sys
+from types import SimpleNamespace
 from typing import Any
 
 import nifty_scalper_bot.execution as execution
@@ -149,3 +150,127 @@ def test_identical_entry_fill_callback_does_not_reactivate_bracket(
 def test_tick_epoch_uses_explicit_receipt_time_when_exchange_time_missing() -> None:
     received_at = datetime(2026, 7, 27, 7, 49, tzinfo=timezone.utc)
     assert bracket_core.tick_exchange_epoch({"received_at": received_at}) == received_at.timestamp()
+
+
+class _ExitBroker:
+    def __init__(self, symbol: str) -> None:
+        self.symbol = symbol
+        self.statuses: dict[str, dict[str, Any]] = {}
+        self.positions: list[dict[str, Any]] = [
+            {"symbol": symbol, "quantity": 65, "average_price": 100.0}
+        ]
+
+    def get_order_status(self, order_id: str) -> dict[str, Any]:
+        return dict(self.statuses.get(order_id, {"status": ""}))
+
+    def get_positions(self) -> list[dict[str, Any]]:
+        return list(self.positions)
+
+
+class _ExitOrderManager(_OrderManager):
+    def __init__(self, broker: _ExitBroker) -> None:
+        super().__init__()
+        self._broker = broker
+
+
+def _exit_manager(tmp_path, monkeypatch):
+    symbol = "NFO:NIFTY2681124500CE"
+    monkeypatch.setenv("BRACKET_FILL_LEDGER_PATH", str(tmp_path / "exit-correlation.db"))
+    monkeypatch.setenv("EXECUTION_MODE", "SHADOW")
+    monkeypatch.setenv("ENABLE_LIVE", "false")
+    broker = _ExitBroker(symbol)
+    manager = bracket_manager.BracketManager(order_manager=_ExitOrderManager(broker))
+    manager._running = False
+    manager._watchdog_thread.join(timeout=1.0)
+    manager._filled_position_sync_grace_seconds = 0.0
+    manager.register_virtual_bracket(
+        order_id="ENTRY-1",
+        symbol=symbol,
+        side="BUY",
+        qty=65,
+        price=100.0,
+        sl=90.0,
+        tp=120.0,
+        activate_immediately=False,
+    )
+    manager.confirm_entry_fill("ENTRY-1", 100.0)
+    return manager, broker, symbol
+
+
+def test_managed_filled_exit_terminalizes_linked_bracket(tmp_path, monkeypatch) -> None:
+    manager, broker, symbol = _exit_manager(tmp_path, monkeypatch)
+    bracket = manager.get_bracket("ENTRY-1")
+    assert bracket is not None
+    bracket.exit_reason = "HARD_SL_BREACH"
+    broker.statuses["EXIT-1"] = {"status": "COMPLETE", "average_price": 95.0}
+    broker.positions = []
+    order = SimpleNamespace(
+        order_id="EXIT-1",
+        symbol=symbol,
+        side="SELL",
+        quantity=65,
+        filled_quantity=65,
+        fill_price=95.0,
+        intent="EXIT",
+        bracket_id="ENTRY-1",
+        linked_entry_order_id="ENTRY-1",
+        trade_lifecycle_id="ENTRY-1",
+    )
+
+    assert manager.reconcile_filled_exit_order(order, broker.statuses["EXIT-1"]) is True
+    assert bracket.exit_state == bracket_core.BracketExitLifecycle.CLOSED.value
+    assert bracket.exit_reason == "HARD_SL_BREACH"
+    assert bracket.exit_order_id == "EXIT-1"
+    assert "EXIT-1" in bracket.linked_exit_order_ids
+    assert manager.has_unresolved_exit() is False
+
+
+def test_external_flatten_closes_only_unique_flat_bracket(tmp_path, monkeypatch) -> None:
+    manager, broker, symbol = _exit_manager(tmp_path, monkeypatch)
+    bracket = manager.get_bracket("ENTRY-1")
+    assert bracket is not None
+    broker.statuses["MANUAL-1"] = {"status": "COMPLETE", "average_price": 97.0}
+    broker.positions = []
+    order = SimpleNamespace(
+        order_id="MANUAL-1",
+        symbol=symbol,
+        side="SELL",
+        quantity=65,
+        filled_quantity=65,
+        fill_price=97.0,
+        intent="EXIT",
+        bracket_id=None,
+        linked_entry_order_id=None,
+        trade_lifecycle_id=None,
+    )
+
+    assert manager.reconcile_filled_exit_order(order, broker.statuses["MANUAL-1"]) is True
+    assert bracket.exit_state == bracket_core.BracketExitLifecycle.CLOSED.value
+    assert bracket.exit_reason == "BROKER_EXTERNAL"
+    assert bracket.close_source == "broker_fill"
+
+
+def test_external_exit_does_not_steal_bracket_while_broker_nonflat(
+    tmp_path, monkeypatch
+) -> None:
+    manager, broker, symbol = _exit_manager(tmp_path, monkeypatch)
+    bracket = manager.get_bracket("ENTRY-1")
+    assert bracket is not None
+    broker.statuses["MANUAL-1"] = {"status": "COMPLETE", "average_price": 97.0}
+    order = SimpleNamespace(
+        order_id="MANUAL-1",
+        symbol=symbol,
+        side="SELL",
+        quantity=65,
+        filled_quantity=65,
+        fill_price=97.0,
+        intent="EXIT",
+        bracket_id=None,
+        linked_entry_order_id=None,
+        trade_lifecycle_id=None,
+    )
+
+    assert manager.reconcile_filled_exit_order(order, broker.statuses["MANUAL-1"]) is False
+    assert bracket.exit_state == bracket_core.BracketExitLifecycle.OPEN_ACTIVE.value
+    assert bracket.exit_order_id is None
+    assert bracket.exit_reason is None

--- a/tests/execution/test_runtime_order_exit_identity_kwargs.py
+++ b/tests/execution/test_runtime_order_exit_identity_kwargs.py
@@ -10,25 +10,19 @@ from nifty_scalper_bot.execution.runtime_order_manager import (
 )
 
 
-def test_strip_exit_identity_kwargs_preserves_core_order_kwargs() -> None:
-    cleaned, identity = _strip_exit_identity_kwargs(
-        {
-            "symbol": "NFO:NIFTY2671424250PE",
-            "side": "SELL",
-            "quantity": 65,
-            "intent": "EXIT",
-            "linked_entry_order_id": "2074702520085045248",
-            "trade_lifecycle_id": "2074702520085045248",
-            "bracket_id": "2074702520085045248",
-        }
-    )
-
-    assert cleaned == {
+def test_exit_identity_helper_preserves_current_core_order_kwargs() -> None:
+    payload = {
         "symbol": "NFO:NIFTY2671424250PE",
         "side": "SELL",
         "quantity": 65,
         "intent": "EXIT",
+        "linked_entry_order_id": "2074702520085045248",
+        "trade_lifecycle_id": "2074702520085045248",
+        "bracket_id": "2074702520085045248",
     }
+    cleaned, identity = _strip_exit_identity_kwargs(payload)
+
+    assert cleaned == payload
     assert identity == {
         "linked_entry_order_id": "2074702520085045248",
         "trade_lifecycle_id": "2074702520085045248",
@@ -36,16 +30,23 @@ def test_strip_exit_identity_kwargs_preserves_core_order_kwargs() -> None:
     }
 
 
-def test_runtime_place_order_strips_exit_identity_only_after_native_gate(monkeypatch) -> None:
+def test_runtime_place_order_preserves_exit_identity_after_native_gate(monkeypatch) -> None:
     manager = object.__new__(RuntimeOrderManager)
     blocked_kwargs: dict[str, Any] = {}
     core_kwargs: dict[str, Any] = {}
 
-    def fake_blocked(self: RuntimeOrderManager, method_name: str, args: tuple[Any, ...], kwargs: dict[str, Any]) -> Any:
+    def fake_blocked(
+        self: RuntimeOrderManager,
+        method_name: str,
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+    ) -> Any:
         blocked_kwargs.update(kwargs)
         return NO_BLOCK
 
-    def fake_core_place_order(self: RuntimeOrderManager, *args: Any, **kwargs: Any) -> str:
+    def fake_core_place_order(
+        self: RuntimeOrderManager, *args: Any, **kwargs: Any
+    ) -> str:
         core_kwargs.update(kwargs)
         return "exit_order_1"
 
@@ -71,7 +72,7 @@ def test_runtime_place_order_strips_exit_identity_only_after_native_gate(monkeyp
     assert blocked_kwargs["intent"] == "EXIT"
     assert blocked_kwargs["linked_entry_order_id"] == "2074702520085045248"
     assert core_kwargs["intent"] == "EXIT"
-    assert "linked_entry_order_id" not in core_kwargs
-    assert "trade_lifecycle_id" not in core_kwargs
-    assert "bracket_id" not in core_kwargs
+    assert core_kwargs["linked_entry_order_id"] == "2074702520085045248"
+    assert core_kwargs["trade_lifecycle_id"] == "2074702520085045248"
+    assert core_kwargs["bracket_id"] == "2074702520085045248"
     assert manager._last_exit_identity_kwargs["bracket_id"] == "2074702520085045248"

--- a/tests/execution/test_runtime_order_facade.py
+++ b/tests/execution/test_runtime_order_facade.py
@@ -208,3 +208,81 @@ print(json.dumps({
     assert payload["before_class"] == payload["after_class"] == payload["package_class"]
     assert payload["before_method"] == payload["after_method"]
     assert payload["module"] == "nifty_scalper_bot.execution.runtime_order_manager"
+
+
+def test_exit_identity_reaches_core_place_order(monkeypatch) -> None:
+    manager = _manager(None)
+    captured: dict[str, Any] = {}
+
+    def core_place_order(self: Any, *args: Any, **kwargs: Any) -> str:
+        captured.update(kwargs)
+        return "EXIT-1"
+
+    monkeypatch.setattr(order_manager_core.OrderManager, "place_order", core_place_order)
+
+    result = manager.place_order(
+        symbol="NFO:NIFTY2681124500CE",
+        side="SELL",
+        quantity=65,
+        intent="EXIT",
+        bracket_id="ENTRY-1",
+        linked_entry_order_id="ENTRY-1",
+        trade_lifecycle_id="ENTRY-1",
+        tag="exit_test",
+        check_risk=False,
+    )
+
+    assert result == "EXIT-1"
+    assert captured["bracket_id"] == "ENTRY-1"
+    assert captured["linked_entry_order_id"] == "ENTRY-1"
+    assert captured["trade_lifecycle_id"] == "ENTRY-1"
+
+
+def test_filled_exit_update_notifies_runtime_bracket_owner(monkeypatch) -> None:
+    class _ExitProvider(_Provider):
+        def __init__(self) -> None:
+            super().__init__(False)
+            self.calls: list[tuple[Any, dict[str, Any]]] = []
+
+        def reconcile_filled_exit_order(
+            self, order: Any, payload: dict[str, Any]
+        ) -> bool:
+            self.calls.append((order, dict(payload)))
+            return True
+
+    provider = _ExitProvider()
+    manager = _manager(provider)
+    manager._bracket_manager = provider
+    filled = SimpleNamespace(
+        order_id="EXIT-1",
+        symbol="NFO:NIFTY2681124500CE",
+        side="SELL",
+        quantity=65,
+        filled_quantity=65,
+        fill_price=95.0,
+        status=order_manager_core.OrderStatus.FILLED,
+        intent="EXIT",
+        bracket_id="ENTRY-1",
+        linked_entry_order_id="ENTRY-1",
+        trade_lifecycle_id="ENTRY-1",
+    )
+
+    def core_apply(self: Any, payload: dict[str, Any]) -> Any:
+        return filled
+
+    monkeypatch.setattr(
+        order_manager_core.OrderManager,
+        "_apply_broker_order_update",
+        core_apply,
+    )
+
+    payload = {
+        "order_id": "EXIT-1",
+        "status": "COMPLETE",
+        "average_price": 95.0,
+        "filled_quantity": 65,
+    }
+    result = RuntimeOrderManager._apply_broker_order_update(manager, payload)
+
+    assert result is filled
+    assert provider.calls == [(filled, payload)]


### PR DESCRIPTION
## Live incident
A real live 65-qty NIFTY option position was flattened by a second broker order, but PositionManager became flat before the canonical virtual bracket terminalized. About one second later the ghost-bracket sweeper had to remove the still-active bracket. The logs also lacked durable exit order -> entry/bracket provenance, so the exit source could not be audited reliably.

## Root causes
1. `RuntimeOrderManager` still removed `bracket_id`, `linked_entry_order_id`, and `trade_lifecycle_id` before delegating to core, even though the current canonical core `place_order()` already accepts and persists those fields.
2. A filled EXIT/REDUCE broker callback finalized PositionManager independently but did not immediately ask the canonical runtime BracketManager to reconcile that same filled exit.

## Fix
- Preserve all currently supported exit identity through the runtime order facade.
- On confirmed EXIT/REDUCE fills, notify the existing canonical bracket owner from both broker-update and immediate-response paths.
- Correlate by durable bracket/entry lifecycle identity first.
- For an external/manual flatten with no lifecycle identity, correlate only if broker truth is flat and exactly one opposite-side active bracket exists for that canonical symbol; otherwise fail closed.
- Do not directly close a live bracket. Delegate to the existing canonical broker-order-status + broker-flat + fill-ledger reconciliation state machine.
- Preserve an existing SL/TP/trailing exit reason; otherwise record `BROKER_EXIT` or `BROKER_EXTERNAL` provenance.
- Expose truthful trailing diagnostic state (`WAITING_ACTIVATION`, `ACTIVE`, `TRAILING`) without changing trailing thresholds.

## TDD
Tests were committed before production changes and cover:
- exit identity reaches current core `place_order()`;
- filled EXIT callback reaches bracket owner;
- managed filled exit terminalizes its linked bracket while preserving the original exit reason;
- unattributed broker flatten closes only a unique same-symbol bracket after authoritative broker-flat proof;
- unattributed/non-flat orders cannot steal bracket ownership.

No strategy trigger, net-RR, sizing, margin, readiness, cooldown, direction, OrderFlow role, kill-switch, SL/TP geometry, trailing activation threshold, or broker risk gate is weakened.