### PR TITLE
Use final live quote spread in net RR gate

### DIFF
--- a/src/nifty_scalper_bot/execution/order_manager_core.py
+++ b/src/nifty_scalper_bot/execution/order_manager_core.py
@@ -3327,6 +3327,10 @@ class OrderManager:
                 )
                 check_risk = False
         if check_risk and self._risk_manager:
+            risk_quote = self._extract_quote_diagnostics(
+                self._get_latest_quote_safe(normalized_symbol) or {}
+            )
+            bid, ask = risk_quote.get("bid", 0.0), risk_quote.get("ask", 0.0)
             signal = OrderSignal(
                 symbol=normalized_symbol,
                 side=side,
@@ -3334,6 +3338,7 @@ class OrderManager:
                 price=price or 0.0,
                 stop_loss=stop_loss,
                 take_profit=take_profit,
+                metadata={"bid": bid, "ask": ask} if bid > 0 and ask >= bid else {},
             )
             is_live = False
             if hasattr(self, "_enable_live_getter") and self._enable_live_getter:

--- a/src/nifty_scalper_bot/risk/risk_manager.py
+++ b/src/nifty_scalper_bot/risk/risk_manager.py
@@ -62,6 +62,7 @@ class OrderSignal:
     price: float
     stop_loss: float | None
     take_profit: float | None
+    metadata: dict[str, Any] = field(default_factory=dict)
 
     def notional(self) -> float:
         return abs(self.price * self.quantity)

--- a/tests/risk/test_final_net_rr_gate.py
+++ b/tests/risk/test_final_net_rr_gate.py
@@ -2,11 +2,14 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+import pytest
+
 from nifty_scalper_bot.risk.entry_guard_patch import (
     _net_rr_block_reason,
     _real_broker_live,
 )
 from nifty_scalper_bot.risk.net_rr_gate import evaluate_final_net_rr
+from nifty_scalper_bot.risk.risk_manager import OrderSignal
 
 
 def _signal(*, target: float, stop: float = 92.0, **metadata):
@@ -78,6 +81,25 @@ def test_wider_spread_reduces_net_reward_risk(monkeypatch) -> None:
     assert tight is not None and wide is not None
     assert wide.net_rr < tight.net_rr
     assert wide.target_cost > tight.target_cost
+
+
+def test_order_signal_uses_final_live_quote_spread(monkeypatch) -> None:
+    monkeypatch.setenv("MIN_NET_REWARD_RISK", "1.5")
+    signal = OrderSignal(
+        symbol="NFO:NIFTY2681824300PE",
+        side="BUY",
+        quantity=65,
+        price=76.2,
+        stop_loss=70.1,
+        take_profit=88.4,
+        metadata={"bid": 76.15, "ask": 76.25},
+    )
+
+    result = evaluate_final_net_rr(signal)
+
+    assert result is not None
+    assert result.allowed is True
+    assert result.half_spread == pytest.approx(0.05)
 
 
 def test_malformed_minimum_uses_safe_default_instead_of_bypassing(monkeypatch) -> None:


### PR DESCRIPTION
Closes #1074

## Root cause
The canonical order path reduced the final entry intent to an `OrderSignal` containing price, SL and TP only. The transaction-cost-aware net-RR gate therefore could not see the already available final bid/ask and used its conservative fallback half-spread. In the production trace this changed the same trade from approximately 1.54 net RR to 1.48 and blocked it.

## Fix
- Add optional metadata to the existing `OrderSignal` contract.
- Immediately before the final risk check, attach the latest valid bid/ask already available from the order manager.
- Preserve the existing fallback when bid/ask is missing or invalid.

## Validation
- Production geometry regression: entry 76.20, SL 70.10, TP 88.40, bid 76.15, ask 76.25 passes at net RR > 1.50.
- Full risk and execution suites pass.