### PR TITLE
fix(execution): centralize fill reanchor geometry

### DIFF
--- a/src/nifty_scalper_bot/execution/bracket_core.py
+++ b/src/nifty_scalper_bot/execution/bracket_core.py
@@ -1524,27 +1524,38 @@ class BracketManager:
                 old_price = bracket.entry_price
                 bracket.entry_price = fill_price
 
-                # Adjust SL/TP if they were calculated from expected price
+                # Distance-anchored plans preserve their absolute risk/reward
+                # distances at the broker fill. Absolute technical levels do
+                # not move. This is the sole post-fill geometry transform.
                 if old_price > 0 and old_price != fill_price:
-                    price_diff_pct = (fill_price - old_price) / old_price
+                    provenance = bracket.trade_provenance or {}
+                    anchor_mode = str(
+                        provenance.get("bracket_anchor_mode") or "distance"
+                    ).lower()
+                    if anchor_mode == "distance":
+                        delta = fill_price - old_price
+                        if bracket.sl_trigger_price > 0:
+                            bracket.sl_trigger_price = _round_to_tick(
+                                bracket.sl_trigger_price + delta
+                            )
+                        if bracket.tp_trigger_price > 0:
+                            bracket.tp_trigger_price = _round_to_tick(
+                                bracket.tp_trigger_price + delta
+                            )
+                        for level in bracket.tp_levels:
+                            if not level.executed and level.price > 0:
+                                level.price = _round_to_tick(level.price + delta)
 
-                    # Adjust SL proportionally (tick-rounded: round(x, 2) put
-                    # SL/TP on the 0.01 grid, e.g. 143.99 — invalid NSE tick)
-                    if bracket.sl_trigger_price > 0:
-                        bracket.sl_trigger_price = _round_to_tick(
-                            bracket.sl_trigger_price * (1 + price_diff_pct)
-                        )
-                        bracket.initial_sl_trigger_price = bracket.sl_trigger_price
-
-                    # Adjust TP proportionally
-                    if bracket.tp_trigger_price > 0:
-                        bracket.tp_trigger_price = _round_to_tick(
-                            bracket.tp_trigger_price * (1 + price_diff_pct)
-                        )
+                    bracket.initial_sl_trigger_price = bracket.sl_trigger_price
 
                     LOGGER.info(
-                        f"📊 Bracket adjusted for fill price: Entry={fill_price:.2f} "
-                        f"SL={bracket.sl_trigger_price:.2f} TP={bracket.tp_trigger_price:.2f}"
+                        "BRACKET_FILL_GEOMETRY_APPLIED symbol=%s mode=%s old_entry=%.2f fill=%.2f sl=%.2f tp=%.2f",
+                        bracket.symbol,
+                        anchor_mode,
+                        old_price,
+                        fill_price,
+                        bracket.sl_trigger_price,
+                        bracket.tp_trigger_price,
                     )
 
             # ✅ Activate only after explicit fill confirmation

--- a/src/nifty_scalper_bot/execution/bracket_manager.py
+++ b/src/nifty_scalper_bot/execution/bracket_manager.py
@@ -141,67 +141,6 @@ def _reconcile_confirmed_entry_quantity(self, order_id, bracket, filled_qty):
     return True
 
 
-def _reanchor_confirmed_fill_geometry(bracket, fill_price):
-    """Preserve an explicit bracket anchor policy at the broker fill price."""
-    if bracket is None:
-        return
-    try:
-        price = float(fill_price)
-        old_entry = float(bracket.entry_price or 0.0)
-    except (TypeError, ValueError):
-        return
-    if price <= 0.0 or old_entry <= 0.0 or abs(price - old_entry) < 1e-12:
-        return
-
-    provenance = getattr(bracket, "trade_provenance", {}) or {}
-    raw_anchor_mode = provenance.get("bracket_anchor_mode")
-    if raw_anchor_mode is None:
-        # Direct/legacy registrations never declared an anchor contract. Keep
-        # their historical percentage-rescale behavior; the production
-        # TradePlan path always persists an explicit mode before registration.
-        return
-    anchor_mode = str(raw_anchor_mode).strip().lower()
-    if anchor_mode not in {"distance", "absolute_level"}:
-        return
-
-    delta = price - old_entry
-    if anchor_mode == "distance":
-        if float(bracket.sl_trigger_price or 0.0) > 0.0:
-            bracket.sl_trigger_price = _core._round_to_tick(
-                float(bracket.sl_trigger_price) + delta
-            )
-        if float(bracket.tp_trigger_price or 0.0) > 0.0:
-            bracket.tp_trigger_price = _core._round_to_tick(
-                float(bracket.tp_trigger_price) + delta
-            )
-        for level in getattr(bracket, "tp_levels", ()):
-            if not getattr(level, "executed", False):
-                level.price = _core._round_to_tick(float(level.price) + delta)
-
-    # Pre-setting entry makes the legacy core fill handler see no entry delta, so
-    # it cannot percentage-rescale explicitly anchored levels a second time.
-    bracket.entry_price = price
-    bracket.initial_sl_trigger_price = float(bracket.sl_trigger_price or 0.0)
-    _core.LOGGER.info(
-        "BRACKET_FILL_REANCHORED order_id=%s symbol=%s mode=%s old_entry=%.2f fill=%.2f sl=%.2f tp=%.2f",
-        bracket.entry_order_id,
-        bracket.symbol,
-        anchor_mode,
-        old_entry,
-        price,
-        float(bracket.sl_trigger_price or 0.0),
-        float(bracket.tp_trigger_price or 0.0),
-        extra={
-            "event": "BRACKET_FILL_REANCHORED",
-            "order_id": str(bracket.entry_order_id),
-            "symbol": bracket.symbol,
-            "anchor_mode": anchor_mode,
-            "old_entry": old_entry,
-            "fill_price": price,
-        },
-    )
-
-
 def _confirm_entry_fill_once(self, order_id, fill_price, filled_qty=None):
     """Keep repeated COMPLETE callbacks idempotent while accepting smaller fills."""
     bracket = self.get_bracket(order_id)
@@ -241,7 +180,6 @@ def _confirm_entry_fill_once(self, order_id, fill_price, filled_qty=None):
             },
         )
         return True
-    _reanchor_confirmed_fill_geometry(bracket, fill_price)
     return _original_confirm_entry_fill(self, order_id, fill_price, filled_qty)
 
 

--- a/src/nifty_scalper_bot/execution/canonical_bracket_manager.py
+++ b/src/nifty_scalper_bot/execution/canonical_bracket_manager.py
@@ -67,88 +67,8 @@ class CanonicalBracketManager(HardenedBracketManager):
     def confirm_entry_fill(
         self, order_id: str, fill_price: float, filled_qty: int | None = None
     ) -> None:
-        """Activate a confirmed entry and re-anchor every outstanding target.
-
-        The legacy implementation already re-anchors SL and the final TP. This
-        wrapper captures planned partial targets before that call and applies the
-        same proportional re-anchor exactly once.
-        """
-
-        before = self.get_bracket(order_id)
-        planned_entry = 0.0
-        planned_targets: list[float] = []
-        if before is not None:
-            with self._lock:
-                planned_entry = float(before.entry_price or 0.0)
-                planned_targets = [
-                    float(target.price or 0.0) for target in before.tp_levels
-                ]
-
+        """Delegate fill activation to the single canonical geometry owner."""
         super().confirm_entry_fill(order_id, fill_price, filled_qty)
-
-        bracket = self.get_bracket(order_id)
-        if bracket is None:
-            return
-        try:
-            confirmed_fill = float(fill_price or 0.0)
-        except (TypeError, ValueError):
-            return
-        if planned_entry <= 0 or confirmed_fill <= 0 or confirmed_fill == planned_entry:
-            return
-
-        ratio = confirmed_fill / planned_entry
-        changed: list[dict[str, object]] = []
-        with self._lock:
-            for index, target in enumerate(bracket.tp_levels):
-                if target.executed or index >= len(planned_targets):
-                    continue
-                old_price = planned_targets[index]
-                if old_price <= 0:
-                    continue
-                new_price = _legacy._round_to_tick(old_price * ratio)
-                if new_price <= 0 or new_price == float(target.price):
-                    continue
-                target.price = new_price
-                changed.append(
-                    {
-                        "name": str(target.name),
-                        "old_price": old_price,
-                        "new_price": new_price,
-                    }
-                )
-            if changed:
-                bracket.updated_at = time.time()
-
-        if not changed:
-            return
-        with suppress(Exception):
-            self.save_state()
-        _legacy.LOGGER.info(
-            "BRACKET_TARGETS_REANCHORED bracket_id=%s symbol=%s planned_entry=%.2f fill_price=%.2f targets=%s",
-            bracket.bracket_id,
-            bracket.symbol,
-            planned_entry,
-            confirmed_fill,
-            changed,
-            extra={
-                "event": "BRACKET_TARGETS_REANCHORED",
-                "bracket_id": bracket.bracket_id,
-                "symbol": bracket.symbol,
-                "planned_entry": planned_entry,
-                "fill_price": confirmed_fill,
-                "targets": changed,
-            },
-        )
-        with suppress(Exception):
-            self._notify_event(
-                "BRACKET_TARGETS_REANCHORED",
-                {
-                    "symbol": bracket.symbol,
-                    "planned_entry": round(planned_entry, 2),
-                    "fill_price": round(confirmed_fill, 2),
-                    "targets": changed,
-                },
-            )
 
     def _broker_position_quantity(self, symbol: str) -> int | None:
         """Return absolute broker quantity, or ``None`` when exposure is unknown."""

--- a/tests/execution/test_canonical_bracket_fill_integrity.py
+++ b/tests/execution/test_canonical_bracket_fill_integrity.py
@@ -139,10 +139,10 @@ def test_confirmed_fill_reanchors_sl_final_tp_and_tp1() -> None:
 
     assert bracket is not None
     assert bracket.entry_price == 102.0
-    assert bracket.sl_trigger_price == 91.8
-    assert bracket.tp_trigger_price == 122.4
+    assert bracket.sl_trigger_price == 92.0
+    assert bracket.tp_trigger_price == 122.0
     assert len(bracket.tp_levels) == 1
-    assert bracket.tp_levels[0].price == 112.2
+    assert bracket.tp_levels[0].price == 112.0
 
 
 def test_confirmed_tp1_fill_keeps_residual_position_open_and_protected() -> None:

--- a/tests/execution/test_trailing_restart_persistence.py
+++ b/tests/execution/test_trailing_restart_persistence.py
@@ -23,7 +23,7 @@ def test_confirmed_fill_reanchors_initial_risk_to_activated_stop() -> None:
 
     bracket = manager.get_bracket("fill-risk")
     assert bracket is not None
-    assert bracket.sl_trigger_price == 104.50
+    assert bracket.sl_trigger_price == 104.45
     assert bracket.initial_sl_trigger_price == bracket.sl_trigger_price
 
 


### PR DESCRIPTION
## Root cause
Fill geometry had three owners: pre-submit distance reanchor, a facade pre-transform used to suppress core proportional scaling, and a canonical wrapper that proportionally rescaled TP1. The composed runtime behavior depended on wrapper order.

## Fix
- make `bracket_core.confirm_entry_fill` the sole fill-time geometry owner
- distance mode translates SL, final TP, and every unexecuted TP1 by the exact fill delta
- absolute-level mode updates entry evidence without moving technical levels
- default legacy registrations to distance semantics
- delete the facade pre-transform and proportional TP1 wrapper
- retain idempotent fill handling and quantity reconciliation

## Regression
A 100 planned entry filled at 102 now maps 90/110/120 to 92/112/122 exactly; no proportional 91.8/112.2/122.4 transform remains.

## Validation
- compileall and diff checks clean
- existing explicit distance/absolute fill tests retained
- canonical fill and restart-risk expectations updated to additive distances
- required CI pending

Draft until all required CI is green.