### PR TITLE
Persist restart-critical bracket timing and progress

### DIFF
--- a/src/nifty_scalper_bot/execution/bracket_core.py
+++ b/src/nifty_scalper_bot/execution/bracket_core.py
@@ -434,6 +434,7 @@ class BracketState:
             "exit_order_id": self.exit_order_id or self.pending_exit_order_id,
             "exit_correlation_id": self.exit_correlation_id,
             "entry_fill_price": self.entry_fill_price,
+            "entry_fill_ts": self.entry_fill_ts,
             "exit_reason": self.exit_reason,
             "exit_triggered_at": self.exit_triggered_at,
             "exit_submitted_at": self.exit_submitted_at,
@@ -1835,6 +1836,7 @@ class BracketManager:
 
         for bracket in candidates:
             tick_id = f"{symbol}:{exchange_ts:.6f}" if exchange_ts is not None else None
+            time_stop_progress_crossed = False
             # Keep all bracket field mutations atomic against watchdog reads.
             with self._lock:
                 if tick_id is not None and bracket.last_processed_tick_id == tick_id:
@@ -1850,11 +1852,29 @@ class BracketManager:
 
                 # Update high/low water marks (atomic operations)
                 if bracket.side == "BUY":
+                    old_watermark = float(bracket.highest_ltp or bracket.entry_price)
                     if ltp > bracket.highest_ltp:
                         bracket.highest_ltp = ltp
                 else:
+                    old_watermark = float(bracket.lowest_ltp or bracket.entry_price)
                     if ltp < bracket.lowest_ltp:
                         bracket.lowest_ltp = ltp
+                initial_risk = abs(
+                    float(bracket.entry_price)
+                    - float(bracket.initial_sl_trigger_price or old_committed_sl)
+                )
+                if initial_risk > 0:
+                    threshold = initial_risk * self._time_stop_min_progress_r
+                    if bracket.side == "BUY":
+                        time_stop_progress_crossed = (
+                            old_watermark - bracket.entry_price < threshold
+                            <= bracket.highest_ltp - bracket.entry_price
+                        )
+                    else:
+                        time_stop_progress_crossed = (
+                            bracket.entry_price - old_watermark < threshold
+                            <= bracket.entry_price - bracket.lowest_ltp
+                        )
 
             if bracket.exit_pending:
                 exits_to_fire.append(
@@ -1893,6 +1913,15 @@ class BracketManager:
 
             if trail_updated:
                 continue
+            if time_stop_progress_crossed:
+                try:
+                    self.save_state()
+                except Exception as exc:  # noqa: BLE001 - exit checks must continue
+                    LOGGER.error(
+                        "BRACKET_PROGRESS_PERSIST_FAILED symbol=%s error=%s",
+                        bracket.symbol,
+                        exc,
+                    )
 
         # ═══════════════════════════════════════════════════════════
         # FIRE EXITS: Batch processing (takes lock once)
@@ -4768,6 +4797,11 @@ class BracketManager:
             or payload.get("pending_exit_order_id"),
             exit_correlation_id=payload.get("exit_correlation_id"),
             entry_fill_price=payload.get("entry_fill_price"),
+            entry_fill_ts=(
+                finite_float("entry fill ts", payload.get("entry_fill_ts"))
+                if payload.get("entry_fill_ts") is not None
+                else None
+            ),
             exit_reason=payload.get("exit_reason"),
             exit_triggered_at=payload.get("exit_triggered_at"),
             exit_submitted_at=payload.get("exit_submitted_at"),

--- a/tests/execution/test_trailing_restart_persistence.py
+++ b/tests/execution/test_trailing_restart_persistence.py
@@ -28,6 +28,7 @@ def test_fallback_trail_revision_survives_restart(monkeypatch, tmp_path) -> None
         activate_immediately=False,
     )
     manager.confirm_entry_fill("restart-trail", 100.0)
+    activated_at = manager.get_bracket("restart-trail").entry_fill_ts
 
     manager.on_tick(symbol, 110.0)
     trailed = manager.get_bracket("restart-trail")
@@ -43,6 +44,26 @@ def test_fallback_trail_revision_survives_restart(monkeypatch, tmp_path) -> None
     assert restored.sl_trigger_price == trailed.sl_trigger_price
     assert restored.highest_ltp == trailed.highest_ltp
     assert restored.trail_revision == trailed.trail_revision
+    assert restored.entry_fill_ts == activated_at
+
+
+def test_time_stop_exemption_progress_survives_restart(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    symbol = "NFO:NIFTY2681824400PE"
+    manager = _manager()
+    manager.register_virtual_bracket(
+        "restart-progress", symbol, "BUY", 65, 100.0, 90.0, 140.0
+    )
+    manager.confirm_entry_fill("restart-progress", 100.0)
+
+    manager.on_tick(symbol, 105.0)
+
+    restarted_manager = _manager()
+    assert restarted_manager.load_state() is True
+    restored = restarted_manager.get_bracket("restart-progress")
+    assert restored is not None
+    assert restored.highest_ltp == 105.0
+    assert restored.trail_revision == 0
 
 
 def test_sub_threshold_tick_does_not_write_bracket_snapshot(
@@ -55,6 +76,6 @@ def test_sub_threshold_tick_does_not_write_bracket_snapshot(
     manager.confirm_entry_fill("no-trail", 100.0)
     manager.save_state = Mock()
 
-    manager.on_tick(symbol, 105.0)
+    manager.on_tick(symbol, 104.95)
 
     manager.save_state.assert_not_called()


### PR DESCRIPTION
Closes #1092

## Root cause
Bracket snapshots omitted `entry_fill_ts`, and favorable high/low watermarks below the first trailing-stop step were only held in memory. A process restart could therefore reset holding-time/progress state and make the time-stop decision from incomplete lifecycle data.

## Fix
- persist and validate `entry_fill_ts` in bracket snapshots
- persist once when favorable progress first crosses the configured time-stop exemption threshold
- retain the existing no-write behavior below that threshold and existing trail persistence behavior

## Validation
- focused bracket reliability, runtime facade, and restart persistence suites pass
- source compilation passes
- changed test file passes Ruff and Black
- two unrelated full-suite timing/environment flakes were reproduced as passing in isolation (`test_slow_tick_subscriber_is_identified_without_tick_accounting_loss`, `test_partial_fill_and_bracket_resize`); inherited SOCKS proxy failure also passes with proxy variables removed