### PR TITLE
fix: demote expected-state log noise

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -12925,7 +12925,7 @@ async def startup_sequence(ctx: BotContext) -> None:
                 len(sorted(set(active_symbols))),
             )
             subscribed_symbols = sorted({sym for sym in targets})
-            LOGGER.critical(
+            LOGGER.info(
                 "📊 STRATEGY SUBSCRIBED SYMBOLS: %s",
                 subscribed_symbols,
             )

--- a/src/nifty_scalper_bot/core/message_bus.py
+++ b/src/nifty_scalper_bot/core/message_bus.py
@@ -208,7 +208,7 @@ class MessageBus:
         if self._running:
             return True
         if not any(self.subscribers.values()):
-            LOGGER.warning("MESSAGE_BUS_START_SKIPPED reason=no_subscribers")
+            LOGGER.info("MESSAGE_BUS_START_SKIPPED reason=no_subscribers")
             return False
         self._running = True
 

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -16017,7 +16017,7 @@ class StrategyRunner:
                                 resolved_bias == "PE" and upper_sym.endswith("CE")
                             ) or (resolved_bias == "CE" and upper_sym.endswith("PE"))
                             if opposite:
-                                self._logger.warning(
+                                self._logger.debug(
                                     "TRIGGER_EVAL_SKIPPED symbol=%s reason=opposite_side_trigger_suppressed underlying_bias=%s confidence=%.2f",
                                     symbol,
                                     resolved_bias,

--- a/tests/test_expected_state_log_levels.py
+++ b/tests/test_expected_state_log_levels.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from nifty_scalper_bot.core.message_bus import MessageBus
+
+
+def _preceding_call(path: str, marker: str, *, width: int = 240) -> str:
+    source = Path(path).read_text(encoding="utf-8")
+    marker_index = source.index(marker)
+    return source[max(0, marker_index - width) : marker_index]
+
+
+def _following_block(path: str, marker: str, *, width: int = 1200) -> str:
+    source = Path(path).read_text(encoding="utf-8")
+    marker_index = source.index(marker)
+    return source[marker_index : marker_index + width]
+
+
+def test_opposite_side_suppression_is_debug_diagnostic() -> None:
+    call = _preceding_call(
+        "src/nifty_scalper_bot/strategies/runner.py",
+        '"TRIGGER_EVAL_SKIPPED symbol=%s ' "reason=opposite_side_trigger_suppressed",
+    )
+
+    assert "self._logger.debug(" in call
+    assert "self._logger.warning(" not in call
+    decision = _following_block(
+        "src/nifty_scalper_bot/strategies/runner.py",
+        '"TRIGGER_EVAL_SKIPPED symbol=%s ' "reason=opposite_side_trigger_suppressed",
+    )
+    assert "self._emit_runner_eval_decision(" in decision
+
+
+def test_successful_strategy_subscription_summary_is_not_critical() -> None:
+    call = _preceding_call(
+        "src/nifty_scalper_bot/core/app.py",
+        '"📊 STRATEGY SUBSCRIBED SYMBOLS: %s"',
+    )
+
+    assert "LOGGER.info(" in call
+    assert "LOGGER.critical(" not in call
+    empty_call = _preceding_call(
+        "src/nifty_scalper_bot/core/app.py",
+        '"⛔ STRATEGY SUBSCRIPTION LIST IS EMPTY"',
+    )
+    assert "LOGGER.critical(" in empty_call
+
+
+def test_empty_message_bus_start_is_informational(caplog) -> None:
+    bus = MessageBus()
+
+    with caplog.at_level(logging.INFO):
+        assert bus.start() is False
+
+    records = [
+        record
+        for record in caplog.records
+        if "MESSAGE_BUS_START_SKIPPED reason=no_subscribers" in record.getMessage()
+    ]
+    assert len(records) == 1
+    assert records[0].levelno == logging.INFO


### PR DESCRIPTION
## Root cause
Normal control-flow states were emitted at warning/critical severity:
- high-confidence opposite-side suppression produced 103 warnings in the reviewed session
- a successful non-empty strategy subscription summary was labeled CRITICAL
- an intentionally unused MessageBus in direct-MDM mode warned on startup

These records obscured actionable failures without representing degraded behavior.

## Change
- Opposite-side suppression: WARNING → DEBUG; the candidate remains rejected and the structured runner decision remains emitted
- Successful subscription summary: CRITICAL → INFO; an empty subscription list remains CRITICAL
- MessageBus with no subscribers: WARNING → INFO; `start()` still returns `False`

No trading, subscription, risk, execution, or recovery behavior changes.

## TDD and validation
- New severity contracts failed against the previous levels
- Focused + adjacent message-bus/live-suppression tests: 21 passed
- Complete repository suite: passed (one existing skip)
- New test Ruff and Black checks: passed
- `python -m compileall -q src`: passed
- `git diff --check`: passed
- Every remote blob exactly matches the locally tested blob