### PR TITLE
Short-circuit non-tradable context strategy work

### DIFF
--- a/src/nifty_scalper_bot/core/__init__.py
+++ b/src/nifty_scalper_bot/core/__init__.py
@@ -149,12 +149,16 @@ def _apply_app_runtime_patches(app_module: Any) -> None:
     from nifty_scalper_bot.core.session_boundary_rearm import (
         apply_app_patch as _session_boundary_adapter,
     )
+    from nifty_scalper_bot.core.strategy_context_fast_path import (
+        apply_patches as _strategy_context_fast_path_adapter,
+    )
     from nifty_scalper_bot.core.strategy_runner_dynamic_universe_safety import (
         apply_patches as _dynamic_universe_adapter,
     )
 
     _dynamic_universe_adapter()
     _runtime_reliability_adapter()
+    _strategy_context_fast_path_adapter()
     _off_market_controller_adapter()
     _off_market_app_adapter(app_module)
     _session_boundary_adapter(app_module)

--- a/src/nifty_scalper_bot/core/strategy_context_fast_path.py
+++ b/src/nifty_scalper_bot/core/strategy_context_fast_path.py
@@ -1,0 +1,154 @@
+"""Skip trade-strategy work for non-tradable spot/futures context symbols."""
+
+from __future__ import annotations
+
+from functools import wraps
+import logging
+from typing import Any, Mapping
+
+from nifty_scalper_bot.utils.logging import get_logger, log_throttled
+from nifty_scalper_bot.utils.symbols import normalize_symbol
+
+_LOG = get_logger(__name__)
+_PATCH_ATTR = "_context_only_fast_path_installed"
+_CONTEXT_ROLES = {"spot_context", "futures_context"}
+
+# Only fields consumed by StrategyManager._update_context_snapshot() and
+# _derive_context_direction(). Strategy-only SMC/ORB/OrderFlow inputs do not
+# belong on spot/futures context evaluation.
+CONTEXT_REQUIRED_INDICATORS = frozenset(
+    {
+        "symbol",
+        "ltp",
+        "price",
+        "close",
+        "open",
+        "day_open",
+        "first_ltp",
+        "previous_close",
+        "prev_close",
+        "previous_price",
+        "recent_ltp_delta",
+        "net_change",
+        "price_change_pct",
+        "tick_slope",
+        "exchange_vwap",
+        "session_vwap",
+        "vwap",
+        "ema_fast",
+        "ema_9",
+        "ema9",
+        "ema_slow",
+        "ema_21",
+        "ema21",
+        "ema_50",
+        "ema50",
+        "ema_slope",
+        "vwap_slope",
+        "adx",
+        "atr",
+        "volume",
+        "avg_volume",
+        "futures_volume_ratio",
+        "direction_bias",
+        "underlying_direction_bias",
+        "underlying_direction_confidence",
+        "direction_confidence",
+        "regime",
+        "market_regime",
+    }
+)
+
+
+def _generate_context_only(
+    manager: Any,
+    symbol: str,
+    current_price: float,
+    role: str,
+) -> None:
+    """Refresh one context snapshot without running trade-strategy machinery."""
+    symbol = normalize_symbol(symbol)
+    decision_map = getattr(manager, "_last_no_signal_decision_by_symbol", None)
+    if isinstance(decision_map, dict):
+        decision_map.pop(str(symbol).upper(), None)
+
+    raw = manager._indicator_engine.get_indicators(
+        symbol,
+        set(CONTEXT_REQUIRED_INDICATORS),
+    )
+    if isinstance(raw, dict):
+        indicators: dict[str, Any] = dict(raw)
+    elif hasattr(raw, "items"):
+        indicators = dict(raw.items())
+    else:
+        indicators = {}
+
+    indicators.setdefault("ltp", current_price)
+    indicators.setdefault("price", current_price)
+    indicators.setdefault("close", current_price)
+    indicators["symbol_role"] = role
+
+    augment = getattr(manager, "_augment_futures_metrics", None)
+    if callable(augment):
+        augment(indicators)
+    manager._update_context_snapshot(
+        symbol=symbol,
+        indicators=indicators,
+        role=role,
+    )
+    log_throttled(
+        _LOG,
+        key=f"context_symbol_strategy_eval_skipped:{symbol}",
+        msg=(
+            "CONTEXT_SYMBOL_STRATEGY_EVAL_SKIPPED "
+            f"symbol={symbol} role={role} "
+            "reason=context_only_fast_path"
+        ),
+        interval_sec=30.0,
+        level=logging.INFO,
+        extra={
+            "event": "CONTEXT_SYMBOL_STRATEGY_EVAL_SKIPPED",
+            "symbol": symbol,
+            "symbol_role": role,
+            "reason": "context_only_fast_path",
+            "required_indicator_count": len(CONTEXT_REQUIRED_INDICATORS),
+        },
+    )
+    return None
+
+
+def apply_patches() -> bool:
+    """Install the context-only short circuit on the production StrategyManager."""
+    from nifty_scalper_bot.core.strategy_manager import (
+        StrategyManager,
+        classify_symbol_role,
+    )
+
+    if bool(getattr(StrategyManager, _PATCH_ATTR, False)):
+        return True
+    original = StrategyManager.generate_signal
+
+    @wraps(original)
+    def generate_signal(
+        self: Any,
+        symbol: str,
+        current_price: float,
+        *,
+        trace_id: str | None = None,
+    ) -> Any:
+        normalized = normalize_symbol(symbol)
+        role = classify_symbol_role(normalized)
+        if role in _CONTEXT_ROLES:
+            return _generate_context_only(self, normalized, current_price, role)
+        return original(self, normalized, current_price, trace_id=trace_id)
+
+    StrategyManager.generate_signal = generate_signal  # type: ignore[method-assign]
+    setattr(StrategyManager, _PATCH_ATTR, True)
+    return True
+
+
+__all__ = [
+    "CONTEXT_REQUIRED_INDICATORS",
+    "_generate_context_only",
+    "apply_patches",
+]

--- a/tests/core/test_strategy_context_fast_path.py
+++ b/tests/core/test_strategy_context_fast_path.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from nifty_scalper_bot.core.strategy_context_fast_path import (
+    CONTEXT_REQUIRED_INDICATORS,
+    _generate_context_only,
+)
+
+
+class _Indicators:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, set[str]]] = []
+
+    def get_indicators(self, symbol: str, required: set[str]):
+        self.calls.append((symbol, set(required)))
+        return {
+            "ltp": 24450.0,
+            "close": 24450.0,
+            "vwap": 24440.0,
+            "ema_fast": 24448.0,
+            "ema_slow": 24442.0,
+            "volume": 1000.0,
+            "avg_volume": 800.0,
+        }
+
+
+def _manager():
+    engine = _Indicators()
+    updates: list[dict] = []
+    augmented: list[dict] = []
+    manager = SimpleNamespace(
+        _indicator_engine=engine,
+        _last_no_signal_decision_by_symbol={"NSE:NIFTY": object()},
+        _augment_futures_metrics=lambda indicators: augmented.append(dict(indicators)),
+        _update_context_snapshot=lambda **kwargs: updates.append(kwargs),
+    )
+    return manager, engine, updates, augmented
+
+
+def test_context_fast_path_uses_compact_indicator_contract() -> None:
+    manager, engine, updates, augmented = _manager()
+
+    assert _generate_context_only(manager, "NSE:NIFTY", 24451.0, "spot_context") is None
+
+    assert len(engine.calls) == 1
+    symbol, required = engine.calls[0]
+    assert symbol == "NSE:NIFTY"
+    assert required == set(CONTEXT_REQUIRED_INDICATORS)
+    assert "bos_confirmed" not in required
+    assert "liquidity_sweep_confirmed" not in required
+    assert "selected_ce" not in required
+    assert augmented
+    assert updates and updates[0]["role"] == "spot_context"
+    indicators = updates[0]["indicators"]
+    assert indicators["ltp"] == 24450.0
+    assert indicators["price"] == 24451.0
+    assert indicators["symbol_role"] == "spot_context"
+    assert "NSE:NIFTY" not in manager._last_no_signal_decision_by_symbol
+
+
+def test_context_fast_path_accepts_mapping_like_indicator_result() -> None:
+    manager, engine, updates, _ = _manager()
+
+    class _MappingLike:
+        def items(self):
+            return {"ltp": 25000.0, "vwap": 24990.0}.items()
+
+    engine.get_indicators = lambda _symbol, _required: _MappingLike()
+
+    _generate_context_only(manager, "NFO:NIFTY26AUGFUT", 25001.0, "futures_context")
+
+    assert updates[0]["indicators"]["ltp"] == 25000.0
+    assert updates[0]["indicators"]["price"] == 25001.0
+    assert updates[0]["role"] == "futures_context"
+
+
+def test_context_fast_path_fails_closed_to_empty_indicator_mapping() -> None:
+    manager, engine, updates, _ = _manager()
+    engine.get_indicators = lambda _symbol, _required: None
+
+    _generate_context_only(manager, "NSE:NIFTY", 24451.0, "spot_context")
+
+    indicators = updates[0]["indicators"]
+    assert indicators["ltp"] == 24451.0
+    assert indicators["close"] == 24451.0
+    assert indicators["price"] == 24451.0


### PR DESCRIPTION
## Live evidence
The 11 Aug 11:47/12:23 logs still show substantial tick-path work while flat. `LOG_THROTTLE_SUMMARY` records `strategy_missing_indicators` for spot/futures at essentially the same cadence as `CONTEXT_SYMBOL_STRATEGY_EVAL_SKIPPED`, while context-only DataHub routes also contribute repeated slow-tick warnings.

## Root cause
`StrategyManager.generate_signal()` correctly classifies NIFTY spot and NIFTY futures as non-tradable context symbols, but only returns after it has already built the full option-strategy indicator union/history diagnostics, regime/scoring state and other trade-evaluation machinery. Those symbols can never submit a trade; their required job is only to refresh `_latest_context_snapshots` for option strategies.

## Targeted correction
- Add a context-only fast path at the existing StrategyManager boundary.
- Request only the fields consumed by `_update_context_snapshot()` / `_derive_context_direction()`.
- Preserve the existing context snapshot builder and futures metric augmentation.
- Continue emitting `CONTEXT_SYMBOL_STRATEGY_EVAL_SKIPPED`, now with `reason=context_only_fast_path`.
- Tradable options delegate to the exact existing `generate_signal()` implementation unchanged.
- Bootstrap the adapter from the existing post-`core.app` runtime patch installation point, avoiding circular imports.

## Safety preserved
No strategy threshold, trigger rule, context direction rule, OrderFlow role, net-RR, sizing, margin, readiness, cooldown, candidate selection, bracket, exit, broker, overload or kill-switch behavior is changed. Spot/futures remain context-only and still refresh the same canonical context snapshot path.

## TDD
Tests were committed before runtime installation and verify the context path uses the compact indicator contract, excludes strategy-only SMC/liquidity/selected-contract fields, preserves context/futures augmentation, accepts mapping-like indicator results, and degrades conservatively to the current price when the indicator mapping is unavailable.

This branch is based on merged #1062 (`5e9f0853...`) and deliberately does not duplicate its critical tick fairness/minute-rollover fix.