### PR TITLE
fix(metrics): report execution-cost net pnl

### DIFF
--- a/src/nifty_scalper_bot/metrics/kpi.py
+++ b/src/nifty_scalper_bot/metrics/kpi.py
@@ -27,15 +27,24 @@ class TradeSample:
     decay: float = 0.0
 
     @property
-    def pnl(self) -> float:
-        """Return the net profit/loss of the trade in currency units."""
-
+    def gross_pnl(self) -> float:
+        """Return direction-adjusted price P&L before execution costs."""
         sign = 1.0 if self.direction.upper().startswith("L") else -1.0
         return (self.exit_price - self.entry_price) * sign * float(self.quantity)
 
     @property
+    def execution_cost(self) -> float:
+        """Return non-negative spread and slippage costs in currency units."""
+        return max(float(self.spread_cost), 0.0) + max(float(self.slippage), 0.0)
+
+    @property
+    def pnl(self) -> float:
+        """Return execution-cost-inclusive profit/loss in currency units."""
+        return self.gross_pnl - self.execution_cost
+
+    @property
     def return_pct(self) -> float:
-        """Return the percentage return relative to entry notional."""
+        """Return the cost-inclusive return relative to entry notional."""
 
         notional = self.entry_price * float(self.quantity)
         if notional == 0:

--- a/tests/metrics/test_kpi.py
+++ b/tests/metrics/test_kpi.py
@@ -1,5 +1,7 @@
 from datetime import datetime
 
+import pytest
+
 from nifty_scalper_bot.metrics.kpi import KPITracker, TradeSample, summarize_trades
 
 
@@ -27,8 +29,21 @@ def test_summarize_trades_computes_kpis() -> None:
     assert report.total_trades == 2
     assert report.hit_rate == 1.0
     assert report.total_spread_cost == 1.0
+    assert report.net_pnl == 98.5
     assert 9 in report.per_hour_returns
     assert 10 in report.per_hour_returns
+
+
+def test_execution_costs_can_turn_gross_winner_into_net_loser() -> None:
+    trade = _trade("LONG", 100.0, 100.01, 9)
+
+    assert trade.gross_pnl == pytest.approx(0.5)
+    assert trade.execution_cost == 0.75
+    assert trade.pnl == pytest.approx(-0.25)
+    report = summarize_trades([trade])
+    assert report.hit_rate == 0.0
+    assert report.net_pnl == pytest.approx(-0.25)
+    assert report.average_return_pct == pytest.approx(-0.25 / 5_000.0)
 
 
 def test_kpi_tracker_formatting() -> None:


### PR DESCRIPTION
## Root cause
`TradeSample.pnl` was direction-adjusted price delta × quantity only. Spread and slippage costs were recorded but excluded from trade wins, returns, hourly attribution, and `KPIReport.net_pnl`.

## Fix
- expose explicit pre-cost `gross_pnl`
- define recorded spread/slippage as non-negative currency execution costs
- make `pnl` and `return_pct` cost-inclusive
- consequently make hit rate, hourly returns, and report net P&L cost-inclusive

## TDD / validation
- two profitable gross trades now report the exact cost-adjusted total
- a marginal gross winner becomes a net loser after execution costs
- compile and diff checks clean

Required repository CI remains the merge gate.