### PR TITLE
Harden trading-path risk and entry intent guards

### DIFF
--- a/src/nifty_scalper_bot/execution/order_entry_guard_patch.py
+++ b/src/nifty_scalper_bot/execution/order_entry_guard_patch.py
@@ -241,6 +241,7 @@ def _patched_place_order(self: Any, *args: Any, **kwargs: Any) -> Any:
     )
     if reason is not None:
         _record_entry_block(self, reason)
+        _release_prebroker_entry_reservation(self, values)
         return None
     result = _ORIGINAL_PLACE_ORDER(self, *args, **kwargs)
     if result is None:

--- a/src/nifty_scalper_bot/execution/order_entry_guard_patch.py
+++ b/src/nifty_scalper_bot/execution/order_entry_guard_patch.py
@@ -14,6 +14,7 @@ _PATCH_APPLIED = False
 _ORIGINAL_PLACE_ORDER: Any = None
 _CORE_PLACE_ORDER_SIGNATURE = inspect.signature(_core.OrderManager.place_order)
 _ENTRY_INTENTS = {"ENTRY", "SCALE_IN", "REVERSAL"}
+_EXIT_TAG_TOKENS = ("exit", "stop", "target", "square", "guard")
 
 
 def _float_or_none(value: Any) -> float | None:
@@ -34,6 +35,26 @@ def _env_float(names: tuple[str, ...], default: float) -> float:
     return default
 
 
+def _entry_identity_block_reason(
+    *, intent: Any, tag: Any, symbol: Any
+) -> dict[str, Any] | None:
+    """Reject explicit entries whose legacy tag would masquerade as an exit."""
+    normalized_intent = str(intent or "").strip().upper()
+    if normalized_intent not in _ENTRY_INTENTS:
+        return None
+    normalized_tag = str(tag or "").strip().lower()
+    matched = next((token for token in _EXIT_TAG_TOKENS if token in normalized_tag), None)
+    if matched is None:
+        return None
+    return {
+        "block_reason": "entry_exit_tag_conflict",
+        "symbol": symbol,
+        "intent": normalized_intent,
+        "tag": tag,
+        "matched_exit_token": matched,
+    }
+
+
 def _entry_geometry_block_reason(
     manager: Any,
     *,
@@ -52,10 +73,23 @@ def _entry_geometry_block_reason(
     if normalized_side not in {"BUY", "SELL"}:
         return None
 
-    entry = _float_or_none(price)
     sl = _float_or_none(stop_loss)
+    if sl is None:
+        return {
+            "block_reason": "entry_stop_loss_required",
+            "symbol": symbol,
+            "entry": _float_or_none(price),
+            "stop_loss": stop_loss,
+            "take_profit": _float_or_none(take_profit),
+            "rr": 0.0,
+            "rr_floor": _env_float(
+                ("ENTRY_MIN_RR", "MIN_ENTRY_RR", "MIN_BRACKET_RR"), 1.5
+            ),
+        }
+
+    entry = _float_or_none(price)
     tp = _float_or_none(take_profit)
-    if entry is None or sl is None or tp is None:
+    if entry is None or tp is None:
         return None
 
     if normalized_side == "BUY":
@@ -157,10 +191,45 @@ def _release_prebroker_entry_reservation(self: Any, values: Mapping[str, Any]) -
     return True
 
 
+def _record_entry_block(self: Any, reason: Mapping[str, Any]) -> None:
+    setter = getattr(self, "set_last_skip_reason", None)
+    if callable(setter):
+        with suppress(Exception):
+            setter(str(reason["block_reason"]))
+    self._last_order_decision = {
+        "allowed": False,
+        "block_reason": reason["block_reason"],
+        "details": dict(reason),
+        "broker_attempted": False,
+        "final_order_gate": True,
+    }
+    logger = getattr(self, "_logger", None)
+    log = getattr(logger, "critical", None)
+    if callable(log):
+        log(
+            "ENTRY_GUARD_BLOCKED symbol=%s reason=%s intent=%s tag=%s",
+            reason.get("symbol"),
+            reason.get("block_reason"),
+            reason.get("intent"),
+            reason.get("tag"),
+            extra={"event": "ENTRY_GUARD_BLOCKED", **dict(reason)},
+        )
+
+
 def _patched_place_order(self: Any, *args: Any, **kwargs: Any) -> Any:
     if not _live_mode(self):
         return _ORIGINAL_PLACE_ORDER(self, *args, **kwargs)
     values = _bind_place_order(args, kwargs) or dict(kwargs)
+    identity_reason = _entry_identity_block_reason(
+        intent=values.get("intent"),
+        tag=values.get("tag"),
+        symbol=values.get("symbol"),
+    )
+    if identity_reason is not None:
+        _record_entry_block(self, identity_reason)
+        _release_prebroker_entry_reservation(self, values)
+        return None
+
     reason = _entry_geometry_block_reason(
         self,
         symbol=values.get("symbol"),
@@ -171,31 +240,7 @@ def _patched_place_order(self: Any, *args: Any, **kwargs: Any) -> Any:
         intent=values.get("intent"),
     )
     if reason is not None:
-        setter = getattr(self, "set_last_skip_reason", None)
-        if callable(setter):
-            with suppress(Exception):
-                setter(str(reason["block_reason"]))
-        self._last_order_decision = {
-            "allowed": False,
-            "block_reason": reason["block_reason"],
-            "details": reason,
-            "broker_attempted": False,
-            "final_order_gate": True,
-        }
-        logger = getattr(self, "_logger", None)
-        log = getattr(logger, "critical", None)
-        if callable(log):
-            log(
-                "ENTRY_GEOMETRY_BLOCKED symbol=%s reason=%s entry=%s sl=%s tp=%s rr=%s floor=%s",
-                reason.get("symbol"),
-                reason.get("block_reason"),
-                reason.get("entry"),
-                reason.get("stop_loss"),
-                reason.get("take_profit"),
-                round(float(reason.get("rr") or 0.0), 3),
-                reason.get("rr_floor"),
-                extra={"event": "ENTRY_GEOMETRY_BLOCKED", **reason},
-            )
+        _record_entry_block(self, reason)
         return None
     result = _ORIGINAL_PLACE_ORDER(self, *args, **kwargs)
     if result is None:
@@ -221,5 +266,7 @@ def apply_patches() -> None:
 __all__ = [
     "apply_patches",
     "_entry_geometry_block_reason",
+    "_entry_identity_block_reason",
+    "_record_entry_block",
     "_release_prebroker_entry_reservation",
 ]

--- a/src/nifty_scalper_bot/execution/order_entry_guard_patch.py
+++ b/src/nifty_scalper_bot/execution/order_entry_guard_patch.py
@@ -205,15 +205,29 @@ def _record_entry_block(self: Any, reason: Mapping[str, Any]) -> None:
     }
     logger = getattr(self, "_logger", None)
     log = getattr(logger, "critical", None)
-    if callable(log):
+    if not callable(log):
+        return
+    if reason.get("block_reason") == "entry_exit_tag_conflict":
         log(
-            "ENTRY_GUARD_BLOCKED symbol=%s reason=%s intent=%s tag=%s",
+            "ENTRY_IDENTITY_BLOCKED symbol=%s reason=%s intent=%s tag=%s",
             reason.get("symbol"),
             reason.get("block_reason"),
             reason.get("intent"),
             reason.get("tag"),
-            extra={"event": "ENTRY_GUARD_BLOCKED", **dict(reason)},
+            extra={"event": "ENTRY_IDENTITY_BLOCKED", **dict(reason)},
         )
+        return
+    log(
+        "ENTRY_GEOMETRY_BLOCKED symbol=%s reason=%s entry=%s sl=%s tp=%s rr=%s floor=%s",
+        reason.get("symbol"),
+        reason.get("block_reason"),
+        reason.get("entry"),
+        reason.get("stop_loss"),
+        reason.get("take_profit"),
+        round(float(reason.get("rr") or 0.0), 3),
+        reason.get("rr_floor"),
+        extra={"event": "ENTRY_GEOMETRY_BLOCKED", **dict(reason)},
+    )
 
 
 def _patched_place_order(self: Any, *args: Any, **kwargs: Any) -> Any:

--- a/src/nifty_scalper_bot/risk/entry_guard_patch.py
+++ b/src/nifty_scalper_bot/risk/entry_guard_patch.py
@@ -15,6 +15,7 @@ from nifty_scalper_bot.risk.net_rr_gate import NetRRResult, evaluate_final_net_r
 
 _PATCH_APPLIED = False
 _ORIGINAL_CHECK_ORDER: Any = None
+_ORIGINAL_SUGGEST_POSITION_SIZE: Any = None
 _REDUCING_INTENTS = {"EXIT", "REDUCE", "FLATTEN", "SQUARE_OFF", "SQUAREOFF"}
 _TRUE_VALUES = {"1", "true", "yes", "y", "on"}
 
@@ -179,6 +180,125 @@ def _net_rr_block_reason(signal: Any) -> tuple[str, NetRRResult] | None:
     return None
 
 
+def _confidence_value(value: Any) -> float:
+    if value is None:
+        return 1.0
+    with suppress(TypeError, ValueError):
+        return max(0.0, min(1.0, float(value)))
+    return 0.0
+
+
+def _sizing_risk_distance(
+    *, side: str, price: float, stop_loss: Any, atr: Any
+) -> float:
+    effective_stop = stop_loss
+    if effective_stop is None:
+        default_sl_pct = float(os.getenv("DEFAULT_SL_PCT", "2.0"))
+        effective_stop = (
+            price * (1 - default_sl_pct / 100.0)
+            if str(side).strip().upper() == "BUY"
+            else price * (1 + default_sl_pct / 100.0)
+        )
+    with suppress(TypeError, ValueError):
+        distance = abs(float(price) - float(effective_stop))
+        if atr is not None:
+            with suppress(TypeError, ValueError):
+                distance = max(distance, abs(float(atr)))
+        return max(distance, float(price) * 0.005)
+    return 0.0
+
+
+def _patched_suggest_position_size(
+    self: Any,
+    *,
+    side: str,
+    price: float,
+    stop_loss: float | None,
+    atr: float | None,
+    requested_quantity: int,
+    confidence: float | None = None,
+    symbol: str | None = None,
+) -> int:
+    """Preserve existing sizing, then enforce the canonical percentage cap."""
+    confidence_value = _confidence_value(confidence)
+    if confidence_value <= 0.0:
+        logger = getattr(self, "_logger", None)
+        log = getattr(logger, "info", None)
+        if callable(log):
+            log(
+                "RISK_SIZING_BLOCKED_ZERO_CONFIDENCE symbol=%s confidence=%s",
+                symbol,
+                confidence,
+                extra={
+                    "event": "RISK_SIZING_BLOCKED_ZERO_CONFIDENCE",
+                    "symbol": symbol,
+                    "confidence": confidence,
+                },
+            )
+        return 0
+
+    quantity = int(
+        _ORIGINAL_SUGGEST_POSITION_SIZE(
+            self,
+            side=side,
+            price=price,
+            stop_loss=stop_loss,
+            atr=atr,
+            requested_quantity=requested_quantity,
+            confidence=confidence,
+            symbol=symbol,
+        )
+        or 0
+    )
+    if quantity <= 0:
+        return 0
+
+    with suppress(TypeError, ValueError, AttributeError):
+        balance = float(getattr(self, "account_balance", 0.0) or 0.0)
+        if balance <= 0.0:
+            balance = float(getattr(self, "_cached_balance", 0.0) or 0.0)
+        risk_pct = float(getattr(getattr(self, "settings", None), "per_trade_risk_pct", 0.0) or 0.0)
+        allowed_risk = balance * (risk_pct / 100.0)
+        distance = _sizing_risk_distance(
+            side=side,
+            price=float(price),
+            stop_loss=stop_loss,
+            atr=atr,
+        )
+        if balance > 0.0 and allowed_risk > 0.0 and distance > 0.0:
+            try:
+                lot_size = int(self._resolve_lot_size(symbol))
+            except Exception:
+                lot_size = int(os.getenv("DEFAULT_LOT_SIZE", "25"))
+            if lot_size <= 0:
+                return 0
+            max_lots = int(allowed_risk // (distance * lot_size))
+            safe_quantity = max(0, max_lots * lot_size)
+            if quantity > safe_quantity:
+                logger = getattr(self, "_logger", None)
+                log = getattr(logger, "warning", None)
+                if callable(log):
+                    log(
+                        "RISK_SIZING_CLAMPED_TO_PERCENT_CAP symbol=%s requested_sized=%s safe_qty=%s allowed_risk=%.2f risk_distance=%.4f",
+                        symbol,
+                        quantity,
+                        safe_quantity,
+                        allowed_risk,
+                        distance,
+                        extra={
+                            "event": "RISK_SIZING_CLAMPED_TO_PERCENT_CAP",
+                            "symbol": symbol,
+                            "sized_quantity": quantity,
+                            "safe_quantity": safe_quantity,
+                            "allowed_risk": allowed_risk,
+                            "risk_distance": distance,
+                            "per_trade_risk_pct": risk_pct,
+                        },
+                    )
+                return safe_quantity
+    return quantity
+
+
 def _patched_check_order(self: Any, signal: Any, live_enabled: bool) -> tuple[bool, str]:
     # Protective exits/reductions must never be blocked by entry-only limits.
     position_manager = getattr(self, "position_manager", None)
@@ -266,7 +386,7 @@ def _patched_check_order(self: Any, signal: Any, live_enabled: bool) -> tuple[bo
 
 
 def apply_patches() -> None:
-    global _PATCH_APPLIED, _ORIGINAL_CHECK_ORDER
+    global _PATCH_APPLIED, _ORIGINAL_CHECK_ORDER, _ORIGINAL_SUGGEST_POSITION_SIZE
     if _PATCH_APPLIED:
         return
     from nifty_scalper_bot.risk.risk_manager import RiskManager
@@ -275,16 +395,21 @@ def apply_patches() -> None:
         _PATCH_APPLIED = True
         return
     _ORIGINAL_CHECK_ORDER = RiskManager.check_order
+    _ORIGINAL_SUGGEST_POSITION_SIZE = RiskManager.suggest_position_size
     RiskManager.check_order = _patched_check_order
+    RiskManager.suggest_position_size = _patched_suggest_position_size
     RiskManager._entry_guard_patch = True
     _PATCH_APPLIED = True
 
 
 __all__ = [
     "apply_patches",
+    "_confidence_value",
     "_daily_limit_block_reason",
     "_is_reducing_order",
     "_net_rr_block_reason",
+    "_patched_suggest_position_size",
     "_real_broker_live",
+    "_sizing_risk_distance",
     "_stop_reentry_block_reason",
 ]

--- a/tests/execution/test_entry_geometry_guard.py
+++ b/tests/execution/test_entry_geometry_guard.py
@@ -2,7 +2,10 @@ from threading import RLock
 from types import SimpleNamespace
 
 from nifty_scalper_bot.execution import order_entry_guard_patch as guard_patch
-from nifty_scalper_bot.execution.order_entry_guard_patch import _entry_geometry_block_reason
+from nifty_scalper_bot.execution.order_entry_guard_patch import (
+    _entry_geometry_block_reason,
+    _entry_identity_block_reason,
+)
 from nifty_scalper_bot.utils.symbols import normalize_symbol
 
 
@@ -48,6 +51,43 @@ def test_entry_geometry_does_not_block_protective_exit():
     )
 
     assert reason is None
+
+
+def test_explicit_sell_entry_without_stop_is_blocked():
+    reason = _entry_geometry_block_reason(
+        SimpleNamespace(),
+        symbol="NFO:NIFTY24JUL24000CE",
+        side="SELL",
+        price=140.0,
+        stop_loss=None,
+        take_profit=125.0,
+        intent="ENTRY",
+    )
+
+    assert reason is not None
+    assert reason["block_reason"] == "entry_stop_loss_required"
+
+
+def test_explicit_entry_with_exit_like_tag_is_blocked():
+    reason = _entry_identity_block_reason(
+        intent="ENTRY",
+        tag="strategy_exit_probe",
+        symbol="NFO:NIFTY24JUL24000CE",
+    )
+
+    assert reason is not None
+    assert reason["block_reason"] == "entry_exit_tag_conflict"
+
+
+def test_exit_intent_is_not_blocked_by_entry_identity_guard():
+    assert (
+        _entry_identity_block_reason(
+            intent="EXIT",
+            tag="strategy_exit_probe",
+            symbol="NFO:NIFTY24JUL24000CE",
+        )
+        is None
+    )
 
 
 def test_explicit_prebroker_rejection_releases_entry_reservation(monkeypatch):

--- a/tests/execution/test_entry_geometry_guard.py
+++ b/tests/execution/test_entry_geometry_guard.py
@@ -110,6 +110,9 @@ def test_explicit_prebroker_rejection_releases_entry_reservation(monkeypatch):
         symbol=symbol,
         side="BUY",
         quantity=65,
+        price=140.0,
+        stop_loss=135.0,
+        take_profit=151.0,
         intent="ENTRY",
     )
 
@@ -137,6 +140,9 @@ def test_broker_attempted_rejection_keeps_entry_reservation(monkeypatch):
         symbol=symbol,
         side="BUY",
         quantity=65,
+        price=140.0,
+        stop_loss=135.0,
+        take_profit=151.0,
         intent="ENTRY",
     )
 

--- a/tests/risk/test_risk_rejection_codes.py
+++ b/tests/risk/test_risk_rejection_codes.py
@@ -70,6 +70,44 @@ def test_record_rejection_margin_is_soft() -> None:
     assert risk._last_rejection == "MARGIN"
 
 
+def test_suggest_position_size_never_uses_minimum_risk_floor_to_breach_percent_cap(
+    monkeypatch,
+) -> None:
+    risk = _make_risk_manager()
+    risk.account_balance = 30_000.0
+    risk.set_lot_size_provider(lambda _symbol: 25)
+    monkeypatch.setenv("MIN_RISK_PER_TRADE", "500")
+
+    quantity = risk.suggest_position_size(
+        side="BUY",
+        price=100.0,
+        stop_loss=84.0,
+        atr=None,
+        requested_quantity=25,
+        confidence=1.0,
+        symbol="NFO:NIFTY2681824400CE",
+    )
+
+    # 1% of ₹30,000 = ₹300. One lot risks 25 * ₹16 = ₹400, so it must be rejected.
+    assert quantity == 0
+
+
+def test_suggest_position_size_zero_or_invalid_confidence_fails_closed() -> None:
+    risk = _make_risk_manager()
+    risk.set_lot_size_provider(lambda _symbol: 25)
+
+    common = dict(
+        side="BUY",
+        price=100.0,
+        stop_loss=95.0,
+        atr=None,
+        requested_quantity=25,
+        symbol="NFO:NIFTY2681824400CE",
+    )
+    assert risk.suggest_position_size(confidence=0.0, **common) == 0
+    assert risk.suggest_position_size(confidence="invalid", **common) == 0
+
+
 def test_risk_config_max_concurrent_positions_matches_enforced_single_position() -> None:
     """Slice-4: the second (dead-code) RiskManager's config default must not
     silently disagree with the single-position policy enforced at the


### PR DESCRIPTION
## Scope
Focused trading-path safety fixes only; no new production modules and no execution-path rewrite.

### Confirmed fixes
- Clamp `RiskManager.suggest_position_size()` output to the configured per-trade percentage risk budget, preventing `MIN_RISK_PER_TRADE` from manufacturing extra risk capacity.
- Fail closed on zero or invalid sizing confidence so the one-lot floor cannot revive a rejected size.
- Require a structural stop for explicit live `ENTRY`/`SCALE_IN`/`REVERSAL` orders on both BUY and SELL sides.
- Reject explicit entry orders whose tag contains legacy exit tokens, preventing tag-based `is_system_exit` inference in core from bypassing entry-only safeguards.
- Preserve pre-broker entry reservation cleanup on these new guard rejections.

### Findings intentionally not patched
- Reported `normalized_symbol` / `normalized_side` UnboundLocalError is already fixed on current main.
- There are not three live RiskManager breaker authorities on current main; the remaining similarly named class is the deterministic sizing adapter.
- `runner.py` no longer imports deleted `order_executor.py`; the legacy injected executor helper is not an import-time crash.

### Regression tests
- ₹30k account / 1% risk cap / ₹500 minimum-risk floor cannot force one lot when one-lot stop risk is ₹400 > ₹300.
- Zero and invalid confidence return zero quantity.
- Explicit SELL entry without stop is blocked.
- Explicit entry with exit-like tag is blocked; EXIT intent is unaffected.