### PR TITLE
Fix same-contract re-entry lifecycle cost basis race

### DIFF
--- a/src/nifty_scalper_bot/execution/position_identity_extension.py
+++ b/src/nifty_scalper_bot/execution/position_identity_extension.py
@@ -116,10 +116,29 @@ def _prepare_broker_positions(manager: Any, broker_positions: Any) -> tuple[Any,
         if symbol:
             cloned["tradingsymbol"] = symbol
             cloned["symbol"] = symbol
+        net_qty = _net_quantity(cloned)
         avg_price = _positive_float(cloned, _AVG_PRICE_FIELDS)
-        if _net_quantity(cloned) != 0 and avg_price <= 0.0:
-            existing = positions.get(symbol) if isinstance(positions, dict) else None
-            existing_entry = float(getattr(existing, "entry_price", 0.0) or 0.0) if existing else 0.0
+        existing = positions.get(symbol) if isinstance(positions, dict) else None
+        existing_entry = (
+            float(getattr(existing, "entry_price", 0.0) or 0.0) if existing else 0.0
+        )
+        existing_qty = int(getattr(existing, "quantity", 0) or 0) if existing else 0
+        existing_side = str(getattr(existing, "side", "") or "").strip().upper()
+        owned_same_exposure = bool(
+            existing
+            and str(getattr(existing, "order_id", "") or "").strip()
+            and abs(net_qty) == existing_qty
+            and (
+                (net_qty > 0 and existing_side == "LONG")
+                or (net_qty < 0 and existing_side == "SHORT")
+            )
+        )
+        if net_qty != 0 and owned_same_exposure and existing_entry > 0.0:
+            # Zerodha's day-position average can span earlier closed trades in the
+            # same contract. Once this exact exposure is locally owned, the
+            # broker-confirmed order fill is the authoritative lifecycle basis.
+            cloned["average_price"] = existing_entry
+        elif net_qty != 0 and avg_price <= 0.0:
             if existing_entry > 0.0:
                 cloned["average_price"] = existing_entry
             else:
@@ -373,7 +392,9 @@ def apply_patches() -> None:
         prepared, unresolved = _prepare_broker_positions(self, broker_positions)
         self._cost_basis_unresolved_symbols = set(unresolved)
         if unresolved and isinstance(prepared, list):
-            prepared = [row for row in prepared if _prepared_row_symbol(row) not in unresolved]
+            prepared = [
+                row for row in prepared if _prepared_row_symbol(row) not in unresolved
+            ]
         result = _ORIGINALS["PositionManager.synchronize_with_broker"](
             self,
             prepared,
@@ -397,8 +418,12 @@ def apply_patches() -> None:
             _canonicalize_payload_symbol(broker_payload),
         )
 
-    def current_entry_protection_blocker(self: Any, symbol: str | None = None) -> str | None:
-        unresolved = set(getattr(self, "_cost_basis_unresolved_symbols", set()) or set())
+    def current_entry_protection_blocker(
+        self: Any, symbol: str | None = None
+    ) -> str | None:
+        unresolved = set(
+            getattr(self, "_cost_basis_unresolved_symbols", set()) or set()
+        )
         if unresolved and (symbol is None or _canonical_key(symbol) in unresolved):
             return "cost_basis_unresolved"
         original = _ORIGINALS.get("PositionManager.current_entry_protection_blocker")
@@ -454,7 +479,9 @@ def apply_patches() -> None:
                             "reason": broker_error,
                         },
                     )
-                return _position_manager.FillApplicationResult(reason="broker_state_unverified")
+                return _position_manager.FillApplicationResult(
+                    reason="broker_state_unverified"
+                )
 
             if callable(log_warning):
                 log_warning(
@@ -475,7 +502,48 @@ def apply_patches() -> None:
             return _position_manager.FillApplicationResult(
                 reason="broker_position_unowned_or_cost_basis_unresolved"
             )
-        return _ORIGINALS["PositionManager._handle_filled_order"](self, order)
+
+        result = _ORIGINALS["PositionManager._handle_filled_order"](self, order)
+        if (
+            intent == "ENTRY"
+            and int(getattr(order, "pre_order_quantity", 0) or 0) == 0
+            and getattr(result, "reason", "")
+            == "entry_fill_already_reflected_by_broker_sync"
+        ):
+            symbol = _canonical_key(getattr(order, "symbol", None))
+            positions = getattr(self, "_positions", {})
+            position = positions.get(symbol) if isinstance(positions, dict) else None
+            basis = float(
+                getattr(order, "last_cumulative_average_price", 0.0)
+                or getattr(order, "fill_price", 0.0)
+                or 0.0
+            )
+            if (
+                position is not None
+                and str(getattr(position, "order_id", "") or "").strip()
+                == str(getattr(order, "order_id", "") or "").strip()
+                and basis > 0.0
+            ):
+                broker_day_basis = float(getattr(position, "entry_price", 0.0) or 0.0)
+                position.entry_price = basis
+                logger = getattr(self, "_logger", None)
+                log_info = getattr(logger, "info", None)
+                if callable(log_info):
+                    log_info(
+                        "ENTRY_LIFECYCLE_BASIS_RESTORED order_id=%s symbol=%s broker_day_basis=%.2f fill_basis=%.2f",
+                        getattr(order, "order_id", None),
+                        symbol,
+                        broker_day_basis,
+                        basis,
+                        extra={
+                            "event": "ENTRY_LIFECYCLE_BASIS_RESTORED",
+                            "order_id": getattr(order, "order_id", None),
+                            "symbol": symbol,
+                            "broker_day_basis": broker_day_basis,
+                            "fill_basis": basis,
+                        },
+                    )
+        return result
 
     if "PositionManager.__init__" in _ORIGINALS:
         cls.__init__ = __init__

--- a/tests/execution/test_reentry_lifecycle_basis_race.py
+++ b/tests/execution/test_reentry_lifecycle_basis_race.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import pytest
+
+from nifty_scalper_bot.execution.position_manager import PositionManager
+
+SYMBOL = "NFO:NIFTY2681824400PE"
+ENTRY_ID = "2087403339074953216"
+
+
+def _broker_day_position(*, last_price: float = 124.30) -> dict[str, object]:
+    return {
+        "symbol": SYMBOL,
+        "product": "MIS",
+        "quantity": 65,
+        # Zerodha day-position average after two same-contract buys:
+        # (103.35 + 124.45) / 2 = 113.90. This is not the new trade's basis.
+        "average_price": 113.90,
+        "last_price": last_price,
+    }
+
+
+def _reentry_manager(tmp_path) -> PositionManager:
+    manager = PositionManager(state_file=str(tmp_path / "positions.json"))
+    manager.add_pending_order(
+        ENTRY_ID,
+        SYMBOL,
+        "BUY",
+        65,
+        124.45,
+        "MARKET",
+        intent="ENTRY",
+        bracket_id=ENTRY_ID,
+    )
+    return manager
+
+
+def test_broker_sync_before_reentry_fill_yields_to_confirmed_order_basis(tmp_path) -> None:
+    """The local broker-confirmed fill owns lifecycle basis, not day-position average."""
+    manager = _reentry_manager(tmp_path)
+
+    # Reproduce the live race: periodic broker position sync lands before the
+    # local COMPLETE callback and creates the quantity with Zerodha's day average.
+    manager.synchronize_with_broker([_broker_day_position()])
+    before_fill = manager.get_position(SYMBOL)
+    assert before_fill is not None
+    assert before_fill.quantity == 65
+    assert before_fill.entry_price == pytest.approx(113.90)
+    assert before_fill.order_id is None
+
+    manager.apply_broker_order_update(
+        ENTRY_ID,
+        {
+            "status": "COMPLETE",
+            "filled_quantity": 65,
+            "average_price": 124.45,
+        },
+    )
+
+    position = manager.get_position(SYMBOL)
+    assert position is not None
+    assert position.quantity == 65  # broker quantity must not be double-applied
+    assert position.order_id == ENTRY_ID
+    assert position.entry_price == pytest.approx(124.45)
+    assert position.current_price == pytest.approx(124.30)
+
+
+def test_owned_reentry_basis_survives_day_sync_and_drives_exit_pnl(tmp_path) -> None:
+    """Later broker day snapshots cannot overwrite an owned trade's fill basis."""
+    manager = _reentry_manager(tmp_path)
+    manager.synchronize_with_broker([_broker_day_position()])
+    manager.apply_broker_order_update(
+        ENTRY_ID,
+        {
+            "status": "COMPLETE",
+            "filled_quantity": 65,
+            "average_price": 124.45,
+        },
+    )
+    manager.confirm_entry_protection(ENTRY_ID, ENTRY_ID, 65)
+
+    # The next periodic reconciliation still reports 113.90 for the day-level
+    # position. Quantity/side/mark remain broker truth, lifecycle basis must not.
+    manager.synchronize_with_broker([_broker_day_position(last_price=122.05)])
+    position = manager.get_position(SYMBOL)
+    assert position is not None
+    assert position.entry_price == pytest.approx(124.45)
+    assert position.current_price == pytest.approx(122.05)
+
+    manager.add_pending_order(
+        "2087404505003384833",
+        SYMBOL,
+        "SELL",
+        65,
+        114.00,
+        "MARKET",
+        intent="EXIT",
+        bracket_id=ENTRY_ID,
+    )
+    manager.apply_broker_order_update(
+        "2087404505003384833",
+        {
+            "status": "COMPLETE",
+            "filled_quantity": 65,
+            "average_price": 114.00,
+        },
+    )
+
+    assert manager.get_position(SYMBOL) is None
+    assert manager.get_realized_pnl() == pytest.approx((114.00 - 124.45) * 65)


### PR DESCRIPTION
## Evidence
Aug 12 live logs reproduced a same-contract re-entry race: the pending BUY filled at 124.45, while a periodic Zerodha day-position snapshot landed first with `average_price=113.90` — exactly `(103.35 + 124.45) / 2`, the same-day average of the earlier and new buys. PositionManager imported 113.90 as the new trade basis, producing false positive unrealized P&L and exposing local realized-P&L accounting to the wrong basis.

## Exact root cause
`PositionManager._handle_filled_order()` correctly avoided applying broker quantity twice when reconciliation had already observed the fill, but its `entry_fill_already_reflected_by_broker_sync` branch only restored `order_id`; it left the broker day-level average as the lifecycle `entry_price`. Later periodic broker sync could overwrite the lifecycle basis again because `position_identity_extension._prepare_broker_positions()` preserved local cost basis only when broker average price was missing.

## Focused correction
- In existing `position_identity_extension.py`, after the core `entry_fill_already_reflected_by_broker_sync` path for a fresh ENTRY, restore the position lifecycle basis from the broker-confirmed order cumulative fill average after verifying order ownership.
- For subsequent broker snapshots, preserve that lifecycle basis only when broker exposure is exactly the same owned side and quantity. Broker side, quantity and current mark remain authoritative.
- No new production subsystem or state store.
- No strategy, risk, RR, order-routing, SL/TP/trailing, bracket, kill-switch, or broker-flat semantics changed.

## TDD proof
Test-only head `ad1cbe4cbbb0bb97086d7aa1a989d36066065e4b` failed exactly as expected: `position.entry_price` remained 113.90 instead of 124.45 after `ENTRY_FILL_ALREADY_REFLECTED_BY_BROKER_SYNC`.

Production head `8dbe41bb60e961beed44e0a31834d28ed6aad3d7` turns that exact contract green and also proves a later broker day-position sync cannot overwrite the owned lifecycle basis and a 114.00 exit realizes `(114.00 - 124.45) * 65` locally.

## Validation on exact production head
- Live Exit Safety CI #1476: success
  - full-tests: success
  - execution-safety-tests: success
  - changed-code-quality: success
  - compile: success
  - Ruff: success
  - Black: success
  - mypy: success
- Validate Market-Aware Optimisations #902: success
- E2E live simulation #649: success
