### PR TITLE
Persist fallback trailing revisions across restarts

### DIFF
--- a/src/nifty_scalper_bot/execution/bracket_core.py
+++ b/src/nifty_scalper_bot/execution/bracket_core.py
@@ -2916,6 +2916,7 @@ class BracketManager:
                                 "profit_pct": round(profit_pct, 2),
                             },
                         )
+                    self.save_state()
                     return True
             else:  # SELL
                 current_sl = bracket.sl_trigger_price  # authoritative read under lock
@@ -2951,6 +2952,7 @@ class BracketManager:
                                 "profit_pct": round(profit_pct, 2),
                             },
                         )
+                    self.save_state()
                     return True
         return False
 

--- a/tests/execution/test_trailing_restart_persistence.py
+++ b/tests/execution/test_trailing_restart_persistence.py
@@ -36,7 +36,9 @@ def test_fallback_trail_revision_survives_restart(monkeypatch, tmp_path) -> None
     assert trailed.highest_ltp == 110.0
     assert trailed.trail_revision == 1
 
-    restored = _manager().get_bracket("restart-trail")
+    restarted_manager = _manager()
+    assert restarted_manager.load_state() is True
+    restored = restarted_manager.get_bracket("restart-trail")
     assert restored is not None
     assert restored.sl_trigger_price == trailed.sl_trigger_price
     assert restored.highest_ltp == trailed.highest_ltp

--- a/tests/execution/test_trailing_restart_persistence.py
+++ b/tests/execution/test_trailing_restart_persistence.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+from nifty_scalper_bot.execution.bracket_manager import BracketManager
+
+
+def _manager() -> BracketManager:
+    order_manager = Mock()
+    order_manager.is_live_mode.return_value = False
+    manager = BracketManager(order_manager=order_manager)
+    manager._running = False
+    return manager
+
+
+def test_fallback_trail_revision_survives_restart(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    symbol = "NFO:NIFTY2681824400PE"
+    manager = _manager()
+    manager.register_virtual_bracket(
+        order_id="restart-trail",
+        symbol=symbol,
+        side="BUY",
+        qty=65,
+        price=100.0,
+        sl=90.0,
+        tp=140.0,
+        activate_immediately=False,
+    )
+    manager.confirm_entry_fill("restart-trail", 100.0)
+
+    manager.on_tick(symbol, 110.0)
+    trailed = manager.get_bracket("restart-trail")
+    assert trailed is not None
+    assert trailed.sl_trigger_price > 100.0
+    assert trailed.highest_ltp == 110.0
+    assert trailed.trail_revision == 1
+
+    restored = _manager().get_bracket("restart-trail")
+    assert restored is not None
+    assert restored.sl_trigger_price == trailed.sl_trigger_price
+    assert restored.highest_ltp == trailed.highest_ltp
+    assert restored.trail_revision == trailed.trail_revision
+
+
+def test_sub_threshold_tick_does_not_write_bracket_snapshot(
+    monkeypatch, tmp_path
+) -> None:
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    symbol = "NFO:NIFTY2681824400PE"
+    manager = _manager()
+    manager.register_virtual_bracket("no-trail", symbol, "BUY", 65, 100.0, 90.0, 140.0)
+    manager.confirm_entry_fill("no-trail", 100.0)
+    manager.save_state = Mock()
+
+    manager.on_tick(symbol, 105.0)
+
+    manager.save_state.assert_not_called()


### PR DESCRIPTION
Closes #1089

## What changed
- persist each committed fallback BUY/SELL trailing-stop revision through the existing atomic bracket snapshot
- add a restart regression proving SL, favorable water mark, and trail revision restore correctly
- prove sub-threshold ticks do not add persistence writes

## Incident impact
The 2026-08-14 trade could trail in memory before the 09:31:59 restart, then restore the activation snapshot with the original stop and erased favorable excursion. This patch makes the existing fallback trailing mutation durable without changing thresholds, one-lot TP handling, SL/TP evaluation, or the time stop.

## Validation
- RED: restored SL was 90.0 while the in-memory trail was 104.0
- GREEN: focused regression: 2 passed
- adjacent execution/trailing suites: 110 passed
- full repository suite: passed (one pre-existing skipped test)
- `git diff --check`, Ruff and Black on the new test, and compileall passed