### PR TITLE
fix: preserve executable quote at order preflight

### DIFF
--- a/src/nifty_scalper_bot/execution/order_manager.py
+++ b/src/nifty_scalper_bot/execution/order_manager.py
@@ -21,10 +21,13 @@ for _name in dir(_core):
     if not _name.startswith("__"):
         globals()[_name] = getattr(_core, _name)
 
-from nifty_scalper_bot.execution import runtime_order_manager as _runtime  # noqa: E402
+from nifty_scalper_bot.execution import (  # noqa: E402,I001
+    runtime_order_manager as _runtime,
+)
 
-
-_original_enrich_trade_plan_exit_provenance = _runtime._enrich_trade_plan_exit_provenance
+_original_enrich_trade_plan_exit_provenance = (
+    _runtime._enrich_trade_plan_exit_provenance
+)
 
 
 def _enrich_trade_plan_exit_provenance(plan):
@@ -64,11 +67,29 @@ def _quote_age_ms(manager, quote):
     return parsed
 
 
+def _quote_execution_rank(manager, quote):
+    """Rank cached quote evidence without treating LTP-only data as executable."""
+    if not isinstance(quote, Mapping):
+        return 0
+    try:
+        diagnostics = manager._extract_quote_diagnostics(quote)
+        bid = float(diagnostics.get("bid") or 0.0)
+        ask = float(diagnostics.get("ask") or 0.0)
+        bid_qty = int(diagnostics.get("bid_qty") or 0)
+        ask_qty = int(diagnostics.get("ask_qty") or 0)
+    except (AttributeError, TypeError, ValueError):
+        return 0
+    if bid <= 0.0 or ask < bid:
+        return 0
+    return 2 if bid_qty > 0 and ask_qty > 0 else 1
+
+
 def _get_latest_quote_freshest_cached(self, symbol):
-    """Prefer the freshest already-cached quote without weakening stale guards."""
+    """Prefer executable cached evidence, then freshness, preserving stale guards."""
     primary = _original_get_latest_quote_safe(self, symbol)
     best = primary if isinstance(primary, Mapping) else None
     best_age = _quote_age_ms(self, best)
+    best_rank = _quote_execution_rank(self, best)
     normalized_symbol = _core.normalize_symbol(symbol)
     seen_providers: set[int] = set()
 
@@ -108,9 +129,18 @@ def _get_latest_quote_freshest_cached(self, symbol):
         candidate_age = _quote_age_ms(self, candidate)
         if candidate_age is None:
             continue
-        if best is None or best_age is None or candidate_age < best_age:
+        candidate_rank = _quote_execution_rank(self, candidate)
+        if (
+            best is None
+            or candidate_rank > best_rank
+            or (
+                candidate_rank == best_rank
+                and (best_age is None or candidate_age < best_age)
+            )
+        ):
             best = candidate
             best_age = candidate_age
+            best_rank = candidate_rank
 
     return dict(best) if isinstance(best, Mapping) else None
 

--- a/tests/execution/test_order_manager_freshest_cached_quote.py
+++ b/tests/execution/test_order_manager_freshest_cached_quote.py
@@ -23,15 +23,29 @@ def _manager(*, data_hub: _TickProvider, mdm: _TickProvider) -> OrderManager:
     return manager
 
 
-def _quote(symbol: str, *, marker: str, age_s: float) -> dict[str, object]:
-    return {
+def _quote(
+    symbol: str,
+    *,
+    marker: str,
+    age_s: float,
+    executable: bool = True,
+) -> dict[str, object]:
+    quote: dict[str, object] = {
         "symbol": symbol,
         "ltp": 100.0,
-        "bid": 99.90,
-        "ask": 100.10,
         "received_at": time.time() - age_s,
         "marker": marker,
     }
+    if executable:
+        quote.update(
+            {
+                "bid": 99.90,
+                "ask": 100.10,
+                "bid_quantity": 65,
+                "ask_quantity": 65,
+            }
+        )
+    return quote
 
 
 def test_order_preflight_uses_freshest_cached_provider_quote() -> None:
@@ -58,3 +72,50 @@ def test_order_preflight_keeps_first_quote_when_it_is_already_freshest() -> None
 
     assert quote is not None
     assert quote["marker"] == "processed"
+
+
+def test_order_preflight_preserves_older_executable_quote_over_fresher_ltp() -> None:
+    symbol = "NFO:NIFTY26AUG24050PE"
+    manager = _manager(
+        data_hub=_TickProvider(_quote(symbol, marker="executable", age_s=0.20)),
+        mdm=_TickProvider(
+            _quote(symbol, marker="ltp_only", age_s=0.01, executable=False)
+        ),
+    )
+
+    quote = manager._get_latest_quote_safe(symbol)
+
+    assert quote is not None
+    assert quote["marker"] == "executable"
+
+
+def test_order_preflight_upgrades_ltp_quote_to_executable_quote() -> None:
+    symbol = "NFO:NIFTY26AUG24050PE"
+    manager = _manager(
+        data_hub=_TickProvider(
+            _quote(symbol, marker="ltp_only", age_s=0.01, executable=False)
+        ),
+        mdm=_TickProvider(_quote(symbol, marker="executable", age_s=0.20)),
+    )
+
+    quote = manager._get_latest_quote_safe(symbol)
+
+    assert quote is not None
+    assert quote["marker"] == "executable"
+
+
+def test_order_preflight_keeps_freshest_quote_when_only_ltp_is_available() -> None:
+    symbol = "NFO:NIFTY26AUG24050PE"
+    manager = _manager(
+        data_hub=_TickProvider(
+            _quote(symbol, marker="processed", age_s=0.20, executable=False)
+        ),
+        mdm=_TickProvider(
+            _quote(symbol, marker="ws_fast", age_s=0.01, executable=False)
+        ),
+    )
+
+    quote = manager._get_latest_quote_safe(symbol)
+
+    assert quote is not None
+    assert quote["marker"] == "ws_fast"


### PR DESCRIPTION
## Root cause

Order preflight chose cached quotes solely by age. A fresher LTP-only tick could therefore replace a slightly older FULL quote containing valid bid, ask, and depth. The downstream live-entry gate then correctly rejected the plan as `entry_bid_ask_missing`, even though executable evidence was available upstream.

## Focused correction

- Rank quote evidence first: full bid/ask/depth, bid/ask, then incomplete/LTP-only.
- Use freshness only between quotes with the same execution-evidence rank.
- Preserve existing symbol, LTP, timestamp, spread, depth, and stale-data validation.
- If only incomplete quotes exist, return the freshest incomplete quote so the existing live preflight still fails closed.
- No change to net reward-risk, sizing, margin, broker submission, cooldown, or bracket behavior.

## TDD evidence

The new regression failed before the correction (`ltp_only` displaced `executable`) and passed after it. Coverage also proves upgrade from incomplete to executable, freshest selection among equivalent quotes, and unchanged fail-closed behavior.

## Local validation

- `python3 -m pytest -q tests/execution/test_order_manager_freshest_cached_quote.py` — 5 passed
- `python3 -m pytest -q tests/execution tests/risk` — passed
- `python3 -m pytest -q` — 100%, one existing skip, no failures
- `python3 -m ruff check ...` — passed
- `python3 -m black --check ...` — passed
- `python3 -m compileall -q src` — passed
- `git diff --check` — passed

Only the execution facade and its focused regression test are included; runtime artifacts are excluded.