### PR TITLE
fix: use freshest cached quote at order preflight

### DIFF
--- a/src/nifty_scalper_bot/execution/order_manager.py
+++ b/src/nifty_scalper_bot/execution/order_manager.py
@@ -12,6 +12,9 @@ Operational constraints:
 
 from __future__ import annotations
 
+import math
+from collections.abc import Mapping
+
 from nifty_scalper_bot.execution import order_manager_core as _core
 
 for _name in dir(_core):
@@ -43,6 +46,76 @@ def _enrich_trade_plan_exit_provenance(plan):
 # Patch that one helper rather than introducing a second submission path.
 _runtime._enrich_trade_plan_exit_provenance = _enrich_trade_plan_exit_provenance
 RuntimeOrderManager = _runtime.RuntimeOrderManager
+
+_original_get_latest_quote_safe = RuntimeOrderManager._get_latest_quote_safe
+
+
+def _quote_age_ms(manager, quote):
+    """Return a finite quote age from the existing canonical diagnostics."""
+    if not isinstance(quote, Mapping):
+        return None
+    try:
+        age = manager._extract_quote_diagnostics(quote).get("age_ms")
+        parsed = float(age) if age is not None else None
+    except (AttributeError, TypeError, ValueError):
+        return None
+    if parsed is None or not math.isfinite(parsed) or parsed < 0.0:
+        return None
+    return parsed
+
+
+def _get_latest_quote_freshest_cached(self, symbol):
+    """Prefer the freshest already-cached quote without weakening stale guards."""
+    primary = _original_get_latest_quote_safe(self, symbol)
+    best = primary if isinstance(primary, Mapping) else None
+    best_age = _quote_age_ms(self, best)
+    normalized_symbol = _core.normalize_symbol(symbol)
+    seen_providers: set[int] = set()
+
+    for attr in (
+        "_market_data_manager",
+        "market_data_manager",
+        "_market_data",
+        "_data_hub",
+        "data_hub",
+    ):
+        provider = getattr(self, attr, None)
+        if provider is None or id(provider) in seen_providers:
+            continue
+        seen_providers.add(id(provider))
+        getter = getattr(provider, "get_latest_tick", None)
+        if not callable(getter):
+            continue
+        try:
+            candidate = getter(symbol)
+        except Exception:
+            continue
+        if not isinstance(candidate, Mapping) or not candidate:
+            continue
+        candidate_symbol = str(candidate.get("symbol") or "").strip()
+        if (
+            candidate_symbol
+            and _core.normalize_symbol(candidate_symbol) != normalized_symbol
+        ):
+            continue
+        try:
+            diagnostics = self._extract_quote_diagnostics(candidate)
+            candidate_ltp = float(diagnostics.get("ltp") or 0.0)
+        except (AttributeError, TypeError, ValueError):
+            continue
+        if candidate_ltp <= 0.0:
+            continue
+        candidate_age = _quote_age_ms(self, candidate)
+        if candidate_age is None:
+            continue
+        if best is None or best_age is None or candidate_age < best_age:
+            best = candidate
+            best_age = candidate_age
+
+    return dict(best) if isinstance(best, Mapping) else None
+
+
+RuntimeOrderManager._get_latest_quote_safe = _get_latest_quote_freshest_cached
 OrderManager = RuntimeOrderManager
 
 __all__ = sorted(

--- a/tests/execution/test_order_manager_freshest_cached_quote.py
+++ b/tests/execution/test_order_manager_freshest_cached_quote.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import time
+
+from nifty_scalper_bot.execution.order_manager import OrderManager
+
+
+class _TickProvider:
+    def __init__(self, quote: dict[str, object]) -> None:
+        self.quote = dict(quote)
+
+    def get_latest_tick(self, _symbol: str) -> dict[str, object]:
+        return dict(self.quote)
+
+
+def _manager(*, data_hub: _TickProvider, mdm: _TickProvider) -> OrderManager:
+    manager = object.__new__(OrderManager)
+    manager._data_hub = data_hub
+    manager.data_hub = None
+    manager._market_data = None
+    manager._market_data_manager = mdm
+    manager.market_data_manager = None
+    return manager
+
+
+def _quote(symbol: str, *, marker: str, age_s: float) -> dict[str, object]:
+    return {
+        "symbol": symbol,
+        "ltp": 100.0,
+        "bid": 99.90,
+        "ask": 100.10,
+        "received_at": time.time() - age_s,
+        "marker": marker,
+    }
+
+
+def test_order_preflight_uses_freshest_cached_provider_quote() -> None:
+    symbol = "NFO:NIFTY26AUG24050PE"
+    manager = _manager(
+        data_hub=_TickProvider(_quote(symbol, marker="processed", age_s=2.4)),
+        mdm=_TickProvider(_quote(symbol, marker="ws_fast", age_s=0.03)),
+    )
+
+    quote = manager._get_latest_quote_safe(symbol)
+
+    assert quote is not None
+    assert quote["marker"] == "ws_fast"
+
+
+def test_order_preflight_keeps_first_quote_when_it_is_already_freshest() -> None:
+    symbol = "NFO:NIFTY26AUG24050PE"
+    manager = _manager(
+        data_hub=_TickProvider(_quote(symbol, marker="processed", age_s=0.02)),
+        mdm=_TickProvider(_quote(symbol, marker="ws_fast", age_s=0.20)),
+    )
+
+    quote = manager._get_latest_quote_safe(symbol)
+
+    assert quote is not None
+    assert quote["marker"] == "processed"


### PR DESCRIPTION
## Why
19-Aug live evidence showed a quote fresh at ~31 ms in runner revalidation but ~2437 ms old when OrderManager preflight ran, causing `quote_stale` before any broker attempt. MDM already records a fast WS-arrival cache before heavier candle/strategy processing. OrderManager currently searches DataHub first and can return that older processed snapshot without comparing the fresher MDM cache.

## TDD
The first commit adds a regression with two existing cached providers: processed DataHub at 2.4 s and MDM fast-WS at 30 ms. Current main should fail because the first provider wins. A second test protects existing behavior when DataHub is already freshest.

## Intended fix
Keep the existing freshness limit unchanged. Wrap the current provider lookup and compare it only with cached `get_latest_tick()` snapshots from already-wired providers, choosing the smallest valid quote age. No REST pull, no threshold changes, no strategy/risk changes, no order-route duplication.