### PR TITLE
Fix candidate fallback to preserve strategy contract

### DIFF
--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -4467,8 +4467,9 @@ class StrategyRunner:
         candidate_snapshots: Sequence[Mapping[str, Any]],
         is_live_mode: bool,
         trace_id: str | None,
+        preferred_symbol: str | None = None,
     ) -> tuple[Any | None, dict[str, dict[str, object]]]:
-        """Return the first ranked, ready candidate that can fund one live lot."""
+        """Prefer the signal contract; use ranked alternatives only as fallback."""
         snapshots_by_symbol = {
             normalize_symbol(str(snapshot.get("symbol") or "")): snapshot
             for snapshot in candidate_snapshots
@@ -4478,7 +4479,13 @@ class StrategyRunner:
         fallback_balance = getattr(
             getattr(self, "_risk_manager", None), "available_balance", None
         )
-        for ranked in ranked_candidates:
+        preferred = normalize_symbol(str(preferred_symbol or ""))
+        ordered_candidates = list(ranked_candidates)
+        if preferred:
+            ordered_candidates.sort(
+                key=lambda ranked: normalize_symbol(str(ranked.symbol)) != preferred
+            )
+        for ranked in ordered_candidates:
             ranked_symbol = normalize_symbol(str(ranked.symbol))
             ready_before = self._is_symbol_execution_ready(ranked_symbol)
             ready_after = bool(
@@ -18835,6 +18842,7 @@ class StrategyRunner:
                             candidate_snapshots=valid_snapshots,
                             is_live_mode=is_live_mode,
                             trace_id=trace_id,
+                            preferred_symbol=signal.symbol,
                         )
                     )
                     if candidate is not None:

--- a/tests/strategies/test_candidate_specific_option_readiness.py
+++ b/tests/strategies/test_candidate_specific_option_readiness.py
@@ -580,3 +580,95 @@ def test_final_contract_gate_accepts_only_runner_approved_replacement() -> None:
         )
         is not None
     )
+
+
+def test_live_candidate_selection_prefers_signal_contract_when_affordable() -> None:
+    """Do not replace an executable affordable strategy contract just for rank."""
+    runner = object.__new__(StrategyRunner)
+    runner._logger = _Logger()
+    runner._order_manager = SimpleNamespace(
+        _margin_factor=1.1,
+        _margin_buffer=0.9,
+        resolve_lot_size=lambda _symbol: 65,
+    )
+    runner._data_hub = SimpleNamespace(
+        get_available_balance=lambda force=False: 9_170.0
+    )
+    runner._risk_manager = SimpleNamespace(available_balance=9_170.0)
+    runner._is_symbol_execution_ready = lambda _symbol: True
+    runner._ensure_symbol_execution_ready_for_order = (
+        lambda _symbol, trace_id=None: True
+    )
+    signal_contract = SimpleNamespace(symbol="NFO:NIFTY2681824300CE")
+    higher_ranked_neighbor = SimpleNamespace(symbol="NFO:NIFTY2681824350CE")
+    snapshots = [
+        {
+            "symbol": higher_ranked_neighbor.symbol,
+            "bid": 49.0,
+            "ask": 49.15,
+            "ltp": 49.10,
+        },
+        {
+            "symbol": signal_contract.symbol,
+            "bid": 73.55,
+            "ask": 73.70,
+            "ltp": 73.65,
+        },
+    ]
+
+    selected, decisions = runner._select_capital_eligible_candidate(
+        ranked_candidates=[higher_ranked_neighbor, signal_contract],
+        candidate_snapshots=snapshots,
+        is_live_mode=True,
+        trace_id="trace-prefer-signal",
+        preferred_symbol=signal_contract.symbol,
+    )
+
+    assert selected is signal_contract
+    assert decisions[signal_contract.symbol]["affordable"] is True
+
+
+def test_live_candidate_selection_still_falls_back_when_signal_contract_unaffordable() -> None:
+    """Preserve capital-aware replacement when the original cannot fund one lot."""
+    runner = object.__new__(StrategyRunner)
+    runner._logger = _Logger()
+    runner._order_manager = SimpleNamespace(
+        _margin_factor=1.1,
+        _margin_buffer=0.9,
+        resolve_lot_size=lambda _symbol: 65,
+    )
+    runner._data_hub = SimpleNamespace(
+        get_available_balance=lambda force=False: 8_500.0
+    )
+    runner._risk_manager = SimpleNamespace(available_balance=8_500.0)
+    runner._is_symbol_execution_ready = lambda _symbol: True
+    runner._ensure_symbol_execution_ready_for_order = (
+        lambda _symbol, trace_id=None: True
+    )
+    signal_contract = SimpleNamespace(symbol="NFO:NIFTY2681824250CE")
+    affordable_neighbor = SimpleNamespace(symbol="NFO:NIFTY2681824300CE")
+    snapshots = [
+        {
+            "symbol": affordable_neighbor.symbol,
+            "bid": 73.55,
+            "ask": 73.70,
+            "ltp": 73.65,
+        },
+        {
+            "symbol": signal_contract.symbol,
+            "bid": 141.8,
+            "ask": 142.0,
+            "ltp": 141.9,
+        },
+    ]
+
+    selected, decisions = runner._select_capital_eligible_candidate(
+        ranked_candidates=[affordable_neighbor, signal_contract],
+        candidate_snapshots=snapshots,
+        is_live_mode=True,
+        trace_id="trace-fallback",
+        preferred_symbol=signal_contract.symbol,
+    )
+
+    assert decisions[signal_contract.symbol]["affordable"] is False
+    assert selected is affordable_neighbor


### PR DESCRIPTION
## Live defect
On 17 Aug 2026, VWAPPro approved `NFO:NIFTY2681824300CE`. That original contract remained executable and affordable, but the capital-aware candidate path selected higher-ranked `NFO:NIFTY2681824350CE` and replaced the strategy contract. The substituted contract was then filled and stopped out.

## Root cause
`StrategyRunner._select_capital_eligible_candidate()` returned the first ranked ready+affordable candidate. The replacement mechanism introduced for affordability fallback therefore acted as a general ranking substitution even when the strategy's original contract was already executable and affordable.

## Focused correction
- Pass the original `signal.symbol` as the preferred contract to the existing capital-eligibility selector.
- Stable-order that contract first when present.
- Preserve every existing readiness and affordability check.
- If the original contract is unready or unaffordable, continue through the existing ranked alternatives unchanged.

No strategy thresholds, score formulas, net-RR rule, stop/target geometry, sizing, margin, broker submission, bracket, trailing, or exit behavior is weakened.

## TDD / validation
- Regression first reproduced the defect: a higher-ranked affordable neighbor displaced an equally affordable strategy contract.
- Control proves an unaffordable strategy contract still falls back to an affordable neighbor.
- Focused regressions passed after the correction.
- Entire strategy suite passed.
- `compileall` passed.
- Full repository suite passed before the validated commit was pushed.
- Temporary validation workflow removed; final diff is only `runner.py` and the existing candidate-readiness test file.

`main` advanced during validation via #1096; it changes risk/entry guards only and does not overlap these files. This PR intentionally relies on PR integration checks before merge.