### PR TITLE
Protect minute rollover from critical tick backlog

### DIFF
--- a/src/nifty_scalper_bot/data/candle_clock_flush_hardening.py
+++ b/src/nifty_scalper_bot/data/candle_clock_flush_hardening.py
@@ -27,10 +27,117 @@ def _coerce_ist_timestamp(value: Any) -> pd.Timestamp | None:
     return timestamp.tz_convert(_IST_TZ)
 
 
+def _raw_tick_minute(tick: Mapping[str, Any]) -> pd.Timestamp | None:
+    for key in ("exchange_timestamp", "timestamp", "last_trade_time"):
+        value = tick.get(key)
+        if value in (None, ""):
+            continue
+        parsed = _coerce_ist_timestamp(value)
+        if parsed is not None:
+            return parsed.floor("1min")
+    return None
+
+
+def _has_unapplied_tick_for_minute(
+    manager: Any, symbol: str, expected_minute: pd.Timestamp
+) -> bool:
+    """Return whether an already-received same-minute tick is not applied yet."""
+    canonicalize = getattr(manager, "_canonical_symbol", None)
+    canonical = canonicalize(symbol) if callable(canonicalize) else symbol
+    lock = getattr(manager, "_pending_tick_lock", None)
+    if lock is None:
+        return False
+    with lock:
+        if getattr(manager, "_candle_tick_inflight_symbol", None) == canonical:
+            return True
+        queues = getattr(manager, "_pending_tick_queues", {}) or {}
+        queue = list(queues.get(canonical, ()))
+        far = (getattr(manager, "_pending_far_ticks", {}) or {}).get(canonical)
+        if isinstance(far, Mapping):
+            queue.append(far)
+    return any(
+        isinstance(tick, Mapping)
+        and _raw_tick_minute(tick) == expected_minute
+        for tick in queue
+    )
+
+
 def install_candle_clock_flush_hardening(manager_cls: type[Any]) -> None:
-    """Replace clock flush with an expected-minute, race-safe implementation."""
+    """Install race-safe clock flush and critical-context queue fairness."""
     if bool(getattr(manager_cls, _INSTALLED_ATTR, False)):
         return
+
+    original_process_tick = manager_cls._process_queued_tick
+
+    def _process_queued_tick(self: Any, raw: Mapping[str, Any]) -> Any:
+        symbol = str(raw.get("symbol") or "")
+        if not symbol:
+            try:
+                token = int(raw.get("instrument_token") or raw.get("token") or 0)
+            except (TypeError, ValueError):
+                token = 0
+            symbol = str((getattr(self, "_symbol_by_token", {}) or {}).get(token) or "")
+        canonicalize = getattr(self, "_canonical_symbol", None)
+        canonical = canonicalize(symbol) if callable(canonicalize) and symbol else symbol
+        lock = getattr(self, "_pending_tick_lock", None)
+        if lock is not None:
+            with lock:
+                self._candle_tick_inflight_symbol = canonical or None
+        try:
+            return original_process_tick(self, raw)
+        finally:
+            if lock is not None:
+                with lock:
+                    if getattr(self, "_candle_tick_inflight_symbol", None) == canonical:
+                        self._candle_tick_inflight_symbol = None
+
+    def _pop_pending_tick_batch(self: Any) -> list[dict[str, Any]]:
+        """Preserve FIFO but prefer critical spot/future context on priority ties."""
+        batch: list[dict[str, Any]] = []
+        with self._pending_tick_lock:
+            if self._pending_count_locked() <= 0:
+                self._tick_drain_scheduled = False
+                return []
+            for _ in range(self._tick_drain_batch_size):
+                selected_key: str | None = None
+                selected_rank: tuple[int, int, float] | None = None
+                for key, queue in self._pending_tick_queues.items():
+                    if not queue:
+                        continue
+                    head = queue[0]
+                    priority = int(head.get("_mdm_priority", 99))
+                    bucket = str(head.get("_mdm_priority_bucket") or "")
+                    # Near-ATM options intentionally remain FIFO so CandleEngine
+                    # still sees every tick, but they must not tie-starve the
+                    # futures/spot context that drives direction/readiness.
+                    bucket_rank = 1 if bucket == "near_atm" else 0
+                    enqueued = head.get("_mdm_enqueued_mono")
+                    age_rank = (
+                        float(enqueued)
+                        if isinstance(enqueued, (int, float))
+                        else float("inf")
+                    )
+                    rank = (priority, bucket_rank, age_rank)
+                    if selected_rank is None or rank < selected_rank:
+                        selected_key = key
+                        selected_rank = rank
+                if selected_key is not None:
+                    queue = self._pending_tick_queues[selected_key]
+                    batch.append(queue.popleft())
+                    self._pending_decrement_locked(1)
+                    if not queue:
+                        self._pending_tick_queues.pop(selected_key, None)
+                    continue
+                if self._pending_far_ticks:
+                    _key, tick = self._pending_far_ticks.popitem()
+                    self._pending_decrement_locked(1)
+                    batch.append(tick)
+                    continue
+                break
+            prune = getattr(self, "_pending_heap_prune_locked", None)
+            if callable(prune):
+                prune()
+        return batch
 
     def flush_due_candles(
         self: Any,
@@ -63,6 +170,11 @@ def install_candle_clock_flush_hardening(manager_cls: type[Any]) -> None:
             if expected_minute is None:
                 continue
             if now_ts < expected_minute + pd.Timedelta(minutes=1, seconds=grace):
+                continue
+            # A tick already received before the clock flush must be incorporated
+            # before this minute becomes immutable. This covers both queued and
+            # currently-processing ticks without allowing finalized OHLC mutation.
+            if _has_unapplied_tick_for_minute(self, symbol, expected_minute):
                 continue
 
             # Completed history is authoritative, and tick-driven rollover can
@@ -177,6 +289,8 @@ def install_candle_clock_flush_hardening(manager_cls: type[Any]) -> None:
                 )
         return flushed
 
+    manager_cls._process_queued_tick = _process_queued_tick
+    manager_cls._pop_pending_tick_batch = _pop_pending_tick_batch
     manager_cls.flush_due_candles = flush_due_candles
     setattr(manager_cls, _INSTALLED_ATTR, True)
 

--- a/src/nifty_scalper_bot/data/candle_clock_flush_hardening.py
+++ b/src/nifty_scalper_bot/data/candle_clock_flush_hardening.py
@@ -67,7 +67,10 @@ def install_candle_clock_flush_hardening(manager_cls: type[Any]) -> None:
     if bool(getattr(manager_cls, _INSTALLED_ATTR, False)):
         return
 
-    original_process_tick = manager_cls._process_queued_tick
+    original_process_tick: Any = getattr(manager_cls, "_process_queued_tick", None)
+    has_tick_queue = callable(original_process_tick) and callable(
+        getattr(manager_cls, "_pop_pending_tick_batch", None)
+    )
 
     def _process_queued_tick(self: Any, raw: Mapping[str, Any]) -> Any:
         symbol = str(raw.get("symbol") or "")
@@ -289,8 +292,9 @@ def install_candle_clock_flush_hardening(manager_cls: type[Any]) -> None:
                 )
         return flushed
 
-    manager_cls._process_queued_tick = _process_queued_tick
-    manager_cls._pop_pending_tick_batch = _pop_pending_tick_batch
+    if has_tick_queue:
+        manager_cls._process_queued_tick = _process_queued_tick
+        manager_cls._pop_pending_tick_batch = _pop_pending_tick_batch
     manager_cls.flush_due_candles = flush_due_candles
     setattr(manager_cls, _INSTALLED_ATTR, True)
 

--- a/tests/data/test_minute_rollover_tick_fairness.py
+++ b/tests/data/test_minute_rollover_tick_fairness.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from collections import deque
+
+import pandas as pd
+
+from nifty_scalper_bot.data.candle_clock_flush_hardening import (
+    install_candle_clock_flush_hardening,
+)
+from nifty_scalper_bot.data.candle_engine import CandleEngine
+from nifty_scalper_bot.data.market_data_manager import MarketDataManager
+
+
+def _tick(symbol: str, *, bucket: str, enqueued: float, timestamp: str) -> dict:
+    return {
+        "symbol": symbol,
+        "last_price": 100.0,
+        "timestamp": timestamp,
+        "exchange_timestamp": timestamp,
+        "_mdm_priority": 2,
+        "_mdm_priority_bucket": bucket,
+        "_mdm_enqueued_mono": enqueued,
+    }
+
+
+def test_equal_priority_context_batch_prefers_spot_future_over_near_atm() -> None:
+    install_candle_clock_flush_hardening(MarketDataManager)
+    mdm = MarketDataManager(kite=None)
+    mdm._tick_drain_batch_size = 1
+    near = "NFO:NIFTY2681124500CE"
+    future = "NFO:NIFTY26AUGFUT"
+    near_tick = _tick(
+        near,
+        bucket="near_atm",
+        enqueued=1.0,
+        timestamp="2026-08-11T12:22:58+05:30",
+    )
+    future_tick = _tick(
+        future,
+        bucket="spot_future_context",
+        enqueued=2.0,
+        timestamp="2026-08-11T12:22:59+05:30",
+    )
+    # Reproduce the live tie: near-ATM queue was inserted first, so the old
+    # dict-order tie breaker drained it ahead of critical futures context.
+    mdm._pending_tick_queues[near] = deque([near_tick])
+    mdm._pending_tick_queues[future] = deque([future_tick])
+    mdm._pending_tick_count = 2
+
+    batch = mdm._pop_pending_tick_batch()
+
+    assert [tick["symbol"] for tick in batch] == [future]
+    assert list(mdm._pending_tick_queues[near]) == [near_tick]
+
+
+def test_clock_flush_waits_for_same_minute_tick_already_pending() -> None:
+    install_candle_clock_flush_hardening(MarketDataManager)
+    mdm = MarketDataManager(kite=None)
+    symbol = "NFO:NIFTY26AUGFUT"
+    minute = pd.Timestamp("2026-08-11T12:22:00+05:30")
+    engine = CandleEngine(symbol=symbol)
+    engine.current_candle = {
+        "timestamp": minute,
+        "open": 24400.0,
+        "high": 24405.0,
+        "low": 24395.0,
+        "close": 24402.0,
+        "volume": 100,
+    }
+    mdm._engines[symbol] = engine
+    pending = _tick(
+        symbol,
+        bucket="spot_future_context",
+        enqueued=1.0,
+        timestamp="2026-08-11T12:22:59+05:30",
+    )
+    mdm._pending_tick_queues[symbol] = deque([pending])
+    mdm._pending_tick_count = 1
+
+    assert (
+        mdm.flush_due_candles(
+            now=pd.Timestamp("2026-08-11T12:23:02+05:30"),
+            grace_seconds=1.5,
+        )
+        == 0
+    )
+    assert engine.current_candle is not None
+    assert engine.latest_finalized_minute() is None
+
+    mdm._pending_tick_queues.clear()
+    mdm._pending_tick_count = 0
+    assert (
+        mdm.flush_due_candles(
+            now=pd.Timestamp("2026-08-11T12:23:03+05:30"),
+            grace_seconds=1.5,
+        )
+        == 1
+    )
+    assert engine.current_candle is None
+    assert engine.latest_finalized_minute() == minute
+
+
+def test_clock_flush_waits_while_same_symbol_tick_is_inflight() -> None:
+    install_candle_clock_flush_hardening(MarketDataManager)
+    mdm = MarketDataManager(kite=None)
+    symbol = "NFO:NIFTY26AUGFUT"
+    minute = pd.Timestamp("2026-08-11T12:22:00+05:30")
+    engine = CandleEngine(symbol=symbol)
+    engine.current_candle = {
+        "timestamp": minute,
+        "open": 24400.0,
+        "high": 24405.0,
+        "low": 24395.0,
+        "close": 24402.0,
+        "volume": 100,
+    }
+    mdm._engines[symbol] = engine
+    mdm._candle_tick_inflight_symbol = symbol
+
+    assert (
+        mdm.flush_due_candles(
+            now=pd.Timestamp("2026-08-11T12:23:02+05:30"),
+            grace_seconds=1.5,
+        )
+        == 0
+    )
+    assert engine.current_candle is not None
+
+    mdm._candle_tick_inflight_symbol = None
+    assert (
+        mdm.flush_due_candles(
+            now=pd.Timestamp("2026-08-11T12:23:03+05:30"),
+            grace_seconds=1.5,
+        )
+        == 1
+    )


### PR DESCRIPTION
## Live evidence
11 Aug live logs show recurring minute-boundary market-data overload and event-loop lag. At 12:23:02 a NIFTY futures tick for the 12:22 candle was processed only after that minute had already been clock-finalized, producing `CANDLE_TICK_DROPPED reason=finalized_minute`.

## Root cause
MDM preserves FIFO for selected/critical context ticks, but `spot_future_context` and `near_atm` both use priority 2. `_pop_pending_tick_batch` resolves equal priority by dict insertion order, so a busy near-ATM queue can repeatedly precede futures/spot. Separately, clock flush checks CandleEngine state but had no visibility into an already-received same-minute tick still queued or currently processing.

## Targeted correction
- Preserve all existing FIFO queues and loss accounting.
- On equal numeric priority, prefer spot/futures context over optional near-ATM context and use oldest queue-head time as the next tie-break.
- Track only the currently processing tick symbol around the existing `_process_queued_tick` call.
- Defer clock finalization when the same symbol has a same-minute tick already pending or is currently processing.
- Keep finalized candles immutable; no late OHLC mutation is permitted.

## Safety preserved
No strategy thresholds, signal gates, net-RR, risk sizing, margin, live readiness, overload fail-closed behavior, open-position priority, protective bracket dispatch, CandleEngine finalized-history contract, or broker order logic is changed.

## Regression coverage
- Equal-priority near-ATM insertion can no longer tie-starve futures context.
- Clock flush waits for a same-minute queued futures tick.
- Clock flush also waits for an in-flight same-symbol tick, closing the pop-vs-flush race.