### PR TITLE
fix: preserve executable quote on bracket protection ticks

### DIFF
--- a/src/nifty_scalper_bot/execution/bracket_manager.py
+++ b/src/nifty_scalper_bot/execution/bracket_manager.py
@@ -12,6 +12,8 @@ Operational constraints:
 
 from __future__ import annotations
 
+from collections.abc import Mapping
+
 from nifty_scalper_bot.execution import bracket_core as _core
 
 for _name in dir(_core):
@@ -235,6 +237,60 @@ from nifty_scalper_bot.execution.market_aware_profit_extension import (  # noqa:
 )
 
 _apply_market_aware_profit_extension(BoundBracketManager)
+
+_original_on_tick = BoundBracketManager.on_tick
+
+
+def _capture_same_tick_cached_quote(self, symbol, ltp, exchange_ts):
+    """Recover executable depth from the cached SSOT without mixing tick identities."""
+    source = getattr(self, "_market_data", None)
+    getter = getattr(source, "get_latest_tick", None) if source is not None else None
+    if not callable(getter):
+        return
+    try:
+        cached = getter(symbol)
+    except Exception:
+        return
+    if not isinstance(cached, Mapping):
+        return
+    try:
+        cached_ltp = float(
+            cached.get("ltp")
+            or cached.get("last_price")
+            or cached.get("price")
+            or 0.0
+        )
+        current_ltp = float(ltp)
+    except (TypeError, ValueError):
+        return
+    if cached_ltp <= 0.0 or current_ltp <= 0.0 or abs(cached_ltp - current_ltp) > 1e-9:
+        return
+    if exchange_ts is not None:
+        cached_ts = tick_exchange_epoch(cached)
+        try:
+            current_ts = float(exchange_ts)
+        except (TypeError, ValueError):
+            return
+        if cached_ts is None or abs(float(cached_ts) - current_ts) > 0.001:
+            return
+    self._capture_exit_quote(_core.normalize_symbol(symbol), cached)
+
+
+def _on_tick_with_cached_executable_quote(
+    self, symbol, ltp, exchange_ts=None, *, defer_submission=False
+):
+    """Preserve executable bid/ask when legacy callers forward only LTP."""
+    _capture_same_tick_cached_quote(self, symbol, ltp, exchange_ts)
+    return _original_on_tick(
+        self,
+        symbol,
+        ltp,
+        exchange_ts,
+        defer_submission=defer_submission,
+    )
+
+
+BoundBracketManager.on_tick = _on_tick_with_cached_executable_quote
 
 BracketManager = BoundBracketManager
 

--- a/tests/execution/test_bracket_cached_executable_quote.py
+++ b/tests/execution/test_bracket_cached_executable_quote.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+from nifty_scalper_bot.execution.bracket_manager import BracketManager
+
+
+class _CachedMarketData:
+    def __init__(self, tick: dict[str, object]) -> None:
+        self.tick = dict(tick)
+
+    def get_latest_tick(self, _symbol: str) -> dict[str, object]:
+        return dict(self.tick)
+
+
+def _manager(market_data: _CachedMarketData) -> BracketManager:
+    order_manager = Mock()
+    order_manager.is_live_mode.return_value = False
+    return BracketManager(order_manager=order_manager, market_data=market_data)
+
+
+def test_runtime_on_tick_recovers_same_tick_executable_quote_from_ssot() -> None:
+    symbol = "NFO:NIFTY26AUG24050PE"
+    manager = _manager(
+        _CachedMarketData(
+            {
+                "symbol": symbol,
+                "ltp": 99.50,
+                "bid": 99.25,
+                "ask": 99.55,
+                "timestamp": 1_000.0,
+                "source": "ws",
+            }
+        )
+    )
+
+    manager.on_tick(symbol, 99.50, exchange_ts=1_000.0, defer_submission=True)
+
+    assert manager._exit_quotes[symbol][:2] == (99.25, 99.55)
+
+
+def test_runtime_on_tick_does_not_mix_quote_from_different_tick() -> None:
+    symbol = "NFO:NIFTY26AUG24050PE"
+    manager = _manager(
+        _CachedMarketData(
+            {
+                "symbol": symbol,
+                "ltp": 99.70,
+                "bid": 99.45,
+                "ask": 99.75,
+                "timestamp": 1_001.0,
+                "source": "ws",
+            }
+        )
+    )
+
+    manager.on_tick(symbol, 99.50, exchange_ts=1_000.0, defer_submission=True)
+
+    assert symbol not in manager._exit_quotes


### PR DESCRIPTION
## Why
Live 19-Aug evidence showed a protective stop evaluated with `src=ltp bid=None ask=None` even though executable-price SL/TP/trailing support exists. The live runner forwards only `(symbol, ltp, exchange_ts)` to `BracketManager.on_tick()`, bypassing the full-tick quote capture path.

## TDD
This PR starts with a failing regression that requires the production bracket manager to recover the same-timestamp full tick from the canonical market-data SSOT before evaluating the LTP-only compatibility call. It also forbids mixing a newer/different tick into the current evaluation.

## Safety invariants
- no strategy/risk/affordability threshold changes
- no order placement changes
- no change to synchronous position protection ordering
- no change to stop/target/trailing math
- no REST pull in the hot path; cached SSOT only

A second, separately validated hot-path latency optimization will only be included if the exact source can be proven without widening this change.