### PR TITLE
Refresh MDM event-loop ownership across lifecycle

### DIFF
--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -1842,6 +1842,8 @@ class MarketDataManager:
         self._tick_consumer_task = None
         if hasattr(self, "_candle_flush_task"):
             self._candle_flush_task = None
+        self._event_loop_thread_id = None
+        self._main_loop = None
         stop_fallback_worker = getattr(self, "_stop_fallback_tick_worker", None)
         if callable(stop_fallback_worker):
             stop_fallback_worker()
@@ -1912,6 +1914,8 @@ class MarketDataManager:
             )
         self._tick_drain_task = None
         self._tick_consumer_task = None
+        self._event_loop_thread_id = None
+        self._main_loop = None
         if should_stop:
             self._stop_worker_threads_for_shutdown()
 
@@ -6254,6 +6258,9 @@ class MarketDataManager:
             return
 
         def _start() -> None:
+            if self._main_loop is not loop:
+                return
+            self._event_loop_thread_id = threading.get_ident()
             task = getattr(self, "_tick_consumer_task", None)
             if task is None or task.done():
                 self._tick_consumer_task = loop.create_task(self._consume_ticks())

--- a/tests/data/test_event_loop_thread_telemetry.py
+++ b/tests/data/test_event_loop_thread_telemetry.py
@@ -127,6 +127,41 @@ def test_set_event_loop_off_thread_claims_no_ownership() -> None:
         loop.close()
 
 
+def test_running_loop_attachment_records_owner_on_loop_thread() -> None:
+    """Off-thread wiring must establish ownership from the scheduled callback."""
+    mdm = _mdm()
+    loop = asyncio.new_event_loop()
+    thread = threading.Thread(target=loop.run_forever, daemon=True)
+    thread.start()
+    callback_ran = threading.Event()
+    try:
+        mdm.set_event_loop(loop)
+        loop.call_soon_threadsafe(callback_ran.set)
+        assert callback_ran.wait(timeout=1.0)
+        assert mdm._event_loop_thread_id == thread.ident
+    finally:
+        asyncio.run_coroutine_threadsafe(mdm.async_stop(), loop).result(timeout=1.0)
+        loop.call_soon_threadsafe(loop.stop)
+        thread.join(timeout=1.0)
+        loop.close()
+
+
+def test_async_stop_detaches_event_loop_owner() -> None:
+    """Shutdown must not retain ownership of a loop that is no longer attached."""
+
+    async def _run() -> None:
+        mdm = _mdm()
+        mdm.set_event_loop(asyncio.get_running_loop())
+        assert mdm._event_loop_thread_id == threading.get_ident()
+
+        await mdm.async_stop()
+
+        assert mdm._event_loop_thread_id is None
+        assert mdm._main_loop is None
+
+    asyncio.run(_run())
+
+
 def test_message_renders_unknown_rather_than_none(caplog) -> None:
     """Operators must read 'unknown', not the literal None."""
     import logging


### PR DESCRIPTION
## What changed

- establish `_event_loop_thread_id` inside the callback that actually runs on the attached loop
- ignore a stale scheduled callback after detach
- clear the loop reference and owner during synchronous and asynchronous shutdown
- add regressions for off-thread running-loop attachment and shutdown detachment

## Root cause

When MDM was wired from outside the running loop, `set_event_loop()` correctly scheduled consumer startup onto that loop but only attempted to record ownership in the calling thread. Ownership therefore remained unknown. Shutdown also retained the old loop reference and thread ID, allowing later telemetry to describe stale ownership and preventing clean replacement.

## Preserved behavior

A supplied loop that is not running still has unknown ownership. Active-loop rewiring remains guarded. Tick processing, queue ordering, readiness, risk, and execution behavior are unchanged.

## Validation

- 8 event-loop telemetry tests passed
- 102 adjacent MDM queue/dispatch/shutdown/generation tests passed
- full suite: 2,617 passed, 1 skipped
- source compilation and diff checks passed
- remote blobs exactly match locally tested blobs