### PR TITLE
fix: preserve minimum net RR for live option entries

### DIFF
--- a/.github/workflows/live-exit-safety-ci.yml
+++ b/.github/workflows/live-exit-safety-ci.yml
@@ -84,6 +84,7 @@ jobs:
             tests/execution/test_explicit_exit_intent_safety.py \
             tests/execution/test_executable_tp_semantics.py \
             tests/execution/test_executable_trailing_watermark.py \
+            tests/execution/test_cost_aware_live_entry_target.py \
             tests/execution/test_live_exit_hardening.py \
             tests/execution/test_virtual_bracket_safety.py \
             tests/execution/test_ledger_bracket_runtime.py \

--- a/src/nifty_scalper_bot/execution/runtime_order_manager.py
+++ b/src/nifty_scalper_bot/execution/runtime_order_manager.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import os
 from contextlib import suppress
+from types import SimpleNamespace
 from typing import Any, Callable, Mapping
 
 from nifty_scalper_bot.execution import order_manager_core as _core
@@ -30,6 +31,7 @@ from nifty_scalper_bot.execution.native_entry_gate import (
     block_result,
     configure_provider,
 )
+from nifty_scalper_bot.risk.net_rr_gate import minimum_target_for_net_rr
 from nifty_scalper_bot.strategies.signal_identity_patch import order_setup_context
 
 _EXIT_IDENTITY_KWARGS = {"linked_entry_order_id", "trade_lifecycle_id", "bracket_id"}
@@ -64,6 +66,109 @@ def _positive_int(value: Any) -> int:
         if parsed > 0:
             return parsed
     return 0
+
+
+def _cost_adjust_entry_target(manager: Any, kwargs: dict[str, Any]) -> dict[str, Any]:
+    """Raise only a distance-anchored BUY option target enough to preserve net RR.
+
+    The stop, entry, quantity and final risk gate are never changed. Explicit
+    technical/absolute targets are immutable. If transaction costs require more
+    than the bounded uplift allowed by ``minimum_target_for_net_rr``, this helper
+    returns the order unchanged so the final risk gate still rejects it.
+    """
+    if not bool(kwargs.get("check_risk", True)):
+        return kwargs
+    if str(kwargs.get("intent") or "ENTRY").strip().upper() != "ENTRY":
+        return kwargs
+    if str(kwargs.get("side") or "").strip().upper() != "BUY":
+        return kwargs
+    symbol = str(kwargs.get("symbol") or "").strip().upper()
+    if not symbol.endswith(("CE", "PE")):
+        return kwargs
+
+    provenance_raw = kwargs.get("trade_provenance")
+    if not isinstance(provenance_raw, Mapping):
+        return kwargs
+    provenance = dict(provenance_raw)
+    if str(provenance.get("bracket_anchor_mode") or "").strip().lower() != "distance":
+        return kwargs
+    if bool(provenance.get("net_rr_target_adjusted")):
+        return kwargs
+
+    entry = _positive_float(kwargs.get("price"))
+    stop = _positive_float(kwargs.get("stop_loss"))
+    target = _positive_float(kwargs.get("take_profit"))
+    quantity = _positive_int(kwargs.get("quantity"))
+    if entry is None or stop is None or target is None or quantity <= 0:
+        return kwargs
+    if not (stop < entry < target):
+        return kwargs
+
+    metadata: dict[str, Any] = {}
+    quote_getter = getattr(manager, "_get_latest_quote_safe", None)
+    diagnostics = getattr(manager, "_extract_quote_diagnostics", None)
+    if callable(quote_getter):
+        with suppress(Exception):
+            quote = quote_getter(symbol) or {}
+            quote_info = diagnostics(quote) if callable(diagnostics) else quote
+            if isinstance(quote_info, Mapping):
+                bid = _positive_float(quote_info.get("bid"))
+                ask = _positive_float(quote_info.get("ask"))
+                if bid is not None:
+                    metadata["bid"] = bid
+                if ask is not None:
+                    metadata["ask"] = ask
+
+    signal = SimpleNamespace(
+        symbol=symbol,
+        action="BUY",
+        quantity=quantity,
+        entry_price=entry,
+        stop_loss=stop,
+        take_profit=target,
+        metadata=metadata,
+    )
+    adjusted_target = minimum_target_for_net_rr(signal)
+    if adjusted_target is None or adjusted_target <= target + 1e-9:
+        return kwargs
+
+    risk_points = entry - stop
+    old_rr = (target - entry) / risk_points
+    new_rr = (adjusted_target - entry) / risk_points
+    adjusted_provenance = dict(provenance)
+    adjusted_provenance["net_rr_target_adjusted"] = True
+    adjusted_provenance.setdefault("original_take_profit", float(target))
+    adjusted_provenance["cost_adjusted_take_profit"] = float(adjusted_target)
+    adjusted_provenance["net_rr_target_adjustment_r"] = float(new_rr - old_rr)
+
+    adjusted = dict(kwargs)
+    adjusted["take_profit"] = float(adjusted_target)
+    adjusted["trade_provenance"] = adjusted_provenance
+
+    logger = getattr(manager, "_logger", None)
+    log = getattr(logger, "info", None)
+    if callable(log):
+        log(
+            "NET_RR_TARGET_ADJUSTED symbol=%s entry=%.2f stop=%.2f old_tp=%.2f new_tp=%.2f old_gross_rr=%.3f new_gross_rr=%.3f",
+            symbol,
+            entry,
+            stop,
+            target,
+            adjusted_target,
+            old_rr,
+            new_rr,
+            extra={
+                "event": "NET_RR_TARGET_ADJUSTED",
+                "symbol": symbol,
+                "entry": entry,
+                "stop_loss": stop,
+                "original_take_profit": target,
+                "adjusted_take_profit": adjusted_target,
+                "old_gross_rr": old_rr,
+                "new_gross_rr": new_rr,
+            },
+        )
+    return adjusted
 
 
 def _enrich_trade_plan_exit_provenance(plan: Any) -> Any:
@@ -267,6 +372,7 @@ class RuntimeOrderManager(_core.OrderManager):
         blocked = self._blocked("place_order", args, effective_kwargs)
         if blocked is not NO_BLOCK:
             return blocked
+        effective_kwargs = _cost_adjust_entry_target(self, effective_kwargs)
         cleaned_kwargs, identity = _strip_exit_identity_kwargs(effective_kwargs)
         if identity:
             self._last_exit_identity_kwargs = dict(identity)
@@ -346,6 +452,7 @@ class RuntimeOrderManager(_core.OrderManager):
 
 __all__ = [
     "RuntimeOrderManager",
+    "_cost_adjust_entry_target",
     "_enrich_trade_plan_exit_provenance",
     "_strip_exit_identity_kwargs",
     "_submit_core_with_exit_provenance",

--- a/src/nifty_scalper_bot/risk/net_rr_gate.py
+++ b/src/nifty_scalper_bot/risk/net_rr_gate.py
@@ -94,6 +94,18 @@ def _minimum_net_rr() -> float:
     return max(0.0, parsed)
 
 
+def _max_target_uplift_r() -> float:
+    """Return the maximum extra gross-R permitted to repair transaction costs."""
+    raw = os.getenv("MAX_NET_RR_TARGET_UPLIFT_R", "0.35")
+    try:
+        parsed = float(raw or 0.35)
+    except (TypeError, ValueError):
+        return 0.35
+    if not math.isfinite(parsed):
+        return 0.35
+    return max(0.0, parsed)
+
+
 def evaluate_final_net_rr(signal: Any) -> NetRRResult | None:
     """Return final BUY-option net RR, or None when the gate is not applicable."""
     symbol = str(getattr(signal, "symbol", "") or "").strip().upper()
@@ -155,4 +167,86 @@ def evaluate_final_net_rr(signal: Any) -> NetRRResult | None:
     )
 
 
-__all__ = ["NetRRResult", "evaluate_final_net_rr"]
+def minimum_target_for_net_rr(signal: Any, *, tick_size: float = 0.05) -> float | None:
+    """Return the smallest bounded BUY-option target satisfying final net RR.
+
+    The final gate remains authoritative. This helper only compensates a modest
+    transaction-cost erosion of an already valid distance-based strategy target.
+    If the configured net RR cannot be reached within ``MAX_NET_RR_TARGET_UPLIFT_R``
+    additional gross R, ``None`` is returned and the caller must fail closed.
+    """
+    current = evaluate_final_net_rr(signal)
+    if current is None:
+        return None
+    target = _price(signal, "take_profit", "target", "target_price")
+    entry = _price(
+        signal,
+        "entry_price",
+        "price",
+        "limit_price",
+        "reference_price",
+        "premium_risk_reference_price",
+        "current_price",
+    )
+    stop = _price(signal, "stop_loss", "sl", "stop_price")
+    quantity = _quantity(signal)
+    if target is None or entry is None or stop is None or quantity <= 0:
+        return None
+    if current.allowed:
+        return float(target)
+
+    risk_points = entry - stop
+    if risk_points <= 0.0 or target <= entry:
+        return None
+    current_gross_rr = (target - entry) / risk_points
+    cap_rr = current_gross_rr + _max_target_uplift_r()
+    cap_target = entry + risk_points * cap_rr
+    tick = float(tick_size) if math.isfinite(float(tick_size)) and tick_size > 0 else 0.05
+    max_tick_target = math.floor((cap_target + 1e-12) / tick) * tick
+    if max_tick_target <= target:
+        return None
+
+    half_spread = _half_spread(signal, entry)
+    stop_cost = estimate_round_trip_cost(
+        entry_price=entry,
+        exit_price=stop,
+        quantity=quantity,
+        half_spread=half_spread,
+    ).total
+    net_risk = (entry - stop) * quantity + stop_cost
+    minimum = _minimum_net_rr()
+    if net_risk <= 0.0:
+        return None
+
+    def _net_rr_at(candidate: float) -> float:
+        target_cost = estimate_round_trip_cost(
+            entry_price=entry,
+            exit_price=candidate,
+            quantity=quantity,
+            half_spread=half_spread,
+        ).total
+        net_reward = (candidate - entry) * quantity - target_cost
+        return net_reward / net_risk if net_reward > 0.0 else 0.0
+
+    if _net_rr_at(max_tick_target) + 1e-12 < minimum:
+        return None
+
+    low = float(target)
+    high = float(max_tick_target)
+    for _ in range(60):
+        midpoint = (low + high) / 2.0
+        if _net_rr_at(midpoint) >= minimum:
+            high = midpoint
+        else:
+            low = midpoint
+
+    candidate = math.ceil((high - 1e-12) / tick) * tick
+    candidate = round(candidate, 2)
+    if candidate > max_tick_target + 1e-9:
+        return None
+    if _net_rr_at(candidate) + 1e-12 < minimum:
+        return None
+    return candidate
+
+
+__all__ = ["NetRRResult", "evaluate_final_net_rr", "minimum_target_for_net_rr"]

--- a/tests/execution/test_cost_aware_live_entry_target.py
+++ b/tests/execution/test_cost_aware_live_entry_target.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from nifty_scalper_bot.execution.runtime_order_manager import _cost_adjust_entry_target
+from nifty_scalper_bot.risk.net_rr_gate import (
+    evaluate_final_net_rr,
+    minimum_target_for_net_rr,
+)
+
+
+SYMBOL = "NFO:NIFTY2681824200CE"
+
+
+def _signal(*, target: float, entry: float = 29.45, stop: float = 26.21):
+    return SimpleNamespace(
+        symbol=SYMBOL,
+        action="BUY",
+        quantity=65,
+        entry_price=entry,
+        stop_loss=stop,
+        take_profit=target,
+        metadata={"bid": 29.40, "ask": 29.50},
+    )
+
+
+def test_minimum_target_repairs_20260818_cost_eroded_two_r_case(monkeypatch) -> None:
+    monkeypatch.setenv("MIN_NET_REWARD_RISK", "1.5")
+    monkeypatch.setenv("MAX_NET_RR_TARGET_UPLIFT_R", "0.35")
+    signal = _signal(target=35.94)
+
+    before = evaluate_final_net_rr(signal)
+    target = minimum_target_for_net_rr(signal)
+
+    assert before is not None and before.allowed is False
+    assert before.net_rr == pytest.approx(1.3515, rel=1e-3)
+    assert target is not None
+    assert target > signal.take_profit
+    # The target must remain a modest bounded uplift, not an arbitrary expansion.
+    risk_points = signal.entry_price - signal.stop_loss
+    assert (target - signal.entry_price) / risk_points <= 2.35
+
+    repaired = _signal(target=target)
+    after = evaluate_final_net_rr(repaired)
+    assert after is not None and after.allowed is True
+    assert after.net_rr >= 1.5
+
+
+def test_minimum_target_fails_closed_when_required_uplift_exceeds_cap(monkeypatch) -> None:
+    monkeypatch.setenv("MIN_NET_REWARD_RISK", "1.5")
+    monkeypatch.setenv("MAX_NET_RR_TARGET_UPLIFT_R", "0.05")
+    signal = _signal(target=35.94)
+
+    assert minimum_target_for_net_rr(signal) is None
+
+
+def test_runtime_adjusts_only_distance_anchored_entry_and_preserves_risk(monkeypatch) -> None:
+    monkeypatch.setenv("MIN_NET_REWARD_RISK", "1.5")
+    monkeypatch.setenv("MAX_NET_RR_TARGET_UPLIFT_R", "0.35")
+    manager = SimpleNamespace(
+        _get_latest_quote_safe=lambda _symbol: {"bid": 29.40, "ask": 29.50},
+        _extract_quote_diagnostics=lambda quote: quote,
+        _logger=SimpleNamespace(info=lambda *args, **kwargs: None),
+    )
+    kwargs = {
+        "symbol": SYMBOL,
+        "side": "BUY",
+        "quantity": 65,
+        "price": 29.45,
+        "stop_loss": 26.21,
+        "take_profit": 35.94,
+        "check_risk": True,
+        "intent": "ENTRY",
+        "trade_provenance": {
+            "bracket_anchor_mode": "distance",
+            "initial_reward_risk": 2.0,
+        },
+    }
+
+    adjusted = _cost_adjust_entry_target(manager, kwargs)
+
+    assert adjusted is not kwargs
+    assert adjusted["price"] == kwargs["price"]
+    assert adjusted["stop_loss"] == kwargs["stop_loss"]
+    assert adjusted["quantity"] == kwargs["quantity"]
+    assert adjusted["take_profit"] > kwargs["take_profit"]
+    assert adjusted["trade_provenance"]["net_rr_target_adjusted"] is True
+    assert adjusted["trade_provenance"]["original_take_profit"] == kwargs["take_profit"]
+
+
+def test_runtime_never_moves_absolute_strategy_target(monkeypatch) -> None:
+    monkeypatch.setenv("MIN_NET_REWARD_RISK", "1.5")
+    manager = SimpleNamespace(
+        _get_latest_quote_safe=lambda _symbol: {"bid": 29.40, "ask": 29.50},
+        _extract_quote_diagnostics=lambda quote: quote,
+        _logger=SimpleNamespace(info=lambda *args, **kwargs: None),
+    )
+    kwargs = {
+        "symbol": SYMBOL,
+        "side": "BUY",
+        "quantity": 65,
+        "price": 29.45,
+        "stop_loss": 26.21,
+        "take_profit": 35.94,
+        "check_risk": True,
+        "intent": "ENTRY",
+        "trade_provenance": {"bracket_anchor_mode": "absolute_level"},
+    }
+
+    adjusted = _cost_adjust_entry_target(manager, kwargs)
+
+    assert adjusted == kwargs


### PR DESCRIPTION
TDD hotfix for the 18 Aug live entry blocker. Current option geometry creates approximately 2.0 gross-R targets, while the final live gate correctly evaluates transaction-cost-adjusted net RR and repeatedly rejects otherwise valid entries at ~1.35-1.38 vs 1.50. This change will preserve the final safety gate and, only for distance-anchored BUY option entries, allow a small capped target uplift sufficient to restore the configured net RR. Absolute/technical targets remain untouched; if the required uplift exceeds the cap the trade still fails closed.