### PR TITLE
Align initial bracket risk with confirmed fill

### DIFF
--- a/src/nifty_scalper_bot/execution/bracket_core.py
+++ b/src/nifty_scalper_bot/execution/bracket_core.py
@@ -1512,6 +1512,7 @@ class BracketManager:
                         bracket.sl_trigger_price = _round_to_tick(
                             bracket.sl_trigger_price * (1 + price_diff_pct)
                         )
+                        bracket.initial_sl_trigger_price = bracket.sl_trigger_price
 
                     # Adjust TP proportionally
                     if bracket.tp_trigger_price > 0:

--- a/tests/execution/test_trailing_restart_persistence.py
+++ b/tests/execution/test_trailing_restart_persistence.py
@@ -13,6 +13,20 @@ def _manager() -> BracketManager:
     return manager
 
 
+def test_confirmed_fill_reanchors_initial_risk_to_activated_stop() -> None:
+    manager = _manager()
+    manager.register_virtual_bracket(
+        "fill-risk", "NFO:NIFTY2681824400PE", "BUY", 65, 114.10, 105.00, 132.35
+    )
+
+    manager.confirm_entry_fill("fill-risk", 113.55)
+
+    bracket = manager.get_bracket("fill-risk")
+    assert bracket is not None
+    assert bracket.sl_trigger_price == 104.50
+    assert bracket.initial_sl_trigger_price == bracket.sl_trigger_price
+
+
 def test_fallback_trail_revision_survives_restart(monkeypatch, tmp_path) -> None:
     monkeypatch.setenv("DATA_DIR", str(tmp_path))
     symbol = "NFO:NIFTY2681824400PE"


### PR DESCRIPTION
Closes #1094

## Root cause
`confirm_entry_fill()` re-anchored the active SL/TP to the broker fill but retained the pre-fill stop in `initial_sl_trigger_price`. R-based trailing, time-stop progress, and outcome metrics therefore used geometry different from the activated bracket.

## Focused fix
Assign the adjusted active stop to the initial-risk anchor at the same point the stop is re-anchored. Existing SL/TP adjustment, order quantities, and exit behavior are unchanged.

## Incident regression
For registered 114.10 / SL 105.00 and confirmed fill 113.55, both the active stop and initial-risk anchor are now 104.50.

## Validation
- 66 focused bracket, restart, trailing-floor, profit-extension, reliability, and facade tests pass
- changed test module passes Ruff and Black
- production source compilation and diff checks pass