### PR TITLE
fix(risk): score candidate edge on net risk

### DIFF
--- a/src/nifty_scalper_bot/risk/cost_model.py
+++ b/src/nifty_scalper_bot/risk/cost_model.py
@@ -15,6 +15,7 @@ COST_SEBI_PCT, COST_GST_PCT, COST_STAMP_BUY_PCT, MIN_EDGE_MULTIPLE.
 
 from __future__ import annotations
 
+import math
 import os
 from dataclasses import dataclass
 
@@ -36,8 +37,34 @@ class CostBreakdown:
     cost_per_unit: float  # total cost expressed in option-premium points per unit
 
 
+@dataclass(slots=True, frozen=True)
+class NetRewardRiskBreakdown:
+    """Cost-adjusted reward/risk across both target and stop outcomes."""
+
+    allowed: bool
+    net_rr: float
+    minimum: float
+    gross_reward: float
+    gross_risk: float
+    net_reward: float
+    net_risk: float
+    target_cost: CostBreakdown
+    stop_cost: CostBreakdown
+
+
 def _rate(name: str, default: float) -> float:
     return parse_float_env(os.getenv(name), default)
+
+
+def minimum_net_reward_risk() -> float:
+    """Return the single finite, non-negative net-R:R threshold."""
+
+    raw = os.getenv("MIN_NET_REWARD_RISK", "1.5")
+    try:
+        parsed = float(raw or 1.5)
+    except (TypeError, ValueError):
+        return 1.5
+    return max(0.0, parsed) if math.isfinite(parsed) else 1.5
 
 
 def estimate_round_trip_cost(
@@ -105,3 +132,48 @@ def passes_cost_edge_gate(
     min_multiple = _rate("MIN_EDGE_MULTIPLE", 2.0)
     edge_multiple = (gross_profit / breakdown.total) if breakdown.total > 0 else 0.0
     return edge_multiple >= min_multiple, edge_multiple, breakdown
+
+
+def evaluate_net_reward_risk(
+    *,
+    entry_price: float,
+    stop_price: float,
+    target_price: float,
+    quantity: int,
+    half_spread: float = 0.0,
+) -> NetRewardRiskBreakdown:
+    """Evaluate long-option target reward against stop risk after both costs."""
+
+    entry = float(entry_price)
+    stop = float(stop_price)
+    target = float(target_price)
+    qty = max(1, int(quantity))
+    target_cost = estimate_round_trip_cost(
+        entry_price=entry,
+        exit_price=target,
+        quantity=qty,
+        half_spread=half_spread,
+    )
+    stop_cost = estimate_round_trip_cost(
+        entry_price=entry,
+        exit_price=stop,
+        quantity=qty,
+        half_spread=half_spread,
+    )
+    gross_reward = max(0.0, target - entry) * qty
+    gross_risk = max(0.0, entry - stop) * qty
+    net_reward = gross_reward - target_cost.total
+    net_risk = gross_risk + stop_cost.total
+    net_rr = net_reward / net_risk if net_reward > 0.0 and net_risk > 0.0 else 0.0
+    minimum = minimum_net_reward_risk()
+    return NetRewardRiskBreakdown(
+        allowed=net_rr >= minimum,
+        net_rr=net_rr,
+        minimum=minimum,
+        gross_reward=gross_reward,
+        gross_risk=gross_risk,
+        net_reward=net_reward,
+        net_risk=net_risk,
+        target_cost=target_cost,
+        stop_cost=stop_cost,
+    )

--- a/src/nifty_scalper_bot/risk/net_rr_gate.py
+++ b/src/nifty_scalper_bot/risk/net_rr_gate.py
@@ -8,7 +8,11 @@ from contextlib import suppress
 from dataclasses import dataclass
 from typing import Any, Mapping
 
-from nifty_scalper_bot.risk.cost_model import estimate_round_trip_cost
+from nifty_scalper_bot.risk.cost_model import (
+    estimate_round_trip_cost,
+    evaluate_net_reward_risk,
+    minimum_net_reward_risk,
+)
 
 
 @dataclass(slots=True, frozen=True)
@@ -85,15 +89,9 @@ def estimate_half_spread(signal: Any, entry: float) -> float:
 
 
 def _minimum_net_rr() -> float:
-    """Return a finite non-negative threshold; malformed config never bypasses."""
-    raw = os.getenv("MIN_NET_REWARD_RISK", "1.5")
-    try:
-        parsed = float(raw or 1.5)
-    except (TypeError, ValueError):
-        return 1.5
-    if not math.isfinite(parsed):
-        return 1.5
-    return max(0.0, parsed)
+    """Compatibility wrapper for the canonical cost-model threshold owner."""
+
+    return minimum_net_reward_risk()
 
 
 def _max_target_uplift_r() -> float:
@@ -137,34 +135,23 @@ def evaluate_final_net_rr(signal: Any) -> NetRRResult | None:
         return None
 
     half_spread = estimate_half_spread(signal, entry)
-    target_cost = estimate_round_trip_cost(
+    economics = evaluate_net_reward_risk(
         entry_price=entry,
-        exit_price=target,
+        stop_price=stop,
+        target_price=target,
         quantity=quantity,
         half_spread=half_spread,
-    ).total
-    stop_cost = estimate_round_trip_cost(
-        entry_price=entry,
-        exit_price=stop,
-        quantity=quantity,
-        half_spread=half_spread,
-    ).total
-    gross_reward = (target - entry) * quantity
-    gross_risk = (entry - stop) * quantity
-    net_reward = gross_reward - target_cost
-    net_risk = gross_risk + stop_cost
-    net_rr = net_reward / net_risk if net_reward > 0.0 and net_risk > 0.0 else 0.0
-    minimum = _minimum_net_rr()
+    )
     return NetRRResult(
-        allowed=net_rr >= minimum,
-        net_rr=net_rr,
-        minimum=minimum,
-        gross_reward=gross_reward,
-        gross_risk=gross_risk,
-        net_reward=net_reward,
-        net_risk=net_risk,
-        target_cost=target_cost,
-        stop_cost=stop_cost,
+        allowed=economics.allowed,
+        net_rr=economics.net_rr,
+        minimum=economics.minimum,
+        gross_reward=economics.gross_reward,
+        gross_risk=economics.gross_risk,
+        net_reward=economics.net_reward,
+        net_risk=economics.net_risk,
+        target_cost=economics.target_cost.total,
+        stop_cost=economics.stop_cost.total,
         half_spread=half_spread,
     )
 

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -18843,6 +18843,9 @@ class StrategyRunner:
                             direction_bias=option_side,
                             atm_strike=atm_strike,
                             snapshots=valid_snapshots,
+                            gross_rr=float(
+                                metadata.get("premium_target_rr") or 2.0
+                            ),
                         )
                     )
                     candidate, candidate_capacity_decisions = (

--- a/src/nifty_scalper_bot/strategies/trade_selector.py
+++ b/src/nifty_scalper_bot/strategies/trade_selector.py
@@ -12,8 +12,9 @@ from nifty_scalper_bot.execution.quote_readiness import (
     resolve_real_tick_count,
     resolve_tick_age_ms,
 )
-from nifty_scalper_bot.risk.cost_model import passes_cost_edge_gate
+from nifty_scalper_bot.risk.cost_model import evaluate_net_reward_risk
 from nifty_scalper_bot.risk.expiry_gate import expiry_theta_block, midday_pause_block
+from nifty_scalper_bot.risk.net_rr_gate import minimum_risk_distance_for_net_rr
 from nifty_scalper_bot.strategies.option_signal import score_option_candidate
 from nifty_scalper_bot.utils.logging import get_logger, log_once_or_throttled
 
@@ -110,7 +111,7 @@ class TradeCandidateSelector:
             return 7.0, 15.0, 1
         return 5.0, 10.0, 1
 
-    def select_ranked_candidates(self, *, direction_bias: str, atm_strike: int, snapshots: list[dict[str, Any]]) -> list[TradeCandidate]:
+    def select_ranked_candidates(self, *, direction_bias: str, atm_strike: int, snapshots: list[dict[str, Any]], gross_rr: float = 2.0) -> list[TradeCandidate]:
         blocked, gate_reason = expiry_theta_block()
         if not blocked:
             blocked, gate_reason = midday_pause_block()
@@ -139,7 +140,7 @@ class TradeCandidateSelector:
             min_ticks = max(min_ticks, parse_int_env(os.getenv('LIVE_CANDIDATE_MIN_REAL_TICKS_60S'), 2))
         allow_ltp_only = (not is_live) and os.getenv('ALLOW_LTP_ONLY_CANDIDATE', 'false').lower() in {'1', 'true', 'yes', 'on'}
         ranked: list[TradeCandidate] = []
-        rejects = {'side_mismatch': 0, 'atm_distance': 0, 'missing_bid_ask': 0, 'live_bid_ask_required': 0, 'premium_out_of_range': 0, 'spread_too_wide': 0, 'tick_stale': 0, 'insufficient_ticks': 0, 'invalid_rr': 0, 'cost_edge_insufficient': 0}
+        rejects = {'side_mismatch': 0, 'atm_distance': 0, 'missing_bid_ask': 0, 'live_bid_ask_required': 0, 'premium_out_of_range': 0, 'spread_too_wide': 0, 'tick_stale': 0, 'insufficient_ticks': 0, 'invalid_rr': 0, 'net_rr_insufficient': 0}
         ltp_only_used = 0
         for s in snapshots:
             side = str(s.get('side') or s.get('option_type') or '').upper()
@@ -242,25 +243,32 @@ class TradeCandidateSelector:
                 ltp_only_used += 1
                 reasons.append('ltp_only_fallback')
             atr = self._f(s.get('atr_option')) or max(entry * 0.012, max((ask or 0.0) - (bid or 0.0), 0.0) * 1.5, 1.0)
+            half_spread = (((ask or 0.0) - (bid or 0.0)) / 2.0) if has_bid_ask else entry * 0.003
+            strategy_rr = max(0.0, float(gross_rr or 0.0))
+            economic_floor = minimum_risk_distance_for_net_rr(entry_price=entry, gross_rr=strategy_rr, quantity=parse_int_env(os.getenv('NIFTY_LOT_SIZE'), 65), half_spread=max(0.0, half_spread), maximum_distance=entry * 0.60)
+            if economic_floor is None:
+                rejects['net_rr_insufficient'] += 1
+                self._log_reject("net_rr_insufficient", symbol, throttle_key_parts=("net_rr_insufficient", symbol), entry=entry, gross_rr=strategy_rr, reason="no_viable_distance")
+                continue
             risk = max(atr * 0.8, entry * 0.08, 5.0)
             risk = min(18.0, max(4.0, risk))
+            risk = max(risk, economic_floor)
             sl = entry - risk
             if sl <= 0:
                 continue
-            target = entry + max(1.6 * risk, atr * 1.2)
+            target = entry + strategy_rr * risk
             rr = (target - entry) / (entry - sl)
             if rr < 1.5:
                 rejects['invalid_rr'] += 1
                 self._log_reject("invalid_rr", symbol, throttle_key_parts=("invalid_rr", symbol), entry=entry, stop_loss=sl, target=target, rr=rr, min_rr=1.5)
                 continue
-            half_spread = (((ask or 0.0) - (bid or 0.0)) / 2.0) if has_bid_ask else entry * 0.003
             lot_size = parse_int_env(os.getenv('NIFTY_LOT_SIZE'), 65)
-            cost_ok, edge_multiple, cost = passes_cost_edge_gate(entry_price=entry, target_price=target, quantity=lot_size, half_spread=max(0.0, half_spread))
-            if not cost_ok:
-                rejects['cost_edge_insufficient'] += 1
-                self._log_reject("cost_edge_insufficient", symbol, throttle_key_parts=("cost_edge_insufficient", symbol), entry=entry, target=target, edge_multiple=round(edge_multiple, 2), round_trip_cost=round(cost.total, 2), cost_per_unit=round(cost.cost_per_unit, 3))
+            economics = evaluate_net_reward_risk(entry_price=entry, stop_price=sl, target_price=target, quantity=lot_size, half_spread=max(0.0, half_spread))
+            if not economics.allowed:
+                rejects['net_rr_insufficient'] += 1
+                self._log_reject("net_rr_insufficient", symbol, throttle_key_parts=("net_rr_insufficient", symbol), entry=entry, stop_loss=sl, target=target, net_rr=round(economics.net_rr, 2), min_net_rr=economics.minimum, target_cost=round(economics.target_cost.total, 2), stop_cost=round(economics.stop_cost.total, 2))
                 continue
-            reasons.append(f'cost_edge_{edge_multiple:.1f}x')
+            reasons.append(f'net_rr_{economics.net_rr:.1f}x')
             liquidity = 5.0 if spread_pct is None else max(0.0, 10.0 - spread_pct)
             micro = min(10.0, real_ticks * 3.0)
             score = 6.0 + liquidity * 0.2 + micro * 0.2 - atm_distance * 0.5 - score_penalty

--- a/tests/risk/test_cost_model.py
+++ b/tests/risk/test_cost_model.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 from nifty_scalper_bot.risk.cost_model import (
+    evaluate_net_reward_risk,
     estimate_round_trip_cost,
+    minimum_net_reward_risk,
     passes_cost_edge_gate,
 )
 
@@ -55,3 +57,43 @@ def test_env_override_min_edge(monkeypatch) -> None:
         entry_price=120, target_price=124, quantity=65, half_spread=0.3
     )
     assert ok
+
+
+def test_cost_adjusted_rr_counts_both_win_and_stop_outcomes(monkeypatch) -> None:
+    monkeypatch.setenv("MIN_NET_REWARD_RISK", "1.5")
+    legacy_ok, legacy_edge, _ = passes_cost_edge_gate(
+        entry_price=100.0,
+        target_price=103.6,
+        quantity=65,
+        half_spread=0.1,
+    )
+
+    result = evaluate_net_reward_risk(
+        entry_price=100.0,
+        stop_price=98.0,
+        target_price=103.6,
+        quantity=65,
+        half_spread=0.1,
+    )
+
+    assert legacy_ok is True and legacy_edge > 2.0
+    assert result.allowed is False
+    assert result.net_rr < 1.5
+    assert result.net_reward < result.gross_reward
+    assert result.net_risk > result.gross_risk
+
+
+def test_cost_adjusted_rr_and_threshold_share_one_owner(monkeypatch) -> None:
+    monkeypatch.setenv("MIN_NET_REWARD_RISK", "1.25")
+
+    result = evaluate_net_reward_risk(
+        entry_price=100.0,
+        stop_price=90.0,
+        target_price=120.0,
+        quantity=65,
+        half_spread=0.1,
+    )
+
+    assert minimum_net_reward_risk() == 1.25
+    assert result.minimum == 1.25
+    assert result.allowed is (result.net_rr >= 1.25)

--- a/tests/strategies/test_trade_selector_quality.py
+++ b/tests/strategies/test_trade_selector_quality.py
@@ -1,3 +1,4 @@
+from nifty_scalper_bot.risk.cost_model import evaluate_net_reward_risk
 from nifty_scalper_bot.strategies.trade_selector import TradeCandidateSelector
 
 
@@ -20,6 +21,19 @@ def test_wide_spread_rejected():
 def test_valid_selected_and_rr():
     r = TradeCandidateSelector().select_ranked_candidates(direction_bias='CE', atm_strike=22000, snapshots=[base()])
     assert r and r[0].rr and r[0].rr >= 1.5
+
+    candidate = r[0]
+    assert candidate.entry_price is not None
+    assert candidate.stop_loss is not None
+    assert candidate.target is not None
+    economics = evaluate_net_reward_risk(
+        entry_price=candidate.entry_price,
+        stop_price=candidate.stop_loss,
+        target_price=candidate.target,
+        quantity=65,
+        half_spread=1.0,
+    )
+    assert economics.allowed is True
 
 
 def test_far_otm_rejected():


### PR DESCRIPTION
## Root cause
Candidate selection used gross profit at target divided by target-outcome cost. It never priced the stop outcome, so it could report strong edge for geometry whose final cost-adjusted reward/risk was below the live threshold.

## Fix
- add one cost-model calculation for target net reward and stop net risk
- make `MIN_NET_REWARD_RISK` the shared finite threshold owner used by candidate and final gates
- pass each strategy's declared gross R:R into candidate selection
- derive candidate risk from the same minimum viable distance used by final premium geometry
- replace production `cost_edge_*` evidence with true `net_rr_*` evidence
- preserve the legacy helper for compatibility; it is no longer used by production selection

## Regression
A 100/98/103.6 geometry reports 3.08x under the old win-side proxy but only 0.77 net R:R. The new path rejects it and prices both target and stop costs.

## Validation
- compileall and diff checks clean
- isolated cost-model checks passed
- required CI pending

Draft until all required CI is green.