### PR TITLE
Report regime-weighted score rejection accurately

### DIFF
--- a/src/nifty_scalper_bot/core/strategy_manager.py
+++ b/src/nifty_scalper_bot/core/strategy_manager.py
@@ -4409,7 +4409,7 @@ class StrategyManager(_BaseStrategyManager):
             blocked_reason = None
             if not final_allowed:
                 if not score_ok:
-                    blocked_reason = "raw_score_below_min"
+                    blocked_reason = "regime_weighted_score_below_min"
                 elif not conf_ok:
                     blocked_reason = "confidence_below_min"
                 elif not selected_ok:
@@ -4536,7 +4536,7 @@ class StrategyManager(_BaseStrategyManager):
                     metadata["candidate_switch_reason"] = "high_score_nearby_option_candidate"
                 else:
                     if not score_ok:
-                        blocked_reason = "raw_score_below_min"
+                        blocked_reason = "regime_weighted_score_below_min"
                     elif not conf_ok:
                         blocked_reason = "confidence_below_min"
                     elif not selected_ok:


### PR DESCRIPTION
Closes #1082.

The single-vote gate already compares `weighted_trigger_score` with the minimum threshold. Its two rejection branches incorrectly emitted `raw_score_below_min`, obscuring that regime down-weighting caused the rejection.

This PR changes only those two diagnostic labels to `regime_weighted_score_below_min`. Thresholds, scores, and trade acceptance are unchanged.

Validation:

- The focused raw 9.0 / weighted 1.8 regression passes.
- The complete strategy test suite passes.
- Python compilation and `git diff --check` pass.