### PR TITLE
Retain open-position feeds during basket rotation

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -10075,6 +10075,29 @@ async def _recompute_and_push_runtime_readiness(
         )
 
 
+def _dynamic_symbol_removal_blocker(ctx: BotContext, symbol: str) -> str | None:
+    """Return the execution owner that requires a symbol's live feed."""
+
+    for manager_name, method_name, blocker in (
+        ("bracket_manager", "is_symbol_managed", "active_bracket"),
+        ("position_manager", "has_open_position", "open_position"),
+    ):
+        manager = getattr(ctx, manager_name, None)
+        if manager is None:
+            continue
+        try:
+            if bool(getattr(manager, method_name)(symbol)):
+                return blocker
+        except Exception:
+            LOGGER.exception(
+                "DYNAMIC_SYMBOL_OWNERSHIP_CHECK_FAILED symbol=%s manager=%s",
+                symbol,
+                manager_name,
+            )
+            return f"{manager_name.removesuffix('_manager')}_state_unknown"
+    return None
+
+
 def _commit_active_dynamic_basket(
     ctx: BotContext,
     *,
@@ -13410,6 +13433,14 @@ async def startup_sequence(ctx: BotContext) -> None:
                             )
 
                         for sym in drop_symbols:
+                            removal_blocker = _dynamic_symbol_removal_blocker(ctx, sym)
+                            if removal_blocker is not None:
+                                LOGGER.info(
+                                    "EXECUTION_UNIVERSE_POSITION_KEEP symbol=%s blocker=%s",
+                                    sym,
+                                    removal_blocker,
+                                )
+                                continue
                             lock_ts = ctx.execution_lock_timestamps.get(sym)
                             lock_age_s = (
                                 (datetime.now(timezone.utc) - lock_ts).total_seconds()

--- a/tests/core/test_dynamic_symbol_removal.py
+++ b/tests/core/test_dynamic_symbol_removal.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from nifty_scalper_bot.core.app import _dynamic_symbol_removal_blocker
+
+
+class _OwnershipManager:
+    def __init__(self, owns_symbol: bool) -> None:
+        self._owns_symbol = owns_symbol
+
+    def is_symbol_managed(self, _symbol: str) -> bool:
+        return self._owns_symbol
+
+    def has_open_position(self, _symbol: str) -> bool:
+        return self._owns_symbol
+
+
+@pytest.mark.parametrize(
+    ("bracket_owned", "position_owned", "expected"),
+    [
+        (True, False, "active_bracket"),
+        (False, True, "open_position"),
+        (False, False, None),
+    ],
+)
+def test_dynamic_symbol_removal_respects_execution_ownership(
+    bracket_owned: bool,
+    position_owned: bool,
+    expected: str | None,
+) -> None:
+    ctx = SimpleNamespace(
+        bracket_manager=_OwnershipManager(bracket_owned),
+        position_manager=_OwnershipManager(position_owned),
+    )
+
+    assert _dynamic_symbol_removal_blocker(ctx, "NFO:NIFTY2681824400PE") == expected
+
+
+def test_dynamic_symbol_removal_fails_safe_when_ownership_is_unknown() -> None:
+    class _BrokenBracketManager:
+        def is_symbol_managed(self, _symbol: str) -> bool:
+            raise RuntimeError("state unavailable")
+
+    ctx = SimpleNamespace(
+        bracket_manager=_BrokenBracketManager(),
+        position_manager=_OwnershipManager(False),
+    )
+
+    assert (
+        _dynamic_symbol_removal_blocker(ctx, "NFO:NIFTY2681824400PE")
+        == "bracket_state_unknown"
+    )


### PR DESCRIPTION
Closes #1088

## What changed
- ask the existing bracket and position managers whether a dropped option symbol still has execution ownership
- retain owned symbols before any WebSocket, market-data, DataHub, runner, or watchdog cleanup occurs
- fail closed if either ownership source is temporarily unavailable
- leave the existing sticky window and ordinary unowned-symbol cleanup unchanged

## Why
After `OPTION_STICKY_SECONDS` expired, dynamic ATM basket rotation could explicitly unsubscribe an option even while an active bracket/open position still required its ticks for trailing and exits. MarketDataManager already marks those symbols high priority, but the app cleanup path bypassed that protection.

## Validation
- RED/GREEN ownership-policy regression: active bracket, broker position, unowned symbol, and unknown state
- adjacent basket/market-data/bracket/exit suite: 100 passed
- full repository suite under `BRACKET_AUTO_RESTORE=false`: passed (one pre-existing skip)
- diff check, Ruff/Black on the new test, and compileall passed