### PR TITLE
fix: rearm EOD flatten across sessions

### DIFF
--- a/src/nifty_scalper_bot/core/app.py
+++ b/src/nifty_scalper_bot/core/app.py
@@ -141,6 +141,47 @@ def _next_eod_flatten_time_ist(now_ist: datetime) -> datetime | None:
     return None
 
 
+def _schedule_next_eod_flatten(
+    loop: asyncio.AbstractEventLoop,
+    bracket_manager: Any,
+    *,
+    now_provider: Callable[[], datetime] | None = None,
+) -> asyncio.TimerHandle | None:
+    """Schedule one EOD flatten and re-arm after it runs."""
+    clock = now_provider or (lambda: datetime.now(ZoneInfo("Asia/Kolkata")))
+    now_ist = clock()
+    target_ist = _next_eod_flatten_time_ist(now_ist)
+    if target_ist is None:
+        LOGGER.error("EOD bracket flatten not scheduled: no trading day found")
+        return None
+    normalized_now = (
+        now_ist.replace(tzinfo=ZoneInfo("Asia/Kolkata"))
+        if now_ist.tzinfo is None
+        else now_ist.astimezone(ZoneInfo("Asia/Kolkata"))
+    )
+    delay = max(0.0, (target_ist - normalized_now).total_seconds())
+
+    def _flatten_and_rearm() -> None:
+        try:
+            bracket_manager.eod_flatten_all()
+        except Exception as exc:  # noqa: BLE001 - next-day protection must survive
+            LOGGER.exception("EOD bracket flatten failed: %s", exc)
+        finally:
+            _schedule_next_eod_flatten(
+                loop,
+                bracket_manager,
+                now_provider=clock,
+            )
+
+    handle = loop.call_later(delay, _flatten_and_rearm)
+    LOGGER.info(
+        "EOD bracket flatten scheduled for %s IST (in %.1fs)",
+        target_ist.isoformat(),
+        delay,
+    )
+    return handle
+
+
 BOT_CONTEXT_RUNTIME_FIELD_DEFAULTS: dict[str, Any] = {
     "canonical_history_ensurer_injection_failed": False,
     "hydration_status_by_symbol": dict,
@@ -14931,18 +14972,7 @@ async def startup_sequence(ctx: BotContext) -> None:
 
     if ctx.bracket_manager:
         try:
-            now_ist = datetime.now(ZoneInfo("Asia/Kolkata"))
-            eod_target_ist = _next_eod_flatten_time_ist(now_ist)
-            if eod_target_ist is None:
-                LOGGER.info("EOD bracket flatten not scheduled: no trading day found")
-            else:
-                seconds_to_15h24 = max(0.0, (eod_target_ist - now_ist).total_seconds())
-                loop.call_later(seconds_to_15h24, ctx.bracket_manager.eod_flatten_all)
-                LOGGER.info(
-                    "EOD bracket flatten scheduled for %s IST (in %.1fs)",
-                    eod_target_ist.isoformat(),
-                    seconds_to_15h24,
-                )
+            _schedule_next_eod_flatten(loop, ctx.bracket_manager)
         except Exception as e:
             LOGGER.error("Failed to schedule EOD flatten: %s", e)
 

--- a/tests/core/test_eod_flatten_schedule.py
+++ b/tests/core/test_eod_flatten_schedule.py
@@ -1,7 +1,10 @@
 from datetime import datetime, timezone
 from zoneinfo import ZoneInfo
 
-from nifty_scalper_bot.core.app import _next_eod_flatten_time_ist
+from nifty_scalper_bot.core.app import (
+    _next_eod_flatten_time_ist,
+    _schedule_next_eod_flatten,
+)
 
 IST = ZoneInfo("Asia/Kolkata")
 
@@ -62,3 +65,64 @@ def test_eod_timezone_conversion_correctness_no_past():
     target = _next_eod_flatten_time_ist(now)
     assert target == datetime(2026, 7, 13, 15, 24, tzinfo=IST)
     assert target > now.astimezone(IST)
+
+
+class _FakeLoop:
+    def __init__(self) -> None:
+        self.calls = []
+
+    def call_later(self, delay, callback):
+        handle = object()
+        self.calls.append((delay, callback, handle))
+        return handle
+
+
+class _BracketManager:
+    def __init__(self, *, fail: bool = False) -> None:
+        self.calls = 0
+        self.fail = fail
+
+    def eod_flatten_all(self) -> None:
+        self.calls += 1
+        if self.fail:
+            raise RuntimeError("test flatten failure")
+
+
+def test_eod_callback_rearms_for_the_next_trading_day() -> None:
+    loop = _FakeLoop()
+    manager = _BracketManager()
+    observed = iter(
+        [
+            datetime(2026, 7, 10, 15, 0, tzinfo=IST),
+            datetime(2026, 7, 10, 15, 24, 1, tzinfo=IST),
+        ]
+    )
+
+    first = _schedule_next_eod_flatten(
+        loop, manager, now_provider=lambda: next(observed)
+    )
+    assert first is loop.calls[0][2]
+
+    loop.calls[0][1]()
+
+    assert manager.calls == 1
+    assert len(loop.calls) == 2
+    monday_delay, _, _ = loop.calls[1]
+    assert monday_delay == 259199.0
+
+
+def test_eod_callback_rearms_even_if_flatten_raises() -> None:
+    loop = _FakeLoop()
+    manager = _BracketManager(fail=True)
+    observed = iter(
+        [
+            datetime(2026, 7, 10, 15, 0, tzinfo=IST),
+            datetime(2026, 7, 10, 15, 24, 1, tzinfo=IST),
+        ]
+    )
+
+    _schedule_next_eod_flatten(loop, manager, now_provider=lambda: next(observed))
+    loop.calls[0][1]()
+
+    assert manager.calls == 1
+    assert len(loop.calls) == 2


### PR DESCRIPTION
## Root cause
The runtime scheduled `eod_flatten_all` once during process startup. A healthy process surviving into the next trading day had no subsequent EOD flatten callback.

## Behavioral invariant
- Keep one timer owner in `core/app.py`.
- After each EOD callback, schedule the next valid NSE trading day.
- Re-arm even when the flatten call raises, so one failure cannot remove future protection.
- Preserve the existing 15:24 IST holiday/weekend calculation and bracket-manager flatten implementation.

## Validation
- Regression proves Friday callback re-arms Monday.
- Regression proves re-arm occurs after a flatten exception.
- `python -m compileall -q src tests/core/test_eod_flatten_schedule.py`
- `git diff --check`

Required repository CI must pass before merge.