### PR TITLE
fix(risk): align premium geometry with net costs

### DIFF
--- a/src/nifty_scalper_bot/risk/net_rr_gate.py
+++ b/src/nifty_scalper_bot/risk/net_rr_gate.py
@@ -59,7 +59,9 @@ def _price(signal: Any, *names: str) -> float | None:
     return None
 
 
-def _half_spread(signal: Any, entry: float) -> float:
+def estimate_half_spread(signal: Any, entry: float) -> float:
+    """Return per-unit half-spread using the final gate's quote fallback rules."""
+
     metadata = _metadata(signal)
     bid = _positive(metadata.get("bid") or metadata.get("best_bid"))
     ask = _positive(metadata.get("ask") or metadata.get("best_ask"))
@@ -134,7 +136,7 @@ def evaluate_final_net_rr(signal: Any) -> NetRRResult | None:
     if not (stop < entry < target):
         return None
 
-    half_spread = _half_spread(signal, entry)
+    half_spread = estimate_half_spread(signal, entry)
     target_cost = estimate_round_trip_cost(
         entry_price=entry,
         exit_price=target,
@@ -206,7 +208,7 @@ def minimum_target_for_net_rr(signal: Any, *, tick_size: float = 0.05) -> float 
     if max_tick_target <= target:
         return None
 
-    half_spread = _half_spread(signal, entry)
+    half_spread = estimate_half_spread(signal, entry)
     stop_cost = estimate_round_trip_cost(
         entry_price=entry,
         exit_price=stop,
@@ -249,4 +251,94 @@ def minimum_target_for_net_rr(signal: Any, *, tick_size: float = 0.05) -> float 
     return candidate
 
 
-__all__ = ["NetRRResult", "evaluate_final_net_rr", "minimum_target_for_net_rr"]
+def minimum_risk_distance_for_net_rr(
+    *,
+    entry_price: float,
+    gross_rr: float,
+    quantity: int,
+    half_spread: float,
+    tick_size: float = 0.05,
+    maximum_distance: float | None = None,
+) -> float | None:
+    """Return the smallest stop distance whose target clears the final net-RR gate.
+
+    Both target and stop outcomes use :func:`estimate_round_trip_cost`, so the
+    geometry floor and final entry gate cannot drift onto different economics.
+    ``None`` means no viable long-option distance exists inside the supplied cap.
+    """
+
+    try:
+        entry = float(entry_price)
+        rr = float(gross_rr)
+        qty = int(quantity)
+        spread = max(0.0, float(half_spread))
+        tick = float(tick_size)
+    except (TypeError, ValueError, OverflowError):
+        return None
+    if not all(math.isfinite(value) for value in (entry, rr, spread, tick)):
+        return None
+    if entry <= tick or rr <= 0.0 or qty <= 0 or tick <= 0.0:
+        return None
+
+    maximum = entry - tick
+    if maximum_distance is not None:
+        try:
+            configured_maximum = float(maximum_distance)
+        except (TypeError, ValueError, OverflowError):
+            return None
+        if not math.isfinite(configured_maximum):
+            return None
+        maximum = min(maximum, configured_maximum)
+    maximum = math.floor((maximum + 1e-12) / tick) * tick
+    if maximum < tick:
+        return None
+
+    minimum = _minimum_net_rr()
+
+    def _net_rr_at(distance: float) -> float:
+        stop = entry - distance
+        target = entry + distance * rr
+        if stop <= 0.0 or target <= entry:
+            return 0.0
+        target_cost = estimate_round_trip_cost(
+            entry_price=entry,
+            exit_price=target,
+            quantity=qty,
+            half_spread=spread,
+        ).total
+        stop_cost = estimate_round_trip_cost(
+            entry_price=entry,
+            exit_price=stop,
+            quantity=qty,
+            half_spread=spread,
+        ).total
+        net_reward = distance * rr * qty - target_cost
+        net_risk = distance * qty + stop_cost
+        return net_reward / net_risk if net_reward > 0.0 and net_risk > 0.0 else 0.0
+
+    if _net_rr_at(maximum) + 1e-12 < minimum:
+        return None
+
+    low = 0.0
+    high = maximum
+    for _ in range(60):
+        midpoint = (low + high) / 2.0
+        if _net_rr_at(midpoint) >= minimum:
+            high = midpoint
+        else:
+            low = midpoint
+
+    candidate = math.ceil((high - 1e-12) / tick) * tick
+    candidate = min(candidate, maximum)
+    if _net_rr_at(candidate) + 1e-12 < minimum:
+        return None
+    return round(candidate, 10)
+
+
+__all__ = [
+    "NetRRResult",
+    "estimate_half_spread",
+    "evaluate_final_net_rr",
+    "minimum_risk_distance_for_net_rr",
+    "minimum_target_for_net_rr",
+]

--- a/src/nifty_scalper_bot/strategies/premium_risk_geometry.py
+++ b/src/nifty_scalper_bot/strategies/premium_risk_geometry.py
@@ -221,12 +221,16 @@ def apply_cost_aware_risk_floor(
     entry = float(entry_price or 0.0)
     action = str(getattr(signal, "action", "") or "").upper()
     symbol = str(getattr(signal, "symbol", "") or "").upper()
+    contract = symbol.split(":", 1)[-1]
+    resolved_contract = bool(
+        contract.endswith(("CE", "PE")) and any(char.isdigit() for char in contract[:-2])
+    )
     metadata = _metadata(signal)
     if (
         entry <= 0.0
         or int(quantity or 0) <= 0
         or action != "BUY"
-        or not symbol.endswith(("CE", "PE"))
+        or not resolved_contract
         or str(metadata.get("bracket_anchor_mode") or "distance").lower()
         != "distance"
     ):

--- a/src/nifty_scalper_bot/strategies/premium_risk_geometry.py
+++ b/src/nifty_scalper_bot/strategies/premium_risk_geometry.py
@@ -11,6 +11,11 @@ import dataclasses
 from contextlib import suppress
 from typing import Any, Mapping
 
+from nifty_scalper_bot.risk.net_rr_gate import (
+    estimate_half_spread,
+    minimum_risk_distance_for_net_rr,
+)
+
 _TICK_SIZE = 0.05
 
 
@@ -204,6 +209,74 @@ def apply_premium_risk_contract(signal: Any, premium: float) -> Any:
     )
 
 
+def apply_cost_aware_risk_floor(
+    signal: Any,
+    *,
+    entry_price: float,
+    quantity: int,
+    half_spread: float | None = None,
+) -> Any:
+    """Apply the minimum viable distance to distance-anchored long options."""
+
+    entry = float(entry_price or 0.0)
+    action = str(getattr(signal, "action", "") or "").upper()
+    symbol = str(getattr(signal, "symbol", "") or "").upper()
+    metadata = _metadata(signal)
+    if (
+        entry <= 0.0
+        or int(quantity or 0) <= 0
+        or action != "BUY"
+        or not symbol.endswith(("CE", "PE"))
+        or str(metadata.get("bracket_anchor_mode") or "distance").lower()
+        != "distance"
+    ):
+        return signal
+
+    stop = _positive_float(getattr(signal, "stop_loss", None))
+    target = _positive_float(getattr(signal, "take_profit", None))
+    if stop is None or target is None or not (0.0 < stop < entry < target):
+        return signal
+    current_distance = entry - stop
+    rr = _positive_float(metadata.get("premium_target_rr"))
+    if rr is None:
+        rr = (target - entry) / current_distance
+    spread = (
+        max(0.0, float(half_spread))
+        if half_spread is not None
+        else estimate_half_spread(signal, entry)
+    )
+    floor = minimum_risk_distance_for_net_rr(
+        entry_price=entry,
+        gross_rr=rr,
+        quantity=int(quantity),
+        half_spread=spread,
+        maximum_distance=entry * 0.60,
+    )
+    updated = dict(metadata)
+    updated["premium_cost_floor_distance"] = floor
+    updated["premium_cost_floor_quantity"] = int(quantity)
+    updated["premium_cost_floor_half_spread"] = spread
+    if floor is None:
+        updated["premium_cost_floor_viable"] = False
+        return dataclasses.replace(signal, metadata=updated)
+    updated["premium_cost_floor_viable"] = True
+    if current_distance + 1e-9 >= floor:
+        updated["premium_cost_floor_applied"] = False
+        return dataclasses.replace(signal, metadata=updated)
+
+    updated["premium_cost_floor_applied"] = True
+    updated["premium_cost_floor_original_distance"] = current_distance
+    updated["premium_stop_distance"] = floor
+    updated["premium_risk_distance"] = floor
+    updated["premium_risk_source"] = "cost_aware_minimum"
+    return dataclasses.replace(
+        signal,
+        stop_loss=max(_TICK_SIZE, entry - floor),
+        take_profit=entry + floor * rr,
+        metadata=updated,
+    )
+
+
 def validate_option_premium_geometry(
     self: Any,
     signal: Any,
@@ -369,6 +442,7 @@ def anchor_option_geometry_to_execution(
 
 __all__ = [
     "anchor_option_geometry_to_execution",
+    "apply_cost_aware_risk_floor",
     "apply_premium_risk_contract",
     "validate_option_premium_geometry",
 ]

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -147,6 +147,7 @@ from nifty_scalper_bot.strategies.market_regime_engine import (
 )
 from nifty_scalper_bot.strategies.premium_risk_geometry import (
     anchor_option_geometry_to_execution,
+    apply_cost_aware_risk_floor,
     apply_premium_risk_contract,
     validate_option_premium_geometry,
 )
@@ -19915,6 +19916,64 @@ class StrategyRunner:
                     price = None
             if not price or price <= 0:
                 price = trade_price if trade_price > 0 else None
+
+            if price is not None and price > 0:
+                try:
+                    quote_bid = float(selected_snapshot.get("bid") or 0.0)
+                    quote_ask = float(selected_snapshot.get("ask") or 0.0)
+                except (TypeError, ValueError):
+                    quote_bid = quote_ask = 0.0
+                quote_half_spread = (
+                    (quote_ask - quote_bid) / 2.0
+                    if quote_bid > 0.0 and quote_ask >= quote_bid
+                    else None
+                )
+                signal = apply_cost_aware_risk_floor(
+                    signal,
+                    entry_price=price,
+                    quantity=qty,
+                    half_spread=quote_half_spread,
+                )
+                metadata = dict(signal.metadata or {})
+                if metadata.get("premium_cost_floor_viable") is False:
+                    return _reject_after_dedup(
+                        reason="premium_cost_geometry_unviable",
+                        details={
+                            "entry_price": price,
+                            "quantity": qty,
+                            "gross_rr": metadata.get("premium_target_rr"),
+                            "maximum_risk_distance": price * 0.60,
+                        },
+                    )
+                if metadata.get("premium_cost_floor_applied"):
+                    self._logger.info(
+                        "PREMIUM_COST_FLOOR_APPLIED symbol=%s entry=%.2f quantity=%s original_distance=%.2f viable_distance=%.2f half_spread=%.4f",
+                        trade_symbol or base_symbol,
+                        price,
+                        qty,
+                        float(
+                            metadata.get("premium_cost_floor_original_distance")
+                            or 0.0
+                        ),
+                        float(metadata.get("premium_cost_floor_distance") or 0.0),
+                        float(metadata.get("premium_cost_floor_half_spread") or 0.0),
+                        extra={
+                            "event": "PREMIUM_COST_FLOOR_APPLIED",
+                            "symbol": trade_symbol or base_symbol,
+                            "entry_price": price,
+                            "quantity": qty,
+                            "gross_rr": metadata.get("premium_target_rr"),
+                            "original_distance": metadata.get(
+                                "premium_cost_floor_original_distance"
+                            ),
+                            "viable_distance": metadata.get(
+                                "premium_cost_floor_distance"
+                            ),
+                            "half_spread": metadata.get(
+                                "premium_cost_floor_half_spread"
+                            ),
+                        },
+                    )
 
             # Stop-loss is mandatory for all intraday entries
             stop_loss = signal.stop_loss

--- a/tests/risk/test_final_net_rr_gate.py
+++ b/tests/risk/test_final_net_rr_gate.py
@@ -8,7 +8,10 @@ from nifty_scalper_bot.risk.entry_guard_patch import (
     _net_rr_block_reason,
     _real_broker_live,
 )
-from nifty_scalper_bot.risk.net_rr_gate import evaluate_final_net_rr
+from nifty_scalper_bot.risk.net_rr_gate import (
+    evaluate_final_net_rr,
+    minimum_risk_distance_for_net_rr,
+)
 from nifty_scalper_bot.risk.risk_manager import OrderSignal
 
 
@@ -34,6 +37,67 @@ def test_final_net_rr_accepts_economic_trade(monkeypatch) -> None:
     assert result.net_rr >= 1.5
     assert result.net_reward < result.gross_reward
     assert result.net_risk > result.gross_risk
+
+
+@pytest.mark.parametrize(
+    ("entry", "gross_rr", "expected_distance"),
+    (
+        (60.0, 2.0, 5.40),
+        (120.0, 2.0, 6.10),
+        (250.0, 2.0, 7.65),
+        (60.0, 1.8, 8.95),
+        (120.0, 1.8, 10.15),
+        (250.0, 1.8, 12.70),
+    ),
+)
+def test_minimum_risk_distance_uses_same_cost_integral_as_final_gate(
+    monkeypatch, entry: float, gross_rr: float, expected_distance: float
+) -> None:
+    monkeypatch.setenv("MIN_NET_REWARD_RISK", "1.5")
+    distance = minimum_risk_distance_for_net_rr(
+        entry_price=entry,
+        gross_rr=gross_rr,
+        quantity=65,
+        half_spread=0.1,
+    )
+
+    assert distance is not None
+    assert distance == pytest.approx(expected_distance)
+    viable = _signal(
+        target=entry + distance * gross_rr,
+        stop=entry - distance,
+        bid=entry - 0.1,
+        ask=entry + 0.1,
+    )
+    viable.entry_price = entry
+    result = evaluate_final_net_rr(viable)
+    assert result is not None and result.allowed is True
+
+    one_tick_tighter = _signal(
+        target=entry + (distance - 0.05) * gross_rr,
+        stop=entry - (distance - 0.05),
+        bid=entry - 0.1,
+        ask=entry + 0.1,
+    )
+    one_tick_tighter.entry_price = entry
+    tighter_result = evaluate_final_net_rr(one_tick_tighter)
+    assert tighter_result is not None and tighter_result.allowed is False
+
+
+def test_minimum_risk_distance_fails_when_gross_rr_cannot_clear_net_threshold(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("MIN_NET_REWARD_RISK", "1.5")
+
+    assert (
+        minimum_risk_distance_for_net_rr(
+            entry_price=100.0,
+            gross_rr=1.5,
+            quantity=65,
+            half_spread=0.0,
+        )
+        is None
+    )
 
 
 def test_final_net_rr_rejects_grossly_valid_but_net_weak_trade(monkeypatch) -> None:

--- a/tests/strategies/test_premium_risk_geometry.py
+++ b/tests/strategies/test_premium_risk_geometry.py
@@ -6,8 +6,10 @@ import sys
 
 import pytest
 
+from nifty_scalper_bot.risk.net_rr_gate import evaluate_final_net_rr
 from nifty_scalper_bot.strategies.premium_risk_geometry import (
     anchor_option_geometry_to_execution,
+    apply_cost_aware_risk_floor,
     apply_premium_risk_contract,
     validate_option_premium_geometry,
 )
@@ -39,6 +41,58 @@ def test_absolute_premium_distance_builds_buy_geometry() -> None:
     assert result.stop_loss == 92.0
     assert result.take_profit == 116.0
     assert result.metadata["premium_risk_source"] == "premium_stop_distance"
+
+
+def test_cost_floor_replaces_unviable_percentage_geometry(monkeypatch) -> None:
+    monkeypatch.setenv("MIN_NET_REWARD_RISK", "1.5")
+    signal = apply_premium_risk_contract(
+        _signal(
+            premium_stop_distance=1.2,
+            premium_target_rr=1.8,
+            invalidation_level_domain="option_premium",
+            bracket_anchor_mode="distance",
+            bid=59.9,
+            ask=60.1,
+        ),
+        60.0,
+    )
+
+    result = apply_cost_aware_risk_floor(
+        signal,
+        entry_price=60.0,
+        quantity=65,
+        half_spread=0.1,
+    )
+
+    assert 8.4 < 60.0 - result.stop_loss < 9.6
+    assert (result.take_profit - 60.0) / (60.0 - result.stop_loss) == pytest.approx(
+        1.8
+    )
+    assert result.metadata["premium_cost_floor_applied"] is True
+    assert result.metadata["premium_cost_floor_original_distance"] == pytest.approx(
+        1.2
+    )
+    net_rr = evaluate_final_net_rr(result)
+    assert net_rr is not None and net_rr.allowed is True
+
+
+def test_cost_floor_does_not_move_absolute_technical_geometry() -> None:
+    signal = _signal(
+        stop_loss=55.0,
+        take_profit=70.0,
+        bracket_anchor_mode="absolute_level",
+        premium_target_rr=2.0,
+        invalidation_level_domain="option_premium",
+    )
+
+    result = apply_cost_aware_risk_floor(
+        signal,
+        entry_price=60.0,
+        quantity=65,
+        half_spread=0.0,
+    )
+
+    assert result is signal
 
 
 def test_absolute_distance_is_not_replaced_by_legacy_percentage() -> None:


### PR DESCRIPTION
## Root cause
The elite-strategy and canonical percentage/ATR floors were materialized before final broker-unit quantity and live spread were known. The final net-R:R gate then evaluated the resulting geometry with the transaction-cost model, so the two contracts could disagree arithmetically.

## Fix
- derive the minimum viable distance with the same target/stop cost integral used by the final net-R:R gate
- apply that floor centrally only after final lot-size conversion and selected-quote spread are known
- preserve each strategy's gross target R:R
- preserve absolute technical invalidations
- cap the economic floor at the existing 60%-of-premium trusted-geometry limit and fail closed if no viable distance exists
- retain the final live gate as authority for quote changes between planning and submission

## Exact regression evidence (65 units, ₹0.10 half-spread, net R:R 1.5)
- 2.0R: ₹5.40 / ₹6.10 / ₹7.65 at premiums ₹60 / ₹120 / ₹250
- 1.8R: ₹8.95 / ₹10.15 / ₹12.70 at premiums ₹60 / ₹120 / ₹250
- one tick below every computed floor fails the same final gate

## Validation
- cost-integral smoke tests passed for all reference economics
- central geometry integration smoke test passed
- `python -m compileall -q src ...`
- `git diff --check`

Draft until all required CI is green.