### PR TITLE
Report selected-option subscription tick age

### DIFF
--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -10095,6 +10095,15 @@ class StrategyRunner:
                 getattr(self, "_active_selected_ce", None),
                 getattr(self, "_active_selected_pe", None),
             )
+            tick_age_s = None
+            time_since_last_tick = getattr(mdm, "time_since_last_tick", None)
+            if sym and callable(time_since_last_tick):
+                try:
+                    age = time_since_last_tick(sym)
+                    if age is not None:
+                        tick_age_s = round(max(0.0, float(age)), 3)
+                except (TypeError, ValueError, RuntimeError):
+                    pass
             state_key = (
                 sym,
                 token_int,
@@ -10116,7 +10125,7 @@ class StrategyRunner:
                     desired,
                     subscription_ready,
                     current_generation_fresh_tick,
-                    None,
+                    tick_age_s,
                 ),
                 reminder_seconds=float(
                     os.getenv("RUNNER_BOOTSTRAP_LOG_REMINDER_SECONDS", "600") or "600"
@@ -10130,7 +10139,7 @@ class StrategyRunner:
                     "subscribed": subscription_ready,
                     "subscription_requested": desired,
                     "fresh_tick": current_generation_fresh_tick,
-                    "tick_age_s": None,
+                    "tick_age_s": tick_age_s,
                     "selected_ce": selected_pair[0],
                     "selected_pe": selected_pair[1],
                     "market_mode": get_runtime_market_mode(),

--- a/tests/strategies/test_selected_option_live_path.py
+++ b/tests/strategies/test_selected_option_live_path.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import threading
 import time
 from datetime import datetime, timezone
@@ -173,6 +174,29 @@ def test_dynamic_readd_preserves_newer_canonical_history(monkeypatch):
     runner.add_symbol(symbol)
 
     assert runner._symbol_history[symbol] == canonical_history
+
+
+def test_selected_option_subscription_state_reports_tick_age(monkeypatch, caplog):
+    """Selected-option telemetry must report the MDM's observed tick age."""
+    runner, _strategy_manager, _risk_manager, _order_manager, selected_ce = (
+        _build_phase9_runner(monkeypatch)
+    )
+    runner._logger = logging.getLogger("test.selected_option_subscription_state")
+    runner._market_data.time_since_last_tick = (
+        lambda symbol: 2.5 if symbol == selected_ce else None
+    )
+
+    with caplog.at_level(logging.INFO):
+        runner._emit_live_universe_bootstrap_status(symbol=selected_ce)
+
+    record = next(
+        item
+        for item in caplog.records
+        if getattr(item, "event", None) == "SELECTED_OPTION_SUBSCRIPTION_STATE"
+        and getattr(item, "symbol", None) == selected_ce
+    )
+    assert record.tick_age_s == 2.5
+    assert "tick_age_s=2.5" in record.message
 
 
 def test_quote_versions_do_not_advance_candle_version_or_starve_same_bar_evaluation(monkeypatch):


### PR DESCRIPTION
## What changed

- populate `SELECTED_OPTION_SUBSCRIPTION_STATE.tick_age_s` from MDM's existing `time_since_last_tick()` owner
- add behavioral coverage for both the structured field and rendered log message

## Root cause

The bootstrap path already evaluated quote freshness, but the subscription-state event hard-coded `tick_age_s=None` in both outputs. This made healthy and stale selected-option delivery indistinguishable in that diagnostic.

## Preserved behavior

No readiness, subscription, strategy, risk, or execution decision changes. Missing or invalid MDM age remains `None`.

## Validation

- regression red before fix, green afterward
- 19 adjacent selected-option/readiness tests passed
- full suite: 2,615 passed, 1 skipped
- source compilation and diff checks passed
- remote blobs exactly match locally tested blobs