### PR TITLE
Fail closed until trading and broker health are ready

### DIFF
--- a/src/nifty_scalper_bot/core/trading_switch.py
+++ b/src/nifty_scalper_bot/core/trading_switch.py
@@ -26,7 +26,7 @@ class TradingSwitch:
 
     def __init__(self) -> None:
         self._lock = threading.RLock()
-        self._enabled = True
+        self._enabled = False
         self._resume_at = 0.0
 
     def pause(self) -> None:

--- a/src/nifty_scalper_bot/strategies/runner.py
+++ b/src/nifty_scalper_bot/strategies/runner.py
@@ -11887,9 +11887,8 @@ class StrategyRunner:
                 health_fn = lambda: health_attr
                 health_source = "health"
         if not callable(health_fn):
-            details["broker_ready"] = True
-            details["broker_ready_assumed"] = True
-            return True, "broker_health_unknown_assumed_ready", details
+            details["broker_health_block_reason"] = "broker_health_unavailable"
+            return False, "broker_health_unknown", details
 
         try:
             raw_health = health_fn()
@@ -11897,14 +11896,12 @@ class StrategyRunner:
             details["broker_health_source"] = health_source
             details["broker_health_error_type"] = type(exc).__name__
             details["broker_health_error"] = str(exc)
-            details["broker_ready"] = True
-            details["broker_ready_assumed"] = True
-            return True, "broker_health_unknown_assumed_ready", details
+            details["broker_health_block_reason"] = "broker_health_check_failed"
+            return False, "broker_health_unknown", details
         if not isinstance(raw_health, Mapping):
             details["broker_health_source"] = health_source
-            details["broker_ready"] = True
-            details["broker_ready_assumed"] = True
-            return True, "broker_health_unknown_assumed_ready", details
+            details["broker_health_block_reason"] = "broker_health_invalid"
+            return False, "broker_health_unknown", details
 
         health = dict(raw_health)
         details["broker_health_source"] = health_source
@@ -11965,6 +11962,18 @@ class StrategyRunner:
             if key in health and health.get(key) is False:
                 details["broker_health_block_reason"] = reason
                 return False, "broker_health_live_orders_blocked", details
+        affirmative_health = any(
+            health.get(key) is True
+            for key in (
+                "ready",
+                "order_api_ready",
+                "order_api_available",
+                "broker_connected",
+            )
+        )
+        if not affirmative_health:
+            details["broker_health_block_reason"] = "broker_health_not_affirmative"
+            return False, "broker_health_unknown", details
         details["broker_ready"] = True
         details["broker_ready_assumed"] = False
         return True, "broker_health_ready", details

--- a/tests/core/test_trading_switch.py
+++ b/tests/core/test_trading_switch.py
@@ -7,7 +7,14 @@ import types
 import pytest
 
 from nifty_scalper_bot.core import trading_switch as switch_module
-from nifty_scalper_bot.core.trading_switch import trading_switch
+from nifty_scalper_bot.core.trading_switch import TradingSwitch, trading_switch
+
+
+def test_new_trading_switch_starts_disabled() -> None:
+    switch = TradingSwitch()
+
+    assert switch.can_trade() is False
+    assert switch.snapshot().enabled is False
 
 
 def test_trading_switch_pause_blocks_until_resume() -> None:

--- a/tests/strategies/test_runner_broker_health_fail_closed.py
+++ b/tests/strategies/test_runner_broker_health_fail_closed.py
@@ -1,0 +1,63 @@
+"""Broker health must be affirmative before live entry is eligible."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from nifty_scalper_bot.strategies.runner import StrategyRunner
+from nifty_scalper_bot.utils.logging import get_logger
+
+
+def _runner(order_manager: object) -> StrategyRunner:
+    runner = StrategyRunner.__new__(StrategyRunner)
+    runner._order_manager = order_manager
+    runner._logger = get_logger(__name__)
+    runner._order_manager_kill_switch_status_for_entry = lambda: (False, {})
+    return runner
+
+
+@pytest.mark.parametrize(
+    "health_surface",
+    (
+        {},
+        {"get_broker_health_snapshot": lambda: None},
+        {"get_broker_health_snapshot": lambda: {}},
+        {
+            "get_broker_health_snapshot": lambda: (_ for _ in ()).throw(
+                RuntimeError("unavailable")
+            )
+        },
+    ),
+)
+def test_unknown_broker_health_blocks_entry(health_surface: dict[str, object]) -> None:
+    manager = SimpleNamespace(is_live_mode=lambda: True, **health_surface)
+
+    allowed, reason, details = _runner(
+        manager
+    )._resolve_order_manager_health_for_entry()
+
+    assert allowed is False
+    assert reason == "broker_health_unknown"
+    assert details["broker_ready"] is False
+    assert details["broker_ready_assumed"] is False
+
+
+def test_affirmative_broker_health_allows_entry() -> None:
+    manager = SimpleNamespace(
+        is_live_mode=lambda: True,
+        get_broker_health_snapshot=lambda: {
+            "broker_connected": True,
+            "order_api_available": True,
+            "trading_allowed_effect": "none",
+        },
+    )
+
+    allowed, reason, details = _runner(
+        manager
+    )._resolve_order_manager_health_for_entry()
+
+    assert allowed is True
+    assert reason == "broker_health_ready"
+    assert details["broker_ready"] is True


### PR DESCRIPTION
## Root cause

The global trading switch initialized enabled, and live-entry health resolution treated absent, throwing, malformed, or empty broker-health surfaces as ready. Startup uncertainty could therefore become entry permission.

## Changes

- initialize a fresh trading switch disabled; operator `resume()` remains the explicit arming action
- block live entries when no broker-health API is available, the health check raises, the payload is invalid, or the payload has no affirmative readiness evidence
- preserve force-exit behavior and all existing explicit resume/cooldown controls
- retain entry permission for snapshots with affirmative connectivity/order-API evidence and no blocking signal

## Validation

- targeted trading-switch and broker-health tests: 8 passed
- full repository non-slow suite: passed
- `python -m compileall -q src`
