### PR TITLE
Avoid duplicate reconciliation before protective exit

### DIFF
--- a/src/nifty_scalper_bot/execution/hardened_bracket_manager.py
+++ b/src/nifty_scalper_bot/execution/hardened_bracket_manager.py
@@ -360,16 +360,6 @@ class HardenedBracketManager(_LegacyBracketManager):
                 self._log_exit_pending_summary_locked(bracket, now)
             return
 
-        if self._reconcile_exit_state(bracket, requested_by="pre_submit_hardened"):
-            return
-        with self._lock:
-            if (
-                bracket.exit_state
-                == _legacy.BracketExitLifecycle.EXIT_FAILED_ESCALATED.value
-                and not self._exit_continue_retry_after_escalation
-            ):
-                self._log_exit_pending_summary_locked(bracket, now)
-                return
         _LegacyBracketManager._process_exit_state(self, bracket, action, now=now)
 
     def _rescue_stale_exit_order(

--- a/tests/execution/test_live_exit_hardening.py
+++ b/tests/execution/test_live_exit_hardening.py
@@ -152,6 +152,29 @@ def test_canonical_imports_use_hardened_implementations() -> None:
     assert AdaptiveTrailingController is HardenedAdaptiveTrailingController
 
 
+def test_first_exit_submission_reconciles_position_once(monkeypatch) -> None:
+    manager, order_manager, _broker = _manager()
+    bracket = manager.get_bracket("entry-1")
+    assert bracket is not None
+    reconcile_requests: list[str] = []
+    original = manager._reconcile_exit_state
+
+    def _tracked(target, *, requested_by):
+        reconcile_requests.append(requested_by)
+        return original(target, requested_by=requested_by)
+
+    monkeypatch.setattr(manager, "_reconcile_exit_state", _tracked)
+
+    manager._process_exit_state(
+        bracket,
+        {"qty": 65, "reason": "HARD_SL_BREACH"},
+        now=time.time(),
+    )
+
+    assert len(order_manager.place_calls) == 1
+    assert reconcile_requests == ["pre_submit", "post_submit"]
+
+
 def test_stale_open_protective_exit_is_cancelled_then_replaced_once() -> None:
     manager, order_manager, broker = _manager()
     bracket = _make_stale_exit(manager)


### PR DESCRIPTION
Closes #1076

## Root cause
The hardened exit wrapper reconciled a no-order exit, then delegated to the canonical legacy processor, which immediately performed the same authoritative reconciliation again. Production logs showed `pre_submit_hardened` followed by `pre_submit`, with roughly three seconds before the hard-stop market submission.

## Fix
For the no-existing-order branch, delegate directly to the canonical processor. It retains the authoritative `pre_submit` reconciliation and all in-flight, escalation, retry, and submission guards.

## Validation
- New regression records reconcile requests and proves the first submission performs `pre_submit` once, followed only by `post_submit`.
- Live exit hardening, exit reconciliation race, and bracket exit state-machine suites all pass.