### PR TITLE
fix(execution): bound protected entry fill wait

### DIFF
--- a/src/nifty_scalper_bot/execution/order_manager_core.py
+++ b/src/nifty_scalper_bot/execution/order_manager_core.py
@@ -3845,14 +3845,56 @@ class OrderManager:
                             normalized_symbol,
                         )
 
-                    # Keep the short entry confirmation used to activate protection.
-                    # System exits are confirmed by the order monitor/reconciliation;
-                    # polling here would block the synchronous protection callback.
-                    fill_confirmed = (
-                        False
-                        if is_system_exit
-                        else self._confirm_fill_fast(order_id, timeout_ms=300)
+                    # A protected entry has one bounded fill owner.  The bracket
+                    # must exist before polling so an observed partial can be
+                    # protected before its remainder is cancelled.  Exit orders
+                    # stay asynchronous: blocking their protection callback can
+                    # deadlock the exit state machine.
+                    protected_entry = (
+                        normalized_intent in {"ENTRY", "SCALE_IN", "REVERSAL"}
+                        and self.is_live_mode()
+                        and self._bracket_manager is not None
+                        and bool(stop_loss or take_profit)
+                        and not _caller_manages_bracket
                     )
+                    if protected_entry:
+                        awaited_entry = self._await_entry_fill(
+                            details,
+                            timeout=self.BRACKET_ENTRY_TIMEOUT_SEC,
+                        )
+                        fill_confirmed = bool(
+                            awaited_entry is not None
+                            and int(awaited_entry.filled_quantity or 0) > 0
+                        )
+                        if not fill_confirmed:
+                            current = self._orders.get(order_id, details)
+                            cancel_confirmed = current.status in {
+                                OrderStatus.CANCELLED,
+                                OrderStatus.REJECTED,
+                                OrderStatus.EXPIRED,
+                            }
+                            reason = (
+                                "entry_fill_timeout_cancelled"
+                                if cancel_confirmed
+                                else "entry_fill_cancel_unconfirmed"
+                            )
+                            if not cancel_confirmed and details.client_order_id:
+                                self._mark_order_uncertain(details.client_order_id)
+                            _log_order_decision(
+                                allowed=False,
+                                block_reason=reason,
+                                order_id=order_id,
+                                broker_attempted=True,
+                            )
+                            if signal_id:
+                                self._clear_pending_signal(signal_id)
+                            return None
+                    else:
+                        fill_confirmed = (
+                            False
+                            if is_system_exit
+                            else self._confirm_fill_fast(order_id, timeout_ms=300)
+                        )
                     if fill_confirmed and self._bracket_manager:
                         bracket = self._bracket_manager.get_bracket(order_id)
                         if bracket:
@@ -6016,6 +6058,16 @@ class OrderManager:
             )
             return updated
 
+        if updated.status in self.FINAL_STATUSES:
+            if updated.filled_quantity > 0:
+                return updated
+            if (
+                self._bracket_manager is not None
+                and self._bracket_manager.get_bracket(entry.order_id) is not None
+            ):
+                self._bracket_manager.unregister_bracket(entry.order_id)
+            return None
+
         if updated.filled_quantity > 0:
             self._logger.info(
                 "Condition met: entry partially filled; cancelling remainder",
@@ -6035,7 +6087,10 @@ class OrderManager:
             )
 
         try:
-            self.cancel_order(entry.order_id)
+            cancel = getattr(self._broker, "cancel_order", None)
+            if cancel is None:
+                raise NotImplementedError("Broker does not support order cancellation")
+            self._call_broker(cancel, entry.order_id)
         except Exception as exc:  # noqa: BLE001
             self._logger.error(
                 "Failure in _await_entry_fill cancel: %s",
@@ -6057,6 +6112,13 @@ class OrderManager:
                 },
             )
             return refreshed
+        if (
+            refreshed.status
+            in {OrderStatus.CANCELLED, OrderStatus.REJECTED, OrderStatus.EXPIRED}
+            and self._bracket_manager is not None
+            and self._bracket_manager.get_bracket(entry.order_id) is not None
+        ):
+            self._bracket_manager.unregister_bracket(entry.order_id)
         return None
 
     def set_notifier(self, notifier: TelegramEnhancedNotifier | None) -> None:

--- a/tests/execution/test_execution_safety_audit_fixes.py
+++ b/tests/execution/test_execution_safety_audit_fixes.py
@@ -1275,6 +1275,15 @@ def test_live_entry_registers_pending_order_with_position_manager(
     bm = BracketManager(order_manager=om)
     bm._running = False
     om.set_bracket_manager(bm)
+    monkeypatch.setattr(om, "is_live_mode", lambda: True)
+    awaited: list[tuple[str, float]] = []
+
+    def _filled_entry(entry, *, timeout):
+        awaited.append((entry.order_id, timeout))
+        entry.filled_quantity = entry.quantity
+        return entry
+
+    monkeypatch.setattr(om, "_await_entry_fill", _filled_entry)
     try:
         oid = om.place_order(
             symbol="NFO:NIFTY2671424100CE",
@@ -1297,6 +1306,7 @@ def test_live_entry_registers_pending_order_with_position_manager(
         # skip condition (entry_confirmed False) must hold for it.
         bracket = bm.get_bracket(oid)
         assert bracket is not None and bracket.entry_confirmed is False
+        assert awaited == [(oid, om.BRACKET_ENTRY_TIMEOUT_SEC)]
     finally:
         bm._running = False
 
@@ -1332,6 +1342,13 @@ def test_system_exit_does_not_poll_for_fill_on_protection_path(
             AssertionError("system exit must not synchronously poll")
         ),
     )
+    monkeypatch.setattr(
+        manager,
+        "_await_entry_fill",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("system exit must not enter bounded entry wait")
+        ),
+    )
 
     order_id = manager.place_order(
         symbol="NFO:NIFTY2671424100CE",
@@ -1344,6 +1361,69 @@ def test_system_exit_does_not_poll_for_fill_on_protection_path(
     )
 
     assert order_id == "SYSTEM-EXIT-1"
+
+
+def test_bounded_entry_wait_cancels_partial_remainder_without_removing_protection(
+) -> None:
+    from nifty_scalper_bot.execution.order_manager import (
+        OrderDetails,
+        OrderManager,
+        OrderStatus,
+        OrderType,
+    )
+
+    entry = OrderDetails(
+        order_id="ENTRY-PARTIAL-1",
+        symbol="NFO:NIFTY2671424100CE",
+        side="BUY",
+        quantity=130,
+        order_type=OrderType.LIMIT,
+        status=OrderStatus.SUBMITTED,
+        filled_quantity=0,
+        intent="ENTRY",
+    )
+    partial = entry
+    partial.status = OrderStatus.PARTIALLY_FILLED
+    partial.filled_quantity = 65
+    cancelled = OrderDetails(
+        order_id=entry.order_id,
+        symbol=entry.symbol,
+        side=entry.side,
+        quantity=entry.quantity,
+        order_type=entry.order_type,
+        status=OrderStatus.CANCELLED,
+        filled_quantity=65,
+        intent="ENTRY",
+    )
+    refreshes = iter((partial, cancelled))
+    cancelled_at_broker: list[str] = []
+    unregistered: list[str] = []
+    bracket_manager = SimpleNamespace(
+        get_bracket=lambda _order_id: object(),
+        unregister_bracket=unregistered.append,
+    )
+    logger = SimpleNamespace(
+        debug=lambda *_args, **_kwargs: None,
+        info=lambda *_args, **_kwargs: None,
+        error=lambda *_args, **_kwargs: None,
+    )
+    manager = SimpleNamespace(
+        _logger=logger,
+        _broker=SimpleNamespace(
+            cancel_order=lambda order_id: cancelled_at_broker.append(order_id) or True
+        ),
+        _bracket_manager=bracket_manager,
+        wait_for_fill=lambda *_args, **_kwargs: False,
+        _refresh_order=lambda _order_id: next(refreshes),
+        _call_broker=lambda callback, order_id: callback(order_id),
+        FINAL_STATUSES=OrderManager.FINAL_STATUSES,
+    )
+
+    result = OrderManager._await_entry_fill(manager, entry, timeout=5.0)
+
+    assert result is cancelled
+    assert cancelled_at_broker == [entry.order_id]
+    assert unregistered == []
 
 
 def test_non_incremental_fill_warning_dedupes_per_snapshot(tmp_path) -> None:


### PR DESCRIPTION
## Root cause
Protected limit entries used only a 300 ms observation after submit. The configured 5-second bounded fill owner existed but was never called, so zero-fill OPEN entries could remain live indefinitely. Its dormant cancellation path also used the public bracket-abort API, which would remove protection from a partial fill.

## Fix
- invoke the existing bounded entry-fill owner after the virtual bracket is registered
- cancel only the unfilled broker remainder, retaining protection for partial exposure
- reject confirmed zero-fill timeouts and latch unconfirmed cancellation as uncertain
- keep exit submission asynchronous

## TDD / validation
- regression proves the canonical protected entry invokes the configured bounded wait
- regression proves partial-fill remainder cancellation preserves its bracket
- regression proves system exits never enter the bounded entry wait
- `python -m compileall -q src tests/execution/test_execution_safety_audit_fixes.py`
- `git diff --check`

Local pytest execution is unavailable in this workspace runtime; required repository CI is the merge gate.