### PR TITLE
Recover same-day PnL date from risk circuit

### DIFF
--- a/src/nifty_scalper_bot/risk/risk_manager.py
+++ b/src/nifty_scalper_bot/risk/risk_manager.py
@@ -1209,6 +1209,13 @@ class RiskManager:
         if callable(resolver):
             with suppress(Exception):
                 today = str(resolver())
+        if not session_date:
+            circuit_reader = getattr(manager, "get_risk_circuit_state", None)
+            if callable(circuit_reader):
+                with suppress(Exception):
+                    circuit_state = circuit_reader() or {}
+                    if isinstance(circuit_state, Mapping):
+                        session_date = circuit_state.get("trading_date")
         if not session_date or not today or str(session_date) != today:
             self._logger.warning(
                 "DAY_PNL_SEED_SKIPPED realized=%.2f session_date=%s today=%s",

--- a/tests/risk/test_day_pnl_restart_seed.py
+++ b/tests/risk/test_day_pnl_restart_seed.py
@@ -9,7 +9,12 @@ from nifty_scalper_bot.risk.limits import RiskSwitches
 from nifty_scalper_bot.risk.risk_manager import RiskManager
 
 
-def _manager(realized: float, session_date: str | None, today: str = "2026-08-03"):
+def _manager(
+    realized: float,
+    session_date: str | None,
+    today: str = "2026-08-03",
+    circuit_date: str | None = None,
+):
     switches = RiskSwitches(
         max_day_loss=1000.0,
         max_consecutive_losses=3,
@@ -25,6 +30,9 @@ def _manager(realized: float, session_date: str | None, today: str = "2026-08-03
         _trip_breaker=lambda reason: tripped.append(reason),
         position_manager=SimpleNamespace(
             get_realized_pnl=lambda: realized,
+            get_risk_circuit_state=lambda: (
+                {"trading_date": circuit_date} if circuit_date else {}
+            ),
             _pnl_trading_date=session_date,
             _trading_date_ist=lambda: today,
         ),
@@ -61,6 +69,27 @@ def test_previous_session_pnl_is_not_seeded() -> None:
 
 def test_unknown_session_date_is_not_seeded() -> None:
     stub, switches, _ = _manager(-400.0, None)
+    stub._seed_day_pnl_from_persisted_state()
+
+    assert switches.day_loss() == 0.0
+
+
+def test_same_day_risk_circuit_recovers_missing_pnl_session_date() -> None:
+    stub, switches, tripped = _manager(
+        -400.0,
+        None,
+        circuit_date="2026-08-03",
+    )
+
+    stub._seed_day_pnl_from_persisted_state()
+
+    assert switches.day_loss() == 400.0
+    assert tripped == []
+
+
+def test_previous_risk_circuit_date_does_not_recover_missing_session_date() -> None:
+    stub, switches, _ = _manager(-400.0, None, circuit_date="2026-08-01")
+
     stub._seed_day_pnl_from_persisted_state()
 
     assert switches.day_loss() == 0.0


### PR DESCRIPTION
Closes #1086.

## What changed

When persisted realized P&L lacks the newer `pnl_trading_date`, `RiskManager` now consults the existing persisted risk-circuit record for a date before applying the unchanged same-day equality check.

## Root cause

Legacy/non-migrated position state retained `-833.42` realized P&L with `pnl_trading_date=None`. The already-restored risk circuit carried `trading_date=2026-08-13`, costs, and the loss streak, but `_seed_day_pnl_from_persisted_state()` ignored that authoritative same-day marker and skipped gross realized loss.

## Safety boundaries

- No date is inferred when the circuit record is absent.
- A previous-day circuit date still skips seeding.
- No P&L arithmetic, cost accounting, streak, cooldown, threshold, readiness, strategy, persistence schema, or execution behavior changes.
- Daily-loss protection becomes conservative and restart-correct.

## Validation

- New same-day regression failed before the fix and passes after it.
- `python -m pytest -q tests/risk/test_day_pnl_restart_seed.py` — 11 passed.
- `python -m pytest -q tests/risk` — 102 passed.
- `python -m compileall -q src dashboard` — passed.
- Full `python -m pytest -q` with sandbox proxy variables removed — passed.
- `git diff --check` — passed.

The exact remote blobs match the locally tested files.