### PR TITLE
fix(data): preserve authoritative websocket quotes

### DIFF
--- a/src/nifty_scalper_bot/data/market_data_manager.py
+++ b/src/nifty_scalper_bot/data/market_data_manager.py
@@ -9028,8 +9028,8 @@ class MarketDataManager:
             "circuit_open": False,
         }
 
-    def _store_tick(self, symbol: str, tick: dict[str, Any]) -> None:
-        """Persist normalized *tick* for *symbol* and refresh derived series."""
+    def _store_tick(self, symbol: str, tick: dict[str, Any]) -> bool:
+        """Persist a current authoritative tick; return whether it was accepted."""
 
         tick.setdefault("received_at", time.time())
         wallclock = self._tick_wallclock(tick) or time.time()
@@ -9043,6 +9043,22 @@ class MarketDataManager:
         now_wall = time.time()
         exchange_ts = self._tick_wallclock(cached_tick) or now_wall
         with self._lock:
+            current_tick = self._latest_ticks.get(symbol)
+            if current_tick is not None and not self._should_replace_cached_tick(
+                symbol, current_tick, cached_tick, now_wall=now_wall
+            ):
+                if hasattr(self, "_candle_metrics"):
+                    self._candle_metrics["tick_cache_authority_reject_total"] += 1
+                self._logger.debug(
+                    "TICK_CACHE_WRITE_REJECTED",
+                    extra={
+                        "event": "tick_cache_write_rejected",
+                        "symbol": symbol,
+                        "current_source": current_tick.get("source"),
+                        "incoming_source": cached_tick.get("source"),
+                    },
+                )
+                return False
             if token_int is not None:
                 self._set_symbol_token_mapping(symbol, token_int, source="store_tick")
             self._latest_ticks[symbol] = cached_tick
@@ -9053,7 +9069,7 @@ class MarketDataManager:
                     "Condition met: mdm_history_append_rejected",
                     extra={"event": "mdm_history_append_rejected", "symbol": symbol},
                 )
-                return
+                return True
             self._raw_tick_history[symbol].append(cached_tick)
             self._ticks_received_per_symbol[symbol] += 1
             self._symbols_with_tick.add(symbol)
@@ -9079,6 +9095,76 @@ class MarketDataManager:
                     "symbol": symbol,
                 },
             )
+        return True
+
+    @staticmethod
+    def _tick_event_wallclock(tick: Mapping[str, Any]) -> float | None:
+        """Return the market-event timestamp used to reject out-of-order writes."""
+
+        for key in (
+            "exchange_timestamp",
+            "last_trade_time",
+            "broker_timestamp",
+            "timestamp",
+            "timestamp_ms",
+            "received_at",
+        ):
+            parsed = MarketDataManager._parse_wallclock(tick.get(key))
+            if parsed is not None:
+                return parsed
+        return None
+
+    @staticmethod
+    def _is_full_websocket_quote(tick: Mapping[str, Any]) -> bool:
+        source = str(tick.get("source") or "").strip().lower()
+        websocket_source = source in {"ws", "ws_full", "full", "websocket"}
+        full_quote = (
+            bool(tick.get("depth_available"))
+            or bool(tick.get("depth"))
+            or str(tick.get("bid_ask_source") or "").lower()
+            in {"market_depth", "ws_full"}
+        )
+        return websocket_source and full_quote
+
+    @staticmethod
+    def _is_rest_tick(tick: Mapping[str, Any]) -> bool:
+        return str(tick.get("source") or "").strip().lower() in {
+            "poll",
+            "rest",
+            "rest_poll",
+            "fallback",
+            "quote",
+            "rest_quote",
+            "rest_ltp",
+            "ltp",
+        }
+
+    def _should_replace_cached_tick(
+        self,
+        symbol: str,
+        current: Mapping[str, Any],
+        incoming: Mapping[str, Any],
+        *,
+        now_wall: float,
+    ) -> bool:
+        """Enforce timestamp and transport authority at the canonical cache writer."""
+
+        current_event = self._tick_event_wallclock(current)
+        incoming_event = self._tick_event_wallclock(incoming)
+        if (
+            current_event is not None
+            and incoming_event is not None
+            and incoming_event < current_event
+        ):
+            return False
+
+        if self._is_full_websocket_quote(current) and self._is_rest_tick(incoming):
+            current_received = self._tick_wallclock(current)
+            if current_received is not None:
+                threshold = self._ltp_stale_threshold_for_symbol(symbol)
+                if max(now_wall - current_received, 0.0) <= threshold:
+                    return False
+        return True
 
     async def _publish_tick_message_with_priority(
         self, bus: Any, msg: Message, *, symbol: str, priority: int, bucket: str
@@ -9454,7 +9540,8 @@ class MarketDataManager:
                     )
             except Exception:
                 pass
-        self._store_tick(symbol, tick)
+        if not self._store_tick(symbol, tick):
+            return
         callbacks: list[TickCallback]
         tick_payload = to_json_safe(dict(tick))
         ts_payload = pd.to_datetime(

--- a/tests/data/test_canonical_history_hydration.py
+++ b/tests/data/test_canonical_history_hydration.py
@@ -471,6 +471,7 @@ def _storage_mdm() -> MarketDataManager:
     mdm._last_tick_wallclock = {}
     mdm._last_quote_ts_ms = {}
     mdm._tick_wallclock = lambda tick: tick.get("timestamp")
+    mdm._ltp_stale_threshold_for_symbol = lambda _symbol: 5.0
     mdm._now_ms = lambda: 1
     mdm._dedupe_symbol_history = lambda *_a, **_k: None
     mdm._refresh_ohlc_from_tick = lambda *_a, **_k: None
@@ -586,6 +587,129 @@ def test_live_tick_writes_raw_tick_history_without_implying_ohlc_ready() -> None
     assert mdm.is_tick_ready("NSE:NIFTY") is True
     assert mdm.is_ohlc_ready("NSE:NIFTY") is False
     assert mdm.is_market_data_ready("NSE:NIFTY") is False
+
+
+def test_fresh_websocket_quote_is_not_overwritten_by_rest_ltp() -> None:
+    mdm = _storage_mdm()
+    now = time.time()
+    ws_tick = {
+        "symbol": "NFO:NIFTY26AUG25000CE",
+        "ltp": 100.0,
+        "bid": 99.9,
+        "ask": 100.1,
+        "depth": {"buy": [{"price": 99.9}], "sell": [{"price": 100.1}]},
+        "tradable_quote": True,
+        "timestamp": now,
+        "received_at": now,
+        "source": "ws_full",
+    }
+    rest_tick = {
+        "symbol": ws_tick["symbol"],
+        "ltp": 100.2,
+        "timestamp": now + 0.1,
+        "received_at": now + 0.1,
+        "source": "rest_poll",
+    }
+
+    mdm._store_tick(ws_tick["symbol"], ws_tick)
+    mdm._store_tick(ws_tick["symbol"], rest_tick)
+
+    assert mdm._latest_ticks[ws_tick["symbol"]] == ws_tick
+    assert mdm._tick_cache[ws_tick["symbol"]] == ws_tick
+    assert len(mdm._raw_tick_history[ws_tick["symbol"]]) == 1
+
+
+def test_stale_websocket_quote_yields_to_rest_fallback() -> None:
+    mdm = _storage_mdm()
+    now = time.time()
+    symbol = "NFO:NIFTY26AUG25000CE"
+    mdm._store_tick(
+        symbol,
+        {
+            "symbol": symbol,
+            "ltp": 100.0,
+            "bid": 99.9,
+            "ask": 100.1,
+            "depth": {"buy": [{"price": 99.9}], "sell": [{"price": 100.1}]},
+            "tradable_quote": True,
+            "timestamp": now - 120.0,
+            "received_at": now - 120.0,
+            "source": "ws_full",
+        },
+    )
+    rest_tick = {
+        "symbol": symbol,
+        "ltp": 100.2,
+        "timestamp": now,
+        "received_at": now,
+        "source": "rest_poll",
+    }
+
+    mdm._store_tick(symbol, rest_tick)
+
+    assert mdm._latest_ticks[symbol] == rest_tick
+    assert len(mdm._raw_tick_history[symbol]) == 2
+
+
+def test_websocket_quote_reclaims_cache_from_rest_fallback() -> None:
+    mdm = _storage_mdm()
+    now = time.time()
+    symbol = "NFO:NIFTY26AUG25000CE"
+    mdm._store_tick(
+        symbol,
+        {
+            "symbol": symbol,
+            "ltp": 100.0,
+            "timestamp": now,
+            "received_at": now,
+            "source": "rest_poll",
+        },
+    )
+    ws_tick = {
+        "symbol": symbol,
+        "ltp": 100.1,
+        "bid": 100.0,
+        "ask": 100.2,
+        "depth_available": True,
+        "tradable_quote": True,
+        "timestamp": now + 0.1,
+        "received_at": now + 0.1,
+        "source": "ws_full",
+    }
+
+    mdm._store_tick(symbol, ws_tick)
+
+    assert mdm._latest_ticks[symbol] == ws_tick
+    assert len(mdm._raw_tick_history[symbol]) == 2
+
+
+def test_out_of_order_tick_does_not_replace_newer_cache_value() -> None:
+    mdm = _storage_mdm()
+    now = time.time()
+    symbol = "NFO:NIFTY26AUG25000CE"
+    current = {
+        "symbol": symbol,
+        "ltp": 100.1,
+        "timestamp": now,
+        "received_at": now,
+        "source": "ws",
+    }
+    mdm._store_tick(symbol, current)
+
+    accepted = mdm._store_tick(
+        symbol,
+        {
+            "symbol": symbol,
+            "ltp": 99.8,
+            "timestamp": now - 1.0,
+            "received_at": now + 0.1,
+            "source": "ws",
+        },
+    )
+
+    assert accepted is False
+    assert mdm._latest_ticks[symbol] == current
+    assert len(mdm._raw_tick_history[symbol]) == 1
 
 
 def _fetch_history_mdm(historical_data) -> MarketDataManager:


### PR DESCRIPTION
## Root cause
`MarketDataManager._store_tick` unconditionally replaced the canonical quote caches, so REST/LTP fallback could overwrite a still-fresh FULL-depth WebSocket quote. The downstream execution consumer added quote ranking, but cache readers and tick subscribers still received the degraded value.

## Fix
- make `_store_tick` the timestamp/source authority boundary
- reject out-of-order writes
- retain fresh FULL-depth WebSocket quotes against REST fallback
- allow REST takeover once WebSocket data is stale
- allow WebSocket data to reclaim the cache after fallback
- stop rejected writes before callback/DataHub publication
- retain downstream execution ranking as defense-in-depth

## Validation
- regression coverage for fresh WS retention, stale REST fallback, WS recovery, and out-of-order rejection
- `python -m compileall -q src tests/data/test_canonical_history_hydration.py`
- `git diff --check`

Draft until required CI is green.