### PR TITLE
fix: preserve candidate depth availability

### DIFF
--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -3201,6 +3201,7 @@ class StrategyRunner:
                         "ask_missing": snap.ask_missing,
                         "bid_ask_source": snap.bid_ask_source,
                         "tradable_quote": snap.tradable_quote,
+                        "depth_available": bool(snap.depth_available),
                         "refresh_pending": symbol_refresh_pending,
                         "atr_option": float(getattr(snap, "atr_option", 0.0) or 0.0),
                         "history_bars": int(getattr(snap, "history_bars", 0) or 0),

--- a/tests/strategies/test_runner_candidate_snapshot_depth.py
+++ b/tests/strategies/test_runner_candidate_snapshot_depth.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from nifty_scalper_bot.strategies.runner import StrategyRunner
+
+
+class _Logger:
+    def debug(self, *args, **kwargs):
+        pass
+
+    def warning(self, *args, **kwargs):
+        pass
+
+    def error(self, *args, **kwargs):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_candidate_snapshot_preserves_normalized_depth_availability() -> None:
+    option_symbol = "NFO:NIFTY26AUG24250CE"
+    spot = SimpleNamespace(ltp=24242.0, canonical_symbol="NSE:NIFTY")
+    option = SimpleNamespace(
+        canonical_symbol=option_symbol,
+        ltp=127.1,
+        bid=127.05,
+        ask=127.15,
+        mid=127.1,
+        tick_age_s=0.25,
+        source="ws_full",
+        real_ticks_last_60s=15,
+        latest_candle_provisional=False,
+        latest_candle_synthetic=False,
+        latest_candle_volume=1300.0,
+        ohlc_valid=True,
+        depth_available=True,
+        bid_missing=False,
+        ask_missing=False,
+        bid_ask_source="depth",
+        tradable_quote=True,
+    )
+    market_data = SimpleNamespace(
+        get_symbol_snapshot=lambda symbol: spot if symbol == "NIFTY" else option,
+        request_symbol_subscription=lambda symbol: None,
+    )
+    runner = StrategyRunner.__new__(StrategyRunner)
+    runner._market_data = market_data
+    runner._logger = _Logger()
+    runner._resolve_candidate_contracts = lambda **kwargs: [(option_symbol, 24250)]
+
+    snapshots, refresh_pending = await runner.build_candidate_snapshots_async(
+        atm_strike=24250,
+        window_each_side=1,
+    )
+
+    assert refresh_pending is False
+    assert len(snapshots) == 1
+    assert snapshots[0]["depth_available"] is True


### PR DESCRIPTION
## Root cause
`StrategyRunner.build_candidate_snapshots_async()` copied executable bid/ask state but dropped the normalized `MarketSnapshot.depth_available` field. Downstream ranking and strict-depth execution therefore observed false depth even after readiness had confirmed broker depth.

## Change
Propagate the existing normalized boolean into each candidate snapshot. No selection weights, risk thresholds, quote eligibility, or fallback behavior change.

## Regression
Adds an async builder regression proving a FULL websocket option snapshot with depth remains depth-capable in the candidate dictionary.

## Validation
- New regression failed before the fix with `KeyError: depth_available`
- Focused + adjacent candidate readiness: 17 passed
- Full suite: passed (one existing skip); rerun with inherited proxy variables removed after isolating the Telegram SOCKS environment failure
- `python -m compileall -q src`: passed
- New test Ruff and Black checks: passed
- `git diff --check`: passed
- Remote blobs exactly match locally tested blobs

Repository-wide Ruff on `runner.py` still reports existing baseline violations unrelated to this one-line change.