### PR TITLE
Compute ADX and fail closed on missing regime input

### DIFF
--- a/src/nifty_scalper_bot/strategies/indicators.py
+++ b/src/nifty_scalper_bot/strategies/indicators.py
@@ -635,6 +635,7 @@ class IndicatorEngine:
             with self._lock:
                 indicators: dict[str, float | tuple[float, float, float] | None] = {}
                 indicators["rsi"] = self.get_rsi(symbol)
+                indicators["adx"] = self.get_adx(symbol)
                 indicators["ema"] = self.get_ema(symbol)
                 indicators["sma"] = self.get_sma(symbol)
             macd = self.get_macd(symbol)
@@ -695,6 +696,7 @@ class IndicatorEngine:
                 "volume",
                 "avg_volume",
                 "rsi",
+                "adx",
                 "high",
                 "low",
                 "close",
@@ -901,6 +903,27 @@ class IndicatorEngine:
             lows = history.get_lows(period + 1)
             closes = history.get_closes(period + 1)
             value = self._calculate_atr(highs, lows, closes, period)
+            self._set_cache(symbol, cache_key, value, last_timestamp)
+            return value
+
+    def get_adx(self, symbol: str, period: int = 14) -> float | None:
+        """Calculate Wilder ADX, returning None until two windows are ready."""
+
+        with self._lock:
+            history = self._histories.get(symbol)
+            if history is None or len(history) < 2 * period:
+                return None
+            last_timestamp = history.last_timestamp
+            if last_timestamp is None:
+                return None
+            cache_key = f"adx_{period}"
+            cached = self._get_cached(symbol, cache_key, last_timestamp)
+            if cached is not None:
+                return cached  # type: ignore[return-value]
+            highs = history.get_highs()
+            lows = history.get_lows()
+            closes = history.get_closes()
+            value = self._calculate_adx(highs, lows, closes, period)
             self._set_cache(symbol, cache_key, value, last_timestamp)
             return value
 
@@ -1807,6 +1830,69 @@ class IndicatorEngine:
         for value in true_ranges[period:]:
             atr += (float(value) - atr) / float(period)
         return float(atr)
+
+    def _calculate_adx(
+        self,
+        highs: list[float],
+        lows: list[float],
+        closes: list[float],
+        period: int,
+    ) -> float:
+        """Return Wilder's Average Directional Index on a 0-100 scale."""
+
+        if period <= 0 or min(len(highs), len(lows), len(closes)) < 2 * period:
+            raise ValueError("Insufficient data for ADX calculation")
+        high_arr = np.asarray(highs, dtype=float)
+        low_arr = np.asarray(lows, dtype=float)
+        close_arr = np.asarray(closes, dtype=float)
+        true_ranges: list[float] = []
+        positive_dm: list[float] = []
+        negative_dm: list[float] = []
+        for index in range(1, len(close_arr)):
+            upward = high_arr[index] - high_arr[index - 1]
+            downward = low_arr[index - 1] - low_arr[index]
+            positive_dm.append(
+                float(upward) if upward > downward and upward > 0 else 0.0
+            )
+            negative_dm.append(
+                float(downward) if downward > upward and downward > 0 else 0.0
+            )
+            true_ranges.append(
+                float(
+                    max(
+                        high_arr[index] - low_arr[index],
+                        abs(high_arr[index] - close_arr[index - 1]),
+                        abs(low_arr[index] - close_arr[index - 1]),
+                    )
+                )
+            )
+
+        smoothed_tr = sum(true_ranges[:period])
+        smoothed_positive = sum(positive_dm[:period])
+        smoothed_negative = sum(negative_dm[:period])
+
+        def _dx() -> float:
+            if smoothed_tr <= 0.0:
+                return 0.0
+            positive_di = 100.0 * smoothed_positive / smoothed_tr
+            negative_di = 100.0 * smoothed_negative / smoothed_tr
+            total = positive_di + negative_di
+            return (
+                0.0 if total <= 0.0 else 100.0 * abs(positive_di - negative_di) / total
+            )
+
+        dx_values = [_dx()]
+        for index in range(period, len(true_ranges)):
+            smoothed_tr += true_ranges[index] - smoothed_tr / period
+            smoothed_positive += positive_dm[index] - smoothed_positive / period
+            smoothed_negative += negative_dm[index] - smoothed_negative / period
+            dx_values.append(_dx())
+        if len(dx_values) < period:
+            raise ValueError("Insufficient data for ADX calculation")
+        adx = sum(dx_values[:period]) / period
+        for value in dx_values[period:]:
+            adx += (value - adx) / period
+        return float(adx)
 
     def _calculate_vwap(self, prices: list[float], volumes: list[int]) -> float | None:
         """Internal VWAP calculation.

--- a/src/nifty_scalper_bot/strategies/market_regime_engine.py
+++ b/src/nifty_scalper_bot/strategies/market_regime_engine.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 from enum import Enum
 from typing import Mapping
@@ -10,10 +11,11 @@ from typing import Mapping
 class MarketRegime(str, Enum):
     """Supported market regime labels."""
 
-    TREND = 'TREND'
-    RANGE = 'RANGE'
-    VOLATILE = 'VOLATILE'
-    LOW_ACTIVITY = 'LOW_ACTIVITY'
+    TREND = "TREND"
+    RANGE = "RANGE"
+    VOLATILE = "VOLATILE"
+    LOW_ACTIVITY = "LOW_ACTIVITY"
+    UNKNOWN = "UNKNOWN"
 
 
 @dataclass(slots=True)
@@ -21,7 +23,7 @@ class RegimeSnapshot:
     """Container for calculated regime inputs and output."""
 
     regime: MarketRegime
-    adx: float
+    adx: float | None
     atr: float
     atr_average: float
     vwap_slope: float
@@ -34,14 +36,16 @@ class MarketRegimeEngine:
     def classify(self, indicators: Mapping[str, float | int | None]) -> RegimeSnapshot:
         """Classify regime. Args: indicators; Returns: RegimeSnapshot; Raises: none."""
 
-        adx = self._as_float(indicators.get('adx'))
-        atr = self._as_float(indicators.get('atr'))
-        atr_average = max(self._as_float(indicators.get('atr_average')), 1e-6)
-        vwap_slope = self._as_float(indicators.get('vwap_slope'))
-        volume_expansion = self._as_float(indicators.get('volume_expansion'))
+        adx = self._as_optional_float(indicators.get("adx"))
+        atr = self._as_float(indicators.get("atr"))
+        atr_average = max(self._as_float(indicators.get("atr_average")), 1e-6)
+        vwap_slope = self._as_float(indicators.get("vwap_slope"))
+        volume_expansion = self._as_float(indicators.get("volume_expansion"))
 
-        regime = MarketRegime.LOW_ACTIVITY
-        if adx > 25.0 and abs(vwap_slope) > 0.01:
+        regime = MarketRegime.UNKNOWN
+        if adx is None:
+            pass
+        elif adx > 25.0 and abs(vwap_slope) > 0.01:
             regime = MarketRegime.TREND
         elif atr > 1.8 * atr_average:
             regime = MarketRegime.VOLATILE
@@ -66,3 +70,13 @@ class MarketRegimeEngine:
         if isinstance(value, (int, float)):
             return float(value)
         return 0.0
+
+    @staticmethod
+    def _as_optional_float(value: float | int | None) -> float | None:
+        """Return a finite numeric input or None when the indicator is missing."""
+
+        if isinstance(value, (int, float)):
+            resolved = float(value)
+            if math.isfinite(resolved) and 0.0 <= resolved <= 100.0:
+                return resolved
+        return None

--- a/tests/strategies/test_market_regime_engine.py
+++ b/tests/strategies/test_market_regime_engine.py
@@ -58,3 +58,18 @@ def test_market_regime_low_activity_classification() -> None:
         }
     )
     assert snapshot.regime == MarketRegime.LOW_ACTIVITY
+
+
+def test_market_regime_missing_adx_is_unknown_not_range() -> None:
+    snapshot = MarketRegimeEngine().classify(
+        {
+            "adx": None,
+            "atr": 8.0,
+            "atr_average": 8.5,
+            "vwap_slope": 0.001,
+            "volume_expansion": 1.0,
+        }
+    )
+
+    assert snapshot.regime == MarketRegime.UNKNOWN
+    assert snapshot.adx is None

--- a/tests/strategies/test_wilder_smoothing.py
+++ b/tests/strategies/test_wilder_smoothing.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timedelta, timezone
+
 import pytest
 
 from nifty_scalper_bot.strategies.indicators import IndicatorEngine
@@ -86,3 +88,43 @@ def test_rsi_edge_cases_are_preserved(monkeypatch) -> None:
 
     rising = [100.0 + i for i in range(20)]
     assert engine._calculate_rsi(rising, 14) == pytest.approx(100.0)
+
+
+def test_adx_uses_wilder_directional_movement() -> None:
+    engine = IndicatorEngine()
+    closes = [100.0 + index for index in range(28)]
+    highs = [value + 1.0 for value in closes]
+    lows = [value - 1.0 for value in closes]
+
+    assert engine._calculate_adx(highs, lows, closes, 14) == pytest.approx(100.0)
+
+
+def test_adx_requires_two_wilder_windows() -> None:
+    engine = IndicatorEngine()
+    closes = [100.0 + index for index in range(15)]
+    highs = [value + 1.0 for value in closes]
+    lows = [value - 1.0 for value in closes]
+
+    with pytest.raises(ValueError):
+        engine._calculate_adx(highs, lows, closes, 14)
+
+
+def test_adx_is_exposed_by_canonical_indicator_snapshots() -> None:
+    engine = IndicatorEngine()
+    start = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    for index in range(31):
+        close = 100.0 + index
+        engine.update_price(
+            "NIFTY",
+            {
+                "open": close - 0.5,
+                "high": close + 1.0,
+                "low": close - 1.0,
+                "close": close,
+            },
+            timestamp=start + timedelta(minutes=index),
+        )
+
+    assert engine.get_adx("NIFTY") == pytest.approx(100.0)
+    assert engine.get_indicators("NIFTY")["adx"] == pytest.approx(100.0)
+    assert engine.get_latest("NIFTY")["adx"] == pytest.approx(100.0)


### PR DESCRIPTION
## Root cause

`IndicatorEngine.get_latest()` looked up a nonexistent `get_adx`, while `get_indicators()` did not publish ADX. The regime engine then converted missing input to `0.0`, making absent evidence an affirmative `RANGE` classification.

## Changes

- implement cached Wilder ADX in the canonical indicator engine
- publish ADX through `get_indicators()` and `get_latest()`
- require two Wilder windows before ADX becomes available
- represent missing/non-finite/out-of-range ADX as `MarketRegime.UNKNOWN`, which is not in any default allowed-regime set

## Validation

- targeted regime, Wilder smoothing, and runner regime tests: 16 passed
- full repository suite with the repo configuration: passed (one unrelated live-simulation freshness timing failure on the first run; the isolated rerun and complete rerun both passed)
- `python -m compileall -q src`
