### PR TITLE
Preserve canonical history on dynamic option re-add

### DIFF
--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -1852,7 +1852,7 @@ class StrategyRunner:
             self._subscribe_symbol(normalized)
 
         cached = self._recent_history_cache.get(normalized) or []
-        if cached:
+        if cached and not self._symbol_history.get(normalized):
             self._symbol_history[normalized] = list(cached)
             self._restored_from_cache_symbols.add(normalized)
             self._logger.info(

--- a/tests/strategies/test_selected_option_live_path.py
+++ b/tests/strategies/test_selected_option_live_path.py
@@ -156,6 +156,25 @@ def test_basket_sync_defers_cold_selected_pair_until_indicator_history_is_ready(
     assert runner._pending_selected_pe is None
 
 
+def test_dynamic_readd_preserves_newer_canonical_history(monkeypatch):
+    """A stale removal cache must not rewind history already synced from MDM."""
+    runner, _strategy_manager, _risk_manager, _order_manager, _selected_ce = (
+        _build_phase9_runner(monkeypatch)
+    )
+    symbol = "NFO:NIFTY26JUN24100CE"
+    canonical_history = [{"timestamp": index} for index in range(100)]
+    stale_removal_cache = canonical_history[:20]
+    runner._running = False
+    runner._symbol_history[symbol] = list(canonical_history)
+    runner._recent_history_cache[symbol] = list(stale_removal_cache)
+    runner._mirror_authoritative_candle_engine = lambda _symbol: None
+    runner._hydrate_from_mdm_cache = lambda _symbol: 0
+
+    runner.add_symbol(symbol)
+
+    assert runner._symbol_history[symbol] == canonical_history
+
+
 def test_quote_versions_do_not_advance_candle_version_or_starve_same_bar_evaluation(monkeypatch):
     """Quote/data sequence counters are not candle identity and must not suppress a leg."""
     apply_patches()


### PR DESCRIPTION
## What changed

- restore the recent removal cache only when canonical symbol history is absent
- add regression coverage proving a dynamic re-add cannot rewind newer MDM-synchronized history

## Root cause

Dynamic basket rotation synchronizes current history before calling `StrategyRunner.add_symbol()`. The method then unconditionally replaced that current history with the older, truncated removal cache, transiently rewinding state and forcing redundant reseeding on the event loop.

## Impact

Keeps the existing startup recovery fallback while avoiding duplicate dynamic rehydration work and reducing trading-path event-loop pressure during basket rotation.

## Validation

- regression confirmed red before the guard and green afterward
- 48 adjacent dynamic-universe/history/reliability tests passed
- full suite: 2,614 passed, 1 skipped
- `python -m compileall -q src` passed
- `git diff --check` passed

Ruff/Black findings in the touched legacy files are pre-existing and would require broad unrelated reformatting.