### PR TITLE
Fix volatile-regime RR boundary precision

### DIFF
--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -9412,7 +9412,8 @@ class StrategyRunner:
                 os.getenv("VWAP_HIGH_VOL_MAX_SPREAD_PCT", "0.75") or "0.75"
             )
             min_rr = float(os.getenv("VWAP_HIGH_VOL_MIN_RR", "1.6") or "1.6")
-            if selected and spread_pct <= max_spread and rr >= min_rr:
+            rr_allowed = rr >= min_rr - 1e-9
+            if selected and spread_pct <= max_spread and rr_allowed:
                 return True, "vwap_high_vol_execution_quality_soft_allow"
             return False, "vwap_high_vol_execution_quality_failed"
         return False, "regime_not_allowed"

--- a/tests/strategies/test_runner_regime_soft_allow_after_candidate.py
+++ b/tests/strategies/test_runner_regime_soft_allow_after_candidate.py
@@ -13,3 +13,37 @@ def test_vwap_high_vol_soft_allow_uses_candidate_metadata() -> None:
     )
     assert allowed is True
     assert reason == 'vwap_high_vol_execution_quality_soft_allow'
+
+
+def test_vwap_high_vol_soft_allow_tolerates_rr_boundary_float_noise() -> None:
+    runner = StrategyRunner.__new__(StrategyRunner)
+    runner._strategy_allowed_for_regime = lambda *_args, **_kwargs: False
+    allowed, reason = runner._strategy_regime_decision(
+        strategy='VWAPPro',
+        regime=MarketRegime.VOLATILE,
+        symbol='NIFTY',
+        metadata={
+            'candidate_selected': True,
+            'candidate_spread_pct': 0.4,
+            'candidate_rr': 1.5999999999999996,
+        },
+    )
+    assert allowed is True
+    assert reason == 'vwap_high_vol_execution_quality_soft_allow'
+
+
+def test_vwap_high_vol_soft_allow_rejects_materially_low_rr() -> None:
+    runner = StrategyRunner.__new__(StrategyRunner)
+    runner._strategy_allowed_for_regime = lambda *_args, **_kwargs: False
+    allowed, reason = runner._strategy_regime_decision(
+        strategy='VWAPPro',
+        regime=MarketRegime.VOLATILE,
+        symbol='NIFTY',
+        metadata={
+            'candidate_selected': True,
+            'candidate_spread_pct': 0.4,
+            'candidate_rr': 1.599,
+        },
+    )
+    assert allowed is False
+    assert reason == 'vwap_high_vol_execution_quality_failed'


### PR DESCRIPTION
Closes #1072

## Root cause
A candidate whose intended RR was exactly 1.60 arrived as `1.5999999999999996`. The volatile-regime quality gate used a direct float comparison and rejected it as below the configured 1.6 threshold.

## Fix
Use a 1e-9 numerical tolerance at this single threshold comparison. Materially sub-threshold RR remains blocked.

## Validation
- Regression test reproduces production value and now passes.
- Control test confirms RR 1.599 is rejected.
- Adjacent regime, final-net-RR, and order-manager tests pass (13 tests).
- Full suite passes with the pre-existing timing-sensitive bracket test deselected; that exact test passes independently.