### PR TITLE
fix: reconcile live broker order updates

### DIFF
--- a/src/nifty_scalper_bot/execution/order_manager_core.py
+++ b/src/nifty_scalper_bot/execution/order_manager_core.py
@@ -7399,14 +7399,17 @@ class OrderManager:
             return
         self.apply_broker_order_update(str(order_id), order_update)
 
-    def _apply_broker_order_update(self, order_update: dict) -> None:
+    def _apply_broker_order_update(
+        self, order_update: dict[str, Any]
+    ) -> OrderDetails | None:
         """Handle broker order updates and follow-up workflows.
 
         Args:
             order_update: Raw broker order update payload.
 
         Returns:
-            None.
+            The updated canonical order, or ``None`` when the payload cannot be
+            associated with an order.
 
         Raises:
             None.
@@ -7417,7 +7420,7 @@ class OrderManager:
         )
         order_id = order_update.get("order_id")
         if not order_id:
-            return
+            return None
 
         # Normalize status to uppercase string
         status_raw = str(order_update.get("status", "")).upper()
@@ -7435,7 +7438,7 @@ class OrderManager:
                 # If a manual/ghost order is already finished (Rejected/Cancelled),
                 # we don't need to track it. Just return silently.
                 if status_raw in ["REJECTED", "CANCELLED", "CANCELED"]:
-                    return
+                    return None
 
                 # B. ADOPT ACTIVE ORDERS (Manual Trades you are holding)
                 try:
@@ -7505,7 +7508,7 @@ class OrderManager:
                 except Exception as e:
                     # Log as DEBUG so it doesn't spam your console if adoption fails
                     self._logger.debug(f"⚠️ Failed to adopt order {order_id}: {e}")
-                    return
+                    return None
 
             # -----------------------------------------------------
             # 🔄 STATE SYNCHRONIZATION
@@ -7629,6 +7632,8 @@ class OrderManager:
                 except Exception:
                     self._logger.exception("Unhandled exception", exc_info=True)
                     raise
+
+            return order
 
     def place_atomic_entry(
         self,

--- a/src/nifty_scalper_bot/execution/runtime_order_manager.py
+++ b/src/nifty_scalper_bot/execution/runtime_order_manager.py
@@ -421,6 +421,23 @@ class RuntimeOrderManager(_core.OrderManager):
 
     def _apply_broker_order_update(self, order_update: dict[str, Any]) -> Any:
         updated = super()._apply_broker_order_update(order_update)
+        if updated is not None:
+            try:
+                _finalize_partial_entry(self, updated, order_update)
+            except Exception as exc:
+                logger = getattr(self, "_logger", None)
+                log = getattr(logger, "error", None)
+                if callable(log):
+                    log(
+                        "ENTRY_PARTIAL_FILL_RECONCILE_FAILED order_id=%s error=%s",
+                        getattr(updated, "order_id", ""),
+                        exc,
+                        extra={
+                            "event": "ENTRY_PARTIAL_FILL_RECONCILE_FAILED",
+                            "order_id": getattr(updated, "order_id", ""),
+                            "error_type": type(exc).__name__,
+                        },
+                    )
         self._sync_filled_exit_bracket(updated, order_update)
         return updated
 

--- a/tests/execution/test_runtime_order_facade.py
+++ b/tests/execution/test_runtime_order_facade.py
@@ -6,6 +6,7 @@ import os
 from types import SimpleNamespace
 import subprocess
 import sys
+import threading
 from typing import Any
 
 import nifty_scalper_bot.execution as execution
@@ -16,6 +17,15 @@ from nifty_scalper_bot.execution.runtime_order_manager import RuntimeOrderManage
 
 
 class _Logger:
+    def debug(self, *_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    def info(self, *_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    def warning(self, *_args: Any, **_kwargs: Any) -> None:
+        return None
+
     def critical(self, *_args: Any, **_kwargs: Any) -> None:
         return None
 
@@ -286,3 +296,98 @@ def test_filled_exit_update_notifies_runtime_bracket_owner(monkeypatch) -> None:
 
     assert result is filled
     assert provider.calls == [(filled, payload)]
+
+
+def test_real_broker_update_returns_order_and_reconciles_filled_exit() -> None:
+    class _ExitProvider(_Provider):
+        def __init__(self) -> None:
+            super().__init__(False)
+            self.calls: list[tuple[Any, dict[str, Any]]] = []
+
+        def reconcile_filled_exit_order(
+            self, order: Any, payload: dict[str, Any]
+        ) -> bool:
+            self.calls.append((order, dict(payload)))
+            return True
+
+    provider = _ExitProvider()
+    manager = _manager(provider)
+    manager._bracket_manager = provider
+    manager._lock = threading.RLock()
+    exit_order = order_manager_core.OrderDetails(
+        order_id="EXIT-1",
+        symbol="NFO:NIFTY2681124500CE",
+        side="SELL",
+        quantity=65,
+        order_type=order_manager_core.OrderType.MARKET,
+        status=order_manager_core.OrderStatus.SUBMITTED,
+        intent="EXIT",
+        bracket_id="ENTRY-1",
+        linked_entry_order_id="ENTRY-1",
+        trade_lifecycle_id="ENTRY-1",
+    )
+    manager._orders = {exit_order.order_id: exit_order}
+    manager._positions = SimpleNamespace(
+        apply_broker_order_update=lambda *_args, **_kwargs: None
+    )
+    manager._register_virtual_bracket_for_fill = lambda *_args, **_kwargs: None
+    manager._confirm_position_protection_for_fill = lambda *_args, **_kwargs: None
+    manager._notify_failed_entry_terminal = lambda *_args, **_kwargs: None
+    manager.save_orders = lambda: None
+
+    payload = {
+        "order_id": "EXIT-1",
+        "status": "COMPLETE",
+        "average_price": 95.0,
+        "filled_quantity": 65,
+    }
+    result = RuntimeOrderManager._apply_broker_order_update(manager, payload)
+
+    assert result is exit_order
+    assert exit_order.status is order_manager_core.OrderStatus.FILLED
+    assert provider.calls == [(exit_order, payload)]
+
+
+def test_real_broker_update_supplies_order_to_partial_fill_reconciler(
+    monkeypatch,
+) -> None:
+    reconciled: list[tuple[Any, dict[str, Any]]] = []
+    monkeypatch.setattr(
+        "nifty_scalper_bot.execution.runtime_order_manager._finalize_partial_entry",
+        lambda manager, order, payload: reconciled.append((order, dict(payload))),
+    )
+    manager = _manager(None)
+    manager._bracket_manager = None
+    manager._lock = threading.RLock()
+    entry_order = order_manager_core.OrderDetails(
+        order_id="ENTRY-1",
+        symbol="NFO:NIFTY2681124500CE",
+        side="BUY",
+        quantity=130,
+        order_type=order_manager_core.OrderType.LIMIT,
+        status=order_manager_core.OrderStatus.SUBMITTED,
+        intent="ENTRY",
+        requested_lots=2,
+        resolved_lot_size=65,
+    )
+    manager._orders = {entry_order.order_id: entry_order}
+    manager._positions = SimpleNamespace(
+        apply_broker_order_update=lambda *_args, **_kwargs: None
+    )
+    manager._register_virtual_bracket_for_fill = lambda *_args, **_kwargs: None
+    manager._confirm_position_protection_for_fill = lambda *_args, **_kwargs: None
+    manager._notify_failed_entry_terminal = lambda *_args, **_kwargs: None
+    manager.save_orders = lambda: None
+
+    payload = {
+        "order_id": "ENTRY-1",
+        "status": "PARTIALLY FILLED",
+        "average_price": 100.0,
+        "filled_quantity": 65,
+        "pending_quantity": 65,
+    }
+    result = RuntimeOrderManager._apply_broker_order_update(manager, payload)
+
+    assert result is entry_order
+    assert entry_order.status is order_manager_core.OrderStatus.PARTIALLY_FILLED
+    assert reconciled == [(entry_order, payload)]


### PR DESCRIPTION
## Root cause

The core broker/WebSocket update handler mutated the canonical order but returned `None`. The production runtime consequently passed `None` to filled-exit bracket reconciliation, and unlike the polling path it never invoked partial-entry finalization. A partial fill or filled exit could therefore reconcile differently depending on whether broker truth arrived by polling or WebSocket.

## Focused correction

- Return the updated canonical `OrderDetails` from the core update handler, and return `None` only when a payload cannot be associated with an order.
- Run the existing bounded partial-entry finalizer for WebSocket updates, matching the polling path.
- Preserve the existing filled-exit bracket reconciliation path, now supplied with the real order.
- Add production-path regressions for both filled exits and partial entries; the tests do not mock the defective core method.

No strategy thresholds, sizing, order routing, stop/target geometry, or broker product behavior changed.

## Validation

- TDD: filled-exit regression failed before the core return fix; partial-entry regression then failed before runtime parity was added.
- `python -m pytest -q tests/execution/test_runtime_order_facade.py` — 12 passed.
- Risk, execution, entry-recovery, explicit-exit, and adjacent safety suites passed.
- 2,696 tests collected. The repository suite passes with the two known thread-timing files isolated; each isolated file also passes (37 and 11 tests). A monolithic local run reproduced an unrelated pre-existing deferred-worker timing race in `test_deferred_exit_latches_without_waiting_for_broker` (passes 5/5 alone).
- `python -m compileall -q src dashboard scripts` — passed.
- Scoped Ruff for the changed files, ignoring documented legacy debt in the two large modules — passed.
- `git diff --check` — passed.

Profitability is not asserted by this safety correction; that requires out-of-sample, paper, and live expectancy evidence.