### PR TITLE
Preserve received ticks across minute rollover backlog

### DIFF
--- a/src/nifty_scalper_bot/core/__init__.py
+++ b/src/nifty_scalper_bot/core/__init__.py
@@ -6,6 +6,7 @@ import importlib.abc
 import importlib.machinery
 import os
 import sys
+from functools import wraps
 from types import ModuleType
 from typing import Any
 
@@ -131,6 +132,35 @@ def _install_market_data_runtime_hardening() -> dict[str, bool]:
     return state
 
 
+def _install_runner_candle_engine_cache_patch() -> bool:
+    """Avoid reacquiring two shared registry locks for every steady-state tick.
+
+    MDM owns one stable CandleEngine object per canonical symbol. Runner only
+    mirrors that object for compatibility, so after first resolution the same
+    reference can be returned directly. Concurrent first use still delegates to
+    the original locked MDM/Runner path and therefore preserves SSOT identity.
+    """
+    from nifty_scalper_bot.strategies.runner import StrategyRunner
+
+    attr = "_candle_engine_mirror_cache_patch_installed"
+    if bool(getattr(StrategyRunner, attr, False)):
+        return True
+    original = StrategyRunner._mirror_authoritative_candle_engine
+
+    @wraps(original)
+    def _mirror_authoritative_candle_engine(self: Any, symbol: str) -> Any | None:
+        normalized = self._normalize_symbol(symbol)
+        cached = getattr(self, "_candle_engines", {}).get(normalized)
+        if cached is not None:
+            return cached
+        return original(self, symbol)
+
+    StrategyRunner._mirror_authoritative_candle_engine = (  # type: ignore[method-assign]
+        _mirror_authoritative_candle_engine
+    )
+    setattr(StrategyRunner, attr, True)
+    return True
+
 
 def _apply_app_runtime_patches(app_module: Any) -> None:
     # The production app import is the single authoritative installation point.
@@ -158,6 +188,7 @@ def _apply_app_runtime_patches(app_module: Any) -> None:
 
     _dynamic_universe_adapter()
     _runtime_reliability_adapter()
+    _install_runner_candle_engine_cache_patch()
     _strategy_context_fast_path_adapter()
     _off_market_controller_adapter()
     _off_market_app_adapter(app_module)

--- a/src/nifty_scalper_bot/data/candle_clock_flush_hardening.py
+++ b/src/nifty_scalper_bot/data/candle_clock_flush_hardening.py
@@ -13,6 +13,7 @@ from nifty_scalper_bot.data.candle_state_hardening import reconcile_stale_curren
 _IST_TZ = "Asia/Kolkata"
 _INSTALLED_ATTR = "_candle_clock_flush_hardening_installed"
 _RESERVED_MINUTES_ATTR = "_candle_tick_reserved_minutes"
+_RESERVED_TICKS_ATTR = "_candle_tick_reserved_ids"
 _LAST_PUBLISHED: dict[int, dict[str, pd.Timestamp]] = defaultdict(dict)
 
 
@@ -62,6 +63,15 @@ def _tick_reservation_key(
 
 def _reserve_popped_tick_locked(manager: Any, tick: Mapping[str, Any]) -> None:
     """Keep a local-batch tick visible to the clock finalization guard."""
+    tick_id = id(tick)
+    reserved_ids = getattr(manager, _RESERVED_TICKS_ATTR, None)
+    if not isinstance(reserved_ids, dict):
+        reserved_ids = {}
+        setattr(manager, _RESERVED_TICKS_ATTR, reserved_ids)
+    # Budget exhaustion may requeue the same dict and pop it again later. That
+    # must remain one reservation, not increment the minute count twice.
+    if tick_id in reserved_ids:
+        return
     key = _tick_reservation_key(manager, tick)
     if key is None:
         return
@@ -70,11 +80,15 @@ def _reserve_popped_tick_locked(manager: Any, tick: Mapping[str, Any]) -> None:
         reservations = {}
         setattr(manager, _RESERVED_MINUTES_ATTR, reservations)
     reservations[key] = int(reservations.get(key, 0) or 0) + 1
+    reserved_ids[tick_id] = key
 
 
 def _release_popped_tick_locked(manager: Any, tick: Mapping[str, Any]) -> None:
     """Release one local-batch reservation after its processing attempt ends."""
-    key = _tick_reservation_key(manager, tick)
+    reserved_ids = getattr(manager, _RESERVED_TICKS_ATTR, None)
+    if not isinstance(reserved_ids, dict):
+        return
+    key = reserved_ids.pop(id(tick), None)
     if key is None:
         return
     reservations = getattr(manager, _RESERVED_MINUTES_ATTR, None)
@@ -163,9 +177,6 @@ def install_candle_clock_flush_hardening(manager_cls: type[Any]) -> None:
                     head = queue[0]
                     priority = int(head.get("_mdm_priority", 99))
                     bucket = str(head.get("_mdm_priority_bucket") or "")
-                    # Near-ATM options intentionally remain FIFO so CandleEngine
-                    # still sees every tick, but they must not tie-starve the
-                    # futures/spot context that drives direction/readiness.
                     bucket_rank = 1 if bucket == "near_atm" else 0
                     enqueued = head.get("_mdm_enqueued_mono")
                     age_rank = (
@@ -220,8 +231,6 @@ def install_candle_clock_flush_hardening(manager_cls: type[Any]) -> None:
         engines = list(getattr(self, "_engines", {}).items())
         flushed = 0
         for symbol, engine in engines:
-            # Snapshot is only a cheap pre-filter. The same minute is rechecked
-            # under the per-engine lock immediately before finalization.
             current = getattr(engine, "current_candle", None)
             if not isinstance(current, Mapping):
                 continue
@@ -230,17 +239,11 @@ def install_candle_clock_flush_hardening(manager_cls: type[Any]) -> None:
                 continue
             if now_ts < expected_minute + pd.Timedelta(minutes=1, seconds=grace):
                 continue
-            # A tick already received before the clock flush must be incorporated
-            # before this minute becomes immutable. This covers queued, popped
-            # local-batch, and currently-processing ticks without allowing
-            # finalized OHLC mutation.
+            # An already-received tick remains visible across queue -> local
+            # batch -> processing transitions, including a budget requeue cycle.
             if _has_unapplied_tick_for_minute(self, symbol, expected_minute):
                 continue
 
-            # Completed history is authoritative, and tick-driven rollover can
-            # race this clock path after the due snapshot. Delegate the final
-            # recheck and finalization to CandleEngine under its native lock so
-            # a newer current minute is never flushed using this stale decision.
             flush_expected = getattr(engine, "flush_if_current_minute", None)
             try:
                 if callable(flush_expected):

--- a/src/nifty_scalper_bot/data/candle_clock_flush_hardening.py
+++ b/src/nifty_scalper_bot/data/candle_clock_flush_hardening.py
@@ -12,6 +12,7 @@ from nifty_scalper_bot.data.candle_state_hardening import reconcile_stale_curren
 
 _IST_TZ = "Asia/Kolkata"
 _INSTALLED_ATTR = "_candle_clock_flush_hardening_installed"
+_RESERVED_MINUTES_ATTR = "_candle_tick_reserved_minutes"
 _LAST_PUBLISHED: dict[int, dict[str, pd.Timestamp]] = defaultdict(dict)
 
 
@@ -38,6 +39,54 @@ def _raw_tick_minute(tick: Mapping[str, Any]) -> pd.Timestamp | None:
     return None
 
 
+def _tick_reservation_key(
+    manager: Any, tick: Mapping[str, Any]
+) -> tuple[str, pd.Timestamp] | None:
+    """Return canonical symbol/minute identity for a popped-but-unapplied tick."""
+    symbol = str(tick.get("symbol") or "")
+    if not symbol:
+        try:
+            token = int(tick.get("instrument_token") or tick.get("token") or 0)
+        except (TypeError, ValueError):
+            token = 0
+        symbol = str((getattr(manager, "_symbol_by_token", {}) or {}).get(token) or "")
+    if not symbol:
+        return None
+    canonicalize = getattr(manager, "_canonical_symbol", None)
+    canonical = canonicalize(symbol) if callable(canonicalize) else symbol
+    minute = _raw_tick_minute(tick)
+    if not canonical or minute is None:
+        return None
+    return canonical, minute
+
+
+def _reserve_popped_tick_locked(manager: Any, tick: Mapping[str, Any]) -> None:
+    """Keep a local-batch tick visible to the clock finalization guard."""
+    key = _tick_reservation_key(manager, tick)
+    if key is None:
+        return
+    reservations = getattr(manager, _RESERVED_MINUTES_ATTR, None)
+    if not isinstance(reservations, dict):
+        reservations = {}
+        setattr(manager, _RESERVED_MINUTES_ATTR, reservations)
+    reservations[key] = int(reservations.get(key, 0) or 0) + 1
+
+
+def _release_popped_tick_locked(manager: Any, tick: Mapping[str, Any]) -> None:
+    """Release one local-batch reservation after its processing attempt ends."""
+    key = _tick_reservation_key(manager, tick)
+    if key is None:
+        return
+    reservations = getattr(manager, _RESERVED_MINUTES_ATTR, None)
+    if not isinstance(reservations, dict):
+        return
+    remaining = int(reservations.get(key, 0) or 0) - 1
+    if remaining > 0:
+        reservations[key] = remaining
+    else:
+        reservations.pop(key, None)
+
+
 def _has_unapplied_tick_for_minute(
     manager: Any, symbol: str, expected_minute: pd.Timestamp
 ) -> bool:
@@ -49,6 +98,9 @@ def _has_unapplied_tick_for_minute(
         return False
     with lock:
         if getattr(manager, "_candle_tick_inflight_symbol", None) == canonical:
+            return True
+        reservations = getattr(manager, _RESERVED_MINUTES_ATTR, {}) or {}
+        if int(reservations.get((canonical, expected_minute), 0) or 0) > 0:
             return True
         queues = getattr(manager, "_pending_tick_queues", {}) or {}
         queue = list(queues.get(canonical, ()))
@@ -93,6 +145,7 @@ def install_candle_clock_flush_hardening(manager_cls: type[Any]) -> None:
                 with lock:
                     if getattr(self, "_candle_tick_inflight_symbol", None) == canonical:
                         self._candle_tick_inflight_symbol = None
+                    _release_popped_tick_locked(self, raw)
 
     def _pop_pending_tick_batch(self: Any) -> list[dict[str, Any]]:
         """Preserve FIFO but prefer critical spot/future context on priority ties."""
@@ -126,13 +179,16 @@ def install_candle_clock_flush_hardening(manager_cls: type[Any]) -> None:
                         selected_rank = rank
                 if selected_key is not None:
                     queue = self._pending_tick_queues[selected_key]
-                    batch.append(queue.popleft())
+                    tick = queue.popleft()
+                    _reserve_popped_tick_locked(self, tick)
+                    batch.append(tick)
                     self._pending_decrement_locked(1)
                     if not queue:
                         self._pending_tick_queues.pop(selected_key, None)
                     continue
                 if self._pending_far_ticks:
                     _key, tick = self._pending_far_ticks.popitem()
+                    _reserve_popped_tick_locked(self, tick)
                     self._pending_decrement_locked(1)
                     batch.append(tick)
                     continue
@@ -175,8 +231,9 @@ def install_candle_clock_flush_hardening(manager_cls: type[Any]) -> None:
             if now_ts < expected_minute + pd.Timedelta(minutes=1, seconds=grace):
                 continue
             # A tick already received before the clock flush must be incorporated
-            # before this minute becomes immutable. This covers both queued and
-            # currently-processing ticks without allowing finalized OHLC mutation.
+            # before this minute becomes immutable. This covers queued, popped
+            # local-batch, and currently-processing ticks without allowing
+            # finalized OHLC mutation.
             if _has_unapplied_tick_for_minute(self, symbol, expected_minute):
                 continue
 

--- a/tests/data/test_mdm_runner_candle_engine_registry.py
+++ b/tests/data/test_mdm_runner_candle_engine_registry.py
@@ -6,6 +6,7 @@ from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 from typing import Any
 
+from nifty_scalper_bot.core import _install_runner_candle_engine_cache_patch
 from nifty_scalper_bot.data.market_data_manager import MarketDataManager
 from nifty_scalper_bot.strategies.runner import StrategyRunner
 
@@ -88,6 +89,7 @@ def test_runner_resolves_same_authoritative_engine_as_mdm() -> None:
 
 def test_runner_reuses_mirrored_engine_without_reentering_mdm_registry() -> None:
     """Steady-state ticks must not reacquire registry locks for the same engine."""
+    _install_runner_candle_engine_cache_patch()
     mdm = _mdm()
     runner = _runner(mdm)
     calls = 0

--- a/tests/data/test_mdm_runner_candle_engine_registry.py
+++ b/tests/data/test_mdm_runner_candle_engine_registry.py
@@ -86,6 +86,27 @@ def test_runner_resolves_same_authoritative_engine_as_mdm() -> None:
     assert runner._candle_engines[SYMBOL] is engine_from_runner
 
 
+def test_runner_reuses_mirrored_engine_without_reentering_mdm_registry() -> None:
+    """Steady-state ticks must not reacquire registry locks for the same engine."""
+    mdm = _mdm()
+    runner = _runner(mdm)
+    calls = 0
+    original = mdm.get_candle_engine
+
+    def counted(symbol: str):
+        nonlocal calls
+        calls += 1
+        return original(symbol)
+
+    mdm.get_candle_engine = counted  # type: ignore[method-assign]
+
+    first = runner._mirror_authoritative_candle_engine("NIFTY")
+    second = runner._mirror_authoritative_candle_engine("nse:nifty")
+
+    assert first is second
+    assert calls == 1
+
+
 def test_history_imported_through_mdm_is_visible_to_runner_engine() -> None:
     mdm = _mdm()
     runner = _runner(mdm)

--- a/tests/data/test_minute_rollover_tick_fairness.py
+++ b/tests/data/test_minute_rollover_tick_fairness.py
@@ -41,8 +41,6 @@ def test_equal_priority_context_batch_prefers_spot_future_over_near_atm() -> Non
         enqueued=2.0,
         timestamp="2026-08-11T12:22:59+05:30",
     )
-    # Reproduce the live tie: near-ATM queue was inserted first, so the old
-    # dict-order tie breaker drained it ahead of critical futures context.
     mdm._pending_tick_queues[near] = deque([near_tick])
     mdm._pending_tick_queues[future] = deque([future_tick])
     mdm._pending_tick_count = 2
@@ -136,13 +134,7 @@ def test_clock_flush_waits_while_same_symbol_tick_is_inflight() -> None:
     )
 
 
-def test_clock_flush_waits_for_tick_popped_into_drain_batch() -> None:
-    """A received tick stays visible to the clock guard after queue pop."""
-    install_candle_clock_flush_hardening(MarketDataManager)
-    mdm = MarketDataManager(kite=None)
-    mdm._tick_drain_batch_size = 1
-    symbol = "NFO:NIFTY2681824250PE"
-    minute = pd.Timestamp("2026-08-12T15:26:00+05:30")
+def _engine_for(symbol: str, minute: pd.Timestamp) -> CandleEngine:
     engine = CandleEngine(symbol=symbol)
     engine.current_candle = {
         "timestamp": minute,
@@ -152,6 +144,17 @@ def test_clock_flush_waits_for_tick_popped_into_drain_batch() -> None:
         "close": 100.5,
         "volume": 100,
     }
+    return engine
+
+
+def test_clock_flush_waits_for_tick_popped_into_drain_batch() -> None:
+    """A received tick stays visible to the clock guard after queue pop."""
+    install_candle_clock_flush_hardening(MarketDataManager)
+    mdm = MarketDataManager(kite=None)
+    mdm._tick_drain_batch_size = 1
+    symbol = "NFO:NIFTY2681824250PE"
+    minute = pd.Timestamp("2026-08-12T15:26:00+05:30")
+    engine = _engine_for(symbol, minute)
     mdm._engines[symbol] = engine
     pending = _tick(
         symbol,
@@ -166,8 +169,6 @@ def test_clock_flush_waits_for_tick_popped_into_drain_batch() -> None:
     assert batch == [pending]
     assert symbol not in mdm._pending_tick_queues
 
-    # This was the live race: the queue is empty, but the already-received tick
-    # has not yet reached CandleEngine because it is waiting in the local batch.
     assert (
         mdm.flush_due_candles(
             now=pd.Timestamp("2026-08-12T15:27:02+05:30"),
@@ -179,6 +180,47 @@ def test_clock_flush_waits_for_tick_popped_into_drain_batch() -> None:
     assert engine.latest_finalized_minute() is None
 
     mdm._process_queued_tick(batch[0])
+    assert (
+        mdm.flush_due_candles(
+            now=pd.Timestamp("2026-08-12T15:27:03+05:30"),
+            grace_seconds=1.5,
+        )
+        == 1
+    )
+    assert engine.latest_finalized_minute() == minute
+
+
+def test_requeued_popped_tick_reservation_is_not_double_counted() -> None:
+    """Budget requeue/pop cycles retain one reservation, then release cleanly."""
+    install_candle_clock_flush_hardening(MarketDataManager)
+    mdm = MarketDataManager(kite=None)
+    mdm._tick_drain_batch_size = 1
+    symbol = "NFO:NIFTY2681824250CE"
+    minute = pd.Timestamp("2026-08-12T15:26:00+05:30")
+    engine = _engine_for(symbol, minute)
+    mdm._engines[symbol] = engine
+    pending = _tick(
+        symbol,
+        bucket="near_atm",
+        enqueued=1.0,
+        timestamp="2026-08-12T15:26:59+05:30",
+    )
+    mdm._pending_tick_queues[symbol] = deque([pending])
+    mdm._pending_tick_count = 1
+
+    first_batch = mdm._pop_pending_tick_batch()
+    mdm._requeue_unprocessed_ticks(first_batch)
+    second_batch = mdm._pop_pending_tick_batch()
+    assert second_batch == [pending]
+    assert (
+        mdm.flush_due_candles(
+            now=pd.Timestamp("2026-08-12T15:27:02+05:30"),
+            grace_seconds=1.5,
+        )
+        == 0
+    )
+
+    mdm._process_queued_tick(second_batch[0])
     assert (
         mdm.flush_due_candles(
             now=pd.Timestamp("2026-08-12T15:27:03+05:30"),

--- a/tests/data/test_minute_rollover_tick_fairness.py
+++ b/tests/data/test_minute_rollover_tick_fairness.py
@@ -134,3 +134,56 @@ def test_clock_flush_waits_while_same_symbol_tick_is_inflight() -> None:
         )
         == 1
     )
+
+
+def test_clock_flush_waits_for_tick_popped_into_drain_batch() -> None:
+    """A received tick stays visible to the clock guard after queue pop."""
+    install_candle_clock_flush_hardening(MarketDataManager)
+    mdm = MarketDataManager(kite=None)
+    mdm._tick_drain_batch_size = 1
+    symbol = "NFO:NIFTY2681824250PE"
+    minute = pd.Timestamp("2026-08-12T15:26:00+05:30")
+    engine = CandleEngine(symbol=symbol)
+    engine.current_candle = {
+        "timestamp": minute,
+        "open": 100.0,
+        "high": 101.0,
+        "low": 99.0,
+        "close": 100.5,
+        "volume": 100,
+    }
+    mdm._engines[symbol] = engine
+    pending = _tick(
+        symbol,
+        bucket="near_atm",
+        enqueued=1.0,
+        timestamp="2026-08-12T15:26:59+05:30",
+    )
+    mdm._pending_tick_queues[symbol] = deque([pending])
+    mdm._pending_tick_count = 1
+
+    batch = mdm._pop_pending_tick_batch()
+    assert batch == [pending]
+    assert symbol not in mdm._pending_tick_queues
+
+    # This was the live race: the queue is empty, but the already-received tick
+    # has not yet reached CandleEngine because it is waiting in the local batch.
+    assert (
+        mdm.flush_due_candles(
+            now=pd.Timestamp("2026-08-12T15:27:02+05:30"),
+            grace_seconds=1.5,
+        )
+        == 0
+    )
+    assert engine.current_candle is not None
+    assert engine.latest_finalized_minute() is None
+
+    mdm._process_queued_tick(batch[0])
+    assert (
+        mdm.flush_due_candles(
+            now=pd.Timestamp("2026-08-12T15:27:03+05:30"),
+            grace_seconds=1.5,
+        )
+        == 1
+    )
+    assert engine.latest_finalized_minute() == minute


### PR DESCRIPTION
## Live evidence
12-Aug live session shows a market-data backlog regression: 3,431 `TICK_STAGE_SLOW`, 194 event-loop-lag alarms, 90 overload episodes and 111 `CANDLE_TICK_DROPPED reason=finalized_minute` events. Exit/order lifecycle itself completed correctly for both real trades.

## Root cause
The #1062 clock-flush guard could see ticks still in `_pending_tick_queues` and the one tick currently marked in-flight, but `_pop_pending_tick_batch()` removes an entire local batch first. A later same-minute tick in that already-received batch therefore became invisible to `flush_due_candles()`, allowing the minute to finalize before that tick reached CandleEngine. Under the observed 100–1200 ms per-tick backlog, the later tick was then rejected by finalized-candle immutability.

## Fix
- Keep popped-but-unprocessed ticks reserved by canonical `(symbol, minute)` until their processing attempt completes.
- Reservation identity is idempotent per tick object so budget requeue/pop cycles do not double-count and cannot defer candle closure indefinitely.
- Existing queued/in-flight/far-tick checks and finalized-candle immutability remain unchanged.
- Remove a secondary hot-path lock amplifier: Runner now resolves the authoritative CandleEngine from MDM only on first use per canonical symbol, then returns the already-mirrored stable SSOT object instead of reacquiring MDM + Runner registry locks every accepted tick.

## TDD
Existing test files extended only:
- popped local-batch rollover race;
- budget requeue reservation idempotency;
- steady-state Runner engine mirror does not re-enter MDM registry;
- prior queue fairness, pending-tick, in-flight, history identity and projection tests retained.

## Safety
No strategy thresholds, risk gates, order routing, broker truth, TP/SL logic, subscription selection, candle grace, or finalized-candle mutation semantics are changed. Duplicate-signal idempotency remains in OrderManager and is deliberately untouched.