### PR TITLE
Initialize risk metrics before circuit restore

### DIFF
--- a/src/nifty_scalper_bot/risk/risk_manager.py
+++ b/src/nifty_scalper_bot/risk/risk_manager.py
@@ -184,15 +184,15 @@ class RiskManager:
             reset_hour_utc=self.settings.trading_day_reset_hour_utc,
             max_day_profit=day_profit_cap,
         )
+        self._m_blocks = Counter("risk_blocks_total", "Orders blocked by risk manager")
+        self._m_cooldown = Gauge(
+            "risk_cooldown_seconds", "Seconds remaining on enforced cooldown"
+        )
         # Must run after _switches exists: the seed writes into the day-loss
         # circuit, so calling it earlier raised AttributeError on any restart
         # that carried non-zero persisted realised P&L.
         self._seed_day_pnl_from_persisted_state()
         self._restore_risk_circuit_from_persisted_state()
-        self._m_blocks = Counter("risk_blocks_total", "Orders blocked by risk manager")
-        self._m_cooldown = Gauge(
-            "risk_cooldown_seconds", "Seconds remaining on enforced cooldown"
-        )
         self._risk_state = self.risk_state
         self._lot_size_lookup = None
         self._lot_size_symbol = None

--- a/tests/risk/test_day_pnl_restart_seed.py
+++ b/tests/risk/test_day_pnl_restart_seed.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from types import MethodType, SimpleNamespace
 
+from nifty_scalper_bot.config.settings import RiskSettings
 from nifty_scalper_bot.risk.limits import RiskSwitches
 from nifty_scalper_bot.risk.risk_manager import RiskManager
 
@@ -135,3 +136,21 @@ def test_completed_trade_persists_the_circuit_state() -> None:
     assert saved and saved[-1]["completed_trade_costs_today"] == 60.0
     assert saved[-1]["consecutive_losses"] == 1
     assert saved[-1]["loss_cooldown_until_epoch"] > 0.0
+
+
+def test_constructor_restores_breached_loss_streak_without_startup_failure() -> None:
+    position_manager = SimpleNamespace(
+        get_realized_pnl=lambda: 0.0,
+        get_risk_circuit_state=lambda: {"consecutive_losses": 3},
+    )
+
+    risk = RiskManager(
+        settings=RiskSettings(max_consecutive_losses=3),
+        position_manager=position_manager,
+        account_balance=50_000.0,
+    )
+
+    assert risk.is_circuit_breaker_tripped() == (
+        True,
+        "Consecutive loss limit reached (3/3)",
+    )


### PR DESCRIPTION
Closes #1084.

## What changed

- Initialize the existing risk block counter and cooldown gauge before persisted day-P&L/circuit restoration.
- Add a constructor-level regression using a persisted three-loss streak.

## Root cause

`RiskManager.__post_init__` restored persisted circuit state before `_m_cooldown` existed. When the restored streak breached its limit, `_trip_breaker()` built a snapshot and `_set_cooldown_metric()` dereferenced the uninitialized gauge, aborting startup into degraded mode.

## Preserved behavior

- The restored breaker remains tripped and fail-closed.
- No risk thresholds, P&L accounting, cooldown duration, persistence schema, readiness, strategy, or order behavior changes.
- No live orders are placed by the regression.

## Production evidence

The same failure reproduced eight times in the 2026-08-13 14:03–14:44 IST event exports on release fingerprints `1a1d84e799c8`, `c6bbb1acc554`, and `209008a23ac9`.

## Validation

- RED before fix: `test_constructor_restores_breached_loss_streak_without_startup_failure` failed with `AttributeError: 'RiskManager' object has no attribute '_m_cooldown'`.
- `python -m pytest -q tests/risk/test_day_pnl_restart_seed.py` — 9 passed.
- `python -m pytest -q tests/risk` — 101 passed.
- `python -m pytest -q tests/risk tests/architecture/test_canonical_bo_ownership.py tests/test_execution_path_contract.py` — 120 passed.
- `python -m compileall -q src dashboard` — passed.
- Full `python -m pytest -q` — passed after removing sandbox SOCKS proxy variables; the first run stopped at 60% only because the local venv lacks optional `socksio`, and the isolated failed Telegram test passed with proxy variables removed.
- `git diff --check` — passed.

Repository-wide Ruff/Black still reports existing baseline debt in `risk_manager.py`; no unrelated formatting churn is included. Remote blob SHAs were verified against the locally tested files.