### PR TITLE
Honor risk breaker in live readiness

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -3049,6 +3049,7 @@ class BotContext:
     background_tasks_started: bool = False
     data_hub_listeners_registered: bool = False
     live_orders_armed: bool = False
+    risk_halt: bool = False
     trading_ready: bool = False
     data_observation_ready: bool = False
     data_pipeline_ready: bool = False
@@ -6946,6 +6947,11 @@ def initialize_components(settings: Settings | None = None) -> BotContext:
         return flattened
 
     def _handle_risk_breaker(reason: str, snapshot: RiskSnapshot) -> None:
+        ctx.risk_halt = True
+        ctx.live_orders_armed = False
+        ctx.execution_armed = False
+        ctx.live_block_reason = "execution_not_armed:risk_halt"
+        ctx.execution_block_reason = ctx.live_block_reason
         ctx.shadow_mode_enabled = True
         safe_order_manager.set_live_enabled(False)
         risk_manager.force_shadow(True)
@@ -9707,6 +9713,14 @@ async def _recompute_and_push_runtime_readiness(
     broker_ready = bool(
         getattr(ctx, "broker_client", None) and getattr(ctx, "order_manager", None)
     )
+    risk_manager = getattr(ctx, "risk_manager", None)
+    risk_halt = bool(getattr(ctx, "risk_halt", False))
+    if risk_manager is not None:
+        try:
+            risk_halt = bool(risk_manager.is_circuit_breaker_tripped()[0])
+        except Exception:
+            risk_halt = True
+    ctx.risk_halt = risk_halt
     pipeline_overloaded = bool(getattr(mdm, "pipeline_overloaded", False))
     ce_market_exec_ready = bool(ce_exec_ready)
     pe_market_exec_ready = bool(pe_exec_ready)
@@ -9900,7 +9914,7 @@ async def _recompute_and_push_runtime_readiness(
             and not bool(getattr(ctx, "broker_balance_valid", False)),
         },
         risk_state={
-            "risk_halt": bool(getattr(ctx, "risk_halt", False)),
+            "risk_halt": risk_halt,
             "daily_loss_limit": bool(getattr(ctx, "daily_loss_limit_hit", False)),
         },
         live_mode=live_mode,

--- a/tests/core/test_minimum_lot_affordability_readiness.py
+++ b/tests/core/test_minimum_lot_affordability_readiness.py
@@ -152,3 +152,43 @@ async def test_pipeline_overload_disarms_canonical_runtime_readiness(
     assert ctx.live_orders_armed is False
     assert ctx.live_block_reason == "execution_not_armed:data_pipeline_overloaded"
     assert calls[-1]["live_orders_armed"] is False
+
+
+@pytest.mark.asyncio
+async def test_authoritative_risk_breaker_disarms_runtime_readiness(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(app, "get_market_state", lambda: app.MarketState.OPEN)
+    ctx, calls = _context({CE: 100.0, PE: 110.0}, 10_000.0)
+    ctx.risk_manager = SimpleNamespace(
+        is_circuit_breaker_tripped=lambda: (True, "Consecutive loss limit reached")
+    )
+
+    await app._recompute_and_push_runtime_readiness(ctx, reason="risk_breaker_test")
+
+    assert ctx.live_orders_armed is False
+    assert ctx.live_block_reason == "execution_not_armed:risk_halt"
+    assert calls[-1]["live_orders_armed"] is False
+
+    ctx.risk_manager.is_circuit_breaker_tripped = lambda: (False, "")
+    await app._recompute_and_push_runtime_readiness(ctx, reason="risk_reset_test")
+
+    assert ctx.risk_halt is False
+    assert ctx.live_orders_armed is True
+
+
+@pytest.mark.asyncio
+async def test_risk_breaker_read_failure_keeps_runtime_disarmed(monkeypatch) -> None:
+    monkeypatch.setattr(app, "get_market_state", lambda: app.MarketState.OPEN)
+    ctx, _calls = _context({CE: 100.0, PE: 110.0}, 10_000.0)
+
+    def _failed_breaker_read():
+        raise RuntimeError("risk state unavailable")
+
+    ctx.risk_manager = SimpleNamespace(is_circuit_breaker_tripped=_failed_breaker_read)
+
+    await app._recompute_and_push_runtime_readiness(ctx, reason="risk_error_test")
+
+    assert ctx.risk_halt is True
+    assert ctx.live_orders_armed is False
+    assert ctx.live_block_reason == "execution_not_armed:risk_halt"


### PR DESCRIPTION
Closes #1080.

## What changed

- Add an explicit `risk_halt` field to the slotted bot context.
- Disarm runtime readiness immediately when the breaker callback fires.
- Re-read the authoritative `RiskManager.is_circuit_breaker_tripped()` state during readiness recomputation.
- Fail closed if an attached risk manager cannot report breaker state.
- Add integration regressions for breaker trip, authoritative reset, and read failure.

## Root cause

Production reported `Breaker=True` and `Consecutive loss limit reached (3/3)` while readiness simultaneously emitted `risk_green=True` and `live_orders_armed=True`. Readiness consulted optional context attributes that were absent from `BotContext` rather than the authoritative risk manager.

The final order risk gate remained fail-closed; this change aligns upstream arming and operator status with that authority.

## Validation

- New regression reproduced the false arming before the fix and passes after it.
- Core suite passed.
- Risk suite passed.
- Execution suite passed.
- Focused runner risk-halt regressions passed.
- Python compilation, test formatting, and `git diff --check` passed.
- Repository baseline has unrelated lint findings and an existing strategy rejection-label assertion (`raw_score_below_min` vs `regime_weighted_score_below_min`); neither is changed in this PR.