### PR TITLE
Cap entry sizing to remaining daily risk budget

### DIFF
--- a/src/nifty_scalper_bot/risk/__init__.py
+++ b/src/nifty_scalper_bot/risk/__init__.py
@@ -5,6 +5,28 @@ from .entry_guard_patch import apply_patches as _apply_entry_guard_patch
 from .time_based_sizer import TimeBasedSizer
 from .volatility_sizer import VolatilitySizer
 
+
+def _resolve_lot_size_from_provider(self: RiskManager, symbol: str | None) -> int:
+    """Resolve lot size from the provider already injected by app wiring."""
+    lookup = self._lot_size_lookup if callable(self._lot_size_lookup) else None
+    target_symbol = symbol or self._lot_size_symbol or "NIFTY"
+    if lookup is None:
+        raise RuntimeError("lot size provider not configured")
+    lot_size = int(lookup(target_symbol) or 0)
+    if lot_size <= 0:
+        raise ValueError(f"invalid lot size for {target_symbol}: {lot_size}")
+    self._logger.info(
+        "LOT_SIZE_RESOLVED underlying=%s lot_size=%s source=provider",
+        "NIFTY" if "NIFTY" in str(target_symbol).upper() else target_symbol,
+        lot_size,
+    )
+    return lot_size
+
+
+# risk_manager.py still references a removed resolver helper. Keep the existing
+# injected InstrumentManager provider as the single source of truth instead of
+# introducing another lot-size lookup path.
+RiskManager._resolve_lot_size = _resolve_lot_size_from_provider
 _apply_entry_guard_patch()
 
 __all__ = [

--- a/src/nifty_scalper_bot/risk/entry_guard_patch.py
+++ b/src/nifty_scalper_bot/risk/entry_guard_patch.py
@@ -208,6 +208,38 @@ def _sizing_risk_distance(
     return 0.0
 
 
+def _daily_risk_budget_state(manager: Any) -> tuple[float | None, float, float]:
+    """Return remaining day-loss budget, current day loss and configured cap."""
+    switches = getattr(manager, "_switches", None)
+    if switches is None:
+        return None, 0.0, 0.0
+    with suppress(TypeError, ValueError):
+        max_day_loss = max(float(getattr(switches, "max_day_loss", 0.0) or 0.0), 0.0)
+        if max_day_loss <= 0.0:
+            return None, 0.0, 0.0
+        day_loss_reader = getattr(switches, "day_loss", None)
+        if not callable(day_loss_reader):
+            return 0.0, 0.0, max_day_loss
+        try:
+            current_day_loss = max(float(day_loss_reader() or 0.0), 0.0)
+        except Exception:
+            return 0.0, 0.0, max_day_loss
+        return max(max_day_loss - current_day_loss, 0.0), current_day_loss, max_day_loss
+    return None, 0.0, 0.0
+
+
+def _signal_stop_risk(signal: Any) -> float | None:
+    """Return deterministic stop-risk for a normalized entry signal."""
+    with suppress(TypeError, ValueError):
+        quantity = abs(int(float(getattr(signal, "quantity", 0) or 0)))
+        price = float(getattr(signal, "price", 0.0) or 0.0)
+        stop_loss = getattr(signal, "stop_loss", None)
+        if quantity <= 0 or price <= 0.0 or stop_loss is None:
+            return None
+        return abs(price - float(stop_loss)) * quantity
+    return None
+
+
 def _patched_suggest_position_size(
     self: Any,
     *,
@@ -219,7 +251,7 @@ def _patched_suggest_position_size(
     confidence: float | None = None,
     symbol: str | None = None,
 ) -> int:
-    """Preserve existing sizing, then enforce the canonical percentage cap."""
+    """Preserve existing sizing, then enforce percentage and remaining-day caps."""
     confidence_value = _confidence_value(confidence)
     if confidence_value <= 0.0:
         logger = getattr(self, "_logger", None)
@@ -257,8 +289,17 @@ def _patched_suggest_position_size(
         balance = float(getattr(self, "account_balance", 0.0) or 0.0)
         if balance <= 0.0:
             balance = float(getattr(self, "_cached_balance", 0.0) or 0.0)
-        risk_pct = float(getattr(getattr(self, "settings", None), "per_trade_risk_pct", 0.0) or 0.0)
+        risk_pct = float(
+            getattr(getattr(self, "settings", None), "per_trade_risk_pct", 0.0)
+            or 0.0
+        )
         allowed_risk = balance * (risk_pct / 100.0)
+        remaining_day_budget, current_day_loss, max_day_loss = _daily_risk_budget_state(
+            self
+        )
+        effective_allowed_risk = allowed_risk
+        if remaining_day_budget is not None:
+            effective_allowed_risk = min(allowed_risk, remaining_day_budget)
         distance = _sizing_risk_distance(
             side=side,
             price=float(price),
@@ -272,27 +313,42 @@ def _patched_suggest_position_size(
                 lot_size = int(os.getenv("DEFAULT_LOT_SIZE", "25"))
             if lot_size <= 0:
                 return 0
-            max_lots = int(allowed_risk // (distance * lot_size))
+            max_lots = int(effective_allowed_risk // (distance * lot_size))
             safe_quantity = max(0, max_lots * lot_size)
             if quantity > safe_quantity:
                 logger = getattr(self, "_logger", None)
                 log = getattr(logger, "warning", None)
+                daily_budget_tighter = (
+                    remaining_day_budget is not None
+                    and remaining_day_budget < allowed_risk
+                )
+                event = (
+                    "RISK_SIZING_CLAMPED_TO_REMAINING_DAY_BUDGET"
+                    if daily_budget_tighter
+                    else "RISK_SIZING_CLAMPED_TO_PERCENT_CAP"
+                )
                 if callable(log):
                     log(
-                        "RISK_SIZING_CLAMPED_TO_PERCENT_CAP symbol=%s requested_sized=%s safe_qty=%s allowed_risk=%.2f risk_distance=%.4f",
+                        "%s symbol=%s requested_sized=%s safe_qty=%s allowed_risk=%.2f effective_risk=%.2f risk_distance=%.4f",
+                        event,
                         symbol,
                         quantity,
                         safe_quantity,
                         allowed_risk,
+                        effective_allowed_risk,
                         distance,
                         extra={
-                            "event": "RISK_SIZING_CLAMPED_TO_PERCENT_CAP",
+                            "event": event,
                             "symbol": symbol,
                             "sized_quantity": quantity,
                             "safe_quantity": safe_quantity,
                             "allowed_risk": allowed_risk,
+                            "effective_allowed_risk": effective_allowed_risk,
                             "risk_distance": distance,
                             "per_trade_risk_pct": risk_pct,
+                            "remaining_day_budget": remaining_day_budget,
+                            "current_day_loss": current_day_loss,
+                            "max_day_loss": max_day_loss,
                         },
                     )
                 return safe_quantity
@@ -325,6 +381,42 @@ def _patched_check_order(self: Any, signal: Any, live_enabled: bool) -> tuple[bo
                     },
                 )
             return False, reentry_reason
+
+    if live_enabled:
+        remaining_day_budget, current_day_loss, max_day_loss = _daily_risk_budget_state(
+            self
+        )
+        prospective_stop_risk = _signal_stop_risk(signal)
+        if (
+            remaining_day_budget is not None
+            and prospective_stop_risk is not None
+            and prospective_stop_risk > remaining_day_budget
+        ):
+            reason = (
+                "remaining daily loss budget insufficient: "
+                f"{prospective_stop_risk:.2f}/{remaining_day_budget:.2f}"
+            )
+            self._last_rejection = "DAILY_RISK_BUDGET"
+            logger = getattr(self, "_logger", None)
+            log = getattr(logger, "warning", None)
+            if callable(log):
+                log(
+                    "RISK_FINAL_GATE_BLOCK reason=%s symbol=%s",
+                    reason,
+                    getattr(signal, "symbol", None),
+                    extra={
+                        "event": "RISK_FINAL_GATE_BLOCK",
+                        "reason": reason,
+                        "code": "DAILY_RISK_BUDGET",
+                        "symbol": getattr(signal, "symbol", None),
+                        "final_order_gate": True,
+                        "prospective_stop_risk": prospective_stop_risk,
+                        "remaining_day_budget": remaining_day_budget,
+                        "current_day_loss": current_day_loss,
+                        "max_day_loss": max_day_loss,
+                    },
+                )
+            return False, reason
 
     if _real_broker_live(live_enabled):
         net_rr_block = _net_rr_block_reason(signal)
@@ -406,10 +498,12 @@ __all__ = [
     "apply_patches",
     "_confidence_value",
     "_daily_limit_block_reason",
+    "_daily_risk_budget_state",
     "_is_reducing_order",
     "_net_rr_block_reason",
     "_patched_suggest_position_size",
     "_real_broker_live",
+    "_signal_stop_risk",
     "_sizing_risk_distance",
     "_stop_reentry_block_reason",
 ]

--- a/src/nifty_scalper_bot/risk/entry_guard_patch.py
+++ b/src/nifty_scalper_bot/risk/entry_guard_patch.py
@@ -382,42 +382,6 @@ def _patched_check_order(self: Any, signal: Any, live_enabled: bool) -> tuple[bo
                 )
             return False, reentry_reason
 
-    if live_enabled:
-        remaining_day_budget, current_day_loss, max_day_loss = _daily_risk_budget_state(
-            self
-        )
-        prospective_stop_risk = _signal_stop_risk(signal)
-        if (
-            remaining_day_budget is not None
-            and prospective_stop_risk is not None
-            and prospective_stop_risk > remaining_day_budget
-        ):
-            reason = (
-                "remaining daily loss budget insufficient: "
-                f"{prospective_stop_risk:.2f}/{remaining_day_budget:.2f}"
-            )
-            self._last_rejection = "DAILY_RISK_BUDGET"
-            logger = getattr(self, "_logger", None)
-            log = getattr(logger, "warning", None)
-            if callable(log):
-                log(
-                    "RISK_FINAL_GATE_BLOCK reason=%s symbol=%s",
-                    reason,
-                    getattr(signal, "symbol", None),
-                    extra={
-                        "event": "RISK_FINAL_GATE_BLOCK",
-                        "reason": reason,
-                        "code": "DAILY_RISK_BUDGET",
-                        "symbol": getattr(signal, "symbol", None),
-                        "final_order_gate": True,
-                        "prospective_stop_risk": prospective_stop_risk,
-                        "remaining_day_budget": remaining_day_budget,
-                        "current_day_loss": current_day_loss,
-                        "max_day_loss": max_day_loss,
-                    },
-                )
-            return False, reason
-
     if _real_broker_live(live_enabled):
         net_rr_block = _net_rr_block_reason(signal)
         if net_rr_block is not None:
@@ -474,7 +438,47 @@ def _patched_check_order(self: Any, signal: Any, live_enabled: bool) -> tuple[bo
                     },
                 )
             return False, reason
-    return _ORIGINAL_CHECK_ORDER(self, signal, live_enabled)
+
+    allowed, reason = _ORIGINAL_CHECK_ORDER(self, signal, live_enabled)
+    if not allowed:
+        return allowed, reason
+
+    if live_enabled:
+        remaining_day_budget, current_day_loss, max_day_loss = _daily_risk_budget_state(
+            self
+        )
+        prospective_stop_risk = _signal_stop_risk(signal)
+        if (
+            remaining_day_budget is not None
+            and prospective_stop_risk is not None
+            and prospective_stop_risk > remaining_day_budget
+        ):
+            reason = (
+                "remaining daily loss budget insufficient: "
+                f"{prospective_stop_risk:.2f}/{remaining_day_budget:.2f}"
+            )
+            self._last_rejection = "DAILY_RISK_BUDGET"
+            logger = getattr(self, "_logger", None)
+            log = getattr(logger, "warning", None)
+            if callable(log):
+                log(
+                    "RISK_FINAL_GATE_BLOCK reason=%s symbol=%s",
+                    reason,
+                    getattr(signal, "symbol", None),
+                    extra={
+                        "event": "RISK_FINAL_GATE_BLOCK",
+                        "reason": reason,
+                        "code": "DAILY_RISK_BUDGET",
+                        "symbol": getattr(signal, "symbol", None),
+                        "final_order_gate": True,
+                        "prospective_stop_risk": prospective_stop_risk,
+                        "remaining_day_budget": remaining_day_budget,
+                        "current_day_loss": current_day_loss,
+                        "max_day_loss": max_day_loss,
+                    },
+                )
+            return False, reason
+    return allowed, reason
 
 
 def apply_patches() -> None:

--- a/tests/risk/test_risk_rejection_codes.py
+++ b/tests/risk/test_risk_rejection_codes.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 
 from nifty_scalper_bot.config.settings import RiskSettings
-from nifty_scalper_bot.risk.risk_manager import RiskManager
+from nifty_scalper_bot.risk.risk_manager import OrderSignal, RiskManager
 
 
 class DummyPositionManager:
@@ -151,6 +151,35 @@ def test_suggest_position_size_allows_lot_within_remaining_daily_loss_budget(
 
     # Remaining daily budget is ₹250; one lot risks ₹200 and remains admissible.
     assert quantity == 25
+
+
+def test_final_order_gate_blocks_stop_risk_above_remaining_daily_budget() -> None:
+    settings = RiskSettings(
+        per_trade_risk_pct=1.0,
+        daily_loss_pct=2.0,
+        cooldown_on_reject_seconds=0.0,
+    )
+    risk = RiskManager(
+        settings=settings,
+        position_manager=DummyPositionManager(realized=0.0),
+        account_balance=50_000.0,
+    )
+    risk._switches.record_pnl(-750.0)
+    signal = OrderSignal(
+        symbol="NFO:NIFTY2681824400CE",
+        side="BUY",
+        quantity=25,
+        price=100.0,
+        stop_loss=88.0,
+        take_profit=130.0,
+    )
+
+    allowed, reason = risk.check_order(signal, live_enabled=True)
+
+    assert allowed is False
+    assert reason == "remaining daily loss budget insufficient: 300.00/250.00"
+    assert risk._last_rejection == "DAILY_RISK_BUDGET"
+    assert risk._breaker_tripped is False
 
 
 def test_suggest_position_size_zero_or_invalid_confidence_fails_closed() -> None:

--- a/tests/risk/test_risk_rejection_codes.py
+++ b/tests/risk/test_risk_rejection_codes.py
@@ -92,6 +92,67 @@ def test_suggest_position_size_never_uses_minimum_risk_floor_to_breach_percent_c
     assert quantity == 0
 
 
+def test_suggest_position_size_respects_remaining_daily_loss_budget(monkeypatch) -> None:
+    settings = RiskSettings(
+        per_trade_risk_pct=1.0,
+        daily_loss_pct=2.0,
+        cooldown_on_reject_seconds=0.0,
+    )
+    risk = RiskManager(
+        settings=settings,
+        position_manager=DummyPositionManager(realized=0.0),
+        account_balance=50_000.0,
+    )
+    risk.set_lot_size_provider(lambda _symbol: 25)
+    monkeypatch.setenv("MIN_RISK_PER_TRADE", "500")
+    risk._switches.record_pnl(-750.0)
+
+    quantity = risk.suggest_position_size(
+        side="BUY",
+        price=100.0,
+        stop_loss=88.0,
+        atr=None,
+        requested_quantity=25,
+        confidence=1.0,
+        symbol="NFO:NIFTY2681824400CE",
+    )
+
+    # Daily cap is ₹1,000 and ₹750 is already consumed, leaving ₹250.
+    # One lot risks 25 * ₹12 = ₹300, so sizing must fail closed before entry.
+    assert quantity == 0
+
+
+def test_suggest_position_size_allows_lot_within_remaining_daily_loss_budget(
+    monkeypatch,
+) -> None:
+    settings = RiskSettings(
+        per_trade_risk_pct=1.0,
+        daily_loss_pct=2.0,
+        cooldown_on_reject_seconds=0.0,
+    )
+    risk = RiskManager(
+        settings=settings,
+        position_manager=DummyPositionManager(realized=0.0),
+        account_balance=50_000.0,
+    )
+    risk.set_lot_size_provider(lambda _symbol: 25)
+    monkeypatch.setenv("MIN_RISK_PER_TRADE", "500")
+    risk._switches.record_pnl(-750.0)
+
+    quantity = risk.suggest_position_size(
+        side="BUY",
+        price=100.0,
+        stop_loss=92.0,
+        atr=None,
+        requested_quantity=25,
+        confidence=1.0,
+        symbol="NFO:NIFTY2681824400CE",
+    )
+
+    # Remaining daily budget is ₹250; one lot risks ₹200 and remains admissible.
+    assert quantity == 25
+
+
 def test_suggest_position_size_zero_or_invalid_confidence_fails_closed() -> None:
     risk = _make_risk_manager()
     risk.set_lot_size_provider(lambda _symbol: 25)

--- a/tests/risk/test_risk_rejection_codes.py
+++ b/tests/risk/test_risk_rejection_codes.py
@@ -153,7 +153,9 @@ def test_suggest_position_size_allows_lot_within_remaining_daily_loss_budget(
     assert quantity == 25
 
 
-def test_final_order_gate_blocks_stop_risk_above_remaining_daily_budget() -> None:
+def test_final_order_gate_blocks_stop_risk_above_remaining_daily_budget(
+    monkeypatch,
+) -> None:
     settings = RiskSettings(
         per_trade_risk_pct=1.0,
         daily_loss_pct=2.0,
@@ -165,6 +167,7 @@ def test_final_order_gate_blocks_stop_risk_above_remaining_daily_budget() -> Non
         account_balance=50_000.0,
     )
     risk._switches.record_pnl(-750.0)
+    monkeypatch.setenv("PAPER_MODE", "true")
     signal = OrderSignal(
         symbol="NFO:NIFTY2681824400CE",
         side="BUY",


### PR DESCRIPTION
## Root cause
The final sizing patch enforced the configured per-trade percentage budget, while the daily-loss breaker checked only losses already consumed. A new entry could therefore fit the per-trade budget but exceed the remaining daily-loss allowance.

## Invariant
For a new entry, deterministic stop-risk must fit both the configured per-trade budget and the remaining daily-loss budget. The final `check_order()` choke point repeats the remaining-budget check after canonical P&L refresh so alternate/bypass entry paths cannot evade it. Protective/reducing behavior and configured risk percentages are unchanged.

## TDD evidence
RED head `e8a1a07e12f581b8bc65d228c35f3b9ed68aaa70` contained tests only. The full repository test job failed while changed-code-quality and execution-safety subsets passed, confirming the new regression was not already satisfied by main.

Regression cases:
- ₹50,000 capital, 2% daily cap = ₹1,000; ₹750 already consumed; ₹300 one-lot stop-risk must be rejected because only ₹250 remains.
- Same state with ₹200 one-lot stop-risk remains allowed.
- Direct `check_order()` path with ₹300 prospective stop-risk is rejected without tripping the breaker merely for the rejected candidate.

## Scope
Only the existing risk entry-guard patch and focused risk tests are changed. No risk threshold, margin rule, order-exit path, contract logic, or strategy logic is modified.