### PR TITLE
fix(execution): preserve product across bracket exits

### DIFF
--- a/src/nifty_scalper_bot/execution/bracket_core.py
+++ b/src/nifty_scalper_bot/execution/bracket_core.py
@@ -351,6 +351,7 @@ class BracketState:
     last_processed_tick_id: str | None = None
     last_trail_price: float | None = None
     trail_revision: int = 0
+    product: str = "MIS"
 
     @property
     def bracket_id(self) -> str:
@@ -390,6 +391,7 @@ class BracketState:
 
     def __post_init__(self):
         self.side = _normalize_bracket_side(self.side)
+        self.product = str(self.product or "MIS").strip().upper()
         if self.requested_entry_quantity <= 0:
             self.requested_entry_quantity = self.quantity
         # Auto-initialize state fields if not set
@@ -428,6 +430,7 @@ class BracketState:
             "lowest_ltp": self.lowest_ltp,
             "last_ltp": self.last_ltp,
             "tag": self.tag,
+            "product": self.product,
             "trade_provenance": dict(self.trade_provenance),
             "created_at": self.created_at,
             "updated_at": self.updated_at,
@@ -1219,6 +1222,7 @@ class BracketManager:
         trailing_atr_mult: float | None = None,
         activate_immediately: bool = False,
         intent: str | None = None,
+        product: str = "MIS",
         resolved_lot_size: int | None = None,
         trade_provenance: Mapping[str, Any] | None = None,
     ) -> None:
@@ -1237,6 +1241,7 @@ class BracketManager:
             tp1_qty: Optional first profit target quantity.
             trailing_atr_mult: Optional ATR-based trailing multiplier.
             activate_immediately: Whether the bracket is active on registration.
+            product: Broker product inherited from the entry order.
             resolved_lot_size: Authoritative instrument lot size for TP allocation.
 
         Returns:
@@ -1284,6 +1289,7 @@ class BracketManager:
                 existing.remaining_quantity = abs(qty)
                 existing.exit_state = BracketExitLifecycle.OPEN_PENDING_FILL.value
                 existing.exit_pending = False
+                existing.product = str(product or "MIS").strip().upper()
                 existing.trade_provenance.update(dict(trade_provenance or {}))
                 self.save_state()  # Persist updates
                 self._sync_active_bracket_symbols_to_mdm()
@@ -1353,6 +1359,7 @@ class BracketManager:
                 ),
                 entry_fill_price=price if activate_immediately else None,
                 tag=tag,
+                product=product,
                 trade_provenance=dict(trade_provenance or {}),
                 entry_order_intent=normalized_intent or "ENTRY",
                 trade_lifecycle_id=order_id,
@@ -2826,7 +2833,13 @@ class BracketManager:
                     order_type="MARKET",
                     tag=f"EXIT_MKT_{bracket.bracket_id[:8]}",
                     check_risk=False,
-                    product="MIS",
+                    product=bracket.product,
+                    intent="EXIT",
+                    linked_entry_order_id=bracket.entry_order_id,
+                    trade_lifecycle_id=(
+                        bracket.trade_lifecycle_id or bracket.entry_order_id
+                    ),
+                    bracket_id=bracket.bracket_id,
                 )
             except Exception as exc:  # noqa: BLE001
                 LOGGER.critical(
@@ -3797,9 +3810,17 @@ class BracketManager:
                 "order_type": order_type,
                 "tag": correlation_tag or f"exit_{reason[:3]}_{bracket_id[:8]}",
                 "check_risk": False,
-                "product": "MIS",
+                "product": bracket.product if bracket is not None else "MIS",
                 "intent": "EXIT",
                 "bracket_id": bracket_id,
+                "linked_entry_order_id": (
+                    bracket.entry_order_id if bracket is not None else None
+                ),
+                "trade_lifecycle_id": (
+                    bracket.trade_lifecycle_id or bracket.entry_order_id
+                    if bracket is not None
+                    else None
+                ),
             }
             if price is not None:
                 kwargs["price"] = price
@@ -4309,7 +4330,13 @@ class BracketManager:
                 order_type="MARKET",
                 tag=f"mkt_exit_{reason[:3]}",
                 check_risk=False,
-                product="MIS",
+                product=bracket.product,
+                intent="EXIT",
+                linked_entry_order_id=bracket.entry_order_id,
+                trade_lifecycle_id=(
+                    bracket.trade_lifecycle_id or bracket.entry_order_id
+                ),
+                bracket_id=bracket.bracket_id,
             )
             if not order_id:
                 LOGGER.critical(
@@ -4849,6 +4876,7 @@ class BracketManager:
                 payload.get("previous_ltp", payload.get("last_ltp", entry_price)),
             ),
             tag=payload.get("tag"),
+            product=str(payload.get("product") or "MIS"),
             trade_provenance=dict(payload.get("trade_provenance") or {}),
             created_at=finite_float(
                 "created at", payload.get("created_at", time.time())

--- a/src/nifty_scalper_bot/execution/live_safety_identity.py
+++ b/src/nifty_scalper_bot/execution/live_safety_identity.py
@@ -475,7 +475,6 @@ def apply_patches() -> None:
     global _PATCH_APPLIED
     if _PATCH_APPLIED:
         return
-    _patch_bracket_manager()
     _patch_position_manager()
     _PATCH_APPLIED = True
 

--- a/src/nifty_scalper_bot/execution/order_manager_core.py
+++ b/src/nifty_scalper_bot/execution/order_manager_core.py
@@ -246,6 +246,7 @@ class OrderDetails:
     resolved_lot_size: int = 0
     entry_lifecycle_state: dict[str, Any] | None = None
     trade_provenance: dict[str, Any] = field(default_factory=dict)
+    product: str = "MIS"
 
 
 @dataclass(slots=True)
@@ -3757,6 +3758,7 @@ class OrderManager:
                         stop_loss=stop_loss,
                         take_profit=take_profit,
                         tag=tag,
+                        product=product,
                         average_price=0.0,
                         intent=cast(OrderIntent, normalized_intent),
                         intended_position_side=intended_position_side,
@@ -3835,6 +3837,7 @@ class OrderManager:
                             tp=float(take_profit) if take_profit else 0.0,
                             tag=tag or "auto",
                             intent=normalized_intent,
+                            product=product,
                             activate_immediately=False,
                             trade_provenance=trade_provenance,
                         )
@@ -5967,6 +5970,7 @@ class OrderManager:
                 sl=stop_loss,
                 tp=take_profit,
                 tag=tag or "virtual_bracket",
+                product=product or "MIS",
                 tp1_price=tp1_price,
                 tp1_qty=tp1_qty,
                 trailing_atr_mult=trailing_atr_mult,
@@ -6300,6 +6304,7 @@ class OrderManager:
                     tp=tp_price,
                     tag=order.tag or source,
                     intent=str(getattr(order, "intent", "ENTRY") or "ENTRY"),
+                    product=str(getattr(order, "product", "MIS") or "MIS"),
                     trade_provenance=order.trade_provenance,
                     **exit_fields,
                 )
@@ -7349,6 +7354,7 @@ class OrderManager:
                         sl=sl_price,
                         tp=tp_price,
                         tag=order.tag,
+                        product=order.product,
                     )
                     self._logger.info(
                         f"✅ Handed off {order.symbol} to Virtual Sniper (SL: {sl_price}, TP: {tp_price})",
@@ -7580,6 +7586,7 @@ class OrderManager:
                         status=self._parse_status(status_raw),
                         timestamp=datetime.now(timezone.utc),
                         tag="adopted_manual_trade",
+                        product=str(order_update.get("product") or "MIS"),
                         intent="UNKNOWN",
                     )
 

--- a/tests/execution/test_bracket_open_position_priority_and_protective_exit.py
+++ b/tests/execution/test_bracket_open_position_priority_and_protective_exit.py
@@ -17,6 +17,7 @@ def _active_bracket(manager: BracketManager, *, side: str = "BUY") -> BracketSta
         remaining_quantity=10,
         active=False,
         entry_confirmed=False,
+        product="NRML",
     )
     manager._brackets[bracket.entry_order_id] = bracket
     return bracket
@@ -71,6 +72,7 @@ def test_hard_sl_protective_exit_defaults_to_market(monkeypatch) -> None:
 
     assert result.accepted is True
     assert order_manager.place_order.call_args.kwargs["order_type"] == "MARKET"
+    assert order_manager.place_order.call_args.kwargs["product"] == "NRML"
     assert "price" not in order_manager.place_order.call_args.kwargs
 
 
@@ -85,6 +87,7 @@ def test_eod_flatten_protective_exit_defaults_to_market(monkeypatch) -> None:
     manager.submit_exit_order("NFO:TEST", 10, "EOD_FLATTEN", "entry-1", preferred_order_type="LIMIT")
 
     assert order_manager.place_order.call_args.kwargs["order_type"] == "MARKET"
+    assert order_manager.place_order.call_args.kwargs["product"] == "NRML"
 
 
 def test_aggressive_limit_sell_exit_prices_below_bid(monkeypatch) -> None:

--- a/tests/execution/test_exit_escalation_forces_market.py
+++ b/tests/execution/test_exit_escalation_forces_market.py
@@ -46,6 +46,7 @@ def _bracket(mgr: BracketManager):
         price=157.0,
         sl=150.0,
         tp=170.0,
+        product="NRML",
     )
     return next(iter(mgr._brackets.values()))
 
@@ -69,6 +70,11 @@ async def test_escalation_cancels_stuck_order_and_fires_market_exit():
     assert mkt["order_type"] == "MARKET"
     assert mkt["side"] == "SELL"
     assert mkt["quantity"] == 65
+    assert mkt["product"] == "NRML"
+    assert mkt["intent"] == "EXIT"
+    assert mkt["linked_entry_order_id"] == "entry-1"
+    assert mkt["trade_lifecycle_id"] == "entry-1"
+    assert mkt["bracket_id"] == "entry-1"
     # new exit order id recorded
     assert b.exit_order_id == "mkt-exit-1"
 

--- a/tests/execution/test_exit_order_type.py
+++ b/tests/execution/test_exit_order_type.py
@@ -23,6 +23,7 @@ def _manager_with_bracket(monkeypatch, *, reason_mode: str | None = None) -> tup
         sl_trigger_price=95.0,
         tp_trigger_price=110.0,
         remaining_quantity=10,
+        product="NRML",
     )
     bracket.last_ltp = 98.0
     manager._brackets[bracket.entry_order_id] = bracket
@@ -42,6 +43,11 @@ def test_exit_order_type_uses_market_for_sl(monkeypatch) -> None:
 
     kwargs = order_manager.place_order.call_args.kwargs
     assert kwargs["order_type"] == "MARKET"
+    assert kwargs["product"] == "NRML"
+    assert kwargs["intent"] == "EXIT"
+    assert kwargs["linked_entry_order_id"] == "entry-1"
+    assert kwargs["trade_lifecycle_id"] == "entry-1"
+    assert kwargs["bracket_id"] == "entry-1"
     assert "price" not in kwargs
 
 


### PR DESCRIPTION
## Root cause
Bracket state did not retain the entry order's broker product. Every normal, EOD, fallback, and escalated bracket exit therefore substituted `MIS`, even when the entry/position belonged to `NRML`.

## Fix
- make broker product durable bracket-owned state, defaulting old snapshots to `MIS`
- propagate the submitted entry product into local order and bracket registration
- reuse the bracket product for normal, EOD, fallback, and escalation exits
- preserve product on adopted broker orders

## TDD / validation
- normal protective exit preserves `NRML`
- EOD protective exit preserves `NRML`
- forced MARKET escalation preserves `NRML`
- production/test compile clean and `git diff --check` clean

Required repository CI remains the merge gate.