### PR TITLE
fix: aggregate slow tick latency telemetry

### DIFF
--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -567,6 +567,7 @@ class MarketDataManager:
         self._tick_submitted_total = 0
         self._tick_processed_total = 0
         self._tick_dropped_total = 0
+        self._slow_tick_stage_stats: dict[str, dict[str, Any]] = {}
         self._tick_coalesced_by_priority: dict[str, int] = defaultdict(int)
         self._tick_dropped_by_reason: dict[str, int] = defaultdict(int)
         self._tick_dropped_by_priority: dict[str, int] = defaultdict(int)
@@ -7285,10 +7286,22 @@ class MarketDataManager:
             if callable(callback)
             else (str(callback) if callback else None)
         )
+        metric_key = stage if callback_name is None else f"{stage}:{callback_name}"
         pending_ticks = 0
         oldest_pending_age_ms = None
         drain_active = 0
         with self._pending_tick_lock:
+            stage_stats = self._slow_tick_stage_stats.setdefault(
+                metric_key,
+                {"count": 0, "max_duration_ms": 0.0, "worst_symbol": None},
+            )
+            stage_stats["count"] = int(stage_stats["count"]) + 1
+            if duration_ms > float(stage_stats["max_duration_ms"]):
+                stage_stats["max_duration_ms"] = duration_ms
+                stage_stats["worst_symbol"] = symbol
+            occurrence_count = int(stage_stats["count"])
+            max_duration_ms = float(stage_stats["max_duration_ms"])
+            worst_symbol = stage_stats["worst_symbol"]
             pending_ticks = self._pending_count_locked()
             oldest_pending_age_ms = (
                 self._oldest_pending_age_ms_locked() if pending_ticks else None
@@ -7302,16 +7315,19 @@ class MarketDataManager:
         # wrong field this telemetry was fixed to stop producing.
         _loop_owner = getattr(self, "_event_loop_thread_id", None)
         event_loop_thread = None if _loop_owner is None else thread_id == _loop_owner
-        key = f"tick_stage_slow:{stage}:{callback_name or ''}:{symbol or ''}"
+        key = f"tick_stage_slow:{id(self)}:{metric_key}"
         log_throttled(
             self._logger,
             key,
-            "TICK_STAGE_SLOW stage=%s callback=%s symbol=%s duration_ms=%.3f pending_ticks=%d oldest_pending_age_ms=%s drain_active=%d source=%s thread_id=%s event_loop_thread=%s"
+            "TICK_STAGE_SLOW stage=%s callback=%s symbol=%s duration_ms=%.3f occurrence_count=%d max_duration_ms=%.3f worst_symbol=%s pending_ticks=%d oldest_pending_age_ms=%s drain_active=%d source=%s thread_id=%s event_loop_thread=%s"
             % (
                 stage,
                 callback_name,
                 symbol,
                 duration_ms,
+                occurrence_count,
+                max_duration_ms,
+                worst_symbol,
                 pending_ticks,
                 (
                     None
@@ -7323,7 +7339,7 @@ class MarketDataManager:
                 thread_id,
                 "unknown" if event_loop_thread is None else event_loop_thread,
             ),
-            interval_sec=10.0,
+            interval_sec=60.0,
             level=logging.WARNING,
             extra={
                 "event": "TICK_STAGE_SLOW",
@@ -7331,6 +7347,9 @@ class MarketDataManager:
                 "callback": callback_name,
                 "symbol": symbol,
                 "duration_ms": duration_ms,
+                "occurrence_count": occurrence_count,
+                "max_duration_ms": max_duration_ms,
+                "worst_symbol": worst_symbol,
                 "pending_ticks": pending_ticks,
                 "oldest_pending_age_ms": oldest_pending_age_ms,
                 "drain_active": drain_active,
@@ -7558,6 +7577,10 @@ class MarketDataManager:
                 "coalesced_by_priority": dict(self._tick_coalesced_by_priority),
                 "dropped_by_reason": dict(self._tick_dropped_by_reason),
                 "dropped_by_priority": dict(self._tick_dropped_by_priority),
+                "slow_tick_stages": {
+                    key: dict(value)
+                    for key, value in self._slow_tick_stage_stats.items()
+                },
                 "drain_callbacks_scheduled": self._tick_drain_callbacks_scheduled,
                 "drain_callbacks_completed": self._tick_drain_callbacks_completed,
                 "drain_task_done": (

--- a/tests/data/test_mdm_tick_coalescing.py
+++ b/tests/data/test_mdm_tick_coalescing.py
@@ -1955,6 +1955,7 @@ def test_slow_tick_telemetry_aggregates_symbols_and_preserves_worst_sample(caplo
         "worst_symbol": "NFO:NIFTY26JUN24100CE",
     }
 
+
 @pytest.mark.asyncio
 async def test_slow_subscriber_exception_isolated_and_drain_continues(caplog):
     mdm = _make_mdm()

--- a/tests/data/test_mdm_tick_coalescing.py
+++ b/tests/data/test_mdm_tick_coalescing.py
@@ -1923,6 +1923,38 @@ def test_slow_tick_subscriber_is_identified_without_tick_accounting_loss(caplog)
     assert any(getattr(r, "stage", None) == "one_tick" for r in records)
 
 
+def test_slow_tick_telemetry_aggregates_symbols_and_preserves_worst_sample(caplog):
+    mdm = _make_mdm()
+
+    with caplog.at_level("WARNING"):
+        mdm._log_slow_tick_stage(
+            stage="one_tick",
+            symbol="NFO:NIFTY26JUN24000CE",
+            duration_ms=120.0,
+            source="ws",
+        )
+        mdm._log_slow_tick_stage(
+            stage="one_tick",
+            symbol="NFO:NIFTY26JUN24100CE",
+            duration_ms=240.0,
+            source="ws",
+        )
+
+    records = [
+        record
+        for record in caplog.records
+        if getattr(record, "event", "") == "TICK_STAGE_SLOW"
+        and getattr(record, "stage", None) == "one_tick"
+    ]
+    assert len(records) == 1
+
+    stage_stats = mdm.get_tick_pressure_stats()["slow_tick_stages"]["one_tick"]
+    assert stage_stats == {
+        "count": 2,
+        "max_duration_ms": 240.0,
+        "worst_symbol": "NFO:NIFTY26JUN24100CE",
+    }
+
 @pytest.mark.asyncio
 async def test_slow_subscriber_exception_isolated_and_drain_continues(caplog):
     mdm = _make_mdm()


### PR DESCRIPTION
## Root cause
`TICK_STAGE_SLOW` throttling included the symbol in its key, so the same slow stage emitted independently for every option symbol every 10 seconds. The production session produced 223 warnings in 34 minutes while retaining no cumulative count or worst sample by stage.

## Change
- Aggregate telemetry by stage and callback, across symbols
- Record cumulative count, maximum duration, and worst symbol in the existing tick-pressure snapshot
- Emit at most once per stage/callback per 60 seconds
- Preserve the current per-stage thresholds and all tick-processing behavior

This reduces hot-path logging I/O while improving latency attribution; it does not hide counts or maxima.

## TDD and validation
- Regression failed before the fix because two symbols emitted two warnings
- Focused slow-stage/loop-thread tests: 13 passed
- Complete `tests/data`: passed
- Complete repository suite: passed (one existing skip)
- `python -m compileall -q src`: passed
- `git diff --check`: passed
- Final remote production and test blobs exactly match locally tested blobs

Existing repository-wide import-order debt in the large legacy test file remains outside this scoped change.