### PR TITLE
Carry newer setup identity through stop-loss rearm

### DIFF
--- a/src/nifty_scalper_bot/execution/runtime_order_manager.py
+++ b/src/nifty_scalper_bot/execution/runtime_order_manager.py
@@ -30,6 +30,7 @@ from nifty_scalper_bot.execution.native_entry_gate import (
     block_result,
     configure_provider,
 )
+from nifty_scalper_bot.strategies.signal_identity_patch import order_setup_context
 
 _EXIT_IDENTITY_KWARGS = {"linked_entry_order_id", "trade_lifecycle_id", "bracket_id"}
 
@@ -269,7 +270,11 @@ class RuntimeOrderManager(_core.OrderManager):
         cleaned_kwargs, identity = _strip_exit_identity_kwargs(effective_kwargs)
         if identity:
             self._last_exit_identity_kwargs = dict(identity)
-        return super().place_order(*args, **cleaned_kwargs)
+        # Keep setup freshness exact and call-scoped. Core still receives the
+        # unchanged order kwargs; the structural stop guard can recover the
+        # strategy setup only while this specific signal is under risk review.
+        with order_setup_context(cleaned_kwargs.get("signal_id")):
+            return super().place_order(*args, **cleaned_kwargs)
 
     def _sync_filled_exit_bracket(
         self,

--- a/src/nifty_scalper_bot/execution/stop_rearm_contract_patch.py
+++ b/src/nifty_scalper_bot/execution/stop_rearm_contract_patch.py
@@ -54,15 +54,33 @@ def _to_epoch(value: Any) -> float | None:
     return None
 
 
-def _signal_setup_epoch(signal: Any) -> float | None:
-    metadata = getattr(signal, "metadata", {})
-    if not isinstance(metadata, Mapping):
-        return None
+def _metadata_setup_epoch(metadata: Mapping[str, Any]) -> float | None:
     for key in _ANCHOR_KEYS:
         anchor = _to_epoch(metadata.get(key))
         if anchor is not None:
             return anchor
     return None
+
+
+def _signal_setup_epoch(signal: Any) -> float | None:
+    metadata = getattr(signal, "metadata", {})
+    if isinstance(metadata, Mapping):
+        anchor = _metadata_setup_epoch(metadata)
+        if anchor is not None:
+            return anchor
+
+    # The final risk layer evaluates a deliberately minimal OrderSignal. The
+    # runtime order facade scopes the exact deterministic strategy setup to this
+    # synchronous call, so recover that identity without using wall-clock time.
+    try:
+        from nifty_scalper_bot.strategies.signal_identity_patch import (
+            current_order_setup_metadata,
+        )
+
+        scoped = current_order_setup_metadata()
+    except Exception:  # noqa: BLE001 - unavailable context must fail closed
+        return None
+    return _metadata_setup_epoch(scoped) if isinstance(scoped, Mapping) else None
 
 
 def _load_persisted_stop(owner: Any) -> dict[str, Any] | None:

--- a/src/nifty_scalper_bot/strategies/signal_identity_patch.py
+++ b/src/nifty_scalper_bot/strategies/signal_identity_patch.py
@@ -2,11 +2,15 @@
 
 from __future__ import annotations
 
+from collections import OrderedDict
+from contextlib import contextmanager
+from contextvars import ContextVar
+from datetime import datetime, timezone
 import hashlib
 import logging
 import re
-from datetime import datetime, timezone
-from typing import Any, Mapping
+import threading
+from typing import Any, Iterator, Mapping
 
 from nifty_scalper_bot.strategies.quote_update_identity import (
     build_evaluation_snapshot_id,
@@ -29,6 +33,20 @@ _ANCHOR_KEYS = (
     "latest_bar_ts",
     "signal_timestamp",
     "timestamp",
+)
+_SETUP_TIMESTAMP_KEYS = (
+    "setup_candle_timestamp",
+    "bar_timestamp",
+    "latest_bar_ts",
+    "signal_timestamp",
+    "timestamp",
+)
+_SETUP_METADATA_LIMIT = 2048
+_SETUP_METADATA_LOCK = threading.Lock()
+_SETUP_METADATA_BY_SIGNAL_ID: OrderedDict[str, dict[str, Any]] = OrderedDict()
+_CURRENT_ORDER_SETUP_METADATA: ContextVar[dict[str, Any] | None] = ContextVar(
+    "current_order_setup_metadata",
+    default=None,
 )
 
 
@@ -74,6 +92,85 @@ def _anchor_value(metadata: Mapping[str, Any]) -> str | None:
     return None
 
 
+def _setup_timestamp_value(metadata: Mapping[str, Any]) -> Any | None:
+    """Return the actual setup candle time, never a wall-clock retry time."""
+    for key in _SETUP_TIMESTAMP_KEYS:
+        value = metadata.get(key)
+        if value not in (None, ""):
+            return value
+
+    # VWAPPro's structural setup_id intentionally embeds the finalized thesis
+    # anchor (``vwap:<side>:<bar timestamp>``). Recover only a timestamp-shaped
+    # suffix; price/structure IDs such as ``smc:PE:66.65`` must not re-arm time.
+    setup_id = str(metadata.get("setup_id") or "").strip()
+    parts = setup_id.split(":", 2)
+    if len(parts) != 3:
+        return None
+    candidate = parts[2].strip()
+    if not candidate:
+        return None
+    if re.fullmatch(r"\d+(?:\.\d+)?", candidate):
+        try:
+            numeric = float(candidate)
+        except ValueError:
+            return None
+        return candidate if numeric >= 1_000_000_000 else None
+    if not re.match(r"^\d{4}-\d{2}-\d{2}[ T]", candidate):
+        return None
+    try:
+        datetime.fromisoformat(candidate.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return candidate
+
+
+def _remember_setup_metadata(signal_id: str, metadata: Mapping[str, Any]) -> None:
+    role = str(metadata.get("role") or "trigger").strip().lower()
+    if role == "context":
+        return
+    timestamp = _setup_timestamp_value(metadata)
+    if timestamp is None:
+        return
+    payload: dict[str, Any] = {"setup_candle_timestamp": timestamp}
+    setup_id = metadata.get("setup_id")
+    if setup_id not in (None, ""):
+        payload["setup_id"] = setup_id
+    with _SETUP_METADATA_LOCK:
+        _SETUP_METADATA_BY_SIGNAL_ID.pop(signal_id, None)
+        _SETUP_METADATA_BY_SIGNAL_ID[signal_id] = payload
+        while len(_SETUP_METADATA_BY_SIGNAL_ID) > _SETUP_METADATA_LIMIT:
+            _SETUP_METADATA_BY_SIGNAL_ID.popitem(last=False)
+
+
+def setup_metadata_for_signal_id(signal_id: object) -> dict[str, Any]:
+    """Return setup metadata previously bound to this deterministic signal id."""
+    key = str(signal_id or "").strip()
+    if not key:
+        return {}
+    with _SETUP_METADATA_LOCK:
+        payload = _SETUP_METADATA_BY_SIGNAL_ID.get(key)
+        if payload is None:
+            return {}
+        _SETUP_METADATA_BY_SIGNAL_ID.move_to_end(key)
+        return dict(payload)
+
+
+def current_order_setup_metadata() -> dict[str, Any]:
+    """Return setup metadata scoped to the currently evaluated order call."""
+    return dict(_CURRENT_ORDER_SETUP_METADATA.get() or {})
+
+
+@contextmanager
+def order_setup_context(signal_id: object) -> Iterator[dict[str, Any]]:
+    """Scope exact setup metadata to one synchronous order/risk evaluation."""
+    payload = setup_metadata_for_signal_id(signal_id)
+    token = _CURRENT_ORDER_SETUP_METADATA.set(payload or None)
+    try:
+        yield payload
+    finally:
+        _CURRENT_ORDER_SETUP_METADATA.reset(token)
+
+
 def _anchor(metadata: Mapping[str, Any]) -> str:
     value = _anchor_value(metadata)
     if value is not None:
@@ -103,7 +200,9 @@ def _deterministic_id(signal: Any) -> str:
     setup_anchor = _anchor(metadata)
     action = str(getattr(signal, "action", ""))
     raw = f"{strategy}:{underlying}:{option_side}:{action}:{setup_anchor}"
-    return hashlib.md5(raw.encode()).hexdigest()[:16]
+    signal_id = hashlib.md5(raw.encode()).hexdigest()[:16]
+    _remember_setup_metadata(signal_id, metadata)
+    return signal_id
 
 
 def _stamp_evaluation_identity(signal: Any, indicators: Mapping[str, Any]) -> Any:
@@ -237,5 +336,8 @@ __all__ = [
     "_deterministic_id",
     "_option_thesis",
     "_stamp_evaluation_identity",
+    "current_order_setup_metadata",
     "has_setup_anchor",
+    "order_setup_context",
+    "setup_metadata_for_signal_id",
 ]

--- a/src/nifty_scalper_bot/strategies/signal_identity_patch.py
+++ b/src/nifty_scalper_bot/strategies/signal_identity_patch.py
@@ -92,43 +92,18 @@ def _anchor_value(metadata: Mapping[str, Any]) -> str | None:
     return None
 
 
-def _setup_timestamp_value(metadata: Mapping[str, Any]) -> Any | None:
-    """Return the actual setup candle time, never a wall-clock retry time."""
-    for key in _SETUP_TIMESTAMP_KEYS:
-        value = metadata.get(key)
-        if value not in (None, ""):
-            return value
-
-    # VWAPPro's structural setup_id intentionally embeds the finalized thesis
-    # anchor (``vwap:<side>:<bar timestamp>``). Recover only a timestamp-shaped
-    # suffix; price/structure IDs such as ``smc:PE:66.65`` must not re-arm time.
-    setup_id = str(metadata.get("setup_id") or "").strip()
-    parts = setup_id.split(":", 2)
-    if len(parts) != 3:
-        return None
-    candidate = parts[2].strip()
-    if not candidate:
-        return None
-    if re.fullmatch(r"\d+(?:\.\d+)?", candidate):
-        try:
-            numeric = float(candidate)
-        except ValueError:
-            return None
-        return candidate if numeric >= 1_000_000_000 else None
-    if not re.match(r"^\d{4}-\d{2}-\d{2}[ T]", candidate):
-        return None
-    try:
-        datetime.fromisoformat(candidate.replace("Z", "+00:00"))
-    except ValueError:
-        return None
-    return candidate
-
-
 def _remember_setup_metadata(signal_id: str, metadata: Mapping[str, Any]) -> None:
-    role = str(metadata.get("role") or "trigger").strip().lower()
-    if role == "context":
+    """Bind only the strategy's stamped setup-candle time to its stable id."""
+    if str(metadata.get("role") or "trigger").strip().lower() == "context":
         return
-    timestamp = _setup_timestamp_value(metadata)
+    timestamp = next(
+        (
+            metadata.get(key)
+            for key in _SETUP_TIMESTAMP_KEYS
+            if metadata.get(key) not in (None, "")
+        ),
+        None,
+    )
     if timestamp is None:
         return
     payload: dict[str, Any] = {"setup_candle_timestamp": timestamp}

--- a/tests/execution/test_stop_rearm_setup_context.py
+++ b/tests/execution/test_stop_rearm_setup_context.py
@@ -44,6 +44,7 @@ def test_runtime_order_scopes_exact_setup_identity_to_core_call(monkeypatch) -> 
             "role": "trigger",
             "contract_side": "PE",
             "setup_id": f"vwap:PE:{setup_timestamp}",
+            "setup_candle_timestamp": setup_timestamp,
         },
     )
     signal_id = _deterministic_id(signal)

--- a/tests/execution/test_stop_rearm_setup_context.py
+++ b/tests/execution/test_stop_rearm_setup_context.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+from nifty_scalper_bot.execution import order_manager_core
+from nifty_scalper_bot.execution.runtime_order_manager import RuntimeOrderManager
+from nifty_scalper_bot.strategies.signal_identity_patch import (
+    _deterministic_id,
+    current_order_setup_metadata,
+)
+
+
+class _Logger:
+    def critical(self, *_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    def error(self, *_args: Any, **_kwargs: Any) -> None:
+        return None
+
+
+class _Provider:
+    def has_unresolved_exit(self) -> bool:
+        return False
+
+
+def _manager() -> RuntimeOrderManager:
+    manager = object.__new__(RuntimeOrderManager)
+    manager._logger = _Logger()
+    manager._last_order_decision = {}
+    manager._unresolved_exit_provider = None
+    manager._unresolved_exit_guard_installed = False
+    return manager
+
+
+def test_runtime_order_scopes_exact_setup_identity_to_core_call(monkeypatch) -> None:
+    manager = _manager()
+    setup_timestamp = "2026-08-11T09:46:00+05:30"
+    signal = SimpleNamespace(
+        symbol="NFO:NIFTY2681124500PE",
+        action="BUY",
+        metadata={
+            "strategy": "VWAPPro",
+            "role": "trigger",
+            "contract_side": "PE",
+            "setup_id": f"vwap:PE:{setup_timestamp}",
+        },
+    )
+    signal_id = _deterministic_id(signal)
+    observed: dict[str, Any] = {}
+
+    def core_place_order(self: Any, *args: Any, **kwargs: Any) -> str:
+        observed.update(current_order_setup_metadata())
+        return "OID-SETUP"
+
+    monkeypatch.setattr(order_manager_core.OrderManager, "place_order", core_place_order)
+
+    order_id = manager.place_order(
+        symbol=signal.symbol,
+        side="BUY",
+        quantity=65,
+        signal_id=signal_id,
+        intent="ENTRY",
+        check_risk=False,
+    )
+
+    assert order_id == "OID-SETUP"
+    assert observed["setup_candle_timestamp"] == setup_timestamp
+    assert observed["setup_id"] == signal.metadata["setup_id"]
+    assert current_order_setup_metadata() == {}
+
+
+def test_context_only_vote_does_not_become_rearm_provenance(monkeypatch) -> None:
+    manager = _manager()
+    signal = SimpleNamespace(
+        symbol="NFO:NIFTY2681124500PE",
+        action="BUY",
+        metadata={
+            "strategy": "OrderFlow",
+            "role": "context",
+            "contract_side": "PE",
+            "setup_candle_timestamp": "2026-08-11T09:47:00+05:30",
+        },
+    )
+    signal_id = _deterministic_id(signal)
+    observed: dict[str, Any] = {"sentinel": True}
+
+    def core_place_order(self: Any, *args: Any, **kwargs: Any) -> str:
+        observed.clear()
+        observed.update(current_order_setup_metadata())
+        return "OID-CONTEXT"
+
+    monkeypatch.setattr(order_manager_core.OrderManager, "place_order", core_place_order)
+
+    manager.place_order(
+        symbol=signal.symbol,
+        side="BUY",
+        quantity=65,
+        signal_id=signal_id,
+        intent="ENTRY",
+        check_risk=False,
+    )
+
+    assert observed == {}

--- a/tests/risk/test_structural_stop_rearm.py
+++ b/tests/risk/test_structural_stop_rearm.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 
+from datetime import datetime, timezone
 import time
 from types import SimpleNamespace
 
 from nifty_scalper_bot.execution.position_manager import PositionManager
+from nifty_scalper_bot.strategies.signal_identity_patch import (
+    _deterministic_id,
+    order_setup_context,
+)
 
 
 def _signal(symbol: str, **metadata):
@@ -25,6 +30,17 @@ def _stopped_manager(monkeypatch, tmp_path) -> PositionManager:
         reason="STOP_LOSS",
     )
     return pm
+
+
+def _vwap_setup_signal(symbol: str, setup_epoch: float) -> SimpleNamespace:
+    anchor = datetime.fromtimestamp(setup_epoch, tz=timezone.utc).isoformat()
+    metadata = {
+        "strategy": "VWAPPro",
+        "role": "trigger",
+        "contract_side": "PE",
+        "setup_id": f"vwap:PE:{anchor}",
+    }
+    return SimpleNamespace(symbol=symbol, action="BUY", metadata=metadata)
 
 
 def test_time_alone_does_not_rearm_stopped_thesis(monkeypatch, tmp_path) -> None:
@@ -81,6 +97,28 @@ def test_new_setup_cannot_bypass_minimum_cooldown(monkeypatch, tmp_path) -> None
     )
 
     assert "stop-loss thesis cooldown active" in reason
+
+
+def test_runtime_setup_context_rearms_only_after_minimum_cooldown(
+    monkeypatch, tmp_path
+) -> None:
+    pm = _stopped_manager(monkeypatch, tmp_path)
+    stopped_at = float(pm._recent_stop_thesis["stopped_at_epoch"])
+    setup = _vwap_setup_signal("NFO:NIFTY2680424350PE", stopped_at + 60)
+    signal_id = _deterministic_id(setup)
+    minimal_risk_signal = SimpleNamespace(symbol=setup.symbol)
+
+    with order_setup_context(signal_id):
+        reason = pm.stop_reentry_block_reason(minimal_risk_signal)
+    assert reason is not None
+    assert "stop-loss thesis cooldown active" in reason
+
+    pm._recent_stop_thesis["expires_epoch"] = time.time() - 1
+    with order_setup_context(signal_id):
+        reason = pm.stop_reentry_block_reason(minimal_risk_signal)
+
+    assert reason is None
+    assert pm._recent_stop_thesis is None
 
 
 def test_opposite_option_side_is_not_blocked(monkeypatch, tmp_path) -> None:

--- a/tests/risk/test_structural_stop_rearm.py
+++ b/tests/risk/test_structural_stop_rearm.py
@@ -39,6 +39,7 @@ def _vwap_setup_signal(symbol: str, setup_epoch: float) -> SimpleNamespace:
         "role": "trigger",
         "contract_side": "PE",
         "setup_id": f"vwap:PE:{anchor}",
+        "setup_candle_timestamp": anchor,
     }
     return SimpleNamespace(symbol=symbol, action="BUY", metadata=metadata)
 


### PR DESCRIPTION
## Live defect
The 11 Aug live logs show repeated valid VWAPPro PE signals reaching candidate selection and final risk after an earlier stop. The timed stop-loss cooldown behaved correctly, but after it expired every new order remained blocked as `stop-loss thesis awaiting newer setup candle` even when the strategy was producing a new 09:46 setup.

## Root cause
The strategy signal already carries a stamped setup-candle timestamp and stable deterministic setup id, but the final risk layer intentionally rebuilds a minimal `OrderSignal`. The structural stop-rearm guard therefore sees no setup metadata and fails closed forever.

## Targeted fix
- Remember only the stamped setup-candle timestamp for trigger signals, keyed by the existing deterministic signal id.
- Exclude context-only votes such as OrderFlow from this cache.
- Scope that exact setup metadata to the synchronous `RuntimeOrderManager.place_order()` call using a ContextVar; clear it immediately afterward.
- Let the existing structural stop guard use this order-scoped timestamp only when the minimal final-risk signal has no explicit setup metadata.
- Keep the cache bounded and thread-safe.

## Safety preserved
- Minimum stop-loss cooldown is unchanged.
- Time alone still cannot re-arm a stopped thesis.
- Missing setup identity still fails closed.
- A stale/reused setup still blocks.
- Only a strictly newer setup candle may clear the latch.
- No strategy scores, net-RR, regime gates, readiness, sizing, margin, cooldown duration, direction logic, OrderFlow role, bracket, exit, or broker safety gates are changed.

## TDD
Regression coverage reproduces the live boundary: a minimal final-risk signal remains blocked during minimum cooldown, then re-arms only when the exact deterministic trigger signal has a newer stamped setup candle. Additional coverage proves the setup context reaches core only during that order call and that context-only votes cannot become re-arm provenance.