### PR TITLE
Ignore closed brackets in watchdog

### DIFF
--- a/src/nifty_scalper_bot/execution/bracket_core.py
+++ b/src/nifty_scalper_bot/execution/bracket_core.py
@@ -854,6 +854,8 @@ class BracketManager:
                 reconcile_candidates: list[BracketState] = []
                 with self._lock:
                     for bracket in self._brackets.values():
+                        if bracket.exit_state == BracketExitLifecycle.CLOSED.value:
+                            continue
                         reconcile_candidates.append(bracket)
                         ltp = float(bracket.last_ltp or 0.0)
                         if bracket.exit_pending and bracket.remaining_quantity > 0:

--- a/tests/execution/test_bracket_manager_reliability.py
+++ b/tests/execution/test_bracket_manager_reliability.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import threading
 import time
 from typing import Mapping
 from unittest.mock import Mock
@@ -728,6 +729,23 @@ def _watchdog_bracket(manager, order_id, symbol, side, sl):
     bracket = manager.get_bracket(order_id)
     assert bracket is not None
     return bracket
+
+
+def test_watchdog_ignores_closed_brackets() -> None:
+    manager = BracketManager(order_manager=Mock())
+    closed = _watchdog_bracket(manager, "wd-closed", "NFO:NIFTYCLOSEDCE", "BUY", 99.0)
+    _watchdog_bracket(manager, "wd-probe", "NFO:NIFTYPROBECE", "BUY", 99.0)
+    manager._close_bracket(closed, close_source="unit_test")
+    closed_seen = threading.Event()
+    cycle_seen = threading.Event()
+    manager._log_throttled = lambda _level, key, *_args: (
+        closed_seen.set()
+        if key == "watchdog_skip_wd-closed"
+        else cycle_seen.set() if key == "watchdog_skip_wd-probe" else None
+    )
+
+    assert cycle_seen.wait(timeout=1.0)
+    assert not closed_seen.is_set()
 
 
 def test_watchdog_stop_uses_bid_for_a_long_position() -> None:


### PR DESCRIPTION
Closes #1078.

## What changed

- Skip brackets whose lifecycle is explicitly `CLOSED` before watchdog stop evaluation, skip logging, and pending-entry reconciliation.
- Add a regression test proving a retained closed bracket is ignored while a live watchdog cycle still runs.

## Root cause

`_close_bracket()` intentionally retains completed bracket records for persistence and audit, but `_watchdog_exit_loop()` scanned every retained record every 250 ms. Production logs showed 206–219 suppressed `watchdog_skip_2087775416030257152` calls every two minutes after the position was already flat.

## Safety

The filter applies only to the terminal `CLOSED` state. Pending entries, active brackets, submitted/retryable exits, and escalated recovery states retain their existing behavior.

## Validation

- Regression reproduced before fix and passes after fix.
- Full `tests/execution` suite passes.
- Focused bracket-close, exit-state-machine, and exit-reconciliation-race suites pass.
- `git diff --check` passes.
- Repository-wide Ruff remains blocked by pre-existing baseline violations in `bracket_core.py`; no new changed-line violation was introduced.