### PR TITLE
Repair same-symbol re-entry cost basis after broker sync race

### DIFF
--- a/src/nifty_scalper_bot/execution/__init__.py
+++ b/src/nifty_scalper_bot/execution/__init__.py
@@ -7,6 +7,7 @@ second live lifecycle authority.
 
 from __future__ import annotations
 
+from functools import wraps
 from typing import Any
 
 from nifty_scalper_bot.execution.adaptive_trailing import (
@@ -26,10 +27,70 @@ import nifty_scalper_bot.data.quote_identity_extension as _quote_identity_extens
 import nifty_scalper_bot.execution.bracket_ownership_extension as _bracket_ownership_extension
 import nifty_scalper_bot.execution.broker_exposure_quarantine_extension as _broker_exposure_quarantine_extension
 import nifty_scalper_bot.execution.broker_order_ledger_patch as _broker_order_ledger_patch
+import nifty_scalper_bot.execution.position_manager as _position_manager
 import nifty_scalper_bot.execution.trade_plan_identity_guard as _trade_plan_identity_guard
+
+
+def _apply_fresh_entry_cost_basis_repair() -> None:
+    """Repair only the broker-sync-before-fill fresh-entry cost-basis race."""
+    cls = _position_manager.PositionManager
+    attr = "_fresh_entry_cost_basis_repair_installed"
+    if bool(getattr(cls, attr, False)):
+        return
+    original = cls._handle_filled_order
+
+    @wraps(original)
+    def _handle_filled_order(self: Any, order: Any) -> Any:
+        result = original(self, order)
+        if (
+            getattr(result, "reason", "")
+            != "entry_fill_already_reflected_by_broker_sync"
+            or str(getattr(order, "intent", "") or "").upper() != "ENTRY"
+            or int(getattr(order, "pre_order_quantity", 0) or 0) != 0
+        ):
+            return result
+        position = getattr(self, "_positions", {}).get(str(getattr(order, "symbol", "")))
+        cumulative_qty = int(
+            getattr(order, "filled_quantity", 0) or getattr(order, "quantity", 0) or 0
+        )
+        fill_price = float(getattr(order, "fill_price", 0.0) or 0.0)
+        side_matches = position is not None and (
+            (getattr(position, "side", None) == "LONG" and getattr(order, "side", None) == "BUY")
+            or (getattr(position, "side", None) == "SHORT" and getattr(order, "side", None) == "SELL")
+        )
+        if not side_matches or cumulative_qty <= 0 or fill_price <= 0:
+            return result
+        if int(getattr(position, "quantity", 0) or 0) != cumulative_qty:
+            return result
+        old_entry = float(getattr(position, "entry_price", 0.0) or 0.0)
+        position.entry_price = fill_price
+        position.order_id = str(getattr(order, "order_id", "") or "") or position.order_id
+        if abs(old_entry - fill_price) > 1e-9:
+            self._logger.warning(
+                "ENTRY_COST_BASIS_REPAIRED_FROM_ORDER_FILL order_id=%s symbol=%s broker_sync_entry=%.2f order_fill=%.2f qty=%s",
+                order.order_id,
+                order.symbol,
+                old_entry,
+                fill_price,
+                cumulative_qty,
+                extra={
+                    "event": "ENTRY_COST_BASIS_REPAIRED_FROM_ORDER_FILL",
+                    "order_id": order.order_id,
+                    "symbol": order.symbol,
+                    "broker_sync_entry_price": old_entry,
+                    "order_fill_price": fill_price,
+                    "quantity": cumulative_qty,
+                },
+            )
+        return result
+
+    cls._handle_filled_order = _handle_filled_order
+    setattr(cls, attr, True)
+
 
 _apply_live_safety_identity_patches()
 _apply_position_identity_extension_patches()
+_apply_fresh_entry_cost_basis_repair()
 _apply_operator_control_patches()
 _apply_protective_order_intent_patches()
 _apply_order_entry_guard_patches()

--- a/tests/execution/test_position_manager_broker_sync_entry_basis.py
+++ b/tests/execution/test_position_manager_broker_sync_entry_basis.py
@@ -23,7 +23,15 @@ def test_flat_to_same_symbol_reentry_fill_repairs_day_aggregate_broker_basis(tmp
     manager = PositionManager(state_file=str(tmp_path / "positions.json"))
     order_id = "2087403339074953216"
 
-    manager.add_pending_order(order_id, SYMBOL, "BUY", 65, intent="ENTRY")
+    manager.add_pending_order(
+        order_id,
+        SYMBOL,
+        "BUY",
+        65,
+        124.45,
+        "LIMIT",
+        intent="ENTRY",
+    )
     assert manager._orders[order_id].pre_order_quantity == 0
 
     # Reproduce 12-Aug live race: periodic broker sync lands after the new buy
@@ -57,7 +65,15 @@ def test_scale_in_broker_sync_race_keeps_broker_weighted_basis(tmp_path) -> None
     manager = PositionManager(state_file=str(tmp_path / "positions.json"))
     manager.open_position(SYMBOL, "LONG", 65, 100.0, order_id="entry-old")
     order_id = "scale-1"
-    manager.add_pending_order(order_id, SYMBOL, "BUY", 65, intent="SCALE_IN")
+    manager.add_pending_order(
+        order_id,
+        SYMBOL,
+        "BUY",
+        65,
+        120.0,
+        "LIMIT",
+        intent="SCALE_IN",
+    )
     assert manager._orders[order_id].pre_order_quantity == 65
 
     manager.synchronize_with_broker(

--- a/tests/execution/test_position_manager_broker_sync_entry_basis.py
+++ b/tests/execution/test_position_manager_broker_sync_entry_basis.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from nifty_scalper_bot.execution.position_manager import PositionManager
+
+
+SYMBOL = "NFO:NIFTY2681824400PE"
+
+
+def _broker_row(*, qty: int, average_price: float, last_price: float) -> dict[str, object]:
+    return {
+        "tradingsymbol": SYMBOL,
+        "exchange": "NFO",
+        "product": "MIS",
+        "quantity": qty,
+        "average_price": average_price,
+        "last_price": last_price,
+        "realised": 0.0,
+    }
+
+
+def test_flat_to_same_symbol_reentry_fill_repairs_day_aggregate_broker_basis(tmp_path) -> None:
+    """A broker-sync race may reflect entry quantity before the order fill callback."""
+    manager = PositionManager(state_file=str(tmp_path / "positions.json"))
+    order_id = "2087403339074953216"
+
+    manager.add_pending_order(order_id, SYMBOL, "BUY", 65, intent="ENTRY")
+    assert manager._orders[order_id].pre_order_quantity == 0
+
+    # Reproduce 12-Aug live race: periodic broker sync lands after the new buy
+    # but before its order-fill callback. 113.90 is the day aggregate; the
+    # authoritative new order fill is 124.45.
+    manager.synchronize_with_broker(
+        [_broker_row(qty=65, average_price=113.90, last_price=124.30)]
+    )
+    assert manager._positions[SYMBOL].quantity == 65
+    assert manager._positions[SYMBOL].entry_price == 113.90
+
+    manager.apply_broker_order_update(
+        order_id,
+        {
+            "order_id": order_id,
+            "tradingsymbol": SYMBOL,
+            "status": "COMPLETE",
+            "filled_quantity": 65,
+            "average_price": 124.45,
+        },
+    )
+
+    position = manager._positions[SYMBOL]
+    assert position.quantity == 65
+    assert position.entry_price == 124.45
+    assert position.order_id == order_id
+
+
+def test_scale_in_broker_sync_race_keeps_broker_weighted_basis(tmp_path) -> None:
+    """Fresh-entry repair must not reinterpret a real scale-in as a new lot."""
+    manager = PositionManager(state_file=str(tmp_path / "positions.json"))
+    manager.open_position(SYMBOL, "LONG", 65, 100.0, order_id="entry-old")
+    order_id = "scale-1"
+    manager.add_pending_order(order_id, SYMBOL, "BUY", 65, intent="SCALE_IN")
+    assert manager._orders[order_id].pre_order_quantity == 65
+
+    manager.synchronize_with_broker(
+        [_broker_row(qty=130, average_price=110.0, last_price=120.0)]
+    )
+    manager.apply_broker_order_update(
+        order_id,
+        {
+            "order_id": order_id,
+            "tradingsymbol": SYMBOL,
+            "status": "COMPLETE",
+            "filled_quantity": 65,
+            "average_price": 120.0,
+        },
+    )
+
+    position = manager._positions[SYMBOL]
+    assert position.quantity == 130
+    assert position.entry_price == 110.0


### PR DESCRIPTION
## Live evidence
12-Aug live trade `2087403339074953216` filled 65 `NFO:NIFTY2681824400PE` at 124.45. A concurrent periodic broker position reconciliation committed quantity 65 with entry 113.90, then the fill handler logged `ENTRY_FILL_ALREADY_REFLECTED_BY_BROKER_SYNC` and preserved that broker-sync basis. 113.90 is exactly the day aggregate of the earlier 103.35 buy and the new 124.45 buy, while the prior position had already been fully closed. Capital tracking then used 113.90 × 65 = 7,403.50 instead of 124.45 × 65 = 8,089.25.

## Exact root cause
`PositionManager.synchronize_with_broker()` imports broker position `average_price`. `_handle_filled_order()` correctly avoids applying quantity twice when the broker snapshot already contains the cumulative fill, but the same branch assumes the imported cost basis is also authoritative. For a fresh flat→same-symbol intraday re-entry, broker day-position average can include the prior round trip, so quantity is current while cost basis is not the current open lot.

## Focused fix
On the existing execution bootstrap, wrap the canonical PositionManager filled-order path and repair cost basis only when the core returns `entry_fill_already_reflected_by_broker_sync`, intent is exactly `ENTRY`, `pre_order_quantity == 0`, side matches, and current position quantity exactly equals the order cumulative fill. Quantity is never reapplied. Scale-ins/reversals/exits are untouched. The authoritative broker order cumulative fill price becomes the local open-lot entry basis.

## TDD
- reproduces the exact 113.90 broker-sync / 124.45 order-fill race and asserts qty stays 65 while entry repairs to 124.45;
- proves a true 65→130 scale-in keeps its broker weighted basis and is not reinterpreted as a fresh entry.

## Safety
No entry thresholds, RR, margin, sizing, broker order routing, hard SL/TP, trailing, stop-rearm, reconciliation cadence, or broker quantity truth changed.