### PR TITLE
fix: grow protection with cumulative entry fills

### DIFF
--- a/src/nifty_scalper_bot/execution/bracket_core.py
+++ b/src/nifty_scalper_bot/execution/bracket_core.py
@@ -257,6 +257,7 @@ class BracketState:
     sl_trigger_price: float
     tp_trigger_price: float  # Final/Ultimate TP
     initial_sl_trigger_price: float = 0.0
+    requested_entry_quantity: int = 0
 
     # Multi-Target & Scaling State (NEW)
     remaining_quantity: int = 0
@@ -385,6 +386,8 @@ class BracketState:
 
     def __post_init__(self):
         self.side = _normalize_bracket_side(self.side)
+        if self.requested_entry_quantity <= 0:
+            self.requested_entry_quantity = self.quantity
         # Auto-initialize state fields if not set
         if self.remaining_quantity == 0:
             self.remaining_quantity = self.quantity
@@ -406,6 +409,7 @@ class BracketState:
             "symbol": self.symbol,
             "side": self.side,
             "quantity": self.quantity,
+            "requested_entry_quantity": self.requested_entry_quantity,
             "entry_price": self.entry_price,
             "sl_trigger_price": self.sl_trigger_price,
             "tp_trigger_price": self.tp_trigger_price,
@@ -1272,6 +1276,7 @@ class BracketManager:
                     existing.tp_trigger_price = tp
                 # Reset quantity if re-registering (e.g. scale-in)
                 existing.quantity = abs(qty)
+                existing.requested_entry_quantity = abs(qty)
                 existing.remaining_quantity = abs(qty)
                 existing.exit_state = BracketExitLifecycle.OPEN_PENDING_FILL.value
                 existing.exit_pending = False
@@ -1326,6 +1331,7 @@ class BracketManager:
                 symbol=symbol,
                 side=side,
                 quantity=abs(qty),
+                requested_entry_quantity=abs(qty),
                 remaining_quantity=abs(qty),
                 entry_price=price,
                 sl_trigger_price=sl,
@@ -1411,47 +1417,59 @@ class BracketManager:
 
     def _reconcile_entry_fill_quantity(
         self, bracket: BracketState, filled_qty: int | None
-    ) -> None:
-        """Shrink a bracket to the quantity the broker actually filled.
+    ) -> bool:
+        """Match protection to cumulative broker fills within the entry request.
 
         Exits must never be sized above the held position: an oversized exit is
-        either rejected (leaving the position unprotected while it retries) or
-        fills into a naked opposite exposure. Only shrinking is permitted -- a
-        reported quantity above the registered size is a data fault, not an
-        instruction to trade more.
+        either rejected or fills into a naked opposite exposure. Broker fill
+        updates are cumulative, so a later 30 -> 65 sequence must also grow
+        protection, but never above the immutable requested entry quantity.
         """
         if filled_qty is None:
-            return
+            return False
         try:
             filled = int(filled_qty)
         except (TypeError, ValueError):
-            return
+            return False
         registered = int(bracket.quantity or 0)
-        if filled <= 0 or registered <= 0 or filled >= registered:
-            return
+        requested = int(bracket.requested_entry_quantity or registered or 0)
+        if filled <= 0 or registered <= 0 or requested <= 0:
+            return False
+        if filled > requested or filled == registered:
+            return False
+        already_exited = max(0, registered - int(bracket.remaining_quantity or 0))
+        if filled < already_exited:
+            LOGGER.critical(
+                "BRACKET_QTY_RECONCILE_REJECTED order_id=%s symbol=%s requested=%s current=%s filled=%s already_exited=%s",
+                bracket.entry_order_id,
+                bracket.symbol,
+                requested,
+                registered,
+                filled,
+                already_exited,
+            )
+            return False
         bracket.quantity = filled
-        bracket.remaining_quantity = filled
-        # A partial-target slice at or above the whole position is no longer a
-        # scale-out; drop it rather than exit the entire position at TP1.
-        bracket.tp_levels = [
-            level
-            for level in bracket.tp_levels
-            if level.executed or int(level.quantity) < filled
-        ]
+        bracket.remaining_quantity = max(0, filled - already_exited)
         LOGGER.warning(
-            "BRACKET_QTY_RECONCILED order_id=%s symbol=%s requested=%s filled=%s",
+            "BRACKET_QTY_RECONCILED order_id=%s symbol=%s requested=%s previous=%s filled=%s remaining=%s",
             bracket.entry_order_id,
             bracket.symbol,
+            requested,
             registered,
             filled,
+            bracket.remaining_quantity,
             extra={
                 "event": "BRACKET_QTY_RECONCILED",
                 "order_id": bracket.entry_order_id,
                 "symbol": bracket.symbol,
-                "requested_qty": registered,
+                "requested_qty": requested,
+                "previous_filled_qty": registered,
                 "filled_qty": filled,
+                "remaining_qty": bracket.remaining_quantity,
             },
         )
+        return True
 
     def confirm_entry_fill(
         self, order_id: str, fill_price: float, filled_qty: int | None = None
@@ -2124,6 +2142,8 @@ class BracketManager:
         # Check partial targets (TP1, TP2, etc.)
         for target in bracket.tp_levels:
             if target.executed:
+                continue
+            if int(target.quantity) >= int(bracket.remaining_quantity):
                 continue
 
             triggered = False
@@ -4737,8 +4757,16 @@ class BracketManager:
         if not symbol:
             raise ValueError(f"{entry_id}: symbol missing")
         quantity = int(payload.get("quantity") or 0)
+        requested_quantity = int(
+            payload.get("requested_entry_quantity", quantity) or 0
+        )
         remaining = int(payload.get("remaining_quantity", quantity) or 0)
-        if quantity <= 0 or remaining < 0 or remaining > quantity:
+        if (
+            quantity <= 0
+            or requested_quantity < quantity
+            or remaining < 0
+            or remaining > quantity
+        ):
             raise ValueError(f"{entry_id}: invalid quantity state")
         trailing_config = payload.get("trailing_config") or {}
         if not isinstance(trailing_config, Mapping):
@@ -4768,6 +4796,7 @@ class BracketManager:
             symbol=symbol,
             side=str(payload.get("side") or ""),
             quantity=quantity,
+            requested_entry_quantity=requested_quantity,
             entry_price=entry_price,
             sl_trigger_price=finite_float(
                 "stop loss", payload.get("sl_trigger_price", 0.0)

--- a/src/nifty_scalper_bot/execution/bracket_manager.py
+++ b/src/nifty_scalper_bot/execution/bracket_manager.py
@@ -67,7 +67,7 @@ def _positive_filled_quantity(value):
 
 
 def _reconcile_confirmed_entry_quantity(self, order_id, bracket, filled_qty):
-    """Shrink bracket and durable entry fill to a later authoritative quantity."""
+    """Reconcile bracket and ledger to cumulative fills within the request."""
     reported = _positive_filled_quantity(filled_qty)
     if bracket is None or reported is None:
         return False
@@ -76,15 +76,24 @@ def _reconcile_confirmed_entry_quantity(self, order_id, bracket, filled_qty):
         return False
     try:
         registered = int(getattr(bracket, "quantity", 0) or 0)
+        requested = int(
+            getattr(bracket, "requested_entry_quantity", 0) or registered
+        )
     except (TypeError, ValueError):
         return False
-    if registered <= 0 or reported >= registered:
+    if (
+        registered <= 0
+        or requested <= 0
+        or reported > requested
+        or reported == registered
+    ):
         return False
 
     reconciler = getattr(self, "_reconcile_entry_fill_quantity", None)
     if not callable(reconciler):
         return False
-    reconciler(bracket, reported)
+    if not bool(reconciler(bracket, reported)):
+        return False
 
     # On the first callback the ledger has not been written yet; pre-shrinking
     # makes the existing ledger layer record the actual quantity. On a later
@@ -95,7 +104,11 @@ def _reconcile_confirmed_entry_quantity(self, order_id, bracket, filled_qty):
         fill_id_builder = getattr(self, "_entry_fill_id", None)
         if callable(ledger_reconcile) and callable(fill_id_builder):
             try:
-                ledger_reconcile(fill_id_builder(str(order_id)), reported)
+                ledger_reconcile(
+                    fill_id_builder(str(order_id)),
+                    reported,
+                    maximum_quantity=requested,
+                )
             except Exception as exc:  # noqa: BLE001 - block release on accounting drift
                 blocker = getattr(self, "_block_ledger_release", None)
                 if callable(blocker):
@@ -110,16 +123,18 @@ def _reconcile_confirmed_entry_quantity(self, order_id, bracket, filled_qty):
                     )
                 raise
         _core.LOGGER.warning(
-            "FILL_LEDGER_ENTRY_QTY_RECONCILED order_id=%s symbol=%s requested=%s filled=%s",
+            "FILL_LEDGER_ENTRY_QTY_RECONCILED order_id=%s symbol=%s requested=%s previous=%s filled=%s",
             order_id,
             bracket.symbol,
+            requested,
             registered,
             reported,
             extra={
                 "event": "FILL_LEDGER_ENTRY_QTY_RECONCILED",
                 "order_id": str(order_id),
                 "symbol": bracket.symbol,
-                "requested_qty": registered,
+                "requested_qty": requested,
+                "previous_filled_qty": registered,
                 "filled_qty": reported,
             },
         )

--- a/src/nifty_scalper_bot/execution/fill_ledger.py
+++ b/src/nifty_scalper_bot/execution/fill_ledger.py
@@ -272,22 +272,36 @@ class BracketFillLedgerStore:
             raise FillLedgerError(f"unable to persist fill {leg.fill_id}: {exc}") from exc
         return True
 
-    def reconcile_entry_quantity(self, fill_id: str, filled_qty: int) -> bool:
-        """Shrink an existing ENTRY fill to a later authoritative broker quantity.
+    def reconcile_entry_quantity(
+        self,
+        fill_id: str,
+        filled_qty: int,
+        *,
+        maximum_quantity: int | None = None,
+    ) -> bool:
+        """Set an ENTRY fill to an authoritative cumulative broker quantity.
 
         Fill rows stay immutable except for this explicit partial-fill correction.
-        The method can never grow exposure or alter price, side, fees, or identity.
+        Growth is allowed only up to the caller-supplied original order quantity;
+        price, side, fees and identity remain immutable.
         """
         quantity = int(filled_qty or 0)
         if quantity <= 0:
             raise FillValidationError("reconciled entry quantity must be positive")
+        maximum = int(maximum_quantity or 0)
+        if maximum_quantity is not None and (maximum <= 0 or quantity > maximum):
+            raise FillValidationError(
+                "reconciled entry quantity exceeds original order quantity"
+            )
         key = str(fill_id or "").strip()
         existing = self.get_fill(key)
         if existing is None:
             return False
         if existing.kind != "ENTRY":
             raise FillConflictError(f"fill_id {key!r} is not an entry fill")
-        if quantity >= existing.quantity:
+        if quantity == existing.quantity:
+            return False
+        if quantity > existing.quantity and maximum_quantity is None:
             return False
         try:
             with self._connect() as connection:
@@ -295,7 +309,7 @@ class BracketFillLedgerStore:
                     """
                     UPDATE bracket_fill_legs
                     SET quantity = ?
-                    WHERE fill_id = ? AND kind = 'ENTRY' AND quantity > ?
+                    WHERE fill_id = ? AND kind = 'ENTRY' AND quantity != ?
                     """,
                     (quantity, key, quantity),
                 )
@@ -305,7 +319,7 @@ class BracketFillLedgerStore:
                 f"unable to reconcile entry fill {key}: {exc}"
             ) from exc
         current = self.get_fill(key)
-        if current is None or current.kind != "ENTRY" or current.quantity > quantity:
+        if current is None or current.kind != "ENTRY" or current.quantity != quantity:
             raise FillConflictError(
                 f"entry fill {key!r} quantity reconciliation was not durable"
             )

--- a/tests/execution/test_bracket_manager_reliability.py
+++ b/tests/execution/test_bracket_manager_reliability.py
@@ -851,7 +851,19 @@ def test_overreported_fill_quantity_never_grows_the_bracket() -> None:
     assert bracket.remaining_quantity == 65
 
 
-def test_partial_fill_drops_a_now_oversized_scale_out_level() -> None:
+def test_later_cumulative_fill_can_grow_to_original_registered_quantity() -> None:
+    manager = BracketManager(order_manager=Mock())
+    bracket = _pending_bracket(manager, "pf-grow", "NFO:NIFTYPFGROWCE", 130)
+
+    manager.confirm_entry_fill("pf-grow", 100.0, 30)
+    manager.confirm_entry_fill("pf-grow", 100.0, 130)
+
+    assert bracket.requested_entry_quantity == 130
+    assert bracket.quantity == 130
+    assert bracket.remaining_quantity == 130
+
+
+def test_partial_fill_suspends_a_now_oversized_scale_out_level() -> None:
     manager = BracketManager(order_manager=Mock())
     from nifty_scalper_bot.execution.bracket_core import TargetLevel
 
@@ -861,4 +873,7 @@ def test_partial_fill_drops_a_now_oversized_scale_out_level() -> None:
     manager.confirm_entry_fill("pf-5", 100.0, 75)
 
     assert bracket.quantity == 75
-    assert [lvl for lvl in bracket.tp_levels if not lvl.executed] == []
+    assert bracket.tp_levels[0].executed is False
+    decision = manager._evaluate_exit_fast(bracket, 111.0)
+    assert decision is not None
+    assert decision["type"] == "FINAL_TP"

--- a/tests/execution/test_entry_fill_quantity_reconciliation.py
+++ b/tests/execution/test_entry_fill_quantity_reconciliation.py
@@ -73,6 +73,38 @@ def test_identical_duplicate_callback_remains_idempotent(monkeypatch, tmp_path) 
     assert entry.quantity == 65
 
 
+def test_later_cumulative_fill_grows_protection_up_to_original_request(
+    monkeypatch, tmp_path
+) -> None:
+    manager = _manager(monkeypatch, tmp_path)
+    manager.confirm_entry_fill("entry-partial", 100.0, 30)
+
+    manager.confirm_entry_fill("entry-partial", 100.0, 65)
+
+    bracket, entry = _entry_fill(manager)
+    assert bracket.requested_entry_quantity == 130
+    assert bracket.quantity == 65
+    assert bracket.remaining_quantity == 65
+    assert entry.quantity == 65
+
+
+def test_cumulative_fill_growth_preserves_already_exited_quantity(
+    monkeypatch, tmp_path
+) -> None:
+    manager = _manager(monkeypatch, tmp_path)
+    manager.confirm_entry_fill("entry-partial", 100.0, 30)
+    bracket = manager.get_bracket("entry-partial")
+    assert bracket is not None
+    bracket.remaining_quantity = 20
+
+    manager.confirm_entry_fill("entry-partial", 100.0, 65)
+
+    bracket, entry = _entry_fill(manager)
+    assert bracket.quantity == 65
+    assert bracket.remaining_quantity == 55
+    assert entry.quantity == 65
+
+
 def test_overreported_quantity_never_grows_bracket_or_ledger(monkeypatch, tmp_path) -> None:
     manager = _manager(monkeypatch, tmp_path)
     manager.confirm_entry_fill("entry-partial", 100.0, 260)


### PR DESCRIPTION
## Root cause
Bracket quantity reconciliation treated every broker fill report as shrink-only. Because broker updates carry cumulative fills, a 30 -> 65 sequence left the bracket and durable entry ledger protecting only 30 units.

## Behavioral invariant
- Preserve the immutable requested entry quantity.
- Reconcile cumulative fills in either direction, never above the original request.
- Preserve already-exited quantity when later entry fills arrive.
- Suspend an oversized TP1 while the partial position is too small, allowing it to become eligible if cumulative fills later grow.

## Files
- Canonical bracket state/reconciliation and persistence
- Canonical fill ledger quantity reconciliation
- Focused bracket and durable-ledger regressions

## Local validation
- `python -m compileall -q src tests/execution/test_entry_fill_quantity_reconciliation.py tests/execution/test_bracket_manager_reliability.py`
- `git diff --check`
- Isolated SQLite ledger test: 30 -> 65 accepted under max 130; 131 rejected

The full local pytest runner was unavailable because dependency installation was blocked by the execution environment. Required repository CI is authoritative before merge.