### PR TITLE
fix: preserve live bracket risk geometry after entry fills

### DIFF
--- a/src/nifty_scalper_bot/execution/bracket_manager.py
+++ b/src/nifty_scalper_bot/execution/bracket_manager.py
@@ -125,7 +125,7 @@ def _reconcile_confirmed_entry_quantity(self, order_id, bracket, filled_qty):
 
 
 def _reanchor_confirmed_fill_geometry(bracket, fill_price):
-    """Preserve the bracket's configured anchor policy at the broker fill price."""
+    """Preserve an explicit bracket anchor policy at the broker fill price."""
     if bracket is None:
         return
     try:
@@ -137,9 +137,18 @@ def _reanchor_confirmed_fill_geometry(bracket, fill_price):
         return
 
     provenance = getattr(bracket, "trade_provenance", {}) or {}
-    anchor_mode = str(provenance.get("bracket_anchor_mode", "distance") or "distance").strip().lower()
+    raw_anchor_mode = provenance.get("bracket_anchor_mode")
+    if raw_anchor_mode is None:
+        # Direct/legacy registrations never declared an anchor contract. Keep
+        # their historical percentage-rescale behavior; the production
+        # TradePlan path always persists an explicit mode before registration.
+        return
+    anchor_mode = str(raw_anchor_mode).strip().lower()
+    if anchor_mode not in {"distance", "absolute_level"}:
+        return
+
     delta = price - old_entry
-    if anchor_mode != "absolute_level":
+    if anchor_mode == "distance":
         if float(bracket.sl_trigger_price or 0.0) > 0.0:
             bracket.sl_trigger_price = _core._round_to_tick(
                 float(bracket.sl_trigger_price) + delta
@@ -153,7 +162,7 @@ def _reanchor_confirmed_fill_geometry(bracket, fill_price):
                 level.price = _core._round_to_tick(float(level.price) + delta)
 
     # Pre-setting entry makes the legacy core fill handler see no entry delta, so
-    # it cannot percentage-rescale the levels a second time.
+    # it cannot percentage-rescale explicitly anchored levels a second time.
     bracket.entry_price = price
     bracket.initial_sl_trigger_price = float(bracket.sl_trigger_price or 0.0)
     _core.LOGGER.info(

--- a/src/nifty_scalper_bot/execution/bracket_manager.py
+++ b/src/nifty_scalper_bot/execution/bracket_manager.py
@@ -124,6 +124,58 @@ def _reconcile_confirmed_entry_quantity(self, order_id, bracket, filled_qty):
     return True
 
 
+def _reanchor_confirmed_fill_geometry(bracket, fill_price):
+    """Preserve the bracket's configured anchor policy at the broker fill price."""
+    if bracket is None:
+        return
+    try:
+        price = float(fill_price)
+        old_entry = float(bracket.entry_price or 0.0)
+    except (TypeError, ValueError):
+        return
+    if price <= 0.0 or old_entry <= 0.0 or abs(price - old_entry) < 1e-12:
+        return
+
+    provenance = getattr(bracket, "trade_provenance", {}) or {}
+    anchor_mode = str(provenance.get("bracket_anchor_mode", "distance") or "distance").strip().lower()
+    delta = price - old_entry
+    if anchor_mode != "absolute_level":
+        if float(bracket.sl_trigger_price or 0.0) > 0.0:
+            bracket.sl_trigger_price = _core._round_to_tick(
+                float(bracket.sl_trigger_price) + delta
+            )
+        if float(bracket.tp_trigger_price or 0.0) > 0.0:
+            bracket.tp_trigger_price = _core._round_to_tick(
+                float(bracket.tp_trigger_price) + delta
+            )
+        for level in getattr(bracket, "tp_levels", ()):
+            if not getattr(level, "executed", False):
+                level.price = _core._round_to_tick(float(level.price) + delta)
+
+    # Pre-setting entry makes the legacy core fill handler see no entry delta, so
+    # it cannot percentage-rescale the levels a second time.
+    bracket.entry_price = price
+    bracket.initial_sl_trigger_price = float(bracket.sl_trigger_price or 0.0)
+    _core.LOGGER.info(
+        "BRACKET_FILL_REANCHORED order_id=%s symbol=%s mode=%s old_entry=%.2f fill=%.2f sl=%.2f tp=%.2f",
+        bracket.entry_order_id,
+        bracket.symbol,
+        anchor_mode,
+        old_entry,
+        price,
+        float(bracket.sl_trigger_price or 0.0),
+        float(bracket.tp_trigger_price or 0.0),
+        extra={
+            "event": "BRACKET_FILL_REANCHORED",
+            "order_id": str(bracket.entry_order_id),
+            "symbol": bracket.symbol,
+            "anchor_mode": anchor_mode,
+            "old_entry": old_entry,
+            "fill_price": price,
+        },
+    )
+
+
 def _confirm_entry_fill_once(self, order_id, fill_price, filled_qty=None):
     """Keep repeated COMPLETE callbacks idempotent while accepting smaller fills."""
     bracket = self.get_bracket(order_id)
@@ -163,6 +215,7 @@ def _confirm_entry_fill_once(self, order_id, fill_price, filled_qty=None):
             },
         )
         return True
+    _reanchor_confirmed_fill_geometry(bracket, fill_price)
     return _original_confirm_entry_fill(self, order_id, fill_price, filled_qty)
 
 

--- a/src/nifty_scalper_bot/execution/order_manager.py
+++ b/src/nifty_scalper_bot/execution/order_manager.py
@@ -18,10 +18,31 @@ for _name in dir(_core):
     if not _name.startswith("__"):
         globals()[_name] = getattr(_core, _name)
 
-from nifty_scalper_bot.execution.runtime_order_manager import (  # noqa: E402
-    RuntimeOrderManager,
-)
+from nifty_scalper_bot.execution import runtime_order_manager as _runtime  # noqa: E402
 
+
+_original_enrich_trade_plan_exit_provenance = _runtime._enrich_trade_plan_exit_provenance
+
+
+def _enrich_trade_plan_exit_provenance(plan):
+    """Carry the TradePlan bracket anchor contract into durable provenance."""
+    plan = _original_enrich_trade_plan_exit_provenance(plan)
+    try:
+        provenance = dict(getattr(plan, "trade_provenance", {}) or {})
+    except (TypeError, ValueError):
+        provenance = {}
+    provenance.setdefault(
+        "bracket_anchor_mode",
+        str(getattr(plan, "bracket_anchor_mode", "distance") or "distance"),
+    )
+    setattr(plan, "trade_provenance", provenance)
+    return plan
+
+
+# RuntimeOrderManager methods resolve this module-global helper at call time.
+# Patch that one helper rather than introducing a second submission path.
+_runtime._enrich_trade_plan_exit_provenance = _enrich_trade_plan_exit_provenance
+RuntimeOrderManager = _runtime.RuntimeOrderManager
 OrderManager = RuntimeOrderManager
 
 __all__ = sorted(

--- a/tests/execution/test_bracket_closed_pnl.py
+++ b/tests/execution/test_bracket_closed_pnl.py
@@ -1,8 +1,10 @@
-"""BRACKET_CLOSED must carry realized P&L so terminals can show daily P&L."""
+"""BRACKET_CLOSED must carry truthful realized P&L for terminal reporting."""
 from __future__ import annotations
 
 import logging
+from types import SimpleNamespace
 from typing import Any
+from unittest.mock import Mock
 
 from nifty_scalper_bot.execution.bracket_manager import BracketManager
 
@@ -10,8 +12,13 @@ from nifty_scalper_bot.execution.bracket_manager import BracketManager
 class _OM:
     def __init__(self) -> None:
         self._broker = None
+
+    def is_live_mode(self) -> bool:
+        return False
+
     def place_order(self, **k: Any) -> str:
         return "x"
+
     def cancel_order(self, _o: str) -> bool:
         return True
 
@@ -19,8 +26,13 @@ class _OM:
 def _mgr_with_bracket():
     mgr = BracketManager(order_manager=_OM())
     mgr.register_virtual_bracket(
-        order_id="e1", symbol="NFO:NIFTY2660923100CE", side="BUY",
-        qty=65, price=137.25, sl=130.0, tp=150.0,
+        order_id="e1",
+        symbol="NFO:NIFTY2660923100CE",
+        side="BUY",
+        qty=65,
+        price=137.25,
+        sl=130.0,
+        tp=150.0,
     )
     return mgr, next(iter(mgr._brackets.values()))
 
@@ -30,7 +42,10 @@ async def test_bracket_closed_logs_realized_pnl(caplog) -> None:
     b.entry_fill_price = 137.25
     with caplog.at_level(logging.INFO):
         mgr._close_bracket(b, close_source="broker_fill", exit_price=140.0)
-    line = next((r.getMessage() for r in caplog.records if "BRACKET_CLOSED" in r.getMessage()), "")
+    line = next(
+        (r.getMessage() for r in caplog.records if "BRACKET_CLOSED" in r.getMessage()),
+        "",
+    )
     # (140.0 - 137.25) * 65 = 178.75
     assert "pnl=178.75" in line
     assert "entry=137.25" in line and "exit=140.0" in line
@@ -41,6 +56,26 @@ async def test_bracket_closed_pnl_negative_on_loss(caplog) -> None:
     b.entry_fill_price = 137.25
     with caplog.at_level(logging.INFO):
         mgr._close_bracket(b, close_source="reconciled_flat", exit_price=133.55)
-    line = next((r.getMessage() for r in caplog.records if "BRACKET_CLOSED" in r.getMessage()), "")
+    line = next(
+        (r.getMessage() for r in caplog.records if "BRACKET_CLOSED" in r.getMessage()),
+        "",
+    )
     # (133.55 - 137.25) * 65 = -240.5
     assert "pnl=-240.5" in line
+
+
+async def test_incomplete_ledger_never_fabricates_full_quantity_pnl(caplog) -> None:
+    mgr, b = _mgr_with_bracket()
+    b.entry_fill_price = 137.25
+    ledger = Mock()
+    ledger.realized_pnl.return_value = SimpleNamespace(complete=False)
+    mgr._fill_ledger = ledger
+
+    with caplog.at_level(logging.INFO):
+        mgr._close_bracket(b, close_source="reconciled_flat", exit_price=133.55)
+
+    line = next(
+        (r.getMessage() for r in caplog.records if "BRACKET_CLOSED" in r.getMessage()),
+        "",
+    )
+    assert "pnl=None" in line

--- a/tests/execution/test_bracket_closed_pnl.py
+++ b/tests/execution/test_bracket_closed_pnl.py
@@ -1,10 +1,8 @@
-"""BRACKET_CLOSED must carry truthful realized P&L for terminal reporting."""
+"""BRACKET_CLOSED must carry realized P&L so terminals can show daily P&L."""
 from __future__ import annotations
 
 import logging
-from types import SimpleNamespace
 from typing import Any
-from unittest.mock import Mock
 
 from nifty_scalper_bot.execution.bracket_manager import BracketManager
 
@@ -12,13 +10,8 @@ from nifty_scalper_bot.execution.bracket_manager import BracketManager
 class _OM:
     def __init__(self) -> None:
         self._broker = None
-
-    def is_live_mode(self) -> bool:
-        return False
-
     def place_order(self, **k: Any) -> str:
         return "x"
-
     def cancel_order(self, _o: str) -> bool:
         return True
 
@@ -26,13 +19,8 @@ class _OM:
 def _mgr_with_bracket():
     mgr = BracketManager(order_manager=_OM())
     mgr.register_virtual_bracket(
-        order_id="e1",
-        symbol="NFO:NIFTY2660923100CE",
-        side="BUY",
-        qty=65,
-        price=137.25,
-        sl=130.0,
-        tp=150.0,
+        order_id="e1", symbol="NFO:NIFTY2660923100CE", side="BUY",
+        qty=65, price=137.25, sl=130.0, tp=150.0,
     )
     return mgr, next(iter(mgr._brackets.values()))
 
@@ -42,10 +30,7 @@ async def test_bracket_closed_logs_realized_pnl(caplog) -> None:
     b.entry_fill_price = 137.25
     with caplog.at_level(logging.INFO):
         mgr._close_bracket(b, close_source="broker_fill", exit_price=140.0)
-    line = next(
-        (r.getMessage() for r in caplog.records if "BRACKET_CLOSED" in r.getMessage()),
-        "",
-    )
+    line = next((r.getMessage() for r in caplog.records if "BRACKET_CLOSED" in r.getMessage()), "")
     # (140.0 - 137.25) * 65 = 178.75
     assert "pnl=178.75" in line
     assert "entry=137.25" in line and "exit=140.0" in line
@@ -56,26 +41,6 @@ async def test_bracket_closed_pnl_negative_on_loss(caplog) -> None:
     b.entry_fill_price = 137.25
     with caplog.at_level(logging.INFO):
         mgr._close_bracket(b, close_source="reconciled_flat", exit_price=133.55)
-    line = next(
-        (r.getMessage() for r in caplog.records if "BRACKET_CLOSED" in r.getMessage()),
-        "",
-    )
+    line = next((r.getMessage() for r in caplog.records if "BRACKET_CLOSED" in r.getMessage()), "")
     # (133.55 - 137.25) * 65 = -240.5
     assert "pnl=-240.5" in line
-
-
-async def test_incomplete_ledger_never_fabricates_full_quantity_pnl(caplog) -> None:
-    mgr, b = _mgr_with_bracket()
-    b.entry_fill_price = 137.25
-    ledger = Mock()
-    ledger.realized_pnl.return_value = SimpleNamespace(complete=False)
-    mgr._fill_ledger = ledger
-
-    with caplog.at_level(logging.INFO):
-        mgr._close_bracket(b, close_source="reconciled_flat", exit_price=133.55)
-
-    line = next(
-        (r.getMessage() for r in caplog.records if "BRACKET_CLOSED" in r.getMessage()),
-        "",
-    )
-    assert "pnl=None" in line

--- a/tests/execution/test_entry_fill_geometry.py
+++ b/tests/execution/test_entry_fill_geometry.py
@@ -1,0 +1,103 @@
+"""Regression tests for post-fill virtual-bracket risk geometry."""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from nifty_scalper_bot.execution.bracket_manager import BracketManager
+from nifty_scalper_bot.execution.runtime_order_manager import (
+    _enrich_trade_plan_exit_provenance,
+)
+
+
+def _manager() -> BracketManager:
+    order_manager = Mock()
+    order_manager.is_live_mode.return_value = False
+    return BracketManager(order_manager=order_manager)
+
+
+def test_buy_fill_preserves_absolute_stop_and_target_distances() -> None:
+    manager = _manager()
+    manager.register_virtual_bracket(
+        order_id="buy-fill",
+        symbol="NFO:NIFTYTESTCE",
+        side="BUY",
+        qty=65,
+        price=100.0,
+        sl=90.0,
+        tp=120.0,
+        trade_provenance={"bracket_anchor_mode": "distance_from_entry"},
+    )
+
+    manager.confirm_entry_fill("buy-fill", 110.0)
+
+    bracket = manager.get_bracket("buy-fill")
+    assert bracket is not None
+    assert bracket.entry_price == 110.0
+    assert bracket.sl_trigger_price == 100.0
+    assert bracket.initial_sl_trigger_price == 100.0
+    assert bracket.tp_trigger_price == 130.0
+
+
+def test_sell_fill_preserves_absolute_stop_and_target_distances() -> None:
+    manager = _manager()
+    manager.register_virtual_bracket(
+        order_id="sell-fill",
+        symbol="NFO:NIFTYTESTPE",
+        side="SELL",
+        qty=65,
+        price=100.0,
+        sl=110.0,
+        tp=80.0,
+        trade_provenance={"bracket_anchor_mode": "distance_from_entry"},
+    )
+
+    manager.confirm_entry_fill("sell-fill", 90.0)
+
+    bracket = manager.get_bracket("sell-fill")
+    assert bracket is not None
+    assert bracket.entry_price == 90.0
+    assert bracket.sl_trigger_price == 100.0
+    assert bracket.initial_sl_trigger_price == 100.0
+    assert bracket.tp_trigger_price == 70.0
+
+
+def test_absolute_level_bracket_does_not_move_levels_on_fill() -> None:
+    manager = _manager()
+    manager.register_virtual_bracket(
+        order_id="absolute-fill",
+        symbol="NFO:NIFTYABSCE",
+        side="BUY",
+        qty=65,
+        price=100.0,
+        sl=90.0,
+        tp=120.0,
+        trade_provenance={"bracket_anchor_mode": "absolute_level"},
+    )
+
+    manager.confirm_entry_fill("absolute-fill", 110.0)
+
+    bracket = manager.get_bracket("absolute-fill")
+    assert bracket is not None
+    assert bracket.entry_price == 110.0
+    assert bracket.sl_trigger_price == 90.0
+    assert bracket.initial_sl_trigger_price == 90.0
+    assert bracket.tp_trigger_price == 120.0
+
+
+def test_runtime_provenance_carries_bracket_anchor_mode() -> None:
+    plan = SimpleNamespace(
+        intent="ENTRY",
+        trade_provenance={},
+        quantity=65,
+        resolved_lot_size=65,
+        entry_price=100.0,
+        stop_loss=90.0,
+        take_profit=120.0,
+        side="BUY",
+        bracket_anchor_mode="absolute_level",
+    )
+
+    _enrich_trade_plan_exit_provenance(plan)
+
+    assert plan.trade_provenance["bracket_anchor_mode"] == "absolute_level"

--- a/tests/execution/test_entry_fill_geometry.py
+++ b/tests/execution/test_entry_fill_geometry.py
@@ -5,7 +5,7 @@ from types import SimpleNamespace
 from unittest.mock import Mock
 
 from nifty_scalper_bot.execution.bracket_manager import BracketManager
-from nifty_scalper_bot.execution.runtime_order_manager import (
+from nifty_scalper_bot.execution.order_manager import (
     _enrich_trade_plan_exit_provenance,
 )
 
@@ -26,7 +26,7 @@ def test_buy_fill_preserves_absolute_stop_and_target_distances() -> None:
         price=100.0,
         sl=90.0,
         tp=120.0,
-        trade_provenance={"bracket_anchor_mode": "distance_from_entry"},
+        trade_provenance={"bracket_anchor_mode": "distance"},
     )
 
     manager.confirm_entry_fill("buy-fill", 110.0)
@@ -49,7 +49,7 @@ def test_sell_fill_preserves_absolute_stop_and_target_distances() -> None:
         price=100.0,
         sl=110.0,
         tp=80.0,
-        trade_provenance={"bracket_anchor_mode": "distance_from_entry"},
+        trade_provenance={"bracket_anchor_mode": "distance"},
     )
 
     manager.confirm_entry_fill("sell-fill", 90.0)
@@ -60,6 +60,29 @@ def test_sell_fill_preserves_absolute_stop_and_target_distances() -> None:
     assert bracket.sl_trigger_price == 100.0
     assert bracket.initial_sl_trigger_price == 100.0
     assert bracket.tp_trigger_price == 70.0
+
+
+def test_distance_fill_reanchors_unexecuted_tp1() -> None:
+    manager = _manager()
+    manager.register_virtual_bracket(
+        order_id="tp1-fill",
+        symbol="NFO:NIFTYTP1CE",
+        side="BUY",
+        qty=130,
+        price=100.0,
+        sl=90.0,
+        tp=120.0,
+        tp1_price=110.0,
+        tp1_qty=65,
+        resolved_lot_size=65,
+        trade_provenance={"bracket_anchor_mode": "distance"},
+    )
+
+    manager.confirm_entry_fill("tp1-fill", 105.0)
+
+    bracket = manager.get_bracket("tp1-fill")
+    assert bracket is not None
+    assert [(level.price, level.quantity) for level in bracket.tp_levels] == [(115.0, 65)]
 
 
 def test_absolute_level_bracket_does_not_move_levels_on_fill() -> None:


### PR DESCRIPTION
Production hotfix for the confirmed LIVE virtual-bracket money-path defect.

TDD evidence:
- regression tests were committed first;
- the initial full-suite run failed exactly because planned 100/90/120 filled at 110 became SL=99, TP=132 under percentage scaling;
- production fix then preserves point-distance geometry and the existing absolute-level contract.

Changes:
- persist `TradePlan.bracket_anchor_mode` into durable bracket provenance;
- for `distance` brackets, translate SL/final TP/unexecuted TP1 by the actual entry-fill delta rather than percentage-rescaling them;
- for `absolute_level` brackets, keep market levels unchanged;
- preserve `initial_sl_trigger_price` from the corrected live SL;
- retain existing duplicate-fill, quantity-reconciliation, ledger, trailing, and exit state-machine behavior.

Deliberately not changed: already-hardened virtual SL ratchet; dormant Adaptive trailing architecture; non-strict PAPER/degraded PnL fallback; strategy signal logic.